### PR TITLE
feat(archetypes): field-dispatch-native archetypes — 17 leaves + 3 categories (Gap A + B)

### DIFF
--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -206,6 +206,42 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
     supplyChain:
       "Our supply chain blends purchased program supplies, in-kind donations from supporters, and contributions from partner organisations. Stewardship matters — we choose suppliers and partners who match our mission and respect that donors' trust comes attached.",
   },
+  "automotive-services": {
+    missionTheme:
+      "get our customers safely back on the road with honest, convenient vehicle service",
+    businessModel:
+      "Mobile service that comes to the customer — most jobs are dispatched to a driveway, workplace, or roadside. Trust, honest diagnosis, and fast turnaround drive repeat work and referrals.",
+    whoWeServe:
+      "We serve drivers and fleet owners who need work done on their vehicle without the hassle of a shop visit. Many are stranded or inconvenienced, so speed and reliability earn the next call.",
+    howWeDecide:
+      "We decide for safety, honest diagnosis, and getting the customer moving again. We never upsell work a vehicle does not need, we stand behind our parts and our calibration, and we are transparent about price before we start.",
+    supplyChain:
+      "We stock parts on the van or truck and resolve the right part from the vehicle's VIN — glass SKUs, filters, tires, keys. Keeping the mobile inventory matched to the day's jobs is the discipline; a wrong or missing part means a second trip and a lost slot.",
+  },
+  "moving-and-logistics": {
+    missionTheme:
+      "move our customers' belongings and freight safely, on time, and with care",
+    businessModel:
+      "Crew-and-truck jobs quoted per move or run on recurring routes; careful handling and on-time delivery turn a stressful day into a referral.",
+    whoWeServe:
+      "We serve households relocating and businesses that need goods moved or delivered. We are handling people's possessions or a company's promises to its own customers, so trust is the product.",
+    howWeDecide:
+      "We decide for careful handling, honest estimates, and hitting the promised window. We protect what we carry, communicate delays early, and never cut corners on securing a load or on a driver's legal hours.",
+    supplyChain:
+      "Our 'inventory' is trucks, fuel, packing materials, and the crew's time; the discipline is routing, load planning, and keeping vehicles and equipment road-ready. Driver hours and vehicle availability are the real constraints on what we can promise.",
+  },
+  "security-services": {
+    missionTheme:
+      "keep the people, property, and events entrusted to us safe",
+    businessModel:
+      "Recurring guard and monitoring contracts plus field installation; dependability and a credible response are what clients renew for.",
+    whoWeServe:
+      "We serve businesses, property managers, and residents who need a visible, reliable security presence. The relationship rests on trust that we will be there and respond when it matters.",
+    howWeDecide:
+      "We decide for the safety of people first, then property — with trained, licensed officers, clear post orders, and documented incident response. We never compromise coverage or cut corners on vetting and licensing.",
+    supplyChain:
+      "We provision uniforms, vehicles, radios, and — for the install side — alarm, camera, and access-control hardware from security distributors. Licensing and training are as load-bearing as equipment; an unlicensed officer or an unmonitored panel is an operational and legal failure.",
+  },
 };
 
 // ─── Flagship specific-archetype overrides (merged over the industry profile) ─

--- a/apps/web/lib/storefront/composition-view.ts
+++ b/apps/web/lib/storefront/composition-view.ts
@@ -77,7 +77,11 @@ function resolveVisualPattern(
   }
   if (
     modules.includes("service-operations") &&
-    (category === "trades-maintenance" || category === "facilities-maintenance")
+    (category === "trades-maintenance" ||
+      category === "facilities-maintenance" ||
+      category === "automotive-services" ||
+      category === "moving-and-logistics" ||
+      category === "security-services")
   ) {
     return "map-dispatch";
   }

--- a/apps/web/lib/storefront/industries.test.ts
+++ b/apps/web/lib/storefront/industries.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { INDUSTRY_OPTIONS, INDUSTRY_SLUGS, isIndustrySlug, industryLabel } from "./industries";
 
 describe("industries", () => {
-  it("exposes exactly the 16 canonical industries", () => {
-    expect(INDUSTRY_OPTIONS).toHaveLength(16);
+  it("exposes exactly the 19 canonical industries", () => {
+    expect(INDUSTRY_OPTIONS).toHaveLength(19);
     expect(INDUSTRY_SLUGS).toContain("healthcare-wellness");
     expect(INDUSTRY_SLUGS).toContain("hoa-property-management");
     expect(INDUSTRY_SLUGS).toContain("software-platform");
@@ -11,6 +11,9 @@ describe("industries", () => {
     expect(INDUSTRY_SLUGS).toContain("public-sector");
     expect(INDUSTRY_SLUGS).toContain("asset-rental");
     expect(INDUSTRY_SLUGS).toContain("real-estate-construction");
+    expect(INDUSTRY_SLUGS).toContain("automotive-services");
+    expect(INDUSTRY_SLUGS).toContain("moving-and-logistics");
+    expect(INDUSTRY_SLUGS).toContain("security-services");
   });
 
   it("slugs are kebab-case, never underscore", () => {

--- a/apps/web/lib/storefront/industries.ts
+++ b/apps/web/lib/storefront/industries.ts
@@ -15,6 +15,9 @@ export const INDUSTRY_OPTIONS = [
   { value: "public-sector", label: "Public Sector & Local Government" },
   { value: "asset-rental", label: "Rental & Shared Assets" },
   { value: "real-estate-construction", label: "Home Building & Construction" },
+  { value: "automotive-services", label: "Automotive Services" },
+  { value: "moving-and-logistics", label: "Moving & Logistics" },
+  { value: "security-services", label: "Security Services" },
 ] as const;
 
 export type IndustrySlug = (typeof INDUSTRY_OPTIONS)[number]["value"];

--- a/apps/web/lib/tak/marketing-playbooks.ts
+++ b/apps/web/lib/tak/marketing-playbooks.ts
@@ -388,6 +388,78 @@ const CATEGORY_PLAYBOOKS: Record<string, MarketingPlaybook> = {
     ctaLanguage: ["Shop now", "Order today", "Browse collection", "Pre-order"],
     agentSkills: ["Product launch campaign", "Seasonal collection promotion", "Gift guide creation", "Loyalty programme ideas"],
   },
+
+  "automotive-services": {
+    primaryGoal: "Win same-day jobs and keep service vans full — fast quotes, local search visibility, and repeat/fleet relationships",
+    stakeholders: "Drivers, fleet managers, insurers, dealerships, local trade networks",
+    campaignTypes: [
+      "Fix-the-chip-before-it-cracks reminders",
+      "Seasonal service pushes (winter batteries and tires, summer A/C)",
+      "Fleet and dealership account acquisition",
+      "Insurance-claim assistance messaging (glass)",
+      "Mobile-convenience promotion (we come to you)",
+      "Review and referral drives",
+      "ADAS-calibration safety awareness",
+    ],
+    contentTone: "Reassuring and fast-response — safety first, honest pricing, no upsell pressure",
+    keyMetrics: [
+      "Same-day booking rate",
+      "Quote-to-job conversion",
+      "Fleet / account growth",
+      "Repeat and referral rate",
+      "Average response time",
+    ],
+    ctaLanguage: ["Get a quote", "Book mobile service", "Request help now", "Add your fleet"],
+    agentSkills: ["Seasonal service reminder", "Fleet outreach", "Review request", "Insurance-claim explainer"],
+  },
+
+  "moving-and-logistics": {
+    primaryGoal: "Fill the calendar in peak season and win recurring B2B routes — fast quotes and trust on careful handling",
+    stakeholders: "Households relocating, businesses, real-estate agents, property managers",
+    campaignTypes: [
+      "Peak-season pushes (summer and month-end)",
+      "Off-peak midweek discounts to smooth demand",
+      "Realtor and property-manager referral partnerships",
+      "Packing and storage add-on upsell",
+      "B2B route and account acquisition",
+      "Review and referral drives",
+      "Moving-checklist and how-to content",
+    ],
+    contentTone: "Reassuring, reliable, stress-reducing",
+    keyMetrics: [
+      "Quote-to-booking conversion",
+      "Calendar fill rate (peak vs off-peak)",
+      "B2B account growth",
+      "Average job value",
+      "Referral rate",
+    ],
+    ctaLanguage: ["Get a moving quote", "Book a pickup", "Open a business account", "Request a route"],
+    agentSkills: ["Peak-season campaign", "Realtor referral outreach", "Review request", "B2B account proposal"],
+  },
+
+  "security-services": {
+    primaryGoal: "Win and renew recurring contracts — built on credibility, a response track record, and compliance assurance",
+    stakeholders: "Businesses, property managers, event organizers, residents, insurers",
+    campaignTypes: [
+      "Contract-renewal nurture sequences",
+      "B2B proposal and RFP responses",
+      "Event-security seasonal outreach",
+      "Alarm and monitoring upsell to install customers",
+      "Compliance, licensing, and vetting trust content",
+      "Incident-response case studies",
+      "Residential security awareness",
+    ],
+    contentTone: "Credible, reassuring, professional — safety and trust, never fear-mongering",
+    keyMetrics: [
+      "Contract win rate",
+      "Renewal / retention rate",
+      "Monitoring-plan attach rate",
+      "Response-time SLA adherence",
+      "Proposal conversion",
+    ],
+    ctaLanguage: ["Request a proposal", "Get a security assessment", "Add monitoring", "Talk to us"],
+    agentSkills: ["Contract renewal nurture", "RFP / proposal draft", "Monitoring upsell campaign", "Incident-response case study"],
+  },
 };
 
 // ─── CTA-Based Fallback (for unknown categories) ───────────────────────────

--- a/docs/architecture/archetype-business-value-streams.md
+++ b/docs/architecture/archetype-business-value-streams.md
@@ -154,7 +154,9 @@ These invariants keep this artefact useful to architecture, UX, testing, and bus
 
 ---
 
-## 6. Per-category value-stream profiles (all 53 archetypes)
+## 6. Per-category value-stream profiles (all 87 archetypes across 19 categories)
+
+> The field-dispatch leaves folded into existing categories on 2026-06-13 (e.g. `hvac-contractor`, `home-health-care`, `mobile-pet-grooming`) share their category's value-stream profile below and are catalogued — with their cross-category pattern — in §10.2. The three new dispatch-native categories are §6.16–6.18.
 
 Each profile gives: the **value the end customer receives** (job-to-be-done), the **commercial model** (Section 3 shape), the **load-bearing stage(s)**, the **distinctive stage** that the audit must scrutinise, and the **trust gate**. Per-archetype rows name only what diverges from the category. Service names and CTA labels are *expected from seed* — where prose and seed disagree, seed wins.
 
@@ -361,6 +363,50 @@ Each profile gives: the **value the end customer receives** (job-to-be-done), th
 
 ---
 
+### 6.16 Automotive Services (field-dispatch) — `auto-glass`, `mobile-mechanic`, `mobile-detailing`, `mobile-tire`, `roadside-assistance`, `locksmith`
+
+- **Value delivered:** a technician travels to the customer's **vehicle** (driveway, workplace, roadside) and restores it — glass, mechanical, cosmetic, mobility, or access. Field service on a VIN-identified asset.
+- **Commercial model:** **appointment-checkout** for scheduled mobile service (glass/mechanic/detailing/tire); **transactional**, per-incident for `roadside-assistance` and `locksmith`; primary consumer `individual`.
+- **Load-bearing stage:** **S3 Assign / S4 Deliver** — the dispatch and the on-site fix. For roadside it collapses to a real-time S2→S4: the call *is* the job.
+- **Distinctive stage:** **VIN→part resolution** at S2/S3 (glass SKU, key blank, tire size) and, for `auto-glass`, a post-install **ADAS calibration** that gates warranty — the category's moat overlay, a sibling to HVAC's EPA 608 that no FSM covers.
+- **Trust gate:** honest diagnosis / no-needless-work; ADAS calibration certified; DOT for towing operations; bonding for locksmith.
+- **Value-stream-critical assertions:** `onsite-plus-portal` axes derive field dispatch; `auto-glass` carries the `adas` tag anchoring its calibration overlay; roadside/locksmith are **emergency-reactive** (real-time), not scheduled appointments.
+
+| Archetype | Diverges by |
+|-----------|-------------|
+| `roadside-assistance` | Real-time, location-keyed (no VIN required); demand is emergency-reactive; the dispatch ETA *is* the product. |
+| `locksmith` | Spans **vehicle and property-site** serviced entities (auto + residential); bonding/licensing gate. |
+
+### 6.17 Moving & Logistics (field-dispatch) — `moving-company`, `junk-removal`, `courier-delivery`, `last-mile-freight`
+
+- **Value delivered:** a **crew and truck** travel to load, haul, and deliver goods — household possessions, junk, parcels, or freight.
+- **Commercial model:** **transactional** per-job for the household side (`moving-company`, `junk-removal`); **account-based-fees** for the B2B side (`courier-delivery`, `last-mile-freight`); consumer `household` vs `business`.
+- **Load-bearing stage:** **S4 Deliver** — the move/haul/run itself, bounded by crew-hours × route geography.
+- **Distinctive stage:** **route + load planning** at S3; the **DOT hours-of-service** overlay; chain-of-custody for medical/legal courier work.
+- **Trust gate:** careful handling; honest estimate; DOT driver hours; chain-of-custody (medical/legal courier).
+- **Value-stream-critical assertions:** `onsite-plus-portal` axes derive field dispatch; **distinct from `wholesale-distribution`** (which is B2B route delivery of a goods brand's *own* stock); the B2B leaves derive `customer-accounts`.
+
+| Archetype | Diverges by |
+|-----------|-------------|
+| `courier-delivery` / `last-mile-freight` | B2B account-based recurring routes rather than one-off household jobs; consolidated billing. |
+| `junk-removal` | Adds a disposal/manifest leg after the haul (S4→settle). |
+
+### 6.18 Security Services (field-dispatch) — `guard-patrol`, `alarm-cctv-install`
+
+- **Value delivered:** physical protection of people and property — manned/patrol coverage (`guard-patrol`) and field-installed alarm/CCTV with recurring monitoring (`alarm-cctv-install`).
+- **Commercial model:** **recurring-agreement** (guard contracts; monitoring plans); `business` consumer for guarding, `household` for residential alarm.
+- **Load-bearing stage:** for `guard-patrol`, **S4 Deliver** runs as a *real-time* post-assignment / patrol-route / incident-response loop — a dispatch variant; for `alarm-cctv-install`, S3/S4 is the install and **S6 Retain** carries the recurring-monitoring relationship.
+- **Distinctive stage:** post assignments + patrol routes + incident response (the real-time dispatch variant); the monitoring stream layered on the install.
+- **Trust gate:** licensed officers (PSO); documented incident response; low-voltage licensing (install); credible, never fear-mongering, marketing.
+- **Value-stream-critical assertions:** `onsite-plus-portal` axes derive field dispatch; `guard-patrol`'s recurring-agreement makes `service-agreements` **required**; install + monitoring compose into one relationship.
+
+| Archetype | Diverges by |
+|-----------|-------------|
+| `guard-patrol` | Real-time patrol/incident dispatch over managed B2B client sites (customer-estate). |
+| `alarm-cctv-install` | One-off field install plus a recurring monitoring retention stream; residential primary. |
+
+---
+
 ## 7. Demand–capacity dynamics at the load-bearing stage
 
 The load-bearing stage (Section 6) is not only where the main transaction interface between stakeholders sits — it is also **where demand meets finite capacity.** That is not a coincidence: a stage is load-bearing precisely because the business lives or dies on its ability to match demand against a scarce resource there. Managing that match — *neither starving demand nor paying for idle capacity* — is the operator's hardest recurring decision, and it is where a typical operator most needs the platform's help.
@@ -546,10 +592,39 @@ The new element is **S4b Return & Inspect** and the re-pool — there is no "ret
 
 **Disposition:** archetypes — **done** (`equipment-rental`, `self-storage`, `agricultural-cooperative`). The **rental/shared-asset value-stream pattern** and its **reusable-pooled-asset** capacity unit are now a recognized part of the model (this section is their canonical description). The asset-pool capacity engine is tracked as capacity-management work, not new-archetype work.
 
+### 10.2 The field-dispatch (mobile-resource-to-customer) loop (now modelled — Gap A leaves + Gap B categories, 2026-06-13)
+
+**Businesses:** any business where a **mobile resource travels to the customer's site, asset, or person** to perform the work, rather than the customer coming to a premises. This recurs across the catalog rather than living in one category:
+
+- **Folded into existing categories (Gap A leaves):** `hvac-contractor`, `pest-control`, `appliance-repair`, `pool-spa-service`, `pressure-washing`, `roofing-gutters` (trades); `home-health-care`, `mobile-phlebotomy`, `dme-delivery` (healthcare); `mobile-pet-grooming`, `mobile-vet` (pet); `field-inspection`, `land-surveying`, `process-serving-notary` (professional); `mobile-beauty` (beauty); `meal-delivery-program` (nonprofit); `furniture-delivery-install` (retail).
+- **New dispatch-native categories (Gap B):** `automotive-services` (§6.16), `moving-and-logistics` (§6.17), `security-services` (§6.18).
+
+**Why it's a recognized pattern — not just a set of leaves.** In every commercial model in Section 3 the **Deliver (S4)** stage happens at the *operator's* premises or in a booked slot there. In field dispatch S4 happens at the *customer's* location, which inserts coordination stages a premises-based stream never has — **assign (skill × proximity × availability), en-route (on-my-way + ETA), and on-site capture.** It is **derived, not flagged**: applicability is a pure function of the operating-model axes —
+
+```
+needsFieldDispatch(axes) := form="services" AND delivery∈{physical,hybrid}
+                            AND service performed at the customer's location or on the customer's asset
+```
+
+read from `consumptionChannel: onsite-plus-portal` (and `episode-of-care` provisioning for in-home care). The loop:
+
+```
+  S1 Attract → S2 Intake/Triage → S3 Schedule & Assign(skill×proximity×availability)
+            → Confirm → En-route (on-my-way + ETA) → S4 On-site (capture / compliance log)
+            → Close → S5 Settle (job → invoice → payment)
+```
+
+**The capacity dynamic (refines §7.1).** The capacity unit is **mobile labour + route capacity** — technician/crew/officer-hours × drive-time geography — already in the §7.1 taxonomy. Demand signatures vary: emergency-reactive (HVAC no-heat, roadside, lockout), seasonal (moving, pest), steady (guard coverage, monitoring).
+
+**Compliance overlays as job by-products — the moat.** Each vertical attaches a regulated artifact captured at job close: **EPA 608** (HVAC), **ADAS calibration** (auto-glass), **pesticide-applicator** logs (pest), **HIPAA/clinical** notes (home-health, phlebotomy, medical courier), **DOT** hours (moving, towing), **PSO / low-voltage** licensing (security). This is a pluggable overlay framework, not per-archetype code — and no field-service-management product in the market covers any of these.
+
+**Disposition:** archetypes — **done** (the 17 Gap-A leaves + 3 Gap-B categories above; all carry the `onsite-plus-portal` axes and compose under `service-operations` until the dispatch module ships). The **horizontal Field Dispatch capability** — the dispatch board (`map-dispatch` visual pattern), the dispatcher coworker, the skill/proximity/value-aware assignment engine, on-my-way/ETA, and the compliance-overlay framework — is built by a **parallel effort** and derives from these axes via `needsFieldDispatch()`; it is tracked as capability work, not new-archetype work. Source: the 2026-06-13 *Field Dispatch capability design* and its companion *archetype gap analysis*.
+
 ---
 
 ## 11. Changelog
 
+- **2026-06-13** — Folded the **field-dispatch archetypes** from the 2026-06-13 gap analysis into the catalog: 17 Gap-A leaves across 7 existing categories (trades, healthcare, pet, professional, beauty, nonprofit, retail) and 3 new dispatch-native categories — `automotive-services` (§6.16), `moving-and-logistics` (§6.17), `security-services` (§6.18). Added §10.2 recognizing the **field-dispatch (mobile-resource-to-customer) loop** as a value-stream pattern that spans categories and is derived from the operating-model axes (`onsite-plus-portal`). Seed count is now **87 archetypes across 19 categories**. Each leaf carries the axes that let the forthcoming horizontal Field Dispatch capability derive dispatch via `needsFieldDispatch()`; the capability itself is a parallel effort.
 - **2026-06-12** — Added **Implemented by** link to the platform implementation design (`2026-06-12-value-stream-architecture-platform-design.md`) and the WWWD consumer/§8.8 reference. Corrected §10.1: the rental / shared-asset gap was **built upstream** (asset-rental category + `equipment-rental`/`self-storage`/`agricultural-cooperative`, `rental` CTA, asset-pool capability types; seed now 56) — flipped from "not modelled" to "now modelled," retaining the pattern as canonical and narrowing the remaining work to the asset-pool capacity engine. (Sweep-main caught a worktree-stale gap claim.)
 - **2026-06-12** — Enterprise architecture / usability / business-analysis review: clarified decision authority, added reader contract, corrected the standards grounding so ArchiMate and Business Architecture Guild usage are aligned rather than conflated, added architecture/usability invariants, added BA acceptance evidence for demand-capacity capabilities, and split EA consumption into operator, evidence, and architecture/export presentation views.
 - **2026-06-11** — Initial draft. Derived from `archetype-audit-plan.md` (53 archetypes, 14 categories), the archetype seed (`packages/storefront-templates/src/archetypes/`), and the operating-model substrate (`types.ts`). Defined the universal six-stage operational value stream, the commercial-model variant table, the stage→surface→phase bridge, the substrate binding, and per-category profiles for all 53 archetypes.

--- a/packages/storefront-templates/src/archetypes/archetypes.test.ts
+++ b/packages/storefront-templates/src/archetypes/archetypes.test.ts
@@ -249,4 +249,65 @@ describe("archetype catalog", () => {
     // Custom builder includes service-operations for active subcontractor coordination.
     expect(chb?.activationProfile?.modules).toContain("service-operations");
   });
+
+  it("ships dispatch-native field-service leaves with onsite operating-model axes (Gap A)", () => {
+    // The Gap-A leaves (2026-06-13 field-dispatch archetype gap analysis) are
+    // businesses where a mobile resource travels to the customer's site / asset /
+    // person. The forthcoming horizontal Field Dispatch capability derives from
+    // form=services + delivery=physical + consumptionChannel=onsite-plus-portal,
+    // so every new dispatch leaf must carry that triple and compose under
+    // service-operations until the field-dispatch module ships.
+    const GAP_A_DISPATCH_LEAVES = [
+      "hvac-contractor", "pest-control", "appliance-repair", "pool-spa-service",
+      "pressure-washing", "roofing-gutters",
+      "home-health-care", "mobile-phlebotomy", "dme-delivery",
+      "mobile-pet-grooming", "mobile-vet",
+      "field-inspection", "land-surveying", "process-serving-notary",
+      "mobile-beauty", "meal-delivery-program", "furniture-delivery-install",
+    ];
+    for (const id of GAP_A_DISPATCH_LEAVES) {
+      const a = ALL_ARCHETYPES.find((x) => x.archetypeId === id);
+      expect(a, `${id} should exist`).toBeDefined();
+      expect(a?.activationProfile?.axes?.form, `${id} form`).toBe("services");
+      expect(a?.activationProfile?.axes?.delivery, `${id} delivery`).toBe("physical");
+      expect(a?.activationProfile?.axes?.consumptionChannel, `${id} channel`).toBe("onsite-plus-portal");
+      expect(a?.activationProfile?.modules, `${id} modules`).toContain("service-operations");
+    }
+  });
+
+  it("ships the three dispatch-native categories with correct axes (Gap B)", () => {
+    const auto = ALL_ARCHETYPES.filter((a) => a.category === "automotive-services");
+    const moving = ALL_ARCHETYPES.filter((a) => a.category === "moving-and-logistics");
+    const security = ALL_ARCHETYPES.filter((a) => a.category === "security-services");
+
+    expect(auto.map((a) => a.archetypeId).sort()).toEqual([
+      "auto-glass", "locksmith", "mobile-detailing", "mobile-mechanic", "mobile-tire", "roadside-assistance",
+    ]);
+    expect(moving.map((a) => a.archetypeId).sort()).toEqual([
+      "courier-delivery", "junk-removal", "last-mile-freight", "moving-company",
+    ]);
+    expect(security.map((a) => a.archetypeId).sort()).toEqual([
+      "alarm-cctv-install", "guard-patrol",
+    ]);
+
+    // Every leaf in the new categories derives field dispatch from its axes.
+    for (const a of [...auto, ...moving, ...security]) {
+      expect(a.activationProfile?.axes?.form, `${a.archetypeId} form`).toBe("services");
+      expect(a.activationProfile?.axes?.delivery, `${a.archetypeId} delivery`).toBe("physical");
+      expect(a.activationProfile?.axes?.consumptionChannel, `${a.archetypeId} channel`).toBe("onsite-plus-portal");
+      expect(a.activationProfile?.modules, `${a.archetypeId} modules`).toContain("service-operations");
+    }
+
+    // The windshield / auto-glass leaf is the capability spec's named example and
+    // carries the ADAS-calibration tag that anchors its compliance overlay.
+    const glass = auto.find((a) => a.archetypeId === "auto-glass");
+    expect(glass?.tags).toContain("adas");
+
+    // Capability derivation is reachable for a recurring-agreement new-category
+    // leaf: guard contracts require service agreements.
+    const guard = readActivationProfile(
+      security.find((a) => a.archetypeId === "guard-patrol")?.activationProfile,
+    );
+    expect(getCapabilityApplicability(guard, "service-agreements")).toBe("required");
+  });
 });

--- a/packages/storefront-templates/src/archetypes/automotive-services.ts
+++ b/packages/storefront-templates/src/archetypes/automotive-services.ts
@@ -1,0 +1,252 @@
+import type { ArchetypeDefinition } from "../types";
+
+// Automotive field services: a technician travels to the customer's vehicle
+// (driveway, workplace, roadside) rather than the customer coming to a shop.
+// form=services + delivery=physical + consumptionChannel=onsite-plus-portal is
+// what the forthcoming horizontal Field Dispatch capability reads via
+// needsFieldDispatch(axes) to derive the dispatch board, technician routing, and
+// map-pin "Dispatch" action — no per-archetype flag (capability design ADR-1/2).
+// Until that module ships, field work composes under service-operations.
+//
+// The distinctive substrate here is VIN→part resolution and the ADAS
+// (Advanced Driver-Assistance Systems) calibration compliance overlay for auto
+// glass — a moat sibling to HVAC's EPA 608 that no FSM in the market covers.
+// Those overlays are captured at the capability layer (design ADR-5), not in the
+// storefront template.
+
+const AUTO_CONTACT_FIELDS = [
+  { name: "name", label: "Full name", type: "text" as const, required: true },
+  { name: "email", label: "Email", type: "email" as const, required: true },
+  { name: "phone", label: "Phone", type: "tel" as const, required: true },
+];
+
+const VEHICLE_FIELDS = [
+  { name: "vehicle", label: "Vehicle (year, make, model)", type: "text" as const, required: true, placeholder: "e.g. 2021 Toyota RAV4" },
+  { name: "vin", label: "VIN (if known)", type: "text" as const, required: false, placeholder: "Helps us quote the exact part" },
+  { name: "serviceAddress", label: "Service location", type: "text" as const, required: true, placeholder: "Where the vehicle will be" },
+];
+
+// Scheduled mobile auto service — settles at the appointment (pay the tech on
+// completion).
+const AUTO_MOBILE_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations"],
+  billingReadinessMode: "none",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "individual",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "appointment-checkout",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
+// Real-time emergency dispatch — roadside and locksmith are per-incident calls,
+// not scheduled appointments.
+const AUTO_EMERGENCY_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations"],
+  billingReadinessMode: "none",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "individual",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "transactional",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
+export const automotiveServicesArchetypes: ArchetypeDefinition[] = [
+  {
+    // The capability spec's named example (Mark's windshield case). VIN→glass-SKU
+    // resolution and the post-install ADAS calibration certificate are the
+    // distinctive substrate; calibration is a capability-layer compliance overlay.
+    archetypeId: "auto-glass",
+    name: "Windshield & Auto Glass Replacement",
+    category: "automotive-services",
+    ctaType: "inquiry",
+    tags: ["auto glass", "windshield", "windscreen", "adas", "calibration", "chip repair", "mobile", "automotive"],
+    itemTemplates: [
+      { name: "Windshield Replacement", description: "Full windshield replacement with OEM-quality glass — quoted from your VIN", priceType: "quote" },
+      { name: "Rock Chip / Crack Repair", description: "Resin repair to stop a chip or crack from spreading", priceType: "fixed" },
+      { name: "Side & Rear Glass", description: "Door, quarter, and back-glass replacement", priceType: "from" },
+      { name: "ADAS Calibration", description: "Recalibrate driver-assistance cameras and sensors after glass replacement", priceType: "from" },
+      { name: "Mobile Service", description: "We come to your home or workplace — no shop visit needed", priceType: "free" },
+      { name: "Fleet & Commercial Glass", description: "Volume glass service for fleets and dealerships", priceType: "quote" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Get a Quote", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...AUTO_CONTACT_FIELDS,
+      ...VEHICLE_FIELDS,
+      { name: "damageType", label: "What needs fixing?", type: "select" as const, required: true, options: ["Windshield replacement", "Chip / crack repair", "Side window", "Rear glass", "ADAS calibration", "Not sure"] },
+      { name: "insuranceClaim", label: "Filing an insurance claim?", type: "select" as const, required: false, options: ["Yes", "No", "Not sure"] },
+    ],
+    activationProfile: AUTO_MOBILE_ACTIVATION,
+  },
+  {
+    archetypeId: "mobile-mechanic",
+    name: "Mobile Mechanic",
+    category: "automotive-services",
+    ctaType: "inquiry",
+    tags: ["mobile mechanic", "auto repair", "car repair", "diagnostics", "automotive", "at-home"],
+    itemTemplates: [
+      { name: "Diagnostic Visit", description: "On-site diagnosis of warning lights and faults", priceType: "fixed" },
+      { name: "Brake Service", description: "Pad, rotor, and brake-fluid service at your location", priceType: "from" },
+      { name: "Battery / Alternator / Starter", description: "Charging-system diagnosis and replacement", priceType: "from" },
+      { name: "Oil & Filter Change", description: "Mobile oil and filter service", priceType: "fixed" },
+      { name: "Pre-Purchase Inspection", description: "Independent inspection before you buy a used car", priceType: "fixed" },
+      { name: "No-Start / Won't-Run", description: "Diagnose and fix a vehicle that won't start", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Book a Mechanic", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...AUTO_CONTACT_FIELDS,
+      ...VEHICLE_FIELDS,
+      { name: "symptom", label: "What's the problem?", type: "textarea" as const, required: false, placeholder: "Describe the symptoms or service you need" },
+    ],
+    activationProfile: AUTO_MOBILE_ACTIVATION,
+  },
+  {
+    archetypeId: "mobile-detailing",
+    name: "Mobile Auto Detailing",
+    category: "automotive-services",
+    ctaType: "inquiry",
+    tags: ["auto detailing", "car wash", "mobile detailing", "ceramic coating", "valeting", "automotive"],
+    itemTemplates: [
+      { name: "Full Detail", description: "Interior and exterior deep clean and protection", priceType: "from" },
+      { name: "Interior Detail", description: "Vacuum, shampoo, and condition the cabin", priceType: "from" },
+      { name: "Exterior Wash & Wax", description: "Hand wash, clay, and wax for lasting shine", priceType: "from" },
+      { name: "Ceramic Coating", description: "Long-life paint protection — quoted after assessment", priceType: "quote" },
+      { name: "Headlight Restoration", description: "Restore clarity to cloudy headlights", priceType: "fixed" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Packages", sortOrder: 1 },
+      { type: "gallery", title: "Before & After", sortOrder: 2 },
+      { type: "about", title: "About Us", sortOrder: 3 },
+      { type: "contact", title: "Book a Detail", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...AUTO_CONTACT_FIELDS,
+      ...VEHICLE_FIELDS,
+      { name: "package", label: "Package of interest", type: "select" as const, required: false, options: ["Full detail", "Interior", "Exterior wash & wax", "Ceramic coating", "Not sure"] },
+    ],
+    activationProfile: AUTO_MOBILE_ACTIVATION,
+  },
+  {
+    archetypeId: "mobile-tire",
+    name: "Mobile Tire Service",
+    category: "automotive-services",
+    ctaType: "inquiry",
+    tags: ["mobile tire", "tyres", "tire replacement", "flat repair", "tpms", "automotive"],
+    itemTemplates: [
+      { name: "Tire Replacement", description: "Supply and fit new tires at your location", priceType: "from" },
+      { name: "Flat Repair", description: "Plug or patch a repairable puncture", priceType: "fixed" },
+      { name: "Rotation & Balance", description: "Rotate and balance for even wear", priceType: "fixed" },
+      { name: "TPMS Service", description: "Tire-pressure sensor diagnosis and replacement", priceType: "from" },
+      { name: "Seasonal Swap", description: "Switch between summer and winter tires", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Request Service", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...AUTO_CONTACT_FIELDS,
+      ...VEHICLE_FIELDS,
+      { name: "tireSize", label: "Tire size (if known)", type: "text" as const, required: false, placeholder: "e.g. 225/65R17" },
+      { name: "serviceNeeded", label: "Service needed", type: "select" as const, required: false, options: ["New tires", "Flat repair", "Rotation & balance", "TPMS", "Seasonal swap", "Not sure"] },
+    ],
+    activationProfile: AUTO_MOBILE_ACTIVATION,
+  },
+  {
+    // Real-time dispatch: location-based, time-critical, motor-club integrations.
+    // DOT applies to towing operations (capability-layer overlay).
+    archetypeId: "roadside-assistance",
+    name: "Roadside Assistance & Towing",
+    category: "automotive-services",
+    ctaType: "inquiry",
+    tags: ["roadside assistance", "towing", "tow truck", "jump start", "lockout", "recovery", "automotive"],
+    itemTemplates: [
+      { name: "Jump Start", description: "Get a dead battery started and back on the road", priceType: "fixed" },
+      { name: "Lockout Service", description: "Locked out of your vehicle? We'll get you in", priceType: "fixed" },
+      { name: "Flat Tire Change", description: "Swap to your spare at the roadside", priceType: "fixed" },
+      { name: "Fuel Delivery", description: "Out of fuel? We bring enough to reach a station", priceType: "fixed" },
+      { name: "Towing", description: "Tow to the repair shop or destination of your choice", priceType: "from" },
+      { name: "Winch-Out / Recovery", description: "Recover a vehicle stuck off the road", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Request Help Now", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...AUTO_CONTACT_FIELDS,
+      { name: "location", label: "Your current location", type: "text" as const, required: true, placeholder: "Address, highway marker, or what's nearby" },
+      { name: "vehicle", label: "Vehicle (year, make, model)", type: "text" as const, required: false },
+      { name: "situation", label: "What happened?", type: "select" as const, required: true, options: ["Dead battery", "Locked out", "Flat tire", "Out of fuel", "Need a tow", "Stuck / off-road", "Other"] },
+    ],
+    activationProfile: AUTO_EMERGENCY_ACTIVATION,
+  },
+  {
+    // Serves both vehicles and property (auto + residential), so it sits in
+    // automotive but the serviced entity spans vehicle and property-site.
+    archetypeId: "locksmith",
+    name: "Locksmith (Auto & Residential)",
+    category: "automotive-services",
+    ctaType: "inquiry",
+    tags: ["locksmith", "car key", "key programming", "lockout", "rekey", "automotive", "residential"],
+    itemTemplates: [
+      { name: "Car Lockout", description: "Fast entry when you're locked out of your vehicle", priceType: "fixed" },
+      { name: "Car Key Replacement & Programming", description: "Cut and program transponder and smart keys", priceType: "from" },
+      { name: "Home / Business Lockout", description: "Regain entry to a locked property", priceType: "fixed" },
+      { name: "Rekey & Lock Change", description: "Rekey existing locks or install new ones", priceType: "from" },
+      { name: "Lock Installation & Upgrade", description: "Install deadbolts, smart locks, and high-security hardware", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Request a Locksmith", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...AUTO_CONTACT_FIELDS,
+      { name: "location", label: "Service location", type: "text" as const, required: true },
+      { name: "serviceType", label: "What do you need?", type: "select" as const, required: true, options: ["Car lockout", "Car key / fob", "Home / business lockout", "Rekey / lock change", "New lock install", "Other"] },
+    ],
+    activationProfile: AUTO_EMERGENCY_ACTIVATION,
+  },
+];

--- a/packages/storefront-templates/src/archetypes/beauty-personal-care.ts
+++ b/packages/storefront-templates/src/archetypes/beauty-personal-care.ts
@@ -40,6 +40,43 @@ const BEAUTY_ACTIVATION_PROFILE: ArchetypeDefinition["activationProfile"] = {
   },
 };
 
+// Mobile beauty travels to the customer (home, hotel, or event) instead of the
+// client coming to a shop — so unlike the salon leaves above it qualifies for
+// field dispatch via consumptionChannel: "onsite-plus-portal". Events run on
+// weekends, hence the 7-day schedule with travel buffers.
+const MOBILE_BEAUTY_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "customer-choice",
+  defaultOperatingHours: [0, 1, 2, 3, 4, 5, 6].map((day) => ({ day, start: "07:00", end: "20:00" })),
+  defaultBeforeBuffer: 15,
+  defaultAfterBuffer: 30,
+  minimumNoticeHours: 24,
+  maxAdvanceDays: 180,
+};
+
+const MOBILE_BEAUTY_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations", "integrations"],
+  billingReadinessMode: "none",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "individual",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "appointment-checkout",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "minimal" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
 export const beautyPersonalCareArchetypes: ArchetypeDefinition[] = [
   {
     archetypeId: "hair-salon",
@@ -183,5 +220,36 @@ export const beautyPersonalCareArchetypes: ArchetypeDefinition[] = [
     ],
     schedulingDefaults: BEAUTY_SCHEDULING,
     activationProfile: BEAUTY_ACTIVATION_PROFILE,
+  },
+  {
+    archetypeId: "mobile-beauty",
+    name: "Mobile Beauty & Glam",
+    category: "beauty-personal-care",
+    ctaType: "booking",
+    tags: ["mobile beauty", "bridal", "makeup artist", "mobile hair", "event glam", "on-location"],
+    itemTemplates: [
+      { name: "Bridal Hair & Makeup", description: "On-location bridal styling for the wedding party", priceType: "from", bookingDurationMinutes: 120 },
+      { name: "Event / Party Glam", description: "Hair and makeup at your home or venue for any occasion", priceType: "from", bookingDurationMinutes: 75 },
+      { name: "Mobile Haircut & Style", description: "A stylist comes to you for a cut and blow-dry", priceType: "from", bookingDurationMinutes: 60 },
+      { name: "Spray Tan", description: "Mobile sunless tanning at your door", priceType: "fixed", bookingDurationMinutes: 30 },
+      { name: "Lash & Brow", description: "Lash extensions, lifts, and brow shaping on location", priceType: "from", bookingDurationMinutes: 90 },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "gallery", title: "Our Work", sortOrder: 2 },
+      { type: "about", title: "About Us", sortOrder: 3 },
+      { type: "testimonials", title: "Client Love", sortOrder: 4 },
+      { type: "contact", title: "Book Your Glam", sortOrder: 5 },
+    ],
+    formSchema: [
+      ...BOOKING_CONTACT_FIELDS,
+      { name: "occasion", label: "Occasion", type: "select" as const, required: false, options: ["Wedding", "Party / event", "Photoshoot", "Everyday", "Prom / formal", "Other"] },
+      { name: "serviceAddress", label: "Service address / venue", type: "text" as const, required: true },
+      { name: "eventDate", label: "Date required", type: "text" as const, required: false, placeholder: "DD/MM/YYYY" },
+      { name: "groupSize", label: "Number of people", type: "select" as const, required: false, options: ["Just me", "2–3", "4–6", "7+"] },
+    ],
+    schedulingDefaults: MOBILE_BEAUTY_SCHEDULING,
+    activationProfile: MOBILE_BEAUTY_ACTIVATION,
   },
 ];

--- a/packages/storefront-templates/src/archetypes/healthcare-wellness.ts
+++ b/packages/storefront-templates/src/archetypes/healthcare-wellness.ts
@@ -17,6 +17,49 @@ const BOOKING_CONTACT_FIELDS = [
   { name: "notes", label: "Additional notes", type: "textarea" as const, required: false },
 ];
 
+// Mobile / in-home healthcare sends a clinician to the patient rather than the
+// patient to a clinic. form=services + delivery=physical + onsite-plus-portal
+// (with episode-of-care provisioning) is what the forthcoming Field Dispatch
+// capability reads to derive the dispatch board and clinician routing. The
+// HIPAA / clinical-notes compliance overlay is captured at the capability layer
+// (Field Dispatch design ADR-5), not in the storefront template.
+const MOBILE_HEALTH_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations", "billing-readiness", "lifecycle-signals"],
+  billingReadinessMode: "prepared-not-prescribed",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    // Patients are individuals from the storefront's perspective; the precise
+    // patient-and-payer consumer is a clinical-billing refinement for later.
+    primaryConsumer: "individual",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "encounter-based",
+    provisioning: "episode-of-care",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
+// Mobile visits run back-to-back with travel time between homes; phlebotomy
+// favours early-morning fasting draws.
+const MOBILE_VISIT_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "next-available",
+  defaultOperatingHours: [1, 2, 3, 4, 5, 6].map((day) => ({ day, start: "07:00", end: "16:00" })),
+  defaultBeforeBuffer: 15,
+  defaultAfterBuffer: 20,
+  minimumNoticeHours: 24,
+  maxAdvanceDays: 60,
+};
+
 export const healthcareWellnessArchetypes: ArchetypeDefinition[] = [
   {
     archetypeId: "veterinary-clinic",
@@ -151,5 +194,110 @@ export const healthcareWellnessArchetypes: ArchetypeDefinition[] = [
     ],
     formSchema: BOOKING_CONTACT_FIELDS,
     schedulingDefaults: HEALTHCARE_SCHEDULING,
+  },
+  {
+    archetypeId: "home-health-care",
+    name: "Home Health & In-Home Care",
+    category: "healthcare-wellness",
+    ctaType: "inquiry",
+    tags: ["home health", "in-home care", "nursing", "caregiver", "elder care", "domiciliary care"],
+    itemTemplates: [
+      { name: "Free Care Assessment", description: "In-home assessment of needs and a personalised care plan", priceType: "free" },
+      { name: "Skilled Nursing Visit", description: "Wound care, medication management, and clinical monitoring at home", priceType: "from" },
+      { name: "Personal Care & Companionship", description: "Help with bathing, dressing, meals, and daily living", priceType: "per-hour" },
+      { name: "Post-Hospital Recovery Care", description: "Short-term support after a hospital stay or surgery", priceType: "from" },
+      { name: "Respite Care", description: "Temporary cover so family caregivers can take a break", priceType: "per-hour" },
+      { name: "24-Hour / Live-In Care", description: "Round-the-clock care in the comfort of home", priceType: "quote" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Our Care Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "team", title: "Our Caregivers", sortOrder: 3 },
+      { type: "testimonials", title: "Family Stories", sortOrder: 4 },
+      { type: "contact", title: "Request an Assessment", sortOrder: 5 },
+    ],
+    formSchema: [
+      ...BOOKING_CONTACT_FIELDS,
+      { name: "careFor", label: "Who is the care for?", type: "select" as const, required: true, options: ["A parent", "A spouse / partner", "Myself", "Another relative", "A client"] },
+      { name: "careType", label: "Type of care needed", type: "select" as const, required: false, options: ["Skilled nursing", "Personal care", "Companionship", "Post-hospital recovery", "Respite", "Live-in / 24-hour", "Not sure"] },
+    ],
+    activationProfile: MOBILE_HEALTH_ACTIVATION,
+  },
+  {
+    archetypeId: "mobile-phlebotomy",
+    name: "Mobile Phlebotomy & Lab Draw",
+    category: "healthcare-wellness",
+    ctaType: "booking",
+    tags: ["phlebotomy", "blood draw", "mobile lab", "specimen collection", "at-home testing"],
+    itemTemplates: [
+      { name: "At-Home Blood Draw", description: "A certified phlebotomist comes to you for a single draw", priceType: "fixed", bookingDurationMinutes: 30 },
+      { name: "Lab Test Panel Collection", description: "Collection and courier of your ordered lab panel", priceType: "from", bookingDurationMinutes: 30 },
+      { name: "Fasting Draw (Early AM)", description: "Early-morning fasting blood collection", priceType: "fixed", bookingDurationMinutes: 30 },
+      { name: "Corporate / Group Draw", description: "On-site collection for workplaces and wellness programs", priceType: "quote" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Book a Draw", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...BOOKING_CONTACT_FIELDS,
+      { name: "address", label: "Collection address", type: "text" as const, required: true },
+      { name: "hasLabOrder", label: "Do you have a lab order / requisition?", type: "select" as const, required: true, options: ["Yes", "No", "Not sure"] },
+    ],
+    schedulingDefaults: MOBILE_VISIT_SCHEDULING,
+    activationProfile: MOBILE_HEALTH_ACTIVATION,
+  },
+  {
+    // DME = durable medical equipment. The dispatch is the delivery + setup +
+    // patient training visit. DMEPOS / HIPAA handling is a capability-layer
+    // compliance overlay (Field Dispatch design ADR-5).
+    archetypeId: "dme-delivery",
+    name: "Medical Equipment Delivery & Setup",
+    category: "healthcare-wellness",
+    ctaType: "inquiry",
+    tags: ["dme", "medical equipment", "durable medical equipment", "oxygen", "mobility", "home medical", "delivery"],
+    itemTemplates: [
+      { name: "Hospital Bed Delivery & Setup", description: "Delivery, assembly, and demonstration of a home hospital bed", priceType: "from" },
+      { name: "Oxygen Equipment Setup", description: "Concentrator or cylinder delivery with patient training", priceType: "quote" },
+      { name: "Mobility Equipment", description: "Wheelchairs, walkers, and scooters fitted to the patient", priceType: "from" },
+      { name: "CPAP / Respiratory Setup", description: "Delivery, fitting, and education for respiratory devices", priceType: "from" },
+      { name: "Equipment Service & Pickup", description: "Maintenance, repair, and collection of returned equipment", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Equipment & Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Request Equipment", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...BOOKING_CONTACT_FIELDS,
+      { name: "equipmentType", label: "Equipment needed", type: "select" as const, required: false, options: ["Hospital bed", "Oxygen", "Mobility (wheelchair / walker)", "CPAP / respiratory", "Other", "Not sure"] },
+      { name: "deliveryAddress", label: "Delivery address", type: "text" as const, required: true },
+    ],
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "billing-readiness"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "individual",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "transactional",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    },
   },
 ];

--- a/packages/storefront-templates/src/archetypes/index.ts
+++ b/packages/storefront-templates/src/archetypes/index.ts
@@ -14,6 +14,9 @@ import { bankingFinancialServicesArchetypes } from "./banking-financial-services
 import { publicSectorArchetypes } from "./public-sector";
 import { assetRentalArchetypes } from "./asset-rental";
 import { realEstateConstructionArchetypes } from "./real-estate-construction";
+import { automotiveServicesArchetypes } from "./automotive-services";
+import { movingAndLogisticsArchetypes } from "./moving-and-logistics";
+import { securityServicesArchetypes } from "./security-services";
 
 export const ALL_ARCHETYPES = [
   ...healthcareWellnessArchetypes,
@@ -32,4 +35,7 @@ export const ALL_ARCHETYPES = [
   ...publicSectorArchetypes,
   ...assetRentalArchetypes,
   ...realEstateConstructionArchetypes,
+  ...automotiveServicesArchetypes,
+  ...movingAndLogisticsArchetypes,
+  ...securityServicesArchetypes,
 ];

--- a/packages/storefront-templates/src/archetypes/moving-and-logistics.ts
+++ b/packages/storefront-templates/src/archetypes/moving-and-logistics.ts
@@ -1,0 +1,178 @@
+import type { ArchetypeDefinition } from "../types";
+
+// Moving & last-mile logistics: a crew and a truck travel to the customer to
+// load, haul, and deliver. form=services + delivery=physical +
+// consumptionChannel=onsite-plus-portal is what derives the forthcoming Field
+// Dispatch capability (crew+truck routing, on-my-way ETAs). The DOT
+// hours-of-service overlay is a capability-layer compliance concern (Field
+// Dispatch design ADR-5), not modelled in the template. Distinct from
+// wholesale-distribution (B2B route delivery of a goods brand's own stock).
+
+const CONTACT_FIELDS = [
+  { name: "name", label: "Full name", type: "text" as const, required: true },
+  { name: "email", label: "Email", type: "email" as const, required: true },
+  { name: "phone", label: "Phone", type: "tel" as const, required: true },
+];
+
+// Consumer move/haul — household primary, quoted per job.
+const MOVING_HOUSEHOLD_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations"],
+  billingReadinessMode: "none",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "household",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "transactional",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
+// B2B courier / freight — business accounts, recurring routes; customer-accounts
+// derive from the business consumer.
+const LOGISTICS_B2B_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["customer-estate", "service-operations", "billing-readiness"],
+  billingReadinessMode: "prepared-not-prescribed",
+  customerGraph: "separate-customer-projection",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "business",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "account-based-fees",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
+export const movingAndLogisticsArchetypes: ArchetypeDefinition[] = [
+  {
+    archetypeId: "moving-company",
+    name: "Moving Company",
+    category: "moving-and-logistics",
+    ctaType: "inquiry",
+    tags: ["movers", "moving company", "relocation", "packing", "removals", "logistics"],
+    itemTemplates: [
+      { name: "Local Move", description: "Door-to-door move within the metro area", priceType: "from" },
+      { name: "Long-Distance Move", description: "Interstate or cross-country relocation — quoted", priceType: "quote" },
+      { name: "Packing & Unpacking", description: "Professional packing with materials supplied", priceType: "from" },
+      { name: "Loading / Unloading Only", description: "Labor-only help for a rented truck or container", priceType: "from" },
+      { name: "Specialty Item Move", description: "Pianos, safes, and oversized or fragile items", priceType: "quote" },
+      { name: "Short-Term Storage", description: "Secure storage between move-out and move-in", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Get a Moving Quote", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "moveFrom", label: "Moving from", type: "text" as const, required: true, placeholder: "Origin address or area" },
+      { name: "moveTo", label: "Moving to", type: "text" as const, required: true, placeholder: "Destination address or area" },
+      { name: "homeSize", label: "Home size", type: "select" as const, required: true, options: ["Studio / 1 bed", "2 bed", "3 bed", "4+ bed", "Office / commercial"] },
+      { name: "moveDate", label: "Preferred move date", type: "text" as const, required: false, placeholder: "DD/MM/YYYY" },
+    ],
+    activationProfile: MOVING_HOUSEHOLD_ACTIVATION,
+  },
+  {
+    archetypeId: "junk-removal",
+    name: "Junk Removal & Hauling",
+    category: "moving-and-logistics",
+    ctaType: "inquiry",
+    tags: ["junk removal", "hauling", "rubbish removal", "cleanout", "debris", "logistics"],
+    itemTemplates: [
+      { name: "Single-Item Pickup", description: "Haul away one large item (sofa, fridge, mattress)", priceType: "fixed" },
+      { name: "Truck-Load Haul", description: "Fill our truck — priced by volume", priceType: "from" },
+      { name: "Furniture & Appliance Removal", description: "Remove and responsibly dispose of bulky goods", priceType: "from" },
+      { name: "Estate / Property Cleanout", description: "Full cleanout of a home, garage, or unit", priceType: "quote" },
+      { name: "Construction Debris", description: "Haul away renovation and construction waste", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "gallery", title: "Before & After", sortOrder: 2 },
+      { type: "about", title: "About Us", sortOrder: 3 },
+      { type: "contact", title: "Book a Pickup", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "pickupAddress", label: "Pickup address", type: "text" as const, required: true },
+      { name: "itemsDescription", label: "What needs hauling?", type: "textarea" as const, required: false, placeholder: "Describe the items or volume" },
+    ],
+    activationProfile: MOVING_HOUSEHOLD_ACTIVATION,
+  },
+  {
+    archetypeId: "courier-delivery",
+    name: "Courier & Delivery Service",
+    category: "moving-and-logistics",
+    ctaType: "inquiry",
+    tags: ["courier", "delivery", "same-day", "medical courier", "dispatch", "logistics"],
+    itemTemplates: [
+      { name: "Same-Day Courier", description: "On-demand pickup and delivery across the metro", priceType: "from" },
+      { name: "Scheduled Route", description: "Recurring scheduled pickups for business clients", priceType: "quote" },
+      { name: "Medical / Lab Courier", description: "Time- and temperature-sensitive specimen transport", priceType: "quote" },
+      { name: "Legal & Document Courier", description: "Chain-of-custody delivery for sensitive documents", priceType: "from" },
+      { name: "Account Setup", description: "Open a business account with consolidated billing", priceType: "free" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Request a Pickup", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "companyName", label: "Company name", type: "text" as const, required: false },
+      { name: "pickupAddress", label: "Pickup address", type: "text" as const, required: true },
+      { name: "deliveryAddress", label: "Delivery address", type: "text" as const, required: true },
+      { name: "serviceType", label: "Service type", type: "select" as const, required: false, options: ["Same-day", "Scheduled route", "Medical / lab", "Legal / document", "Not sure"] },
+    ],
+    activationProfile: LOGISTICS_B2B_ACTIVATION,
+  },
+  {
+    archetypeId: "last-mile-freight",
+    name: "Last-Mile Freight & Delivery",
+    category: "moving-and-logistics",
+    ctaType: "inquiry",
+    tags: ["last mile", "freight", "ltl", "delivery", "white glove", "logistics", "b2b"],
+    itemTemplates: [
+      { name: "LTL / Local Freight", description: "Less-than-truckload local and regional delivery", priceType: "quote" },
+      { name: "White-Glove Freight", description: "Delivery with placement, assembly, and packaging removal", priceType: "from" },
+      { name: "Scheduled Distribution Route", description: "Recurring multi-stop delivery routes", priceType: "quote" },
+      { name: "Returns & Reverse Logistics", description: "Scheduled pickup of returns and exchanges", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Request a Quote", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "companyName", label: "Company name", type: "text" as const, required: true },
+      { name: "volume", label: "Estimated volume / frequency", type: "select" as const, required: false, options: ["One-off shipment", "Daily", "Weekly", "Multiple times a week"] },
+      { name: "details", label: "What do you need delivered?", type: "textarea" as const, required: false },
+    ],
+    activationProfile: LOGISTICS_B2B_ACTIVATION,
+  },
+];

--- a/packages/storefront-templates/src/archetypes/nonprofit-community.ts
+++ b/packages/storefront-templates/src/archetypes/nonprofit-community.ts
@@ -277,4 +277,53 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       ],
     },
   },
+  {
+    // Meals-on-Wheels-style program: a nonprofit funded by donation whose
+    // *operating model* is a physical, route-based meal-delivery service to
+    // homebound recipients. The donation CTA funds it; the volunteer-driver
+    // dispatch is the operational layer that derives the Field Dispatch
+    // capability (form=services + delivery=physical + onsite-plus-portal).
+    // Food-handling is a capability-layer compliance overlay (design ADR-5).
+    archetypeId: "meal-delivery-program",
+    name: "Meal Delivery Program",
+    category: "nonprofit-community",
+    ctaType: "donation",
+    tags: ["meals on wheels", "meal delivery", "food", "seniors", "homebound", "charity", "volunteer", "route"],
+    itemTemplates: [
+      { name: "Donate", description: "Fund meals for homebound neighbours in need", priceType: "donation", ctaType: "donation" },
+      { name: "Sponsor a Route", description: "Underwrite a full delivery route for a month", priceType: "donation", ctaType: "donation" },
+      { name: "Request Meal Service", description: "Sign up yourself or a loved one to receive meals", priceType: "free", ctaType: "inquiry" },
+      { name: "Volunteer as a Driver", description: "Deliver meals and a friendly check-in on a local route", priceType: "free", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "about", title: "About Our Program", sortOrder: 1 },
+      { type: "items", title: "Get Involved", sortOrder: 2 },
+      { type: "donate", title: "Donate", sortOrder: 3 },
+      { type: "contact", title: "Contact Us", sortOrder: 4 },
+    ],
+    formSchema: DONATION_FORM_FIELDS,
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "lifecycle-signals"],
+      billingReadinessMode: "none",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "individual",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "transactional",
+        provisioning: "none",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    },
+  },
 ];

--- a/packages/storefront-templates/src/archetypes/pet-services.ts
+++ b/packages/storefront-templates/src/archetypes/pet-services.ts
@@ -24,6 +24,44 @@ const PET_FIELDS = [
   { name: "vaccinationsUpToDate", label: "Vaccinations up to date?", type: "select" as const, required: true, options: ["Yes", "No", "Not sure"] },
 ];
 
+// Mobile pet services bring the van to the customer's door (grooming) or the
+// vet to the animal (home / farm calls). form=services + delivery=physical +
+// onsite-plus-portal is what derives the forthcoming Field Dispatch capability;
+// rabies-vax checks and DEA/controlled-substance handling are capability-layer
+// overlays (Field Dispatch design ADR-5), not modelled in the template.
+const MOBILE_PET_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "next-available",
+  defaultOperatingHours: [1, 2, 3, 4, 5, 6].map((day) => ({ day, start: "08:00", end: "17:00" })),
+  defaultBeforeBuffer: 15,
+  defaultAfterBuffer: 20,
+  minimumNoticeHours: 12,
+  maxAdvanceDays: 60,
+};
+
+const MOBILE_PET_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations"],
+  billingReadinessMode: "none",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "individual",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "appointment-checkout",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
 export const petServicesArchetypes: ArchetypeDefinition[] = [
   {
     archetypeId: "pet-grooming",
@@ -108,5 +146,91 @@ export const petServicesArchetypes: ArchetypeDefinition[] = [
       { name: "checkOutDate", label: "Check-out date", type: "text" as const, required: true, placeholder: "DD/MM/YYYY" },
     ],
     schedulingDefaults: PET_SCHEDULING,
+  },
+  {
+    // Distinct from the shop-based pet-grooming leaf: the groomer's van comes to
+    // the customer (mobile-to-customer), which is why this one derives field
+    // dispatch and the shop one does not.
+    archetypeId: "mobile-pet-grooming",
+    name: "Mobile Pet Grooming",
+    category: "pet-services",
+    ctaType: "booking",
+    tags: ["mobile grooming", "pet grooming", "dog", "cat", "van", "at-home"],
+    itemTemplates: [
+      { name: "Mobile Full Groom", description: "Full groom at your door — bath, dry, trim, nails, ears", priceType: "from", bookingDurationMinutes: 90 },
+      { name: "Mobile Bath & Brush", description: "Shampoo, condition, and brush-out in the van", priceType: "from", bookingDurationMinutes: 60 },
+      { name: "Nail Trim & Tidy", description: "Quick nail clip and sanitary trim at your home", priceType: "fixed", bookingDurationMinutes: 30 },
+      { name: "De-shedding Treatment", description: "Deep de-shed treatment without leaving home", priceType: "from", bookingDurationMinutes: 90 },
+      { name: "Cat Mobile Groom", description: "Low-stress grooming for cats at home", priceType: "from", bookingDurationMinutes: 60 },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Grooming Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "gallery", title: "Our Grooming Results", sortOrder: 3 },
+      { type: "contact", title: "Book a Mobile Groom", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...BOOKING_CONTACT_FIELDS,
+      ...PET_FIELDS,
+      { name: "serviceAddress", label: "Service address", type: "text" as const, required: true },
+      { name: "coatType", label: "Coat type", type: "select" as const, required: false, options: ["Short", "Medium", "Long", "Wire", "Curly", "Double coat"] },
+    ],
+    schedulingDefaults: MOBILE_PET_SCHEDULING,
+    activationProfile: MOBILE_PET_ACTIVATION,
+  },
+  {
+    // Mobile / house-call vet — companion-animal home visits and farm calls.
+    // Encounter-based billing (ad-hoc invoice per visit) rather than checkout.
+    archetypeId: "mobile-vet",
+    name: "Mobile Veterinary Service",
+    category: "pet-services",
+    ctaType: "booking",
+    tags: ["mobile vet", "house call vet", "veterinary", "farm vet", "at-home euthanasia", "animals"],
+    itemTemplates: [
+      { name: "Home Wellness Visit", description: "In-home checkup and vaccinations for your pet", priceType: "from", bookingDurationMinutes: 45 },
+      { name: "Sick Visit", description: "House-call assessment for an unwell pet", priceType: "from", bookingDurationMinutes: 45 },
+      { name: "Vaccination Visit", description: "Core and lifestyle vaccinations at home", priceType: "fixed", bookingDurationMinutes: 30 },
+      { name: "Farm / Large Animal Call", description: "On-farm visit for livestock and equine patients", priceType: "quote" },
+      { name: "End-of-Life & Hospice Care", description: "Compassionate in-home palliative care and euthanasia", priceType: "quote", bookingDurationMinutes: 60 },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Our Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "team", title: "Meet the Vet", sortOrder: 3 },
+      { type: "testimonials", title: "What Pet Owners Say", sortOrder: 4 },
+      { type: "contact", title: "Book a Visit", sortOrder: 5 },
+    ],
+    formSchema: [
+      ...BOOKING_CONTACT_FIELDS,
+      { name: "petName", label: "Pet / animal name", type: "text" as const, required: true },
+      { name: "species", label: "Species", type: "select" as const, required: true, options: ["Dog", "Cat", "Horse", "Livestock", "Small animal", "Other"] },
+      { name: "serviceAddress", label: "Visit address", type: "text" as const, required: true },
+      { name: "reason", label: "Reason for visit", type: "textarea" as const, required: false },
+    ],
+    schedulingDefaults: MOBILE_PET_SCHEDULING,
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "billing-readiness"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "individual",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "encounter-based",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    },
   },
 ];

--- a/packages/storefront-templates/src/archetypes/professional-services.ts
+++ b/packages/storefront-templates/src/archetypes/professional-services.ts
@@ -13,6 +13,35 @@ const BUSINESS_FIELDS = [
   { name: "currentSituation", label: "Current situation", type: "textarea" as const, required: false },
 ];
 
+// Field-dispatch professional services send a credentialed person to a site,
+// vehicle, or person, and produce a report as the deliverable — no parts or
+// inventory. form=services + delivery=physical + onsite-plus-portal is what the
+// forthcoming Field Dispatch capability reads to derive dispatch. Professional
+// licensing (inspector cert, PLS, notary commission) is a capability-layer
+// compliance overlay (Field Dispatch design ADR-5).
+const FIELD_PROFESSIONAL_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations"],
+  billingReadinessMode: "none",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "household",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "transactional",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
 export const professionalServicesArchetypes: ArchetypeDefinition[] = [
   {
     archetypeId: "it-managed-services",
@@ -263,5 +292,115 @@ export const professionalServicesArchetypes: ArchetypeDefinition[] = [
       { name: "budgetRange", label: "Budget range", type: "select" as const, required: false, options: ["Under £10k", "£10k–£50k", "£50k–£150k", "£150k+", "Not sure"] },
       { name: "currentSituation", label: "What challenge are you facing?", type: "textarea" as const, required: true },
     ],
+  },
+  {
+    archetypeId: "field-inspection",
+    name: "Property & Field Inspection",
+    category: "professional-services",
+    ctaType: "inquiry",
+    tags: ["inspection", "home inspection", "property inspection", "insurance inspection", "inspector", "report"],
+    itemTemplates: [
+      { name: "Home Buyer's Inspection", description: "Full pre-purchase inspection with a written report", priceType: "from" },
+      { name: "Pre-Listing Inspection", description: "Seller's inspection to surface issues before listing", priceType: "from" },
+      { name: "Specialty Inspection", description: "Radon, mold, sewer scope, or thermal imaging add-ons", priceType: "from" },
+      { name: "Insurance / 4-Point Inspection", description: "Wind mitigation and 4-point reports for insurers", priceType: "fixed" },
+      { name: "Commercial Property Inspection", description: "Condition assessment for commercial buildings", priceType: "quote" },
+      { name: "Re-Inspection", description: "Verify that flagged items have been repaired", priceType: "fixed" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Inspection Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Client Reviews", sortOrder: 3 },
+      { type: "contact", title: "Schedule an Inspection", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...INQUIRY_BASE_FIELDS,
+      { name: "propertyAddress", label: "Property address", type: "text" as const, required: true },
+      { name: "inspectionType", label: "Inspection type", type: "select" as const, required: true, options: ["Home buyer's", "Pre-listing", "Specialty", "Insurance / 4-point", "Commercial", "Re-inspection"] },
+      { name: "propertyType", label: "Property type", type: "select" as const, required: false, options: ["Single-family home", "Condo / townhouse", "Multi-family", "Commercial", "Land"] },
+    ],
+    activationProfile: FIELD_PROFESSIONAL_ACTIVATION,
+  },
+  {
+    // Equipment-bound and project-flavored — surveys are scheduled jobs with a
+    // plat/report deliverable, so this carries the projects module.
+    archetypeId: "land-surveying",
+    name: "Land Surveying",
+    category: "professional-services",
+    ctaType: "inquiry",
+    tags: ["surveying", "land survey", "boundary survey", "topographic", "ALTA", "surveyor", "PLS"],
+    itemTemplates: [
+      { name: "Boundary Survey", description: "Establish and mark property lines and corners", priceType: "quote" },
+      { name: "Topographic Survey", description: "Map elevations and features for design and permits", priceType: "quote" },
+      { name: "ALTA / Title Survey", description: "ALTA/NSPS land title survey for commercial transactions", priceType: "quote" },
+      { name: "Subdivision / Plat", description: "Survey and plat preparation for lot subdivision", priceType: "quote" },
+      { name: "Elevation Certificate", description: "FEMA elevation certificate for flood insurance", priceType: "from" },
+      { name: "Construction Staking", description: "Stake-out of building corners and grades on site", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Survey Services", sortOrder: 1 },
+      { type: "about", title: "About the Firm", sortOrder: 2 },
+      { type: "contact", title: "Request a Survey", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...INQUIRY_BASE_FIELDS,
+      { name: "propertyAddress", label: "Property address or parcel ID", type: "text" as const, required: true },
+      { name: "surveyType", label: "Survey type", type: "select" as const, required: true, options: ["Boundary", "Topographic", "ALTA / title", "Subdivision / plat", "Elevation certificate", "Construction staking", "Not sure"] },
+    ],
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "projects"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "household",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "transactional",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["requirement-to-deploy", "request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    },
+  },
+  {
+    // Pure go-to-person dispatch: the server/notary travels to a person to serve
+    // documents or witness a signing. Jurisdiction rules are a capability-layer
+    // compliance overlay.
+    archetypeId: "process-serving-notary",
+    name: "Process Serving & Mobile Notary",
+    category: "professional-services",
+    ctaType: "inquiry",
+    tags: ["process serving", "process server", "mobile notary", "loan signing", "apostille", "legal support"],
+    itemTemplates: [
+      { name: "Serve Legal Documents", description: "Service of summons, subpoenas, and court papers", priceType: "from" },
+      { name: "Rush / Same-Day Service", description: "Priority service of time-sensitive documents", priceType: "from" },
+      { name: "Skip Trace", description: "Locate a hard-to-find party for service", priceType: "from" },
+      { name: "Mobile Notary", description: "A notary travels to you to witness signatures", priceType: "fixed" },
+      { name: "Loan Signing", description: "Notarized signing agent for real-estate closings", priceType: "fixed" },
+      { name: "Court Filing & Courier", description: "File documents with the court on your behalf", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "contact", title: "Request Service", sortOrder: 3 },
+    ],
+    formSchema: [
+      ...INQUIRY_BASE_FIELDS,
+      { name: "serviceType", label: "Service needed", type: "select" as const, required: true, options: ["Serve documents", "Skip trace", "Mobile notary", "Loan signing", "Court filing", "Other"] },
+      { name: "serviceAddress", label: "Address for service / signing", type: "text" as const, required: false },
+      { name: "urgency", label: "Urgency", type: "select" as const, required: false, options: ["Standard", "Rush", "Same-day"] },
+    ],
+    activationProfile: FIELD_PROFESSIONAL_ACTIVATION,
   },
 ];

--- a/packages/storefront-templates/src/archetypes/retail-goods.ts
+++ b/packages/storefront-templates/src/archetypes/retail-goods.ts
@@ -152,4 +152,57 @@ export const retailGoodsArchetypes: ArchetypeDefinition[] = [
       },
     },
   },
+  {
+    // White-glove last-mile: the operating model is a delivery + installation
+    // *service* (crew + truck to a property), not a goods sale — which is why it
+    // sets form=services and derives field dispatch. Composes as a secondary
+    // service line on a retail primary (Field Dispatch composition design §6).
+    archetypeId: "furniture-delivery-install",
+    name: "Furniture & Appliance Delivery & Install",
+    category: "retail-goods",
+    ctaType: "inquiry",
+    tags: ["delivery", "white glove", "furniture assembly", "appliance installation", "last mile", "haul away"],
+    itemTemplates: [
+      { name: "White-Glove Delivery", description: "Two-person delivery to the room of choice with packaging removed", priceType: "from", ctaType: "inquiry" },
+      { name: "Furniture Assembly", description: "On-site assembly of flat-pack and built furniture", priceType: "from", ctaType: "inquiry" },
+      { name: "Appliance Delivery & Install", description: "Deliver, connect, and test large appliances", priceType: "from", ctaType: "inquiry" },
+      { name: "TV & Wall Mounting", description: "Mount and set up televisions and shelving", priceType: "fixed", ctaType: "inquiry" },
+      { name: "Haul-Away of Old Item", description: "Remove and responsibly dispose of the item being replaced", priceType: "fixed", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Delivery & Install Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Request a Quote", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "itemType", label: "What needs delivering or installing?", type: "select" as const, required: true, options: ["Furniture", "Large appliance", "TV / electronics", "Multiple items", "Other"] },
+      { name: "deliveryAddress", label: "Delivery address", type: "text" as const, required: true },
+      { name: "accessNotes", label: "Access notes (stairs, lift, parking)", type: "textarea" as const, required: false },
+    ],
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations"],
+      billingReadinessMode: "none",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "household",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "transactional",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    },
+  },
 ];

--- a/packages/storefront-templates/src/archetypes/security-services.ts
+++ b/packages/storefront-templates/src/archetypes/security-services.ts
@@ -1,0 +1,129 @@
+import type { ArchetypeDefinition } from "../types";
+
+// Physical security services. Guard/patrol is genuinely dispatch-native — post
+// assignments, patrol routes, and incident response are a real-time variant of
+// the dispatch loop — while alarm/CCTV is field-service installation. Both set
+// form=services + delivery=physical + consumptionChannel=onsite-plus-portal so
+// the forthcoming Field Dispatch capability derives officer/technician routing.
+// Guard licensing (PSO) and low-voltage licensing are capability-layer
+// compliance overlays (Field Dispatch design ADR-5), not modelled here.
+
+const CONTACT_FIELDS = [
+  { name: "name", label: "Full name", type: "text" as const, required: true },
+  { name: "email", label: "Email", type: "email" as const, required: true },
+  { name: "phone", label: "Phone", type: "tel" as const, required: true },
+];
+
+const BUSINESS_FIELDS = [
+  { name: "companyName", label: "Company / organization", type: "text" as const, required: false },
+  { name: "siteAddress", label: "Site address", type: "text" as const, required: false },
+];
+
+export const securityServicesArchetypes: ArchetypeDefinition[] = [
+  {
+    // Officer-on-a-post / patrol-route dispatch with incident response — the
+    // real-time variant of the field-dispatch loop. B2B contracts (recurring
+    // agreements) over managed client sites.
+    archetypeId: "guard-patrol",
+    name: "Security Guard & Patrol Services",
+    category: "security-services",
+    ctaType: "inquiry",
+    tags: ["security guard", "patrol", "manned guarding", "event security", "alarm response", "security"],
+    itemTemplates: [
+      { name: "Manned Guarding", description: "Static security officers posted at your site", priceType: "from" },
+      { name: "Mobile Patrol", description: "Scheduled and random patrols across one or more sites", priceType: "from" },
+      { name: "Event Security", description: "Crowd management and access control for events", priceType: "quote" },
+      { name: "Alarm Response & Keyholding", description: "Rapid response to alarm activations on your behalf", priceType: "from" },
+      { name: "Concierge / Front-of-House", description: "Reception and access control with a security mandate", priceType: "from" },
+      { name: "Loss Prevention", description: "Retail and warehouse loss-prevention officers", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Client Reviews", sortOrder: 3 },
+      { type: "contact", title: "Request a Proposal", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      ...BUSINESS_FIELDS,
+      { name: "serviceType", label: "Service needed", type: "select" as const, required: true, options: ["Manned guarding", "Mobile patrol", "Event security", "Alarm response", "Concierge", "Loss prevention", "Not sure"] },
+      { name: "coverage", label: "Coverage required", type: "select" as const, required: false, options: ["Daytime", "Overnight", "24/7", "One-off / event", "Not sure"] },
+    ],
+    activationProfile: {
+      profileType: "standard",
+      modules: ["customer-estate", "service-operations", "service-agreements", "billing-readiness", "lifecycle-signals"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "separate-customer-projection",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "business",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "recurring-agreement",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill", "detect-to-correct"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    },
+  },
+  {
+    // Field-service installation + recurring monitoring. The install is the
+    // dispatch (technician to the property-site); monitoring is the recurring
+    // revenue that anchors the recurring-agreement commercial model.
+    archetypeId: "alarm-cctv-install",
+    name: "Alarm & CCTV Installation",
+    category: "security-services",
+    ctaType: "inquiry",
+    tags: ["alarm", "cctv", "security cameras", "access control", "monitoring", "low voltage", "security"],
+    itemTemplates: [
+      { name: "Alarm System Installation", description: "Intruder alarm design and installation", priceType: "from" },
+      { name: "CCTV Installation", description: "Camera system design, install, and setup", priceType: "from" },
+      { name: "Access Control", description: "Keypad, fob, and smart-lock access systems", priceType: "quote" },
+      { name: "Monitoring Plan", description: "24/7 professional alarm monitoring on a monthly plan", priceType: "from" },
+      { name: "Smart-Home Security", description: "Integrated cameras, sensors, and app control", priceType: "from" },
+      { name: "Service & Upgrade", description: "Maintenance, fault-fix, and system upgrades", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Get a Quote", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "propertyType", label: "Property type", type: "select" as const, required: true, options: ["Residential", "Commercial", "Industrial"] },
+      { name: "systemInterest", label: "What are you interested in?", type: "select" as const, required: false, options: ["Alarm", "CCTV", "Access control", "Monitoring", "Smart-home security", "Not sure"] },
+      { name: "siteAddress", label: "Property address", type: "text" as const, required: false },
+    ],
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "service-agreements", "billing-readiness", "lifecycle-signals"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "household",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "recurring-agreement",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["requirement-to-deploy", "request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    },
+  },
+];

--- a/packages/storefront-templates/src/archetypes/trades-maintenance.ts
+++ b/packages/storefront-templates/src/archetypes/trades-maintenance.ts
@@ -26,6 +26,96 @@ const FACILITIES_FORM_FIELDS = [
   { name: "notes", label: "Additional details", type: "textarea" as const, required: false },
 ];
 
+// Field-dispatch trades send a mobile technician or crew to the customer's
+// property to work on a site or a piece of equipment. The load-bearing axis is
+// `consumptionChannel: "onsite-plus-portal"` together with `form: "services"`
+// and `delivery: "physical"` — that triple is what the (forthcoming) horizontal
+// Field Dispatch capability reads via `needsFieldDispatch(axes)` to derive the
+// dispatch board, dispatcher coworker, and map-pin "Dispatch" action without a
+// per-archetype flag (capability design 2026-06-13 ADR-1/ADR-2). Until that
+// module ships, field work composes under `service-operations`.
+//
+// Three operating shapes recur across the trades:
+//  - RECURRING — maintenance plans / route-based recurring visits with an
+//    ongoing customer relationship and serviced asset (HVAC, pest, pool).
+//  - ONE_OFF   — a single diagnose-and-fix visit, billed per job (appliance,
+//    pressure washing).
+//  - PROJECT   — a quoted, milestone-billed build/replacement (roofing).
+const TRADES_DISPATCH_RECURRING: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: [
+    "customer-estate",
+    "service-operations",
+    "service-agreements",
+    "billing-readiness",
+    "lifecycle-signals",
+  ],
+  billingReadinessMode: "prepared-not-prescribed",
+  customerGraph: "separate-customer-projection",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "household",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "recurring-agreement",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill", "detect-to-correct"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
+const TRADES_DISPATCH_ONE_OFF: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations"],
+  billingReadinessMode: "none",
+  customerGraph: "none",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "household",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "transactional",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
+const TRADES_DISPATCH_PROJECT: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations", "projects", "billing-readiness", "customer-estate"],
+  billingReadinessMode: "prepared-not-prescribed",
+  customerGraph: "separate-customer-projection",
+  estateSeparation: "shared",
+  axes: {
+    form: "services",
+    delivery: "physical",
+    primaryConsumer: "household",
+    consumptionChannel: "onsite-plus-portal",
+    commercialModel: "transactional",
+    provisioning: "account-with-billing",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "minimal" },
+    manufactureAndDeliver: { scope: "primary", it4itStages: ["requirement-to-deploy", "request-to-fulfill"] },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+};
+
 export const tradesMaintenanceArchetypes: ArchetypeDefinition[] = [
   {
     archetypeId: "facilities-maintenance",
@@ -155,5 +245,175 @@ export const tradesMaintenanceArchetypes: ArchetypeDefinition[] = [
       { name: "frequency", label: "Frequency", type: "select" as const, required: false, options: ["One-off", "Weekly", "Fortnightly", "Monthly", "Seasonal"] },
       { name: "notes", label: "Additional details", type: "textarea" as const, required: false },
     ],
+  },
+  {
+    // The Field Dispatch capability's reference vertical (Dale's HVAC business).
+    // The EPA 608 refrigerant-handling overlay is captured at job close by the
+    // capability's compliance framework (design §6.2 / ADR-5), not modelled here.
+    archetypeId: "hvac-contractor",
+    name: "HVAC Contractor",
+    category: "trades-maintenance",
+    ctaType: "inquiry",
+    tags: ["hvac", "heating", "cooling", "air conditioning", "furnace", "heat pump", "ductwork", "trades", "installation", "repair"],
+    itemTemplates: [
+      { name: "AC Repair", description: "Diagnose and repair air conditioning faults", priceType: "from" },
+      { name: "Heating / Furnace Repair", description: "Furnace, boiler, and heat pump fault diagnosis and repair", priceType: "from" },
+      { name: "System Installation", description: "Supply and install a new HVAC system — quoted after a site survey", priceType: "quote" },
+      { name: "Maintenance Plan", description: "Seasonal tune-ups and priority service on an annual agreement", priceType: "from" },
+      { name: "Indoor Air Quality", description: "Air purification, humidity control, and ventilation upgrades", priceType: "from" },
+      { name: "Emergency Call-Out", description: "24/7 response for no-heat and no-cool emergencies", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Request Service", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...TRADES_FORM_FIELDS,
+      { name: "systemType", label: "System type", type: "select" as const, required: false, options: ["Central air conditioning", "Furnace", "Heat pump", "Boiler", "Mini-split / ductless", "Not sure"] },
+    ],
+    activationProfile: TRADES_DISPATCH_RECURRING,
+  },
+  {
+    // Pesticide-applicator licensing + per-application logs are a capability-layer
+    // compliance overlay (design ADR-5); weather/re-entry gating lives in the
+    // dispatcher, not the storefront template.
+    archetypeId: "pest-control",
+    name: "Pest Control",
+    category: "trades-maintenance",
+    ctaType: "inquiry",
+    tags: ["pest control", "exterminator", "termite", "rodent", "insects", "wildlife", "trades"],
+    itemTemplates: [
+      { name: "General Pest Treatment", description: "Treatment for ants, spiders, roaches, and common pests", priceType: "from" },
+      { name: "Recurring Protection Plan", description: "Quarterly preventative treatment on an annual agreement", priceType: "from" },
+      { name: "Termite Inspection & Treatment", description: "Inspection, report, and treatment for termites", priceType: "quote" },
+      { name: "Rodent Control", description: "Exclusion, trapping, and removal of mice and rats", priceType: "from" },
+      { name: "Bed Bug Treatment", description: "Heat or chemical treatment for bed bug infestations", priceType: "quote" },
+      { name: "Wildlife Removal", description: "Humane removal of raccoons, squirrels, and other wildlife", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Request a Quote", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...TRADES_FORM_FIELDS,
+      { name: "pestType", label: "Pest problem", type: "select" as const, required: false, options: ["General insects", "Termites", "Rodents", "Bed bugs", "Wasps / hornets", "Wildlife", "Not sure"] },
+    ],
+    activationProfile: TRADES_DISPATCH_RECURRING,
+  },
+  {
+    archetypeId: "appliance-repair",
+    name: "Appliance Repair",
+    category: "trades-maintenance",
+    ctaType: "inquiry",
+    tags: ["appliance repair", "refrigerator", "washer", "dryer", "dishwasher", "oven", "trades"],
+    itemTemplates: [
+      { name: "Diagnostic Visit", description: "On-site diagnosis with the fee credited toward the repair", priceType: "fixed" },
+      { name: "Refrigerator / Freezer Repair", description: "Cooling, leak, and ice-maker fault repair", priceType: "from" },
+      { name: "Washer / Dryer Repair", description: "Repair for washing machines and dryers", priceType: "from" },
+      { name: "Oven / Range / Cooktop Repair", description: "Heating element, ignition, and control repair", priceType: "from" },
+      { name: "Dishwasher Repair", description: "Drainage, leak, and cleaning-performance repair", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Book a Repair", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...TRADES_FORM_FIELDS,
+      { name: "applianceType", label: "Appliance", type: "select" as const, required: true, options: ["Refrigerator / freezer", "Washer", "Dryer", "Oven / range", "Cooktop", "Dishwasher", "Microwave", "Other"] },
+      { name: "brand", label: "Brand & model (if known)", type: "text" as const, required: false },
+    ],
+    activationProfile: TRADES_DISPATCH_ONE_OFF,
+  },
+  {
+    archetypeId: "pool-spa-service",
+    name: "Pool & Spa Service",
+    category: "trades-maintenance",
+    ctaType: "inquiry",
+    tags: ["pool", "spa", "hot tub", "pool cleaning", "pool maintenance", "trades"],
+    itemTemplates: [
+      { name: "Weekly Pool Service", description: "Recurring cleaning, water testing, and chemical balancing", priceType: "from" },
+      { name: "Pool Opening / Closing", description: "Seasonal opening and winterization service", priceType: "from" },
+      { name: "Equipment Repair", description: "Pumps, heaters, filters, and automation repair", priceType: "from" },
+      { name: "Green-to-Clean Recovery", description: "Restore a neglected or algae-filled pool to swimmable", priceType: "quote" },
+      { name: "Leak Detection & Repair", description: "Locate and repair pool and plumbing leaks", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "about", title: "About Us", sortOrder: 2 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 3 },
+      { type: "contact", title: "Request Service", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...TRADES_FORM_FIELDS,
+      { name: "poolType", label: "Pool / spa type", type: "select" as const, required: false, options: ["In-ground pool", "Above-ground pool", "Spa / hot tub", "Pool and spa combo"] },
+      { name: "frequency", label: "Service frequency", type: "select" as const, required: false, options: ["One-off", "Weekly", "Fortnightly", "Monthly", "Seasonal"] },
+    ],
+    activationProfile: TRADES_DISPATCH_RECURRING,
+  },
+  {
+    archetypeId: "pressure-washing",
+    name: "Pressure Washing & Exterior Cleaning",
+    category: "trades-maintenance",
+    ctaType: "inquiry",
+    tags: ["pressure washing", "power washing", "soft wash", "exterior cleaning", "driveway", "trades"],
+    itemTemplates: [
+      { name: "House Soft Wash", description: "Low-pressure exterior wash for siding, render, and brick", priceType: "from" },
+      { name: "Driveway & Concrete Cleaning", description: "Pressure cleaning for driveways, paths, and patios", priceType: "from" },
+      { name: "Deck & Fence Cleaning", description: "Restore timber and composite decking and fences", priceType: "from" },
+      { name: "Roof Cleaning", description: "Soft-wash moss and algae removal from roofs", priceType: "quote" },
+      { name: "Gutter Clearing", description: "Clear and flush blocked gutters and downpipes", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "gallery", title: "Before & After", sortOrder: 2 },
+      { type: "about", title: "About Us", sortOrder: 3 },
+      { type: "contact", title: "Request a Quote", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...TRADES_FORM_FIELDS,
+      { name: "surfaceType", label: "Surface to clean", type: "select" as const, required: false, options: ["House exterior", "Driveway / concrete", "Deck / fence", "Roof", "Gutters", "Multiple"] },
+    ],
+    activationProfile: TRADES_DISPATCH_ONE_OFF,
+  },
+  {
+    // Project-flavored: replacements are quoted, milestone-billed builds. OSHA
+    // fall-protection is a capability-layer compliance overlay (design ADR-5).
+    archetypeId: "roofing-gutters",
+    name: "Roofing & Gutters",
+    category: "trades-maintenance",
+    ctaType: "inquiry",
+    tags: ["roofing", "roofer", "roof repair", "roof replacement", "gutters", "storm damage", "trades"],
+    itemTemplates: [
+      { name: "Roof Inspection", description: "Condition survey with a photo report and recommendations", priceType: "from" },
+      { name: "Roof Repair", description: "Leak, flashing, and storm-damage repair", priceType: "from" },
+      { name: "Roof Replacement", description: "Full re-roof — quoted after an inspection", priceType: "quote" },
+      { name: "Gutter Installation", description: "New seamless gutters and downpipes", priceType: "from" },
+      { name: "Storm Damage & Emergency Tarp", description: "Rapid response and temporary weatherproofing", priceType: "from" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Services", sortOrder: 1 },
+      { type: "gallery", title: "Our Work", sortOrder: 2 },
+      { type: "about", title: "About Us", sortOrder: 3 },
+      { type: "testimonials", title: "Customer Reviews", sortOrder: 4 },
+      { type: "contact", title: "Request a Quote", sortOrder: 5 },
+    ],
+    formSchema: [
+      ...TRADES_FORM_FIELDS,
+      { name: "serviceType", label: "What do you need?", type: "select" as const, required: true, options: ["Inspection", "Repair", "Full replacement", "Gutters", "Storm damage", "Not sure"] },
+      { name: "roofType", label: "Roof type (if known)", type: "select" as const, required: false, options: ["Asphalt shingle", "Tile", "Metal", "Flat / membrane", "Slate", "Not sure"] },
+    ],
+    activationProfile: TRADES_DISPATCH_PROJECT,
   },
 ];

--- a/packages/storefront-templates/src/operational-value-stream.ts
+++ b/packages/storefront-templates/src/operational-value-stream.ts
@@ -141,6 +141,9 @@ const CATEGORY_DEFAULT_COMMERCIAL_MODEL: Partial<Record<ArchetypeCategory, Comme
   "hoa-property-management": "statutory-fees-and-levies",
   "public-sector": "statutory-fees-and-levies",
   "banking-financial-services": "account-based-fees",
+  "automotive-services": "appointment-checkout",
+  "moving-and-logistics": "transactional",
+  "security-services": "recurring-agreement",
 };
 
 function resolveCommercialModel(a: ArchetypeDefinition): CommercialModel {
@@ -170,6 +173,12 @@ const CATEGORY_DEFAULT_DEMAND: Partial<Record<ArchetypeCategory, DemandSignature
   "nonprofit-community": "fiscal-calendar",
   "banking-financial-services": "rate-sensitive",
   "software-platform": "steady",
+  // Automotive: chips, breakdowns, and lockouts arrive unscheduled.
+  "automotive-services": "emergency-reactive",
+  // Moving peaks at month-end and over summer.
+  "moving-and-logistics": "seasonal",
+  // Guard contracts and monitoring are steady recurring coverage.
+  "security-services": "steady",
 };
 
 const CATEGORY_DEFAULT_CAPACITY: Partial<Record<ArchetypeCategory, CapacityUnitType>> = {
@@ -185,6 +194,10 @@ const CATEGORY_DEFAULT_CAPACITY: Partial<Record<ArchetypeCategory, CapacityUnitT
   "nonprofit-community": "volunteer-or-bed-capacity",
   "software-platform": "service-throughput",
   "hoa-property-management": "service-throughput",
+  // Field-dispatch services are bounded by technician / crew / officer hours.
+  "automotive-services": "slot-hours",
+  "moving-and-logistics": "slot-hours",
+  "security-services": "slot-hours",
 };
 
 // ── Derivation ───────────────────────────────────────────────────────────────

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -34,7 +34,23 @@ export type ArchetypeCategory =
    *  and custom builders (build-on-your-lot / BYOL). The defining value stream is
    *  design → permit → build → inspect → handover; subcontractors deliver most
    *  trade work under the builder's project management umbrella. */
-  | "real-estate-construction";
+  | "real-estate-construction"
+  /** Automotive field services: a technician travels to the customer's vehicle
+   *  (auto glass, mobile mechanic/detailing/tire, roadside/towing, locksmith).
+   *  Dispatch-native — the distinctive substrate is VIN→part resolution and the
+   *  ADAS calibration compliance overlay (a moat sibling to HVAC's EPA 608). See
+   *  docs/superpowers/research/2026-06-13-field-dispatch-archetype-gap-analysis.md §4 (B1). */
+  | "automotive-services"
+  /** Moving & last-mile logistics: a crew and truck travel to load, haul, and
+   *  deliver (moving, junk removal, courier, last-mile freight). Crew+truck
+   *  dispatch with a DOT hours-of-service overlay; distinct from
+   *  wholesale-distribution's B2B route delivery. Gap analysis §4 (B2). */
+  | "moving-and-logistics"
+  /** Physical security services: guard/patrol dispatch (post assignments, patrol
+   *  routes, incident response — a real-time dispatch variant) and alarm/CCTV
+   *  field installation with recurring monitoring. Guard (PSO) and low-voltage
+   *  licensing overlays. Gap analysis §4 (B3). */
+  | "security-services";
 
 export interface FormField {
   name: string;


### PR DESCRIPTION
## Summary

Folds the dispatch-native archetypes identified in the **2026-06-13 field-dispatch archetype gap analysis** into the catalog — the "separate thread" that doc hands off to. Adds **29 archetypes** (catalog now **87 archetypes across 19 categories**), each shaped so the forthcoming horizontal **Field Dispatch capability** derives dispatch from its operating-model axes.

Every new leaf is a business where a **mobile resource travels to the customer's site, asset, or person**. The load-bearing requirement is the axis triple `form: "services"` + `delivery: "physical"` + `consumptionChannel: "onsite-plus-portal"`, which is what `needsFieldDispatch(axes)` reads to derive the dispatch board, dispatcher coworker, and map-pin action — **no per-archetype flag** (capability design ADR-1/ADR-2). Until that module ships, field work composes under `service-operations`. **The capability itself is a parallel effort; this PR is only the archetypes + wiring + docs.**

## Gap A — 17 leaves into existing categories
- **trades-maintenance:** `hvac-contractor` (the capability's reference vertical), `pest-control`, `appliance-repair`, `pool-spa-service`, `pressure-washing`, `roofing-gutters`
- **healthcare-wellness:** `home-health-care`, `mobile-phlebotomy`, `dme-delivery`
- **pet-services:** `mobile-pet-grooming`, `mobile-vet`
- **professional-services:** `field-inspection`, `land-surveying`, `process-serving-notary`
- **beauty-personal-care:** `mobile-beauty`
- **nonprofit-community:** `meal-delivery-program`
- **retail-goods:** `furniture-delivery-install`

## Gap B — 3 new dispatch-native categories (12 leaves)
- **`automotive-services`:** `auto-glass` (Mark's windshield/ADAS example), `mobile-mechanic`, `mobile-detailing`, `mobile-tire`, `roadside-assistance`, `locksmith`
- **`moving-and-logistics`:** `moving-company`, `junk-removal`, `courier-delivery`, `last-mile-freight`
- **`security-services`:** `guard-patrol`, `alarm-cctv-install`

## Wiring
- `ArchetypeCategory` union (+3) — the only compile-forced change; every other consumer degrades to defaults.
- `archetypes/index.ts` (import + spread); `INDUSTRY_OPTIONS` 16→19 (+ test); `operational-value-stream` demand/capacity/commercial defaults; `composition-view` `map-dispatch` visual pattern for the new field categories; onboarding business-context profiles; per-category marketing playbooks.
- Architecture doc: §6.16–6.18 (new category value-stream profiles), §10.2 (recognizes the field-dispatch loop as a cross-category value-stream pattern, mirroring §10.1 rental), changelog.

Compliance overlays (EPA 608, ADAS calibration, pesticide-applicator, HIPAA, DOT, PSO/low-voltage) are noted as **capability-layer** concerns (design ADR-5), not modelled in the templates. No new Prisma model; additive only.

## Verification
- `@dpf/storefront-templates`: **108 tests pass, `tsc --noEmit` clean** — run against this branch's code. The package's all-archetypes-iterating tests (value-stream + media-profile) exercise every new archetype.
- New Gap-A/Gap-B test block asserts the dispatch axes on all 29 leaves + the new category membership.
- Touched `apps/web` tests pass: `industries.test`, `archetype-business-context.test`, `marketing-playbooks.test`, `composition-view.test`.
- `apps/web` typecheck and the `@dpf`-importing wrapper tests (e.g. `route-context`) can't run in this deps-less worktree (no `next` binary / workspace symlink); deferred to CI. Changes are additive and type-safe by construction.

Reviewable commit-by-commit: Gap A leaves → Gap B categories → docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)