### PR TITLE
feat(onboarding): business-context profiles for trades, pet-services & software-platform

### DIFF
--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -59,6 +59,9 @@ describe("resolveBusinessProfile", () => {
       "public-sector",
       "asset-rental",
       "real-estate-construction",
+      "trades-maintenance",
+      "pet-services",
+      "software-platform",
     ];
 
     it("populates a non-empty supplyChain on every industry profile", () => {

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -242,6 +242,42 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
     supplyChain:
       "We provision uniforms, vehicles, radios, and — for the install side — alarm, camera, and access-control hardware from security distributors. Licensing and training are as load-bearing as equipment; an unlicensed officer or an unmonitored panel is an operational and legal failure.",
   },
+  "trades-maintenance": {
+    missionTheme:
+      "do reliable, quality work that keeps our customers' homes and properties running",
+    businessModel:
+      "Job- and call-out-based work — quotes, repairs, installs, and maintenance plans. Reputation, reliability, and showing up when we said we would drive repeat work and referrals.",
+    whoWeServe:
+      "We serve homeowners, landlords, and businesses who need work done right and on time, often urgently. Trust is earned one job at a time, and a good tradesperson becomes the one they call again.",
+    howWeDecide:
+      "We decide for quality workmanship, safety, and honest pricing. We never cut corners on a fix that affects safety, we are upfront about what is needed versus what can wait, and we stand behind our work.",
+    supplyChain:
+      "We rely on trade suppliers and merchants for parts and materials — much of it carried as van stock so common jobs are first-visit fixes. Matching the right parts to the day's jobs is the discipline; a missing part means a second trip and a lost slot.",
+  },
+  "pet-services": {
+    missionTheme:
+      "care for every pet as if it were our own",
+    businessModel:
+      "Appointment- and visit-based services — grooming, walking, boarding, and care. Trust with people's animals drives loyalty and word-of-mouth referrals.",
+    whoWeServe:
+      "We serve pet owners who trust us with a member of their family. Many become regulars, so each visit is part of an ongoing relationship built on the animal's wellbeing and the owner's peace of mind.",
+    howWeDecide:
+      "We decide for the animal's safety, comfort, and wellbeing first, then the owner's trust. We are honest about what a pet needs, careful with handling and health, and we never take on more than we can care for well.",
+    supplyChain:
+      "We provision grooming and care consumables, food, and supplies from pet-trade distributors, plus equipment that must be cleaned and maintained to a hygiene standard. Running out of a consumable or a broken piece of equipment is a welfare and reputation issue, not just a cost one.",
+  },
+  "software-platform": {
+    missionTheme:
+      "build software that genuinely helps the people and businesses who depend on it",
+    businessModel:
+      "Subscription and usage-based recurring revenue. The business compounds on retention, expansion, and word-of-mouth — keeping customers successful matters far more than any single sale.",
+    whoWeServe:
+      "We serve the users and organizations who run part of their work on our product. The relationship is ongoing and renewal-driven, so their success and trust are the whole business, not a one-time transaction.",
+    howWeDecide:
+      "We decide for long-term customer success, reliability, and data trust over short-term growth hacks. We protect uptime and security, are honest about limitations and roadmap, and keep humans in control of consequential automated decisions.",
+    supplyChain:
+      "Our supply chain is almost entirely digital — cloud infrastructure, third-party APIs, and software subscriptions. The discipline is vendor selection, dependency and security review, and avoiding lock-in; an unreviewed dependency or a single-vendor outage can take the whole product down.",
+  },
 };
 
 // ─── Flagship specific-archetype overrides (merged over the industry profile) ─


### PR DESCRIPTION
## Summary

Small follow-up to the merged field-dispatch archetype expansion (#1856). Closes the last onboarding gap: of the 19 archetype categories, **`trades-maintenance`, `pet-services`, and `software-platform`** were the only ones with no `INDUSTRY_PROFILES` entry in `archetype-business-context.ts` — they silently fell back to the generic profile during onboarding.

Each now gets a business-model-aware starter (`missionTheme` / `businessModel` / `whoWeServe` / `howWeDecide` / `supplyChain`), matching the depth of the other 16 categories, so a fresh install's WWWD corpus reads like it understands trades work, pet care, and SaaS on day one. All entries are editable starters, per the file's contract.

## Changes
- `apps/web/lib/onboarding/archetype-business-context.ts` — +3 `INDUSTRY_PROFILES` entries.
- `apps/web/lib/onboarding/archetype-business-context.test.ts` — the `supplyChain` coverage check now asserts all three.

## Verification
- `archetype-business-context.test.ts`: **11 tests pass** (run against this branch).
- apps/web typecheck deferred to CI (deps-less worktree); changes are 3 data entries + 3 test strings, type-safe by construction against the existing `ArchetypeBusinessProfile` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)