### PR TITLE
fix(local-ai): self-calibrate local capability scores + fix first-run auto-pull on Docker Model Runner

### DIFF
--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -1040,6 +1040,60 @@ export async function autoDiscoverAndProfile(providerId: string): Promise<{
 }
 
 /**
+ * Queue deterministic dimension evals for any ACTIVE models on a provider whose
+ * profiles are still un-calibrated seed priors (profileSource="seed",
+ * evalCount=0). This is the catch-up path for the bundled local provider: its
+ * models are seeded at install but, unlike user-configured providers, never went
+ * through autoDiscoverAndProfile — so they were stuck on flat seed priors and
+ * routing could not tell a strong tool-caller from a weak one.
+ *
+ * Safe to call repeatedly (e.g. on page-load health checks): once a model's
+ * first eval completes (evalCount>=1, even if inconclusive) it no longer matches
+ * the filter, so it stops re-queueing. No-op for providers ineligible for
+ * background evals (OAuth-delegated, non-LLM endpoints). Returns the number of
+ * models queued.
+ */
+export async function queueUncalibratedModelEvals(providerId: string): Promise<number> {
+  const provider = await prisma.modelProvider.findUnique({
+    where: { providerId },
+    select: {
+      providerId: true,
+      endpointType: true,
+      category: true,
+      serviceKind: true,
+      authMethod: true,
+      cliEngine: true,
+    },
+  });
+  if (!canQueueBackgroundModelEvals(provider ?? {})) {
+    console.log(
+      `[auto-eval] Skipping calibration evals for ${JSON.stringify(providerId)}: ${JSON.stringify(backgroundModelEvalSkipReason(provider))}`,
+    );
+    return 0;
+  }
+
+  const models = await prisma.modelProfile.findMany({
+    where: { providerId, modelStatus: "active", profileSource: "seed", evalCount: 0 },
+    select: { modelId: true, id: true },
+  });
+  if (models.length === 0) return 0;
+
+  try {
+    const { inngest } = await import("@/lib/queue/inngest-client");
+    for (const event of buildAutoDiscoveryEvalEvents(providerId, models)) {
+      await inngest.send(event);
+    }
+    console.log(`[auto-eval] Queued calibration evals for ${models.length} un-calibrated model(s) on ${JSON.stringify(providerId)}`);
+  } catch (err) {
+    // Non-fatal — seed priors remain usable until the eval runs.
+    console.warn("[auto-eval] Failed to queue calibration evals for %s: %s",
+      JSON.stringify(providerId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
+  }
+  return models.length;
+}
+
+/**
  * Seed DiscoveredModel + ModelProfile from the known-model catalog.
  * Used for providers that can't call /v1/models (subscription OAuth, agent providers).
  */

--- a/apps/web/lib/inference/bootstrap-first-run.ts
+++ b/apps/web/lib/inference/bootstrap-first-run.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@dpf/db";
 import { checkBundledProviders, getOllamaHardwareInfo } from "./ollama";
-import { getOllamaBaseUrl } from "./ollama-url";
+import { getOllamaBaseUrl, getOllamaApiRoot } from "./ollama-url";
 import { isFirstRun, createSetupProgress } from "../actions/setup-progress";
 import { activateProvider } from "@/lib/govern/activate-provider";
 import { syncAgentPrincipal } from "@/lib/identity/principal-linking";
@@ -151,9 +151,14 @@ export async function executeFirstRunBootstrap(
     // 1. Try to activate Ollama — but don't block setup if it's unavailable
     try {
       const baseUrl = getOllamaBaseUrl();
+      // The Ollama-native /api/* endpoints live at the management root, not under
+      // the OpenAI-compatible /v1 inference prefix. On Docker Model Runner,
+      // `${baseUrl}/api/tags` resolves to /v1/api/tags (404), which silently
+      // skipped first-run auto-pull. getOllamaApiRoot() strips the /v1 suffix.
+      const apiRoot = getOllamaApiRoot();
 
-      // Check if Ollama is reachable
-      const pingRes = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
+      // Check if the local runtime is reachable
+      const pingRes = await fetch(`${apiRoot}/api/tags`, { signal: AbortSignal.timeout(3000) });
       if (pingRes.ok) {
         const tagsData = await pingRes.json() as { models?: Array<{ name: string }> };
         const pulledModels = (tagsData.models ?? []).filter(
@@ -166,7 +171,7 @@ export async function executeFirstRunBootstrap(
           console.log(`[bootstrap] No chat models found — pulling ${modelToPull}`);
           onStatus?.({ phase: "pulling_model", progress: 0, total: 1, status: `Pulling ${modelToPull}...` });
 
-          const pullRes = await fetch(`${baseUrl}/api/pull`, {
+          const pullRes = await fetch(`${apiRoot}/api/pull`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ name: modelToPull, stream: false }),

--- a/apps/web/lib/inference/ollama-url.test.ts
+++ b/apps/web/lib/inference/ollama-url.test.ts
@@ -68,3 +68,53 @@ describe("getOllamaBaseUrl", () => {
     delete process.env.LLM_BASE_URL;
   });
 });
+
+describe("getOllamaApiRoot", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.OLLAMA_INTERNAL_URL;
+    delete process.env.LLM_BASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("strips the /v1 inference prefix so /api/* hits the management root", async () => {
+    // Regression: `${base}/api/tags` on the /v1 base => /v1/api/tags (404 on
+    // Docker Model Runner), which silently disabled first-run auto-pull.
+    const { getOllamaApiRoot } = await import("./ollama-url");
+    expect(getOllamaApiRoot()).toBe("http://model-runner.docker.internal");
+  });
+
+  it("strips an /engines/v1 prefix", async () => {
+    const { getOllamaApiRoot } = await import("./ollama-url");
+    expect(
+      getOllamaApiRoot({ providerId: "local", baseUrl: "http://model-runner.docker.internal/engines/v1", endpoint: null }),
+    ).toBe("http://model-runner.docker.internal");
+  });
+
+  it("strips a /v1 with a trailing slash", async () => {
+    const { getOllamaApiRoot } = await import("./ollama-url");
+    expect(
+      getOllamaApiRoot({ providerId: "local", baseUrl: "http://localhost:11434/v1/", endpoint: null }),
+    ).toBe("http://localhost:11434");
+  });
+
+  it("leaves a native Ollama base URL (no /v1) unchanged", async () => {
+    const { getOllamaApiRoot } = await import("./ollama-url");
+    expect(
+      getOllamaApiRoot({ providerId: "local", baseUrl: "http://localhost:11434", endpoint: null }),
+    ).toBe("http://localhost:11434");
+  });
+
+  it("respects LLM_BASE_URL and strips its /v1 suffix", async () => {
+    process.env.LLM_BASE_URL = "http://custom:8080/v1";
+    const { getOllamaApiRoot } = await import("./ollama-url");
+    expect(getOllamaApiRoot()).toBe("http://custom:8080");
+    delete process.env.LLM_BASE_URL;
+  });
+});

--- a/apps/web/lib/inference/ollama-url.ts
+++ b/apps/web/lib/inference/ollama-url.ts
@@ -21,3 +21,19 @@ export function getOllamaBaseUrl(provider?: ProviderUrlFields | null): string {
   }
   return provider?.endpoint ?? provider?.baseUrl ?? "http://model-runner.docker.internal/v1";
 }
+
+/**
+ * Returns the root URL for the local provider's Ollama-native management API
+ * (`/api/tags`, `/api/pull`, `/api/version`).
+ *
+ * Docker Model Runner serves those endpoints at the host root
+ * (e.g. http://model-runner.docker.internal), NOT under the OpenAI-compatible
+ * `/v1` (or `/engines/v1`) inference prefix that getOllamaBaseUrl() returns.
+ * Appending `/api/tags` directly to the `/v1` base yields `/v1/api/tags`, which
+ * 404s on Docker Model Runner — silently disabling first-run model auto-pull.
+ * Strip the inference suffix so `/api/*` calls hit the management root. A real
+ * Ollama base URL (no `/v1` suffix) is returned unchanged.
+ */
+export function getOllamaApiRoot(provider?: ProviderUrlFields | null): string {
+  return getOllamaBaseUrl(provider).replace(/\/(engines\/)?v1\/?$/, "");
+}

--- a/apps/web/lib/inference/ollama.ts
+++ b/apps/web/lib/inference/ollama.ts
@@ -4,7 +4,7 @@
 // OpenAI-compatible local inference endpoint.
 
 import { prisma, syncInfraCI } from "@dpf/db";
-import { discoverModelsInternal, profileModelsInternal } from "./ai-provider-internals";
+import { autoDiscoverAndProfile, queueUncalibratedModelEvals } from "./ai-provider-internals";
 import { getOllamaBaseUrl } from "./ollama-url";
 export { getOllamaBaseUrl } from "./ollama-url";
 
@@ -92,18 +92,22 @@ export async function checkBundledProviders(): Promise<void> {
       data: { status: "active" },
     });
 
-    const result = await discoverModelsInternal("local");
-    if (result.discovered < 20) {
-      await profileModelsInternal("local");
-    }
+    // Discover + profile + queue the deterministic capability evals that promote
+    // each model's seed prior to measured ("evaluated") scores. Without the eval
+    // queue (the prior behaviour here), local models stayed on flat seed priors
+    // forever and routing could not tell a strong tool-caller from a weak one.
+    await autoDiscoverAndProfile("local");
     await enrichLocalInfraCI(baseUrl, "operational");
   } else if (reachable && provider.status === "active") {
     const profileCount = await prisma.modelProfile.count({ where: { providerId: "local" } });
     if (profileCount === 0) {
-      const result = await discoverModelsInternal("local");
-      if (result.discovered < 20) {
-        await profileModelsInternal("local");
-      }
+      await autoDiscoverAndProfile("local");
+    } else {
+      // Profiles exist but may still be un-calibrated seed priors (e.g. seeded at
+      // install, never evaluated). Queue the deterministic eval so capability
+      // scores reflect the real model. Self-limiting: stops once each model has
+      // an eval on record.
+      await queueUncalibratedModelEvals("local");
     }
     await enrichLocalInfraCI(baseUrl, "operational");
   } else if (!reachable && provider.status === "active") {

--- a/packages/db/src/local-model-capabilities.ts
+++ b/packages/db/src/local-model-capabilities.ts
@@ -1,0 +1,168 @@
+/**
+ * Capability *priors* for locally-served models (Docker Model Runner / Ollama).
+ *
+ * These are BOOTSTRAP priors only. A fresh install needs *some* capability
+ * scores so routing can function before the deterministic dimension eval
+ * (apps/web/lib/routing/eval-runner.ts) runs at provider activation and promotes
+ * profileSource seed -> evaluated with *measured* scores. Per the
+ * "seed is bootstrap, calibration is runtime" principle these values carry
+ * profileConfidence="low" so an activation-time eval always wins.
+ *
+ * Why a per-family prior instead of a flat default: the prior implementation
+ * stamped toolFidelity=20 on *every* discovered local model. That made routing
+ * unable to distinguish a strong tool-caller (Qwen3, Gemma — verified to emit
+ * clean tool_calls via Docker Model Runner) from a reasoning model that
+ * fabricates instead of calling tools (Magistral) from an embedding model that
+ * cannot chat at all (nomic-embed, which was additionally mis-flagged
+ * supportsToolUse=true). With every model scored identically, the tool-routing
+ * gate either stripped tools or could not pick the capable model, surfacing as
+ * the "I'm on a local AI that wasn't strong enough" coworker message.
+ * See the 2026-06 local-model capability investigation.
+ */
+
+export interface LocalModelCapabilityPrior {
+  /** True for embedding models (nomic, bge, e5, ...). Not chat/tool routable. */
+  isEmbedding: boolean;
+  capabilityCategory: string;
+  supportsToolUse: boolean;
+  reasoning: number;
+  codegen: number;
+  toolFidelity: number;
+  instructionFollowingScore: number;
+  structuredOutputScore: number;
+  conversational: number;
+  contextRetention: number;
+  bestFor: string[];
+  avoidFor: string[];
+}
+
+export type LocalModelFamily =
+  | "embedding"
+  | "qwen-coder"
+  | "qwen"
+  | "gemma"
+  | "magistral"
+  | "mistral"
+  | "llama"
+  | "phi"
+  | "deepseek"
+  | "unknown";
+
+/** Normalize a Docker Model Runner / Ollama model id to a bare lowercase name. */
+export function normalizeLocalModelId(modelId: string): string {
+  return modelId
+    .replace(/^docker\.io\//, "")
+    .replace(/^ai\//, "")
+    .toLowerCase();
+}
+
+/** Best-effort family detection from a (possibly registry-prefixed) model id. */
+export function detectLocalModelFamily(modelId: string): LocalModelFamily {
+  const id = normalizeLocalModelId(modelId);
+  // Embedding first — "nomic-embed" etc. must never fall through to a chat tier.
+  if (/embed|nomic|bge|e5-|gte-/.test(id)) return "embedding";
+  if (/qwen.*coder|coder.*qwen/.test(id)) return "qwen-coder";
+  if (/qwen/.test(id)) return "qwen";
+  if (/gemma/.test(id)) return "gemma";
+  if (/magistral/.test(id)) return "magistral";
+  if (/mistral|mixtral/.test(id)) return "mistral";
+  if (/llama/.test(id)) return "llama";
+  if (/phi/.test(id)) return "phi";
+  if (/deepseek/.test(id)) return "deepseek";
+  return "unknown";
+}
+
+/**
+ * Derive a capability prior for a local model id. Pure — no DB, no network.
+ * The numbers are deliberately coarse: they only need to be *good enough to
+ * route* until the deterministic eval measures the real model.
+ */
+export function deriveLocalModelCapabilityPrior(modelId: string): LocalModelCapabilityPrior {
+  const family = detectLocalModelFamily(modelId);
+  switch (family) {
+    case "embedding":
+      return {
+        isEmbedding: true,
+        capabilityCategory: "embedding",
+        supportsToolUse: false,
+        reasoning: 0, codegen: 0, toolFidelity: 0,
+        instructionFollowingScore: 0, structuredOutputScore: 0,
+        conversational: 0, contextRetention: 0,
+        bestFor: ["embedding", "retrieval"],
+        avoidFor: ["conversation", "tool-use", "reasoning"],
+      };
+    case "qwen-coder":
+      return {
+        isEmbedding: false, capabilityCategory: "standard", supportsToolUse: true,
+        reasoning: 68, codegen: 82, toolFidelity: 80,
+        instructionFollowingScore: 78, structuredOutputScore: 80,
+        conversational: 60, contextRetention: 55,
+        bestFor: ["coding", "tool-use", "general"], avoidFor: [],
+      };
+    case "qwen":
+      // Qwen3/3.6: the DPF-preferred local tier (strong tool-calling, F1 0.93+).
+      return {
+        isEmbedding: false, capabilityCategory: "standard", supportsToolUse: true,
+        reasoning: 70, codegen: 65, toolFidelity: 80,
+        instructionFollowingScore: 78, structuredOutputScore: 78,
+        conversational: 65, contextRetention: 55,
+        bestFor: ["tool-use", "conversation", "general"], avoidFor: [],
+      };
+    case "gemma":
+      // Verified: Gemma emits clean, valid tool_calls via Docker Model Runner.
+      return {
+        isEmbedding: false, capabilityCategory: "standard", supportsToolUse: true,
+        reasoning: 55, codegen: 45, toolFidelity: 65,
+        instructionFollowingScore: 65, structuredOutputScore: 60,
+        conversational: 70, contextRetention: 45,
+        bestFor: ["conversation", "tool-use", "general"], avoidFor: [],
+      };
+    case "magistral":
+      // Reasoning model: emits <think> monologue and tends to fabricate rather
+      // than emit a tool_call. Low tool prior; the eval confirms or corrects.
+      return {
+        isEmbedding: false, capabilityCategory: "basic", supportsToolUse: true,
+        reasoning: 68, codegen: 40, toolFidelity: 30,
+        instructionFollowingScore: 50, structuredOutputScore: 40,
+        conversational: 55, contextRetention: 50,
+        bestFor: ["reasoning"], avoidFor: ["tool-use", "agentic-tasks"],
+      };
+    case "mistral":
+      return {
+        isEmbedding: false, capabilityCategory: "basic", supportsToolUse: true,
+        reasoning: 55, codegen: 50, toolFidelity: 50,
+        instructionFollowingScore: 58, structuredOutputScore: 52,
+        conversational: 60, contextRetention: 45,
+        bestFor: ["conversation", "general"], avoidFor: [],
+      };
+    case "llama":
+      return {
+        isEmbedding: false, capabilityCategory: "basic", supportsToolUse: true,
+        reasoning: 52, codegen: 45, toolFidelity: 50,
+        instructionFollowingScore: 55, structuredOutputScore: 50,
+        conversational: 60, contextRetention: 45,
+        bestFor: ["conversation", "general"], avoidFor: [],
+      };
+    case "phi":
+    case "deepseek":
+      return {
+        isEmbedding: false, capabilityCategory: "basic", supportsToolUse: true,
+        reasoning: 58, codegen: 60, toolFidelity: 45,
+        instructionFollowingScore: 55, structuredOutputScore: 52,
+        conversational: 55, contextRetention: 45,
+        bestFor: ["coding", "general"], avoidFor: [],
+      };
+    case "unknown":
+    default:
+      // Conservative prior for an unrecognized local model. Above the old flat
+      // 20 so a capable-but-unknown model is not excluded outright, but low
+      // confidence so the deterministic eval corrects it quickly.
+      return {
+        isEmbedding: false, capabilityCategory: "basic", supportsToolUse: true,
+        reasoning: 40, codegen: 35, toolFidelity: 40,
+        instructionFollowingScore: 50, structuredOutputScore: 40,
+        conversational: 55, contextRetention: 40,
+        bestFor: ["conversation", "general"], avoidFor: [],
+      };
+  }
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -46,6 +46,7 @@ import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
 import { toModelProfileSeedCreateData } from "./model-profile-seed.js";
+import { deriveLocalModelCapabilityPrior } from "./local-model-capabilities.js";
 import { seedIntegrationCoverage } from "../scripts/seed-integration-coverage.js";
 import * as crypto from "crypto";
 import bcrypt from "bcryptjs";
@@ -1750,24 +1751,35 @@ async function seedLocalModels(): Promise<void> {
       where: { providerId_modelId: { providerId: "local", modelId: m.id } },
     });
     if (!existing) {
+      // Capability-aware bootstrap prior, keyed on model family. These are only
+      // priors (profileSource="seed", confidence "low") — the activation-time
+      // deterministic dimension eval promotes them to "evaluated" with measured
+      // scores. Replaces the prior flat toolFidelity=20 that made routing unable
+      // to distinguish a strong tool-caller from a reasoning model from an
+      // embedding model. See packages/db/src/local-model-capabilities.ts.
+      const prior = deriveLocalModelCapabilityPrior(m.id);
       await prisma.modelProfile.create({
         data: {
           providerId: "local",
           modelId: m.id,
-          friendlyName: m.id.replace("docker.io/ai/", ""),
-          summary: "Local model via Docker Model Runner",
-          capabilityCategory: "basic",
+          friendlyName: m.id.replace(/^docker\.io\/ai\//, "").replace(/^ai\//, ""),
+          summary: prior.isEmbedding
+            ? "Local embedding model via Docker Model Runner"
+            : "Local model via Docker Model Runner",
+          capabilityCategory: prior.capabilityCategory,
           costTier: "free",
-          bestFor: ["conversation", "general"],
-          avoidFor: [],
+          bestFor: prior.bestFor,
+          avoidFor: prior.avoidFor,
           modelStatus: "active",
           generatedBy: "system:seed",
           profileSource: "seed",
           profileConfidence: "low",
-          reasoning: 40, codegen: 30, toolFidelity: 20,
-          instructionFollowingScore: 50, structuredOutputScore: 30,
-          conversational: 60, contextRetention: 40,
-          capabilities: { streaming: true } as any,
+          supportsToolUse: prior.supportsToolUse,
+          reasoning: prior.reasoning, codegen: prior.codegen, toolFidelity: prior.toolFidelity,
+          instructionFollowingScore: prior.instructionFollowingScore,
+          structuredOutputScore: prior.structuredOutputScore,
+          conversational: prior.conversational, contextRetention: prior.contextRetention,
+          capabilities: { streaming: true, embedding: prior.isEmbedding } as any,
         },
       });
       discovered++;

--- a/packages/db/test/local-model-capabilities.test.ts
+++ b/packages/db/test/local-model-capabilities.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveLocalModelCapabilityPrior,
+  detectLocalModelFamily,
+  normalizeLocalModelId,
+} from "../src/local-model-capabilities";
+
+describe("normalizeLocalModelId", () => {
+  it("strips docker.io/ and ai/ registry prefixes and lowercases", () => {
+    expect(normalizeLocalModelId("docker.io/ai/gemma4:latest")).toBe("gemma4:latest");
+    expect(normalizeLocalModelId("ai/qwen3:14B-Q6_K")).toBe("qwen3:14b-q6_k");
+    expect(normalizeLocalModelId("Gemma4:26B")).toBe("gemma4:26b");
+  });
+});
+
+describe("detectLocalModelFamily", () => {
+  it("classifies the models currently bundled via Docker Model Runner", () => {
+    expect(detectLocalModelFamily("docker.io/ai/gemma4:latest")).toBe("gemma");
+    expect(detectLocalModelFamily("docker.io/ai/gemma4:26B")).toBe("gemma");
+    expect(detectLocalModelFamily("docker.io/ai/magistral-small-3.2:latest")).toBe("magistral");
+    expect(detectLocalModelFamily("docker.io/ai/qwen3:14B-Q6_K")).toBe("qwen");
+    expect(detectLocalModelFamily("docker.io/ai/nomic-embed-text-v1.5:latest")).toBe("embedding");
+  });
+
+  it("detects qwen coder before the generic qwen tier", () => {
+    expect(detectLocalModelFamily("ai/qwen2.5-coder:7B")).toBe("qwen-coder");
+  });
+});
+
+describe("deriveLocalModelCapabilityPrior", () => {
+  it("never returns the old flat toolFidelity=20 for a chat model", () => {
+    // Regression guard: the flat-20 prior is what made routing unable to tell a
+    // strong tool-caller from a reasoning model from an embedding model.
+    for (const id of [
+      "ai/gemma4:latest",
+      "ai/qwen3:14B-Q6_K",
+      "ai/magistral-small-3.2:latest",
+      "ai/some-unknown-model:latest",
+    ]) {
+      expect(deriveLocalModelCapabilityPrior(id).toolFidelity).not.toBe(20);
+    }
+  });
+
+  it("scores Qwen3 as a strong tool-caller", () => {
+    const p = deriveLocalModelCapabilityPrior("ai/qwen3:14B-Q6_K");
+    expect(p.supportsToolUse).toBe(true);
+    expect(p.toolFidelity).toBeGreaterThanOrEqual(75);
+    expect(p.isEmbedding).toBe(false);
+  });
+
+  it("scores Gemma as tool-capable (verified emits clean tool_calls)", () => {
+    const p = deriveLocalModelCapabilityPrior("docker.io/ai/gemma4:latest");
+    expect(p.supportsToolUse).toBe(true);
+    expect(p.toolFidelity).toBeGreaterThanOrEqual(60);
+  });
+
+  it("scores Magistral (reasoning model) as a weak tool-caller and warns against agentic use", () => {
+    const p = deriveLocalModelCapabilityPrior("ai/magistral-small-3.2:latest");
+    expect(p.toolFidelity).toBeLessThanOrEqual(35);
+    expect(p.avoidFor).toContain("tool-use");
+  });
+
+  it("classifies embedding models as non-chat, non-tool", () => {
+    const p = deriveLocalModelCapabilityPrior("docker.io/ai/nomic-embed-text-v1.5:latest");
+    expect(p.isEmbedding).toBe(true);
+    expect(p.supportsToolUse).toBe(false);
+    expect(p.toolFidelity).toBe(0);
+    expect(p.capabilityCategory).toBe("embedding");
+  });
+
+  it("gives an unknown chat model a conservative but routable prior", () => {
+    const p = deriveLocalModelCapabilityPrior("ai/brand-new-model:latest");
+    expect(p.isEmbedding).toBe(false);
+    expect(p.supportsToolUse).toBe(true);
+    expect(p.toolFidelity).toBeGreaterThan(20);
+    expect(p.toolFidelity).toBeLessThan(60);
+  });
+});


### PR DESCRIPTION
Two cohesive fixes from the local-AI reliability investigation: capable local models were present but coworkers still fell back to "I'm on a local AI that wasn't strong enough", and the optimal model set never auto-pulled on a Docker Model Runner install.

## Commit 1 — self-calibrate local model capability scores at activation

Root cause was fabricated capability metadata, not model capability (Gemma verified to emit clean `tool_calls` via Docker Model Runner):

- Every local model carried an identical flat seed prior — `toolFidelity: 20`, `profileSource: "seed"` — so routing could not distinguish a strong tool-caller (Qwen3 / Gemma) from a reasoning model that fabricates instead of calling tools (Magistral) from an **embedding model wrongly flagged `supportsToolUse: true`** (nomic-embed).
- The deterministic capability eval that would measure real `toolFidelity` **was never queued for the bundled local provider** (`checkBundledProviders()` discovered + profiled but never called `autoDiscoverAndProfile`), so scores were frozen at the seed prior. A fresh install resets `ModelProfile` every time, so prior calibration was silently lost.

Fix: capability-aware seed priors keyed on model family (`local-model-capabilities.ts`, pure + unit-tested); classify embedding models as non-tool/non-chat; wire `checkBundledProviders()` to `autoDiscoverAndProfile` + a new `queueUncalibratedModelEvals` so the **deterministic** eval (`scoreToolCall`, no judge model) measures real capability and promotes `profileSource: seed -> evaluated`. Self-limiting and self-healing on every install.

## Commit 2 — fix first-run model auto-pull on Docker Model Runner

`getOllamaBaseUrl()` returns the OpenAI-compatible base (`.../v1`), but `executeFirstRunBootstrap` appended the Ollama-native management paths to it → `/v1/api/tags` and `/v1/api/pull`. Docker Model Runner serves `/api/*` at the host root, so those 404 — the first-run "no chat models present → pull the optimal Qwen3 tier" path was **silently dead on every Docker Model Runner install** (the default). Confirmed live: `/v1/api/tags` → 404, `/api/tags` → 200.

Fix: `getOllamaApiRoot()` strips a trailing `/v1` or `/engines/v1` and is used for the `/api/tags` probe and `/api/pull`. Native Ollama base URLs (no `/v1`) are unchanged.

## Verification

- New unit tests: capability prior 9/9 green; URL-derivation regex 5/5 (node) + covered in `ollama-url.test.ts` (CI).
- `@dpf/db` typecheck clean for changed files; corrected `/api/tags` path returns 200 on the live Docker Model Runner.
- `apps/web` typecheck + full suite deferred to CI (deps-less worktree cannot resolve workspace packages locally).

Providers UX hardening (silent-failure surfacing, dead-button removal) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)