### PR TITLE
fix(ui): Providers — confirm OAuth Disconnect + honest action labels

### DIFF
--- a/apps/web/components/platform/ProviderDetailForm.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.tsx
@@ -57,6 +57,7 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
   const [saveMessage, setSaveMessage]               = useState<string | null>(null);
   const [discoveryResult, setDiscoveryResult]       = useState<{ discovered: number; newCount: number; error?: string; warning?: string } | null>(null);
   const [profilingResult, setProfilingResult]       = useState<{ profiled: number; failed: number; error?: string } | null>(null);
+  const [disconnectConfirm, setDisconnectConfirm]   = useState(false);
   const [pipelineStatus, setPipelineStatus]         = useState<string | null>(null);
 
   const [clientId, setClientId]                     = useState(credential?.clientId ?? "");
@@ -468,21 +469,45 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
                   Connected · token expires {new Date(credential.tokenExpiresAt).toLocaleString()}
                 </span>
               </div>
-              <button
-                type="button"
-                disabled={isPending}
-                onClick={() => startTransition(async () => {
-                  const result = await disconnectProviderOAuth(provider.providerId);
-                  if (result.error) {
-                    setTestResult({ ok: false, message: result.error });
-                    return;
-                  }
-                  router.refresh();
-                })}
-                style={{ background: "transparent", border: "1px solid var(--dpf-error)", color: "var(--dpf-error)", padding: "6px 14px", borderRadius: 6, cursor: "pointer", fontSize: 12 }}
-              >
-                Disconnect
-              </button>
+              {disconnectConfirm ? (
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                  <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>
+                    Disconnect this account? Linked services will be deactivated.
+                  </span>
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => startTransition(async () => {
+                      const result = await disconnectProviderOAuth(provider.providerId);
+                      if (result.error) {
+                        setTestResult({ ok: false, message: result.error });
+                        setDisconnectConfirm(false);
+                        return;
+                      }
+                      router.refresh();
+                    })}
+                    style={{ background: "color-mix(in srgb, var(--dpf-error) 15%, transparent)", border: "1px solid var(--dpf-error)", color: "var(--dpf-error)", padding: "6px 14px", borderRadius: 6, cursor: "pointer", fontSize: 12 }}
+                  >
+                    Confirm disconnect
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDisconnectConfirm(false)}
+                    style={{ background: "transparent", border: "1px solid var(--dpf-border)", color: "var(--dpf-muted)", padding: "6px 14px", borderRadius: 6, cursor: "pointer", fontSize: 12 }}
+                  >
+                    Cancel
+                  </button>
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  disabled={isPending}
+                  onClick={() => setDisconnectConfirm(true)}
+                  style={{ background: "transparent", border: "1px solid var(--dpf-error)", color: "var(--dpf-error)", padding: "6px 14px", borderRadius: 6, cursor: "pointer", fontSize: 12 }}
+                >
+                  Disconnect
+                </button>
+              )}
             </div>
           ) : credential?.status === "expired" ? (
             <div>
@@ -569,9 +594,10 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
           <button
             onClick={handleTest}
             disabled={isPending}
+            title="Verifies the connection, then discovers and profiles the provider's models."
             style={{ padding: "8px 16px", background: "transparent", border: "1px solid var(--dpf-border)", color: "var(--dpf-text)", borderRadius: 4, fontSize: 13, cursor: "pointer" }}
           >
-            Test connection
+            Test &amp; Discover
           </button>
           {saveMessage && <span style={{ fontSize: 12, color: saveMessage.startsWith("Error") ? "var(--dpf-error)" : "var(--dpf-success)" }}>{saveMessage}</span>}
           {testResult && (
@@ -594,7 +620,7 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
             disabled={isPending}
             style={{ background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)", color: "var(--dpf-text)", fontSize: 13, padding: "8px 14px", borderRadius: 4, cursor: isPending ? "not-allowed" : "pointer", opacity: isPending ? 0.6 : 1 }}
           >
-            {isPending ? "Syncing..." : "Sync Models & Profiles"}
+            {isPending ? "Syncing..." : "Discover & Profile Models"}
           </button>
           {isPending && (
             <span style={{ marginLeft: 8, fontSize: 12, color: "var(--dpf-muted)" }} className="animate-pulse">

--- a/apps/web/components/platform/SyncProvidersButton.tsx
+++ b/apps/web/components/platform/SyncProvidersButton.tsx
@@ -61,7 +61,7 @@ export function SyncProvidersButton({ lastSyncAt }: Props) {
   return (
     <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
       <button onClick={handleClick} disabled={isPending} style={buttonStyle}>
-        {isPending ? "Updating…" : "Update Providers"}
+        {isPending ? "Syncing…" : "Sync Provider Registry"}
       </button>
       {result && (
         <span style={{ fontSize: 10, color: result.ok ? "var(--dpf-success)" : "var(--dpf-error)" }}>


### PR DESCRIPTION
Tightens the **Platform > AI > Providers** surface — the controls that were "do something, but not sure what" and the one destructive action with no guard. Scoped deliberately: an audit flagged more, but on inspection the model-delete confirm and red error states **already existed**, so this PR only changes the genuine gaps.

## Changes

- **OAuth Disconnect now confirms.** It previously fired `disconnectProviderOAuth` immediately on click (deactivating linked services). Now a two-step inline confirm ("Disconnect this account? … / Confirm disconnect / Cancel"), matching the existing model-delete pattern.
- **Honest labels** (the buttons now say what they do):
  - "Test connection" → **"Test & Discover"** (+ tooltip) — it already ran discovery + profiling after the auth check.
  - "Sync Models & Profiles" → **"Discover & Profile Models"**.
  - "Update Providers" → **"Sync Provider Registry"** (it syncs the registry, not user connections).

No behavior change beyond the new confirm gate.

## Scope notes (verified against the code, not assumed)

- Model **Delete already has** an inline Confirm/Cancel — left as-is.
- Discovery/profiling/test errors **already render in red** (`var(--dpf-error)`), not muted gray — not a silent-failure bug.
- Scheduled-job "Run now" is non-destructive (idempotent sync trigger) — left without a confirm to avoid friction.

## Verification

`apps/web` typecheck + suite run in CI (deps-less worktree can't resolve workspace packages locally). JSX balance hand-verified.

Companion to [#1860](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1860) (local-model capability self-calibration + Docker Model Runner auto-pull) — separate surface, independent of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)