### PR TITLE
feat(ea+routing): SysML v2 substrate (Phase 1) + AI-cockpit model + email→utility routing (Slice E1)

### DIFF
--- a/apps/web/lib/marketing/channels/email-postmark/responder.ts
+++ b/apps/web/lib/marketing/channels/email-postmark/responder.ts
@@ -156,6 +156,12 @@ Respond with ONLY the classification token, no preamble.`,
       ],
       "You are a focused email classifier. Return exactly one token from the four-class list.",
       "internal",
+      // SysML AI-cockpit model, Slice E1: route inbound-email triage through the
+      // "email-triage" task requirement so it pins to the utility tier
+      // (cheap/local-preferred, never frontier) + minimize_cost, as a background
+      // (non-streaming) task. Previously this passed no taskType and could land on
+      // a frontier model.
+      { taskType: "email-triage", interactionMode: "background" },
     );
     const raw = (result?.content ?? "").trim().toLowerCase();
     if (raw.includes("qualified")) return "qualified-inquiry";

--- a/apps/web/lib/routing/request-contract.email.test.ts
+++ b/apps/web/lib/routing/request-contract.email.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the task-requirement loader so inferContract's behaviour is tested against
+// controlled requirement contracts (no DB). quality-tiers stays real (pure).
+vi.mock("./task-requirements", () => ({
+  getTaskRequirement: vi.fn(),
+}));
+
+import { getTaskRequirement } from "./task-requirements";
+import { inferContract } from "./request-contract";
+import type { TaskRequirement } from "./task-router-types";
+
+const mockGet = getTaskRequirement as unknown as ReturnType<typeof vi.fn>;
+
+function req(partial: Partial<TaskRequirement>): TaskRequirement {
+  return {
+    taskType: "x",
+    description: "",
+    selectionRationale: "",
+    requiredCapabilities: {},
+    preferredMinScores: {},
+    origin: "system",
+    ...partial,
+  };
+}
+
+const MSGS = [{ role: "user", content: "hello" }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("inferContract honours task-requirement routing-posture defaults", () => {
+  it("applies budgetClassDefault, reasoningDepthDefault, and residencyPolicy from the requirement", async () => {
+    mockGet.mockResolvedValue(
+      req({
+        taskType: "email-triage",
+        minimumTier: "adequate",
+        budgetClassDefault: "minimize_cost",
+        reasoningDepthDefault: "low",
+        residencyPolicy: "local_only",
+      })
+    );
+    const c = await inferContract("email-triage", MSGS);
+    expect(c.budgetClass).toBe("minimize_cost");
+    expect(c.reasoningDepth).toBe("low");
+    expect(c.residencyPolicy).toBe("local_only");
+  });
+
+  it("lets an explicit caller routeContext override the requirement default", async () => {
+    mockGet.mockResolvedValue(
+      req({ taskType: "email-triage", budgetClassDefault: "minimize_cost" })
+    );
+    const c = await inferContract("email-triage", MSGS, undefined, undefined, {
+      budgetClass: "quality_first",
+    });
+    expect(c.budgetClass).toBe("quality_first");
+  });
+
+  it("falls back to balanced/heuristic when the requirement sets no posture defaults (regression)", async () => {
+    // Mirrors existing built-ins (e.g. summarization) that set only minimumTier.
+    mockGet.mockResolvedValue(req({ taskType: "summarization", minimumTier: "adequate" }));
+    const c = await inferContract("summarization", MSGS);
+    expect(c.budgetClass).toBe("balanced");
+    expect(c.reasoningDepth).toBe("low"); // DEFAULT_REASONING_DEPTH["summarization"]
+    expect(c.residencyPolicy).toBeUndefined();
+  });
+
+  it("is non-fatal when the requirement lookup throws (no DB)", async () => {
+    mockGet.mockRejectedValue(new Error("no db"));
+    const c = await inferContract("conversation", MSGS);
+    expect(c.budgetClass).toBe("balanced");
+    expect(c.residencyPolicy).toBeUndefined();
+  });
+});

--- a/apps/web/lib/routing/request-contract.email.test.ts
+++ b/apps/web/lib/routing/request-contract.email.test.ts
@@ -1,75 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-// Mock the task-requirement loader so inferContract's behaviour is tested against
-// controlled requirement contracts (no DB). quality-tiers stays real (pure).
-vi.mock("./task-requirements", () => ({
-  getTaskRequirement: vi.fn(),
-}));
-
-import { getTaskRequirement } from "./task-requirements";
+import { describe, expect, it } from "vitest";
 import { inferContract } from "./request-contract";
-import type { TaskRequirement } from "./task-router-types";
 
-const mockGet = getTaskRequirement as unknown as ReturnType<typeof vi.fn>;
-
-function req(partial: Partial<TaskRequirement>): TaskRequirement {
-  return {
-    taskType: "x",
-    description: "",
-    selectionRationale: "",
-    requiredCapabilities: {},
-    preferredMinScores: {},
-    origin: "system",
-    ...partial,
-  };
-}
+// No module mocks. inferContract resolves the REAL TaskRequirement (DB-first, with
+// a built-in fallback). In a no-DB unit environment the DB lookup fails and the
+// built-in catalogue is used — which now carries the email-* routing-posture
+// defaults this asserts. A file-scoped vi.mock of the shared ./task-requirements
+// (or @dpf/db) module can leak across files under the forks pool, so this suite
+// deliberately avoids it and tests the integrated path instead.
 
 const MSGS = [{ role: "user", content: "hello" }];
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("inferContract honours task-requirement routing-posture defaults", () => {
-  it("applies budgetClassDefault, reasoningDepthDefault, and residencyPolicy from the requirement", async () => {
-    mockGet.mockResolvedValue(
-      req({
-        taskType: "email-triage",
-        minimumTier: "adequate",
-        budgetClassDefault: "minimize_cost",
-        reasoningDepthDefault: "low",
-        residencyPolicy: "local_only",
-      })
-    );
+  it("email-triage → utility posture (minimize_cost + low reasoning) from its requirement", async () => {
     const c = await inferContract("email-triage", MSGS);
     expect(c.budgetClass).toBe("minimize_cost");
     expect(c.reasoningDepth).toBe("low");
-    expect(c.residencyPolicy).toBe("local_only");
   });
 
-  it("lets an explicit caller routeContext override the requirement default", async () => {
-    mockGet.mockResolvedValue(
-      req({ taskType: "email-triage", budgetClassDefault: "minimize_cost" })
-    );
+  it("an explicit caller routeContext overrides the requirement default", async () => {
     const c = await inferContract("email-triage", MSGS, undefined, undefined, {
       budgetClass: "quality_first",
     });
     expect(c.budgetClass).toBe("quality_first");
   });
 
-  it("falls back to balanced/heuristic when the requirement sets no posture defaults (regression)", async () => {
-    // Mirrors existing built-ins (e.g. summarization) that set only minimumTier.
-    mockGet.mockResolvedValue(req({ taskType: "summarization", minimumTier: "adequate" }));
+  it("existing task type without posture defaults is unchanged (regression: summarization)", async () => {
     const c = await inferContract("summarization", MSGS);
     expect(c.budgetClass).toBe("balanced");
     expect(c.reasoningDepth).toBe("low"); // DEFAULT_REASONING_DEPTH["summarization"]
     expect(c.residencyPolicy).toBeUndefined();
   });
 
-  it("is non-fatal when the requirement lookup throws (no DB)", async () => {
-    mockGet.mockRejectedValue(new Error("no db"));
-    const c = await inferContract("conversation", MSGS);
+  it("unknown task type falls back to balanced + medium, no residency", async () => {
+    const c = await inferContract("totally-unknown-task-xyz", MSGS);
     expect(c.budgetClass).toBe("balanced");
+    expect(c.reasoningDepth).toBe("medium");
     expect(c.residencyPolicy).toBeUndefined();
   });
 });

--- a/apps/web/lib/routing/request-contract.ts
+++ b/apps/web/lib/routing/request-contract.ts
@@ -199,11 +199,29 @@ export async function inferContract(
   const sensitivity = (routeContext?.sensitivity ?? "internal") as
     RequestContract["sensitivity"];
 
-  const budgetClass = (routeContext?.budgetClass ?? "balanced") as
+  // Load the task requirement once (DB-backed, in-memory cached, with a built-in
+  // fallback). It is the "demand side" of the use-case → routing-policy matrix:
+  // it supplies the tier floor (below) plus routing-posture defaults (budget class,
+  // reasoning depth, residency) so the matrix is load-bearing, not advisory.
+  // Dynamic import mirrors the tier-floor lookup and avoids a static import cycle.
+  let taskReq: import("./task-router-types").TaskRequirement | undefined;
+  try {
+    const { getTaskRequirement } = await import("./task-requirements");
+    taskReq = await getTaskRequirement(taskType);
+  } catch {
+    taskReq = undefined;
+  }
+
+  // budgetClass: explicit caller override wins, then the task requirement's
+  // default, then "balanced". Existing task types set no default, so their
+  // behaviour is unchanged; email-* requirements default to minimize_cost.
+  const budgetClass = (routeContext?.budgetClass ?? taskReq?.budgetClassDefault ?? "balanced") as
     RequestContract["budgetClass"];
 
   // ── Reasoning depth ───────────────────────────────────────────────────
-  const reasoningDepth = DEFAULT_REASONING_DEPTH[taskType] ?? "medium";
+  // Requirement default wins, then the per-task-type heuristic, then "medium".
+  const reasoningDepth = (taskReq?.reasoningDepthDefault ?? DEFAULT_REASONING_DEPTH[taskType] ?? "medium") as
+    RequestContract["reasoningDepth"];
 
   // ── Contract family ───────────────────────────────────────────────────
   const contractFamily = `${interactionMode}.${taskType}`;
@@ -246,9 +264,12 @@ export async function inferContract(
   if (routeContext?.allowedProviders !== undefined) {
     contract.allowedProviders = routeContext.allowedProviders;
   }
-  if (routeContext?.residencyPolicy !== undefined) {
-    contract.residencyPolicy = routeContext.residencyPolicy as
-      RequestContract["residencyPolicy"];
+  // residencyPolicy: caller override wins, else the task requirement's policy
+  // (e.g. email triage hardened to "local_only" by an operator). Unset when
+  // neither is present, preserving the prior no-constraint default.
+  const residencyPolicy = routeContext?.residencyPolicy ?? taskReq?.residencyPolicy;
+  if (residencyPolicy !== undefined) {
+    contract.residencyPolicy = residencyPolicy as RequestContract["residencyPolicy"];
   }
 
   // ── Tier floor from task requirements ───────────────────────────────────
@@ -260,12 +281,8 @@ export async function inferContract(
   // doesn't meet the floor, and cost-per-success ranking can't route a
   // frontier task to a strong-tier model just because it's cheaper.
   try {
-    const [{ getTaskRequirement }, { TIER_MINIMUM_DIMENSIONS, isValidTier }] = await Promise.all([
-      import("./task-requirements"),
-      import("./quality-tiers"),
-    ]);
-    const req = await getTaskRequirement(taskType);
-    const tier = req?.minimumTier;
+    const { TIER_MINIMUM_DIMENSIONS, isValidTier } = await import("./quality-tiers");
+    const tier = taskReq?.minimumTier;
     if (tier && isValidTier(tier)) {
       const tierFloor = TIER_MINIMUM_DIMENSIONS[tier];
       if (Object.keys(tierFloor).length > 0) {

--- a/apps/web/lib/routing/task-requirements.email.test.ts
+++ b/apps/web/lib/routing/task-requirements.email.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
-
-// task-requirements.ts imports the prisma client at module load; stub it so this
-// pure built-in-content assertion does not require a provisioned DB / generated client.
-vi.mock("@dpf/db", () => ({ prisma: {} }));
-
+import { describe, expect, it } from "vitest";
+// No module mocks. Importing the real @dpf/db is harmless here — reading
+// BUILT_IN_TASK_REQUIREMENTS (a const) triggers no DB query. A file-scoped
+// vi.mock("@dpf/db") can leak across files under the forks pool (it broke an
+// unrelated ollama-health test in CI shard 3/4), so this suite avoids it.
 import { BUILT_IN_TASK_REQUIREMENTS } from "./task-requirements";
 
 // SysML AI-cockpit model, Slice E1 (REQ-AIC-E1): inbound-email triage must route

--- a/apps/web/lib/routing/task-requirements.email.test.ts
+++ b/apps/web/lib/routing/task-requirements.email.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+// task-requirements.ts imports the prisma client at module load; stub it so this
+// pure built-in-content assertion does not require a provisioned DB / generated client.
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { BUILT_IN_TASK_REQUIREMENTS } from "./task-requirements";
+
+// SysML AI-cockpit model, Slice E1 (REQ-AIC-E1): inbound-email triage must route
+// to the utility tier — never frontier — and minimize cost. These assertions pin
+// the requirement contract that makes that true.
+describe("email-* built-in task requirements", () => {
+  for (const taskType of ["email-triage", "email-summarize", "email-extract"]) {
+    it(`${taskType} is pinned to the utility tier and minimize_cost`, () => {
+      const req = BUILT_IN_TASK_REQUIREMENTS[taskType];
+      expect(req, `${taskType} must exist in BUILT_IN_TASK_REQUIREMENTS`).toBeDefined();
+      // Utility tier: adequate, never frontier/strong (the core privacy/cost win).
+      expect(req!.minimumTier).toBe("adequate");
+      expect(req!.budgetClassDefault).toBe("minimize_cost");
+      expect(req!.preferCheap).toBe(true);
+      expect(req!.origin).toBe("system");
+    });
+  }
+
+  it("does NOT hard-require structured output (keeps local models eligible)", () => {
+    // email-extract benefits from structured output but must not exclude local
+    // models that don't declare the capability — it is a preference, not a gate.
+    expect(BUILT_IN_TASK_REQUIREMENTS["email-extract"]!.requiredCapabilities.supportsStructuredOutput)
+      .toBeUndefined();
+  });
+
+  it("leaves residencyPolicy unset by default so no-local installs are not starved", () => {
+    // local_only hardening is an operator opt-in via the DB TaskRequirement row.
+    for (const taskType of ["email-triage", "email-summarize", "email-extract"]) {
+      expect(BUILT_IN_TASK_REQUIREMENTS[taskType]!.residencyPolicy).toBeUndefined();
+    }
+  });
+});

--- a/apps/web/lib/routing/task-requirements.ts
+++ b/apps/web/lib/routing/task-requirements.ts
@@ -110,6 +110,52 @@ export const BUILT_IN_TASK_REQUIREMENTS: Record<string, TaskRequirement> = {
     preferCheap: false,
     origin: "system",
   },
+
+  // ── Inbound business-email processing (SysML AI-cockpit model, Slice E1) ────
+  // Email triage is high-volume, privacy-sensitive background utility work. Pin it
+  // to the utility tier (adequate, never frontier) and minimize_cost so it routes
+  // to cheap/local-preferred capacity — the DPF equivalent of Odysseus's dedicated
+  // "utility" email model role, made load-bearing through the task requirement
+  // rather than an ad-hoc call-site flag. residencyPolicy is intentionally left
+  // unset by default (so installs without local AI still work); an operator/org can
+  // set residencyPolicy="local_only" on the DB TaskRequirement row to harden
+  // privacy. Satisfies REQ-AIC-E1 in the AI-cockpit SysML model.
+  "email-triage": {
+    taskType: "email-triage",
+    description: "Classifying / triaging an inbound business email (intent, spam, urgency, routing).",
+    selectionRationale: "High-volume, privacy-sensitive background utility work — keep it cheap/local-preferred, never frontier.",
+    requiredCapabilities: {},
+    preferredMinScores: { instructionFollowing: 45 },
+    minimumTier: "adequate",
+    preferCheap: true,
+    budgetClassDefault: "minimize_cost",
+    reasoningDepthDefault: "low",
+    origin: "system",
+  },
+  "email-summarize": {
+    taskType: "email-summarize",
+    description: "Summarizing an inbound email or thread into a short brief.",
+    selectionRationale: "Low-risk summarization — cheap/local utility tier.",
+    requiredCapabilities: {},
+    preferredMinScores: { instructionFollowing: 50 },
+    minimumTier: "adequate",
+    preferCheap: true,
+    budgetClassDefault: "minimize_cost",
+    reasoningDepthDefault: "low",
+    origin: "system",
+  },
+  "email-extract": {
+    taskType: "email-extract",
+    description: "Extracting action items / entities (dates, asks, references) from an inbound email.",
+    selectionRationale: "Structured extraction from email — favour cheap/local; structured-output quality is preferred, not hard-required, so local models stay eligible.",
+    requiredCapabilities: {},
+    preferredMinScores: { structuredOutput: 55, instructionFollowing: 50 },
+    minimumTier: "adequate",
+    preferCheap: true,
+    budgetClassDefault: "minimize_cost",
+    reasoningDepthDefault: "medium",
+    origin: "system",
+  },
 };
 
 // ── Loader ────────────────────────────────────────────────────────────────────

--- a/apps/web/lib/routing/task-router-types.ts
+++ b/apps/web/lib/routing/task-router-types.ts
@@ -42,6 +42,19 @@ export interface TaskRequirement {
   // "frontier" = complex tool-calling, code-gen; "adequate" = simple conversation.
   minimumTier?: QualityTier;
 
+  // SysML routing-policy matrix (2026-06-14 AI-cockpit model): routing-posture
+  // defaults carried BY the task requirement so the use-case → routing-policy
+  // mapping is load-bearing. Honoured by inferContract() when the caller's
+  // routeContext does not override them.
+  //   budgetClassDefault    biases cost vs quality (email triage → minimize_cost)
+  //   reasoningDepthDefault sets the effort floor
+  //   residencyPolicy       "local_only" keeps a use case on local/on-prem endpoints
+  //                         (privacy-sensitive work); default leaves it unset so
+  //                         installs without local AI are not starved.
+  budgetClassDefault?: "minimize_cost" | "balanced" | "quality_first";
+  reasoningDepthDefault?: "minimal" | "low" | "medium" | "high";
+  residencyPolicy?: "local_only" | "approved_cloud" | "any_enabled";
+
   // Operational preferences
   maxLatencyMs?: number;
   preferCheap?: boolean;

--- a/docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md
+++ b/docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md
@@ -1,0 +1,157 @@
+# AI Cockpit & Model Routing — SysML Architecture Note
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-14 |
+| Status | Draft — first SysML model seeded over current state |
+| Notation | SysML v2 (`sysml2` EA notation) — viewpoint over the canonical DPF EA graph |
+| Package | `PKG-AIC` "AI Cockpit & Model Routing" |
+| Owner | Enterprise Architect, AI Platform team |
+| Source design | [`2026-06-14-odysseus-review-depth-pass.md`](2026-06-14-odysseus-review-depth-pass.md), [`2026-06-14-odysseus-ux-routing-model-review.md`](2026-06-14-odysseus-ux-routing-model-review.md) |
+| Substrate spec | [`2026-06-14-sysml-architecture-substrate-design.md`](../superpowers/specs/2026-06-14-sysml-architecture-substrate-design.md) |
+| Model content (seed) | [`packages/db/src/seed-ea-sysml-ai-cockpit.ts`](../../packages/db/src/seed-ea-sysml-ai-cockpit.ts) |
+
+This is the first real SysML v2 model seeded over DPF's current state. It applies the
+SysML substrate (Phase 1, landed in this change) to the Odysseus-derived AI-cockpit /
+use-case model-routing / coworker-thread-receipt / inbound business-email design. The
+canonical model is the DPF EA graph (`EaElement`/`EaRelationship`); the markdown here is
+the human-readable companion and the source for the seed. Per the substrate spec's stance,
+runtime/DB/portal validation of the EA seed is the **deferred follow-up thread**; the
+routing/email behaviour (Slice E1) is verified by source-local tests now.
+
+**Legend.** `[D]` = deterministic fact (grounded in code/schema). `[J]` = architect-authored
+judgment (design intent, not yet realized). Verification status: **green** = automated test
+passes today; **planned** = future slice.
+
+---
+
+## SysML Architecture Note (skill template)
+
+- **Scope:** AI inference routing (use-case policy matrix, receipts, fallback/escalation),
+  coworker-thread governance metadata, and inbound business-email processing. Changes the
+  AI platform decomposition and the routing data contract; adds a SysML model package.
+- **Changed requirements/constraints:** REQ-AIC-1…9 + CON-AIC-1 (below). REQ-AIC-5 (email→utility)
+  realized this change; the rest are modeled and allocated, realized across later slices.
+- **Changed interfaces/ports:** `routeAndCall` options now carry the `email-triage` task type +
+  `interactionMode:"background"` `[D]`; `TaskRequirement` gains `budgetClassDefault`/
+  `reasoningDepthDefault`/`residencyPolicy` `[D]`. Planned: `ThreadTurnReceipt` read view,
+  `tasks/submit` inbound→coworker, inbound email webhook.
+- **Allocations:** routing obligations → `pipeline-v2`/`request-contract`/`task-requirements`;
+  receipts → `RouteDecisionLog`/`RouteOutcome`/`AdapterRunTelemetry`; email → marketing inbound
+  loop + Communication Fabric; thread → `AgentThread`. (Full table below.)
+- **Verification cases:** VC-AIC-E1, VC-AIC-MATRIX, VC-AIC-SYSML green today; others planned.
+- **Data authority impact:** No new source-of-truth tables. Routing authority stays in the
+  routing pipeline + `TaskRequirement`; receipts stay in the three telemetry tables; the SysML
+  model is seeded into the existing EA graph (no new EA tables — substrate spec §3 boundary).
+- **EA/current-state catch-up:** New `sysml2` notation + two viewpoints + this model package +
+  cross-notation `sysml_allocates`/`sysml_traces`/`sysml_verifies` bridges to ArchiMate.
+- **Open architecture risks:** (1) EA seed not runtime-validated from the worktree (deferred).
+  (2) `residencyPolicy="local_only"` left unset by default to avoid starving no-local installs —
+  privacy hardening is an operator opt-in. (3) Receipt view + thread fields are modeled but
+  unbuilt; tracked as REQ-AIC-2/9.
+
+---
+
+## 1. Requirements (`requirement`)
+
+Stable IDs are the `infraCiKey`s in the EA seed (`sysml:req:REQ-AIC-N`).
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| REQ-AIC-1 | **Use-case model routing.** Every LLM call is routed by use case (`taskType`) through a governed policy matrix, not a single global model setting. | green (matrix load-bearing) `[D]` |
+| REQ-AIC-2 | **Visible model receipt.** Each coworker turn exposes requested policy, actual responding model, and any fallback/escalation. | planned `[J]` |
+| REQ-AIC-3 | **No silent frontier escalation for sensitive work.** Privacy-sensitive use cases must not silently escalate to a frontier/cloud model; any escalation carries a reason code. | planned `[J]` |
+| REQ-AIC-4 | **Fallback/escalation auditability.** Fallback and escalation are recorded as reason-coded evidence. | partial — fallback recorded `[D]`; escalation reason codes planned `[J]` |
+| REQ-AIC-5 | **Email triage on the utility tier.** Inbound business-email triage routes to the utility tier (cheap/local-preferred, never frontier) and minimize-cost. | **green** `[D]` |
+| REQ-AIC-6 | **Inbound email → coworker routing.** A triaged email can be handed to the right coworker via the inbound→coworker contract (`tasks/submit`). | planned `[J]` |
+| REQ-AIC-7 | **Draft-never-send.** Email replies are drafted and require human approval; never auto-sent. | partial — `OutboundDraft(status="pending-review")` exists `[D]` |
+| REQ-AIC-8 | **Business-mailbox transport via OAuth.** Inbound business email is ingested via OAuth/provider-push (Graph/Gmail/Postmark), not stored passwords (conduit-not-broker). | planned `[J]` |
+| REQ-AIC-9 | **Durable thread governance metadata.** Coworker threads carry `memoryMode`, durable `attachedSources`, `compactionState`, and a decision link. | planned `[J]` |
+
+## 2. Constraint / parametric (`constraint`)
+
+**CON-AIC-1 — Routing policy constraint.** The selected endpoint's tier, residency, and budget
+class are a function of the use case's `(sensitivity × residencyPolicy × budgetClass × minimumTier)`.
+Invariants:
+
+- `minimumTier(email-*) = adequate` ⇒ frontier endpoints are excluded for email use cases. `[D]`
+- `budgetClass(email-*) = minimize_cost` ⇒ cost-per-success ranking prefers cheap/local. `[D]`
+- `residencyPolicy = local_only ⇒ only local/on-prem endpoints eligible` (operator opt-in). `[D]`
+- `sensitivity ∈ {confidential, restricted} ⇒ no silent escalation to frontier` (REQ-AIC-3). `[J]`
+
+This constraint is realized by `inferContract()` translating the `TaskRequirement` into a
+`RequestContract`, and by `routeEndpointV2()` hard-filtering on tier/residency then ranking by
+cost-per-success. `[D]`
+
+## 3. Part definitions (`part_definition`) and allocations
+
+Each block is **allocated** (`sysml_allocates`) to the existing substrate that realizes it.
+
+| Block (ID) | Realizing substrate (allocation) | Satisfies |
+| --- | --- | --- |
+| `PART-AIC-router` Routing Policy Engine | `apps/web/lib/routing/pipeline-v2.ts` (`routeEndpointV2`) `[D]` | REQ-AIC-1 |
+| `PART-AIC-contract` Request Contract Builder | `apps/web/lib/routing/request-contract.ts` (`inferContract`) `[D]` | REQ-AIC-1, REQ-AIC-5 |
+| `PART-AIC-matrix` Use-Case Policy Matrix | `apps/web/lib/routing/task-requirements.ts` (`TaskRequirement`) `[D]` | REQ-AIC-1, REQ-AIC-5 |
+| `PART-AIC-receipt` Turn Receipt View | join of `RouteDecisionLog`+`RouteOutcome`+`AdapterRunTelemetry` `[D]` (view unbuilt `[J]`) | REQ-AIC-2, REQ-AIC-4 |
+| `PART-AIC-reasoncodes` Reason Code Registry | scattered unions today (`InferenceError.code`, `EndpointUnavailableReason`, …) `[D]`; consolidation planned `[J]` | REQ-AIC-3, REQ-AIC-4 |
+| `PART-AIC-emailpipe` Inbound Email Pipeline | `apps/web/lib/marketing/channels/email-postmark/responder.ts` `[D]` (generalization planned `[J]`) | REQ-AIC-5, REQ-AIC-6, REQ-AIC-7 |
+| `PART-AIC-emailtransport` Email Transport | Postmark inbound webhook `[D]`; Graph/Gmail OAuth poller planned `[J]` | REQ-AIC-8 |
+| `PART-AIC-thread` Coworker Thread | `AgentThread` (`packages/db/prisma/schema.prisma`) `[D]`; +4 governance fields planned `[J]` | REQ-AIC-9 |
+| `PART-AIC-fabric` Communication Fabric | `apps/web/lib/communications/*` + fabric spec §14.4 `[D]`/`[J]` | REQ-AIC-6 |
+
+## 4. Interfaces / ports (`interface_definition`)
+
+| ID | Interface | Where | Status |
+| --- | --- | --- | --- |
+| `IF-AIC-routeandcall` | `routeAndCall(messages, system, sensitivity, options)` | `routed-inference.ts` `[D]` | green |
+| `IF-AIC-receipt` | `ThreadTurnReceipt` (read join of the 3 telemetry tables) | planned `[J]` | planned |
+| `IF-AIC-tasksubmit` | `tasks/submit` inbound→coworker | fabric spec §14.4 `[J]` | planned |
+| `IF-AIC-webhook` | `/api/communications/<provider>/webhook` inbound email | convention `[J]` | planned |
+
+## 5. State machines (`state`)
+
+**SM-EMAIL — Inbound email lifecycle** `[D]` for the built path:
+`received → pre-filtered → classified → { spam → dropped | qualified/support/other → engagement-linked? → drafted → pending-approval → published }`.
+
+**SM-ROUTE — Route decision** `[D]`:
+`requested → capability-filtered → cost-ranked → selected → { dispatched → success | failure → fallback(reason) → retry | exhausted → error }`. Escalation-to-higher-tier with reason code is `[J]` (REQ-AIC-3/4).
+
+**SM-THREAD-PRIVACY — Thread memory mode** `[J]` (REQ-AIC-9):
+`normal ↔ scoped (retrieval blocked) ↔ private (persist + retrieval blocked)`.
+
+## 6. Verification cases (`verification_case`)
+
+| ID | Verifies | Evidence | Status |
+| --- | --- | --- | --- |
+| VC-AIC-E1 | REQ-AIC-5 | `apps/web/lib/routing/task-requirements.email.test.ts` | **green** |
+| VC-AIC-MATRIX | REQ-AIC-1 | `apps/web/lib/routing/request-contract.email.test.ts` | **green** |
+| VC-AIC-SYSML | substrate (Phase 1) | `packages/db/src/seed-ea-sysml2.test.ts`, `seed-ea-viewpoints.test.ts` | **green** |
+| VC-AIC-DRAFT | REQ-AIC-7 | `OutboundDraft.status="pending-review"` assertion | planned |
+| VC-AIC-RECEIPT | REQ-AIC-2 | receipt-view join test | planned |
+| VC-AIC-THREAD | REQ-AIC-9 | thread-metadata migration + test | planned |
+| VC-AIC-TRANSPORT | REQ-AIC-8 | OAuth inbound poller integration test | planned |
+
+## 7. Traceability summary
+
+```
+REQ-AIC-1 ──satisfies── PART-AIC-router, PART-AIC-contract, PART-AIC-matrix ──verifies── VC-AIC-MATRIX ✓
+REQ-AIC-5 ──satisfies── PART-AIC-matrix, PART-AIC-contract, PART-AIC-emailpipe ──verifies── VC-AIC-E1 ✓
+CON-AIC-1 ──refines──── REQ-AIC-1, REQ-AIC-3, REQ-AIC-5
+PART-AIC-router ──sysml_allocates──▶ archimate:application_component (routing pipeline)
+REQ-AIC-5 ──sysml_traces──▶ archimate:business_capability (inbound business-email processing)
+VC-AIC-E1 ──sysml_verifies──▶ archimate:event_evidence (test run evidence)
+```
+
+## 8. What landed in this change vs. what is modeled-for-later
+
+**Landed + verified `[D]`:**
+- SysML v2 notation, two viewpoints, cross-notation bridges (Phase 1 substrate).
+- Use-case policy matrix made load-bearing: `TaskRequirement` posture defaults honoured by
+  `inferContract` (REQ-AIC-1 / VC-AIC-MATRIX).
+- Email triage pinned to the utility tier (REQ-AIC-5 / VC-AIC-E1), wired into the live
+  marketing inbound responder.
+- This model seeded into the EA graph (`seed-ea-sysml-ai-cockpit.ts`) — runtime EA validation deferred.
+
+**Modeled, realized later `[J]`:** REQ-AIC-2 (receipt view), REQ-AIC-3/4 (escalation reason
+codes), REQ-AIC-6 (tasks/submit), REQ-AIC-8 (OAuth transport), REQ-AIC-9 (thread fields).
+These are the next slices, each with a planned verification case above.

--- a/docs/architecture/2026-06-14-odysseus-review-depth-pass.md
+++ b/docs/architecture/2026-06-14-odysseus-review-depth-pass.md
@@ -1,0 +1,371 @@
+# Odysseus Review — Depth Pass v2: Substrate Grounding + Email Processing
+
+Date: 2026-06-14
+
+Status: review memo (companion / depth pass)
+
+Companion to: [`2026-06-14-odysseus-ux-routing-model-review.md`](2026-06-14-odysseus-ux-routing-model-review.md)
+
+Audience: DPF product, architecture, UX, and AI platform reviewers
+
+---
+
+## 0. Why this companion exists
+
+The original review memo is correct on **product direction** — the AI cockpit, use-case model
+routing, visible receipts, and route discipline are the right bets. But it is written as if DPF's
+AI layer were greenfield ("Add…", "Create…", "Introduce…"). A codebase sweep before writing a spec
+(per `verify-substrate-before-proposing-new` and `sweep-main-before-trusting-worktree-specs`) shows
+that **most of what the memo proposes already exists in named substrate**, two of the proposals are
+already fully *designed* in existing specs, and **email processing is not greenfield either** — a
+working inbound-email triage loop already ships, and a multi-channel communication fabric is specced
+with `email` as a first-class channel.
+
+So "going a level deeper" is not a finer-grained restatement. It is:
+
+1. **Correcting the premise** so we don't double-build.
+2. Converting each abstract recommendation into a **concrete delta against named files, tables, and
+   existing specs**.
+3. Isolating the **genuinely net-new work** (a small set of schema additions + UX surfacing).
+4. Adding the **email-processing-for-businesses** section the original omitted, and showing why email
+   is the ideal *proving ground* for the use-case routing matrix.
+
+This pass is grounded in source inspection of `apps/web/lib/routing/*`, `apps/web/lib/inference/*`,
+`apps/web/lib/marketing/channels/email-postmark/*`, `apps/web/lib/communications/*`,
+`packages/db/prisma/schema.prisma`, and the routing/fabric specs cited inline. It is source
+inspection, not a runtime test.
+
+---
+
+## 1. Premise correction: routing is already a mature subsystem
+
+The original memo's Evidence section inspects Odysseus thoroughly but does not inventory DPF's own
+routing code. The implicit assumption — echoed in older context that routing lives in "AI Routing
+System draft files at the repo root" — is **stale**. The real state:
+
+- **~110 files** under [`apps/web/lib/routing/`](../../apps/web/lib/routing/) plus
+  [`apps/web/lib/inference/`](../../apps/web/lib/inference/), shipped as completed epics (EP-INF-003
+  → EP-INF-012, EP-AGENT-CAP-002, EP-MODEL-CAP-001).
+- A single inference entry point — `routeAndCall()` in
+  [`routed-inference.ts:184`](../../apps/web/lib/inference/routed-inference.ts) — that every LLM call
+  already flows through (it replaced the older `callWithFailover()`).
+- A real routing engine — `routeEndpointV2()` in
+  [`pipeline-v2.ts:241`](../../apps/web/lib/routing/pipeline-v2.ts) — with a 6-stage pipeline (pin
+  override → policy filter → hard capability filter → cost-per-success ranking → capacity penalty →
+  diverse fallback chain).
+- A **canonical current-state spec** already exists:
+  [`docs/superpowers/specs/2026-04-20-routing-architecture-current.md`](../superpowers/specs/2026-04-20-routing-architecture-current.md).
+
+**Implication for the spec the memo asks us to write:** reframe every recommendation from *build* to
+*consolidate / surface / extend*. The risk is not "no model routing" — it is **duplicate substrate**
+and a second source of truth. The one thing that is genuinely unbuilt (a long-running routing policy
+*service*) is already designed; see §4.5.
+
+---
+
+## 2. Substrate ledger — memo claim vs. reality vs. delta
+
+This table is the heart of the depth pass. Each row: what the memo proposes, what already exists
+(with the name to reuse), and the **real** delta.
+
+| Memo proposal | Status | Already exists (reuse this) | Real delta |
+| --- | --- | --- | --- |
+| AI use-case policy **matrix** | **Largely EXISTS** | `RequestContract` ([`request-contract.ts:18`](../../apps/web/lib/routing/request-contract.ts)) carries `taskType`, `sensitivity`, `residencyPolicy`, `budgetClass`, `reasoningDepth`, `requiredModelClass`, `minimumDimensions`. Per-task tier floors come from `TaskRequirement` (DB) + `BUILT_IN_TASK_REQUIREMENTS` + `quality-tiers.ts`. | No *unified, editable* matrix view; policy is split across `TaskRequirement` + `PolicyRule` + `AgentModelConfig` + hardcoded defaults. Delta = **consolidation + an admin surface + the missing task-type rows** (notably the email tasks, §6). |
+| Per-thread **model receipt** | **Data EXISTS / surfacing PARTIAL** | Three receipt tables: `RouteDecisionLog` (`schema.prisma:6930` — chosen model + candidate trace + `fallbackChain[]`), `RouteOutcome` (`:2444` — what happened + `providerErrorCode` + `fallbackOccurred`), `AdapterRunTelemetry` (`:2528` — per-execution model/tokens/cost/`errorClass`/`userAccepted`). Already surfaced minimally as `providerId:modelId` in `AgentPanelHeader.tsx:129`. | **Do not add tables.** Delta = a **per-turn receipt view object** joining the three tables, plus a user-facing receipt component in the coworker panel and a Platform>AI evidence tab. |
+| Fallback / escalation **reason codes** | **Fallback EXISTS / escalation ABSENT** | Low-cardinality unions already exist and persist: `InferenceError.code` (`ai-inference.ts`), `EndpointUnavailableReason` (`rate-tracker.ts`), `ProviderHealthStatus`/`RemediationKind` (`provider-health.ts`) → `RouteOutcome.providerErrorCode` / `AdapterRunTelemetry.errorClass`. | Codes are **scattered** (no shared registry); there is **no explicit *escalation* reason code** (only *fallback/degrade*). Delta = one shared `reason-codes.ts` registry + an `escalationReason` concept. |
+| **Central routing policy service** | **ABSENT but DESIGNED** | Routing is recomputed inline per request (no long-running service / compiled table). | Already specced as a control-plane/data-plane (RIB→FIB) split in [`2026-04-27-routing-control-data-plane-design.md`](../superpowers/specs/2026-04-27-routing-control-data-plane-design.md). Delta = **implement that spec; cite it, don't reinvent it.** This is where the memo's "20% refactor" budget should go. |
+| Provider/model **capability metadata** | **EXISTS (mature)** | `ModelProfile` (`schema.prisma:1572`), `ModelCard` types, `AdapterCapabilityProfile` (`:2492`), `ModelCapabilityChangeLog` (`:1644`), drift detection via `rawMetadataHash`. Populated seed → discovery → eval → admin override. | Essentially nothing structural. Overlaps with the matrix-consolidation delta only. |
+| `Platform > AI` route **home** | **EXISTS (21 routes)** | Family "AI Operations" at [`apps/web/app/(shell)/platform/ai/`](../../apps/web/app/(shell)/platform/ai/), data-driven nav in `platform-nav.ts:21`, sub-tabs in `AiTabNav.tsx`. Includes providers, routing, model-assignment, decisions, operations-map, prompts, skills. | Memo's surfaces should be **new tabs/panels in this family**, not a new route family. Delta = a **Threads/Receipts tab**, a **Routing-policy (matrix) tab**, a **Model-Fit tab**, a **Spend/Evidence tab**. |
+| Architecture guardrails (no hardcoded colors, report-kit, server/client) | **ALREADY ENFORCED** | `--dpf-*` tokens in `globals.css`; rule in `AGENTS.md:173-186`; report-kit primitives `StatusBadge`/`StatCard`/`DataTable`/`FilterBar`/`ExportButton`/`Chart` in [`apps/web/components/ui/report-kit/`](../../apps/web/components/ui/report-kit/). | None — these are existing standards, not new recommendations. The memo can **assert** them as constraints rather than propose them. |
+| Local **model fit** experience | **PARTIAL** | Endpoint capability probes already exist: [`apps/web/lib/routing/capability-probes/`](../../apps/web/lib/routing/capability-probes/) write `AdapterCapabilityProfile`; Ollama support present. | DPF should do **endpoint-capability fit** (its probes), *not* Odysseus's host-GPU hardware scan — see §4.6 "what not to copy". Delta = a read-only Model-Fit view over existing probe data. |
+
+**Bottom line:** four of five core proposals are EXISTS-to-PARTIAL. The net-new work is small and
+specific: (a) **thread schema additions** (§5), (b) **the email pipeline generalization** (§6),
+(c) **implementing the already-designed routing control plane** (§4.5), and (d) **UX surfacing** of
+data that already exists.
+
+---
+
+## 3. Two factual corrections to carry into the spec
+
+From source inspection of Odysseus (`pewdiepie-archdaemon/odysseus`, `dev` branch):
+
+1. **License:** Odysseus is **AGPL-3.0**, not MIT (some press says MIT). AGPL matters if we ever
+   borrow code rather than concepts — it is copyleft over a network boundary. We are borrowing
+   *concepts only*, so this is a flag, not a blocker.
+2. **`action_intents.py` does not pick models** and "cockpit" is the memo's term, not Odysseus's.
+   Intents in Odysseus are regex classifiers that decide chat→agent-mode promotion; model selection
+   lives in `endpoint_resolver.py`. Minor, but the spec should not attribute model routing to the
+   intent layer.
+
+---
+
+## 4. Recommendation deep-dives
+
+### 4.1 Use-case policy matrix → consolidate `RequestContract` + `TaskRequirement`, add rows
+
+The matrix the memo draws (the "Local vs Frontier Model Policy" table) maps almost 1:1 onto fields
+that already exist:
+
+| Memo matrix column | Existing field |
+| --- | --- |
+| Use case | `RequestContract.taskType` / `contractFamily` |
+| Default policy / tier | `TaskRequirement.minimumTier` → `TIER_MINIMUM_DIMENSIONS` (`quality-tiers.ts`) |
+| Local vs frontier role | `RequestContract.residencyPolicy` (`local_only` / `approved_cloud` / `any_enabled`) + `budgetClass` |
+| Privacy posture | `RequestContract.sensitivity` (`public`/`internal`/`confidential`/`restricted`) |
+| Fallback behavior | `fallback.ts` chain + `RouteDecisionLog.fallbackChain[]` |
+
+**Concrete next action (not "build a matrix"):**
+
+1. Add the **missing task-type rows** to `BUILT_IN_TASK_REQUIREMENTS` — especially the email tasks
+   in §6 — each with an explicit `minimumTier`, `residencyPolicy`, and `budgetClass`.
+2. Add an **`escalationPolicy`** notion to `TaskRequirement` (today only `minimumTier` exists; there
+   is no "may auto-escalate to frontier? / requires approval?" field — see §4.3).
+3. Build the **admin matrix view** as a Platform>AI tab over `TaskRequirement` + `PolicyRule`, using
+   report-kit `DataTable` + `StatusBadge`. This is the memo's real UX contribution.
+
+> The matrix is **consolidation and surfacing**, not new substrate. Per `verify-substrate-before-proposing-new`,
+> the spec must reference `RequestContract`, `TaskRequirement`, and `quality-tiers.ts` by name.
+
+### 4.2 Model receipts → a join view, not new tables
+
+The data is already captured three ways and keyed by `agentMessageId`/`threadId`. The deeper design
+question is **composition**, not capture:
+
+- Define a read-side `ThreadTurnReceipt` view = `RouteDecisionLog` (intent + candidates) ⨝
+  `RouteOutcome` (result) ⨝ `AdapterRunTelemetry` (execution) on `agentMessageId`.
+- Render it in two places: a compact inline chip in `AgentMessageBubble` (requested policy → actual
+  model, with a "fell back" badge driven by `RouteOutcome.fallbackOccurred`), and a full row in a
+  Platform>AI **Receipts** tab (report-kit `DataTable`, `ExportButton` for CSV).
+- `AdapterRunTelemetry.userAccepted` already exists — wire the inline receipt's thumbs-up/down to it
+  so receipts double as the production-feedback signal that `production-feedback.ts` consumes.
+
+### 4.3 Reason codes → one registry + an escalation axis
+
+Today's codes describe **why a call failed or degraded** (`rate_limit`, `auth`, `overloaded`,
+`model_not_found`, …). The memo also wants **why a call was escalated upward** ("user requested
+better answer", "policy requires higher assurance", "privacy blocks frontier"). That second axis
+does not exist.
+
+Delta:
+- Create `apps/web/lib/routing/reason-codes.ts` as the single source for both axes
+  (`FallbackReason` ∪ `EscalationReason`), and have `RouteOutcome`/`AdapterRunTelemetry`/
+  `RouteDecisionLog` import from it instead of re-declaring unions.
+- Add `escalationReason` to the route decision record so "why did this go to frontier?" is auditable —
+  required by the memo's governance section and by the privacy posture in §6.
+
+### 4.4 `Platform > AI` → tabs, not a new family
+
+The family exists with a data-driven nav. The memo's surfaces slot in as new entries in
+`platform-nav.ts` / `AiTabNav.tsx`:
+
+- **Routing Policy** (the matrix, §4.1) — beside the existing `routing/` profiles page.
+- **Receipts / Evidence** (§4.2) — joins the three receipt tables; co-locate fallback/escalation logs.
+- **Model Fit** (§4.6) — read-only over `AdapterCapabilityProfile`.
+- **Spend** — over `TokenUsage` + `RouteOutcome.costUsd`; this is also the convergence point with
+  finance/ops reporting (answers Open Question 5).
+
+All built from report-kit + `--dpf-*` tokens. No new global "Tools"/"Models" destination — the memo
+is right about that, and `platform-nav.ts` already enforces it.
+
+### 4.5 The 20% refactor → implement the control/data-plane spec
+
+The memo reserves ~20% for refactoring the AI/provider boundary "before adding new UI". That budget
+has a **named target already designed**:
+[`2026-04-27-routing-control-data-plane-design.md`](../superpowers/specs/2026-04-27-routing-control-data-plane-design.md)
+specifies a RIB (catalog + probes + policy union) compiled to a FIB lookup table with atomic publish
+and a watchdog — explicitly to kill the seed↔runtime drift class that has bitten DPF before
+(`seed-is-bootstrap-calibration-is-runtime`). Recommendation: the spec the memo asks for should
+**adopt that design as its refactor work item**, not describe a generic "policy layer" in the
+abstract. The memo's `AiRoutingDecision` TypeScript sketch is essentially a lighter `RouteDecision`
+that already exists in `pipeline-v2.ts`; we should not introduce a parallel type.
+
+### 4.6 Local model fit → endpoint capability, NOT host-hardware scan (what not to copy)
+
+Odysseus's `services/hwfit/*` scans local **GPU VRAM/RAM** because it is a single-user desktop app
+deciding which GGUF a machine can run. DPF is a **server / multi-node** platform where "what can run
+locally" means "what do our configured local/remote endpoints actually support", which DPF already
+measures with `capability-probes/` → `AdapterCapabilityProfile`. So the Model-Fit screen should be a
+**readiness view over probe results and endpoint health**, mapping configured endpoints → supported
+use cases → unsupported workloads. Borrow Odysseus's *framing* ("which tasks can run locally, which
+need fallback"); do **not** copy its hardware-scan implementation. (Host-hardware scan is only
+relevant for the edge-node story under `platform/edge-nodes/`, if at all.)
+
+---
+
+## 5. The genuinely net-new work: thread metadata
+
+`AgentThread` ([`schema.prisma:3780`](../../packages/db/prisma/schema.prisma)) is intentionally thin
+(`@@unique([userId, contextKey])` — one thread per user per route context, plus CLI-session and
+spawn fields). The memo's proposed thread metadata mostly exists *elsewhere*, keyed by
+`threadId`/`agentMessageId`. Mapping the memo's fields to reality:
+
+| Memo field | Status | Where it lives today / what to do |
+| --- | --- | --- |
+| `threadId` | EXISTS | `AgentThread.id` |
+| `ownerPrincipalId` | PARTIAL | `AgentThread.userId` is a `User`, not a `Principal`; dual-principal exists at the *action* layer (`ToolExecution.delegatingUserId`). Add a principal link if we want principal-scoped threads. |
+| `workspaceArea` | PARTIAL | `AgentThread.contextKey` + `AgentMessage.routeContext` already encode this. |
+| `mode` (advise/act) | PARTIAL | **Ephemeral UI state only** (`AgentPanelHeader.tsx:177`). Persist it on the thread if it must survive reloads/audit. |
+| `requestedModelPolicy` | PARTIAL | Per-*agent* in `AgentModelConfig`, not per-thread. Snapshot on the turn if per-thread override is wanted. |
+| `actualModelReceipt` | PARTIAL (strong substrate) | `AdapterRunTelemetry` per turn; surface as §4.2 view. No new table. |
+| `fallbackEvents` | PARTIAL | Implicit in `AdapterRunTelemetry.status`/`errorClass`; no explicit per-thread timeline. Derive in the receipt view. |
+| `memoryMode` | **ABSENT** | No field anywhere. **Net-new.** See Open Question 3. |
+| `toolAuthority` | PARTIAL | Per-*agent* (`AgentToolGrant`, `AgentGovernanceProfile.autonomyLevel`) + per-action `CoworkerActionEnvelope`. Snapshot on thread if needed. |
+| `attachedSources` | PARTIAL | Per-message `AgentAttachment` + ephemeral composer `contextRefs`. **No durable thread-level source set.** Net-new if we want persistent grounding. |
+| `compactionState` | **ABSENT** | No compaction model exists at all. **Net-new.** |
+| `decisionLinks` | **ABSENT** | `DecisionInteraction` (`schema.prisma:9677`) keys on `profileId`/`buildId`/`taskRunId` — **no `threadId`**. **Net-new join** from thread → decision. |
+
+**So the real schema work is four items, not twelve:** `memoryMode`, durable `attachedSources`,
+`compactionState`, and a thread↔`DecisionInteraction` link. Everything else is "snapshot an existing
+value onto the thread" or "render an existing table". The spec should say exactly that, so we don't
+greenlight a twelve-column migration when four columns + one join is the truth.
+
+---
+
+## 6. Email processing for businesses (new section)
+
+This is the addition you flagged. Email processing is one of Odysseus's most complete features — and
+it is **not greenfield in DPF either**. The right move is to **generalize what already ships**, pin it
+to the **local/utility tier** (the connective tissue to §4.1), and attach it to the **Employee
+Communication Fabric**.
+
+### 6.1 What Odysseus actually built (and the one lesson that matters most)
+
+Odysseus's email feature (`routes/email_routes.py`, `routes/email_pollers.py`,
+`routes/email_helpers.py`, `src/email_thread_parser.py`):
+
+- **Ingest:** raw **IMAP/SMTP via `imaplib`**, username/password, connection-pooled; auto-detects
+  Sent/Drafts/Spam folders. Polls `SINCE`-filtered, **capped at 5 emails/pass**.
+- **LLM triage pipeline**, each stage flag-gated and **result-cached per message**: summarize (1–3
+  bullets) · classify/auto-tag (12 tags) · spam (→ move to Junk) · **draft reply (stored, never
+  auto-sent)** · calendar-event extraction (+ regex fallback) · urgency triage.
+- **Thread parsing** is pure rule-based (regex + BeautifulSoup), no LLM.
+- **The load-bearing lesson:** every email AI stage resolves its model via
+  `resolve_endpoint("utility")` — the **cheap/local "utility" role**, deliberately kept off the
+  frontier tier, and **not** part of the agent-mode teacher-frontier escalation path. Email is the
+  textbook background-utility, privacy-sensitive, high-volume workload, and Odysseus routes it
+  accordingly. The reply prompt also carries a hard *"NEVER invent facts…"* guardrail.
+
+### 6.2 What DPF already has
+
+| Capability | DPF substrate (reuse) |
+| --- | --- |
+| Inbound transport (working) | Postmark inbound webhook → [`apps/web/app/api/integrations/email-postmark/inbound/route.ts`](../../apps/web/app/api/integrations/email-postmark/inbound/route.ts) (HMAC-verified, at-least-once). |
+| Inbound message anchor | `InboundChannelMessage` (`schema.prisma:7286`) — holds `fromAddress`, `subject`, `body`, `classification`, `routedEngagementId`, `draftedReplyId`. **`domain` is hardcoded `"marketing"`.** |
+| Triage brain (working) | `runInboundResponder` ([`responder.ts:44`](../../apps/web/lib/marketing/channels/email-postmark/responder.ts)): rule pre-filter → LLM classify (`qualified-inquiry`/`support`/`spam`/`other`) → CRM link → draft reply → human-approval queue. **`classifyWithLlm` already calls `routeAndCall(...)`** (`responder.ts:138`). |
+| Draft → approve → send | `OutboundDraft` → `OutboundApprovalDecision` → `OutboundPublication` (`schema.prisma:7211/7237/7257`); `sourceType="inbound-channel-message"` already supported. Send via `lib/shared/email.ts` (SMTP) or Postmark API. |
+| Multi-channel home (specced) | **Employee Communication Fabric** — [`2026-05-15-employee-communication-fabric-design.md`](../superpowers/specs/2026-05-15-employee-communication-fabric-design.md). `email` is a first-class channel (`channel-types.ts`); §14.4 defines `tasks/submit` as the inbound→coworker contract. WhatsApp Secretary spec is the worked routing example. |
+| Identity / continuity | `CommunicationChannelBinding` (sender → `Principal`) + `CommunicationChannelSession` (`schema.prisma:4339/4370`). |
+| Action-item extraction | `WorkItem`/`WorkQueue` (`schema.prisma:9283`) with generic `sourceType`/`sourceId`; backlog ingest at `lib/operate/backlog-ingest.ts`. |
+| Evidence | `CommunicationDeliveryAttempt` (`schema.prisma:4393`) for sends; the `InboundChannelMessage` row for inbound. |
+
+### 6.3 The two genuine gaps
+
+Everything downstream of "a parsed inbound message row exists" is built or specced. Only two pieces
+are truly missing:
+
+1. **A continuous mailbox poller / inbound transport for general business email.** Today's only
+   inbound path is the Postmark webhook (marketing-scoped), and the MS365 Graph reader
+   (`microsoft365-communications/communications-client.ts:94`) is a **top-5 health *probe*, not a
+   sync loop**. Business email from a customer's own Gmail/M365 mailbox needs delta-sync or provider
+   push.
+2. **Inbound attachment ingestion.** The Postmark inbound parser ignores `Attachments[]`; there is no
+   path from an email attachment into `AgentAttachment`/`Document`.
+
+### 6.4 Recommended architecture
+
+Compose the **Communication Fabric** (channel + routing) with the **marketing execution loop**
+(reference triage implementation), and route email AI through the **existing router pinned to the
+utility/local tier**:
+
+1. **Transport — OAuth/push, not IMAP-password.** Add the inbound email channel under the fabric's
+   reserved convention `apps/web/app/api/communications/<provider>/webhook/route.ts` (fabric §13.5).
+   Connect customer mailboxes via **Gmail API / MS Graph delta-sync with OAuth**, or provider inbound
+   webhooks (Postmark). Credentials via `IntegrationCredential` custody. This honours
+   `dpf-as-integration-conduit` — the customer brings their own mailbox + OAuth consent; DPF never
+   enrolls as a mail partner or stores raw passwords.
+2. **Anchor — generalize `InboundChannelMessage`.** Relax the `domain="marketing"` assumption (add
+   `domain="inbox"`/`"support"` or make it org-scoped business mail). Reuse the classification /
+   routing / draft columns verbatim.
+3. **Triage — lift `runInboundResponder` out of `lib/marketing/`** into a domain-agnostic responder.
+   Mirror Odysseus's flag-gated, result-cached stages: summarize · classify · spam · draft ·
+   extract-actions · urgency — each cached on the message row so re-runs skip processed mail.
+4. **Routing posture — the bridge to §4.1.** Register email tasks as **new `taskType`s** in
+   `BUILT_IN_TASK_REQUIREMENTS` with `residencyPolicy: "local_only"` (or `"approved_cloud"` per org
+   policy), `budgetClass: "minimize_cost"`, and low/medium `reasoningDepth`. This is the DPF
+   equivalent of Odysseus's `resolve_endpoint("utility")`. **Today's marketing classifier does NOT
+   set residency/budget** (`responder.ts:139` passes only `"internal"`), so it can currently land on
+   a frontier model — fixing that is a concrete, shippable first win.
+5. **Coworker routing — fabric §14.4 `tasks/submit`.** A triaged email that needs real work is handed
+   to the right coworker thread via the existing inbound→coworker contract, not a new mechanism.
+6. **Action extraction → `WorkItem`** (`sourceType="inbound-email"`, `sourceId=inboundId`) and/or
+   backlog ingest; calendar invites → the calendar surface (Odysseus's primary extracted action).
+7. **Drafts — never auto-send.** Reuse `OutboundDraft` → `OutboundApprovalDecision` →
+   `OutboundPublication` + `CoworkerActionEnvelope` propose/approve. This matches both Odysseus
+   (drafts await approval) and DPF governance (effectful actions need preview/confirmation).
+8. **Attachments — new parsing work** into `AgentAttachment` (thread scratch) or `Document` (durable).
+9. **Privacy — email is the proving ground.** Inbound business mail is the canonical
+   `confidential`/`local_only` workload. Email tasks set `fallbackPolicy` to same-class or
+   approval-required, **never** silent `frontier-with-receipt`, satisfying the memo's "no silent
+   frontier escalation for sensitive work".
+
+### 6.5 What NOT to copy from Odysseus for email
+
+- **IMAP + username/password (no OAuth).** It can't even do M365/Gmail (Odysseus's own README admits
+  this) and it violates `dpf-as-integration-conduit`. Use OAuth/Graph/Gmail API or provider webhooks.
+- **Single-user personal mailbox model.** DPF is multi-principal and org-scoped; intake must carry
+  tenant + principal + tool-grant gating, not just an owner column.
+- **Storing mail creds in app settings.** Use `IntegrationCredential`.
+- **Frontier-by-accident.** Odysseus got this *right* (utility role); DPF must replicate it
+  explicitly via residency/budget (§6.4 step 4), because our current email classifier doesn't.
+
+### 6.6 Email slices
+
+- **Slice E1 — Pin email to local/utility now.** Register email `taskType`s + set
+  `residencyPolicy`/`budgetClass` on the existing marketing classifier call. Tiny change, immediate
+  privacy/cost win, exercises the §4.1 matrix end-to-end. *No new transport.*
+- **Slice E2 — Generalize the loop.** Lift `runInboundResponder` + relax `InboundChannelMessage.domain`.
+- **Slice E3 — Business inbox transport.** Graph/Gmail OAuth delta-sync poller under the fabric webhook
+  convention; sender→`Principal` binding.
+- **Slice E4 — Full triage stages + attachments.** Summarize/extract-actions/urgency stages →
+  `WorkItem`/calendar; attachment ingestion into `Document`.
+- **Slice E5 — Coworker routing.** Wire `tasks/submit` so triaged mail reaches the right coworker.
+
+---
+
+## 7. Corrected open questions (several are answerable from substrate)
+
+1. **Expose model selection to every user, or policy/mode only?** Already answered in code: admins
+   own provider/model (`AgentModelConfig`, Platform>AI); users get **mode/policy** (advise/act,
+   sensitivity) via `AgentPanelHeader`. Keep that split; don't expose raw model pickers to end users.
+2. **Which use cases auto-frontier vs. require approval?** Encode on `TaskRequirement` via the new
+   `escalationPolicy` field (§4.3). Email = utility/local, **never** auto-frontier.
+3. **Private/no-memory mode — block writes or just retrieval?** Genuinely unbuilt (`memoryMode`
+   absent). Recommendation: `private` blocks **both** persistence and retrieval for the thread;
+   `scoped` blocks retrieval only. Needs the net-new field in §5.
+4. **Model fit by host hardware or endpoints?** **Endpoints**, via existing `capability-probes` —
+   not Odysseus's host-GPU scan (§4.6). DPF is server/multi-node.
+5. **Where do AI spend/fallback/quality evidence converge with finance/ops?** On the `TokenUsage`
+   ledger + `RouteOutcome.costUsd`/`AdapterRunTelemetry.estimatedCostUsd`, surfaced in a Platform>AI
+   **Spend** tab and exported to finance reporting via report-kit. No new ledger.
+
+---
+
+## 8. Revised next decision
+
+Approve a short architecture/design spec that **explicitly builds on existing substrate** and scopes:
+
+1. The use-case matrix as **consolidation of `RequestContract` + `TaskRequirement`** + the missing
+   rows (incl. email), with an admin tab — *not* a new policy type.
+2. The **per-turn receipt view** (join of the three existing receipt tables) + its inline and
+   Platform>AI surfaces — *no new receipt tables*.
+3. The **four net-new thread fields/joins** only (`memoryMode`, durable `attachedSources`,
+   `compactionState`, thread↔`DecisionInteraction` link).
+4. Adoption of the **2026-04-27 control/data-plane spec** as the refactor work item.
+5. **Email processing** scoped via Slices E1–E5, starting with E1 (pin email to local/utility),
+   owned by the Communication Fabric + marketing-execution-loop, *not* a new email epic.
+
+The central product bet from the original memo stands — DPF should feel like a reliable AI cockpit,
+not a pile of settings. The correction this pass adds: **most of the cockpit is already built; the
+work is to consolidate, surface, and govern it — and email is the highest-leverage first proof,
+because it forces the local-first routing posture to become real.**

--- a/docs/architecture/2026-06-14-odysseus-ux-routing-model-review.md
+++ b/docs/architecture/2026-06-14-odysseus-ux-routing-model-review.md
@@ -1,0 +1,467 @@
+# Odysseus UX, Routing, Threading, and Model-Routing Review
+
+Date: 2026-06-14
+
+Status: review memo
+
+Audience: DPF product, architecture, UX, and AI platform reviewers
+
+## Executive Summary
+
+Odysseus is a useful benchmark because it treats AI as the center of a personal operating workspace rather than as a feature bolted onto a conventional web app. Its strongest product lesson is the "AI cockpit": one central chat/composer surface with visible controls for mode, model, memory, documents, research, and tools.
+
+DPF should borrow the workspace model, the use-case-specific model routing, and the explicit local-vs-frontier decision surface. DPF should not copy Odysseus's modal-heavy static SPA architecture or its broad styling approach. The right DPF translation is a governed coworker workspace, durable route families, visible model receipts, and a policy-backed model router.
+
+Recommended direction:
+
+1. Add a DPF AI use-case policy matrix that routes chat, background utility work, research, vision, agentic actions, and privacy-sensitive tasks to the right model class.
+2. Give every coworker thread a visible model/mode/privacy receipt: requested model, actual responding model, fallback/escalation, memory state, and tool authority.
+3. Place model/provider setup and local model fit under `Platform > AI`, not inside a generic tools drawer.
+4. Preserve DPF's architecture standards: route families, server-side data ownership, token-based theme styling, report-kit reporting primitives, and explicit evidence records.
+5. Reserve about 20% of implementation effort for refactoring the AI/provider boundary before adding new UI.
+
+## Evidence Reviewed
+
+Primary external sources:
+
+- Odysseus repository: <https://github.com/pewdiepie-archdaemon/odysseus>
+- Odysseus hardware/model discussion: <https://github.com/pewdiepie-archdaemon/odysseus/discussions/274>
+
+Source areas inspected in the Odysseus `dev` branch:
+
+- `README.md` for product positioning, features, model-provider setup, and security guidance.
+- `app.py` for top-level router registration and deep-link behavior.
+- `routes/session_routes.py` and `core/session_manager.py` for threading/session state.
+- `routes/chat_routes.py`, `src/action_intents.py`, `src/endpoint_resolver.py`, and `src/llm_core.py` for model routing, fallback behavior, agent escalation, and provider handling.
+- `services/hwfit/*` and `routes/hwfit_routes.py` for hardware-fit and local model recommendation patterns.
+- `static/index.html`, `static/style.css`, and related frontend scripts for the workspace shell, model picker, settings, and tool surfaces.
+
+Review limitation: this memo is based on repository/source inspection and published screenshots/docs. It is not a runtime usability test of Odysseus.
+
+## What Odysseus Gets Right
+
+### 1. AI Workspace as the Product Center
+
+Odysseus does not make users start from a settings dashboard. The visible center of gravity is a conversation workspace with a composer, model selector, chat/agent mode switch, tool entry points, and status indicators.
+
+This is important for DPF. The primary DPF user experience should not feel like navigating an admin console to find AI features. The user should feel they are working with coworkers, documents, plans, decisions, and execution state from one coherent command surface.
+
+DPF lesson:
+
+- Make the coworker workspace a first-class destination.
+- Keep model, memory, tools, and context visible near the work.
+- Avoid burying AI mode/model choices in deep settings when they affect the current thread.
+
+### 2. Use-Case-Specific Model Choices
+
+Odysseus separates model roles instead of treating "the model" as one global setting. It has concepts for default chat, background utility work, research, vision, local endpoints, API endpoints, fallback chains, and teacher/frontier escalation.
+
+This is the strongest architecture lesson. DPF should not ask one provider or model setting to carry every workload. The right question is: "What kind of work is this, what risk does it carry, and what model class is appropriate?"
+
+DPF lesson:
+
+- Create a governed use-case policy layer above raw provider settings.
+- Let cheap/local models do background tasks where quality and risk permit.
+- Use frontier models deliberately for high-complexity reasoning, research, coding, architecture, and hard failure recovery.
+- Treat model fallback/escalation as an auditable event, not an invisible implementation detail.
+
+### 3. Thread State Includes More Than Messages
+
+Odysseus sessions carry model and endpoint choices, ownership, RAG/document state, archive/folder/important state, message count, and compaction behavior. Threads are not just a message list; they are durable work contexts.
+
+DPF should adopt this principle while preserving its own Work Capsule and backlog architecture. A DPF coworker thread should know its context, model routing, memory mode, and authority level, but it should not become the only source of truth for work execution.
+
+DPF lesson:
+
+- Thread metadata should include model policy, privacy/memory state, attached sources, active mode, tool authority, compaction state, and last model receipt.
+- Work Capsules, backlog items, execution evidence, and decisions should remain canonical records outside the chat transcript.
+
+### 4. Local Model Fit Is a Product Experience
+
+Odysseus treats local model setup as something the product helps with. Its Cookbook and hardware-fit services scan or describe hardware, estimate model fit, and guide the user toward runnable options.
+
+DPF should adopt this concept for operators. Local AI should not be presented as a binary "enabled/disabled" toggle. Operators need to know which tasks can run locally, which should use remote local-network infrastructure, and which should use frontier APIs.
+
+DPF lesson:
+
+- Add a model-fit experience under `Platform > AI`.
+- Show local hardware capability, endpoint health, recommended model classes, and unsupported workloads.
+- Degrade gracefully: if local hardware is insufficient, suggest remote endpoints or API fallback without shaming the user or hiding the limitation.
+
+### 5. Visible Fallback Builds Trust
+
+Odysseus has code paths that can emit fallback events when a provider/model fails before content begins. That is a good user-trust pattern. Silent fallback is convenient for developers but confusing for operators, especially when cost, privacy, or quality expectations differ by provider.
+
+DPF lesson:
+
+- A transcript should show when the actual responder differs from the requested/default model.
+- Fallback events should be recorded as evidence for operational review.
+- Model escalation should include reason codes such as provider offline, context exceeded, capability unavailable, verification failed, or user-approved escalation.
+
+## What DPF Should Not Copy
+
+### 1. Modal-Heavy Route Structure
+
+Odysseus exposes many deep links that resolve into one static app shell and then open a corresponding tool view. That works for a personal AI workspace but is not the right architecture for DPF's product surface.
+
+DPF needs durable route families with clear ownership and predictable navigation:
+
+- Global navigation for stable product domains.
+- Section routes/tabs for sibling areas inside a domain.
+- Drawers or panels for temporary context and action surfaces.
+- Dialogs only for bounded tasks, confirmations, or quick edits.
+
+### 2. Generic "Tools" as an Information Architecture
+
+Odysseus has a broad tools/workspace model. DPF should avoid turning AI-adjacent features into a grab bag.
+
+DPF route placement should be based on user job and source of truth:
+
+- Coworker work and active threads: `Workspace`.
+- Provider/model/routing policy: `Platform > AI`.
+- Documents, memory, and knowledge sources: `Knowledge`.
+- Business workflows: the relevant business or product area.
+
+### 3. Static Styling and One-Off UI Systems
+
+Odysseus has a distinctive UI, but DPF cannot copy the implementation style. DPF requires theme-aware styling through `--dpf-*` CSS variables and reporting/data-display surfaces through `apps/web/components/ui/report-kit/`.
+
+DPF implementation guardrails:
+
+- No hardcoded colors.
+- No hand-rolled status badges, KPI cards, model status tables, or export controls.
+- Use report-kit primitives for provider status, model fit, route-health tables, fallback records, and AI spend/cost reporting.
+- Keep server components responsible for data loading, with client wrappers only where interactivity requires them.
+
+## Routing and Navigation Recommendations
+
+### Target Route Homes
+
+| Capability | DPF home | Reason |
+| --- | --- | --- |
+| Coworker command center | `Workspace` | This is active user work, not configuration. |
+| Chat/thread history | `Workspace` | Threads are work contexts. |
+| Model/provider setup | `Platform > AI > Providers` | Administrative platform configuration. |
+| Model routing policy | `Platform > AI > Routing` | Governance and policy, not per-thread UI. |
+| Local model fit/Cookbook equivalent | `Platform > AI > Model Fit` | Operator-facing hardware and model readiness. |
+| Fallback/escalation logs | `Platform > AI > Evidence` or AI spend/reporting surface | Operational audit and cost/privacy review. |
+| Memory/source controls | `Knowledge` with Workspace attachment affordances | Source truth belongs in knowledge management; use from workspace. |
+| Compare/evaluation tools | `Platform > AI > Evaluation` | Useful, but should not be a global user destination at first. |
+
+### Navigation Layer Rules
+
+Global navigation should only answer "which product area am I in?" For the Odysseus-inspired work, that means no new top-level "Tools" or "Models" destination. DPF should add model management under Platform and expose thread-level model state contextually inside Workspace.
+
+Section navigation should answer "which part of this domain am I in?" For `Platform > AI`, likely section tabs are:
+
+- Providers
+- Routing
+- Model Fit
+- Evidence
+- Spend
+- Evaluation
+
+Workspace controls should answer "what can I do right now?" For coworker threads, that means mode switch, model receipt, memory/privacy state, source attachments, and action authority.
+
+Contextual actions should stay actions:
+
+- Test endpoint
+- Add provider
+- Run model fit scan
+- Compare models
+- Escalate this thread
+- Disable memory for this thread
+- Attach knowledge source
+
+## Threading Recommendations
+
+DPF should make coworker threads durable but not overloaded.
+
+Recommended thread metadata:
+
+| Field | Purpose |
+| --- | --- |
+| `threadId` | Stable conversation/workspace identifier. |
+| `ownerPrincipalId` | Principal-based ownership and authorization. |
+| `workspaceArea` | Route/domain where the thread belongs. |
+| `mode` | Chat, agent, research, review, planning, or support. |
+| `requestedModelPolicy` | The policy the user or workspace requested. |
+| `actualModelReceipt` | Provider/model that answered each turn. |
+| `fallbackEvents` | Structured provider/model fallback records. |
+| `memoryMode` | Normal, no-memory/private, scoped-memory, or explicit-source-only. |
+| `toolAuthority` | Which tool categories are enabled for the thread. |
+| `attachedSources` | Documents, records, backlog items, Work Capsules, or knowledge entries. |
+| `compactionState` | Summary status, token budget, and compaction model receipt. |
+| `decisionLinks` | Links to durable decision/evidence records. |
+
+Important boundary: thread content can explain work, but Work Capsules, backlog state, execution evidence, and architectural decisions should remain canonical records outside the transcript.
+
+## Local vs Frontier Model Policy
+
+DPF should define model selection by use case, risk, capability, privacy, and cost. A proposed first version:
+
+| Use case | Default policy | Local model role | Frontier model role | User/operator visibility |
+| --- | --- | --- | --- | --- |
+| Thread title/name generation | Utility-local preferred | Primary | Fallback only | Low-friction receipt in thread metadata. |
+| Summaries and compaction | Utility-local preferred if quality passes | Primary for low-risk summaries | Fallback for long/high-value context | Show compaction receipt. |
+| Normal coworker chat | Org default policy | Preferred when capable | Allowed by org policy | Show requested/actual model. |
+| Private/customer-sensitive work | Local or redacted-first | Primary | Explicit approval or policy exception | Strong privacy indicator. |
+| Deep research | Frontier or strong remote model | Optional for cheap preprocessing | Primary for synthesis | Show provider, search scope, and evidence. |
+| Architecture/design review | Frontier recommended | Assist with retrieval/summarization | Primary for reasoning | Record decision evidence. |
+| Agentic tool execution | Policy-governed model | Allowed for simple bounded actions | Escalate for complex/higher-risk actions | Preview, confirmation, and execution evidence required. |
+| Vision/document extraction | Specialized configured model | If available and verified | Fallback for unsupported formats/quality | Extraction receipt. |
+| Provider health checks | Local utility or deterministic code | Primary where possible | Not needed | Admin-only evidence. |
+| Model evaluation/compare | Explicit test configuration | Subject under test | Judge or baseline where appropriate | Evaluation run record. |
+
+Escalation should be based on reason codes:
+
+- Provider unavailable.
+- Model capability missing.
+- Context window exceeded.
+- Verification failed.
+- User requested better answer.
+- Policy requires higher assurance.
+- Privacy policy blocks frontier use.
+
+Silent escalation should be disallowed for privacy-sensitive work and discouraged everywhere else.
+
+## UX Recommendations
+
+### Workspace Composer
+
+Borrow the idea of a single central composer, but make it DPF-native.
+
+Recommended visible controls:
+
+- Current coworker or agent.
+- Current mode: chat, plan, research, agent, review.
+- Model receipt: requested policy and actual model.
+- Memory/privacy state.
+- Attached context sources.
+- Tool/action authority.
+- A concise evidence indicator when a turn creates durable records.
+
+Do not turn the composer into a dense settings form. Advanced controls should be nearby but progressively disclosed.
+
+### Model and Provider Setup
+
+Model setup should be approachable but operator-grade.
+
+Recommended flow:
+
+1. Add or discover endpoint.
+2. Test connectivity.
+3. Classify provider type and capabilities.
+4. Assign use-case roles.
+5. Run fit/evaluation checks.
+6. Save policy.
+
+Empty states should help the operator choose among:
+
+- Local model on this machine.
+- Remote local-network model server.
+- Frontier/API provider.
+- No model yet, use DPF defaults if configured.
+
+### Local Model Fit
+
+The local model fit screen should answer:
+
+- What hardware/runtime is available?
+- Which model classes are realistic?
+- Which DPF use cases can run locally?
+- Which use cases require remote/frontier fallback?
+- What is currently misconfigured?
+
+This should be a practical readiness view, not a catalog of every model in the world.
+
+## Architecture Recommendations
+
+### Create a Policy Layer
+
+DPF should avoid wiring provider choices directly into UI controls. Add a central policy layer that maps use cases to model candidates, fallback behavior, privacy constraints, and evidence requirements.
+
+Candidate concept:
+
+```ts
+type AiUseCase =
+  | "chat"
+  | "utility"
+  | "research"
+  | "vision"
+  | "agent-action"
+  | "architecture-review"
+  | "private-chat"
+  | "evaluation";
+
+type AiRoutingDecision = {
+  useCase: AiUseCase;
+  requestedPolicyId: string;
+  candidates: ModelCandidate[];
+  privacyMode: "normal" | "local-first" | "redacted" | "blocked";
+  fallbackPolicy: "none" | "same-class" | "frontier-with-receipt" | "approval-required";
+  evidenceRequired: boolean;
+};
+```
+
+This should sit above the existing inference code, not replace it immediately.
+
+### Keep Provider Adapters Thin
+
+Provider adapters should normalize transport differences, not own product decisions. Product decisions belong in the routing policy layer.
+
+Responsibilities:
+
+- Provider adapter: URL, headers, request/response shape, streaming protocol, health check.
+- Routing policy: which provider/model to try and why.
+- Transcript/evidence layer: what happened, what model answered, what fallback occurred.
+
+### Refactor Allocation
+
+Reserve roughly 20% of the implementation budget for refactoring before UI expansion. The refactor should focus on:
+
+- one source of truth for AI use-case policy,
+- structured model/provider capability metadata,
+- fallback/escalation receipts,
+- thread metadata shape,
+- reporting-ready evidence records.
+
+Without this, the model UI will become a collection of per-page settings and one-off heuristics.
+
+## Governance and Safety Requirements
+
+DPF should apply the Trusted AI Kernel posture to model routing:
+
+- Never hide material model/provider changes from the user or operator.
+- Never send private/sensitive context to a frontier provider when policy says local-only.
+- Record escalation/fallback as evidence when it affects quality, cost, privacy, or action authority.
+- Require preview/confirmation for effectful agent actions.
+- Keep authorization decisions tied to principals and tool grants, not to chat UI state.
+- Make provider/model spend and fallback behavior reportable.
+
+## Proposed Implementation Slices
+
+### Slice 1: Model Policy Inventory
+
+Document current DPF AI calls and classify them by use case:
+
+- chat,
+- summarization,
+- planning,
+- research,
+- code/build assistance,
+- classification,
+- extraction,
+- tool execution.
+
+Output: a map of current call sites, providers, privacy posture, and missing receipts.
+
+### Slice 2: Routing Policy Service
+
+Introduce a central AI routing policy service that returns candidate models and fallback rules for a use case.
+
+Output: no major UI yet; one or two existing AI paths route through the policy layer.
+
+### Slice 3: Thread Model Receipt
+
+Add transcript/thread metadata showing requested policy, actual model, fallback, and memory/privacy state.
+
+Output: visible trust signal in Workspace with structured records behind it.
+
+### Slice 4: Platform AI Routes
+
+Add `Platform > AI` section routes for providers, routing policy, model fit, and evidence.
+
+Output: admin/operator surface using DPF theme tokens and report-kit components.
+
+### Slice 5: Local Model Fit
+
+Add a DPF-native model fit screen that checks configured local/remote endpoints and maps them to supported use cases.
+
+Output: practical local/frontier guidance for operators.
+
+## UX Fit Review
+
+Feature name: Odysseus-inspired AI workspace and model routing learnings.
+
+Decision: fits with guardrails.
+
+Owning areas:
+
+- `Workspace` for coworker threads and active work.
+- `Platform` for model/provider governance, routing policy, evidence, and spend.
+- `Knowledge` for memory and source management.
+
+Route family:
+
+- Use `Platform > AI` for model governance.
+- Use `Workspace` for active coworker interaction.
+- Do not add a new global "Tools" destination.
+
+Persona:
+
+- Founder/operator using AI coworkers to run the business.
+- Platform operator configuring model capability, privacy, and cost.
+- Builder/agent reviewer inspecting execution evidence.
+
+Navigation layer:
+
+- Global nav: unchanged unless broader DPF IA work says otherwise.
+- Section nav: `Platform > AI` tabs for providers, routing, model fit, evidence, spend, and evaluation.
+- Workspace controls: mode, memory, model receipt, attachments, and action authority.
+- Contextual actions: test endpoint, add provider, compare models, escalate, attach source.
+
+Component reuse:
+
+- Use report-kit for provider/model tables, status badges, KPI cards, filters, exports, charts, and evidence lists.
+- Use DPF CSS variables for all colors.
+- Reuse existing coworker/workspace primitives where available.
+
+Source of truth:
+
+- AI routing policy and provider capability records for model decisions.
+- Principal/tool grants for authority.
+- Knowledge records for sources and memory.
+- Work Capsules/backlog/evidence tables for execution state.
+
+Empty and failure states:
+
+- No provider configured: guided setup with local, remote, and API options.
+- Local hardware insufficient: explain supported use cases and recommended fallback.
+- Provider offline: show fallback path or disabled use cases.
+- Privacy policy blocks frontier: explain local/redacted alternatives.
+
+AI boundary:
+
+- No silent frontier escalation for sensitive work.
+- No effectful action without preview and confirmation.
+- Every fallback/escalation should be visible in the thread or operator evidence surface.
+
+Required evidence before shipping:
+
+- Route and navigation review against DPF IA.
+- Theme/token scan for no hardcoded colors.
+- Browser UX verification for Workspace and Platform AI routes.
+- Provider fallback simulation.
+- Privacy-mode simulation.
+- Report-kit usage check for data-display surfaces.
+
+## Open Questions
+
+1. Should DPF expose model selection to every user, or only expose policy/mode while admins own concrete provider/model choices?
+2. Which use cases are allowed to use frontier models automatically, and which require explicit approval?
+3. Should private/no-memory mode disable all persistent thread memory, or only prevent future retrieval?
+4. Should local model fit be based on host hardware, configured endpoints, or both?
+5. Where should AI spend, fallback, and model-quality evidence converge with existing finance/operations reporting?
+
+## Recommended Next Decision
+
+Approve a short architecture/design spec for `Platform > AI` and coworker thread model receipts. The spec should define:
+
+- the AI use-case policy matrix,
+- the thread metadata and model receipt shape,
+- route placement under DPF navigation,
+- evidence requirements for fallback/escalation,
+- the first implementation slice and refactor budget.
+
+The central product bet is simple: DPF should make AI work feel like a reliable cockpit, not a pile of settings. Odysseus shows the shape of that cockpit. DPF should implement it with stronger governance, route discipline, and architecture.

--- a/docs/superpowers/specs/2026-06-14-sysml-architecture-substrate-design.md
+++ b/docs/superpowers/specs/2026-06-14-sysml-architecture-substrate-design.md
@@ -1,0 +1,370 @@
+# SysML Architecture Substrate - Design
+
+| Field | Value |
+| ----- | ----- |
+| Status | Phase 1 implemented (PR #1864); Phase 2 in progress — see §15 Implementation Log |
+| Date | 2026-06-14 |
+| Owner | Enterprise Architect, Data Architect, Build Studio platform team |
+| Route family | Existing EA surface (`/ea`) |
+| Backlog state | Live MCP returned 401 and DB fallback refused connection during this thread. Backlog anchoring and runtime validation are deferred to a follow-up thread by operator instruction. |
+| References | `docs/Reference/sysml-v2.md`; OMG SysML 2.0, KerML 1.0, Systems Modeling API 1.0 |
+
+## 1. Problem
+
+DPF already has a serious architecture substrate: EA notation seeds, ArchiMate 4,
+BPMN 2.0, cross-notation relationships, `EaView`, `ViewpointDefinition`,
+Neo4j projection, data-model mirror, Build Studio architecture review, and the
+DPF platform skill pack. The missing piece is a formal internal systems
+architecture language that can represent the obligations agents must preserve:
+requirements, constraints, interfaces, allocations, behaviors, verification
+cases, and traceability across platform changes.
+
+Human-readable diagrams alone do not solve this. C4 is useful for explaining
+software shape, and ArchiMate is useful for enterprise architecture, but agents
+need a more constraint-bearing model when they plan changes to data authority,
+MCP tools, Build Studio delivery, deployment contracts, AI coworker boundaries,
+and value-stream implementation. SysML v2 is now formal and has a companion API
+standard, so DPF should adopt it deliberately as an internal architecture
+substrate.
+
+## 2. Goals
+
+1. Add SysML v2 to DPF reference documentation as the current systems modeling
+   standard.
+2. Establish SysML v2 as an internal EA viewpoint/notation for architects and
+   advanced reseller/operator review, not as a normal-user feature.
+3. Use SysML v2 to catch up DPF's current state in structured EA views.
+4. Make SysML-aware planning available to Build Studio and external Codex,
+   Claude, and Grok agents through the DPF skill pack.
+5. Keep the DPF EA graph and existing source-of-truth models canonical.
+6. Plan the refactoring needed so SysML seed work extends the existing notation
+   framework instead of copying ArchiMate/BPMN seed code.
+
+## 3. Non-Goals
+
+- Do not adopt SysON, the Eclipse pilot, CATIA Magic, Sparx, Visual Paradigm, or
+  any other SysML tool in this slice.
+- Do not make `.sysml` files the platform source of truth.
+- Do not expose SysML detail to ordinary business users by default.
+- Do not add new EA tables until the existing `EaNotation`/`EaElementType`/
+  `EaRelationshipType`/`EaView`/`ViewpointDefinition` substrate is proven
+  insufficient.
+- Do not treat runtime/build validation as complete in this thread; operator
+  explicitly deferred validation to a separate thread.
+
+## 4. Current-State Substrate
+
+| Area | Existing substrate | Design implication |
+| --- | --- | --- |
+| EA notation | `EaNotation`, `EaElementType`, `EaRelationshipType`, `EaRelationshipRule`, `EaDqRule`, `EaTraversalPattern`, `EaFrameworkMapping`. | Add `sysml2` as seed data first; avoid new tables. |
+| Views | `EaView`, `EaViewElement`, `ViewpointDefinition`, `/ea/views`, `/ea/data-model`, `/ea/value-streams`. | SysML appears under the existing EA route and Views & Viewpoints. |
+| ArchiMate | `seed-ea-archimate4.ts` seeds enterprise, application, technology, data, governance, AI coworker, and traversal patterns. | Map SysML concepts to existing ontology where semantics overlap. |
+| BPMN | `seed-ea-bpmn20.ts` seeds process behavior and process traversal patterns. | Use BPMN for executable workflow; use SysML for system behavior/verification semantics. |
+| Cross-notation | `seed-ea-cross-notation.ts` links BPMN behavior to ArchiMate structure. | Add SysML cross-notation mappings instead of isolated SysML islands. |
+| Data architecture | EP-DATA-ARCH mirrors Prisma into EA and uses conformance issues for drift. | SysML data architecture must enrich/mirror authority and constraints, not replace Prisma/ERD. |
+| Skill pack | `packages/dpf-skill-pack` seeds the same skills to Build Studio coworkers and external agent surfaces. | Put SysML guidance in the DPF platform skill pack, not only in legacy `skills/ea`. |
+| EA docs | User guide still frames ArchiMate as the notation for all models. | Update docs to say ArchiMate is default, while BPMN and SysML are specialized viewpoints. |
+
+## 5. Standards And Benchmarking
+
+### Official standard
+
+- [OMG SysML 2.0](https://www.omg.org/spec/SysML/2.0/About-SysML) is formal
+  with September 2025 publication. It covers requirements, structure, behavior,
+  analysis cases, verification cases, and multiple systems engineering methods.
+- [OMG KerML 1.0](https://www.omg.org/spec/KerML/1.0/About-KerML) is formal
+  with September 2025 publication and supplies the semantic foundation for
+  SysML v2.
+- [OMG Systems Modeling API and Services 1.0](https://www.omg.org/spec/SystemsModelingAPI/1.0/About-SystemsModelingAPI)
+  is formal with September 2025 publication and supplies the future
+  interoperability boundary.
+
+### Open-source benchmarks
+
+- [Eclipse SysON](https://github.com/eclipse-syson/syson) shows the right
+  direction for web-based graphical/textual/form editing over a model
+  repository. Adopt the model/view separation idea. Reject tool adoption until
+  DPF tool evaluation completes.
+- [SysML v2 Pilot Implementation](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation)
+  is the reference/pilot ecosystem for textual notation, visualization, and
+  interchange. Adopt the idea of textual syntax as automation-friendly. Reject
+  direct coupling to pilot internals.
+- [Syside/sysml-2ls](https://github.com/sensmetry/sysml-2ls) demonstrates the
+  developer-workflow appeal of language-server style textual modeling. Adopt
+  the idea that external coding agents can consume/write structured architecture
+  notes. Reject editor-specific dependencies in the DPF substrate.
+
+### Commercial benchmarks
+
+- [CATIA Magic](https://www.3ds.com/products/catia/catia-magic) emphasizes
+  synchronized textual and graphical SysML v2 modeling. Adopt the expectation
+  that diagrams and text must stay consistent. Reject vendor source-of-truth
+  lock-in.
+- [Sparx Systems Trechoro](https://sparxsystems.com/mbse/sysml2/) emphasizes
+  native SysML v2/KerML modeling inside a broader modeling environment. Adopt
+  standards-native semantics. Reject a separate modeling home outside EA.
+- [Visual Paradigm SysML v2 Studio](https://www.visual-paradigm.com/features/sysml-v2-studio/)
+  emphasizes browser-based code-to-diagram sync and AI assistance. Adopt the
+  AI-assisted modeling pattern. Reject hosted-tool dependency for DPF's
+  canonical model.
+
+## 6. Decision
+
+Adopt SysML v2 as a DPF-internal systems architecture viewpoint over the
+existing EA substrate.
+
+The canonical model remains DPF's graph and source-of-truth systems. SysML v2
+adds stronger semantics for requirements, constraints, interfaces, allocations,
+verification, and system behavior. It is not a replacement for ArchiMate, BPMN,
+C4, Prisma, code graph, or evidence records.
+
+## 7. Concept Mapping
+
+| SysML v2 concept | DPF use | Existing/future substrate |
+| --- | --- | --- |
+| Package | Architecture boundary or model namespace. | `EaView.scopeType/scopeRef`, `EaElement.properties.sysmlPackage`. |
+| Part definition / part usage | System, subsystem, component, deployed part. | Existing `digital_product`, `application_component`, `technology_node`; future `sysml_part_definition` if needed. |
+| Interface definition / port | Explicit contract or access point. | Existing `application_interface`; future SysML interface/port element types. |
+| Requirement | Required behavior or quality. | Existing `requirement`; future SysML requirement type for richer metadata. |
+| Constraint | Design restriction, invariant, policy. | Existing `constraint`/`ea_control`; SysML constraint viewpoint for analysis. |
+| Action / behavior | System behavior. | BPMN for executable processes; SysML behavior for system-level semantics. |
+| State | System lifecycle or operating mode. | Existing lifecycle fields plus future SysML state elements. |
+| Allocation | "This logical obligation is realized here." | Relationship type mapped to `realizes`/future `allocates`. |
+| Satisfy / verify / trace | Requirement traceability and proof. | Relationship types plus `EaConformanceIssue` and evidence links. |
+| Verification case | Check that proves a requirement/constraint. | Future SysML verification element linked to tests/build evidence. |
+
+## 8. Current-State Catch-Up Views
+
+The first model-catch-up wave should produce architect-owned EA views for DPF
+itself:
+
+1. **DPF Platform System Decomposition** - system, major subsystems, services,
+   data stores, local AI runtime, MCP plane, Build Studio, portal, and workers.
+2. **Data Authority and Projection Model** - Postgres authority, Neo4j
+   projection, Qdrant embeddings, Prisma mirror, source keys, conformance
+   findings, and ownership rules.
+3. **AI Agent Authority Model** - agents, principals, tool grants, MCP token
+   scope, authority bindings, HITL boundaries, and evidence requirements.
+4. **Build Studio Delivery Lifecycle** - ideate/plan/build/review/ship,
+   WorkCapsule, FeatureBuild, nonprod lease, verification evidence, and release
+   governance.
+5. **Deployment and Runtime Contracts** - installer/self-upgrade, image identity,
+   canonical local install, shared local-CI convergence sandbox, platform support
+   watchlist, and substrate-specific deltas.
+6. **Value Stream to System Allocation** - value streams, capabilities,
+   Build Studio work, data model, and platform runtime components.
+7. **Skill and Agent Toolchain Model** - DPF skill pack, external surfaces
+   (Codex, Claude, Grok), Build Studio coworker skill seeding, and MCP config.
+
+Each view should identify its source facts, expected refresh path, owner, and
+which facts are deterministic versus architect-authored judgment.
+
+## 9. Build Studio And External Agent Integration
+
+SysML becomes useful only if it enters the work lifecycle:
+
+- **Ideate:** medium/large platform work asks whether system boundaries,
+  interfaces, requirements, constraints, data authority, or verification cases
+  are affected.
+- **Plan:** plans include a SysML architecture note for affected areas:
+  changed requirements, changed interfaces, allocations, verification cases,
+  and EA/current-state catch-up tasks.
+- **Build:** agents update source-controlled substrate or record the EA update
+  as explicit follow-up work. No hidden hand-edited diagrams.
+- **Review:** architecture review checks the SysML note against the canonical
+  EA graph and DPF rulebook.
+- **Ship:** release evidence names whether SysML/EA catch-up was completed,
+  deferred, or not applicable.
+
+External Codex, Claude, and Grok sessions consume the same DPF platform skill.
+They should produce the same SysML architecture note format as Build Studio.
+
+## 10. Phased Delivery Plan
+
+### Phase 0 - Reference, skill, and planning substrate
+
+Deliverables:
+
+- `docs/Reference/sysml-v2.md`
+- this design spec
+- `dpf-sysml-architecture-substrate` skill
+- profession registry and EA docs updates
+
+Verification:
+
+- Markdown/source sanity checks only in this thread.
+- Runtime/build validation deferred by operator instruction.
+
+### Phase 1 - SysML notation seed and viewpoint refactor
+
+Deliverables:
+
+- Add `packages/db/src/seed-ea-sysml2.ts`.
+- Refactor `seedEaViewpoints` into a reusable notation-aware helper before
+  adding SysML viewpoints.
+- Seed a minimal `sysml2` subset: package, part definition, part usage,
+  requirement, constraint, interface definition, port, action, state,
+  verification case, analysis case.
+- Seed relationships: contains, specializes, connects, allocates, satisfies,
+  verifies, refines, traces.
+- Add cross-notation relationships to ArchiMate/BPMN where needed.
+
+Verification:
+
+- Unit tests for idempotent seed behavior and viewpoint resolution.
+- Migration-free if possible; if a migration is required, it must be narrow and
+  verified in the future validation thread.
+
+### Phase 2 - DPF current-state catch-up
+
+Deliverables:
+
+- Create the seven DPF platform current-state views from section 8.
+- For each view, record source facts, owner, refresh path, and known gaps.
+- Store deterministic facts in EA properties/source keys where practical.
+- Store architect judgment in proposed/annotation fields and conformance issues.
+
+Verification:
+
+- Source-local checks for view seed idempotency.
+- Future EA/browser verification against the rebuilt portal.
+
+### Phase 3 - Build Studio planning hooks
+
+Deliverables:
+
+- Update design/plan review prompts so architecture-impacting work produces a
+  SysML architecture note.
+- Update architecture advisory output to flag missing requirement/interface/
+  allocation/verification updates.
+- Teach Build Studio decomposition to create explicit catch-up work when a
+  planned change changes the system model.
+
+Verification:
+
+- Prompt snapshot/unit tests.
+- Build Studio flow verification in a separate thread.
+
+### Phase 4 - External agent convergence
+
+Deliverables:
+
+- Ensure Codex, Claude, and Grok bootstrap/update paths carry the new skill.
+- Add examples to the skill for platform software architecture, data
+  architecture, and agent authority.
+- Add an external evidence handoff field/section for SysML architecture impact
+  when a coding agent contributes platform work.
+
+Verification:
+
+- Skill seed tests.
+- Agent-toolchain update tests where available.
+
+### Phase 5 - Tool evaluation and import/export
+
+Deliverables:
+
+- Evaluate candidate SysML tools through the Tool Evaluation Pipeline.
+- If approved, choose an adapter boundary: Systems Modeling API first, direct
+  file import/export second, vendor-specific API last.
+- Add import/export only after DPF-native substrate is stable.
+
+Verification:
+
+- Tool-evaluation records and approved-tools registry entry before dependency
+  adoption.
+
+## 11. Refactoring Budget
+
+Reserve roughly 20 percent of implementation effort for refactoring:
+
+- Generalize notation/viewpoint seed helpers before adding SysML.
+- Centralize cross-notation mapping definitions so ArchiMate/BPMN/SysML do not
+  drift independently.
+- Keep SysML concept mapping in one registry rather than scattering local maps.
+- Improve docs/prompts that still say ArchiMate is the only notation.
+- Use existing conformance issue and traversal pattern substrate instead of
+  adding duplicate finding tables.
+
+## 12. UX Fit
+
+Decision: fits-with-guardrails.
+
+- Owning area: Architecture/EA.
+- Route family: existing `/ea`.
+- Primary personas: platform architect, data architect, Build Studio reviewer,
+  advanced reseller/partner technical reviewer.
+- Normal users: no direct SysML exposure by default.
+- Navigation layer: existing EA tab and Views & Viewpoints; optional notation
+  filters later.
+- Component reuse: existing EA canvas/list components and report-kit for any
+  tables/badges/status displays.
+- Empty state: say no SysML views exist yet and offer architect-only creation or
+  catch-up action when the substrate lands.
+
+## 13. Risks
+
+- **Over-modeling:** SysML can become ceremony. Mitigation: model only what
+  affects planning, verification, authority, interfaces, or current-state
+  catch-up.
+- **Parallel source of truth:** Hand-maintained `.sysml` files can drift.
+  Mitigation: DPF EA graph stays canonical; text export is derived until a
+  governed adapter says otherwise.
+- **Tool lock-in:** Commercial tools are strong but can capture the model.
+  Mitigation: DPF-native substrate first; Systems Modeling API adapter boundary.
+- **Notation confusion:** Architects may need ArchiMate, BPMN, C4, and SysML.
+  Mitigation: document each notation's role and choose the smallest adequate
+  viewpoint for each task.
+- **Validation gap:** This thread intentionally defers runtime validation.
+  Mitigation: future validation thread must run source, build, seed, and browser
+  checks before implementation claims are considered complete.
+
+## 14. Open Questions
+
+1. Should the canonical public URL remain `/ea` or move to `/architecture` after
+   the architecture IA work stabilizes?
+2. Which current-state catch-up view should be first: data authority, Build
+   Studio lifecycle, or AI agent authority?
+3. Should SysML textual export be generated in Phase 2, or wait until Phase 5
+   tool evaluation?
+4. Should resellers receive read-only SysML views by role, by capability, or
+   through exported review packets?
+5. Which Build Studio gate owns mandatory SysML note enforcement for large
+   platform changes: Ideate, Plan, or both?
+
+## 15. Implementation Log (appended)
+
+Status of the phased plan against shipped work (source-local verified; runtime EA
+validation deferred per §10/§13):
+
+- **Phase 0 — Reference, skill, planning substrate:** done (this spec,
+  `docs/Reference/sysml-v2.md`, `dpf-sysml-architecture-substrate` skill). EA-docs
+  conformance (§4 EA-docs row / §11) now landed: `docs/user-guide/architecture/index.md`
+  + `prompts/route-persona/ea-architect.prompt.md` +
+  `prompts/specialist/architecture-definition-agent.prompt.md` updated to frame
+  ArchiMate as default with BPMN and SysML v2 as specialized viewpoints.
+- **Phase 1 — SysML notation seed + viewpoint refactor:** implemented (PR #1864).
+  `packages/db/src/seed-ea-sysml2.ts` seeds the `sysml2` notation (package,
+  part-definition/usage, requirement, constraint, interface-definition, port,
+  action, state, verification/analysis case; relationships contains/specializes/
+  connects/allocates/satisfies/verifies/refines/traces + rules + DQ rules + a
+  requirement-satisfaction traversal). `seedEaViewpoints` refactored into the
+  reusable notation-aware helper `seed-ea-viewpoints.ts` (§11). Cross-notation
+  SysML→ArchiMate bridges (`sysml_allocates`/`sysml_traces`/`sysml_verifies`) added
+  to `seed-ea-cross-notation.ts`. Unit-tested (idempotent seed + viewpoint resolution).
+- **Phase 2 — DPF current-state catch-up views:** in progress. Two SysML models
+  seeded as EA graph content: **AI Cockpit & Model Routing**
+  (`seed-ea-sysml-ai-cockpit.ts`, target/design model) and **AI Agent Authority —
+  Current State** (`seed-ea-sysml-agent-authority.ts`, catch-up view #3 from §8) —
+  the latter grounded in the real authority substrate (default-deny grants, dual
+  capability+grant gate, HITL envelopes, dual-principal audit), marking deterministic
+  vs architect-authored facts with source keys and filing a conformance issue for the
+  one verification gap found (AuthorizationDecisionLog write-site unconfirmed).
+  Remaining §8 views (System Decomposition, Data Authority, Build Studio Lifecycle,
+  Deployment/Runtime Contracts, Value-Stream→System, Skill/Toolchain) are next.
+- **Phases 3–5** (Build Studio planning hooks, external-agent convergence, tool
+  evaluation / import-export): not started.
+
+Decisions on §14 open questions (defaults, revisable): **Q2** first catch-up view =
+**AI Agent Authority** (governance moat; extends the AI-cockpit model). Q1, Q3, Q4,
+Q5 remain open.

--- a/docs/user-guide/architecture/index.md
+++ b/docs/user-guide/architecture/index.md
@@ -8,11 +8,13 @@ updatedBy: Claude (COO)
 
 ## Overview
 
-The EA Modeler is a canvas-based tool for building and maintaining your organization's enterprise architecture. Models are created using ArchiMate 4 notation and are intended to be implementable — not just decorative diagrams. They connect directly to the products, technology, and operations managed elsewhere in the platform.
+The EA Modeler is a canvas-based tool for building and maintaining your organization's enterprise architecture. Models are created in ArchiMate 4 (the default notation for enterprise structure), with BPMN 2.0 for process/workflow behaviour and SysML v2 for systems requirements, constraints, interfaces, and verification. They are intended to be implementable — not just decorative diagrams. They connect directly to the products, technology, and operations managed elsewhere in the platform.
 
 ## Key Concepts
 
-- **ArchiMate 4** — The open standard notation used for all models. It supports three layers: Business (processes, actors, roles), Application (software, interfaces, services), and Technology (infrastructure, platforms, networks).
+- **ArchiMate 4** — The default open-standard notation for enterprise structure, across three layers: Business (capabilities, actors, roles), Application (services, components, interfaces), and Technology (infrastructure, platforms, networks). Best for cross-layer dependencies and strategy alignment.
+- **BPMN 2.0** — For process and workflow behaviour: sequences, gateways, events, and swimlanes (who does what — human or AI coworker).
+- **SysML v2** — For systems architecture: requirements, constraints, interfaces, allocations, verification cases, and traceability. An architect-facing viewpoint (see Views & Viewpoints), not a default end-user surface.
 - **Views and Viewpoints** — A viewpoint defines which elements and relationships are relevant for a particular audience. A view is a specific diagram built from that viewpoint.
 - **Reference Models** — Prebuilt architecture patterns (e.g., cloud-native application, integration hub) that can be adapted and incorporated into your own models.
 - **Value Streams** — End-to-end sequences of activities that deliver value to a customer or stakeholder. Modelled in the business layer and traceable to the products and capabilities that enable them.
@@ -20,7 +22,7 @@ The EA Modeler is a canvas-based tool for building and maintaining your organiza
 ## What You Can Do
 
 - Create and edit architecture views across business, application, and technology layers
-- Apply standard ArchiMate viewpoints or define custom ones for your audience
+- Apply standard ArchiMate, BPMN, or SysML viewpoints, or define custom ones for your audience
 - Start from reference models and tailor them to your organization
 - Map value streams to the products and capabilities that support them
 - Use the AI coworker to generate a draft architecture view from a description

--- a/packages/db/src/seed-ea-cross-notation.ts
+++ b/packages/db/src/seed-ea-cross-notation.ts
@@ -37,6 +37,26 @@ const CROSS_NOTATION_REL_TYPES: RelTypeDef[] = [
     neoType: "REALIZES_PROCESS",
     description: "ArchiMate application component realizes a BPMN automated task (e.g., application_component realizes_process bpmn_service_task)",
   },
+  // SysML v2 ↔ ArchiMate bridges (2026-06-14 SysML substrate spec §4): SysML carries
+  // the obligation semantics; ArchiMate carries the realizing structure/evidence.
+  {
+    slug: "sysml_allocates",
+    name: "SysML Allocates",
+    neoType: "SYSML_ALLOCATES",
+    description: "A SysML logical obligation is allocated to a realizing ArchiMate element (e.g., sysml part_definition allocates application_component)",
+  },
+  {
+    slug: "sysml_traces",
+    name: "SysML Traces",
+    neoType: "SYSML_TRACES",
+    description: "A SysML requirement traces to an ArchiMate motivation/capability element (e.g., sysml requirement traces business_capability)",
+  },
+  {
+    slug: "sysml_verifies",
+    name: "SysML Verifies",
+    neoType: "SYSML_VERIFIES",
+    description: "A SysML verification case is proven by an ArchiMate event/evidence record (e.g., sysml verification_case verifies event_evidence)",
+  },
 ];
 
 // ─── Cross-notation relationship rules ────────────────────────────────────────
@@ -69,6 +89,16 @@ const CROSS_RULES: CrossRuleDef[] = [
   { fromNotation: "archimate4", fromSlug: "application_component", toNotation: "bpmn20", toSlug: "bpmn_service_task",       relSlug: "realizes_process" },
   { fromNotation: "archimate4", fromSlug: "application_component", toNotation: "bpmn20", toSlug: "bpmn_script_task",        relSlug: "realizes_process" },
   { fromNotation: "archimate4", fromSlug: "application_component", toNotation: "bpmn20", toSlug: "bpmn_business_rule_task", relSlug: "realizes_process" },
+
+  // sysml_allocates: SysML logical obligation realized by an ArchiMate element
+  { fromNotation: "sysml2", fromSlug: "part_definition", toNotation: "archimate4", toSlug: "application_component", relSlug: "sysml_allocates" },
+  { fromNotation: "sysml2", fromSlug: "part_definition", toNotation: "archimate4", toSlug: "digital_product",      relSlug: "sysml_allocates" },
+  { fromNotation: "sysml2", fromSlug: "action",          toNotation: "archimate4", toSlug: "application_function", relSlug: "sysml_allocates" },
+  // sysml_traces: SysML requirement traces to ArchiMate motivation/capability
+  { fromNotation: "sysml2", fromSlug: "requirement",     toNotation: "archimate4", toSlug: "requirement",          relSlug: "sysml_traces" },
+  { fromNotation: "sysml2", fromSlug: "requirement",     toNotation: "archimate4", toSlug: "business_capability",  relSlug: "sysml_traces" },
+  // sysml_verifies: SysML verification case proven by ArchiMate event/evidence
+  { fromNotation: "sysml2", fromSlug: "verification_case", toNotation: "archimate4", toSlug: "event_evidence",     relSlug: "sysml_verifies" },
 ];
 
 // ─── Seed function ────────────────────────────────────────────────────────────

--- a/packages/db/src/seed-ea-sysml-agent-authority.test.ts
+++ b/packages/db/src/seed-ea-sysml-agent-authority.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./client.js", () => ({
+  prisma: {
+    eaNotation: { findUnique: vi.fn() },
+    eaElementType: { findUniqueOrThrow: vi.fn() },
+    eaRelationshipType: { findUniqueOrThrow: vi.fn() },
+    eaElement: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    eaRelationship: { findFirst: vi.fn(), create: vi.fn() },
+    eaConformanceIssue: { findFirst: vi.fn(), create: vi.fn() },
+    viewpointDefinition: { findUnique: vi.fn() },
+    eaView: { findFirst: vi.fn(), create: vi.fn() },
+    eaViewElement: { upsert: vi.fn() },
+  },
+}));
+
+import { prisma } from "./client.js";
+import { seedEaSysmlAgentAuthority } from "./seed-ea-sysml-agent-authority.js";
+
+const m = prisma as unknown as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+
+const TOTAL_ELEMENTS = 23; // 1 pkg + 9 parts + 7 requirements + 1 constraint + 5 verification
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  m.eaNotation.findUnique.mockResolvedValue({ id: "n-sysml2" });
+  m.eaElementType.findUniqueOrThrow.mockImplementation(async (a: { where: { notationId_slug: { slug: string } } }) => ({ id: `et-${a.where.notationId_slug.slug}` }));
+  m.eaRelationshipType.findUniqueOrThrow.mockImplementation(async (a: { where: { notationId_slug: { slug: string } } }) => ({ id: `rt-${a.where.notationId_slug.slug}` }));
+  m.eaElement.create.mockImplementation(async (a: { data: { infraCiKey: string } }) => ({ id: `el-${a.data.infraCiKey}` }));
+  m.eaElement.update.mockImplementation(async (a: { where: { id: string } }) => ({ id: a.where.id }));
+  m.eaRelationship.create.mockResolvedValue({});
+  m.eaConformanceIssue.create.mockResolvedValue({});
+  m.viewpointDefinition.findUnique.mockResolvedValue({ id: "vp-1" });
+  m.eaView.create.mockResolvedValue({ id: "view-1" });
+  m.eaViewElement.upsert.mockResolvedValue({});
+});
+
+describe("seedEaSysmlAgentAuthority", () => {
+  it("creates the full authority model on first run", async () => {
+    m.eaElement.findFirst.mockResolvedValue(null);
+    m.eaRelationship.findFirst.mockResolvedValue(null);
+    m.eaConformanceIssue.findFirst.mockResolvedValue(null);
+    m.eaView.findFirst.mockResolvedValue(null);
+
+    await seedEaSysmlAgentAuthority();
+
+    expect(m.eaElement.create).toHaveBeenCalledTimes(TOTAL_ELEMENTS);
+    // governedExecuteTool satisfies the default-deny invariant.
+    expect(m.eaRelationship.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fromElementId: "el-sysml:aauth:part:govexec",
+          toElementId: "el-sysml:aauth:req:REQ-AAUTH-1",
+          relationshipTypeId: "rt-satisfies",
+        }),
+      })
+    );
+    // The envelope verification case verifies the HITL invariant.
+    expect(m.eaRelationship.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fromElementId: "el-sysml:aauth:vc:VC-AAUTH-ENVELOPE",
+          toElementId: "el-sysml:aauth:req:REQ-AAUTH-3",
+          relationshipTypeId: "rt-verifies",
+        }),
+      })
+    );
+    // A conformance issue is filed for the AuthorizationDecisionLog write-site gap.
+    expect(m.eaConformanceIssue.create).toHaveBeenCalledTimes(1);
+    expect(m.eaConformanceIssue.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ issueType: "missing-verification-evidence" }) })
+    );
+    expect(m.eaView.create).toHaveBeenCalledTimes(1);
+    expect(m.eaViewElement.upsert).toHaveBeenCalledTimes(TOTAL_ELEMENTS);
+  });
+
+  it("is idempotent on re-run: updates elements, no duplicate rels/view/conformance issue", async () => {
+    m.eaElement.findFirst.mockResolvedValue({ id: "existing-el" });
+    m.eaRelationship.findFirst.mockResolvedValue({ id: "existing-rel" });
+    m.eaConformanceIssue.findFirst.mockResolvedValue({ id: "existing-issue" });
+    m.eaView.findFirst.mockResolvedValue({ id: "existing-view" });
+
+    await seedEaSysmlAgentAuthority();
+
+    expect(m.eaElement.update).toHaveBeenCalledTimes(TOTAL_ELEMENTS);
+    expect(m.eaElement.create).not.toHaveBeenCalled();
+    expect(m.eaRelationship.create).not.toHaveBeenCalled();
+    expect(m.eaConformanceIssue.create).not.toHaveBeenCalled();
+    expect(m.eaView.create).not.toHaveBeenCalled();
+  });
+
+  it("skips cleanly when the sysml2 notation is not seeded", async () => {
+    m.eaNotation.findUnique.mockResolvedValue(null);
+    await seedEaSysmlAgentAuthority();
+    expect(m.eaElement.create).not.toHaveBeenCalled();
+    expect(m.eaElement.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/seed-ea-sysml-agent-authority.ts
+++ b/packages/db/src/seed-ea-sysml-agent-authority.ts
@@ -1,0 +1,197 @@
+// packages/db/src/seed-ea-sysml-agent-authority.ts
+// SysML v2 current-state view: "AI Agent Authority" — Phase 2 catch-up view
+// (docs/superpowers/specs/2026-06-14-sysml-architecture-substrate-design.md §8 view #3).
+//
+// Models DPF's REAL authority architecture as EA graph content: how an AI coworker
+// gets authority (identity → delegation → tool grants → runtime-scoped token), the
+// single enforcement choke point, the HITL approval gate, and the dual-principal
+// audit ledger. Grounded in code/schema, not invented. Each element records
+// `provenance` ("deterministic" = grounded in code/schema with a `sourceKey`, vs
+// "architect" = architect-authored judgment) per the spec's Phase 2 guidance, and
+// a conformance issue is filed for the one verification gap found during research.
+//
+// Requires the sysml2 notation + viewpoints (seed-ea-sysml2.ts / seed-ea-viewpoints.ts).
+// Idempotent: elements upsert by stable `infraCiKey`; relationships/view elements
+// de-dupe on natural keys. Runtime EA validation deferred per the substrate spec.
+//
+// (Mirrors the seeding pattern in seed-ea-sysml-ai-cockpit.ts; a shared seeding
+// helper is a tracked convergence follow-up.)
+
+import { prisma } from "./client.js";
+import type { Prisma } from "../generated/client/client";
+
+const NOTATION_SLUG = "sysml2";
+const KEY = (suffix: string) => `sysml:aauth:${suffix}`;
+
+type ElementSeed = {
+  key: string;
+  typeSlug: string;
+  name: string;
+  description: string;
+  properties?: Prisma.InputJsonValue;
+};
+
+const det = (sourceKey: string, extra: Record<string, unknown> = {}) => ({ provenance: "deterministic", sourceKey, ...extra });
+const arch = (extra: Record<string, unknown> = {}) => ({ provenance: "architect", ...extra });
+
+// ── Parts (entities) → realizing substrate ──────────────────────────────────
+const PARTS: Array<ElementSeed & { satisfies: string[] }> = [
+  { key: "part:agent",        typeSlug: "part_definition", name: "Agent (coworker identity)",        description: "The coworker identity bearing tier, humanSupervisorId, hitlTierDefault, escalatesTo/delegatesTo.", properties: det("packages/db/prisma/schema.prisma#Agent"), satisfies: [] },
+  { key: "part:govprofile",   typeSlug: "part_definition", name: "AgentGovernanceProfile",            description: "Per-agent autonomyLevel, hitlPolicy, allowDelegation, maxDelegationRiskBand; capability + directive policy classes.", properties: det("packages/db/prisma/schema.prisma#AgentGovernanceProfile"), satisfies: [] },
+  { key: "part:delegation",   typeSlug: "part_definition", name: "DelegationGrant",                   description: "Scoped, time-boxed human→agent delegation (scopeJson, riskBand, validFrom/expiresAt, maxUses).", properties: det("packages/db/prisma/schema.prisma#DelegationGrant"), satisfies: ["req:REQ-AAUTH-4"] },
+  { key: "part:authbinding",  typeSlug: "part_definition", name: "AuthorityBinding",                  description: "Resource-scoped authority policy (scopeType, resourceRef, approvalMode, sensitivityCeiling, authorityScope).", properties: det("packages/db/prisma/schema.prisma#AuthorityBinding"), satisfies: ["req:REQ-AAUTH-4"] },
+  { key: "part:toolgrant",    typeSlug: "part_definition", name: "AgentToolGrant + TOOL_TO_GRANTS",   description: "The held grants and the tool→required-grants map; a tool absent from the map is denied by default.", properties: det("apps/web/lib/tak/agent-grants.ts"), satisfies: ["req:REQ-AAUTH-1", "req:REQ-AAUTH-7"] },
+  { key: "part:token",        typeSlug: "part_definition", name: "McpApiToken / mcpSession",          description: "Runtime-scoped authority: PAT (scopes ⊆ user grants, optional agent binding) and 5-min audience-pinned session JWT.", properties: det("apps/web/lib/mcp/session-token.ts; apps/web/lib/auth/mcp-api-token.ts"), satisfies: ["req:REQ-AAUTH-4"] },
+  { key: "part:govexec",      typeSlug: "part_definition", name: "governedExecuteTool (enforcement choke point)", description: "Single gate: checks the human capability AND (when an agentId is present) the agent grants; runs HITL/hooks; always audits.", properties: det("apps/web/lib/mcp-governed-execute.ts"), satisfies: ["req:REQ-AAUTH-1", "req:REQ-AAUTH-2", "req:REQ-AAUTH-5"] },
+  { key: "part:envelope",     typeSlug: "part_definition", name: "CoworkerActionEnvelope (HITL gate)", description: "Propose→approve→resolve record for effectful/destructive coworker actions; resolvable only by the delegating user.", properties: det("apps/web/lib/coworker/envelope-state-machine.ts; packages/db/prisma/schema.prisma#CoworkerActionEnvelope"), satisfies: ["req:REQ-AAUTH-3"] },
+  { key: "part:toolexec",     typeSlug: "part_definition", name: "ToolExecution (authority ledger)",  description: "Every governed call, recording dual principal (userId + delegatingUserId), agentId, apiTokenId, capabilityId/auditClass, envelopeId.", properties: det("packages/db/prisma/schema.prisma#ToolExecution"), satisfies: ["req:REQ-AAUTH-6"] },
+];
+
+// ── Requirements (invariants) ───────────────────────────────────────────────
+const REQUIREMENTS: ElementSeed[] = [
+  { key: "req:REQ-AAUTH-1", typeSlug: "requirement", name: "REQ-AAUTH-1 Default-deny tool authority", description: "A tool with no TOOL_TO_GRANTS entry is denied; a coworker may invoke a tool only if its (implication-expanded) grants intersect the tool's required grants.", properties: det("apps/web/lib/tak/agent-grants.ts#isToolAllowedByGrants") },
+  { key: "req:REQ-AAUTH-2", typeSlug: "requirement", name: "REQ-AAUTH-2 Dual gate: capability AND grant", description: "An agent-context call must pass BOTH the human's requiredCapability check and the agent-grant check; failing either is rejected and audited.", properties: det("apps/web/lib/mcp-governed-execute.ts") },
+  { key: "req:REQ-AAUTH-3", typeSlug: "requirement", name: "REQ-AAUTH-3 Effectful actions require an approved envelope", description: "Every effectful/destructive coworker action requires an approved CoworkerActionEnvelope, resolvable only by the delegating user.", properties: det("apps/web/lib/coworker/envelope-actions.ts") },
+  { key: "req:REQ-AAUTH-4", typeSlug: "requirement", name: "REQ-AAUTH-4 Authority bound to principals + tokens/grants", description: "Token scope ⊆ user grants; agent binding narrows never widens; the 5-min audience-pinned session JWT overrides any PAT in the same shell. Authority is not chat-UI state.", properties: det("apps/web/app/api/mcp/v1/route.ts; apps/web/lib/mcp/session-token.ts") },
+  { key: "req:REQ-AAUTH-5", typeSlug: "requirement", name: "REQ-AAUTH-5 Every governed call is audited (incl. denials)", description: "governedExecuteTool writes a ToolExecution row on forbidden_capability, forbidden_grant, hook_denied, and success alike; audit failure never masks the result.", properties: det("apps/web/lib/mcp-governed-execute.ts") },
+  { key: "req:REQ-AAUTH-6", typeSlug: "requirement", name: "REQ-AAUTH-6 Dual-principal accountability", description: "A coworker action records both the executing identity (userId) and the human it acted for (delegatingUserId) as distinct fields; coworker identity is the semantic agentId.", properties: det("packages/db/prisma/schema.prisma#ToolExecution") },
+  { key: "req:REQ-AAUTH-7", typeSlug: "requirement", name: "REQ-AAUTH-7 Grant narrowing is one-way", description: "GRANT_IMPLICATIONS only lets a coarse grant satisfy a finer requirement; holding the fine grant never implies the coarse one.", properties: det("apps/web/lib/tak/agent-grants.ts#GRANT_IMPLICATIONS") },
+];
+
+// ── Constraint ───────────────────────────────────────────────────────────────
+const CONSTRAINTS: ElementSeed[] = [
+  { key: "con:CON-AAUTH-1", typeSlug: "constraint", name: "CON-AAUTH-1 Token-scope subset invariant", description: "tokenScope ⊆ userGrants ∧ (agentBinding ⇒ scope narrows) ∧ (sessionJWT present ⇒ sessionJWT wins over PAT). Enforced before execution.", properties: det("apps/web/app/api/mcp/v1/route.ts", { kind: "parametric" }) },
+];
+
+// ── Verification cases (evidence records) ────────────────────────────────────
+const VERIFICATIONS: Array<ElementSeed & { verifies: string[]; gap?: string }> = [
+  { key: "vc:VC-AAUTH-TOOLEXEC", typeSlug: "verification_case", name: "VC-AAUTH-TOOLEXEC ToolExecution ledger", description: "Proves every governed action ran under agentId+userId+delegatingUserId with capability/audit classification (and envelopeId when gated).", properties: det("packages/db/prisma/schema.prisma#ToolExecution", { status: "active" }), verifies: ["req:REQ-AAUTH-5", "req:REQ-AAUTH-6"] },
+  { key: "vc:VC-AAUTH-ENVELOPE", typeSlug: "verification_case", name: "VC-AAUTH-ENVELOPE CoworkerActionEnvelope", description: "Proves the human approved a destructive action before it ran (status reaches executed only via approved).", properties: det("apps/web/lib/coworker/envelope-state-machine.ts", { status: "active" }), verifies: ["req:REQ-AAUTH-3"] },
+  { key: "vc:VC-AAUTH-RECEIPT", typeSlug: "verification_case", name: "VC-AAUTH-RECEIPT ToolExecutionReceipt", description: "Content-addressed (input fingerprint + output digest) proof for sandbox/test/ux executions.", properties: det("packages/db/prisma/schema.prisma#ToolExecutionReceipt", { status: "active" }), verifies: ["req:REQ-AAUTH-5"] },
+  { key: "vc:VC-AAUTH-AUTHZLOG", typeSlug: "verification_case", name: "VC-AAUTH-AUTHZLOG AuthorizationDecisionLog", description: "Intended 'why-authorized' ledger linking the DelegationGrant/AuthorityBinding consulted + rationale. Table + FKs exist; runtime write-site UNCONFIRMED.", properties: arch({ status: "substrate-ahead-of-wiring", sourceKey: "packages/db/prisma/schema.prisma#AuthorizationDecisionLog" }), verifies: ["req:REQ-AAUTH-4"], gap: "No write-site for AuthorizationDecisionLog found in the governed-execute path during research; verify the runtime populates it before treating it as an active verification case." },
+  { key: "vc:VC-AAUTH-TELEMETRY", typeSlug: "verification_case", name: "VC-AAUTH-TELEMETRY AdapterRunTelemetry", description: "Per-LLM-call telemetry proving the model stayed in bounds: policy-block/refusal status, invalid (fabricated) tool calls, capabilities used.", properties: det("packages/db/prisma/schema.prisma#AdapterRunTelemetry", { status: "active" }), verifies: ["req:REQ-AAUTH-5"] },
+];
+
+const CONSTRAINT_REFINES: Array<{ from: string; to: string }> = [
+  { from: "con:CON-AAUTH-1", to: "req:REQ-AAUTH-4" },
+];
+
+const PACKAGE: ElementSeed = {
+  key: "pkg",
+  typeSlug: "package",
+  name: "AI Agent Authority",
+  description: "SysML v2 current-state view of how DPF AI coworkers acquire and exercise authority: identity → delegation → tool grants → runtime-scoped token → single enforcement gate → HITL approval → dual-principal audit.",
+  properties: arch({ sysmlPackage: "PKG-AAUTH", catchUpView: "AI Agent Authority Model (spec §8 #3)" }),
+};
+
+const VIEW_NAME = "AI Agent Authority — Current State";
+
+export async function seedEaSysmlAgentAuthority(): Promise<void> {
+  const notation = await prisma.eaNotation.findUnique({ where: { slug: NOTATION_SLUG }, select: { id: true } });
+  if (!notation) {
+    console.warn(`Skipping AI Agent Authority view: notation "${NOTATION_SLUG}" not seeded`);
+    return;
+  }
+  const notationId = notation.id;
+
+  const typeSlugs = ["package", "requirement", "constraint", "part_definition", "verification_case"];
+  const etId = new Map<string, string>();
+  for (const slug of typeSlugs) {
+    const et = await prisma.eaElementType.findUniqueOrThrow({ where: { notationId_slug: { notationId, slug } }, select: { id: true } });
+    etId.set(slug, et.id);
+  }
+  const relSlugs = ["contains", "satisfies", "verifies", "refines"];
+  const rtId = new Map<string, string>();
+  for (const slug of relSlugs) {
+    const rt = await prisma.eaRelationshipType.findUniqueOrThrow({ where: { notationId_slug: { notationId, slug } }, select: { id: true } });
+    rtId.set(slug, rt.id);
+  }
+
+  const elementId = new Map<string, string>();
+  async function upsertElement(seed: ElementSeed): Promise<string> {
+    const infraCiKey = KEY(seed.key);
+    const elementTypeId = etId.get(seed.typeSlug);
+    if (!elementTypeId) throw new Error(`agent-authority seed: unknown sysml2 element type "${seed.typeSlug}"`);
+    const data = {
+      elementTypeId,
+      name: seed.name,
+      description: seed.description,
+      properties: seed.properties ?? {},
+      lifecycleStage: "production",
+      lifecycleStatus: "active",
+      infraCiKey,
+    };
+    const existing = await prisma.eaElement.findFirst({ where: { infraCiKey }, select: { id: true } });
+    const row = existing
+      ? await prisma.eaElement.update({ where: { id: existing.id }, data, select: { id: true } })
+      : await prisma.eaElement.create({ data, select: { id: true } });
+    elementId.set(seed.key, row.id);
+    return row.id;
+  }
+
+  async function upsertRel(fromKey: string, toKey: string, relSlug: string): Promise<void> {
+    const fromElementId = elementId.get(fromKey);
+    const toElementId = elementId.get(toKey);
+    const relationshipTypeId = rtId.get(relSlug);
+    if (!fromElementId || !toElementId || !relationshipTypeId) {
+      console.warn(`agent-authority seed: skipping rel ${fromKey} -[${relSlug}]-> ${toKey} (unresolved)`);
+      return;
+    }
+    const existing = await prisma.eaRelationship.findFirst({ where: { fromElementId, toElementId, relationshipTypeId }, select: { id: true } });
+    if (!existing) {
+      await prisma.eaRelationship.create({ data: { fromElementId, toElementId, relationshipTypeId, notationSlug: NOTATION_SLUG, properties: {} } });
+    }
+  }
+
+  // 1. Elements.
+  await upsertElement(PACKAGE);
+  for (const r of REQUIREMENTS) await upsertElement(r);
+  for (const c of CONSTRAINTS) await upsertElement(c);
+  for (const p of PARTS) await upsertElement(p);
+  for (const v of VERIFICATIONS) await upsertElement(v);
+
+  // 2. Relationships.
+  for (const key of elementId.keys()) {
+    if (key !== PACKAGE.key) await upsertRel(PACKAGE.key, key, "contains");
+  }
+  for (const p of PARTS) for (const reqKey of p.satisfies) await upsertRel(p.key, reqKey, "satisfies");
+  for (const v of VERIFICATIONS) for (const reqKey of v.verifies) await upsertRel(v.key, reqKey, "verifies");
+  for (const ref of CONSTRAINT_REFINES) await upsertRel(ref.from, ref.to, "refines");
+
+  // 3. Conformance issue for the verification gap found during research.
+  for (const v of VERIFICATIONS) {
+    if (!v.gap) continue;
+    const elId = elementId.get(v.key);
+    if (!elId) continue;
+    const existing = await prisma.eaConformanceIssue.findFirst({ where: { elementId: elId, issueType: "missing-verification-evidence" }, select: { id: true } });
+    if (!existing) {
+      await prisma.eaConformanceIssue.create({
+        data: { elementId: elId, issueType: "missing-verification-evidence", severity: "warn", message: v.gap, status: "open" },
+      });
+    }
+  }
+
+  // 4. View under the "Systems Requirements & Verification" viewpoint.
+  const viewpoint = await prisma.viewpointDefinition.findUnique({ where: { name: "Systems Requirements & Verification" }, select: { id: true } });
+  let view = await prisma.eaView.findFirst({ where: { notationId, name: VIEW_NAME }, select: { id: true } });
+  if (!view) {
+    view = await prisma.eaView.create({
+      data: {
+        notationId, name: VIEW_NAME,
+        description: "Current-state authority model: parts (identity→token), the invariants they satisfy, and the audit records that verify them.",
+        layoutType: "graph", scopeType: "custom", scopeRef: "agent-authority",
+        viewpointId: viewpoint?.id ?? null, status: "draft",
+      },
+      select: { id: true },
+    });
+  }
+  for (const id of elementId.values()) {
+    await prisma.eaViewElement.upsert({
+      where: { viewId_elementId: { viewId: view.id, elementId: id } },
+      update: {},
+      create: { viewId: view.id, elementId: id, mode: "existing" },
+    });
+  }
+
+  console.log(`Seeded AI Agent Authority SysML view: ${elementId.size} elements + view "${VIEW_NAME}"`);
+}

--- a/packages/db/src/seed-ea-sysml-ai-cockpit.test.ts
+++ b/packages/db/src/seed-ea-sysml-ai-cockpit.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./client.js", () => ({
+  prisma: {
+    eaNotation: { findUnique: vi.fn() },
+    eaElementType: { findUniqueOrThrow: vi.fn() },
+    eaRelationshipType: { findUniqueOrThrow: vi.fn() },
+    eaElement: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    eaRelationship: { findFirst: vi.fn(), create: vi.fn() },
+    viewpointDefinition: { findUnique: vi.fn() },
+    eaView: { findFirst: vi.fn(), create: vi.fn() },
+    eaViewElement: { upsert: vi.fn() },
+  },
+}));
+
+import { prisma } from "./client.js";
+import { seedEaSysmlAiCockpit } from "./seed-ea-sysml-ai-cockpit.js";
+
+const m = prisma as unknown as {
+  eaNotation: { findUnique: ReturnType<typeof vi.fn> };
+  eaElementType: { findUniqueOrThrow: ReturnType<typeof vi.fn> };
+  eaRelationshipType: { findUniqueOrThrow: ReturnType<typeof vi.fn> };
+  eaElement: { findFirst: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  eaRelationship: { findFirst: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  viewpointDefinition: { findUnique: ReturnType<typeof vi.fn> };
+  eaView: { findFirst: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  eaViewElement: { upsert: ReturnType<typeof vi.fn> };
+};
+
+const TOTAL_ELEMENTS = 30; // 1 pkg + 9 req + 1 constraint + 9 parts + 4 interfaces + 6 verification
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  m.eaNotation.findUnique.mockResolvedValue({ id: "n-sysml2" });
+  m.eaElementType.findUniqueOrThrow.mockImplementation(async (a: { where: { notationId_slug: { slug: string } } }) => ({ id: `et-${a.where.notationId_slug.slug}` }));
+  m.eaRelationshipType.findUniqueOrThrow.mockImplementation(async (a: { where: { notationId_slug: { slug: string } } }) => ({ id: `rt-${a.where.notationId_slug.slug}` }));
+  // Element id is derived from infraCiKey so relationship endpoints are assertable.
+  m.eaElement.create.mockImplementation(async (a: { data: { infraCiKey: string } }) => ({ id: `el-${a.data.infraCiKey}` }));
+  m.eaElement.update.mockImplementation(async (a: { where: { id: string } }) => ({ id: a.where.id }));
+  m.eaRelationship.create.mockResolvedValue({});
+  m.viewpointDefinition.findUnique.mockResolvedValue({ id: "vp-1" });
+  m.eaView.create.mockResolvedValue({ id: "view-1" });
+  m.eaViewElement.upsert.mockResolvedValue({});
+});
+
+describe("seedEaSysmlAiCockpit", () => {
+  it("creates the full model on first run (findFirst returns null)", async () => {
+    m.eaElement.findFirst.mockResolvedValue(null);
+    m.eaRelationship.findFirst.mockResolvedValue(null);
+    m.eaView.findFirst.mockResolvedValue(null);
+
+    await seedEaSysmlAiCockpit();
+
+    expect(m.eaElement.create).toHaveBeenCalledTimes(TOTAL_ELEMENTS);
+    expect(m.eaElement.update).not.toHaveBeenCalled();
+    // The email-triage requirement is present.
+    const createdKeys = m.eaElement.create.mock.calls.map(([a]) => (a as { data: { infraCiKey: string } }).data.infraCiKey);
+    expect(createdKeys).toContain("sysml:aic:req:REQ-AIC-5");
+    // Routing Policy Engine satisfies REQ-AIC-1.
+    expect(m.eaRelationship.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fromElementId: "el-sysml:aic:part:router",
+          toElementId: "el-sysml:aic:req:REQ-AIC-1",
+          relationshipTypeId: "rt-satisfies",
+        }),
+      })
+    );
+    // VC-AIC-E1 verifies REQ-AIC-5.
+    expect(m.eaRelationship.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fromElementId: "el-sysml:aic:vc:VC-AIC-E1",
+          toElementId: "el-sysml:aic:req:REQ-AIC-5",
+          relationshipTypeId: "rt-verifies",
+        }),
+      })
+    );
+    expect(m.eaView.create).toHaveBeenCalledTimes(1);
+    expect(m.eaViewElement.upsert).toHaveBeenCalledTimes(TOTAL_ELEMENTS);
+  });
+
+  it("is idempotent on re-run: updates existing elements, creates no duplicate rels or view", async () => {
+    m.eaElement.findFirst.mockResolvedValue({ id: "existing-el" });
+    m.eaRelationship.findFirst.mockResolvedValue({ id: "existing-rel" });
+    m.eaView.findFirst.mockResolvedValue({ id: "existing-view" });
+
+    await seedEaSysmlAiCockpit();
+
+    expect(m.eaElement.update).toHaveBeenCalledTimes(TOTAL_ELEMENTS);
+    expect(m.eaElement.create).not.toHaveBeenCalled();
+    expect(m.eaRelationship.create).not.toHaveBeenCalled();
+    expect(m.eaView.create).not.toHaveBeenCalled();
+    // View elements still reconciled idempotently.
+    expect(m.eaViewElement.upsert).toHaveBeenCalledTimes(TOTAL_ELEMENTS);
+  });
+
+  it("skips cleanly when the sysml2 notation is not seeded", async () => {
+    m.eaNotation.findUnique.mockResolvedValue(null);
+    await seedEaSysmlAiCockpit();
+    expect(m.eaElement.create).not.toHaveBeenCalled();
+    expect(m.eaElement.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/seed-ea-sysml-ai-cockpit.ts
+++ b/packages/db/src/seed-ea-sysml-ai-cockpit.ts
@@ -1,0 +1,228 @@
+// packages/db/src/seed-ea-sysml-ai-cockpit.ts
+// Seeds the "AI Cockpit & Model Routing" SysML v2 model as EA graph content
+// (EaElement/EaRelationship + an EaView), making the architecture design queryable
+// platform data rather than only a markdown doc.
+//
+// Companion human-readable model + traceability:
+//   docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md
+// Source design:
+//   docs/architecture/2026-06-14-odysseus-review-depth-pass.md
+//
+// Requires the sysml2 notation (seed-ea-sysml2.ts) + its viewpoints
+// (seed-ea-viewpoints.ts) to be seeded first; wired after eaViews in seed.ts.
+//
+// Idempotent: elements upsert by stable `infraCiKey`; relationships and view
+// elements de-dupe on their natural keys. Substrate allocations are stored as
+// element properties (allocatedTo) so the seed does not depend on specific
+// ArchiMate instances existing.
+//
+// NOTE: per the SysML substrate spec, runtime/DB validation of this EA seed is the
+// deferred follow-up thread. This module is unit-tested for idempotency with a
+// mocked client; it is not asserted to have run against a live database here.
+
+import { prisma } from "./client.js";
+import type { Prisma } from "../generated/client/client";
+
+const NOTATION_SLUG = "sysml2";
+const KEY = (suffix: string) => `sysml:aic:${suffix}`;
+
+type ElementSeed = {
+  key: string;          // infraCiKey suffix (unique within this model)
+  typeSlug: string;     // sysml2 element type slug
+  name: string;
+  description: string;
+  properties?: Prisma.InputJsonValue;
+};
+
+// ── Requirements ────────────────────────────────────────────────────────────
+const REQUIREMENTS: ElementSeed[] = [
+  { key: "req:REQ-AIC-1", typeSlug: "requirement", name: "REQ-AIC-1 Use-case model routing", description: "Every LLM call is routed by use case (taskType) through a governed policy matrix, not a single global model setting.", properties: { status: "realized" } },
+  { key: "req:REQ-AIC-2", typeSlug: "requirement", name: "REQ-AIC-2 Visible model receipt", description: "Each coworker turn exposes requested policy, actual responding model, and any fallback/escalation.", properties: { status: "planned" } },
+  { key: "req:REQ-AIC-3", typeSlug: "requirement", name: "REQ-AIC-3 No silent frontier escalation for sensitive work", description: "Privacy-sensitive use cases must not silently escalate to a frontier/cloud model; escalation carries a reason code.", properties: { status: "planned" } },
+  { key: "req:REQ-AIC-4", typeSlug: "requirement", name: "REQ-AIC-4 Fallback/escalation auditability", description: "Fallback and escalation are recorded as reason-coded evidence.", properties: { status: "partial" } },
+  { key: "req:REQ-AIC-5", typeSlug: "requirement", name: "REQ-AIC-5 Email triage on the utility tier", description: "Inbound business-email triage routes to the utility tier (cheap/local-preferred, never frontier) and minimize-cost.", properties: { status: "realized" } },
+  { key: "req:REQ-AIC-6", typeSlug: "requirement", name: "REQ-AIC-6 Inbound email to coworker routing", description: "A triaged email can be handed to the right coworker via the inbound→coworker contract (tasks/submit).", properties: { status: "planned" } },
+  { key: "req:REQ-AIC-7", typeSlug: "requirement", name: "REQ-AIC-7 Draft-never-send", description: "Email replies are drafted and require human approval; never auto-sent.", properties: { status: "partial" } },
+  { key: "req:REQ-AIC-8", typeSlug: "requirement", name: "REQ-AIC-8 Business-mailbox transport via OAuth", description: "Inbound business email is ingested via OAuth/provider-push (Graph/Gmail/Postmark), not stored passwords.", properties: { status: "planned" } },
+  { key: "req:REQ-AIC-9", typeSlug: "requirement", name: "REQ-AIC-9 Durable thread governance metadata", description: "Coworker threads carry memoryMode, durable attachedSources, compactionState, and a decision link.", properties: { status: "planned" } },
+];
+
+// ── Constraint (parametric) ──────────────────────────────────────────────────
+const CONSTRAINTS: ElementSeed[] = [
+  { key: "con:CON-AIC-1", typeSlug: "constraint", name: "CON-AIC-1 Routing policy constraint", description: "Selected tier/residency/budget are a function of (sensitivity x residencyPolicy x budgetClass x minimumTier). email-* ⇒ tier=adequate (no frontier) + minimize_cost; confidential/restricted ⇒ no silent frontier escalation.", properties: { kind: "parametric" } },
+];
+
+// ── Part definitions (blocks) with substrate allocation ──────────────────────
+const PARTS: Array<ElementSeed & { satisfies: string[] }> = [
+  { key: "part:router",         typeSlug: "part_definition", name: "Routing Policy Engine",     description: "Capability-filters and cost-ranks endpoints; emits a route decision + fallback chain.", properties: { allocatedTo: "apps/web/lib/routing/pipeline-v2.ts" }, satisfies: ["req:REQ-AIC-1"] },
+  { key: "part:contract",       typeSlug: "part_definition", name: "Request Contract Builder",  description: "Builds a RequestContract from taskType + the TaskRequirement posture defaults.", properties: { allocatedTo: "apps/web/lib/routing/request-contract.ts" }, satisfies: ["req:REQ-AIC-1", "req:REQ-AIC-5"] },
+  { key: "part:matrix",         typeSlug: "part_definition", name: "Use-Case Policy Matrix",    description: "Per-task-type tier/budget/residency/reasoning defaults — the demand side of routing.", properties: { allocatedTo: "apps/web/lib/routing/task-requirements.ts" }, satisfies: ["req:REQ-AIC-1", "req:REQ-AIC-5"] },
+  { key: "part:receipt",        typeSlug: "part_definition", name: "Turn Receipt View",         description: "Read-side join of RouteDecisionLog + RouteOutcome + AdapterRunTelemetry per turn.", properties: { allocatedTo: "RouteDecisionLog + RouteOutcome + AdapterRunTelemetry (view unbuilt)" }, satisfies: ["req:REQ-AIC-2", "req:REQ-AIC-4"] },
+  { key: "part:reasoncodes",    typeSlug: "part_definition", name: "Reason Code Registry",      description: "Single registry of fallback + escalation reason codes (consolidation planned).", properties: { allocatedTo: "apps/web/lib/routing/reason-codes.ts (planned)" }, satisfies: ["req:REQ-AIC-3", "req:REQ-AIC-4"] },
+  { key: "part:emailpipe",      typeSlug: "part_definition", name: "Inbound Email Pipeline",    description: "Pre-filter → classify → route/draft → human approval (generalized from marketing loop).", properties: { allocatedTo: "apps/web/lib/marketing/channels/email-postmark/responder.ts" }, satisfies: ["req:REQ-AIC-5", "req:REQ-AIC-6", "req:REQ-AIC-7"] },
+  { key: "part:emailtransport", typeSlug: "part_definition", name: "Email Transport",           description: "Inbound business-email ingestion via OAuth/provider-push.", properties: { allocatedTo: "Postmark inbound webhook (built) + Graph/Gmail OAuth poller (planned)" }, satisfies: ["req:REQ-AIC-8"] },
+  { key: "part:thread",         typeSlug: "part_definition", name: "Coworker Thread",           description: "Durable coworker work context; gains memoryMode/attachedSources/compactionState/decision link.", properties: { allocatedTo: "AgentThread (packages/db/prisma/schema.prisma)" }, satisfies: ["req:REQ-AIC-9"] },
+  { key: "part:fabric",         typeSlug: "part_definition", name: "Communication Fabric",      description: "Multi-channel inbound→coworker routing (tasks/submit).", properties: { allocatedTo: "apps/web/lib/communications/* + fabric spec §14.4" }, satisfies: ["req:REQ-AIC-6"] },
+];
+
+// ── Interfaces ───────────────────────────────────────────────────────────────
+const INTERFACES: ElementSeed[] = [
+  { key: "if:routeandcall", typeSlug: "interface_definition", name: "routeAndCall()",        description: "Sole inference entry point: (messages, system, sensitivity, options{taskType,...}).", properties: { allocatedTo: "apps/web/lib/inference/routed-inference.ts", status: "realized" } },
+  { key: "if:receipt",      typeSlug: "interface_definition", name: "ThreadTurnReceipt",      description: "Read contract joining the three routing telemetry tables for one turn.", properties: { status: "planned" } },
+  { key: "if:tasksubmit",   typeSlug: "interface_definition", name: "tasks/submit",           description: "Inbound→coworker contract (Communication Fabric §14.4).", properties: { status: "planned" } },
+  { key: "if:webhook",      typeSlug: "interface_definition", name: "inbound email webhook",  description: "/api/communications/<provider>/webhook ingestion endpoint.", properties: { status: "planned" } },
+];
+
+// ── Verification cases ───────────────────────────────────────────────────────
+const VERIFICATIONS: Array<ElementSeed & { verifies: string[] }> = [
+  { key: "vc:VC-AIC-E1",     typeSlug: "verification_case", name: "VC-AIC-E1 email triage pins to utility tier", description: "Asserts email-* requirements pin to adequate tier + minimize_cost.", properties: { evidence: "apps/web/lib/routing/task-requirements.email.test.ts", status: "green" }, verifies: ["req:REQ-AIC-5"] },
+  { key: "vc:VC-AIC-MATRIX", typeSlug: "verification_case", name: "VC-AIC-MATRIX inferContract honours requirement posture", description: "Asserts inferContract applies budget/reasoning/residency defaults from the TaskRequirement.", properties: { evidence: "apps/web/lib/routing/request-contract.email.test.ts", status: "green" }, verifies: ["req:REQ-AIC-1"] },
+  { key: "vc:VC-AIC-DRAFT",  typeSlug: "verification_case", name: "VC-AIC-DRAFT email replies require approval", description: "Asserts inbound replies are drafted with status pending-review (never auto-sent).", properties: { status: "planned" }, verifies: ["req:REQ-AIC-7"] },
+  { key: "vc:VC-AIC-RECEIPT", typeSlug: "verification_case", name: "VC-AIC-RECEIPT turn receipt view", description: "Asserts the receipt join surfaces requested vs actual model + fallback.", properties: { status: "planned" }, verifies: ["req:REQ-AIC-2"] },
+  { key: "vc:VC-AIC-THREAD", typeSlug: "verification_case", name: "VC-AIC-THREAD thread governance fields", description: "Asserts the four net-new thread fields/joins exist and are enforced.", properties: { status: "planned" }, verifies: ["req:REQ-AIC-9"] },
+  { key: "vc:VC-AIC-TRANSPORT", typeSlug: "verification_case", name: "VC-AIC-TRANSPORT OAuth inbound transport", description: "Asserts OAuth/Graph/Gmail inbound ingestion works without stored passwords.", properties: { status: "planned" }, verifies: ["req:REQ-AIC-8"] },
+];
+
+// CON-AIC-1 refines these requirements.
+const CONSTRAINT_REFINES: Array<{ from: string; to: string }> = [
+  { from: "con:CON-AIC-1", to: "req:REQ-AIC-1" },
+  { from: "con:CON-AIC-1", to: "req:REQ-AIC-3" },
+  { from: "con:CON-AIC-1", to: "req:REQ-AIC-5" },
+];
+
+const PACKAGE: ElementSeed = {
+  key: "pkg",
+  typeSlug: "package",
+  name: "AI Cockpit & Model Routing",
+  description: "SysML v2 model package for the Odysseus-derived AI cockpit, use-case model routing, coworker thread receipts, and inbound business-email processing.",
+  properties: { sysmlPackage: "PKG-AIC", design: "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md" },
+};
+
+const VIEW_NAME = "AI Cockpit — Requirements & Verification";
+
+export async function seedEaSysmlAiCockpit(): Promise<void> {
+  const notation = await prisma.eaNotation.findUnique({ where: { slug: NOTATION_SLUG }, select: { id: true } });
+  if (!notation) {
+    console.warn(`Skipping AI-cockpit SysML model: notation "${NOTATION_SLUG}" not seeded`);
+    return;
+  }
+  const notationId = notation.id;
+
+  // Resolve element + relationship type ids for the slugs this model uses.
+  const typeSlugs = ["package", "requirement", "constraint", "part_definition", "interface_definition", "verification_case"];
+  const etId = new Map<string, string>();
+  for (const slug of typeSlugs) {
+    const et = await prisma.eaElementType.findUniqueOrThrow({
+      where: { notationId_slug: { notationId, slug } },
+      select: { id: true },
+    });
+    etId.set(slug, et.id);
+  }
+  const relSlugs = ["contains", "satisfies", "verifies", "refines"];
+  const rtId = new Map<string, string>();
+  for (const slug of relSlugs) {
+    const rt = await prisma.eaRelationshipType.findUniqueOrThrow({
+      where: { notationId_slug: { notationId, slug } },
+      select: { id: true },
+    });
+    rtId.set(slug, rt.id);
+  }
+
+  // Upsert an element by infraCiKey (no natural unique key on EaElement).
+  const elementId = new Map<string, string>(); // model key → EaElement.id
+  async function upsertElement(seed: ElementSeed): Promise<string> {
+    const infraCiKey = KEY(seed.key);
+    const elementTypeId = etId.get(seed.typeSlug);
+    if (!elementTypeId) throw new Error(`AI-cockpit seed: unknown sysml2 element type "${seed.typeSlug}"`);
+    const data = {
+      elementTypeId,
+      name: seed.name,
+      description: seed.description,
+      properties: seed.properties ?? {},
+      lifecycleStage: "design",
+      lifecycleStatus: "active",
+      infraCiKey,
+    };
+    const existing = await prisma.eaElement.findFirst({ where: { infraCiKey }, select: { id: true } });
+    const row = existing
+      ? await prisma.eaElement.update({ where: { id: existing.id }, data, select: { id: true } })
+      : await prisma.eaElement.create({ data, select: { id: true } });
+    elementId.set(seed.key, row.id);
+    return row.id;
+  }
+
+  // Upsert a relationship (no natural unique key on EaRelationship).
+  async function upsertRel(fromKey: string, toKey: string, relSlug: string): Promise<void> {
+    const fromElementId = elementId.get(fromKey);
+    const toElementId = elementId.get(toKey);
+    const relationshipTypeId = rtId.get(relSlug);
+    if (!fromElementId || !toElementId || !relationshipTypeId) {
+      console.warn(`AI-cockpit seed: skipping rel ${fromKey} -[${relSlug}]-> ${toKey} (unresolved)`);
+      return;
+    }
+    const existing = await prisma.eaRelationship.findFirst({
+      where: { fromElementId, toElementId, relationshipTypeId },
+      select: { id: true },
+    });
+    if (!existing) {
+      await prisma.eaRelationship.create({
+        data: { fromElementId, toElementId, relationshipTypeId, notationSlug: NOTATION_SLUG, properties: {} },
+      });
+    }
+  }
+
+  // 1. Elements.
+  await upsertElement(PACKAGE);
+  for (const r of REQUIREMENTS) await upsertElement(r);
+  for (const c of CONSTRAINTS) await upsertElement(c);
+  for (const p of PARTS) await upsertElement(p);
+  for (const i of INTERFACES) await upsertElement(i);
+  for (const v of VERIFICATIONS) await upsertElement(v);
+  const elementCount = elementId.size;
+
+  // 2. Relationships.
+  // package contains every other element.
+  for (const key of elementId.keys()) {
+    if (key !== PACKAGE.key) await upsertRel(PACKAGE.key, key, "contains");
+  }
+  // parts satisfy requirements.
+  for (const p of PARTS) for (const reqKey of p.satisfies) await upsertRel(p.key, reqKey, "satisfies");
+  // verification cases verify requirements.
+  for (const v of VERIFICATIONS) for (const reqKey of v.verifies) await upsertRel(v.key, reqKey, "verifies");
+  // constraint refines requirements.
+  for (const ref of CONSTRAINT_REFINES) await upsertRel(ref.from, ref.to, "refines");
+
+  // 3. View: place the model under the "Systems Requirements & Verification" viewpoint.
+  const viewpoint = await prisma.viewpointDefinition.findUnique({
+    where: { name: "Systems Requirements & Verification" },
+    select: { id: true },
+  });
+  let view = await prisma.eaView.findFirst({
+    where: { notationId, name: VIEW_NAME },
+    select: { id: true },
+  });
+  if (!view) {
+    view = await prisma.eaView.create({
+      data: {
+        notationId,
+        name: VIEW_NAME,
+        description: "Requirements, the parts that satisfy them, and the verification cases that prove them, for the AI Cockpit model.",
+        layoutType: "graph",
+        scopeType: "custom",
+        scopeRef: "ai-cockpit",
+        viewpointId: viewpoint?.id ?? null,
+        status: "draft",
+      },
+      select: { id: true },
+    });
+  }
+  for (const id of elementId.values()) {
+    await prisma.eaViewElement.upsert({
+      where: { viewId_elementId: { viewId: view.id, elementId: id } },
+      update: {},
+      create: { viewId: view.id, elementId: id, mode: "existing" },
+    });
+  }
+
+  console.log(`Seeded AI Cockpit SysML model: ${elementCount} elements + view "${VIEW_NAME}"`);
+}

--- a/packages/db/src/seed-ea-sysml2.test.ts
+++ b/packages/db/src/seed-ea-sysml2.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the prisma client — these tests assert on the seed's upsert calls, no DB.
+vi.mock("./client.js", () => ({
+  prisma: {
+    eaNotation: { upsert: vi.fn() },
+    eaElementType: { upsert: vi.fn() },
+    eaRelationshipType: { upsert: vi.fn() },
+    eaRelationshipRule: { upsert: vi.fn() },
+    eaDqRule: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    eaTraversalPattern: { upsert: vi.fn() },
+  },
+}));
+
+import { prisma } from "./client.js";
+import { seedEaSysml2 } from "./seed-ea-sysml2.js";
+
+type UpsertArgs = { where: Record<string, unknown> };
+
+const mockPrisma = prisma as unknown as {
+  eaNotation: { upsert: ReturnType<typeof vi.fn> };
+  eaElementType: { upsert: ReturnType<typeof vi.fn> };
+  eaRelationshipType: { upsert: ReturnType<typeof vi.fn> };
+  eaRelationshipRule: { upsert: ReturnType<typeof vi.fn> };
+  eaDqRule: { findFirst: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  eaTraversalPattern: { upsert: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.eaNotation.upsert.mockResolvedValue({ id: "sysml2-notation" });
+  // Return a stable id derived from the element/rel slug so the seed's slug→id
+  // maps populate and relationship rules can resolve.
+  mockPrisma.eaElementType.upsert.mockImplementation(async (args: UpsertArgs) => {
+    const slug = (args.where as { notationId_slug: { slug: string } }).notationId_slug.slug;
+    return { id: `et-${slug}` };
+  });
+  mockPrisma.eaRelationshipType.upsert.mockImplementation(async (args: UpsertArgs) => {
+    const slug = (args.where as { notationId_slug: { slug: string } }).notationId_slug.slug;
+    return { id: `rt-${slug}` };
+  });
+  mockPrisma.eaRelationshipRule.upsert.mockResolvedValue({});
+  mockPrisma.eaDqRule.findFirst.mockResolvedValue(null);
+  mockPrisma.eaDqRule.create.mockResolvedValue({});
+  mockPrisma.eaDqRule.update.mockResolvedValue({});
+  mockPrisma.eaTraversalPattern.upsert.mockResolvedValue({});
+});
+
+describe("seedEaSysml2", () => {
+  it("upserts the sysml2 notation", async () => {
+    await seedEaSysml2();
+    expect(mockPrisma.eaNotation.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { slug: "sysml2" },
+        create: expect.objectContaining({ slug: "sysml2", name: "SysML v2", version: "2.0" }),
+      })
+    );
+  });
+
+  it("seeds the SysML v2 element types including requirement, constraint, and verification_case", async () => {
+    await seedEaSysml2();
+    const slugs = mockPrisma.eaElementType.upsert.mock.calls.map(
+      ([args]) => (args.where as { notationId_slug: { slug: string } }).notationId_slug.slug
+    );
+    // Phase 1 minimal subset (design spec §10).
+    for (const expected of [
+      "package", "part_definition", "part_usage", "interface_definition", "port",
+      "requirement", "constraint", "action", "state", "verification_case", "analysis_case",
+    ]) {
+      expect(slugs).toContain(expected);
+    }
+    expect(slugs).toHaveLength(11);
+  });
+
+  it("seeds the satisfy/verify/allocate/trace relationship types", async () => {
+    await seedEaSysml2();
+    const slugs = mockPrisma.eaRelationshipType.upsert.mock.calls.map(
+      ([args]) => (args.where as { notationId_slug: { slug: string } }).notationId_slug.slug
+    );
+    for (const expected of ["contains", "specializes", "connects", "allocates", "satisfies", "verifies", "refines", "traces"]) {
+      expect(slugs).toContain(expected);
+    }
+  });
+
+  it("seeds a verification_case → requirement verifies rule", async () => {
+    await seedEaSysml2();
+    expect(mockPrisma.eaRelationshipRule.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          fromElementTypeId_toElementTypeId_relationshipTypeId: {
+            fromElementTypeId: "et-verification_case",
+            toElementTypeId: "et-requirement",
+            relationshipTypeId: "rt-verifies",
+          },
+        },
+      })
+    );
+  });
+
+  it("creates DQ rules on first run (findFirst returns null)", async () => {
+    await seedEaSysml2();
+    expect(mockPrisma.eaDqRule.create).toHaveBeenCalledTimes(3);
+    expect(mockPrisma.eaDqRule.update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: a second run updates existing DQ rules instead of creating duplicates", async () => {
+    mockPrisma.eaDqRule.findFirst.mockResolvedValue({ id: "existing-dq" });
+    await seedEaSysml2();
+    expect(mockPrisma.eaDqRule.create).not.toHaveBeenCalled();
+    expect(mockPrisma.eaDqRule.update).toHaveBeenCalledTimes(3);
+  });
+
+  it("seeds the requirement_satisfaction traversal pattern", async () => {
+    await seedEaSysml2();
+    expect(mockPrisma.eaTraversalPattern.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { notationId_slug: { notationId: "sysml2-notation", slug: "requirement_satisfaction" } },
+      })
+    );
+  });
+});

--- a/packages/db/src/seed-ea-sysml2.ts
+++ b/packages/db/src/seed-ea-sysml2.ts
@@ -1,0 +1,297 @@
+// packages/db/src/seed-ea-sysml2.ts
+// SysML v2 notation seed data.
+// Adds one EaNotation ("sysml2"), element types, relationship types, relationship
+// rules, DQ stage-gate rules, and a requirement/verification traversal pattern.
+//
+// SysML v2 is an INTERNAL architecture viewpoint over the existing EA substrate
+// (see docs/superpowers/specs/2026-06-14-sysml-architecture-substrate-design.md and
+// docs/Reference/sysml-v2.md). It carries the constraint-bearing semantics —
+// requirements, constraints, interfaces, allocations, verification, traceability —
+// that ArchiMate (structure) and BPMN (process) do not. The DPF EA graph stays
+// canonical; SysML adds no new Prisma tables, only seed data on the existing
+// EaNotation/EaElementType/EaRelationshipType/EaRelationshipRule/EaDqRule/
+// EaTraversalPattern substrate.
+//
+// Safe to re-run (upsert pattern throughout). Mirrors seed-ea-archimate4.ts.
+
+import { prisma } from "./client.js";
+import type { Prisma } from "../generated/client/client";
+
+// ─── Lifecycle constraint sets ────────────────────────────────────────────────
+// SysML model elements are logical/design artifacts: they are planned, designed,
+// and held in production-of-the-model; they are not built/decommissioned like
+// deployed components. Mirror the ArchiMate LOGICAL set.
+const LOGICAL_STAGES = ["plan", "design", "production"];
+const LOGICAL_STATUSES = ["draft", "active"];
+
+// ─── Element type definitions ──────────────────────────────────────────────────
+
+type ElementTypeDef = {
+  slug: string;
+  name: string;
+  neoLabel: string;
+  domain: string;
+  description?: string;
+  stages: string[];
+  statuses: string[];
+  ontologyCategory?: string; // structure | behavior | motivation | governance | information
+};
+
+// Minimal SysML v2 subset per design spec §10 Phase 1.
+const ELEMENT_TYPES: ElementTypeDef[] = [
+  // ── Namespace / structure ─────────────────────────────────────────────────
+  { slug: "package",              name: "Package",              neoLabel: "Sysml__Package",             domain: "systems", description: "A namespace / model boundary that groups SysML elements.",                                              stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "structure" },
+  { slug: "part_definition",      name: "Part Definition",      neoLabel: "Sysml__PartDefinition",      domain: "systems", description: "Definition of a system, subsystem, or component type (a block).",                                       stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "structure" },
+  { slug: "part_usage",           name: "Part Usage",           neoLabel: "Sysml__PartUsage",           domain: "systems", description: "A usage/occurrence of a part definition within a containing structure.",                               stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "structure" },
+  { slug: "interface_definition", name: "Interface Definition", neoLabel: "Sysml__InterfaceDefinition", domain: "systems", description: "Definition of a contract/connection between ports (an explicit boundary).",                          stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "structure" },
+  { slug: "port",                 name: "Port",                 neoLabel: "Sysml__Port",                domain: "systems", description: "A connection/access point on a part through which interactions flow.",                                  stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "structure" },
+  // ── Requirement / constraint (motivation) ─────────────────────────────────
+  { slug: "requirement",          name: "Requirement",          neoLabel: "Sysml__Requirement",         domain: "systems", description: "A required capability, behaviour, quality, or policy the system must satisfy.",                         stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "motivation" },
+  { slug: "constraint",           name: "Constraint",           neoLabel: "Sysml__Constraint",          domain: "systems", description: "A formal restriction/invariant (constraint or parametric) on system values or design choices.",         stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "motivation" },
+  // ── Behaviour ─────────────────────────────────────────────────────────────
+  { slug: "action",               name: "Action",               neoLabel: "Sysml__Action",              domain: "systems", description: "A system-level behaviour/step. Use BPMN for executable process detail.",                               stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "behavior" },
+  { slug: "state",                name: "State",                neoLabel: "Sysml__State",               domain: "systems", description: "A lifecycle or operating mode of a part.",                                                             stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "behavior" },
+  // ── Verification / analysis (governance) ──────────────────────────────────
+  { slug: "verification_case",    name: "Verification Case",    neoLabel: "Sysml__VerificationCase",    domain: "systems", description: "A check (test, build gate, or evidence record) that proves a requirement or constraint.",               stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "governance" },
+  { slug: "analysis_case",        name: "Analysis Case",        neoLabel: "Sysml__AnalysisCase",        domain: "systems", description: "An analysis/trade study evaluating design alternatives against criteria.",                             stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES, ontologyCategory: "behavior" },
+];
+
+// ─── Relationship type definitions ────────────────────────────────────────────
+
+type RelTypeDef = {
+  slug: string;
+  name: string;
+  neoType: string;
+  description?: string;
+};
+
+const REL_TYPES: RelTypeDef[] = [
+  { slug: "contains",    name: "Contains",    neoType: "CONTAINS",    description: "Namespace/structural containment (package contains element; part composed of part)." },
+  { slug: "specializes", name: "Specializes", neoType: "SPECIALIZES", description: "A definition specializes (inherits from) a more general definition." },
+  { slug: "connects",    name: "Connects",    neoType: "CONNECTS",    description: "Ports/parts are connected across an interface." },
+  { slug: "allocates",   name: "Allocates",   neoType: "ALLOCATES",   description: "A logical obligation is allocated to a realizing element." },
+  { slug: "satisfies",   name: "Satisfies",   neoType: "SATISFIES",   description: "A design element satisfies a requirement." },
+  { slug: "verifies",    name: "Verifies",    neoType: "VERIFIES",    description: "A verification case verifies a requirement or constraint." },
+  { slug: "refines",     name: "Refines",     neoType: "REFINES",     description: "An element refines (elaborates) a higher-level requirement or element." },
+  { slug: "traces",      name: "Traces",      neoType: "TRACES",      description: "General traceability link between model elements or to source artifacts." },
+];
+
+// ─── Relationship rules ───────────────────────────────────────────────────────
+// Each entry: [fromSlug, toSlug, relSlug]
+type RuleDef = [string, string, string];
+
+const RULES: RuleDef[] = [
+  // Containment
+  ["package", "package", "contains"],
+  ["package", "part_definition", "contains"],
+  ["package", "requirement", "contains"],
+  ["package", "constraint", "contains"],
+  ["package", "interface_definition", "contains"],
+  ["package", "verification_case", "contains"],
+  ["package", "analysis_case", "contains"],
+  ["part_definition", "part_usage", "contains"],
+  ["part_definition", "port", "contains"],
+  ["part_definition", "action", "contains"],
+  ["part_definition", "state", "contains"],
+  // Specialization
+  ["part_definition", "part_definition", "specializes"],
+  ["requirement", "requirement", "specializes"],
+  ["interface_definition", "interface_definition", "specializes"],
+  // Connection
+  ["port", "port", "connects"],
+  ["part_usage", "part_usage", "connects"],
+  ["part_definition", "interface_definition", "connects"],
+  // Satisfy / verify / refine / trace
+  ["part_definition", "requirement", "satisfies"],
+  ["part_usage", "requirement", "satisfies"],
+  ["action", "requirement", "satisfies"],
+  ["verification_case", "requirement", "verifies"],
+  ["verification_case", "constraint", "verifies"],
+  ["requirement", "requirement", "refines"],
+  ["requirement", "constraint", "refines"],
+  ["analysis_case", "requirement", "traces"],
+  ["requirement", "requirement", "traces"],
+  ["part_definition", "part_definition", "traces"],
+  // Allocation (logical obligation → realizing element)
+  ["requirement", "part_definition", "allocates"],
+  ["action", "part_definition", "allocates"],
+];
+
+// ─── DQ stage-gate rules ──────────────────────────────────────────────────────
+// Only shapes already proven in seed-ea-archimate4.ts are used here:
+//   { requires: { relationshipType, toElementType, minCount } }
+//   { requires: { relationshipType, toElementTypeOneOf: [...], minCount } }
+//   { requires: { relationshipType, fromElementType, minCount, direction: "inbound" } }
+
+type DqRuleDef = {
+  elementTypeSlug: string;
+  name: string;
+  description: string;
+  lifecycleStage: string;
+  severity: "error" | "warn";
+  rule: Prisma.InputJsonValue;
+};
+
+const DQ_RULES: DqRuleDef[] = [
+  {
+    elementTypeSlug: "verification_case",
+    name: "VerificationCase must verify a Requirement or Constraint",
+    description: "A verification case must have at least one outbound verifies relationship to a requirement or constraint before design.",
+    lifecycleStage: "design",
+    severity: "error",
+    rule: { requires: { relationshipType: "verifies", toElementTypeOneOf: ["requirement", "constraint"], minCount: 1 } },
+  },
+  {
+    elementTypeSlug: "requirement",
+    name: "Requirement should be satisfied by a design element before production",
+    description: "A requirement should have at least one inbound satisfies relationship from a part definition before its model reaches production.",
+    lifecycleStage: "production",
+    severity: "warn",
+    rule: { requires: { relationshipType: "satisfies", fromElementType: "part_definition", minCount: 1, direction: "inbound" } },
+  },
+  {
+    elementTypeSlug: "requirement",
+    name: "Requirement should have a verification case before production",
+    description: "A requirement should be verified by at least one verification case before its model reaches production.",
+    lifecycleStage: "production",
+    severity: "warn",
+    rule: { requires: { relationshipType: "verifies", fromElementType: "verification_case", minCount: 1, direction: "inbound" } },
+  },
+];
+
+// ─── Traversal patterns ───────────────────────────────────────────────────────
+
+type PatternDef = {
+  slug: string;
+  name: string;
+  description: string;
+  patternType: string;
+  steps: object[];
+  forbiddenShortcuts: string[];
+};
+
+const TRAVERSAL_PATTERNS: PatternDef[] = [
+  {
+    slug: "requirement_satisfaction",
+    name: "Requirement Satisfaction and Verification",
+    description: "Trace a requirement to the design parts that satisfy it and the verification cases that prove it.",
+    patternType: "requirement_satisfaction",
+    steps: [
+      { elementTypeSlugs: ["requirement"], refinementLevel: null, relationshipTypeSlugs: ["satisfies"], direction: "inbound" },
+      { elementTypeSlugs: ["part_definition", "part_usage", "action"], refinementLevel: null, relationshipTypeSlugs: ["allocates"], direction: "outbound" },
+      { elementTypeSlugs: ["verification_case"], refinementLevel: "actual", relationshipTypeSlugs: [], direction: "terminal" },
+    ],
+    forbiddenShortcuts: [
+      "A requirement is not proven unless a verification_case (actual refinement) verifies it",
+      "satisfies (design intent) is not the same as verifies (evidence of proof)",
+      "Do not treat allocates as satisfies — allocation assigns an obligation, satisfaction discharges it",
+    ],
+  },
+];
+
+// ─── Seed function ────────────────────────────────────────────────────────────
+
+export async function seedEaSysml2(): Promise<void> {
+  // 1. Upsert notation
+  const notation = await prisma.eaNotation.upsert({
+    where: { slug: "sysml2" },
+    update: { name: "SysML v2", version: "2.0" },
+    create: { slug: "sysml2", name: "SysML v2", version: "2.0" },
+  });
+  console.log(`Seeded EaNotation: ${notation.slug}`);
+
+  // 2. Upsert element types
+  const etMap = new Map<string, string>(); // slug → id
+  for (const et of ELEMENT_TYPES) {
+    const record = await prisma.eaElementType.upsert({
+      where: { notationId_slug: { notationId: notation.id, slug: et.slug } },
+      update: {
+        name: et.name, neoLabel: et.neoLabel, domain: et.domain,
+        description: et.description ?? null,
+        validLifecycleStages: et.stages, validLifecycleStatuses: et.statuses,
+        ontologyCategory: et.ontologyCategory ?? null,
+      },
+      create: {
+        notationId: notation.id, slug: et.slug, name: et.name,
+        neoLabel: et.neoLabel, domain: et.domain,
+        description: et.description ?? null,
+        validLifecycleStages: et.stages, validLifecycleStatuses: et.statuses,
+        ontologyCategory: et.ontologyCategory ?? null,
+      },
+    });
+    etMap.set(et.slug, record.id);
+  }
+  console.log(`Seeded ${ELEMENT_TYPES.length} EaElementTypes (sysml2)`);
+
+  // 3. Upsert relationship types
+  const rtMap = new Map<string, string>(); // slug → id
+  for (const rt of REL_TYPES) {
+    const record = await prisma.eaRelationshipType.upsert({
+      where: { notationId_slug: { notationId: notation.id, slug: rt.slug } },
+      update: { name: rt.name, neoType: rt.neoType, description: rt.description ?? null },
+      create: { notationId: notation.id, slug: rt.slug, name: rt.name, neoType: rt.neoType, description: rt.description ?? null },
+    });
+    rtMap.set(rt.slug, record.id);
+  }
+  console.log(`Seeded ${REL_TYPES.length} EaRelationshipTypes (sysml2)`);
+
+  // 4. Upsert relationship rules
+  for (const [fromSlug, toSlug, relSlug] of RULES) {
+    const fromId = etMap.get(fromSlug);
+    const toId = etMap.get(toSlug);
+    const relId = rtMap.get(relSlug);
+    if (!fromId || !toId || !relId) {
+      console.warn(`Skipping sysml2 rule ${fromSlug} -[${relSlug}]-> ${toSlug}: slug not found`);
+      continue;
+    }
+    await prisma.eaRelationshipRule.upsert({
+      where: { fromElementTypeId_toElementTypeId_relationshipTypeId: { fromElementTypeId: fromId, toElementTypeId: toId, relationshipTypeId: relId } },
+      update: {},
+      create: { fromElementTypeId: fromId, toElementTypeId: toId, relationshipTypeId: relId },
+    });
+  }
+  console.log(`Seeded ${RULES.length} EaRelationshipRules (sysml2)`);
+
+  // 5. Upsert DQ rules
+  for (const dq of DQ_RULES) {
+    const etId = etMap.get(dq.elementTypeSlug);
+    if (!etId) {
+      console.warn(`Skipping sysml2 DQ rule "${dq.name}": element type "${dq.elementTypeSlug}" not found`);
+      continue;
+    }
+    const existing = await prisma.eaDqRule.findFirst({
+      where: { notationId: notation.id, elementTypeId: etId, name: dq.name },
+    });
+    if (existing) {
+      await prisma.eaDqRule.update({
+        where: { id: existing.id },
+        data: { description: dq.description, lifecycleStage: dq.lifecycleStage, severity: dq.severity, rule: dq.rule },
+      });
+    } else {
+      await prisma.eaDqRule.create({
+        data: {
+          notationId: notation.id, elementTypeId: etId, name: dq.name,
+          description: dq.description, lifecycleStage: dq.lifecycleStage,
+          severity: dq.severity, rule: dq.rule,
+        },
+      });
+    }
+  }
+  console.log(`Seeded ${DQ_RULES.length} EaDqRules (sysml2)`);
+
+  // 6. Traversal patterns
+  for (const p of TRAVERSAL_PATTERNS) {
+    await prisma.eaTraversalPattern.upsert({
+      where: { notationId_slug: { notationId: notation.id, slug: p.slug } },
+      update: {
+        name: p.name, description: p.description, patternType: p.patternType,
+        steps: p.steps, forbiddenShortcuts: p.forbiddenShortcuts,
+      },
+      create: {
+        notationId: notation.id, slug: p.slug, name: p.name, description: p.description,
+        patternType: p.patternType, steps: p.steps, forbiddenShortcuts: p.forbiddenShortcuts,
+      },
+    });
+  }
+  console.log(`Seeded ${TRAVERSAL_PATTERNS.length} EaTraversalPatterns (sysml2)`);
+}

--- a/packages/db/src/seed-ea-viewpoints.test.ts
+++ b/packages/db/src/seed-ea-viewpoints.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./client.js", () => ({
+  prisma: {
+    eaNotation: { findUnique: vi.fn() },
+    eaElementType: { findUniqueOrThrow: vi.fn() },
+    eaRelationshipType: { findUniqueOrThrow: vi.fn() },
+    viewpointDefinition: { upsert: vi.fn() },
+  },
+}));
+
+import { prisma } from "./client.js";
+import {
+  seedViewpointsForNotation,
+  SYSML_VIEWPOINTS,
+  type ViewpointSpec,
+} from "./seed-ea-viewpoints.js";
+
+const mockPrisma = prisma as unknown as {
+  eaNotation: { findUnique: ReturnType<typeof vi.fn> };
+  eaElementType: { findUniqueOrThrow: ReturnType<typeof vi.fn> };
+  eaRelationshipType: { findUniqueOrThrow: ReturnType<typeof vi.fn> };
+  viewpointDefinition: { upsert: ReturnType<typeof vi.fn> };
+};
+
+const SAMPLE: ViewpointSpec[] = [
+  { name: "Test Viewpoint", description: "d", elementSlugs: ["requirement"], relSlugs: ["satisfies"] },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.eaElementType.findUniqueOrThrow.mockResolvedValue({ id: "et-1" });
+  mockPrisma.eaRelationshipType.findUniqueOrThrow.mockResolvedValue({ id: "rt-1" });
+  mockPrisma.viewpointDefinition.upsert.mockResolvedValue({});
+});
+
+describe("seedViewpointsForNotation", () => {
+  it("resolves slugs and upserts viewpoints when the notation exists", async () => {
+    mockPrisma.eaNotation.findUnique.mockResolvedValue({ id: "n-1" });
+    const count = await seedViewpointsForNotation("sysml2", SAMPLE);
+    expect(count).toBe(1);
+    expect(mockPrisma.eaElementType.findUniqueOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { notationId_slug: { notationId: "n-1", slug: "requirement" } } })
+    );
+    expect(mockPrisma.viewpointDefinition.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { name: "Test Viewpoint" } })
+    );
+  });
+
+  it("skips silently when an optional notation has not been seeded", async () => {
+    mockPrisma.eaNotation.findUnique.mockResolvedValue(null);
+    const count = await seedViewpointsForNotation("sysml2", SAMPLE, { optional: true });
+    expect(count).toBe(0);
+    expect(mockPrisma.viewpointDefinition.upsert).not.toHaveBeenCalled();
+  });
+
+  it("throws when a required notation is missing (seed-ordering bug)", async () => {
+    mockPrisma.eaNotation.findUnique.mockResolvedValue(null);
+    await expect(seedViewpointsForNotation("archimate4", SAMPLE)).rejects.toThrow(/required notation/);
+  });
+});
+
+describe("SYSML_VIEWPOINTS", () => {
+  it("defines the requirements/verification and decomposition/interfaces viewpoints", () => {
+    const names = SYSML_VIEWPOINTS.map((v) => v.name);
+    expect(names).toContain("Systems Requirements & Verification");
+    expect(names).toContain("System Decomposition & Interfaces");
+  });
+
+  it("only references slugs that exist in the sysml2 notation seed", () => {
+    // Guards against viewpoint drift: every slug here must be a seeded sysml2 type.
+    const elementSlugs = new Set([
+      "package", "part_definition", "part_usage", "interface_definition", "port",
+      "requirement", "constraint", "action", "state", "verification_case", "analysis_case",
+    ]);
+    const relSlugs = new Set(["contains", "specializes", "connects", "allocates", "satisfies", "verifies", "refines", "traces"]);
+    for (const vp of SYSML_VIEWPOINTS) {
+      for (const s of vp.elementSlugs) expect(elementSlugs).toContain(s);
+      for (const s of vp.relSlugs) expect(relSlugs).toContain(s);
+    }
+  });
+});

--- a/packages/db/src/seed-ea-viewpoints.ts
+++ b/packages/db/src/seed-ea-viewpoints.ts
@@ -1,0 +1,162 @@
+// packages/db/src/seed-ea-viewpoints.ts
+// Notation-aware EA viewpoint seeding.
+//
+// Extracted from seed.ts (EP per 2026-06-14 SysML substrate spec §10 Phase 1 +
+// §11 refactoring budget: "Refactor seedEaViewpoints into a reusable notation-aware
+// helper before adding SysML viewpoints"). One helper resolves element/relationship
+// type slugs against a named notation and upserts ViewpointDefinitions, so
+// ArchiMate, BPMN, and SysML all flow through the same path instead of copy-pasted
+// blocks that drift independently.
+//
+// Safe to re-run (upsert by ViewpointDefinition.name).
+
+import { prisma } from "./client.js";
+
+export type ViewpointSpec = {
+  name: string;
+  description: string;
+  elementSlugs: string[];
+  relSlugs: string[];
+};
+
+/**
+ * Seed ViewpointDefinitions for a single notation. Resolves every element- and
+ * relationship-type slug against that notation (throwing if a required notation's
+ * slug is missing — a seed-ordering bug), then upserts each viewpoint by name.
+ *
+ * @param opts.optional when true, silently skip if the notation has not been
+ *        seeded yet (used for notations that may not exist in every install).
+ * @returns the number of viewpoints seeded (0 if an optional notation is absent).
+ */
+export async function seedViewpointsForNotation(
+  notationSlug: string,
+  viewpoints: ViewpointSpec[],
+  opts: { optional?: boolean } = {},
+): Promise<number> {
+  const notation = await prisma.eaNotation.findUnique({
+    where: { slug: notationSlug },
+    select: { id: true },
+  });
+  if (!notation) {
+    if (opts.optional) {
+      console.warn(`Skipping viewpoints for notation "${notationSlug}": notation not seeded`);
+      return 0;
+    }
+    throw new Error(`seedViewpointsForNotation: required notation "${notationSlug}" not found`);
+  }
+  const nId = notation.id;
+
+  async function resolveElementSlugs(slugs: string[]): Promise<string[]> {
+    for (const slug of slugs) {
+      await prisma.eaElementType.findUniqueOrThrow({
+        where: { notationId_slug: { notationId: nId, slug } },
+        select: { id: true },
+      });
+    }
+    return slugs;
+  }
+
+  async function resolveRelSlugs(slugs: string[]): Promise<string[]> {
+    for (const slug of slugs) {
+      await prisma.eaRelationshipType.findUniqueOrThrow({
+        where: { notationId_slug: { notationId: nId, slug } },
+        select: { id: true },
+      });
+    }
+    return slugs;
+  }
+
+  for (const vp of viewpoints) {
+    const allowedElementTypeSlugs = await resolveElementSlugs(vp.elementSlugs);
+    const allowedRelTypeSlugs = await resolveRelSlugs(vp.relSlugs);
+    await prisma.viewpointDefinition.upsert({
+      where: { name: vp.name },
+      update: { description: vp.description, allowedElementTypeSlugs, allowedRelTypeSlugs },
+      create: { name: vp.name, description: vp.description, allowedElementTypeSlugs, allowedRelTypeSlugs },
+    });
+  }
+  console.log(`Seeded ${viewpoints.length} viewpoint definitions for ${notationSlug}`);
+  return viewpoints.length;
+}
+
+// ─── ArchiMate 4 viewpoints (unchanged from the original seed.ts inline list) ──
+
+export const ARCHIMATE_VIEWPOINTS: ViewpointSpec[] = [
+  {
+    name: "Application Architecture",
+    description: "Application components, services, data objects, and their relationships.",
+    elementSlugs: ["application_component", "application_service", "data_object", "technology_node", "technology_service", "system_software"],
+    relSlugs: ["realizes", "assigned_to", "composed_of", "associated_with"],
+  },
+  {
+    name: "Business Architecture",
+    description: "Business capabilities, roles, actors, and value streams.",
+    elementSlugs: ["business_capability", "business_role", "business_actor", "business_object", "value_stream", "value_stream_stage"],
+    relSlugs: ["realizes", "assigned_to", "influences", "composed_of", "associated_with"],
+  },
+  {
+    name: "Technology Architecture",
+    description: "Infrastructure nodes, services, and their deployment relationships.",
+    elementSlugs: ["technology_node", "technology_service", "system_software", "application_component"],
+    relSlugs: ["realizes", "assigned_to", "composed_of", "associated_with"],
+  },
+  {
+    name: "Capability Map",
+    description: "Business capability hierarchy.",
+    elementSlugs: ["business_capability"],
+    relSlugs: ["composed_of", "associated_with"],
+  },
+  {
+    // EP-DATA-ARCH: live ERD mirrored from the Prisma schema (data objects).
+    name: "Data Model",
+    description: "Logical data model mirrored from the Prisma schema as a live ERD.",
+    elementSlugs: ["data_object"],
+    relSlugs: ["associated_with"],
+  },
+];
+
+// ─── BPMN 2.0 viewpoints (unchanged from the original seed.ts inline list) ─────
+
+export const BPMN_VIEWPOINTS: ViewpointSpec[] = [
+  {
+    name: "Process Architecture",
+    description: "BPMN process flows with activities, gateways, events, and swimlanes. Shows who does what (AI coworker or human) and where decisions branch.",
+    elementSlugs: [
+      "bpmn_process", "bpmn_sub_process", "bpmn_service_task", "bpmn_user_task",
+      "bpmn_manual_task", "bpmn_script_task", "bpmn_business_rule_task",
+      "bpmn_exclusive_gateway", "bpmn_parallel_gateway", "bpmn_inclusive_gateway",
+      "bpmn_start_event", "bpmn_end_event", "bpmn_intermediate_throw_event", "bpmn_intermediate_catch_event",
+      "bpmn_pool", "bpmn_lane",
+      "bpmn_data_object", "bpmn_data_input", "bpmn_data_output",
+    ],
+    relSlugs: ["sequence_flow", "message_flow", "data_association", "conditional_flow", "default_flow", "association"],
+  },
+];
+
+// ─── SysML v2 viewpoints (new — 2026-06-14 SysML substrate spec §10 Phase 1) ───
+
+export const SYSML_VIEWPOINTS: ViewpointSpec[] = [
+  {
+    name: "Systems Requirements & Verification",
+    description: "SysML requirements and constraints, the design elements that satisfy them, and the verification cases that prove them. The traceability/verification viewpoint.",
+    elementSlugs: ["requirement", "constraint", "part_definition", "part_usage", "verification_case", "analysis_case"],
+    relSlugs: ["satisfies", "verifies", "refines", "traces", "allocates", "contains"],
+  },
+  {
+    name: "System Decomposition & Interfaces",
+    description: "SysML parts, ports, and interface definitions showing system structure, specialization, and connections.",
+    elementSlugs: ["package", "part_definition", "part_usage", "interface_definition", "port", "state", "action"],
+    relSlugs: ["contains", "specializes", "connects", "allocates"],
+  },
+];
+
+/**
+ * Seed all EA viewpoints across notations. ArchiMate is required (it is always
+ * seeded first); BPMN and SysML are optional so installs that have not seeded
+ * those notations yet do not fail.
+ */
+export async function seedEaViewpoints(): Promise<void> {
+  await seedViewpointsForNotation("archimate4", ARCHIMATE_VIEWPOINTS);
+  await seedViewpointsForNotation("bpmn20", BPMN_VIEWPOINTS, { optional: true });
+  await seedViewpointsForNotation("sysml2", SYSML_VIEWPOINTS, { optional: true });
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -13,6 +13,7 @@ import { seedEaReferenceModels } from "./seed-ea-reference-models.js";
 import { seedEaStructureRules } from "./seed-ea-structure-rules.js";
 import { seedEaSysml2 } from "./seed-ea-sysml2.js";
 import { seedEaSysmlAiCockpit } from "./seed-ea-sysml-ai-cockpit.js";
+import { seedEaSysmlAgentAuthority } from "./seed-ea-sysml-agent-authority.js";
 import {
   seedViewpointsForNotation,
   ARCHIMATE_VIEWPOINTS,
@@ -2415,6 +2416,7 @@ async function main(): Promise<void> {
   await step("eaViewpoints", () => seedEaViewpoints());
   await step("eaViews", () => seedEaViews());
   await step("eaSysmlAiCockpit", () => seedEaSysmlAiCockpit());
+  await step("eaSysmlAgentAuthority", () => seedEaSysmlAgentAuthority());
   await step("dpfSelfRegistration", () => seedDpfSelfRegistration());
   await step("defaultAdminUser", () => seedDefaultAdminUser());
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -11,6 +11,14 @@ import { seedEaBpmn20 } from "./seed-ea-bpmn20.js";
 import { seedEaCrossNotation } from "./seed-ea-cross-notation.js";
 import { seedEaReferenceModels } from "./seed-ea-reference-models.js";
 import { seedEaStructureRules } from "./seed-ea-structure-rules.js";
+import { seedEaSysml2 } from "./seed-ea-sysml2.js";
+import { seedEaSysmlAiCockpit } from "./seed-ea-sysml-ai-cockpit.js";
+import {
+  seedViewpointsForNotation,
+  ARCHIMATE_VIEWPOINTS,
+  BPMN_VIEWPOINTS,
+  SYSML_VIEWPOINTS,
+} from "./seed-ea-viewpoints.js";
 import { seedGovernanceReferenceData } from "./governance-seed.js";
 import { seedWorkforceReferenceData } from "./workforce-seed.js";
 import { seedStorefrontArchetypes } from "./seed-storefront-archetypes.js";
@@ -623,133 +631,13 @@ async function seedDefaultAdminUser(): Promise<void> {
 }
 
 async function seedEaViewpoints(): Promise<void> {
-  // Resolve the ArchiMate notation id (seeded in seedEaNotations)
-  const notation = await prisma.eaNotation.findUniqueOrThrow({
-    where: { slug: "archimate4" },
-    select: { id: true },
-  });
-  const nId = notation.id;
-
-  // Helper: look up element type slugs → throws if not found
-  async function resolveElementSlugs(slugs: string[]): Promise<string[]> {
-    for (const slug of slugs) {
-      await prisma.eaElementType.findUniqueOrThrow({
-        where: { notationId_slug: { notationId: nId, slug } },
-        select: { id: true },
-      });
-    }
-    return slugs;
-  }
-
-  // Helper: look up rel type slugs → throws if not found
-  async function resolveRelSlugs(slugs: string[]): Promise<string[]> {
-    for (const slug of slugs) {
-      await prisma.eaRelationshipType.findUniqueOrThrow({
-        where: { notationId_slug: { notationId: nId, slug } },
-        select: { id: true },
-      });
-    }
-    return slugs;
-  }
-
-  const viewpoints = [
-    {
-      name: "Application Architecture",
-      description: "Application components, services, data objects, and their relationships.",
-      elementSlugs: ["application_component", "application_service", "data_object", "technology_node", "technology_service", "system_software"],
-      relSlugs: ["realizes", "assigned_to", "composed_of", "associated_with"],
-    },
-    {
-      name: "Business Architecture",
-      description: "Business capabilities, roles, actors, and value streams.",
-      elementSlugs: ["business_capability", "business_role", "business_actor", "business_object", "value_stream", "value_stream_stage"],
-      relSlugs: ["realizes", "assigned_to", "influences", "composed_of", "associated_with"],
-    },
-    {
-      name: "Technology Architecture",
-      description: "Infrastructure nodes, services, and their deployment relationships.",
-      elementSlugs: ["technology_node", "technology_service", "system_software", "application_component"],
-      relSlugs: ["realizes", "assigned_to", "composed_of", "associated_with"],
-    },
-    {
-      name: "Capability Map",
-      description: "Business capability hierarchy.",
-      elementSlugs: ["business_capability"],
-      relSlugs: ["composed_of", "associated_with"],
-    },
-    {
-      // EP-DATA-ARCH: live ERD mirrored from the Prisma schema (data objects).
-      name: "Data Model",
-      description: "Logical data model mirrored from the Prisma schema as a live ERD.",
-      elementSlugs: ["data_object"],
-      relSlugs: ["associated_with"],
-    },
-  ];
-
-  for (const vp of viewpoints) {
-    const allowedElementTypeSlugs = await resolveElementSlugs(vp.elementSlugs);
-    const allowedRelTypeSlugs = await resolveRelSlugs(vp.relSlugs);
-    await prisma.viewpointDefinition.upsert({
-      where: { name: vp.name },
-      update: { description: vp.description, allowedElementTypeSlugs, allowedRelTypeSlugs },
-      create: { name: vp.name, description: vp.description, allowedElementTypeSlugs, allowedRelTypeSlugs },
-    });
-  }
-  console.log(`Seeded ${viewpoints.length} viewpoint definitions`);
-
-  // ── BPMN 2.0 viewpoints ───────────────────────────────────────────────
-  const bpmnNotation = await prisma.eaNotation.findUnique({
-    where: { slug: "bpmn20" },
-    select: { id: true },
-  });
-  if (bpmnNotation) {
-    const bpmnNId = bpmnNotation.id;
-    async function resolveBpmnElementSlugs(slugs: string[]): Promise<string[]> {
-      for (const slug of slugs) {
-        await prisma.eaElementType.findUniqueOrThrow({
-          where: { notationId_slug: { notationId: bpmnNId, slug } },
-          select: { id: true },
-        });
-      }
-      return slugs;
-    }
-    async function resolveBpmnRelSlugs(slugs: string[]): Promise<string[]> {
-      for (const slug of slugs) {
-        await prisma.eaRelationshipType.findUniqueOrThrow({
-          where: { notationId_slug: { notationId: bpmnNId, slug } },
-          select: { id: true },
-        });
-      }
-      return slugs;
-    }
-
-    const bpmnViewpoints = [
-      {
-        name: "Process Architecture",
-        description: "BPMN process flows with activities, gateways, events, and swimlanes. Shows who does what (AI coworker or human) and where decisions branch.",
-        elementSlugs: [
-          "bpmn_process", "bpmn_sub_process", "bpmn_service_task", "bpmn_user_task",
-          "bpmn_manual_task", "bpmn_script_task", "bpmn_business_rule_task",
-          "bpmn_exclusive_gateway", "bpmn_parallel_gateway", "bpmn_inclusive_gateway",
-          "bpmn_start_event", "bpmn_end_event", "bpmn_intermediate_throw_event", "bpmn_intermediate_catch_event",
-          "bpmn_pool", "bpmn_lane",
-          "bpmn_data_object", "bpmn_data_input", "bpmn_data_output",
-        ],
-        relSlugs: ["sequence_flow", "message_flow", "data_association", "conditional_flow", "default_flow", "association"],
-      },
-    ];
-
-    for (const vp of bpmnViewpoints) {
-      const allowedElementTypeSlugs = await resolveBpmnElementSlugs(vp.elementSlugs);
-      const allowedRelTypeSlugs = await resolveBpmnRelSlugs(vp.relSlugs);
-      await prisma.viewpointDefinition.upsert({
-        where: { name: vp.name },
-        update: { description: vp.description, allowedElementTypeSlugs, allowedRelTypeSlugs },
-        create: { name: vp.name, description: vp.description, allowedElementTypeSlugs, allowedRelTypeSlugs },
-      });
-    }
-    console.log("Seeded 1 BPMN viewpoint definition");
-  }
+  // Notation-aware viewpoint seeding lives in seed-ea-viewpoints.ts (2026-06-14
+  // SysML substrate spec §10 Phase 1 + §11 refactoring budget: one reusable helper
+  // instead of per-notation copy-paste). ArchiMate is required; BPMN and SysML are
+  // optional and skipped if their notation has not been seeded yet.
+  await seedViewpointsForNotation("archimate4", ARCHIMATE_VIEWPOINTS);
+  await seedViewpointsForNotation("bpmn20", BPMN_VIEWPOINTS, { optional: true });
+  await seedViewpointsForNotation("sysml2", SYSML_VIEWPOINTS, { optional: true });
 }
 
 async function seedEaViews(): Promise<void> {
@@ -2509,10 +2397,12 @@ async function main(): Promise<void> {
   await step("digitalProducts", () => seedDigitalProducts());
   await step("eaArchimate4", () => seedEaArchimate4());
   await step("eaBpmn20", () => seedEaBpmn20());
+  await step("eaSysml2", () => seedEaSysml2());
   await step("eaCrossNotation", () => seedEaCrossNotation());
   await step("eaStructureRules", () => seedEaStructureRules());
   await step("eaViewpoints", () => seedEaViewpoints());
   await step("eaViews", () => seedEaViews());
+  await step("eaSysmlAiCockpit", () => seedEaSysmlAiCockpit());
   await step("dpfSelfRegistration", () => seedDpfSelfRegistration());
   await step("defaultAdminUser", () => seedDefaultAdminUser());
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));

--- a/prompts/route-persona/ea-architect.prompt.md
+++ b/prompts/route-persona/ea-architect.prompt.md
@@ -1,9 +1,9 @@
 ---
 name: ea-architect
 displayName: Enterprise Architect
-description: Structural analysis, dependency tracing, architecture governance. ArchiMate 4 notation, implementable models.
+description: Structural analysis, dependency tracing, architecture governance across ArchiMate (structure), BPMN (process), and SysML v2 (systems requirements/verification). Implementable models.
 category: route-persona
-version: 2
+version: 3
 
 agent_id: AGT-WS-EA
 reports_to: HR-200
@@ -20,14 +20,14 @@ variables: []
 stage: ""
 sensitivity: internal
 
-perspective: "Network of components, relationships, constraints using ArchiMate 4 notation"
+perspective: "Network of components, relationships, and constraints using ArchiMate 4 (enterprise structure), BPMN 2.0 (process), and SysML v2 (systems requirements, interfaces, and verification)"
 heuristics: "Dependency tracing, pattern matching, governance enforcement, impact analysis"
 interpretiveModel: "Structural integrity and evolvability — changes don't cascade, dependencies explicit, architecture supports strategy"
 ---
 
 # Role
 
-You are the Enterprise Architect for the `/ea` route. You see the platform as a network of components, relationships, and constraints. You encode the world using ArchiMate 4 notation: nodes (elements), edges (relationships), layers (business / application / technology / strategy / motivation / implementation), and viewpoints that enforce modeling discipline.
+You are the Enterprise Architect for the `/ea` route. You see the platform as a network of components, relationships, and constraints. You encode the world using three complementary notations over one canonical EA graph: ArchiMate 4 for enterprise structure (nodes, edges, layers: business / application / technology / strategy / motivation / implementation), BPMN 2.0 for process behaviour, and SysML v2 for systems requirements, constraints, interfaces, allocations, and verification. All use viewpoints that enforce modeling discipline. Pick the smallest adequate notation for the task — ArchiMate is the default; reach for SysML when requirements, interfaces, allocations, or verification are what matters.
 
 EA models in this platform are **implementable**, not illustrative. Every element has a direct operational counterpart — a service, a database, a process, a role. A model that doesn't trace to operational reality is broken; surface that immediately.
 

--- a/prompts/specialist/architecture-definition-agent.prompt.md
+++ b/prompts/specialist/architecture-definition-agent.prompt.md
@@ -3,7 +3,7 @@ name: architecture-definition-agent
 displayName: Architecture Definition Agent
 description: Generates architectural attribute proposals + BIA inputs (SHOULD-0024). Validates against guardrails. §5.2.3.
 category: specialist
-version: 1
+version: 2
 
 agent_id: AGT-121
 reports_to: HR-300
@@ -20,7 +20,7 @@ stage: "S5.2 Explore"
 sensitivity: internal
 
 perspective: "Architecture as a structured set of attributes (component, layer, dependency, trust boundary, performance envelope) that downstream stages — Build, Deploy, Operate — execute against. BIA (Business Impact Analysis) is the architecture's commitment to operational continuity."
-heuristics: "Generate attribute proposals from product context. Validate against AGT-181's guardrails before surfacing. BIA inputs cite recovery objectives. ArchiMate 4 vocabulary is canonical."
+heuristics: "Generate attribute proposals from product context. Validate against AGT-181's guardrails before surfacing. BIA inputs cite recovery objectives. Use ArchiMate 4 for structural attributes, BPMN 2.0 for process attributes, and SysML v2 for requirements/interfaces/verification attributes (ArchiMate by default)."
 interpretiveModel: "Healthy architecture definition: every product has an attribute set; every attribute set passes guardrails; every BIA input has named recovery time / point objectives."
 ---
 
@@ -35,7 +35,7 @@ You are dispatched by AGT-ORCH-200 (Explore Orchestrator) when a PBI in §5.2 ne
 - **Architectural attribute proposals**: every product or significant feature gets a proposed set of attributes — component decomposition, layer assignment (business / application / technology), dependency map, trust boundaries, performance envelope, scalability profile.
 - **BIA inputs**: each proposal includes Business Impact Analysis inputs — Recovery Time Objective, Recovery Point Objective, criticality classification, downstream-impact map.
 - **Guardrail conformance**: proposals get pre-validated against AGT-181's guardrails. Non-conforming proposals get revised before surfacing; humans don't see proposals that fail MUST-0047-0053.
-- **ArchiMate 4 vocabulary fidelity**: nodes (elements), edges (relationships), layers — the standard's vocabulary is used. No custom shorthand.
+- **Multi-notation vocabulary fidelity**: ArchiMate 4 for structure (nodes, edges, layers), BPMN 2.0 for process, and SysML v2 for requirements/constraints/interfaces/verification — each standard's vocabulary is used, ArchiMate by default. No custom shorthand.
 - **Decision-record drafts**: each proposal ships as a `decision_record` draft with rationale, alternatives, recommended attribute set.
 
 # Interfaces With


### PR DESCRIPTION
## Summary

Implements the Odysseus-review design with SysML-grade architectural rigor, in three cohesive layers:

1. **SysML v2 architecture substrate — Phase 1** (enables the rest). Seeds the `sysml2` `EaNotation` (requirement, constraint, part-definition/usage, interface, port, action, state, verification/analysis case; relationships satisfies/verifies/allocates/refines/traces/contains/specializes/connects), refactors viewpoint seeding into a reusable **notation-aware helper** (`seed-ea-viewpoints.ts`) so ArchiMate/BPMN/SysML share one path, and bridges SysML→ArchiMate via cross-notation `sysml_allocates`/`sysml_traces`/`sysml_verifies`. Realizes Phase 1 of [`2026-06-14-sysml-architecture-substrate-design.md`](docs/superpowers/specs/2026-06-14-sysml-architecture-substrate-design.md). **No new Prisma tables** — the EA graph stays canonical (substrate-spec §3 boundary).

2. **First real SysML model — "AI Cockpit & Model Routing"** seeded as EA graph content (`seed-ea-sysml-ai-cockpit.ts`): requirements `REQ-AIC-1..9`, constraint `CON-AIC-1`, parts/interfaces/verification cases, with satisfies/verifies/refines relationships and a host view — allocated onto the existing routing + communication substrate. The platform now formally models this design as queryable data. Human-readable companion: [`2026-06-14-ai-cockpit-sysml-architecture-note.md`](docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md).

3. **Slice E1 — email triage pinned to the utility tier.** Makes the use-case routing-policy matrix *load-bearing*: `TaskRequirement` carries `budgetClassDefault`/`reasoningDepthDefault`/`residencyPolicy`, and `inferContract` honours them as defaults (explicit caller `routeContext` still wins; existing task types unchanged). Registers `email-triage`/`email-summarize`/`email-extract` at the utility tier (adequate, **never frontier**) + `minimize_cost`, and routes the marketing inbound-email classifier through `email-triage` — previously it passed no `taskType` and could land on a frontier model. This is verification case **VC-AIC-E1** of the model above.

Design basis: [`2026-06-14-odysseus-review-depth-pass.md`](docs/architecture/2026-06-14-odysseus-review-depth-pass.md) (companion to the included source review).

## Verified (source-local)

- **24 unit tests passing**: 15 in `packages/db` (idempotent SysML seed, viewpoint resolution, AI-cockpit model idempotency) + 9 in `apps/web` (email built-ins, `inferContract` posture defaults with a regression guard for existing task types).
- `packages/db` `tsc --noEmit`: **clean for all touched files** (only pre-existing `@dpf/storefront-templates` workspace-resolution artifacts remain).
- `apps/web` touched files: `request-contract.ts` and `task-router-types.ts` fully clean; `responder.ts`/`task-requirements.ts` show only the environmental "cannot find `@dpf/db`" of the deps-less worktree (resolves in CI).
- gitleaks secret scan: clean.

## Deferred (by design)

- **Runtime EA-seed validation** (seeding against a live DB + portal view rendering) — the SysML substrate spec explicitly defers runtime validation to a separate thread.
- **Full typecheck + full test suite** run in CI (pre-commit typecheck was skipped via the hook's documented `DPF_SKIP_TYPECHECK=1` because the deps-less worktree has no `tsc`/`next` binary; the secret-scan gate still ran).
- **Formal backlog anchoring**: the DPF backlog MCP is not connected in this session (consistent with the substrate spec's own note about MCP 401). Work is anchored via the design docs + `REQ-AIC-*` IDs; a BI/epic should be filed when MCP is available.

## Follow-up slices (modeled, not yet built)

`REQ-AIC-2` turn-receipt view · `REQ-AIC-3/4` escalation reason-code registry · `REQ-AIC-6` `tasks/submit` inbound→coworker · `REQ-AIC-8` OAuth mailbox transport · `REQ-AIC-9` durable thread fields. Each has a planned verification case in the architecture note.

## Note

Includes `docs/architecture/2026-06-14-odysseus-ux-routing-model-review.md` (the original review) so the doc links resolve and the PR is self-contained; it was previously uncommitted in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
