### PR TITLE
doc(superpowers): note HTML artifacts double as publishable public-site content

### DIFF
--- a/docs/superpowers/html-artifacts-guide.md
+++ b/docs/superpowers/html-artifacts-guide.md
@@ -191,6 +191,35 @@ the body — same no-hardcoded-colors discipline the portal UI follows. The
 templates ship with a palette already wired; reuse it so artifacts look like one
 family.
 
+## Side benefit: artifacts can double as public-site content
+
+The public site at [opendigitalproductfactory.com](https://opendigitalproductfactory.com)
+is a Jekyll site served from `docs/`. It already ships **one bespoke,
+self-contained HTML page** — the landing page `docs/index.html`, which is opted
+*out* of the Jekyll layout (`layout: null`) and carries its own embedded styles.
+
+The artifacts this guide produces are built the same way: **self-contained**
+(inline CSS, inline SVG, no external assets or CDN). That means a *curated*
+HTML artifact can be published to the public domain **as-is** — no Jekyll chrome,
+no template wiring, exactly the pattern `index.html` already uses. Over time,
+surfacing select design explainers, architecture overviews, or worked specs on
+the public site deepens its content and **veracity** as a long-term side effect
+of writing artifacts in this format — the same file serves the internal reader,
+the agent, and (when cleared) the public.
+
+Two honest caveats so this stays a *deliberate* act, never an automatic leak:
+
+- **`superpowers/` is currently Jekyll-excluded** (see `docs/_config.yml`
+  `exclude:`) — it holds internal specs/plans and Liquid markers that must not
+  hit the public build. Nothing under it publishes today, and that default is
+  correct.
+- **Publishing is curated and outward-facing.** Internal specs stay internal;
+  only an artifact explicitly cleared for public consumption gets surfaced
+  (e.g. copied to a public-cleared path outside the `exclude` list).
+  Self-containment makes publishing *cheap when you choose to*; it does not make
+  it the default. Treat any move that puts an artifact on the public domain as a
+  publish decision requiring review.
+
 ## Relationship to existing conventions
 
 - **Locations are unchanged.** HTML specs live in `docs/superpowers/specs/`


### PR DESCRIPTION
## What

Captures a founder observation into the HTML-artifacts doctrine (the guide added by #1867, extended by #1869 — both merged): **HTML artifacts double as publishable public-site content, expanding the public site's veracity as a long-term side effect.**

> Intended as a follow-on to #1869, but that PR had already squash-merged, so this lands as a small standalone PR against `main`. One file, +29 lines.

## The connection

- The public site at **opendigitalproductfactory.com** is a Jekyll site served from `docs/`. It already ships **one bespoke, self-contained HTML page** — `docs/index.html`, opted *out* of the Jekyll layout (`layout: null`) with its own embedded styles.
- The artifacts this convention produces are built the same way — **self-contained** (inline CSS/SVG, no external assets). So a *curated* artifact can be published to the public domain **as-is**, no Jekyll chrome, exactly the `index.html` pattern. The same file then serves the internal reader, the agent, and (when cleared) the public.

## Two honest caveats baked into the note (so it stays deliberate, never a leak)

- **`superpowers/` is currently Jekyll-excluded** (`docs/_config.yml` `exclude:`) — internal specs/plans + Liquid markers must not hit the public build. Nothing under it publishes today; that default is correct.
- **Publishing is curated and outward-facing.** Internal specs stay internal; only an artifact explicitly cleared for public consumption gets surfaced (e.g. copied to a public-cleared path outside `exclude`). Self-containment makes publishing cheap *when you choose to* — it does not make it the default.

## Verification

- One Markdown file, additive. Pre-commit secret scan: clean. No code paths or public content touched (this only documents the option; it does **not** publish anything or change `_config.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
