### PR TITLE
fix(finance): default recurring-invoice & PO line tax from org VAT (not 20%)

### DIFF
--- a/apps/web/app/(shell)/finance/invoices/new/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/new/page.tsx
@@ -1,13 +1,14 @@
 // apps/web/app/(shell)/finance/invoices/new/page.tsx
 import { prisma } from "@dpf/db";
-import { getFinancialProfile } from "@dpf/finance-templates";
 import Link from "next/link";
 import { CreateInvoiceForm } from "@/components/finance/CreateInvoiceForm";
-import { resolveInvoiceDefaultTaxRate } from "@/lib/finance/invoice-default-tax";
+import { getInvoiceDefaultTaxRate } from "@/lib/actions/financial-setup";
 import { defaultSignatureRequiredForArchetype } from "@/lib/finance/invoice-signature-default";
 
 export default async function NewInvoicePage() {
-  const [customers, taxProfile, orgSettings, storefront] = await Promise.all([
+  // Default the TAX % field from the org's wizard VAT selection, not a 20% hardcode
+  // (shared with the recurring-schedule form via getInvoiceDefaultTaxRate).
+  const [customers, storefront, defaultTaxRate] = await Promise.all([
     prisma.customerAccount.findMany({
       where: {
         status: { in: ["active", "prospect", "qualified", "onboarding"] },
@@ -20,22 +21,11 @@ export default async function NewInvoicePage() {
         currency: true,
       },
     }),
-    prisma.organizationTaxProfile.findFirst({ select: { taxModel: true } }),
-    prisma.orgSettings.findFirst({ select: { appliedProfileSlug: true } }),
     prisma.storefrontConfig.findFirst({
       select: { archetype: { select: { archetypeId: true } } },
     }),
+    getInvoiceDefaultTaxRate(),
   ]);
-
-  // Default the TAX % field from the org's wizard VAT selection, not a 20% hardcode.
-  const financeProfile = orgSettings?.appliedProfileSlug
-    ? getFinancialProfile(orgSettings.appliedProfileSlug)
-    : null;
-  const defaultTaxRate = resolveInvoiceDefaultTaxRate({
-    taxModel: taxProfile?.taxModel ?? null,
-    profileVatRegistered: financeProfile?.vatRegistered ?? null,
-    profileDefaultTaxRate: financeProfile?.defaultTaxRate ?? null,
-  });
 
   // Default "require signature" on for regulated archetypes (legal/accounting).
   const defaultSignatureRequired = defaultSignatureRequiredForArchetype(

--- a/apps/web/app/(shell)/finance/purchase-orders/new/page.tsx
+++ b/apps/web/app/(shell)/finance/purchase-orders/new/page.tsx
@@ -6,6 +6,10 @@ import Link from "next/link";
 
 type Props = { searchParams: Promise<{ supplierId?: string }> };
 
+// Purchase orders are accounts-payable, like bills: line items default to 0% tax.
+// An operator who needs tax sets it per line. Fixed default, mirrors bills/new.
+const DEFAULT_PO_TAX_RATE = 0;
+
 export default async function NewPOPage({ searchParams }: Props) {
   const { supplierId } = await searchParams;
 
@@ -44,6 +48,7 @@ export default async function NewPOPage({ searchParams }: Props) {
           }))}
           {...(supplierId ? { defaultSupplierId: supplierId } : {})}
           defaultCurrency={orgSettings.baseCurrency}
+          defaultTaxRate={DEFAULT_PO_TAX_RATE}
         />
       </div>
     </div>

--- a/apps/web/app/(shell)/finance/recurring/new/page.tsx
+++ b/apps/web/app/(shell)/finance/recurring/new/page.tsx
@@ -2,20 +2,26 @@
 import { prisma } from "@dpf/db";
 import Link from "next/link";
 import { CreateRecurringForm } from "@/components/finance/CreateRecurringForm";
+import { getInvoiceDefaultTaxRate } from "@/lib/actions/financial-setup";
 
 export default async function NewRecurringPage() {
-  const customers = await prisma.customerAccount.findMany({
-    where: {
-      status: { in: ["active", "prospect", "qualified", "onboarding"] },
-    },
-    orderBy: { name: "asc" },
-    select: {
-      id: true,
-      accountId: true,
-      name: true,
-      currency: true,
-    },
-  });
+  // Recurring schedules generate customer invoices, so default tax the same way
+  // a one-off invoice does — from the org's VAT selection, not a 20% hardcode.
+  const [customers, defaultTaxRate] = await Promise.all([
+    prisma.customerAccount.findMany({
+      where: {
+        status: { in: ["active", "prospect", "qualified", "onboarding"] },
+      },
+      orderBy: { name: "asc" },
+      select: {
+        id: true,
+        accountId: true,
+        name: true,
+        currency: true,
+      },
+    }),
+    getInvoiceDefaultTaxRate(),
+  ]);
 
   return (
     <div>
@@ -48,7 +54,7 @@ export default async function NewRecurringPage() {
         </p>
       </div>
 
-      <CreateRecurringForm customers={customers} />
+      <CreateRecurringForm customers={customers} defaultTaxRate={defaultTaxRate} />
     </div>
   );
 }

--- a/apps/web/components/finance/CreatePOForm.tsx
+++ b/apps/web/components/finance/CreatePOForm.tsx
@@ -26,13 +26,15 @@ interface Props {
   suppliers: Supplier[];
   defaultSupplierId?: string;
   defaultCurrency?: string;
+  /** Org default line-item tax rate (%). 0 for AP (mirrors bills); operator sets per line. */
+  defaultTaxRate?: number;
 }
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
-export function CreatePOForm({ suppliers, defaultSupplierId, defaultCurrency }: Props) {
+export function CreatePOForm({ suppliers, defaultSupplierId, defaultCurrency, defaultTaxRate = 0 }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,7 +45,7 @@ export function CreatePOForm({ suppliers, defaultSupplierId, defaultCurrency }: 
   const [terms, setTerms] = useState("");
   const [notes, setNotes] = useState("");
   const [lineItems, setLineItems] = useState<LineItem[]>([
-    { description: "", quantity: 1, unitPrice: 0, taxRate: 20 },
+    { description: "", quantity: 1, unitPrice: 0, taxRate: defaultTaxRate },
   ]);
 
   const handleSupplierChange = useCallback(
@@ -60,7 +62,7 @@ export function CreatePOForm({ suppliers, defaultSupplierId, defaultCurrency }: 
   const addLineItem = () => {
     setLineItems((prev) => [
       ...prev,
-      { description: "", quantity: 1, unitPrice: 0, taxRate: 20 },
+      { description: "", quantity: 1, unitPrice: 0, taxRate: defaultTaxRate },
     ]);
   };
 

--- a/apps/web/components/finance/CreateRecurringForm.tsx
+++ b/apps/web/components/finance/CreateRecurringForm.tsx
@@ -32,6 +32,8 @@ interface Customer {
 
 interface Props {
   customers: Customer[];
+  /** Org default line-item tax rate (%). 0 unless the org is VAT/GST registered. */
+  defaultTaxRate?: number;
 }
 
 function round2(n: number): number {
@@ -42,7 +44,7 @@ function getTodayDate(): string {
   return new Date().toISOString().split("T")[0]!;
 }
 
-export function CreateRecurringForm({ customers }: Props) {
+export function CreateRecurringForm({ customers, defaultTaxRate = 0 }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +58,7 @@ export function CreateRecurringForm({ customers }: Props) {
   const [templateNotes, setTemplateNotes] = useState("");
   const [currency, setCurrency] = useState("GBP");
   const [lineItems, setLineItems] = useState<LineItem[]>([
-    { description: "", quantity: 1, unitPrice: 0, taxRate: 20 },
+    { description: "", quantity: 1, unitPrice: 0, taxRate: defaultTaxRate },
   ]);
 
   const handleCustomerChange = useCallback(
@@ -73,7 +75,7 @@ export function CreateRecurringForm({ customers }: Props) {
   const addLineItem = () => {
     setLineItems((prev) => [
       ...prev,
-      { description: "", quantity: 1, unitPrice: 0, taxRate: 20 },
+      { description: "", quantity: 1, unitPrice: 0, taxRate: defaultTaxRate },
     ]);
   };
 

--- a/apps/web/lib/actions/financial-setup.test.ts
+++ b/apps/web/lib/actions/financial-setup.test.ts
@@ -15,6 +15,7 @@ vi.mock("@dpf/db", () => ({
     },
     organizationTaxProfile: {
       upsert: vi.fn(),
+      findFirst: vi.fn(),
     },
   },
 }));
@@ -25,7 +26,11 @@ vi.mock("@/lib/actions/dunning", () => ({
 
 import { prisma } from "@dpf/db";
 import { seedDefaultDunningSequence } from "@/lib/actions/dunning";
-import { applyFinancialProfile, getFinancialSetupStatus } from "./financial-setup";
+import {
+  applyFinancialProfile,
+  getFinancialSetupStatus,
+  getInvoiceDefaultTaxRate,
+} from "./financial-setup";
 
 const mockPrisma = prisma as unknown as {
   orgSettings: {
@@ -41,6 +46,7 @@ const mockPrisma = prisma as unknown as {
   };
   organizationTaxProfile: {
     upsert: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
   };
 };
 const mockSeedDunning = vi.mocked(seedDefaultDunningSequence);
@@ -194,5 +200,47 @@ describe("getFinancialSetupStatus", () => {
     const result = await getFinancialSetupStatus();
 
     expect(result.baseCurrency).toBe("EUR");
+  });
+});
+
+// ─── getInvoiceDefaultTaxRate ───────────────────────────────────────────────
+
+describe("getInvoiceDefaultTaxRate", () => {
+  it("uses the profile rate when the org tax model is 'vat'", async () => {
+    mockPrisma.organizationTaxProfile.findFirst.mockResolvedValue({ taxModel: "vat" });
+    mockPrisma.orgSettings.findFirst.mockResolvedValue(
+      makeSettings({ appliedProfileSlug: "trades_construction" }), // VAT-registered, 20%
+    );
+    expect(await getInvoiceDefaultTaxRate()).toBe(20);
+  });
+
+  it("returns 0 when the org tax model is 'none' even if the profile is VAT-registered", async () => {
+    mockPrisma.organizationTaxProfile.findFirst.mockResolvedValue({ taxModel: "none" });
+    mockPrisma.orgSettings.findFirst.mockResolvedValue(
+      makeSettings({ appliedProfileSlug: "trades_construction" }),
+    );
+    expect(await getInvoiceDefaultTaxRate()).toBe(0);
+  });
+
+  it("falls back to a VAT-registered applied profile when no tax-profile row exists", async () => {
+    mockPrisma.organizationTaxProfile.findFirst.mockResolvedValue(null);
+    mockPrisma.orgSettings.findFirst.mockResolvedValue(
+      makeSettings({ appliedProfileSlug: "trades_construction" }),
+    );
+    expect(await getInvoiceDefaultTaxRate()).toBe(20);
+  });
+
+  it("falls back to a non-VAT applied profile (→ 0) when no tax-profile row exists", async () => {
+    mockPrisma.organizationTaxProfile.findFirst.mockResolvedValue(null);
+    mockPrisma.orgSettings.findFirst.mockResolvedValue(
+      makeSettings({ appliedProfileSlug: "healthcare_wellness" }), // not VAT-registered, 0%
+    );
+    expect(await getInvoiceDefaultTaxRate()).toBe(0);
+  });
+
+  it("returns 0 when neither a tax profile nor an applied profile exists", async () => {
+    mockPrisma.organizationTaxProfile.findFirst.mockResolvedValue(null);
+    mockPrisma.orgSettings.findFirst.mockResolvedValue(null);
+    expect(await getInvoiceDefaultTaxRate()).toBe(0);
   });
 });

--- a/apps/web/lib/actions/financial-setup.ts
+++ b/apps/web/lib/actions/financial-setup.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@dpf/db";
 import { getFinancialProfile } from "@dpf/finance-templates";
 import { seedDefaultDunningSequence } from "@/lib/actions/dunning";
+import { resolveInvoiceDefaultTaxRate } from "@/lib/finance/invoice-default-tax";
 
 // ─── applyFinancialProfile ────────────────────────────────────────────────────
 
@@ -80,4 +81,27 @@ export async function getFinancialSetupStatus(): Promise<{
     baseCurrency: settings.baseCurrency,
     dunningActive: dunningSequence !== null,
   };
+}
+
+// ─── getInvoiceDefaultTaxRate ─────────────────────────────────────────────────
+
+/**
+ * Default line-item tax rate (%) for a new customer invoice or recurring
+ * schedule, derived from the org's VAT selection rather than a hardcoded 20.
+ * Shared by the invoice and recurring-schedule new-forms so the two cannot
+ * drift. See lib/finance/invoice-default-tax.ts for the pure resolution rules.
+ */
+export async function getInvoiceDefaultTaxRate(): Promise<number> {
+  const [taxProfile, settings] = await Promise.all([
+    prisma.organizationTaxProfile.findFirst({ select: { taxModel: true } }),
+    prisma.orgSettings.findFirst({ select: { appliedProfileSlug: true } }),
+  ]);
+  const profile = settings?.appliedProfileSlug
+    ? getFinancialProfile(settings.appliedProfileSlug)
+    : null;
+  return resolveInvoiceDefaultTaxRate({
+    taxModel: taxProfile?.taxModel ?? null,
+    profileVatRegistered: profile?.vatRegistered ?? null,
+    profileDefaultTaxRate: profile?.defaultTaxRate ?? null,
+  });
 }

--- a/docs/testing/archetype-audit-plan.md
+++ b/docs/testing/archetype-audit-plan.md
@@ -686,10 +686,11 @@ Apply this checklist to every archetype within a run. Log findings in Section 8 
 
 > Regression guard for the three invoice gaps that Runs 6 & 7 surfaced. Run after Phase G. **G-REG-2** is a common platform mechanic `[C]` (evaluate once, in Run 0); **G-REG-1** and **G-REG-3** are archetype-conditional `[A]` — the expected value depends on the run's VAT status and archetype. Record evidence as **drove X → observed Y → signed off / DEFECT Z**, not screenshots.
 
-- [ ] **G-REG-1** `[A]` *(tax default — Gap 1)* On a fresh `/finance/invoices/new`, read the default **TAX %** on the first (empty) line item **before typing anything**, then add a second line and confirm it inherits the same default.
+- [ ] **G-REG-1** `[A]` *(tax default — Gap 1)* On a fresh `/finance/invoices/new` **and `/finance/recurring/new`** (both are customer/AR forms), read the default **TAX %** on the first (empty) line item **before typing anything**, then add a second line and confirm it inherits the same default.
   - *No-VAT org* (operator chose "No VAT" in setup → `OrganizationTaxProfile.taxModel = none`; most US installs and non-VAT archetypes): expect **0**.
   - *VAT-registered org* (`taxModel = vat` — e.g. legal-services, accounting, trades): expect the standard rate from the applied finance profile (e.g. **20** for UK professional services; **0** for VAT-exempt industries such as healthcare).
-  - **DEFECT** if a No-VAT org shows a hardcoded **20** (the original Runs 6 & 7 finding).
+  - *Accounts-payable forms* (`/finance/bills/new`, `/finance/purchase-orders/new`): expect a fixed **0** default regardless of VAT status (operator sets tax per line).
+  - **DEFECT** if any of the four forms shows a hardcoded **20** on a No-VAT org (the original Runs 6 & 7 finding; AR forms fixed in PR #1865, recurring/PO forms in the follow-up).
 
 - [ ] **G-REG-2** `[C]` *(Send Invoice with no SMTP — Gap 2)* On a saved invoice detail page with **no SMTP configured** (fresh-install default), click **Send Invoice**. *Expect:* an operator-visible inline error — "Email delivery is not configured…" (HTTP 422) — **and the invoice status stays draft/approved (NOT flipped to "sent")**. **DEFECT** if the click silently succeeds ("Sent!") with no email, or returns an opaque 500. *(If SMTP has been configured on the install, record N/A.)*
 


### PR DESCRIPTION
Completes the Runs 6 & 7 tax-default gap. [PR #1865](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1865) fixed the hardcoded 20% TAX default on the one-off invoice form, but a thoroughness sweep found **two more finance line-item forms with the same `taxRate: 20` hardcode**:

| Form | Type | Before | After |
|---|---|---|---|
| `CreateInvoiceForm` | AR (invoice) | ✅ fixed in #1865 | from org VAT |
| `CreateBillForm` | AP (bill) | ✅ already 0% | 0% |
| **`CreateRecurringForm`** | AR (recurring invoices) | ❌ hardcoded 20 | **from org VAT** |
| **`CreatePOForm`** | AP (purchase orders) | ❌ hardcoded 20 | **0% (mirrors bills)** |

## Changes
- Extracts **`getInvoiceDefaultTaxRate()`** into `lib/actions/financial-setup.ts` — one DB→resolver path shared by the invoice and recurring-schedule forms (the invoice page is refactored onto it, so the logic can't drift). Recurring invoices bill customers, so they default tax the same way one-off invoices do.
- `CreatePOForm` gains a `defaultTaxRate` prop defaulted to **0** (`DEFAULT_PO_TAX_RATE`), matching the accounts-payable decision already in `bills/new` (#1759).
- Unit tests for `getInvoiceDefaultTaxRate` (vat → rate, none → 0, no-profile bootstrap fallbacks, empty → 0).

## Verification
- ✅ 28 unit tests pass (`financial-setup.test.ts` + `invoice-default-tax.test.ts`).
- ✅ No type errors in the changed files (CI Typecheck is binding — deps-less worktree resolves `@dpf/db` to the root clone's client, so the only local errors are unrelated pre-existing env noise in untouched files).
- Functional verification of the TAX % pre-fill on these forms is covered by the audit plan's **Phase G-REG-1** (I'll extend it to name the recurring and PO forms too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
