### PR TITLE
feat(kernel): Optimize for the Whole — commandment + enforced in design validation

### DIFF
--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -31,6 +31,20 @@ describe("buildDesignReviewPrompt", () => {
     expect(prompt).toContain("JSON FORMAT");
   });
 
+  it("gates on whole-outcome alignment per the Optimize for the Whole commandment", () => {
+    const prompt = buildDesignReviewPrompt({
+      problemStatement: "Users need filtering",
+      existingCodeAudit: "No existing filter",
+      reusePlan: "Reuse OpsClient pattern",
+      proposedApproach: "Add checkbox filter",
+      acceptanceCriteria: ["Filter hides done items"],
+    }, "Test project");
+    // The design review must ask which end-to-end outcome the change serves —
+    // local correctness alone is not "done".
+    expect(prompt).toContain("WHOLE-OUTCOME ALIGNMENT");
+    expect(prompt).toContain("Optimize for the Whole");
+  });
+
   // BI-CE49D82E — Delta-aware design review prompt, mirror of the plan path
   // added in BI-4396EFEC (D38). Live repro that drove this fix: FB-5E20E793
   // (Voice Slice 1.6) looped on the same "missing accessibility section"
@@ -501,6 +515,8 @@ describe("buildArchitectureReviewPrompt", () => {
     expect(prompt).toContain("ArchitectureReview table");
     // The chief-architect lens must invite reference-doc feedback.
     expect(prompt).toContain("[reference-doc]");
+    // Whole-over-local is a first-class architectural-alignment concern.
+    expect(prompt).toContain("Optimize for the Whole");
     expect(prompt).toContain("JSON FORMAT");
   });
 
@@ -523,6 +539,12 @@ describe("buildArchitectureReviewPrompt", () => {
   it("exposes the reference standards as a non-empty, repo-relative list", () => {
     expect(ARCHITECTURE_REVIEW_REFERENCES.length).toBeGreaterThan(0);
     expect(ARCHITECTURE_REVIEW_REFERENCES.map((r) => r.path)).toContain("AGENTS.md");
+    // The Optimize-for-the-Whole commandment is among the kernel principles the
+    // architect lens measures a spec against.
+    const kernel = ARCHITECTURE_REVIEW_REFERENCES.find(
+      (r) => r.path === "docs/founder-kernel/wiki/principles/",
+    );
+    expect(kernel?.covers).toContain("optimize-for-the-whole");
   });
 });
 

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -68,6 +68,7 @@ REVIEW CHECKLIST — evaluate EVERY item before responding:
 7. Are acceptance criteria testable and specific?
 ${hasUI ? `8. Does the design's "Accessibility" field explicitly address a11y? (semantic HTML, keyboard operability, ARIA labels, visible focus, color-not-sole-conveyor.) If the Accessibility field is present and covers these points, accept it — do NOT re-demand the same criteria as a failure reason. If the Accessibility field is missing or says "Not applicable" despite obvious UI surface, THAT's a critical issue.` : `8. (Accessibility review skipped — this feature has no user-facing UI components.)`}
 9. If reusabilityAnalysis exists and scope is "parameterizable", does the proposed approach actually parameterize the identified domain entities? Flag any entity listed in domainEntities that appears hardcoded in the proposedApproach rather than stored as configuration.
+10. WHOLE-OUTCOME ALIGNMENT (per the "Optimize for the Whole" commandment): does the design name the end-to-end outcome — the user objective or value stream — it serves, and is the proposed approach the right thing for that whole, not a local optimization that advances one step at the whole's expense? A small or local change can state its served outcome briefly. Reserve "critical" only for a design that demonstrably degrades the broader objective in order to win locally; use "important" when the served outcome is simply unstated or only weakly connected to the approach.
 
 SEVERITY CALIBRATION: Use "critical" ONLY for issues that would cause data loss, security vulnerabilities, or broken functionality. Use "important" for design gaps that should be addressed but don't block implementation. Use "minor" for style, naming, or nice-to-have improvements. A health endpoint or simple utility does NOT need the same rigor as a payment system — calibrate accordingly.
 
@@ -196,7 +197,7 @@ export const ARCHITECTURE_REVIEW_REFERENCES: ReadonlyArray<{
     label: "Kernel principles",
     path: "docs/founder-kernel/wiki/principles/",
     covers:
-      "architecture-over-shortcuts, single-source-of-truth, schema-audit-before-features, organization-canonical-identity, principal-convergence",
+      "optimize-for-the-whole, architecture-over-shortcuts, single-source-of-truth, schema-audit-before-features, organization-canonical-identity, principal-convergence",
   },
   {
     label: "Platform usability standards",
@@ -262,7 +263,8 @@ export function buildArchitectureReviewPrompt(
   const artifactLabel = input.kind === "design" ? "design document" : "implementation plan";
   const focus =
     input.kind === "design"
-      ? `- Does the data model EXTEND canonical models (Organization for identity, Principal/PrincipalAlias for identity-bearing entities) rather than create parallel tables?
+      ? `- Does this serve the end-to-end outcome / value stream it belongs to, rather than locally optimizing one step at the whole's expense? The design should name the broader objective it advances (Optimize for the Whole).
+- Does the data model EXTEND canonical models (Organization for identity, Principal/PrincipalAlias for identity-bearing entities) rather than create parallel tables?
 - Does the proposed approach respect single-source-of-truth (no rule/fact/decision duplicated)?
 - Does it choose the architecturally sound shape over a shortcut that creates debt?
 - Are string-enum columns aligned with the canonical enum registry (hyphens, not underscores)?

--- a/docs/founder-kernel/wiki/principles/optimize-for-the-whole.md
+++ b/docs/founder-kernel/wiki/principles/optimize-for-the-whole.md
@@ -1,0 +1,52 @@
+---
+title: Optimize for the Whole
+pageKind: principle
+status: published
+abstract: Validate every local function — human, AI, or application — against the end-to-end outcome it serves; a change that optimizes one step while degrading the whole is rejected, however good it looks locally.
+principleTier: commandment
+principleDirection: Balance every local function against the end-to-end outcome it serves, and reject local optimizations that degrade the whole.
+principleDimensionVector: {"long_term_maintainability": 1.0, "reusability": 0.6, "governance_compliance": 0.7, "speed_to_value": -0.5}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - universal-ring
+principleConsumerArchetype: universal
+principlePublic: true
+principlePublicRationale: This is DPF's founding thesis. The platform exists to stop local optimization from forsaking the whole outcome — the systemic gap that IT4IT value streams and CSDM coherence were created to close. Adopters must know the platform balances every local function, human or machine, against the end-to-end objective.
+sources:
+  - frameworks/it4it-v3
+  - frameworks/csdm
+  - articles/possible-futures-enterprise-architecture
+---
+
+## Rule
+
+Every local function — a button, an agent, a feature, a query, a team's budget request — is validated against the end-to-end outcome it serves. When a local optimum conflicts with the whole, the whole wins. A change that advances one step while degrading the broader objective is rejected, however good it looks in isolation.
+
+## Why
+
+This is the chronic, systemic failure the platform exists to mitigate: a part is optimized in a way that forsakes the whole. It is the same failure in every layer. In IT, a tool optimizes its own function and the end-to-end value stream breaks at the seams between tools — the gap [IT4IT](../../raw-sources/frameworks/it4it-v3.md) closes by making the *value stream*, not the function, the unit of design. In data, each application models services its own local way and the enterprise loses a coherent picture — the gap [CSDM](../../raw-sources/frameworks/csdm.md) closes by making one common model the authority. In organizations, a leader advocates for their function's funding and the portfolio tilts to a locally-optimal, globally-lopsided allocation. The mechanism is identical; only the actor changes.
+
+Local optimization is seductive because it is *legible and immediate* — the local step measurably improves, and the cost lands somewhere else, later, diffusely, on the whole. So it is chosen by default unless something holds the whole as the explicit counterweight. That counterweight is this principle. A platform built to mitigate this failure at scale must, above all, not commit it itself: every local function it ships — and every local decision its coworkers make — is answerable to the broader outcome.
+
+## Applies To
+
+Universal and symmetric: in-platform coworkers, external coding agents, and humans setting direction. It governs software design (a feature must serve the value stream, not just pass its own checklist), data design (one canonical model over per-surface locals), agent topology (the orchestrator owns the whole outcome; workers own steps), capacity and budget allocation (fund the portfolio outcome, not the loudest function), and UX (optimize the user's end-to-end objective, not the local screen). It does **not** forbid local excellence — a step should be done well — but local excellence is necessary, never sufficient: it must also advance the whole. The exception is named and tracked, not silent: when a deliberate local trade-off is taken for a stated reason, record the whole-outcome cost it accepts.
+
+## How To Apply
+
+Before accepting any change or decision, name the end-to-end outcome it serves — the value stream, the user objective, the epic goal, the portfolio result — and check that the local move advances *that*, not merely its own step. If a local optimization would degrade the whole, surface the trade-off explicitly and prefer the whole; do not let the legible local win quietly override the diffuse global cost. In review and validation gates, treat "does this serve the whole outcome?" as a first-class criterion alongside local correctness — a design that is locally sound but unmoored from the outcome it was meant to advance is not done. When you cannot see the whole an artifact serves, that absence is itself the finding.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 1.0` — whole-system coherence *is* long-term maintainability; locally-optimized parts are exactly what erode it over time.
+- `governance_compliance: 0.7` — this is a governance balance: the whole-outcome is the standard every local actor is held to, so the principle pulls strongly toward governed, outcome-anchored decisions.
+- `reusability: 0.6` — designing for the whole favors shared, coherent substrate over per-local duplication, which is what makes parts reusable across the system.
+- `speed_to_value: -0.5` — explicitly negative. Holding the whole as the counterweight costs throughput on the local step now; the payback is the end-to-end outcome not breaking later.
+
+## Examples
+
+- **Positive:** Local model calibration was made automatic at provider activation rather than a button an operator must remember. The local "feature" (a calibrate action) was subordinated to the whole outcome (a coworker that reliably works on a fresh install) — so the step that could be skipped was removed, not merely guarded. Designing for the whole user outcome, not the local screen, is the same move generalized: collapse a provider-config surface to one authenticate action plus a self-healing pipeline, because the user's objective is "AI that works," not "a configured providers page."
+- **Counterexample:** A CI suite that runs every test but gates merge on only a subset, so a green-on-the-required-checks PR merges with red tests and breaks `main` — a check optimized for its local job (it *ran*) that failed the whole (it did not *gate*). Equivalently: a design review that validates a feature's local checklist (problem statement, acceptance criteria, reuse) but never asks which end-to-end value stream the feature advances, letting locally-perfect, globally-orphaned work pass.


### PR DESCRIPTION
Makes the platform's founding thesis **first-class and enforced**: no local function — human, AI, or application — may be optimized in a way that forsakes the end-to-end outcome. This is the IT4IT value-stream / CSDM coherence gap the founder's career has been about closing, and it was **not yet a kernel principle** (the closest — `one-data-model`, `architecture-over-shortcuts`, `diversity-of-thought` — are instances of it, not the universal rule).

The sharper finding that motivated this: **the platform had the exact gap it exists to close, in its own build pipeline.** IT4IT value streams are modeled (portfolios + 43 agents mapped, Neo4j labels, reference model seeded) — but the design-validation gates validated *local* correctness and never asked which end-to-end outcome a change serves. A locally-sound, outcome-orphaned design could pass.

## What this delivers

**1. New commandment principle** — `docs/founder-kernel/wiki/principles/optimize-for-the-whole.md`. Universal (coworkers + external agents + humans), public, cites `frameworks/it4it-v3`, `frameworks/csdm`, `articles/possible-futures-enterprise-architecture`. Recalled into every coworker/agent prompt via the existing principle-recall path, so it governs decisions everywhere — not just docs.

**2. Enforced in design validation** (`apps/web/lib/integrate/build-reviewers.ts`):
- Added to `ARCHITECTURE_REVIEW_REFERENCES` so the Enterprise Architect lens measures specs against it.
- New **gating** checklist item in the design review: a design must name the end-to-end outcome / value stream it serves; local correctness alone is no longer "done".
- A whole-vs-local focus bullet in the architecture advisory.

**3. First design authored under the gate** — `docs/superpowers/specs/2026-06-14-whole-outcome-provider-activation-design.html` (HTML + SysML v2). The "zero-touch provider activation" proof case, governed by the new commandment: it names its whole outcome (working AI for the user's objective, not a configured page), and frames **zero as aspirational/directional** — a trend in required-human-steps and opportunities-to-fail, never an absolute to game. It also specs the outcome-traceability substrate the requirements half needs (`Epic.expectedOutcome`, BacklogItem → value stream). Self-demonstrating: it passes the new gate by naming its outcome.

## Verification

- `build-reviewers` 42/42 (3 new assertions lock in the criterion).
- Kernel + wiki validators 128/128 (frontmatter, kernel seed, lint, public-safety, wired-commandments) — the new commandment page passes all governance checks.

## Follow-on (filed via portal — no backlog MCP in the authoring session)

The spec's **build** (collapse the happy path; single blocking failure state; `Epic.expectedOutcome` schema + backlog→value-stream link; promote outcome-alignment from advisory to hard gate; activate the dormant IT4IT orchestrators) enters Build Studio as a backlog item once filed through the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)