### PR TITLE
feat(ea): schedule the SysML projection reconcile — activate the auto-extractors (Parity Engine)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => ({
   toolsToOpenAIFormat: vi.fn(),
   executeTool: vi.fn(),
   governedExecuteTool: vi.fn(),
+  reconcileSysmlProjections: vi.fn(),
 }));
 
 vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
@@ -52,6 +53,7 @@ vi.mock("@dpf/db", () => ({
   // The const must be exported from the mock or vitest throws on access; none of
   // these tests use the mirror task id, so any non-matching value is fine.
   DATA_MODEL_MIRROR_TASK_ID: "data-model-mirror-nightly",
+  SYSML_PROJECTION_TASK_ID: "sysml-projection-nightly",
 }));
 vi.mock("@/lib/tak/agent-routing-server", () => ({
   resolveAgentForRouteWithPrompts: mocks.resolveAgentForRouteWithPrompts,
@@ -67,6 +69,9 @@ vi.mock("@/lib/mcp-tools", () => ({
 }));
 vi.mock("@/lib/mcp-governed-execute", () => ({
   governedExecuteTool: mocks.governedExecuteTool,
+}));
+vi.mock("@/lib/ea/reconcile-sysml-projections", () => ({
+  reconcileSysmlProjections: mocks.reconcileSysmlProjections,
 }));
 
 import {
@@ -753,6 +758,53 @@ describe("executeScheduledAgentTask TaskRun lifecycle", () => {
       "external-catalog-scout",
       expect.objectContaining({
         userId: "user-1",
+      }),
+    );
+  });
+});
+
+describe("executeScheduledAgentTask — SysML projection reconcile branch", () => {
+  it("runs the deterministic reconcile directly (no LLM loop) and records ok status", async () => {
+    mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+      taskId: "sysml-projection-nightly",
+      isActive: true,
+      schedule: "0 4 * * *",
+    });
+    mocks.reconcileSysmlProjections.mockResolvedValue({
+      mcpAuthority: { status: "applied", created: 0, updated: 304, removed: 0, toolCount: 248, grantCount: 54 },
+      coworkerAuthority: { status: "applied", created: 0, updated: 64, removed: 0 },
+    });
+    mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
+    mocks.prisma.scheduledJob.update.mockResolvedValue({});
+
+    await executeScheduledAgentTask("sysml-projection-nightly");
+
+    expect(mocks.reconcileSysmlProjections).toHaveBeenCalledOnce();
+    expect(mocks.runAgenticLoop).not.toHaveBeenCalled();
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "sysml-projection-nightly" },
+        data: expect.objectContaining({ lastStatus: "ok", lastError: null }),
+      }),
+    );
+  });
+
+  it("records error status when the reconcile throws", async () => {
+    mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+      taskId: "sysml-projection-nightly",
+      isActive: true,
+      schedule: "0 4 * * *",
+    });
+    mocks.reconcileSysmlProjections.mockRejectedValue(new Error("notation missing"));
+    mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
+    mocks.prisma.scheduledJob.update.mockResolvedValue({});
+
+    await executeScheduledAgentTask("sysml-projection-nightly");
+
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "sysml-projection-nightly" },
+        data: expect.objectContaining({ lastStatus: "error", lastError: "notation missing" }),
       }),
     );
   });

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -1,9 +1,10 @@
 "use server";
 
 import { auth } from "@/lib/auth";
-import { prisma, DATA_MODEL_MIRROR_TASK_ID } from "@dpf/db";
+import { prisma, DATA_MODEL_MIRROR_TASK_ID, SYSML_PROJECTION_TASK_ID } from "@dpf/db";
 import { randomUUID } from "crypto";
 import { runDataModelMirror } from "@/lib/ea/run-data-model-mirror";
+import { reconcileSysmlProjections } from "@/lib/ea/reconcile-sysml-projections";
 import { extractScheduledTaskSummary } from "./agent-task-scheduler-summary";
 import {
   createTaskRunForScheduledTask,
@@ -208,6 +209,42 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         JSON.stringify(result.mirror.status),
         result.mirror.summary.created,
         result.steward.created,
+      );
+      const nextRunAt = computeNextCronRun(task.schedule, startedAt);
+      await prisma.scheduledAgentTask.update({
+        where: { taskId },
+        data: { lastRunAt: startedAt, lastStatus: "ok", lastError: null, nextRunAt },
+      });
+      await prisma.scheduledJob
+        .update({ where: { jobId: taskId }, data: { lastRunAt: startedAt, lastStatus: "ok", lastError: null, nextRunAt } })
+        .catch(() => {});
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : "unknown error";
+      const nextRunAt = computeNextCronRun(task.schedule, startedAt);
+      await prisma.scheduledAgentTask.update({
+        where: { taskId },
+        data: { lastRunAt: startedAt, lastStatus: "error", lastError: errMsg, nextRunAt },
+      });
+      await prisma.scheduledJob
+        .update({ where: { jobId: taskId }, data: { lastRunAt: startedAt, lastStatus: "error", lastError: errMsg, nextRunAt } })
+        .catch(() => {});
+    }
+    return;
+  }
+
+  // Parity Engine: the SysML projection reconcile is deterministic — run it
+  // directly (re-derives the MCP-authority + coworker-workforce SysML projections
+  // from their source registries), no LLM loop. Mirrors the data-model mirror branch.
+  if (task.taskId === SYSML_PROJECTION_TASK_ID) {
+    const startedAt = new Date();
+    try {
+      const result = await reconcileSysmlProjections();
+      console.info(
+        "[agent-task-scheduler] sysml projections mcp=%s coworker=%s (tools=%d, coworkers=%d)",
+        result.mcpAuthority.status,
+        result.coworkerAuthority.status,
+        result.mcpAuthority.toolCount,
+        result.coworkerAuthority.created + result.coworkerAuthority.updated,
       );
       const nextRunAt = computeNextCronRun(task.schedule, startedAt);
       await prisma.scheduledAgentTask.update({

--- a/apps/web/lib/ea/reconcile-sysml-projections.test.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+import { reconcileSysmlProjections } from "./reconcile-sysml-projections";
+
+// Inject a db whose notation lookup returns null → both domain reconciles take the
+// "skipped" path. That both come back skipped proves both ran and their results were
+// threaded — without deep-mocking either reconcile (and with no module mocks → no
+// forks-pool bleed).
+describe("reconcileSysmlProjections", () => {
+  it("runs both domain reconciles and threads their results", async () => {
+    const db = { eaNotation: { findUnique: vi.fn().mockResolvedValue(null) } };
+    const r = await reconcileSysmlProjections({ db: db as never });
+    expect(r.mcpAuthority.status).toBe("skipped");
+    expect(r.coworkerAuthority.status).toBe("skipped");
+    expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -1,0 +1,26 @@
+// apps/web/lib/ea/reconcile-sysml-projections.ts
+//
+// Combined reconcile for all auto-extracted SysML projections (Parity Engine).
+// Runs each domain reconcile (MCP tool authority, AI coworker workforce) so a
+// single scheduled/on-demand pass keeps every live projection current. Each
+// reconcile re-derives from its source registry, so the projections cannot drift.
+//
+// Thin orchestrator over the per-domain reconciles; db injected for tests.
+
+import { prisma } from "@dpf/db";
+import { reconcileMcpAuthorityModel, type McpAuthorityReconcileResult } from "./reconcile-mcp-authority";
+import { reconcileCoworkerAuthority } from "./reconcile-coworker-authority";
+import type { SysmlSeedResult } from "./sysml-model-seed";
+
+export interface SysmlProjectionsResult {
+  mcpAuthority: McpAuthorityReconcileResult;
+  coworkerAuthority: SysmlSeedResult;
+}
+
+export async function reconcileSysmlProjections(
+  opts: { db?: typeof prisma } = {},
+): Promise<SysmlProjectionsResult> {
+  const mcpAuthority = await reconcileMcpAuthorityModel({ db: opts.db });
+  const coworkerAuthority = await reconcileCoworkerAuthority({ db: opts.db });
+  return { mcpAuthority, coworkerAuthority };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -133,6 +133,7 @@ export {
   CANONICAL_PRISMA_SCHEMA_PATH,
 } from "./schema-source";
 export { DATA_MODEL_MIRROR_TASK_ID } from "./data-model-mirror-config";
+export { SYSML_PROJECTION_TASK_ID } from "./sysml-projection-config";
 export {
   buildDiscoveredKey,
   buildInventoryEntityKey,

--- a/packages/db/src/seed-sysml-projection.ts
+++ b/packages/db/src/seed-sysml-projection.ts
@@ -1,0 +1,107 @@
+// packages/db/src/seed-sysml-projection.ts
+// Parity Engine: seed the nightly SysML-projection reconcile scheduled task. The
+// deterministic handler lives in apps/web's scheduler (executeScheduledAgentTask
+// early-branches on this task id and runs reconcileSysmlProjections without an LLM
+// loop). Mirrors seed-data-model-mirror.ts.
+import type { PrismaClient } from "../generated/client/client";
+
+import {
+  SYSML_PROJECTION_AGENT_ID,
+  SYSML_PROJECTION_DEFAULT_TIMEZONE,
+  SYSML_PROJECTION_PROMPT,
+  SYSML_PROJECTION_ROUTE_CONTEXT,
+  SYSML_PROJECTION_SCHEDULE,
+  SYSML_PROJECTION_SCHEDULED_JOB_NAME,
+  SYSML_PROJECTION_TASK_ID,
+  SYSML_PROJECTION_TASK_TITLE,
+} from "./sysml-projection-config";
+
+type ScheduledTaskSeedClient = Pick<PrismaClient, "user" | "scheduledAgentTask" | "scheduledJob">;
+
+function computeNextCronRun(cronExpr: string, from: Date): Date {
+  const parts = cronExpr.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    const fallback = new Date(from);
+    fallback.setUTCDate(fallback.getUTCDate() + 1);
+    return fallback;
+  }
+  const [minPart, hourPart] = parts;
+  const minute = minPart === "*" ? 0 : parseInt(minPart!, 10);
+  const hour = hourPart === "*" ? from.getUTCHours() : parseInt(hourPart!, 10);
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(minute);
+  next.setUTCHours(hour);
+  if (next <= from) next.setUTCDate(next.getUTCDate() + 1);
+  return next;
+}
+
+export async function ensureSysmlProjectionScheduledTask(
+  prisma: ScheduledTaskSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  const owner = await prisma.user.findFirst({
+    where: { isSuperuser: true },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  if (!owner) {
+    throw new Error("seed: no superuser found - cannot seed SysML projection scheduled task");
+  }
+
+  const timezone = process.env.INSTALL_TIMEZONE ?? SYSML_PROJECTION_DEFAULT_TIMEZONE;
+  const nextRunAt = computeNextCronRun(SYSML_PROJECTION_SCHEDULE, now);
+
+  const existing = await prisma.scheduledAgentTask.findUnique({
+    where: { taskId: SYSML_PROJECTION_TASK_ID },
+    select: { taskId: true, nextRunAt: true },
+  });
+
+  if (existing) {
+    await prisma.scheduledAgentTask.update({
+      where: { taskId: SYSML_PROJECTION_TASK_ID },
+      data: {
+        agentId: SYSML_PROJECTION_AGENT_ID,
+        title: SYSML_PROJECTION_TASK_TITLE,
+        prompt: SYSML_PROJECTION_PROMPT,
+        routeContext: SYSML_PROJECTION_ROUTE_CONTEXT,
+        schedule: SYSML_PROJECTION_SCHEDULE,
+        timezone,
+        ownerUserId: owner.id,
+        isActive: true,
+        nextRunAt: existing.nextRunAt ?? nextRunAt,
+      },
+    });
+  } else {
+    await prisma.scheduledAgentTask.create({
+      data: {
+        taskId: SYSML_PROJECTION_TASK_ID,
+        agentId: SYSML_PROJECTION_AGENT_ID,
+        title: SYSML_PROJECTION_TASK_TITLE,
+        prompt: SYSML_PROJECTION_PROMPT,
+        routeContext: SYSML_PROJECTION_ROUTE_CONTEXT,
+        schedule: SYSML_PROJECTION_SCHEDULE,
+        timezone,
+        ownerUserId: owner.id,
+        nextRunAt,
+      },
+    });
+  }
+
+  await prisma.scheduledJob.upsert({
+    where: { jobId: SYSML_PROJECTION_TASK_ID },
+    create: {
+      jobId: SYSML_PROJECTION_TASK_ID,
+      name: SYSML_PROJECTION_SCHEDULED_JOB_NAME,
+      schedule: SYSML_PROJECTION_SCHEDULE,
+      nextRunAt: existing?.nextRunAt ?? nextRunAt,
+    },
+    update: {
+      name: SYSML_PROJECTION_SCHEDULED_JOB_NAME,
+      schedule: SYSML_PROJECTION_SCHEDULE,
+      nextRunAt: existing?.nextRunAt ?? nextRunAt,
+    },
+  });
+
+  return { created: !existing };
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -48,6 +48,7 @@ import { seedDeliberationPatterns } from "./seed-deliberation.js";
 import { seedStallThresholds } from "./seed-stall-thresholds.js";
 import { ensureDiscoveryTriageScheduledTask } from "./seed-discovery-triage.js";
 import { ensureDataModelMirrorScheduledTask } from "./seed-data-model-mirror.js";
+import { ensureSysmlProjectionScheduledTask } from "./seed-sysml-projection.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
 import { ensureAllBackupScheduledJobs } from "./seed-platform-backup.js";
 import { ensureContributorInventoryScheduledJob } from "./seed-contributor-inventory.js";
@@ -2423,6 +2424,7 @@ async function main(): Promise<void> {
   await step("defaultAdminUser", () => seedDefaultAdminUser());
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));
   await step("dataModelMirrorScheduledTask", () => ensureDataModelMirrorScheduledTask(prisma));
+  await step("sysmlProjectionScheduledTask", () => ensureSysmlProjectionScheduledTask(prisma));
   await step("hiveScoutScheduledTask", () => ensureHiveScoutScheduledTask(prisma));
   await step("allBackupScheduledJobs", () => ensureAllBackupScheduledJobs(prisma));
   await step("contributorInventoryScheduledJob", () => ensureContributorInventoryScheduledJob(prisma));

--- a/packages/db/src/sysml-projection-config.ts
+++ b/packages/db/src/sysml-projection-config.ts
@@ -1,0 +1,17 @@
+// packages/db/src/sysml-projection-config.ts
+// Parity Engine: shared identity for the nightly SysML-projection reconcile.
+// Imported by the seed (packages/db) and the scheduler branch (apps/web) so both
+// agree on the task id. The deterministic handler lives in apps/web's scheduler
+// (executeScheduledAgentTask early-branches on this task id and runs
+// reconcileSysmlProjections without an LLM loop), mirroring the data-model mirror.
+
+export const SYSML_PROJECTION_TASK_ID = "sysml-projection-nightly";
+export const SYSML_PROJECTION_AGENT_ID = "AGT-WS-EA"; // Enterprise Architect
+export const SYSML_PROJECTION_TASK_TITLE = "SysML Projection Reconcile (nightly)";
+export const SYSML_PROJECTION_ROUTE_CONTEXT = "/ea";
+export const SYSML_PROJECTION_SCHEDULE = "0 4 * * *"; // 04:00 UTC daily (after the data-model mirror at 03:00)
+export const SYSML_PROJECTION_DEFAULT_TIMEZONE = "UTC";
+export const SYSML_PROJECTION_SCHEDULED_JOB_NAME = "SysML Projection Nightly";
+export const SYSML_PROJECTION_PROMPT =
+  "Reconcile the auto-extracted SysML projections (MCP tool authority, AI coworker workforce) into the EA graph. " +
+  "Deterministic — re-derives from the source registries and runs without an LLM loop.";


### PR DESCRIPTION
## Summary

Makes the auto-extractors **live**. Slices 1–2 shipped the MCP-authority and coworker-workforce extractors as reconcile-ready engines; this wires them to a **nightly + deterministic scheduled reconcile** so the SysML projections re-derive from their source registries automatically and stay in parity with the implementation — **no human or AI vigilance**, which is the cognitive-load removal the goal calls for.

Mirrors the data-model mirror's proven scheduling pattern exactly:

- **`packages/db/src/sysml-projection-config.ts`** — shared task identity (`sysml-projection-nightly`, `0 4 * * *` UTC, owner `AGT-WS-EA`), imported by both the seed and the scheduler so they agree on the id.
- **`apps/web/lib/ea/reconcile-sysml-projections.ts`** — combined orchestrator over the two domain reconciles (MCP authority + coworker workforce); db injected for bleed-free tests.
- **`agent-task-scheduler.ts`** — a deterministic early-branch in `executeScheduledAgentTask` that runs the reconcile directly (no LLM loop), recording ok/error + next run, exactly like the data-model mirror branch.
- **`packages/db/src/seed-sysml-projection.ts`** — seeds the `ScheduledAgentTask` + `ScheduledJob` rows (04:00 UTC, staggered after the 03:00 data-model mirror).

With this, the engine is end-to-end live: the parity **gate** (merged #1878) blocks drift in hand-authored models; the **auto-extractors** (merged #1880/#1881) re-derive the authority + workforce projections; and this **scheduler** keeps them current without anyone touching them.

## Verified (source-local)

- **16 unit tests pass** — the combined reconcile (both domains run + results threaded), the new scheduler branch (ok status + error status), and the **existing scheduler suite unbroken** by the added branch/mock.
- `packages/db` typecheck clean; `apps/web` touched files clean modulo the worktree's `@dpf/db` resolution artifact (resolves in CI) and two pre-existing implicit-anys in untouched functions.
- Branched fresh off `origin/main` (with #1880/#1881 merged). Runtime validation (the scheduled run firing in a live install) is the deferred follow-up per the substrate spec.

## Where the engine stands
- ✅ Parity gate (drift detection) — merged + live in CI.
- ✅ Auto-extractors (authority, workforce) — merged.
- ✅ **Scheduling** (this PR) — projections refresh automatically.
- Next: routes / value-stream / BPMN-process extractors; converge the older hand-seeds onto the shared seeder; an on-demand refresh action; the kernel-principle promotion (awaiting your vector calibration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
