### PR TITLE
feat(ea): on-demand SysML projection refresh action (Parity Engine)

### DIFF
--- a/apps/web/lib/actions/sysml-projections.ts
+++ b/apps/web/lib/actions/sysml-projections.ts
@@ -1,0 +1,48 @@
+"use server";
+
+// Parity Engine: on-demand trigger for the SysML projection reconcile — the
+// "refresh now" path. Runs the same deterministic reconcile (MCP tool authority +
+// AI coworker workforce) the nightly schedule runs, so an operator/agent can
+// refresh the live projections immediately after a change instead of waiting for
+// the 04:00 UTC pass. Mirrors refreshDataArchitecture.
+import { revalidatePath } from "next/cache";
+
+import { auth } from "@/lib/auth";
+import { reconcileSysmlProjections } from "@/lib/ea/reconcile-sysml-projections";
+
+type DomainSummary = { status: string; created: number; updated: number; removed: number };
+
+export type RefreshSysmlProjectionsResult =
+  | { ok: true; mcpAuthority: DomainSummary & { toolCount: number; grantCount: number }; coworkerAuthority: DomainSummary }
+  | { ok: false; error: string };
+
+export async function refreshSysmlProjections(): Promise<RefreshSysmlProjectionsResult> {
+  const session = await auth();
+  if (!session?.user) {
+    return { ok: false, error: "Not authorized." };
+  }
+
+  try {
+    const result = await reconcileSysmlProjections();
+    revalidatePath("/ea");
+    return {
+      ok: true,
+      mcpAuthority: {
+        status: result.mcpAuthority.status,
+        created: result.mcpAuthority.created,
+        updated: result.mcpAuthority.updated,
+        removed: result.mcpAuthority.removed,
+        toolCount: result.mcpAuthority.toolCount,
+        grantCount: result.mcpAuthority.grantCount,
+      },
+      coworkerAuthority: {
+        status: result.coworkerAuthority.status,
+        created: result.coworkerAuthority.created,
+        updated: result.coworkerAuthority.updated,
+        removed: result.coworkerAuthority.removed,
+      },
+    };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Projection reconcile failed." };
+  }
+}


### PR DESCRIPTION
## Summary

Completes the projection **trigger surface**. The nightly scheduled reconcile (merged #1883) keeps the SysML projections current; this adds the **on-demand "refresh now"** path: `refreshSysmlProjections` is an auth-gated server action that runs the same deterministic reconcile (MCP tool authority + AI coworker workforce) immediately, so an operator/agent can re-derive the live projections right after a change instead of waiting for 04:00 UTC.

Mirrors `refreshDataArchitecture` exactly: `auth → reconcileSysmlProjections → revalidatePath('/ea') → typed summary | error`. Thin glue over the unit-tested `reconcileSysmlProjections`; follows the same no-unit-test convention as the analogous data-architecture action.

## Verified
- Touched file typechecks clean (worktree `@dpf/db` artifacts aside).
- Branched fresh off `origin/main` (with #1883 merged).

## Engine status
Detect (gate) ✅ · auto-derive (extractors) ✅ · schedule ✅ · **on-demand ✅ (this PR)**. Remaining: more domain extractors (routes / value-stream / BPMN), converge the older hand-seeds onto the shared seeder, and the kernel-principle vector calibration (yours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)