### PR TITLE
fix(storefront): CTA-label single source of truth + seed booking schedule on archetype reset (R9-CAT-001, R9-RES-001)

### DIFF
--- a/apps/web/app/api/storefront/admin/setup/route.ts
+++ b/apps/web/app/api/storefront/admin/setup/route.ts
@@ -3,8 +3,8 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { applyBusinessCapabilityPerspective } from "@dpf/db/business-capability-perspectives";
 import { nanoid } from "nanoid";
-import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
 import { generateDesignSystem } from "@/lib/design-intelligence";
+import { seedBookingScheduleDefaults } from "@/lib/storefront/seed-booking-defaults";
 import {
   deriveRevenueModelFromActivationProfile,
   readActivationProfile,
@@ -188,116 +188,19 @@ export async function POST(req: NextRequest) {
     archetypeId,
   });
 
-  // Seed default provider, availability, and booking config from template
-  // scheduling defaults. This block keys on *item-level* ctaType when linking
-  // providers and seeding bookingConfig, so an archetype that has booking items
-  // but no explicit schedulingDefaults (a template config gap) must still get a
-  // working calendar instead of silently shipping an empty one — fall back to a
-  // 09:00–17:00 Mon–Fri provider. Every shipped archetype with a booking item
-  // carries explicit schedulingDefaults (guarded by archetypes.test.ts); this
-  // fallback is defence-in-depth so a future archetype can't regress to the
-  // empty-calendar bug (AUDIT-R3/R4).
-  const template = ALL_ARCHETYPES.find((a: { archetypeId: string }) => a.archetypeId === archetypeId);
-  const templateCtaType = template?.ctaType;
-  const templateHasBookingItems =
-    template?.itemTemplates.some(
-      (t: { ctaType?: string }) => (t.ctaType ?? templateCtaType) === "booking",
-    ) ?? false;
-  const FALLBACK_SCHEDULING = {
-    schedulingPattern: "slot" as const,
-    assignmentMode: "next-available" as const,
-    defaultOperatingHours: [1, 2, 3, 4, 5].map((day) => ({ day, start: "09:00", end: "17:00" })),
-    defaultBeforeBuffer: 0,
-    defaultAfterBuffer: 0,
-    minimumNoticeHours: 2,
-    maxAdvanceDays: 60,
-  };
-  const defaults =
-    template?.schedulingDefaults ?? (templateHasBookingItems ? FALLBACK_SCHEDULING : null);
-  if (template && defaults) {
-    // 1. Create default ServiceProvider named after the org
-    const provider = await prisma.serviceProvider.create({
-      data: {
-        providerId: `SP-${nanoid(6).toUpperCase()}`,
-        storefrontId: config.id,
-        name: orgName ?? org.name,
-        isActive: true,
-      },
-    });
+  // Seed a default provider, availability, provider→item links, and per-item
+  // bookingConfig for booking archetypes so the storefront ships with a working
+  // calendar instead of an empty one (AUDIT-R3/R4, R9-RES-001). Shared with the
+  // archetype-reset path so the two seed paths can never drift.
+  const seededBooking = await seedBookingScheduleDefaults(prisma, {
+    storefrontId: config.id,
+    archetypeId,
+    providerName: orgName ?? org.name,
+  });
 
-    // 2. Create availability rows — use confirmed BusinessProfile hours if available
-    const profile = await prisma.businessProfile.findFirst({
-      where: { isActive: true, hoursConfirmedAt: { not: null } },
-      select: { businessHours: true },
-    });
-
-    let operatingHours: { day: number; start: string; end: string }[];
-    if (profile?.businessHours) {
-      const bh = profile.businessHours as Record<string, { open: string; close: string } | null>;
-      const dayMap: Record<string, number> = {
-        sunday: 0, monday: 1, tuesday: 2, wednesday: 3,
-        thursday: 4, friday: 5, saturday: 6,
-      };
-      operatingHours = Object.entries(bh)
-        .filter(([, hours]) => hours !== null)
-        .map(([day, hours]) => ({
-          day: dayMap[day] ?? 0,
-          start: hours!.open,
-          end: hours!.close,
-        }));
-    } else {
-      operatingHours = defaults.defaultOperatingHours;
-    }
-
-    const grouped = new Map<string, number[]>();
-    for (const h of operatingHours) {
-      const key = `${h.start}-${h.end}`;
-      if (!grouped.has(key)) grouped.set(key, []);
-      grouped.get(key)!.push(h.day);
-    }
-    for (const [key, days] of grouped) {
-      const keyParts = key.split("-");
-      const startTime = keyParts[0] ?? "09:00";
-      const endTime = keyParts[1] ?? "17:00";
-      await prisma.providerAvailability.create({
-        data: { providerId: provider.id, days, startTime, endTime },
-      });
-    }
-
-    // 3. Link provider to all booking items
-    const bookingItems = await prisma.storefrontItem.findMany({
-      where: { storefrontId: config.id, ctaType: "booking" },
-      select: { id: true, name: true },
-    });
-
-    for (const item of bookingItems) {
-      await prisma.providerService.create({
-        data: { providerId: provider.id, itemId: item.id },
-      });
-    }
-
-    // 4. Set bookingConfig on each booking item from template + defaults
-    const itemTemplates = template.itemTemplates;
-    for (const tmpl of itemTemplates) {
-      if ((tmpl.ctaType ?? template.ctaType) === "booking") {
-        await prisma.storefrontItem.updateMany({
-          where: { storefrontId: config.id, name: tmpl.name },
-          data: {
-            bookingConfig: {
-              durationMinutes: tmpl.bookingDurationMinutes ?? 60,
-              schedulingPattern: defaults.schedulingPattern,
-              assignmentMode: defaults.assignmentMode,
-              beforeBufferMinutes: defaults.defaultBeforeBuffer,
-              afterBufferMinutes: defaults.defaultAfterBuffer,
-              minimumNoticeHours: defaults.minimumNoticeHours,
-              maxAdvanceDays: defaults.maxAdvanceDays,
-            },
-          },
-        });
-      }
-    }
-
-    // Update BusinessProfile to reflect storefront existence
+  if (seededBooking) {
+    // Mark the business as having a storefront (booking archetypes only,
+    // preserving prior behaviour).
     await prisma.businessProfile.updateMany({
       where: { isActive: true },
       data: { hasStorefront: true },

--- a/apps/web/components/storefront-admin/ItemFormDialog.tsx
+++ b/apps/web/components/storefront-admin/ItemFormDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { DEFAULT_CTA_LABELS } from "@/lib/storefront/cta-labels";
 import { MediaUploader } from "./MediaUploader";
 
 export type ItemFormData = {
@@ -73,13 +74,6 @@ const PRICE_TYPES_BY_CTA: Record<string, Array<{ value: string; label: string }>
   donation: [
     { value: "donation", label: "Any amount" },
   ],
-};
-
-const CTA_LABEL_DEFAULTS: Record<string, string> = {
-  booking: "Book now",
-  purchase: "Order now",
-  inquiry: "Get a quote",
-  donation: "Donate now",
 };
 
 type Props = {
@@ -256,7 +250,7 @@ export function ItemFormDialog({
                   type="text"
                   value={form.ctaLabel}
                   onChange={(e) => set("ctaLabel", e.target.value)}
-                  placeholder={CTA_LABEL_DEFAULTS[form.ctaType] ?? ""}
+                  placeholder={DEFAULT_CTA_LABELS[form.ctaType] ?? ""}
                   className="w-full px-3 py-1.5 text-sm rounded-md bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]"
                 />
               </Field>

--- a/apps/web/components/storefront/CtaButton.test.tsx
+++ b/apps/web/components/storefront/CtaButton.test.tsx
@@ -89,3 +89,20 @@ describe("CtaButton price-less purchase guard (AUDIT-R3/R4)", () => {
     expect(hrefFor("inquiry", null)).toBe("/s/acme/inquire/item-1");
   });
 });
+
+describe("CtaButton custom label rendering (R9-CAT-001)", () => {
+  it("renders a stored inquiry label instead of the 'Enquire' default", () => {
+    // The defect report claimed inquiry CTAs ignore the stored label; they do
+    // not — a genuinely stored label must win over the default.
+    expect(labelFor({ ctaType: "inquiry", ctaLabel: "Get a quote" })).toBe("Get a quote");
+  });
+
+  it("falls back to 'Enquire' when an inquiry item has no stored label", () => {
+    expect(labelFor({ ctaType: "inquiry", ctaLabel: null })).toBe("Enquire");
+  });
+
+  it("leaves booking labels unaffected — stored label wins, default is 'Book Now'", () => {
+    expect(labelFor({ ctaType: "booking", ctaLabel: "Reserve a table" })).toBe("Reserve a table");
+    expect(labelFor({ ctaType: "booking", ctaLabel: null })).toBe("Book Now");
+  });
+});

--- a/apps/web/components/storefront/CtaButton.tsx
+++ b/apps/web/components/storefront/CtaButton.tsx
@@ -1,12 +1,5 @@
 import Link from "next/link";
-
-const DEFAULT_LABELS: Record<string, string> = {
-  booking: "Book Now",
-  purchase: "Buy",
-  inquiry: "Enquire",
-  donation: "Donate",
-  rental: "Reserve",
-};
+import { DEFAULT_CTA_LABELS } from "@/lib/storefront/cta-labels";
 
 export function CtaButton({
   ctaType,
@@ -34,7 +27,7 @@ export function CtaButton({
   // Drop a stale purchase-oriented custom label when downgrading so we don't
   // show "Buy" on a button that now routes to the inquiry form.
   const label =
-    (isPricelessPurchase ? null : ctaLabel) ?? DEFAULT_LABELS[effectiveCtaType] ?? "Get in Touch";
+    (isPricelessPurchase ? null : ctaLabel) ?? DEFAULT_CTA_LABELS[effectiveCtaType] ?? "Get in Touch";
 
   const href =
     effectiveCtaType === "booking" ? `/s/${orgSlug}/book/${itemId}`

--- a/apps/web/lib/storefront/archetype-reset.test.ts
+++ b/apps/web/lib/storefront/archetype-reset.test.ts
@@ -25,6 +25,13 @@ vi.mock("./project-operational-value-stream", () => ({
   projectOperationalValueStreamForArchetype: mockProjectOvs,
 }));
 
+// Booking-seed is unit-tested in seed-booking-defaults.test.ts; mock it here so
+// the reset test asserts the call contract without re-exercising provider seeding.
+const { mockSeedBooking } = vi.hoisted(() => ({ mockSeedBooking: vi.fn() }));
+vi.mock("./seed-booking-defaults", () => ({
+  seedBookingScheduleDefaults: mockSeedBooking,
+}));
+
 import { resetStorefrontArchetype } from "./archetype-reset";
 
 function businessCapabilityProjectionStore() {
@@ -44,6 +51,8 @@ describe("resetStorefrontArchetype", () => {
     mockPrisma.$transaction.mockReset();
     mockProjectOvs.mockReset();
     mockProjectOvs.mockResolvedValue({ viewId: "view-ovs" });
+    mockSeedBooking.mockReset();
+    mockSeedBooking.mockResolvedValue(false);
     mockNanoid.mockReturnValue("abcd1234");
   });
 
@@ -173,6 +182,13 @@ describe("resetStorefrontArchetype", () => {
     expect(tx.storefrontItem.createMany).toHaveBeenCalled();
     expect(result.sectionsCreated).toBe(2);
     expect(result.itemsCreated).toBe(2);
+    // Reset seeds booking schedule defaults inside the transaction so a booking
+    // archetype gets a working calendar instead of an empty one (R9-RES-001).
+    expect(mockSeedBooking).toHaveBeenCalledWith(tx, {
+      storefrontId: "sf_1",
+      archetypeId: "software-platform",
+      providerName: "Bookings",
+    });
   });
 
   it("preserves manually managed contact fields and org slug", async () => {

--- a/apps/web/lib/storefront/archetype-reset.ts
+++ b/apps/web/lib/storefront/archetype-reset.ts
@@ -2,6 +2,7 @@ import { prisma } from "@dpf/db";
 import { applyBusinessCapabilityPerspective } from "@dpf/db/business-capability-perspectives";
 import { nanoid } from "nanoid";
 import { projectOperationalValueStreamForArchetype } from "./project-operational-value-stream";
+import { seedBookingScheduleDefaults } from "./seed-booking-defaults";
 
 type ResetMode = "replace-seeded-content";
 
@@ -15,7 +16,7 @@ export async function resetStorefrontArchetype(input: {
   return prisma.$transaction(async (tx) => {
     const organization = await tx.organization.findUnique({
       where: { id: organizationId },
-      select: { id: true },
+      select: { id: true, name: true },
     });
 
     if (!organization) {
@@ -148,6 +149,19 @@ export async function resetStorefrontArchetype(input: {
 
       sectionsCreated = sectionResult.count;
       itemsCreated = itemResult.count;
+
+      // Booking archetypes (e.g. restaurant) seed booking items but, before this,
+      // no provider/availability — leaving the storefront's booking calendar with
+      // every date greyed out (R9-RES-001). Seed a default provider + hours +
+      // provider→item links + bookingConfig from the template, inside the reset
+      // transaction so it commits or rolls back atomically with the rest. No-op
+      // for non-booking archetypes. Shared with storefront setup so the two seed
+      // paths can't drift.
+      await seedBookingScheduleDefaults(tx, {
+        storefrontId: storefront.id,
+        archetypeId: targetArchetype.archetypeId,
+        providerName: organization.name ?? "Bookings",
+      });
     }
 
     return {

--- a/apps/web/lib/storefront/cta-labels.ts
+++ b/apps/web/lib/storefront/cta-labels.ts
@@ -1,0 +1,25 @@
+/**
+ * Default customer-facing CTA button labels, keyed by `ctaType`.
+ *
+ * Single source of truth shared by the public storefront CTA ({@link CtaButton})
+ * and the admin item editor's "Button label" placeholder (`ItemFormDialog`), so
+ * the placeholder an operator sees always reflects what the storefront will
+ * actually render when no custom label is set.
+ *
+ * Before this was shared, the admin form advertised its own nicer defaults
+ * (inquiry -> "Get a quote") while the storefront rendered different ones
+ * (inquiry -> "Enquire"). An operator who applied an archetype saw "Get a quote"
+ * in the editor placeholder and reasonably expected it on the card, but the card
+ * showed "Enquire" — reported as R9-CAT-001 (a phantom "stored label ignored"
+ * bug; the label was never stored, the placeholder just lied). Keep these two
+ * surfaces honest by reading the same map.
+ *
+ * An item's own `ctaLabel` always wins; this map is only the fallback.
+ */
+export const DEFAULT_CTA_LABELS: Record<string, string> = {
+  booking: "Book Now",
+  purchase: "Buy",
+  inquiry: "Enquire",
+  donation: "Donate",
+  rental: "Reserve",
+};

--- a/apps/web/lib/storefront/seed-booking-defaults.test.ts
+++ b/apps/web/lib/storefront/seed-booking-defaults.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the template source so the helper's branching logic is tested against
+// fixed archetype shapes (mirroring the real restaurant/catering templates)
+// rather than the shipped data — the real templates are guarded by
+// archetypes.test.ts. This also keeps the suite hermetic (no workspace-package
+// resolution) like the sibling archetype-reset.test.ts.
+const { FIXTURE_ARCHETYPES } = vi.hoisted(() => ({
+  FIXTURE_ARCHETYPES: [
+    {
+      archetypeId: "restaurant",
+      ctaType: "booking",
+      itemTemplates: [
+        { name: "Table for 2", ctaType: "booking", bookingDurationMinutes: 90 },
+        { name: "Table for 4", ctaType: "booking", bookingDurationMinutes: 90 },
+        { name: "Private Dining", ctaType: "booking", bookingDurationMinutes: 180 },
+      ],
+      schedulingDefaults: {
+        schedulingPattern: "slot",
+        assignmentMode: "next-available",
+        defaultOperatingHours: [0, 1, 2, 3, 4, 5, 6].map((day) => ({ day, start: "11:00", end: "22:00" })),
+        defaultBeforeBuffer: 0,
+        defaultAfterBuffer: 15,
+        minimumNoticeHours: 1,
+        maxAdvanceDays: 30,
+      },
+    },
+    {
+      // Inquiry archetype with no booking items and no schedulingDefaults.
+      archetypeId: "catering",
+      ctaType: "inquiry",
+      itemTemplates: [{ name: "Corporate Catering", ctaType: "inquiry" }],
+    },
+    {
+      // Booking items but NO explicit schedulingDefaults — must fall back to the
+      // built-in defence-in-depth schedule rather than ship an empty calendar.
+      archetypeId: "booking-no-defaults",
+      ctaType: "booking",
+      itemTemplates: [{ name: "Slot A", ctaType: "booking" }],
+    },
+  ],
+}));
+
+vi.mock("@dpf/storefront-templates", () => ({ ALL_ARCHETYPES: FIXTURE_ARCHETYPES }));
+
+const mockNanoid = vi.hoisted(() => vi.fn());
+vi.mock("nanoid", () => ({ nanoid: mockNanoid }));
+
+import { seedBookingScheduleDefaults } from "./seed-booking-defaults";
+
+type MockDb = ReturnType<typeof makeDb>;
+
+function makeDb(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    serviceProvider: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({ id: "prov_new" }),
+    },
+    providerAvailability: {
+      count: vi.fn().mockResolvedValue(0),
+      create: vi.fn().mockResolvedValue({}),
+    },
+    providerService: {
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    storefrontItem: {
+      findMany: vi.fn().mockResolvedValue([{ id: "i1" }, { id: "i2" }, { id: "i3" }]),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    businessProfile: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+    ...overrides,
+  };
+}
+
+describe("seedBookingScheduleDefaults", () => {
+  beforeEach(() => {
+    mockNanoid.mockReset();
+    mockNanoid.mockReturnValue("abc123");
+  });
+
+  it("seeds a provider, availability, links, and bookingConfig for a fresh booking archetype", async () => {
+    const db = makeDb();
+    const result = await seedBookingScheduleDefaults(db, {
+      storefrontId: "sf_1",
+      archetypeId: "restaurant",
+      providerName: "Joe's Diner",
+    });
+
+    expect(result).toBe(true);
+
+    // Creates one default provider when none exists.
+    expect(db.serviceProvider.create).toHaveBeenCalledTimes(1);
+    expect(db.serviceProvider.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ storefrontId: "sf_1", name: "Joe's Diner", isActive: true }),
+      }),
+    );
+
+    // Seeds restaurant hours (all 7 days, 11:00–22:00) as one grouped row.
+    expect(db.providerAvailability.create).toHaveBeenCalledTimes(1);
+    expect(db.providerAvailability.create).toHaveBeenCalledWith({
+      data: { providerId: "prov_new", days: [0, 1, 2, 3, 4, 5, 6], startTime: "11:00", endTime: "22:00" },
+    });
+
+    // Links the provider to every booking item.
+    expect(db.providerService.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([{ providerId: "prov_new", itemId: "i1" }]),
+        skipDuplicates: true,
+      }),
+    );
+
+    // Writes bookingConfig for each of the 3 booking items, with the template duration.
+    expect(db.storefrontItem.updateMany).toHaveBeenCalledTimes(3);
+    expect(db.storefrontItem.updateMany).toHaveBeenCalledWith({
+      where: { storefrontId: "sf_1", name: "Table for 2" },
+      data: {
+        bookingConfig: expect.objectContaining({
+          durationMinutes: 90,
+          schedulingPattern: "slot",
+          assignmentMode: "next-available",
+        }),
+      },
+    });
+  });
+
+  it("reuses an existing provider and never clobbers its availability", async () => {
+    const db = makeDb({
+      serviceProvider: {
+        findMany: vi.fn().mockResolvedValue([{ id: "prov_existing" }]),
+        create: vi.fn(),
+      },
+      providerAvailability: {
+        count: vi.fn().mockResolvedValue(3), // already has hours
+        create: vi.fn(),
+      },
+    }) as MockDb;
+
+    const result = await seedBookingScheduleDefaults(db, {
+      storefrontId: "sf_1",
+      archetypeId: "restaurant",
+      providerName: "Joe's Diner",
+    });
+
+    expect(result).toBe(true);
+    expect(db.serviceProvider.create).not.toHaveBeenCalled();
+    expect(db.providerAvailability.create).not.toHaveBeenCalled();
+    // Still re-links the surviving provider to the new booking items (the step
+    // the reset bug was missing).
+    expect(db.providerService.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([{ providerId: "prov_existing", itemId: "i1" }]),
+        skipDuplicates: true,
+      }),
+    );
+  });
+
+  it("prefers the operator's confirmed business hours over the template defaults", async () => {
+    const db = makeDb({
+      businessProfile: {
+        findFirst: vi.fn().mockResolvedValue({
+          businessHours: {
+            monday: { open: "08:00", close: "16:00" },
+            tuesday: { open: "08:00", close: "16:00" },
+            sunday: null,
+          },
+        }),
+      },
+    }) as MockDb;
+
+    await seedBookingScheduleDefaults(db, {
+      storefrontId: "sf_1",
+      archetypeId: "restaurant",
+      providerName: "Joe's Diner",
+    });
+
+    expect(db.providerAvailability.create).toHaveBeenCalledWith({
+      data: { providerId: "prov_new", days: [1, 2], startTime: "08:00", endTime: "16:00" },
+    });
+  });
+
+  it("falls back to a default schedule for a booking archetype lacking schedulingDefaults", async () => {
+    const db = makeDb();
+    const result = await seedBookingScheduleDefaults(db, {
+      storefrontId: "sf_1",
+      archetypeId: "booking-no-defaults",
+      providerName: "Acme",
+    });
+
+    expect(result).toBe(true);
+    // Fallback is Mon–Fri 09:00–17:00 — the calendar must not be empty.
+    expect(db.providerAvailability.create).toHaveBeenCalledWith({
+      data: { providerId: "prov_new", days: [1, 2, 3, 4, 5], startTime: "09:00", endTime: "17:00" },
+    });
+  });
+
+  it("is a no-op for a non-booking archetype", async () => {
+    const db = makeDb();
+    const result = await seedBookingScheduleDefaults(db, {
+      storefrontId: "sf_1",
+      archetypeId: "catering", // inquiry archetype, no booking items
+      providerName: "X",
+    });
+
+    expect(result).toBe(false);
+    expect(db.serviceProvider.findMany).not.toHaveBeenCalled();
+    expect(db.serviceProvider.create).not.toHaveBeenCalled();
+    expect(db.storefrontItem.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for an unknown archetype", async () => {
+    const db = makeDb();
+    const result = await seedBookingScheduleDefaults(db, {
+      storefrontId: "sf_1",
+      archetypeId: "does-not-exist",
+      providerName: "X",
+    });
+
+    expect(result).toBe(false);
+    expect(db.serviceProvider.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/storefront/seed-booking-defaults.ts
+++ b/apps/web/lib/storefront/seed-booking-defaults.ts
@@ -1,0 +1,211 @@
+import { nanoid } from "nanoid";
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+
+/**
+ * Narrow structural view of the Prisma client used by the booking seeder.
+ *
+ * Hand-rolled (not `PrismaClient` / `Prisma.TransactionClient`) on purpose:
+ * naming the Prisma client type here forces every importer to compute Prisma's
+ * large `Omit<PrismaClient, …>` mapped type, which has blown the typecheck heap
+ * (OOM) elsewhere in this repo — see the same note on
+ * `ProjectArchetypeValueStreamInput.db`. Callers pass `prisma` or a
+ * `$transaction` client; both satisfy this shape structurally.
+ */
+type IdRow = { id: string };
+interface BookingSeedDb {
+  serviceProvider: {
+    findMany(args: unknown): Promise<IdRow[]>;
+    create(args: unknown): Promise<IdRow>;
+  };
+  providerAvailability: {
+    count(args: unknown): Promise<number>;
+    create(args: unknown): Promise<unknown>;
+  };
+  providerService: {
+    createMany(args: unknown): Promise<{ count: number }>;
+  };
+  storefrontItem: {
+    findMany(args: unknown): Promise<IdRow[]>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  businessProfile: {
+    findFirst(args: unknown): Promise<{ businessHours: unknown } | null>;
+  };
+}
+
+type OperatingHour = { day: number; start: string; end: string };
+
+/**
+ * Defence-in-depth scheduling for an archetype that has booking items but no
+ * explicit `schedulingDefaults` (a template-config gap). Every shipped archetype
+ * with a booking item carries explicit `schedulingDefaults` (guarded by
+ * archetypes.test.ts); this fallback ensures a future archetype can never
+ * regress to the empty-calendar bug (AUDIT-R3/R4, R9-RES-001).
+ */
+const FALLBACK_SCHEDULING = {
+  schedulingPattern: "slot" as const,
+  assignmentMode: "next-available" as const,
+  defaultOperatingHours: [1, 2, 3, 4, 5].map((day) => ({ day, start: "09:00", end: "17:00" })),
+  defaultBeforeBuffer: 0,
+  defaultAfterBuffer: 0,
+  minimumNoticeHours: 2,
+  maxAdvanceDays: 60,
+};
+
+const DAY_NAME_TO_INDEX: Record<string, number> = {
+  sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6,
+};
+
+/**
+ * Ensure every booking item on a storefront has a working calendar: a default
+ * provider, recurring availability, provider→item links, and per-item
+ * `bookingConfig` — derived from the archetype template's scheduling defaults.
+ *
+ * Idempotent and safe to re-run on an existing storefront (the archetype-reset
+ * path): a provider is created only when none exists, and availability is seeded
+ * only for a provider that has none, so operator-customized hours are never
+ * clobbered. It always (re)links providers to the current booking items and
+ * (re)writes each booking item's `bookingConfig` from the template — those are
+ * freshly seeded by the reset and carry no operator edits.
+ *
+ * Shared by storefront setup (initial install) and archetype reset so the two
+ * seed paths can never drift — reset used to skip this entirely, shipping an
+ * empty booking calendar with every date greyed out (R9-RES-001).
+ *
+ * @returns true when the archetype has booking items and defaults were applied;
+ *          false (a no-op) for a non-booking archetype.
+ *
+ * `dbClient` is a `PrismaClient` or a `$transaction` client, typed `unknown` and
+ * cast to the narrow {@link BookingSeedDb} at the boundary — naming the Prisma
+ * client type in the signature forces importers to compute its large mapped type
+ * and has blown the typecheck heap before (see `BookingSeedDb`).
+ */
+export async function seedBookingScheduleDefaults(
+  dbClient: unknown,
+  input: { storefrontId: string; archetypeId: string; providerName: string },
+): Promise<boolean> {
+  const db = dbClient as BookingSeedDb;
+  const { storefrontId, archetypeId, providerName } = input;
+
+  const template = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!template) return false;
+
+  const templateCtaType = template.ctaType;
+  const hasBookingItems = template.itemTemplates.some(
+    (t) => (t.ctaType ?? templateCtaType) === "booking",
+  );
+  const defaults = template.schedulingDefaults ?? (hasBookingItems ? FALLBACK_SCHEDULING : null);
+  if (!defaults) return false;
+
+  // 1. Ensure at least one active provider. Reuse an existing one (e.g. a
+  //    survivor from a prior archetype) rather than creating duplicates; create
+  //    a default provider only when none exists.
+  let providers = await db.serviceProvider.findMany({
+    where: { storefrontId, isActive: true },
+    select: { id: true },
+  });
+  if (providers.length === 0) {
+    const provider = await db.serviceProvider.create({
+      data: {
+        providerId: `SP-${nanoid(6).toUpperCase()}`,
+        storefrontId,
+        name: providerName,
+        isActive: true,
+      },
+      select: { id: true },
+    });
+    providers = [provider];
+  }
+
+  // 2. Resolve operating hours — prefer the operator's confirmed BusinessProfile
+  //    hours over the template defaults, matching storefront setup.
+  const operatingHours = await resolveOperatingHours(db, defaults.defaultOperatingHours);
+  const grouped = new Map<string, number[]>();
+  for (const h of operatingHours) {
+    const key = `${h.start}-${h.end}`;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(h.day);
+  }
+
+  // 3. Seed availability for any provider that has none (never overwrite
+  //    existing/operator-edited hours).
+  for (const provider of providers) {
+    const availCount = await db.providerAvailability.count({
+      where: { providerId: provider.id },
+    });
+    if (availCount > 0) continue;
+    for (const [key, days] of grouped) {
+      const keyParts = key.split("-");
+      const startTime = keyParts[0] ?? "09:00";
+      const endTime = keyParts[1] ?? "17:00";
+      await db.providerAvailability.create({
+        data: { providerId: provider.id, days, startTime, endTime },
+      });
+    }
+  }
+
+  // 4. Link every active provider to every current booking item.
+  const bookingItems = await db.storefrontItem.findMany({
+    where: { storefrontId, ctaType: "booking" },
+    select: { id: true },
+  });
+  if (bookingItems.length > 0) {
+    for (const provider of providers) {
+      await db.providerService.createMany({
+        data: bookingItems.map((item) => ({ providerId: provider.id, itemId: item.id })),
+        skipDuplicates: true,
+      });
+    }
+  }
+
+  // 5. Write bookingConfig on each booking item from the template + defaults.
+  for (const tmpl of template.itemTemplates) {
+    if ((tmpl.ctaType ?? templateCtaType) !== "booking") continue;
+    await db.storefrontItem.updateMany({
+      where: { storefrontId, name: tmpl.name },
+      data: {
+        bookingConfig: {
+          durationMinutes: tmpl.bookingDurationMinutes ?? 60,
+          schedulingPattern: defaults.schedulingPattern,
+          assignmentMode: defaults.assignmentMode,
+          beforeBufferMinutes: defaults.defaultBeforeBuffer,
+          afterBufferMinutes: defaults.defaultAfterBuffer,
+          minimumNoticeHours: defaults.minimumNoticeHours,
+          maxAdvanceDays: defaults.maxAdvanceDays,
+        },
+      },
+    });
+  }
+
+  return true;
+}
+
+/**
+ * Prefer the operator's confirmed BusinessProfile hours; fall back to the
+ * template defaults. A confirmed-but-empty schedule (every day closed) would
+ * otherwise wipe the calendar, so fall back there too — a booking storefront
+ * needs some bookable window to be usable.
+ */
+async function resolveOperatingHours(
+  db: BookingSeedDb,
+  fallback: OperatingHour[],
+): Promise<OperatingHour[]> {
+  const profile = await db.businessProfile.findFirst({
+    where: { isActive: true, hoursConfirmedAt: { not: null } },
+    select: { businessHours: true },
+  });
+  const businessHours = profile?.businessHours as
+    | Record<string, { open: string; close: string } | null>
+    | undefined
+    | null;
+  if (!businessHours) return fallback;
+
+  const hours = Object.entries(businessHours)
+    .filter(([, h]) => h !== null)
+    .map(([day, h]) => ({
+      day: DAY_NAME_TO_INDEX[day] ?? 0,
+      start: h!.open,
+      end: h!.close,
+    }));
+  return hours.length > 0 ? hours : fallback;
+}


### PR DESCRIPTION
## Summary

Fixes two storefront bugs surfaced in Phase W Run 9 (food & hospitality archetypes):

- **R9-CAT-001 (Medium):** the inquiry CTA rendered "Enquire" while the admin editor's "Button label" field showed "Get a quote".
- **R9-RES-001 (Critical):** applying the restaurant archetype produced a booking calendar with every date greyed out and no message to the customer.

Both are fixed by collapsing duplicated logic — one shared default-label constant, and one shared booking-seed helper — so the two storefront surfaces in each case (admin vs public; setup vs reset) can no longer drift.

## R9-CAT-001 — CTA label

The ticket hypothesised the CTA "hardcodes Enquire and ignores the stored label." It doesn't: `CtaButton` already reads `ctaLabel`, the items API persists it, and the public query selects it — a genuinely-stored label already renders. The real defect was a **single-source-of-truth violation**: the admin editor's placeholder map (`CTA_LABEL_DEFAULTS`, inquiry → "Get a quote") diverged from the storefront render-default map (`DEFAULT_LABELS`, inquiry → "Enquire"). The audit saw the admin **placeholder** "Get a quote" and read it as a stored value — but no label was ever stored. The "Book now" admin placeholder vs the "Book Now" rendered default was the same latent mismatch for booking, which is why booking *appeared* to render the stored label correctly.

**Fix:** one shared `DEFAULT_CTA_LABELS` (`apps/web/lib/storefront/cta-labels.ts`) consumed by both `CtaButton` (render) and `ItemFormDialog` (placeholder), so the placeholder always reflects what the storefront will render.

Acceptance criteria:
- ✅ A catering item with button label "Get a quote" renders "Get a quote".
- ✅ A catering item with no button label falls back to "Enquire" (default unchanged).
- ✅ Booking items unaffected (a stored label wins; default stays "Book Now").

## R9-RES-001 — empty booking calendar

`resetStorefrontArchetype` created `ctaType=booking` items but no `ServiceProvider`, `ProviderAvailability`, provider→item links, or `bookingConfig`, so the slot engine (`computeAvailableSlots` / `getAvailableDates`) returned zero results for every date. Storefront **setup** already seeded all of this; **reset** silently skipped it. (The complementary template-side fix #1811 ensured every booking archetype declares `schedulingDefaults`; this PR makes the reset path actually apply them.)

**Fix (approach 1 — seed defaults):** extracted the setup route's booking-seed block into a shared `seedBookingScheduleDefaults` helper (`apps/web/lib/storefront/seed-booking-defaults.ts`), called from both setup and reset (inside the reset transaction so it commits atomically). It:

- reuses an existing provider, or creates a default one when none exists;
- seeds availability only when the provider has none — never clobbering operator-edited hours — preferring confirmed BusinessProfile hours, else the template hours;
- links providers to all booking items;
- writes per-item `bookingConfig` from the template;
- no-ops for non-booking archetypes.

Acceptance criteria:
- ✅ After a `restaurant` reset, the seeded provider + availability (template hours — all 7 days 11:00–22:00, within `maxAdvanceDays`=30) make time slots available on dates in the next 30 days.

## Verification

- **20 unit tests pass** across the three affected files (`CtaButton`, `seed-booking-defaults` [new — fresh seed, provider reuse, confirmed-hours override, fallback schedule, non-booking no-op], `archetype-reset`). Substrate: worktree source-local via the root clone's toolchain.
- **Typecheck clean** on all changed files.
- Full suite + production build run in CI. Functional end-to-end behaviour (live booking calendar showing slots; catering CTA reading stored labels) is validated in the broader archetype-rebuild scenarios — these surfaces are hard to exercise independently of a larger flow.

## Note for reviewers

`setup` still gates the `hasStorefront` flag on booking-seeding (pre-existing — a non-booking storefront never gets it set). Preserved as-is to keep this PR scoped; flagged here for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
