### PR TITLE
feat(email): in-portal SMTP configuration (Admin → Settings → Email)

### DIFF
--- a/apps/web/app/(shell)/admin/settings/page.test.tsx
+++ b/apps/web/app/(shell)/admin/settings/page.test.tsx
@@ -17,6 +17,10 @@ vi.mock("@/components/admin/SocialAuthPanel", () => ({
   SocialAuthPanel: () => <div>social-auth-panel</div>,
 }));
 
+vi.mock("@/components/admin/EmailSettingsPanel", () => ({
+  EmailSettingsPanel: () => <div>email-settings-panel</div>,
+}));
+
 vi.mock("@/components/admin/PlatformKeysPanel", () => ({
   PLATFORM_KEY_CONFIGS: [
     {

--- a/apps/web/app/(shell)/admin/settings/page.tsx
+++ b/apps/web/app/(shell)/admin/settings/page.tsx
@@ -2,6 +2,8 @@ import { prisma } from "@dpf/db";
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { PlatformKeysPanel } from "@/components/admin/PlatformKeysPanel";
 import { SocialAuthPanel } from "@/components/admin/SocialAuthPanel";
+import { EmailSettingsPanel } from "@/components/admin/EmailSettingsPanel";
+import { getSmtpConfigStatus } from "@/lib/shared/smtp-config";
 
 const PLATFORM_KEYS = ["upload_storage_path"];
 const ADMIN_PLATFORM_KEY_CONFIGS = [
@@ -51,6 +53,7 @@ export default async function AdminSettingsPage() {
         configs={ADMIN_PLATFORM_KEY_CONFIGS}
       />
       <SocialAuthPanel keyData={await getKeyData(SOCIAL_AUTH_KEYS)} />
+      <EmailSettingsPanel status={await getSmtpConfigStatus()} />
     </div>
   );
 }

--- a/apps/web/app/api/v1/finance/invoices/[id]/send/route.ts
+++ b/apps/web/app/api/v1/finance/invoices/[id]/send/route.ts
@@ -20,10 +20,10 @@ export async function POST(
     // of marking the invoice sent and silently dropping the email (the cold-start
     // fresh-install failure from the Runs 6 & 7 audit). Checked before any state
     // mutation so a failed send never leaves the invoice falsely marked "sent".
-    if (!isEmailConfigured()) {
+    if (!(await isEmailConfigured())) {
       throw apiError(
         "EMAIL_NOT_CONFIGURED",
-        "Email delivery is not configured, so this invoice can't be emailed. Set the SMTP environment variables (SMTP_HOST, and SMTP_USER/SMTP_PASS if your server requires auth), then try again.",
+        "Email delivery is not configured, so this invoice can't be emailed. Set it up in Admin → Settings → Email (or via SMTP environment variables), then try again.",
         422,
       );
     }

--- a/apps/web/components/admin/EmailSettingsPanel.tsx
+++ b/apps/web/components/admin/EmailSettingsPanel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { saveEmailConfig, sendTestEmail } from "@/lib/actions/email-config";
+
+type Props = {
+  status: {
+    configured: boolean;
+    host: string | null;
+    port: number;
+    user: string | null;
+    from: string | null;
+    secure: boolean;
+    passConfigured: boolean;
+    source: "db" | "env" | "none";
+  };
+};
+
+const inputCls =
+  "w-full px-3 py-2 text-xs bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]";
+const labelCls = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+export function EmailSettingsPanel({ status }: Props) {
+  const router = useRouter();
+  const [saving, startSave] = useTransition();
+  const [testing, startTest] = useTransition();
+  const [host, setHost] = useState(status.host ?? "");
+  const [port, setPort] = useState(String(status.port || 587));
+  const [user, setUser] = useState(status.user ?? "");
+  const [from, setFrom] = useState(status.from ?? "");
+  const [secure, setSecure] = useState(status.secure);
+  const [pass, setPass] = useState("");
+  const [testTo, setTestTo] = useState("");
+  const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  const save = () => {
+    setMsg(null);
+    startSave(async () => {
+      try {
+        await saveEmailConfig({
+          host: host.trim(),
+          port: Number.parseInt(port, 10) || 587,
+          user: user.trim(),
+          from: from.trim(),
+          secure,
+          ...(pass ? { pass } : {}),
+        });
+        setPass("");
+        setMsg({ kind: "ok", text: "Email settings saved." });
+        router.refresh();
+      } catch (e) {
+        setMsg({ kind: "err", text: e instanceof Error ? e.message : "Failed to save." });
+      }
+    });
+  };
+
+  const test = () => {
+    setMsg(null);
+    startTest(async () => {
+      try {
+        await sendTestEmail(testTo.trim());
+        setMsg({ kind: "ok", text: `Test email sent to ${testTo.trim()}.` });
+      } catch (e) {
+        setMsg({ kind: "err", text: e instanceof Error ? e.message : "Failed to send test email." });
+      }
+    });
+  };
+
+  const statusColor = status.configured ? "var(--dpf-success)" : "var(--dpf-warning)";
+
+  return (
+    <div className="mt-8">
+      <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">Email (SMTP)</h2>
+      <p className="text-sm text-[var(--dpf-muted)] mb-4">
+        Outbound email for invoices, payment links, dunning, and approvals. Without this,
+        &ldquo;Send Invoice&rdquo; and signed-confirmation emails cannot be delivered.
+      </p>
+
+      <div
+        className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4"
+        style={{ borderLeftColor: statusColor }}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-sm font-semibold text-[var(--dpf-text)]">SMTP server</span>
+          <span
+            className="text-[10px] px-2 py-0.5 rounded-full"
+            style={{
+              background: `color-mix(in srgb, ${statusColor} 13%, transparent)`,
+              color: statusColor,
+            }}
+          >
+            {status.configured
+              ? `Configured${status.source === "env" ? " (env vars)" : ""}`
+              : "Not configured"}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="sm:col-span-2">
+            <label className={labelCls}>Host *</label>
+            <input
+              className={inputCls}
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+              placeholder="smtp.example.com"
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Port</label>
+            <input
+              className={inputCls}
+              value={port}
+              onChange={(e) => setPort(e.target.value)}
+              placeholder="587"
+              inputMode="numeric"
+            />
+          </div>
+          <div className="flex items-end pb-1.5">
+            <label className="flex items-center gap-2 cursor-pointer text-xs text-[var(--dpf-text)]">
+              <input
+                type="checkbox"
+                checked={secure}
+                onChange={(e) => setSecure(e.target.checked)}
+                className="accent-[var(--dpf-accent)]"
+              />
+              Use TLS/SSL (implicit, port 465)
+            </label>
+          </div>
+          <div>
+            <label className={labelCls}>Username</label>
+            <input
+              className={inputCls}
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+              placeholder="apikey / user@example.com"
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Password</label>
+            <input
+              className={inputCls}
+              type="password"
+              value={pass}
+              onChange={(e) => setPass(e.target.value)}
+              placeholder={status.passConfigured ? "•••••• (leave blank to keep)" : "SMTP password / API key"}
+              autoComplete="new-password"
+              data-1p-ignore
+              data-lpignore="true"
+            />
+          </div>
+          <div className="sm:col-span-2">
+            <label className={labelCls}>From address</label>
+            <input
+              className={inputCls}
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              placeholder="billing@yourbusiness.com"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <button
+            onClick={save}
+            disabled={saving || !host.trim()}
+            className="px-4 py-2 text-xs font-semibold bg-[var(--dpf-accent)] text-white rounded disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+
+        {/* Send test email */}
+        <div className="mt-4 pt-4 border-t border-[var(--dpf-border)]">
+          <label className={labelCls}>Send a test email to</label>
+          <div className="flex gap-2">
+            <input
+              className={`${inputCls} flex-1`}
+              value={testTo}
+              onChange={(e) => setTestTo(e.target.value)}
+              placeholder="you@example.com"
+              type="email"
+            />
+            <button
+              onClick={test}
+              disabled={testing || !testTo.trim()}
+              className="px-4 py-2 text-xs font-semibold border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed hover:border-[var(--dpf-accent)]"
+            >
+              {testing ? "Sending…" : "Send test"}
+            </button>
+          </div>
+        </div>
+
+        {msg && (
+          <p
+            className="mt-3 text-xs"
+            style={{ color: msg.kind === "ok" ? "var(--dpf-success)" : "var(--dpf-error)" }}
+          >
+            {msg.text}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/email-config.test.ts
+++ b/apps/web/lib/actions/email-config.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/permissions", () => ({ can: vi.fn() }));
+vi.mock("@dpf/db", () => ({ prisma: { platformConfig: { upsert: vi.fn() } } }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/govern/credential-crypto", () => ({
+  encryptSecret: vi.fn((s: string) => `enc:${s}`),
+}));
+vi.mock("@/lib/email", () => ({
+  sendEmail: vi.fn().mockResolvedValue({ messageId: "x" }),
+  isEmailConfigured: vi.fn().mockResolvedValue(true),
+}));
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { prisma } from "@dpf/db";
+import { encryptSecret } from "@/lib/govern/credential-crypto";
+import { sendEmail, isEmailConfigured } from "@/lib/email";
+import { saveEmailConfig, sendTestEmail } from "./email-config";
+
+const mockAuth = vi.mocked(auth);
+const mockCan = vi.mocked(can);
+const mockPrisma = prisma as unknown as {
+  platformConfig: { upsert: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({
+    user: { id: "u1", platformRole: "HR-000", isSuperuser: true },
+  } as never);
+  mockCan.mockReturnValue(true);
+  mockPrisma.platformConfig.upsert.mockResolvedValue({});
+  vi.mocked(isEmailConfigured).mockResolvedValue(true);
+});
+
+describe("saveEmailConfig", () => {
+  it("throws when unauthorized", async () => {
+    mockCan.mockReturnValue(false);
+    await expect(saveEmailConfig({ host: "h", port: 587 })).rejects.toThrow("Unauthorized");
+    expect(mockPrisma.platformConfig.upsert).not.toHaveBeenCalled();
+  });
+
+  it("requires a host", async () => {
+    await expect(saveEmailConfig({ host: "", port: 587 } as never)).rejects.toThrow();
+  });
+
+  it("writes plaintext fields and encrypts the password when provided", async () => {
+    await saveEmailConfig({
+      host: "smtp.x",
+      port: 465,
+      user: "u",
+      from: "f@x.com",
+      secure: true,
+      pass: "secret",
+    });
+
+    const keys = mockPrisma.platformConfig.upsert.mock.calls.map((c) => c[0].where.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "smtp_host",
+        "smtp_port",
+        "smtp_user",
+        "smtp_from",
+        "smtp_secure",
+        "smtp_pass_enc",
+      ]),
+    );
+    expect(encryptSecret).toHaveBeenCalledWith("secret");
+    const passWrite = mockPrisma.platformConfig.upsert.mock.calls.find(
+      (c) => c[0].where.key === "smtp_pass_enc",
+    );
+    expect(passWrite?.[0].create.value).toBe("enc:secret");
+  });
+
+  it("does NOT touch the password key when pass is blank (keeps existing)", async () => {
+    await saveEmailConfig({ host: "smtp.x", port: 587 });
+    const keys = mockPrisma.platformConfig.upsert.mock.calls.map((c) => c[0].where.key);
+    expect(keys).not.toContain("smtp_pass_enc");
+    expect(encryptSecret).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendTestEmail", () => {
+  it("throws when unauthorized", async () => {
+    mockCan.mockReturnValue(false);
+    await expect(sendTestEmail("x@y.com")).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects an invalid recipient", async () => {
+    await expect(sendTestEmail("not-an-email")).rejects.toThrow();
+  });
+
+  it("refuses when email is not configured", async () => {
+    vi.mocked(isEmailConfigured).mockResolvedValue(false);
+    await expect(sendTestEmail("x@y.com")).rejects.toThrow(/Save your SMTP settings/);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends a test email when configured", async () => {
+    await sendTestEmail("x@y.com");
+    expect(sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: "x@y.com" }));
+  });
+});

--- a/apps/web/lib/actions/email-config.ts
+++ b/apps/web/lib/actions/email-config.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { z } from "zod";
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { encryptSecret } from "@/lib/govern/credential-crypto";
+import { sendEmail, isEmailConfigured } from "@/lib/email";
+
+// Admin → Settings → Email. Same guard the adjacent platform-key / social-auth
+// panels use (manage_provider_connections) — SMTP is an outbound-email provider
+// connection at the install level.
+async function requireManageEmailConfig(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "manage_provider_connections",
+    )
+  ) {
+    throw new Error("Unauthorized");
+  }
+}
+
+const emailConfigSchema = z.object({
+  host: z.string().trim().min(1, "SMTP host is required").max(255),
+  port: z.number().int().min(1).max(65535).default(587),
+  user: z.string().trim().max(255).optional().default(""),
+  from: z.string().trim().max(320).optional().default(""),
+  secure: z.boolean().optional().default(false),
+  // Only set/replace the password when a non-empty value is provided; a blank
+  // value means "keep the existing password" so editing other fields is safe.
+  pass: z.string().max(1024).optional(),
+});
+
+// z.input (not z.infer): defaulted fields (port/user/from/secure) stay optional
+// for callers; emailConfigSchema.parse() fills the defaults inside the action.
+export type EmailConfigInput = z.input<typeof emailConfigSchema>;
+
+export async function saveEmailConfig(input: EmailConfigInput): Promise<{ ok: true }> {
+  await requireManageEmailConfig();
+  const parsed = emailConfigSchema.parse(input);
+
+  const writes: Array<{ key: string; value: string }> = [
+    { key: "smtp_host", value: parsed.host },
+    { key: "smtp_port", value: String(parsed.port) },
+    { key: "smtp_user", value: parsed.user ?? "" },
+    { key: "smtp_from", value: parsed.from ?? "" },
+    { key: "smtp_secure", value: parsed.secure ? "true" : "false" },
+  ];
+  // Password is stored encrypted at rest (credential-crypto), never plaintext.
+  if (parsed.pass && parsed.pass.length > 0) {
+    writes.push({ key: "smtp_pass_enc", value: encryptSecret(parsed.pass) });
+  }
+
+  for (const { key, value } of writes) {
+    await prisma.platformConfig.upsert({
+      where: { key },
+      create: { key, value },
+      update: { value },
+    });
+  }
+
+  revalidatePath("/admin/settings");
+  return { ok: true };
+}
+
+const testEmailSchema = z.object({ to: z.string().trim().email() });
+
+export async function sendTestEmail(to: string): Promise<{ ok: true }> {
+  await requireManageEmailConfig();
+  const { to: recipient } = testEmailSchema.parse({ to });
+
+  if (!(await isEmailConfigured())) {
+    throw new Error("Save your SMTP settings before sending a test email.");
+  }
+
+  await sendEmail({
+    to: recipient,
+    subject: "DPF test email",
+    text: "This is a test email from DPF. If you received it, outbound email is configured correctly.",
+    html: "<p>This is a test email from DPF.</p><p>If you received it, your outbound email (SMTP) is configured correctly.</p>",
+  });
+
+  return { ok: true };
+}

--- a/apps/web/lib/actions/finance.ts
+++ b/apps/web/lib/actions/finance.ts
@@ -492,7 +492,7 @@ export async function signInvoice(input: SignInvoiceInput): Promise<{ ok: true }
 }
 
 async function sendSignedConfirmation(invoiceId: string, token: string): Promise<void> {
-  if (!isEmailConfigured()) return;
+  if (!(await isEmailConfigured())) return;
 
   const invoice = await prisma.invoice.findUnique({
     where: { id: invoiceId },

--- a/apps/web/lib/shared/email.test.ts
+++ b/apps/web/lib/shared/email.test.ts
@@ -8,6 +8,11 @@ vi.mock("nodemailer", () => ({
   },
 }));
 
+// No in-portal SMTP config in these tests → resolveSmtpConfig falls back to env vars.
+vi.mock("@dpf/db", () => ({
+  prisma: { platformConfig: { findMany: vi.fn(() => Promise.resolve([])) } },
+}));
+
 import { sendEmail, composeInvoiceEmail, isEmailConfigured } from "./email";
 
 describe("composeInvoiceEmail", () => {
@@ -57,25 +62,25 @@ describe("composeInvoiceEmail", () => {
 });
 
 describe("isEmailConfigured", () => {
-  it("returns true when SMTP_HOST is set", () => {
+  it("returns true when SMTP_HOST is set (env fallback)", async () => {
     const saved = process.env.SMTP_HOST;
     process.env.SMTP_HOST = "smtp.test.example";
-    expect(isEmailConfigured()).toBe(true);
+    expect(await isEmailConfigured()).toBe(true);
     if (saved === undefined) delete process.env.SMTP_HOST;
     else process.env.SMTP_HOST = saved;
   });
 
-  it("returns false when SMTP_HOST is unset (cold-start fresh install)", () => {
+  it("returns false when SMTP_HOST is unset (cold-start fresh install)", async () => {
     const saved = process.env.SMTP_HOST;
     delete process.env.SMTP_HOST;
-    expect(isEmailConfigured()).toBe(false);
+    expect(await isEmailConfigured()).toBe(false);
     if (saved !== undefined) process.env.SMTP_HOST = saved;
   });
 
-  it("returns false when SMTP_HOST is empty", () => {
+  it("returns false when SMTP_HOST is empty", async () => {
     const saved = process.env.SMTP_HOST;
     process.env.SMTP_HOST = "";
-    expect(isEmailConfigured()).toBe(false);
+    expect(await isEmailConfigured()).toBe(false);
     if (saved === undefined) delete process.env.SMTP_HOST;
     else process.env.SMTP_HOST = saved;
   });

--- a/apps/web/lib/shared/email.ts
+++ b/apps/web/lib/shared/email.ts
@@ -1,4 +1,5 @@
 import nodemailer from "nodemailer";
+import { resolveSmtpConfig, isSmtpConfigured } from "./smtp-config";
 
 type EmailOptions = {
   to: string;
@@ -362,7 +363,8 @@ export function composeExpenseApprovalEmail(params: ExpenseApprovalEmailParams) 
 }
 
 /**
- * Whether outbound email delivery is configured (SMTP host present).
+ * Whether outbound email delivery is configured — a usable SMTP host resolves
+ * from either the in-portal settings (Admin → Settings → Email) or env vars.
  *
  * Send flows that are operator-triggered (e.g. "Send Invoice") should pre-flight
  * this and surface an actionable error, rather than relying on sendEmail's
@@ -370,16 +372,17 @@ export function composeExpenseApprovalEmail(params: ExpenseApprovalEmailParams) 
  * cold-start fresh install with no SMTP, that fake dev success is exactly the
  * silent no-op the Runs 6 & 7 audit flagged.
  */
-export function isEmailConfigured(): boolean {
-  return Boolean(process.env.SMTP_HOST);
+export async function isEmailConfigured(): Promise<boolean> {
+  return isSmtpConfigured();
 }
 
 export async function sendEmail(options: EmailOptions): Promise<{ messageId: string }> {
-  const host = process.env.SMTP_HOST;
-  const port = parseInt(process.env.SMTP_PORT || "587", 10);
-  const user = process.env.SMTP_USER;
-  const pass = process.env.SMTP_PASS;
-  const from = options.from || process.env.SMTP_FROM || "noreply@example.com";
+  const cfg = await resolveSmtpConfig();
+  const host = cfg.host;
+  const port = cfg.port;
+  const user = cfg.user;
+  const pass = cfg.pass;
+  const from = options.from || cfg.from || "noreply@example.com";
 
   // Without SMTP config: in production this is a hard failure — returning a
   // fake success would let callers record an email as "sent" that never went
@@ -402,8 +405,8 @@ export async function sendEmail(options: EmailOptions): Promise<{ messageId: str
   const transport = nodemailer.createTransport({
     host,
     port,
-    secure: port === 465,
-    auth: user ? { user, pass } : undefined,
+    secure: cfg.secure,
+    auth: user ? { user, pass: pass ?? undefined } : undefined,
   });
 
   const result = await transport.sendMail({

--- a/apps/web/lib/shared/smtp-config.test.ts
+++ b/apps/web/lib/shared/smtp-config.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: { platformConfig: { findMany: vi.fn() } },
+}));
+
+import { prisma } from "@dpf/db";
+import { resolveSmtpConfig, isSmtpConfigured, getSmtpConfigStatus } from "./smtp-config";
+
+const mockFindMany = (
+  prisma as unknown as { platformConfig: { findMany: ReturnType<typeof vi.fn> } }
+).platformConfig.findMany;
+
+const ENV_KEYS = ["SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASS", "SMTP_FROM", "SMTP_SECURE"];
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  mockFindMany.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe("resolveSmtpConfig", () => {
+  it("returns no host when neither DB nor env is configured", async () => {
+    const cfg = await resolveSmtpConfig();
+    expect(cfg.host).toBeNull();
+    expect(cfg.source).toBe("none");
+    expect(await isSmtpConfigured()).toBe(false);
+  });
+
+  it("falls back to env vars when the DB has no config", async () => {
+    process.env.SMTP_HOST = "smtp.env.example";
+    process.env.SMTP_PORT = "2525";
+    process.env.SMTP_USER = "envuser";
+    process.env.SMTP_PASS = "envpass";
+    process.env.SMTP_FROM = "env@example.com";
+
+    const cfg = await resolveSmtpConfig();
+    expect(cfg).toMatchObject({
+      host: "smtp.env.example",
+      port: 2525,
+      user: "envuser",
+      pass: "envpass",
+      from: "env@example.com",
+      source: "env",
+    });
+    expect(await isSmtpConfigured()).toBe(true);
+  });
+
+  it("prefers DB config over env vars", async () => {
+    process.env.SMTP_HOST = "smtp.env.example";
+    mockFindMany.mockResolvedValue([
+      { key: "smtp_host", value: "smtp.db.example" },
+      { key: "smtp_port", value: "465" },
+      { key: "smtp_user", value: "dbuser" },
+      { key: "smtp_from", value: "db@example.com" },
+      { key: "smtp_secure", value: "true" },
+      { key: "smtp_pass_enc", value: "dbsecret" }, // stored plaintext → decrypt passes through
+    ]);
+
+    const cfg = await resolveSmtpConfig();
+    expect(cfg).toMatchObject({
+      host: "smtp.db.example",
+      port: 465,
+      user: "dbuser",
+      pass: "dbsecret",
+      from: "db@example.com",
+      secure: true,
+      source: "db",
+    });
+  });
+
+  it("derives secure=true from port 465 when not explicitly set", async () => {
+    mockFindMany.mockResolvedValue([
+      { key: "smtp_host", value: "h" },
+      { key: "smtp_port", value: "465" },
+    ]);
+    expect((await resolveSmtpConfig()).secure).toBe(true);
+  });
+});
+
+describe("getSmtpConfigStatus", () => {
+  it("reports configured + passConfigured without exposing the password", async () => {
+    mockFindMany.mockResolvedValue([
+      { key: "smtp_host", value: "smtp.db.example" },
+      { key: "smtp_pass_enc", value: "stored-secret" },
+    ]);
+    const s = await getSmtpConfigStatus();
+    expect(s.configured).toBe(true);
+    expect(s.passConfigured).toBe(true);
+    expect(s).not.toHaveProperty("pass");
+    expect(Object.values(s)).not.toContain("stored-secret");
+  });
+
+  it("reports not-configured on a cold install", async () => {
+    const s = await getSmtpConfigStatus();
+    expect(s.configured).toBe(false);
+    expect(s.passConfigured).toBe(false);
+    expect(s.source).toBe("none");
+  });
+});

--- a/apps/web/lib/shared/smtp-config.ts
+++ b/apps/web/lib/shared/smtp-config.ts
@@ -1,0 +1,104 @@
+// Resolve the install's outbound SMTP config from the in-portal settings
+// (PlatformConfig) with a fall-back to environment variables, so existing
+// env-configured installs keep working while operators can self-serve via
+// Admin → Settings → Email. The password is stored encrypted (credential-crypto);
+// everything else is plain PlatformConfig key/value.
+//
+// Server-only (reads the DB + decrypts). Do not import from a client component.
+
+import { prisma } from "@dpf/db";
+import { decryptSecret } from "@/lib/govern/credential-crypto";
+
+export const SMTP_CONFIG_KEYS = [
+  "smtp_host",
+  "smtp_port",
+  "smtp_user",
+  "smtp_from",
+  "smtp_secure",
+  "smtp_pass_enc",
+] as const;
+
+export type ResolvedSmtp = {
+  host: string | null;
+  port: number;
+  secure: boolean;
+  user: string | null;
+  pass: string | null;
+  from: string | null;
+  /** Where the host came from — drives the settings UI's "source" hint. */
+  source: "db" | "env" | "none";
+};
+
+export type SmtpConfigStatus = {
+  configured: boolean;
+  host: string | null;
+  port: number;
+  user: string | null;
+  from: string | null;
+  secure: boolean;
+  /** True when a password is stored (we never return the value itself). */
+  passConfigured: boolean;
+  source: ResolvedSmtp["source"];
+};
+
+async function readDbConfig(): Promise<Record<string, string>> {
+  const rows = await prisma.platformConfig.findMany({
+    where: { key: { in: [...SMTP_CONFIG_KEYS] } },
+    select: { key: true, value: true },
+  });
+  const out: Record<string, string> = {};
+  for (const r of rows) {
+    if (r.value == null) continue;
+    const v = typeof r.value === "string" ? r.value : String(r.value);
+    if (v.length > 0) out[r.key] = v;
+  }
+  return out;
+}
+
+/** Full resolved config including the (decrypted) password. Server-only. */
+export async function resolveSmtpConfig(): Promise<ResolvedSmtp> {
+  const db = await readDbConfig();
+
+  const host = db.smtp_host ?? process.env.SMTP_HOST ?? null;
+  const source: ResolvedSmtp["source"] = db.smtp_host
+    ? "db"
+    : process.env.SMTP_HOST
+      ? "env"
+      : "none";
+
+  const portStr = db.smtp_port ?? process.env.SMTP_PORT ?? "587";
+  const port = Number.parseInt(portStr, 10) || 587;
+
+  const user = db.smtp_user ?? process.env.SMTP_USER ?? null;
+  const from = db.smtp_from ?? process.env.SMTP_FROM ?? null;
+
+  const secureRaw = db.smtp_secure ?? process.env.SMTP_SECURE ?? null;
+  const secure = secureRaw != null ? secureRaw === "true" : port === 465;
+
+  const pass = db.smtp_pass_enc
+    ? decryptSecret(db.smtp_pass_enc)
+    : (process.env.SMTP_PASS ?? null);
+
+  return { host, port, secure, user, pass, from, source };
+}
+
+/** Whether outbound email can be sent (a host is resolvable from DB or env). */
+export async function isSmtpConfigured(): Promise<boolean> {
+  return Boolean((await resolveSmtpConfig()).host);
+}
+
+/** Status for the settings UI — never includes the password value. */
+export async function getSmtpConfigStatus(): Promise<SmtpConfigStatus> {
+  const db = await readDbConfig();
+  const cfg = await resolveSmtpConfig();
+  return {
+    configured: Boolean(cfg.host),
+    host: cfg.host,
+    port: cfg.port,
+    user: cfg.user,
+    from: cfg.from,
+    secure: cfg.secure,
+    passConfigured: Boolean(db.smtp_pass_enc || process.env.SMTP_PASS),
+    source: cfg.source,
+  };
+}

--- a/docs/testing/pending-backlog-items.md
+++ b/docs/testing/pending-backlog-items.md
@@ -16,14 +16,15 @@
 
 | PBI ref | Title | Severity | Source | GitHub Issue | Portal BI (post-audit) | Status |
 |---|---|---|---|---|---|---|
-| PBI-INV-01 | SMTP configuration UI / onboarding prompt | important | [PR #1865](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1865) — Gap 2 follow-up | [#1875](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/1875) | — | open |
+| PBI-INV-01 | SMTP configuration UI / onboarding prompt | important | [PR #1865](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1865) — Gap 2 follow-up | [#1875](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/1875) | — | **in [PR #1887](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1887)** |
 | PBI-INV-02 | Phase 2 — third-party e-signature (DocuSign/HelloSign) for standalone documents | important | [PR #1865](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1865) — Gap 3 Phase 2 | [#1876](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/1876) | — | open |
 | PBI-INV-03 | Remove dead `InvoiceActions.tsx` (superseded by `InvoiceSendButton`) | minor | [PR #1865](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1865) cleanup | [#1871](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1871) | n/a — shipped | **done** |
+| PBI-INV-04 | Bundled zero-config email relay (SMTP panel becomes the BYO override) | important | [PR #1887](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1887) follow-up; DPF zero-click principle | [#1888](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/1888) | — | open |
 
 ## Details
 
 ### PBI-INV-01 — SMTP configuration UI / onboarding prompt
-- **Severity:** important · **Issue:** #1875
+- **Severity:** important · **Issue:** #1875 · **Status:** in [PR #1887](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1887)
 - **Context:** PR #1865 added a send-time pre-flight (`isEmailConfigured()` → HTTP 422 with an actionable message) so "Send Invoice" no longer silently fails when SMTP is unconfigured. But SMTP is **env-var only** (`SMTP_HOST` / `SMTP_USER` / `SMTP_PASS` / `SMTP_FROM`) — there is no in-portal way to configure it, so a fresh-install operator cannot enable email delivery without shell/env access.
 - **Scope:** a Settings → Email surface (and/or setup-wizard step) to enter SMTP config, stored via the credential-encryption layer (`CREDENTIAL_ENCRYPTION_KEY`); `isEmailConfigured()` / `sendEmail()` resolve from this store (env-var fallback retained).
 - **Acceptance:** operator configures SMTP from the portal on a fresh install → "Send Invoice" delivers with no env var set; with nothing configured the 422 still surfaces.
@@ -39,3 +40,9 @@
 ### PBI-INV-03 — Remove dead `InvoiceActions.tsx`
 - **Severity:** minor · **Status: done** — shipped via [PR #1871](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1871) (merged to main).
 - **Context:** `apps/web/app/(shell)/finance/invoices/[id]/InvoiceActions.tsx` was unreferenced dead code; the live send button is `apps/web/components/finance/InvoiceSendButton.tsx`. Removed.
+
+### PBI-INV-04 — Bundled zero-config email relay
+- **Severity:** important · **Issue:** #1888
+- **Context:** the SMTP panel (PBI-INV-01) is the **BYO** path. DPF's zero-click / bundled-services-active-by-default principle wants outbound email to work on a fresh install with **no** setup. This tracks shipping a bundled default sender, with the SMTP panel as the override.
+- **Scope:** default platform email sender/relay; resolution order operator-SMTP (DB) → env → bundled relay; deliverability (SPF/DKIM), per-install limits/abuse controls, from-address rewriting. Larger build / own epic.
+- **Acceptance:** a brand-new install with nothing configured can "Send Invoice" and the customer receives it; operators can still override with their own SMTP.


### PR DESCRIPTION
Builds the in-portal SMTP configuration the handoff's Gap 2 deferred (PBI-INV-01 / #1875). A non-technical operator can now enable outbound email from the portal instead of needing env-var/shell access — which is what makes "Send Invoice" and the e-signature emails work end-to-end for a real customer (not just a test rig).

## What
- **Admin → Settings → Email** panel: host, port, username, password (masked, "leave blank to keep"), from-address, TLS toggle, and a **Send test email** button.
- Config resolves **DB-first with env-var fallback**, so existing env-configured installs are unchanged.
- Password **encrypted at rest** via the existing `credential-crypto` layer; never returned to the client.
- **No schema change** — reuses the `PlatformConfig` key/value store (where Google/Apple OAuth secrets already live).
- The "Send Invoice" 422 now points operators to the new page.

## Reuse (no new substrate)
| Concern | Reused |
|---|---|
| Storage | `PlatformConfig` |
| Secret encryption | `lib/govern/credential-crypto` |
| UI placement | Admin → Settings (beside PlatformKeys / SocialAuth panels) |
| Auth guard | `manage_provider_connections` (same as sibling panels) |

## Tests (62 pass)
- `smtp-config` resolver: DB/env precedence, secure-from-port, **no password leak** in status
- `email-config` actions: auth gate, password encryption, blank-keeps-existing, test-email gating
- updated `email.test` for the async `isEmailConfigured`/`sendEmail` path

Typecheck clean on changed files (CI is binding), bundle-boundary + barrel snapshots green.

Follow-up filed separately: a **bundled zero-config email relay** so email works out of the box (DPF zero-click principle), with this SMTP panel as the BYO override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
