### PR TITLE
feat(ea): IT4IT value-stream SysML extractor — auto-extraction domain 3 (Parity Engine)

### DIFF
--- a/apps/web/lib/ea/reconcile-sysml-projections.test.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.test.ts
@@ -6,11 +6,19 @@ import { reconcileSysmlProjections } from "./reconcile-sysml-projections";
 // threaded — without deep-mocking either reconcile (and with no module mocks → no
 // forks-pool bleed).
 describe("reconcileSysmlProjections", () => {
-  it("runs both domain reconciles and threads their results", async () => {
-    const db = { eaNotation: { findUnique: vi.fn().mockResolvedValue(null) } };
+  it("runs every domain reconcile and threads their results", async () => {
+    // notation absent → the two notation-backed reconciles skip; reference model
+    // absent → the value-stream reconcile skips. All three come back skipped, which
+    // proves all three ran and were threaded — no module mocks → no forks-pool bleed.
+    const db = {
+      eaNotation: { findUnique: vi.fn().mockResolvedValue(null) },
+      eaReferenceModel: { findUnique: vi.fn().mockResolvedValue(null) },
+    };
     const r = await reconcileSysmlProjections({ db: db as never });
     expect(r.mcpAuthority.status).toBe("skipped");
     expect(r.coworkerAuthority.status).toBe("skipped");
+    expect(r.valueStreams.status).toBe("skipped");
     expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(2);
+    expect(db.eaReferenceModel.findUnique).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -10,11 +10,13 @@
 import { prisma } from "@dpf/db";
 import { reconcileMcpAuthorityModel, type McpAuthorityReconcileResult } from "./reconcile-mcp-authority";
 import { reconcileCoworkerAuthority } from "./reconcile-coworker-authority";
+import { reconcileValueStreams } from "./reconcile-value-streams";
 import type { SysmlSeedResult } from "./sysml-model-seed";
 
 export interface SysmlProjectionsResult {
   mcpAuthority: McpAuthorityReconcileResult;
   coworkerAuthority: SysmlSeedResult;
+  valueStreams: SysmlSeedResult;
 }
 
 export async function reconcileSysmlProjections(
@@ -22,5 +24,6 @@ export async function reconcileSysmlProjections(
 ): Promise<SysmlProjectionsResult> {
   const mcpAuthority = await reconcileMcpAuthorityModel({ db: opts.db });
   const coworkerAuthority = await reconcileCoworkerAuthority({ db: opts.db });
-  return { mcpAuthority, coworkerAuthority };
+  const valueStreams = await reconcileValueStreams({ db: opts.db });
+  return { mcpAuthority, coworkerAuthority, valueStreams };
 }

--- a/apps/web/lib/ea/reconcile-value-streams.test.ts
+++ b/apps/web/lib/ea/reconcile-value-streams.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { reconcileValueStreams } from "./reconcile-value-streams";
+
+describe("reconcileValueStreams", () => {
+  it("skips when the IT4IT reference model is not seeded", async () => {
+    const db = {
+      eaReferenceModel: { findUnique: vi.fn().mockResolvedValue(null) },
+      eaReferenceModelElement: { findMany: vi.fn() },
+    };
+    const r = await reconcileValueStreams({ db: db as never });
+    expect(r.status).toBe("skipped");
+    expect(db.eaReferenceModelElement.findMany).not.toHaveBeenCalled();
+  });
+
+  it("queries the IT4IT value-stream + stage rows and threads them to the seeder", async () => {
+    // notation absent → applySysmlModel skips, but the query path is still exercised.
+    const db = {
+      eaReferenceModel: { findUnique: vi.fn().mockResolvedValue({ id: "m1" }) },
+      eaReferenceModelElement: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "vs1", kind: "value_stream", slug: "evaluate", name: "Evaluate", parentId: null },
+          { id: "st1", kind: "value_stream_stage", slug: "eval-gather", name: "Gather", parentId: "vs1" },
+        ]),
+      },
+      eaNotation: { findUnique: vi.fn().mockResolvedValue(null) },
+    };
+    const r = await reconcileValueStreams({ db: db as never });
+    expect(r.status).toBe("skipped");
+    expect(db.eaReferenceModelElement.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { modelId: "m1", kind: { in: ["value_stream", "value_stream_stage"] } },
+      })
+    );
+  });
+});

--- a/apps/web/lib/ea/reconcile-value-streams.ts
+++ b/apps/web/lib/ea/reconcile-value-streams.ts
@@ -1,0 +1,40 @@
+// apps/web/lib/ea/reconcile-value-streams.ts
+//
+// Reconcile the IT4IT value-stream taxonomy into a live SysML projection (Parity
+// Engine). Runtime-safe: reads EaReferenceModelElement (Postgres), resolves the
+// stage→stream hierarchy, and applies via the shared idempotent seeder. Re-derives
+// every run, so it cannot drift. db injected for tests.
+
+import { prisma } from "@dpf/db";
+import { buildValueStreamModel, type ValueStreamRow } from "./value-stream-extract";
+import { applySysmlModel, type SysmlSeedResult } from "./sysml-model-seed";
+
+const IT4IT_MODEL_SLUG = "it4it_v3_0_1";
+
+export async function reconcileValueStreams(opts: { db?: typeof prisma } = {}): Promise<SysmlSeedResult> {
+  const db = opts.db ?? prisma;
+
+  const model = await db.eaReferenceModel.findUnique({ where: { slug: IT4IT_MODEL_SLUG }, select: { id: true } });
+  if (!model) {
+    console.warn(`[value-streams] IT4IT reference model "${IT4IT_MODEL_SLUG}" not seeded — skipping`);
+    return { status: "skipped", created: 0, updated: 0, removed: 0 };
+  }
+
+  const elements: Array<{ id: string; kind: string; slug: string; name: string; parentId: string | null }> =
+    await db.eaReferenceModelElement.findMany({
+      where: { modelId: model.id, kind: { in: ["value_stream", "value_stream_stage"] } },
+      select: { id: true, kind: true, slug: true, name: true, parentId: true },
+    });
+
+  const idToSlug = new Map(elements.map((e) => [e.id, e.slug]));
+  const rows: ValueStreamRow[] = elements.map((e) => ({
+    kind: e.kind,
+    slug: e.slug,
+    name: e.name,
+    parentSlug: e.parentId ? idToSlug.get(e.parentId) ?? null : null,
+  }));
+
+  const result = await applySysmlModel(buildValueStreamModel(rows), { db });
+  console.info(`[value-streams] reconcile ${result.status}: created=${result.created} updated=${result.updated} removed=${result.removed}`);
+  return result;
+}

--- a/apps/web/lib/ea/value-stream-extract.test.ts
+++ b/apps/web/lib/ea/value-stream-extract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildValueStreamModel, VALUE_STREAM_PACKAGE_KEY, type ValueStreamRow } from "./value-stream-extract";
+
+const ROWS: ValueStreamRow[] = [
+  { kind: "value_stream", slug: "strategy-to-portfolio", name: "Strategy to Portfolio", parentSlug: null },
+  { kind: "value_stream_stage", slug: "s2p-evaluate", name: "Evaluate", parentSlug: "strategy-to-portfolio" },
+  { kind: "value_stream_stage", slug: "orphan-stage", name: "Orphan", parentSlug: "nonexistent" },
+];
+
+describe("buildValueStreamModel", () => {
+  const model = buildValueStreamModel(ROWS);
+  const byKey = new Map(model.elements.map((e) => [e.sysmlKey, e]));
+
+  it("maps value streams to part_definitions and stages to part_usages", () => {
+    expect(byKey.get(VALUE_STREAM_PACKAGE_KEY)?.typeSlug).toBe("package");
+    expect(byKey.get("vstream:vs:strategy-to-portfolio")?.typeSlug).toBe("part_definition");
+    expect(byKey.get("vstream:stage:s2p-evaluate")?.typeSlug).toBe("part_usage");
+    expect(model.elements).toHaveLength(4); // pkg + 1 stream + 2 stages
+  });
+
+  it("contains a stage under its parent stream when the parent is known", () => {
+    expect(model.relationships).toContainEqual({
+      fromKey: "vstream:vs:strategy-to-portfolio",
+      toKey: "vstream:stage:s2p-evaluate",
+      relSlug: "contains",
+    });
+  });
+
+  it("falls back to the package when a stage's parent stream is unknown", () => {
+    expect(model.relationships).toContainEqual({
+      fromKey: VALUE_STREAM_PACKAGE_KEY,
+      toKey: "vstream:stage:orphan-stage",
+      relSlug: "contains",
+    });
+  });
+
+  it("declares the element/relationship types and soft-remove prefix it needs", () => {
+    expect(model.elementTypeSlugs).toEqual(["package", "part_definition", "part_usage"]);
+    expect(model.relTypeSlugs).toEqual(["contains"]);
+    expect(model.softRemovePrefix).toBe("vstream:");
+  });
+});

--- a/apps/web/lib/ea/value-stream-extract.ts
+++ b/apps/web/lib/ea/value-stream-extract.ts
@@ -1,0 +1,82 @@
+// apps/web/lib/ea/value-stream-extract.ts
+//
+// Pure extractor for the IT4IT value-stream SysML projection (Parity Engine).
+// Projects the value-stream taxonomy (already auto-extracted from the IT4IT
+// functional-criteria workbook into EaReferenceModelElement) into the SysML
+// notation, so SysML requirements/parts can trace to value streams and the
+// operating-model dimension is represented in the systems model. Runtime-safe: the
+// source is a Postgres table, read by the reconcile shell; this module is pure
+// (takes the rows) and testable. SysML mapping:
+//   - value_stream        → part_definition (vstream:vs:<slug>)
+//   - value_stream_stage  → part_usage      (vstream:stage:<slug>), contained by its stream
+//   - package contains the streams; each stream contains its stages
+
+import type { SysmlDesiredModel } from "./sysml-model-seed";
+
+export const VALUE_STREAM_PACKAGE_KEY = "vstream:pkg";
+
+export interface ValueStreamRow {
+  kind: string; // "value_stream" | "value_stream_stage"
+  slug: string;
+  name: string;
+  /** For a stage: the slug of its parent value_stream (resolved by the reconcile). */
+  parentSlug: string | null;
+}
+
+export function buildValueStreamModel(rows: ValueStreamRow[]): SysmlDesiredModel {
+  const elements: SysmlDesiredModel["elements"] = [];
+  const relationships: SysmlDesiredModel["relationships"] = [];
+
+  elements.push({
+    sysmlKey: VALUE_STREAM_PACKAGE_KEY,
+    typeSlug: "package",
+    name: "IT4IT Value Streams",
+    description:
+      "Live SysML projection of the IT4IT value-stream taxonomy, derived from the EaReferenceModelElement IT4IT model so it cannot drift from the reference data.",
+    properties: { sourceKey: "packages/db/src/seed-ea-reference-models.ts (IT4IT)" },
+  });
+
+  const streamKeys = new Set<string>();
+  for (const r of rows) {
+    if (r.kind !== "value_stream") continue;
+    const key = `vstream:vs:${r.slug}`;
+    streamKeys.add(r.slug);
+    elements.push({
+      sysmlKey: key,
+      typeSlug: "part_definition",
+      name: r.name,
+      description: `IT4IT value stream: ${r.name}.`,
+      properties: { sourceKey: `it4it:value_stream:${r.slug}`, slug: r.slug },
+    });
+    relationships.push({ fromKey: VALUE_STREAM_PACKAGE_KEY, toKey: key, relSlug: "contains" });
+  }
+
+  for (const r of rows) {
+    if (r.kind !== "value_stream_stage") continue;
+    const key = `vstream:stage:${r.slug}`;
+    elements.push({
+      sysmlKey: key,
+      typeSlug: "part_usage",
+      name: r.name,
+      description: `Value-stream stage: ${r.name}.`,
+      properties: { sourceKey: `it4it:value_stream_stage:${r.slug}`, slug: r.slug, parent: r.parentSlug },
+    });
+    // Contain the stage under its parent stream when known, else under the package.
+    const parentKey = r.parentSlug && streamKeys.has(r.parentSlug) ? `vstream:vs:${r.parentSlug}` : VALUE_STREAM_PACKAGE_KEY;
+    relationships.push({ fromKey: parentKey, toKey: key, relSlug: "contains" });
+  }
+
+  return {
+    elements,
+    relationships,
+    elementTypeSlugs: ["package", "part_definition", "part_usage"],
+    relTypeSlugs: ["contains"],
+    view: {
+      name: "IT4IT Value Streams — Live Projection",
+      description: "Live, system-maintained projection of the IT4IT value-stream taxonomy.",
+      viewpointName: "System Decomposition & Interfaces",
+      scopeRef: "value-streams",
+    },
+    softRemovePrefix: "vstream:",
+  };
+}


### PR DESCRIPTION
## Summary

Third auto-extraction domain for the Parity Engine. **Pivoted from routes** after research: there is no runtime-importable route source (the app dir is compiled away in a standalone build; no nav-config module), so a routes projection would need a build-time manifest — deferred as its own slice. **Value streams have a clean, runtime-safe source**: the IT4IT taxonomy is already auto-extracted into `EaReferenceModelElement` (Postgres), so it projects cleanly with the existing shared seeder — no new infra.

- **`value-stream-extract.ts`** (pure): `value_stream → part_definition`, `value_stream_stage → part_usage` (contained under its stream; falls back to the package if the parent is unknown), stable `vstream:*` keys.
- **`reconcile-value-streams.ts`**: reads the IT4IT model rows, resolves the stage→stream hierarchy, applies via `applySysmlModel`. Wired into `reconcile-sysml-projections` so the **nightly + on-demand** passes refresh it alongside MCP-authority and coworker-workforce.

The engine now auto-derives **three** architecture domains (tool authority, coworker workforce, value streams), all drift-proof by re-derivation.

## Verified (source-local)
- **7 unit tests pass** — pure builder (type mapping, stage-under-stream hierarchy, unknown-parent fallback, declared types/prefix), reconcile (IT4IT-absent skip, correct query filter), and the combined orchestrator now threading all three domains.
- Touched files typecheck clean (worktree `@dpf/db` artifact aside).
- Branched fresh off `origin/main`; rebased current.

## Engine status
Detect (gate) ✅ · auto-derive: authority ✅ workforce ✅ **value-streams ✅ (this PR)** · schedule ✅ · on-demand ✅. Remaining: routes (needs a build-time manifest), code-structure bridge (Neo4j), BPMN processes; converge the older hand-seeds onto the shared seeder; kernel-principle vector calibration (yours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)