### PR TITLE
feat(gates): make whole-outcome enforcement archetype-aware — design gate + release gate

### DIFF
--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -517,6 +517,8 @@ describe("buildArchitectureReviewPrompt", () => {
     expect(prompt).toContain("[reference-doc]");
     // Whole-over-local is a first-class architectural-alignment concern.
     expect(prompt).toContain("Optimize for the Whole");
+    // Archetype/storefront designs are measured against their load-bearing stages.
+    expect(prompt).toContain("LOAD-BEARING value-stream");
     expect(prompt).toContain("JSON FORMAT");
   });
 
@@ -545,6 +547,10 @@ describe("buildArchitectureReviewPrompt", () => {
       (r) => r.path === "docs/founder-kernel/wiki/principles/",
     );
     expect(kernel?.covers).toContain("optimize-for-the-whole");
+    // Archetype designs are measured against their load-bearing value-stream
+    // stages — the whole-outcome measure that survives portal rebuilds.
+    expect(ARCHITECTURE_REVIEW_REFERENCES.map((r) => r.path))
+      .toContain("docs/architecture/archetype-business-value-streams.md");
   });
 });
 

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -209,6 +209,12 @@ export const ARCHITECTURE_REVIEW_REFERENCES: ReadonlyArray<{
     path: "docs/superpowers/specs/2026-05-09-deployment-contracts.md",
     covers: "the canonical deployment contracts every substrate must wrap",
   },
+  {
+    label: "Archetype value streams",
+    path: "docs/architecture/archetype-business-value-streams.md",
+    covers:
+      "per-archetype operational value streams + load-bearing stages — the whole outcome each archetype design must serve; stage names stay stable across portal rebuilds, so this is the rebuild-surviving measure of whole-vs-local for storefront/archetype work",
+  },
 ];
 
 function formatArchitectureReferences(): string {
@@ -264,6 +270,7 @@ export function buildArchitectureReviewPrompt(
   const focus =
     input.kind === "design"
       ? `- Does this serve the end-to-end outcome / value stream it belongs to, rather than locally optimizing one step at the whole's expense? The design should name the broader objective it advances (Optimize for the Whole).
+- If the change touches an archetype/storefront surface, does it serve that archetype's LOAD-BEARING value-stream stage(s) (per docs/architecture/archetype-business-value-streams.md), not just a generic step? Strengthening a non-load-bearing stage while weakening the load-bearing one fails the whole — and those stage names stay stable across portal rebuilds, so they are the durable measure.
 - Does the data model EXTEND canonical models (Organization for identity, Principal/PrincipalAlias for identity-bearing entities) rather than create parallel tables?
 - Does the proposed approach respect single-source-of-truth (no rule/fact/decision duplicated)?
 - Does it choose the architecturally sound shape over a shortcut that creates debt?


### PR DESCRIPTION
Archetype-rebuild prep, at the **stable spine** level so it survives portal regeneration. The portal is rebuilt per business archetype (53 of them); these two changes ensure every archetype build is held to **its** whole outcome — its load-bearing value-stream stages — at both ends of the lifecycle, without coupling to the churning portal layer.

The rebuild already has a whole-outcome model: the canonical audit derives severity from each archetype's **load-bearing value-stream stages** (`docs/architecture/archetype-business-value-streams.md`), which "stay stable even when the portal design changes." These changes wire the kernel's `optimize-for-the-whole` gate ([#1882](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1882)) to that model.

## Commit 1 — design gate (design time)

- Adds `archetype-business-value-streams.md` to `ARCHITECTURE_REVIEW_REFERENCES` so the Enterprise Architect lens measures archetype designs against their load-bearing stages.
- Adds an archetype-conditional focus bullet: a change touching a storefront/archetype surface must serve that archetype's **load-bearing** stage — strengthening a non-load-bearing stage while weakening the load-bearing one fails the whole.

## Commit 2 — release gate (release time)

- Adds a **Release Gate: Archetype Whole-Outcome Acceptance** to `tests/e2e/platform-qa-plan.md`: the representative **12-archetype acceptance bar** must `Pass` (severity derived from load-bearing stages) before a release. Enforced by the existing `release-qa-plan` principle ("every release passes this plan") — no new machinery.
- Registers the `ARCH-ACC` QA-ID family in the parser and **locks the gate into the plan with a test** so it can't be silently dropped (the principle applied to itself).

So an archetype's whole outcome is now the measure at design time *and* release time, from one source of truth — and verification still flows through the canonical browser audit, never ad-hoc previews of an in-rebuild portal.

## Verification

`build-reviewers` 42/42, `route-contracts` + `qa-plan-index` 7/7. Spine-only (governance/contract/QA-plan); no schema, no portal-instance coupling.

## Follow-on

Make the per-archetype outcome **queryable** (`Epic.expectedOutcome` generalized to archetypes) so the design gate and the audit read load-bearing stages as data from one place — filed via the portal given the platform's current fragility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)