### PR TITLE
feat(build): persist per-reviewer verdicts → named reviewer chips (spec §6.2a)

### DIFF
--- a/apps/web/components/build/ReviewReadinessStrip.test.tsx
+++ b/apps/web/components/build/ReviewReadinessStrip.test.tsx
@@ -104,6 +104,30 @@ describe("ReviewReadinessStrip chips", () => {
     expect(html).toContain('aria-label="Architecture: advisory — 1 note"');
   });
 
+  it("renders named reviewer chips when per-reviewer verdicts are persisted", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip
+        build={build({
+          planReview: review({
+            decision: "fail",
+            reviewers: [
+              { source: "reviewer-1", label: "Primary review", role: "reviewer", decision: "pass", issueCounts: { critical: 0, important: 0, minor: 0 } },
+              { source: "reviewer-2", label: "Independent review", role: "reviewer", decision: "fail", issueCounts: { critical: 1, important: 0, minor: 0 } },
+              { source: "architect", label: "Architecture", role: "architect", decision: "pass", issueCounts: { critical: 0, important: 0, minor: 0 } },
+            ],
+          }),
+        })}
+        phase="review"
+      />,
+    );
+    expect(html).toContain('data-lens-key="reviewer:reviewer-1"');
+    expect(html).toContain('aria-label="Primary review: pass — cleared"');
+    expect(html).toContain('aria-label="Independent review: fail — 1 critical"');
+    expect(html).toContain('aria-label="Architecture: advisory — aligned"');
+    // The merged checklist chip is replaced by the per-reviewer chips.
+    expect(html).not.toContain('data-lens-key="checklist"');
+  });
+
   it("renders no raw hex literals (DPF token invariant)", () => {
     const html = renderToStaticMarkup(
       <ReviewReadinessStrip

--- a/apps/web/lib/build/review-lenses.test.ts
+++ b/apps/web/lib/build/review-lenses.test.ts
@@ -361,3 +361,82 @@ describe("deriveReviewLenses — composition", () => {
     ]);
   });
 });
+
+describe("deriveReviewLenses — per-reviewer graduation", () => {
+  const reviewers = [
+    {
+      source: "reviewer-1" as const,
+      label: "Primary review",
+      role: "reviewer" as const,
+      decision: "pass" as const,
+      issueCounts: { critical: 0, important: 0, minor: 0 },
+    },
+    {
+      source: "reviewer-2" as const,
+      label: "Independent review",
+      role: "reviewer" as const,
+      decision: "fail" as const,
+      issueCounts: { critical: 1, important: 0, minor: 1 },
+    },
+    {
+      source: "architect" as const,
+      label: "Architecture",
+      role: "architect" as const,
+      decision: "pass" as const,
+      issueCounts: { critical: 0, important: 2, minor: 0 },
+    },
+  ];
+
+  it("expands the merged checklist chip into one chip per named reviewer", () => {
+    const keys = deriveReviewLenses(build({ planReview: review({ reviewers }) })).map((l) => l.key);
+    expect(keys).toEqual([
+      "reviewer:reviewer-1",
+      "reviewer:reviewer-2",
+      "reviewer:architect",
+      "verification",
+    ]);
+    // The merged checklist + architectureAdvisory lenses are replaced, not added.
+    expect(keys).not.toContain("checklist");
+    expect(keys).not.toContain("architecture");
+  });
+
+  it("maps reviewer decision + severity to chip state and detail", () => {
+    const lenses = deriveReviewLenses(build({ planReview: review({ reviewers }) }));
+    expect(lensByKey(lenses, "reviewer:reviewer-1")).toMatchObject({ state: "pass", detail: "cleared" });
+    expect(lensByKey(lenses, "reviewer:reviewer-2")).toMatchObject({
+      state: "fail",
+      detail: "1 critical · 1 minor",
+    });
+    // architect role is always advisory, never gating, regardless of decision
+    expect(lensByKey(lenses, "reviewer:architect")).toMatchObject({ state: "advisory", detail: "2 notes" });
+  });
+
+  it("shows 'review unavailable' for a parse-error reviewer verdict", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          planReview: review({
+            reviewers: [
+              {
+                source: "reviewer-1",
+                label: "Primary review",
+                role: "reviewer",
+                decision: "fail",
+                issueCounts: { critical: 0, important: 0, minor: 0 },
+                parseError: true,
+              },
+            ],
+          }),
+        }),
+      ),
+      "reviewer:reviewer-1",
+    );
+    expect(l).toMatchObject({ state: "pending", detail: "review unavailable" });
+  });
+
+  it("falls back to the merged checklist lens when reviewers[] is absent (older rows)", () => {
+    const keys = deriveReviewLenses(build({ planReview: review({ decision: "pass" }) })).map((l) => l.key);
+    expect(keys).toContain("checklist");
+    expect(keys).not.toContain("reviewer:reviewer-1");
+  });
+});

--- a/apps/web/lib/build/review-lenses.ts
+++ b/apps/web/lib/build/review-lenses.ts
@@ -12,7 +12,7 @@
 //
 // No DB imports, no side effects — fully unit-testable in the node environment.
 
-import type { FeatureBuildRow, ReviewResult } from "@/lib/feature-build-types";
+import type { FeatureBuildRow, ReviewResult, ReviewerVerdict } from "@/lib/feature-build-types";
 
 export type ReviewLensState = "pass" | "fail" | "advisory" | "partial" | "pending";
 
@@ -36,6 +36,45 @@ function summarizeIssues(issues: ReviewResult["issues"]): string {
   if (counts.important) parts.push(`${counts.important} important`);
   if (counts.minor) parts.push(`${counts.minor} minor`);
   return parts.join(" · ");
+}
+
+/** Compact severity summary from pre-counted verdict tallies. */
+function summarizeCounts(counts: ReviewerVerdict["issueCounts"]): string {
+  const parts: string[] = [];
+  if (counts.critical) parts.push(`${counts.critical} critical`);
+  if (counts.important) parts.push(`${counts.important} important`);
+  if (counts.minor) parts.push(`${counts.minor} minor`);
+  return parts.join(" · ");
+}
+
+/** Graduation path: when per-reviewer verdicts were persisted (newer rows),
+ *  expand the single merged checklist chip into one chip per named reviewer
+ *  (Primary / Independent / Architecture). Returns null when no verdicts are
+ *  present, so the caller falls back to the merged checklist + architecture
+ *  lenses for older rows. */
+function reviewerLenses(review: ReviewResult | null): ReviewLens[] | null {
+  const reviewers = review?.reviewers;
+  if (!reviewers || reviewers.length === 0) return null;
+  return reviewers.map((v): ReviewLens => {
+    const key = `reviewer:${v.source}`;
+    if (v.parseError) {
+      return { key, label: v.label, state: "pending", detail: "review unavailable" };
+    }
+    if (v.role === "architect") {
+      const notes = v.issueCounts.critical + v.issueCounts.important + v.issueCounts.minor;
+      return {
+        key,
+        label: v.label,
+        state: "advisory",
+        detail: notes === 0 ? "aligned" : `${notes} note${notes === 1 ? "" : "s"}`,
+      };
+    }
+    const summary = summarizeCounts(v.issueCounts);
+    if (v.decision === "fail") {
+      return { key, label: v.label, state: "fail", detail: summary || "blocking issues" };
+    }
+    return { key, label: v.label, state: "pass", detail: summary ? `cleared · ${summary}` : "cleared" };
+  });
 }
 
 /** Append a "round N" / oscillating suffix when the review iterated. */
@@ -162,13 +201,19 @@ function acceptanceLens(acceptanceMet: FeatureBuildRow["acceptanceMet"]): Review
  */
 export function deriveReviewLenses(build: FeatureBuildRow): ReviewLens[] {
   const checklistReview = build.planReview ?? build.designReview ?? null;
-  const lenses: Array<ReviewLens | null> = [
-    checklistLens(checklistReview),
-    architectureLens(checklistReview),
+  // Graduation: when per-reviewer verdicts are persisted, expand the merged
+  // checklist + architecture chips into one chip per named reviewer. Older rows
+  // (no reviewers[]) fall back to the merged checklist + architecture lenses.
+  const head: Array<ReviewLens | null> =
+    reviewerLenses(checklistReview) ?? [
+      checklistLens(checklistReview),
+      architectureLens(checklistReview),
+    ];
+  const tail: Array<ReviewLens | null> = [
     codeReviewLens(build.taskResults),
     uxLens(build.uxTestResults),
     verificationLens(build.verificationOut),
     acceptanceLens(build.acceptanceMet),
   ];
-  return lenses.filter((lens): lens is ReviewLens => lens !== null);
+  return [...head, ...tail].filter((lens): lens is ReviewLens => lens !== null);
 }

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -197,6 +197,32 @@ export type ReviewResult = {
    *  deliberation trail as the `architect` branch and are surfaced to the
    *  build coworker so it can fold actionable concerns back into the spec. */
   architectureAdvisory?: ArchitectureAdvisory;
+  /** Per-reviewer verdicts captured BEFORE mergeReviews() collapses the two
+   *  gating reviewers (+ the advisory architect) into a single decision. Lets
+   *  the Review-phase UI show WHICH named reviewer cleared vs flagged instead
+   *  of only the merged outcome. Nested on the JSON column (like
+   *  architectureAdvisory) — no migration. Absent on rows reviewed before this
+   *  shipped; the UI falls back to the merged checklist lens. */
+  reviewers?: ReviewerVerdict[];
+};
+
+/** A single reviewer's verdict, preserved on ReviewResult.reviewers so the
+ *  Review-phase UI can render named reviewer chips. The three sources match the
+ *  deliberation branch ids the dual-review run already emits (reviewer-1,
+ *  reviewer-2, architect). There is NO larger named-discipline roster — the
+ *  build review system runs exactly these three reviewers. */
+export type ReviewerVerdict = {
+  /** Stable reviewer id — matches the deliberation branchNodeId. */
+  source: "reviewer-1" | "reviewer-2" | "architect";
+  /** Operator-facing name: "Primary review" / "Independent review" / "Architecture". */
+  label: string;
+  /** "reviewer" verdicts gate via mergeReviews; "architect" is advisory only. */
+  role: "reviewer" | "architect";
+  decision: "pass" | "fail";
+  /** Issue counts by severity — enough to render a chip without the full list. */
+  issueCounts: { critical: number; important: number; minor: number };
+  /** True when this reviewer's output failed to parse (absent, not dissenting). */
+  parseError?: boolean;
 };
 
 /** Compact, advisory-only record of an architectural-alignment review.

--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -9,6 +9,7 @@ import {
   parseReviewResponse,
   extractClaimsFromReview,
   buildReviewBranchArtifacts,
+  collectReviewerVerdicts,
   deriveReviewRiskLevel,
   artifactTypeForPhase,
   mapCompactSummaryToBuildEntry,
@@ -571,5 +572,67 @@ describe("architectureAdvisoryFromReview", () => {
         parseError: true,
       }),
     ).toBeNull();
+  });
+});
+
+describe("collectReviewerVerdicts", () => {
+  function rev(overrides: Partial<ReviewResult> = {}): ReviewResult {
+    return { decision: "pass", issues: [], summary: "", ...overrides };
+  }
+
+  it("maps r1/r2/archReview to named verdicts in deliberation-branch order", () => {
+    const verdicts = collectReviewerVerdicts(
+      rev({ decision: "pass" }),
+      rev({ decision: "fail", issues: [{ severity: "critical", description: "x" }] }),
+      rev({ decision: "pass", issues: [{ severity: "minor", description: "n" }] }),
+    );
+    expect(verdicts.map((v) => v.source)).toEqual(["reviewer-1", "reviewer-2", "architect"]);
+    expect(verdicts.map((v) => v.label)).toEqual([
+      "Primary review",
+      "Independent review",
+      "Architecture",
+    ]);
+    expect(verdicts[1]).toMatchObject({
+      role: "reviewer",
+      decision: "fail",
+      issueCounts: { critical: 1, important: 0, minor: 0 },
+    });
+    expect(verdicts[2]).toMatchObject({ role: "architect", decision: "pass" });
+  });
+
+  it("omits reviewers that did not respond (null) rather than inventing a pass", () => {
+    const verdicts = collectReviewerVerdicts(rev(), null, null);
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0]?.source).toBe("reviewer-1");
+  });
+
+  it("returns an empty array when no reviewer responded", () => {
+    expect(collectReviewerVerdicts(null, null, null)).toEqual([]);
+  });
+
+  it("preserves the parseError flag so the UI can show 'unavailable' not a false pass", () => {
+    const verdicts = collectReviewerVerdicts(
+      rev({ parseError: true, decision: "fail" }),
+      rev({ decision: "pass" }),
+      null,
+    );
+    expect(verdicts[0]).toMatchObject({ source: "reviewer-1", parseError: true });
+    expect(verdicts[1]).not.toHaveProperty("parseError");
+  });
+
+  it("counts issues by severity", () => {
+    const verdicts = collectReviewerVerdicts(
+      rev({
+        issues: [
+          { severity: "critical", description: "a" },
+          { severity: "important", description: "b" },
+          { severity: "important", description: "c" },
+          { severity: "minor", description: "d" },
+        ],
+      }),
+      null,
+      null,
+    );
+    expect(verdicts[0]?.issueCounts).toEqual({ critical: 1, important: 2, minor: 1 });
   });
 });

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -4,6 +4,7 @@
 
 import type {
   ReviewResult,
+  ReviewerVerdict,
   ArchitectureAdvisory,
   BuildDesignDoc,
   BuildPlanDoc,
@@ -311,6 +312,58 @@ export function architectureAdvisoryFromReview(
 ): ArchitectureAdvisory | null {
   if (!arch || arch.parseError) return null;
   return { summary: arch.summary, issues: arch.issues };
+}
+
+// ─── Per-reviewer verdicts ───────────────────────────────────────────────────
+
+/** The three reviewers a dual-review run produces, in deliberation-branch order.
+ *  Source ids match the branchNodeIds emitted to runBuildReviewDeliberation, so
+ *  the persisted verdicts and the deliberation trail name reviewers identically.
+ *  This is the COMPLETE roster — there is no security/accessibility/governance
+ *  reviewer as a distinct agent; those are focus areas inside reviewer-2. */
+const REVIEWER_VERDICT_META = [
+  { source: "reviewer-1", label: "Primary review", role: "reviewer" },
+  { source: "reviewer-2", label: "Independent review", role: "reviewer" },
+  { source: "architect", label: "Architecture", role: "architect" },
+] as const;
+
+function countIssuesBySeverity(
+  issues: ReviewResult["issues"],
+): ReviewerVerdict["issueCounts"] {
+  const counts = { critical: 0, important: 0, minor: 0 };
+  for (const issue of issues) counts[issue.severity]++;
+  return counts;
+}
+
+/**
+ * Capture the individual reviewer verdicts BEFORE mergeReviews() collapses them,
+ * so they can be nested on the persisted ReviewResult.reviewers for the UI.
+ *
+ * Inputs are the same r1 / r2 / archReview the deliberation trail consumes; a
+ * null input means that reviewer did not respond and is simply omitted (it never
+ * appears as a passing verdict). A parse-error review is preserved with its
+ * parseError flag so the UI can show "unavailable" rather than a false pass.
+ */
+export function collectReviewerVerdicts(
+  r1: ReviewResult | null,
+  r2: ReviewResult | null,
+  archReview: ReviewResult | null,
+): ReviewerVerdict[] {
+  const inputs = [r1, r2, archReview];
+  const verdicts: ReviewerVerdict[] = [];
+  REVIEWER_VERDICT_META.forEach((meta, i) => {
+    const review = inputs[i];
+    if (!review) return;
+    verdicts.push({
+      source: meta.source,
+      label: meta.label,
+      role: meta.role,
+      decision: review.decision,
+      issueCounts: countIssuesBySeverity(review.issues),
+      ...(review.parseError ? { parseError: true } : {}),
+    });
+  });
+  return verdicts;
 }
 
 // ─── Review Merging ──────────────────────────────────────────────────────────

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -8258,7 +8258,7 @@ export async function executeTool(
       }
 
       if (!build?.designDoc) return { success: false, error: "No design document saved yet.", message: "Save designDoc first." };
-      const { buildDesignReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews } = await import("@/lib/build-reviewers");
+      const { buildDesignReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews, collectReviewerVerdicts } = await import("@/lib/build-reviewers");
       const designDocTyped = build.designDoc as Parameters<typeof buildDesignReviewPrompt>[0];
       // BI-CE49D82E — Compute the iteration context up front so we can
       // (a) feed prior issues into the reviewer prompt and (b) populate
@@ -8346,7 +8346,11 @@ export async function executeTool(
       // have already seen the signal in passing.
       const { sizeDesignDoc } = await import("@/lib/build/size-design-doc");
       const sizeAssessment = sizeDesignDoc(build.designDoc as Parameters<typeof sizeDesignDoc>[0]);
-      const reviewWithSize = { ...review, sizeAssessment };
+      // Preserve the individual reviewer verdicts (pre-merge) so the Review-phase
+      // UI can show which named reviewer cleared vs flagged. Nested on the JSON
+      // column — no migration. Same r1/r2/archReview the deliberation trail uses.
+      const reviewers = collectReviewerVerdicts(r1, r2, archReview);
+      const reviewWithSize = { ...review, sizeAssessment, ...(reviewers.length > 0 ? { reviewers } : {}) };
       await prisma.featureBuild.update({ where: { buildId }, data: { designReview: reviewWithSize as unknown as import("@dpf/db").Prisma.InputJsonValue } });
       const { agentEventBus } = await import("@/lib/agent-event-bus");
       if (context?.threadId) agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "designReview" });
@@ -8703,7 +8707,7 @@ export async function executeTool(
           data: { review, blocked: true, action: "revise_and_resubmit" },
         };
       }
-      const { buildPlanReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews } = await import("@/lib/build-reviewers");
+      const { buildPlanReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews, collectReviewerVerdicts } = await import("@/lib/build-reviewers");
       // BI-4396EFEC (D38) — Compute the iteration context up front so we can
       // (a) feed prior issues into the reviewer prompt and (b) populate
       // ReviewResult.iteration on the output. Round is 1-based: first
@@ -8778,7 +8782,10 @@ export async function executeTool(
       const review = architectureAdvisory
         ? { ...reviewWithIteration, architectureAdvisory }
         : reviewWithIteration;
-      await prisma.featureBuild.update({ where: { buildId }, data: { planReview: review as unknown as import("@dpf/db").Prisma.InputJsonValue } });
+      // Preserve individual reviewer verdicts (pre-merge) for the Review-phase UI.
+      const reviewers = collectReviewerVerdicts(r1, r2, archReview);
+      const planReviewToPersist = reviewers.length > 0 ? { ...review, reviewers } : review;
+      await prisma.featureBuild.update({ where: { buildId }, data: { planReview: planReviewToPersist as unknown as import("@dpf/db").Prisma.InputJsonValue } });
       const { agentEventBus } = await import("@/lib/agent-event-bus");
       if (context?.threadId) agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "planReview" });
       logBuildActivity(buildId, "reviewBuildPlan", `Plan review: ${review.decision}. ${review.summary}`);

--- a/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
+++ b/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
@@ -164,7 +164,25 @@ Data: `FeatureBuildRow.taskResults` (done/failed, deduped by title — last resu
 | Verification | `verificationOut` (typecheck + tests) | pass · fail · pending |
 | Acceptance | `acceptanceMet[]` (omitted if none) | pass · partial |
 
-Checklist + Verification are the always-on spine (render even when pending); the other four are omitted entirely when their backing artifact is absent, so **no chip ever shows without evidence**. State is conveyed by colour **and** glyph **and** text (WCAG 1.4.1); each chip carries an `aria-label` of `"<lens>: <state> — <detail>"`. The section header shows an `N/M cleared · K blocking` roll-up. DPF token-only, zero new server plumbing.
+Checklist + Verification are the always-on spine (render even when pending); the other four are omitted entirely when their backing artifact is absent, so **no chip ever shows without evidence**. State is conveyed by colour **and** glyph **and** text (WCAG 1.4.1); each chip carries an `aria-label` of `"<lens>: <state> — <detail>"`. The section header shows an `N/M cleared · K blocking` roll-up. DPF token-only.
+
+#### §6.2a Graduation: per-reviewer verdicts — **Implemented** (server-side persistence)
+
+The "heavier alternative" flagged above shipped: individual reviewer verdicts are now **persisted**, so the merged Checklist chip graduates into **one chip per named reviewer**. Substrate verification ([build-reviewers.ts](../../../apps/web/lib/integrate/build-reviewers.ts), [mcp-tools.ts](../../../apps/web/lib/mcp-tools.ts) review tools) established the **complete, real roster** — there is no security/governance/accessibility reviewer as a distinct agent:
+
+| Reviewer (`source`) | Label | Role | Gates? |
+|---|---|---|---|
+| `reviewer-1` | Primary review | reviewer | yes (via merge) |
+| `reviewer-2` | Independent review (focus: security, edge cases, a11y / task completeness) | reviewer | yes (via merge) |
+| `architect` | Architecture | architect | no — advisory |
+
+Mechanism (no migration — JSON column, like `architectureAdvisory`):
+
+1. `collectReviewerVerdicts(r1, r2, archReview)` captures each reviewer's `{ source, label, role, decision, issueCounts, parseError? }` **before** `mergeReviews()` collapses them — the same `r1`/`r2`/`archReview` the deliberation trail already consumes, so verdicts and the deliberation branches name reviewers identically.
+2. The MCP `reviewDesignDoc` / `reviewBuildPlan` tools nest the array on `ReviewResult.reviewers` at the existing persist sites.
+3. `deriveReviewLenses` expands `reviewers[]` into per-reviewer chips when present (architect → always `advisory`; a `parseError` verdict → `pending`/"unavailable", never a false pass), and **falls back** to the merged Checklist + Architecture lenses for rows reviewed before this shipped.
+
+Verification of the full path (review runs → `reviewers[]` persisted → named chips render) is deferred to a live Build Studio install per the operator's standing constraint; unit coverage (`collectReviewerVerdicts`, graduation, fallback) is in place.
 
 ### §7. Animation
 


### PR DESCRIPTION
## What

Graduates the **ReviewReadinessStrip** ([#1854](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1854), merged) from the merged "Checklist review" chip to **one chip per named reviewer**, backed by new **server-side per-reviewer persistence**. This is the "heavier alternative" #1854's description flagged as a separate BI — built directly in the worktree per the operator's *"no stable portal; build here, validate later"* direction.

```
REVIEW READINESS  2/4 cleared · 1 blocking
[✓ Primary review]  [✗ Independent review]  [ⓘ Architecture]  [✓ Verification]
   cleared             1 critical               aligned            typecheck ✓
```

## Substrate verification first (the honest roster)

Before persisting anything, I mapped the real review system ([build-reviewers.ts](apps/web/lib/integrate/build-reviewers.ts), [mcp-tools.ts](apps/web/lib/mcp-tools.ts) `reviewDesignDoc`/`reviewBuildPlan`). It runs **exactly three reviewers** — there is **no** security / API-governance / accessibility / test-coverage reviewer as a distinct agent (those are *focus areas inside* reviewer-2):

| `source` | Label | Role | Gates? |
|---|---|---|---|
| `reviewer-1` | Primary review | reviewer | yes (via `mergeReviews`) |
| `reviewer-2` | Independent review | reviewer | yes (via `mergeReviews`) |
| `architect` | Architecture | architect | no — advisory |

`mergeReviews(r1, r2)` collapses the two gating reviewers before persistence, so individual identity previously survived only in the deliberation trail — never on `designReview`/`planReview`. The original spec sketch's six named cards were fiction; this ships the three that are real.

## How (no migration — nested on the JSON column)

1. **`collectReviewerVerdicts(r1, r2, archReview)`** ([build-reviewers.ts](apps/web/lib/integrate/build-reviewers.ts)) captures each reviewer's `{ source, label, role, decision, issueCounts, parseError? }` **before** the merge — the same `r1`/`r2`/`archReview` the deliberation branches already consume, so verdicts and deliberation name reviewers identically. A non-responding reviewer is omitted (never a false pass); a parse-error verdict keeps its flag.
2. **`ReviewResult`** gains a nested `reviewers?: ReviewerVerdict[]` ([feature-build-types.ts](apps/web/lib/explore/feature-build-types.ts)) — JSON column, like `architectureAdvisory`, so **no Prisma migration**.
3. The MCP **`reviewDesignDoc` / `reviewBuildPlan`** tools attach the array at the existing persist sites ([mcp-tools.ts](apps/web/lib/mcp-tools.ts)).
4. **`deriveReviewLenses`** ([review-lenses.ts](apps/web/lib/build/review-lenses.ts)) expands `reviewers[]` into per-reviewer chips when present (architect → always `advisory`; `parseError` → `pending`/"unavailable"), and **falls back** to the merged Checklist + Architecture lenses for rows reviewed before this shipped. The strip component is unchanged — it just renders the lenses it's given.

## Tests

- `collectReviewerVerdicts` — branch order, null-omission, parseError preservation, severity counts.
- `deriveReviewLenses` graduation — expansion into named chips, state/detail mapping, parse-error handling, and **legacy fallback** when `reviewers[]` absent.
- `ReviewReadinessStrip` — named reviewer chips render with correct `aria-label`s.
- **86 review-component tests pass; zero type errors** in changed files (incl. the 12k-line `mcp-tools.ts`).

## Validation note

The full runtime path (review actually runs → `reviewers[]` persisted → named chips render in the live inspector) is **deferred to a testable Build Studio install** per the operator's standing constraint. Unit coverage stands in until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)