### PR TITLE
feat(workbooks): surface the grid on Suppliers (List/Grid/Board)

### DIFF
--- a/apps/web/app/(shell)/finance/suppliers/page.tsx
+++ b/apps/web/app/(shell)/finance/suppliers/page.tsx
@@ -1,7 +1,11 @@
 // apps/web/app/(shell)/finance/suppliers/page.tsx
 import { listSuppliers } from "@/lib/actions/ap";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
+import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 import Link from "next/link";
+
+export const dynamic = "force-dynamic";
 
 const SUPPLIER_STATUS_COLOURS: Record<string, string> = {
   active: "#4ade80",
@@ -9,7 +13,13 @@ const SUPPLIER_STATUS_COLOURS: Record<string, string> = {
   blocked: "#ef4444",
 };
 
-export default async function SuppliersPage() {
+export default async function SuppliersPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ view?: string }>;
+}) {
+  const sp = await searchParams;
+  const view = sp?.view === "grid" || sp?.view === "board" ? sp.view : null;
   const suppliers = await listSuppliers();
 
   return (
@@ -36,7 +46,11 @@ export default async function SuppliersPage() {
 
       <FinanceTabNav />
 
-      {suppliers.length === 0 ? (
+      <SurfaceViewSwitcher entityType="supplier" current={view ?? "list"} />
+
+      {view ? (
+        <SurfacePlatformGrid entityType="supplier" view={view} />
+      ) : suppliers.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)]">No suppliers yet.</p>
       ) : (
         <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -197,7 +197,8 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Suppliers as an editable spreadsheet — edit safe fields inline; tax/bank details stay out.",
     viewCapability: "view_finance",
     manageCapability: "manage_finance", // validated raw-write tier (editableFields allow-list)
-    homeSurface: { path: "/finance", label: "Finance", board: true },
+    // The Suppliers list lives at /finance/suppliers, so the List/Grid tabs target it.
+    homeSurface: { path: "/finance/suppliers", label: "Suppliers", board: true },
   },
 ];
 


### PR DESCRIPTION
## What

First step of the **surfacing rollout** — embed the workbook grid as an *alternative view* on a domain list page, so the grid is "the alternative form for data entry/manipulation/export" right where the user already is (not only via the standalone `/workbooks/system/<entity>` route).

`supplier` was already registered in `PLATFORM_TABLES` (editable raw-write tier) but `/finance/suppliers` didn't expose the switcher.

## Changes

- `/finance/suppliers` gains the **List / Grid / Board** switcher (`SurfaceViewSwitcher`) and renders `SurfacePlatformGrid` for grid/board views — identical to the proven `/ops`, `/finance/invoices`, `/compliance/risks` wiring.
- Fix the supplier `homeSurface` path → `/finance/suppliers` (was `/finance`, the hub), so the switcher tabs target the actual list page.

## Context — the rollout

Per the surfacing audit: the grid engine is complete, but it's embedded on only 3 surfaces. This starts closing that gap. Remaining registered entities (`digital_product` → portfolio, `customer_account` → customer, `employee_profile` → people) and the ~20 unregistered list surfaces follow. A shared auto-surfacing wrapper (registry-driven) is the proposed systematic mechanism so we don't hand-wire each page.

Gate: `pnpm --filter web typecheck` green; 141 workbooks tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
