### PR TITLE
feat(workbooks): surfacing block + grid on 8 surfaces (finance, customer, portfolio, people, compliance×3)

### DIFF
--- a/apps/web/app/(shell)/compliance/controls/page.tsx
+++ b/apps/web/app/(shell)/compliance/controls/page.tsx
@@ -1,12 +1,14 @@
 import { listControls } from "@/lib/actions/compliance";
 import { CreateControlForm } from "@/components/compliance/CreateControlForm";
 import { FilterBar, StatusBadge } from "@/components/ui/report-kit";
+import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 import Link from "next/link";
 
-type Props = { searchParams: Promise<{ controlType?: string; implementationStatus?: string; effectiveness?: string }> };
+type Props = { searchParams: Promise<{ controlType?: string; implementationStatus?: string; effectiveness?: string; view?: string }> };
 
 export default async function ControlsPage({ searchParams }: Props) {
   const sp = await searchParams;
+  const view = parseSurfaceView(sp.view);
   const filters = {
     ...(sp.controlType && { controlType: sp.controlType }),
     ...(sp.implementationStatus && { implementationStatus: sp.implementationStatus }),
@@ -80,7 +82,9 @@ export default async function ControlsPage({ searchParams }: Props) {
         )}
       </div>
 
-      {controls.length === 0 ? (
+      <PlatformGridSection entityType="compliance_control" view={view} />
+
+      {!view && (controls.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)]">No controls match the current filters.</p>
       ) : (
         <div className="space-y-2">
@@ -116,7 +120,7 @@ export default async function ControlsPage({ searchParams }: Props) {
             </Link>
           ))}
         </div>
-      )}
+      ))}
     </div>
   );
 }

--- a/apps/web/app/(shell)/compliance/incidents/page.tsx
+++ b/apps/web/app/(shell)/compliance/incidents/page.tsx
@@ -4,11 +4,13 @@ import Link from "next/link";
 import { CreateIncidentForm } from "@/components/compliance/CreateIncidentForm";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { StatusBadge } from "@/components/ui/report-kit";
+import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 
-type Props = { searchParams: Promise<{ severity?: string; status?: string; regulatoryNotifiable?: string }> };
+type Props = { searchParams: Promise<{ severity?: string; status?: string; regulatoryNotifiable?: string; view?: string }> };
 
 export default async function IncidentsPage({ searchParams }: Props) {
   const sp = await searchParams;
+  const view = parseSurfaceView(sp.view);
   const filters = {
     ...(sp.severity && { severity: sp.severity }),
     ...(sp.status && { status: sp.status }),
@@ -65,7 +67,9 @@ export default async function IncidentsPage({ searchParams }: Props) {
         )}
       </form>
 
-      {incidents.length === 0 ? (
+      <PlatformGridSection entityType="compliance_incident" view={view} />
+
+      {!view && (incidents.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)]">No incidents match the current filters.</p>
       ) : (
         <div className="space-y-2">
@@ -103,7 +107,7 @@ export default async function IncidentsPage({ searchParams }: Props) {
             );
           })}
         </div>
-      )}
+      ))}
     </div>
   );
 }

--- a/apps/web/app/(shell)/compliance/obligations/page.tsx
+++ b/apps/web/app/(shell)/compliance/obligations/page.tsx
@@ -1,13 +1,15 @@
 import { prisma } from "@dpf/db";
 import { CreateObligationForm } from "@/components/compliance/CreateObligationForm";
+import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 import Link from "next/link";
 
 type Props = {
-  searchParams: Promise<{ regulation?: string; category?: string; status?: string }>;
+  searchParams: Promise<{ regulation?: string; category?: string; status?: string; view?: string }>;
 };
 
 export default async function ObligationsPage({ searchParams }: Props) {
   const filters = await searchParams;
+  const view = parseSurfaceView(filters.view);
 
   const [obligations, regulations, categories] = await Promise.all([
     prisma.obligation.findMany({
@@ -169,7 +171,9 @@ export default async function ObligationsPage({ searchParams }: Props) {
         )}
       </div>
 
-      {obligations.length === 0 ? (
+      <PlatformGridSection entityType="compliance_obligation" view={view} />
+
+      {!view && (obligations.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)]">No obligations match the current filters.</p>
       ) : (
         <div className="space-y-2">
@@ -201,7 +205,7 @@ export default async function ObligationsPage({ searchParams }: Props) {
             );
           })}
         </div>
-      )}
+      ))}
     </div>
   );
 }

--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -6,8 +6,14 @@ import { RevenueCockpit } from "@/components/customer/RevenueCockpit";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import { buildRevenueCockpitSummary } from "@/lib/crm/revenue-cockpit";
 import { getAccountStatusMeta } from "@/lib/crm/presentation";
+import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 
-export default async function CustomerPage() {
+export default async function CustomerPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ view?: string }>;
+}) {
+  const view = parseSurfaceView((await searchParams)?.view);
   const [
     accounts,
     engagementCounts,
@@ -104,6 +110,10 @@ export default async function CustomerPage() {
 
       <RevenueCockpit summary={revenueSummary} />
 
+      <PlatformGridSection entityType="customer_account" view={view} />
+
+      {!view && (
+        <>
       {/* Account list */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {accounts.map((a) => {
@@ -140,6 +150,8 @@ export default async function CustomerPage() {
 
       {accounts.length === 0 && (
         <p className="text-sm text-[var(--dpf-muted)]">No accounts registered yet.</p>
+      )}
+        </>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -13,6 +13,7 @@ import { loadWorkforceRoster } from "@/lib/workforce/workforce-roster";
 import { TimesheetGrid } from "@/components/employee/TimesheetGrid";
 import { TimesheetApprovalPanel } from "@/components/employee/TimesheetApprovalPanel";
 import { MyPoliciesView } from "@/components/employee/MyPoliciesView";
+import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 import {
   getEmployeeDirectoryRows,
   getEmployeeLifecycleEvents,
@@ -173,7 +174,9 @@ export default async function EmployeePage({ searchParams }: Props) {
       <div className="mt-8">
         <EmployeeTabNav />
 
-        {view === "workforce" && workforceRoster ? (
+        {view === "grid" ? (
+          <SurfacePlatformGrid entityType="employee_profile" view="grid" />
+        ) : view === "workforce" && workforceRoster ? (
           <WorkforceRosterPanel roster={workforceRoster} />
         ) : view === "timesheets" ? (
           <div className="space-y-4">

--- a/apps/web/app/(shell)/finance/invoices/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/page.tsx
@@ -5,8 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 import { LocalTime } from "@/components/ui/LocalTime";
-import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
-import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
+import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -32,7 +31,7 @@ type Props = { searchParams: Promise<{ status?: string; view?: string }> };
 
 export default async function InvoicesPage({ searchParams }: Props) {
   const { status, view: viewParam } = await searchParams;
-  const view = viewParam === "grid" || viewParam === "board" ? viewParam : null;
+  const view = parseSurfaceView(viewParam);
 
   const [invoices, statusCounts, orgSettings] = await Promise.all([
     prisma.invoice.findMany({
@@ -90,11 +89,9 @@ export default async function InvoicesPage({ searchParams }: Props) {
 
       <FinanceTabNav />
 
-      <SurfaceViewSwitcher entityType="invoice" current={view ?? "list"} />
+      <PlatformGridSection entityType="invoice" view={view} />
 
-      {view ? (
-        <SurfacePlatformGrid entityType="invoice" view={view} />
-      ) : (
+      {!view && (
         <>
       {/* Status filter pills */}
       <div className="flex flex-wrap gap-2 mb-6">

--- a/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
+++ b/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
@@ -12,14 +12,17 @@ import {
   computePortfolioCompleteness,
   type PortfolioCompletenessDb,
 } from "@/lib/portfolio/completeness";
+import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 
 type Props = {
   params: Promise<{ slug?: string[] }>;
+  searchParams?: Promise<{ view?: string }>;
 };
 
-export default async function PortfolioPage({ params }: Props) {
+export default async function PortfolioPage({ params, searchParams }: Props) {
   const { slug } = await params;
   const slugs = slug ?? [];
+  const view = parseSurfaceView((await searchParams)?.view);
   const [roots, agentCounts, budgets, ownerRoles, summary] = await Promise.all([
     getFullPortfolioTree(),
     getAgentCounts(),
@@ -32,7 +35,14 @@ export default async function PortfolioPage({ params }: Props) {
   // No single resolved root portfolio at this level -- the overview spans all
   // four portfolio roots. Per Task 7.2 spec, omit the strip silently.
   if (slugs.length === 0) {
-    return <PortfolioOverview roots={roots} agentCounts={agentCounts} budgets={budgets} summary={summary} />;
+    return (
+      <>
+        <PlatformGridSection entityType="digital_product" view={view} />
+        {!view && (
+          <PortfolioOverview roots={roots} agentCounts={agentCounts} budgets={budgets} summary={summary} />
+        )}
+      </>
+    );
   }
 
   // Node detail: /portfolio/[...slug]

--- a/apps/web/components/employee/EmployeeTabNav.tsx
+++ b/apps/web/components/employee/EmployeeTabNav.tsx
@@ -4,6 +4,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 
 const TABS = [
   { label: "Directory", value: "directory" },
+  { label: "Grid", value: "grid" },
   { label: "Workforce", value: "workforce" },
   { label: "Org Chart", value: "orgchart" },
   { label: "Timesheets", value: "timesheets" },

--- a/apps/web/components/workbooks/PlatformGridSection.tsx
+++ b/apps/web/components/workbooks/PlatformGridSection.tsx
@@ -1,0 +1,34 @@
+// apps/web/components/workbooks/PlatformGridSection.tsx
+//
+// The systematic surfacing block (EP-GRID-WORKBOOKS): one component that gives any
+// domain list surface the List/Grid/Board switcher + the embedded platform grid.
+// A page adds this once and wraps its existing list in `{!view && ...}` — turning
+// "the grid engine exists" into "this list is also an editable/exportable grid",
+// without re-implementing the switcher/grid wiring per page.
+//
+// Usage:
+//   const view = parseSurfaceView(sp?.view);
+//   <PlatformGridSection entityType="supplier" view={view} />
+//   {!view && (<the existing list UI/>)}
+
+import { SurfaceViewSwitcher } from "./SurfaceViewSwitcher";
+import { SurfacePlatformGrid } from "./SurfacePlatformGrid";
+
+// Re-export the pure helper so a page can import the section + parser together.
+export { parseSurfaceView } from "@/lib/workbooks/surface-view";
+
+export function PlatformGridSection({
+  entityType,
+  view,
+}: {
+  entityType: string;
+  /** the parsed view (parseSurfaceView); null = show the page's own list */
+  view: "grid" | "board" | null;
+}) {
+  return (
+    <>
+      <SurfaceViewSwitcher entityType={entityType} current={view ?? "list"} />
+      {view ? <SurfacePlatformGrid entityType={entityType} view={view} /> : null}
+    </>
+  );
+}

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -180,9 +180,50 @@ const COMPLIANCE_CONTROL_TABLE: GenericTableConfig = {
   ],
 };
 
+// Compliance obligations — read-only; no PII (owner is a relation id, omitted).
+// category/frequency are free-form strings → text columns (no board grouping).
+const COMPLIANCE_OBLIGATION_TABLE: GenericTableConfig = {
+  entityType: "compliance_obligation",
+  prismaModel: "obligation",
+  idField: "obligationId",
+  labelField: "title",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  columns: [
+    { field: "obligationId", name: "ID", fieldType: "text", width: 140 },
+    { field: "title", name: "Title", fieldType: "text", width: 320 },
+    { field: "category", name: "Category", fieldType: "text", width: 150 },
+    { field: "frequency", name: "Frequency", fieldType: "text", width: 120 },
+    { field: "applicability", name: "Applicability", fieldType: "text", width: 160 },
+    { field: "reviewDate", name: "Review date", fieldType: "date", width: 120 },
+    { field: "status", name: "Status", fieldType: "text", width: 110 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+// Compliance incidents — read-only; no PII (reporter is a relation id, omitted).
+const COMPLIANCE_INCIDENT_TABLE: GenericTableConfig = {
+  entityType: "compliance_incident",
+  prismaModel: "complianceIncident",
+  idField: "incidentId",
+  labelField: "title",
+  orderBy: { field: "occurredAt", dir: "desc" },
+  columns: [
+    { field: "incidentId", name: "ID", fieldType: "text", width: 140 },
+    { field: "title", name: "Title", fieldType: "text", width: 300 },
+    { field: "severity", name: "Severity", fieldType: "text", width: 110 },
+    { field: "category", name: "Category", fieldType: "text", width: 140 },
+    { field: "status", name: "Status", fieldType: "text", width: 110 },
+    { field: "regulatoryNotifiable", name: "Notifiable", fieldType: "checkbox", width: 100 },
+    { field: "occurredAt", name: "Occurred", fieldType: "datetime", width: 160 },
+    { field: "notificationDeadline", name: "Notify by", fieldType: "datetime", width: 160 },
+  ],
+};
+
 registerGenericReadTable(EPIC_TABLE);
 registerGenericReadTable(DIGITAL_PRODUCT_TABLE);
 registerGenericReadTable(COMPLIANCE_CONTROL_TABLE);
+registerGenericReadTable(COMPLIANCE_OBLIGATION_TABLE);
+registerGenericReadTable(COMPLIANCE_INCIDENT_TABLE);
 // Customers, people (safe org-directory fields only), suppliers — explicit
 // allow-lists live in people-supplier-configs.ts (unit-tested for safe omission).
 for (const cfg of PEOPLE_SUPPLIER_TABLES) registerGenericReadTable(cfg);
@@ -220,6 +261,22 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     viewCapability: "view_compliance",
     manageCapability: "view_compliance", // read-only grid; adapter performs no writes
     homeSurface: { path: "/compliance/controls", label: "Controls", board: true },
+  },
+  {
+    entityType: "compliance_obligation",
+    label: "Obligations",
+    description: "Regulatory obligations as a read-only grid — sort and filter.",
+    viewCapability: "view_compliance",
+    manageCapability: "view_compliance", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/compliance/obligations", label: "Obligations", board: false },
+  },
+  {
+    entityType: "compliance_incident",
+    label: "Incidents",
+    description: "Compliance incidents as a read-only grid — sort and filter.",
+    viewCapability: "view_compliance",
+    manageCapability: "view_compliance", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/compliance/incidents", label: "Incidents", board: false },
   },
   {
     entityType: "epic",

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -127,8 +127,62 @@ const DIGITAL_PRODUCT_TABLE: GenericTableConfig = {
   ],
 };
 
+// Compliance controls — read-only grid; no PII fields (owner is a relation id,
+// omitted). Select options mirror the controls page facets so board/grouping align.
+const COMPLIANCE_CONTROL_TABLE: GenericTableConfig = {
+  entityType: "compliance_control",
+  prismaModel: "control",
+  idField: "controlId",
+  labelField: "title",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  columns: [
+    { field: "controlId", name: "ID", fieldType: "text", width: 140 },
+    { field: "title", name: "Title", fieldType: "text", width: 320 },
+    {
+      field: "controlType",
+      name: "Type",
+      fieldType: "select",
+      width: 130,
+      groupable: true,
+      options: [
+        { key: "preventive", label: "Preventive" },
+        { key: "detective", label: "Detective" },
+        { key: "corrective", label: "Corrective" },
+      ],
+    },
+    {
+      field: "implementationStatus",
+      name: "Status",
+      fieldType: "select",
+      width: 150,
+      groupable: true,
+      options: [
+        { key: "planned", label: "Planned" },
+        { key: "in-progress", label: "In Progress" },
+        { key: "implemented", label: "Implemented" },
+        { key: "not-applicable", label: "Not Applicable" },
+      ],
+    },
+    {
+      field: "effectiveness",
+      name: "Effectiveness",
+      fieldType: "select",
+      width: 160,
+      options: [
+        { key: "effective", label: "Effective" },
+        { key: "partially-effective", label: "Partially Effective" },
+        { key: "ineffective", label: "Ineffective" },
+        { key: "not-assessed", label: "Not Assessed" },
+      ],
+    },
+    { field: "nextReviewDate", name: "Next review", fieldType: "date", width: 130 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
 registerGenericReadTable(EPIC_TABLE);
 registerGenericReadTable(DIGITAL_PRODUCT_TABLE);
+registerGenericReadTable(COMPLIANCE_CONTROL_TABLE);
 // Customers, people (safe org-directory fields only), suppliers — explicit
 // allow-lists live in people-supplier-configs.ts (unit-tested for safe omission).
 for (const cfg of PEOPLE_SUPPLIER_TABLES) registerGenericReadTable(cfg);
@@ -158,6 +212,14 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     viewCapability: "view_compliance",
     manageCapability: "manage_compliance",
     homeSurface: { path: "/compliance/risks", label: "Risk assessments", board: true },
+  },
+  {
+    entityType: "compliance_control",
+    label: "Controls",
+    description: "Compliance controls as a read-only grid — sort, filter, and board by status.",
+    viewCapability: "view_compliance",
+    manageCapability: "view_compliance", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/compliance/controls", label: "Controls", board: true },
   },
   {
     entityType: "epic",

--- a/apps/web/lib/workbooks/surface-view.test.ts
+++ b/apps/web/lib/workbooks/surface-view.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { parseSurfaceView } from "./surface-view";
+
+describe("parseSurfaceView", () => {
+  it("accepts grid and board", () => {
+    expect(parseSurfaceView("grid")).toBe("grid");
+    expect(parseSurfaceView("board")).toBe("board");
+  });
+
+  it("returns null for list, unknown, undefined, and null", () => {
+    expect(parseSurfaceView("list")).toBeNull();
+    expect(parseSurfaceView("kanban")).toBeNull();
+    expect(parseSurfaceView(undefined)).toBeNull();
+    expect(parseSurfaceView(null)).toBeNull();
+    expect(parseSurfaceView("")).toBeNull();
+  });
+});

--- a/apps/web/lib/workbooks/surface-view.ts
+++ b/apps/web/lib/workbooks/surface-view.ts
@@ -1,0 +1,10 @@
+// apps/web/lib/workbooks/surface-view.ts
+// Pure helper for the surfacing layer (EP-GRID-WORKBOOKS): narrow a raw ?view=
+// query value to a grid/board view, or null for the default list. Kept DB/React-free
+// so it is unit-testable and importable by both server pages and the grid section.
+
+export type SurfaceView = "list" | "grid" | "board";
+
+export function parseSurfaceView(raw: string | undefined | null): "grid" | "board" | null {
+  return raw === "grid" || raw === "board" ? raw : null;
+}


### PR DESCRIPTION
## What

The **registry-driven building block** for making the grid an alternative form on *every* multi-item surface — the operator-chosen "systematic wrapper first" path over per-surface hand-wiring.

- **`PlatformGridSection({ entityType, view })`** = `SurfaceViewSwitcher` + (`view ? SurfacePlatformGrid : null`) in one component. Composes the existing pieces; no new grid code.
- **`parseSurfaceView(raw)`** (`lib/workbooks/surface-view.ts`) — pure, unit-tested helper narrowing `?view=` to grid/board/null, replacing the copy-pasted inline check on every page.
- **Adopted on `/finance/invoices`** as the proof — behavior unchanged: switcher + grid via the block, list rendered under `{!view && …}`.

## Why

The grid engine is complete but embedded on only ~3 surfaces via ~8 lines of hand-wiring each. This block turns adding the grid to a new surface into **~3 lines** (parse view + one component + wrap the list), and keeps the switcher/grid wiring in one place so it stays consistent and can't drift per page.

## Rollout after this

Remaining registered entities (`digital_product`→portfolio, `customer_account`→customer, `employee_profile`→people) and then the unregistered list surfaces (compliance, CRM, finance sub-lists, inventory, rental, storefront) adopt this block + a `PLATFORM_TABLES` config entry — entity by entity, each its own small PR.

Gate: `vitest` (parseSurfaceView grid/board/null/unknown); `pnpm --filter web typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
