### PR TITLE
feat(mobile): finalize install manifest — full renderer theming + shared @dpf/types contract

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,21 +1,46 @@
 import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/src/lib/theme";
+import { useAppConfigStore } from "@/src/lib/appConfig";
+import { resolveVisibleTabs } from "@/src/lib/navigation";
 
 export default function TabsLayout() {
+  const { colors } = useTheme();
+  const persona = useAppConfigStore((s) => s.persona);
+  const capabilities = useAppConfigStore((s) => s.capabilities);
+  const navigation = useAppConfigStore((s) => s.navigation);
+
+  // Which tabs the connected install exposes for this persona. With no manifest
+  // loaded this returns the full operator set, so the default app is unchanged.
+  const visible = new Set(
+    resolveVisibleTabs({
+      persona,
+      capabilities,
+      manifestTabs: navigation?.tabs,
+    }),
+  );
+  // `href: null` hides a tab from the bar; `undefined` leaves it visible.
+  const hiddenHref = (name: string): null | undefined =>
+    visible.has(name) ? undefined : null;
+
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: "#818cf8",
-        tabBarInactiveTintColor: "#9ca3af",
-        tabBarStyle: { backgroundColor: "#1e1e2e", borderTopColor: "#3f3f5a" },
-        headerStyle: { backgroundColor: "#1e1e2e" },
-        headerTintColor: "#e2e8f0",
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textMuted,
+        tabBarStyle: {
+          backgroundColor: colors.surface1,
+          borderTopColor: colors.border,
+        },
+        headerStyle: { backgroundColor: colors.surface1 },
+        headerTintColor: colors.text,
       }}
     >
       <Tabs.Screen
         name="index"
         options={{
           title: "Home",
+          href: hiddenHref("index"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="home" size={size} color={color} />
           ),
@@ -26,6 +51,7 @@ export default function TabsLayout() {
         options={{
           title: "Ops",
           headerShown: false,
+          href: hiddenHref("ops"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="list" size={size} color={color} />
           ),
@@ -36,6 +62,7 @@ export default function TabsLayout() {
         options={{
           title: "Portfolio",
           headerShown: false,
+          href: hiddenHref("portfolio"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="pie-chart" size={size} color={color} />
           ),
@@ -46,6 +73,7 @@ export default function TabsLayout() {
         options={{
           title: "Customers",
           headerShown: false,
+          href: hiddenHref("customers"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="people" size={size} color={color} />
           ),
@@ -56,6 +84,7 @@ export default function TabsLayout() {
         options={{
           title: "More",
           headerShown: false,
+          href: hiddenHref("more"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="ellipsis-horizontal" size={size} color={color} />
           ),

--- a/apps/mobile/dynamic/FormRenderer.tsx
+++ b/apps/mobile/dynamic/FormRenderer.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { ScrollView, StyleSheet } from "react-native";
 import type { DynamicFormSchema } from "@dpf/types";
 import { Button } from "@/src/components/ui/Button";
-import { colors, spacing } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import { fieldRegistry, type FieldProps } from "./fields";
 
 interface FormRendererProps {
@@ -16,8 +16,24 @@ export function FormRenderer({
   onSubmit,
   isSubmitting,
 }: FormRendererProps) {
+  const { colors, spacing } = useTheme();
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: colors.surface1,
+        },
+        content: {
+          padding: spacing.md,
+          paddingBottom: spacing.xl,
+        },
+      }),
+    [colors, spacing],
+  );
 
   function validate(): boolean {
     const newErrors: Record<string, string> = {};
@@ -60,22 +76,7 @@ export function FormRenderer({
           />
         );
       })}
-      <Button
-        title="Submit"
-        onPress={handleSubmit}
-        loading={isSubmitting}
-      />
+      <Button title="Submit" onPress={handleSubmit} loading={isSubmitting} />
     </ScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.surface1,
-  },
-  content: {
-    padding: spacing.md,
-    paddingBottom: spacing.xl,
-  },
-});

--- a/apps/mobile/dynamic/fields/CameraField.tsx
+++ b/apps/mobile/dynamic/fields/CameraField.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 /**
@@ -8,6 +8,49 @@ import type { FieldProps } from "./index";
  * Full implementation will integrate expo-image-picker or expo-camera.
  */
 export function CameraField({ definition, value, onChange, error }: FieldProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.xs,
+        },
+        photoRow: {
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: spacing.sm,
+          marginBottom: spacing.sm,
+        },
+        thumbnail: {
+          width: 60,
+          height: 60,
+          backgroundColor: colors.surface2,
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderRadius: borderRadius.sm,
+          alignItems: "center",
+          justifyContent: "center",
+        },
+        thumbnailText: { color: colors.textMuted, fontSize: 14 },
+        button: {
+          backgroundColor: colors.surface2,
+          borderWidth: 1,
+          borderColor: colors.primary,
+          borderRadius: borderRadius.sm,
+          paddingVertical: spacing.sm + 4,
+          alignItems: "center",
+        },
+        buttonText: { color: colors.primary, fontSize: 14, fontWeight: "600" },
+        limitText: { color: colors.textMuted, fontSize: 13 },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const photos = Array.isArray(value) ? (value as string[]) : [];
   const maxCount = definition.maxCount ?? 5;
   const canAdd = photos.length < maxCount;
@@ -38,65 +81,9 @@ export function CameraField({ definition, value, onChange, error }: FieldProps) 
           <Text style={styles.buttonText}>Take Photo</Text>
         </Pressable>
       ) : (
-        <Text style={styles.limitText}>
-          Maximum {maxCount} photos reached
-        </Text>
+        <Text style={styles.limitText}>Maximum {maxCount} photos reached</Text>
       )}
       {error ? <Text style={styles.error}>{error}</Text> : null}
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  photoRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.sm,
-    marginBottom: spacing.sm,
-  },
-  thumbnail: {
-    width: 60,
-    height: 60,
-    backgroundColor: colors.surface2,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: borderRadius.sm,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  thumbnailText: {
-    color: colors.textMuted,
-    fontSize: 14,
-  },
-  button: {
-    backgroundColor: colors.surface2,
-    borderWidth: 1,
-    borderColor: colors.primary,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm + 4,
-    alignItems: "center",
-  },
-  buttonText: {
-    color: colors.primary,
-    fontSize: 14,
-    fontWeight: "600",
-  },
-  limitText: {
-    color: colors.textMuted,
-    fontSize: 13,
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/DateField.tsx
+++ b/apps/mobile/dynamic/fields/DateField.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { View, Text, TextInput, StyleSheet } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 /**
@@ -8,6 +8,33 @@ import type { FieldProps } from "./index";
  * A native date picker integration can replace this later.
  */
 export function DateField({ definition, value, onChange, error }: FieldProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.xs,
+        },
+        input: {
+          backgroundColor: colors.surface1,
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderRadius: borderRadius.sm,
+          paddingVertical: spacing.sm + 4,
+          paddingHorizontal: spacing.md,
+          color: colors.text,
+          fontSize: 16,
+        },
+        inputError: { borderColor: colors.error },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const [localError, setLocalError] = useState<string | null>(null);
   const textValue = value != null ? String(value) : "";
 
@@ -34,39 +61,7 @@ export function DateField({ definition, value, onChange, error }: FieldProps) {
         accessibilityLabel={definition.label}
         testID={`field-${definition.key}`}
       />
-      {displayError ? (
-        <Text style={styles.error}>{displayError}</Text>
-      ) : null}
+      {displayError ? <Text style={styles.error}>{displayError}</Text> : null}
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  input: {
-    backgroundColor: colors.surface1,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm + 4,
-    paddingHorizontal: spacing.md,
-    color: colors.text,
-    fontSize: 16,
-  },
-  inputError: {
-    borderColor: colors.error,
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/LocationField.tsx
+++ b/apps/mobile/dynamic/fields/LocationField.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 interface LocationValue {
@@ -18,6 +18,38 @@ export function LocationField({
   onChange,
   error,
 }: FieldProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.xs,
+        },
+        coordBox: {
+          backgroundColor: colors.surface2,
+          borderRadius: borderRadius.sm,
+          padding: spacing.sm,
+          marginBottom: spacing.sm,
+        },
+        coordText: { color: colors.text, fontSize: 14, fontFamily: "monospace" },
+        button: {
+          backgroundColor: colors.surface2,
+          borderWidth: 1,
+          borderColor: colors.primary,
+          borderRadius: borderRadius.sm,
+          paddingVertical: spacing.sm + 4,
+          alignItems: "center",
+        },
+        buttonText: { color: colors.primary, fontSize: 14, fontWeight: "600" },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const location = value as LocationValue | undefined;
 
   function handleCapture() {
@@ -53,44 +85,3 @@ export function LocationField({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  coordBox: {
-    backgroundColor: colors.surface2,
-    borderRadius: borderRadius.sm,
-    padding: spacing.sm,
-    marginBottom: spacing.sm,
-  },
-  coordText: {
-    color: colors.text,
-    fontSize: 14,
-    fontFamily: "monospace",
-  },
-  button: {
-    backgroundColor: colors.surface2,
-    borderWidth: 1,
-    borderColor: colors.primary,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm + 4,
-    alignItems: "center",
-  },
-  buttonText: {
-    color: colors.primary,
-    fontSize: 14,
-    fontWeight: "600",
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/LookupField.tsx
+++ b/apps/mobile/dynamic/fields/LookupField.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, TextInput, StyleSheet } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 /**
@@ -13,6 +13,38 @@ export function LookupField({
   onChange,
   error,
 }: FieldProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.xs,
+        },
+        input: {
+          backgroundColor: colors.surface1,
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderRadius: borderRadius.sm,
+          paddingVertical: spacing.sm + 4,
+          paddingHorizontal: spacing.md,
+          color: colors.text,
+          fontSize: 16,
+        },
+        inputError: { borderColor: colors.error },
+        sourceHint: {
+          color: colors.textMuted,
+          fontSize: 11,
+          marginTop: spacing.xs,
+        },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const textValue = value != null ? String(value) : "";
 
   return (
@@ -34,38 +66,3 @@ export function LookupField({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  input: {
-    backgroundColor: colors.surface1,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm + 4,
-    paddingHorizontal: spacing.md,
-    color: colors.text,
-    fontSize: 16,
-  },
-  inputError: {
-    borderColor: colors.error,
-  },
-  sourceHint: {
-    color: colors.textMuted,
-    fontSize: 11,
-    marginTop: spacing.xs,
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/MultiSelectField.tsx
+++ b/apps/mobile/dynamic/fields/MultiSelectField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -7,7 +7,7 @@ import {
   FlatList,
   StyleSheet,
 } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 export function MultiSelectField({
@@ -16,6 +16,91 @@ export function MultiSelectField({
   onChange,
   error,
 }: FieldProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.xs,
+        },
+        picker: {
+          backgroundColor: colors.surface1,
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderRadius: borderRadius.sm,
+          paddingVertical: spacing.sm,
+          paddingHorizontal: spacing.md,
+          minHeight: 48,
+          justifyContent: "center",
+        },
+        pickerError: { borderColor: colors.error },
+        placeholder: { color: colors.textMuted, fontSize: 16 },
+        chipRow: { flexDirection: "row", flexWrap: "wrap", gap: spacing.xs },
+        chip: {
+          backgroundColor: colors.primary + "22",
+          borderRadius: borderRadius.sm,
+          paddingVertical: spacing.xs,
+          paddingHorizontal: spacing.sm,
+        },
+        chipText: { color: colors.primary, fontSize: 13, fontWeight: "500" },
+        overlay: {
+          flex: 1,
+          justifyContent: "flex-end",
+          backgroundColor: "rgba(0,0,0,0.5)",
+        },
+        sheet: {
+          backgroundColor: colors.surface2,
+          borderTopLeftRadius: borderRadius.lg,
+          borderTopRightRadius: borderRadius.lg,
+          padding: spacing.md,
+          maxHeight: "60%",
+        },
+        sheetTitle: {
+          color: colors.text,
+          fontSize: 18,
+          fontWeight: "600",
+          marginBottom: spacing.md,
+          textAlign: "center",
+        },
+        option: {
+          flexDirection: "row",
+          alignItems: "center",
+          paddingVertical: spacing.sm + 4,
+          paddingHorizontal: spacing.md,
+          borderRadius: borderRadius.sm,
+        },
+        optionSelected: { backgroundColor: colors.primary + "22" },
+        checkbox: {
+          width: 20,
+          height: 20,
+          borderRadius: 4,
+          borderWidth: 2,
+          borderColor: colors.border,
+          marginRight: spacing.sm,
+        },
+        checkboxChecked: {
+          backgroundColor: colors.primary,
+          borderColor: colors.primary,
+        },
+        optionText: { color: colors.text, fontSize: 16 },
+        optionTextSelected: { color: colors.primary, fontWeight: "600" },
+        doneButton: {
+          marginTop: spacing.md,
+          backgroundColor: colors.primary,
+          borderRadius: borderRadius.md,
+          paddingVertical: spacing.sm + 4,
+          alignItems: "center",
+        },
+        doneText: { color: colors.white, fontSize: 16, fontWeight: "600" },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const [open, setOpen] = useState(false);
   const options = definition.options ?? [];
   const selected = Array.isArray(value) ? (value as string[]) : [];
@@ -65,10 +150,7 @@ export function MultiSelectField({
                 const isSelected = selected.includes(item);
                 return (
                   <Pressable
-                    style={[
-                      styles.option,
-                      isSelected && styles.optionSelected,
-                    ]}
+                    style={[styles.option, isSelected && styles.optionSelected]}
                     onPress={() => toggleOption(item)}
                     testID={`option-${item}`}
                   >
@@ -90,10 +172,7 @@ export function MultiSelectField({
                 );
               }}
             />
-            <Pressable
-              style={styles.doneButton}
-              onPress={() => setOpen(false)}
-            >
+            <Pressable style={styles.doneButton} onPress={() => setOpen(false)}>
               <Text style={styles.doneText}>Done</Text>
             </Pressable>
           </View>
@@ -102,114 +181,3 @@ export function MultiSelectField({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  picker: {
-    backgroundColor: colors.surface1,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.md,
-    minHeight: 48,
-    justifyContent: "center",
-  },
-  pickerError: {
-    borderColor: colors.error,
-  },
-  placeholder: {
-    color: colors.textMuted,
-    fontSize: 16,
-  },
-  chipRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.xs,
-  },
-  chip: {
-    backgroundColor: colors.primary + "22",
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.xs,
-    paddingHorizontal: spacing.sm,
-  },
-  chipText: {
-    color: colors.primary,
-    fontSize: 13,
-    fontWeight: "500",
-  },
-  overlay: {
-    flex: 1,
-    justifyContent: "flex-end",
-    backgroundColor: "rgba(0,0,0,0.5)",
-  },
-  sheet: {
-    backgroundColor: colors.surface2,
-    borderTopLeftRadius: borderRadius.lg,
-    borderTopRightRadius: borderRadius.lg,
-    padding: spacing.md,
-    maxHeight: "60%",
-  },
-  sheetTitle: {
-    color: colors.text,
-    fontSize: 18,
-    fontWeight: "600",
-    marginBottom: spacing.md,
-    textAlign: "center",
-  },
-  option: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: spacing.sm + 4,
-    paddingHorizontal: spacing.md,
-    borderRadius: borderRadius.sm,
-  },
-  optionSelected: {
-    backgroundColor: colors.primary + "22",
-  },
-  checkbox: {
-    width: 20,
-    height: 20,
-    borderRadius: 4,
-    borderWidth: 2,
-    borderColor: colors.border,
-    marginRight: spacing.sm,
-  },
-  checkboxChecked: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
-  },
-  optionText: {
-    color: colors.text,
-    fontSize: 16,
-  },
-  optionTextSelected: {
-    color: colors.primary,
-    fontWeight: "600",
-  },
-  doneButton: {
-    marginTop: spacing.md,
-    backgroundColor: colors.primary,
-    borderRadius: borderRadius.md,
-    paddingVertical: spacing.sm + 4,
-    alignItems: "center",
-  },
-  doneText: {
-    color: colors.white,
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/RadioField.tsx
+++ b/apps/mobile/dynamic/fields/RadioField.tsx
@@ -1,9 +1,49 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 export function RadioField({ definition, value, onChange, error }: FieldProps) {
+  const { colors, spacing } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.sm,
+        },
+        optionRow: {
+          flexDirection: "row",
+          alignItems: "center",
+          paddingVertical: spacing.sm,
+        },
+        radioOuter: {
+          width: 22,
+          height: 22,
+          borderRadius: 11,
+          borderWidth: 2,
+          borderColor: colors.border,
+          alignItems: "center",
+          justifyContent: "center",
+          marginRight: spacing.sm,
+        },
+        radioOuterSelected: { borderColor: colors.primary },
+        radioInner: {
+          width: 12,
+          height: 12,
+          borderRadius: 6,
+          backgroundColor: colors.primary,
+        },
+        optionText: { color: colors.text, fontSize: 16 },
+        optionTextSelected: { color: colors.primary, fontWeight: "500" },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing],
+  );
+
   const options = definition.options ?? [];
 
   return (
@@ -43,52 +83,3 @@ export function RadioField({ definition, value, onChange, error }: FieldProps) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.sm,
-  },
-  optionRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: spacing.sm,
-  },
-  radioOuter: {
-    width: 22,
-    height: 22,
-    borderRadius: 11,
-    borderWidth: 2,
-    borderColor: colors.border,
-    alignItems: "center",
-    justifyContent: "center",
-    marginRight: spacing.sm,
-  },
-  radioOuterSelected: {
-    borderColor: colors.primary,
-  },
-  radioInner: {
-    width: 12,
-    height: 12,
-    borderRadius: 6,
-    backgroundColor: colors.primary,
-  },
-  optionText: {
-    color: colors.text,
-    fontSize: 16,
-  },
-  optionTextSelected: {
-    color: colors.primary,
-    fontWeight: "500",
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/SelectField.tsx
+++ b/apps/mobile/dynamic/fields/SelectField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -8,10 +8,74 @@ import {
   Switch,
   StyleSheet,
 } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
+function makeStyles({
+  colors,
+  spacing,
+  borderRadius,
+}: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    container: { marginBottom: spacing.md },
+    label: {
+      color: colors.text,
+      fontSize: 14,
+      fontWeight: "500",
+      marginBottom: spacing.xs,
+    },
+    toggleRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+    },
+    picker: {
+      backgroundColor: colors.surface1,
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: borderRadius.sm,
+      paddingVertical: spacing.sm + 4,
+      paddingHorizontal: spacing.md,
+    },
+    pickerError: { borderColor: colors.error },
+    pickerText: { color: colors.text, fontSize: 16 },
+    placeholder: { color: colors.textMuted },
+    overlay: {
+      flex: 1,
+      justifyContent: "flex-end",
+      backgroundColor: "rgba(0,0,0,0.5)",
+    },
+    sheet: {
+      backgroundColor: colors.surface2,
+      borderTopLeftRadius: borderRadius.lg,
+      borderTopRightRadius: borderRadius.lg,
+      padding: spacing.md,
+      maxHeight: "60%",
+    },
+    sheetTitle: {
+      color: colors.text,
+      fontSize: 18,
+      fontWeight: "600",
+      marginBottom: spacing.md,
+      textAlign: "center",
+    },
+    option: {
+      paddingVertical: spacing.sm + 4,
+      paddingHorizontal: spacing.md,
+      borderRadius: borderRadius.sm,
+    },
+    optionSelected: { backgroundColor: colors.primary + "22" },
+    optionText: { color: colors.text, fontSize: 16 },
+    optionTextSelected: { color: colors.primary, fontWeight: "600" },
+    error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+  });
+}
+
 export function SelectField({ definition, value, onChange, error }: FieldProps) {
+  const theme = useTheme();
+  const { colors } = theme;
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+
   const isToggle =
     definition.type === "checkbox" || definition.type === "toggle";
 
@@ -34,10 +98,19 @@ export function SelectField({ definition, value, onChange, error }: FieldProps) 
     );
   }
 
-  return <SelectPicker definition={definition} value={value} onChange={onChange} error={error} />;
+  return (
+    <SelectPicker
+      definition={definition}
+      value={value}
+      onChange={onChange}
+      error={error}
+    />
+  );
 }
 
 function SelectPicker({ definition, value, onChange, error }: FieldProps) {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
   const [open, setOpen] = useState(false);
   const options = definition.options ?? [];
   const displayValue = value != null ? String(value) : "";
@@ -52,12 +125,7 @@ function SelectPicker({ definition, value, onChange, error }: FieldProps) {
         accessibilityLabel={`Select ${definition.label}`}
         testID={`field-${definition.key}`}
       >
-        <Text
-          style={[
-            styles.pickerText,
-            !displayValue && styles.placeholder,
-          ]}
-        >
+        <Text style={[styles.pickerText, !displayValue && styles.placeholder]}>
           {displayValue || `Select ${definition.label.toLowerCase()}`}
         </Text>
       </Pressable>
@@ -99,78 +167,3 @@ function SelectPicker({ definition, value, onChange, error }: FieldProps) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  toggleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  picker: {
-    backgroundColor: colors.surface1,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm + 4,
-    paddingHorizontal: spacing.md,
-  },
-  pickerError: {
-    borderColor: colors.error,
-  },
-  pickerText: {
-    color: colors.text,
-    fontSize: 16,
-  },
-  placeholder: {
-    color: colors.textMuted,
-  },
-  overlay: {
-    flex: 1,
-    justifyContent: "flex-end",
-    backgroundColor: "rgba(0,0,0,0.5)",
-  },
-  sheet: {
-    backgroundColor: colors.surface2,
-    borderTopLeftRadius: borderRadius.lg,
-    borderTopRightRadius: borderRadius.lg,
-    padding: spacing.md,
-    maxHeight: "60%",
-  },
-  sheetTitle: {
-    color: colors.text,
-    fontSize: 18,
-    fontWeight: "600",
-    marginBottom: spacing.md,
-    textAlign: "center",
-  },
-  option: {
-    paddingVertical: spacing.sm + 4,
-    paddingHorizontal: spacing.md,
-    borderRadius: borderRadius.sm,
-  },
-  optionSelected: {
-    backgroundColor: colors.primary + "22",
-  },
-  optionText: {
-    color: colors.text,
-    fontSize: 16,
-  },
-  optionTextSelected: {
-    color: colors.primary,
-    fontWeight: "600",
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/SignatureField.tsx
+++ b/apps/mobile/dynamic/fields/SignatureField.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 /**
@@ -13,6 +13,34 @@ export function SignatureField({
   onChange,
   error,
 }: FieldProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.xs,
+        },
+        canvas: {
+          height: 120,
+          backgroundColor: colors.surface1,
+          borderWidth: 2,
+          borderColor: colors.border,
+          borderRadius: borderRadius.md,
+          borderStyle: "dashed",
+          alignItems: "center",
+          justifyContent: "center",
+        },
+        canvasError: { borderColor: colors.error },
+        canvasText: { color: colors.textMuted, fontSize: 16 },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const hasSigned = Boolean(value);
 
   function handleTap() {
@@ -38,37 +66,3 @@ export function SignatureField({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  canvas: {
-    height: 120,
-    backgroundColor: colors.surface1,
-    borderWidth: 2,
-    borderColor: colors.border,
-    borderRadius: borderRadius.md,
-    borderStyle: "dashed",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  canvasError: {
-    borderColor: colors.error,
-  },
-  canvasText: {
-    color: colors.textMuted,
-    fontSize: 16,
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/fields/TextField.tsx
+++ b/apps/mobile/dynamic/fields/TextField.tsx
@@ -1,9 +1,43 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, TextInput, StyleSheet } from "react-native";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { FieldProps } from "./index";
 
 export function TextField({ definition, value, onChange, error }: FieldProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: spacing.md },
+        label: {
+          color: colors.text,
+          fontSize: 14,
+          fontWeight: "500",
+          marginBottom: spacing.xs,
+        },
+        input: {
+          backgroundColor: colors.surface1,
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderRadius: borderRadius.sm,
+          paddingVertical: spacing.sm + 4,
+          paddingHorizontal: spacing.md,
+          color: colors.text,
+          fontSize: 16,
+        },
+        multiline: { minHeight: 100, textAlignVertical: "top" },
+        inputError: { borderColor: colors.error },
+        counter: {
+          color: colors.textMuted,
+          fontSize: 12,
+          textAlign: "right",
+          marginTop: spacing.xs,
+        },
+        error: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const isMultiline = definition.type === "textarea";
   const isNumeric = definition.type === "number";
   const textValue = value != null ? String(value) : "";
@@ -44,43 +78,3 @@ export function TextField({ definition, value, onChange, error }: FieldProps) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    color: colors.text,
-    fontSize: 14,
-    fontWeight: "500",
-    marginBottom: spacing.xs,
-  },
-  input: {
-    backgroundColor: colors.surface1,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm + 4,
-    paddingHorizontal: spacing.md,
-    color: colors.text,
-    fontSize: 16,
-  },
-  multiline: {
-    minHeight: 100,
-    textAlignVertical: "top",
-  },
-  inputError: {
-    borderColor: colors.error,
-  },
-  counter: {
-    color: colors.textMuted,
-    fontSize: 12,
-    textAlign: "right",
-    marginTop: spacing.xs,
-  },
-  error: {
-    color: colors.error,
-    fontSize: 12,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/widgets/BarChart.tsx
+++ b/apps/mobile/dynamic/widgets/BarChart.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { Card } from "@/src/components/ui/Card";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { WidgetProps } from "./index";
 
 interface ChartItem {
@@ -14,12 +14,51 @@ interface ChartItem {
  * percentage of the maximum value. No chart library dependency.
  */
 export function BarChart({ definition, data }: WidgetProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: { marginBottom: spacing.md },
+        title: {
+          color: colors.text,
+          fontSize: 16,
+          fontWeight: "600",
+          marginBottom: spacing.sm,
+        },
+        empty: {
+          color: colors.textMuted,
+          fontSize: 14,
+          textAlign: "center",
+          padding: spacing.md,
+        },
+        row: {
+          flexDirection: "row",
+          alignItems: "center",
+          marginBottom: spacing.sm,
+        },
+        rowLabel: { color: colors.text, fontSize: 13, width: 80 },
+        barTrack: {
+          flex: 1,
+          height: 16,
+          backgroundColor: colors.surface1,
+          borderRadius: borderRadius.sm,
+          overflow: "hidden",
+          marginHorizontal: spacing.sm,
+        },
+        barFill: { height: "100%", borderRadius: borderRadius.sm },
+        rowValue: {
+          color: colors.textMuted,
+          fontSize: 13,
+          width: 40,
+          textAlign: "right",
+        },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const raw = data[definition.dataKey];
   const items: ChartItem[] = Array.isArray(raw) ? raw : [];
-  const maxValue = items.reduce(
-    (max, item) => Math.max(max, item.value),
-    1,
-  );
+  const maxValue = items.reduce((max, item) => Math.max(max, item.value), 1);
 
   return (
     <Card style={styles.card}>
@@ -38,8 +77,7 @@ export function BarChart({ definition, data }: WidgetProps) {
                     styles.barFill,
                     {
                       width: `${pct}%`,
-                      backgroundColor:
-                        definition.color ?? colors.primary,
+                      backgroundColor: definition.color ?? colors.primary,
                     },
                   ]}
                 />
@@ -52,49 +90,3 @@ export function BarChart({ definition, data }: WidgetProps) {
     </Card>
   );
 }
-
-const styles = StyleSheet.create({
-  card: {
-    marginBottom: spacing.md,
-  },
-  title: {
-    color: colors.text,
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: spacing.sm,
-  },
-  empty: {
-    color: colors.textMuted,
-    fontSize: 14,
-    textAlign: "center",
-    padding: spacing.md,
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: spacing.sm,
-  },
-  rowLabel: {
-    color: colors.text,
-    fontSize: 13,
-    width: 80,
-  },
-  barTrack: {
-    flex: 1,
-    height: 16,
-    backgroundColor: colors.surface1,
-    borderRadius: borderRadius.sm,
-    overflow: "hidden",
-    marginHorizontal: spacing.sm,
-  },
-  barFill: {
-    height: "100%",
-    borderRadius: borderRadius.sm,
-  },
-  rowValue: {
-    color: colors.textMuted,
-    fontSize: 13,
-    width: 40,
-    textAlign: "right",
-  },
-});

--- a/apps/mobile/dynamic/widgets/ListView.tsx
+++ b/apps/mobile/dynamic/widgets/ListView.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, FlatList, StyleSheet } from "react-native";
 import { Card } from "@/src/components/ui/Card";
-import { colors, spacing } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { WidgetProps } from "./index";
 
 /**
@@ -9,6 +9,48 @@ import type { WidgetProps } from "./index";
  * from the widget definition's columns and data key.
  */
 export function ListView({ definition, data }: WidgetProps) {
+  const { colors, spacing } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: { marginBottom: spacing.md },
+        title: {
+          color: colors.text,
+          fontSize: 16,
+          fontWeight: "600",
+          marginBottom: spacing.sm,
+        },
+        headerRow: {
+          flexDirection: "row",
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+          paddingBottom: spacing.xs,
+          marginBottom: spacing.xs,
+        },
+        headerCell: {
+          flex: 1,
+          color: colors.textMuted,
+          fontSize: 12,
+          fontWeight: "600",
+          textTransform: "uppercase",
+        },
+        dataRow: {
+          flexDirection: "row",
+          paddingVertical: spacing.xs,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border + "44",
+        },
+        dataCell: { flex: 1, color: colors.text, fontSize: 14 },
+        empty: {
+          color: colors.textMuted,
+          fontSize: 14,
+          textAlign: "center",
+          padding: spacing.md,
+        },
+      }),
+    [colors, spacing],
+  );
+
   const raw = data[definition.dataKey];
   const rows: Record<string, unknown>[] = Array.isArray(raw) ? raw : [];
   const columns = definition.columns ?? [];
@@ -45,46 +87,3 @@ export function ListView({ definition, data }: WidgetProps) {
     </Card>
   );
 }
-
-const styles = StyleSheet.create({
-  card: {
-    marginBottom: spacing.md,
-  },
-  title: {
-    color: colors.text,
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: spacing.sm,
-  },
-  headerRow: {
-    flexDirection: "row",
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-    paddingBottom: spacing.xs,
-    marginBottom: spacing.xs,
-  },
-  headerCell: {
-    flex: 1,
-    color: colors.textMuted,
-    fontSize: 12,
-    fontWeight: "600",
-    textTransform: "uppercase",
-  },
-  dataRow: {
-    flexDirection: "row",
-    paddingVertical: spacing.xs,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border + "44",
-  },
-  dataCell: {
-    flex: 1,
-    color: colors.text,
-    fontSize: 14,
-  },
-  empty: {
-    color: colors.textMuted,
-    fontSize: 14,
-    textAlign: "center",
-    padding: spacing.md,
-  },
-});

--- a/apps/mobile/dynamic/widgets/MapWidget.tsx
+++ b/apps/mobile/dynamic/widgets/MapWidget.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { Card } from "@/src/components/ui/Card";
-import { colors, spacing, borderRadius } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { WidgetProps } from "./index";
 
 /**
@@ -9,6 +9,41 @@ import type { WidgetProps } from "./index";
  * Full implementation will use react-native-maps.
  */
 export function MapWidget({ definition, data }: WidgetProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: { marginBottom: spacing.md },
+        title: {
+          color: colors.text,
+          fontSize: 16,
+          fontWeight: "600",
+          marginBottom: spacing.sm,
+        },
+        placeholder: {
+          height: 180,
+          backgroundColor: colors.surface1,
+          borderRadius: borderRadius.md,
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderStyle: "dashed",
+          alignItems: "center",
+          justifyContent: "center",
+        },
+        placeholderText: {
+          color: colors.textMuted,
+          fontSize: 18,
+          fontWeight: "600",
+        },
+        markerCount: {
+          color: colors.textMuted,
+          fontSize: 14,
+          marginTop: spacing.xs,
+        },
+      }),
+    [colors, spacing, borderRadius],
+  );
+
   const raw = data[definition.dataKey];
   const markers = Array.isArray(raw) ? raw.length : 0;
 
@@ -24,35 +59,3 @@ export function MapWidget({ definition, data }: WidgetProps) {
     </Card>
   );
 }
-
-const styles = StyleSheet.create({
-  card: {
-    marginBottom: spacing.md,
-  },
-  title: {
-    color: colors.text,
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: spacing.sm,
-  },
-  placeholder: {
-    height: 180,
-    backgroundColor: colors.surface1,
-    borderRadius: borderRadius.md,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderStyle: "dashed",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  placeholderText: {
-    color: colors.textMuted,
-    fontSize: 18,
-    fontWeight: "600",
-  },
-  markerCount: {
-    color: colors.textMuted,
-    fontSize: 14,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/dynamic/widgets/StatCard.tsx
+++ b/apps/mobile/dynamic/widgets/StatCard.tsx
@@ -1,15 +1,38 @@
-import React from "react";
-import { View, Text, StyleSheet, type ViewStyle } from "react-native";
+import React, { useMemo } from "react";
+import { Text, StyleSheet, type ViewStyle } from "react-native";
 import { Card } from "@/src/components/ui/Card";
-import { colors, spacing } from "@/src/lib/theme";
+import { useTheme } from "@/src/lib/theme";
 import type { WidgetProps } from "./index";
 
 export function StatCard({ definition, data }: WidgetProps) {
+  const { colors, spacing } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
+          marginBottom: spacing.md,
+        },
+        value: {
+          color: colors.text,
+          fontSize: 32,
+          fontWeight: "700",
+        },
+        label: {
+          color: colors.textMuted,
+          fontSize: 14,
+          marginTop: spacing.xs,
+        },
+      }),
+    [colors, spacing],
+  );
+
   const value = data[definition.dataKey];
   const displayValue = value != null ? String(value) : "--";
   const cardStyle: ViewStyle = {
     ...styles.card,
-    ...(definition.color ? { borderLeftColor: definition.color, borderLeftWidth: 3 } : undefined),
+    ...(definition.color
+      ? { borderLeftColor: definition.color, borderLeftWidth: 3 }
+      : undefined),
   };
 
   return (
@@ -21,19 +44,3 @@ export function StatCard({ definition, data }: WidgetProps) {
     </Card>
   );
 }
-
-const styles = StyleSheet.create({
-  card: {
-    marginBottom: spacing.md,
-  },
-  value: {
-    color: colors.text,
-    fontSize: 32,
-    fontWeight: "700",
-  },
-  label: {
-    color: colors.textMuted,
-    fontSize: 14,
-    marginTop: spacing.xs,
-  },
-});

--- a/apps/mobile/src/lib/appConfig.test.ts
+++ b/apps/mobile/src/lib/appConfig.test.ts
@@ -5,7 +5,7 @@ import {
   useAppConfigStore,
 } from "./appConfig";
 import { useThemeStore, defaultColors } from "./theme";
-import type { AppConfigManifest } from "./manifest.types";
+import type { AppConfigManifest } from "@dpf/types";
 
 /* ------------------------------------------------------------------ */
 /*  Mocks                                                              */

--- a/apps/mobile/src/lib/appConfig.ts
+++ b/apps/mobile/src/lib/appConfig.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { AppConfigManifest, AppPersona } from "@/src/lib/manifest.types";
+import type { AppConfigManifest, AppPersona } from "@dpf/types";
 import { getServerUrl } from "@/src/lib/serverConfig";
 import { SecureStorage } from "@/src/repositories/SecureStorage";
 import { useThemeStore, type ColorScheme } from "@/src/lib/theme";

--- a/apps/mobile/src/lib/navigation.test.ts
+++ b/apps/mobile/src/lib/navigation.test.ts
@@ -1,0 +1,76 @@
+import { resolveVisibleTabs, type TabSpec } from "./navigation";
+
+describe("resolveVisibleTabs", () => {
+  it("defaults to the full operator tab set when nothing is loaded", () => {
+    expect(resolveVisibleTabs({})).toEqual([
+      "index",
+      "ops",
+      "portfolio",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("operator persona sees all platform tabs", () => {
+    expect(resolveVisibleTabs({ persona: { kind: "operator" } })).toEqual([
+      "index",
+      "ops",
+      "portfolio",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("customer persona sees a reduced tab set (no ops / portfolio)", () => {
+    expect(resolveVisibleTabs({ persona: { kind: "customer" } })).toEqual([
+      "index",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("employee persona hides portfolio", () => {
+    expect(resolveVisibleTabs({ persona: { kind: "employee" } })).toEqual([
+      "index",
+      "ops",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("an explicit manifest tab order wins and is filtered to known tabs", () => {
+    expect(
+      resolveVisibleTabs({
+        persona: { kind: "operator" },
+        manifestTabs: ["customers", "index", "bogus"],
+      }),
+    ).toEqual(["customers", "index"]);
+  });
+
+  it("capability-gates a tab only when capabilities are known", () => {
+    const registry: TabSpec[] = [
+      { key: "index", personas: ["operator"] },
+      { key: "jobs", personas: ["operator"], capability: "work-items" },
+    ];
+    // capabilities unknown → ungated (jobs shown)
+    expect(
+      resolveVisibleTabs({ persona: { kind: "operator" }, registry }),
+    ).toEqual(["index", "jobs"]);
+    // capabilities known, without work-items → jobs hidden
+    expect(
+      resolveVisibleTabs({
+        persona: { kind: "operator" },
+        capabilities: ["notifications"],
+        registry,
+      }),
+    ).toEqual(["index"]);
+    // capabilities known, with work-items → jobs shown
+    expect(
+      resolveVisibleTabs({
+        persona: { kind: "operator" },
+        capabilities: ["work-items"],
+        registry,
+      }),
+    ).toEqual(["index", "jobs"]);
+  });
+});

--- a/apps/mobile/src/lib/navigation.ts
+++ b/apps/mobile/src/lib/navigation.ts
@@ -1,0 +1,66 @@
+import type { AppPersona, AppPersonaKind } from "@dpf/types";
+
+/** A mobile tab and the personas / capability that make it visible. */
+export interface TabSpec {
+  key: string;
+  /** Personas that see this tab when the manifest gives no explicit nav order. */
+  personas: AppPersonaKind[];
+  /** Optional capability gate; when capabilities are known, the tab shows only if present. */
+  capability?: string;
+}
+
+/**
+ * Registry of the app's bottom tabs. The current set is the platform-operator
+ * surface; persona-specific tabs (field / customer) are added as those modes
+ * land. Persona membership already makes navigation install-driven — a customer
+ * install shows fewer tabs than an operator one — without breaking the operator
+ * default. See docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html.
+ */
+export const TAB_REGISTRY: TabSpec[] = [
+  { key: "index", personas: ["operator", "employee", "customer", "admin"] },
+  { key: "ops", personas: ["operator", "employee", "admin"] },
+  { key: "portfolio", personas: ["operator", "admin"] },
+  { key: "customers", personas: ["operator", "employee", "customer", "admin"] },
+  { key: "more", personas: ["operator", "employee", "customer", "admin"] },
+];
+
+const DEFAULT_PERSONA: AppPersonaKind = "operator";
+
+export interface ResolveTabsInput {
+  persona?: AppPersona | null;
+  capabilities?: string[];
+  /** manifest.navigation.tabs — an explicit, server-driven tab order. */
+  manifestTabs?: string[];
+  registry?: TabSpec[];
+}
+
+/**
+ * Resolve which tabs are visible (and in what order) from the install manifest.
+ * Precedence: explicit manifest tab order → persona defaults. A capability gate
+ * applies only when capabilities are known (a connected install); with none
+ * loaded the app shows its persona defaults ungated, preserving the operator app.
+ */
+export function resolveVisibleTabs(input: ResolveTabsInput): string[] {
+  const registry = input.registry ?? TAB_REGISTRY;
+  const personaKind = input.persona?.kind ?? DEFAULT_PERSONA;
+  const caps = input.capabilities;
+  const capsKnown = Array.isArray(caps) && caps.length > 0;
+  const byKey = new Map(registry.map((t) => [t.key, t]));
+
+  const capAllowed = (spec: TabSpec): boolean => {
+    if (!spec.capability) return true;
+    if (!capsKnown) return true;
+    return caps!.includes(spec.capability);
+  };
+
+  if (input.manifestTabs && input.manifestTabs.length > 0) {
+    return input.manifestTabs
+      .filter((k) => byKey.has(k))
+      .filter((k) => capAllowed(byKey.get(k)!));
+  }
+
+  return registry
+    .filter((t) => t.personas.includes(personaKind))
+    .filter(capAllowed)
+    .map((t) => t.key);
+}

--- a/apps/mobile/src/lib/serverConfig.ts
+++ b/apps/mobile/src/lib/serverConfig.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from "expo-secure-store";
+import type { InstanceDescriptor } from "@dpf/types";
 
 /**
  * Runtime server (install) configuration.
@@ -113,21 +114,9 @@ export async function clearServerUrl(): Promise<void> {
   }
 }
 
-/**
- * Descriptor served by every DPF install at `/.well-known/dpf-instance.json`.
- * Lets the app prove a URL is a real install and learn its identity, archetype,
- * auth modes, and branding before the user signs in. (Portal endpoint lands in
- * the next P1 increment; this is the client contract.)
- */
-export interface InstanceDescriptor {
-  instanceId: string;
-  orgName: string;
-  archetype?: string;
-  apiVersion: string;
-  authModes: string[];
-  capabilities?: string[];
-  branding?: { accent?: string; logoUrl?: string };
-}
+// InstanceDescriptor (the /.well-known/dpf-instance.json wire shape) is the
+// shared contract from @dpf/types; re-exported here for callers of this module.
+export type { InstanceDescriptor };
 
 /**
  * Fetch and validate the instance descriptor for a candidate URL. Used by the

--- a/apps/mobile/src/lib/theme.ts
+++ b/apps/mobile/src/lib/theme.ts
@@ -7,10 +7,7 @@
  * See docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html (§3).
  */
 import { create } from "zustand";
-import type {
-  BrandingThemeTokens,
-  DualBrandingThemeTokens,
-} from "@/src/lib/manifest.types";
+import type { BrandingThemeTokens, DualBrandingThemeTokens } from "@dpf/types";
 
 export interface ThemeColors {
   primary: string;

--- a/apps/web/app/api/v1/app/config/route.ts
+++ b/apps/web/app/api/v1/app/config/route.ts
@@ -15,9 +15,8 @@ import { getCompositeActivationProfile } from "@/lib/storefront/archetype-activa
 import {
   buildAppConfigManifest,
   activationToCapabilities,
-  type AppPersona,
-  type MobileAppConfigManifest,
 } from "@/lib/mobile/manifest";
+import type { AppPersona, AppConfigManifest } from "@dpf/types";
 
 export const dynamic = "force-dynamic";
 
@@ -62,7 +61,7 @@ export async function GET(request: Request) {
       capabilities,
     });
 
-    return apiSuccess<MobileAppConfigManifest>(manifest);
+    return apiSuccess<AppConfigManifest>(manifest);
   } catch (e) {
     if (e instanceof ApiError) return e.toResponse();
     return NextResponse.json(

--- a/apps/web/lib/mobile/manifest.ts
+++ b/apps/web/lib/mobile/manifest.ts
@@ -6,59 +6,18 @@
  * the generic mobile app consumes (GET /api/v1/app/config) and the discovery
  * descriptor (GET /.well-known/dpf-instance.json).
  *
- * These types mirror the mobile-side contract in
- * apps/mobile/src/lib/manifest.types.ts; both describe the same wire JSON. They
- * converge into @dpf/types in a follow-up once shared-package changes are
- * verifiable from linked worktrees.
+ * The wire types are the single source of truth in `@dpf/types`
+ * (mobile-manifest.ts); this module owns only the projection logic.
  * Spec: docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html (§3).
  */
-
-export interface BrandingPalette {
-  bg?: string;
-  surface1?: string;
-  surface2?: string;
-  text?: string;
-  accent?: string;
-  muted?: string;
-  border?: string;
-}
-export interface BrandingTypography {
-  fontFamily?: string;
-  headingFontFamily?: string;
-}
-export interface BrandingThemeTokens {
-  palette?: BrandingPalette;
-  typography?: BrandingTypography;
-}
-export interface DualBrandingThemeTokens {
-  light?: BrandingThemeTokens;
-  dark?: BrandingThemeTokens;
-}
-
-export type AppPersonaKind = "customer" | "employee" | "operator" | "admin";
-export interface AppPersona {
-  kind: AppPersonaKind;
-  mode?: string;
-}
-
-export interface MobileInstanceDescriptor {
-  instanceId: string;
-  orgName: string;
-  archetype?: string;
-  apiVersion: string;
-  authModes: string[];
-  capabilities?: string[];
-  branding?: { accent?: string; logoUrl?: string };
-}
-
-export interface MobileAppConfigManifest {
-  schemaVersion: string;
-  org: { name: string; archetype?: string };
-  persona: AppPersona;
-  designTokens?: BrandingThemeTokens | DualBrandingThemeTokens;
-  capabilities: string[];
-  vocabulary?: Record<string, string>;
-}
+import type {
+  AppConfigManifest,
+  AppPersona,
+  BrandingPalette,
+  BrandingThemeTokens,
+  DualBrandingThemeTokens,
+  InstanceDescriptor,
+} from "@dpf/types";
 
 const PALETTE_KEYS: (keyof BrandingPalette)[] = [
   "bg",
@@ -86,7 +45,7 @@ function extractSingle(raw: unknown): BrandingThemeTokens | undefined {
     const v = str(paletteRaw[k]);
     if (v) palette[k] = v;
   }
-  const typography: BrandingTypography = {};
+  const typography: { fontFamily?: string; headingFontFamily?: string } = {};
   const ff = str(typoRaw.fontFamily);
   if (ff) typography.fontFamily = ff;
   const hf = str(typoRaw.headingFontFamily);
@@ -162,8 +121,8 @@ export function buildInstanceDescriptor(input: {
   capabilities?: string[];
   accent?: string | null;
   logoUrl?: string | null;
-}): MobileInstanceDescriptor {
-  const descriptor: MobileInstanceDescriptor = {
+}): InstanceDescriptor {
+  const descriptor: InstanceDescriptor = {
     instanceId: input.instanceId,
     orgName: input.orgName || "DPF",
     apiVersion: "v1",
@@ -194,8 +153,8 @@ export function buildAppConfigManifest(input: {
   brandingTokensRaw?: unknown;
   capabilities: string[];
   vocabulary?: Record<string, string>;
-}): MobileAppConfigManifest {
-  const manifest: MobileAppConfigManifest = {
+}): AppConfigManifest {
+  const manifest: AppConfigManifest = {
     schemaVersion: "1",
     org: {
       name: input.orgName || "DPF",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@dpf/finance-templates": "workspace:*",
     "@dpf/integration-shared": "workspace:*",
     "@dpf/storefront-templates": "workspace:*",
+    "@dpf/types": "workspace:*",
     "@dpf/validators": "workspace:*",
     "@floating-ui/react": "^0.27.19",
     "@fullcalendar/core": "^6.1.20",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./entities";
 export * from "./api";
 export * from "./dynamic";
+export * from "./mobile-manifest";

--- a/packages/types/src/mobile-manifest.ts
+++ b/packages/types/src/mobile-manifest.ts
@@ -1,16 +1,14 @@
-import type { DynamicFormSchema, DynamicViewSchema } from "@dpf/types";
+import type { DynamicFormSchema, DynamicViewSchema } from "./dynamic";
 
 /**
- * Install-manifest contract (mobile-facing).
+ * Install-manifest wire contract — the single source of truth shared by the
+ * portal producer (apps/web/lib/mobile/manifest.ts) and the mobile consumer
+ * (apps/mobile/src/lib/appConfig.ts, theme.ts, serverConfig.ts).
  *
  * The install drives the app: after connect + login the app fetches this
  * manifest (GET /api/v1/app/config) and re-themes + re-functions from it.
  * Three layers — design tokens, capabilities, server-driven screens.
- * See docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html (§3).
- *
- * NOTE: these types live in the mobile app for now; they lift to `@dpf/types`
- * when the portal `/api/v1/app/config` endpoint lands so both surfaces share one
- * contract (the "build the glue" item in the spec).
+ * Spec: docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html (§3).
  */
 
 /** Branding palette — mirrors the portal's BrandingConfig.tokens palette keys. */
@@ -75,4 +73,19 @@ export interface AppConfigManifest {
   /** (3) screen layer — server-driven navigation + screens. */
   navigation?: AppNavigation;
   screens?: AppScreen[];
+}
+
+/**
+ * Public discovery descriptor served at /.well-known/dpf-instance.json. Lets the
+ * app prove a URL is a real install and learn its identity, archetype, auth
+ * modes, and branding seed before sign-in.
+ */
+export interface InstanceDescriptor {
+  instanceId: string;
+  orgName: string;
+  archetype?: string;
+  apiVersion: string;
+  authModes: string[];
+  capabilities?: string[];
+  branding?: { accent?: string; logoUrl?: string };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@dpf/storefront-templates':
         specifier: workspace:*
         version: link:../../packages/storefront-templates
+      '@dpf/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@dpf/validators':
         specifier: workspace:*
         version: link:../../packages/validators


### PR DESCRIPTION
## What & why

**One consolidated, DCO-signed commit** that finalizes the install-driven mobile manifest (this branch previously tangled #1897 + a merged #1901 + two "Update branch" merge commits — one unsigned, which failed DCO; collapsed to a single clean commit on `main`). Follows #1886 (P1 connectivity + P2 manifest).

Three things, all verified:
1. **Theme the full dynamic renderer** — `FormRenderer` + 9 fields + 4 widgets migrated to the runtime `useTheme()` hook, so every server-driven surface re-themes from the install (`ViewRenderer` was the proof in #1886).
2. **Converge manifest wire-types into `@dpf/types`** — `BrandingThemeTokens`, `AppConfigManifest`, `InstanceDescriptor`, `AppNavigation`, etc. are now single-sourced; the mobile consumer and portal producer import the same types. apps/web gains `@dpf/types` as a direct dependency.
3. **Manifest-driven, capability-gated tab navigation** — pure `resolveVisibleTabs()` (persona defaults → explicit manifest order → capability gate) wired into a themed tab shell. A customer install shows a reduced tab set; the operator default is unchanged.

## Verification (compile-ready worktree, no skips)
- Mobile: typecheck clean; **jest 186/186 (28 suites)**.
- Web: typecheck clean; manifest projection **vitest 12/12**.
- Pre-commit ran scoped typecheck across `apps/web` + `packages/types` + `apps/mobile` — green. DCO green (single signed commit, author == sign-off).

## Notes
- #1901 (nav) is folded into this commit; no longer a separate merge.
- Process lesson (recorded): avoid GitHub "Update branch" / `gh pr update-branch` (creates unsigned merges → DCO fail) and deep PR stacks; prefer linear PRs off `main`.

## Next
Producer emits `manifest.navigation` per persona/archetype + per-archetype `DynamicForm`/`DynamicView` seeding; then first persona use-case screens + live-install verification.

Generated with Claude Code