### PR TITLE
feat(mobile): manifest-driven, capability-gated tab navigation

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,21 +1,46 @@
 import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/src/lib/theme";
+import { useAppConfigStore } from "@/src/lib/appConfig";
+import { resolveVisibleTabs } from "@/src/lib/navigation";
 
 export default function TabsLayout() {
+  const { colors } = useTheme();
+  const persona = useAppConfigStore((s) => s.persona);
+  const capabilities = useAppConfigStore((s) => s.capabilities);
+  const navigation = useAppConfigStore((s) => s.navigation);
+
+  // Which tabs the connected install exposes for this persona. With no manifest
+  // loaded this returns the full operator set, so the default app is unchanged.
+  const visible = new Set(
+    resolveVisibleTabs({
+      persona,
+      capabilities,
+      manifestTabs: navigation?.tabs,
+    }),
+  );
+  // `href: null` hides a tab from the bar; `undefined` leaves it visible.
+  const hiddenHref = (name: string): null | undefined =>
+    visible.has(name) ? undefined : null;
+
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: "#818cf8",
-        tabBarInactiveTintColor: "#9ca3af",
-        tabBarStyle: { backgroundColor: "#1e1e2e", borderTopColor: "#3f3f5a" },
-        headerStyle: { backgroundColor: "#1e1e2e" },
-        headerTintColor: "#e2e8f0",
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textMuted,
+        tabBarStyle: {
+          backgroundColor: colors.surface1,
+          borderTopColor: colors.border,
+        },
+        headerStyle: { backgroundColor: colors.surface1 },
+        headerTintColor: colors.text,
       }}
     >
       <Tabs.Screen
         name="index"
         options={{
           title: "Home",
+          href: hiddenHref("index"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="home" size={size} color={color} />
           ),
@@ -26,6 +51,7 @@ export default function TabsLayout() {
         options={{
           title: "Ops",
           headerShown: false,
+          href: hiddenHref("ops"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="list" size={size} color={color} />
           ),
@@ -36,6 +62,7 @@ export default function TabsLayout() {
         options={{
           title: "Portfolio",
           headerShown: false,
+          href: hiddenHref("portfolio"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="pie-chart" size={size} color={color} />
           ),
@@ -46,6 +73,7 @@ export default function TabsLayout() {
         options={{
           title: "Customers",
           headerShown: false,
+          href: hiddenHref("customers"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="people" size={size} color={color} />
           ),
@@ -56,6 +84,7 @@ export default function TabsLayout() {
         options={{
           title: "More",
           headerShown: false,
+          href: hiddenHref("more"),
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="ellipsis-horizontal" size={size} color={color} />
           ),

--- a/apps/mobile/src/lib/navigation.test.ts
+++ b/apps/mobile/src/lib/navigation.test.ts
@@ -1,0 +1,76 @@
+import { resolveVisibleTabs, type TabSpec } from "./navigation";
+
+describe("resolveVisibleTabs", () => {
+  it("defaults to the full operator tab set when nothing is loaded", () => {
+    expect(resolveVisibleTabs({})).toEqual([
+      "index",
+      "ops",
+      "portfolio",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("operator persona sees all platform tabs", () => {
+    expect(resolveVisibleTabs({ persona: { kind: "operator" } })).toEqual([
+      "index",
+      "ops",
+      "portfolio",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("customer persona sees a reduced tab set (no ops / portfolio)", () => {
+    expect(resolveVisibleTabs({ persona: { kind: "customer" } })).toEqual([
+      "index",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("employee persona hides portfolio", () => {
+    expect(resolveVisibleTabs({ persona: { kind: "employee" } })).toEqual([
+      "index",
+      "ops",
+      "customers",
+      "more",
+    ]);
+  });
+
+  it("an explicit manifest tab order wins and is filtered to known tabs", () => {
+    expect(
+      resolveVisibleTabs({
+        persona: { kind: "operator" },
+        manifestTabs: ["customers", "index", "bogus"],
+      }),
+    ).toEqual(["customers", "index"]);
+  });
+
+  it("capability-gates a tab only when capabilities are known", () => {
+    const registry: TabSpec[] = [
+      { key: "index", personas: ["operator"] },
+      { key: "jobs", personas: ["operator"], capability: "work-items" },
+    ];
+    // capabilities unknown → ungated (jobs shown)
+    expect(
+      resolveVisibleTabs({ persona: { kind: "operator" }, registry }),
+    ).toEqual(["index", "jobs"]);
+    // capabilities known, without work-items → jobs hidden
+    expect(
+      resolveVisibleTabs({
+        persona: { kind: "operator" },
+        capabilities: ["notifications"],
+        registry,
+      }),
+    ).toEqual(["index"]);
+    // capabilities known, with work-items → jobs shown
+    expect(
+      resolveVisibleTabs({
+        persona: { kind: "operator" },
+        capabilities: ["work-items"],
+        registry,
+      }),
+    ).toEqual(["index", "jobs"]);
+  });
+});

--- a/apps/mobile/src/lib/navigation.ts
+++ b/apps/mobile/src/lib/navigation.ts
@@ -1,0 +1,66 @@
+import type { AppPersona, AppPersonaKind } from "@dpf/types";
+
+/** A mobile tab and the personas / capability that make it visible. */
+export interface TabSpec {
+  key: string;
+  /** Personas that see this tab when the manifest gives no explicit nav order. */
+  personas: AppPersonaKind[];
+  /** Optional capability gate; when capabilities are known, the tab shows only if present. */
+  capability?: string;
+}
+
+/**
+ * Registry of the app's bottom tabs. The current set is the platform-operator
+ * surface; persona-specific tabs (field / customer) are added as those modes
+ * land. Persona membership already makes navigation install-driven — a customer
+ * install shows fewer tabs than an operator one — without breaking the operator
+ * default. See docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html.
+ */
+export const TAB_REGISTRY: TabSpec[] = [
+  { key: "index", personas: ["operator", "employee", "customer", "admin"] },
+  { key: "ops", personas: ["operator", "employee", "admin"] },
+  { key: "portfolio", personas: ["operator", "admin"] },
+  { key: "customers", personas: ["operator", "employee", "customer", "admin"] },
+  { key: "more", personas: ["operator", "employee", "customer", "admin"] },
+];
+
+const DEFAULT_PERSONA: AppPersonaKind = "operator";
+
+export interface ResolveTabsInput {
+  persona?: AppPersona | null;
+  capabilities?: string[];
+  /** manifest.navigation.tabs — an explicit, server-driven tab order. */
+  manifestTabs?: string[];
+  registry?: TabSpec[];
+}
+
+/**
+ * Resolve which tabs are visible (and in what order) from the install manifest.
+ * Precedence: explicit manifest tab order → persona defaults. A capability gate
+ * applies only when capabilities are known (a connected install); with none
+ * loaded the app shows its persona defaults ungated, preserving the operator app.
+ */
+export function resolveVisibleTabs(input: ResolveTabsInput): string[] {
+  const registry = input.registry ?? TAB_REGISTRY;
+  const personaKind = input.persona?.kind ?? DEFAULT_PERSONA;
+  const caps = input.capabilities;
+  const capsKnown = Array.isArray(caps) && caps.length > 0;
+  const byKey = new Map(registry.map((t) => [t.key, t]));
+
+  const capAllowed = (spec: TabSpec): boolean => {
+    if (!spec.capability) return true;
+    if (!capsKnown) return true;
+    return caps!.includes(spec.capability);
+  };
+
+  if (input.manifestTabs && input.manifestTabs.length > 0) {
+    return input.manifestTabs
+      .filter((k) => byKey.has(k))
+      .filter((k) => capAllowed(byKey.get(k)!));
+  }
+
+  return registry
+    .filter((t) => t.personas.includes(personaKind))
+    .filter(capAllowed)
+    .map((t) => t.key);
+}


### PR DESCRIPTION
## What & why

Makes the mobile app's **navigation install-driven** — the first slice of the manifest's functionality layer (the design layer is complete; this starts "archetypes drive functionality").

- New pure `resolveVisibleTabs()` (`src/lib/navigation.ts`): precedence is **explicit manifest tab order → persona defaults**, with a **capability gate** applied only when a connected install's capabilities are loaded. With no manifest the full operator set is returned, so the default app is unchanged.
- Wired into the tab shell (`app/(tabs)/_layout.tsx`), which now also **themes from the install** (tab bar + header read `useTheme()`).
- Net effect: a **customer-persona install shows a reduced tab set** (no Ops/Portfolio); an operator install shows all — one binary, install-driven nav. Capability-gated tabs (e.g. a future field "jobs" tab) hide unless the archetype enables them.

## Verification
- Mobile typecheck clean; jest **186/186 (28 suites)**, incl. 6 new navigation tests. No regressions.

## Stacking
Stacked on #1897 (uses the `@dpf/types` `AppNavigation`/`AppPersona` contract). Base will retarget to `main` once #1897 merges.

## Next
- Producer: emit `manifest.navigation` per persona/archetype (portal).
- Per-archetype `DynamicForm`/`DynamicView` seeding + first persona use-case screens (field/customer).
- Live-install functional verification.

Generated with Claude Code