### PR TITLE
feat(kernel): remove-avoidable-failure-opportunities principle

### DIFF
--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,7 +1,7 @@
 {
   "kernelVersion": "0.2.1",
   "schemaVersion": "0.3.0",
-  "pageCount": 87,
+  "pageCount": 88,
   "sourceCount": 11,
   "embeddingModel": "ai/nomic-embed-text-v1.5",
   "embeddingDims": 768,

--- a/docs/founder-kernel/wiki/principles/remove-avoidable-failure-opportunities.md
+++ b/docs/founder-kernel/wiki/principles/remove-avoidable-failure-opportunities.md
@@ -1,0 +1,208 @@
+---
+title: Remove avoidable failure opportunities
+slug: remove-avoidable-failure-opportunities
+pageKind: principle
+status: published
+abstract: The cheapest failure is the one the system can no longer express. Remove avoidable failure modes structurally — make the wrong state unrepresentable or auto-detected — instead of relying on a human or an AI to stay vigilant. Self-heal what you can; make the residual, unavoidable failures loudly observable. Drift control as a designed-in property, not a maintenance chore, is one of DPF's differentiating benefits.
+principleTier: core
+principleDirection: Remove avoidable failure modes structurally and keep correctness through automated, self-checking process — not human or AI vigilance; make the residual, unavoidable failures loudly observable.
+principleDimensionVector: {"long_term_maintainability": 1.0, "human_cognitive_load": -0.6, "evidence_density": 0.6, "governance_compliance": 0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleConsumerArchetype: ai-coworker-universal
+principleRingScope:
+  - universal-ring
+principlePublic: false
+authoredAt: 2026-06-14
+authoredBy: mark-bodman
+---
+
+# Remove avoidable failure opportunities
+
+**The cheapest failure is the one the system can no longer express.**
+Before you write the code that catches a mistake, ask whether the mistake
+can be made *unrepresentable* — designed out of the system so it cannot
+occur, rather than detected after it does. When prevention isn't possible,
+make the system *self-heal*. When neither is possible, fall back to the
+residual leg: make the unavoidable failure loudly observable.
+
+This is **systemic prevention over vigilance.** A failure mode that depends
+on a human — or an AI agent — *remembering* to do the right thing every
+single time will eventually fail, because vigilance does not scale and
+does not compound. A failure mode the architecture forbids cannot recur.
+The work is to keep moving correctness out of the "someone must remember"
+column and into the "the system guarantees it" column.
+
+## What "removing the failure opportunity" looks like
+
+- **Make the wrong state unrepresentable.** A `string` that should be one
+  of four values is a typo waiting to happen; a string-literal union or
+  enum makes the typo a compile error. The failure opportunity is deleted,
+  not guarded. (See [[principles/strongly-typed-string-enums]].)
+- **Derive, don't duplicate.** Two hand-maintained copies of the same fact
+  drift the instant one moves. A single source of truth that the other
+  view is *projected from* cannot drift by construction — the second copy
+  no longer exists to be wrong. (See [[principles/single-source-of-truth]]
+  and [[mirror-dont-migrate]].)
+- **Fix the seed, then guard the invariant.** A config regression that
+  keeps coming back means the bootstrap data was never corrected. Patch
+  the seed so the bad state can't be born, and add a guard that fails the
+  build if it ever reappears. (See [[principles/fix-the-seed-not-the-runtime]].)
+- **Default-deny, then grant explicitly.** A permission surface that is
+  permissive-by-default fails open on every new tool nobody remembered to
+  lock down. Deny-by-default fails closed; the only way to grant is to say
+  so, on the record.
+- **Automate the check at the point work enters the system.** A drift gate
+  in CI, a build gate at the Review phase, and the agent skill that runs
+  the same gate — one check, three consumers — means no one has to
+  *remember* to verify parity. The system verifies it, every time.
+
+## Why this exists
+
+**Drift is the tax on complexity, and most of it is avoidable.** As a
+system grows, design and implementation pull apart: the model says one
+thing, the code says another, and the gap widens silently until the
+architecture is fiction. The naive fix is to ask people to keep the two in
+sync by hand — which relocates the cognitive load instead of removing it,
+and rots on arrival.
+
+The Design–Implementation Parity Engine is this principle made concrete.
+Its very first run — a read-only gate that re-checks every
+deterministic-provenance `sourceKey` in the architecture views against real
+code — caught a real broken reference (`data-model-mirror-apply.ts` missing
+its directory prefix) that a human reviewer would not have found by reading.
+The hand-authored model had already drifted; the *system* caught it because
+the check was automated, not because anyone was vigilant. That is the whole
+argument in one data point: **the gate finds what the human eye skips, and
+it finds it every run, at zero ongoing human cost.**
+
+This is also a differentiator, not just hygiene. Keeping design and
+implementation in provable parity — drift control as a designed-in property
+of the platform — is one of DPF's core differentiating benefits. A platform
+that *cannot* drift by construction is worth more than one that merely
+documents that it shouldn't.
+
+The vigilance alternative fails three predictable ways:
+
+1. **It does not scale.** Every new tool, route, persona, or seed row adds
+   another thing someone must remember to keep correct. The remembering
+   surface grows without bound; attention does not.
+2. **It does not compound.** A manually-maintained invariant is re-paid in
+   full on every change. A structurally-guaranteed invariant is paid once,
+   at design time, and stays paid.
+3. **It fails silently.** The failure that depends on vigilance is, by
+   definition, invisible until someone notices the thing that should have
+   happened didn't — which is exactly the failure mode
+   [[make-silent-failures-observable]] exists to cover.
+
+## The three legs
+
+This principle is a layered defense, strongest leg first:
+
+1. **Prevent structurally** — make the failure mode unrepresentable
+   (types, single source of truth, default-deny, derivation over
+   duplication). The failure cannot occur.
+2. **Self-heal automatically** — when the failure *can* occur, let the
+   system detect and correct it without a human in the loop (idempotent
+   reconcilers, revive-on-conflict, scheduled re-projection). The failure
+   occurs but does not persist.
+3. **Make the residual observable** — for failures that are genuinely
+   unavoidable, emit a structured, queryable signal so the failure is
+   loud, attributable, and fixable. This is the residual leg, owned by
+   [[make-silent-failures-observable]]; this principle sits above it and
+   says: *get to this leg as rarely as possible.*
+
+A design that reaches for leg 3 where leg 1 was available has not removed
+the failure opportunity — it has merely instrumented it.
+
+## How to apply
+
+Before merging a change, walk the legs in order:
+
+1. **Name the failure mode.** What is the specific wrong state this code
+   could end up in — the typo, the drifted copy, the forgotten grant, the
+   stale seed?
+2. **Try to delete it (leg 1).** Can a type, an enum, a single source of
+   truth, a derived projection, or a default-deny make that wrong state
+   impossible to represent? If yes, do that instead of writing a guard
+   around it.
+3. **If it can still occur, automate the catch (leg 1.5/2).** Add the
+   invariant guard, the idempotent reconciler, or the CI/Build-Studio gate
+   that detects or repairs it without anyone remembering to look. Verify
+   the gate actually fails on the bad state — a gate that never goes red is
+   [[structural-verification-is-not-functional|structural theatre]].
+4. **For the irreducible residual, make it observable (leg 3).** Emit the
+   structured signal per [[make-silent-failures-observable]] and, if it
+   represents future work, file the tracking item in the same change.
+5. **Remove the maintenance surface you replaced.** When a gate or
+   projection makes a hand-maintained artifact redundant, delete the
+   artifact in the same change — don't leave the drift-prone copy alongside
+   its replacement.
+
+The test of whether you applied this principle: after the change, is there
+*less* for a human or an AI to remember, or more? Removing a failure
+opportunity should shrink the vigilance surface, never grow it.
+
+## Decision dimensions
+
+The signed `principleDimensionVector` (proposed; see the calibration note):
+
+- `long_term_maintainability: 1.0` — this principle *is* the
+  maintainability axis. Structural prevention is what keeps a system
+  correct as it evolves. Maximum positive weight.
+- `human_cognitive_load: -0.6` — explicitly negative. In the scorer,
+  option feature scores are non-negative ("how much does this option
+  exhibit this axis"), so a negative weight means an option that *adds*
+  human/AI upkeep aligns *against* this principle. Removing the vigilance
+  burden is central here — more central than to the residual-leg sibling
+  [[make-silent-failures-observable]] (`-0.3`), so the magnitude is larger.
+- `evidence_density: 0.6` — automated, self-checking process emits governed
+  evidence (drift findings, gate results, conformance issues) as a byproduct
+  of prevention. Positive.
+- `governance_compliance: 0.4` — parity gates and default-deny surfaces are
+  how the platform stays provably within its own rules. Positive.
+
+## Anti-patterns
+
+- **A code comment instead of a constraint.** "Remember to update the
+  other copy when you change this" is a failure opportunity with a sticky
+  note on it. Derive the second copy or make the divergence a build error.
+- **A guard you never test going red.** An invariant check that has never
+  failed might be checking nothing. Prove it catches the bad state.
+- **Catch-and-continue that hides the bad state.** `try { … } catch {}`
+  around the thing that can drift converts a removable failure into a silent
+  one — the opposite of every leg.
+- **Relocating the load and calling it removed.** Replacing "remember to
+  run the script" with "remember to read the dashboard" has not removed the
+  vigilance burden; it has renamed it.
+- **Instrumenting a failure that leg 1 could have deleted.** Reaching
+  straight for observability when a type or a single source of truth would
+  have made the failure impossible.
+
+## Related principles
+
+- [`make-silent-failures-observable`](make-silent-failures-observable.md) —
+  the residual leg. This principle says *remove the failure*; that one says
+  *when you can't, make it loud.* They are paired: prevention first,
+  observability for the irreducible remainder.
+- [`single-source-of-truth`](single-source-of-truth.md) — drift's root
+  cause is duplicated authority; collapsing copies into one derivation is
+  the most common way to delete a failure mode.
+- [`fix-the-seed-not-the-runtime`](fix-the-seed-not-the-runtime.md) — patch
+  where the bad state is born plus an invariant guard, so the regression
+  cannot return.
+- [`live-state-over-seed-data`](live-state-over-seed-data.md) — seed is
+  bootstrap; runtime truth comes from live probes, so the seed cannot be
+  load-bearing where it would drift.
+- [`structural-verification-is-not-functional`](structural-verification-is-not-functional.md)
+  — a gate that compiles is not a gate that catches; verify the check
+  actually fails on the failure it claims to prevent.
+- [`architecture-over-shortcuts`](architecture-over-shortcuts.md) — the
+  quick fix is usually a new special case, i.e. a new failure opportunity;
+  the sound fix removes one.
+
+## Spec references
+
+- [Design–Implementation Parity Engine design](../../../superpowers/specs/2026-06-14-design-implementation-parity-engine-design.md) — §1 (drift as the tax on complexity), §8 (this principle's promotion record and proposed vector/tier)
+- [Self-Maintaining Data Architecture design](../../../superpowers/specs/2026-06-06-data-architecture-self-maintenance-design.md) — the auto-extraction / mirror pattern that removes the hand-maintenance surface

--- a/packages/db/src/seed-wiki-kernel.test.ts
+++ b/packages/db/src/seed-wiki-kernel.test.ts
@@ -10,6 +10,7 @@ import {
   type SeedablePage,
   type WikiPageFrontmatter,
 } from "./seed-wiki-kernel";
+import { isPrincipleDimension } from "./wiki-taxonomy";
 
 describe("seed-wiki-kernel: parseFrontmatter", () => {
   it("parses scalar fields", () => {
@@ -474,6 +475,59 @@ describe("founder-kernel principle frontmatter", () => {
     }
 
     expect(missing).toEqual([]);
+  });
+});
+
+describe("founder-kernel principle: remove-avoidable-failure-opportunities", () => {
+  // Spec: docs/superpowers/specs/2026-06-14-design-implementation-parity-engine-design.md §8.
+  // Guards that the WWMD "avoid opportunities to fail" principle seeds with a
+  // structurally valid, registry-backed dimensionVector so principle_decide
+  // scores it via STRUCTURED alignment (not semantic fallback). The proposed
+  // tier/vector are flagged for operator calibration in the PR, so this test
+  // pins structural intent (valid keys + the two researched signs), NOT exact
+  // magnitudes — recalibrating a weight must not break the build.
+  const principlePath = resolve(
+    process.cwd(),
+    "../../docs/founder-kernel/wiki/principles/remove-avoidable-failure-opportunities.md",
+  );
+
+  it("seeds as a core principle with a valid, registry-backed dimensionVector", () => {
+    const raw = readFileSync(principlePath, "utf8");
+    const { frontmatter } = parseFrontmatter<WikiPageFrontmatter>(raw);
+
+    expect(frontmatter.pageKind).toBe("principle");
+    expect(frontmatter.principleTier).toBe("core");
+
+    // extractPrinciplePayload throws on any unknown dimension key, so a clean
+    // extraction is itself the "valid vector" guarantee — assert it explicitly.
+    expect(() => extractPrinciplePayload(frontmatter)).not.toThrow();
+    const payload = extractPrinciplePayload(frontmatter);
+
+    const vector = payload.principleDimensionVector ?? {};
+    const keys = Object.keys(vector);
+    expect(keys.length).toBeGreaterThan(0);
+    // Every axis must exist in the closed PRINCIPLE_DIMENSIONS registry, else
+    // structured scoring could never key on it (and seeding would have thrown).
+    for (const key of keys) {
+      expect(isPrincipleDimension(key)).toBe(true);
+    }
+
+    // Semantic load-bearing signs (researched against option-scoring.ts):
+    // option feature scores are non-negative, so a NEGATIVE weight means
+    // "an option that adds this axis aligns AGAINST the principle".
+    //   - long_term_maintainability: the defining (positive, dominant) axis.
+    //   - human_cognitive_load: negative — the principle removes upkeep burden.
+    expect(vector["long_term_maintainability"]).toBeGreaterThan(0);
+    expect(vector["human_cognitive_load"]).toBeLessThan(0);
+
+    // principleDimensions is derived from the vector keys 1:1 when omitted.
+    expect((payload.principleDimensions ?? []).slice().sort()).toEqual(
+      keys.slice().sort(),
+    );
+
+    // Coherent consumer scoping: an agent-class archetype that must NOT pair
+    // with `human` in principleAppliesTo (enforced by the seed coherence matrix).
+    expect(frontmatter.principleConsumerArchetype).toBe("ai-coworker-universal");
   });
 });
 


### PR DESCRIPTION
## What

Authors the founder-kernel principle **`remove-avoidable-failure-opportunities`** — the WWMD *"avoid opportunities to fail"* doctrine — as a `core` principle, and wires it into kernel seeding so `principle_decide` can score against it.

The principle: **remove avoidable failure modes structurally** (make the wrong state unrepresentable — types, single source of truth, default-deny, derivation over duplication) instead of relying on human or AI vigilance; **self-heal** what you can; fall back to **making the residual, unavoidable failures observable**. It pairs with and sits *above* `make-silent-failures-observable` — prevention first, observability for the irreducible remainder. Drift control as a designed-in property is framed as a DPF differentiator (per the Parity Engine spec).

Part of the **Design–Implementation Parity Engine** initiative — `docs/superpowers/specs/2026-06-14-design-implementation-parity-engine-design.md` §8, which drafted this promotion.

## How it's wired

- **Seeding (no registry change):** the kernel seed walker (`packages/db/src/seed-wiki-kernel.ts`) globs `docs/founder-kernel/wiki/**`, so the new page is picked up automatically. Frontmatter passes the seed-time validators (dimension registry, consumer-archetype coherence matrix) — confirmed by the existing `founder-kernel principle frontmatter` sweep, which now also covers this page.
- **Test:** adds a focused regression test in `seed-wiki-kernel.test.ts` asserting the page seeds as a `core` principle with a valid, registry-backed `dimensionVector`. It pins *structural intent* (every key ∈ `PRINCIPLE_DIMENSIONS`; the two load-bearing signs) **not exact magnitudes**, so recalibrating a weight won't break the build.
- **Manifest:** `pageCount` 87 → 88. Embeddings-sidecar rebuild is **deferred** — structured `principle_decide` scoring reads the Postgres row (`dimensionVector`), not embeddings; semantic fallback degrades gracefully until the next embeddings batch.

## ⚠️ Proposed for operator calibration

Per the spec's stance (*mis-calibrating a kernel vector mis-governs `principle_decide`*), **tier and vector are surfaced for your adjustment, not shipped blind:**

- **tier: `core`** — design doctrine; pairs with / sits above the residual-failure leg `make-silent-failures-observable` (also core). Deliberately **not** `commandment`.
- **dimensionVector (proposed):**

  | axis | weight | rationale |
  |---|---|---|
  | `long_term_maintainability` | **1.0** | this principle *is* the maintainability axis; dominant |
  | `human_cognitive_load` | **−0.6** | negative by design (see below) |
  | `evidence_density` | **0.6** | automated self-checking emits governed evidence as a byproduct |
  | `governance_compliance` | **0.4** | parity gates / default-deny keep the platform provably in-rule |

**On the negative weight (researched against `apps/web/lib/decision/option-scoring.ts`):** `computeStructuredAlignment` computes `Σ option[dim]×vector[dim] / Σ |vector[dim]|`, where option feature scores are **non-negative** (`[0,1]` — "how much the option exhibits this axis"). So a **negative** `human_cognitive_load` weight means *an option that adds human/AI upkeep aligns against this principle* — exactly the intent ("remove the vigilance burden"). The magnitude (−0.6) is deliberately larger than the sibling `make-silent-failures-observable` (−0.3) because reducing maintenance load is more central to *this* principle. Signs and magnitudes all check out against the scorer semantics, so I kept the spec's proposed vector unchanged.

- **`principleConsumerArchetype: ai-coworker-universal`** mirrors `make-silent-failures-observable` (coherent — no `human` in `principleAppliesTo`). If you'd rather it also bind humans-setting-direction, that's a `universal` + add-`human` recalibration — flagging it alongside tier/vector.

## Verification (deferred-validation mode)

- `vitest run packages/db/src/seed-wiki-kernel.test.ts` → **48/48 pass** (new test + the all-principles frontmatter sweep over the new page).
- Filtered `tsc --noEmit` → **zero errors in touched files**. (The local deps-less worktree surfaces 3 pre-existing `@dpf/storefront-templates` workspace-resolution errors in files this PR does not touch; CI resolves them with a full install.)
- Full suite intentionally skipped per the deferred-validation directive — **relying on CI** for the complete gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
