### PR TITLE
ci(ea): route-manifest freshness gate (Parity Engine — domain 4 enforcement)

### DIFF
--- a/.github/workflows/audit-route-manifest.yml
+++ b/.github/workflows/audit-route-manifest.yml
@@ -1,0 +1,64 @@
+name: Route Manifest Freshness
+
+# CodeQL actions/missing-workflow-permissions: least-privilege default.
+# Read-only freshness check; needs no write surface.
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Route-defining files — the only changes that can make the manifest stale.
+      - "apps/web/app/**/page.ts"
+      - "apps/web/app/**/page.tsx"
+      - "apps/web/app/**/route.ts"
+      - "apps/web/app/**/route.tsx"
+      # The manifest, its generator, and the row type the generator imports.
+      - "apps/web/lib/ea/route-manifest.json"
+      - "apps/web/scripts/build-route-manifest.ts"
+      - "apps/web/lib/ea/route-extract.ts"
+      - ".github/workflows/audit-route-manifest.yml"
+  push:
+    branches: [main]
+
+concurrency:
+  group: audit-route-manifest-${{ github.ref }}
+  cancel-in-progress: true
+
+# What this guard does
+# --------------------
+# Regenerates apps/web/lib/ea/route-manifest.json in-memory from the Next.js App
+# Router tree (apps/web/app/**/{page,route}.{ts,tsx}) and fails if it differs from the
+# committed file. A PR that adds, removes, or renames a route without regenerating the
+# manifest is design↔implementation drift: the live SysML route projection
+# (reconcile-routes.ts reads this manifest) would no longer match the actual routes.
+#
+# This is the enforcement leg (spec §4.3) for the Parity Engine routes domain
+# (docs/superpowers/specs/2026-06-14-design-implementation-parity-engine-design.md):
+# it makes the committed manifest self-policing so the navigation architecture cannot
+# silently rot — automation over vigilance. Mirrors audit-architecture-parity.yml.
+#
+# To fix a STALE failure: pnpm --filter web build:route-manifest && commit the result.
+
+jobs:
+  freshness:
+    name: Route Manifest Freshness
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check route manifest is up to date
+        run: pnpm --filter web check:route-manifest


### PR DESCRIPTION
## What

Closes the **enforcement loop** for the Parity Engine routes domain (domain 4, shipped in #1900): a CI gate that regenerates the Next.js route manifest in-memory and **fails if it differs from the committed `apps/web/lib/ea/route-manifest.json`**.

A PR that adds, removes, or renames a route without regenerating the manifest is design↔implementation drift — the live SysML route projection (`reconcile-routes.ts` reads this manifest) would no longer match the actual routes. This makes the committed manifest self-policing (spec §4.3, automation over vigilance), mirroring `audit-architecture-parity.yml`.

## How

Runs `pnpm --filter web check:route-manifest` (the `--check` mode already shipped in `build-route-manifest.ts`). Scoped precisely to the files that can make the manifest stale:

- `apps/web/app/**/{page,route}.{ts,tsx}` — route-defining files
- the manifest, its generator, and the row type it imports
- the workflow itself

So it only runs when the manifest could actually go stale, not on every app change.

## Verification

- **Fresh case**: `--check` passes on current main — `up to date (494 routes)`, exit 0.
- **Drift case (functional)**: added a throwaway route → `--check` reports `STALE`, exit 1; removed it → exit 0 again. The gate genuinely bites.

## Tracking

`BI-PARITY-ROUTES-CI` under `EP-PARITY-ENGINE`. This is the pending follow-up I flagged when domain 4 landed; the epic now tracks all landed slices (done) + remaining roadmap (BPMN process extraction, generalized steward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
