### PR TITLE
feat(decision): UI-surface feature-deriver for the design gate

### DIFF
--- a/apps/web/lib/decision/ui-surface-features.test.ts
+++ b/apps/web/lib/decision/ui-surface-features.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyUiSurfaceTier,
+  scoreUiSurfaceChange,
+  uiSurfaceFeatures,
+  type UiSurfaceChange,
+} from "./ui-surface-features";
+
+const base: UiSurfaceChange = {
+  controlsAdded: 0,
+  controlsRemoved: 0,
+  justification: "none",
+  reuseBreadth: 0,
+  clarifiesOutcome: 0,
+};
+
+describe("classifyUiSurfaceTier", () => {
+  it("no-op when no surface changes", () => {
+    expect(classifyUiSurfaceTier(base)).toBe("no-op");
+  });
+
+  it("removal when surface is only retired", () => {
+    expect(classifyUiSurfaceTier({ ...base, controlsRemoved: 2 })).toBe("removal");
+  });
+
+  it("low for a net addition with inadequate justification (even if reusable)", () => {
+    expect(
+      classifyUiSurfaceTier({
+        ...base,
+        controlsAdded: 1,
+        justification: "none",
+        reuseBreadth: 1,
+        clarifiesOutcome: 1,
+      }),
+    ).toBe("low");
+  });
+
+  it("mid for a justified addition with narrow reuse / no clarification", () => {
+    expect(
+      classifyUiSurfaceTier({
+        ...base,
+        controlsAdded: 1,
+        justification: "researched",
+        reuseBreadth: 0.2,
+        clarifiesOutcome: 0.2,
+      }),
+    ).toBe("mid");
+  });
+
+  it("high for a justified, clarifying, broadly-reusable addition", () => {
+    expect(
+      classifyUiSurfaceTier({
+        ...base,
+        controlsAdded: 1,
+        justification: "researched",
+        reuseBreadth: 0.8,
+        clarifiesOutcome: 0.8,
+      }),
+    ).toBe("high");
+  });
+});
+
+describe("uiSurfaceFeatures", () => {
+  it("imposes high cognitive load for an unjustified net addition", () => {
+    const { ship } = uiSurfaceFeatures({ ...base, controlsAdded: 1, justification: "none" });
+    expect(ship.human_cognitive_load).toBeGreaterThan(0.7);
+    expect(ship.evidence_density).toBeLessThan(0.2);
+  });
+
+  it("buys load down for a justified, reusable, clarifying addition", () => {
+    const { ship } = uiSurfaceFeatures({
+      ...base,
+      controlsAdded: 1,
+      justification: "researched",
+      reuseBreadth: 0.9,
+      clarifiesOutcome: 0.9,
+    });
+    expect(ship.human_cognitive_load).toBeLessThan(0.2);
+    expect(ship.reusability).toBeGreaterThan(0.8);
+    expect(ship.evidence_density).toBeCloseTo(0.9);
+  });
+
+  it("net removal imposes near-zero load on the ship option", () => {
+    const { ship } = uiSurfaceFeatures({ ...base, controlsAdded: 1, controlsRemoved: 3, justification: "weak" });
+    expect(ship.human_cognitive_load).toBeCloseTo(0.1);
+  });
+
+  it("retire baseline is constant and favors removal (low load, high maintainability)", () => {
+    const { retire } = uiSurfaceFeatures({ ...base, controlsAdded: 2, justification: "researched" });
+    expect(retire.human_cognitive_load).toBeLessThan(0.1);
+    expect(retire.long_term_maintainability).toBeGreaterThan(0.8);
+  });
+
+  it("keeps every feature within [0,1]", () => {
+    const { ship, retire } = uiSurfaceFeatures({
+      ...base,
+      controlsAdded: 5,
+      justification: "researched",
+      reuseBreadth: 1,
+      clarifiesOutcome: 1,
+    });
+    for (const v of [...Object.values(ship), ...Object.values(retire)]) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("scoreUiSurfaceChange", () => {
+  it("short-circuits no-op without calling the kernel", async () => {
+    const exec = vi.fn();
+    const v = await scoreUiSurfaceChange(base, { userId: "u1", toolExecutor: exec });
+    expect(v.gate).toBe("no-op");
+    expect(v.pass).toBe(true);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("passes a pure removal without calling the kernel", async () => {
+    const exec = vi.fn();
+    const v = await scoreUiSurfaceChange(
+      { ...base, controlsRemoved: 2 },
+      { userId: "u1", toolExecutor: exec },
+    );
+    expect(v.tier).toBe("removal");
+    expect(v.gate).toBe("pass");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("passes when ship beats retire with high confidence", async () => {
+    const exec = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        recommendation: { optionId: "ship", confidence: "high", margin: 0.3 },
+        scores: [{ optionId: "ship" }],
+        reasoning: "Ship earns its surface.",
+      },
+    });
+    const v = await scoreUiSurfaceChange(
+      { ...base, controlsAdded: 1, justification: "researched", reuseBreadth: 0.9, clarifiesOutcome: 0.9 },
+      { userId: "u1", toolExecutor: exec },
+    );
+    expect(exec).toHaveBeenCalledOnce();
+    expect(exec.mock.calls[0][0]).toBe("principle_decide");
+    expect(v.gate).toBe("pass");
+    expect(v.pass).toBe(true);
+    expect(v.tier).toBe("high");
+  });
+
+  it("soft-blocks when retire beats ship (unjustified surface)", async () => {
+    const exec = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        recommendation: { optionId: "retire", confidence: "high", margin: 0.4 },
+        scores: [{ optionId: "retire" }],
+        reasoning: "Removal beats unjustified surface.",
+      },
+    });
+    const v = await scoreUiSurfaceChange(
+      { ...base, controlsAdded: 1, justification: "none" },
+      { userId: "u1", toolExecutor: exec },
+    );
+    expect(v.gate).toBe("soft-block");
+    expect(v.pass).toBe(false);
+    expect(v.tier).toBe("low");
+  });
+
+  it("soft-blocks when ship wins but only at low confidence", async () => {
+    const exec = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        recommendation: { optionId: "ship", confidence: "low", margin: 0.05 },
+        scores: [],
+        reasoning: "Close call.",
+      },
+    });
+    const v = await scoreUiSurfaceChange(
+      { ...base, controlsAdded: 1, justification: "weak", reuseBreadth: 0.3, clarifiesOutcome: 0.3 },
+      { userId: "u1", toolExecutor: exec },
+    );
+    expect(v.gate).toBe("soft-block");
+    expect(v.pass).toBe(false);
+  });
+});

--- a/apps/web/lib/decision/ui-surface-features.ts
+++ b/apps/web/lib/decision/ui-surface-features.ts
@@ -1,0 +1,216 @@
+// Interface-surface scoring for the `remove-avoidable-failure-opportunities`
+// kernel principle (founder-kernel §"Interface surface is failure surface").
+//
+// Mirrors the browser-drive means-selector pattern (./../browser-drive/select-means.ts):
+// derive a feature vector from change signals, then let a scoped `principle_decide`
+// call weigh "ship this surface as designed" against the "retire / rework" baseline.
+// A new control must BEAT removal to pass — which is how "removing interfaces is
+// better" becomes a scored gate rather than a slogan.
+//
+// Operator rubric (2026-06-14), encoded in `classifyUiSurfaceTier`:
+//   no-op   — no interface change; the dimension does not apply.
+//   removal — the change retires surface; favored.
+//   high    — clarification interaction → better outcome, reusable across many
+//             internal outcomes long-term, backed by research/evidence.
+//   mid     — well-thought-out + justified, but narrow reuse.
+//   low     — new surface with inadequate justification/research (surface bloat).
+//
+// The cost axes are scored HONESTLY here (a net addition imposes
+// `human_cognitive_load`), which only produces the right verdict because the
+// cost-axis signs were corrected to the directional convention (PR #1904).
+//
+// `executeTool` (the real governed principle_decide path) is imported lazily
+// inside `scoreUiSurfaceChange` only when no executor is injected, so the pure
+// derivation functions stay free of the heavy mcp-tools import graph.
+
+export const UI_SURFACE_SELECT_SURFACE = "design-gate-ui-surface";
+
+export type UiSurfaceJustification = "none" | "weak" | "researched";
+
+/** Signals describing an interface-surface change (counts >= 0; ratios 0..1). */
+export type UiSurfaceChange = {
+  /** New interactive controls: buttons, fillable fields, forms, routes. */
+  controlsAdded: number;
+  /** Retired controls (collapsed into a derived value, replaced by an automatic step, deleted). */
+  controlsRemoved: number;
+  /** Evidence backing the added surface. */
+  justification: UiSurfaceJustification;
+  /** Breadth of long-term reuse across internal outcomes (0 single .. 1 many). */
+  reuseBreadth: number;
+  /** Does the control clarify intent toward a demonstrably better outcome? (0..1) */
+  clarifiesOutcome: number;
+};
+
+export type UiSurfaceTier = "no-op" | "removal" | "high" | "mid" | "low";
+
+const clamp = (n: number): number => Math.max(0, Math.min(1, n));
+
+const EVIDENCE: Record<UiSurfaceJustification, number> = {
+  none: 0.1,
+  weak: 0.5,
+  researched: 0.9,
+};
+
+/**
+ * Classify a surface change into the operator rubric tier. Pure — the gate uses
+ * this for the human-readable verdict; `scoreUiSurfaceChange` produces the
+ * principle_decide-backed pass/soft-block decision.
+ */
+export function classifyUiSurfaceTier(change: UiSurfaceChange): UiSurfaceTier {
+  const { controlsAdded, controlsRemoved, justification, reuseBreadth, clarifiesOutcome } = change;
+  if (controlsAdded <= 0 && controlsRemoved <= 0) return "no-op";
+  if (controlsAdded <= 0 && controlsRemoved > 0) return "removal";
+  // A net addition with inadequate justification is low regardless of reuse —
+  // "we might want it" is not justification.
+  if (EVIDENCE[justification] < 0.3) return "low";
+  // Justified: high requires a clarifying outcome AND broad long-term reuse;
+  // otherwise the surface is amortized too thinly to be more than mid.
+  if (clarifiesOutcome >= 0.5 && reuseBreadth >= 0.5) return "high";
+  return "mid";
+}
+
+/**
+ * Derive `principle_decide` feature vectors for the two options the gate weighs:
+ *   ship   — ship the surface as designed (load bought down by justification/reuse/clarify)
+ *   retire — retire / rework instead (the removal baseline the change must beat)
+ *
+ * Pure. Feature keys are `PRINCIPLE_DIMENSIONS`; values 0..1 = how much the
+ * option exhibits that axis. `human_cognitive_load` is a cost axis: a net
+ * addition imposes load, reduced by evidence + reuse + clarification; a net
+ * removal imposes near-zero.
+ */
+export function uiSurfaceFeatures(change: UiSurfaceChange): {
+  ship: Record<string, number>;
+  retire: Record<string, number>;
+} {
+  const { controlsAdded, controlsRemoved, justification, reuseBreadth, clarifiesOutcome } = change;
+  const e = EVIDENCE[justification];
+  const netAddition = controlsAdded > controlsRemoved;
+  // Net additions impose cognitive load; justification, reuse, and clarification
+  // value buy it down. A net removal imposes near-zero.
+  const load = netAddition
+    ? clamp(0.85 - 0.4 * e - 0.25 * reuseBreadth - 0.2 * clarifiesOutcome)
+    : 0.1;
+  return {
+    ship: {
+      human_cognitive_load: load,
+      reusability: clamp(0.15 + 0.8 * reuseBreadth),
+      evidence_density: e,
+      long_term_maintainability: clamp(0.3 + 0.25 * e + 0.25 * reuseBreadth + 0.15 * clarifiesOutcome),
+      governance_compliance: 0.4,
+      public_safety: clamp(0.3 + 0.3 * clarifiesOutcome),
+    },
+    retire: {
+      human_cognitive_load: 0.05,
+      reusability: 0.2,
+      evidence_density: 0.3,
+      long_term_maintainability: 0.9,
+      governance_compliance: 0.5,
+      public_safety: 0.4,
+    },
+  };
+}
+
+export type UiSurfaceVerdict = {
+  tier: UiSurfaceTier;
+  /** true = the surface earns its place (ship beats retire with confidence). */
+  pass: boolean;
+  /** Gate action: "soft-block" is overridable, recorded as evidence. */
+  gate: "pass" | "soft-block" | "no-op";
+  recommendation: { optionId?: string; confidence?: string; margin?: number } | null;
+  /** Contribution ledger for evidence persistence. */
+  ledger: unknown;
+  reason: string;
+};
+
+type ToolExecutor = (
+  toolName: string,
+  args: Record<string, unknown>,
+  userId: string,
+  context: Record<string, unknown>,
+) => Promise<{ success?: boolean; data?: Record<string, unknown>; error?: string }>;
+
+/**
+ * Score an interface-surface change at the design gate. Injectable executor for
+ * tests; defaults to the platform tool executor so the real call goes through
+ * the governed `principle_decide` path. No-op and pure-removal changes
+ * short-circuit without a WWMD round-trip (the rubric's "no-op" / "removal").
+ *
+ * Gate semantics (soft-block-override, per the kernel's own WWMD verdict on
+ * enforcement strength): "ship" must beat the removal baseline with high
+ * confidence to pass; otherwise the gate soft-blocks — a low-scoring,
+ * unjustified surface addition is held, but an operator can override with the
+ * override recorded as evidence.
+ */
+export async function scoreUiSurfaceChange(
+  change: UiSurfaceChange,
+  opts: { userId: string; routeContext?: string; toolExecutor?: ToolExecutor },
+): Promise<UiSurfaceVerdict> {
+  const tier = classifyUiSurfaceTier(change);
+  if (tier === "no-op") {
+    return {
+      tier,
+      pass: true,
+      gate: "no-op",
+      recommendation: null,
+      ledger: null,
+      reason: "No interface surface changed; the interface-surface dimension does not apply.",
+    };
+  }
+  if (tier === "removal") {
+    return {
+      tier,
+      pass: true,
+      gate: "pass",
+      recommendation: null,
+      ledger: null,
+      reason: "Change retires interface surface; favored — removing interfaces is better.",
+    };
+  }
+
+  const { ship, retire } = uiSurfaceFeatures(change);
+  const options = [
+    { id: "ship", description: "Ship the new/changed interface surface as designed.", features: ship },
+    {
+      id: "retire",
+      description: "Retire or rework instead of adding the surface (the removal baseline).",
+      features: retire,
+    },
+  ];
+
+  const exec = opts.toolExecutor ?? (await import("@/lib/mcp-tools")).executeTool;
+  const response = await exec(
+    "principle_decide",
+    {
+      context:
+        "A Build Studio change adds interface surface (a button, fillable field, form, or route). " +
+        "Does shipping it as designed beat retiring or reworking it, given its justification and " +
+        "long-term reuse? Governed by remove-avoidable-failure-opportunities — interface surface is " +
+        "failure surface; a new control must earn its surface.",
+      callingPopulation: "in_platform_coworker",
+      callingSurface: UI_SURFACE_SELECT_SURFACE,
+      options,
+    },
+    opts.userId,
+    { routeContext: opts.routeContext ?? UI_SURFACE_SELECT_SURFACE },
+  );
+
+  const data = response.success ? response.data : undefined;
+  const rec =
+    (data?.recommendation as { optionId?: string; confidence?: string; margin?: number } | undefined) ?? null;
+  const shipWins = rec?.optionId === "ship";
+  const confident = rec?.confidence === "high";
+  const pass = shipWins && confident;
+
+  return {
+    tier,
+    pass,
+    gate: pass ? "pass" : "soft-block",
+    recommendation: rec,
+    ledger: data?.scores ?? data ?? null,
+    reason:
+      typeof data?.reasoning === "string"
+        ? (data.reasoning as string)
+        : "Scored by governed decision against the removal baseline.",
+  };
+}


### PR DESCRIPTION
## What

A pure, tested **UI-surface feature-deriver** — the mechanism that lets future work actually *supply the input* to score interface changes against `remove-avoidable-failure-opportunities`, instead of falling back to semantic.

It mirrors the proven browser-drive means-selector (`apps/web/lib/browser-drive/select-means.ts`):

- **`uiSurfaceFeatures(change)`** → `principle_decide` feature vectors for two options: **`ship`** (the surface as designed, with `human_cognitive_load` bought down by justification + reuse + clarification) vs **`retire`** (the removal baseline). A new control must *beat removal* to pass — which is how **"removing interfaces is better"** becomes a scored gate, not a slogan.
- **`classifyUiSurfaceTier(change)`** → the operator rubric: `no-op` / `removal` (favored) / `high` (clarifying + reusable + researched) / `mid` (justified, narrow reuse) / `low` (unjustified).
- **`scoreUiSurfaceChange(change, opts)`** → a `pass` / `soft-block` / `no-op` verdict via the governed `principle_decide` path (injectable executor for tests). No-op and pure-removal short-circuit without a WWMD round-trip.

**Gate hardness = `soft-block-override`**, chosen by running the decision *through the kernel itself*: with the corrected (#1904) vectors, `principle_decide` ranked `block` > `soft-block-override` > `advisory` (composite 4.29 / 3.94 / 1.97, high confidence), driven by the governance/evidence commandments. `soft-block-override` is the kernel's close #2 and the safer first cut for a heuristic scorer — it blocks unjustified surface by default but lets an operator override, recorded as evidence.

`human_cognitive_load` is scored **honestly as a cost** here — which only produces the right verdict because the cost-axis signs were corrected in #1904. That's the whole chain paying off.

## Why this depends on #1904

If the cost-axis signs were still inverted, `ship`'s imposed cognitive load would *help* it beat `retire` — rewarding surface bloat. The deriver is only correct on top of the recalibrated kernel.

## Verification

- `vitest apps/web/lib/decision/ui-surface-features.test.ts` → **15/15 pass** (rubric tiers, feature derivation bounds, no-op/removal short-circuits, ship-wins-high-confidence → pass, retire-wins / low-confidence → soft-block).
- Filtered `tsc` → **zero errors in the new files**.
- `executeTool` imported lazily so the pure functions carry no heavy import graph.

## Next (wiring PR)

Phase 3b wires this into the two consumers you asked for: the **Build Studio design gate** (derive the surface delta from the plan/design, score, soft-block on low) and the **`dpf-decision-via-kernel`** skill (require UI-surface features for interface-affecting decisions — kill the silent `features: {}` fallback for that class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
