### PR TITLE
feat(build-studio): register opencode as a provisionable build engine (Phase 2c, BI-01D6A51B)

### DIFF
--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -257,7 +257,7 @@ export function BuildStudioConfigForm({
             desc="Built-in tool-calling loop"
           />
         </div>
-        {(provider === "claude" || provider === "codex" || provider === "grok") &&
+        {(provider === "claude" || provider === "codex" || provider === "grok" || provider === "opencode") &&
           engineReadiness?.[provider]?.present === false && (
             <div role="status" style={{ marginTop: 10, fontSize: 11, color: "var(--dpf-warning)" }}>
               ⚠ {provider.charAt(0).toUpperCase() + provider.slice(1)} is selected but not installed in the sandbox —

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2339,11 +2339,11 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "provision_build_engine",
-    description: "Install a build-dispatch engine (claude, codex, grok) into the running sandbox from its registry recipe, then verify by re-probing. Idempotent — a no-op if the engine is already present. Side-effecting: runs the install command (e.g. `npm install -g`, or the grok curl-installer) inside the sandbox, so it requires sandbox_execute. Pass offline:true to use only no-egress (prestaged-binary) recipes for air-gapped installs. Returns { kind, version, recipe }.",
+    description: "Install a build-dispatch engine (claude, codex, grok, opencode) into the running sandbox from its registry recipe, then verify by re-probing. Idempotent — a no-op if the engine is already present. Side-effecting: runs the install command (e.g. `npm install -g`, the grok curl-installer, or the opencode prestaged-binary/tarball) inside the sandbox, so it requires sandbox_execute. Pass offline:true to use only no-egress (prestaged-binary) recipes for air-gapped installs. Returns { kind, version, recipe }.",
     inputSchema: {
       type: "object",
       properties: {
-        engineId: { type: "string", description: "Engine to provision: 'claude' | 'codex' | 'grok'." },
+        engineId: { type: "string", description: "Engine to provision: 'claude' | 'codex' | 'grok' | 'opencode'." },
         offline: {
           type: "boolean",
           description: "When true, only run no-egress (prestaged-binary) recipes (air-gapped install). Default false.",
@@ -2358,7 +2358,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "get_build_engine_readiness",
-    description: "Report whether each build-dispatch engine (claude, codex, grok) is present and healthy in the build sandbox. Returns per-engine { present, version, lastProbedAt, bakeInDefault } from the last probe (BuildEngineState). Pass refresh:true to live re-probe each engine (docker exec <verifyCommand>) and persist the fresh result. Use this to see engine readiness before selecting a build dispatch engine — e.g. an engine that is selectable but shows present:false would fail at runtime with 'not found'.",
+    description: "Report whether each build-dispatch engine (claude, codex, grok, opencode) is present and healthy in the build sandbox. Returns per-engine { present, version, lastProbedAt, bakeInDefault } from the last probe (BuildEngineState). Pass refresh:true to live re-probe each engine (docker exec <verifyCommand>) and persist the fresh result. Use this to see engine readiness before selecting a build dispatch engine — e.g. an engine that is selectable but shows present:false would fail at runtime with 'not found'.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/db/data/build-engines.json
+++ b/packages/db/data/build-engines.json
@@ -56,5 +56,29 @@
         "priority": 20
       }
     ]
+  },
+  "opencode": {
+    "binary": "opencode",
+    "verify": {
+      "command": "opencode --version",
+      "versionRegex": "([0-9.]+)"
+    },
+    "bakeInDefault": true,
+    "recipes": [
+      {
+        "method": "prestaged-binary",
+        "stagedPath": "/opt/dpf-engines/opencode",
+        "muslSafe": true,
+        "requiresEgress": false,
+        "priority": 10
+      },
+      {
+        "method": "curl-installer",
+        "command": "curl -fsSL -o /tmp/opencode.tar.gz https://github.com/anomalyco/opencode/releases/download/v1.17.4/opencode-linux-x64-baseline-musl.tar.gz && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin && rm /tmp/opencode.tar.gz && chmod 755 /usr/local/bin/opencode",
+        "muslSafe": true,
+        "requiresEgress": true,
+        "priority": 20
+      }
+    ]
   }
 }

--- a/packages/db/scripts/sync-engine-registry.test.ts
+++ b/packages/db/scripts/sync-engine-registry.test.ts
@@ -37,11 +37,12 @@ describe('syncEngineRegistry', () => {
 
     await syncEngineRegistry(mockPrisma, dataPath);
 
-    expect(upsert).toHaveBeenCalledTimes(3);
+    expect(upsert).toHaveBeenCalledTimes(4);
     expect(upsert.mock.calls.map(([args]) => args.create.engineId)).toEqual([
       'claude',
       'codex',
       'grok',
+      'opencode',
     ]);
   });
 
@@ -52,7 +53,7 @@ describe('syncEngineRegistry', () => {
     await syncEngineRegistry(mockPrisma, dataPath);
     await syncEngineRegistry(mockPrisma, dataPath);
 
-    expect(upsert).toHaveBeenCalledTimes(6);
+    expect(upsert).toHaveBeenCalledTimes(8);
   });
 
   it('throws with file path on malformed JSON', async () => {


### PR DESCRIPTION
## Summary

Closes the wiring gap that made the `opencode` engine invisible to readiness/provisioning. Diagnosed live: `get_build_engine_readiness` only knew claude/codex/grok, so the sandbox couldn't probe or install opencode and the UI showed no readiness badge. Backlog: **BI-01D6A51B** (EP-BUILD-STUDIO).

## Changes

- **`build-engines.json`** — `opencode` registry entry (`bakeInDefault: true`) with two musl-safe recipes: **prestaged-binary** from `/opt/dpf-engines/opencode` (offline, priority 10 — the binary [#1796](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1796) already stages into the image) and a **curl-installer** fallback fetching the pinned v1.17.4 baseline-musl tarball (online, priority 20 — for a sandbox that lacks the baked binary). The seeder iterates generically, so a `BuildEngine` row, readiness probe, and `provision_build_engine` path all light up automatically.
- **`mcp-tools.ts`** — `provision_build_engine` / `get_build_engine_readiness` descriptions now list `opencode` (`engineId` was already a free string, so the tool accepted it).
- **`BuildStudioConfigForm`** — the "selected but not installed in the sandbox" warning + Provision button now also fire for `opencode`.
- **`sync-engine-registry.test`** — 3 → 4 engines.

## Why this matters

After deploy, this is what lets the operator (or an MCP session) run `provision_build_engine("opencode")` to install the binary into the running sandbox **without an image rebuild**, and see the readiness badge in Admin > Build Studio. Readiness + UI enumerate from the `BuildEngine` table, so opencode appears as soon as the registry is seeded on deploy.

## Verification

- Seeder test green (4 tests; asserts the opencode row is created).
- Typecheck via CI — the source-only worktree's junctioned toolchain is missing newly-added `@dpf/types`/`@dpf/storefront-templates` workspace packages (unrelated files); my changes are a JSON data row, two description strings, and one boolean condition.

## Context: this unblocks the live install

This is the last code gap before the OpenCode option is usable end-to-end. The remaining steps are operational, not code: advance the live install via `/ops/self-upgrade` (seeds the engine + ships the UI), then `provision_build_engine("opencode")`, configure `provider=opencode`, and run a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)