### PR TITLE
fix(governance): add missing email_config grant to the catalog (unblocks merge gate)

### DIFF
--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -586,6 +586,16 @@
       "implies": []
     },
     {
+      "key": "email_config",
+      "description": "Configure the organization's OWN outbound email (SMTP) — detect provider, save settings, send a test. Operator-gated (manage_provider_connections); DPF never relays mail on the operator's behalf.",
+      "category": "integrate",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "setup_email"
+      ],
+      "implies": []
+    },
+    {
       "key": "ea_graph_read",
       "description": "Read ea graph.",
       "category": "explore",


### PR DESCRIPTION
## Summary

**Unblocks the merge gate for all PRs.** [#1908](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1908) added the `setup_email` tool + `email_config` grant on `AGT-WS-ONBOARD` but never added `email_config` to `grant_catalog.json`, so the **Coworker Tool-Grant Audit** fails (GRANT-001 + GRANT-003) on every branch off current main.

This backfills the one missing catalog entry (`category: integrate`, `confidential` — it handles SMTP credentials; `honored_by_tools: [setup_email]`).

## Verification

Ran the audit locally with the committed baseline:
```
[audit] baseline diff: unchanged=73 resolved=0 new=0   (exit 0)
```
Was `new=2` before the fix.

Found while diagnosing an unrelated CI failure on the OpenCode Build Studio work ([#1920](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1920)) — surfacing as a standalone governance hotfix per one-concern-per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)