### PR TITLE
fix(backups): proactive alerting on backup corruption (BI-EA67A758)

### DIFF
--- a/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
+++ b/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
@@ -346,6 +346,22 @@ export function BackupsClient({
               </div>
             </div>
 
+            {/* BI-EA67A758: inline warning banner when last trial restore failed */}
+            {target === "postgres" && r.openCorruptionAlert && (
+              <div
+                className="mb-3 p-3 rounded text-sm"
+                style={{
+                  background: "rgba(248, 113, 113, 0.15)",
+                  color: "#f87171",
+                  border: "1px solid rgba(248, 113, 113, 0.3)",
+                }}
+              >
+                <strong>Critical:</strong> The last Postgres backup trial restore failed &mdash;{" "}
+                {r.openCorruptionAlert.message} Run a new backup and use &ldquo;Verify last
+                backup&rdquo; to confirm integrity.
+              </div>
+            )}
+
             {/* ─── Readiness card ──────────────────────────────────────── */}
             <div
               className="rounded p-4 grid gap-3 text-sm mb-3"

--- a/apps/web/lib/operate/backups/postgres-trial-restore-runner.test.ts
+++ b/apps/web/lib/operate/backups/postgres-trial-restore-runner.test.ts
@@ -12,6 +12,7 @@ vi.mock("@dpf/db", () => ({
     backupRun: { findMany: vi.fn() },
     backupRestore: { create: vi.fn() },
     scheduledJob: { update: vi.fn() },
+    platformNotification: { create: vi.fn(), updateMany: vi.fn() },
   },
 }));
 
@@ -22,13 +23,19 @@ type Mock = ReturnType<typeof vi.fn>;
 const findManyMock = prisma.backupRun.findMany as unknown as Mock;
 const createMock = prisma.backupRestore.create as unknown as Mock;
 const scheduledJobUpdateMock = prisma.scheduledJob.update as unknown as Mock;
+const notificationCreateMock = prisma.platformNotification.create as unknown as Mock;
+const notificationUpdateManyMock = prisma.platformNotification.updateMany as unknown as Mock;
 
 beforeEach(() => {
   findManyMock.mockReset();
   createMock.mockReset();
   scheduledJobUpdateMock.mockReset();
+  notificationCreateMock.mockReset();
+  notificationUpdateManyMock.mockReset();
   createMock.mockImplementation(async ({ data, select }) => ({ id: "restore_test_id", ...(select ? {} : data) }));
   scheduledJobUpdateMock.mockResolvedValue({});
+  notificationCreateMock.mockResolvedValue({ id: "notif_test_id" });
+  notificationUpdateManyMock.mockResolvedValue({ count: 1 });
 });
 
 describe("parseResultLine", () => {
@@ -237,6 +244,67 @@ describe("runPostgresTrialRestore", () => {
           }),
         }),
       );
+    } finally {
+      accessSpy.mockRestore();
+    }
+  });
+
+  it("failed trial restore creates a critical PlatformNotification (BI-EA67A758)", async () => {
+    const { promises: fs } = await import("node:fs");
+    const accessSpy = vi.spyOn(fs, "access").mockResolvedValue(undefined);
+    try {
+      findManyMock.mockResolvedValue([
+        { id: "backuprun_a", storagePath: "postgres/2026-05-24T03-00-00Z" },
+      ]);
+      const failedScript: ScriptOutcome = {
+        ok: false,
+        stdout: "RESULT failed assert_BacklogItem=0 duration_ms=5000 reason=BacklogItem:zero-rows\n",
+        stderr: "",
+        exitCode: 5,
+      };
+      await runPostgresTrialRestore({ backupsRoot: "/test/backups", runScript: async () => failedScript });
+      expect(notificationCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            severity: "critical",
+            category: "backup-trial-restore-failed",
+            subjectId: "postgres",
+            message: expect.stringContaining("failed"),
+          }),
+        }),
+      );
+      expect(notificationUpdateManyMock).not.toHaveBeenCalled();
+    } finally {
+      accessSpy.mockRestore();
+    }
+  });
+
+  it("successful trial restore resolves open PlatformNotification (BI-EA67A758)", async () => {
+    const { promises: fs } = await import("node:fs");
+    const accessSpy = vi.spyOn(fs, "access").mockResolvedValue(undefined);
+    try {
+      findManyMock.mockResolvedValue([
+        { id: "backuprun_a", storagePath: "postgres/2026-05-24T03-00-00Z" },
+      ]);
+      const okScript: ScriptOutcome = {
+        ok: true,
+        stdout:
+          "RESULT ok assert_BacklogItem=550 assert_Epic=62 assert_ModelProvider=30 assert_User=1 duration_ms=10000\n",
+        stderr: "",
+        exitCode: 0,
+      };
+      await runPostgresTrialRestore({ backupsRoot: "/test/backups", runScript: async () => okScript });
+      expect(notificationUpdateManyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            category: "backup-trial-restore-failed",
+            subjectId: "postgres",
+            resolvedAt: null,
+          }),
+          data: expect.objectContaining({ resolvedAt: expect.any(Date) }),
+        }),
+      );
+      expect(notificationCreateMock).not.toHaveBeenCalled();
     } finally {
       accessSpy.mockRestore();
     }

--- a/apps/web/lib/operate/backups/postgres-trial-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-trial-restore-runner.ts
@@ -254,6 +254,30 @@ export async function runPostgresTrialRestore(
     postgresTrialRestoreLastSuccessSeconds.set(Math.floor(finishedAt.getTime() / 1000));
   }
 
+  // BI-EA67A758: proactive operator alerting via PlatformNotification.
+  // On failure: create a critical notification so the operator sees a banner
+  // without having to navigate to Admin > Backups. On success: resolve any
+  // open notification so the banner clears automatically.
+  if (finalStatus === "failed") {
+    await prisma.platformNotification
+      .create({
+        data: {
+          severity: "critical",
+          category: "backup-trial-restore-failed",
+          subjectId: "postgres",
+          message: `Postgres backup trial restore failed: ${errorMessage ?? "unknown error"}. Navigate to Admin → Backups to inspect the log and trigger a new backup.`,
+        },
+      })
+      .catch(() => {}); // never crash the runner on a notification write failure
+  } else {
+    await prisma.platformNotification
+      .updateMany({
+        where: { category: "backup-trial-restore-failed", subjectId: "postgres", resolvedAt: null },
+        data: { resolvedAt: finishedAt },
+      })
+      .catch(() => {});
+  }
+
   await prisma.scheduledJob
     .update({
       where: { jobId: POSTGRES_TRIAL_RESTORE_JOB_ID },

--- a/apps/web/lib/operate/backups/readiness.ts
+++ b/apps/web/lib/operate/backups/readiness.ts
@@ -25,7 +25,7 @@ async function getReadinessForTarget(
   jobId: string,
   target: BackupTarget,
 ): Promise<ReadinessSummary> {
-  const [job, lastRun, lastSuccess, retainedRuns, recentFailures, lastTrialRestore] =
+  const [job, lastRun, lastSuccess, retainedRuns, recentFailures, lastTrialRestore, openCorruptionAlert] =
     await Promise.all([
       prisma.scheduledJob.findUnique({ where: { jobId } }),
       prisma.backupRun.findFirst({
@@ -65,6 +65,16 @@ async function getReadinessForTarget(
               finishedAt: true,
               errorMessage: true,
             },
+          })
+        : Promise.resolve(null),
+      // BI-EA67A758: open critical alert for a failed trial restore. The runner
+      // creates a PlatformNotification on failure and resolves it on success.
+      // The readiness card surfaces this as an inline warning banner.
+      target === "postgres"
+        ? prisma.platformNotification.findFirst({
+            where: { category: "backup-trial-restore-failed", subjectId: target, resolvedAt: null },
+            orderBy: { createdAt: "desc" },
+            select: { id: true, message: true, createdAt: true },
           })
         : Promise.resolve(null),
     ]);
@@ -121,6 +131,13 @@ async function getReadinessForTarget(
           lastStartedAt: lastTrialRestore.startedAt.toISOString(),
           lastFinishedAt: lastTrialRestore.finishedAt?.toISOString() ?? null,
           lastError: lastTrialRestore.errorMessage,
+        }
+      : null,
+    openCorruptionAlert: openCorruptionAlert
+      ? {
+          id: openCorruptionAlert.id,
+          message: openCorruptionAlert.message,
+          createdAt: openCorruptionAlert.createdAt.toISOString(),
         }
       : null,
   };

--- a/apps/web/lib/operate/backups/types.ts
+++ b/apps/web/lib/operate/backups/types.ts
@@ -138,4 +138,16 @@ export interface ReadinessSummary {
     lastFinishedAt: string | null;
     lastError: string | null;
   } | null;
+  /**
+   * Open critical PlatformNotification for a failed trial restore on this
+   * target (category="backup-trial-restore-failed", resolvedAt=null).
+   * Non-null means the operator needs to act — the last trial restore failed
+   * and no subsequent successful restore has cleared it (or the operator
+   * has not dismissed it). Null when healthy or never run.
+   */
+  openCorruptionAlert: {
+    id: string;
+    message: string;
+    createdAt: string;
+  } | null;
 }

--- a/scripts/backup-postgres.sh
+++ b/scripts/backup-postgres.sh
@@ -89,6 +89,22 @@ else
   fail "pg_dump failed (exit=$EXIT)" 3
 fi
 
+# Structural validation: pg_restore --list exercises the custom-format header
+# and TOC catalog without performing a full restore. This catches silent
+# stream truncation caused by Docker socket proxy resets — the host-side
+# redirect commits partial bytes silently and pg_dump may exit 0 inside the
+# container while the dump is already corrupt. SHA256 cannot detect this
+# because it is computed on whatever bytes were written.
+# postgresql16-client is installed in the runner image (Dockerfile:apk add).
+if pg_restore --list "$DUMP_FILE" > /dev/null 2>> "$LOG_FILE"; then
+  log "structural validation passed (pg_restore --list ok)"
+else
+  VALID_EXIT=$?
+  log "structural validation failed exit=$VALID_EXIT — dump is truncated or corrupt, deleting"
+  rm -f "$DUMP_FILE"
+  fail "corrupt dump detected by structural validation (pg_restore --list exit=$VALID_EXIT)" 3
+fi
+
 # sha256 checksum so the admin UX can verify integrity without re-reading the
 # whole dump. We store the bare hash for easy comparison.
 DUMP_SHA="$(sha256sum "$DUMP_FILE" | awk '{print $1}')" || fail "sha256sum failed" 4


### PR DESCRIPTION
## Summary
- Adds \`pg_restore --list\` structural validation in \`backup-postgres.sh\` after pg_dump — catches Docker socket proxy truncation that produces a partial dump with exit 0 but corrupt bytes. SHA256 cannot detect this. Deletes the corrupt file and exits code 3.
- Creates a critical \`PlatformNotification\` (category=\`backup-trial-restore-failed\`) on trial-restore failure; resolves it via \`updateMany\` on success. Operator is alerted immediately rather than only when navigating to Admin > Backups.
- Surfaces the open notification as an inline red banner above the Postgres readiness card via a new \`openCorruptionAlert\` field on \`ReadinessSummary\`.
- BI-EA67A758

## Test plan
- [x] vitest \`postgres-trial-restore-runner.test.ts\`: 13 passed (includes 2 new cases — failed restore creates notification, success resolves it)
- [x] typecheck: pre-existing \`@dpf/db\` workspace-resolution errors in worktree (calendar-data, workforce, build-lifecycle — none in changed files); DPF_SKIP_TYPECHECK=1 used; CI will gate merge
- [x] next build: n/a (no new pages, banner is inline JSX in existing component)
- [x] UX verification: n/a pending live banner trigger (requires a failing trial restore)

Overlap sweep: no open PRs touching backup files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)