### PR TITLE
fix(self-upgrade): make derived-store backups best-effort in the recovery point

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -32,6 +32,7 @@ import {
 import { emitUpgradeEvent } from "@/lib/self-upgrade/notifications";
 import {
   createSelfUpgradeRecoveryPoint,
+  summarizeRecoveryPointDegradation,
   summarizeRecoveryPointFailure,
 } from "@/lib/self-upgrade/recovery-point";
 import {
@@ -434,6 +435,13 @@ export async function runSelfUpgrade(
     dryRun: params.dryRun,
   });
   await recordRunRecoveryPoint(run.runId, recoveryPoint);
+  if (recoveryPoint.status === "degraded") {
+    // A best-effort (derived-store) backup failed — neo4j (code/knowledge
+    // graph) and qdrant (vectors) rebuild from source, so this does NOT block
+    // the upgrade. Record it loudly for the operator audit trail and proceed.
+    const note = summarizeRecoveryPointDegradation(recoveryPoint);
+    if (note) console.warn(`[self-upgrade] ${run.runId}: ${note}`);
+  }
   if (recoveryPoint.status === "failed") {
     const reason = summarizeRecoveryPointFailure(recoveryPoint);
     if (quiescenceRunId) await failQuiescenceSwap(quiescenceRunId, reason);

--- a/apps/web/lib/self-upgrade/recovery-point.test.ts
+++ b/apps/web/lib/self-upgrade/recovery-point.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  classifyRecoveryPointStatus,
   createSelfUpgradeRecoveryPoint,
+  resolveRequiredRecoveryTargets,
+  summarizeRecoveryPointDegradation,
   summarizeRecoveryPointFailure,
+  type SelfUpgradeRecoveryPointMember,
 } from "./recovery-point";
 
 describe("self-upgrade recovery point", () => {
@@ -47,7 +51,7 @@ describe("self-upgrade recovery point", () => {
     });
   });
 
-  it("fails the recovery point when a backup runner reports failed", async () => {
+  it("degrades — not fails — when only a best-effort (derived-store) backup fails", async () => {
     const point = await createSelfUpgradeRecoveryPoint({
       runId: "SUR-TEST",
       runners: {
@@ -57,9 +61,28 @@ describe("self-upgrade recovery point", () => {
       },
     });
 
+    // neo4j (code/knowledge graph) is rebuilt from source, so a failed backup
+    // of it must NOT block the upgrade — the recovery point is degraded, not
+    // failed, and the orchestrator only aborts on "failed".
+    expect(point.status).toBe("degraded");
+    expect(summarizeRecoveryPointDegradation(point)).toBe(
+      "recovery-point-degraded (best-effort backup failed, upgrade proceeding): neo4j",
+    );
+  });
+
+  it("fails the recovery point only when the required postgres backup fails", async () => {
+    const point = await createSelfUpgradeRecoveryPoint({
+      runId: "SUR-TEST",
+      runners: {
+        postgres: vi.fn().mockResolvedValue({ runId: "BR-PG", status: "failed" }),
+        neo4j: vi.fn().mockResolvedValue({ runId: "BR-N4J", status: "ok" }),
+        qdrant: vi.fn().mockResolvedValue({ runId: "BR-QD", status: "ok" }),
+      },
+    });
+
     expect(point.status).toBe("failed");
     expect(summarizeRecoveryPointFailure(point)).toBe(
-      "recovery-point-failed: neo4j BR-N4J",
+      "recovery-point-failed: postgres BR-PG",
     );
   });
 
@@ -99,5 +122,41 @@ describe("self-upgrade recovery point", () => {
       members: [],
     });
     expect(postgres).not.toHaveBeenCalled();
+  });
+
+  it("classifies status by required vs best-effort targets", () => {
+    const members: SelfUpgradeRecoveryPointMember[] = [
+      { target: "postgres", runId: "BR-PG", status: "ok" },
+      { target: "neo4j", runId: "BR-N4J", status: "failed" },
+      { target: "qdrant", runId: "BR-QD", status: "ok" },
+    ];
+    // Default: postgres required, neo4j/qdrant best-effort → degraded.
+    expect(classifyRecoveryPointStatus(members, new Set(["postgres"]))).toBe("degraded");
+    // Operator widens the required set to include neo4j → now it blocks.
+    expect(classifyRecoveryPointStatus(members, new Set(["postgres", "neo4j"]))).toBe(
+      "failed",
+    );
+    // Everything ok → ok.
+    expect(
+      classifyRecoveryPointStatus(
+        members.map((member) => ({ ...member, status: "ok" as const })),
+        new Set(["postgres"]),
+      ),
+    ).toBe("ok");
+  });
+
+  it("resolveRequiredRecoveryTargets defaults to postgres and honors the env override", () => {
+    expect([...resolveRequiredRecoveryTargets({})]).toEqual(["postgres"]);
+    expect(
+      [
+        ...resolveRequiredRecoveryTargets({
+          DPF_RECOVERY_POINT_REQUIRED_TARGETS: "postgres,neo4j",
+        }),
+      ].sort(),
+    ).toEqual(["neo4j", "postgres"]);
+    // Unknown values are ignored, falling back to the postgres-only default.
+    expect([
+      ...resolveRequiredRecoveryTargets({ DPF_RECOVERY_POINT_REQUIRED_TARGETS: "bogus" }),
+    ]).toEqual(["postgres"]);
   });
 });

--- a/apps/web/lib/self-upgrade/recovery-point.ts
+++ b/apps/web/lib/self-upgrade/recovery-point.ts
@@ -24,7 +24,7 @@ interface RecoveryPointRunners {
   qdrant: QdrantBackupRunner;
 }
 
-export type SelfUpgradeRecoveryPointStatus = "ok" | "failed" | "skipped";
+export type SelfUpgradeRecoveryPointStatus = "ok" | "degraded" | "failed" | "skipped";
 
 export interface SelfUpgradeRecoveryPointMember {
   target: BackupTarget;
@@ -102,12 +102,64 @@ export async function createSelfUpgradeRecoveryPoint(
 
   return {
     schemaVersion: 1,
-    status: members.every((member) => member.status === "ok") ? "ok" : "failed",
+    status: classifyRecoveryPointStatus(members),
     trigger: RECOVERY_TRIGGER,
     selfUpgradeRunId: args.runId,
     createdAt,
     members,
   };
+}
+
+/**
+ * Targets whose backup MUST succeed before an upgrade may proceed. Only the
+ * primary data store — postgres (epics, backlog, config, credentials) — is
+ * irreplaceable. neo4j (code + knowledge graph) and qdrant (vector index) are
+ * DERIVED stores, rebuilt from source by the code-graph bootstrap, so a failed
+ * or skipped backup of them must NOT block an upgrade — gating on a backup of
+ * regenerable data turns a transient backup-tooling fault into an upgrade
+ * outage (observed 2026-06-14: a neo4j backup volume-mismatch blocked every
+ * self-upgrade). Operators who want stricter gating can widen the set via
+ * DPF_RECOVERY_POINT_REQUIRED_TARGETS (comma-separated targets).
+ */
+export const DEFAULT_REQUIRED_RECOVERY_TARGETS: readonly BackupTarget[] = ["postgres"];
+
+const ALL_BACKUP_TARGETS: ReadonlySet<BackupTarget> = new Set([
+  "postgres",
+  "neo4j",
+  "qdrant",
+]);
+
+export function resolveRequiredRecoveryTargets(
+  env: Record<string, string | undefined> = process.env,
+): Set<BackupTarget> {
+  const raw = env.DPF_RECOVERY_POINT_REQUIRED_TARGETS;
+  if (raw && raw.trim()) {
+    const parsed = raw
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t): t is BackupTarget => ALL_BACKUP_TARGETS.has(t as BackupTarget));
+    if (parsed.length > 0) return new Set(parsed);
+  }
+  return new Set(DEFAULT_REQUIRED_RECOVERY_TARGETS);
+}
+
+/**
+ * Classify a recovery point from its members:
+ *   - "failed"   — a REQUIRED target's backup failed → the upgrade must abort.
+ *   - "degraded" — only best-effort (derived-store) backups failed → the
+ *                  upgrade proceeds, but the gap is recorded for the operator.
+ *   - "ok"       — every backup succeeded.
+ */
+export function classifyRecoveryPointStatus(
+  members: SelfUpgradeRecoveryPointMember[],
+  required: Set<BackupTarget> = resolveRequiredRecoveryTargets(),
+): SelfUpgradeRecoveryPointStatus {
+  const requiredFailed = members.some(
+    (member) => required.has(member.target) && member.status === "failed",
+  );
+  if (requiredFailed) return "failed";
+  const anyFailed = members.some((member) => member.status === "failed");
+  return anyFailed ? "degraded" : "ok";
 }
 
 async function resolveRecoveryPointRunners(
@@ -168,4 +220,22 @@ export function summarizeRecoveryPointFailure(point: SelfUpgradeRecoveryPoint): 
     return `${member.target}${runId}${suffix}`;
   });
   return `recovery-point-failed: ${parts.join("; ")}`;
+}
+
+/**
+ * Human-readable note naming the best-effort (derived-store) backups that
+ * failed on a "degraded" recovery point. Returns null when nothing failed.
+ * The upgrade proceeds regardless; this is for the operator audit trail.
+ */
+export function summarizeRecoveryPointDegradation(
+  point: SelfUpgradeRecoveryPoint,
+): string | null {
+  const failed = point.members.filter((member) => member.status === "failed");
+  if (failed.length === 0) return null;
+
+  const parts = failed.map((member) => {
+    const suffix = member.error ? `: ${member.error}` : "";
+    return `${member.target}${suffix}`;
+  });
+  return `recovery-point-degraded (best-effort backup failed, upgrade proceeding): ${parts.join("; ")}`;
 }


### PR DESCRIPTION
## Problem

The pre-upgrade **recovery point** aborts the *entire* self-upgrade if **any** of the three managed backups (postgres, neo4j, qdrant) fails ([recovery-point.ts](apps/web/lib/self-upgrade/recovery-point.ts) used `members.every(... 'ok')`). But **neo4j** (code + knowledge graph) and **qdrant** (vector index) are *derived* stores, rebuilt from source by the code-graph bootstrap. Gating an upgrade on a backup of regenerable data turns a transient backup-tooling fault into an upgrade outage.

**Observed 2026-06-14:** a neo4j backup volume mismatch (live data on a bind mount; the offline dump read the empty named volume) failed with `recovery-point-failed: neo4j … Database does not exist` and **blocked every self-upgrade** — even though the graph data was intact and rebuildable.

## Fix

Only the **primary** store (postgres — epics, backlog, config, credentials) is required. A neo4j/qdrant backup failure now yields a **`degraded`** recovery point that records the gap but lets the upgrade proceed; the orchestrator still aborts on `failed`. Operators can widen the required set via `DPF_RECOVERY_POINT_REQUIRED_TARGETS`.

## Tests
- `recovery-point.test.ts` — 7 pass: neo4j-failure → `degraded` (proceeds), postgres-failure → `failed` (blocks), classifier + env-override units.

## Follow-ups (separate PRs)
- neo4j backup: derive the data mount from the live container (so it can't drift bind-vs-named again).
- watchdog: fix the early-`return` that makes stuck-quiescence-coordinator recovery dead code.
- ops: a background-job-engine health banner so a dead Inngest can't be silently broken for days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)