### PR TITLE
fix(self-upgrade): skip derived-store backups entirely in the recovery point

### DIFF
--- a/apps/web/lib/self-upgrade/recovery-point.test.ts
+++ b/apps/web/lib/self-upgrade/recovery-point.test.ts
@@ -1,16 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   classifyRecoveryPointStatus,
   createSelfUpgradeRecoveryPoint,
-  resolveRequiredRecoveryTargets,
+  resolveRecoveryBackupTargets,
   summarizeRecoveryPointDegradation,
   summarizeRecoveryPointFailure,
   type SelfUpgradeRecoveryPointMember,
 } from "./recovery-point";
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("self-upgrade recovery point", () => {
-  it("runs all managed data-store backups with the pre-upgrade trigger", async () => {
+  it("backs up only the primary store by default and skips the derived stores", async () => {
     const postgres = vi.fn().mockResolvedValue({ runId: "BR-PG", status: "ok" });
     const neo4j = vi.fn().mockResolvedValue({ runId: "BR-N4J", status: "ok" });
     const qdrant = vi.fn().mockResolvedValue({ runId: "BR-QD", status: "ok" });
@@ -31,8 +35,8 @@ describe("self-upgrade recovery point", () => {
       createdAt: "2026-06-01T00:00:00.000Z",
       members: [
         { target: "postgres", runId: "BR-PG", status: "ok" },
-        { target: "neo4j", runId: "BR-N4J", status: "ok" },
-        { target: "qdrant", runId: "BR-QD", status: "ok" },
+        { target: "neo4j", runId: null, status: "skipped" },
+        { target: "qdrant", runId: null, status: "skipped" },
       ],
     });
     expect(postgres).toHaveBeenCalledWith({
@@ -40,43 +44,17 @@ describe("self-upgrade recovery point", () => {
       composeProject: "dpf-test",
       backupsRoot: "/tmp/backups",
     });
-    expect(neo4j).toHaveBeenCalledWith({
-      trigger: "pre-upgrade-recovery",
-      composeProject: "dpf-test",
-      backupsRoot: "/tmp/backups",
-    });
-    expect(qdrant).toHaveBeenCalledWith({
-      trigger: "pre-upgrade-recovery",
-      backupsRoot: "/tmp/backups",
-    });
+    // Derived stores rebuild from source and aren't touched by a portal upgrade,
+    // so they are never backed up by default — the runners must not be invoked.
+    expect(neo4j).not.toHaveBeenCalled();
+    expect(qdrant).not.toHaveBeenCalled();
   });
 
-  it("degrades — not fails — when only a best-effort (derived-store) backup fails", async () => {
-    const point = await createSelfUpgradeRecoveryPoint({
-      runId: "SUR-TEST",
-      runners: {
-        postgres: vi.fn().mockResolvedValue({ runId: "BR-PG", status: "ok" }),
-        neo4j: vi.fn().mockResolvedValue({ runId: "BR-N4J", status: "failed" }),
-        qdrant: vi.fn().mockResolvedValue({ runId: "BR-QD", status: "ok" }),
-      },
-    });
-
-    // neo4j (code/knowledge graph) is rebuilt from source, so a failed backup
-    // of it must NOT block the upgrade — the recovery point is degraded, not
-    // failed, and the orchestrator only aborts on "failed".
-    expect(point.status).toBe("degraded");
-    expect(summarizeRecoveryPointDegradation(point)).toBe(
-      "recovery-point-degraded (best-effort backup failed, upgrade proceeding): neo4j",
-    );
-  });
-
-  it("fails the recovery point only when the required postgres backup fails", async () => {
+  it("fails the recovery point when the required postgres backup fails", async () => {
     const point = await createSelfUpgradeRecoveryPoint({
       runId: "SUR-TEST",
       runners: {
         postgres: vi.fn().mockResolvedValue({ runId: "BR-PG", status: "failed" }),
-        neo4j: vi.fn().mockResolvedValue({ runId: "BR-N4J", status: "ok" }),
-        qdrant: vi.fn().mockResolvedValue({ runId: "BR-QD", status: "ok" }),
       },
     });
 
@@ -86,13 +64,11 @@ describe("self-upgrade recovery point", () => {
     );
   });
 
-  it("captures thrown runner errors as failed members", async () => {
+  it("captures a thrown postgres error as a failed member", async () => {
     const point = await createSelfUpgradeRecoveryPoint({
       runId: "SUR-TEST",
       runners: {
         postgres: vi.fn().mockRejectedValue(new Error("pg_dump unavailable")),
-        neo4j: vi.fn().mockResolvedValue({ runId: "BR-N4J", status: "ok" }),
-        qdrant: vi.fn().mockResolvedValue({ runId: "BR-QD", status: "ok" }),
       },
     });
 
@@ -105,6 +81,25 @@ describe("self-upgrade recovery point", () => {
     });
     expect(summarizeRecoveryPointFailure(point)).toBe(
       "recovery-point-failed: postgres: pg_dump unavailable",
+    );
+  });
+
+  it("backs up an opted-in derived store best-effort: degraded (not failed) on failure", async () => {
+    vi.stubEnv("DPF_RECOVERY_POINT_BACKUP_TARGETS", "neo4j");
+    const postgres = vi.fn().mockResolvedValue({ runId: "BR-PG", status: "ok" });
+    const neo4j = vi.fn().mockResolvedValue({ runId: "BR-N4J", status: "failed" });
+
+    const point = await createSelfUpgradeRecoveryPoint({
+      runId: "SUR-TEST",
+      runners: { postgres, neo4j },
+    });
+
+    // Opted in, so neo4j IS backed up — but a failure only degrades the
+    // recovery point; the orchestrator still proceeds (it aborts on "failed").
+    expect(neo4j).toHaveBeenCalled();
+    expect(point.status).toBe("degraded");
+    expect(summarizeRecoveryPointDegradation(point)).toBe(
+      "recovery-point-degraded (best-effort backup failed, upgrade proceeding): neo4j",
     );
   });
 
@@ -124,39 +119,43 @@ describe("self-upgrade recovery point", () => {
     expect(postgres).not.toHaveBeenCalled();
   });
 
-  it("classifies status by required vs best-effort targets", () => {
-    const members: SelfUpgradeRecoveryPointMember[] = [
+  it("classifyRecoveryPointStatus blocks only on the required (postgres) target", () => {
+    const ok: SelfUpgradeRecoveryPointMember[] = [
       { target: "postgres", runId: "BR-PG", status: "ok" },
-      { target: "neo4j", runId: "BR-N4J", status: "failed" },
-      { target: "qdrant", runId: "BR-QD", status: "ok" },
+      { target: "neo4j", runId: null, status: "skipped" },
+      { target: "qdrant", runId: null, status: "skipped" },
     ];
-    // Default: postgres required, neo4j/qdrant best-effort → degraded.
-    expect(classifyRecoveryPointStatus(members, new Set(["postgres"]))).toBe("degraded");
-    // Operator widens the required set to include neo4j → now it blocks.
-    expect(classifyRecoveryPointStatus(members, new Set(["postgres", "neo4j"]))).toBe(
-      "failed",
-    );
-    // Everything ok → ok.
+    expect(classifyRecoveryPointStatus(ok)).toBe("ok");
+    // A required (postgres) failure blocks the upgrade.
     expect(
-      classifyRecoveryPointStatus(
-        members.map((member) => ({ ...member, status: "ok" as const })),
-        new Set(["postgres"]),
-      ),
-    ).toBe("ok");
+      classifyRecoveryPointStatus([
+        { target: "postgres", runId: "BR-PG", status: "failed" },
+        ok[1],
+        ok[2],
+      ]),
+    ).toBe("failed");
+    // A best-effort (derived-store) failure only degrades.
+    expect(
+      classifyRecoveryPointStatus([
+        ok[0],
+        { target: "neo4j", runId: "BR-N4J", status: "failed" },
+        ok[2],
+      ]),
+    ).toBe("degraded");
   });
 
-  it("resolveRequiredRecoveryTargets defaults to postgres and honors the env override", () => {
-    expect([...resolveRequiredRecoveryTargets({})]).toEqual(["postgres"]);
+  it("resolveRecoveryBackupTargets always includes postgres and honors the opt-in", () => {
+    expect([...resolveRecoveryBackupTargets({})]).toEqual(["postgres"]);
     expect(
       [
-        ...resolveRequiredRecoveryTargets({
-          DPF_RECOVERY_POINT_REQUIRED_TARGETS: "postgres,neo4j",
+        ...resolveRecoveryBackupTargets({
+          DPF_RECOVERY_POINT_BACKUP_TARGETS: "neo4j,qdrant",
         }),
       ].sort(),
-    ).toEqual(["neo4j", "postgres"]);
-    // Unknown values are ignored, falling back to the postgres-only default.
+    ).toEqual(["neo4j", "postgres", "qdrant"]);
+    // postgres can never be dropped; unknown tokens are ignored.
     expect([
-      ...resolveRequiredRecoveryTargets({ DPF_RECOVERY_POINT_REQUIRED_TARGETS: "bogus" }),
+      ...resolveRecoveryBackupTargets({ DPF_RECOVERY_POINT_BACKUP_TARGETS: "bogus" }),
     ]).toEqual(["postgres"]);
   });
 });

--- a/apps/web/lib/self-upgrade/recovery-point.ts
+++ b/apps/web/lib/self-upgrade/recovery-point.ts
@@ -29,8 +29,10 @@ export type SelfUpgradeRecoveryPointStatus = "ok" | "degraded" | "failed" | "ski
 export interface SelfUpgradeRecoveryPointMember {
   target: BackupTarget;
   runId: string | null;
-  status: "ok" | "failed";
+  status: "ok" | "failed" | "skipped";
   error?: string;
+  /** Why a target was skipped (a derived store that isn't backed up). */
+  reason?: string;
 }
 
 export interface SelfUpgradeRecoveryPoint {
@@ -70,35 +72,28 @@ export async function createSelfUpgradeRecoveryPoint(
     };
   }
 
-  const runners = await resolveRecoveryPointRunners(args.runners);
+  const backupTargets = resolveRecoveryBackupTargets();
+  const overrides = args.runners ?? {};
 
+  // postgres (the primary data store, and the only store a portal upgrade
+  // migrates) is always backed up. neo4j (code + knowledge graph) and qdrant
+  // (vectors) are DERIVED stores — rebuilt from source and untouched by a
+  // portal upgrade — so they are skipped unless an operator opts them in via
+  // DPF_RECOVERY_POINT_BACKUP_TARGETS. Skipping avoids running (and failing on)
+  // a backup of regenerable data on every upgrade.
   const members: SelfUpgradeRecoveryPointMember[] = [];
-  members.push(
-    await runMember("postgres", () =>
-      runners.postgres({
-        trigger: RECOVERY_TRIGGER,
-        composeProject: args.composeProject,
-        backupsRoot: args.backupsRoot,
-      }),
-    ),
-  );
-  members.push(
-    await runMember("neo4j", () =>
-      runners.neo4j({
-        trigger: RECOVERY_TRIGGER,
-        composeProject: args.composeProject,
-        backupsRoot: args.backupsRoot,
-      }),
-    ),
-  );
-  members.push(
-    await runMember("qdrant", () =>
-      runners.qdrant({
-        trigger: RECOVERY_TRIGGER,
-        backupsRoot: args.backupsRoot,
-      }),
-    ),
-  );
+  for (const target of RECOVERY_TARGET_ORDER) {
+    if (backupTargets.has(target)) {
+      members.push(await runBackupForTarget(target, overrides, args));
+    } else {
+      members.push({
+        target,
+        runId: null,
+        status: "skipped",
+        reason: DERIVED_STORE_SKIP_REASON,
+      });
+    }
+  }
 
   return {
     schemaVersion: 1,
@@ -110,37 +105,43 @@ export async function createSelfUpgradeRecoveryPoint(
   };
 }
 
+/** The order recovery-point members are recorded in. */
+const RECOVERY_TARGET_ORDER: readonly BackupTarget[] = ["postgres", "neo4j", "qdrant"];
+
+const DERIVED_STORE_SKIP_REASON =
+  "derived store — rebuilt from source and unchanged by a portal upgrade; " +
+  "not backed up (set DPF_RECOVERY_POINT_BACKUP_TARGETS to opt in)";
+
 /**
- * Targets whose backup MUST succeed before an upgrade may proceed. Only the
- * primary data store — postgres (epics, backlog, config, credentials) — is
- * irreplaceable. neo4j (code + knowledge graph) and qdrant (vector index) are
- * DERIVED stores, rebuilt from source by the code-graph bootstrap, so a failed
- * or skipped backup of them must NOT block an upgrade — gating on a backup of
- * regenerable data turns a transient backup-tooling fault into an upgrade
- * outage (observed 2026-06-14: a neo4j backup volume-mismatch blocked every
- * self-upgrade). Operators who want stricter gating can widen the set via
- * DPF_RECOVERY_POINT_REQUIRED_TARGETS (comma-separated targets).
+ * The primary data store. Always backed up, and the only target whose backup
+ * failure BLOCKS an upgrade: it holds the irreplaceable data (epics, backlog,
+ * config, credentials) and the only schema migrations an upgrade runs.
  */
-export const DEFAULT_REQUIRED_RECOVERY_TARGETS: readonly BackupTarget[] = ["postgres"];
+export const PRIMARY_BACKUP_TARGET: BackupTarget = "postgres";
 
-const ALL_BACKUP_TARGETS: ReadonlySet<BackupTarget> = new Set([
-  "postgres",
-  "neo4j",
-  "qdrant",
-]);
-
-export function resolveRequiredRecoveryTargets(
+/**
+ * Which stores the pre-upgrade recovery point backs up. postgres is ALWAYS
+ * included. neo4j (code + knowledge graph) and qdrant (vectors) are DERIVED
+ * stores — rebuilt from source by the code-graph bootstrap and untouched by a
+ * portal upgrade (separate containers + volumes) — so backing them up before
+ * every upgrade is wasted work and a source of spurious failures (observed
+ * 2026-06-14: a neo4j backup volume-mismatch blocked every self-upgrade). They
+ * are skipped by default. An operator who prefers a fast restore over a
+ * from-source rebuild can opt them in via DPF_RECOVERY_POINT_BACKUP_TARGETS
+ * (comma-separated); opted-in derived backups are best-effort — a failure
+ * degrades the recovery point but never blocks the upgrade.
+ */
+export function resolveRecoveryBackupTargets(
   env: Record<string, string | undefined> = process.env,
 ): Set<BackupTarget> {
-  const raw = env.DPF_RECOVERY_POINT_REQUIRED_TARGETS;
+  const targets = new Set<BackupTarget>([PRIMARY_BACKUP_TARGET]);
+  const raw = env.DPF_RECOVERY_POINT_BACKUP_TARGETS;
   if (raw && raw.trim()) {
-    const parsed = raw
-      .split(",")
-      .map((t) => t.trim())
-      .filter((t): t is BackupTarget => ALL_BACKUP_TARGETS.has(t as BackupTarget));
-    if (parsed.length > 0) return new Set(parsed);
+    for (const token of raw.split(",").map((t) => t.trim())) {
+      if (token === "neo4j" || token === "qdrant") targets.add(token);
+    }
   }
-  return new Set(DEFAULT_REQUIRED_RECOVERY_TARGETS);
+  return targets;
 }
 
 /**
@@ -152,7 +153,7 @@ export function resolveRequiredRecoveryTargets(
  */
 export function classifyRecoveryPointStatus(
   members: SelfUpgradeRecoveryPointMember[],
-  required: Set<BackupTarget> = resolveRequiredRecoveryTargets(),
+  required: Set<BackupTarget> = new Set([PRIMARY_BACKUP_TARGET]),
 ): SelfUpgradeRecoveryPointStatus {
   const requiredFailed = members.some(
     (member) => required.has(member.target) && member.status === "failed",
@@ -162,25 +163,46 @@ export function classifyRecoveryPointStatus(
   return anyFailed ? "degraded" : "ok";
 }
 
-async function resolveRecoveryPointRunners(
-  overrides?: Partial<RecoveryPointRunners>,
-): Promise<RecoveryPointRunners> {
-  const [postgres, neo4j, qdrant] = await Promise.all([
-    overrides?.postgres ??
-      import("@/lib/operate/backups/postgres-backup-runner").then(
-        (module) => module.runPostgresBackup,
-      ),
-    overrides?.neo4j ??
-      import("@/lib/operate/backups/neo4j-backup-runner").then(
-        (module) => module.runNeo4jBackup,
-      ),
-    overrides?.qdrant ??
-      import("@/lib/operate/backups/qdrant-backup-runner").then(
-        (module) => module.runQdrantBackup,
-      ),
-  ]);
-
-  return { postgres, neo4j, qdrant };
+/**
+ * Run the backup for a single target, lazily importing only the runner we
+ * actually need — so a skipped derived store never even pulls in its backup
+ * module. Test callers pass runner overrides to avoid spawning real backups.
+ */
+async function runBackupForTarget(
+  target: BackupTarget,
+  overrides: Partial<RecoveryPointRunners>,
+  args: CreateRecoveryPointArgs,
+): Promise<SelfUpgradeRecoveryPointMember> {
+  return runMember(target, async () => {
+    if (target === "postgres") {
+      const run =
+        overrides.postgres ??
+        (await import("@/lib/operate/backups/postgres-backup-runner"))
+          .runPostgresBackup;
+      return run({
+        trigger: RECOVERY_TRIGGER,
+        composeProject: args.composeProject,
+        backupsRoot: args.backupsRoot,
+      });
+    }
+    if (target === "neo4j") {
+      const run =
+        overrides.neo4j ??
+        (await import("@/lib/operate/backups/neo4j-backup-runner")).runNeo4jBackup;
+      return run({
+        trigger: RECOVERY_TRIGGER,
+        composeProject: args.composeProject,
+        backupsRoot: args.backupsRoot,
+      });
+    }
+    const run =
+      overrides.qdrant ??
+      (await import("@/lib/operate/backups/qdrant-backup-runner")).runQdrantBackup;
+    return run({
+      trigger: RECOVERY_TRIGGER,
+      backupsRoot: args.backupsRoot,
+    });
+  });
 }
 
 async function runMember(


### PR DESCRIPTION
Follow-up to #1923.

## Why
#1923 made neo4j/qdrant backups **non-blocking**, but they still **ran** on every upgrade — wasted work on regenerable data, and the failing neo4j backup still produced failure noise. Per operator feedback: *derived stores rebuilt from source shouldn't be backed up at all.*

## What
The pre-upgrade recovery point now backs up **only postgres** — the primary store (irreplaceable data) and the only store a portal upgrade migrates. **neo4j** (code + knowledge graph) and **qdrant** (vectors) are recorded as `skipped` members and their runners are **never invoked** (separate containers/volumes, rebuilt from source — untouched by an upgrade).

Operators who prefer a fast restore over a from-source rebuild can opt them back in via `DPF_RECOVERY_POINT_BACKUP_TARGETS=neo4j,qdrant` — opted-in derived backups are best-effort (failure degrades, never blocks).

## Tests
`recovery-point.test.ts` (7 pass): default → postgres backed up + neo4j/qdrant `skipped` (runners not called); postgres-fail → `failed`; opted-in neo4j-fail → `degraded`; classifier + target-resolution units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)