### PR TITLE
fix(skills): own skill-curator TaskRun via resolved superuser, not a "system" sentinel

### DIFF
--- a/apps/web/lib/queue/functions/governed-backlog-tee-up.ts
+++ b/apps/web/lib/queue/functions/governed-backlog-tee-up.ts
@@ -2,24 +2,6 @@ import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
 
-async function resolveScheduledUserId(): Promise<string> {
-  const { prisma } = await import("@dpf/db");
-  const user = await prisma.user.findFirst({
-    where: {
-      isSuperuser: true,
-      isActive: true,
-    },
-    orderBy: { createdAt: "asc" },
-    select: { id: true },
-  });
-
-  if (!user) {
-    throw new Error("No active superuser is available to own governed backlog drafts.");
-  }
-
-  return user.id;
-}
-
 export const governedBacklogTeeUpScheduled = inngest.createFunction(
   {
     id: "build/governed-backlog-tee-up-scheduled",
@@ -34,10 +16,11 @@ export const governedBacklogTeeUpScheduled = inngest.createFunction(
     return step.run("tee-up-governed-backlog-daily", async () => {
       const { prisma } = await import("@dpf/db");
       const { runGovernedBacklogTeeUp } = await import("@/lib/governed-backlog-tee-up");
+      const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
 
       return runGovernedBacklogTeeUp({
         prisma,
-        userId: await resolveScheduledUserId(),
+        userId: await resolveScheduledOwnerUserId(),
         trigger: "daily",
       });
     });

--- a/apps/web/lib/queue/functions/skill-curator.ts
+++ b/apps/web/lib/queue/functions/skill-curator.ts
@@ -11,6 +11,12 @@ import { gateAtEntry } from "../quiescence-gates";
  * The curator is idempotent end-to-end: classification is deterministic,
  * signal emission dedupes on (sourceType, sourceId), and a missed tick is
  * recovered automatically on the next run.
+ *
+ * Ownership: the proactive TaskRun the curator writes is owned by the
+ * bootstrap superuser (HR-000), resolved at run time via
+ * resolveScheduledOwnerUserId — the same principal every other proactive cron
+ * attributes to. It must never be a hardcoded "system" string: TaskRun.userId
+ * is a NOT NULL FK to User, so a sentinel id violates TaskRun_userId_fkey.
  */
 export const skillCurator = inngest.createFunction(
   {
@@ -25,7 +31,10 @@ export const skillCurator = inngest.createFunction(
 
     return step.run("run-skill-curator", async () => {
       const { runSkillCurator } = await import("@/lib/skills/curator");
-      const result = await runSkillCurator({ invokedByUserId: "system" });
+      const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
+      const result = await runSkillCurator({
+        invokedByUserId: await resolveScheduledOwnerUserId(),
+      });
       console.log(
         `[skill-curator] scanned ${result.findings.length} skills; totals=${JSON.stringify(result.totals)}`,
       );

--- a/apps/web/lib/queue/scheduled-owner.test.ts
+++ b/apps/web/lib/queue/scheduled-owner.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveScheduledOwnerUserId,
+  type ScheduledOwnerClient,
+} from "./scheduled-owner";
+
+function clientReturning(owner: { id: string } | null): ScheduledOwnerClient {
+  return { user: { findFirst: vi.fn(async () => owner) } };
+}
+
+describe("resolveScheduledOwnerUserId", () => {
+  it("returns the resolved superuser id", async () => {
+    const db = clientReturning({ id: "usr_admin" });
+    await expect(resolveScheduledOwnerUserId(db)).resolves.toBe("usr_admin");
+  });
+
+  it("resolves the oldest ACTIVE superuser (deterministic install owner)", async () => {
+    const findFirst = vi.fn(async () => ({ id: "usr_admin" }));
+    await resolveScheduledOwnerUserId({ user: { findFirst } });
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { isSuperuser: true, isActive: true },
+      orderBy: { createdAt: "asc" },
+      select: { id: true },
+    });
+  });
+
+  it("throws rather than fall back to a sentinel when no owner exists", async () => {
+    // Guards the regression this helper was built for: a hardcoded
+    // userId:"system" silently violated TaskRun_userId_fkey. A missing owner
+    // must fail loudly, never resolve to a non-existent principal.
+    const db = clientReturning(null);
+    await expect(resolveScheduledOwnerUserId(db)).rejects.toThrow(/superuser/i);
+  });
+});

--- a/apps/web/lib/queue/scheduled-owner.ts
+++ b/apps/web/lib/queue/scheduled-owner.ts
@@ -1,0 +1,49 @@
+/**
+ * Resolve the User principal that OWNS scheduled / proactive platform work.
+ *
+ * Proactive crons (the skill curator, governed backlog tee-up, …) are not run
+ * by any human in the moment, but every `TaskRun` they create must still be
+ * owned by a real `User` — `TaskRun.userId` is a NOT NULL FK to `User`. The
+ * platform convention, verified against live `TaskRun` rows, is to attribute
+ * that ownership to the bootstrap superuser (HR-000), the same principal that
+ * owns the install. The non-human *executor* of the work is carried separately
+ * on `TaskRun.initiatingAgentId` / `currentAgentId` when a specific AI coworker
+ * (an `Agent` identity) drives it — the skill curator is a governance cron
+ * owned by the human supervisor, so it sets only the owner.
+ *
+ * There is NO sentinel "system" user: a literal `userId: "system"` has no
+ * matching `User` row and fails the FK (`TaskRun_userId_fkey`, P2003). Always
+ * resolve a real owner through this helper instead of hardcoding a string.
+ */
+export type ScheduledOwnerClient = {
+  user: {
+    findFirst: (args: unknown) => Promise<{ id: string } | null>;
+  };
+};
+
+export async function resolveScheduledOwnerUserId(
+  db?: ScheduledOwnerClient,
+): Promise<string> {
+  // Dynamic import (not a top-level one) keeps @dpf/db out of the inngest
+  // function-registration module graph and mirrors how the callers already
+  // load prisma inside their step closures. Tests inject `db` and never reach
+  // this branch, so they stay hermetic.
+  const client =
+    db ?? ((await import("@dpf/db")).prisma as unknown as ScheduledOwnerClient);
+
+  const owner = await client.user.findFirst({
+    where: { isSuperuser: true, isActive: true },
+    // Oldest active superuser = the bootstrap install owner. Deterministic so
+    // every proactive job attributes to the same principal across runs.
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+
+  if (!owner) {
+    throw new Error(
+      "No active superuser is available to own scheduled platform work.",
+    );
+  }
+
+  return owner.id;
+}

--- a/apps/web/lib/skills/curator.test.ts
+++ b/apps/web/lib/skills/curator.test.ts
@@ -108,7 +108,7 @@ describe("runSkillCurator — happy path", () => {
       createdAt: new Date("2026-05-01"),
     });
 
-    const report = await runSkillCurator({ invokedByUserId: "system" });
+    const report = await runSkillCurator({ invokedByUserId: "usr_owner" });
 
     // The stale skill produced a finding and a signal.
     expect(report.findings.find((f) => f.skillId === "stale-skill")?.toState).toBe("stale");
@@ -121,6 +121,13 @@ describe("runSkillCurator — happy path", () => {
     expect(
       (state.artifactsCreated[0]?.metadata as { kind?: string })?.kind,
     ).toBe(CURATOR_REPORT_KIND);
+
+    // The proactive TaskRun is owned by the resolved principal that was passed
+    // in — NOT a "system" sentinel. Regression guard for the FK violation
+    // (TaskRun_userId_fkey) caused by hardcoding a non-existent user id.
+    expect(state.taskRunsCreated).toHaveLength(1);
+    expect(state.taskRunsCreated[0]?.userId).toBe("usr_owner");
+    expect(state.taskRunsCreated[0]?.userId).not.toBe("system");
   });
 });
 
@@ -136,7 +143,7 @@ describe("runSkillCurator — pin protection invariant", () => {
     // would otherwise be a candidate to archive — but pin protection
     // overrides everything.
 
-    const report = await runSkillCurator({ invokedByUserId: "system" });
+    const report = await runSkillCurator({ invokedByUserId: "usr_owner" });
 
     // No skill update was made for the pinned skill.
     expect(state.skillUpdates).toHaveLength(0);
@@ -168,7 +175,7 @@ describe("runSkillCurator — pin protection invariant", () => {
       createdAt: new Date("2026-05-01"),
     });
 
-    const report = await runSkillCurator({ invokedByUserId: "system" });
+    const report = await runSkillCurator({ invokedByUserId: "usr_owner" });
     expect(state.skillUpdates).toHaveLength(0);
     expect(report.findings.find((f) => f.skillId === "q-skill")?.toState).toBe(
       "quarantined",
@@ -180,7 +187,7 @@ describe("runSkillCurator — no skillMdContent mutation", () => {
   it("only writes lifecycleState in any skill update", async () => {
     addSkill({ skillId: "stale-skill" });
 
-    await runSkillCurator({ invokedByUserId: "system" });
+    await runSkillCurator({ invokedByUserId: "usr_owner" });
 
     // The curator may or may not produce an update on any given skill,
     // but every update it DOES produce must touch only lifecycleState.
@@ -196,7 +203,7 @@ describe("runSkillCurator — dedupe", () => {
   it("re-running the curator over the same population produces the same signal sourceIds", async () => {
     addSkill({ skillId: "stale-skill" });
 
-    await runSkillCurator({ invokedByUserId: "system" });
+    await runSkillCurator({ invokedByUserId: "usr_owner" });
     const firstIds = state.signalsTouched.map((s) => s.sourceId);
 
     state.signalsTouched.length = 0;
@@ -204,7 +211,7 @@ describe("runSkillCurator — dedupe", () => {
     state.artifactsCreated.length = 0;
     state.taskRunsCreated.length = 0;
 
-    await runSkillCurator({ invokedByUserId: "system" });
+    await runSkillCurator({ invokedByUserId: "usr_owner" });
     const secondIds = state.signalsTouched.map((s) => s.sourceId);
 
     expect(secondIds).toEqual(firstIds);
@@ -217,7 +224,7 @@ describe("runSkillCurator — dedupe", () => {
 
 describe("runSkillCurator — empty population", () => {
   it("still writes a TaskRun + TaskArtifact with zero findings when no skills exist", async () => {
-    const report = await runSkillCurator({ invokedByUserId: "system" });
+    const report = await runSkillCurator({ invokedByUserId: "usr_owner" });
     expect(report.findings).toEqual([]);
     expect(state.taskRunsCreated).toHaveLength(1);
     expect(state.artifactsCreated).toHaveLength(1);

--- a/apps/web/lib/skills/curator.ts
+++ b/apps/web/lib/skills/curator.ts
@@ -46,7 +46,12 @@ export type CuratorReport = {
 };
 
 export type RunSkillCuratorInput = {
-  /** Reviewer or system user attributed for the proactive TaskRun. */
+  /**
+   * Real `User.id` that OWNS the proactive TaskRun this run writes. Must be a
+   * resolved principal (the scheduled cron passes the bootstrap superuser via
+   * resolveScheduledOwnerUserId) — never a sentinel like "system", which has no
+   * `User` row and violates `TaskRun_userId_fkey`.
+   */
   invokedByUserId: string;
   /** Optional override for "now" — used in tests. */
   now?: Date;


### PR DESCRIPTION
## Problem

The `skills/curator` daily cron created its proactive `TaskRun` with `userId: "system"`, but no `User` with that id exists and `TaskRun.userId` is a `NOT NULL` FK (`TaskRun_userId_fkey`). Every run threw Prisma **P2003** — flooding the portal logs and failing the inngest function *after* its work (lifecycle updates + signals) was already done.

This was the dominant **real** error in the docker logs.

## Root cause

The curator bypassed the platform's established attribution pattern. Verified against the live install:

- 81 active AI coworker (`Agent`) identities exist and are assigned.
- All 60 existing `TaskRun` rows are owned by the bootstrap superuser (`admin@dpf.local` / HR-000) and carry the non-human executor on `initiatingAgentId` / `currentAgentId` (e.g. `inventory-specialist` ×10, `external-catalog-scout` ×9).
- The curator was the **only** job hardcoding `userId:"system"` (a principal that doesn't exist), with the agent columns left null.

The canonical resolver already existed privately in `governed-backlog-tee-up.ts`.

## Fix

- **New** `apps/web/lib/queue/scheduled-owner.ts` → `resolveScheduledOwnerUserId()`: resolves the oldest active superuser (the install owner). Throws if none — never falls back to a sentinel.
- `skill-curator` and `governed-backlog-tee-up` both route through it (the private copy is removed — DRY).
- `curator.ts`: tightened the `invokedByUserId` contract doc.

The curator is a governance cron owned by the human supervisor (its plan doc: *"let humans act"*), so it sets only the owner — consistent with `governed-backlog-tee-up`. Coworker (`Agent`) attribution is reserved for jobs that are a specific coworker's autonomous work.

## Verification

- `scheduled-owner.test.ts` (new) + `curator.test.ts` regression assert (TaskRun owner is the resolved principal, never `"system"`).
- **9 targeted + 212 `lib/queue`/`lib/skills` tests pass**; changed files typecheck clean.
- The live resolver query returns the superuser, so the `TaskRun` create will succeed once deployed.

> Takes effect on the live install after a portal rebuild/redeploy (operator-gated).

## Not in this PR

The other docker-log errors are separate: stale infra (`loki`/`alloy` containers not up), a false-positive `redis-exporter` healthcheck (`wget` missing from the distroless image), and config gaps (no xAI credential; local `gemma4:26B` eval timeouts). A latent `actorUserId ?? "system"` ship-dispatch fallback in `build-review-verification.ts:198` (only fires when a build has null `createdById`) shares the conceptual root cause but is a different subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
