### PR TITLE
fix(build-studio): resolve auto-ship actor via install owner, not a "system" sentinel

### DIFF
--- a/apps/web/lib/queue/functions/build-review-verification.test.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory state to exercise the auto-ship actor resolution without a live DB.
+// Mirrors the skill-curator regression test (curator.test.ts): mock @dpf/db,
+// capture the downstream write's principal, and assert it is the resolved owner
+// and NEVER a "system" sentinel.
+
+const state = vi.hoisted(() => ({
+  build: null as { createdById: string | null } | null,
+  dispatchCalls: [] as Array<{
+    buildId: string;
+    userId: string;
+    verificationStatus: string;
+  }>,
+  ownerResolveCount: 0,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    featureBuild: {
+      findUnique: vi.fn(async () => state.build),
+    },
+  },
+}));
+
+vi.mock("../scheduled-owner", () => ({
+  resolveScheduledOwnerUserId: vi.fn(async () => {
+    state.ownerResolveCount++;
+    return "usr_owner";
+  }),
+}));
+
+vi.mock("@/lib/integrate/ship-on-review-approval", () => ({
+  dispatchShipForVerifiedBuild: vi.fn(
+    async (params: { buildId: string; userId: string; verificationStatus: string }) => {
+      state.dispatchCalls.push(params);
+      return { kind: "dispatched-success", durationMs: 1 };
+    },
+  ),
+}));
+
+import { autoDispatchShipForCompletedVerification } from "./build-review-verification";
+
+beforeEach(() => {
+  state.build = null;
+  state.dispatchCalls.length = 0;
+  state.ownerResolveCount = 0;
+});
+
+describe("autoDispatchShipForCompletedVerification — actor resolution", () => {
+  it("uses the build creator as the ship actor when createdById is set", async () => {
+    state.build = { createdById: "usr_creator" };
+
+    await autoDispatchShipForCompletedVerification("build-1");
+
+    expect(state.dispatchCalls).toHaveLength(1);
+    expect(state.dispatchCalls[0]?.userId).toBe("usr_creator");
+    expect(state.dispatchCalls[0]?.verificationStatus).toBe("complete");
+    // When the creator is known there is no need to resolve the install owner.
+    expect(state.ownerResolveCount).toBe(0);
+  });
+
+  it("resolves the install owner (never a 'system' sentinel) when createdById is null", async () => {
+    // Regression guard for the latent FK violation: a null createdById used to
+    // fall back to userId:"system", which has no matching User row and fails
+    // TaskRun_userId_fkey (Prisma P2003) downstream via
+    // dispatchShipForVerifiedBuild -> executeTool(deploy_feature). Same bug
+    // fixed for the skill curator in PR #1925.
+    state.build = { createdById: null };
+
+    await autoDispatchShipForCompletedVerification("build-2");
+
+    expect(state.dispatchCalls).toHaveLength(1);
+    expect(state.dispatchCalls[0]?.userId).toBe("usr_owner");
+    expect(state.dispatchCalls[0]?.userId).not.toBe("system");
+    expect(state.ownerResolveCount).toBe(1);
+  });
+
+  it("resolves the install owner when the build row is missing entirely", async () => {
+    // findUnique returning null is the same hazard as a null createdById:
+    // it must still resolve a real principal, not the sentinel.
+    state.build = null;
+
+    await autoDispatchShipForCompletedVerification("build-3");
+
+    expect(state.dispatchCalls).toHaveLength(1);
+    expect(state.dispatchCalls[0]?.userId).toBe("usr_owner");
+    expect(state.dispatchCalls[0]?.userId).not.toBe("system");
+  });
+
+  it("propagates the resolver error rather than shipping under a bogus actor", async () => {
+    // If no active superuser exists, resolveScheduledOwnerUserId throws. The
+    // dispatch must NOT proceed with a fabricated principal — fail loudly.
+    const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
+    vi.mocked(resolveScheduledOwnerUserId).mockRejectedValueOnce(
+      new Error("No active superuser is available to own scheduled platform work."),
+    );
+    state.build = { createdById: null };
+
+    await expect(
+      autoDispatchShipForCompletedVerification("build-4"),
+    ).rejects.toThrow(/superuser/i);
+    expect(state.dispatchCalls).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/queue/functions/build-review-verification.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.ts
@@ -189,23 +189,44 @@ export const buildReviewVerification = inngest.createFunction(
     // finalStatus is "complete" | "failed" here (skipped was handled above).
     // Treat "complete" as the passing signal for auto-ship dispatch.
     if (finalStatus === "complete") {
-      await step.run("auto-dispatch-ship", async () => {
-        const { prisma: db } = await import("@dpf/db");
-        const b = await db.featureBuild.findUnique({
-          where: { buildId },
-          select: { createdById: true },
-        });
-        const actorUserId = b?.createdById ?? "system";
-        const { dispatchShipForVerifiedBuild } = await import("@/lib/integrate/ship-on-review-approval");
-        const outcome = await dispatchShipForVerifiedBuild({
-          buildId,
-          userId: actorUserId,
-          verificationStatus: "complete",
-        });
-        return { shipOutcome: outcome.kind };
-      });
+      await step.run("auto-dispatch-ship", () =>
+        autoDispatchShipForCompletedVerification(buildId),
+      );
     }
 
     return { status: finalStatus, passed: steps.filter((s) => s.passed).length, total: steps.length };
   },
 );
+
+/**
+ * Auto-dispatch the ship phase for a build whose review verification just
+ * completed. Extracted from the inngest `step.run` closure so the actor
+ * resolution is unit-testable.
+ *
+ * The resolved actor flows into `dispatchShipForVerifiedBuild` ->
+ * `executeTool("deploy_feature")` and ultimately `TaskRun.userId`, a NOT NULL
+ * FK to `User` (`TaskRun_userId_fkey`). When the build has no `createdById` the
+ * actor MUST resolve to the real install owner via `resolveScheduledOwnerUserId`
+ * — NEVER a `"system"` sentinel. There is no `User` row with id `"system"`, so
+ * the downstream write fails the FK with Prisma P2003. This is the same latent
+ * bug fixed for the skill curator in PR #1925; it only surfaces here when a
+ * `FeatureBuild` has a null `createdById`, so it never appears in normal flows.
+ */
+export async function autoDispatchShipForCompletedVerification(
+  buildId: string,
+): Promise<{ shipOutcome: string }> {
+  const { prisma: db } = await import("@dpf/db");
+  const b = await db.featureBuild.findUnique({
+    where: { buildId },
+    select: { createdById: true },
+  });
+  const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
+  const actorUserId = b?.createdById ?? (await resolveScheduledOwnerUserId());
+  const { dispatchShipForVerifiedBuild } = await import("@/lib/integrate/ship-on-review-approval");
+  const outcome = await dispatchShipForVerifiedBuild({
+    buildId,
+    userId: actorUserId,
+    verificationStatus: "complete",
+  });
+  return { shipOutcome: outcome.kind };
+}


### PR DESCRIPTION
## Problem

`build-review-verification`'s `auto-dispatch-ship` step resolved the ship actor as:

```ts
const actorUserId = b?.createdById ?? "system";
```

That actor is passed as the principal for the governed `deploy_feature` tool execution (`dispatchShipForVerifiedBuild` → `executeTool("deploy_feature", …, actorUserId)`), whose downstream writes include `TaskRun.userId` — a **NOT NULL FK to `User`** (`TaskRun_userId_fkey`). There is no `User` row with id `"system"`, so when a `FeatureBuild` has a null `createdById` the write throws Prisma **P2003**.

It's latent — `createdById` is almost always set, so it never surfaces in normal flows — but it is exactly the class of bug fixed for the skill curator in #1925.

## Fix

- Replace the `"system"` fallback with `resolveScheduledOwnerUserId()` — the shared helper added in #1925 that resolves the oldest active superuser / install owner and **throws if none** (never falls back to a sentinel).
- Extract the step body into a testable `autoDispatchShipForCompletedVerification()`, mirroring the curator's worker-fn + thin-inngest-wrapper split.

## Audit of other `userId: "system"` / `?? "system"` sites

Swept every occurrence that could feed a User-FK DB write. This was the only FK risk; the rest are safe:

| Site | Verdict |
|---|---|
| `ToolExecution.userId` (`dpf-native-agent-runner.ts:213`) | bare `String`, no `@relation` → not a User FK |
| `SandboxSlot.userId` (`build-pipeline.ts:270`) | nullable bare `String`, no `@relation` → not a User FK |
| `runAgenticLoop({ userId })` (`build-pipeline.ts:435`) | creates no `TaskRun`; only writes `ToolExecution.userId` (non-FK) |
| `build-pipeline.ts:400` | in-memory tool-filter context, never persisted |
| `buildAutoDiscoveryEvalEvents` default (`ai-provider-internals.ts:122`) | eval path never persists `userId` |
| `savedByUserId: "system"` (×2) | `BuildArtifactRevision.savedByUserId` is a non-referential `String` |

## Tests

- New regression test `build-review-verification.test.ts`, mirroring the curator one: a null `createdById` resolves to the real owner (never `"system"`); a missing build row still resolves a real principal; and a missing owner **fails loudly** rather than shipping under a bogus actor.
- `lib/queue/` vitest slice green: **16 files / 149 tests** (confirms the new `@dpf/db`-mocking test coexists cleanly in the forks pool — no mock bleed).
- `tsc --noEmit` clean for the changed files (only pre-existing unbuilt-workspace noise remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
