### PR TITLE
feat(observability): EP-FULL-OBS Tier 2 item #6 — alert-delivery bridge (Prometheus + Loki ruler -> PortfolioQualityIssue)

### DIFF
--- a/apps/web/app/api/platform/alerts/route.ts
+++ b/apps/web/app/api/platform/alerts/route.ts
@@ -1,8 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@dpf/db";
+import {
+  upsertHealthAlertIssue,
+  resolveHealthAlertIssue,
+  healthAlertIssueKey,
+} from "@/lib/observability/health-alert-issue";
 
-// Grafana webhook alert receiver.
-// Creates/resolves PortfolioQualityIssue records from Prometheus alerts.
+// Grafana / Alertmanager webhook alert receiver.
+// Creates/resolves PortfolioQualityIssue records from pushed alerts. Shares the
+// writer (lib/observability/health-alert-issue) with the alert-delivery-bridge
+// poll path so push and poll produce identical rows. Note: there is no
+// Alertmanager in the default stack today, so the active delivery path is the
+// poll bridge — this endpoint remains a valid receiver if one is ever added.
 
 type GrafanaAlert = {
   labels: Record<string, string>;
@@ -29,46 +38,18 @@ export async function POST(req: NextRequest) {
 
   const alerts = body.alerts ?? [];
 
+  // `prisma as never` at the db-handle boundary matches the established pattern
+  // for passing the full client to a narrow injectable handle (see
+  // discovery-runner.ts); the writer body stays type-checked against HealthAlertDb.
   for (const alert of alerts) {
-    const alertName = alert.labels?.alertname ?? "unknown";
-    const issueKey = `health-alert-${alertName}`;
-    const severity = alert.labels?.severity === "critical" ? "error" : "warn";
-    const summary = alert.annotations?.summary ?? alertName;
-    const description = alert.annotations?.description ?? "";
-
     if (alert.status === "firing") {
-      // Upsert: create if new, update lastDetectedAt if existing
-      await prisma.portfolioQualityIssue.upsert({
-        where: { issueKey },
-        create: {
-          issueKey,
-          issueType: "health_alert",
-          severity,
-          summary,
-          details: { alertName, description, labels: alert.labels },
-          status: "open",
-          firstDetectedAt: alert.startsAt ? new Date(alert.startsAt) : new Date(),
-          lastDetectedAt: new Date(),
-        },
-        update: {
-          severity,
-          summary,
-          details: { alertName, description, labels: alert.labels },
-          status: "open",
-          lastDetectedAt: new Date(),
-          resolvedAt: null,
-        },
+      await upsertHealthAlertIssue(prisma as never, {
+        labels: alert.labels ?? {},
+        annotations: alert.annotations ?? {},
+        startsAt: alert.startsAt,
       });
     } else if (alert.status === "resolved") {
-      // Auto-resolve
-      await prisma.portfolioQualityIssue.updateMany({
-        where: { issueKey, status: "open" },
-        data: {
-          status: "resolved",
-          resolvedAt: new Date(),
-          lastDetectedAt: new Date(),
-        },
-      });
+      await resolveHealthAlertIssue(prisma as never, healthAlertIssueKey(alert.labels ?? {}));
     }
   }
 

--- a/apps/web/app/api/platform/metrics/alerts/route.ts
+++ b/apps/web/app/api/platform/metrics/alerts/route.ts
@@ -1,24 +1,36 @@
 import { NextResponse } from "next/server";
+import { fetchAlertSources } from "@/lib/observability/alert-sources";
 
 export const dynamic = "force-dynamic";
 
-const PROMETHEUS_URL = process.env.PROMETHEUS_URL || "http://prometheus:9090";
 const NO_CACHE_HEADERS = {
   "Cache-Control": "no-cache, no-store, must-revalidate",
   "Pragma": "no-cache",
 };
 
+// Unified firing-alerts endpoint for the System Health UI (AlertBanner,
+// PlatformHealthIndicator shell-nav dot, RecentAlertsPanel — all via
+// useAlertQuery). Merges BOTH evaluators: Prometheus metric alerts AND the Loki
+// ruler's log-rate/storm alerts (EP-FULL-OBS Tier 2, BI-5FE8656F item #6). This
+// is what flips the shell-nav health dot on a container log storm — previously
+// the dot only saw Prometheus and was blind to log-rate alerts.
+//
+// Resilient: one source being down never blanks the other. Only when BOTH are
+// unreachable do we report the monitoring stack offline (503), matching the
+// frontend's offline handling.
+
 export async function GET() {
-  try {
-    const res = await fetch(`${PROMETHEUS_URL}/api/v1/alerts`, {
-      signal: AbortSignal.timeout(2_000),
-    });
-    const data = await res.json();
-    return NextResponse.json(data, { headers: NO_CACHE_HEADERS });
-  } catch {
+  const { alerts, reached } = await fetchAlertSources();
+
+  if (!reached.prometheus && !reached["loki-ruler"]) {
     return NextResponse.json(
       { status: "error", error: "Monitoring stack unreachable", data: { alerts: [] } },
       { status: 503, headers: NO_CACHE_HEADERS },
     );
   }
+
+  return NextResponse.json(
+    { status: "success", data: { alerts } },
+    { headers: NO_CACHE_HEADERS },
+  );
 }

--- a/apps/web/lib/observability/alert-sources.test.ts
+++ b/apps/web/lib/observability/alert-sources.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchAlertSources } from "./alert-sources";
+
+function okResp(alerts: unknown[]) {
+  return { ok: true, json: async () => ({ status: "success", data: { alerts } }) } as unknown as Response;
+}
+function badStatusResp() {
+  return { ok: true, json: async () => ({ status: "error", data: { alerts: [] } }) } as unknown as Response;
+}
+function httpErrResp() {
+  return { ok: false, json: async () => ({}) } as unknown as Response;
+}
+
+const promAlert = { labels: { alertname: "PostgresDown", severity: "critical" }, annotations: { summary: "pg down" }, state: "firing", activeAt: "2026-06-15T00:00:00Z" };
+const lokiAlert = { labels: { alertname: "ContainerErrorLogSpike", service: "sandbox", severity: "warning", source: "log-rate" }, annotations: { summary: "sandbox spike" }, state: "pending", value: "140" };
+
+function routedFetch(promImpl: () => Response, lokiImpl: () => Response) {
+  return vi.fn(async (url: string) => (url.includes("3100") || url.includes("loki") ? lokiImpl() : promImpl()));
+}
+
+describe("fetchAlertSources", () => {
+  it("merges Prometheus + Loki ruler alerts, tagging sourceSystem", async () => {
+    const fetchImpl = routedFetch(() => okResp([promAlert]), () => okResp([lokiAlert]));
+    const res = await fetchAlertSources({ fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(res.reached).toEqual({ prometheus: true, "loki-ruler": true });
+    expect(res.alerts).toHaveLength(2);
+    const byName = Object.fromEntries(res.alerts.map((a) => [a.labels.alertname, a]));
+    expect(byName.PostgresDown.sourceSystem).toBe("prometheus");
+    expect(byName.ContainerErrorLogSpike.sourceSystem).toBe("loki-ruler");
+    // preserves state + value for downstream filtering
+    expect(byName.ContainerErrorLogSpike.state).toBe("pending");
+    expect(byName.ContainerErrorLogSpike.value).toBe("140");
+  });
+
+  it("keeps the other source when one is unreachable (no cross-suppression)", async () => {
+    const fetchImpl = routedFetch(
+      () => { throw new Error("ECONNREFUSED"); },
+      () => okResp([lokiAlert]),
+    );
+    const res = await fetchAlertSources({ fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(res.reached.prometheus).toBe(false);
+    expect(res.reached["loki-ruler"]).toBe(true);
+    expect(res.alerts).toHaveLength(1);
+    expect(res.alerts[0].sourceSystem).toBe("loki-ruler");
+  });
+
+  it("marks a source unreached on HTTP error or non-success body", async () => {
+    const res1 = await fetchAlertSources({
+      fetchImpl: routedFetch(() => httpErrResp(), () => okResp([lokiAlert])) as unknown as typeof fetch,
+    });
+    expect(res1.reached.prometheus).toBe(false);
+
+    const res2 = await fetchAlertSources({
+      fetchImpl: routedFetch(() => okResp([promAlert]), () => badStatusResp()) as unknown as typeof fetch,
+    });
+    expect(res2.reached["loki-ruler"]).toBe(false);
+    expect(res2.alerts).toHaveLength(1);
+  });
+
+  it("reports both unreached when both fail", async () => {
+    const res = await fetchAlertSources({
+      fetchImpl: routedFetch(() => { throw new Error("x"); }, () => { throw new Error("y"); }) as unknown as typeof fetch,
+    });
+    expect(res.reached).toEqual({ prometheus: false, "loki-ruler": false });
+    expect(res.alerts).toEqual([]);
+  });
+});

--- a/apps/web/lib/observability/alert-sources.ts
+++ b/apps/web/lib/observability/alert-sources.ts
@@ -1,0 +1,114 @@
+// EP-FULL-OBS Tier 2 (BI-5FE8656F item #6) — unified firing-alert source.
+//
+// The platform runs TWO alert evaluators that each expose a Prometheus-shaped
+// alerts API but neither pushes anywhere (there is no Alertmanager, by design —
+// "minimize entirely new processes"):
+//
+//   - Prometheus    GET  {PROMETHEUS_URL}/api/v1/alerts            (metric rules)
+//   - Loki ruler    GET  {LOKI_URL}/prometheus/api/v1/alerts       (log-rate rules)
+//
+// This helper reads BOTH and returns one normalized list plus per-source
+// reachability. It is the single source consumed by:
+//   - the live display endpoint  (/api/platform/metrics/alerts)  → health dot
+//   - the persistence cron        (alert-delivery-bridge)         → PortfolioQualityIssue
+//
+// Reading aggregated alert state (not raw log lines) is what makes the whole
+// path storm-proof: a container flooding 10k lines/sec still produces exactly
+// ONE ContainerErrorLogStorm alert here, never a per-line flood.
+
+const PROMETHEUS_URL = process.env.PROMETHEUS_URL || "http://prometheus:9090";
+const LOKI_URL = process.env.LOKI_URL || "http://loki:3100";
+const DEFAULT_TIMEOUT_MS = 4_000;
+
+export type AlertSourceSystem = "prometheus" | "loki-ruler";
+
+/**
+ * Prometheus-compatible alert shape, shared by both evaluators. Structurally a
+ * superset of the frontend's MonitoringAlert (health-summary.ts), so the
+ * display route can hand these straight to the client — the extra
+ * `sourceSystem`/`value` fields are ignored there and used by the cron for
+ * source-attributed reconciliation.
+ */
+export interface PlatformAlert {
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  state: "firing" | "pending" | "inactive" | string;
+  activeAt?: string;
+  value?: string;
+  /** Which evaluator surfaced this alert — drives reconciliation ownership. */
+  sourceSystem: AlertSourceSystem;
+}
+
+export interface AlertSourcesResult {
+  alerts: PlatformAlert[];
+  /** True iff the source responded this cycle. False = unreachable; its alerts
+   *  are absent from `alerts` and the caller MUST NOT treat that as "resolved". */
+  reached: Record<AlertSourceSystem, boolean>;
+}
+
+export interface FetchAlertSourcesOptions {
+  prometheusUrl?: string;
+  lokiUrl?: string;
+  timeoutMs?: number;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+interface RawPromAlert {
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  state?: string;
+  activeAt?: string;
+  value?: string;
+}
+
+async function fetchOneSource(
+  url: string,
+  sourceSystem: AlertSourceSystem,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<{ alerts: PlatformAlert[]; reached: boolean }> {
+  try {
+    const res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return { alerts: [], reached: false };
+    const json = (await res.json()) as { status?: string; data?: { alerts?: RawPromAlert[] } };
+    if (json.status && json.status !== "success") return { alerts: [], reached: false };
+    const alerts: PlatformAlert[] = (json.data?.alerts ?? []).map((a) => ({
+      labels: a.labels ?? {},
+      annotations: a.annotations ?? {},
+      state: a.state ?? "firing",
+      activeAt: a.activeAt,
+      value: a.value,
+      sourceSystem,
+    }));
+    return { alerts, reached: true };
+  } catch {
+    // Timeout / connection refused / bad JSON — source unreachable this cycle.
+    return { alerts: [], reached: false };
+  }
+}
+
+/**
+ * Read firing/pending alerts from Prometheus and the Loki ruler in parallel.
+ * Each source is independent: one being down never suppresses the other, and a
+ * down source is reported via `reached` so callers don't false-resolve its
+ * issues.
+ */
+export async function fetchAlertSources(
+  opts: FetchAlertSourcesOptions = {},
+): Promise<AlertSourcesResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const promUrl = `${opts.prometheusUrl ?? PROMETHEUS_URL}/api/v1/alerts`;
+  const lokiUrl = `${opts.lokiUrl ?? LOKI_URL}/prometheus/api/v1/alerts`;
+
+  const [prom, loki] = await Promise.all([
+    fetchOneSource(promUrl, "prometheus", fetchImpl, timeoutMs),
+    fetchOneSource(lokiUrl, "loki-ruler", fetchImpl, timeoutMs),
+  ]);
+
+  return {
+    alerts: [...prom.alerts, ...loki.alerts],
+    reached: { prometheus: prom.reached, "loki-ruler": loki.reached },
+  };
+}

--- a/apps/web/lib/observability/health-alert-issue.test.ts
+++ b/apps/web/lib/observability/health-alert-issue.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  healthAlertIssueKey,
+  upsertHealthAlertIssue,
+  resolveHealthAlertIssue,
+  type HealthAlertDb,
+} from "./health-alert-issue";
+
+function mockDb() {
+  // Bare vi.fn() so recorded call args type as `any` (a typed-impl mock would
+  // infer an empty arg tuple and break .mock.calls[0][0] indexing).
+  const upsert = vi.fn().mockResolvedValue({});
+  const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+  const db = { portfolioQualityIssue: { upsert, updateMany } } as unknown as HealthAlertDb;
+  return { db, upsert, updateMany };
+}
+
+describe("healthAlertIssueKey", () => {
+  it("scopes by service so two services firing the same alert are distinct", () => {
+    expect(healthAlertIssueKey({ alertname: "ContainerErrorLogSpike", service: "sandbox" }))
+      .toBe("health-alert-ContainerErrorLogSpike:sandbox");
+    expect(healthAlertIssueKey({ alertname: "ContainerErrorLogSpike", service: "portal" }))
+      .toBe("health-alert-ContainerErrorLogSpike:portal");
+  });
+
+  it("falls back instance -> job -> bare alertname", () => {
+    expect(healthAlertIssueKey({ alertname: "X", instance: "sandbox:3000" })).toBe("health-alert-X:sandbox:3000");
+    expect(healthAlertIssueKey({ alertname: "X", job: "qdrant" })).toBe("health-alert-X:qdrant");
+    expect(healthAlertIssueKey({ alertname: "PostgresDown" })).toBe("health-alert-PostgresDown");
+  });
+});
+
+describe("upsertHealthAlertIssue", () => {
+  it("opens a health_alert issue, maps critical->error, attributes source, returns the key", async () => {
+    const { db, upsert } = mockDb();
+    const key = await upsertHealthAlertIssue(db, {
+      labels: { alertname: "ContainerErrorLogStorm", service: "sandbox", severity: "critical" },
+      annotations: { summary: "storm", description: "flooding" },
+      activeAt: "2026-06-15T02:00:00Z",
+      sourceSystem: "loki-ruler",
+    });
+
+    expect(key).toBe("health-alert-ContainerErrorLogStorm:sandbox");
+    const arg = upsert.mock.calls[0][0];
+    expect(arg.where.issueKey).toBe(key);
+    expect(arg.create.issueType).toBe("health_alert");
+    expect(arg.create.severity).toBe("error"); // critical -> error
+    expect((arg.create.details as { source: string }).source).toBe("loki-ruler");
+    expect(arg.update.resolvedAt).toBeNull(); // re-open semantics on refresh
+  });
+
+  it("maps non-critical severity to warn and defaults source to webhook", async () => {
+    const { db, upsert } = mockDb();
+    await upsertHealthAlertIssue(db, {
+      labels: { alertname: "ContainerErrorLogSpike", service: "portal", severity: "warning" },
+    });
+    const arg = upsert.mock.calls[0][0];
+    expect(arg.create.severity).toBe("warn");
+    expect((arg.create.details as { source: string }).source).toBe("webhook");
+  });
+});
+
+describe("resolveHealthAlertIssue", () => {
+  it("flips only the open row for the key to resolved", async () => {
+    const { db, updateMany } = mockDb();
+    await resolveHealthAlertIssue(db, "health-alert-PostgresDown");
+    const arg = updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ issueKey: "health-alert-PostgresDown", status: "open" });
+    expect(arg.data.status).toBe("resolved");
+    expect(arg.data.resolvedAt).toBeInstanceOf(Date);
+  });
+});

--- a/apps/web/lib/observability/health-alert-issue.ts
+++ b/apps/web/lib/observability/health-alert-issue.ts
@@ -1,0 +1,122 @@
+// EP-FULL-OBS Tier 2 (BI-5FE8656F item #6) — shared health-alert issue writer.
+//
+// Turns a firing Prometheus/Loki alert into a PortfolioQualityIssue row in the
+// operator's existing inbox. Extracted from /api/platform/alerts (the Grafana
+// webhook receiver) so the SAME writer serves both delivery paths:
+//   - push  — the webhook route, if an Alertmanager/Grafana ever POSTs
+//   - poll  — alert-delivery-bridge cron (the active path today; no Alertmanager)
+//
+// Why not reuse packages/db's openOrUpdateQualityIssue: that canonical writer
+// owns the discovery->portfolio quality family — a CLOSED QualityIssueType set
+// (none of them health_alert) keyed by a REQUIRED inventory/taxonomy/portfolio
+// FK scope (it throws without one). Health alerts have no such FK; they are
+// keyed by alertname+service. Same table, deliberately different family — so
+// this is a focused sibling writer, not a duplicate.
+
+export type HealthAlertSeverity = "info" | "warn" | "error";
+
+/** Normalized alert input shared by the push (webhook) and poll (cron) paths. */
+export interface IncomingHealthAlert {
+  labels: Record<string, string>;
+  annotations?: Record<string, string>;
+  /** Grafana/Alertmanager push provides startsAt; the poll path has activeAt. */
+  startsAt?: string;
+  activeAt?: string;
+  /** "prometheus" | "loki-ruler" for the poll path; undefined → "webhook". */
+  sourceSystem?: string;
+}
+
+/** Narrow Prisma surface so tests inject a mock without the full client type. */
+export interface HealthAlertDb {
+  portfolioQualityIssue: {
+    upsert(args: {
+      where: { issueKey: string };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }): Promise<unknown>;
+    updateMany(args: {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    }): Promise<{ count: number }>;
+  };
+}
+
+/**
+ * Deterministic issueKey for a health alert. Scoped by the most specific
+ * distinguishing label so two services firing the same alert (e.g.
+ * ContainerErrorLogSpike on `sandbox` AND `portal`) become two distinct
+ * tracked issues instead of clobbering one row. Singleton metric alerts with
+ * no service/instance/job label fall back to the bare alertname (backward
+ * compatible with the original webhook key shape).
+ */
+export function healthAlertIssueKey(labels: Record<string, string>): string {
+  const name = labels.alertname ?? "unknown";
+  const scope = labels.service || labels.instance || labels.job || null;
+  return scope ? `health-alert-${name}:${scope}` : `health-alert-${name}`;
+}
+
+function detailsFor(alert: IncomingHealthAlert) {
+  return {
+    alertName: alert.labels.alertname ?? "unknown",
+    description: alert.annotations?.description ?? "",
+    labels: alert.labels,
+    // Attribution drives the cron's reconciliation: it only auto-resolves rows
+    // whose source it actually polled this cycle (never webhook-owned rows).
+    source: alert.sourceSystem ?? "webhook",
+  };
+}
+
+/**
+ * Open or refresh the PortfolioQualityIssue for a firing alert. Idempotent:
+ * the unique issueKey means repeated firings update lastDetectedAt rather than
+ * duplicating. Returns the issueKey so callers can track the firing set.
+ */
+export async function upsertHealthAlertIssue(
+  db: HealthAlertDb,
+  alert: IncomingHealthAlert,
+): Promise<string> {
+  const issueKey = healthAlertIssueKey(alert.labels);
+  const alertName = alert.labels.alertname ?? "unknown";
+  const severity: HealthAlertSeverity = alert.labels.severity === "critical" ? "error" : "warn";
+  const summary = alert.annotations?.summary ?? alertName;
+  const details = detailsFor(alert);
+  const firstDetectedAt = alert.startsAt
+    ? new Date(alert.startsAt)
+    : alert.activeAt
+      ? new Date(alert.activeAt)
+      : new Date();
+
+  await db.portfolioQualityIssue.upsert({
+    where: { issueKey },
+    create: {
+      issueKey,
+      issueType: "health_alert",
+      severity,
+      summary,
+      details,
+      status: "open",
+      firstDetectedAt,
+      lastDetectedAt: new Date(),
+    },
+    update: {
+      severity,
+      summary,
+      details,
+      status: "open",
+      lastDetectedAt: new Date(),
+      resolvedAt: null,
+    },
+  });
+  return issueKey;
+}
+
+/** Flip an open health-alert issue to resolved (alert stopped firing). */
+export async function resolveHealthAlertIssue(
+  db: HealthAlertDb,
+  issueKey: string,
+): Promise<void> {
+  await db.portfolioQualityIssue.updateMany({
+    where: { issueKey, status: "open" },
+    data: { status: "resolved", resolvedAt: new Date(), lastDetectedAt: new Date() },
+  });
+}

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.test.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchAlertSources: vi.fn(),
+  upsert: vi.fn(),
+  resolve: vi.fn(),
+  findMany: vi.fn(),
+}));
+
+vi.mock("@/lib/observability/alert-sources", () => ({
+  fetchAlertSources: mocks.fetchAlertSources,
+}));
+vi.mock("@/lib/observability/health-alert-issue", () => ({
+  upsertHealthAlertIssue: mocks.upsert,
+  resolveHealthAlertIssue: mocks.resolve,
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: { portfolioQualityIssue: { findMany: mocks.findMany } },
+}));
+
+import { runAlertDeliveryScan } from "./alert-delivery-bridge";
+
+type AlertState = "firing" | "pending";
+function alert(name: string, source: "prometheus" | "loki-ruler", state: AlertState, service?: string) {
+  return {
+    labels: { alertname: name, ...(service ? { service } : {}) },
+    annotations: { summary: name },
+    state,
+    sourceSystem: source,
+    activeAt: "2026-06-15T02:00:00Z",
+  };
+}
+// Mirror healthAlertIssueKey so reconciliation key-matching is realistic.
+function keyOf(name: string, service?: string) {
+  return service ? `health-alert-${name}:${service}` : `health-alert-${name}`;
+}
+
+const BOTH_UP = { prometheus: true, "loki-ruler": true };
+
+describe("runAlertDeliveryScan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: upsert returns the deterministic key for the alert it received.
+    mocks.upsert.mockImplementation(async (_db: unknown, a: { labels: Record<string, string> }) =>
+      keyOf(a.labels.alertname, a.labels.service),
+    );
+    mocks.findMany.mockResolvedValue([]);
+  });
+
+  it("delivers one issue per FIRING alert and ignores pending ones", async () => {
+    mocks.fetchAlertSources.mockResolvedValue({
+      alerts: [
+        alert("PostgresDown", "prometheus", "firing"),
+        alert("ContainerErrorLogSpike", "loki-ruler", "pending", "sandbox"), // still in `for:` window
+      ],
+      reached: BOTH_UP,
+    });
+
+    const res = await runAlertDeliveryScan();
+
+    expect(res.delivered).toBe(1);
+    expect(res.firing).toBe(1);
+    expect(mocks.upsert).toHaveBeenCalledTimes(1);
+    expect(mocks.upsert.mock.calls[0][1].labels.alertname).toBe("PostgresDown");
+  });
+
+  it("resolves an open issue whose alert cleared, from a source it reached", async () => {
+    mocks.fetchAlertSources.mockResolvedValue({
+      alerts: [alert("ContainerErrorLogStorm", "loki-ruler", "firing", "sandbox")],
+      reached: BOTH_UP,
+    });
+    mocks.findMany.mockResolvedValue([
+      { issueKey: keyOf("ContainerErrorLogStorm", "sandbox"), details: { source: "loki-ruler" } }, // still firing -> keep
+      { issueKey: keyOf("PostgresDown"), details: { source: "prometheus" } },                       // cleared -> resolve
+    ]);
+
+    const res = await runAlertDeliveryScan();
+
+    expect(res.delivered).toBe(1);
+    expect(res.resolved).toBe(1);
+    expect(mocks.resolve).toHaveBeenCalledTimes(1);
+    expect(mocks.resolve.mock.calls[0][1]).toBe(keyOf("PostgresDown"));
+  });
+
+  it("NEVER resolves issues from an unreached source (no false-resolve)", async () => {
+    mocks.fetchAlertSources.mockResolvedValue({
+      alerts: [alert("ContainerErrorLogSpike", "loki-ruler", "firing", "portal")],
+      reached: { prometheus: false, "loki-ruler": true }, // Prometheus blind this cycle
+    });
+    mocks.findMany.mockResolvedValue([
+      { issueKey: keyOf("PostgresDown"), details: { source: "prometheus" } },        // unreached source -> keep
+      { issueKey: keyOf("ContainerErrorLogSpike", "stt"), details: { source: "loki-ruler" } }, // reached + cleared -> resolve
+    ]);
+
+    const res = await runAlertDeliveryScan();
+
+    expect(res.resolved).toBe(1);
+    expect(mocks.resolve).toHaveBeenCalledTimes(1);
+    expect(mocks.resolve.mock.calls[0][1]).toBe(keyOf("ContainerErrorLogSpike", "stt"));
+  });
+
+  it("never auto-resolves webhook-owned rows", async () => {
+    mocks.fetchAlertSources.mockResolvedValue({ alerts: [], reached: BOTH_UP });
+    mocks.findMany.mockResolvedValue([
+      { issueKey: "health-alert-ManualThing", details: { source: "webhook" } },
+    ]);
+
+    const res = await runAlertDeliveryScan();
+
+    expect(res.resolved).toBe(0);
+    expect(mocks.resolve).not.toHaveBeenCalled();
+  });
+
+  it("does nothing (and resolves nothing) when both sources are unreachable", async () => {
+    mocks.fetchAlertSources.mockResolvedValue({
+      alerts: [],
+      reached: { prometheus: false, "loki-ruler": false },
+    });
+
+    const res = await runAlertDeliveryScan();
+
+    expect(res.sourcesUnreachable).toBe(true);
+    expect(res.delivered).toBe(0);
+    expect(res.resolved).toBe(0);
+    expect(mocks.findMany).not.toHaveBeenCalled(); // never touch the DB to resolve
+    expect(mocks.resolve).not.toHaveBeenCalled();
+  });
+
+  it("caps delivery under a pathological storm fan-out", async () => {
+    const many = Array.from({ length: 250 }, (_, i) =>
+      alert("ContainerErrorLogStorm", "loki-ruler", "firing", `svc-${i}`),
+    );
+    mocks.fetchAlertSources.mockResolvedValue({ alerts: many, reached: BOTH_UP });
+
+    const res = await runAlertDeliveryScan();
+
+    expect(res.firing).toBe(250);
+    expect(res.delivered).toBe(200); // MAX_ALERTS_PER_CYCLE default
+    expect(res.capped).toBe(true);
+  });
+});

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.ts
@@ -1,0 +1,133 @@
+// apps/web/lib/queue/functions/alert-delivery-bridge.ts
+// EP-FULL-OBS Tier 2 (BI-5FE8656F item #6) — alert-delivery bridge.
+//
+// The platform has no Alertmanager (deliberately — "minimize entirely new
+// processes"), so firing Prometheus metric alerts and Loki ruler log-rate/storm
+// alerts evaluate but never reach the operator. This cron closes that loop
+// WITHOUT a new process: it reuses the existing inngest runtime (where the
+// log-signature-scanner already lives), polls both evaluators' Prometheus-shaped
+// alerts APIs, and upserts each FIRING alert into the same PortfolioQualityIssue
+// inbox the rest of the platform's health alerts use — then resolves issues
+// whose alert has cleared.
+//
+// Mirrors token-expiry-monitor / log-signature-scanner exactly: a pure exported
+// scan function (driveable by tests without the Inngest harness) + a thin
+// wrapper with the quiescence gate.
+//
+// Storm-proof by construction: it reads AGGREGATED alert state, so a container
+// flooding 10k lines/sec yields exactly ONE ContainerErrorLogStorm issue, never
+// a per-line flood. MAX_ALERTS_PER_CYCLE is a belt-and-suspenders cap.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  fetchAlertSources,
+  type AlertSourceSystem,
+} from "@/lib/observability/alert-sources";
+import {
+  upsertHealthAlertIssue,
+  resolveHealthAlertIssue,
+} from "@/lib/observability/health-alert-issue";
+
+// Defensive bound on issues touched per cycle. Real alert counts are tiny
+// (rules x services); this only matters under a pathological fan-out. No hard
+// pin — operator-tunable.
+const MAX_ALERTS_PER_CYCLE = Number(process.env.DPF_ALERT_BRIDGE_MAX_PER_CYCLE ?? 200);
+
+export interface AlertDeliveryResult {
+  firing: number;
+  delivered: number;
+  resolved: number;
+  capped: boolean;
+  sourcesReached: Record<AlertSourceSystem, boolean>;
+  /** True iff BOTH sources were unreachable — nothing delivered or resolved. */
+  sourcesUnreachable?: boolean;
+}
+
+const ZERO = (reached: Record<AlertSourceSystem, boolean>): AlertDeliveryResult => ({
+  firing: 0,
+  delivered: 0,
+  resolved: 0,
+  capped: false,
+  sourcesReached: reached,
+});
+
+/**
+ * Pure scan: poll both alert sources, deliver firing alerts to the issue inbox,
+ * and reconcile-resolve cleared ones. Exported for unit tests (mirrors
+ * runLogSignatureScan / runTokenExpiryScan).
+ */
+export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
+  const { prisma } = await import("@dpf/db");
+
+  const { alerts, reached } = await fetchAlertSources();
+
+  // Both evaluators down — do nothing. Critically, do NOT resolve anything: an
+  // empty firing set here means "we couldn't see", not "everything cleared".
+  if (!reached.prometheus && !reached["loki-ruler"]) {
+    return { ...ZERO(reached), sourcesUnreachable: true };
+  }
+
+  // Persist FIRING only. `pending` alerts are still inside their rule's `for:`
+  // debounce window — surfaced live on the dashboard for early warning, but not
+  // yet a tracked issue (avoids churning rows for transient blips).
+  const firingAll = alerts.filter((a) => a.state === "firing");
+  const capped = firingAll.length > MAX_ALERTS_PER_CYCLE;
+  const firing = capped ? firingAll.slice(0, MAX_ALERTS_PER_CYCLE) : firingAll;
+  if (capped) {
+    console.warn(
+      `[alert-delivery-bridge] ${firingAll.length} firing alerts exceeds cap ${MAX_ALERTS_PER_CYCLE}; delivering first ${MAX_ALERTS_PER_CYCLE}`,
+    );
+  }
+
+  // Deliver: upsert one PortfolioQualityIssue per firing alert. Track the keys
+  // we just saw firing so reconciliation can resolve the rest.
+  // `prisma as never` at the db-handle boundary matches the established pattern
+  // for passing the full client to a narrow injectable handle (discovery-runner.ts).
+  const firingKeys = new Set<string>();
+  let delivered = 0;
+  for (const a of firing) {
+    const key = await upsertHealthAlertIssue(prisma as never, {
+      labels: a.labels,
+      annotations: a.annotations,
+      activeAt: a.activeAt,
+      sourceSystem: a.sourceSystem,
+    });
+    firingKeys.add(key);
+    delivered++;
+  }
+
+  // Reconcile-resolve. Only resolve open issues that (a) we OWN via a source we
+  // actually reached this cycle, and (b) are no longer in the firing set. This
+  // is the guard against false-resolve: if Prometheus was unreachable, we leave
+  // every prometheus-sourced issue open even though it's absent from `firing`.
+  const respondedSources = new Set<string>(
+    (Object.keys(reached) as AlertSourceSystem[]).filter((s) => reached[s]),
+  );
+  const openIssues = await prisma.portfolioQualityIssue.findMany({
+    where: { issueType: "health_alert", status: "open" },
+    select: { issueKey: true, details: true },
+  });
+  let resolved = 0;
+  for (const row of openIssues) {
+    const source = (row.details as { source?: string } | null)?.source;
+    // Never auto-resolve webhook-owned rows or rows from an unreached source.
+    if (!source || !respondedSources.has(source)) continue;
+    if (firingKeys.has(row.issueKey)) continue;
+    await resolveHealthAlertIssue(prisma as never, row.issueKey);
+    resolved++;
+  }
+
+  return { firing: firingAll.length, delivered, resolved, capped, sourcesReached: reached };
+}
+
+export const alertDeliveryBridge = inngest.createFunction(
+  { id: "ops/alert-delivery-bridge", retries: 2, triggers: [cron("*/1 * * * *")] },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return await step.run("deliver-alerts", async () => runAlertDeliveryScan());
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -46,6 +46,7 @@ import {
 } from "./postgres-daily-backup";
 import { runtimeTargetJanitor } from "./runtime-target-janitor";
 import { logSignatureScanner } from "./log-signature-scanner";
+import { alertDeliveryBridge } from "./alert-delivery-bridge";
 import { releaseHealthCheck } from "./release-health-check";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
@@ -73,6 +74,7 @@ export const scheduledFunctions = [
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
   logSignatureScanner,   // BI-5FE8656F: EP-FULL-OBS Tier 2 novel-signature log scan, every 15m
+  alertDeliveryBridge,   // BI-5FE8656F: EP-FULL-OBS Tier 2 item #6 — Prometheus+Loki firing alerts -> PortfolioQualityIssue, every 1m
   releaseHealthCheck,    // BI-3630773C: EP-FULL-OBS release stamp verify-gate watch, every 15m
 ];
 


### PR DESCRIPTION
## What & why

Closes the last unbuilt piece of **BI-5FE8656F** (EP-FULL-OBS Tier 2 — proactive log monitoring). Items 1–5 (Loki+Alloy capture, novel-signature scanner, PIR dedupe, Log Issues panel) shipped in #1672 / #1658. **Item #6 — the loud-path alert delivery — was never built**, and live evidence shows the consequence:

- The Loki ruler's `ContainerErrorLogSpike`/`Storm` rules and Prometheus's metric alerts **evaluate and fire**, but the stack ships **no Alertmanager** (deliberately — *minimize entirely new processes*), and Grafana's webhook contact point has no rules. So firing alerts routed **nowhere**.
- Verified on the live install: **0 `health_alert` `PortfolioQualityIssue` rows** over 2 days while a `ContainerErrorLogSpike`+`Storm` fired on `sandbox`. The "I only caught it because I happened to watch Docker Desktop" class of problem — for the *loud* case — still reached no one.

## Approach — no new process

Reuses the existing **inngest runtime** (where the log-signature scanner already lives) and the operator's existing **`PortfolioQualityIssue` inbox**. No Alertmanager, no new container.

**Two halves, one shared source of truth:**

| Half | Change | Effect |
|---|---|---|
| **Display** (flip the health dot) | `/api/platform/metrics/alerts` now merges Prometheus `/api/v1/alerts` **and** the Loki ruler `/prometheus/api/v1/alerts` | Shell-nav health dot, `AlertBanner`, `RecentAlertsPanel` (all via `useAlertQuery`) now reflect log-rate/storm alerts — previously blind to the Loki ruler |
| **Persistence** (managed going forward) | `alert-delivery-bridge` inngest cron (every 1m) upserts each **firing** alert → `PortfolioQualityIssue`, reconcile-resolves cleared ones | Log-rate alerts become tracked, deduped, operator-visible issues |

**New shared modules:**
- `lib/observability/alert-sources.ts` — `fetchAlertSources()`: both evaluators, per-source reachability; used by **both** the route and the cron.
- `lib/observability/health-alert-issue.ts` — `upsert`/`resolve`/`key`, refactored out of the `/api/platform/alerts` webhook so **push (webhook) and poll (cron) share one writer**. `issueKey` is now service-scoped so two services firing the same alert are distinct issues.

## Resilient to log storms (by construction)

Reads **aggregated** alert state, so a container flooding 10k lines/sec yields **one** storm issue, never a per-line flood. Firing-only persistence (pending stays display-only); **source-attributed reconciliation never false-resolves** an issue whose source was unreachable that cycle; per-cycle cap.

## Verification

- **15/15 unit tests** pass — merge + source-down resilience; key scoping + severity mapping; firing-only persist, no-false-resolve, storm cap, never-resolve-webhook-owned.
- **web typecheck clean** for all changed/new files (root toolchain; remaining worktree TS errors are pre-existing source-only cross-workspace resolution noise — `@dpf/types`, `@dpf/storefront-templates`, `sharp`).
- **Live functional validation** on the running install: drove the real `/api/platform/alerts` webhook with a labeled probe → `PortfolioQualityIssue` `health_alert` row **created (open)** → **resolved** (`resolvedAt` set) → probe deleted. The live Loki ruler is firing `ContainerErrorLogSpike`+`Storm` on `sandbox` right now — the real anomaly this bridge surfaces once deployed.

The new code runs after the next governed self-upgrade; each mechanism it uses is proven live above. Full typecheck/build/migrate run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
