### PR TITLE
fix(routing): skip uncredentialed providers in background evals; never retire a model for a config gap

### DIFF
--- a/apps/web/lib/inference/ai-provider-internals.test.ts
+++ b/apps/web/lib/inference/ai-provider-internals.test.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @dpf/db so providerHasConfiguredCredential can be exercised without a
+// live database. The other (pure) functions under test never touch prisma, so
+// this mock is inert for them.
+const credState = vi.hoisted(() => ({
+  row: null as Record<string, unknown> | null,
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    credentialEntry: {
+      findUnique: vi.fn(async () => credState.row),
+    },
+  },
+}));
+
 import {
   buildAutoDiscoveryEvalEvents,
   extractTokenUsage,
+  providerHasConfiguredCredential,
 } from "./ai-provider-internals";
 
 describe("extractTokenUsage", () => {
@@ -60,5 +76,40 @@ describe("buildAutoDiscoveryEvalEvents", () => {
         },
       },
     ]);
+  });
+});
+
+describe("providerHasConfiguredCredential", () => {
+  beforeEach(() => {
+    credState.row = null;
+  });
+
+  it("treats no-auth endpoints (local runner) as always eligible", async () => {
+    expect(await providerHasConfiguredCredential("local", "none")).toBe(true);
+    // null / empty auth is treated the same as "none"
+    expect(await providerHasConfiguredCredential("speaches", null)).toBe(true);
+  });
+
+  it("api_key provider is eligible only when a secretRef is stored", async () => {
+    credState.row = { secretRef: "enc:abc", clientSecret: null, cachedToken: null, refreshToken: null };
+    expect(await providerHasConfiguredCredential("anthropic", "api_key")).toBe(true);
+  });
+
+  it("api_key provider with a credential row but NO secret is NOT eligible", async () => {
+    // The exact xAI / gemini state that flooded the eval logs.
+    credState.row = { secretRef: null, clientSecret: null, cachedToken: null, refreshToken: null };
+    expect(await providerHasConfiguredCredential("gemini", "api_key")).toBe(false);
+  });
+
+  it("api_key provider with no credential row at all is NOT eligible", async () => {
+    credState.row = null;
+    expect(await providerHasConfiguredCredential("xai", "api_key")).toBe(false);
+  });
+
+  it("oauth2_client_credentials is eligible with a client secret or token material", async () => {
+    credState.row = { secretRef: null, clientSecret: "enc:cs", cachedToken: null, refreshToken: null };
+    expect(await providerHasConfiguredCredential("p", "oauth2_client_credentials")).toBe(true);
+    credState.row = { secretRef: null, clientSecret: null, cachedToken: null, refreshToken: null };
+    expect(await providerHasConfiguredCredential("p", "oauth2_client_credentials")).toBe(false);
   });
 });

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -69,6 +69,50 @@ export async function getDecryptedCredential(providerId: string) {
   return { ...cred, secretRef, clientSecret, cachedToken, refreshToken };
 }
 
+/**
+ * Cheap pre-flight: does this provider have credential material adequate for
+ * its auth method? Existence-only (no decrypt, no warning log) so it is safe to
+ * call in hot loops such as the background eval scheduler. "none" / unset auth
+ * (local Docker Model Runner, self-hosted speech) needs no credential and is
+ * always eligible. Returns false when the provider needs a key but has none —
+ * the caller should skip it rather than make a guaranteed-to-fail call that
+ * floods the logs with "No credential configured".
+ *
+ * Intentionally NOT getDecryptedCredential: that decrypts every field and emits
+ * diagnostic warnings on a missing/rotated row, which would itself become
+ * per-call log noise when used as a filter.
+ */
+export async function providerHasConfiguredCredential(
+  providerId: string,
+  authMethod: string | null,
+): Promise<boolean> {
+  const method = (authMethod ?? "").toLowerCase();
+  // No-auth endpoints (local model runner, self-hosted) need no credential.
+  if (method === "none" || method === "") return true;
+
+  const cred = await prisma.credentialEntry.findUnique({
+    where: { providerId },
+    select: {
+      secretRef: true,
+      clientSecret: true,
+      cachedToken: true,
+      refreshToken: true,
+    },
+  });
+  if (!cred) return false;
+
+  if (method === "api_key") return Boolean(cred.secretRef);
+  if (method === "oauth2_client_credentials") {
+    return Boolean(cred.clientSecret || cred.cachedToken || cred.refreshToken);
+  }
+  // oauth2_authorization_code + unknown methods: usable only if SOME token or
+  // secret material is present. (authorization_code is excluded from background
+  // eval upstream, but keep this correct for other callers.)
+  return Boolean(
+    cred.secretRef || cred.clientSecret || cred.cachedToken || cred.refreshToken,
+  );
+}
+
 /** Provider-specific headers required beyond auth (e.g. Anthropic API versioning). */
 export function isAnthropicProvider(providerId: string): boolean {
   return providerId === "anthropic" || providerId.startsWith("anthropic-");

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -3,6 +3,7 @@ import {
   computeNewScore,
   detectDrift,
   errorLooksLikeInfrastructure,
+  errorLooksLikeConfigGap,
   type DriftResult,
 } from "./eval-runner";
 
@@ -106,5 +107,34 @@ describe("errorLooksLikeInfrastructure (BI-INST-008 circuit breaker)", () => {
   it("is case-insensitive", () => {
     expect(errorLooksLikeInfrastructure("NETWORK ERROR")).toBe(true);
     expect(errorLooksLikeInfrastructure("Fetch Failed")).toBe(true);
+  });
+});
+
+describe("errorLooksLikeConfigGap (credential/setup circuit breaker)", () => {
+  // The exact error that flooded the portal logs and wrongly retired xAI's
+  // grok models: a provider with no API key configured.
+  it("classifies a missing credential as a config gap (not model quality)", () => {
+    expect(errorLooksLikeConfigGap("No credential configured")).toBe(true);
+  });
+  it("matches the CLI-adapter 'No credential for' phrasing", () => {
+    expect(
+      errorLooksLikeConfigGap('No credential for "xai". Configure via Admin.'),
+    ).toBe(true);
+  });
+  it("matches a rotated-key decrypt failure", () => {
+    expect(
+      errorLooksLikeConfigGap("All encrypted fields failed to decrypt"),
+    ).toBe(true);
+  });
+  it("does NOT match a genuine model-quality / not-found failure (still retires)", () => {
+    expect(errorLooksLikeConfigGap("Model not found on local")).toBe(false);
+    expect(errorLooksLikeConfigGap("schema validation failed")).toBe(false);
+  });
+  it("returns false for null / empty", () => {
+    expect(errorLooksLikeConfigGap(null)).toBe(false);
+    expect(errorLooksLikeConfigGap("")).toBe(false);
+  });
+  it("is case-insensitive", () => {
+    expect(errorLooksLikeConfigGap("NO CREDENTIAL CONFIGURED")).toBe(true);
   });
 });

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -5,6 +5,7 @@
 import { prisma } from "@dpf/db";
 import * as crypto from "crypto";
 import { callProvider, InferenceError } from "@/lib/ai-inference";
+import { providerHasConfiguredCredential } from "@/lib/inference/ai-provider-internals";
 import type { BuiltinDimension } from "./types";
 import { BUILTIN_DIMENSIONS } from "./types";
 import { getTestsForDimension, type GoldenTest, type ScoringMethod } from "./golden-tests";
@@ -49,6 +50,35 @@ const INFRASTRUCTURE_ERROR_PATTERNS: RegExp[] = [
  */
 export function errorLooksLikeInfrastructure(error: string | null): boolean {
   return error !== null && INFRASTRUCTURE_ERROR_PATTERNS.some((re) => re.test(error));
+}
+
+// ── Config-gap Error Classifier ────────────────────────────────────────────
+//
+// Credential / setup gaps: the provider is selectable but not actually usable
+// (no API key, a key that no longer decrypts, OAuth never connected). Like
+// infrastructure errors, these describe a FIXABLE setup problem, not a
+// model-quality failure — so the auto-retire circuit breaker must NOT retire
+// the model for them. Retiring on "No credential configured" was a real bug:
+// the operator adds the key later and finds every model stranded as "retired".
+// The eval scheduler also pre-filters these providers out entirely (see
+// runAllDimensionEvals) so this classifier is the second line of defence.
+const CONFIG_ERROR_PATTERNS: RegExp[] = [
+  /No credential configured/i,
+  /No credential for/i,
+  /failed to decrypt/i,
+  /re-configure this provider/i,
+  /requires an API key/i,
+  /not connected/i,
+];
+
+/**
+ * Classify an eval error string as a provider config/credential gap.
+ * Returns true for fixable setup problems (missing/rotated key, OAuth not
+ * connected) — in which case the model must NOT be auto-retired. Returns false
+ * for null/unknown errors so they fall through to existing behaviour.
+ */
+export function errorLooksLikeConfigGap(error: string | null): boolean {
+  return error !== null && CONFIG_ERROR_PATTERNS.some((re) => re.test(error));
 }
 
 // ── Score Computation ────────────────────────────────────────────────────────
@@ -409,8 +439,9 @@ export async function runDimensionEval(
   // classifier is the only behavior change here that's worth a focused
   // test, and keeping it pure makes that test trivial.
   const looksLikeInfrastructure = errorLooksLikeInfrastructure(firstError);
+  const looksLikeConfigGap = errorLooksLikeConfigGap(firstError);
 
-  if (allInconclusive && firstError && !looksLikeInfrastructure) {
+  if (allInconclusive && firstError && !looksLikeInfrastructure && !looksLikeConfigGap) {
     await prisma.modelProfile.update({
       where: { providerId_modelId: { providerId, modelId } },
       data: {
@@ -420,9 +451,9 @@ export async function runDimensionEval(
       },
     });
     console.log(`[eval-runner] Auto-retired ${providerId}/${modelId}: all tests failed — ${firstError.slice(0, 100)}`);
-  } else if (allInconclusive && looksLikeInfrastructure) {
+  } else if (allInconclusive && (looksLikeInfrastructure || looksLikeConfigGap)) {
     console.warn(
-      `[eval-runner] All dimensions inconclusive for ${providerId}/${modelId} but error looks like infrastructure — NOT retiring. Error: ${firstError?.slice(0, 200)}`,
+      `[eval-runner] All dimensions inconclusive for ${providerId}/${modelId} but error looks like ${looksLikeConfigGap ? "a config gap" : "infrastructure"} — NOT retiring. Error: ${firstError?.slice(0, 200)}`,
     );
   }
 
@@ -451,11 +482,39 @@ export async function runAllDimensionEvals(triggeredBy: string): Promise<EvalRun
         NOT: { authMethod: "oauth2_authorization_code" },
       },
     },
-    select: { providerId: true, modelId: true },
+    select: {
+      providerId: true,
+      modelId: true,
+      provider: { select: { authMethod: true } },
+    },
   });
 
-  const results: EvalRunResult[] = [];
+  // Pre-filter providers with no usable credential. Calling them is guaranteed
+  // to fail with "No credential configured" — which floods the logs (one error
+  // per golden test) and used to wrongly auto-retire otherwise-fine models for
+  // a setup gap. Skip with ONE log line per provider instead. Credential
+  // presence is cached so a multi-model provider is only checked once.
+  const credentialOk = new Map<string, boolean>();
+  const eligible: typeof models = [];
   for (const m of models) {
+    let ok = credentialOk.get(m.providerId);
+    if (ok === undefined) {
+      ok = await providerHasConfiguredCredential(
+        m.providerId,
+        m.provider?.authMethod ?? null,
+      );
+      credentialOk.set(m.providerId, ok);
+      if (!ok) {
+        console.log(
+          `[eval-runner] Skipping ${m.providerId}: no credential configured — not scheduling evals until the provider is set up`,
+        );
+      }
+    }
+    if (ok) eligible.push(m);
+  }
+
+  const results: EvalRunResult[] = [];
+  for (const m of eligible) {
     try {
       const result = await runDimensionEval(m.providerId, m.modelId, triggeredBy);
       results.push(result);


### PR DESCRIPTION
## Problem

The second-largest source of docker-log noise was the eval-runner repeatedly logging `No credential configured`. Two root causes:

1. **`runAllDimensionEvals` scheduled golden tests against any active provider** regardless of whether it had a usable credential. A provider with `api_key` auth but no stored secret failed **every** golden test with `No credential configured` — one error line per test, per eval cycle.
2. That error is a **fixable setup gap, not a model-quality failure**, yet the auto-retire circuit breaker treated it as the latter and **retired the model**. Adding the API key later would then leave the model stranded as `retired` — the same class of wrongful-retire bug as the BI-INST-008 infrastructure incident.

Verified against the live install:
- `xai` — `api_key`, **no secret**, already `disabled` (the routing fallback's `auth`-error handler disables a provider on the first credential failure, which is why the `[callWithFallbackChain] xai` path self-healed).
- `gemini` — **active**, `api_key`, **no secret**, models never eval'd → it would have flooded the *next* eval cycle and retired its models.

## Fix

- **`providerHasConfiguredCredential`** (`ai-provider-internals`): a cheap, no-decrypt existence check of credential material keyed by auth method. `none`/local needs no credential. Used to **pre-filter the eval scheduler** so uncredentialed providers are skipped with **one log line per provider** instead of one error per test.
- **`errorLooksLikeConfigGap`** (`eval-runner`): credential/setup errors (`No credential configured`, rotated-key decrypt failures, OAuth-not-connected) now join infrastructure errors as **non-retiring** — the circuit breaker never retires a model for a fixable config gap.

## Not a bug (verified, no change needed)

The local `gemma4:26B` timeout noise was a **separate, already-correct** case: it's retired as `model_not_found` because it's genuinely absent from the Docker Model Runner (which only has `qwen3-coder` + `nomic-embed-text`). The active local model evals fine.

## Verification

- New tests: `errorLooksLikeConfigGap` (6 cases) + `providerHasConfiguredCredential` (5 cases, incl. the exact xAI/gemini "row but no secret" state).
- **1186 `lib/routing` + `lib/inference` tests pass**; changed files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
