### PR TITLE
fix(redeploy): use --no-deps so a manual portal redeploy never recreates postgres

### DIFF
--- a/scripts/redeploy-portal.ps1
+++ b/scripts/redeploy-portal.ps1
@@ -94,7 +94,13 @@ $buildArgs += @("portal", "portal-init")
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "[redeploy-portal] Recreating portal-init and portal from the built images"
-$upArgs = $composeArgs + @("up", "-d", "--no-build", "--force-recreate", "portal-init", "portal")
+# --no-deps: recreate ONLY portal-init + portal, never their dependency containers.
+# Without it, `compose up` also recreates postgres/neo4j/qdrant — and if a running
+# container's data volume differs from what compose resolves (e.g. an override bind
+# vs a named volume), that silently swaps the data store and can present an empty,
+# freshly-seeded DB. (Data-loss incident 2026-06-15.) The self-upgrade promoter
+# already swaps the portal with --no-deps for the same reason.
+$upArgs = $composeArgs + @("up", "-d", "--no-build", "--no-deps", "--force-recreate", "portal-init", "portal")
 & docker @upArgs
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/scripts/redeploy-portal.sh
+++ b/scripts/redeploy-portal.sh
@@ -70,7 +70,13 @@ echo "[redeploy-portal] Building portal and portal-init with DPF_VERSION=$sha"
 docker compose ${compose_args[@]+"${compose_args[@]}"} build ${build_flags[@]+"${build_flags[@]}"} portal portal-init
 
 echo "[redeploy-portal] Recreating portal-init and portal from the built images"
-docker compose ${compose_args[@]+"${compose_args[@]}"} up -d --no-build --force-recreate portal-init portal
+# --no-deps: recreate ONLY portal-init + portal, never their dependency containers.
+# Without it, `compose up` also recreates postgres/neo4j/qdrant — and if a running
+# container's data volume differs from what compose resolves (override bind vs
+# named volume), that silently swaps the data store and can present an empty,
+# freshly-seeded DB. (Data-loss incident 2026-06-15.) The self-upgrade promoter
+# already swaps the portal with --no-deps for the same reason.
+docker compose ${compose_args[@]+"${compose_args[@]}"} up -d --no-build --no-deps --force-recreate portal-init portal
 
 portal_container="$(docker compose ${compose_args[@]+"${compose_args[@]}"} ps -a -q portal | head -n 1)"
 portal_init_container="$(docker compose ${compose_args[@]+"${compose_args[@]}"} ps -a -q portal-init | head -n 1)"


### PR DESCRIPTION
## Problem
`scripts/redeploy-portal.{ps1,sh}` ran `docker compose up -d --force-recreate portal-init portal` **without `--no-deps`**, so compose also recreated the **postgres/neo4j/qdrant dependency** containers. When a running container's data volume differs from what compose resolves — e.g. a `docker-compose.override.yml` **bind** vs the base **named** volume — that silently swaps the data store.

**Observed 2026-06-15:** a manual redeploy recreated postgres onto an empty bind and presented a freshly-seeded 2-epic DB instead of the live 93-epic data. Recovered from a pre-redeploy `pg_dump`, but it was a real data-loss scare.

## Fix
Add `--no-deps` so the redeploy recreates **only** `portal-init` + `portal`, never their stateful dependencies. The self-upgrade promoter ([scripts/promote.sh](scripts/promote.sh)) already swaps the portal with `--no-deps` for exactly this reason — which is why self-upgrades were unaffected by the incident.

Relates to BI-C63BDBA8 (guard upgrades against recreating stateful services onto a divergent volume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)