### PR TITLE
feat(build-studio): route opencode Ideate through portal inference — completes end-to-end local-LLM builds (BI-01D6A51B)

### DIFF
--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -355,6 +355,47 @@ export async function dispatchIdeateResearch(params: {
   const providerId = params.providerId || "";
   const model = params.model ?? "";
 
+  // Local-model engine (opencode): Ideate research runs through portal-side
+  // routing — the SAME routeAndCall path the Plan phase uses — not a vendor CLI.
+  // The configured local model (e.g. qwen3-coder via Docker Model Runner)
+  // generates the design doc with no credential and no egress. This is the last
+  // piece that lets the full Build Studio pipeline (ideate → plan → build) run
+  // end-to-end off a local LLM: Plan already uses routeAndCall, Build dispatches
+  // to the opencode runner, and now Ideate uses routing too instead of falling
+  // through to the `codex exec` branch below. (BI-01D6A51B)
+  if (dispatchEngine === "opencode") {
+    const startMs = Date.now();
+    try {
+      const prompt = buildResearchPrompt(params);
+      const { routeAndCall } = await import("@/lib/inference/routed-inference");
+      const response = await routeAndCall(
+        [{ role: "user" as const, content: prompt }],
+        "You are a senior software architect producing a structured design document. Respond with the design document content only — no preamble.",
+        "internal",
+        { budgetClass: "quality_first" },
+      );
+      const rawOutput = (response.content ?? "").trim();
+      const designDoc = parseDesignDoc(rawOutput);
+      return {
+        designDoc,
+        rawOutput,
+        success: !!designDoc,
+        durationMs: Date.now() - startMs,
+        error: designDoc
+          ? undefined
+          : "Local-model ideate output could not be parsed into a design document.",
+      };
+    } catch (err) {
+      return {
+        designDoc: null,
+        rawOutput: "",
+        success: false,
+        durationMs: Date.now() - startMs,
+        error: `Local-model ideate failed: ${(err as Error).message}`,
+      };
+    }
+  }
+
   // Auth
   if (!providerId) {
     return {


### PR DESCRIPTION
## Summary

The **last** piece that makes Build Studio run a build end-to-end off a local LLM. Backlog: **BI-01D6A51B** (EP-BUILD-STUDIO).

Build Studio's three dispatched phases, after this:

| Phase | Mechanism | On local LLM? |
|---|---|---|
| **Ideate** | **was** CLI-only — opencode fell through to `codex exec` (unauthed on a local-only install → pipeline stalled). **Now** routes through `routeAndCall` (portal inference). | ✅ (this PR) |
| **Plan** | already `routeAndCall` (portal routing) | ✅ (no change) |
| **Build** | dispatches to the opencode runner | ✅ (proven writing files via qwen3-coder) |

## Change

One isolated early-return branch in `dispatchIdeateResearch`: when `dispatchEngine === "opencode"`, generate the design doc via `routeAndCall` (the **same** routing path Plan uses) + the existing `parseDesignDoc`, instead of a vendor CLI. No credential, no egress — the configured local model produces the design doc. Other engines (claude/codex/grok) keep their codebase-aware CLI ideate path **unchanged**.

## Why this is the finish

Verified live on the running install during this work:
- opencode + qwen3-coder writes files via tool-calling (~0.9s) — build phase proven.
- Build Studio dispatch configured to `provider: opencode`, `opencodeProviderId: local`.
- Plan already runs on the local model via routing.

The only gap was Ideate's codex fallback. With this branch, **ideate → plan → build** all run on the local model. Needs the governed self-upgrade deploy to go live.

## Verification

Typecheck clean (change is a new isolated branch reusing the proven Plan-phase pattern); CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)