### PR TITLE
fix(mcp): coerce JSON-string tool args at the governed-execute chokepoint (BI-16A80690)

### DIFF
--- a/apps/web/lib/mcp-arg-coercion.test.ts
+++ b/apps/web/lib/mcp-arg-coercion.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import { coerceMcpToolArgs } from "./mcp-arg-coercion";
+
+// A faithful subset of the real principle_decide inputSchema: `options` is an
+// array of objects, each with a nested `features` object map; `ringScope` is a
+// string array; `callingPopulation`/`context` are plain strings. Kept inline so
+// this unit test is hermetic. The governed-execute test exercises the *real*
+// registry schema end-to-end. (BI-16A80690)
+const PRINCIPLE_DECIDE_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    context: { type: "string" },
+    options: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          description: { type: "string" },
+          features: {
+            type: "object",
+            additionalProperties: { type: "number" },
+          },
+        },
+        required: ["id", "description"],
+      },
+    },
+    callingPopulation: {
+      type: "string",
+      enum: ["in_platform_coworker", "external_coding_agent", "human"],
+    },
+    ringScope: { type: "array", items: { type: "string" } },
+  },
+  required: ["context", "options", "callingPopulation"],
+};
+
+const STRUCTURED_OPTIONS = [
+  { id: "a", description: "A" },
+  { id: "b", description: "B" },
+];
+
+describe("coerceMcpToolArgs — principle_decide shapes (BI-16A80690)", () => {
+  it("coerces options sent as a JSON string into a native array (mode 2)", () => {
+    const out = coerceMcpToolArgs(
+      {
+        context: "x",
+        callingPopulation: "external_coding_agent",
+        options: JSON.stringify(STRUCTURED_OPTIONS),
+      },
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    expect(Array.isArray(out.options)).toBe(true);
+    expect(out.options).toEqual(STRUCTURED_OPTIONS);
+    // scalar fields are left exactly as sent
+    expect(out.callingPopulation).toBe("external_coding_agent");
+    expect(out.context).toBe("x");
+  });
+
+  it("leaves already-structured options unchanged (idempotent — structured shape)", () => {
+    const out = coerceMcpToolArgs(
+      {
+        context: "x",
+        callingPopulation: "human",
+        options: STRUCTURED_OPTIONS,
+      },
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    expect(out.options).toEqual(STRUCTURED_OPTIONS);
+    expect(out.callingPopulation).toBe("human");
+  });
+
+  it("parses a whole arguments object sent as a single JSON string (mode 1)", () => {
+    const out = coerceMcpToolArgs(
+      JSON.stringify({
+        context: "x",
+        callingPopulation: "external_coding_agent",
+        options: STRUCTURED_OPTIONS,
+      }),
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    expect(out.callingPopulation).toBe("external_coding_agent");
+    expect(Array.isArray(out.options)).toBe(true);
+    expect(out.options).toEqual(STRUCTURED_OPTIONS);
+  });
+
+  it("handles mode 1 + mode 2 together (whole object string with a stringified inner array)", () => {
+    const out = coerceMcpToolArgs(
+      JSON.stringify({
+        context: "x",
+        callingPopulation: "external_coding_agent",
+        options: JSON.stringify(STRUCTURED_OPTIONS),
+      }),
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    expect(Array.isArray(out.options)).toBe(true);
+    expect(out.options).toEqual(STRUCTURED_OPTIONS);
+  });
+
+  it("coerces ringScope sent as a JSON string into an array", () => {
+    const out = coerceMcpToolArgs(
+      {
+        context: "x",
+        callingPopulation: "human",
+        options: STRUCTURED_OPTIONS,
+        ringScope: JSON.stringify(["ring-1-coworker", "universal-ring"]),
+      },
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    expect(out.ringScope).toEqual(["ring-1-coworker", "universal-ring"]);
+  });
+
+  it("re-hydrates a per-option features map sent as a string (nested recursion)", () => {
+    const out = coerceMcpToolArgs(
+      {
+        context: "x",
+        callingPopulation: "human",
+        options: [
+          { id: "a", description: "A", features: JSON.stringify({ x: 0.5 }) },
+          { id: "b", description: "B", features: { y: 0.25 } },
+        ],
+      },
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    const opts = out.options as Array<Record<string, unknown>>;
+    expect(opts[0].features).toEqual({ x: 0.5 });
+    expect(opts[1].features).toEqual({ y: 0.25 });
+  });
+});
+
+describe("coerceMcpToolArgs — safety: no false positives", () => {
+  it("does not parse a string-typed param even when it looks like JSON", () => {
+    const out = coerceMcpToolArgs(
+      {
+        context: '{"looks":"like json but is a string param"}',
+        callingPopulation: "human",
+        options: STRUCTURED_OPTIONS,
+      },
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    // `context` is type:string in the schema — must stay the literal string.
+    expect(typeof out.context).toBe("string");
+    expect(out.context).toBe('{"looks":"like json but is a string param"}');
+  });
+
+  it("never parses a string-typed `content` param (content-bearing tool safety)", () => {
+    const writeFileSchema: Record<string, unknown> = {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+    };
+    const jsonFileContent = '{"a":1,"b":[2,3]}';
+
+    const out = coerceMcpToolArgs(
+      { path: "config.json", content: jsonFileContent },
+      writeFileSchema,
+    );
+
+    // A blanket "parse anything that looks like JSON" would corrupt this into
+    // an object; schema-driven coercion keeps it the exact string to write.
+    expect(typeof out.content).toBe("string");
+    expect(out.content).toBe(jsonFileContent);
+  });
+
+  it("leaves a malformed JSON string for a structured param as the original string", () => {
+    const out = coerceMcpToolArgs(
+      {
+        context: "x",
+        callingPopulation: "human",
+        options: "[ this is not valid json",
+      },
+      PRINCIPLE_DECIDE_SCHEMA,
+    );
+
+    // Left untouched so the handler's strict check emits a clear error instead
+    // of us masking malformed input.
+    expect(typeof out.options).toBe("string");
+    expect(out.options).toBe("[ this is not valid json");
+  });
+
+  it("passes object fields through untouched when no schema is provided", () => {
+    const out = coerceMcpToolArgs({
+      options: JSON.stringify(STRUCTURED_OPTIONS),
+      callingPopulation: "human",
+    });
+
+    // No schema => no safe way to know `options` is meant to be structured.
+    expect(typeof out.options).toBe("string");
+    expect(out.callingPopulation).toBe("human");
+  });
+
+  it("does not mutate the caller's input object or nested arrays", () => {
+    const input = {
+      context: "x",
+      callingPopulation: "human",
+      options: [{ id: "a", description: "A", features: JSON.stringify({ x: 1 }) }],
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    coerceMcpToolArgs(input, PRINCIPLE_DECIDE_SCHEMA);
+
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("coerceMcpToolArgs — non-object payloads", () => {
+  it("returns {} for a bare string that is not JSON", () => {
+    expect(coerceMcpToolArgs("not json at all", PRINCIPLE_DECIDE_SCHEMA)).toEqual(
+      {},
+    );
+  });
+
+  it("returns {} for a JSON string that parses to a non-object", () => {
+    expect(coerceMcpToolArgs("[1,2,3]", PRINCIPLE_DECIDE_SCHEMA)).toEqual({});
+    expect(coerceMcpToolArgs("42", PRINCIPLE_DECIDE_SCHEMA)).toEqual({});
+  });
+
+  it("returns {} for null / undefined / number payloads", () => {
+    expect(coerceMcpToolArgs(null, PRINCIPLE_DECIDE_SCHEMA)).toEqual({});
+    expect(coerceMcpToolArgs(undefined, PRINCIPLE_DECIDE_SCHEMA)).toEqual({});
+    expect(coerceMcpToolArgs(99, PRINCIPLE_DECIDE_SCHEMA)).toEqual({});
+  });
+});

--- a/apps/web/lib/mcp-arg-coercion.ts
+++ b/apps/web/lib/mcp-arg-coercion.ts
@@ -1,0 +1,151 @@
+// MCP wire-argument coercion (BI-16A80690).
+//
+// Some MCP clients — and some JSON-RPC bridges — serialize structured tool
+// arguments as JSON *strings* instead of native JSON values. This shows up two
+// ways on the wire:
+//
+//   mode 1 — the whole `arguments` object arrives as a string:
+//     "{\"callingPopulation\":\"external_coding_agent\",\"options\":[...]}"
+//     -> every field reads back `undefined` -> "Invalid callingPopulation".
+//
+//   mode 2 — an individual array/object-typed arg arrives as a string:
+//     { callingPopulation: "external_coding_agent",
+//       options: "[{\"id\":\"a\",\"description\":\"A\"}]" }
+//     -> Array.isArray(options) === false -> "Empty options".
+//
+// Both make a perfectly valid call fail strict validation in the handler. We
+// re-hydrate those values once, before the tool switch, so every handler sees
+// native JSON regardless of how the client framed it.
+//
+// The coercion is driven by each tool's declared `inputSchema` so it is
+// precise: only params the schema types as `array`/`object` are JSON.parsed.
+// A string-typed param (e.g. a file's literal JSON `content`, a free-text
+// `description` that happens to start with `{`) is never touched, so
+// content-bearing tools keep their exact payloads — a blanket
+// "parse anything that looks like JSON" would corrupt them.
+//
+// Precedent: mcp-tools.ts already does the `typeof x === "string" ? JSON.parse(x) : x`
+// dance ad hoc in a few handlers; this centralizes it for every tool, and
+// sits alongside sanitizeToolParams() as the other schema-driven param
+// normalizer that runs before the switch.
+
+/** Guards against pathological / self-referential schemas. Real tool schemas
+ *  here are shallow (options -> items -> features), so 6 is generous. */
+const MAX_DEPTH = 6;
+
+type JsonSchemaNode = {
+  type?: string | string[];
+  properties?: Record<string, unknown>;
+  items?: unknown;
+  additionalProperties?: unknown;
+};
+
+function asSchemaNode(value: unknown): JsonSchemaNode | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonSchemaNode)
+    : null;
+}
+
+function schemaDeclaresStructured(schema: JsonSchemaNode): boolean {
+  const t = schema.type;
+  if (Array.isArray(t)) return t.includes("array") || t.includes("object");
+  return t === "array" || t === "object";
+}
+
+function tryParseJson(
+  value: string,
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: JSON.parse(value) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Coerce a single value against its schema node, recursing into array items
+ *  and object properties so nested stringification (e.g. a per-option
+ *  `features` map sent as a string) is also re-hydrated. Pure — never mutates
+ *  the input; returns new arrays/objects where it changes anything. */
+function coerceValue(
+  value: unknown,
+  schema: JsonSchemaNode | null,
+  depth: number,
+): unknown {
+  if (schema === null || depth > MAX_DEPTH) return value;
+
+  let current = value;
+
+  // Re-hydrate a stringified array/object whose schema says it should be
+  // structured. If it does not parse, leave the original string in place so
+  // the handler's own strict check emits a clear "must be an array" error
+  // rather than us masking genuinely malformed input.
+  if (typeof current === "string" && schemaDeclaresStructured(schema)) {
+    const parsed = tryParseJson(current);
+    if (parsed.ok) current = parsed.value;
+  }
+
+  if (Array.isArray(current)) {
+    const itemSchema = asSchemaNode(schema.items);
+    if (!itemSchema) return current;
+    return current.map((item) => coerceValue(item, itemSchema, depth + 1));
+  }
+
+  if (current && typeof current === "object") {
+    const props = schema.properties;
+    if (!props || typeof props !== "object") return current;
+    const out: Record<string, unknown> = {
+      ...(current as Record<string, unknown>),
+    };
+    for (const [key, propSchema] of Object.entries(props)) {
+      if (key in out) {
+        out[key] = coerceValue(out[key], asSchemaNode(propSchema), depth + 1);
+      }
+    }
+    return out;
+  }
+
+  return current;
+}
+
+/**
+ * Normalize tool arguments that a client may have serialized as JSON strings.
+ *
+ * @param rawParams   The `arguments` payload as received from the transport.
+ *                    May itself be a JSON string (mode 1).
+ * @param inputSchema The tool's declared JSON Schema. When omitted, only the
+ *                    whole-object-string case is handled and individual fields
+ *                    are passed through untouched (no schema => no safe way to
+ *                    know which strings are meant to be structured).
+ * @returns A plain object suitable for the tool handler. Returns `{}` when the
+ *          payload cannot be resolved to an object, so the handler's own
+ *          "missing required field" checks fire with a clear message.
+ */
+export function coerceMcpToolArgs(
+  rawParams: unknown,
+  inputSchema?: Record<string, unknown> | null,
+): Record<string, unknown> {
+  let top: unknown = rawParams;
+
+  // mode 1: the entire arguments object arrived as a JSON string.
+  if (typeof top === "string") {
+    const parsed = tryParseJson(top);
+    if (parsed.ok) top = parsed.value;
+  }
+
+  // Tool arguments are always a JSON object. Anything else (a bare string that
+  // did not parse, a number, an array, null/undefined) cannot be indexed by a
+  // handler — hand back {} and let the strict checks report the real problem.
+  if (!top || typeof top !== "object" || Array.isArray(top)) {
+    return {};
+  }
+
+  const schema = asSchemaNode(inputSchema);
+  if (!schema) return top as Record<string, unknown>;
+
+  // mode 2: individual array/object args arrived as JSON strings. Coerce per
+  // the declared schema.
+  const coerced = coerceValue(top, schema, 0);
+  return coerced && typeof coerced === "object" && !Array.isArray(coerced)
+    ? (coerced as Record<string, unknown>)
+    : (top as Record<string, unknown>);
+}

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -374,3 +374,57 @@ describe("governedExecuteTool — resilience", () => {
     expect(auditRows[0]?.success).toBe(false);
   });
 });
+
+// BI-16A80690: some MCP clients serialize array/object tool args as JSON
+// strings on the wire. governedExecuteTool is the single funnel for all MCP
+// wire transports, so it re-hydrates those strings (schema-driven) before the
+// tool switch sees them. These tests use the REAL principle_decide schema from
+// PLATFORM_TOOLS (resolved by findTool) and assert via the executeTool spy that
+// the handler receives native values — locking BOTH the JSON-string and the
+// already-structured shapes.
+describe("governedExecuteTool — JSON-string arg coercion (BI-16A80690)", () => {
+  const STRUCTURED_OPTIONS = [
+    { id: "a", description: "Option A" },
+    { id: "b", description: "Option B" },
+  ];
+
+  it("re-hydrates principle_decide options sent as a JSON string before dispatch", async () => {
+    await governedExecuteTool({
+      toolName: "principle_decide",
+      rawParams: {
+        context: "ship now vs. wait",
+        callingPopulation: "external_coding_agent",
+        options: JSON.stringify(STRUCTURED_OPTIONS), // <-- stringified by client
+      },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      source: "external-jsonrpc",
+    });
+
+    expect(executeMock).toHaveBeenCalledOnce();
+    const dispatchedParams = executeMock.mock.calls[0]![1];
+    // Pre-fix this arrived as a string -> Array.isArray() false -> "Empty options".
+    expect(Array.isArray(dispatchedParams.options)).toBe(true);
+    expect(dispatchedParams.options).toEqual(STRUCTURED_OPTIONS);
+    expect(dispatchedParams.callingPopulation).toBe("external_coding_agent");
+  });
+
+  it("passes already-structured principle_decide args through unchanged", async () => {
+    await governedExecuteTool({
+      toolName: "principle_decide",
+      rawParams: {
+        context: "ship now vs. wait",
+        callingPopulation: "human",
+        options: STRUCTURED_OPTIONS, // <-- native array
+      },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      source: "external-jsonrpc",
+    });
+
+    expect(executeMock).toHaveBeenCalledOnce();
+    const dispatchedParams = executeMock.mock.calls[0]![1];
+    expect(dispatchedParams.options).toEqual(STRUCTURED_OPTIONS);
+    expect(dispatchedParams.callingPopulation).toBe("human");
+  });
+});

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -16,6 +16,7 @@ import {
   type ToolDefinition,
   type ToolResult,
 } from "./mcp-tools";
+import { coerceMcpToolArgs } from "./mcp-arg-coercion";
 import { deriveAuditClassForTool, deriveCapabilityId } from "./tool-audit-helpers";
 
 export type GovernedExecuteSource =
@@ -376,6 +377,19 @@ export async function governedExecuteTool(
       governance: { rejected: "unknown_tool" },
     };
   }
+
+  // Re-hydrate any tool args a client serialized as JSON strings — the whole
+  // arguments object, or individual array/object-typed fields — before the
+  // governance hooks, audit, and tool switch see them. Schema-driven so
+  // string-typed params are never parsed. This is the single funnel for all
+  // MCP wire transports (REST /api/mcp/call, JSON-RPC /api/mcp/v1, internal
+  // MCP session), which is exactly where client-side JSON-string framing
+  // happens; in-process executeTool() callers pass native objects and are
+  // unaffected. BI-16A80690.
+  args = {
+    ...args,
+    rawParams: coerceMcpToolArgs(args.rawParams, tool.inputSchema),
+  };
 
   // Capability check — user must have the platform role required by the tool.
   if (tool.requiredCapability) {


### PR DESCRIPTION
## BI-16A80690 — `principle_decide` rejects valid calls

Some MCP clients serialize nested array/object tool arguments as JSON **strings** on the wire. `principle_decide` then rejected valid calls two ways:

- `options` arriving as the string `'[{...}]'` → `Array.isArray` is false → `{"error":"Empty options"}`
- a fully stringified `arguments` object → every field reads `undefined` → `{"error":"Invalid callingPopulation"}`

## Fix

Re-hydrate those strings **once** in `governedExecuteTool` — the single funnel for all MCP wire transports (REST `/api/mcp/call`, JSON-RPC `/api/mcp/v1`, internal MCP session) — before hooks, audit, and the tool switch see them.

The new `coerceMcpToolArgs` helper (`apps/web/lib/mcp-arg-coercion.ts`) is **schema-driven**: it reads each tool's declared `inputSchema` and `JSON.parse`s only params typed `array`/`object`. String-typed params (e.g. a file's literal JSON `content`) are never touched — a blanket "parse anything that looks like JSON" would corrupt content-bearing tools. It recurses into array items + object properties (so a per-option `features` map sent as a string is also re-hydrated) and handles both the per-field (mode 2) and whole-object (mode 1) stringification.

This hardens **every** MCP tool, not just `principle_decide`. In-process `executeTool()` callers (build orchestration, agentic loop, server actions) pass native objects and are unaffected.

### Why this layer
`governedExecuteTool` is the documented single governed entry point and the boundary where client-side JSON-string framing actually happens. All direct `executeTool` callers were verified to pass structured in-process objects, so they never hit the bug; placing the coercion here keeps it DRY across both wire transports while leaving the in-process path untouched.

## Tests
- `mcp-arg-coercion.test.ts` (14): both arg shapes, ring-scope coercion, nested-features recursion, no-false-positive safety (a string `content` param and a JSON-looking string `context` are left untouched), malformed JSON left as-is for a clear downstream error, non-object payloads → `{}`, and no-mutation of the caller's input.
- `mcp-governed-execute.test.ts` (+2): wiring against the **real** `principle_decide` schema — stringified `options` arrives at the handler as a native array; already-structured args pass through unchanged.
- Local run: **196 tests green** across the coercion helper, governed-execute, both MCP routes, and 4 heavy `governedExecuteTool` consumer suites (agentic-loop, autonomous-work-run, agent-coworker-external, agent-task-scheduler). Changed files type-check clean — the only `tsc` errors are unrelated source-only-worktree cross-workspace resolution noise (`@dpf/types`, `@dpf/storefront-templates`, `sharp`); CI runs the authoritative full typecheck.

## Functional verification
A live `principle_decide` MCP call from this Claude Code session returned a recommendation plus the full per-principle contribution ledger — confirming the tool works end-to-end on the running install for the structured-array shape, which isolates the failure to the stringified-arg path this PR fixes. End-to-end confirmation of the **stringified** shape on the live install is deploy-gated (self-upgrade is operator/UI-gated) and lands in the canonical post-merge rebuild; the stringified→structured behavior is locked by the unit + real-schema wiring tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
