### PR TITLE
fix(routing): short-circuit eval probing when an endpoint is unreachable

### DIFF
--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -1,9 +1,57 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocks for the runDimensionEval integration test. The pure-function tests in
+// this file don't touch either module, so the mocks are inert for them.
+const evalState = vi.hoisted(() => ({
+  profileUpdates: [] as Array<Record<string, unknown>>,
+  callCount: 0,
+}));
+
+vi.mock("@/lib/ai-inference", () => {
+  class InferenceError extends Error {
+    code: string;
+    constructor(message: string, code: string) {
+      super(message);
+      this.code = code;
+    }
+  }
+  return {
+    InferenceError,
+    callProvider: vi.fn(async () => {
+      evalState.callCount++;
+      throw new InferenceError(
+        "The operation was aborted due to timeout",
+        "network",
+      );
+    }),
+  };
+});
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    modelProfile: {
+      findUnique: vi.fn(async () => ({ evalCount: 0, modelStatus: "active" })),
+      update: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        evalState.profileUpdates.push(args.data);
+        return {};
+      }),
+    },
+    modelProvider: {
+      findUnique: vi.fn(async () => ({ authMethod: "none", name: "Local" })),
+    },
+    endpointTestRun: {
+      create: vi.fn(async () => ({})),
+      update: vi.fn(async () => ({})),
+    },
+  },
+}));
+
 import {
   computeNewScore,
   detectDrift,
   errorLooksLikeInfrastructure,
   errorLooksLikeConfigGap,
+  runDimensionEval,
   type DriftResult,
 } from "./eval-runner";
 
@@ -136,5 +184,32 @@ describe("errorLooksLikeConfigGap (credential/setup circuit breaker)", () => {
   });
   it("is case-insensitive", () => {
     expect(errorLooksLikeConfigGap("NO CREDENTIAL CONFIGURED")).toBe(true);
+  });
+});
+
+describe("runDimensionEval — infrastructure short-circuit", () => {
+  beforeEach(() => {
+    evalState.profileUpdates.length = 0;
+    evalState.callCount = 0;
+  });
+
+  it("stops after the first timed-out probe instead of grinding every test", async () => {
+    await runDimensionEval("local", "docker.io/ai/qwen3-coder:latest", "test");
+
+    // A single failing probe ends the whole run — not ~30 sequential 60s
+    // timeouts across every dimension. This is the wall-clock + log-flood fix
+    // for an unreachable/slow local Docker Model Runner.
+    expect(evalState.callCount).toBe(1);
+  });
+
+  it("does NOT retire the model on an infrastructure timeout", async () => {
+    await runDimensionEval("local", "docker.io/ai/qwen3-coder:latest", "test");
+
+    // A timeout is a broken probe path, not a model-quality failure — retiring
+    // would strand a working-but-slow model.
+    const retired = evalState.profileUpdates.some(
+      (u) => u.modelStatus === "retired",
+    );
+    expect(retired).toBe(false);
   });
 });

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -248,6 +248,7 @@ async function evalDimension(
   const tests = getTestsForDimension(dimension);
   const testResults: TestResult[] = [];
 
+  let infraAborted = false;
   for (let i = 0; i < tests.length; i++) {
     if (i > 0) {
       // 500 ms between tests to avoid triggering burst rate limits
@@ -255,11 +256,25 @@ async function evalDimension(
     }
     const result = await runGoldenTest(endpointId, modelId, tests[i]!);
     testResults.push(result);
+
+    // Infrastructure short-circuit: once the probe path itself is broken
+    // (timeout, network, runner down), every remaining test in this dimension
+    // fails identically — and each local timeout burns up to 60s plus a log
+    // line. Stop now; the dimension is inconclusive regardless. Turns ~30
+    // duplicate error lines (and minutes of wasted wall-clock) into one.
+    if (errorLooksLikeInfrastructure(result.error ?? null)) {
+      console.warn(
+        `[eval-runner] ${endpointId}/${modelId}: infrastructure error on ${dimension} — skipping remaining tests this cycle: ${result.error}`,
+      );
+      infraAborted = true;
+      break;
+    }
   }
 
-  // Check if inconclusive (>50% errors)
+  // Inconclusive when we aborted early on infrastructure (probe path broken), or
+  // when >50% of the tests that ran errored. Either way scores are preserved.
   const errorCount = testResults.filter((r) => r.error).length;
-  const inconclusive = errorCount > tests.length / 2;
+  const inconclusive = infraAborted || errorCount > tests.length / 2;
 
   if (inconclusive) {
     return {
@@ -362,6 +377,22 @@ export async function runDimensionEval(
     const previousScore = (modelProfile as Record<string, unknown>)[dbField] as number ?? 50;
     const result = await evalDimension(providerId, modelId, dim, previousScore, currentEvalCount);
     dimensions.push(result);
+
+    // Per-model infrastructure short-circuit: if this dimension was abandoned
+    // because the endpoint's probe path is broken (timeout/network/runner down),
+    // the remaining dimensions fail identically. Stop rather than burn another
+    // ~7 dimensions × up-to-60s timeouts. Skipped dimensions keep their previous
+    // scores (they were never re-scored), and the all-inconclusive verdict below
+    // still correctly avoids retiring the model.
+    const endpointUnreachable =
+      result.inconclusive &&
+      result.testResults.some((t) => errorLooksLikeInfrastructure(t.error ?? null));
+    if (endpointUnreachable) {
+      console.warn(
+        `[eval-runner] ${providerId}/${modelId}: endpoint unreachable this cycle — skipping remaining dimensions`,
+      );
+      break;
+    }
   }
 
   // Update ModelProfile with new scores (skip inconclusive dimensions)


### PR DESCRIPTION
## Problem

Follow-up to #1929 (credential pre-filter). The remaining live eval-log flood was the **local timeout** noise: when a local model is slow or unreachable, the eval-runner ground through every golden test across all 8 dimensions — up to ~30 sequential **60s** timeouts per cycle, each emitting an error line.

Confirmed on the live install: `qwen3-coder` (the active local model) **works but is slow** — ~25s for a trivial prompt, so heavier eval calls exceed the intentional 60s local fail-fast timeout. The model is genuinely usable, just slow on this hardware, so retiring it would be wrong (and the BI-INST-008 classifier correctly doesn't). But nothing stopped the runner from re-probing it ~30 times every cycle.

## Fix

An **infrastructure short-circuit** in the eval-runner:

- **Per dimension** (`evalDimension`): once a probe fails with an infrastructure error (timeout / network / runner down), stop running the remaining tests in that dimension — they fail identically. The dimension is marked inconclusive (scores preserved).
- **Per model** (`runDimensionEval`): once a dimension is abandoned for an infrastructure reason, skip the remaining dimensions for that model.

Net: ~30 timeout calls + ~30 log lines → **~1**, and **minutes of wasted eval wall-clock saved** per cycle. The model is still not retired (infrastructure, not model-quality). Real interactive routing is untouched — it keeps its own fail-fast 60s local timeout and cloud fallback.

## Verification

- New tests assert `callProvider` is invoked **once** (not ~30) when the endpoint always times out, and that the model is **not retired**.
- **1153 `lib/routing` + `lib/inference` tests pass**; changed file typechecks clean.

## Note (operator/capacity, not code)

The deeper issue this surfaces — `qwen3-coder` being too slow for interactive use on this box, with no credentialed *unattended* cloud provider to fall back to (the OAuth providers aren't usable in background, xAI/gemini have no key) — is a capacity/config decision: pull a smaller local model, add a cloud API key for unattended work, or accept local latency. This PR only stops the wasteful eval probing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
