### PR TITLE
docs(observability): document the issue-handling pipeline + highlight log monitoring on the landing page

### DIFF
--- a/docs/architecture/platform-overview.md
+++ b/docs/architecture/platform-overview.md
@@ -294,6 +294,57 @@ The monitoring stack runs as part of the default Docker Compose stack. All servi
 
 *[High-resolution PNG](monitoring-diagrams/png/02-monitoring-stack-topology.png) | [Mermaid source](monitoring-diagrams/02-monitoring-stack-topology.mmd)*
 
+### Layer 3b: Loki + Alloy — Container Logs (the unbounded signal)
+
+Metrics answer "how is a *pre-declared* signal trending?" Logs answer the larger, unbounded question: "what did any container actually write to stdout/stderr?" An error line repeated 500×/min, or a brand-new exception nobody instrumented, is invisible to Prometheus. Loki + Alloy close that gap, and — like the rest of the stack — run default-on in the base Compose project.
+
+| Component | Role | Why it is cross-platform |
+|-----------|------|--------------------------|
+| **Alloy** (Grafana Alloy) | Discovers every container on the Docker daemon and tails its stdout/stderr into Loki, labeled by compose service. One config, no per-service wiring — a new container is captured on the next 15-second discovery refresh. | Reads the Docker **log API via the socket** — no host-path bind mounts (`/proc`, `/sys`, `/var/lib/docker`), so it runs identically on Docker Desktop for macOS/Windows and native Linux, unlike cAdvisor/node-exporter. |
+| **Loki** | Stores the lines, label-indexed (not full-text), 14-day retention. A per-stream rate cap means one flooding container cannot fill the disk — excess is dropped, and the drop is itself an alert (`LogIngestionThrottled`). | Touches no host paths; the log *source* is Alloy. |
+
+Two complementary detectors run on top, because a *loud* problem and a *quiet* problem need different lenses:
+
+- **Loud path — Loki ruler (LogQL).** Error-rate rules (`ContainerErrorLogSpike` at >5 lines/min for 10m; `ContainerErrorLogStorm` at >60/min) fire in real time when a service sustains an elevated error rate.
+- **Quiet path — novel-signature scanner.** An Inngest cron (every 15 min) clusters error lines into signatures — template extraction strips digits, UUIDs, hex, paths, and timestamps to a stable hash — and files **one** issue per *first-seen* signature. It catches a single novel exception even at low volume, deduped so a recurring line is filed once, not every cycle.
+
+### How the Platform Handles Anything That Happens
+
+The defining design choice is **one issue substrate**: every detection source — a metric breach, a log storm, a novel error line, an in-process crash, or a human report — converges into a single deduped inbox, is auto-triaged into the backlog, and is tracked to resolution. No source gets its own parallel inbox, so a *new* detector plugs into the same pipe without new surfacing or triage code. This is the IT4IT SS5.7 *Detect → Diagnose → Change → Resolve → Close* loop.
+
+```
+DETECT (many sources)        CONVERGE (one inbox)     SURFACE              MANAGE → RESOLVE
+─────────────────────        ────────────────────     ───────              ────────────────
+metric thresholds  ┐                                   System Health tab    auto-triage →
+log rate / storm   ┤                                   shell health dot       BacklogItem
+novel log lines    ┼─►  PlatformIssueReport      ─►   (amber/red, any    ─►  (deduped, sized)
+app crash/regress  ┤    + PortfolioQualityIssue        page) + backlog     resolve: auto-clear
+user reports       ┘    (deduped by key)                                    or "fix" build
+```
+
+**1 — Detect.** Each source carries its own dedup key so a recurring problem files *once*:
+
+| Source | Mechanism | Lands as |
+|--------|-----------|----------|
+| Metric thresholds | Prometheus alert rules (`ContainerDown`, `HighErrorRate`, `HostDiskCritical`, `PostgresDown`, `AIInferenceHighLatency`…) | `PortfolioQualityIssue` (`health_alert`) |
+| Log rate / storm | Loki ruler LogQL rules | `PortfolioQualityIssue` (`health_alert`) |
+| Novel log lines | Novel-signature scanner (Inngest, 15 min) | `PlatformIssueReport` (`log_signature`) |
+| App crashes / regressions | In-process error boundary + coworker-regression detector | `PlatformIssueReport` (`runtime_error`) |
+| User reports | Feedback + support intake | `PlatformIssueReport` (`user_report` / `feedback`) |
+| Estate drift | Discovery/portfolio quality writer | `PortfolioQualityIssue` (discovery kinds) |
+
+**2 — Converge.** Two sibling tables share the operator inbox: `PlatformIssueReport` (runtime/log/user issues, deduped by `dedupeKey`) and `PortfolioQualityIssue` (metric/log-rate health alerts + discovery quality, keyed by `issueKey`). One inbox, one triage, one backlog.
+
+**3 — Surface.** The native **System Health** tab (alert banner, service grid, resource gauges, Log Issues panel), the shell-nav **health dot** (`PlatformHealthIndicator`, amber/red on every page), and the **backlog**.
+
+**4 — Manage → Resolve.** The `issue-report-triage` cron projects each issue into a tracked `BacklogItem` (`source=automated-detection`) — the "managed going forward" loop. Resolution is automatic (the issue auto-closes when its alert stops firing) or operator-driven ("Send to Build Studio as a fix" spins a fix-kind build).
+
+**Alert delivery without an Alertmanager.** The stack deliberately ships **no** Alertmanager (fewer moving parts). Instead, an `alert-delivery-bridge` Inngest cron polls firing alerts from both Prometheus (`/api/v1/alerts`) and the Loki ruler (`/prometheus/api/v1/alerts`) and upserts them into `PortfolioQualityIssue` via the same writer the webhook receiver uses; the System Health alert endpoint (`/api/platform/metrics/alerts`) merges both evaluators so the shell-nav health dot reflects log-rate alerts, not just metric alerts. New detectors reuse the existing Inngest runtime rather than adding a process.
+
+**Storm-resilient by construction.** The bridge reads **aggregated** alert state, so a container flooding 10k lines/sec yields exactly **one** `ContainerErrorLogStorm` issue, never a per-line flood. Loki's per-stream rate cap bounds disk; only *firing* alerts (past their `for:` debounce) are persisted; and reconciliation is source-attributed, so a transient Prometheus outage never false-resolves a still-firing issue.
+
+**Coverage edges (honest limits).** The platform can tell you *that* something failed and *how often*, but not yet reconstruct a single request's path across services — **distributed tracing (Tier 3) is not built**. Detection is threshold- and novelty-based, not predictive: a slow drift that never crosses a threshold and repeats an existing signature stays invisible.
+
 ### AI Provider Failure Detection and Recovery
 
 When an AI provider fails (credential expiry, rate limit exhaustion, network outage), the platform detects, adapts, and surfaces the issue through a governed cascade:

--- a/docs/index.html
+++ b/docs/index.html
@@ -588,7 +588,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         <tr><td>Identity &amp; Federation</td><td>LDAP, Active Directory, and Microsoft Entra federation for sign-in and directory bootstrap; the platform remains the source of truth for roles, route bundles, and coworker associations.</td></tr>
         <tr><td>Common Skills Library</td><td>A registry of reusable, role-bound AI skills (<code>.skill.md</code> files) declaring tools, triggers, risk band, and which coworkers can invoke them.</td></tr>
         <tr><td>Agent Interoperability</td><td>Internal coworker runtime structured around an A2A-aligned task envelope; MCP (Model Context Protocol) for tool and context interoperability.</td></tr>
-        <tr><td>Observability &amp; Evidence</td><td>Prometheus-based discovery and metrics, an append-only authorization decision log, and chain-of-custody traces linking principal, agent, tool call, approval, and outcome.</td></tr>
+        <tr><td>Observability &amp; Evidence</td><td>Full-stack monitoring &mdash; Prometheus metrics plus Loki/Alloy container-log aggregation with real-time error-storm and novel-signature detection. Every signal (metric, log, crash, user report) converges into one deduped issue inbox, auto-triaged to the backlog and reflected on a shell-nav health dot. Plus an append-only authorization decision log and chain-of-custody traces linking principal, agent, tool call, approval, and outcome.</td></tr>
         <tr><td>Hive Mind</td><td>Opt-in cross-install contribution: features built locally can be reviewed, parameterized, and shared so the next install gets them out of the box.</td></tr>
       </tbody>
     </table>
@@ -1017,9 +1017,19 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="observability">
     <h2>Observability and evidence</h2>
     <p class="sub">
-      Governance is only worth the policy if you can see what happened. The platform ships with discovery, metrics, and an append-only audit ledger so every meaningful action by a human or an agent is reviewable end-to-end. <strong>Detailed guides:</strong> <a href="/user-guide/platform/authority-and-audit">platform/authority-and-audit</a> and <a href="/user-guide/operations/infrastructure-discovery">operations/infrastructure-discovery</a>.
+      Governance is only worth the policy if you can see what happened &mdash; and the platform has to notice problems before you do. It ships with full-stack monitoring (metrics <em>and</em> container logs), proactive anomaly detection, a single deduped issue inbox that every signal converges into, and an append-only audit ledger, so anything that happens to a human or an agent is both <em>caught</em> and reviewable end-to-end. <strong>Detailed guides:</strong> <a href="/architecture/platform-overview#how-the-platform-handles-anything-that-happens">how the platform handles anything that happens</a>, <a href="/user-guide/platform/authority-and-audit">platform/authority-and-audit</a>, and <a href="/user-guide/operations/infrastructure-discovery">operations/infrastructure-discovery</a>.
     </p>
     <div class="pillars">
+      <div class="pillar">
+        <div class="tag">Log monitoring</div>
+        <strong>Full-stack logs, not just metrics.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Loki + Alloy tail every container&rsquo;s stdout/stderr &mdash; one config, cross-platform via the Docker socket, so the macOS/Windows installs that exporters can&rsquo;t cover are still watched. A Loki ruler catches error-rate spikes and storms in real time; a novel-signature scanner files an issue the first time an unseen error appears, even once. A per-stream rate cap keeps a flooding container from filling the disk.</p>
+      </div>
+      <div class="pillar">
+        <div class="tag">One issue inbox</div>
+        <strong>Every signal converges and is tracked.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Metric breaches, log storms, novel errors, in-process crashes, and user reports all land in one deduped inbox (<code>PlatformIssueReport</code> / <code>PortfolioQualityIssue</code>), auto-triage into the backlog, flip a shell-nav health dot visible on every page, and are tracked to resolution &mdash; no source gets its own parallel inbox, so the platform surfaces hidden problems without anyone watching Docker.</p>
+      </div>
       <div class="pillar">
         <div class="tag">Discovery</div>
         <strong>Prometheus-based estate inventory.</strong>


### PR DESCRIPTION
## What

Documentation for the **EP-FULL-OBS observability / issue-handling capability** — the pipeline completed by the alert-delivery bridge ([#1927](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1927), merged). Docs-only; no code.

- **`docs/architecture/platform-overview.md`** — two new sections under the monitoring stack:
  - *Layer 3b: Loki + Alloy* — the container-log capture layer (cross-platform via the Docker socket, default-on where exporters can't run), the Loki ruler **loud** path, and the novel-signature scanner **quiet** path.
  - *How the Platform Handles Anything That Happens* — the **Detect → converge-to-one-inbox → surface → manage/resolve** pipeline, the detection-source table, the **no-Alertmanager poll bridge**, storm resilience (aggregated alert state, per-stream cap, firing-only, source-attributed reconciliation), and honest coverage edges (no distributed tracing yet; detection is threshold/novelty, not predictive).
- **`docs/index.html`** (docs landing page) — broadened the Observability section intro, added **Log monitoring** and **One issue inbox** pillars, linked the new doc section, and refreshed the *Observability & Evidence* capability-table row.

Follows the "update docs with code" principle for the capability #1927 delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
