### PR TITLE
fix(watchdog): run stuck-coordinator recovery on every tick, not behind the stall early-return

### DIFF
--- a/apps/web/lib/queue/functions/taskrun-watchdog.test.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocks for the lazy + module imports the watchdog touches.
+const quiescenceFindManyMock = vi.fn();
+const transitionStateMock = vi.fn();
+const setQuiescenceLevelMock = vi.fn();
+const inngestSendMock = vi.fn();
+const isStallWatchdogEnabledMock = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    quiescenceRun: { findMany: (...a: unknown[]) => quiescenceFindManyMock(...a) },
+    // Reached only past the flag check; default-empty so the handler short-circuits.
+    buildStudioStallThreshold: { findMany: vi.fn().mockResolvedValue([]) },
+    taskRun: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+vi.mock("@/lib/self-upgrade/quiescence", () => ({
+  transitionState: (...a: unknown[]) => transitionStateMock(...a),
+  setQuiescenceLevel: (...a: unknown[]) => setQuiescenceLevelMock(...a),
+}));
+vi.mock("../inngest-client", () => ({
+  inngest: {
+    // The module calls inngest.createFunction(config, handler) at import; expose
+    // the raw handler as `.fn` so the test can invoke it directly.
+    createFunction: (_config: unknown, fn: unknown) => ({ fn }),
+    send: (...a: unknown[]) => inngestSendMock(...a),
+  },
+}));
+vi.mock("@/lib/shared/feature-flags", () => ({
+  isStallWatchdogEnabled: (...a: unknown[]) => isStallWatchdogEnabledMock(...a),
+}));
+
+import {
+  recoverStuckQuiescenceCoordinators,
+  taskrunWatchdog,
+} from "./taskrun-watchdog";
+
+const stuck = (runId: string, status = "ready-to-swap") => ({
+  runId,
+  status,
+  lastHeartbeatAt: null,
+  startedAt: new Date("2026-06-10T00:00:00.000Z"),
+});
+
+beforeEach(() => {
+  quiescenceFindManyMock.mockReset();
+  transitionStateMock.mockReset().mockResolvedValue(undefined);
+  setQuiescenceLevelMock.mockReset().mockResolvedValue(undefined);
+  inngestSendMock.mockReset().mockResolvedValue(undefined);
+  isStallWatchdogEnabledMock.mockReset().mockResolvedValue(true);
+});
+
+describe("recoverStuckQuiescenceCoordinators", () => {
+  it("reaps a stuck coordinator: fails it, resets the level, clears the queue", async () => {
+    quiescenceFindManyMock.mockResolvedValueOnce([stuck("QR-1")]);
+
+    const recovered = await recoverStuckQuiescenceCoordinators(
+      new Date("2026-06-14T00:00:00.000Z"),
+    );
+
+    expect(recovered).toBe(1);
+    expect(transitionStateMock).toHaveBeenCalledWith(
+      "QR-1",
+      "failed",
+      expect.objectContaining({ outcome: "failed", completionSource: "watchdog" }),
+    );
+    expect(setQuiescenceLevelMock).toHaveBeenCalledWith("normal", null);
+    expect(inngestSendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "platform.quiescence-cleared",
+        data: expect.objectContaining({ runId: "QR-1", reason: "watchdog-reaped" }),
+      }),
+    );
+  });
+
+  it("is a no-op when no coordinator is stuck", async () => {
+    quiescenceFindManyMock.mockResolvedValueOnce([]);
+    const recovered = await recoverStuckQuiescenceCoordinators(new Date());
+    expect(recovered).toBe(0);
+    expect(transitionStateMock).not.toHaveBeenCalled();
+    expect(setQuiescenceLevelMock).not.toHaveBeenCalled();
+    expect(inngestSendMock).not.toHaveBeenCalled();
+  });
+
+  it("is best-effort: a single failure doesn't abort the rest", async () => {
+    quiescenceFindManyMock.mockResolvedValueOnce([stuck("QR-bad"), stuck("QR-ok")]);
+    transitionStateMock
+      .mockRejectedValueOnce(new Error("db blip"))
+      .mockResolvedValue(undefined);
+
+    const recovered = await recoverStuckQuiescenceCoordinators(new Date());
+
+    expect(recovered).toBe(1); // QR-ok still reaped
+    expect(setQuiescenceLevelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a 2-minute stale cutoff (stale heartbeat OR null + old start)", async () => {
+    quiescenceFindManyMock.mockResolvedValueOnce([]);
+    const now = new Date("2026-06-14T00:10:00.000Z");
+    await recoverStuckQuiescenceCoordinators(now);
+    const where = quiescenceFindManyMock.mock.calls[0][0].where;
+    expect(where.status.notIn).toContain("completed");
+    expect(where.OR[0].lastHeartbeatAt.lt.getTime()).toBe(now.getTime() - 2 * 60 * 1000);
+  });
+});
+
+describe("taskrunWatchdog handler (the early-return fix)", () => {
+  it("runs quiescence recovery even when the stall watchdog is flag-off", async () => {
+    isStallWatchdogEnabledMock.mockResolvedValueOnce(false);
+    quiescenceFindManyMock.mockResolvedValueOnce([stuck("QR-1", "draining")]);
+
+    // Invoke the raw handler exposed by the mocked createFunction.
+    const result = await (taskrunWatchdog as unknown as { fn: () => Promise<unknown> }).fn();
+
+    // It short-circuits on flag-off, but ONLY after reaping the stuck coordinator.
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: "flag-off",
+      quiescenceRecovered: 1,
+    });
+    expect(transitionStateMock).toHaveBeenCalledWith("QR-1", "failed", expect.any(Object));
+    expect(setQuiescenceLevelMock).toHaveBeenCalledWith("normal", null);
+  });
+});

--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -30,6 +30,76 @@ import { isStallWatchdogEnabled } from "@/lib/shared/feature-flags";
 // creating a deadlock: a crashed coordinator would never be reaped.
 // Same rationale exempts selfUpgradeScheduled + selfUpgradeManual.
 
+/**
+ * BI-QUIESCE-007 (early-return fix, 2026-06-15): reap quiescence coordinators
+ * whose heartbeat went stale. A coordinator that crashes mid-protocol leaves its
+ * QuiescenceRun row non-terminal and the PlatformConfig.portal.quiescence level
+ * stuck 'draining'/'swapping', which permanently gates the entire Inngest queue
+ * (every gated cron skips; every gateBetweenSteps suspends). This forces the
+ * level back to normal and emits platform.quiescence-cleared so suspended
+ * functions wake up.
+ *
+ * Runs on EVERY watchdog tick. It previously lived inline AFTER the
+ * `decisions.length === 0` early-return, so it almost never ran — a crashed
+ * coordinator could hold the platform draining for days (root cause of the
+ * 2026-06-14 Inngest outage, only cleared by a portal reboot).
+ *
+ * Spec: docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md §5.7
+ */
+export async function recoverStuckQuiescenceCoordinators(now: Date): Promise<number> {
+  const { prisma } = await import("@dpf/db");
+  const STUCK_COORDINATOR_TIMEOUT_MS = 2 * 60 * 1000;
+  const stuckCutoff = new Date(now.getTime() - STUCK_COORDINATOR_TIMEOUT_MS);
+  const stuckCoordinators = await prisma.quiescenceRun.findMany({
+    where: {
+      status: { notIn: ["completed", "deferred", "aborted", "failed"] },
+      OR: [
+        { lastHeartbeatAt: { lt: stuckCutoff } },
+        { AND: [{ lastHeartbeatAt: null }, { startedAt: { lt: stuckCutoff } }] },
+      ],
+    },
+    select: { runId: true, status: true, lastHeartbeatAt: true, startedAt: true },
+    take: 10,
+  });
+  if (stuckCoordinators.length === 0) return 0;
+
+  const { transitionState, setQuiescenceLevel } = await import(
+    "@/lib/self-upgrade/quiescence"
+  );
+  let recovered = 0;
+  for (const sc of stuckCoordinators) {
+    try {
+      await transitionState(sc.runId, "failed", {
+        outcome: "failed",
+        completionSource: "watchdog",
+        outcomeNotes: `Watchdog reaped stuck coordinator (status=${sc.status}, lastHeartbeat=${sc.lastHeartbeatAt?.toISOString() ?? "never"})`,
+        completedAt: now,
+      });
+      await setQuiescenceLevel("normal", null);
+      await inngest.send({
+        name: "platform.quiescence-cleared",
+        data: {
+          runId: sc.runId,
+          outcome: "failed",
+          triggerRefId: null,
+          deferSurface: null,
+          reason: "watchdog-reaped",
+        },
+      });
+      recovered += 1;
+      console.warn(
+        `[taskrun-watchdog] quiescence-recovery: reaped stuck coordinator ${sc.runId} (was ${sc.status})`,
+      );
+    } catch (err) {
+      console.warn(
+        `[taskrun-watchdog] failed to reap quiescence coordinator ${sc.runId}:`,
+        err,
+      );
+    }
+  }
+  return recovered;
+}
+
 export const taskrunWatchdog = inngest.createFunction(
   {
     id: "ops/taskrun-watchdog",
@@ -38,15 +108,22 @@ export const taskrunWatchdog = inngest.createFunction(
     triggers: [cron("* * * * *")],
   },
   async () => {
+    // Reap crashed quiescence coordinators FIRST, on every tick — before any
+    // early-return. This is platform-safety, not a stall-detection feature, so
+    // it must run even when the stall watchdog is flag-off, no thresholds are
+    // seeded, or no build is stalled. (It previously sat after all three of
+    // those returns and so almost never ran — the 4-day Inngest outage.)
+    const quiescenceRecovered = await recoverStuckQuiescenceCoordinators(new Date());
+
     if (!(await isStallWatchdogEnabled())) {
-      return { skipped: true, reason: "flag-off" };
+      return { skipped: true, reason: "flag-off", quiescenceRecovered };
     }
 
     const { prisma } = await import("@dpf/db");
 
     const thresholds = await prisma.buildStudioStallThreshold.findMany();
     if (thresholds.length === 0) {
-      return { skipped: true, reason: "no-thresholds-seeded" };
+      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered };
     }
 
     // Coarse SQL filter using the smallest applicable thresholds across all
@@ -96,7 +173,7 @@ export const taskrunWatchdog = inngest.createFunction(
     }
 
     if (decisions.length === 0) {
-      return { processed: 0 };
+      return { processed: 0, quiescenceRecovered };
     }
 
     // Batch id-resolution: business taskRunId → cuid id for FK writes.
@@ -191,75 +268,6 @@ export const taskrunWatchdog = inngest.createFunction(
       }
 
       processed += 1;
-    }
-
-    // ─── BI-QUIESCE-007: stuck quiescence coordinator detection ──────────
-    //
-    // The QuiescenceRun coordinator function writes lastHeartbeatAt every
-    // ~5s during its wait loop. If a coordinator crashes between ticks the
-    // row sits in a non-terminal state forever; without intervention the
-    // PlatformConfig.portal.quiescence level would stay 'draining' /
-    // 'swapping' and the Inngest queue would be permanently blocked
-    // (every gated cron skips; every gateBetweenSteps suspends).
-    //
-    // Detection: row in non-terminal status with lastHeartbeatAt older
-    // than 2 minutes (or null + startedAt older than 2 minutes — covers
-    // rows that crashed before their first tick).
-    //
-    // Action: transition to failed (completionSource='watchdog'), force
-    // level back to normal, emit platform.quiescence-cleared so suspended
-    // Inngest functions wake up.
-    //
-    // Spec: docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md §5.7
-    const STUCK_COORDINATOR_TIMEOUT_MS = 2 * 60 * 1000;
-    const stuckCutoff = new Date(now.getTime() - STUCK_COORDINATOR_TIMEOUT_MS);
-    const stuckCoordinators = await prisma.quiescenceRun.findMany({
-      where: {
-        status: { notIn: ["completed", "deferred", "aborted", "failed"] },
-        OR: [
-          { lastHeartbeatAt: { lt: stuckCutoff } },
-          { AND: [{ lastHeartbeatAt: null }, { startedAt: { lt: stuckCutoff } }] },
-        ],
-      },
-      select: { runId: true, status: true, lastHeartbeatAt: true, startedAt: true },
-      take: 10,
-    });
-
-    let quiescenceRecovered = 0;
-    if (stuckCoordinators.length > 0) {
-      const { transitionState, setQuiescenceLevel } = await import(
-        "@/lib/self-upgrade/quiescence"
-      );
-      for (const sc of stuckCoordinators) {
-        try {
-          await transitionState(sc.runId, "failed", {
-            outcome: "failed",
-            completionSource: "watchdog",
-            outcomeNotes: `Watchdog reaped stuck coordinator (status=${sc.status}, lastHeartbeat=${sc.lastHeartbeatAt?.toISOString() ?? "never"})`,
-            completedAt: now,
-          });
-          await setQuiescenceLevel("normal", null);
-          await inngest.send({
-            name: "platform.quiescence-cleared",
-            data: {
-              runId: sc.runId,
-              outcome: "failed",
-              triggerRefId: null,
-              deferSurface: null,
-              reason: "watchdog-reaped",
-            },
-          });
-          quiescenceRecovered += 1;
-          console.warn(
-            `[taskrun-watchdog] quiescence-recovery: reaped stuck coordinator ${sc.runId} (was ${sc.status})`,
-          );
-        } catch (err) {
-          console.warn(
-            `[taskrun-watchdog] failed to reap quiescence coordinator ${sc.runId}:`,
-            err,
-          );
-        }
-      }
     }
 
     return { processed, quiescenceRecovered };


### PR DESCRIPTION
## The brittleness
The watchdog's **BI-QUIESCE-007** stuck-quiescence-coordinator recovery reaps a crashed coordinator and forces `portal.quiescence` back to `normal` so the Inngest queue isn't permanently gated. But it sat **inline, after the `decisions.length === 0` early-return** (and after the flag-off + no-thresholds returns). With no build TaskRun stalled — the common case — the watchdog returned *before* ever reaching it, so the safety net almost never ran.

**Consequence (observed 2026-06-14):** a crashed coordinator held the platform `draining`, which gated the **entire Inngest queue** (every cron skipped, every step suspended). Nothing recovered it for ~4 days until a portal reboot ran the boot reconciler. That outage is the headline brittleness from the recent incident.

## The fix
Extract the recovery to `recoverStuckQuiescenceCoordinators()` and call it **first, before any early-return** — independent of the stall-watchdog flag, threshold seeding, and stall presence (it's platform safety, not stall detection). The recovered count is threaded through every return path.

## Tests (new `taskrun-watchdog.test.ts`, 5 pass)
reap → fail/reset-level/clear-queue; no-op when none stuck; best-effort on a per-row failure; 2-minute stale cutoff; and the handler **runs recovery even when flag-off** (the regression guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)