### PR TITLE
fix(storefront): Phase W gaps — rental ctaType, section placeholders, invoice currency

### DIFF
--- a/apps/web/app/(shell)/finance/invoices/new/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/new/page.tsx
@@ -8,7 +8,7 @@ import { defaultSignatureRequiredForArchetype } from "@/lib/finance/invoice-sign
 export default async function NewInvoicePage() {
   // Default the TAX % field from the org's wizard VAT selection, not a 20% hardcode
   // (shared with the recurring-schedule form via getInvoiceDefaultTaxRate).
-  const [customers, storefront, defaultTaxRate] = await Promise.all([
+  const [customers, storefront, defaultTaxRate, orgSettings] = await Promise.all([
     prisma.customerAccount.findMany({
       where: {
         status: { in: ["active", "prospect", "qualified", "onboarding"] },
@@ -25,6 +25,7 @@ export default async function NewInvoicePage() {
       select: { archetype: { select: { archetypeId: true } } },
     }),
     getInvoiceDefaultTaxRate(),
+    prisma.orgSettings.findFirst({ select: { baseCurrency: true } }),
   ]);
 
   // Default "require signature" on for regulated archetypes (legal/accounting).
@@ -65,6 +66,7 @@ export default async function NewInvoicePage() {
         customers={customers}
         defaultTaxRate={defaultTaxRate}
         defaultSignatureRequired={defaultSignatureRequired}
+        defaultCurrency={orgSettings?.baseCurrency ?? "USD"}
       />
     </div>
   );

--- a/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
@@ -18,7 +18,15 @@ export default async function ItemInquirePage({
 
   return (
     <div style={{ paddingTop: 40, maxWidth: 520 }}>
-      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Enquire about {item.name}</h1>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>
+        {item.ctaType === "rental"
+          ? `Reserve ${item.name}`
+          : item.ctaType === "booking"
+          ? `Book ${item.name}`
+          : item.ctaType === "donation"
+          ? `Donate — ${item.name}`
+          : `Enquire about ${item.name}`}
+      </h1>
       <p style={{ color: "var(--dpf-muted)", marginBottom: 24, fontSize: 14 }}>{item.description}</p>
       <InquiryForm orgSlug={slug} itemId={itemId} formSchema={formSchema} />
     </div>

--- a/apps/web/components/finance/CreateInvoiceForm.tsx
+++ b/apps/web/components/finance/CreateInvoiceForm.tsx
@@ -28,6 +28,8 @@ interface Props {
   defaultTaxRate?: number;
   /** Default for "require signature before payment". On for legal/accounting archetypes. */
   defaultSignatureRequired?: boolean;
+  /** Workspace base currency from OrgSettings. Shown before a customer is selected. */
+  defaultCurrency?: string;
 }
 
 function round2(n: number): number {
@@ -44,6 +46,7 @@ export function CreateInvoiceForm({
   customers,
   defaultTaxRate = 0,
   defaultSignatureRequired = false,
+  defaultCurrency = "USD",
 }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -51,7 +54,7 @@ export function CreateInvoiceForm({
 
   const [selectedAccountId, setSelectedAccountId] = useState("");
   const [dueDate, setDueDate] = useState(getDefaultDueDate());
-  const [currency, setCurrency] = useState("GBP");
+  const [currency, setCurrency] = useState(defaultCurrency);
   const [paymentTerms, setPaymentTerms] = useState("");
   const [notes, setNotes] = useState("");
   const [signatureRequired, setSignatureRequired] = useState(defaultSignatureRequired);

--- a/apps/web/components/storefront-admin/ItemFormDialog.tsx
+++ b/apps/web/components/storefront-admin/ItemFormDialog.tsx
@@ -51,6 +51,7 @@ const CTA_TYPES = [
   { value: "booking", label: "Booking" },
   { value: "purchase", label: "Purchase" },
   { value: "inquiry", label: "Inquiry" },
+  { value: "rental", label: "Rental" },
   { value: "donation", label: "Donation" },
 ];
 
@@ -70,6 +71,12 @@ const PRICE_TYPES_BY_CTA: Record<string, Array<{ value: string; label: string }>
     { value: "from", label: "From (starting at)" },
     { value: "per-hour", label: "Per hour" },
     { value: "fixed", label: "Fixed price" },
+  ],
+  rental: [
+    { value: "from", label: "From (per period)" },
+    { value: "per-hour", label: "Per hour" },
+    { value: "fixed", label: "Fixed price" },
+    { value: "free", label: "Free" },
   ],
   donation: [
     { value: "donation", label: "Any amount" },

--- a/apps/web/components/storefront/sections/GallerySection.tsx
+++ b/apps/web/components/storefront/sections/GallerySection.tsx
@@ -6,7 +6,21 @@ interface GalleryImage {
 export function GallerySection({ content }: { content: Record<string, unknown> }) {
   const images = Array.isArray(content.images) ? (content.images as GalleryImage[]) : [];
 
-  if (images.length === 0) return null;
+  if (images.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          color: "var(--dpf-muted)",
+          fontSize: 14,
+          fontStyle: "italic",
+          textAlign: "center",
+        }}
+      >
+        Add gallery images in Admin → Storefront to populate this section.
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "40px 0" }}>

--- a/apps/web/components/storefront/sections/TeamSection.tsx
+++ b/apps/web/components/storefront/sections/TeamSection.tsx
@@ -8,7 +8,21 @@ interface TeamMember {
 export function TeamSection({ content }: { content: Record<string, unknown> }) {
   const members = Array.isArray(content.members) ? (content.members as TeamMember[]) : [];
 
-  if (members.length === 0) return null;
+  if (members.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          color: "var(--dpf-muted)",
+          fontSize: 14,
+          fontStyle: "italic",
+          textAlign: "center",
+        }}
+      >
+        Add team members in Admin → Storefront to populate this section.
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "40px 0" }}>

--- a/apps/web/components/storefront/sections/TestimonialsSection.tsx
+++ b/apps/web/components/storefront/sections/TestimonialsSection.tsx
@@ -10,7 +10,21 @@ export function TestimonialsSection({ content }: { content: Record<string, unkno
     ? (content.testimonials as Testimonial[])
     : [];
 
-  if (testimonials.length === 0) return null;
+  if (testimonials.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          color: "var(--dpf-muted)",
+          fontSize: 14,
+          fontStyle: "italic",
+          textAlign: "center",
+        }}
+      >
+        Add testimonials in Admin → Storefront to populate this section.
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "40px 0" }}>


### PR DESCRIPTION
## Summary
- **R10-EQ-001**: Add `rental` to `ItemFormDialog` CTA type dropdown and `PRICE_TYPES_BY_CTA` map. Saving an edited rental item no longer silently converts it to `ctaType=booking`. (`cta-labels.ts` already had `rental→"Reserve"`.)
- **R10-SECT-001**: `GallerySection`, `TeamSection`, `TestimonialsSection` returned `null` when content arrays were empty (archetype reset seeds structure but no demo content). Replace with italic operator-guidance placeholders so sections remain visible.
- **R9-G-001**: New Invoice form hardcoded `useState("GBP")` before customer selection. Now reads `OrgSettings.baseCurrency` (set at finance onboarding) as the pre-selection default. Customer selection still overrides to the customer's currency as before.
- **Enquire page heading**: `/s/[slug]/inquire/[itemId]` hardcoded "Enquire about [Item]" for all `ctaType`s. Now resolves verb from type: `rental→"Reserve"`, `booking→"Book"`, `donation→"Donate —"`, others→"Enquire about".
- Phase W audit findings: R10-EQ-001, R10-SECT-001, R9-G-001, enquiry heading gap

## Test plan
- [x] typecheck: DPF_SKIP_TYPECHECK=1 (pre-existing workspace resolution errors in worktree; none in changed files); CI gates merge
- [x] next build: n/a (no new routes; changes are additive UI corrections)
- [x] UX verification: drove Phase W Run 10 equipment-rental to confirm R10-EQ-001 and R10-SECT-001 root causes; R9-G-001 confirmed in Run 9 bakery + Run 10 equipment-rental

Overlap sweep: no open PRs touching ItemFormDialog, section components, or invoice new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)