### PR TITLE
fix(self-upgrade): reconcile stuck running + never-dispatched upgrade runs periodically in-process

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -179,6 +179,39 @@ describe("reconcileSelfUpgradeRunsOnBoot", () => {
       expect.stringContaining("deployed=actual-sha expected=expected-sha target=upstream-sha"),
     );
   });
+
+  it("on boot (no staleAfterMs) reconciles every running row with no startedAt filter", async () => {
+    getDeployedShaMock.mockResolvedValueOnce("sha");
+    selfUpgradeRunFindManyMock.mockResolvedValueOnce([]);
+
+    await reconcileSelfUpgradeRunsOnBoot({ log: vi.fn(), error: vi.fn() });
+
+    expect(selfUpgradeRunFindManyMock.mock.calls[0][0].where).toEqual({ status: "running" });
+  });
+
+  it("in periodic mode (staleAfterMs > 0) only touches runs stuck past the window, labelled watchdog-reaped", async () => {
+    getDeployedShaMock.mockResolvedValueOnce("actual-sha");
+    selfUpgradeRunFindManyMock.mockResolvedValueOnce([
+      { runId: "SUR-STUCK", deployedSha: "expected-sha", targetSha: "upstream-sha" },
+    ]);
+    failRunMock.mockResolvedValueOnce({});
+    const now = () => new Date("2026-06-14T01:00:00.000Z");
+
+    const result = await reconcileSelfUpgradeRunsOnBoot(
+      { log: vi.fn(), error: vi.fn() },
+      { staleAfterMs: 30 * 60 * 1000, now },
+    );
+
+    expect(result).toEqual({ succeeded: 0, failed: 1 });
+    // Scoped so an in-flight upgrade (started < 30m ago) is never reconciled.
+    const where = selfUpgradeRunFindManyMock.mock.calls[0][0].where;
+    expect(where.status).toBe("running");
+    expect(where.startedAt.lt.getTime()).toBe(now().getTime() - 30 * 60 * 1000);
+    expect(failRunMock).toHaveBeenCalledWith(
+      "SUR-STUCK",
+      expect.stringContaining('watchdog (stuck "running" > 30m)'),
+    );
+  });
 });
 
 describe("isStartupModelRevalidationEnabled", () => {

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -118,13 +118,29 @@ export async function syncPlatformVersionOnBoot(
  */
 export async function reconcileSelfUpgradeRunsOnBoot(
   logger: Pick<Console, "log" | "error"> = console,
+  opts: { staleAfterMs?: number; now?: () => Date } = {},
 ): Promise<{ succeeded: number; failed: number } | null> {
   try {
     const { prisma } = await import("@dpf/db");
     const { getDeployedSha } = await import("@/lib/self-upgrade/completion");
     const { completeRun, failRun } = await import("@/lib/self-upgrade/run-store");
     const deployedSha = await getDeployedSha();
-    const running = await prisma.selfUpgradeRun.findMany({ where: { status: "running" } });
+    // staleAfterMs > 0 → PERIODIC mode (called in-process on an interval, not just
+    // on boot): only touch runs stuck "running" well past a normal upgrade (~7
+    // min), so an in-flight swap is never reconciled out from under itself.
+    // staleAfterMs = 0 (boot default) reconciles every "running" row, because a
+    // boot means the orchestrating process is already gone.
+    const staleAfterMs = opts.staleAfterMs ?? 0;
+    const now = opts.now?.() ?? new Date();
+    const running = await prisma.selfUpgradeRun.findMany({
+      where:
+        staleAfterMs > 0
+          ? {
+              status: "running",
+              startedAt: { lt: new Date(now.getTime() - staleAfterMs) },
+            }
+          : { status: "running" },
+    });
     let succeeded = 0;
     let failed = 0;
     for (const run of running) {
@@ -140,7 +156,9 @@ export async function reconcileSelfUpgradeRunsOnBoot(
       } else {
         await failRun(
           run.runId,
-          `Reconciled on boot: orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`,
+          staleAfterMs > 0
+            ? `Reconciled by watchdog (stuck "running" > ${Math.round(staleAfterMs / 60000)}m): orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`
+            : `Reconciled on boot: orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`,
         );
         failed++;
         logger.log(`[self-upgrade-reconcile] ${run.runId} -> failed (orphaned)`);
@@ -464,6 +482,20 @@ export async function register() {
     // (a real upgrade recreates this very container). Records succeeded when we
     // came up on the target SHA; fails orphans so triggers aren't blocked.
     void reconcileSelfUpgradeRunsOnBoot();
+
+    // Periodic safety net — cron-independent (the boot reconcile above and the
+    // Inngest cron can BOTH miss this). If a swap's orchestrator dies while the
+    // portal stays UP (no reboot), the SelfUpgradeRun sits "running" forever and
+    // every future trigger silently no-ops (requestPortalSelfUpgradeAction). The
+    // June-10 run sat "running" for 4 days until a manual restart — this re-runs
+    // the reconcile in-process so a stuck run self-heals within ~20 min instead.
+    // Staleness-guarded so a legitimately in-flight upgrade is never touched.
+    setInterval(
+      () => {
+        void reconcileSelfUpgradeRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
+      },
+      20 * 60 * 1000,
+    );
 
     // Build Studio engine reliability (spec §3.1 engine-first / FB-78E967D4).
     // These run unconditionally — they are correctness reconcilers, not optional


### PR DESCRIPTION
## Brittleness (audit finding #1 / #5)
`reconcileSelfUpgradeRunsOnBoot` runs **once, at startup**. If a swap's orchestrator dies while the portal stays **up** (no reboot), the `SelfUpgradeRun` sits `running` forever — and `requestPortalSelfUpgradeAction` **silently no-ops** on any running row, so *every future upgrade is blocked* with no operator-visible reason. The June-10 run sat `running` for **4 days** until a manual restart (same outage).

## Fix
Add a staleness-guarded **periodic mode** (`staleAfterMs`) and call it from an in-process `setInterval` every 20 min, scoped to runs stuck `running` **> 30 min** so a legitimately in-flight upgrade (~7 min) is never reconciled out from under itself.

**In-process, not an Inngest cron — on purpose.** The incident proved the cron engine itself can die; a recovery net for the upgrade system must not depend on it. Pairs with the watchdog quiescence-coordinator fix (#1936), which covers the QuiescenceRun side.

## Tests
boot mode (every running row, no `startedAt` filter) + periodic mode (staleness filter + `watchdog (stuck "running" > 30m)` reason). 24 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)