### PR TITLE
feat(ea): BPMN process extractor — auto-extraction domain 6 (Parity Engine)

### DIFF
--- a/apps/web/lib/ea/process-extract.test.ts
+++ b/apps/web/lib/ea/process-extract.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { buildProcessModel, type ProcessStateMachine } from "./process-extract";
+
+// A small machine: new → active → {done|cancelled}; new → cancelled. done/cancelled terminal.
+const DEMO: ProcessStateMachine = {
+  key: "demo",
+  name: "Demo Lifecycle",
+  statuses: ["new", "active", "done", "cancelled"],
+  isTerminal: (s) => s === "done" || s === "cancelled",
+  canTransition: (f, t) =>
+    (f === "new" && (t === "active" || t === "cancelled")) ||
+    (f === "active" && (t === "done" || t === "cancelled")),
+};
+
+describe("buildProcessModel", () => {
+  const model = buildProcessModel([DEMO]);
+  const byKey = new Map(model.elements.map((e) => [e.sysmlKey, e]));
+  const flow = (from: string, to: string) =>
+    model.relationships.some((r) => r.fromKey === from && r.toKey === to && r.relSlug === "sequence_flow");
+
+  it("maps the machine to a process, start event, state tasks, and terminal end events", () => {
+    expect(byKey.get("proc:demo")?.typeSlug).toBe("bpmn_process");
+    expect(byKey.get("proc:demo:start")?.typeSlug).toBe("bpmn_start_event");
+    expect(byKey.get("proc:demo:state:new")?.typeSlug).toBe("bpmn_task");
+    expect(byKey.get("proc:demo:state:active")?.typeSlug).toBe("bpmn_task");
+    expect(byKey.get("proc:demo:end:done")?.typeSlug).toBe("bpmn_end_event");
+    expect(byKey.get("proc:demo:end:cancelled")?.typeSlug).toBe("bpmn_end_event");
+    // process + start + 2 tasks + 2 ends
+    expect(model.elements).toHaveLength(6);
+  });
+
+  it("starts at the no-incoming state and wires transitions as sequence flows", () => {
+    expect(flow("proc:demo:start", "proc:demo:state:new")).toBe(true); // new has no incoming → initial
+    expect(flow("proc:demo:state:new", "proc:demo:state:active")).toBe(true);
+    expect(flow("proc:demo:state:new", "proc:demo:end:cancelled")).toBe(true); // to a terminal → end node
+    expect(flow("proc:demo:state:active", "proc:demo:end:done")).toBe(true);
+    expect(flow("proc:demo:state:active", "proc:demo:end:cancelled")).toBe(true);
+    // start→new + 4 transitions
+    expect(model.relationships).toHaveLength(5);
+  });
+
+  it("emits no outgoing flow from terminal states", () => {
+    const fromTerminal = model.relationships.filter((r) => r.fromKey.startsWith("proc:demo:end:"));
+    expect(fromTerminal).toHaveLength(0);
+  });
+
+  it("namespaces nodes per machine so multiple machines don't collide", () => {
+    const two = buildProcessModel([DEMO, { ...DEMO, key: "other", name: "Other" }]);
+    expect(two.elements.some((e) => e.sysmlKey === "proc:other:state:new")).toBe(true);
+    expect(two.elements.filter((e) => e.typeSlug === "bpmn_process")).toHaveLength(2);
+  });
+
+  it("targets the bpmn20 process viewpoint and re-derives cleanly via soft-remove", () => {
+    expect(model.elementTypeSlugs).toEqual(["bpmn_process", "bpmn_start_event", "bpmn_task", "bpmn_end_event"]);
+    expect(model.relTypeSlugs).toEqual(["sequence_flow"]);
+    expect(model.view.viewpointName).toBe("Process Architecture");
+    expect(model.softRemovePrefix).toBe("proc:");
+  });
+});

--- a/apps/web/lib/ea/process-extract.ts
+++ b/apps/web/lib/ea/process-extract.ts
@@ -1,0 +1,115 @@
+// apps/web/lib/ea/process-extract.ts
+//
+// Pure extractor for the BPMN process projection (Parity Engine, domain 6). Platform
+// behaviour lives in pure transition tables (the HITL CoworkerActionEnvelope lifecycle,
+// the backlog-item lifecycle, …). This projects each such state machine into the
+// already-seeded BPMN 2.0 notation so the ACTUAL process flows are represented in a
+// notation business users know — and cannot drift, because they are re-derived from
+// the transition tables every run.
+//
+// State-machine → BPMN mapping (states-as-nodes, transitions-as-flows):
+//   - the machine         → bpmn_process (proc:<key>)
+//   - a synthetic entry   → bpmn_start_event (proc:<key>:start) → the initial state
+//   - a non-terminal state→ bpmn_task       (proc:<key>:state:<status>)
+//   - a terminal state    → bpmn_end_event  (proc:<key>:end:<status>)
+//   - a legal transition  → sequence_flow
+// This yields a valid start→…→end BPMN process per machine. The reconcile applies the
+// model under the bpmn20 notation via the shared applySysmlModel.
+
+import type { SysmlDesiredModel } from "./sysml-model-seed";
+
+export interface ProcessStateMachine {
+  /** Stable key (→ infraCiKey prefix, under "proc:"). */
+  key: string;
+  name: string;
+  statuses: readonly string[];
+  isTerminal: (status: string) => boolean;
+  /** True iff there is a real (non-self) transition from→to. */
+  canTransition: (from: string, to: string) => boolean;
+  description?: string;
+  /** Explicit entry status; otherwise derived (the no-incoming source, else statuses[0]). */
+  initial?: string;
+}
+
+const PROC_PREFIX = "proc:";
+
+function nodeKey(mKey: string, status: string, terminal: boolean): string {
+  return `${PROC_PREFIX}${mKey}:${terminal ? "end" : "state"}:${status}`;
+}
+
+/** Entry status: explicit override → the unique no-incoming status → declared first
+ *  (both platform machines list their entry status first). */
+function initialStatusOf(m: ProcessStateMachine): string | null {
+  if (!m.statuses.length) return null;
+  if (m.initial && m.statuses.includes(m.initial)) return m.initial;
+  const hasIncoming = (s: string) => m.statuses.some((f) => f !== s && m.canTransition(f, s));
+  const sources = m.statuses.filter((s) => !hasIncoming(s));
+  return sources[0] ?? m.statuses[0]!;
+}
+
+export function buildProcessModel(machines: ProcessStateMachine[]): SysmlDesiredModel {
+  const elements: SysmlDesiredModel["elements"] = [];
+  const relationships: SysmlDesiredModel["relationships"] = [];
+
+  for (const m of machines) {
+    const procKey = `${PROC_PREFIX}${m.key}`;
+    const startKey = `${PROC_PREFIX}${m.key}:start`;
+
+    elements.push({
+      sysmlKey: procKey,
+      typeSlug: "bpmn_process",
+      name: m.name,
+      description: m.description ?? `Process model auto-derived from the ${m.key} state machine.`,
+      properties: { sourceKey: `state-machine:${m.key}`, machine: m.key },
+    });
+    elements.push({
+      sysmlKey: startKey,
+      typeSlug: "bpmn_start_event",
+      name: "Start",
+      description: `Entry into the ${m.name}.`,
+      properties: { sourceKey: `state-machine:${m.key}:start`, machine: m.key },
+    });
+
+    for (const status of m.statuses) {
+      const terminal = m.isTerminal(status);
+      elements.push({
+        sysmlKey: nodeKey(m.key, status, terminal),
+        typeSlug: terminal ? "bpmn_end_event" : "bpmn_task",
+        name: status,
+        description: `${terminal ? "Terminal state" : "State"} "${status}" of the ${m.name}.`,
+        properties: { sourceKey: `state-machine:${m.key}:status:${status}`, machine: m.key, status, terminal },
+      });
+    }
+
+    const initial = initialStatusOf(m);
+    if (initial) {
+      relationships.push({ fromKey: startKey, toKey: nodeKey(m.key, initial, m.isTerminal(initial)), relSlug: "sequence_flow" });
+    }
+    for (const from of m.statuses) {
+      if (m.isTerminal(from)) continue; // terminals have no outgoing flow
+      for (const to of m.statuses) {
+        if (from === to || !m.canTransition(from, to)) continue;
+        relationships.push({
+          fromKey: nodeKey(m.key, from, false),
+          toKey: nodeKey(m.key, to, m.isTerminal(to)),
+          relSlug: "sequence_flow",
+        });
+      }
+    }
+  }
+
+  return {
+    elements,
+    relationships,
+    elementTypeSlugs: ["bpmn_process", "bpmn_start_event", "bpmn_task", "bpmn_end_event"],
+    relTypeSlugs: ["sequence_flow"],
+    view: {
+      name: "Platform Process Models — Live Projection",
+      description:
+        "Live BPMN projection of platform process state machines (HITL envelope, backlog lifecycle, …), auto-derived from their transition tables so they cannot drift from the code.",
+      viewpointName: "Process Architecture",
+      scopeRef: "process-models",
+    },
+    softRemovePrefix: PROC_PREFIX,
+  };
+}

--- a/apps/web/lib/ea/reconcile-process.test.ts
+++ b/apps/web/lib/ea/reconcile-process.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { reconcileProcessModels, PLATFORM_PROCESS_MACHINES } from "./reconcile-process";
+
+describe("reconcileProcessModels", () => {
+  it("applies the process registry under the bpmn20 notation (skips cleanly if absent)", async () => {
+    const db = { eaNotation: { findUnique: vi.fn().mockResolvedValue(null) } };
+    const r = await reconcileProcessModels({ db: db as never });
+    expect(r.status).toBe("skipped");
+    expect(db.eaNotation.findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { slug: "bpmn20" } }));
+  });
+
+  it("registers the platform state machines as well-formed descriptors", () => {
+    expect(PLATFORM_PROCESS_MACHINES.length).toBeGreaterThanOrEqual(2);
+    for (const m of PLATFORM_PROCESS_MACHINES) {
+      expect(m.statuses.length).toBeGreaterThan(0);
+      // Every machine has at least one terminal state and one live (non-terminal) state.
+      expect(m.statuses.some((s) => m.isTerminal(s))).toBe(true);
+      expect(m.statuses.some((s) => !m.isTerminal(s))).toBe(true);
+      // Self-transitions are never real BPMN edges.
+      expect(m.statuses.every((s) => !m.canTransition(s, s))).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/ea/reconcile-process.ts
+++ b/apps/web/lib/ea/reconcile-process.ts
@@ -1,0 +1,50 @@
+// apps/web/lib/ea/reconcile-process.ts
+//
+// Reconcile the platform's process state machines into a live BPMN projection (Parity
+// Engine, domain 6). The source is in-code transition tables (no external store), so
+// this always runs; it applies via the shared applySysmlModel under the already-seeded
+// bpmn20 notation. Re-derives every run, so the BPMN models cannot drift from the code.
+//
+// To add a process: register its state machine below (key, statuses, isTerminal,
+// canTransition) — the rest is automatic. db injected for tests.
+
+import { prisma } from "@dpf/db";
+import { ENVELOPE_STATUSES, TERMINAL_STATUSES, canTransition as envelopeCanTransition } from "@/lib/coworker/envelope-state-machine";
+import { BACKLOG_STATUSES, isLegalTransition } from "@/lib/backlog/transitions";
+import { buildProcessModel, type ProcessStateMachine } from "./process-extract";
+import { applySysmlModel, type SysmlSeedResult } from "./sysml-model-seed";
+
+const envelopeTerminals = new Set<string>(TERMINAL_STATUSES);
+const envelopeCan = envelopeCanTransition as (from: string, to: string) => boolean;
+const backlogCan = isLegalTransition as (from: string, to: string) => boolean;
+
+export const PLATFORM_PROCESS_MACHINES: ProcessStateMachine[] = [
+  {
+    key: "coworker-action-envelope",
+    name: "Coworker Action Envelope (PUC) Lifecycle",
+    statuses: ENVELOPE_STATUSES,
+    isTerminal: (s) => envelopeTerminals.has(s),
+    canTransition: (from, to) => from !== to && envelopeCan(from, to),
+    description:
+      "Propose → approve → execute HITL gate for effectful/destructive coworker actions (CoworkerActionEnvelope; apps/web/lib/coworker/envelope-state-machine.ts).",
+  },
+  {
+    key: "backlog-item",
+    name: "Backlog Item Lifecycle",
+    statuses: BACKLOG_STATUSES,
+    // A status is terminal iff it has no legal transition to a *different* status.
+    isTerminal: (s) => !BACKLOG_STATUSES.some((t) => t !== s && backlogCan(s, t)),
+    canTransition: (from, to) => from !== to && backlogCan(from, to),
+    description:
+      "Triage → build → done lifecycle governing every backlog item (apps/web/lib/backlog/transitions.ts).",
+  },
+];
+
+export async function reconcileProcessModels(
+  opts: { db?: typeof prisma; machines?: ProcessStateMachine[] } = {},
+): Promise<SysmlSeedResult> {
+  const machines = opts.machines ?? PLATFORM_PROCESS_MACHINES;
+  const result = await applySysmlModel(buildProcessModel(machines), { db: opts.db, notationSlug: "bpmn20" });
+  console.info(`[process-models] reconcile ${result.status}: created=${result.created} updated=${result.updated} removed=${result.removed}`);
+  return result;
+}

--- a/apps/web/lib/ea/reconcile-sysml-projections.test.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.test.ts
@@ -19,9 +19,11 @@ describe("reconcileSysmlProjections", () => {
     expect(r.valueStreams.status).toBe("skipped");
     expect(r.routes.status).toBe("skipped");
     expect(r.codeStructure.status).toBe("skipped");
-    // mcp + coworker + routes are notation-backed; value-streams checks the reference
-    // model first; code-structure checks graph freshness first.
-    expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(3);
+    expect(r.processModels.status).toBe("skipped");
+    // mcp + coworker + routes (sysml2) + process (bpmn20) are notation-backed;
+    // value-streams checks the reference model first; code-structure checks graph
+    // freshness first.
+    expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(4);
     expect(db.eaReferenceModel.findUnique).toHaveBeenCalledTimes(1);
     expect(getFreshness).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -1,10 +1,11 @@
 // apps/web/lib/ea/reconcile-sysml-projections.ts
 //
-// Combined reconcile for all auto-extracted SysML projections (Parity Engine).
+// Combined reconcile for all auto-extracted SysML/EA projections (Parity Engine).
 // Runs each domain reconcile (MCP tool authority, AI coworker workforce, IT4IT value
-// streams, Next.js route tree, source-code structure) so a single scheduled/on-demand
-// pass keeps every live projection current. Each reconcile re-derives from its source
-// registry/manifest/graph, so the projections cannot drift.
+// streams, Next.js route tree, source-code structure, platform process models) so a
+// single scheduled/on-demand pass keeps every live projection current. Each reconcile
+// re-derives from its source registry/manifest/graph/transition-table, so the
+// projections cannot drift.
 //
 // Thin orchestrator over the per-domain reconciles; db injected for tests. The
 // code-structure reconcile additionally reads the Neo4j code graph, so its graph deps
@@ -16,6 +17,7 @@ import { reconcileCoworkerAuthority } from "./reconcile-coworker-authority";
 import { reconcileValueStreams } from "./reconcile-value-streams";
 import { reconcileRoutes } from "./reconcile-routes";
 import { reconcileCodeStructure, type CodeStructureReconcileOpts } from "./reconcile-code-structure";
+import { reconcileProcessModels } from "./reconcile-process";
 import type { SysmlSeedResult } from "./sysml-model-seed";
 
 export interface SysmlProjectionsResult {
@@ -24,6 +26,7 @@ export interface SysmlProjectionsResult {
   valueStreams: SysmlSeedResult;
   routes: SysmlSeedResult;
   codeStructure: SysmlSeedResult;
+  processModels: SysmlSeedResult;
 }
 
 export async function reconcileSysmlProjections(
@@ -34,5 +37,6 @@ export async function reconcileSysmlProjections(
   const valueStreams = await reconcileValueStreams({ db: opts.db });
   const routes = await reconcileRoutes({ db: opts.db });
   const codeStructure = await reconcileCodeStructure({ db: opts.db, ...opts.codeGraph });
-  return { mcpAuthority, coworkerAuthority, valueStreams, routes, codeStructure };
+  const processModels = await reconcileProcessModels({ db: opts.db });
+  return { mcpAuthority, coworkerAuthority, valueStreams, routes, codeStructure, processModels };
 }


### PR DESCRIPTION
## Summary

The **sixth and final** auto-extraction domain — and it lands in **BPMN**, the process notation business users already know. The BPMN 2.0 notation was already seeded (`seed-ea-bpmn20.ts`); the missing piece was auto-**extraction**. Platform behaviour lives in pure transition tables, so each is projected into a live BPMN process that re-derives from the code and cannot drift.

**State-machine → BPMN mapping** (states-as-nodes):
- machine → `bpmn_process` · synthetic entry → `bpmn_start_event` → initial state · non-terminal state → `bpmn_task` · terminal state → `bpmn_end_event` · legal transition → `sequence_flow`
- Yields a valid `start → … → end` process per machine.

**Sources** (in-code, via stable exported APIs — no internal exports needed):
- the **HITL CoworkerActionEnvelope** lifecycle (`envelope-state-machine.ts`)
- the **backlog-item** lifecycle (`backlog/transitions.ts`)

A registry makes adding the next process a one-liner.

- **`process-extract.ts`** (pure): owns the mapping and derives the entry state (unique no-incoming status, else declared-first).
- **`reconcile-process.ts`**: builds the registry from the real machines, applies via the shared `applySysmlModel` under `notationSlug: "bpmn20"`; view under the existing **Process Architecture** viewpoint, `softRemovePrefix: "proc:"`.
- Wired into `reconcile-sysml-projections` so the **nightly + on-demand** passes refresh it.

## The parity engine is now complete — six auto-derived domains
tool authority · coworker workforce · value streams · routes · code structure · **process models (this PR)** — plus the CI drift gate, the converged single applier, scheduled + on-demand reconciles, and the governing kernel principle. Design↔implementation parity is a systemic, self-maintaining property across **structure, behaviour, and operating model**.

## Verified (source-local)
- **100 `apps/web/lib/ea` tests pass** — pure builder (mapping, entry derivation, terminal handling, per-machine namespacing), reconcile (bpmn20 notation + skip), and the 6-domain orchestrator.
- Touched files typecheck clean modulo the worktree-only `@dpf/db` resolution artifact (resolves in CI; same as every prior slice).
- Branched fresh off `origin/main`; overlap-swept (no EA/parity conflicts).

## Governance
`BI-EC2F115F` under `EP-PARITY-ENGINE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)