### PR TITLE
fix(crm): workspace base currency in pipeline cockpit + from-price badge on storefront cards

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -24,6 +24,7 @@ export default async function CustomerPage({
     campaignBriefsOpen,
     assetTasksOpen,
     automationCandidatesOpen,
+    orgSettings,
   ] = await Promise.all([
     prisma.customerAccount.findMany({
       orderBy: { name: "asc" },
@@ -68,6 +69,7 @@ export default async function CustomerPage({
     prisma.marketingAutomationCandidate.count({
       where: { status: "draft" },
     }),
+    prisma.orgSettings.findFirst({ select: { baseCurrency: true } }),
   ]);
 
   const revenueSummary = buildRevenueCockpitSummary({
@@ -88,6 +90,7 @@ export default async function CustomerPage({
       status: item.status,
       count: item._count,
     })),
+    currency: orgSettings?.baseCurrency ?? "USD",
     staleOpportunityCount,
     marketingWork: {
       campaignBriefsOpen,

--- a/apps/web/components/storefront/ItemCard.tsx
+++ b/apps/web/components/storefront/ItemCard.tsx
@@ -13,6 +13,7 @@ function formatPrice(item: PublicItem): string | null {
   if (!item.priceAmount && item.priceType === "free") return "Free";
   if (!item.priceAmount && item.priceType === "quote") return "POA";
   if (!item.priceAmount && item.priceType === "donation") return "Donation";
+  if (!item.priceAmount && item.priceType === "from") return "From...";
   if (!item.priceAmount) return null;
   const prefix = PRICE_PREFIX[item.priceType ?? ""] ?? "";
   const suffix = PRICE_SUFFIX[item.priceType ?? ""] ?? "";

--- a/apps/web/lib/crm/revenue-cockpit.test.ts
+++ b/apps/web/lib/crm/revenue-cockpit.test.ts
@@ -52,7 +52,7 @@ describe("revenue cockpit summary", () => {
         id: "pipeline",
         label: "Pipeline",
         value: "3",
-        detail: "£6,000 open",
+        detail: "$6,000 open",
         href: "/customer/opportunities",
         tone: "accent",
       },

--- a/apps/web/lib/crm/revenue-cockpit.ts
+++ b/apps/web/lib/crm/revenue-cockpit.ts
@@ -38,6 +38,8 @@ export type RevenueCockpitInput = {
   opportunityCounts: CountByStage[];
   quoteCounts: CountByStatus[];
   orderCounts: CountByStatus[];
+  /** Workspace base currency (from OrgSettings). Defaults to "USD" when not passed. */
+  currency?: string;
   staleOpportunityCount: number;
   marketingWork: {
     campaignBriefsOpen: number;
@@ -64,6 +66,7 @@ function countWhere(items: CountByStatus[], statuses: string[]): number {
 }
 
 export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueCockpitSummary {
+  const currency = input.currency ?? "USD";
   const engagementTotal = input.engagementCounts.reduce((sum, item) => sum + item.count, 0);
   const newEngagements = countWhere(input.engagementCounts, ["new"]);
   const openOpportunities = input.opportunityCounts.filter((item) => isOpenOpportunityStage(item.stage));
@@ -111,7 +114,7 @@ export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueC
         id: "pipeline",
         label: "Pipeline",
         value: String(pipelineCount),
-        detail: `${formatRevenueAmount(pipelineValue)} open`,
+        detail: `${formatRevenueAmount(pipelineValue, currency)} open`,
         href: "/customer/opportunities",
         tone: "accent",
       },


### PR DESCRIPTION
## Summary
- R9-G-002: Revenue cockpit pipeline detail now reads \`OrgSettings.baseCurrency\` and passes it to \`formatRevenueAmount\`; previously hardcoded GBP regardless of install locale (customer pipeline showed £ on USD installs)
- Cross-archetype from-price badge: \`ItemCard.tsx\` \`formatPrice\` now returns \`\"From...\"\` for items with \`priceType=from\` and no \`priceAmount\` set, instead of returning null and hiding the badge entirely
- Phase W audit gap fixes (R9-G-002 + cross-archetype finding)

## Test plan
- [x] vitest \`apps/web/lib/crm/revenue-cockpit.test.ts\`: 5/5 passing (updated summary test to expect USD when no currency supplied)
- [x] typecheck: pre-existing \`@dpf/db\` worktree resolution errors only (DPF_SKIP_TYPECHECK=1); CI gates merge
- [x] next build: n/a (no new page surfaces)
- [x] UX verification: functional gap confirmed from Phase W archetype audit runs R9 (retail-goods, professional-services) and R10 (marketplace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)