### PR TITLE
fix(self-upgrade): reconcile never-dispatched queued/pending runs (follow-up to #1939)

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -191,9 +191,11 @@ describe("reconcileSelfUpgradeRunsOnBoot", () => {
 
   it("in periodic mode (staleAfterMs > 0) only touches runs stuck past the window, labelled watchdog-reaped", async () => {
     getDeployedShaMock.mockResolvedValueOnce("actual-sha");
-    selfUpgradeRunFindManyMock.mockResolvedValueOnce([
-      { runId: "SUR-STUCK", deployedSha: "expected-sha", targetSha: "upstream-sha" },
-    ]);
+    selfUpgradeRunFindManyMock
+      .mockResolvedValueOnce([
+        { runId: "SUR-STUCK", deployedSha: "expected-sha", targetSha: "upstream-sha" },
+      ])
+      .mockResolvedValueOnce([]); // 2nd query: no stale queued/pending runs
     failRunMock.mockResolvedValueOnce({});
     const now = () => new Date("2026-06-14T01:00:00.000Z");
 
@@ -210,6 +212,31 @@ describe("reconcileSelfUpgradeRunsOnBoot", () => {
     expect(failRunMock).toHaveBeenCalledWith(
       "SUR-STUCK",
       expect.stringContaining('watchdog (stuck "running" > 30m)'),
+    );
+  });
+
+  it("in periodic mode also fails never-dispatched runs stuck queued/pending", async () => {
+    getDeployedShaMock.mockResolvedValueOnce("sha");
+    selfUpgradeRunFindManyMock
+      .mockResolvedValueOnce([]) // no stuck "running"
+      .mockResolvedValueOnce([{ runId: "SUR-QUEUED", status: "queued" }]);
+    failRunMock.mockResolvedValueOnce({});
+    const now = () => new Date("2026-06-14T01:00:00.000Z");
+
+    const result = await reconcileSelfUpgradeRunsOnBoot(
+      { log: vi.fn(), error: vi.fn() },
+      { staleAfterMs: 30 * 60 * 1000, now },
+    );
+
+    expect(result).toEqual({ succeeded: 0, failed: 1 });
+    // 2nd query targets never-started queued/pending rows older than the window.
+    const where = selfUpgradeRunFindManyMock.mock.calls[1][0].where;
+    expect(where.status).toEqual({ in: ["queued", "pending"] });
+    expect(where.startedAt).toBeNull();
+    expect(where.createdAt.lt.getTime()).toBe(now().getTime() - 30 * 60 * 1000);
+    expect(failRunMock).toHaveBeenCalledWith(
+      "SUR-QUEUED",
+      expect.stringContaining("dispatch never started"),
     );
   });
 });

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -164,6 +164,33 @@ export async function reconcileSelfUpgradeRunsOnBoot(
         logger.log(`[self-upgrade-reconcile] ${run.runId} -> failed (orphaned)`);
       }
     }
+
+    // In PERIODIC mode, also fail runs stuck "queued"/"pending" that never
+    // started — the dispatch event was dropped (e.g. the job engine was down),
+    // so they can never run, yet requestPortalSelfUpgradeAction silently no-ops
+    // on a queued/pending row and blocks every future upgrade. (SUR-B26DF3E4 had
+    // to be cleared by hand during the 2026-06-14 incident.) Boot mode leaves
+    // these alone — a freshly-queued run there may still be mid-dispatch.
+    if (staleAfterMs > 0) {
+      const staleQueued = await prisma.selfUpgradeRun.findMany({
+        where: {
+          status: { in: ["queued", "pending"] },
+          startedAt: null,
+          createdAt: { lt: new Date(now.getTime() - staleAfterMs) },
+        },
+      });
+      for (const run of staleQueued) {
+        await failRun(
+          run.runId,
+          `Reconciled by watchdog: dispatch never started (stuck "${run.status}" > ${Math.round(staleAfterMs / 60000)}m — the queue event was likely dropped). Re-invoke to retry.`,
+        );
+        failed++;
+        logger.log(
+          `[self-upgrade-reconcile] ${run.runId} -> failed (never-dispatched ${run.status})`,
+        );
+      }
+    }
+
     if (succeeded || failed) {
       logger.log(`[self-upgrade-reconcile] resolved ${succeeded} succeeded, ${failed} failed`);
     }


### PR DESCRIPTION
Follow-up to #1939 (which covered stuck `running` runs).

## Brittleness
A `SelfUpgradeRun` whose dispatch event was **dropped** (the job engine was down) sits `queued`/`pending` forever. `requestPortalSelfUpgradeAction` **silently no-ops** on any queued/pending row, so it **blocks every future upgrade** with no operator-visible reason — and nothing auto-recovers it (the boot/periodic reconciler only handled `running`). `SUR-B26DF3E4` had to be cleared **by hand** during the 2026-06-14 incident.

## Fix
The periodic reconcile (in-process, from #1939) now **also** fails never-started `queued`/`pending` runs older than the staleness window (`startedAt: null`, `createdAt` past the threshold), so the operator can simply re-invoke. **Boot mode is unchanged** — a freshly-queued run there may still be mid-dispatch.

## Tests
periodic mode targets never-started queued/pending rows + fails them with a `dispatch never started` reason. 25 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)