### PR TITLE
fix(routing): short-circuit eval probing on config gaps too, not just infrastructure

### DIFF
--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const evalState = vi.hoisted(() => ({
   profileUpdates: [] as Array<Record<string, unknown>>,
   callCount: 0,
+  errorMessage: "The operation was aborted due to timeout",
 }));
 
 vi.mock("@/lib/ai-inference", () => {
@@ -19,10 +20,7 @@ vi.mock("@/lib/ai-inference", () => {
     InferenceError,
     callProvider: vi.fn(async () => {
       evalState.callCount++;
-      throw new InferenceError(
-        "The operation was aborted due to timeout",
-        "network",
-      );
+      throw new InferenceError(evalState.errorMessage, "network");
     }),
   };
 });
@@ -51,6 +49,7 @@ import {
   detectDrift,
   errorLooksLikeInfrastructure,
   errorLooksLikeConfigGap,
+  errorEndsEvalCycle,
   runDimensionEval,
   type DriftResult,
 } from "./eval-runner";
@@ -187,10 +186,27 @@ describe("errorLooksLikeConfigGap (credential/setup circuit breaker)", () => {
   });
 });
 
-describe("runDimensionEval — infrastructure short-circuit", () => {
+describe("errorEndsEvalCycle (whole-endpoint short-circuit predicate)", () => {
+  it("is true for infrastructure failures", () => {
+    expect(errorEndsEvalCycle("The operation was aborted due to timeout")).toBe(true);
+    expect(errorEndsEvalCycle("fetch failed")).toBe(true);
+  });
+  it("is true for config/credential gaps", () => {
+    expect(errorEndsEvalCycle("No credential configured")).toBe(true);
+    expect(errorEndsEvalCycle("All encrypted fields failed to decrypt")).toBe(true);
+  });
+  it("is false for genuine model-quality failures (those still get scored/retired)", () => {
+    expect(errorEndsEvalCycle("schema validation failed")).toBe(false);
+    expect(errorEndsEvalCycle("Model not found on local")).toBe(false);
+    expect(errorEndsEvalCycle(null)).toBe(false);
+  });
+});
+
+describe("runDimensionEval — whole-endpoint short-circuit", () => {
   beforeEach(() => {
     evalState.profileUpdates.length = 0;
     evalState.callCount = 0;
+    evalState.errorMessage = "The operation was aborted due to timeout";
   });
 
   it("stops after the first timed-out probe instead of grinding every test", async () => {
@@ -207,6 +223,21 @@ describe("runDimensionEval — infrastructure short-circuit", () => {
 
     // A timeout is a broken probe path, not a model-quality failure — retiring
     // would strand a working-but-slow model.
+    const retired = evalState.profileUpdates.some(
+      (u) => u.modelStatus === "retired",
+    );
+    expect(retired).toBe(false);
+  });
+
+  it("also short-circuits on a config gap (rotated/missing key fails every test identically)", async () => {
+    // Regression for the gap found in live verification: a credential error is
+    // a whole-endpoint failure too, but only infrastructure errors used to
+    // short-circuit — so an uncredentialed/rotated provider flooded ~24 lines.
+    evalState.errorMessage = "No credential configured";
+
+    await runDimensionEval("gemini", "gemma-3-1b-it", "test");
+
+    expect(evalState.callCount).toBe(1);
     const retired = evalState.profileUpdates.some(
       (u) => u.modelStatus === "retired",
     );

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -81,6 +81,19 @@ export function errorLooksLikeConfigGap(error: string | null): boolean {
   return error !== null && CONFIG_ERROR_PATTERNS.some((re) => re.test(error));
 }
 
+/**
+ * Whole-endpoint failure: an error that will recur identically on EVERY test of
+ * this endpoint because it describes the endpoint/setup, not the model output —
+ * infrastructure (timeout / network / runner down) OR a config gap (missing or
+ * rotated key, OAuth not connected). When the first probe matches, the eval
+ * cycle short-circuits the remaining tests and dimensions: re-running them only
+ * reproduces the same failure, burning wall-clock and flooding the logs.
+ * Neither cause retires the model — both are fixable without touching it.
+ */
+export function errorEndsEvalCycle(error: string | null): boolean {
+  return errorLooksLikeInfrastructure(error) || errorLooksLikeConfigGap(error);
+}
+
 // ── Score Computation ────────────────────────────────────────────────────────
 
 /** Compute new dimension score from eval result and previous score. */
@@ -248,7 +261,7 @@ async function evalDimension(
   const tests = getTestsForDimension(dimension);
   const testResults: TestResult[] = [];
 
-  let infraAborted = false;
+  let endpointAborted = false;
   for (let i = 0; i < tests.length; i++) {
     if (i > 0) {
       // 500 ms between tests to avoid triggering burst rate limits
@@ -257,24 +270,25 @@ async function evalDimension(
     const result = await runGoldenTest(endpointId, modelId, tests[i]!);
     testResults.push(result);
 
-    // Infrastructure short-circuit: once the probe path itself is broken
-    // (timeout, network, runner down), every remaining test in this dimension
-    // fails identically — and each local timeout burns up to 60s plus a log
-    // line. Stop now; the dimension is inconclusive regardless. Turns ~30
-    // duplicate error lines (and minutes of wasted wall-clock) into one.
-    if (errorLooksLikeInfrastructure(result.error ?? null)) {
+    // Whole-endpoint short-circuit: once a probe fails for an endpoint/setup
+    // reason — infrastructure (timeout, network, runner down) OR a config gap
+    // (missing/rotated key) — every remaining test in this dimension fails
+    // identically. Each can burn up to 60s plus a log line. Stop now; the
+    // dimension is inconclusive regardless. Turns ~30 duplicate error lines
+    // (and minutes of wasted wall-clock) into one.
+    if (errorEndsEvalCycle(result.error ?? null)) {
       console.warn(
-        `[eval-runner] ${endpointId}/${modelId}: infrastructure error on ${dimension} — skipping remaining tests this cycle: ${result.error}`,
+        `[eval-runner] ${endpointId}/${modelId}: endpoint/setup error on ${dimension} — skipping remaining tests this cycle: ${result.error}`,
       );
-      infraAborted = true;
+      endpointAborted = true;
       break;
     }
   }
 
-  // Inconclusive when we aborted early on infrastructure (probe path broken), or
-  // when >50% of the tests that ran errored. Either way scores are preserved.
+  // Inconclusive when we aborted early on an endpoint/setup failure, or when
+  // >50% of the tests that ran errored. Either way scores are preserved.
   const errorCount = testResults.filter((r) => r.error).length;
-  const inconclusive = infraAborted || errorCount > tests.length / 2;
+  const inconclusive = endpointAborted || errorCount > tests.length / 2;
 
   if (inconclusive) {
     return {
@@ -378,18 +392,19 @@ export async function runDimensionEval(
     const result = await evalDimension(providerId, modelId, dim, previousScore, currentEvalCount);
     dimensions.push(result);
 
-    // Per-model infrastructure short-circuit: if this dimension was abandoned
-    // because the endpoint's probe path is broken (timeout/network/runner down),
-    // the remaining dimensions fail identically. Stop rather than burn another
-    // ~7 dimensions × up-to-60s timeouts. Skipped dimensions keep their previous
+    // Per-model short-circuit: if this dimension was abandoned for an
+    // endpoint/setup reason (infrastructure OR config gap — e.g. a rotated key
+    // that passed the existence pre-filter but fails at call time), the
+    // remaining dimensions fail identically. Stop rather than burn another ~7
+    // dimensions × up-to-60s timeouts. Skipped dimensions keep their previous
     // scores (they were never re-scored), and the all-inconclusive verdict below
     // still correctly avoids retiring the model.
-    const endpointUnreachable =
+    const endpointUnusable =
       result.inconclusive &&
-      result.testResults.some((t) => errorLooksLikeInfrastructure(t.error ?? null));
-    if (endpointUnreachable) {
+      result.testResults.some((t) => errorEndsEvalCycle(t.error ?? null));
+    if (endpointUnusable) {
       console.warn(
-        `[eval-runner] ${providerId}/${modelId}: endpoint unreachable this cycle — skipping remaining dimensions`,
+        `[eval-runner] ${providerId}/${modelId}: endpoint unusable this cycle — skipping remaining dimensions`,
       );
       break;
     }


### PR DESCRIPTION
## Problem (found via live verification)

After deploying #1929 + #1933, I functionally verified the eval fixes on the live install. The credential **classifier** worked perfectly (gemini with no key was correctly **not retired**). But it exposed a gap: the whole-endpoint **short-circuit** fired only on *infrastructure* errors (timeout/network), not *config-gap* errors — even though a missing/rotated credential fails **every** test identically.

Result: a direct `Run Eval` on an uncredentialed model — or, in the **scheduled** path, a **rotated key** that passes the existence pre-filter but fails to decrypt at call time — still ground through all ~24 golden tests, flooding the logs (the model was correctly not retired, but the noise remained). Observed live: `gemini/gemma-3-1b-it` logged 24 `No credential configured` lines.

## Fix

Extract `errorEndsEvalCycle = errorLooksLikeInfrastructure(e) || errorLooksLikeConfigGap(e)` and use it for **both** the per-dimension and per-model short-circuits. Any whole-endpoint failure now stops the cycle after the first probe (~1 line instead of ~24). Neither cause retires the model (scores preserved).

This also hardens the **scheduled** path against rotated keys, not just manual evals.

## Verification

- New: `errorEndsEvalCycle` unit cases + a config-gap short-circuit integration test (asserts `callProvider` invoked once, model not retired).
- **32 eval-runner tests pass**; changed file typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)