### PR TITLE
fix(storefront): seed storefront items in workspace base currency, not hardcoded GBP

### DIFF
--- a/apps/web/app/api/storefront/admin/items/route.ts
+++ b/apps/web/app/api/storefront/admin/items/route.ts
@@ -95,6 +95,8 @@ export async function POST(req: NextRequest) {
     };
   }
 
+  const orgSettingsRow = await prisma.orgSettings.findFirst({ select: { baseCurrency: true } });
+
   const item = await prisma.storefrontItem.create({
     data: {
       itemId,
@@ -105,7 +107,7 @@ export async function POST(req: NextRequest) {
       ctaType: body.ctaType,
       priceType: body.priceType ?? null,
       priceAmount: body.priceAmount != null ? body.priceAmount : null,
-      priceCurrency: body.priceCurrency ?? "GBP",
+      priceCurrency: body.priceCurrency ?? orgSettingsRow?.baseCurrency ?? "USD",
       imageUrl: body.imageUrl ?? null,
       ctaLabel: body.ctaLabel ?? null,
       ...(bookingConfig && { bookingConfig }),

--- a/apps/web/app/api/storefront/admin/setup/route.ts
+++ b/apps/web/app/api/storefront/admin/setup/route.ts
@@ -55,6 +55,9 @@ export async function POST(req: NextRequest) {
   const archetype = await prisma.storefrontArchetype.findUnique({ where: { archetypeId } });
   if (!archetype) return NextResponse.json({ error: "Archetype not found" }, { status: 400 });
 
+  const orgSettingsRow = await prisma.orgSettings.findFirst({ select: { baseCurrency: true } });
+  const seedCurrency = orgSettingsRow?.baseCurrency ?? "USD";
+
   const config = await prisma.storefrontConfig.create({
     data: {
       organizationId: org.id,
@@ -95,7 +98,7 @@ export async function POST(req: NextRequest) {
           priceAmount: t.priceAmount ?? null,
           sortOrder: i,
           isActive: true,
-          priceCurrency: "GBP",
+          priceCurrency: seedCurrency,
         })),
       },
     },

--- a/apps/web/components/storefront/ItemCard.tsx
+++ b/apps/web/components/storefront/ItemCard.tsx
@@ -1,4 +1,5 @@
 import type { PublicItem } from "@/lib/storefront-types";
+import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import { CtaButton } from "./CtaButton";
 import { MediaImage } from "./MediaImage";
 
@@ -16,7 +17,7 @@ function formatPrice(item: PublicItem): string | null {
   if (!item.priceAmount) return null;
   const prefix = PRICE_PREFIX[item.priceType ?? ""] ?? "";
   const suffix = PRICE_SUFFIX[item.priceType ?? ""] ?? "";
-  const currency = item.priceCurrency === "GBP" ? "£" : item.priceCurrency;
+  const currency = getCurrencySymbol(item.priceCurrency);
   return `${prefix}${currency}${item.priceAmount}${suffix}`;
 }
 

--- a/apps/web/lib/storefront/archetype-reset.test.ts
+++ b/apps/web/lib/storefront/archetype-reset.test.ts
@@ -58,6 +58,9 @@ describe("resetStorefrontArchetype", () => {
 
   it("re-syncs Organization.industry and BusinessContext.industry from the new archetype", async () => {
     const tx = {
+      orgSettings: {
+        findFirst: vi.fn().mockResolvedValue({ baseCurrency: "USD" }),
+      },
       organization: {
         findUnique: vi.fn().mockResolvedValue({ id: "org_1", slug: "managing-digital", email: "ops@example.com", phone: "123" }),
         update: vi.fn().mockResolvedValue({}),
@@ -123,6 +126,9 @@ describe("resetStorefrontArchetype", () => {
 
   it("replaces seeded items and sections when reset is run in replace mode", async () => {
     const tx = {
+      orgSettings: {
+        findFirst: vi.fn().mockResolvedValue({ baseCurrency: "USD" }),
+      },
       organization: {
         findUnique: vi.fn().mockResolvedValue({ id: "org_1", slug: "old-slug", email: null, phone: null }),
         update: vi.fn().mockResolvedValue({}),
@@ -193,6 +199,9 @@ describe("resetStorefrontArchetype", () => {
 
   it("preserves manually managed contact fields and org slug", async () => {
     const tx = {
+      orgSettings: {
+        findFirst: vi.fn().mockResolvedValue({ baseCurrency: "USD" }),
+      },
       organization: {
         findUnique: vi.fn().mockResolvedValue({ id: "org_1", slug: "open-digital-product-factory", email: "ops@dpf.local", phone: "555-1234" }),
         update: vi.fn().mockResolvedValue({}),

--- a/apps/web/lib/storefront/archetype-reset.ts
+++ b/apps/web/lib/storefront/archetype-reset.ts
@@ -80,6 +80,9 @@ export async function resetStorefrontArchetype(input: {
       archetypeId: targetArchetype.archetypeId,
     });
 
+    const orgSettingsRow = await tx.orgSettings.findFirst({ select: { baseCurrency: true } });
+    const seedCurrency = orgSettingsRow?.baseCurrency ?? "USD";
+
     let sectionsCreated = 0;
     let itemsCreated = 0;
 
@@ -140,7 +143,7 @@ export async function resetStorefrontArchetype(input: {
           description: item.description ?? null,
           category: item.category ?? null,
           priceType: item.priceType ?? null,
-          priceCurrency: "GBP",
+          priceCurrency: seedCurrency,
           ctaType: item.ctaType ?? targetArchetype.ctaType,
           ctaLabel: item.ctaLabel ?? null,
           sortOrder: index,

--- a/apps/web/lib/storefront/service-line-actions.ts
+++ b/apps/web/lib/storefront/service-line-actions.ts
@@ -87,6 +87,9 @@ export async function addStorefrontServiceLine(
         },
       });
 
+  const orgSettingsRow = await prisma.orgSettings.findFirst({ select: { baseCurrency: true } });
+  const seedCurrency = orgSettingsRow?.baseCurrency ?? "USD";
+
   // Seed item templates from the secondary archetype
   const itemTemplates = secondaryArchetype.itemTemplates as Array<{
     name: string;
@@ -110,7 +113,7 @@ export async function addStorefrontServiceLine(
         priceAmount: t.priceAmount ?? null,
         sortOrder: 1000 + i,
         isActive: true,
-        priceCurrency: "GBP",
+        priceCurrency: seedCurrency,
         sourceCompositionId: composition.id,
       })),
     });


### PR DESCRIPTION
## Summary
- All five paths that create `StorefrontItem` records hardcoded `priceCurrency=\"GBP\"`, causing every archetype install on a USD/EUR/etc. workspace to seed items showing GBP prices
- Fixed in: `archetype-reset.ts` (archetype switch), `setup/route.ts` (initial install), `items/route.ts` (new item via admin), `service-line-actions.ts` (secondary service line), `ItemCard.tsx` (display)
- Each seeding path now reads `OrgSettings.baseCurrency` with `\"USD\"` fallback
- `ItemCard.formatPrice` now uses `getCurrencySymbol()` so any stored currency code renders its proper symbol (USD→\$, EUR→€, CAD→C\$) instead of the raw 3-letter string
- `ItemFormDialog` default state (`priceCurrency: \"GBP\"`) is intentionally left for a follow-up PR after [#1938](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1938) merges (both branches modify the same file)
- Phase W audit cross-archetype currency gap

## Test plan
- [x] vitest `apps/web/lib/storefront`: 58 tests passing (4 pre-existing `@dpf/storefront-templates` workspace resolution failures unrelated to this change)
- [x] typecheck: pre-existing `@dpf/db` worktree resolution errors only (DPF_SKIP_TYPECHECK=1); CI gates merge
- [x] next build: n/a (no new page surfaces; ItemCard is a client component, no new routes)
- [x] UX verification: Phase W audit confirmed USD workspaces showed GBP prices on all archetype storefront cards — root cause was these seeding paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)