### PR TITLE
fix(storefront): AnimalsSection shows placeholder when no animals seeded (R10-SECT-001 extension)

### DIFF
--- a/apps/web/components/storefront/sections/AnimalsSection.tsx
+++ b/apps/web/components/storefront/sections/AnimalsSection.tsx
@@ -74,7 +74,21 @@ export function AnimalsSection({
   const legacy = Array.isArray(content.animals) ? (content.animals as LegacyAnimal[]) : [];
   const records = animals ?? [];
 
-  if (!intro && records.length === 0 && legacy.length === 0) return null;
+  if (!intro && records.length === 0 && legacy.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          color: "var(--dpf-muted)",
+          fontSize: 14,
+          fontStyle: "italic",
+          textAlign: "center",
+        }}
+      >
+        Add animals in Admin → Animals to populate this section.
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "40px 0" }}>


### PR DESCRIPTION
## Summary
- The `animals-available` section type returned `null` when no intro text, no database animals, and no legacy animals were present — the same R10-SECT-001 pattern as team/gallery/testimonials (fixed separately in [#1938](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1938))
- Animal-shelter and pet-rescue archetypes on fresh install now show a placeholder prompt instead of silently hiding the section from the public storefront
- Phase W audit gap from nonprofit-community run 16 (animal-shelter, pet-rescue)

## Test plan
- [x] vitest: n/a — no test file for this component
- [x] typecheck: pre-existing `@dpf/db` worktree resolution errors only (DPF_SKIP_TYPECHECK=1); CI gates merge
- [x] next build: n/a (no new routes)
- [x] UX verification: Phase W run 16 confirmed animals-available section absent on fresh nonprofit archetype install

🤖 Generated with [Claude Code](https://claude.com/claude-code)