### PR TITLE
feat(retention): EP-DATA-RETENTION — declarative retention registry + scheduled purge engine

### DIFF
--- a/apps/web/lib/operate/retention/constants.ts
+++ b/apps/web/lib/operate/retention/constants.ts
@@ -1,0 +1,69 @@
+// EP-DATA-RETENTION — Data retention & lifecycle governance constants.
+//
+// Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
+//
+// The scheduled-job identifiers are duplicated (intentionally — packages/db
+// cannot import from apps/web) in packages/db/src/seed-platform-retention.ts.
+// If you change one, change both, or the ScheduledJob heartbeat row will be
+// orphaned. This mirrors the postgres-backup constants convention.
+
+export const DATA_RETENTION_JOB_ID = "data-retention-sweep";
+export const DATA_RETENTION_JOB_NAME =
+  "Data retention sweep (platform-managed)";
+export const DATA_RETENTION_SCHEDULE = "daily";
+
+/** Inngest function ids. */
+export const DATA_RETENTION_SCHEDULED_INNGEST_ID =
+  "ops/data-retention-sweep-scheduled";
+export const DATA_RETENTION_REQUESTED_INNGEST_ID =
+  "ops/data-retention-sweep-requested";
+
+/** Event that triggers a one-shot manual run (operator "run now" / dry-run). */
+export const DATA_RETENTION_REQUESTED_EVENT = "ops/data-retention.requested";
+
+/** Runs at 04:00 UTC — strictly AFTER the 03:00 backup crons, so a durable
+ *  backup always exists before any row is purged. Do not move earlier. */
+export const DATA_RETENTION_CRON = "0 4 * * *";
+
+const MS_PER_DAY = 86_400_000;
+
+/** Rows fetched + deleted per batch. Keeps each DELETE small so a nightly
+ *  sweep never takes a long lock on a hot table. */
+export const RETENTION_BATCH_SIZE = 1_000;
+
+/** Upper bound on rows purged per policy per run. A fresh install with years
+ *  of accumulated logs catches up over several nights rather than issuing one
+ *  enormous delete. `capped: true` in the report flags a policy that hit it. */
+export const RETENTION_PER_POLICY_CAP = 100_000;
+
+// ── Named retention windows (days) ──────────────────────────────────────────
+// Conservative defaults. Industry floors (industry-floors.ts) may LENGTHEN
+// these; nothing shortens them. See the spec's retention matrix for rationale.
+export const DAYS_30 = 30;
+export const DAYS_90 = 90;
+export const DAYS_180 = 180;
+export const DAYS_365 = 365;
+export const DAYS_545 = 545; // ~18 months
+/** 7 years — the common statutory floor for financial / tax records. */
+export const YEARS_7_IN_DAYS = 2_555;
+/** 6 years — common HIPAA-adjacent clinical record floor. */
+export const YEARS_6_IN_DAYS = 2_190;
+/** 3 years — common public-records / general operational audit floor. */
+export const YEARS_3_IN_DAYS = 1_095;
+
+/** Returns `now - days` as the purge cutoff: rows strictly older are eligible. */
+export function cutoffForDays(days: number, now: Date): Date {
+  return new Date(now.getTime() - days * MS_PER_DAY);
+}
+
+/** Next 04:00 UTC strictly after `from` (mirrors the backup seed helper). */
+export function nextRetentionRunAt(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(4);
+  if (next <= from) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}

--- a/apps/web/lib/operate/retention/execute.ts
+++ b/apps/web/lib/operate/retention/execute.ts
@@ -1,0 +1,226 @@
+// EP-DATA-RETENTION — Generic retention purge engine.
+//
+// Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md §5
+//
+// Pure, prisma-injected, deterministic given `now`. No scheduling, no
+// ScheduledJob writes, no industry I/O here — that orchestration lives in
+// run.ts. This file just: for each PURGE_POLICY, compute the effective cutoff
+// (base widened by industry floor), then either count (dry-run) or batch-delete
+// rows older than the cutoff, bounded by a per-policy cap.
+
+import {
+  PURGE_POLICIES,
+  RETAINED_DATASETS,
+  type PurgePolicy,
+  type RetentionPrismaClient,
+} from "./policies";
+import { resolveEffectiveRetentionDays } from "./industry-floors";
+import {
+  RETENTION_BATCH_SIZE,
+  RETENTION_PER_POLICY_CAP,
+  cutoffForDays,
+} from "./constants";
+
+export interface PolicyResult {
+  model: string;
+  label: string;
+  category: string;
+  baseRetentionDays: number;
+  effectiveRetentionDays: number;
+  /** ISO cutoff: rows with timestamp < this were eligible. */
+  cutoff: string;
+  /** Rows deleted (or, in dry-run, rows that WOULD be deleted). */
+  affected: number;
+  /** True when the per-policy cap was hit (more remain for the next run). */
+  capped: boolean;
+  durationMs: number;
+  error?: string;
+}
+
+export interface RetentionSweepReport {
+  dryRun: boolean;
+  industryKey: string | null;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  /** Total rows deleted (0 in dry-run). */
+  totalAffected: number;
+  /** How many policies errored (the sweep continues past a failing policy). */
+  errorCount: number;
+  results: PolicyResult[];
+  /** Count of regulated datasets explicitly excluded from purge this run. */
+  retainedDatasetCount: number;
+}
+
+export interface RunRetentionSweepOptions {
+  prisma: RetentionPrismaClient;
+  now: Date;
+  /** When true, count only — no deletes. */
+  dryRun: boolean;
+  /** Industry/archetype key for floor widening (null = base windows). */
+  industryKey: string | null;
+  /** Test/operator overrides. */
+  batchSize?: number;
+  perPolicyCap?: number;
+  /** Restrict to a subset of policies (by model). Defaults to all. */
+  onlyModels?: string[];
+}
+
+/**
+ * Batch-delete rows older than `cutoff` using an id-windowed loop: select a page
+ * of ids matching the cutoff, delete them by id, repeat until none remain or the
+ * cap is reached. deleteMany-by-id keeps each statement small and index-friendly
+ * (PK), avoiding one giant range delete that locks the table.
+ */
+async function purgeByTimestamp(
+  policy: PurgePolicy,
+  prisma: RetentionPrismaClient,
+  cutoff: Date,
+  batchSize: number,
+  cap: number,
+): Promise<{ deleted: number; capped: boolean }> {
+  const delegate = prisma[policy.model];
+  if (!delegate) {
+    throw new Error(`Unknown Prisma model for retention policy: ${policy.model}`);
+  }
+  const baseWhere: Record<string, unknown> = {
+    [policy.timestampField]: { lt: cutoff },
+    ...(policy.extraWhere ?? {}),
+  };
+
+  let deleted = 0;
+  while (deleted < cap) {
+    const take = Math.min(batchSize, cap - deleted);
+    const rows = await delegate.findMany({
+      where: baseWhere,
+      select: { id: true },
+      take,
+    });
+    if (rows.length === 0) break;
+    const res = await delegate.deleteMany({
+      where: { id: { in: rows.map((r) => r.id) } },
+    });
+    deleted += res.count;
+    if (rows.length < take) break; // last partial page — nothing more matches
+  }
+  return { deleted, capped: deleted >= cap };
+}
+
+/** Dry-run count of rows a policy would purge. */
+async function countEligible(
+  policy: PurgePolicy,
+  prisma: RetentionPrismaClient,
+  cutoff: Date,
+  cap: number,
+): Promise<{ deleted: number; capped: boolean }> {
+  const delegate = prisma[policy.model];
+  if (!delegate) {
+    throw new Error(`Unknown Prisma model for retention policy: ${policy.model}`);
+  }
+  const count = await delegate.count({
+    where: {
+      [policy.timestampField]: { lt: cutoff },
+      ...(policy.extraWhere ?? {}),
+    },
+  });
+  return { deleted: Math.min(count, cap), capped: count > cap };
+}
+
+/** Run the full sweep across all (or a subset of) purge policies. */
+export async function runRetentionSweep(
+  opts: RunRetentionSweepOptions,
+): Promise<RetentionSweepReport> {
+  const {
+    prisma,
+    now,
+    dryRun,
+    industryKey,
+    batchSize = RETENTION_BATCH_SIZE,
+    perPolicyCap = RETENTION_PER_POLICY_CAP,
+    onlyModels,
+  } = opts;
+
+  const startedAt = now;
+  const policies = onlyModels
+    ? PURGE_POLICIES.filter((p) => onlyModels.includes(p.model))
+    : PURGE_POLICIES;
+
+  const results: PolicyResult[] = [];
+  let totalAffected = 0;
+  let errorCount = 0;
+
+  for (const policy of policies) {
+    const policyStart = Date.now();
+    const effectiveRetentionDays = resolveEffectiveRetentionDays(
+      policy,
+      industryKey,
+    );
+    const cutoff = cutoffForDays(effectiveRetentionDays, now);
+
+    try {
+      let outcome: { deleted: number; capped: boolean };
+      if (dryRun) {
+        // Custom handlers don't expose a count path; report 0 with a note in
+        // the rationale-driven docs. For dry-run we count via the timestamp
+        // field even for custom-purge policies (parent-row estimate).
+        outcome = await countEligible(policy, prisma, cutoff, perPolicyCap);
+      } else if (policy.customPurge) {
+        outcome = await policy.customPurge({
+          prisma,
+          cutoff,
+          batchSize,
+          cap: perPolicyCap,
+        });
+      } else {
+        outcome = await purgeByTimestamp(
+          policy,
+          prisma,
+          cutoff,
+          batchSize,
+          perPolicyCap,
+        );
+      }
+
+      totalAffected += outcome.deleted;
+      results.push({
+        model: policy.model,
+        label: policy.label,
+        category: policy.category,
+        baseRetentionDays: policy.baseRetentionDays,
+        effectiveRetentionDays,
+        cutoff: cutoff.toISOString(),
+        affected: outcome.deleted,
+        capped: outcome.capped,
+        durationMs: Date.now() - policyStart,
+      });
+    } catch (err) {
+      errorCount += 1;
+      results.push({
+        model: policy.model,
+        label: policy.label,
+        category: policy.category,
+        baseRetentionDays: policy.baseRetentionDays,
+        effectiveRetentionDays,
+        cutoff: cutoff.toISOString(),
+        affected: 0,
+        capped: false,
+        durationMs: Date.now() - policyStart,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Continue: one policy failing must not strand the rest of the sweep.
+    }
+  }
+
+  const finishedAt = new Date();
+  return {
+    dryRun,
+    industryKey,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: finishedAt.getTime() - startedAt.getTime(),
+    totalAffected,
+    errorCount,
+    results,
+    retainedDatasetCount: RETAINED_DATASETS.length,
+  };
+}

--- a/apps/web/lib/operate/retention/industry-floors.ts
+++ b/apps/web/lib/operate/retention/industry-floors.ts
@@ -1,0 +1,159 @@
+// EP-DATA-RETENTION — Archetype / industry retention floors.
+//
+// Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md §7
+//
+// "Research and implement what makes sense ... and archetype considerations."
+// A retention window that is fine for a coffee shop is illegal for a bank. The
+// archetype/industry an install operates as (StorefrontConfig.archetypeId →
+// category, mirrored on Organization.industry) raises the floor on certain
+// categories. Floors only ever LENGTHEN retention — effective = max(base,
+// floor) — so an industry rule can never make the platform delete sooner than a
+// regulator allows, and the conservative base always wins when no floor exists.
+//
+// Keys are archetype CATEGORY ids (the values used by Organization.industry and
+// the storefront-templates archetype categories), not leaf archetype ids, so a
+// whole industry inherits one floor set. A leaf archetype that needs more can be
+// added as its own key later.
+
+import {
+  YEARS_7_IN_DAYS,
+  YEARS_6_IN_DAYS,
+  YEARS_3_IN_DAYS,
+  DAYS_365,
+} from "./constants";
+import type { RetentionCategory, RetentionPrismaClient } from "./policies";
+
+export type IndustryRetentionFloor = Partial<Record<RetentionCategory, number>>;
+
+/**
+ * Minimum retention days per category, keyed by archetype/industry category.
+ * Sources cited in the spec's Research & Benchmarking section. These are
+ * deliberately conservative defaults an operator can extend; they encode the
+ * "many business models require 7-year financial records" requirement and its
+ * sector cousins (HIPAA ~6y clinical, public-records ~3y).
+ */
+export const INDUSTRY_RETENTION_FLOORS: Record<string, IndustryRetentionFloor> = {
+  // Banks / credit unions / lenders — BSA/AML + financial-advice record rules.
+  "banking-financial-services": {
+    "audit-log": YEARS_7_IN_DAYS,
+    "security-audit": YEARS_7_IN_DAYS,
+    "routing-log": DAYS_365,
+    "ai-telemetry": DAYS_365,
+    "coworker-chat": YEARS_7_IN_DAYS, // coworker may give financial guidance
+    "coworker-metrics": DAYS_365,
+  },
+  // Accounting / legal / consultancy — 7-year professional record norms.
+  "professional-services": {
+    "audit-log": YEARS_7_IN_DAYS,
+    "security-audit": YEARS_7_IN_DAYS,
+    "coworker-chat": YEARS_7_IN_DAYS,
+  },
+  // Clinics / dental / therapy — HIPAA-adjacent ~6-year floor.
+  "healthcare-wellness": {
+    "audit-log": YEARS_6_IN_DAYS,
+    "security-audit": YEARS_6_IN_DAYS,
+    "coworker-chat": YEARS_6_IN_DAYS,
+  },
+  // Municipal / civic — public-records-law ~3-year floor.
+  "public-sector": {
+    "audit-log": YEARS_3_IN_DAYS,
+    "security-audit": YEARS_3_IN_DAYS,
+    "coworker-chat": YEARS_3_IN_DAYS,
+  },
+};
+
+/**
+ * Aliases mapping the many ways an industry is spelled (Organization.industry
+ * is freeform / seed-derived, e.g. "financial"; archetype categories are
+ * "banking-financial-services") onto a canonical floor key. Resilience here is
+ * deliberate: a missed alias only means floors don't apply (safe — base
+ * windows + RETAINED_DATASETS still protect regulated records), never an
+ * over-eager delete.
+ */
+export const INDUSTRY_ALIASES: Record<string, string> = {
+  // banking / financial
+  financial: "banking-financial-services",
+  finance: "banking-financial-services",
+  banking: "banking-financial-services",
+  bank: "banking-financial-services",
+  "community-bank": "banking-financial-services",
+  "credit-union": "banking-financial-services",
+  "mortgage-lending": "banking-financial-services",
+  fintech: "banking-financial-services",
+  "banking-financial-services": "banking-financial-services",
+  // professional services
+  legal: "professional-services",
+  law: "professional-services",
+  "law-firm": "professional-services",
+  accounting: "professional-services",
+  consulting: "professional-services",
+  "professional-services": "professional-services",
+  // healthcare
+  health: "healthcare-wellness",
+  healthcare: "healthcare-wellness",
+  medical: "healthcare-wellness",
+  wellness: "healthcare-wellness",
+  "healthcare-wellness": "healthcare-wellness",
+  // public sector
+  government: "public-sector",
+  municipal: "public-sector",
+  civic: "public-sector",
+  "public-sector": "public-sector",
+};
+
+/**
+ * Effective retention for a policy under an install's industry.
+ * `max(base, floor)` — floors lengthen, never shorten. Unknown industry or
+ * uncovered category falls through to the policy's conservative base.
+ */
+export function resolveEffectiveRetentionDays(
+  policy: { category: RetentionCategory; baseRetentionDays: number },
+  industryKey: string | null | undefined,
+): number {
+  const floorKey = industryKey != null ? toFloorKey(industryKey) : null;
+  const floor =
+    floorKey != null
+      ? INDUSTRY_RETENTION_FLOORS[floorKey]?.[policy.category]
+      : undefined;
+  return Math.max(policy.baseRetentionDays, floor ?? 0);
+}
+
+/**
+ * Resolve the install's industry for floor lookup. DPF is single-org-per-install
+ * (project: single-org-per-install), so this reads the one Organization's
+ * industry. Returns null when unset — the conservative base windows then apply
+ * unchanged, and regulated records remain protected by RETAINED_DATASETS
+ * regardless of industry.
+ *
+ * Defensive: any read failure resolves to null (apply base windows) rather than
+ * throwing — a retention sweep must never abort because industry is unreadable.
+ */
+export async function resolveOrgIndustryKey(
+  prisma: unknown,
+): Promise<string | null> {
+  try {
+    const db = prisma as {
+      organization?: {
+        findFirst(args: unknown): Promise<{ industry: string | null } | null>;
+      };
+    };
+    const org = await db.organization?.findFirst({
+      where: { industry: { not: null } },
+      select: { industry: true },
+    });
+    return org?.industry ? toFloorKey(org.industry) : null;
+  } catch {
+    // Industry is an optimization for floors; never block a sweep on it.
+    return null;
+  }
+}
+
+/** Normalize a raw industry string to its canonical floor key (or normalized
+ *  form when no alias matches — still safe, it just won't hit a floor). */
+export function toFloorKey(raw: string): string {
+  const normalized = raw.trim().toLowerCase().replace(/[\s_]+/g, "-");
+  return INDUSTRY_ALIASES[normalized] ?? normalized;
+}
+
+// Re-export for callers that only need the type.
+export type { RetentionPrismaClient };

--- a/apps/web/lib/operate/retention/policies.ts
+++ b/apps/web/lib/operate/retention/policies.ts
@@ -1,0 +1,383 @@
+// EP-DATA-RETENTION — Declarative data-retention policy registry.
+//
+// Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
+//
+// This file is the SINGLE SOURCE OF TRUTH for what the platform purges and what
+// it must retain. It is code, not seed data, on purpose (kernel:
+// single-source-of-truth + fix-the-seed-not-the-runtime): the registry that
+// DEFINES a policy is the same artifact the engine ENFORCES, so the two can
+// never drift. Per-org tuning happens through industry floors
+// (industry-floors.ts) and the operator kill switch (ScheduledJob.enabled),
+// not by editing rows that could disagree with this code.
+//
+// Two closed axes:
+//   • PURGE_POLICIES   — accumulating operational / telemetry / log / chat
+//                        datasets that are safe to delete past a retention
+//                        window.
+//   • RETAINED_DATASETS — regulated records the platform must NOT auto-purge
+//                        (financial, tax, compliance, licensing, HR, consent).
+//                        Listed explicitly so the guard test
+//                        (retention.test.ts) fails the build if any regulated
+//                        model is ever enrolled for deletion.
+
+import {
+  DAYS_90,
+  DAYS_180,
+  DAYS_365,
+  DAYS_545,
+} from "./constants";
+
+/** Closed set of retention categories. Industry floors key off these, so the
+ *  union is shared with industry-floors.ts. Add a value here before using it. */
+export type RetentionCategory =
+  | "ai-telemetry"
+  | "audit-log"
+  | "security-audit"
+  | "routing-log"
+  | "build-log"
+  | "coworker-chat"
+  | "coworker-metrics"
+  | "skill-telemetry"
+  | "knowledge-audit"
+  | "eval-history"
+  | "inbox"
+  | "self-upgrade-log"
+  | "coordination-log";
+
+export const RETENTION_CATEGORIES: readonly RetentionCategory[] = [
+  "ai-telemetry",
+  "audit-log",
+  "security-audit",
+  "routing-log",
+  "build-log",
+  "coworker-chat",
+  "coworker-metrics",
+  "skill-telemetry",
+  "knowledge-audit",
+  "eval-history",
+  "inbox",
+  "self-upgrade-log",
+  "coordination-log",
+] as const;
+
+/** Minimal structural view of a Prisma model delegate the engine needs. Keeping
+ *  it structural (rather than importing PrismaClient) decouples the engine and
+ *  makes it trivially testable with an in-memory fake. */
+export interface RetentionModelDelegate {
+  findMany(args: {
+    where: Record<string, unknown>;
+    select: { id: true };
+    take: number;
+  }): Promise<Array<{ id: string }>>;
+  deleteMany(args: { where: Record<string, unknown> }): Promise<{ count: number }>;
+  count(args: { where: Record<string, unknown> }): Promise<number>;
+}
+
+/** Structural Prisma surface the engine + custom handlers rely on. */
+export type RetentionPrismaClient = Record<string, RetentionModelDelegate> & {
+  $transaction(operations: unknown[]): Promise<unknown[]>;
+};
+
+/** Custom purge handler for models whose children RESTRICT a plain delete (e.g.
+ *  AgentThread, whose AgentActionProposal children block a naive deleteMany).
+ *  Returns rows (or parent records) removed. */
+export type RetentionCustomPurge = (args: {
+  prisma: RetentionPrismaClient;
+  cutoff: Date;
+  batchSize: number;
+  cap: number;
+}) => Promise<{ deleted: number; capped: boolean }>;
+
+export interface PurgePolicy {
+  /** Prisma model accessor on PrismaClient, e.g. "toolExecution". */
+  model: string;
+  /** Human label for reports + the admin surface. */
+  label: string;
+  category: RetentionCategory;
+  /** Timestamp column the cutoff is applied to (varies: createdAt / startedAt /
+   *  updatedAt / detectedAt). MUST be a real column with an index — see the
+   *  purge-index migration. */
+  timestampField: string;
+  /** Base retention in days. Industry floors may LENGTHEN this, never shorten. */
+  baseRetentionDays: number;
+  /** Extra where-clause AND-ed with the cutoff (e.g. only purge READ
+   *  notifications). Optional. */
+  extraWhere?: Record<string, unknown>;
+  /** Custom cascade-correct handler; when present the generic path is bypassed. */
+  customPurge?: RetentionCustomPurge;
+  /** What it stores + why it is safe to purge past the window. */
+  rationale: string;
+}
+
+export interface RetainedDataset {
+  /** Prisma model accessor. */
+  model: string;
+  label: string;
+  /** Statutory / regulatory basis for retention (cited, not invented). */
+  regulatoryBasis: string;
+  /** Minimum the business is typically obligated to keep. */
+  minRetentionYears: number;
+}
+
+// ── Custom handlers ─────────────────────────────────────────────────────────
+
+/**
+ * Coworker chat purge. AgentThread has three child relations:
+ *   • AgentMessage   — onDelete: Cascade  (DB removes with the thread)
+ *   • AgentAttachment — onDelete: Cascade (DB removes with the thread)
+ *   • AgentActionProposal — onDelete: RESTRICT on BOTH thread + message FKs
+ * so a plain deleteMany on AgentThread throws whenever a thread ever produced a
+ * proposal. We therefore delete the proposals for the selected threads first
+ * (inside one transaction), then delete the threads — which cascades messages +
+ * attachments. Selection is by `updatedAt` (last activity), so an actively-used
+ * thread is never swept just because it is old.
+ */
+export const purgeStaleAgentThreads: RetentionCustomPurge = async ({
+  prisma,
+  cutoff,
+  batchSize,
+  cap,
+}) => {
+  let deleted = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (deleted < cap) {
+    const take = Math.min(batchSize, cap - deleted);
+    const threads = await prisma.agentThread.findMany({
+      where: { updatedAt: { lt: cutoff } },
+      select: { id: true },
+      take,
+    });
+    if (threads.length === 0) break;
+    const ids = threads.map((t) => t.id);
+    await prisma.$transaction([
+      // Remove the RESTRICT-ing children first so the thread delete is legal.
+      prisma.agentActionProposal.deleteMany({ where: { threadId: { in: ids } } }),
+      // Cascades AgentMessage + AgentAttachment via their onDelete: Cascade FKs.
+      prisma.agentThread.deleteMany({ where: { id: { in: ids } } }),
+    ]);
+    deleted += threads.length;
+    if (threads.length < take) break;
+  }
+  return { deleted, capped: deleted >= cap };
+};
+
+// ── Purge policies (enrolled accumulation surfaces) ─────────────────────────
+// Ordered roughly by growth rate. Windows are conservative; see spec §6.
+
+export const PURGE_POLICIES: readonly PurgePolicy[] = [
+  {
+    model: "toolExecution",
+    label: "Tool execution audit log",
+    category: "audit-log",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_365,
+    rationale:
+      "Every tool/capability invocation (the #1 growth driver, /platform/ai/authority audit trail). One year of operational audit; regulated industries lengthen via floors.",
+  },
+  {
+    model: "adapterRunTelemetry",
+    label: "AI adapter run telemetry",
+    category: "ai-telemetry",
+    timestampField: "startedAt",
+    baseRetentionDays: DAYS_180,
+    rationale:
+      "One row per LLM inference (probes, evals, coworker reasoning, builds). Cost/quality telemetry; running aggregates live elsewhere, so raw rows are disposable past 6 months.",
+  },
+  {
+    model: "tokenUsage",
+    label: "Token usage accounting",
+    category: "ai-telemetry",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_180,
+    rationale:
+      "Per-inference token/cost rows. Kept long enough for billing reconciliation; superseded by aggregates afterwards.",
+  },
+  {
+    model: "routeDecisionLog",
+    label: "AI routing decision log",
+    category: "routing-log",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "Endpoint-selection reasoning per coworker/task call. Debugging value decays fast; 90 days is ample.",
+  },
+  {
+    model: "authorizationDecisionLog",
+    label: "Authorization decision log",
+    category: "security-audit",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_365,
+    rationale:
+      "Every authorization decision (actor, grant, outcome). Security-audit trail; one year baseline, longer for regulated industries.",
+  },
+  {
+    model: "coworkerTurnMetric",
+    label: "Coworker turn metrics",
+    category: "coworker-metrics",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_180,
+    rationale:
+      "Per-turn latency/dispatch/tool counts. Quality telemetry; disposable past 6 months.",
+  },
+  {
+    model: "skillUsageEvent",
+    label: "Skill usage events",
+    category: "skill-telemetry",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_180,
+    rationale:
+      "Per skill invocation. Feeds the daily skill-metrics aggregator; raw rows disposable afterwards.",
+  },
+  {
+    model: "buildActivity",
+    label: "Build Studio activity log",
+    category: "build-log",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "Tool runs during a build. Operational build trail; 90 days covers post-build investigation.",
+  },
+  {
+    model: "buildDispatchAttempt",
+    label: "Build dispatch attempts",
+    category: "build-log",
+    timestampField: "startedAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "One row per AI specialist dispatch attempt/retry. Build telemetry; 90 days.",
+  },
+  {
+    model: "stallEvent",
+    label: "Build watchdog stall events",
+    category: "build-log",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "Build Studio stall detections + operator outcomes. Operational; 90 days.",
+  },
+  {
+    model: "taskEvaluation",
+    label: "Endpoint task evaluations",
+    category: "eval-history",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "Per-eval rows. Spec 2026-03-16 confirms EndpointTaskPerformance running averages are the source of truth; raw rows >90d are archivable.",
+  },
+  {
+    model: "endpointTestRun",
+    label: "Endpoint test runs",
+    category: "eval-history",
+    timestampField: "startedAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "Probe/scenario test-run summaries. Trending value is short-lived; 90 days.",
+  },
+  {
+    model: "wikiIngestEvent",
+    label: "Wiki ingest events",
+    category: "knowledge-audit",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "Knowledge-base ingest audit. Operational; 90 days.",
+  },
+  {
+    model: "notification",
+    label: "Read in-app notifications",
+    category: "inbox",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_90,
+    // Only purge notifications the user has already read. Unread ones are never
+    // swept regardless of age — they are still pending work.
+    extraWhere: { read: true },
+    rationale:
+      "Read inbox items past 90 days. Unread notifications are preserved at any age.",
+  },
+  {
+    model: "selfUpgradeRun",
+    label: "Self-upgrade run log",
+    category: "self-upgrade-log",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_365,
+    rationale:
+      "Platform self-upgrade orchestration history. Low volume but operationally valuable; one year of deployment history.",
+  },
+  {
+    model: "quiescenceRun",
+    label: "Quiescence orchestration runs",
+    category: "coordination-log",
+    timestampField: "startedAt",
+    baseRetentionDays: DAYS_90,
+    rationale:
+      "Activity-quiescence drain orchestration records. Coordination audit; 90 days.",
+  },
+  {
+    model: "agentThread",
+    label: "AI coworker chat threads",
+    category: "coworker-chat",
+    timestampField: "updatedAt",
+    baseRetentionDays: DAYS_545,
+    customPurge: purgeStaleAgentThreads,
+    rationale:
+      "Coworker conversations with no activity for ~18 months, cascading their messages + attachments. Conservative default; regulated industries lengthen via floors. Selection by last activity so active threads are never swept.",
+  },
+] as const;
+
+// ── Retained datasets (regulated — NEVER auto-purged) ───────────────────────
+// The engine never touches these. They are catalogued here so the regulatory
+// posture is explicit and the guard test can assert no overlap with
+// PURGE_POLICIES. Deletion of these, when ever needed, is a deliberate,
+// separately-governed action (legal hold release), not a scheduled sweep.
+
+export const RETAINED_DATASETS: readonly RetainedDataset[] = [
+  // Financial records — IRS/SOX-style 7-year floor.
+  { model: "invoice", label: "Invoices", regulatoryBasis: "Financial record retention (IRS / SOX-style statutory)", minRetentionYears: 7 },
+  { model: "invoiceLineItem", label: "Invoice line items", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "payment", label: "Payments", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "paymentAllocation", label: "Payment allocations", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "bill", label: "Bills (AP)", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "billLineItem", label: "Bill line items", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "billApproval", label: "Bill approvals", regulatoryBasis: "Financial controls audit (SOX)", minRetentionYears: 7 },
+  { model: "purchaseOrder", label: "Purchase orders", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "purchaseOrderLineItem", label: "PO line items", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "expenseClaim", label: "Expense claims", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "expenseItem", label: "Expense items", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  { model: "fixedAsset", label: "Fixed assets", regulatoryBasis: "Depreciation / financial record retention", minRetentionYears: 7 },
+  { model: "exchangeRate", label: "Exchange rates", regulatoryBasis: "Financial record reproducibility", minRetentionYears: 7 },
+  { model: "dunningLog", label: "Dunning log", regulatoryBasis: "Collections / financial audit", minRetentionYears: 7 },
+  { model: "storefrontOrder", label: "Storefront orders", regulatoryBasis: "Sales/financial record retention", minRetentionYears: 7 },
+  { model: "storefrontDonation", label: "Storefront donations", regulatoryBasis: "Nonprofit financial record retention", minRetentionYears: 7 },
+  { model: "rentalAgreement", label: "Rental agreements", regulatoryBasis: "Contract / financial record retention", minRetentionYears: 7 },
+
+  // Tax records.
+  { model: "taxRemittanceRun", label: "Tax remittance runs", regulatoryBasis: "Tax record retention", minRetentionYears: 7 },
+  { model: "taxDecisionSnapshot", label: "Tax decision snapshots", regulatoryBasis: "Tax record retention", minRetentionYears: 7 },
+  { model: "taxLiabilityEntry", label: "Tax liability entries", regulatoryBasis: "Tax record retention", minRetentionYears: 7 },
+  { model: "taxFilingArtifact", label: "Tax filing artifacts", regulatoryBasis: "Tax filing retention", minRetentionYears: 7 },
+
+  // Compliance / regulatory evidence.
+  { model: "complianceEvidence", label: "Compliance evidence", regulatoryBasis: "GRC evidence (per-record retentionUntil)", minRetentionYears: 7 },
+  { model: "complianceAuditLog", label: "Compliance audit log", regulatoryBasis: "Compliance change audit", minRetentionYears: 7 },
+  { model: "complianceAudit", label: "Compliance audits", regulatoryBasis: "Audit record retention", minRetentionYears: 7 },
+  { model: "auditFinding", label: "Audit findings", regulatoryBasis: "Audit record retention", minRetentionYears: 7 },
+  { model: "regulatorySubmission", label: "Regulatory submissions", regulatoryBasis: "Regulatory filing retention", minRetentionYears: 7 },
+  { model: "requirementCompletion", label: "Requirement completions", regulatoryBasis: "Training/compliance evidence", minRetentionYears: 6 },
+  { model: "policyAcknowledgment", label: "Policy acknowledgments", regulatoryBasis: "Policy compliance evidence", minRetentionYears: 6 },
+
+  // Licensing / credentials.
+  { model: "organizationLicenseRecord", label: "Org license records", regulatoryBasis: "Licensing compliance", minRetentionYears: 7 },
+  { model: "personLicenseRecord", label: "Person license records", regulatoryBasis: "Credential / licensing compliance", minRetentionYears: 7 },
+
+  // HR lifecycle.
+  { model: "employmentEvent", label: "Employment events", regulatoryBasis: "Employment record retention (varies; conservative 7y)", minRetentionYears: 7 },
+  { model: "terminationRecord", label: "Termination records", regulatoryBasis: "Employment record retention", minRetentionYears: 7 },
+
+  // Consent.
+  { model: "voiceConsentRecord", label: "Voice consent records", regulatoryBasis: "Consent provenance (GDPR/biometric)", minRetentionYears: 7 },
+] as const;
+
+/** Models the engine will purge (for guard tests + reporting). */
+export const PURGE_MODELS: readonly string[] = PURGE_POLICIES.map((p) => p.model);
+/** Regulated models the engine must never touch. */
+export const RETAINED_MODELS: readonly string[] = RETAINED_DATASETS.map((d) => d.model);

--- a/apps/web/lib/operate/retention/retention.test.ts
+++ b/apps/web/lib/operate/retention/retention.test.ts
@@ -1,0 +1,307 @@
+// EP-DATA-RETENTION — engine + registry tests.
+//
+// Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
+//
+// The load-bearing invariant: a regulated model must NEVER be enrolled for
+// automatic purge. That guard fails the build if anyone adds, say, "invoice" to
+// PURGE_POLICIES. The rest exercises floor math (industries lengthen, never
+// shorten) and the executor (batched delete, per-policy cap, dry-run count-only,
+// cascade-ordered chat handler, error isolation).
+
+import { describe, it, expect } from "vitest";
+
+import {
+  PURGE_POLICIES,
+  RETAINED_DATASETS,
+  PURGE_MODELS,
+  RETAINED_MODELS,
+  RETENTION_CATEGORIES,
+  type RetentionPrismaClient,
+} from "./policies";
+import {
+  resolveEffectiveRetentionDays,
+  toFloorKey,
+  INDUSTRY_RETENTION_FLOORS,
+} from "./industry-floors";
+import { runRetentionSweep } from "./execute";
+import { SCHEDULED_JOB_CATALOG } from "../scheduled-jobs/catalog";
+
+describe("retention registry invariants", () => {
+  it("NEVER enrolls a regulated model for purge (the load-bearing guard)", () => {
+    const overlap = PURGE_MODELS.filter((m) => RETAINED_MODELS.includes(m));
+    expect(overlap).toEqual([]);
+  });
+
+  it("retains the core financial models for at least 7 years", () => {
+    for (const model of ["invoice", "payment", "bill"]) {
+      const entry = RETAINED_DATASETS.find((d) => d.model === model);
+      expect(entry, `${model} must be a retained dataset`).toBeDefined();
+      expect(entry!.minRetentionYears).toBeGreaterThanOrEqual(7);
+    }
+  });
+
+  it("every purge policy is well-formed", () => {
+    for (const p of PURGE_POLICIES) {
+      expect(p.model.length).toBeGreaterThan(0);
+      expect(p.label.length).toBeGreaterThan(0);
+      expect(p.rationale.length).toBeGreaterThan(0);
+      expect(p.timestampField.length).toBeGreaterThan(0);
+      expect(RETENTION_CATEGORIES).toContain(p.category);
+      // Nothing is ever purged younger than a week — a tripwire against a
+      // fat-fingered tiny window deleting live data.
+      expect(p.baseRetentionDays).toBeGreaterThanOrEqual(7);
+    }
+  });
+
+  it("has no duplicate models in either axis", () => {
+    expect(new Set(PURGE_MODELS).size).toBe(PURGE_MODELS.length);
+    expect(new Set(RETAINED_MODELS).size).toBe(RETAINED_MODELS.length);
+  });
+
+  it("routes coworker chat through a cascade-correct custom handler", () => {
+    const chat = PURGE_POLICIES.find((p) => p.model === "agentThread");
+    expect(chat).toBeDefined();
+    expect(chat!.customPurge).toBeTypeOf("function");
+    expect(chat!.timestampField).toBe("updatedAt"); // last activity, not creation
+  });
+
+  it("is registered in the scheduled-jobs catalog as an editable run-now job", () => {
+    const entry = SCHEDULED_JOB_CATALOG.find(
+      (e) => e.jobId === "data-retention-sweep",
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.category).toBe("editable"); // operator can disable a destructive purge
+    expect(entry!.runNowEvent).toBe("ops/data-retention.requested");
+    expect(entry!.tracksRunData).toBe(true);
+  });
+});
+
+describe("industry / archetype retention floors", () => {
+  const auditPolicy = { category: "audit-log" as const, baseRetentionDays: 365 };
+
+  it("applies the base window when industry is null/unknown", () => {
+    expect(resolveEffectiveRetentionDays(auditPolicy, null)).toBe(365);
+    expect(resolveEffectiveRetentionDays(auditPolicy, "coffee-shop")).toBe(365);
+  });
+
+  it("lengthens audit retention to 7 years for banking", () => {
+    expect(
+      resolveEffectiveRetentionDays(auditPolicy, "banking-financial-services"),
+    ).toBe(INDUSTRY_RETENTION_FLOORS["banking-financial-services"]["audit-log"]);
+    expect(
+      resolveEffectiveRetentionDays(auditPolicy, "banking-financial-services"),
+    ).toBe(2555);
+  });
+
+  it("never shortens: a base longer than the floor wins", () => {
+    const longPolicy = { category: "audit-log" as const, baseRetentionDays: 5000 };
+    expect(
+      resolveEffectiveRetentionDays(longPolicy, "banking-financial-services"),
+    ).toBe(5000);
+  });
+
+  it("normalizes industry aliases onto the canonical floor key", () => {
+    expect(toFloorKey("financial")).toBe("banking-financial-services");
+    expect(toFloorKey("Healthcare")).toBe("healthcare-wellness");
+    expect(toFloorKey("public_sector")).toBe("public-sector");
+    // unknown stays normalized (and simply hits no floor)
+    expect(toFloorKey("Widget Co")).toBe("widget-co");
+  });
+});
+
+// ── Executor (in-memory fake prisma) ────────────────────────────────────────
+
+interface FakeModelState {
+  remaining: number;
+  log: string[];
+  calls: Array<{ op: string; where: unknown; take?: number }>;
+}
+
+function makeFakeModel(
+  name: string,
+  remaining: number,
+  sharedLog: string[],
+  opts: { throwOn?: "findMany" | "deleteMany" } = {},
+) {
+  const state: FakeModelState = { remaining, log: sharedLog, calls: [] };
+  let counter = 0;
+  const model = {
+    state,
+    async findMany({ where, take }: { where: unknown; take: number }) {
+      state.calls.push({ op: "findMany", where, take });
+      sharedLog.push(`${name}.findMany`);
+      if (opts.throwOn === "findMany") throw new Error(`${name} findMany boom`);
+      const n = Math.min(take, state.remaining);
+      return Array.from({ length: n }, () => ({ id: `${name}-${++counter}` }));
+    },
+    async deleteMany({ where }: { where: Record<string, unknown> }) {
+      state.calls.push({ op: "deleteMany", where });
+      sharedLog.push(`${name}.deleteMany`);
+      if (opts.throwOn === "deleteMany") throw new Error(`${name} deleteMany boom`);
+      const idClause = where?.id as { in?: string[] } | undefined;
+      if (idClause?.in) {
+        const n = idClause.in.length;
+        state.remaining -= n;
+        return { count: n };
+      }
+      // Non-id delete (e.g. chat proposals by threadId): doesn't drain the pool.
+      return { count: 0 };
+    },
+    async count() {
+      state.calls.push({ op: "count", where: undefined });
+      sharedLog.push(`${name}.count`);
+      return state.remaining;
+    },
+  };
+  return model;
+}
+
+function makeFakePrisma(
+  models: Record<string, number>,
+  opts: { throwOn?: Record<string, "findMany" | "deleteMany"> } = {},
+) {
+  const sharedLog: string[] = [];
+  const built: Record<string, ReturnType<typeof makeFakeModel>> = {};
+  for (const [name, remaining] of Object.entries(models)) {
+    built[name] = makeFakeModel(name, remaining, sharedLog, {
+      throwOn: opts.throwOn?.[name],
+    });
+  }
+  const prisma = {
+    ...built,
+    sharedLog,
+    async $transaction(ops: unknown[]) {
+      return Promise.all(ops as Promise<unknown>[]);
+    },
+  };
+  return prisma as unknown as RetentionPrismaClient & {
+    sharedLog: string[];
+    [k: string]: unknown;
+  };
+}
+
+describe("retention executor", () => {
+  const NOW = new Date("2026-06-14T04:00:00.000Z");
+
+  it("dry-run counts and never deletes", async () => {
+    const prisma = makeFakePrisma({ toolExecution: 42 });
+    const report = await runRetentionSweep({
+      prisma,
+      now: NOW,
+      dryRun: true,
+      industryKey: null,
+      onlyModels: ["toolExecution"],
+    });
+    expect(report.dryRun).toBe(true);
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0].affected).toBe(42);
+    expect(prisma.sharedLog).toContain("toolExecution.count");
+    expect(prisma.sharedLog).not.toContain("toolExecution.deleteMany");
+  });
+
+  it("batch-deletes all eligible rows on a real run", async () => {
+    const prisma = makeFakePrisma({ toolExecution: 2300 });
+    const report = await runRetentionSweep({
+      prisma,
+      now: NOW,
+      dryRun: false,
+      industryKey: null,
+      onlyModels: ["toolExecution"],
+      batchSize: 1000,
+      perPolicyCap: 100_000,
+    });
+    expect(report.results[0].affected).toBe(2300);
+    expect(report.results[0].capped).toBe(false);
+    // 3 delete batches: 1000 + 1000 + 300
+    const deletes = prisma.sharedLog.filter((l) => l === "toolExecution.deleteMany");
+    expect(deletes).toHaveLength(3);
+  });
+
+  it("stops at the per-policy cap and flags capped", async () => {
+    const prisma = makeFakePrisma({ toolExecution: 10_000 });
+    const report = await runRetentionSweep({
+      prisma,
+      now: NOW,
+      dryRun: false,
+      industryKey: null,
+      onlyModels: ["toolExecution"],
+      batchSize: 1000,
+      perPolicyCap: 2500,
+    });
+    expect(report.results[0].affected).toBe(2500);
+    expect(report.results[0].capped).toBe(true);
+  });
+
+  it("computes the cutoff from the industry-widened retention", async () => {
+    const prisma = makeFakePrisma({ toolExecution: 1 });
+    const report = await runRetentionSweep({
+      prisma,
+      now: NOW,
+      dryRun: false,
+      industryKey: "banking-financial-services", // audit-log floor = 2555d
+      onlyModels: ["toolExecution"],
+    });
+    expect(report.results[0].effectiveRetentionDays).toBe(2555);
+    const findManyCall = (
+      prisma.toolExecution as unknown as { state: FakeModelState }
+    ).state.calls.find((c) => c.op === "findMany");
+    const where = findManyCall!.where as { createdAt: { lt: Date } };
+    const expectedCutoff = new Date(NOW.getTime() - 2555 * 86_400_000);
+    expect(where.createdAt.lt.toISOString()).toBe(expectedCutoff.toISOString());
+  });
+
+  it("purges chat via the cascade-ordered handler: proposals before threads", async () => {
+    const prisma = makeFakePrisma({
+      agentThread: 5,
+      agentActionProposal: 0,
+    });
+    const report = await runRetentionSweep({
+      prisma,
+      now: NOW,
+      dryRun: false,
+      industryKey: null,
+      onlyModels: ["agentThread"],
+    });
+    expect(report.results[0].affected).toBe(5);
+    const log = prisma.sharedLog;
+    const proposalsAt = log.indexOf("agentActionProposal.deleteMany");
+    const threadsAt = log.indexOf("agentThread.deleteMany");
+    expect(proposalsAt).toBeGreaterThanOrEqual(0);
+    expect(threadsAt).toBeGreaterThan(proposalsAt);
+  });
+
+  it("isolates a failing policy: others still run", async () => {
+    const prisma = makeFakePrisma(
+      { toolExecution: 10, tokenUsage: 10 },
+      { throwOn: { toolExecution: "findMany" } },
+    );
+    const report = await runRetentionSweep({
+      prisma,
+      now: NOW,
+      dryRun: false,
+      industryKey: null,
+      onlyModels: ["toolExecution", "tokenUsage"],
+    });
+    expect(report.errorCount).toBe(1);
+    const failed = report.results.find((r) => r.model === "toolExecution");
+    const ok = report.results.find((r) => r.model === "tokenUsage");
+    expect(failed!.error).toBeTruthy();
+    expect(ok!.affected).toBe(10);
+  });
+
+  it("only purges read notifications (extraWhere is honored)", async () => {
+    const prisma = makeFakePrisma({ notification: 7 });
+    await runRetentionSweep({
+      prisma,
+      now: NOW,
+      dryRun: false,
+      industryKey: null,
+      onlyModels: ["notification"],
+    });
+    const findManyCall = (
+      prisma.notification as unknown as { state: FakeModelState }
+    ).state.calls.find((c) => c.op === "findMany");
+    const where = findManyCall!.where as { read?: boolean };
+    expect(where.read).toBe(true);
+  });
+});

--- a/apps/web/lib/operate/retention/run.ts
+++ b/apps/web/lib/operate/retention/run.ts
@@ -1,0 +1,128 @@
+// EP-DATA-RETENTION — Scheduled retention orchestration.
+//
+// Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md §5
+//
+// Wraps the pure engine (execute.ts) with the live-system concerns the inngest
+// function needs: the operator kill switch (ScheduledJob.enabled), industry
+// resolution for floors, and persistence of the run heartbeat + a compact,
+// durable summary of what was purged (the auditable record — ScheduledJob.metadata
+// outlives Loki's 14-day log retention).
+
+import { type Prisma } from "@dpf/db";
+
+import { runRetentionSweep, type RetentionSweepReport } from "./execute";
+import type { RetentionPrismaClient } from "./policies";
+import { resolveOrgIndustryKey } from "./industry-floors";
+import {
+  DATA_RETENTION_JOB_ID,
+  nextRetentionRunAt,
+} from "./constants";
+
+export interface ScheduledRetentionResult extends RetentionSweepReport {
+  /** True when the operator disabled the job (ScheduledJob.enabled=false). */
+  skipped?: boolean;
+  skipReason?: string;
+}
+
+/** Keep the last N per-run summaries on the heartbeat row for the admin view. */
+const MAX_RECENT_RUNS = 10;
+
+function summarizeForMetadata(report: RetentionSweepReport) {
+  const byCategory: Record<string, number> = {};
+  for (const r of report.results) {
+    byCategory[r.category] = (byCategory[r.category] ?? 0) + r.affected;
+  }
+  return {
+    at: report.finishedAt,
+    dryRun: report.dryRun,
+    industryKey: report.industryKey,
+    totalAffected: report.totalAffected,
+    errorCount: report.errorCount,
+    durationMs: report.durationMs,
+    byCategory,
+    capped: report.results.filter((r) => r.capped).map((r) => r.model),
+    errors: report.results
+      .filter((r) => r.error)
+      .map((r) => ({ model: r.model, error: r.error })),
+  };
+}
+
+/**
+ * Execute a retention sweep as the scheduled/manual job would.
+ * - Honors the operator kill switch (ScheduledJob.enabled === false → skip).
+ * - Resolves industry for floor widening.
+ * - On a real (non-dry) run, persists lastRunAt/lastStatus/nextRunAt and pushes
+ *   a compact summary onto ScheduledJob.metadata.recentRuns.
+ */
+export async function executeScheduledRetentionSweep(opts: {
+  dryRun: boolean;
+  now?: Date;
+}): Promise<ScheduledRetentionResult> {
+  const { dryRun } = opts;
+  const now = opts.now ?? new Date();
+
+  const { prisma } = await import("@dpf/db");
+  const retentionPrisma = prisma as unknown as RetentionPrismaClient;
+
+  // Operator kill switch. A destructive purge MUST be disableable without code.
+  const job = await prisma.scheduledJob
+    .findUnique({
+      where: { jobId: DATA_RETENTION_JOB_ID },
+      select: { enabled: true, metadata: true },
+    })
+    .catch(() => null);
+
+  if (job && job.enabled === false) {
+    return {
+      dryRun,
+      industryKey: null,
+      startedAt: now.toISOString(),
+      finishedAt: now.toISOString(),
+      durationMs: 0,
+      totalAffected: 0,
+      errorCount: 0,
+      results: [],
+      retainedDatasetCount: 0,
+      skipped: true,
+      skipReason: "disabled-by-operator",
+    };
+  }
+
+  const industryKey = await resolveOrgIndustryKey(prisma);
+
+  const report = await runRetentionSweep({
+    prisma: retentionPrisma,
+    now,
+    dryRun,
+    industryKey,
+  });
+
+  if (!dryRun) {
+    const prior = (job?.metadata ?? {}) as { recentRuns?: unknown[] };
+    const recentRuns = Array.isArray(prior.recentRuns) ? prior.recentRuns : [];
+    const nextRecent = [summarizeForMetadata(report), ...recentRuns].slice(
+      0,
+      MAX_RECENT_RUNS,
+    );
+
+    await prisma.scheduledJob
+      .update({
+        where: { jobId: DATA_RETENTION_JOB_ID },
+        data: {
+          lastRunAt: new Date(report.finishedAt),
+          lastStatus: report.errorCount > 0 ? "error" : "ok",
+          lastError:
+            report.errorCount > 0
+              ? `${report.errorCount} policy error(s)`
+              : null,
+          nextRunAt: nextRetentionRunAt(now),
+          metadata: { recentRuns: nextRecent } as Prisma.InputJsonValue,
+        },
+      })
+      .catch(() => {
+        // Heartbeat is best-effort; the purge itself already happened.
+      });
+  }
+
+  return report;
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -179,6 +179,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   },
   // ── Editable (operationally tunable) ──────────────────────────────────────
   {
+    jobId: "data-retention-sweep",
+    inngestId: "ops/data-retention-sweep-scheduled",
+    name: "Data retention sweep",
+    purpose:
+      "Purges aged operational logs, AI telemetry, and inactive coworker chat so the database does not grow without bound. Regulated records (financial, tax, compliance, licensing, HR, consent) are never auto-purged. Editable so an operator can disable or run-now this destructive sweep.",
+    cron: "0 4 * * *",
+    cadence: "Daily at 04:00",
+    category: "editable",
+    tracksRunData: true,
+    runNowEvent: "ops/data-retention.requested",
+  },
+  {
     jobId: "discovery-prometheus-poll",
     inngestId: "ops/prometheus-poll",
     name: "Discovery: Prometheus poll",

--- a/apps/web/lib/queue/functions/data-retention-sweep.ts
+++ b/apps/web/lib/queue/functions/data-retention-sweep.ts
@@ -1,0 +1,66 @@
+// EP-DATA-RETENTION — Scheduled data-retention sweep (inngest).
+//
+// Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
+//
+// Daily purge of accumulating operational/telemetry/log/chat data past its
+// retention window. Regulated records (financial/tax/compliance/licensing/HR/
+// consent) are never touched — see policies.ts RETAINED_DATASETS.
+//
+// Runs at 04:00 UTC, strictly AFTER the 03:00 backup crons, so a durable backup
+// always exists before any row is purged. Quiescence-gated (skips cleanly during
+// a self-upgrade drain) and concurrency-limited to one in-flight run. The
+// operator kill switch (ScheduledJob.enabled=false) is honored inside
+// executeScheduledRetentionSweep.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  DATA_RETENTION_CRON,
+  DATA_RETENTION_REQUESTED_EVENT,
+  DATA_RETENTION_SCHEDULED_INNGEST_ID,
+  DATA_RETENTION_REQUESTED_INNGEST_ID,
+} from "@/lib/operate/retention/constants";
+
+export const dataRetentionSweepScheduled = inngest.createFunction(
+  {
+    id: DATA_RETENTION_SCHEDULED_INNGEST_ID,
+    retries: 1,
+    // One sweep at a time. A still-running sweep (catching up a backlog) must
+    // not overlap the next nightly trigger.
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(DATA_RETENTION_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("data-retention-sweep", async () => {
+      const { executeScheduledRetentionSweep } = await import(
+        "@/lib/operate/retention/run"
+      );
+      return executeScheduledRetentionSweep({ dryRun: false });
+    });
+  },
+);
+
+// Manual one-shot trigger for the admin "run now" action. Supports a dry-run
+// (count-only) preview via `event.data.dryRun = true`.
+export const dataRetentionSweepRequested = inngest.createFunction(
+  {
+    id: DATA_RETENTION_REQUESTED_INNGEST_ID,
+    retries: 1,
+    triggers: [{ event: DATA_RETENTION_REQUESTED_EVENT }],
+  },
+  async ({ event, step }) => {
+    const dryRun = Boolean(
+      (event.data as { dryRun?: boolean } | undefined)?.dryRun,
+    );
+    return step.run("data-retention-sweep-manual", async () => {
+      const { executeScheduledRetentionSweep } = await import(
+        "@/lib/operate/retention/run"
+      );
+      return executeScheduledRetentionSweep({ dryRun });
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -45,6 +45,10 @@ import {
   qdrantBackupRequested,
 } from "./postgres-daily-backup";
 import { runtimeTargetJanitor } from "./runtime-target-janitor";
+import {
+  dataRetentionSweepScheduled,
+  dataRetentionSweepRequested,
+} from "./data-retention-sweep";
 import { logSignatureScanner } from "./log-signature-scanner";
 import { alertDeliveryBridge } from "./alert-delivery-bridge";
 import { releaseHealthCheck } from "./release-health-check";
@@ -73,6 +77,7 @@ export const scheduledFunctions = [
   postgresDailyBackupScheduled,
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
+  dataRetentionSweepScheduled, // EP-DATA-RETENTION: daily DB purge of aged logs/telemetry/chat, 04:00
   logSignatureScanner,   // BI-5FE8656F: EP-FULL-OBS Tier 2 novel-signature log scan, every 15m
   alertDeliveryBridge,   // BI-5FE8656F: EP-FULL-OBS Tier 2 item #6 — Prometheus+Loki firing alerts -> PortfolioQualityIssue, every 1m
   releaseHealthCheck,    // BI-3630773C: EP-FULL-OBS release stamp verify-gate watch, every 15m
@@ -102,6 +107,7 @@ export const eventFunctions = [
   qdrantBackupRequested,
   selfUpgradeManual,
   quiescenceRun,
+  dataRetentionSweepRequested, // EP-DATA-RETENTION: operator "run now" / dry-run
 ];
 
 export const allFunctions = [...scheduledFunctions, ...eventFunctions];

--- a/docs/superpowers/plans/2026-06-14-data-retention-lifecycle-governance.md
+++ b/docs/superpowers/plans/2026-06-14-data-retention-lifecycle-governance.md
@@ -1,0 +1,49 @@
+# Data Retention & Lifecycle Governance — Implementation Plan
+
+- **Date:** 2026-06-14
+- **Epic:** EP-DATA-RETENTION
+- **Spec:** [`docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md`](../specs/2026-06-14-data-retention-lifecycle-governance-design.md)
+
+This plan is phased so each slice is independently shippable and verifiable. Slice 1 is implemented in this PR.
+
+## Phase 1 — Foundation: registry + engine + scheduled purge (DONE — this PR)
+
+1. **Policy registry** — `apps/web/lib/operate/retention/policies.ts`: `PURGE_POLICIES` (17 enrolled datasets), `RETAINED_DATASETS` (regulated holds), `RetentionCategory` union, cascade-correct chat handler.
+2. **Industry floors** — `industry-floors.ts`: `INDUSTRY_RETENTION_FLOORS`, `resolveEffectiveRetentionDays` (max, never shorten), `resolveOrgIndustryKey` + alias map.
+3. **Engine** — `execute.ts`: `runRetentionSweep` (batched id-windowed delete, per-policy cap, dry-run count, custom handler, error isolation).
+4. **Orchestration** — `run.ts`: kill switch, industry resolve, `ScheduledJob` heartbeat + rolling summary.
+5. **Scheduled job** — `queue/functions/data-retention-sweep.ts` (cron `0 4 * * *` after backups; manual event); registered in `functions/index.ts`; catalogued (editable, run-now) in `scheduled-jobs/catalog.ts`; `ScheduledJob` row seeded via `seed-platform-retention.ts` + `seed.ts`.
+6. **Indexes** — migration `20260614180000_add_data_retention_purge_indexes` (12 single-column purge indexes).
+7. **Tests** — `retention.test.ts` (17) + existing `scheduled-jobs.test.ts` (9) green.
+
+**Exit criteria (met):** unit tests + typecheck + `prisma validate` green in the worktree; production build + migration apply + first live sweep verified via CI / shared local-CI lease per §5.
+
+## Phase 2 — Consolidate ad-hoc purges
+
+- Move `ModelCapabilityChangeLog` 90d prune out of `reconcile-catalog-capabilities.ts` into a `PURGE_POLICIES` entry.
+- Move device-session cleanup out of `infra-prune.ts` (or have it delegate to the registry).
+- Goal: one source of truth; retire bespoke `deleteMany` calls. Add a lint/test discouraging new ad-hoc date-based deletes outside the registry.
+
+## Phase 3 — Status-aware datasets
+
+- Enroll `TaskRun` + cascaded children (`TaskMessage`, `TaskArtifact`, `TaskNode`) and `DecisionInteraction` with terminal-state-aware selection (only completed/failed runs past the window). Needs custom handlers (joins + cascade ordering) like the chat handler.
+
+## Phase 4 — Admin UX
+
+- Surface the retention matrix, effective (industry-widened) windows, last-run summary (`ScheduledJob.metadata.recentRuns`), and a dry-run preview button on the Scheduled Jobs admin surface. `tracksRunData` is already true.
+
+## Phase 5 — Archival + erasure
+
+- Export-then-delete cold-storage tier for categories that need recoverability.
+- GDPR right-to-be-forgotten flows over chat/PII (anonymize vs delete), distinct from time-based retention.
+
+## Phase 6 — Scale strategy
+
+- Add a per-policy `strategy: "delete" | "partition-drop"`; route the largest tables to time-range partitioning + partition drop (pg_partman-style) when an install's volume warrants it. Registry-level change; callers unaffected.
+
+## Risks & mitigations
+
+- **Large first run on an aged install** → per-policy cap + nightly catch-up; `capped` reported.
+- **Deleting wanted data** → conservative base windows, regulated-exclusion guard test, dry-run, kill switch, backup-before-purge ordering.
+- **Index build lock on huge tables** → for very large existing installs, create the purge indexes `CONCURRENTLY` out-of-band before enabling the sweep (noted in the migration comment); young installs are unaffected.
+- **Industry misclassification** → floors only lengthen; regulated records protected regardless; null industry = safe base windows.

--- a/docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
+++ b/docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
@@ -1,0 +1,166 @@
+# Data Retention & Lifecycle Governance — Design
+
+- **Date:** 2026-06-14
+- **Status:** Slice 1 implemented (this PR); follow-up slices specified below
+- **Epic:** EP-DATA-RETENTION — Data Retention & Lifecycle Governance
+- **Author:** Platform engineering (Claude, direct-implementation per Build-Studio-rearchitecture override)
+
+## 1. Problem
+
+The platform writes to dozens of append-only tables that grow without bound: tool/authority audit logs, AI adapter telemetry, routing decisions, build-dispatch logs, self-upgrade history, coworker chat, notifications, eval runs, skill/wiki events, coworker turn metrics, and more. The two busiest (`ToolExecution`, `AdapterRunTelemetry`) gain a row on **every** tool call and **every** LLM inference respectively. With no application-database retention, an install's Postgres grows monotonically until it degrades query performance and eventually exhausts disk — a guaranteed "down the line" failure.
+
+Two existing retention mechanisms cover only the edges:
+
+- **Observability stack** — Loki logs (`retention_period: 336h`, 14d) and Prometheus TSDB (`--storage.tsdb.retention.time=15d`) already self-prune. These are the LGTM stack, **not** the application database.
+- **Ad-hoc purges** — `runtime-target-janitor` (lease/heartbeat expiry), `infra-prune` (stale CIs + device sessions), and `reconcile-catalog-capabilities` (prunes `ModelCapabilityChangeLog` > 90d). These are scattered, table-specific, and cover a tiny fraction of the accumulation surface.
+
+There is **no** unified retention policy, **no** scheduled purge across the high-volume tables, and **no** explicit regulatory-hold posture (financial records that many business models must keep for 7 years sit in the same database with no protection guaranteeing they are *not* deleted, and no guarantee the rest *is*).
+
+This design adds a single declarative retention policy registry, a generic scheduled purge engine, regulatory holds, and archetype/industry-aware retention floors.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- One declarative source of truth for "what we purge, how long we keep it, and what we must never delete."
+- A daily, governed, operator-controllable scheduled purge across the highest-volume accumulation surfaces.
+- Hard protection for regulated records (financial, tax, compliance, licensing, HR, consent) — never auto-purged.
+- Archetype/industry awareness: a bank or clinic automatically retains audit/chat longer than a coffee shop; floors only ever **lengthen** retention.
+- Performance: every enrolled purge is index-driven (no nightly full-table scans).
+- Safety: purge runs after backups, in batches, under a per-policy cap, with a dry-run mode and an operator kill switch.
+
+**Non-goals (this slice)**
+- Archival/cold-storage tiering (export-then-delete). Slice 1 deletes; archival is a future slice.
+- Per-org, admin-editable retention windows in the DB. Slice 1 windows are code-defined (auditable, drift-free); industry floors + the kill switch provide per-install variance.
+- Purging `TaskRun`/`TaskMessage`/`DecisionInteraction` (status-aware, needs join logic) — future slice.
+- Anonymization/pseudonymization as an alternative to deletion — future slice (GDPR erasure flows).
+
+## 3. Research & Benchmarking
+
+Comparison of how mature systems model data lifecycle, reading their mechanisms (not just feature lists).
+
+### Open source
+- **Grafana Loki** (already in our stack) — time-window retention via a compactor that deletes chunks older than `retention_period`, with optional per-stream overrides. **Adopted:** the "delete strictly older than a cutoff" model and per-category windows. **Rejected:** stream-label-based overrides (our categories are coarser).
+- **PostHog / ClickHouse TTL** — declarative `TTL eventTime + INTERVAL n DAY` on the table; the engine reclaims expired rows in background merges. **Adopted:** declarative per-dataset windows. **Rejected:** engine-native TTL — Postgres has no row TTL, and a per-table TTL column is invasive vs. a central registry.
+- **pg_partman (Postgres partitioning + retention)** — time-range partitions with automatic drop of old partitions (metadata-only, near-instant vs. row `DELETE`). **Adopted as a future option** for the very largest tables at scale. **Rejected for slice 1:** partitioning every hot table is a heavy schema change unjustified for young installs; batched `DELETE` on an index is sufficient now and the registry can later route a table to a partition-drop strategy without changing callers.
+- **ServiceNow Table Cleanup / Table Rotation** (commercial-OSS-adjacent reference) — scheduled jobs delete (cleanup) or rotate (rolling partitions) records per a per-table policy table. **Adopted:** the central per-table policy + scheduled executor pattern, and the cleanup-vs-rotation distinction (we start with cleanup).
+
+### Commercial
+- **Datadog / Splunk** — tiered retention; Splunk `frozenTimePeriodInSecs` per index; Datadog configurable log retention + 15-month metrics. **Adopted:** category-tiered windows (telemetry short, audit long).
+- **AWS S3 Lifecycle / DynamoDB TTL** — declarative per-object/item expiry with a managed sweeper. **Adopted:** declarative intent separated from the execution engine.
+- **Financial/records regimes (IRS, SOX, HIPAA, GDPR)** — IRS/SOX → ~7-year financial-record retention; HIPAA → ~6-year clinical; GDPR → storage-limitation + erasure. **Adopted:** the regulated-hold list with cited bases, and industry floors keyed to sector.
+
+### Patterns adopted
+1. Declarative per-dataset policy, central registry, generic executor (ServiceNow, S3, DynamoDB).
+2. Delete-older-than-cutoff with category-tiered windows (Loki, Splunk, Datadog).
+3. Regulated-hold exclusion with statutory basis (IRS/SOX/HIPAA/GDPR).
+4. Industry-aware floors that only lengthen (sector record-keeping law).
+
+### Anti-patterns identified (and what we do instead)
+- **Silent unbounded growth** (current state) → scheduled bounded purge.
+- **Scattered ad-hoc `deleteMany`** (`infra-prune`, `reconcile-catalog`) → one registry; existing ad-hoc purges flagged for consolidation (§9).
+- **Purge without a backup** → schedule the sweep *after* the daily backups.
+- **Hard-coded windows with no operator escape** → kill switch + dry-run + caps.
+
+## 4. Architecture overview
+
+```
+PURGE_POLICIES (policies.ts)  ─┐
+RETAINED_DATASETS (policies.ts)│  declarative registry (single source of truth)
+INDUSTRY_RETENTION_FLOORS ─────┘  (industry-floors.ts)
+            │
+            ▼
+runRetentionSweep (execute.ts)   pure engine: cutoff = now - max(base, industryFloor)
+            │                     batched id-windowed deleteMany | custom handler | dry-run count
+            ▼
+executeScheduledRetentionSweep (run.ts)   kill switch + industry resolve + ScheduledJob heartbeat
+            │
+            ▼
+dataRetentionSweepScheduled / ...Requested (queue/functions/data-retention-sweep.ts)
+   cron "0 4 * * *" (after 03:00 backups) + manual event, quiescence-gated
+            │
+            ▼
+catalog.ts (editable, run-now)   ·   ScheduledJob row (seed-platform-retention.ts)
+```
+
+## 5. Components (slice 1, implemented)
+
+- **`apps/web/lib/operate/retention/policies.ts`** — `PURGE_POLICIES` (enrolled datasets) + `RETAINED_DATASETS` (regulated, never purged) + the closed `RetentionCategory` union + the cascade-correct `purgeStaleAgentThreads` custom handler. The single source of truth.
+- **`industry-floors.ts`** — `INDUSTRY_RETENTION_FLOORS`, `resolveEffectiveRetentionDays` (`max(base, floor)`), `resolveOrgIndustryKey`, and alias normalization (`"financial"` → `"banking-financial-services"`).
+- **`execute.ts`** — `runRetentionSweep`: per policy, compute the industry-widened cutoff, then **dry-run** (count only), **custom handler**, or **generic batched delete**. Batched id-windowed `deleteMany` keeps each statement small and PK-indexed; a per-policy cap bounds a single run so a backlog catches up over nights rather than one giant lock. One failing policy never strands the rest.
+- **`run.ts`** — `executeScheduledRetentionSweep`: honors the operator kill switch (`ScheduledJob.enabled === false`), resolves industry, runs the sweep, and persists `lastRunAt/lastStatus/nextRunAt` + a compact rolling summary in `ScheduledJob.metadata.recentRuns` (durable audit that outlives Loki's 14-day window).
+- **`constants.ts`** — job ids, cron (`0 4 * * *`), batch size, per-policy cap, named windows.
+- **`queue/functions/data-retention-sweep.ts`** — the scheduled cron function (quiescence-gated, concurrency-limited to 1) and the manual `ops/data-retention.requested` event (supports `dryRun`).
+- **Wiring** — registered in `queue/functions/index.ts`; catalogued in `operate/scheduled-jobs/catalog.ts` as **editable** with a run-now event; `ScheduledJob` heartbeat row seeded via `packages/db/src/seed-platform-retention.ts` (called from `seed.ts`).
+- **Indexes** — migration `20260614180000_add_data_retention_purge_indexes` adds single-column purge indexes to the 12 enrolled tables whose only timestamp indexes were composite (would seq-scan).
+
+## 6. Retention matrix (slice 1 enrolled datasets)
+
+| Model | Category | Timestamp | Base window | Notes |
+| --- | --- | --- | --- | --- |
+| `ToolExecution` | audit-log | createdAt | 365d | #1 growth driver; authority audit trail |
+| `AdapterRunTelemetry` | ai-telemetry | startedAt | 180d | per LLM inference; aggregates kept elsewhere |
+| `TokenUsage` | ai-telemetry | createdAt | 180d | billing reconciliation window |
+| `RouteDecisionLog` | routing-log | createdAt | 90d | routing reasoning; short debug value |
+| `AuthorizationDecisionLog` | security-audit | createdAt | 365d | security audit; lengthened by floors |
+| `CoworkerTurnMetric` | coworker-metrics | createdAt | 180d | per-turn telemetry |
+| `SkillUsageEvent` | skill-telemetry | createdAt | 180d | feeds daily aggregator |
+| `BuildActivity` | build-log | createdAt | 90d | build tool runs |
+| `BuildDispatchAttempt` | build-log | startedAt | 90d | dispatch attempts/retries |
+| `StallEvent` | build-log | createdAt | 90d | watchdog stall detections |
+| `TaskEvaluation` | eval-history | createdAt | 90d | EndpointTaskPerformance is source of truth |
+| `EndpointTestRun` | eval-history | startedAt | 90d | probe/scenario run summaries |
+| `WikiIngestEvent` | knowledge-audit | createdAt | 90d | KB ingest audit |
+| `Notification` | inbox | createdAt | 90d | **read only**; unread never swept |
+| `SelfUpgradeRun` | self-upgrade-log | createdAt | 365d | deployment history |
+| `QuiescenceRun` | coordination-log | startedAt | 90d | drain orchestration audit |
+| `AgentThread` (chat) | coworker-chat | updatedAt | 545d | custom cascade handler; by last activity |
+
+## 7. Regulatory holds + archetype floors
+
+**Regulated datasets (`RETAINED_DATASETS`) are never touched by the engine.** They are catalogued with a cited basis and minimum years: invoices/payments/bills/POs/expenses/fixed-assets/exchange-rates/dunning/storefront-orders/donations/rental-agreements (financial, 7y); tax remittance/decision/liability/filing (7y); compliance evidence/audits/findings/submissions, requirement & policy acknowledgments (6–7y); org/person license records (7y); employment & termination records (7y); voice consent (7y). A unit test fails the build if any regulated model is ever enrolled for purge (`PURGE_MODELS ∩ RETAINED_MODELS = ∅`).
+
+**Archetype/industry floors** raise the minimum retention for operational categories based on the install's `Organization.industry` (DPF is single-org-per-install). `effective = max(base, floor)` — floors only lengthen:
+
+| Industry (archetype category) | audit-log | security-audit | coworker-chat | other |
+| --- | --- | --- | --- | --- |
+| banking-financial-services | 7y | 7y | 7y | routing/telemetry 1y |
+| professional-services | 7y | 7y | 7y | — |
+| healthcare-wellness | 6y | 6y | 6y | — |
+| public-sector | 3y | 3y | 3y | — |
+| (default / unknown) | base | base | base | base |
+
+A null/unknown industry safely falls back to base windows; regulated **records** remain protected regardless of industry. Industry strings are alias-normalized (`"financial"`, `"credit-union"`, … → `"banking-financial-services"`).
+
+## 8. Safety properties
+
+1. **Backup-before-purge** — cron at `0 4 * * *`, strictly after the `0 3 * * *` backup crons.
+2. **Operator kill switch** — `editable` catalog classification; `ScheduledJob.enabled = false` skips the sweep (checked in `run.ts`).
+3. **Dry-run** — `ops/data-retention.requested {dryRun:true}` counts what *would* be purged, deletes nothing.
+4. **Per-policy cap** (100k/run) + **batched deletes** (1k) — no single giant lock; backlog drains over nights; `capped` is reported.
+5. **Floor-only-lengthens** — industry rules can never shorten below a regulator's minimum.
+6. **Regulated exclusion** — enforced in code and by a build-failing test.
+7. **Quiescence-gated + concurrency 1** — never overlaps a self-upgrade drain or a prior in-flight sweep.
+8. **Auditable** — rolling per-run summaries persist on the `ScheduledJob` row.
+
+## 9. Follow-up slices
+
+- **Slice 2 — consolidate ad-hoc purges:** fold `reconcile-catalog-capabilities` `ModelCapabilityChangeLog` prune and the device-session cleanup into the registry; retire the bespoke calls (single source of truth).
+- **Slice 3 — status-aware datasets:** enroll `TaskRun`/`TaskMessage`/`TaskArtifact`/`TaskNode` and `DecisionInteraction` with terminal-state-aware selection (only purge messages of completed/failed runs past the window).
+- **Slice 4 — admin UX:** surface the retention matrix, last-run summary, and a dry-run "preview" button on the Scheduled Jobs admin page (`tracksRunData` already true).
+- **Slice 5 — archival tier:** export-then-delete to cold storage for categories that want recoverability, and GDPR erasure (right-to-be-forgotten) flows over the chat/PII surfaces.
+- **Slice 6 — scale strategy:** route the very largest tables to a partition-drop strategy (pg_partman-style) once an install's volume warrants it; the registry can carry a per-policy `strategy` without changing callers.
+- **Per-org editable windows:** if demanded, back the windows with a DB policy table layered over the code defaults (code = floor, DB = operator override, never below statutory).
+
+## 10. Verification
+
+- **Unit tests** (`retention.test.ts`, 17 cases): regulated-exclusion guard, registry well-formedness, floor math (lengthen/never-shorten/aliases), executor batching + cap + dry-run + cutoff math, chat cascade-order, `extraWhere` (read-only notifications), catalog registration. **Green (17/17).**
+- **Catalog test** (`scheduled-jobs.test.ts`): unchanged, still green (9/9) with the new entry.
+- **Typecheck:** new files type-clean (`tsc --noEmit`, full project config).
+- **Schema:** `prisma validate` passes with the 12 new indexes.
+- **Runtime-bound gates** (production build, migration apply, live purge) run via CI / the shared local-CI lease / canonical install per AGENTS.md §5 — not in the source-only worktree.
+
+## 11. References
+
+- AGENTS.md §6 (backlog), §10 (design research), §11 (data-model stewardship), §5 (gates).
+- Existing precedent: `infra-prune.ts`, `runtime-target-janitor.ts`, `postgres-daily-backup.ts`, `scheduled-jobs/catalog.ts`.
+- Observability retention: `monitoring/loki/loki-config.yml`, `docker-compose.yml` (Prometheus).

--- a/packages/db/prisma/migrations/20260614180000_add_data_retention_purge_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20260614180000_add_data_retention_purge_indexes/migration.sql
@@ -1,0 +1,49 @@
+-- EP-DATA-RETENTION — single-column purge indexes.
+--
+-- Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
+--
+-- The scheduled data-retention sweep deletes rows older than a per-table cutoff
+-- using `WHERE <timestamp> < cutoff`. The enrolled high-volume tables below only
+-- had COMPOSITE indexes leading with another column (e.g. ToolExecution has
+-- (agentId, createdAt) but not (createdAt)), which Postgres cannot use to seek
+-- on the timestamp alone — the nightly sweep would seq-scan the busiest tables.
+-- These single-column indexes make each purge index-driven. Tiny tables
+-- (QuiescenceRun, SelfUpgradeRun) are intentionally not indexed — a scan there
+-- is cheap. Tables that already had a single-column timestamp index
+-- (Notification, RouteDecisionLog, AuthorizationDecisionLog) are unchanged.
+
+-- CreateIndex
+CREATE INDEX "ToolExecution_createdAt_idx" ON "ToolExecution"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AdapterRunTelemetry_startedAt_idx" ON "AdapterRunTelemetry"("startedAt");
+
+-- CreateIndex
+CREATE INDEX "TokenUsage_createdAt_idx" ON "TokenUsage"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "TaskEvaluation_createdAt_idx" ON "TaskEvaluation"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "EndpointTestRun_startedAt_idx" ON "EndpointTestRun"("startedAt");
+
+-- CreateIndex
+CREATE INDEX "BuildActivity_createdAt_idx" ON "BuildActivity"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "BuildDispatchAttempt_startedAt_idx" ON "BuildDispatchAttempt"("startedAt");
+
+-- CreateIndex
+CREATE INDEX "StallEvent_createdAt_idx" ON "StallEvent"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "SkillUsageEvent_createdAt_idx" ON "SkillUsageEvent"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "WikiIngestEvent_createdAt_idx" ON "WikiIngestEvent"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "CoworkerTurnMetric_createdAt_idx" ON "CoworkerTurnMetric"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentThread_updatedAt_idx" ON "AgentThread"("updatedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1666,6 +1666,8 @@ model TokenUsage {
   inferenceMs  Int?
   costUsd      Float    @default(0)
   createdAt    DateTime @default(now())
+
+  @@index([createdAt])
 }
 
 model EndpointTaskPerformance {
@@ -1712,6 +1714,7 @@ model TaskEvaluation {
 
   @@index([endpointId, taskType, createdAt])
   @@index([threadId])
+  @@index([createdAt])
 }
 
 model EndpointTestRun {
@@ -1734,6 +1737,7 @@ model EndpointTestRun {
 
   @@index([endpointId])
   @@index([status])
+  @@index([startedAt])
 }
 
 model ScheduledJob {
@@ -2573,6 +2577,7 @@ model AdapterRunTelemetry {
   @@index([raceCohortId])
   @@index([threadId, startedAt])
   @@index([agentId, startedAt])
+  @@index([startedAt])
 }
 
 // EP-COST Phase 2 prerequisite — one row per budget event so the
@@ -3811,6 +3816,7 @@ model AgentThread {
   @@unique([userId, contextKey])
   @@index([cliSessionLastUsedAt])
   @@index([parentThreadId])
+  @@index([updatedAt])
 }
 
 model AgentMessage {
@@ -3993,6 +3999,7 @@ model ToolExecution {
   @@index([skillId, createdAt(sort: Desc)])
   @@index([envelopeId])
   @@index([delegatingUserId, createdAt(sort: Desc)])
+  @@index([createdAt])
 }
 
 // Pseudo-User Contract (spec §6.4 + §8): destructive-action confirmation
@@ -5020,6 +5027,7 @@ model BuildActivity {
   build     FeatureBuild @relation(fields: [buildId], references: [buildId])
 
   @@index([buildId, createdAt])
+  @@index([createdAt])
 }
 
 model BuildDispatchAttempt {
@@ -5045,6 +5053,7 @@ model BuildDispatchAttempt {
   @@index([buildId, startedAt])
   @@index([buildId, taskTitle, startedAt])
   @@index([failureAxis, startedAt])
+  @@index([startedAt])
 }
 
 // ─── EP-COST-001 Phase 3: Build Phase Run cost rollup ─────────────────────────
@@ -5202,6 +5211,7 @@ model StallEvent {
   @@index([buildId])
   @@index([phase, reason])
   @@index([outcome])
+  @@index([createdAt])
 }
 
 // ─── Activity Quiescence Protocol — coordinator audit (BI-QUIESCE-001) ───
@@ -8885,6 +8895,7 @@ model SkillUsageEvent {
   @@index([threadId, createdAt(sort: Desc)])
   @@index([taskRunId, createdAt(sort: Desc)])
   @@index([phase, createdAt(sort: Desc)])
+  @@index([createdAt])
 }
 
 // Governed Hermes learning Slice 3: immutable per-version snapshot of a
@@ -9162,6 +9173,7 @@ model WikiIngestEvent {
 
   @@index([sourceId])
   @@index([organizationId])
+  @@index([createdAt])
 }
 
 model WikiLintFinding {
@@ -10441,6 +10453,7 @@ model CoworkerTurnMetric {
   createdAt       DateTime @default(now())
 
   @@unique([threadId, agentMessageId])
+  @@index([createdAt])
   @@index([agentId, routeContext, createdAt])
   @@index([threadId, createdAt])
 }

--- a/packages/db/src/seed-platform-retention.ts
+++ b/packages/db/src/seed-platform-retention.ts
@@ -1,0 +1,72 @@
+import type { PrismaClient } from "../generated/client/client";
+
+/**
+ * Schedule + identifier constants for the platform-managed data-retention sweep.
+ *
+ * Spec: docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md
+ *
+ * The ScheduledJob row is the live heartbeat surfaced in the Scheduled Jobs
+ * admin view and carries the recent-run summaries in `metadata`.
+ *
+ * These identifiers are duplicated (intentionally — packages/db cannot import
+ * from apps/web) in apps/web/lib/operate/retention/constants.ts. If you change
+ * one, change both, or the heartbeat row will be orphaned.
+ */
+export const DATA_RETENTION_JOB_ID = "data-retention-sweep";
+export const DATA_RETENTION_JOB_NAME =
+  "Data retention sweep (platform-managed)";
+export const DATA_RETENTION_SCHEDULE = "daily";
+
+type ScheduledJobSeedClient = Pick<PrismaClient, "scheduledJob">;
+
+/** Returns the next 04:00 UTC strictly after `from` (after the 03:00 backups). */
+function nextRetentionRunAt(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(4);
+  if (next <= from) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}
+
+/**
+ * Idempotent: create the data-retention ScheduledJob heartbeat row if missing;
+ * update name/schedule/nextRunAt on every seed run. Does not clobber
+ * lastRunAt / lastStatus / lastError / metadata / enabled — those are owned by
+ * the runner and the operator (the `enabled` flag is the kill switch).
+ */
+export async function ensureDataRetentionScheduledJob(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  const nextRunAt = nextRetentionRunAt(now);
+
+  const existing = await prisma.scheduledJob.findUnique({
+    where: { jobId: DATA_RETENTION_JOB_ID },
+    select: { jobId: true, nextRunAt: true },
+  });
+
+  if (existing) {
+    await prisma.scheduledJob.update({
+      where: { jobId: DATA_RETENTION_JOB_ID },
+      data: {
+        name: DATA_RETENTION_JOB_NAME,
+        schedule: DATA_RETENTION_SCHEDULE,
+        nextRunAt: existing.nextRunAt ?? nextRunAt,
+      },
+    });
+    return { created: false };
+  }
+
+  await prisma.scheduledJob.create({
+    data: {
+      jobId: DATA_RETENTION_JOB_ID,
+      name: DATA_RETENTION_JOB_NAME,
+      schedule: DATA_RETENTION_SCHEDULE,
+      nextRunAt,
+    },
+  });
+  return { created: true };
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -51,6 +51,7 @@ import { ensureDataModelMirrorScheduledTask } from "./seed-data-model-mirror.js"
 import { ensureSysmlProjectionScheduledTask } from "./seed-sysml-projection.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
 import { ensureAllBackupScheduledJobs } from "./seed-platform-backup.js";
+import { ensureDataRetentionScheduledJob } from "./seed-platform-retention.js";
 import { ensureContributorInventoryScheduledJob } from "./seed-contributor-inventory.js";
 import { seedAgentControlPlaneMaturity } from "./seed-agent-control-plane-maturity.js";
 import { syncCapabilities } from "./sync-capabilities.js";
@@ -2437,6 +2438,7 @@ async function main(): Promise<void> {
   await step("sysmlProjectionScheduledTask", () => ensureSysmlProjectionScheduledTask(prisma));
   await step("hiveScoutScheduledTask", () => ensureHiveScoutScheduledTask(prisma));
   await step("allBackupScheduledJobs", () => ensureAllBackupScheduledJobs(prisma));
+  await step("dataRetentionScheduledJob", () => ensureDataRetentionScheduledJob(prisma));
   await step("contributorInventoryScheduledJob", () => ensureContributorInventoryScheduledJob(prisma));
   await step("mcpServers", () => seedMcpServers());
   await step("sandboxPool", () => seedSandboxPool());


### PR DESCRIPTION
## EP-DATA-RETENTION — Data Retention & Lifecycle Governance (Slice 1)

Closes the unbounded-growth gap on the application database. Today only the observability stack (Loki 14d, Prometheus 15d) and a few ad-hoc purges self-prune; the high-volume app tables (`ToolExecution`, `AdapterRunTelemetry`, routing/auth logs, build-dispatch logs, self-upgrade history, coworker chat, notifications, eval/skill/wiki/turn telemetry) grow forever. This adds a unified, governed retention substrate.

### What's in this slice
- **Declarative policy registry** (`apps/web/lib/operate/retention/policies.ts`) — the single source of truth. `PURGE_POLICIES` (17 enrolled datasets, conservative per-category windows) + `RETAINED_DATASETS` (regulated records — financial/tax/compliance/licensing/HR/consent, 6–7yr statutory basis) that are **never** auto-purged.
- **Generic purge engine** (`execute.ts`) — batched, id-windowed deletes with a per-policy cap, a dry-run (count-only) mode, error isolation per policy, and a cascade-correct custom handler for coworker chat (`AgentThread` → delete proposals, then cascade messages/attachments).
- **Archetype/industry floors** (`industry-floors.ts`) — a bank/clinic/firm automatically retains audit & chat longer (`effective = max(base, floor)`, floors **only lengthen**). Null/unknown industry safely uses base windows; regulated records are protected regardless.
- **Scheduled job** (`queue/functions/data-retention-sweep.ts`) — daily **04:00** (strictly after the 03:00 backups), quiescence-gated, concurrency-limited; operator **kill switch** + **run-now/dry-run** event. Catalogued as **editable** so an operator can disable a destructive sweep; `ScheduledJob` heartbeat row seeded.
- **Purge indexes** (migration `20260614180000`) — single-column timestamp indexes on the 12 enrolled tables whose only indexes were composite (would otherwise nightly seq-scan the busiest tables).

### Safety
Backup-before-purge ordering · operator kill switch · dry-run preview · per-policy cap + batched deletes (no giant locks) · floors only lengthen · regulated-exclusion enforced by a **build-failing test** (`PURGE_MODELS ∩ RETAINED_MODELS = ∅`) · quiescence-gated · auditable rolling run summaries on the `ScheduledJob` row.

### Verification (substrate: source-only worktree + borrowed root toolchain)
- ✅ `retention.test.ts` — **17/17** (regulated-exclusion guard, floor math, executor batching/cap/dry-run/cutoff, chat cascade order, read-only notifications).
- ✅ `scheduled-jobs.test.ts` — **9/9** (catalog entry compatible).
- ✅ `tsc --noEmit` — new files type-clean (full project config).
- ✅ `prisma validate` — schema valid with the 12 new indexes.
- ⏳ Runtime-bound gates (production build, **migration apply**, first live sweep) run via CI / shared local-CI lease / canonical install per AGENTS.md §5. The migration was authored to Prisma's canonical `CREATE INDEX` convention (Prisma 7.8 offline `migrate diff` does not emit index-only deltas without a shadow DB).

### Follow-ups (specified, not in this slice)
Consolidate existing ad-hoc purges into the registry · status-aware enrollment of `TaskRun`/`TaskMessage`/`DecisionInteraction` · admin UX (matrix + dry-run preview) · archival/GDPR-erasure tier · partition-drop strategy at scale.

Spec: `docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md` · Plan: `docs/superpowers/plans/2026-06-14-data-retention-lifecycle-governance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
