### PR TITLE
fix(backups): reconcile BackupRun rows stuck "running" (crashed runner = false in-progress forever)

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -497,6 +497,17 @@ export async function register() {
       20 * 60 * 1000,
     );
 
+    // Same boot + periodic safety net for BackupRun rows stuck "running": a
+    // backup runner that dies mid-dump leaves a false "in progress" row forever
+    // (no other recovery), polluting the backup-health card + corruption alerts.
+    void (async () => {
+      const { reconcileStuckBackupRuns } = await import(
+        "@/lib/operate/backups/reconcile-stuck-runs"
+      );
+      await reconcileStuckBackupRuns();
+      setInterval(() => void reconcileStuckBackupRuns(), 20 * 60 * 1000);
+    })();
+
     // Build Studio engine reliability (spec §3.1 engine-first / FB-78E967D4).
     // These run unconditionally — they are correctness reconcilers, not optional
     // maintenance — and FIX 1 runs before FIX 2 so contradictory checkpoints are

--- a/apps/web/lib/operate/backups/reconcile-stuck-runs.test.ts
+++ b/apps/web/lib/operate/backups/reconcile-stuck-runs.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findManyMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    backupRun: {
+      findMany: (...a: unknown[]) => findManyMock(...a),
+      update: (...a: unknown[]) => updateMock(...a),
+    },
+  },
+}));
+
+import { reconcileStuckBackupRuns } from "./reconcile-stuck-runs";
+
+beforeEach(() => {
+  findManyMock.mockReset();
+  updateMock.mockReset().mockResolvedValue({});
+});
+
+describe("reconcileStuckBackupRuns", () => {
+  it("fails a backup run stuck running past the window, scoped to never-finished old rows", async () => {
+    const now = () => new Date("2026-06-14T02:00:00.000Z");
+    findManyMock.mockResolvedValueOnce([
+      { id: "BR-1", target: "postgres", startedAt: new Date("2026-06-14T00:00:00.000Z") },
+    ]);
+
+    const result = await reconcileStuckBackupRuns(
+      { staleAfterMs: 45 * 60 * 1000, now },
+      { log: vi.fn(), error: vi.fn() },
+    );
+
+    expect(result).toEqual({ failed: 1 });
+    const where = findManyMock.mock.calls[0][0].where;
+    expect(where.status).toBe("running");
+    expect(where.finishedAt).toBeNull();
+    expect(where.startedAt.lt.getTime()).toBe(now().getTime() - 45 * 60 * 1000);
+
+    const update = updateMock.mock.calls[0][0];
+    expect(update.where).toEqual({ id: "BR-1" });
+    expect(update.data.status).toBe("failed");
+    expect(update.data.finishedAt.getTime()).toBe(now().getTime());
+    expect(update.data.errorMessage).toContain("stuck");
+  });
+
+  it("is a no-op when nothing is stuck", async () => {
+    findManyMock.mockResolvedValueOnce([]);
+    const result = await reconcileStuckBackupRuns({}, { log: vi.fn(), error: vi.fn() });
+    expect(result).toEqual({ failed: 0 });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("never throws (boot-path safety) — returns null on a DB error", async () => {
+    findManyMock.mockRejectedValueOnce(new Error("db down"));
+    const result = await reconcileStuckBackupRuns({}, { log: vi.fn(), error: vi.fn() });
+    expect(result).toBeNull();
+  });
+
+  it("defaults the stale window to 45 minutes (past the longest backup timeout)", async () => {
+    const now = () => new Date("2026-06-14T02:00:00.000Z");
+    findManyMock.mockResolvedValueOnce([]);
+    await reconcileStuckBackupRuns({ now }, { log: vi.fn(), error: vi.fn() });
+    expect(findManyMock.mock.calls[0][0].where.startedAt.lt.getTime()).toBe(
+      now().getTime() - 45 * 60 * 1000,
+    );
+  });
+});

--- a/apps/web/lib/operate/backups/reconcile-stuck-runs.ts
+++ b/apps/web/lib/operate/backups/reconcile-stuck-runs.ts
@@ -1,0 +1,55 @@
+import { prisma } from "@dpf/db";
+
+/**
+ * Reconcile BackupRun rows stuck in "running". A backup runner records a row as
+ * `status: "running"` up front to surface progress, then flips it to ok/failed
+ * with `finishedAt` set. If the runner process dies between those two points
+ * (crash, container kill, OOM), the row sits "running" with `finishedAt = null`
+ * FOREVER — a false "backup in progress" that pollutes the backup-health card
+ * and the corruption-alerting (BI-EA67A758, #1922), and hides that the backup
+ * actually failed hours ago. There is no other recovery for it.
+ *
+ * This marks rows stuck "running" past a generous window (default 45 min — well
+ * past the longest backup's 30-min hard timeout) as failed. Runs in-process on
+ * an interval (NOT an Inngest cron — the 2026-06-14 incident proved the cron
+ * engine itself can die, and a recovery net must not depend on it).
+ *
+ * Non-fatal: never throws; returns null on error.
+ */
+export async function reconcileStuckBackupRuns(
+  opts: { staleAfterMs?: number; now?: () => Date } = {},
+  logger: Pick<Console, "log" | "error"> = console,
+): Promise<{ failed: number } | null> {
+  const staleAfterMs = opts.staleAfterMs ?? 45 * 60 * 1000;
+  const now = opts.now?.() ?? new Date();
+  try {
+    const stuck = await prisma.backupRun.findMany({
+      where: {
+        status: "running",
+        finishedAt: null,
+        startedAt: { lt: new Date(now.getTime() - staleAfterMs) },
+      },
+      select: { id: true, target: true, startedAt: true },
+    });
+    if (stuck.length === 0) return { failed: 0 };
+
+    for (const run of stuck) {
+      await prisma.backupRun.update({
+        where: { id: run.id },
+        data: {
+          status: "failed",
+          finishedAt: now,
+          errorMessage: `Reconciled by watchdog: backup runner died with no finish recorded (stuck "running" > ${Math.round(staleAfterMs / 60000)}m). The backup did not complete.`,
+        },
+      });
+      logger.log(
+        `[backup-reconcile] ${run.target} ${run.id} -> failed (orphaned; started ${run.startedAt.toISOString()})`,
+      );
+    }
+    logger.log(`[backup-reconcile] resolved ${stuck.length} stuck backup run(s)`);
+    return { failed: stuck.length };
+  } catch (err) {
+    logger.error("[backup-reconcile] failed (non-fatal):", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Brittleness (cross-subsystem sweep, top finding)
A backup runner records `BackupRun status:"running"` up front, then flips it to ok/failed with `finishedAt` set. If the runner dies between (crash, container kill, OOM), the row sits `running` / `finishedAt=null` **forever** — a false *"backup in progress"* with **no other recovery**. It pollutes the backup-health card + the corruption alerting (#1922) and hides that the backup actually failed hours ago. Same stuck-`running`-no-watchdog pattern as the self-upgrade runs.

## Fix
`reconcileStuckBackupRuns()` marks rows stuck `running` past **45 min** (well past the 30-min hard timeout) as failed, run **in-process on boot + every 20 min** — mirroring the self-upgrade reconciler (#1939). In-process, not an Inngest cron, because the incident proved the cron engine itself can die.

4 tests (fail-stuck, no-op, non-fatal, default window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)