### PR TITLE
fix(storefront): donation form, admin price display, new-item form, rental badge + edit form pre-population

### DIFF
--- a/apps/web/app/(shell)/storefront/items/page.tsx
+++ b/apps/web/app/(shell)/storefront/items/page.tsx
@@ -4,11 +4,14 @@ import { ItemsManager } from "@/components/storefront-admin/ItemsManager";
 import { getVocabulary, getCategorySuggestions } from "@/lib/storefront/archetype-vocabulary";
 
 export default async function ItemsPage() {
-  const config = await prisma.storefrontConfig.findFirst({
-    include: {
-      archetype: { select: { archetypeId: true, category: true, ctaType: true, customVocabulary: true } },
-    },
-  });
+  const [config, orgSettings] = await Promise.all([
+    prisma.storefrontConfig.findFirst({
+      include: {
+        archetype: { select: { archetypeId: true, category: true, ctaType: true, customVocabulary: true } },
+      },
+    }),
+    prisma.orgSettings.findFirst({ select: { baseCurrency: true } }),
+  ]);
   if (!config) redirect("/storefront/setup");
 
   const items = await prisma.storefrontItem.findMany({
@@ -33,6 +36,7 @@ export default async function ItemsPage() {
       vocabulary={vocabulary}
       categorySuggestions={categorySuggestions}
       defaultCtaType={config.archetype.ctaType}
+      defaultCurrency={orgSettings?.baseCurrency ?? "USD"}
     />
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/donate/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/donate/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
 import { getPublicStorefront } from "@/lib/storefront-data";
+import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import { DonationForm } from "@/components/storefront/DonationForm";
 
 export default async function DonatePage({
@@ -8,8 +10,13 @@ export default async function DonatePage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const storefront = await getPublicStorefront(slug);
+  const [storefront, orgSettings] = await Promise.all([
+    getPublicStorefront(slug),
+    prisma.orgSettings.findFirst({ select: { baseCurrency: true } }),
+  ]);
   if (!storefront) notFound();
+
+  const currencySymbol = getCurrencySymbol(orgSettings?.baseCurrency ?? "USD");
 
   return (
     <div style={{ paddingTop: 40, maxWidth: 520 }}>
@@ -17,7 +24,7 @@ export default async function DonatePage({
       <p style={{ color: "var(--dpf-muted)", marginBottom: 24, fontSize: 14 }}>
         Your support makes a real difference. Thank you.
       </p>
-      <DonationForm orgSlug={slug} />
+      <DonationForm orgSlug={slug} currencySymbol={currencySymbol} />
     </div>
   );
 }

--- a/apps/web/components/storefront-admin/ItemFormDialog.tsx
+++ b/apps/web/components/storefront-admin/ItemFormDialog.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
 import { DEFAULT_CTA_LABELS } from "@/lib/storefront/cta-labels";
+import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import { MediaUploader } from "./MediaUploader";
 
 export type ItemFormData = {
@@ -84,6 +85,8 @@ type Props = {
   vocabulary: ArchetypeVocabulary;
   categorySuggestions: string[];
   defaultCtaType: string;
+  /** Workspace base currency; defaults to USD when not provided. */
+  defaultPriceCurrency?: string;
   isEditing: boolean;
   /** DB id of the item being edited; enables the photo-gallery uploader. */
   editingItemId?: string;
@@ -97,11 +100,13 @@ export function ItemFormDialog({
   vocabulary,
   categorySuggestions,
   defaultCtaType,
+  defaultPriceCurrency = "USD",
   isEditing,
   editingItemId,
 }: Props) {
   const [form, setForm] = useState<ItemFormData>(() => ({
     ...EMPTY_FORM,
+    priceCurrency: defaultPriceCurrency,
     ctaType: defaultCtaType,
     priceType: PRICE_TYPES_BY_CTA[defaultCtaType]?.[0]?.value ?? "",
     ...initial,
@@ -230,7 +235,7 @@ export function ItemFormDialog({
                 <Field label="Amount">
                   <div className="flex gap-2">
                     <span className="flex items-center text-sm text-[var(--dpf-muted)]">
-                      {form.priceCurrency === "GBP" ? "\u00a3" : form.priceCurrency === "USD" ? "$" : form.priceCurrency === "EUR" ? "\u20ac" : form.priceCurrency}
+                      {getCurrencySymbol(form.priceCurrency)}
                     </span>
                     <input
                       type="number"
@@ -356,7 +361,7 @@ export function ItemFormDialog({
               <Field label="Suggested amount">
                 <div className="flex gap-2">
                   <span className="flex items-center text-sm text-[var(--dpf-muted)]">
-                    {form.priceCurrency === "GBP" ? "\u00a3" : form.priceCurrency === "USD" ? "$" : form.priceCurrency === "EUR" ? "\u20ac" : form.priceCurrency}
+                    {getCurrencySymbol(form.priceCurrency)}
                   </span>
                   <input
                     type="number"
@@ -373,7 +378,7 @@ export function ItemFormDialog({
               <Field label="Goal amount">
                 <div className="flex gap-2">
                   <span className="flex items-center text-sm text-[var(--dpf-muted)]">
-                    {form.priceCurrency === "GBP" ? "\u00a3" : form.priceCurrency === "USD" ? "$" : form.priceCurrency === "EUR" ? "\u20ac" : form.priceCurrency}
+                    {getCurrencySymbol(form.priceCurrency)}
                   </span>
                   <input
                     type="number"

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useCallback } from "react";
 import { ItemFormDialog, type ItemFormData } from "./ItemFormDialog";
+import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
 
 type Item = {
@@ -319,7 +320,7 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatPrice(amount: string | null, currency: string, priceType: string | null): string {
-  const symbol = currency === "GBP" ? "\u00a3" : currency === "USD" ? "$" : currency === "EUR" ? "\u20ac" : currency + " ";
+  const symbol = getCurrencySymbol(currency);
 
   if (!priceType) return "\u2014";
 

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -35,6 +35,7 @@ const CTA_BADGES: Record<string, { color: string; label: string }> = {
   purchase: { color: "var(--dpf-success)", label: "Purchase" },
   inquiry: { color: "#fb923c", label: "Inquiry" },
   donation: { color: "#f472b6", label: "Donation" },
+  rental: { color: "#a78bfa", label: "Rental" },
 };
 
 export function ItemsManager({ storefrontId, items: initial, vocabulary, categorySuggestions, defaultCtaType, defaultCurrency }: Props) {

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -27,6 +27,7 @@ type Props = {
   vocabulary: ArchetypeVocabulary;
   categorySuggestions: string[];
   defaultCtaType: string;
+  defaultCurrency?: string;
 };
 
 const CTA_BADGES: Record<string, { color: string; label: string }> = {
@@ -36,7 +37,7 @@ const CTA_BADGES: Record<string, { color: string; label: string }> = {
   donation: { color: "#f472b6", label: "Donation" },
 };
 
-export function ItemsManager({ storefrontId, items: initial, vocabulary, categorySuggestions, defaultCtaType }: Props) {
+export function ItemsManager({ storefrontId, items: initial, vocabulary, categorySuggestions, defaultCtaType, defaultCurrency }: Props) {
   const [items, setItems] = useState(initial);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<Item | null>(null);
@@ -310,6 +311,7 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
         vocabulary={vocabulary}
         categorySuggestions={categorySuggestions}
         defaultCtaType={defaultCtaType}
+        defaultPriceCurrency={defaultCurrency}
         isEditing={!!editingItem}
         editingItemId={editingItem?.id}
       />

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -303,8 +303,9 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
         </p>
       )}
 
-      {/* Form dialog */}
+      {/* Form dialog — key forces remount when editing item changes so useState initializer re-runs */}
       <ItemFormDialog
+        key={editingItem?.id ?? "new"}
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditingItem(null); }}
         onSave={handleSave}

--- a/apps/web/components/storefront/DonationForm.tsx
+++ b/apps/web/components/storefront/DonationForm.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 
 const PRESET_AMOUNTS = [5, 10, 25, 50, 100];
 
-export function DonationForm({ orgSlug }: { orgSlug: string }) {
+export function DonationForm({ orgSlug, currencySymbol = "£" }: { orgSlug: string; currencySymbol?: string }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -58,12 +58,12 @@ export function DonationForm({ orgSlug }: { orgSlug: string }) {
                 color: selected === amt ? "var(--dpf-text)" : "var(--dpf-text)",
                 border: "none",
               }}>
-              £{amt}
+              {currencySymbol}{amt}
             </button>
           ))}
         </div>
         <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 8 }}>
-          <span style={{ fontSize: 14, color: "var(--dpf-muted)" }}>Custom: £</span>
+          <span style={{ fontSize: 14, color: "var(--dpf-muted)" }}>Custom: {currencySymbol}</span>
           <input type="number" min="1" step="0.01" value={custom}
             onChange={(e) => { setCustom(e.target.value); setSelected(null); }}
             placeholder="Other amount"


### PR DESCRIPTION
## Summary
- **DonationForm** (`/s/[slug]/donate`): replace hardcoded `£` with workspace currency symbol fetched from `OrgSettings.baseCurrency` — fixes R9-G-001 / donation-specific gap from run-16 nonprofit audit
- **ItemsManager**: `formatPrice` helper uses `getCurrencySymbol()` instead of 3-entry GBP/USD/EUR conditional; adds `defaultCurrency` prop threaded from the items page
- **ItemFormDialog**: `defaultPriceCurrency` prop defaults new items to workspace currency instead of hardcoded GBP (`EMPTY_FORM.priceCurrency`); replaces 3 currency symbol conditionals with `getCurrencySymbol(form.priceCurrency)`
- **CTA_BADGES**: adds `rental` entry (violet) so rental items show a styled badge instead of muted-lowercase fallback — complements R10-EQ-001 fix in #1938
- **ItemFormDialog key prop** (`key={editingItem?.id ?? "new"}`): forces remount when editing item changes so the useState initializer re-runs with the correct item values — fixes **R9-BAK-001** (Edit Item form always showed EMPTY_FORM defaults regardless of the item clicked)
- **Items admin page**: fetches `OrgSettings.baseCurrency` in parallel and passes it down the `ItemsManager → ItemFormDialog` chain

## Test plan
- [x] vitest: 823 passing (470 pre-existing `next/server` worktree path failures — unrelated; no storefront-admin test coverage)
- [x] typecheck: `DPF_SKIP_TYPECHECK=1` (worktree); CI typecheck gate will run
- [x] next build: n/a (no new routes)
- [x] UX verification: n/a (structural fix; dynamic analysis deferred to post-merge archetype audit re-run)

Unblocked by #1951 (Route Manifest Freshness). No overlap with #1938, #1942, #1946, #1947, #1952.

🤖 Generated with [Claude Code](https://claude.com/claude-code)