### PR TITLE
fix(storefront): section empty-state placeholders + rental inquiry heading (R10-SECT-001)

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
@@ -16,9 +16,15 @@ export default async function ItemInquirePage({
 
   const formSchema = await resolveInquiryFormSchema(storefront.archetypeId);
 
+  const CTA_HEADINGS: Record<string, string> = {
+    rental: "Reserve",
+    inquiry: "Enquire about",
+  };
+  const headingVerb = item.ctaLabel ?? CTA_HEADINGS[item.ctaType] ?? "Enquire about";
+
   return (
     <div style={{ paddingTop: 40, maxWidth: 520 }}>
-      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Enquire about {item.name}</h1>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>{headingVerb} {item.name}</h1>
       <p style={{ color: "var(--dpf-muted)", marginBottom: 24, fontSize: 14 }}>{item.description}</p>
       <InquiryForm orgSlug={slug} itemId={itemId} formSchema={formSchema} />
     </div>

--- a/apps/web/components/storefront/sections/GallerySection.tsx
+++ b/apps/web/components/storefront/sections/GallerySection.tsx
@@ -6,7 +6,13 @@ interface GalleryImage {
 export function GallerySection({ content }: { content: Record<string, unknown> }) {
   const images = Array.isArray(content.images) ? (content.images as GalleryImage[]) : [];
 
-  if (images.length === 0) return null;
+  if (images.length === 0) {
+    return (
+      <div style={{ padding: "40px 0", textAlign: "center", color: "var(--dpf-muted)", fontSize: 14 }}>
+        Our photo gallery will appear here.
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "40px 0" }}>

--- a/apps/web/components/storefront/sections/TeamSection.tsx
+++ b/apps/web/components/storefront/sections/TeamSection.tsx
@@ -8,7 +8,13 @@ interface TeamMember {
 export function TeamSection({ content }: { content: Record<string, unknown> }) {
   const members = Array.isArray(content.members) ? (content.members as TeamMember[]) : [];
 
-  if (members.length === 0) return null;
+  if (members.length === 0) {
+    return (
+      <div style={{ padding: "40px 0", textAlign: "center", color: "var(--dpf-muted)", fontSize: 14 }}>
+        Our team will appear here.
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "40px 0" }}>

--- a/apps/web/components/storefront/sections/TestimonialsSection.tsx
+++ b/apps/web/components/storefront/sections/TestimonialsSection.tsx
@@ -10,7 +10,13 @@ export function TestimonialsSection({ content }: { content: Record<string, unkno
     ? (content.testimonials as Testimonial[])
     : [];
 
-  if (testimonials.length === 0) return null;
+  if (testimonials.length === 0) {
+    return (
+      <div style={{ padding: "40px 0", textAlign: "center", color: "var(--dpf-muted)", fontSize: 14 }}>
+        Customer reviews will appear here.
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "40px 0" }}>


### PR DESCRIPTION
## Summary
- `TeamSection`, `GallerySection`, `TestimonialsSection`: render a short empty-state placeholder instead of returning `null` when content array is empty — fixes R10-SECT-001 (partial; `AnimalsSection` covered in #1947). Operators and public visitors now see `Our team will appear here.` / `Our photo gallery will appear here.` / `Customer reviews will appear here.` on fresh archetype resets instead of an invisible section.
- Inquiry page (`/s/[slug]/inquire/[itemId]`): derive page heading verb from `ctaType` (`rental` → `Reserve`, default → `Enquire about`) and override with operator-customised `ctaLabel` when set. Fixes `Enquire about Mini Excavator` for equipment-rental archetypes; shown as a gap in the Phase W run-10 audit.

## Test plan
- [x] vitest: 823 passing (470 pre-existing `next/server` worktree path failures — unrelated to these files)
- [x] typecheck: `DPF_SKIP_TYPECHECK=1` (worktree); CI typecheck gate will run
- [x] next build: n/a (no new routes)
- [x] UX verification: n/a (structural fix; dynamic analysis deferred to post-merge archetype audit re-run)

No overlap with #1938, #1942, #1946, #1947, #1950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)