### PR TITLE
fix(finance): new invoice form defaults to workspace currency not GBP (R9-G-001)

### DIFF
--- a/apps/web/app/(shell)/finance/invoices/new/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/new/page.tsx
@@ -8,7 +8,7 @@ import { defaultSignatureRequiredForArchetype } from "@/lib/finance/invoice-sign
 export default async function NewInvoicePage() {
   // Default the TAX % field from the org's wizard VAT selection, not a 20% hardcode
   // (shared with the recurring-schedule form via getInvoiceDefaultTaxRate).
-  const [customers, storefront, defaultTaxRate] = await Promise.all([
+  const [customers, storefront, defaultTaxRate, orgSettings] = await Promise.all([
     prisma.customerAccount.findMany({
       where: {
         status: { in: ["active", "prospect", "qualified", "onboarding"] },
@@ -25,6 +25,7 @@ export default async function NewInvoicePage() {
       select: { archetype: { select: { archetypeId: true } } },
     }),
     getInvoiceDefaultTaxRate(),
+    prisma.orgSettings.findFirst({ select: { baseCurrency: true } }),
   ]);
 
   // Default "require signature" on for regulated archetypes (legal/accounting).
@@ -65,6 +66,7 @@ export default async function NewInvoicePage() {
         customers={customers}
         defaultTaxRate={defaultTaxRate}
         defaultSignatureRequired={defaultSignatureRequired}
+        defaultCurrency={orgSettings?.baseCurrency ?? "USD"}
       />
     </div>
   );

--- a/apps/web/components/finance/CreateInvoiceForm.tsx
+++ b/apps/web/components/finance/CreateInvoiceForm.tsx
@@ -28,6 +28,8 @@ interface Props {
   defaultTaxRate?: number;
   /** Default for "require signature before payment". On for legal/accounting archetypes. */
   defaultSignatureRequired?: boolean;
+  /** Workspace base currency; pre-fills the currency field before a customer is selected. */
+  defaultCurrency?: string;
 }
 
 function round2(n: number): number {
@@ -44,6 +46,7 @@ export function CreateInvoiceForm({
   customers,
   defaultTaxRate = 0,
   defaultSignatureRequired = false,
+  defaultCurrency = "USD",
 }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -51,7 +54,7 @@ export function CreateInvoiceForm({
 
   const [selectedAccountId, setSelectedAccountId] = useState("");
   const [dueDate, setDueDate] = useState(getDefaultDueDate());
-  const [currency, setCurrency] = useState("GBP");
+  const [currency, setCurrency] = useState(defaultCurrency);
   const [paymentTerms, setPaymentTerms] = useState("");
   const [notes, setNotes] = useState("");
   const [signatureRequired, setSignatureRequired] = useState(defaultSignatureRequired);


### PR DESCRIPTION
## Summary
- `CreateInvoiceForm`: adds `defaultCurrency?: string` prop (default `"USD"`); changes `useState("GBP")` to `useState(defaultCurrency)` so the currency field is pre-filled from the workspace setting rather than hardcoded GBP
- `/finance/invoices/new` page: fetches `OrgSettings.baseCurrency` in the existing `Promise.all` and passes it as `defaultCurrency` to `<CreateInvoiceForm>`
- Customer selection still overrides currency (existing behaviour preserved) — this only fixes the initial pre-selection state

Fixes **R9-G-001** from the Phase W run-9 bakery audit: "New Invoice form defaults currency to GBP before a customer is selected, then silently switches to USD after customer selection."

## Test plan
- [x] vitest: no tests for `CreateInvoiceForm` (client component); no regressions in existing passing suite
- [x] typecheck: `DPF_SKIP_TYPECHECK=1` (worktree); CI typecheck gate will run
- [x] next build: n/a (existing route, no new pages)
- [x] UX verification: n/a (structural fix; dynamic analysis deferred to post-merge archetype audit re-run)

No overlap with any open Phase W PR (#1938, #1942, #1946, #1947, #1950, #1951, #1952).

🤖 Generated with [Claude Code](https://claude.com/claude-code)