### PR TITLE
fix(mcp): expand grant implications in the token-scope gate

### DIFF
--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -897,6 +897,43 @@ describe("POST — tools/call", () => {
     expect(call.source).toBe("external-jsonrpc");
   });
 
+  it("accepts an implying grant for a finer required grant (build_promote → build_lifecycle)", async () => {
+    // promote_to_build_studio requires `build_lifecycle`; a legacy
+    // `build_promote` token implies it via GRANT_IMPLICATIONS. The token-scope
+    // gate must expand before checking, mirroring the agent-grant layer.
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_promote",
+      userId: "u1",
+      agentId: "AGT-BUILD",
+      scopes: ["build_promote"], // NOT build_lifecycle directly
+      capability: "write",
+      scope: "write",
+    });
+    govMock.mockResolvedValue({
+      success: true,
+      message: "Promoted BI-SCOPE to Build Studio.",
+      entityId: "BI-SCOPE",
+      data: { buildId: "FB-SCOPE" },
+    });
+
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_PROMOTE",
+        body: {
+          jsonrpc: "2.0",
+          id: 73,
+          method: "tools/call",
+          params: { name: "promote_to_build_studio", arguments: { itemId: "BI-SCOPE" } },
+        },
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.result.isError).toBe(false);
+    expect(govMock).toHaveBeenCalledOnce();
+    expect(govMock.mock.calls[0]![0].toolName).toBe("promote_to_build_studio");
+  });
+
   it("dispatches to governedExecuteTool with source=external-jsonrpc and apiTokenId", async () => {
     resolveMock.mockResolvedValue({
       tokenId: "tok_abc",

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -23,7 +23,7 @@ import { verifyMcpSessionToken } from "@/lib/mcp/session-token";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { PLATFORM_TOOLS, resolveAnnotations, type ToolDefinition } from "@/lib/mcp-tools";
 import { submitRemoteCoworkerTask } from "@/lib/mcp-task-submit";
-import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+import { getToolGrantMapping, expandGrants } from "@/lib/tak/agent-grants";
 import { can, type CapabilityKey, type UserContext } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 
@@ -236,7 +236,10 @@ function tokenCanUseTool(
   if (!tokenScopeSatisfies(normalizeTokenScope(token), requiredScope)) {
     return false;
   }
-  return required.some((g) => token.scopes.includes(g));
+  // Expand through GRANT_IMPLICATIONS so an implying grant (e.g. build_promote)
+  // surfaces the finer-grant tools it implies (e.g. build_lifecycle). Mirrors
+  // the call-time check below and the agent-grant layer.
+  return required.some((g) => expandGrants(token.scopes).includes(g));
 }
 
 function requiredTokenScopeForTool(
@@ -379,7 +382,14 @@ async function handleToolsCall(
       insufficientScopeResult(toolName, tokenScope, requiredScope, required),
     );
   }
-  const tokenAllowed = required.some((g) => token.scopes.includes(g));
+  // Expand the token's scopes through GRANT_IMPLICATIONS before checking, so a
+  // legacy implying-grant satisfies the finer grant it implies (e.g. a
+  // `build_promote` token satisfies `build_lifecycle`). Without this expansion
+  // the token layer rejected implying-grant tokens that the agent-grant layer
+  // (isToolAllowedByGrants, which already expands) would accept — an
+  // inconsistency that left valid tokens unable to reach refactored tools.
+  const expandedScopes = expandGrants(token.scopes);
+  const tokenAllowed = required.some((g) => expandedScopes.includes(g));
   if (!tokenAllowed) {
     return jsonRpcOk(id, {
       content: [

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 494,
+  "routeCount": 496,
   "routes": [
     {
       "routePath": "/",
@@ -2691,6 +2691,31 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/v1/upload/route.ts"
+    },
+    {
+      "routePath": "/api/v1/work-items",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "work-items"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/work-items/route.ts"
+    },
+    {
+      "routePath": "/api/v1/work-items/[itemId]",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "work-items",
+        "[itemId]"
+      ],
+      "dynamicParams": [
+        "itemId"
+      ],
+      "file": "apps/web/app/api/v1/work-items/[itemId]/route.ts"
     },
     {
       "routePath": "/api/v1/work-queue/[itemId]/claim",


### PR DESCRIPTION
## Problem

The MCP `/api/mcp/v1` **token-scope gate** checked the raw `token.scopes` array:

```ts
const tokenAllowed = required.some((g) => token.scopes.includes(g));
```

…without applying `GRANT_IMPLICATIONS`. The **agent-grant layer** (`isToolAllowedByGrants`) already expands via `expandGrants()`, so the two enforcement layers disagreed. A token holding a legacy **implying** grant (e.g. `build_promote`) was accepted by the agent layer but **rejected by the token layer** for the finer grant it implies (`build_lifecycle`).

Net effect: a validly-scoped token could not reach tools that were refactored onto the finer grant under BI-B2F7ABF5 — including `promote_to_build_studio`, which gates Build Studio promotion. The grant catalog documents `build_promote` as *"remains for backwards compat and implies build_lifecycle (one-way)"*, but the runtime token gate never honored that implication.

## Fix

Run `token.scopes` through `expandGrants()` in **both** token-layer checks:
- the call-time gate (`tools/call`), and
- the tool-listing filter (`tokenCanUseTool`, which is why such tools weren't even surfaced).

This mirrors the agent-grant layer exactly — single source of truth for implications (`GRANT_IMPLICATIONS` / `expandGrants`).

## Test

Adds a regression test: a `build_promote`-only token reaches `promote_to_build_studio` (requires `build_lifecycle`) via the one-way implication. Full `route.test.ts` green (49 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)