### PR TITLE
fix(finance): invoice detail and list use invoice currency not org currency (R8-OPT-003)

### DIFF
--- a/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
@@ -1,6 +1,5 @@
 // apps/web/app/(shell)/finance/invoices/[id]/page.tsx
 import { getInvoice } from "@/lib/actions/finance";
-import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -36,8 +35,7 @@ export default async function InvoiceDetailPage({ params }: Props) {
     notFound();
   }
 
-  const orgSettings = await getOrgSettings();
-  const sym = getCurrencySymbol(orgSettings.baseCurrency);
+  const sym = getCurrencySymbol(invoice.currency);
 
   const colour = STATUS_COLOURS[invoice.status] ?? "#6b7280";
   const totalAmount = Number(invoice.totalAmount);

--- a/apps/web/app/(shell)/finance/invoices/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/page.tsx
@@ -1,6 +1,5 @@
 // apps/web/app/(shell)/finance/invoices/page.tsx
 import { prisma } from "@dpf/db";
-import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
@@ -33,7 +32,7 @@ export default async function InvoicesPage({ searchParams }: Props) {
   const { status, view: viewParam } = await searchParams;
   const view = parseSurfaceView(viewParam);
 
-  const [invoices, statusCounts, orgSettings] = await Promise.all([
+  const [invoices, statusCounts] = await Promise.all([
     prisma.invoice.findMany({
       ...(status ? { where: { status } } : {}),
       orderBy: { createdAt: "desc" },
@@ -42,6 +41,7 @@ export default async function InvoicesPage({ searchParams }: Props) {
         invoiceRef: true,
         status: true,
         totalAmount: true,
+        currency: true,
         dueDate: true,
         account: { select: { name: true } },
       },
@@ -50,9 +50,7 @@ export default async function InvoicesPage({ searchParams }: Props) {
       by: ["status"],
       _count: true,
     }),
-    getOrgSettings(),
   ]);
-  const sym = getCurrencySymbol(orgSettings.baseCurrency);
 
   const countByStatus = Object.fromEntries(
     statusCounts.map((s) => [s.status, s._count])
@@ -192,7 +190,7 @@ export default async function InvoicesPage({ searchParams }: Props) {
                       <LocalTime value={inv.dueDate} utc />
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(Number(inv.totalAmount))}
+                      {getCurrencySymbol(inv.currency)}{formatMoney(Number(inv.totalAmount))}
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## Summary
- Invoice detail page was deriving the currency symbol from `orgSettings.baseCurrency`, so a GBP invoice on a USD-configured install showed `$1,234.00` instead of `£1,234.00`
- Each `Invoice` row already carries its own `currency` field — detail page now uses it directly, removing the unnecessary `getOrgSettings()` call
- Invoice list page had the same issue; also fixed to use `inv.currency` per row (adds `currency` to the select)

## Test plan
- [x] typecheck: skipped (DPF_SKIP_TYPECHECK=1, no node_modules in worktree)
- [x] next build: n/a
- [x] UX verification: code-verified — `invoice.currency` is always set on the model; no runtime fallback needed

## Context
Phase W audit gap R8-OPT-003: "Invoice detail renders \$ currency symbol for GBP invoices (SQL-created customer account)." Root cause was using org currency for display instead of the invoice's own currency field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)