### PR TITLE
fix(storefront): content-dependent sections seed as hidden until content is added (R10-SECT-001)

### DIFF
--- a/apps/web/app/api/storefront/admin/setup/route.ts
+++ b/apps/web/app/api/storefront/admin/setup/route.ts
@@ -73,7 +73,8 @@ export async function POST(req: NextRequest) {
           title: s.title,
           sortOrder: s.sortOrder,
           content: {},
-          isVisible: true,
+          // Content-dependent sections start hidden until operator adds content (R10-SECT-001).
+          isVisible: !["team", "gallery", "testimonials"].includes(s.type),
         })),
       },
       items: {

--- a/apps/web/lib/storefront/archetype-reset.ts
+++ b/apps/web/lib/storefront/archetype-reset.ts
@@ -124,15 +124,23 @@ export async function resetStorefrontArchetype(input: {
         ctaLabel?: string | null;
       }>;
 
+      // Content-dependent sections (team, gallery, testimonials) return null when
+      // their content is empty. Seed them as hidden until the operator adds content
+      // so the public storefront never shows invisible gap-sections (R10-SECT-001).
+      const CONTENT_DEPENDENT_TYPES = ["team", "gallery", "testimonials"];
+
       const sectionResult = await tx.storefrontSection.createMany({
-        data: sectionTemplates.map((section) => ({
-          storefrontId: storefront.id,
-          type: section.type,
-          title: section.title ?? null,
-          content: (section.content ?? {}) as unknown as Prisma.InputJsonValue,
-          sortOrder: section.sortOrder,
-          isVisible: true,
-        })),
+        data: sectionTemplates.map((section) => {
+          const hasContent = Object.keys(section.content ?? {}).length > 0;
+          return {
+            storefrontId: storefront.id,
+            type: section.type,
+            title: section.title ?? null,
+            content: (section.content ?? {}) as unknown as Prisma.InputJsonValue,
+            sortOrder: section.sortOrder,
+            isVisible: CONTENT_DEPENDENT_TYPES.includes(section.type) ? hasContent : true,
+          };
+        }),
       });
 
       const itemResult = await tx.storefrontItem.createMany({


### PR DESCRIPTION
## Summary
- TeamSection, GallerySection, and TestimonialsSection return \`null\` when seeded with empty \`content = {}\`, leaving invisible gap-sections on the public storefront after fresh setup or archetype reset (R10-SECT-001)
- Fix: seed these three section types with \`isVisible = false\` so they are hidden until the operator adds members/images/testimonials via the admin UI
- All other section types (hero, items, contact, about, donate, calculator, etc.) continue to seed as \`isVisible = true\` since they render without needing content

## Test plan
- [x] typecheck: skipped (no-node_modules worktree) — CI gate
- [x] vitest: n/a (no test file for archetype-reset seeding; behaviour verified by code inspection)
- [x] Logic: `CONTENT_DEPENDENT_TYPES.includes(section.type) ? hasContent : true` — team/gallery/testimonials with empty content → false; all others → true; content-seeded team → true
- [x] Both seed paths updated: `archetype-reset.ts` (switch archetype) and `setup/route.ts` (initial wizard)

Overlap sweep: no open PRs touch `archetype-reset.ts` or `setup/route.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)