### PR TITLE
feat(build-studio): allow local builds via the opencode engine

### DIFF
--- a/apps/web/lib/build/build-studio-capability-db.test.ts
+++ b/apps/web/lib/build/build-studio-capability-db.test.ts
@@ -8,6 +8,9 @@ vi.mock("@dpf/db", () => ({
     modelProvider: {
       findMany: vi.fn(),
     },
+    buildEngine: {
+      findFirst: vi.fn(),
+    },
   },
 }));
 
@@ -16,6 +19,7 @@ import { loadBuildStudioCapability } from "./build-studio-capability";
 
 const mockModelProfileFindMany = vi.mocked(prisma.modelProfile.findMany);
 const mockModelProviderFindMany = vi.mocked(prisma.modelProvider.findMany);
+const mockBuildEngineFindFirst = vi.mocked(prisma.buildEngine.findFirst);
 
 describe("loadBuildStudioCapability", () => {
   beforeEach(() => {
@@ -23,6 +27,10 @@ describe("loadBuildStudioCapability", () => {
     // Default: nothing merely disabled.
     mockModelProviderFindMany.mockResolvedValue(
       [] as unknown as Awaited<ReturnType<typeof prisma.modelProvider.findMany>>,
+    );
+    // Default: opencode engine not present (preserves pre-opencode gate behavior).
+    mockBuildEngineFindFirst.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof prisma.buildEngine.findFirst>>,
     );
   });
 
@@ -79,6 +87,53 @@ describe("loadBuildStudioCapability", () => {
       expect(result.enableableRunners).toEqual([
         { providerId: "anthropic-sub", name: "Claude / Anthropic (OAuth Subscription)", shortLabel: "Claude" },
       ]);
+    }
+  });
+
+  it("opens the gate for a local strong-tier model when the opencode engine is present (baked-in/probed)", async () => {
+    mockModelProfileFindMany.mockResolvedValue([
+      {
+        providerId: "local",
+        modelId: "docker.io/ai/qwen3-coder:latest",
+        supportsToolUse: false, // local API flag — opencode supplies the tool loop
+        maxInputTokens: null,
+        provider: { name: "Docker Model Runner (local)" },
+      },
+    ] as unknown as Awaited<ReturnType<typeof prisma.modelProfile.findMany>>);
+    mockBuildEngineFindFirst.mockResolvedValue(
+      { bakeInDefault: true, state: { present: true } } as unknown as Awaited<
+        ReturnType<typeof prisma.buildEngine.findFirst>
+      >,
+    );
+
+    const result = await loadBuildStudioCapability();
+
+    expect(mockBuildEngineFindFirst).toHaveBeenCalledWith({
+      where: { engineId: "opencode" },
+      select: { bakeInDefault: true, state: { select: { present: true } } },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.satisfyingProviderNames).toEqual(["Docker Model Runner (local)"]);
+    }
+  });
+
+  it("keeps the gate closed for a local model when the opencode engine is absent", async () => {
+    mockModelProfileFindMany.mockResolvedValue([
+      {
+        providerId: "local",
+        modelId: "docker.io/ai/qwen3-coder:latest",
+        supportsToolUse: false,
+        maxInputTokens: null,
+        provider: { name: "Docker Model Runner (local)" },
+      },
+    ] as unknown as Awaited<ReturnType<typeof prisma.modelProfile.findMany>>);
+    // buildEngine.findFirst → null (default from beforeEach)
+
+    const result = await loadBuildStudioCapability();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("only_local_provider_active");
     }
   });
 });

--- a/apps/web/lib/build/build-studio-capability.test.ts
+++ b/apps/web/lib/build/build-studio-capability.test.ts
@@ -103,7 +103,7 @@ describe("deriveBuildStudioCapability", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("REJECTS even strong-tier local models — Build Studio requires a remote provider regardless of local model strength (operator directive 2026-05-23)", () => {
+  it("REJECTS strong-tier local models when opencode is NOT available — the original robustness safeguard still holds (default localBuildEngineAvailable=false)", () => {
     const result = deriveBuildStudioCapability([
       model({
         providerId: "local",
@@ -116,6 +116,43 @@ describe("deriveBuildStudioCapability", () => {
     if (!result.ok) {
       expect(result.reason).toBe("only_local_provider_active");
     }
+  });
+
+  it("ACCEPTS a strong-tier local model when opencode IS available — even with API supportsToolUse=false (opencode supplies the tool loop) (operator decision 2026-06-15)", () => {
+    const result = deriveBuildStudioCapability(
+      [
+        model({
+          providerId: "local",
+          providerName: "Docker Model Runner (local)",
+          modelId: "docker.io/ai/qwen3-coder:latest",
+          supportsToolUse: false, // local chat model API flag — opencode handles tools
+          maxInputTokens: null, // 32K configured; null = assumed sufficient
+        }),
+      ],
+      [],
+      true, // localBuildEngineAvailable — opencode present/baked-in
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.satisfyingProviderNames).toContain("Docker Model Runner (local)");
+    }
+  });
+
+  it("REJECTS an adequate-tier local model even with opencode available — tier floor still applies", () => {
+    const result = deriveBuildStudioCapability(
+      [
+        model({
+          providerId: "local",
+          providerName: "Docker Model Runner (local)",
+          modelId: "docker.io/ai/gemma4:latest", // adequate tier
+          supportsToolUse: false,
+          maxInputTokens: null,
+        }),
+      ],
+      [],
+      true,
+    );
+    expect(result.ok).toBe(false);
   });
 
   it("REJECTS docker.io-prefixed local model IDs (real shape from Docker Model Runner)", () => {

--- a/apps/web/lib/build/build-studio-capability.ts
+++ b/apps/web/lib/build/build-studio-capability.ts
@@ -124,21 +124,29 @@ function isLocalProviderName(name: string): boolean {
  * decide whether Build Studio's build-specialist agent can be served by at
  * least one of them.
  *
- * **Hard rule: local-provider models never satisfy the gate**, regardless
- * of tier classification. Operator directive (Mark, 2026-05-23): Build Studio
- * does code generation + long tool sequences + complex reasoning that exceed
- * even strong-tier local model robustness (cf. `project_mechanism_question_
- * grounding_gap.md` — small/local models confabulate on this workload).
- * Local stays valid for less demanding coworkers; Build Studio specifically
- * requires a remote provider.
+ * **Local-provider rule: local models satisfy the gate ONLY when a
+ * deterministic tool-calling build engine (opencode) is available** to drive
+ * them. The original blanket block (operator directive, Mark, 2026-05-23) was
+ * grounded in raw local-model robustness on long tool sequences — small/local
+ * models confabulate on this workload (cf. `project_mechanism_question_
+ * grounding_gap.md`). That concern is addressed when the build dispatch runs
+ * through opencode, which parses the model's native tool-call format and
+ * supplies the tool loop itself rather than relying on the model's API
+ * tool-use. Operator decision (Mark, 2026-06-15): with opencode proven on
+ * qwen3-coder, enable local Build Studio gated on that engine's presence.
+ * Without opencode, local still cannot satisfy the gate. Remote providers are
+ * unchanged — they still require their own API tool-use.
  *
  * Nullable fields (supportsToolUse, maxInputTokens) are treated as "assumed
  * sufficient" so a freshly connected REMOTE provider isn't blocked while
- * model discovery is still running in the background.
+ * model discovery is still running in the background. For LOCAL models the
+ * API supportsToolUse flag is intentionally NOT required, because opencode —
+ * not the model API — provides the tool-call loop.
  */
 export function deriveBuildStudioCapability(
   models: ActiveProviderModel[],
   inactiveRunners: ConfiguredInactiveRunner[] = [],
+  localBuildEngineAvailable = false,
 ): BuildStudioCapability {
   const enableableRunners: EnableableRunner[] = inactiveRunners.map((r) => ({
     providerId: r.providerId,
@@ -159,11 +167,16 @@ export function deriveBuildStudioCapability(
   const activeProviderNames = Array.from(new Set(models.map((m) => m.providerName)));
 
   const satisfying = models.filter((m) => {
-    // Hard rule: local providers never satisfy Build Studio's gate, even when
-    // the tier classifier rates the model as strong (e.g. Qwen3 14B). The
-    // workload exceeds even strong-tier local robustness.
-    if (isLocalProviderName(m.providerName)) return false;
-    if (m.supportsToolUse === false) return false;
+    const isLocal = isLocalProviderName(m.providerName);
+    // Local providers satisfy the gate only when opencode is available to
+    // drive them (it supplies the tool-call loop the build workload needs).
+    // Without that engine, local stays blocked — preserving the original
+    // robustness safeguard.
+    if (isLocal && !localBuildEngineAvailable) return false;
+    // Remote providers must advertise API tool-use. Local models route their
+    // tool-calls through opencode's parser, so the model's API supportsToolUse
+    // flag (often false for local chat models) must NOT gate them out.
+    if (!isLocal && m.supportsToolUse === false) return false;
     const tier = assignTierFromModelId(m.modelId);
     if (!BUILD_STUDIO_REQUIRED_TIERS.has(tier)) return false;
     if (m.maxInputTokens !== null && m.maxInputTokens < BUILD_STUDIO_REQUIRED_CONTEXT_TOKENS) {
@@ -195,7 +208,7 @@ export function deriveBuildStudioCapability(
  * calls the pure decision function. Used at /build page render time.
  */
 export async function loadBuildStudioCapability(): Promise<BuildStudioCapability> {
-  const [profiles, inactiveProviders] = await Promise.all([
+  const [profiles, inactiveProviders, localEngine] = await Promise.all([
     prisma.modelProfile.findMany({
       where: {
         modelClass: { in: ["chat", "code"] },
@@ -220,7 +233,17 @@ export async function loadBuildStudioCapability(): Promise<BuildStudioCapability
       select: { providerId: true, name: true, cliEngine: true },
       orderBy: { providerId: "asc" },
     }),
+    // The opencode build engine — the deterministic tool-calling runner that
+    // makes a local model viable for Build Studio. "Available" = its binary is
+    // present in the sandbox (probed) OR it is baked into the image by default.
+    prisma.buildEngine.findFirst({
+      where: { engineId: "opencode" },
+      select: { bakeInDefault: true, state: { select: { present: true } } },
+    }),
   ]);
+
+  const localBuildEngineAvailable =
+    !!localEngine && (localEngine.state?.present === true || localEngine.bakeInDefault === true);
 
   const models: ActiveProviderModel[] = profiles.map((p) => ({
     providerId: p.providerId,
@@ -236,7 +259,7 @@ export async function loadBuildStudioCapability(): Promise<BuildStudioCapability
     cliEngine: p.cliEngine,
   }));
 
-  return deriveBuildStudioCapability(models, inactiveRunners);
+  return deriveBuildStudioCapability(models, inactiveRunners, localBuildEngineAvailable);
 }
 
 /**


### PR DESCRIPTION
## Problem

The Build Studio UI gate (`/build`) shows **"Connect a code-capable AI runner to start building — the local AI on this install can chat, but it is not the right runner for production code work yet"** and refuses to open the build flow on a local-only install. This is `deriveBuildStudioCapability`'s hard rule:

```ts
if (isLocalProviderName(m.providerName)) return false; // local NEVER satisfies
```

That rule (operator directive, 2026-05-23) was grounded in raw local-model robustness on long tool sequences — a real concern **before** the opencode build engine existed. opencode is the deterministic tool-calling runner built to solve exactly that: it parses the model's native `<function=…>` tool format and supplies the tool loop itself, independent of the model's API tool-use. It's proven writing files on qwen3-coder.

## Fix (operator decision 2026-06-15)

A local provider now satisfies the gate when:
- the **opencode `BuildEngine` is present** (probed) or baked-in, **and**
- the local model meets the existing **strong-tier + 32K-context** floor.

The model's API `supportsToolUse` flag is intentionally **not** required for local (opencode supplies tools). **Without opencode, local stays blocked** — the original robustness safeguard is preserved. Remote providers are unchanged.

Also unblocks `agentic-loop.ts`, which uses `isOnlyLocalLLMActive()` to pick honest-failure copy — it now proceeds for local+opencode instead of refusing.

## Tests (24 passed)

- pure fn: accepts local strong-tier + opencode even with `supportsToolUse=false`; rejects adequate-tier local; rejects local when opencode absent
- DB wrapper: queries the opencode engine, opens the gate when present, keeps it closed when absent

Backward-compatible: `localBuildEngineAvailable` defaults to `false`, so all prior call sites/tests behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)