### PR TITLE
docs(build-studio): local-LLM build engine (opencode) architecture + landing-page feature

### DIFF
--- a/docs/architecture/build-studio-diagrams/svg/01-opencode-local-llm-dispatch.svg
+++ b/docs/architecture/build-studio-diagrams/svg/01-opencode-local-llm-dispatch.svg
@@ -1,0 +1,62 @@
+<svg viewBox="0 0 680 520" xmlns="http://www.w3.org/2000/svg" role="img" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif">
+<title>opencode local-LLM dispatch architecture</title>
+<desc>The Build Studio orchestrator dispatches a build task through opencode-dispatch.ts into the sandbox container, where the opencode CLI runs an agent loop pointed at the install's local Docker Model Runner (qwen3-coder on the GPU), parses the model's native tool-call format, and writes files into the workspace — with no vendor credential.</desc>
+<style>
+  .t { fill: #1a1f25; }
+  .m { fill: #515b66; }
+  .grp { stroke: #d9dde3; }
+  @media (prefers-color-scheme: dark) {
+    .t { fill: #e6e8eb; }
+    .m { fill: #a4adb8; }
+    .grp { stroke: #262d36; }
+  }
+</style>
+
+<text x="340" y="28" text-anchor="middle" font-size="17" font-weight="600" class="t">Build Studio · opencode local-LLM dispatch</text>
+
+<rect x="30" y="46" width="620" height="92" rx="6" fill="none" class="grp" stroke-dasharray="4 4"/>
+<text x="44" y="64" font-size="12" font-weight="600" class="m">dpf-portal-1 · portal</text>
+<rect x="55" y="72" width="262" height="54" rx="4" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
+<text x="186" y="96" text-anchor="middle" font-size="14" font-weight="600" class="t">Build orchestrator</text>
+<text x="186" y="114" text-anchor="middle" font-size="12" class="m">picks dispatchEngine</text>
+<rect x="363" y="72" width="262" height="54" rx="4" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
+<text x="494" y="96" text-anchor="middle" font-size="14" font-weight="600" class="t">opencode-dispatch.ts</text>
+<text x="494" y="114" text-anchor="middle" font-size="12" class="m">runner · preflight</text>
+<path d="M317 99 L361 99" stroke="#9ca3af" stroke-width="1.5" marker-end="url(#a)"/>
+
+<path d="M494 138 L494 168" stroke="#9ca3af" stroke-width="1.5" marker-end="url(#a)"/>
+<text x="504" y="157" font-size="12" class="m">docker exec</text>
+
+<rect x="30" y="170" width="620" height="100" rx="6" fill="none" class="grp" stroke-dasharray="4 4"/>
+<text x="44" y="188" font-size="12" font-weight="600" class="m">dpf-sandbox-1 · sandbox</text>
+<rect x="55" y="198" width="262" height="58" rx="4" fill="none" stroke="#14b8a6" stroke-width="1.5"/>
+<text x="186" y="222" text-anchor="middle" font-size="14" font-weight="600" class="t">opencode CLI</text>
+<text x="186" y="240" text-anchor="middle" font-size="12" class="m">agent loop · no credential</text>
+<rect x="363" y="198" width="262" height="58" rx="4" fill="none" stroke="#14b8a6" stroke-width="1.5"/>
+<text x="494" y="222" text-anchor="middle" font-size="14" font-weight="600" class="t">parses &lt;function=…&gt;</text>
+<text x="494" y="240" text-anchor="middle" font-size="12" class="m">native tool-call format</text>
+<path d="M317 227 L361 227" stroke="#9ca3af" stroke-width="1.5" marker-end="url(#a)"/>
+
+<path d="M186 256 L186 306" stroke="#9ca3af" stroke-width="1.5" marker-end="url(#a)" marker-start="url(#b)"/>
+<text x="196" y="285" font-size="12" class="m">OpenAI /v1</text>
+<path d="M494 256 L494 306" stroke="#9ca3af" stroke-width="1.5" marker-end="url(#a)"/>
+<text x="504" y="285" font-size="12" class="m">writes files</text>
+
+<rect x="55" y="308" width="262" height="66" rx="4" fill="none" stroke="#8b5cf6" stroke-width="1.5"/>
+<text x="186" y="334" text-anchor="middle" font-size="14" font-weight="600" class="t">Docker Model Runner</text>
+<text x="186" y="353" text-anchor="middle" font-size="12" class="m">qwen3-coder · local GPU</text>
+<rect x="363" y="308" width="262" height="66" rx="4" fill="none" stroke="#16a34a" stroke-width="1.5"/>
+<text x="494" y="334" text-anchor="middle" font-size="14" font-weight="600" class="t">/workspace</text>
+<text x="494" y="353" text-anchor="middle" font-size="12" class="m">files + git diff returned</text>
+
+<rect x="30" y="402" width="620" height="86" rx="6" fill="none" class="grp"/>
+<text x="44" y="424" font-size="13" font-weight="600" class="t">vs. claude / codex / grok engines</text>
+<text x="44" y="446" font-size="12.5" class="m">Same in-sandbox agent loop — only the model endpoint differs.</text>
+<text x="44" y="465" font-size="12.5" class="m">opencode: local endpoint · no vendor credential · zero token cost · air-gappable.</text>
+<text x="44" y="481" font-size="12.5" class="m">Others: vendor cloud API + OAuth/key required.</text>
+
+<defs>
+<marker id="a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 Z" fill="#9ca3af"/></marker>
+<marker id="b" markerWidth="8" markerHeight="8" refX="0" refY="3" orient="auto"><path d="M6 0 L0 3 L6 6 Z" fill="#9ca3af"/></marker>
+</defs>
+</svg>

--- a/docs/architecture/local-llm-build-engine.md
+++ b/docs/architecture/local-llm-build-engine.md
@@ -1,0 +1,95 @@
+---
+title: Local-LLM build engine (opencode)
+description: How Build Studio writes code on the install's own local LLM — the opencode dispatch engine, its sandbox agent loop, and how it differs from the cloud-credentialed claude/codex/grok engines.
+---
+
+# Local-LLM build engine (opencode)
+
+Build Studio can develop the platform using the install's **own local LLM**, with no
+vendor credential and no token cost. This is the platform's built-in support for
+developing itself on the operator's own hardware. The capability is delivered by a
+dedicated Build Studio dispatch engine, **opencode**, that runs the install's bundled
+Docker Model Runner model (e.g. `qwen3-coder`) as a coding agent inside the sandbox.
+
+![opencode local-LLM dispatch architecture](build-studio-diagrams/svg/01-opencode-local-llm-dispatch.svg)
+
+## What opencode is
+
+[opencode](https://github.com/sst/opencode) (`sst/opencode`, npm `opencode-ai`, pinned
+to a baseline-musl build) is an open-source terminal coding agent — the same category as
+Claude Code or the Codex CLI, but vendor-neutral. You point it at any OpenAI-compatible
+model endpoint and run it headless:
+
+```
+opencode run --dir /workspace -m local/<model> --format json \
+  --dangerously-skip-permissions "<prompt>"
+```
+
+It runs its own agent loop (read files → call the model → execute tool calls → repeat),
+emits structured JSON events, and edits files in place.
+
+## Why it exists
+
+Build Studio already had three dispatch engines — `claude`, `codex`, `grok` — but every
+one needs a vendor credential and bills tokens to a cloud API. opencode is the
+**local-LLM equivalent**: inference goes to the install's own endpoint (Docker Model
+Runner / Ollama / vLLM), so a build runs **with no credential, at zero token cost, and
+air-gappable**. That is what "Build Studio off the local LLM" means.
+
+The decisive technical detail: small local models such as `qwen3-coder` do not reliably
+do *API-level* tool calling, but they emit tool calls in their **native `<function=…>`
+text format**. opencode parses that format itself and drives the tool loop — so the
+robustness comes from opencode, not from the model's API. This is why the build path
+works on a model whose API `supportsToolUse` flag is `false`, and why the Build Studio
+capability gate admits a local model **only when the opencode engine is present**.
+
+## How it is wired in
+
+- **Portal** (`dpf-portal-1`): the build orchestrator picks the `dispatchEngine` and hands
+  the task to `opencode-dispatch.ts` — the runner that mirrors `claude-dispatch.ts` /
+  `codex-dispatch.ts`. It runs a hard **preflight** (endpoint reachable + model present +
+  context above an advisory floor) before spending minutes on local inference.
+- **Sandbox** (`dpf-sandbox-1`): the runner does `docker exec` into the sandbox and runs
+  the **opencode CLI** there — the same isolation as the other engines. A generated
+  `~/.config/opencode/opencode.json` declares a custom provider named `local` and sets
+  `permission: allow` so a TTY-less container never blocks.
+- **Model**: opencode calls the **Docker Model Runner** (e.g. `qwen3-coder` on the local
+  GPU) over the OpenAI-compatible `/v1` API.
+- **Output**: tool calls write into `/workspace`; the `--format json` stream is parsed
+  back into a dispatch record plus a git diff.
+
+## Install and registration
+
+- `Dockerfile.sandbox` installs the pinned opencode binary into `/usr/local/bin` and
+  pre-stages it under `/opt/dpf-engines/opencode` (the musl variant sidesteps an
+  npm-on-Alpine install bug).
+- `packages/db/data/build-engines.json` registers opencode as a build engine with
+  `bakeInDefault: true` plus prestaged-binary and curl provisioning recipes — which is the
+  `BuildEngine` / `BuildEngineState.present` row the capability gate checks.
+
+## Where it sits in the pipeline
+
+A local-only install serves all five Build Studio phases:
+
+- **Ideate** and **Plan**: pure text generation via portal-side routing
+  (`routeAndCall`, quality-first) → the strong-tier local model; no API tool-use is
+  required.
+- **Build**: the orchestrator dispatches the task to the opencode runner → opencode plus
+  the local model writes the code.
+- **Review** / **Ship**: the same governed gates as any other engine.
+
+So the local LLM serves the whole pipeline; opencode is specifically the **build-phase
+execution engine** that makes code-writing robust on a small local model.
+
+## Relationship to the other engines
+
+opencode is one of several Build Studio dispatch engines and is selected by the same
+auto-detection and provider configuration as the rest. The only structural difference is
+the model endpoint: opencode points at a **local** OpenAI-compatible endpoint and needs
+no vendor credential, whereas claude / codex / grok point at a **cloud** API and require
+OAuth or an API key. The in-sandbox agent loop, the preflight, the JSON event parsing,
+and the governed phase gates are shared.
+
+> **Versioning note:** the opencode CLI contract above is pinned to a specific release
+> and was researched against opencode's own documentation. Re-verify the `run` flags and
+> config schema on any version bump.

--- a/docs/index.html
+++ b/docs/index.html
@@ -724,6 +724,11 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
     </p>
     <div class="pillars" style="margin-top:18px;">
       <div class="pillar">
+        <div class="tag">Develops itself on local AI</div>
+        <strong>Build Studio writes code on your own local LLM.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A dedicated dispatch engine, <strong>opencode</strong>, runs the bundled Docker Model Runner model (e.g. <code>qwen3-coder</code>) as a coding agent inside the sandbox &mdash; no vendor credential, zero token cost, air-gappable. It parses the local model&rsquo;s native tool-call format itself, so the platform can ideate, plan, and build a change end-to-end without a cloud API. Architecture: <a href="/architecture/local-llm-build-engine">local-llm-build-engine</a>.</p>
+      </div>
+      <div class="pillar">
         <div class="tag">Design-time decomposition</div>
         <strong>Oversized builds split before Plan churn.</strong>
         <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The Dale HVAC dogfood run exposed a real cliff: a feature can be directionally correct but too large for one Build Studio plan. The new design-time decomposition work keeps one parent design contract and creates smaller child builds before plan review oscillates.</p>


### PR DESCRIPTION
Preserves the opencode local-LLM dispatch architecture diagram so it isn't lost, and surfaces the capability as a first-class Build Studio feature on the docs landing page.

## What's included

- **Architecture diagram** — `docs/architecture/build-studio-diagrams/svg/01-opencode-local-llm-dispatch.svg`. Standalone, theme-adaptive (light/dark via `prefers-color-scheme`), following the existing `architecture/<topic>-diagrams/svg/` convention.
- **Architecture doc** — `docs/architecture/local-llm-build-engine.md`. Embeds the diagram plus an overview: what opencode is, why it exists (no credential / zero token cost / air-gappable), how it's wired into portal + sandbox + Docker Model Runner, install/registration, where it sits in the five-phase pipeline, and the version-pin caveat.
- **Landing page** — `docs/index.html`: a lead Build Studio pillar *'Develops itself on local AI — Build Studio writes code on your own local LLM'* linking to the architecture doc.

Docs-only change; no code or runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)