### PR TITLE
fix(build-studio): deterministic kind-aware test-first lenience in plan review

### DIFF
--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -7,6 +7,7 @@ import {
   architectureAdvisoryFromReview,
   ARCHITECTURE_REVIEW_REFERENCES,
   parseReviewResponse,
+  applyTestFirstLenienceForKind,
   extractClaimsFromReview,
   buildReviewBranchArtifacts,
   collectReviewerVerdicts,
@@ -131,6 +132,52 @@ describe("buildPlanReviewPrompt", () => {
     });
     expect(prompt).toContain("DOCUMENTATION-ONLY changes");
     expect(prompt).toContain("require NO test-first step");
+  });
+});
+
+describe("applyTestFirstLenienceForKind", () => {
+  const testFirstCritical = {
+    decision: "fail" as const,
+    issues: [
+      { severity: "critical" as const, description: "Task 2 does not specify a real failing test to write first for the header comment addition." },
+      { severity: "important" as const, description: "Task 1 omits the expected function signature." },
+    ],
+    summary: "two issues",
+  };
+
+  it("downgrades a test-first critical to non-blocking for a chore build → decision flips to pass", () => {
+    const out = applyTestFirstLenienceForKind(testFirstCritical, "chore");
+    expect(out.decision).toBe("pass");
+    expect(out.issues.find((i) => i.description.includes("test to write first"))?.severity).toBe("minor");
+    // the unrelated important issue is preserved as-is
+    expect(out.issues.find((i) => i.description.includes("function signature"))?.severity).toBe("important");
+  });
+
+  it("applies to fix and docs kinds too", () => {
+    expect(applyTestFirstLenienceForKind(testFirstCritical, "fix").decision).toBe("pass");
+    expect(applyTestFirstLenienceForKind(testFirstCritical, "docs").decision).toBe("pass");
+  });
+
+  it("does NOT touch a feature build — test-first stays critical and blocking", () => {
+    const out = applyTestFirstLenienceForKind(testFirstCritical, "feature");
+    expect(out.decision).toBe("fail");
+    expect(out.issues[0].severity).toBe("critical");
+  });
+
+  it("leaves a genuine (non-test-first) critical blocking even for a chore", () => {
+    const realBlocker = {
+      decision: "fail" as const,
+      issues: [{ severity: "critical" as const, description: "Plan refers to a missing modify target: lib/gone.ts" }],
+      summary: "missing file",
+    };
+    const out = applyTestFirstLenienceForKind(realBlocker, "chore");
+    expect(out.decision).toBe("fail");
+    expect(out.issues[0].severity).toBe("critical");
+  });
+
+  it("is a no-op when kind is null/undefined", () => {
+    expect(applyTestFirstLenienceForKind(testFirstCritical, null).decision).toBe("fail");
+    expect(applyTestFirstLenienceForKind(testFirstCritical, undefined).decision).toBe("fail");
   });
 
   it("includes task count for reviewer context", () => {

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -417,6 +417,51 @@ export function mergeReviews(r1: ReviewResult, r2: ReviewResult): ReviewResult {
   return { decision, issues: merged, summary };
 }
 
+/** Build kinds for which a missing test-first step must not block the plan gate.
+ *  Test-first is a feature-grade discipline; a chore, fix, or docs build changes
+ *  little or no logic, so a "write a real failing test first" complaint is not a
+ *  genuine blocker for it. */
+const TEST_FIRST_LENIENT_KINDS: ReadonlySet<string> = new Set(["chore", "fix", "docs", "doc"]);
+
+/** Matches a reviewer issue that complains about a missing/weak test-first step. */
+const TEST_FIRST_ISSUE_RE = /test[\s-]?first|failing test|real test|test for (logic|behavior)|write (a |the )?(real |failing )?test/i;
+
+/**
+ * Deterministic kind-aware lenience for the plan-review gate.
+ *
+ * The plan-review rubric already scopes the test-first requirement to LOGIC
+ * changes and exempts documentation-only work, but a reviewer model — notably a
+ * small local model running the build on-host — over-applies TDD and marks a
+ * comment/chore task "critical" for lacking a test, wedging the gate across
+ * rounds. Rather than depend on the model honoring the prose exemption, enforce
+ * it in code: for a chore/fix/docs build, downgrade any test-first critical to
+ * minor (non-blocking) and recompute the severity-driven decision. Genuine
+ * blockers (missing files, broken logic, oversized tasks) are untouched.
+ *
+ * Pure + side-effect-free so it is trivially unit-testable.
+ */
+export function applyTestFirstLenienceForKind(
+  review: ReviewResult,
+  kind: string | null | undefined,
+): ReviewResult {
+  if (!kind || !TEST_FIRST_LENIENT_KINDS.has(kind)) return review;
+  let changed = false;
+  const issues = review.issues.map((i) => {
+    if (i.severity === "critical" && TEST_FIRST_ISSUE_RE.test(i.description)) {
+      changed = true;
+      return {
+        ...i,
+        severity: "minor" as const,
+        description: `${i.description} [non-blocking for a ${kind} build — test-first is a feature-grade gate]`,
+      };
+    }
+    return i;
+  });
+  if (!changed) return review;
+  const decision: "pass" | "fail" = issues.some((i) => i.severity === "critical") ? "fail" : "pass";
+  return { ...review, issues, decision };
+}
+
 // ─── Response Parsing ────────────────────────────────────────────────────────
 
 export function parseReviewResponse(raw: string): ReviewResult {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -8697,7 +8697,7 @@ export async function executeTool(
       // BI-4396EFEC (D38) — also load the prior planReview so we can pass
       // its issues to the reviewer prompt for delta-awareness and compute
       // the iteration trajectory for the operator-facing chip.
-      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { buildPlan: true, planReview: true } });
+      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { buildPlan: true, planReview: true, kind: true } });
       if (!build?.buildPlan) return { success: false, error: "No build plan saved yet.", message: "Save buildPlan first." };
       const priorPlanReview = (build.planReview ?? null) as
         | { issues?: Array<{ severity?: string; description?: string }>; iteration?: { round?: number } }
@@ -8732,7 +8732,7 @@ export async function executeTool(
           data: { review, blocked: true, action: "revise_and_resubmit" },
         };
       }
-      const { buildPlanReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews, collectReviewerVerdicts } = await import("@/lib/build-reviewers");
+      const { buildPlanReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews, applyTestFirstLenienceForKind, collectReviewerVerdicts } = await import("@/lib/build-reviewers");
       // BI-4396EFEC (D38) — Compute the iteration context up front so we can
       // (a) feed prior issues into the reviewer prompt and (b) populate
       // ReviewResult.iteration on the output. Round is 1-based: first
@@ -8780,11 +8780,17 @@ export async function executeTool(
       const archAdvisoryNote = architectureAdvisory && architectureAdvisory.issues.length > 0
         ? ` Architecture review (advisory): ${architectureAdvisory.summary} Fold actionable items into the plan before building — they do not block this gate.`
         : "";
-      const mergedReview = r1 && r2 ? mergeReviews(r1, r2) : r1 ?? r2 ?? {
+      const rawMergedReview = r1 && r2 ? mergeReviews(r1, r2) : r1 ?? r2 ?? {
         decision: "fail" as const,
         issues: [{ severity: "critical" as const, description: "Both review agents failed to respond" }],
         summary: "Review could not be completed — retry.",
       };
+      // Deterministic kind-aware lenience: a chore/fix/docs build must not be
+      // blocked by a reviewer's missing-test-first complaint (test-first is a
+      // feature-grade gate). Enforced in code so it does not depend on the
+      // reviewer model honoring the rubric's prose exemption — the local model
+      // in particular over-applies TDD to comment/chore tasks.
+      const mergedReview = applyTestFirstLenienceForKind(rawMergedReview, build.kind);
       // BI-4396EFEC (D38) — Compute the iteration delta against the prior
       // round and attach to the ReviewResult. computeReviewDelta + isOscillating
       // live in feature-build-types so they're independently unit-testable.


### PR DESCRIPTION
## Problem

[#1974](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1974) added a prose exemption to the plan-review rubric for documentation-only changes, but a reviewer **model** — notably the small **local** model that runs builds on-host — does not reliably honor it. Driving an end-to-end local-LLM build of a `chore` (add a header comment), the local reviewer kept marking the task **critical** for lacking a 'real failing test', oscillating across rounds and wedging the plan gate so the build phase never ran.

The prose fix helps frontier models; it does not bind a weak local model. Ironically this is the exact small-model rigidity the original local-build block worried about.

## Fix

Enforce the policy **in code** rather than relying on the model reading nuance. `applyTestFirstLenienceForKind` downgrades a *test-first* critical to **minor** (non-blocking) for **chore / fix / docs** builds and recomputes the severity-driven decision. Wired into the dual-reviewer `reviewBuildPlan` MCP handler, keyed on `FeatureBuild.kind`.

- Genuine blockers (missing files, broken logic, oversized tasks) are **untouched**.
- **feature** builds are unaffected — test-first stays blocking.
- Pure, unit-tested helper (5 new cases); 53 tests pass.

## Context

Fourth in the chain enabling Build Studio off the local LLM: [#1958](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1958) (governed promote), [#1973](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1973) (local capability gate), [#1974](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1974) (rubric prose), this one (deterministic enforcement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)