### PR TITLE
fix(opencode): write runner files as node + never auto-pick an embedding model

### DIFF
--- a/apps/web/lib/integrate/opencode-dispatch.test.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   sandboxReachableUrl,
   preflightLocalEndpoint,
+  pickDefaultCodingModel,
   buildOpencodeConfig,
   summarizeOpencodeEvent,
   extractOpencodeResult,
@@ -78,11 +79,38 @@ describe("preflightLocalEndpoint", () => {
     expect(res.resolvedModel).toBe("qwen3-coder");
   });
 
-  it("falls back to the first served model when none requested", async () => {
+  it("falls back to the first served CHAT model when none requested", async () => {
     const fetchImpl = (async () => modelsResponse(["first-model", "second"])) as unknown as typeof fetch;
     const res = await preflightLocalEndpoint("http://localhost:11434/v1", "", fetchImpl);
     expect(res.ok).toBe(true);
     expect(res.resolvedModel).toBe("first-model");
+  });
+
+  it("never auto-resolves to an embedding model — skips nomic-embed and prefers the coder (regression: build dispatched to nomic-embed-text)", async () => {
+    const fetchImpl = (async () =>
+      modelsResponse(["docker.io/ai/nomic-embed-text-v1.5:latest", "docker.io/ai/qwen3-coder:latest"])) as unknown as typeof fetch;
+    const res = await preflightLocalEndpoint("http://localhost:11434/v1", "", fetchImpl);
+    expect(res.ok).toBe(true);
+    expect(res.resolvedModel).toBe("docker.io/ai/qwen3-coder:latest");
+  });
+});
+
+describe("pickDefaultCodingModel", () => {
+  it("excludes embedding/rerank/stt models", () => {
+    expect(pickDefaultCodingModel(["nomic-embed-text", "bge-m3", "qwen3:8b"])).toBe("qwen3:8b");
+    expect(pickDefaultCodingModel(["whisper-base", "gemma3:latest"])).toBe("gemma3:latest");
+  });
+
+  it("prefers a coder model over a plain chat model", () => {
+    expect(pickDefaultCodingModel(["gemma3", "qwen3-coder", "qwen3"])).toBe("qwen3-coder");
+  });
+
+  it("prefers a qwen3 model when no explicit coder is present", () => {
+    expect(pickDefaultCodingModel(["gemma3", "qwen3:14b"])).toBe("qwen3:14b");
+  });
+
+  it("returns null when only non-chat models are served", () => {
+    expect(pickDefaultCodingModel(["nomic-embed-text", "bge-reranker"])).toBeNull();
   });
 
   it("enforces the context floor only when the endpoint reports it", async () => {

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -76,6 +76,27 @@ type OpenAiModelsResponse = {
  * Hard gate: the endpoint must return a model list, and the requested model (if
  * any) must be present. Context is enforced only when the endpoint reports it.
  */
+/**
+ * Pick a coding-capable model when none was explicitly requested.
+ *
+ * A local OpenAI-compatible endpoint (Docker Model Runner / Ollama) commonly
+ * serves NON-chat models too — embeddings (nomic-embed, bge), rerankers, STT
+ * (whisper). Blindly taking models[0] picked `nomic-embed-text` and dispatched
+ * a build to an embedding model (it cannot follow a coding agent loop). Exclude
+ * those classes and prefer an explicit coder model, then a qwen3 family model,
+ * then any remaining chat model. Returns null only when nothing usable is served.
+ */
+export function pickDefaultCodingModel(models: string[]): string | null {
+  const NON_CHAT_RE = /embed|nomic|bge[-_]|rerank|whisper|\bstt\b|\btts\b|clip|vision-embed/i;
+  const chatModels = models.filter((m) => !NON_CHAT_RE.test(m));
+  return (
+    chatModels.find((m) => /coder|[-_]code\b|code[-_]/i.test(m)) ??
+    chatModels.find((m) => /qwen3/i.test(m)) ??
+    chatModels[0] ??
+    null
+  );
+}
+
 export async function preflightLocalEndpoint(
   portalBaseUrl: string,
   requestedModel: string,
@@ -104,7 +125,7 @@ export async function preflightLocalEndpoint(
     ? requestedModel
     : requestedModel
       ? null
-      : models[0];
+      : pickDefaultCodingModel(models);
 
   if (!resolvedModel) {
     return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Requested model "${requestedModel}" is not served by the local endpoint. Available: ${models.join(", ")}.` };
@@ -310,8 +331,11 @@ export async function dispatchOpencodeTask(params: {
     );
 
     const promptB64 = Buffer.from(taskPrompt).toString("base64");
+    // Write as the `node` user — the runner script below is executed as `node`
+    // (docker exec --user node), and it `cat`s this prompt file. Writing it as
+    // root with chmod 600 makes it unreadable to node ("Permission denied").
     await execAsync(
-      `docker exec ${containerId} sh -c "echo '${promptB64}' | base64 -d > ${promptFile} && chmod 600 ${promptFile}"`,
+      `docker exec --user node ${containerId} sh -c "echo '${promptB64}' | base64 -d > ${promptFile} && chmod 600 ${promptFile}"`,
       { timeout: 5_000 },
     );
 
@@ -329,8 +353,11 @@ export async function dispatchOpencodeTask(params: {
       "cleanup",
     ].join("\n");
     const scriptB64 = Buffer.from(script).toString("base64");
+    // Write as the `node` user for the same reason — the script is executed via
+    // `docker exec --user node ... ${runnerScript}`; written as root with chmod
+    // 700 it is unreadable/unexecutable to node ("Permission denied").
     await execAsync(
-      `docker exec ${containerId} sh -c "echo '${scriptB64}' | base64 -d > ${runnerScript} && chmod 700 ${runnerScript}"`,
+      `docker exec --user node ${containerId} sh -c "echo '${scriptB64}' | base64 -d > ${runnerScript} && chmod 700 ${runnerScript}"`,
       { timeout: 5_000 },
     );
 


### PR DESCRIPTION
Two bugs surfaced by the **first real orchestrator-driven local build** of FB-2E55A512 (the earlier proof was a direct opencode invocation that skipped both code paths). Both showed up in `BuildDispatchAttempt`:

```
model: docker.io/ai/nomic-embed-text-v1.5:latest
stderr: /bin/sh: can't open '/tmp/opencode-run-<uuid>.sh': Permission denied
```

## 1. Permission denied

The prompt file and runner script are written with `docker exec` (default **root** user) + `chmod 600/700`, then executed/read with `docker exec --user node` — so `node` can't open its own runner script. The `opencode.json` config write already uses `--user node`; the prompt + script writes didn't. Fixed to match.

## 2. Wrong model (embedding model)

`opencodeModel` defaults to empty ("resolved at dispatch"), and preflight took `models[0]` from `/v1/models` — which was the **embedding** model `nomic-embed-text-v1.5`. A local endpoint (Docker Model Runner / Ollama) commonly serves embeddings, rerankers, and STT alongside chat models. New `pickDefaultCodingModel` excludes those classes and prefers a coder model, then qwen3, then any chat model.

## Tests (23 pass)

Regression: `[nomic-embed-text, qwen3-coder]` with no requested model → resolves `qwen3-coder`; plus `pickDefaultCodingModel` unit cases (embedding exclusion, coder preference, qwen3 preference, all-non-chat → null).

Fifth in the chain enabling Build Studio off the local LLM — this is the build-phase execution path itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)