### PR TITLE
fix(build-studio): route durable pipeline code-gen to opencode for local builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,10 @@
 node_modules
 **/node_modules
+# Prisma client + other generated artifacts are rebuilt in the image
+# (Dockerfile runs `prisma generate`). Excluding them keeps the build context
+# clean — in a dev worktree these are symlinks/junctions to the root clone
+# (the test "junction trick") that otherwise leak in and break `COPY packages/`.
+**/generated
 .next
 **/.next
 apps/web/.next

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -424,6 +424,63 @@ async function stepGenerateCode(
   });
   const threadId = thread?.id ?? `build-pipeline-${buildId}`;
 
+  // Local-LLM build path: when the configured dispatch engine is opencode, run
+  // the build through the opencode CLI runner instead of runAgenticLoop. The
+  // agentic loop relies on the model's API tool-calling (requireTools), which a
+  // local model can't do reliably — it fails with "No AI model that supports
+  // tools is active." opencode is exactly the runner built to bridge that: it
+  // parses the local model's native <function=…> tool format itself and drives
+  // the read-edit-write loop in the sandbox. Gated on provider === "opencode"
+  // so installs with a frontier CLI/provider keep the existing agentic path.
+  const { getBuildStudioConfig } = await import("./build-studio-config");
+  const dispatchConfig = await getBuildStudioConfig();
+  if (dispatchConfig.provider === "opencode") {
+    const { dispatchOpencodeTask } = await import("./opencode-dispatch");
+    const ocTask: import("./task-dependency-graph").AssignedTask = {
+      taskIndex: 0,
+      title: brief?.title ?? build.title ?? buildId,
+      specialist: "software-engineer",
+      files: [],
+      task: {
+        title: brief?.title ?? build.title ?? buildId,
+        testFirst: "",
+        implement: userMessage,
+        verify: Array.isArray(brief?.acceptanceCriteria) ? brief.acceptanceCriteria.join("; ") : "",
+      },
+    };
+    const oc = await dispatchOpencodeTask({
+      task: ocTask,
+      buildId,
+      buildContext,
+      model: dispatchConfig.opencodeModel,
+      providerId: dispatchConfig.opencodeProviderId,
+      onProgress: (message) => {
+        if (thread?.id) {
+          agentEventBus.emit(thread.id, { type: "orchestrator:task_progress", buildId, taskTitle: ocTask.title, message });
+        }
+      },
+    });
+    const ocToolNames = oc.executedTools.map((t) => t.name);
+    await prisma.featureBuild.update({
+      where: { buildId },
+      data: {
+        taskResults: {
+          agenticResult: oc.content.slice(0, 5000),
+          toolsExecuted: ocToolNames,
+          // opencode emits write/edit tool events for file changes.
+          filesChanged: ocToolNames.filter((n) => n === "write" || n === "edit").length,
+          ranTests: false,
+          providerId: dispatchConfig.opencodeProviderId || "local",
+          modelId: dispatchConfig.opencodeModel || "local",
+        } as unknown as import("@dpf/db").Prisma.InputJsonValue,
+      },
+    });
+    if (!oc.success) {
+      throw new Error(`opencode build dispatch failed: ${oc.content.slice(0, 300)}`);
+    }
+    return state;
+  }
+
   // Run the agentic loop — this gives us iterative tool use with the full
   // read-edit-test-fix workflow instead of single-shot code generation
   const result = await runAgenticLoop({


### PR DESCRIPTION
## The actual reason Build Studio couldn't build off the local LLM

The durable `build/execute` pipeline's `stepGenerateCode` (build-pipeline.ts) **always** used `runAgenticLoop({ requireTools: true })`, which depends on the model's **API tool-calling**. On a local-only install that fails outright — `No AI model that supports tools is active` — because qwen3-coder is `supportsToolUse=false` and there's no frontier provider. So a local build reached `complete` with `filesChanged:0` and never wrote code.

The opencode runner (which parses the local model's native `<function=…>` format and needs no API tool-use) was wired into the **legacy** orchestrator `runSpecialistTask` — a path the durable pipeline never calls. That was the disconnect.

## Fix

Route `stepGenerateCode` through the opencode runner when the configured dispatch provider is `opencode`. Gated on `provider === 'opencode'`, so installs with a frontier CLI keep the agentic path unchanged.

## Verified end-to-end on the live instance (qwen3-coder)

```diff
+// This endpoint is used by the opencode build engine for dispatching builds
+// to a local model endpoint. The getOllamaBaseUrl() function returns the
+// OpenAI-compatible base URL for the local model endpoint.
```
Dispatch: `model=qwen3-coder, success=true, exitCode=0`. opencode read the file, corrected the stale path, and wrote a clarifying header referencing the real function — the chore (BI-8F528C08), authored by the local model through the durable pipeline.

Also re-applies the `.dockerignore **/generated` exclusion (lost between PRs), needed to build a deploy image from a dev worktree.

Known minor follow-up: `OpencodeResult.executedTools` comes back empty from the JSON parse, so the `filesChanged` counter under-reports (cosmetic; the write itself succeeds). Final piece of the local-LLM chain: #1958, #1973, #1974, #1976, #1977, this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)