### PR TITLE
fix(build): AgentActivityStrip crash on non-array taskResults (/build detail)

### DIFF
--- a/apps/web/components/build/AgentActivityStrip.test.tsx
+++ b/apps/web/components/build/AgentActivityStrip.test.tsx
@@ -71,6 +71,24 @@ describe("AgentActivityStrip render gate", () => {
     render(<AgentActivityStrip build={makeRow()} />);
     expect(screen.getByTestId("agent-activity-strip")).toBeTruthy();
   });
+
+  it("does not throw when taskResults is a non-array JSON object (agentic single-shot summary)", () => {
+    // Regression: the /build detail page crashed because the orchestrator
+    // persists taskResults as an object, not a TaskResult[]. `{} ?? []`
+    // returns the object, so `.forEach` threw. FleetDensityBar was fixed in
+    // #1978; AgentActivityStrip (the detail center pane) had the same bug.
+    const agenticSummary = {
+      modelId: "qwen3-coder",
+      providerId: "opencode",
+      filesChanged: ["apps/web/lib/ollama-url.ts"],
+      toolsExecuted: 3,
+      ranTests: true,
+    } as unknown as FeatureBuildRow["taskResults"];
+    render(<AgentActivityStrip build={makeRow({ taskResults: agenticSummary })} />);
+    // No per-task results → every cell is queued, strip still renders.
+    expect(screen.getByTestId("agent-activity-strip")).toBeTruthy();
+    expect(screen.getAllByRole("img", { name: /: queued/i }).length).toBe(5);
+  });
 });
 
 describe("AgentActivityStrip cell state priority", () => {

--- a/apps/web/components/build/AgentActivityStrip.tsx
+++ b/apps/web/components/build/AgentActivityStrip.tsx
@@ -102,9 +102,14 @@ export function AgentActivityStrip({ build }: Props) {
       build.buildPlan.tasks,
     );
 
-    // Build lookup of completed task results: title → passed
+    // Build lookup of completed task results: title → passed.
+    // taskResults is typed TaskResult[] but the orchestrator persists a
+    // non-array JSON shape (an empty `{}`, the per-task `{ tasks, ... }`
+    // object, or the agentic single-shot `{ modelId, filesChanged, ... }`
+    // summary). `{} ?? []` returns `{}`, so iterating the raw value throws.
+    // Guard with Array.isArray — mirrors the FleetDensityBar fix (#1978).
     const resultByTitle = new Map<string, boolean>();
-    (build.taskResults ?? []).forEach((r) => {
+    (Array.isArray(build.taskResults) ? build.taskResults : []).forEach((r) => {
       resultByTitle.set(r.title, r.testResult?.passed ?? true);
     });
 


### PR DESCRIPTION
## Problem

The Build Studio detail page `/build?buildId=<id>` crashed with the Next.js error boundary ("Something went wrong") for a build in the **build** phase whose execution had stalled/failed (e.g. `FB-2E55A512`, stalled at `db_ready`). The build **list** rendered fine — only the detail view crashed.

Server log:
```
⨯ TypeError: (a ?? []) is not iterable   // FleetDensityBar (sidebar)
⨯ TypeError: build.taskResults.forEach is not a function   // AgentActivityStrip (detail center pane)
```

## Root cause

`FeatureBuild.taskResults` is typed `TaskResult[] | null`, but the orchestrator persists a **non-array JSON object**:
- an empty `{}`,
- the per-task `{ tasks, completedTasks, ... }` runtime object, or
- (for the opencode local-LLM agentic runner) a single-shot summary `{ modelId, providerId, filesChanged, toolsExecuted, ranTests, ... }` — confirmed as the live shape on the install.

Because `{} ?? []` returns the object, any component iterating the raw value throws.

[#1978](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1978) fixed `FleetDensityBar` (sidebar/list) with an `Array.isArray` guard, but the **same bug remained in `AgentActivityStrip`** — which only renders in the detail center pane during the build phase, so the detail page still crashed.

## Fix

Guard the `AgentActivityStrip` task-result iteration with `Array.isArray`, mirroring the #1978 FleetDensityBar fix. A non-array `taskResults` is treated as "no per-task results yet" (all cells queued) instead of crashing. This unblocks the operator's path to the **Reset Build** affordance for any build in this state.

Adds a regression test rendering the agentic single-shot summary shape.

## Verification

- New + existing `AgentActivityStrip`, `FleetDensityBar`, `BuildListItem` tests pass (39/39). The regression test feeds the exact live object shape from the install DB.
- Root cause confirmed by querying the live install: `jsonb_typeof(taskResults) = 'object'`, keys `{modelId, ranTests, providerId, filesChanged, agenticResult, toolsExecuted}`, `phase = build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)