### PR TITLE
fix(build-studio): wire real code-graph research into local ideate

### DIFF
--- a/apps/web/lib/integrate/ideate-dispatch.test.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect } from "vitest";
-import { buildResearchPrompt } from "./ideate-dispatch";
+import { buildResearchPrompt, deriveSearchTerms } from "./ideate-dispatch";
+
+describe("deriveSearchTerms", () => {
+  it("splits camelCase and drops boilerplate stopwords", () => {
+    const terms = deriveSearchTerms("Add truncateMiddle string helper with unit tests", "A pure utility function");
+    expect(terms).toContain("truncate");
+    expect(terms).toContain("middle");
+    expect(terms).not.toContain("add");
+    expect(terms).not.toContain("helper");
+  });
+
+  it("keeps distinctive identifier terms and caps the list at 6 (title-priority)", () => {
+    const terms = deriveSearchTerms("Exclude minilm models", "harden the pickDefaultCodingModel selection regex");
+    expect(terms).toContain("minilm");
+    expect(terms).toContain("pick"); // camelCase split of pickDefaultCodingModel
+    expect(terms.length).toBeLessThanOrEqual(6);
+  });
+
+  it("returns an empty list for an all-stopword input", () => {
+    expect(deriveSearchTerms("Add a helper", "with unit tests")).toEqual([]);
+  });
+});
 
 describe("buildResearchPrompt", () => {
   const baseParams = {

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -339,6 +339,69 @@ function parseDesignDoc(output: string): Record<string, unknown> | null {
 /**
  * Dispatch ideate research to the selected external CLI (Claude / Codex / Grok) inside the sandbox.
  */
+/** Derive a few distinctive search terms from the feature title + description,
+ *  splitting camelCase and dropping boilerplate stopwords. */
+export function deriveSearchTerms(title: string, description: string): string[] {
+  const STOP = new Set([
+    "add","with","unit","test","tests","the","and","for","into","that","this","from",
+    "helper","function","functions","value","values","new","build","studio","apps","web",
+    "lib","shared","existing","module","modules","return","returns","length","place",
+    "search","codebase","first","rather","than","creating","duplicate","only","create",
+    "file","files","cover","covering","acceptance","pure","string","stateless","reuse",
+  ]);
+  const normalized = `${title} ${description}`
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2") // split camelCase: truncateMiddle → truncate Middle
+    .toLowerCase();
+  const words = normalized.match(/[a-z][a-z0-9]{2,}/g) ?? [];
+  const seen = new Set<string>();
+  const terms: string[] = [];
+  for (const w of words) {
+    if (STOP.has(w) || seen.has(w)) continue;
+    seen.add(w);
+    terms.push(w);
+    if (terms.length >= 6) break;
+  }
+  return terms;
+}
+
+/**
+ * Real codebase research for the LOCAL (routeAndCall) ideate path. The frontier
+ * path searches /workspace via its in-sandbox CLI; locally we query the indexed
+ * code graph (searchCodeGraph) for each derived term and format the hits so the
+ * model grounds existingFunctionalityAudit on real symbols/paths instead of
+ * fabricating the search. Resilient: any failure or an unbuilt graph yields "".
+ */
+async function gatherCodeGraphContext(
+  terms: string[],
+  onProgress?: (message: string) => void,
+): Promise<string> {
+  if (terms.length === 0) return "";
+  try {
+    const { searchCodeGraph } = await import("@/lib/integrate/code-graph/graph-queries");
+    const blocks: string[] = [];
+    let anyAvailable = false;
+    for (const term of terms) {
+      const r = await searchCodeGraph({ query: term, limit: 6 });
+      if (!r.available) continue;
+      anyAvailable = true;
+      if (r.results.length > 0) {
+        const hits = r.results
+          .map((x) => `  - ${x.name} (${x.path}${x.startLine ? `:${x.startLine}` : ""})`)
+          .join("\n");
+        blocks.push(`Search "${term}" → ${r.results.length} hit(s):\n${hits}`);
+      }
+    }
+    if (!anyAvailable) return "";
+    onProgress?.(`Code graph searched: ${terms.join(", ")}`);
+    if (blocks.length === 0) {
+      return `\n\nCODE GRAPH SEARCH (authoritative — the indexed codebase was searched for you):\nNo indexed symbol or file matched the feature's key terms: ${terms.join(", ")}. For existingFunctionalityAudit, state that you searched these exact terms in the code graph and found no pre-existing implementation — do NOT invent file paths.`;
+    }
+    return `\n\nCODE GRAPH SEARCH RESULTS (authoritative — the indexed codebase was searched for you; ground existingFunctionalityAudit and reusePlan on THESE real symbols/paths, do not invent paths):\n${blocks.join("\n")}\n\nIf none of the above is genuinely related, say so explicitly and treat the feature as new.`;
+  } catch {
+    return "";
+  }
+}
+
 export async function dispatchIdeateResearch(params: {
   featureTitle: string;
   featureDescription: string;
@@ -366,7 +429,17 @@ export async function dispatchIdeateResearch(params: {
   if (dispatchEngine === "opencode") {
     const startMs = Date.now();
     try {
-      const prompt = buildResearchPrompt(params);
+      // The frontier ideate path dispatches a CLI into the sandbox that actually
+      // searches /workspace. The local routeAndCall path can't — so without help
+      // the model FABRICATES the "existingFunctionalityAudit" ("Searched for …")
+      // per the prompt template without searching anything. Wire the real code
+      // graph in: pre-fetch indexed symbols/files for the feature's terms and
+      // inject them as authoritative search results the model must ground on.
+      const codeGraphContext = await gatherCodeGraphContext(
+        deriveSearchTerms(params.featureTitle, params.featureDescription),
+        params.onProgress,
+      );
+      const prompt = buildResearchPrompt(params) + codeGraphContext;
       const { routeAndCall } = await import("@/lib/inference/routed-inference");
       const response = await routeAndCall(
         [{ role: "user" as const, content: prompt }],


### PR DESCRIPTION
## Problem (found while running a local build through the pipeline)

The frontier ideate path dispatches a CLI into the sandbox that searches `/workspace`. The **local** path (`routeAndCall`) can't search anything, so the model **fabricated** the design doc's `existingFunctionalityAudit` — writing *'Searched for X, found nothing'* per the prompt template without actually searching. On a feature whose related code already exists, local ideate would miss it and propose a duplicate.

## Fix

Wire the indexed **code graph** into the local ideate path:
- `deriveSearchTerms` extracts distinctive terms from the feature title/description (camelCase-split, stopword-filtered)
- query `searchCodeGraph` for each, inject the real symbol/path hits into the research prompt as authoritative results to ground the audit + reuse plan on
- resilient: an unbuilt/unavailable graph injects nothing (unchanged behavior)

First of the WWMD/WWWD/WSID/code-graph tools to wire into the local build process.

## Verified on the live install

Before (fabricated): *'No existing implementation found. Searched for string-helpers, truncate…'*
After (grounded): the audit now cites **real indexed files** (e.g. `apps/web/lib/integrate/sandbox/sandbox.ts`, `.../api/sandbox/preview/route.ts`) pulled from the code graph.

## Known follow-up (filed separately)

Surfaced a real index gap: the code graph was indexed off a stale branch (`my-changes`) missing `opencode-dispatch.ts`, so grounding is only as complete as the index. Tracking that separately — it makes this fix *more* accurate once resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)