### PR TITLE
fix(self-upgrade,nonprod): retire host-clone direct-merge + cap shared-lease holds (BI-4043A64B)

### DIFF
--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   claimNonprodEnvironmentLease,
+  clampLeaseExpiry,
   listActiveNonprodEnvironmentLeases,
   releaseNonprodEnvironmentLease,
+  renewNonprodEnvironmentLease,
+  reapExpiredNonprodEnvironmentLeases,
+  MAX_LEASE_TTL_MS,
 } from "./environment-lease";
 
 function db() {
@@ -10,8 +14,10 @@ function db() {
     nonProductionEnvironmentLease: {
       findMany: vi.fn().mockResolvedValue([]),
       findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
       create: vi.fn().mockResolvedValue({ leaseId: "NPEL-1" }),
       update: vi.fn().mockResolvedValue({ leaseId: "NPEL-1", status: "released" }),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
   };
 }
@@ -90,6 +96,104 @@ describe("non-production environment leases", () => {
         status: "released",
         releasedAt: new Date("2026-05-26T19:00:00.000Z"),
       },
+    });
+  });
+});
+
+describe("nonprod lease anti-monopolization (BI-4043A64B)", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  it("clamps a hold longer than the max window down to now + MAX_LEASE_TTL_MS", () => {
+    const requested = new Date(now.getTime() + 8 * 60 * 60_000); // 8h ask
+    const clamped = clampLeaseExpiry(now, requested);
+    expect(clamped.getTime()).toBe(now.getTime() + MAX_LEASE_TTL_MS);
+  });
+
+  it("leaves a within-window hold unchanged", () => {
+    const requested = new Date(now.getTime() + 5 * 60_000); // 5 min
+    expect(clampLeaseExpiry(now, requested).getTime()).toBe(requested.getTime());
+  });
+
+  it("caps the claimed expiry so one process cannot hold the instance for hours", async () => {
+    const mockDb = db();
+    await claimNonprodEnvironmentLease({
+      db: mockDb as never,
+      environmentKey: "active-candidate",
+      ownerProvider: "claude",
+      ownerSessionId: "s1",
+      purpose: "long job",
+      url: "http://localhost:3001",
+      ports: [3001],
+      expiresAt: new Date(now.getTime() + 8 * 60 * 60_000), // asks for 8h
+      now,
+    });
+    const data = mockDb.nonProductionEnvironmentLease.create.mock.calls[0][0].data;
+    expect(data.expiresAt.getTime()).toBe(now.getTime() + MAX_LEASE_TTL_MS);
+  });
+
+  it("renews an active, owned, unexpired lease (heartbeat extends the window)", async () => {
+    const mockDb = db();
+    mockDb.nonProductionEnvironmentLease.findUnique.mockResolvedValue({
+      leaseId: "NPEL-1",
+      status: "active",
+      ownerSessionId: "s1",
+      expiresAt: new Date(now.getTime() + 60_000),
+    });
+    mockDb.nonProductionEnvironmentLease.update.mockResolvedValue({ leaseId: "NPEL-1" });
+    const r = await renewNonprodEnvironmentLease({
+      db: mockDb as never,
+      leaseId: "NPEL-1",
+      ownerSessionId: "s1",
+      now,
+    });
+    expect(r.status).toBe("renewed");
+    const data = mockDb.nonProductionEnvironmentLease.update.mock.calls[0][0].data;
+    expect(data.expiresAt.getTime()).toBe(now.getTime() + MAX_LEASE_TTL_MS);
+  });
+
+  it("refuses to revive an already-expired lease (holder lost it → must re-claim)", async () => {
+    const mockDb = db();
+    mockDb.nonProductionEnvironmentLease.findUnique.mockResolvedValue({
+      leaseId: "NPEL-1",
+      status: "active",
+      ownerSessionId: "s1",
+      expiresAt: new Date(now.getTime() - 60_000), // already lapsed
+    });
+    const r = await renewNonprodEnvironmentLease({
+      db: mockDb as never,
+      leaseId: "NPEL-1",
+      ownerSessionId: "s1",
+      now,
+    });
+    expect(r).toEqual({ status: "lost", reason: "expired" });
+    expect(mockDb.nonProductionEnvironmentLease.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses renewal from a non-owner session", async () => {
+    const mockDb = db();
+    mockDb.nonProductionEnvironmentLease.findUnique.mockResolvedValue({
+      leaseId: "NPEL-1",
+      status: "active",
+      ownerSessionId: "s1",
+      expiresAt: new Date(now.getTime() + 60_000),
+    });
+    const r = await renewNonprodEnvironmentLease({
+      db: mockDb as never,
+      leaseId: "NPEL-1",
+      ownerSessionId: "intruder",
+      now,
+    });
+    expect(r).toEqual({ status: "lost", reason: "not-owner" });
+  });
+
+  it("reaps active-but-expired leases (frees the instance for the next waiter)", async () => {
+    const mockDb = db();
+    mockDb.nonProductionEnvironmentLease.updateMany.mockResolvedValue({ count: 3 });
+    const r = await reapExpiredNonprodEnvironmentLeases({ db: mockDb as never, now });
+    expect(r).toEqual({ reaped: 3 });
+    expect(mockDb.nonProductionEnvironmentLease.updateMany).toHaveBeenCalledWith({
+      where: { status: "active", expiresAt: { lt: now }, releasedAt: null },
+      data: { status: "expired", releasedAt: now },
     });
   });
 });

--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -7,6 +7,7 @@ import {
   renewNonprodEnvironmentLease,
   reapExpiredNonprodEnvironmentLeases,
   MAX_LEASE_TTL_MS,
+  DEFAULT_LEASE_TTL_MS,
 } from "./environment-lease";
 
 function db() {
@@ -148,7 +149,8 @@ describe("nonprod lease anti-monopolization (BI-4043A64B)", () => {
     });
     expect(r.status).toBe("renewed");
     const data = mockDb.nonProductionEnvironmentLease.update.mock.calls[0][0].data;
-    expect(data.expiresAt.getTime()).toBe(now.getTime() + MAX_LEASE_TTL_MS);
+    // Heartbeat with no explicit ttl uses the DEFAULT window (clamped to MAX).
+    expect(data.expiresAt.getTime()).toBe(now.getTime() + DEFAULT_LEASE_TTL_MS);
   });
 
   it("refuses to revive an already-expired lease (holder lost it → must re-claim)", async () => {

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -6,6 +6,31 @@ export type NonprodOwnerProvider = "build-studio" | "claude" | "codex" | "cowork
 
 type LeaseDb = Pick<typeof prisma, "nonProductionEnvironmentLease">;
 
+// BI-4043A64B — anti-monopolization for the single shared nonprod instance.
+// A lease can never be held longer than MAX_LEASE_TTL_MS without an active
+// heartbeat (renew). One stuck/long-running process therefore cannot lock the
+// instance for everyone else: if it stops renewing (crash, stall, a long batch
+// job that forgot to heartbeat), the lease expires and is reclaimed/reaped.
+// The shared lease is for SHORT interactive integration/UX windows; long jobs
+// run on an ephemeral isolated runtime, not this lease.
+export const MAX_LEASE_TTL_MS = 20 * 60_000; // hard cap per claim/renew window
+export const DEFAULT_LEASE_TTL_MS = 15 * 60_000; // default interactive window
+
+/**
+ * Clamp a requested expiry to at most `now + MAX_LEASE_TTL_MS`. A caller asking
+ * for an hours-long hold is capped to the max window; it must heartbeat (renew)
+ * to keep the lease. A missing request defaults to `now + ttlMs`.
+ */
+export function clampLeaseExpiry(
+  now: Date,
+  requested: Date | undefined,
+  ttlMs: number = DEFAULT_LEASE_TTL_MS,
+): Date {
+  const cap = now.getTime() + MAX_LEASE_TTL_MS;
+  const want = (requested ?? new Date(now.getTime() + ttlMs)).getTime();
+  return new Date(Math.min(want, cap));
+}
+
 function createLeaseId() {
   return `NPEL-${randomUUID().replace(/-/g, "").slice(0, 10).toUpperCase()}`;
 }
@@ -60,7 +85,8 @@ export async function claimNonprodEnvironmentLease(input: {
       purpose: input.purpose,
       url: input.url,
       ports: input.ports,
-      expiresAt: input.expiresAt,
+      // Cap the hold window (BI-4043A64B); longer holds require heartbeat renew.
+      expiresAt: clampLeaseExpiry(input.now ?? new Date(), input.expiresAt),
       worktreePath: input.worktreePath,
       branchName: input.branchName,
       buildId: input.buildId,
@@ -84,4 +110,58 @@ export async function releaseNonprodEnvironmentLease(input: {
       releasedAt: input.now ?? new Date(),
     },
   });
+}
+
+/**
+ * Heartbeat: extend an active lease's hold window (BI-4043A64B). Only the owning
+ * session can renew, and only while the lease is still active and unexpired — a
+ * lease that already lapsed is NOT revivable (the holder lost it; it may have
+ * been reclaimed by another waiter), forcing an honest re-claim. The new expiry
+ * is clamped to the max window, so renewing does not grant an unbounded hold.
+ */
+export async function renewNonprodEnvironmentLease(input: {
+  db?: LeaseDb;
+  leaseId: string;
+  ownerSessionId: string;
+  ttlMs?: number;
+  now?: Date;
+}): Promise<
+  | { status: "renewed"; lease: Awaited<ReturnType<LeaseDb["nonProductionEnvironmentLease"]["update"]>> }
+  | { status: "lost"; reason: "not-found" | "not-active" | "not-owner" | "expired" }
+> {
+  const db = input.db ?? prisma;
+  const now = input.now ?? new Date();
+  const lease = await db.nonProductionEnvironmentLease.findUnique({
+    where: { leaseId: input.leaseId },
+  });
+  if (!lease) return { status: "lost", reason: "not-found" };
+  if (lease.status !== "active") return { status: "lost", reason: "not-active" };
+  if (lease.ownerSessionId !== input.ownerSessionId) return { status: "lost", reason: "not-owner" };
+  if (lease.expiresAt.getTime() <= now.getTime()) return { status: "lost", reason: "expired" };
+
+  const updated = await db.nonProductionEnvironmentLease.update({
+    where: { leaseId: input.leaseId },
+    data: { expiresAt: clampLeaseExpiry(now, undefined, input.ttlMs) },
+  });
+  return { status: "renewed", lease: updated };
+}
+
+/**
+ * Reaper: mark every active-but-expired lease as `expired` and stamp
+ * `releasedAt` (BI-4043A64B). The claim/list queries already ignore expired
+ * leases, so this is hygiene + audit + freeing the env for the next waiter —
+ * the scheduled counterpart to the RuntimeTarget heartbeat sweep. Returns the
+ * count reaped. Idempotent.
+ */
+export async function reapExpiredNonprodEnvironmentLeases(input: {
+  db?: LeaseDb;
+  now?: Date;
+} = {}): Promise<{ reaped: number }> {
+  const db = input.db ?? prisma;
+  const now = input.now ?? new Date();
+  const res = await db.nonProductionEnvironmentLease.updateMany({
+    where: { status: "active", expiresAt: { lt: now }, releasedAt: null },
+    data: { status: "expired", releasedAt: now },
+  });
+  return { reaped: res.count };
 }

--- a/apps/web/lib/queue/functions/runtime-target-janitor.ts
+++ b/apps/web/lib/queue/functions/runtime-target-janitor.ts
@@ -16,6 +16,7 @@
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { prisma } from "@dpf/db";
+import { reapExpiredNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
 
 const STALE_RUNNING_HOURS = 2;   // running/starting targets with no heartbeat
 const STALE_PLANNED_DAYS  = 7;   // planned targets with no consumer ever started
@@ -107,24 +108,12 @@ type ExpireLeaseResult = {
 };
 
 async function expireStaleLeases(): Promise<ExpireLeaseResult> {
-  const now = new Date();
-
-  // Any lease whose expiresAt has passed and releasedAt is still null is orphaned.
-  // The gate-worktree.sh script explicitly calls release_nonprod_environment_lease
-  // on completion; this sweep catches crashes or sessions that were killed.
-  const update = await prisma.nonProductionEnvironmentLease.updateMany({
-    where: {
-      expiresAt: { lt: now },
-      releasedAt: null,
-      // Only sweep "active" leases. Leases already in a terminal state
-      // (released, expired) are fine as-is; don't touch them.
-      status: "active",
-    },
-    data: {
-      status: "expired",
-      releasedAt: now,
-    },
-  });
-
-  return { expired: update.count };
+  // Single source of truth: the reaper the lease lib also exposes for unit tests
+  // and on-demand callers (BI-4043A64B). Catches crashed/killed sessions whose
+  // lease never got an explicit release_nonprod_environment_lease (gate-worktree.sh
+  // releases on clean completion), and is the safety net for a holder that
+  // stopped heartbeating (renew) — a long/stuck process can't lock the single
+  // shared instance because its lapsed lease is swept here.
+  const { reaped } = await reapExpiredNonprodEnvironmentLeases();
+  return { expired: reaped };
 }

--- a/apps/web/lib/self-upgrade/config.test.ts
+++ b/apps/web/lib/self-upgrade/config.test.ts
@@ -127,13 +127,15 @@ describe("parseSelfUpgradeConfig", () => {
     expect(parseSelfUpgradeConfig(null).useIsolatedWorkspace).toBe(true);
   });
 
-  it("honors an explicit useIsolatedWorkspace=false opt-out", () => {
+  it("forces useIsolatedWorkspace true even when explicitly disabled (legacy direct-merge retired, BI-4043A64B)", () => {
+    // The legacy direct-merge the false value once selected mutated the host
+    // clone's working tree and corrupted it (721 files lost, 2026-06-15). The
+    // opt-out is retired: a stored false is no longer honored.
     const cfg = parseSelfUpgradeConfig({ useIsolatedWorkspace: false });
-    expect(cfg.useIsolatedWorkspace).toBe(false);
+    expect(cfg.useIsolatedWorkspace).toBe(true);
   });
 
-  it("ignores non-boolean useIsolatedWorkspace values and falls back to the safe default", () => {
-    // Defensive: a malformed value MUST NOT silently flip behavior either way.
+  it("forces useIsolatedWorkspace true for any stored value (boolean or malformed)", () => {
     expect(parseSelfUpgradeConfig({ useIsolatedWorkspace: "yes" }).useIsolatedWorkspace).toBe(true);
     expect(parseSelfUpgradeConfig({ useIsolatedWorkspace: 1 }).useIsolatedWorkspace).toBe(true);
   });

--- a/apps/web/lib/self-upgrade/config.ts
+++ b/apps/web/lib/self-upgrade/config.ts
@@ -68,8 +68,13 @@ export type SelfUpgradeConfig = {
    * bind-mount — no docker-compose change needed) and is git-ignored.
    * Resolves BI-A8A7CCFD / BI-888435E5 / BI-57E77CB4: contributor installs
    * whose install clone doubles as a dirty dev tree no longer collide with
-   * the upgrade merge. Defaults to true; can be disabled per-install via
-   * PlatformConfig for fallback to the legacy direct-merge behavior.
+   * the upgrade merge.
+   *
+   * BI-4043A64B: ALWAYS true. The legacy direct-merge fallback this once
+   * toggled is retired — it mutated the host clone's working tree and corrupted
+   * it. `parseSelfUpgradeConfig` forces this true regardless of stored value,
+   * and `prepareUpgradeSource` refuses an upstream merge without a workspace.
+   * The field is retained (not removed) for callers and forward-compat.
    */
   useIsolatedWorkspace: boolean;
   /**
@@ -201,10 +206,11 @@ export function parseSelfUpgradeConfig(raw: unknown): SelfUpgradeConfig {
       typeof cfg.installBranch === "string" && cfg.installBranch.trim().length > 0
         ? cfg.installBranch.trim()
         : DEFAULTS.installBranch,
-    useIsolatedWorkspace:
-      typeof cfg.useIsolatedWorkspace === "boolean"
-        ? cfg.useIsolatedWorkspace
-        : DEFAULTS.useIsolatedWorkspace,
+    // BI-4043A64B — isolation is FORCED on. A stored `false` is no longer
+    // honored: the legacy direct-merge it selected mutated the host clone's
+    // working tree and corrupted it (721 files lost, 2026-06-15). prepare-source
+    // refuses an upstream merge without a workspace, so this must stay true.
+    useIsolatedWorkspace: true,
   };
   for (const key of [
     "hostInstallPath",

--- a/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -68,123 +68,21 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     return () => cleanup.forEach((d) => rmSync(d, { recursive: true, force: true }));
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
-  it("merges upstream into the install branch, PRESERVING local commits", async () => {
+  it("REFUSES an upstream merge without an isolated workspace, leaving the host clone untouched (legacy direct-merge retired, BI-4043A64B)", async () => {
     const { upstream, install, root } = makeWorld();
     cleanup.push(root);
 
     // Local customization on the durable install branch (never pushed upstream).
     git(install, "checkout", "-b", "dpf/install");
     commit(install, "local.txt", "my private feature\n", "local: feature");
-    const localCommit = git(install, "rev-parse", "HEAD").trim();
-
-    // Upstream advances with a new feature on a disjoint file.
-    commit(upstream, "upstream.txt", "new upstream feature\n", "feat: upstream thing");
-    const upstreamCommit = git(upstream, "rev-parse", "HEAD").trim();
-
-    const r = await prepareUpgradeSource(
-      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
-      defaultGitRunner,
-    );
-
-    expect(r.ok).toBe(true);
-    if (!r.ok) return;
-
-    const head = git(install, "rev-parse", "HEAD").trim();
-    // Stamp is the real merge-commit identity.
-    expect(r.stamp).toBe(head);
-    expect(r.upstreamSha).toBe(upstreamCommit);
-    // It is a real merge commit (two parents): one is the local commit, the
-    // other carries the upstream change.
-    const parents = git(install, "rev-list", "--parents", "-n", "1", "HEAD").trim().split(/\s+/).slice(1);
-    expect(parents).toContain(localCommit);
-    expect(parents).toContain(upstreamCommit);
-    // BOTH the local customization AND the upstream feature are present — the
-    // whole point: stay current without losing local work.
-    expect(existsSync(join(install, "local.txt"))).toBe(true);
-    expect(existsSync(join(install, "upstream.txt"))).toBe(true);
-    // We are on the install branch, clean.
-    expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
-    expect(git(install, "status", "--porcelain").trim()).toBe("");
-  }, REAL_GIT_TEST_TIMEOUT_MS);
-
-  it("creates the install branch from HEAD on first run when it is absent", async () => {
-    const { upstream, install, root } = makeWorld();
-    cleanup.push(root);
-    commit(upstream, "upstream.txt", "x\n", "feat: x");
-
-    const r = await prepareUpgradeSource(
-      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
-      defaultGitRunner,
-    );
-
-    expect(r.ok).toBe(true);
-    expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
-    expect(existsSync(join(install, "upstream.txt"))).toBe(true);
-  }, REAL_GIT_TEST_TIMEOUT_MS);
-
-  it("ABORTS to a clean tree on a real conflict and reports the file", async () => {
-    const { upstream, install, root } = makeWorld();
-    cleanup.push(root);
-
-    // Local and upstream both edit the same file → genuine merge conflict.
-    git(install, "checkout", "-b", "dpf/install");
-    commit(install, "base.txt", "local edit\n", "local: edit base");
-    const beforeHead = git(install, "rev-parse", "HEAD").trim();
-    commit(upstream, "base.txt", "upstream edit\n", "fix: edit base");
-
-    const r = await prepareUpgradeSource(
-      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
-      defaultGitRunner,
-    );
-
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.reason).toBe("merge-conflict");
-    if (r.reason !== "merge-conflict") return;
-    expect(r.conflictFiles).toContain("base.txt");
-    // Critically: the clone is NOT left mid-merge — it was aborted clean.
-    expect(existsSync(join(install, ".git", "MERGE_HEAD"))).toBe(false);
-    expect(git(install, "status", "--porcelain").trim()).toBe("");
-    expect(git(install, "rev-parse", "HEAD").trim()).toBe(beforeHead);
-  }, REAL_GIT_TEST_TIMEOUT_MS);
-
-  it("survives a hard-failing post-checkout hook (e.g. Git LFS hook with no git-lfs binary)", async () => {
-    const { upstream, install, root } = makeWorld();
-    cleanup.push(root);
-    commit(upstream, "upstream.txt", "x\n", "feat: x");
-
-    // Reproduce the Mac/container blocker: the clone has a post-checkout hook
-    // that exits non-zero (the git-lfs hook does exactly this when git-lfs is
-    // absent). Without hook-bypassing, `git checkout` returns non-zero and prep
-    // would abort with prep-error even though the checkout itself succeeds.
-    const hooksDir = join(install, ".dpf-hooks");
-    mkdirSync(hooksDir, { recursive: true });
-    const hook = join(hooksDir, "post-checkout");
-    writeFileSync(hook, "#!/bin/sh\necho 'git-lfs not found' >&2\nexit 2\n");
-    chmodSync(hook, 0o755);
-    git(install, "config", "core.hooksPath", hooksDir);
-
-    const r = await prepareUpgradeSource(
-      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
-      defaultGitRunner,
-    );
-
-    expect(r.ok).toBe(true);
-    expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
-    expect(existsSync(join(install, "upstream.txt"))).toBe(true);
-  }, REAL_GIT_TEST_TIMEOUT_MS);
-
-  it("refuses up front on an uncommitted working tree (does not switch branch or merge)", async () => {
-    const { upstream, install, root } = makeWorld();
-    cleanup.push(root);
-    commit(upstream, "upstream.txt", "x\n", "feat: x");
-
-    // Uncommitted local change in the install clone — the real-world case
-    // (e.g. WIP edits). The merge would otherwise abort with "local changes
-    // would be overwritten" and surface as an empty, misleading merge-conflict.
     const startBranch = git(install, "rev-parse", "--abbrev-ref", "HEAD").trim();
-    writeFileSync(join(install, "base.txt"), "uncommitted edit\n");
+    const startHead = git(install, "rev-parse", "HEAD").trim();
 
+    // Upstream advances; a legacy direct-merge would have pulled this into the
+    // host working tree (and an interrupted run could corrupt it).
+    commit(upstream, "upstream.txt", "new upstream feature\n", "feat: upstream thing");
+
+    // No workspacePath → the retired legacy path. It must refuse, not merge.
     const r = await prepareUpgradeSource(
       { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
       defaultGitRunner,
@@ -192,13 +90,17 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
 
     expect(r.ok).toBe(false);
     if (r.ok) return;
-    expect(r.reason).toBe("dirty-tree");
-    expect(r.message).toContain("base.txt");
-    expect(r.message).toContain("uncommitted");
-    // The clone is untouched: still on the original branch, never switched to
-    // the install branch, no merge in progress.
+    expect(r.reason).toBe("prep-error");
+    expect(r.message).toMatch(/isolated workspace/i);
+
+    // The PROOF: the host clone's working tree is never mutated — same branch,
+    // same HEAD, no merge in progress, no upstream file pulled in, clean status.
+    // This is the corruption path (721-file loss, 2026-06-15) being closed.
     expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe(startBranch);
+    expect(git(install, "rev-parse", "HEAD").trim()).toBe(startHead);
     expect(existsSync(join(install, ".git", "MERGE_HEAD"))).toBe(false);
+    expect(existsSync(join(install, "upstream.txt"))).toBe(false);
+    expect(git(install, "status", "--porcelain").trim()).toBe("");
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("local mode stamps the working tree HEAD, with -dirty when uncommitted", async () => {

--- a/apps/web/lib/self-upgrade/prepare-source.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.test.ts
@@ -57,85 +57,83 @@ describe("prepareUpgradeSource — local mode", () => {
   });
 });
 
-describe("prepareUpgradeSource — upstream mode", () => {
-  it("fetches, checks out an existing install branch, merges, and stamps the merge commit", async () => {
+describe("prepareUpgradeSource — upstream mode (isolated workspace, BI-4043A64B)", () => {
+  // The workspace lives under the host clone but the merge runs entirely inside
+  // it; the host clone's WORKING TREE is never checked-out/merged/cleaned.
+  const baseWorkspace = { ...baseUpstream, workspacePath: "/host-dpf/.upgrade-workspace" };
+
+  // Asserts no git op mutates the host clone's working tree directly
+  // (`-C /host-dpf <checkout|merge|reset|clean>`). The retired legacy path did.
+  function noHostTreeMutation(calls: string[][]): boolean {
+    const mutating = new Set(["checkout", "merge", "reset", "clean"]);
+    return !calls.some(
+      (c) => c[0] === "-C" && c[1] === "/host-dpf" && c.some((a) => mutating.has(a)),
+    );
+  }
+
+  it("refuses an upstream merge without an isolated workspace (legacy direct-merge retired)", async () => {
+    const git = fakeGit([]);
+    const r = await prepareUpgradeSource(baseUpstream, git); // no workspacePath
+    expect(r).toMatchObject({ ok: false, reason: "prep-error" });
+    if (r.ok) return;
+    expect(r.message).toMatch(/isolated workspace/i);
+    // Must NOT touch the host clone at all — no checkout/merge against it.
+    expect(git.calls.some((c) => c.includes("checkout") || c.includes("merge"))).toBe(false);
+  });
+
+  it("merges upstream inside the workspace and stamps the merge commit (clean)", async () => {
     const git = fakeGit([
-      ["fetch origin main", ok()],
-      ["rev-parse origin/main", ok(`${UPSTREAM}\n`)],
-      ["rev-parse --verify --quiet dpf/install", ok(`${SHA}\n`)], // branch exists
-      ["merge --no-edit --no-ff", ok()],
+      ["rev-parse --git-dir", ok()], // workspace already initialized
+      ["config --get remote.origin.url", ok("https://github.com/x/y.git\n")],
+      ["config --get remote.upgrade-upstream.url", ok("")],
+      ["rev-parse upgrade-upstream/main", ok(`${UPSTREAM}\n`)],
       ["rev-parse HEAD", ok(`${MERGE}\n`)],
       ["status --porcelain", ok("")],
     ]);
-    const r = await prepareUpgradeSource(baseUpstream, git);
+    const r = await prepareUpgradeSource(baseWorkspace, git);
     expect(r).toEqual({ ok: true, mode: "upstream", stamp: MERGE, upstreamSha: UPSTREAM });
-    // existing branch is checked out, not recreated/reset.
-    expect(git.calls.some((c) => c.join(" ").includes("checkout dpf/install"))).toBe(true);
-    expect(git.calls.some((c) => c.includes("-B"))).toBe(false);
+    expect(noHostTreeMutation(git.calls)).toBe(true);
+    // The merge runs in the workspace tree.
+    expect(
+      git.calls.some(
+        (c) => c[0] === "-C" && c[1] === "/host-dpf/.upgrade-workspace" && c.includes("merge"),
+      ),
+    ).toBe(true);
+    // The new install-branch tip is pushed back to the install clone (ref-only).
+    expect(
+      git.calls.some((c) => c.join(" ").includes("push origin HEAD:refs/heads/dpf/install")),
+    ).toBe(true);
   });
 
-  it("creates the install branch from HEAD on first run", async () => {
+  it("defers on merge conflict and cleans the workspace (host tree untouched)", async () => {
     const git = fakeGit([
-      ["fetch origin main", ok()],
-      ["rev-parse origin/main", ok(`${UPSTREAM}\n`)],
-      ["rev-parse --verify --quiet dpf/install", fail("", 1)], // branch absent
-      ["checkout -b dpf/install", ok()],
-      ["merge --no-edit --no-ff", ok()],
-      ["rev-parse HEAD", ok(`${MERGE}\n`)],
-      ["status --porcelain", ok("")],
-    ]);
-    const r = await prepareUpgradeSource(baseUpstream, git);
-    expect(r).toMatchObject({ ok: true, stamp: MERGE });
-    expect(git.calls.some((c) => c.join(" ").includes("checkout -b dpf/install"))).toBe(true);
-  });
-
-  it("defers on merge conflict: reports the files and aborts the merge", async () => {
-    const git = fakeGit([
-      ["fetch origin main", ok()],
-      ["rev-parse origin/main", ok(`${UPSTREAM}\n`)],
-      ["rev-parse --verify --quiet dpf/install", ok(`${SHA}\n`)],
-      ["merge --no-edit --no-ff", fail("CONFLICT", 1)],
+      ["rev-parse --git-dir", ok()],
+      ["config --get remote.origin.url", ok("https://github.com/x/y.git\n")],
+      ["config --get remote.upgrade-upstream.url", ok("")],
+      ["rev-parse upgrade-upstream/main", ok(`${UPSTREAM}\n`)],
+      ["merge --no-ff", fail("CONFLICT", 1)],
       ["diff --name-only --diff-filter=U", ok("apps/web/a.ts\napps/web/b.ts\n")],
-      ["merge --abort", ok()],
     ]);
-    const r = await prepareUpgradeSource(baseUpstream, git);
+    const r = await prepareUpgradeSource(baseWorkspace, git);
     expect(r).toMatchObject({
       ok: false,
       reason: "merge-conflict",
       conflictFiles: ["apps/web/a.ts", "apps/web/b.ts"],
       upstreamSha: UPSTREAM,
     });
-    // the clone must be returned to a clean state.
     expect(git.calls.some((c) => c.join(" ").includes("merge --abort"))).toBe(true);
+    expect(noHostTreeMutation(git.calls)).toBe(true);
   });
 
-  it("refuses on an uncommitted working tree before fetching or checking out", async () => {
+  it("returns no-target when the upstream ref cannot be resolved in the workspace", async () => {
     const git = fakeGit([
-      ["status --porcelain", ok(" M apps/web/x.ts\n?? apps/web/y.ts\n")],
+      ["rev-parse --git-dir", ok()],
+      ["config --get remote.origin.url", ok("https://github.com/x/y.git\n")],
+      ["config --get remote.upgrade-upstream.url", ok("")],
+      ["rev-parse upgrade-upstream/main", fail("unknown revision", 128)],
     ]);
-    const r = await prepareUpgradeSource(baseUpstream, git);
-    expect(r).toMatchObject({ ok: false, reason: "dirty-tree" });
-    if (r.ok || r.reason !== "dirty-tree") return;
-    expect(r.message).toContain("apps/web/x.ts");
-    // Fails fast: no fetch, checkout, or merge against a dirty tree.
-    expect(git.calls.some((c) => c.includes("fetch") || c.includes("checkout") || c.includes("merge"))).toBe(false);
-  });
-
-  it("returns no-target when the upstream ref cannot be resolved", async () => {
-    const git = fakeGit([
-      ["fetch origin main", ok()],
-      ["rev-parse origin/main", fail("unknown revision", 128)],
-    ]);
-    const r = await prepareUpgradeSource(baseUpstream, git);
+    const r = await prepareUpgradeSource(baseWorkspace, git);
     expect(r).toMatchObject({ ok: false, reason: "no-target" });
-    // must not attempt a merge with no resolved target.
-    expect(git.calls.some((c) => c.includes("merge"))).toBe(false);
-  });
-
-  it("surfaces a fetch failure as prep-error without merging", async () => {
-    const git = fakeGit([["fetch origin main", fail("network down", 1)]]);
-    const r = await prepareUpgradeSource(baseUpstream, git);
-    expect(r).toMatchObject({ ok: false, reason: "prep-error" });
-    expect(git.calls.some((c) => c.includes("merge"))).toBe(false);
+    expect(git.calls.some((c) => c.join(" ").includes("merge --no-ff"))).toBe(false);
   });
 });

--- a/apps/web/lib/self-upgrade/prepare-source.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.ts
@@ -18,11 +18,8 @@
 //             tree has uncommitted changes).
 
 import {
-  buildFetchCommand,
-  buildRemoteHeadCommand,
   buildHeadShaCommand,
   buildDirtyCheckCommand,
-  buildMergeCommand,
   deriveDeployedStamp,
 } from "./version";
 import type { UpgradeSourceMode } from "./config";
@@ -83,22 +80,6 @@ function trim(s: string): string {
   return s.trim();
 }
 
-/**
- * Repo-relative paths of TRACKED modifications (staged or unstaged) from
- * `git status --porcelain`, or [] when none. Untracked entries ("??") are
- * excluded: they don't block a merge the way modified tracked files do, and
- * counting them would trip on benign artifacts. Note: do NOT trim the whole
- * porcelain blob first — that would strip the leading status space of the first
- * line and corrupt the `slice(3)` path extraction.
- */
-function dirtyFiles(porcelain: string): string[] {
-  return porcelain
-    .split("\n")
-    .filter((l) => l.trim().length > 0 && !l.startsWith("??"))
-    .map((l) => l.slice(3).trim()) // strip the 2-char status + 1 space prefix
-    .filter(Boolean);
-}
-
 async function readHeadStamp(run: GitRunner, hostSourcePath: string): Promise<string> {
   const head = await run(buildHeadShaCommand(hostSourcePath).slice(1));
   const dirty = await run(buildDirtyCheckCommand(hostSourcePath).slice(1));
@@ -139,75 +120,21 @@ export async function prepareUpgradeSource(
     );
   }
 
-  // ── upstream (legacy: direct merge against the install clone) ─────────────
-  try {
-    // Refuse FAST on an uncommitted working tree. The merge below would abort
-    // with "local changes would be overwritten" — git reports that as exit 1
-    // with NO conflict markers, so the generic merge path would surface an
-    // empty, misleading "merge-conflict". This design preserves *committed*
-    // local delta (on the install branch); uncommitted changes are unmergeable
-    // and must be committed to the install branch or stashed first. Detecting
-    // them up front (before any checkout) keeps the clone untouched and gives
-    // the operator an actionable message.
-    const preDirty = await run(buildDirtyCheckCommand(hostSourcePath).slice(1));
-    const pending = dirtyFiles(preDirty.stdout);
-    if (pending.length > 0) {
-      const sample = pending.slice(0, 5).join(", ");
-      const more = pending.length > 5 ? `, +${pending.length - 5} more` : "";
-      return {
-        ok: false,
-        reason: "dirty-tree",
-        message: `the install clone has ${pending.length} uncommitted change(s) (${sample}${more}); commit them to ${installBranch} or stash before upgrading`,
-      };
-    }
-
-    const fetch = await run(buildFetchCommand({ hostSourcePath, remote, branch }).slice(1));
-    if (fetch.code !== 0) {
-      return { ok: false, reason: "prep-error", message: `fetch failed: ${trim(fetch.stderr) || fetch.code}` };
-    }
-
-    const head = await run(buildRemoteHeadCommand({ hostSourcePath, remote, branch }).slice(1));
-    const upstreamSha = trim(head.stdout);
-    if (head.code !== 0 || !upstreamSha) {
-      return { ok: false, reason: "no-target", message: `cannot resolve ${remote}/${branch}` };
-    }
-
-    // Move the clone onto the durable install branch WITHOUT discarding its
-    // local commits: check it out if it exists, otherwise create it from the
-    // current HEAD. (`-B` is deliberately avoided — it would reset an existing
-    // install branch to HEAD and destroy the local delta this whole design
-    // exists to preserve.)
-    const exists = await run(["-C", hostSourcePath, "rev-parse", "--verify", "--quiet", installBranch]);
-    const checkout =
-      exists.code === 0
-        ? await run(["-C", hostSourcePath, "checkout", installBranch])
-        : await run(["-C", hostSourcePath, "checkout", "-b", installBranch]);
-    if (checkout.code !== 0) {
-      return { ok: false, reason: "prep-error", message: `checkout ${installBranch} failed: ${trim(checkout.stderr) || checkout.code}` };
-    }
-
-    const merge = await run(buildMergeCommand({ hostSourcePath, remote, branch }).slice(1));
-    if (merge.code !== 0) {
-      // Collect the conflicting files, then abort so the clone is never left
-      // mid-merge. The operator resolves in the Upgrade Center; until then the
-      // current build keeps running.
-      const conflicts = await run(["-C", hostSourcePath, "diff", "--name-only", "--diff-filter=U"]);
-      const conflictFiles = trim(conflicts.stdout).split("\n").map(trim).filter(Boolean);
-      await run(["-C", hostSourcePath, "merge", "--abort"]);
-      return {
-        ok: false,
-        reason: "merge-conflict",
-        conflictFiles,
-        upstreamSha,
-        message: `upstream merge conflicts in ${conflictFiles.length} file(s)`,
-      };
-    }
-
-    const stamp = await readHeadStamp(run, hostSourcePath);
-    return { ok: true, mode: "upstream", stamp, upstreamSha };
-  } catch (err) {
-    return { ok: false, reason: "prep-error", message: errMsg(err) };
-  }
+  // ── upstream WITHOUT an isolated workspace: RETIRED (BI-4043A64B) ──────────
+  // The legacy path ran `git checkout <installBranch>` + `git merge` directly
+  // against the host clone's WORKING TREE (`/host-dpf`). An interrupted or
+  // partial run corrupted the operator's tree — observed 2026-06-15 as 721
+  // deleted `packages/` files + files rewritten to main. Source-prep must never
+  // mutate the host working tree, so an isolated workspace (BI-A8A7CCFD) is now
+  // mandatory for upstream merges. `useIsolatedWorkspace` defaults true (and is
+  // forced true in config parsing), so a workspacePath is always derived;
+  // reaching here means it was explicitly disabled — refuse rather than corrupt.
+  return {
+    ok: false,
+    reason: "prep-error",
+    message:
+      "upstream upgrade requires an isolated workspace — the legacy direct-merge against the host clone is retired (it mutated the operator working tree; BI-4043A64B). Leave useIsolatedWorkspace enabled (the default) so the merge runs in .upgrade-workspace.",
+  };
 }
 
 function errMsg(err: unknown): string {


### PR DESCRIPTION
Closes the two gaps in `BI-4043A64B` that the tiered-dev-loop-isolation cluster does not cover: the recurring `D:\DPF` clone corruption, and the single-leased-instance lock-up risk.

## Gap 1 — corruption stop-gap (self-upgrade)

The legacy direct-merge ran `git checkout <installBranch>` + `git merge` **directly against the host clone's working tree** (`/host-dpf`). An interrupted run corrupted the operator tree — observed 2026-06-15 as **721 `packages/` files deleted** + files rewritten to `main`.

- `prepare-source.ts`: the upstream-without-workspace path is **retired** — it now refuses with a clear `prep-error` instead of mutating the host clone. Only the BI-A8A7CCFD isolated workspace (merges in `.upgrade-workspace`, pushes refs back, never touches the operator tree) performs upstream merges.
- `config.ts`: `useIsolatedWorkspace` is **forced true** (a stored `false` is no longer honored) so a `workspacePath` is always derived.

**Design note:** a blunt "/host-dpf read-only" mount was rejected — the isolated workspace lives *inside* `/host-dpf` and pushes refs to `/host-dpf/.git`, so RO would break the correct path too. The right invariant is *"never mutate the host **working tree**,"* enforced here in code.

## Gap 2 — shared-lease anti-monopolization (nonprod)

A single leased instance must not be lockable by one long/stuck hold.

- `clampLeaseExpiry` + `MAX_LEASE_TTL_MS`: every claim is capped to a max window; an hours-long ask is clamped down.
- `renewNonprodEnvironmentLease`: heartbeat that extends an active, owned, unexpired lease (clamped). A **lapsed lease is not revivable** — the holder lost it and must re-claim, so a dead/stalled process frees the instance.
- `reapExpiredNonprodEnvironmentLeases`: single-source-of-truth reaper; the hourly RuntimeTarget janitor now **delegates** to it (removing the duplicated inline sweep).

Remaining Gap-2 work (fair "N ahead" queue, priority lane for deploy/recovery, MCP `renew` tool) is gated on `BI-6701C6BF` (the active-candidate instance) and tracked on the BI.

## Verification

⚠️ Local vitest/tsc could not be run at authoring time: a concurrent session's `pnpm install --frozen-lockfile` had wiped the shared `node_modules` store for ~40 min (the exact contention this BI addresses — live dogfooding evidence). **Relying on CI to gate the suite; will not merge until green.** New/updated unit tests cover: prepare-source retirement guard + isolated-path clean/conflict/no-target, config force-true, and lease clamp/renew/reap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)