### PR TITLE
fix(build-studio): honor WWMD kernel gate on plan→build auto-advance

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -8893,6 +8893,7 @@ export async function executeTool(
             title: true,
             kind: true,
             parentEpicId: true,
+            deliberationSummary: true,
             dependenciesOut: FEATURE_BUILD_DEPENDENCY_GATE_SELECT.dependenciesOut,
           },
         });
@@ -8912,6 +8913,37 @@ export async function executeTool(
             if (!dependencyGate.allowed) {
               logBuildActivity(buildId, "phase:gate-blocked", dependencyGate.message);
             } else {
+              // WWMD kernel gate. The structural checkPhaseGate + dependency gate
+              // above are necessary but not sufficient: the decision kernel
+              // (principle_decide) is the authority on whether plan→build honors
+              // platform principles. The advance-phase HTTP route runs this gate;
+              // this agentic-loop auto-advance MUST too, or local-model builds
+              // silently bypass WWMD. Fail OPEN on evaluator error so a kernel
+              // hiccup can't wedge the streamlined flow — but a genuine principle
+              // conflict (gate not allowed) blocks the auto-advance and surfaces a
+              // DecisionInteraction for operator review.
+              let decisionAllowed = true;
+              try {
+                const { evaluateBuildStudioPlanAdvancementGate } = await import("@/lib/decision-perspective/build-studio-gate");
+                const decisionGate = await evaluateBuildStudioPlanAdvancementGate({
+                  db: prisma,
+                  build: {
+                    buildId: updatedBuild.buildId,
+                    title: updatedBuild.title,
+                    phase: "plan",
+                    planReview: updatedBuild.planReview,
+                    deliberationSummary: updatedBuild.deliberationSummary,
+                  },
+                  triggeredByUserId: userId,
+                } as Parameters<typeof evaluateBuildStudioPlanAdvancementGate>[0]);
+                if (!decisionGate.allowed) {
+                  decisionAllowed = false;
+                  logBuildActivity(buildId, "wwmd:gate-blocked", decisionGate.operatorMessage ?? "Decision kernel withheld plan→build advancement.");
+                }
+              } catch (wwmdErr) {
+                console.error("[reviewBuildPlan] WWMD gate errored (failing open):", wwmdErr);
+              }
+              if (decisionAllowed) {
               // Initialize the build branch BEFORE flipping the phase. If the
               // phase flip lands without buildBranch set, deploy_feature runs
               // on whatever the current sandbox HEAD is — picking up leftover
@@ -8947,6 +8979,7 @@ export async function executeTool(
                 }
               } catch (branchErr) {
                 logBuildActivity(buildId, "phase:gate-blocked", `startBuildBranch failed: ${(branchErr as Error).message?.slice(0, 200)}`);
+              }
               }
             }
           } else {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -8929,13 +8929,13 @@ export async function executeTool(
                   db: prisma,
                   build: {
                     buildId: updatedBuild.buildId,
-                    title: updatedBuild.title,
+                    title: updatedBuild.title ?? updatedBuild.buildId,
                     phase: "plan",
-                    planReview: updatedBuild.planReview,
-                    deliberationSummary: updatedBuild.deliberationSummary,
+                    planReview: updatedBuild.planReview as Parameters<typeof evaluateBuildStudioPlanAdvancementGate>[0]["build"]["planReview"],
+                    deliberationSummary: updatedBuild.deliberationSummary as Parameters<typeof evaluateBuildStudioPlanAdvancementGate>[0]["build"]["deliberationSummary"],
                   },
                   triggeredByUserId: userId,
-                } as Parameters<typeof evaluateBuildStudioPlanAdvancementGate>[0]);
+                });
                 if (!decisionGate.allowed) {
                   decisionAllowed = false;
                   logBuildActivity(buildId, "wwmd:gate-blocked", decisionGate.operatorMessage ?? "Decision kernel withheld plan→build advancement.");


### PR DESCRIPTION
## What

Wire the **WWMD decision kernel** (`evaluateBuildStudioPlanAdvancementGate`) into `reviewBuildPlan`'s plan→build **auto-advance** path in `mcp-tools.ts`.

## Why

`reviewBuildPlan` auto-advances plan→build directly via a DB update — the agentic loop has no HTTP request context to call the `advanceBuildPhase` server action. That path ran:

- `checkPhaseGate` (structural right-sizing), and
- `deriveFeatureBuildDependencyGate` (dependency readiness),

but **never** `evaluateBuildStudioPlanAdvancementGate`. So any build that flows through the agentic-loop auto-advance — which is the normal path for local-model (opencode) builds — **silently bypassed the WWMD kernel** that the `/api/agent/build/advance-phase` HTTP route enforces. No `wwmd.gate.invoked` trace, no `DecisionInteraction` ledger entry.

This was surfaced directly while driving local-LLM builds end-to-end through Build Studio: the kernel that's supposed to be the authority on whether plan→build honors platform principles was never consulted on the auto-advanced builds.

## How

After the structural + dependency gates pass and **before** branch init / phase flip, invoke the kernel gate with the same build context the HTTP route uses (`planReview`, `deliberationSummary`).

- **Fail OPEN** on evaluator error — a kernel hiccup must not wedge the streamlined auto-cascade flow.
- A genuine **principle conflict** (`gate.allowed === false`) blocks the auto-advance, logs `wwmd:gate-blocked`, and surfaces a `DecisionInteraction` for operator review — exactly the authority the HTTP route applies.

Added `deliberationSummary` to the existing `updatedBuild` select so the gate sees the real deliberation context.

## Verification

- `tsc --noEmit` clean (verified directly; the deps-less worktree's pre-commit `next typegen` step can't run, so the hook typecheck was skipped — CI gates it).
- Functional verification happens on the next live-install deploy: drive a plan→build auto-advance and confirm a `wwmd.gate.invoked` / `wwmd.ledger.written` trace pair now appears (none did before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
