### PR TITLE
fix(build-studio): aggregate QA test counts across all packages (monorepo parse)

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.test.ts
+++ b/apps/web/lib/integrate/build-orchestrator.test.ts
@@ -476,6 +476,42 @@ describe("parseQAVerification", () => {
     expect(result.typecheckPassed).toBe(true);
     expect(result.parseConfidence).toBe("high");
   });
+
+  it("aggregates counts across multiple package summaries (monorepo pnpm -r run)", () => {
+    // A real `pnpm -r test` prints one vitest summary per package. The old
+    // single-.match() parse captured only the first package's numbers.
+    const multiPkg = [
+      " Tests  26 passed (26)",
+      " Tests  137 passed (137)",
+      " Tests  17 passed (17)",
+    ].join("\n");
+    const result = parseQAVerification(multiPkg);
+    expect(result.testsPassed).toBe(180);
+    expect(result.testsFailed).toBe(0);
+  });
+
+  it("flags a failure in a LATER package that a first-match parse would miss", () => {
+    // Regression for the truncateMiddle build: apps/web sorts last in pnpm -r,
+    // so its failures appear after several all-green package summaries. The old
+    // parser stopped at the first "N passed" and reported testsFailed:0, letting
+    // the build slip past the build→review gate.
+    const output = [
+      " Tests  26 passed (26)",
+      " Tests  137 passed (137)",
+      " Tests  3 failed | 2 passed (5)", // apps/web — the feature's broken tests
+    ].join("\n");
+    const result = parseQAVerification(output);
+    expect(result.testsFailed).toBe(3);
+    expect(result.testsPassed).toBe(165);
+  });
+
+  it("strips ANSI color codes before counting", () => {
+    // vitest colorizes its output; the escape sequences must not corrupt counts.
+    const colorized = " \x1b[32mTests\x1b[39m  \x1b[31m4 failed\x1b[39m | \x1b[32m10 passed\x1b[39m (14)";
+    const result = parseQAVerification(colorized);
+    expect(result.testsFailed).toBe(4);
+    expect(result.testsPassed).toBe(10);
+  });
 });
 
 // ─── Outcome Classification: False Positive Fixes ─────────────────────────

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -662,21 +662,43 @@ export function parseQAVerification(qaContent: string): QAVerification {
     return { typecheckPassed: false, testsPassed: 0, testsFailed: 0, parseConfidence: "low" };
   }
 
-  const lower = qaContent.toLowerCase();
+  // Strip ANSI color codes. A real `pnpm -r test` run is colorized, and the
+  // escape sequences otherwise wedge between digits and keywords and corrupt
+  // the count regexes below.
+  // eslint-disable-next-line no-control-regex -- ANSI color strip
+  const clean = qaContent.replace(/\x1b\[[0-9;]*m/g, "");
+  const lower = clean.toLowerCase();
 
   // Typecheck: explicit fail indicators mean failure; absence alone is not a pass
-  const hasTypecheckFail = /typecheck[\s:]*fail/i.test(qaContent)
-    || /type\s*error/i.test(qaContent)
-    || /tsc.*error/i.test(qaContent);
-  const hasTypecheckPass = /typecheck[\s:]*pass/i.test(qaContent)
-    || /typecheck[\s:]*(?:ok|success)/i.test(qaContent)
+  const hasTypecheckFail = /typecheck[\s:]*fail/i.test(clean)
+    || /type\s*error/i.test(clean)
+    || /tsc.*error/i.test(clean);
+  const hasTypecheckPass = /typecheck[\s:]*pass/i.test(clean)
+    || /typecheck[\s:]*(?:ok|success)/i.test(clean)
     || lower.includes("no type errors");
 
-  // Broader test count regexes to handle: "12 pass", "12 passing", "12 tests passed"
-  const passMatch = qaContent.match(/(\d+)\s*(?:tests?\s+)?pass(?:ing|ed)?/i);
-  const failMatch = qaContent.match(/(\d+)\s*(?:tests?\s+)?fail(?:ing|ed|ures?)?/i);
+  // Test counts. A monorepo `pnpm -r test` run prints one vitest summary PER
+  // package, so a single .match() captures only the FIRST package's numbers and
+  // silently drops failures in later packages (e.g. apps/web). That let builds
+  // whose own feature tests fail slip past the build→review gate with
+  // testsFailed:0 — the model wrote broken tests, but the pipeline reported
+  // green. Aggregate every count across the whole output instead: for gate
+  // purposes an over-count of failures is safe (it errs toward blocking the
+  // advance), an under-count is not. Legacy single-summary inputs sum to the
+  // same single value, so existing behavior is preserved.
+  let testsPassed = 0;
+  let testsFailed = 0;
+  let sawCount = false;
+  for (const m of clean.matchAll(/(\d+)\s*(?:tests?\s+)?pass(?:ing|ed)?/gi)) {
+    testsPassed += parseInt(m[1]!);
+    sawCount = true;
+  }
+  for (const m of clean.matchAll(/(\d+)\s*(?:tests?\s+)?fail(?:ing|ed|ures?)?/gi)) {
+    testsFailed += parseInt(m[1]!);
+    sawCount = true;
+  }
 
-  const hasTestResults = !!(passMatch || failMatch);
+  const hasTestResults = sawCount;
   const hasTypecheckSignal = hasTypecheckFail || hasTypecheckPass;
 
   if (!hasTestResults && !hasTypecheckSignal) {
@@ -685,8 +707,8 @@ export function parseQAVerification(qaContent: string): QAVerification {
 
   return {
     typecheckPassed: hasTypecheckPass || (!hasTypecheckFail && hasTestResults),
-    testsPassed: passMatch ? parseInt(passMatch[1]!) : 0,
-    testsFailed: failMatch ? parseInt(failMatch[1]!) : 0,
+    testsPassed,
+    testsFailed,
     parseConfidence: "high",
   };
 }


### PR DESCRIPTION
## What

`parseQAVerification` now strips ANSI color codes and **aggregates** test pass/fail counts across every package summary in the qa-engineer output, instead of reading only the first `.match()`.

## Why

A real `pnpm -r test` run prints one vitest summary **per package**. The old single `.match()` captured only the *first* package's numbers and silently dropped failures in later packages. **apps/web sorts last** in `pnpm -r`, so a build whose own feature tests fail reported `testsFailed: 0` — and could slip past the build→review phase gate.

This was surfaced directly: the local-model `truncateMiddle` build wrote broken tests (qwen3-coder hallucinated an expected value with a char not in the input), yet the verification evidence read green.

> Note: there is a *second, deeper* gap on the durable-build-pipeline path — that QA step runs the whole monorepo suite and **truncates output to 5000 chars before apps/web even runs**, so the failing tests aren't captured at all. That is tracked separately (verification should be scoped to the build's changed files). This PR fixes the orchestrator-path parser, which is correct and valuable on its own.

## How

- Strip ANSI escapes before parsing.
- `matchAll` + sum instead of first `.match()`. Over-counting failures is gate-safe (errs toward blocking); under-counting is not. Legacy single-summary inputs sum to the same single value — all prior tests preserved.

## Verification

- tsc clean.
- Logic exercised against 9 cases (4 legacy formats + multi-package aggregate + later-package failure + ANSI + edges) — all pass. New regression tests added to `build-orchestrator.test.ts`; CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)