### PR TITLE
fix(build-studio): scope QA verification to the build's changed files

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -533,7 +533,18 @@ async function stepRunTests(
   const { prisma } = await import("@dpf/db");
   const { runSandboxTests, diagnoseTestFailures } = await import("./coding-agent");
 
-  const results = await runSandboxTests(state.containerId!);
+  // Scope verification to the build's changed files so the feature's own tests
+  // gate the build and their output isn't truncated behind the full suite.
+  let changedFiles: string[] = [];
+  try {
+    const { getSandboxStateForBuild } = await import("@/lib/build/sandbox-state");
+    const sandboxState = await getSandboxStateForBuild(buildId);
+    changedFiles = sandboxState?.sourceDiffstat.map((entry) => entry.path) ?? [];
+  } catch (err) {
+    console.warn("[stepRunTests] could not resolve changed files for scoping:", (err as Error)?.message);
+  }
+
+  const results = await runSandboxTests(state.containerId!, { changedFiles });
   const diagnosis = results.passed ? null : diagnoseTestFailures(results);
 
   // Persist test results to the build record.

--- a/apps/web/lib/integrate/coding-agent.test.ts
+++ b/apps/web/lib/integrate/coding-agent.test.ts
@@ -57,3 +57,48 @@ describe("buildCodeGenPrompt", () => {
     expect(() => buildCodeGenPrompt(null, { fileStructure: [], tasks: [] })).not.toThrow();
   });
 });
+
+const { deriveScopedTestFiles, groupTestFilesByPackage } = await import("./coding-agent");
+
+describe("deriveScopedTestFiles", () => {
+  it("includes changed test files directly", () => {
+    expect(deriveScopedTestFiles(["apps/web/lib/utils/string-helpers.test.ts"]))
+      .toContain("apps/web/lib/utils/string-helpers.test.ts");
+  });
+
+  it("derives sibling test candidates for a changed source file", () => {
+    const result = deriveScopedTestFiles(["apps/web/lib/utils/string-helpers.ts"]);
+    expect(result).toContain("apps/web/lib/utils/string-helpers.test.ts");
+    expect(result).toContain("apps/web/lib/utils/string-helpers.test.tsx");
+  });
+
+  it("returns an empty list when nothing testable changed", () => {
+    expect(deriveScopedTestFiles(["README.md", "package.json", ""])).toEqual([]);
+  });
+
+  it("does not duplicate when both source and its test changed", () => {
+    const result = deriveScopedTestFiles([
+      "apps/web/lib/utils/string-helpers.ts",
+      "apps/web/lib/utils/string-helpers.test.ts",
+    ]);
+    const occurrences = result.filter((p) => p === "apps/web/lib/utils/string-helpers.test.ts");
+    expect(occurrences).toHaveLength(1);
+  });
+});
+
+describe("groupTestFilesByPackage", () => {
+  it("groups files by their apps/* or packages/* workspace root", () => {
+    const grouped = groupTestFilesByPackage([
+      "apps/web/lib/a.test.ts",
+      "apps/web/lib/b.test.ts",
+      "packages/db/src/c.test.ts",
+    ]);
+    expect(grouped.get("apps/web")).toEqual(["lib/a.test.ts", "lib/b.test.ts"]);
+    expect(grouped.get("packages/db")).toEqual(["src/c.test.ts"]);
+  });
+
+  it("ignores paths outside a workspace package", () => {
+    const grouped = groupTestFilesByPackage(["scripts/x.test.ts", "foo.test.ts"]);
+    expect(grouped.size).toBe(0);
+  });
+});

--- a/apps/web/lib/integrate/coding-agent.ts
+++ b/apps/web/lib/integrate/coding-agent.ts
@@ -297,9 +297,55 @@ export type SandboxTestResult = {
   typeCheckPassed: boolean;
   testOutput: string;
   typeCheckOutput: string;
+  /** "scoped" when we ran only the build's own feature tests, "full" otherwise. */
+  scope?: "scoped" | "full";
+  /** Number of feature test files run when scope === "scoped". */
+  scopedTestsRun?: number;
 };
 
-export async function runSandboxTests(containerId: string): Promise<SandboxTestResult> {
+/**
+ * Derive the vitest test files to run for a build, scoped to its changed files.
+ * Returns changed test files directly, plus sibling test candidates for changed
+ * source files. Candidates may not exist on disk — the runner filters to
+ * existing files before invoking vitest.
+ */
+export function deriveScopedTestFiles(changedFiles: string[]): string[] {
+  const tests = new Set<string>();
+  for (const raw of changedFiles) {
+    const f = raw.trim();
+    if (!f) continue;
+    if (/\.(test|spec)\.[tj]sx?$/.test(f)) {
+      tests.add(f);
+      continue;
+    }
+    if (/\.[tj]sx?$/.test(f)) {
+      const base = f.replace(/\.[tj]sx?$/, "");
+      tests.add(`${base}.test.ts`);
+      tests.add(`${base}.test.tsx`);
+      tests.add(`${base}.spec.ts`);
+    }
+  }
+  return [...tests];
+}
+
+/** Group test file paths by their workspace package (apps/* or packages/*). */
+export function groupTestFilesByPackage(files: string[]): Map<string, string[]> {
+  const grouped = new Map<string, string[]>();
+  for (const f of files) {
+    const match = f.match(/^(apps\/[^/]+|packages\/[^/]+)\/(.+)$/);
+    if (!match) continue;
+    const [, pkg, rel] = match;
+    const arr = grouped.get(pkg) ?? [];
+    arr.push(rel);
+    grouped.set(pkg, arr);
+  }
+  return grouped;
+}
+
+export async function runSandboxTests(
+  containerId: string,
+  opts?: { changedFiles?: string[] },
+): Promise<SandboxTestResult> {
   // Typecheck is the primary gate — catches real compilation errors in feature code.
   // Run it first via the web workspace's tsconfig (not bare `tsc` which prints help).
   let typeCheckOutput = "";
@@ -312,26 +358,70 @@ export async function runSandboxTests(containerId: string): Promise<SandboxTestR
     typeCheckOutput = e instanceof Error ? e.message : String(e);
   }
 
-  // Unit tests are informational — the sandbox contains the full platform codebase,
-  // so pre-existing test failures in unrelated modules must not block feature builds.
-  // Only feature-specific test failures (if any feature tests exist) should matter,
-  // but we don't have a way to scope vitest to just the feature's files yet.
-  // For now, record test output but gate only on typecheck.
+  // Scoped tests. Historically we gated on typecheck ONLY because "we don't have
+  // a way to scope vitest to just the feature's files yet" — so a build whose own
+  // feature tests failed still passed. When we know the build's changed files we
+  // now run ONLY the feature's test files: (a) the feature's tests actually GATE
+  // the build, and (b) the output stays small so a real failure is never
+  // truncated behind hundreds of unrelated monorepo tests. With no changed-file
+  // hint we fall back to the legacy full-suite run, recorded but typecheck-gated.
   let testOutput = "";
-  let testPassed = false;
-  try {
-    testOutput = await execInSandbox(containerId, "cd /workspace && pnpm test 2>&1 || true");
-    testPassed = testOutput.includes("Tests  ") && !testOutput.includes("FAIL");
-  } catch (e) {
-    testOutput = e instanceof Error ? e.message : String(e);
+  let testPassed = true;
+  let scope: "scoped" | "full" = "full";
+  let scopedTestsRun = 0;
+
+  const candidates = deriveScopedTestFiles(opts?.changedFiles ?? []);
+  let scopedTestFiles: string[] = [];
+  if (candidates.length > 0) {
+    const existence = await Promise.all(
+      candidates.map(async (p) => {
+        try {
+          const out = await execInSandbox(containerId, `test -f "/workspace/${p}" && echo __yes__ || echo __no__`);
+          return out.includes("__yes__") ? p : null;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    scopedTestFiles = existence.filter((p): p is string => p !== null);
+  }
+
+  if (scopedTestFiles.length > 0) {
+    scope = "scoped";
+    scopedTestsRun = scopedTestFiles.length;
+    const sections: string[] = [];
+    let anyFailed = false;
+    for (const [pkg, rel] of groupTestFilesByPackage(scopedTestFiles)) {
+      const fileArgs = rel.map((r) => `"${r}"`).join(" ");
+      const out = await execInSandbox(containerId, `cd /workspace/${pkg} && npx vitest run ${fileArgs} 2>&1 || true`);
+      sections.push(`# ${pkg}\n${out}`);
+      // vitest omits the "failed" segment entirely when zero, so any "N failed"
+      // with N>=1 (or a FAIL marker) means the feature's own tests are red.
+      if (/\b[1-9]\d*\s+failed/i.test(out) || /^\s*FAIL\b/m.test(out)) {
+        anyFailed = true;
+      }
+    }
+    testOutput = sections.join("\n\n");
+    testPassed = !anyFailed;
+  } else {
+    try {
+      testOutput = await execInSandbox(containerId, "cd /workspace && pnpm test 2>&1 || true");
+      testPassed = testOutput.includes("Tests  ") && !testOutput.includes("FAIL");
+    } catch (e) {
+      testOutput = e instanceof Error ? e.message : String(e);
+      testPassed = false;
+    }
   }
 
   return {
-    // Gate on typecheck only — unit tests are recorded but informational
-    passed: typeCheckPassed,
+    // Gate on typecheck AND — when feature tests were scoped and run — those
+    // tests. The legacy full-suite path stays typecheck-gated (informational).
+    passed: typeCheckPassed && (scope === "scoped" ? testPassed : true),
     typeCheckPassed,
     testOutput,
     typeCheckOutput,
+    scope,
+    scopedTestsRun,
   };
 }
 

--- a/apps/web/lib/integrate/specialist-prompts.ts
+++ b/apps/web/lib/integrate/specialist-prompts.ts
@@ -166,7 +166,10 @@ You are the QA Engineer specialist. Your domain: test execution, typecheck verif
 
 WORKFLOW:
 1. run_sandbox_command with "pnpm exec tsc --noEmit" -- typecheck first
-2. run_sandbox_tests -- full test suite
+2. run_sandbox_tests -- runs the feature's OWN tests (scoped to the build's
+   changed files) plus typecheck. These tests GATE the build: if the feature's
+   tests fail, the build does not pass. (Unrelated pre-existing failures
+   elsewhere in the monorepo do not block — only the feature's own tests.)
 3. If tests fail: read the test output, identify WHICH test and the exact error
 4. read_sandbox_file on the failing test to understand what it expects
 5. Report results: pass count, fail count, typecheck status, specific failures

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -9397,7 +9397,19 @@ export async function executeTool(
       const autoFix = params.auto_fix === true;
       const MAX_FIX_ATTEMPTS = 3;
 
-      let results = await runSandboxTests(rstSandboxId);
+      // Scope verification to the build's changed files so the feature's OWN
+      // tests gate the build (not just typecheck) and their output isn't
+      // truncated behind the full monorepo suite.
+      let rstChangedFiles: string[] = [];
+      try {
+        const { getSandboxStateForBuild } = await import("@/lib/build/sandbox-state");
+        const rstState = await getSandboxStateForBuild(buildId);
+        rstChangedFiles = rstState?.sourceDiffstat.map((entry) => entry.path) ?? [];
+      } catch (err) {
+        console.warn("[run_sandbox_tests] could not resolve changed files for scoping:", (err as Error)?.message);
+      }
+
+      let results = await runSandboxTests(rstSandboxId, { changedFiles: rstChangedFiles });
       let fixAttempts = 0;
 
       // Auto-fix loop: diagnose failures, apply fixes via LLM, re-test
@@ -9554,8 +9566,8 @@ export async function executeTool(
             break; // LLM call failed — stop retrying
           }
 
-          // Re-run tests
-          results = await runSandboxTests(rstSandboxId);
+          // Re-run tests (same scoping as the initial run)
+          results = await runSandboxTests(rstSandboxId, { changedFiles: rstChangedFiles });
         }
       }
 


### PR DESCRIPTION
## What

`runSandboxTests` now runs **only the build's own feature tests** (scoped to its changed files) and **gates on them** — instead of running the whole monorepo `pnpm test` and gating on typecheck alone.

## Why

This resolves a long-standing, code-commented limitation:

> "we don't have a way to scope vitest to just the feature's files yet ... gate only on typecheck."

Consequence: a build whose **own feature tests fail still passed QA**. The local-model `truncateMiddle` build hit this exactly — qwen3-coder wrote 3 broken tests, but the build read green. Worse, the full-suite output truncated at 5000 chars *before apps/web ran*, so the failures were never even captured. This is the root cause behind the verification-layer findings from the local-model campaign (complements #1986 WWMD gate and #1987 multi-package parse).

## How

- `deriveScopedTestFiles(changedFiles)` — changed test files + sibling test candidates for changed sources.
- `groupTestFilesByPackage(files)` — group by `apps/*` | `packages/*`.
- `runSandboxTests(containerId, { changedFiles })` — filter candidates to files that exist in the sandbox, run vitest scoped to them per package from each package root. `passed = typecheck AND scoped tests`. Output stays small → no truncation. **No changed-file hint → legacy full-suite (typecheck-gated) preserved**, so builds with no feature tests don't regress.
- Wired through both QA callers with build context: the `run_sandbox_tests` tool (+ auto-fix re-test) and the durable pipeline's `stepRunTests`. qa-engineer prompt updated.

## Verification

- tsc clean.
- Pure helpers exercised — 7 cases (direct test, sibling derive, dedup, package grouping, out-of-workspace ignore). New unit tests added.
- **Functional**: the scoped vitest invocation run live against the `truncateMiddle` fixture still in the sandbox correctly reports `3 failed` → `results.passed` becomes false → the build would now be **held, not passed**. (Worktree vitest config can't resolve under the deps-less junction; CI runs the full suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)