### PR TITLE
feat(routing,inference): enable local vision capability (Gemma 4 12B on DMR)

### DIFF
--- a/apps/web/lib/inference/ai-inference-toolcalls.test.ts
+++ b/apps/web/lib/inference/ai-inference-toolcalls.test.ts
@@ -100,6 +100,35 @@ describe("formatMessagesForProvider", () => {
       const formatted = formatMessageForAnthropic(msg);
       expect(formatted).toEqual({ role: "user", content: "hello" });
     });
+
+    it("converts a multimodal user message (text + image_url) to Anthropic image source blocks", () => {
+      const msg: ChatMessage = {
+        role: "user",
+        content: [
+          { type: "text", text: "Assess this UI" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAAB" } },
+        ],
+      };
+      const formatted = formatMessageForAnthropic(msg);
+      expect(formatted).toEqual({
+        role: "user",
+        content: [
+          { type: "text", text: "Assess this UI" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAB" } },
+        ],
+      });
+    });
+
+    it("converts an http image_url to an Anthropic url image source", () => {
+      const msg: ChatMessage = {
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: "https://x/y.png" } }],
+      };
+      const formatted = formatMessageForAnthropic(msg);
+      expect(formatted.content).toEqual([
+        { type: "image", source: { type: "url", url: "https://x/y.png" } },
+      ]);
+    });
   });
 
   describe("OpenAI-compatible", () => {
@@ -133,6 +162,15 @@ describe("formatMessagesForProvider", () => {
       const msg: ChatMessage = { role: "user", content: "hello" };
       const formatted = formatMessageForOpenAI(msg);
       expect(formatted).toEqual({ role: "user", content: "hello" });
+    });
+
+    it("passes a multimodal user message through as the OpenAI vision wire format", () => {
+      const content: ChatMessage["content"] = [
+        { type: "text", text: "Assess this UI" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,AAAB" } },
+      ];
+      const formatted = formatMessageForOpenAI({ role: "user", content });
+      expect(formatted).toEqual({ role: "user", content });
     });
   });
 

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -43,8 +43,32 @@ import "../routing/codex-cli-adapter"; // codex: registers "codex-cli" adapter
 /** Anthropic-style content blocks for structured tool-calling messages */
 export type ContentBlock =
   | { type: "text"; text: string }
+  /**
+   * Image input for multimodal models. Carried in OpenAI Chat Completions wire
+   * form (`image_url` with a data: URL or http(s) URL); converted to the
+   * Anthropic `image` source block by formatMessageForAnthropic. Enables vision
+   * models (e.g. local Gemma 4 via Docker Model Runner) to receive screenshots.
+   */
+  | { type: "image_url"; image_url: { url: string; detail?: "auto" | "low" | "high" } }
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
   | { type: "tool_result"; tool_use_id: string; content: string };
+
+/** True when a message's content array carries only model-facing input blocks
+ *  (text / image) that can be passed through to a chat API as-is. The formatters
+ *  rely on ContentBlock discriminated-union narrowing for per-block typing. */
+function isMultimodalInputContent(content: ContentBlock[]): boolean {
+  return content.length > 0 && content.every((b) => b.type === "text" || b.type === "image_url");
+}
+
+/** Convert an OpenAI-style image_url (data: URL) to an Anthropic image source block. */
+function imageUrlToAnthropicBlock(url: string): Record<string, unknown> {
+  const m = /^data:([^;]+);base64,(.*)$/s.exec(url);
+  if (m) {
+    return { type: "image", source: { type: "base64", media_type: m[1], data: m[2] } };
+  }
+  // Anthropic also accepts URL image sources.
+  return { type: "image", source: { type: "url", url } };
+}
 
 export type ChatMessage = {
   role: "user" | "assistant" | "system" | "tool";
@@ -305,6 +329,17 @@ export function formatMessageForAnthropic(msg: ChatMessage): Record<string, unkn
       ],
     };
   }
+  // Multimodal user input (text + image blocks) → Anthropic content array.
+  if (Array.isArray(msg.content) && isMultimodalInputContent(msg.content)) {
+    return {
+      role: msg.role,
+      content: msg.content.map((b) => {
+        if (b.type === "image_url") return imageUrlToAnthropicBlock(b.image_url.url);
+        // isMultimodalInputContent guarantees the only other member is text.
+        return { type: "text", text: b.type === "text" ? b.text : "" };
+      }),
+    };
+  }
   // Plain messages — pass through with string content
   return { role: msg.role, content: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content) };
 }
@@ -325,6 +360,11 @@ export function formatMessageForOpenAI(msg: ChatMessage): Record<string, unknown
         function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
       })),
     };
+  }
+  // Multimodal user input (text + image_url blocks) → pass through as-is; this is
+  // already the OpenAI Chat Completions vision wire format.
+  if (Array.isArray(msg.content) && isMultimodalInputContent(msg.content)) {
+    return { role: msg.role, content: msg.content };
   }
   // Plain messages — pass through with string content
   return { role: msg.role, content: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content) };

--- a/docs/superpowers/specs/2026-06-15-local-multimodal-capability-gemma4-spike-design.md
+++ b/docs/superpowers/specs/2026-06-15-local-multimodal-capability-gemma4-spike-design.md
@@ -1,0 +1,113 @@
+# Local Multimodal Capability (Gemma 4 12B) — Spike Design
+
+- **Status:** spike (evidence-gathering); BI **BI-7C8E3F8F** filed under `EP-ROUTING-11`
+- **Date:** 2026-06-15
+- **Author:** Claude (autonomous spike)
+- **Epic:** EP-ROUTING-11 (Routing substrate + execution adapters)
+
+## Summary
+
+Register **Gemma 4 12B** (multimodal-IN / text-OUT, Apache 2.0, released 2026-06-03) as a
+new **local vision capability** on the existing Docker Model Runner (DMR) substrate, without
+disturbing the code-gen path (`qwen3-coder`) or the embeddings path (`nomic-embed-text`).
+Prove it end-to-end on one high-value use case: **vision-based UI cognitive-load assessment
+feeding the existing WWMD `human_cognitive_load` rubric** — closing the "structural ≠ functional"
+gap on UI evaluation by giving the rubric *real visual input* for the first time.
+
+## On-machine verification (done before scoping)
+
+1. **DMR tag.** `ai/gemma4:12B` resolves directly in the Docker Hub `ai/` catalog at **7.54 GB**
+   (≈Q4). `docker model pull ai/gemma4:12B` — no GGUF side-pull needed. Zero-click story holds.
+   (Family also publishes E2B/E4B/4B/12B/26B/31B + `gemma4-safetensors`.)
+2. **VRAM.** RTX 4090, 24564 MiB. Idle baseline 1353 MiB (qwen3-coder idle-unloaded — DMR
+   load-on-demand confirmed). Measured: `gemma4:12B` resident ~14988 MiB; **gemma4 + qwen3-coder
+   co-resident ~22525 MiB / 24564 MiB (both fit, ~1.6 GB headroom)**. Cold model load ~40 s;
+   warm = no swap. Co-residency is better than predicted — common case needs no swap, but thin
+   headroom means a large context window can still force an eviction. `docker model ps` shows a
+   per-model idle TTL (auto-unload).
+3. **Activation probe** (OpenAI-compatible `/v1/chat/completions`, base64 `image_url` blocks):
+   - **Text:** works. Gemma 4 12B is a **reasoning model** — emits a separate `reasoning_content`
+     field; with a low `max_tokens` the budget is consumed by reasoning before any `content`
+     appears (empty content + `finish_reason:"length"`). With adequate budget, correct answers.
+   - **Vision sanity:** "3 red squares, 2 blue circles" → `3 and 2` (correct).
+   - **Cognitive-load discrimination:** clean single-action card → `{cognitive_load:0.1,
+     visual_density:0.1, control_count_estimate:2}`; dense 24-card dashboard → `{cognitive_load:0.75,
+     visual_density:0.85, control_count_estimate:33}` (actual controls: 9 + 24 = 33 — exact).
+     Reasoning text was accurate ("dense grid of repetitive metric cards ... lack of visual
+     hierarchy"). **Latency ~7–10 s/image** once warm.
+
+## Substrate already present (verify-before-proposing-new)
+
+- `ModelCardCapabilities` already has `imageInput`, `pdfInput`, `inputModalities`,
+  `outputModalities` — `apps/web/lib/routing/model-card-types.ts:20-36,65-107`.
+- The agent routing floor already enforces `imageInput` —
+  `apps/web/lib/routing/agent-capability-types.ts:11-64`, `satisfiesMinimumCapabilities()`.
+- `gemma4` already maps to the `adequate` quality tier — `apps/web/lib/routing/quality-tiers.ts`.
+- Modality adapters already exist: `image-gen-adapter`, `transcription-adapter`,
+  `embedding-adapter` registered in `apps/web/lib/inference/ai-inference.ts:34-37`.
+- The WWMD cognitive-load rubric exists — `apps/web/lib/decision/ui-surface-features.ts`
+  (`uiSurfaceFeatures()` / `scoreUiSurfaceChange()`), scoring axis `human_cognitive_load`
+  in `packages/db/src/wiki-taxonomy.ts:144-160` (cost axis).
+- `evaluate_page` already captures a screenshot — `apps/web/lib/mcp-tools.ts` (~11459).
+
+## Gaps (the actual work — verified in source)
+
+- **GAP 1 — seed never tags local vision capability.** `seedLocalModels()`
+  (`packages/db/src/seed.ts:1684`) writes `capabilities: { streaming, embedding }` only.
+  No `imageInput` / `inputModalities`, so a vision-capable local model is invisible to the
+  `imageInput` routing floor. Fix in the **family-prior** (`local-model-capabilities.ts`) +
+  seed, keyed on family — bootstrap prior, runtime eval still calibrates.
+- **GAP 2 — inference layer can't carry an image.** `ContentBlock`
+  (`ai-inference.ts:44-47`) is text/tool_use/tool_result only; `formatMessageForOpenAI`
+  (line 330) `JSON.stringify`s array content, destroying image blocks. OpenAI's vision wire
+  format wants the `[{type:text},{type:image_url,image_url:{url}}]` array passed through
+  natively; Anthropic wants `{type:image,source:{type:base64,...}}`.
+- **GAP 3 — `evaluate_page` screenshot is captured but never seen by a model.** The base64
+  is returned unused. No pipeline from screenshot → vision model → `human_cognitive_load`
+  score → `scoreUiSurfaceChange()`.
+- **GAP 4 — reasoning-model token budget / `reasoning_content`.** Gemma 4 12B emits a separate
+  `reasoning_content` channel; a too-small `max_tokens` yields empty `content`. The inference
+  layer's OpenAI response handling must (a) allocate adequate output budget for vision/reasoning
+  calls and (b) optionally surface/discard `reasoning_content`. Low-risk but must be handled or
+  vision calls silently return empty.
+
+## Approach (no provider pinning; capability-routed)
+
+1. **Family prior + seed (GAP 1):** vision-aware prior for the gemma multimodal family;
+   seed populates `imageInput: true` + `inputModalities: ["text","image"]`. Bootstrap only —
+   activation eval still promotes confidence.
+2. **Inference transport (GAP 2):** extend `ContentBlock` with an `image_url` block; pass
+   array content through in `formatMessageForOpenAI`; convert to base64 source in
+   `formatMessageForAnthropic`. Smallest enabling change; unblocks all multimodal use cases.
+3. **Vision UI assessment (GAP 3):** route the captured screenshot to the vision-capable
+   local model (capability-routed via `imageInput` floor — never pinned to "gemma4"), parse a
+   structured cognitive-load score, merge into the rubric feature vector.
+
+## Implementation status (PR A — enabling substrate)
+
+GAP 1 + GAP 2 implemented directly in this worktree (BS re-architecture standing rule):
+- `packages/db/src/local-model-capabilities.ts` — `supportsVision` prior + `detectLocalModelVision()`
+  (orthogonal to family; embeddings never vision; bootstrap prior, eval still calibrates).
+- `packages/db/src/seed.ts` — `seedLocalModels()` writes `capabilities.imageInput` +
+  `inputModalities/outputModalities/supportedModalities` for vision-capable locals.
+- `apps/web/lib/inference/ai-inference.ts` — `ContentBlock` `image_url` member; OpenAI formatter
+  passes the vision array through (native wire format); Anthropic formatter converts to `image`
+  base64/url source blocks.
+- Unit tests: `packages/db/test/local-model-capabilities.test.ts`,
+  `apps/web/lib/inference/ai-inference-toolcalls.test.ts`.
+
+GAP 3 (vision UI assessment → rubric) and GAP 4 (reasoning-token budget at the call site) are the
+follow-on use-case work tracked under BI-7C8E3F8F; the enabling transport above unblocks them.
+
+## Research & Benchmarking
+
+- **Google guidance:** Gemma 4 + Docker Model Runner is the published ADK local-agent pattern —
+  OpenAI-compatible serving on :12434 maps 1:1 onto DPF's existing `ai-inference.ts` chat path.
+- **Wire format:** OpenAI Chat Completions vision (`content: [{type:text},{type:image_url,
+  image_url:{url:"data:image/png;base64,..."}}]`) is the cross-engine standard (llama.cpp /
+  vLLM / DMR). Anthropic uses `{type:image, source:{type:base64,media_type,data}}` — both covered.
+- **vs. prior `evaluate_page` heuristic:** the structural/DOM-only path (axe-core findings +
+  unused screenshot) cannot see visual density, whitespace, grouping, or information scent — the
+  exact signals `human_cognitive_load` wants. The probe showed Gemma 4 scoring those correctly
+  (clean 0.1 / cluttered 0.75), closing the structural≠functional gap on UI with a local,
+  zero-egress model (data never leaves the machine).

--- a/packages/db/src/local-model-capabilities.ts
+++ b/packages/db/src/local-model-capabilities.ts
@@ -23,6 +23,13 @@
 export interface LocalModelCapabilityPrior {
   /** True for embedding models (nomic, bge, e5, ...). Not chat/tool routable. */
   isEmbedding: boolean;
+  /**
+   * True for multimodal-IN models that accept image content (Gemma 4, Gemma 3n,
+   * *-VL, LLaVA, moondream, pixtral, MiniCPM-V, ...). Drives ModelProfile
+   * capabilities.imageInput so the `imageInput` routing floor can select it.
+   * Bootstrap prior only — the activation eval still calibrates.
+   */
+  supportsVision: boolean;
   capabilityCategory: string;
   supportsToolUse: boolean;
   reasoning: number;
@@ -73,11 +80,41 @@ export function detectLocalModelFamily(modelId: string): LocalModelFamily {
 }
 
 /**
+ * Best-effort detection of multimodal (image-input) local models, orthogonal to
+ * the text/tool family. Capability-routing relies on this to populate
+ * ModelProfile.capabilities.imageInput so the `imageInput` floor
+ * (apps/web/lib/routing/agent-capability-types.ts) can select a vision model
+ * without any provider/model pin. Verified on-machine 2026-06-15: Gemma 4 12B
+ * (ai/gemma4:12B) accepts OpenAI-compatible image_url content via Docker Model
+ * Runner and returns accurate visual assessments. This is a prior — the
+ * activation eval still measures and can correct it.
+ */
+export function detectLocalModelVision(modelId: string): boolean {
+  const id = normalizeLocalModelId(modelId);
+  // Embedding models are never vision-routable, regardless of name.
+  if (/embed|nomic|bge|e5-|gte-/.test(id)) return false;
+  return /gemma4|gemma-4|gemma3n|gemma-3n|llava|moondream|pixtral|minicpm-v|[-/]vl\b|-vl[-:]|vision/.test(
+    id,
+  );
+}
+
+/**
  * Derive a capability prior for a local model id. Pure — no DB, no network.
  * The numbers are deliberately coarse: they only need to be *good enough to
  * route* until the deterministic eval measures the real model.
  */
 export function deriveLocalModelCapabilityPrior(modelId: string): LocalModelCapabilityPrior {
+  const base = derivePriorBase(modelId);
+  return {
+    ...base,
+    // Vision is orthogonal to the text/tool family; embedding models are never
+    // vision-routable. Bootstrap prior — the activation eval still calibrates.
+    supportsVision: base.isEmbedding ? false : detectLocalModelVision(modelId),
+  };
+}
+
+/** Family-keyed text/tool capability base (vision added by the wrapper above). */
+function derivePriorBase(modelId: string): Omit<LocalModelCapabilityPrior, "supportsVision"> {
   const family = detectLocalModelFamily(modelId);
   switch (family) {
     case "embedding":

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1681,7 +1681,19 @@ async function seedLocalModels(): Promise<void> {
           instructionFollowingScore: prior.instructionFollowingScore,
           structuredOutputScore: prior.structuredOutputScore,
           conversational: prior.conversational, contextRetention: prior.contextRetention,
-          capabilities: { streaming: true, embedding: prior.isEmbedding } as any,
+          // imageInput drives the `imageInput` routing floor so vision tasks can
+          // select a multimodal local model (e.g. Gemma 4) with no provider pin.
+          capabilities: {
+            streaming: true,
+            embedding: prior.isEmbedding,
+            ...(prior.supportsVision ? { imageInput: true } : {}),
+          } as any,
+          inputModalities: prior.supportsVision ? ["text", "image"] : ["text"],
+          outputModalities: ["text"],
+          supportedModalities: {
+            input: prior.supportsVision ? ["text", "image"] : ["text"],
+            output: ["text"],
+          },
         },
       });
       discovered++;

--- a/packages/db/test/local-model-capabilities.test.ts
+++ b/packages/db/test/local-model-capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveLocalModelCapabilityPrior,
   detectLocalModelFamily,
+  detectLocalModelVision,
   normalizeLocalModelId,
 } from "../src/local-model-capabilities";
 
@@ -74,5 +75,48 @@ describe("deriveLocalModelCapabilityPrior", () => {
     expect(p.supportsToolUse).toBe(true);
     expect(p.toolFidelity).toBeGreaterThan(20);
     expect(p.toolFidelity).toBeLessThan(60);
+  });
+
+  it("flags multimodal models as vision-capable (drives imageInput floor)", () => {
+    // Verified on-machine 2026-06-15: ai/gemma4:12B does real vision via DMR.
+    expect(deriveLocalModelCapabilityPrior("ai/gemma4:12B").supportsVision).toBe(true);
+    expect(deriveLocalModelCapabilityPrior("docker.io/ai/gemma4:26B").supportsVision).toBe(true);
+  });
+
+  it("does not flag text-only local models as vision-capable", () => {
+    expect(deriveLocalModelCapabilityPrior("ai/qwen3:14B-Q6_K").supportsVision).toBe(false);
+    expect(deriveLocalModelCapabilityPrior("ai/qwen2.5-coder:7B").supportsVision).toBe(false);
+    expect(deriveLocalModelCapabilityPrior("ai/magistral-small-3.2:latest").supportsVision).toBe(false);
+  });
+
+  it("never marks an embedding model vision-capable", () => {
+    expect(deriveLocalModelCapabilityPrior("docker.io/ai/nomic-embed-text-v1.5:latest").supportsVision).toBe(false);
+  });
+});
+
+describe("detectLocalModelVision", () => {
+  it("detects multimodal families orthogonal to the text/tool family", () => {
+    for (const id of [
+      "ai/gemma4:12B",
+      "docker.io/ai/gemma3n:latest",
+      "ai/llava:13b",
+      "ai/moondream2:latest",
+      "ai/pixtral-12b:latest",
+      "ai/qwen2.5-vl:7b",
+      "ai/minicpm-v:latest",
+    ]) {
+      expect(detectLocalModelVision(id)).toBe(true);
+    }
+  });
+
+  it("returns false for text-only and embedding models", () => {
+    for (const id of [
+      "ai/qwen3-coder:latest",
+      "ai/gemma3:latest",
+      "ai/magistral-small-3.2:latest",
+      "docker.io/ai/nomic-embed-text-v1.5:latest",
+    ]) {
+      expect(detectLocalModelVision(id)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Enable local vision capability — Gemma 4 12B on Docker Model Runner

Spike (BI-7C8E3F8F, EP-ROUTING-11). Registers **Gemma 4 12B** as a local **vision** capability on the existing DMR substrate with **no provider pinning** (routes via the existing `imageInput` floor), without disturbing the code-gen path (`qwen3-coder`) or embeddings (`nomic-embed-text`).

### On-machine evidence (live 4090 install, 2026-06-15)
- DMR tag `ai/gemma4:12B` = **7.54 GB**, zero-click pull from the Docker Hub `ai/` catalog (no GGUF side-pull). Served at `docker.io/ai/gemma4:12B` on `:12434`.
- **Vision is real & accurate** via the OpenAI-compatible `image_url` (base64) wire format: shape-count sanity correct; UI cognitive-load **discriminates clean (0.10) vs cluttered (0.75)** with exact control counts (2 / 33) and accurate reasoning. ~7–10 s/image warm.
- Gemma 4 is a **reasoning model** — emits a separate `reasoning_content`; a too-small `max_tokens` yields empty `content` (caller-side budget concern → GAP 4, follow-on).
- VRAM: `gemma4` ~15 GB resident; **gemma4 + qwen3-coder co-resident ~22.5/24 GB** (both fit, warm = no swap; thin headroom can still force an eviction under large context).

### Changes (enabling substrate)
- **`packages/db/src/local-model-capabilities.ts`** — `supportsVision` prior + `detectLocalModelVision()`. Vision is orthogonal to the text/tool family (gemma4/gemma3n/`*-vl`/llava/moondream/pixtral/minicpm-v); embeddings are never vision. Bootstrap prior — the activation eval still calibrates.
- **`packages/db/src/seed.ts`** — `seedLocalModels()` now writes `capabilities.imageInput` + `input/output/supportedModalities` for vision-capable local models, so the `imageInput` routing floor (`agent-capability-types`) can select them.
- **`apps/web/lib/inference/ai-inference.ts`** — `ContentBlock` gains an `image_url` member; OpenAI formatter passes the `text + image_url` array through (native OpenAI vision wire format); Anthropic formatter converts to `image` base64/url source blocks.

### Tests / gates (worktree, deps installed locally)
- `packages/db` vitest **14/14** (7 new vision cases) ✅
- `apps/web` `ai-inference-toolcalls` vitest **17/17** (3 new multimodal cases) ✅
- `@dpf/db` + `web` `tsc --noEmit` clean ✅
- Merged `origin/main` locally; tests green post-merge.

### Scope / follow-on (tracked under BI-7C8E3F8F)
- **GAP 3** — wire `evaluate_page`'s captured screenshot → vision model → `human_cognitive_load` → `scoreUiSurfaceChange()` (closes structural≠functional on UI eval).
- **GAP 4** — reasoning-token budget + `reasoning_content` handling at the vision call site.

Spec: `docs/superpowers/specs/2026-06-15-local-multimodal-capability-gemma4-spike-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
