### PR TITLE
fix(grants): map renew_nonprod_environment_lease grant (INV-1 on main)

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -173,6 +173,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   list_nonprod_environment_leases: ["work_capsule_read"],
   claim_nonprod_environment_lease: ["work_capsule_write"],
   release_nonprod_environment_lease: ["work_capsule_write"],
+  renew_nonprod_environment_lease: ["work_capsule_write"],
 
   // Backlog triage and Build Studio promotion (spec 2026-04-21)
   // These were defined in PLATFORM_TOOLS but missing here, so every call was


### PR DESCRIPTION
**Hotfix for main.** [#1990](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1990) merged the `renew_nonprod_environment_lease` MCP tool, but auto-merge raced ahead of the grant-mapping commit — so main has the tool with **no `TOOL_TO_GRANTS` entry**. The Routing Invariants Audit **INV-1** now flags it on main and will block subsequent PRs.

One-line fix: map `renew_nonprod_environment_lease` → `work_capsule_write`, mirroring `claim`/`release`. That grant key is already cataloged and non-empty, so no `grant_catalog.json` change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)