### PR TITLE
fix(portal-context): dock overlay drawer beside coworker panel, not behind it

### DIFF
--- a/apps/web/components/portal-context/PortalContextOverlayDrawer.test.tsx
+++ b/apps/web/components/portal-context/PortalContextOverlayDrawer.test.tsx
@@ -29,6 +29,27 @@ describe("PortalContextOverlayDrawer", () => {
     expect(screen.getByText("WC-123")).toBeTruthy();
   });
 
+  it("docks beside the AI coworker panel instead of underneath it", () => {
+    // Regression guard: the coworker panel is z-50 and reserves the
+    // --agent-panel-reserved-width gutter on the right. The drawer must offset
+    // its right edge by that gutter (so the two sit side by side) and sit above
+    // the coworker tier (so it is never hidden behind a floating coworker on a
+    // narrow viewport). See the comment in PortalContextOverlayDrawer.tsx.
+    // Assert against the rendered markup rather than element.style — jsdom's
+    // CSS parser drops var() values on the `right` longhand.
+    const html = renderToStaticMarkup(
+      <PortalContextOverlayDrawer envelope={makeEnvelope()} open={true} onClose={() => {}} />,
+    );
+
+    // Offsets by the coworker's reserved-width gutter (side by side, not under).
+    expect(html).toContain("--agent-panel-reserved-width");
+    // Sits above the coworker tier (z-50)...
+    expect(html).toContain("z-[60]");
+    // ...and no longer below it / pinned to the raw viewport edge.
+    expect(html).not.toContain("z-40");
+    expect(html).not.toContain("right-0");
+  });
+
   it("renders empty hive and evidence states without hardcoded colors", () => {
     const envelope = makeEnvelope({ coworkers: [], evidence: [] });
     render(<PortalContextOverlayDrawer envelope={envelope} open={true} onClose={vi.fn()} />);

--- a/apps/web/components/portal-context/PortalContextOverlayDrawer.tsx
+++ b/apps/web/components/portal-context/PortalContextOverlayDrawer.tsx
@@ -22,7 +22,18 @@ export function PortalContextOverlayDrawer({
   return (
     <aside
       aria-label="Portal context overlay"
-      className="fixed inset-y-0 right-0 z-40 flex w-full max-w-xl flex-col border-l border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] shadow-xl"
+      // Dock to the LEFT of the AI coworker panel instead of underneath it.
+      // The coworker panel (z-50) docks to the viewport's right edge on desktop
+      // and reserves a gutter via --agent-panel-reserved-width — the same gutter
+      // the shell content honors in (shell)/layout.tsx. Offsetting our right
+      // edge by that gutter lets both panels sit side by side rather than
+      // overlapping. When the coworker is closed or floating the gutter is 0px
+      // and we fall back to the right edge. z-[60] keeps the drawer above the
+      // coworker tier (z-50) for the narrow-viewport floating case, where there
+      // is no gutter to offset around, while staying below the z-[80] banner
+      // overlay tier.
+      style={{ right: "var(--agent-panel-reserved-width, 0px)" }}
+      className="fixed inset-y-0 z-[60] flex w-full max-w-xl flex-col border-l border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] shadow-xl transition-[right] duration-200"
     >
       <div className="flex items-center justify-between gap-3 border-b border-[var(--dpf-border)] px-4 py-3">
         <div className="min-w-0">


### PR DESCRIPTION
## Problem

Opening **Portal context** (the "Open context" button on `/build` and Work Control) slid the drawer in on the right **behind the AI coworker panel**, hiding the Context/Work/Hive tabs. Reported before but unresolved.

## Root cause

Both panels dock to the viewport's right edge, but they never coexisted cleanly:

- The **AI coworker panel** is `zIndex: 50` and, on desktop, reserves a gutter via `--agent-panel-reserved-width` — the same gutter the shell content honors in [`(shell)/layout.tsx`](apps/web/app/(shell)/layout.tsx) so it never collides.
- The **Portal context drawer** was `fixed right-0 z-40` — it ignored that gutter *and* sat one z-tier below the coworker, so it rendered underneath it.

The overlay spec ([§19 Q1](docs/superpowers/specs/2026-05-17-portal-context-overlay-hive-mind-work-surface-design.md)) intends both panels to be open **simultaneously**, flagging only that it should be revisited "if simultaneous-open ergonomics prove confusing." They were.

## Fix

- Offset the drawer's right edge by `--agent-panel-reserved-width` so the two panels sit **side by side** instead of overlapping. When the coworker is closed/floating the gutter is `0px` and the drawer falls back to the right edge.
- Raise the drawer to `z-[60]` (above the coworker tier `z-50`, below the `z-[80]` banner overlay tier) so it stays visible in the narrow-viewport *floating* case, where there is no gutter to offset around.
- Add a regression-guard test asserting the offset + z-tier (using `renderToStaticMarkup` to avoid jsdom dropping the `var()` value).

Two-line component change; no behavior change to envelope resolution, tabs, or content.

## Verification

- **Unit:** new + existing `PortalContextOverlayDrawer` tests run in **PR CI** — this worktree is source-only (no local `node_modules`), so the pre-commit typecheck was skipped with the documented `DPF_SKIP_TYPECHECK=1` override; CI gates typecheck + tests.
- **Functional (UX):** the live install runs the deployed image, so driving the `/build` happy path happens post-merge via the governed deploy/audit path (single-verification-path rule), not a worktree-local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)