### PR TITLE
fix(self-upgrade): explain WHY a run was skipped instead of a silent 'skipped' badge

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -143,6 +143,7 @@ describe("SelfUpgradePage", () => {
       currentSha: "abc123",
       targetSha: "def456",
       deployedSha: null,
+      reason: null,
       startedAt: new Date("2025-01-01"),
       completedAt: new Date("2025-01-01"),
       failureLog: null,

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -69,6 +69,7 @@ function makeRun(status: string, overrides: Record<string, unknown> = {}) {
     currentSha: "abc1234",
     targetSha: "def5678",
     deployedSha: "def5678",
+    reason: null as string | null,
     startedAt: new Date("2026-05-20T02:00:00Z"),
     completedAt: new Date("2026-05-20T02:05:00Z"),
     completionEvidence: null,
@@ -304,6 +305,32 @@ describe("SelfUpgradeClient – skipped", () => {
     );
     // No error property on a skipped run
     expect(html).not.toContain("promoter exited");
+  });
+
+  it("explains WHY a skip happened instead of a silent badge", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("skipped", {
+          reason: "activity-in-flight: build-studio.phase.build, build-studio.phase.build",
+        })}
+      />,
+    );
+    // The persisted reason is surfaced (machine string in a data attribute) ...
+    expect(html).toContain(
+      'data-skip-reason="activity-in-flight: build-studio.phase.build, build-studio.phase.build"',
+    );
+    // ... and rendered as an operator-facing explanation + remedy.
+    expect(html).toContain("Work in progress");
+    expect(html).toContain("Build Studio build phase");
+    expect(html).toContain("Emergency override");
+  });
+
+  it("does not render a skip explanation block for a succeeded run", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("succeeded")} />,
+    );
+    expect(html).not.toContain("data-skip-reason");
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -11,6 +11,7 @@ import {
 import { LocalTime } from "@/components/ui/LocalTime";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
 import { StatusBadge } from "@/components/ui/report-kit";
+import { describeSkipReason } from "@/lib/self-upgrade/skip-reason";
 
 type LatestRun = {
   runId: string;
@@ -19,6 +20,7 @@ type LatestRun = {
   currentSha: string | null;
   targetSha: string | null;
   deployedSha: string | null;
+  reason: string | null;
   startedAt: Date | string | null;
   completedAt: Date | string | null;
   completionEvidence?: unknown;
@@ -816,6 +818,29 @@ export default function SelfUpgradeClient({
               </div>
             </details>
           )}
+
+          {/* A skipped run persists WHY on `reason`. Without surfacing it, the
+              operator sees only a "skipped" badge with no words — the silent
+              no-op an operator should never be left guessing about. */}
+          {latestRun.status === "skipped" &&
+            (() => {
+              const explanation = describeSkipReason(latestRun.reason);
+              if (!explanation) return null;
+              return (
+                <div
+                  className="mt-1 p-2 rounded-lg bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-xs space-y-1"
+                  data-skip-reason={latestRun.reason ?? ""}
+                >
+                  <div className="font-medium text-[var(--dpf-text)]">
+                    {explanation.title} — upgrade did not run
+                  </div>
+                  <div className="text-[var(--dpf-muted)]">{explanation.detail}</div>
+                  {explanation.remedy && (
+                    <div className="text-[var(--dpf-muted)]">{explanation.remedy}</div>
+                  )}
+                </div>
+              );
+            })()}
 
           {latestRecoveryPoint && (
             <div

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -565,6 +565,7 @@ describe("listSelfUpgradeRuns – DTO shape", () => {
     expect(select.currentSha).toBe(true);
     expect(select.targetSha).toBe(true);
     expect(select.deployedSha).toBe(true);
+    expect(select.reason).toBe(true);
     expect(select.completionEvidence).toBe(true);
     expect(select.startedAt).toBe(true);
     expect(select.completedAt).toBe(true);

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -595,6 +595,7 @@ export type SelfUpgradeRunDto = {
   currentSha: string | null;    // schema: currentSha (was: fromVersion)
   targetSha: string | null;     // schema: targetSha (was: toVersion)
   deployedSha: string | null;   // schema: deployedSha (was: absent — adding for completeness)
+  reason: string | null;        // why a run was skipped (audit + operator-facing explanation)
   completionEvidence?: Prisma.JsonValue | null;
   startedAt: Date | null;
   completedAt: Date | null;
@@ -622,6 +623,7 @@ export async function listSelfUpgradeRuns(opts?: {
       currentSha: true,
       targetSha: true,
       deployedSha: true,
+      reason: true,
       completionEvidence: true,
       startedAt: true,
       completedAt: true,

--- a/apps/web/lib/self-upgrade/skip-reason.test.ts
+++ b/apps/web/lib/self-upgrade/skip-reason.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { describeSkipReason } from "./skip-reason";
+
+describe("describeSkipReason", () => {
+  it("returns null for empty / missing reasons", () => {
+    expect(describeSkipReason(null)).toBeNull();
+    expect(describeSkipReason(undefined)).toBeNull();
+    expect(describeSkipReason("")).toBeNull();
+    expect(describeSkipReason("   ")).toBeNull();
+  });
+
+  it("explains activity-in-flight with a humanised, de-duplicated surface and an override remedy", () => {
+    const e = describeSkipReason(
+      "activity-in-flight: build-studio.phase.build, build-studio.phase.build",
+    );
+    expect(e).not.toBeNull();
+    expect(e!.title).toBe("Work in progress");
+    // Two identical build-studio surfaces collapse to one phrase, not "×2".
+    expect(e!.detail).toContain("a Build Studio build phase");
+    expect(e!.detail).not.toContain("build-studio.phase.build,");
+    expect(e!.remedy).toContain("Emergency override");
+  });
+
+  it("joins multiple distinct activity surfaces readably", () => {
+    const e = describeSkipReason(
+      "activity-in-flight: build-studio.phase.build, coworker.reasoning-loop",
+    );
+    expect(e!.detail).toContain("a Build Studio build phase and an AI coworker working");
+  });
+
+  it("explains the cooldown backoff", () => {
+    const e = describeSkipReason("cooldown: 2026-06-15T00:13:22.503Z");
+    expect(e!.title).toBe("Cooling down");
+    expect(e!.remedy).toContain("Emergency override");
+  });
+
+  it("distinguishes outside-window (scheduled-only gate) from a manual path", () => {
+    const e = describeSkipReason("outside-window");
+    expect(e!.title).toBe("Outside the upgrade window");
+    expect(e!.remedy).toContain("Upgrade now");
+  });
+
+  it("explains promoter-unavailable and names the missing image", () => {
+    const e = describeSkipReason("promoter-unavailable: dpf-promoter");
+    expect(e!.title).toBe("Upgrade engine not ready");
+    expect(e!.detail).toContain("dpf-promoter");
+  });
+
+  it("treats up-to-date as a correct no-op with no remedy", () => {
+    const e = describeSkipReason("up-to-date: d9531b7eb836");
+    expect(e!.title).toBe("Already up to date");
+    expect(e!.detail).toContain("d9531b7eb836");
+    expect(e!.remedy).toBeUndefined();
+  });
+
+  it("explains active-run, interval-not-elapsed, no-target, and disabled", () => {
+    expect(describeSkipReason("active-run: SUR-ABC")!.title).toBe("Another run is active");
+    expect(describeSkipReason("interval-not-elapsed")!.title).toBe("Checked recently");
+    expect(describeSkipReason("no-target")!.title).toBe("No upgrade target");
+    expect(describeSkipReason("disabled")!.title).toBe("Self-upgrade disabled");
+  });
+
+  it("falls back to surfacing the raw reason for an unknown key rather than a blank skip", () => {
+    const e = describeSkipReason("some-future-reason: extra detail");
+    expect(e!.title).toBe("Upgrade skipped");
+    expect(e!.detail).toBe("some-future-reason: extra detail");
+  });
+
+  it("handles a bare key with no extra detail", () => {
+    const e = describeSkipReason("up-to-date");
+    expect(e!.title).toBe("Already up to date");
+    expect(e!.detail).not.toContain("(");
+  });
+});

--- a/apps/web/lib/self-upgrade/skip-reason.ts
+++ b/apps/web/lib/self-upgrade/skip-reason.ts
@@ -1,0 +1,154 @@
+/**
+ * Human-readable explanations for a self-upgrade run's `skipped` status.
+ *
+ * `runSelfUpgrade` (apps/web/lib/queue/functions/self-upgrade.ts) records a
+ * machine reason string on the run's `reason` column whenever it short-circuits
+ * to `skipped` — e.g. `activity-in-flight: build-studio.phase.build` or
+ * `cooldown: 2026-06-15T00:13:22.503Z`. That string is persisted for audit but
+ * is not operator-facing on its own: "skipped" with no words is the silent
+ * no-op the Self-Upgrade panel must never show (an operator should never be left
+ * guessing whether a skip was correct or a bug).
+ *
+ * This maps the persisted reason to a title + plain-English detail + an
+ * optional remedy, so the panel can explain WHY the upgrade didn't run and what
+ * the operator can do about it. Keep the keys in sync with the `skipAttempt`
+ * reasons in self-upgrade.ts.
+ */
+
+export type SkipReasonExplanation = {
+  /** Short label, e.g. "Build in progress". */
+  title: string;
+  /** One-sentence plain-English explanation of why the upgrade was skipped. */
+  detail: string;
+  /** Optional next action the operator can take. */
+  remedy?: string;
+};
+
+/**
+ * Friendly label for a quiescence blocker surface key. Mirrors `surfaceLabel`
+ * in SelfUpgradeClient.tsx so the activity-in-flight detail reads the same
+ * whether it comes from a live blocker line or a persisted skip reason.
+ */
+function surfaceLabel(surface: string): string {
+  if (surface === "coworker.reasoning-loop") return "an AI coworker working";
+  if (surface === "request.recent-tool-execution") return "recent portal / MCP activity";
+  if (surface === "build-studio.phase.ship") return "a Build Studio ship phase";
+  if (surface.startsWith("build-studio.phase.")) {
+    return `a Build Studio ${surface.slice("build-studio.phase.".length)} phase`;
+  }
+  return surface;
+}
+
+/** Deduplicate + humanise the comma-separated surfaces in an activity reason. */
+function describeActiveSurfaces(rest: string): string {
+  const surfaces = Array.from(
+    new Set(
+      rest
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    ),
+  ).map(surfaceLabel);
+  if (surfaces.length === 0) return "in-flight work";
+  if (surfaces.length === 1) return surfaces[0];
+  if (surfaces.length === 2) return `${surfaces[0]} and ${surfaces[1]}`;
+  return `${surfaces.slice(0, -1).join(", ")}, and ${surfaces[surfaces.length - 1]}`;
+}
+
+const EMERGENCY_OVERRIDE_REMEDY =
+  'Wait for the work to finish and try again, or tick "Emergency override" to force the upgrade now (this can interrupt in-flight work).';
+
+/**
+ * Turn a persisted self-upgrade skip `reason` into an operator-facing
+ * explanation. The reason is of the form `key` or `key: extra`; we branch on the
+ * key prefix and fold any extra detail into the message.
+ */
+export function describeSkipReason(
+  reason: string | null | undefined,
+): SkipReasonExplanation | null {
+  if (!reason) return null;
+  const trimmed = reason.trim();
+  if (!trimmed) return null;
+
+  const sepIndex = trimmed.indexOf(":");
+  const key = (sepIndex === -1 ? trimmed : trimmed.slice(0, sepIndex)).trim();
+  const rest = sepIndex === -1 ? "" : trimmed.slice(sepIndex + 1).trim();
+
+  switch (key) {
+    case "activity-in-flight":
+      return {
+        title: "Work in progress",
+        detail: `The upgrade didn't run because ${describeActiveSurfaces(
+          rest,
+        )} was in flight. The portal was left running rather than drained mid-task.`,
+        remedy: EMERGENCY_OVERRIDE_REMEDY,
+      };
+    case "cooldown":
+      return {
+        title: "Cooling down",
+        detail:
+          "A recent attempt deferred or failed, so automatic upgrades are paused briefly to avoid re-draining the portal in a loop.",
+        remedy:
+          'Wait for the cooldown to clear, or tick "Emergency override" to run now.',
+      };
+    case "outside-window":
+      return {
+        title: "Outside the upgrade window",
+        detail:
+          "Scheduled upgrades only run while the storefront is closed (the maintenance window). The store is currently open.",
+        remedy:
+          'Use "Upgrade now" to run immediately — a manual upgrade is not window-gated.',
+      };
+    case "interval-not-elapsed":
+      return {
+        title: "Checked recently",
+        detail:
+          "The scheduled poll already checked for a new build within the configured interval, so this tick was skipped.",
+        remedy: 'Use "Upgrade now" to check immediately.',
+      };
+    case "promoter-unavailable":
+      return {
+        title: "Upgrade engine not ready",
+        detail: `The promoter image${
+          rest ? ` (${rest})` : ""
+        } isn't built on this host, so the portal can't be swapped. The portal was left running rather than drained.`,
+        remedy:
+          "Build the promoter image, then retry — the next attempt resumes automatically once it's present.",
+      };
+    case "up-to-date":
+      return {
+        title: "Already up to date",
+        detail: `The running build already contains the target${
+          rest ? ` (${rest})` : ""
+        }, so there was nothing newer to deploy.`,
+      };
+    case "no-target":
+      return {
+        title: "No upgrade target",
+        detail:
+          "No target build could be resolved from the upstream source, so there was nothing to deploy.",
+      };
+    case "active-run":
+      return {
+        title: "Another run is active",
+        detail: `Another self-upgrade run${
+          rest ? ` (${rest})` : ""
+        } is already in flight, so this trigger was skipped to avoid a double swap.`,
+        remedy: "Wait for the active run to finish, then retry.",
+      };
+    case "disabled":
+      return {
+        title: "Self-upgrade disabled",
+        detail:
+          "Self-upgrade is turned off, so the trigger was skipped without checking for a new build.",
+        remedy: "Enable self-upgrade in settings to allow upgrades.",
+      };
+    default:
+      // Unknown reason: still surface the raw string rather than a blank skip,
+      // so the operator is never left guessing.
+      return {
+        title: "Upgrade skipped",
+        detail: trimmed,
+      };
+  }
+}


### PR DESCRIPTION
## Symptom
An operator triggered **Self-Upgrade** from `/ops/self-upgrade` and the run went to **`skipped`** with no explanation — a silent no-op that reads as broken.

## Root cause (evidence-first, not the log's guess)
Queried the live `SelfUpgradeRun` table on the running install:

| run | status | reason |
|---|---|---|
| `SUR-700509F1` (21:14) | **skipped** | `activity-in-flight: build-studio.phase.build, build-studio.phase.build` |
| `SUR-C0C0A8D0` (21:17) | **succeeded** | — (deployed `e96aea88`, target `d9531b7e` = #1988) |

So the precondition that fired was **`activity-in-flight`**, *not* a version gate. A manual "Upgrade now" deliberately early-skips — **without draining the portal** — when a **hard blocker** (a Build Studio build phase, a coworker reasoning loop) is in flight (`apps/web/lib/queue/functions/self-upgrade.ts:185-211`, per BI-F36E7510 / BI-CC82B9A8). The operator's lever is **Emergency override** (force), which bypasses the precheck. A retry 3 min later, once the build finished, succeeded.

**Verdict: the skip is correct behavior.** The bug is that the UX never explained it:
- `skipRun()` persists the explanation on the run's `reason` column…
- …but `SelfUpgradeRunDto` omitted `reason`, the read paths didn't `select` it, the client `LatestRun` type dropped it, and **nothing rendered it**.
- The early-skip also creates no QuiescenceRun / cooldown, so the existing "Upgrade activity" panel stays hidden.

Net: operator sees "Upgrade queued." → bare `skipped` badge → zero words. The silent no-op an operator should never be left guessing about.

## Fix
- **`describeSkipReason()`** (`apps/web/lib/self-upgrade/skip-reason.ts`) — maps every `skipAttempt` reason (`activity-in-flight`, `cooldown`, `outside-window`, `interval-not-elapsed`, `promoter-unavailable`, `up-to-date`, `no-target`, `active-run`, `disabled`) to an operator-facing **title + plain-English detail + remedy**. De-duplicates/humanises the in-flight surfaces; unknown keys surface the raw reason rather than a blank skip.
- Thread `reason` through `SelfUpgradeRunDto` + `listSelfUpgradeRuns` select and the client `LatestRun` type; **render an explanation block** on the Latest Run panel when status is `skipped`.

This is the goal's first branch — when a skip is *correct*, make the UX explain it (current state, what's holding it, what to do) so the governed self-upgrade path carries a clear status the operator can trust. No precondition logic changed; the early-skip remains by design.

## Tests
- `skip-reason.test.ts` — all reason classes + de-dup / multi-surface join / bare-key / unknown-fallback.
- `SelfUpgradeClient.test.tsx` — asserts the explanation + remedy render for a skipped run with `activity-in-flight`, and that a succeeded run renders none.
- `promotions.self-upgrade.test.ts` — DTO-select now asserts `reason`.

## Verification
Substrate: **topic worktree (source-local gates)**.
- `pnpm --filter web typecheck` — clean (also enforced by the pre-commit hook).
- Targeted `vitest` — **127 tests pass** across the 4 affected files.

Runtime-bound UX verification on the live install routes through the governed self-upgrade path itself; the skip-explanation surface is covered by the React render test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)