### PR TITLE
feat(routing,inference): local audio (ASR) input capability (Gemma 4 input_audio via DMR)

### DIFF
--- a/apps/web/lib/inference/ai-inference-toolcalls.test.ts
+++ b/apps/web/lib/inference/ai-inference-toolcalls.test.ts
@@ -172,6 +172,15 @@ describe("formatMessagesForProvider", () => {
       const formatted = formatMessageForOpenAI({ role: "user", content });
       expect(formatted).toEqual({ role: "user", content });
     });
+
+    it("passes an audio (input_audio) user message through as the OpenAI wire format", () => {
+      const content: ChatMessage["content"] = [
+        { type: "text", text: "Transcribe this" },
+        { type: "input_audio", input_audio: { data: "QUJD", format: "wav" } },
+      ];
+      const formatted = formatMessageForOpenAI({ role: "user", content });
+      expect(formatted).toEqual({ role: "user", content });
+    });
   });
 
   describe("Responses API", () => {

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -50,14 +50,32 @@ export type ContentBlock =
    * models (e.g. local Gemma 4 via Docker Model Runner) to receive screenshots.
    */
   | { type: "image_url"; image_url: { url: string; detail?: "auto" | "low" | "high" } }
+  /**
+   * Audio input for multimodal models (ASR / diarization / audio understanding).
+   * OpenAI Chat Completions wire form (`input_audio` with base64 data + format).
+   * Verified on-machine (2026-06-15): local Gemma 4 12B transcribes a wav via
+   * Docker Model Runner through this exact block. Anthropic has no audio-input
+   * block, so this is OpenAI-compatible only — routing sends audio to an
+   * audio-capable endpoint via the `audioInput` floor, never to Anthropic.
+   */
+  | { type: "input_audio"; input_audio: { data: string; format: "wav" | "mp3" } }
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
   | { type: "tool_result"; tool_use_id: string; content: string };
 
-/** True when a message's content array carries only model-facing input blocks
- *  (text / image) that can be passed through to a chat API as-is. The formatters
- *  rely on ContentBlock discriminated-union narrowing for per-block typing. */
+/** True when content carries only text/image blocks — the subset both the OpenAI
+ *  AND Anthropic formatters can pass through (Anthropic has no audio block). */
 function isMultimodalInputContent(content: ContentBlock[]): boolean {
   return content.length > 0 && content.every((b) => b.type === "text" || b.type === "image_url");
+}
+
+/** True when content carries only model-facing input blocks the OpenAI Chat
+ *  Completions API accepts natively (text / image / audio). Superset of the
+ *  Anthropic predicate — used only by the OpenAI formatter passthrough. */
+function isOpenAIInputContent(content: ContentBlock[]): boolean {
+  return (
+    content.length > 0 &&
+    content.every((b) => b.type === "text" || b.type === "image_url" || b.type === "input_audio")
+  );
 }
 
 /** Convert an OpenAI-style image_url (data: URL) to an Anthropic image source block. */
@@ -361,9 +379,9 @@ export function formatMessageForOpenAI(msg: ChatMessage): Record<string, unknown
       })),
     };
   }
-  // Multimodal user input (text + image_url blocks) → pass through as-is; this is
-  // already the OpenAI Chat Completions vision wire format.
-  if (Array.isArray(msg.content) && isMultimodalInputContent(msg.content)) {
+  // Multimodal user input (text + image_url + input_audio blocks) → pass through
+  // as-is; this is already the OpenAI Chat Completions multimodal wire format.
+  if (Array.isArray(msg.content) && isOpenAIInputContent(msg.content)) {
     return { role: msg.role, content: msg.content };
   }
   // Plain messages — pass through with string content

--- a/apps/web/lib/routing/agent-capability-types.test.ts
+++ b/apps/web/lib/routing/agent-capability-types.test.ts
@@ -42,6 +42,19 @@ describe("satisfiesMinimumCapabilities", () => {
     expect(result).toEqual({ satisfied: true });
   });
 
+  it("fails audioInput floor when capabilities.audioInput is falsy", () => {
+    const result = satisfiesMinimumCapabilities(ep({ capabilities: {} as never }), { audioInput: true });
+    expect(result).toEqual({ satisfied: false, missingCapability: "audioInput" });
+  });
+
+  it("passes audioInput floor when capabilities.audioInput is true", () => {
+    const result = satisfiesMinimumCapabilities(
+      ep({ capabilities: { audioInput: true } as never }),
+      { audioInput: true },
+    );
+    expect(result).toEqual({ satisfied: true });
+  });
+
   it("fails on first missing capability in multi-cap floor", () => {
     const result = satisfiesMinimumCapabilities(
       ep({ supportsToolUse: true, capabilities: {} as never }),

--- a/apps/web/lib/routing/agent-capability-types.ts
+++ b/apps/web/lib/routing/agent-capability-types.ts
@@ -11,6 +11,7 @@ import type { EndpointManifest } from "./types";
 export interface AgentMinimumCapabilities {
   toolUse?: boolean;
   imageInput?: boolean;
+  audioInput?: boolean;
   pdfInput?: boolean;
   codeExecution?: boolean;
   computerUse?: boolean;
@@ -47,6 +48,9 @@ export function satisfiesMinimumCapabilities(
   const caps = endpoint.capabilities as unknown as Record<string, unknown> | null | undefined;
   if (floor.imageInput && !caps?.imageInput) {
     return { satisfied: false, missingCapability: "imageInput" };
+  }
+  if (floor.audioInput && !caps?.audioInput) {
+    return { satisfied: false, missingCapability: "audioInput" };
   }
   if (floor.pdfInput && !caps?.pdfInput) {
     return { satisfied: false, missingCapability: "pdfInput" };

--- a/apps/web/lib/routing/model-card-types.ts
+++ b/apps/web/lib/routing/model-card-types.ts
@@ -27,6 +27,7 @@ export interface ModelCardCapabilities {
   webSearch: boolean | null;
   computerUse: boolean | null;
   imageInput: boolean | null;
+  audioInput: boolean | null;
   pdfInput: boolean | null;
   thinking: boolean | null;
   adaptiveThinking: boolean | null;
@@ -117,6 +118,7 @@ export const EMPTY_CAPABILITIES: ModelCardCapabilities = {
   webSearch: null,
   computerUse: null,
   imageInput: null,
+  audioInput: null,
   pdfInput: null,
   thinking: null,
   adaptiveThinking: null,

--- a/packages/db/src/local-model-capabilities.ts
+++ b/packages/db/src/local-model-capabilities.ts
@@ -30,6 +30,13 @@ export interface LocalModelCapabilityPrior {
    * Bootstrap prior only — the activation eval still calibrates.
    */
   supportsVision: boolean;
+  /**
+   * True for multimodal-IN models that accept audio content (Gemma 4, Gemma 3n,
+   * Qwen-Omni, Whisper-family, ...). Drives ModelProfile capabilities.audioInput
+   * so the `audioInput` routing floor can select it. Verified on-machine
+   * (2026-06-15): ai/gemma4:12B transcribes a wav via DMR. Bootstrap prior only.
+   */
+  supportsAudio: boolean;
   capabilityCategory: string;
   supportsToolUse: boolean;
   reasoning: number;
@@ -99,6 +106,34 @@ export function detectLocalModelVision(modelId: string): boolean {
 }
 
 /**
+ * Best-effort detection of audio-input local models (ASR / audio understanding),
+ * orthogonal to the text/tool family. Drives ModelProfile.capabilities.audioInput
+ * so the `audioInput` floor can select an audio-capable model with no pin.
+ * Verified on-machine 2026-06-15: Gemma 4 12B (ai/gemma4:12B) transcribes a wav
+ * via OpenAI-compatible input_audio content on Docker Model Runner. Prior only —
+ * the activation eval still measures and can correct it.
+ */
+export function detectLocalModelAudio(modelId: string): boolean {
+  const id = normalizeLocalModelId(modelId);
+  if (/embed|nomic|bge|e5-|gte-/.test(id)) return false;
+  return /gemma4|gemma-4|gemma3n|gemma-3n|whisper|qwen.*omni|omni|[-/]audio\b|voxtral|ultravox/.test(
+    id,
+  );
+}
+
+/**
+ * Input modalities a local model accepts, derived from its capability prior.
+ * Always includes "text"; adds "image"/"audio" for multimodal-IN models. Used by
+ * the seed to populate ModelProfile.inputModalities/supportedModalities.
+ */
+export function localInputModalities(prior: LocalModelCapabilityPrior): string[] {
+  const mods = ["text"];
+  if (prior.supportsVision) mods.push("image");
+  if (prior.supportsAudio) mods.push("audio");
+  return mods;
+}
+
+/**
  * Derive a capability prior for a local model id. Pure — no DB, no network.
  * The numbers are deliberately coarse: they only need to be *good enough to
  * route* until the deterministic eval measures the real model.
@@ -107,14 +142,15 @@ export function deriveLocalModelCapabilityPrior(modelId: string): LocalModelCapa
   const base = derivePriorBase(modelId);
   return {
     ...base,
-    // Vision is orthogonal to the text/tool family; embedding models are never
-    // vision-routable. Bootstrap prior — the activation eval still calibrates.
+    // Vision/audio are orthogonal to the text/tool family; embedding models are
+    // never multimodal-routable. Bootstrap priors — the activation eval calibrates.
     supportsVision: base.isEmbedding ? false : detectLocalModelVision(modelId),
+    supportsAudio: base.isEmbedding ? false : detectLocalModelAudio(modelId),
   };
 }
 
-/** Family-keyed text/tool capability base (vision added by the wrapper above). */
-function derivePriorBase(modelId: string): Omit<LocalModelCapabilityPrior, "supportsVision"> {
+/** Family-keyed text/tool capability base (vision/audio added by the wrapper above). */
+function derivePriorBase(modelId: string): Omit<LocalModelCapabilityPrior, "supportsVision" | "supportsAudio"> {
   const family = detectLocalModelFamily(modelId);
   switch (family) {
     case "embedding":

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -58,7 +58,7 @@ import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
 import { toModelProfileSeedCreateData } from "./model-profile-seed.js";
-import { deriveLocalModelCapabilityPrior } from "./local-model-capabilities.js";
+import { deriveLocalModelCapabilityPrior, localInputModalities } from "./local-model-capabilities.js";
 import { seedIntegrationCoverage } from "../scripts/seed-integration-coverage.js";
 import * as crypto from "crypto";
 import bcrypt from "bcryptjs";
@@ -1681,17 +1681,18 @@ async function seedLocalModels(): Promise<void> {
           instructionFollowingScore: prior.instructionFollowingScore,
           structuredOutputScore: prior.structuredOutputScore,
           conversational: prior.conversational, contextRetention: prior.contextRetention,
-          // imageInput drives the `imageInput` routing floor so vision tasks can
-          // select a multimodal local model (e.g. Gemma 4) with no provider pin.
+          // imageInput/audioInput drive the routing floors so vision/audio tasks
+          // can select a multimodal local model (e.g. Gemma 4) with no provider pin.
           capabilities: {
             streaming: true,
             embedding: prior.isEmbedding,
             ...(prior.supportsVision ? { imageInput: true } : {}),
+            ...(prior.supportsAudio ? { audioInput: true } : {}),
           } as any,
-          inputModalities: prior.supportsVision ? ["text", "image"] : ["text"],
+          inputModalities: localInputModalities(prior),
           outputModalities: ["text"],
           supportedModalities: {
-            input: prior.supportsVision ? ["text", "image"] : ["text"],
+            input: localInputModalities(prior),
             output: ["text"],
           },
         },

--- a/packages/db/test/local-model-capabilities.test.ts
+++ b/packages/db/test/local-model-capabilities.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveLocalModelCapabilityPrior,
+  detectLocalModelAudio,
   detectLocalModelFamily,
   detectLocalModelVision,
+  localInputModalities,
   normalizeLocalModelId,
 } from "../src/local-model-capabilities";
 
@@ -91,6 +93,38 @@ describe("deriveLocalModelCapabilityPrior", () => {
 
   it("never marks an embedding model vision-capable", () => {
     expect(deriveLocalModelCapabilityPrior("docker.io/ai/nomic-embed-text-v1.5:latest").supportsVision).toBe(false);
+  });
+
+  it("flags audio-capable models (drives audioInput floor) — verified on-machine for Gemma 4", () => {
+    expect(deriveLocalModelCapabilityPrior("ai/gemma4:12B").supportsAudio).toBe(true);
+    expect(deriveLocalModelCapabilityPrior("ai/qwen3-omni:latest").supportsAudio).toBe(true);
+  });
+
+  it("does not flag text-only / embedding models as audio-capable", () => {
+    expect(deriveLocalModelCapabilityPrior("ai/qwen3-coder:latest").supportsAudio).toBe(false);
+    expect(deriveLocalModelCapabilityPrior("ai/gemma3:latest").supportsAudio).toBe(false);
+    expect(deriveLocalModelCapabilityPrior("docker.io/ai/nomic-embed-text-v1.5:latest").supportsAudio).toBe(false);
+  });
+
+  it("derives input modalities from the prior (text + image + audio for Gemma 4)", () => {
+    expect(localInputModalities(deriveLocalModelCapabilityPrior("ai/gemma4:12B"))).toEqual([
+      "text", "image", "audio",
+    ]);
+    expect(localInputModalities(deriveLocalModelCapabilityPrior("ai/qwen3-coder:latest"))).toEqual(["text"]);
+    expect(localInputModalities(deriveLocalModelCapabilityPrior("ai/nomic-embed-text-v1.5:latest"))).toEqual(["text"]);
+  });
+});
+
+describe("detectLocalModelAudio", () => {
+  it("detects audio-input families", () => {
+    for (const id of ["ai/gemma4:12B", "docker.io/ai/gemma3n:latest", "ai/whisper-large:latest", "ai/qwen2.5-omni:7b", "ai/ultravox:latest"]) {
+      expect(detectLocalModelAudio(id)).toBe(true);
+    }
+  });
+  it("returns false for text-only and embedding models", () => {
+    for (const id of ["ai/qwen3-coder:latest", "ai/gemma3:latest", "ai/llama3.3:latest", "docker.io/ai/nomic-embed-text-v1.5:latest"]) {
+      expect(detectLocalModelAudio(id)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Local audio (ASR) input capability — Gemma 4 `input_audio` via DMR

Completes the multimodal-IN story (**text + image + audio**) on the local Docker Model Runner substrate, mirroring the merged vision transport ([#1989](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1989)). **No provider pinning** — routes via a new `audioInput` capability floor. Code-gen path (`qwen3-coder`) untouched. (BI-1E1BF647, EP-ROUTING-11)

### On-machine evidence (live 4090, 2026-06-15)
A SAPI-synthesized WAV was transcribed by `ai/gemma4:12B` through the **real platform transport** (`formatMessageForOpenAI` passthrough) → DMR → **`"The quick brown fox jumps over the lazy dog."`** (~7.5s warm). The DMR GGUF includes the audio encoder; ASR works through the OpenAI-compatible `input_audio` content block on `localhost:12434`.

### Changes (mirror #1989's vision pattern)
- **`ai-inference.ts`** — `ContentBlock` gains an `input_audio` member (`{data, format}`); a new `isOpenAIInputContent` predicate (text|image|audio) drives the OpenAI formatter passthrough (already the OpenAI audio wire format). Anthropic (no audio block) keeps the text+image predicate; routing never sends audio there.
- **`routing/model-card-types.ts`** — `ModelCardCapabilities.audioInput` + `EMPTY_CAPABILITIES`.
- **`routing/agent-capability-types.ts`** — `AgentMinimumCapabilities.audioInput` floor + `satisfiesMinimumCapabilities()` check.
- **`local-model-capabilities.ts`** — `supportsAudio` prior + `detectLocalModelAudio` (gemma4 / gemma3n / whisper / qwen-omni / ultravox / voxtral); `localInputModalities()` helper.
- **`seed.ts`** — `seedLocalModels()` writes `capabilities.audioInput` + audio in `input/supportedModalities` for audio-capable local models.

### Tests / gates
- `packages/db` vitest **19/19** (`detectLocalModelAudio` + `supportsAudio` prior + `localInputModalities`).
- `apps/web` vitest **27/27** (`input_audio` OpenAI passthrough + `audioInput` floor).
- `@dpf/db` + `web` `tsc --noEmit` clean; pre-commit typecheck passed; merged `origin/main` (up to date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
