### PR TITLE
fix(self-upgrade): reconcile build phase runs the build advanced past (phantom "session in flight")

### DIFF
--- a/apps/web/lib/self-upgrade/quiescence.test.ts
+++ b/apps/web/lib/self-upgrade/quiescence.test.ts
@@ -14,6 +14,7 @@ const prismaMock = vi.hoisted(() => ({
   taskRunFindMany: vi.fn(),
   buildPhaseRunFindMany: vi.fn(),
   buildPhaseRunUpdateMany: vi.fn(),
+  executeRaw: vi.fn(),
   toolExecutionFindMany: vi.fn(),
   quiescenceRunFindUnique: vi.fn(),
   quiescenceRunUpdate: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock("@dpf/db", () => ({
       findMany: (...args: unknown[]) => prismaMock.buildPhaseRunFindMany(...args),
       updateMany: (...args: unknown[]) => prismaMock.buildPhaseRunUpdateMany(...args),
     },
+    $executeRaw: (...args: unknown[]) => prismaMock.executeRaw(...args),
     toolExecution: {
       findMany: (...args: unknown[]) => prismaMock.toolExecutionFindMany(...args),
     },
@@ -68,6 +70,7 @@ beforeEach(() => {
   prismaMock.taskRunFindMany.mockResolvedValue([]);
   prismaMock.buildPhaseRunFindMany.mockResolvedValue([]);
   prismaMock.buildPhaseRunUpdateMany.mockResolvedValue({ count: 0 });
+  prismaMock.executeRaw.mockResolvedValue(0);
   prismaMock.toolExecutionFindMany.mockResolvedValue([]);
   prismaMock.quiescenceRunFindUnique.mockResolvedValue(null);
   prismaMock.quiescenceRunUpdate.mockResolvedValue({});
@@ -286,6 +289,7 @@ describe("reconcileTerminalBuildPhaseRuns", () => {
     const now = new Date("2026-05-31T19:30:00.000Z");
     prismaMock.buildPhaseRunUpdateMany.mockResolvedValueOnce({ count: 3 });
 
+    // count = terminal/abandoned updateMany (3) + advanced-past correlated UPDATE (0).
     await expect(reconcileTerminalBuildPhaseRuns(now)).resolves.toBe(3);
 
     expect(prismaMock.buildPhaseRunUpdateMany).toHaveBeenCalledWith({
@@ -300,6 +304,20 @@ describe("reconcileTerminalBuildPhaseRuns", () => {
       },
       data: { completedAt: now },
     });
+  });
+
+  it("also closes runs the build advanced past (phase ≠ build.phase) and sums both", async () => {
+    const now = new Date("2026-06-16T01:30:00.000Z");
+    prismaMock.buildPhaseRunUpdateMany.mockResolvedValueOnce({ count: 1 });
+    // The correlated UPDATE closed 2 advance-orphans (e.g. a "build" run whose
+    // build had moved on to "review") — the live blocker class from 2026-06-16.
+    prismaMock.executeRaw.mockResolvedValueOnce(2);
+
+    await expect(reconcileTerminalBuildPhaseRuns(now)).resolves.toBe(3);
+
+    // The advance-past close runs as a correlated UPDATE, threading `now`.
+    expect(prismaMock.executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.executeRaw.mock.calls[0]).toContain(now);
   });
 });
 

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -686,11 +686,22 @@ export function isBuildPhaseReapable(args: {
 }
 
 /**
- * Repair stale phase-run rows from terminal builds before blocker capture.
- * Abandon/fail paths that predate BI-2CC024DB can leave completedAt null, which
- * otherwise makes quiescence defer forever on work that is no longer active.
+ * Repair stale phase-run rows before blocker capture, so quiescence does not
+ * report a "Build Studio session in flight" for work that is no longer active.
+ * Two classes of orphan, both of which leave completedAt null forever:
+ *
+ *  (1) the parent build is terminal/abandoned (abandon/fail paths predating
+ *      BI-2CC024DB), and
+ *  (2) the parent build has ADVANCED PAST this phase — the run's phase no
+ *      longer matches the build's current phase. Observed on a live install
+ *      (2026-06-16): a "build" phase run sat open for ~6h while its build was
+ *      already in "review" (its build task had completed), blocking a
+ *      self-upgrade with 0 active TaskRuns. The normal phase-advance path is
+ *      expected to close the prior run; this is the always-on safety net for
+ *      any advance that doesn't.
  */
 export async function reconcileTerminalBuildPhaseRuns(now: Date = new Date()): Promise<number> {
+  // (1) Parent build terminal/abandoned — close all its still-open runs.
   const result = await prisma.buildPhaseRun.updateMany({
     where: {
       completedAt: null,
@@ -703,7 +714,20 @@ export async function reconcileTerminalBuildPhaseRuns(now: Date = new Date()): P
     },
     data: { completedAt: now },
   });
-  return result.count;
+
+  // (2) Parent build advanced past this phase. Prisma cannot compare a row
+  // column to a related column in updateMany, so close them with one
+  // correlated UPDATE (the build provably finished any phase it has left).
+  const advanced = await prisma.$executeRaw`
+    UPDATE "BuildPhaseRun" AS bpr
+    SET "completedAt" = ${now}
+    FROM "FeatureBuild" AS fb
+    WHERE bpr."buildId" = fb."buildId"
+      AND bpr."completedAt" IS NULL
+      AND bpr."phase" <> fb."phase"
+  `;
+
+  return result.count + advanced;
 }
 
 /**


### PR DESCRIPTION
## Symptom (operator-reported)

A self-upgrade refused to run, reporting a **"Build Studio session in flight" — when nothing was actually running.**

## Root cause

The quiescence drain's `BuildPhaseRun` "in flight" detection counts any phase run with `completedAt = null` whose parent build is non-terminal. The always-on safety net, `reconcileTerminalBuildPhaseRuns`, only closed phase runs whose **parent build was terminal/abandoned** — it missed the case where a build **advances to a later phase** but the prior phase run's `completedAt` is left null. That orphaned row then blocks the drain forever.

**Live evidence (2026-06-16):** two stale rows were blocking the upgrade with **0 active TaskRuns**:
- `FB-FD850A2C`: a `build` phase run open for ~6h while the build was already in `review` (its build task completed at 19:53) — a clean advance-orphan.
- `FB-69231490`: a `plan` phase run whose deliberation tasks had all `stalled`.

## Fix

Extend the reconciler to also close any open phase run whose **phase no longer matches its build's current phase** (the build provably finished it), via a single correlated `UPDATE` — Prisma can't compare a row column to a related column in `updateMany`. The phase-advance happy path is still expected to close the prior run; this is the always-on safety net for any advance that doesn't.

## Verification

- New `reconcileTerminalBuildPhaseRuns` test for the advance-orphan path; **42 quiescence tests pass**; pre-commit typecheck clean.
- The correlated `UPDATE` was validated against the **live schema** (read-only `SELECT` form, correct table/column names).
- The two live orphans were cleared so the operator's upgrade could proceed immediately; this code change makes that recovery automatic going forward.

## Known follow-up (separate, more deliberate change)

The `FB-69231490`-style case — a build stuck in its **current** phase with all tasks `stalled` (phase matches, so this fix doesn't cover it) — needs build-lifecycle handling (fail/abandon a build whose tasks all died) or enabling the deliberately flag-gated dead-phase reaper (`QUIESCENCE_REAP_DEAD_PHASES`). Flagging rather than bundling, since that path is load-test-gated by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)