### PR TITLE
fix(providers): one routing-eligibility state per provider; kill bogus "Not connected"

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -11,13 +11,26 @@ import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
 import { SyncProvidersButton } from "@/components/platform/SyncProvidersButton";
 import { ServiceSection } from "@/components/platform/ServiceSection";
 import { ServiceRow } from "@/components/platform/ServiceRow";
-import { getAllCliPoolStatuses } from "@/lib/routing/cli-pool-status";
+import { getAllCliPoolStatuses, type CliPoolState } from "@/lib/routing/cli-pool-status";
 import { CliPoolStatusPanel } from "@/components/platform/CliPoolStatusPanel";
+import { cliAdapterTypeForProvider, deriveRoutingEligibility, type RoutingEligibility } from "@/lib/routing/provider-routing-eligibility";
 import { getRecentBudgetEvents, countRecentRejections } from "@/lib/inference/budget-events-data";
 import { AgentBudgetEventsPanel } from "@/components/platform/AgentBudgetEventsPanel";
 import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
+
+/**
+ * Short, human reset hint for an exhausted CLI pool, e.g. "in ~5min".
+ * Fills the routing-eligibility "rate_limited" reason on CLI-backed rows.
+ */
+function poolResetHint(pool: CliPoolState): string | null {
+  const s = pool.secondsUntilReset;
+  if (s == null) return null;
+  if (s <= 0) return "any moment";
+  if (s < 60) return `in ~${s}s`;
+  return `in ~${Math.ceil(s / 60)}min`;
+}
 
 export default async function ProvidersPage() {
   const session = await auth();
@@ -61,6 +74,36 @@ export default async function ProvidersPage() {
   ]);
   const aiProviders = providers.filter((pw) => pw.provider.endpointType !== "service");
 
+  // Derive the single routing-eligibility state per provider from data already
+  // loaded above (status + credential + discovered models + CLI pool). This one
+  // answer drives the row badge and the section counts — replacing the old
+  // status-dot / "needs credentials" / billing "Not connected" muddle, and
+  // folding the separate CLI-pool box's signal into each CLI-backed row.
+  const cliPoolByAdapter = new Map(cliPoolStatuses.map((s) => [s.adapterType, s] as const));
+  const nowMs = now.getTime();
+  const eligibilityById: Record<string, RoutingEligibility> = {};
+  for (const pw of aiProviders) {
+    const p = pw.provider;
+    const adapterType = cliAdapterTypeForProvider(p.providerId);
+    const pool = adapterType ? cliPoolByAdapter.get(adapterType) : undefined;
+    const summary = modelSummaries.get(p.providerId);
+    const credentialExpired =
+      !!pw.credential?.tokenExpiresAt &&
+      new Date(pw.credential.tokenExpiresAt).getTime() < nowMs;
+    eligibilityById[p.providerId] = deriveRoutingEligibility({
+      status: p.status,
+      endpointType: p.endpointType,
+      category: p.category,
+      serviceKind: p.serviceKind ?? null,
+      authMethod: p.authMethod,
+      hasCredential: !!pw.credential,
+      credentialExpired,
+      discoveredModelCount: summary?.totalModels ?? 0,
+      cliPoolExhausted: pool?.isExhausted ?? false,
+      cliPoolResetHint: pool ? poolResetHint(pool) : null,
+    });
+  }
+
   const lastSync = freshJobs.find((j) => j.jobId === "provider-registry-sync")?.lastRunAt;
 
   return (
@@ -75,7 +118,10 @@ export default async function ProvidersPage() {
 
       <DetectedServicesBanner detected={detected} />
 
-      {/* EP-COST Phase 4: CLI Pool Status — surface rate-limit state for claude-cli and codex-cli */}
+      {/* CLI pool rate-limit detail (reset times, error snippets). The live gate
+          itself now also shows inline on each CLI-backed provider's row as the
+          "rate_limited" eligibility state (BI-1C4AAE1E); this panel is the
+          drill-down. Only renders when a pool has a recorded 429. */}
       <CliPoolStatusPanel statuses={cliPoolStatuses} />
 
       {/* EP-COST Phase 2: Agent Budget Events — surface warning_95 and rejected threshold crossings */}
@@ -116,9 +162,15 @@ export default async function ProvidersPage() {
               endpointType={group.endpointType}
               displayName={group.displayName}
               providers={group.providers}
+              eligibilityById={eligibilityById}
             >
               {group.providers.map((pw) => (
-                <ServiceRow key={pw.provider.providerId} pw={pw} {...(modelSummaries.has(pw.provider.providerId) ? { modelSummary: modelSummaries.get(pw.provider.providerId)! } : {})} />
+                <ServiceRow
+                  key={pw.provider.providerId}
+                  pw={pw}
+                  eligibility={eligibilityById[pw.provider.providerId]!}
+                  {...(modelSummaries.has(pw.provider.providerId) ? { modelSummary: modelSummaries.get(pw.provider.providerId)! } : {})}
+                />
               ))}
             </ServiceSection>
           ))

--- a/apps/web/components/platform/ServiceRow.test.tsx
+++ b/apps/web/components/platform/ServiceRow.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ProviderRow, ProviderWithCredential } from "@/lib/ai-provider-types";
+import type { RoutingEligibility } from "@/lib/routing/provider-routing-eligibility";
+
+// ProviderStatusToggle pulls in next/navigation + a server action; stub it so
+// the row renders in a plain node environment. We are testing the eligibility
+// surface, not the admin toggle.
+vi.mock("./ProviderStatusToggle", () => ({
+  ProviderStatusToggle: ({ initialStatus }: { initialStatus: string }) => (
+    <span>toggle:{initialStatus}</span>
+  ),
+}));
+
+import { ServiceRow } from "./ServiceRow";
+
+function provider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  return {
+    id: "p1",
+    providerId: "local",
+    name: "Docker Model Runner (local)",
+    families: [],
+    enabledFamilies: [],
+    status: "active",
+    costModel: "compute",
+    category: "direct",
+    baseUrl: "http://localhost:12434/engines/v1",
+    authMethod: "none",
+    supportedAuthMethods: ["none"],
+    authHeader: null,
+    endpoint: null,
+    inputPricePerMToken: null,
+    outputPricePerMToken: null,
+    computeWatts: null,
+    electricityRateKwh: null,
+    docsUrl: null,
+    consoleUrl: null,
+    billingLabel: null,
+    costPerformanceNotes: null,
+    endpointType: "llm",
+    serviceKind: null,
+    sensitivityClearance: [],
+    capabilityTier: "basic",
+    costBand: "free",
+    taskTags: [],
+    mcpTransport: null,
+    maxConcurrency: null,
+    reasoning: 50,
+    codegen: 50,
+    toolFidelity: 50,
+    instructionFollowing: 50,
+    structuredOutput: 50,
+    conversational: 50,
+    contextRetention: 50,
+    authorizeUrl: null,
+    tokenUrl: null,
+    oauthClientId: null,
+    oauthRedirectUri: null,
+    ...overrides,
+  };
+}
+
+function pw(p: ProviderRow, credential: ProviderWithCredential["credential"] = null): ProviderWithCredential {
+  return { provider: p, credential };
+}
+
+const routable: RoutingEligibility = {
+  state: "routable",
+  eligible: true,
+  label: "Routable",
+  reason: "Reachable and enabled — routing can use it now.",
+};
+
+describe("ServiceRow eligibility surface (BI-1C4AAE1E)", () => {
+  it("an active local provider shows its eligibility and NEVER the bogus billing 'Not connected'", () => {
+    const html = renderToStaticMarkup(
+      <ServiceRow pw={pw(provider())} eligibility={routable} />,
+    );
+    expect(html).toContain("Routable");
+    // The exact regression: an active provider must not also read "Not connected".
+    expect(html).not.toContain("Not connected");
+  });
+
+  it("renders the eligibility label and reason for a credential-gap provider", () => {
+    const eligibility: RoutingEligibility = {
+      state: "needs_credentials",
+      eligible: false,
+      label: "Needs credentials",
+      reason: "Enabled, but no credentials are connected yet.",
+    };
+    const html = renderToStaticMarkup(
+      <ServiceRow
+        pw={pw(provider({ providerId: "openai", name: "OpenAI", authMethod: "api_key", costModel: "token" }))}
+        eligibility={eligibility}
+      />,
+    );
+    expect(html).toContain("Needs credentials");
+    expect(html).toContain("Enabled, but no credentials are connected yet.");
+    expect(html).not.toContain("Not connected");
+  });
+
+  it("surfaces rate_limited for a CLI-backed provider whose pool is exhausted", () => {
+    const eligibility: RoutingEligibility = {
+      state: "rate_limited",
+      eligible: false,
+      label: "Rate-limited",
+      reason: "Temporarily rate-limited at the provider. Recovers in ~5min.",
+    };
+    const html = renderToStaticMarkup(
+      <ServiceRow
+        pw={pw(provider({ providerId: "codex", name: "OpenAI Codex", endpointType: "responses", category: "agent", authMethod: "api_key" }))}
+        eligibility={eligibility}
+      />,
+    );
+    expect(html).toContain("Rate-limited");
+  });
+});

--- a/apps/web/components/platform/ServiceRow.tsx
+++ b/apps/web/components/platform/ServiceRow.tsx
@@ -3,16 +3,13 @@
 import { useState } from "react";
 import Link from "next/link";
 import type { ProviderWithCredential, ProviderModelSummary } from "@/lib/ai-provider-types";
+import type { RoutingEligibility } from "@/lib/routing/provider-routing-eligibility";
 import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
 import { DataSourceBadge } from "@/components/ui/DataSourceBadge";
+import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
+import { intentStyle, resolveIntent } from "@/components/ui/report-kit/statusColors";
 import { ModelClassBadges } from "./ModelClassBadge";
 import { ProviderStatusToggle } from "./ProviderStatusToggle";
-
-const STATUS_COLORS: Record<string, string> = {
-  active:       "var(--dpf-success)",
-  unconfigured: "var(--dpf-warning)",
-  inactive:     "var(--dpf-muted)",
-};
 
 const ROUTING_DIMENSION_LABELS: Record<string, string> = {
   reasoning:            "Reasoning",
@@ -80,17 +77,18 @@ const SENSITIVITY_ABBR: Record<string, string> = {
 type Props = {
   pw: ProviderWithCredential;
   modelSummary?: ProviderModelSummary;
+  /**
+   * The single, mutually-exclusive "can routing use this now?" answer, derived
+   * server-side by deriveRoutingEligibility(). Replaces the old muddle of a
+   * status dot + "needs credentials" badge + a billing "Not connected" label.
+   */
+  eligibility: RoutingEligibility;
 };
 
-export function ServiceRow({ pw, modelSummary }: Props) {
+export function ServiceRow({ pw, modelSummary, eligibility }: Props) {
   const { provider, credential } = pw;
   const [expanded, setExpanded] = useState(false);
   const [hovered, setHovered] = useState(false);
-
-  // Show actual readiness, not just the DB status field.
-  // A provider marked "active" but with no credential is NOT ready.
-  const needsCredential = provider.authMethod !== "none" && !credential;
-  const effectiveStatus = (provider.status === "active" && needsCredential) ? "needs-credentials" : provider.status;
 
   // D25 (2026-05-23): prefer the tier derived from actually-discovered models
   // over the seeded provider.capabilityTier. The seed value is frequently
@@ -98,11 +96,9 @@ export function ServiceRow({ pw, modelSummary }: Props) {
   // shouldn't render as "basic" because the provider seed never updated.
   const displayedTier = modelSummary?.derivedTier ?? provider.capabilityTier ?? null;
 
-  const STATUS_COLORS_EXT: Record<string, string> = {
-    ...STATUS_COLORS,
-    "needs-credentials": "var(--dpf-warning)",
-  };
-  const statusColor = STATUS_COLORS_EXT[effectiveStatus] ?? "var(--dpf-muted)";
+  // The status dot mirrors the eligibility badge intent so a quick scan down the
+  // left edge of the list reads the same yes/no as the badge text.
+  const statusColor = intentStyle(resolveIntent("routingEligibility", eligibility.state)).fg;
   const typeLabel   = provider.endpointType === "service" ? "MCP" : "LLM";
   const costView = buildProviderCostView({ provider, financeProfile: null, internalUsage: null });
 
@@ -130,9 +126,9 @@ export function ServiceRow({ pw, modelSummary }: Props) {
           transition: "background 0.1s",
         }}
       >
-        {/* Status dot */}
+        {/* Status dot — colored by routing eligibility */}
         <span
-          title={effectiveStatus === "needs-credentials" ? "Active but missing credentials — configure to use" : provider.status}
+          title={eligibility.reason}
           style={{
             width: 7,
             height: 7,
@@ -158,6 +154,17 @@ export function ServiceRow({ pw, modelSummary }: Props) {
           {provider.name}
         </span>
 
+        {/* Routing eligibility — the single "can routing use this now?" answer */}
+        <span title={eligibility.reason} style={{ flexShrink: 0, display: "inline-flex" }}>
+          <StatusBadge
+            domain="routingEligibility"
+            status={eligibility.state}
+            label={eligibility.label}
+            variant="soft"
+            uppercase={false}
+          />
+        </span>
+
         {/* Type badge */}
         <span
           style={{
@@ -174,23 +181,6 @@ export function ServiceRow({ pw, modelSummary }: Props) {
         >
           {typeLabel}
         </span>
-
-        {/* Credential warning */}
-        {needsCredential && (
-          <span
-            style={{
-              fontSize: 9,
-              fontWeight: 600,
-              color: "var(--dpf-warning)",
-              background: "color-mix(in srgb, var(--dpf-warning) 10%, transparent)",
-              padding: "1px 5px",
-              borderRadius: 3,
-              flexShrink: 0,
-            }}
-          >
-            needs credentials
-          </span>
-        )}
 
         {/* Model count — LLM only */}
         {provider.endpointType === "llm" && modelSummary && (
@@ -254,9 +244,10 @@ export function ServiceRow({ pw, modelSummary }: Props) {
           </span>
         )}
 
-        <span className="hidden sm:inline" style={{ color: "var(--dpf-muted)", fontSize: 10, flexShrink: 0 }}>
-          {costView.externalProviderBilling.value}
-        </span>
+        {/* External-billing reconciliation status lives in the expanded detail
+            below (clearly labeled), NOT here — it is a finance signal, not a
+            connectivity one, and rendering it beside the toggle made every
+            provider read "Not connected" (BI-1C4AAE1E). */}
 
         {/* Status toggle */}
         <span

--- a/apps/web/components/platform/ServiceSection.tsx
+++ b/apps/web/components/platform/ServiceSection.tsx
@@ -2,26 +2,33 @@
 
 import { useState } from "react";
 import type { ProviderWithCredential } from "@/lib/ai-provider-types";
-
-const STATUS_COLORS = {
-  active:       "var(--dpf-success)",
-  unconfigured: "var(--dpf-warning)",
-  inactive:     "var(--dpf-muted)",
-} as const;
+import type { RoutingEligibility } from "@/lib/routing/provider-routing-eligibility";
+import { intentStyle } from "@/components/ui/report-kit/statusColors";
 
 type Props = {
   endpointType: string;
   displayName: string;
   providers: ProviderWithCredential[];
+  /** Per-provider routing eligibility, keyed by providerId. Drives the counts. */
+  eligibilityById: Record<string, RoutingEligibility>;
   children: React.ReactNode;
 };
 
-export function ServiceSection({ endpointType, displayName, providers, children }: Props) {
-  const activeCount       = providers.filter((pw) => pw.provider.status === "active").length;
-  const unconfiguredCount = providers.filter((pw) => pw.provider.status === "unconfigured").length;
-  const inactiveCount     = providers.filter((pw) => pw.provider.status === "inactive").length;
+export function ServiceSection({ endpointType, displayName, providers, eligibilityById, children }: Props) {
+  // Summarize by routing eligibility (the operator question), not raw lifecycle.
+  const states = providers.map(
+    (pw) => eligibilityById[pw.provider.providerId]?.state ?? "unconfigured",
+  );
+  const routableCount  = states.filter((s) => s === "routable").length;
+  const attentionCount = states.filter(
+    (s) => s === "needs_credentials" || s === "no_models" || s === "rate_limited",
+  ).length;
+  const offCount = states.filter(
+    (s) => s === "disabled" || s === "unconfigured" || s === "not_routable",
+  ).length;
 
-  const [expanded, setExpanded] = useState(activeCount > 0);
+  // Open the section when something is usable or needs attention.
+  const [expanded, setExpanded] = useState(routableCount > 0 || attentionCount > 0);
 
   const typeLabel = endpointType === "service"
     ? "MCP"
@@ -93,21 +100,21 @@ export function ServiceSection({ endpointType, displayName, providers, children 
           {displayName}
         </span>
 
-        {/* Status counts */}
+        {/* Eligibility counts */}
         <span style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 10 }}>
-          {activeCount > 0 && (
-            <span style={{ color: STATUS_COLORS.active }}>
-              {activeCount} active
+          {routableCount > 0 && (
+            <span style={{ color: intentStyle("success").fg }}>
+              {routableCount} routable
             </span>
           )}
-          {unconfiguredCount > 0 && (
-            <span style={{ color: STATUS_COLORS.unconfigured }}>
-              {unconfiguredCount} unconfigured
+          {attentionCount > 0 && (
+            <span style={{ color: intentStyle("warning").fg }}>
+              {attentionCount} need attention
             </span>
           )}
-          {inactiveCount > 0 && (
-            <span style={{ color: STATUS_COLORS.inactive }}>
-              {inactiveCount} inactive
+          {offCount > 0 && (
+            <span style={{ color: intentStyle("neutral").fg }}>
+              {offCount} off
             </span>
           )}
         </span>

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -245,6 +245,20 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     "in-motion": "accent",
     unknown: "neutral",
   },
+  // Provider routing-eligibility (Providers admin surface). Mirrors
+  // RoutingEligibilityState in lib/routing/provider-routing-eligibility.ts —
+  // the single mutually-exclusive answer to "can routing use this now?".
+  // routable=success; the temporary/needs-action states are warning; off/never
+  // and not-a-routing-target are neutral.
+  routingEligibility: {
+    routable: "success",
+    rate_limited: "warning",
+    needs_credentials: "warning",
+    no_models: "warning",
+    disabled: "neutral",
+    unconfigured: "neutral",
+    not_routable: "neutral",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",

--- a/apps/web/lib/routing/provider-routing-eligibility.test.ts
+++ b/apps/web/lib/routing/provider-routing-eligibility.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  cliAdapterTypeForProvider,
+  deriveRoutingEligibility,
+  type RoutingEligibilityInput,
+} from "./provider-routing-eligibility";
+
+/** Base = a healthy local provider (no credentials required). */
+function base(overrides: Partial<RoutingEligibilityInput> = {}): RoutingEligibilityInput {
+  return {
+    status: "active",
+    endpointType: "llm",
+    category: "direct",
+    authMethod: "none",
+    hasCredential: false,
+    discoveredModelCount: 3,
+    ...overrides,
+  };
+}
+
+describe("deriveRoutingEligibility", () => {
+  it("local active provider with models is routable (no credentials needed)", () => {
+    const r = deriveRoutingEligibility(base());
+    expect(r.state).toBe("routable");
+    expect(r.eligible).toBe(true);
+    expect(r.label).toBe("Routable");
+    expect(r.reason).toMatch(/Reachable and enabled/);
+  });
+
+  it("cloud provider with a credential is routable", () => {
+    const r = deriveRoutingEligibility(
+      base({ authMethod: "api_key", hasCredential: true }),
+    );
+    expect(r.state).toBe("routable");
+    expect(r.reason).toMatch(/Connected and enabled/);
+  });
+
+  it("the bogus 'Not connected' case: active local provider is NEVER not-connected", () => {
+    // Regression for BI-1C4AAE1E: Docker Model Runner / Local STT show active +
+    // a billing 'Not connected' label at once. A reachable local provider must
+    // read as routable, not as anything connectivity-negative.
+    const docker = deriveRoutingEligibility(
+      base({ endpointType: "llm", authMethod: "none", hasCredential: false }),
+    );
+    const whisper = deriveRoutingEligibility(
+      base({ endpointType: "transcription", authMethod: "none", discoveredModelCount: 1 }),
+    );
+    expect(docker.eligible).toBe(true);
+    expect(whisper.eligible).toBe(true);
+    expect(whisper.state).toBe("routable");
+  });
+
+  it("transcription endpoints are routable and skip the model-count gate when count omitted", () => {
+    const r = deriveRoutingEligibility({
+      status: "active",
+      endpointType: "transcription",
+      category: "direct",
+      authMethod: "none",
+      hasCredential: false,
+      // discoveredModelCount intentionally omitted
+    });
+    expect(r.state).toBe("routable");
+  });
+
+  it("unconfigured provider reads as 'Not set up'", () => {
+    const r = deriveRoutingEligibility(base({ status: "unconfigured" }));
+    expect(r.state).toBe("unconfigured");
+    expect(r.eligible).toBe(false);
+    expect(r.label).toBe("Not set up");
+  });
+
+  it("inactive/disabled provider reads as disabled", () => {
+    expect(deriveRoutingEligibility(base({ status: "inactive" })).state).toBe("disabled");
+    expect(deriveRoutingEligibility(base({ status: "disabled" })).state).toBe("disabled");
+  });
+
+  it("active provider that requires creds but has none → needs_credentials", () => {
+    const r = deriveRoutingEligibility(
+      base({ authMethod: "api_key", hasCredential: false }),
+    );
+    expect(r.state).toBe("needs_credentials");
+    expect(r.reason).toMatch(/no credentials are connected/);
+  });
+
+  it("expired OAuth credential → needs_credentials with reconnect wording", () => {
+    const r = deriveRoutingEligibility(
+      base({
+        authMethod: "oauth2_authorization_code",
+        hasCredential: true,
+        credentialExpired: true,
+      }),
+    );
+    expect(r.state).toBe("needs_credentials");
+    expect(r.reason).toMatch(/expired/);
+  });
+
+  it("CLI pool exhaustion surfaces rate_limited with the reset hint", () => {
+    const r = deriveRoutingEligibility(
+      base({
+        authMethod: "oauth2_authorization_code",
+        hasCredential: true,
+        cliPoolExhausted: true,
+        cliPoolResetHint: "~5min",
+      }),
+    );
+    expect(r.state).toBe("rate_limited");
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toContain("~5min");
+  });
+
+  it("disabled wins over a missing credential (off is the dominant action)", () => {
+    const r = deriveRoutingEligibility(
+      base({ status: "inactive", authMethod: "api_key", hasCredential: false }),
+    );
+    expect(r.state).toBe("disabled");
+  });
+
+  it("needs_credentials wins over an exhausted pool (connect first, then it can rate-limit)", () => {
+    const r = deriveRoutingEligibility(
+      base({
+        authMethod: "oauth2_authorization_code",
+        hasCredential: false,
+        cliPoolExhausted: true,
+      }),
+    );
+    expect(r.state).toBe("needs_credentials");
+  });
+
+  it("model-routing endpoint with zero discovered models → no_models", () => {
+    const r = deriveRoutingEligibility(base({ discoveredModelCount: 0 }));
+    expect(r.state).toBe("no_models");
+    expect(r.eligible).toBe(false);
+  });
+
+  it("degraded provider is still routable but the reason notes the errors", () => {
+    const r = deriveRoutingEligibility(base({ status: "degraded" }));
+    expect(r.state).toBe("routable");
+    expect(r.eligible).toBe(true);
+    expect(r.reason).toMatch(/recent requests showed some errors/);
+  });
+
+  it("MCP service is not_routable", () => {
+    const r = deriveRoutingEligibility(
+      base({ endpointType: "service", category: "mcp-subscribed", serviceKind: "mcp" }),
+    );
+    expect(r.state).toBe("not_routable");
+    expect(r.eligible).toBe(false);
+  });
+
+  it("every state maps to a distinct label", () => {
+    const labels = new Set(
+      [
+        deriveRoutingEligibility(base()).label,
+        deriveRoutingEligibility(base({ status: "unconfigured" })).label,
+        deriveRoutingEligibility(base({ status: "inactive" })).label,
+        deriveRoutingEligibility(base({ authMethod: "api_key", hasCredential: false })).label,
+        deriveRoutingEligibility(base({ discoveredModelCount: 0 })).label,
+        deriveRoutingEligibility(base({ cliPoolExhausted: true })).label,
+        deriveRoutingEligibility(base({ endpointType: "service" })).label,
+      ],
+    );
+    expect(labels.size).toBe(7);
+  });
+});
+
+describe("cliAdapterTypeForProvider", () => {
+  it("maps the subscription CLI providers to their pools", () => {
+    expect(cliAdapterTypeForProvider("anthropic-sub")).toBe("claude-cli");
+    expect(cliAdapterTypeForProvider("codex")).toBe("codex-cli");
+    expect(cliAdapterTypeForProvider("chatgpt")).toBe("codex-cli");
+  });
+
+  it("returns null for direct-HTTP providers", () => {
+    expect(cliAdapterTypeForProvider("anthropic")).toBeNull();
+    expect(cliAdapterTypeForProvider("openai")).toBeNull();
+    expect(cliAdapterTypeForProvider("local")).toBeNull();
+    expect(cliAdapterTypeForProvider("gemini")).toBeNull();
+  });
+});

--- a/apps/web/lib/routing/provider-routing-eligibility.ts
+++ b/apps/web/lib/routing/provider-routing-eligibility.ts
@@ -1,0 +1,192 @@
+/**
+ * Provider routing-eligibility projection (BI-1C4AAE1E, EP-ROUTING-11).
+ *
+ * Answers the single question the Providers admin surface must answer at a
+ * glance: "can routing use this provider right now — yes/no, and why?"
+ *
+ * One mutually-exclusive state replaces the muddle that used to be scattered
+ * across a provider row (lifecycle status dot + a standalone "needs credentials"
+ * badge + the toggle text + a billing-snapshot "Not connected" label + a
+ * separate CLI-pool box). Pure + deterministic (no DB; the only time input is an
+ * injected `now` via `credentialExpired`) so it is fully unit-testable; a thin
+ * caller in the page wires it to data already loaded for the grid.
+ *
+ * Where this sits among siblings:
+ *   - `provider-eligibility.ts`          → STRUCTURAL: is this endpoint type a
+ *                                          routing target at all
+ *   - `loader.ts` loadEndpointManifests  → the canonical runtime candidate query
+ *                                          (status ∈ {active,degraded} + routable
+ *                                          endpoint type + a usable ModelProfile)
+ *   - `provider-health.ts`               → LIVE reachability from RouteOutcome
+ *                                          telemetry (needs a per-provider query)
+ *   - THIS module                        → operator-facing CONFIG/CREDENTIAL/POOL
+ *                                          gate, computed from data already on the
+ *                                          admin page (no per-row telemetry query).
+ *                                          It never mutates any of them.
+ */
+
+import type { CliAdapterType } from "./cli-pool-status";
+import { usesCliAdapter, usesCodexCli } from "./provider-utils";
+
+/** Low-cardinality, mutually-exclusive routing-eligibility state. */
+export type RoutingEligibilityState =
+  | "routable" // eligible now — routing can select it
+  | "rate_limited" // temporarily blocked at the provider (CLI pool 429); self-recovers
+  | "needs_credentials" // enabled, but credentials are missing or expired
+  | "no_models" // enabled + credentialed, but no model has been discovered yet
+  | "disabled" // an administrator turned it off
+  | "unconfigured" // never set up
+  | "not_routable"; // not a model/voice endpoint (an MCP tool/service) — routing never selects it
+
+export interface RoutingEligibility {
+  state: RoutingEligibilityState;
+  /** True only for `routable` — the yes/no half of the answer. */
+  eligible: boolean;
+  /** Short badge label, e.g. "Routable", "Needs credentials". */
+  label: string;
+  /** One-line, plain-language reason — the "why" half. No model IDs / internals. */
+  reason: string;
+}
+
+export interface RoutingEligibilityInput {
+  /** ModelProvider.status — active | degraded | unconfigured | inactive | disabled. */
+  status: string;
+  endpointType?: string | null;
+  category?: string | null;
+  serviceKind?: string | null;
+  /** ModelProvider.authMethod — "none" means no credential is required (local). */
+  authMethod?: string | null;
+  /** Whether a credential row exists for this provider. */
+  hasCredential: boolean;
+  /** For OAuth providers: the saved token's expiry is in the past. */
+  credentialExpired?: boolean;
+  /**
+   * How many models have been discovered for this provider. Only applied to
+   * model-routing endpoint types; omit/undefined to skip the check (voice /
+   * transcription resolves its model through a separate readiness path). A
+   * value of 0 means nothing is discovered yet → routing has nothing to pick.
+   */
+  discoveredModelCount?: number | null;
+  /** The provider's CLI subscription pool is currently exhausted (saw a 429). */
+  cliPoolExhausted?: boolean;
+  /** Human reset hint for the exhausted pool, e.g. "~5min" or "any moment". */
+  cliPoolResetHint?: string | null;
+}
+
+const LABELS: Record<RoutingEligibilityState, string> = {
+  routable: "Routable",
+  rate_limited: "Rate-limited",
+  needs_credentials: "Needs credentials",
+  no_models: "No models",
+  disabled: "Disabled",
+  unconfigured: "Not set up",
+  not_routable: "Not routable",
+};
+
+/** Endpoint types whose providers are selected by the model (chat/LLM) router. */
+const MODEL_ROUTING_ENDPOINT_TYPES = new Set(["llm", "chat", "responses", "gemini", "ollama"]);
+
+function isNonRoutableSurface(input: RoutingEligibilityInput): boolean {
+  const endpointType = (input.endpointType ?? "llm").toLowerCase();
+  const category = (input.category ?? "").toLowerCase();
+  const serviceKind = (input.serviceKind ?? "").toLowerCase();
+  // MCP tools / services are not model or voice endpoints — routing never
+  // selects them. (The admin page already filters endpointType="service" out,
+  // but keeping the check here makes the projection total and correct.)
+  return endpointType === "service" || serviceKind === "mcp" || category.startsWith("mcp");
+}
+
+/**
+ * Derive a provider's routing eligibility. Precedence is most-actionable-first
+ * so the single state always names the dominant thing to look at:
+ *
+ *   0. not a routing target (MCP service)     → not_routable
+ *   1. never set up                           → unconfigured
+ *   2. not active/degraded (off)              → disabled
+ *   3. requires creds but has none            → needs_credentials
+ *   4. creds present but expired              → needs_credentials
+ *   5. CLI subscription pool exhausted        → rate_limited
+ *   6. model endpoint with nothing discovered → no_models
+ *   7. otherwise                              → routable
+ */
+export function deriveRoutingEligibility(input: RoutingEligibilityInput): RoutingEligibility {
+  const mk = (state: RoutingEligibilityState, reason: string): RoutingEligibility => ({
+    state,
+    eligible: state === "routable",
+    label: LABELS[state],
+    reason,
+  });
+
+  // 0. Not a model/voice endpoint at all.
+  if (isNonRoutableSurface(input)) {
+    return mk("not_routable", "This is a tool/service, not a model endpoint — routing never selects it.");
+  }
+
+  const status = (input.status ?? "").toLowerCase();
+
+  // 1. Never set up.
+  if (status === "unconfigured" || status === "") {
+    return mk("unconfigured", "Not set up yet. Configure it to make it routable.");
+  }
+
+  // 2. Anything that is not active/degraded is off (inactive, disabled, …).
+  if (status !== "active" && status !== "degraded") {
+    return mk("disabled", "Turned off by an administrator. Enable it to allow routing.");
+  }
+
+  const requiresCredential = (input.authMethod ?? "").toLowerCase() !== "none";
+
+  // 3. Requires credentials but none are connected.
+  if (requiresCredential && !input.hasCredential) {
+    return mk("needs_credentials", "Enabled, but no credentials are connected yet.");
+  }
+
+  // 4. Credentials present but expired (OAuth subscriptions).
+  if (requiresCredential && input.credentialExpired) {
+    return mk("needs_credentials", "The saved sign-in has expired — reconnect to restore routing.");
+  }
+
+  // 5. CLI subscription pool exhausted — temporary, recovers on its own.
+  if (input.cliPoolExhausted) {
+    const hint = input.cliPoolResetHint
+      ? ` Recovers ${input.cliPoolResetHint}.`
+      : " It recovers automatically.";
+    return mk("rate_limited", `Temporarily rate-limited at the provider.${hint}`);
+  }
+
+  // 6. Model-routing endpoint with nothing discovered yet → can't pick a model.
+  const endpointType = (input.endpointType ?? "llm").toLowerCase();
+  if (
+    MODEL_ROUTING_ENDPOINT_TYPES.has(endpointType) &&
+    input.discoveredModelCount != null &&
+    input.discoveredModelCount <= 0
+  ) {
+    return mk("no_models", "Enabled, but no models have been discovered yet.");
+  }
+
+  // 7. Eligible.
+  if (status === "degraded") {
+    return mk("routable", "Routing can use it now, though recent requests showed some errors.");
+  }
+  return mk(
+    "routable",
+    requiresCredential
+      ? "Connected and enabled — routing can use it now."
+      : "Reachable and enabled — routing can use it now.",
+  );
+}
+
+/**
+ * Which CLI subscription pool (if any) gates a provider's live availability,
+ * grounded in the canonical adapter predicates in `provider-utils.ts`:
+ *   - anthropic-sub → claude-cli  (Claude OAuth subscription, routes via `claude -p`)
+ *   - codex         → codex-cli   (OpenAI Codex, routes via `codex exec`)
+ *   - chatgpt       → codex-cli   (ChatGPT subscription rides the same OpenAI
+ *                                  codex-engine pool; cliEngine="codex")
+ * Every other provider routes via direct HTTP and has no CLI pool gate (null).
+ */
+export function cliAdapterTypeForProvider(providerId: string): CliAdapterType | null {
+  if (usesCliAdapter(providerId)) return "claude-cli";
+  if (usesCodexCli(providerId) || providerId === "chatgpt") return "codex-cli";
+  return null;
+}


### PR DESCRIPTION
## What & why

On `/platform/ai/providers` an operator could not tell at a glance which providers routing can actually use:

1. **Bogus "Not connected" on every provider — including active ones.** Each collapsed row rendered `buildProviderCostView({…, financeProfile: null}).externalProviderBilling.value`, which on the list is **always** the literal string "Not connected" (no finance profile is loaded there). It is a *billing-reconciliation* label, not a connectivity one — yet it sat beside the "active" toggle. So Docker Model Runner (`local`) and Local STT/whisper (`speaches`), both `authMethod: none`, read **"active" AND "Not connected" at once**.
2. **Muddled, overlapping vocabulary.** A single row mixed a status dot, a "needs credentials" badge, the toggle text ("active"), and the billing "Not connected" — none answered *"can routing use this now?"*.
3. **CLI-pool cloud path shown separately.** ChatGPT/Codex/Claude-subscription providers are real rows, but their live routing gate (CLI pool rate-limit) only appeared in the separate **CLI Pool Status** box.

## Change

- **New pure projection** `lib/routing/provider-routing-eligibility.ts` → one mutually-exclusive state answering *routing-eligible: yes/no + why*:
  `routable · rate_limited · needs_credentials · no_models · disabled · unconfigured · not_routable`, each with a plain-language reason. Grounded in the canonical runtime query (`loadEndpointManifests`): `status ∈ {active,degraded}` + routable endpoint type + a usable model, plus credential presence/expiry.
- **Rendered via report-kit `StatusBadge`** through a new token-backed `routingEligibility` intent domain in `statusColors.ts` (no hex). The left-edge status dot is recolored to the same intent.
- **Removed** the billing "Not connected" from the collapsed row — it stays, clearly labeled "External provider billing", in the expanded detail where it belongs.
- **Unified the CLI-pool path**: pool exhaustion for `anthropic-sub`→claude-cli and `codex`/`chatgpt`→codex-cli now surfaces as `rate_limited` on the provider's own row. The CLI Pool Status panel remains as drill-down detail.
- **Section headers** now summarize by eligibility: `N routable · N need attention · N off`.

## Acceptance

- Each row shows exactly one eligibility badge + reason; no provider shows "active" + "Not connected" at once.
- `local` / `speaches` (reachable, no creds) → **Routable**; cloud provider missing/expired creds → **Needs credentials**; exhausted CLI pool → **Rate-limited** on `chatgpt`/`codex`/`anthropic-sub`.

## Verification (substrate: worktree-local isolated deps)

- `provider-routing-eligibility.test.ts` — 18 cases (precedence, CLI-pool mapping, the exact "active local is never not-connected" regression).
- `ServiceRow.test.tsx` — 3 render cases asserting the badge renders and the collapsed row never emits "Not connected".
- `pnpm --filter web typecheck` — green.
- report-kit + `lib/routing` suites — 1065 tests green.
- Runtime-bound gates (production build, live-install UX drive of `/platform/ai/providers`) are the post-merge / self-upgrade step.

Closes **BI-1C4AAE1E** · Epic **EP-ROUTING-11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
