### PR TITLE
fix(self-upgrade): recovery-point shows skipped derived stores as "re-derived", not "missing"

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -233,8 +233,38 @@ describe("SelfUpgradeClient – succeeded", () => {
       />,
     );
     expect(html).toContain("Recovery point: ok");
-    expect(html).toContain("postgres:BR-PG");
+    expect(html).toContain("postgres: backed up");
     expect(html).toContain("Restore recovery point");
+  });
+
+  it("labels intentionally-skipped derived stores as re-derived, not 'missing'", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("succeeded", {
+          completionEvidence: {
+            recoveryPoint: {
+              schemaVersion: 1,
+              status: "ok",
+              trigger: "pre-upgrade-recovery",
+              // The default postgres-only recovery point: postgres backed up,
+              // the derived stores skipped (they re-derive from source).
+              members: [
+                { target: "postgres", runId: "BR-PG", status: "ok" },
+                { target: "neo4j", runId: null, status: "skipped" },
+                { target: "qdrant", runId: null, status: "skipped" },
+              ],
+            },
+          },
+        })}
+      />,
+    );
+    expect(html).toContain("Recovery point: ok");
+    expect(html).toContain("postgres: backed up");
+    expect(html).toContain("neo4j: skipped (re-derived)");
+    expect(html).toContain("qdrant: skipped (re-derived)");
+    // The deliberate skip must never read as a failure/gap.
+    expect(html).not.toContain("missing");
   });
 
   it("does not show rollback button after recovery point rollback succeeds", () => {

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -189,6 +189,23 @@ function recoveryPointSummary(run: LatestRun | null): RecoveryPointSummary | nul
   };
 }
 
+// Operator-facing label for a recovery-point member. The derived stores
+// (neo4j, qdrant) are INTENTIONALLY not backed up — they re-derive from
+// postgres + source — so a "skipped" member must read as a deliberate choice,
+// not as a "missing" backup (which looks like a failure sitting next to a
+// "Recovery point: ok" header). And a successful backup's internal runId/cuid
+// means nothing to an operator — "backed up" is what they need to see.
+function recoveryMemberLabel(member: { target: string; status: string }): string {
+  switch (member.status) {
+    case "skipped":
+      return `${member.target}: skipped (re-derived)`;
+    case "failed":
+      return `${member.target}: failed`;
+    default:
+      return `${member.target}: backed up`;
+  }
+}
+
 const DEFAULT_STATUS_STYLE =
   "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] border-[var(--dpf-border)]";
 
@@ -855,7 +872,7 @@ export default function SelfUpgradeClient({
               </div>
               <div className="mt-1 text-[var(--dpf-muted)]">
                 {latestRecoveryPoint.members
-                  .map((member) => `${member.target}:${member.runId ?? "missing"}`)
+                  .map((member) => recoveryMemberLabel(member))
                   .join(" · ")}
               </div>
               {latestRecoveryPoint.rollbackStatus && (


### PR DESCRIPTION
## Symptom (operator-spotted, live)

On a running self-upgrade, the recovery-point line read:

> Recovery point: **ok**
> postgres:cmqg0g9cv01ml01pc6dv7f175 · neo4j:**missing** · qdrant:**missing**

"missing" looks like a failure — directly contradicting the **ok** header right above it.

## Cause

The line rendered each member as `` `${target}:${runId ?? "missing"}` ``, ignoring the member's `status`. With the default **postgres-only** recovery point (neo4j/qdrant are intentionally not backed up — they re-derive from postgres + source), those members are `status: "skipped"` with no `runId`, so they fell through to the `"missing"` fallback. The raw postgres backup cuid was also surfaced, which means nothing to an operator.

## Fix

Render **status-aware** labels:
- `skipped` → **"skipped (re-derived)"** — communicates the deliberate choice
- `failed` → **"failed"**
- `ok` → **"backed up"** (drops the opaque internal cuid)

New line: `postgres: backed up · neo4j: skipped (re-derived) · qdrant: skipped (re-derived)` — consistent with the "ok" status.

## Verification

68 SelfUpgradeClient tests pass, including a new case asserting the deliberate skip renders as "skipped (re-derived)" and **never** as "missing". Pre-commit typecheck clean. (Recovery-point *status* logic was already correct — postgres-only → ok; this is display wording only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)