### PR TITLE
feat(routing,build-studio): Model Selection & Runtime Health — per-phase model/provider/engine resolution

### DIFF
--- a/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
@@ -1,0 +1,286 @@
+// apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
+//
+// Model Selection & Runtime Health — the single authoritative view that answers
+// "which model/provider/engine runs each build phase right now — local or cloud?"
+// and "where does live config contradict platform guidance?". It synthesizes the
+// three otherwise-disconnected sources (Providers & Routing, Build Runtime, DMR
+// serving config) so a fresh operator can answer in ONE place rather than
+// grepping code or clicking two admin pages. See BI-768AFB99 / EP-FULL-OBS.
+import { auth } from "@/lib/auth";
+import {
+  resolveModelSelectionByPhase,
+  type ModelSelectionOverview,
+  type PhaseResolution,
+  type FlagSeverity,
+} from "@/lib/inference/phase-model-resolution";
+import { LocalTime } from "@/components/ui/LocalTime";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+const SEVERITY_STYLE: Record<FlagSeverity, { bg: string; fg: string; label: string }> = {
+  error: { bg: "var(--dpf-state-error)", fg: "var(--dpf-error)", label: "Error" },
+  warning: { bg: "var(--dpf-state-warning)", fg: "var(--dpf-warning)", label: "Warning" },
+  info: { bg: "var(--dpf-state-info)", fg: "var(--dpf-info)", label: "Info" },
+};
+
+const VERDICT_COPY: Record<ModelSelectionOverview["verdict"], { tone: string; title: string }> = {
+  "all-local": { tone: "var(--dpf-success)", title: "All phases run locally" },
+  "all-cloud": { tone: "var(--dpf-accent)", title: "All phases route to cloud" },
+  mixed: { tone: "var(--dpf-warning)", title: "Mixed: local + cloud" },
+  unconfigured: { tone: "var(--dpf-error)", title: "Not configured" },
+};
+
+function Chip({ children, bg, fg }: { children: React.ReactNode; bg: string; fg: string }) {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "1px 7px",
+        borderRadius: 999,
+        fontSize: 10,
+        fontWeight: 700,
+        background: bg,
+        color: fg,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function LocalCloudChip({ isLocal }: { isLocal: boolean | null }) {
+  if (isLocal === null)
+    return <Chip bg="var(--dpf-surface-2)" fg="var(--dpf-muted)">Not resolved</Chip>;
+  return isLocal ? (
+    <Chip bg="var(--dpf-state-success)" fg="var(--dpf-success)">● Local</Chip>
+  ) : (
+    <Chip bg="var(--dpf-state-info)" fg="var(--dpf-accent)">☁ Cloud</Chip>
+  );
+}
+
+const GOVERNED_LABEL: Record<PhaseResolution["governedBy"], string> = {
+  "build-runtime": "Build Runtime",
+  "providers-routing": "Providers & Routing",
+  "dmr-serving": "Local endpoint (DMR)",
+};
+
+const td: React.CSSProperties = {
+  padding: "8px 10px",
+  borderBottom: "1px solid var(--dpf-border)",
+  fontSize: 12,
+  color: "var(--dpf-text)",
+  verticalAlign: "top",
+};
+const th: React.CSSProperties = {
+  padding: "6px 10px",
+  textAlign: "left",
+  fontSize: 10,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: 0.4,
+  color: "var(--dpf-muted)",
+  borderBottom: "1px solid var(--dpf-border)",
+};
+
+export default async function RuntimeHealthPage() {
+  await auth(); // (shell)/platform layout gates platform access; render read-only.
+
+  let overview: ModelSelectionOverview | null = null;
+  let loadError: string | null = null;
+  try {
+    overview = await resolveModelSelectionByPhase();
+  } catch (err) {
+    loadError = (err as Error).message;
+  }
+
+  const errorCount = overview?.flags.filter((f) => f.severity === "error").length ?? 0;
+
+  return (
+    <div>
+      <div style={{ marginBottom: 20 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>
+          Model Selection &amp; Runtime Health
+        </h1>
+        <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, maxWidth: 760 }}>
+          One authoritative view of which model, provider, and engine will run each
+          build phase <em>right now</em> — and where live config contradicts platform
+          guidance. Resolved before a build runs, using the same routing logic the
+          build uses.
+        </p>
+      </div>
+
+      {loadError && (
+        <div
+          style={{
+            border: "1px solid var(--dpf-error)",
+            background: "var(--dpf-state-error)",
+            borderRadius: 8,
+            padding: 14,
+            fontSize: 12,
+            color: "var(--dpf-text)",
+          }}
+        >
+          Could not resolve model selection: {loadError}
+        </div>
+      )}
+
+      {overview && (
+        <>
+          {/* Verdict banner */}
+          <div
+            style={{
+              border: `1px solid ${VERDICT_COPY[overview.verdict].tone}`,
+              borderLeft: `4px solid ${VERDICT_COPY[overview.verdict].tone}`,
+              background: "var(--dpf-surface-1)",
+              borderRadius: 8,
+              padding: 14,
+              marginBottom: 18,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+              <span style={{ fontSize: 14, fontWeight: 700, color: VERDICT_COPY[overview.verdict].tone }}>
+                {VERDICT_COPY[overview.verdict].title}
+              </span>
+              <Chip bg="var(--dpf-surface-2)" fg="var(--dpf-muted)">
+                Build engine: {overview.buildEngineLabel}
+              </Chip>
+              {errorCount > 0 && (
+                <Chip bg={SEVERITY_STYLE.error.bg} fg={SEVERITY_STYLE.error.fg}>
+                  {errorCount} error(s)
+                </Chip>
+              )}
+            </div>
+            <p style={{ fontSize: 12, color: "var(--dpf-text)", marginTop: 8, marginBottom: 0 }}>
+              {overview.summary}
+            </p>
+          </div>
+
+          {/* Per-phase table */}
+          <div style={{ overflowX: "auto", marginBottom: 22 }}>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr>
+                  <th style={th}>Phase</th>
+                  <th style={th}>Runs on</th>
+                  <th style={th}>Provider / Model</th>
+                  <th style={th}>Mechanism</th>
+                  <th style={th}>Governed by</th>
+                  <th style={th}>Context</th>
+                  <th style={th}>Flags</th>
+                </tr>
+              </thead>
+              <tbody>
+                {overview.phases.map((p) => {
+                  const errs = p.flags.filter((f) => f.severity === "error").length;
+                  const warns = p.flags.filter((f) => f.severity === "warning").length;
+                  return (
+                    <tr key={p.phase}>
+                      <td style={td}>
+                        <div style={{ fontWeight: 600 }}>{p.label}</div>
+                        <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{p.engine}</div>
+                      </td>
+                      <td style={td}>
+                        <LocalCloudChip isLocal={p.isLocal} />
+                      </td>
+                      <td style={td}>
+                        <div style={{ fontWeight: 600 }}>{p.providerId ?? "—"}</div>
+                        <div style={{ fontSize: 11, color: "var(--dpf-muted)", fontFamily: "var(--dpf-mono, monospace)" }}>
+                          {p.modelId ?? "—"}
+                        </div>
+                      </td>
+                      <td style={td}>{p.mechanism}</td>
+                      <td style={td}>{GOVERNED_LABEL[p.governedBy]}</td>
+                      <td style={td}>
+                        {p.contextTokens !== null ? `${p.contextTokens.toLocaleString()} tok` : "—"}
+                      </td>
+                      <td style={td}>
+                        {errs === 0 && warns === 0 ? (
+                          <Chip bg="var(--dpf-state-success)" fg="var(--dpf-success)">OK</Chip>
+                        ) : (
+                          <span style={{ display: "inline-flex", gap: 4 }}>
+                            {errs > 0 && (
+                              <Chip bg={SEVERITY_STYLE.error.bg} fg={SEVERITY_STYLE.error.fg}>{errs} err</Chip>
+                            )}
+                            {warns > 0 && (
+                              <Chip bg={SEVERITY_STYLE.warning.bg} fg={SEVERITY_STYLE.warning.fg}>{warns} warn</Chip>
+                            )}
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mismatches & remediation */}
+          <h2 style={{ fontSize: 13, fontWeight: 700, color: "var(--dpf-text)", marginBottom: 10 }}>
+            Mismatches &amp; remediation
+          </h2>
+          {overview.flags.length === 0 ? (
+            <p style={{ fontSize: 12, color: "var(--dpf-muted)" }}>
+              No mismatches — live config matches platform guidance for every phase.
+            </p>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 22 }}>
+              {overview.flags.map((f, i) => {
+                const s = SEVERITY_STYLE[f.severity];
+                const phaseLabel = overview!.phases.find((p) => p.phase === f.phase)?.label ?? f.phase;
+                return (
+                  <div
+                    key={`${f.code}-${i}`}
+                    style={{
+                      border: "1px solid var(--dpf-border)",
+                      borderLeft: `3px solid ${s.fg}`,
+                      borderRadius: 6,
+                      padding: "10px 12px",
+                      background: "var(--dpf-surface-1)",
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
+                      <Chip bg={s.bg} fg={s.fg}>{s.label}</Chip>
+                      <span style={{ fontSize: 11, fontWeight: 600, color: "var(--dpf-text)" }}>{phaseLabel}</span>
+                      <code style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{f.code}</code>
+                    </div>
+                    <div style={{ fontSize: 12, color: "var(--dpf-text)" }}>{f.message}</div>
+                    <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 4 }}>
+                      → {f.remediation}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* How this is resolved + cross-links */}
+          <details style={{ marginBottom: 14 }}>
+            <summary style={{ fontSize: 11, color: "var(--dpf-muted)", cursor: "pointer" }}>
+              How this is resolved
+            </summary>
+            <ul style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 8, paddingLeft: 18, lineHeight: 1.6 }}>
+              {overview.notes.map((n, i) => (
+                <li key={i}>{n}</li>
+              ))}
+            </ul>
+          </details>
+
+          <div style={{ fontSize: 11, color: "var(--dpf-muted)", display: "flex", gap: 14, flexWrap: "wrap" }}>
+            <Link href="/platform/ai/providers" style={{ color: "var(--dpf-accent)" }}>
+              Providers &amp; Routing →
+            </Link>
+            <Link href="/platform/ai/build-studio" style={{ color: "var(--dpf-accent)" }}>
+              Build Runtime →
+            </Link>
+            <span>
+              Resolved <LocalTime value={overview.generatedAt} />
+            </span>
+            <span>Agents: <code>resolve_model_selection</code> (MCP)</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/platform/AiTabNav.tsx
+++ b/apps/web/components/platform/AiTabNav.tsx
@@ -14,6 +14,7 @@ const TABS = [
   { label: "Capability Needs", href: "/platform/ai/capability-needs" },
   { label: "Providers & Routing", href: "/platform/ai/providers" },
   { label: BUILD_STUDIO_CONFIG_ROUTE_COPY.navLabel, href: "/platform/ai/build-studio" },
+  { label: "Runtime Health", href: "/platform/ai/runtime-health" },
 ];
 
 export function AiTabNav() {

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -115,7 +115,7 @@ export function BuildStudioConfigForm({
       try {
         setEndpointCheck(await checkLocalEndpoint(opencodeModel));
       } catch (err) {
-        setEndpointCheck({ ok: false, resolvedModel: null, models: [], contextOk: false, reason: (err as Error).message });
+        setEndpointCheck({ ok: false, resolvedModel: null, models: [], contextOk: false, reason: (err as Error).message, reportedContextTokens: null });
       } finally {
         setCheckingEndpoint(false);
       }

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 498,
+  "routeCount": 499,
   "routes": [
     {
       "routePath": "/",
@@ -4498,6 +4498,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/platform/ai/routing/page.tsx"
+    },
+    {
+      "routePath": "/platform/ai/runtime-health",
+      "kind": "page",
+      "segments": [
+        "platform",
+        "ai",
+        "runtime-health"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/platform/ai/runtime-health/page.tsx"
     },
     {
       "routePath": "/platform/ai/skills",

--- a/apps/web/lib/inference/phase-model-resolution.test.ts
+++ b/apps/web/lib/inference/phase-model-resolution.test.ts
@@ -1,0 +1,251 @@
+// apps/web/lib/inference/phase-model-resolution.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+const mockGetConfig = vi.fn();
+const mockPreviewRoute = vi.fn();
+const mockPreflight = vi.fn();
+
+vi.mock("@/lib/integrate/build-studio-config", () => ({
+  getBuildStudioConfig: () => mockGetConfig(),
+}));
+vi.mock("@/lib/inference/routed-inference", () => ({
+  previewRoute: (...args: unknown[]) => mockPreviewRoute(...args),
+}));
+vi.mock("@/lib/inference/ollama-url", () => ({
+  getOllamaBaseUrl: () => "http://model-runner.docker.internal/v1",
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    modelProvider: {
+      findUnique: vi.fn(async () => ({
+        providerId: "local",
+        endpoint: "http://model-runner.docker.internal/v1",
+        baseUrl: null,
+      })),
+    },
+  },
+}));
+vi.mock("@/lib/integrate/opencode-dispatch", () => ({
+  preflightLocalEndpoint: (...args: unknown[]) => mockPreflight(...args),
+  isLikelyNonChatModel: (m: string) =>
+    /embed|nomic|bge[-_]|rerank|whisper/i.test(m),
+  OPENCODE_MIN_CONTEXT_TOKENS: 22_000,
+}));
+
+import { resolveModelSelectionByPhase } from "./phase-model-resolution";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+const OPENCODE_CONFIG = {
+  provider: "opencode" as const,
+  claudeProviderId: "",
+  codexProviderId: "",
+  grokProviderId: "",
+  opencodeProviderId: "local",
+  claudeModel: "sonnet",
+  codexModel: "",
+  grokModel: "",
+  opencodeModel: "qwen3-coder",
+};
+
+function cloudWinner() {
+  return {
+    decision: {
+      selectedEndpoint: "ep-chatgpt",
+      selectedModelId: "gpt-5.1",
+      reason: "Selected ChatGPT (chatgpt) for task type 'analysis'.",
+      fitnessScore: 90,
+      fallbackChain: ["ep-chatgpt"],
+      candidates: [],
+      excludedCount: 0,
+      excludedReasons: [],
+      policyRulesApplied: [],
+      taskType: "analysis",
+      sensitivity: "internal",
+      timestamp: new Date(0),
+    },
+    selectedManifest: {
+      id: "ep-chatgpt",
+      providerId: "chatgpt",
+      modelId: "gpt-5.1",
+      name: "ChatGPT GPT-5.1",
+      providerTier: "user_configured",
+      maxContextTokens: 200_000,
+    },
+    contract: { taskType: "analysis" },
+  };
+}
+
+function localWinner() {
+  return {
+    decision: {
+      selectedEndpoint: "ep-local",
+      selectedModelId: "qwen3-coder",
+      reason: "Selected Local qwen3-coder (local) for task type 'analysis'.",
+      fitnessScore: 80,
+      fallbackChain: ["ep-local"],
+      candidates: [],
+      excludedCount: 0,
+      excludedReasons: [],
+      policyRulesApplied: [],
+      taskType: "analysis",
+      sensitivity: "internal",
+      timestamp: new Date(0),
+    },
+    selectedManifest: {
+      id: "ep-local",
+      providerId: "local",
+      modelId: "qwen3-coder",
+      name: "Local qwen3-coder",
+      providerTier: "bundled",
+      maxContextTokens: 32_000,
+    },
+    contract: { taskType: "analysis" },
+  };
+}
+
+const HEALTHY_PREFLIGHT = {
+  ok: true,
+  resolvedModel: "qwen3-coder",
+  models: ["qwen3-coder"],
+  contextOk: true,
+  reason: null,
+  reportedContextTokens: 32_000,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveModelSelectionByPhase — the local-but-cloud blind spot", () => {
+  it("flags every reasoning phase that routes to cloud when the build engine is Local (OpenCode)", async () => {
+    mockGetConfig.mockResolvedValue(OPENCODE_CONFIG);
+    mockPreviewRoute.mockResolvedValue(cloudWinner()); // ideate, plan, design-review, plan-review
+    mockPreflight.mockResolvedValue(HEALTHY_PREFLIGHT); // build (local)
+
+    const overview = await resolveModelSelectionByPhase();
+
+    expect(overview.verdict).toBe("mixed");
+    expect(overview.summary).toMatch(/GPU sits idle/i);
+
+    const build = overview.phases.find((p) => p.phase === "build")!;
+    expect(build.isLocal).toBe(true);
+    expect(build.mechanism).toBe("local-opencode");
+
+    for (const phase of ["ideate", "plan", "design-review", "plan-review"] as const) {
+      const p = overview.phases.find((x) => x.phase === phase)!;
+      expect(p.isLocal).toBe(false);
+      expect(p.flags.some((f) => f.code === "local-intent-cloud-reasoning")).toBe(true);
+    }
+    // The headline mismatch is an error.
+    expect(overview.flags.some((f) => f.severity === "error" && f.code === "local-intent-cloud-reasoning")).toBe(true);
+  });
+
+  it("flags a served context window below the OpenCode floor", async () => {
+    mockGetConfig.mockResolvedValue(OPENCODE_CONFIG);
+    mockPreviewRoute.mockResolvedValue(cloudWinner());
+    mockPreflight.mockResolvedValue({
+      ok: false,
+      resolvedModel: "qwen3-coder",
+      models: ["qwen3-coder"],
+      contextOk: false,
+      reason: "serves only 4096 context tokens",
+      reportedContextTokens: 4096,
+    });
+
+    const overview = await resolveModelSelectionByPhase();
+    const build = overview.phases.find((p) => p.phase === "build")!;
+    expect(build.contextTokens).toBe(4096);
+    const ctx = build.flags.find((f) => f.code === "context-too-small")!;
+    expect(ctx).toBeTruthy();
+    expect(ctx.message).toMatch(/4096/);
+    expect(ctx.message).toMatch(/22000/);
+  });
+
+  it("warns when the local endpoint lists an embedding model first", async () => {
+    mockGetConfig.mockResolvedValue(OPENCODE_CONFIG);
+    mockPreviewRoute.mockResolvedValue(cloudWinner());
+    mockPreflight.mockResolvedValue({
+      ok: true,
+      resolvedModel: "qwen3-coder",
+      models: ["nomic-embed-text", "qwen3-coder"],
+      contextOk: true,
+      reason: null,
+      reportedContextTokens: 32_000,
+    });
+
+    const overview = await resolveModelSelectionByPhase();
+    const build = overview.phases.find((p) => p.phase === "build")!;
+    expect(build.flags.some((f) => f.code === "embedding-model-first")).toBe(true);
+  });
+
+  it("reports all-local and raises no error flags when every phase resolves local", async () => {
+    mockGetConfig.mockResolvedValue(OPENCODE_CONFIG);
+    mockPreviewRoute.mockResolvedValue(localWinner()); // routed reasoning phases land local
+    mockPreflight.mockResolvedValue(HEALTHY_PREFLIGHT);
+
+    const overview = await resolveModelSelectionByPhase();
+    expect(overview.verdict).toBe("all-local");
+    expect(overview.flags.some((f) => f.severity === "error")).toBe(false);
+    expect(overview.flags.some((f) => f.code === "local-intent-cloud-reasoning")).toBe(false);
+  });
+});
+
+describe("resolveModelSelectionByPhase — non-local engines", () => {
+  it("reports all-cloud for a Claude engine and notes the build phase still routes", async () => {
+    mockGetConfig.mockResolvedValue({
+      ...OPENCODE_CONFIG,
+      provider: "claude" as const,
+      claudeProviderId: "anthropic",
+      opencodeProviderId: "",
+      opencodeModel: "",
+    });
+    mockPreviewRoute.mockResolvedValue(cloudWinner()); // plan, reviews, build
+
+    const overview = await resolveModelSelectionByPhase();
+
+    expect(overview.verdict).toBe("all-cloud");
+
+    const ideate = overview.phases.find((p) => p.phase === "ideate")!;
+    expect(ideate.mechanism).toBe("vendor-cli");
+    expect(ideate.isLocal).toBe(false);
+    expect(ideate.providerId).toBe("anthropic");
+
+    const build = overview.phases.find((p) => p.phase === "build")!;
+    expect(build.mechanism).toBe("routed");
+    expect(build.flags.some((f) => f.code === "build-engine-not-applied")).toBe(true);
+
+    // Not opencode → no local-intent mismatch flag anywhere.
+    expect(overview.flags.some((f) => f.code === "local-intent-cloud-reasoning")).toBe(false);
+  });
+
+  it("marks ideate unsupported under the Agentic Loop engine", async () => {
+    mockGetConfig.mockResolvedValue({
+      ...OPENCODE_CONFIG,
+      provider: "agentic" as const,
+      opencodeProviderId: "",
+      opencodeModel: "",
+    });
+    mockPreviewRoute.mockResolvedValue(cloudWinner());
+
+    const overview = await resolveModelSelectionByPhase();
+    const ideate = overview.phases.find((p) => p.phase === "ideate")!;
+    expect(ideate.mechanism).toBe("unsupported");
+    expect(ideate.flags.some((f) => f.code === "ideate-agentic-unsupported")).toBe(true);
+  });
+
+  it("surfaces a configuration gap when no providers are eligible", async () => {
+    mockGetConfig.mockResolvedValue({
+      ...OPENCODE_CONFIG,
+      provider: "agentic" as const,
+      opencodeProviderId: "",
+      opencodeModel: "",
+    });
+    mockPreviewRoute.mockRejectedValue(new Error("No active endpoint manifests found."));
+
+    const overview = await resolveModelSelectionByPhase();
+    // ideate is unsupported (null) and every routed phase errored (null) → unconfigured.
+    expect(overview.verdict).toBe("unconfigured");
+    expect(overview.flags.some((f) => f.code === "no-providers")).toBe(true);
+  });
+});

--- a/apps/web/lib/inference/phase-model-resolution.ts
+++ b/apps/web/lib/inference/phase-model-resolution.ts
@@ -1,0 +1,545 @@
+// apps/web/lib/inference/phase-model-resolution.ts
+//
+// Model Selection & Runtime Health — the single resolver that answers, per
+// Build Studio phase, "which model/provider/engine WILL run right now, and does
+// live config contradict platform guidance?" — BEFORE a build runs.
+//
+// WHY THIS EXISTS (the blind spot it closes): model selection is split across
+// THREE config sources that nothing synthesizes, so a "local-model" campaign
+// silently ran on cloud until the GPU sat idle:
+//   1. Providers & Routing (/platform/ai/providers) governs routeAndCall →
+//      routeEndpointV2. Its Stage-5b tier-sort (pipeline-v2.ts) puts
+//      user_configured (cloud) endpoints AHEAD of bundled (local) ones, so on a
+//      mixed install local never wins a routed phase.
+//   2. Build Runtime (/platform/ai/build-studio) governs the build-phase
+//      dispatch engine via getBuildStudioConfig() (PlatformConfig row
+//      "build-studio-dispatch").
+//   3. DMR serving config (served context window) — read only inside
+//      preflightLocalEndpoint(), invisible to both admin pages.
+//
+// As-built per-phase truth this resolver encodes (verified against the code):
+//   - ideate: engine = config.provider. opencode → routeAndCall(quality_first)
+//     (so it ROUTES, despite the "local" engine); claude/codex/grok → vendor CLI.
+//   - plan: always routeAndCall(quality_first).
+//   - design-review / plan-review: always routeAndCall(analysis).
+//   - build: opencode → dispatchOpencodeTask (truly local); everything else →
+//     runAgenticLoop → routeAndCall(analysis, requireTools).
+// Net: selecting "Local model (OpenCode)" makes ONLY the build phase local;
+// ideate + plan + both reviews route to cloud on a mixed install.
+//
+// The resolver reuses the REAL routing logic via previewRoute() (a side-effect-
+// free dry-run of routeEndpointV2) so its prediction matches what actually runs.
+
+import { prisma } from "@dpf/db";
+import { previewRoute, type RouteAndCallOptions } from "@/lib/inference/routed-inference";
+import {
+  getBuildStudioConfig,
+  type BuildStudioDispatchConfig,
+} from "@/lib/integrate/build-studio-config";
+import {
+  preflightLocalEndpoint,
+  isLikelyNonChatModel,
+  OPENCODE_MIN_CONTEXT_TOKENS,
+} from "@/lib/integrate/opencode-dispatch";
+import { getOllamaBaseUrl } from "@/lib/inference/ollama-url";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export type BuildPhaseId =
+  | "ideate"
+  | "plan"
+  | "design-review"
+  | "plan-review"
+  | "build";
+
+export type DispatchMechanism =
+  /** routeAndCall → V2 routing. Provider/model chosen by Providers & Routing. */
+  | "routed"
+  /** A vendor CLI (claude/codex/grok) dispatched in the sandbox. */
+  | "vendor-cli"
+  /** The opencode CLI run against the install's local OpenAI-compatible endpoint. */
+  | "local-opencode"
+  /** This engine has no dispatch path for this phase. */
+  | "unsupported";
+
+/** Which admin surface (or none) actually decides this phase's model. */
+export type ConfigSource = "build-runtime" | "providers-routing" | "dmr-serving";
+
+export type FlagSeverity = "error" | "warning" | "info";
+
+export interface PhaseFlag {
+  severity: FlagSeverity;
+  /** Stable machine code, e.g. "local-intent-cloud-reasoning". */
+  code: string;
+  message: string;
+  remediation: string;
+}
+
+export interface PhaseResolution {
+  phase: BuildPhaseId;
+  label: string;
+  /** Plain-language statement of which admin surface governs this phase. */
+  governedBy: ConfigSource;
+  mechanism: DispatchMechanism;
+  /** The Build Runtime dispatch engine label, for context (e.g. "Local model (OpenCode)"). */
+  engine: string;
+  providerId: string | null;
+  modelId: string | null;
+  /** true = local/bundled (on-box), false = cloud, null = unknown / none eligible. */
+  isLocal: boolean | null;
+  /** Routed winner's provider tier ("bundled" | "user_configured"), when routed. */
+  providerTier: string | null;
+  /** Served / max context window in tokens, when known. */
+  contextTokens: number | null;
+  /** One-line rationale (route reason or config explanation). */
+  rationale: string;
+  flags: PhaseFlag[];
+}
+
+export type RuntimeVerdict =
+  | "all-local"
+  | "all-cloud"
+  | "mixed"
+  | "unconfigured";
+
+export interface ModelSelectionOverview {
+  verdict: RuntimeVerdict;
+  /** One-line human summary. */
+  summary: string;
+  /** The Build Runtime dispatch engine (config.provider). */
+  buildEngine: BuildStudioDispatchConfig["provider"];
+  /** Display label for the build engine. */
+  buildEngineLabel: string;
+  phases: PhaseResolution[];
+  /** All phase flags, tagged with their phase, sorted error→warning→info. */
+  flags: Array<PhaseFlag & { phase: BuildPhaseId }>;
+  /** How each phase was resolved — surfaced so the answer is auditable. */
+  notes: string[];
+  generatedAt: string;
+}
+
+// ─── Phase routing contracts (must mirror the real call sites exactly) ─────────
+//
+// These are the EXACT routeAndCall options each routed phase passes in code, so
+// previewRoute predicts the same winner. Keep in sync with:
+//   plan            → plan-on-approval.ts   routeAndCall(..., "internal", { budgetClass: "quality_first" })
+//   design/plan-rev → build.ts              routeAndCall(..., "internal", { taskType: "analysis" })
+//   ideate(opencode)→ ideate-dispatch.ts    routeAndCall(..., "internal", { budgetClass: "quality_first" })
+//   build(agentic)  → build-pipeline.ts     runAgenticLoop({ taskType: "analysis", requireTools: true, tools })
+
+const REASONING_SAMPLE =
+  "Produce a structured implementation plan for a small feature change.";
+/** A non-empty tools array makes inferContract set requiresTools=true (build agentic loop). */
+const BUILD_SENTINEL_TOOLS: Array<Record<string, unknown>> = [
+  { name: "edit_sandbox_file" },
+  { name: "run_sandbox_tests" },
+];
+
+export function buildEngineLabel(provider: BuildStudioDispatchConfig["provider"]): string {
+  switch (provider) {
+    case "claude":
+      return "Claude Code CLI";
+    case "codex":
+      return "Codex CLI";
+    case "grok":
+      return "Grok CLI";
+    case "opencode":
+      return "Local model (OpenCode)";
+    case "agentic":
+      return "Agentic Loop";
+    default:
+      return provider;
+  }
+}
+
+// ─── Routed-phase resolution (the shared dry-run) ──────────────────────────────
+
+async function resolveRoutedPhase(args: {
+  phase: BuildPhaseId;
+  label: string;
+  engine: string;
+  governedBy: ConfigSource;
+  sample: string;
+  opts: RouteAndCallOptions;
+}): Promise<PhaseResolution> {
+  const base = {
+    phase: args.phase,
+    label: args.label,
+    governedBy: args.governedBy,
+    mechanism: "routed" as const,
+    engine: args.engine,
+  };
+  try {
+    const { decision, selectedManifest } = await previewRoute(
+      [{ role: "user", content: args.sample }],
+      "internal",
+      args.opts,
+    );
+    if (!decision.selectedEndpoint || !selectedManifest) {
+      return {
+        ...base,
+        providerId: null,
+        modelId: decision.selectedModelId,
+        isLocal: null,
+        providerTier: null,
+        contextTokens: null,
+        rationale: decision.reason,
+        flags: [
+          {
+            severity: "error",
+            code: "no-eligible-endpoint",
+            message: `No eligible AI endpoint for the ${args.label} phase under its routing contract.`,
+            remediation:
+              "Activate a provider that satisfies this phase's requirements (tools, context, sensitivity) in Providers & Routing.",
+          },
+        ],
+      };
+    }
+    return {
+      ...base,
+      providerId: selectedManifest.providerId,
+      modelId: selectedManifest.modelId,
+      isLocal: selectedManifest.providerTier === "bundled",
+      providerTier: selectedManifest.providerTier,
+      contextTokens: selectedManifest.maxContextTokens,
+      rationale: decision.reason,
+      flags: [],
+    };
+  } catch (err) {
+    // prepareRoute throws NoEligibleEndpointsError when zero providers exist.
+    return {
+      ...base,
+      providerId: null,
+      modelId: null,
+      isLocal: null,
+      providerTier: null,
+      contextTokens: null,
+      rationale: (err as Error).message,
+      flags: [
+        {
+          severity: "error",
+          code: "no-providers",
+          message: `No AI providers are configured — the ${args.label} phase cannot run.`,
+          remediation:
+            "Connect a provider in Providers & Routing, or configure a local model endpoint.",
+        },
+      ],
+    };
+  }
+}
+
+// ─── Engine-governed phase resolution (ideate, build) ──────────────────────────
+
+async function resolveIdeatePhase(
+  config: BuildStudioDispatchConfig,
+): Promise<PhaseResolution> {
+  const engine = buildEngineLabel(config.provider);
+
+  if (config.provider === "opencode") {
+    // Subtle: ideate-opencode does NOT use the local runner — it calls
+    // routeAndCall (conversation/quality_first), so it routes like any other
+    // reasoning phase and lands on cloud on a mixed install.
+    const res = await resolveRoutedPhase({
+      phase: "ideate",
+      label: "Ideate",
+      engine,
+      governedBy: "providers-routing",
+      sample: "Research and draft a design document for a small feature.",
+      opts: { budgetClass: "quality_first" },
+    });
+    res.flags.push({
+      severity: "info",
+      code: "ideate-opencode-routes",
+      message:
+        "Ideate runs through portal routing even though the build engine is Local (OpenCode); it does not invoke the local runner directly.",
+      remediation:
+        "Expect ideate to follow Providers & Routing, not the local model — the local engine only changes the build phase.",
+    });
+    return res;
+  }
+
+  if (config.provider === "claude" || config.provider === "codex" || config.provider === "grok") {
+    const providerId =
+      config.provider === "claude"
+        ? config.claudeProviderId
+        : config.provider === "codex"
+          ? config.codexProviderId
+          : config.grokProviderId;
+    const model =
+      config.provider === "claude"
+        ? config.claudeModel
+        : config.provider === "grok"
+          ? config.grokModel
+          : config.codexModel;
+    const flags: PhaseFlag[] = [];
+    if (!providerId) {
+      flags.push({
+        severity: "error",
+        code: "ideate-no-credential",
+        message: `Ideate engine is ${engine} but no ${config.provider} provider credential is configured.`,
+        remediation: `Connect a ${config.provider} provider in Providers & Routing, or change the Build Runtime engine.`,
+      });
+    }
+    return {
+      phase: "ideate",
+      label: "Ideate",
+      governedBy: "build-runtime",
+      mechanism: "vendor-cli",
+      engine,
+      providerId: providerId || null,
+      modelId: model || "(provider default)",
+      isLocal: false,
+      providerTier: "user_configured",
+      contextTokens: null,
+      rationale: `Build Runtime engine ${engine}: ideate dispatches the ${config.provider} CLI in the sandbox.`,
+      flags,
+    };
+  }
+
+  // agentic — ideate has no agentic dispatch path (falls through to an auth error).
+  return {
+    phase: "ideate",
+    label: "Ideate",
+    governedBy: "build-runtime",
+    mechanism: "unsupported",
+    engine,
+    providerId: null,
+    modelId: null,
+    isLocal: null,
+    providerTier: null,
+    contextTokens: null,
+    rationale:
+      "The Agentic Loop engine has no ideate dispatch path; ideate requires a CLI or the local engine.",
+    flags: [
+      {
+        severity: "warning",
+        code: "ideate-agentic-unsupported",
+        message:
+          "Ideate cannot run under the Agentic Loop engine (it falls through to an auth error).",
+        remediation:
+          "Select Claude / Codex / Grok or Local (OpenCode) as the Build Runtime engine to run ideate.",
+      },
+    ],
+  };
+}
+
+async function resolveBuildPhase(
+  config: BuildStudioDispatchConfig,
+): Promise<PhaseResolution> {
+  const engine = buildEngineLabel(config.provider);
+
+  if (config.provider === "opencode") {
+    const flags: PhaseFlag[] = [];
+    const providerId = config.opencodeProviderId || null;
+    let modelId: string | null = config.opencodeModel || null;
+    let contextTokens: number | null = null;
+    try {
+      const provider = providerId
+        ? await prisma.modelProvider.findUnique({
+            where: { providerId },
+            select: { providerId: true, endpoint: true, baseUrl: true },
+          })
+        : null;
+      const baseUrl = getOllamaBaseUrl(
+        provider
+          ? { providerId: provider.providerId, endpoint: provider.endpoint, baseUrl: provider.baseUrl }
+          : null,
+      );
+      const pre = await preflightLocalEndpoint(baseUrl, config.opencodeModel || "");
+      modelId = pre.resolvedModel ?? modelId ?? "(auto-detect at dispatch)";
+      contextTokens = pre.reportedContextTokens;
+      if (!pre.ok && pre.contextOk) {
+        // ok=false for a reason OTHER than context (unreachable / no models / unknown model)
+        flags.push({
+          severity: "error",
+          code: "local-endpoint-unhealthy",
+          message: pre.reason ?? "Local model endpoint preflight failed.",
+          remediation:
+            "Check the local AI provider is running and serving a coding model, then retry.",
+        });
+      }
+      if (!pre.contextOk && pre.reportedContextTokens !== null) {
+        flags.push({
+          severity: "error",
+          code: "context-too-small",
+          message: `The local model serves only ${pre.reportedContextTokens} context tokens — below the OpenCode floor of ${OPENCODE_MIN_CONTEXT_TOKENS}. Builds will truncate or fail.`,
+          remediation:
+            "Serve a longer-context coding model (e.g. qwen3-coder at ≥ 22k context) via the local provider / DMR.",
+        });
+      }
+      if (pre.models.length > 0 && isLikelyNonChatModel(pre.models[0]!)) {
+        flags.push({
+          severity: "warning",
+          code: "embedding-model-first",
+          message: `The local endpoint lists a non-chat model ("${pre.models[0]}") first. If no model is pinned, an embedding model can be selected for code generation.`,
+          remediation:
+            "Pin the OpenCode model in Build Runtime, or reorder the served models so a coder model is first.",
+        });
+      }
+    } catch (err) {
+      flags.push({
+        severity: "warning",
+        code: "local-preflight-error",
+        message: `Could not preflight the local endpoint: ${(err as Error).message}`,
+        remediation: "Verify the local provider endpoint URL is reachable from the portal.",
+      });
+    }
+    return {
+      phase: "build",
+      label: "Build (code generation)",
+      governedBy: "dmr-serving",
+      mechanism: "local-opencode",
+      engine,
+      providerId,
+      modelId,
+      isLocal: true,
+      providerTier: "bundled",
+      contextTokens,
+      rationale:
+        "Build Runtime engine Local (OpenCode): the build dispatches the opencode CLI against the install's local model endpoint.",
+      flags,
+    };
+  }
+
+  // claude / codex / grok / agentic → runAgenticLoop → routeAndCall(analysis, requireTools).
+  const res = await resolveRoutedPhase({
+    phase: "build",
+    label: "Build (code generation)",
+    engine,
+    governedBy: "providers-routing",
+    sample: REASONING_SAMPLE,
+    opts: { taskType: "analysis", requireTools: true, tools: BUILD_SENTINEL_TOOLS },
+  });
+  if (config.provider !== "agentic") {
+    res.flags.push({
+      severity: "info",
+      code: "build-engine-not-applied",
+      message: `Build Runtime engine is ${engine}, but the build phase runs through the agentic loop and routes via Providers & Routing — the selected CLI governs only the ideate phase, not the build.`,
+      remediation:
+        "To build with a local model, set the Build Runtime engine to Local (OpenCode).",
+    });
+  }
+  return res;
+}
+
+// ─── Top-level resolver ────────────────────────────────────────────────────────
+
+const REASONING_PHASES: ReadonlySet<BuildPhaseId> = new Set([
+  "ideate",
+  "plan",
+  "design-review",
+  "plan-review",
+]);
+
+const SEVERITY_ORDER: Record<FlagSeverity, number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+/**
+ * Resolve, per build phase, the provider+engine+model that WILL run given the
+ * current Build Runtime + Providers & Routing + DMR configuration, and flag
+ * where live config contradicts platform guidance.
+ *
+ * Read-only and side-effect-free: previewRoute does not dispatch, persist a
+ * route decision, roll the challenger arm, or call any model.
+ */
+export async function resolveModelSelectionByPhase(): Promise<ModelSelectionOverview> {
+  const config = await getBuildStudioConfig();
+  const buildEngine = config.provider;
+
+  const phases: PhaseResolution[] = [
+    await resolveIdeatePhase(config),
+    await resolveRoutedPhase({
+      phase: "plan",
+      label: "Plan",
+      engine: "Portal routing",
+      governedBy: "providers-routing",
+      sample: REASONING_SAMPLE,
+      opts: { budgetClass: "quality_first" },
+    }),
+    await resolveRoutedPhase({
+      phase: "design-review",
+      label: "Design review",
+      engine: "Portal routing",
+      governedBy: "providers-routing",
+      sample: "Review a design document and return a structured verdict.",
+      opts: { taskType: "analysis" },
+    }),
+    await resolveRoutedPhase({
+      phase: "plan-review",
+      label: "Plan review",
+      engine: "Portal routing",
+      governedBy: "providers-routing",
+      sample: "Review an implementation plan and return a structured verdict.",
+      opts: { taskType: "analysis" },
+    }),
+    await resolveBuildPhase(config),
+  ];
+
+  // Cross-phase mismatch: the headline blind spot. When the operator selected
+  // the local build engine but a reasoning phase routes to cloud, the GPU sits
+  // idle for that phase — exactly the failure this view exists to surface.
+  if (buildEngine === "opencode") {
+    for (const p of phases) {
+      if (REASONING_PHASES.has(p.phase) && p.isLocal === false) {
+        p.flags.push({
+          severity: "error",
+          code: "local-intent-cloud-reasoning",
+          message: `Build Runtime is set to Local (OpenCode), but the ${p.label} phase routes to a cloud provider (${p.providerId ?? "unknown"}). Your local GPU sits idle for this phase.`,
+          remediation:
+            "Make the local model win routing for this phase in Providers & Routing — note a user-configured cloud provider always outranks the bundled local model — or accept that only the build phase runs locally.",
+        });
+      }
+    }
+  }
+
+  const decided = phases.filter((p) => p.isLocal !== null);
+  const localCount = decided.filter((p) => p.isLocal === true).length;
+  const cloudCount = decided.filter((p) => p.isLocal === false).length;
+
+  let verdict: RuntimeVerdict;
+  if (decided.length === 0) verdict = "unconfigured";
+  else if (cloudCount === 0) verdict = "all-local";
+  else if (localCount === 0) verdict = "all-cloud";
+  else verdict = "mixed";
+
+  let summary: string;
+  if (verdict === "unconfigured") {
+    summary =
+      "No AI providers resolved for any build phase — configure a provider to run builds.";
+  } else if (verdict === "all-local") {
+    summary = `All ${decided.length} resolved build phase(s) run on the local model.`;
+  } else if (verdict === "all-cloud") {
+    summary = `All ${decided.length} resolved build phase(s) route to cloud providers.`;
+  } else {
+    summary = `Mixed: ${localCount} phase(s) local, ${cloudCount} route to cloud.`;
+    if (buildEngine === "opencode" && cloudCount > 0) {
+      summary +=
+        " Build runs local, but ideate / plan / reviews route to cloud — the GPU sits idle for reasoning.";
+    }
+  }
+
+  const flags = phases
+    .flatMap((p) => p.flags.map((f) => ({ ...f, phase: p.phase })))
+    .sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+
+  const notes = [
+    "Routed phases are predicted with previewRoute() — a side-effect-free dry-run of the same routeEndpointV2 the live build uses — so the predicted provider/model matches what will actually run.",
+    "Stage-5b tier-sort (pipeline-v2.ts) ranks user-configured (cloud) endpoints ahead of bundled (local) ones, so on a mixed install a routed phase will pick cloud even when a local model is available.",
+    "Build Runtime governs the build engine and the ideate engine; plan and both reviews always route via Providers & Routing. For claude/codex/grok the build phase still routes through the agentic loop — only Local (OpenCode) makes the build phase local.",
+    "The served context window comes from the local endpoint's /v1/models (DMR serving config) and is invisible to both admin pages.",
+  ];
+
+  return {
+    verdict,
+    summary,
+    buildEngine,
+    buildEngineLabel: buildEngineLabel(buildEngine),
+    phases,
+    flags,
+    notes,
+    generatedAt: new Date().toISOString(),
+  };
+}

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -9,10 +9,16 @@
  */
 
 import type { ChatMessage } from "@/lib/ai-inference";
-import type { RouteDecision } from "@/lib/routing/types";
+import type {
+  RouteDecision,
+  EndpointManifest,
+  PolicyRuleEval,
+  EndpointOverride,
+} from "@/lib/routing/types";
 import type { RouteSensitivity } from "@/lib/agent-sensitivity";
 import type { ModelClass } from "@/lib/routing/model-card-types";
 import { inferContract } from "@/lib/routing/request-contract";
+import type { RequestContract } from "@/lib/routing/request-contract";
 import {
   loadEndpointManifests,
   loadPolicyRules,
@@ -166,30 +172,35 @@ export interface RouteAndCallOptions {
   mcpSession?: import("@/lib/routing/adapter-types").AdapterMcpSession;
 }
 
-// ─── Main function ──────────────────────────────────────────────────────────
+// ─── Route preparation (shared by routeAndCall + previewRoute) ───────────────
+
+interface PreparedRoute {
+  contract: RequestContract;
+  decision: RouteDecision;
+  manifests: EndpointManifest[];
+  policies: PolicyRuleEval[];
+  overrides: EndpointOverride[];
+  taskType: string;
+}
 
 /**
- * Route and execute an LLM inference call through the V2 pipeline.
+ * The routing half of routeAndCall: contract inference → routing-data load →
+ * V2 endpoint selection. Produces the RouteDecision WITHOUT dispatching. Both
+ * the live path (routeAndCall) and the side-effect-free preview (previewRoute)
+ * go through here, so a prediction can never drift from what actually runs.
  *
- * This is the sole entry point for inference after EP-INF-009b.
- * It replaces `callWithFailover` by running:
- *   1. Contract inference (from task type + messages)
- *   2. Endpoint manifest loading
- *   3. V2 routing (capability filter, cost-per-success ranking, recipes)
- *   4. Fallback chain dispatch
- *
- * Throws `NoEligibleEndpointsError` if no endpoints qualify — no silent
- * degradation to a different routing mechanism.
+ * `skipRecipe` (preview) makes routeEndpointV2 deterministic and skips the
+ * challenger Math.random() roll; the live path leaves it false so the
+ * executionPlan is built for dispatch.
  */
-export async function routeAndCall(
+async function prepareRoute(
   messages: ChatMessage[],
-  systemPrompt: string,
-  sensitivity: RouteSensitivity = "internal",
-  options?: RouteAndCallOptions,
-): Promise<RoutedInferenceResult> {
+  sensitivity: RouteSensitivity,
+  options: RouteAndCallOptions | undefined,
+  prep?: { skipRecipe?: boolean },
+): Promise<PreparedRoute> {
   const taskType = options?.taskType ?? "conversation";
 
-  // 1. Infer contract
   const contract = await inferContract(
     taskType,
     messages,
@@ -223,7 +234,6 @@ export async function routeAndCall(
     }
   }
 
-  // 2. Load routing data
   const [manifests, policies, overrides] = await Promise.all([
     loadEndpointManifests(),
     loadPolicyRules(),
@@ -238,8 +248,84 @@ export async function routeAndCall(
     );
   }
 
-  // 3. V2 routing
-  let decision = await routeEndpointV2(manifests, contract, policies, overrides);
+  const decision = await routeEndpointV2(manifests, contract, policies, overrides, {
+    skipRecipe: prep?.skipRecipe,
+  });
+
+  return { contract, decision, manifests, policies, overrides, taskType };
+}
+
+/** Result of a side-effect-free routing dry-run. */
+export interface RoutePreview {
+  /** The endpoint the live router would select first (selectedEndpoint=null → none eligible). */
+  decision: RouteDecision;
+  /** Full manifest of the selected endpoint, for provider-tier / context inspection. */
+  selectedManifest: EndpointManifest | null;
+  /** The inferred request contract (taskType, sensitivity, budgetClass, …). */
+  contract: RequestContract;
+}
+
+/**
+ * Side-effect-free dry-run of V2 routing: resolves the endpoint that WOULD be
+ * selected for a given task contract, without dispatching, persisting a route
+ * decision, rolling the challenger arm, or building an executionPlan.
+ *
+ * This is the primitive the Model Selection & Runtime Health resolver uses to
+ * predict, per build phase, which provider/model the live routeAndCall path
+ * will pick — answering "local or cloud, per phase?" BEFORE a run rather than
+ * discovering it after the GPU has sat idle. It mirrors routeAndCall's routing
+ * inputs (taskType, sensitivity, budgetClass, tools→requiresTools) so the
+ * predicted winner matches the live one.
+ *
+ * Throws NoEligibleEndpointsError when no providers are configured at all —
+ * callers should catch and surface that as a configuration gap.
+ */
+export async function previewRoute(
+  messages: ChatMessage[],
+  sensitivity: RouteSensitivity = "internal",
+  options?: RouteAndCallOptions,
+): Promise<RoutePreview> {
+  const { contract, decision, manifests } = await prepareRoute(
+    messages,
+    sensitivity,
+    options,
+    { skipRecipe: true },
+  );
+  const selectedManifest = decision.selectedEndpoint
+    ? manifests.find((m) => m.id === decision.selectedEndpoint) ?? null
+    : null;
+  return { decision, selectedManifest, contract };
+}
+
+// ─── Main function ──────────────────────────────────────────────────────────
+
+/**
+ * Route and execute an LLM inference call through the V2 pipeline.
+ *
+ * This is the sole entry point for inference after EP-INF-009b.
+ * It replaces `callWithFailover` by running:
+ *   1. Contract inference (from task type + messages)
+ *   2. Endpoint manifest loading
+ *   3. V2 routing (capability filter, cost-per-success ranking, recipes)
+ *   4. Fallback chain dispatch
+ *
+ * Throws `NoEligibleEndpointsError` if no endpoints qualify — no silent
+ * degradation to a different routing mechanism.
+ */
+export async function routeAndCall(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  sensitivity: RouteSensitivity = "internal",
+  options?: RouteAndCallOptions,
+): Promise<RoutedInferenceResult> {
+  // 1-3. Contract inference, routing-data load, and V2 endpoint selection —
+  // shared with previewRoute() via prepareRoute() so a model-selection
+  // prediction can never drift from what this live path actually picks. The
+  // live path keeps recipe selection (skipRecipe defaults false) so the
+  // executionPlan is built for dispatch below.
+  const prepared = await prepareRoute(messages, sensitivity, options);
+  const { contract, manifests, policies, overrides, taskType } = prepared;
+  let decision = prepared.decision;
   let toolsStripped = false;
 
   // EP-INF-013: Inject effort into the execution plan so adapters can translate it

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -35,7 +35,7 @@ const OPENCODE_SCHEMA_TASK_TIMEOUT_MS = Number(process.env.OPENCODE_SCHEMA_TASK_
 // Real agent runs consume 39k–156k tokens; a serving context below this fails
 // outright. Advisory floor — /v1/models rarely exposes context length, so this
 // is enforced only when the endpoint reports it (see preflightLocalEndpoint).
-const OPENCODE_MIN_CONTEXT_TOKENS = Number(process.env.OPENCODE_MIN_CONTEXT_TOKENS) || 22_000;
+export const OPENCODE_MIN_CONTEXT_TOKENS = Number(process.env.OPENCODE_MIN_CONTEXT_TOKENS) || 22_000;
 
 export type OpencodeResult = {
   content: string;
@@ -50,6 +50,13 @@ export type LocalEndpointPreflight = {
   models: string[];
   contextOk: boolean;       // false only when the endpoint reports a context below the floor
   reason: string | null;    // BLOCKED-classifiable message when ok === false
+  /**
+   * Served context window the endpoint reported for the resolved model, in
+   * tokens. null when the endpoint omits it (the common OpenAI-/v1/models case).
+   * Surfaced so the Model Selection & Runtime Health view can show e.g.
+   * "served 4096 / needs >= 22000" rather than just a pass/fail.
+   */
+  reportedContextTokens: number | null;
 };
 
 /**
@@ -86,9 +93,20 @@ type OpenAiModelsResponse = {
  * those classes and prefer an explicit coder model, then a qwen3 family model,
  * then any remaining chat model. Returns null only when nothing usable is served.
  */
+/**
+ * Model-id classes that are NOT chat/coding models — embeddings, rerankers,
+ * STT/TTS, vision-embed. Single source of truth, shared by pickDefaultCodingModel
+ * and the Runtime Health "embedding model first-in-list" check.
+ */
+const NON_CHAT_MODEL_RE = /embed|nomic|bge[-_]|rerank|whisper|\bstt\b|\btts\b|clip|vision-embed|minilm|gte|e5/i;
+
+/** True when a served model id looks like a non-chat model (embedding/rerank/STT/…). */
+export function isLikelyNonChatModel(model: string): boolean {
+  return NON_CHAT_MODEL_RE.test(model);
+}
+
 export function pickDefaultCodingModel(models: string[]): string | null {
-  const NON_CHAT_RE = /embed|nomic|bge[-_]|rerank|whisper|\bstt\b|\btts\b|clip|vision-embed|minilm|gte|e5/i;
-  const chatModels = models.filter((m) => !NON_CHAT_RE.test(m));
+  const chatModels = models.filter((m) => !isLikelyNonChatModel(m));
   return (
     chatModels.find((m) => /coder|[-_]code\b|code[-_]/i.test(m)) ??
     chatModels.find((m) => /qwen3/i.test(m)) ??
@@ -108,17 +126,17 @@ export async function preflightLocalEndpoint(
   try {
     const res = await fetchImpl(url, { method: "GET" });
     if (!res.ok) {
-      return { ok: false, resolvedModel: null, models: [], contextOk: false, reason: `Local model endpoint ${url} returned HTTP ${res.status}. Is the local AI provider running?` };
+      return { ok: false, resolvedModel: null, models: [], contextOk: false, reason: `Local model endpoint ${url} returned HTTP ${res.status}. Is the local AI provider running?`, reportedContextTokens: null };
     }
     body = (await res.json()) as OpenAiModelsResponse;
   } catch (err) {
-    return { ok: false, resolvedModel: null, models: [], contextOk: false, reason: `Local model endpoint ${url} is unreachable: ${(err as Error).message}` };
+    return { ok: false, resolvedModel: null, models: [], contextOk: false, reason: `Local model endpoint ${url} is unreachable: ${(err as Error).message}`, reportedContextTokens: null };
   }
 
   const entries = Array.isArray(body.data) ? body.data : [];
   const models = entries.map((m) => m.id).filter((id): id is string => typeof id === "string");
   if (models.length === 0) {
-    return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Local model endpoint ${url} returned no models. Pull a coding model first (e.g. a qwen3-coder build).` };
+    return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Local model endpoint ${url} returned no models. Pull a coding model first (e.g. a qwen3-coder build).`, reportedContextTokens: null };
   }
 
   const resolvedModel = requestedModel && models.includes(requestedModel)
@@ -128,7 +146,7 @@ export async function preflightLocalEndpoint(
       : pickDefaultCodingModel(models);
 
   if (!resolvedModel) {
-    return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Requested model "${requestedModel}" is not served by the local endpoint. Available: ${models.join(", ")}.` };
+    return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Requested model "${requestedModel}" is not served by the local endpoint. Available: ${models.join(", ")}.`, reportedContextTokens: null };
   }
 
   // Best-effort context check: only enforced when the endpoint reports a context
@@ -143,10 +161,11 @@ export async function preflightLocalEndpoint(
       models,
       contextOk: false,
       reason: `Model "${resolvedModel}" serves only ${reported} context tokens; agent runs need >= ${OPENCODE_MIN_CONTEXT_TOKENS}. Pull a longer-context model.`,
+      reportedContextTokens: reported,
     };
   }
 
-  return { ok: true, resolvedModel, models, contextOk: true, reason: null };
+  return { ok: true, resolvedModel, models, contextOk: true, reason: null, reportedContextTokens: reported ?? null };
 }
 
 /**

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2391,6 +2391,20 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     buildPhases: ["ideate", "plan", "build", "review"],
   },
   {
+    name: "resolve_model_selection",
+    description:
+      "Model Selection & Runtime Health — resolve which model/provider/engine WILL run each Build Studio phase (ideate, plan, design-review, plan-review, build) given current config, and flag where live config contradicts platform guidance. Answers 'local or cloud, per phase?' and 'how is the model chosen per phase?' in ONE call, BEFORE a build runs — establish ground truth here rather than discovering after the GPU sat idle. Model selection is split across three sources with no other synthesis: Providers & Routing (routeAndCall/V2 routing; user-configured cloud endpoints outrank the bundled local model), Build Runtime (the dispatch engine), and the local endpoint's served context window (DMR). Returns per-phase { mechanism, engine, providerId, modelId, isLocal, providerTier, contextTokens, rationale, flags } plus an overall verdict (all-local | all-cloud | mixed | unconfigured) and remediation. Read-only; runs a side-effect-free routing dry-run (no dispatch, no model call).",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    buildPhases: ["ideate", "plan", "build", "review"],
+    annotations: { readOnlyHint: true, idempotentHint: true },
+  },
+  {
     name: "check_sandbox",
     description: "Check whether the sandbox container (dpf-sandbox-1) is running. Returns status: 'running', 'stopped', or 'not_found'. If the result is not_found or detached, call diagnose_sandbox for governed recovery guidance.",
     inputSchema: { type: "object", properties: {} },
@@ -7945,6 +7959,18 @@ export async function executeTool(
         entityId: buildId,
         message: `Dispatch history loaded for ${buildId}: ${history.length} attempt(s).`,
         data: { buildId, attempts: history },
+      };
+    }
+
+    case "resolve_model_selection": {
+      const { resolveModelSelectionByPhase } = await import(
+        "@/lib/inference/phase-model-resolution"
+      );
+      const overview = await resolveModelSelectionByPhase();
+      return {
+        success: true,
+        message: `Model selection (${overview.verdict}): ${overview.summary}`,
+        data: overview as unknown as Record<string, unknown>,
       };
     }
 

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -243,6 +243,15 @@ export async function routeEndpointV2(
   contract: RequestContract,
   policyRules: PolicyRuleEval[],
   overrides: EndpointOverride[],
+  /**
+   * skipRecipe: skip execution-recipe selection (and its executionPlan build).
+   * The recipe only shapes the executionPlan/provider settings — never the
+   * selected endpoint — and `selectRecipeWithExploration` rolls Math.random()
+   * for the challenger arm. A model-selection PREVIEW must be deterministic and
+   * side-effect-free, so it routes with skipRecipe=true: same winner, no roll,
+   * executionPlan omitted. The live `routeAndCall` path leaves it false.
+   */
+  opts?: { skipRecipe?: boolean },
 ): Promise<RouteDecision> {
   const timestamp = new Date();
   const allCandidates: CandidateTrace[] = [];
@@ -443,13 +452,19 @@ export async function routeEndpointV2(
     }
   }
 
-  // EP-INF-005b/006: Recipe lookup with exploration selection
-  const { recipe, explorationMode } = await selectRecipeWithExploration(
-    winner.endpoint.providerId, winner.endpoint.modelId, contract,
-  );
+  // EP-INF-005b/006: Recipe lookup with exploration selection.
+  // skipRecipe (preview) short-circuits this: no recipe, no challenger roll,
+  // no executionPlan — the winner above is already fully determined.
+  const { recipe, explorationMode } = opts?.skipRecipe
+    ? { recipe: null, explorationMode: "champion" as const }
+    : await selectRecipeWithExploration(
+        winner.endpoint.providerId, winner.endpoint.modelId, contract,
+      );
   const executionPlan = recipe
     ? buildPlanFromRecipe(recipe, contract)
-    : buildDefaultPlan(winner.endpoint, contract);
+    : opts?.skipRecipe
+      ? undefined
+      : buildDefaultPlan(winner.endpoint, contract);
 
   // Build full candidate trace (eligible endpoints, with rankScore as fitnessScore)
   const eligibleTraces: CandidateTrace[] = ranked.map(

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -301,6 +301,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   recover_sandbox: ["sandbox_execute"],
   // Build-progress observation tools are read-only work capsule inspection.
   get_build_engine_readiness: ["work_capsule_read"],
+  resolve_model_selection: ["work_capsule_read"],
   get_build_progress_visibility: ["work_capsule_read"],
   get_build_sandbox_state: ["work_capsule_read"],
   get_build_dispatch_history: ["work_capsule_read"],

--- a/docs/superpowers/specs/2026-06-15-model-selection-as-built-dispatch-allocation.html
+++ b/docs/superpowers/specs/2026-06-15-model-selection-as-built-dispatch-allocation.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Model Selection — As-Built Dispatch &amp; Routing Allocation (SysML projection)</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 15px/1.6 -apple-system, "Segoe UI", Roboto, sans-serif; max-width: 60rem; margin: 2rem auto; padding: 0 1.2rem; }
+  h1 { font-size: 1.7rem; } h2 { margin-top: 2rem; border-bottom: 1px solid #8884; padding-bottom: .2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #8886; padding: .35rem .5rem; text-align: left; vertical-align: top; }
+  code { font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace; font-size: .9em; }
+  pre { background: #8881; padding: 1rem; overflow-x: auto; border-radius: 6px; }
+  pre code { font-size: .85em; line-height: 1.5; }
+  .kw { color: #07d; font-weight: 600; } .com { color: #690; font-style: italic; } .str { color: #a50; }
+  .tag { display: inline-block; font-size: .75em; padding: .05rem .4rem; border: 1px solid #8886; border-radius: 999px; }
+  blockquote { border-left: 3px solid #8886; margin: 1rem 0; padding: .2rem 1rem; color: inherit; }
+  .bad { color: #c0392b; font-weight: 600; } .good { color: #1e8449; font-weight: 600; }
+</style>
+</head>
+<body>
+
+<h1>Model Selection — As-Built Dispatch &amp; Routing Allocation</h1>
+
+<table>
+  <tr><th>Field</th><th>Value</th></tr>
+  <tr><td>Status</td><td><strong>As-built projection (current state)</strong> — documents the system as it exists, plus the observability layer that closes the gap. Not a future design.</td></tr>
+  <tr><td>Date</td><td>2026-06-15</td></tr>
+  <tr><td>Owner</td><td>Enterprise Architect, Build Studio platform team</td></tr>
+  <tr><td>Backlog</td><td><code>BI-768AFB99</code> (Model Selection &amp; Runtime Health)</td></tr>
+  <tr><td>Epics</td><td><code>EP-FULL-OBS</code> (the operator/agent view) · <code>EP-PARITY-ENGINE</code> (this is the missing as-built dispatch/routing projection that epic exists to produce)</td></tr>
+  <tr><td>Builds on</td><td><a href="2026-06-14-sysml-architecture-substrate-design.md">SysML Architecture Substrate</a> (notation), <a href="2026-06-14-interface-surface-governance-design.html">Interface-Surface Governance</a> (the as-built projection pattern), <a href="2026-06-10-local-llm-build-agent-design.md">Local-LLM Build Agent</a> (the opencode dispatch path)</td></tr>
+  <tr><td>WWMD anchor</td><td><code>structural-verification-is-not-functional</code> (a "local" label is not a local run) · <code>evidence-before-diagnosis</code> (resolve ground truth before driving) · Single Source of Truth (one resolver, three surfaces)</td></tr>
+</table>
+
+<h2>1. Problem — model selection is split across three sources with no synthesis</h2>
+
+<p>A "local-model" Build Studio campaign actually ran on <strong>cloud</strong> — nobody noticed
+until the GPU sat idle. The cause is structural: which model/provider/engine executes a build
+phase is decided in three places that nothing reconciles, and no view or tool resolves the
+<em>effective</em> per-phase answer before a run.</p>
+
+<table>
+  <tr><th>#</th><th>Config source</th><th>Admin surface</th><th>Governs</th></tr>
+  <tr><td>1</td><td>V2 routing (<code>routeAndCall</code> → <code>routeEndpointV2</code>)</td><td>Providers &amp; Routing (<code>/platform/ai/providers</code>)</td><td>Every <em>routed</em> phase: plan, design-review, plan-review, ideate-when-opencode, build-when-not-opencode</td></tr>
+  <tr><td>2</td><td>Build dispatch engine (<code>getBuildStudioConfig().provider</code>, <code>PlatformConfig["build-studio-dispatch"]</code>)</td><td>Build Runtime (<code>/platform/ai/build-studio</code>)</td><td>The ideate engine and the build engine (only <code>opencode</code> makes build local)</td></tr>
+  <tr><td>3</td><td>Served context window (<code>preflightLocalEndpoint</code> → <code>/v1/models</code>)</td><td><em>none</em> — invisible to both pages</td><td>Whether the local model can actually run an agent loop (≥ <code>OPENCODE_MIN_CONTEXT_TOKENS</code>)</td></tr>
+</table>
+
+<p>The decisive mechanism is Stage-5b of <code>routeEndpointV2</code>
+(<code>apps/web/lib/routing/pipeline-v2.ts</code>): a stable sort puts
+<code>user_configured</code> (cloud) endpoints <strong>ahead of</strong> <code>bundled</code> (local)
+ones. So on a mixed install a routed phase picks cloud <em>even when a local model is
+available and free</em>. Selecting "Local model (OpenCode)" in Build Runtime makes <strong>only
+the build phase</strong> local; ideate, plan, and both reviews still route to cloud.</p>
+
+<h2>2. As-built per-phase allocation</h2>
+
+<p>The effective dispatch for each phase, verified against the code (call sites cited):</p>
+
+<table>
+  <tr><th>Phase</th><th>Engine governed by</th><th>Mechanism</th><th>Effective provider/model</th><th>Code (as-built)</th></tr>
+  <tr><td><strong>ideate</strong></td><td>Build Runtime <code>provider</code></td><td><code>opencode</code> → <span class="bad">routed</span>; claude/codex/grok → vendor CLI; agentic → unsupported</td><td>opencode path ROUTES (cloud on mixed); CLI path uses the configured vendor</td><td><code>ideate-dispatch.ts:417,444</code>; callers <code>ideate-on-approval.ts:177</code>, <code>agent-coworker.ts:1699</code></td></tr>
+  <tr><td><strong>plan</strong></td><td>Providers &amp; Routing</td><td>routed (<code>conversation</code>, <code>quality_first</code>)</td><td>V2 winner → cloud on mixed</td><td><code>plan-on-approval.ts:276</code></td></tr>
+  <tr><td><strong>design-review</strong></td><td>Providers &amp; Routing</td><td>routed (<code>analysis</code>)</td><td>V2 winner → cloud on mixed</td><td><code>build.ts:1688</code> (<code>callReviewerLLM</code>)</td></tr>
+  <tr><td><strong>plan-review</strong></td><td>Providers &amp; Routing</td><td>routed (<code>analysis</code>)</td><td>V2 winner → cloud on mixed</td><td><code>build.ts:1730</code> (same reviewer)</td></tr>
+  <tr><td><strong>build</strong></td><td>Build Runtime <code>provider</code></td><td><code>opencode</code> → <span class="good">local CLI</span>; else → routed (<code>analysis</code>, <code>requireTools</code>)</td><td>opencode → local model; claude/codex/grok/agentic → V2 winner (the CLI choice does NOT apply to build)</td><td><code>build-pipeline.ts:437</code> (opencode) / <code>:486</code> (agentic loop)</td></tr>
+</table>
+
+<blockquote>Net: with the local engine selected on a mixed install, <strong>4 of 5 phases route to
+cloud</strong> and only the build phase uses the GPU.</blockquote>
+
+<h2>3. The SysML v2 model</h2>
+
+<p>The build lifecycle's model-selection allocation in SysML v2 textual notation — phase
+<code>action</code>s allocated to the dispatch-mechanism <code>part</code>s that realize them,
+each part allocated to its governing config source and its as-built code, with the tier-sort
+recorded as a <code>constraint</code>:</p>
+
+<pre><code><span class="kw">package</span> ModelSelectionAsBuilt {
+
+  <span class="com">// ---- Requirements (what the runtime-health layer must guarantee) ----</span>
+  <span class="kw">requirement def</span> R1_OneAuthoritativeView {
+    <span class="kw">doc</span> <span class="str">/* An operator OR an agent resolves, in one place, which
+           provider/engine/model runs each phase right now. */</span>
+  }
+  <span class="kw">requirement def</span> R2_PredictBeforeRun {
+    <span class="kw">doc</span> <span class="str">/* The answer is available BEFORE a build runs, using the same
+           routing logic the build uses (no drift). */</span>
+  }
+  <span class="kw">requirement def</span> R3_FlagContradictions {
+    <span class="kw">doc</span> <span class="str">/* Where live config contradicts platform guidance is flagged:
+           local-intent-but-cloud-reasoning, context-below-floor,
+           embedding-model-first. */</span>
+  }
+
+  <span class="com">// ---- Config sources (the three split authorities) ----</span>
+  <span class="kw">part def</span> ProvidersAndRouting;   <span class="com">// V2 routing — /platform/ai/providers</span>
+  <span class="kw">part def</span> BuildRuntime;          <span class="com">// dispatch engine — /platform/ai/build-studio</span>
+  <span class="kw">part def</span> DmrServingConfig;      <span class="com">// served context window — no admin surface</span>
+
+  <span class="com">// ---- Dispatch mechanisms (how a phase actually reaches a model) ----</span>
+  <span class="kw">part def</span> RoutedDispatch;        <span class="com">// routeAndCall -> routeEndpointV2</span>
+  <span class="kw">part def</span> VendorCliDispatch;     <span class="com">// claude/codex/grok CLI in the sandbox</span>
+  <span class="kw">part def</span> LocalOpencodeDispatch;  <span class="com">// opencode CLI against the local endpoint</span>
+
+  <span class="com">// ---- The blind-spot constraint: tier-sort dominates ranking ----</span>
+  <span class="kw">constraint def</span> C1_TierSortPrefersCloud {
+    <span class="kw">doc</span> <span class="str">/* routeEndpointV2 Stage-5b stable-sorts user_configured ahead of
+           bundled, so a routed phase picks cloud over an available local
+           model on a mixed install. pipeline-v2.ts. */</span>
+  }
+
+  <span class="com">// ---- Phase actions, allocated to the mechanism that realizes them ----</span>
+  <span class="kw">action def</span> Ideate;        <span class="kw">allocate</span> Ideate      <span class="kw">to</span> RoutedDispatch, VendorCliDispatch;
+  <span class="kw">action def</span> Plan;          <span class="kw">allocate</span> Plan        <span class="kw">to</span> RoutedDispatch;
+  <span class="kw">action def</span> DesignReview;  <span class="kw">allocate</span> DesignReview <span class="kw">to</span> RoutedDispatch;
+  <span class="kw">action def</span> PlanReview;    <span class="kw">allocate</span> PlanReview  <span class="kw">to</span> RoutedDispatch;
+  <span class="kw">action def</span> Build;         <span class="kw">allocate</span> Build       <span class="kw">to</span> LocalOpencodeDispatch, RoutedDispatch;
+
+  <span class="com">// ---- Mechanism -> governing source, and the tier-sort it inherits ----</span>
+  <span class="kw">allocate</span> RoutedDispatch       <span class="kw">to</span> ProvidersAndRouting;
+  <span class="kw">allocate</span> VendorCliDispatch    <span class="kw">to</span> BuildRuntime;
+  <span class="kw">allocate</span> LocalOpencodeDispatch <span class="kw">to</span> BuildRuntime, DmrServingConfig;
+  <span class="kw">satisfy</span> C1_TierSortPrefersCloud <span class="kw">by</span> RoutedDispatch;
+
+  <span class="com">// ---- As-built code allocations (the projection's authority) ----</span>
+  <span class="kw">allocate</span> RoutedDispatch <span class="kw">to</span>
+    <span class="str">"apps/web/lib/inference/routed-inference.ts#routeAndCall"</span>,
+    <span class="str">"apps/web/lib/routing/pipeline-v2.ts#routeEndpointV2"</span>;
+  <span class="kw">allocate</span> VendorCliDispatch <span class="kw">to</span>
+    <span class="str">"apps/web/lib/integrate/ideate-dispatch.ts#dispatchIdeateResearch"</span>;
+  <span class="kw">allocate</span> LocalOpencodeDispatch <span class="kw">to</span>
+    <span class="str">"apps/web/lib/integrate/build-pipeline.ts#stepGenerateCode"</span>,
+    <span class="str">"apps/web/lib/integrate/opencode-dispatch.ts#preflightLocalEndpoint"</span>;
+
+  <span class="com">// ---- The runtime-health layer that resolves + flags all of the above ----</span>
+  <span class="kw">action def</span> ResolveModelSelection;  <span class="com">// one resolver, three surfaces</span>
+  <span class="kw">verification def</span> V_PredictionMatchesRun {
+    <span class="kw">doc</span> <span class="str">/* previewRoute (a side-effect-free dry-run of routeEndpointV2)
+           predicts the per-phase winner; verified to match what actually
+           ran by driving a build on the live install. */</span>
+  }
+  <span class="kw">verify</span> R2_PredictBeforeRun <span class="kw">by</span> V_PredictionMatchesRun;
+
+  <span class="kw">allocate</span> ResolveModelSelection <span class="kw">to</span>
+    <span class="str">"apps/web/lib/inference/phase-model-resolution.ts#resolveModelSelectionByPhase"</span>,
+    <span class="str">"apps/web/lib/inference/routed-inference.ts#previewRoute"</span>,
+    <span class="str">"apps/web/lib/mcp-tools.ts#resolve_model_selection"</span>,
+    <span class="str">"apps/web/app/(shell)/platform/ai/runtime-health/page.tsx"</span>;
+  <span class="kw">satisfy</span> R1_OneAuthoritativeView <span class="kw">by</span> ResolveModelSelection;
+  <span class="kw">satisfy</span> R3_FlagContradictions   <span class="kw">by</span> ResolveModelSelection;
+}
+</code></pre>
+
+<h2>4. How the gap is closed — one resolver, three surfaces</h2>
+
+<p>A single resolver,
+<code>apps/web/lib/inference/phase-model-resolution.ts#resolveModelSelectionByPhase</code>,
+computes the per-phase allocation above and the contradiction flags. It reuses the
+<em>real</em> routing logic via <code>previewRoute()</code>
+(<code>routed-inference.ts</code>) — extracted from <code>routeAndCall</code> so the prediction
+runs the identical <code>routeEndpointV2</code> the build uses, with <code>skipRecipe</code> to stay
+deterministic and side-effect-free (no dispatch, no challenger roll, no persisted decision).</p>
+
+<ul>
+  <li><strong>Operator</strong> → the <code>/platform/ai/runtime-health</code> page: a verdict
+  (<code>all-local</code> / <code>all-cloud</code> / <code>mixed</code> / <code>unconfigured</code>),
+  a per-phase table (runs-on, provider/model, mechanism, governed-by, context), and a
+  Mismatches &amp; remediation list.</li>
+  <li><strong>Agent</strong> → the <code>resolve_model_selection</code> MCP tool: the same overview
+  as structured data, so a coworker establishes ground truth in one call <em>before</em> driving a
+  build.</li>
+  <li><strong>Architecture</strong> → this projection: the as-built dispatch/routing allocation the
+  Parity Engine (<code>EP-PARITY-ENGINE</code>) had no source for.</li>
+</ul>
+
+<h2>5. Contradiction flags (realized)</h2>
+
+<table>
+  <tr><th>Code</th><th>Severity</th><th>Fires when</th></tr>
+  <tr><td><code>local-intent-cloud-reasoning</code></td><td>error</td><td>Build engine = opencode but a reasoning phase (ideate/plan/design-review/plan-review) resolves to a cloud provider — the headline blind spot.</td></tr>
+  <tr><td><code>context-too-small</code></td><td>error</td><td>The local endpoint reports a served context below <code>OPENCODE_MIN_CONTEXT_TOKENS</code> (e.g. qwen3-coder at 4096 vs the 22k floor).</td></tr>
+  <tr><td><code>embedding-model-first</code></td><td>warning</td><td>The local <code>/v1/models</code> list leads with a non-chat model (<code>isLikelyNonChatModel</code>), risking an embedding model being picked for code-gen.</td></tr>
+  <tr><td><code>build-engine-not-applied</code></td><td>info</td><td>A claude/codex/grok build engine is selected, but the build phase still routes through the agentic loop — the CLI choice only governs ideate.</td></tr>
+  <tr><td><code>ideate-opencode-routes</code></td><td>info</td><td>Ideate runs through routing even under the local engine (it does not invoke the local runner directly).</td></tr>
+</table>
+
+<h2>6. Verification</h2>
+
+<ul>
+  <li>Pure unit tests for the resolver
+  (<code>apps/web/lib/inference/phase-model-resolution.test.ts</code>): local-but-cloud-reasoning
+  flags on every routed phase, context-below-floor, embedding-first, all-local clean, all-cloud +
+  build-engine-not-applied, agentic-ideate-unsupported, no-providers → unconfigured.</li>
+  <li>Existing routing suites (<code>pipeline-v2.test.ts</code>) confirm the
+  <code>previewRoute</code>/<code>skipRecipe</code> extraction did not change routing behavior.</li>
+  <li><strong>Live functional verification</strong> (<code>V_PredictionMatchesRun</code>): drive a
+  build on the live install and confirm the predicted per-phase provider/model matches what
+  actually ran — closing <code>structural-verification-is-not-functional</code>.</li>
+</ul>
+
+<h2>7. SysML Architecture Note</h2>
+
+<table>
+  <tr><th>Field</th><th>Value</th></tr>
+  <tr><td>Scope</td><td>As-built model-selection allocation across the five build phases; the runtime-health resolver + MCP tool + admin view; the <code>previewRoute</code> extraction.</td></tr>
+  <tr><td>Requirements/constraints</td><td>R1 one-authoritative-view, R2 predict-before-run, R3 flag-contradictions; constraint C1 tier-sort-prefers-cloud (the blind-spot root).</td></tr>
+  <tr><td>Interfaces/ports</td><td>New read-only MCP tool <code>resolve_model_selection</code>; new exported <code>previewRoute()</code> on the inference module; <code>LocalEndpointPreflight</code> gains <code>reportedContextTokens</code>. No external API change.</td></tr>
+  <tr><td>Allocations</td><td>Phase actions → dispatch parts → governing config sources → as-built code (§3). Resolver → page + MCP tool.</td></tr>
+  <tr><td>Verification cases</td><td>Resolver unit tests; routing-suite regression; live build-drive prediction match.</td></tr>
+  <tr><td>Data authority impact</td><td>None new. The overview is a derived projection — no new table, no new element type; uses existing <code>sysml2</code> grammar.</td></tr>
+  <tr><td>EA/current-state catch-up</td><td>This artifact <em>is</em> the catch-up: the dispatch/routing domain now has an as-built SysML projection the Parity Engine can diff future drift against.</td></tr>
+  <tr><td>Open architecture risks</td><td>Ideate-opencode routing (vs the local runner) is a genuine local-intent inconsistency tracked as follow-up, not just observability. Semantic code-graph search ("how is the model chosen per phase") remains a larger, separate lever.</td></tr>
+</table>
+
+<h2>8. Discoverability &amp; relationships</h2>
+
+<p>Indexed by <code>search_specs_and_plans</code> / <code>doc_search</code> so the conceptual question
+— "how is the model chosen per phase", "local or cloud per phase", "model selection per build
+phase" — returns this projection. It complements the <em>runtime</em> answer (the health view + MCP
+tool, current config) with the <em>design-time</em> answer (this allocation, config-independent).
+Parity target for <code>EP-PARITY-ENGINE</code>; observability surface for
+<code>EP-FULL-OBS</code>; embedding-first flag relates to <code>EP-BUILD-391A81</code>.</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Why

A "local-model" Build Studio campaign actually ran on **cloud** — nobody noticed until the GPU sat idle. The cause is structural: which model/provider/engine runs a build phase is decided in **three places that nothing reconciles**, and no view or tool resolves the *effective* per-phase answer before a run.

| Source | Admin surface | Governs |
|---|---|---|
| V2 routing (`routeAndCall`→`routeEndpointV2`) | Providers & Routing | every routed phase |
| Build dispatch engine (`getBuildStudioConfig`) | Build Runtime | ideate engine + build engine |
| Served context window (`preflightLocalEndpoint`) | *none* | whether the local model can run an agent loop |

Stage-5b of `routeEndpointV2` stable-sorts `user_configured` (cloud) ahead of `bundled` (local), so on a mixed install a routed phase picks cloud **even when a local model is available**. Selecting "Local model (OpenCode)" makes **only the build phase** local:

| Phase | Mechanism | Local? (mixed install) |
|---|---|---|
| ideate | opencode→routed / vendor CLI | ❌ routes to cloud |
| plan | routed (`quality_first`) | ❌ |
| design-review | routed (`analysis`) | ❌ |
| plan-review | routed (`analysis`) | ❌ |
| build | opencode→local / else routed | ✅ only when engine=opencode |

## What

One shared resolver, three surfaces — reusing the **real** routing logic so the prediction can't drift:

- **`previewRoute()`** — a side-effect-free dry-run extracted from `routeAndCall` (+ `skipRecipe` on `routeEndpointV2`, deterministic, no dispatch/persist/challenger-roll). The live path now calls the same `prepareRoute()` helper, so behavior is unchanged.
- **`resolveModelSelectionByPhase()`** (`phase-model-resolution.ts`) — per-phase engine / mechanism / provider / model / context + mismatch flags: `local-intent-cloud-reasoning`, `context-too-small`, `embedding-model-first`, `build-engine-not-applied`, `ideate-opencode-routes`, `ideate-agentic-unsupported`.
- **(a) Admin view** `/platform/ai/runtime-health` — verdict banner + per-phase table + Mismatches & remediation. A fresh operator answers "local or cloud, per phase?" in one place.
- **(b) MCP tool** `resolve_model_selection` (read-only) — an agent answers it in one call **before** driving a build.
- **(c) As-built SysML projection** (`docs/superpowers/specs/2026-06-15-model-selection-as-built-dispatch-allocation.html`) — the dispatch/routing allocation `EP-PARITY-ENGINE` had no source for; makes "how is the model chosen per phase" answerable in the specs layer (confirmed live: `search_code_graph` returns nothing for that query today).

Supporting: `opencode-dispatch` exports `isLikelyNonChatModel` + `OPENCODE_MIN_CONTEXT_TOKENS` and surfaces `reportedContextTokens` from `preflightLocalEndpoint`.

## Verification

- **7 resolver unit tests** (`phase-model-resolution.test.ts`) cover every flag + verdict path.
- Full routing/inference/mcp/grants suites green (**1355 tests, 88 files**); `apps/web` typecheck clean. The `previewRoute`/`skipRecipe` extraction is regression-tested by the existing `pipeline-v2` suite.
- **Live ground truth** (existing MCP tools): engine readiness shows `codex` + `opencode` present; `search_code_graph "how is the model chosen per build phase"` → *no results* (validates deliverable c).
- **Live functional verification** (drive a build on the rebuilt portal, compare the health view's predicted model to `get_build_dispatch_history` per phase) follows on the **canonical post-merge rebuild** — the worktree has no live-DB credential (the resolver code path executed through Prisma to the auth handshake; only the intentionally-absent worktree secret blocks it). Procedure once deployed: call `resolve_model_selection`, run a build, then `get_build_dispatch_history` and confirm per-phase match.

## Links

`BI-768AFB99` · `EP-FULL-OBS` (the view) · `EP-PARITY-ENGINE` (the projection). Follow-up noted in the spec: ideate-opencode routes instead of using the local runner — a genuine local-intent inconsistency, not just observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
