### PR TITLE
feat(build-studio,routing): operator-configurable fully-local build via admin UX (BI-594E8782)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -15,6 +15,8 @@ import { getAllCliPoolStatuses } from "@/lib/routing/cli-pool-status";
 import { CliPoolStatusPanel } from "@/components/platform/CliPoolStatusPanel";
 import { getRecentBudgetEvents, countRecentRejections } from "@/lib/inference/budget-events-data";
 import { AgentBudgetEventsPanel } from "@/components/platform/AgentBudgetEventsPanel";
+import { LocalOnlyInferenceToggle } from "@/components/platform/LocalOnlyInferenceToggle";
+import { getLocalOnlyInference } from "@/lib/inference/local-only";
 import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
@@ -48,7 +50,7 @@ export default async function ProvidersPage() {
   const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
 
   // Bypass React cache for jobs — syncProviderRegistry() may have mutated the DB above.
-  const [providers, byProvider, byAgent, freshJobs, detected, modelSummaries, cliPoolStatuses, budgetEvents, recentRejections] = await Promise.all([
+  const [providers, byProvider, byAgent, freshJobs, detected, modelSummaries, cliPoolStatuses, budgetEvents, recentRejections, localOnlyInference] = await Promise.all([
     getProviders(),
     getTokenSpendByProvider(currentMonth),
     getTokenSpendByAgent(currentMonth),
@@ -58,6 +60,7 @@ export default async function ProvidersPage() {
     getAllCliPoolStatuses(),
     getRecentBudgetEvents(),
     countRecentRejections(),
+    getLocalOnlyInference(),
   ]);
   const aiProviders = providers.filter((pw) => pw.provider.endpointType !== "service");
 
@@ -80,6 +83,9 @@ export default async function ProvidersPage() {
 
       {/* EP-COST Phase 2: Agent Budget Events — surface warning_95 and rejected threshold crossings */}
       <AgentBudgetEventsPanel events={budgetEvents} recentRejections={recentRejections} />
+
+      {/* Local-only inference (cloud-disabled) guarantee — BI-594E8782 */}
+      <LocalOnlyInferenceToggle initialEnabled={localOnlyInference} canWrite={canWrite} />
 
       <div
         style={{

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
-import { saveBuildStudioConfig, checkLocalEndpoint } from "@/lib/actions/build-studio";
+import { saveBuildStudioConfig, checkLocalEndpoint, applyLocalModelContext } from "@/lib/actions/build-studio";
 import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
 import type { LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
@@ -99,6 +99,11 @@ export function BuildStudioConfigForm({
   const [opencodeModel, setOpencodeModel] = useState(config.opencodeModel);
   const [endpointCheck, setEndpointCheck] = useState<LocalEndpointPreflight | null>(null);
   const [checkingEndpoint, setCheckingEndpoint] = useState(false);
+  // (a) Per-model served context window (tokens) the operator applies to the
+  // local runtime without touching Docker.
+  const [contextTokens, setContextTokens] = useState("");
+  const [applyingContext, setApplyingContext] = useState(false);
+  const [contextResult, setContextResult] = useState<{ ok: boolean; reason: string | null } | null>(null);
   const [isPending, startTransition] = useTransition();
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -111,13 +116,40 @@ export function BuildStudioConfigForm({
   function runEndpointCheck() {
     setCheckingEndpoint(true);
     setEndpointCheck(null);
+    setContextResult(null);
     startTransition(async () => {
       try {
-        setEndpointCheck(await checkLocalEndpoint(opencodeModel));
+        const result = await checkLocalEndpoint(opencodeModel);
+        setEndpointCheck(result);
+        // Prefill the context input with the real served size (or the floor) so
+        // the operator edits from the truth, not a blank box.
+        if (typeof result.servedContextTokens === "number" && result.servedContextTokens > 0) {
+          setContextTokens(String(result.servedContextTokens));
+        } else if (!contextTokens) {
+          setContextTokens("22000");
+        }
       } catch (err) {
         setEndpointCheck({ ok: false, resolvedModel: null, models: [], contextOk: false, reason: (err as Error).message });
       } finally {
         setCheckingEndpoint(false);
+      }
+    });
+  }
+
+  function applyContext() {
+    const model = endpointCheck?.resolvedModel || opencodeModel.trim();
+    const tokens = Number(contextTokens);
+    setContextResult(null);
+    setApplyingContext(true);
+    startTransition(async () => {
+      try {
+        const res = await applyLocalModelContext(model, tokens);
+        setContextResult({ ok: res.ok, reason: res.reason });
+        if (res.preflight) setEndpointCheck(res.preflight);
+      } catch (err) {
+        setContextResult({ ok: false, reason: (err as Error).message });
+      } finally {
+        setApplyingContext(false);
       }
     });
   }
@@ -434,7 +466,7 @@ export function BuildStudioConfigForm({
                   value={opencodeModel}
                   onChange={e => setOpencodeModel(e.target.value)}
                   disabled={!canWrite}
-                  placeholder="auto (first served model)"
+                  placeholder="auto (first coding model)"
                   style={{
                     width: 200,
                     fontSize: 11,
@@ -447,9 +479,65 @@ export function BuildStudioConfigForm({
                 />
               </label>
               <p style={{ fontSize: 10, color: "var(--dpf-muted)", marginBottom: 8 }}>
-                Leave blank to use the first model your local endpoint serves. A coding model
-                with ≥22k context (e.g. a qwen3-coder build) is recommended.
+                Leave blank to use the first <strong>coding</strong> model your endpoint serves
+                (embedding models like nomic-embed are skipped). A coding model with ≥22k context
+                (e.g. a qwen3-coder build) is recommended — set the context window below if your
+                runtime serves it lower.
               </p>
+
+              {/* (a) Per-model served context window — applied to the local runtime
+                  (Docker Model Runner) over HTTP; the operator never touches Docker. */}
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+                <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--dpf-text)" }}>
+                  Context window:
+                  <input
+                    type="number"
+                    min={1024}
+                    step={1024}
+                    value={contextTokens}
+                    onChange={e => setContextTokens(e.target.value)}
+                    disabled={!canWrite}
+                    placeholder="22000"
+                    style={{
+                      width: 110,
+                      fontSize: 11,
+                      padding: "2px 6px",
+                      border: "1px solid var(--dpf-border)",
+                      borderRadius: 4,
+                      background: "var(--dpf-bg)",
+                      color: "var(--dpf-text)",
+                    }}
+                  />
+                  <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>tokens</span>
+                </label>
+                {canWrite && (
+                  <button
+                    type="button"
+                    onClick={applyContext}
+                    disabled={applyingContext || !contextTokens}
+                    style={{
+                      padding: "4px 12px",
+                      fontSize: 11,
+                      fontWeight: 600,
+                      background: "var(--dpf-surface-2)",
+                      color: "var(--dpf-text)",
+                      border: "1px solid var(--dpf-border)",
+                      borderRadius: 6,
+                      cursor: applyingContext ? "wait" : "pointer",
+                    }}
+                  >
+                    {applyingContext ? "Applying…" : "Apply to local runtime"}
+                  </button>
+                )}
+              </div>
+              {contextResult && (
+                <div role="status" style={{ marginBottom: 8, fontSize: 11, color: contextResult.ok ? "var(--dpf-success)" : "var(--dpf-error)" }}>
+                  {contextResult.ok
+                    ? "✓ Context window applied to the local runtime. It takes effect the next time the model loads."
+                    : <>⚠ {contextResult.reason}</>}
+                </div>
+              )}
+
               {canWrite && (
                 <button
                   type="button"
@@ -482,6 +570,11 @@ export function BuildStudioConfigForm({
                     <>
                       ✓ Endpoint reachable — will dispatch to{" "}
                       <strong>{endpointCheck.resolvedModel}</strong>.
+                      {typeof endpointCheck.servedContextTokens === "number" && endpointCheck.servedContextTokens > 0 && (
+                        <span style={{ color: "var(--dpf-muted)" }}>
+                          {" "}Served context: {endpointCheck.servedContextTokens.toLocaleString()} tokens.
+                        </span>
+                      )}
                       {endpointCheck.models.length > 0 && (
                         <span style={{ color: "var(--dpf-muted)" }}>
                           {" "}Models served: {endpointCheck.models.join(", ")}.
@@ -493,6 +586,20 @@ export function BuildStudioConfigForm({
                   )}
                 </div>
               )}
+              {/* (b) Non-fatal advisories (e.g. embedding model selected). */}
+              {endpointCheck?.warnings?.map((w, i) => (
+                <div key={i} role="status" style={{ marginTop: 6, fontSize: 11, color: "var(--dpf-warning)" }}>
+                  ⚠ {w}
+                </div>
+              ))}
+
+              <p style={{ fontSize: 10, color: "var(--dpf-muted)", marginTop: 10 }}>
+                Running fully offline? Turn on{" "}
+                <Link href="/platform/ai/providers" style={{ color: "var(--dpf-accent)", textDecoration: "underline" }}>
+                  local-only inference
+                </Link>{" "}
+                in Providers &amp; Routing so every build phase stays on local with no silent cloud fallback.
+              </p>
             </div>
           )}
         </section>

--- a/apps/web/components/platform/LocalOnlyInferenceToggle.tsx
+++ b/apps/web/components/platform/LocalOnlyInferenceToggle.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { setLocalOnlyInferenceSetting } from "@/lib/actions/build-studio";
+
+type Props = {
+  initialEnabled: boolean;
+  canWrite: boolean;
+};
+
+/**
+ * "Local-only inference (disable cloud)" switch for Providers & Routing.
+ *
+ * When ON, every routed AI call is pinned to the local provider; calls no local
+ * model can serve fail loudly rather than silently using a configured cloud
+ * provider. The discoverable, one-switch alternative to disabling each cloud
+ * provider by hand (which leaves a silent-fallback footgun if one is missed).
+ */
+export function LocalOnlyInferenceToggle({ initialEnabled, canWrite }: Props) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function toggle(next: boolean) {
+    setError(null);
+    const prev = enabled;
+    setEnabled(next); // optimistic
+    startTransition(async () => {
+      try {
+        await setLocalOnlyInferenceSetting(next);
+      } catch (err) {
+        setEnabled(prev); // revert on failure
+        setError((err as Error).message);
+      }
+    });
+  }
+
+  return (
+    <div
+      style={{
+        marginBottom: 24,
+        border: `1px solid ${enabled ? "var(--dpf-accent)" : "var(--dpf-border)"}`,
+        borderRadius: 8,
+        padding: "12px 14px",
+        background: "var(--dpf-surface-1)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+        <div style={{ maxWidth: 640 }}>
+          <div style={{ color: "var(--dpf-accent)", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
+            Local-only inference
+          </div>
+          <p style={{ margin: 0, fontSize: 12, color: "var(--dpf-text)" }}>
+            Route every AI call to your local model and <strong>never fall back to cloud</strong>.
+            When on, a call that no local model can serve fails loudly (&ldquo;no eligible local
+            model&rdquo;) instead of silently using a cloud provider — so a fully-local Build Studio
+            run executes every phase (ideate / plan / review / build) on local.
+          </p>
+          <p style={{ margin: "6px 0 0", fontSize: 11, color: "var(--dpf-muted)" }}>
+            This is the one-switch guarantee; you don&rsquo;t have to disable each cloud provider by
+            hand. Disabled providers below still stay excluded.
+          </p>
+          {error && <p style={{ margin: "6px 0 0", fontSize: 11, color: "var(--dpf-error)" }}>⚠ {error}</p>}
+        </div>
+
+        <label style={{ display: "inline-flex", alignItems: "center", gap: 8, cursor: canWrite ? "pointer" : "not-allowed", whiteSpace: "nowrap" }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={!canWrite || isPending}
+            onChange={(e) => toggle(e.target.checked)}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: enabled ? "var(--dpf-accent)" : "var(--dpf-muted)" }}>
+            {enabled ? "On — cloud disabled" : "Off — cloud allowed"}
+          </span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/build-studio.ts
+++ b/apps/web/lib/actions/build-studio.ts
@@ -4,8 +4,10 @@ import { prisma, type Prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
-import { getOllamaBaseUrl } from "@/lib/inference/ollama-url";
-import { preflightLocalEndpoint, type LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
+import { getOllamaBaseUrl, getOllamaApiRoot } from "@/lib/inference/ollama-url";
+import { preflightLocalEndpoint, OPENCODE_MIN_CONTEXT_TOKENS, type LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
+import { setServedContextTokens } from "@/lib/inference/dmr-runtime-config";
+import { getLocalOnlyInference, setLocalOnlyInference } from "@/lib/inference/local-only";
 
 async function requireManageProviders(): Promise<string> {
   const session = await auth();
@@ -86,5 +88,77 @@ export async function checkLocalEndpoint(
 ): Promise<LocalEndpointPreflight> {
   await requireManageProviders();
   const portalBaseUrl = getOllamaBaseUrl().replace(/\/$/, "");
-  return preflightLocalEndpoint(portalBaseUrl, model ?? "");
+  // checkServedContext: read the authoritative runtime context window so the
+  // UX shows the real served size (e.g. a 32768 override) and warns/blocks
+  // below the agent floor — not the misleading /v1/models artifact default.
+  return preflightLocalEndpoint(portalBaseUrl, model ?? "", fetch, { checkServedContext: true });
+}
+
+const MIN_CONTEXT_FLOOR = 1024;
+const MAX_CONTEXT_CEILING = 1_048_576; // 1M — generous upper guard; DMR rejects values a model can't serve
+
+/**
+ * Raise (or lower) the served context window of a local model via Docker Model
+ * Runner's runtime configure API — the operator never touches Docker. Persists
+ * the value to the matching local ModelProfile.maxContextTokens so routing and
+ * the dispatch preflight use the real number, then returns a fresh preflight.
+ *
+ * Gated on manage-providers. The model id is the one `/v1/models` reports
+ * (e.g. "docker.io/ai/qwen3-coder:latest"); DMR matches it leniently.
+ */
+export async function applyLocalModelContext(
+  model: string,
+  contextTokens: number,
+): Promise<{ ok: boolean; reason: string | null; preflight: LocalEndpointPreflight | null }> {
+  await requireManageProviders();
+
+  const trimmed = (model ?? "").trim();
+  if (!trimmed) {
+    return { ok: false, reason: "No model specified. Resolve the served model first (Test local endpoint).", preflight: null };
+  }
+  if (!Number.isFinite(contextTokens) || !Number.isInteger(contextTokens)) {
+    return { ok: false, reason: "Context window must be a whole number of tokens.", preflight: null };
+  }
+  if (contextTokens < MIN_CONTEXT_FLOOR || contextTokens > MAX_CONTEXT_CEILING) {
+    return { ok: false, reason: `Context window must be between ${MIN_CONTEXT_FLOOR} and ${MAX_CONTEXT_CEILING} tokens.`, preflight: null };
+  }
+  if (contextTokens < OPENCODE_MIN_CONTEXT_TOKENS) {
+    // Allowed (operator may know better), but make the consequence explicit.
+    console.warn(`[build-studio] applyLocalModelContext set ${trimmed} to ${contextTokens} (< ${OPENCODE_MIN_CONTEXT_TOKENS} agent floor)`);
+  }
+
+  const apiRoot = getOllamaApiRoot();
+  const applied = await setServedContextTokens(apiRoot, trimmed, contextTokens);
+  if (!applied.ok) {
+    return { ok: false, reason: applied.reason, preflight: null };
+  }
+
+  // Persist to the matching local ModelProfile so routing eligibility + the
+  // dispatch preflight use the real served context (fix-the-seed: the DB row is
+  // the routing source of truth, not the artifact default).
+  await prisma.modelProfile.updateMany({
+    where: { providerId: { in: ["local", "ollama"] }, modelId: trimmed },
+    data: { maxContextTokens: applied.contextTokens ?? contextTokens },
+  });
+
+  const portalBaseUrl = getOllamaBaseUrl().replace(/\/$/, "");
+  const preflight = await preflightLocalEndpoint(portalBaseUrl, trimmed, fetch, { checkServedContext: true });
+  return { ok: true, reason: null, preflight };
+}
+
+/** Read the local-only inference (cloud-disabled) switch. */
+export async function getLocalOnlyInferenceSetting(): Promise<boolean> {
+  await requireManageProviders();
+  return getLocalOnlyInference();
+}
+
+/**
+ * Toggle local-only inference. When ON, every routed inference call is pinned
+ * to the local provider (residencyPolicy=local_only) and fails loudly if no
+ * local model qualifies — no silent cloud fallback.
+ */
+export async function setLocalOnlyInferenceSetting(enabled: boolean): Promise<{ ok: true; enabled: boolean }> {
+  await requireManageProviders();
+  await setLocalOnlyInference(enabled);
+  return { ok: true, enabled };
 }

--- a/apps/web/lib/actions/build-studio.ts
+++ b/apps/web/lib/actions/build-studio.ts
@@ -124,7 +124,10 @@ export async function applyLocalModelContext(
   }
   if (contextTokens < OPENCODE_MIN_CONTEXT_TOKENS) {
     // Allowed (operator may know better), but make the consequence explicit.
-    console.warn(`[build-studio] applyLocalModelContext set ${trimmed} to ${contextTokens} (< ${OPENCODE_MIN_CONTEXT_TOKENS} agent floor)`);
+    // Strip control chars from the operator-supplied model id before logging —
+    // neutralizes log injection (CR/LF/control-char forging of log lines).
+    const safeModel = trimmed.replace(/[^a-zA-Z0-9._:@/+-]/g, "");
+    console.warn(`[build-studio] applyLocalModelContext set ${safeModel} to ${contextTokens} (< ${OPENCODE_MIN_CONTEXT_TOKENS} agent floor)`);
   }
 
   const apiRoot = getOllamaApiRoot();

--- a/apps/web/lib/inference/dmr-runtime-config.test.ts
+++ b/apps/web/lib/inference/dmr-runtime-config.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { getServedContextTokens, setServedContextTokens } from "./dmr-runtime-config";
+
+const API_ROOT = "http://model-runner.docker.internal";
+
+describe("getServedContextTokens", () => {
+  it("parses the context-size from a DMR configure response", async () => {
+    const fetchImpl = (async (url: string) => {
+      expect(url).toContain("/engines/_configure?model=");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [{ Backend: "llama.cpp", Model: "docker.io/ai/qwen3-coder:latest", Config: { "context-size": 32768 } }],
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const res = await getServedContextTokens(API_ROOT, "qwen3-coder", fetchImpl);
+    expect(res.supported).toBe(true);
+    expect(res.contextTokens).toBe(32768);
+  });
+
+  it("reports supported=true, contextTokens=null when no runtime override is set", async () => {
+    const fetchImpl = (async () => ({ ok: true, status: 200, json: async () => [] })) as unknown as typeof fetch;
+    const res = await getServedContextTokens(API_ROOT, "gemma4:12B", fetchImpl);
+    expect(res.supported).toBe(true);
+    expect(res.contextTokens).toBeNull();
+  });
+
+  it("reports supported=false on 404 (endpoint not available)", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 404, json: async () => [], text: async () => "" })) as unknown as typeof fetch;
+    const res = await getServedContextTokens(API_ROOT, "x", fetchImpl);
+    expect(res.supported).toBe(false);
+    expect(res.contextTokens).toBeNull();
+  });
+
+  it("never throws on a network error", async () => {
+    const fetchImpl = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    const res = await getServedContextTokens(API_ROOT, "x", fetchImpl);
+    expect(res.supported).toBe(false);
+    expect(res.reason).toContain("unreachable");
+  });
+});
+
+describe("setServedContextTokens", () => {
+  it("POSTs the model + context-size and verifies by read-back", async () => {
+    const calls: Array<{ method?: string; body?: string }> = [];
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      calls.push({ method: init?.method, body: init?.body as string | undefined });
+      if (init?.method === "POST") {
+        return { ok: true, status: 200, json: async () => ({}), text: async () => "{}" } as unknown as Response;
+      }
+      // verification read-back
+      return { ok: true, status: 200, json: async () => [{ Config: { "context-size": 32768 } }] } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const res = await setServedContextTokens(API_ROOT, "qwen3-coder", 32768, fetchImpl);
+    expect(res.ok).toBe(true);
+    expect(res.contextTokens).toBe(32768);
+    const post = calls.find((c) => c.method === "POST");
+    expect(post?.body).toBe(JSON.stringify({ model: "qwen3-coder", "context-size": 32768 }));
+  });
+
+  it("surfaces a 404 as an unsupported-runtime reason", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 404, text: async () => "" })) as unknown as typeof fetch;
+    const res = await setServedContextTokens(API_ROOT, "x", 22000, fetchImpl);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/does not expose/i);
+  });
+
+  it("surfaces a non-OK write (e.g. runner already active) with detail", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 409, text: async () => "runner already active" })) as unknown as typeof fetch;
+    const res = await setServedContextTokens(API_ROOT, "x", 22000, fetchImpl);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/runner already active/i);
+  });
+});

--- a/apps/web/lib/inference/dmr-runtime-config.ts
+++ b/apps/web/lib/inference/dmr-runtime-config.ts
@@ -1,0 +1,131 @@
+// apps/web/lib/inference/dmr-runtime-config.ts
+//
+// Read/write Docker Model Runner (DMR) per-model RUNTIME configuration — most
+// importantly the served context window (`context-size`) — over DMR's HTTP API,
+// so an operator can raise a local coding model to >= 22k tokens from the admin
+// UX WITHOUT touching Docker.
+//
+// Why HTTP and not the CLI: `docker model configure --context-size N` is the
+// supported host-side mechanism, but the portal image ships `/usr/bin/docker`
+// WITHOUT the `docker model` CLI plugin (`docker: unknown command: docker
+// model`). The CLI is a thin client over a model-runner HTTP endpoint that the
+// portal CAN reach at the management root:
+//
+//   GET  /engines/_configure?model=<name>
+//        -> [{ Backend, Model, ModelID, Mode, Config: { "context-size": N } }]
+//   POST /engines/_configure   body: {"model":"<name>","context-size":<N>}
+//
+// (Contract captured live against docker-model-cli/v1.1.37 + Docker Desktop
+// DMR, 2026-06-15 — re-verify on a DMR bump. The `_configure` path is an
+// internal engines sub-route; treat a 404 as "this endpoint does not support
+// runtime configuration" and degrade gracefully rather than throwing.)
+//
+// The model name is matched leniently by DMR (short `qwen3-coder`, `ai/...`,
+// and the full `docker.io/ai/qwen3-coder:latest` tag all resolve), so callers
+// pass the same model id the OpenAI `/v1/models` endpoint reports.
+//
+// `apiRoot` is the management root (NO `/v1` suffix) — callers compute it with
+// `getOllamaApiRoot()`, which strips the OpenAI-compatible inference prefix.
+
+/** DMR `_configure` GET response shape (array, one entry per backend/model). */
+type DmrConfigureEntry = {
+  Backend?: string;
+  Model?: string;
+  ModelID?: string;
+  Mode?: string;
+  Config?: { "context-size"?: number } & Record<string, unknown>;
+};
+
+export type ServedContextResult = {
+  /** The served context window in tokens, or null when DMR doesn't report one. */
+  contextTokens: number | null;
+  /** False only when the configure endpoint isn't reachable/supported. */
+  supported: boolean;
+  /** Human-readable detail when supported === false. */
+  reason: string | null;
+};
+
+export type ApplyContextResult = {
+  ok: boolean;
+  /** Echoed served context after the write, when DMR reports it back. */
+  contextTokens: number | null;
+  reason: string | null;
+};
+
+function configureUrl(apiRoot: string): string {
+  return `${apiRoot.replace(/\/$/, "")}/engines/_configure`;
+}
+
+/**
+ * Read the runtime-configured served context window for a local model from DMR.
+ *
+ * Best-effort: returns `{ supported: false }` (never throws) when the endpoint
+ * is missing (non-DMR local server, older DMR) or unreachable, so callers can
+ * fall back to the `/v1/models`-reported context or the documented floor.
+ */
+export async function getServedContextTokens(
+  apiRoot: string,
+  model: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ServedContextResult> {
+  const url = `${configureUrl(apiRoot)}?model=${encodeURIComponent(model)}`;
+  try {
+    const res = await fetchImpl(url, { method: "GET" });
+    if (res.status === 404) {
+      return { contextTokens: null, supported: false, reason: "Local runtime does not expose a context-size configuration API." };
+    }
+    if (!res.ok) {
+      return { contextTokens: null, supported: false, reason: `Configure endpoint returned HTTP ${res.status}.` };
+    }
+    const body = (await res.json()) as DmrConfigureEntry[] | DmrConfigureEntry;
+    const entries = Array.isArray(body) ? body : [body];
+    for (const entry of entries) {
+      const size = entry?.Config?.["context-size"];
+      if (typeof size === "number" && size > 0) {
+        return { contextTokens: size, supported: true, reason: null };
+      }
+    }
+    // Endpoint exists but no runtime override is set for this model.
+    return { contextTokens: null, supported: true, reason: null };
+  } catch (err) {
+    return { contextTokens: null, supported: false, reason: `Configure endpoint unreachable: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * Set the served context window for a local model via DMR's configure API.
+ *
+ * The runtime config persists across model loads (it is stored by DMR, not the
+ * loaded runner). A change takes effect the next time the model is loaded; DMR
+ * refuses to reconfigure a model whose runner is already active ("runner
+ * already active"), which is surfaced in `reason` so the caller can ask the
+ * operator to retry once the model idles/unloads.
+ */
+export async function setServedContextTokens(
+  apiRoot: string,
+  model: string,
+  contextTokens: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ApplyContextResult> {
+  const url = configureUrl(apiRoot);
+  try {
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, "context-size": contextTokens }),
+    });
+    if (res.status === 404) {
+      return { ok: false, contextTokens: null, reason: "Local runtime does not expose a context-size configuration API (Docker Model Runner update may be required)." };
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      const detail = text.trim().slice(0, 300);
+      return { ok: false, contextTokens: null, reason: `Configure request failed: HTTP ${res.status}${detail ? ` — ${detail}` : ""}.` };
+    }
+    // Confirm by reading the value back — DMR's POST body is often empty `{}`.
+    const verify = await getServedContextTokens(apiRoot, model, fetchImpl);
+    return { ok: true, contextTokens: verify.contextTokens, reason: null };
+  } catch (err) {
+    return { ok: false, contextTokens: null, reason: `Configure endpoint unreachable: ${(err as Error).message}` };
+  }
+}

--- a/apps/web/lib/inference/local-only.ts
+++ b/apps/web/lib/inference/local-only.ts
@@ -1,0 +1,62 @@
+// apps/web/lib/inference/local-only.ts
+//
+// "Local-only inference" platform switch — the discoverable, first-class way an
+// operator disables cloud AI for the WHOLE platform. When ON, every routed
+// inference call (coworker chat, Build Studio ideate/plan/review, evals, …) is
+// pinned to the bundled local provider via the existing `residencyPolicy:
+// "local_only"` routing constraint. If no local model can satisfy a request,
+// routing fails LOUDLY (NoEligibleEndpointsError) rather than silently falling
+// back to a configured cloud endpoint.
+//
+// This is deliberately broader than "disable each cloud provider": leaving one
+// provider active is the silent-fallback footgun this switch removes. It
+// composes with per-provider status — a disabled provider is still excluded —
+// but it does not depend on the operator having disabled them one by one.
+//
+// Stored in PlatformConfig (key below). Read on the hot inference path, so a
+// small TTL cache avoids a DB round-trip per call; the setter invalidates it so
+// the toggle takes effect promptly.
+
+import { prisma } from "@dpf/db";
+
+export const LOCAL_ONLY_INFERENCE_CONFIG_KEY = "inference-local-only";
+
+type LocalOnlyConfigValue = { enabled?: boolean };
+
+let cached: { value: boolean; at: number } | null = null;
+const TTL_MS = 5_000;
+
+/** Clear the in-memory cache (used by the setter and by tests). */
+export function invalidateLocalOnlyInferenceCache(): void {
+  cached = null;
+}
+
+/**
+ * True when local-only inference is enabled. Defaults to false (cloud allowed).
+ * Never throws — a DB error degrades to the permissive default so inference is
+ * not bricked by a config-read failure.
+ */
+export async function getLocalOnlyInference(now: number = Date.now()): Promise<boolean> {
+  if (cached && now - cached.at < TTL_MS) return cached.value;
+  try {
+    const row = await prisma.platformConfig.findUnique({
+      where: { key: LOCAL_ONLY_INFERENCE_CONFIG_KEY },
+    });
+    const value = !!(row?.value && typeof row.value === "object" && (row.value as LocalOnlyConfigValue).enabled === true);
+    cached = { value, at: now };
+    return value;
+  } catch (err) {
+    console.error("[local-only] failed to read inference-local-only config:", err);
+    return false;
+  }
+}
+
+/** Persist the local-only inference switch and invalidate the read cache. */
+export async function setLocalOnlyInference(enabled: boolean): Promise<void> {
+  await prisma.platformConfig.upsert({
+    where: { key: LOCAL_ONLY_INFERENCE_CONFIG_KEY },
+    update: { value: { enabled } },
+    create: { key: LOCAL_ONLY_INFERENCE_CONFIG_KEY, value: { enabled } },
+  });
+  invalidateLocalOnlyInferenceCache();
+}

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -21,6 +21,7 @@ import {
 } from "@/lib/routing/loader";
 import { routeEndpointV2 } from "@/lib/routing/pipeline-v2";
 import { callWithFallbackChain } from "@/lib/routing/fallback";
+import { getLocalOnlyInference } from "@/lib/inference/local-only";
 import { logTokenUsage } from "@/lib/ai-inference";
 import type { RouteDecisionActor } from "@/lib/routing/route-decision-attribution";
 
@@ -189,6 +190,13 @@ export async function routeAndCall(
 ): Promise<RoutedInferenceResult> {
   const taskType = options?.taskType ?? "conversation";
 
+  // Local-only inference (cloud disabled): the operator-set platform switch.
+  // When ON, force residencyPolicy=local_only for EVERY call so routing never
+  // selects a cloud endpoint — it routes local or fails loudly below. This is
+  // authoritative over a task requirement's residency, and the guarantee the
+  // "disable cloud" admin toggle promises (no silent per-phase cloud fallback).
+  const localOnlyInference = await getLocalOnlyInference();
+
   // 1. Infer contract
   const contract = await inferContract(
     taskType,
@@ -203,6 +211,7 @@ export async function routeAndCall(
       requiresComputerUse: options?.requiresComputerUse,
       budgetClass: options?.budgetClass,
       requiredModelClass: options?.requiredModelClass,
+      ...(localOnlyInference ? { residencyPolicy: "local_only" as const } : {}),
     },
   );
 
@@ -289,11 +298,14 @@ export async function routeAndCall(
   // stripping destroys task semantics. Fail fast instead of silently degrading.
   if (!decision.selectedEndpoint && contract.requiresTools) {
     if (options?.requireTools) {
+      const fix = contract.residencyPolicy === "local_only"
+        ? `Local-only inference is ON (cloud disabled), so routing will not fall back to a cloud provider. ` +
+          `Enable a tool-capable LOCAL model (or run the build through the opencode engine, which supplies the tool loop), ` +
+          `or turn off local-only inference in Admin > AI > Providers & Routing.`
+        : `Configure a tool-capable provider (OpenAI, Anthropic, Gemini) or check that existing providers are active.`;
       throw new NoEligibleEndpointsError(
         taskType,
-        `No tool-capable endpoint available. Build Studio requires tool support — ` +
-        `cannot fall back to generic chat. Configure a tool-capable provider (OpenAI, Anthropic, Gemini) ` +
-        `or check that existing providers are active.`,
+        `No tool-capable endpoint available. Build Studio requires tool support — cannot fall back to generic chat. ${fix}`,
         decision.excludedCount,
       );
     }
@@ -311,6 +323,20 @@ export async function routeAndCall(
   }
 
   if (!decision.selectedEndpoint) {
+    // Local-only inference: fail LOUDLY and specifically rather than letting the
+    // generic "no eligible endpoints" mask the real cause (cloud is disabled and
+    // no local model qualified for this task's tier/capability/context).
+    if (contract.residencyPolicy === "local_only") {
+      throw new NoEligibleEndpointsError(
+        taskType,
+        `No eligible LOCAL model for task '${taskType}' (sensitivity '${sensitivity}'). ` +
+        `Local-only inference is ON, so cloud providers are excluded and routing will NOT silently fall back to cloud. ` +
+        `Pull or enable a local model that meets this task's requirements (tool support, context window, quality tier), ` +
+        `raise the model's context window in Build Runtime, or turn off local-only inference in Admin > AI > Providers & Routing. ` +
+        `Router detail: ${decision.reason}`,
+        decision.excludedCount,
+      );
+    }
     throw new NoEligibleEndpointsError(
       taskType,
       decision.reason,

--- a/apps/web/lib/integrate/opencode-dispatch.test.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.test.ts
@@ -3,6 +3,7 @@ import {
   sandboxReachableUrl,
   preflightLocalEndpoint,
   pickDefaultCodingModel,
+  isEmbeddingModelId,
   buildOpencodeConfig,
   summarizeOpencodeEvent,
   extractOpencodeResult,
@@ -180,5 +181,84 @@ describe("extractOpencodeResult", () => {
 
   it("falls back to raw stdout when no recognized events", () => {
     expect(extractOpencodeResult("just text output")).toBe("just text output");
+  });
+});
+
+describe("isEmbeddingModelId", () => {
+  it("flags embedding / non-chat model families", () => {
+    expect(isEmbeddingModelId("docker.io/ai/nomic-embed-text-v1.5:latest")).toBe(true);
+    expect(isEmbeddingModelId("bge-m3")).toBe(true);
+    expect(isEmbeddingModelId("all-minilm:latest")).toBe(true);
+    expect(isEmbeddingModelId("whisper-base")).toBe(true);
+  });
+  it("does not flag coding/chat models", () => {
+    expect(isEmbeddingModelId("docker.io/ai/qwen3-coder:latest")).toBe(false);
+    expect(isEmbeddingModelId("gemma4:12B")).toBe(false);
+  });
+});
+
+// A fetch double that branches on whether the URL is the /models list or the
+// DMR /engines/_configure runtime-config endpoint.
+function urlAwareFetch(opts: {
+  models: string[];
+  configContextSize?: number | null; // null => configure endpoint 404 (unsupported)
+}) {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/engines/_configure")) {
+      if (opts.configContextSize === null || opts.configContextSize === undefined) {
+        return { ok: false, status: 404, json: async () => [], text: async () => "" } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [{ Backend: "llama.cpp", Model: opts.models[0], Config: { "context-size": opts.configContextSize } }],
+      } as unknown as Response;
+    }
+    // /models list
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: opts.models.map((id) => ({ id })) }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("preflightLocalEndpoint — embedding warnings + served context (a/b)", () => {
+  it("warns when an embedding model is explicitly selected", async () => {
+    const fetchImpl = urlAwareFetch({ models: ["docker.io/ai/nomic-embed-text-v1.5:latest", "docker.io/ai/qwen3-coder:latest"] });
+    const res = await preflightLocalEndpoint("http://localhost:11434/v1", "docker.io/ai/nomic-embed-text-v1.5:latest", fetchImpl);
+    expect(res.ok).toBe(true); // served + present, but…
+    expect(res.warnings?.some((w) => /embedding model/i.test(w))).toBe(true);
+  });
+
+  it("gives an actionable message when only embedding models are served", async () => {
+    const fetchImpl = urlAwareFetch({ models: ["docker.io/ai/nomic-embed-text-v1.5:latest", "all-minilm:latest"] });
+    const res = await preflightLocalEndpoint("http://localhost:11434/v1", "", fetchImpl);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/embedding/i);
+    expect(res.reason).toMatch(/coding model/i);
+  });
+
+  it("reads the authoritative served context and BLOCKS below the floor", async () => {
+    const fetchImpl = urlAwareFetch({ models: ["docker.io/ai/qwen3-coder:latest"], configContextSize: 4096 });
+    const res = await preflightLocalEndpoint("http://localhost:11434/v1", "docker.io/ai/qwen3-coder:latest", fetchImpl, { checkServedContext: true });
+    expect(res.ok).toBe(false);
+    expect(res.servedContextTokens).toBe(4096);
+    expect(res.reason).toMatch(/context/i);
+  });
+
+  it("passes and reports the served context when it clears the floor", async () => {
+    const fetchImpl = urlAwareFetch({ models: ["docker.io/ai/qwen3-coder:latest"], configContextSize: 32768 });
+    const res = await preflightLocalEndpoint("http://localhost:11434/v1", "docker.io/ai/qwen3-coder:latest", fetchImpl, { checkServedContext: true });
+    expect(res.ok).toBe(true);
+    expect(res.servedContextTokens).toBe(32768);
+  });
+
+  it("degrades gracefully when the runtime has no configure API (404)", async () => {
+    const fetchImpl = urlAwareFetch({ models: ["docker.io/ai/qwen3-coder:latest"], configContextSize: null });
+    const res = await preflightLocalEndpoint("http://localhost:11434/v1", "docker.io/ai/qwen3-coder:latest", fetchImpl, { checkServedContext: true });
+    expect(res.ok).toBe(true);
+    expect(res.servedContextTokens).toBeNull();
   });
 });

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -24,6 +24,7 @@
 
 import type { AssignedTask, SpecialistRole } from "./task-dependency-graph";
 import { getOllamaBaseUrl } from "@/lib/inference/ollama-url";
+import { getServedContextTokens } from "@/lib/inference/dmr-runtime-config";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
 
@@ -35,7 +36,7 @@ const OPENCODE_SCHEMA_TASK_TIMEOUT_MS = Number(process.env.OPENCODE_SCHEMA_TASK_
 // Real agent runs consume 39k–156k tokens; a serving context below this fails
 // outright. Advisory floor — /v1/models rarely exposes context length, so this
 // is enforced only when the endpoint reports it (see preflightLocalEndpoint).
-const OPENCODE_MIN_CONTEXT_TOKENS = Number(process.env.OPENCODE_MIN_CONTEXT_TOKENS) || 22_000;
+export const OPENCODE_MIN_CONTEXT_TOKENS = Number(process.env.OPENCODE_MIN_CONTEXT_TOKENS) || 22_000;
 
 export type OpencodeResult = {
   content: string;
@@ -50,7 +51,33 @@ export type LocalEndpointPreflight = {
   models: string[];
   contextOk: boolean;       // false only when the endpoint reports a context below the floor
   reason: string | null;    // BLOCKED-classifiable message when ok === false
+  /**
+   * The authoritative served context window (tokens) read from the local
+   * runtime's runtime-config API, when available. null when the runtime does
+   * not report it. Distinct from the `/v1/models`-advertised context, which on
+   * Docker Model Runner is the artifact default, not the runtime override.
+   */
+  servedContextTokens?: number | null;
+  /**
+   * Non-fatal advisories the operator should see (e.g. an embedding model was
+   * selected, or the served context is below the agent floor). Surfaced in the
+   * Build Runtime UX without forcing ok === false.
+   */
+  warnings?: string[];
 };
+
+// Non-chat model families a local OpenAI-compatible endpoint commonly also
+// serves (embeddings, rerankers, STT/TTS). These cannot run a coding agent
+// loop. Single source of truth for pickDefaultCodingModel + isEmbeddingModelId.
+const NON_CHAT_MODEL_RE = /embed|nomic|bge[-_]|rerank|whisper|\bstt\b|\btts\b|clip|vision-embed|minilm|gte|e5/i;
+
+/**
+ * True when a model id looks like an embedding / non-chat model that cannot run
+ * a coding agent. Used to warn an operator who selected one explicitly.
+ */
+export function isEmbeddingModelId(modelId: string): boolean {
+  return NON_CHAT_MODEL_RE.test(modelId);
+}
 
 /**
  * Rewrite the portal's view of the local endpoint into one the sandbox
@@ -87,8 +114,7 @@ type OpenAiModelsResponse = {
  * then any remaining chat model. Returns null only when nothing usable is served.
  */
 export function pickDefaultCodingModel(models: string[]): string | null {
-  const NON_CHAT_RE = /embed|nomic|bge[-_]|rerank|whisper|\bstt\b|\btts\b|clip|vision-embed|minilm|gte|e5/i;
-  const chatModels = models.filter((m) => !NON_CHAT_RE.test(m));
+  const chatModels = models.filter((m) => !NON_CHAT_MODEL_RE.test(m));
   return (
     chatModels.find((m) => /coder|[-_]code\b|code[-_]/i.test(m)) ??
     chatModels.find((m) => /qwen3/i.test(m)) ??
@@ -101,6 +127,15 @@ export async function preflightLocalEndpoint(
   portalBaseUrl: string,
   requestedModel: string,
   fetchImpl: typeof fetch = fetch,
+  opts?: {
+    /**
+     * Also read the authoritative served context window from the runtime's
+     * configure API (Docker Model Runner `/engines/_configure`) and enforce the
+     * >= OPENCODE_MIN_CONTEXT_TOKENS floor against it. Off by default so the
+     * pure model-list preflight stays a single call.
+     */
+    checkServedContext?: boolean;
+  },
 ): Promise<LocalEndpointPreflight> {
   const base = portalBaseUrl.replace(/\/$/, "");
   const url = `${base}/models`;
@@ -121,32 +156,64 @@ export async function preflightLocalEndpoint(
     return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Local model endpoint ${url} returned no models. Pull a coding model first (e.g. a qwen3-coder build).` };
   }
 
-  const resolvedModel = requestedModel && models.includes(requestedModel)
-    ? requestedModel
-    : requestedModel
+  const requested = requestedModel.trim();
+  const resolvedModel = requested && models.includes(requested)
+    ? requested
+    : requested
       ? null
       : pickDefaultCodingModel(models);
 
   if (!resolvedModel) {
-    return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Requested model "${requestedModel}" is not served by the local endpoint. Available: ${models.join(", ")}.` };
+    // Distinguish "you named a model we don't serve" from "you named nothing
+    // and everything served is an embedding model" — the latter is the
+    // nomic-embed footgun and deserves its own actionable message.
+    if (!requested && models.every(isEmbeddingModelId)) {
+      return { ok: false, resolvedModel: null, models, contextOk: false, reason: `The local endpoint only serves embedding / non-chat models (${models.join(", ")}). Pull a CODING model (e.g. a qwen3-coder build) before running a build.` };
+    }
+    return { ok: false, resolvedModel: null, models, contextOk: false, reason: `Requested model "${requested}" is not served by the local endpoint. Available: ${models.join(", ")}.` };
   }
 
-  // Best-effort context check: only enforced when the endpoint reports a context
-  // length for the resolved model. Most OpenAI-compatible /v1/models responses
-  // omit it, in which case we proceed and rely on the documented model floor.
+  const warnings: string[] = [];
+  // (b) Warn when the operator explicitly selected an embedding model — it
+  // cannot run a coding agent loop, even though it's served.
+  if (requested && isEmbeddingModelId(resolvedModel)) {
+    warnings.push(`"${resolvedModel}" looks like an embedding model — it cannot run a coding agent. Choose a coding model (e.g. a qwen3-coder build).`);
+  }
+
+  // Best-effort /v1/models context check: only enforced when the endpoint
+  // reports a context length for the resolved model. Most OpenAI-compatible
+  // /v1/models responses omit it (Docker Model Runner reports the artifact
+  // default, not the runtime override), in which case we fall through to the
+  // authoritative served-context read below.
   const entry = entries.find((m) => m.id === resolvedModel);
   const reported = entry?.context_length ?? entry?.context_window ?? entry?.max_context_length;
-  if (typeof reported === "number" && reported > 0 && reported < OPENCODE_MIN_CONTEXT_TOKENS) {
+
+  // (a) Authoritative served-context read from the runtime configure API.
+  // This is the real served window (e.g. a `docker model configure
+  // --context-size 32768` override) that /v1/models does NOT reflect.
+  let servedContextTokens: number | null = null;
+  if (opts?.checkServedContext) {
+    const apiRoot = base.replace(/\/(engines\/)?v1\/?$/, "");
+    const served = await getServedContextTokens(apiRoot, resolvedModel, fetchImpl);
+    servedContextTokens = served.contextTokens;
+  }
+
+  // Enforce the floor against the most authoritative number available: the
+  // served-context override wins; otherwise the /v1/models-reported value.
+  const effectiveContext = servedContextTokens ?? (typeof reported === "number" && reported > 0 ? reported : null);
+  if (effectiveContext !== null && effectiveContext < OPENCODE_MIN_CONTEXT_TOKENS) {
     return {
       ok: false,
       resolvedModel,
       models,
       contextOk: false,
-      reason: `Model "${resolvedModel}" serves only ${reported} context tokens; agent runs need >= ${OPENCODE_MIN_CONTEXT_TOKENS}. Pull a longer-context model.`,
+      servedContextTokens,
+      warnings,
+      reason: `Model "${resolvedModel}" serves only ${effectiveContext} context tokens; agent runs need >= ${OPENCODE_MIN_CONTEXT_TOKENS}. Raise the model's context window (Build Runtime > local model > context window) or pull a longer-context model.`,
     };
   }
 
-  return { ok: true, resolvedModel, models, contextOk: true, reason: null };
+  return { ok: true, resolvedModel, models, contextOk: true, servedContextTokens, warnings, reason: null };
 }
 
 /**
@@ -274,9 +341,10 @@ export async function dispatchOpencodeTask(params: {
   const portalBaseUrl = getOllamaBaseUrl().replace(/\/$/, "");
   const sandboxBaseUrl = sandboxReachableUrl(portalBaseUrl);
 
-  // Hard preflight: endpoint reachable + model present. A failure here is an
-  // honest BLOCKED, not a silent degrade.
-  const pre = await preflightLocalEndpoint(portalBaseUrl, params.model ?? "", params.fetchImpl ?? fetch);
+  // Hard preflight: endpoint reachable + model present + served context clears
+  // the agent floor. A failure here is an honest BLOCKED, not a silent degrade
+  // (and not a silent truncation when the served context is too small).
+  const pre = await preflightLocalEndpoint(portalBaseUrl, params.model ?? "", params.fetchImpl ?? fetch, { checkServedContext: true });
   if (!pre.ok || !pre.resolvedModel) {
     return {
       content: `BLOCKED: ${pre.reason ?? "local endpoint preflight failed"}`,


### PR DESCRIPTION
## Operator-configurable fully-local Build Studio run

Closes the config gaps that block a fully-local Build Studio run even when the local engine (OpenCode + Docker Model Runner) is installed — all fixable **through the admin UX, no backdoor scripts**. Tracks **BI-594E8782** under **EP-9FC5D2FD** (Build Studio first-customer hardening); extends the BI-01D6A51B local-LLM cluster.

### Ground truth (verified live, 2026-06-15)
- `qwen3-coder` served by DMR — `docker model ls`/`inspect` show the **artifact default 4096**, but the runtime override is **32768** (`docker model configure show`) and the local `ModelProfile.maxContextTokens=32768`. No admin surface showed or set this; the displayed values were inconsistent.
- DMR exposes a configure API the portal reaches over HTTP (the portal image lacks the `docker model` CLI plugin): `GET /engines/_configure?model=<id>` and `POST /engines/_configure {"model","context-size"}`.
- `gemma4:12B` is served but DMR reports **no context** (new arch, no GGUF block) and there's **no active ModelProfile** for it (DB has retired `gemma4:26B`/`:latest`).
- Routing already had `residencyPolicy:"local_only"` (pipeline-v2) but **no first-class, discoverable switch** fed it — so reasoning phases could silently pick an active cloud endpoint.

### What changed
**(a) Per-model context window — `inference/dmr-runtime-config.ts` + Build Runtime UX**
- Read/write DMR's served context over `/engines/_configure` (operator never touches Docker). A new "Context window (tokens)" field + **Apply to local runtime** button raises e.g. qwen3-coder to ≥22k, persists to `ModelProfile.maxContextTokens`, and the preflight now reads + reports the **authoritative served context** (not the misleading `/v1/models` artifact default). Dispatch blocks loudly below the floor instead of silently truncating.

**(b) Honest default-coding-model + embedding warning — `opencode-dispatch.ts` + Build Runtime UX**
- Copy/placeholder now say **"first CODING model"** (matching the `pickDefaultCodingModel` guard), warn when an embedding model is selected, and give a clear "only embedding models served" message.

**(c) Local-only inference (cloud disabled) — `inference/local-only.ts` + `routed-inference.ts` + Providers & Routing toggle**
- A first-class platform switch. When on, `routeAndCall` forces `residencyPolicy=local_only` for **every** phase (ideate/plan/review/build) so routing never silently falls back to cloud; if no local model qualifies it throws a **loud, specific** `NoEligibleEndpointsError` ("no eligible LOCAL model for tier X — cloud is disabled"). One switch instead of disabling each provider by hand (the silent-fallback footgun).

**(d) gemma4:12B** — finding documented; usable as a ≥22k local reasoning model via the (a) context setting (DMR doesn't report its context, so the per-model setting is exactly what it needs).

### Verification (substrate: Build Studio sandbox `dpf-sandbox-1`, node 24 / pnpm 10.33, post-merge with `origin/main@53b44725`)
- `tsc --noEmit` clean across `apps/web` (after `prisma generate` refreshed a stale sandbox client).
- **140 unit tests passed** — `opencode-dispatch`, `dmr-runtime-config`, `pipeline-v2`, `request-contract`.
- `next build` **BUILD_EXIT=0** (`NODE_ENV=production`). (A first attempt failed on `/_global-error` `useContext null` purely because the sandbox shell exports `NODE_ENV=development`; my branch touches none of global-error/error/layout/providers.)
- **Live DMR integration:** `GET/POST /engines/_configure` with the full id `docker.io/ai/qwen3-coder:latest` → `32768 / HTTP 202 / 32768`.

Evidence recorded via `record_local_integration_result` (`cmqg15yz5001m01qy4n32opgm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
