### PR TITLE
fix(inference): reconcile newly-pulled local models + stamp discovery job runs (gemma4 12B)

### DIFF
--- a/apps/web/lib/inference/ollama-health.test.ts
+++ b/apps/web/lib/inference/ollama-health.test.ts
@@ -10,6 +10,9 @@ vi.mock("@dpf/db", () => ({
     modelProfile: {
       count: vi.fn().mockResolvedValue(1),
     },
+    discoveredModel: {
+      aggregate: vi.fn(),
+    },
   },
   syncInfraCI: vi.fn(),
 }));
@@ -33,6 +36,7 @@ import { checkBundledProviders } from "./ollama";
 
 const mockFindFirst = vi.mocked(prisma.modelProvider.findFirst);
 const mockUpdate = vi.mocked(prisma.modelProvider.update);
+const mockDiscoveredAggregate = vi.mocked(prisma.discoveredModel.aggregate);
 const mockAutoDiscover = vi.mocked(autoDiscoverAndProfile);
 const mockQueueEvals = vi.mocked(queueUncalibratedModelEvals);
 const mockSyncInfraCI = vi.mocked(syncInfraCI);
@@ -42,6 +46,9 @@ describe("checkBundledProviders", () => {
     mockFindFirst.mockReset();
     mockUpdate.mockReset();
     mockFetch.mockReset();
+    // Default: local model set was just seen, so the steady-state throttle does
+    // NOT re-enumerate (BI-86CC0266). Stale-case tests override this.
+    mockDiscoveredAggregate.mockReset().mockResolvedValue({ _max: { lastSeenAt: new Date() } } as any);
     mockAutoDiscover.mockReset().mockResolvedValue({ discovered: 2, profiled: 2 });
     mockQueueEvals.mockReset().mockResolvedValue(0);
     mockSyncInfraCI.mockReset();
@@ -164,9 +171,9 @@ describe("checkBundledProviders", () => {
 
     await checkBundledProviders();
 
-    // Profiles already exist (count mocked to 1), so we don't re-run full
-    // discovery — but we DO queue the catch-up calibration eval for any models
-    // still on a seed prior.
+    // Profiles already exist (count mocked to 1) AND the model set was just seen
+    // (throttle default = fresh), so we don't re-run full discovery — but we DO
+    // queue the catch-up calibration eval for any models still on a seed prior.
     expect(mockAutoDiscover).not.toHaveBeenCalled();
     expect(mockQueueEvals).toHaveBeenCalledWith("local");
     // Should update hardware info
@@ -174,5 +181,33 @@ describe("checkBundledProviders", () => {
       expect.objectContaining({ status: "operational" }),
       expect.objectContaining({ modelCount: 1 }),
     );
+  });
+
+  it("re-enumerates in steady state when the local model set is stale (>1h since last seen) — BI-86CC0266", async () => {
+    mockFindFirst.mockResolvedValue({
+      providerId: "local",
+      status: "active",
+      baseUrl: "http://localhost:11434/v1",
+      endpoint: null,
+    } as any);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ id: "ai/gemma4:12B" }] }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ id: "ai/gemma4:12B" }] }),
+    });
+    // Freshest local discovery is 2h old → re-enumerate so a newly-pulled tag
+    // (e.g. gemma4:12B replacing 26B/latest) gets profiled and the gone tag retired.
+    mockDiscoveredAggregate.mockResolvedValue({
+      _max: { lastSeenAt: new Date(Date.now() - 2 * 60 * 60 * 1000) },
+    } as any);
+
+    await checkBundledProviders();
+
+    expect(mockAutoDiscover).toHaveBeenCalledWith("local");
+    // Calibration catch-up still runs alongside the re-discovery.
+    expect(mockQueueEvals).toHaveBeenCalledWith("local");
   });
 });

--- a/apps/web/lib/inference/ollama.ts
+++ b/apps/web/lib/inference/ollama.ts
@@ -103,10 +103,25 @@ export async function checkBundledProviders(): Promise<void> {
     if (profileCount === 0) {
       await autoDiscoverAndProfile("local");
     } else {
-      // Profiles exist but may still be un-calibrated seed priors (e.g. seeded at
-      // install, never evaluated). Queue the deterministic eval so capability
-      // scores reflect the real model. Self-limiting: stops once each model has
-      // an eval on record.
+      // Profiles exist. Re-enumerate the runner periodically so a newly-pulled or
+      // swapped local model (e.g. gemma4:26B → gemma4:12B) is discovered and a
+      // vanished tag retired. autoDiscoverAndProfile owns that reconciliation, but
+      // the steady-state path used to skip it entirely — so once any profile
+      // existed, new local models were never picked up and stale tags lingered
+      // (the daily revalidation cron is the primary path, but it is not always
+      // effective and page visits are far more frequent). Throttle on the freshest
+      // lastSeenAt so we don't re-profile on every render. (BI-86CC0266)
+      const freshest = await prisma.discoveredModel.aggregate({
+        where: { providerId: "local" },
+        _max: { lastSeenAt: true },
+      });
+      const lastSeenMs = freshest._max.lastSeenAt?.getTime() ?? 0;
+      const REDISCOVER_AFTER_MS = 60 * 60 * 1000; // 1h
+      if (Date.now() - lastSeenMs > REDISCOVER_AFTER_MS) {
+        await autoDiscoverAndProfile("local");
+      }
+      // Always catch up calibration for any models still on a seed prior.
+      // Self-limiting: stops once each model has an eval on record.
       await queueUncalibratedModelEvals("local");
     }
     await enrichLocalInfraCI(baseUrl, "operational");

--- a/apps/web/lib/queue/functions/model-discovery-refresh.ts
+++ b/apps/web/lib/queue/functions/model-discovery-refresh.ts
@@ -3,6 +3,9 @@ import { Pool } from "pg";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
 
+// jobId of the catalog ScheduledJob row this cron corresponds to.
+const JOB_ID = "model-discovery-refresh";
+
 // Lazy singleton pool — created once per process, reused across invocations.
 let _pgPool: Pool | undefined;
 function getPool(): Pool {
@@ -10,6 +13,23 @@ function getPool(): Pool {
     _pgPool = new Pool({ connectionString: process.env.DATABASE_URL });
   }
   return _pgPool;
+}
+
+/**
+ * Stamp the catalog ScheduledJob row so the Scheduled Jobs UI reflects when model
+ * discovery last ran and whether it succeeded (BI-86CC0266). Previously this
+ * function never wrote back, so the row read lastRunAt=NULL indefinitely even
+ * while the cron fired — hiding whether discovery was healthy and making it look
+ * permanently "never run". Best-effort: never fail the job over a stamp.
+ */
+async function recordRun(status: "ok" | "error", error?: string): Promise<void> {
+  const { prisma } = await import("@dpf/db");
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: JOB_ID },
+      data: { lastRunAt: new Date(), lastStatus: status, lastError: error ?? null },
+    })
+    .catch(() => {});
 }
 
 export const modelDiscoveryRefresh = inngest.createFunction(
@@ -23,11 +43,17 @@ export const modelDiscoveryRefresh = inngest.createFunction(
     const gate = await gateAtEntry(step);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
-    await step.run("refresh-all-providers", async () => {
-      const { runModelRevalidation } = await import(
-        "@/lib/inference/model-revalidation"
-      );
-      await runModelRevalidation({ source: "scheduled" }, getPool());
-    });
+    try {
+      await step.run("refresh-all-providers", async () => {
+        const { runModelRevalidation } = await import(
+          "@/lib/inference/model-revalidation"
+        );
+        await runModelRevalidation({ source: "scheduled" }, getPool());
+      });
+      await step.run("record-success", () => recordRun("ok"));
+    } catch (err) {
+      await step.run("record-failure", () => recordRun("error", String(err).slice(0, 500)));
+      throw err;
+    }
   },
 );


### PR DESCRIPTION
## What & why

Two related model-discovery reliability gaps surfaced while investigating the "providers show flat 50/50/50" goal (sibling of merged #2002). Verified on the live install.

### (d) Newly-pulled local models are never discovered in steady state — the gemma4 tag drift
`checkBundledProviders` (runs on every `/platform/ai/providers` load) only re-runs `autoDiscoverAndProfile("local")` when the provider is `unconfigured`/`disabled` or has **zero** profiles. Once `local` is `active` **with** profiles, it only queued calibration evals — it never re-enumerated the runner. So when a local model is swapped (Docker Model Runner now serves **`gemma4:12B`**, replacing `gemma4:26B`/`gemma4:latest`), the new tag was **never profiled** and the gone tags lingered (`ModelProfile` still tracks `26B`/`:latest`, both retired; the pulled `12B` has no profile; eval jobs chase the dead tags).

The reconciliation logic in `autoDiscoverAndProfile` is correct (it adds new models and retires vanished ones via `missedDiscoveryCount`) — it just wasn't being called. Fix: re-enumerate on the frequent, reliable page-load path, **throttled** to ≥1h since the freshest `DiscoveredModel.lastSeenAt` so we don't re-profile on every render. The daily revalidation cron remains the primary path; this is the reliable backstop.

### (a) The discovery cron never recorded its runs
`model-discovery-refresh` (cron `0 3 * * *`) never wrote back to its `ScheduledJob` row, so the Scheduled Jobs UI showed `lastRunAt=NULL` for 3+ weeks even if the cron fired — making it impossible to tell whether discovery was healthy. Now stamps `lastRunAt`/`lastStatus`/`lastError` (mirrors the `infra-prune`/`mcp-catalog` convention).

## DMR ground truth (why this reconciles)
`GET /engines/v1/models` on the live runner returns exactly: `nomic-embed-text-v1.5:latest`, `qwen3-coder:latest`, **`gemma4:12B`** — so the next discovery pass picks up `12B` and starts retiring `26B`/`:latest`.

## Tests
- `ollama-health.test.ts`: adds a stale-set case asserting re-enumeration fires when the freshest local model is >1h old; the existing steady-state test now asserts the fresh-throttle path (no re-discovery, evals still queued).
- `model-discovery-refresh` is a thin inngest wrapper (no existing test); the stamping is a best-effort `scheduledJob.update`.
- Typecheck/build run in CI (source-only worktree). Live reconciliation of `gemma4:12B` follows the next discovery run after deploy.

## Backlog
`BI-86CC0266` — `EP-BUILD-9DB5B0` (parent design `BI-308660B6`). Completes deliverables (a) + (d) of the calibration-routing goal; (c) landed in #2002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
