### PR TITLE
test(routing): verify routeAndCall downranks still-50 (unproven) models

### DIFF
--- a/apps/web/lib/routing/cost-ranking.test.ts
+++ b/apps/web/lib/routing/cost-ranking.test.ts
@@ -271,6 +271,40 @@ describe("estimateSuccessProbability", () => {
     expect(highProb).toBeCloseTo(1.0);
     expect(lowProb).toBeCloseTo(0.85);
   });
+
+  // BI-DDE007C7: routeAndCall consumes the calibrated per-model ModelProfile
+  // scores (loader → cost-ranking), and a model still on its bootstrap seed prior
+  // (a flat 50/50/50 "unproven" profile) must not be silently trusted. Two
+  // existing mechanisms already enforce that; this locks them as a regression.
+  it("does not silently trust a still-50 (unproven) model — floor + low confidence downrank it", () => {
+    const caps = { ...EMPTY_CAPABILITIES, toolUse: true, structuredOutput: true, streaming: true };
+
+    // (1) Quality floor: a never-measured 50/50/50 model is strongly downranked
+    // for any task needing medium+ reasoning (floor 60 > avg 50 → 0.3), so it
+    // cannot win real work on placeholder scores.
+    const seed50 = makeEndpoint({
+      reasoning: 50, codegen: 50, toolFidelity: 50, instructionFollowing: 50,
+      structuredOutput: 50, conversational: 50, contextRetention: 50,
+      profileSource: "seed", profileConfidence: "low", recentFailureRate: 0, capabilities: caps,
+    });
+    const mediumWork = makeContract({ taskType: "code-gen", reasoningDepth: "medium" }); // floor 60
+    expect(estimateSuccessProbability(seed50, mediumWork)).toBe(0.3);
+
+    // (2) Confidence provenance: even above the floor, at EQUAL scores a still-seed
+    // (low-confidence) profile is ranked below a measured (evaluated, high-confidence)
+    // one — the unproven model is never preferred over a proven peer.
+    const easyWork = makeContract({ taskType: "code-gen", reasoningDepth: "minimal" }); // floor 30
+    const seedAbove = makeEndpoint({
+      codegen: 70, instructionFollowing: 70,
+      profileSource: "seed", profileConfidence: "low", recentFailureRate: 0, capabilities: caps,
+    });
+    const provenAbove = makeEndpoint({
+      codegen: 70, instructionFollowing: 70,
+      profileSource: "evaluated", profileConfidence: "high", recentFailureRate: 0, capabilities: caps,
+    });
+    expect(estimateSuccessProbability(seedAbove, easyWork))
+      .toBeLessThan(estimateSuccessProbability(provenAbove, easyWork));
+  });
 });
 
 // ── averageRelevantDimensions ────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Deliverable (b) of the calibration-routing goal is a **verification**: confirm `routeAndCall` consumes the calibrated per-model scores and does **not** silently trust a still-50 ("unproven") model. It does — through two existing mechanisms — and this locks them as a regression so they can't silently erode.

- **Source of truth:** `routeAndCall` → `loadEndpointManifests` (`loader.ts`) → `cost-ranking.ts` reads `ModelProfile.{reasoning,codegen,toolFidelity,…}` (the calibrated per-model table), never the dead `ModelProvider` seed columns (that was the #2002 UX bug).
- **Quality floor:** a never-measured `50/50/50` profile scores below the medium/high reasoning floor (50 < 60/75) → `estimateSuccessProbability` returns `0.3`, so placeholder scores can't win real work.
- **Confidence provenance:** at equal scores above the floor, a still-seed (`profileConfidence:"low"`) profile is ranked below an `evaluated` (`high`) peer via the confidence multiplier — the unproven model is never preferred over a proven one.

The new test asserts both with the **current** code (no production change).

## Why not a stronger penalty here

A direct `profileSource === "seed"` penalty in `estimateSuccessProbability` would ripple absolute-value assertions across 7 routing test suites (they default endpoints to `seed`) and can't be safely re-baselined without the local runtime. The stronger, explicit **tool-routing calibration/eligibility gate** is already owned and architect-reviewed under `BI-308660B6` (§5.2 `isToolRoutingEligible`) — this PR deliberately stays a verification + regression lock rather than duplicating that design.

## Backlog

`BI-DDE007C7` — `EP-BUILD-9DB5B0`. Completes the (b) verification of the calibration-routing goal; (c) merged in #2002, (a)+(d) in #2005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
