### PR TITLE
feat(ci): un-skippable UX-fit / cognitive-load gate across all build surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,33 @@ jobs:
       - name: Run guard
         run: node scripts/check-bundle-boundaries.mjs
 
+  ux-fit-gate:
+    name: UX-Fit Gate
+    runs-on: ubuntu-latest
+    # Only meaningful on PRs — it diffs against the PR base and reads the PR body.
+    if: github.event_name == 'pull_request'
+    # BI-65DEE968. The un-skippable UX-fit / cognitive-load gate. A UI-impacting
+    # diff (new user-facing form controls, numeric inputs, or routes under
+    # apps/web) must carry a recorded UX-fit decision — a `UX-Fit-Decision:`
+    # trailer in a commit message or the PR body. AGENTS.md §12/§16/§17 had the
+    # rule; nothing enforced it, so #2004 shipped a raw "Context window: 22000
+    # tokens" input a non-technical user can't answer. Surface-agnostic: Claude
+    # Code, Codex, Grok, and Build Studio all land via PR, so all are caught — it
+    # reads the evidence, never which surface produced it (AGENTS.md §17).
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Run UX-fit gate
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-ux-fit-decision.mjs
+
   janitor-tests:
     name: Janitor Tests
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,8 @@ Sole exception: `text-white` on `bg-[var(--dpf-accent)]` buttons. Inline `style=
 
 Full standard: `docs/platform-usability-standards.md`. Other UI conventions: tab-nav with sub-routes for sections, progressive disclosure (3–5 essential fields, advanced via coworker), wizard-first setup with quick-edit on return, consistent welcome messages (identity → 2-3 capabilities → skills hint).
 
+**UX-fit gate (mandatory, enforced — BI-65DEE968).** Any UI-impacting change — a new user-facing form control, a numeric/raw input, a new route/tab, or a metric/status component — MUST carry a recorded UX-fit / cognitive-load decision before it lands. Run the `dpf-ux-fit-review` skill and score the options with `principle_decide` on the `human_cognitive_load` axis. Progressive disclosure wins by default: auto-derive what the platform can compute (model context, hardware limits) and keep the default view to 3–5 plain choices — never ask a layman to type a token count. Attest the decision with a `UX-Fit-Decision:` trailer in a commit message or the PR body. This is **enforced in CI** by the `UX-Fit Gate` check (`scripts/check-ux-fit-decision.mjs`), which fails any UI-impacting PR lacking the attestation — surface-agnostic across Claude Code, Codex, Grok, and Build Studio, because all changes land via PR (§4) and the gate reads the evidence, not which surface produced it (§17). The rule lived in this file unenforced once — the #2004 Build Runtime screen shipped a raw "Context window: 22000 tokens" input a non-technical user can't answer — which is exactly why a passive document is not enough and the gate exists.
+
 ## 13. Login & Local QA
 
 - Login email: `admin@dpf.local` unless told otherwise.

--- a/scripts/check-ux-fit-decision.mjs
+++ b/scripts/check-ux-fit-decision.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// scripts/check-ux-fit-decision.mjs
+//
+// BI-65DEE968 — The un-skippable UX-fit / cognitive-load gate.
+//
+// THE PROBLEM IT FIXES: AGENTS.md §12 (progressive disclosure), §16
+// (dpf-ux-fit-review), and §17 (hide complexity from layman users) are a passive
+// document + an advisory skill. A fast, operator-focused build (#2004's Build
+// Runtime screen) shipped a raw "Context window: 22000 tokens" input that a
+// non-technical user can't answer — the rule existed and nothing enforced it.
+//
+// THE FIX: enforce the check as EVIDENCE at the one chokepoint every build
+// surface (Claude Code / Codex / Grok / Build Studio) must traverse — the PR.
+// This gate fails a PR that introduces a UI-impacting change (new user-facing
+// form controls, numeric inputs, or new routes) UNLESS a UX-fit / cognitive-load
+// decision is attested. It reads the evidence, never which surface produced it
+// ("governance approves evidence, not provenance" — AGENTS.md §17).
+//
+// ATTESTATION: a `UX-Fit-Decision:` trailer in any commit message in the PR
+// range, or in the PR body. Authoring that trailer means the author ran the
+// ux-fit review (and ideally scored options with principle_decide on the
+// human_cognitive_load axis). v1 is a conscious-attestation MVP; a follow-up can
+// verify a persisted DecisionInteraction record (BI-65DEE968 §5).
+
+import { execSync } from "node:child_process";
+
+const ATTESTATION_RE = /UX-Fit-Decision:/i;
+
+// Added lines that introduce a user-facing control the operator must understand.
+const UI_CONTROL_RE = /<input\b|<select\b|<textarea\b|type=["'](?:number|range)["']|<form\b/i;
+// A newly-added route is a new surface that deserves a fit review.
+const ROUTE_FILE_RE = /app\/.*\/page\.tsx$/;
+// Don't gate test/story scaffolding — those controls aren't user-facing.
+const EXCLUDE_RE = /\.(test|spec|stories)\.tsx$/;
+
+function sh(cmd) {
+  try {
+    return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  } catch (e) {
+    return (e.stdout && e.stdout.toString()) || "";
+  }
+}
+
+const base = process.env.BASE_SHA || "origin/main";
+// Ensure the base ref is present (CI checks out a shallow tree).
+sh(`git fetch --no-tags --depth=1 origin main`);
+
+const changed = sh(`git diff --name-only ${base}...HEAD -- "apps/web/**/*.tsx"`)
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean)
+  .filter((f) => !EXCLUDE_RE.test(f));
+
+if (changed.length === 0) {
+  console.log("[ux-fit-gate] No user-facing apps/web/*.tsx changes — nothing to gate.");
+  process.exit(0);
+}
+
+const addedFiles = new Set(
+  sh(`git diff --name-only --diff-filter=A ${base}...HEAD -- "apps/web/**/*.tsx"`)
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+const impacting = [];
+for (const f of changed) {
+  const isNewRoute = ROUTE_FILE_RE.test(f) && addedFiles.has(f);
+  const added = sh(`git diff ${base}...HEAD -- "${f}"`)
+    .split("\n")
+    .filter((l) => l.startsWith("+") && !l.startsWith("+++"));
+  const addsControl = added.some((l) => UI_CONTROL_RE.test(l));
+  if (isNewRoute || addsControl) {
+    impacting.push(f + (isNewRoute ? " (new route)" : " (adds a user-facing control)"));
+  }
+}
+
+if (impacting.length === 0) {
+  console.log("[ux-fit-gate] No UI-impacting controls or routes added — nothing to gate.");
+  process.exit(0);
+}
+
+const commits = sh(`git log ${base}..HEAD --format=%B`);
+const prBody = process.env.PR_BODY || "";
+const attested = ATTESTATION_RE.test(commits) || ATTESTATION_RE.test(prBody);
+
+if (attested) {
+  console.log("[ux-fit-gate] UI-impacting change carries a UX-Fit-Decision attestation. OK.");
+  for (const f of impacting) console.log("  • " + f);
+  process.exit(0);
+}
+
+console.error("");
+console.error("[ux-fit-gate] FAILED — UI-impacting change without a recorded UX-fit decision.");
+console.error("");
+console.error("These changes add user-facing controls / routes:");
+for (const f of impacting) console.error("  • " + f);
+console.error("");
+console.error("Every UI-impacting change must carry a UX-fit / cognitive-load decision so");
+console.error("over-exposed screens can't ship (AGENTS.md §12 progressive disclosure, §16");
+console.error("dpf-ux-fit-review, §17 hide complexity from layman users).");
+console.error("");
+console.error("To resolve:");
+console.error("  1. Run the UX-fit review (dpf-ux-fit-review skill) and score the options");
+console.error("     with principle_decide on the human_cognitive_load axis.");
+console.error("  2. Attest the decision — add a trailer to a commit message OR the PR body:");
+console.error("       UX-Fit-Decision: <one-line outcome>");
+console.error("     e.g.  UX-Fit-Decision: progressive-disclosure (principle_decide, margin 0.85)");
+console.error("");
+console.error("This gate reads the evidence, not which surface produced it — it applies");
+console.error("identically to Claude Code, Codex, Grok, and Build Studio PRs.");
+console.error("");
+process.exit(1);


### PR DESCRIPTION
## What & why

AGENTS.md §12 (progressive disclosure), §16 (`dpf-ux-fit-review`), and §17 (hide complexity) **had** the rule — but it was a *passive document + an advisory skill*. Nothing forced it, so #2004's Build Runtime screen shipped a raw `Context window: 22000 tokens` input a non-technical user can't answer, and `DecisionInteraction` had **0** recorded decisions. A rule that lives only in a doc is advisory.

## The fix — enforce as evidence at the one chokepoint every surface traverses

Every change from every surface (Claude Code / Codex / Grok / Build Studio) **lands via PR** (§4). So the gate lives there:

- **`scripts/check-ux-fit-decision.mjs`** — fails a PR that adds a user-facing control (`<input>`/`<select>`/`<textarea>`/`type="number"|"range"`/`<form>`) or a new route under `apps/web/**/*.tsx`, **unless** a `UX-Fit-Decision:` trailer is present in a commit message or the PR body. Excludes `*.test/spec/stories.tsx`.
- **`UX-Fit Gate` job in `ci.yml`** (mirrors the existing guard jobs), PR-only, `fetch-depth: 0`, passes `BASE_SHA` + `PR_BODY`.
- **AGENTS.md §12** documents it and points to the enforcement.

It reads the **evidence, not the provenance** (§17) — identical for all four surfaces.

## Tested locally (node v24)
- Pass path (this PR's own diff — docs/CI/script, no `apps/web/*.tsx`): `No user-facing apps/web/*.tsx changes — nothing to gate`, exit 0.
- Detection: the sibling screen PR #2007 diff adds **3** control lines and carries **0** trailers → the gate would correctly require attestation there.

## Operator follow-up (one-time)
Add **`UX-Fit Gate`** to the `main` branch-protection required checks so it *blocks* merge (the job runs now; making it required is a repo-settings toggle). Further hardening tracked in the BI: a Claude Code `PreToolUse` hook, sharper `dpf-ux-fit-review` triggers, verifying a persisted `DecisionInteraction`, and wiring the #1983 Build-Studio gate.

## Backlog
`BI-65DEE968` (EP-PRINCIPLES). Sibling proof-of-concept: #2007 (Build Runtime screen redesigned via this exact process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
