### PR TITLE
fix(inference): serialize local inference so single-GPU builds don't time out

### DIFF
--- a/apps/web/lib/routing/chat-adapter.test.ts
+++ b/apps/web/lib/routing/chat-adapter.test.ts
@@ -143,7 +143,7 @@ vi.mock("@/lib/ai-inference", () => {
 
 import type { AdapterRequest } from "./adapter-types";
 import type { RoutedExecutionPlan } from "./recipe-types";
-import { chatAdapter } from "./chat-adapter";
+import { chatAdapter, withLocalInferenceLock } from "./chat-adapter";
 import { InferenceError } from "@/lib/ai-inference";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -782,5 +782,38 @@ describe("chatAdapter", () => {
 
   it("adapter type is 'chat'", () => {
     expect(chatAdapter.type).toBe("chat");
+  });
+});
+
+describe("withLocalInferenceLock — single-GPU serialization", () => {
+  it("runs local calls strictly one at a time (never concurrent)", async () => {
+    const order: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const task = (id: string, ms: number) => () =>
+      new Promise<string>((resolve) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        order.push(`start${id}`);
+        setTimeout(() => {
+          active--;
+          order.push(`end${id}`);
+          resolve(id);
+        }, ms);
+      });
+    // Shorter tasks queued after a longer one must still wait their turn.
+    await Promise.all([
+      withLocalInferenceLock(task("A", 20)),
+      withLocalInferenceLock(task("B", 5)),
+      withLocalInferenceLock(task("C", 1)),
+    ]);
+    expect(maxActive).toBe(1);
+    expect(order).toEqual(["startA", "endA", "startB", "endB", "startC", "endC"]);
+  });
+
+  it("a rejected/timed-out call does not wedge subsequent local calls", async () => {
+    await expect(withLocalInferenceLock(() => Promise.reject(new Error("aborted due to timeout")))).rejects.toThrow();
+    // The chain must still advance — the next call runs and resolves.
+    await expect(withLocalInferenceLock(() => Promise.resolve("ok"))).resolves.toBe("ok");
   });
 });

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -34,10 +34,30 @@ import { extractToolCalls as extractTextualToolUse } from "./extract-tool-calls"
 // the fresh-install audit (R1-*-O-001). Cloud providers keep the longer ceiling.
 // Both are env-overridable for operators on slow local hardware / cold model loads.
 const DEFAULT_INFERENCE_TIMEOUT_MS = Number(process.env.DPF_INFERENCE_TIMEOUT_MS) || 180_000;
-const LOCAL_INFERENCE_TIMEOUT_MS = Number(process.env.DPF_LOCAL_INFERENCE_TIMEOUT_MS) || 60_000;
+const LOCAL_INFERENCE_TIMEOUT_MS = Number(process.env.DPF_LOCAL_INFERENCE_TIMEOUT_MS) || 120_000;
 
 function resolveInferenceTimeoutMs(providerId: string): number {
   return providerId === "local" ? LOCAL_INFERENCE_TIMEOUT_MS : DEFAULT_INFERENCE_TIMEOUT_MS;
+}
+
+// A single-GPU local endpoint (Docker Model Runner / Ollama) serves ONE request
+// at a time. The platform routinely fires inference concurrently — reviewBuildPlan
+// alone dispatches 3 reviewer calls in parallel, on top of the coworker's agentic
+// loop — which makes those calls queue behind each other inside the endpoint,
+// blow past the per-call timeout while still waiting, and 502 the endpoint under
+// load. Observed live: "Both review agents failed to respond" on every local
+// build because both reviewers aborted with "operation was aborted due to timeout".
+// Serialize local inference through a promise chain so each call gets the full GPU
+// and its timeout (created by the caller, inside this lock) covers real inference,
+// not queue-wait. Cloud providers are unaffected — only providerId === "local"
+// goes through the lock.
+let localInferenceChain: Promise<unknown> = Promise.resolve();
+export function withLocalInferenceLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = localInferenceChain.then(fn, fn);
+  // Keep the chain alive regardless of this call's outcome so one failure/timeout
+  // never wedges every subsequent local call.
+  localInferenceChain = run.then(() => undefined, () => undefined);
+  return run;
 }
 
 // ─── Gemini part types ───────────────────────────────────────────────────────
@@ -327,12 +347,16 @@ export const chatAdapter: ExecutionAdapterHandler = {
     const startMs = Date.now();
     let res: Response;
     try {
-      res = await fetch(chatUrl, {
+      // The AbortSignal is created inside the thunk so, for serialized local
+      // calls, the timeout clock starts when the call actually dispatches — not
+      // while it waits its turn in the local-inference lock.
+      const doFetch = () => fetch(chatUrl, {
         method: "POST",
         headers,
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(resolveInferenceTimeoutMs(providerId)),
       });
+      res = providerId === "local" ? await withLocalInferenceLock(doFetch) : await doFetch();
     } catch (e) {
       throw new InferenceError(
         `Network error calling ${providerId}: ${e instanceof Error ? e.message : String(e)}`,


### PR DESCRIPTION
## What
Serialize local LLM inference through a promise chain (`withLocalInferenceLock`) so a single-GPU local endpoint (DMR/Ollama) processes one request at a time. The per-call `AbortSignal` is created *inside* the lock, so the timeout measures real inference, not queue-wait. Local timeout default bumped 60s→120s for cold loads + large prompts. Cloud providers untouched.

## Why (found live by the local-model acid test)
Every local build failed the plan gate with **"Both review agents failed to respond"**. Portal logs showed the real cause:
```
[callWithFallbackChain] local failed: Network error calling local: The operation was aborted due to timeout
[callWithFallbackChain] local failed: Transient error (502) from local
```
`reviewBuildPlan` fires **3 reviewer calls in parallel** (+ the coworker agentic loop), but a local endpoint serves **one request at a time** on a single GPU. The concurrent calls queue, blow past the 60s timeout while waiting, and 502 the endpoint. With local-only inference on there's no cloud fallback → reviewers return null → **no local build can pass the plan gate.** The model tool-called correctly; the dispatch/timeout were tuned for cloud-style concurrency. Misconfiguration, not the model.

## Tests
- `withLocalInferenceLock` runs calls strictly one-at-a-time (maxConcurrent=1, strict order even when later calls are shorter).
- A rejected/timed-out call doesn't wedge subsequent local calls (chain stays alive).
- tsc clean; serialization logic verified standalone.

## Follow-up (not in this PR)
Verify on the live install once deployed: re-run a local plan review and confirm the reviewers complete instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)