### PR TITLE
fix(build-studio): make the build agent ground domain facts, never invent them

### DIFF
--- a/apps/web/lib/integrate/opencode-dispatch.test.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.test.ts
@@ -7,6 +7,7 @@ import {
   buildOpencodeConfig,
   summarizeOpencodeEvent,
   extractOpencodeResult,
+  buildOpencodeInstructions,
 } from "./opencode-dispatch";
 
 describe("sandboxReachableUrl", () => {
@@ -260,5 +261,27 @@ describe("preflightLocalEndpoint — embedding warnings + served context (a/b)",
     const res = await preflightLocalEndpoint("http://localhost:11434/v1", "docker.io/ai/qwen3-coder:latest", fetchImpl, { checkServedContext: true });
     expect(res.ok).toBe(true);
     expect(res.servedContextTokens).toBeNull();
+  });
+});
+
+describe("buildOpencodeInstructions — domain-fact grounding", () => {
+  it("tells the build agent to ground domain facts in the codebase and never invent conventions", () => {
+    // Regression: a local build invented a semantic-ID taxonomy (colon-separated
+    // words) instead of DPF's real BI-/EP-/FB- codes, because the plan deferred
+    // the taxonomy to a knowledge base the build agent can't reach. The fix is a
+    // mandatory grounding instruction — the agent has grep/bash, so it must find
+    // the real convention rather than guess.
+    const instructions = buildOpencodeInstructions("software-engineer", "PROJECT CONTEXT: build a classifier");
+    expect(instructions).toContain("GROUND DOMAIN FACTS");
+    expect(instructions).toMatch(/NEVER INVENT/);
+    expect(instructions).toMatch(/grep/);
+    // it's in the MANDATORY discipline block, applied to every role
+    expect(instructions).toContain("DPF BUILD DISCIPLINE (MANDATORY)");
+  });
+
+  it("includes the grounding rule for every specialist role", () => {
+    for (const role of ["data-architect", "software-engineer", "frontend-engineer", "qa-engineer"] as const) {
+      expect(buildOpencodeInstructions(role, "ctx")).toContain("GROUND DOMAIN FACTS");
+    }
   });
 });

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -269,7 +269,7 @@ async function ensureSandboxNodeUser(containerId: string): Promise<void> {
   );
 }
 
-function buildOpencodeInstructions(
+export function buildOpencodeInstructions(
   role: SpecialistRole,
   buildContext: string,
   priorResults?: string,
@@ -317,6 +317,7 @@ Key patterns:
   parts.push(
     "",
     "DPF BUILD DISCIPLINE (MANDATORY):",
+    "- GROUND DOMAIN FACTS IN THE CODEBASE — NEVER INVENT a platform convention: an identifier/prefix format, taxonomy, enum value, naming pattern, or API shape. When a task (or the design) references 'platform conventions', 'the knowledge base', or 'the canonical taxonomy' for a fact you don't have, FIND the real one before writing code — grep the repo for actual usage (existing identifiers, enums, similar utilities) and match it EXACTLY. Example: before classifying/parsing IDs, grep for real ones (e.g. `grep -rohE \"\\b(BI|EP|FB|WC)-[0-9A-F]+\" apps packages | sort -u | head`) instead of assuming a format. A plausible-but-wrong convention is a defect; if you genuinely cannot find the fact, say so in your output rather than guessing.",
     "- For ANY TypeScript work: run `pnpm --filter web typecheck` (or `pnpm exec tsc --noEmit`) and fix errors before finishing.",
     "- For final-task-in-epic or any UI change: ALSO run `cd apps/web && npx next build` and fix errors.",
     "- UI work MUST follow Theme-Aware Styling: ONLY use CSS custom properties (`text-[var(--dpf-text)]`, `bg-[var(--dpf-surface-1)]`, etc.). NEVER hardcode colors, tailwind gray-*, or raw hex.",


### PR DESCRIPTION
## What
A mandatory grounding rule in the OpenCode build prompt: **never invent a platform convention** (identifier/prefix format, taxonomy, enum, naming, API shape). When a task/design defers a fact to "platform conventions" / "the knowledge base," the agent must **find the real one** by grepping the repo and match it exactly.

## Why (found live on the first end-to-end local build)
On FB-69231490 / BI-4FF277BF, qwen3-coder wrote structurally clean but **domain-wrong** code: it invented a colon-separated, lowercase-word ID taxonomy (`'epic'`,`'backlog'`,`'feature'`) when real DPF IDs are `BI-<hex>`, `EP-<hex>`, `FB-<hex>`. `classifySemanticId('BI-4FF277BF')` → `null`.

**Root cause = a tool gap, not a hallucination:** the build phase runs `opencode run` with only file/bash tools — no DPF MCP, no `searchPlatformKnowledge` (WWWD), no code-graph. The plan deferred the taxonomy to a knowledge base the build agent can't reach, so it guessed. It also wrote tests for its own wrong impl, so the verification gate passes and never catches it.

But the agent **has grep/bash**, and the real conventions are all over the codebase — it simply wasn't told to ground itself. This rule fixes that with the tools it already has.

## Tests
Grounding rule present in the MANDATORY discipline block for every specialist role. tsc clean.

## Follow-up (not in this PR)
Richer grounding: pre-resolve deferred domain facts **upstream** in ideate/plan (where WWWD + code-graph live) and inject them into the build context — mirroring #1984's code-graph injection for ideate. Verify on deploy by re-running classifySemanticId and confirming `BI-`/`EP-`/`FB-` instead of invented words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)