### PR TITLE
fix(build-studio): scope build→review verification gate to changed files (BI-4890FDC3)

### DIFF
--- a/apps/web/lib/build/scoped-verification.test.ts
+++ b/apps/web/lib/build/scoped-verification.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildScopedVerificationFromParts, extractFilePathsFromText } from "./scoped-verification";
+import {
+  buildScopedVerificationFromParts,
+  extractFilePathsFromText,
+  extractTypecheckErrorFiles,
+  scopeVerificationOutputForGate,
+  typecheckPassedForChangedScope,
+} from "./scoped-verification";
 import { normalizeVerificationOutput } from "./verification-output";
 
 describe("extractFilePathsFromText", () => {
@@ -42,5 +48,97 @@ describe("buildScopedVerificationFromParts", () => {
 
     expect(verification.buildScoped.affectedFiles).toEqual([]);
     expect(verification.buildScoped.failureAxis).toBe("unknown");
+  });
+});
+
+describe("scopeVerificationOutputForGate", () => {
+  it("neutralizes an out-of-scope failure so the gate advances", () => {
+    const gate = scopeVerificationOutputForGate({
+      verification: normalizeVerificationOutput({
+        typecheckPassed: false,
+        testsPassed: 0,
+        testsFailed: 192,
+        fullOutput: "FAIL apps/web/app/(shell)/platform/identity/applications/page.tsx Unexpected JSX expression",
+      }),
+      changedFiles: ["apps/web/lib/utils/semanticIdClassifier.ts"],
+    });
+
+    expect(gate.outOfScopeNoise).toBe(true);
+    expect(gate.typecheckPassed).toBe(true);
+    expect(gate.testsFailed).toBe(0);
+    // Full-repo signal preserved for visibility.
+    expect(gate.globalTestsFailed).toBe(192);
+    expect(gate.failureAxis).toBe("out-of-scope-noise");
+  });
+
+  it("keeps an in-scope failure blocking", () => {
+    const gate = scopeVerificationOutputForGate({
+      verification: normalizeVerificationOutput({
+        typecheckPassed: false,
+        testsFailed: 1,
+        fullOutput: "FAIL apps/web/lib/utils/semanticIdClassifier.test.ts",
+      }),
+      changedFiles: ["apps/web/lib/utils/semanticIdClassifier.ts"],
+    });
+
+    expect(gate.outOfScopeNoise).toBe(false);
+    expect(gate.typecheckPassed).toBe(false);
+  });
+
+  it("passes the raw verdict through when no changed-file scope is known", () => {
+    const gate = scopeVerificationOutputForGate({
+      verification: normalizeVerificationOutput({
+        typecheckPassed: false,
+        testsFailed: 3,
+        fullOutput: "FAIL apps/web/lib/foo.test.ts",
+      }),
+      changedFiles: [],
+    });
+
+    expect(gate.outOfScopeNoise).toBe(false);
+    expect(gate.typecheckPassed).toBe(false);
+  });
+});
+
+describe("typecheckPassedForChangedScope", () => {
+  it("passes when there are no TS errors", () => {
+    expect(typecheckPassedForChangedScope("", ["apps/web/lib/foo.ts"]).passed).toBe(true);
+  });
+
+  it("passes when every TS error is outside the changed surface", () => {
+    const out = [
+      "app/(shell)/platform/identity/applications/page.tsx(12,5): error TS1005: ';' expected.",
+      "lib/other/unrelated.ts(3,1): error TS2304: Cannot find name 'foo'.",
+    ].join("\n");
+    const result = typecheckPassedForChangedScope(out, ["apps/web/lib/utils/semanticIdClassifier.ts"]);
+    expect(result.passed).toBe(true);
+    expect(result.outOfScopeErrorFiles.length).toBe(2);
+    expect(result.inScopeErrorFiles).toEqual([]);
+  });
+
+  it("fails when an in-scope file has a TS error (pretty format)", () => {
+    const out = "lib/utils/semanticIdClassifier.ts:9:3 - error TS2345: Argument of type ...";
+    const result = typecheckPassedForChangedScope(out, ["apps/web/lib/utils/semanticIdClassifier.ts"]);
+    expect(result.passed).toBe(false);
+    expect(result.inScopeErrorFiles.length).toBe(1);
+  });
+
+  it("fails legacy-style when errors exist but no scope is provided", () => {
+    expect(typecheckPassedForChangedScope("foo.ts(1,1): error TS1: x", []).passed).toBe(false);
+  });
+
+  it("fails conservatively when errors are present but unattributable", () => {
+    expect(typecheckPassedForChangedScope("error TS9999: internal", ["apps/web/lib/foo.ts"]).passed).toBe(false);
+  });
+});
+
+describe("extractTypecheckErrorFiles", () => {
+  it("handles both pretty and non-pretty tsc formats", () => {
+    const out = [
+      "lib/a.tsx(12,5): error TS1005: ';' expected.",
+      "lib/b.ts:3:1 - error TS2304: Cannot find name.",
+      "./lib/c.mts(1,1): error TS1: x",
+    ].join("\n");
+    expect(extractTypecheckErrorFiles(out)).toEqual(["lib/a.tsx", "lib/b.ts", "lib/c.mts"]);
   });
 });

--- a/apps/web/lib/build/scoped-verification.ts
+++ b/apps/web/lib/build/scoped-verification.ts
@@ -86,8 +86,125 @@ export function buildScopedVerificationFromParts(args: {
 }
 
 export function extractFilePathsFromText(value: string): string[] {
-  return unique([...value.matchAll(/\b(?:apps|packages)\/[A-Za-z0-9_./-]+\.[A-Za-z0-9]+/g)]
+  // The character class includes `()` so Next.js route-group segments like
+  // `app/(shell)/…/page.tsx` are captured — without this, the file that stalled
+  // FB-69231490 (`apps/web/app/(shell)/platform/identity/applications/page.tsx`)
+  // was never extracted, so out-of-scope classification silently failed.
+  return unique([...value.matchAll(/\b(?:apps|packages)\/[A-Za-z0-9_./()-]+\.[A-Za-z0-9]+/g)]
     .map((match) => match[0].replace(/[),.;:]$/, "")));
+}
+
+/**
+ * Gate-facing verification record scoped to the build's changed files.
+ *
+ * The build→review gate (`checkPhaseGate` → `verification-typecheck-passed`)
+ * reads `verificationOut.typecheckPassed` verbatim. When a build runs a wider
+ * test/typecheck pass than its own changed surface — the full monorepo suite,
+ * or a whole-`apps/web` `tsc` run — a pre-existing failure ELSEWHERE in the
+ * repo lands in the output and flips `typecheckPassed=false`, blocking a build
+ * whose own files are clean. That is the FB-69231490 stall: an unrelated broken
+ * `.tsx` test gated a ~30-line helper.
+ *
+ * This realizes #1988's intent at the gate: when EVERY observed failure is
+ * outside the changed surface, report the build's own surface as clean
+ * (`typecheckPassed=true`, `testsFailed=0`) so the advance proceeds, while
+ * preserving the full-repo signal in `globalTestsFailed` for visibility. An
+ * in-scope failure (the feature's own tests/typecheck) still blocks — only
+ * out-of-scope NOISE is neutralized. With no changed-file set we cannot scope,
+ * so the raw verdict passes through unchanged (conservative: keeps blocking).
+ */
+export type GateScopedVerification = {
+  typecheckPassed: boolean | null;
+  testsPassed: number | null;
+  testsFailed: number | null;
+  failureAxis: BuildFailureAxis | null;
+  /** True when all observed failures are outside the changed surface. */
+  outOfScopeNoise: boolean;
+  /** Full-repo failure count, preserved for visibility even when neutralized. */
+  globalTestsFailed: number | null;
+  affectedFiles: string[];
+};
+
+export function scopeVerificationOutputForGate(args: {
+  verification: NormalizedVerificationOutput;
+  changedFiles: string[];
+  dispatchHistory?: BuildDispatchAttemptView[];
+}): GateScopedVerification {
+  const scoped = buildScopedVerificationFromParts({
+    verification: args.verification,
+    changedFiles: args.changedFiles,
+    dispatchHistory: args.dispatchHistory ?? [],
+  });
+  const outOfScopeNoise = scoped.buildScoped.failureAxis === "out-of-scope-noise";
+
+  return {
+    // Out-of-scope noise ⇒ the build's own surface is clean. Map the nulled
+    // scoped verdict to an explicit pass so the gate advances.
+    typecheckPassed: outOfScopeNoise ? true : scoped.buildScoped.typecheckPassed,
+    testsPassed: outOfScopeNoise ? args.verification.testsPassed : scoped.buildScoped.testsPassed,
+    testsFailed: outOfScopeNoise ? 0 : scoped.buildScoped.testsFailed,
+    failureAxis: scoped.buildScoped.failureAxis,
+    outOfScopeNoise,
+    globalTestsFailed: scoped.globalHealth.testsFailed,
+    affectedFiles: scoped.buildScoped.affectedFiles,
+  };
+}
+
+/**
+ * Scope a raw `tsc --noEmit` output to the build's changed files.
+ *
+ * `runSandboxTests` runs `tsc` over the whole `apps/web` workspace — there is no
+ * cheap way to typecheck one file in isolation because the project graph is
+ * shared. So we post-filter: parse every `error TS` line for its file, and if
+ * EVERY error sits outside the changed surface, the build's own files typecheck
+ * clean. `tsc` prints paths relative to its cwd (`apps/web`), while changed
+ * files are repo-relative (`apps/web/lib/foo.ts`); `isPathInScope` already
+ * matches on containment in both directions, so a suffix match succeeds.
+ *
+ * Returns `passed:true` when there are no `error TS` markers. When errors exist
+ * but NONE could be attributed to a file (unparseable output), we conservatively
+ * report `passed:false` — better to block than to wave through an opaque failure.
+ */
+export function typecheckPassedForChangedScope(
+  typeCheckOutput: string,
+  changedFiles: string[],
+): { passed: boolean; inScopeErrorFiles: string[]; outOfScopeErrorFiles: string[] } {
+  if (!typeCheckOutput.includes("error TS")) {
+    return { passed: true, inScopeErrorFiles: [], outOfScopeErrorFiles: [] };
+  }
+  // No scope to apply ⇒ preserve legacy behavior (any error fails).
+  if (changedFiles.length === 0) {
+    return { passed: false, inScopeErrorFiles: [], outOfScopeErrorFiles: [] };
+  }
+
+  const errorFiles = extractTypecheckErrorFiles(typeCheckOutput);
+  if (errorFiles.length === 0) {
+    // Errors present but no file attributable — do not wave it through.
+    return { passed: false, inScopeErrorFiles: [], outOfScopeErrorFiles: [] };
+  }
+
+  const inScope = errorFiles.filter((file) => isPathInScope(file, changedFiles));
+  const outOfScope = errorFiles.filter((file) => !isPathInScope(file, changedFiles));
+  return {
+    passed: inScope.length === 0,
+    inScopeErrorFiles: inScope,
+    outOfScopeErrorFiles: outOfScope,
+  };
+}
+
+/**
+ * Extract the source files named by `tsc --noEmit` diagnostics. Handles both
+ * pretty (`path/file.tsx:12:5 - error TS…`) and non-pretty
+ * (`path/file.tsx(12,5): error TS…`) formats.
+ */
+export function extractTypecheckErrorFiles(typeCheckOutput: string): string[] {
+  const files = new Set<string>();
+  const pattern = /^(.+?\.[cm]?tsx?)[(:]\d+/gm;
+  for (const match of typeCheckOutput.matchAll(pattern)) {
+    const raw = match[1]?.trim();
+    if (raw) files.add(raw.replace(/^\.\//, ""));
+  }
+  return [...files];
 }
 
 function deriveScopedFailureAxis(args: {
@@ -106,7 +223,23 @@ function deriveScopedFailureAxis(args: {
 }
 
 function isPathInScope(path: string, changedFiles: string[]): boolean {
-  return changedFiles.some((changed) => path === changed || path.includes(changed) || changed.includes(path));
+  // Treat a `.test.`/`.spec.` sibling as in-scope for its source file: a build
+  // that changes `foo.ts` owns failures in `foo.test.ts` even when only the
+  // source appears in the diffstat. Normalize both sides by stripping the
+  // test/spec infix before the containment check.
+  const norm = (p: string) => p.replace(/\.(test|spec)\.([cm]?[jt]sx?)$/, ".$2");
+  const np = norm(path);
+  return changedFiles.some((changed) => {
+    const nc = norm(changed);
+    return (
+      path === changed
+      || path.includes(changed)
+      || changed.includes(path)
+      || np === nc
+      || np.includes(nc)
+      || nc.includes(np)
+    );
+  });
 }
 
 function unique<T>(values: T[]): T[] {

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -1335,10 +1335,40 @@ export async function runBuildOrchestrator(params: {
       const { executeTool } = await import("@/lib/mcp-tools");
       const qaContent = qaResult.result.content;
       const verification = parseQAVerification(qaContent);
+
+      // Scope the gate verdict to the build's changed files. A QA specialist may
+      // run a wider pass than the feature's own surface (a stray "run full test
+      // suite" task, or `tsc` over all of apps/web), so a pre-existing failure
+      // ELSEWHERE in the repo would otherwise flip typecheckPassed=false and
+      // block a build whose own files are clean (the FB-69231490 stall).
+      // Neutralize out-of-scope noise here while preserving the full-repo signal.
+      let changedFiles: string[] = [];
+      try {
+        const { getSandboxStateForBuild } = await import("@/lib/build/sandbox-state");
+        const sandboxState = await getSandboxStateForBuild(buildId);
+        changedFiles = sandboxState?.sourceDiffstat.map((entry) => entry.path) ?? [];
+      } catch (err) {
+        console.warn("[orchestrator] could not resolve changed files for gate scoping:", (err as Error)?.message);
+      }
+      const { scopeVerificationOutputForGate } = await import("@/lib/build/scoped-verification");
+      const { normalizeVerificationOutput } = await import("@/lib/build/verification-output");
+      const scoped = scopeVerificationOutputForGate({
+        verification: normalizeVerificationOutput({ ...verification, fullOutput: qaContent }),
+        changedFiles,
+      });
+
       await executeTool("saveBuildEvidence", {
         field: "verificationOut",
         value: {
           ...verification,
+          // Gate-facing fields reflect the changed surface, not the whole repo.
+          typecheckPassed: scoped.typecheckPassed ?? verification.typecheckPassed,
+          testsFailed: scoped.testsFailed ?? verification.testsFailed,
+          testsPassed: scoped.testsPassed ?? verification.testsPassed,
+          outOfScopeNoise: scoped.outOfScopeNoise,
+          globalTestsFailed: scoped.globalTestsFailed,
+          failureAxis: scoped.failureAxis,
+          scopedToChangedFiles: changedFiles,
           fullOutput: qaContent.slice(0, 2000),
           timestamp: new Date().toISOString(),
         },

--- a/apps/web/lib/integrate/coding-agent.ts
+++ b/apps/web/lib/integrate/coding-agent.ts
@@ -366,8 +366,12 @@ export async function runSandboxTests(
   let typeCheckPassed = false;
   try {
     typeCheckOutput = await execInSandbox(containerId, "cd /workspace/apps/web && npx tsc --noEmit 2>&1 || true");
-    // Empty output or no TS errors = pass. Help text (no --noEmit) = also no "error TS" = pass.
-    typeCheckPassed = !typeCheckOutput.includes("error TS");
+    // `tsc` typechecks the whole apps/web project graph (no cheap per-file mode),
+    // so a pre-existing type error in an UNRELATED file would block a build whose
+    // own changed files are clean. When we know the changed surface, gate only on
+    // in-scope errors; with no scope hint, any error fails (legacy behavior).
+    const { typecheckPassedForChangedScope } = await import("@/lib/build/scoped-verification");
+    typeCheckPassed = typecheckPassedForChangedScope(typeCheckOutput, opts?.changedFiles ?? []).passed;
   } catch (e) {
     typeCheckOutput = e instanceof Error ? e.message : String(e);
   }


### PR DESCRIPTION
## Problem

A local Build Studio build (**FB-69231490**, the `classifySemanticId` helper) completed its code-gen tasks but **stalled in the build phase** — never advancing to review, status stuck on "Run scoped verification".

Root cause for the **gate**: the build→review gate (`checkPhaseGate` → `verification-typecheck-passed`) reads `verificationOut.typecheckPassed` verbatim. But:
- The orchestrator (`build-orchestrator.ts`) wrote that field from **unscoped** `parseQAVerification(qaContent)`.
- `runSandboxTests` (`coding-agent.ts`) runs `tsc --noEmit` over **all of `apps/web`**.

So a pre-existing failure **elsewhere** in the repo (an unrelated `.tsx` test, or a route-group page) flipped `typecheckPassed=false` and blocked a build whose **own changed files were clean**. This realizes [#1988](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1988)'s intent end-to-end.

## Fix

- **`scopeVerificationOutputForGate()`** + **`typecheckPassedForChangedScope()`** in `scoped-verification.ts`: when **every** observed failure is outside the changed surface, report the build's own surface clean (`typecheckPassed=true`, `testsFailed=0`) while preserving the full-repo signal in `globalTestsFailed`. An **in-scope** failure (the feature's own tests/typecheck) still blocks.
- The **orchestrator** resolves changed files (`sourceDiffstat`) and writes a scoped `verificationOut`.
- `runSandboxTests` typecheck now gates only on **in-scope** `error TS` files.
- **`extractFilePathsFromText`** now captures Next.js route-group paths (`app/(shell)/…`) — the exact file that stalled FB-69231490 was previously unextractable, so out-of-scope classification silently failed.
- **`isPathInScope`** treats a `.test.`/`.spec.` sibling as in-scope for its source file.
- Unit tests for all new helpers.

## Acceptance

A local build whose own changed-file tests + typecheck pass advances to review **even when an unrelated pre-existing test is broken in the repo**.

## Substrate

Pure-function unit tests with no runtime deps — executed by the CI **Unit Tests** job (clean install). The topic worktree is source-only (no `node_modules`), so they were not run locally per AGENTS.md §5 ("an unrun gate, not a red gate").

BI-4890FDC3 · part of the FB-69231490 build-reliability series (sandbox health + stall surfacing follow in sibling PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
