### PR TITLE
fix(build-studio): scope the build->review gate so unrelated failures don't stall every build

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -1435,8 +1435,31 @@ export async function runBuildOrchestrator(params: {
     const updatedBuild = await prisma.featureBuild.findUnique({ where: { buildId } });
     const hasBlockingTasks = allResults.some((r) => r.outcome === "BLOCKED" || r.outcome === "NEEDS_CONTEXT");
     if (!hasBlockingTasks && updatedBuild && updatedBuild.phase === "build" && canTransitionPhase("build", "review")) {
+      // Scope the verification to THIS build's changed files before gating.
+      // A pre-existing typecheck/test failure ELSEWHERE in the repo (e.g. an
+      // unrelated broken test, a stale sandbox) otherwise sets
+      // verificationOut.typecheckPassed=false and stalls EVERY build at
+      // build->review even though the build's OWN files are clean — observed
+      // live: a build's full-suite verification hit an unrelated rolldown parse
+      // error and never advanced. getScopedVerificationForBuild nulls
+      // out-of-scope failures; treat null (out-of-scope only) as a pass, keep an
+      // in-scope failure (false) blocking.
+      let verificationForGate: Record<string, unknown> | unknown = updatedBuild.verificationOut;
+      try {
+        const { getScopedVerificationForBuild } = await import("@/lib/build/scoped-verification");
+        const scoped = await getScopedVerificationForBuild(buildId);
+        if (scoped) {
+          verificationForGate = {
+            ...((updatedBuild.verificationOut ?? {}) as Record<string, unknown>),
+            typecheckPassed: scoped.buildScoped.typecheckPassed ?? true,
+            testsFailed: scoped.buildScoped.testsFailed ?? 0,
+          };
+        }
+      } catch (scopeErr) {
+        console.warn("[orchestrator] scoped verification for gate failed; using raw verificationOut:", (scopeErr as Error)?.message);
+      }
       const gate = checkPhaseGate("build", "review", {
-        verificationOut: updatedBuild.verificationOut,
+        verificationOut: verificationForGate as typeof updatedBuild.verificationOut,
       });
       if (gate.allowed) {
         await prisma.featureBuild.update({ where: { buildId }, data: { phase: "review" } });


### PR DESCRIPTION
## What
Before the build->review auto-advance gate, scope the verification to the build's **changed files** (via `getScopedVerificationForBuild`, which nulls out-of-scope failures). A pre-existing failure *elsewhere* in the repo no longer blocks a build whose own files are clean. An in-scope failure still blocks. Fails open to the raw result.

## Why (found live)
The first end-to-end local build (FB-69231490) generated code, finished its tasks, then **stalled at build->review** (agent quiet 11+ min). The gate reads raw `verificationOut.typecheckPassed`, which went `false` because the full-suite verification hit an **unrelated** pre-existing failure (a rolldown parse error in an identity page test + stale sandbox). So a broken test *anywhere* stalls *every* build — the prerequisite blocker to validating builds to completion.

## Verification
tsc clean; `scoped-verification` + `checkPhaseGate` are unit-tested separately. Functional proof is the next local build advancing to review despite an unrelated pre-existing failure.

## Note
Complements the in-progress build-completion-robustness thread (stall recovery, sandbox health, over-decomposition). This PR is the minimal gate-scoping unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)