### PR TITLE
fix(build-studio): sandbox toolchain preflight — auto-restore unloadable node_modules (BI-6D26A77A)

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -1177,6 +1177,47 @@ export async function runBuildOrchestrator(params: {
     }
   }
 
+  // ─── Pre-flight check: sandbox test toolchain is loadable ────────────────
+  // The shared sandbox (dpf-sandbox-1) reuses node_modules across builds. A
+  // stale/partial install makes vitest fail to LOAD (rolldown native-binding
+  // error, vitest-not-found) and surfaces later as a confusing parse error on a
+  // valid file — the FB-69231490 stall. Heal it BEFORE dispatching tasks so the
+  // QA specialist's verification runs against a sound toolchain; if it cannot be
+  // healed, block LOUD with the structured diagnosis instead of letting a
+  // specialist hang on an opaque failure.
+  try {
+    const { ensureSandboxToolchainHealthy } = await import("./sandbox/sandbox-toolchain-health");
+    const health = await ensureSandboxToolchainHealthy(sandboxContainer);
+    if (health.restored) {
+      await prisma.buildActivity.create({
+        data: {
+          buildId,
+          tool: "sandbox:toolchain-restored",
+          summary: `Sandbox toolchain was unloadable (${health.signature ?? "unknown"}); auto-restored node_modules before dispatch.`,
+        },
+      }).catch(() => {});
+    }
+    if (!health.healthy) {
+      return {
+        content: formatCoworkerOperationalCloseout({
+          status: "blocked before implementation",
+          evidence:
+            `the build sandbox test toolchain is not loadable` +
+            `${health.signature ? ` (${health.signature})` : ""}: ${health.diagnosis ?? "vitest could not load after a clean reinstall."} ` +
+            `This is sandbox state, not a code defect.`,
+          nextAction: "recover the sandbox (diagnose_sandbox / recover_sandbox) or rebuild its node_modules, then retry implementation.",
+          owner: "operator/admin",
+        }),
+        totalTasks: 0, completedTasks: 0, failedTasks: 0,
+        specialistResults: [], totalInputTokens: 0, totalOutputTokens: 0,
+      };
+    }
+  } catch (err) {
+    // A probe failure must not hard-stop the build — log and proceed; the QA
+    // gate still guards the advance.
+    console.warn("[orchestrator] toolchain preflight skipped:", (err as Error)?.message);
+  }
+
   // Build dependency graph from plan
   const phases = buildDependencyGraph(
     normalizedPlan.plan.fileStructure ?? [],

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -331,11 +331,38 @@ async function stepInitDb(
 }
 
 async function stepInstallDeps(
-  _buildId: string,
+  buildId: string,
   state: BuildExecutionState,
 ): Promise<BuildExecutionState> {
   const { installDepsAndStart } = await import("./sandbox/sandbox-workspace");
   await installDepsAndStart(state.containerId!);
+
+  // Preflight the test toolchain. The shared pool sandbox reuses node_modules
+  // across builds; a stale/partial install makes vitest fail to LOAD (rolldown
+  // native-binding error, vitest-not-found) and surfaces later as a confusing
+  // parse error on a valid file — the FB-69231490 stall. Heal it here so the
+  // sandbox is sound for every subsequent command (run_sandbox_command,
+  // run_sandbox_tests, the QA specialist). If it cannot be healed, fail LOUD
+  // with the structured diagnosis rather than proceeding to an opaque failure.
+  const { ensureSandboxToolchainHealthy } = await import("./sandbox/sandbox-toolchain-health");
+  const health = await ensureSandboxToolchainHealthy(state.containerId!);
+  if (health.restored) {
+    const { prisma } = await import("@dpf/db");
+    await prisma.buildActivity.create({
+      data: {
+        buildId,
+        tool: "sandbox:toolchain-restored",
+        summary: `Sandbox toolchain was unloadable (${health.signature ?? "unknown"}); auto-restored node_modules before verification.`,
+      },
+    }).catch(() => {});
+  }
+  if (!health.healthy) {
+    throw new Error(
+      `Sandbox toolchain is not loadable${health.signature ? ` (${health.signature})` : ""}: ` +
+      `${health.diagnosis ?? "vitest could not be loaded after a clean reinstall."} ` +
+      `This is sandbox state, not a code defect — recover the sandbox before retrying.`,
+    );
+  }
   return state;
 }
 

--- a/apps/web/lib/integrate/sandbox/sandbox-toolchain-health.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-toolchain-health.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyToolchainFailure,
+  interpretVersionProbe,
+  isRestorableSignature,
+} from "./sandbox-toolchain-health";
+
+describe("classifyToolchainFailure", () => {
+  it("recognizes a rolldown native-binding failure", () => {
+    const out = "Error: failed to load native binding\n  at rolldown ...";
+    const result = classifyToolchainFailure(out);
+    expect(result.signature).toBe("native-binding");
+    expect(result.diagnosis).toMatch(/native binding/i);
+  });
+
+  it("recognizes vitest-not-found", () => {
+    expect(classifyToolchainFailure("sh: 1: vitest: not found").signature).toBe("vitest-missing");
+    expect(classifyToolchainFailure("command not found: vitest").signature).toBe("vitest-missing");
+  });
+
+  it("recognizes a module-load failure", () => {
+    expect(classifyToolchainFailure("Error [ERR_MODULE_NOT_FOUND]: ...").signature).toBe("module-load");
+    expect(classifyToolchainFailure("Cannot find module 'tinypool'").signature).toBe("module-load");
+  });
+
+  it("recognizes out-of-memory", () => {
+    expect(classifyToolchainFailure("FATAL ERROR: JavaScript heap out of memory").signature).toBe("out-of-memory");
+  });
+
+  it("returns null for a normal test pass", () => {
+    expect(classifyToolchainFailure("Test Files  3 passed (3)\nTests  12 passed").signature).toBeNull();
+  });
+
+  it("returns null for an ordinary test failure (not a toolchain problem)", () => {
+    expect(classifyToolchainFailure("FAIL src/foo.test.ts > does a thing\nexpected 1 to be 2").signature).toBeNull();
+  });
+});
+
+describe("isRestorableSignature", () => {
+  it("treats node_modules-corruption signatures as restorable", () => {
+    expect(isRestorableSignature("native-binding")).toBe(true);
+    expect(isRestorableSignature("vitest-missing")).toBe(true);
+    expect(isRestorableSignature("module-load")).toBe(true);
+  });
+
+  it("does not restore for out-of-memory or no failure", () => {
+    expect(isRestorableSignature("out-of-memory")).toBe(false);
+    expect(isRestorableSignature(null)).toBe(false);
+  });
+});
+
+describe("interpretVersionProbe", () => {
+  it("is healthy when a version string is printed", () => {
+    const probe = interpretVersionProbe("4.0.1");
+    expect(probe.healthy).toBe(true);
+    expect(probe.signature).toBeNull();
+  });
+
+  it("is unhealthy with a signature when the probe shows a load failure", () => {
+    const probe = interpretVersionProbe("Error: failed to load native binding (rolldown)");
+    expect(probe.healthy).toBe(false);
+    expect(probe.signature).toBe("native-binding");
+  });
+
+  it("treats a version-less, signature-less probe as a module-load failure", () => {
+    const probe = interpretVersionProbe("");
+    expect(probe.healthy).toBe(false);
+    expect(probe.signature).toBe("module-load");
+  });
+});

--- a/apps/web/lib/integrate/sandbox/sandbox-toolchain-health.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-toolchain-health.ts
@@ -1,0 +1,179 @@
+// apps/web/lib/integrate/sandbox/sandbox-toolchain-health.ts
+//
+// Toolchain preflight for the build sandbox.
+//
+// The shared pool sandbox (dpf-sandbox-1) reuses node_modules across builds. A
+// stale or partially-corrupted install makes `pnpm exec vitest` fail to LOAD —
+// "vitest: not found", an ERR_MODULE_NOT_FOUND, or a rolldown native-binding /
+// transform error that surfaces as a confusing parse error ("Unexpected JSX
+// expression") on a perfectly valid .tsx. CI (a fresh install) passes, so it is
+// sandbox state, not a code bug. A build that hits this either records a false
+// red verdict or stalls with an opaque message.
+//
+// This module gives the pipeline a fast, deterministic preflight: probe that
+// the test toolchain LOADS, and on a recognized failure signature either
+// auto-restore the install (rm -rf node_modules && pnpm install) or surface the
+// diagnosis loudly with a structured signature — never a confusing parse error.
+//
+// The detection/classification functions are pure and unit-tested; the exec
+// wrappers are thin so the same logic runs in the durable pipeline and in any
+// caller that runs tests in the sandbox.
+
+export type ToolchainFailureSignature =
+  | "vitest-missing"
+  | "module-load"
+  | "native-binding"
+  | "out-of-memory";
+
+export type ToolchainProbe = {
+  healthy: boolean;
+  signature: ToolchainFailureSignature | null;
+  /** Operator-facing one-line diagnosis. */
+  diagnosis: string | null;
+};
+
+export type ToolchainHealthResult = ToolchainProbe & {
+  /** True when a clean reinstall was performed during this call. */
+  restored: boolean;
+};
+
+// Ordered most-specific-first. Each entry maps a recognizable substring in the
+// toolchain's stderr/stdout to a structured signature + plain-English cause.
+const FAILURE_PATTERNS: Array<{
+  signature: ToolchainFailureSignature;
+  test: RegExp;
+  diagnosis: string;
+}> = [
+  {
+    signature: "native-binding",
+    test: /rolldown|failed to load native binding|code signature|napi|\.node['"]?\s*(?:not found|invalid)|invalid ELF header/i,
+    diagnosis:
+      "Sandbox node_modules has a broken native binding (rolldown/napi) — vitest cannot load. Stale/partial install.",
+  },
+  {
+    signature: "vitest-missing",
+    test: /vitest:?\s*(?:command\s+)?not found|command not found:\s*vitest|no such file or directory.*vitest/i,
+    diagnosis: "vitest is not installed in the sandbox — node_modules is missing or incomplete.",
+  },
+  {
+    signature: "module-load",
+    test: /ERR_MODULE_NOT_FOUND|Cannot find (?:module|package)|ERR_REQUIRE_ESM|Failed to resolve (?:entry|import)/i,
+    diagnosis: "A module failed to resolve in the sandbox — node_modules is stale relative to the lockfile.",
+  },
+  {
+    signature: "out-of-memory",
+    test: /JavaScript heap out of memory|ENOMEM|Killed/i,
+    diagnosis: "The toolchain ran out of memory in the sandbox — not a node_modules corruption.",
+  },
+];
+
+/**
+ * Classify raw toolchain output for a load/availability failure. Returns the
+ * first matching signature, or null when the output shows no recognized
+ * toolchain-load failure (a normal test PASS or an ordinary test FAILURE both
+ * return null — those are not toolchain problems).
+ */
+export function classifyToolchainFailure(output: string): {
+  signature: ToolchainFailureSignature | null;
+  diagnosis: string | null;
+} {
+  const text = output ?? "";
+  for (const { signature, test, diagnosis } of FAILURE_PATTERNS) {
+    if (test.test(text)) {
+      return { signature, diagnosis };
+    }
+  }
+  return { signature: null, diagnosis: null };
+}
+
+/**
+ * A node_modules-corruption signature is auto-restorable (a clean reinstall
+ * fixes it). Out-of-memory is NOT — restoring would waste minutes and fail
+ * again, so it is surfaced rather than retried.
+ */
+export function isRestorableSignature(signature: ToolchainFailureSignature | null): boolean {
+  return signature === "native-binding" || signature === "vitest-missing" || signature === "module-load";
+}
+
+/**
+ * Interpret the result of a `vitest --version` probe. Healthy iff the command
+ * printed a version string and showed no failure signature.
+ */
+export function interpretVersionProbe(output: string): ToolchainProbe {
+  const { signature, diagnosis } = classifyToolchainFailure(output);
+  if (signature) {
+    return { healthy: false, signature, diagnosis };
+  }
+  // A working `vitest --version` prints a semver line (e.g. "vitest/4.0.1" or
+  // "4.0.1"). Absence of any version token alongside no recognized signature is
+  // still suspicious — treat as a module-load failure so it gets restored.
+  if (/\d+\.\d+\.\d+/.test(output)) {
+    return { healthy: true, signature: null, diagnosis: null };
+  }
+  return {
+    healthy: false,
+    signature: "module-load",
+    diagnosis: "vitest --version produced no version string in the sandbox — toolchain is not loadable.",
+  };
+}
+
+// ─── Sandbox-bound operations (thin wrappers over execInSandbox) ──────────────
+
+const VERSION_PROBE_CMD = "cd /workspace/apps/web && npx vitest --version 2>&1 || true";
+const RESTORE_CMD =
+  "cd /workspace && rm -rf node_modules apps/web/node_modules packages/*/node_modules " +
+  "&& (pnpm install --frozen-lockfile 2>&1 || pnpm install 2>&1) " +
+  "&& (pnpm --filter @dpf/db exec prisma generate 2>&1 || true)";
+
+/**
+ * Probe that the sandbox test toolchain loads. Best-effort: an exec failure is
+ * itself classified (it usually carries the failure text on stderr).
+ */
+export async function probeSandboxToolchain(containerId: string): Promise<ToolchainProbe> {
+  const { execInSandbox } = await import("./sandbox");
+  let output: string;
+  try {
+    output = await execInSandbox(containerId, VERSION_PROBE_CMD);
+  } catch (err) {
+    output = err instanceof Error ? err.message : String(err);
+  }
+  return interpretVersionProbe(output);
+}
+
+/**
+ * Clean-reinstall the sandbox node_modules. Returns the install output for
+ * evidence/diagnosis.
+ */
+export async function restoreSandboxToolchain(containerId: string): Promise<string> {
+  const { execInSandbox } = await import("./sandbox");
+  return execInSandbox(containerId, RESTORE_CMD);
+}
+
+/**
+ * Ensure the sandbox test toolchain is loadable BEFORE verification runs.
+ *
+ * Probe → if broken with a restorable signature and autoRestore !== false,
+ * clean-reinstall once and re-probe. The final result names the outcome so a
+ * caller can fail LOUD with a structured diagnosis (failureAxis) instead of
+ * letting a confusing parse error masquerade as a code defect.
+ */
+export async function ensureSandboxToolchainHealthy(
+  containerId: string,
+  opts?: { autoRestore?: boolean },
+): Promise<ToolchainHealthResult> {
+  const autoRestore = opts?.autoRestore !== false;
+  const first = await probeSandboxToolchain(containerId);
+  if (first.healthy) {
+    return { ...first, restored: false };
+  }
+  if (!autoRestore || !isRestorableSignature(first.signature)) {
+    return { ...first, restored: false };
+  }
+
+  console.warn(
+    `[sandbox-toolchain] ${containerId}: ${first.signature} — ${first.diagnosis} Restoring node_modules…`,
+  );
+  await restoreSandboxToolchain(containerId);
+  const second = await probeSandboxToolchain(containerId);
+  return { ...second, restored: true };
+}


### PR DESCRIPTION
## Problem

The shared pool sandbox (`dpf-sandbox-1`) reuses `node_modules` across builds. A stale or partially-corrupted install makes `pnpm exec vitest` **fail to load** — `vitest: not found`, `ERR_MODULE_NOT_FOUND`, or a rolldown native-binding error that surfaces as a **confusing parse error** ("Unexpected JSX expression") on a perfectly valid `.tsx`. CI (a fresh install) passes, so it is **sandbox state, not a code bug**.

This was a root cause of the **FB-69231490** build stall, and the long-known *"Restore sandbox node_modules — vitest not found blocks test"* backlog gap.

## Fix

- **`sandbox-toolchain-health.ts`** — pure, unit-tested classification: `classifyToolchainFailure` / `interpretVersionProbe` / `isRestorableSignature` → signatures `native-binding | vitest-missing | module-load | out-of-memory`. Thin `probeSandboxToolchain` / `restoreSandboxToolchain` / `ensureSandboxToolchainHealthy(autoRestore)` wrappers over `execInSandbox`.
- Wired into **both** build paths: the durable pipeline (`stepInstallDeps`) and the agentic **orchestrator** startup (the path FB-69231490 used).
- Behavior: probe → restorable signature ⇒ clean reinstall once (`rm -rf node_modules … && pnpm install … && prisma generate`) and re-probe → still broken ⇒ **fail/block LOUD** with the structured diagnosis instead of an opaque parse error. `out-of-memory` is surfaced, not retried.

Supersedes the existing *"Restore sandbox node_modules"* backlog gap.

## Acceptance

A broken sandbox is **auto-healed** before verification, or **reported clearly** with its signature — no more confusing parse errors masquerading as code defects.

## Substrate

Pure-function unit tests — executed by the CI **Unit Tests** job (clean install). The topic worktree is source-only (no `node_modules`), so not run locally per AGENTS.md §5.

BI-6D26A77A · part of the FB-69231490 build-reliability series (gate scoping #2019; stall surfacing + planner right-size follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
