### PR TITLE
fix(build-studio): surface a stalled build phase as actionable BLOCKED (BI-11FF1EA4)

### DIFF
--- a/apps/web/lib/observability/stall-surface.test.ts
+++ b/apps/web/lib/observability/stall-surface.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStallSurface,
+  mergeVerificationPatch,
+  stallReasonToFailureAxis,
+} from "./stall-surface";
+
+describe("stallReasonToFailureAxis", () => {
+  it("maps every stall reason to the timeout axis", () => {
+    expect(stallReasonToFailureAxis("heartbeat_timeout")).toBe("timeout");
+    expect(stallReasonToFailureAxis("total_timeout")).toBe("timeout");
+    expect(stallReasonToFailureAxis("never_started")).toBe("timeout");
+  });
+});
+
+describe("buildStallSurface", () => {
+  it("flips an in-flight step to a failed checkpoint that resumes from it", () => {
+    const surface = buildStallSurface({
+      reason: "heartbeat_timeout",
+      phase: "build",
+      heartbeatTimeoutSeconds: 180,
+      totalPhaseTimeoutSeconds: 3600,
+      priorExecState: { step: "code_generated", retryCount: 0, containerId: "dpf-sandbox-1" },
+      now: "2026-06-16T01:00:00.000Z",
+    });
+
+    expect(surface.failureAxis).toBe("timeout");
+    expect(surface.execState.step).toBe("failed");
+    expect(surface.execState.failedAt).toBe("code_generated");
+    expect(surface.execState.stalledByWatchdog).toBe(true);
+    expect(surface.execState.containerId).toBe("dpf-sandbox-1"); // prior fields preserved
+    expect(surface.error).toMatch(/stalled \(heartbeat_timeout\)/);
+    expect(surface.verificationPatch).toEqual({
+      failureAxis: "timeout",
+      stalledByWatchdog: true,
+      observedAt: "2026-06-16T01:00:00.000Z",
+    });
+  });
+
+  it("falls back to code_generated when there is no usable prior step", () => {
+    const surface = buildStallSurface({
+      reason: "total_timeout",
+      phase: "build",
+      heartbeatTimeoutSeconds: 180,
+      totalPhaseTimeoutSeconds: 3600,
+      priorExecState: null,
+      now: "2026-06-16T01:00:00.000Z",
+    });
+    expect(surface.execState.failedAt).toBe("code_generated");
+  });
+
+  it("does not treat a terminal step as the resume point", () => {
+    const surface = buildStallSurface({
+      reason: "heartbeat_timeout",
+      phase: "build",
+      heartbeatTimeoutSeconds: 180,
+      totalPhaseTimeoutSeconds: 3600,
+      priorExecState: { step: "complete", failedAt: "tests_run" },
+      now: "2026-06-16T01:00:00.000Z",
+    });
+    expect(surface.execState.failedAt).toBe("tests_run");
+  });
+});
+
+describe("mergeVerificationPatch", () => {
+  it("merges over an existing verificationOut, preserving prior fields", () => {
+    const merged = mergeVerificationPatch(
+      { testsPassed: 3, fullOutput: "ok" },
+      { failureAxis: "timeout", stalledByWatchdog: true, observedAt: "2026-06-16T01:00:00.000Z" },
+    );
+    expect(merged.testsPassed).toBe(3);
+    expect(merged.failureAxis).toBe("timeout");
+    expect(merged.stalledByWatchdog).toBe(true);
+  });
+
+  it("tolerates a null/non-object existing value", () => {
+    const merged = mergeVerificationPatch(null, {
+      failureAxis: "timeout",
+      stalledByWatchdog: true,
+      observedAt: "2026-06-16T01:00:00.000Z",
+    });
+    expect(merged.failureAxis).toBe("timeout");
+  });
+});

--- a/apps/web/lib/observability/stall-surface.ts
+++ b/apps/web/lib/observability/stall-surface.ts
@@ -1,0 +1,90 @@
+// apps/web/lib/observability/stall-surface.ts
+//
+// When the watchdog detects a stalled build-phase TaskRun it records a
+// StallEvent + Notification, but historically left the FeatureBuild itself
+// untouched: phase stayed "build", buildExecState stayed mid-step, and the
+// progress panel surfaced no failureAxis. The build just sat quiet — exactly
+// the FB-69231490 symptom ("agent quiet 11+ min, never advanced").
+//
+// This module derives the build-state mutations that turn a silent stall into
+// an ACTIONABLE blocked state: flip buildExecState to a failed checkpoint (which
+// lights up the existing Reset/Resume recovery affordances) and stamp a
+// failureAxis the progress visibility layer (deriveFailureAxis) can surface.
+//
+// Pure + unit-tested; the watchdog applies the result in its stall transaction.
+
+import type { BuildFailureAxis } from "@/lib/build/progress-visibility-types";
+
+export type StallReason =
+  | "heartbeat_timeout"
+  | "total_timeout"
+  | "never_started"
+  | "parent_stalled"
+  | "parent_abandoned";
+
+/**
+ * Map a watchdog stall reason to a closed BuildFailureAxis. From the build's
+ * perspective every stall is a timeout — work went quiet and never produced a
+ * verdict — so "timeout" is the honest closed-axis value.
+ */
+export function stallReasonToFailureAxis(_reason: StallReason): BuildFailureAxis {
+  return "timeout";
+}
+
+export type StallSurface = {
+  failureAxis: BuildFailureAxis;
+  error: string;
+  /** New buildExecState JSON to persist (failed checkpoint). */
+  execState: Record<string, unknown>;
+  /** Patch to merge into verificationOut so deriveFailureAxis surfaces it. */
+  verificationPatch: { failureAxis: BuildFailureAxis; stalledByWatchdog: true; observedAt: string };
+};
+
+/**
+ * Derive the build-state mutations for a stalled build-phase TaskRun.
+ *
+ * The failed checkpoint reuses the last in-flight step as `failedAt` so the
+ * resume path (taskrunRetry "resume-build" → runBuildPipeline(existingState))
+ * picks up where it stalled. Terminal/absent steps fall back to
+ * "code_generated" — the step before verification, the common stall point.
+ */
+export function buildStallSurface(args: {
+  reason: StallReason;
+  phase: string | null;
+  heartbeatTimeoutSeconds: number;
+  totalPhaseTimeoutSeconds: number;
+  priorExecState: Record<string, unknown> | null;
+  now: string;
+}): StallSurface {
+  const failureAxis = stallReasonToFailureAxis(args.reason);
+  const error =
+    `Build ${args.phase ?? "build"} phase stalled (${args.reason}) — no heartbeat within ` +
+    `${args.heartbeatTimeoutSeconds}s (total budget ${args.totalPhaseTimeoutSeconds}s). ` +
+    `Surfaced by the watchdog; resume to re-run from the last checkpoint.`;
+
+  const prior = args.priorExecState ?? {};
+  const priorStep = typeof prior.step === "string" ? prior.step : undefined;
+  const priorFailedAt = typeof prior.failedAt === "string" ? prior.failedAt : undefined;
+  const failedAt =
+    priorStep && priorStep !== "failed" && priorStep !== "complete"
+      ? priorStep
+      : priorFailedAt ?? "code_generated";
+
+  return {
+    failureAxis,
+    error,
+    execState: { ...prior, step: "failed", failedAt, error, stalledByWatchdog: true },
+    verificationPatch: { failureAxis, stalledByWatchdog: true, observedAt: args.now },
+  };
+}
+
+/** Merge the verification patch over an existing verificationOut JSON value. */
+export function mergeVerificationPatch(
+  existing: unknown,
+  patch: StallSurface["verificationPatch"],
+): Record<string, unknown> {
+  const base = existing && typeof existing === "object" && !Array.isArray(existing)
+    ? (existing as Record<string, unknown>)
+    : {};
+  return { ...base, ...patch };
+}

--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -19,6 +19,7 @@
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { decideStall, type WatchdogCandidate, type StallDecision } from "@/lib/observability/watchdog-detect";
+import { buildStallSurface, mergeVerificationPatch } from "@/lib/observability/stall-surface";
 import { isStallWatchdogEnabled } from "@/lib/shared/feature-flags";
 
 // QUIESCENCE EXEMPTION (BI-QUIESCE-004a + spec §6.1 extension): this
@@ -194,13 +195,33 @@ export const taskrunWatchdog = inngest.createFunction(
       // task user. If neither resolves, skip notification — the StallEvent
       // row is the durable record.
       let notifyUserId: string | null = idEntry.userId ?? null;
+      let buildRow: { createdById: string | null; buildExecState: unknown; verificationOut: unknown } | null = null;
       if (d.candidate.buildId) {
-        const fb = await prisma.featureBuild.findUnique({
+        buildRow = await prisma.featureBuild.findUnique({
           where: { buildId: d.candidate.buildId },
-          select: { createdById: true },
+          select: { createdById: true, buildExecState: true, verificationOut: true },
         });
-        if (fb?.createdById) notifyUserId = fb.createdById;
+        if (buildRow?.createdById) notifyUserId = buildRow.createdById;
       }
+
+      // Surface a build-phase stall as an ACTIONABLE blocked state (failed
+      // checkpoint + failureAxis) so the build no longer sits silently quiet —
+      // the FB-69231490 symptom. Only the build phase: other phases own their
+      // own recovery flows.
+      const stallSurface =
+        d.candidate.buildId && buildRow && d.candidate.phase === "build"
+          ? buildStallSurface({
+              reason: d.reason as import("@/lib/observability/stall-surface").StallReason,
+              phase: d.candidate.phase,
+              heartbeatTimeoutSeconds: d.threshold.heartbeatTimeoutSeconds,
+              totalPhaseTimeoutSeconds: d.threshold.totalPhaseTimeoutSeconds,
+              priorExecState:
+                buildRow.buildExecState && typeof buildRow.buildExecState === "object" && !Array.isArray(buildRow.buildExecState)
+                  ? (buildRow.buildExecState as Record<string, unknown>)
+                  : null,
+              now: now.toISOString(),
+            })
+          : null;
 
       await prisma.$transaction(async (tx) => {
         // 1. Transition TaskRun.
@@ -234,6 +255,22 @@ export const taskrunWatchdog = inngest.createFunction(
               buildId: d.candidate.buildId,
               tool: "watchdog:stall",
               summary: `Watchdog detected stall (${d.reason}) in phase ${d.candidate.phase}`,
+            },
+          });
+        }
+
+        // 3b. Surface the build-phase stall as an actionable failed checkpoint
+        //     so the operator sees Reset/Resume + a failureAxis instead of a
+        //     silently quiet build.
+        if (stallSurface && d.candidate.buildId) {
+          await tx.featureBuild.update({
+            where: { buildId: d.candidate.buildId },
+            data: {
+              buildExecState: stallSurface.execState as import("@dpf/db").Prisma.InputJsonValue,
+              verificationOut: mergeVerificationPatch(
+                buildRow?.verificationOut,
+                stallSurface.verificationPatch,
+              ) as import("@dpf/db").Prisma.InputJsonValue,
             },
           });
         }


### PR DESCRIPTION
## Problem

**FB-69231490** went quiet 11+ min in the build phase and never advanced. The `taskrun-watchdog` **detects** the stall (`StallEvent` + `Notification` + `taskrun:stalled` AgentEvent + `TaskRun.status=stalled`) — but it left the `FeatureBuild` itself untouched: phase stayed `build`, `buildExecState` stayed mid-step, and the progress panel (`deriveFailureAxis`) surfaced **no failureAxis**. The build just sat silently quiet with no recovery affordance lit.

## Fix

- **`observability/stall-surface.ts`** (pure, unit-tested): `stallReasonToFailureAxis` → `"timeout"`; `buildStallSurface` → a **failed `buildExecState` checkpoint** whose `failedAt` = the last in-flight step (so `taskrunRetry` "resume-build" picks up there) + a verification patch carrying `failureAxis`; `mergeVerificationPatch`.
- The watchdog's stall transaction now — **for build-phase stalls only** — flips `buildExecState` to failed and stamps `verificationOut.failureAxis`, so the operator sees Reset/Resume + a failureAxis instead of a quiet build.

Existing operator recovery (`taskrunRetry` resume-build) already resumes from the checkpoint, so this closes the "silent stall" gap without new UI.

## Acceptance

A build phase quiet past its heartbeat/total threshold is surfaced as an **actionable BLOCKED** with a `failureAxis`, not left silently stalled.

## Substrate

Pure-function unit tests — executed by the CI **Unit Tests** job (clean install). The topic worktree is source-only, so not run locally per AGENTS.md §5.

BI-11FF1EA4 · part of the FB-69231490 build-reliability series (gate scoping #2019, sandbox health #2021, planner right-size in a sibling PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
