### PR TITLE
fix(build-studio): prune redundant full-suite verification tasks from the plan (BI-9C217A02)

### DIFF
--- a/apps/web/lib/integrate/task-dependency-graph.test.ts
+++ b/apps/web/lib/integrate/task-dependency-graph.test.ts
@@ -1,5 +1,44 @@
 import { describe, it, expect } from "vitest";
-import { buildDependencyGraph, type PlanTask, type PlanFileEntry } from "./task-dependency-graph";
+import {
+  buildDependencyGraph,
+  isRedundantVerificationTask,
+  type PlanTask,
+  type PlanFileEntry,
+} from "./task-dependency-graph";
+
+describe("isRedundantVerificationTask", () => {
+  const t = (over: Partial<PlanTask>): PlanTask => ({ title: "", testFirst: "", implement: "", verify: "", ...over });
+
+  it("flags explicit full/entire/all test-suite tasks", () => {
+    expect(isRedundantVerificationTask(t({ title: "Run the full test suite" }))).toBe(true);
+    expect(isRedundantVerificationTask(t({ title: "Run all tests" }))).toBe(true);
+    expect(isRedundantVerificationTask(t({ title: "Full verification" }))).toBe(true);
+    expect(isRedundantVerificationTask(t({ verify: "pnpm test" }))).toBe(true);
+    expect(isRedundantVerificationTask(t({ implement: "pnpm -r test" }))).toBe(true);
+  });
+
+  it("does NOT flag a real implementation/test-writing task", () => {
+    expect(isRedundantVerificationTask(t({ title: "Add classifySemanticId helper", implement: "write the function" }))).toBe(false);
+    expect(isRedundantVerificationTask(t({ title: "Write unit tests for the helper", verify: "tests cover each kind" }))).toBe(false);
+  });
+
+  it("prunes redundant tasks while keeping the synthetic QA phase", () => {
+    const files: PlanFileEntry[] = [
+      { path: "apps/web/lib/utils/semanticIdClassifier.ts", action: "create", purpose: "helper" },
+    ];
+    const tasks: PlanTask[] = [
+      { title: "Add classifySemanticId helper", testFirst: "", implement: "write helper", verify: "" },
+      { title: "Run full test suite", testFirst: "", implement: "pnpm test", verify: "" },
+      { title: "Full verification", testFirst: "", implement: "", verify: "run all tests" },
+    ];
+    const phases = buildDependencyGraph(files, tasks);
+    const allTitles = phases.flatMap((p) => p.tasks.map((tk) => tk.title));
+    expect(allTitles).not.toContain("Run full test suite");
+    expect(allTitles.filter((x) => x === "Full verification: tests + typecheck")).toHaveLength(1);
+    // Exactly one verification phase remains (the synthetic QA one).
+    expect(phases[phases.length - 1]!.tasks[0]!.specialist).toBe("qa-engineer");
+  });
+});
 
 describe("buildDependencyGraph", () => {
   it("puts schema tasks in phase 1, API in phase 2, frontend in phase 3, QA last", () => {

--- a/apps/web/lib/integrate/task-dependency-graph.ts
+++ b/apps/web/lib/integrate/task-dependency-graph.ts
@@ -125,6 +125,33 @@ function classifyFromTask(task: PlanTask): SpecialistRole {
   return "software-engineer";
 }
 
+// --- Redundant verification task pruning -------------------------------------
+//
+// buildDependencyGraph ALWAYS appends a synthetic QA phase ("Full verification:
+// tests + typecheck", run via scoped run_sandbox_tests). When the LLM planner
+// ALSO emits explicit "run the full test suite" / "full verification" tasks, the
+// build runs the whole monorepo suite redundantly — slow, brittle, and the exact
+// over-decomposition that let an unrelated broken test stall FB-69231490. Those
+// tasks duplicate the synthetic QA phase, so prune them.
+
+const FULL_SUITE_VERIFICATION_PATTERNS: RegExp[] = [
+  /\bfull(?:\s+|-)test\s+suite\b/i,
+  /\bentire\s+test\s+suite\b/i,
+  /\brun\s+(?:the\s+)?(?:full|entire|all|complete|whole)\s+(?:test\s+suite|tests)\b/i,
+  /\bfull\s+verification\b/i,
+  /\bpnpm\s+(?:-r\s+|--filter\s+\S+\s+)?test\b/i,
+  /\bregression\s+suite\b/i,
+];
+
+/**
+ * True when a planner task merely re-runs the whole suite / re-verifies — work
+ * the always-appended synthetic QA phase already does. Pure + testable.
+ */
+export function isRedundantVerificationTask(task: PlanTask): boolean {
+  const text = [task.title, task.testFirst, task.implement, task.verify].join(" ");
+  return FULL_SUITE_VERIFICATION_PATTERNS.some((p) => p.test(text));
+}
+
 // --- Dependency Ordering -----------------------------------------------------
 
 const ROLE_PRIORITY: Record<SpecialistRole, number> = {
@@ -163,8 +190,19 @@ export function buildDependencyGraph(
       })
     : [];
 
+  // Prune redundant full-suite/verification tasks — the synthetic QA phase
+  // below always runs scoped verification, so these only add slow, brittle
+  // whole-monorepo runs. Right-sizes an over-decomposed plan.
+  const prunableTasks = safeTasks.filter((task) => !isRedundantVerificationTask(task));
+  const prunedCount = safeTasks.length - prunableTasks.length;
+  if (prunedCount > 0) {
+    console.log(
+      `[task-graph] pruned ${prunedCount} redundant full-suite/verification task(s); the synthetic QA phase covers verification.`,
+    );
+  }
+
   // Assign specialists to tasks
-  const assigned = safeTasks.map((task, i) => assignSpecialist(task, i, safeFiles));
+  const assigned = prunableTasks.map((task, i) => assignSpecialist(task, i, safeFiles));
 
   // Group by priority level
   const byPriority = new Map<number, AssignedTask[]>();


### PR DESCRIPTION
## Problem

For **FB-69231490** (a ~30-line helper) the LLM planner emitted ~10 tasks — including a **"Run full test suite"** task and a **"Full verification"** QA task. But `buildDependencyGraph` **always appends a synthetic QA phase** ("Full verification: tests + typecheck", run via scoped `run_sandbox_tests`), so those LLM tasks are redundant: they trigger whole-monorepo runs that are slow, brittle, and (against a broken sandbox) part of what stalled the build.

## Fix

- **`isRedundantVerificationTask(task)`** — pure, unit-tested predicate matching explicit *full/entire/all test-suite*, *"full verification"*, *"pnpm test"*, *"regression suite"* tasks. Conservative patterns deliberately do **not** prune real test-writing / implementation tasks (covered by tests).
- `buildDependencyGraph` prunes them before specialist assignment. The always-appended synthetic QA phase still runs scoped verification, so **coverage is unchanged** while the plan is right-sized.

## Acceptance

An over-decomposed plan with redundant full-suite/verification tasks runs only the scoped synthetic QA verification — builds are faster and less brittle.

## Substrate

Pure-function unit tests — executed by the CI **Unit Tests** job (clean install). Source-only worktree, so not run locally per AGENTS.md §5.

BI-9C217A02 · part of the FB-69231490 build-reliability series (gate scoping #2019, sandbox health #2021, stall surfacing #2022).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
