### PR TITLE
feat(ai-workforce): inject profession corpus into coworker prompts at runtime (WSID Phase 3)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -12,6 +12,7 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { AgentModelRoutingCard } from "@/components/platform/AgentModelRoutingCard";
 import { loadCoworkerRecord } from "@/lib/coworker-record/load-record";
+import { loadFamilyCorpusSignals } from "@/lib/coworker-record/corpus-signals";
 import { CoworkerRecordTabs, type CoworkerTab } from "@/components/platform/coworker-record/CoworkerRecordTabs";
 import {
   OverviewPanel,
@@ -37,6 +38,12 @@ export default async function AgentDetailPage({
   const record = await loadCoworkerRecord(agentId);
   if (!record) return notFound();
   const { agent, gaid, profession, decisions } = record;
+
+  // WSID Phase 3: per-family runtime corpus signals (usage / misses / growth gaps)
+  // for the Profession & Knowledge tab. Null when the coworker is unmapped.
+  const corpusSignals = profession.family
+    ? await loadFamilyCorpusSignals(profession.family.professionKey)
+    : null;
 
   // Model-routing card data (kept page-side: needs the live provider catalog).
   const [session, modelConfig, lastModelRows, activeProviders] = await Promise.all([
@@ -144,7 +151,7 @@ export default async function AgentDetailPage({
 
       <CoworkerRecordTabs tabs={tabs}>
         <OverviewPanel record={record} />
-        <ProfessionPanel record={record} />
+        <ProfessionPanel record={record} corpusSignals={corpusSignals} />
         <CapabilitiesPanel record={record} routingCard={routingCard} />
         <GovernancePanel record={record} />
         <PerformancePanel record={record} />

--- a/apps/web/app/(shell)/platform/ai/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/page.tsx
@@ -4,10 +4,15 @@
 // jurisdiction / lifecycle / coverage-gap) with fitness-for-duty signals,
 // each row linking to that coworker's record.
 import { loadRoster } from "@/lib/coworker-record/roster";
+import { loadProfessionCorpusSignals } from "@/lib/coworker-record/corpus-signals";
 import { RosterView } from "@/components/platform/coworker-record/RosterView";
+import { ProfessionCorpusPanel } from "@/components/platform/coworker-record/ProfessionCorpusPanel";
 
 export default async function PlatformAiPage() {
-  const { rows, facets } = await loadRoster();
+  const [{ rows, facets }, corpusSignals] = await Promise.all([
+    loadRoster(),
+    loadProfessionCorpusSignals(),
+  ]);
 
   const brokenProviders = rows.filter((r) => !r.providerHealthy);
   const coverageGaps = rows.filter((r) => r.unmapped || r.emptyCorpus);
@@ -40,6 +45,8 @@ export default async function PlatformAiPage() {
       ) : (
         <p style={{ fontSize: 12, color: "var(--dpf-muted)" }}>No coworkers registered yet.</p>
       )}
+
+      <ProfessionCorpusPanel signals={corpusSignals} />
     </div>
   );
 }

--- a/apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx
+++ b/apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx
@@ -1,0 +1,142 @@
+// apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx
+// WSID Phase 3 — operator panel for profession-corpus RUNTIME signals on the AI
+// Workforce surface. Surfaces usage (corpus injected into prompts), misses, and
+// the growth backlog (open ProfessionCorpusGap rows) so an operator can see
+// coverage→usage→growth at a glance. Client component (DataTable needs client
+// sort/paging); fed serializable props from a server loader (corpus-signals.ts).
+"use client";
+
+import { DataTable, StatCard, StatusBadge, type Column } from "@/components/ui/report-kit";
+import type { Intent } from "@/components/ui/report-kit/statusColors";
+import type { CorpusGapRow, ProfessionCorpusSignals } from "@/lib/coworker-record/corpus-signals";
+
+const REASON_INTENT: Record<string, Intent> = {
+  unmapped: "danger",
+  "empty-corpus": "danger",
+  "low-relevance": "warning",
+  deferred: "info",
+};
+
+const REASON_LABEL: Record<string, string> = {
+  unmapped: "Unmapped role",
+  "empty-corpus": "Empty corpus",
+  "low-relevance": "Not covered",
+  deferred: "Deferred",
+};
+
+const GAP_COLUMNS: Column<CorpusGapRow>[] = [
+  {
+    key: "profession",
+    header: "Profession",
+    cell: (r) => r.label,
+    sortAccessor: (r) => r.label,
+  },
+  {
+    key: "reason",
+    header: "Reason",
+    cell: (r) => (
+      <StatusBadge intent={REASON_INTENT[r.reason] ?? "neutral"} label={REASON_LABEL[r.reason] ?? r.reason} />
+    ),
+    sortAccessor: (r) => r.reason,
+  },
+  {
+    key: "topic",
+    header: "Missing topic",
+    cell: (r) => <span title={r.missingTopic}>{r.missingTopic}</span>,
+    sortAccessor: (r) => r.missingTopic,
+  },
+  {
+    key: "occurrences",
+    header: "Hits",
+    align: "right",
+    cell: (r) => r.occurrences,
+    sortAccessor: (r) => r.occurrences,
+  },
+  {
+    key: "suggested",
+    header: "Suggested source to seed",
+    cell: (r) =>
+      r.suggestedSource ? (
+        <span className="text-[var(--dpf-muted)]" title={r.suggestedSource}>
+          {r.suggestedSource.length > 80 ? `${r.suggestedSource.slice(0, 80)}…` : r.suggestedSource}
+        </span>
+      ) : (
+        <span className="text-[var(--dpf-muted)]">—</span>
+      ),
+  },
+  {
+    key: "lastSeen",
+    header: "Last seen",
+    align: "right",
+    cell: (r) => r.lastSeen,
+    sortAccessor: (r) => r.lastSeen,
+  },
+];
+
+export function ProfessionCorpusPanel({ signals }: { signals: ProfessionCorpusSignals }) {
+  const { totals, gaps } = signals;
+  const rate = totals.injectionRatePct;
+
+  return (
+    <section style={{ marginTop: 24 }}>
+      <div style={{ marginBottom: 10 }}>
+        <h2 style={{ fontSize: 14, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>
+          Profession corpus — runtime usage &amp; growth
+        </h2>
+        <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2 }}>
+          Coverage is not usage. These are live signals from coworker conversations over the last 30 days:
+          how often each profession&apos;s knowledge base was injected into a prompt, how often it was missed,
+          and the deduplicated backlog of topics the corpus could not answer.
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+          gap: 10,
+          marginBottom: 16,
+        }}
+      >
+        <StatCard
+          label="Corpus injections"
+          value={totals.injected.toLocaleString()}
+          intent="success"
+          hint="Prompts grounded in profession corpus"
+        />
+        <StatCard
+          label="Misses"
+          value={totals.missed.toLocaleString()}
+          intent={totals.missed > 0 ? "warning" : "neutral"}
+          hint="Turns with no corpus injected"
+        />
+        <StatCard
+          label="Injection rate"
+          value={rate === null ? "—" : `${rate}%`}
+          intent={rate === null ? "neutral" : rate >= 80 ? "success" : rate >= 50 ? "warning" : "danger"}
+          hint="Injected ÷ total coworker turns"
+        />
+        <StatCard
+          label="Open growth gaps"
+          value={totals.openGaps.toLocaleString()}
+          intent={totals.openGaps > 0 ? "warning" : "success"}
+          hint="Deduped topics to seed next"
+        />
+      </div>
+
+      <DataTable
+        columns={GAP_COLUMNS}
+        rows={gaps}
+        getRowKey={(r) => r.id}
+        initialSort={{ key: "occurrences", dir: "desc" }}
+        pageSize={15}
+        dense
+        empty={
+          <span style={{ color: "var(--dpf-muted)" }}>
+            No corpus gaps recorded yet — every coworker turn has been grounded in its profession corpus.
+          </span>
+        }
+      />
+    </section>
+  );
+}

--- a/apps/web/components/platform/coworker-record/panels.tsx
+++ b/apps/web/components/platform/coworker-record/panels.tsx
@@ -6,11 +6,19 @@
 
 import Link from "next/link";
 import type { CoworkerRecord } from "@/lib/coworker-record/load-record";
+import type { CorpusGapRow, CorpusUsageRollup } from "@/lib/coworker-record/corpus-signals";
 import {
   PROFESSION_JURISDICTIONS,
   PROFESSION_COMPETENCY_LEVELS,
 } from "@dpf/db/wiki-taxonomy";
 import { LocalTime } from "@/components/ui/LocalTime";
+
+const GAP_REASON_LABEL: Record<string, string> = {
+  unmapped: "Unmapped role",
+  "empty-corpus": "Empty corpus",
+  "low-relevance": "Not covered",
+  deferred: "Deferred",
+};
 
 // ─── Shared primitives ───────────────────────────────────────────────────────
 
@@ -176,7 +184,13 @@ export function OverviewPanel({ record }: { record: CoworkerRecord }) {
 
 // ─── Profession & Knowledge (WSID) ──────────────────────────────────────────
 
-export function ProfessionPanel({ record }: { record: CoworkerRecord }) {
+export function ProfessionPanel({
+  record,
+  corpusSignals,
+}: {
+  record: CoworkerRecord;
+  corpusSignals?: { usage: CorpusUsageRollup; gaps: CorpusGapRow[] } | null;
+}) {
   const { profession } = record;
   if (!profession.family) {
     return (
@@ -215,6 +229,39 @@ export function ProfessionPanel({ record }: { record: CoworkerRecord }) {
           </>
         ) : (
           <EmptyState text="No published corpus pages for this family yet (empty corpus — the rollout demand signal)." />
+        )}
+      </Section>
+
+      <Section title="Runtime usage & gaps (30d)" action={deepLink("/platform/ai", "Workforce signals")}>
+        {corpusSignals ? (
+          <>
+            <InfoGrid>
+              <InfoCard label="Corpus injections" value={String(corpusSignals.usage.injected)} />
+              <InfoCard label="Misses" value={String(corpusSignals.usage.missed)} />
+              <InfoCard
+                label="Injection rate"
+                value={corpusSignals.usage.injectionRatePct === null ? "—" : `${corpusSignals.usage.injectionRatePct}%`}
+              />
+              <InfoCard label="Open growth gaps" value={String(corpusSignals.gaps.length)} />
+            </InfoGrid>
+            {corpusSignals.gaps.length > 0 ? (
+              <ul style={{ margin: "10px 0 0", paddingLeft: 18 }}>
+                {corpusSignals.gaps.slice(0, 8).map((gap) => (
+                  <li key={gap.id} style={{ fontSize: 11, color: "var(--dpf-text-secondary)", marginBottom: 4 }}>
+                    <Chip tone="muted">{GAP_REASON_LABEL[gap.reason] ?? gap.reason}</Chip>{" "}
+                    <span title={gap.missingTopic}>{gap.missingTopic}</span>{" "}
+                    <span style={{ color: "var(--dpf-muted)" }}>×{gap.occurrences}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 8 }}>
+                No corpus gaps recorded — every recent turn was grounded in this corpus.
+              </div>
+            )}
+          </>
+        ) : (
+          <EmptyState text="No runtime usage recorded yet. Once this coworker answers questions, its corpus injection/miss signal and growth gaps appear here." />
         )}
       </Section>
 

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -46,6 +46,8 @@ import {
 import { recordSkillUsageEvents } from "@/lib/skills/usage-events";
 import { recallWikiContext } from "@/lib/wiki/recall";
 import { recordCoverageGap } from "@/lib/wiki/coverage-gap";
+import { resolveProfessionCorpusContext } from "@/lib/decision-perspective/profession-corpus";
+import { recordProfessionCorpusEvidence } from "@/lib/decision-perspective/profession-corpus-evidence";
 import {
   classifyPerspective,
   extractPageTopic,
@@ -628,6 +630,35 @@ export async function sendMessage(input: {
   // happen to be tagged with the current route.
   const isCrossCuttingOverlay = agent.agentId === "AGT-ORCH-000";
 
+  // ── WSID Phase 3: profession-corpus retrieval (shared by both prompt paths) ──
+  // Resolve the coworker's profession-family corpus ONCE so every response is
+  // grounded in the right professional knowledge base. Fail-open: a null result
+  // never blocks the response. The registry resolver keys on the PERSISTED Agent
+  // identity tuple (role slug lives in Agent.name for registry agents, slugId for
+  // hardcoded seeds), so fetch that rather than trusting the routing agent shape.
+  // Promise.resolve().then(...) so a synchronous throw (e.g. a partial prisma
+  // mock without `agent.findFirst`) becomes a rejection the .catch() absorbs —
+  // the identity lookup must never break a coworker response.
+  const professionIdentityRow = await Promise.resolve()
+    .then(() =>
+      prisma.agent.findFirst({
+        where: { agentId: agent.agentId },
+        select: { agentId: true, slugId: true, name: true },
+      }),
+    )
+    .catch(() => null);
+  const professionCorpus = await resolveProfessionCorpusContext({
+    db: prisma,
+    identity: professionIdentityRow ?? { agentId: agent.agentId },
+    query: trimmedContent,
+  }).catch((e) => {
+    console.warn("[profession-corpus] resolve failed (fail-open):", e);
+    return null;
+  });
+  // Whether the corpus block actually landed in the final prompt (the unified
+  // path's arbitrator can drop it under a tight token budget). Set per-branch.
+  let professionInjectedIntoPrompt = false;
+
   let populatedPrompt: string;
   // Governed Hermes learning Slice 1: active coworker skill (if any).
   // Set inside the unified-prompt branch when the user message invokes a
@@ -682,9 +713,18 @@ export async function sendMessage(input: {
     const contextSources = [
       // L1: Route-essential context
       { tier: "L1" as const, priority: 0, content: domainBlock, tokenCount: countTokens(domainBlock), source: "domain", compressible: false },
+      // L1: Profession corpus (WSID Phase 3) — the coworker's professional
+      // knowledge base, ranked above generic wiki recall. Priority 1 (just under
+      // route-domain context); compressible to abstracts-only under tight budget.
+      ...(professionCorpus?.promptBlock ? [{
+        tier: "L1" as const, priority: 1, content: professionCorpus.promptBlock,
+        tokenCount: professionCorpus.tokenCount, source: "profession-corpus", compressible: true,
+        compressedContent: professionCorpus.compactBlock ?? "",
+        compressedTokenCount: professionCorpus.compactTokenCount,
+      }] : []),
       ...(portalContextPrompt ? [{
         tier: "L1" as const,
-        priority: 1,
+        priority: 2,
         content: portalContextPrompt,
         tokenCount: countTokens(portalContextPrompt),
         source: "portal-context",
@@ -692,7 +732,7 @@ export async function sendMessage(input: {
       }] : []),
       // L1: User facts — structured memory from prior conversations
       ...(factsContext ? [{
-        tier: "L1" as const, priority: 2, content: factsContext, tokenCount: countTokens(factsContext),
+        tier: "L1" as const, priority: 3, content: factsContext, tokenCount: countTokens(factsContext),
         source: "user-facts", compressible: true,
         compressedContent: factsCompressed ?? "",
         compressedTokenCount: countTokens(factsCompressed ?? ""),
@@ -732,6 +772,10 @@ export async function sendMessage(input: {
     const selectedAttachments = result.selected.find((s) => s.source === "attachments")?.content ?? null;
     const selectedKnowledge = result.selected.find((s) => s.source === "knowledge")?.content ?? null;
     const selectedMemory = result.selected.find((s) => s.source === "semantic-memory")?.content ?? null;
+    // WSID Phase 3: the profession corpus block that survived arbitration (null
+    // if it was dropped under budget — recorded as a usage miss below).
+    const selectedProfessionContext = result.selected.find((s) => s.source === "profession-corpus")?.content ?? null;
+    professionInjectedIntoPrompt = selectedProfessionContext !== null;
 
     // Merge knowledge and semantic memory into domain context if they made the budget
     let finalDomainContext = selectedDomain;
@@ -814,6 +858,7 @@ export async function sendMessage(input: {
       domainTools: [], // Already included in domain block
       routeData: selectedPageData,
       attachmentContext: selectedAttachments,
+      professionContext: selectedProfessionContext,
       wikiContext,
       skills: skillSummaries,
       questionPacket: input.questionPacket ?? null,
@@ -984,7 +1029,35 @@ export async function sendMessage(input: {
       promptSections.push(recalledContext);
     }
 
+    // WSID Phase 3: inject the profession corpus (no arbitration on this legacy
+    // path — bounded by the service's own page/excerpt caps).
+    if (professionCorpus?.promptBlock) {
+      promptSections.push("", professionCorpus.promptBlock);
+      professionInjectedIntoPrompt = true;
+    }
+
     populatedPrompt = promptSections.join("\n");
+  }
+
+  // WSID Phase 3: record corpus usage/miss evidence for this turn — fire-and-
+  // forget, fail-open. `injected` reflects what actually reached the prompt
+  // (the unified arbitrator may have dropped the block under budget); misses and
+  // low-relevance hits also write a deduped growth-gap so the corpus grows from
+  // real usage. Telemetry line mirrors the existing `[tools]`/`[handoff]` style.
+  if (professionCorpus) {
+    console.log(
+      `[profession-corpus] agent=${JSON.stringify(agent.agentId)} ` +
+        `family=${JSON.stringify(professionCorpus.professionKey)} status=${professionCorpus.status} ` +
+        `injected=${professionInjectedIntoPrompt} pages=${professionCorpus.pages.length} ` +
+        `lowRelevance=${professionCorpus.lowRelevance}`,
+    );
+    void recordProfessionCorpusEvidence({
+      context: professionCorpus,
+      query: trimmedContent,
+      agentId: agent.agentId,
+      routeContext: input.routeContext,
+      promptInjected: professionInjectedIntoPrompt,
+    }).catch((e) => console.warn("[profession-corpus] evidence record failed (fail-open):", e));
   }
 
   // Get ALL platform tools (no mode filtering — we filter the merged set below)

--- a/apps/web/lib/coworker-record/corpus-signals.ts
+++ b/apps/web/lib/coworker-record/corpus-signals.ts
@@ -1,0 +1,203 @@
+// apps/web/lib/coworker-record/corpus-signals.ts
+// WSID Phase 3 — operator view of profession-corpus RUNTIME signals.
+//
+// Coverage (coverage.ts) answers "is corpus seeded?". This answers the harder
+// question the goal insists on: "is the corpus actually USED, and where is it
+// MISSING?" — by rolling up the ProfessionCorpusUsageStat counters and the
+// open ProfessionCorpusGap growth-backlog the prompt path writes at runtime.
+//
+// Server-side, direct-Prisma (same pattern as coverage.ts / roster.ts). All
+// reads are fail-open (.catch → empty) so the AI Workforce page renders even if
+// the runtime tables are empty on a cold install.
+
+import { prisma } from "@dpf/db";
+import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
+
+export type CorpusUsageRollup = {
+  professionKey: string;
+  label: string;
+  injected: number;
+  missed: number;
+  total: number;
+  /** injected / total as a 0–100 percent, or null when there is no usage yet. */
+  injectionRatePct: number | null;
+};
+
+export type CorpusGapRow = {
+  id: string;
+  professionKey: string;
+  label: string;
+  /** unmapped | empty-corpus | low-relevance | deferred */
+  reason: string;
+  missingTopic: string;
+  occurrences: number;
+  routeContext: string | null;
+  suggestedSource: string | null;
+  /** Preformatted YYYY-MM-DD (kept server-side so the client panel stays dumb). */
+  lastSeen: string;
+};
+
+export type ProfessionCorpusSignals = {
+  usage: CorpusUsageRollup[];
+  gaps: CorpusGapRow[];
+  totals: {
+    injected: number;
+    missed: number;
+    openGaps: number;
+    injectionRatePct: number | null;
+  };
+};
+
+function labelFor(professionKey: string): string {
+  return (
+    PROFESSION_REGISTRY.families.find((f) => f.professionKey === professionKey)?.label ??
+    professionKey
+  );
+}
+
+function cutoffDay(windowDays: number): string {
+  // Day buckets are YYYY-MM-DD strings → lexicographically comparable.
+  return new Date(Date.now() - windowDays * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Run a Prisma read and fall back on ANY failure — including a synchronous
+ * throw when the model is missing on a partial test mock or a pre-migration
+ * client. A server-component render must never crash on the runtime-signal
+ * tables (fail-open, same posture as the rest of this surface).
+ */
+async function safeRead<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await fn();
+  } catch {
+    return fallback;
+  }
+}
+
+type UsageGroup = {
+  professionKey: string;
+  _sum: { injectedCount: number | null; missedCount: number | null };
+};
+
+type GapRecord = {
+  id: string;
+  professionKey: string;
+  reason: string;
+  missingTopic: string;
+  occurrences: number;
+  routeContext: string | null;
+  suggestedSource: string | null;
+  lastSeenAt: Date;
+};
+
+function toUsageRollup(group: UsageGroup): CorpusUsageRollup {
+  const injected = group._sum.injectedCount ?? 0;
+  const missed = group._sum.missedCount ?? 0;
+  const total = injected + missed;
+  return {
+    professionKey: group.professionKey,
+    label: labelFor(group.professionKey),
+    injected,
+    missed,
+    total,
+    injectionRatePct: total > 0 ? Math.round((injected / total) * 100) : null,
+  };
+}
+
+function toGapRow(gap: GapRecord): CorpusGapRow {
+  return {
+    id: gap.id,
+    professionKey: gap.professionKey,
+    label: labelFor(gap.professionKey),
+    reason: gap.reason,
+    missingTopic: gap.missingTopic,
+    occurrences: gap.occurrences,
+    routeContext: gap.routeContext,
+    suggestedSource: gap.suggestedSource,
+    lastSeen: gap.lastSeenAt.toISOString().slice(0, 10),
+  };
+}
+
+/** Roll up corpus usage + open growth gaps across all professions. */
+export async function loadProfessionCorpusSignals(
+  windowDays = 30,
+): Promise<ProfessionCorpusSignals> {
+  const cutoff = cutoffDay(windowDays);
+
+  const [usageRows, gapRows] = await Promise.all([
+    safeRead<UsageGroup[]>(async () => {
+      const rows = await prisma.professionCorpusUsageStat.groupBy({
+        by: ["professionKey"],
+        where: { day: { gte: cutoff } },
+        _sum: { injectedCount: true, missedCount: true },
+      });
+      return rows as unknown as UsageGroup[];
+    }, []),
+    safeRead<GapRecord[]>(async () => {
+      const rows = await prisma.professionCorpusGap.findMany({
+        where: { status: "open" },
+        orderBy: [{ occurrences: "desc" }, { lastSeenAt: "desc" }],
+        take: 100,
+      });
+      return rows as unknown as GapRecord[];
+    }, []),
+  ]);
+
+  const usage = usageRows.map(toUsageRollup).sort((a, b) => b.total - a.total);
+  const gaps = gapRows.map(toGapRow);
+
+  const injected = usage.reduce((sum, u) => sum + u.injected, 0);
+  const missed = usage.reduce((sum, u) => sum + u.missed, 0);
+  const total = injected + missed;
+
+  return {
+    usage,
+    gaps,
+    totals: {
+      injected,
+      missed,
+      openGaps: gaps.length,
+      injectionRatePct: total > 0 ? Math.round((injected / total) * 100) : null,
+    },
+  };
+}
+
+/** Per-family corpus signals for the coworker-record Profession tab. */
+export async function loadFamilyCorpusSignals(
+  professionKey: string,
+  windowDays = 30,
+): Promise<{ usage: CorpusUsageRollup; gaps: CorpusGapRow[] }> {
+  const cutoff = cutoffDay(windowDays);
+
+  const [usageRows, gapRows] = await Promise.all([
+    safeRead<UsageGroup[]>(async () => {
+      const rows = await prisma.professionCorpusUsageStat.groupBy({
+        by: ["professionKey"],
+        where: { professionKey, day: { gte: cutoff } },
+        _sum: { injectedCount: true, missedCount: true },
+      });
+      return rows as unknown as UsageGroup[];
+    }, []),
+    safeRead<GapRecord[]>(async () => {
+      const rows = await prisma.professionCorpusGap.findMany({
+        where: { professionKey, status: "open" },
+        orderBy: [{ occurrences: "desc" }, { lastSeenAt: "desc" }],
+        take: 25,
+      });
+      return rows as unknown as GapRecord[];
+    }, []),
+  ]);
+
+  const usage = usageRows[0]
+    ? toUsageRollup(usageRows[0])
+    : {
+        professionKey,
+        label: labelFor(professionKey),
+        injected: 0,
+        missed: 0,
+        total: 0,
+        injectionRatePct: null,
+      };
+
+  return { usage, gaps: gapRows.map(toGapRow) };
+}

--- a/apps/web/lib/decision-perspective/profession-corpus-evidence.test.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus-evidence.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProfessionCorpusContext } from "./profession-corpus";
+import {
+  corpusGapFingerprint,
+  corpusUsageDay,
+  gapReasonForContext,
+  recordProfessionCorpusEvidence,
+  recordProfessionCorpusGap,
+  recordProfessionCorpusUsage,
+  UNMAPPED_PROFESSION_KEY,
+  type ProfessionCorpusEvidenceClient,
+} from "./profession-corpus-evidence";
+
+// ─── Stateful in-memory fake (interprets prisma {increment} semantics) ────────
+
+type GapRow = {
+  fingerprint: string;
+  professionKey: string;
+  reason: string;
+  query: string;
+  occurrences: number;
+  agentId: string | null;
+  routeContext: string | null;
+  suggestedSource: string | null;
+  status: string;
+};
+type UsageRow = { professionKey: string; day: string; injectedCount: number; missedCount: number };
+
+function applyIncrement(current: number, op: unknown): number {
+  if (op && typeof op === "object" && "increment" in op) {
+    return current + (op as { increment: number }).increment;
+  }
+  return typeof op === "number" ? op : current;
+}
+
+function fakeEvidenceDb() {
+  const gaps = new Map<string, GapRow>();
+  const usage = new Map<string, UsageRow>();
+  const db: ProfessionCorpusEvidenceClient = {
+    professionCorpusGap: {
+      upsert: async ({ where, create, update }) => {
+        const existing = gaps.get(where.fingerprint);
+        if (!existing) {
+          gaps.set(where.fingerprint, {
+            fingerprint: where.fingerprint,
+            professionKey: create.professionKey as string,
+            reason: create.reason as string,
+            query: create.query as string,
+            occurrences: (create.occurrences as number) ?? 1,
+            agentId: (create.agentId as string | null) ?? null,
+            routeContext: (create.routeContext as string | null) ?? null,
+            suggestedSource: (create.suggestedSource as string | null) ?? null,
+            status: (create.status as string) ?? "open",
+          });
+        } else {
+          existing.occurrences = applyIncrement(existing.occurrences, update.occurrences);
+          if ("query" in update) existing.query = update.query as string;
+          if ("agentId" in update) existing.agentId = update.agentId as string | null;
+        }
+        return gaps.get(where.fingerprint);
+      },
+    },
+    professionCorpusUsageStat: {
+      upsert: async ({ where, create, update }) => {
+        const key = `${where.professionKey_day.professionKey}:${where.professionKey_day.day}`;
+        const existing = usage.get(key);
+        if (!existing) {
+          usage.set(key, {
+            professionKey: where.professionKey_day.professionKey,
+            day: where.professionKey_day.day,
+            injectedCount: (create.injectedCount as number) ?? 0,
+            missedCount: (create.missedCount as number) ?? 0,
+          });
+        } else {
+          existing.injectedCount = applyIncrement(existing.injectedCount, update.injectedCount);
+          existing.missedCount = applyIncrement(existing.missedCount, update.missedCount);
+        }
+        return usage.get(key);
+      },
+    },
+  };
+  return { db, gaps, usage };
+}
+
+function makeContext(over: Partial<ProfessionCorpusContext>): ProfessionCorpusContext {
+  return {
+    status: "injected",
+    professionKey: "software-engineer",
+    familyLabel: "Software Engineer",
+    profileId: "wsid-software-engineer",
+    pages: [],
+    promptBlock: "PROFESSION CORPUS — Software Engineer",
+    compactBlock: "compact",
+    tokenCount: 10,
+    compactTokenCount: 4,
+    lowRelevance: false,
+    missingTopic: "topic",
+    suggestedSource: null,
+    ...over,
+  };
+}
+
+const FIXED_DAY = new Date("2026-06-16T09:30:00.000Z");
+
+// ─── Fingerprint ──────────────────────────────────────────────────────────────
+
+describe("corpusGapFingerprint", () => {
+  it("is stable across whitespace/case/punctuation variants of the same topic", () => {
+    const a = corpusGapFingerprint("finance", "How do I book a deferral?", "low-relevance");
+    const b = corpusGapFingerprint("finance", "  how do i book a   DEFERRAL  ", "low-relevance");
+    expect(a).toBe(b);
+  });
+
+  it("differs by reason and by profession", () => {
+    expect(corpusGapFingerprint("finance", "x topic", "low-relevance")).not.toBe(
+      corpusGapFingerprint("finance", "x topic", "empty-corpus"),
+    );
+    expect(corpusGapFingerprint("finance", "x topic", "low-relevance")).not.toBe(
+      corpusGapFingerprint("security", "x topic", "low-relevance"),
+    );
+  });
+});
+
+describe("corpusUsageDay", () => {
+  it("buckets to a UTC YYYY-MM-DD string", () => {
+    expect(corpusUsageDay(FIXED_DAY)).toBe("2026-06-16");
+  });
+});
+
+// ─── Usage stat ───────────────────────────────────────────────────────────────
+
+describe("recordProfessionCorpusUsage", () => {
+  it("increments injected/missed counters in the same day bucket", async () => {
+    const { db, usage } = fakeEvidenceDb();
+    await recordProfessionCorpusUsage({ professionKey: "finance", injected: true, now: FIXED_DAY }, { db });
+    await recordProfessionCorpusUsage({ professionKey: "finance", injected: true, now: FIXED_DAY }, { db });
+    await recordProfessionCorpusUsage({ professionKey: "finance", injected: false, now: FIXED_DAY }, { db });
+
+    const row = usage.get("finance:2026-06-16")!;
+    expect(row.injectedCount).toBe(2);
+    expect(row.missedCount).toBe(1);
+  });
+});
+
+// ─── Gap dedup / idempotency ──────────────────────────────────────────────────
+
+describe("recordProfessionCorpusGap", () => {
+  it("coalesces re-detections into occurrences (idempotent dedup)", async () => {
+    const { db, gaps } = fakeEvidenceDb();
+    const input = {
+      professionKey: "finance",
+      reason: "low-relevance" as const,
+      query: "How do I book a multi-year deferral?",
+    };
+    const first = await recordProfessionCorpusGap(input, { db });
+    const second = await recordProfessionCorpusGap(input, { db });
+
+    expect(first.recorded).toBe(true);
+    expect(second.fingerprint).toBe(first.fingerprint);
+    expect(gaps.size).toBe(1);
+    expect(gaps.get(first.fingerprint)!.occurrences).toBe(2);
+  });
+
+  it("keeps distinct rows for different reasons on the same topic", async () => {
+    const { db, gaps } = fakeEvidenceDb();
+    await recordProfessionCorpusGap({ professionKey: "finance", reason: "low-relevance", query: "topic x" }, { db });
+    await recordProfessionCorpusGap({ professionKey: "finance", reason: "deferred", query: "topic x" }, { db });
+    expect(gaps.size).toBe(2);
+  });
+
+  it("does not record an empty-topic gap", async () => {
+    const { db, gaps } = fakeEvidenceDb();
+    const result = await recordProfessionCorpusGap({ professionKey: "finance", reason: "deferred", query: "   " }, { db });
+    expect(result.recorded).toBe(false);
+    expect(gaps.size).toBe(0);
+  });
+});
+
+// ─── gapReasonForContext ──────────────────────────────────────────────────────
+
+describe("gapReasonForContext", () => {
+  it("maps statuses to gap reasons", () => {
+    expect(gapReasonForContext(makeContext({ status: "missed-unmapped" }))).toBe("unmapped");
+    expect(gapReasonForContext(makeContext({ status: "missed-empty-corpus" }))).toBe("empty-corpus");
+    expect(gapReasonForContext(makeContext({ status: "injected", lowRelevance: true }))).toBe("low-relevance");
+    expect(gapReasonForContext(makeContext({ status: "injected", lowRelevance: false }))).toBeNull();
+    expect(gapReasonForContext(makeContext({ status: "error" }))).toBeNull();
+  });
+});
+
+// ─── Orchestrator ─────────────────────────────────────────────────────────────
+
+describe("recordProfessionCorpusEvidence", () => {
+  it("records an injection (usage only, no gap) for a healthy hit", async () => {
+    const { db, gaps, usage } = fakeEvidenceDb();
+    await recordProfessionCorpusEvidence(
+      { context: makeContext({ status: "injected" }), query: "secure coding", agentId: "AGT-1", routeContext: "/workspace", now: FIXED_DAY },
+      { db },
+    );
+    expect(usage.get("software-engineer:2026-06-16")!.injectedCount).toBe(1);
+    expect(gaps.size).toBe(0);
+  });
+
+  it("records a miss + gap for an unmapped coworker (not silently swallowed)", async () => {
+    const { db, gaps, usage } = fakeEvidenceDb();
+    await recordProfessionCorpusEvidence(
+      {
+        context: makeContext({ status: "missed-unmapped", professionKey: null, profileId: null }),
+        query: "What is our refund policy?",
+        agentId: "AGT-2",
+        routeContext: "/workspace",
+        now: FIXED_DAY,
+      },
+      { db },
+    );
+    expect(usage.get(`${UNMAPPED_PROFESSION_KEY}:2026-06-16`)!.missedCount).toBe(1);
+    expect(gaps.size).toBe(1);
+    expect([...gaps.values()][0]!.reason).toBe("unmapped");
+  });
+
+  it("records a low-relevance gap when the corpus did not cover the question", async () => {
+    const { db, gaps } = fakeEvidenceDb();
+    await recordProfessionCorpusEvidence(
+      { context: makeContext({ status: "injected", lowRelevance: true, suggestedSource: "Seed corpus covering: x" }), query: "kubernetes rollout strategy", now: FIXED_DAY },
+      { db },
+    );
+    expect(gaps.size).toBe(1);
+    expect([...gaps.values()][0]!.reason).toBe("low-relevance");
+  });
+
+  it("records nothing on a transient DB error (no infra noise in the backlog)", async () => {
+    const { db, gaps, usage } = fakeEvidenceDb();
+    await recordProfessionCorpusEvidence(
+      { context: makeContext({ status: "error" }), query: "secure coding", now: FIXED_DAY },
+      { db },
+    );
+    expect(gaps.size).toBe(0);
+    expect(usage.size).toBe(0);
+  });
+});

--- a/apps/web/lib/decision-perspective/profession-corpus-evidence.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus-evidence.ts
@@ -1,0 +1,226 @@
+// apps/web/lib/decision-perspective/profession-corpus-evidence.ts
+//
+// WSID Phase 3 — record what actually happens at runtime when a coworker's
+// profession corpus is (or is not) injected into its prompt. Coverage ≠ usage:
+// these writes are the evidence that distinguishes "pages seeded" from "corpus
+// used" and turns every miss into a deduplicated growth-backlog item.
+//
+//   • recordProfessionCorpusUsage — per-profession/day injected vs. missed counter.
+//   • recordProfessionCorpusGap   — deduped gap (unmapped | empty-corpus |
+//                                    low-relevance | deferred), occurrences++.
+//   • recordProfessionCorpusEvidence — orchestrator called from the prompt path.
+//
+// Fail-open + fire-and-forget: a coworker response must NEVER break because a
+// telemetry write failed. Every public fn swallows its own errors (logs + warns)
+// and the orchestrator additionally guards each sub-write.
+
+import { createHash } from "node:crypto";
+import { prisma } from "@dpf/db";
+import {
+  normalizeCorpusTopic,
+  type ProfessionCorpusContext,
+} from "./profession-corpus";
+
+/** Sentinel profession key for misses where the agent mapped to no family. */
+export const UNMAPPED_PROFESSION_KEY = "(unmapped)";
+
+export type ProfessionCorpusGapReason =
+  | "unmapped"
+  | "empty-corpus"
+  | "low-relevance"
+  | "deferred";
+
+// ─── Structural DB client (satisfied by PrismaClient + test fakes) ────────────
+
+export type ProfessionCorpusEvidenceClient = {
+  professionCorpusGap: {
+    upsert(args: {
+      where: { fingerprint: string };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }): Promise<unknown>;
+  };
+  professionCorpusUsageStat: {
+    upsert(args: {
+      where: { professionKey_day: { professionKey: string; day: string } };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }): Promise<unknown>;
+  };
+};
+
+function resolveDb(db?: ProfessionCorpusEvidenceClient): ProfessionCorpusEvidenceClient {
+  return db ?? (prisma as unknown as ProfessionCorpusEvidenceClient);
+}
+
+/** UTC day bucket `YYYY-MM-DD` (bounds usage-stat cardinality to families×days). */
+export function corpusUsageDay(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/** Deterministic, dedupe fingerprint (16 hex chars). */
+export function corpusGapFingerprint(
+  professionKey: string,
+  topic: string,
+  reason: ProfessionCorpusGapReason,
+): string {
+  return createHash("sha256")
+    .update(`${professionKey}:${normalizeCorpusTopic(topic)}:${reason}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+// ─── Usage stat ───────────────────────────────────────────────────────────────
+
+export async function recordProfessionCorpusUsage(
+  input: { professionKey: string; injected: boolean; now?: Date },
+  deps: { db?: ProfessionCorpusEvidenceClient } = {},
+): Promise<void> {
+  const db = resolveDb(deps.db);
+  const day = corpusUsageDay(input.now ?? new Date());
+  const injectedDelta = input.injected ? 1 : 0;
+  const missedDelta = input.injected ? 0 : 1;
+  try {
+    await db.professionCorpusUsageStat.upsert({
+      where: { professionKey_day: { professionKey: input.professionKey, day } },
+      create: {
+        professionKey: input.professionKey,
+        day,
+        injectedCount: injectedDelta,
+        missedCount: missedDelta,
+      },
+      update: {
+        injectedCount: { increment: injectedDelta },
+        missedCount: { increment: missedDelta },
+      },
+    });
+  } catch (err) {
+    console.warn("[profession-corpus] usage-stat write failed (fail-open):", err);
+  }
+}
+
+// ─── Gap ──────────────────────────────────────────────────────────────────────
+
+export type RecordProfessionCorpusGapInput = {
+  professionKey: string;
+  reason: ProfessionCorpusGapReason;
+  query: string;
+  agentId?: string | null;
+  routeContext?: string | null;
+  suggestedSource?: string | null;
+};
+
+/**
+ * Record (or coalesce) a profession-corpus gap. Re-detecting the same
+ * (professionKey, topic, reason) increments `occurrences` and refreshes the
+ * latest context rather than piling up duplicate rows.
+ */
+export async function recordProfessionCorpusGap(
+  input: RecordProfessionCorpusGapInput,
+  deps: { db?: ProfessionCorpusEvidenceClient } = {},
+): Promise<{ recorded: boolean; fingerprint: string }> {
+  const db = resolveDb(deps.db);
+  const topic = normalizeCorpusTopic(input.query);
+  if (topic.length === 0) return { recorded: false, fingerprint: "" };
+
+  const fingerprint = corpusGapFingerprint(input.professionKey, topic, input.reason);
+  try {
+    await db.professionCorpusGap.upsert({
+      where: { fingerprint },
+      create: {
+        fingerprint,
+        professionKey: input.professionKey,
+        agentId: input.agentId ?? null,
+        routeContext: input.routeContext ?? null,
+        query: input.query.slice(0, 2000),
+        missingTopic: topic,
+        reason: input.reason,
+        suggestedSource: input.suggestedSource ?? null,
+        occurrences: 1,
+        status: "open",
+      },
+      update: {
+        occurrences: { increment: 1 },
+        // Refresh the latest-occurrence context for the operator.
+        agentId: input.agentId ?? null,
+        routeContext: input.routeContext ?? null,
+        query: input.query.slice(0, 2000),
+        suggestedSource: input.suggestedSource ?? null,
+      },
+    });
+    return { recorded: true, fingerprint };
+  } catch (err) {
+    console.warn("[profession-corpus] gap write failed (fail-open):", err);
+    return { recorded: false, fingerprint };
+  }
+}
+
+// ─── Orchestrator (called from the prompt path) ───────────────────────────────
+
+/** Map a resolved corpus context to the gap reason it should record, if any. */
+export function gapReasonForContext(
+  context: ProfessionCorpusContext,
+): ProfessionCorpusGapReason | null {
+  switch (context.status) {
+    case "missed-unmapped":
+      return "unmapped";
+    case "missed-empty-corpus":
+      return "empty-corpus";
+    case "injected":
+      return context.lowRelevance ? "low-relevance" : null;
+    case "error":
+      // Transient DB error — do NOT pollute the growth backlog with infra noise.
+      return null;
+  }
+}
+
+/**
+ * Record both the usage signal and (when applicable) the growth gap for a single
+ * coworker turn. Designed to be called fire-and-forget: it never throws.
+ */
+export async function recordProfessionCorpusEvidence(
+  input: {
+    context: ProfessionCorpusContext;
+    query: string;
+    agentId?: string | null;
+    routeContext?: string | null;
+    /**
+     * Whether the corpus block ACTUALLY landed in the final prompt. Defaults to
+     * `status === "injected"`, but the caller can override it: context
+     * arbitration may drop a resolved block under a tight token budget, which is
+     * a usage miss (corpus exists, but the coworker didn't get it) without being
+     * a corpus gap (no growth-backlog item — the corpus is fine).
+     */
+    promptInjected?: boolean;
+    now?: Date;
+  },
+  deps: { db?: ProfessionCorpusEvidenceClient } = {},
+): Promise<void> {
+  const { context } = input;
+  const professionKey = context.professionKey ?? UNMAPPED_PROFESSION_KEY;
+  const injected = input.promptInjected ?? context.status === "injected";
+
+  // Usage stat — skip transient DB errors so the counter reflects real outcomes,
+  // not infra blips.
+  if (context.status !== "error") {
+    await recordProfessionCorpusUsage(
+      { professionKey, injected, now: input.now },
+      { db: deps.db },
+    );
+  }
+
+  const reason = gapReasonForContext(context);
+  if (reason) {
+    await recordProfessionCorpusGap(
+      {
+        professionKey,
+        reason,
+        query: input.query,
+        agentId: input.agentId ?? null,
+        routeContext: input.routeContext ?? null,
+        suggestedSource: context.suggestedSource,
+      },
+      { db: deps.db },
+    );
+  }
+}

--- a/apps/web/lib/decision-perspective/profession-corpus-wiring.test.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus-wiring.test.ts
@@ -1,0 +1,41 @@
+// Invariant: the coworker runtime prompt path ATTEMPTS profession-corpus
+// retrieval and records usage/miss evidence. This is a source-level guard (the
+// behavioral proof lives in profession-corpus.test.ts + prompt-assembler.test.ts):
+// if a future refactor drops the wiring from the sendMessage prompt path, this
+// fails loudly instead of silently reverting coworkers to corpus-blind prompts.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const AGENT_COWORKER_SRC = readFileSync(
+  join(__dirname, "../actions/agent-coworker.ts"),
+  "utf8",
+);
+
+describe("profession-corpus runtime wiring (agent-coworker sendMessage)", () => {
+  it("imports the profession-corpus retrieval service and evidence recorder", () => {
+    expect(AGENT_COWORKER_SRC).toContain(
+      'from "@/lib/decision-perspective/profession-corpus"',
+    );
+    expect(AGENT_COWORKER_SRC).toContain(
+      'from "@/lib/decision-perspective/profession-corpus-evidence"',
+    );
+  });
+
+  it("invokes the retrieval service in the prompt path", () => {
+    expect(AGENT_COWORKER_SRC).toMatch(/resolveProfessionCorpusContext\(\{/);
+  });
+
+  it("feeds the resolved corpus into the unified assembler as professionContext", () => {
+    expect(AGENT_COWORKER_SRC).toMatch(/professionContext:\s*selectedProfessionContext/);
+  });
+
+  it("injects the corpus into the legacy prompt path as well", () => {
+    expect(AGENT_COWORKER_SRC).toMatch(/professionCorpus\?\.promptBlock/);
+  });
+
+  it("records corpus usage/miss evidence so misses are not silently swallowed", () => {
+    expect(AGENT_COWORKER_SRC).toMatch(/recordProfessionCorpusEvidence\(/);
+  });
+});

--- a/apps/web/lib/decision-perspective/profession-corpus.test.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  corpusQueryTerms,
+  normalizeCorpusTopic,
+  rankCorpusPages,
+  resolveProfessionCorpusContext,
+  type ProfessionCorpusClient,
+} from "./profession-corpus";
+import { findProfessionFamily } from "./resolve-profession-profile";
+
+// ─── Fake corpus DB ───────────────────────────────────────────────────────────
+
+type Row = { slug: string; title: string; abstract: string | null; body: string };
+
+const SOFTWARE_ENGINEER_PAGES: Row[] = [
+  {
+    slug: "professions/software-engineer/owasp-top-ten",
+    title: "OWASP Top Ten Web Application Security Risks",
+    abstract: "The ten most critical web application security risks.",
+    body: "Injection, broken access control, and cryptographic failures lead the list. Mitigate with validation.",
+  },
+  {
+    slug: "professions/software-engineer/semantic-versioning",
+    title: "Semantic Versioning",
+    abstract: "MAJOR.MINOR.PATCH version increments convey compatibility.",
+    body: "Increment MAJOR for breaking changes, MINOR for features, PATCH for fixes.",
+  },
+  {
+    slug: "professions/software-engineer/code-review-standard",
+    title: "The Standard of Code Review",
+    abstract: "Approve once a change improves overall code health.",
+    body: "Reviewers approve when the change improves code health; perfection is not required.",
+  },
+];
+
+function fakeCorpusDb(rows: Row[]): ProfessionCorpusClient {
+  return {
+    wikiPage: {
+      findMany: async (args) => {
+        const prefix = (args.where.slug as { startsWith: string }).startsWith;
+        return rows.filter((r) => r.slug.startsWith(prefix));
+      },
+    },
+  };
+}
+
+function throwingDb(): ProfessionCorpusClient {
+  return {
+    wikiPage: {
+      findMany: async () => {
+        throw new Error("db down");
+      },
+    },
+  };
+}
+
+// ─── Tokeniser ────────────────────────────────────────────────────────────────
+
+describe("corpusQueryTerms", () => {
+  it("drops stopwords and short tokens, dedupes, lowercases", () => {
+    expect(corpusQueryTerms("How should we handle SQL injection injection?")).toEqual([
+      "handle",
+      "sql",
+      "injection",
+    ]);
+  });
+
+  it("returns empty for a greeting with no content terms", () => {
+    expect(corpusQueryTerms("hi there")).toEqual([]);
+  });
+});
+
+describe("normalizeCorpusTopic", () => {
+  it("normalises whitespace, case, and trailing punctuation", () => {
+    expect(normalizeCorpusTopic("  How do I prevent   SQL injection??  ")).toBe(
+      "how do i prevent sql injection",
+    );
+  });
+});
+
+// ─── Ranking ──────────────────────────────────────────────────────────────────
+
+describe("rankCorpusPages", () => {
+  const family = findProfessionFamily("software-engineer")!;
+
+  it("ranks a title/abstract match above a body-only match", () => {
+    const ranked = rankCorpusPages(SOFTWARE_ENGINEER_PAGES, "versioning compatibility", family);
+    expect(ranked[0]!.slug).toBe("professions/software-engineer/semantic-versioning");
+  });
+
+  it("is deterministic for a query that matches nothing (slug asc)", () => {
+    const ranked = rankCorpusPages(SOFTWARE_ENGINEER_PAGES, "xyzzy nothing matches", family);
+    expect(ranked.every((r) => r.score === 0)).toBe(true);
+    expect(ranked.map((r) => r.slug)).toEqual(
+      [...SOFTWARE_ENGINEER_PAGES.map((r) => r.slug)].sort((a, b) => a.localeCompare(b)),
+    );
+  });
+});
+
+// ─── Resolver ─────────────────────────────────────────────────────────────────
+
+describe("resolveProfessionCorpusContext", () => {
+  it("injects ranked corpus for a mapped coworker", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(SOFTWARE_ENGINEER_PAGES),
+      identity: { agentId: "build-software-engineer" },
+      query: "How do I prevent SQL injection in a query?",
+    });
+
+    expect(ctx.status).toBe("injected");
+    expect(ctx.professionKey).toBe("software-engineer");
+    expect(ctx.profileId).toBe("wsid-software-engineer");
+    expect(ctx.promptBlock).toContain("PROFESSION CORPUS — Software Engineer");
+    expect(ctx.promptBlock).toContain("professions/software-engineer/owasp-top-ten");
+    expect(ctx.pages[0]!.slug).toBe("professions/software-engineer/owasp-top-ten");
+    expect(ctx.tokenCount).toBeGreaterThan(0);
+    expect(ctx.compactBlock).toContain("PROFESSION CORPUS — Software Engineer");
+    expect(ctx.lowRelevance).toBe(false);
+  });
+
+  it("resolves registry agents whose role slug lives in Agent.name", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(SOFTWARE_ENGINEER_PAGES),
+      identity: { agentId: "AGT-XYZ-001", name: "build-software-engineer" },
+      query: "code review standards",
+    });
+    expect(ctx.status).toBe("injected");
+    expect(ctx.professionKey).toBe("software-engineer");
+  });
+
+  it("caps the number of injected pages", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(SOFTWARE_ENGINEER_PAGES),
+      identity: { agentId: "software-engineer" },
+      query: "security versioning review",
+      maxPages: 2,
+    });
+    expect(ctx.pages).toHaveLength(2);
+  });
+
+  it("returns missed-unmapped for an agent in no family", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(SOFTWARE_ENGINEER_PAGES),
+      identity: { agentId: "totally-unknown-agent" },
+      query: "anything",
+    });
+    expect(ctx.status).toBe("missed-unmapped");
+    expect(ctx.promptBlock).toBeNull();
+    expect(ctx.professionKey).toBeNull();
+    expect(ctx.missingTopic).toBe("anything");
+  });
+
+  it("returns missed-empty-corpus when the family has no published pages", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb([]), // no rows for any prefix
+      identity: { agentId: "build-software-engineer" },
+      query: "secure coding",
+    });
+    expect(ctx.status).toBe("missed-empty-corpus");
+    expect(ctx.professionKey).toBe("software-engineer");
+    expect(ctx.promptBlock).toBeNull();
+    expect(ctx.suggestedSource).toContain("Seed corpus");
+  });
+
+  it("returns error status (fail-open) when the corpus read throws", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: throwingDb(),
+      identity: { agentId: "build-software-engineer" },
+      query: "secure coding",
+    });
+    expect(ctx.status).toBe("error");
+    expect(ctx.promptBlock).toBeNull();
+  });
+
+  it("flags low-relevance when a substantive query overlaps no corpus page", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(SOFTWARE_ENGINEER_PAGES),
+      identity: { agentId: "build-software-engineer" },
+      query: "kubernetes helm chart rollout",
+    });
+    expect(ctx.status).toBe("injected"); // corpus still injected (always grounded)
+    expect(ctx.lowRelevance).toBe(true);
+    expect(ctx.suggestedSource).not.toBeNull();
+  });
+});

--- a/apps/web/lib/decision-perspective/profession-corpus.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus.ts
@@ -1,0 +1,321 @@
+// apps/web/lib/decision-perspective/profession-corpus.ts
+//
+// WSID Phase 3 — runtime profession-corpus retrieval service.
+//
+// Closes the coverage→usage gap: PR #2016 made every coworker resolve to a
+// profession family with seeded corpus, but nothing INJECTED that corpus into a
+// coworker's prompt at runtime. This service is the single retrieval entry
+// point that turns an Agent identity into prompt-ready professional grounding:
+//
+//   Agent identity → profession family → wsid-<key> profileId
+//                  → corpus WikiPages (slug prefix `professions/<key>/`)
+//                  → lexically-ranked, token-bounded excerpts → prompt block
+//
+// Why slug-prefix (not Qdrant): the profession corpus is seeded into Postgres
+// WikiPage rows but is NOT embedded into the Qdrant wiki collection (Phase 2
+// seeded pages only). A deterministic lexical ranker over the small per-family
+// page set (4–9 pages) needs no vector sidecar, works on a cold install, and is
+// fully unit-testable. When Phase 3+ seeds embeddings, this can swap to vector
+// recall behind the same return shape.
+//
+// Contract: pure + db-injected (mirrors resolveProfessionProfile /
+// resolveProfileMaterial) so callers in tests pass a structural fake. The
+// caller decides what to do with `status` (record usage vs. gap) — this module
+// computes, it does not write.
+
+import {
+  findProfessionFamilyForAgentIdentity,
+  professionProfileId,
+  type ProfessionAgentIdentity,
+  type ProfessionFamily,
+} from "./resolve-profession-profile";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export type ProfessionCorpusStatus =
+  | "injected" // a family resolved AND it has corpus pages → promptBlock is non-null
+  | "missed-unmapped" // the agent maps to no profession family
+  | "missed-empty-corpus" // the family resolved but has no published corpus pages
+  | "error"; // a DB read failed (fail-open — caller still proceeds without corpus)
+
+export type ProfessionCorpusPageExcerpt = {
+  slug: string;
+  title: string;
+  abstract: string | null;
+  /** Bounded, whitespace-normalised body preview for the prompt. */
+  excerpt: string;
+  /** Lexical relevance score against the query (0 when nothing overlapped). */
+  score: number;
+};
+
+export type ProfessionCorpusContext = {
+  status: ProfessionCorpusStatus;
+  professionKey: string | null;
+  familyLabel: string | null;
+  /** Deterministic `wsid-<professionKey>` profile id, or null when unmapped. */
+  profileId: string | null;
+  /** Top-ranked pages selected for the prompt (empty on a miss). */
+  pages: ProfessionCorpusPageExcerpt[];
+  /** Full, token-bounded prompt block. Null when there is nothing to inject. */
+  promptBlock: string | null;
+  /** Abstracts-only compact variant (arbitration compression fallback). */
+  compactBlock: string | null;
+  tokenCount: number;
+  compactTokenCount: number;
+  /**
+   * True when the query carried ≥2 substantive terms yet NONE of them overlapped
+   * any corpus page — i.e. the corpus exists but likely does not cover this
+   * question. Drives a `low-relevance` growth-gap so corpora grow from real use.
+   */
+  lowRelevance: boolean;
+  /** Normalised topic for gap dedupe (always set; basis = the query). */
+  missingTopic: string;
+  /** Suggested corpus/source to close a gap (registry checklist + first source). */
+  suggestedSource: string | null;
+};
+
+// ─── DB client surface (structural — satisfied by PrismaClient + test fakes) ──
+
+type WikiPageCorpusRow = {
+  slug: string;
+  title: string;
+  abstract: string | null;
+  body: string;
+};
+
+export type ProfessionCorpusClient = {
+  wikiPage: {
+    findMany(args: {
+      where: Record<string, unknown>;
+      select: { slug: true; title: true; abstract: true; body: true };
+    }): Promise<WikiPageCorpusRow[]>;
+  };
+};
+
+// ─── Tunables ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_PAGES = 3;
+const DEFAULT_EXCERPT_CHARS = 320;
+
+// Lightweight token estimate (~4 chars/token) — matches context-arbitrator.
+function estimateTokens(text: string | null): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+// ─── Lexical ranking (deterministic, dependency-free) ─────────────────────────
+
+const STOPWORDS = new Set([
+  "the", "and", "for", "are", "but", "not", "you", "all", "any", "can", "had",
+  "her", "was", "one", "our", "out", "day", "get", "has", "him", "his", "how",
+  "man", "new", "now", "old", "see", "two", "way", "who", "boy", "did", "its",
+  "let", "put", "say", "she", "too", "use", "what", "when", "with", "this",
+  "that", "from", "they", "would", "there", "their", "about", "which", "your",
+  "have", "will", "into", "should", "could", "does", "doing", "need", "want",
+  "please", "help", "tell", "show", "give", "make", "like", "want",
+]);
+
+/** Tokenise a query into deduped lowercase content terms (len ≥ 3, non-stopword). */
+export function corpusQueryTerms(query: string): string[] {
+  const seen = new Set<string>();
+  const terms: string[] = [];
+  for (const raw of query.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length < 3 || STOPWORDS.has(raw) || seen.has(raw)) continue;
+    seen.add(raw);
+    terms.push(raw);
+  }
+  return terms;
+}
+
+type ScoredRow = WikiPageCorpusRow & { score: number; matchedTerms: number; checklistHits: number };
+
+function slugTail(slug: string): string {
+  // `professions/software-engineer/owasp-top-ten` → `owasp top ten`
+  const last = slug.split("/").pop() ?? slug;
+  return last.replace(/[^a-z0-9]+/gi, " ").toLowerCase();
+}
+
+/**
+ * Rank corpus pages against the query by weighted field presence
+ * (title ×3, abstract ×2, slug ×2, body ×1). Presence, not frequency, so a
+ * long body cannot dominate a precise title match. Deterministic tie-break:
+ * more distinct terms matched → more checklist keywords present → slug asc.
+ */
+export function rankCorpusPages(
+  rows: WikiPageCorpusRow[],
+  query: string,
+  family: ProfessionFamily,
+): ScoredRow[] {
+  const terms = corpusQueryTerms(query);
+  const checklistTokens = new Set(
+    family.coverageChecklist.flatMap((c) => c.split(/[^a-z0-9]+/i).map((t) => t.toLowerCase())),
+  );
+
+  const scored: ScoredRow[] = rows.map((row) => {
+    const title = row.title.toLowerCase();
+    const abstract = (row.abstract ?? "").toLowerCase();
+    const slug = slugTail(row.slug);
+    const body = row.body.toLowerCase();
+
+    let score = 0;
+    let matchedTerms = 0;
+    for (const term of terms) {
+      let termScore = 0;
+      if (title.includes(term)) termScore += 3;
+      if (abstract.includes(term)) termScore += 2;
+      if (slug.includes(term)) termScore += 2;
+      if (body.includes(term)) termScore += 1;
+      if (termScore > 0) matchedTerms += 1;
+      score += termScore;
+    }
+
+    let checklistHits = 0;
+    for (const term of terms) {
+      if (checklistTokens.has(term)) checklistHits += 1;
+    }
+
+    return { ...row, score, matchedTerms, checklistHits };
+  });
+
+  return scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.matchedTerms !== a.matchedTerms) return b.matchedTerms - a.matchedTerms;
+    if (b.checklistHits !== a.checklistHits) return b.checklistHits - a.checklistHits;
+    return a.slug.localeCompare(b.slug); // stable, deterministic final tie-break
+  });
+}
+
+// ─── Formatting ───────────────────────────────────────────────────────────────
+
+function boundedExcerpt(body: string, maxChars: number): string {
+  const normalised = body.replace(/\s+/g, " ").trim();
+  if (normalised.length <= maxChars) return normalised;
+  return normalised.slice(0, maxChars).replace(/\s+\S*$/, "") + "…";
+}
+
+function formatFullBlock(family: ProfessionFamily, pages: ProfessionCorpusPageExcerpt[]): string {
+  const lines = [
+    `PROFESSION CORPUS — ${family.label} (your professional knowledge base; cite pages by their slug):`,
+  ];
+  for (const page of pages) {
+    lines.push(`- ${page.title} [${page.slug}]`);
+    if (page.abstract) lines.push(`  ${page.abstract.replace(/\s+/g, " ").trim()}`);
+    if (page.excerpt) lines.push(`  ${page.excerpt}`);
+  }
+  lines.push(
+    "Ground craft and professional-practice answers in this corpus before generic recall. " +
+      "If it does not cover the question, say so plainly instead of inventing an answer.",
+  );
+  return lines.join("\n");
+}
+
+function formatCompactBlock(family: ProfessionFamily, pages: ProfessionCorpusPageExcerpt[]): string {
+  const titles = pages.map((p) => `${p.title} [${p.slug}]`).join("; ");
+  return `PROFESSION CORPUS — ${family.label}: ${titles}. Cite by slug; ground craft answers here first.`;
+}
+
+// ─── Gap suggestion ───────────────────────────────────────────────────────────
+
+/** Normalise a query into a stable, human-readable topic (dedupe basis). */
+export function normalizeCorpusTopic(query: string): string {
+  return query.trim().toLowerCase().replace(/\s+/g, " ").replace(/[?!.]+$/, "").slice(0, 160);
+}
+
+function suggestSourceForFamily(family: ProfessionFamily): string {
+  const checklist = family.coverageChecklist.slice(0, 4).join(", ");
+  const source = family.sources[0];
+  const sourceHint = source ? ` Candidate source: ${source.name} (${source.url}).` : "";
+  return `Seed corpus covering: ${checklist}.${sourceHint}`;
+}
+
+// ─── Resolver ─────────────────────────────────────────────────────────────────
+
+function missContext(
+  status: Exclude<ProfessionCorpusStatus, "injected">,
+  family: ProfessionFamily | null,
+  query: string,
+): ProfessionCorpusContext {
+  return {
+    status,
+    professionKey: family?.professionKey ?? null,
+    familyLabel: family?.label ?? null,
+    profileId: family ? professionProfileId(family.professionKey) : null,
+    pages: [],
+    promptBlock: null,
+    compactBlock: null,
+    tokenCount: 0,
+    compactTokenCount: 0,
+    lowRelevance: false,
+    missingTopic: normalizeCorpusTopic(query),
+    suggestedSource: family ? suggestSourceForFamily(family) : null,
+  };
+}
+
+/**
+ * Resolve prompt-ready profession-corpus context for a coworker turn.
+ *
+ * Always returns (fail-open): on a miss or DB error the caller still assembles a
+ * prompt — just without corpus — and records the miss as evidence. `status`
+ * tells the caller which evidence to record.
+ */
+export async function resolveProfessionCorpusContext(input: {
+  db: ProfessionCorpusClient;
+  identity: ProfessionAgentIdentity;
+  query: string;
+  maxPages?: number;
+  excerptChars?: number;
+}): Promise<ProfessionCorpusContext> {
+  const family = findProfessionFamilyForAgentIdentity(input.identity);
+  if (!family) return missContext("missed-unmapped", null, input.query);
+
+  let rows: WikiPageCorpusRow[];
+  try {
+    rows = await input.db.wikiPage.findMany({
+      where: {
+        slug: { startsWith: `professions/${family.professionKey}/` },
+        status: "published",
+      },
+      select: { slug: true, title: true, abstract: true, body: true },
+    });
+  } catch {
+    return missContext("error", family, input.query);
+  }
+
+  if (rows.length === 0) return missContext("missed-empty-corpus", family, input.query);
+
+  const ranked = rankCorpusPages(rows, input.query, family);
+  const top = ranked.slice(0, input.maxPages ?? DEFAULT_MAX_PAGES);
+  const excerptChars = input.excerptChars ?? DEFAULT_EXCERPT_CHARS;
+
+  const pages: ProfessionCorpusPageExcerpt[] = top.map((r) => ({
+    slug: r.slug,
+    title: r.title,
+    abstract: r.abstract,
+    excerpt: boundedExcerpt(r.body, excerptChars),
+    score: r.score,
+  }));
+
+  const promptBlock = formatFullBlock(family, pages);
+  const compactBlock = formatCompactBlock(family, pages);
+
+  // Low-relevance signal: a real (≥2 content terms) question that overlapped
+  // nothing in the corpus. The corpus is still injected (professional grounding
+  // is always relevant), but the gap is captured so the corpus can grow.
+  const terms = corpusQueryTerms(input.query);
+  const lowRelevance = terms.length >= 2 && ranked.every((r) => r.score === 0);
+
+  return {
+    status: "injected",
+    professionKey: family.professionKey,
+    familyLabel: family.label,
+    profileId: professionProfileId(family.professionKey),
+    pages,
+    promptBlock,
+    compactBlock,
+    tokenCount: estimateTokens(promptBlock),
+    compactTokenCount: estimateTokens(compactBlock),
+    lowRelevance,
+    missingTopic: normalizeCorpusTopic(input.query),
+    suggestedSource: lowRelevance ? suggestSourceForFamily(family) : null,
+  };
+}

--- a/apps/web/lib/decision-perspective/profession-corpus.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus.ts
@@ -216,9 +216,24 @@ function formatCompactBlock(family: ProfessionFamily, pages: ProfessionCorpusPag
 
 // ─── Gap suggestion ───────────────────────────────────────────────────────────
 
-/** Normalise a query into a stable, human-readable topic (dedupe basis). */
+/** Trailing characters stripped from a normalised topic (punctuation + space). */
+const CORPUS_TOPIC_TRAILING = "?!. ";
+
+/**
+ * Normalise a query into a stable, human-readable topic (dedupe basis).
+ *
+ * The trailing strip is a linear char-walk, NOT an anchored regex like
+ * `/[?!.]+$/` — that pattern is a polynomial-ReDoS vector on user-controlled
+ * input (CodeQL js/polynomial-redos), the same reason `normalizeGapTopic`
+ * (wiki/coverage-gap.ts) walks instead of matching.
+ */
 export function normalizeCorpusTopic(query: string): string {
-  return query.trim().toLowerCase().replace(/\s+/g, " ").replace(/[?!.]+$/, "").slice(0, 160);
+  const collapsed = query.trim().toLowerCase().replace(/\s+/g, " ");
+  let end = collapsed.length;
+  while (end > 0 && CORPUS_TOPIC_TRAILING.includes(collapsed.charAt(end - 1))) {
+    end--;
+  }
+  return collapsed.slice(0, end).slice(0, 160);
 }
 
 function suggestSourceForFamily(family: ProfessionFamily): string {

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -278,6 +278,48 @@ describe("assembleSystemPrompt", () => {
     expect(boundaryIdx).toBeLessThan(wikiIdx);
   });
 
+  // ─── WSID Phase 3: professionContext injection in Block 5 ──────────────────
+
+  it("omits the profession corpus block when professionContext is null or undefined", async () => {
+    const prompt = await assembleSystemPrompt(fullInput);
+    expect(prompt).not.toContain("PROFESSION CORPUS");
+  });
+
+  it("renders professionContext in Block 5 ABOVE generic wiki recall (corpus outranks wiki)", async () => {
+    const professionBlock =
+      "PROFESSION CORPUS — Software Engineer (your professional knowledge base; cite pages by their slug):";
+    const wikiBlock = "RELEVANT WIKI CONTEXT:\n- entities/x (entity, kernel) — body";
+    const prompt = await assembleSystemPrompt({
+      ...fullInput,
+      professionContext: professionBlock,
+      wikiContext: wikiBlock,
+    });
+
+    const domainIdx = indexOf(prompt, "portfolio tree");
+    const professionIdx = indexOf(prompt, "PROFESSION CORPUS");
+    const wikiIdx = indexOf(prompt, "RELEVANT WIKI CONTEXT");
+    const toolsIdx = indexOf(prompt, "Available domain tools");
+
+    expect(domainIdx).toBeGreaterThanOrEqual(0);
+    expect(professionIdx).toBeGreaterThanOrEqual(0);
+    expect(wikiIdx).toBeGreaterThanOrEqual(0);
+    // domain context → profession corpus → generic wiki recall → domain tools
+    expect(domainIdx).toBeLessThan(professionIdx);
+    expect(professionIdx).toBeLessThan(wikiIdx);
+    expect(wikiIdx).toBeLessThan(toolsIdx);
+  });
+
+  it("places professionContext on the dynamic side of the cache boundary", async () => {
+    const prompt = await assembleSystemPrompt({
+      ...minimalInput,
+      professionContext: "PROFESSION CORPUS — QA Engineer: ...",
+    });
+    const boundaryIdx = indexOf(prompt, "DYNAMIC_BOUNDARY");
+    const professionIdx = indexOf(prompt, "PROFESSION CORPUS");
+    expect(boundaryIdx).toBeGreaterThanOrEqual(0);
+    expect(boundaryIdx).toBeLessThan(professionIdx);
+  });
+
   // ─── Block 5 governed Hermes learning Slice 1: coworker skills ──────────────
 
   it("renders an Available coworker skills block when skills are supplied", async () => {

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -28,6 +28,15 @@ export type PromptInput = {
    */
   wikiContext?: string | null;
   /**
+   * WSID Phase 3: the coworker's profession corpus — graded, cited excerpts of
+   * its professional knowledge base, resolved from the agent's profession family
+   * (apps/web/lib/decision-perspective/profession-corpus.ts). Rendered at the TOP
+   * of Block 5, ABOVE generic `wikiContext`, because craft grounding outranks
+   * generic recall for a specialist coworker. Token-bounded by the caller's
+   * context arbitration; pass `null` to omit.
+   */
+  professionContext?: string | null;
+  /**
    * Governed Hermes learning Slice 1: eligible coworker skills.
    * The assembler renders a concise summary alongside domain context so the
    * coworker can pick one without flooding the prompt with full SKILL.md
@@ -150,8 +159,14 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
     dynamicBlocks.push(questionPacketBlock);
   }
 
-  // Block 5: Domain context (+ wiki context per EP-WIKI-001 §7)
+  // Block 5: Domain context (+ profession corpus per WSID Phase 3, + wiki context
+  // per EP-WIKI-001 §7). Profession corpus sits directly under domainContext and
+  // ABOVE generic wiki recall — a specialist grounds craft answers in its own
+  // profession corpus first.
   let domainBlock = input.domainContext;
+  if (input.professionContext) {
+    domainBlock += `\n\n${input.professionContext}`;
+  }
   if (input.wikiContext) {
     domainBlock += `\n\n${input.wikiContext}`;
   }

--- a/docs/superpowers/plans/2026-06-16-profession-corpus-runtime-injection.md
+++ b/docs/superpowers/plans/2026-06-16-profession-corpus-runtime-injection.md
@@ -1,0 +1,109 @@
+# Profession-corpus runtime injection (WSID Phase 3)
+
+**Date:** 2026-06-16
+**Status:** Implemented
+**Predecessor:** PR #2016 — *fix: close AI Workforce profession coverage gaps* (coverage/mapping/visibility)
+**Epic context:** EP-WSID (WSID — per-coworker professional corpus & knowledge graph)
+
+## Problem — coverage is not usage
+
+PR #2016 guaranteed that every one of the 82 AI coworkers **resolves** to exactly
+one profession family with a **seeded** corpus, and surfaced that on `/platform/ai`.
+But it stopped at *visibility*. A profession-substrate audit confirmed the harder
+gap:
+
+- `resolveProfessionProfile` / `findProfessionFamilyForAgentIdentity` had **zero
+  runtime consumers** — they were called only by HRIS/display surfaces
+  (`coworker-record/*`, `wiki/perspectives`).
+- Nothing **injected** a coworker's profession corpus into its prompt at runtime.
+  The generic `recallWikiContext` is org-scoped vector search; profession pages are
+  seeded with `organizationId = null` and are **not embedded in Qdrant** (Phase 2
+  seeded Postgres rows only) — so generic recall essentially never surfaced them.
+- No **evidence** that corpus was used or missed; no profession-specific **gap
+  capture**; no operator view of usage vs. growth.
+
+Net: the corpus existed but coworkers reasoned without it.
+
+## Design decision — retrieval + arbitration, not prompt-stuffing
+
+The WSID spec (`docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md`)
+intended runtime access via the **decision gate** (`evaluateDecisionPerspective` +
+Qdrant material recall) and §3 lists *"prompt-stuffed expertise / giant role
+prompts"* as an anti-pattern. The operator directive for this work is explicit:
+inject the corpus into **every coworker response**, high-priority in context
+arbitration, subject to token budget.
+
+These are **complementary, not contradictory**:
+
+- The gate covers *decision points*; the directive covers *every response*.
+- The anti-pattern targets *static, hardcoded* expertise. This implementation is
+  **retrieval-based, token-bounded, context-arbitrated, and cited** — the opposite
+  of a giant static prompt.
+
+So Phase 3 here implements the "every response" layer as retrieval under the
+existing context-arbitration budget. (Wiring `resolveProfessionProfile` into the
+decision gate itself remains valid future work and is not foreclosed.)
+
+Retrieval ranks via a deterministic **lexical** scorer rather than Qdrant because
+profession pages are not embedded; the lexical path needs no vector sidecar, works
+on a cold install, and is fully unit-testable. It can swap to vector recall behind
+the same return shape once profession pages are embedded.
+
+## Architecture
+
+```
+Agent identity ──► findProfessionFamilyForAgentIdentity ──► professionKey
+   │                                                            │
+   │                                              wsid-<key> profileId
+   ▼                                                            │
+prisma.wikiPage (slug startsWith `professions/<key>/`, published)
+   │
+   ▼  rankCorpusPages (lexical, deterministic)
+prompt-ready excerpts ──► Block 5 (above generic wiki) ──► coworker prompt
+   │
+   ▼  recordProfessionCorpusEvidence (fire-and-forget, fail-open)
+ProfessionCorpusUsageStat (injected/missed per family/day)
+ProfessionCorpusGap        (deduped growth backlog: unmapped | empty-corpus | low-relevance | deferred)
+```
+
+### New code
+- `apps/web/lib/decision-perspective/profession-corpus.ts` — `resolveProfessionCorpusContext`
+  (the single retrieval entry point) + lexical ranker + formatter. Pure, db-injected.
+- `apps/web/lib/decision-perspective/profession-corpus-evidence.ts` — `recordProfessionCorpusUsage`,
+  `recordProfessionCorpusGap` (deduped upsert by fingerprint), `recordProfessionCorpusEvidence`
+  orchestrator. Fail-open.
+- `apps/web/lib/coworker-record/corpus-signals.ts` — operator rollups (usage + open gaps).
+- `apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx` — report-kit
+  StatCards + growth-queue DataTable on `/platform/ai`.
+- DB: `ProfessionCorpusGap`, `ProfessionCorpusUsageStat` (+ migration
+  `20260616120000_add_profession_corpus_runtime`).
+
+### Wiring
+- `assembleSystemPrompt` gains `professionContext?` rendered at the TOP of Block 5,
+  **above** generic `wikiContext`.
+- `agent-coworker.ts` `sendMessage` (both unified + legacy paths): resolves the
+  corpus once, registers it as an **L1 priority-1** arbitrated source (compressible
+  to abstracts-only), passes the survivor to the assembler, and records evidence +
+  telemetry fire-and-forget. Fail-open throughout — a corpus/DB failure never
+  blocks a coworker response.
+
+### Operator UX
+- `/platform/ai`: usage/miss StatCards + deduped growth-queue table.
+- Coworker record → *Profession & Knowledge* tab: per-family injections / misses /
+  injection-rate / open gaps.
+
+## Invariants (tests)
+- Every active coworker → exactly one profession family *(existing, PR #2016)*.
+- Every family has non-empty corpus *(existing, PR #2016)*.
+- A resolved coworker prompt includes profession corpus context, OR a miss is
+  recorded — `profession-corpus.test.ts`, `prompt-assembler.test.ts`.
+- Misses recorded, not swallowed; gap/usage upserts idempotent —
+  `profession-corpus-evidence.test.ts`.
+- The sendMessage prompt path attempts retrieval + records evidence —
+  `profession-corpus-wiring.test.ts`.
+
+## Fail-open posture
+Every runtime write is fire-and-forget and swallows its own errors; the identity
+lookup is guarded against synchronous throws (partial mocks / DB outage). Corpus
+retrieval failure degrades to a normal (corpus-blind) response plus a recorded
+`error` status — never an exception into the response path.

--- a/packages/db/prisma/migrations/20260616120000_add_profession_corpus_runtime/migration.sql
+++ b/packages/db/prisma/migrations/20260616120000_add_profession_corpus_runtime/migration.sql
@@ -1,0 +1,58 @@
+-- Profession corpus runtime (WSID Phase 3): persist coworker USAGE of the
+-- per-profession corpus, distinct from coverage (pages seeded). Two additive
+-- tables: a deduplicated growth-backlog of corpus gaps surfaced by real usage,
+-- and a bounded per-profession/day usage counter (injected vs missed). Additive
+-- only — no existing table or row is touched.
+
+-- CreateTable
+CREATE TABLE "ProfessionCorpusGap" (
+    "id" TEXT NOT NULL,
+    "fingerprint" TEXT NOT NULL,
+    "professionKey" TEXT NOT NULL,
+    "agentId" TEXT,
+    "routeContext" TEXT,
+    "query" TEXT NOT NULL,
+    "missingTopic" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "suggestedSource" TEXT,
+    "occurrences" INTEGER NOT NULL DEFAULT 1,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProfessionCorpusGap_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProfessionCorpusUsageStat" (
+    "id" TEXT NOT NULL,
+    "professionKey" TEXT NOT NULL,
+    "day" TEXT NOT NULL,
+    "injectedCount" INTEGER NOT NULL DEFAULT 0,
+    "missedCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProfessionCorpusUsageStat_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProfessionCorpusGap_fingerprint_key" ON "ProfessionCorpusGap"("fingerprint");
+
+-- CreateIndex
+CREATE INDEX "ProfessionCorpusGap_professionKey_status_idx" ON "ProfessionCorpusGap"("professionKey", "status");
+
+-- CreateIndex
+CREATE INDEX "ProfessionCorpusGap_status_idx" ON "ProfessionCorpusGap"("status");
+
+-- CreateIndex
+CREATE INDEX "ProfessionCorpusGap_reason_idx" ON "ProfessionCorpusGap"("reason");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProfessionCorpusUsageStat_professionKey_day_key" ON "ProfessionCorpusUsageStat"("professionKey", "day");
+
+-- CreateIndex
+CREATE INDEX "ProfessionCorpusUsageStat_professionKey_idx" ON "ProfessionCorpusUsageStat"("professionKey");
+
+-- CreateIndex
+CREATE INDEX "ProfessionCorpusUsageStat_day_idx" ON "ProfessionCorpusUsageStat"("day");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -9151,6 +9151,60 @@ model WikiPage {
   @@index([principlePublic])
 }
 
+// ─── Profession corpus runtime (WSID Phase 3 / BI close coverage→usage gap) ──
+// Coverage (corpus pages seeded per family) is NOT usage. These two additive
+// tables record what actually happens at runtime when a coworker assembles a
+// prompt: was its profession corpus injected, or missed — and when missed, the
+// gap becomes a deduplicated growth-backlog item so each corpus grows from real
+// usage. Written fire-and-forget / fail-open from the prompt path so they can
+// never break a coworker response. See
+// docs/superpowers/plans/2026-06-16-profession-corpus-runtime-injection.md.
+
+model ProfessionCorpusGap {
+  id String @id @default(cuid())
+  // Deterministic dedupe key: sha256(professionKey:normalizedTopic:reason)[0:16].
+  // Re-detecting the same gap coalesces (occurrences++) instead of piling up.
+  fingerprint     String  @unique
+  professionKey   String
+  // The coworker that surfaced the gap (Agent.agentId). Null when the agent
+  // mapped to no profession family at all (reason = "unmapped").
+  agentId         String?
+  routeContext    String?
+  // The task/query the coworker could not ground in its profession corpus.
+  query           String  @db.Text
+  // Normalized, human-readable topic (the dedupe basis).
+  missingTopic    String
+  // unmapped | empty-corpus | low-relevance | deferred
+  reason          String
+  // Suggested corpus / source to close the gap (from the registry checklist + sources).
+  suggestedSource String? @db.Text
+  occurrences     Int      @default(1)
+  // open | addressed | dismissed
+  status          String   @default("open")
+  firstSeenAt     DateTime @default(now())
+  lastSeenAt      DateTime @updatedAt
+
+  @@index([professionKey, status])
+  @@index([status])
+  @@index([reason])
+}
+
+model ProfessionCorpusUsageStat {
+  id            String @id @default(cuid())
+  professionKey String
+  // UTC day bucket (YYYY-MM-DD). Bucketing keeps the per-turn upsert at bounded
+  // cardinality (families × days) instead of a row per coworker turn.
+  day           String
+  injectedCount Int      @default(0)
+  missedCount   Int      @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@unique([professionKey, day])
+  @@index([professionKey])
+  @@index([day])
+}
+
 model WikiPageRevision {
   id               String   @id @default(cuid())
   pageId           String


### PR DESCRIPTION
## Summary

PR #2016 made every AI coworker **resolve** to a profession family with **seeded** corpus and surfaced coverage on `/platform/ai` — but it did **not** make coworkers *use* that corpus. Audit confirmed: `resolveProfessionProfile` had **zero runtime consumers**, profession pages are `organizationId=null` and not embedded in Qdrant, so generic wiki recall never surfaced them. Coverage ≠ usage.

This wires the corpus into the runtime so every coworker response is grounded in its profession, with evidence and a growth loop.

## What changed

- **Retrieval service** (`apps/web/lib/decision-perspective/profession-corpus.ts`): `resolveProfessionCorpusContext` — Agent identity → profession family → `wsid-*` profile → corpus WikiPages (`professions/<key>/` slug prefix) → lexically-ranked, token-bounded prompt-ready excerpts + status. Pure, db-injected, deterministic (no Qdrant dependency; works on a cold install).
- **Prompt wiring** (`agent-coworker.ts` sendMessage, unified + legacy): resolves the corpus once, registers it as a **high-priority L1 arbitrated** context source (compressible to abstracts under budget), rendered in Block 5 **above** generic wiki recall (`assembleSystemPrompt` gains `professionContext`). Fail-open throughout; `[profession-corpus]` telemetry.
- **Evidence + growth** (`profession-corpus-evidence.ts` + `ProfessionCorpusGap` / `ProfessionCorpusUsageStat`): records injected/missed per family/day and a **deduped** growth backlog of gaps (`unmapped` | `empty-corpus` | `low-relevance` | `deferred`) carrying agentId, professionKey, routeContext, query, missing topic, suggested source.
- **Operator UX**: `/platform/ai` usage/miss StatCards + growth-queue DataTable; per-coworker **Profession & Knowledge** tab gains usage/miss/gaps (report-kit, theme-aware).

## Design note

WSID §3 cautions against "prompt-stuffed expertise / giant role prompts" and the spec intended runtime access via the decision *gate*. Mark's directive is to inject into *every response*. These are complementary (gate = decision points; this = every response), and this is **retrieval under token arbitration with citations** — not static prompt-stuffing. Gate wiring remains valid future work. Detail: [`docs/superpowers/plans/2026-06-16-profession-corpus-runtime-injection.md`](docs/superpowers/plans/2026-06-16-profession-corpus-runtime-injection.md).

## Verification

- `@dpf/db` typecheck, `web` typecheck, `web` build — pass.
- Full `web` vitest: **11,267 passed / 0 failed** (1311 files).
- New invariant tests: prompt includes corpus or records a miss; misses not swallowed; gap/usage idempotent; sendMessage path attempts retrieval. (Existing invariants — every coworker maps to one family, every family non-empty corpus — retained.)
- **Live read-only check** against the production WikiPage corpus: **82/82 coworkers resolve a family and inject corpus, 0 missed** (e.g. `software-engineer → owasp-asvs-summary`, ~2.1k-char grounded block). Confirmed 23 families with published corpus + 82 agents in the live DB; the two new runtime tables are correctly absent pre-migration.

> Live happy-path UX click-through (panel render + a driven coworker chat recording a gap) runs after deploy via the canonical post-merge archetype-rebuild audit — the running install serves pre-merge bytes, so it can't exercise this code yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)