### PR TITLE
fix(self-upgrade): stop "show more" from repeating the truncated update list

### DIFF
--- a/apps/web/components/ops/UpgradeImpactPanel.test.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+//
+// Regression guard for the "What's in this update?" self-upgrade panel.
+//
+// The "show more" disclosure used to render the FULL `allItems` list, which
+// includes the top-N rows already shown above it — so expanding repeated the
+// truncated list instead of extending it. The disclosure must reveal ONLY the
+// items not already shown, so each change appears exactly once.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type {
+  ChangeCategory,
+  ImpactItem,
+  SummaryResult,
+  UpgradeImpactSummary,
+} from "@/lib/self-upgrade/impact/types";
+import UpgradeImpactPanel from "./UpgradeImpactPanel";
+
+afterEach(() => cleanup());
+
+function item(
+  sha: string,
+  description: string,
+  category: ChangeCategory = "feature",
+): ImpactItem {
+  return {
+    sha,
+    description,
+    type: "feat",
+    scope: null,
+    category,
+    breaking: false,
+    prNumber: null,
+    prTitle: null,
+    prLabels: [],
+    score: 0,
+    reasons: [],
+    touchesCustomizations: false,
+  };
+}
+
+function summaryWith(
+  topItems: ImpactItem[],
+  allItems: ImpactItem[],
+): SummaryResult {
+  const summary: UpgradeImpactSummary = {
+    currentLineageSha: "a".repeat(40),
+    targetSha: "b".repeat(40),
+    counts: {
+      breaking: 0,
+      feature: allItems.length,
+      fix: 0,
+      performance: 0,
+      other: 0,
+      total: allItems.length,
+    },
+    topItems,
+    allItems,
+    phrased: null,
+    enrichment: { githubReachable: true, prsEnriched: 0 },
+    generatedAt: "2026-06-16T00:00:00.000Z",
+    fromCache: true,
+  };
+  return { ok: true, summary };
+}
+
+describe("UpgradeImpactPanel — show-more disclosure", () => {
+  const top = [item("sha1", "Top change one"), item("sha2", "Top change two")];
+  const all = [
+    ...top,
+    item("sha3", "Tail change three"),
+    item("sha4", "Tail change four"),
+  ];
+
+  it("does not duplicate the top-N rows when the full list is available", () => {
+    render(<UpgradeImpactPanel enabled initialSummary={summaryWith(top, all)} />);
+
+    // Each change — top-N and tail alike — must appear exactly once. Before the
+    // fix, the top-N rows rendered twice (once in the top list, once inside the
+    // disclosure that re-rendered the whole `allItems`).
+    expect(screen.getAllByText("Top change one")).toHaveLength(1);
+    expect(screen.getAllByText("Top change two")).toHaveLength(1);
+    expect(screen.getAllByText("Tail change three")).toHaveLength(1);
+    expect(screen.getAllByText("Tail change four")).toHaveLength(1);
+  });
+
+  it("labels the disclosure with the remaining count, not the full count", () => {
+    render(<UpgradeImpactPanel enabled initialSummary={summaryWith(top, all)} />);
+
+    // 4 total, 2 shown up top -> 2 remaining behind the fold.
+    expect(screen.getByText("Show 2 more changes")).toBeTruthy();
+    expect(screen.queryByText("Show all 4 changes")).toBeNull();
+  });
+
+  it("flips the label when expanded and keeps rows unduplicated", () => {
+    const { container } = render(
+      <UpgradeImpactPanel enabled initialSummary={summaryWith(top, all)} />,
+    );
+
+    // jsdom doesn't toggle <details open> or fire `toggle` from a summary
+    // click, so reproduce what the browser does — open the element and fire the
+    // toggle event — to drive the controlled onToggle -> setShowFullList path.
+    const details = container.querySelector("details") as HTMLDetailsElement;
+    details.open = true;
+    fireEvent(details, new Event("toggle"));
+
+    expect(screen.getByText("Show fewer")).toBeTruthy();
+    // Expanded view still shows each change exactly once.
+    expect(screen.getAllByText("Top change one")).toHaveLength(1);
+    expect(screen.getAllByText("Tail change four")).toHaveLength(1);
+  });
+
+  it("omits the disclosure entirely when nothing exceeds the top-N", () => {
+    render(<UpgradeImpactPanel enabled initialSummary={summaryWith(top, top)} />);
+
+    expect(screen.queryByText(/more change/)).toBeNull();
+    expect(screen.queryByText("Show fewer")).toBeNull();
+    expect(screen.getAllByText("Top change one")).toHaveLength(1);
+  });
+});

--- a/apps/web/components/ops/UpgradeImpactPanel.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.tsx
@@ -159,6 +159,18 @@ export default function UpgradeImpactPanel({
 
   if (!enabled) return null;
 
+  // The top-N rows are always rendered. The "show more" disclosure must reveal
+  // only the items NOT already shown above — rendering the full `allItems` here
+  // repeated the entire truncated top-N list instead of extending it. Compute
+  // the remainder as a set-difference by SHA so it is correct regardless of how
+  // `topItems` is ordered relative to `allItems`.
+  const summary = result?.ok ? result.summary : null;
+  const remainingItems = (() => {
+    if (!summary) return [];
+    const shownShas = new Set(summary.topItems.map((i) => i.sha));
+    return summary.allItems.filter((item) => !shownShas.has(item.sha));
+  })();
+
   return (
     <div
       className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] space-y-3"
@@ -242,17 +254,19 @@ export default function UpgradeImpactPanel({
             </ul>
           )}
 
-          {result.summary.allItems.length > result.summary.topItems.length && (
+          {remainingItems.length > 0 && (
             <details
               className="text-xs"
               open={showFullList}
               onToggle={(e) => setShowFullList((e.target as HTMLDetailsElement).open)}
             >
               <summary className="cursor-pointer text-[var(--dpf-accent)] hover:underline">
-                Show all {result.summary.allItems.length} changes
+                {showFullList
+                  ? "Show fewer"
+                  : `Show ${remainingItems.length} more change${remainingItems.length === 1 ? "" : "s"}`}
               </summary>
               <ul className="space-y-2 mt-2">
-                {result.summary.allItems.map((item) => (
+                {remainingItems.map((item) => (
                   <ItemRow key={item.sha} item={item} />
                 ))}
               </ul>


### PR DESCRIPTION
## Problem

On the Self-Upgrade page, the **"What''s in this update?"** panel has a "show all" control at the bottom of the truncated change list. Clicking it **repeated the first (truncated) list and then appended the rest** — every top row appeared twice — instead of extending the list in place. (Operator-reported.)

## Root cause

`UpgradeImpactPanel` renders the top-N rows, then a `<details>` disclosure that re-rendered the **entire** `allItems` array. But `topItems` is exactly `allItems.slice(0, N)` (see `apps/web/lib/self-upgrade/impact/index.ts`), so the disclosure re-emitted every row already shown above it.

## Fix

- The disclosure now renders **only the items not already shown** — computed as a set-difference by SHA, so it is correct regardless of how `topItems` is ordered relative to `allItems`.
- Relabeled the control **"Show N more changes"** (closed) / **"Show fewer"** (open) to reflect that it extends rather than replaces the list.

For a 12-change update (8 shown up top), expanding now appends the remaining 4 with no repeats.

## Verification

- New regression test `apps/web/components/ops/UpgradeImpactPanel.test.tsx` (4 cases) — asserts each change appears **exactly once** before and after expanding (fails on the old code), plus the remainder-count label and the no-disclosure case. All green.
- `tsc --noEmit` clean; pre-commit scoped typecheck + gitleaks passed.
- Re-ran the related self-upgrade suite: **66 tests pass** across 9 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)