### PR TITLE
feat(ai-workforce): archetype & region corpus axis + variant-aware retrieval (WSID Phase 4)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -13,6 +13,7 @@ import { can } from "@/lib/permissions";
 import { AgentModelRoutingCard } from "@/components/platform/AgentModelRoutingCard";
 import { loadCoworkerRecord } from "@/lib/coworker-record/load-record";
 import { loadFamilyCorpusSignals } from "@/lib/coworker-record/corpus-signals";
+import { resolveInstallVariantContext } from "@/lib/decision-perspective/install-variant-context";
 import { CoworkerRecordTabs, type CoworkerTab } from "@/components/platform/coworker-record/CoworkerRecordTabs";
 import {
   OverviewPanel,
@@ -41,9 +42,12 @@ export default async function AgentDetailPage({
 
   // WSID Phase 3: per-family runtime corpus signals (usage / misses / growth gaps)
   // for the Profession & Knowledge tab. Null when the coworker is unmapped.
-  const corpusSignals = profession.family
-    ? await loadFamilyCorpusSignals(profession.family.professionKey)
-    : null;
+  // The install's resolved archetype is shown so the operator sees which corpus
+  // slice this coworker is served (the "noted at setup" surface).
+  const [corpusSignals, installVariant] = await Promise.all([
+    profession.family ? loadFamilyCorpusSignals(profession.family.professionKey) : null,
+    resolveInstallVariantContext(prisma),
+  ]);
 
   // Model-routing card data (kept page-side: needs the live provider catalog).
   const [session, modelConfig, lastModelRows, activeProviders] = await Promise.all([
@@ -151,7 +155,7 @@ export default async function AgentDetailPage({
 
       <CoworkerRecordTabs tabs={tabs}>
         <OverviewPanel record={record} />
-        <ProfessionPanel record={record} corpusSignals={corpusSignals} />
+        <ProfessionPanel record={record} corpusSignals={corpusSignals} installArchetype={installVariant.archetype ?? null} />
         <CapabilitiesPanel record={record} routingCard={routingCard} />
         <GovernancePanel record={record} />
         <PerformancePanel record={record} />

--- a/apps/web/components/platform/coworker-record/panels.tsx
+++ b/apps/web/components/platform/coworker-record/panels.tsx
@@ -187,9 +187,12 @@ export function OverviewPanel({ record }: { record: CoworkerRecord }) {
 export function ProfessionPanel({
   record,
   corpusSignals,
+  installArchetype,
 }: {
   record: CoworkerRecord;
   corpusSignals?: { usage: CorpusUsageRollup; gaps: CorpusGapRow[] } | null;
+  /** The install's resolved archetype (selects the corpus slice this coworker is served). */
+  installArchetype?: string | null;
 }) {
   const { profession } = record;
   if (!profession.family) {
@@ -224,8 +227,19 @@ export function ProfessionPanel({
             <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginBottom: 10 }}>
               {cov.pageCount} corpus page{cov.pageCount !== 1 ? "s" : ""} under{" "}
               <code style={{ fontSize: 10 }}>professions/{fam.professionKey}/</code>
+              {" · "}This install&apos;s archetype:{" "}
+              <strong style={{ color: "var(--dpf-text)" }}>{installArchetype ?? "universal (none set)"}</strong>
             </div>
             <CoverageMatrix coverage={cov} />
+            <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 10 }}>
+              Archetype variants:{" "}
+              {Object.keys(cov.archetype).length > 0
+                ? Object.entries(cov.archetype)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([a, n]) => `${a} (${n})`)
+                    .join(", ")
+                : "universal only"}
+            </div>
           </>
         ) : (
           <EmptyState text="No published corpus pages for this family yet (empty corpus — the rollout demand signal)." />

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -48,6 +48,7 @@ import { recallWikiContext } from "@/lib/wiki/recall";
 import { recordCoverageGap } from "@/lib/wiki/coverage-gap";
 import { resolveProfessionCorpusContext } from "@/lib/decision-perspective/profession-corpus";
 import { recordProfessionCorpusEvidence } from "@/lib/decision-perspective/profession-corpus-evidence";
+import { resolveInstallVariantContext } from "@/lib/decision-perspective/install-variant-context";
 import {
   classifyPerspective,
   extractPageTopic,
@@ -89,6 +90,7 @@ async function requireAuthUser() {
   if (!user?.id) throw new Error("Unauthorized");
   return user;
 }
+
 
 async function buildPortalContextPromptSection(input: {
   routeContext: string;
@@ -647,10 +649,17 @@ export async function sendMessage(input: {
       }),
     )
     .catch(() => null);
+  // WSID archetype/region axis: resolve the install's variant context so the
+  // coworker is served its archetype's craft (and shielded from another
+  // archetype's) and the right regional doctrine. Fail-open to {} (no filtering).
+  const installVariantContext = await Promise.resolve()
+    .then(() => resolveInstallVariantContext(prisma))
+    .catch(() => ({}));
   const professionCorpus = await resolveProfessionCorpusContext({
     db: prisma,
     identity: professionIdentityRow ?? { agentId: agent.agentId },
     query: trimmedContent,
+    installContext: installVariantContext,
   }).catch((e) => {
     console.warn("[profession-corpus] resolve failed (fail-open):", e);
     return null;

--- a/apps/web/lib/coworker-record/coverage.test.ts
+++ b/apps/web/lib/coworker-record/coverage.test.ts
@@ -11,15 +11,15 @@ import {
 } from "@/lib/decision-perspective/resolve-profession-profile";
 
 describe("normalizeVariantAxes", () => {
-  it("defaults to global / practitioner when metadata is empty (seed parity)", () => {
-    expect(normalizeVariantAxes(null)).toEqual({ jurisdictions: ["global"], level: "practitioner" });
-    expect(normalizeVariantAxes({})).toEqual({ jurisdictions: ["global"], level: "practitioner" });
+  it("defaults to global / practitioner / universal when metadata is empty (seed parity)", () => {
+    expect(normalizeVariantAxes(null)).toEqual({ jurisdictions: ["global"], level: "practitioner", archetypes: ["universal"] });
+    expect(normalizeVariantAxes({})).toEqual({ jurisdictions: ["global"], level: "practitioner", archetypes: ["universal"] });
   });
 
   it("reads persisted variant axes from metadata", () => {
     expect(
       normalizeVariantAxes({ professionJurisdiction: ["us", "eu"], professionCompetencyLevel: "expert" }),
-    ).toEqual({ jurisdictions: ["us", "eu"], level: "expert" });
+    ).toEqual({ jurisdictions: ["us", "eu"], level: "expert", archetypes: ["universal"] });
   });
 
   it("falls back to global when jurisdiction array is empty", () => {

--- a/apps/web/lib/coworker-record/coverage.ts
+++ b/apps/web/lib/coworker-record/coverage.ts
@@ -25,6 +25,8 @@ export type ProfessionCoverage = {
   jurisdiction: Record<string, number>;
   /** Count of corpus pages at each competency level (omitted = practitioner). */
   competency: Record<string, number>;
+  /** Count of corpus pages tagged for each archetype (omitted = universal). */
+  archetype: Record<string, number>;
   /** Coverage-checklist knowledge areas declared by the registry for this family. */
   checklist: string[];
   /** True when the family has a registry entry but no published corpus pages. */
@@ -50,6 +52,9 @@ export async function loadProfessionCoverage(
   const competency: Record<string, number> = Object.fromEntries(
     PROFESSION_COMPETENCY_LEVELS.map((l: string) => [l, 0]),
   );
+  // Archetype counts start empty and grow as archetype-specific pages appear —
+  // most families are still universal-only, so listing all 20 slugs would be noise.
+  const archetype: Record<string, number> = {};
 
   const pages = (await prisma.wikiPage
     .findMany({
@@ -62,11 +67,14 @@ export async function loadProfessionCoverage(
     .catch(() => [])) as PageMetaRow[];
 
   for (const page of pages) {
-    const { jurisdictions, level } = normalizeVariantAxes(page.metadata);
+    const { jurisdictions, level, archetypes } = normalizeVariantAxes(page.metadata);
     for (const jur of jurisdictions) {
       jurisdiction[jur] = (jurisdiction[jur] ?? 0) + 1;
     }
     competency[level] = (competency[level] ?? 0) + 1;
+    for (const arch of archetypes) {
+      archetype[arch] = (archetype[arch] ?? 0) + 1;
+    }
   }
 
   return {
@@ -75,6 +83,7 @@ export async function loadProfessionCoverage(
     pageCount: pages.length,
     jurisdiction,
     competency,
+    archetype,
     checklist: family?.coverageChecklist ?? [],
     emptyCorpus: pages.length === 0,
   };

--- a/apps/web/lib/coworker-record/variant-axes.ts
+++ b/apps/web/lib/coworker-record/variant-axes.ts
@@ -6,9 +6,12 @@
 /**
  * Normalize a WikiPage.metadata blob into the WSID variant axes, applying the
  * same defaults the profession-corpus seed uses: omitted jurisdiction = global;
- * omitted competency = practitioner (variants spec §4).
+ * omitted competency = practitioner; omitted archetype = universal
+ * (variants spec §4 + archetype axis addendum 2026-06-16).
  */
-export function normalizeVariantAxes(metadata: unknown): { jurisdictions: string[]; level: string } {
+export function normalizeVariantAxes(
+  metadata: unknown,
+): { jurisdictions: string[]; level: string; archetypes: string[] } {
   const meta = (metadata ?? {}) as Record<string, unknown>;
   const rawJur = meta.professionJurisdiction;
   const jurisdictions =
@@ -17,5 +20,10 @@ export function normalizeVariantAxes(metadata: unknown): { jurisdictions: string
       : ["global"];
   const rawLevel = meta.professionCompetencyLevel;
   const level = typeof rawLevel === "string" ? rawLevel : "practitioner";
-  return { jurisdictions, level };
+  const rawArch = meta.professionArchetype;
+  const archetypes =
+    Array.isArray(rawArch) && rawArch.length > 0
+      ? rawArch.filter((a): a is string => typeof a === "string")
+      : ["universal"];
+  return { jurisdictions, level, archetypes };
 }

--- a/apps/web/lib/decision-perspective/install-variant-context.test.ts
+++ b/apps/web/lib/decision-perspective/install-variant-context.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveInstallVariantContext,
+  type InstallVariantClient,
+} from "./install-variant-context";
+
+function fakeDb(category: string | null | undefined, opts: { throws?: boolean } = {}): InstallVariantClient {
+  return {
+    storefrontConfig: {
+      findFirst: async () => {
+        if (opts.throws) throw new Error("no storefront");
+        if (category === undefined) return null;
+        return { archetype: category === null ? null : { category } };
+      },
+    },
+  };
+}
+
+describe("resolveInstallVariantContext", () => {
+  it("maps a storefront archetype category to the install archetype", async () => {
+    const ctx = await resolveInstallVariantContext(fakeDb("automotive-services"));
+    expect(ctx).toEqual({ archetype: "automotive-services", jurisdiction: null });
+  });
+
+  it("ignores a category that is not a known PROFESSION_ARCHETYPES slug", async () => {
+    const ctx = await resolveInstallVariantContext(fakeDb("totally-made-up"));
+    expect(ctx.archetype).toBeNull();
+  });
+
+  it("returns null archetype when no storefront config exists", async () => {
+    const ctx = await resolveInstallVariantContext(fakeDb(undefined));
+    expect(ctx).toEqual({ archetype: null, jurisdiction: null });
+  });
+
+  it("fails open to {} on a DB error", async () => {
+    const ctx = await resolveInstallVariantContext(fakeDb(null, { throws: true }));
+    expect(ctx).toEqual({});
+  });
+});

--- a/apps/web/lib/decision-perspective/install-variant-context.ts
+++ b/apps/web/lib/decision-perspective/install-variant-context.ts
@@ -1,0 +1,41 @@
+// apps/web/lib/decision-perspective/install-variant-context.ts
+// WSID archetype/region axis — resolve the install's variant context (which
+// business archetype + region this install is) ONCE, shared by the runtime
+// corpus retrieval (agent-coworker) and the operator surfaces so they agree on
+// which corpus slice each coworker is served. Fail-open: any error → {} (no
+// variant filtering, full corpus preserved).
+
+import { isProfessionArchetype } from "@dpf/db/wiki-taxonomy";
+import type { ProfessionCorpusInstallContext } from "./profession-corpus";
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type InstallVariantClient = {
+  storefrontConfig: {
+    findFirst(args: {
+      select: { archetype: { select: { category: true } } };
+    }): Promise<{ archetype: { category: string } | null } | null>;
+  };
+};
+
+/**
+ * Resolve the install's archetype (from the storefront's archetype category,
+ * already a PROFESSION_ARCHETYPES slug) and region. Region is not yet a
+ * first-class install setting, so `jurisdiction` stays `null` (unfiltered) until
+ * setup notation captures it.
+ */
+export async function resolveInstallVariantContext(
+  db: InstallVariantClient,
+): Promise<ProfessionCorpusInstallContext> {
+  try {
+    const sf = await db.storefrontConfig.findFirst({
+      select: { archetype: { select: { category: true } } },
+    });
+    const category = sf?.archetype?.category ?? null;
+    return {
+      archetype: category && isProfessionArchetype(category) ? category : null,
+      jurisdiction: null,
+    };
+  } catch {
+    return {};
+  }
+}

--- a/apps/web/lib/decision-perspective/profession-archetype-axis.test.ts
+++ b/apps/web/lib/decision-perspective/profession-archetype-axis.test.ts
@@ -1,0 +1,57 @@
+// Invariant: the WSID corpus archetype axis (PROFESSION_ARCHETYPES) stays in
+// sync with the canonical install archetype taxonomy (ArchetypeCategory /
+// ALL_ARCHETYPES). If a new business archetype is added to the platform but not
+// to the corpus axis, an install of that archetype could never be served (or
+// tagged with) archetype-specific craft — this fails loudly so the axis grows
+// alongside the taxonomy.
+import { describe, expect, it } from "vitest";
+
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+import { PROFESSION_ARCHETYPES, isProfessionArchetype } from "@dpf/db/wiki-taxonomy";
+import { normalizeVariantAxes } from "@/lib/coworker-record/variant-axes";
+
+const canonicalCategories = [...new Set(ALL_ARCHETYPES.map((a) => a.category))];
+
+describe("profession-archetype axis sync", () => {
+  it("covers every canonical ArchetypeCategory", () => {
+    const corpus = new Set(PROFESSION_ARCHETYPES as readonly string[]);
+    const missing = canonicalCategories.filter((c) => !corpus.has(c));
+    expect(missing, `categories missing from PROFESSION_ARCHETYPES: ${missing.join(", ")}`).toHaveLength(0);
+  });
+
+  it("has no slug beyond `universal` + the canonical categories", () => {
+    const allowed = new Set<string>(["universal", ...canonicalCategories]);
+    const extra = (PROFESSION_ARCHETYPES as readonly string[]).filter((s) => !allowed.has(s));
+    expect(extra, `unknown archetype slugs in PROFESSION_ARCHETYPES: ${extra.join(", ")}`).toHaveLength(0);
+  });
+
+  it("includes the `universal` archetype-neutral default", () => {
+    expect(isProfessionArchetype("universal")).toBe(true);
+    expect(PROFESSION_ARCHETYPES[0]).toBe("universal");
+  });
+});
+
+describe("normalizeVariantAxes — archetype axis", () => {
+  it("defaults a page with no archetype to universal", () => {
+    expect(normalizeVariantAxes({}).archetypes).toEqual(["universal"]);
+    expect(normalizeVariantAxes(null).archetypes).toEqual(["universal"]);
+  });
+
+  it("reads declared archetypes from metadata", () => {
+    const axes = normalizeVariantAxes({ professionArchetype: ["automotive-services", "moving-and-logistics"] });
+    expect(axes.archetypes).toEqual(["automotive-services", "moving-and-logistics"]);
+  });
+
+  it("still returns jurisdiction + level alongside archetype", () => {
+    const axes = normalizeVariantAxes({
+      professionJurisdiction: ["us"],
+      professionCompetencyLevel: "expert",
+      professionArchetype: ["banking-financial-services"],
+    });
+    expect(axes).toEqual({
+      jurisdictions: ["us"],
+      level: "expert",
+      archetypes: ["banking-financial-services"],
+    });
+  });
+});

--- a/apps/web/lib/decision-perspective/profession-corpus.test.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   corpusQueryTerms,
   normalizeCorpusTopic,
+  pageEligibleForInstall,
   rankCorpusPages,
   resolveProfessionCorpusContext,
   type ProfessionCorpusClient,
@@ -11,7 +12,14 @@ import { findProfessionFamily } from "./resolve-profession-profile";
 
 // ─── Fake corpus DB ───────────────────────────────────────────────────────────
 
-type Row = { slug: string; title: string; abstract: string | null; body: string };
+type Row = {
+  slug: string;
+  title: string;
+  abstract: string | null;
+  body: string;
+  /** WSID variant metadata; null → universal/global (the seed default). */
+  metadata: unknown;
+};
 
 const SOFTWARE_ENGINEER_PAGES: Row[] = [
   {
@@ -19,18 +27,21 @@ const SOFTWARE_ENGINEER_PAGES: Row[] = [
     title: "OWASP Top Ten Web Application Security Risks",
     abstract: "The ten most critical web application security risks.",
     body: "Injection, broken access control, and cryptographic failures lead the list. Mitigate with validation.",
+    metadata: null,
   },
   {
     slug: "professions/software-engineer/semantic-versioning",
     title: "Semantic Versioning",
     abstract: "MAJOR.MINOR.PATCH version increments convey compatibility.",
     body: "Increment MAJOR for breaking changes, MINOR for features, PATCH for fixes.",
+    metadata: null,
   },
   {
     slug: "professions/software-engineer/code-review-standard",
     title: "The Standard of Code Review",
     abstract: "Approve once a change improves overall code health.",
     body: "Reviewers approve when the change improves code health; perfection is not required.",
+    metadata: null,
   },
 ];
 
@@ -39,7 +50,9 @@ function fakeCorpusDb(rows: Row[]): ProfessionCorpusClient {
     wikiPage: {
       findMany: async (args) => {
         const prefix = (args.where.slug as { startsWith: string }).startsWith;
-        return rows.filter((r) => r.slug.startsWith(prefix));
+        return rows
+          .filter((r) => r.slug.startsWith(prefix))
+          .map((r) => ({ ...r, metadata: r.metadata ?? null }));
       },
     },
   };
@@ -182,5 +195,88 @@ describe("resolveProfessionCorpusContext", () => {
     expect(ctx.status).toBe("injected"); // corpus still injected (always grounded)
     expect(ctx.lowRelevance).toBe(true);
     expect(ctx.suggestedSource).not.toBeNull();
+  });
+});
+
+// ─── Archetype / jurisdiction variant selection ───────────────────────────────
+
+function meta(archetypes?: string[], jurisdictions?: string[]): unknown {
+  return {
+    ...(archetypes ? { professionArchetype: archetypes } : {}),
+    ...(jurisdictions ? { professionJurisdiction: jurisdictions } : {}),
+  };
+}
+
+describe("pageEligibleForInstall", () => {
+  it("serves universal pages to any install", () => {
+    const axes = { archetypes: ["universal"], jurisdictions: ["global"] };
+    expect(pageEligibleForInstall(axes, {})).toBe(true);
+    expect(pageEligibleForInstall(axes, { archetype: "retail-goods" })).toBe(true);
+  });
+
+  it("serves an archetype-specific page ONLY to the matching install", () => {
+    const axes = { archetypes: ["automotive-services"], jurisdictions: ["global"] };
+    expect(pageEligibleForInstall(axes, { archetype: "automotive-services" })).toBe(true);
+    expect(pageEligibleForInstall(axes, { archetype: "retail-goods" })).toBe(false);
+    expect(pageEligibleForInstall(axes, {})).toBe(false); // generic install never sees it
+  });
+
+  it("filters jurisdiction only when the install declares a concrete region", () => {
+    const usPage = { archetypes: ["universal"], jurisdictions: ["us"] };
+    expect(pageEligibleForInstall(usPage, {})).toBe(true); // no region declared → no filter
+    expect(pageEligibleForInstall(usPage, { jurisdiction: "us" })).toBe(true);
+    expect(pageEligibleForInstall(usPage, { jurisdiction: "eu" })).toBe(false); // shielded
+  });
+});
+
+describe("resolveProfessionCorpusContext — variant selection", () => {
+  const PAGES: Row[] = [
+    {
+      slug: "professions/operations/incident-severity",
+      title: "Incident severity classification",
+      abstract: "Classify incidents by impact.",
+      body: "SEV1/SEV2/SEV3 by customer impact and scope.",
+      metadata: meta(), // universal/global
+    },
+    {
+      slug: "professions/operations/automotive-adas-recalibration",
+      title: "ADAS recalibration after auto-glass replacement",
+      abstract: "Windshield work can require ADAS camera recalibration.",
+      body: "After glass replacement, recalibrate ADAS per OEM spec; document compliance.",
+      metadata: meta(["automotive-services"]),
+    },
+  ];
+
+  it("excludes another archetype's craft from a non-matching install", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(PAGES),
+      identity: { agentId: "operate-orchestrator" },
+      query: "how do I handle this incident",
+      installContext: { archetype: "retail-goods" },
+    });
+    expect(ctx.status).toBe("injected");
+    expect(ctx.pages.map((p) => p.slug)).not.toContain(
+      "professions/operations/automotive-adas-recalibration",
+    );
+  });
+
+  it("includes AND boosts the archetype-specific page for a matching install", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(PAGES),
+      identity: { agentId: "operate-orchestrator" },
+      query: "recalibration after glass replacement",
+      installContext: { archetype: "automotive-services" },
+    });
+    expect(ctx.status).toBe("injected");
+    expect(ctx.pages[0]!.slug).toBe("professions/operations/automotive-adas-recalibration");
+  });
+
+  it("a generic install (no context) sees only the universal page", async () => {
+    const ctx = await resolveProfessionCorpusContext({
+      db: fakeCorpusDb(PAGES),
+      identity: { agentId: "operate-orchestrator" },
+      query: "incident severity",
+    });
+    expect(ctx.pages.map((p) => p.slug)).toEqual(["professions/operations/incident-severity"]);
   });
 });

--- a/apps/web/lib/decision-perspective/profession-corpus.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus.ts
@@ -29,6 +29,10 @@ import {
   type ProfessionAgentIdentity,
   type ProfessionFamily,
 } from "./resolve-profession-profile";
+import { normalizeVariantAxes } from "@/lib/coworker-record/variant-axes";
+
+const ARCHETYPE_NEUTRAL = "universal";
+const JURISDICTION_NEUTRAL = "global";
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -81,15 +85,30 @@ type WikiPageCorpusRow = {
   title: string;
   abstract: string | null;
   body: string;
+  /** WikiPage.metadata blob carrying the WSID variant axes. */
+  metadata: unknown;
 };
 
 export type ProfessionCorpusClient = {
   wikiPage: {
     findMany(args: {
       where: Record<string, unknown>;
-      select: { slug: true; title: true; abstract: true; body: true };
+      select: { slug: true; title: true; abstract: true; body: true; metadata: true };
     }): Promise<WikiPageCorpusRow[]>;
   };
+};
+
+/**
+ * The install's resolved variant context. Selects which corpus slice a coworker
+ * is served. `archetype` defaults to `"universal"` (an install with no business
+ * archetype gets only archetype-neutral pages — never another archetype's
+ * craft). `jurisdiction` is nullable: `null` means "region not declared yet" and
+ * does NOT filter (preserves the full corpus); a concrete value serves
+ * global + that jurisdiction and shields the coworker from conflicting doctrine.
+ */
+export type ProfessionCorpusInstallContext = {
+  archetype?: string | null;
+  jurisdiction?: string | null;
 };
 
 // ─── Tunables ─────────────────────────────────────────────────────────────────
@@ -127,7 +146,63 @@ export function corpusQueryTerms(query: string): string[] {
   return terms;
 }
 
-type ScoredRow = WikiPageCorpusRow & { score: number; matchedTerms: number; checklistHits: number };
+type ScoredRow = WikiPageCorpusRow & {
+  score: number;
+  matchedTerms: number;
+  checklistHits: number;
+  /** Bonus for matching the install's archetype/jurisdiction (ranks tailored doctrine first). */
+  variantBoost: number;
+};
+
+/**
+ * Is this page eligible to serve the given install? Archetype-specific pages are
+ * served ONLY to a matching install (a retail install never sees HVAC craft);
+ * jurisdiction is filtered only when the install declares a concrete region
+ * (otherwise the full corpus is preserved — no regression for installs that
+ * haven't set a region yet).
+ */
+export function pageEligibleForInstall(
+  axes: { archetypes: string[]; jurisdictions: string[] },
+  install: ProfessionCorpusInstallContext,
+): boolean {
+  const installArch = install.archetype || ARCHETYPE_NEUTRAL;
+  const archOk =
+    axes.archetypes.includes(ARCHETYPE_NEUTRAL) || axes.archetypes.includes(installArch);
+
+  const installJur =
+    install.jurisdiction && install.jurisdiction !== JURISDICTION_NEUTRAL
+      ? install.jurisdiction
+      : null;
+  const jurOk =
+    installJur === null
+      ? true
+      : axes.jurisdictions.includes(JURISDICTION_NEUTRAL) || axes.jurisdictions.includes(installJur);
+
+  return archOk && jurOk;
+}
+
+/** Ranking bonus for a page that SPECIFICALLY matches the install's variant. */
+function variantBoostFor(
+  axes: { archetypes: string[]; jurisdictions: string[] },
+  install: ProfessionCorpusInstallContext,
+): number {
+  let boost = 0;
+  if (
+    install.archetype &&
+    install.archetype !== ARCHETYPE_NEUTRAL &&
+    axes.archetypes.includes(install.archetype)
+  ) {
+    boost += 3;
+  }
+  if (
+    install.jurisdiction &&
+    install.jurisdiction !== JURISDICTION_NEUTRAL &&
+    axes.jurisdictions.includes(install.jurisdiction)
+  ) {
+    boost += 3;
+  }
+  return boost;
+}
 
 function slugTail(slug: string): string {
   // `professions/software-engineer/owasp-top-ten` → `owasp top ten`
@@ -145,6 +220,7 @@ export function rankCorpusPages(
   rows: WikiPageCorpusRow[],
   query: string,
   family: ProfessionFamily,
+  install: ProfessionCorpusInstallContext = {},
 ): ScoredRow[] {
   const terms = corpusQueryTerms(query);
   const checklistTokens = new Set(
@@ -174,11 +250,17 @@ export function rankCorpusPages(
       if (checklistTokens.has(term)) checklistHits += 1;
     }
 
-    return { ...row, score, matchedTerms, checklistHits };
+    const variantBoost = variantBoostFor(normalizeVariantAxes(row.metadata), install);
+
+    // `score` stays pure-lexical (drives the low-relevance gap signal); the
+    // variant boost is a separate axis folded into the sort only.
+    return { ...row, score, matchedTerms, checklistHits, variantBoost };
   });
 
   return scored.sort((a, b) => {
-    if (b.score !== a.score) return b.score - a.score;
+    const aRank = a.score + a.variantBoost;
+    const bRank = b.score + b.variantBoost;
+    if (bRank !== aRank) return bRank - aRank;
     if (b.matchedTerms !== a.matchedTerms) return b.matchedTerms - a.matchedTerms;
     if (b.checklistHits !== a.checklistHits) return b.checklistHits - a.checklistHits;
     return a.slug.localeCompare(b.slug); // stable, deterministic final tie-break
@@ -277,6 +359,8 @@ export async function resolveProfessionCorpusContext(input: {
   db: ProfessionCorpusClient;
   identity: ProfessionAgentIdentity;
   query: string;
+  /** The install's resolved archetype/jurisdiction — selects the corpus slice. */
+  installContext?: ProfessionCorpusInstallContext;
   maxPages?: number;
   excerptChars?: number;
 }): Promise<ProfessionCorpusContext> {
@@ -290,7 +374,7 @@ export async function resolveProfessionCorpusContext(input: {
         slug: { startsWith: `professions/${family.professionKey}/` },
         status: "published",
       },
-      select: { slug: true, title: true, abstract: true, body: true },
+      select: { slug: true, title: true, abstract: true, body: true, metadata: true },
     });
   } catch {
     return missContext("error", family, input.query);
@@ -298,7 +382,14 @@ export async function resolveProfessionCorpusContext(input: {
 
   if (rows.length === 0) return missContext("missed-empty-corpus", family, input.query);
 
-  const ranked = rankCorpusPages(rows, input.query, family);
+  // Variant selection: keep pages eligible for this install (archetype-specific
+  // craft only to a matching install; jurisdiction filtered only when declared).
+  // Fail-safe: if filtering would starve the coworker, fall back to all pages.
+  const install = input.installContext ?? {};
+  const eligible = rows.filter((r) => pageEligibleForInstall(normalizeVariantAxes(r.metadata), install));
+  const usable = eligible.length > 0 ? eligible : rows;
+
+  const ranked = rankCorpusPages(usable, input.query, family, install);
   const top = ranked.slice(0, input.maxPages ?? DEFAULT_MAX_PAGES);
   const excerptChars = input.excerptChars ?? DEFAULT_EXCERPT_CHARS;
 

--- a/docs/professions/operations/wiki/automotive-adas-recalibration-dispatch.md
+++ b/docs/professions/operations/wiki/automotive-adas-recalibration-dispatch.md
@@ -1,0 +1,29 @@
+---
+title: Recalibrate ADAS after windshield work before returning the vehicle
+pageKind: heuristic
+status: published
+abstract: In automotive field service, windshield replacement or alignment work can require recalibrating windshield-mounted ADAS cameras and sensors; the dispatcher schedules the recalibration step and records compliance evidence before the job is closed.
+professionCompetencyLevel: practitioner
+professionArchetype:
+  - automotive-services
+sources:
+  - wikipedia/adas
+---
+
+## Heuristic
+
+Advanced driver-assistance systems (ADAS) are "technologies that assist drivers with the safe operation of a vehicle," and aftermarket ADAS commonly use a windshield-mounted camera. Because these systems "can be affected by mechanical alignment adjustments or damage from a collision," many manufacturers require a recalibration (an automatic reset) after alignment or glass work.
+
+For a dispatcher coordinating mobile auto-glass, collision, or alignment jobs on an ADAS-equipped vehicle:
+
+- Treat ADAS recalibration as a **required step** of the work order, not an optional add-on.
+- Schedule the recalibration (static and/or dynamic per the OEM procedure) so the job cannot be marked complete until it is done.
+- Capture the recalibration result as **compliance evidence** on the job. An un-recalibrated ADAS is a safety defect, not a cosmetic one.
+
+## Why it matters
+
+ADAS are real-time safety systems, and miscalibrated priorities "can cause more harm than good." Returning a vehicle with an uncalibrated windshield camera exposes the customer to a safety failure and the business to liability — so the recalibration gate belongs in the dispatch workflow, not in the technician's discretion.
+
+## Source
+
+- *Advanced driver-assistance system* (Wikipedia, CC BY-SA): https://en.wikipedia.org/wiki/Advanced_driver-assistance_system

--- a/docs/professions/operations/wiki/moving-dot-hours-of-service-dispatch.md
+++ b/docs/professions/operations/wiki/moving-dot-hours-of-service-dispatch.md
@@ -1,0 +1,34 @@
+---
+title: Schedule moving crews within DOT hours-of-service limits
+pageKind: heuristic
+status: published
+abstract: In moving and last-mile logistics, commercial-motor-vehicle drivers are bound by FMCSA hours-of-service limits; the dispatcher plans routes and shifts within the driving/on-duty windows and ensures the trip is logged (ELD), so a job is never scheduled that forces a driver past a legal limit.
+professionCompetencyLevel: practitioner
+professionArchetype:
+  - moving-and-logistics
+sources:
+  - fmcsa/hours-of-service
+---
+
+## Heuristic
+
+"Hours of service regulations are issued by the Federal Motor Carrier Safety Administration (FMCSA) and govern the working hours of anyone operating a commercial motor vehicle (CMV) in the United States." For property-carrying drivers the core limits are:
+
+- **11-hour** driving limit within a **14-hour** on-duty window;
+- a **30-minute break** within the first 8 hours of driving;
+- **60 hours / 7 days** or **70 hours / 8 days** weekly caps, with a 34-hour restart;
+- **10 hours** off-duty before the next shift.
+
+For a dispatcher coordinating moving/last-mile crews:
+
+- Plan each route and shift to **fit inside the driving and on-duty windows** — do not book a job that can only be completed by exceeding a limit.
+- Account for the **30-minute break** and weekly caps when sequencing multi-stop days.
+- Ensure hours are recorded via "a log book… or use electronic logging devices (ELDs)"; the record is the compliance evidence.
+
+## Why it matters
+
+An over-hours dispatch is an FMCSA violation and a fatigue-safety risk, not a scheduling inconvenience. Building the HOS limits into the dispatch plan keeps the crew legal and the customer's delivery window honest.
+
+## Source
+
+- *Hours of service* (Wikipedia, CC BY-SA; incorporates US FMCSA public-domain material): https://en.wikipedia.org/wiki/Hours_of_service

--- a/docs/professions/operations/wiki/trades-epa-608-refrigerant-certification.md
+++ b/docs/professions/operations/wiki/trades-epa-608-refrigerant-certification.md
@@ -1,0 +1,34 @@
+---
+title: Require EPA 608 certification before dispatching refrigerant work
+pageKind: heuristic
+status: published
+abstract: In HVAC/refrigeration field service, technicians who maintain, service, repair, or dispose of refrigerant-containing equipment must hold EPA Section 608 certification; the dispatcher checks the certification type against the job and never schedules a venting-prohibited task to an uncertified tech.
+professionCompetencyLevel: practitioner
+professionArchetype:
+  - trades-maintenance
+sources:
+  - epa/section-608
+---
+
+## Heuristic
+
+Under EPA Section 608 (Clean Air Act, 40 CFR Part 82 Subpart F), "technicians who maintain, service, repair, or dispose of equipment that could release refrigerants into the atmosphere must be certified." Certification comes in four types, matched to the equipment:
+
+- **Type I** — small appliances
+- **Type II** — high / very-high-pressure appliances
+- **Type III** — low-pressure appliances
+- **Universal** — all of the above
+
+For a dispatcher coordinating HVAC/refrigeration work:
+
+- Verify the assigned technician holds the **right 608 type for the equipment** before the job is dispatched, not after.
+- Treat the prohibition on **knowingly venting or releasing** ozone-depleting refrigerants (and their substitutes) as a hard rule — a recovery step belongs in the work order, not the technician's discretion.
+- Keep the certification on file as compliance evidence; 608 credentials do not expire, so capture them once per technician and reuse.
+
+## Why it matters
+
+Dispatching refrigerant work to an uncertified technician — or allowing venting — is a federal violation, not a quality slip. The certification check belongs in the dispatch gate so the business never books work it cannot legally perform.
+
+## Source
+
+- *Section 608 Technician Certification Requirements* (US EPA, public domain): https://www.epa.gov/section608/section-608-technician-certification-requirements

--- a/docs/superpowers/plans/2026-06-16-profession-corpus-archetype-region-axis.md
+++ b/docs/superpowers/plans/2026-06-16-profession-corpus-archetype-region-axis.md
@@ -1,0 +1,63 @@
+# Profession corpus — archetype & region axis (WSID Phase 4)
+
+**Date:** 2026-06-16
+**Status:** Phase 1 (mechanism + first content) implemented
+**Predecessor:** PR #2024 — profession-corpus runtime injection (WSID Phase 3)
+
+## Problem
+
+After #2024 every coworker resolves to a profession family and is served its
+family corpus at runtime. But the corpus is **family-level and mostly
+jurisdiction-neutral**: 150 pages across 23 families (avg 6.5), regional variants
+for only 4 families, and **no archetype dimension at all** — a veterinary clinic
+and a bank get byte-identical corpus. "Resolving to a family" is not the same as
+"having the right corpus on install."
+
+## Model
+
+Corpus becomes **profession × jurisdiction × archetype**. Each coworker resolves
+to its profession; the **install's archetype + region** select the slice it is
+served, always falling back to archetype-neutral (`universal`) / region-neutral
+(`global`) so nothing is ever empty.
+
+- **Archetype axis** (`PROFESSION_ARCHETYPES`, wiki-taxonomy.ts) — `universal` +
+  the 19 canonical `ArchetypeCategory` slugs (kept in sync by the
+  `profession-archetype axis sync` invariant test). A page omitting
+  `professionArchetype` is `universal`.
+- **Selection rule** (`pageEligibleForInstall`): an archetype-specific page is
+  served ONLY to a matching install (a retail install never sees HVAC craft).
+  Jurisdiction is filtered ONLY when the install declares a concrete region —
+  otherwise the full corpus is preserved (no regression for installs that haven't
+  set a region). Matching variant pages are **ranked above** neutral ones.
+
+## What shipped (Phase 1)
+
+- Axis substrate: `PROFESSION_ARCHETYPES` + `isProfessionArchetype`; frontmatter
+  `professionArchetype`; seed validate + tally + persist to `WikiPage.metadata`;
+  `normalizeVariantAxes` archetype; `SeedProfessionCorpusResult.archetypeCoverage`.
+- Variant-aware retrieval: `resolveProfessionCorpusContext` takes an
+  `installContext`, filters eligible pages, and boosts matching variants.
+- Install resolution: `resolveInstallVariantContext` (storefront archetype
+  category → install archetype; region TBD), shared by the runtime path and the
+  operator surfaces.
+- "Noted at setup": the coworker record's Profession tab shows the install's
+  resolved archetype + the family's archetype coverage.
+- First archetype content: `professions/operations/automotive-adas-recalibration-dispatch`
+  (`automotive-services`) — ADAS recalibration as a dispatcher compliance gate,
+  sourced from an open CC-BY-SA reference.
+- Tests: axis sync (corpus axis ⊇ canonical categories), eligibility +
+  boost + generic-install isolation, install resolution, normalize archetype.
+
+## Staged next (Phase 2+)
+
+This is the mechanism + a first content wave. Building out a corpus for **every
+unique region × archetype difference** is sustained, multi-wave work, driven by:
+
+1. **Content waves** — thicken thin families; author archetype-specific craft for
+   the dispatch wedge (trades-maintenance / automotive-services / moving-and-
+   logistics / security-services) and regional doctrine, each with provenance.
+2. **The growth-gap loop from #2024** — real coworker misses (now including
+   archetype/region context) feed `ProfessionCorpusGap` as the prioritized backlog.
+3. **Region as a first-class install setting** — capture the install's
+   jurisdiction at setup so jurisdiction filtering engages (today: `null` =
+   unfiltered).

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -16,8 +16,10 @@ import { appendRevision, attachSource, linkPages, upsertWikiPage } from "./wiki-
 import { extractWikilinks } from "./wiki-frontmatter";
 import type { WikiPageFrontmatter } from "./wiki-frontmatter";
 import {
+  PROFESSION_ARCHETYPES,
   PROFESSION_COMPETENCY_LEVELS,
   PROFESSION_JURISDICTIONS,
+  isProfessionArchetype,
   isProfessionCompetencyLevel,
   isProfessionJurisdiction,
 } from "./wiki-taxonomy";
@@ -877,6 +879,21 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
     retrievedAt: "2026-06-13",
   },
 
+  // ── Archetype-specific craft (WSID archetype axis, first wave) ──
+  // automotive-services dispatch: ADAS recalibration compliance after glass /
+  // alignment work — an archetype-specific safety gate the dispatcher owns.
+  "wikipedia/adas": {
+    sourceType: "reference",
+    title: "Advanced driver-assistance system",
+    url: "https://en.wikipedia.org/wiki/Advanced_driver-assistance_system",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "ADAS use windshield-mounted cameras/sensors; mechanical alignment or " +
+      "collision/glass work can require recalibration (an automatic reset) to " +
+      "keep the safety systems accurate.",
+    retrievedAt: "2026-06-16",
+  },
+
   // ── HR / people-ops family (WSID wave 7) — jurisdiction split us vs eu ──
   // SHRM BASK is licensed (cluster names used as facts, checklist-only). EEOC
   // and EU Your-Europe are public-domain/open-reuse. US OPM/HHS interview
@@ -1557,6 +1574,8 @@ export type SeedProfessionCorpusResult = {
   jurisdictionCoverage: Record<string, number>;
   /** Page counts by declared competency level (omitted pages count as "practitioner"). */
   competencyCoverage: Record<string, number>;
+  /** Page counts by declared archetype (omitted pages count as "universal"). */
+  archetypeCoverage: Record<string, number>;
 };
 
 /**
@@ -1571,7 +1590,8 @@ function tallyVariantCoverage(
   frontmatter: WikiPageFrontmatter,
   jurisdictionCoverage: Record<string, number>,
   competencyCoverage: Record<string, number>,
-): { jurisdictions: string[]; competencyLevel: string } {
+  archetypeCoverage: Record<string, number>,
+): { jurisdictions: string[]; competencyLevel: string; archetypes: string[] } {
   const jurisdictions =
     frontmatter.professionJurisdiction && frontmatter.professionJurisdiction.length > 0
       ? frontmatter.professionJurisdiction
@@ -1605,11 +1625,30 @@ function tallyVariantCoverage(
   }
   competencyCoverage[level] = (competencyCoverage[level] ?? 0) + 1;
 
+  const archetypes =
+    frontmatter.professionArchetype && frontmatter.professionArchetype.length > 0
+      ? frontmatter.professionArchetype
+      : ["universal"];
+  for (const arch of archetypes) {
+    if (!isProfessionArchetype(arch)) {
+      throw new Error(
+        "[seedProfessionCorpus] page " +
+          slug +
+          ' declares unknown professionArchetype "' +
+          arch +
+          '". Allowed: ' +
+          PROFESSION_ARCHETYPES.join(", ") +
+          ". Add it to PROFESSION_ARCHETYPES in wiki-taxonomy.ts (kept in sync with ArchetypeCategory) before using it.",
+      );
+    }
+    archetypeCoverage[arch] = (archetypeCoverage[arch] ?? 0) + 1;
+  }
+
   // Return the normalized axes so the caller can persist them into
   // WikiPage.metadata for runtime coverage queries (HRIS management surface,
   // and the future gate↔material variant binding). The seed is the single
   // place that has already validated these against the closed registries.
-  return { jurisdictions, competencyLevel: level };
+  return { jurisdictions, competencyLevel: level, archetypes };
 }
 
 /**
@@ -1637,6 +1676,7 @@ export async function seedProfessionCorpus(
       emptyCorpus: true,
       jurisdictionCoverage: {},
       competencyCoverage: {},
+      archetypeCoverage: {},
     };
   }
 
@@ -1658,6 +1698,7 @@ export async function seedProfessionCorpus(
       emptyCorpus: true,
       jurisdictionCoverage: {},
       competencyCoverage: {},
+      archetypeCoverage: {},
     };
   }
 
@@ -1665,6 +1706,7 @@ export async function seedProfessionCorpus(
   const bodies = new Map<string, string>();
   const jurisdictionCoverage: Record<string, number> = {};
   const competencyCoverage: Record<string, number> = {};
+  const archetypeCoverage: Record<string, number> = {};
 
   // Pass 1: upsert wiki pages and append revisions.
   for (const file of wikiFiles) {
@@ -1673,21 +1715,24 @@ export async function seedProfessionCorpus(
     const slug = deriveCorpusSlug(file);
     const status = frontmatter.status ?? "published";
 
-    const { jurisdictions, competencyLevel } = tallyVariantCoverage(
+    const { jurisdictions, competencyLevel, archetypes } = tallyVariantCoverage(
       slug,
       frontmatter,
       jurisdictionCoverage,
       competencyCoverage,
+      archetypeCoverage,
     );
 
     const principlePayload = extractPrinciplePayload(frontmatter);
 
     // Persist the validated WSID variant axes into WikiPage.metadata so the
-    // HRIS coverage helper (and the future gate variant binding) can query
-    // jurisdiction/competency at runtime without re-parsing the corpus files.
+    // HRIS coverage helper, the runtime retrieval service, and the gate variant
+    // binding can query jurisdiction/competency/archetype at runtime without
+    // re-parsing the corpus files.
     const metadata = {
       professionJurisdiction: jurisdictions,
       professionCompetencyLevel: competencyLevel,
+      professionArchetype: archetypes,
     };
 
     const upserted = (await upsertWikiPage(prisma, {
@@ -1767,5 +1812,6 @@ export async function seedProfessionCorpus(
     emptyCorpus: false,
     jurisdictionCoverage,
     competencyCoverage,
+    archetypeCoverage,
   };
 }

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -880,8 +880,8 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
   },
 
   // ── Archetype-specific craft (WSID archetype axis, first wave) ──
-  // automotive-services dispatch: ADAS recalibration compliance after glass /
-  // alignment work — an archetype-specific safety gate the dispatcher owns.
+  // Dispatch-native compliance gates the dispatcher owns, one per archetype.
+  // automotive-services: ADAS recalibration after glass / alignment work.
   "wikipedia/adas": {
     sourceType: "reference",
     title: "Advanced driver-assistance system",
@@ -891,6 +891,30 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "ADAS use windshield-mounted cameras/sensors; mechanical alignment or " +
       "collision/glass work can require recalibration (an automatic reset) to " +
       "keep the safety systems accurate.",
+    retrievedAt: "2026-06-16",
+  },
+  // trades-maintenance: EPA Section 608 technician certification for refrigerant work.
+  "epa/section-608": {
+    sourceType: "standard",
+    title: "Section 608 Technician Certification Requirements (US EPA)",
+    url: "https://www.epa.gov/section608/section-608-technician-certification-requirements",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "EPA Clean Air Act §608: technicians who maintain, service, repair, or " +
+      "dispose of refrigerant-containing equipment must be certified (Type I/II/" +
+      "III/Universal); knowingly venting refrigerants is prohibited.",
+    retrievedAt: "2026-06-16",
+  },
+  // moving-and-logistics: FMCSA hours-of-service limits for commercial drivers.
+  "fmcsa/hours-of-service": {
+    sourceType: "reference",
+    title: "Hours of service (FMCSA, via encyclopedia summary)",
+    url: "https://en.wikipedia.org/wiki/Hours_of_service",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "FMCSA hours-of-service limits for commercial motor vehicle drivers: " +
+      "11-hour driving limit, 14-hour on-duty window, 30-minute break, 60/70-hour " +
+      "weekly caps; hours logged via logbook or ELD.",
     retrievedAt: "2026-06-16",
   },
 

--- a/packages/db/src/wiki-frontmatter.ts
+++ b/packages/db/src/wiki-frontmatter.ts
@@ -46,6 +46,12 @@ export type WikiPageFrontmatter = {
    * "practitioner". Values from PROFESSION_COMPETENCY_LEVELS.
    */
   professionCompetencyLevel?: string;
+  /**
+   * Business archetypes this page's craft variant is specific to. Omitted =
+   * archetype-neutral (equivalent to ["universal"]). Values from
+   * PROFESSION_ARCHETYPES (mirror of ArchetypeCategory).
+   */
+  professionArchetype?: string[];
   // ─── Principle-only frontmatter (spec section 9) ───
   // Required-field gating lives in lint detectors per spec section 14, not
   // here. The seed walker accepts incomplete principle data so lint can

--- a/packages/db/src/wiki-taxonomy.ts
+++ b/packages/db/src/wiki-taxonomy.ts
@@ -293,6 +293,47 @@ export const PROFESSION_COMPETENCY_LEVELS = [
 export type ProfessionCompetencyLevel =
   (typeof PROFESSION_COMPETENCY_LEVELS)[number];
 
+/**
+ * Archetype axis — the business archetype whose practice a page is specific to.
+ * A page omitting `professionArchetype` is archetype-neutral (applies to every
+ * install) — equivalent to `["universal"]`. Archetype-specific doctrine (a
+ * dispatcher's running-late cascade in field trades vs. a storefront order
+ * handoff in retail; ADAS-calibration compliance for automotive vs. EPA-608 for
+ * HVAC) declares the archetypes it governs so an install of that archetype is
+ * served the right craft variant and shielded from the irrelevant one.
+ *
+ * The non-`universal` slugs mirror `ArchetypeCategory`
+ * (packages/storefront-templates/src/types.ts) — the canonical install archetype
+ * taxonomy — so an install's resolved archetype category maps 1:1 onto a corpus
+ * tag. Kept in sync by the `profession-archetype-axis` invariant test; grow only
+ * alongside that union. Like jurisdiction, seed archetype-specific content as
+ * real per-archetype demand appears, not speculatively — but the axis is
+ * complete so any install's archetype can be *noted* at setup from day one.
+ */
+export const PROFESSION_ARCHETYPES = [
+  "universal",
+  "healthcare-wellness",
+  "beauty-personal-care",
+  "trades-maintenance",
+  "professional-services",
+  "software-platform",
+  "education-training",
+  "pet-services",
+  "food-hospitality",
+  "retail-goods",
+  "fitness-recreation",
+  "nonprofit-community",
+  "hoa-property-management",
+  "banking-financial-services",
+  "public-sector",
+  "asset-rental",
+  "real-estate-construction",
+  "automotive-services",
+  "moving-and-logistics",
+  "security-services",
+] as const;
+export type ProfessionArchetype = (typeof PROFESSION_ARCHETYPES)[number];
+
 // ─── Type-narrowing predicates ──────────────────────────────────────────────
 
 /**
@@ -387,6 +428,19 @@ export function isProfessionCompetencyLevel(
   return (
     typeof value === "string" &&
     (PROFESSION_COMPETENCY_LEVELS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Narrowing predicate for the WSID archetype axis. Gates `professionArchetype`
+ * frontmatter against `PROFESSION_ARCHETYPES`.
+ */
+export function isProfessionArchetype(
+  value: unknown,
+): value is ProfessionArchetype {
+  return (
+    typeof value === "string" &&
+    (PROFESSION_ARCHETYPES as readonly string[]).includes(value)
   );
 }
 


### PR DESCRIPTION
## Summary

After #2024 every coworker resolves to a profession family and is served its family corpus at runtime — but that corpus was **family-level and mostly jurisdiction-neutral** (150 pages / 23 families, regional variants for only 4, **zero archetype dimension**). A veterinary clinic and a bank got byte-identical corpus. *Resolving to a family is not the same as having the right corpus on install.*

This makes corpus **profession × jurisdiction × archetype**. Each coworker resolves to its profession; the **install's archetype + region** select the slice it is served — always falling back to `universal`/`global` so nothing is ever empty.

## What changed

- **Archetype axis** — `PROFESSION_ARCHETYPES` (`universal` + the 19 canonical `ArchetypeCategory` slugs) + `isProfessionArchetype`; `professionArchetype` frontmatter; seed validate/tally/persist to `WikiPage.metadata`; `normalizeVariantAxes`; `SeedProfessionCorpusResult.archetypeCoverage`. A **sync invariant test** fails if the corpus axis ever drifts from the canonical install archetype taxonomy.
- **Variant-aware retrieval** — `resolveProfessionCorpusContext` takes an `installContext` and `pageEligibleForInstall`: archetype-specific craft is served **only** to a matching install (a retail install never sees HVAC craft); jurisdiction is filtered **only** when the install declares a concrete region (no regression otherwise); matching variants are **ranked first**.
- **Install resolution** — `resolveInstallVariantContext` (storefront archetype category → install archetype) shared by the runtime path and the operator surfaces. The coworker record's **Profession tab now notes the install's archetype** + the family's archetype coverage ("noted at setup").
- **First archetype content** — [`professions/operations/automotive-adas-recalibration-dispatch`](docs/professions/operations/wiki/automotive-adas-recalibration-dispatch.md) (`automotive-services`): ADAS recalibration as a dispatcher compliance gate, with open-license (CC-BY-SA) provenance — proving the axis end-to-end.

## Phasing

This is the **mechanism + first content wave**. Building a corpus for every unique region × archetype difference is sustained, multi-wave work, driven by content waves (dispatch wedge: trades / automotive / moving / security; regional doctrine) and the growth-gap loop from #2024. Region as a first-class install setting (so jurisdiction filtering engages) is staged next. Detail: [plan](docs/superpowers/plans/2026-06-16-profession-corpus-archetype-region-axis.md).

## Verification

- `@dpf/db` + `web` typecheck pass; seed validation (`src/seed.test.ts`) passes.
- Full `web` vitest: **11,303 passed / 0 failed**.
- New tests: archetype-axis sync, eligibility + boost + generic-install isolation, install resolution, normalize-archetype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)