### PR TITLE
feat(ea): cross-layer relationship edges in applySysmlModel (living-graph bridge keystone)

### DIFF
--- a/packages/db/src/sysml-model-seed.test.ts
+++ b/packages/db/src/sysml-model-seed.test.ts
@@ -15,14 +15,22 @@ const MODEL: SysmlDesiredModel = {
 
 type ExistingEl = { id: string; infraCiKey: string; properties: Record<string, unknown> };
 
-function makeDb(existing: ExistingEl[] = [], opts: { notation?: boolean; relExists?: boolean; viewExists?: boolean } = {}) {
+function makeDb(
+  existing: ExistingEl[] = [],
+  opts: { notation?: boolean; relExists?: boolean; viewExists?: boolean; crossTargets?: Record<string, string> } = {},
+) {
   return {
     eaNotation: { findUnique: vi.fn().mockResolvedValue(opts.notation === false ? null : { id: "n" }) },
     eaElementType: { findUniqueOrThrow: vi.fn(async (a: { where: { notationId_slug: { slug: string } } }) => ({ id: `et-${a.where.notationId_slug.slug}` })) },
     eaRelationshipType: { findUniqueOrThrow: vi.fn(async (a: { where: { notationId_slug: { slug: string } } }) => ({ id: `rt-${a.where.notationId_slug.slug}` })) },
     eaElement: {
       findMany: vi.fn().mockResolvedValue(existing),
-      findFirst: vi.fn().mockResolvedValue(null),
+      // Resolves a cross-layer target by infraCiKey when opts.crossTargets maps it;
+      // otherwise null (the prior behaviour every existing test relies on).
+      findFirst: vi.fn(async (a: { where: { infraCiKey: string } }) => {
+        const id = opts.crossTargets?.[a.where.infraCiKey];
+        return id ? { id } : null;
+      }),
       create: vi.fn(async (a: { data: { infraCiKey: string } }) => ({ id: `el-${a.data.infraCiKey}` })),
       update: vi.fn(async (a: { where: { id: string } }) => ({ id: a.where.id })),
     },
@@ -124,5 +132,49 @@ describe("applySysmlModel", () => {
     await applySysmlModel({ ...MODEL, softRemovePrefix: undefined }, { db: db as never });
     expect(db.eaConformanceIssue.findFirst).not.toHaveBeenCalled();
     expect(db.eaConformanceIssue.create).not.toHaveBeenCalled();
+  });
+
+  const crossModel: SysmlDesiredModel = {
+    ...MODEL,
+    softRemovePrefix: undefined,
+    relTypeSlugs: ["contains", "allocates"],
+    crossLayerRelationships: [{ fromKey: "x:a", toKey: "other:logical", relSlug: "allocates" }],
+  };
+
+  it("links a cross-layer edge to an element another projection owns (resolved by infraCiKey)", async () => {
+    const db = makeDb([], { crossTargets: { "other:logical": "el-other" } });
+    const r = await applySysmlModel(crossModel, { db: db as never });
+    expect(r.crossLayerLinked).toBe(1);
+    expect(r.crossLayerUnresolved).toBe(0);
+    const xcall = db.eaRelationship.create.mock.calls.find(
+      ([a]) => (a as { data: { toElementId: string } }).data.toElementId === "el-other",
+    );
+    expect(xcall).toBeTruthy();
+    const data = (xcall![0] as { data: { fromElementId: string; relationshipTypeId: string; properties: { crossLayer: boolean } } }).data;
+    expect(data.fromElementId).toBe("el-x:a"); // resolved in-model
+    expect(data.relationshipTypeId).toBe("rt-allocates");
+    expect(data.properties.crossLayer).toBe(true);
+  });
+
+  it("counts a cross-layer edge as unresolved (never silent) when the target is absent", async () => {
+    const db = makeDb([], {}); // no crossTargets → target won't resolve
+    const r = await applySysmlModel(
+      { ...crossModel, crossLayerRelationships: [{ fromKey: "x:a", toKey: "missing:logical", relSlug: "allocates" }] },
+      { db: db as never },
+    );
+    expect(r.crossLayerUnresolved).toBe(1);
+    expect(r.crossLayerLinked).toBe(0);
+    const xcall = db.eaRelationship.create.mock.calls.find(
+      ([a]) => (a as { data: { toElementId: string } }).data.toElementId === "el-missing:logical",
+    );
+    expect(xcall).toBeFalsy(); // no phantom edge created
+  });
+
+  it("is idempotent for cross-layer edges: counts linked but creates no duplicate", async () => {
+    const db = makeDb([], { crossTargets: { "other:logical": "el-other" } });
+    db.eaRelationship.findFirst.mockResolvedValue({ id: "rx" }); // every edge already present
+    const r = await applySysmlModel(crossModel, { db: db as never });
+    expect(r.crossLayerLinked).toBe(1);
+    expect(db.eaRelationship.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/db/src/sysml-model-seed.ts
+++ b/packages/db/src/sysml-model-seed.ts
@@ -68,6 +68,16 @@ export interface SysmlDesiredModel {
   /** When set, existing elements with this infraCiKey prefix that are NOT in the
    *  desired set are soft-removed (mirrorRemoved=true, lifecycleStatus=inactive). */
   softRemovePrefix?: string;
+  /** Cross-LAYER relationships: edges from this model's elements to elements that live
+   *  in OTHER projections, resolved against existing `EaElement.infraCiKey` rather than
+   *  only this model's in-memory keys. This is the bridge that makes impact analysis
+   *  (blast_radius) span layers — e.g. an actual-layer operational/network/integration
+   *  occurrence `allocates`/`traces` to the logical part it realizes. Endpoints are
+   *  resolved in-model first, then against the live graph; an unresolved endpoint is
+   *  logged and counted (never silently dropped) and is linked on a later reconcile once
+   *  its projection exists. relSlugs used here MUST appear in `relTypeSlugs`. Ordinary
+   *  same-projection edges belong in `relationships`, not here. */
+  crossLayerRelationships?: SysmlDesiredRel[];
 }
 
 export interface SysmlSeedResult {
@@ -75,6 +85,10 @@ export interface SysmlSeedResult {
   created: number;
   updated: number;
   removed: number;
+  /** Cross-layer edges resolved + present this run (see `crossLayerRelationships`). */
+  crossLayerLinked?: number;
+  /** Cross-layer edges whose endpoint did not resolve to a live element this run. */
+  crossLayerUnresolved?: number;
 }
 
 export async function applySysmlModel(
@@ -114,6 +128,8 @@ export async function applySysmlModel(
   let created = 0;
   let updated = 0;
   let removed = 0;
+  let crossLayerLinked = 0;
+  let crossLayerUnresolved = 0;
   const idByKey = new Map<string, string>();
 
   for (const el of model.elements) {
@@ -162,6 +178,37 @@ export async function applySysmlModel(
     }
   }
 
+  // Cross-LAYER edges: resolve each endpoint in-model first, then against the live graph
+  // by infraCiKey, so a projection can link to elements another projection owns (the
+  // bridge that lets blast_radius span layers). A miss is logged + counted, never
+  // silently dropped — the next reconcile links it once the target projection exists.
+  if (model.crossLayerRelationships?.length) {
+    const resolveId = async (key: string): Promise<string | null> => {
+      const inModel = idByKey.get(key);
+      if (inModel) return inModel;
+      const found = await db.eaElement.findFirst({ where: { infraCiKey: key }, select: { id: true } });
+      return found?.id ?? null;
+    };
+    for (const rel of model.crossLayerRelationships) {
+      const relationshipTypeId = rtId.get(rel.relSlug);
+      if (!relationshipTypeId) continue;
+      const fromElementId = await resolveId(rel.fromKey);
+      const toElementId = await resolveId(rel.toKey);
+      if (!fromElementId || !toElementId) {
+        crossLayerUnresolved++;
+        console.warn(
+          `[sysml-model-seed] cross-layer ${rel.fromKey} -[${rel.relSlug}]-> ${rel.toKey}: ${!fromElementId ? "from" : "to"} endpoint unresolved — skipping (links on a later reconcile once its projection exists)`,
+        );
+        continue;
+      }
+      const found = await db.eaRelationship.findFirst({ where: { fromElementId, toElementId, relationshipTypeId }, select: { id: true } });
+      if (!found) {
+        await db.eaRelationship.create({ data: { fromElementId, toElementId, relationshipTypeId, notationSlug, properties: { crossLayer: true } } });
+      }
+      crossLayerLinked++;
+    }
+  }
+
   // Conformance issues this model records (idempotent by element + issueType). Only
   // touches the table when the model actually carries issues — so consumers that file
   // none never depend on the eaConformanceIssue delegate.
@@ -197,5 +244,5 @@ export async function applySysmlModel(
   }
 
   const status: SysmlSeedResult["status"] = created === 0 && updated === 0 && removed === 0 ? "noop" : "applied";
-  return { status, created, updated, removed };
+  return { status, created, updated, removed, crossLayerLinked, crossLayerUnresolved };
 }


### PR DESCRIPTION
## Why

This is the keystone the living architecture graph needs. Today `applySysmlModel` resolves relationship endpoints **intra-model only** (from the current model's in-memory keys), so every Parity Engine projection — MCP tools, coworkers, value streams, routes, code structure, processes — is a self-contained **island**. A `blast_radius` traversal stops at one layer because there are no edges *between* projections.

The operator's goal (2026-06-16) is a graph where impact analysis spans enterprise → systems → **code → operational → network/integration**. That requires edges *across* projections. This PR adds that capability — the foundation every operational/network/integration bridge (`EP-ARCH-GRAPH-LIVE`) builds on.

## What

A small, explicit, **opt-in** addition to the shared SysML applier (`packages/db/src/sysml-model-seed.ts`):

- `SysmlDesiredModel.crossLayerRelationships?: SysmlDesiredRel[]` — edges whose endpoints are resolved **in-model first, then against the live graph by `EaElement.infraCiKey`**. This is how an actual-layer occurrence (a running `RuntimeTarget`, a discovered host, a connected app) will `allocate`/`trace` to the logical part it realizes.
- An unresolved endpoint is **logged and counted** (`SysmlSeedResult.crossLayerUnresolved`), never silently dropped (`make-silent-failures-observable`), and links on a later reconcile once its projection exists — no ordering coupling between projections.
- **Fully back-compatible:** the intra-model `relationships` path is byte-for-byte unchanged; the new fields are optional, so all six existing projections and the steward are unaffected.

## Design intent

This keeps cross-layer linking **explicit** (a separate field, not a fuzzy fallback on every key) so a typo can't accidentally bind to an unrelated element. The per-pair key conventions (which `infraCiKey` an operational instance traces to) are defined in each bridge PR; this PR only provides the safe resolution + observability mechanism.

## Verification

Substrate: **compile-ready worktree** (source-local gates).
- `@dpf/db` typecheck — clean. `web` typecheck — clean (the re-exported `SysmlSeedResult`/`SysmlDesiredModel` changes are additive).
- `applySysmlModel` vitest — **11/11 green** (8 prior + 3 new: link-by-`infraCiKey`, unresolved-not-silent, idempotency).

## Backlog

`EP-ARCH-GRAPH-LIVE` ← `BI-4F7ACE0F`. Unblocks `BI-C51075B0` (operational), `BI-E6815A9D` (network), `BI-FBEE4389` (integration), `BI-4A73ED94` (cross-layer impact). Spec: `docs/superpowers/specs/2026-06-16-living-architecture-graph-and-operational-bridge-design.md` §5–§6 (lands in #2029).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
