### PR TITLE
feat(build-studio): let start_ideate_research/start_build target a specific buildId for batch driving

### DIFF
--- a/apps/web/lib/build/ideate-build-resolution.test.ts
+++ b/apps/web/lib/build/ideate-build-resolution.test.ts
@@ -137,6 +137,59 @@ describe("resolveIdeateBuildForToolPure (BI-F4A30FCB regression)", () => {
     });
   });
 
+  describe("explicit buildId param batch-driving (start_ideate_research/start_build target a chosen build)", () => {
+    it("resolves to the supplied build with NO ambiguity error when multiple builds are in-flight", async () => {
+      // Autonomous-batch scenario: an operator/agent drives a SPECIFIC build's
+      // ideate research while several feature builds are concurrently in ideate.
+      // The handler now forwards an explicit `buildId` param into contextBuildId
+      // (extractBuildIdHint(params) ?? context?.featureBuildId), so the
+      // ambiguous ambient resolution is skipped entirely.
+      const findUniqueBuild = vi.fn().mockResolvedValue({
+        buildId: "FB-TARGET",
+        phase: "ideate",
+      });
+      // Several other builds are simultaneously in ideate — the ambient path
+      // would refuse with the multi-build ambiguity error if it were reached.
+      const findIdeateBuilds = vi.fn().mockResolvedValue([
+        { buildId: "FB-TARGET" },
+        { buildId: "FB-BATCH-2" },
+        { buildId: "FB-BATCH-3" },
+      ]);
+
+      const result = await resolveIdeateBuildForToolPure(
+        { contextBuildId: "FB-TARGET", toolName: "start_ideate_research" },
+        makeDeps({ findUniqueBuild, findIdeateBuilds }),
+      );
+
+      expect(result.build).toEqual({ buildId: "FB-TARGET" });
+      expect(result.refusal).toBeUndefined();
+      // Critical: the ambiguous ambient resolution must be short-circuited.
+      expect(findIdeateBuilds).not.toHaveBeenCalled();
+    });
+
+    it("still raises the ambiguity error for the same multi-build state when NO buildId is supplied (purely additive)", async () => {
+      // Same fleet of in-flight builds, but no explicit buildId — the exact
+      // prior behavior is preserved: refuse rather than mis-target.
+      const findIdeateBuilds = vi.fn().mockResolvedValue([
+        { buildId: "FB-TARGET" },
+        { buildId: "FB-BATCH-2" },
+        { buildId: "FB-BATCH-3" },
+      ]);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await resolveIdeateBuildForToolPure(
+        { toolName: "start_ideate_research" },
+        makeDeps({ findIdeateBuilds }),
+      );
+
+      expect(result.build).toBe(null);
+      expect(result.refusal?.success).toBe(false);
+      expect(result.refusal?.message).toContain("couldn't tell which build");
+
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("cross-contamination scenario (the exact Dale dogfood repro)", () => {
     it("targets the user's build FB-DALE when contextBuildId=FB-DALE, even when FB-OTHER has a newer updatedAt", async () => {
       // Repro: two builds in ideate; FB-OTHER updated more recently. Pre-fix,

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2425,7 +2425,12 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   {
     name: "start_build",
     description: "Initialize the build workspace. Call this ONCE at the start of the build phase. Verifies the sandbox container is running and creates a git branch for this build. If it returns 'not running', call diagnose_sandbox and use the returned recovery actions.",
-    inputSchema: { type: "object", properties: {} },
+    inputSchema: {
+      type: "object",
+      properties: {
+        buildId: { type: "string", description: "Optional FB-* build ID. Omit to target the current active build. Supply it to drive a specific build when several builds are in-flight (e.g. an autonomous batch)." },
+      },
+    },
     requiredCapability: "view_platform",
     executionMode: "immediate",
     sideEffect: false,
@@ -2919,6 +2924,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
       properties: {
         reusabilityScope: { type: "string", enum: ["one_off", "parameterizable", "already_generic"], description: "The user's reusability preference" },
         userContext: { type: "string", description: "Summary of what the user wants, including any answers to clarifying questions" },
+        buildId: { type: "string", description: "Optional FB-* build ID. Omit to target the current active build (the ambient ideate conversation). Supply it to drive a specific build's research when several builds are in-flight (e.g. an autonomous 20-build batch)." },
       },
       required: ["reusabilityScope", "userContext"],
     },
@@ -11806,8 +11812,12 @@ export async function executeTool(
       // ordered by updatedAt" silently mis-targeted whenever multiple
       // builds were in ideate concurrently — the user's request landed on
       // an unrelated build whose updatedAt happened to be newer.
+      // An explicit buildId param wins over the ambient conversation context:
+      // it lets an operator/agent drive a chosen build's research even when
+      // several builds are in-flight (autonomous batch). When omitted, the
+      // exact prior ambient-resolution behavior is preserved.
       const activeBuild = await resolveIdeateBuildForTool({
-        contextBuildId: context?.featureBuildId,
+        contextBuildId: extractBuildIdHint(params) ?? context?.featureBuildId,
         toolName: "start_ideate_research",
       });
       if (!activeBuild.build) {


### PR DESCRIPTION
## What

Add an optional `buildId` (FB-*) parameter to the `start_ideate_research` and `start_build` MCP tools so an operator/agent can drive a **specific** build's phase from the MCP/agent layer when multiple feature builds are in-flight.

## Why

`start_ideate_research` resolved "the current active build" from ambient UI-conversation context. When multiple feature builds are in ideate concurrently, it can't resolve a target and refuses with:

> "I couldn't tell which build you wanted me to research — the system is processing several feature conversations right now. Open the specific feature you want and ask again from inside it."

That blocks driving a chosen build's ideate phase when several builds are in-flight — for example an autonomous batch driving 20 builds. The other phase-driver tools (`reviewDesignDoc`, `reviewBuildPlan`) already accept an optional `buildId`; this brings `start_ideate_research`/`start_build` to parity.

## Change

- **`start_ideate_research`**: expose `buildId` in the input schema and forward it into the resolver as `contextBuildId` (`extractBuildIdHint(params) ?? context?.featureBuildId`). An explicit param wins over the ambient conversation context and skips the ambiguous multi-build resolution. When omitted, behavior is unchanged — ambient resolution plus the existing ambiguity refusal.
- **`start_build`**: already resolved via `resolveActiveBuildId(userId, extractBuildIdHint(params))`, which already honored a `buildId` hint; only the input schema needed to expose `buildId` so callers can supply it. No handler change required.
- **Tests**: extend `ideate-build-resolution.test.ts` — with `buildId` supplied and multiple in-flight builds it resolves to that build with no ambiguity error (ambient resolution short-circuited); without it, the multi-build ambiguous case still errors as before.

Purely additive: ambient-resolution behavior is unchanged when `buildId` is omitted.

## Verification

- `pnpm exec vitest run apps/web/lib/build/ideate-build-resolution.test.ts` → 9 passed (7 prior + 2 new)
- `pnpm -C apps/web exec tsc --noEmit` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
