### PR TITLE
Publish GitHub Releases from tags + accurate cross-platform install docs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,92 @@
+name: Publish GitHub Release
+
+# Promotes each stable version tag (vX.Y.Z) into a published GitHub Release.
+#
+# The maintainer already stamps tags periodically when a build is stable
+# (git describe is the canonical platform version - see version.json and
+# apps/web/lib/platform/version.ts). This workflow turns those tags into
+# official, dated Release entries. Every Release automatically carries the
+# source archives GitHub generates (.zip / .tar.gz), which are downloadable
+# and counted per-asset - so the project finally accrues a real
+# downloads-over-time series instead of relying on uncounted git clones.
+#
+# Docker image publishing is handled separately by publish-image.yml; this
+# workflow is source-distribution only and attaches no custom build assets.
+#
+# Triggers:
+#   - push of a tag matching v*  -> release that tag automatically.
+#   - workflow_dispatch          -> backfill a specific existing tag
+#                                    (defaults to the most recent tag), so a
+#                                    notable pre-existing tag such as v6.4.0
+#                                    can be turned into a Release on demand
+#                                    without re-tagging.
+#
+# Only GitHub built-ins are used (actions/checkout + the preinstalled gh
+# CLI), so no third-party action needs the external-tool evaluation gate.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release (e.g. v6.4.0). Empty = most recent tag."
+        required: false
+        default: ""
+
+# Least-privilege default; the publish job opts up to contents: write.
+permissions:
+  contents: read
+
+concurrency:
+  group: github-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history + tags so git describe / tag verification work.
+          fetch-depth: 0
+
+      - name: Resolve target tag
+        id: resolve
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${GITHUB_REF#refs/tags/}"
+          elif [ -n "${DISPATCH_TAG}" ]; then
+            tag="${DISPATCH_TAG}"
+          else
+            tag="$(git describe --tags --abbrev=0)"
+          fi
+          if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "::error::Tag '${tag}' does not exist in this repository."
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: ${tag}"
+
+      - name: Publish release if it does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists - nothing to do (idempotent)."
+            exit 0
+          fi
+          gh release create "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${TAG}" \
+            --generate-notes \
+            --verify-tag
+          echo "Published GitHub Release ${TAG}."

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ The installer asks one question — **Ready to go** (pre-built images; Build Stu
 
 **AI toolchain readiness.** If you have Claude Code or Codex CLI installed on the host, the installer wires them automatically — DPF skills, MCP tools, and kernel-tier memory all available on the first turn of every new contributor session. Re-running the installer is a no-op when nothing has drifted. See [Install operations](docs/operations/install.md) for the readiness states and what each one means.
 
+**Releases & versions.** Stable versions are published on the [Releases page](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/releases) — each carries a changelog and downloadable source archives (`.zip` / `.tar.gz`). The install scripts above (which track `main`) remain the recommended path; the Releases page is where you see what changed between versions and pin a specific one. Releases are cut automatically from each `vX.Y.Z` tag.
+
 If you hit a wall — happy-path success stories and "the installer hit a wall at step X" failures are equally useful — open an issue using the [Install verification report template](.github/ISSUE_TEMPLATE/install_verification.md) and attach the bundle produced by `bash install-dpf.sh doctor`.
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -392,7 +392,7 @@
       An open, AI-native platform that helps a business run from its own archetype. DPF gives small teams a customer portal, an internal workspace, and purposed AI coworkers that speak the language of the work &mdash; HVAC jobs, clinic appointments, retail stock, nonprofit programs, HOA requests &mdash; while keeping every meaningful action governed end-to-end on your own hardware.
     </p>
     <div class="cta-row">
-      <a class="btn primary" href="#install-on-windows">Install on Windows</a>
+      <a class="btn primary" href="#install">Install</a>
       <a class="btn" href="#what-it-does">See what it does</a>
       <a class="btn" href="#autonomy-wwmd">Autonomy &amp; WWMD</a>
       <a class="btn" href="#audience">Is it for me?</a>
@@ -423,7 +423,7 @@
 <nav class="toc" aria-label="In-page navigation">
   <div class="toc-inner">
     <span class="toc-label">Jump to</span>
-    <a href="#install-on-windows">Install</a>
+    <a href="#install">Install</a>
     <a href="#what-it-does">Capabilities</a>
     <a href="#archetypes">Archetypes</a>
     <a href="#coworkers">Coworkers</a>
@@ -445,25 +445,36 @@
 
 <main class="wrap">
 
-  <section id="install-on-windows">
-    <h2>Install on Windows</h2>
+  <section id="install">
+    <h2>Install</h2>
     <p class="sub">
-      Open PowerShell and paste one of the snippets below. The installer asks a single question &mdash; <strong>Ready to go</strong> (pre-built images and guided portal surfaces) or <strong>Customizable</strong> (full source clone, Build Studio and a local IDE share the same workspace) &mdash; and handles everything else: Docker Desktop, WSL2, hardware detection, AI model selection, credential generation, and auto-start. Use Customizable for serious source edits while Build Studio hardening continues.
+      Windows and macOS are generally available (GA); native Linux and Cloud Single-VM are in early access. Whichever you pick, the installer asks a single question &mdash; <strong>Ready to go</strong> (pre-built images; extend the platform with Build Studio inside the portal) or <strong>Customizable</strong> (full source; Build Studio and your editor work from the same workspace) &mdash; and handles everything else: container runtime, hardware detection, AI model selection, credential generation, and auto-start. Use Customizable for serious source edits while Build Studio hardening continues. Expect 5&ndash;10 minutes for the platform itself, plus additional time for the initial AI model download; login credentials are shown at the end and saved to <code>.admin-credentials</code> in your install directory.
     </p>
     <div class="install">
-      <h3>Recommended: with the GitHub CLI</h3>
-      <pre><code>gh api repos/OpenDigitalProductFactory/opendigitalproductfactory/contents/install-dpf.ps1 -H "Accept: application/vnd.github.raw" &gt; install-dpf.ps1
+      <h3>Windows 10 / 11 &mdash; GA</h3>
+      <p style="color:var(--fg-muted); margin:6px 0 10px; font-size:14px;">The PowerShell installer clones the repo for you. Open PowerShell and paste one snippet.</p>
+      <pre><code># With the GitHub CLI
+gh api repos/OpenDigitalProductFactory/opendigitalproductfactory/contents/install-dpf.ps1 -H "Accept: application/vnd.github.raw" &gt; install-dpf.ps1
 powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
-      <h3 style="margin-top:18px;">Without the GitHub CLI</h3>
-      <pre><code>iwr https://raw.githubusercontent.com/OpenDigitalProductFactory/opendigitalproductfactory/main/install-dpf.ps1 -OutFile install-dpf.ps1
+      <pre><code># Without the GitHub CLI
+iwr https://raw.githubusercontent.com/OpenDigitalProductFactory/opendigitalproductfactory/main/install-dpf.ps1 -OutFile install-dpf.ps1
 powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
+    </div>
+    <div class="install" style="margin-top:18px;">
+      <h3>macOS Apple Silicon &mdash; GA</h3>
+      <p style="color:var(--fg-muted); margin:6px 0 10px; font-size:14px;">Validated end-to-end on real Apple Silicon (M-series, macOS 14+), including the voice STT + native-host TTS path. The Unix installer sources helper libraries from inside the repo, so clone first.</p>
+      <pre><code>git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git
+cd opendigitalproductfactory
+bash install-dpf.sh</code></pre>
       <div class="note">
-        Expect 5&ndash;10 minutes for the platform itself, plus additional time for the initial AI model download. Login credentials are shown at the end of installation and saved to <code>.admin-credentials</code> in your install directory. After installation: <code>dpf-start</code> to start, <code>dpf-stop</code> to stop.
+        See the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/install/macos.md">macOS install guide</a> (including voice setup). After installation: <code>dpf-start</code> to start, <code>dpf-stop</code> to stop.
       </div>
-      <div class="note" style="margin-top:14px;">
-        <strong>macOS Apple Silicon (GA):</strong> validated end-to-end on real Apple Silicon hardware (M-series, macOS 14+), including the voice STT + native-host TTS path &mdash; see the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/install/macos.md">macOS install guide</a>.<br>
-        <strong>Other platforms (early access &mdash; pilots wanted):</strong> the native Linux and Cloud Single-VM (AWS / GCP / Azure, with Terraform modules) installers are code-complete on <code>main</code> with green CI. Real-hardware verification reports are what graduate them from Early Access to GA &mdash; see the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/README.md#quick-start">Quick Start table</a> and the dedicated install runbooks under <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/install">docs/install/</a>.
-      </div>
+    </div>
+    <div class="note" style="margin-top:14px;">
+      <strong>Native Linux &amp; Cloud Single-VM (AWS / GCP / Azure) &mdash; early access, pilots wanted:</strong> both installers (Terraform modules included for the cloud path) are code-complete on <code>main</code> with green CI; real-hardware verification reports are what graduate them from Early Access to GA. See the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/README.md#quick-install">Quick Install table</a> and the per-platform runbooks under <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/install">docs/install/</a>.
+    </div>
+    <div class="note" style="margin-top:14px;">
+      <strong>Releases &amp; versions:</strong> each stable version is published on the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/releases">Releases page</a> with a changelog and downloadable source archives. The installers above remain the recommended path &mdash; Releases are where you see what changed between versions and grab a specific one.
     </div>
   </section>
 


### PR DESCRIPTION
## What

Two related changes that fix the project's distribution & install story:

1. **`.github/workflows/publish-release.yml`** — promotes each stable `vX.Y.Z` tag into a published GitHub **Release**.
2. **`docs/index.html` + `README.md`** — present Windows and macOS as co-equal GA, and link the Releases page.

## Why

- The repo had **0 GitHub Releases**, so it accrued no download metric — distribution is git clone + install scripts + Docker, none of which GitHub retains as a queryable time series. 100+ stable tags already exist (`v0.67.0` → `v6.4.0`). Turning tags into Releases gives an official dated entry per version plus auto-attached source archives (`.zip`/`.tar.gz`) that are **counted per-asset** — i.e. a real downloads-over-time series and a clear "latest release" front door. (npm was considered and rejected: every workspace package is `"private": true`; DPF is a runnable platform, not a library.)
- The marketing site led with an **"Install on Windows"** hero button, nav link, and section, while **macOS — which is equally GA — was buried in a footnote**. That understated cross-platform support. The README already used honest maturity labels; this brings the site up to that standard.

## Release workflow

- **`push` of a `v*` tag** → releases that tag automatically (tagging stays exactly as today, provided the tag is pushed to GitHub).
- **`workflow_dispatch`** → backfills a specific existing tag (defaults to most recent), so `v6.4.0` can be published on demand without re-tagging.
- Idempotent via `gh release view` guard; notes via `--generate-notes`. Only GitHub built-ins (`actions/checkout@v6` + preinstalled `gh`) under least-privilege `contents: read`, publish job opts up to `contents: write`. Docker image publishing remains owned by `publish-image.yml`.

## Docs changes

- `docs/index.html`: hero button + nav + section are now platform-neutral **"Install"**; Windows (GA) and macOS (GA) shown as co-equal blocks with their own snippets; native Linux + Cloud Single-VM presented as early access; in-page mode-prompt copy aligned to the script's actual wording; small **"Releases & versions"** note linking the Releases page.
- `README.md`: adds a **"Releases & versions"** note (install scripts remain the recommended path; Releases for changelog + pinning a version).

## Install-script review (no change)

Reviewed the `install-dpf.sh` mode prompt as requested — it's sound: one plain-language question (`[1] Ready to go` / `[2] Customizable`), sensible default, resume-aware, headless-safe, validated. No change needed; only the site's paraphrase of it was tightened.

## After merge

Future stable tag pushes auto-publish. To get the first downloadable Release immediately (and make the new Releases links non-empty), run the workflow via dispatch against `v6.4.0` — I'll do that right after this lands.

https://claude.ai/code/session_016113Pf7CKx2DRVvQYvfJE2