### PR TITLE
ci: snapshot repo traffic into a permanent downloads-over-time series

### DIFF
--- a/.github/workflows/snapshot-traffic.yml
+++ b/.github/workflows/snapshot-traffic.yml
@@ -1,0 +1,106 @@
+name: Snapshot Repo Traffic
+
+# GitHub keeps clone/view traffic for only a rolling 14-day window and then
+# deletes it - so a repo accrues no permanent downloads-over-time series. This
+# workflow snapshots the Traffic API on a schedule and UPSERTS each day's
+# numbers (deduped by date) into CSVs on a dedicated 'traffic-stats' data
+# branch, building the history GitHub itself discards.
+#
+# Data branch (not main): the series is machine-generated, append-only
+# telemetry - like a gh-pages branch - so it lives on its own branch and is
+# deliberately outside the code-review PR flow. main stays PR-only.
+#
+# TOKEN REQUIREMENT (important): the Traffic API requires *push* access and
+# returns 403 to read-only callers. The built-in GITHUB_TOKEN cannot be
+# granted the 'Administration' access these endpoints want, so in practice a
+# personal access token is required. Create a fine-grained PAT scoped to this
+# repo with "Administration: read" (or a classic token with the 'repo' scope)
+# and save it as the repo secret TRAFFIC_TOKEN:
+#   Settings > Secrets and variables > Actions > New repository secret.
+# The workflow prefers TRAFFIC_TOKEN and falls back to GITHUB_TOKEN; if the
+# API call 403s it FAILS LOUDLY with this guidance instead of recording zeros.
+#
+# Not covered: GHCR (Docker image) pull counts are not part of the Traffic API
+# and are not captured here.
+
+on:
+  schedule:
+    - cron: "23 6 * * *" # daily at 06:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: snapshot-traffic
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    name: Snapshot traffic to data branch
+    runs-on: ubuntu-latest
+    steps:
+      # main checkout provides scripts/metrics/merge-traffic.mjs.
+      - uses: actions/checkout@v6
+
+      - name: Fetch clones + views from the Traffic API
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          fetch() {
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/traffic/$1"
+          }
+          if ! fetch clones > "${RUNNER_TEMP}/clones.json" 2> "${RUNNER_TEMP}/err.txt"; then
+            echo "::error::Traffic API call failed - the token lacks the push / Administration:read access these endpoints require (GitHub returns 403)."
+            echo "::error::Fix: create a fine-grained PAT for this repo with 'Administration: read' (or a classic token with 'repo' scope) and save it as the repo secret TRAFFIC_TOKEN, then re-run this workflow."
+            sed 's/^/  api: /' "${RUNNER_TEMP}/err.txt" || true
+            exit 1
+          fi
+          fetch views > "${RUNNER_TEMP}/views.json"
+          echo "Fetched clones + views snapshots."
+
+      - name: Merge snapshot into the traffic-stats data branch
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          DATA_DIR="${RUNNER_TEMP}/traffic-data"
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git clone --depth 1 --branch traffic-stats "$REMOTE" "$DATA_DIR" 2>/dev/null; then
+            echo "Cloned existing traffic-stats branch."
+          else
+            echo "traffic-stats branch absent - initializing it as an orphan."
+            git clone --depth 1 "$REMOTE" "$DATA_DIR"
+            git -C "$DATA_DIR" checkout --orphan traffic-stats
+            git -C "$DATA_DIR" rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          if [ ! -f "${DATA_DIR}/README.md" ]; then
+            {
+              printf '# Repository traffic snapshots\n\n'
+              printf 'Machine-generated; do not edit by hand. Each row is one day, upserted\n'
+              printf '(deduped by date) from the GitHub Traffic API by\n'
+              printf '`.github/workflows/snapshot-traffic.yml`, because GitHub keeps only the\n'
+              printf 'most recent 14 days.\n\n'
+              printf '- `clones.csv` - daily git clones (`date,count,uniques`)\n'
+              printf '- `views.csv`  - daily page views (`date,count,uniques`)\n'
+            } > "${DATA_DIR}/README.md"
+          fi
+
+          node "${GITHUB_WORKSPACE}/scripts/metrics/merge-traffic.mjs" \
+            "$DATA_DIR" "${RUNNER_TEMP}/clones.json" "${RUNNER_TEMP}/views.json"
+
+          cd "$DATA_DIR"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No new traffic data to commit."
+            exit 0
+          fi
+          git -c user.name="dpf-traffic-bot" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "chore(traffic): snapshot $(date -u +%Y-%m-%d)"
+          git push "$REMOTE" HEAD:traffic-stats
+          echo "Pushed traffic snapshot to traffic-stats."

--- a/scripts/metrics/merge-traffic.mjs
+++ b/scripts/metrics/merge-traffic.mjs
@@ -1,0 +1,58 @@
+// Merge a GitHub Traffic API snapshot into append-only daily CSVs.
+//
+// GitHub keeps clone/view traffic for only a rolling 14-day window, so each
+// API response overlaps the previous one. We therefore UPSERT by date (the
+// latest snapshot wins for any given day) rather than blindly appending, then
+// write the full series back sorted by date. Run by the snapshot-traffic
+// workflow; not intended for manual edits.
+//
+// Usage: node merge-traffic.mjs <dataDir> <clonesJson> <viewsJson>
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Upsert the daily rows from a Traffic API payload into a CSV.
+ * @param {string} csvPath   destination CSV (date,count,uniques)
+ * @param {string} jsonPath  Traffic API response file
+ * @param {string} key       "clones" or "views" - the array field in the payload
+ * @returns {number} total number of distinct days now in the series
+ */
+function mergeSeries(csvPath, jsonPath, key) {
+  const payload = JSON.parse(readFileSync(jsonPath, "utf8"));
+  const incoming = Array.isArray(payload[key]) ? payload[key] : [];
+
+  /** @type {Map<string, {count: number, uniques: number}>} */
+  const byDate = new Map();
+
+  // Seed with whatever history already exists on the data branch.
+  if (existsSync(csvPath)) {
+    const lines = readFileSync(csvPath, "utf8").trim().split("\n");
+    for (const line of lines.slice(1)) {
+      if (!line.trim()) continue;
+      const [date, count, uniques] = line.split(",");
+      byDate.set(date, { count: Number(count), uniques: Number(uniques) });
+    }
+  }
+
+  // Overlay the fresh 14-day window; same-date rows are replaced.
+  for (const row of incoming) {
+    const date = String(row.timestamp).slice(0, 10);
+    byDate.set(date, { count: Number(row.count), uniques: Number(row.uniques) });
+  }
+
+  const sorted = [...byDate.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const out = ["date,count,uniques", ...sorted.map(([d, v]) => `${d},${v.count},${v.uniques}`)];
+  writeFileSync(csvPath, out.join("\n") + "\n");
+  return sorted.length;
+}
+
+const [, , dataDir, clonesJson, viewsJson] = process.argv;
+if (!dataDir || !clonesJson || !viewsJson) {
+  console.error("Usage: node merge-traffic.mjs <dataDir> <clonesJson> <viewsJson>");
+  process.exit(2);
+}
+
+const clones = mergeSeries(join(dataDir, "clones.csv"), clonesJson, "clones");
+const views = mergeSeries(join(dataDir, "views.csv"), viewsJson, "views");
+console.log(`clones.csv: ${clones} day(s); views.csv: ${views} day(s).`);

--- a/scripts/metrics/merge-traffic.mjs
+++ b/scripts/metrics/merge-traffic.mjs
@@ -8,7 +8,7 @@
 //
 // Usage: node merge-traffic.mjs <dataDir> <clonesJson> <viewsJson>
 
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -25,14 +25,19 @@ function mergeSeries(csvPath, jsonPath, key) {
   /** @type {Map<string, {count: number, uniques: number}>} */
   const byDate = new Map();
 
-  // Seed with whatever history already exists on the data branch.
-  if (existsSync(csvPath)) {
-    const lines = readFileSync(csvPath, "utf8").trim().split("\n");
-    for (const line of lines.slice(1)) {
-      if (!line.trim()) continue;
-      const [date, count, uniques] = line.split(",");
-      byDate.set(date, { count: Number(count), uniques: Number(uniques) });
-    }
+  // Seed with whatever history already exists on the data branch. Read
+  // directly and treat a missing file as empty history - avoids the
+  // exists()-then-read() time-of-check/time-of-use race (CodeQL js/file-system-race).
+  let existing = "";
+  try {
+    existing = readFileSync(csvPath, "utf8");
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+  for (const line of existing.trim().split("\n").slice(1)) {
+    if (!line.trim()) continue;
+    const [date, count, uniques] = line.split(",");
+    byDate.set(date, { count: Number(count), uniques: Number(uniques) });
   }
 
   // Overlay the fresh 14-day window; same-date rows are replaced.


### PR DESCRIPTION
## What

Adds a scheduled workflow (`.github/workflows/snapshot-traffic.yml`) + a small merge script (`scripts/metrics/merge-traffic.mjs`) that captures the repo's clone/view traffic into a **permanent, dedup'd daily series**.

## Why

GitHub keeps clone/view traffic for only a **rolling 14-day window** and then deletes it — which is why an earlier ~8,000-clone spike is already gone and the project has no downloads-over-time history. This stops the leak going forward: each run snapshots the Traffic API and **upserts each day's numbers (deduped by date)** so the window accumulates into a permanent record instead of being discarded.

## How it works

- Runs daily (`cron`) + `workflow_dispatch`.
- Fetches `traffic/clones` and `traffic/views` via the preinstalled `gh` CLI.
- `merge-traffic.mjs` upserts the 14-day window into CSVs **by date** (latest snapshot wins per day), sorted — no double counting from overlapping windows.
- Writes to a dedicated **`traffic-stats` data branch** (created as an orphan on first run), not `main`. The series is machine-generated, append-only telemetry — like a `gh-pages` branch — so it's deliberately outside the code-review PR flow and keeps `main` PR-only.
- Files produced: `clones.csv`, `views.csv` (`date,count,uniques`) + a generated `README.md`.

## ⚠️ One setup step required (token)

The Traffic API requires **push access** and returns `403` to read-only callers; the built-in `GITHUB_TOKEN` **cannot** be granted the `Administration` access these endpoints want, so a personal access token is required:

1. Create a **fine-grained PAT** scoped to this repo with **`Administration: read`** (or a classic token with the `repo` scope).
2. Save it as the repo secret **`TRAFFIC_TOKEN`** (Settings → Secrets and variables → Actions → New repository secret).

The workflow prefers `TRAFFIC_TOKEN`, falls back to `GITHUB_TOKEN`, and **fails loudly with these exact instructions** if the call 403s — it will never silently record zeros.

> Not covered: GHCR (Docker image) pull counts aren't part of the Traffic API and aren't captured here.

## Note on scope

The release-publishing workflow + install-docs fixes landed separately in #2038 (merged). This PR is the distinct traffic-capture piece, on the same working branch.

https://claude.ai/code/session_016113Pf7CKx2DRVvQYvfJE2

---
_Generated by [Claude Code](https://claude.ai/code/session_016113Pf7CKx2DRVvQYvfJE2)_