### PR TITLE
feat(mobile): resolve employee persona and emit landing tab from the install manifest

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -2,7 +2,7 @@ import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@/src/lib/theme";
 import { useAppConfigStore } from "@/src/lib/appConfig";
-import { resolveVisibleTabs } from "@/src/lib/navigation";
+import { resolveDefaultTab, resolveVisibleTabs } from "@/src/lib/navigation";
 
 export default function TabsLayout() {
   const { colors } = useTheme();
@@ -12,19 +12,24 @@ export default function TabsLayout() {
 
   // Which tabs the connected install exposes for this persona. With no manifest
   // loaded this returns the full operator set, so the default app is unchanged.
-  const visible = new Set(
-    resolveVisibleTabs({
-      persona,
-      capabilities,
-      manifestTabs: navigation?.tabs,
-    }),
-  );
+  const visibleTabs = resolveVisibleTabs({
+    persona,
+    capabilities,
+    manifestTabs: navigation?.tabs,
+  });
+  const visible = new Set(visibleTabs);
   // `href: null` hides a tab from the bar; `undefined` leaves it visible.
   const hiddenHref = (name: string): null | undefined =>
     visible.has(name) ? undefined : null;
+  // Landing tab: a field tech lands on Jobs, customer/operator land on Home.
+  const initialRouteName = resolveDefaultTab({
+    manifestDefault: navigation?.defaultTab,
+    visibleTabs,
+  });
 
   return (
     <Tabs
+      initialRouteName={initialRouteName}
       screenOptions={{
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.textMuted,

--- a/apps/mobile/src/lib/navigation.test.ts
+++ b/apps/mobile/src/lib/navigation.test.ts
@@ -1,4 +1,4 @@
-import { resolveVisibleTabs, type TabSpec } from "./navigation";
+import { resolveDefaultTab, resolveVisibleTabs, type TabSpec } from "./navigation";
 
 describe("resolveVisibleTabs", () => {
   it("defaults to the full operator tab set when nothing is loaded", () => {
@@ -81,5 +81,35 @@ describe("resolveVisibleTabs", () => {
         capabilities: ["work-items"],
       }),
     ).toEqual(["index", "ops", "jobs", "customers", "more"]);
+  });
+});
+
+describe("resolveDefaultTab", () => {
+  it("honors the manifest default when it's a visible tab", () => {
+    expect(
+      resolveDefaultTab({
+        manifestDefault: "jobs",
+        visibleTabs: ["index", "ops", "jobs", "customers", "more"],
+      }),
+    ).toBe("jobs");
+  });
+
+  it("falls back to the first visible tab when the manifest default is hidden", () => {
+    expect(
+      resolveDefaultTab({
+        manifestDefault: "jobs",
+        visibleTabs: ["index", "customers", "more"],
+      }),
+    ).toBe("index");
+  });
+
+  it("falls back to the first visible tab when the manifest gave no default", () => {
+    expect(resolveDefaultTab({ visibleTabs: ["customers", "more"] })).toBe(
+      "customers",
+    );
+  });
+
+  it("ultimate fallback to 'index' when nothing is visible", () => {
+    expect(resolveDefaultTab({ visibleTabs: [] })).toBe("index");
   });
 });

--- a/apps/mobile/src/lib/navigation.ts
+++ b/apps/mobile/src/lib/navigation.ts
@@ -66,3 +66,26 @@ export function resolveVisibleTabs(input: ResolveTabsInput): string[] {
     .filter(capAllowed)
     .map((t) => t.key);
 }
+
+const FALLBACK_DEFAULT_TAB = "index";
+
+export interface ResolveDefaultTabInput {
+  /** Server-emitted landing tab (manifest.navigation.defaultTab). */
+  manifestDefault?: string;
+  /** The visible tab set this persona/install can actually mount. */
+  visibleTabs: string[];
+}
+
+/**
+ * Pick the tab the app opens on after login. Honors the install's preference
+ * (`manifest.navigation.defaultTab`) as long as it's actually mountable for
+ * this persona; otherwise falls back to the first visible tab so the app
+ * never opens onto a hidden route.
+ */
+export function resolveDefaultTab(input: ResolveDefaultTabInput): string {
+  const { manifestDefault, visibleTabs } = input;
+  if (manifestDefault && visibleTabs.includes(manifestDefault)) {
+    return manifestDefault;
+  }
+  return visibleTabs[0] ?? FALLBACK_DEFAULT_TAB;
+}

--- a/apps/web/app/api/v1/app/config/route.ts
+++ b/apps/web/app/api/v1/app/config/route.ts
@@ -15,14 +15,16 @@ import { getCompositeActivationProfile } from "@/lib/storefront/archetype-activa
 import {
   buildAppConfigManifest,
   activationToCapabilities,
+  resolveAppPersona,
+  resolveAppNavigation,
 } from "@/lib/mobile/manifest";
-import type { AppPersona, AppConfigManifest } from "@dpf/types";
+import type { AppConfigManifest } from "@dpf/types";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
-    const { user } = await authenticateRequest(request);
+    const { user, authContext } = await authenticateRequest(request);
 
     const org = await prisma.organization.findFirst({ select: { name: true } });
     if (!org) {
@@ -48,10 +50,12 @@ export async function GET(request: Request) {
         : null,
     );
 
-    // v1 persona: customers get the customer surface; workforce gets operator.
-    // Richer employee/field resolution lands with the use-case work (P4/P5).
-    const persona: AppPersona =
-      user.type === "customer" ? { kind: "customer" } : { kind: "operator" };
+    const persona = resolveAppPersona({
+      userType: user.type,
+      employeeId: authContext.employeeId,
+      capabilities,
+    });
+    const navigation = resolveAppNavigation({ persona, capabilities });
 
     const manifest = buildAppConfigManifest({
       orgName: org.name,
@@ -59,6 +63,7 @@ export async function GET(request: Request) {
       persona,
       brandingTokensRaw: branding?.tokens ?? null,
       capabilities,
+      navigation,
     });
 
     return apiSuccess<AppConfigManifest>(manifest);

--- a/apps/web/lib/mobile/manifest.test.ts
+++ b/apps/web/lib/mobile/manifest.test.ts
@@ -4,6 +4,8 @@ import {
   activationToCapabilities,
   buildInstanceDescriptor,
   buildAppConfigManifest,
+  resolveAppPersona,
+  resolveAppNavigation,
 } from "./manifest";
 
 describe("normalizeBrandingTokens", () => {
@@ -118,5 +120,91 @@ describe("buildAppConfigManifest", () => {
     });
     expect(m.designTokens).toBeUndefined();
     expect(m.org.archetype).toBeUndefined();
+  });
+
+  it("emits the navigation block when provided", () => {
+    const m = buildAppConfigManifest({
+      orgName: "Acme HVAC",
+      persona: { kind: "employee", mode: "field" },
+      capabilities: ["field-dispatch", "work-items"],
+      navigation: { tabs: [], defaultTab: "jobs" },
+    });
+    expect(m.navigation).toEqual({ tabs: [], defaultTab: "jobs" });
+  });
+
+  it("omits navigation when not provided", () => {
+    const m = buildAppConfigManifest({
+      orgName: "Acme",
+      persona: { kind: "operator" },
+      capabilities: ["notifications"],
+    });
+    expect(m.navigation).toBeUndefined();
+  });
+});
+
+describe("resolveAppPersona", () => {
+  it("returns customer for a customer principal", () => {
+    expect(
+      resolveAppPersona({ userType: "customer", employeeId: null, capabilities: [] }),
+    ).toEqual({ kind: "customer" });
+  });
+
+  it("returns employee:field when the workforce user has an employee profile and the install has field-dispatch", () => {
+    expect(
+      resolveAppPersona({
+        userType: "admin",
+        employeeId: "emp_1",
+        capabilities: ["field-dispatch", "work-items"],
+      }),
+    ).toEqual({ kind: "employee", mode: "field" });
+  });
+
+  it("returns plain employee for a workforce user with an employee profile but no field-dispatch", () => {
+    expect(
+      resolveAppPersona({
+        userType: "admin",
+        employeeId: "emp_1",
+        capabilities: ["notifications"],
+      }),
+    ).toEqual({ kind: "employee" });
+  });
+
+  it("returns operator for a workforce user with no employee profile (platform operator)", () => {
+    expect(
+      resolveAppPersona({
+        userType: "admin",
+        employeeId: null,
+        capabilities: ["notifications"],
+      }),
+    ).toEqual({ kind: "operator" });
+  });
+});
+
+describe("resolveAppNavigation", () => {
+  it("lands a field employee on Jobs", () => {
+    expect(
+      resolveAppNavigation({
+        persona: { kind: "employee", mode: "field" },
+        capabilities: ["field-dispatch", "work-items"],
+      }),
+    ).toEqual({ tabs: [], defaultTab: "jobs" });
+  });
+
+  it("falls back to Home for operator / admin / non-field employee", () => {
+    for (const persona of [
+      { kind: "operator" as const },
+      { kind: "admin" as const },
+      { kind: "employee" as const },
+    ]) {
+      expect(
+        resolveAppNavigation({ persona, capabilities: ["notifications"] }),
+      ).toEqual({ tabs: [], defaultTab: "index" });
+    }
+  });
+
+  it("lands a customer on Home (customer surface lights up post-P5)", () => {
+    expect(
+      resolveAppNavigation({ persona: { kind: "customer" }, capabilities: [] }),
+    ).toEqual({ tabs: [], defaultTab: "index" });
   });
 });

--- a/apps/web/lib/mobile/manifest.ts
+++ b/apps/web/lib/mobile/manifest.ts
@@ -12,6 +12,7 @@
  */
 import type {
   AppConfigManifest,
+  AppNavigation,
   AppPersona,
   BrandingPalette,
   BrandingThemeTokens,
@@ -153,6 +154,7 @@ export function buildAppConfigManifest(input: {
   brandingTokensRaw?: unknown;
   capabilities: string[];
   vocabulary?: Record<string, string>;
+  navigation?: AppNavigation;
 }): AppConfigManifest {
   const manifest: AppConfigManifest = {
     schemaVersion: "1",
@@ -168,5 +170,57 @@ export function buildAppConfigManifest(input: {
   if (input.vocabulary && Object.keys(input.vocabulary).length > 0) {
     manifest.vocabulary = input.vocabulary;
   }
+  if (input.navigation) manifest.navigation = input.navigation;
   return manifest;
+}
+
+/**
+ * Persona resolver — the install side of "who am I, mobile?". Today the auth
+ * layer distinguishes only `customer` from workforce (`admin`); within the
+ * workforce we tell a real employee apart from a platform operator by whether
+ * an `EmployeeProfile` is linked, and within employees we promote the persona
+ * to field-tech `mode: "field"` when the install carries the `field-dispatch`
+ * capability (the same axis-derived signal the manifest already projects).
+ *
+ * Lives next to the manifest builders so the wire shape and the resolution
+ * rules stay co-located.
+ */
+export interface ResolvePersonaInput {
+  userType: "admin" | "customer";
+  employeeId: string | null;
+  capabilities: string[];
+}
+
+export function resolveAppPersona(input: ResolvePersonaInput): AppPersona {
+  if (input.userType === "customer") return { kind: "customer" };
+  if (input.employeeId) {
+    if (input.capabilities.includes("field-dispatch")) {
+      return { kind: "employee", mode: "field" };
+    }
+    return { kind: "employee" };
+  }
+  return { kind: "operator" };
+}
+
+/**
+ * Navigation resolver — which tab the app opens on after login. The mobile
+ * shell already resolves the visible tab *set* from persona × capabilities
+ * (apps/mobile/src/lib/navigation.ts); this picks the *landing* tab so a field
+ * tech opens on Jobs instead of the operator Home. We leave `tabs` empty so
+ * the client keeps owning the order until per-archetype overrides land.
+ */
+export interface ResolveNavigationInput {
+  persona: AppPersona;
+  capabilities: string[];
+}
+
+export function resolveAppNavigation(input: ResolveNavigationInput): AppNavigation {
+  if (
+    input.persona.kind === "employee" &&
+    input.persona.mode === "field" &&
+    input.capabilities.includes("work-items")
+  ) {
+    return { tabs: [], defaultTab: "jobs" };
+  }
+  return { tabs: [], defaultTab: "index" };
 }


### PR DESCRIPTION
## Summary

Server-side persona resolution + navigation projection on `/api/v1/app/config` so a workforce user with an `EmployeeProfile` connected to a field-dispatch install authenticates as `{ kind: "employee", mode: "field" }` instead of collapsing to `operator`, and the generic mobile shell lands them on the **Jobs** tab on launch.

Foundation slice for the native-mobile-archetype-apps roadmap (P3 keystone): keeps the binary generic and the install in the driver's seat for both design **and** persona-driven nav. Field/customer use-cases (P4/P5) compose on this.

Spec: [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html) (§3 keystone, §7 personas, §11 roadmap).

## Mechanics

- `apps/web/lib/mobile/manifest.ts`:
  - `resolveAppPersona({userType, employeeId, capabilities})` → `customer` | `employee:field` | `employee` | `operator`.
  - `resolveAppNavigation({persona, capabilities})` → `{ tabs: [], defaultTab }` (`"jobs"` for field-tech, `"index"` otherwise).
  - `buildAppConfigManifest` now accepts + emits `navigation`.
- `apps/web/app/api/v1/app/config/route.ts`: wires both resolvers via the `authContext.employeeId` already produced by `buildEffectiveAuthContext`.
- `apps/mobile/src/lib/navigation.ts`: `resolveDefaultTab()` honors `manifest.navigation.defaultTab` only when it's in the visible set, so the app never lands on a hidden route.
- `apps/mobile/app/(tabs)/_layout.tsx`: passes the resolved tab as `<Tabs initialRouteName>`.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/mobile/` — 21/21 passing (4 new persona + nav cases).
- [x] `pnpm --filter mobile exec jest src/lib/navigation.test.ts` — 11/11 passing (4 new `resolveDefaultTab` cases).
- [x] `pnpm --filter mobile typecheck` — clean.
- [x] `pnpm --filter web typecheck` — clean.
- [ ] Functional gate (P4 onward, per spec §15): drive *connect → manifest → mode* on the live install via `dpf-verify-on-live-install` once field-tech screens land.

## What's next (roadmap)

This slice unlocks — but does not yet implement — the field-tech and customer surfaces from the spec. Subsequent right-sized PRs:

1. **Field-tech (P4):** Jobs board → on-my-way → check-in → work capture (photo, signature, line items) → draft invoice → payment collection. The HVAC scenario the goal called out.
2. **Customer (P5):** book / my-visits / pay / messages / service requests.
3. **Multi-business "Town" super-app (M1–M5):** spaces switcher, shared device layer, `Nearby` directory — separate spec [`2026-06-14-multi-business-town-super-app-design.html`](docs/superpowers/specs/2026-06-14-multi-business-town-super-app-design.html).
4. **P7 store release:** EAS production profiles + TestFlight/Play submit under Arcamanus LLC (owner-only actions per spec §9).