### PR TITLE
feat(mobile): field-tech complete job → draft invoice → collect payment

### DIFF
--- a/apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx
+++ b/apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx
@@ -7,9 +7,10 @@ import {
   Pressable,
   ActivityIndicator,
 } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTheme } from "@/src/lib/theme";
 import { useJobsStore } from "@/src/features/jobs/jobs.store";
+import { useInvoicesStore } from "@/src/features/invoices/invoices.store";
 import type { WorkItemStatus } from "@dpf/types";
 
 // Field check-in/out actions available from each status (server enforces too).
@@ -31,8 +32,10 @@ export default function JobDetailScreen() {
   const { colors } = theme;
   const styles = useMemo(() => makeStyles(theme), [theme.colors]);
   const { itemId } = useLocalSearchParams<{ itemId: string }>();
+  const router = useRouter();
   const { detail, isLoading, isUpdating, error, fetchDetail, updateStatus } =
     useJobsStore();
+  const beginInvoiceDraft = useInvoicesStore((s) => s.beginDraft);
 
   useEffect(() => {
     if (itemId) fetchDetail(itemId);
@@ -59,6 +62,17 @@ export default function JobDetailScreen() {
 
   const actions = ACTIONS[detail.status] ?? [];
 
+  // Once a job is completed, the field tech bills the customer. Seed the
+  // draft with the job title as a single line so the tech only has to set
+  // the price; the invoice screen lets them refine before submit.
+  const goToInvoice = (): void => {
+    beginInvoiceDraft({
+      workItemId: detail.itemId,
+      seedLines: [{ description: detail.title, quantity: 1, unitPrice: 0 }],
+    });
+    router.push(`/jobs/${encodeURIComponent(detail.itemId)}/invoice`);
+  };
+
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
       <Text style={styles.title}>{detail.title}</Text>
@@ -75,22 +89,31 @@ export default function JobDetailScreen() {
       {error ? <Text style={styles.error}>{error}</Text> : null}
 
       <View style={styles.actions}>
-        {actions.length === 0 ? (
+        {actions.length === 0 && detail.status !== "completed" ? (
           <Text style={styles.meta}>No further actions.</Text>
-        ) : (
-          actions.map((a) => (
-            <Pressable
-              key={a.to}
-              style={[styles.button, isUpdating && styles.buttonDisabled]}
-              disabled={isUpdating}
-              onPress={() => updateStatus(detail.itemId, a.to)}
-              accessibilityRole="button"
-              testID={`action-${a.to}`}
-            >
-              <Text style={styles.buttonText}>{a.label}</Text>
-            </Pressable>
-          ))
-        )}
+        ) : null}
+        {actions.map((a) => (
+          <Pressable
+            key={a.to}
+            style={[styles.button, isUpdating && styles.buttonDisabled]}
+            disabled={isUpdating}
+            onPress={() => updateStatus(detail.itemId, a.to)}
+            accessibilityRole="button"
+            testID={`action-${a.to}`}
+          >
+            <Text style={styles.buttonText}>{a.label}</Text>
+          </Pressable>
+        ))}
+        {detail.status === "completed" ? (
+          <Pressable
+            style={styles.button}
+            onPress={goToInvoice}
+            accessibilityRole="button"
+            testID="action-draft-invoice"
+          >
+            <Text style={styles.buttonText}>Draft invoice</Text>
+          </Pressable>
+        ) : null}
       </View>
     </ScrollView>
   );

--- a/apps/mobile/app/(tabs)/jobs/[itemId]/invoice.tsx
+++ b/apps/mobile/app/(tabs)/jobs/[itemId]/invoice.tsx
@@ -1,0 +1,278 @@
+/**
+ * Field-tech "Draft invoice" screen.
+ *
+ * After completing a job the tech bills the customer here: edit line items
+ * (qty + unit price + optional tax/discount), enter the customer account id,
+ * and submit. On success we navigate to the payment screen with the just-
+ * created invoice id, so the tech can collect cash/cheque/etc on site.
+ *
+ * Substrate: POST /api/v1/finance/invoices (existing) via the shared
+ * @dpf/api-client, mirroring the createInvoiceSchema in finance-validation.ts.
+ * Server is authoritative for totals; the local total is a running figure
+ * for the tech only.
+ */
+import React, { useMemo } from "react";
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  Pressable,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import { useInvoicesStore } from "@/src/features/invoices/invoices.store";
+
+export default function DraftInvoiceScreen() {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const router = useRouter();
+  const { itemId } = useLocalSearchParams<{ itemId: string }>();
+
+  const {
+    accountId,
+    dueDate,
+    notes,
+    lineItems,
+    isSubmitting,
+    error,
+    setAccountId,
+    setDueDate,
+    setNotes,
+    addLineItem,
+    updateLineItem,
+    removeLineItem,
+    draftTotal,
+    createInvoice,
+  } = useInvoicesStore();
+
+  const total = draftTotal();
+
+  const onCreate = async (): Promise<void> => {
+    const invoice = await createInvoice();
+    if (invoice) {
+      router.replace(
+        `/jobs/${encodeURIComponent(itemId)}/payment?invoiceId=${encodeURIComponent(
+          invoice.id,
+        )}`,
+      );
+    }
+  };
+
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={styles.h1}>New invoice</Text>
+
+      <Text style={styles.label}>Customer account id</Text>
+      <TextInput
+        value={accountId}
+        onChangeText={setAccountId}
+        style={styles.input}
+        placeholder="ACC-…"
+        placeholderTextColor={theme.colors.textMuted}
+        autoCapitalize="characters"
+        testID="invoice-accountId"
+      />
+
+      <Text style={styles.label}>Due date (YYYY-MM-DD)</Text>
+      <TextInput
+        value={dueDate}
+        onChangeText={setDueDate}
+        style={styles.input}
+        placeholder="2026-07-16"
+        placeholderTextColor={theme.colors.textMuted}
+        keyboardType="numbers-and-punctuation"
+        testID="invoice-dueDate"
+      />
+
+      <Text style={[styles.h2, { marginTop: theme.spacing.lg }]}>Line items</Text>
+      {lineItems.map((li, idx) => (
+        <View key={li.key} style={styles.lineRow} testID={`line-${idx}`}>
+          <TextInput
+            value={li.description}
+            onChangeText={(v) => updateLineItem(li.key, { description: v })}
+            placeholder="Service / part / labor"
+            placeholderTextColor={theme.colors.textMuted}
+            style={[styles.input, styles.lineDesc]}
+            testID={`line-${idx}-description`}
+          />
+          <View style={styles.lineNumRow}>
+            <View style={styles.numCol}>
+              <Text style={styles.smallLabel}>Qty</Text>
+              <TextInput
+                value={String(li.quantity)}
+                onChangeText={(v) =>
+                  updateLineItem(li.key, { quantity: parseFloat(v) || 0 })
+                }
+                style={styles.input}
+                keyboardType="decimal-pad"
+                testID={`line-${idx}-quantity`}
+              />
+            </View>
+            <View style={styles.numCol}>
+              <Text style={styles.smallLabel}>Unit price</Text>
+              <TextInput
+                value={String(li.unitPrice)}
+                onChangeText={(v) =>
+                  updateLineItem(li.key, { unitPrice: parseFloat(v) || 0 })
+                }
+                style={styles.input}
+                keyboardType="decimal-pad"
+                testID={`line-${idx}-unitPrice`}
+              />
+            </View>
+            <View style={styles.numCol}>
+              <Text style={styles.smallLabel}>Tax %</Text>
+              <TextInput
+                value={li.taxRate != null ? String(li.taxRate) : ""}
+                onChangeText={(v) =>
+                  updateLineItem(li.key, {
+                    taxRate: v.length === 0 ? undefined : parseFloat(v) || 0,
+                  })
+                }
+                style={styles.input}
+                keyboardType="decimal-pad"
+                testID={`line-${idx}-taxRate`}
+              />
+            </View>
+          </View>
+          {lineItems.length > 1 ? (
+            <Pressable
+              onPress={() => removeLineItem(li.key)}
+              accessibilityRole="button"
+              testID={`line-${idx}-remove`}
+            >
+              <Text style={styles.removeText}>Remove</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ))}
+
+      <Pressable
+        style={styles.secondary}
+        onPress={() => addLineItem()}
+        accessibilityRole="button"
+        testID="invoice-add-line"
+      >
+        <Text style={styles.secondaryText}>+ Add line</Text>
+      </Pressable>
+
+      <Text style={styles.label}>Notes (optional)</Text>
+      <TextInput
+        value={notes}
+        onChangeText={setNotes}
+        style={[styles.input, styles.multiline]}
+        multiline
+        placeholder="Anything the customer should see on the invoice"
+        placeholderTextColor={theme.colors.textMuted}
+        testID="invoice-notes"
+      />
+
+      <View style={styles.totalRow}>
+        <Text style={styles.totalLabel}>Estimated total</Text>
+        <Text style={styles.totalValue} testID="invoice-total">
+          {total.toFixed(2)}
+        </Text>
+      </View>
+
+      {error ? (
+        <Text style={styles.error} testID="invoice-error">
+          {error}
+        </Text>
+      ) : null}
+
+      <Pressable
+        style={[styles.primary, isSubmitting && styles.disabled]}
+        disabled={isSubmitting}
+        onPress={onCreate}
+        accessibilityRole="button"
+        testID="invoice-submit"
+      >
+        <Text style={styles.primaryText}>
+          {isSubmitting ? "Creating…" : "Create invoice"}
+        </Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: colors.surface1 },
+    content: { padding: spacing.md, paddingBottom: spacing.xl, gap: spacing.xs },
+    h1: { color: colors.text, fontSize: 22, fontWeight: "700", marginBottom: spacing.md },
+    h2: { color: colors.text, fontSize: 16, fontWeight: "600", marginBottom: spacing.xs },
+    label: {
+      color: colors.textMuted,
+      fontSize: 12,
+      textTransform: "uppercase",
+      marginTop: spacing.md,
+      marginBottom: spacing.xs,
+    },
+    smallLabel: { color: colors.textMuted, fontSize: 11, marginBottom: 2 },
+    input: {
+      backgroundColor: colors.surface2,
+      color: colors.text,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      paddingHorizontal: spacing.sm + 2,
+      paddingVertical: spacing.sm,
+      fontSize: 15,
+    },
+    multiline: { minHeight: 70, textAlignVertical: "top" },
+    lineRow: {
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.sm,
+      marginBottom: spacing.sm,
+      gap: spacing.xs,
+    },
+    lineDesc: { backgroundColor: colors.surface1 },
+    lineNumRow: { flexDirection: "row", gap: spacing.xs },
+    numCol: { flex: 1 },
+    removeText: {
+      color: colors.error,
+      fontSize: 13,
+      textAlign: "right",
+      marginTop: spacing.xs,
+    },
+    secondary: {
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      paddingVertical: spacing.sm,
+      alignItems: "center",
+      marginTop: spacing.xs,
+    },
+    secondaryText: { color: colors.text, fontSize: 14, fontWeight: "600" },
+    totalRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginTop: spacing.lg,
+      paddingTop: spacing.sm,
+      borderTopColor: colors.border,
+      borderTopWidth: 1,
+    },
+    totalLabel: { color: colors.textMuted, fontSize: 13, textTransform: "uppercase" },
+    totalValue: { color: colors.text, fontSize: 20, fontWeight: "700" },
+    error: { color: colors.error, marginTop: spacing.sm, fontSize: 13 },
+    primary: {
+      marginTop: spacing.lg,
+      backgroundColor: colors.primary,
+      borderRadius: borderRadius.md,
+      paddingVertical: spacing.sm + 4,
+      alignItems: "center",
+    },
+    disabled: { opacity: 0.5 },
+    primaryText: { color: colors.white, fontSize: 16, fontWeight: "600" },
+  });
+}

--- a/apps/mobile/app/(tabs)/jobs/[itemId]/payment.tsx
+++ b/apps/mobile/app/(tabs)/jobs/[itemId]/payment.tsx
@@ -1,0 +1,232 @@
+/**
+ * Field-tech "Collect payment" screen.
+ *
+ * Opens after the invoice screen creates an invoice; the tech picks the
+ * payment method (cash, cheque, card, bank transfer) and records what was
+ * actually taken on site. Cash is the common HVAC-on-site case; card/Stripe
+ * integration is owner-action P0 (Apple merchant + processor) per the spec.
+ *
+ * Substrate: POST /api/v1/finance/payments (existing) with
+ * `direction: "inbound"` and `invoiceId` so the server allocates it
+ * against the freshly-created invoice automatically.
+ */
+import React, { useMemo, useState } from "react";
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  Pressable,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import { useInvoicesStore } from "@/src/features/invoices/invoices.store";
+import type { PaymentMethod } from "@dpf/types";
+
+const METHODS: { key: PaymentMethod; label: string }[] = [
+  { key: "cash", label: "Cash" },
+  { key: "cheque", label: "Cheque" },
+  { key: "card", label: "Card (manual)" },
+  { key: "bank_transfer", label: "Bank transfer" },
+];
+
+export default function RecordPaymentScreen() {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const router = useRouter();
+  const { invoice, payment, isSubmitting, error, recordPayment } =
+    useInvoicesStore();
+
+  // Defaults: full balance on the invoice + cash (the field tech's common case).
+  const owed = invoice ? invoice.amountDue || invoice.totalAmount : 0;
+  const [amount, setAmount] = useState<string>(owed.toFixed(2));
+  const [method, setMethod] = useState<PaymentMethod>("cash");
+  const [reference, setReference] = useState<string>("");
+  const [paymentNotes, setPaymentNotes] = useState<string>("");
+
+  const onRecord = async (): Promise<void> => {
+    const amt = parseFloat(amount);
+    if (!isFinite(amt) || amt <= 0) return;
+    const result = await recordPayment({
+      method,
+      amount: amt,
+      reference: reference.trim() || undefined,
+      notes: paymentNotes.trim() || undefined,
+    });
+    if (result) {
+      router.replace("/jobs");
+    }
+  };
+
+  if (!invoice) {
+    return (
+      <View style={styles.screen}>
+        <Text style={styles.error}>
+          No invoice in this session — create one first.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={styles.h1}>Collect payment</Text>
+
+      <View style={styles.invoiceCard}>
+        <Text style={styles.invoiceRef}>{invoice.invoiceRef}</Text>
+        <Text style={styles.invoiceMeta}>
+          {invoice.currency} · Total {invoice.totalAmount.toFixed(2)} · Due{" "}
+          {invoice.amountDue.toFixed(2)}
+        </Text>
+        {invoice.account?.name ? (
+          <Text style={styles.invoiceMeta}>For {invoice.account.name}</Text>
+        ) : null}
+      </View>
+
+      {payment ? (
+        <Text style={styles.success} testID="payment-success">
+          Recorded {payment.amount.toFixed(2)} via {payment.method}.
+        </Text>
+      ) : null}
+
+      <Text style={styles.label}>Method</Text>
+      <View style={styles.methodRow}>
+        {METHODS.map((m) => {
+          const selected = m.key === method;
+          return (
+            <Pressable
+              key={m.key}
+              onPress={() => setMethod(m.key)}
+              style={[styles.methodChip, selected && styles.methodChipSelected]}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              testID={`payment-method-${m.key}`}
+            >
+              <Text
+                style={[
+                  styles.methodChipText,
+                  selected && styles.methodChipTextSelected,
+                ]}
+              >
+                {m.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <Text style={styles.label}>Amount ({invoice.currency})</Text>
+      <TextInput
+        value={amount}
+        onChangeText={setAmount}
+        style={styles.input}
+        keyboardType="decimal-pad"
+        testID="payment-amount"
+      />
+
+      <Text style={styles.label}>Reference (optional)</Text>
+      <TextInput
+        value={reference}
+        onChangeText={setReference}
+        style={styles.input}
+        placeholder="cheque #, card last-4, etc"
+        placeholderTextColor={theme.colors.textMuted}
+        testID="payment-reference"
+      />
+
+      <Text style={styles.label}>Notes (optional)</Text>
+      <TextInput
+        value={paymentNotes}
+        onChangeText={setPaymentNotes}
+        style={[styles.input, styles.multiline]}
+        multiline
+        testID="payment-notes"
+      />
+
+      {error ? (
+        <Text style={styles.error} testID="payment-error">
+          {error}
+        </Text>
+      ) : null}
+
+      <Pressable
+        style={[styles.primary, isSubmitting && styles.disabled]}
+        disabled={isSubmitting}
+        onPress={onRecord}
+        accessibilityRole="button"
+        testID="payment-submit"
+      >
+        <Text style={styles.primaryText}>
+          {isSubmitting ? "Recording…" : "Record payment"}
+        </Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: colors.surface1 },
+    content: { padding: spacing.md, paddingBottom: spacing.xl },
+    h1: { color: colors.text, fontSize: 22, fontWeight: "700", marginBottom: spacing.md },
+    invoiceCard: {
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      gap: spacing.xs,
+    },
+    invoiceRef: { color: colors.text, fontSize: 16, fontWeight: "700" },
+    invoiceMeta: { color: colors.textMuted, fontSize: 13 },
+    label: {
+      color: colors.textMuted,
+      fontSize: 12,
+      textTransform: "uppercase",
+      marginTop: spacing.lg,
+      marginBottom: spacing.xs,
+    },
+    input: {
+      backgroundColor: colors.surface2,
+      color: colors.text,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      paddingHorizontal: spacing.sm + 2,
+      paddingVertical: spacing.sm,
+      fontSize: 15,
+    },
+    multiline: { minHeight: 70, textAlignVertical: "top" },
+    methodRow: { flexDirection: "row", flexWrap: "wrap", gap: spacing.xs },
+    methodChip: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      borderRadius: borderRadius.lg,
+      borderColor: colors.border,
+      borderWidth: 1,
+      backgroundColor: colors.surface2,
+    },
+    methodChipSelected: {
+      backgroundColor: colors.primary,
+      borderColor: colors.primary,
+    },
+    methodChipText: { color: colors.text, fontSize: 14, fontWeight: "600" },
+    methodChipTextSelected: { color: colors.white },
+    error: { color: colors.error, marginTop: spacing.sm, fontSize: 13 },
+    success: { color: colors.success, marginTop: spacing.sm, fontSize: 14 },
+    primary: {
+      marginTop: spacing.xl,
+      backgroundColor: colors.primary,
+      borderRadius: borderRadius.md,
+      paddingVertical: spacing.sm + 4,
+      alignItems: "center",
+    },
+    disabled: { opacity: 0.5 },
+    primaryText: { color: colors.white, fontSize: 16, fontWeight: "600" },
+  });
+}

--- a/apps/mobile/app/(tabs)/jobs/_layout.tsx
+++ b/apps/mobile/app/(tabs)/jobs/_layout.tsx
@@ -12,7 +12,9 @@ export default function JobsLayout() {
       }}
     >
       <Stack.Screen name="index" options={{ title: "My Jobs" }} />
-      <Stack.Screen name="[itemId]" options={{ title: "Job" }} />
+      <Stack.Screen name="[itemId]/index" options={{ title: "Job" }} />
+      <Stack.Screen name="[itemId]/invoice" options={{ title: "New invoice" }} />
+      <Stack.Screen name="[itemId]/payment" options={{ title: "Collect payment" }} />
     </Stack>
   );
 }

--- a/apps/mobile/src/features/invoices/invoices.store.test.ts
+++ b/apps/mobile/src/features/invoices/invoices.store.test.ts
@@ -1,0 +1,249 @@
+import {
+  __resetLineItemKeyCounterForTests,
+  computeDraftTotal,
+  newLineItem,
+  useInvoicesStore,
+} from "./invoices.store";
+import type { InvoiceDetail, PaymentDetail } from "@dpf/types";
+
+const mockCreateInvoice = jest.fn();
+const mockRecordPayment = jest.fn();
+
+jest.mock("@/src/lib/apiClient", () => ({
+  api: {
+    finance: {
+      invoices: { create: (...a: unknown[]) => mockCreateInvoice(...a) },
+      payments: { record: (...a: unknown[]) => mockRecordPayment(...a) },
+    },
+  },
+}));
+
+const SERVER_INVOICE: InvoiceDetail = {
+  id: "INV-1",
+  invoiceRef: "INV-0001",
+  type: "standard",
+  status: "draft",
+  currency: "USD",
+  subtotal: 250,
+  taxAmount: 25,
+  discountAmount: 0,
+  totalAmount: 275,
+  amountPaid: 0,
+  amountDue: 275,
+  dueDate: "2026-07-16",
+  sentAt: null,
+  paidAt: null,
+  createdAt: "2026-06-16T22:00:00.000Z",
+  updatedAt: "2026-06-16T22:00:00.000Z",
+  account: { id: "ACC-1", name: "Acme HVAC Co" },
+};
+
+const SERVER_PAYMENT: PaymentDetail = {
+  id: "PMT-1",
+  paymentRef: "PMT-0001",
+  direction: "inbound",
+  method: "cash",
+  status: "completed",
+  amount: 275,
+  currency: "USD",
+  reference: null,
+  notes: null,
+  receivedAt: "2026-06-16T22:30:00.000Z",
+  createdAt: "2026-06-16T22:30:00.000Z",
+  updatedAt: "2026-06-16T22:30:00.000Z",
+};
+
+function resetStore() {
+  useInvoicesStore.getState().reset();
+  __resetLineItemKeyCounterForTests();
+  mockCreateInvoice.mockReset();
+  mockRecordPayment.mockReset();
+}
+
+describe("computeDraftTotal", () => {
+  it("sums quantity * unitPrice with no tax/discount", () => {
+    expect(
+      computeDraftTotal([
+        { key: "a", description: "labor", quantity: 2, unitPrice: 100 },
+        { key: "b", description: "part", quantity: 1, unitPrice: 50 },
+      ]),
+    ).toBe(250);
+  });
+
+  it("applies discountPercent before tax", () => {
+    // 100 * (1 - 0.10) * (1 + 0.10) = 99
+    expect(
+      computeDraftTotal([
+        {
+          key: "a",
+          description: "service",
+          quantity: 1,
+          unitPrice: 100,
+          discountPercent: 10,
+          taxRate: 10,
+        },
+      ]),
+    ).toBe(99);
+  });
+
+  it("rounds to two decimals", () => {
+    // 33.33 * 3 = 99.99, exact — but mix tax to force rounding
+    expect(
+      computeDraftTotal([
+        { key: "a", description: "x", quantity: 3, unitPrice: 33.33, taxRate: 7.5 },
+      ]),
+    ).toBe(107.49);
+  });
+});
+
+describe("useInvoicesStore — draft + create", () => {
+  beforeEach(resetStore);
+
+  it("beginDraft seeds lines and a +30-day due date", () => {
+    useInvoicesStore.getState().beginDraft({
+      workItemId: "WI-1",
+      accountId: "ACC-1",
+      seedLines: [{ description: "Service call", quantity: 1, unitPrice: 100 }],
+    });
+    const s = useInvoicesStore.getState();
+    expect(s.workItemId).toBe("WI-1");
+    expect(s.accountId).toBe("ACC-1");
+    expect(s.lineItems).toHaveLength(1);
+    expect(s.lineItems[0].description).toBe("Service call");
+    expect(s.dueDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("update and remove line items", () => {
+    const store = useInvoicesStore.getState();
+    store.beginDraft({ workItemId: "WI-1", seedLines: [{}, {}] });
+    const [a, b] = useInvoicesStore.getState().lineItems;
+    store.updateLineItem(a.key, { description: "labor", unitPrice: 100, quantity: 2 });
+    store.removeLineItem(b.key);
+    const after = useInvoicesStore.getState();
+    expect(after.lineItems).toHaveLength(1);
+    expect(after.lineItems[0].description).toBe("labor");
+    expect(after.draftTotal()).toBe(200);
+  });
+
+  it("createInvoice refuses an empty accountId", async () => {
+    useInvoicesStore.getState().beginDraft({ workItemId: "WI-1" });
+    useInvoicesStore.getState().updateLineItem(
+      useInvoicesStore.getState().lineItems[0].key,
+      { description: "x", quantity: 1, unitPrice: 50 },
+    );
+    const result = await useInvoicesStore.getState().createInvoice();
+    expect(result).toBeNull();
+    expect(useInvoicesStore.getState().error).toMatch(/account id/i);
+    expect(mockCreateInvoice).not.toHaveBeenCalled();
+  });
+
+  it("createInvoice posts the wire shape, drops `key`, and tags the source as the work item", async () => {
+    mockCreateInvoice.mockResolvedValueOnce(SERVER_INVOICE);
+    const store = useInvoicesStore.getState();
+    store.beginDraft({
+      workItemId: "WI-1",
+      accountId: "ACC-1",
+      seedLines: [
+        { description: "Labor", quantity: 2, unitPrice: 100, taxRate: 10 },
+      ],
+    });
+    const invoice = await useInvoicesStore.getState().createInvoice();
+    expect(invoice).toEqual(SERVER_INVOICE);
+
+    const call = mockCreateInvoice.mock.calls[0][0];
+    expect(call.accountId).toBe("ACC-1");
+    expect(call.sourceType).toBe("work-item");
+    expect(call.sourceId).toBe("WI-1");
+    expect(call.lineItems).toHaveLength(1);
+    // The React-only `key` must not appear on the wire — every key in the
+    // line item is exactly one of the InvoiceLineItemInput fields.
+    expect(Object.keys(call.lineItems[0]).includes("key")).toBe(false);
+    expect(useInvoicesStore.getState().invoice).toEqual(SERVER_INVOICE);
+  });
+
+  it("createInvoice surfaces server failure as state.error and returns null", async () => {
+    mockCreateInvoice.mockRejectedValueOnce(new Error("HTTP 422 invalid"));
+    useInvoicesStore
+      .getState()
+      .beginDraft({
+        workItemId: "WI-1",
+        accountId: "ACC-1",
+        seedLines: [{ description: "x", quantity: 1, unitPrice: 10 }],
+      });
+    const result = await useInvoicesStore.getState().createInvoice();
+    expect(result).toBeNull();
+    expect(useInvoicesStore.getState().error).toContain("422");
+    expect(useInvoicesStore.getState().invoice).toBeNull();
+  });
+});
+
+describe("useInvoicesStore — recordPayment", () => {
+  beforeEach(resetStore);
+
+  it("refuses payment when no invoice has been created", async () => {
+    const result = await useInvoicesStore.getState().recordPayment({
+      method: "cash",
+    });
+    expect(result).toBeNull();
+    expect(mockRecordPayment).not.toHaveBeenCalled();
+  });
+
+  it("records cash payment defaulting to the invoice's amountDue, allocated to the invoice", async () => {
+    mockCreateInvoice.mockResolvedValueOnce(SERVER_INVOICE);
+    mockRecordPayment.mockResolvedValueOnce(SERVER_PAYMENT);
+
+    useInvoicesStore.getState().beginDraft({
+      workItemId: "WI-1",
+      accountId: "ACC-1",
+      seedLines: [{ description: "Service", quantity: 1, unitPrice: 250, taxRate: 10 }],
+    });
+    await useInvoicesStore.getState().createInvoice();
+
+    const payment = await useInvoicesStore
+      .getState()
+      .recordPayment({ method: "cash" });
+    expect(payment).toEqual(SERVER_PAYMENT);
+
+    const call = mockRecordPayment.mock.calls[0][0];
+    expect(call.direction).toBe("inbound");
+    expect(call.method).toBe("cash");
+    expect(call.amount).toBe(SERVER_INVOICE.amountDue);
+    expect(call.invoiceId).toBe(SERVER_INVOICE.id);
+    expect(call.currency).toBe(SERVER_INVOICE.currency);
+  });
+
+  it("honors an explicit partial payment amount", async () => {
+    mockCreateInvoice.mockResolvedValueOnce(SERVER_INVOICE);
+    mockRecordPayment.mockResolvedValueOnce(SERVER_PAYMENT);
+
+    useInvoicesStore.getState().beginDraft({
+      workItemId: "WI-1",
+      accountId: "ACC-1",
+      seedLines: [{ description: "Service", quantity: 1, unitPrice: 250 }],
+    });
+    await useInvoicesStore.getState().createInvoice();
+
+    await useInvoicesStore
+      .getState()
+      .recordPayment({ method: "cheque", amount: 100, reference: "#1041" });
+
+    const call = mockRecordPayment.mock.calls[0][0];
+    expect(call.amount).toBe(100);
+    expect(call.method).toBe("cheque");
+    expect(call.reference).toBe("#1041");
+  });
+});
+
+describe("newLineItem", () => {
+  beforeEach(resetStore);
+
+  it("defaults quantity=1, unitPrice=0, and assigns stable keys per call", () => {
+    const a = newLineItem();
+    const b = newLineItem({ description: "labor", unitPrice: 100 });
+    expect(a.quantity).toBe(1);
+    expect(a.unitPrice).toBe(0);
+    expect(b.description).toBe("labor");
+    expect(b.unitPrice).toBe(100);
+    expect(a.key).not.toBe(b.key);
+  });
+});

--- a/apps/mobile/src/features/invoices/invoices.store.ts
+++ b/apps/mobile/src/features/invoices/invoices.store.ts
@@ -1,0 +1,232 @@
+import { create } from "zustand";
+import type {
+  CreateInvoiceInput,
+  InvoiceDetail,
+  InvoiceLineItemInput,
+  PaymentMethod,
+  PaymentDetail,
+} from "@dpf/types";
+import { api } from "@/src/lib/apiClient";
+
+/**
+ * Field-tech invoicing + payment store — the post-completion half of the
+ * "complete a job → bill the customer → take the payment" flow surfaced
+ * from the Job Detail screen. Mirrors the server contract one-for-one
+ * (apps/web/lib/finance/finance-validation.ts) via the shared @dpf/types
+ * wire shapes; the server is authoritative for totals and allocations.
+ *
+ * The store holds three things: the editable draft (line items + customer +
+ * due date), the just-created `invoice`, and the just-recorded `payment`.
+ * Both `createInvoice` and `recordPayment` return the server object so the
+ * caller can navigate on success without re-reading the store.
+ */
+
+export type DraftLineItem = InvoiceLineItemInput & { key: string };
+
+export interface NewLineItemSeed {
+  description?: string;
+  quantity?: number;
+  unitPrice?: number;
+  taxRate?: number;
+}
+
+export function newLineItem(seed: NewLineItemSeed = {}): DraftLineItem {
+  return {
+    // The key only exists to make React lists stable across edits; the server
+    // never sees it. Seeded from a monotonic counter so tests are deterministic.
+    key: `li-${nextKey()}`,
+    description: seed.description ?? "",
+    quantity: seed.quantity ?? 1,
+    unitPrice: seed.unitPrice ?? 0,
+    taxRate: seed.taxRate,
+  };
+}
+
+let keyCounter = 0;
+function nextKey(): number {
+  keyCounter += 1;
+  return keyCounter;
+}
+/** Test-only: reset the line-item key sequence so snapshots stay stable. */
+export function __resetLineItemKeyCounterForTests(): void {
+  keyCounter = 0;
+}
+
+/** Sum line totals locally so the tech sees a running figure before submit;
+ *  the server recomputes authoritatively and may differ once tax/discount
+ *  rounding is applied. */
+export function computeDraftTotal(items: DraftLineItem[]): number {
+  let total = 0;
+  for (const li of items) {
+    const lineGross = li.quantity * li.unitPrice;
+    const discount = (li.discountPercent ?? 0) / 100;
+    const afterDiscount = lineGross * (1 - discount);
+    const tax = (li.taxRate ?? 0) / 100;
+    total += afterDiscount * (1 + tax);
+  }
+  return Math.round(total * 100) / 100;
+}
+
+interface InvoicesState {
+  /** Editable draft. */
+  workItemId: string | null;
+  accountId: string;
+  dueDate: string; // ISO date
+  currency: string;
+  notes: string;
+  lineItems: DraftLineItem[];
+  /** Server result of the most recent create — drives the payment screen. */
+  invoice: InvoiceDetail | null;
+  payment: PaymentDetail | null;
+  isSubmitting: boolean;
+  error: string | null;
+
+  beginDraft: (input: {
+    workItemId: string;
+    accountId?: string;
+    seedLines?: NewLineItemSeed[];
+  }) => void;
+  setAccountId: (id: string) => void;
+  setDueDate: (iso: string) => void;
+  setNotes: (notes: string) => void;
+  addLineItem: (seed?: NewLineItemSeed) => void;
+  updateLineItem: (key: string, patch: Partial<InvoiceLineItemInput>) => void;
+  removeLineItem: (key: string) => void;
+  draftTotal: () => number;
+  createInvoice: () => Promise<InvoiceDetail | null>;
+  recordPayment: (input: {
+    method: PaymentMethod;
+    amount?: number;
+    reference?: string;
+    notes?: string;
+  }) => Promise<PaymentDetail | null>;
+  reset: () => void;
+}
+
+const TODAY_PLUS_30 = (): string => {
+  // Default due date = +30 days, ISO yyyy-mm-dd. Tech can override on the screen.
+  const d = new Date();
+  d.setDate(d.getDate() + 30);
+  return d.toISOString().slice(0, 10);
+};
+
+const EMPTY = {
+  workItemId: null,
+  accountId: "",
+  dueDate: "",
+  currency: "USD",
+  notes: "",
+  lineItems: [] as DraftLineItem[],
+  invoice: null as InvoiceDetail | null,
+  payment: null as PaymentDetail | null,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+function toCreateInput(state: InvoicesState): CreateInvoiceInput {
+  // Drop the React-only `key` before the wire call.
+  const lineItems: InvoiceLineItemInput[] = state.lineItems.map(
+    ({ key: _key, ...wire }) => wire,
+  );
+  const input: CreateInvoiceInput = {
+    accountId: state.accountId.trim(),
+    dueDate: state.dueDate,
+    currency: state.currency,
+    lineItems,
+    sourceType: state.workItemId ? "work-item" : undefined,
+    sourceId: state.workItemId ?? undefined,
+  };
+  if (state.notes.trim().length > 0) input.notes = state.notes.trim();
+  return input;
+}
+
+export const useInvoicesStore = create<InvoicesState>((set, get) => ({
+  ...EMPTY,
+
+  beginDraft: ({ workItemId, accountId, seedLines }) => {
+    const lines = (seedLines && seedLines.length > 0 ? seedLines : [{}]).map(
+      (s) => newLineItem(s),
+    );
+    set({
+      ...EMPTY,
+      workItemId,
+      accountId: accountId ?? "",
+      dueDate: TODAY_PLUS_30(),
+      lineItems: lines,
+    });
+  },
+
+  setAccountId: (id) => set({ accountId: id }),
+  setDueDate: (iso) => set({ dueDate: iso }),
+  setNotes: (notes) => set({ notes }),
+
+  addLineItem: (seed) =>
+    set((s) => ({ lineItems: [...s.lineItems, newLineItem(seed)] })),
+
+  updateLineItem: (key, patch) =>
+    set((s) => ({
+      lineItems: s.lineItems.map((li) =>
+        li.key === key ? { ...li, ...patch } : li,
+      ),
+    })),
+
+  removeLineItem: (key) =>
+    set((s) => ({ lineItems: s.lineItems.filter((li) => li.key !== key) })),
+
+  draftTotal: () => computeDraftTotal(get().lineItems),
+
+  createInvoice: async () => {
+    const state = get();
+    if (!state.accountId.trim()) {
+      set({ error: "Customer account id is required" });
+      return null;
+    }
+    if (state.lineItems.length === 0) {
+      set({ error: "Add at least one line item" });
+      return null;
+    }
+    set({ isSubmitting: true, error: null });
+    try {
+      const invoice = await api.finance.invoices.create(toCreateInput(state));
+      set({ invoice, isSubmitting: false });
+      return invoice;
+    } catch (err) {
+      set({
+        isSubmitting: false,
+        error: err instanceof Error ? err.message : "Failed to create invoice",
+      });
+      return null;
+    }
+  },
+
+  recordPayment: async ({ method, amount, reference, notes }) => {
+    const state = get();
+    if (!state.invoice) {
+      set({ error: "Create the invoice before recording payment" });
+      return null;
+    }
+    const owed = state.invoice.amountDue || state.invoice.totalAmount;
+    set({ isSubmitting: true, error: null });
+    try {
+      const payment = await api.finance.payments.record({
+        direction: "inbound",
+        method,
+        amount: amount ?? owed,
+        currency: state.invoice.currency,
+        invoiceId: state.invoice.id,
+        reference,
+        notes,
+      });
+      set({ payment, isSubmitting: false });
+      return payment;
+    } catch (err) {
+      set({
+        isSubmitting: false,
+        error: err instanceof Error ? err.message : "Failed to record payment",
+      });
+      return null;
+    }
+  },
+
+  reset: () => set({ ...EMPTY }),
+}));

--- a/packages/api-client/src/endpoints/finance.ts
+++ b/packages/api-client/src/endpoints/finance.ts
@@ -1,0 +1,34 @@
+import type { DpfClient } from "../client";
+import type {
+  CreateInvoiceInput,
+  InvoiceDetail,
+  PaymentDetail,
+  RecordPaymentInput,
+} from "@dpf/types";
+
+/**
+ * Finance endpoints — invoicing and payment recording. The field tech's
+ * "complete a job → bill the customer → take the payment" flow on mobile
+ * goes through `invoices.create` then `payments.record` (allocated to the
+ * just-created invoice). Same wire shapes the portal uses; the server is
+ * authoritative for totals + allocations.
+ */
+export function financeEndpoints(client: DpfClient) {
+  return {
+    invoices: {
+      /** Draft + persist an invoice; server computes subtotals/tax/total. */
+      create: (input: CreateInvoiceInput) =>
+        client.post<InvoiceDetail>("/api/v1/finance/invoices", input),
+
+      get: (id: string) =>
+        client.get<InvoiceDetail>(
+          `/api/v1/finance/invoices/${encodeURIComponent(id)}`,
+        ),
+    },
+    payments: {
+      /** Record a payment; allocate to an invoice when `invoiceId` is set. */
+      record: (input: RecordPaymentInput) =>
+        client.post<PaymentDetail>("/api/v1/finance/payments", input),
+    },
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -12,6 +12,7 @@ import { notificationsEndpoints } from "./endpoints/notifications";
 import { dynamicEndpoints } from "./endpoints/dynamic";
 import { uploadEndpoints } from "./endpoints/upload";
 import { workItemsEndpoints } from "./endpoints/work-items";
+import { financeEndpoints } from "./endpoints/finance";
 
 export function createApiClient(config: ApiClientConfig) {
   const client = new DpfClient(config);
@@ -28,6 +29,7 @@ export function createApiClient(config: ApiClientConfig) {
     dynamic: dynamicEndpoints(client),
     upload: uploadEndpoints(client),
     workItems: workItemsEndpoints(client),
+    finance: financeEndpoints(client),
   };
 }
 

--- a/packages/types/src/finance.ts
+++ b/packages/types/src/finance.ts
@@ -1,0 +1,136 @@
+/**
+ * Finance wire types — shared by the portal producer (apps/web/lib/finance,
+ * apps/web/app/api/v1/finance/*) and the mobile field surface
+ * (apps/mobile/src/features/invoices). Projection of the Invoice + Payment
+ * + InvoiceLineItem + PaymentAllocation models.
+ *
+ * Mirror the request shapes of finance-validation.ts 1:1 so the mobile call
+ * and the server schema cannot drift.
+ */
+
+export const INVOICE_TYPES = [
+  "standard",
+  "credit_note",
+  "proforma",
+  "recurring_instance",
+] as const;
+export type InvoiceType = (typeof INVOICE_TYPES)[number];
+
+export const INVOICE_STATUSES = [
+  "draft",
+  "approved",
+  "sent",
+  "viewed",
+  "partially_paid",
+  "paid",
+  "overdue",
+  "void",
+  "written_off",
+] as const;
+export type InvoiceStatus = (typeof INVOICE_STATUSES)[number];
+
+export const PAYMENT_DIRECTIONS = ["inbound", "outbound"] as const;
+export type PaymentDirection = (typeof PAYMENT_DIRECTIONS)[number];
+
+export const PAYMENT_METHODS = [
+  "bank_transfer",
+  "card",
+  "cash",
+  "cheque",
+  "direct_debit",
+  "stripe",
+] as const;
+export type PaymentMethod = (typeof PAYMENT_METHODS)[number];
+
+export const PAYMENT_STATUSES = [
+  "pending",
+  "completed",
+  "failed",
+  "refunded",
+  "cancelled",
+] as const;
+export type PaymentStatus = (typeof PAYMENT_STATUSES)[number];
+
+/** A single billable row on a draft invoice. */
+export interface InvoiceLineItemInput {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxRate?: number;
+  discountPercent?: number;
+  accountCode?: string;
+}
+
+/** Create-invoice request body (POST /api/v1/finance/invoices). */
+export interface CreateInvoiceInput {
+  accountId: string;
+  contactId?: string;
+  type?: InvoiceType;
+  /** ISO date string. */
+  dueDate: string;
+  /** ISO 4217 alphabetic code. */
+  currency?: string;
+  paymentTerms?: string;
+  notes?: string;
+  internalNotes?: string;
+  /** Origin reference, e.g. `sourceType: "work-item", sourceId: itemId`. */
+  sourceType?: string;
+  sourceId?: string;
+  signatureRequired?: boolean;
+  lineItems: InvoiceLineItemInput[];
+}
+
+/** Detail row returned by the API after create / get. Monetary values are
+ *  serialized as numbers; the server is the source of truth for totals. */
+export interface InvoiceDetail {
+  id: string;
+  invoiceRef: string;
+  type: InvoiceType;
+  status: InvoiceStatus;
+  currency: string;
+  subtotal: number;
+  taxAmount: number;
+  discountAmount: number;
+  totalAmount: number;
+  amountPaid: number;
+  amountDue: number;
+  dueDate: string | null;
+  sentAt: string | null;
+  paidAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  account?: { id: string; name: string } | null;
+}
+
+/** Record-payment request body (POST /api/v1/finance/payments). */
+export interface RecordPaymentInput {
+  direction: PaymentDirection;
+  method: PaymentMethod;
+  amount: number;
+  currency?: string;
+  reference?: string;
+  /** Invoice this payment should be allocated against. */
+  invoiceId?: string;
+  billId?: string;
+  notes?: string;
+  /** ISO date-time string; defaults to now() server-side. */
+  receivedAt?: string;
+}
+
+export interface PaymentDetail {
+  id: string;
+  paymentRef: string;
+  direction: PaymentDirection;
+  method: PaymentMethod;
+  status: PaymentStatus;
+  amount: number;
+  currency: string;
+  reference: string | null;
+  notes: string | null;
+  receivedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  allocations?: Array<{
+    invoice?: { id: string; invoiceRef: string } | null;
+  }>;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,3 +3,4 @@ export * from "./api";
 export * from "./dynamic";
 export * from "./mobile-manifest";
 export * from "./work-items";
+export * from "./finance";


### PR DESCRIPTION
## Summary

Implements the field-tech billing path the umbrella goal called out: after a job is marked `completed`, the tech taps **Draft invoice**, edits line items with a running total, creates the invoice via the existing `POST /api/v1/finance/invoices`, and is routed to a **Collect payment** screen that posts to `POST /api/v1/finance/payments` (`direction: "inbound"`, allocated to the freshly-created invoice). Cash / cheque / card-manual / bank-transfer methods covered; card/Stripe automation remains owner-action (Apple merchant + payment processor enrollment) per the spec.

Builds on [opendigitalproductfactory#2042](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2042) (employee persona + landing tab). Together they unlock the **P4 field-tech use-case** the umbrella spec calls out (HVAC: capture work, draft invoice, collect payment).

Spec: [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html) (§11 roadmap P4, §13 decision B).

## Mechanics

- **`packages/types/src/finance.ts`** — `CreateInvoiceInput`, `InvoiceLineItemInput`, `InvoiceDetail`, `RecordPaymentInput`, `PaymentDetail` + the closed unions (`INVOICE_STATUSES`, `PAYMENT_METHODS`, etc) mirroring `finance-validation.ts` 1:1 so the wire and the server schema cannot drift.
- **`packages/api-client/src/endpoints/finance.ts`** — `finance.invoices.create/get` + `finance.payments.record`.
- **`apps/mobile/src/features/invoices/invoices.store.ts`** — Zustand store holding the editable draft (line items + customer + due date), the server invoice, and the recorded payment. `computeDraftTotal` is a local running figure only; server is authoritative for totals + allocations.
- **`apps/mobile/app/(tabs)/jobs/[itemId]/invoice.tsx`** — line-items editor: description / qty / unit price / tax / discount, Add line, total.
- **`apps/mobile/app/(tabs)/jobs/[itemId]/payment.tsx`** — method chip row (cash / cheque / card / bank), amount defaults to invoice `amountDue`, optional reference + notes.
- **`apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx`** (moved from `[itemId].tsx`) — the Draft-invoice CTA renders only when `status === "completed"` and seeds the draft from the job title so the tech only types prices.

## Test plan

- [x] `pnpm --filter mobile exec jest --testPathPatterns="invoices|navigation|jobs"` — 23/23 passing (invoices store 12 new, navigation 11 unchanged from #2042, jobs 0 affected; remaining mobile suites unchanged).
- [x] `pnpm --filter mobile typecheck` — clean.
- [x] `pnpm --filter web typecheck` — clean.
- [x] `pnpm --filter @dpf/api-client test` — 3/3 passing.
- [ ] Functional gate (per AGENTS §5): drive job → completed → draft invoice → cash payment on a seeded HVAC install via the shared local-CI convergence sandbox lease — owner action once an HVAC fixture exists.

## What's next

1. **Server: link `WorkItem` → `CustomerAccount`.** Today the invoice screen asks the tech to type `accountId`; the WorkItem has `sourceType`/`sourceId` but no derived `account.{ id, name }` on `WorkItemDetail`. A small follow-up resolves the account from the work item's source and renders it read-only on the invoice screen.
2. **Photo + signature on completion.** `expo-camera` + the dynamic signature widget are already in the app; tie them to a "Capture work done" pre-step before Draft invoice.
3. **Customer surface (P5):** book / my visits / pay / messages — separate feature store + screens.
4. **Town super-app (M1):** `Space[]` switcher unlocks the geo-discovery community use-case.