### PR TITLE
chore(security): close 23 GitHub security alerts (deps + CodeQL)

### DIFF
--- a/.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml
+++ b/.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml
@@ -62,6 +62,19 @@ extensions:
       # forge a log line. Breaks taint flow for js/log-injection (CWE-117).
       - ["safe-log", "Module", "Member[sanitizeForLog]", "Argument[0]", "ReturnValue", "taint", "manual"]
 
+  # ─── media-storage — js/http-to-file-access sanitiser ───────────────────
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: summaryModel
+    data:
+      # prepareMediaBlobContentForStorage validates the buffer's mime type
+      # (probeImage rejects anything outside DEFAULT_MEDIA_BLOB_MIME_TYPES)
+      # AND enforces DEFAULT_MEDIA_BLOB_MAX_BYTES before returning a branded
+      # ValidatedMediaBlobContent. Bytes reaching writeMediaBlob/fs.writeFile
+      # have cleared both gates — the network → file dataflow is no longer
+      # arbitrary file upload (CWE-434/CWE-912). Closes alert #269.
+      - ["media-storage", "Module", "Member[prepareMediaBlobContentForStorage]", "Argument[0]", "ReturnValue", "taint", "manual"]
+
   # ─── safe-property — js/remote-property-injection guard ──────────────────
   - addsTo:
       pack: codeql/javascript-all

--- a/apps/web/lib/actions/build-studio.ts
+++ b/apps/web/lib/actions/build-studio.ts
@@ -8,6 +8,7 @@ import { getOllamaBaseUrl, getOllamaApiRoot } from "@/lib/inference/ollama-url";
 import { preflightLocalEndpoint, OPENCODE_MIN_CONTEXT_TOKENS, type LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 import { setServedContextTokens } from "@/lib/inference/dmr-runtime-config";
 import { getLocalOnlyInference, setLocalOnlyInference } from "@/lib/inference/local-only";
+import { sanitizeForLog } from "@/lib/security/safe-log";
 
 async function requireManageProviders(): Promise<string> {
   const session = await auth();
@@ -124,10 +125,15 @@ export async function applyLocalModelContext(
   }
   if (contextTokens < OPENCODE_MIN_CONTEXT_TOKENS) {
     // Allowed (operator may know better), but make the consequence explicit.
-    // Strip control chars from the operator-supplied model id before logging —
-    // neutralizes log injection (CR/LF/control-char forging of log lines).
-    const safeModel = trimmed.replace(/[^a-zA-Z0-9._:@/+-]/g, "");
-    console.warn(`[build-studio] applyLocalModelContext set ${safeModel} to ${contextTokens} (< ${OPENCODE_MIN_CONTEXT_TOKENS} agent floor)`);
+    // sanitizeForLog (the CodeQL-registered sanitizer) strips C0 + DEL so a
+    // CR/LF in the operator-supplied model id cannot forge a downstream log
+    // line (CWE-117). contextTokens is already Number.isInteger above, so it
+    // safely composes into the same sanitized line.
+    console.warn(
+      sanitizeForLog(
+        `[build-studio] applyLocalModelContext set ${trimmed} to ${contextTokens} (< ${OPENCODE_MIN_CONTEXT_TOKENS} agent floor)`,
+      ),
+    );
   }
 
   const apiRoot = getOllamaApiRoot();

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -27,6 +27,7 @@ import { getOllamaBaseUrl } from "@/lib/inference/ollama-url";
 import { getServedContextTokens } from "@/lib/inference/dmr-runtime-config";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
+import { sanitizeForLog } from "@/lib/security/safe-log";
 
 const DEFAULT_SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 
@@ -446,7 +447,14 @@ export async function dispatchOpencodeTask(params: {
       { timeout: 5_000 },
     );
 
-    console.log(`[opencode-dispatch] Starting task "${task.title}" with local/${model} in ${containerId} (timeout: ${timeoutMs / 1000}s, endpoint: ${sandboxBaseUrl})`);
+    // task.title and the model id originate from operator-authored BIs and the
+    // build config, so they're CWE-117 sources. sanitizeForLog (CodeQL-registered)
+    // strips C0 + DEL before the line lands.
+    console.log(
+      sanitizeForLog(
+        `[opencode-dispatch] Starting task "${task.title}" with local/${model} in ${containerId} (timeout: ${timeoutMs / 1000}s, endpoint: ${sandboxBaseUrl})`,
+      ),
+    );
 
     const { stdout, durationMs: elapsed } = await new Promise<{ stdout: string; durationMs: number }>((resolve, reject) => {
       const proc = spawnCb("docker", ["exec", "--user", "node", containerId, runnerScript]);
@@ -478,7 +486,11 @@ export async function dispatchOpencodeTask(params: {
         } else if (code === 0 || stdout.trim()) {
           resolve({ stdout, durationMs: d });
         } else {
-          console.error(`[opencode-dispatch] Task "${task.title}" stderr: ${stderrBuf.slice(0, 500)}`);
+          console.error(
+            sanitizeForLog(
+              `[opencode-dispatch] Task "${task.title}" stderr: ${stderrBuf.slice(0, 500)}`,
+            ),
+          );
           reject(Object.assign(new Error(`Exit code ${code}`), { stdout, code, stderr: stderrBuf }));
         }
       });
@@ -489,7 +501,11 @@ export async function dispatchOpencodeTask(params: {
     });
 
     const content = extractOpencodeResult(stdout);
-    console.log(`[opencode-dispatch] Task "${task.title}" completed in ${(elapsed / 1000).toFixed(1)}s (${content.length} chars)`);
+    console.log(
+      sanitizeForLog(
+        `[opencode-dispatch] Task "${task.title}" completed in ${(elapsed / 1000).toFixed(1)}s (${content.length} chars)`,
+      ),
+    );
 
     await recordBuildDispatchAttempt({
       buildId: params.buildId,

--- a/apps/web/lib/media/media-storage.ts
+++ b/apps/web/lib/media/media-storage.ts
@@ -139,8 +139,10 @@ class FilesystemMediaDriver implements MediaStorageDriver {
 
     try {
       // Bytes reach this sink only after prepareMediaBlobContentForStorage has
-      // probed type and size; the path is content-addressed and root-confined.
-      // codeql[js/http-to-file-access]
+      // probed type and size and re-typed them as ValidatedMediaBlobContent;
+      // the path is content-addressed and root-confined. The validator is
+      // registered as a CodeQL sanitiser in
+      // .github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml — alert #269.
       await fs.writeFile(temporaryPath, buffer, { flag: "wx" });
       await fs.rename(temporaryPath, absolutePath);
     } catch (error) {

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -456,15 +456,13 @@ async function withSwapSignalRetry(
       return;
     } catch (err) {
       lastErr = err;
-      // printf-style positional substitution (safe-log.ts / PR #999 convention):
-      // CodeQL models `%s` args + the registered sanitizer natively, so taint is
-      // broken unambiguously — clearer than a template literal for the dataflow.
+      // Wrap the full template literal (matches the working
+      // agent-coworker.ts / assurance.ts pattern). The printf-with-%s shape
+      // splits args across multiple call-edges and CodeQL js/log-injection
+      // does not propagate the sanitiser through them — alert #276.
+      const errMsg = err instanceof Error ? err.message : String(err);
       console.warn(
-        "[quiescence] %s attempt %d/%d failed: %s",
-        sanitizeForLog(label),
-        i + 1,
-        attempts,
-        sanitizeForLog(err instanceof Error ? err.message : String(err)),
+        sanitizeForLog(`[quiescence] ${label} attempt ${i + 1}/${attempts} failed: ${errMsg}`),
       );
       if (i < attempts - 1) await sleep(500 * (i + 1));
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,16 +14,16 @@ overrides:
   lodash-es: 4.18.0
   '@tootallnate/once': 3.0.1
   '@xmldom/xmldom': 0.8.13
-  dompurify: 3.4.0
+  dompurify: 3.4.9
   node-forge: 1.4.0
   postcss: ^8.5.10
   uuid: ^14.0.0
   '@opentelemetry/otlp-transformer>protobufjs': ^8.3.0
-  protobufjs@<=7.5.7: ^7.5.8
+  protobufjs@<7.6.3: ^7.6.3
   ws@>=8.0.0 <8.20.1: ^8.20.1
   esbuild@>=0.17.0 <0.28.1: ^0.28.1
   fast-uri: ^3.1.2
-  hono: ^4.12.21
+  hono: ^4.12.25
   mermaid: ^11.15.0
   ip-address: ^10.2.0
   qs: ^6.15.2
@@ -259,7 +259,7 @@ importers:
         version: 4.0.3
       inngest:
         specifier: ^4.5.1
-        version: 4.5.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(express@5.2.1)(hono@4.12.23)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
+        version: 4.5.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(express@5.2.1)(hono@4.12.25)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -1820,7 +1820,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.12.21
+      hono: ^4.12.25
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -3124,9 +3124,6 @@ packages:
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -5493,8 +5490,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.4.9:
+    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -6266,8 +6263,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@7.0.2:
@@ -6414,7 +6411,7 @@ packages:
       express: '>=4.19.2'
       fastify: '>=4.21.0'
       h3: '>=1.8.1'
-      hono: ^4.12.21
+      hono: ^4.12.25
       koa: '>=2.14.2'
       next: '>=12.0.0'
       react: '>=18.0.0'
@@ -8153,10 +8150,6 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
-
-  protobufjs@7.5.8:
-    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
-    engines: {node: '>=12.0.0'}
 
   protobufjs@7.6.4:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
@@ -11237,9 +11230,9 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
 
-  '@hono/node-server@1.19.13(hono@4.12.23)':
+  '@hono/node-server@1.19.13(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@iconify/types@2.0.0': {}
 
@@ -11797,7 +11790,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.23)
+      '@hono/node-server': 1.19.13(hono@4.12.25)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -11807,7 +11800,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.0(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12686,13 +12679,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.13(hono@4.12.23)
+      '@hono/node-server': 1.19.13(hono@4.12.25)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.23
+      hono: 4.12.25
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -12762,8 +12755,6 @@ snapshots:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -14253,7 +14244,7 @@ snapshots:
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       color-string: 2.1.4
-      dompurify: 3.4.0
+      dompurify: 3.4.9
       highlight.js: 11.11.1
       html-to-image: 1.11.13
       immer: 10.2.0
@@ -15356,7 +15347,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.0:
+  dompurify@3.4.9:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -16233,7 +16224,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -16372,7 +16363,7 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inngest@4.5.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(express@5.2.1)(hono@4.12.23)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3):
+  inngest@4.5.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(express@5.2.1)(hono@4.12.25)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@bufbuild/protobuf': 2.12.0
       '@inngest/ai': 0.1.7
@@ -16400,7 +16391,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       express: 5.2.1
-      hono: 4.12.23
+      hono: 4.12.25
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       typescript: 6.0.3
@@ -17398,7 +17389,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.0
+      dompurify: 3.4.9
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -18031,7 +18022,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.26.0
       platform: 1.3.6
-      protobufjs: 7.5.8
+      protobufjs: 7.6.4
 
   ono@4.0.11:
     dependencies:
@@ -18514,21 +18505,6 @@ snapshots:
       signal-exit: 3.0.7
 
   property-information@7.1.0: {}
-
-  protobufjs@7.5.8:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.1
-      '@protobufjs/fetch': 1.1.1
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.9.3
-      long: 5.3.2
 
   protobufjs@7.6.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,19 +14,26 @@ overrides:
   lodash-es: '4.18.0'
   '@tootallnate/once': '3.0.1'
   '@xmldom/xmldom': '0.8.13'
-  dompurify: '3.4.0'
+  # dompurify < 3.4.9: 6 GHSA advisories (template-tag bypass, IN_PLACE clobber,
+  # cross-realm bypass, etc.). Dev-only transitive via @mermaid-js/mermaid-cli.
+  dompurify: '3.4.9'
   node-forge: '1.4.0'
   postcss: '^8.5.10'
   uuid: '^14.0.0'
   '@opentelemetry/otlp-transformer>protobufjs': '^8.3.0'
-  'protobufjs@<=7.5.7': '^7.5.8'
+  # protobufjs < 7.6.3: GHSA-f38q-mgvj-vph7 prototype-property shadowing +
+  # GHSA-wcpc-wj8m-hjx6 unbounded Any expansion DoS. Floor every runtime entry
+  # to a patched release.
+  'protobufjs@<7.6.3': '^7.6.3'
   'ws@>=8.0.0 <8.20.1': '^8.20.1'
   # esbuild < 0.28.1: GHSA binary-integrity RCE via NPM_CONFIG_REGISTRY (high) +
   # arbitrary file read by the Windows dev server (low). Dev-only transitive dep
   # of vite/vitest; pin the vulnerable range up to the patched release.
   'esbuild@>=0.17.0 <0.28.1': '^0.28.1'
   fast-uri: '^3.1.2'
-  hono: '^4.12.21'
+  # hono < 4.12.25: GHSA-88fw-hqm2-52qc CORS-with-credentials wildcard reflection
+  # (high) + 4 medium Lambda/edge adapter issues. Runtime dependency.
+  hono: '^4.12.25'
   mermaid: '^11.15.0'
   ip-address: '^10.2.0'
   qs: '^6.15.2'

--- a/scripts/check-ux-fit-decision.mjs
+++ b/scripts/check-ux-fit-decision.mjs
@@ -22,7 +22,7 @@
 // human_cognitive_load axis). v1 is a conscious-attestation MVP; a follow-up can
 // verify a persisted DecisionInteraction record (BI-65DEE968 §5).
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 const ATTESTATION_RE = /UX-Fit-Decision:/i;
 
@@ -33,19 +33,44 @@ const ROUTE_FILE_RE = /app\/.*\/page\.tsx$/;
 // Don't gate test/story scaffolding — those controls aren't user-facing.
 const EXCLUDE_RE = /\.(test|spec|stories)\.tsx$/;
 
-function sh(cmd) {
+// Refs reach us from CI env vars (BASE_SHA) and from git's own output. Pin the
+// set of characters we accept so a forged value cannot smuggle shell metachars
+// or git option flags through to execFile. (js/indirect-command-line-injection.)
+const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
+// Repo-relative paths git emits in --name-only. Reject anything that could be
+// reinterpreted as a flag or escape the worktree.
+const PATH_RE = /^[A-Za-z0-9._\-/]+$/;
+
+function assertSafeRef(ref, label) {
+  if (!REF_RE.test(ref) || ref.startsWith("-")) {
+    throw new Error(`[ux-fit-gate] refusing unsafe ${label}: ${JSON.stringify(ref)}`);
+  }
+  return ref;
+}
+
+function assertSafePath(path) {
+  if (!PATH_RE.test(path) || path.startsWith("-")) {
+    throw new Error(`[ux-fit-gate] refusing unsafe path: ${JSON.stringify(path)}`);
+  }
+  return path;
+}
+
+// execFile with arg array — bypasses the shell entirely, so individual args
+// containing $, `, ;, &, |, etc. are inert. The first-arg validator above
+// guards against `--upload-pack`-style git option injection on the ref.
+function git(...args) {
   try {
-    return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
   } catch (e) {
     return (e.stdout && e.stdout.toString()) || "";
   }
 }
 
-const base = process.env.BASE_SHA || "origin/main";
+const base = assertSafeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
 // Ensure the base ref is present (CI checks out a shallow tree).
-sh(`git fetch --no-tags --depth=1 origin main`);
+git("fetch", "--no-tags", "--depth=1", "origin", "main");
 
-const changed = sh(`git diff --name-only ${base}...HEAD -- "apps/web/**/*.tsx"`)
+const changed = git("diff", "--name-only", `${base}...HEAD`, "--", "apps/web/**/*.tsx")
   .split("\n")
   .map((s) => s.trim())
   .filter(Boolean)
@@ -57,7 +82,7 @@ if (changed.length === 0) {
 }
 
 const addedFiles = new Set(
-  sh(`git diff --name-only --diff-filter=A ${base}...HEAD -- "apps/web/**/*.tsx"`)
+  git("diff", "--name-only", "--diff-filter=A", `${base}...HEAD`, "--", "apps/web/**/*.tsx")
     .split("\n")
     .map((s) => s.trim())
     .filter(Boolean),
@@ -65,13 +90,14 @@ const addedFiles = new Set(
 
 const impacting = [];
 for (const f of changed) {
-  const isNewRoute = ROUTE_FILE_RE.test(f) && addedFiles.has(f);
-  const added = sh(`git diff ${base}...HEAD -- "${f}"`)
+  const safePath = assertSafePath(f);
+  const isNewRoute = ROUTE_FILE_RE.test(safePath) && addedFiles.has(safePath);
+  const added = git("diff", `${base}...HEAD`, "--", safePath)
     .split("\n")
     .filter((l) => l.startsWith("+") && !l.startsWith("+++"));
   const addsControl = added.some((l) => UI_CONTROL_RE.test(l));
   if (isNewRoute || addsControl) {
-    impacting.push(f + (isNewRoute ? " (new route)" : " (adds a user-facing control)"));
+    impacting.push(safePath + (isNewRoute ? " (new route)" : " (adds a user-facing control)"));
   }
 }
 
@@ -80,7 +106,7 @@ if (impacting.length === 0) {
   process.exit(0);
 }
 
-const commits = sh(`git log ${base}..HEAD --format=%B`);
+const commits = git("log", `${base}..HEAD`, "--format=%B");
 const prBody = process.env.PR_BODY || "";
 const attested = ATTESTATION_RE.test(commits) || ATTESTATION_RE.test(prBody);
 


### PR DESCRIPTION
## Summary

Closes every open alert on the [Security tab](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/security) — 16 Dependabot + 7 CodeQL = **23 alerts**. No new functionality; one consolidated PR so the security tab can flip green in a single re-scan.

### Dependabot (16 alerts)

| Pkg | From → To | Alerts | Worst sev |
|---|---|---|---|
| hono | `^4.12.21` → `^4.12.25` | #84 #85 #86 #87 #88 | **high** (CORS-with-credentials wildcard reflection) |
| dompurify | `3.4.0` → `3.4.9` | #78 #79 #80 #81 #82 #83 | medium (dev-scope, transitive via @mermaid-js/mermaid-cli) |
| protobufjs | floor `^7.5.8` → `^7.6.3` | #75 #76 | **high** (Any-expansion DoS) |
| js-yaml | already `4.2.0` | #74 | auto-closes on next rescan |
| @babel/core | already `7.29.7` | #73 | auto-closes on next rescan |

`pnpm install` collapses the lockfile to a single `protobufjs@7.6.4`, removes `7.5.8`, and resolves `hono@4.12.25` / `dompurify@3.4.9`.

### CodeQL (7 alerts)

**js/log-injection** — 5 alerts, CWE-117 (CRLF log forgery):
- `opencode-dispatch.ts:449/481/492` (#277 #278 #279) — `task.title` / `stderrBuf` originate from operator-authored BIs; wrap in `sanitizeForLog`.
- `build-studio.ts:130` (#281) — replace ad-hoc `.replace()` with the registered `sanitizeForLog`.
- `quiescence.ts:464` (#276) — the printf-with-`%s` shape did **not** propagate the sanitiser through dataflow. Converted to a single template literal wrapped in `sanitizeForLog`, matching the already-working `agent-coworker.ts` / `assurance.ts` pattern.

**js/indirect-command-line-injection** — `check-ux-fit-decision.mjs:38` (#282):
- Swap `execSync(string)` for `execFileSync(arg-array)` and allow-list every arg derived from `BASE_SHA` or git output (`REF_RE` + `PATH_RE`). The shell is no longer in the path, so a forged `BASE_SHA=";rm -rf ..."` or a `--upload-pack=...`-style git option-injection cannot reach git.

**js/http-to-file-access** — `media-storage.ts:144` (#269):
- `prepareMediaBlobContentForStorage` already validates mime via `probeImage` + caps byte length and returns a branded `ValidatedMediaBlobContent`, but CodeQL did not know that. Registered it as a sanitiser in `.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml`. Also removed the `// codeql[js/http-to-file-access]` comment — that syntax is **not honoured** by GitHub Code Scanning; the model pack is.

## Test plan
- [x] `pnpm install` — lockfile resolves cleanly
- [x] `pnpm --filter web typecheck` — green
- [x] Targeted vitest suites — `safe-log` 4/4, `quiescence` + `opencode-dispatch` 80/80 (84 total)
- [ ] CI: Unit Tests + CodeQL re-scan on PR
- [ ] CodeQL re-scan after merge: confirm 7 code-scanning alerts close
- [ ] Dependabot re-scan after merge: confirm 16 alerts close (incl. the already-stale js-yaml + @babel/core)

UX-Fit-Decision: no-ui-impact (security PR — no operator-facing controls)