### PR TITLE
feat(mobile): customer "My invoices" surface scoped to the signed-in account

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -10,6 +10,8 @@ import {
 import { colors, spacing } from "@/src/lib/theme";
 import { DashboardTile } from "@/src/components/DashboardTile";
 import { useWorkspaceStore } from "@/src/features/workspace/workspace.store";
+import { useAppConfigStore } from "@/src/lib/appConfig";
+import { CustomerInvoicesPanel } from "@/src/features/customer-invoices/CustomerInvoicesPanel";
 import type { ActivityItem, DashboardTile as TileType } from "@dpf/types";
 
 function TilesGrid({ tiles }: { tiles: TileType[] }) {
@@ -45,6 +47,9 @@ function ActivityRow({ item }: { item: ActivityItem }) {
 }
 
 export default function HomeScreen() {
+  const persona = useAppConfigStore((s) => s.persona);
+  const isCustomer = persona?.kind === "customer";
+
   const {
     tiles,
     activityFeed,
@@ -56,12 +61,23 @@ export default function HomeScreen() {
   } = useWorkspaceStore();
 
   const refresh = useCallback(async () => {
+    // The operator dashboard requires workforce auth; skip the calls when
+    // the customer surface is mounted to avoid auth-noise 403s in the panel.
+    if (isCustomer) return;
     await Promise.all([fetchDashboard(), fetchActivity()]);
-  }, [fetchDashboard, fetchActivity]);
+  }, [fetchDashboard, fetchActivity, isCustomer]);
 
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  if (isCustomer) {
+    return (
+      <View style={styles.screen} testID="customer-home">
+        <CustomerInvoicesPanel />
+      </View>
+    );
+  }
 
   const lastSyncedText = lastSynced
     ? `Last synced: ${new Date(lastSynced).toLocaleTimeString()}`

--- a/apps/mobile/src/features/customer-invoices/CustomerInvoicesPanel.tsx
+++ b/apps/mobile/src/features/customer-invoices/CustomerInvoicesPanel.tsx
@@ -1,0 +1,142 @@
+/**
+ * Customer-mode home panel: "My invoices" — the signed-in customer's open
+ * balances, with a tap-through to the in-platform Pay flow on the install.
+ *
+ * Renders only when the install manifest tells us this is the customer
+ * surface; on the operator/employee/admin shell it stays absent and the
+ * existing operator home is untouched.
+ */
+import React, { useEffect, useMemo } from "react";
+import { ActivityIndicator, FlatList, Linking, Pressable, StyleSheet, Text, View } from "react-native";
+import { useTheme } from "@/src/lib/theme";
+import { getServerUrl } from "@/src/lib/serverConfig";
+import {
+  selectOpenInvoices,
+  useCustomerInvoicesStore,
+} from "./customer-invoices.store";
+import type { InvoiceDetail } from "@dpf/types";
+
+interface Row {
+  invoice: InvoiceDetail;
+}
+
+function payUrlFor(invoice: InvoiceDetail): string {
+  // Customer-facing pay portal already exists at the install (Phase 1
+  // e-signature + cash/card etc). We open it in the system browser to keep
+  // App Store 3.1.3(e) / 3.1.1 happy on physical-service IAP exemption — and
+  // because Apple/Google merchant onboarding is owner-action P0 work the
+  // app itself doesn't yet drive. Deep link by invoiceRef.
+  return `${getServerUrl()}/pay/${encodeURIComponent(invoice.invoiceRef)}`;
+}
+
+function InvoiceRow({ invoice }: Row): React.JSX.Element {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () => makeRowStyles({ colors, spacing, borderRadius }),
+    [colors, spacing, borderRadius],
+  );
+  const onPress = (): void => {
+    Linking.openURL(payUrlFor(invoice)).catch(() => undefined);
+  };
+  return (
+    <Pressable
+      onPress={onPress}
+      style={styles.row}
+      accessibilityRole="button"
+      testID={`customer-invoice-${invoice.invoiceRef}`}
+    >
+      <View style={styles.left}>
+        <Text style={styles.ref}>{invoice.invoiceRef}</Text>
+        <Text style={styles.meta}>
+          {invoice.status === "overdue" ? "Overdue" : "Due"}
+          {invoice.dueDate
+            ? ` ${new Date(invoice.dueDate).toLocaleDateString()}`
+            : ""}
+        </Text>
+      </View>
+      <View style={styles.right}>
+        <Text style={styles.amount}>
+          {invoice.currency} {invoice.amountDue.toFixed(2)}
+        </Text>
+        <Text style={styles.pay}>Pay →</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+export function CustomerInvoicesPanel(): React.JSX.Element {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const { invoices, isLoading, error, fetch } = useCustomerInvoicesStore();
+
+  useEffect(() => {
+    void fetch();
+  }, [fetch]);
+
+  const open = useMemo(() => selectOpenInvoices(invoices), [invoices]);
+
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.h1}>My invoices</Text>
+      {error ? (
+        <Text style={styles.error} testID="customer-invoices-error">
+          {error}
+        </Text>
+      ) : null}
+      {isLoading && open.length === 0 ? (
+        <ActivityIndicator
+          color={theme.colors.primary}
+          testID="customer-invoices-loading"
+        />
+      ) : open.length === 0 ? (
+        <Text style={styles.empty}>You're all paid up.</Text>
+      ) : (
+        <FlatList
+          data={open}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => <InvoiceRow invoice={item} />}
+          scrollEnabled={false}
+        />
+      )}
+    </View>
+  );
+}
+
+function makeStyles({ colors, spacing }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    panel: { padding: spacing.md, gap: spacing.sm },
+    h1: { color: colors.text, fontSize: 20, fontWeight: "700" },
+    empty: { color: colors.textMuted, fontSize: 14, marginTop: spacing.sm },
+    error: { color: colors.error, fontSize: 13 },
+  });
+}
+
+function makeRowStyles({
+  colors,
+  spacing,
+  borderRadius,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  spacing: ReturnType<typeof useTheme>["spacing"];
+  borderRadius: ReturnType<typeof useTheme>["borderRadius"];
+}) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      marginVertical: spacing.xs,
+    },
+    left: { flex: 1 },
+    right: { alignItems: "flex-end" },
+    ref: { color: colors.text, fontSize: 15, fontWeight: "700" },
+    meta: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+    amount: { color: colors.text, fontSize: 16, fontWeight: "700" },
+    pay: { color: colors.primary, fontSize: 13, fontWeight: "600", marginTop: 2 },
+  });
+}

--- a/apps/mobile/src/features/customer-invoices/customer-invoices.store.test.ts
+++ b/apps/mobile/src/features/customer-invoices/customer-invoices.store.test.ts
@@ -1,0 +1,98 @@
+import {
+  selectOpenInvoices,
+  useCustomerInvoicesStore,
+} from "./customer-invoices.store";
+import type { InvoiceDetail } from "@dpf/types";
+
+const mockMyInvoices = jest.fn();
+
+jest.mock("@/src/lib/apiClient", () => ({
+  api: {
+    customer: {
+      myInvoices: (...a: unknown[]) => mockMyInvoices(...a),
+    },
+  },
+}));
+
+const inv = (
+  id: string,
+  amountDue: number,
+  status: InvoiceDetail["status"] = "sent",
+  createdAt = "2026-06-10T00:00:00.000Z",
+): InvoiceDetail => ({
+  id,
+  invoiceRef: `INV-${id}`,
+  type: "standard",
+  status,
+  currency: "USD",
+  subtotal: 100,
+  taxAmount: 0,
+  discountAmount: 0,
+  totalAmount: amountDue,
+  amountPaid: 0,
+  amountDue,
+  dueDate: "2026-07-10",
+  sentAt: null,
+  paidAt: null,
+  createdAt,
+  updatedAt: createdAt,
+  account: null,
+});
+
+function resetStore() {
+  useCustomerInvoicesStore.getState().reset();
+  mockMyInvoices.mockReset();
+}
+
+describe("useCustomerInvoicesStore.fetch", () => {
+  beforeEach(resetStore);
+
+  it("populates `invoices` from the API on success", async () => {
+    mockMyInvoices.mockResolvedValueOnce({ data: [inv("1", 100)], nextCursor: null });
+    await useCustomerInvoicesStore.getState().fetch();
+    expect(useCustomerInvoicesStore.getState().invoices).toHaveLength(1);
+    expect(useCustomerInvoicesStore.getState().isLoading).toBe(false);
+    expect(useCustomerInvoicesStore.getState().error).toBeNull();
+  });
+
+  it("forwards the status filter", async () => {
+    mockMyInvoices.mockResolvedValueOnce({ data: [], nextCursor: null });
+    await useCustomerInvoicesStore.getState().fetch("sent");
+    expect(mockMyInvoices.mock.calls[0][0]).toEqual({ status: "sent", limit: 25 });
+  });
+
+  it("surfaces API errors and leaves the previous list alone", async () => {
+    useCustomerInvoicesStore.setState({ invoices: [inv("seed", 50)] });
+    mockMyInvoices.mockRejectedValueOnce(new Error("HTTP 500"));
+    await useCustomerInvoicesStore.getState().fetch();
+    const s = useCustomerInvoicesStore.getState();
+    expect(s.isLoading).toBe(false);
+    expect(s.error).toContain("500");
+    expect(s.invoices).toHaveLength(1);
+  });
+});
+
+describe("selectOpenInvoices", () => {
+  it("drops zero-balance invoices", () => {
+    expect(selectOpenInvoices([inv("1", 0)])).toHaveLength(0);
+  });
+
+  it("drops voided and written_off invoices even with a balance", () => {
+    expect(
+      selectOpenInvoices([
+        inv("v", 100, "void"),
+        inv("w", 100, "written_off"),
+        inv("ok", 100, "sent"),
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it("orders most-recent-first, then by amountDue desc", () => {
+    const out = selectOpenInvoices([
+      inv("older", 100, "sent", "2026-05-01T00:00:00.000Z"),
+      inv("newer-small", 50, "sent", "2026-06-15T00:00:00.000Z"),
+      inv("newer-large", 200, "sent", "2026-06-15T00:00:00.000Z"),
+    ]);
+    expect(out.map((i) => i.id)).toEqual(["newer-large", "newer-small", "older"]);
+  });
+});

--- a/apps/mobile/src/features/customer-invoices/customer-invoices.store.ts
+++ b/apps/mobile/src/features/customer-invoices/customer-invoices.store.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import type { InvoiceDetail } from "@dpf/types";
+import { api } from "@/src/lib/apiClient";
+
+/**
+ * Customer-side "My invoices" store — backs the customer-mode home panel
+ * with the signed-in customer's own invoices (scoped server-side via
+ * /api/v1/customer/invoices + requireCustomerAuth). The mobile binary stays
+ * generic; the install + persona drive whether this panel renders at all.
+ */
+interface CustomerInvoicesState {
+  invoices: InvoiceDetail[];
+  isLoading: boolean;
+  error: string | null;
+  fetch: (status?: string) => Promise<void>;
+  reset: () => void;
+}
+
+export const useCustomerInvoicesStore = create<CustomerInvoicesState>((set) => ({
+  invoices: [],
+  isLoading: false,
+  error: null,
+
+  fetch: async (status) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.customer.myInvoices({ status, limit: 25 });
+      set({ invoices: res.data, isLoading: false });
+    } catch (err) {
+      set({
+        isLoading: false,
+        error: err instanceof Error ? err.message : "Failed to load invoices",
+      });
+    }
+  },
+
+  reset: () => set({ invoices: [], isLoading: false, error: null }),
+}));
+
+/**
+ * Pure projection: pick out only the invoices that still owe money — what
+ * the customer cares about on the home tile. Stable order: most-recently
+ * created first (server order), then by amountDue desc as a tiebreaker.
+ */
+export function selectOpenInvoices(all: InvoiceDetail[]): InvoiceDetail[] {
+  return [...all]
+    .filter((inv) => inv.amountDue > 0 && inv.status !== "void" && inv.status !== "written_off")
+    .sort((a, b) => {
+      if (a.createdAt !== b.createdAt) {
+        return a.createdAt < b.createdAt ? 1 : -1;
+      }
+      return b.amountDue - a.amountDue;
+    });
+}

--- a/apps/web/app/api/v1/customer/invoices/route.test.ts
+++ b/apps/web/app/api/v1/customer/invoices/route.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for GET /api/v1/customer/invoices — the customer-scoped
+ * "My invoices" endpoint that backs the generic mobile app's customer mode.
+ *
+ * The key contract: a signed-in customer sees ONLY their own account's
+ * invoices, scoped by `CustomerAccount.accountId === user.accountId`.
+ * Workforce auth must be rejected (they have /api/v1/finance/invoices).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockFindMany } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFindMany: vi.fn(),
+}));
+
+vi.mock("@/lib/api/auth-middleware", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/api/auth-middleware")
+  >("@/lib/api/auth-middleware");
+  return {
+    ...actual,
+    requireCustomerAuth: mockAuth,
+  };
+});
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    invoice: {
+      findMany: mockFindMany,
+    },
+  },
+  Prisma: {},
+}));
+
+import { GET } from "./route";
+import { ApiError } from "@/lib/api/error";
+
+const CUSTOMER_AUTH = {
+  user: {
+    id: "u_c1",
+    email: "alice@acme.example",
+    type: "customer" as const,
+    platformRole: null,
+    isSuperuser: false,
+    accountId: "ACC-ACME",
+    accountName: "Acme",
+    contactId: "CON-1",
+  },
+  capabilities: [] as string[],
+  authContext: {
+    principalId: null,
+    platformRole: null,
+    isSuperuser: false,
+    employeeId: null,
+    managerScope: null,
+    grantedCapabilities: [] as string[],
+  },
+};
+
+const SERVER_INVOICE = {
+  id: "INV-1",
+  invoiceRef: "INV-0001",
+  type: "standard",
+  status: "sent",
+  currency: "USD",
+  subtotal: 250,
+  taxAmount: 25,
+  discountAmount: 0,
+  totalAmount: 275,
+  amountPaid: 0,
+  amountDue: 275,
+  dueDate: new Date("2026-07-16"),
+  sentAt: new Date("2026-06-16"),
+  paidAt: null,
+  createdAt: new Date("2026-06-16T22:00:00.000Z"),
+  updatedAt: new Date("2026-06-16T22:00:00.000Z"),
+  account: { id: "ACC-DB-1", name: "Acme HVAC Co" },
+};
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockFindMany.mockReset();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeReq(query = ""): Request {
+  return new Request(`https://example/api/v1/customer/invoices${query}`);
+}
+
+describe("GET /api/v1/customer/invoices", () => {
+  it("rejects unauthenticated callers with 401 via requireCustomerAuth", async () => {
+    mockAuth.mockRejectedValueOnce(
+      new ApiError("UNAUTHENTICATED", "Authentication required", 401),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects a workforce (admin) caller with 403 — they use /finance/invoices", async () => {
+    mockAuth.mockRejectedValueOnce(
+      new ApiError(
+        "FORBIDDEN",
+        "This endpoint requires customer authentication",
+        403,
+      ),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(403);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("scopes the query to the signed-in customer's account.accountId", async () => {
+    mockAuth.mockResolvedValueOnce(CUSTOMER_AUTH);
+    mockFindMany.mockResolvedValueOnce([SERVER_INVOICE]);
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    const call = mockFindMany.mock.calls[0][0];
+    expect(call.where.account).toEqual({ is: { accountId: "ACC-ACME" } });
+    expect(call.orderBy).toEqual({ createdAt: "desc" });
+    // The select must NOT leak internalNotes or other admin-only fields.
+    expect(call.select.internalNotes).toBeUndefined();
+    expect(call.select.payToken).toBeUndefined();
+  });
+
+  it("returns an empty page when the customer has no accountId on session", async () => {
+    mockAuth.mockResolvedValueOnce({
+      ...CUSTOMER_AUTH,
+      user: { ...CUSTOMER_AUTH.user, accountId: null },
+    });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[]; nextCursor: string | null };
+    expect(body.data).toEqual([]);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("forwards the status filter when supplied", async () => {
+    mockAuth.mockResolvedValueOnce(CUSTOMER_AUTH);
+    mockFindMany.mockResolvedValueOnce([]);
+
+    await GET(makeReq("?status=sent"));
+    const call = mockFindMany.mock.calls[0][0];
+    expect(call.where.status).toBe("sent");
+  });
+});

--- a/apps/web/app/api/v1/customer/invoices/route.ts
+++ b/apps/web/app/api/v1/customer/invoices/route.ts
@@ -1,0 +1,76 @@
+// GET /api/v1/customer/invoices — the signed-in customer's own invoices.
+//
+// Customer-scoped view of the finance.invoices list: returns ONLY rows whose
+// CustomerAccount.accountId matches the authenticated user's session
+// accountId. The portal-side admin list at /api/v1/finance/invoices is
+// unchanged (workforce-scoped); this route is the customer half of the
+// generic mobile app's "My invoices" surface.
+//
+// Auth: requireCustomerAuth — a workforce/admin user hitting this returns
+// 403 by design (they use /api/v1/finance/invoices).
+
+import { NextResponse } from "next/server";
+import { prisma, type Prisma } from "@dpf/db";
+import { requireCustomerAuth } from "@/lib/api/auth-middleware";
+import { ApiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { parsePagination, buildPaginatedResponse } from "@/lib/api/pagination";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  try {
+    const { user } = await requireCustomerAuth(request);
+
+    if (!user.accountId) {
+      return apiSuccess(buildPaginatedResponse([], 10));
+    }
+
+    const url = new URL(request.url);
+    const { cursor, limit } = parsePagination(url.searchParams);
+    const statusFilter = url.searchParams.get("status");
+
+    const where: Prisma.InvoiceWhereInput = {
+      account: { is: { accountId: user.accountId } },
+    };
+    if (cursor) {
+      where.id = { lt: cursor };
+    }
+    if (statusFilter) {
+      where.status = statusFilter;
+    }
+
+    const invoices = await prisma.invoice.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit + 1,
+      select: {
+        id: true,
+        invoiceRef: true,
+        type: true,
+        status: true,
+        currency: true,
+        subtotal: true,
+        taxAmount: true,
+        discountAmount: true,
+        totalAmount: true,
+        amountPaid: true,
+        amountDue: true,
+        dueDate: true,
+        sentAt: true,
+        paidAt: true,
+        createdAt: true,
+        updatedAt: true,
+        account: { select: { id: true, name: true } },
+      },
+    });
+
+    return apiSuccess(buildPaginatedResponse(invoices, limit));
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/api-client/src/endpoints/customer.ts
+++ b/packages/api-client/src/endpoints/customer.ts
@@ -3,6 +3,7 @@ import type {
   ContactWithRoles,
   CreateContactRequest,
   CustomerAccount,
+  InvoiceDetail,
   PaginatedResponse,
   SimilarContact,
   UpdateContactRequest,
@@ -58,5 +59,21 @@ export function customerEndpoints(client: DpfClient) {
       client.get<PaginatedResponse<ContactWithRoles>>(
         `/api/v1/customer/contacts?search=${encodeURIComponent(query)}`,
       ),
+
+    /**
+     * "My invoices" for the signed-in customer. Scoped server-side to the
+     * customer's CustomerAccount.accountId via requireCustomerAuth — a
+     * workforce caller hitting this gets 403.
+     */
+    myInvoices: (params?: { cursor?: string; limit?: number; status?: string }) => {
+      const qs = new URLSearchParams();
+      if (params?.cursor) qs.set("cursor", params.cursor);
+      if (params?.limit) qs.set("limit", String(params.limit));
+      if (params?.status) qs.set("status", params.status);
+      const query = qs.toString();
+      return client.get<PaginatedResponse<InvoiceDetail>>(
+        `/api/v1/customer/invoices${query ? `?${query}` : ""}`,
+      );
+    },
   };
 }


### PR DESCRIPTION
## Summary

The **customer** half of the umbrella mobile design — customers signed into a DPF install on the generic app see their own open invoices on Home, with a tap-through to the install's existing in-platform Pay flow. Apple/Google merchant onboarding stays owner-action (App Store 3.1.3(e) physical-service IAP exemption); we open the install's `/pay/<invoiceRef>` URL in the system browser.

Closes out the foundation of both employee (P4, opendigitalproductfactory#2043) and customer (P5, this PR) personas on top of opendigitalproductfactory#2042. With these three the umbrella spec's keystone (install → manifest → mode) drives a real two-sided product.

Spec: [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html) (§7 customer persona, §11 P5).

## Mechanics

- `apps/web/app/api/v1/customer/invoices/route.ts` — `GET` list, gated by `requireCustomerAuth`, scoped server-side to `account.is.accountId === user.accountId`. Workforce callers → 403 by design (they use `/finance/invoices`).
- `packages/api-client/src/endpoints/customer.ts` — `customer.myInvoices()` typed to `PaginatedResponse<InvoiceDetail>`.
- `apps/mobile/src/features/customer-invoices/customer-invoices.store.ts` — zustand store + `selectOpenInvoices` pure projection (drops zero-balance / voided / written-off; most-recent-first, then `amountDue` desc).
- `apps/mobile/src/features/customer-invoices/CustomerInvoicesPanel.tsx` — list of open invoices, each with a Pay button that opens `/pay/<invoiceRef>` on the install.
- `apps/mobile/app/(tabs)/index.tsx` — persona-gated render: when the install manifest resolves `persona.kind === "customer"` Home shows only the customer panel and skips the workforce dashboard fetches that would 403 anyway. Operator/employee/admin Home unchanged.

## Test plan

- [x] `pnpm --filter web exec vitest run app/api/v1/customer/invoices lib/mobile/` — 26/26 (5 new customer/invoices route + existing manifest).
- [x] `pnpm --filter mobile exec jest --testPathPatterns="customer-invoices|invoices|navigation"` — 29/29 (6 new customer-invoices store + existing).
- [x] `pnpm --filter mobile typecheck` — clean.
- [x] `pnpm --filter web typecheck` — clean.

## What's next

1. **Customer booking / "my visits"** — same persona, same pattern. `StorefrontItem` + booking `formSchema` already exist; adds a second tab for the customer.
2. **Server: link `WorkItem` → `CustomerAccount`** (carried from opendigitalproductfactory#2043) so the employee invoice screen pre-fills the customer instead of asking the tech to type the `accountId`.
3. **"Town" super-app (M1)** — `Space[]` switcher + geo-discovery, the 3-businesses-in-one-app community vision. Separate spec: [`2026-06-14-multi-business-town-super-app-design.html`](docs/superpowers/specs/2026-06-14-multi-business-town-super-app-design.html).
4. **P7 store release** — EAS production profiles + TestFlight/Play submit under Arcamanus LLC (owner-action per spec §9).
