### PR TITLE
fix(routing): guard background dimension evals against in-flight pile-up

### DIFF
--- a/apps/web/lib/queue/functions/eval-background.ts
+++ b/apps/web/lib/queue/functions/eval-background.ts
@@ -31,25 +31,30 @@ export const evalBackground = inngest.createFunction(
       return runDimensionEval(endpointId, modelId, userId);
     });
 
-    // Record completion in ScheduledJob for UI visibility
-    await step.run("record-completion", async () => {
-      const { prisma } = await import("@dpf/db");
-      await prisma.scheduledJob.upsert({
-        where: { jobId: `eval-${modelId}` },
-        create: {
-          jobId: `eval-${modelId}`,
-          name: `Eval: ${modelId}`,
-          schedule: "manual",
-          lastRunAt: new Date(),
-          lastStatus: "completed",
-          nextRunAt: null,
-        },
-        update: {
-          lastRunAt: new Date(),
-          lastStatus: "completed",
-        },
+    // BI-C8164664: don't stamp ScheduledJob as completed when the eval was
+    // skipped by the in-flight guard — that would mask the real status of the
+    // last successful eval and make stuck retry loops invisible.
+    if (!result.skipped) {
+      // Record completion in ScheduledJob for UI visibility
+      await step.run("record-completion", async () => {
+        const { prisma } = await import("@dpf/db");
+        await prisma.scheduledJob.upsert({
+          where: { jobId: `eval-${modelId}` },
+          create: {
+            jobId: `eval-${modelId}`,
+            name: `Eval: ${modelId}`,
+            schedule: "manual",
+            lastRunAt: new Date(),
+            lastStatus: "completed",
+            nextRunAt: null,
+          },
+          update: {
+            lastRunAt: new Date(),
+            lastStatus: "completed",
+          },
+        });
       });
-    });
+    }
 
     return result;
   },

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -6,6 +6,10 @@ const evalState = vi.hoisted(() => ({
   profileUpdates: [] as Array<Record<string, unknown>>,
   callCount: 0,
   errorMessage: "The operation was aborted due to timeout",
+  // BI-C8164664: in-flight + reaper guard test fixtures
+  inflightRun: null as { runId: string; startedAt: Date } | null,
+  createCount: 0,
+  reapedCount: 0,
 }));
 
 vi.mock("@/lib/ai-inference", () => {
@@ -38,8 +42,23 @@ vi.mock("@dpf/db", () => ({
       findUnique: vi.fn(async () => ({ authMethod: "none", name: "Local" })),
     },
     endpointTestRun: {
-      create: vi.fn(async () => ({})),
+      // BI-C8164664: serve the recent-in-flight fixture; assert that runs older
+      // than the guard window are reaped rather than re-counted as in-flight.
+      findFirst: vi.fn(async () => evalState.inflightRun),
+      create: vi.fn(async () => {
+        evalState.createCount++;
+        return {};
+      }),
       update: vi.fn(async () => ({})),
+      updateMany: vi.fn(async (args: { where: { startedAt?: { lte?: Date } } }) => {
+        // Test reaper: pretend one stale row was reaped whenever the where clause
+        // includes the `lte` cutoff filter the eval-runner uses.
+        if (args.where?.startedAt?.lte) {
+          evalState.reapedCount++;
+          return { count: 1 };
+        }
+        return { count: 0 };
+      }),
     },
   },
 }));
@@ -207,6 +226,9 @@ describe("runDimensionEval — whole-endpoint short-circuit", () => {
     evalState.profileUpdates.length = 0;
     evalState.callCount = 0;
     evalState.errorMessage = "The operation was aborted due to timeout";
+    evalState.inflightRun = null;
+    evalState.createCount = 0;
+    evalState.reapedCount = 0;
   });
 
   it("stops after the first timed-out probe instead of grinding every test", async () => {
@@ -242,5 +264,64 @@ describe("runDimensionEval — whole-endpoint short-circuit", () => {
       (u) => u.modelStatus === "retired",
     );
     expect(retired).toBe(false);
+  });
+});
+
+// BI-C8164664 — in-flight + recency guard
+//
+// Background: an Inngest scheduler lease error retried ai/eval.run forever,
+// stacking dimension evals against the local LLM until 184 EndpointTestRun rows
+// were stuck in "running" and the model burned its GPU on the golden corpus.
+// These tests pin the guard so the loop cannot recur.
+describe("runDimensionEval — in-flight + recency guard (BI-C8164664)", () => {
+  beforeEach(() => {
+    evalState.profileUpdates.length = 0;
+    evalState.callCount = 0;
+    evalState.errorMessage = "The operation was aborted due to timeout";
+    evalState.inflightRun = null;
+    evalState.createCount = 0;
+    evalState.reapedCount = 0;
+  });
+
+  it("skips when a recent in-flight run exists, without hitting the provider or creating a new row", async () => {
+    evalState.inflightRun = {
+      runId: "DE-INFLIGHT",
+      startedAt: new Date(Date.now() - 30_000), // 30s ago — well inside the 10-min guard
+    };
+
+    const result = await runDimensionEval("local", "docker.io/ai/qwen3.6:latest", "test");
+
+    expect(result.skipped).toBe(true);
+    expect(result.testRunId).toBe("DE-INFLIGHT");
+    expect(evalState.callCount).toBe(0);  // no provider calls — model untouched
+    expect(evalState.createCount).toBe(0); // no new EndpointTestRun row
+  });
+
+  it("returns a structured EvalRunResult on skip so callers can branch on result.skipped", async () => {
+    evalState.inflightRun = {
+      runId: "DE-INFLIGHT",
+      startedAt: new Date(Date.now() - 30_000),
+    };
+
+    const result = await runDimensionEval("local", "docker.io/ai/qwen3.6:latest", "test");
+
+    // Callers (eval-background.ts) MUST be able to detect a skip so they don't
+    // stamp ScheduledJob as completed for an eval that didn't actually run.
+    expect(result.skipped).toBe(true);
+    expect(result.dimensions).toEqual([]);
+    expect(result.hasDrift).toBe(false);
+    expect(result.hasSevereDrift).toBe(false);
+    expect(result.firstError).toMatch(/Skipped.*DE-INFLIGHT/);
+  });
+
+  it("reaps stale 'running' rows and proceeds with a fresh eval when no recent in-flight exists", async () => {
+    // No recent in-flight row, but the reaper still fires unconditionally to
+    // clean up any rows older than the guard window. The eval then proceeds.
+    evalState.inflightRun = null;
+
+    await runDimensionEval("local", "docker.io/ai/qwen3.6:latest", "test");
+
+    expect(evalState.reapedCount).toBe(1); // reaper called with the lte cutoff
+    expect(evalState.createCount).toBe(1); // a fresh EndpointTestRun was created
   });
 });

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -328,7 +328,18 @@ export interface EvalRunResult {
   hasSevereDrift: boolean;
   /** First error message encountered across all tests, if any. Null when all tests succeeded. */
   firstError: string | null;
+  /** True when the eval was short-circuited because another run was already in
+   *  flight for (endpointId, modelId). Callers (e.g. eval-background.ts) should
+   *  not stamp ScheduledJob as completed on a skipped result. */
+  skipped?: true;
 }
+
+/** Maximum age of an in-flight EndpointTestRun before it is reaped as failed
+ *  and a new eval is allowed to start. Tuned to be longer than a healthy full
+ *  dimension eval (~90s for the bundled local model with 7 dimensions × ~10
+ *  tests × <1s each) but short enough that an Inngest function timeout doesn't
+ *  pin the model out of evals for hours. BI-C8164664. */
+const EVAL_INFLIGHT_GUARD_MS = 10 * 60 * 1000;
 
 /**
  * Run a full dimension evaluation for one endpoint/model pair.
@@ -361,6 +372,67 @@ export async function runDimensionEval(
     throw new Error(
       `${provider.name ?? providerId} uses user-delegated OAuth — evals require an API key or service credentials. ` +
       `Connect via a direct API key provider instead.`,
+    );
+  }
+
+  // BI-C8164664: in-flight + recency guard. Without this, Inngest retries (or
+  // any rapid-fire enqueue path — first-boot, page-load checkBundledProviders,
+  // model-discovery refresh) can stack dozens of parallel dimension evals
+  // against the same model. Each eval fires the full golden-test corpus, which
+  // on a local Apple Silicon model runner pins the Metal GPU at 76+ t/s
+  // continuously and creates EndpointTestRun(status="running") rows that may
+  // never complete if the step is cut off mid-eval. Snapshot from the live
+  // investigation: 184 stuck "running" rows in 24h, 0 completions, qwen3.6
+  // serving 364k tasks — pure capability-eval traffic.
+  const guardCutoff = new Date(Date.now() - EVAL_INFLIGHT_GUARD_MS);
+  const inflightRecent = await prisma.endpointTestRun.findFirst({
+    where: {
+      endpointId: providerId,
+      modelId,
+      taskType: "dimension-eval",
+      status: "running",
+      startedAt: { gt: guardCutoff },
+    },
+    select: { runId: true, startedAt: true },
+    orderBy: { startedAt: "desc" },
+  });
+  if (inflightRecent) {
+    console.log(
+      `[eval-runner] Skipping ${providerId}/${modelId}: run ${inflightRecent.runId} already in flight (started ${inflightRecent.startedAt.toISOString()})`,
+    );
+    return {
+      endpointId: providerId,
+      modelId,
+      dimensions: [],
+      testRunId: inflightRecent.runId,
+      hasDrift: false,
+      hasSevereDrift: false,
+      firstError: `Skipped: run ${inflightRecent.runId} already in flight`,
+      skipped: true,
+    };
+  }
+
+  // Reap stale "running" rows older than the guard window so they don't pile
+  // up forever. The most common cause is an Inngest step timeout that cuts the
+  // function off after callProvider() has fired but before the terminal
+  // endpointTestRun.update() runs. Treat these as failed so operators can see
+  // them in the test-run history rather than silently disappearing.
+  const reaped = await prisma.endpointTestRun.updateMany({
+    where: {
+      endpointId: providerId,
+      modelId,
+      taskType: "dimension-eval",
+      status: "running",
+      startedAt: { lte: guardCutoff },
+    },
+    data: {
+      status: "failed",
+      completedAt: new Date(),
+    },
+  });
+  if (reaped.count > 0) {
+    console.warn(
+      `[eval-runner] Reaped ${reaped.count} stale "running" eval run(s) for ${providerId}/${modelId} older than ${EVAL_INFLIGHT_GUARD_MS / 60_000}min`,
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes **BI-C8164664**. Background capability evals (`ai/eval.run`) against the bundled local model runner were piling up `EndpointTestRun` rows stuck in `status="running"` and replaying the golden-test corpus at the model indefinitely, pinning the Apple Silicon Metal GPU continuously with traffic the operator never asked for.

This surfaced from a live investigation: the operator noticed Docker Desktop → Models → Requests scrolling with golden-test prompts they didn't type (the bat-and-ball CRT puzzle, "Create a backlog item titled 'Fix login timeout'", etc.) and the local `llama-server` working hard with "not much going on."

### Evidence captured during investigation
- 184 `EndpointTestRun` rows stuck `running` over 24h, **0 completions**, 6 fresh rows every ~15 min.
- Local `llama-server` served 364k+ tasks; sample showed 83% of time GPU-bound in `ggml_metal_synchronize` — sustained work, not idle.
- `qwen3.6` is a reasoning model, so each tiny golden-test prompt produces a 350–2100 token `<think>` trace — which is why the logs look so busy.
- `docker model ps` idle-unload timer ("5 minutes from now") kept resetting because requests never stopped arriving.

## Root cause

A long operation inside an Inngest step that is killed before its terminal DB write. The eval fires the full golden corpus, but the Inngest step times out before `runDimensionEval` reaches the `EndpointTestRun.update(status)` / `record-completion` writes. The scheduler then retries, and every cron / page-load / first-boot tick re-enqueues another eval — so runs stack up without bound.

## Fix

- `runDimensionEval` short-circuits if an `EndpointTestRun` for the same `(providerId, modelId, dimension-eval)` is already `running` within a 10-minute window — **at most one eval runs at a time** regardless of retry volume.
- It reaps stale `running` rows older than that window (marks them `failed`) so the pile-up self-heals instead of growing forever.
- `EvalRunResult` gains an optional `skipped` flag; `eval-background.ts` skips the `ScheduledJob` completion stamp on a skipped run so a real eval's status isn't masked and stuck loops stay visible.

This makes the eval path **resilient to** the underlying Inngest issues rather than depending on them being fixed.

## Out of scope (tracked separately)
- The self-hosted Inngest `missing envID` capacity-lease error (`inngest/inngest:latest`, `inngest start`, `INNGEST_DEV=0`) — the retry storm amplifying this loop.
- The Inngest step timeout that prevents `runDimensionEval` from reaching its terminal write.

## Testing
- 3 new unit tests pin the guard (skip on recent in-flight, structured skip result, reaper fires).
- `eval-runner.test.ts`: 35/35 pass. Broader routing + queue suite: 172/172 pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)