### PR TITLE
fix: stop local-LLM eval churn — recency cooldown + inngest v1.30.0 pin (BI-C8164664)

### DIFF
--- a/apps/web/lib/actions/endpoint-performance.ts
+++ b/apps/web/lib/actions/endpoint-performance.ts
@@ -167,12 +167,14 @@ export async function triggerDimensionEval(endpointId: string, modelId?: string)
     throw new Error("Running dimension eval requires manage_capabilities permission");
   }
 
+  // Operator-initiated runs always execute — bypass the recency-cooldown guard
+  // (BI-C8164664) so "Run Eval" is never silently a no-op.
   if (modelId) {
     // Fire-and-forget via Inngest — returns immediately to the UI
     const { inngest } = await import("@/lib/queue/inngest-client");
     await inngest.send({
       name: "ai/eval.run",
-      data: { endpointId, modelId, userId },
+      data: { endpointId, modelId, userId, force: true },
     });
 
     return { queued: true, message: "Eval running in background..." };
@@ -187,7 +189,7 @@ export async function triggerDimensionEval(endpointId: string, modelId?: string)
     for (const p of profiles) {
       await inngest.send({
         name: "ai/eval.run",
-        data: { endpointId, modelId: p.modelId, userId },
+        data: { endpointId, modelId: p.modelId, userId, force: true },
       });
     }
     return { queued: true, message: `${profiles.length} eval(s) running in background...` };

--- a/apps/web/lib/queue/functions/eval-background.ts
+++ b/apps/web/lib/queue/functions/eval-background.ts
@@ -24,11 +24,11 @@ export const evalBackground = inngest.createFunction(
     const gate = await gateAtEntry(step);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
-    const { endpointId, modelId, userId } = event.data;
+    const { endpointId, modelId, userId, force } = event.data;
 
     const result = await step.run("run-dimension-eval", async () => {
       const { runDimensionEval } = await import("@/lib/routing/eval-runner");
-      return runDimensionEval(endpointId, modelId, userId);
+      return runDimensionEval(endpointId, modelId, userId, { force: force === true });
     });
 
     // BI-C8164664: don't stamp ScheduledJob as completed when the eval was

--- a/apps/web/lib/queue/inngest-client.ts
+++ b/apps/web/lib/queue/inngest-client.ts
@@ -84,7 +84,12 @@ export interface QualityIssueTriageEvent {
 
 export interface AiEvalRunEvent {
   name: "ai/eval.run";
-  data: { endpointId: string; modelId: string; userId: string };
+  /** force: bypass the recency-cooldown guard in runDimensionEval. Set by the
+   *  operator-initiated "Run Eval" UI action so a manual re-eval always runs;
+   *  left unset on automated enqueue paths (first-boot, page-load
+   *  checkBundledProviders, model-discovery refresh) so a freshly-calibrated
+   *  model isn't re-evaluated on every Inngest retry. BI-C8164664. */
+  data: { endpointId: string; modelId: string; userId: string; force?: boolean };
 }
 
 export interface AiProbeRunEvent {

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -10,6 +10,8 @@ const evalState = vi.hoisted(() => ({
   inflightRun: null as { runId: string; startedAt: Date } | null,
   createCount: 0,
   reapedCount: 0,
+  // BI-C8164664: recency-cooldown fixture
+  lastEvalAt: null as Date | null,
 }));
 
 vi.mock("@/lib/ai-inference", () => {
@@ -32,7 +34,11 @@ vi.mock("@/lib/ai-inference", () => {
 vi.mock("@dpf/db", () => ({
   prisma: {
     modelProfile: {
-      findUnique: vi.fn(async () => ({ evalCount: 0, modelStatus: "active" })),
+      findUnique: vi.fn(async () => ({
+        evalCount: 0,
+        modelStatus: "active",
+        lastEvalAt: evalState.lastEvalAt,
+      })),
       update: vi.fn(async (args: { data: Record<string, unknown> }) => {
         evalState.profileUpdates.push(args.data);
         return {};
@@ -229,6 +235,7 @@ describe("runDimensionEval — whole-endpoint short-circuit", () => {
     evalState.inflightRun = null;
     evalState.createCount = 0;
     evalState.reapedCount = 0;
+    evalState.lastEvalAt = null;
   });
 
   it("stops after the first timed-out probe instead of grinding every test", async () => {
@@ -281,6 +288,7 @@ describe("runDimensionEval — in-flight + recency guard (BI-C8164664)", () => {
     evalState.inflightRun = null;
     evalState.createCount = 0;
     evalState.reapedCount = 0;
+    evalState.lastEvalAt = null;
   });
 
   it("skips when a recent in-flight run exists, without hitting the provider or creating a new row", async () => {
@@ -323,5 +331,65 @@ describe("runDimensionEval — in-flight + recency guard (BI-C8164664)", () => {
 
     expect(evalState.reapedCount).toBe(1); // reaper called with the lte cutoff
     expect(evalState.createCount).toBe(1); // a fresh EndpointTestRun was created
+  });
+});
+
+// BI-C8164664 — recency cooldown
+//
+// The in-flight guard above only spans 10 min. Inngest's lease-failure retries
+// land further apart and would re-run the full golden corpus against an
+// already-calibrated model every cooldown-cycle. The recency cooldown makes
+// those automated retries no-ops at the GPU level while leaving operator-forced
+// runs (force:true) and never-evaluated models unaffected.
+describe("runDimensionEval — recency cooldown (BI-C8164664)", () => {
+  beforeEach(() => {
+    evalState.profileUpdates.length = 0;
+    evalState.callCount = 0;
+    evalState.errorMessage = "The operation was aborted due to timeout";
+    evalState.inflightRun = null;
+    evalState.createCount = 0;
+    evalState.reapedCount = 0;
+    evalState.lastEvalAt = null;
+  });
+
+  it("skips an automated eval when the model was evaluated within the cooldown window", async () => {
+    evalState.lastEvalAt = new Date(Date.now() - 60_000); // 1 min ago
+
+    const result = await runDimensionEval("local", "docker.io/ai/qwen3.6:latest", "system");
+
+    expect(result.skipped).toBe(true);
+    expect(result.firstError).toMatch(/cooldown/i);
+    expect(evalState.callCount).toBe(0);  // model untouched
+    expect(evalState.createCount).toBe(0); // no EndpointTestRun row created
+  });
+
+  it("runs an operator-forced eval even inside the cooldown window", async () => {
+    evalState.lastEvalAt = new Date(Date.now() - 60_000);
+
+    const result = await runDimensionEval(
+      "local",
+      "docker.io/ai/qwen3.6:latest",
+      "operator",
+      { force: true },
+    );
+
+    expect(result.skipped).toBeUndefined(); // not cooldown-skipped
+    expect(evalState.createCount).toBe(1);  // a real run was created
+  });
+
+  it("runs a never-evaluated model (no lastEvalAt) regardless of cooldown", async () => {
+    evalState.lastEvalAt = null;
+
+    await runDimensionEval("local", "docker.io/ai/qwen3.6:latest", "system");
+
+    expect(evalState.createCount).toBe(1);
+  });
+
+  it("runs once the cooldown window has elapsed", async () => {
+    evalState.lastEvalAt = new Date(Date.now() - 7 * 60 * 60 * 1000); // 7h ago (> 6h default)
+
+    await runDimensionEval("local", "docker.io/ai/qwen3.6:latest", "system");
+
+    expect(evalState.createCount).toBe(1);
   });
 });

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -341,14 +341,31 @@ export interface EvalRunResult {
  *  pin the model out of evals for hours. BI-C8164664. */
 const EVAL_INFLIGHT_GUARD_MS = 10 * 60 * 1000;
 
+/** How recently a model must have been evaluated to skip an automated re-eval.
+ *  The in-flight guard above stops PARALLEL pile-up, but it only spans 10min —
+ *  Inngest retries (the upstream `missing envID` lease bug re-queues each event
+ *  up to maxAtts) land spaced further apart and would otherwise re-run the full
+ *  golden-test corpus against an already-calibrated model indefinitely (~15%
+ *  GPU duty cycle observed on the bundled local runner with evalCount=25). A
+ *  recency cooldown makes those retries no-ops at the GPU level while leaving
+ *  the daily model-discovery refresh and operator-forced re-evals unaffected.
+ *  Override with DPF_EVAL_COOLDOWN_MS. BI-C8164664. */
+const EVAL_RECENCY_COOLDOWN_MS = (() => {
+  const raw = Number(process.env.DPF_EVAL_COOLDOWN_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 6 * 60 * 60 * 1000;
+})();
+
 /**
  * Run a full dimension evaluation for one endpoint/model pair.
  * Updates ModelProfile capability scores and creates an EndpointTestRun record.
+ *
+ * @param opts.force bypass the recency-cooldown guard (operator-initiated runs).
  */
 export async function runDimensionEval(
   providerId: string,
   modelId: string,
   triggeredBy: string,
+  opts: { force?: boolean } = {},
 ): Promise<EvalRunResult> {
   const modelProfile = await prisma.modelProfile.findUnique({
     where: { providerId_modelId: { providerId, modelId } },
@@ -373,6 +390,32 @@ export async function runDimensionEval(
       `${provider.name ?? providerId} uses user-delegated OAuth — evals require an API key or service credentials. ` +
       `Connect via a direct API key provider instead.`,
     );
+  }
+
+  // BI-C8164664: recency cooldown. A model that was evaluated within the
+  // cooldown window does not need re-evaluating on an automated path — and
+  // without this guard, Inngest's lease-failure retries re-run the full golden
+  // suite every cooldown-cycle even though scores barely move once calibrated.
+  // Operator-forced runs (opts.force) and never-evaluated models bypass it.
+  if (
+    !opts.force &&
+    EVAL_RECENCY_COOLDOWN_MS > 0 &&
+    modelProfile.lastEvalAt &&
+    Date.now() - modelProfile.lastEvalAt.getTime() < EVAL_RECENCY_COOLDOWN_MS
+  ) {
+    console.log(
+      `[eval-runner] Skipping ${providerId}/${modelId}: evaluated ${modelProfile.lastEvalAt.toISOString()} (within ${EVAL_RECENCY_COOLDOWN_MS / 60_000}min cooldown)`,
+    );
+    return {
+      endpointId: providerId,
+      modelId,
+      dimensions: [],
+      testRunId: "",
+      hasDrift: false,
+      hasSevereDrift: false,
+      firstError: `Skipped: evaluated within cooldown (last ${modelProfile.lastEvalAt.toISOString()})`,
+      skipped: true,
+    };
   }
 
   // BI-C8164664: in-flight + recency guard. Without this, Inngest retries (or


### PR DESCRIPTION
Fixes both root causes behind BI-C8164664 ("Eval-runner background loop burns local LLM GPU after Inngest lease error").

## Symptom
Bundled local LLM (Docker Model Runner, `qwen3.6`) ran continuously while the platform was idle (task counter ~364k→705k over ~5h), `dpf-inngest-1` pinned at ~55% CPU, and **375 `EndpointTestRun` rows stuck `running`** (oldest Jun 9).

## Root cause 1 — infra: Inngest `missing envID` lease regression
`inngest/inngest:latest` had drifted onto **1.26.0**, whose self-hosted `inngest start` mode fails every capacity-lease with `missing envID` (`itemLeaseConstraintCheck`) and retries up to `maxAtts`. Present since first boot (2026-06-09), 99k+ error lines. It spins the scheduler and re-queues every background job — amplifying the dimension evals into continuous GPU load.

**Fix:** pin `docker-compose.yml` to **v1.30.0** (forward fixes: #4400 ErrQueueItemExists retries, #4419 set envid, #4391/#4438 constraint/lease scan). Verified the 1.26→1.30 Postgres goose migration on a throwaway copy of the live inngest DB: clean **v7→v10**, executor boots, no errors. Pinning stops `:latest` from regressing again.

## Root cause 2 — code: uncapped dimension-eval re-runs
[#2046](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2046) added an in-flight guard + reaper (stops *parallel* pile-up). But its 10-min window doesn't stop *periodic* re-eval of an already-calibrated model — retries spaced beyond it replay the full golden corpus indefinitely (~15% GPU duty cycle, `evalCount=25`).

**Fix:** recency cooldown in `runDimensionEval` (default 6h, env `DPF_EVAL_COOLDOWN_MS`). Automated retries become no-ops at the GPU level; the daily refresh still runs; operator "Run Eval" passes `force:true` and is never skipped.

## Changes
- `docker-compose.yml` — pin inngest `:latest` → `v1.30.0`.
- `eval-runner.ts` — recency cooldown guard + `opts.force`.
- `inngest-client.ts` — `AiEvalRunEvent.data.force?`.
- `eval-background.ts` — thread `event.data.force`.
- `endpoint-performance.ts` — manual "Run Eval" sends `force:true`.
- `eval-runner.test.ts` — 4 new cooldown tests.

## Verification
- `vitest run lib/routing/eval-runner.test.ts` → 39 passed (4 new).
- `tsc --noEmit` clean on changed files.
- Inngest forward-migration validated on a throwaway DB copy (no live mutation).

## Follow-up (not in this PR)
- Reap the 375 pre-existing stuck `EndpointTestRun` rows on running installs (the deployed reaper cleans them per-model on the next eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)