### PR TITLE
fix(infra): pin inngest to v1.30.0 — clear missing-envID lease storm (BI-C8164664)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -791,13 +791,13 @@ services:
   # No profile gate — voice ships working on `docker compose up`.
   dpf-stt:
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-06-17 (the prior 4e1d727c… digest was deleted from the
-    # registry — Release Image Manifest Guard caught it, see PR #2041). The
-    # registry owner re-pushes :latest periodically and prunes the previous
-    # index, so this digest must be re-resolved every time the guard fails.
-    # Bump deliberately; never reach for `:latest` in shipped compose because
-    # it makes the install non-reproducible.
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:3f109fa1cfd99d701b9e60a8ef52457630b0711ef2c1ad44d57cd95e25b91b39}
+    # resolved on 2026-06-18 (the prior 3f109fa1… digest was deleted from the
+    # registry — Release Image Manifest Guard caught it again). The registry
+    # owner re-pushes :latest periodically and prunes the previous index, so
+    # this digest must be re-resolved every time the guard fails. Bump
+    # deliberately; never reach for `:latest` in shipped compose because it
+    # makes the install non-reproducible.
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:008ef78e8164be1a52d3c16a0a4702af4190bc355c057e481ceb35af739ab184}
     restart: unless-stopped
     environment:
       # `base` (~145 MB) is the smallest model with usable accuracy on English.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -735,7 +735,16 @@ services:
     # scraping /metrics is the effective health signal.
 
   inngest:
-    image: inngest/inngest:latest
+    # Pinned (was :latest). :latest drifted onto 1.26.0, which has a
+    # self-hosted `inngest start` regression: every queued item fails its
+    # capacity-lease with "missing envID" (itemLeaseConstraintCheck) and
+    # retries up to maxAtts, spinning the scheduler at ~55% CPU and amplifying
+    # every background job (incl. dimension evals → local-LLM GPU churn).
+    # Fixed forward in 1.28/1.29 (#4400 ErrQueueItemExists retries, #4419 set
+    # envid, #4391/#4438 constraint/lease scan). 1.26→1.30 goose migration
+    # validated on a throwaway DB copy (v7→v10, clean). Pin to keep :latest
+    # from silently regressing again. BI-C8164664.
+    image: inngest/inngest:v1.30.0
     restart: unless-stopped
     command: "inngest start"
     ports:

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:4e1d727c2d9a3d2e89e38a8f3fd21fcbdb2398ae2772b9f0fafec7fb662426d8";
-const CURRENT_STT_DIGEST =
   "hwdsl2/whisper-server@sha256:3f109fa1cfd99d701b9e60a8ef52457630b0711ef2c1ad44d57cd95e25b91b39";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:008ef78e8164be1a52d3c16a0a4702af4190bc355c057e481ceb35af739ab184";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
Second half of the BI-C8164664 fix (the recency cooldown landed in #2047). This addresses the **infra root cause**.

## Problem
`inngest/inngest:latest` had drifted onto **1.26.0**, whose self-hosted `inngest start` mode fails every capacity-lease with `missing envID` (`itemLeaseConstraintCheck`) and retries up to `maxAtts`. On the operator install this pinned `dpf-inngest-1` at ~55% CPU and amplified every background job (incl. the dimension evals that burn the local-LLM GPU). Present since first boot (2026-06-09), 99k+ error lines.

## Fix
Pin `docker-compose.yml` to **v1.30.0** and stop using the floating `:latest`. The regression is fixed forward:
- v1.28.0 — `#4400` ErrQueueItemExists unnecessary retries; `#4419` set envid on resync path; `#4394` state-leak fix.
- v1.29.0 — `#4391` track earliest peek before Constraint API; `#4438` ignore already-leased partitions during scan.

## Migration validation (no live mutation)
Dumped the live `inngest` Postgres DB into a throwaway copy and booted v1.30.0 against it with an isolated Redis: forward goose migration **v7→v10** applied cleanly, executor started, zero errors. Forward migration (1.26→1.30) is the supported direction.

## Why pin instead of `:latest`
`:latest` is what silently regressed here. Pinning to a validated version keeps a future upstream change from re-breaking self-hosted installs without review — consistent with addressing the regression by moving *forward* to a fixed version rather than working around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)