### PR TITLE
fix(install): prefetch git tags in build-images.ps1 before version stamp (BI-145214F0)

### DIFF
--- a/scripts/build-images.ps1
+++ b/scripts/build-images.ps1
@@ -48,7 +48,15 @@ if (-not $sha) {
 $env:DPF_VERSION = $sha
 Write-Host "[build-images] Stamping images with DPF_VERSION=$sha"
 
-# Real platform version from the repo's git release tags (e.g. "5.6.0").
+# Real platform version from the repo's git release tags (e.g. "5.6.0" or
+# "5.6.0-35-gbcaa30a8"). This is the authoritative version shown in the portal.
+# BI-145214F0 - refresh tags first so a stale local tag cache doesn't silently
+# bake the wrong release-line label into the image (the DPF_VERSION SHA stamp
+# is unaffected by this; only the human-readable describe). Best-effort: a
+# fetch failure (offline, auth) must not abort the build. Mirrors build-images.sh.
+# try/catch is the PS equivalent of the bash "|| true": under PS 7.4+ a failed
+# native command throws when ErrorActionPreference=Stop, so swallow it here.
+try { git fetch --tags --force origin 2>$null } catch { }
 $platformVersion = (git describe --tags --always 2>$null) -replace '^v',''
 if ($platformVersion) {
   $env:DPF_PLATFORM_VERSION = $platformVersion


### PR DESCRIPTION
## What

Adds `git fetch --tags --force origin` before the `git describe` version stamp in `scripts/build-images.ps1`, the Windows twin of `scripts/build-images.sh`.

## Why (BI-145214F0)

The image-build wrappers stamp `DPF_PLATFORM_VERSION` from `git describe --tags --always`. Without first refreshing tags, a long-running install whose local tag cache stopped at e.g. `v5.6.0` (while upstream cut `v6.0..v6.4`) silently bakes the **wrong release-line label** into the portal image — the operator sees `v5.6.0` even though source is `v6.4.0+`. The `DPF_VERSION` SHA stamp stays honest throughout; only the human-readable `describe` falls back to the nearest old tag and counts every commit forward.

The three bash/install paths already landed this prefetch citing the BI:
- `install-dpf.sh:806`
- `scripts/build-images.sh:31`
- `scripts/promote.sh:109`

This closes the **only remaining gap** — the PowerShell twin was missed — so both canonical surfaces (Windows + macOS/Linux) stay in parity per the AGENTS.md cross-platform rule.

## Notes

- Wrapped in `try { ... } catch { }` — the PowerShell equivalent of bash `|| true`. Under PS 7.4+ with `ErrorActionPreference=Stop`, a failed native command can throw; the catch guarantees a fetch failure (offline, auth) does **not** abort the build, satisfying the BI's acceptance criterion. The `2>$null` suppresses stderr noise.
- Plain ASCII only (PowerShell rule). No TS / migration touched, so unit-test / `next build` / migration gates are N/A; change is a literal mirror of the shipped, reviewed bash line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)