### PR TITLE
fix(infra): rotate hwdsl2/whisper-server pin to the current reachable digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -782,13 +782,13 @@ services:
   # No profile gate — voice ships working on `docker compose up`.
   dpf-stt:
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-06-17 (the prior 4e1d727c… digest was deleted from the
-    # registry — Release Image Manifest Guard caught it, see PR #2041). The
-    # registry owner re-pushes :latest periodically and prunes the previous
-    # index, so this digest must be re-resolved every time the guard fails.
-    # Bump deliberately; never reach for `:latest` in shipped compose because
-    # it makes the install non-reproducible.
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:3f109fa1cfd99d701b9e60a8ef52457630b0711ef2c1ad44d57cd95e25b91b39}
+    # resolved on 2026-06-18 (the prior 3f109fa1… digest was deleted from the
+    # registry — Release Image Manifest Guard caught it again). The registry
+    # owner re-pushes :latest periodically and prunes the previous index, so
+    # this digest must be re-resolved every time the guard fails. Bump
+    # deliberately; never reach for `:latest` in shipped compose because it
+    # makes the install non-reproducible.
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:008ef78e8164be1a52d3c16a0a4702af4190bc355c057e481ceb35af739ab184}
     restart: unless-stopped
     environment:
       # `base` (~145 MB) is the smallest model with usable accuracy on English.

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:4e1d727c2d9a3d2e89e38a8f3fd21fcbdb2398ae2772b9f0fafec7fb662426d8";
-const CURRENT_STT_DIGEST =
   "hwdsl2/whisper-server@sha256:3f109fa1cfd99d701b9e60a8ef52457630b0711ef2c1ad44d57cd95e25b91b39";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:008ef78e8164be1a52d3c16a0a4702af4190bc355c057e481ceb35af739ab184";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
## Summary

Upstream `hwdsl2/whisper-server` owner re-pushed `:latest` on **2026-06-17** and pruned the previous multi-arch index — so `sha256:3f109fa1…` is now `HTTP 404` on `registry-1.docker.io`. Result: the **Release Image Manifest Guard** is failing on every PR opened against main (e.g. [PR #2048 job 82154893819](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/27766592090/job/82154893819?pr=2048)).

This is the rotation the comment in `docker-compose.yml` predicts ("the registry owner re-pushes :latest periodically and prunes the previous index, so this digest must be re-resolved every time the guard fails"). Same shape as the prior cycle's fix (commit `3cc74e7b`).

## Mechanics

- `docker-compose.yml` — `DPF_STT_IMAGE` default bumped from `sha256:3f109fa1…` → `sha256:008ef78e8164be1a52d3c16a0a4702af4190bc355c057e481ceb35af739ab184`. Comment cycles "prior 4e1d727c…" → "prior 3f109fa1…" and the rotation date.
- `tests/release/installer-release-contract.test.mjs` — `RETIRED_STT_DIGEST` advances to `3f109fa1…`, `CURRENT_STT_DIGEST` advances to `008ef78e…`.

The new index resolves to `linux/amd64=523144…` and `linux/arm64=c5da4e2…` — both platforms covered, same as before.

## Verification

- [x] `node tests/release/installer-release-contract.test.mjs` — 14/14 passing locally.
- [x] Direct registry probe with an anonymous pull token: new digest `HTTP 200`, retired digest `HTTP 404`.
- [ ] CI: Release Image Manifest Guard turns green on this PR (and unblocks every other open PR retroactively once merged).

## Follow-up

Per the docker-compose comment, this rotation is expected to recur each time the owner re-pushes `:latest`. A follow-up could automate the resolve step (a workflow that runs the Hub API on a cron and opens a digest-bump PR), but the manual rotation is cheap enough that it isn't in scope here.
