### PR TITLE
docs: worked examples for the WWMD/WWWD/WSID decision gate

### DIFF
--- a/docs/architecture/autonomy-and-wwmd.md
+++ b/docs/architecture/autonomy-and-wwmd.md
@@ -169,6 +169,40 @@ Code references:
 - [`persistDecisionInteraction`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/apps/web/lib/decision-perspective/persistence.ts)
 - [`DecisionInteraction`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/packages/db/prisma/schema.prisma)
 
+## A worked example
+
+The flow above is abstract until you watch a question move through it. Here is a representative WWMD
+run — the numbers illustrate the real `decide()` math (`composite = Σ principle.weight × alignment`),
+they are not a captured transcript.
+
+A `build-specialist` coworker has built an "overdue jobs" widget for an HVAC dispatcher board and hits
+an open product question before shipping: *should this be generalized into the reusable workspace-home
+primitive library for the Hive Mind, or kept local to this install?* (`domainClass:
+architecture-tradeoff`, `riskTier: medium`).
+
+It frames two options and scores each against the principles in scope. Each cell is a contribution
+(`weight × alignment`); the composite is the column sum.
+
+| Principle (tier, weight) | Option A — keep local | Option B — parameterize for the hive |
+|--------------------------|----------------------:|-------------------------------------:|
+| Learnings belong in the shared commons (commandment, 1.0) | +0.10 | **+0.85** |
+| Architecture over shortcuts (core, 0.4) | +0.12 | **+0.32** |
+| Speed to value (contextual, 0.1) | **+0.09** | +0.05 |
+| **Composite** | **0.31** | **1.22** |
+
+Option B wins with `margin = 0.91`, far above the default `tieMargin` of `0.2`, so `confidence` is
+high; `structuredCoverage` is strong and `commandmentConflict` is false. The contextual "ship faster"
+pull toward Option A is genuine, but at weight `0.1` it cannot overcome a commandment-tier reusability
+pull at weight `1.0` — which is exactly what tier weighting is for. The gate returns `recommend`
+Option B with the full contribution ledger; execution and approval still belong to the caller.
+
+The same engine, pointed at a customer's WWWD corpus or a profession's WSID corpus, produces the
+right *kind* of answer for the kind of doubt it faces — an honest `escalate` when an organization
+hasn't authored a policy yet, or a source-cited `recommend` (with a `commandmentConflict` flag on the
+tempting-wrong option) when a profession corpus has crisp doctrine. The user-guide walkthrough runs all
+three scopes end-to-end with their ledger rows: [Decision Perspective in
+Practice](/user-guide/ai-workforce/decision-perspective-in-practice).
+
 ## The learning loop
 
 The most important output is not only the recommendation. It is the gap signal.

--- a/docs/index.html
+++ b/docs/index.html
@@ -935,18 +935,55 @@ bash install-dpf.sh</code></pre>
       </tbody>
     </table>
 
+    <h3 style="margin-top:24px; font-size:16px;">A worked example: one question, scored end-to-end</h3>
+    <p class="sub" style="margin-top:0;">
+      Abstractly, &ldquo;weighted vectors&rdquo; is hard to picture. Concretely, it is a column you can add up. During the Dale HVAC dogfood install, the <code>build-specialist</code> coworker built an &ldquo;overdue jobs&rdquo; widget and hit an open product question before shipping it &mdash; <em>should this be generalized for the Hive Mind, or kept local to one install?</em> The gate framed two options and scored each against the principles in scope. Every cell below is a <em>contribution</em> (<code>tier&nbsp;weight &times; alignment</code>); the composite is the column sum.
+    </p>
+    <table class="guide" style="margin-top:8px;">
+      <thead>
+        <tr>
+          <th style="width:46%;">Principle (tier &middot; weight)</th>
+          <th>Option A &mdash; keep local</th>
+          <th>Option B &mdash; parameterize for the hive</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Learnings belong in the shared commons (<strong>commandment &middot; 1.0</strong>)</td><td>+0.10</td><td><strong>+0.85</strong></td></tr>
+        <tr><td>Architecture over shortcuts (<strong>core &middot; 0.4</strong>)</td><td>+0.12</td><td><strong>+0.32</strong></td></tr>
+        <tr><td>Speed to value (<strong>contextual &middot; 0.1</strong>)</td><td><strong>+0.09</strong></td><td>+0.05</td></tr>
+        <tr><td><strong>Composite</strong></td><td><strong>0.31</strong></td><td><strong>1.22</strong></td></tr>
+      </tbody>
+    </table>
+    <p class="sub" style="margin-top:10px;">
+      Winner <strong>B</strong> by a margin of <strong>0.91</strong> &mdash; far above the tie threshold, so confidence is <em>high</em>. Note what the tiers do: the contextual &ldquo;ship faster&rdquo; pull toward keeping it local is real, but at weight <code>0.1</code> it can never overrule a commandment-tier reusability pull at weight <code>1.0</code>. The gate returns <strong>recommend Option B</strong> with that contribution ledger attached &mdash; the coworker still owns execution and approval. <strong>See the same loop run for an organization business decision (WWWD, which escalates) and a profession craft question (WSID, which blocks the tempting-wrong answer) in the deep dive:</strong> <a href="/user-guide/ai-workforce/decision-perspective-in-practice">Decision Perspective in Practice</a>.
+    </p>
+
     <p class="note">
-      Why this matters: every unanswered or low-confidence WWMD question is a chance to improve the kernel. Over time, repeated human resolutions become reviewed wiki and perspective material, which lets coworkers handle more decisions safely without losing the audit trail. See the deeper architecture note: <a href="/architecture/autonomy-and-wwmd">Autonomy, WWMD, and trusted coworker decisions</a>.
+      Why this matters: every unanswered or low-confidence WWMD question is a chance to improve the kernel. Over time, repeated human resolutions become reviewed wiki and perspective material, which lets coworkers handle more decisions safely without losing the audit trail. See the deeper architecture note: <a href="/architecture/autonomy-and-wwmd">Autonomy, WWMD, and trusted coworker decisions</a>, and the worked walkthrough for all three scopes: <a href="/user-guide/ai-workforce/decision-perspective-in-practice">Decision Perspective in Practice</a>.
     </p>
 
     <h3 style="margin-top:24px; font-size:16px;">The organization corpus (WWWD): your business, not just the founder kernel</h3>
     <p class="sub" style="margin-top:0;">
       WWMD draws on the shared founder-kernel principles. WWWD &mdash; the organization knowledge corpus &mdash; is the org-specific complement: a governed, single-org knowledge base built from onboarding context, uploaded business documents, market Q&amp;A, and approved AI research. Every source &mdash; data entry, document upload, scheduled research, integrations, coverage-gap detection &mdash; flows through one enrichment contract that handles idempotency, provenance, and trust grading (first-party, derived, researched). Material lands <em>draft-by-default</em> regardless of source; human review promotes it to authoritative before it influences anything. Reviewed material projects into the decision profile that feeds the WWMD gate and coworker recall, and a freshness-governance layer supersedes stale material and re-enqueues research when coverage gaps appear.
     </p>
+    <p class="sub" style="margin-top:8px;">
+      <strong>In practice:</strong> a customer asks the <code>customer-advisor</code> coworker to approve net-60 terms instead of the standard net-15 on a $12k job. If the organization hasn&rsquo;t yet encoded a credit-terms policy, the gate finds <em>zero</em> applicable org material &mdash; and the non-inherit boundary means it must <strong>not</strong> borrow DPF&rsquo;s platform doctrine as authority for a customer&rsquo;s business decision. So it <strong>escalates</strong> to the business owner rather than guessing. The owner&rsquo;s resolution is captured as draft WWWD material; once reviewed and promoted, the <em>next</em> such question can resolve with the org&rsquo;s own policy as the cited source. A customer&rsquo;s business judgment is the customer&rsquo;s to author.
+    </p>
 
     <h3 style="margin-top:24px; font-size:16px;">The profession corpus (WSID): what a competent professional in this role should do</h3>
     <p class="sub" style="margin-top:0;">
       WWMD answers <em>&ldquo;what would the founder/platform do?&rdquo;</em> and WWWD answers <em>&ldquo;what would this organization do?&rdquo;</em> &mdash; but a coworker doing a specialist&rsquo;s job also needs a governed source for <em>what a competent professional in that role should do</em>. WSID (&ldquo;What Should I Do?&rdquo;) is the third scope in the same family, reusing the same architecture &mdash; a versioned profile, a source-traced corpus, weighted retrieval, and an audited gate &mdash; but scoped to the <strong>profession</strong> rather than the founder or the org. Each coworker role family gets its own profile (<code>WSID-DATA-ARCHITECT</code>, <code>WSID-FINANCE</code>, <code>WSID-MARKETING</code>, &hellip;) backed by a corpus distilled from <em>fetched, verifiable sources</em> &mdash; DAMA-DMBOK and ANSI SQL and OWASP for a data architect, GAAP and SOX control concepts for finance, the AMA body of knowledge and CAN-SPAM / GDPR consent rules for marketing &mdash; never authored from model memory. When a coworker hits a craft question, the gate resolves against its profession profile first, then falls back through role &rarr; org WWWD &rarr; DPF doctrine &rarr; defer-with-gap-capture. The contract is full-roster: WSID is designed to scope <em>every</em> coworker on the platform, with data-architect, finance, and marketing as the pilot three that prove the pipeline.
+    </p>
+    <p class="sub" style="margin-top:8px;">
+      <strong>In practice:</strong> mid-build, the <code>build-data-architect</code> coworker must choose how to store a money column &mdash; <code>FLOAT</code>, <code>DECIMAL(12,2)</code>, or integer cents. It resolves against the <code>WSID-DATA-ARCHITECT</code> corpus (DAMA-DMBOK, ANSI&nbsp;SQL exact-numeric types) and <strong>recommends <code>DECIMAL</code></strong> with the source pages cited. The interesting part is the guardrail: <code>FLOAT</code> trips a <em>commandment conflict</em> &mdash; a commandment-tier principle contributes strongly negatively to it &mdash; so even if the underlying model were nudged toward <code>FLOAT</code> &ldquo;for performance,&rdquo; the gate flags it as violating professional doctrine. The judgment is source-traced, not LLM folklore.
+    </p>
+
+    <h3 style="margin-top:24px; font-size:16px;">Human-in-the-loop and the immutable decision ledger</h3>
+    <p class="sub" style="margin-top:0;">
+      The four outcomes are not a fixed automation level &mdash; they are inputs to the calling coworker&rsquo;s autonomy policy and HITL tier. Two rules keep this honest rather than theatrical: <strong>high risk overrides confidence</strong> (a <em>high</em> or <em>critical</em> risk tier raises a human surface even when the math looks strong &mdash; that is partly why the WWWD example above escalates), and <strong>HITL tiers bound autonomy independently of the gate</strong> (Tier&nbsp;0 executive oversight through Tier&nbsp;3 informational gate whether a coworker may <em>act</em>; the gate only decides what it <em>recommends</em>). Confidence itself is earned in drops and lost in buckets &mdash; a recommendation made, observed, and human-confirmed raises it slowly; one contradicted or stale rationale pulls it back fast.
+    </p>
+    <p class="sub" style="margin-top:8px;">
+      None of this is trustworthy unless it is reconstructable. <strong>Every</strong> gate call &mdash; <em>recommend</em>, <em>arbitrate</em>, <em>escalate</em>, and even <em>defer</em> &mdash; writes an append-only <code>DecisionInteraction</code> row: the profile and its version, the domain class, the outcome, confidence before/after, the cited sources, the rationale, the resolved profile chain, and whether a human follow-up was captured. Nothing is edited in place &mdash; a profile change snapshots a new version, so an old decision always resolves against the doctrine that was live when it ran. That ledger is one strand of the platform&rsquo;s broader append-only authorization decision log and chain-of-custody traces (principal &rarr; agent &rarr; tool call &rarr; approval &rarr; outcome). Full walkthrough, including ledger fields per scope: <a href="/user-guide/ai-workforce/decision-perspective-in-practice">Decision Perspective in Practice</a>.
     </p>
   </section>
 

--- a/docs/user-guide/ai-workforce/decision-perspective-in-practice.md
+++ b/docs/user-guide/ai-workforce/decision-perspective-in-practice.md
@@ -1,0 +1,279 @@
+---
+title: "Decision Perspective in Practice (WWMD / WWWD / WSID)"
+area: ai-workforce
+order: 6
+lastUpdated: 2026-06-18
+updatedBy: Claude
+---
+
+## What this page adds
+
+The [Decision Perspective & Persona Voice](decision-perspective.md) page describes *what* the
+three decision scopes are. The platform [index](/) and the
+[architecture note](/architecture/autonomy-and-wwmd) describe *how the machinery is wired*. This
+page closes the gap they both leave: it walks a **real question end-to-end through the gate** for
+each scope — the situation, the options the coworker framed, the **decision vectors that were
+scored**, the outcome the gate returned, and the ledger row it wrote — and then shows how
+**human-in-the-loop (HITL)** and the **immutable decision ledger** wrap every one of them.
+
+The three scopes are the same engine pointed at three different bodies of doctrine:
+
+| Scope | Shorthand | Answers | Backed by |
+|-------|-----------|---------|-----------|
+| **WWMD** | *What Would Mark Do?* | "What would the **founder / platform** do here?" | The founder-kernel wiki (tiered principles) |
+| **WWWD** | *What Would We Do?* | "What would **this organization** do here?" | The org's governed knowledge corpus |
+| **WSID** | *What Should I Do?* | "What would a **competent professional in this role** do here?" | A per-profession, source-traced corpus |
+
+All three share the inner scoring engine
+([`apps/web/lib/decision/option-scoring.ts`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/apps/web/lib/decision/option-scoring.ts)),
+the four-outcome contract (`recommend` / `arbitrate` / `escalate` / `defer`), and the same audit
+ledger (`DecisionInteraction`). The worked numbers below are **representative illustrations of the
+real math**, not transcripts of a single captured run — they show how the contribution ledger adds
+up, so you can read a real one.
+
+## Anatomy of one interaction
+
+Every gate call, regardless of scope, runs the same six steps. Keep this picture in mind while
+reading the examples — each example is just this loop with different doctrine loaded.
+
+1. **Retrieve** — `wiki_query` pulls the principles and prior decisions in scope (founder-kernel for
+   WWMD, the org corpus for WWWD, the profession corpus for WSID), by vector search with optional
+   PageRank re-ranking over the wiki link graph.
+2. **Frame options** — the coworker turns the ambiguity into 2–4 concrete options, each with a
+   plain-language description and explicit feature scores on the principle dimension registry
+   (`reusability`, `blast_radius`, `schema_grounding`, `speed_to_value`, …).
+3. **Score** — `principle_decide` computes, for every option × principle pair, an `alignment` in
+   `[-1, 1]`, then a **contribution** = `principle.weight × alignment`. An option's **composite** is
+   the sum of its contributions. Tier sets the weight: **commandment 1.0, core 0.4, contextual 0.1**.
+4. **Guardrails** — the engine flags a close `margin` (→ `confidence: low`), weak structured coverage
+   (too many semantic fallbacks), and `commandmentConflict` (a commandment contributing strongly
+   negatively to the winner). The autonomy policy and risk tier then map the scored result onto one
+   of the four outcomes.
+5. **Outcome** — `recommend` / `arbitrate` / `escalate` / `defer`, with the winning option,
+   composite scores, margin, confidence, and the per-principle contribution ledger.
+6. **Ledger** — a `DecisionInteraction` row records the profile + version, domain class, outcome,
+   confidence before/after, cited sources, rationale, the resolved profile chain, and whether a human
+   escalation or deferral follow-up was captured.
+
+---
+
+## Example 1 — WWMD: generalize for the hive, or keep it local?
+
+**Situation.** During the Dale HVAC dogfood install, the `build-specialist` coworker has just built an
+"overdue jobs" widget for the dispatcher board. Before it ships, it hits an open product question
+that code can't answer deterministically.
+
+**Question (`domainClass: architecture-tradeoff`, `riskTier: medium`).**
+> Should the overdue-jobs widget be generalized into the reusable workspace-home primitive library
+> (parameterized for any archetype) and offered to the Hive Mind, or kept local to this HVAC install?
+
+**Options framed.**
+
+- **A — Keep local.** Hard-code HVAC vocabulary and ship today. Fast, but the next install rebuilds it.
+- **B — Parameterize for the hive.** Lift it into the primitive library behind the projection service
+  so trades, clinics, and retail all inherit it. Slower now, compounding later.
+
+**Decision vectors scored.** Three principles were in scope. Each cell is a *contribution*
+(`weight × alignment`); the composite is the column sum.
+
+| Principle (tier · weight) | What it pulls on | Option A contribution | Option B contribution |
+|---|---|---:|---:|
+| Learnings belong in the shared commons (**commandment · 1.0**) | `reusability`, `operational_independence` | +0.10 | **+0.85** |
+| Architecture over shortcuts (**core · 0.4**) | `long_term_maintainability`, `blast_radius` | +0.12 | **+0.32** |
+| Speed to value (**contextual · 0.1**) | `speed_to_value` | **+0.09** | +0.05 |
+| **Composite** | | **0.31** | **1.22** |
+
+**Result.** Winner **B**, `margin = 0.91` (well above the `0.2` tie threshold → `confidence: high`),
+`structuredCoverage: strong`, `commandmentConflict: false`. The contextual "ship faster" pull is real
+but, at weight `0.1`, never overcomes a commandment-tier reusability pull at weight `1.0` — which is
+exactly the point of tier weighting.
+
+> **Outcome: `recommend` Option B.** Rationale: *"Parameterizing for the hive is favored by the
+> commandment-tier commons principle and the core maintainability principle; the only pull toward
+> keeping it local is contextual speed-to-value, which is outweighed."* The coworker still owns
+> execution and approval — `recommend` advises, it does not act.
+
+This is the **autonomy flywheel** in one frame: the answer is not a vibe, it is a column sum you can
+audit, and the reusability win is what feeds the next install for free.
+
+---
+
+## Example 2 — WWWD: a customer asks for terms the org hasn't decided yet
+
+**Situation.** On a customer install, the `customer-advisor` coworker is handling a commercial account.
+WWWD here is the **organization's** scope, not the platform's — and the non-inherit boundary is
+load-bearing: the org may not have encoded a policy yet, and the platform must **not** invent one for
+it.
+
+**Question (`domainClass: risk-assessment`, `riskTier: high`).**
+> A repeat commercial customer wants net-60 payment terms instead of our standard net-15 on a $12k
+> job. Approve, counter, or decline?
+
+**Options framed.** A — Approve net-60. B — Counter at net-30 with a deposit. C — Decline, hold net-15.
+
+**Decision vectors scored.** The gate retrieves against the org's WWWD corpus and finds it thin: the
+organization has onboarding context and a storefront, but **no approved credit-terms or
+accounts-receivable-risk material**. The only doctrine that *would* match is DPF platform product
+guidance — which, by the non-inherit boundary, is **advisory only and cannot be authoritative for a
+customer's business decision**.
+
+| Signal | Value | Effect |
+|---|---|---|
+| Applicable org (WWWD) materials | 0 promoted, 0 approved | `coverageGap: true` |
+| Resolved profile chain | `[WWWD-ORG → DPF-doctrine(advisory) → defer]` | platform judgment not borrowed as authority |
+| Confidence | low | below the autonomy policy's recommendation floor |
+| Risk tier | high | high risk forces a human resolver regardless |
+
+**Result.** The gate will not fabricate a credit policy from the founder kernel, and it will not let a
+high-risk financial commitment ride on low confidence.
+
+> **Outcome: `escalate`** to the business owner via the **owner/operator review queue**, with
+> `gapReason: no-applicable-material`. The work pauses; an approval surface is raised showing the
+> three framed options and the empty-coverage explanation. If the org never wants the coworker to
+> decide this class at all, the same surface is where they say so.
+
+**The learning loop closes the gap.** When the owner resolves it ("net-30 with a 25% deposit for
+accounts over 12 months old"), that resolution is captured as **draft** WWWD material. Once an owner
+reviews and promotes it, the *next* time this question arises the gate retrieves real org doctrine,
+scores it, and can return `recommend` with the org's own policy as the cited source — and the ledger
+shows the profile version that made each decision, so the two interactions never look identical.
+
+This example is the whole reason WWMD and WWWD are separate scopes: **a customer's business judgment
+is the customer's to author**, and until they author it the honest answer is "escalate," not a guess
+dressed up as confidence.
+
+---
+
+## Example 3 — WSID: what a competent data architect would do
+
+**Situation.** Inside a Build Studio build, the `build-data-architect` coworker is adding an `Invoice`
+table. It hits a craft question with a well-established professional answer — the kind of thing the
+underlying LLM might get right *or* might improvise. WSID makes the answer **source-traced** instead.
+
+**Question (`domainClass: professional-practice`, `riskTier: medium`).**
+> The invoices table needs a monetary `amount` column. Store it as `FLOAT`, `DECIMAL(12,2)`, or
+> integer cents?
+
+**Options framed.** A — `FLOAT`. B — `DECIMAL(12,2)`. C — integer cents (`BIGINT`).
+
+**Decision vectors scored.** The gate resolves against the **`WSID-DATA-ARCHITECT`** profession profile
+*first*, whose corpus is distilled from fetched, verifiable sources (DAMA-DMBOK2 on data quality,
+ISO/IEC 9075 / ANSI SQL on exact numeric types). Contributions (`weight × alignment`):
+
+| Profession principle (tier · weight) | Source | A `FLOAT` | B `DECIMAL` | C cents |
+|---|---|---:|---:|---:|
+| Use exact numeric types for money (**commandment · 1.0**) | ISO/IEC 9075 §exact numeric | **−0.90** | +0.95 | +0.90 |
+| Preserve precision across arithmetic (**core · 0.4**) | DAMA-DMBOK data quality | −0.32 | +0.36 | +0.34 |
+| Minimize application-layer conversion (**contextual · 0.1**) | corpus heuristic | +0.05 | +0.09 | −0.06 |
+| **Composite** | | **−1.17** | **1.40** | **1.18** |
+
+**Result.** Winner **B** (`DECIMAL(12,2)`), with **C** a close second (`margin = 0.22`, just over the
+threshold → `confidence: high` but narrow). Critically, **`FLOAT` triggers `commandmentConflict`**: a
+commandment-tier principle contributes strongly negatively (`−0.90`) to it, so even if a prompt nudged
+the model toward `FLOAT` "for performance," the gate flags it as violating professional doctrine.
+
+> **Outcome: `recommend` Option B**, with the cited corpus pages attached so a reviewer sees *why*:
+> "exact numeric type for currency (ANSI SQL); integer cents is an acceptable alternative." The
+> rationale is grounded in fetched sources, **not** model memory — which is the entire WSID value
+> proposition.
+
+If the profession corpus had **no** material on the question, the gate would fall back through
+`role → org WWWD → DPF doctrine (advisory) → defer-with-gap-capture` — the same auditable chain you
+saw escalate in Example 2.
+
+---
+
+## Human-in-the-loop: where a person enters each path
+
+The four outcomes are not a fixed automation level; they are inputs to the **autonomy policy** and the
+**HITL tier** for the calling coworker. The two work together:
+
+| Outcome | Default human involvement | Governed by |
+|---|---|---|
+| `recommend` | Coworker proceeds; the recommendation is logged and remains reversible. The caller still owns approval of any *action* the recommendation implies. | Tool grants + action approval envelope |
+| `arbitrate` | Allowed **only** for low-risk decisions above the policy's confidence floor; otherwise treated as `escalate`. | `DecisionAutonomyPolicy.maxRiskForArbitration` + confidence floors |
+| `escalate` | Work pauses; an approval surface is raised to the right resolver (founder review for WWMD, owner/operator review for WWWD). | HITL tier + resolver rule |
+| `defer` | No guess is made; the unanswered question is captured as a **profile gap** for curation. | Review queue + enrichment pipeline |
+
+Two rules make this trustworthy rather than theatrical:
+
+- **High risk overrides confidence.** A `high` or `critical` risk tier raises a human surface even when
+  the math looks strong — Example 2 escalated partly for this reason. Autonomy is earned per risk tier,
+  not granted globally.
+- **HITL tiers bound autonomy independently of the gate.** Tier 0 (executive oversight) through Tier 3
+  (informational) gate *whether the coworker may act at all*; the Decision Perspective outcome only
+  decides *what the coworker recommends doing*. A Tier-1 coworker with a `recommend` outcome still
+  routes its resulting action through manager approval. See
+  [authority and audit](/user-guide/platform/authority-and-audit) and the AI Workforce
+  [Authority tab](/user-guide/ai-workforce/).
+
+The **confidence model** is what lets the human surface appear less often over time without lowering the
+bar: *confidence is earned in drops and lost in buckets.* A recommendation that is made, observed, and
+human-confirmed nudges the profile's confidence for that domain up slowly; one contradicted or stale
+rationale pulls it back fast.
+
+## The immutable decision ledger
+
+None of the above is trustworthy unless it is **reconstructable after the fact**. Every gate call —
+`recommend`, `arbitrate`, `escalate`, *and* `defer` — writes an append-only `DecisionInteraction` row.
+Nothing is edited in place: a profile change snapshots a **new version**, so an old interaction always
+resolves against the doctrine that was actually live when it ran.
+
+A single ledger row carries enough to answer "what perspective governed this decision, and on what
+evidence?":
+
+| Field | Example 1 (WWMD) | Example 2 (WWWD) | Example 3 (WSID) |
+|---|---|---|---|
+| `profileId` + `profileVersionId` | Mark / DPF Platform · v-N | Customer org · v-N | `WSID-DATA-ARCHITECT` · v-N |
+| `domainClass` | architecture-tradeoff | risk-assessment | professional-practice |
+| `outcomeType` | recommend | escalate | recommend |
+| `confidenceScore` | high (margin 0.91) | low | high (margin 0.22) |
+| `resolvedProfileChain` | platform | org → doctrine → defer | profession → … |
+| `sources` | commons + architecture principles | (empty — coverage gap) | ANSI SQL + DMBOK pages |
+| `rationale` | top-contributor summary | empty-coverage explanation | source-cited summary |
+| `escalationCaptured` / `deferralCaptured` | — | escalation captured | — |
+
+This ledger is one strand of the platform's broader **append-only authorization decision log and
+chain-of-custody traces**, which link principal → agent → tool call → approval → outcome for *any*
+governed action, not just gate calls (see the
+[Observability & evidence](/) section of the overview and
+[authority and audit](/user-guide/platform/authority-and-audit)). The operator-facing projections of a
+gate decision are:
+
+- **Decision Canvas** — a read view of one `DecisionInteraction`: the question, options, recommendation
+  or deferral, confidence, which materials pulled the result, and the next action — without leaking
+  internal tool names.
+- **Material Backlinks** — the bounded neighborhood of a cited principle: related stances, heuristics,
+  citations, and prior decisions (approved/promoted material only).
+- **Review queues** — unresolved `escalate`/`defer` decisions grouped by gap reason; founder-review
+  wording for WWMD, owner/operator wording for WWWD.
+- **Operations Map** — decision-pressure overlays, so a rising escalation rate on one profile is visible
+  next to cost pressure.
+
+## How the three examples relate
+
+Read together, the trio shows the same engine producing the *right kind* of answer for the *kind of
+doubt* it faces:
+
+- **WWMD** had strong, tiered platform doctrine → confident `recommend`, and the reusability win feeds
+  the hive.
+- **WWWD** had a genuine coverage gap and a high-risk business call → honest `escalate`, because a
+  customer's business judgment is the customer's to author and the platform refuses to borrow its own
+  doctrine as authority.
+- **WSID** had crisp professional doctrine with a commandment that actively *blocked* the tempting-wrong
+  option → source-traced `recommend` with a `commandmentConflict` flag on `FLOAT`.
+
+In all three, the human is in the loop at exactly the point where judgment is genuinely required, and
+the ledger makes every path — including the ones where the platform chose *not* to decide —
+reconstructable.
+
+## Related reading
+
+- [Decision Perspective & Persona Voice](decision-perspective.md) — the capability reference (profile
+  kinds, inheritance chain, voice layer)
+- [Autonomy, WWMD, and trusted coworker decisions](/architecture/autonomy-and-wwmd) — the architecture
+  note and code references
+- [Authority and audit](/user-guide/platform/authority-and-audit) — HITL tiers, tool grants, and the
+  authorization decision log
+- Specs: `docs/superpowers/specs/2026-05-17-wwmd-decision-perspective-kernel-design.md`,
+  `docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md`

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -17,6 +17,11 @@ The naming: **WWMD** is "What Would Mark Do" — the first profile, seeded for t
 
 There is a third scope in the same family. **WSID** is "What Should I Do" — the *profession* profile. Where WWMD encodes founder/platform doctrine and WWWD encodes organization doctrine, WSID encodes what a competent professional in a given role should do. Each coworker role family gets its own profile (`WSID-DATA-ARCHITECT`, `WSID-FINANCE`, `WSID-MARKETING`, …) backed by a source-traced professional corpus, reusing the same profile + corpus + retrieval + gate architecture. See [The Profession Scope (WSID)](#the-profession-scope-wsid) below.
 
+> **Want to see it work, not just read what it is?** [Decision Perspective in
+> Practice](decision-perspective-in-practice.md) walks a real question end-to-end through the gate for
+> each scope (WWMD / WWWD / WSID) — the options framed, the decision vectors scored, the outcome
+> returned, and the ledger row written — plus how HITL and the immutable ledger wrap every one.
+
 The full design lives in three specs:
 
 - `docs/superpowers/specs/2026-05-17-wwmd-decision-perspective-kernel-design.md` — the kernel


### PR DESCRIPTION
## Why

The index overview and the `autonomy-and-wwmd` architecture note explain the Decision Perspective mechanism (weighted principle vectors, four outcomes, the ledger) but never show a **concrete question flowing through it**, nor connect it to human-in-the-loop and the immutable log in practice. The page is a good overview with no real-world context — this PR closes that gap.

## What changed

- **New deep-dive — `docs/user-guide/ai-workforce/decision-perspective-in-practice.md`.** Runs a real question end-to-end through the gate for each scope, with decision-vector **contribution tables grounded in the actual `decide()` math** (`composite = Σ tier-weight × alignment`, tier weights 1.0 / 0.4 / 0.1):
  - **WWMD** — generalize-for-hive vs keep-local → `recommend`, showing how a commandment-tier pull outweighs a contextual one.
  - **WWWD** — a customer asking for non-standard payment terms an org hasn't policy'd yet → `escalate` on a coverage gap, demonstrating the non-inherit boundary (the platform won't borrow its own doctrine as authority for a customer's business call) and the learning loop that closes the gap.
  - **WSID** — `FLOAT` vs `DECIMAL` vs integer cents → source-cited `recommend`, with `FLOAT` tripping a `commandmentConflict` guardrail.
  - Plus an **anatomy of an interaction** primer, a **HITL** section (autonomy policy, risk-overrides-confidence, HITL tiers, the confidence model), and an **immutable decision ledger** section with the per-scope `DecisionInteraction` field table.
- **`index.html` autonomy section** — added the worked WWMD scoring table, concrete WWWD/WSID "in practice" examples, and a *Human-in-the-loop and the immutable decision ledger* subsection, all linking to the deep dive.
- **`autonomy-and-wwmd.md`** — added a worked example grounded in the engine math and cross-linked the walkthrough.
- **`decision-perspective.md`** — cross-linked the new page.

All numbers are clearly framed as representative illustrations of the real math, not captured transcripts. Field names, tier weights, the four outcomes, the `commandmentConflict`/`margin`/`tieMargin` guardrails, and the inheritance chain are grounded in `apps/web/lib/decision/option-scoring.ts` and `apps/web/lib/decision-perspective/types.ts`.

## Verification

Docs-only change. HTML tag balance verified (section/table/thead/tbody all balanced); all internal link targets confirmed to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TexkwJUYdMnuWHSgbWJhoA)_