### PR TITLE
doc: reframe agent dev environments around client apps + local settings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Entry points for people using the platform day-to-day:
 - [Getting Started](user-guide/getting-started/index.md) — what the platform does, how navigation works, and where your AI coworker lives.
 - [Developer Setup](user-guide/getting-started/developer-setup.md) — running the codebase locally with pnpm + Docker sidecars.
 - [Dev Container Setup](user-guide/getting-started/dev-container.md) — fully containerized alternative that needs only Docker Desktop and VS Code.
-- [Agent CLI Development Environments](user-guide/getting-started/agent-dev-environments.md) — set up Claude Code, Codex, and Grok as governed CLI coding agents, and run multiple concurrent threads (worktrees) without breaking the portal's processes.
+- [Agent Development Environments](user-guide/getting-started/agent-dev-environments.md) — set up Claude, Codex, and Grok (desktop apps or CLI) as governed coding agents: MCP, the skill pack, AGENTS.md, local client settings, and running multiple concurrent threads without breaking the portal's processes.
 - [Development Workspace](user-guide/development-workspace.md) — how Build Studio, VS Code, policy states, and validation environments fit together.
 - [AI Coworker](user-guide/getting-started/ai-coworker.md) — working with the context-aware AI assistant on every screen.
 - [Roles & Access](user-guide/getting-started/roles-and-access.md) — platform roles and what each one can do.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1352,7 +1352,7 @@ bash install-dpf.sh</code></pre>
         <tr><td>AI coworker</td><td><a href="/user-guide/getting-started/ai-coworker">getting-started/ai-coworker</a></td></tr>
         <tr><td>Roles &amp; access</td><td><a href="/user-guide/getting-started/roles-and-access">getting-started/roles-and-access</a></td></tr>
         <tr><td>Development workspace</td><td><a href="/user-guide/development-workspace">user-guide/development-workspace</a></td></tr>
-        <tr><td>Agent CLI dev environments (Claude, Codex, Grok)</td><td><a href="/user-guide/getting-started/agent-dev-environments">getting-started/agent-dev-environments</a></td></tr>
+        <tr><td>Agent dev environments (Claude, Codex, Grok)</td><td><a href="/user-guide/getting-started/agent-dev-environments">getting-started/agent-dev-environments</a></td></tr>
         <tr><td>AI workforce &amp; providers</td><td><a href="/user-guide/ai-workforce/">user-guide/ai-workforce</a></td></tr>
         <tr><td>Build Studio</td><td><a href="/user-guide/build-studio/">user-guide/build-studio</a></td></tr>
         <tr><td>Compliance</td><td><a href="/user-guide/compliance/">user-guide/compliance</a></td></tr>

--- a/docs/user-guide/development-workspace.md
+++ b/docs/user-guide/development-workspace.md
@@ -166,4 +166,4 @@ flowchart TD
 
 - [Build Studio](build-studio/index)
 - [Build Studio Sandbox](build-studio/sandbox)
-- [Agent CLI Development Environments](getting-started/agent-dev-environments) — Claude Code, Codex, and Grok as governed CLI coding agents, and managing multiple concurrent threads
+- [Agent Development Environments](getting-started/agent-dev-environments) — Claude, Codex, and Grok (desktop apps or CLI) as governed coding agents: MCP, skill pack, AGENTS.md, local settings, and managing multiple concurrent threads

--- a/docs/user-guide/getting-started/agent-dev-environments.md
+++ b/docs/user-guide/getting-started/agent-dev-environments.md
@@ -1,51 +1,59 @@
 ---
-title: "Agent CLI Development Environments — Claude Code, Codex, Grok"
+title: "Agent Development Environments — Claude, Codex, Grok"
 area: getting-started
 order: 7
 lastUpdated: 2026-06-18
 updatedBy: Claude (Opus 4.8)
 ---
 
-## Agent CLI Development Environments — Claude Code, Codex, Grok
+## Agent Development Environments — Claude, Codex, Grok
 
-This guide is for contributors who want to develop the platform with a **command-line AI coding agent** — Claude Code, the Codex CLI, or the Grok CLI — instead of (or alongside) the in-portal **Build Studio**. All three are first-class, peer delivery surfaces: none is privileged, and all three advance the *same* evidence-gated lifecycle the portal enforces. Where Build Studio is the guided, governed authoring surface, the CLI agents are the more advanced surface — they let an experienced contributor run **multiple concurrent threads of work** (one branch and one git worktree per thread) while still adhering to every process the portal establishes.
+This guide is for contributors who want to develop the platform with a **dedicated AI coding agent** — Claude, Codex, or Grok — instead of (or alongside) the in-portal **Build Studio**. Each agent ships in more than one form, and **all of them are valid options**:
 
-If you only want the guided experience, use [Build Studio](build-studio/index) and stop here. If you want to run several streams of work in parallel from the terminal, read on.
+| Agent | Available as | Notes |
+| ----- | ------------ | ----- |
+| **Claude** | Desktop app (Mac/Windows), IDE extension (VS Code / JetBrains), **or** CLI (Claude Code) | Use whichever client you prefer; they share the same `~/.claude` config |
+| **Codex** | Desktop / IDE client app **or** CLI | Both read the same `~/.codex/config.toml` |
+| **Grok** | **CLI only** | No GUI client yet — the Grok CLI is the only surface today |
 
-> **One process, three surfaces.** Claude Code, Codex CLI, and Build Studio are interchangeable adapters behind one contract: the evidence-gated lifecycle (`ideate → plan → build → review → ship`), the DPF MCP coordination plane, and the worktree/lease isolation model. Governance reads the *evidence*, never *which surface produced it*. See the [Unified Delivery Surfaces spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-06-05-unified-delivery-surfaces-execution-alignment-design.md) for the canonical decisions.
+Whether you run the **desktop app** or the **CLI**, the DPF setup is the same: connect the **DPF MCP server**, load the **`dpf-platform` skill pack** and the **AGENTS.md** operating doctrine, and adjust a few **local client settings** so the agent follows the portal's processes. These agents are the more advanced surface — they let an experienced contributor run **multiple concurrent threads of work** (one branch and one git worktree per thread) while still adhering to every process the portal establishes.
+
+If you only want the guided experience, use [Build Studio](build-studio/index) and stop here. If you want to drive the platform from a full agent client, read on.
+
+> **One process, three surfaces.** Claude, Codex, and Build Studio are interchangeable adapters behind one contract: the evidence-gated lifecycle (`ideate → plan → build → review → ship`), the DPF MCP coordination plane, and the worktree/lease isolation model. Governance reads the *evidence*, never *which surface produced it*. See the [Unified Delivery Surfaces spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-06-05-unified-delivery-surfaces-execution-alignment-design.md).
 
 ---
 
-### Why a CLI agent instead of Build Studio?
+### Why a dedicated agent client instead of Build Studio?
 
-| | Build Studio (in-portal) | CLI agents (Claude / Codex / Grok) |
+| | Build Studio (in-portal) | Agent clients (Claude / Codex / Grok) |
 | --- | --- | --- |
-| Audience | Non-technical operators; guided authoring | Experienced contributors comfortable with git + terminals |
+| Audience | Non-technical operators; guided authoring | Experienced contributors comfortable with git |
 | Concurrency | One guided build at a time per operator | **Many concurrent threads** — one branch + one worktree each |
 | Source access | Governed, abstracted | Direct source edits, debugging, arbitrary tooling |
 | Same governance? | **Yes** — identical gates, MCP coordination, PR/DCO, evidence | **Yes** — identical gates, MCP coordination, PR/DCO, evidence |
 
-The headline advantage of the CLI surfaces is **thread management**. You can have several worktrees open — each on its own branch, each with its own isolated Docker Compose project — and an agent driving each one, without their working trees, container names, or HEADs colliding. The rest of this guide is mostly about doing that *without* breaking the processes the portal depends on.
+The headline advantage is **thread management**: several worktrees open at once, each on its own branch and its own isolated Docker Compose project, without their working trees, container names, or HEADs colliding. The rest of this guide is mostly about doing that *without* breaking the processes the portal depends on.
 
 ---
 
 ### Prerequisites
 
-You need the base developer environment first — see [Developer Setup](developer-setup) (pnpm + Docker sidecars) or the [Dev Container Setup](dev-container). Then install **at least one** agent CLI:
+You need the base developer environment first — see [Developer Setup](developer-setup) (pnpm + Docker sidecars) or the [Dev Container Setup](dev-container). Then install **at least one** agent client:
 
-| Agent | Install | Local config it uses |
-| ----- | ------- | -------------------- |
-| **Claude Code** | [code.claude.com/docs](https://code.claude.com/docs) | `~/.claude/` (plugins, settings, projects/memory) |
-| **Codex CLI** | [developers.openai.com/codex](https://developers.openai.com/codex) | `~/.codex/config.toml`, `~/.codex/auth.json` |
-| **Grok CLI** | xAI Grok Build CLI (`grok`) | `~/.grok/config.toml`, `~/.grok/auth.json` |
+| Agent | Where to get it |
+| ----- | --------------- |
+| **Claude** (desktop app, IDE extension, or Claude Code CLI) | [code.claude.com/docs](https://code.claude.com/docs) |
+| **Codex** (desktop/IDE app or CLI) | [developers.openai.com/codex](https://developers.openai.com/codex) |
+| **Grok** (CLI — no GUI yet) | xAI Grok Build CLI (`grok`) |
 
-You do not have to install all three. The setup is symmetric, so you can add another later and re-run the bootstrap — it converges whatever is present and skips what is not.
+You do not have to install all three, or pick one form over another. The setup is symmetric: install whatever you like, run the bootstrap, and add more later by re-running it.
 
 ---
 
-### One command sets everything up
+### Step 1 — Wire MCP, the skill pack, and AGENTS.md (one command)
 
-From the repo root, run the **agent toolchain bootstrap**. It is the single, client-agnostic entry point that wires Claude Code, Codex, and Grok to DPF in one pass:
+From the repo root, run the **agent toolchain bootstrap**. It is the single, client-agnostic entry point that connects every installed client — desktop app or CLI — to DPF in one pass:
 
 ```bash
 # macOS / Linux
@@ -55,73 +63,94 @@ bash scripts/dpf-bootstrap-agent-toolchain.sh
 .\scripts\dpf-bootstrap-agent-toolchain.ps1
 ```
 
-The bootstrap is **idempotent** — re-running on a converged install is a no-op — and it detects, plans, and applies for all three clients from one place. It:
+The bootstrap is **idempotent** (re-running on a converged install is a no-op) and writes the **shared client configuration that both the desktop app and the CLI read** (`~/.claude`, `~/.codex/config.toml`, `~/.grok/config.toml`). It:
 
-1. **Detects** which of Claude Code / Codex / Grok are installed (resolving GUI-app and non-PATH install locations, not just `which`).
-2. **Mints and persists a DPF MCP token** if one isn't present (issued inside the portal container, persisted to `~/.dpf/agent-toolchain.env` and your shell profile, never logged). Default scope is `write` so the agent can use side-effecting MCP tools (backlog, evidence, Build Studio handoff).
-3. **Wires each client** to the `dpf-platform` skill pack and the DPF MCP server:
-   - **Claude Code** — installs the `dpf-platform` plugin from the repo-local marketplace.
-   - **Codex** — upserts a `[plugins."dpf-platform"]` block and `[mcp_servers.dpf]` into `~/.codex/config.toml`, preserving all your other config byte-for-byte.
-   - **Grok** — writes the DPF MCP server block into `~/.grok/config.toml`.
-4. **Seeds kernel-tier memory** — projects the turn-one kernel principles into your contributor memory so the agent is kernel-aware from the first turn (before any MCP retrieval round-trip).
-5. **Runs read-only MCP + kernel smoke probes** and prints a **single readiness banner** — no substrate names, no command snippets in the normal output.
+1. **Detects** which of Claude / Codex / Grok are installed — resolving GUI-app and non-PATH install locations, not just `which`.
+2. **Mints and persists a DPF MCP token** if one isn't present (issued inside the portal container, persisted to `~/.dpf/agent-toolchain.env` and your shell profile, never logged). Default scope is `write` so the agent can use side-effecting MCP tools (backlog, evidence, Build Studio handoff). On macOS it also injects the token via `launchctl` so GUI-launched apps — which don't read your shell profile — still pick it up.
+3. **Connects the DPF MCP server** in each client (`.mcp.json` / `.vscode/mcp.json` for Claude, `[mcp_servers.dpf]` in Codex/Grok config), all referencing `${DPF_MCP_BEARER_TOKEN}`.
+4. **Installs the `dpf-platform` skill pack** for each client (the kernel-principle-enforcing skills — worktree-per-session, evidence-before-diagnosis, pr-with-dco, etc.).
+5. **Seeds kernel-tier memory** so the agent is kernel-aware from the first turn, before any MCP retrieval round-trip.
+6. **Runs read-only MCP + kernel smoke probes** and prints a single **readiness banner**.
 
-After it finishes, **restart the client** so it reloads `/mcp` and the skill pack.
+After it finishes, **restart the client** (desktop app or CLI) so it reloads the MCP connection and the skill pack.
 
-> **Restart matters.** Claude Code and Codex only pick up newly-wired MCP servers and plugins on restart. If `/mcp` doesn't show the `dpf` connector, restart the client in the repo root.
+> **AGENTS.md is already in the repo.** `AGENTS.md` at the repo root is the canonical rulebook, and the tool-specific pointer files (`CLAUDE.md`, `.cursor/rules/`, `.clinerules/`, `.github/copilot-instructions.md`, `CONVENTIONS.md`, `.continue/rules/`) already point to it — they're checked in. You don't author these; you just make sure your client loads project instructions (most do automatically from the repo root). **Don't duplicate rules into the pointer files** — they are pointers, not copies.
 
 #### Reading the readiness banner
-
-The banner reports one of six states with one next action:
 
 | State | Meaning | Next action |
 | ----- | ------- | ----------- |
 | `ready` | Client(s) wired, MCP reachable, kernel principle fired | Start working |
 | `partial` | One client is ready; another needs setup | Repair toolchain (re-run bootstrap) |
-| `missing_cli` | No supported agent CLI detected | Install Claude Code / Codex / Grok |
+| `missing_cli` | No supported agent detected | Install Claude / Codex / Grok |
 | `missing_token` | No DPF MCP token | Issue a development token (Admin → Platform Development → MCP) |
 | `needs_refresh` | Token exists but the running client hasn't picked it up | Restart the client / refresh the binding |
 | `failed_smoke` | Installed but did not apply a kernel principle | View evidence under `--show-substrate` |
 
-For debugging, re-run with `--show-substrate` to see plugin/config/memory detail, or `--dry-run` to see planned writes without applying them. See [docs/operations/install.md](../../operations/install) for what each readiness state means in depth.
+Re-run with `--show-substrate` for plugin/config/memory detail, or `--dry-run` to preview writes. See [docs/operations/install.md](../../operations/install) for what each state means in depth.
 
 ---
 
-### Per-client specifics
+### Step 2 — Adjust local client settings to match DPF's processes
 
-The bootstrap hides the substrate, but it helps to know how each client differs once you're working.
+The bootstrap wires the connection, but a few **client-local settings** are not DPF's to set for you. Check these so your agent's defaults don't fight the portal's processes:
 
-#### Claude Code
+#### Turn off "open PRs as draft"
 
-- Loads the `dpf-platform` skill pack and the `dpf` MCP connector via the repo-local marketplace + `.claude/settings.json` (which declares `enabledPlugins`, `enabledMcpjsonServers: ["dpf"]`, and worktree/transcript hooks).
-- **Enforced lease guard.** A `PreToolUse` hook (`scripts/hooks/lease-guard.mjs`) *refuses* ungoverned dev-server launches (`pnpm/npm/yarn dev`, `next dev`, `turbo dev`). This is what prevents a pile-up of rogue servers on shared singletons. Use the governed path (lease the shared runtime) instead. Emergency bypass only: prefix `DPF_ALLOW_UNGATED_SERVER=1`.
+**This is the important one.** Some clients open pull requests as **drafts by default** — Codex's GitHub/cloud integration is known to do this. **DPF does not use draft PRs.** Per [AGENTS.md §4](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md), *a PR means ready to merge* — there is no draft→final review process to graduate through. A pushed branch is the in-flight handoff artifact; the PR is opened only when the branch is green and ready for merge automation.
 
-#### Codex CLI
+In your client's GitHub / PR settings, **disable any "create pull requests as draft" default** so your PRs open **ready for review**. If a PR is opened as a draft by mistake, mark it ready for review immediately (or close it and keep the branch).
 
-- Reads the DPF MCP server and the `dpf-platform` plugin from `~/.codex/config.toml`. The bearer token is referenced via `bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`, not stored in the file.
-- **No `.claude/settings.json` hook applies to Codex.** Codex (and Grok) get the same contract by *reading* it — comply **by construction**: claim a lease before you launch any shared runtime, claim a Work Capsule before you start, record evidence as you go. A shared `dpf worktree` wrapper to enforce this for Codex/Grok is planned.
+#### Confirm the DPF MCP server is connected
 
-#### Grok CLI
+After restarting, verify the `dpf` connector is present:
+- **Claude** — run `/mcp`; you should see the `dpf` server and its tools.
+- **Codex / Grok** — the `[mcp_servers.dpf]` block is in your config; the server appears once the client restarts with the token in its environment.
 
-- Reads the DPF MCP server block from `~/.grok/config.toml` (HTTP transport, same `${DPF_MCP_BEARER_TOKEN}` pattern).
-- **Authentication to xAI** is separate from the DPF MCP token. Preferred path is the OAuth **device-code** flow — `grok login --device-auth` opens `accounts.x.ai/oauth2/device`, you sign in with Google / X / Apple, and the credential lands in `~/.grok/auth.json`. An `XAI_API_KEY` is the fallback. (Build Studio's containerized Grok dispatch uses the same credential model; see the [Grok device-code OAuth spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md).)
-- Same comply-by-construction contract as Codex: no settings hook, so claim leases and capsules yourself.
+If it's missing, the token probably isn't in the running client's environment yet — restart the client (GUI apps need a full restart to pick up a freshly minted token), or re-run the bootstrap.
+
+#### Let the client load project instructions
+
+Make sure your client reads repo-root project instructions (`AGENTS.md` via its pointer file). Desktop apps and CLIs generally do this automatically when opened at the repo root; if your client has a "project rules / instructions" setting, point it at the repo root rather than copying rules elsewhere.
+
+#### Be deliberate about auto-run / auto-approve
+
+DPF relies on local guardrails — the pre-commit secret scan + typecheck hook (`git config core.hooksPath .githooks`, auto-set on new clones), and for **Claude Code** a `PreToolUse` **lease guard** (`scripts/hooks/lease-guard.mjs`) that *refuses* ungoverned dev-server launches (`pnpm/npm/yarn dev`, `next dev`, `turbo dev`). Don't loosen these. Emergency bypass for the lease guard only: prefix `DPF_ALLOW_UNGATED_SERVER=1`.
+
+> **Codex and Grok get the same contract by reading it, not by a hook.** There's no `.claude/settings.json` equivalent that fires for them, so comply **by construction**: claim a lease before launching any shared runtime, claim a Work Capsule before you start, record evidence as you go. A shared `dpf worktree` wrapper to enforce this for Codex/Grok is planned.
 
 ---
 
-### The DPF MCP token (all three clients)
+### Per-agent specifics
 
-All three clients authenticate to the DPF MCP server with the same `DPF_MCP_BEARER_TOKEN` environment variable, referenced (never inlined) from each client's config. `.mcp.json` and `.vscode/mcp.json` are **gitignored credential files** — never commit them.
+#### Claude
 
-- **Scopes.** Tokens are coarse `read` / `write` / `admin` plus granular per-tool grants. Default is `read` and cannot call side-effecting tools. Use **Issue write token** in Admin → Platform Development → MCP when an agent must create/update backlog items, evidence, capsules, or coordination records.
+- Desktop app, IDE extension, and Claude Code CLI share `~/.claude`, so one bootstrap covers whichever you run. Loads the `dpf-platform` skill pack and `dpf` MCP connector via the repo-local marketplace + `.claude/settings.json` (which also declares the lease guard and worktree/transcript hooks).
+
+#### Codex
+
+- Desktop/IDE app and CLI both read `~/.codex/config.toml`. The bearer token is referenced via `bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`, never stored in the file. **Check the draft-PR default** (above).
+
+#### Grok
+
+- **CLI only — no GUI client yet.** Reads the DPF MCP server block from `~/.grok/config.toml` (HTTP transport, same `${DPF_MCP_BEARER_TOKEN}` pattern).
+- **Authentication to xAI** is separate from the DPF MCP token. Preferred path is the OAuth **device-code** flow — `grok login --device-auth` opens `accounts.x.ai/oauth2/device`; you sign in with Google / X / Apple and the credential lands in `~/.grok/auth.json`. An `XAI_API_KEY` is the fallback. (Build Studio's containerized Grok dispatch uses the same credential model — see the [Grok device-code OAuth spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md).)
+
+---
+
+### The DPF MCP token (all clients)
+
+All clients authenticate to the DPF MCP server with the same `DPF_MCP_BEARER_TOKEN` environment variable, referenced (never inlined) from each client's config. `.mcp.json` and `.vscode/mcp.json` are **gitignored credential files** — never commit them.
+
+- **Scopes.** Coarse `read` / `write` / `admin` plus granular per-tool grants. Default is `read` and cannot call side-effecting tools. Use **Issue write token** in Admin → Platform Development → MCP when an agent must create/update backlog items, evidence, capsules, or coordination records.
 - **Scope escalation.** If a tool returns `insufficient_token_scope`, *stop* — do not fall back to `psql`/Prisma/direct DB edits. Issue a scoped token in the portal, update the client, call `/api/mcp/token/refresh`, and retry through MCP.
-- **Rotation** (no file edits): set the `DPF_MCP_BEARER_TOKEN` user environment variable to the new value, then `POST /api/mcp/token/refresh` with the new token, then retry the call in the running session.
+- **Rotation** (no file edits): set the `DPF_MCP_BEARER_TOKEN` user environment variable to the new value, `POST /api/mcp/token/refresh` with the new token, then retry in the running session.
 
 ---
 
-### Managing multiple threads (the main reason to use a CLI agent)
+### Managing multiple threads
 
-This is where the CLI surfaces go beyond Build Studio. The model is simple and strict:
+This is where the agent clients go beyond Build Studio. The model is simple and strict:
 
 > **One thread = one branch = one git worktree.** Never share a working tree across sessions — that causes index/HEAD collisions and cross-thread file sweeps.
 
@@ -143,13 +172,11 @@ cd ~/dpf-worktrees/<slug>
 
 #### Commit and push fast
 
-The durability boundary is the **remote**, not your disk. Commit and push after every logical step:
+The durability boundary is the **remote**, not your disk. Commit and push after every logical step, DCO-signed (`-s`) — the DCO bot blocks merge otherwise:
 
 ```bash
 git add -A && git commit -s -m "…" && git push -u origin <prefix>/<slug>
 ```
-
-Every commit needs DCO sign-off (`-s`) — the DCO bot blocks merge otherwise.
 
 #### Worktrees are source-control isolation, not runtime isolation
 
@@ -159,7 +186,7 @@ A worktree keeps your code changes off the root clone's HEAD. It is **not** a se
 claim_nonprod_environment_lease(environmentKey="local-integration-ci")
 ```
 
-Harness friction inside a worktree (missing pnpm on PATH, cross-workspace symlinks, missing Prisma client) is a *harness limitation, not a product defect* — verify via the lease, not by fighting the worktree. Cheap source-local checks (targeted `vitest`, `pnpm --filter <pkg> typecheck`) are fine to run in the worktree.
+Harness friction inside a worktree (missing pnpm on PATH, cross-workspace symlinks, missing Prisma client) is a *harness limitation, not a product defect* — verify via the lease. Cheap source-local checks (targeted `vitest`, `pnpm --filter <pkg> typecheck`) are fine in the worktree.
 
 #### Clean up when merged
 
@@ -171,17 +198,17 @@ git -C ~/dpf worktree remove ~/dpf-worktrees/<slug>
 
 ### Adhering to the portal's processes
 
-The CLI surfaces are powerful precisely because they don't get a governance discount. Hold these whichever client you drive:
+The agent surfaces are powerful precisely because they don't get a governance discount. Hold these whichever client you drive:
 
 - **MCP is the coordination plane.** Work tracking, capsule claims, and gate evidence live in the DPF MCP substrate. **If it isn't in the MCP plane, it didn't happen** — a thread that runs without claiming a capsule and recording evidence is invisible to coordination and cannot advance a gate.
-- **All changes land via PR against `main`, DCO-signed.** One concern per branch, one concern per PR. Open the PR only when it's green and ready to merge — no draft PRs, no parking-place PRs.
+- **All changes land via PR against `main`, DCO-signed.** One concern per branch, one concern per PR. **Open the PR only when it's green and ready to merge — no draft PRs**, no parking-place PRs.
 - **The build gate is mandatory** (unit tests, production build, UX verification, migration apply) and runtime-bound gates run on the canonical install or the leased sandbox — never a worktree-local harness. "Tests passed" is incomplete without naming **where** it ran.
 - **The live install advances only via the self-upgrade pipeline.** No surface hand-advances the root clone HEAD or rebuilds the portal to "update."
 - **Shared singletons are lease-gated.** No ad-hoc `docker run` / `compose up` against shared runtimes from any surface; claim the lease, heartbeat, release on exit.
-- **CI gates are surface-agnostic.** The UX-Fit Gate, Native Dialog Guard, secret scan, and typecheck read the *evidence in the PR*, not which agent produced it — so Claude, Codex, Grok, and Build Studio are all held to the same bar.
+- **CI gates are surface-agnostic.** The UX-Fit Gate, Native Dialog Guard, secret scan, and typecheck read the *evidence in the PR*, not which agent produced it.
 - **Route durable learnings to the commons** (WWMD / WWWD / WSID / code + AGENTS.md) so every agent and every install inherits them. Local-only knowledge is a defect.
 
-The full operating contract is [AGENTS.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md) at the repo root — read it before any work. The CLI skill pack enforces the same kernel principles AGENTS.md documents.
+The full operating contract is [AGENTS.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md) — read it before any work. The skill pack enforces the same kernel principles it documents.
 
 ---
 
@@ -189,9 +216,10 @@ The full operating contract is [AGENTS.md](https://github.com/OpenDigitalProduct
 
 | Symptom | Fix |
 | ------- | --- |
-| `/mcp` doesn't list `dpf` | Restart the client in the repo root; re-run the bootstrap if still missing |
+| `/mcp` (or the client's MCP panel) doesn't list `dpf` | Restart the client in the repo root; GUI apps need a full restart to pick up a new token; re-run the bootstrap if still missing |
 | Banner shows `missing_token` | Issue a write token in Admin → Platform Development → MCP, then re-run the bootstrap |
 | Banner shows `needs_refresh` | Restart the client; if rotated, `POST /api/mcp/token/refresh` with the new token |
+| PRs keep opening as drafts | Disable the "create PRs as draft" default in your client's GitHub settings (DPF uses ready-for-review PRs only) |
 | Tool returns `insufficient_token_scope` | Issue a scoped token, refresh, retry — do **not** bypass with direct DB edits |
 | New worktree has no `dpf` connector | Run `scripts/dpf-bootstrap-agent-toolchain.sh` inside the worktree, then restart |
 | Dev-server launch refused (Claude Code) | Use a lease for the shared runtime, or run in an isolated worktree compose stack |
@@ -208,4 +236,3 @@ The full operating contract is [AGENTS.md](https://github.com/OpenDigitalProduct
 - [AGENTS.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md) — the canonical agent rulebook
 - Specs: [Agent Toolchain Bootstrap](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md) · [Unified Delivery Surfaces](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-06-05-unified-delivery-surfaces-execution-alignment-design.md) · [First-Class Grok Support](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-31-grok-first-class-support-design.md)
 </content>
-</invoke>

--- a/docs/user-guide/getting-started/developer-setup.md
+++ b/docs/user-guide/getting-started/developer-setup.md
@@ -133,5 +133,5 @@ Branch prefixes by intent: `feat/*`, `fix/*`, `chore/*`, `doc/*`, `clean/*`. One
 ### Related
 
 - [Dev Container Setup](dev-container) — fully containerized alternative, no local Node.js required
-- [Agent CLI Development Environments](agent-dev-environments) — set up Claude Code, Codex, and Grok as governed CLI coding agents and manage multiple concurrent threads
+- [Agent Development Environments](agent-dev-environments) — set up Claude, Codex, and Grok (desktop apps or CLI): MCP, skill pack, AGENTS.md, local settings, and managing multiple concurrent threads
 - [Development Workspace](../development-workspace) — how Build Studio, VS Code, and production promotion fit together

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -49,4 +49,4 @@ Every page has an AI coworker available via the floating action button in the bo
 - [Market Archetypes And Coworkers](../market-archetypes) — Understand how archetypes, coworkers, and voice fit together
 - [AI Coworker](ai-coworker) — Learn how to work with the AI assistant
 - [Development Workspace](../development-workspace) — Learn how Build Studio, VS Code, policy states, and validation environments fit together
-- [Agent CLI Development Environments](agent-dev-environments) — Set up Claude Code, Codex, and Grok as governed CLI coding agents and run multiple concurrent threads
+- [Agent Development Environments](agent-dev-environments) — Set up Claude, Codex, and Grok (desktop apps or CLI): MCP, skill pack, AGENTS.md, local settings, and managing multiple concurrent threads


### PR DESCRIPTION
## Summary

Follow-up to #2051. The first version framed the guide as **CLI** environments. That was too narrow: the surfaces I had in mind are primarily the **client apps** (Claude and Codex desktop/IDE apps), with the CLI as an equally valid alternative. **Grok is the only CLI-only one** (no GUI yet). This PR reframes the guide around that, and makes **wiring the environment** — MCP, the skill pack, AGENTS.md, and the **local client settings** — the spine of the doc.

## Changes

`docs/user-guide/getting-started/agent-dev-environments.md`:
- **Retitled** "Agent CLI Development Environments" → **"Agent Development Environments — Claude, Codex, Grok"**.
- **Surfaces table** up front: Claude (desktop app / IDE extension / Claude Code CLI), Codex (desktop-IDE app / CLI), **Grok (CLI only — no GUI yet)**. Both app and CLI are presented as valid; they share the same client config.
- **New "Step 2 — adjust local client settings" section**, led by the one that matters:
  - **Turn off "open PRs as draft."** Codex's GitHub integration is known to default PRs to draft; DPF has **no draft→final review process** — a PR means ready to merge (AGENTS.md §4). Guidance: disable the draft default so PRs open ready for review.
  - Confirm the DPF MCP server is connected (`/mcp` or the client's MCP panel).
  - Let the client load project instructions (AGENTS.md via its pointer files — already checked in; don't duplicate rules).
  - Be deliberate about auto-run/auto-approve; don't loosen the pre-commit hook or the Claude Code lease guard.
- Clarified the bootstrap writes the **shared config that both the desktop app and CLI read**, and injects the token via `launchctl` so **GUI apps** (which don't read the shell profile) pick it up.
- Added a draft-PR row to the troubleshooting table.
- Updated link labels in `docs/README.md`, `docs/index.html`, the getting-started nav, `developer-setup.md`, and `development-workspace.md` to drop "CLI" and mention "desktop apps or CLI."

## Sourcing

- Draft-PR rule grounded in AGENTS.md §4 ("PR creation means ready to merge… do not use GitHub draft PRs"); the Codex draft default is the operator's stated behavior to correct.
- Surfaces/auth grounded in the bootstrap script (`scripts/dpf-bootstrap-agent-toolchain.sh` — GUI-app detection, `launchctl` token injection, Grok device-code OAuth) and the Grok specs.

## Test plan

- [x] Docs-only; no code/schema/UI surface — build/typecheck/UX gates not applicable.
- [x] All cross-referenced paths verified to resolve.
- [x] Frontmatter unchanged (`order: 7`); DCO sign-off on the commit.

## Notes for the reviewer

- Same file as #2051, reframed — no new doc, no new links, just corrected emphasis and the local-settings section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4UF6k7EP6KJpb3oKQQpZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4UF6k7EP6KJpb3oKQQpZs)_