### PR TITLE
chore(compose): pin third-party images + CI guard against :latest (BI-C8164664)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,21 @@ jobs:
           done < <(find . -type f \( -name 'Dockerfile' -o -name 'Dockerfile.*' \) -not -path './node_modules/*' -not -path './.git/*' -print0)
           exit $fail
 
+  compose-image-pins:
+    name: Compose Image Pins
+    runs-on: ubuntu-latest
+    # Guards against the failure mode in BI-C8164664: a third-party image on
+    # `:latest` is both unpinned (no reproducibility / review gate) AND
+    # invisible to Dependabot (no version to bump), so it silently drifts.
+    # inngest/inngest:latest rotted onto a broken 1.26.0 and pinned the
+    # scheduler at ~55% CPU for 9 days. Every third-party image must carry an
+    # explicit version (or digest) so Dependabot's docker ecosystem can track
+    # it. Burn down the allowlist in scripts/check-compose-image-pins.sh.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Assert third-party compose images are pinned
+        run: bash scripts/check-compose-image-pins.sh docker-compose.yml
+
   adp-integration-tests:
     name: ADP Integration Tests
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       start_period: 30s
 
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.18.2
     restart: unless-stopped
     volumes:
       - qdrant_data:/qdrant/storage
@@ -496,7 +496,7 @@ services:
       start_period: 30s
 
   dev-qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.18.2
     restart: unless-stopped
     profiles: ["dev"]
     volumes:
@@ -569,7 +569,7 @@ services:
   # Grafana (power-user tool) available at :3002.
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.12.0
     restart: unless-stopped
     ports:
       - "9090:9090"
@@ -590,7 +590,7 @@ services:
       retries: 3
 
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:13.0.2
     restart: unless-stopped
     ports:
       - "3002:3000"
@@ -696,7 +696,7 @@ services:
       - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
 
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.19.1
     restart: unless-stopped
     ports:
       - "9187:9187"
@@ -723,7 +723,7 @@ services:
   # exposes it on :9121/metrics in Prometheus format. Lets the platform Health
   # tab promote the "Redis" tile from "Not scraped" to a real UP/DOWN tile.
   redis-exporter:
-    image: oliver006/redis_exporter:latest
+    image: oliver006/redis_exporter:v1.86.0
     restart: unless-stopped
     command: ["--redis.addr=redis://redis:6379"]
     depends_on:

--- a/scripts/check-compose-image-pins.sh
+++ b/scripts/check-compose-image-pins.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# check-compose-image-pins.sh — fail CI if a third-party container image in
+# docker-compose.yml floats on a mutable tag (`:latest` or no tag).
+#
+# Why: `:latest` is both unpinned (no reproducibility / no review gate) AND
+# invisible to Dependabot (no version anchor to bump from), so it silently
+# drifts. BI-C8164664: `inngest/inngest:latest` drifted onto a broken 1.26.0
+# release and rotted 9 days behind upstream, pinning the scheduler at ~55% CPU.
+# Pinning every third-party image to an explicit version lets the existing
+# Dependabot `docker` ecosystem propose reviewed, CI-gated bumps instead.
+#
+# First-party images are exempt: they use `${DPF_IMAGE_TAG:-latest}` (release
+# pipeline controls the tag) and are matched by the `${` parameter syntax.
+#
+# ALLOWLIST holds images not yet pinned, tracked for burn-down in BI-C8164664.
+# Add to it only with a tracking reference; the goal is an empty allowlist.
+
+set -euo pipefail
+
+COMPOSE_FILE="${1:-docker-compose.yml}"
+
+# Images permitted to remain on :latest for now (burn-down tracked in BI-C8164664).
+# Each entry is the image repository (no tag).
+ALLOWLIST=(
+  "grafana/loki"                  # observability profile — not exercised in CI; pin when validated
+  "grafana/alloy"                 # observability profile — not exercised in CI; pin when validated
+  "gcr.io/cadvisor/cadvisor"      # observability profile — not exercised in CI; pin when validated
+  "prom/node-exporter"            # observability profile — not exercised in CI; pin when validated
+  "inngest/inngest"               # pinned to v1.30.0 by PR #2048; remove this entry once merged
+)
+
+is_allowlisted() {
+  local repo="$1"
+  local entry
+  for entry in "${ALLOWLIST[@]}"; do
+    [ "$repo" = "$entry" ] && return 0
+  done
+  return 1
+}
+
+violations=0
+while IFS= read -r line; do
+  # Extract the image reference from `    image: <ref>` lines.
+  ref="$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*image:[[:space:]]*//')"
+
+  # Skip first-party / parameterized images (release pipeline controls the tag).
+  case "$ref" in
+    *'${'*) continue ;;
+  esac
+
+  # Pinned by digest (name@sha256:...) is always acceptable.
+  case "$ref" in
+    *@sha256:*) continue ;;
+  esac
+
+  repo="${ref%%:*}"
+  tag="${ref#*:}"
+  [ "$repo" = "$ref" ] && tag="<none>"   # bare image, no tag
+
+  if [ "$tag" = "latest" ] || [ "$tag" = "<none>" ]; then
+    if is_allowlisted "$repo"; then
+      printf 'ALLOWLISTED (tracked, BI-C8164664): %s\n' "$ref" >&2
+    else
+      printf '::error::Unpinned third-party image (use an explicit version, not :latest): %s\n' "$ref" >&2
+      violations=$((violations + 1))
+    fi
+  fi
+done < <(grep -E '^[[:space:]]*image:[[:space:]]' "$COMPOSE_FILE")
+
+if [ "$violations" -gt 0 ]; then
+  printf '\n%d unpinned third-party image(s) found in %s.\n' "$violations" "$COMPOSE_FILE" >&2
+  printf 'Pin to an explicit version (e.g. prom/prometheus:v3.12.0) so Dependabot can track it.\n' >&2
+  exit 1
+fi
+
+echo "All third-party images in $COMPOSE_FILE are pinned (or allowlisted)."


### PR DESCRIPTION
## Why
A `:latest` third-party image is the worst of both worlds: **unpinned** (no reproducibility, no review gate) *and* **invisible to Dependabot** (no version anchor to bump from), so it silently drifts. `inngest/inngest:latest` drifted onto a broken **1.26.0** and pinned the self-hosted scheduler at ~55% CPU for **9 days** before it surfaced (BI-C8164664). ~11 third-party images were on `:latest`.

## What
- **Pin the 5 images whose running version is verified** (zero behavior change — pinned to exactly what's deployed):

  | image | pin |
  |---|---|
  | `qdrant/qdrant` | `v1.18.2` |
  | `prom/prometheus` | `v3.12.0` |
  | `grafana/grafana-oss` | `13.0.2` |
  | `prometheuscommunity/postgres-exporter` | `v0.19.1` |
  | `oliver006/redis_exporter` | `v1.86.0` |

- **`scripts/check-compose-image-pins.sh` + a `Compose Image Pins` CI job** (modeled on the existing `dockerfile-node-version` guard) that fails on any new third-party `:latest`. First-party `${DPF_IMAGE_TAG}` images and `@sha256:` digest pins are exempt.
- **Allowlist** the 4 not-currently-running observability images (`loki`, `alloy`, `cadvisor`, `node-exporter`) + `inngest` (pinned by #2048) for tracked burn-down. The goal is an empty allowlist.

## Effect
Once pinned, **Dependabot's existing `docker` ecosystem** proposes reviewed, CI-gated version bumps instead of silent drift — this incident would have surfaced as a routine "inngest 1.26→1.27" PR within a week.

## Follow-up (tracked in BI-C8164664)
- Pin the 4 allowlisted observability images (need a profile that exercises them to validate).
- Remove `inngest` from the allowlist once #2048 merges.
- Consider the parameterized `${DPF_TTS_IMAGE:-...:latest}` default and `caddy:2-alpine` (major-pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)