### PR TITLE
test(adp): de-flake cert-parse expiry test against aging fixture

### DIFF
--- a/apps/web/lib/integrate/adp/cert-parse.test.ts
+++ b/apps/web/lib/integrate/adp/cert-parse.test.ts
@@ -10,15 +10,16 @@ describe("parseCertExpiry", () => {
   it("extracts a future expiry date from a valid PEM (cert is openssl -days 365)", () => {
     const result = parseCertExpiry(validPem);
     expect(result).toBeInstanceOf(Date);
-    const msUntilExpiry = result!.getTime() - Date.now();
-    // Cert was generated with `-days 365` at fixture-gen time. Loose bounds so
-    // the test doesn't go flaky as the fixture ages. Valid as long as the
-    // fixture hasn't aged more than ~15 days past generation.
-    const days = msUntilExpiry / (24 * 60 * 60 * 1000);
-    // Fixture is a 365-day cert; loosened lower bound slightly as fixture ages over time
-    // (was >350, now >340 to avoid flakiness while still validating "future" and "<366").
-    expect(days).toBeGreaterThan(340);
-    expect(days).toBeLessThan(366);
+    // Assert against the fixture's actual notAfter, not a days-from-now window.
+    // The cert's expiry is fixed (`openssl x509 -enddate` on
+    // fixtures/valid-cert.pem -> "May 24 15:24:15 2027 GMT"), but a relative
+    // day-count bound shrinks every day and aged into flakiness — it was
+    // loosened >350 -> >340 once and then failed again at 339.78. Comparing to
+    // the fixed date is deterministic and still proves we parsed the real
+    // expiry. If the fixture is regenerated, update this expected value.
+    expect(result!.toISOString()).toBe("2027-05-24T15:24:15.000Z");
+    // Sanity: the parsed expiry is genuinely in the future.
+    expect(result!.getTime()).toBeGreaterThan(Date.now());
   });
 
   it("returns null for a malformed PEM (fail-closed)", () => {


### PR DESCRIPTION
## Problem
`Unit Tests (web shard 3/4)` is failing on `main` and every open PR:

```
AssertionError: expected 339.7828373148148 to be greater than 340
 ❯ lib/integrate/adp/cert-parse.test.ts:20:18
```

Not a regression in any feature branch — it's a **time bomb in the test**. `cert-parse.test.ts` asserts a *days-from-now* window (`> 340 && < 366`) against a static 365-day fixture cert. The lower bound shrinks one day per day as the fixture ages. The comment shows it was already loosened `>350 → >340` once; today the fixture is ~25 days old, so days-remaining is 339.78 and the bound fails again. Bumping the threshold again just resets the same fuse.

## Fix
Assert against the fixture's **fixed `notAfter`** instead of a relative window:

```
openssl x509 -in fixtures/valid-cert.pem -noout -enddate
notAfter=May 24 15:24:15 2027 GMT
```

```ts
expect(result!.toISOString()).toBe("2027-05-24T15:24:15.000Z");
expect(result!.getTime()).toBeGreaterThan(Date.now()); // future sanity
```

Deterministic — it can't age — and still proves the parser extracts the real future expiry. If the fixture is ever regenerated, the expected value is updated alongside it (explicit, not silent drift).

## Verify
`vitest run lib/integrate/adp/cert-parse.test.ts` → **5 passed** (was 1 failed).

Unblocks Unit Tests on main, #2054, #2048, and any other open PR inheriting this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)