### PR TITLE
fix(ci): regenerate stale route manifest (499 → 500 routes)

### DIFF
--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 499,
+  "routeCount": 500,
   "routes": [
     {
       "routePath": "/",
@@ -1793,6 +1793,18 @@
         "id"
       ],
       "file": "apps/web/app/api/v1/customer/engagements/[id]/route.ts"
+    },
+    {
+      "routePath": "/api/v1/customer/invoices",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "customer",
+        "invoices"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/customer/invoices/route.ts"
     },
     {
       "routePath": "/api/v1/customer/opportunities",


### PR DESCRIPTION
Superseded by #2060, which consolidates this route-manifest regeneration with the UX-Fit gate and cert-parse fixes into one PR. The three fixes mutually block each other under branch protection, so they must land together. Closing in favor of #2060.