### PR TITLE
feat(coworker): proactive WWMD/WWWD/WSID decision-routing on both prompt paths

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -906,8 +906,17 @@ export async function sendMessage(input: {
     }
   } else {
     // ── Legacy persona-based prompt assembly ──
+    // Proactive decision-routing governance contract (WWMD/WWWD/WSID) — must be
+    // surface-uniform with the unified prompt-assembler path. Without this, a
+    // legacy-path coworker (the install default while USE_UNIFIED_COWORKER is
+    // off) never sees the instruction to consult a decision surface before
+    // proposing or asking, and never sees its decision skills at all.
+    const { loadDecisionRoutingBlock } = await import("@/lib/tak/decision-routing-block");
+    const legacyDecisionRoutingBlock = await loadDecisionRoutingBlock();
     const promptSections = [
       agent.systemPrompt,
+      "",
+      legacyDecisionRoutingBlock,
       "",
       "Current context:",
       `- Route: ${input.routeContext}`,
@@ -1043,6 +1052,46 @@ export async function sendMessage(input: {
     if (professionCorpus?.promptBlock) {
       promptSections.push("", professionCorpus.promptBlock);
       professionInjectedIntoPrompt = true;
+    }
+
+    // Surface the coworker's eligible skills on the legacy path too. The unified
+    // path lists these via assembleSystemPrompt; without this the install default
+    // (USE_UNIFIED_COWORKER off) hides every skill — including the decision-routing
+    // skills (dpf-decision-via-kernel, dpf-retrieve-decision-context,
+    // dpf-record-decision-outcome) the governance block above tells the coworker
+    // to run. Telemetry mirrors the unified path so eligibility is observable.
+    const legacyCoworkerSkills = await getSkillsForAgent(agent.agentId);
+    const legacySkillSummaries = toSkillSummariesForPrompt(legacyCoworkerSkills);
+    if (legacySkillSummaries.length > 0) {
+      let skillsBlock = "Available coworker skills:";
+      for (const skill of legacySkillSummaries) {
+        skillsBlock += `\n- ${skill.skillId}: ${skill.label} - ${skill.description}`;
+      }
+      promptSections.push("", skillsBlock);
+      const legacyEligibleSkillIds = legacySkillSummaries.map((s) => s.skillId);
+      void recordSkillUsageEvents({
+        phase: "eligible",
+        skillIds: legacyEligibleSkillIds,
+        agentId: agent.agentId,
+        userId: user.id ?? null,
+        threadId: input.threadId ?? null,
+        routeContext: input.routeContext,
+      });
+      const legacyCandidateSkillId = extractInvokedSkillId(input.content);
+      activeSkillId =
+        legacyCandidateSkillId && legacyEligibleSkillIds.includes(legacyCandidateSkillId)
+          ? legacyCandidateSkillId
+          : null;
+      if (activeSkillId) {
+        void recordSkillUsageEvents({
+          phase: "invoked",
+          skillIds: [activeSkillId],
+          agentId: agent.agentId,
+          userId: user.id ?? null,
+          threadId: input.threadId ?? null,
+          routeContext: input.routeContext,
+        });
+      }
     }
 
     populatedPrompt = promptSections.join("\n");

--- a/apps/web/lib/tak/decision-routing-block.ts
+++ b/apps/web/lib/tak/decision-routing-block.ts
@@ -1,0 +1,33 @@
+// apps/web/lib/tak/decision-routing-block.ts
+//
+// The proactive decision-routing governance contract injected into EVERY
+// in-portal coworker's system prompt, on BOTH the unified prompt-assembler
+// path and the legacy persona path. This is the fix for the gap where a
+// coworker (e.g. the Scrum Master) would bring a raw "should we…?" proposal
+// or question straight to the employee without first consulting the decision
+// surface that owns the question — WWMD (founder kernel / principle_decide),
+// WWWD (the organization's recorded business stance), or WSID (profession
+// craft knowledge). See the design spec:
+// docs/superpowers/specs/2026-06-18-coworker-decision-routing-governance-design.md
+//
+// DB-overridable like the other identity blocks: seeded as PromptTemplate
+// `platform-identity/decision-routing` from prompts/platform-identity/
+// decision-routing.prompt.md; the constant below is the offline fallback.
+
+import { loadPrompt } from "./prompt-loader";
+
+export const DECISION_ROUTING_BLOCK = `DECISION ROUTING — CONSULT GOVERNANCE BEFORE YOU PROPOSE OR ASK.
+Before you bring the employee a recommendation, a proposal, a prioritization, a strategically-weighted status change (activating, deferring, or reordering epics or backlog items), or any "should we… / which approach / what's next" question, FIRST consult the decision surface that owns that question, then lead with a grounded recommendation and a one-line reason — not a raw open question. Routing:
+- PLATFORM / BUILD / TECHNICAL trade-off (architecture, tooling, how to build something): score the options against the founder kernel — call principle_decide with the candidate options and surface the recommendation plus the per-principle reasoning. Pull the governing rule with wiki_query when you need the principle itself.
+- THE ORGANIZATION'S BUSINESS CALL ("what would WE do", what to fund or defer, priorities, customer or market direction): ground the answer in the organization's own recorded stance — its mission and "how we decide" guidance in the context below. If the organization has no settled position on the specific question, SAY SO plainly, summarize the closest recorded stance, and frame it as a decision to make together. Never assert one answer as fact, and never substitute the founder/platform doctrine as the organization's authority — platform doctrine is advisory to a business decision, not binding.
+- A CRAFT / ROLE question (the competent-professional answer for your discipline): ground it in your profession knowledge provided in the context below.
+You ARE the path to governance — run the right surface yourself; do not deflect with "should I check with governance first?" or escalate a decision you can ground. Only put a choice back to the employee when a genuine option remains after you have consulted the surface, or when a required fact is missing. Never surface tool names, principle names, or internal mechanics to the employee — give them the recommendation and the reasoning in plain language.`;
+
+/**
+ * Load the decision-routing governance block, DB-override first
+ * (PromptTemplate `platform-identity/decision-routing`), falling back to the
+ * constant above when the DB row is absent/disabled or the DB is unreachable.
+ */
+export async function loadDecisionRoutingBlock(): Promise<string> {
+  return loadPrompt("platform-identity", "decision-routing", DECISION_ROUTING_BLOCK);
+}

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -82,6 +82,28 @@ describe("assembleSystemPrompt", () => {
     expect(prompt).not.toContain("Mode: ACT");
   });
 
+  // Test 2b: Decision-routing governance block is present, positioned between
+  // identity and mode (static, cacheable), and carries the WWMD/WWWD/WSID
+  // routing contract. Regression guard for the coworker decision-routing gap.
+  it("injects the decision-routing governance block between identity and mode", async () => {
+    const prompt = await assembleSystemPrompt(fullInput);
+
+    expect(prompt).toContain("DECISION ROUTING — CONSULT GOVERNANCE BEFORE YOU PROPOSE OR ASK.");
+    // The three surfaces must all be named so the coworker can route.
+    expect(prompt).toContain("principle_decide"); // WWMD / founder kernel
+    expect(prompt).toContain("what would WE do"); // WWWD / org stance
+    expect(prompt).toContain("competent-professional answer for your discipline"); // WSID / craft
+    // Non-inherit boundary: platform doctrine is advisory to a business call.
+    expect(prompt).toContain("platform doctrine is advisory to a business decision, not binding");
+
+    const identityIdx = indexOf(prompt, "digital product management");
+    const routingIdx = indexOf(prompt, "DECISION ROUTING —");
+    const modeIdx = indexOf(prompt, "Mode: ACT");
+    expect(identityIdx).toBeGreaterThanOrEqual(0);
+    expect(identityIdx).toBeLessThan(routingIdx);
+    expect(routingIdx).toBeLessThan(modeIdx);
+  });
+
   // Test 3: Act mode text is injected correctly
   it("injects act mode text when mode is 'act'", async () => {
     const prompt = await assembleSystemPrompt(fullInput);

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -9,6 +9,7 @@ import {
   type QuestionPacket,
 } from "./question-packet";
 import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
+import { DECISION_ROUTING_BLOCK } from "./decision-routing-block";
 
 export type PromptInput = {
   hrRole: string;
@@ -113,6 +114,7 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
   const modeSlug = input.mode === "advise" ? "advise-mode" : "act-mode";
   const loaded = await loadPrompts([
     { category: "platform-identity", slug: "identity-block", fallback: IDENTITY_BLOCK },
+    { category: "platform-identity", slug: "decision-routing", fallback: DECISION_ROUTING_BLOCK },
     { category: "platform-identity", slug: modeSlug, fallback: input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK },
     { category: "platform-mission", slug: "company-mission", fallback: COMPANY_MISSION_FALLBACK },
   ]);
@@ -122,6 +124,11 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
 
   // Block 1: Identity (static)
   staticBlocks.push(loaded.get("platform-identity/identity-block") ?? IDENTITY_BLOCK);
+
+  // Block 1b: Decision routing (static) — proactive governance contract: consult
+  // WWMD/WWWD/WSID before proposing or asking. Surface-uniform with the legacy
+  // path (apps/web/lib/actions/agent-coworker.ts).
+  staticBlocks.push(loaded.get("platform-identity/decision-routing") ?? DECISION_ROUTING_BLOCK);
 
   // Block 3: Mode (static per session — advise or act doesn't change mid-conversation)
   staticBlocks.push(loaded.get(`platform-identity/${modeSlug}`) ?? (input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK));

--- a/docs/superpowers/specs/2026-06-18-coworker-decision-routing-governance-design.md
+++ b/docs/superpowers/specs/2026-06-18-coworker-decision-routing-governance-design.md
@@ -1,0 +1,107 @@
+# Coworker Decision-Routing Governance — Design
+
+- **Date:** 2026-06-18
+- **Status:** Phase 1 implemented (this PR); Phases 2–4 filed as backlog
+- **Epic:** EP-F7E35344 (AI Coworker Capability Inputs)
+- **Trigger:** Operator dialog — the "Scrum Master" coworker activated a deferred backlog item, then admitted "I don't have visibility into WWMD or WWWD in my current toolset" and asked the user whether to escalate, instead of routing the decision through governance itself.
+
+## 1. Problem
+
+In-portal AI coworkers bring raw proposals and "should we…?" questions straight to the
+employee without first consulting the decision surface that owns the question. The coworker
+in the trigger dialog was not hallucinating its limitation — it genuinely had no decision
+machinery in its prompt. Four stacked failures, in priority order:
+
+### F1 — The default prompt path strips skills entirely (install-wide today)
+`USE_UNIFIED_COWORKER` is **`false`** on the live install (confirmed in `PlatformConfig`).
+Every coworker therefore runs the **legacy persona path** at
+[`agent-coworker.ts:908`](../../../apps/web/lib/actions/agent-coworker.ts), which assembles the
+prompt from `agent.systemPrompt` + context and **never calls `getSkillsForAgent`**. The decision
+skills (`dpf-decision-via-kernel`, `dpf-retrieve-decision-context`, `dpf-record-decision-outcome`)
+are seeded and assigned `["*"]`, but they are invisible to the running coworkers. Skills are only
+injected on the **unified path** ([`agent-coworker.ts:846`](../../../apps/web/lib/actions/agent-coworker.ts)),
+which is off by default.
+
+### F2 — Governance is passive even when skills are shown
+On the unified path skills are listed ("Available coworker skills: …") with no instruction to
+*route a decision through them before answering*. IDENTITY_BLOCK rule #23 only tells the coworker
+to *attribute* Mark's / the org's recorded view if it happens to be in context — never to
+*consult* `principle_decide` / the org's WWWD stance and return a grounded recommendation. There is
+**no proactive decision gate** anywhere in the chat loop; governance is a tool the coworker may
+choose to call, not a contract it must satisfy.
+
+### F3 — The decision tools are reachable, but WWWD has no coworker-callable door
+`principle_decide` and `wiki_query` gate only on `registry_read`, a baseline grant every coworker
+holds ([`agent-grants.ts:79,243,262`](../../../apps/web/lib/tak/agent-grants.ts)) — so **WWMD is
+callable**. But **WWWD** (the Decision Perspective Gate,
+[`decision-perspective/build-studio-gate.ts`](../../../apps/web/lib/decision-perspective/build-studio-gate.ts))
+is only invoked internally during Build Studio plan advancement — there is **no coworker-callable
+tool** for an arbitrary "what would WE do?" business question. **WSID** profession corpus is
+read-only context, not a decision door. Per AGENTS.md §16 raw `principle_decide` must **not** settle
+a customer's business question (the non-inherit boundary); consolidation is open as **BI-E1FB2307**,
+and the org resolver **BI-230C9EF7** landed.
+
+### F4 — Skill-assignment coverage is uneven
+Several user-facing personas (Customer Success, HR, Marketing, Onboarding COO, Admin) have **no**
+decision skills assigned at all; the orchestrators and Enterprise Architect do. Even the personas
+that have them get nothing today because of F1.
+
+## 2. Resolution (phased)
+
+### Phase 1 — Proactive decision-routing contract on BOTH paths *(this PR)*
+A new, DB-overridable **decision-routing governance block** is injected into every coworker's
+system prompt on **both** the unified and legacy paths, making the behavior surface-uniform and
+flag-independent:
+
+- New module [`decision-routing-block.ts`](../../../apps/web/lib/tak/decision-routing-block.ts) —
+  exports the `DECISION_ROUTING_BLOCK` constant + `loadDecisionRoutingBlock()` (PromptTemplate
+  `platform-identity/decision-routing` override, constant fallback).
+- Seed file [`prompts/platform-identity/decision-routing.prompt.md`](../../../prompts/platform-identity/decision-routing.prompt.md)
+  so admins can tune the contract without a redeploy.
+- Unified path: added as a static (cacheable) block between identity and mode in
+  [`prompt-assembler.ts`](../../../apps/web/lib/tak/prompt-assembler.ts).
+- Legacy path: loaded and injected after `agent.systemPrompt`, **plus** the coworker's eligible
+  skills are now rendered on the legacy path too (with the same eligible/invoked telemetry), closing
+  F1 directly.
+
+The block routes each decision class to its owning surface — platform/build → `principle_decide`
+(WWMD); the organization's business call → the org's recorded stance (WWWD), explicitly **not**
+the founder kernel; craft/role → the profession corpus (WSID) — and instructs the coworker to lead
+with a grounded recommendation, not a raw question, and never to deflect with "should I check with
+governance?". It respects the AGENTS.md §16 non-inherit boundary (platform doctrine is advisory to a
+business decision, not binding).
+
+### Phase 2 — Coworker-callable WWWD decision door *(filed; depends on BI-E1FB2307)*
+Expose the Decision Perspective Gate as a coworker-callable tool (or land the consolidation in
+BI-E1FB2307) so "what would WE do?" has a real governed door rather than only Build-Studio-internal
+plumbing. Until then Phase 1 grounds business answers in the org's recorded stance and surfaces
+coverage gaps via the existing `recordCoverageGap` path.
+
+### Phase 3 — Unified-path migration / legacy retirement *(filed)*
+The two divergent prompt paths are the underlying architectural debt. Decide whether to default
+`USE_UNIFIED_COWORKER` on (after per-persona verification) or retire the legacy path. Phase 1
+removes the urgency by making the governance contract present on both, but one path should win.
+
+### Phase 4 — Skill-assignment coverage audit *(filed)*
+Ensure every user-facing persona that can face a decision carries the decision-routing skills, and
+prune the EP-661D395E "stale skill" false positives (empty `SkillUsageEvent` telemetry — now being
+populated by the legacy-path telemetry added in Phase 1).
+
+## 3. Verification
+
+- `prompt-assembler.test.ts` — new regression test asserts the block is present, correctly ordered
+  (identity → routing → mode), names all three surfaces, and carries the non-inherit boundary line.
+  34/34 pass.
+- `pnpm --filter web typecheck` — clean.
+- Substrate: source-local gates from the root clone. Live coworker-chat UX drive (gate #3) is the
+  Phase 1 follow-up once merged, since it exercises the running portal's legacy path.
+
+## 4. Research & Benchmarking
+
+The pattern mirrors how agent frameworks inject a standing "operating contract" into the system
+prompt rather than relying on optional tool discovery (e.g. Claude Code's `AGENTS.md`/system-prompt
+contract, and the founder-kernel `principle_decide` scoring model already in DPF). Rejected
+alternative: a hard pre-response gate that blocks the model until it calls `principle_decide` —
+too brittle for conversational turns (analysis/advise turns legitimately need no decision) and
+would fight IDENTITY_BLOCK rule #19. A prompt-level contract + visible skills is the
+lowest-blast-radius lever that makes the behavior proactive without a runtime chokepoint.

--- a/prompts/platform-identity/decision-routing.prompt.md
+++ b/prompts/platform-identity/decision-routing.prompt.md
@@ -1,0 +1,22 @@
+---
+name: decision-routing
+displayName: Decision Routing Governance Block
+description: Proactive contract requiring coworkers to consult WWMD/WWWD/WSID before proposing or asking
+category: platform-identity
+version: 1
+
+composesFrom: []
+contentFormat: markdown
+variables: []
+
+valueStream: ""
+stage: ""
+sensitivity: internal
+---
+
+DECISION ROUTING — CONSULT GOVERNANCE BEFORE YOU PROPOSE OR ASK.
+Before you bring the employee a recommendation, a proposal, a prioritization, a strategically-weighted status change (activating, deferring, or reordering epics or backlog items), or any "should we… / which approach / what's next" question, FIRST consult the decision surface that owns that question, then lead with a grounded recommendation and a one-line reason — not a raw open question. Routing:
+- PLATFORM / BUILD / TECHNICAL trade-off (architecture, tooling, how to build something): score the options against the founder kernel — call principle_decide with the candidate options and surface the recommendation plus the per-principle reasoning. Pull the governing rule with wiki_query when you need the principle itself.
+- THE ORGANIZATION'S BUSINESS CALL ("what would WE do", what to fund or defer, priorities, customer or market direction): ground the answer in the organization's own recorded stance — its mission and "how we decide" guidance in the context below. If the organization has no settled position on the specific question, SAY SO plainly, summarize the closest recorded stance, and frame it as a decision to make together. Never assert one answer as fact, and never substitute the founder/platform doctrine as the organization's authority — platform doctrine is advisory to a business decision, not binding.
+- A CRAFT / ROLE question (the competent-professional answer for your discipline): ground it in your profession knowledge provided in the context below.
+You ARE the path to governance — run the right surface yourself; do not deflect with "should I check with governance first?" or escalate a decision you can ground. Only put a choice back to the employee when a genuine option remains after you have consulted the surface, or when a required fact is missing. Never surface tool names, principle names, or internal mechanics to the employee — give them the recommendation and the reasoning in plain language.


### PR DESCRIPTION
## Problem

In-portal AI coworkers (e.g. the **Scrum Master**) bring raw proposals and "should we…?" questions straight to the employee without consulting any decision surface. The coworker in the trigger dialog wasn't hallucinating — it genuinely had no decision machinery in its prompt.

**Root cause is install-wide today:** `USE_UNIFIED_COWORKER` is **false** on the live install (confirmed in `PlatformConfig`), so every coworker runs the **legacy persona path** (`agent-coworker.ts:908`), which assembles the prompt from `agent.systemPrompt` + context and **never injects skills**. And no path — legacy or unified — carried a *proactive* instruction to route a decision through WWMD/WWWD/WSID. `principle_decide`/`wiki_query` were already reachable (`registry_read` baseline grant) — governance was just **passive**, never a contract.

## Fix (Phase 1)

A new **DB-overridable decision-routing governance block** injected into every coworker's prompt on **both** paths (surface-uniform, flag-independent), plus **skill visibility on the legacy path**:

- `decision-routing-block.ts` — `DECISION_ROUTING_BLOCK` constant + `loadDecisionRoutingBlock()` (PromptTemplate override, constant fallback)
- `prompts/platform-identity/decision-routing.prompt.md` — admin-editable seed
- Unified path: static cacheable block between identity and mode (`prompt-assembler.ts`)
- Legacy path: block after `agent.systemPrompt` **+** eligible skills now rendered (with eligible/invoked telemetry — also begins populating the empty `SkillUsageEvent` table behind the EP-661D395E stale-skill false positives)

The block routes **platform/build → `principle_decide` (WWMD)**, **the org's business call → its recorded WWWD stance (not the founder kernel — respecting the AGENTS.md §16 non-inherit boundary)**, **craft → WSID profession corpus**, and tells the coworker to lead with a grounded recommendation, not a raw question, and never deflect with "should I check with governance?".

## Verification

- `prompt-assembler.test.ts` — new regression test (block present, ordered identity→routing→mode, all three surfaces named, non-inherit boundary line). **34/34 pass.**
- `pnpm --filter web typecheck` — clean (pre-commit gate passed). Source-local gates from the root clone.
- Live coworker-chat UX drive is the post-merge follow-up (exercises the running portal's legacy path).

## Follow-on (filed under EP-F7E35344)

- **Phase 2** — coworker-callable WWWD decision door (consolidates with BI-E1FB2307; org resolver BI-230C9EF7 landed)
- **Phase 3** — resolve the legacy-vs-unified prompt-path split
- **Phase 4** — decision-skill assignment coverage audit across personas

Spec: `docs/superpowers/specs/2026-06-18-coworker-decision-routing-governance-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)