### PR TITLE
feat(agentic): persistent ExecutionPlan in the agentic loop (BI-2AC48661)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -1813,3 +1813,113 @@ describe("runAgenticLoop interactionMode gate (Phase J)", () => {
     expect(zeroToolCall).toBeUndefined();
   });
 });
+
+// BI-2AC48661 — persistent ExecutionPlan in the agentic loop.
+describe("runAgenticLoop — execution plan", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(prisma.agentModelConfig.findUnique).mockResolvedValue(null as never);
+    vi.mocked(prisma.toolExecution.create).mockResolvedValue({} as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      isSuperuser: true,
+      groups: [{ platformRole: { roleId: "ceo" } }],
+    } as never);
+    vi.mocked(governedExecuteTool).mockImplementation(async (args: any) =>
+      executeTool(args.toolName, args.rawParams, args.userId, args.context as any) as any,
+    );
+  });
+
+  const planParams = {
+    chatHistory: [{ role: "user" as const, content: "do a multi-step task" }],
+    systemPrompt: "You are a helpful assistant.",
+    sensitivity: "internal" as const,
+    // No sideEffect/build tools → fabrication detection won't fire on text-only.
+    tools: [{ name: "search_project_files", description: "Search", inputSchema: {}, requiredCapability: null, executionMode: "immediate" as const, sideEffect: false }],
+    toolsForProvider: [{ type: "function", function: { name: "search_project_files", description: "Search", parameters: {} } }],
+    userId: "user-1",
+    routeContext: "/work",
+    agentId: "software-engineer",
+    threadId: "thread-plan",
+  };
+
+  it("exposes no plan tools and carries no plan when enableExecutionPlan is off", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockResolvedValueOnce(mockResult({ content: "Hi there, how can I help?", providerId: "anthropic-sub" }) as never);
+
+    const result = await runAgenticLoop({ ...planParams });
+
+    expect(result.content).toBe("Hi there, how can I help?");
+    expect(result.executionPlan ?? null).toBeNull();
+    // The provider tool list passed to routeAndCall has only the base tool.
+    const optsArg = mockRoute.mock.calls[0]![3] as { tools?: Array<{ function?: { name?: string } }> };
+    const names = (optsArg.tools ?? []).map((t) => t.function?.name);
+    expect(names).toEqual(["search_project_files"]);
+  });
+
+  it("exposes the plan tools to the model when enabled", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    // Reply ends in "?" → treated as a clarifying question, so the loop accepts
+    // it without nudging and we get a single deterministic dispatch to inspect.
+    mockRoute.mockResolvedValueOnce(mockResult({ content: "What would you like me to tackle first?", providerId: "anthropic-sub" }) as never);
+
+    await runAgenticLoop({ ...planParams, enableExecutionPlan: true });
+
+    const optsArg = mockRoute.mock.calls[0]![3] as { tools?: Array<{ function?: { name?: string } }> };
+    const names = (optsArg.tools ?? []).map((t) => t.function?.name);
+    expect(names).toContain("record_execution_plan");
+    expect(names).toContain("update_execution_plan_step");
+  });
+
+  it("intercepts plan tools (never dispatches them) and returns the final plan", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+        toolCalls: [{ id: "t1", name: "record_execution_plan", arguments: { goal: "g", steps: ["a", "b"] } }],
+      }) as never)
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+        toolCalls: [
+          { id: "t2", name: "update_execution_plan_step", arguments: { stepId: "s1", status: "done" } },
+          { id: "t3", name: "update_execution_plan_step", arguments: { stepId: "s2", status: "done" } },
+        ],
+      }) as never)
+      .mockResolvedValueOnce(mockResult({ content: "Everything is wrapped up." }) as never);
+
+    const result = await runAgenticLoop({ ...planParams, enableExecutionPlan: true });
+
+    // Plan tools are loop-intrinsic — governedExecuteTool is never called for them.
+    const dispatched = vi.mocked(governedExecuteTool).mock.calls.map((c: any) => c[0].toolName);
+    expect(dispatched).not.toContain("record_execution_plan");
+    expect(dispatched).not.toContain("update_execution_plan_step");
+
+    expect(result.content).toBe("Everything is wrapped up.");
+    expect(result.executionPlan?.steps.map((s) => s.status)).toEqual(["done", "done"]);
+  });
+
+  it("bounces a premature text-only stop while plan steps remain open", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+        toolCalls: [{ id: "t1", name: "record_execution_plan", arguments: { goal: "g", steps: ["a", "b"] } }],
+      }) as never)
+      // Premature stop at iteration 1 — plan still has open steps → gate nudges.
+      .mockResolvedValueOnce(mockResult({ content: "Standing by." }) as never)
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+        toolCalls: [
+          { id: "t2", name: "update_execution_plan_step", arguments: { stepId: "s1", status: "done" } },
+          { id: "t3", name: "update_execution_plan_step", arguments: { stepId: "s2", status: "skipped" } },
+        ],
+      }) as never)
+      .mockResolvedValueOnce(mockResult({ content: "All wrapped up now." }) as never);
+
+    const result = await runAgenticLoop({ ...planParams, enableExecutionPlan: true });
+
+    // The premature stop forced an extra dispatch (4 total, not 2).
+    expect(mockRoute.mock.calls.length).toBe(4);
+    expect(result.content).toBe("All wrapped up now.");
+    expect(result.executionPlan && (result.executionPlan.steps.every((s) => s.status === "done" || s.status === "skipped"))).toBe(true);
+  });
+});

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -20,6 +20,16 @@ import {
 import { extractToolCalls } from "@/lib/routing/extract-tool-calls";
 import type { AgentMinimumCapabilities } from "@/lib/routing/agent-capability-types";
 import type { UserContext } from "@/lib/permissions";
+import {
+  type ExecutionPlan,
+  EXECUTION_PLAN_TOOL_NAMES,
+  executionPlanProviderTools,
+  applyPlanToolCall,
+  renderPlanReminder,
+  renderNoPlanReminder,
+  planCompletionGate,
+  planProgress,
+} from "./execution-plan";
 
 // Safety ceiling — NOT a behavioral limit. The loop terminates when the model
 // responds with text only (no tool calls), matching the Anthropic API pattern
@@ -731,6 +741,13 @@ export type AgenticResult = {
   executedTools: ExecutedTool[];
   /** If a proposal tool was called, return it for approval card rendering */
   proposal: { name: string; arguments: Record<string, unknown>; content: string } | null;
+  /**
+   * BI-2AC48661: the execution plan as it stood when the loop returned, when
+   * `enableExecutionPlan` was set. Null when planning was off or the model
+   * never recorded one. Carried out for observability and for the streamed-plan
+   * UX (BI-95C0835E).
+   */
+  executionPlan?: ExecutionPlan | null;
 };
 
 async function resolveUserContext(userId: string): Promise<UserContext> {
@@ -991,6 +1008,16 @@ export async function runAgenticLoop(params: {
    * the join key and the UI badge degrades to provider-name-only.
    */
   agentMessageId?: string | null;
+  /**
+   * BI-2AC48661 (EP-F7E35344): opt into the persistent ExecutionPlan. When
+   * true, two loop-intrinsic tools (record_execution_plan,
+   * update_execution_plan_step) are appended to the model's tool list, the
+   * current plan is rendered into the prompt every iteration (outside the
+   * compacted window, so it never scrolls away), and a text-only "done" reply
+   * is gated on all plan steps being closed. Default false — every existing
+   * caller is byte-for-byte unchanged until it opts in.
+   */
+  enableExecutionPlan?: boolean;
 }): Promise<AgenticResult> {
   const {
     chatHistory,
@@ -1056,6 +1083,41 @@ export async function runAgenticLoop(params: {
     mcpSession: { userId, agentId, threadId, routeContext },
   };
 
+  // BI-2AC48661: persistent execution plan. When enabled, expose the two
+  // plan tools to the model and keep the plan in loop state (never in the
+  // compacted message array). MAX_PLAN_NUDGES caps how many times a text-only
+  // "done" with open steps is bounced back to work before we accept the stop,
+  // mirroring the existing one-shot continuation-nudge discipline.
+  const planEnabled = params.enableExecutionPlan === true;
+  const MAX_PLAN_NUDGES = 2;
+  let executionPlan: ExecutionPlan | null = null;
+  let planNudges = 0;
+  if (planEnabled) {
+    const planProviderTools = executionPlanProviderTools();
+    routeOptions.tools = [
+      ...((routeOptions.tools as Array<Record<string, unknown>> | undefined) ?? []),
+      ...planProviderTools,
+    ];
+  }
+
+  // Append the current plan as an ephemeral reminder to the messages handed to
+  // the model. NOT stored in `messages`, so it is regenerated from live plan
+  // state every iteration and can never be compacted away — this is the
+  // "reads the plan outside the compacted window" mechanism. No-op when off.
+  const withPlanReminder = (msgs: ChatMessage[]): ChatMessage[] => {
+    if (!planEnabled) return msgs;
+    const reminder = executionPlan ? renderPlanReminder(executionPlan) : renderNoPlanReminder();
+    const block = `[System notice]\n${reminder}`;
+    // Merge into a trailing user message to avoid two consecutive user turns
+    // (some providers reject that); otherwise append after the assistant/tool
+    // tail, which is a valid alternation.
+    const last = msgs[msgs.length - 1];
+    if (last && last.role === "user" && typeof last.content === "string") {
+      return [...msgs.slice(0, -1), { ...last, content: `${last.content}\n\n${block}` }];
+    }
+    return [...msgs, { role: "user" as const, content: block }];
+  };
+
   let messages = [...chatHistory];
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
@@ -1077,7 +1139,7 @@ export async function runAgenticLoop(params: {
   // meant hand-stitching timestamps across un-correlated [cli-adapter] /
   // [agentic-loop] lines while a concurrent coworker's logs interleaved. See
   // the Portfolio Analyst latency investigation, 2026-06-04.
-  const toolsAttachedForTurn = Boolean(toolsForProvider && toolsForProvider.length > 0);
+  const toolsAttachedForTurn = Boolean((toolsForProvider && toolsForProvider.length > 0) || planEnabled);
   const logTurnSummary = (provider: string, model: string): void => {
     console.log(
       sanitizeForLog(
@@ -1276,7 +1338,7 @@ export async function runAgenticLoop(params: {
         const { withHeartbeatTicker } = await import("@/lib/observability/heartbeat");
         result = await withHeartbeatTicker(taskRunId, () =>
           routeAndCall(
-            compactAgenticMessages(messages),
+            withPlanReminder(compactAgenticMessages(messages)),
             systemPrompt,
             sensitivity,
             { ...enrichedRouteOptions, previousResponseId },
@@ -1284,7 +1346,7 @@ export async function runAgenticLoop(params: {
         );
       } else {
         result = await routeAndCall(
-          compactAgenticMessages(messages),
+          withPlanReminder(compactAgenticMessages(messages)),
           systemPrompt,
           sensitivity,
           { ...enrichedRouteOptions, previousResponseId },
@@ -1594,7 +1656,7 @@ export async function runAgenticLoop(params: {
         continuationNudges,
         iteration,
         maxIterations: MAX_ITERATIONS,
-        hasTools: !!(toolsForProvider && toolsForProvider.length > 0),
+        hasTools: !!(toolsForProvider && toolsForProvider.length > 0) || planEnabled,
         executedToolCount: executedTools.length,
         responseLength: trimmed.length,
         responseText: trimmed,
@@ -1732,6 +1794,27 @@ export async function runAgenticLoop(params: {
         continue;
       }
 
+      // BI-2AC48661: plan completion gate. The model's text-only reply is its
+      // natural "done" signal — but with an execution plan that still has open
+      // steps, "done" is premature. Bounce it back to the next open step
+      // (capped at MAX_PLAN_NUDGES so a model that refuses to mark steps can
+      // still terminate). Skipped when tools were stripped (degraded mode) —
+      // a tool-less model can't work the plan and must be allowed to answer.
+      if (planEnabled && !result.toolsStripped) {
+        const gate = planCompletionGate({ plan: executionPlan, planNudges, maxPlanNudges: MAX_PLAN_NUDGES });
+        if (gate.action === "nudge" && gate.nudge) {
+          planNudges++;
+          console.log(`[agentic-loop] plan-incomplete nudge (${planNudges}/${MAX_PLAN_NUDGES})`);
+          if (trimmed.length > bestPreNudgeContent.length) bestPreNudgeContent = trimmed;
+          messages = [
+            ...messages,
+            ...(trimmed.length > 0 ? [{ role: "assistant" as const, content: result.content }] : []),
+            { role: "user" as const, content: gate.nudge },
+          ];
+          continue;
+        }
+      }
+
       // If the final response is empty but we had a good pre-nudge response,
       // use that instead of returning nothing. This prevents quality-gate
       // failures when the nudge causes the model to return empty.
@@ -1751,6 +1834,7 @@ export async function runAgenticLoop(params: {
         totalOutputTokens,
         executedTools,
         proposal: null,
+        executionPlan,
       };
     }
 
@@ -1761,6 +1845,20 @@ export async function runAgenticLoop(params: {
     }> = [];
 
     for (const tc of result.toolCalls) {
+      // BI-2AC48661: plan tools are loop-intrinsic. Intercept them here — they
+      // mutate loop state and return a synthetic result; they never reach
+      // governedExecuteTool, take no capability grant, and write no audit row.
+      if (planEnabled && EXECUTION_PLAN_TOOL_NAMES.has(tc.name)) {
+        const applied = applyPlanToolCall(executionPlan, tc.name, tc.arguments, iteration);
+        executionPlan = applied.plan;
+        console.log(
+          `[agentic-tool] PLAN iter=${iteration} tool=${tc.name} success=${applied.result.success}` +
+          (executionPlan ? ` progress=${planProgress(executionPlan).done}/${planProgress(executionPlan).total}` : ""),
+        );
+        iterationResults.push({ tc, toolResult: applied.result });
+        continue;
+      }
+
       const toolDef = tools.find((t) => t.name === tc.name);
 
       // Proposal tools (side-effecting, need approval) — break the loop and return
@@ -1955,5 +2053,6 @@ export async function runAgenticLoop(params: {
     totalOutputTokens,
     executedTools,
     proposal: null,
+    executionPlan,
   };
 }

--- a/apps/web/lib/tak/execution-plan.test.ts
+++ b/apps/web/lib/tak/execution-plan.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import {
+  createExecutionPlan,
+  updateStepStatus,
+  openSteps,
+  isPlanComplete,
+  nextOpenStep,
+  planProgress,
+  renderPlanReminder,
+  renderNoPlanReminder,
+  applyPlanToolCall,
+  planCompletionGate,
+  executionPlanProviderTools,
+  EXECUTION_PLAN_TOOL_DEFS,
+  EXECUTION_PLAN_TOOL_NAMES,
+  RECORD_PLAN_TOOL,
+  UPDATE_PLAN_STEP_TOOL,
+  type ExecutionPlan,
+} from "./execution-plan";
+
+describe("createExecutionPlan", () => {
+  it("builds a plan with deterministic step ids from string steps", () => {
+    const plan = createExecutionPlan({ goal: "ship feature", steps: ["read code", "write code", "test"] }, 0);
+    expect(plan).not.toBeNull();
+    expect(plan!.goal).toBe("ship feature");
+    expect(plan!.steps.map((s) => s.id)).toEqual(["s1", "s2", "s3"]);
+    expect(plan!.steps.every((s) => s.status === "pending")).toBe(true);
+    expect(plan!.createdAtIteration).toBe(0);
+  });
+
+  it("accepts object steps with a description field", () => {
+    const plan = createExecutionPlan({ goal: "g", steps: [{ description: "do a thing" }] }, 2);
+    expect(plan!.steps[0]).toMatchObject({ id: "s1", description: "do a thing", status: "pending" });
+  });
+
+  it("drops empty step descriptions and renumbers remaining ids", () => {
+    const plan = createExecutionPlan({ goal: "g", steps: ["", "  ", "real step"] }, 0);
+    expect(plan!.steps).toHaveLength(1);
+    expect(plan!.steps[0]!.id).toBe("s1");
+  });
+
+  it("returns null when there are no usable steps", () => {
+    expect(createExecutionPlan({ goal: "g", steps: [] }, 0)).toBeNull();
+    expect(createExecutionPlan({ goal: "g", steps: "not an array" }, 0)).toBeNull();
+    expect(createExecutionPlan({ goal: "g", steps: ["", ""] }, 0)).toBeNull();
+  });
+
+  it("caps steps at the maximum", () => {
+    const many = Array.from({ length: 40 }, (_, i) => `step ${i}`);
+    const plan = createExecutionPlan({ goal: "g", steps: many }, 0);
+    expect(plan!.steps.length).toBeLessThanOrEqual(25);
+  });
+});
+
+describe("updateStepStatus + progress", () => {
+  const base = createExecutionPlan({ goal: "g", steps: ["a", "b", "c"] }, 0)!;
+
+  it("does not mutate the input plan", () => {
+    const next = updateStepStatus(base, "s1", "done", 1);
+    expect(base.steps[0]!.status).toBe("pending");
+    expect(next.steps[0]!.status).toBe("done");
+    expect(next.updatedAtIteration).toBe(1);
+  });
+
+  it("is a no-op clone for an unknown step id", () => {
+    const next = updateStepStatus(base, "s99", "done", 5);
+    expect(next.steps).toEqual(base.steps);
+    expect(next.updatedAtIteration).toBe(base.updatedAtIteration);
+  });
+
+  it("computes open/done/total and completion", () => {
+    expect(planProgress(base)).toEqual({ done: 0, total: 3, open: 3 });
+    let p = updateStepStatus(base, "s1", "done", 1);
+    p = updateStepStatus(p, "s2", "skipped", 2);
+    expect(planProgress(p)).toEqual({ done: 2, total: 3, open: 1 });
+    expect(isPlanComplete(p)).toBe(false);
+    p = updateStepStatus(p, "s3", "done", 3);
+    expect(isPlanComplete(p)).toBe(true);
+    expect(openSteps(p)).toHaveLength(0);
+  });
+
+  it("nextOpenStep prefers in_progress then first pending", () => {
+    expect(nextOpenStep(base)!.id).toBe("s1");
+    const p = updateStepStatus(base, "s2", "in_progress", 1);
+    expect(nextOpenStep(p)!.id).toBe("s2");
+  });
+});
+
+describe("renderPlanReminder", () => {
+  it("renders progress, glyphs, and a next-step footer", () => {
+    let plan = createExecutionPlan({ goal: "do work", steps: ["a", "b"] }, 0)!;
+    plan = updateStepStatus(plan, "s1", "done", 1);
+    const text = renderPlanReminder(plan);
+    expect(text).toContain("(1/2 complete)");
+    expect(text).toContain("[x] s1");
+    expect(text).toContain("[ ] s2");
+    expect(text).toContain("Next open step: s2");
+  });
+
+  it("renders a final-summary footer when complete", () => {
+    let plan = createExecutionPlan({ goal: "g", steps: ["a"] }, 0)!;
+    plan = updateStepStatus(plan, "s1", "done", 1);
+    expect(renderPlanReminder(plan)).toContain("All steps are done");
+  });
+
+  it("renderNoPlanReminder tells the model to record a plan", () => {
+    expect(renderNoPlanReminder()).toContain(RECORD_PLAN_TOOL);
+  });
+});
+
+describe("applyPlanToolCall", () => {
+  it("records a plan from record_execution_plan", () => {
+    const { plan, result } = applyPlanToolCall(null, RECORD_PLAN_TOOL, { goal: "g", steps: ["a", "b"] }, 0);
+    expect(result.success).toBe(true);
+    expect(plan!.steps).toHaveLength(2);
+  });
+
+  it("rejects record_execution_plan with no steps", () => {
+    const { plan, result } = applyPlanToolCall(null, RECORD_PLAN_TOOL, { goal: "g", steps: [] }, 0);
+    expect(result.success).toBe(false);
+    expect(plan).toBeNull();
+  });
+
+  it("updates a step and normalises status variants", () => {
+    const created = applyPlanToolCall(null, RECORD_PLAN_TOOL, { goal: "g", steps: ["a"] }, 0).plan!;
+    const { plan, result } = applyPlanToolCall(created, UPDATE_PLAN_STEP_TOOL, { stepId: "s1", status: "completed" }, 1);
+    expect(result.success).toBe(true);
+    expect(plan!.steps[0]!.status).toBe("done");
+  });
+
+  it("rejects update before a plan exists", () => {
+    const { result } = applyPlanToolCall(null, UPDATE_PLAN_STEP_TOOL, { stepId: "s1", status: "done" }, 0);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("no_plan");
+  });
+
+  it("rejects an unknown step id and lists valid ids", () => {
+    const created = applyPlanToolCall(null, RECORD_PLAN_TOOL, { goal: "g", steps: ["a"] }, 0).plan!;
+    const { result } = applyPlanToolCall(created, UPDATE_PLAN_STEP_TOOL, { stepId: "s9", status: "done" }, 1);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("s1");
+  });
+
+  it("rejects an invalid status", () => {
+    const created = applyPlanToolCall(null, RECORD_PLAN_TOOL, { goal: "g", steps: ["a"] }, 0).plan!;
+    const { result } = applyPlanToolCall(created, UPDATE_PLAN_STEP_TOOL, { stepId: "s1", status: "banana" }, 1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("invalid_update");
+  });
+});
+
+describe("planCompletionGate", () => {
+  const incomplete: ExecutionPlan = createExecutionPlan({ goal: "g", steps: ["a", "b"] }, 0)!;
+  const complete = updateStepStatus(updateStepStatus(incomplete, "s1", "done", 1), "s2", "done", 1);
+
+  it("completes when there is no plan", () => {
+    expect(planCompletionGate({ plan: null, planNudges: 0, maxPlanNudges: 2 }).action).toBe("complete");
+  });
+
+  it("completes when the plan is fully closed", () => {
+    expect(planCompletionGate({ plan: complete, planNudges: 0, maxPlanNudges: 2 }).action).toBe("complete");
+  });
+
+  it("nudges toward the next open step when steps remain", () => {
+    const gate = planCompletionGate({ plan: incomplete, planNudges: 0, maxPlanNudges: 2 });
+    expect(gate.action).toBe("nudge");
+    expect(gate.nudge).toContain("s1");
+  });
+
+  it("stops nudging once the budget is spent (no infinite standoff)", () => {
+    expect(planCompletionGate({ plan: incomplete, planNudges: 2, maxPlanNudges: 2 }).action).toBe("complete");
+  });
+});
+
+describe("tool definitions", () => {
+  it("exposes exactly the two intrinsic plan tools with no capability gate", () => {
+    expect([...EXECUTION_PLAN_TOOL_NAMES].sort()).toEqual([RECORD_PLAN_TOOL, UPDATE_PLAN_STEP_TOOL].sort());
+    for (const def of EXECUTION_PLAN_TOOL_DEFS) {
+      expect(def.requiredCapability).toBeNull();
+      expect(def.sideEffect).toBe(false);
+      expect(def.executionMode).toBe("immediate");
+    }
+  });
+
+  it("emits OpenAI-wire-format provider tools matching the defs", () => {
+    const provider = executionPlanProviderTools();
+    expect(provider).toHaveLength(2);
+    expect(provider[0]).toMatchObject({ type: "function", function: { name: RECORD_PLAN_TOOL } });
+    expect((provider[1] as { function: { name: string } }).function.name).toBe(UPDATE_PLAN_STEP_TOOL);
+  });
+});

--- a/apps/web/lib/tak/execution-plan.ts
+++ b/apps/web/lib/tak/execution-plan.ts
@@ -1,0 +1,359 @@
+// apps/web/lib/tak/execution-plan.ts
+//
+// BI-2AC48661 (EP-F7E35344 — AI Coworker Capability Inputs).
+//
+// A persistent ExecutionPlan for the agentic loop. The loop compacts message
+// history to a sliding window of the last MAX_AGENTIC_HISTORY_MESSAGES every
+// iteration, so on a long, comprehensive task the model loses sight of the
+// original objective and re-derives intent from whatever survived the window.
+// Perplexity's Pro/Deep-Research mode separates *planning* from *execution*:
+// an explicit plan (objectives + steps) is authored once, then an execution
+// loop works the plan and refines it — the plan is a durable artifact, not a
+// message that scrolls out of context.
+//
+// This module is the plan artifact + the pure logic around it. The agentic
+// loop holds one ExecutionPlan in loop state (not in the compacted message
+// array), renders it into the prompt fresh every iteration (so it ALWAYS
+// survives compaction), and gates completion on open steps rather than on a
+// bare text-only reply. The two plan tools below are intercepted inside the
+// loop — they mutate loop state and never reach governedExecuteTool, so they
+// need no capability grant and write no audit row.
+//
+// Everything here is pure and synchronous, so it is fully unit-testable
+// without a running model, sandbox, or DB. Mutators return new objects and
+// never mutate their input.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+
+export type ExecutionPlanStepStatus = "pending" | "in_progress" | "done" | "skipped";
+
+/** A step is "open" while it still needs work — pending or in_progress. */
+const OPEN_STATUSES: ReadonlySet<ExecutionPlanStepStatus> = new Set(["pending", "in_progress"]);
+
+export type ExecutionPlanStep = {
+  id: string;
+  description: string;
+  status: ExecutionPlanStepStatus;
+};
+
+export type ExecutionPlan = {
+  goal: string;
+  steps: ExecutionPlanStep[];
+  /** Loop iteration the plan was first recorded — for observability only. */
+  createdAtIteration: number;
+  /** Loop iteration the plan was last mutated — for observability only. */
+  updatedAtIteration: number;
+};
+
+export const RECORD_PLAN_TOOL = "record_execution_plan";
+export const UPDATE_PLAN_STEP_TOOL = "update_execution_plan_step";
+
+/** Tool names the agentic loop intercepts and handles in-process. */
+export const EXECUTION_PLAN_TOOL_NAMES: ReadonlySet<string> = new Set([
+  RECORD_PLAN_TOOL,
+  UPDATE_PLAN_STEP_TOOL,
+]);
+
+const MAX_STEPS = 25;
+const MAX_GOAL_CHARS = 500;
+const MAX_STEP_CHARS = 300;
+
+function clamp(value: string, max: number): string {
+  const trimmed = value.trim();
+  return trimmed.length <= max ? trimmed : trimmed.slice(0, max);
+}
+
+function normaliseStatus(raw: unknown): ExecutionPlanStepStatus | null {
+  if (raw === "pending" || raw === "in_progress" || raw === "done" || raw === "skipped") {
+    return raw;
+  }
+  // Tolerate common model variants rather than rejecting the call outright.
+  if (raw === "in-progress" || raw === "started" || raw === "active") return "in_progress";
+  if (raw === "complete" || raw === "completed" || raw === "finished") return "done";
+  if (raw === "skip" || raw === "skipped" || raw === "cancelled" || raw === "canceled") return "skipped";
+  if (raw === "todo" || raw === "open" || raw === "not_started") return "pending";
+  return null;
+}
+
+/**
+ * Build a plan from a model-supplied goal + step descriptions. Step ids are
+ * assigned deterministically ("s1", "s2", …) so the model can reference them
+ * in update_execution_plan_step without us trusting model-authored ids.
+ */
+export function createExecutionPlan(
+  input: { goal: unknown; steps: unknown },
+  iteration: number,
+): ExecutionPlan | null {
+  const goal = typeof input.goal === "string" ? clamp(input.goal, MAX_GOAL_CHARS) : "";
+  const rawSteps = Array.isArray(input.steps) ? input.steps : [];
+  const steps: ExecutionPlanStep[] = [];
+  for (const raw of rawSteps) {
+    if (steps.length >= MAX_STEPS) break;
+    const description =
+      typeof raw === "string"
+        ? clamp(raw, MAX_STEP_CHARS)
+        : raw && typeof raw === "object" && typeof (raw as { description?: unknown }).description === "string"
+          ? clamp((raw as { description: string }).description, MAX_STEP_CHARS)
+          : "";
+    if (!description) continue;
+    steps.push({ id: `s${steps.length + 1}`, description, status: "pending" });
+  }
+  if (steps.length === 0) return null;
+  return {
+    goal,
+    steps,
+    createdAtIteration: iteration,
+    updatedAtIteration: iteration,
+  };
+}
+
+/** Return a new plan with one step's status changed. No-op clone if id unknown. */
+export function updateStepStatus(
+  plan: ExecutionPlan,
+  stepId: string,
+  status: ExecutionPlanStepStatus,
+  iteration: number,
+): ExecutionPlan {
+  let changed = false;
+  const steps = plan.steps.map((step) => {
+    if (step.id !== stepId || step.status === status) return step;
+    changed = true;
+    return { ...step, status };
+  });
+  return { ...plan, steps, updatedAtIteration: changed ? iteration : plan.updatedAtIteration };
+}
+
+export function openSteps(plan: ExecutionPlan): ExecutionPlanStep[] {
+  return plan.steps.filter((step) => OPEN_STATUSES.has(step.status));
+}
+
+/** The plan is complete when no step is still pending or in_progress. */
+export function isPlanComplete(plan: ExecutionPlan): boolean {
+  return openSteps(plan).length === 0;
+}
+
+export function nextOpenStep(plan: ExecutionPlan): ExecutionPlanStep | null {
+  // Prefer an in_progress step, else the first pending one.
+  return (
+    plan.steps.find((step) => step.status === "in_progress") ??
+    plan.steps.find((step) => step.status === "pending") ??
+    null
+  );
+}
+
+export function planProgress(plan: ExecutionPlan): { done: number; total: number; open: number } {
+  const total = plan.steps.length;
+  const open = openSteps(plan).length;
+  return { done: total - open, total, open };
+}
+
+const STATUS_GLYPH: Record<ExecutionPlanStepStatus, string> = {
+  pending: "[ ]",
+  in_progress: "[~]",
+  done: "[x]",
+  skipped: "[-]",
+};
+
+/**
+ * Render the plan as a compact reminder block. The loop appends this as an
+ * ephemeral message every iteration — it is NOT stored in the persisted
+ * message array, so it is regenerated from current state each turn and can
+ * never be compacted away. This is the "reads the plan outside the compacted
+ * window" mechanism.
+ */
+export function renderPlanReminder(plan: ExecutionPlan): string {
+  const { done, total } = planProgress(plan);
+  const lines = plan.steps.map((step) => `  ${STATUS_GLYPH[step.status]} ${step.id}: ${step.description}`);
+  const next = nextOpenStep(plan);
+  const footer = next
+    ? `Next open step: ${next.id} — ${next.description}. When you finish a step call ${UPDATE_PLAN_STEP_TOOL} ` +
+      `with its status, then keep working. Do not stop until every step is done or skipped.`
+    : `All steps are done or skipped — you may now give your final summary.`;
+  return (
+    `## Execution plan (${done}/${total} complete)\n` +
+    `Goal: ${plan.goal || "(unstated)"}\n` +
+    `${lines.join("\n")}\n` +
+    footer
+  );
+}
+
+/** Shown when planning is enabled but the model has not recorded a plan yet. */
+export function renderNoPlanReminder(): string {
+  return (
+    `## Execution plan\n` +
+    `No execution plan recorded yet. For any multi-step task, call ${RECORD_PLAN_TOOL} ` +
+    `with a short goal and an ordered list of concrete steps BEFORE doing the work, ` +
+    `then work the steps and mark each one with ${UPDATE_PLAN_STEP_TOOL} as you go. ` +
+    `Skip this only for a trivial single-step request.`
+  );
+}
+
+/**
+ * Apply an intercepted plan tool call to loop state. Returns the next plan and
+ * a synthetic ToolResult to feed back to the model. Pure — caller owns state.
+ */
+export function applyPlanToolCall(
+  plan: ExecutionPlan | null,
+  toolName: string,
+  args: Record<string, unknown>,
+  iteration: number,
+): { plan: ExecutionPlan | null; result: ToolResult } {
+  if (toolName === RECORD_PLAN_TOOL) {
+    const next = createExecutionPlan({ goal: args.goal, steps: args.steps }, iteration);
+    if (!next) {
+      return {
+        plan,
+        result: {
+          success: false,
+          error: "invalid_plan",
+          message: `${RECORD_PLAN_TOOL} needs a non-empty "steps" array of step descriptions.`,
+        },
+      };
+    }
+    const { done, total } = planProgress(next);
+    return {
+      plan: next,
+      result: {
+        success: true,
+        message: `Execution plan recorded: ${total} step(s), ${done} already complete. ${renderPlanReminder(next)}`,
+        data: { goal: next.goal, steps: next.steps },
+      },
+    };
+  }
+
+  if (toolName === UPDATE_PLAN_STEP_TOOL) {
+    if (!plan) {
+      return {
+        plan,
+        result: {
+          success: false,
+          error: "no_plan",
+          message: `No execution plan exists yet — call ${RECORD_PLAN_TOOL} first.`,
+        },
+      };
+    }
+    const stepId = typeof args.stepId === "string" ? args.stepId : "";
+    const status = normaliseStatus(args.status);
+    if (!stepId || !status) {
+      return {
+        plan,
+        result: {
+          success: false,
+          error: "invalid_update",
+          message: `${UPDATE_PLAN_STEP_TOOL} needs "stepId" and a "status" of pending|in_progress|done|skipped.`,
+        },
+      };
+    }
+    if (!plan.steps.some((step) => step.id === stepId)) {
+      return {
+        plan,
+        result: {
+          success: false,
+          error: "unknown_step",
+          message: `No step "${stepId}" in the plan. Valid ids: ${plan.steps.map((s) => s.id).join(", ")}.`,
+        },
+      };
+    }
+    const next = updateStepStatus(plan, stepId, status, iteration);
+    return {
+      plan: next,
+      result: {
+        success: true,
+        message: `Step ${stepId} → ${status}. ${renderPlanReminder(next)}`,
+        data: { steps: next.steps },
+      },
+    };
+  }
+
+  return {
+    plan,
+    result: { success: false, error: "unknown_tool", message: `${toolName} is not an execution-plan tool.` },
+  };
+}
+
+/**
+ * Completion gate. Called when the model returns text-only (its natural
+ * "done" signal). With a plan that still has open steps, the loop should nudge
+ * the model back to work rather than accept the stop — UNLESS we have already
+ * spent the plan-nudge budget (avoids an infinite plan-vs-model standoff).
+ */
+export function planCompletionGate(params: {
+  plan: ExecutionPlan | null;
+  planNudges: number;
+  maxPlanNudges: number;
+}): { action: "complete" | "nudge"; nudge?: string } {
+  const { plan, planNudges, maxPlanNudges } = params;
+  if (!plan) return { action: "complete" };
+  if (isPlanComplete(plan)) return { action: "complete" };
+  if (planNudges >= maxPlanNudges) return { action: "complete" };
+  const next = nextOpenStep(plan);
+  const { done, total } = planProgress(plan);
+  return {
+    action: "nudge",
+    nudge:
+      `Your execution plan still has open steps (${done}/${total} done). Do not stop yet. ` +
+      (next ? `Continue with ${next.id}: ${next.description}. ` : "") +
+      `Use your tools to complete it, then mark it with ${UPDATE_PLAN_STEP_TOOL}. ` +
+      `If a step genuinely cannot be done, mark it "skipped" with ${UPDATE_PLAN_STEP_TOOL} and explain why.`,
+  };
+}
+
+const STEP_STATUS_VALUES: ExecutionPlanStepStatus[] = ["pending", "in_progress", "done", "skipped"];
+
+/** ToolDefinition objects for the two plan tools (loop-intrinsic, no capability gate). */
+export const EXECUTION_PLAN_TOOL_DEFS: ToolDefinition[] = [
+  {
+    name: RECORD_PLAN_TOOL,
+    description:
+      "Record an execution plan for a multi-step task: a short goal and an ordered list of concrete steps. " +
+      "Call this BEFORE starting the work. The plan persists across the whole task and is shown to you every turn, " +
+      "even after older messages scroll out of context. Re-call it to replace the plan if scope changes materially.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        goal: { type: "string", description: "One sentence: what completing this task achieves." },
+        steps: {
+          type: "array",
+          description: "Ordered concrete steps. Each is a short imperative phrase.",
+          items: { type: "string" },
+          minItems: 1,
+          maxItems: MAX_STEPS,
+        },
+      },
+      required: ["steps"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: UPDATE_PLAN_STEP_TOOL,
+    description:
+      "Update one execution-plan step's status as you make progress. Mark a step in_progress when you start it " +
+      "and done when it is verifiably complete (or skipped if it genuinely cannot be done). The loop will not let " +
+      "you stop while steps remain open.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        stepId: { type: "string", description: 'The step id from the plan, e.g. "s2".' },
+        status: { type: "string", enum: STEP_STATUS_VALUES },
+      },
+      required: ["stepId", "status"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+];
+
+/** OpenAI-wire-format versions for toolsForProvider (matches toolsToOpenAIFormat). */
+export function executionPlanProviderTools(): Array<Record<string, unknown>> {
+  return EXECUTION_PLAN_TOOL_DEFS.map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema,
+    },
+  }));
+}


### PR DESCRIPTION
## What & why

Closes **BI-2AC48661** under epic **EP-F7E35344** (AI Coworker Capability Inputs — Perplexity-lessons gap closure). Spec: `docs/superpowers/specs/2026-06-18-perplexity-architecture-lessons-analysis.md` (Lesson B).

`runAgenticLoop` compacts message history to a 24-message sliding window every iteration, so on a long, comprehensive task the model loses the original objective and re-derives intent from whatever survived the window. Perplexity's Pro/Deep-Research mode separates *planning* from *execution* — an explicit plan is a durable artifact, not a message that scrolls out of context. This adds that capability.

## Change

- **`apps/web/lib/tak/execution-plan.ts`** (new): pure plan model (`goal` + ordered steps with status), helpers (`createExecutionPlan`, `updateStepStatus`, `isPlanComplete`, `renderPlanReminder`, `planCompletionGate`), the two loop-intrinsic tools (`record_execution_plan`, `update_execution_plan_step`), and OpenAI-wire-format provider tools.
- **`apps/web/lib/tak/agentic-loop.ts`**: opt-in `enableExecutionPlan` param. When on, the loop exposes the plan tools, **intercepts** them in-process (they never reach `governedExecuteTool`, take no capability grant, write no audit row), injects the plan reminder **outside the compacted window** every iteration (so it can never scroll away), and **bounces a premature text-only stop** while steps remain open (capped at 2 nudges — no infinite standoff). Plan surfaced on `AgenticResult.executionPlan`.

## Safety / blast radius

**Default OFF.** Every existing caller is byte-for-byte unchanged until it opts in. Activation per surface (+ runtime UX verification) lands with the streamed-plan work in **BI-95C0835E**. This is the deliberate "land the mechanism dark, activate in a follow-up" path for a load-bearing loop.

## Verification

Substrate: **isolated git worktree, source-local gates** (this is a library-only, default-off change with no route/UI surface; runtime gates are N/A until a caller activates it).
- `pnpm --filter web typecheck` — clean.
- `pnpm --filter web exec vitest run lib/tak` — **108/108** (24 new pure-module cases + 4 new loop integration cases + 80 pre-existing loop tests **unchanged**, confirming the default-off no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)