### PR TITLE
feat(routing): infer reasoning depth from prompt content (BI-08CE1ADF)

### DIFF
--- a/apps/web/lib/routing/request-contract.email.test.ts
+++ b/apps/web/lib/routing/request-contract.email.test.ts
@@ -31,10 +31,13 @@ describe("inferContract honours task-requirement routing-posture defaults", () =
     expect(c.residencyPolicy).toBeUndefined();
   });
 
-  it("unknown task type falls back to balanced + medium, no residency", async () => {
+  it("unknown task type falls back to balanced posture, no residency; depth from content (BI-08CE1ADF)", async () => {
     const c = await inferContract("totally-unknown-task-xyz", MSGS);
     expect(c.budgetClass).toBe("balanced");
-    expect(c.reasoningDepth).toBe("medium");
+    // No declared depth for this task type → classified from content. MSGS is a
+    // bare "hello" greeting, so the classifier returns minimal (was a blanket
+    // "medium" before the content classifier landed).
+    expect(c.reasoningDepth).toBe("minimal");
     expect(c.residencyPolicy).toBeUndefined();
   });
 });

--- a/apps/web/lib/routing/request-contract.test.ts
+++ b/apps/web/lib/routing/request-contract.test.ts
@@ -154,9 +154,29 @@ describe("inferContract – reasoning depth", () => {
     });
   }
 
-  it("defaults unknown task types to medium", async () => {
+  it("classifies an unmapped task type's depth from content — ordinary ask stays medium", async () => {
     const contract = await inferContract("totally-unknown-task", SIMPLE_MESSAGES);
     expect(contract.reasoningDepth).toBe("medium");
+  });
+
+  // BI-08CE1ADF: for a task type with no declared depth, the classifier reads
+  // the prompt content instead of the old blanket "medium".
+  it("raises an unmapped task type to high for complex content", async () => {
+    const msgs = [textMsg("user", "Investigate the root cause and refactor the scheduler step-by-step")];
+    const contract = await inferContract("conversation", msgs);
+    expect(contract.reasoningDepth).toBe("high");
+  });
+
+  it("lowers an unmapped task type to minimal for a bare greeting", async () => {
+    const contract = await inferContract("conversation", [textMsg("user", "hi")]);
+    expect(contract.reasoningDepth).toBe("minimal");
+  });
+
+  it("does NOT let content classification override a mapped task type's declared depth", async () => {
+    // "summarization" is declared "low" — a complex-sounding prompt must not raise it.
+    const msgs = [textMsg("user", "Investigate the root cause and refactor everything step-by-step")];
+    const contract = await inferContract("summarization", msgs);
+    expect(contract.reasoningDepth).toBe("low");
   });
 });
 

--- a/apps/web/lib/routing/request-contract.ts
+++ b/apps/web/lib/routing/request-contract.ts
@@ -12,6 +12,7 @@
 
 import { randomUUID } from "crypto";
 import type { ModelClass } from "./model-card-types";
+import { classifyTask } from "./task-classifier";
 
 // ── RequestContract type ────────────────────────────────────────────────────
 
@@ -219,9 +220,17 @@ export async function inferContract(
     RequestContract["budgetClass"];
 
   // ── Reasoning depth ───────────────────────────────────────────────────
-  // Requirement default wins, then the per-task-type heuristic, then "medium".
-  const reasoningDepth = (taskReq?.reasoningDepthDefault ?? DEFAULT_REASONING_DEPTH[taskType] ?? "medium") as
-    RequestContract["reasoningDepth"];
+  // Requirement default wins, then the per-task-type heuristic. BI-08CE1ADF:
+  // when the task type carries NO declared depth (e.g. the ubiquitous default
+  // taskType "conversation", which maps to nothing), classify the prompt
+  // CONTENT instead of falling through to a blanket "medium" — DPF's analogue
+  // of Perplexity's "Best" auto-router. This only affects task types that were
+  // already hitting the neutral default; every mapped type is unchanged.
+  const reasoningDepth = (
+    taskReq?.reasoningDepthDefault ??
+    DEFAULT_REASONING_DEPTH[taskType] ??
+    classifyTask(messages).reasoningDepth
+  ) as RequestContract["reasoningDepth"];
 
   // ── Contract family ───────────────────────────────────────────────────
   const contractFamily = `${interactionMode}.${taskType}`;

--- a/apps/web/lib/routing/task-classifier.test.ts
+++ b/apps/web/lib/routing/task-classifier.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { classifyTask } from "./task-classifier";
+
+function u(text: string) {
+  return [{ role: "user", content: text }];
+}
+
+describe("classifyTask — trivial", () => {
+  it.each(["hi", "Hello!", "thanks", "Thank you", "ok", "got it", "sounds good"])(
+    "treats pure greeting %j as trivial/minimal",
+    (text) => {
+      const c = classifyTask(u(text));
+      expect(c.complexity).toBe("trivial");
+      expect(c.reasoningDepth).toBe("minimal");
+      expect(c.archetype).toBe("greeting");
+    },
+  );
+
+  it("treats a short status ask as trivial/low", () => {
+    const c = classifyTask(u("what's the status?"));
+    expect(c.complexity).toBe("trivial");
+    expect(c.reasoningDepth).toBe("low");
+    expect(c.archetype).toBe("status");
+  });
+
+  it("does not treat a greeting embedded in a longer sentence as trivial", () => {
+    const c = classifyTask(u("Hello, can you walk me through how the routing pipeline ranks endpoints?"));
+    expect(c.complexity).not.toBe("trivial");
+  });
+});
+
+describe("classifyTask — complex", () => {
+  it("flags explicit multi-step / architectural language as complex/high", () => {
+    for (const text of [
+      "Refactor the auth module and migrate the sessions table",
+      "Walk me through this step-by-step and analyze the trade-offs",
+      "Investigate the root cause of the latency regression",
+      "Design the architecture for a new billing service",
+    ]) {
+      const c = classifyTask(u(text));
+      expect(c.complexity, text).toBe("complex");
+      expect(c.reasoningDepth, text).toBe("high");
+    }
+  });
+
+  it("flags a code block as complex", () => {
+    const c = classifyTask(u("why does this throw?\n```ts\nconst x = foo()\n```"));
+    expect(c.complexity).toBe("complex");
+    expect(c.archetype).toBe("analysis");
+  });
+
+  it("flags very long input as complex", () => {
+    const c = classifyTask(u("please summarize. ".repeat(120))); // > 1500 chars
+    expect(c.complexity).toBe("complex");
+  });
+
+  it("flags three or more questions as complex", () => {
+    const c = classifyTask(u("What is it? How does it work? Why was it chosen?"));
+    expect(c.complexity).toBe("complex");
+    expect(c.signals).toContain("multi-question");
+  });
+});
+
+describe("classifyTask — standard (the conservative default)", () => {
+  it("leaves an ordinary single request at standard/medium", () => {
+    const c = classifyTask(u("Add a phone number field to the customer form"));
+    expect(c.complexity).toBe("standard");
+    expect(c.reasoningDepth).toBe("medium");
+  });
+
+  it("tags generation verbs as the generation archetype but still standard", () => {
+    const c = classifyTask(u("Write a welcome email for new signups"));
+    expect(c.complexity).toBe("standard");
+    expect(c.archetype).toBe("generation");
+  });
+
+  it("reads the latest user message, not assistant turns", () => {
+    const msgs = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "Hello! How can I help?" },
+      { role: "user", content: "Refactor the scheduler to support cron expressions" },
+    ];
+    const c = classifyTask(msgs);
+    expect(c.complexity).toBe("complex");
+  });
+
+  it("handles multimodal content arrays without throwing", () => {
+    const msgs = [{ role: "user", content: [{ type: "text", text: "what's the status?" }, { type: "image" }] }];
+    const c = classifyTask(msgs);
+    expect(c.archetype).toBe("status");
+  });
+
+  it("handles empty input deterministically", () => {
+    expect(classifyTask([]).complexity).toBe("standard");
+  });
+});

--- a/apps/web/lib/routing/task-classifier.ts
+++ b/apps/web/lib/routing/task-classifier.ts
@@ -1,0 +1,127 @@
+/**
+ * BI-08CE1ADF (EP-F7E35344 — AI Coworker Capability Inputs).
+ *
+ * A cheap, deterministic task classifier — DPF's analogue of Perplexity's
+ * "Best" auto-router. Today a request's quality posture (reasoning depth →
+ * the cost-per-success quality floor) is *caller-declared* via taskType, and
+ * the very common default taskType `"conversation"` maps to nothing, so it
+ * falls through to a blanket "medium". The result: a one-word greeting and a
+ * multi-step refactor route with the same floor.
+ *
+ * This module infers complexity from the prompt CONTENT (no extra LLM call —
+ * pure heuristics, so it is free and fully unit-testable). `inferContract`
+ * uses it ONLY as the fallback when the task type carries no declared reasoning
+ * depth, so every mapped task type and every explicit caller posture is
+ * unchanged. The heuristics are intentionally conservative: only a clear
+ * trivial signal lowers the floor, only a clear complex signal raises it,
+ * everything else stays "medium".
+ *
+ * A future upgrade can swap the heuristic for a Haiku-class classification call
+ * behind the same `classifyTask` signature without touching callers.
+ */
+
+export type TaskComplexity = "trivial" | "standard" | "complex";
+
+export type TaskArchetype =
+  | "greeting"
+  | "status"
+  | "lookup"
+  | "generation"
+  | "analysis"
+  | "general";
+
+export interface TaskClassification {
+  complexity: TaskComplexity;
+  reasoningDepth: "minimal" | "low" | "medium" | "high";
+  archetype: TaskArchetype;
+  /** Human-readable reasons, for routing observability. */
+  signals: string[];
+}
+
+// Pure greeting / acknowledgement — nothing to reason about.
+const GREETING_RE =
+  /^(?:hi|hey|hello|yo|howdy|good (?:morning|afternoon|evening)|thanks?|thank you|thx|ok(?:ay)?|cool|great|got it|sounds good|nice|perfect|cheers)[\s!.]*$/i;
+
+// Short status / lookup asks — shallow retrieval, not deep reasoning.
+const STATUS_RE =
+  /\b(?:status|what'?s the status|any update|is it (?:done|ready|up)|list|show me|what are|how many|when (?:is|does|did)|where is)\b/i;
+
+// Markers of genuinely complex, multi-step work that warrant a stronger model.
+const COMPLEX_RE =
+  /\b(?:step[- ]by[- ]step|step \d|architect(?:ure|ural)?|design (?:a|the|doc)|refactor|migrat(?:e|ion)|investigat(?:e|ion)|root cause|debug|trace through|analy[sz]e|compare (?:and|the)|trade[- ]?offs?|implement(?:ation)?|end[- ]to[- ]end|comprehensive|in depth|reason through|prove|derive|optimi[sz]e|plan (?:out|the|a)|break (?:this|it) down|multi[- ]step)\b/i;
+
+// Generation verbs — writing/building substantial output (default standard).
+const GENERATION_RE =
+  /\b(?:write|generate|create|build|draft|compose|produce|code|script|function|component)\b/i;
+
+// Code / diff fences strongly imply non-trivial work.
+const CODE_BLOCK_RE = /```|^\s*(?:diff --git|@@ |[+-]{3} )/m;
+
+const LONG_INPUT_CHARS = 1500;
+const SHORT_INPUT_CHARS = 60;
+
+function messageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && typeof part === "object" && "text" in part && typeof (part as { text?: unknown }).text === "string"
+          ? (part as { text: string }).text
+          : "",
+      )
+      .join(" ");
+  }
+  return "";
+}
+
+function depthFor(complexity: TaskComplexity, archetype: TaskArchetype): TaskClassification["reasoningDepth"] {
+  if (complexity === "complex") return "high";
+  if (complexity === "trivial") return archetype === "greeting" ? "minimal" : "low";
+  return "medium";
+}
+
+/**
+ * Classify a request from its messages. Examines the latest user message (the
+ * actual ask) plus total input size. Pure and synchronous.
+ */
+export function classifyTask(messages: Array<{ role: string; content: unknown }>): TaskClassification {
+  const userTexts = messages.filter((m) => m.role === "user").map((m) => messageText(m.content));
+  const latest = (userTexts[userTexts.length - 1] ?? "").trim();
+  const totalChars = messages.reduce((sum, m) => sum + messageText(m.content).length, 0);
+  const signals: string[] = [];
+
+  // ── Trivial: pure greeting / acknowledgement ──────────────────────────
+  if (latest.length > 0 && latest.length <= 40 && GREETING_RE.test(latest)) {
+    return { complexity: "trivial", reasoningDepth: "minimal", archetype: "greeting", signals: ["greeting"] };
+  }
+
+  const hasCode = CODE_BLOCK_RE.test(latest);
+  const isComplexLang = COMPLEX_RE.test(latest);
+  const isLong = totalChars >= LONG_INPUT_CHARS;
+  const isShort = latest.length > 0 && latest.length <= SHORT_INPUT_CHARS;
+  const isStatus = STATUS_RE.test(latest);
+  const questionCount = (latest.match(/\?/g) ?? []).length;
+
+  // ── Complex: explicit complex language, code/diffs, very long, or many asks ─
+  if (isComplexLang) signals.push("complex-language");
+  if (hasCode) signals.push("code-or-diff");
+  if (isLong) signals.push("long-input");
+  if (questionCount >= 3) signals.push("multi-question");
+  if (isComplexLang || hasCode || isLong || questionCount >= 3) {
+    const archetype: TaskArchetype = isComplexLang || hasCode ? "analysis" : "general";
+    return { complexity: "complex", reasoningDepth: "high", archetype, signals };
+  }
+
+  // ── Trivial: short status / lookup ────────────────────────────────────
+  if (isStatus && isShort) {
+    return { complexity: "trivial", reasoningDepth: "low", archetype: "status", signals: ["short-status"] };
+  }
+  if (isStatus) {
+    return { complexity: "standard", reasoningDepth: "medium", archetype: "lookup", signals: ["status-lookup"] };
+  }
+
+  // ── Standard: everything else ─────────────────────────────────────────
+  const archetype: TaskArchetype = GENERATION_RE.test(latest) ? "generation" : "general";
+  signals.push("default-standard");
+  return { complexity: "standard", reasoningDepth: depthFor("standard", archetype), archetype, signals };
+}


### PR DESCRIPTION
## What & why

Closes **BI-08CE1ADF** under epic **EP-F7E35344** (AI Coworker Capability Inputs). Spec: `docs/superpowers/specs/2026-06-18-perplexity-architecture-lessons-analysis.md` (Lesson A).

A request's quality posture — `reasoningDepth`, which drives the `REASONING_DEPTH_FLOORS` quality floor in cost-per-success ranking — was **caller-declared** via `taskType`. The ubiquitous default `taskType="conversation"` (the agentic loop's default) maps to nothing in `DEFAULT_REASONING_DEPTH` / `TaskRequirement`, so it fell through to a blanket `"medium"`. A one-word greeting and a multi-step refactor routed with the **same** floor — the routing machinery was sophisticated but starved of a signal about what the task actually needs.

## Change

- **`apps/web/lib/routing/task-classifier.ts`** (new): pure, deterministic `classifyTask(messages)` → `{ complexity, reasoningDepth, archetype, signals }`. DPF's analogue of Perplexity's "Best" auto-router. **Conservative by design**: only a clear trivial signal lowers the floor (greeting → `minimal`, short status → `low`), only a clear complex signal raises it (multi-step/architectural language, code/diff fences, very long input, 3+ questions → `high`); everything else stays `medium`. No extra LLM call.
- **`apps/web/lib/routing/request-contract.ts`**: the classifier feeds `reasoningDepth` **only** when both `taskReq.reasoningDepthDefault` and `DEFAULT_REASONING_DEPTH[taskType]` are absent — i.e. exactly the unmapped types that were already hitting the neutral default.

## Safety / blast radius

Every **mapped** task type (greeting, code-gen, reasoning, summarization, …) and every **explicit caller posture** is byte-for-byte unchanged — verified by the existing `inferContract` reasoning-depth cases, which still pass. Only previously-unmapped types (chiefly `"conversation"`) change, and only from a blind `medium` to a content-aware depth. A future Haiku-class classifier can drop in behind the same `classifyTask` signature.

## Verification

Substrate: **isolated git worktree, source-local gates** (pure library + contract logic, no route/UI surface).
- `pnpm --filter web typecheck` — clean.
- `pnpm --filter web exec vitest run lib/routing` — **1053/1053** (18 new classifier cases + new contract integration cases; one pre-existing email-contract test updated to reflect the intended content-aware depth, with rationale in-line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)