### PR TITLE
feat(routing): seed day-1 pricing coverage + per-archetype golden sets (BI-6F42465E)

### DIFF
--- a/apps/web/lib/routing/golden-tests.test.ts
+++ b/apps/web/lib/routing/golden-tests.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  GOLDEN_TESTS,
+  getTestsForDimension,
+  getTestsForTaskType,
+  GOLDEN_TEST_TASK_TYPES,
+} from "./golden-tests";
+
+describe("getTestsForTaskType (per-archetype golden sets)", () => {
+  it("returns the codegen + instruction-following tests for code-gen, primary dimension first", () => {
+    const tests = getTestsForTaskType("code-gen");
+    expect(tests.length).toBeGreaterThan(0);
+    // code-gen maps to codegen (1.0) then instructionFollowing (0.5).
+    const dims = tests.map((t) => t.dimension);
+    expect(dims).toContain("codegen");
+    expect(dims).toContain("instructionFollowing");
+    // primary (codegen) tests precede the secondary ones.
+    expect(dims.indexOf("codegen")).toBeLessThan(dims.lastIndexOf("instructionFollowing"));
+  });
+
+  it("returns only the reasoning tests for the reasoning archetype", () => {
+    const tests = getTestsForTaskType("reasoning");
+    expect(tests.length).toBeGreaterThan(0);
+    expect(tests.every((t) => t.dimension === "reasoning")).toBe(true);
+    expect(tests).toEqual(getTestsForDimension("reasoning"));
+  });
+
+  it("de-duplicates when two dimensions would surface the same test", () => {
+    const tests = getTestsForTaskType("creative"); // conversational + reasoning
+    const ids = tests.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("returns an empty set for an unknown task type (caller falls back to full sweep)", () => {
+    expect(getTestsForTaskType("totally-unknown")).toEqual([]);
+    expect(getTestsForTaskType("")).toEqual([]);
+  });
+
+  it("every known task type resolves to at least one golden test", () => {
+    for (const taskType of GOLDEN_TEST_TASK_TYPES) {
+      expect(getTestsForTaskType(taskType).length, taskType).toBeGreaterThan(0);
+    }
+  });
+
+  it("only draws from the canonical GOLDEN_TESTS registry", () => {
+    const allIds = new Set(GOLDEN_TESTS.map((t) => t.id));
+    for (const taskType of GOLDEN_TEST_TASK_TYPES) {
+      for (const t of getTestsForTaskType(taskType)) {
+        expect(allIds.has(t.id)).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/lib/routing/golden-tests.ts
+++ b/apps/web/lib/routing/golden-tests.ts
@@ -4,6 +4,7 @@
  * These are the primary authority for capability scores.
  */
 import type { BuiltinDimension } from "./types";
+import { getDimensionsForTask, KNOWN_TASK_TYPES } from "./task-dimension-map";
 
 export type ScoringMethod =
   | "exact"        // exact string match
@@ -382,3 +383,35 @@ export const GOLDEN_TESTS: GoldenTest[] = [
 export function getTestsForDimension(dimension: BuiltinDimension): GoldenTest[] {
   return GOLDEN_TESTS.filter((t) => t.dimension === dimension);
 }
+
+/**
+ * BI-6F42465E: per-archetype (per-task-type) golden set. Assembles the golden
+ * tests relevant to a given task archetype by following the shared
+ * task-type → dimension mapping, so evals can be scoped to "the capabilities
+ * this kind of task actually exercises" rather than re-running the entire
+ * dimension suite. This is the bridge from the task classifier's archetypes
+ * (BI-08CE1ADF) to the eval corpus — the analogue of tying SimpleQA to
+ * factuality rather than to a generic benchmark.
+ *
+ * Returns tests for the task's mapped dimensions, de-duplicated and ordered by
+ * the mapping weight (primary-dimension tests first). An unknown task type
+ * yields an empty set (caller falls back to the full dimension sweep).
+ */
+export function getTestsForTaskType(taskType: string): GoldenTest[] {
+  const mappings = getDimensionsForTask(taskType);
+  if (mappings.length === 0) return [];
+  const ordered = [...mappings].sort((a, b) => b.weight - a.weight);
+  const seen = new Set<string>();
+  const tests: GoldenTest[] = [];
+  for (const { dimension } of ordered) {
+    for (const test of getTestsForDimension(dimension)) {
+      if (seen.has(test.id)) continue;
+      seen.add(test.id);
+      tests.push(test);
+    }
+  }
+  return tests;
+}
+
+/** The task archetypes that have a golden set (those with a dimension mapping). */
+export const GOLDEN_TEST_TASK_TYPES: string[] = KNOWN_TASK_TYPES;

--- a/apps/web/lib/routing/index.ts
+++ b/apps/web/lib/routing/index.ts
@@ -25,7 +25,7 @@ export type { FallbackResult } from "./fallback";
 export { runDimensionEval, runAllDimensionEvals, computeNewScore, detectDrift } from "./eval-runner";
 export type { EvalRunResult } from "./eval-runner";
 export { scoreDimension } from "./eval-scoring";
-export { GOLDEN_TESTS, getTestsForDimension } from "./golden-tests";
+export { GOLDEN_TESTS, getTestsForDimension, getTestsForTaskType, GOLDEN_TEST_TASK_TYPES } from "./golden-tests";
 export { updateEndpointDimensionScores } from "./production-feedback";
 export { getBaselineForModel } from "./family-baselines";
 export type { FamilyBaseline } from "./family-baselines";

--- a/apps/web/lib/routing/production-feedback.ts
+++ b/apps/web/lib/routing/production-feedback.ts
@@ -5,37 +5,19 @@
  * propagate to ModelProvider once threshold is met.
  */
 import { prisma } from "@dpf/db";
-import type { BuiltinDimension } from "./types";
 
 // ── Task-to-Dimension Mapping ────────────────────────────────────────────────
-
-interface DimensionMapping {
-  dimension: BuiltinDimension;
-  weight: number; // 1.0 for primary, 0.5 for secondary
-}
-
-const TASK_DIMENSION_MAP: Record<string, DimensionMapping[]> = {
-  "reasoning":       [{ dimension: "reasoning", weight: 1.0 }],
-  "code-gen":        [{ dimension: "codegen", weight: 1.0 }, { dimension: "instructionFollowing", weight: 0.5 }],
-  "tool-action":     [{ dimension: "toolFidelity", weight: 1.0 }],
-  "data-extraction": [{ dimension: "structuredOutput", weight: 1.0 }],
-  "summarization":   [{ dimension: "instructionFollowing", weight: 1.0 }],
-  "greeting":        [{ dimension: "conversational", weight: 1.0 }],
-  "creative":        [{ dimension: "conversational", weight: 1.0 }, { dimension: "reasoning", weight: 0.5 }],
-  "web-search":      [{ dimension: "toolFidelity", weight: 1.0 }],
-  "status-query":    [{ dimension: "instructionFollowing", weight: 1.0 }],
-};
-
-/** Get the dimension mappings for a task type. Returns empty for unknown. */
-export function getDimensionsForTask(taskType: string): DimensionMapping[] {
-  if (!taskType) return [];
-  return TASK_DIMENSION_MAP[taskType] ?? [];
-}
-
-/** Compute the dimension delta from an orchestrator score (1-5). */
-export function computeObservationDelta(orchestratorScore: number): number {
-  return (orchestratorScore - 3) * 4;
-}
+// The mapping itself now lives in the prisma-free task-dimension-map module so
+// the golden-test archetype grouping can share it (BI-6F42465E). Re-exported
+// here for backward compatibility with existing importers (cost-ranking, tests).
+export {
+  type DimensionMapping,
+  TASK_DIMENSION_MAP,
+  KNOWN_TASK_TYPES,
+  getDimensionsForTask,
+  computeObservationDelta,
+} from "./task-dimension-map";
+import { getDimensionsForTask, computeObservationDelta } from "./task-dimension-map";
 
 // ── Accumulation & Propagation ───────────────────────────────────────────────
 

--- a/apps/web/lib/routing/task-dimension-map.ts
+++ b/apps/web/lib/routing/task-dimension-map.ts
@@ -1,0 +1,41 @@
+/**
+ * Task-type → capability-dimension mapping.
+ *
+ * Extracted from production-feedback.ts (BI-6F42465E) into a pure, prisma-free
+ * module so both the production-feedback accumulator AND the golden-test
+ * archetype grouping can share one source of truth for "which dimensions
+ * matter for this kind of task." production-feedback.ts re-exports these for
+ * backward compatibility.
+ */
+import type { BuiltinDimension } from "./types";
+
+export interface DimensionMapping {
+  dimension: BuiltinDimension;
+  weight: number; // 1.0 for primary, 0.5 for secondary
+}
+
+export const TASK_DIMENSION_MAP: Record<string, DimensionMapping[]> = {
+  "reasoning":       [{ dimension: "reasoning", weight: 1.0 }],
+  "code-gen":        [{ dimension: "codegen", weight: 1.0 }, { dimension: "instructionFollowing", weight: 0.5 }],
+  "tool-action":     [{ dimension: "toolFidelity", weight: 1.0 }],
+  "data-extraction": [{ dimension: "structuredOutput", weight: 1.0 }],
+  "summarization":   [{ dimension: "instructionFollowing", weight: 1.0 }],
+  "greeting":        [{ dimension: "conversational", weight: 1.0 }],
+  "creative":        [{ dimension: "conversational", weight: 1.0 }, { dimension: "reasoning", weight: 0.5 }],
+  "web-search":      [{ dimension: "toolFidelity", weight: 1.0 }],
+  "status-query":    [{ dimension: "instructionFollowing", weight: 1.0 }],
+};
+
+/** The task types with a declared dimension mapping. */
+export const KNOWN_TASK_TYPES: string[] = Object.keys(TASK_DIMENSION_MAP);
+
+/** Get the dimension mappings for a task type. Returns empty for unknown. */
+export function getDimensionsForTask(taskType: string): DimensionMapping[] {
+  if (!taskType) return [];
+  return TASK_DIMENSION_MAP[taskType] ?? [];
+}
+
+/** Compute the dimension delta from an orchestrator score (1-5). */
+export function computeObservationDelta(orchestratorScore: number): number {
+  return (orchestratorScore - 3) * 4;
+}

--- a/packages/db/src/model-pricing-brackets.test.ts
+++ b/packages/db/src/model-pricing-brackets.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { resolveSeedPrice, PRICE_BRACKETS } from "./model-pricing-brackets.js";
+
+describe("resolveSeedPrice", () => {
+  it.each([
+    ["anthropic-sub", "claude-opus-4-8", 15, 75],
+    ["anthropic-sub", "claude-sonnet-4-6", 3, 15],
+    ["anthropic-sub", "claude-haiku-4-5", 1, 5],
+    ["anthropic", "claude-3-5-haiku", 1, 5],
+    ["openai", "gpt-5.3", 10, 40],
+    ["openai", "gpt-4o", 5, 15],
+    ["codex", "gpt-5.3-codex", 5, 20],
+    ["local", "qwen3:8b", 0, 0],
+    ["ollama", "llama3.3", 0, 0],
+  ])("prices the existing %s/%s bracket unchanged", (provider, model, input, output) => {
+    expect(resolveSeedPrice(provider, model)).toEqual({ inputPerMToken: input, outputPerMToken: output });
+  });
+
+  it.each([
+    // BI-6F42465E: second-tier providers that were previously null-priced.
+    ["deepseek", "deepseek-chat", 0.14, 0.28],
+    ["deepseek", "deepseek-reasoner", 0.14, 0.28],
+    ["deepseek", "deepseek-v4-pro", 0.435, 0.87],
+    ["groq", "llama-3.1-8b-instant", 0.05, 0.08],
+    ["groq", "llama-3.3-70b-versatile", 0.59, 0.79],
+    ["mistral", "mistral-small-latest", 0.1, 0.3],
+    ["mistral", "mistral-large-latest", 0.5, 1.5],
+    ["xai", "grok-build-0.1", 1, 2],
+    ["xai", "grok-4.3", 1.25, 2.5],
+    ["together", "llama-3.3-70b-instruct-turbo", 1.04, 1.04],
+    ["fireworks", "llama-v3p3-70b-instruct", 0.9, 0.9],
+  ])("prices the newly-covered %s/%s bracket", (provider, model, input, output) => {
+    expect(resolveSeedPrice(provider, model)).toEqual({ inputPerMToken: input, outputPerMToken: output });
+  });
+
+  it("returns null for unverified/unknown providers (e.g. cohere) so the seeder leaves them null", () => {
+    expect(resolveSeedPrice("cohere", "command-r-plus")).toBeNull();
+    expect(resolveSeedPrice("some-future-provider", "x")).toBeNull();
+  });
+
+  it("orders specific matchers before the provider flagship (mini/small/8b/build/pro win)", () => {
+    // groq 8b must not be captured by the general groq 70b bracket.
+    expect(resolveSeedPrice("groq", "llama-3.1-8b-instant")?.inputPerMToken).toBe(0.05);
+    // mistral small must not be captured by mistral large.
+    expect(resolveSeedPrice("mistral", "mistral-small-3")?.inputPerMToken).toBe(0.1);
+  });
+
+  it("every bracket carries a source for the audit trail", () => {
+    for (const b of PRICE_BRACKETS) {
+      expect(b.source.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/db/src/model-pricing-brackets.ts
+++ b/packages/db/src/model-pricing-brackets.ts
@@ -1,0 +1,81 @@
+/**
+ * BI-6F42465E (EP-F7E35344 — AI Coworker Capability Inputs).
+ *
+ * Day-1 seed pricing for model profiles. On a fresh install a model profile
+ * whose `pricing.inputPerMToken`/`outputPerMToken` are null gets a `null` cost
+ * from `estimateCost` (apps/web/lib/routing/cost-ranking.ts) and is then
+ * penalized in cost-per-success ranking (rankScore = successProb * 50). When
+ * EVERY paid model is null-priced they all tie at that half-score and routing
+ * collapses onto whatever the crude provider-tier sort surfaces first — the
+ * reason the Stage-5b `user_configured > bundled` override exists at all.
+ *
+ * `seedModelPricing()` backfills null prices by substring-matching the modelId
+ * against these brackets. Extracted from seed.ts into this pure, dependency-free
+ * module so the resolution logic is unit-testable without a database.
+ *
+ * Prices are public list rates per 1M tokens, verified 2026-06-18 with the
+ * source on each bracket. Substring matching means new model versions inherit
+ * the right bracket automatically; admin-tuned values are always preserved
+ * (the seeder only fills nulls).
+ */
+
+export interface SeedPrice {
+  inputPerMToken: number;
+  outputPerMToken: number;
+}
+
+export interface PriceBracket extends SeedPrice {
+  match: (providerId: string, modelId: string) => boolean;
+  /** Source for the published rate (audit trail; not consumed at runtime). */
+  source: string;
+}
+
+// Order matters: more specific matchers (mini/small/8b/build/pro) must precede
+// the provider's general flagship bracket. `resolveSeedPrice` returns the first
+// match.
+export const PRICE_BRACKETS: PriceBracket[] = [
+  // ── Anthropic Claude family (subscription + direct) ──────────────────────
+  { match: (p, m) => (p === "anthropic-sub" || p === "anthropic") && m.includes("haiku"), inputPerMToken: 1, outputPerMToken: 5, source: "anthropic.com/pricing" },
+  { match: (p, m) => (p === "anthropic-sub" || p === "anthropic") && m.includes("sonnet"), inputPerMToken: 3, outputPerMToken: 15, source: "anthropic.com/pricing" },
+  { match: (p, m) => (p === "anthropic-sub" || p === "anthropic") && m.includes("opus"), inputPerMToken: 15, outputPerMToken: 75, source: "anthropic.com/pricing" },
+
+  // ── OpenAI (codex CLI / ChatGPT subscription + direct) ───────────────────
+  { match: (p, m) => (p === "codex" || p === "chatgpt") && m.includes("codex"), inputPerMToken: 5, outputPerMToken: 20, source: "openai.com/api/pricing" },
+  { match: (p, m) => (p === "codex" || p === "chatgpt" || p === "openai") && m.startsWith("gpt-5"), inputPerMToken: 10, outputPerMToken: 40, source: "openai.com/api/pricing" },
+  { match: (p, m) => (p === "codex" || p === "chatgpt" || p === "openai") && m.startsWith("gpt-4"), inputPerMToken: 5, outputPerMToken: 15, source: "openai.com/api/pricing" },
+
+  // ── DeepSeek (deepseek-chat/reasoner are aliases of v4-flash) ────────────
+  { match: (p, m) => p === "deepseek" && m.includes("pro"), inputPerMToken: 0.435, outputPerMToken: 0.87, source: "api-docs.deepseek.com/quick_start/pricing" },
+  { match: (p) => p === "deepseek", inputPerMToken: 0.14, outputPerMToken: 0.28, source: "api-docs.deepseek.com/quick_start/pricing" },
+
+  // ── Groq (hosted Llama) ──────────────────────────────────────────────────
+  { match: (p, m) => p === "groq" && m.includes("8b"), inputPerMToken: 0.05, outputPerMToken: 0.08, source: "groq.com/pricing" },
+  { match: (p) => p === "groq", inputPerMToken: 0.59, outputPerMToken: 0.79, source: "groq.com/pricing" },
+
+  // ── Mistral (large-3 / small-4; -latest aliases resolve to these) ────────
+  { match: (p, m) => p === "mistral" && m.includes("small"), inputPerMToken: 0.1, outputPerMToken: 0.3, source: "mistral.ai/pricing" },
+  { match: (p) => p === "mistral", inputPerMToken: 0.5, outputPerMToken: 1.5, source: "mistral.ai/pricing" },
+
+  // ── xAI Grok (grok-3 line retired → redirects bill at grok-4.3) ──────────
+  { match: (p, m) => p === "xai" && m.includes("build"), inputPerMToken: 1, outputPerMToken: 2, source: "docs.x.ai/docs/models" },
+  { match: (p) => p === "xai", inputPerMToken: 1.25, outputPerMToken: 2.5, source: "docs.x.ai/docs/models" },
+
+  // ── Together / Fireworks (flat input=output for Llama-3.3-70B class) ─────
+  { match: (p) => p === "together", inputPerMToken: 1.04, outputPerMToken: 1.04, source: "together.ai/models/llama-3-3-70b" },
+  { match: (p) => p === "fireworks", inputPerMToken: 0.9, outputPerMToken: 0.9, source: "fireworks.ai (serverless llama-v3p3-70b)" },
+
+  // ── Bundled local — always free (compute cost, not per-token) ────────────
+  { match: (p) => p === "local" || p === "ollama", inputPerMToken: 0, outputPerMToken: 0, source: "bundled local inference (no per-token cost)" },
+
+  // NOTE: Cohere intentionally omitted — only legacy-table rates were
+  // verifiable as of 2026-06-18; do not seed unverified prices (never-fabricate).
+];
+
+/**
+ * Resolve the seed price for a (providerId, modelId), or null when no bracket
+ * matches (e.g. an unknown provider, or one with verification still pending).
+ */
+export function resolveSeedPrice(providerId: string, modelId: string): SeedPrice | null {
+  const bracket = PRICE_BRACKETS.find((b) => b.match(providerId, modelId));
+  return bracket ? { inputPerMToken: bracket.inputPerMToken, outputPerMToken: bracket.outputPerMToken } : null;
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -9,6 +9,7 @@ import { loadFingerprintCatalogIntoDb, defaultCatalogPath } from "./discovery-fi
 import { seedEaArchimate4 } from "./seed-ea-archimate4.js";
 import { seedEaBpmn20 } from "./seed-ea-bpmn20.js";
 import { seedEaCrossNotation } from "./seed-ea-cross-notation.js";
+import { resolveSeedPrice } from "./model-pricing-brackets.js";
 import { seedEaReferenceModels } from "./seed-ea-reference-models.js";
 import { seedEaStructureRules } from "./seed-ea-structure-rules.js";
 import { seedEaSysml2 } from "./seed-ea-sysml2.js";
@@ -2083,33 +2084,9 @@ async function seedSpeachesTranscriptionModel(): Promise<void> {
  * admin-tuned prices are preserved.
  */
 async function seedModelPricing(): Promise<void> {
-  // Public API rates (per 1M tokens) as of early 2026.
-  // Pattern matching is substring-on-modelId — new model versions pick
-  // up the right bracket automatically.
-  const priceBrackets: Array<{
-    match: (providerId: string, modelId: string) => boolean;
-    inputPerMToken: number;
-    outputPerMToken: number;
-  }> = [
-    // Anthropic Claude family
-    { match: (p, m) => p === "anthropic-sub" && m.includes("haiku"), inputPerMToken: 1, outputPerMToken: 5 },
-    { match: (p, m) => p === "anthropic-sub" && m.includes("sonnet"), inputPerMToken: 3, outputPerMToken: 15 },
-    { match: (p, m) => p === "anthropic-sub" && m.includes("opus"), inputPerMToken: 15, outputPerMToken: 75 },
-    // Anthropic direct API
-    { match: (p, m) => p === "anthropic" && m.includes("haiku"), inputPerMToken: 1, outputPerMToken: 5 },
-    { match: (p, m) => p === "anthropic" && m.includes("sonnet"), inputPerMToken: 3, outputPerMToken: 15 },
-    { match: (p, m) => p === "anthropic" && m.includes("opus"), inputPerMToken: 15, outputPerMToken: 75 },
-    // OpenAI subscription (codex CLI) + ChatGPT
-    { match: (p, m) => (p === "codex" || p === "chatgpt") && m.includes("codex"), inputPerMToken: 5, outputPerMToken: 20 },
-    { match: (p, m) => (p === "codex" || p === "chatgpt") && m.startsWith("gpt-5"), inputPerMToken: 10, outputPerMToken: 40 },
-    { match: (p, m) => (p === "codex" || p === "chatgpt") && m.startsWith("gpt-4"), inputPerMToken: 5, outputPerMToken: 15 },
-    // OpenAI direct
-    { match: (p, m) => p === "openai" && m.startsWith("gpt-5"), inputPerMToken: 10, outputPerMToken: 40 },
-    { match: (p, m) => p === "openai" && m.startsWith("gpt-4"), inputPerMToken: 5, outputPerMToken: 15 },
-    // Bundled local — always free
-    { match: (p) => p === "local" || p === "ollama", inputPerMToken: 0, outputPerMToken: 0 },
-  ];
-
+  // Public API rates (per 1M tokens) live in model-pricing-brackets.ts as a
+  // pure, unit-tested module (BI-6F42465E). Substring matching means new model
+  // versions pick up the right bracket automatically.
   const profiles = await prisma.modelProfile.findMany({
     select: { id: true, providerId: true, modelId: true, pricing: true },
   });
@@ -2123,8 +2100,8 @@ async function seedModelPricing(): Promise<void> {
       skipped++;
       continue;
     }
-    const bracket = priceBrackets.find((b) => b.match(mp.providerId, mp.modelId));
-    if (!bracket) {
+    const price = resolveSeedPrice(mp.providerId, mp.modelId);
+    if (!price) {
       skipped++;
       continue;
     }
@@ -2133,11 +2110,11 @@ async function seedModelPricing(): Promise<void> {
       data: {
         pricing: {
           ...currentPricing,
-          inputPerMToken: bracket.inputPerMToken,
-          outputPerMToken: bracket.outputPerMToken,
+          inputPerMToken: price.inputPerMToken,
+          outputPerMToken: price.outputPerMToken,
         } as never,
-        inputPricePerMToken: bracket.inputPerMToken,
-        outputPricePerMToken: bracket.outputPerMToken,
+        inputPricePerMToken: price.inputPerMToken,
+        outputPricePerMToken: price.outputPerMToken,
       },
     });
     updated++;


### PR DESCRIPTION
## What & why

Closes **BI-6F42465E** under epic **EP-F7E35344** (AI Coworker Capability Inputs). Spec: `docs/superpowers/specs/2026-06-18-perplexity-architecture-lessons-analysis.md` (Lesson C). Two cold-start fixes so fresh installs route on data, not tier guesses.

### 1. Pricing coverage (the reason the Stage-5b override exists)
On a fresh install a model with null `pricing.inputPerMToken` gets a `null` cost from `estimateCost` and is penalized to `successProb * 50` in cost-per-success ranking. When **every** paid model is null-priced they tie at that half-score and routing collapses onto the crude provider-tier sort. The seed brackets covered only Anthropic/OpenAI/local — so every **xAI, DeepSeek, Groq, Mistral, Together, Fireworks** model shipped null-priced.

- **`packages/db/src/model-pricing-brackets.ts`** (new): the price brackets + `resolveSeedPrice()` extracted from `seed.ts` into a pure, **unit-tested**, dependency-free module. Adds the six providers above with public list rates **verified 2026-06-18, source cited per bracket**.
- **Cohere intentionally omitted** — only legacy-table rates were verifiable, so seeding them would be fabrication.
- `seed.ts`'s `seedModelPricing()` now calls `resolveSeedPrice()` (behavior for existing brackets unchanged).

### 2. Per-archetype golden eval sets
Golden tests were grouped by **dimension** only — an eval was all-or-nothing across 7 dimensions, with no way to evaluate "the capabilities this kind of task exercises" (the SimpleQA-ties-to-factuality idea).

- **`apps/web/lib/routing/task-dimension-map.ts`** (new): the task-type → dimension map extracted **prisma-free** from `production-feedback.ts` (single source of truth; `production-feedback` re-exports it for back-compat).
- **`golden-tests.ts`**: `getTestsForTaskType(taskType)` assembles the golden set for a task archetype via that map (primary dimension first, de-duplicated) — the bridge from the **BI-08CE1ADF** classifier's archetypes to the eval corpus.

## Deliberately NOT included (would be fabrication, not seeding)
Re-scoring the 31 flat-50 gemini profiles and seeding `local`/`ollama` dimension scores need **real eval runs, not invented numbers** — left as an explicit follow-on. Per the never-fabricate kernel principle.

## Verification

Substrate: **isolated git worktree, source-local gates** (pure data/library; the seed runs at install time, no UI surface).
- `pnpm --filter web typecheck` + `pnpm --filter @dpf/db tsc --noEmit` — clean.
- `pnpm --filter web exec vitest run lib/routing` — **1038/1038** (incl. new golden-tests + unchanged production-feedback via the re-export).
- `pnpm --filter @dpf/db exec vitest run src/model-pricing-brackets.test.ts` — **23/23**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)