### PR TITLE
feat(agentic): stream plan:update events from the loop (BI-95C0835E, slice 1)

### DIFF
--- a/apps/web/lib/tak/agent-event-bus.ts
+++ b/apps/web/lib/tak/agent-event-bus.ts
@@ -13,6 +13,10 @@ export type AgentEvent =
   | { type: "brief:update"; buildId: string }
   | { type: "evidence:update"; buildId: string; field: string }
   | { type: "iteration"; iteration: number; toolCount: number }
+  // BI-95C0835E: the agentic loop's execution plan changed (recorded or a step
+  // updated). Streamed so the UI can show the plan executing step-by-step —
+  // the perceived-progress + trust mechanism (Perplexity's streamed Pro plan).
+  | { type: "plan:update"; goal: string; steps: Array<{ id: string; description: string; status: string }>; done: number; total: number }
   | { type: "test:step"; stepIndex: number; description: string; screenshot?: string; passed: boolean }
   | { type: "sync:progress"; totalFetched: number; totalUpserted: number; totalNew: number }
   | { type: "done"; agentMessageId?: string; systemMessageId?: string; formAssistUpdate?: Record<string, unknown>; providerInfo?: { providerId: string; modelId: string }; error?: string }

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -1922,4 +1922,33 @@ describe("runAgenticLoop — execution plan", () => {
     expect(result.content).toBe("All wrapped up now.");
     expect(result.executionPlan && (result.executionPlan.steps.every((s) => s.status === "done" || s.status === "skipped"))).toBe(true);
   });
+
+  it("streams plan:update events as the plan is recorded and steps progress (BI-95C0835E)", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+        toolCalls: [{ id: "t1", name: "record_execution_plan", arguments: { goal: "ship it", steps: ["a", "b"] } }],
+      }) as never)
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+        toolCalls: [{ id: "t2", name: "update_execution_plan_step", arguments: { stepId: "s1", status: "done" } }],
+      }) as never)
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+        toolCalls: [{ id: "t3", name: "update_execution_plan_step", arguments: { stepId: "s2", status: "done" } }],
+      }) as never)
+      .mockResolvedValueOnce(mockResult({ content: "Done." }) as never);
+
+    const events: Array<{ type: string; done?: number; total?: number }> = [];
+    await runAgenticLoop({
+      ...planParams,
+      enableExecutionPlan: true,
+      onProgress: (e) => events.push(e as { type: string; done?: number; total?: number }),
+    });
+
+    const planEvents = events.filter((e) => e.type === "plan:update") as Array<{ done: number; total: number }>;
+    // One on record, one per step update = 3 total, with monotonic progress.
+    expect(planEvents.map((e) => `${e.done}/${e.total}`)).toEqual(["0/2", "1/2", "2/2"]);
+  });
 });

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1855,6 +1855,18 @@ export async function runAgenticLoop(params: {
           `[agentic-tool] PLAN iter=${iteration} tool=${tc.name} success=${applied.result.success}` +
           (executionPlan ? ` progress=${planProgress(executionPlan).done}/${planProgress(executionPlan).total}` : ""),
         );
+        // BI-95C0835E: stream the plan so the UI can render it executing
+        // step-by-step. Only on a successful mutation that left a plan in place.
+        if (applied.result.success && executionPlan) {
+          const { done, total } = planProgress(executionPlan);
+          onProgress?.({
+            type: "plan:update",
+            goal: executionPlan.goal,
+            steps: executionPlan.steps.map((s) => ({ id: s.id, description: s.description, status: s.status })),
+            done,
+            total,
+          });
+        }
         iterationResults.push({ tc, toolResult: applied.result });
         continue;
       }


### PR DESCRIPTION
## What & why

First slice of **BI-95C0835E** under epic **EP-F7E35344** (AI Coworker Capability Inputs). Spec: `docs/superpowers/specs/2026-06-18-perplexity-architecture-lessons-analysis.md` (Lesson E).

When the execution plan (BI-2AC48661) is recorded or a step changes, the loop now emits a `plan:update` `AgentEvent` over the existing `onProgress` bus (goal + steps + done/total). This is the backend plumbing the UI renders so a user watches the plan execute step-by-step — the perceived-progress + trust mechanism (Perplexity's streamed Pro plan), and DPF's analogue of inline source citations.

- `apps/web/lib/tak/agent-event-bus.ts`: add the `plan:update` event member.
- `apps/web/lib/tak/agentic-loop.ts`: emit it from the plan interceptor on a successful mutation.
- Test: `plan:update` events stream with monotonic progress (0/2 → 1/2 → 2/2).

## ⚠️ Stacked on #2064

This branch contains #2064's ExecutionPlan commit (the object it observes). **Merge #2064 first**, then this rebases cleanly onto main. The net new delta here is the 3 files above (+45 lines).

## Scope: what is deliberately NOT here

The remaining BI-95C0835E work is **UI + live-install UX verification**, which a source-control worktree cannot honestly provide:
1. **Auto-default model selection** — stop asking the user to pick a model/tier/context window (the #2004 raw-token-input class of problem); make manual override advanced-only.
2. **Evidence-as-citation panel** — surface `record_execution_evidence` as a verifiable "what I did + how I know" artifact.
3. **Rendering** this `plan:update` stream in the coworker UI.

All three are UI-impacting → they require the **mandatory UX-Fit Gate** (a recorded `principle_decide` on `human_cognitive_load` + a `UX-Fit-Decision:` trailer, AGENTS.md §12) and **runtime UX verification on the canonical live install**. Per the worktree-is-source-control doctrine and never-fabricate, I am not faking that evidence here. Tracked on BI-95C0835E for a live-install session.

## Verification

Substrate: **isolated git worktree, source-local gates** (backend event plumbing).
- `pnpm --filter web typecheck` — clean (would catch any exhaustive `switch` consumer of the event union).
- `pnpm --filter web exec vitest run lib/tak` — **109/109**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)