### PR TITLE
feat(ea): wire cross-layer edges (operational/network/integration → data-model layer)

### DIFF
--- a/apps/web/lib/ea/integration-bridge-extract.test.ts
+++ b/apps/web/lib/ea/integration-bridge-extract.test.ts
@@ -27,7 +27,14 @@ describe("buildIntegrationModel", () => {
 
   it("declares rule-valid types and a soft-remove prefix", () => {
     expect(model.elementTypeSlugs).toEqual(["package", "part_definition"]);
-    expect(model.relTypeSlugs).toEqual(["contains"]);
+    expect(model.relTypeSlugs).toEqual(["contains", "traces"]);
     expect(model.softRemovePrefix).toBe("integration:");
+  });
+
+  it("traces each connected app to the IntegrationCredential data-model element (cross-layer)", () => {
+    expect(model.crossLayerRelationships).toEqual([
+      { fromKey: "integration:app:adp", toKey: "prisma:model:IntegrationCredential", relSlug: "traces" },
+      { fromKey: "integration:app:qb", toKey: "prisma:model:IntegrationCredential", relSlug: "traces" },
+    ]);
   });
 });

--- a/apps/web/lib/ea/integration-bridge-extract.ts
+++ b/apps/web/lib/ea/integration-bridge-extract.ts
@@ -24,9 +24,16 @@ export interface IntegrationFact {
 
 export const INTEGRATION_PACKAGE_KEY = "integration:pkg";
 
+// Cross-LAYER target: the data-model element the EP-DATA-ARCH Prisma→EA mirror projects
+// for the IntegrationCredential table (`infraCiKey = prisma:model:<Model>`). Each connected
+// application IS an IntegrationCredential row, so it `traces` to that model — the real edge
+// that lets a data-model change's blast_radius reach the connected applications.
+export const INTEGRATION_CREDENTIAL_MODEL_KEY = "prisma:model:IntegrationCredential";
+
 export function buildIntegrationModel(integrations: IntegrationFact[]): SysmlDesiredModel {
   const elements: SysmlDesiredModel["elements"] = [];
   const relationships: SysmlDesiredModel["relationships"] = [];
+  const crossLayerRelationships: SysmlDesiredModel["relationships"] = [];
 
   elements.push({
     sysmlKey: INTEGRATION_PACKAGE_KEY,
@@ -56,13 +63,15 @@ export function buildIntegrationModel(integrations: IntegrationFact[]): SysmlDes
       },
     });
     relationships.push({ fromKey: INTEGRATION_PACKAGE_KEY, toKey: key, relSlug: "contains" });
+    // Cross-layer: this connected application traces to the IntegrationCredential model.
+    crossLayerRelationships.push({ fromKey: key, toKey: INTEGRATION_CREDENTIAL_MODEL_KEY, relSlug: "traces" });
   }
 
   return {
     elements,
     relationships,
     elementTypeSlugs: ["package", "part_definition"],
-    relTypeSlugs: ["contains"],
+    relTypeSlugs: ["contains", "traces"],
     view: {
       name: "Integrations — Live Projection",
       description: "Live, system-maintained projection of the connected external applications the portal integrates with.",
@@ -70,5 +79,6 @@ export function buildIntegrationModel(integrations: IntegrationFact[]): SysmlDes
       scopeRef: "integration-boundary",
     },
     softRemovePrefix: "integration:",
+    crossLayerRelationships,
   };
 }

--- a/apps/web/lib/ea/network-bridge-extract.test.ts
+++ b/apps/web/lib/ea/network-bridge-extract.test.ts
@@ -49,7 +49,15 @@ describe("buildNetworkTopologyModel", () => {
 
   it("declares rule-valid types and a soft-remove prefix", () => {
     expect(model.elementTypeSlugs).toEqual(["package", "part_definition", "part_usage"]);
-    expect(model.relTypeSlugs).toEqual(["contains", "connects"]);
+    expect(model.relTypeSlugs).toEqual(["contains", "connects", "traces"]);
     expect(model.softRemovePrefix).toBe("network:");
+  });
+
+  it("traces each host/entity to its data-model element (cross-layer)", () => {
+    expect(model.crossLayerRelationships).toEqual([
+      { fromKey: "network:host:n1", toKey: "prisma:model:EdgeNode", relSlug: "traces" },
+      { fromKey: "network:entity:e1", toKey: "prisma:model:InventoryEntity", relSlug: "traces" },
+      { fromKey: "network:entity:e2", toKey: "prisma:model:InventoryEntity", relSlug: "traces" },
+    ]);
   });
 });

--- a/apps/web/lib/ea/network-bridge-extract.ts
+++ b/apps/web/lib/ea/network-bridge-extract.ts
@@ -48,6 +48,13 @@ export const NETWORK_PACKAGE_KEY = "network:pkg";
 export const NETWORK_HOSTS_KEY = "network:hosts";
 export const NETWORK_DEVICES_KEY = "network:devices";
 
+// Cross-LAYER targets: the data-model elements the EP-DATA-ARCH Prisma→EA mirror projects
+// for the EdgeNode and InventoryEntity tables (`infraCiKey = prisma:model:<Model>`). Each
+// discovered host/device IS a row of those tables, so it `traces` to its model — the real
+// edge that lets a data-model change's blast_radius reach the discovered network elements.
+export const EDGE_NODE_MODEL_KEY = "prisma:model:EdgeNode";
+export const INVENTORY_ENTITY_MODEL_KEY = "prisma:model:InventoryEntity";
+
 function truncate(s: string | undefined, n = 200): string {
   if (!s) return "";
   return s.length > n ? `${s.slice(0, n - 1)}…` : s;
@@ -60,6 +67,7 @@ export function buildNetworkTopologyModel(args: {
 }): SysmlDesiredModel {
   const elements: SysmlDesiredModel["elements"] = [];
   const relationships: SysmlDesiredModel["relationships"] = [];
+  const crossLayerRelationships: SysmlDesiredModel["relationships"] = [];
 
   elements.push({
     sysmlKey: NETWORK_PACKAGE_KEY,
@@ -107,6 +115,7 @@ export function buildNetworkTopologyModel(args: {
       },
     });
     relationships.push({ fromKey: NETWORK_HOSTS_KEY, toKey: key, relSlug: "contains" });
+    crossLayerRelationships.push({ fromKey: key, toKey: EDGE_NODE_MODEL_KEY, relSlug: "traces" });
   }
 
   const known = new Set(args.entities.map((e) => e.entityKey));
@@ -129,6 +138,7 @@ export function buildNetworkTopologyModel(args: {
       },
     });
     relationships.push({ fromKey: NETWORK_DEVICES_KEY, toKey: key, relSlug: "contains" });
+    crossLayerRelationships.push({ fromKey: key, toKey: INVENTORY_ENTITY_MODEL_KEY, relSlug: "traces" });
   }
 
   // Inventory dependency edges — only when both endpoints were projected.
@@ -146,7 +156,7 @@ export function buildNetworkTopologyModel(args: {
     elements,
     relationships,
     elementTypeSlugs: ["package", "part_definition", "part_usage"],
-    relTypeSlugs: ["contains", "connects"],
+    relTypeSlugs: ["contains", "connects", "traces"],
     view: {
       name: "Network Topology — Live Projection",
       description: "Live, system-maintained projection of discovered network hosts, devices, and their dependencies.",
@@ -154,5 +164,6 @@ export function buildNetworkTopologyModel(args: {
       scopeRef: "network-topology",
     },
     softRemovePrefix: "network:",
+    crossLayerRelationships,
   };
 }

--- a/apps/web/lib/ea/operational-bridge-extract.test.ts
+++ b/apps/web/lib/ea/operational-bridge-extract.test.ts
@@ -40,8 +40,18 @@ describe("buildOperationalGraphModel", () => {
 
   it("declares rule-valid types and a soft-remove prefix", () => {
     expect(model.elementTypeSlugs).toEqual(["package", "part_definition", "part_usage"]);
-    expect(model.relTypeSlugs).toEqual(["contains"]);
+    expect(model.relTypeSlugs).toEqual(["contains", "traces"]);
     expect(model.softRemovePrefix).toBe("operational:");
+  });
+
+  it("traces each actual instance to the RuntimeTarget data-model element (cross-layer)", () => {
+    // one traces edge per instance → prisma:model:RuntimeTarget; resolved by the applier
+    expect(model.crossLayerRelationships).toEqual([
+      { fromKey: "operational:instance:d", toKey: "prisma:model:RuntimeTarget", relSlug: "traces" }, // service "edge"
+      { fromKey: "operational:instance:a", toKey: "prisma:model:RuntimeTarget", relSlug: "traces" },
+      { fromKey: "operational:instance:b", toKey: "prisma:model:RuntimeTarget", relSlug: "traces" },
+      { fromKey: "operational:instance:c", toKey: "prisma:model:RuntimeTarget", relSlug: "traces" },
+    ]);
   });
 
   it("serviceOf falls back to kind when serviceName is blank", () => {

--- a/apps/web/lib/ea/operational-bridge-extract.ts
+++ b/apps/web/lib/ea/operational-bridge-extract.ts
@@ -33,6 +33,14 @@ export interface RuntimeTargetFact {
 
 export const OPERATIONAL_PACKAGE_KEY = "operational:pkg";
 
+// Cross-LAYER target: the data-model element the EP-DATA-ARCH Prisma→EA mirror projects
+// for the RuntimeTarget table (it stamps `infraCiKey = prisma:model:<Model>`). Every
+// runtime instance IS a RuntimeTarget row, so each instance `traces` to that model —
+// the real, by-construction edge that lets a data-model change's blast_radius reach the
+// live operational instances. Resolved by the applier against the live graph; if the
+// data-model mirror has not run yet it is counted unresolved and links on a later pass.
+export const RUNTIME_TARGET_MODEL_KEY = "prisma:model:RuntimeTarget";
+
 /** The logical deployable service a runtime target belongs to (serviceName, else kind). */
 export function serviceOf(t: RuntimeTargetFact): string {
   return (t.serviceName && t.serviceName.trim()) || t.kind || "service";
@@ -41,6 +49,7 @@ export function serviceOf(t: RuntimeTargetFact): string {
 export function buildOperationalGraphModel(targets: RuntimeTargetFact[]): SysmlDesiredModel {
   const elements: SysmlDesiredModel["elements"] = [];
   const relationships: SysmlDesiredModel["relationships"] = [];
+  const crossLayerRelationships: SysmlDesiredModel["relationships"] = [];
 
   elements.push({
     sysmlKey: OPERATIONAL_PACKAGE_KEY,
@@ -95,6 +104,8 @@ export function buildOperationalGraphModel(targets: RuntimeTargetFact[]): SysmlD
         },
       });
       relationships.push({ fromKey: serviceKey, toKey: instanceKey, relSlug: "contains" });
+      // Cross-layer: this actual instance traces to the RuntimeTarget data-model type.
+      crossLayerRelationships.push({ fromKey: instanceKey, toKey: RUNTIME_TARGET_MODEL_KEY, relSlug: "traces" });
     }
   }
 
@@ -102,7 +113,7 @@ export function buildOperationalGraphModel(targets: RuntimeTargetFact[]): SysmlD
     elements,
     relationships,
     elementTypeSlugs: ["package", "part_definition", "part_usage"],
-    relTypeSlugs: ["contains"],
+    relTypeSlugs: ["contains", "traces"],
     view: {
       name: "Operational Graph — Live Projection",
       description: "Live, system-maintained projection of running platform services and their instances.",
@@ -110,5 +121,6 @@ export function buildOperationalGraphModel(targets: RuntimeTargetFact[]): SysmlD
       scopeRef: "operational-graph",
     },
     softRemovePrefix: "operational:",
+    crossLayerRelationships,
   };
 }


### PR DESCRIPTION
## Why

The three operational-reality bridges ([#2034](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2034)) put the operational, network, and integration layers into the architecture graph — but as **self-contained islands**. A `blast_radius` traversal couldn't cross from those layers into the rest of the graph. This wires the **first real cross-layer edges** using the merged `applySysmlModel` keystone ([#2033](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2033)) — the step that turns the bridged layers into a connected impact-analysis surface.

## What — only edges with real backing

The discipline here was to wire **no invented FKs**. The one correspondence that is **real by construction**: every actual-layer element *is* a row of its source table, and the EP-DATA-ARCH Prisma→EA mirror projects each table as an EA element keyed `prisma:model:<Model>`. So each bridge now `traces` its actual elements to their data-model type:

| Actual element | traces → data-model element |
| --- | --- |
| `operational:instance:<id>` | `prisma:model:RuntimeTarget` |
| `network:host:<nodeId>` | `prisma:model:EdgeNode` |
| `network:entity:<entityKey>` | `prisma:model:InventoryEntity` |
| `integration:app:<id>` | `prisma:model:IntegrationCredential` |

A data-model change's `blast_radius` now reaches the live instances, discovered hosts/devices, and connected apps that realize it — **operational reality meeting the data-architecture layer.** Edges resolve via the keystone's `infraCiKey` lookup; if the data-model mirror hasn't run yet they're counted `crossLayerUnresolved` (observable) and link on a later reconcile — never silent, never fabricated.

## What I deliberately did NOT wire (honest gap)

Investigated the schema and found **no real FK** for the two edges that sound appealing:
- **operational instance → network host** — `RuntimeTarget` (the portal's own containers) has no link to `EdgeNode` (customer-estate hosts). Different domains.
- **integration → MCP tools** — `IntegrationCredential` carries only a `provider` string; no FK to the MCP tool registry.

Wiring those would be invented data. They need deliberate per-pair key conventions (or a new FK in the source model) — tracked under `BI-4A73ED94`, not faked here.

## Verification

Substrate: **compile-ready worktree** (source-local gates). `web` typecheck clean (after regenerating the Prisma client for `main`'s `SelfUpgradeRun.changeRequestId`); EA `vitest` **126/126** — each bridge test now asserts its exact cross-layer `traces` set and updated `relTypeSlugs`. The keystone's own merged tests already prove `applySysmlModel` resolves these by `infraCiKey`.

`EP-ARCH-GRAPH-LIVE` / `BI-4A73ED94`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
