### PR TITLE
feat(contribution): structural private-paths boundary on outbound PR diffs

### DIFF
--- a/.dpf/private-paths
+++ b/.dpf/private-paths
@@ -1,0 +1,21 @@
+# DPF private paths — proprietary boundary for the contribution pipeline.
+#
+# Files and directories matching a pattern here are NEVER included in an
+# upstream contribution diff, regardless of a change's share/keep disposition.
+# This is the structural complement to the per-change disposition: disposition
+# decides "share this change or not"; this file decides "these paths never
+# leave the box, period."
+#
+# Syntax: one gitignore-style glob per line. `#` starts a comment; blank lines
+# are ignored. Matching is conservative — a directory pattern also matches
+# everything beneath it. Edit here, or via Admin > Platform Development (which
+# writes PrivatePathRule overrides that merge with this file).
+#
+# This file ships intentionally empty of active patterns so it changes no
+# platform behavior by default. Add your business-proprietary paths below.
+#
+# Examples (uncomment / adapt to your install):
+# proprietary/
+# **/*.secret
+# apps/web/lib/pricing/private-rates.ts
+# config/customer-overrides/

--- a/apps/web/lib/integrate/contribution-pipeline.ts
+++ b/apps/web/lib/integrate/contribution-pipeline.ts
@@ -210,8 +210,23 @@ function parseGitHubRepo(remoteUrl: string): { owner: string; repo: string } | n
 export async function submitBuildAsPR(
   input: SubmitBuildAsPRInput,
 ): Promise<PRContribution> {
-  // 1. Run security scan
-  const securityScan = scanDiffForSecurityIssues(input.diffPatch);
+  // 0. Private-paths boundary (Phase 1 of Private/Public Change Segregation).
+  // Strip any file the operator marked proprietary BEFORE the diff can reach a
+  // remote — structural, regardless of disposition. The checked-in
+  // `.dpf/private-paths` manifest ships empty, so this is a no-op until an
+  // operator opts in. Spec:
+  // docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
+  const { loadPrivatePathPatterns, compilePrivatePathMatcher, stripPrivatePathsFromDiff } =
+    await import("@/lib/integrate/private-paths");
+  const privatePatterns = await loadPrivatePathPatterns();
+  const { kept: outboundDiff } = stripPrivatePathsFromDiff(
+    input.diffPatch,
+    compilePrivatePathMatcher(privatePatterns),
+  );
+
+  // 1. Run security scan on the OUTBOUND (post-strip) diff — what would
+  // actually be shared, never the private-inclusive original.
+  const securityScan = scanDiffForSecurityIssues(outboundDiff);
 
   // 2. Gather build evidence for PR body
   const build = await prisma.featureBuild.findUnique({
@@ -297,6 +312,14 @@ export async function submitBuildAsPR(
   }
 
   if (targetRepo && token) {
+    // If every changed file was stripped as private, there is nothing to
+    // share — fall back to local review rather than opening an empty PR.
+    if (!outboundDiff.trim()) {
+      return buildLocalContribution(
+        branchName, prTitle, prBody, securityScan, input.impactReport,
+        "This change only affects parts of your system you've marked private, so there is nothing to share upstream.",
+      );
+    }
     // ─── GitHub API Mode: Create PR via REST API (no local git needed) ──
     const { createBranchAndPR } = await import("@/lib/integrate/github-api-commit");
 
@@ -324,7 +347,7 @@ export async function submitBuildAsPR(
         baseRepo: base.repo,
         branchName,
         commitMessage,
-        diff: input.diffPatch,
+        diff: outboundDiff,
         prTitle,
         prBody,
         labels,

--- a/apps/web/lib/integrate/private-paths.test.ts
+++ b/apps/web/lib/integrate/private-paths.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePrivatePathManifest,
+  compilePrivatePathMatcher,
+  matchesPrivatePath,
+  splitUnifiedDiffByFile,
+  stripPrivatePathsFromDiff,
+} from "./private-paths";
+
+describe("parsePrivatePathManifest", () => {
+  it("drops comments and blank lines, trims, dedupes, preserves order", () => {
+    const text = [
+      "# comment",
+      "",
+      "  proprietary/  ",
+      "**/*.secret",
+      "proprietary/", // dup after trim
+      "   ",
+      "# another comment",
+      "config/x",
+    ].join("\n");
+    expect(parsePrivatePathManifest(text)).toEqual([
+      "proprietary/",
+      "**/*.secret",
+      "config/x",
+    ]);
+  });
+});
+
+describe("compilePrivatePathMatcher", () => {
+  it("matches an unanchored, slash-free pattern at any depth (incl. subtree)", () => {
+    const isPrivate = compilePrivatePathMatcher(["secrets"]);
+    expect(isPrivate("secrets")).toBe(true);
+    expect(isPrivate("apps/web/secrets")).toBe(true);
+    expect(isPrivate("apps/web/secrets/keys.ts")).toBe(true);
+    expect(isPrivate("apps/web/public/logo.svg")).toBe(false);
+  });
+
+  it("anchors a leading-slash pattern to the repo root", () => {
+    const isPrivate = compilePrivatePathMatcher(["/config/private"]);
+    expect(isPrivate("config/private")).toBe(true);
+    expect(isPrivate("config/private/x.ts")).toBe(true);
+    expect(isPrivate("apps/config/private")).toBe(false);
+  });
+
+  it("supports `*` (within-segment) and `**` (across-segments)", () => {
+    const star = compilePrivatePathMatcher(["**/*.secret"]);
+    expect(star("a/b/c.secret")).toBe(true);
+    expect(star("top.secret")).toBe(true);
+    expect(star("a/b/c.ts")).toBe(false);
+
+    const single = compilePrivatePathMatcher(["config/*.key"]);
+    expect(single("config/api.key")).toBe(true);
+    expect(single("config/nested/api.key")).toBe(false); // * does not cross /
+  });
+
+  it("treats a trailing-slash dir pattern as the dir and its subtree", () => {
+    const isPrivate = compilePrivatePathMatcher(["proprietary/"]);
+    expect(isPrivate("proprietary")).toBe(true);
+    expect(isPrivate("proprietary/pricing.ts")).toBe(true);
+    expect(isPrivate("proprietaryX")).toBe(false);
+  });
+
+  it("normalizes leading ./ and backslashes", () => {
+    expect(matchesPrivatePath("./proprietary/x.ts", ["proprietary/"])).toBe(true);
+    expect(matchesPrivatePath("proprietary\\x.ts", ["proprietary/"])).toBe(true);
+  });
+
+  it("empty pattern set matches nothing", () => {
+    const isPrivate = compilePrivatePathMatcher([]);
+    expect(isPrivate("anything")).toBe(false);
+  });
+});
+
+const GIT_DIFF = [
+  "diff --git a/apps/web/lib/public.ts b/apps/web/lib/public.ts",
+  "index 111..222 100644",
+  "--- a/apps/web/lib/public.ts",
+  "+++ b/apps/web/lib/public.ts",
+  "@@ -1,1 +1,1 @@",
+  "-old",
+  "+new",
+  "diff --git a/proprietary/pricing.ts b/proprietary/pricing.ts",
+  "index 333..444 100644",
+  "--- a/proprietary/pricing.ts",
+  "+++ b/proprietary/pricing.ts",
+  "@@ -1,1 +1,1 @@",
+  "-secret-old",
+  "+secret-new",
+].join("\n");
+
+describe("splitUnifiedDiffByFile", () => {
+  it("splits a git diff into per-file blocks with their paths", () => {
+    const { blocks } = splitUnifiedDiffByFile(GIT_DIFF);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].paths).toContain("apps/web/lib/public.ts");
+    expect(blocks[1].paths).toContain("proprietary/pricing.ts");
+  });
+});
+
+describe("stripPrivatePathsFromDiff", () => {
+  it("removes the private file block, keeps the public one", () => {
+    const isPrivate = compilePrivatePathMatcher(["proprietary/"]);
+    const result = stripPrivatePathsFromDiff(GIT_DIFF, isPrivate);
+    expect(result.didStrip).toBe(true);
+    expect(result.strippedPaths).toEqual(["proprietary/pricing.ts"]);
+    expect(result.kept).toContain("apps/web/lib/public.ts");
+    expect(result.kept).not.toContain("proprietary/pricing.ts");
+    expect(result.kept).not.toContain("secret-new");
+  });
+
+  it("returns an empty kept diff when every file is private", () => {
+    const isPrivate = compilePrivatePathMatcher(["apps/web/", "proprietary/"]);
+    const result = stripPrivatePathsFromDiff(GIT_DIFF, isPrivate);
+    expect(result.didStrip).toBe(true);
+    expect(result.kept.trim()).toBe("");
+  });
+
+  it("is a no-op when nothing is private", () => {
+    const isPrivate = compilePrivatePathMatcher(["does-not-exist/"]);
+    const result = stripPrivatePathsFromDiff(GIT_DIFF, isPrivate);
+    expect(result.didStrip).toBe(false);
+    expect(result.kept).toBe(GIT_DIFF);
+  });
+
+  it("handles empty / whitespace diffs without throwing", () => {
+    const isPrivate = compilePrivatePathMatcher(["x"]);
+    expect(stripPrivatePathsFromDiff("", isPrivate).kept).toBe("");
+    expect(stripPrivatePathsFromDiff("   ", isPrivate).didStrip).toBe(false);
+  });
+
+  it("retains a preamble before the first file block", () => {
+    const withPreamble = "From: agent\nSubject: change\n\n" + GIT_DIFF;
+    const isPrivate = compilePrivatePathMatcher(["proprietary/"]);
+    const result = stripPrivatePathsFromDiff(withPreamble, isPrivate);
+    expect(result.kept).toContain("Subject: change");
+    expect(result.kept).toContain("apps/web/lib/public.ts");
+    expect(result.kept).not.toContain("proprietary/pricing.ts");
+  });
+});

--- a/apps/web/lib/integrate/private-paths.ts
+++ b/apps/web/lib/integrate/private-paths.ts
@@ -1,0 +1,276 @@
+/**
+ * Private-paths boundary — Phase 1 of Private/Public Change Segregation.
+ * Spec: docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
+ *
+ * A declarative, gitignore-style list of paths that must NEVER appear in an
+ * upstream contribution diff, regardless of a change's disposition. Patterns
+ * are sourced from a checked-in `.dpf/private-paths` manifest at the repo root
+ * plus operator overrides in the `PrivatePathRule` table.
+ *
+ * The boundary is structural and fail-closed by construction: matching is
+ * deliberately liberal (a path under any matched dir is private), so when in
+ * doubt a path is treated as private — excluded from sharing — never shared by
+ * accident. The outbound contribution diff is filtered through
+ * `stripPrivatePathsFromDiff` before it is ever pushed to a remote.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// ─── Manifest parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Parse a `.dpf/private-paths` manifest body into gitignore-style patterns.
+ * Blank lines and `#` comment lines are dropped; surrounding whitespace is
+ * trimmed. Order is preserved and duplicates removed.
+ */
+export function parsePrivatePathManifest(text: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    if (!seen.has(line)) {
+      seen.add(line);
+      out.push(line);
+    }
+  }
+  return out;
+}
+
+// ─── Glob matching ──────────────────────────────────────────────────────────
+
+/** Convert a single glob segment-body into a regex source fragment. */
+function globToRegexSource(glob: string): string {
+  let re = "";
+  let i = 0;
+  while (i < glob.length) {
+    const c = glob[i];
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        // `**/` matches zero or more path segments; bare `**` matches anything.
+        if (glob[i + 2] === "/") {
+          re += "(?:.*/)?";
+          i += 3;
+          continue;
+        }
+        re += ".*";
+        i += 2;
+        continue;
+      }
+      re += "[^/]*"; // single `*` does not cross a path separator
+      i += 1;
+      continue;
+    }
+    if (c === "?") {
+      re += "[^/]";
+      i += 1;
+      continue;
+    }
+    if ("\\^$.|+()[]{}".includes(c)) {
+      re += "\\" + c;
+    } else {
+      re += c;
+    }
+    i += 1;
+  }
+  return re;
+}
+
+/** Compile one gitignore-style pattern into a path predicate. */
+function compilePattern(pattern: string): ((path: string) => boolean) | null {
+  let p = pattern.trim();
+  if (!p || p.startsWith("#")) return null;
+
+  const anchored = p.startsWith("/");
+  if (anchored) p = p.slice(1);
+  // A trailing slash signals a directory but we already match subtrees, so
+  // strip it for a uniform body.
+  p = p.replace(/\/+$/, "");
+  if (!p) return null;
+
+  const hasSlash = p.includes("/");
+  // Unanchored, slash-free patterns (e.g. `secrets`) match at any depth — the
+  // gitignore convention. Anchored or slash-bearing patterns match from root.
+  const prefix = anchored || hasSlash ? "^" : "^(?:.*/)?";
+  // Match the path itself OR anything beneath it (conservative / fail-closed):
+  // `proprietary` matches `proprietary` and `proprietary/foo.ts`.
+  const suffix = "(?:/.*)?$";
+  const body = globToRegexSource(p);
+  const re = new RegExp(prefix + body + suffix);
+  return (path: string) => re.test(normalizePath(path));
+}
+
+/** Normalize a path for matching: strip leading `./` and `/`, use `/` seps. */
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\.?\/+/, "");
+}
+
+/**
+ * Compile a set of patterns into a single predicate. The predicate returns
+ * true when a path is private (matches any pattern). An empty pattern set
+ * matches nothing.
+ */
+export function compilePrivatePathMatcher(patterns: string[]): (path: string) => boolean {
+  const tests = patterns.map(compilePattern).filter((t): t is (path: string) => boolean => t !== null);
+  if (tests.length === 0) return () => false;
+  return (path: string) => tests.some((t) => t(path));
+}
+
+/** Convenience: does `path` match any of `patterns`? */
+export function matchesPrivatePath(path: string, patterns: string[]): boolean {
+  return compilePrivatePathMatcher(patterns)(path);
+}
+
+// ─── Unified-diff splitting & stripping ───────────────────────────────────────
+
+export interface DiffFileBlock {
+  /** Candidate paths this block touches (a-side, b-side, renames). */
+  paths: string[];
+  /** The verbatim lines of this block. */
+  text: string;
+}
+
+export interface SplitDiff {
+  /** Any preamble before the first `diff --git` header (kept verbatim). */
+  preamble: string;
+  blocks: DiffFileBlock[];
+}
+
+const DIFF_GIT_HEADER = /^diff --git a\/(.+?) b\/(.+)$/;
+const MINUS_HEADER = /^--- (?:a\/)?(.+)$/;
+const PLUS_HEADER = /^\+\+\+ (?:b\/)?(.+)$/;
+const RENAME_HEADER = /^rename (?:from|to) (.+)$/;
+
+/**
+ * Split a unified (git) diff into per-file blocks. Recognizes `diff --git`
+ * headers; falls back to `--- a/ … +++ b/` boundaries for non-git diffs.
+ */
+export function splitUnifiedDiffByFile(diff: string): SplitDiff {
+  const lines = diff.split("\n");
+  const blocks: DiffFileBlock[] = [];
+  const preambleLines: string[] = [];
+  let current: { paths: Set<string>; lines: string[] } | null = null;
+  let sawHeader = false;
+
+  const flush = () => {
+    if (current) {
+      blocks.push({ paths: [...current.paths], text: current.lines.join("\n") });
+      current = null;
+    }
+  };
+
+  for (const line of lines) {
+    const gitMatch = line.match(DIFF_GIT_HEADER);
+    if (gitMatch) {
+      sawHeader = true;
+      flush();
+      current = { paths: new Set([gitMatch[1], gitMatch[2]]), lines: [line] };
+      continue;
+    }
+    if (!sawHeader && line.startsWith("--- ")) {
+      // Non-git diff: a `--- a/path` line begins a new file section.
+      flush();
+      const m = line.match(MINUS_HEADER);
+      current = { paths: new Set(m ? [m[1]] : []), lines: [line] };
+      continue;
+    }
+    if (current) {
+      current.lines.push(line);
+      const plus = line.match(PLUS_HEADER);
+      if (plus && plus[1] !== "/dev/null") current.paths.add(plus[1]);
+      const minus = line.match(MINUS_HEADER);
+      if (minus && line.startsWith("--- ") && minus[1] !== "/dev/null") current.paths.add(minus[1]);
+      const rename = line.match(RENAME_HEADER);
+      if (rename) current.paths.add(rename[1]);
+    } else {
+      preambleLines.push(line);
+    }
+  }
+  flush();
+
+  return { preamble: preambleLines.join("\n"), blocks };
+}
+
+export interface StripResult {
+  /** The diff with private-path file blocks removed. */
+  kept: string;
+  /** Distinct paths that were stripped (for plain-language reporting). */
+  strippedPaths: string[];
+  /** True when something was removed. */
+  didStrip: boolean;
+}
+
+/**
+ * Remove every file block whose touched paths include a private path. A block
+ * is dropped if ANY of its candidate paths is private (conservative). The
+ * preamble is always retained.
+ */
+export function stripPrivatePathsFromDiff(
+  diff: string,
+  isPrivate: (path: string) => boolean,
+): StripResult {
+  if (!diff || !diff.trim()) return { kept: diff ?? "", strippedPaths: [], didStrip: false };
+  const { preamble, blocks } = splitUnifiedDiffByFile(diff);
+  const keptParts: string[] = [];
+  if (preamble.trim()) keptParts.push(preamble);
+  const stripped = new Set<string>();
+  for (const block of blocks) {
+    const privateHit = block.paths.find((p) => isPrivate(p));
+    if (privateHit) {
+      for (const p of block.paths) if (isPrivate(p)) stripped.add(p);
+      continue;
+    }
+    keptParts.push(block.text);
+  }
+  return {
+    kept: keptParts.join("\n"),
+    strippedPaths: [...stripped].sort(),
+    didStrip: stripped.size > 0,
+  };
+}
+
+// ─── Loading patterns from manifest + DB ───────────────────────────────────────
+
+/** Minimal Prisma shape we need — avoids importing the full client type here. */
+interface PrivatePathRuleReader {
+  privatePathRule: { findMany: (args: { select: { pattern: true } }) => Promise<{ pattern: string }[]> };
+}
+
+export interface LoadPrivatePathOptions {
+  /** Repo root to read `.dpf/private-paths` from. Defaults to process.cwd(). */
+  repoRoot?: string;
+  /** Prisma client to read PrivatePathRule overrides. Optional. */
+  prisma?: PrivatePathRuleReader | null;
+}
+
+/**
+ * Load the effective private-path patterns: the checked-in manifest first,
+ * then any operator overrides from the database. Missing manifest or DB is
+ * non-fatal — an absent source contributes no patterns.
+ */
+export async function loadPrivatePathPatterns(opts: LoadPrivatePathOptions = {}): Promise<string[]> {
+  const repoRoot = opts.repoRoot ?? process.cwd();
+  const patterns: string[] = [];
+
+  try {
+    const text = await readFile(join(repoRoot, ".dpf", "private-paths"), "utf8");
+    patterns.push(...parsePrivatePathManifest(text));
+  } catch {
+    // No manifest — fine, DB and disposition still apply.
+  }
+
+  if (opts.prisma) {
+    try {
+      const rows = await opts.prisma.privatePathRule.findMany({ select: { pattern: true } });
+      for (const r of rows) {
+        const p = r.pattern.trim();
+        if (p && !patterns.includes(p)) patterns.push(p);
+      }
+    } catch {
+      // PrivatePathRule may not exist yet (pre-migration) — non-fatal.
+    }
+  }
+
+  return patterns;
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10380,6 +10380,23 @@ export async function executeTool(
       const diff = (build.diffPatch ?? "") as string;
       if (!diff.trim()) return { success: false, error: "No diff available.", message: "Run deploy_feature first to extract the diff." };
 
+      // Private-paths boundary (Phase 1 of Private/Public Change Segregation):
+      // local records keep the full diff, but any OUTBOUND PR diff must never
+      // carry a path the operator marked proprietary. The `.dpf/private-paths`
+      // manifest ships empty → no-op until opted in. Spec:
+      // docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
+      const { loadPrivatePathPatterns: _loadPriv, compilePrivatePathMatcher: _compilePriv, stripPrivatePathsFromDiff: _stripPriv } =
+        await import("@/lib/integrate/private-paths");
+      const shareableDiff = _stripPriv(diff, _compilePriv(await _loadPriv())).kept;
+      if (!shareableDiff.trim()) {
+        return {
+          success: false,
+          error: "Only private paths.",
+          message:
+            "This change only affects parts of your system you've marked private (see .dpf/private-paths or Admin > Platform Development), so there is nothing to share upstream.",
+        };
+      }
+
       const { buildSandboxStateFromRecord, assertSandboxReadyForPromotion, serializePlanDocument } = await import("@/lib/build/sandbox-state");
       const sandboxState = buildSandboxStateFromRecord({
         buildBranch: build.buildBranch,
@@ -10443,7 +10460,7 @@ export async function executeTool(
 
       // Run pre-PR gates
       const { runPrePRGates, formatGateReport } = await import("@/lib/integrate/pre-pr-gates");
-      const gateResult = runPrePRGates(diff);
+      const gateResult = runPrePRGates(shareableDiff);
 
       // If gates block, return the report without creating a PR
       if (!gateResult.canProceed) {
@@ -10519,7 +10536,7 @@ export async function executeTool(
         baseRepo: repoName,
         branchName,
         commitMessage,
-        diff,
+        diff: shareableDiff,
         prTitle,
         prBody,
         labels,
@@ -11375,6 +11392,23 @@ export async function executeTool(
       const diff = (build.diffPatch ?? "") as string;
       if (!diff.trim()) return { success: false, error: "No diff available.", message: "Run deploy_feature first to extract the diff." };
 
+      // Private-paths boundary (Phase 1 of Private/Public Change Segregation):
+      // local records keep the full diff, but any OUTBOUND PR diff must never
+      // carry a path the operator marked proprietary. The `.dpf/private-paths`
+      // manifest ships empty → no-op until opted in. Spec:
+      // docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
+      const { loadPrivatePathPatterns: _loadPriv, compilePrivatePathMatcher: _compilePriv, stripPrivatePathsFromDiff: _stripPriv } =
+        await import("@/lib/integrate/private-paths");
+      const shareableDiff = _stripPriv(diff, _compilePriv(await _loadPriv())).kept;
+      if (!shareableDiff.trim()) {
+        return {
+          success: false,
+          error: "Only private paths.",
+          message:
+            "This change only affects parts of your system you've marked private (see .dpf/private-paths or Admin > Platform Development), so there is nothing to share upstream.",
+        };
+      }
+
       const { buildSandboxStateFromRecord, assertSandboxReadyForPromotion, serializePlanDocument } = await import("@/lib/build/sandbox-state");
       const sandboxState = buildSandboxStateFromRecord({
         buildBranch: build.buildBranch,
@@ -11507,7 +11541,7 @@ export async function executeTool(
 
             const prTitle = `feat: ${build.title}`;
             const { submitBuildAsPR } = await import("@/lib/contribution-pipeline");
-            const securityScan = (await import("@/lib/security-scan")).scanDiffForSecurityIssues(diff);
+            const securityScan = (await import("@/lib/security-scan")).scanDiffForSecurityIssues(shareableDiff);
             const prBody = [
               "## Summary",
               "",
@@ -11536,7 +11570,7 @@ export async function executeTool(
               baseRepo: upstreamMatch[2],
               branchName,
               commitMessage,
-              diff,
+              diff: shareableDiff,
               prTitle,
               prBody,
               labels,
@@ -11561,7 +11595,7 @@ export async function executeTool(
                     repoOwner: upstreamMatch[1],
                     repoName: upstreamMatch[2],
                     token: hiveToken,
-                    diff,
+                    diff: shareableDiff,
                   });
                   logBuildActivity(buildId, "contribution_review", `Merge readiness: ${reviewResult.mergeReadiness}. Verticals: ${reviewResult.verticals.applicableVerticals.filter((v) => v.relevance !== "unlikely").map((v) => v.category).join(", ") || "none"}`);
                 } catch (reviewErr) {

--- a/docs/superpowers/specs/2026-06-18-local-git-and-private-public-segregation-analysis.md
+++ b/docs/superpowers/specs/2026-06-18-local-git-and-private-public-segregation-analysis.md
@@ -1,0 +1,137 @@
+# Local Git Substrate & Private/Public Change Segregation — Investigation & Recommendation
+
+**Date:** 2026-06-18
+**Status:** Analysis (pre-spec). Investigates whether DPF should install/integrate a local git repository for local checkin and tighter GitLab integration, and how proprietary-local vs shareable-public changes are threaded.
+**Author:** Investigation per operator goal.
+
+---
+
+## 0. The question, restated
+
+The operator asked three things that turn out to be one:
+
+1. Is it worth installing/integrating a **local git repository** for local checkin/work?
+2. Support **more seamless integration with a GitLab instance** for the project.
+3. Support **local builds where the customer keeps some things proprietary** and does not contribute everything to the public repo.
+
+The clarifying answer narrowed it: *"We have a contribution mode that can be set to not share with the public repo. When that happens, where do those changes go? How do we thread what stays local/proprietary vs shared publicly? The feature is there but we have no real way to segregate."* Priority: **both** the private/local-build capability **and** GitLab, equally.
+
+**Finding in one line:** DPF already has a local git substrate and a private lane, but it has **no structural boundary** between proprietary and shareable changes — and a private git remote (which a self-hosted GitLab can be) is the missing physical home that would make the boundary real. "Install a local git repo / integrate GitLab" and "thread private vs public" are the same project viewed from two angles.
+
+---
+
+## 1. What already exists (do NOT rebuild)
+
+### 1.1 A local git substrate is already in place
+The install is not a stateless container. The governed self-upgrade path maintains a **durable per-install branch `dpf/install`** in a host clone (`~/.dpf/install/`), and merges upstream into it inside an isolated `.upgrade-workspace/` sub-clone via `git merge --no-ff` (`apps/web/lib/self-upgrade/prepare-source.ts`). On conflict it aborts, returns `conflictFiles`, and **defers** — the operator is never broken, only not-yet-updated. The built image is stamped with the **merge-commit SHA** (identity-equals-bytes, BI-5B6C1C35), so a build that contains local delta is honestly labelled.
+
+> Implication: there is **no need to install a second git server for "local checkin."** That capability exists. The `dpf/install` branch *is* the local working substrate.
+
+### 1.2 A private (non-contributed) lane already exists
+`PlatformDevConfig.contributionMode` ∈ `fork_only | selective | contribute_all` (Admin → Platform Development, onboarding Step 7):
+- **`fork_only`** — closed system; nothing pushed upstream by default. Optional backup to a user-configured `gitRemoteUrl`. DCO not required.
+- **`selective`** — per-feature human decision; default = keep local.
+- **`contribute_all`** — per-feature decision; default = contribute.
+
+### 1.3 Customer-proprietary *data* is already off git
+Secrets/credentials (`.env`, `Credential`), branding/org config (`Organization`, `PlatformConfig`), prompts (`PromptTemplate`), and skills (`SkillDefinition`) live in **env + Postgres**, never in the public source tree. This part of "proprietary stays local" is already handled.
+
+---
+
+## 2. The real gap: there is no structural private/public boundary
+
+The unit of contribution is a **per-feature diff** (`FeatureBuild.diffPatch`), not repo state. At deploy:
+- **Public:** the diff is pushed as a GitHub PR branch (`submitBuildAsPR` → `createBranchAndPR`, `apps/web/lib/integrate/contribution-pipeline.ts:299`).
+- **Local:** the same diff is applied to `dpf/install` and **not pushed** (`mode: "local"`, `prUrl: null`, `contribution-pipeline.ts:359`).
+
+Segregation today rests on three things, **none of which is a boundary**:
+
+| Mechanism | What it is | What it does NOT do |
+|---|---|---|
+| `selective`/`fork_only` mode | A per-feature human choice | No policy/classifier; nothing stops proprietary logic from being chosen "share" by mistake |
+| `scanDiffForSecurityIssues` + `redactHostnames` + pseudonymous author | Outbound redaction of **secrets & identity** | Does **not** detect proprietary *business logic* or customer-specific IP |
+| Single `dpf/install` branch | Holds local diffs **intermingled** with merged-upstream commits | No separate private layer; no "these paths never leave the box" rule; no way to later audit "what have we kept private?" |
+
+**Consequences the operator correctly sensed:**
+1. **No declarative partition.** Nothing in the model says "directory/feature X is proprietary-local and structurally excluded from every public PR." It's re-decided per build, by a human, every time.
+2. **No private *home*.** A `fork_only` change has nowhere durable to go except intermingled on `dpf/install`. The `gitRemoteUrl` backup hook is designed but only ever pushed to GitHub-shaped remotes in code (see §3).
+3. **No reconciliation ledger for customizations.** Seeded content (prompts/skills) has `isOverridden` (a boolean) but **no `seedContentHash` / merge base** — true 3-way merge of customer edits vs upstream is impossible today (governed-upgrade-lifecycle spec §2.3). So "what's mine vs theirs" is unanswerable for seed data.
+
+---
+
+## 3. Why DPF is not ready for GitLab today (and the doctrine tension)
+
+DPF is **100% GitHub-coupled** with **no forge abstraction**:
+- The git-host type is a one-value union: `export type GitProvider = "github"` (`apps/web/lib/integrate/git-promotion-intake.ts`).
+- `parseGitHubRepo()` regex-matches `github.com` and returns `null` otherwise — duplicated in `contribution-pipeline.ts:183`, `issue-bridge.ts:133`, and the change-lanes reader. A GitLab URL fails the regex → "Cannot determine repository."
+- All API calls hardcode `https://api.github.com` (`github-api-commit.ts`, `github-fork.ts`, `github-rest-reader.ts`), webhooks read `x-github-*` headers, release-health reads GitHub Actions workflows, OAuth is GitHub device-flow, CI + DCO bot are GitHub Actions.
+- GitLab appears **only in docs**, never in code; a test explicitly asserts `parseRepoFromUrl("https://gitlab.com/...")` returns `null`.
+
+**Doctrine tension to resolve explicitly.** AGENTS.md §1: *"Learnings belong in the shared commons … local-only knowledge is a defect. Local, client-only storage is reserved for genuinely install-specific config."* A "keep it proprietary" feature must therefore **distinguish two kinds of local change**:
+- **Proprietary business content** (a customer's pricing logic, vertical-specific workflow, private branding) → legitimately local; the private lane is correct.
+- **Platform improvements** (a bug fix, a reusable capability) → the doctrine says these should flow to the hive; keeping them local is the defect the doctrine warns about.
+
+The segregation design's hardest job is not plumbing — it's making *that* classification explicit so the private lane is used for genuinely-proprietary content, not as a quiet way to fork the platform.
+
+---
+
+## 4. Recommendation
+
+**Yes, it is worth the work — but not as "install a local git repo."** You already have the local substrate. The worthwhile work is making the private/public boundary *structural* and giving the private lane a *real home*. GitLab is the natural home, but it should be reached through an abstraction, not hardcoded.
+
+Three phases, in priority order. Phase 1 delivers most of the operator's value without any GitLab work.
+
+### Phase 1 — Make the boundary real (no GitLab dependency). HIGHEST VALUE.
+Turn segregation from a per-build human guess into a declared, auditable partition.
+1. **Classification at the point of contribution.** Extend the `selective` gate so each change is tagged `shareable | proprietary` with a reason, persisted on `FeatureBuild`/`FeaturePack`. Default-deny outbound for anything not explicitly classified `shareable` (fail closed).
+2. **Declarative proprietary scope.** A repo-level manifest (e.g. `.dpf/private-paths`) + DB policy listing paths/features that are structurally never eligible for a public PR. The contribution pipeline refuses to include them in an upstream diff regardless of mode.
+3. **A "local changes ledger" UI** in the Upgrade Center: every commit on `dpf/install` that is not in upstream, labelled shareable/proprietary, so the operator can answer "what have we kept private?" at a glance.
+4. **Seed reconciliation prerequisite** (close the §2.3 gap): add `seedContentHash` + merge-base capture so customer edits to prompts/skills are 3-way mergeable and visibly "mine vs upstream."
+
+### Phase 2 — Give the private lane a home: a forge abstraction + private remote.
+1. **Extract a `GitForgeProvider` interface** (`parseRepo`, `createBranch`, `commit`, `openChangeRequest`, `readChangeRequests`, webhook verification) behind the existing call sites. This is the unlock for *any* non-GitHub remote and pays down the duplication in §3. Scope ≈ the touchpoints listed above; mid-sized, low-risk refactor.
+2. **Implement a plain-git private-remote target first** (cheapest, no API): the `fork_only` `gitRemoteUrl` backup becomes a real `git push` to the customer's private remote — this alone satisfies "proprietary work has a durable off-box home" and needs **no** GitLab API.
+3. Route `shareable` → upstream (GitHub) provider; `proprietary` → private provider. The classification from Phase 1 now drives *where bytes physically go*, not just whether a PR opens.
+
+### Phase 3 — First-class GitLab (only if a concrete instance/role is confirmed).
+Add a `GitLabForgeProvider` implementing the Phase-2 interface (merge requests, GitLab OAuth, `gitlab-ci.yml` equivalent for self-hosted CI, webhook signature). Optionally ship a self-hosted `gitlab-ce` Docker service for air-gapped installs. This is the ~30–45 day item and should **not** start until §5 below is answered.
+
+---
+
+## 5. Decision resolved: the private git home ships *inside* the install
+
+**Operator decision (2026-06-18):** the git instance is **part of this installation** — a self-hosted private home that ships with the install, not an external corporate GitLab DPF connects to. And it must be **invisible to non-technical users by default** (AGENTS.md §17: hide complexity, expose only to those who want access).
+
+This settles the §4 phasing and adds a hard product constraint, with one new sub-decision (the bundled engine):
+
+### 5.1 The non-technical-user constraint reshapes the design
+The majority of users never see git. Therefore:
+- **Segregation must be automatic and fail-closed**, with no git vocabulary in the default UI. A change is **private by default**; it only becomes public if a human with access explicitly approves contribution. The non-technical user sees "Keep on my system" vs "Share with the community" in plain language — never "branch", "remote", "PR", "merge".
+- **The private git home is backstage plumbing**, like the worktree/lease coordination plane. It exists so proprietary work has a durable, versioned home on the box; the layman never logs into it.
+- **Git/forge controls are admin-gated** (Admin → Platform Development), surfaced only to operators who opt into technical access. This mirrors how `.mcp.json`, leases, and `COMPOSE_PROJECT_NAME` are already operator-grade.
+
+### 5.2 New sub-decision: which engine hosts the bundled private remote?
+Because it ships *in the install* and serves *mostly non-technical users*, weight and admin-surface matter more than features:
+
+| Option | RAM cost | Admin surface | Fit |
+|---|---|---|---|
+| **Bare git remote** on the existing host volume (no service) | ~0 | none | Lightest; gives a durable private home + push target with zero new service. No UI/MRs — but non-technical users don't need one. **Recommended default.** |
+| **Gitea** (self-hosted, single Go binary) | ~100–300 MB | small, optional | Light enough to bundle; gives a real web UI + MR/issue API for the *technical* opt-in tier if wanted. Good middle ground. |
+| **GitLab CE Omnibus** | ~4–8 GB | large, always-on | Heavy on an already-heavy stack; admin surface is the opposite of "hidden complexity." **Do NOT bundle by default.** Reserve for a technical customer who explicitly runs GitLab and wants DPF to integrate with *their* instance (the `GitForgeProvider` from Phase 2 covers this without bundling). |
+
+**Recommendation:** bundle a **bare private remote** (Phase 2.2) as the default invisible home; offer **Gitea** as an opt-in technical upgrade for operators who want a private UI; treat **GitLab CE** only as an *external* integration target via the forge abstraction, never as a default bundled service. This keeps the layman's install light and silent while still letting a technical org point at their own GitLab.
+
+### 5.3 What this does to the phasing
+- Phase 1 (classify/ledger/seed merge-base) is unchanged and still highest value — and its UI must follow §5.1 (plain-language, private-by-default, no git terms).
+- Phase 2.2 (plain-git private remote) is now **confirmed in scope** as the bundled private home, not optional.
+- Phase 3 (first-class GitLab) is **demoted to "external integration only, on demand"** — not part of the default install. The bundled need is met by 2.2 (+ optional Gitea).
+
+---
+
+## 6. Bottom line
+
+- **Don't install a second git repo** for local checkin — `dpf/install` already is one.
+- **The feature the operator doubts is real — and they're right to doubt it.** Today's "private" lane is a per-build human choice plus secret/identity redaction, intermingled on one branch, with no structural boundary and no private home. That is the gap.
+- **Highest-value, GitLab-independent work is Phase 1**: classify changes shareable/proprietary (fail-closed), declare proprietary scope structurally, add a local-changes ledger, and close the seed merge-base gap.
+- **The private home ships inside the install and stays invisible to non-technical users** (§5). Default = a **bare private remote** on the existing host volume (zero new service); the layman sees "Keep on my system" vs "Share with the community," private-by-default and fail-closed, with no git vocabulary. Git/forge controls are admin-gated for the technical opt-in tier.
+- **Do not bundle GitLab CE by default** — too heavy (~4–8 GB) and too much admin surface for a layman install. Offer **Gitea** as an opt-in private UI, and treat **GitLab CE only as an *external* integration target** via the `GitForgeProvider` abstraction (Phase 2.1), on demand — never the default bundled service.

--- a/docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
+++ b/docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
@@ -1,0 +1,71 @@
+# Private/Public Change Segregation — Phase 1 Design
+
+**Date:** 2026-06-18
+**Status:** Draft spec (implementable). Phase 1 of the program scoped in [`2026-06-18-local-git-and-private-public-segregation-analysis.md`](2026-06-18-local-git-and-private-public-segregation-analysis.md).
+**Depends on:** governed-upgrade-lifecycle seed merge-base work (§2.3 of that spec) for the seed-reconciliation slice only; the rest stands alone.
+**Surface:** contribution pipeline (`apps/web/lib/integrate/`), AI Coworker ship-phase UX, Admin → Platform Development.
+
+---
+
+## 1. Problem
+
+A change a customer chooses *not* to contribute upstream has no structural boundary and no durable home (see analysis §2). Segregation today is a per-build human choice plus secret/hostname redaction on the outbound diff; proprietary business logic can still be selected "share" by mistake, and once a local diff lands it intermingles with merged-upstream commits on `dpf/install` with no way to answer "what have we kept private?"
+
+The majority of users are **non-technical** (AGENTS.md §17). The fix must be **automatic, private-by-default, fail-closed, and free of git vocabulary** in the default UI, with technical controls available only on opt-in.
+
+## 2. Goals / Non-goals
+
+**Goals (Phase 1):**
+1. Every change carries an explicit `disposition` (`private` | `shareable`) with a reason, persisted and auditable.
+2. Outbound contribution is **fail-closed**: nothing is pushed upstream unless a change is explicitly `shareable` AND passes the existing secret/identity scans.
+3. A **declarative proprietary boundary** (`private-paths`) structurally excludes designated paths/features from any upstream diff regardless of disposition.
+4. A **local-changes ledger** lets an operator see, in plain language, what is kept private vs shared.
+5. Default UX uses plain language ("Keep on my system" / "Share with the community"), never git terms; git/forge controls are admin-gated.
+
+**Non-goals (deferred):**
+- The git engine / bundled private remote (analysis Phase 2.2) — separate spec.
+- Forge abstraction and GitLab (analysis Phase 2.1 / 3).
+- Full seed 3-way merge (depends on `seedContentHash`); Phase 1 only *surfaces* unreconciled seed overrides in the ledger.
+
+## 3. Design
+
+### 3.1 Data model (audit-first — AGENTS.md §11)
+Reuse existing models; add the minimum.
+- **`FeatureBuild`**: add `disposition String @default("private")` (enum: `private` | `shareable`) + `dispositionReason String?` + `dispositionSetById String?` / `dispositionSetAt DateTime?`. Default-private is the fail-closed posture.
+- **`PlatformDevConfig`**: no new columns; `contributionMode` still governs the *default suggestion* the coworker makes, but the per-build `disposition` is the authority and defaults private even in `contribute_all`.
+- **Proprietary boundary**: a checked-in manifest `.dpf/private-paths` (gitignore-style globs) plus an optional DB override table `PrivatePathRule { id, pattern, reason, createdById, createdAt }` so an operator can extend it without a code change. The contribution pipeline treats a path matching either source as **never eligible** for an upstream diff.
+
+### 3.2 Contribution pipeline (fail-closed gate)
+In `submitBuildAsPR` (`contribution-pipeline.ts`) and the `contribute_to_hive` handler:
+1. Resolve `disposition`. If unset → treat as `private` (no upstream push; local apply only).
+2. If `shareable`: strip any hunk touching a `private-paths` match **before** the diff is built into a PR; if stripping empties the diff, abort with a plain-language explanation ("This change only affects parts of your system you've marked private").
+3. Run existing `scanDiffForSecurityIssues` + `redactHostnames` on the *post-strip* diff.
+4. Only then create the PR. A change can never reach `createBranchAndPR` while `private` or while it still contains private-path hunks.
+
+### 3.3 UX — progressive disclosure (AGENTS.md §12 UX-Fit, §17 hide-complexity)
+- **Non-technical default** (AI Coworker ship phase): a two-option plain-language control — **"Keep on my system"** (default, selected) vs **"Share with the community"** — with a one-line consequence sentence each. No "branch", "PR", "remote", "merge".
+- Choosing "Share" surfaces a short, human review of *what will be shared* (file/feature summary, not a raw diff) and the secret-scan result in plain terms.
+- **Technical opt-in** (Admin → Platform Development): the existing `contributionMode`, `upstreamRemoteUrl`, private-remote config, the `private-paths` editor, and the raw diff/PR controls. Surfaced only here.
+- **Local-changes ledger** (Upgrade Center): a `report-kit` `DataTable` (per AGENTS.md §12) listing commits on `dpf/install` not in upstream, each tagged `private`/`shareable` with reason, plus a flag for seed overrides not yet reconciled. Plain status badges via `statusColors`, no hardcoded colors.
+- UX-Fit-Decision attestation required on the PR (the two-option control is a new user-facing control on the `human_cognitive_load` axis; default view ≤ 5 choices — passes by construction).
+
+## 4. Research & Benchmarking (AGENTS.md §10)
+
+- **GitHub fork visibility model:** a private fork of a public repo stays private; you opt specific branches into PRs. Pattern adopted: *default-private, opt-in-to-share per change*. Anti-pattern rejected: GitHub has no path-level "never leaves" rule — we add `private-paths` to cover proprietary code that must be structurally excluded, not just unpushed.
+- **GitLab project visibility (private/internal/public)** + protected paths via CODEOWNERS: confirms a declarative ownership/visibility manifest is the standard shape; we mirror it with `private-paths` rather than per-file ACLs (too heavy for non-technical installs).
+- **Inner-source / "upstream-first" patterns (Bloomberg, SAP):** the durable lesson is an explicit *classification gate* deciding what is generally reusable vs org-specific — exactly the `disposition` gate, and it aligns with AGENTS.md §1 "platform improvements flow to the hive; proprietary content stays local."
+- **Data-loss-prevention (DLP) default-deny:** classification-driven egress that fails closed is the security-standard posture; adopted for the outbound contribution gate. Rejected anti-pattern: trusting a post-hoc scan as the only barrier (our current state) — scans catch secrets, not proprietary intent.
+- **Gitea vs GitLab CE weight** (for the deferred bundled-remote phase): Gitea single-binary ~100–300 MB vs GitLab CE ~4–8 GB informed the analysis-doc decision to default to a bare remote + optional Gitea, never bundle GitLab CE.
+
+## 5. Acceptance criteria
+
+1. A new `FeatureBuild` defaults to `disposition = "private"`; no upstream PR is created unless explicitly set `shareable`.
+2. A `shareable` change whose diff touches a `private-paths` match has those hunks stripped before PR creation; an all-private diff is refused with a plain-language message.
+3. The AI Coworker ship phase shows the two-option plain-language control with no git vocabulary; the technical controls appear only in Admin → Platform Development.
+4. The Upgrade Center ledger lists not-yet-upstreamed commits tagged private/shareable, built from `report-kit` primitives with no hardcoded colors.
+5. Unit tests cover: default-private, private-path stripping, all-private refusal, and that `contribute_all` mode still defaults a *new* build to private until explicitly shared.
+6. UX-Fit-Decision trailer present on the PR.
+
+## 6. Rollout
+
+Single PR against `main` (one concern): data-model migration + pipeline gate + ledger + ship-phase control. Verify on the canonical local install / shared local-CI sandbox per AGENTS.md §5 (migration apply + `next build` + UX exercise of the two-option control). The git-engine and forge-abstraction phases follow in their own specs.


### PR DESCRIPTION
## Summary

First increment of **Private/Public Change Segregation** (program analysis: `docs/superpowers/specs/2026-06-18-local-git-and-private-public-segregation-analysis.md`; Phase 1 spec: `docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md`; epic EP-1A78BAE1).

**Problem.** A change a customer declines to contribute upstream has no *structural* boundary today — the outbound diff is gated only by a per-build human choice plus secret/hostname redaction, which does not catch proprietary business logic.

**This change.** Adds a declarative, gitignore-style `.dpf/private-paths` manifest. Any file matching it is **stripped from the outbound contribution diff** before it can reach a remote — in `contribute_to_hive`, `create_portal_pr`, and `submitBuildAsPR`. Local records (FeaturePack/manifest) keep the full diff; only what is *shared* is filtered. If every changed file is private, the tool returns a plain-language "nothing to share" result instead of opening an empty PR. The security scan now runs on the post-strip (outbound) diff.

**Safe by default.** The manifest ships empty → zero behavior change until an operator opts in.

## What's NOT in this PR (later increments on the same program)
- `FeatureBuild.disposition` fail-closed per-change gate + `PrivatePathRule` DB overrides (needs a migration).
- Plain-language ship-phase control ("Keep on my system" / "Share with the community") + Admin private-paths editor + Upgrade Center local-changes ledger (needs canonical-install UX verification per AGENTS.md §5).

## Verification
- **Unit tests:** 13 new tests for the glob matcher, unified-diff splitter, and stripper — all pass (`vitest`).
- **Typecheck:** `pnpm --filter web typecheck` clean (run via root-clone overlay; the source-only worktree has no toolchain per AGENTS.md §5).
- **Substrate:** source-local gates only. `next build` + any runtime/UX exercise deferred to CI / the canonical install — this PR adds no UI and no migration.

EP-1A78BAE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)