### PR TITLE
fix(self-upgrade): don't crash the page when a forced upgrade swaps the portal mid-request

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.swap-resilience.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.swap-resilience.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for the forced-self-upgrade crash: a forced upgrade
+// bypasses the quiescence drain and swaps the portal out from under the
+// operator's own request, so the server-action response comes back as a
+// non-RSC transport failure (Next error code E394, "An unexpected response was
+// received from the server"). Previously the handlers awaited the actions with
+// no try/catch, so that rejection escalated to the global (shell) error
+// boundary and painted a full-page crash over an upgrade that actually
+// succeeded. The page must instead recognise the expected mid-swap disconnect
+// and hold a calm "reconnecting" state.
+import "@/components/build-studio/test-setup";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/promotions", () => ({
+  triggerSelfUpgrade: vi.fn(),
+  forceActiveRun: vi.fn(),
+  abortActiveRun: vi.fn(),
+  rollbackSelfUpgrade: vi.fn(),
+}));
+
+// The impact panel loads its own data on mount; keep it out of these behavior
+// tests so they stay focused on the trigger/force handlers.
+vi.mock("@/components/ops/UpgradeImpactPanel", () => ({
+  default: () => null,
+}));
+
+import { triggerSelfUpgrade, forceActiveRun } from "@/lib/actions/promotions";
+import SelfUpgradeClient, { isExpectedDuringSwap } from "./SelfUpgradeClient";
+
+const triggerMock = triggerSelfUpgrade as unknown as ReturnType<typeof vi.fn>;
+const forceMock = forceActiveRun as unknown as ReturnType<typeof vi.fn>;
+
+// The real Next.js E394 transport error: a generic message plus a stable,
+// non-enumerable error code stamped by the server-action reducer.
+function makeE394(): Error {
+  const e = new Error("An unexpected response was received from the server.");
+  Object.defineProperty(e, "__NEXT_ERROR_CODE", {
+    value: "E394",
+    enumerable: false,
+  });
+  return e;
+}
+
+const baseProps = {
+  enabled: true,
+  channel: "stable",
+  inMaintenanceWindow: false,
+  nextScheduledCheckAt: "2026-06-18T18:00:00.000Z",
+  deployedSha: "abc1234",
+  targetSha: "def5678",
+  isFresh: false,
+  latestRun: null,
+  platformVersion: {
+    version: "1.0.0",
+    publishedAt: "2026-06-18T00:00:00.000Z",
+    gitSha: "9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1098",
+    note: "baseline",
+  },
+} as const;
+
+function makeRun(status: string, overrides: Record<string, unknown> = {}) {
+  return {
+    runId: "SUR-0001",
+    status,
+    trigger: "manual",
+    currentSha: "abc1234",
+    targetSha: "def5678",
+    deployedSha: "def5678",
+    reason: null as string | null,
+    startedAt: new Date("2026-06-18T02:00:00Z"),
+    completedAt: null,
+    completionEvidence: null,
+    failureLog: null as string | null,
+    createdAt: new Date("2026-06-18T02:00:00Z"),
+    ...overrides,
+  };
+}
+
+const drainingQuiescence = {
+  level: "draining" as const,
+  runId: "QR-DRAIN",
+  enteredAt: "2026-06-18T01:44:00.000Z",
+  run: {
+    runId: "QR-DRAIN",
+    status: "draining",
+    trigger: "self-upgrade",
+    targetVersion: "abcdef0123456789",
+    targetBundleHash: "abcdef0123456789",
+    deferSurface: null,
+    deferReason: null,
+    budgetMs: 300000,
+    drainStartedAt: "2026-06-18T01:44:00.000Z",
+    lastHeartbeatAt: "2026-06-18T01:44:30.000Z",
+  },
+  blockersCapturedAt: null,
+  blockers: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── isExpectedDuringSwap (pure) ───────────────────────────────────────────
+
+describe("isExpectedDuringSwap", () => {
+  it("detects the Next E394 transport error by code", () => {
+    expect(isExpectedDuringSwap(makeE394())).toBe(true);
+  });
+
+  it("detects the transport error by message when no code is present", () => {
+    expect(
+      isExpectedDuringSwap(
+        new Error("An unexpected response was received from the server."),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects bare network failures from a severed connection", () => {
+    expect(isExpectedDuringSwap(new TypeError("Failed to fetch"))).toBe(true);
+    expect(
+      isExpectedDuringSwap(new Error("NetworkError when attempting to fetch resource")),
+    ).toBe(true);
+    expect(isExpectedDuringSwap(new Error("connection reset"))).toBe(true);
+  });
+
+  it("does not match ordinary application errors", () => {
+    expect(isExpectedDuringSwap(new Error("Unauthorized"))).toBe(false);
+    expect(isExpectedDuringSwap(new Error("disabled"))).toBe(false);
+    expect(isExpectedDuringSwap(null)).toBe(false);
+    expect(isExpectedDuringSwap(undefined)).toBe(false);
+  });
+});
+
+// ─── Forced trigger severed by the swap ────────────────────────────────────
+
+describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
+  it("shows a reconnecting state (not the crash boundary) when the forced upgrade swaps the portal mid-request", async () => {
+    triggerMock.mockRejectedValue(makeE394());
+
+    render(<SelfUpgradeClient {...baseProps} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /emergency override/i }));
+    fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Applying the upgrade/i)).toBeInTheDocument();
+    });
+
+    // The raw Next transport message must never reach the operator as an error.
+    expect(
+      screen.queryByText(/An unexpected response was received from the server/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Not queued/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces a genuine (non-swap) trigger failure inline instead of reconnecting", async () => {
+    triggerMock.mockRejectedValue(new Error("Unauthorized"));
+
+    render(<SelfUpgradeClient {...baseProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Not queued:/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Unauthorized/i)).toBeInTheDocument();
+    // A real error is not dressed up as a successful "applying" swap.
+    expect(screen.queryByText(/Applying the upgrade/i)).not.toBeInTheDocument();
+  });
+
+  it("treats a severed Force-now request during a drain as applying, not a crash", async () => {
+    forceMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    render(
+      <SelfUpgradeClient
+        {...baseProps}
+        latestRun={makeRun("running")}
+        quiescence={drainingQuiescence}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Force upgrade run QR-DRAIN now/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /confirm force/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Applying the upgrade/i)).toBeInTheDocument();
+    });
+  });
+
+  it("clears the reconnecting banner once the swapped-in portal returns fresh data", async () => {
+    triggerMock.mockRejectedValue(makeE394());
+
+    const { rerender } = render(<SelfUpgradeClient {...baseProps} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /emergency override/i }));
+    fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Applying the upgrade/i)).toBeInTheDocument();
+    });
+
+    // The poll reaches the new container: a fresh run is now visible, the
+    // deployed SHA has advanced and the install reports up to date.
+    rerender(
+      <SelfUpgradeClient
+        {...baseProps}
+        deployedSha="def5678"
+        isFresh={true}
+        latestRun={makeRun("succeeded", {
+          completedAt: new Date("2026-06-18T02:05:00Z"),
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Applying the upgrade/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps a normal queued trigger working (no false reconnecting state)", async () => {
+    triggerMock.mockResolvedValue({ queued: true, runId: "SUR-9999" });
+
+    render(<SelfUpgradeClient {...baseProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
+
+    await waitFor(() => {
+      expect(triggerMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(/Applying the upgrade/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import {
   rollbackSelfUpgrade,
@@ -209,6 +209,28 @@ function recoveryMemberLabel(member: { target: string; status: string }): string
 const DEFAULT_STATUS_STYLE =
   "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] border-[var(--dpf-border)]";
 
+// A forced upgrade intentionally bypasses the quiescence drain and swaps the
+// portal container out from under the very request that triggered it. When the
+// swap lands mid-flight, the operator's own server-action response never returns
+// intact — Next surfaces a non-RSC transport failure ("An unexpected response
+// was received from the server", error code E394), or the browser reports a bare
+// network error. For the self-upgrade page that is the EXPECTED success path of
+// a force, not a crash: the upgrade is applying and the portal is restarting.
+// Recognising it lets the page hold a calm "reconnecting" state instead of
+// letting the rejection escalate to the global (shell) error boundary and paint
+// a full-page "Something went wrong" over an upgrade that actually succeeded.
+// Exported for unit testing.
+export function isExpectedDuringSwap(err: unknown): boolean {
+  if (!err) return false;
+  // Next stamps server-action transport failures with a stable error code.
+  const code = (err as { __NEXT_ERROR_CODE?: unknown }).__NEXT_ERROR_CODE;
+  if (code === "E394") return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return /unexpected response was received|failed to fetch|fetch failed|load failed|networkerror|err_connection|connection (?:refused|reset|closed)|the operation was aborted/i.test(
+    message,
+  );
+}
+
 export default function SelfUpgradeClient({
   enabled,
   channel,
@@ -240,6 +262,13 @@ export default function SelfUpgradeClient({
   const [forceConfirm, setForceConfirm] = useState(false);
   const [abortConfirm, setAbortConfirm] = useState(false);
   const [inFlightError, setInFlightError] = useState<string | null>(null);
+  // A forced upgrade can swap this portal out from under the operator's own
+  // request. `restarting` holds a calm reconnect banner (and keeps the status
+  // poll alive) so a *successful* forced upgrade never paints the global crash
+  // screen. See isExpectedDuringSwap. `restartBaselineRef` snapshots the server
+  // signature at swap time so we know when the new container has answered.
+  const [restarting, setRestarting] = useState(false);
+  const restartBaselineRef = useRef<string | null>(null);
   const [rollbackConfirmation, setRollbackConfirmation] = useState("");
   const [rollbackResult, setRollbackResult] = useState<{
     status: "idle" | "ok" | "error";
@@ -285,21 +314,97 @@ export default function SelfUpgradeClient({
   }, [justQueued]);
 
   useEffect(() => {
-    if (!justQueued && !upgradeInFlight) return;
+    if (!justQueued && !upgradeInFlight && !restarting) return;
     const interval = setInterval(() => router.refresh(), 4_000);
     return () => clearInterval(interval);
-  }, [justQueued, upgradeInFlight, router]);
+  }, [justQueued, upgradeInFlight, restarting, router]);
+
+  // Drop the reconnect banner once the swapped-in portal actually answers with
+  // fresh data. We snapshot the server-derived signature at the moment the swap
+  // severs the request (enterRestarting), then clear as soon as any of those
+  // fields change — the deployed SHA flips, the run reaches a terminal state, or
+  // the drain returns to normal — which only happens after a poll gets through to
+  // the new container. Keying off "the data changed" (not the instantaneous
+  // in-flight flag, which is already false on an idle force) avoids both a
+  // premature flash and a banner that lingers long after the portal is back.
+  useEffect(() => {
+    if (!restarting || restartBaselineRef.current === null) return;
+    if (serverSignature() !== restartBaselineRef.current) {
+      restartBaselineRef.current = null;
+      setRestarting(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    restarting,
+    latestRun?.runId,
+    latestRun?.status,
+    deployedSha,
+    isFresh,
+    quiescence?.level,
+  ]);
+
+  // Safety net: never let the reconnect banner wedge if the portal stays
+  // unreachable (e.g. a swap that genuinely failed). The run-status surfaces
+  // below still tell the operator what happened.
+  useEffect(() => {
+    if (!restarting) return;
+    const timeout = setTimeout(() => {
+      restartBaselineRef.current = null;
+      setRestarting(false);
+    }, 120_000);
+    return () => clearTimeout(timeout);
+  }, [restarting]);
 
   const triggerBusy = isPending || justQueued;
 
+  // A compact fingerprint of the server-derived state. When it changes after a
+  // swap-induced disconnect, the new container has answered and the reconnect
+  // banner can clear.
+  function serverSignature(): string {
+    return [
+      latestRun?.runId ?? "",
+      latestRun?.status ?? "",
+      deployedSha ?? "",
+      isFresh ? "1" : "0",
+      quiescence?.level ?? "",
+    ].join("|");
+  }
+
+  // Enter the calm "applying / reconnecting" state after the swap severed this
+  // page's own request. Snapshot the current signature so the clear effect can
+  // detect when the swapped-in portal returns fresh data, and keep the status
+  // poll alive so the page reconnects on its own.
+  function enterRestarting() {
+    restartBaselineRef.current = serverSignature();
+    setRestarting(true);
+    setJustQueued(true);
+    router.refresh();
+  }
+
   function handleTrigger() {
     setTriggerResult(null);
+    setInFlightError(null);
     const force = override;
     startTransition(async () => {
-      const result = await triggerSelfUpgrade(force ? { force: true } : undefined);
-      setTriggerResult(result);
-      if (result.queued) setJustQueued(true);
-      router.refresh();
+      try {
+        const result = await triggerSelfUpgrade(force ? { force: true } : undefined);
+        setTriggerResult(result);
+        if (result.queued) setJustQueued(true);
+        router.refresh();
+      } catch (err) {
+        // A forced upgrade can swap the portal out from under this request
+        // before its response returns. That's the upgrade applying — hold the
+        // reconnect state instead of crashing the page; a non-swap failure
+        // (e.g. unauthorized) is surfaced inline.
+        if (isExpectedDuringSwap(err)) {
+          enterRestarting();
+        } else {
+          setTriggerResult({
+            queued: false,
+            reason: err instanceof Error ? err.message : "trigger failed",
+          });
+        }
+      }
     });
   }
 
@@ -310,10 +415,21 @@ export default function SelfUpgradeClient({
     if (!runId) return;
     setInFlightError(null);
     startTransition(async () => {
-      const r = await forceActiveRun(runId);
-      setForceConfirm(false);
-      if (!r.ok) setInFlightError(r.error ?? "Force failed");
-      router.refresh();
+      try {
+        const r = await forceActiveRun(runId);
+        setForceConfirm(false);
+        if (!r.ok) setInFlightError(r.error ?? "Force failed");
+        router.refresh();
+      } catch (err) {
+        // Forcing the swap can sever this very request the moment the
+        // coordinator proceeds — the expected outcome, not an error.
+        setForceConfirm(false);
+        if (isExpectedDuringSwap(err)) {
+          enterRestarting();
+        } else {
+          setInFlightError(err instanceof Error ? err.message : "Force failed");
+        }
+      }
     });
   }
 
@@ -324,34 +440,68 @@ export default function SelfUpgradeClient({
     if (!runId) return;
     setInFlightError(null);
     startTransition(async () => {
-      const r = await abortActiveRun(runId);
-      setAbortConfirm(false);
-      if (!r.ok) setInFlightError(r.error ?? "Abort failed");
-      router.refresh();
+      try {
+        const r = await abortActiveRun(runId);
+        setAbortConfirm(false);
+        if (!r.ok) setInFlightError(r.error ?? "Abort failed");
+        router.refresh();
+      } catch (err) {
+        setAbortConfirm(false);
+        if (isExpectedDuringSwap(err)) {
+          enterRestarting();
+        } else {
+          setInFlightError(err instanceof Error ? err.message : "Abort failed");
+        }
+      }
     });
   }
 
   function handleRollback(runId: string) {
     setRollbackResult({ status: "idle", message: "" });
     startRollbackTransition(async () => {
-      const result = await rollbackSelfUpgrade(runId, rollbackConfirmation);
-      if (result.ok) {
-        setRollbackResult({
-          status: "ok",
-          message: "Recovery point restored.",
-        });
-      } else {
-        setRollbackResult({
-          status: "error",
-          message: result.error ?? "Recovery point restore failed.",
-        });
+      try {
+        const result = await rollbackSelfUpgrade(runId, rollbackConfirmation);
+        if (result.ok) {
+          setRollbackResult({
+            status: "ok",
+            message: "Recovery point restored.",
+          });
+        } else {
+          setRollbackResult({
+            status: "error",
+            message: result.error ?? "Recovery point restore failed.",
+          });
+        }
+        router.refresh();
+      } catch (err) {
+        // A restore can restart services; if it severs this request, treat it
+        // as "applying" rather than crashing the page to the error boundary.
+        if (isExpectedDuringSwap(err)) {
+          enterRestarting();
+        } else {
+          setRollbackResult({
+            status: "error",
+            message: err instanceof Error ? err.message : "Recovery point restore failed.",
+          });
+        }
       }
-      router.refresh();
     });
   }
 
   return (
     <div className="space-y-4">
+      {restarting && (
+        <div
+          className="p-3 rounded-lg bg-[var(--dpf-info)]/10 border border-[var(--dpf-info)]/30 text-sm text-[var(--dpf-text)]"
+          role="status"
+          aria-live="polite"
+          data-upgrade-restarting="true"
+        >
+          <span className="font-medium">Applying the upgrade…</span> the portal is
+          restarting to finish the swap. This page reconnects automatically — no
+          need to refresh.
+        </div>
+      )}
       {jobEngine?.status === "degraded" && (
         <div
           className="p-3 rounded-lg bg-[var(--dpf-warning)]/15 border border-[var(--dpf-warning)]/40 text-sm"


### PR DESCRIPTION
## Symptom

Forcing a self-upgrade from `/ops/self-upgrade` painted the global crash screen:

> **Something went wrong** — Page: `/ops/self-upgrade` — Error: *An unexpected response was received from the server.*

…even though the upgrade had actually **succeeded**.

## Root cause

That message is a Next.js framework error (**code E394**, from `server-action-reducer.js`) thrown client-side when a Server Action's HTTP response isn't a valid RSC payload (`content-type: text/x-component`).

A **forced** upgrade intentionally bypasses the quiescence drain and swaps the portal container *immediately* — including out from under the operator's own in-flight request that triggered it. When the swap lands, the `triggerSelfUpgrade` / `forceActiveRun` response (or the follow-up poll) is severed and comes back as a non-RSC transport failure. The handlers `await`ed the actions inside `startTransition` with **no `try/catch`**, so the rejection escalated to the `(shell)/error.tsx` boundary.

Net effect: a *successful* forced upgrade looked like a fatal crash to the operator who triggered it.

### Evidence (live install)

Pulled from the running portal + Loki — no server-side exception anywhere:

| time (UTC) | event |
|---|---|
| 04:51 | quiescence drain in progress |
| 04:52 | pre-upgrade backup started |
| 04:55 | swap coordinator reached `ready-to-swap` |
| 04:56 | portal **container replaced** + rebooted, migrations clean, run `SUR-A480EC06 -> succeeded` (deployed `1d4c9e36`) |

The crash was purely client-side handling of the expected mid-swap disconnect.

## Fix

A forced swap killing the in-flight request is the **expected** success path of "force", not an error. `SelfUpgradeClient` now:

- Detects the expected mid-swap disconnect (`isExpectedDuringSwap` — matches Next's E394 code + transport/network error messages) in the **trigger / force / abort / rollback** handlers.
- Holds a calm **"Applying the upgrade… reconnecting"** banner instead of crashing; the status poll stays alive and the page reconnects on its own.
- Clears the banner deterministically once the swapped-in container returns **fresh data** (tracked via a server-state signature snapshot — not the instantaneous in-flight flag, which would flash on an idle force), with a 2-minute safety timeout.
- Still surfaces genuine (non-swap) action errors inline rather than as a full-page crash.

No server-side change — the upgrade pipeline already works; this is client resilience to a disconnect the force path is designed to cause.

## Testing

- New `SelfUpgradeClient.swap-resilience.test.tsx` (RTL/jsdom): drives the click, rejects the action with a real-shaped E394, and asserts the reconnect banner appears (no crash), clears on fresh data, and that genuine errors still show inline + the happy path is unaffected.
- Unit coverage for `isExpectedDuringSwap` (E394 by code, by message, network failures, negatives).
- Full ops suite green locally: **101 passed** (incl. the existing `SelfUpgradeClient` + self-upgrade page tests). Changed files typecheck clean (local hook typecheck skipped via `DPF_SKIP_TYPECHECK=1` due to a stale generated Prisma client in the worktree; CI regenerates and runs the real typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)