### PR TITLE
fix(coordination): close nonprod-lease claim TOCTOU with a single-active DB invariant

### DIFF
--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -96,8 +96,69 @@ describe("non-production environment leases", () => {
       data: {
         status: "released",
         releasedAt: new Date("2026-05-26T19:00:00.000Z"),
+        activeKey: null,
       },
     });
+  });
+
+  it("stamps activeKey = environmentKey so the DB enforces one active lease per env", async () => {
+    const mockDb = db();
+    await claimNonprodEnvironmentLease({
+      db: mockDb as never,
+      environmentKey: "local-integration-ci",
+      ownerProvider: "claude",
+      ownerSessionId: "s1",
+      purpose: "ci",
+      url: "http://localhost:3001",
+      ports: [3001],
+      expiresAt: new Date("2026-05-26T18:00:00.000Z"),
+    });
+    const data = mockDb.nonProductionEnvironmentLease.create.mock.calls[0][0].data;
+    expect(data.activeKey).toBe("local-integration-ci");
+  });
+
+  it("frees a lapsed-but-active lease for the key before claiming", async () => {
+    const mockDb = db();
+    const at = new Date("2026-06-15T12:00:00.000Z");
+    await claimNonprodEnvironmentLease({
+      db: mockDb as never,
+      environmentKey: "active-candidate",
+      ownerProvider: "codex",
+      ownerSessionId: "s1",
+      purpose: "claim",
+      url: "http://localhost:3001",
+      ports: [3001],
+      expiresAt: new Date(at.getTime() + 60_000),
+      now: at,
+    });
+    expect(mockDb.nonProductionEnvironmentLease.updateMany).toHaveBeenCalledWith({
+      where: { environmentKey: "active-candidate", status: "active", expiresAt: { lte: at } },
+      data: { status: "expired", activeKey: null, releasedAt: at },
+    });
+  });
+
+  it("returns conflict (not a throw) when the unique index rejects a racing claim", async () => {
+    const mockDb = db();
+    // Fast-path findFirst sees no active lease; the create loses the race and the
+    // unique index throws P2002; the recovery findFirst returns the winner.
+    mockDb.nonProductionEnvironmentLease.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ leaseId: "NPEL-WINNER" });
+    mockDb.nonProductionEnvironmentLease.create.mockRejectedValue({ code: "P2002" });
+
+    const result = await claimNonprodEnvironmentLease({
+      db: mockDb as never,
+      environmentKey: "active-candidate",
+      ownerProvider: "claude",
+      ownerSessionId: "s2",
+      purpose: "racing claim",
+      url: "http://localhost:3001",
+      ports: [3001],
+      expiresAt: new Date("2026-05-26T18:00:00.000Z"),
+    });
+
+    expect(result.status).toBe("conflict");
+    expect(result).toMatchObject({ active: { leaseId: "NPEL-WINNER" } });
   });
 });
 
@@ -195,7 +256,7 @@ describe("nonprod lease anti-monopolization (BI-4043A64B)", () => {
     expect(r).toEqual({ reaped: 3 });
     expect(mockDb.nonProductionEnvironmentLease.updateMany).toHaveBeenCalledWith({
       where: { status: "active", expiresAt: { lt: now }, releasedAt: null },
-      data: { status: "expired", releasedAt: now },
+      data: { status: "expired", releasedAt: now, activeKey: null },
     });
   });
 });

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -35,6 +35,19 @@ function createLeaseId() {
   return `NPEL-${randomUUID().replace(/-/g, "").slice(0, 10).toUpperCase()}`;
 }
 
+/**
+ * Prisma throws PrismaClientKnownRequestError { code: "P2002" } when a unique
+ * index rejects a write. Duck-typed so this module stays decoupled from the
+ * client import and the check is trivially mockable in unit tests.
+ */
+function isUniqueConstraintViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === "P2002"
+  );
+}
+
 export async function listActiveNonprodEnvironmentLeases(input: {
   db?: LeaseDb;
   now?: Date;
@@ -67,34 +80,71 @@ export async function claimNonprodEnvironmentLease(input: {
   now?: Date;
 }) {
   const db = input.db ?? prisma;
+  const now = input.now ?? new Date();
+
+  // Fast path: an already-active, unexpired lease for this key is a conflict.
   const active = await db.nonProductionEnvironmentLease.findFirst({
     where: {
       environmentKey: input.environmentKey,
       status: "active",
-      expiresAt: { gt: input.now ?? new Date() },
+      expiresAt: { gt: now },
     },
   });
   if (active) return { status: "conflict" as const, active };
 
-  const lease = await db.nonProductionEnvironmentLease.create({
-    data: {
-      leaseId: createLeaseId(),
+  // Self-heal: free any lapsed-but-still-"active" row for this key so its
+  // single-active slot (activeKey) is released before we claim. Without this,
+  // the unique index would block a legitimate claim on an env whose previous
+  // holder already expired but has not been reaped yet.
+  await db.nonProductionEnvironmentLease.updateMany({
+    where: {
       environmentKey: input.environmentKey,
-      ownerProvider: input.ownerProvider,
-      ownerSessionId: input.ownerSessionId,
-      purpose: input.purpose,
-      url: input.url,
-      ports: input.ports,
-      // Cap the hold window (BI-4043A64B); longer holds require heartbeat renew.
-      expiresAt: clampLeaseExpiry(input.now ?? new Date(), input.expiresAt),
-      worktreePath: input.worktreePath,
-      branchName: input.branchName,
-      buildId: input.buildId,
-      taskRunId: input.taskRunId,
-      cleanupCommand: input.cleanupCommand,
+      status: "active",
+      expiresAt: { lte: now },
     },
+    data: { status: "expired", activeKey: null, releasedAt: now },
   });
-  return { status: "claimed" as const, lease };
+
+  // The create is the atomic gate: a UNIQUE index on `activeKey` (= the env key
+  // while active) means only ONE concurrent claim can succeed. The findFirst
+  // above is a fast path, not the guarantee — two sessions can both pass it,
+  // but only one create wins. The loser catches P2002 and reports the conflict
+  // instead of a 500. This closes the claim TOCTOU on the single shared nonprod
+  // instance (two sessions both believing they own :3001 / active-candidate).
+  try {
+    const lease = await db.nonProductionEnvironmentLease.create({
+      data: {
+        leaseId: createLeaseId(),
+        environmentKey: input.environmentKey,
+        activeKey: input.environmentKey,
+        ownerProvider: input.ownerProvider,
+        ownerSessionId: input.ownerSessionId,
+        purpose: input.purpose,
+        url: input.url,
+        ports: input.ports,
+        // Cap the hold window (BI-4043A64B); longer holds require heartbeat renew.
+        expiresAt: clampLeaseExpiry(now, input.expiresAt),
+        worktreePath: input.worktreePath,
+        branchName: input.branchName,
+        buildId: input.buildId,
+        taskRunId: input.taskRunId,
+        cleanupCommand: input.cleanupCommand,
+      },
+    });
+    return { status: "claimed" as const, lease };
+  } catch (err) {
+    if (isUniqueConstraintViolation(err)) {
+      const winner = await db.nonProductionEnvironmentLease.findFirst({
+        where: {
+          environmentKey: input.environmentKey,
+          status: "active",
+          expiresAt: { gt: now },
+        },
+      });
+      if (winner) return { status: "conflict" as const, active: winner };
+    }
+    throw err;
+  }
 }
 
 export async function releaseNonprodEnvironmentLease(input: {
@@ -108,6 +158,8 @@ export async function releaseNonprodEnvironmentLease(input: {
     data: {
       status: "released",
       releasedAt: input.now ?? new Date(),
+      // Free the single-active slot so a new claim for this env can succeed.
+      activeKey: null,
     },
   });
 }
@@ -161,7 +213,8 @@ export async function reapExpiredNonprodEnvironmentLeases(input: {
   const now = input.now ?? new Date();
   const res = await db.nonProductionEnvironmentLease.updateMany({
     where: { status: "active", expiresAt: { lt: now }, releasedAt: null },
-    data: { status: "expired", releasedAt: now },
+    // Free the single-active slot (activeKey) as part of reaping.
+    data: { status: "expired", releasedAt: now, activeKey: null },
   });
   return { reaped: res.count };
 }

--- a/packages/db/prisma/migrations/20260619120000_add_nonprod_lease_active_sentinel/migration.sql
+++ b/packages/db/prisma/migrations/20260619120000_add_nonprod_lease_active_sentinel/migration.sql
@@ -1,0 +1,29 @@
+-- De-conflict the single shared nonprod instance: enforce "at most one ACTIVE
+-- lease per environmentKey" at the database level. `activeKey` mirrors
+-- environmentKey while the lease is active and is NULL once released/expired;
+-- a UNIQUE index on it lets Postgres reject a second active claim atomically
+-- (multiple NULLs are allowed for history rows), closing the claim TOCTOU race
+-- where two sessions could both win :3001 / active-candidate.
+
+-- AlterTable
+ALTER TABLE "NonProductionEnvironmentLease" ADD COLUMN "activeKey" TEXT;
+
+-- Backfill (inline per AGENTS.md): collapse any pre-existing duplicate active
+-- leases (keep the most recent per environmentKey) so the unique index can be
+-- built, then stamp activeKey on the surviving active rows.
+UPDATE "NonProductionEnvironmentLease"
+SET "status" = 'expired', "releasedAt" = now()
+WHERE "status" = 'active'
+  AND "id" NOT IN (
+    SELECT DISTINCT ON ("environmentKey") "id"
+    FROM "NonProductionEnvironmentLease"
+    WHERE "status" = 'active'
+    ORDER BY "environmentKey", "createdAt" DESC
+  );
+
+UPDATE "NonProductionEnvironmentLease"
+SET "activeKey" = "environmentKey"
+WHERE "status" = 'active';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NonProductionEnvironmentLease_activeKey_key" ON "NonProductionEnvironmentLease"("activeKey");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4582,6 +4582,11 @@ model NonProductionEnvironmentLease {
   id               String    @id @default(cuid())
   leaseId          String    @unique
   environmentKey   String
+  // Mirrors environmentKey while the lease is active; NULL once released/expired.
+  // The @@unique below makes "at most one active lease per environmentKey" a DB
+  // invariant (Postgres allows many NULLs), closing the claim TOCTOU race where
+  // two sessions could otherwise both win the single shared nonprod slot.
+  activeKey        String?
   status           String    @default("active")
   ownerProvider    String
   ownerSessionId   String
@@ -4599,6 +4604,7 @@ model NonProductionEnvironmentLease {
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
 
+  @@unique([activeKey])
   @@index([environmentKey, status])
   @@index([ownerProvider, ownerSessionId])
   @@index([buildId, createdAt])


### PR DESCRIPTION
## Problem

The shared nonproduction environment lease (`:3001` / `active-candidate` / `local-integration-ci`) was claimed with `findFirst(active)` then `create()` and **no atomicity** (`environment-lease.ts:70`). Two concurrent sessions could both observe "no active lease" and both `create` one — two holders believing they own the single shared instance. The `@@index([environmentKey, status])` was non-unique, so the DB did not prevent it.

Surfaced by the 2026-06-19 architecture review (the "who's working on this answered N ways" / unguarded-shared-resource class, also called out in the Reduction Gear spec's divergence signals).

## Fix — make "one active lease per env key" a database invariant

- New nullable **`activeKey`** column mirrors `environmentKey` while the lease is active and is `NULL` once released/expired. `@@unique([activeKey])` enforces the invariant (Postgres allows many NULLs, so history rows never collide).
- `claim()` now treats `create()` as the **atomic gate**: it self-heals a lapsed-but-active slot, then catches Prisma `P2002` from a racing claim and returns the winner as a **conflict** instead of throwing.
- `release()` / `reap()` null `activeKey` to free the slot.
- Migration collapses any pre-existing duplicate active leases before building the unique index (inline backfill).

## Verification

- **Unit tests: 14 pass** on the worktree-junction vitest runner — 3 new (activeKey stamping, lapsed-slot self-heal, `P2002`→conflict race recovery). nonprod + runtime-target-janitor suites green (20/20).
- **Production build + migration apply + full typecheck run in CI** — this worktree is source-only and cannot host the runtime-bound gates.
- Schema-regression guard: additive only (no removed fields), passes.

## Process-Spine-Decision

Targeted concurrency bugfix extending the existing nonprod-lease module (BI-4043A64B lineage); rationale captured in the commit, schema, and migration comments. No separate design doc — this implements an already-reviewed finding. The durable architecture-review artifact is tracked separately under the proposed **EP-ARCH-CONVERGENCE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)