### PR TITLE
fix(build-studio): stop non-UI builds stranding at review-phase UX verification (BI-2F10D6D3)

### DIFF
--- a/apps/web/lib/build/ui-surface.test.ts
+++ b/apps/web/lib/build/ui-surface.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHasUiSurface,
+  isUiSurfaceFile,
+  shouldRunBrowserUxVerification,
+} from "./ui-surface";
+
+describe("isUiSurfaceFile", () => {
+  it("treats React components and Next pages/layouts as UI surfaces", () => {
+    expect(isUiSurfaceFile("apps/web/app/(shell)/build/page.tsx")).toBe(true);
+    expect(isUiSurfaceFile("apps/web/app/(shell)/layout.tsx")).toBe(true);
+    expect(isUiSurfaceFile("apps/web/components/build/ReviewPanel.tsx")).toBe(true);
+    expect(isUiSurfaceFile("apps/web/components/Thing.jsx")).toBe(true);
+  });
+
+  it("does not treat libraries, server code, route handlers, docs, or schema as UI", () => {
+    expect(isUiSurfaceFile("apps/web/lib/utils/string-helpers.ts")).toBe(false);
+    expect(isUiSurfaceFile("apps/web/lib/utils/string-helpers.test.ts")).toBe(false);
+    expect(isUiSurfaceFile("apps/web/app/api/decisions/ledger/route.ts")).toBe(false);
+    expect(isUiSurfaceFile("packages/db/prisma/schema.prisma")).toBe(false);
+    expect(isUiSurfaceFile("UTILITY_ANALYSIS.md")).toBe(false);
+    expect(isUiSurfaceFile("scripts/seed.ts")).toBe(false);
+  });
+
+  it("ignores empty/whitespace paths", () => {
+    expect(isUiSurfaceFile("")).toBe(false);
+    expect(isUiSurfaceFile("   ")).toBe(false);
+  });
+});
+
+describe("buildHasUiSurface", () => {
+  it("is true when any changed file is a UI surface", () => {
+    expect(
+      buildHasUiSurface([
+        "apps/web/lib/data.ts",
+        "apps/web/components/build/ReviewPanel.tsx",
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false for a pure library/backend change set (the truncateMiddle strand)", () => {
+    expect(
+      buildHasUiSurface([
+        "UTILITY_ANALYSIS.md",
+        "apps/web/lib/utils/string-helpers.test.ts",
+        "apps/web/lib/utils/string-helpers.ts",
+      ]),
+    ).toBe(false);
+  });
+
+  it("is false for an empty change set", () => {
+    expect(buildHasUiSurface([])).toBe(false);
+  });
+});
+
+describe("shouldRunBrowserUxVerification", () => {
+  it("skips when there are no acceptance criteria", () => {
+    expect(
+      shouldRunBrowserUxVerification({
+        testCaseCount: 0,
+        changedFiles: ["apps/web/app/(shell)/build/page.tsx"],
+      }),
+    ).toBe(false);
+  });
+
+  it("skips a pure non-UI build even when it has acceptance criteria", () => {
+    // This is the FB-FD850A2C strand: a string helper with 5 code-level ACs and
+    // no page to drive must NOT run browser-use (which returns a vacuous 0/1).
+    expect(
+      shouldRunBrowserUxVerification({
+        testCaseCount: 5,
+        changedFiles: [
+          "apps/web/lib/utils/string-helpers.ts",
+          "apps/web/lib/utils/string-helpers.test.ts",
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("runs when a UI surface changed and there are acceptance criteria", () => {
+    expect(
+      shouldRunBrowserUxVerification({
+        testCaseCount: 3,
+        changedFiles: ["apps/web/app/(shell)/build/page.tsx"],
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves legacy behavior (runs) when changed files are unknown", () => {
+    // A briefly-unavailable diff projection must not silently disable UX
+    // verification fleet-wide — with no changed-file signal we still run it.
+    expect(
+      shouldRunBrowserUxVerification({ testCaseCount: 2, changedFiles: [] }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/build/ui-surface.ts
+++ b/apps/web/lib/build/ui-surface.ts
@@ -1,0 +1,76 @@
+// apps/web/lib/build/ui-surface.ts
+//
+// Build Studio review-phase helper: decide whether a build introduced a
+// user-facing surface that browser-driven UX verification can actually exercise.
+//
+// Why this exists:
+//   build-review-verification.ts verifies a build by navigating its sandbox
+//   preview with browser-use and checking the build's acceptance criteria. That
+//   only makes sense when the build changed a RENDERED UI surface (a page,
+//   layout, or React component). For a pure library / backend / doc change — a
+//   string helper, a server util, an API route handler, a migration — the
+//   acceptance criteria are code-level assertions ("truncateMiddle('abc',1)
+//   returns '…'") with no page to drive, so browser-use returns a vacuous 0/1
+//   failure. Combined with the auto-ship-only-on-"complete" rule, that stranded
+//   non-UI builds in `review` forever (the FB-FD850A2C strand: a ~50-line string
+//   helper looped review verification on every portal boot for days). Detect the
+//   no-UI case up front and SKIP browser UX verification instead of failing it,
+//   consistent with the ratified "UX verification is advisory" gate policy
+//   (build-process-matrix.ts `uxVerification-not-blocking`).
+
+/**
+ * True when a single changed file is a rendered UI surface that browser UX
+ * verification can drive — a React component / Next.js page or layout
+ * (`.tsx` / `.jsx`).
+ *
+ * Pure `.ts` (libraries, server actions, API route handlers), `.md`, `.sql`,
+ * `.prisma`, `.json`, and scripts are NOT browser-verifiable via acceptance
+ * criteria.
+ */
+export function isUiSurfaceFile(file: string): boolean {
+  const path = file.trim();
+  if (!path) return false;
+  return /\.(tsx|jsx)$/i.test(path);
+}
+
+/**
+ * True when at least one changed file is a browser-drivable UI surface.
+ *
+ * An empty change set returns `false` — there is nothing to drive — but callers
+ * deciding whether to SKIP a browser run should treat "no changed files known"
+ * as "surface unknown" and preserve legacy behavior rather than skipping (see
+ * {@link shouldRunBrowserUxVerification}). This function answers only the
+ * positive question "did this build touch UI?".
+ */
+export function buildHasUiSurface(changedFiles: readonly string[]): boolean {
+  return changedFiles.some((file) => isUiSurfaceFile(file));
+}
+
+/**
+ * Decide whether the review phase should run browser-use UX verification.
+ *
+ * - No acceptance criteria  → false (nothing to assert; matches the existing
+ *   `testCases.length === 0` skip path).
+ * - Changed files unknown   → true. We cannot prove the build is non-UI, so we
+ *   preserve the legacy behavior (run the check) rather than silently disabling
+ *   UX verification fleet-wide if a diff projection is briefly unavailable.
+ * - Changed files known and contain a UI surface → true.
+ * - Changed files known and contain NO UI surface → false (skip: the build is a
+ *   pure library / backend / doc change with no page to drive).
+ *
+ * @example
+ * shouldRunBrowserUxVerification({ testCaseCount: 5, changedFiles: ["apps/web/lib/utils/string-helpers.ts"] })
+ * // → false  (library-only build: skip browser UX verification, advance to ship)
+ *
+ * @example
+ * shouldRunBrowserUxVerification({ testCaseCount: 3, changedFiles: ["apps/web/app/(shell)/build/page.tsx"] })
+ * // → true   (page changed: drive the preview and check the acceptance criteria)
+ */
+export function shouldRunBrowserUxVerification(args: {
+  testCaseCount: number;
+  changedFiles: readonly string[];
+}): boolean {
+  if (args.testCaseCount <= 0) return false;
+  if (args.changedFiles.length === 0) return true;
+  return buildHasUiSurface(args.changedFiles);
+}

--- a/apps/web/lib/queue/functions/build-review-verification.test.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.test.ts
@@ -60,6 +60,27 @@ describe("autoDispatchShipForCompletedVerification — actor resolution", () => 
     expect(state.ownerResolveCount).toBe(0);
   });
 
+  it("forwards a 'skipped' verification status so non-UI builds ship instead of stranding", async () => {
+    // The FB-FD850A2C strand: a non-UI build skips browser UX verification and
+    // must auto-dispatch ship with verificationStatus="skipped" (not "complete"),
+    // mirroring the complete path so it advances to ship rather than looping.
+    state.build = { createdById: "usr_creator" };
+
+    await autoDispatchShipForCompletedVerification("build-skip", "skipped");
+
+    expect(state.dispatchCalls).toHaveLength(1);
+    expect(state.dispatchCalls[0]?.verificationStatus).toBe("skipped");
+    expect(state.dispatchCalls[0]?.userId).toBe("usr_creator");
+  });
+
+  it("defaults the verification status to 'complete' when omitted", async () => {
+    state.build = { createdById: "usr_creator" };
+
+    await autoDispatchShipForCompletedVerification("build-default");
+
+    expect(state.dispatchCalls[0]?.verificationStatus).toBe("complete");
+  });
+
   it("resolves the install owner (never a 'system' sentinel) when createdById is null", async () => {
     // Regression guard for the latent FK violation: a null createdById used to
     // fall back to userId:"system", which has no matching User row and fails

--- a/apps/web/lib/queue/functions/build-review-verification.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.ts
@@ -6,7 +6,12 @@
  * coworker-driven UX verification pipeline end to end:
  *
  *   1. Load build + brief
- *   2. If no acceptance criteria, mark `uxVerificationStatus = "skipped"`
+ *   2. If there are no acceptance criteria, OR the build changed no UI surface
+ *      a browser can drive (pure library/backend/doc change — see
+ *      `shouldRunBrowserUxVerification`), mark `uxVerificationStatus = "skipped"`
+ *      and auto-dispatch ship. UX verification is advisory (non-blocking) per
+ *      the ratified gate policy, so a build with nothing browser-verifiable must
+ *      advance to ship rather than strand in review on a vacuous 0/1 failure.
  *   3. Otherwise call browser-use with `evidence_dir: build_<buildId>`
  *      so screenshots land on the shared /evidence volume
  *   4. Persist UxTestStep[] to `FeatureBuild.uxTestResults` AND set
@@ -21,6 +26,7 @@
 
 import { inngest } from "../inngest-client";
 import { buildPipelineConcurrency } from "../admission";
+import { shouldRunBrowserUxVerification } from "@/lib/build/ui-surface";
 
 export const buildReviewVerification = inngest.createFunction(
   {
@@ -59,6 +65,25 @@ export const buildReviewVerification = inngest.createFunction(
         ? deriveFixUxTestCases(brief?.fixContext)
         : brief?.acceptanceCriteria ?? [];
 
+    // Resolve the build's changed files so we can tell whether there is a
+    // RENDERED UI surface for browser-use to drive. A pure library/backend/doc
+    // build (no .tsx/.jsx) has only code-level acceptance criteria a browser
+    // cannot assert — running browser-use on it returns a vacuous 0/1 failure
+    // that, combined with auto-ship-only-on-"complete", stranded the build in
+    // review forever. Prefer the captured diff; fall back to the plan's declared
+    // files when the diff projection is not yet populated at review time.
+    const changedFiles = await step.run("resolve-changed-files", async () => {
+      const { getSandboxStateForBuild } = await import("@/lib/build/sandbox-state");
+      const sandboxState = await getSandboxStateForBuild(buildId);
+      const diffFiles = sandboxState?.sourceDiffstat.map((entry) => entry.path) ?? [];
+      if (diffFiles.length > 0) return diffFiles;
+      return sandboxState?.expectedPlanFiles.map((file) => file.path) ?? [];
+    });
+    const runBrowserUse = shouldRunBrowserUxVerification({
+      testCaseCount: testCases.length,
+      changedFiles,
+    });
+
     await step.run("start-verification", async () => {
       const { prisma } = await import("@dpf/db");
       await prisma.featureBuild.update({
@@ -75,13 +100,31 @@ export const buildReviewVerification = inngest.createFunction(
       }
     });
 
-    if (testCases.length === 0) {
+    if (!runBrowserUse) {
+      // Either there are no acceptance criteria to assert, or the build changed
+      // no UI surface a browser can drive. Mark UX verification "skipped"
+      // (advisory, non-blocking per the ratified gate policy) and proceed to
+      // ship rather than stranding in review. The "Ship to GitHub" step remains
+      // a human gate downstream — auto-ship only extracts the diff and advances
+      // the phase to `ship`.
+      const skipReason: "no-acceptance-criteria" | "no-ui-surface" =
+        testCases.length === 0 ? "no-acceptance-criteria" : "no-ui-surface";
       await step.run("mark-skipped", async () => {
         const { prisma } = await import("@dpf/db");
         await prisma.featureBuild.update({
           where: { buildId },
           data: { uxVerificationStatus: "skipped" },
         });
+        await prisma.buildActivity.create({
+          data: {
+            buildId,
+            tool: "review-verification",
+            summary:
+              skipReason === "no-ui-surface"
+                ? `UX verification skipped: build changed no UI surface (${changedFiles.length} file(s), none .tsx/.jsx). Browser checks are not applicable to a library/backend change; advancing to ship.`
+                : "UX verification skipped: no acceptance criteria to verify; advancing to ship.",
+          },
+        }).catch(() => {});
         if (build.threadId) {
           const { agentEventBus } = await import("@/lib/agent-event-bus");
           agentEventBus.emit(build.threadId, {
@@ -93,7 +136,14 @@ export const buildReviewVerification = inngest.createFunction(
           });
         }
       });
-      return { status: "skipped", testCount: 0 };
+      // Auto-dispatch ship for the skipped (non-blocking) verification — mirrors
+      // the "complete" path below so non-UI / no-AC builds are not stranded in
+      // review. dispatchShipForVerifiedBuild only extracts the diff and advances
+      // to the ship phase; pushing to GitHub stays a human gate.
+      await step.run("auto-dispatch-ship", () =>
+        autoDispatchShipForCompletedVerification(buildId, "skipped"),
+      );
+      return { status: "skipped", testCount: testCases.length, reason: skipReason };
     }
 
     type UxTestStep = {
@@ -214,6 +264,7 @@ export const buildReviewVerification = inngest.createFunction(
  */
 export async function autoDispatchShipForCompletedVerification(
   buildId: string,
+  verificationStatus: "complete" | "skipped" = "complete",
 ): Promise<{ shipOutcome: string }> {
   const { prisma: db } = await import("@dpf/db");
   const b = await db.featureBuild.findUnique({
@@ -226,7 +277,7 @@ export async function autoDispatchShipForCompletedVerification(
   const outcome = await dispatchShipForVerifiedBuild({
     buildId,
     userId: actorUserId,
-    verificationStatus: "complete",
+    verificationStatus,
   });
   return { shipOutcome: outcome.kind };
 }

--- a/docs/superpowers/plans/2026-06-19-build-studio-non-ui-review-verification-strand.md
+++ b/docs/superpowers/plans/2026-06-19-build-studio-non-ui-review-verification-strand.md
@@ -1,0 +1,47 @@
+# Build Studio: non-UI builds strand at review-phase UX verification
+
+- **Date:** 2026-06-19
+- **Status:** implementing
+- **Backlog item:** BI-2F10D6D3
+- **Epic:** EP-BUILD-STUDIO
+- **Related:** BI-4890FDC3 (out-of-scope test scoping — already landed via `scopeVerificationOutputForGate`), BI-17377D05 / BI-9257CF19 (stranded-build resume), the ratified 2026-06-07 "UX verification is advisory" gate decision (`build-process-matrix.ts` `uxVerification-not-blocking`).
+
+## Problem
+
+Every in-flight Build Studio build was stranding before delivery. Live evidence (2026-06-19): of 12 builds, **0 had delivered**; FB-FD850A2C ("Add truncateMiddle string helper with unit tests") looped `review-verification → "UX verification failed: 0/1 passed"` on **every portal boot since 2026-06-15**.
+
+Root cause — a contradiction between the gate policy and the auto-ship trigger:
+
+1. `build-review-verification.ts` runs **browser-use UX tests** by navigating the sandbox preview and checking the build's **acceptance criteria**. That only works when the build changed a **rendered UI surface** (a page, layout, or React component).
+2. For a pure **library / backend / doc** build (e.g. `truncateMiddle`, a string helper), the acceptance criteria are **code-level assertions** ("`truncateMiddle('abc',1)` returns `'…'`") with **no page to drive**. browser-use returns a vacuous `0/1` failure.
+3. The review→ship gate already treats UX verification as **advisory / non-blocking** (`uxVerification-not-blocking`, ratified 2026-06-07) — only the transient `running` state defers.
+4. **But** the auto-ship trigger in `build-review-verification.ts` only fired on `finalStatus === "complete"`. A `failed` (false negative) or `skipped` verification never dispatched ship, so the build sat in `review`, and `resumeStrandedBuildsOnBoot` just re-queued the same failing browser-use run forever.
+
+The unit-test gate is **not** the blocker: `checkRequirement("verification-typecheck-passed")` gates build→review on **typecheck only**, and `scopeVerificationOutputForGate` already neutralizes out-of-scope test noise (BI-4890FDC3). The 88 "failed" tests shown in the panel are cosmetic global-health signal.
+
+## Fix
+
+Two coordinated, surgical changes — keep the browser UX check where it is meaningful, stop stranding where it is not.
+
+1. **Skip browser UX verification for builds with no UI surface.** New helper `apps/web/lib/build/ui-surface.ts`:
+   - `buildHasUiSurface(changedFiles)` — true when any changed file is `.tsx`/`.jsx`.
+   - `shouldRunBrowserUxVerification({ testCaseCount, changedFiles })` — false when there are no acceptance criteria **or** the (known, non-empty) change set has no UI surface; conservatively true when the change set is unknown (a briefly-unavailable diff projection must not disable UX verification fleet-wide).
+   - Changed files are resolved from the build's captured diff (`getSandboxStateForBuild` → `sourceDiffstat`), falling back to the plan's declared files (`expectedPlanFiles`) when the diff isn't populated yet at review time. This is branch-scoped, so it is correct despite shared-sandbox branch contention.
+
+2. **Auto-dispatch ship on `skipped`, not only `complete`.** When UX verification is skipped (no AC or no UI surface), `build-review-verification.ts` now marks `uxVerificationStatus = "skipped"`, logs a clear `BuildActivity`, and calls `autoDispatchShipForCompletedVerification(buildId, "skipped")`. `dispatchShipForVerifiedBuild` already accepts `"skipped"`. This mirrors the `complete` path so non-UI builds advance to the `ship` phase instead of looping.
+
+`failed` (a genuine UI build whose UX check failed) is intentionally left non-auto-shipping — the operator inspects a real UI regression. Only the **false** failure (non-UI build) is converted to `skipped` and advanced.
+
+**Safety:** auto-ship only runs `deploy_feature` (extract diff, impact analysis, advance phase to `ship`). Pushing to GitHub remains the human "Ship to GitHub" gate, so no outward action is automated by this change.
+
+## Verification
+
+- Unit: `apps/web/lib/build/ui-surface.test.ts` (predicate matrix incl. the truncateMiddle change set) and `build-review-verification.test.ts` (auto-ship forwards `"skipped"`, defaults to `"complete"`).
+- Typecheck: `pnpm --filter web typecheck`.
+- Functional: on the live install, the stranded library builds (FB-FD850A2C truncateMiddle, FB-69231490 classifySemanticId, etc.) reach `ship` (diff extracted, awaiting "Ship to GitHub") after the next review-verification run, instead of looping `0/1`.
+
+## Out of scope (follow-ups)
+
+- Local endpoint throughput / model-swap thrash (gemma4 ↔ qwen3-coder) causing 502s on routed phases — separate config/infra work.
+- Quality of the browser-use agent on genuine UI builds (BI-4BD81F3B).
+- Shared-sandbox branch contention across concurrent builds.


### PR DESCRIPTION
## Problem

Driving the re-architected Build Studio on the live install (2026-06-19) surfaced that **0 of 12 in-flight builds had delivered**. `FB-FD850A2C` ("Add truncateMiddle string helper with unit tests") had looped `review-verification → "UX verification failed: 0/1 passed"` on **every portal boot since 2026-06-15**.

Root cause — a contradiction between the gate policy and the auto-ship trigger:

- The review phase runs **browser-use UX tests** against the build's **acceptance criteria**. For a pure **library/backend/doc** build (no `.tsx`/`.jsx` surface), the ACs are **code-level assertions** (`truncateMiddle('abc',1)` returns `'…'`) with no page to drive, so browser-use returns a vacuous `0/1`.
- The review→ship gate already treats UX verification as **advisory / non-blocking** (`build-process-matrix.ts` `uxVerification-not-blocking`, ratified 2026-06-07) — only the transient `running` state defers.
- **But** the auto-ship trigger in `build-review-verification.ts` fired only on `finalStatus === "complete"`. A `failed` (false negative) or `skipped` verification never dispatched ship, so the build sat in `review` and `resumeStrandedBuildsOnBoot` re-queued the same failing run forever.

The unit-test gate is **not** the blocker: `verification-typecheck-passed` keys on typecheck only, and `scopeVerificationOutputForGate` already neutralizes out-of-scope test noise (BI-4890FDC3). The 88 "failed" tests in the panel are cosmetic global-health signal.

## Fix

Two coordinated, surgical changes — keep browser UX verification where it's meaningful, stop stranding where it isn't:

1. **`apps/web/lib/build/ui-surface.ts` (new)** — `shouldRunBrowserUxVerification({ testCaseCount, changedFiles })` returns false when there are no ACs **or** the (known, non-empty) change set has no UI surface; conservatively **true** when the change set is unknown (a briefly-unavailable diff projection must not disable UX verification fleet-wide). Changed files come from the captured diff (`getSandboxStateForBuild`) with plan-file fallback — branch-scoped, so correct despite shared-sandbox branch contention.
2. **`build-review-verification.ts`** — non-UI / no-AC builds are marked `uxVerificationStatus = "skipped"` (with a clear `BuildActivity`) and **auto-dispatch ship(`"skipped"`)**, mirroring the `complete` path. A genuine UI build that *fails* UX is intentionally left non-auto-ship for operator inspection.

**Safety:** auto-ship runs only `deploy_feature` (extract diff, impact analysis, advance phase to `ship`). The **"Ship to GitHub" push stays a human gate** — no outward action is automated.

## Verification

Substrate: **source-local gates in the compile-ready worktree** (per AGENTS.md §5 for cheap checks).
- `vitest` — 16/16 pass (`ui-surface.test.ts` predicate matrix incl. the truncateMiddle change set; `build-review-verification.test.ts` auto-ship forwards `"skipped"`, defaults to `"complete"`).
- `pnpm --filter web typecheck` — exit 0, no TS errors. (Re-run clean after merging `origin/main`.)

Runtime/functional confirmation — that the stranded library builds reach `ship` after the next review-verification run — happens on the live install **after this lands via the governed self-upgrade path** (not done in this PR).

## Links
- BI-2F10D6D3 (EP-BUILD-STUDIO)
- Plan: `docs/superpowers/plans/2026-06-19-build-studio-non-ui-review-verification-strand.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)