### PR TITLE
fix(work-capsules): make scope-overlap detection path-subtree aware

### DIFF
--- a/apps/web/lib/work-capsules/work-capsule-store.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.test.ts
@@ -488,6 +488,55 @@ describe("work capsule store", () => {
       expect(activityArg.data.payload.forcedOverConflicts).toHaveLength(1);
     });
 
+    it("rejects an edit on a file beneath another capsule's directory path claim", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-MINE001", scopeClaims: [] });
+      db.workCapsule.findMany.mockResolvedValueOnce([
+        otherCapsule({
+          scopeClaims: [{ kind: "path", value: "apps/web/lib/", intent: "edit", recordedAt: "2026-06-18T00:00:00.000Z", recordedByPrincipalId: "PRN-2" }],
+        }),
+      ]);
+
+      await expect(
+        claimWorkCapsuleScope({
+          db: capsuleDb(),
+          capsuleId: "WC-MINE001",
+          claims: [{ kind: "path", value: "apps/web/lib/foo.ts", intent: "edit" }],
+          actor,
+        }),
+      ).rejects.toBeInstanceOf(ScopeOverlapError);
+      expect(db.workCapsule.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects an edit directory claim that contains another capsule's file claim", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-MINE001", scopeClaims: [] });
+      db.workCapsule.findMany.mockResolvedValueOnce([otherCapsule({})]); // holds apps/web/lib/foo.ts (edit)
+
+      await expect(
+        claimWorkCapsuleScope({
+          db: capsuleDb(),
+          capsuleId: "WC-MINE001",
+          claims: [{ kind: "path", value: "apps/web", intent: "edit" }],
+          actor,
+        }),
+      ).rejects.toBeInstanceOf(ScopeOverlapError);
+    });
+
+    it("does not treat a sibling path sharing a string prefix as overlapping", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-MINE001", scopeClaims: [] });
+      db.workCapsule.findMany.mockResolvedValueOnce([otherCapsule({})]); // holds apps/web/lib/foo.ts (edit)
+      db.workCapsule.update.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-MINE001" });
+      db.workCapsuleActivity.create.mockResolvedValueOnce({ id: "act-1" });
+
+      const result = await claimWorkCapsuleScope({
+        db: capsuleDb(),
+        capsuleId: "WC-MINE001",
+        claims: [{ kind: "path", value: "apps/web/lib/foobar.ts", intent: "edit" }],
+        actor,
+      });
+      expect(result.capsuleId).toBe("WC-MINE001");
+      expect(db.workCapsule.update).toHaveBeenCalledTimes(1);
+    });
+
     it("scopes the conflict query to active, non-terminal, unexpired, non-self capsules", async () => {
       db.workCapsule.findMany.mockResolvedValueOnce([]);
       const now = new Date("2026-06-18T12:00:00.000Z");

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -456,6 +456,26 @@ function intentsConflict(a: ScopeClaim["intent"], b: ScopeClaim["intent"]): bool
   return a === "edit" || b === "edit";
 }
 
+// Normalize a path scope value so separators and trailing slashes don't defeat
+// containment checks ("src/", "src", and "src\\x" must compare consistently).
+function normalizePathScope(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/+$/g, "");
+}
+
+// Two scope values overlap when they claim the same resource. For `path` kinds a
+// directory claim covers its whole subtree, so an ancestor/descendant pair
+// overlaps; the trailing-"/" boundary keeps siblings that merely share a string
+// prefix (src/foo.ts vs src/foobar.ts) from colliding. All other kinds are
+// exact-match scopes.
+function scopeValuesOverlap(kind: ScopeClaim["kind"], a: string, b: string): boolean {
+  if (a === b) return true;
+  if (kind !== "path") return false;
+  const na = normalizePathScope(a);
+  const nb = normalizePathScope(b);
+  if (na === nb) return true;
+  return na.startsWith(`${nb}/`) || nb.startsWith(`${na}/`);
+}
+
 /**
  * Find active claims on OTHER capsules that conflict with `claims`. "Active" =
  * not archived, not in a terminal status, and (for lease-backed executors) the
@@ -470,9 +490,7 @@ export async function detectScopeConflicts(args: {
   claims: ScopeClaimInput[];
   now?: Date;
 }): Promise<ScopeConflict[]> {
-  const incomingByKey = new Map<string, ScopeClaimInput>();
-  for (const claim of args.claims) incomingByKey.set(`${claim.kind}:${claim.value}`, claim);
-  if (incomingByKey.size === 0) return [];
+  if (args.claims.length === 0) return [];
 
   const now = args.now ?? new Date();
   const others = await args.db.workCapsule.findMany({
@@ -493,8 +511,18 @@ export async function detectScopeConflicts(args: {
   const conflicts: ScopeConflict[] = [];
   for (const other of others ?? []) {
     for (const existing of parseScopeClaims(other.scopeClaims)) {
-      const incoming = incomingByKey.get(`${existing.kind}:${existing.value}`);
-      if (incoming && intentsConflict(existing.intent, incoming.intent)) {
+      // A `path` claim covers its whole subtree, so a directory claim conflicts
+      // with a file/dir beneath it (and vice-versa) even though the kind:value
+      // strings differ — without this, `path:dir/` and `path:dir/file.ts` were
+      // treated as disjoint and two sessions could both "own" overlapping edit
+      // scope. Non-path kinds keep exact-value matching.
+      const incoming = args.claims.find(
+        (c) =>
+          c.kind === existing.kind &&
+          scopeValuesOverlap(existing.kind, existing.value, c.value) &&
+          intentsConflict(existing.intent, c.intent),
+      );
+      if (incoming) {
         conflicts.push({
           capsuleId: other.capsuleId,
           title: other.title,


### PR DESCRIPTION
## Problem

`detectScopeConflicts` matched scope claims by **exact `kind:value` string** (`work-capsule-store.ts`), so a directory claim `path:apps/web/lib` and a file claim beneath it `path:apps/web/lib/foo.ts` were treated as **disjoint**. Two sessions could both "own" overlapping edit scope on the same files — defeating the capsule lock added in #2068. Surfaced by the 2026-06-19 architecture review (unguarded-shared-resource / de-confliction class).

## Fix

For `path` kinds a claim now covers its whole **subtree**: an ancestor/descendant pair conflicts. A trailing-`/` boundary ensures siblings that merely share a string prefix (`src/foo.ts` vs `src/foobar.ts`) do **not** collide, and separators/trailing-slashes are normalized. Non-path kinds (`module`/`package`/`route`/`skill`/`prompt`) keep exact-value matching. Intent semantics (`edit` exclusive, `read` shared) and `force=true` override are unchanged.

## Verification

- **22 unit tests pass** (3 new: dir-contains-file conflict, file-under-dir conflict, sibling string-prefix non-conflict). All existing exact-match cases unchanged.
- Full typecheck + production build run in CI (worktree is source-only).

## Process-Spine-Decision

Targeted correctness fix to existing capsule conflict-detection (~25 lines, no new surface); rationale captured in code comments. Part of the reviewed **EP-ARCH-CONVERGENCE** de-confliction work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)