### PR TITLE
feat(contribution): apply private/public boundary only at public-hive egress

### DIFF
--- a/apps/web/lib/integrate/contribution-egress.test.ts
+++ b/apps/web/lib/integrate/contribution-egress.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRepoCoords,
+  classifyEgress,
+  CANONICAL_UPSTREAM_OWNER,
+  CANONICAL_UPSTREAM_REPO,
+} from "./contribution-egress";
+
+describe("parseRepoCoords", () => {
+  it("parses HTTPS and SSH GitHub URLs", () => {
+    expect(parseRepoCoords("https://github.com/acme/portal.git")).toEqual({ owner: "acme", repo: "portal" });
+    expect(parseRepoCoords("git@github.com:acme/portal.git")).toEqual({ owner: "acme", repo: "portal" });
+  });
+  it("returns null for non-GitHub or empty input", () => {
+    expect(parseRepoCoords("https://gitlab.com/acme/portal")).toBeNull();
+    expect(parseRepoCoords(null)).toBeNull();
+    expect(parseRepoCoords(undefined)).toBeNull();
+  });
+});
+
+describe("classifyEgress", () => {
+  const upstream = "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git";
+
+  it("classifies the configured upstream as public-hive", () => {
+    expect(classifyEgress({ owner: "acme", repo: "dpf-fork" }, "https://github.com/acme/dpf-fork.git"))
+      .toBe("public-hive");
+  });
+
+  it("classifies the canonical DPF upstream as public-hive even when upstream is customized", () => {
+    expect(classifyEgress({ owner: CANONICAL_UPSTREAM_OWNER, repo: CANONICAL_UPSTREAM_REPO }, "https://github.com/acme/private.git"))
+      .toBe("public-hive");
+  });
+
+  it("classifies the canonical DPF upstream as public-hive when upstream is unset", () => {
+    expect(classifyEgress({ owner: CANONICAL_UPSTREAM_OWNER, repo: CANONICAL_UPSTREAM_REPO }, null))
+      .toBe("public-hive");
+  });
+
+  it("classifies a customer's own repo as own-repo (unfiltered home)", () => {
+    expect(classifyEgress({ owner: "acme", repo: "our-private-portal" }, upstream)).toBe("own-repo");
+  });
+
+  it("is case-insensitive on owner/repo", () => {
+    expect(classifyEgress({ owner: "opendigitalproductfactory", repo: "OpenDigitalProductFactory" }, null))
+      .toBe("public-hive");
+  });
+});

--- a/apps/web/lib/integrate/contribution-egress.ts
+++ b/apps/web/lib/integrate/contribution-egress.ts
@@ -1,0 +1,58 @@
+/**
+ * Contribution egress classification — Private/Public Change Segregation.
+ * Spec: docs/superpowers/specs/2026-06-19-hive-contribution-architecture-and-egress-model.md
+ *
+ * The private/public boundary applies at PUBLIC-HIVE egress only. A PR to the
+ * install's OWN repo is its private home and must keep the full diff (incl.
+ * proprietary paths); a PR to the public upstream hive is gated by disposition
+ * and private-paths stripping.
+ *
+ * `create_portal_pr` resolves its target from the local git remote first and
+ * silently falls back to the public upstream, so the publicness of its target
+ * varies at runtime — the boundary must key off the resolved target, not the
+ * tool that produced it.
+ */
+
+/** The canonical public DPF upstream — the public hive of last resort. */
+export const CANONICAL_UPSTREAM_OWNER = "OpenDigitalProductFactory";
+export const CANONICAL_UPSTREAM_REPO = "opendigitalproductfactory";
+
+export type EgressTarget = "public-hive" | "own-repo";
+
+export interface RepoCoords {
+  owner: string;
+  repo: string;
+}
+
+/** Parse owner/repo from a GitHub HTTPS or SSH remote URL. */
+export function parseRepoCoords(url: string | null | undefined): RepoCoords | null {
+  if (!url) return null;
+  const m = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
+  return m ? { owner: m[1], repo: m[2] } : null;
+}
+
+function eq(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Classify a resolved PR target as the public hive or the install's own repo.
+ *
+ * A target is the public hive when it matches the configured
+ * `upstreamRemoteUrl`, OR the canonical DPF upstream (so a customer who left
+ * the default never silently leaks proprietary work to it). Everything else is
+ * the install's own repo — unfiltered, its private home.
+ */
+export function classifyEgress(
+  target: RepoCoords,
+  upstreamRemoteUrl: string | null | undefined,
+): EgressTarget {
+  const configured = parseRepoCoords(upstreamRemoteUrl);
+  if (configured && eq(target.owner, configured.owner) && eq(target.repo, configured.repo)) {
+    return "public-hive";
+  }
+  if (eq(target.owner, CANONICAL_UPSTREAM_OWNER) && eq(target.repo, CANONICAL_UPSTREAM_REPO)) {
+    return "public-hive";
+  }
+  return "own-repo";
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10380,23 +10380,6 @@ export async function executeTool(
       const diff = (build.diffPatch ?? "") as string;
       if (!diff.trim()) return { success: false, error: "No diff available.", message: "Run deploy_feature first to extract the diff." };
 
-      // Private-paths boundary (Phase 1 of Private/Public Change Segregation):
-      // local records keep the full diff, but any OUTBOUND PR diff must never
-      // carry a path the operator marked proprietary. The `.dpf/private-paths`
-      // manifest ships empty → no-op until opted in. Spec:
-      // docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
-      const { loadPrivatePathPatterns: _loadPriv, compilePrivatePathMatcher: _compilePriv, stripPrivatePathsFromDiff: _stripPriv } =
-        await import("@/lib/integrate/private-paths");
-      const shareableDiff = _stripPriv(diff, _compilePriv(await _loadPriv())).kept;
-      if (!shareableDiff.trim()) {
-        return {
-          success: false,
-          error: "Only private paths.",
-          message:
-            "This change only affects parts of your system you've marked private (see .dpf/private-paths or Admin > Platform Development), so there is nothing to share upstream.",
-        };
-      }
-
       const { buildSandboxStateFromRecord, assertSandboxReadyForPromotion, serializePlanDocument } = await import("@/lib/build/sandbox-state");
       const sandboxState = buildSandboxStateFromRecord({
         buildBranch: build.buildBranch,
@@ -10449,6 +10432,39 @@ export async function executeTool(
 
       if (!repoOwner || !repoName) {
         return { success: false, error: "Cannot determine repository.", message: "No git remote or upstream URL configured." };
+      }
+
+      // Public-egress boundary (Private/Public Change Segregation): the
+      // private/public filter applies ONLY when shipping to the PUBLIC hive. A
+      // PR to the install's OWN repo is its private home and keeps the full
+      // diff (proprietary paths included). This also closes the silent
+      // fall-back-to-public leak — a customer's proprietary build never goes to
+      // the canonical upstream unless that IS the configured target. Spec:
+      // docs/superpowers/specs/2026-06-19-hive-contribution-architecture-and-egress-model.md
+      let shareableDiff = diff;
+      {
+        const _egCfg = await prisma.platformDevConfig.findUnique({
+          where: { id: "singleton" },
+          select: { upstreamRemoteUrl: true },
+        });
+        const { classifyEgress } = await import("@/lib/integrate/contribution-egress");
+        const egress = classifyEgress({ owner: repoOwner, repo: repoName }, _egCfg?.upstreamRemoteUrl);
+        if (egress === "public-hive") {
+          const { loadPrivatePathPatterns, compilePrivatePathMatcher, stripPrivatePathsFromDiff } =
+            await import("@/lib/integrate/private-paths");
+          shareableDiff = stripPrivatePathsFromDiff(
+            diff,
+            compilePrivatePathMatcher(await loadPrivatePathPatterns()),
+          ).kept;
+          if (!shareableDiff.trim()) {
+            return {
+              success: false,
+              error: "Only private paths.",
+              message:
+                "This change only affects parts of your system you've marked private (see .dpf/private-paths or Admin > Platform Development), so there is nothing to share upstream.",
+            };
+          }
+        }
       }
 
       // Resolve token

--- a/docs/superpowers/specs/2026-06-19-hive-contribution-architecture-and-egress-model.md
+++ b/docs/superpowers/specs/2026-06-19-hive-contribution-architecture-and-egress-model.md
@@ -1,0 +1,91 @@
+# Hive Contribution Architecture & the Public-Egress Boundary
+
+**Date:** 2026-06-19
+**Status:** Research synthesis + design refinement for Private/Public Change Segregation (epic EP-1A78BAE1).
+**Builds on:** [`2026-06-18-local-git-and-private-public-segregation-analysis.md`](2026-06-18-local-git-and-private-public-segregation-analysis.md), [`2026-06-18-private-public-change-segregation-design.md`](2026-06-18-private-public-change-segregation-design.md).
+**Goal it serves:** make segregation work with **no new container/resource overhead**, keep **Build Studio + external (Claude/Codex)** paths working, hide complexity from users, and be robust + well-architected.
+
+---
+
+## 1. The hive is a lightweight git+ledger mechanism — zero new infra
+
+The "hive mind" is **not a service**. It is:
+- **Destination:** the public GitHub upstream repo named by `PlatformDevConfig.upstreamRemoteUrl` (default `OpenDigitalProductFactory/opendigitalproductfactory`).
+- **Auth:** a GitHub PAT resolved by `resolveHiveToken()` (`identity-privacy.ts:211`) from `HIVE_CONTRIBUTION_TOKEN` env → encrypted `CredentialEntry(providerId="hive-contribution")` → `GITHUB_TOKEN` → `git-backup` cred.
+- **Identity:** a pseudonymous per-install agent `dpf-agent-<shortId>` / `agent-<shortId>@hive.dpf` derived from `clientId` (`getPlatformIdentity()`); real identity stays in local Postgres only.
+- **Outbound:** `createBranchAndPR()` → `api.github.com`. **Inbound:** self-upgrade git merge (code+schema+wiki), the scheduled hive-scout DB ingest (`run_hive_scout_ingest`), and in-process MCP tools.
+- **Ledger:** `FeaturePack`, `ImprovementProposal.contributionStatus` (`"local"`→`"contributed"`), `HiveContributionLedger` — all rows in the existing Postgres.
+
+**Footprint verdict:** the entire contribution path is in-process in the `portal` container + GitHub API + existing Postgres. **No hive container, no sidecar, no new service.** The "no added overhead" constraint is satisfied by construction, and the private-home decision from the analysis doc (bare git remote, optional Gitea, never bundle GitLab CE) is consistent with this.
+
+## 2. Build Studio vs external paths — where they converge
+
+| | Build Studio (in-portal) | External (Claude/Codex via MCP) |
+|---|---|---|
+| Diff extraction | `deploy_feature` → `FeatureBuild.diffPatch` | same |
+| Substrate | `FeatureBuild` | same |
+| Ship/contribute tool | `create_portal_pr` | `contribute_to_hive` |
+| Outbound call | `createBranchAndPR(shareableDiff)` | `createBranchAndPR(shareableDiff)` |
+| Extra steps | `runPrePRGates`, auto-merge | `runContributionReview` |
+
+**Convergence:** both populate `FeatureBuild.diffPatch` via `deploy_feature`, and both reach `createBranchAndPR`. Increment 1 already placed private-paths stripping in **both** plus `submitBuildAsPR` — so the three egress chokepoints are covered. **Governance-approves-evidence-not-provenance (AGENTS.md §17) holds:** the boundary reads the diff + target, never which surface produced it.
+
+## 3. The real architectural fix: the boundary is the *target's publicness*, not the tool
+
+`create_portal_pr` resolves its target from the **local git remote first, then falls back to `upstreamRemoteUrl`** (`mcp-tools.ts:10427-10448`). So its target's publicness **varies at runtime**:
+- Maintainer dev box → resolves to the public upstream (intended platform-contribution path).
+- Customer install with their own remote → their own repo.
+- Customer install with no remote → **silently falls back to the public upstream**.
+
+Two consequences make a tool-keyed boundary wrong:
+1. **Stripping toward a customer's own repo loses proprietary code** — their repo is the rightful *home* for everything, private included.
+2. **The silent public fallback is a latent leak** — a customer who never opted into public contribution could push proprietary work to the public repo.
+
+**Principle:** *The private/public boundary applies only at PUBLIC-HIVE egress.* A diff going to the install's own repo (private home / `dpf/install` / a private remote) is unfiltered — it holds everything. A diff going to the public upstream hive is gated by disposition + private-paths stripping.
+
+### 3.1 This mirrors the EXISTING knowledge-segregation pattern (reuse, don't invent)
+DPF already segregates *knowledge* with a kernel + org-overlay model (`WikiPage`):
+- **Kernel row** (`organizationId=NULL`, `isKernel=true`) = global/public. **Org overlay** (`organizationId=SET`, `kernelPageId→`) = proprietary/local, shadows the kernel.
+- Retrieval is two-pass: org-scoped first, kernel fallback with masking. `principlePublic` flags a principle as shareable. `ImprovementProposal.contributionStatus` already marks `local` vs `contributed`.
+- **Pure DB scoping + retrieval precedence. No new infra.**
+
+The code segregation is the same shape:
+| Knowledge | Code (this program) |
+|---|---|
+| Org-overlay WikiPage (proprietary) | Customer's own repo / `dpf/install` branch (proprietary home) |
+| Kernel WikiPage (public) | Public upstream hive |
+| `principlePublic` flag | `FeatureBuild.disposition` (`private`\|`shareable`) |
+| Two-pass retrieval masking | Self-upgrade merge of upstream into `dpf/install` |
+| `contributionStatus` local→contributed | `FeaturePack`/proposal contribution state |
+
+So the well-architected answer is **not new machinery** — it is: (a) a per-change disposition equivalent to `principlePublic`, (b) a public-egress classifier that decides when the boundary applies, (c) the existing `dpf/install` branch as the proprietary home. All DB + git + in-process; zero new containers.
+
+## 4. The public-egress classifier (increment 2, first step)
+
+Add one helper: `classifyEgress(repoOwner, repoName)` → `"public-hive" | "own-repo"`, deciding by whether the target matches `upstreamRemoteUrl`'s owner/repo (or the canonical `OpenDigitalProductFactory` default).
+
+- `contribute_to_hive` → always `public-hive` (by definition) → apply disposition gate + private-paths strip.
+- `create_portal_pr` / `submitBuildAsPR` → classify the resolved target:
+  - `own-repo` → **no strip, no disposition gate** (full diff to the customer's home).
+  - `public-hive` → apply disposition gate + strip (and never silently fall back to public — require explicit shareable).
+
+This **corrects increment 1's unconditional strip in `create_portal_pr`** (harmless today only because the manifest ships empty) and closes the silent-public-fallback leak. Build Studio shipping to its own/portal repo is unaffected; external hive contribution is gated.
+
+## 5. Disposition gate without breaking the paths (increment 2)
+
+- `FeatureBuild.disposition` defaults `private` (fail-closed) — but the gate **only fires at `public-hive` egress** (§4). Build Studio shipping to its own repo never hits it, so the BS path keeps working unchanged.
+- A setter is needed so a change can be marked `shareable`. Cheapest robust mechanism: a `set_change_disposition(disposition, reason)` MCP tool (in-process, write-scope) callable by coworker/operator — no UI dependency. The plain-language ship UI (increment 3) becomes presentation over this, not a prerequisite.
+- `PrivatePathRule` DB overrides merge with the `.dpf/private-paths` manifest (the loader already tolerates the table's absence).
+
+## 6. Hiding complexity (AGENTS.md §17)
+
+- Default experience: change is private; nothing reaches the public hive unless explicitly shared. No git vocabulary — "Keep on my system" / "Share with the community."
+- The egress classifier, disposition, and private-paths plumbing are backstage. Operator-grade controls (private-paths editor, remote config) are admin-only.
+- The local-changes ledger answers "what have we kept private?" in plain language over the `dpf/install` not-in-upstream commits.
+
+## 7. Net
+
+- **No new infra** — confirmed; the hive is git+API+Postgres in the existing portal container.
+- **Both paths keep working** — boundary keys off target publicness; BS→own-repo is unfiltered, external→hive is gated; provenance-blind per §17.
+- **Robust & reuses substrate** — code segregation mirrors the proven knowledge kernel/org-overlay pattern; disposition ≈ `principlePublic`; `dpf/install` is the proprietary home.
+- **Next implementation step:** the public-egress classifier (§4) — corrects increment 1 and is the foundation for the disposition gate (§5).


### PR DESCRIPTION
## Summary

Second increment of **Private/Public Change Segregation** (epic EP-1A78BAE1), building on #2074. Research doc: `docs/superpowers/specs/2026-06-19-hive-contribution-architecture-and-egress-model.md`.

**Finding.** Research into the hive/contribution architecture confirmed the hive is a lightweight git + GitHub-API + Postgres mechanism (zero new containers), and that `create_portal_pr` resolves its PR target from the local git remote first and **silently falls back to the public upstream**. So its target's publicness varies at runtime. Increment 1 (#2074) stripped private paths there *unconditionally*, which is wrong toward a customer's **own** repo (their repo is the rightful home for proprietary code), and the silent public fallback is a latent **leak**.

**Fix.** Introduce `classifyEgress(target, upstreamRemoteUrl)` → `public-hive | own-repo`. The private/public filter now applies **only at public-hive egress**:
- `create_portal_pr`: classify the resolved target; strip + "nothing to share" guard only when the target is the public hive — a PR to the install's own repo keeps the full diff.
- `contribute_to_hive`: unchanged — always public-hive by definition.
- `submitBuildAsPR`: unchanged — fork/upstream targets are contribution-bound.

**Why it matters for the goal:** keeps Build Studio's ship-to-own-repo path working untouched, closes the silent-fallback leak, adds **no new infra**, and makes code segregation mirror DPF's existing knowledge kernel/org-overlay pattern (own repo / `dpf-install` branch = proprietary home; public upstream = shared commons).

## Verification
- **Unit tests:** 7 new `contribution-egress` tests + 13 `private-paths` tests = 20 pass (`vitest`).
- **Typecheck:** `pnpm --filter web typecheck` clean (root-clone overlay; source-only worktree per AGENTS.md §5).
- **Substrate:** source-local gates only; CI runs the full build. No migration, no UI in this PR.

## Still ahead (same program)
- `FeatureBuild.disposition` fail-closed gate fired **only at public-hive egress** + `set_change_disposition` setter + `PrivatePathRule` DB overrides (needs migration).
- Plain-language ship UI + admin private-paths editor + Upgrade Center local-changes ledger (needs canonical-install UX verification).

EP-1A78BAE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)