### PR TITLE
fix(build-studio): reap inert stuck builds to unjam the WIP cap (BI-8F45BA74)

### DIFF
--- a/apps/web/lib/build/inert-build-reaper.test.ts
+++ b/apps/web/lib/build/inert-build-reaper.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { isInertBuildReapable, INERT_BUILD_REAP_MS } from "./inert-build-reaper";
+
+const NOW = new Date("2026-06-19T16:00:00.000Z");
+const thresholdMs = 3 * 60 * 60 * 1000; // 3h
+
+function base(overrides: Partial<Parameters<typeof isInertBuildReapable>[0]> = {}) {
+  return {
+    phase: "ideate",
+    abandonedAt: null as Date | null,
+    parentEpicId: null as string | null,
+    createdAt: new Date(NOW.getTime() - 24 * 60 * 60 * 1000), // 24h old
+    activityCount: 0,
+    liveTaskRunCount: 0,
+    now: NOW,
+    thresholdMs,
+    ...overrides,
+  };
+}
+
+describe("isInertBuildReapable", () => {
+  it("reaps an old build with zero activity stuck in ideate", () => {
+    expect(isInertBuildReapable(base())).toBe(true);
+  });
+
+  it("reaps an old inert build stuck in plan", () => {
+    expect(isInertBuildReapable(base({ phase: "plan" }))).toBe(true);
+  });
+
+  it("does NOT reap a build younger than the threshold", () => {
+    expect(isInertBuildReapable(base({ createdAt: new Date(NOW.getTime() - 60 * 60 * 1000) }))).toBe(false); // 1h old
+  });
+
+  it("does NOT reap a build that has any activity (it did something)", () => {
+    expect(isInertBuildReapable(base({ activityCount: 1 }))).toBe(false);
+  });
+
+  it("does NOT reap a build with a live/working TaskRun", () => {
+    expect(isInertBuildReapable(base({ liveTaskRunCount: 1 }))).toBe(false);
+  });
+
+  it("does NOT reap an already-abandoned build", () => {
+    expect(isInertBuildReapable(base({ abandonedAt: NOW }))).toBe(false);
+  });
+
+  it("does NOT reap a terminal build", () => {
+    expect(isInertBuildReapable(base({ phase: "complete" }))).toBe(false);
+    expect(isInertBuildReapable(base({ phase: "failed" }))).toBe(false);
+    expect(isInertBuildReapable(base({ phase: "abandoned" }))).toBe(false);
+  });
+
+  it("does NOT reap an epic-decomposed child build", () => {
+    expect(isInertBuildReapable(base({ parentEpicId: "EP-123" }))).toBe(false);
+  });
+
+  it("does NOT reap a build exactly at the threshold (strictly greater required)", () => {
+    expect(isInertBuildReapable(base({ createdAt: new Date(NOW.getTime() - thresholdMs) }))).toBe(false);
+  });
+
+  it("exports a sane default threshold (a few hours)", () => {
+    expect(INERT_BUILD_REAP_MS).toBeGreaterThanOrEqual(60 * 60 * 1000);
+    expect(INERT_BUILD_REAP_MS).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+});

--- a/apps/web/lib/build/inert-build-reaper.ts
+++ b/apps/web/lib/build/inert-build-reaper.ts
@@ -1,0 +1,142 @@
+// apps/web/lib/build/inert-build-reaper.ts
+//
+// BI-8F45BA74 — reap INERT stuck builds so they stop jamming the WIP cap.
+//
+// Why this exists:
+//   Auto-promoted builds (e.g. a daily backlog batch) that stall at the
+//   operator-driven ideate intent gate produce ZERO observable activity and sit
+//   in a non-terminal phase forever. Each holds a Build Studio WIP slot (the cap
+//   is intentionally small — see wip-cap.ts), so a handful of dead-on-arrival
+//   builds jam the pipeline: `promote_to_build_studio` then rejects every new
+//   build with `wip_cap_reached`, and nothing can be built at all. Observed live
+//   2026-06-19: 15 builds in `ideate`/`plan` with 0 BuildActivity against a cap
+//   of 3.
+//
+//   The dead-phase reaper in self-upgrade/quiescence.ts only closes orphaned
+//   BuildPhaseRun rows — these builds never created one (0 activity), so it can't
+//   help. This reaper targets the build itself.
+//
+// Safety: only a build that has produced NO observable work is reapable — zero
+// BuildActivity AND no active/working TaskRun — and only after it's older than
+// the inert threshold, in a non-terminal phase, not already abandoned, and not
+// an epic-decomposed child (those are coordinated by the epic, not reaped here).
+// A build that ever did anything (any phase that reached build/review/ship) has
+// BuildActivity and is therefore never touched. Re-promoting the backlog item
+// restarts the work cleanly.
+
+/** Default inert threshold: 3h with zero activity = dead-on-arrival. Override with BUILD_INERT_REAP_MS. */
+export const INERT_BUILD_REAP_MS = Number(process.env.BUILD_INERT_REAP_MS) || 3 * 60 * 60 * 1000;
+
+const TERMINAL_BUILD_PHASES = ["complete", "failed", "abandoned"];
+
+/**
+ * Pure decision: is this build an inert corpse safe to abandon? No DB. Unit-tested.
+ * A build is reapable only when it has produced no observable work at all and is
+ * older than the threshold.
+ */
+export function isInertBuildReapable(args: {
+  phase: string;
+  abandonedAt: Date | null;
+  parentEpicId: string | null;
+  createdAt: Date;
+  activityCount: number;
+  liveTaskRunCount: number;
+  now: Date;
+  thresholdMs: number;
+}): boolean {
+  const { phase, abandonedAt, parentEpicId, createdAt, activityCount, liveTaskRunCount, now, thresholdMs } = args;
+  if (abandonedAt) return false;
+  if (parentEpicId) return false; // epic-decomposed child — coordinated elsewhere
+  if (TERMINAL_BUILD_PHASES.includes(phase)) return false;
+  if (activityCount > 0) return false; // did something — not inert
+  if (liveTaskRunCount > 0) return false; // actively running right now
+  return now.getTime() - createdAt.getTime() > thresholdMs;
+}
+
+/**
+ * DB wrapper — find inert builds and abandon them, freeing their WIP slots.
+ * Returns the count reaped. Best-effort per row (one tx each) so a single
+ * failure never aborts the sweep. Re-checks under the transaction to avoid
+ * racing a build that just came alive between the scan and the write.
+ */
+export async function reapInertStuckBuilds(
+  now: Date = new Date(),
+  thresholdMs: number = INERT_BUILD_REAP_MS,
+): Promise<number> {
+  const { prisma } = await import("@dpf/db");
+  const cutoff = new Date(now.getTime() - thresholdMs);
+
+  // Coarse scalar filter (indexed); per-candidate activity/taskrun checks below.
+  const candidates = await prisma.featureBuild.findMany({
+    where: {
+      phase: { notIn: TERMINAL_BUILD_PHASES },
+      abandonedAt: null,
+      parentEpicId: null,
+      createdAt: { lt: cutoff },
+    },
+    select: { buildId: true, phase: true, createdAt: true },
+    take: 100,
+  });
+  if (candidates.length === 0) return 0;
+
+  let reaped = 0;
+  for (const c of candidates) {
+    const [activityCount, liveTaskRunCount] = await Promise.all([
+      prisma.buildActivity.count({ where: { buildId: c.buildId } }),
+      prisma.taskRun.count({ where: { buildId: c.buildId, status: { in: ["working", "active"] } } }),
+    ]);
+    if (
+      !isInertBuildReapable({
+        phase: c.phase,
+        abandonedAt: null,
+        parentEpicId: null,
+        createdAt: c.createdAt,
+        activityCount,
+        liveTaskRunCount,
+        now,
+        thresholdMs,
+      })
+    ) {
+      continue;
+    }
+
+    const hoursOld = Math.round((now.getTime() - c.createdAt.getTime()) / 3_600_000);
+    try {
+      await prisma.$transaction(async (tx) => {
+        // Re-check under the row: don't reap a build that just came alive.
+        const fresh = await tx.featureBuild.findUnique({
+          where: { buildId: c.buildId },
+          select: { phase: true, abandonedAt: true },
+        });
+        if (!fresh || fresh.abandonedAt || TERMINAL_BUILD_PHASES.includes(fresh.phase)) return;
+        const recount = await tx.buildActivity.count({ where: { buildId: c.buildId } });
+        if (recount > 0) return;
+
+        await tx.featureBuild.update({
+          where: { buildId: c.buildId },
+          data: {
+            phase: "abandoned",
+            abandonedAt: now,
+            abandonReason:
+              `Auto-reaped: inert build — no activity for >${Math.round(thresholdMs / 3_600_000)}h, ` +
+              `stuck in ${c.phase}. Freed a Build Studio WIP slot; re-promote the backlog item to retry. (BI-8F45BA74)`,
+          },
+        });
+        await tx.buildActivity.create({
+          data: {
+            buildId: c.buildId,
+            tool: "watchdog:reap-inert",
+            summary: `Reaped inert build (${hoursOld}h old, 0 activity in ${c.phase}) to free a WIP slot.`,
+          },
+        });
+      });
+      reaped += 1;
+      console.warn(
+        `[inert-build-reaper] reaped inert build ${c.buildId} (${hoursOld}h old, phase=${c.phase}, 0 activity)`,
+      );
+    } catch (err) {
+      console.warn(`[inert-build-reaper] failed to reap inert build ${c.buildId}:`, err);
+    }
+  }
+  return reaped;
+}

--- a/apps/web/lib/queue/functions/taskrun-watchdog.test.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.test.ts
@@ -12,7 +12,11 @@ vi.mock("@dpf/db", () => ({
     quiescenceRun: { findMany: (...a: unknown[]) => quiescenceFindManyMock(...a) },
     // Reached only past the flag check; default-empty so the handler short-circuits.
     buildStudioStallThreshold: { findMany: vi.fn().mockResolvedValue([]) },
-    taskRun: { findMany: vi.fn().mockResolvedValue([]) },
+    taskRun: { findMany: vi.fn().mockResolvedValue([]), count: vi.fn().mockResolvedValue(0) },
+    // BI-8F45BA74 inert-build reaper runs every tick before the flag check;
+    // no candidates → no-op (returns 0).
+    featureBuild: { findMany: vi.fn().mockResolvedValue([]) },
+    buildActivity: { count: vi.fn().mockResolvedValue(0) },
   },
 }));
 vi.mock("@/lib/self-upgrade/quiescence", () => ({

--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -21,6 +21,7 @@ import { inngest } from "../inngest-client";
 import { decideStall, type WatchdogCandidate, type StallDecision } from "@/lib/observability/watchdog-detect";
 import { buildStallSurface, mergeVerificationPatch } from "@/lib/observability/stall-surface";
 import { isStallWatchdogEnabled } from "@/lib/shared/feature-flags";
+import { reapInertStuckBuilds } from "@/lib/build/inert-build-reaper";
 
 // QUIESCENCE EXEMPTION (BI-QUIESCE-004a + spec §6.1 extension): this
 // function is intentionally NOT wrapped with gateAtEntry. The watchdog
@@ -116,15 +117,21 @@ export const taskrunWatchdog = inngest.createFunction(
     // those returns and so almost never ran — the 4-day Inngest outage.)
     const quiescenceRecovered = await recoverStuckQuiescenceCoordinators(new Date());
 
+    // BI-8F45BA74: reap inert builds (0 activity, stuck non-terminal) every tick,
+    // before any early-return — they jam the WIP cap and block all new builds, so
+    // this must run even when the stall watchdog is flag-off or no thresholds are
+    // seeded. Independent of stall detection (which keys off live TaskRuns).
+    const inertBuildsReaped = await reapInertStuckBuilds(new Date());
+
     if (!(await isStallWatchdogEnabled())) {
-      return { skipped: true, reason: "flag-off", quiescenceRecovered };
+      return { skipped: true, reason: "flag-off", quiescenceRecovered, inertBuildsReaped };
     }
 
     const { prisma } = await import("@dpf/db");
 
     const thresholds = await prisma.buildStudioStallThreshold.findMany();
     if (thresholds.length === 0) {
-      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered };
+      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered, inertBuildsReaped };
     }
 
     // Coarse SQL filter using the smallest applicable thresholds across all
@@ -174,7 +181,7 @@ export const taskrunWatchdog = inngest.createFunction(
     }
 
     if (decisions.length === 0) {
-      return { processed: 0, quiescenceRecovered };
+      return { processed: 0, quiescenceRecovered, inertBuildsReaped };
     }
 
     // Batch id-resolution: business taskRunId → cuid id for FK writes.
@@ -307,6 +314,6 @@ export const taskrunWatchdog = inngest.createFunction(
       processed += 1;
     }
 
-    return { processed, quiescenceRecovered };
+    return { processed, quiescenceRecovered, inertBuildsReaped };
   },
 );

--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -121,7 +121,14 @@ export const taskrunWatchdog = inngest.createFunction(
     // before any early-return — they jam the WIP cap and block all new builds, so
     // this must run even when the stall watchdog is flag-off or no thresholds are
     // seeded. Independent of stall detection (which keys off live TaskRuns).
-    const inertBuildsReaped = await reapInertStuckBuilds(new Date());
+    // Best-effort: a reaper error must never abort the tick (quiescence recovery
+    // already ran above; stall detection still follows).
+    let inertBuildsReaped = 0;
+    try {
+      inertBuildsReaped = await reapInertStuckBuilds(new Date());
+    } catch (err) {
+      console.warn("[taskrun-watchdog] inert-build reaper failed:", err);
+    }
 
     if (!(await isStallWatchdogEnabled())) {
       return { skipped: true, reason: "flag-off", quiescenceRecovered, inertBuildsReaped };

--- a/docs/superpowers/specs/2026-06-19-build-studio-reliability-analysis.md
+++ b/docs/superpowers/specs/2026-06-19-build-studio-reliability-analysis.md
@@ -1,0 +1,90 @@
+# Build Studio Reliability — Research Pass & Design-Improvement Roadmap
+
+- **Status:** Analysis / recommendations (not yet ratified). Feeds EP-9FC5D2FD (Build Studio first-customer hardening).
+- **Date:** 2026-06-19
+- **Method:** three parallel code audits (pipeline map, per-LLM-call/prompt inventory, failure-mode + fix-churn analysis) cross-validated against **empirical build history on the live install** and the recent git fix-churn. Every claim carries a `file:line` or a DB number.
+- **Framing:** the operator's words — *"death by a thousand cuts."* This pass finds that the thousand cuts are **four root failure families** re-surfacing in different shapes, each historically patched narrowly.
+
+---
+
+## 1. The reality, quantified (live install, `BuildDispatchAttempt` + `FeatureBuild`)
+
+| Signal | Value | Source |
+|---|---|---|
+| Builds that **completed** | **5 / 39 (13%)** | `FeatureBuild.phase` |
+| Builds **abandoned** | 24 / 39 (62%) (`abandonedAt` set) | `FeatureBuild` |
+| Builds **failed** | 9 / 39 (23%) | `FeatureBuild.phase='failed'` |
+| Dispatch failure rate | **19 / 67 (28%)** | `BuildDispatchAttempt` |
+| Dominant failure axis | **`usage-limit` = 17/19 (89%)** | `BuildDispatchAttempt.failureAxis` |
+| usage-limit source | **`chatgpt` (Codex CLI, cloud) — one build fired ~17 dead dispatches** into an exhausted ChatGPT/Codex subscription cap | rootCauseSummary |
+| Local coder result | **`qwen3-coder` 8/8 success, 0 failures** | dispatch attempts |
+| Local embedding footgun | `nomic-embed-text` 2 failures (qa + software specialists) | dispatch attempts |
+| **Plan phase latency** | **avg 2,242 s (~37 min), max 15,247 s (4.2 hours)** | `BuildPhaseRun` |
+| Ideate phase latency | avg 158 s, max 1,583 s (26 min) | `BuildPhaseRun` |
+
+Read-through: **~87% of builds never shipped.** The single largest *dispatch* killer was a cloud subscription cap, against which the orchestrator had no fast-abort — it kept firing the same doomed dispatch ~17 times. The local coder path, by contrast, has a clean record once configured. The plan phase is a multi-hour latency sink.
+
+---
+
+## 2. The four root failure families
+
+Each family is cross-validated by (code) a `file:line` root cause, (churn) the recent commits that keep patching it, and (data) the empirical signal above.
+
+### Family 1 — No verification → fix loop (the biggest architectural gap)
+Verification failures **stall** the build; they are never fed back to a coding agent to repair.
+- Pipeline records test failures but **does not fail the step** and sets `testsFailed` to a coarse `1`, assuming the agentic loop already fixed them — `apps/web/lib/integrate/build-pipeline.ts:555,569-572`.
+- Typecheck gate **blocks build→review with no remediation dispatch** — the build just sits.
+- Orchestrator: any `BLOCKED`/`NEEDS_CONTEXT` specialist halts auto-advance with no fix attempt — `apps/web/lib/integrate/build-orchestrator.ts:1436-1447`.
+- The only repair that exists is *within* one agentic-loop invocation; there is no **cross-step** repair.
+- **Churn:** the hottest surface — `#2019/#2020/#2023` all scope the build→review gate so unrelated/whole-repo failures stop blocking every build. Because the scoping is regex-on-output (Family 4), it keeps churning.
+
+### Family 2 — Cloud usage-limits with no fast-abort, failover, or resumable pause
+- Empirically the #1 dispatch killer: 17 dead `chatgpt` dispatches in one build, each returning *"You've hit your usage limit"*, none aborting the storm.
+- The CLI dispatch path maps a non-zero exit straight to `BLOCKED` with **zero per-task retry/backoff or axis-aware handling** — `build-orchestrator.ts:823-837,578-579`.
+- There is no "this whole provider is capped → stop dispatching / switch the build to local / pause until reset" logic. Local-only mode (`#2004`) *removed the cloud safety net*, so on a mixed install a cap is fatal rather than degraded.
+
+### Family 3 — Single-GPU local concurrency + inconsistent timeouts (the latency sink)
+- **Four independent timeout layers that don't compose:** local HTTP `LOCAL_INFERENCE_TIMEOUT_MS=60_000` (`apps/web/lib/routing/chat-adapter.ts:36-37`) vs agentic wall-clocks (build 10 min, **default 2 min**, `apps/web/lib/tak/agentic-loop.ts:41-45,1179-1184`) vs CLI dispatch (15–40 min, `*-dispatch.ts`) vs orchestrator 40 min (`build-orchestrator.ts:50`). The 60 s local HTTP cap is shorter than a cold qwen load + long generation, and on local-only there is no fallback.
+- **`withLocalInferenceLock` (`#2009`) only serializes the in-process HTTP path.** The sandbox-CLI path (`build-orchestrator.ts:793-822`) runs the model *inside the container* and **bypasses the lock**, so two parallel sandbox specialists still collide on one GPU. Background dimension evals pile onto the same GPU (`#2046/#2047`).
+- Symptom in data: **plan phase avg 37 min / max 4.2 h.**
+- **Local agentic path is unusable by construction:** the loop abandons after **8 tool calls** when `providerId==='local'` (`agentic-loop.ts:1197-1208`), and the pipeline hard-codes `taskType:'analysis'`+`requireTools:true` to force API tool-calling (`build-pipeline.ts:486,496-501`). Only `opencode` makes local builds work — so it must be the *first-class* local path, not a branch.
+
+### Family 4 — Output fragility on local models (no structured-output contract)
+- Strict parsing everywhere: ideate `repairJson` only fixes trailing commas + unescaped quotes (`apps/web/lib/integrate/ideate-dispatch.ts:260-308`); plan parsing validates only array presence with 2 attempts (`apps/web/lib/integrate/plan-on-approval.ts:125-155,269`); code-gen uses a strict `### FILE:` regex with **no fallback** (`apps/web/lib/integrate/coding-agent.ts:512`).
+- CLI dispatch treats `exitCode===0` as success and takes raw stdout — a model that exits 0 with garbage is recorded `DONE` (`build-orchestrator.ts:823-828`).
+- Failure axis is inferred by **substring-matching output text** (`apps/web/lib/build/verification-output.ts:45-73`, truncated to 2000 chars) — brittle and the reason Family 1's gate scoping keeps churning.
+- The **embedding-model footgun** (2 live failures) is the concrete instance; partially fixed by `pickDefaultCodingModel` + the new Build Runtime warning/pin (`#2004`), but `resolve_model_selection` still flags served-list ordering.
+
+### Supporting cuts (real, lower-frequency)
+- **Watchdog/heartbeat blind spots:** TaskRuns in `quiescing`/`input-required`/`auth-required` emit no heartbeat and aren't watched (`apps/web/lib/queue/functions/taskrun-watchdog.ts`); dead-phase reaping is **feature-flagged OFF** (`QUIESCENCE_REAP_DEAD_PHASES`, `apps/web/lib/self-upgrade/quiescence.ts`). Churn: `#2022/#2026/#2032`.
+- **Sandbox node_modules drift:** `pnpm install --frozen-lockfile` falls back to plain install on *any* error, silently changing the dep tree; preflight (`#2021`) heals only *unloadable* node_modules, not *stale-but-loadable*. Recurring across sessions.
+- **Self-upgrade swap mid-build** orphaned checkpoints (`#2010`); **slot pool** resets `in_use`→`available` on restart with no lease/epoch (slot races / leaks), 30-min blind queue wait (`apps/web/lib/integrate/sandbox/sandbox-pool.ts`, `build-pipeline.ts:270-277`).
+- **UI-click unreliability:** an abandon reason on the live install was *"approve-start UI click unreliable."*
+
+---
+
+## 3. Prioritized improvement roadmap
+
+Ordered by leverage (impact on the 13% completion rate × breadth of churn absorbed).
+
+### P0 — architectural, highest ROI
+1. **Verification → bounded fix loop.** On typecheck/test failure, dispatch a scoped repair turn (the failing files + the real error) back to the coding agent, up to N bounded iterations, before stalling. Replaces "stall + wait for human." Absorbs most of Family 1's recurring gate churn. *Files:* `build-pipeline.ts`, `build-orchestrator.ts`, `build/scoped-verification.ts`, `build/verification-output.ts`.
+2. **Usage-limit fast-abort + failover + resumable pause.** Detect the `usage-limit` axis on the *first* hit; immediately stop dispatching to the capped provider; either (a) fail the build over to the local engine (now viable) or (b) pause-and-resume when the cap resets. Kills the "17 dead dispatches" pattern. *Files:* `build-orchestrator.ts` dispatch loop, `*-dispatch.ts`, `routing/`.
+3. **Make `opencode`/local the first-class build path + one GPU-sized inference gate for ALL local calls.** Route both the in-process HTTP path *and* the sandbox-CLI path through a single concurrency gate sized to GPU count; reconcile the four timeout layers (raise/remove the 60 s local HTTP cap; one coherent budget per phase). Removes usage-limits entirely and fixes the plan-phase latency. *Files:* `chat-adapter.ts` (`withLocalInferenceLock`), `build-orchestrator.ts`, `*-dispatch.ts`, `agentic-loop.ts:41-45,1179-1208`.
+
+### P1 — robustness
+4. **Structured-output contract for ideate/plan/codegen.** Schema-validate parsed output; detect truncation pre-parse; retry with the validation error as a hint; add a loose-format fallback for code-gen; keep the embedding guard. *Files:* `ideate-dispatch.ts`, `plan-on-approval.ts`, `coding-agent.ts`, `propose-decomposition.ts`.
+5. **Right-size context to the model's real window.** Read `maxContextTokens` from the endpoint manifest; set the agentic history cap + injected-context budget dynamically (an 8K-window local model must truncate sooner than a 32K one). *Files:* `agentic-loop.ts:46-47`, `build-pipeline.ts:357-405`.
+6. **Close watchdog/heartbeat blind spots + flip dead-phase reaping ON by default.** Cover `quiescing`/`input-required`/`auth-required`; default `QUIESCENCE_REAP_DEAD_PHASES=1`. *Files:* `taskrun-watchdog.ts`, `observability/heartbeat.ts`, `self-upgrade/quiescence.ts`.
+
+### P2 — durability & latency
+7. **Content-hash/pin the sandbox node_modules** so "stale-but-loadable" is detected, not just "unloadable." *Files:* `integrate/sandbox/sandbox.ts`.
+8. **Durable orchestrator sub-steps + slot lease/epoch.** Break the single `pipeline:implement` durable step into per-batch sub-steps (resume mid-build); give sandbox slots a lease/epoch so restarts don't race or leak. *Files:* `queue/functions/build-execute.ts`, `integrate/sandbox/sandbox-pool.ts`.
+9. **Investigate the 37-min plan phase directly** (model right-sizing for the reasoning tier, prompt trimming, or splitting plan generation) — it is the worst single latency sink.
+
+---
+
+## 4. Appendix — artifact pointers
+- **Pipeline map** (phase-by-phase entry points, durable vs inline, gates): ideate (`integrate/ideate-dispatch.ts`, `actions/build.ts`), plan (`integrate/plan-on-approval.ts`), reviews (`integrate/build-reviewers.ts`, `prompts/reviewer/*.prompt.md`), build (`queue/functions/build-execute.ts` → `integrate/build-orchestrator.ts` / `integrate/build-pipeline.ts`), review-verify (`queue/functions/build-review-verification.ts`), ship (`actions/build.ts`). Two execution paths exist (pipeline single-task vs orchestrator specialist-fan-out) with divergent timeouts/retries/parse logic — a recurring "works one way, breaks the other" source.
+- **LLM call inventory** (prompt source + routeAndCall config + parse fragility) for ideate / plan / decomposition / design-review / plan-review / code-gen / compaction / utility: see §2 Family 4 refs.
+- **Data model:** `FeatureBuild`, `BuildPhaseRun`, `BuildDispatchAttempt` (`packages/db/prisma/schema.prisma`).


### PR DESCRIPTION
## Reap inert stuck builds — unjam the Build Studio WIP cap (BI-8F45BA74)

First slice of **BI-8F45BA74** (EP-9FC5D2FD), and the bootstrap unblock for Build Studio.

### Problem (observed live 2026-06-19)
**15 builds were stuck in `ideate`/`plan` with ZERO `BuildActivity`** against a WIP cap of 3. Auto-promoted builds (a daily backlog batch) stall at the operator-driven ideate intent gate, produce no activity, and sit non-terminal forever — each holding a WIP slot. The result: `promote_to_build_studio` rejects every new build with `wip_cap_reached` and **nothing can be built at all**. The existing dead-phase reaper (`self-upgrade/quiescence.ts`) only closes orphaned `BuildPhaseRun` rows — these builds never created one.

### Fix
`apps/web/lib/build/inert-build-reaper.ts`:
- `isInertBuildReapable()` — pure decision (no DB, unit-tested 10 ways): reapable only when **0 BuildActivity AND no live TaskRun AND non-terminal phase AND not abandoned AND not an epic child AND older than the inert threshold** (default 3h, `BUILD_INERT_REAP_MS`). A build that ever did anything (reached build/review/ship) has activity and is never touched.
- `reapInertStuckBuilds()` — finds + abandons inert builds (per-row transaction with a re-check to avoid racing a build that just came alive), freeing the WIP slot. The abandon reason tells the operator to re-promote the backlog item to retry.

Wired into the `taskrun-watchdog` cron (every tick, before the early-returns — like the quiescence-coordinator recovery — so it runs even when the stall watchdog is flag-off).

### Verification (Build Studio sandbox, post-merge with `origin/main`)
- `tsc --noEmit` clean · `inert-build-reaper.test.ts` **10/10 pass** · `next build` **exit 0** (NODE_ENV=production).

Ships the Build Studio reliability analysis (`docs/superpowers/specs/2026-06-19-build-studio-reliability-analysis.md`) that specifies this and the sibling P0/P1 BIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
