### PR TITLE
chore(compose): make Grafana + adp opt-in to shrink the default-on footprint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -278,8 +278,6 @@ services:
         condition: service_healthy
       browser-use:
         condition: service_healthy
-      adp:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://127.0.0.1:3000/api/health"]
       interval: 10s
@@ -439,6 +437,13 @@ services:
       dockerfile: services/adp/Dockerfile
     restart: unless-stopped
     logging: *default-logging
+    # Opt-in (BI architecture-review footprint cut). The ADP payroll/HRIS bridge
+    # is only needed by installs that actually connect ADP — most never do, so it
+    # no longer runs by default. The portal's depends_on no longer waits on it
+    # (an absent profiled dependency would otherwise block `compose up`), and the
+    # ADP integration degrades to "unavailable" until enabled. Turn on with:
+    #   docker compose --profile integrations-adp up -d adp
+    profiles: ["integrations-adp"]
     ports:
       - "8600:8600"
     environment:
@@ -622,6 +627,14 @@ services:
     image: grafana/grafana-oss:13.0.2
     restart: unless-stopped
     logging: *default-logging
+    # Opt-in (BI architecture-review footprint cut). Grafana is the power-user
+    # escape hatch: the platform renders its own context-aware dashboards
+    # (Postgres + Neo4j + Prometheus) on the System Health tab and delivers
+    # alerts via the Inngest poll-bridge, so Grafana is not on the operational or
+    # alerting path. The HEADLESS monitoring stack (prometheus/loki/alloy/
+    # exporters) stays default-on; only this dashboard UI is opt-in. Turn on with:
+    #   docker compose --profile observability-ui up -d grafana
+    profiles: ["observability-ui"]
     ports:
       - "3002:3000"
     volumes:

--- a/docs/architecture/platform-overview.md
+++ b/docs/architecture/platform-overview.md
@@ -266,7 +266,7 @@ No single data store has all three. This is why the platform renders its own das
 
 ### Grafana's Role: Power-User Escape Hatch
 
-Grafana is included in the monitoring stack but serves a different audience and purpose:
+Grafana ships as an **opt-in** power-user tool — it is not started by `docker compose up` (enable it with `docker compose --profile observability-ui up -d grafana`). It serves a different audience and purpose than the platform UI:
 
 | | Platform UI | Grafana |
 |---|---|---|
@@ -288,7 +288,7 @@ Grafana is included in the monitoring stack but serves a different audience and 
 
 ### Monitoring Stack Topology
 
-The monitoring stack runs as part of the default Docker Compose stack. All services are headless infrastructure — they feed the platform's native UI and alert pipeline.
+The **headless** monitoring stack (Prometheus, Loki, Alloy, and the metric exporters) runs as part of the default Docker Compose stack — these feed the platform's native UI and alert pipeline. The Grafana **UI** is opt-in (`--profile observability-ui`), since the platform renders its own context-aware dashboards and delivers alerts via the Inngest poll-bridge rather than through Grafana.
 
 ![Monitoring Stack Topology](monitoring-diagrams/svg/02-monitoring-stack-topology.svg)
 

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -51,12 +51,16 @@ scrape_configs:
     static_configs:
       - targets: ["inngest:8288"]
 
-  # ─── ADP (payroll/HRIS MCP) ─────────────────────────────────
-  # GET /metrics added in services/adp/src/server.ts. Default-process
-  # metrics + per-tool latency histogram + error counter.
-  - job_name: "adp"
-    static_configs:
-      - targets: ["adp:8600"]
+  # ─── ADP (payroll/HRIS MCP) — opt-in (integrations-adp profile) ─────────────
+  # adp is no longer default-on (it runs only under the `integrations-adp`
+  # compose profile), so it is intentionally NOT scraped by default — otherwise
+  # the ContainerDown alert (`up == 0`) would fire CRITICAL for a service that is
+  # absent on purpose. Re-enable this job when you turn on the integrations-adp
+  # profile to restore adp's /metrics (per-tool latency histogram + error counter
+  # from services/adp/src/server.ts).
+  # - job_name: "adp"
+  #   static_configs:
+  #     - targets: ["adp:8600"]
 
   # ─── Redis (via redis-exporter sidecar) ─────────────────────
   # The redis-exporter container scrapes redis:6379 INFO and exposes it on


### PR DESCRIPTION
## Why

The base compose runs **~19 containers by default** vs the **7** `platform-overview.md` documents as "core" — organic accretion flagged by the 2026-06-19 architecture review (the "condense containers" goal). This trims the two clearly-optional sidecars whose coupling can be cleanly handled.

## What

| Service | Now | Rationale |
|---|---|---|
| **grafana** | `observability-ui` profile | Zero ripple — not a Prometheus scrape target, nothing `depends_on` it, not on the alert path (Inngest poll-bridge reads Prometheus/Loki directly). The platform renders its own dashboards; Grafana is the documented power-user escape hatch. |
| **adp** | `integrations-adp` profile | ADP payroll/HRIS bridge — used only by installs that connect ADP. Removed from the portal's `depends_on` (a non-profiled service can't depend on a profiled one; adp isn't called at portal boot) and **commented out its Prometheus scrape job** so the blanket `ContainerDown` (`up == 0`) alert can't false-fire on an intentionally-absent service. |

**Default-on services: 19 → 17.** Re-enable either with `docker compose --profile <name> up -d <svc>`.

## Deliberately left default-on (need a bigger change)

- **sandbox / sandbox-init / sandbox-postgres** (−3, the biggest remaining cut) — the build pipeline *assumes the sandbox is running* (`build-pipeline.ts:264` throws "Sandbox container is not running"), so gating it needs an on-demand-launch feature first. Staged as a follow-up.
- **dpf-stt**, **browser-use** — deliberate "ships working on `docker compose up`" defaults; flipping them is a product call, not a mechanical cut.

## Verification

- `docker compose config --services` (default) lists **neither** grafana nor adp; with `--profile observability-ui --profile integrations-adp` **both** appear.
- The default config **parses without error**, which only happens because the portal's `depends_on` no longer references the now-profiled adp.
- `platform-overview.md` updated so the Grafana section matches reality.
- Full stack-up runs via the `install-verification` workflow (manual/release gate — per repo design it is **not** a per-PR gate).

## Process-Spine-Decision

Deployment-default config change from the reviewed **EP-ARCH-CONVERGENCE** footprint finding; durable rationale in the compose/prometheus comments + the platform-overview update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)