### PR TITLE
docs(edge-node): deployment topology — opt-in local, easy remote, fleet-per-archetype

### DIFF
--- a/docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md
+++ b/docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md
@@ -1,0 +1,138 @@
+# Edge Node Deployment Topology — SysML Architecture Note
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-19 |
+| Status | Draft — hand-authored SysML model over current state (interim until the Phase D extractor lands) |
+| Notation | SysML v2 (`sysml2` EA notation) — viewpoint over the canonical DPF EA graph |
+| Package | `PKG-EDGE-TOPO` "Edge Node Deployment Topology" |
+| Owner | Enterprise Architect, Platform team |
+| Source design | [`2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md`](../superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md) |
+| Binding parent | [`2026-05-09-dpf-edge-node-design.md`](../superpowers/specs/2026-05-09-dpf-edge-node-design.md) |
+| Substrate spec | [`2026-06-14-sysml-architecture-substrate-design.md`](../superpowers/specs/2026-06-14-sysml-architecture-substrate-design.md) |
+| Living-graph program | [`2026-06-16-living-architecture-graph-and-operational-bridge-design.md`](../superpowers/specs/2026-06-16-living-architecture-graph-and-operational-bridge-design.md) (Phase D — network topology bridge) |
+| Model content (seed) | _planned_ `packages/db/src/seed-ea-sysml-edge-topology.ts` (filed under EP-EDGE-TOPOLOGY / EP-ARCH-GRAPH-LIVE) |
+
+This models the **deployment topology** of the edge node (how it is deployed, where, with what footprint, at what scale) — not the discovery wire-contract internals, which the binding 2026-05-09 spec already owns. The canonical model is the DPF EA graph (`EaElement`/`EaRelationship`); this markdown is the human-readable companion and the source for the future seed. Per the substrate spec's stance, the edge node is the planned Phase D "network topology bridge" of the living-architecture program; this note is the **hand-authored interim** until that extractor makes the model self-maintaining (see §8 — the convergence plan).
+
+**Legend.** `[D]` = deterministic fact (grounded in code/schema/scripts today). `[J]` = architect-authored judgment (design intent from the source spec, not yet realized). Verification status: **green** = automated test passes today; **planned** = future slice.
+
+---
+
+## SysML Architecture Note (skill template)
+
+- **Scope:** the Authority-Core ↔ edge-node deployment relationship — deploy posture (opt-in), remote provisioning, minimal footprint, and the fleet-across-contexts pattern (base + retail + MSP). It changes the platform's deployment decomposition; it does **not** change the discovery ingestion contract.
+- **Changed requirements/constraints:** REQ-EDGE-1…10 + CON-EDGE-1 (below). REQ-EDGE-3/4/5 (deploy opt-in, easy remote, footprint) are the realized-later posture changes from the source spec; REQ-EDGE-1/2/6/7 are deterministic today.
+- **Changed interfaces/ports:** no change to `/api/v1/edge/*` wire shapes `[D]`; adds the portal **"add a node on another machine"** provisioning interface `[J]` and an `install-state.json` `edge` deploy-record port `[J]`.
+- **Allocations:** agent → `services/edge-node-go/` + `services/edge-node/`; enrollment/trust → `apps/web/app/api/v1/edge/*` + `resolveEdgeNodeAuth`; fleet registry → `EdgeNode`/`BootstrapToken` + `/platform/edge-nodes`; deploy gate → `install-dpf.sh`/`fresh-install.ps1`/`dpf-start.*` + `docker-compose.edge*.yml`. (Full table §3.)
+- **Verification cases:** VC-EDGE-LIFECYCLE, VC-EDGE-STATE, VC-EDGE-AIRGAP green today; VC-EDGE-OPTIN, VC-EDGE-REMOTE-EASY, VC-EDGE-FOOTPRINT, VC-EDGE-FLEET planned.
+- **Data authority impact:** no new source-of-truth tables. Identity stays on `Principal`/`PrincipalAlias`; node state on `EdgeNode`/`BootstrapToken`/`EdgeNodeCapability`; the only new fact is a non-DB `install-state.json` `edge` record. The SysML model seeds into the existing EA graph (no new EA tables — substrate spec §3 boundary).
+- **EA/current-state catch-up:** this is the first SysML coverage of the edge node at all; it closes part of the living-graph Phase D gap with a hand-authored note, ahead of the extractor.
+- **Open architecture risks:** (1) note vs. future extractor drift — this note is the interim source, the extractor BI is linked (§8). (2) Default-flip migration must grandfather existing local nodes. (3) Retail per-location scope is `[J]` — depends on a site model audit. (Full list in source spec §14.)
+
+---
+
+## 1. Requirements (`requirement`)
+
+Stable IDs are the `infraCiKey`s for the future EA seed (`sysml:req:REQ-EDGE-N`).
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| REQ-EDGE-1 | **Authority-client topology.** An edge node is always a client of exactly one Authority Core; it registers with an Authority URL and never operates standalone. | green `[D]` |
+| REQ-EDGE-2 | **Deployment-target neutral.** The same edge agent runs on Windows / macOS / Linux, container or native, against a local / LAN / cloud / TAPPaaS Authority. | green (binary parity-tested) `[D]` |
+| REQ-EDGE-3 | **Opt-in deployment.** Where the platform is installed, no edge node runs unless the operator explicitly chooses it; the choice is identical across host OSes and persisted in `install-state.json`. | planned `[J]` (today: bundled+auto-trusted, the inverse) |
+| REQ-EDGE-4 | **Easy remote provisioning.** An operator can add an edge node on separate hardware and connect it to the portal without cloning the repo or editing files — the portal generates a ready-to-run, token-bound artifact. | planned `[J]` |
+| REQ-EDGE-5 | **Minimal footprint.** An edge node carries no portal, DB, graph/vector store, or LLM; it is one process/binary with outbound-only reach to the Authority URL + a small local state file. | partial — true of the standalone compose + Go binary `[D]`; not yet stated/tested as a contract `[J]` |
+| REQ-EDGE-6 | **Trust is operator-gated for remote nodes.** Paste/remote-provisioned nodes enroll `pending` and submit nothing until an operator approves; a *chosen* local node may auto-approve (the choice is the consent). | green `[D]` |
+| REQ-EDGE-7 | **Scope from the authority-issued token, never the request body.** A node's customer/site (or location) scope is bound on the bootstrap token and copied to `EdgeNode` at enrollment; runtime derives scope from the authenticated record. | green `[D]` (MSP) |
+| REQ-EDGE-8 | **Fleet is first-class.** One Authority Core supports zero-or-more edge nodes; admin list, discovery evidence, adapter credentials, status, and reaping are all per-node and scope-qualified. | partial — data model green `[D]`; fleet-grouped UX planned `[J]` |
+| REQ-EDGE-9 | **Retail fleet by location.** A retail org can run one edge node per store/warehouse/HQ, each scoped to its location, under one Authority Core. | planned `[J]` (retail site model gap) |
+| REQ-EDGE-10 | **MSP fleet by customer × site.** An MSP can run one edge node per customer site with strict estate separation; overlapping private IP ranges are valid under different scopes. | green at data layer `[D]`; provisioning/fleet UX planned `[J]` |
+
+## 2. Constraint / parametric (`constraint`)
+
+**CON-EDGE-1 — Edge footprint & isolation constraint.** A deployed edge node satisfies, for all topologies:
+
+- `inbound_listeners(edge) = ∅` — outbound-only to `DPF_AUTHORITY_URL` (FP1). `[D]`
+- `persistent_stores(edge) = { state.json }` — no relational/graph/vector store (FP2). `[D]`
+- `llm_runtimes(edge) = ∅` — no inference on the edge (FP3). `[D]`
+- `install_artifacts(edge) ⊆ { single_binary, single_compose_file }` — no monorepo clone required (FP4). `[J]`
+- `scope(node) = scope(bootstrapToken)` — derived at enrollment, server-enforced; `customerSiteId ⇒ customerAccountId`. `[D]`
+- `deploy(local_node) ⇒ operator_choice ∧ recorded(install-state.json.edge)` — the deploy gate (REQ-EDGE-3). `[J]`
+
+Realized by: the standalone/edge compose overlays' `network_mode`/`${VAR:?}` guards + `cap_add` minimalism `[D]`; `resolveEdgeNodeAuth` scope derivation `[D]`; the proposed `install-state.json` `edge` record + start-script reads `[J]`.
+
+## 3. Part definitions (`part_definition`) and allocations
+
+Each block is **allocated** (`sysml_allocates`) to the substrate that realizes it.
+
+| Block (ID) | Realizing substrate (allocation) | Satisfies |
+| --- | --- | --- |
+| `PART-EDGE-authority` Authority Core | the full portal compose stack (`docker-compose.yml`) + `apps/web` `[D]` | REQ-EDGE-1, REQ-EDGE-8 |
+| `PART-EDGE-agent` Edge Node Agent | `services/edge-node-go/` (native, default remote) + `services/edge-node/` (container) `[D]` | REQ-EDGE-1, REQ-EDGE-2, REQ-EDGE-5 |
+| `PART-EDGE-enroll` Enrollment & Trust Service | `apps/web/app/api/v1/edge/enroll/route.ts` + `heartbeat/route.ts` + `resolveEdgeNodeAuth` `[D]` | REQ-EDGE-1, REQ-EDGE-6, REQ-EDGE-7 |
+| `PART-EDGE-token` Bootstrap Token Service | `BootstrapToken` model + `scripts/issue-edge-bootstrap-token.ts` + Authority-side issuance `[D]`; portal-flow issuance planned `[J]` | REQ-EDGE-4, REQ-EDGE-6, REQ-EDGE-7 |
+| `PART-EDGE-registry` Fleet Registry & Admin | `EdgeNode`/`EdgeNodeCapability` + `apps/web/app/(shell)/platform/edge-nodes/page.tsx` `[D]`; fleet grouping by context planned `[J]` | REQ-EDGE-8, REQ-EDGE-9, REQ-EDGE-10 |
+| `PART-EDGE-deploygate` Deploy Gate | `install-dpf.sh`/`fresh-install.ps1`/`dpf-start.{sh,ps1}` + `docker-compose.edge*.yml` `[D]`; opt-in default + `install-state.json` record planned `[J]` | REQ-EDGE-3 |
+| `PART-EDGE-provision` Remote Provisioning Flow | _planned_ portal "add a node on another machine" → token-bound command/bundle `[J]` | REQ-EDGE-4 |
+| `PART-EDGE-ingest` Discovery Ingestion | `apps/web/app/api/v1/edge/discovery-runs/route.ts` + `adapters/route.ts` + `events/route.ts` `[D]` (owned by the binding 2026-05-09 spec) | REQ-EDGE-7, REQ-EDGE-10 |
+
+## 4. Interfaces / ports (`interface_definition`)
+
+| ID | Interface | Where | Status |
+| --- | --- | --- | --- |
+| `IF-EDGE-enroll` | `POST /api/v1/edge/enroll` (`dpfboot_*` → `dpfedge_*` + intervals) | `enroll/route.ts` `[D]` | green |
+| `IF-EDGE-heartbeat` | `POST /api/v1/edge/heartbeat` (`dpfedge_*`, liveness + intervals) | `heartbeat/route.ts` `[D]` | green |
+| `IF-EDGE-discovery` | `POST /api/v1/edge/discovery-runs` (scoped, idempotent, freshness-gated) | `discovery-runs/route.ts` `[D]` | green |
+| `IF-EDGE-adapters` | `GET /api/v1/edge/adapters` (scope-filtered adapter config) | `adapters/route.ts` `[D]` | green |
+| `IF-EDGE-events` | `POST /api/v1/edge/events` (canonical event envelope) | `events/route.ts` `[D]` | green |
+| `IF-EDGE-provision` | portal "add a node on another machine" → token-bound install artifact | spec §8 `[J]` | planned |
+| `IF-EDGE-deployrecord` | `install-state.json` `edge:{enabled,mode}` read by start scripts + portal | spec §5.2 `[J]` | planned |
+
+## 5. State machines (`state`)
+
+**SM-DEPLOY — Local deploy gate** `[J]` (REQ-EDGE-3):
+`absent (default) → operator-chooses → recorded(install-state) → overlay-included → enrolled`. Today the path is `installed → bundled → auto-enrolled → auto-trusted` with no `absent` start state — that inversion is what this model changes.
+
+**SM-TRUST — Node trust lifecycle** `[D]` (REQ-EDGE-6):
+`pending → trusted → { quarantined → trusted | revoked(terminal) }`. Local chosen node may transition `enrolled → trusted` automatically (consent = the choice); remote node holds at `pending` until operator approve.
+
+**SM-ENROLL — Agent enrollment** `[D]`:
+`first-run(has bootstrap token) → enroll → persist state.json(node token) → { heartbeat-loop ∥ sweep-loop } → on 401 node_revoked → clear state → exit`. Subsequent runs skip enroll and read `state.json`.
+
+## 6. Verification cases (`verification_case`)
+
+| ID | Verifies | Evidence | Status |
+| --- | --- | --- | --- |
+| VC-EDGE-LIFECYCLE | REQ-EDGE-1, REQ-EDGE-6 | `services/edge-node/scripts/verify-lifecycle.ts`; `scripts/verify-install-edge.sh` | **green** |
+| VC-EDGE-STATE | REQ-EDGE-5 (state-only persistence) | `services/edge-node/src/__tests__/state.test.ts` | **green** |
+| VC-EDGE-AIRGAP | CON-EDGE-1 (outbound-only) | `scripts/verify-edge-node-air-gap.sh` | **green** |
+| VC-EDGE-REMOTE-LAN | REQ-EDGE-1, REQ-EDGE-2 | `docs/install/edge-node-multi-host.md` §6 runbook gate | **green** (manual runbook) |
+| VC-EDGE-OPTIN | REQ-EDGE-3 | default install runs no node; opt-in adds one; Win/bash parity via `install-state.json` | planned |
+| VC-EDGE-REMOTE-EASY | REQ-EDGE-4 | portal-generated command enrolls a node with no repo clone / file edit | planned |
+| VC-EDGE-FOOTPRINT | REQ-EDGE-5 / CON-EDGE-1 (FP1–FP4) | egress allow-list + image bill-of-materials + no-clone install assertions | planned |
+| VC-EDGE-FLEET-MSP | REQ-EDGE-10 | two nodes, different customer/site scope, isolated inventory/adapters/evidence | planned |
+| VC-EDGE-FLEET-RETAIL | REQ-EDGE-9 | two nodes, different location scope, isolated posture | planned (after retail site model) |
+
+## 7. Traceability summary
+
+```
+REQ-EDGE-1 ──satisfies── PART-EDGE-authority, PART-EDGE-agent, PART-EDGE-enroll ──verifies── VC-EDGE-LIFECYCLE ✓
+REQ-EDGE-3 ──satisfies── PART-EDGE-deploygate ──verifies── VC-EDGE-OPTIN (planned)
+REQ-EDGE-4 ──satisfies── PART-EDGE-provision, PART-EDGE-token ──verifies── VC-EDGE-REMOTE-EASY (planned)
+REQ-EDGE-5 ──satisfies── PART-EDGE-agent ──refines── CON-EDGE-1 ──verifies── VC-EDGE-STATE ✓, VC-EDGE-AIRGAP ✓, VC-EDGE-FOOTPRINT (planned)
+REQ-EDGE-7 ──satisfies── PART-EDGE-enroll, PART-EDGE-token ──verifies── (covered by VC-EDGE-FLEET-*)
+REQ-EDGE-10 ─satisfies── PART-EDGE-registry, PART-EDGE-ingest ──verifies── VC-EDGE-FLEET-MSP (planned)
+CON-EDGE-1 ──refines──── REQ-EDGE-5, REQ-EDGE-7, REQ-EDGE-3
+PART-EDGE-agent ──sysml_allocates──▶ code:subsystem:services/edge-node-go
+PART-EDGE-registry ──sysml_traces──▶ prisma:model:EdgeNode   (the Phase-D cross-layer edge, per PR #2073 pattern)
+PART-EDGE-enroll ──sysml_traces──▶ archimate:application_component (edge enrollment API)
+```
+
+## 8. What is modeled now vs. the extractor convergence plan
+
+**Authored now `[J]` (this note):** the full deployment-topology model — REQ-EDGE-1…10, CON-EDGE-1, the eight parts, interfaces, three state machines, nine verification cases. Hand-authored architect judgment over verified current state.
+
+**Deterministic today `[D]`:** the Authority-client topology, deployment-target-neutral binary, outbound-only footprint, pending→approve trust, and scope-from-token are all real and test-backed (VC-EDGE-LIFECYCLE / STATE / AIRGAP green).
+
+**Convergence plan (Phase D extractor).** This note is the **interim source of truth**. The living-architecture program's network-topology bridge will add `buildEdgeTopologyModel(facts) → SysmlDesiredModel`, projecting each live `EdgeNode` row as a `part_usage` (`layer="network"`, `refinementLevel="actual"`, `sysmlKey="runtime:edge-node:<nodeId>"`) allocated to `PART-EDGE-agent` and `traces`-linked to `prisma:model:EdgeNode` — the cross-layer edge pattern established by PR #2073. When that lands, the *actual* fleet self-maintains in the graph and this note keeps only the *logical* definitions + judgment. The extractor is filed against EP-ARCH-GRAPH-LIVE (source spec §13 BI 5) so the two never compete.

--- a/docs/edge-node/deployment-topology.md
+++ b/docs/edge-node/deployment-topology.md
@@ -1,0 +1,115 @@
+# DPF Edge Node — Deployment Topology
+
+> **What this is.** The operator's map of *where* an edge node can run and *how* it
+> connects to your DPF portal. It is the front door above the developer runbooks
+> ([multi-host](../install/edge-node-multi-host.md), [air-gapped](../install/edge-node-air-gapped.md)).
+>
+> **Design:** [`2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md`](../superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md)
+> · **SysML:** [`2026-06-19-edge-node-deployment-sysml-architecture-note.md`](../architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md)
+> · **Binding spec:** [`2026-05-09-dpf-edge-node-design.md`](../superpowers/specs/2026-05-09-dpf-edge-node-design.md)
+
+## The one-sentence model
+
+Your DPF install is **one Authority Core** (the full portal) plus **zero or more edge nodes** —
+small, host-resident agents that map a network and report back. An edge node is always a client
+of an Authority Core; it never runs on its own.
+
+## What an edge node is *not*
+
+An edge node is **not a second copy of DPF**. It carries:
+
+| | Authority Core (the portal) | Edge node |
+| --- | --- | --- |
+| Web portal / admin UI | ✅ | ❌ |
+| Database, graph, vector store | ✅ | ❌ — just one small local state file |
+| AI / LLM | ✅ | ❌ — no inference on the edge |
+| Inbound network ports | serves the portal | ❌ — **outbound only**, to your Authority URL |
+| What it needs to run | a full install | the Authority URL, a one-time enrollment token, a state folder |
+
+That is why an edge node is cheap to drop onto a small box at a remote site: it only reaches
+*out* to your portal and holds nothing but its own enrollment.
+
+## Edge nodes are opt-in
+
+Installing DPF does **not** start an edge node. Mapping a network is a deliberate choice you make
+— at setup, or later under **Platform → Edge Nodes**. (If you upgraded from an older install that
+already ran a local edge node, it is kept; new installs start with none.)
+
+There are two separate decisions, and it helps to keep them apart:
+
+- **Deploy** — *do I want an edge node running here at all?* Off by default; you turn it on.
+- **Trust** — *may this node submit what it finds?* A node you add on another machine arrives
+  **pending** and submits nothing until you click **Approve**. A node you deliberately add on the
+  portal's own machine can trust itself, because choosing it *is* the consent.
+
+## Pick your situation
+
+### A — Map the network from the machine that runs DPF (co-located)
+
+The simplest case: you want to see the LAN around the box that already runs the portal.
+**Platform → Edge Nodes → Add an edge node here.** On Linux, choose the host-network profile for
+full LAN visibility; on Windows/macOS the native agent is used (a container on Docker Desktop
+cannot see your real LAN — see [why](wsl-mirrored-note.md)).
+
+Under the hood this is the [`docker-compose.edge.yml`](../../docker-compose.edge.yml) overlay,
+now included only when you opt in.
+
+### B — Put an edge node on a *different* machine (remote)
+
+A box on a LAN you want to map, a branch office, a customer site. The edge node runs there; your
+portal runs elsewhere (same building, a data centre, or the cloud).
+
+**Platform → Edge Nodes → Add a node on another machine.** Tell the portal the host's OS and (for
+multi-customer / multi-location setups) which context it belongs to. The portal hands you **one
+command to run on the other machine** with the Authority URL and a one-time token already filled
+in — no repo to clone, no file to edit. The default is a single native agent download; a Docker
+one-liner is offered as a fallback.
+
+The node appears as **pending**; click **Approve** and within a few minutes it submits its first
+discovery run.
+
+> The step-by-step substrate beneath this flow (and the manual path if you prefer it) is the
+> [multi-host runbook](../install/edge-node-multi-host.md), with
+> [TLS](../install/edge-node-multi-host.md#optional--upgrade-the-lan-path-to-https) and
+> [air-gapped](../install/edge-node-air-gapped.md) variants.
+
+### C — Many edge nodes across many contexts (a fleet)
+
+Situation B, repeated, grouped by the context that matters to your business. One Authority Core is
+the single pane; each node stays in its own lane (its inventory, credentials, and findings never
+blur with another's). This is where the archetypes differ:
+
+- **Retail** — one node **per location** (each store, the warehouse, HQ). Each store's network —
+  POS, payment devices, Wi-Fi, cameras — is mapped and kept separate (it also keeps each store's
+  PCI scope clean). See [Marisol, the retail persona](../personas/marisol-retail.md).
+- **MSP (managed services)** — one node **per customer, per site**. Each customer's estate is
+  strictly separated; two customers can even use the same private IP range without colliding. The
+  data boundary is specified in the
+  [edge-node customer-site binding design](../superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md).
+- **Other multi-site businesses** — property management (per building), HOAs (per community),
+  field-service trades (per yard) follow the same one-node-per-context pattern.
+
+## Decision guide
+
+| If you want to… | Situation | Start here |
+| --- | --- | --- |
+| See the LAN around the portal machine | A | Platform → Edge Nodes → *Add an edge node here* |
+| Map a network on another machine / site | B | Platform → Edge Nodes → *Add a node on another machine* |
+| Cover many stores / customers / sites | C | Add a node (B) per context; the fleet view groups them |
+| Run with no internet / disconnected | B/C (air-gap) | [air-gapped runbook](../install/edge-node-air-gapped.md) |
+| Not map any network | — | Do nothing — edge nodes are opt-in |
+
+## Verifying it works
+
+Each topology has a verification path (full matrix in the
+[design spec §11.2](../superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md#112-verification-matrix)):
+co-located + remote lifecycle via `scripts/verify-install-edge.sh`, outbound-only footprint via
+`scripts/verify-edge-node-air-gap.sh`, and the multi-host runbook's own §6 assertions. Success in
+every case is the same shape: the node shows **trusted** with a recent **last seen**, and a
+**discovery run** carries real LAN-side addresses.
+
+## See also
+
+- [Single-host overlay](../../docker-compose.edge.yml) · [standalone (separate host)](../../docker-compose.edge-standalone.yml) · [TLS overlay](../../docker-compose.edge-standalone-tls.yml) · [SNMP overlay](../../docker-compose.edge-snmp.yml) · [macvlan](../../docker-compose.edge.macvlan.yml)
+- [Event envelope](event-envelope.md) · [UniFi adapter](unifi-adapter.md) · [macvlan deployment](macvlan-deployment.md) · [WSL mirrored networking note](wsl-mirrored-note.md)
+- Deployment doctrine: [`2026-05-09-deployment-contracts.md` Contract 5](../superpowers/specs/2026-05-09-deployment-contracts.md)

--- a/docs/install/edge-node-multi-host.md
+++ b/docs/install/edge-node-multi-host.md
@@ -1,5 +1,10 @@
 # DPF Edge Node — Multi-Host LAN Installation
 
+> **New here? Start with the [Edge Node Deployment Topology guide](../edge-node/deployment-topology.md)**
+> for the operator-level map (local opt-in vs. remote vs. fleet) and the portal-driven
+> "add a node on another machine" flow. This runbook is the manual/developer substrate beneath
+> that flow — use it when you want the step-by-step or the portal flow isn't available.
+
 > **Status:** T2 — multi-host real-LAN deployment. Phase 0
 > ([2026-05-12-edge-node-phase0-roadmap.md](../superpowers/plans/2026-05-12-edge-node-phase0-roadmap.md))
 > covers single-host (Authority + Edge Node on the same machine).

--- a/docs/personas/marisol-retail.md
+++ b/docs/personas/marisol-retail.md
@@ -74,6 +74,21 @@ Related live backlog anchors:
 - `BI-3E8D2CF5` - Vertical workspace home projection service; live status `open`.
 - `BI-4396EFEC` - Dale D38 plan-iteration divergence; live status `triaging`, gating new peer-persona Build Studio sessions.
 
+## Network visibility across locations (edge node fleet)
+
+Marisol's shop is multi-context by nature: two stores plus a back room, each its own small
+network of POS terminals, payment devices, Wi-Fi, and back-office PCs. Retail's edge-node
+topology is therefore **one edge node per location**, each scoped to its store, all reporting to
+one Authority Core (at HQ or in the cloud) — the retail specialization of the base fleet model.
+This keeps each store's network posture (and its PCI/cardholder-data scope) cleanly separated, and
+it is **opt-in**: Marisol's install maps nothing until she chooses to add a node at a location.
+
+This is a deployment consideration for the retail archetype, not a first-feature ask — Marisol's
+day-one need is still the merchandising board. The substrate detail:
+
+- The fleet/topology model and the per-location specialization: [edge-node deployment topology design §7.2](../superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md) and the [operator topology guide](../edge-node/deployment-topology.md).
+- **Substrate gap to file:** retail does not yet have MSP's customer/site scoping wired for a single org; scoping retail edge nodes *by location* needs a site-model audit first (do not assume a new table). Tracked as the retail-fleet BI under EP-EDGE-TOPOLOGY.
+
 ## Source evidence
 
 - Workspace-home anchor: [Vertical Workspace Home design](../superpowers/specs/2026-05-24-vertical-workspace-home-design.md).

--- a/docs/superpowers/specs/2026-05-09-deployment-contracts.md
+++ b/docs/superpowers/specs/2026-05-09-deployment-contracts.md
@@ -117,7 +117,27 @@ configuration from there. The same binary supports Windows, macOS,
 Linux, cloud-hosted Authority Cores, TAPPaaS-hosted Authority Cores,
 and remote managed hosts.
 
-Per `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`.
+**Opt-in deployment.** Where the platform is installed, no Edge Node
+runs unless the operator chooses it; the choice is identical across
+host OSes and persisted in `install-state.json`. This is the *deploy*
+gate, distinct from the *trust* gate (remote nodes still enroll
+`pending` until approved).
+
+**Minimal footprint.** An Edge Node carries no portal, database,
+graph/vector store, or LLM — it is one process/binary, outbound-only
+to the Authority URL, holding only a small local state file. The
+remote artifact installs without a monorepo clone (a single native
+binary, or a single compose file fetched by URL).
+
+**Fleet topology.** One Authority Core supports a fleet of Edge Nodes
+across many contexts; admin list, discovery evidence, adapter
+credentials, status, and reaping are per-node and scope-qualified.
+Archetypes specialize the fleet: retail one node per location, MSP one
+per customer × site (strict estate separation).
+
+Per `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md` and the
+deployment-topology + remote-provisioning design
+`docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md`.
 
 ### 6. Build execution
 

--- a/docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md
+++ b/docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md
@@ -10,6 +10,7 @@
 - `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`
 - `docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md`
 - `docs/superpowers/specs/2026-04-23-it-service-provider-msp-archetype-design.md`
+- `docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md` — the *deployment topology* on top of this data boundary: how an MSP provisions one node per customer × site at scale (this spec remains authoritative for the scope model itself)
 
 ## 1. Problem Statement
 

--- a/docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md
+++ b/docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md
@@ -1,0 +1,330 @@
+# Edge Node Deployment Topology & Remote Provisioning — Design
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-19 |
+| Status | Draft — for review |
+| Author | Claude (Opus 4.8) with founder direction |
+| Epic | EP-EDGE-TOPOLOGY (proposed) — see §13 |
+| Supersedes | nothing; **extends** the binding edge-node design |
+| Binding parent | [`2026-05-09-dpf-edge-node-design.md`](2026-05-09-dpf-edge-node-design.md) (binding) |
+| Doctrine | [`2026-05-09-deployment-contracts.md`](2026-05-09-deployment-contracts.md) Contract 5 (Edge) |
+| Related | [`2026-05-20-edge-node-deployment-matrix.md`](2026-05-20-edge-node-deployment-matrix.md), [`2026-05-22-edge-node-customer-site-binding-design.md`](2026-05-22-edge-node-customer-site-binding-design.md), [`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md), [`2026-06-16-living-architecture-graph-and-operational-bridge-design.md`](2026-06-16-living-architecture-graph-and-operational-bridge-design.md) |
+| SysML companion | [`docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md`](../../architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md) |
+| Operator doc | [`docs/edge-node/deployment-topology.md`](../../edge-node/deployment-topology.md) |
+
+> **Legend.** `[D]` = deterministic fact grounded in current code/schema/scripts. `[J]` = architect judgment / proposed change not yet realized.
+
+---
+
+## 1. Problem Statement
+
+The edge node is the right architecture for **remote network visibility**: a host-resident agent that enrolls against a DPF Authority Core (the portal) and submits LAN/device/topology observations. The implementation is mature — TypeScript container + Go native binary, a full enrollment/heartbeat/discovery wire contract, customer/site-scoped fleet binding, and standalone/TLS/SNMP/air-gap compose overlays all exist today.
+
+But the **deployment topology** around it is not yet described as one coherent, supportable, testable architecture, and its default posture is wrong for the product. The founder's direction names five concrete gaps:
+
+1. **It is bundled and active by default; it must be opt-in.** Every install — `install-dpf.sh` and Windows `fresh-install.ps1` — bundles the edge-node container, **auto-issues a bootstrap token (`--auto-approve`)**, writes it to `.env`, and force-recreates the container so the local node **auto-enrolls and auto-trusts**. `[D]` This is silent default-on. Where the platform is installed, running an edge node should be a deliberate operator choice.
+2. **There is no *easy* way to put an edge node on separate hardware and connect it to the portal.** The capability exists (`docker-compose.edge-standalone.yml`, the multi-host runbook), but the path requires cloning the whole monorepo onto the second host just for a compose file, hand-editing `.env`, copying a token out-of-band, and re-approving in the portal. `[D]` That is a developer runbook, not an operator experience.
+3. **The edge install does not need everything the portal has — but that minimal footprint is not a described contract.** The standalone compose is already lean (no portal/postgres/neo4j/qdrant/LLM), and the Go binary is a single static executable. `[D]` Yet "what an edge node needs vs. what an Authority Core needs" is nowhere stated as a first-class footprint contract we can support and test against. `[J]`
+4. **The architecture is not described uniformly across documentation, SysML, and specifications.** Docs exist but are scattered (multi-host, air-gapped, deployment-contracts Contract 5, user guide). The edge node is **not yet in the SysML/EA graph** (it is the planned-but-unbuilt "network topology bridge", Phase D of [EP-ARCH-GRAPH-LIVE]). `[D]` There is no single deployment-topology description tying local/remote/fleet together.
+5. **Some archetypes deploy *many* edge nodes in different contexts, and that is not a base-architecture concept.** MSPs run an edge node per customer per site (the customer/site-binding spec already models the data boundary). Retail runs one per store/warehouse/HQ. `[D for MSP data model; J for the topology framing]` The "one Authority Core, a fleet of edge nodes across many contexts" pattern must be a base-architecture consideration and then specialized per archetype — not an MSP-only special case.
+
+This spec consolidates the deployment topology, flips the default posture to opt-in, defines the easy-remote provisioning experience and the minimal-footprint contract, models the system in SysML, gives a per-topology verification matrix, and adds the multi-node fleet consideration to the base architecture and to the retail and MSP archetypes.
+
+**This spec introduces no new identity-bearing tables.** It reuses `EdgeNode`, `BootstrapToken`, `EdgeNodeCapability`, and the `customerAccountId`/`customerSiteId` scope already on those models (Principal convergence preserved — §10). The work is posture, packaging, UX, description, and verification — not new substrate.
+
+---
+
+## 2. Current State (what already exists — credit the substrate)
+
+A substrate sweep (code + specs + scripts + live backlog, 2026-06-19) found the edge node is far denser than a first read suggests. The table separates *capability that exists* from *the gap this spec closes*.
+
+| Concern | Exists today `[D]` | Gap this spec closes |
+| --- | --- | --- |
+| Agent runtime | TypeScript container (`services/edge-node/`, Phase 0) + Go native binary (`services/edge-node-go/`, T3). Same `/api/v1/edge/*` wire contract; parity-tested. | Name the Go binary the **default remote artifact**; describe the footprint as a contract. |
+| Enrollment | `POST /api/v1/edge/enroll` consumes a single-use `dpfboot_*` token, returns a `dpfedge_*` node token + intervals. Heartbeat + discovery-runs follow. | Make the *local* bundled node deploy opt-in; keep the remote node's pending→approve trust gate. |
+| Trust | `trustState`: pending→trusted→quarantined→revoked. Installer-local tokens auto-approve; paste-provisioned remote tokens land pending. | Local install must default to **not enrolling at all**, not "enroll + auto-trust". |
+| Co-located deploy | `docker-compose.edge.yml` overlay; default-ON via `DPF_INCLUDE_EDGE=1` (bash) and **hardcoded** in both `dpf-start.ps1` files (no Windows opt-out). | Flip default to **opt-in**; add Windows parity for the opt-out/opt-in choice. |
+| Remote deploy | `docker-compose.edge-standalone.yml` (complete on its own — no portal/db), `-standalone-tls.yml`, `-snmp.yml`, `.macvlan.yml`. Multi-host + air-gapped runbooks. | Replace "clone the monorepo + hand-edit .env" with a portal-generated, copy-paste / single-artifact provisioning flow. |
+| Fleet scoping | `BootstrapToken.targetCustomerAccountId/SiteId` → copied to `EdgeNode.customerAccountId/SiteId` at enrollment; adapters + discovery runs filtered by authenticated scope. | Elevate "fleet across contexts" to base architecture; add retail; document operator UX for many nodes. |
+| Identity | `Principal(kind="edge_node")` + `PrincipalAlias` + `EdgeNode` side table. | Unchanged — reused. |
+| Admin UX | `/platform/edge-nodes`: issue token, approve, quarantine, revoke. | Add a guided "add a node on another machine / another site" flow; fleet grouping by customer/site. |
+| SysML / EA | **Absent.** Planned as the Phase D "network topology bridge" of the living-architecture graph. | Author the SysML architecture note now (§9) and define the extractor. |
+| Verification | `scripts/verify-install-edge.sh`, `scripts/verify-edge-node-air-gap.sh`, `services/edge-node/scripts/verify-lifecycle.ts`, multi-host runbook §6. | Unify into a per-topology verification matrix (§11). |
+
+**Key inconsistencies found:**
+
+- `install-dpf.sh:136` defaults `DPF_INCLUDE_EDGE=1` and (lines 873–946) auto-issues an `--auto-approve` token, writing it to `.env` and force-recreating `edge-node`. `fresh-install.ps1:299–392` mirrors this on Windows with **no `--no-edge` equivalent**. `[D]`
+- `scripts/dpf-start.ps1` and root `dpf-start.ps1` both **hardcode** `-f docker-compose.edge.yml` with no opt-out, while `dpf-start.sh` honors `--no-edge`/`DPF_INCLUDE_EDGE=0`. The two host surfaces disagree. `[D]`
+- The multi-host runbook calls the pending→approve step "the friction that makes Edge Node enrollment opt-in" — but that governs *trust of a remote node*, not *whether the local node deploys*. The local node is auto-approved, i.e. fully silent. `[D]` The product needs deploy-opt-in, distinct from trust-opt-in.
+
+---
+
+## 3. Goals / Non-Goals
+
+**Goals**
+
+- G1. Edge node deployment is **opt-in** where the platform is installed: default OFF, an explicit operator choice turns it on, identical on Windows / macOS / Linux.
+- G2. An operator can add an edge node on **separate hardware** and connect it to the portal **without cloning the repo or hand-editing files** — a portal-driven flow that yields a single copy-paste command (or downloadable minimal bundle) with the enrollment token pre-bound.
+- G3. The **minimal edge footprint** is a described, testable contract — what an edge node requires, and explicitly what it does *not* (no DB, no LLM, no web app, outbound-only to the Authority URL).
+- G4. The architecture is described coherently in **documentation, SysML, and specification** form, each pointing to the others (single source of truth, §10).
+- G5. "One Authority Core, a **fleet** of edge nodes across many contexts" is a **base-architecture** concept, specialized for **retail** (per location) and **MSP** (per customer × site).
+- G6. A per-topology **verification matrix** lets us test each deployment shape on its real substrate.
+
+**Non-Goals**
+
+- No change to the edge wire contract, the `dpfboot_*`/`dpfedge_*` token model, or the discovery ingestion controls (the binding 2026-05-09 spec remains authoritative for those).
+- No mTLS / client-cert work (that is the binding spec's Phase 1+ / T4 track).
+- No new customer-estate modeling beyond the existing customer/site scope.
+- No removal of the developer runbooks; they remain the substrate the easy flow wraps.
+
+---
+
+## 4. The Deployment Topology Model
+
+One **Authority Core** (the full portal install) owns identity, policy, the inventory graph, and the admin surface. Around it sits a **fleet of edge nodes**, each a thin host-resident agent. An edge node is *always* a client of an Authority Core; it never stands alone. Three deployment **situations** compose from that one relationship:
+
+```
+                          ┌─────────────────────────────────────────┐
+                          │            DPF Authority Core            │
+                          │  portal · postgres · neo4j · qdrant ·    │
+                          │  LLM routing · /api/v1/edge/* ingestion · │
+                          │  /platform/edge-nodes admin + fleet view │
+                          └───────────────▲───────────▲─────────────┘
+        enroll/heartbeat/discovery (HTTPS)│           │
+            outbound from edge → Authority │           │
+        ┌──────────────────────┬──────────┘           └────────────────────┐
+        │                      │                                            │
+ ┌──────┴───────┐     ┌────────┴─────────┐                       ┌──────────┴──────────┐
+ │ (A) Co-located│     │ (B) Remote node  │                       │ (C) Fleet across     │
+ │ opt-in node   │     │ on separate HW   │                       │ contexts (B ×N)      │
+ │ same host as  │     │ another machine/ │                       │ retail: per store    │
+ │ Authority     │     │ site/LAN         │                       │ MSP: per customer×site│
+ └───────────────┘     └──────────────────┘                       └──────────────────────┘
+```
+
+### 4.1 Situation A — Co-located, opt-in (the local node)
+
+The edge node runs on the same host as the Authority Core, in the same compose project (`docker-compose.edge.yml`). Useful for a single-site business that wants to map its own LAN from the box that already runs DPF.
+
+**Change (G1):** this is **opt-in**, default OFF. The platform installs and runs with no edge node unless the operator chooses to add one. Choosing it is a single decision at setup (or later, from `/platform/edge-nodes`), surfaced as a plain choice — not a token-paste chore.
+
+### 4.2 Situation B — Remote, on separate hardware (the remote node)
+
+The edge node runs on a **different machine** from the Authority Core — a box on the LAN to be mapped, a branch office, a customer site. It carries no portal, no database, no LLM. It needs only outbound reach to the Authority URL and a one-time enrollment token. This is the situation the founder flagged as having "no easy way" today.
+
+**Change (G2):** the portal's `/platform/edge-nodes` gains an **"Add a node on another machine"** flow that:
+
+1. Captures the node's intended scope (and, for MSP, the target customer/site) and a friendly name.
+2. Issues a bootstrap token bound to that scope (existing `BootstrapToken` machinery).
+3. Renders **one copy-paste provisioning command** (and a downloadable equivalent) with the Authority URL and token already substituted — defaulting to the **Go native binary** so the remote host needs neither Docker nor a repo clone. A Docker one-liner against `docker-compose.edge-standalone.yml` (pulled by URL, not cloned) is the fallback for hosts that prefer containers.
+4. Shows the node arriving in `pending`, with an **Approve** button (trust-opt-in preserved).
+
+### 4.3 Situation C — Fleet across contexts (many remote nodes)
+
+Situation B repeated N times, grouped by the context that matters to the business. The Authority Core is the single pane; each node is scoped so its inventory, adapter credentials, and discovery evidence stay in their lane. This is where archetypes diverge (§7).
+
+---
+
+## 5. Opt-In Posture (G1)
+
+### 5.1 Two independent gates — name them
+
+- **Deploy gate** — *is an edge node running here at all?* Today: implicitly yes (bundled). Target: **no, unless chosen.**
+- **Trust gate** — *may this enrolled node submit observations?* Today: local auto-approves; remote lands pending. Target: **unchanged** — remote stays pending→approve; a *chosen* local node may auto-approve because choosing it is the consent.
+
+The founder's "it needs to be opt-in" is about the **deploy gate**. The existing pending→approve friction is the trust gate and is correct; this spec leaves it intact.
+
+### 5.2 Changes `[J]`
+
+| Surface | Today `[D]` | Target |
+| --- | --- | --- |
+| `install-dpf.sh` | `DPF_INCLUDE_EDGE=1` default; auto-issues `--auto-approve` token | Default `DPF_INCLUDE_EDGE=0`; `--with-edge` opt-in flag; no token auto-issue unless opted in |
+| `fresh-install.ps1` | hardcoded edge bootstrap, no opt-out | Mirror bash: default off; `-WithEdge` switch; parity with `--with-edge` |
+| `dpf-start.sh` | honors `--no-edge`/`DPF_INCLUDE_EDGE=0`, default on | Default off; `--with-edge`/`DPF_INCLUDE_EDGE=1` to include; **read the persisted setup choice** from `install-state.json` |
+| `dpf-start.ps1` (both) | hardcoded `-f docker-compose.edge.yml` | Read the persisted choice; include the overlay only when chosen; Windows parity |
+| Setup UX | none | One plain choice: "Map this network from this machine? (adds an edge node)" — default No, with a one-line plain-language explanation |
+| `/platform/edge-nodes` | manage existing | "Add an edge node here" (local) and "Add on another machine" (remote) as first-class actions |
+
+`install-state.json` already records compose files and mode (`compose.sh` writes `composeFiles`); it gains an `edge: { enabled, mode }` record so start/stop scripts and the portal agree on whether the local node is part of this install — one source of truth, no drift between the two `dpf-start.ps1` files and `dpf-start.sh`.
+
+### 5.3 Migration for existing installs
+
+Existing installs already running a bundled+auto-trusted local node must not have it ripped out on upgrade. On first start after this lands: if an enrolled local edge node exists, record `edge.enabled=true, mode=local` in `install-state.json` (grandfather the choice) and surface a one-time portal notice — "Network mapping is now opt-in; your existing local edge node is kept. Manage it under Platform → Edge Nodes." Fresh installs get default-off. `[J]`
+
+---
+
+## 6. Minimal Edge Footprint (G3)
+
+The edge node is **not a portal**. Stating the bill-of-materials as a contract is what lets us support and test "the edge install doesn't need everything the portal has."
+
+| Concern | Authority Core (full portal) | Edge node (minimal) |
+| --- | --- | --- |
+| Web app / portal UI | yes | **no** |
+| Postgres / Neo4j / Qdrant | yes | **no** — state is one small `state.json` under a state dir |
+| LLM / model runtime | yes (routing + local DMR) | **no** — no inference on the edge |
+| Inbound network | serves :3000 (+:443 TLS) | **none** — outbound-only to the Authority URL |
+| Identity store | owns `Principal`/`User`/policy | holds only its own `dpfedge_*` node token in `state.json` (mode 0600) |
+| Compute/footprint | multi-container stack | one process / one container; static Go binary or the lean edge image |
+| Required inputs | install env, secrets | `DPF_AUTHORITY_URL`, one-time `DPF_BOOTSTRAP_TOKEN`, a state dir, (optional) a CA bundle for TLS |
+| Capabilities | n/a | `NET_RAW`/`NET_ADMIN` only when the active-sweep collectors are enabled |
+
+**Footprint contract (testable):**
+
+- FP1. An edge node makes **only outbound** connections to `DPF_AUTHORITY_URL`; it opens no inbound listener. (Verified by the air-gap egress allow-list harness.)
+- FP2. An edge node persists **only** `state.json` (node token + intervals + capabilities) — no relational/graph/vector store. (Verified by the lifecycle harness + image inspection.)
+- FP3. An edge node performs **no LLM inference**. (Verified by image bill-of-materials: no model runtime, no provider keys required.)
+- FP4. The remote artifact is installable **without a monorepo clone** — a single binary or a single compose file fetched by URL. (Verified by the remote-provisioning test, §11.)
+
+The footprint is the same across archetypes; what varies per archetype is *how many* nodes and *how they are scoped* (§7), never what one node carries.
+
+---
+
+## 7. Archetype Fleet Considerations (G5)
+
+### 7.1 Base architecture — the fleet is first-class
+
+A DPF install is **one Authority Core with zero-or-more edge nodes**. The default is zero (opt-in, §5). Beyond one, the model is a **fleet**: each node is independently enrolled, scoped, trusted, and reaped; the Authority Core is the single pane for all of them. Scope is carried from the bootstrap token to the `EdgeNode` row at enrollment and enforced server-side on every path (the customer/site-binding spec). The base architecture therefore must treat "node" as plural everywhere it surfaces: the admin list groups and filters by context; discovery evidence, adapter credentials, and operational status are always scope-qualified; reaping/upgrade act per-node. This base capability is then *specialized*, not reinvented, per archetype.
+
+### 7.2 Retail — one node per location `[J]`
+
+Retail businesses (archetype `retail-goods`; persona Marisol, two stores + warehouse + online) live across **physical locations**, each its own LAN with POS terminals, payment devices, back-office PCs, Wi-Fi APs, and cameras. The natural topology is **one edge node per store/warehouse**, each scoped to that location, all reporting to one Authority Core (typically at HQ or in the cloud).
+
+- **Context dimension:** *location* (store / warehouse / HQ). For single-org retail without the MSP customer layer, the scope dimension is the **site**: model each location as a `CustomerSite`-equivalent under the org, or extend `EdgeNode` scope to carry an org-site key. (Substrate check: retail does not yet have a per-location site model wired the way MSP does — this is the retail-specific gap to file, not a base-arch change.)
+- **Why it matters:** PCI scope (cardholder-data environment) is per-store; "what's on the network at store #2" must not blur with store #1. Aligns with the CADA / sovereignty posture (location-scoped evidence).
+- **Operator UX:** "Add an edge node at a location" picks the store; the fleet view groups nodes by location; a store's network posture is one filtered view.
+
+### 7.3 MSP — one node per customer × site `[D for data model]`
+
+MSPs (archetype `it-managed-services`; first target TeamLogic IT) manage **many customers**, each with **many sites**. The customer/site-binding spec already models this precisely: a bootstrap token is bound to a `targetCustomerAccountId` (+ optional `targetCustomerSiteId`); enrollment copies that scope to the `EdgeNode`; `resolveEdgeNodeAuth` returns it; discovery runs and adapter selection are filtered by it; overlapping private IP ranges are valid under different customer/site scopes.
+
+- **Context dimension:** *customer account* → *customer site*. The deepest fleet — `customers × sites` nodes under one MSP Authority Core.
+- **What this spec adds:** the *deployment-topology* framing on top of that data model — the remote-provisioning flow (§4.2) must let the MSP pick customer + site when issuing the token; the fleet view must group by customer then site; the minimal footprint (§6) is what makes "drop a node into each customer site" operationally cheap; strict estate separation (`estateSeparation:"strict"`) is the invariant the topology must never violate.
+- **Open follow-ups already named** by the customer/site spec (selector UI, adapter targeting UI, customer-estate projection, remote-support consent) are the MSP-fleet backlog; this spec references rather than duplicates them.
+
+### 7.4 Other multi-context archetypes
+
+The same pattern serves any archetype that operates across physical contexts — property management (per building), HOA (per community), field-service trades (per yard/branch), municipalities (per facility). The base-architecture fleet concept (§7.1) covers them; each can specialize later. We call out retail and MSP because the founder did and because they bracket the two scope models (single-org-by-location vs. multi-customer-by-site).
+
+---
+
+## 8. Easy Remote Provisioning (G2) — target experience
+
+The design principle: **the operator never leaves the portal and never edits a file.** The portal holds the Authority URL and can mint a scoped token; it should therefore hand the operator a ready-to-run artifact.
+
+**Flow (proposed `[J]`):**
+
+1. `/platform/edge-nodes` → **Add a node on another machine**.
+2. Operator picks: a friendly name; the host OS (Windows / macOS / Linux); for MSP, the customer + site; for retail, the location.
+3. Portal resolves the **Authority URL reachable from elsewhere** (LAN IP / DNS / public HTTPS — not `localhost`) and warns if only a loopback URL is known.
+4. Portal issues a scoped, short-TTL bootstrap token and renders:
+   - **Default — native binary:** one command that downloads the platform-matched Go edge binary and runs its `enroll` with `--authority <url> --token <dpfboot_...>` baked in. No Docker, no repo.
+   - **Fallback — container:** one `docker compose` command using `docker-compose.edge-standalone.yml` fetched by raw URL, with `DPF_AUTHORITY_URL`/`DPF_BOOTSTRAP_TOKEN` inlined.
+   - **Air-gapped:** a link to the offline bundle path (existing air-gap runbook) with the token shown for manual transfer.
+5. The node enrolls `pending`; the portal row updates live; operator clicks **Approve**.
+
+**Why the Go binary is the default remote artifact:** it is the only path with full host-LAN fidelity on Windows/macOS (Docker Desktop cannot see the real LAN — verified, deployment-matrix spec), it needs no Docker, and it *is* the minimal footprint (§6). This makes G2 and G3 the same artifact.
+
+**Dependencies / known blockers:** release/customer installs currently can't issue a bootstrap token host-side because `issue-edge-bootstrap-token.ts` imports `@dpf/db` (EP-BUILD-D78835). The portal-side issuance in this flow goes through the running Authority (not host-side tsx), which sidesteps that blocker — but the blocker must be closed for the installer's own opt-in local path. Cross-reference, do not duplicate.
+
+---
+
+## 9. SysML Description (G4)
+
+The edge node is **not yet in the EA/SysML graph**; it is the planned Phase D "network topology bridge" of [EP-ARCH-GRAPH-LIVE] / [EP-PARITY-ENGINE]. This spec ships the **hand-authored SysML architecture note** now (architect judgment over current state) and defines how the later extractor projects live `EdgeNode` rows, so the two converge instead of competing.
+
+- **Note (now):** [`docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md`](../../architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md) — package `PKG-EDGE-TOPO`, requirements REQ-EDGE-1…10, constraint CON-EDGE-1 (footprint + outbound-only + scope-from-token), parts for Authority Core / edge agent / enrollment service / fleet registry, interfaces (`/api/v1/edge/*`), state machines (deploy gate, trust lifecycle), verification cases mapped to §11. Follows the AI-cockpit note pattern (`[D]`/`[J]`, traceability, allocations to real code).
+- **Extractor (later, Phase D):** a `buildEdgeTopologyModel(facts) → SysmlDesiredModel` extractor reads `EdgeNode`/`BootstrapToken`/`EdgeNodeCapability` and projects each node as a SysML `part_usage` with `layer="network"`, `refinementLevel="actual"`, `sysmlKey="runtime:edge-node:<nodeId>"`, allocated to the logical `PART-EDGE-agent` definition and `traces`-linked to its `prisma:model:EdgeNode` data element — exactly the cross-layer edge pattern PR #2073 established. Reuses the existing EA tables (no new EA substrate).
+
+The note is the architect's source of truth until the extractor makes it self-maintaining; the extractor is filed against EP-ARCH-GRAPH-LIVE so it lands in that program, not as a parallel effort.
+
+---
+
+## 10. Research & Benchmarking (AGENTS.md §10)
+
+Remote-agent enrollment + fleet management is a mature pattern; we benchmark the *provisioning UX* and *fleet scoping*, not feature lists.
+
+- **Tailscale** (mesh agent). *Adopted:* one-line install that bakes an auth key into the command the control plane hands you — the model for §8's copy-paste artifact; pre-authorized vs. manual-approve keys map to our auto-approve (local) vs. pending (remote) trust gate. *Rejected:* a coordination server in the data path — DPF edge is outbound-only to the Authority, no relay.
+- **NinjaOne / ConnectWise (RMM/PSA)** — already benchmarked in the customer/site-binding spec. *Adopted:* installer carries org/location target so the agent lands in the right scope; policy applies at org/location/device tiers. *Rejected:* endpoint self-asserting its organization — DPF binds scope in the authority-issued token, never the request body.
+- **NetBox tenancy** — already benchmarked there. *Adopted:* customer ownership is a first-class relation, not a metadata label. *Rejected:* assigning every shared object to a tenant — DPF keeps organization-scoped nodes for the non-MSP/base case.
+- **Prometheus node_exporter / Datadog Agent** (host agents). *Adopted:* a deliberately thin host agent with a tiny local footprint and a single config surface — validates §6 (no DB, no UI, outbound to a collector). *Rejected:* a pull model where the server scrapes the agent (inbound to the host) — DPF edge is push/outbound-only (FP1), which is what makes it safe to drop into a customer site behind NAT.
+- **HashiCorp Nomad/Consul client agents** (fleet-of-clients to one control plane). *Adopted:* the "one control plane, N thin clients, each scoped" mental model is exactly §7.1; clients hold only their own token + local state. *Rejected:* gossip between clients — DPF nodes never talk to each other, only to the Authority (smaller blast radius per FP1).
+
+**Anti-pattern identified:** shipping the *capability* (standalone compose, multi-host runbook) and calling remote deployment "supported" while the only path is a developer runbook. The benchmark across all five is that the control plane *generates the install artifact*; that is the gap §8 closes.
+
+---
+
+## 11. Data-Model Stewardship (AGENTS.md §11) & Verification (G6)
+
+### 11.1 Stewardship
+
+- **No new identity tables.** Reuse `EdgeNode`, `BootstrapToken`, `EdgeNodeCapability`; identity stays on `Principal`/`PrincipalAlias` (kernel: principal-convergence).
+- **Reuse existing scope columns** (`customerAccountId`/`customerSiteId`/`scopePolicy`) for MSP. For **retail**, prefer extending the existing site concept rather than a new "location" table — substrate-audit before any schema add (file as a retail-fleet BI; do not pre-commit a table here).
+- **`install-state.json`** gains an `edge` record (not a DB table) — the source of truth for whether *this install* runs a local node, read by both start scripts and surfaced in the portal.
+- No change to the wire contract, ingestion controls, or token namespaces.
+
+### 11.2 Verification matrix
+
+| Topology | What we test | Substrate / harness `[D where it exists]` |
+| --- | --- | --- |
+| A — co-located opt-in | Default install runs **no** edge node; opting in adds one that enrolls + (chosen) auto-trusts | extend `verify-install-edge.sh`; assert absence by default |
+| A — opt-out parity | Windows + bash agree via `install-state.json`; no hardcoded overlay | new cross-script test (CI compose-render policy check) |
+| B — remote LAN (HTTP) | Node on a second host enrolls `pending`, approves, submits real LAN IPs | `verify-install-edge.sh` + multi-host runbook §6 (exists) |
+| B — remote LAN (TLS) | Same over HTTPS with operator CA bundle | `-standalone-tls.yml` + `issue-authority-tls-cert.sh` (exists) |
+| B — easy provisioning | Portal-generated command enrolls a node **without repo clone / file edit** | new test for the §8 flow (binary + container forms) |
+| C — fleet scoping (MSP) | Two nodes under different customer/site scopes keep inventory/adapters/evidence separate | extend with customer/site-binding assertions |
+| C — fleet scoping (retail) | Two nodes under different locations keep posture separate | new, after retail site model lands |
+| Footprint FP1–FP4 | Outbound-only egress; state-only persistence; no LLM; no-clone install | `verify-edge-node-air-gap.sh` (egress) + image BoM inspection + §8 test |
+| Air-gapped | Enroll + replay across an Authority outage, drop-oldest | `verify-edge-node-air-gap.sh` (exists) |
+
+Each row maps to a verification case in the SysML note (§9). Runtime-bound rows run on the canonical install or the shared local-CI convergence sandbox (AGENTS.md §5), never a worktree harness.
+
+---
+
+## 12. Documentation Plan (G4)
+
+| Artifact | Action | Role |
+| --- | --- | --- |
+| This spec | new | Single source of truth for the topology, posture, footprint, fleet, testability |
+| SysML note (§9) | new | The architecture in SysML form |
+| `docs/edge-node/deployment-topology.md` | new | Operator-facing "front door": local-opt-in vs remote vs fleet, footprint, decision guide |
+| `deployment-contracts.md` Contract 5 | edit | Add opt-in default + minimal-footprint + fleet language to the doctrine |
+| `2026-05-22-edge-node-customer-site-binding-design.md` | edit (xref) | Add a topology cross-reference; it remains authoritative for the MSP data boundary |
+| `docs/personas/marisol-retail.md` | edit | Add the per-location edge-node consideration |
+| `docs/install/edge-node-multi-host.md` | edit (note) | Point to the easy-provisioning flow as the operator path; this runbook is the developer substrate beneath it |
+
+Every new artifact links the others (single-source-of-truth): docs → spec → SysML note → code/scripts.
+
+---
+
+## 13. Backlog & Sequencing
+
+Proposed epic **EP-EDGE-TOPOLOGY** — "Edge Node Deployment Topology: opt-in local, easy remote, fleet-per-archetype." Check overlap before creating: it is distinct from EP-ESTATE-SOVEREIGNTY (compliance posture over edge), EP-ARCH-GRAPH-LIVE (SysML/graph projection — the SysML extractor BI links *there*), and EP-ARCH-8D4F2A (archetype model — the archetype-fleet BIs may link there). 
+
+Candidate BIs:
+
+1. **Opt-in default flip + cross-surface parity** — `install-dpf.sh`/`fresh-install.ps1` default off + `--with-edge`/`-WithEdge`; both `dpf-start.ps1` + `dpf-start.sh` read `install-state.json`; grandfather migration (§5.3). `workType=feature`.
+2. **Setup + portal opt-in UX** — the setup choice and the `/platform/edge-nodes` "Add an edge node here" action (UX-fit reviewed). `workType=feature`.
+3. **Easy remote provisioning flow** — portal "Add on another machine" → copy-paste command (binary default + container fallback), Authority-side token issuance. Depends on EP-BUILD-D78835. `workType=feature`.
+4. **Minimal-footprint contract tests** — FP1–FP4 harness rows (§11). `workType=test/chore`.
+5. **Edge node SysML extractor (Phase D)** — `buildEdgeTopologyModel` → EA graph; **link to EP-ARCH-GRAPH-LIVE**. `workType=feature`.
+6. **Retail per-location fleet** — substrate-audit the retail site model; scope retail edge nodes by location; fleet-by-location view. `workType=feature` (may link EP-ARCH-8D4F2A).
+7. **Docs** — deployment-topology operator doc + Contract 5 edit + persona/runbook xrefs (this spec ships the first cut). `workType=doc`.
+
+Sequence: 7 (this PR) → 1 → 2 → 3 → 5 → 4 → 6.
+
+---
+
+## 14. Open Risks
+
+1. **Existing installs.** The default flip must grandfather running local nodes (§5.3) or it reads as "the upgrade deleted my edge node." Mitigated by the `install-state.json` record + one-time notice.
+2. **"Reachable Authority URL" is the perennial remote footgun.** The standalone compose already `${VAR:?}`-guards it; the portal flow must resolve and validate a non-loopback URL before rendering a command, or operators get nodes that can never connect.
+3. **Binary distribution + signing.** Making the Go binary the default remote artifact means a trustworthy download (checksum/signature) and platform-matched builds. Scope with the release-artifact contract (Contract 1), don't hand-roll.
+4. **Retail site model gap.** Retail lacks MSP's customer/site scoping; §7.2 is `[J]` until a site/location model is audited and (if needed) extended. Do not assume a table — file the substrate audit first.
+5. **SysML note vs. extractor drift.** The hand-authored note (§9) is correct only until the Phase D extractor lands; the note must be marked as the interim source and the extractor BI linked so it converges.
+
+---
+
+## 15. Summary
+
+The edge node is mature; its *deployment architecture* was undescribed and defaulted the wrong way. This spec makes the local node **opt-in**, defines the **easy remote provisioning** experience and the **minimal-footprint contract**, makes **"one Authority Core, a fleet of edge nodes across contexts"** a base-architecture concept specialized for **retail** (per location) and **MSP** (per customer × site), and describes the whole in **documentation, SysML, and specification** with a per-topology **verification matrix** — all on the existing substrate, no new identity tables.


### PR DESCRIPTION
## Why

Founder `/goal` (2026-06-19): the edge node is the right architecture for remote situations, but today it is **bundled and active by default**, there is **no easy way** to put it on separate hardware and connect it to the portal, and the architecture is **not described** uniformly across documentation, SysML, and specifications. Some archetypes (retail, MSPs) deploy **many** edge nodes in different contexts — a consideration missing from the archetypes and the base architecture.

A substrate sweep first established that the capability is **dense and mostly built** — `docker-compose.edge-standalone{,-tls}.yml`, `-snmp`, `.macvlan` overlays, multi-host + air-gapped runbooks, the Go native binary, and the MSP customer/site-scoped fleet data model all exist. The gaps are **posture, packaging, UX, description, and verification — not new substrate.** This PR is the description; no code/schema changes, no new tables.

## What this delivers (mapped to the goal)

| Goal | Deliverable |
| --- | --- |
| "opt-in where the platform is installed" | Spec §5 defines the deploy-gate flip (default OFF, Win/bash/macOS parity via `install-state.json`, grandfather migration), distinct from the trust gate. Doctrine Contract 5 updated. |
| "no easy way to install on separate hardware + connect" | Spec §8: portal-driven "Add a node on another machine" → one copy-paste command (native Go binary default; container fallback), token pre-bound, **no repo clone / file edit**. |
| "edge install doesn't need everything the portal has" | Spec §6: minimal-footprint **contract** (FP1–FP4: outbound-only, state-only, no LLM, no-clone) with verification rows. |
| "describe in documentation, SysML, and specifications" | **Spec** (`…topology-and-remote-provisioning-design.md`), **SysML note** (`…edge-node-deployment-sysml-architecture-note.md`, `PKG-EDGE-TOPO`), **operator doc** (`docs/edge-node/deployment-topology.md`). |
| "support and test this effectively" | Spec §11.2 + SysML §6: per-topology verification matrix mapped to existing + new harnesses. |
| "retail & MSPs deploy many edge nodes in different contexts" | Spec §7 fleet model: base-arch first-class; **retail** per location (persona updated); **MSP** per customer × site (customer-site spec xref). |

## Files
**New:** topology design spec · SysML architecture note · operator deployment-topology guide.
**Edited:** deployment-contracts Contract 5 (opt-in + footprint + fleet) · edge-node customer-site-binding spec (xref) · marisol-retail persona (per-location fleet) · multi-host runbook (pointer).

## Backlog
Epic **EP-EDGE-TOPOLOGY** + BIs: opt-in flip & parity (`BI-72CFF89D`), opt-in UX (`BI-ED6B90C0`), easy remote provisioning (`BI-D18DD7A9`), footprint tests (`BI-4B381171`), retail fleet (`BI-80F4201A`); SysML extractor (`BI-80C7B9E5`) filed under **EP-ARCH-GRAPH-LIVE** (Phase D network-topology bridge). All left at `triaging` for founder/scrum-master review.

## Status
The spec is **Draft — for review**: this PR is the review vehicle. No code changed; Spec/Plan/Doc gate satisfied by the durable-knowledge artifacts; no UI change (no UX-Fit gate). Implementation is sequenced in the BIs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
