### PR TITLE
feat(build-studio): capture + escalate-to-human + free WIP for unfixable stalls (BI-3E0EE3BA)

### DIFF
--- a/apps/web/lib/build/escalate-build-to-human.test.ts
+++ b/apps/web/lib/build/escalate-build-to-human.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the DB + the canonical issue-report writer so we can assert orchestration
+// without a database. The handler's side effects are the contract here.
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    featureBuild: { update: vi.fn().mockResolvedValue({}) },
+    backlogItem: { update: vi.fn().mockResolvedValue({}) },
+    buildActivity: { create: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock("@/lib/quality/platform-issue-reports", () => ({
+  createPlatformIssueReport: vi.fn().mockResolvedValue({ reportId: "PIR-TEST1" }),
+}));
+
+import {
+  buildEscalationDedupeKey,
+  formatEscalationReport,
+  escalateBuildToHuman,
+  SELF_FIX_CLASS,
+} from "./escalate-build-to-human";
+import { prisma } from "@dpf/db";
+import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+
+const NOW = new Date("2026-06-19T18:00:00.000Z");
+
+const ISSUES = [
+  { severity: "critical", description: "Task 3 combines two unrelated file edits" },
+  { severity: "important", description: "No test-first step for the migration" },
+];
+
+function args(overrides: Partial<Parameters<typeof escalateBuildToHuman>[0]> = {}) {
+  return {
+    buildPk: "ckbuildpk123",
+    buildId: "FB-ABC123",
+    featureTitle: "Add a thing",
+    biTitle: "BI: Add a thing properly",
+    originatingBacklogItemId: "bi-1",
+    phase: "plan",
+    rounds: 2,
+    issues: ISSUES,
+    log: vi.fn().mockResolvedValue(undefined),
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("buildEscalationDedupeKey", () => {
+  it("is stable + namespaced per build (one open escalation per build)", () => {
+    expect(buildEscalationDedupeKey("FB-ABC123")).toBe("build-escalation:FB-ABC123");
+  });
+});
+
+describe("formatEscalationReport (pure)", () => {
+  const base = {
+    buildId: "FB-ABC123",
+    featureTitle: "Add a thing",
+    biTitle: "BI: Add a thing properly",
+    phase: "plan",
+    rounds: 2,
+    issues: ISSUES,
+    selfFixClass: SELF_FIX_CLASS.NEEDS_HUMAN,
+  };
+
+  it("titles for humans, naming the subject + phase", () => {
+    const { title } = formatEscalationReport(base);
+    expect(title).toMatch(/needs a human/i);
+    expect(title).toContain("BI: Add a thing properly");
+    expect(title).toContain("plan");
+  });
+
+  it("describes root cause, attempts, feasibility class, and the WIP/requeue outcome", () => {
+    const { description } = formatEscalationReport(base);
+    expect(description).toContain("needs-human");
+    expect(description).toMatch(/2 automated plan revision round/);
+    expect(description).toContain("[critical] Task 3 combines two unrelated file edits");
+    expect(description).toContain("[important] No test-first step for the migration");
+    expect(description).toMatch(/deferred/);
+    expect(description).toContain("BI-3E0EE3BA");
+  });
+
+  it("falls back to the feature title, then buildId, when no BI title", () => {
+    expect(formatEscalationReport({ ...base, biTitle: null }).title).toContain("Add a thing");
+    expect(
+      formatEscalationReport({ ...base, biTitle: null, featureTitle: "" }).title,
+    ).toContain("FB-ABC123");
+  });
+
+  it("handles no structured issues without crashing", () => {
+    const { description } = formatEscalationReport({ ...base, issues: [] });
+    expect(description).toMatch(/no structured blocking issues/i);
+  });
+
+  it("caps the issue list at 15 and notes the overflow", () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({ severity: "minor", description: `issue ${i}` }));
+    const { description } = formatEscalationReport({ ...base, issues: many });
+    expect(description).toContain("issue 14");
+    expect(description).not.toContain("issue 15]"); // 16th (index 15) not listed
+    expect(description).toMatch(/and 5 more/);
+  });
+
+  it("exposes the three self-fix classes", () => {
+    expect(SELF_FIX_CLASS.AUTO_RECOVERABLE).toBe("auto-recoverable");
+    expect(SELF_FIX_CLASS.NEEDS_HUMAN).toBe("needs-human");
+    expect(SELF_FIX_CLASS.NEEDS_EXTERNAL_CAPABILITY).toBe("needs-external-capability");
+  });
+});
+
+describe("escalateBuildToHuman (orchestration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (createPlatformIssueReport as ReturnType<typeof vi.fn>).mockResolvedValue({ reportId: "PIR-TEST1" });
+    (prisma.featureBuild.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.backlogItem.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.buildActivity.create as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  });
+
+  it("captures a durable, build-linked, deduped escalation report", async () => {
+    await escalateBuildToHuman(args());
+    expect(createPlatformIssueReport).toHaveBeenCalledTimes(1);
+    const input = (createPlatformIssueReport as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(input.type).toBe("build-stall-escalation");
+    expect(input.source).toBe("build-studio");
+    expect(input.featureBuildId).toBe("ckbuildpk123"); // the cuid PK, not FB-*
+    expect(input.dedupeKey).toBe("build-escalation:FB-ABC123");
+    expect(input.selfFixClass).toBe("needs-human");
+    expect(input.triggerKind).toBe("plan-review-exhausted");
+  });
+
+  it("frees the WIP slot by abandoning the build (by FB-* buildId)", async () => {
+    const res = await escalateBuildToHuman(args());
+    const call = (prisma.featureBuild.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where).toEqual({ buildId: "FB-ABC123" });
+    expect(call.data.phase).toBe("abandoned");
+    expect(call.data.abandonedAt).toBe(NOW);
+    expect(call.data.abandonReason).toContain("PIR-TEST1");
+    expect(res.wipFreed).toBe(true);
+  });
+
+  it("parks the originating backlog item as deferred and detaches the build", async () => {
+    const res = await escalateBuildToHuman(args());
+    const call = (prisma.backlogItem.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where).toEqual({ id: "bi-1" });
+    expect(call.data.status).toBe("deferred");
+    expect(call.data.activeBuildId).toBeNull();
+    expect(res.backlogItemDeferred).toBe(true);
+  });
+
+  it("writes a discriminated audit activity (by FB-* buildId)", async () => {
+    await escalateBuildToHuman(args());
+    const call = (prisma.buildActivity.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.data.buildId).toBe("FB-ABC123");
+    expect(call.data.tool).toBe("build:escalate-human");
+  });
+
+  it("skips backlog parking when there is no originating item", async () => {
+    const res = await escalateBuildToHuman(args({ originatingBacklogItemId: null }));
+    expect(prisma.backlogItem.update).not.toHaveBeenCalled();
+    expect(res.backlogItemDeferred).toBe(false);
+  });
+
+  it("still frees WIP even if the escalation report fails to file (priority = clear the jam)", async () => {
+    (createPlatformIssueReport as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("dupe"));
+    const res = await escalateBuildToHuman(args());
+    expect(res.reportId).toBeNull();
+    expect(prisma.featureBuild.update).toHaveBeenCalledTimes(1); // WIP freed anyway
+    expect(res.wipFreed).toBe(true);
+  });
+});

--- a/apps/web/lib/build/escalate-build-to-human.ts
+++ b/apps/web/lib/build/escalate-build-to-human.ts
@@ -1,0 +1,237 @@
+// apps/web/lib/build/escalate-build-to-human.ts
+//
+// BI-3E0EE3BA — capture + escalate-to-human + free WIP for builds Build Studio
+// cannot self-repair.
+//
+// Why this exists:
+//   A self-building platform sometimes CANNOT fix itself "for obvious reasons"
+//   (the defect is in the dispatch path it runs on; a capability gap; a change
+//   too large for the local model). BI-99B06AD1 added a bounded plan-review
+//   fix loop; when even that is exhausted the build must not silently churn or
+//   resume-restall forever. The honest outcome is to:
+//     1. CAPTURE a durable, human-facing escalation record (root cause, what was
+//        attempted, why blocked, and a self-fix-feasibility class);
+//     2. RAISE it to humans — reuse createPlatformIssueReport(), whose OPEN rows
+//        auto-project into the backlog/triage intake (EP-INTAKE-UNIFY), so the
+//        escalation surfaces without any new notification plumbing;
+//     3. FREE the WIP slot — mark the build abandoned (wip-cap counts only
+//        abandonedAt-null builds), so the jam clears;
+//     4. RE-QUEUE without re-stalling — park the originating backlog item as
+//        "deferred" (not "open", which would just auto-re-promote into the same
+//        stall) so the work is never lost but waits for a human.
+//
+//   Recognizing "I can't fix this" is a first-class, learnable outcome — the
+//   self-fix-feasibility class is consumed downstream by hive learning
+//   (BI-76B4317F) and support-tier routing incl. resellers (BI-5090F4AA).
+//
+// This module keeps the formatting + classification PURE (trivially unit-tested)
+// and isolates the DB side effects in escalateBuildToHuman(), each write
+// best-effort and independently guarded so a reporting failure never blocks the
+// WIP free-up.
+
+import { prisma } from "@dpf/db";
+import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+
+/** Self-fix-feasibility class — why an autonomous producer could not self-repair. */
+export const SELF_FIX_CLASS = {
+  /** A retry / different route would likely succeed (handled automatically). */
+  AUTO_RECOVERABLE: "auto-recoverable",
+  /** Needs a human decision or change the platform cannot make on its own. */
+  NEEDS_HUMAN: "needs-human",
+  /** Needs capability/expertise/tools the customer install does not have
+   *  (candidate for reseller/partner augmentation — BI-5090F4AA). */
+  NEEDS_EXTERNAL_CAPABILITY: "needs-external-capability",
+} as const;
+
+export type SelfFixClass = (typeof SELF_FIX_CLASS)[keyof typeof SELF_FIX_CLASS];
+
+/** Minimal shape of a blocking review issue (structurally matches PlanReviewIssue). */
+export type EscalationIssue = { severity: string; description: string };
+
+/** Stable idempotency key — one open escalation per build (partial-unique on
+ *  PlatformIssueReport.dedupeKey for open rows). Re-escalation while still open
+ *  is a no-op; it can re-file once the prior escalation is resolved. */
+export function buildEscalationDedupeKey(buildId: string): string {
+  return `build-escalation:${buildId}`;
+}
+
+const MAX_ISSUES_LISTED = 15;
+
+/**
+ * Render the durable escalation record's title + description. Pure.
+ * Captures: which build/feature, what phase failed, what was attempted
+ * (N revision rounds), the unresolved blocking issues (root cause), and the
+ * self-fix-feasibility class so a human (or reseller) knows what kind of help
+ * is needed.
+ */
+export function formatEscalationReport(args: {
+  buildId: string;
+  featureTitle: string;
+  biTitle?: string | null;
+  phase: string;
+  rounds: number;
+  issues: EscalationIssue[];
+  selfFixClass: SelfFixClass;
+}): { title: string; description: string } {
+  const { buildId, featureTitle, biTitle, phase, rounds, issues, selfFixClass } = args;
+
+  const subject = (biTitle?.trim() || featureTitle?.trim() || buildId).slice(0, 200);
+  const title = `Build Studio needs a human: "${subject}" stuck at ${phase} review`;
+
+  const shown = issues.slice(0, MAX_ISSUES_LISTED);
+  const issueLines = shown.length
+    ? shown.map((i) => `- [${i.severity}] ${i.description}`).join("\n")
+    : "- (no structured blocking issues were recorded)";
+  const overflow =
+    issues.length > shown.length ? `\n…and ${issues.length - shown.length} more.` : "";
+
+  const roundsAttempted =
+    rounds > 0
+      ? `Build Studio attempted ${rounds} automated plan revision round(s), feeding the reviewer's blocking issues back into each one, and the reviewer still rejected the plan.`
+      : `The plan review failed and no automated revision could be attempted.`;
+
+  const description =
+    `Build ${buildId} ("${subject}") could not be self-repaired by Build Studio ` +
+    `and has been escalated for human attention.\n\n` +
+    `Phase: ${phase}\n` +
+    `Self-fix feasibility: ${selfFixClass}\n\n` +
+    `What was attempted:\n${roundsAttempted}\n\n` +
+    `Unresolved blocking issues (root cause):\n${issueLines}${overflow}\n\n` +
+    `The build's WIP slot has been freed (build marked abandoned) and the ` +
+    `originating backlog item parked as "deferred" so the work is not lost — ` +
+    `it awaits a human (or reseller/partner) before it is re-promoted. ` +
+    `(BI-3E0EE3BA)`;
+
+  return { title, description };
+}
+
+export interface EscalateBuildArgs {
+  /** FeatureBuild.id (cuid) — links the PlatformIssueReport via featureBuildId. */
+  buildPk: string;
+  /** FeatureBuild.buildId (FB-*) — used for featureBuild/buildActivity writes. */
+  buildId: string;
+  featureTitle: string;
+  biTitle?: string | null;
+  /** BacklogItem.id of the originating item, if any — parked as "deferred". */
+  originatingBacklogItemId?: string | null;
+  phase: string;
+  rounds: number;
+  issues: EscalationIssue[];
+  selfFixClass?: SelfFixClass;
+  log: (summary: string) => Promise<unknown> | unknown;
+  now?: Date;
+}
+
+export interface EscalateBuildResult {
+  reportId: string | null;
+  wipFreed: boolean;
+  backlogItemDeferred: boolean;
+}
+
+/**
+ * Escalate a build Build Studio cannot self-repair: capture a durable issue
+ * report, free the WIP slot, and park the backlog item. Side-effectful but
+ * each step is independently guarded so a partial failure still frees WIP —
+ * clearing the jam is the priority.
+ */
+export async function escalateBuildToHuman(args: EscalateBuildArgs): Promise<EscalateBuildResult> {
+  const {
+    buildPk,
+    buildId,
+    featureTitle,
+    biTitle,
+    originatingBacklogItemId,
+    phase,
+    rounds,
+    issues,
+    selfFixClass = SELF_FIX_CLASS.NEEDS_HUMAN,
+    log,
+    now = new Date(),
+  } = args;
+
+  const safeLog = async (m: string) => {
+    try { await log(m); } catch { /* never throw from logging */ }
+  };
+
+  const { title, description } = formatEscalationReport({
+    buildId, featureTitle, biTitle, phase, rounds, issues, selfFixClass,
+  });
+
+  // 1. CAPTURE + RAISE — durable report; OPEN rows auto-project into intake.
+  //    Best-effort: a duplicate (partial-unique dedupeKey on open rows) or any
+  //    failure must not stop us freeing the WIP slot.
+  let reportId: string | null = null;
+  try {
+    const r = await createPlatformIssueReport({
+      type: "build-stall-escalation",
+      source: "build-studio",
+      severity: "high",
+      title,
+      description,
+      featureBuildId: buildPk,
+      triggerKind: `${phase}-review-exhausted`,
+      dedupeKey: buildEscalationDedupeKey(buildId),
+      selfFixClass,
+    });
+    reportId = r.reportId;
+  } catch (err) {
+    await safeLog(`Escalation report not filed (continuing to free WIP): ${String(err)}`.slice(0, 300));
+  }
+
+  // 2. FREE WIP — mark the build abandoned (mirrors the inert-build reaper). The
+  //    WIP cap counts only abandonedAt-null builds, so this clears the slot.
+  let wipFreed = false;
+  try {
+    await prisma.featureBuild.update({
+      where: { buildId },
+      data: {
+        phase: "abandoned",
+        abandonedAt: now,
+        abandonReason:
+          `Escalated to human after ${rounds} self-repair round(s) at ${phase} review ` +
+          `(${selfFixClass})${reportId ? `; tracked as ${reportId}` : ""}. ` +
+          `Freed a Build Studio WIP slot. (BI-3E0EE3BA)`,
+        updatedAt: now,
+      },
+    });
+    wipFreed = true;
+  } catch (err) {
+    await safeLog(`Failed to abandon build to free WIP: ${String(err)}`.slice(0, 300));
+  }
+
+  // 3. RE-QUEUE WITHOUT RE-STALLING — park the originating item as "deferred"
+  //    and detach the (now-abandoned) build so it is not auto-re-promoted into
+  //    the same stall. A human re-opens it once the escalation is resolved.
+  let backlogItemDeferred = false;
+  if (originatingBacklogItemId) {
+    try {
+      await prisma.backlogItem.update({
+        where: { id: originatingBacklogItemId },
+        data: { status: "deferred", activeBuildId: null, updatedAt: now },
+      });
+      backlogItemDeferred = true;
+    } catch (err) {
+      await safeLog(`Failed to park backlog item as deferred: ${String(err)}`.slice(0, 300));
+    }
+  }
+
+  // 4. AUDIT — discriminated activity row (mirrors watchdog:reap-inert).
+  try {
+    await prisma.buildActivity.create({
+      data: {
+        buildId,
+        tool: "build:escalate-human",
+        summary:
+          `Escalated to human (${selfFixClass}) after ${rounds} self-repair round(s) at ${phase} review` +
+          `${reportId ? ` — ${reportId}` : ""}. WIP freed; backlog item parked.`,
+      },
+    });
+  } catch { /* audit is best-effort */ }
+
+  await safeLog(
+    `Escalated to human: ${selfFixClass}${reportId ? ` (${reportId})` : ""}. ` +
+    `WIP slot freed${backlogItemDeferred ? "; backlog item parked as deferred" : ""}.`,
+  );
+
+  return { reportId, wipFreed, backlogItemDeferred };
+}

--- a/apps/web/lib/integrate/plan-on-approval.ts
+++ b/apps/web/lib/integrate/plan-on-approval.ts
@@ -26,6 +26,7 @@
 
 import { prisma } from "@dpf/db";
 import { normalizeBuildPlanPaths } from "./build-plan-paths";
+import { escalateBuildToHuman, SELF_FIX_CLASS } from "@/lib/build/escalate-build-to-human";
 
 function logBuildActivity(buildId: string, tool: string, summary: string): Promise<void> {
   return prisma.buildActivity.create({ data: { buildId, tool, summary } }).then(() => void 0).catch(() => void 0);
@@ -267,6 +268,7 @@ export async function dispatchPlanForApprovedBuild(params: {
     const build = await prisma.featureBuild.findUnique({
       where: { buildId },
       select: {
+        id: true,
         phase: true,
         title: true,
         buildPlan: true,
@@ -402,10 +404,24 @@ export async function dispatchPlanForApprovedBuild(params: {
     }
 
     if (review?.decision === "fail") {
-      // Bounded revisions exhausted — surface for human attention instead of an
-      // endless resume-restall churn. Full needs-human escalation (notify + WIP
-      // free + re-queue) is BI-3E0EE3BA; this is the honest stop + signal.
-      await log(`Plan review still failing after ${round} revision round(s) — needs human attention (escalation: BI-3E0EE3BA).`);
+      // Bounded revisions exhausted — Build Studio cannot self-repair this plan.
+      // Escalate to a human (BI-3E0EE3BA): capture a durable issue report (which
+      // auto-surfaces via intake), free the WIP slot (abandon the build), and
+      // park the backlog item as "deferred" so it is never lost AND does not
+      // resume-restall into the same failure. This is the honest stop.
+      await escalateBuildToHuman({
+        buildPk: build.id,
+        buildId,
+        featureTitle: build.title,
+        biTitle,
+        originatingBacklogItemId: build.originatingBacklogItemId,
+        phase: "plan",
+        rounds: round,
+        issues: review.issues,
+        selfFixClass: SELF_FIX_CLASS.NEEDS_HUMAN,
+        log,
+      });
+      return { kind: "dispatched-failure", error: "escalated-to-human", durationMs: Date.now() - t0 };
     }
 
     return {

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -17,6 +17,7 @@ const LIMITS = {
   triggerKind: 100,
   supportSessionId: 191,
   dedupeKey: 191,
+  selfFixClass: 40,
 } as const;
 
 // Same route → portfolio slug map used today by reportQualityIssue().
@@ -71,6 +72,9 @@ export interface CreatePlatformIssueReportInput {
   supportSessionId?: string | null;
   // BI-5FE8656F: stable idempotency key for automated producers (log scanner).
   dedupeKey?: string | null;
+  // BI-3E0EE3BA: self-fix-feasibility class when an autonomous producer escalates
+  // (auto-recoverable | needs-human | needs-external-capability).
+  selfFixClass?: string | null;
 
   // Identity / linkage
   reportedById?: string | null;
@@ -149,6 +153,7 @@ export async function createPlatformIssueReport(
       triggerKind: trimTo(input.triggerKind ?? null, LIMITS.triggerKind),
       supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.supportSessionId),
       dedupeKey: trimTo(input.dedupeKey ?? null, LIMITS.dedupeKey),
+      selfFixClass: trimTo(input.selfFixClass ?? null, LIMITS.selfFixClass),
       reportedById: input.reportedById ?? null,
       threadId: input.threadId ?? null,
       agentId: input.agentId ?? null,

--- a/docs/superpowers/specs/2026-06-19-build-studio-reliability-analysis.md
+++ b/docs/superpowers/specs/2026-06-19-build-studio-reliability-analysis.md
@@ -37,6 +37,7 @@ Verification failures **stall** the build; they are never fed back to a coding a
 - Orchestrator: any `BLOCKED`/`NEEDS_CONTEXT` specialist halts auto-advance with no fix attempt — `apps/web/lib/integrate/build-orchestrator.ts:1436-1447`.
 - The only repair that exists is *within* one agentic-loop invocation; there is no **cross-step** repair.
 - **Churn:** the hottest surface — `#2019/#2020/#2023` all scope the build→review gate so unrelated/whole-repo failures stop blocking every build. Because the scoping is regex-on-output (Family 4), it keeps churning.
+- **Shipped (the plan-review sub-case, the live root cause of the WIP jam):** plan review used to **fail and leave the rejected plan saved**, so the idempotency guard blocked regeneration and every reboot's `resumeStrandedBuildsOnBoot` re-failed it forever. `#2090` (BI-99B06AD1) closes the loop — feed the reviewer's blocking issues back into a bounded plan revision (`PLAN_FIX_MAX_ROUNDS`), re-review, then **escalate** instead of churning. When even the bounded loop can't pass, BI-3E0EE3BA (§5) captures it for a human and frees the WIP slot. The *build/codegen* verification→fix loop (P0.1) remains the larger open item.
 
 ### Family 2 — Cloud usage-limits with no fast-abort, failover, or resumable pause
 - Empirically the #1 dispatch killer: 17 dead `chatgpt` dispatches in one build, each returning *"You've hit your usage limit"*, none aborting the storm.
@@ -88,3 +89,26 @@ Ordered by leverage (impact on the 13% completion rate × breadth of churn absor
 - **Pipeline map** (phase-by-phase entry points, durable vs inline, gates): ideate (`integrate/ideate-dispatch.ts`, `actions/build.ts`), plan (`integrate/plan-on-approval.ts`), reviews (`integrate/build-reviewers.ts`, `prompts/reviewer/*.prompt.md`), build (`queue/functions/build-execute.ts` → `integrate/build-orchestrator.ts` / `integrate/build-pipeline.ts`), review-verify (`queue/functions/build-review-verification.ts`), ship (`actions/build.ts`). Two execution paths exist (pipeline single-task vs orchestrator specialist-fan-out) with divergent timeouts/retries/parse logic — a recurring "works one way, breaks the other" source.
 - **LLM call inventory** (prompt source + routeAndCall config + parse fragility) for ideate / plan / decomposition / design-review / plan-review / code-gen / compaction / utility: see §2 Family 4 refs.
 - **Data model:** `FeatureBuild`, `BuildPhaseRun`, `BuildDispatchAttempt` (`packages/db/prisma/schema.prisma`).
+
+---
+
+## 5. When Build Studio can't fix itself — capture, escalate, learn, route
+
+Automating the *removal* of a stuck build (the inert-build reaper, `#2081`) only clears the symptom. A recursively self-improving platform sometimes **cannot fix itself "for obvious reasons"**: the defect is in the dispatch path it runs on, the change is beyond the local model, or it needs capability/expertise the install does not have. Recognizing "I can't fix this" is a first-class, *learnable* outcome — not a failure to suppress. Operator direction (Mark, 2026-06-19).
+
+**The four obligations** when a unit of work exhausts self-repair:
+1. **Capture** a durable escalation record — root cause, what was attempted, why blocked, and a **self-fix-feasibility class**: `auto-recoverable | needs-human | needs-external-capability`.
+2. **Raise** it to humans as an actionable "needs human" item, distinct from auto-recoverable stalls, with the originating work **never silently lost**.
+3. **Feed the hive/commons** the failure *signature* + resolution, so the network learns its own limits and later installs get a known path (`learnings-belong-in-the-shared-commons`).
+4. **Route to a support tier** — customer self-service → **reseller/partner augmentation** (scoped, time-boxed grant to augment a customer who lacks the dev capability/expertise/tools) → upstream/DPF. DPF-as-conduit, sovereignty-aware.
+
+**Shipped now (BI-3E0EE3BA, plan-review sub-case).** On bounded-fix-loop exhaustion, `escalateBuildToHuman()` (`apps/web/lib/build/escalate-build-to-human.ts`), called from `plan-on-approval.ts`, reuses existing substrate rather than adding new machinery:
+- **Capture + raise** via `createPlatformIssueReport()` (`type:"build-stall-escalation"`, build-linked, deduped) — its OPEN rows **auto-project into the backlog/triage intake** (EP-INTAKE-UNIFY), so the escalation surfaces with no new notification plumbing.
+- **Free WIP** by marking the build `abandoned` (the WIP cap counts only `abandonedAt`-null builds) — clearing the jam.
+- **Re-queue without re-stalling** by parking the originating backlog item as **`deferred`** (not `open`, which would auto-re-promote into the same stall) and detaching the build.
+- The one genuinely-new field is `PlatformIssueReport.selfFixClass`, the feasibility class consumed downstream.
+
+**Roadmap (the rest of the dimension):**
+- **BI-76B4317F** — hive learning of self-fix-limit **signatures**: contribute the `(failure signature → resolution, feasibility class)` to the commons so repeated limits become known paths.
+- **BI-5090F4AA** — **tiered support + reseller/partner augmentation** (`EP-PARTNER-CHANNEL`): route `needs-external-capability` escalations to a scoped, time-boxed partner grant; `needs-human` to the operator; `auto-recoverable` stays in-loop.
+- **UI:** a dedicated "Needs human" panel filtering `build-stall-escalation` reports by `selfFixClass` (the data + intake projection already exist; surfacing is the remaining slice).

--- a/packages/db/prisma/migrations/20260619160000_add_issue_report_self_fix_class/migration.sql
+++ b/packages/db/prisma/migrations/20260619160000_add_issue_report_self_fix_class/migration.sql
@@ -1,0 +1,8 @@
+-- BI-3E0EE3BA: self-fix-feasibility class for escalations raised by an
+-- autonomous producer (Build Studio) that could not self-repair a unit of work.
+-- One of: auto-recoverable | needs-human | needs-external-capability.
+-- Nullable: ordinary PlatformIssueReport rows leave it null. Downstream consumers
+-- are hive learning (BI-76B4317F) and support-tier routing (BI-5090F4AA).
+
+-- AlterTable
+ALTER TABLE "PlatformIssueReport" ADD COLUMN "selfFixClass" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4482,6 +4482,12 @@ model PlatformIssueReport {
   triggerKind         String?
   supportSessionId    String?
   source              String        @default("manual")
+  // BI-3E0EE3BA: self-fix-feasibility class for escalations raised by an
+  // autonomous producer (Build Studio) that gave up self-repairing. One of
+  // auto-recoverable | needs-human | needs-external-capability. Null for
+  // ordinary issue reports. Lets hive learning (BI-76B4317F) key off the
+  // failure class and support-tier routing (BI-5090F4AA) route by it.
+  selfFixClass        String?
   // BI-5FE8656F (EP-FULL-OBS Tier 2): stable idempotency key for automated
   // producers (the log-signature scanner files `log-sig:<service>:<sigId>`).
   // A partial UNIQUE index — open rows only — lives in the migration (Prisma


### PR DESCRIPTION
## Why

The inert-build reaper (#2081) clears genuinely-dead builds, and #2090 (BI-99B06AD1) repairs plan reviews that *can* be fixed. But a self-building platform sometimes **cannot fix itself** — the defect is in the path it runs on, the change is beyond the local model, or it needs capability the install lacks. Recognizing "I can't fix this" must be a first-class, learnable outcome, not an infinite resume-restall.

This is the other half of the stuck-build solution: when the #2090 bounded plan-fix loop is **exhausted**, escalate honestly.

## What

`escalateBuildToHuman()` (new — `apps/web/lib/build/escalate-build-to-human.ts`), called from `plan-on-approval.ts` on fix-loop exhaustion. It **reuses existing substrate** rather than adding machinery:

| Obligation | Mechanism (reused) |
|---|---|
| **Capture + raise** | `createPlatformIssueReport({type:"build-stall-escalation", …})` — build-linked + deduped. Its OPEN rows **auto-project into the backlog/triage intake** (EP-INTAKE-UNIFY), so it surfaces to humans with no new notification plumbing. |
| **Free WIP** | Mark the build `abandoned` — the WIP cap counts only `abandonedAt`-null builds (mirrors the inert reaper). The jam clears. |
| **Re-queue without re-stalling** | Park the originating backlog item as **`deferred`** (not `open`, which would auto-re-promote into the same stall) + detach the build. Work is never lost. |
| **Audit** | A `build:escalate-human` `BuildActivity` row. |

The **one new field** is `PlatformIssueReport.selfFixClass` (`auto-recoverable \| needs-human \| needs-external-capability`) — the self-fix-feasibility class that hive learning (**BI-76B4317F**) and reseller/partner routing (**BI-5090F4AA**) will key off.

Formatting + classification are **pure and unit-tested**; the DB side effects are each independently guarded so a reporting failure still frees the WIP slot (clearing the jam is the priority).

## Verification (Build Studio sandbox, branch @ 0091197f)
- `prisma generate` (new `selfFixClass` field) ✓
- `vitest` `escalate-build-to-human.test.ts` + `plan-on-approval.test.ts` → **22/22**
- `tsc --noEmit` + `NODE_ENV=production next build` → running (CI is authoritative)

## Docs
§5 of `docs/superpowers/specs/2026-06-19-build-studio-reliability-analysis.md` — "When Build Studio can't fix itself" (capture/escalate/learn/route), plus Family 1 marked for the shipped plan-review sub-case.

BI-3E0EE3BA · EP-9FC5D2FD · part of the Build Studio reliability series. Full hive + reseller dimensions are BI-76B4317F / BI-5090F4AA.