### PR TITLE
feat(build-studio): per-build worktree isolation primitives (BI-98B723C0 Phase 2 slice 1)

### DIFF
--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -11,6 +11,10 @@ import {
   buildSandboxCommitInFlightWorkCommand,
   buildSandboxGitCommitPrunedArtifactsCommand,
   buildSandboxGitPruneTrackedArtifactsCommand,
+  buildWorktreePath,
+  buildSandboxWorktreeAddCommand,
+  buildSandboxWorktreeRemoveCommand,
+  BUILD_WORKTREE_ROOT_SEGMENT,
   getClientIdentity,
   wrapSandboxGitCommand,
 } from "./build-branch";
@@ -104,6 +108,52 @@ describe("wrapSandboxGitCommand", () => {
     expect(command).toContain("if ! git diff --cached --quiet --exit-code; then git commit -m 'chore: untrack sandbox generated artifacts'; fi");
     expect(command).toContain(".next");
     expect(command).toContain("node_modules");
+  });
+});
+
+// ─── Per-build worktree primitives (BI-98B723C0 Phase 2) ─────────────────────
+
+describe("per-build worktree primitives (BI-98B723C0 Phase 2)", () => {
+  it("derives a per-build worktree path under the .builds root", () => {
+    expect(BUILD_WORKTREE_ROOT_SEGMENT).toBe(".builds");
+    expect(buildWorktreePath("FB-ABCD1234")).toBe("/workspace/.builds/FB-ABCD1234");
+    // honors a non-default workspace so the path can be threaded per dispatcher
+    expect(buildWorktreePath("FB-ABCD1234", "/ws")).toBe("/ws/.builds/FB-ABCD1234");
+  });
+
+  it("creates an isolated worktree on the build branch with shared node_modules symlinks", () => {
+    const cmd = buildSandboxWorktreeAddCommand("FB-ABCD1234", "build/FB-ABCD1234");
+    // idempotent: clears any stale worktree first, then prunes the registry
+    expect(cmd).toContain(
+      "git worktree remove --force /workspace/.builds/FB-ABCD1234 2>/dev/null || true",
+    );
+    expect(cmd).toContain("git worktree prune");
+    // attaches the build branch into the worktree
+    expect(cmd).toContain(
+      "git worktree add --force /workspace/.builds/FB-ABCD1234 build/FB-ABCD1234",
+    );
+    // node_modules shared by symlink — NOT reinstalled (verified live in dpf-sandbox-1)
+    expect(cmd).toContain(
+      "ln -s /workspace/node_modules /workspace/.builds/FB-ABCD1234/node_modules",
+    );
+    expect(cmd).toContain(
+      "ln -s /workspace/apps/web/node_modules /workspace/.builds/FB-ABCD1234/apps/web/node_modules",
+    );
+    expect(cmd).toContain(
+      "ln -s /workspace/packages/db/node_modules /workspace/.builds/FB-ABCD1234/packages/db/node_modules",
+    );
+    // never runs an install in the worktree — the symlinks are the whole point
+    expect(cmd).not.toContain("pnpm install");
+  });
+
+  it("tears down a build's worktree best-effort without touching the shared install", () => {
+    const cmd = buildSandboxWorktreeRemoveCommand("FB-ABCD1234");
+    expect(cmd).toContain(
+      "git worktree remove --force /workspace/.builds/FB-ABCD1234 2>/dev/null || true",
+    );
+    expect(cmd).toContain("git worktree prune");
+    // teardown must not rm -rf anything — node_modules are symlinks, removal is git's job
+    expect(cmd).not.toContain("rm -rf");
   });
 });
 

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -109,6 +109,90 @@ export function buildSandboxCommitInFlightWorkCommand(workspace: string = WORKSP
   ].join(" && ");
 }
 
+// ─── Phase 2: per-build worktree isolation (BI-98B723C0) ─────────────────────
+// commitInFlightWork above is the Phase 1 *mitigation* — it preserves a build's
+// source before the shared /workspace tree is scrubbed for the next build. The
+// durable fix is to stop sharing one tree at all: give each build its OWN git
+// worktree under /workspace/.builds/<buildId> so a concurrent build's branch
+// switch can never scrub or corrupt another build's working tree (the root
+// cause of the data loss — the WWMD kernel chose this over a serial-rebuild
+// shortcut on Architecture-Over-Shortcuts grounds).
+//
+// node_modules is NOT reinstalled per worktree — it is shared from the canonical
+// /workspace install by symlink. Verified live in dpf-sandbox-1 (2026-06-19):
+// with the symlinks below, `tsc`, `react`, and `next` all resolve from the
+// worktree, so a per-build worktree needs no `pnpm install` of its own.
+//
+// These are the lifecycle PRIMITIVES (slice 1). Wiring them into
+// startBuildBranch + threading the per-build workdir through the dispatchers is
+// the follow-up slice; until then nothing calls these, so behaviour is
+// unchanged.
+
+/** Root under which each build's isolated worktree lives. */
+export const BUILD_WORKTREE_ROOT_SEGMENT = ".builds";
+
+/** Absolute path of a build's isolated git worktree inside the sandbox. */
+export function buildWorktreePath(buildId: string, workspace: string = WORKSPACE): string {
+  return `${workspace}/${BUILD_WORKTREE_ROOT_SEGMENT}/${buildId}`;
+}
+
+// node_modules trees shared from the canonical install into each worktree by
+// symlink: the repo root plus the web app and the workspace packages whose
+// node_modules the build/typecheck toolchain resolves through. Adding a new
+// package that a build must compile against means adding its node_modules here.
+const WORKTREE_SHARED_NODE_MODULES = [
+  "node_modules",
+  "apps/web/node_modules",
+  "packages/db/node_modules",
+  "packages/dpf-skill-pack/node_modules",
+  "packages/dpf-bootstrap/node_modules",
+] as const;
+
+/**
+ * Create a build's isolated worktree at buildWorktreePath(buildId), checked out
+ * to `branchRef` (its `build/<buildId>` branch), with node_modules shared from
+ * the canonical /workspace install via symlink — no per-worktree `pnpm install`.
+ * Idempotent: force-removes any stale worktree at the path and prunes the
+ * registry first, so a re-dispatch never trips on a leftover worktree. The
+ * `--force` on `worktree add` lets the same branch be (re)attached after a prior
+ * crash left the registry pointing at a now-gone path.
+ */
+export function buildSandboxWorktreeAddCommand(
+  buildId: string,
+  branchRef: string,
+  workspace: string = WORKSPACE,
+): string {
+  const path = buildWorktreePath(buildId, workspace);
+  const symlinks = WORKTREE_SHARED_NODE_MODULES.map(
+    (rel) => `ln -s ${workspace}/${rel} ${path}/${rel}`,
+  ).join(" && ");
+  return [
+    `cd ${workspace}`,
+    `git worktree remove --force ${path} 2>/dev/null || true`,
+    `git worktree prune`,
+    `git worktree add --force ${path} ${branchRef}`,
+    symlinks,
+  ].join(" && ");
+}
+
+/**
+ * Tear down a build's worktree and prune the registry. Best-effort
+ * (`|| true`) so cleanup of an already-gone worktree never fails a build's
+ * teardown. The symlinked node_modules are not real files, so removing the
+ * worktree never touches the shared install.
+ */
+export function buildSandboxWorktreeRemoveCommand(
+  buildId: string,
+  workspace: string = WORKSPACE,
+): string {
+  const path = buildWorktreePath(buildId, workspace);
+  return [
+    `cd ${workspace}`,
+    `git worktree remove --force ${path} 2>/dev/null || true`,
+    `git worktree prune`,
+  ].join(" && ");
+}
+
 export function buildSandboxGitPruneTrackedArtifactsCommand(): string {
   const cacheFindExpr = SANDBOX_TRACKED_CACHE_FIND_PATHS
     .map((pattern) => `-path '${pattern}'`)


### PR DESCRIPTION
## What

Phase 2 slice 1 of BI-98B723C0: the lifecycle **primitives** for per-build git worktrees.

- `buildWorktreePath(buildId)` → `/workspace/.builds/<buildId>`
- `buildSandboxWorktreeAddCommand(buildId, branchRef)` — create the worktree on the build branch + share `node_modules` from the canonical install by **symlink** (no per-worktree `pnpm install`)
- `buildSandboxWorktreeRemoveCommand(buildId)` — best-effort teardown + prune

## Why

Phase 1 (`buildSandboxCommitInFlightWorkCommand`, already merged) only *mitigates* shared-`/workspace` cross-build contamination. The durable fix is to stop sharing one tree: each build gets its own worktree so a concurrent build''s branch switch can never scrub another build''s work — the confirmed root cause of in-flight builds losing their generated code. The WWMD kernel selected this (`phase2-impl`) over a serial-rebuild shortcut on Architecture-Over-Shortcuts grounds (composite 8.06, high confidence).

## Verification

- **Live-verified in `dpf-sandbox-1`**: `git worktree add` + the node_modules symlink set → `tsc` (6.0.3), `react`, and `next` all resolve from the worktree; clean teardown leaves the registry at 1 worktree. So a per-build worktree needs no install of its own.
- 15/15 unit tests in `build-branch.test.ts` (3 new), scoped typecheck + gitleaks green via pre-commit.

## Scope / safety

Slice 1 is **inert** — nothing calls these yet, so build behaviour is unchanged. Wiring them into `startBuildBranch` and threading the per-build workdir through the dispatchers (the ~30-file change) is the follow-up slice, which carries the live end-to-end build verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)