### PR TITLE
fix(sse): stop full-page reload loop from useResilientEventSource (BI-864E83B0-followup)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -14,9 +14,21 @@ export const metadata: Metadata = {
 // the PlatformBanner can detect bundle-hash mismatch after a swap and
 // trigger a soft reload (spec §7.2 defensive layer). Values come from
 // process.env so a docker rebuild updates them automatically.
+//
+// CRITICAL (BI-864E83B0-followup): bundleHash MUST be derived from the same
+// source as /api/internal/quiescence-state (getDeployedSha → DEPLOYED_SHA),
+// otherwise the two identities never match and every mismatch check is a
+// false positive. The old value read PORTAL_BUNDLE_HASH/PORTAL_GIT_SHA, which
+// nothing sets in the container, so boot was "unknown" while the API returned
+// the real DEPLOYED_SHA — a permanent mismatch that drove a page-reload loop
+// once a consumer started checking it. DEPLOYED_SHA is always populated on a
+// built image (the Dockerfile seeds it from the baked /app/.dpf-image-version).
 const BOOT_VERSION = process.env.PORTAL_VERSION ?? "unknown";
 const BOOT_BUNDLE_HASH =
-  process.env.PORTAL_BUNDLE_HASH ?? process.env.PORTAL_GIT_SHA ?? "unknown";
+  process.env.DEPLOYED_SHA ??
+  process.env.PORTAL_BUNDLE_HASH ??
+  process.env.PORTAL_GIT_SHA ??
+  "unknown";
 const BOOT_JSON = JSON.stringify({ version: BOOT_VERSION, bundleHash: BOOT_BUNDLE_HASH });
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/lib/hooks/useResilientEventSource.ts
+++ b/apps/web/lib/hooks/useResilientEventSource.ts
@@ -2,7 +2,7 @@
 
 /**
  * useResilientEventSource — drop-in wrapper around the browser's EventSource
- * with four resilience additions on top of the default behavior
+ * with three resilience additions on top of the default behavior
  * (BI-QUIESCE-008 §7.5; heartbeat watchdog added by BI-864E83B0):
  *
  *   1. Minimum 5s reconnect floor — even if the server returns immediate
@@ -14,13 +14,7 @@
  *      max(5s, Retry-After seconds) before retrying. EventSource itself
  *      doesn't honor Retry-After, so the wrapper enforces it.
  *
- *   3. Stale-bundle check on successful reconnect — after a reconnect
- *      succeeds, fetches /api/internal/quiescence-state and compares to
- *      window.__DPF_BOOT__. Mismatch → forces soft reload. Catches the
- *      "client reconnected to a new bundle" case the bundle-hash header
- *      would otherwise detect on the next user action.
- *
- *   4. Heartbeat watchdog (the zombie-reaper) — the server now emits a
+ *   3. Heartbeat watchdog (the zombie-reaper) — the server now emits a
  *      named `dpf-hb` event every ~15s (lib/sse/sse-stream.ts). The hook
  *      resets a watchdog on every inbound frame; if NOTHING arrives within
  *      HEARTBEAT_WATCHDOG_MS it treats the connection as dead and force-
@@ -33,20 +27,21 @@
  *      slots per origin until the browser is restarted. The watchdog reaps
  *      that zombie itself, freeing the slot, so the page never wedges.
  *
+ * This hook NEVER reloads the page. A transport wrapper reconnecting an SSE
+ * stream is the orthodox behavior; deciding to reload after a deploy is an
+ * application concern, owned by PlatformBanner's controlled post-upgrade
+ * reload (gated on the explicit `system:quiescence` "succeeded" event), not
+ * a side effect of every (re)connect. (An earlier version reloaded on a
+ * bundle-hash mismatch on every connect; with the boot/identity signals
+ * derived from divergent env sources that mismatch was permanent, so the
+ * page reloaded every ~1-2s — removed in BI-864E83B0-followup.)
+ *
  * Migration: replaces `new EventSource(url)` in consumers. The always-on
  * consumers (PlatformBanner, usePlatformReady) are migrated; the remaining
  * transient streams migrate in BI-1AFF530D.
  */
 import { useEffect, useRef, useState } from "react";
 import { SSE_HEARTBEAT_EVENT } from "@/lib/sse/constants";
-
-type BootGlobal = { version: string; bundleHash: string };
-
-declare global {
-  interface Window {
-    __DPF_BOOT__?: BootGlobal;
-  }
-}
 
 const MIN_RECONNECT_DELAY_MS = 5_000;
 
@@ -83,8 +78,7 @@ export type ResilientEventSourceOptions = {
 export type ResilientEventSourceStatus =
   | "connecting"
   | "open"
-  | "reconnecting"
-  | "stale-bundle-reload";
+  | "reconnecting";
 
 export function useResilientEventSource(
   url: string | null,
@@ -153,15 +147,6 @@ export function useResilientEventSource(
       source.onopen = () => {
         setStatus("open");
         armWatchdog();
-        // Stale-bundle check on every successful (re)connect.
-        void detectStaleBundle().then((stale) => {
-          if (stale && !closed) {
-            setStatus("stale-bundle-reload");
-            setTimeout(() => {
-              if (!closed) window.location.reload();
-            }, 1_000);
-          }
-        });
       };
 
       source.onmessage = (event) => {
@@ -214,28 +199,4 @@ export function useResilientEventSource(
   }, [url]);
 
   return { status };
-}
-
-/**
- * Compare boot identity to the current server's identity. Returns true
- * when the running bundle differs from the page's boot bundle.
- *
- * Best-effort: any fetch failure returns false (caller stays connected
- * to whatever it had). The next response with X-Bundle-Hash header
- * (BI-QUIESCE-003) is the secondary detection path.
- */
-async function detectStaleBundle(): Promise<boolean> {
-  if (typeof window === "undefined") return false;
-  const boot = window.__DPF_BOOT__;
-  if (!boot) return false;
-  try {
-    const res = await fetch("/api/internal/quiescence-state", { cache: "no-store" });
-    if (!res.ok) return false;
-    const body = (await res.json()) as { version?: string; bundleHash?: string };
-    const versionChanged = body.version && body.version !== boot.version;
-    const bundleChanged = body.bundleHash && body.bundleHash !== boot.bundleHash;
-    return Boolean(versionChanged || bundleChanged);
-  } catch {
-    return false;
-  }
 }

--- a/docs/superpowers/specs/2026-06-19-sse-liveness-heartbeat-design.md
+++ b/docs/superpowers/specs/2026-06-19-sse-liveness-heartbeat-design.md
@@ -127,3 +127,39 @@ shared builder preserves the prior `: connected` + event-shape contract; consume
 bodies are unchanged. Tunables (`DPF_SSE_HEARTBEAT_MS`, the 40s client watchdog) bound behavior.
 Revert = restore the per-route `ReadableStream` blocks and the raw `EventSource` in the two migrated
 consumers.
+
+## 7. Post-merge regression — full-page reload loop (BI-864E83B0-followup)
+
+**Symptom (operator-reported):** after the always-on consumers were migrated to
+`useResilientEventSource`, the whole page reloaded every ~1-2 seconds.
+
+**Cause:** the hook carried a dormant `detectStaleBundle()` that ran `window.location.reload()` on
+**every (re)connect** when the boot identity didn't match the server's. That code had never executed
+before because no component used the hook; migrating the always-mounted `PlatformBanner` armed it.
+It then looped because the two identities are derived from **divergent env sources**:
+
+- `__DPF_BOOT__.bundleHash` (`app/layout.tsx`) read `PORTAL_BUNDLE_HASH ?? PORTAL_GIT_SHA ?? "unknown"`
+  — none of which the container sets → `"unknown"`.
+- `/api/internal/quiescence-state.bundleHash` reads `getDeployedSha()` → `DEPLOYED_SHA`, which the
+  Dockerfile **always** seeds on a built image → the real SHA.
+
+`"<sha>" !== "unknown"` is permanently true, so the hook reloaded, the page re-booted to the same
+`"unknown"`, and it reloaded again — a tight loop.
+
+**Fix (two parts):**
+
+1. **The transport hook never reloads the page.** Removed `detectStaleBundle()`, the
+   `stale-bundle-reload` status, and the `window.location.reload()` from `useResilientEventSource`.
+   Reconnecting a stream is a transport concern; reloading after a deploy is an application concern.
+   This makes the loop impossible on any install regardless of env config.
+2. **The identities now agree.** `__DPF_BOOT__.bundleHash` derives from `DEPLOYED_SHA` first — the
+   same source `getDeployedSha()` uses — so the comparison is meaningful (equal when not upgraded).
+
+The legitimate post-upgrade soft-reload is unchanged and still owned by `PlatformBanner`'s
+`detectBundleMismatchAndReload`, which fires **only** on the explicit `system:quiescence`
+"succeeded" event (once per upgrade), not on every connect.
+
+**Lesson:** adopting a shared hook means owning *all* of its side effects. A page-reload buried in a
+"resilient EventSource" wrapper, fed by two independently-maintained identity sources, was a latent
+trap; the heartbeat/watchdog design was sound but the wholesale hook adoption was not vetted for
+on-connect behavior.


### PR DESCRIPTION
## Urgent regression — page reloads every 1-2s

After the SSE-liveness PR ([#2108](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2108)) migrated `PlatformBanner`/`usePlatformReady` onto `useResilientEventSource`, the **entire page reloads every ~1-2 seconds**, making the portal unusable. This fixes it.

## Cause (a latent trap I armed)

`useResilientEventSource` carried a dormant `detectStaleBundle()` that called `window.location.reload()` on **every (re)connect** when the page's boot identity didn't match the server's. That code had never run because no component used the hook — migrating the always-mounted banner armed it. It then looped forever because the two identities are derived from **divergent env sources**:

| Identity | Source | Value in the container |
| --- | --- | --- |
| `__DPF_BOOT__.bundleHash` (`app/layout.tsx`) | `PORTAL_BUNDLE_HASH ?? PORTAL_GIT_SHA ?? "unknown"` | **`"unknown"`** (nothing sets those) |
| `/api/internal/quiescence-state.bundleHash` | `getDeployedSha()` → `DEPLOYED_SHA` | the **real SHA** (Dockerfile always seeds it) |

`"<sha>" !== "unknown"` is permanently true → reload → re-boot to `"unknown"` → reload again. A transport hook reloading the page on connect is the wrong design regardless of the env mismatch.

## Fix (two parts)

1. **The transport hook never reloads the page.** Removed `detectStaleBundle()`, the `stale-bundle-reload` status, and `window.location.reload()` from `useResilientEventSource`. It now only connects, delivers messages, and reconnects (the heartbeat watchdog from #2108 is retained). This makes the loop impossible on any install, regardless of env config.
2. **The two identities now agree.** `__DPF_BOOT__.bundleHash` derives from `DEPLOYED_SHA` first — the same source `quiescence-state` uses — so any comparison is meaningful (equal when not upgraded).

The legitimate **post-upgrade** soft-reload is unchanged and still owned by `PlatformBanner.detectBundleMismatchAndReload`, which fires **only** on the explicit `system:quiescence` "succeeded" event (once per upgrade), never on every connect — the orthodox "reload after a deploy" pattern.

## Verification
- 9 hook/sse unit tests green (watchdog behavior unaffected); `lib/sse` + `lib/hooks` green.
- No other code references the removed `detectStaleBundle`/`stale-bundle-reload` (grep-confirmed).
- Spec updated with a §7 post-mortem of the regression.

## Notes
- `BI-864E83B0`-followup. Spec: `docs/superpowers/specs/2026-06-19-sse-liveness-heartbeat-design.md` §7.
- Honest assessment: the heartbeat/watchdog design (#2108) was researched and standard; this loop came from adopting the hook **wholesale** without vetting its on-connect side effects. That review gap is the real lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)