### PR TITLE
feat(build-studio): route claude/codex/grok dispatch exec cwd through resolveBuildWorkdir (BI-98B723C0 Phase 2c)

### DIFF
--- a/apps/web/lib/integrate/claude-dispatch.ts
+++ b/apps/web/lib/integrate/claude-dispatch.ts
@@ -15,6 +15,7 @@ import type { AssignedTask } from "./task-dependency-graph";
 import type { SpecialistRole } from "./task-dependency-graph";
 import { getDecryptedCredential, getProviderBearerToken } from "@/lib/inference/ai-provider-internals";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { resolveBuildWorkdir } from "./sandbox/build-branch";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 
@@ -159,6 +160,9 @@ export async function dispatchClaudeTask(params: {
   const model = params.model ?? "sonnet";
   const sessionId = params.sessionId;
   const role = task.specialist;
+  // Per-build working dir: the build's worktree when isolation is ON, else
+  // /workspace (default — byte-identical). Container ops stay container-rooted.
+  const workdir = resolveBuildWorkdir(params.buildId);
 
   // Resolve auth credentials (OAuth for Max Plan, or API key for per-token billing)
   let auth: ClaudeAuth;
@@ -250,7 +254,7 @@ export async function dispatchClaudeTask(params: {
     const runnerScript = `/tmp/claude-run-${taskSlug}.sh`;
     const script = [
       "#!/bin/sh",
-      "cd /workspace",
+      `cd ${workdir}`,
       authExportLine,
       `exec claude ${bareFlag}${sessionFlag}-p - --dangerously-skip-permissions --output-format json --model ${model} < ${promptFile}`,
     ].join("\n");

--- a/apps/web/lib/integrate/codex-dispatch.ts
+++ b/apps/web/lib/integrate/codex-dispatch.ts
@@ -14,6 +14,7 @@ import type { SpecialistRole } from "./task-dependency-graph";
 import { getDecryptedCredential } from "@/lib/inference/ai-provider-internals";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
+import { resolveBuildWorkdir } from "./sandbox/build-branch";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 
@@ -165,6 +166,8 @@ export async function dispatchCodexTask(params: {
   const { task, buildContext, priorResults } = params;
   const providerId = params.providerId ?? "chatgpt";
   const model = params.model ?? "";
+  // Per-build working dir: worktree when isolation ON, else /workspace (default).
+  const workdir = resolveBuildWorkdir(params.buildId);
   const role = task.specialist;
   const startedAt = new Date();
 
@@ -245,7 +248,7 @@ export async function dispatchCodexTask(params: {
     }>((resolve, reject) => {
       const proc = spawnCb("docker", [
         "exec", SANDBOX_CONTAINER, "sh", "-c",
-        `cd /workspace && codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check ${modelFlag} < /tmp/codex-prompt.txt`,
+        `cd ${workdir} && codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check ${modelFlag} < /tmp/codex-prompt.txt`,
       ]);
 
       let stdout = "";

--- a/apps/web/lib/integrate/grok-dispatch.ts
+++ b/apps/web/lib/integrate/grok-dispatch.ts
@@ -18,6 +18,7 @@ import type { AssignedTask } from "./task-dependency-graph";
 import type { SpecialistRole } from "./task-dependency-graph";
 import { getDecryptedCredential } from "@/lib/inference/ai-provider-internals";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { resolveBuildWorkdir } from "./sandbox/build-branch";
 import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
 
 const DEFAULT_SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
@@ -234,6 +235,8 @@ export async function dispatchGrokTask(params: {
 }): Promise<GrokResult> {
   const { task, buildContext, priorResults } = params;
   const providerId = params.providerId ?? "xai";
+  // Per-build working dir: worktree when isolation ON, else /workspace (default).
+  const workdir = resolveBuildWorkdir(params.buildId);
   const model = params.model ?? "";
   const role = task.specialist;
   const containerId = params.containerId ?? DEFAULT_SANDBOX_CONTAINER;
@@ -309,7 +312,7 @@ export async function dispatchGrokTask(params: {
       "set -e",
       `cleanup() { rm -f ${promptFile} ${keyFile} ${runnerScript} 2>/dev/null || true; }`,
       "trap cleanup EXIT INT TERM",
-      "cd /workspace",
+      `cd ${workdir}`,
       // OAuth mode: grok reads the ~/.grok/auth.json injected by ensureGrokAuth (no env needed).
       // API-key mode: export XAI_API_KEY from the per-task key file.
       grokAuth.mode === "apikey"


### PR DESCRIPTION
## What

Phase 2c (remote dispatchers) of BI-98B723C0: routes the **claude / codex / grok** dispatchers'' exec working directory through `resolveBuildWorkdir(params.buildId)` — the same pattern as opencode (#2124). Completes the **dispatcher layer (4/4)**.

- `dispatchClaudeTask` / `dispatchCodexTask` / `dispatchGrokTask` each compute `const workdir = resolveBuildWorkdir(params.buildId)` and use it for the runner `cd` / `codex exec` cwd.
- Flag OFF (default) → `/workspace`, **byte-identical** to today.
- Container-level ops (`chown`, `docker exec` target) stay container-rooted.

## Why

For the worktree-isolation flag to be flippable safely, **every** dispatcher must honor the per-build workdir — otherwise a remote-provider build would break under isolation. With these three threaded, all four build dispatchers run a build in its own worktree when isolation is on.

## Scope / safety

**Default OFF** — behaviour unchanged (resolver → `/workspace` when off; scoped typecheck + gitleaks green). Remaining 2c is the non-dispatcher exec paths: `ideate-dispatch`, `sandbox-verification` (typecheck), `build-pipeline` (diff) — those need per-ref judgment (container vs per-build ops). The flag is **not** flipped until those land and one real build is verified end-to-end through a worktree (Phase 2d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)