### PR TITLE
feat(build-studio): route build verification + ship-diff through resolveBuildWorkdir (BI-98B723C0 Phase 2c)

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -571,7 +571,13 @@ async function stepRunTests(
     console.warn("[stepRunTests] could not resolve changed files for scoping:", (err as Error)?.message);
   }
 
-  const results = await runSandboxTests(state.containerId!, { changedFiles });
+  // Run verification in the build's working dir: its own worktree when isolation
+  // is on, else /workspace (default — byte-identical). BI-98B723C0 Phase 2c.
+  const { resolveBuildWorkdir } = await import("./sandbox/build-branch");
+  const results = await runSandboxTests(state.containerId!, {
+    changedFiles,
+    workdir: resolveBuildWorkdir(buildId),
+  });
   const diagnosis = results.passed ? null : diagnoseTestFailures(results);
 
   // Persist test results to the build record.

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -620,14 +620,17 @@ async function stepComplete(
 
   const { prisma } = await import("@dpf/db");
   const { extractDiff, listSandboxCommitsAheadOfBase } = await import("./sandbox/sandbox");
-  const { getClientIdentity } = await import("./sandbox/build-branch");
+  const { getClientIdentity, resolveBuildWorkdir } = await import("./sandbox/build-branch");
 
   const identity = await getClientIdentity();
   const baseRef = identity.clientBranch;
+  // Extract the diff from the build's working dir: its own worktree when
+  // isolation is on, else /workspace (default — byte-identical). BI-98B723C0 2c.
+  const buildWorkdir = resolveBuildWorkdir(buildId);
 
   const [fullDiff, commitHashes] = await Promise.all([
-    extractDiff(state.containerId, { baseRef }),
-    listSandboxCommitsAheadOfBase(state.containerId, baseRef),
+    extractDiff(state.containerId, { baseRef, workspace: buildWorkdir }),
+    listSandboxCommitsAheadOfBase(state.containerId, baseRef, buildWorkdir),
   ]);
 
   await prisma.featureBuild.update({

--- a/apps/web/lib/integrate/coding-agent.ts
+++ b/apps/web/lib/integrate/coding-agent.ts
@@ -358,14 +358,17 @@ export function outputIndicatesTestFailure(output: string): boolean {
 
 export async function runSandboxTests(
   containerId: string,
-  opts?: { changedFiles?: string[] },
+  opts?: { changedFiles?: string[]; workdir?: string },
 ): Promise<SandboxTestResult> {
+  // Per-build working dir: the build's worktree when isolation is on, else
+  // /workspace (default — byte-identical to prior behaviour). BI-98B723C0 Phase 2c.
+  const workdir = opts?.workdir ?? "/workspace";
   // Typecheck is the primary gate — catches real compilation errors in feature code.
   // Run it first via the web workspace's tsconfig (not bare `tsc` which prints help).
   let typeCheckOutput = "";
   let typeCheckPassed = false;
   try {
-    typeCheckOutput = await execInSandbox(containerId, "cd /workspace/apps/web && npx tsc --noEmit 2>&1 || true");
+    typeCheckOutput = await execInSandbox(containerId, `cd ${workdir}/apps/web && npx tsc --noEmit 2>&1 || true`);
     // `tsc` typechecks the whole apps/web project graph (no cheap per-file mode),
     // so a pre-existing type error in an UNRELATED file would block a build whose
     // own changed files are clean. When we know the changed surface, gate only on
@@ -394,7 +397,7 @@ export async function runSandboxTests(
     const existence = await Promise.all(
       candidates.map(async (p) => {
         try {
-          const out = await execInSandbox(containerId, `test -f "/workspace/${p}" && echo __yes__ || echo __no__`);
+          const out = await execInSandbox(containerId, `test -f "${workdir}/${p}" && echo __yes__ || echo __no__`);
           return out.includes("__yes__") ? p : null;
         } catch {
           return null;
@@ -411,7 +414,7 @@ export async function runSandboxTests(
     let anyFailed = false;
     for (const [pkg, rel] of groupTestFilesByPackage(scopedTestFiles)) {
       const fileArgs = rel.map((r) => `"${r}"`).join(" ");
-      const out = await execInSandbox(containerId, `cd /workspace/${pkg} && npx vitest run ${fileArgs} 2>&1 || true`);
+      const out = await execInSandbox(containerId, `cd ${workdir}/${pkg} && npx vitest run ${fileArgs} 2>&1 || true`);
       sections.push(`# ${pkg}\n${out}`);
       // vitest omits the "failed" segment entirely when zero, so any "N failed"
       // with N>=1 (or a FAIL marker) means the feature's own tests are red.
@@ -425,7 +428,7 @@ export async function runSandboxTests(
     testPassed = !anyFailed;
   } else {
     try {
-      testOutput = await execInSandbox(containerId, "cd /workspace && pnpm test 2>&1 || true");
+      testOutput = await execInSandbox(containerId, `cd ${workdir} && pnpm test 2>&1 || true`);
       testPassed = testOutput.includes("Tests  ") && !testOutput.includes("FAIL");
     } catch (e) {
       testOutput = e instanceof Error ? e.message : String(e);

--- a/apps/web/lib/integrate/sandbox/sandbox-verification.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-verification.ts
@@ -31,7 +31,15 @@ export type SandboxGateResult = {
   ranAt: string;
 };
 
-export const SANDBOX_TYPECHECK_COMMAND = "cd /workspace && pnpm --filter web typecheck 2>&1";
+// Default working dir when a build is not running in its own worktree.
+const VERIFY_WORKSPACE_DEFAULT = "/workspace";
+
+// Typecheck/build gate commands for a build's working directory: the build's own
+// worktree when isolation is on, else /workspace (default — byte-identical to the
+// prior string constants). BI-98B723C0 Phase 2c.
+export function sandboxTypecheckCommand(workdir: string = VERIFY_WORKSPACE_DEFAULT): string {
+  return `cd ${workdir} && pnpm --filter web typecheck 2>&1`;
+}
 // The sandbox container ships with NODE_ENV=development so the in-container Next
 // dev server behaves like local dev. Production builds must NOT inherit that:
 // Next.js emits a "non-standard NODE_ENV" warning and then crashes prerendering
@@ -39,8 +47,12 @@ export const SANDBOX_TYPECHECK_COMMAND = "cd /workspace && pnpm --filter web typ
 // when client-component code is run through the dev-mode React runtime during
 // the prerender pass. Force NODE_ENV=production for the build gate only — the
 // dev-server launch in sandbox.ts is unaffected.
-export const SANDBOX_BUILD_COMMAND =
-  "cd /workspace && NODE_ENV=production pnpm --filter web build 2>&1";
+export function sandboxBuildCommand(workdir: string = VERIFY_WORKSPACE_DEFAULT): string {
+  return `cd ${workdir} && NODE_ENV=production pnpm --filter web build 2>&1`;
+}
+// Back-compat string constants (default /workspace) for non-per-build callers.
+export const SANDBOX_TYPECHECK_COMMAND = sandboxTypecheckCommand();
+export const SANDBOX_BUILD_COMMAND = sandboxBuildCommand();
 
 const OUTPUT_TAIL_LIMIT = 15_000;
 
@@ -103,14 +115,17 @@ async function runCheck(
 export async function runSandboxTypecheckBuildGate(
   containerId: string,
   exec: ExecImpl = execInSandbox,
+  workdir: string = VERIFY_WORKSPACE_DEFAULT,
 ): Promise<SandboxGateResult> {
   const ranAt = new Date().toISOString();
-  const typecheck = await runCheck(containerId, "typecheck", SANDBOX_TYPECHECK_COMMAND, exec);
+  const typecheckCommand = sandboxTypecheckCommand(workdir);
+  const buildCommand = sandboxBuildCommand(workdir);
+  const typecheck = await runCheck(containerId, "typecheck", typecheckCommand, exec);
   const build: SandboxCheckResult = typecheck.passed
-    ? await runCheck(containerId, "build", SANDBOX_BUILD_COMMAND, exec)
+    ? await runCheck(containerId, "build", buildCommand, exec)
     : {
         name: "build",
-        command: SANDBOX_BUILD_COMMAND,
+        command: buildCommand,
         passed: false,
         exitCode: null,
         stdoutTail: "Build skipped — typecheck failed. Fix typecheck errors first.",

--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -214,13 +214,13 @@ export function parseSandboxChangedFiles(output: string): string[] {
     .filter(Boolean);
 }
 
-async function resetSandboxGitIndex(containerId: string): Promise<void> {
-  await execInSandbox(containerId, `cd ${SANDBOX_WORKSPACE} && git reset >/dev/null 2>&1 || true`);
+async function resetSandboxGitIndex(containerId: string, workspace: string = SANDBOX_WORKSPACE): Promise<void> {
+  await execInSandbox(containerId, `cd ${workspace} && git reset >/dev/null 2>&1 || true`);
 }
 
-async function stageSandboxWorkspaceChanges(containerId: string): Promise<void> {
-  await resetSandboxGitIndex(containerId);
-  await execInSandbox(containerId, buildSandboxStageCommand());
+async function stageSandboxWorkspaceChanges(containerId: string, workspace: string = SANDBOX_WORKSPACE): Promise<void> {
+  await resetSandboxGitIndex(containerId, workspace);
+  await execInSandbox(containerId, buildSandboxStageCommand(workspace));
 }
 
 export async function listReleasableSandboxFiles(
@@ -460,22 +460,26 @@ export async function getSandboxLogs(containerId: string, tail: number = 50): Pr
 
 export async function extractDiff(
   containerId: string,
-  opts?: { baseRef?: string },
+  opts?: { baseRef?: string; workspace?: string },
 ): Promise<string> {
-  await stageSandboxWorkspaceChanges(containerId);
+  // Per-build working dir: the build's worktree when isolation is on, else
+  // /workspace (default — byte-identical). The diff is `--cached`, i.e. the
+  // per-worktree index, so it must run in the build's own tree. BI-98B723C0 2c.
+  const workspace = opts?.workspace ?? SANDBOX_WORKSPACE;
+  await stageSandboxWorkspaceChanges(containerId, workspace);
   try {
     const changedFiles = await execInSandbox(
       containerId,
-      buildSandboxListReleasableFilesCommand(SANDBOX_WORKSPACE, opts?.baseRef),
+      buildSandboxListReleasableFilesCommand(workspace, opts?.baseRef),
     );
     const files = parseSandboxChangedFiles(changedFiles);
     if (files.length === 0) return "";
     return execInSandbox(
       containerId,
-      buildSandboxDiffForFilesCommand(files, SANDBOX_WORKSPACE, opts?.baseRef),
+      buildSandboxDiffForFilesCommand(files, workspace, opts?.baseRef),
     );
   } finally {
-    await resetSandboxGitIndex(containerId);
+    await resetSandboxGitIndex(containerId, workspace);
   }
 }
 


### PR DESCRIPTION
## What

Phase 2c (verification path) of BI-98B723C0: routes the **production build verification** through `resolveBuildWorkdir(buildId)`.

- `coding-agent.runSandboxTests` (the path `stepRunTests` actually calls) now takes `opts.workdir` (default `/workspace`) and runs typecheck (`tsc --noEmit`), scoped test-file existence checks, scoped `vitest`, and the full-suite fallback in it.
- `build-pipeline.stepRunTests` passes `resolveBuildWorkdir(buildId)`.
- `sandbox-verification` gate commands are now `sandboxTypecheckCommand(workdir)` / `sandboxBuildCommand(workdir)` (string consts preserved for non-per-build callers).

## Why

With the dispatchers (#2124/#2125) and now verification routed to the per-build worktree, a build under isolation generates **and verifies** its code entirely in its own tree — no shared-`/workspace` contamination.

## Scope / safety

**Default OFF** — `resolveBuildWorkdir` returns `/workspace` when off, so every command is byte-identical to today. 29 unit tests pass (coding-agent + sandbox-verification); scoped typecheck + gitleaks green. Remaining 2c: `build-pipeline` diff-extract (`stepComplete`) + `ideate-dispatch`; then Phase 2d flips `DPF_BUILD_WORKTREE_ISOLATION=1` and verifies one real local-LLM build end-to-end through a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)