### PR TITLE
fix(build-studio): exempt in-sandbox git from the host root-clone guard (unblocks stuck builds)

### DIFF
--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -68,6 +68,16 @@ describe("wrapSandboxGitCommand", () => {
     );
   });
 
+  it("exempts in-sandbox commits from the host-oriented root-clone pre-commit guard", () => {
+    // The sandbox /workspace is the build tree, not the host merge/release clone
+    // the root-clone guard protects. Without this override a baseline/build
+    // commit silently fails start_build whenever the sandbox sits on a
+    // feat/*|fix/*|… branch (BI-98B723C0 — observed live blocking a re-dispatch).
+    expect(wrapSandboxGitCommand('git -C /workspace commit -m "sandbox baseline"')).toContain(
+      "export DPF_ALLOW_ROOT_CLONE_COMMIT=1",
+    );
+  });
+
   it("stops preview processes and removes app-local next artifacts before switching branches", () => {
     const command = buildSandboxBranchSwitchPrepCommand();
 

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -243,6 +243,17 @@ export function buildSandboxGitCommitPrunedArtifactsCommand(
 
 function sandboxGitPrelude(): string {
   return [
+    // The sandbox /workspace is the dedicated BUILD tree — NOT the host
+    // merge/release clone that the root-clone pre-commit guard (.githooks,
+    // check-root-clone.sh) protects. That guard ships in the repo (so it also
+    // runs inside the sandbox image) and refuses a commit whenever the working
+    // tree sits on a feat/*|fix/*|chore/*|doc/*|clean/* branch. If the sandbox is
+    // ever left on such a branch (e.g. a dev branch got checked out), it silently
+    // fails start_build's baseline commit for EVERY subsequent build. Set the
+    // guard's sanctioned override here so legitimate in-sandbox build commits
+    // never trip the host-oriented guard. (BI-98B723C0 follow-up — observed
+    // blocking a re-dispatch when the sandbox sat on feat/bs-local-gpu-serialize.)
+    `export DPF_ALLOW_ROOT_CLONE_COMMIT=1`,
     `if [ -f "${GIT_INDEX_LOCK}" ]; then for _dpf_git_wait in 1 2 3 4 5; do if ! pgrep -x git >/dev/null 2>&1; then break; fi; sleep 1; done; if [ -f "${GIT_INDEX_LOCK}" ] && ! pgrep -x git >/dev/null 2>&1; then rm -f "${GIT_INDEX_LOCK}"; fi; fi`,
     `git config --global --add safe.directory "${WORKSPACE}" >/dev/null 2>&1 || true`,
   ].join(" && ");


### PR DESCRIPTION
## What

Set the root-clone guard's sanctioned override (`DPF_ALLOW_ROOT_CLONE_COMMIT=1`) in `sandboxGitPrelude`, so all in-sandbox git commands are exempt from the **host** root-clone pre-commit guard.

## Why (a real, live-diagnosed build-blocker)

`.githooks/check-root-clone.sh` refuses `feat/*|fix/*|chore/*|doc/*|clean/*` commits in the primary (non-worktree) clone — correct for the **host** merge/release clone. But the hook ships in the repo, so it also runs inside the **sandbox** `/workspace`, which is the dedicated *build tree* where build commits are legitimate.

When the sandbox is left checked out on such a branch (observed live on `feat/bs-local-gpu-serialize`), `start_build`'s `git commit -m 'sandbox baseline'` trips the guard and **every subsequent build silently fails to initialize**. Normal `build/<id>`/`client/<id>` commits were already exempt (not feature-class); this covers the anomalous-branch case that otherwise wedges the whole build pipeline.

## Verification

Diagnosed while re-dispatching FB-69231490 (BI-4FF277BF): `start_build` failed on this exact guard, then succeeded after manually switching the sandbox off the dev branch — this fix makes that robust so it never recurs. 18 unit tests pass (`build-branch.test.ts`, 1 new); scoped typecheck + gitleaks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)