### PR TITLE
fix(db): backfill cross_layer_impact traversal pattern to existing installs

### DIFF
--- a/docs/superpowers/specs/2026-06-16-living-architecture-graph-and-operational-bridge-design.md
+++ b/docs/superpowers/specs/2026-06-16-living-architecture-graph-and-operational-bridge-design.md
@@ -314,3 +314,36 @@ on landing, and adds exactly one extractor + its tests.
 - No runtime-validation claims from the worktree; route runtime gates through the canonical
   install or shared local-CI lease.
 - No SysML where a smaller ArchiMate/BPMN/C4 view is the adequate answer.
+
+## 14. Implementation Log (appended)
+
+Shipped against `EP-ARCH-GRAPH-LIVE`, in order:
+
+- **#2029** — roadmap spec (this doc) + the skill & agent-toolchain extractor (the last
+  unextracted static portal domain). **#2033** — the keystone: `applySysmlModel.crossLayerRelationships`,
+  resolving an edge endpoint against existing `EaElement.infraCiKey` across projections.
+  **#2034** — the three Tier-2 bridges (operational `RuntimeTarget`, network `EdgeNode`/
+  `InventoryEntity`, integration `IntegrationCredential`) as self-contained drift-proof
+  projections. **#2073** — the first cross-layer `traces` edges: each actual element traces
+  to its `prisma:model:<Model>` data-model type.
+- **Functional verification (live, 2026-06-19):** after deploy, triggering the
+  `sysml-projection-nightly` reconcile created **331 cross-layer `traces` edges from real data**
+  (network 317 / operational 12 / edge-node 1 / integration 1), each resolving against the live
+  `prisma:model:*` elements. A data-model change's blast radius now reaches the live elements
+  that realize it — confirmed by direct DB inspection.
+- **#2104** — `cross_layer_impact` traversal pattern (in `seed-ea-archimate4.ts`) + the slug in
+  the `run_traversal_pattern` MCP enum, so the impact *query* walks the `traces` edges. Engine
+  note: the traversal executor matches relationship/element slugs **globally** (no notation
+  scoping), so an archimate4-registered pattern traverses the sysml2 `traces` edges; registered
+  under archimate4 because `run_traversal_pattern` defaults to that notation.
+- **#2130 (this PR) — seed→migration backfill finding.** Seed data does **not** reliably
+  re-apply on self-upgrade (`seed.ts` tolerates partial failure), so the `cross_layer_impact`
+  pattern added to the seed in #2104 never reached the already-running install — the edges were
+  live but the pattern row was absent. **Lesson: a new seeded EA artifact (traversal pattern,
+  element type, notation) needs a paired idempotent data migration to reach existing installs;
+  the seed alone only covers fresh installs.** This PR adds that migration (`migrate deploy` runs
+  reliably, before the seed). Generalize this to future EA seed additions.
+
+**Remaining (filed):** impact VIEW/UX surface (`BI-4A73ED94`); `docker-compose` infra-topology
+extractor; event-driven real-time projection (`BI-F0923D0F`); Tier-1 leftovers
+(deployment-contracts extractor `BI-26C6F5B4`, Build-Studio/value-stream BPMN `BI-PARITY-BPMN`).

--- a/packages/db/prisma/migrations/20260619180000_backfill_cross_layer_impact_pattern/migration.sql
+++ b/packages/db/prisma/migrations/20260619180000_backfill_cross_layer_impact_pattern/migration.sql
@@ -1,0 +1,32 @@
+-- Backfill the `cross_layer_impact` EA traversal pattern onto EXISTING installs.
+--
+-- The pattern is seeded for fresh installs by packages/db/src/seed-ea-archimate4.ts
+-- (PR #2104), but seed data does not reliably re-apply on self-upgrade (seed.ts tolerates
+-- partial failure), so existing installs never received it. `migrate deploy` runs
+-- reliably (and before the seed) on every deploy, so this idempotent data migration is
+-- the correct backfill per the seed+migration convention.
+--
+-- Effect: lets run_traversal_pattern("cross_layer_impact", [<data-model element>]) walk the
+-- Parity Engine cross-layer `traces` edges from a Prisma-model element to the ACTUAL
+-- operational/network/integration elements that realize it. EP-ARCH-GRAPH-LIVE / BI-4A73ED94.
+--
+-- Idempotent: ON CONFLICT on the (notationId, slug) unique key; a no-op if the archimate4
+-- notation is absent (the SELECT yields no rows) or the pattern already exists. Steps and
+-- forbiddenShortcuts mirror the seed so fresh installs (which run both) converge identically.
+INSERT INTO "EaTraversalPattern"
+  ("id", "notationId", "slug", "name", "description", "patternType", "steps", "forbiddenShortcuts", "status", "createdAt", "updatedAt")
+SELECT
+  gen_random_uuid()::text,
+  n."id",
+  'cross_layer_impact',
+  'Cross-Layer Data-Model Impact',
+  'From a data-model element, trace the actual operational, network, and integration elements that realize it via the Parity Engine cross-layer traces edges - the cross-layer blast radius of a data-model change.',
+  'cross_layer_impact',
+  '[{"elementTypeSlugs":["part_usage","part_definition"],"refinementLevel":null,"relationshipTypeSlugs":["traces"],"direction":"inbound"},{"elementTypeSlugs":["part_usage","part_definition"],"refinementLevel":null,"relationshipTypeSlugs":[],"direction":"terminal"}]'::jsonb,
+  '["A data-model element''s cross-layer impact is the ACTUAL elements that trace to it, not other data-model elements","A traces edge records that an actual element is an occurrence of the model type - it is not a runtime dependency","These cross-layer edges are derived by the Parity Engine bridges, not hand-authored - verify against the live projection"]'::jsonb,
+  'active',
+  now(),
+  now()
+FROM "EaNotation" n
+WHERE n."slug" = 'archimate4'
+ON CONFLICT ("notationId", "slug") DO NOTHING;


### PR DESCRIPTION
## Why

[#2104](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2104) added the `cross_layer_impact` traversal pattern to the EA seed. It deployed (live SHA includes it) and the cross-layer **edges** are live-proven (331 `traces` edges, verified directly against the production DB) — **but the pattern row never reached the live install.** Diagnosis on the running portal: the DB has the 7 prior traversal patterns, not `cross_layer_impact`.

**Root cause:** seed data doesn't reliably re-apply on self-upgrade. The entrypoint runs `seed.ts`, but it tolerates partial failure ("SEED INCOMPLETE"), so a newly-added pattern can be skipped on existing installs. This is exactly the **seed + migration** convention — #2104 shipped the seed change without the backfill migration for existing installs.

## What

An idempotent **data migration** that upserts the pattern:
- Resolves the `archimate4` notation id at runtime (`SELECT ... FROM "EaNotation" WHERE slug='archimate4'`).
- `ON CONFLICT ("notationId","slug") DO NOTHING` — safe to re-run; no-op if the pattern exists or the notation is absent.
- `steps` / `forbiddenShortcuts` mirror the seed, so fresh installs (which run both the migration and the seed's upsert) converge identically.

`migrate deploy` runs **reliably, and before the seed**, on every deploy — so this lands on existing installs where the seed didn't. After it deploys, `run_traversal_pattern("cross_layer_impact", [<data-model element>])` returns the actual elements that realize it.

## Verification

Validated against the **live production DB schema** in a rolled-back transaction (no persistence):
```
INSERT 0 1
slug=cross_layer_impact | patternType=cross_layer_impact | steps=2 | fshorts=3 | step0_dir=inbound | step0_rel=traces
```
Data-only migration (no schema change), so the schema↔migrations diff is unaffected.

`EP-ARCH-GRAPH-LIVE` / `BI-4A73ED94`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
