### PR TITLE
feat(edge-node): easy remote provisioning — portal-generated install command (BI-D18DD7A9)

### DIFF
--- a/apps/web/lib/actions/edge-nodes.ts
+++ b/apps/web/lib/actions/edge-nodes.ts
@@ -16,8 +16,15 @@ import { revalidatePath } from "next/cache";
 
 import { prisma } from "@dpf/db";
 
+import { resolveAppBaseUrl } from "@/lib/app-url";
 import { auth } from "@/lib/auth";
 import { issueBootstrapToken } from "@/lib/edge-node/enrollment";
+import {
+  buildRemoteProvisioningPlan,
+  EDGE_HOST_OSES,
+  type EdgeHostOs,
+  type RemoteProvisioningPlan,
+} from "@/lib/edge-node/remote-provisioning";
 import { syncUserPrincipal } from "@/lib/identity/principal-linking";
 import { can } from "@/lib/permissions";
 
@@ -178,6 +185,74 @@ export async function issueEdgeBootstrapTokenAction(input: {
       message: err instanceof Error ? err.message : "issuance failed",
     };
   }
+}
+
+// ── Easy remote provisioning ────────────────────────────────────────────────
+
+export type PrepareRemoteEdgeProvisioningAction =
+  | {
+      ok: true;
+      tokenId: string;
+      prefix: string;
+      expiresAt: string; // ISO
+      /** The ready-to-run command(s) + URL assessment for the chosen host. */
+      plan: RemoteProvisioningPlan;
+    }
+  | ActionFailure;
+
+/**
+ * Prepare an Edge Node on *separate hardware* (BI-D18DD7A9 / edge-topology
+ * design §8): issue a scoped, short-TTL bootstrap token through the running
+ * Authority (so no host-side `@dpf/db` import — EP-BUILD-D78835 — is needed)
+ * and render a copy-paste install command with the Authority URL + token
+ * already baked in. The operator never clones the repo or edits a `.env`.
+ *
+ * Reuses `issueEdgeBootstrapTokenAction` for the manage_platform gate, scope
+ * validation, and issuance; this only adds OS validation + URL resolution +
+ * command rendering on top.
+ */
+export async function prepareRemoteEdgeProvisioningAction(input: {
+  os: EdgeHostOs;
+  nodeName?: string;
+  ttlMs?: number;
+  targetCustomerAccountId?: string | null;
+  targetCustomerSiteId?: string | null;
+  /** Git ref for the raw standalone-compose URL; defaults to `main`. */
+  composeRef?: string;
+}): Promise<PrepareRemoteEdgeProvisioningAction> {
+  if (!EDGE_HOST_OSES.includes(input.os)) {
+    return {
+      ok: false,
+      error: "invalid_input",
+      message: "os must be one of: linux, macos, windows",
+    };
+  }
+
+  // Delegate the gate + scope validation + token mint to the existing action
+  // so there is exactly one issuance path. Only mint after OS validation so a
+  // bad request never consumes a token.
+  const issued = await issueEdgeBootstrapTokenAction({
+    ...(input.ttlMs !== undefined ? { ttlMs: input.ttlMs } : {}),
+    targetCustomerAccountId: input.targetCustomerAccountId ?? null,
+    targetCustomerSiteId: input.targetCustomerSiteId ?? null,
+  });
+  if (!issued.ok) return issued;
+
+  const plan = buildRemoteProvisioningPlan({
+    resolvedAuthorityUrl: resolveAppBaseUrl(),
+    bootstrapToken: issued.plaintext,
+    os: input.os,
+    ...(input.nodeName?.trim() ? { nodeName: input.nodeName.trim() } : {}),
+    ...(input.composeRef?.trim() ? { composeRef: input.composeRef.trim() } : {}),
+  });
+
+  return {
+    ok: true,
+    tokenId: issued.tokenId,
+    prefix: issued.prefix,
+    expiresAt: issued.expiresAt,
+    plan,
+  };
 }
 
 // ── Lifecycle actions: approve / quarantine / revoke ──────────────────────

--- a/apps/web/lib/edge-node/remote-provisioning.test.ts
+++ b/apps/web/lib/edge-node/remote-provisioning.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  assessAuthorityUrl,
+  buildRemoteProvisioningPlan,
+  isLoopbackAuthorityUrl,
+  renderEdgeInstallCommands,
+  DEFAULT_COMPOSE_REF,
+  DEFAULT_REPO_SLUG,
+} from "./remote-provisioning";
+
+const TOKEN = "dpfboot_abc123XYZ";
+const GOOD_URL = "https://dpf-authority.lan:443";
+
+describe("isLoopbackAuthorityUrl", () => {
+  it.each([
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://127.5.9.9:3000",
+    "https://0.0.0.0",
+    "http://host.docker.internal:3000",
+    "http://[::1]:3000",
+  ])("flags %s as loopback (unreachable from another machine)", (url) => {
+    expect(isLoopbackAuthorityUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "http://192.168.1.10:3000",
+    "http://10.0.0.5:3000",
+    "http://172.16.4.4:3000",
+    "https://dpf-authority.lan",
+    "https://portal.example.com",
+    "http://my-host.local:3000",
+  ])("treats %s as a reachable remote target", (url) => {
+    expect(isLoopbackAuthorityUrl(url)).toBe(false);
+  });
+
+  it("returns false (not loopback) for an unparseable URL — assess flags it as missing", () => {
+    expect(isLoopbackAuthorityUrl("not a url")).toBe(false);
+  });
+});
+
+describe("assessAuthorityUrl", () => {
+  it("flags a missing URL", () => {
+    expect(assessAuthorityUrl(null).issues).toEqual(["missing"]);
+    expect(assessAuthorityUrl("").issues).toEqual(["missing"]);
+    expect(assessAuthorityUrl("   ").issues).toEqual(["missing"]);
+  });
+
+  it("flags an unparseable URL as missing (no url returned)", () => {
+    const r = assessAuthorityUrl("::::");
+    expect(r.url).toBe("");
+    expect(r.issues).toContain("missing");
+  });
+
+  it("flags loopback + insecure-http for http://localhost", () => {
+    const r = assessAuthorityUrl("http://localhost:3000");
+    expect(r.issues).toContain("loopback");
+    expect(r.issues).toContain("insecure-http");
+  });
+
+  it("accepts an https LAN/DNS host with no issues and strips trailing slashes", () => {
+    const r = assessAuthorityUrl("https://dpf-authority.lan:443///");
+    expect(r.url).toBe("https://dpf-authority.lan:443");
+    expect(r.issues).toEqual([]);
+  });
+
+  it("flags only insecure-http for a reachable private-IP over http", () => {
+    const r = assessAuthorityUrl("http://192.168.1.5:3000");
+    expect(r.issues).toEqual(["insecure-http"]);
+  });
+});
+
+describe("renderEdgeInstallCommands — Linux/macOS (works today, no clone)", () => {
+  it("renders a single bash container one-liner with URL + token inlined", () => {
+    const [cmd] = renderEdgeInstallCommands({ authorityUrl: GOOD_URL, bootstrapToken: TOKEN, os: "linux" });
+    expect(cmd.kind).toBe("container");
+    expect(cmd.shell).toBe("bash");
+    expect(cmd.worksToday).toBe(true);
+    // no repo clone — fetch the single compose file by URL
+    expect(cmd.command).toContain("curl -fsSL");
+    expect(cmd.command).toContain(
+      `https://raw.githubusercontent.com/${DEFAULT_REPO_SLUG}/${DEFAULT_COMPOSE_REF}/docker-compose.edge-standalone.yml`,
+    );
+    // no .env edit — env passed inline, single-quoted
+    expect(cmd.command).toContain(`DPF_AUTHORITY_URL='${GOOD_URL}'`);
+    expect(cmd.command).toContain(`DPF_BOOTSTRAP_TOKEN='${TOKEN}'`);
+    expect(cmd.command).toContain("docker compose -f docker-compose.edge-standalone.yml up -d");
+  });
+
+  it("omits DPF_EDGE_NODE_NAME when no name is given, includes it when given", () => {
+    const without = renderEdgeInstallCommands({ authorityUrl: GOOD_URL, bootstrapToken: TOKEN, os: "linux" })[0];
+    expect(without.command).not.toContain("DPF_EDGE_NODE_NAME");
+    const withName = renderEdgeInstallCommands({
+      authorityUrl: GOOD_URL,
+      bootstrapToken: TOKEN,
+      os: "linux",
+      nodeName: "warehouse-2",
+    })[0];
+    expect(withName.command).toContain(`DPF_EDGE_NODE_NAME='warehouse-2'`);
+  });
+
+  it("labels macOS as enrollment-proof with a VM caveat", () => {
+    const [cmd] = renderEdgeInstallCommands({ authorityUrl: GOOD_URL, bootstrapToken: TOKEN, os: "macos" });
+    expect(cmd.shell).toBe("bash");
+    expect(cmd.note?.toLowerCase()).toContain("vm");
+  });
+
+  it("honors repoSlug + composeRef overrides (pin to a release tag)", () => {
+    const [cmd] = renderEdgeInstallCommands({
+      authorityUrl: GOOD_URL,
+      bootstrapToken: TOKEN,
+      os: "linux",
+      repoSlug: "acme/dpf",
+      composeRef: "v1.2.3",
+    });
+    expect(cmd.command).toContain("https://raw.githubusercontent.com/acme/dpf/v1.2.3/docker-compose.edge-standalone.yml");
+  });
+
+  it("escapes a single quote in the token so the shell command stays safe", () => {
+    const [cmd] = renderEdgeInstallCommands({
+      authorityUrl: GOOD_URL,
+      bootstrapToken: "dpfboot_a'b",
+      os: "linux",
+    });
+    expect(cmd.command).toContain(`DPF_BOOTSTRAP_TOKEN='dpfboot_a'\\''b'`);
+  });
+});
+
+describe("renderEdgeInstallCommands — Windows (PowerShell)", () => {
+  it("renders a PowerShell container command with Invoke-WebRequest + env", () => {
+    const [cmd] = renderEdgeInstallCommands({ authorityUrl: GOOD_URL, bootstrapToken: TOKEN, os: "windows" });
+    expect(cmd.shell).toBe("powershell");
+    expect(cmd.command).toContain("Invoke-WebRequest");
+    expect(cmd.command).toContain(`$env:DPF_AUTHORITY_URL = '${GOOD_URL}'`);
+    expect(cmd.command).toContain(`$env:DPF_BOOTSTRAP_TOKEN = '${TOKEN}'`);
+    expect(cmd.command).toContain("docker compose -f docker-compose.edge-standalone.yml up -d");
+  });
+
+  it("escapes single quotes for PowerShell by doubling them", () => {
+    const [cmd] = renderEdgeInstallCommands({
+      authorityUrl: GOOD_URL,
+      bootstrapToken: "dpfboot_a'b",
+      os: "windows",
+    });
+    expect(cmd.command).toContain(`$env:DPF_BOOTSTRAP_TOKEN = 'dpfboot_a''b'`);
+  });
+});
+
+describe("buildRemoteProvisioningPlan", () => {
+  it("returns a clean plan for a reachable https URL", () => {
+    const plan = buildRemoteProvisioningPlan({
+      resolvedAuthorityUrl: GOOD_URL,
+      bootstrapToken: TOKEN,
+      os: "linux",
+    });
+    expect(plan.authorityUrl).toBe(GOOD_URL);
+    expect(plan.authorityUrlIssues).toEqual([]);
+    expect(plan.commands).toHaveLength(1);
+    expect(plan.approveHint).toMatch(/pending/i);
+    expect(plan.nativeBinaryNote).toMatch(/native/i);
+  });
+
+  it("flags a loopback URL but still renders a usable command shape", () => {
+    const plan = buildRemoteProvisioningPlan({
+      resolvedAuthorityUrl: "http://localhost:3000",
+      bootstrapToken: TOKEN,
+      os: "linux",
+    });
+    expect(plan.authorityUrlIssues).toContain("loopback");
+    expect(plan.commands).toHaveLength(1);
+    // the (unreachable) URL is still shown so the operator can swap the host
+    expect(plan.commands[0].command).toContain("http://localhost:3000");
+  });
+
+  it("falls back to a visible placeholder host when no URL is configured", () => {
+    const plan = buildRemoteProvisioningPlan({
+      resolvedAuthorityUrl: null,
+      bootstrapToken: TOKEN,
+      os: "linux",
+    });
+    expect(plan.authorityUrlIssues).toEqual(["missing"]);
+    expect(plan.authorityUrl).toContain("<your-portal-host>");
+  });
+});

--- a/apps/web/lib/edge-node/remote-provisioning.ts
+++ b/apps/web/lib/edge-node/remote-provisioning.ts
@@ -1,0 +1,253 @@
+// Easy remote Edge Node provisioning — command renderer (pure).
+//
+// Turns an issued bootstrap token + a reachable Authority URL into a
+// ready-to-run install command for a host on *separate hardware*, so the
+// operator never clones the repo or hand-edits a `.env` (BI-D18DD7A9 /
+// edge-topology design §8). This module is intentionally pure (no DB, no
+// `next/*`, no env reads) so it is exhaustively unit-testable; the server
+// action in `lib/actions/edge-nodes.ts` resolves the URL + issues the token
+// and calls this.
+//
+// What works TODAY: the container path — fetch the single standalone compose
+// file by URL and `docker compose up` with the Authority URL + token passed
+// inline as environment. The signed, downloadable native Go binary (Mode 4,
+// the full-LAN-fidelity path on Windows/macOS) is not published for download
+// yet; it is surfaced as a note, not a runnable command, so we never hand the
+// operator a command that 404s.
+//
+// Spec: docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md §8
+
+export type EdgeHostOs = "linux" | "macos" | "windows";
+
+export const EDGE_HOST_OSES: readonly EdgeHostOs[] = ["linux", "macos", "windows"];
+
+/** Why the resolved Authority URL is unsuitable for a remote host. */
+export type AuthorityUrlIssue =
+  | "missing" // no URL could be resolved
+  | "loopback" // localhost / 127.* / ::1 / 0.0.0.0 / host.docker.internal — unreachable from another machine
+  | "insecure-http"; // plain HTTP — tokens are sniffable on a shared LAN (advisory, not fatal)
+
+export const DEFAULT_REPO_SLUG = "OpenDigitalProductFactory/opendigitalproductfactory";
+export const DEFAULT_COMPOSE_REF = "main";
+const STANDALONE_COMPOSE_FILE = "docker-compose.edge-standalone.yml";
+
+export interface RenderedInstallCommand {
+  /** Stable id for UI keys / telemetry. */
+  id: string;
+  /** Human label, e.g. "Linux — Docker (real LAN)". */
+  label: string;
+  kind: "container" | "native";
+  /** Whether this command runs end-to-end today (false = build-from-source / not yet downloadable). */
+  worksToday: boolean;
+  shell: "bash" | "powershell";
+  /** The ready-to-run command with the Authority URL + token already substituted. */
+  command: string;
+  /** Caveats the operator must see (e.g. degraded discovery on Docker Desktop). */
+  note?: string;
+}
+
+export interface RemoteProvisioningPlan {
+  /** The Authority URL baked into the commands (best-resolved; may still carry issues). */
+  authorityUrl: string;
+  /** Empty = good to go. Non-empty = surface a warning; commands are still rendered. */
+  authorityUrlIssues: AuthorityUrlIssue[];
+  os: EdgeHostOs;
+  commands: RenderedInstallCommand[];
+  /** One-line reminder that a remote node lands `pending` and needs Approve. */
+  approveHint: string;
+  /** Why the full-fidelity native binary isn't a one-click download yet. */
+  nativeBinaryNote: string;
+}
+
+const LOOPBACK_HOSTS = new Set([
+  "localhost",
+  "0.0.0.0",
+  "host.docker.internal",
+  "::1",
+  "[::1]",
+]);
+
+/**
+ * True when `url`'s host is not reachable from a *different* machine — the
+ * single most common remote-provisioning footgun (the multi-host runbook
+ * warns about exactly this). Covers localhost, the 127/8 loopback block,
+ * IPv6 ::1, 0.0.0.0, and Docker Desktop's host.docker.internal alias.
+ * Private LAN ranges (10/8, 172.16/12, 192.168/16) and mDNS `*.local` are
+ * NOT loopback — they are the intended remote targets.
+ */
+export function isLoopbackAuthorityUrl(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false; // unparseable — let assessAuthorityUrl flag "missing" instead
+  }
+  if (LOOPBACK_HOSTS.has(host)) return true;
+  if (host.startsWith("127.")) return true;
+  return false;
+}
+
+/**
+ * Assess a resolved base URL for remote use. Returns the URL to bake in
+ * (trailing slash stripped) plus any issues. A loopback or missing URL is
+ * flagged but NOT thrown — the operator may still want the rendered command
+ * with the right host swapped in, and the UI can prompt for a reachable URL.
+ */
+export function assessAuthorityUrl(resolved: string | null | undefined): {
+  url: string;
+  issues: AuthorityUrlIssue[];
+} {
+  const issues: AuthorityUrlIssue[] = [];
+  const trimmed = resolved?.trim().replace(/\/+$/, "") ?? "";
+  if (!trimmed) {
+    return { url: "", issues: ["missing"] };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { url: "", issues: ["missing"] };
+  }
+  if (isLoopbackAuthorityUrl(trimmed)) issues.push("loopback");
+  if (parsed.protocol === "http:") issues.push("insecure-http");
+  return { url: trimmed, issues };
+}
+
+/** Single-quote a value for safe interpolation into a POSIX `sh` command. */
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Quote a value for a PowerShell single-quoted string literal. */
+function psQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function rawComposeUrl(repoSlug: string, composeRef: string): string {
+  return `https://raw.githubusercontent.com/${repoSlug}/${composeRef}/${STANDALONE_COMPOSE_FILE}`;
+}
+
+/**
+ * Render the install command(s) for one host OS. The container path is the
+ * works-today, no-clone path for every OS; on macOS/Windows it enrolls and
+ * proves the path but Docker Desktop can't see the real LAN (the native
+ * binary closes that gap — see `nativeBinaryNote`).
+ */
+export function renderEdgeInstallCommands(input: {
+  authorityUrl: string;
+  bootstrapToken: string;
+  os: EdgeHostOs;
+  nodeName?: string;
+  repoSlug?: string;
+  composeRef?: string;
+}): RenderedInstallCommand[] {
+  const { authorityUrl, bootstrapToken, os } = input;
+  const repoSlug = input.repoSlug?.trim() || DEFAULT_REPO_SLUG;
+  const composeRef = input.composeRef?.trim() || DEFAULT_COMPOSE_REF;
+  const nodeName = input.nodeName?.trim();
+  const composeUrl = rawComposeUrl(repoSlug, composeRef);
+
+  if (os === "windows") {
+    // PowerShell: download the compose file, set env for this process, bring it up.
+    const lines = [
+      `Invoke-WebRequest -UseBasicParsing ${psQuote(composeUrl)} -OutFile ${psQuote(STANDALONE_COMPOSE_FILE)}`,
+      `$env:DPF_AUTHORITY_URL = ${psQuote(authorityUrl)}`,
+      `$env:DPF_BOOTSTRAP_TOKEN = ${psQuote(bootstrapToken)}`,
+      ...(nodeName ? [`$env:DPF_EDGE_NODE_NAME = ${psQuote(nodeName)}`] : []),
+      `docker compose -f ${STANDALONE_COMPOSE_FILE} up -d`,
+    ];
+    return [
+      {
+        id: "windows-container",
+        label: "Windows — Docker Desktop (enrollment proof)",
+        kind: "container",
+        worksToday: true,
+        shell: "powershell",
+        command: lines.join("\n"),
+        note:
+          "Docker Desktop runs the node inside its Linux VM, so it enrolls and proves the path but cannot see the host's real LAN. The native Windows service (Mode 4) is the full-LAN path — see below.",
+      },
+    ];
+  }
+
+  // Linux + macOS: a single POSIX one-liner. No repo clone, no .env edit —
+  // the Authority URL + token are passed inline as environment to compose.
+  const envInline = [
+    `DPF_AUTHORITY_URL=${shQuote(authorityUrl)}`,
+    `DPF_BOOTSTRAP_TOKEN=${shQuote(bootstrapToken)}`,
+    ...(nodeName ? [`DPF_EDGE_NODE_NAME=${shQuote(nodeName)}`] : []),
+  ].join(" ");
+  const command =
+    `curl -fsSL ${shQuote(composeUrl)} -o ${STANDALONE_COMPOSE_FILE} && \\\n` +
+    `${envInline} \\\n` +
+    `docker compose -f ${STANDALONE_COMPOSE_FILE} up -d`;
+
+  if (os === "macos") {
+    return [
+      {
+        id: "macos-container",
+        label: "macOS — Docker Desktop (enrollment proof)",
+        kind: "container",
+        worksToday: true,
+        shell: "bash",
+        command,
+        note:
+          "Docker Desktop runs the node inside its Linux VM, so it enrolls and proves the path but cannot see the Mac's real LAN. The native macOS LaunchDaemon (Mode 4) is the full-LAN path — see below.",
+      },
+    ];
+  }
+
+  return [
+    {
+      id: "linux-container",
+      label: "Linux — Docker (real LAN)",
+      kind: "container",
+      worksToday: true,
+      shell: "bash",
+      command,
+      note:
+        "Native Docker Engine on Linux (not Docker Desktop) sees the host's real NICs via the compose file's host-network mode — full discovery fidelity.",
+    },
+  ];
+}
+
+const NATIVE_BINARY_NOTE =
+  "Full-fidelity LAN discovery on Windows/macOS needs the native Mode 4 binary (services/edge-node-go), which sees the host's real NICs. A signed, one-click download is not published yet — until it ships, build it with `make build` from services/edge-node-go, or use the container command above to prove enrollment. Tracked under EP-EDGE-TOPOLOGY.";
+
+/**
+ * Compose a full remote-provisioning plan: assess the URL, render the
+ * command(s) for the chosen OS, and attach the operator reminders. The
+ * caller (server action) supplies an already-issued token and a resolved
+ * Authority URL.
+ */
+export function buildRemoteProvisioningPlan(input: {
+  resolvedAuthorityUrl: string | null | undefined;
+  bootstrapToken: string;
+  os: EdgeHostOs;
+  nodeName?: string;
+  repoSlug?: string;
+  composeRef?: string;
+}): RemoteProvisioningPlan {
+  const { url, issues } = assessAuthorityUrl(input.resolvedAuthorityUrl);
+  // Render against the resolved URL when we have one; otherwise a clearly
+  // bogus placeholder so the command shows the shape and the UI's "set a
+  // reachable URL" warning (from `issues`) tells the operator what to fix.
+  const authorityUrl = url || "https://<your-portal-host>:3000";
+  const commands = renderEdgeInstallCommands({
+    authorityUrl,
+    bootstrapToken: input.bootstrapToken,
+    os: input.os,
+    ...(input.nodeName ? { nodeName: input.nodeName } : {}),
+    ...(input.repoSlug ? { repoSlug: input.repoSlug } : {}),
+    ...(input.composeRef ? { composeRef: input.composeRef } : {}),
+  });
+  return {
+    authorityUrl,
+    authorityUrlIssues: issues,
+    os: input.os,
+    commands,
+    approveHint:
+      "The node enrolls as pending. Approve it here on this Edge Nodes page; it submits its first discovery run within one sweep interval (~5 min).",
+    nativeBinaryNote: NATIVE_BINARY_NOTE,
+  };
+}

--- a/docs/superpowers/plans/2026-06-19-edge-node-easy-remote-provisioning.md
+++ b/docs/superpowers/plans/2026-06-19-edge-node-easy-remote-provisioning.md
@@ -1,0 +1,33 @@
+# Easy Remote Edge Node Provisioning — Implementation Plan
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-19 |
+| BI | BI-D18DD7A9 (EP-EDGE-TOPOLOGY) |
+| Design | [`2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md`](../specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md) §8 |
+| Scope (this slice) | Backend: the command renderer + a server action that issues a scoped token and returns a ready-to-run command. UI + functional verification are the follow-on. |
+
+## The gap
+
+Putting an Edge Node on *separate hardware* today means: clone the whole monorepo on the second host (just for a compose file), hand-edit `.env`, copy a token out-of-band, then approve in the portal. The founder flagged this as "no easy way." Design §8's principle: **the operator never leaves the portal and never edits a file** — the portal holds the Authority URL and can mint a scoped token, so it should hand back a ready-to-run command.
+
+## What this slice lands
+
+1. **Pure renderer** — [`apps/web/lib/edge-node/remote-provisioning.ts`](../../../apps/web/lib/edge-node/remote-provisioning.ts):
+   - `isLoopbackAuthorityUrl` / `assessAuthorityUrl` — catch the #1 remote footgun (a `localhost`/`127.*`/`::1`/`host.docker.internal` Authority URL that no other machine can reach) and flag insecure plain-HTTP.
+   - `renderEdgeInstallCommands` — per host OS, a **no-clone, no-`.env`-edit** command: `curl` the single `docker-compose.edge-standalone.yml` by raw URL and `docker compose up` with the Authority URL + token passed inline as environment (PowerShell `Invoke-WebRequest` + `$env:` on Windows). Tokens/URLs are shell-quote-escaped.
+   - `buildRemoteProvisioningPlan` — composes URL assessment + commands + the pending→approve reminder + the native-binary note.
+   - **Works-today honesty:** the container path is real (the standalone compose + GHCR image exist). The signed, downloadable native Go binary (full-LAN fidelity on Windows/macOS) is **not** published yet, so it is surfaced as a *note*, never a runnable command that would 404.
+2. **Server action** — `prepareRemoteEdgeProvisioningAction` in [`apps/web/lib/actions/edge-nodes.ts`](../../../apps/web/lib/actions/edge-nodes.ts): validates OS, **reuses `issueEdgeBootstrapTokenAction`** (one issuance path: `manage_platform` gate + scope validation + mint, through the running Authority — sidestepping the host-side `@dpf/db` blocker EP-BUILD-D78835), resolves the URL via `resolveAppBaseUrl`, and returns the plan.
+
+## Verification
+
+- `apps/web/lib/edge-node/remote-provisioning.test.ts` — exhaustive unit coverage (loopback/URL assessment, all three OSes, quote escaping, repo/ref override, plan assembly). Runs in CI.
+- Executed source-local in the worktree via native Node type-stripping (toolchain-degraded host couldn't host vitest): **all assertions passed**.
+- Typecheck + the vitest suite run in CI (worktree has no compile toolchain; runtime sandbox lease was unavailable — DPF MCP offline — per AGENTS.md §5 this is an *unrun* gate deferred to CI, not a red one).
+
+## Follow-on (next slice, separate PR)
+
+- **UI** on `/platform/edge-nodes`: an "Add a node on another machine" flow (OS picker, optional MSP customer/site or retail location, copy-button command block, URL-not-reachable warning). UI-impacting → carries a `UX-Fit-Decision` (AGENTS.md §12).
+- **Functional verification** (VC-EDGE-REMOTE-EASY): drive the flow on the canonical install / shared sandbox; confirm a second host enrolls from the generated command with no clone/edit.
+- **Native binary download** (signed release artifact) so the Windows/macOS default becomes the full-LAN path, not just enrollment proof.


### PR DESCRIPTION
## Why

Founder `/goal` "make it happen" → after the opt-in flip ([#2111](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2111)), this is the next step toward the founder's original ask: *"no easy way to install the edge node on separate hardware and easily connect it to the portal."* `BI-D18DD7A9`, `EP-EDGE-TOPOLOGY`, design §8.

## What (backend slice)

The portal can now hand an operator **one ready-to-run command** to stand up an Edge Node on another machine — **no monorepo clone, no `.env` edit**.

- **Pure renderer** `lib/edge-node/remote-provisioning.ts`:
  - `isLoopbackAuthorityUrl` / `assessAuthorityUrl` — catch the #1 footgun (an Authority URL like `localhost`/`127.*`/`::1`/`host.docker.internal` that no *other* machine can reach) and flag insecure plain HTTP.
  - `renderEdgeInstallCommands` — per host OS: `curl` the single `docker-compose.edge-standalone.yml` by raw URL + `docker compose up` with the Authority URL + token inlined as env (PowerShell `Invoke-WebRequest` + `$env:` on Windows). Shell-quote-escaped.
  - **Works-today honesty:** the container path is real (standalone compose + GHCR image exist); the not-yet-downloadable native Go binary (full-LAN fidelity on Win/Mac) is surfaced as a *note*, never a command that 404s.
- **Server action** `prepareRemoteEdgeProvisioningAction` — reuses `issueEdgeBootstrapTokenAction` (one issuance path through the running Authority, sidestepping the host-side `@dpf/db` blocker `EP-BUILD-D78835`), resolves the URL via `resolveAppBaseUrl`, returns the plan.

## Verification

`remote-provisioning.test.ts` — exhaustive unit coverage (loopback/URL assessment, all three OSes, quote-escaping, repo/ref override, plan assembly). Executed source-local via native Node type-stripping (the toolchain-degraded host can't host vitest) — **all assertions passed**. Typecheck + the vitest suite run in CI (worktree has no compile toolchain; runtime sandbox lease unavailable — DPF MCP offline — so per AGENTS.md §5 this is an *unrun* gate deferred to CI, not red).

## Follow-on (separate PR)

UI "Add a node on another machine" on `/platform/edge-nodes` (UX-Fit gated) + functional verification (`VC-EDGE-REMOTE-EASY`) + a signed native-binary download. No new tables.

Plan: `docs/superpowers/plans/2026-06-19-edge-node-easy-remote-provisioning.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
