### PR TITLE
feat(backlog): auto-capture build/self-upgrade failures into a corrective BI

### DIFF
--- a/apps/web/lib/backlog/capture-corrective-bi.test.ts
+++ b/apps/web/lib/backlog/capture-corrective-bi.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findFirst = vi.fn();
+const create = vi.fn();
+const update = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    backlogItem: {
+      findFirst: (...a: unknown[]) => findFirst(...a),
+      create: (...a: unknown[]) => create(...a),
+      update: (...a: unknown[]) => update(...a),
+    },
+  },
+}));
+
+import { captureCorrectiveFailureBI, correctiveFingerprint } from "./capture-corrective-bi";
+
+beforeEach(() => {
+  findFirst.mockReset();
+  create.mockReset();
+  update.mockReset();
+});
+
+describe("correctiveFingerprint", () => {
+  it("is stable for the same (source, signature) and is 16 hex chars", () => {
+    const a = correctiveFingerprint("build-failure", "qa:Verify checkout");
+    const b = correctiveFingerprint("build-failure", "qa:Verify checkout");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("differs by source and by signature", () => {
+    expect(correctiveFingerprint("build-failure", "x")).not.toBe(
+      correctiveFingerprint("self-upgrade-failure", "x"),
+    );
+    expect(correctiveFingerprint("build-failure", "x")).not.toBe(
+      correctiveFingerprint("build-failure", "y"),
+    );
+  });
+});
+
+describe("captureCorrectiveFailureBI", () => {
+  it("creates a fingerprinted corrective BI on first failure", async () => {
+    findFirst.mockResolvedValue(null);
+    create.mockResolvedValue({ itemId: "BI-ABCD1234" });
+
+    const res = await captureCorrectiveFailureBI({
+      source: "build-failure",
+      signature: "qa:Verify checkout",
+      title: "[build-failure] 1 task(s) failed: Verify checkout",
+      body: "buildId: FB-1\nfailedTasks: 1",
+    });
+
+    const fp = correctiveFingerprint("build-failure", "qa:Verify checkout");
+    expect(res).toEqual({ action: "created", itemId: "BI-ABCD1234", fingerprint: fp });
+    expect(create).toHaveBeenCalledTimes(1);
+    const data = create.mock.calls[0][0].data;
+    expect(data.source).toBe("build-failure");
+    expect(data.workType).toBe("bug");
+    expect(data.status).toBe("triaging");
+    expect(data.type).toBe("product");
+    expect(data.body).toContain(`failureFingerprint: ${fp}`);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("dedups to occurrenceCount++ when an open item with the same signature exists", async () => {
+    findFirst.mockResolvedValue({ id: "row-1", itemId: "BI-EXISTING" });
+
+    const res = await captureCorrectiveFailureBI({
+      source: "self-upgrade-failure",
+      signature: "unknown|trace",
+      title: "t",
+      body: "b",
+    });
+
+    expect(res).toEqual({
+      action: "updated",
+      itemId: "BI-EXISTING",
+      fingerprint: correctiveFingerprint("self-upgrade-failure", "unknown|trace"),
+    });
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][0].data.occurrenceCount).toEqual({ increment: 1 });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("dedups by the stable fingerprint regardless of run id in the body", async () => {
+    findFirst.mockResolvedValue(null);
+    create.mockResolvedValue({ itemId: "BI-1" });
+    const fp = correctiveFingerprint("self-upgrade-failure", "unknown|same-trace");
+
+    await captureCorrectiveFailureBI({ source: "self-upgrade-failure", signature: "unknown|same-trace", title: "t", body: "runId: SUR-AAA" });
+    await captureCorrectiveFailureBI({ source: "self-upgrade-failure", signature: "unknown|same-trace", title: "t", body: "runId: SUR-BBB" });
+
+    for (const call of findFirst.mock.calls) {
+      expect(call[0].where.body.contains).toBe(`failureFingerprint: ${fp}`);
+      expect(call[0].where.source).toBe("self-upgrade-failure");
+    }
+  });
+
+  it("is best-effort: a prisma error returns skipped and never throws", async () => {
+    findFirst.mockRejectedValue(new Error("db down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const res = await captureCorrectiveFailureBI({ source: "build-failure", signature: "x", title: "t", body: "b" });
+      expect(res).toEqual({ action: "skipped", reason: "error" });
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});

--- a/apps/web/lib/backlog/capture-corrective-bi.ts
+++ b/apps/web/lib/backlog/capture-corrective-bi.ts
@@ -1,0 +1,96 @@
+// apps/web/lib/backlog/capture-corrective-bi.ts
+//
+// Best-effort capture of a build / self-upgrade FAILURE into a fingerprinted
+// corrective BacklogItem. (BI-9EA09823)
+//
+// "Every bug is a permanent upgrade" is systematized for incidents -> CI guards,
+// but the failure -> capture half was voluntary: Build Studio build failures and
+// self-upgrade failures auto-filed nothing. This turns "an agent must remember
+// to call record_functional_failure_evidence" into "the failure chokepoint
+// always captures."
+//
+// Deduped by failure SIGNATURE (never a run/build id) so a recurring failure
+// increments occurrenceCount instead of spamming new items — the same mechanic
+// the record_functional_failure_evidence tool uses (mcp-tools.ts), extracted
+// here so the orchestrator / self-upgrade runner can call it server-side.
+//
+// NEVER throws: a failure inside capture must not corrupt the failure path that
+// called it.
+
+import { createHash, randomUUID } from "node:crypto";
+import { prisma } from "@dpf/db";
+
+export type CorrectiveFailureSource = "build-failure" | "self-upgrade-failure";
+
+export type CorrectiveFailureInput = {
+  source: CorrectiveFailureSource;
+  /**
+   * Stable failure SIGNATURE — a description of *how* it failed, NEVER a
+   * run/build id. This is what the fingerprint hashes, so two runs that fail
+   * the same way dedup to one item.
+   */
+  signature: string;
+  title: string;
+  /** Free-text detail. The `failureFingerprint:` line is prepended by the helper. */
+  body: string;
+  submittedById?: string | null;
+  agentId?: string | null;
+};
+
+export type CorrectiveCaptureResult =
+  | { action: "created" | "updated"; itemId: string; fingerprint: string }
+  | { action: "skipped"; reason: string };
+
+/** 16-hex fingerprint of (source, signature). Exported for tests + callers. */
+export function correctiveFingerprint(source: string, signature: string): string {
+  return createHash("sha256").update(`${source}|${signature}`).digest("hex").slice(0, 16);
+}
+
+export async function captureCorrectiveFailureBI(
+  input: CorrectiveFailureInput,
+): Promise<CorrectiveCaptureResult> {
+  const fingerprint = correctiveFingerprint(input.source, input.signature);
+  try {
+    // Dedup on the fingerprint stored as a body line (mirrors the
+    // functional-test-failure dedup query) scoped to this source so the
+    // build / self-upgrade / functional-test spaces never cross-collide.
+    const existing = await prisma.backlogItem.findFirst({
+      where: {
+        source: input.source,
+        status: { notIn: ["done", "deferred"] },
+        body: { contains: `failureFingerprint: ${fingerprint}` },
+      },
+      select: { id: true, itemId: true },
+    });
+
+    if (existing) {
+      await prisma.backlogItem.update({
+        where: { id: existing.id },
+        data: { occurrenceCount: { increment: 1 }, lastSeenAt: new Date() },
+      });
+      return { action: "updated", itemId: existing.itemId, fingerprint };
+    }
+
+    const created = await prisma.backlogItem.create({
+      data: {
+        itemId: `BI-${randomUUID().slice(0, 8).toUpperCase()}`,
+        title: input.title.slice(0, 200),
+        type: "product",
+        workType: "bug",
+        status: "triaging",
+        source: input.source,
+        submittedById: input.submittedById ?? null,
+        agentId: input.agentId ?? null,
+        lastSeenAt: new Date(),
+        body: `failureFingerprint: ${fingerprint}\n${input.body}`,
+      },
+      select: { itemId: true },
+    });
+    return { action: "created", itemId: created.itemId, fingerprint };
+  } catch (err) {
+    // Best-effort: log loudly (make-silent-failures-observable) but never throw.
+    // eslint-disable-next-line no-console
+    console.error("[capture-corrective-bi] best-effort capture failed:", err);
+    return { action: "skipped", reason: "error" };
+  }
+}

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -1720,6 +1720,39 @@ export async function runBuildOrchestrator(params: {
     })),
   };
 
+  // BI-9EA09823 — best-effort, additive: a build that failed (a failed task or a
+  // BLOCKED/NEEDS_CONTEXT task that never advanced to review) lands a
+  // fingerprinted corrective BI. Keyed on the sorted role:title of the failing
+  // tasks — NOT buildId — so the same feature failing the same way increments
+  // occurrenceCount instead of spamming a new item on every rebuild.
+  const blockingTasks = allResults.filter(
+    r => !r.success || r.outcome === "BLOCKED" || r.outcome === "NEEDS_CONTEXT",
+  );
+  if (blockingTasks.length > 0) {
+    try {
+      const { captureCorrectiveFailureBI } = await import("@/lib/backlog/capture-corrective-bi");
+      const signature = blockingTasks
+        .map(r => `${r.task.specialist}:${r.task.title}`)
+        .sort()
+        .join("|");
+      await captureCorrectiveFailureBI({
+        source: "build-failure",
+        signature,
+        title: `[build-failure] ${blockingTasks.length} task(s) failed: ${blockingTasks[0]!.task.title}`.slice(0, 200),
+        body: [
+          `buildId: ${buildId}`,
+          `failedTasks: ${failedTasks}`,
+          ``,
+          ...blockingTasks.map(
+            r => `- [${r.outcome}] ${r.task.specialist} / ${r.task.title}: ${sanitizeSpecialistOutput(r.result.content.slice(0, 200))}`,
+          ),
+        ].join("\n"),
+      });
+    } catch (err) {
+      console.error("[orchestrator] corrective-BI capture failed:", err);
+    }
+  }
+
   return {
     content: formatBuildCompleteMessage(summary),
     totalTasks,

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -79,6 +79,32 @@ export async function failRun(runId: string, error: string) {
     data: { status: "failed", completedAt: new Date(), failureLog: error },
   });
   await safeSyncSelfUpgradeChangeRecord(runId);
+  // BI-9EA09823 — best-effort: every self-upgrade failure lands a fingerprinted
+  // corrective BI, keyed on the failure CLASS (not runId) so recurrences
+  // increment occurrenceCount instead of spamming new items. The run row is
+  // already persisted above, so a throw here cannot corrupt run state — but the
+  // helper never throws anyway.
+  try {
+    const { classifyBuildFailure } = await import("@/lib/self-upgrade/build-failure-classifier");
+    const cls = classifyBuildFailure({ log: error });
+    const { captureCorrectiveFailureBI } = await import("@/lib/backlog/capture-corrective-bi");
+    await captureCorrectiveFailureBI({
+      source: "self-upgrade-failure",
+      signature: `${cls.class}|${cls.failingTrace.slice(0, 200)}`,
+      title: `[self-upgrade] ${cls.class}: ${cls.summary}`.slice(0, 200),
+      body: [
+        `class: ${cls.class}`,
+        `disposition: ${cls.isMainDefectVsEnvironment ?? "unknown"}`,
+        `playbook: ${cls.playbookLink}`,
+        `runId: ${runId}`,
+        ``,
+        cls.failingTrace,
+      ].join("\n"),
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[failRun] corrective-BI capture failed:", err);
+  }
   return updated;
 }
 


### PR DESCRIPTION
## What

Build Studio build failures and self-upgrade failures auto-filed **nothing** — the capture primitives existed (`record_functional_failure_evidence` with fingerprint dedup) but required an agent to remember to call them. This wires the *failure → permanent-upgrade capture* half ("every bug is a permanent upgrade") into both failure chokepoints, so a failure **always** lands a fingerprinted, deduped corrective BI.

## How

- **New helper** `apps/web/lib/backlog/capture-corrective-bi.ts` extracts the existing functional-test-failure dedup mechanic into a reusable, server-callable `captureCorrectiveFailureBI()`: hash the failure **signature** (never a run/build id), `findFirst` on the fingerprint body line, `occurrenceCount++` on recurrence else create a `workType:bug` / `source:<failure-kind>` item in `triaging`. **Best-effort — never throws**, so it can't corrupt the failure path that called it.
- **`run-store.ts` `failRun`**: classifies via `build-failure-classifier` and keys the fingerprint on the failure **class** — one insertion covers all `failRun` call sites.
- **`build-orchestrator.ts`**: on a build that ended with failed / `BLOCKED` / `NEEDS_CONTEXT` tasks, keys the fingerprint on the sorted `role:title` of the blocking tasks so the same feature failing the same way **dedups across rebuilds** instead of spamming.

No new contract/route/schema — new `source` values (`build-failure`, `self-upgrade-failure`) are free-form strings that keep these out of the existing `functional-test-failure` dedup space.

## Verification

Unit test (`capture-corrective-bi.test.ts`, mocked prisma): create / dedup-to-occurrenceCount++ / stable-key-across-runIds / best-effort-never-throws.

⚠️ **Local vitest was unavailable this session** — the shared root `node_modules` was churned/emptied by concurrent work, and reinstalling on the shared clone mid-multi-session is the corruption risk DPF explicitly avoids. So **CI is the verification of record** here (unit tests + typecheck + build), per AGENTS.md §5 "unrun gate, not red gate." The code mirrors the existing `record_functional_failure_evidence` patterns exactly.

BI-9EA09823 (EP-LEARNING-COMMONS) · from the 2026-06-19 agent-architecture review (gap 8). `Process-Spine-Decision` attestation in the commit (additive wiring, no new contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
