### PR TITLE
feat(agentic): tier-aware compaction + real-window context-pressure ratio

### DIFF
--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -51,6 +51,10 @@ export interface RoutedInferenceResult {
   routeDecision: RouteDecision;
   /** EP-INF-009d: Set when interactionMode is "background". Poll via pollAsyncOperation(). */
   asyncOperationId?: string;
+  /** Resolved endpoint's context window (tokens) when known; null for local /
+   *  unknown. The agentic loop learns this from the first dispatch to size
+   *  compaction + the context-pressure gauge to the real window (BI-9679EB1A). */
+  resolvedMaxContextTokens?: number | null;
 }
 
 // ─── Error ──────────────────────────────────────────────────────────────────
@@ -677,6 +681,7 @@ export async function routeAndCall(
     toolsStripped,
     routeDecision: decision,
     responseId: result.responseId,
+    resolvedMaxContextTokens: selectedManifest?.maxContextTokens ?? null,
   };
 }
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -30,7 +30,7 @@ import {
   planCompletionGate,
   planProgress,
 } from "./execution-plan";
-import { estimateContextTokens, classifyContextPressure } from "./context-pressure";
+import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } from "./context-pressure";
 
 // Safety ceiling — NOT a behavioral limit. The loop terminates when the model
 // responds with text only (no tool calls), matching the Anthropic API pattern
@@ -888,10 +888,18 @@ function truncateMessageContent(content: string, maxChars: number, label: string
 }
 
 
-function compactAgenticMessages(messages: ChatMessage[]): ChatMessage[] {
-  const scopedMessages = messages.length <= MAX_AGENTIC_HISTORY_MESSAGES
+function compactAgenticMessages(messages: ChatMessage[], maxContextTokens?: number | null): ChatMessage[] {
+  // BI-9679EB1A: size the caps from the real model window when known, never
+  // below today's floor. Unknown window (incl. iteration 0) -> floor exactly,
+  // so the unknown-window path is byte-for-byte identical to before.
+  const caps = deriveCompactionCaps(maxContextTokens, {
+    maxHistory: MAX_AGENTIC_HISTORY_MESSAGES,
+    toolCap: MAX_TOOL_RESULT_CHARS,
+    textCap: MAX_TEXT_MESSAGE_CHARS,
+  });
+  const scopedMessages = messages.length <= caps.maxHistory
     ? messages
-    : [messages[0]!, ...messages.slice(-(MAX_AGENTIC_HISTORY_MESSAGES - 1))];
+    : [messages[0]!, ...messages.slice(-(caps.maxHistory - 1))];
 
   const retainedToolCallIds = new Set(
     scopedMessages.flatMap((message) =>
@@ -912,12 +920,12 @@ function compactAgenticMessages(messages: ChatMessage[]): ChatMessage[] {
       if (message.role === "tool") {
         return {
           ...message,
-          content: truncateMessageContent(message.content, MAX_TOOL_RESULT_CHARS, "tool output"),
+          content: truncateMessageContent(message.content, caps.toolCap, "tool output"),
         };
       }
       return {
         ...message,
-        content: truncateMessageContent(message.content, MAX_TEXT_MESSAGE_CHARS, "message context"),
+        content: truncateMessageContent(message.content, caps.textCap, "message context"),
       };
     });
 }
@@ -1131,6 +1139,7 @@ export async function runAgenticLoop(params: {
   const startTime = Date.now();
   let inferenceCallCount = 0;
   let ctxPeakTokens = 0; // Peak assembled context (est. tokens) this turn — dumb-zone gauge.
+  let resolvedMaxContextTokens: number | null = null; // BI-9679EB1A: learned from the first dispatch; sizes compaction + the gauge to the real window.
   let sandboxUnavailableCount = 0; // Circuit breaker: stop trying sandbox tools if unavailable
   let previousResponseId: string | undefined; // Responses API conversation chaining
 
@@ -1150,7 +1159,7 @@ export async function runAgenticLoop(params: {
         `dispatches=${inferenceCallCount} nudges=${continuationNudges} ` +
         `toolsAttached=${toolsAttachedForTurn} executedTools=${executedTools.length} ` +
         `totalMs=${Date.now() - startTime} ` +
-        `ctxPeakTokens=${ctxPeakTokens} ctxZone=${classifyContextPressure(ctxPeakTokens).zone}`,
+        `ctxPeakTokens=${ctxPeakTokens} ctxZone=${classifyContextPressure(ctxPeakTokens, resolvedMaxContextTokens).zone}`,
       ),
     );
     // BI-47443B67: persist the same rollup durably so the regression detector
@@ -1334,8 +1343,8 @@ export async function runAgenticLoop(params: {
     // only — the array is sent unchanged; this just makes context fill visible
     // per dispatch (the autonomous loop is the run most likely to drift into
     // the dumb zone). See ./context-pressure.
-    const assembledMessages = withPlanReminder(compactAgenticMessages(messages));
-    const ctxPressure = classifyContextPressure(estimateContextTokens(assembledMessages, systemPrompt));
+    const assembledMessages = withPlanReminder(compactAgenticMessages(messages, resolvedMaxContextTokens));
+    const ctxPressure = classifyContextPressure(estimateContextTokens(assembledMessages, systemPrompt), resolvedMaxContextTokens);
     if (ctxPressure.estimatedTokens > ctxPeakTokens) ctxPeakTokens = ctxPressure.estimatedTokens;
     if (ctxPressure.zone !== "sharp") {
       console.log(
@@ -1415,6 +1424,9 @@ export async function runAgenticLoop(params: {
     }
 
     lastResult = result;
+    if (resolvedMaxContextTokens == null && result.resolvedMaxContextTokens != null) {
+      resolvedMaxContextTokens = result.resolvedMaxContextTokens;
+    }
     totalInputTokens += result.inputTokens;
     totalOutputTokens += result.outputTokens;
 

--- a/apps/web/lib/tak/context-pressure.test.ts
+++ b/apps/web/lib/tak/context-pressure.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   estimateContextTokens,
   classifyContextPressure,
+  deriveCompactionCaps,
   CONTEXT_WARNING_ZONE_TOKENS,
   CONTEXT_DUMB_ZONE_TOKENS,
 } from "./context-pressure";
@@ -61,5 +62,52 @@ describe("classifyContextPressure", () => {
 
   it("keeps the thresholds ordered (sharp < warning < dumb)", () => {
     expect(CONTEXT_WARNING_ZONE_TOKENS).toBeLessThan(CONTEXT_DUMB_ZONE_TOKENS);
+  });
+});
+
+describe("classifyContextPressure — ratio-of-window (BI-9679EB1A)", () => {
+  it("bands by ratio when the window is known", () => {
+    expect(classifyContextPressure(50_000, 200_000).zone).toBe("sharp"); // 0.25
+    expect(classifyContextPressure(130_000, 200_000).zone).toBe("warning"); // 0.65
+    expect(classifyContextPressure(170_000, 200_000).zone).toBe("dumb"); // 0.85
+  });
+
+  it("does not cry wolf on a large window where absolute thresholds would", () => {
+    // 190k tokens is past the absolute dumb floor (180k) but only 19% of a 1M window.
+    expect(classifyContextPressure(190_000).zone).toBe("dumb");
+    expect(classifyContextPressure(190_000, 1_000_000).zone).toBe("sharp");
+  });
+
+  it("falls back to absolute thresholds for an unknown / non-positive window", () => {
+    expect(classifyContextPressure(190_000, null).zone).toBe("dumb");
+    expect(classifyContextPressure(190_000, 0).zone).toBe("dumb");
+    expect(classifyContextPressure(190_000, undefined).zone).toBe("dumb");
+  });
+});
+
+describe("deriveCompactionCaps (BI-9679EB1A)", () => {
+  const FLOOR = { maxHistory: 24, toolCap: 1_500, textCap: 4_000 };
+
+  it("returns the floor exactly for an unknown / non-positive window (non-regressive)", () => {
+    expect(deriveCompactionCaps(undefined, FLOOR)).toEqual(FLOOR);
+    expect(deriveCompactionCaps(null, FLOOR)).toEqual(FLOOR);
+    expect(deriveCompactionCaps(0, FLOOR)).toEqual(FLOOR);
+  });
+
+  it("never returns a cap below the floor, even for a tiny local window", () => {
+    const small = deriveCompactionCaps(8_000, FLOOR);
+    expect(small.maxHistory).toBeGreaterThanOrEqual(FLOOR.maxHistory);
+    expect(small.toolCap).toBeGreaterThanOrEqual(FLOOR.toolCap);
+    expect(small.textCap).toBeGreaterThanOrEqual(FLOOR.textCap);
+  });
+
+  it("raises the history depth for a large window, monotonic in window size", () => {
+    const w200k = deriveCompactionCaps(200_000, FLOOR);
+    const w1m = deriveCompactionCaps(1_000_000, FLOOR);
+    expect(w200k.maxHistory).toBeGreaterThan(FLOOR.maxHistory);
+    expect(w1m.maxHistory).toBeGreaterThan(w200k.maxHistory);
+    // Per-message caps stay at/above the floor (depth grows, per-msg size does not shrink).
+    expect(w1m.toolCap).toBeGreaterThanOrEqual(FLOOR.toolCap);
+    expect(w1m.textCap).toBeGreaterThanOrEqual(FLOOR.textCap);
   });
 });

--- a/apps/web/lib/tak/context-pressure.ts
+++ b/apps/web/lib/tak/context-pressure.ts
@@ -47,6 +47,19 @@ export type ContextPressure = {
 export const CONTEXT_WARNING_ZONE_TOKENS = 100_000;
 export const CONTEXT_DUMB_ZONE_TOKENS = 180_000;
 
+// When the real model context window IS known (BI-9679EB1A), band by ratio-of-
+// window instead of the absolute hints above — a 0.85-full 200k model is in the
+// dumb zone, a 0.19-full 1M model is not. Tunable.
+export const CONTEXT_WARNING_ZONE_RATIO = 0.6;
+export const CONTEXT_DUMB_ZONE_RATIO = 0.8;
+
+// Fraction of the real window devoted to RETAINED HISTORY (the rest covers the
+// system prompt, tool schemas, the current turn, and output headroom). Used to
+// size compaction caps from the real window — never BELOW today's floor, so the
+// known-window path is strictly non-regressive.
+const HISTORY_WINDOW_FRACTION = 0.5;
+const AVG_TOKENS_PER_MSG = 750;
+
 /**
  * Rough token estimate (~chars/4) for the assembled prompt actually sent to the
  * model this dispatch: the system prompt plus every message's content, plus any
@@ -69,13 +82,63 @@ export function estimateContextTokens(
   return Math.ceil(chars / 4);
 }
 
-/** Band an estimated token load into a dumb-zone pressure zone. Pure. */
-export function classifyContextPressure(estimatedTokens: number): ContextPressure {
-  const zone: ContextPressureZone =
-    estimatedTokens >= CONTEXT_DUMB_ZONE_TOKENS
-      ? "dumb"
-      : estimatedTokens >= CONTEXT_WARNING_ZONE_TOKENS
-        ? "warning"
-        : "sharp";
+/**
+ * Band an estimated token load into a dumb-zone pressure zone. Pure.
+ *
+ * When `maxContextTokens` is a known positive window, band by ratio-of-window
+ * (precise per-model signal); otherwise fall back to the absolute, model-
+ * agnostic hints. The param is optional, so existing call sites are unchanged.
+ */
+export function classifyContextPressure(
+  estimatedTokens: number,
+  maxContextTokens?: number | null,
+): ContextPressure {
+  const win = typeof maxContextTokens === "number" && maxContextTokens > 0 ? maxContextTokens : 0;
+  let zone: ContextPressureZone;
+  if (win > 0) {
+    const ratio = estimatedTokens / win;
+    zone =
+      ratio >= CONTEXT_DUMB_ZONE_RATIO ? "dumb" : ratio >= CONTEXT_WARNING_ZONE_RATIO ? "warning" : "sharp";
+  } else {
+    zone =
+      estimatedTokens >= CONTEXT_DUMB_ZONE_TOKENS
+        ? "dumb"
+        : estimatedTokens >= CONTEXT_WARNING_ZONE_TOKENS
+          ? "warning"
+          : "sharp";
+  }
   return { estimatedTokens, zone };
+}
+
+export type CompactionCaps = {
+  /** Max history messages retained (besides the always-kept first message). */
+  maxHistory: number;
+  /** Per-tool-result char cap. */
+  toolCap: number;
+  /** Per-text-message char cap. */
+  textCap: number;
+};
+
+/**
+ * Size the agentic loop's compaction caps from the real model window when known
+ * (BI-9679EB1A), clamped to NEVER go below today's `floor`. Pure.
+ *
+ * Invariant: an unknown / non-positive window returns `floor` exactly (byte-for-
+ * byte identical to pre-window behavior), and any known window only ever RAISES
+ * a cap. So a frontier model retains more history; a small/local model and the
+ * first dispatch (window not yet learned) are unchanged.
+ */
+export function deriveCompactionCaps(
+  maxContextTokens: number | null | undefined,
+  floor: CompactionCaps,
+): CompactionCaps {
+  const win = typeof maxContextTokens === "number" && maxContextTokens > 0 ? maxContextTokens : 0;
+  if (win === 0) return floor;
+  const historyTokenBudget = Math.floor(win * HISTORY_WINDOW_FRACTION);
+  const historyBudgetChars = historyTokenBudget * 4;
+  const maxHistory = Math.max(floor.maxHistory, Math.floor(historyTokenBudget / AVG_TOKENS_PER_MSG));
+  const perMsgChars = Math.floor(historyBudgetChars / Math.max(1, maxHistory));
+  const textCap = Math.max(floor.textCap, perMsgChars);
+  const toolCap = Math.max(floor.toolCap, Math.floor(perMsgChars / 2));
+  return { maxHistory, toolCap, textCap };
 }


### PR DESCRIPTION
## What

The dumb-zone gauge ([#2112](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2112)) measured assembled tokens against **absolute, model-agnostic** thresholds, and compaction used **fixed tier-agnostic caps** (24 msgs / 1500 tool chars / 4000 text chars). This threads the resolved model's **real context window** into the loop.

## How

- **`routed-inference.ts`** surfaces `resolvedMaxContextTokens` (from the selected endpoint manifest) on `RoutedInferenceResult`.
- **`agentic-loop.ts`** learns it from the **first dispatch** and, from iteration 1 on, sizes compaction from a fraction of the real window via the pure `deriveCompactionCaps`, and bands the gauge by **ratio-of-window** via `classifyContextPressure`'s new optional param.

**Strictly non-regressive by construction:** an unknown/non-positive window (including iteration 0 and local models) returns the floor **exactly**, and any known window only ever **raises** a cap (`Math.max`). A frontier 200k/1M model retains more history *depth*; small/local models and the first dispatch are byte-for-byte unchanged. The ratio gauge also stops the absolute 180k threshold from crying wolf on a 1M-window model.

## Verification

Pure helpers (`deriveCompactionCaps` + the window-aware `classifyContextPressure`) covered by `context-pressure.test.ts`; existing tests stay green (the new params are optional, and the unknown-window path is identical to today). ⚠️ **Local vitest unavailable this session** (shared-clone `node_modules` churned) — **CI is the verification of record** (unit tests + typecheck + build).

> ⚠️ This is the one BI in the set that **changes what the model receives** (only *upward*, only on the known-window path). It increases retained history + input tokens/cost for large-window models by design — **Build Studio should validate the larger-window retention while tuning.**

BI-9679EB1A (EP-COST-001) · 2026-06-19 agent-architecture review (gap 2 behavior half). `Process-Spine-Decision` attestation in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
