### PR TITLE
feat(contribution): 2-state contribution model + per-change suggest-then-confirm (EP-1A78BAE1)

### DIFF
--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -5,6 +5,7 @@ import { ForkSetupPanel } from "@/components/admin/ForkSetupPanel";
 import LegacyTokenOverrideBanner from "@/components/admin/LegacyTokenOverrideBanner";
 import { McpTokenManager } from "@/components/admin/McpTokenManager";
 import { PlatformDevelopmentForm } from "@/components/admin/PlatformDevelopmentForm";
+import { PrivatePathsEditor } from "@/components/admin/PrivatePathsEditor";
 import TokenExpiryBanner from "@/components/admin/TokenExpiryBanner";
 import {
   getGitHubConnectedState,
@@ -12,6 +13,7 @@ import {
   getUntrackedFeatureCount,
   hasContributionToken,
   hasGitBackupCredential,
+  listPrivatePathRules,
 } from "@/lib/actions/platform-dev-config";
 import { isContributionModelEnabled } from "@/lib/flags/contribution-model";
 import { getDisplayPseudonym } from "@/lib/integrate/identity-privacy";
@@ -25,6 +27,7 @@ export default async function AdminPlatformDevelopmentPage() {
     : 0;
   const hasCredential = await hasGitBackupCredential();
   const hasContribToken = await hasContributionToken();
+  const privatePathRules = await listPrivatePathRules();
   // Pseudonym is only defined once the install has seeded its client identity.
   // Catch: during the first boot the identity may not be ready yet.
   const pseudonym = await getDisplayPseudonym().catch(() => null);
@@ -75,6 +78,9 @@ export default async function AdminPlatformDevelopmentPage() {
         pseudonym={pseudonym}
         initialConnected={initialConnected}
       />
+      <div className="mt-6">
+        <PrivatePathsEditor rules={privatePathRules} />
+      </div>
       <McpTokenManager
         baseUrl={baseUrl}
       />

--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -20,7 +20,7 @@ import type { PlatformDevPolicyState } from "@/lib/platform-dev-policy";
 export default async function AdminPlatformDevelopmentPage() {
   const config = await getPlatformDevConfig();
   const policyState: PlatformDevPolicyState = config?.policyState ?? "policy_pending";
-  const untrackedCount = config?.contributionMode === "fork_only"
+  const untrackedCount = (config?.contributionMode === "private" || config?.contributionMode === "fork_only")
     ? await getUntrackedFeatureCount()
     : 0;
   const hasCredential = await hasGitBackupCredential();
@@ -63,7 +63,7 @@ export default async function AdminPlatformDevelopmentPage() {
       />
       <PlatformDevelopmentForm
         policyState={policyState}
-        currentMode={(config?.contributionMode as "fork_only" | "selective" | "contribute_all") ?? null}
+        currentMode={policyState === "policy_pending" ? null : policyState}
         configuredAt={config?.configuredAt?.toISOString() ?? null}
         configuredByEmail={config?.configuredBy?.email ?? null}
         gitRemoteUrl={config?.gitRemoteUrl ?? null}

--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -4,6 +4,8 @@ import { loadPersistedImpactSummary } from "@/lib/self-upgrade/impact";
 import SelfUpgradeClient from "@/components/ops/SelfUpgradeClient";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
 import { PlatformUpdateApplyPanel } from "@/components/admin/PlatformUpdateApplyPanel";
+import { LocalChangesLedger } from "@/components/ops/LocalChangesLedger";
+import { getLocalChangesLedger } from "@/lib/self-upgrade/local-changes-ledger";
 
 export default async function SelfUpgradePage() {
   // BI-D43EB266: Self-Upgrade is the single operator entry point for "update
@@ -11,10 +13,11 @@ export default async function SelfUpgradePage() {
   // primary path; the source-merge sub-step (PlatformUpdateApplyPanel) is
   // folded in below and surfaces only when the install customises source
   // (updatePending). getPlatformDevConfig can be null on a fresh install.
-  const [status, { runs, nextCursor }, devConfig] = await Promise.all([
+  const [status, { runs, nextCursor }, devConfig, localChanges] = await Promise.all([
     getSelfUpgradeStatus(),
     listSelfUpgradeRuns(),
     getPlatformDevConfig(),
+    getLocalChangesLedger(),
   ]);
 
   // Rehydrate the "What's in this update?" panel from the durable store so a
@@ -49,6 +52,10 @@ export default async function SelfUpgradePage() {
         updatePending={devConfig?.updatePending ?? false}
         pendingVersion={devConfig?.pendingVersion ?? null}
       />
+
+      <div className="mt-6">
+        <LocalChangesLedger result={localChanges} />
+      </div>
     </div>
   );
 }

--- a/apps/web/components/admin/AdvancedTokenPaste.test.tsx
+++ b/apps/web/components/admin/AdvancedTokenPaste.test.tsx
@@ -9,7 +9,7 @@ import { AdvancedTokenPaste } from "@/components/admin/AdvancedTokenPaste";
 
 describe("AdvancedTokenPaste", () => {
   it("renders the disclosure as a <details> element (collapsed by default)", () => {
-    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="contributing" />);
     // <details> without `open` attribute is collapsed by default in browsers.
     expect(html).toMatch(/^<details[^>]*>/);
     expect(html).not.toMatch(/<details[^>]*\bopen\b/);
@@ -17,7 +17,7 @@ describe("AdvancedTokenPaste", () => {
   });
 
   it("renders the fine-grained PAT section with help copy and an input", () => {
-    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="contributing" />);
     expect(html).toContain('data-testid="fine-grained-pat-section"');
     expect(html).toMatch(/Fine-grained PAT \(advanced\)/);
     expect(html).toMatch(/fine-grained PAT at github\.com\/settings\/personal-access-tokens/i);
@@ -27,7 +27,7 @@ describe("AdvancedTokenPaste", () => {
   });
 
   it("renders the classic PAT section with the no-expiry warning", () => {
-    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="contribute_all" />);
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="private" />);
     expect(html).toContain('data-testid="classic-pat-section"');
     expect(html).toMatch(/Classic PAT \(emergency\)/);
     expect(html).toMatch(/Classic PATs have no expiry/i);
@@ -37,8 +37,8 @@ describe("AdvancedTokenPaste", () => {
   });
 
   it("renders both sections regardless of mode prop", () => {
-    const fork = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
-    const all = renderToStaticMarkup(<AdvancedTokenPaste mode="contribute_all" />);
+    const fork = renderToStaticMarkup(<AdvancedTokenPaste mode="contributing" />);
+    const all = renderToStaticMarkup(<AdvancedTokenPaste mode="private" />);
     expect(fork).toContain('data-testid="fine-grained-pat-section"');
     expect(fork).toContain('data-testid="classic-pat-section"');
     expect(all).toContain('data-testid="fine-grained-pat-section"');
@@ -46,7 +46,7 @@ describe("AdvancedTokenPaste", () => {
   });
 
   it("uses distinct placeholder formats for each token tier", () => {
-    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="contributing" />);
     // Fine-grained PATs use the github_pat_ prefix; classic PATs use ghp_.
     expect(html).toMatch(/placeholder="github_pat_/);
     expect(html).toMatch(/placeholder="ghp_/);

--- a/apps/web/components/admin/AdvancedTokenPaste.tsx
+++ b/apps/web/components/admin/AdvancedTokenPaste.tsx
@@ -14,7 +14,7 @@ import { saveContributionSetup } from "@/lib/actions/platform-dev-config";
 // detection happens server-side in `validateGitHubToken` via prefix
 // inspection. The labels just steer the user toward the right token type.
 
-type ContributionMode = "fork_only" | "selective" | "contribute_all";
+type ContributionMode = "private" | "contributing";
 
 const FINE_GRAINED_HELP =
   "Create a fine-grained PAT at github.com/settings/personal-access-tokens with Repository Access limited to your fork and Contents: read and write. Expiry: 90 days or more.";

--- a/apps/web/components/admin/ContributionModelBanner.tsx
+++ b/apps/web/components/admin/ContributionModelBanner.tsx
@@ -20,8 +20,10 @@ export interface ContributionModelBannerProps {
 
 export function ContributionModelBanner(props: ContributionModelBannerProps) {
   if (!props.enabled) return null;
-  // fork_only never pushes anywhere — contributionModel is irrelevant.
-  if (props.contributionMode !== "selective" && props.contributionMode !== "contribute_all") {
+  // A private install never pushes anywhere — contributionModel is irrelevant.
+  // Show only for a contributing install (legacy selective/contribute_all incl.).
+  const m = props.contributionMode;
+  if (m !== "contributing" && m !== "selective" && m !== "contribute_all") {
     return null;
   }
   // Already configured — nothing to surface.

--- a/apps/web/components/admin/PlatformDevelopmentForm.test.tsx
+++ b/apps/web/components/admin/PlatformDevelopmentForm.test.tsx
@@ -32,18 +32,16 @@ const baseProps = {
 };
 
 describe("PlatformDevelopmentForm", () => {
-  it("renders the three contribution-mode options", () => {
+  it("renders the two contribution-mode options", () => {
     const html = renderToStaticMarkup(<PlatformDevelopmentForm {...baseProps} />);
-    expect(html).toContain("Keep everything here");
-    expect(html).toContain("Share selectively");
-    expect(html).toContain("Share everything");
+    expect(html).toContain("Keep everything on my system");
+    expect(html).toContain("Contribute improvements to the community");
   });
 
-  it("does not render the Connect card before mode is contribution and DCO is accepted", () => {
+  it("does not render the Connect card before mode is contributing and DCO is accepted", () => {
     const html = renderToStaticMarkup(<PlatformDevelopmentForm {...baseProps} />);
-    // Default selected is `selective`, but the wizard starts at "mode" until
-    // DCO is accepted — so neither connect card nor advanced paste should be
-    // visible yet.
+    // Default selected is `private` (fail-closed) — the contributing connect
+    // card and advanced paste should not be visible yet.
     expect(html).not.toContain('data-testid="github-connect-block"');
     expect(html).not.toContain('data-testid="connect-github-card"');
   });
@@ -52,7 +50,7 @@ describe("PlatformDevelopmentForm", () => {
     const html = renderToStaticMarkup(
       <PlatformDevelopmentForm
         {...baseProps}
-        currentMode="selective"
+        currentMode="contributing"
         dcoAcceptedAt="2026-04-24T12:00:00Z"
       />,
     );
@@ -70,7 +68,7 @@ describe("PlatformDevelopmentForm", () => {
     const html = renderToStaticMarkup(
       <PlatformDevelopmentForm
         {...baseProps}
-        currentMode="contribute_all"
+        currentMode="contributing"
         dcoAcceptedAt="2026-04-24T12:00:00Z"
       />,
     );
@@ -79,14 +77,14 @@ describe("PlatformDevelopmentForm", () => {
     expect(html).toMatch(/GitHub username will be visible/i);
   });
 
-  it("renders the fork-only backup form when mode=fork_only", () => {
+  it("renders the private-install backup form when mode=private", () => {
     const html = renderToStaticMarkup(
-      <PlatformDevelopmentForm {...baseProps} currentMode="fork_only" />,
+      <PlatformDevelopmentForm {...baseProps} currentMode="private" />,
     );
     expect(html).toContain("Backup your work (optional)");
     expect(html).toContain("Repository URL");
-    // The contribution Connect card is gated on contribution mode; should not
-    // appear in fork_only.
+    // The contribution Connect card is gated on contributing mode; it should
+    // not appear for a private install.
     expect(html).not.toContain('data-testid="github-connect-block"');
   });
 
@@ -94,7 +92,7 @@ describe("PlatformDevelopmentForm", () => {
     const html = renderToStaticMarkup(
       <PlatformDevelopmentForm
         {...baseProps}
-        currentMode="selective"
+        currentMode="contributing"
         dcoAcceptedAt="2026-04-24T12:00:00Z"
         dcoAcceptedByEmail="admin@example.com"
       />,
@@ -108,7 +106,7 @@ describe("PlatformDevelopmentForm", () => {
     const html = renderToStaticMarkup(
       <PlatformDevelopmentForm
         {...baseProps}
-        currentMode="selective"
+        currentMode="contributing"
         dcoAcceptedAt="2026-04-24T12:00:00Z"
         initialConnected={{
           username: "jane-dev",

--- a/apps/web/components/admin/PlatformDevelopmentForm.tsx
+++ b/apps/web/components/admin/PlatformDevelopmentForm.tsx
@@ -12,28 +12,24 @@ import {
   savePlatformDevConfig,
 } from "@/lib/actions/platform-dev-config";
 
-type ContributionMode = "fork_only" | "selective" | "contribute_all";
+// 2-state contribution model (EP-1A78BAE1). Per-change sharing is decided by a
+// suggestion + your confirmation when you ship, not by an up-front policy.
+type ContributionMode = "private" | "contributing";
 
 // ─── Mode Options ──────────────────────────────────────────────────────────
 
 const MODE_OPTIONS: { value: ContributionMode; label: string; description: string }[] = [
   {
-    value: "fork_only",
-    label: "Keep everything here",
+    value: "private",
+    label: "Keep everything on my system",
     description:
-      "Changes you make in Build Studio stay on your platform only. Nothing is shared externally.",
+      "Everything you build stays on your own system. Nothing is ever shared with the community.",
   },
   {
-    value: "selective",
-    label: "Share selectively",
+    value: "contributing",
+    label: "Contribute improvements to the community",
     description:
-      "After building a feature, the AI will ask if you'd like to share it with the community. You decide each time.",
-  },
-  {
-    value: "contribute_all",
-    label: "Share everything",
-    description:
-      "Features you build are shared with the community by default. You can still keep individual ones private.",
+      "When you ship a change, we suggest whether to keep it on your system or share it — and you make the final call. Nothing is shared unless you confirm.",
   },
 ];
 
@@ -84,12 +80,12 @@ interface PlatformDevelopmentFormProps {
 // ─── Component ──────────────────────────────────────────────────────────────
 
 export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
-  const [selected, setSelected] = useState<ContributionMode>(props.currentMode ?? "selective");
+  const [selected, setSelected] = useState<ContributionMode>(props.currentMode ?? "private");
   const [isPending, startTransition] = useTransition();
   const [saved, setSaved] = useState(false);
 
   // Wizard state
-  const isContributionMode = selected === "selective" || selected === "contribute_all";
+  const isContributionMode = selected === "contributing";
   const isAlreadySetUp = isContributionMode && !!props.dcoAcceptedAt;
   const [wizardStep, setWizardStep] = useState<WizardStep>(isAlreadySetUp ? "done" : "mode");
   const [dcoError, setDcoError] = useState<string | null>(null);
@@ -101,7 +97,7 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
   const handleModeSelect = (mode: ContributionMode) => {
     setSelected(mode);
     setSaved(false);
-    if (mode === "fork_only") {
+    if (mode === "private") {
       setWizardStep("mode");
     }
   };
@@ -109,7 +105,7 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
   const handleForkOnlySave = () => {
     setSaved(false);
     startTransition(async () => {
-      await savePlatformDevConfig("fork_only");
+      await savePlatformDevConfig("private");
 
       if (gitUrl !== (props.gitRemoteUrl ?? "")) {
         const { saveGitRemoteUrl } = await import("@/lib/actions/platform-dev-config");
@@ -205,8 +201,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
         ))}
       </div>
 
-      {/* ─── Fork Only: Git Backup ──────────────────────────────────────── */}
-      {selected === "fork_only" && (
+      {/* ─── Private install: Git Backup ────────────────────────────────── */}
+      {selected === "private" && (
         <div className="space-y-3 rounded-lg border border-[var(--dpf-border)] p-4">
           <div>
             <h3 className="text-sm font-semibold text-[var(--dpf-text)] mb-1">
@@ -326,9 +322,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
               repeat contributors, but reveals nothing about you or your organization.
             </p>
             <p>
-              {selected === "selective"
-                ? "You'll be asked each time whether to share or keep a feature private."
-                : "Features are shared by default, but you can keep any individual one private."}
+              When you ship a change, we suggest whether to keep it on your system or share it,
+              and you make the final call. Nothing is shared unless you confirm.
             </p>
           </div>
           <div className="flex justify-between items-center mt-4">
@@ -456,9 +451,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
             <div>
               <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Sharing is set up</h3>
               <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
-                {selected === "selective"
-                  ? "When the AI Coworker finishes building a feature, it will ask if you'd like to share it with the community."
-                  : "Features you build will be shared with the community by default. You can keep any individual feature private when asked."}
+                When the AI Coworker finishes a change, it suggests whether to keep it on your
+                system or share it with the community — and you make the final call.
               </p>
             </div>
           </div>

--- a/apps/web/components/admin/PrivatePathsEditor.test.tsx
+++ b/apps/web/components/admin/PrivatePathsEditor.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/platform-dev-config", () => ({
+  addPrivatePathRule: vi.fn(),
+  removePrivatePathRule: vi.fn(),
+}));
+
+import { PrivatePathsEditor } from "@/components/admin/PrivatePathsEditor";
+
+describe("PrivatePathsEditor", () => {
+  it("renders the empty state with an add form", () => {
+    const html = renderToStaticMarkup(<PrivatePathsEditor rules={[]} />);
+    expect(html).toContain("Keep these paths private");
+    expect(html).toMatch(/Pattern/);
+    expect(html).toContain(".dpf/private-paths");
+  });
+
+  it("lists existing rules with their patterns and reasons", () => {
+    const html = renderToStaticMarkup(
+      <PrivatePathsEditor
+        rules={[
+          { id: "1", pattern: "proprietary/", reason: "our pricing logic", createdAt: "2026-06-19T00:00:00Z" },
+          { id: "2", pattern: "**/*.secret", reason: null, createdAt: "2026-06-19T00:00:00Z" },
+        ]}
+      />,
+    );
+    expect(html).toContain("proprietary/");
+    expect(html).toContain("our pricing logic");
+    expect(html).toContain("**/*.secret");
+    expect(html).toContain('data-testid="remove-private-path"');
+  });
+});

--- a/apps/web/components/admin/PrivatePathsEditor.tsx
+++ b/apps/web/components/admin/PrivatePathsEditor.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import {
+  addPrivatePathRule,
+  removePrivatePathRule,
+  type PrivatePathRuleView,
+} from "@/lib/actions/platform-dev-config";
+
+// Private-paths editor (EP-1A78BAE1). Operator-only surface to manage glob
+// rules that mark paths as proprietary — they are never shared at public-hive
+// egress, regardless of a change's Keep/Share decision.
+
+export function PrivatePathsEditor({ rules }: { rules: PrivatePathRuleView[] }) {
+  const [pattern, setPattern] = useState("");
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleAdd = () => {
+    setError(null);
+    startTransition(async () => {
+      const res = await addPrivatePathRule(pattern, reason);
+      if (!res.ok) {
+        setError(res.error ?? "Could not add the rule.");
+        return;
+      }
+      setPattern("");
+      setReason("");
+    });
+  };
+
+  const handleRemove = (id: string) => {
+    startTransition(async () => {
+      await removePrivatePathRule(id);
+    });
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border border-[var(--dpf-border)] p-4">
+      <div>
+        <h3 className="text-sm font-semibold text-[var(--dpf-text)] mb-1">Keep these paths private</h3>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          Files matching these patterns are never shared with the community, no matter what you
+          choose when shipping a change. One gitignore-style pattern per rule (e.g.{" "}
+          <span className="font-mono">proprietary/</span> or{" "}
+          <span className="font-mono">**/*.secret</span>). These merge with the built-in{" "}
+          <span className="font-mono">.dpf/private-paths</span> list.
+        </p>
+      </div>
+
+      {rules.length > 0 && (
+        <ul className="space-y-1">
+          {rules.map((r) => (
+            <li
+              key={r.id}
+              className="flex items-center justify-between gap-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5"
+            >
+              <div className="min-w-0">
+                <span className="font-mono text-xs text-[var(--dpf-text)]">{r.pattern}</span>
+                {r.reason && (
+                  <span className="ml-2 text-xs text-[var(--dpf-muted)] truncate">— {r.reason}</span>
+                )}
+              </div>
+              <button
+                onClick={() => handleRemove(r.id)}
+                disabled={isPending}
+                className="text-xs text-[var(--dpf-accent)] hover:underline shrink-0"
+                data-testid="remove-private-path"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-[var(--dpf-text)] mb-1">Pattern</label>
+          <input
+            type="text"
+            value={pattern}
+            onChange={(e) => { setPattern(e.target.value); setError(null); }}
+            placeholder="proprietary/ or **/*.secret"
+            className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none font-mono"
+          />
+        </div>
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-[var(--dpf-text)] mb-1">Reason (optional)</label>
+          <input
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Why this stays private"
+            className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none"
+          />
+        </div>
+        <button
+          onClick={handleAdd}
+          disabled={isPending || !pattern.trim()}
+          className={[
+            "rounded px-4 py-1.5 text-sm font-medium transition-colors shrink-0",
+            isPending || !pattern.trim()
+              ? "bg-[var(--dpf-border)] text-[var(--dpf-muted)] cursor-not-allowed"
+              : "bg-[var(--dpf-accent)] text-white hover:opacity-90",
+          ].join(" ")}
+        >
+          Add
+        </button>
+      </div>
+
+      {error && <p className="text-xs text-[var(--dpf-accent)]">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/components/ops/LocalChangesLedger.tsx
+++ b/apps/web/components/ops/LocalChangesLedger.tsx
@@ -1,0 +1,44 @@
+import type { LocalChangesResult } from "@/lib/self-upgrade/local-changes-ledger";
+
+// Local-changes ledger (EP-1A78BAE1). Shows the changes kept on this system and
+// not shared with the community — the install's private delta over upstream.
+
+export function LocalChangesLedger({ result }: { result: LocalChangesResult }) {
+  return (
+    <section className="rounded-lg border border-[var(--dpf-border)] p-4 space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold text-[var(--dpf-text)] mb-1">
+          Changes kept on your system
+        </h3>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          These changes live only on this system and have not been shared with the community.
+          Shared changes flow upstream and come back through updates, so anything listed here is
+          your private work.
+        </p>
+      </div>
+
+      {!result.available ? (
+        <p className="text-xs text-[var(--dpf-muted)]">{result.note ?? "No local-changes list available."}</p>
+      ) : result.changes.length === 0 ? (
+        <p className="text-xs text-[var(--dpf-muted)]">
+          Nothing kept private — everything on this system matches the community version.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {result.changes.map((c) => (
+            <li
+              key={c.sha}
+              className="flex items-start justify-between gap-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5"
+            >
+              <span className="text-xs text-[var(--dpf-text)] min-w-0">{c.subject}</span>
+              <span className="text-xs text-[var(--dpf-muted)] font-mono shrink-0">
+                {c.sha}
+                {c.date ? ` · ${c.date.slice(0, 10)}` : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1344,7 +1344,7 @@ export async function sendMessage(input: {
           );
         }
 
-        if (mode === "fork_only" && !hasRepo) {
+        if ((mode === "private" || mode === "fork_only") && !hasRepo) {
           const untrackedCount = await prisma.featureBuild.count({
             where: { phase: "complete", gitCommitHashes: { isEmpty: true } },
           });
@@ -1358,7 +1358,7 @@ export async function sendMessage(input: {
           }
         }
 
-        if (mode === "selective" || mode === "contribute_all") {
+        if (mode === "contributing" || mode === "selective" || mode === "contribute_all") {
           if (!hasDco) {
             modeContext.push(
               "DCO has NOT been accepted yet. If the user chooses to contribute, remind them",

--- a/apps/web/lib/actions/feedback-escalation.ts
+++ b/apps/web/lib/actions/feedback-escalation.ts
@@ -104,8 +104,8 @@ export async function escalateReportUpstream(input: {
   if (config.hiveContributionsPaused) {
     return { ok: false, status: "blocked", reason: "Hive contributions are paused." };
   }
-  if (config.contributionMode === "fork_only") {
-    return { ok: false, status: "blocked", reason: "This install keeps everything private (fork_only)." };
+  if (config.contributionMode === "private" || config.contributionMode === "fork_only") {
+    return { ok: false, status: "blocked", reason: "This install keeps everything on your own system (private)." };
   }
 
   const report = await prisma.platformIssueReport.findUnique({
@@ -189,7 +189,9 @@ export async function getUpstreamFeedbackConsent(): Promise<UpstreamFeedbackCons
   return {
     optIn: config?.upstreamFeedbackOptIn ?? false,
     relayConfigured: Boolean(config?.upstreamRelayUrl),
-    forkOnly: config?.contributionMode === "fork_only",
+    // `forkOnly` retains its name for back-compat with consumers; true when the
+    // install is private (legacy "fork_only" included).
+    forkOnly: config?.contributionMode === "private" || config?.contributionMode === "fork_only",
     paused: config?.hiveContributionsPaused ?? false,
   };
 }

--- a/apps/web/lib/actions/hive-contributions.ts
+++ b/apps/web/lib/actions/hive-contributions.ts
@@ -25,7 +25,7 @@ const HIVE_PATH = "/admin/hive";
 const DEFAULT_CONFIG: HiveContributionConfig = {
   deviceFingerprintOptIn: true,
   hiveContributionsPaused: false,
-  contributionMode: "selective",
+  contributionMode: "private",
 };
 
 export type HiveContributionsView = {

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -21,7 +21,9 @@ async function requireManagePlatform(): Promise<string> {
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
 
-const VALID_MODES = ["fork_only", "selective", "contribute_all"] as const;
+// 2-state contribution model (EP-1A78BAE1). Per-change sharing is decided by
+// the FeatureBuild disposition (suggest-then-confirm), not by this mode.
+const VALID_MODES = ["private", "contributing"] as const;
 type ContributionMode = (typeof VALID_MODES)[number];
 
 export async function savePlatformDevConfig(mode: ContributionMode) {
@@ -73,8 +75,8 @@ export async function acceptDco(): Promise<{ accepted: boolean; error?: string }
 
   const config = await prisma.platformDevConfig.findUnique({ where: { id: "singleton" } });
 
-  if (config?.contributionMode === "fork_only") {
-    return { accepted: false, error: "DCO is not required for fork_only mode" };
+  if (config?.contributionMode === "private") {
+    return { accepted: false, error: "DCO is not required for a private install" };
   }
 
   // Upsert to handle case where singleton doesn't exist yet (e.g., during onboarding)
@@ -86,7 +88,7 @@ export async function acceptDco(): Promise<{ accepted: boolean; error?: string }
     },
     create: {
       id: "singleton",
-      contributionMode: "selective",
+      contributionMode: "contributing",
       dcoAcceptedAt: new Date(),
       dcoAcceptedById: userId,
       configuredAt: new Date(),
@@ -114,7 +116,7 @@ export async function saveGitRemoteUrl(url: string | null): Promise<void> {
     update: { gitRemoteUrl: url?.trim() || null },
     create: {
       id: "singleton",
-      contributionMode: "fork_only",
+      contributionMode: "private",
       gitRemoteUrl: url?.trim() || null,
       configuredAt: new Date(),
       configuredById: userId,

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -21,6 +21,46 @@ async function requireManagePlatform(): Promise<string> {
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
 
+// Private-paths overrides (EP-1A78BAE1). Operator-managed glob rules that merge
+// with the checked-in `.dpf/private-paths` manifest; matched paths never leave
+// at public-hive egress.
+
+export interface PrivatePathRuleView {
+  id: string;
+  pattern: string;
+  reason: string | null;
+  createdAt: string;
+}
+
+export async function listPrivatePathRules(): Promise<PrivatePathRuleView[]> {
+  await requireManagePlatform();
+  const rows = await prisma.privatePathRule.findMany({ orderBy: { createdAt: "asc" } });
+  return rows.map((r) => ({ id: r.id, pattern: r.pattern, reason: r.reason, createdAt: r.createdAt.toISOString() }));
+}
+
+export async function addPrivatePathRule(pattern: string, reason?: string | null): Promise<{ ok: boolean; error?: string }> {
+  const userId = await requireManagePlatform();
+  const p = pattern.trim();
+  if (!p) return { ok: false, error: "Pattern is required." };
+  if (p.length > 200) return { ok: false, error: "Pattern is too long." };
+  try {
+    await prisma.privatePathRule.create({
+      data: { pattern: p, reason: reason?.trim() || null, createdById: userId },
+    });
+  } catch {
+    return { ok: false, error: "That pattern already exists." };
+  }
+  revalidatePath("/admin/platform-development");
+  return { ok: true };
+}
+
+export async function removePrivatePathRule(id: string): Promise<{ ok: boolean }> {
+  await requireManagePlatform();
+  await prisma.privatePathRule.deleteMany({ where: { id } });
+  revalidatePath("/admin/platform-development");
+  return { ok: true };
+}
+
 // 2-state contribution model (EP-1A78BAE1). Per-change sharing is decided by
 // the FeatureBuild disposition (suggest-then-confirm), not by this mode.
 const VALID_MODES = ["private", "contributing"] as const;

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -305,7 +305,7 @@ async function deriveUpstreamFork(
     where: { id: "singleton" },
     select: { contributionMode: true },
   });
-  if (devConfig?.contributionMode === "fork_only") {
+  if (devConfig?.contributionMode === "private" || devConfig?.contributionMode === "fork_only") {
     return { state: "skipped", prUrl: null, prNumber: null, packId: null, errorMessage: null };
   }
 

--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -419,22 +419,18 @@ STEP 4 — contribution (depends on the Platform contribution mode injected belo
   the portal container, which would end this conversation. Contribution must happen
   while the sandbox is still available.
 
-If mode is "fork_only":
+If mode is "private":
   - Do NOT call assess_contribution or contribute_to_hive.
   - Continue to STEP 5 (deployment).
 
-If mode is "selective":
-  - Call assess_contribution.
-  - Present the full assessment and recommendation to the user.
-  - Offer [Keep local] and [Contribute] — wait for user choice.
-  - Call contribute_to_hive only if user explicitly chooses to contribute.
-  - Continue to STEP 5 (deployment).
-
-If mode is "contribute_all":
-  - Call assess_contribution.
-  - Present the assessment — indicate contribution is the default.
-  - Offer [Contribute] as primary and [Keep this one local] as secondary.
-  - Call contribute_to_hive unless user explicitly chooses to keep local.
+If mode is "contributing":
+  - Call assess_contribution to get the per-change suggestion (Keep / Share)
+    and its reason.
+  - Present the suggestion and recommendation to the user in plain language:
+    "Keep on my system" vs "Share with the community".
+  - The human makes the final call. Default to Keep if there is no explicit
+    choice — never contribute without the human's confirmation (fail-closed).
+  - Call contribute_to_hive only when the user explicitly chooses to Share.
   - Continue to STEP 5 (deployment).
 
 STEP 5: Create a PR for the portal codebase.
@@ -983,11 +979,9 @@ export async function getBuildContextSection(ctx: BuildContext): Promise<string>
     if (ctx.phase === "ideate" || ctx.phase === "plan") {
       const modeExplain = ctx.contributionMode === "policy_pending"
         ? "production promotion and upstream contribution stay blocked until platform development policy is configured in the portal"
-        : ctx.contributionMode === "contribute_all"
-        ? "contributions are sent upstream by default — flag any proprietary data models or trade secrets in your design"
-        : ctx.contributionMode === "selective"
-        ? "the user will be asked whether to contribute each feature"
-        : "code stays local only — no upstream contribution";
+        : (ctx.contributionMode === "contributing" || ctx.contributionMode === "selective" || ctx.contributionMode === "contribute_all")
+        ? "this is a contributing install — each change gets a Keep/Share suggestion and the user makes the final call; flag any proprietary data models or trade secrets so they are suggested Keep"
+        : "code stays on the user's own system — no upstream contribution";
       lines.push(`Platform contribution mode: ${ctx.contributionMode}. ${modeExplain}.`);
     } else {
       // build, review, ship — simple injection (ship prompt has its own detailed STEP 5 logic)

--- a/apps/web/lib/integrate/disposition.test.ts
+++ b/apps/web/lib/integrate/disposition.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { suggestDisposition, mayShareToPublicHive, privateDispositionBlockMessage } from "./disposition";
+
+describe("suggestDisposition", () => {
+  it("suggests private when the outbound diff is empty (all private-path)", () => {
+    const s = suggestDisposition({ outboundEmpty: true, reusabilityScope: "already_generic" });
+    expect(s.suggested).toBe("private");
+  });
+
+  it("suggests private when org-specific content is present (overrides reusability)", () => {
+    const s = suggestDisposition({ orgSpecificHits: 2, reusabilityScope: "already_generic" });
+    expect(s.suggested).toBe("private");
+    expect(s.reason).toMatch(/business-specific/i);
+  });
+
+  it("suggests private for one_off changes", () => {
+    expect(suggestDisposition({ reusabilityScope: "one_off" }).suggested).toBe("private");
+  });
+
+  it("suggests shareable for already_generic + clean", () => {
+    expect(suggestDisposition({ reusabilityScope: "already_generic", orgSpecificHits: 0 }).suggested).toBe("shareable");
+  });
+
+  it("suggests shareable for parameterizable + clean", () => {
+    expect(suggestDisposition({ reusabilityScope: "parameterizable", orgSpecificHits: 0 }).suggested).toBe("shareable");
+  });
+
+  it("fail-closed: unknown reusability + clean defaults to private", () => {
+    expect(suggestDisposition({}).suggested).toBe("private");
+    expect(suggestDisposition({ reusabilityScope: null }).suggested).toBe("private");
+  });
+});
+
+describe("mayShareToPublicHive", () => {
+  it("only true for explicit shareable", () => {
+    expect(mayShareToPublicHive("shareable")).toBe(true);
+    expect(mayShareToPublicHive("private")).toBe(false);
+    expect(mayShareToPublicHive(null)).toBe(false);
+    expect(mayShareToPublicHive(undefined)).toBe(false);
+    expect(mayShareToPublicHive("anything-else")).toBe(false);
+  });
+});
+
+describe("privateDispositionBlockMessage", () => {
+  it("includes the suggestion reason when provided", () => {
+    expect(privateDispositionBlockMessage("because X")).toMatch(/because X/);
+    expect(privateDispositionBlockMessage()).toMatch(/stay on your system/i);
+  });
+});

--- a/apps/web/lib/integrate/disposition.ts
+++ b/apps/web/lib/integrate/disposition.ts
@@ -1,0 +1,90 @@
+/**
+ * Per-change disposition — Private/Public Change Segregation (EP-1A78BAE1).
+ * Spec: docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
+ * Plan: docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md
+ *
+ * A change ships with a disposition: "private" (default, fail-closed) or
+ * "shareable". Only "shareable" changes may leave at public-hive egress. The
+ * AI suggests a disposition from signals DPF already computes; the human makes
+ * the final call. This file holds the pure suggestion logic (unit-tested) and
+ * the fail-closed gate predicate; callers (contribute_to_hive, create_portal_pr)
+ * enforce the gate at public-hive egress only.
+ */
+
+export type Disposition = "private" | "shareable";
+
+export interface SuggestionInputs {
+  /** designDoc.reusabilityAnalysis.scope, if known. */
+  reusabilityScope?: "one_off" | "parameterizable" | "already_generic" | null;
+  /** Count of org-specific / proprietary hits from the sanitization scan. */
+  orgSpecificHits?: number;
+  /** Whether the post-strip outbound diff is empty (everything was private-path). */
+  outboundEmpty?: boolean;
+}
+
+export interface DispositionSuggestion {
+  suggested: Disposition;
+  reason: string;
+}
+
+/**
+ * Suggest a disposition. Fail-closed: defaults to "private" unless the change
+ * is clearly generic/reusable AND carries no org-specific content. The human
+ * still confirms — this only pre-fills the recommendation.
+ */
+export function suggestDisposition(inputs: SuggestionInputs): DispositionSuggestion {
+  const { reusabilityScope, orgSpecificHits = 0, outboundEmpty = false } = inputs;
+
+  if (outboundEmpty) {
+    return {
+      suggested: "private",
+      reason: "This change only affects parts of your system marked private — nothing to share.",
+    };
+  }
+  if (orgSpecificHits > 0) {
+    return {
+      suggested: "private",
+      reason: `Contains ${orgSpecificHits} piece(s) of business-specific content (names, pricing, or data) — suggest keeping it on your system.`,
+    };
+  }
+  if (reusabilityScope === "one_off") {
+    return {
+      suggested: "private",
+      reason: "Looks specific to your business — suggest keeping it on your system.",
+    };
+  }
+  if (reusabilityScope === "already_generic") {
+    return {
+      suggested: "shareable",
+      reason: "Looks broadly reusable and carries no business-specific content — a good candidate to share.",
+    };
+  }
+  if (reusabilityScope === "parameterizable") {
+    return {
+      suggested: "shareable",
+      reason: "Could benefit others once generalized, and carries no business-specific content — consider sharing.",
+    };
+  }
+  // Unknown reusability + clean: lean conservative (private) — fail-closed.
+  return {
+    suggested: "private",
+    reason: "Not clearly reusable — suggest keeping it on your system unless you intend to share it.",
+  };
+}
+
+/**
+ * Fail-closed gate predicate for public-hive egress. A change may leave only
+ * when explicitly "shareable". Anything else (incl. the default "private" and
+ * any unknown value) is blocked.
+ */
+export function mayShareToPublicHive(disposition: string | null | undefined): boolean {
+  return disposition === "shareable";
+}
+
+/** Plain-language refusal message when a private change is blocked at egress. */
+export function privateDispositionBlockMessage(suggestionReason?: string | null): string {
+  const base =
+    "This change is set to stay on your system, so it was not shared with the community. " +
+    "To share it, mark it shareable (Admin > Platform Development, or ask the coworker to share this change).";
+  return suggestionReason ? `${base}\n\n${suggestionReason}` : base;
+}

--- a/apps/web/lib/integrate/issue-bridge.test.ts
+++ b/apps/web/lib/integrate/issue-bridge.test.ts
@@ -230,7 +230,7 @@ describe("escalateToUpstreamIssue", () => {
 
     expect(result).toEqual({
       status: "skipped",
-      reason: expect.stringContaining("fork_only"),
+      reason: expect.stringContaining("private"),
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/web/lib/integrate/issue-bridge.ts
+++ b/apps/web/lib/integrate/issue-bridge.ts
@@ -360,10 +360,10 @@ export async function escalateToUpstreamIssue(
       reason: "platform development policy not configured",
     };
   }
-  if (config.contributionMode === "fork_only") {
+  if (config.contributionMode === "private" || config.contributionMode === "fork_only") {
     return {
       status: "skipped",
-      reason: "contribution mode is fork_only — no upstream escalation",
+      reason: "install is private — no upstream escalation",
     };
   }
   if (!config.upstreamRemoteUrl) {

--- a/apps/web/lib/mcp-tools-sandbox-admin.test.ts
+++ b/apps/web/lib/mcp-tools-sandbox-admin.test.ts
@@ -400,6 +400,10 @@ describe("sandbox admin MCP and coworker messaging", () => {
         brief: {},
         diffPatch: "diff --git a/apps/web/lib/inference/ollama-url.ts b/apps/web/lib/inference/ollama-url.ts\n@@ -1 +1,2 @@\n+new\n",
         diffSummary: "summary",
+        // Confirmed shareable so the test reaches the sandbox-promotion-integrity
+        // check it targets (the disposition gate fires first otherwise).
+        disposition: "shareable",
+        dispositionSuggestionReason: null,
         sandboxId: "dpf-sandbox-2",
         portfolioId: null,
         createdById: "user-1",

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2847,16 +2847,13 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "proposal",
     sideEffect: true,
     buildPhases: ["ship"],
-    // Skip the proposal card when the user has pre-authorized via `contribute_all`
-    // and accepted the DCO. In that configuration every shipped build is cleared
-    // to contribute upstream; an extra per-build approval step is redundant and
-    // silently stalls autonomous runs (no human is present to click approve).
+    // 2-state model (EP-1A78BAE1): there is no mode-based pre-authorization.
+    // Sharing is a per-change human-in-the-loop decision (the FeatureBuild
+    // disposition, suggest-then-confirm). Until that disposition gate lands,
+    // never auto-approve outbound contribution — fail closed to requiring the
+    // human's final call.
     autoApproveWhen: async () => {
-      const cfg = await prisma.platformDevConfig.findUnique({
-        where: { id: "singleton" },
-        select: { contributionMode: true, dcoAcceptedAt: true },
-      });
-      return cfg?.contributionMode === "contribute_all" && !!cfg.dcoAcceptedAt;
+      return false;
     },
   },
   {
@@ -10319,9 +10316,9 @@ export async function executeTool(
       // Contribution mode awareness (EP-BUILD-HANDOFF-002 Phase 2e extension)
       let contributionModeInfo = "";
       try {
-        const mode = devConfig?.contributionMode ?? "fork_only";
+        const mode = devConfig?.contributionMode ?? "private";
 
-        if (mode === "fork_only" && !devConfig?.gitRemoteUrl) {
+        if ((mode === "private" || mode === "fork_only") && !devConfig?.gitRemoteUrl) {
           // Count untracked shipped features for escalating warning
           const untrackedCount = await prisma.featureBuild.count({
             where: { phase: "complete", gitCommitHashes: { isEmpty: true } },
@@ -11364,12 +11361,12 @@ export async function executeTool(
             "Contribution is blocked until Platform Development is configured in the portal. Finish that setup first, then decide whether this install stays private or contributes governed changes upstream.",
         };
       }
-      if (devConfig?.contributionMode === "fork_only") {
+      if (devConfig?.contributionMode === "private" || devConfig?.contributionMode === "fork_only") {
         return {
           success: false,
-          error: "Install is configured for private development only.",
+          error: "Install is configured to keep everything on this system.",
           message:
-            "This install is configured to keep shipped features private. Change Platform Development settings if you want Build Studio to create upstream contributions.",
+            "This install keeps shipped work on your own system and does not contribute to the community. Switch to a contributing install in Admin > Platform Development if you want to share changes upstream.",
         };
       }
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10152,7 +10152,7 @@ export async function executeTool(
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
       const build = await prisma.featureBuild.findUnique({
         where: { buildId },
-        select: { sandboxId: true, buildBranch: true, phase: true, createdById: true },
+        select: { sandboxId: true, buildBranch: true, phase: true, createdById: true, designDoc: true },
       });
       if (!build || build.createdById !== userId) {
         return { success: false, error: "Build not found.", message: `No active build ${buildId} was found for this user.` };
@@ -10268,6 +10268,44 @@ export async function executeTool(
           gitCommitHashes: commitHashes,
         },
       });
+
+      // Compute + cache the per-change disposition suggestion (EP-1A78BAE1) so
+      // the ship UI / coworker can prefill Keep vs Share. The human still makes
+      // the final call via set_change_disposition; this only pre-fills.
+      // Non-fatal — a failed suggestion leaves the fail-closed default.
+      try {
+        const { suggestDisposition } = await import("@/lib/integrate/disposition");
+        const { loadPrivatePathPatterns, compilePrivatePathMatcher, stripPrivatePathsFromDiff } =
+          await import("@/lib/integrate/private-paths");
+        const outboundEmpty = !stripPrivatePathsFromDiff(
+          extracted.fullDiff,
+          compilePrivatePathMatcher(await loadPrivatePathPatterns({ prisma })),
+        ).kept.trim();
+        let reusabilityScope: "one_off" | "parameterizable" | "already_generic" | null = null;
+        const dd = build.designDoc as Record<string, unknown> | null;
+        const scope = (dd?.reusabilityAnalysis as { scope?: string } | undefined)?.scope;
+        if (scope === "one_off" || scope === "parameterizable" || scope === "already_generic") {
+          reusabilityScope = scope;
+        }
+        let orgSpecificHits = 0;
+        try {
+          const { runSanitizationScan } = await import("@/lib/integrate/contribution-review");
+          const san = await runSanitizationScan(extracted.fullDiff);
+          orgSpecificHits = san.mustFixCount;
+        } catch { /* sanitization optional */ }
+        const suggestion = suggestDisposition({ reusabilityScope, orgSpecificHits, outboundEmpty });
+        await prisma.featureBuild.update({
+          where: { buildId },
+          data: {
+            dispositionSuggested: suggestion.suggested,
+            dispositionSuggestionReason: suggestion.reason,
+            dispositionSource: "suggested",
+          },
+        });
+        logBuildActivity(buildId, "deploy_feature", `disposition suggestion: ${suggestion.suggested} — ${suggestion.reason}`);
+      } catch (err) {
+        console.warn("[deploy_feature] disposition suggestion failed:", err);
+      }
 
       // Scan migrations for destructive operations
       let destructiveWarnings: string[] = [];

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2601,6 +2601,22 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
     buildPhases: ["ship"],
   },
+  {
+    name: "set_change_disposition",
+    description: "Record the human's final call on whether the current change is kept private (on the user's own system) or shared with the community. Use after presenting the Keep/Share suggestion at ship time. A change must be 'shareable' before contribute_to_hive or a public-hive PR will share it; the default is 'private' (fail-closed), so inaction never shares.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        disposition: { type: "string", enum: ["private", "shareable"], description: "'private' keeps the change on the user's system; 'shareable' clears it to be contributed to the community." },
+        reason: { type: "string", description: "Optional short note on why this disposition was chosen." },
+      },
+      required: ["disposition"],
+    },
+    requiredCapability: "manage_capabilities",
+    executionMode: "immediate",
+    sideEffect: true,
+    buildPhases: ["ship"],
+  },
   // ─── Email setup (PBI-INV-04 Phase 2) ──────────────────────────────────
   // Lets the onboarding/COO coworker walk a non-technical operator through
   // configuring their OWN outbound email (SMTP). Operator-only
@@ -10383,6 +10399,7 @@ export async function executeTool(
           description: true, gitCommitHashes: true, updatedAt: true, buildExecState: true,
           verificationOut: true, acceptanceMet: true, phase: true,
           designDoc: true, buildPlan: true,
+          disposition: true, dispositionSuggestionReason: true,
           productVersions: {
             take: 1,
             orderBy: { shippedAt: "desc" },
@@ -10468,11 +10485,23 @@ export async function executeTool(
         const { classifyEgress } = await import("@/lib/integrate/contribution-egress");
         const egress = classifyEgress({ owner: repoOwner, repo: repoName }, _egCfg?.upstreamRemoteUrl);
         if (egress === "public-hive") {
+          // Fail-closed disposition gate (EP-1A78BAE1): a public-hive PR may only
+          // carry a change confirmed "shareable". Own-repo PRs skip this — that
+          // is the install's private home.
+          const { mayShareToPublicHive, privateDispositionBlockMessage } = await import("@/lib/integrate/disposition");
+          if (!mayShareToPublicHive(build.disposition)) {
+            logBuildActivity(buildId, "create_portal_pr", "blocked: change disposition is private (public-hive target)");
+            return {
+              success: false,
+              error: "Change is kept private.",
+              message: privateDispositionBlockMessage(build.dispositionSuggestionReason),
+            };
+          }
           const { loadPrivatePathPatterns, compilePrivatePathMatcher, stripPrivatePathsFromDiff } =
             await import("@/lib/integrate/private-paths");
           shareableDiff = stripPrivatePathsFromDiff(
             diff,
-            compilePrivatePathMatcher(await loadPrivatePathPatterns()),
+            compilePrivatePathMatcher(await loadPrivatePathPatterns({ prisma })),
           ).kept;
           if (!shareableDiff.trim()) {
             return {
@@ -11343,6 +11372,33 @@ export async function executeTool(
       return { success: true, message: assessment.summary, data: assessment };
     }
 
+    case "set_change_disposition": {
+      const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
+      if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
+      const disposition = (params.disposition as string) ?? "";
+      if (disposition !== "private" && disposition !== "shareable") {
+        return { success: false, error: "Invalid disposition.", message: "disposition must be 'private' or 'shareable'." };
+      }
+      const reason = typeof params.reason === "string" ? params.reason : null;
+      await prisma.featureBuild.update({
+        where: { buildId },
+        data: {
+          disposition,
+          dispositionReason: reason,
+          dispositionSource: "operator",
+          dispositionDecidedAt: new Date(),
+          dispositionDecidedById: userId,
+        },
+      });
+      logBuildActivity(buildId, "set_change_disposition", `disposition=${disposition}${reason ? ` (${reason})` : ""}`);
+      return {
+        success: true,
+        message: disposition === "shareable"
+          ? "This change is marked to share with the community. Run contribute_to_hive (or create the portal PR) to share it."
+          : "This change is kept on your system and will not be shared.",
+      };
+    }
+
     case "contribute_to_hive": {
       const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
@@ -11417,6 +11473,7 @@ export async function executeTool(
           sandboxId: true, portfolioId: true, createdById: true,
           buildBranch: true, gitCommitHashes: true, updatedAt: true, buildPlan: true,
           description: true, buildExecState: true,
+          disposition: true, dispositionSuggestionReason: true,
           createdBy: { select: { email: true } },
         },
       });
@@ -11448,13 +11505,27 @@ export async function executeTool(
       // docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md
       const { loadPrivatePathPatterns: _loadPriv, compilePrivatePathMatcher: _compilePriv, stripPrivatePathsFromDiff: _stripPriv } =
         await import("@/lib/integrate/private-paths");
-      const shareableDiff = _stripPriv(diff, _compilePriv(await _loadPriv())).kept;
+      const shareableDiff = _stripPriv(diff, _compilePriv(await _loadPriv({ prisma }))).kept;
       if (!shareableDiff.trim()) {
         return {
           success: false,
           error: "Only private paths.",
           message:
             "This change only affects parts of your system you've marked private (see .dpf/private-paths or Admin > Platform Development), so there is nothing to share upstream.",
+        };
+      }
+
+      // Fail-closed disposition gate (EP-1A78BAE1): contribute_to_hive is always
+      // public-hive egress, so a change may leave only when explicitly
+      // "shareable". Default "private" blocks — the human's confirmation (via
+      // set_change_disposition / the ship UI) is required first.
+      const { mayShareToPublicHive, privateDispositionBlockMessage } = await import("@/lib/integrate/disposition");
+      if (!mayShareToPublicHive(build.disposition)) {
+        logBuildActivity(buildId, "contribute_to_hive", "blocked: change disposition is private (not confirmed shareable)");
+        return {
+          success: false,
+          error: "Change is kept private.",
+          message: privateDispositionBlockMessage(build.dispositionSuggestionReason),
         };
       }
 

--- a/apps/web/lib/platform-dev-policy.ts
+++ b/apps/web/lib/platform-dev-policy.ts
@@ -4,5 +4,10 @@ export function getPlatformDevPolicyState(
   config: { contributionMode: string | null } | null | undefined,
 ): PlatformDevPolicyState {
   if (!config) return "policy_pending";
-  return config.contributionMode === "fork_only" ? "private" : "contributing";
+  // 2-state model (EP-1A78BAE1): contributionMode is "private" | "contributing".
+  // Legacy values ("fork_only" | "selective" | "contribute_all") are mapped for
+  // back-compat in case a row predates the collapse migration.
+  const mode = config.contributionMode;
+  if (mode === "private" || mode === "fork_only") return "private";
+  return "contributing";
 }

--- a/apps/web/lib/self-upgrade/local-changes-ledger.test.ts
+++ b/apps/web/lib/self-upgrade/local-changes-ledger.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { parseLedgerLog, collectLocalChanges, LEDGER_LOG_FORMAT } from "./local-changes-ledger";
+import type { GitResult } from "./prepare-source";
+
+const SEP = "\x1f";
+const ok = (stdout: string): GitResult => ({ stdout, stderr: "", code: 0 });
+const fail = (): GitResult => ({ stdout: "", stderr: "not a git repository", code: 128 });
+
+describe("parseLedgerLog", () => {
+  it("parses sha/subject/date rows and truncates the sha", () => {
+    const out = [
+      `abcdef1234567890${SEP}feat: pricing tweak${SEP}2026-06-19T10:00:00Z`,
+      `0011223344556677${SEP}fix: internal report${SEP}2026-06-18T09:00:00Z`,
+    ].join("\n");
+    expect(parseLedgerLog(out)).toEqual([
+      { sha: "abcdef123456", subject: "feat: pricing tweak", date: "2026-06-19T10:00:00Z" },
+      { sha: "001122334455", subject: "fix: internal report", date: "2026-06-18T09:00:00Z" },
+    ]);
+  });
+  it("ignores blank lines and malformed rows", () => {
+    expect(parseLedgerLog("\n  \n")).toEqual([]);
+  });
+});
+
+describe("collectLocalChanges", () => {
+  it("returns unavailable for a non-git install (consumer mode)", async () => {
+    const run = vi.fn().mockResolvedValueOnce(fail());
+    const res = await collectLocalChanges(run, { hostSourcePath: "/workspace", remote: "origin", branch: "main", installBranch: "dpf/install" });
+    expect(res.available).toBe(false);
+    expect(res.changes).toEqual([]);
+    expect(res.note).toMatch(/does not track changes in git/i);
+  });
+
+  it("returns the local-only commits when git succeeds", async () => {
+    const run = vi.fn()
+      .mockResolvedValueOnce(ok("true")) // rev-parse is-inside-work-tree
+      .mockResolvedValueOnce(ok(`deadbeef0000${SEP}feat: keep this private${SEP}2026-06-19T00:00:00Z`)); // log
+    const res = await collectLocalChanges(run, { hostSourcePath: "/workspace", remote: "origin", branch: "main", installBranch: "dpf/install" });
+    expect(res.available).toBe(true);
+    expect(res.changes).toHaveLength(1);
+    expect(res.changes[0].subject).toBe("feat: keep this private");
+    // log invoked with the upstream..installBranch range
+    expect(run).toHaveBeenLastCalledWith(expect.arrayContaining(["origin/main..dpf/install", `--format=${LEDGER_LOG_FORMAT}`]));
+  });
+
+  it("returns unavailable (not an error) when the log command fails", async () => {
+    const run = vi.fn().mockResolvedValueOnce(ok("true")).mockResolvedValueOnce(fail());
+    const res = await collectLocalChanges(run, { hostSourcePath: "/workspace", remote: "origin", branch: "main", installBranch: "dpf/install" });
+    expect(res.available).toBe(false);
+  });
+});

--- a/apps/web/lib/self-upgrade/local-changes-ledger.ts
+++ b/apps/web/lib/self-upgrade/local-changes-ledger.ts
@@ -1,0 +1,101 @@
+/**
+ * Local-changes ledger — Private/Public Change Segregation (EP-1A78BAE1).
+ *
+ * Lists the commits on the durable install branch (`dpf/install`) that are NOT
+ * in upstream — i.e. the changes the operator has kept on their own system and
+ * not shared with the community. Shared changes flow upstream (and return via
+ * the self-upgrade merge), so by construction the local-only commits ARE the
+ * private delta. This answers, in plain language, "what have we kept private?"
+ *
+ * Pure parsing/collection here (unit-tested over a GitRunner); the server
+ * resolver `getLocalChangesLedger` wires the live install path + config.
+ */
+
+import type { GitRunner } from "./prepare-source";
+
+export interface LocalChange {
+  sha: string;
+  subject: string;
+  date: string;
+}
+
+export interface LocalChangesResult {
+  available: boolean;
+  note?: string;
+  changes: LocalChange[];
+}
+
+// Unit separator — safe field delimiter for `git log --format`.
+const SEP = "\x1f";
+export const LEDGER_LOG_FORMAT = `%H${SEP}%s${SEP}%aI`;
+
+/** Parse `git log --format=%H<SEP>%s<SEP>%aI` output into LocalChange rows. */
+export function parseLedgerLog(stdout: string): LocalChange[] {
+  return stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, subject, date] = line.split(SEP);
+      return { sha: (sha ?? "").slice(0, 12), subject: subject ?? "", date: date ?? "" };
+    })
+    .filter((c) => c.sha.length > 0);
+}
+
+export interface CollectOptions {
+  hostSourcePath: string;
+  remote: string;
+  branch: string;
+  installBranch: string;
+  max?: number;
+}
+
+/**
+ * Collect local-only commits (on installBranch, not in remote/branch). Never
+ * throws: a non-git install (consumer mode) or an unset install branch returns
+ * `available: false` with a plain-language note instead of an error.
+ */
+export async function collectLocalChanges(run: GitRunner, opts: CollectOptions): Promise<LocalChangesResult> {
+  const { hostSourcePath, remote, branch, installBranch, max = 200 } = opts;
+
+  const isRepo = await run(["-C", hostSourcePath, "rev-parse", "--is-inside-work-tree"]);
+  if (isRepo.code !== 0) {
+    return {
+      available: false,
+      note: "This install does not track changes in git, so there is no local-changes list to show.",
+      changes: [],
+    };
+  }
+
+  const range = `${remote}/${branch}..${installBranch}`;
+  const res = await run([
+    "-C", hostSourcePath, "log", "--no-merges", `--max-count=${max}`, `--format=${LEDGER_LOG_FORMAT}`, range,
+  ]);
+  if (res.code !== 0) {
+    return {
+      available: false,
+      note: "Could not read the local-changes list yet (the install branch or community reference may not be set up).",
+      changes: [],
+    };
+  }
+
+  return { available: true, changes: parseLedgerLog(res.stdout) };
+}
+
+/** Server resolver: read the live install's config + run git. */
+export async function getLocalChangesLedger(): Promise<LocalChangesResult> {
+  try {
+    const { getSelfUpgradeConfig } = await import("./config");
+    const { defaultGitRunner } = await import("./prepare-source");
+    const config = await getSelfUpgradeConfig();
+    const hostSourcePath = config.hostSourceMountPath ?? process.env.HOST_SOURCE_PATH ?? "/workspace";
+    return await collectLocalChanges(defaultGitRunner, {
+      hostSourcePath,
+      remote: config.repositoryRemote ?? "origin",
+      branch: config.repositoryBranch ?? "main",
+      installBranch: config.installBranch,
+    });
+  } catch {
+    return { available: false, note: "The local-changes list is unavailable right now.", changes: [] };
+  }
+}

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -461,6 +461,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // Hive Mind / Platform updates
   assess_contribution:    ["backlog_read"],
   contribute_to_hive:     ["backlog_write"],
+  set_change_disposition: ["backlog_write"],
   apply_platform_update:  ["admin_write"],
   // BI-C26F7EE1: read-only operator preview of the upstream change set —
   // paired with apply_platform_update's admin_write as the read tier.

--- a/docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md
+++ b/docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md
@@ -1,0 +1,52 @@
+# Plan — Contribution Model Refactor: 2 States + Suggest-Then-Confirm
+
+**Date:** 2026-06-19
+**Epic:** EP-1A78BAE1 · **BI:** BI-6BAE4748
+**Decision:** WWMD-ratified via `principle_decide` (population `external_coding_agent`): `two-state-suggest-confirm` — composite **9.15**, margin **1.11**, confidence **high**, no commandment conflict. Operator-directed ("plan and deliver this").
+**Specs:** [private-public-change-segregation-design](../specs/2026-06-18-private-public-change-segregation-design.md), [hive-contribution-architecture-and-egress-model](../specs/2026-06-19-hive-contribution-architecture-and-egress-model.md).
+**Surface:** delivered here (Claude Code direct PRs), **not** Build Studio.
+
+## Decision in one line
+Collapse `PlatformDevConfig.contributionMode` from `fork_only|selective|contribute_all` → **`private|contributing`**. For `contributing` installs, every shipped change carries a per-change **disposition** (`private|shareable`, fail-closed to private) with an **AI suggestion + human final call**; the suggestion replaces the old static `selective`/`contribute_all` default lean and is computed from signals DPF already produces (sanitization scan, `reusabilityScope`, vertical tagging). The durable local git home makes "keep private" always safe.
+
+## Mapping (old → new)
+| Old | New |
+|---|---|
+| `fork_only` | `private` |
+| `selective` | `contributing` (suggestion defaults conservative) |
+| `contribute_all` | `contributing` (suggestion may lean share; human still confirms) |
+
+## Data model
+- `PlatformDevConfig.contributionMode` default `private`; valid `private|contributing`. (`VALID_MODES` in [platform-dev-config.ts](../../../apps/web/lib/actions/platform-dev-config.ts) + the MCP enum + any union types updated in the same commit per AGENTS.md §3.)
+- `FeatureBuild.disposition` `String @default("private")` + `dispositionReason String?` + `dispositionSource String?` (`suggested|operator`) + `dispositionDecidedAt DateTime?` + `dispositionDecidedById String?`. Cached suggestion: `dispositionSuggested String?` + `dispositionSuggestionReason String?`.
+- `PrivatePathRule { id, pattern, reason, createdById, createdAt }` — DB overrides merged with `.dpf/private-paths` (loader already tolerates absence).
+- Migration backfills existing rows: `fork_only→private`, else `→contributing`; all in-flight `FeatureBuild`s get `disposition="private"` (safe).
+
+## Logic / programmatic processes
+1. **Disposition gate** at **public-hive egress only** (`classifyEgress` from increment 2): `contribute_to_hive` (always public) and `create_portal_pr` (when public) refuse unless `disposition==="shareable"`. Own-repo egress unaffected → **Build Studio ship-to-own-repo keeps working**.
+2. **Suggestion engine** `suggestDisposition({ buildId|diff })`: maps existing signals — `already_generic` + clean sanitization ⇒ suggest `shareable`; `one_off`/org-specific hits ⇒ suggest `private`. Computed at `deploy_feature` time and cached on the build. No new classifier.
+3. **`set_change_disposition` MCP tool** (write scope): the human/coworker final call; records `dispositionSource="operator"`.
+4. **Readers updated** (13): `platform-dev-policy.ts` (becomes near-identity), `git-backup.ts`, `build-flow-state.ts`, `issue-bridge.ts`, `feedback-escalation.ts`, `agent-coworker.ts`, `hive-contributions.ts`, `feature-build-data.ts`, `build.ts`, `mcp-tools.ts` (3 sites), `build-agent-prompts.ts` (Build Studio prompt: 3-branch → 2-state + suggestion).
+5. **Sandbox:** builds populate `diffPatch` via `deploy_feature` → suggestion computed there; sandbox adds no infra. Disposition defaults private; ship path enforces at egress.
+6. **Self-upgrade:** the enum migration must apply cleanly through the governed upgrade (merge into `dpf/install`); `private` installs keep everything local — self-upgrade unchanged. Add a migration note; verify apply on canonical install.
+7. **MCP:** update tool descriptions (`contribute_to_hive`, `create_portal_pr`, `deploy_feature`), add `set_change_disposition` (+ token scope), surface the suggestion in tool responses so external Claude/Codex see it. Provenance-blind (§17).
+
+## UX pages (plain-language, §12/§17 — no git vocabulary)
+- **Onboarding (SetupOverlay):** Step 7 → one binary — **"Keep everything on my system"** vs **"Contribute improvements to the community"**.
+- **Admin > Platform Development:** 2-state toggle; `ContributionModelBanner`/`ForkSetupPanel` reworded; private-paths editor (writes `PrivatePathRule`).
+- **AI Coworker ship phase:** per-change **Keep / Share** control prefilled with the AI suggestion + reason; human confirms; fail-closed.
+- **Upgrade Center:** local-changes ledger (commits on `dpf/install` not upstream, tagged kept/shared) — `report-kit` `DataTable`, no hardcoded colors.
+- UX-Fit-Decision trailer on each UI-bearing PR (new user-facing controls on `human_cognitive_load`).
+
+## Docs to update
+AGENTS.md §1 (commons wording if it cites modes), `docs/user-guide/ai-workforce/*` (decision-perspective + contribution), `docs/superpowers/specs/2026-04-01-contribution-mode-git-integration-design.md` + `2026-04-23-public-contribution-mode-design.md` (addendum: superseded by 2-state), install docs, and the two segregation specs (mark the ratified model).
+
+## Rollout (verified increments, each its own PR)
+1. **Increment 1** ✅ merged (#2074) — private-paths boundary.
+2. **Increment 2** ✅ open (#2079) — public-hive egress classifier.
+3. **Increment 3** (this push) — schema migration (enum collapse + `FeatureBuild.disposition` + `PrivatePathRule`) + all reader/writer updates + MCP enum/defs + `set_change_disposition` + suggestion engine. Gates: migration apply + `next build` on canonical install; unit tests + typecheck source-local.
+4. **Increment 4** — UX pages (onboarding, admin, ship-phase, ledger) + docs sweep. Gate: UX verification on canonical install (AGENTS.md §5).
+5. **Increment 5** — Build Studio prompt + verify both BS and external paths end-to-end on the live install.
+
+## Verification substrate note
+Migration apply, `next build`, and all UX verification run on the **canonical local install or the shared local-CI sandbox** (AGENTS.md §5) — never the source-only worktree. Source-local gates (vitest, typecheck) run via the root-clone overlay until the worktree is compile-ready.

--- a/docs/superpowers/specs/2026-04-01-contribution-mode-git-integration-design.md
+++ b/docs/superpowers/specs/2026-04-01-contribution-mode-git-integration-design.md
@@ -1,5 +1,13 @@
 # Contribution Mode & Git Integration Design
 
+> **Superseded (2026-06-19, EP-1A78BAE1):** the three install-level modes
+> described here (`fork_only` / `selective` / `contribute_all`) were collapsed
+> to **two** (`private` / `contributing`); per-change sharing is now a
+> suggest-then-confirm decision (`FeatureBuild.disposition`), not a static mode
+> default. Retained as the historical record of the original three-mode design.
+> Current model:
+> [`docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md`](../plans/2026-06-19-contribution-model-2state-suggest-confirm.md).
+
 | Field | Value |
 |-------|-------|
 | **Epic** | EP-BUILD-HANDOFF-002 (Phase 2e extension) |

--- a/docs/superpowers/specs/2026-04-23-public-contribution-mode-design.md
+++ b/docs/superpowers/specs/2026-04-23-public-contribution-mode-design.md
@@ -1,5 +1,12 @@
 # Public Contribution Mode — Fork-Based PR Flow
 
+> **Partially superseded (2026-06-19, EP-1A78BAE1):** the install-level
+> `fork_only` / `selective` / `contribute_all` modes referenced here were
+> collapsed to **two** (`private` / `contributing`) with per-change
+> suggest-then-confirm sharing. The fork-vs-direct *push model* described in
+> this doc is unchanged. Current contribution model:
+> [`docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md`](../plans/2026-06-19-contribution-model-2state-suggest-confirm.md).
+
 | Field | Value |
 |-------|-------|
 | **Epic** | EP-BUILD-HANDOFF-002 (Phase 2e extension, public-repo follow-on) |

--- a/docs/user-guide/build-studio/deployment.md
+++ b/docs/user-guide/build-studio/deployment.md
@@ -90,10 +90,10 @@ If any gate finds issues, the PR is created but not merged. The findings are pos
 
 ### Configuration
 
-Pull request creation requires a GitHub token. This is configured differently depending on your contribution mode:
+Pull request creation requires a GitHub token. This is configured differently depending on whether your install is **Contributing** or **Private** (the two contribution states — see Admin > Platform Development):
 
-- **Anonymous contributions** (selective/contribute_all mode) — The platform uses a pre-provisioned token (`HIVE_CONTRIBUTION_TOKEN` environment variable). No GitHub account is needed from the customer.
-- **Private mode** (fork_only) — If you want PR-based code tracking for your own repository, configure a personal access token in Admin > Platform Development.
+- **Contributing install** — The platform uses a pre-provisioned token (`HIVE_CONTRIBUTION_TOKEN` environment variable) for anonymous contributions. No GitHub account is needed from the customer. When you ship a change, the platform suggests whether to keep it on your system or share it with the community, and you make the final call (nothing is shared without your confirmation).
+- **Private install** — Everything stays on your own system. If you want PR-based code tracking for your own repository, configure a personal access token in Admin > Platform Development.
 
 To set up the hive contribution token, add it to your `.env` file:
 

--- a/packages/db/prisma/migrations/20260619140000_collapse_contribution_mode_to_two_state/migration.sql
+++ b/packages/db/prisma/migrations/20260619140000_collapse_contribution_mode_to_two_state/migration.sql
@@ -1,0 +1,19 @@
+-- Private/Public Change Segregation (EP-1A78BAE1): collapse the install-level
+-- contribution mode from three values (fork_only | selective | contribute_all)
+-- to two (private | contributing). Per-change sharing is decided by the
+-- FeatureBuild disposition (suggest-then-confirm) in a later migration, not by
+-- this mode. Plan:
+-- docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md
+--
+-- Data-only migration: backfills existing rows. The schema field declaration
+-- is intentionally unchanged (the schema-regression guard treats a @default
+-- value change as a field removal); fresh-install fail-closed is handled
+-- explicitly in the seed (contributionMode: "private"), not via the column
+-- default. New creation paths set the value explicitly.
+
+UPDATE "PlatformDevConfig"
+SET "contributionMode" = CASE
+  WHEN "contributionMode" = 'fork_only' THEN 'private'
+  ELSE 'contributing'
+END
+WHERE "contributionMode" IN ('fork_only', 'selective', 'contribute_all');

--- a/packages/db/prisma/migrations/20260619150000_add_change_disposition_and_private_path_rule/migration.sql
+++ b/packages/db/prisma/migrations/20260619150000_add_change_disposition_and_private_path_rule/migration.sql
@@ -1,0 +1,30 @@
+-- Private/Public Change Segregation (EP-1A78BAE1): per-change disposition +
+-- operator-managed private-path overrides. Additive — fail-closed default
+-- "private" on every existing/in-flight FeatureBuild. Plan:
+-- docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md
+
+-- 1. Per-change disposition on FeatureBuild.
+ALTER TABLE "FeatureBuild"
+  ADD COLUMN "disposition" TEXT NOT NULL DEFAULT 'private',
+  ADD COLUMN "dispositionReason" TEXT,
+  ADD COLUMN "dispositionSource" TEXT,
+  ADD COLUMN "dispositionDecidedAt" TIMESTAMP(3),
+  ADD COLUMN "dispositionDecidedById" TEXT,
+  ADD COLUMN "dispositionSuggested" TEXT,
+  ADD COLUMN "dispositionSuggestionReason" TEXT;
+
+-- 2. Operator-managed private-path overrides (merge with .dpf/private-paths).
+CREATE TABLE "PrivatePathRule" (
+  "id" TEXT NOT NULL,
+  "pattern" TEXT NOT NULL,
+  "reason" TEXT,
+  "createdById" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PrivatePathRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PrivatePathRule_pattern_key" ON "PrivatePathRule"("pattern");
+
+ALTER TABLE "PrivatePathRule"
+  ADD CONSTRAINT "PrivatePathRule_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -84,6 +84,7 @@ model User {
   businessModelRoleAssignments  BusinessModelRoleAssignment[]
   platformDevConfigs            PlatformDevConfig[]           @relation("PlatformDevConfiguredBy")
   platformDevDcoAcceptances     PlatformDevConfig[]           @relation("PlatformDevDcoAcceptedBy")
+  privatePathRules              PrivatePathRule[]             @relation("PrivatePathRuleCreatedBy")
   platformDevFeedbackOptIns     PlatformDevConfig[]           @relation("PlatformDevUpstreamFeedbackOptInBy")
   agentModelConfigs             AgentModelConfig[]            @relation("AgentModelConfiguredBy")
   knowledgeArticles             KnowledgeArticle[]            @relation("KnowledgeArticleAuthor")
@@ -4650,6 +4651,18 @@ model FeatureBuild {
   claimedAt                DateTime?
   claimStatus              String?
   gitCommitHashes          String[]                 @default([])
+  // Private/Public Change Segregation (EP-1A78BAE1). Per-change disposition,
+  // fail-closed to "private": no public-hive egress unless explicitly
+  // "shareable". `dispositionSuggested`/`Reason` cache the AI suggestion from
+  // review signals; `dispositionSource` is null until a human makes the final
+  // call ("operator") or the suggestion is recorded ("suggested").
+  disposition                  String                @default("private")
+  dispositionReason            String?
+  dispositionSource            String?
+  dispositionDecidedAt         DateTime?
+  dispositionDecidedById       String?
+  dispositionSuggested         String?
+  dispositionSuggestionReason  String?
   uxTestResults            Json?
   uxVerificationStatus     String? // null | "running" | "complete" | "failed" | "skipped"
   deliberationSummary      Json? // compact BuildDeliberationSummary (see apps/web/lib/feature-build-types.ts)
@@ -5516,6 +5529,19 @@ model UpgradeImpactSummary {
 
   @@unique([currentLineageSha, targetSha])
   @@index([targetSha])
+}
+
+// PrivatePathRule — operator-managed overrides that merge with the checked-in
+// `.dpf/private-paths` manifest. Paths matching either source are NEVER
+// included in a public-hive contribution diff (Private/Public Change
+// Segregation, EP-1A78BAE1). gitignore-style glob in `pattern`.
+model PrivatePathRule {
+  id          String   @id @default(cuid())
+  pattern     String   @unique
+  reason      String?
+  createdById String?
+  createdBy   User?    @relation("PrivatePathRuleCreatedBy", fields: [createdById], references: [id])
+  createdAt   DateTime @default(now())
 }
 
 model PlatformDevConfig {

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1290,6 +1290,10 @@ async function seedClientIdentity(): Promise<void> {
       id: "singleton",
       clientId,
       gitAgentEmail,
+      // Fail-closed default for a fresh install (EP-1A78BAE1): keep everything
+      // private until the operator opts into contributing. Set explicitly here
+      // rather than via the column default so the 2-state intent is unambiguous.
+      contributionMode: "private",
     },
     update: {
       clientId,


### PR DESCRIPTION
## Summary

The full **contribution-model refactor** ratified via `principle_decide` (composite 9.15, margin 1.11, high confidence, no commandment conflict). Plan: `docs/superpowers/plans/2026-06-19-contribution-model-2state-suggest-confirm.md`. Continues #2074 (private-paths boundary) and #2079 (public-hive egress), both merged.

Collapses the install model from **3 modes** (`fork_only`/`selective`/`contribute_all`) to **2** (`private`/`contributing`), and replaces the static default lean with a per-change **suggest-then-confirm** decision — the AI suggests Keep/Share, the human makes the final call, **fail-closed** to private.

## What's in this PR
**Enum collapse (all surfaces):**
- 13 reader/writer touchpoints → 2-state with legacy back-compat; data-only backfill migration; seed sets `"private"` explicitly (fail-closed).
- UX: `PlatformDevelopmentForm` 3→2 plain-language options + `AdvancedTokenPaste`/`ContributionModelBanner`/page + tests.
- Build Studio ship prompt + MCP gating moved to 2-state.

**Per-change disposition (suggest-then-confirm):**
- Schema (additive): `FeatureBuild.disposition` (default `private`) + reason/source/decided + cached suggestion; new `PrivatePathRule` table. Migration backfills every build to `private`.
- **Fail-closed gate at public-hive egress only** — `contribute_to_hive` (always public) and `create_portal_pr` (when public) refuse unless `shareable`; own-repo PRs unaffected → Build Studio ship-to-own-repo keeps working.
- **`set_change_disposition` MCP tool** — the human's final call.
- `suggestDisposition()` — pure suggestion from existing review signals (reusabilityScope + sanitization hits), fail-closed.

**Docs:** user-guide deployment reframed to 2-state; supersession notes on the two canonical 3-mode design specs. AGENTS.md needs no change (no mode literals).

## Surfaces / processes (per goal)
- **Build Studio + external (Claude/Codex):** identical 2-state + disposition model; provenance-blind (§17).
- **Sandbox / self-upgrade / MCP:** no new infra; migrations apply through the governed self-upgrade merge into `dpf/install`; private installs stay fully local.

## Verification
- **Compile-ready worktree** (deps + regenerated Prisma client): `pnpm --filter web typecheck` clean; **69 unit tests pass**; pre-commit schema-regression guard ✅ and scoped typecheck ✅.
- Migration apply + `next build` + UX exercise deferred to the canonical install (AGENTS.md §5).

## Still ahead (follow-up)
- Wire `suggestDisposition` into `deploy_feature` to cache the suggestion; onboarding `SetupOverlay` binary + Upgrade Center local-changes ledger (UI, canonical-install UX verification); admin private-paths editor.

EP-1A78BAE1 BI-6BAE4748

🤖 Generated with [Claude Code](https://claude.com/claude-code)