### PR TITLE
fix(build-studio): route Ideate research to the local engine on opencode installs

### DIFF
--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -109,6 +109,42 @@ describe("dispatchIdeateForApprovedBuild", () => {
     expect(mockExecuteTool).not.toHaveBeenCalled();
   });
 
+  it("routes Ideate to the LOCAL engine when provider=opencode (not the codex/chatgpt fallback)", async () => {
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({ originatingBacklogItemId: "cmpcuid1", designDoc: null, title: "T", description: "D" })
+      .mockResolvedValueOnce({ designDoc: { problemStatement: "P" } });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "Body." });
+    mockGetBuildStudioConfig.mockResolvedValue({
+      provider: "opencode",
+      opencodeProviderId: "local",
+      opencodeModel: "docker.io/ai/qwen3-coder:latest",
+      // The codex fallback MUST NOT be used for an opencode install.
+      codexProviderId: "chatgpt",
+      codexModel: "gpt-5.3-codex",
+      claudeProviderId: "", grokProviderId: "", claudeModel: "", grokModel: "",
+    });
+    mockDispatchIdeateResearch.mockResolvedValue({
+      success: true,
+      designDoc: { problemStatement: "P", proposedApproach: "x".repeat(60) },
+      rawOutput: "", durationMs: 1,
+    });
+    mockExecuteTool.mockResolvedValue({ success: true });
+
+    await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(mockDispatchIdeateResearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "local",
+        model: "docker.io/ai/qwen3-coder:latest",
+        dispatchEngine: "opencode",
+      }),
+    );
+    // Regression guard: it must NOT fall back to the cloud chatgpt provider.
+    expect(mockDispatchIdeateResearch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "chatgpt" }),
+    );
+  });
+
   it("dispatches research and saves designDoc evidence on the happy path", async () => {
     // 2026-05-24: originatingBacklogItemId is a FK to BacklogItem.id (cuid),
     // not BacklogItem.itemId (BI-XXXXX semantic id). Use a cuid-shaped value

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -132,11 +132,17 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // Short-circuit to a clean skip with a meaningful BuildActivity row.
     const { getBuildStudioConfig } = await import("@/lib/integrate/build-studio-config");
     const config = await getBuildStudioConfig();
+    // BI-0F291741/local-tuning: resolve per the configured engine. Without the
+    // `opencode` branch this fell through to codexProviderId (cloud chatgpt),
+    // so a fully-local install (provider="opencode", opencodeProviderId="local")
+    // silently ran Ideate research on the cloud instead of the local model.
     const providerId = config.provider === "claude"
       ? config.claudeProviderId
       : config.provider === "grok"
         ? config.grokProviderId
-        : config.codexProviderId;
+        : config.provider === "opencode"
+          ? config.opencodeProviderId
+          : config.codexProviderId;
 
     if (config.provider === "agentic" || !providerId) {
       const outcome: DispatchOutcome = {
@@ -151,7 +157,9 @@ export async function dispatchIdeateForApprovedBuild(params: {
       ? config.claudeModel
       : config.provider === "grok"
         ? config.grokModel
-        : config.codexModel;
+        : config.provider === "opencode"
+          ? config.opencodeModel
+          : config.codexModel;
 
     // The BI body is the canonical context for backlog-promoted drafts.
     // It typically contains problem statement, acceptance criteria, and


### PR DESCRIPTION
## Bottleneck (live, local-tuning)
Ideate auto-dispatch resolved provider/model with a ternary covering claude/grok + an **else → codexProviderId** fallback. With the engine configured `opencode` (`opencodeProviderId:"local"`), it fell through to codex and ran Ideate research on **cloud chatgpt** — observed live: *"Dispatching ideate research via opencode (provider=chatgpt)"*. A fully-local install was silently paying cloud and ignoring its local model.

## Fix
Add the `opencode` branch to both the providerId and model resolution (`ideate-on-approval.ts`). `dispatchIdeateResearch` already has an opencode path; only this resolution was missing it. Unit-tested: `provider=opencode` → `providerId:"local"` + local model, never the chatgpt fallback.

## Verify (sandbox @ 00b3623c)
`vitest ideate-on-approval.test.ts` → **13/13** (incl. new local-routing test); `tsc` running.

Part of the local-LLM plumbing tuning pass.