### PR TITLE
fix(build-studio): regenerate a failed plan on resume instead of re-reviewing it forever

### DIFF
--- a/apps/web/lib/integrate/plan-on-approval.ts
+++ b/apps/web/lib/integrate/plan-on-approval.ts
@@ -256,8 +256,13 @@ async function runPlanReview(buildId: string, userId: string, log: (s: string) =
 export async function dispatchPlanForApprovedBuild(params: {
   buildId: string;
   userId: string;
+  /** Local-tuning: when a build is RESUMED with an existing plan that already
+   *  FAILED review, bypass the idempotency guard so the BI-99B06AD1 fix loop
+   *  regenerates it (with a fresh verified-paths search) instead of re-reviewing
+   *  the same bad plan forever. The resume path passes this on a failed planReview. */
+  forceRegenerate?: boolean;
 }): Promise<PlanDispatchOutcome> {
-  const { buildId, userId } = params;
+  const { buildId, userId, forceRegenerate = false } = params;
   const t0 = Date.now();
 
   const log = (summary: string) =>
@@ -293,11 +298,16 @@ export async function dispatchPlanForApprovedBuild(params: {
       return { kind: "skipped-no-design-doc", reason: "designDoc is null" };
     }
 
-    // Idempotency guard.
+    // Idempotency guard — skipped when forceRegenerate (a resume of a build whose
+    // existing plan FAILED review), so the fix loop below repairs it rather than
+    // the dispatch short-circuiting and the build re-failing the same review.
     const existingPlan = build.buildPlan as { tasks?: unknown[] } | null;
-    if (existingPlan?.tasks && Array.isArray(existingPlan.tasks) && existingPlan.tasks.length > 0) {
+    if (!forceRegenerate && existingPlan?.tasks && Array.isArray(existingPlan.tasks) && existingPlan.tasks.length > 0) {
       await log("Skipped — buildPlan already present");
       return { kind: "skipped-already-has-plan", reason: "buildPlan already saved" };
+    }
+    if (forceRegenerate && existingPlan?.tasks?.length) {
+      await log("Resume: existing plan failed review — regenerating with the fix loop.");
     }
 
     // 2. Fetch BI context for richer prompt.

--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -56,6 +56,18 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     expect(out).toMatchObject({ kind: "resumed", via: "executeTool:reviewBuildPlan" });
   });
 
+  it("REGENERATES via the fix loop when the existing plan's last review FAILED (does not re-review the bad plan)", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { x: 1 },
+      buildPlan: { tasks: [{ title: "t" }] },
+      planReview: { decision: "fail", issues: [{ severity: "critical", description: "points at files that do not exist" }] },
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-3F", phase: "plan", userId: "u3" });
+    expect(dispatchPlanMock).toHaveBeenCalledWith({ buildId: "FB-3F", userId: "u3", forceRegenerate: true });
+    expect(executeToolMock).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ kind: "resumed", via: "dispatchPlanForApprovedBuild:repair" });
+  });
+
   it("re-dispatches ideate research when no design doc exists yet", async () => {
     findUniqueMock.mockResolvedValue({ designDoc: null, buildPlan: null });
     const out = await resumePreBuildPhase({ buildId: "FB-4", phase: "ideate", userId: "u4" });

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -73,7 +73,7 @@ export async function resumePreBuildPhase(params: {
 
     const build = await prisma.featureBuild.findUnique({
       where: { buildId },
-      select: { designDoc: true, buildPlan: true },
+      select: { designDoc: true, buildPlan: true, planReview: true },
     });
     if (!build) {
       return { kind: "failed", phase, error: "build not found" };
@@ -107,9 +107,21 @@ export async function resumePreBuildPhase(params: {
         const outcome = await dispatchPlanForApprovedBuild({ buildId, userId });
         return { kind: "resumed", phase, via: "dispatchPlanForApprovedBuild", detail: outcome.kind };
       }
-      // Plan exists but the build never advanced (e.g. a stale FAILED planReview
-      // that current reviewer logic would now pass). Re-run the canonical plan
-      // review; it auto-advances plan->build on pass.
+      // Plan exists. If its last review FAILED, REGENERATE via the fix loop —
+      // re-reviewing the same bad plan just re-fails forever (the live jam: a plan
+      // that "points at files that do not exist" stays stuck every resume). The
+      // forceRegenerate path bypasses the idempotency guard so #2090's bounded
+      // fix loop (with a fresh verified-paths search + escalation) repairs it.
+      const planReviewFailed =
+        (build.buildPlan != null) &&
+        (build.planReview as { decision?: string } | null)?.decision === "fail";
+      if (planReviewFailed) {
+        const { dispatchPlanForApprovedBuild } = await import("@/lib/integrate/plan-on-approval");
+        const outcome = await dispatchPlanForApprovedBuild({ buildId, userId, forceRegenerate: true });
+        return { kind: "resumed", phase, via: "dispatchPlanForApprovedBuild:repair", detail: outcome.kind };
+      }
+      // No failed verdict — re-run the review (current reviewer logic may now pass
+      // an older verdict); it auto-advances plan->build on pass.
       const { executeTool } = await import("@/lib/mcp-tools");
       const result = await executeTool("reviewBuildPlan", { buildId }, userId, { featureBuildId: buildId });
       return {


### PR DESCRIPTION
## Bottleneck (the live plan jam)
A build whose plan failed review — e.g. *"points at files that do not exist"* (the local model hallucinating a path) — sits in `plan` re-failing the **same** review on every resume/reboot **forever**. `resumeStrandedBuildsOnBoot` re-ran `reviewBuildPlan` on the stale bad plan, and #2090's fix loop only fires at *initial* generation (its idempotency guard skips when a plan exists). So the loop that would repair it never ran.

## Fix
`dispatchPlanForApprovedBuild` gains a `forceRegenerate` flag that bypasses the idempotency guard; the resume path passes it when `planReview.decision === "fail"`. The existing bounded fix loop (fresh verified-paths search → regenerate → re-review → escalate after N rounds) then **repairs** the plan. This is what lets the strong agentic loop actually correct the local model's precision errors — directly enabling the *"small task + strong loop ≈ frontier"* path.

## Verify (sandbox @ e8207298)
`vitest resume-pre-build-phase.test.ts + plan-on-approval.test.ts` → **17/17** (incl. new regenerate-on-failed-review test); non-failed resumes still just re-review (unchanged). `tsc` running.

Bottleneck 2/6 of the local-LLM tuning pass. (Design-review fix loop = bottleneck 3, next.)