### PR TITLE
feat(build-studio): capture the build's PR onto its WorkCapsule + delivery-visibility design (BI-620261D8)

### DIFF
--- a/apps/web/lib/build/capture-build-pr.test.ts
+++ b/apps/web/lib/build/capture-build-pr.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { captureBuildPrOntoCapsule } from "./capture-build-pr";
+
+function mkDb(count = 1) {
+  const updateMany = vi.fn().mockResolvedValue({ count });
+  return { db: { workCapsule: { updateMany } }, updateMany };
+}
+
+describe("captureBuildPrOntoCapsule (delivery visibility — PR capture onto the WorkCapsule)", () => {
+  it("stamps url + number onto the build's capsule(s), keyed by featureBuildId (the cuid)", async () => {
+    const { db, updateMany } = mkDb(1);
+    const out = await captureBuildPrOntoCapsule({
+      db,
+      featureBuildId: "ckcuid123",
+      prNumber: 2145,
+      prUrl: "https://github.com/o/r/pull/2145",
+    });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { featureBuildId: "ckcuid123" },
+      data: { pullRequestUrl: "https://github.com/o/r/pull/2145", pullRequestNumber: 2145 },
+    });
+    expect(out).toEqual({ captured: 1 });
+  });
+
+  it("reports captured 0 (not an error) when the build has no capsule yet", async () => {
+    const { db } = mkDb(0);
+    const out = await captureBuildPrOntoCapsule({ db, featureBuildId: "c", prNumber: 5, prUrl: "u" });
+    expect(out).toEqual({ captured: 0 });
+  });
+
+  it("is a no-op (no DB write) when featureBuildId is blank", async () => {
+    const { db, updateMany } = mkDb();
+    const out = await captureBuildPrOntoCapsule({ db, featureBuildId: "", prNumber: 5, prUrl: "u" });
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(out).toEqual({ captured: 0 });
+  });
+
+  it("is a no-op when prUrl is empty", async () => {
+    const { db, updateMany } = mkDb();
+    const out = await captureBuildPrOntoCapsule({ db, featureBuildId: "c", prNumber: 5, prUrl: "" });
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(out).toEqual({ captured: 0 });
+  });
+
+  it("is a no-op when prNumber is not a positive finite number", async () => {
+    const { db, updateMany } = mkDb();
+    for (const bad of [0, -3, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const out = await captureBuildPrOntoCapsule({ db, featureBuildId: "c", prNumber: bad, prUrl: "u" });
+      expect(out).toEqual({ captured: 0 });
+    }
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/build/capture-build-pr.ts
+++ b/apps/web/lib/build/capture-build-pr.ts
@@ -1,0 +1,70 @@
+// apps/web/lib/build/capture-build-pr.ts
+//
+// Capture a Build Studio build's pull request onto its Work Capsule so the PR
+// becomes a first-class, queryable, surfaceable fact instead of a free-text line
+// buried in BuildActivity.
+//
+// Why this exists (delivery visibility — "where are my PRs?"):
+//   A FeatureBuild auto-attaches a WorkCapsule at draft time
+//   (work-capsules/build-studio-attachment.ts, featureBuildId = FeatureBuild.id),
+//   and that capsule already carries `pullRequestUrl` / `pullRequestNumber`.
+//   Those columns are READ in many places — the change-lanes projection
+//   (lib/contributor-change-lanes/lane-projection.ts), the runtime-target rollup
+//   (lib/runtime-coordination/runtime-targets.ts), and the capsule presenters —
+//   but NOTHING wrote them at PR-creation time. `create_portal_pr` opened the PR,
+//   logged it as free text, and the capsule fields stayed null, so every reader
+//   fell back to a delayed, branch-name-matched GitHub inventory snapshot (or to
+//   nothing). The model and the readers existed; only the writer was missing.
+//   This is that writer: the moment a PR exists, stamp it onto the build's
+//   capsule(s) so the delivery surfaces show it immediately.
+//
+// Migration-free: the columns already exist. Best-effort by contract: opening a
+// PR must never hinge on this write — the caller wraps it in try/catch, and a
+// build with no capsule yet (or missing inputs) is a non-error that returns
+// `{ captured: 0 }` rather than throwing.
+
+/** The narrow slice of the Prisma client this helper needs (injectable for tests). */
+export interface CaptureBuildPrDeps {
+  workCapsule: {
+    updateMany: (args: {
+      where: { featureBuildId: string };
+      data: { pullRequestUrl: string; pullRequestNumber: number };
+    }) => Promise<{ count: number }>;
+  };
+}
+
+export interface CaptureBuildPrArgs {
+  db: CaptureBuildPrDeps;
+  /**
+   * FeatureBuild.id (the cuid) — the capsule's `featureBuildId` link.
+   * NOT the FB-* semantic build id (that is the capsule's `executorRef`).
+   */
+  featureBuildId: string;
+  prNumber: number;
+  prUrl: string;
+}
+
+/**
+ * Stamp the PR (url + number) onto every Work Capsule linked to this build.
+ *
+ * @returns the number of capsules updated. `0` is a normal outcome — the build
+ *   may not have a capsule yet, or a required input may be absent; neither is an
+ *   error.
+ */
+export async function captureBuildPrOntoCapsule(
+  args: CaptureBuildPrArgs,
+): Promise<{ captured: number }> {
+  const { db, featureBuildId, prNumber, prUrl } = args;
+
+  // Guard: only write a real PR onto a real build. A blank id, an empty url, or
+  // a non-positive/NaN number means there is nothing meaningful to capture.
+  if (!featureBuildId || !prUrl || !Number.isFinite(prNumber) || prNumber <= 0) {
+    return { captured: 0 };
+  }
+
+  const res = await db.workCapsule.updateMany({
+    where: { featureBuildId },
+    data: { pullRequestUrl: prUrl, pullRequestNumber: prNumber },
+  });
+  return { captured: res.count };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10654,6 +10654,28 @@ export async function executeTool(
         };
       }
 
+      // Capture the PR onto the build's Work Capsule so it becomes a queryable,
+      // surfaceable fact (delivery visibility). The capsule's pullRequestUrl/
+      // Number are READ by the change-lanes projection, the runtime-target
+      // rollup, and the capsule presenters, but had no writer at PR-creation
+      // time — so a build's PR stayed invisible until a delayed branch-name-
+      // matched GitHub inventory snapshot backfilled it (or never). Migration-
+      // free + best-effort: opening the PR must never hinge on this write.
+      try {
+        const { captureBuildPrOntoCapsule } = await import("@/lib/build/capture-build-pr");
+        const cap = await captureBuildPrOntoCapsule({
+          db: prisma,
+          featureBuildId: build.id,
+          prNumber: prResult.prNumber,
+          prUrl: prResult.prUrl,
+        });
+        if (cap.captured > 0) {
+          logBuildActivity(buildId, "create_portal_pr", `Linked PR #${prResult.prNumber} to ${cap.captured} work capsule(s).`);
+        }
+      } catch (err) {
+        console.warn("[create_portal_pr] PR-capture onto capsule failed:", err);
+      }
+
       // Auto-merge decision: all gates pass + build fully verified
       const fullyVerified = typecheckPassed && testsFailed === 0 && acMet === acTotal && acTotal > 0;
       let merged = false;

--- a/docs/superpowers/specs/2026-06-19-delivery-visibility-and-pr-capture-addendum.md
+++ b/docs/superpowers/specs/2026-06-19-delivery-visibility-and-pr-capture-addendum.md
@@ -1,0 +1,91 @@
+# Delivery Visibility & PR Capture — Addendum to Unified Build Studio Tracking
+
+- **Date:** 2026-06-19
+- **Status:** draft (research + keystone shipped)
+- **Author:** Claude Code (operator `/goal` session)
+- **Extends:** [`2026-06-19-unified-build-studio-tracking-all-surfaces-design.md`](2026-06-19-unified-build-studio-tracking-all-surfaces-design.md) (EP-UNIFIED-TRACKING) — that spec chose the WorkCapsule as the universal work-unit and the unified timeline backbone. This addendum does **not** restate or compete with it; it closes three gaps that surfaced from a *delivery-visibility* operator ask the parent spec did not center.
+- **Epic:** EP-UNIFIED-TRACKING
+- **New backlog:** BI-620261D8 (PR capture + status node), BI-DF8537CC (delivery→change-record), BI-D3E09880 (delivery IA)
+- **Cross-epic:** [BI-7C4FDBF5](#) (EP-BUILD-STUDIO — PR merge-resolution; produces the PR-status read this addendum renders)
+- **Related:** [`2026-06-19-build-studio-pr-merge-resolution-design.md`](2026-06-19-build-studio-pr-merge-resolution-design.md)
+
+---
+
+## 1. Operator intent (verbatim framing)
+
+> "I'm trying to see how the 2 complete runs are tracked with their PRs and what the status of those PRs are in the platform. Under admin there is Platform Development, and also Hive Contributions — these are related but they are not showing me the PRs either. Where are PRs captured? I also looked at Build Runtime under AI Operations, it's not there either. … I also looked at a Change Log, there is nothing there either. We need a much better design for these surfaces, and better visibility. … There may be other surfaces I didn't even find."
+
+This is a **delivery-visibility** ask: *for a build, where is its PR, what is the PR's status, where is the change record, and why are the surfaces scattered?* The parent spec (EP-UNIFIED-TRACKING) answers the structurally-adjacent "track external-agent work in one timeline" ask and picks the right backbone (WorkCapsule-anchored unified timeline). Three gaps remain against the delivery-visibility framing.
+
+## 2. The backbone already chosen (parent spec — do not duplicate)
+
+The parent spec's decisions are adopted wholesale:
+- **WorkCapsule = the universal work-unit** (executor-agnostic, leased, already feeding the cross-surface change-lanes view); `FeatureBuild` is the BS-internal execution detail that attaches to a capsule.
+- **One unified timeline** rendered by the existing `UnifiedEvidenceTimeline` component, merging `WorkCapsuleActivity` + linked `BuildActivity`/`BuildArtifactRevision` + `ExternalEvidenceRecord` + `RuntimeVerification` + `PhaseHandoff` (BI-C25374E4), retiring the *faked* external lane at `WorkflowStageInspector.tsx:137`.
+- A capsule/build-keyed live channel + Daily-Steward status reconciler (BI-8F83933B).
+
+## 3. Gap A — PRs are not captured as a queryable fact (the headline)
+
+**Finding (sharper than "scattered"): the model and the readers exist; only the *writer* was missing.**
+
+`WorkCapsule.pullRequestUrl`/`pullRequestNumber` (`schema.prisma:1058-1059`) already exist and are **read** in at least three projections:
+- change-lanes lane projection — `lib/contributor-change-lanes/lane-projection.ts:108,162`
+- runtime-target rollup — `lib/runtime-coordination/runtime-targets.ts:347-348`
+- capsule presenter — `lib/work-capsules/work-capsule-presenter.ts:31`
+
+But **no code wrote them at PR-creation time.** `create_portal_pr` (`mcp-tools.ts`) opened the PR, captured `prResult.prUrl`/`prNumber`, logged them as a free-text BuildActivity line, and returned — never stamping them onto the build's attached capsule. Every reader therefore fell back to `pr?.url` (a delayed, branch-name-matched GitHub *inventory snapshot* from contributor-inventory-sync) `?? capsule.pullRequestUrl` (null). Result: a freshly-shipped build's PR is invisible until an out-of-band sync maybe backfills it. And no live PR *status* (open / checks / mergeable / behind / conflicting / merged) is synced at all.
+
+### 3.1 Keystone — shipped in this change (the missing writer)
+`apps/web/lib/build/capture-build-pr.ts` → `captureBuildPrOntoCapsule({ db, featureBuildId, prNumber, prUrl })`, wired into `create_portal_pr` immediately after the PR is confirmed. It `updateMany`s the build's capsule(s) (keyed by `featureBuildId = FeatureBuild.id`, the link set at `work-capsules/build-studio-attachment.ts:72`) with the PR url + number. Migration-free (columns already exist); best-effort (opening the PR never hinges on it); unit-tested. This alone makes the change-lanes / runtime-target / presenter readers show the real PR the moment it is opened.
+
+### 3.2 Remaining (BI-620261D8)
+- **Live PR-status sync:** a queryable status + checks summary + `mergedAt` + `deployedSha`, sourced by consuming the watcher **BI-7C4FDBF5** stands up (it revives the dead `getPRStatus()` and already needs to poll mergeable state) — *not* a second poller.
+- **Render the PR → merge → deploy node** on the unified timeline (BI-C25374E4), in plain language ("Finalizing against the latest platform…", "Your change is live").
+- Persist status so the BI-8F83933B reconciler projects capsule status from real PR state.
+
+## 4. Gap B — delivered builds create no change record (empty Change Log)
+
+`/ops/changes` reads `ChangeRequest`/`ChangeItem`; a BS build never creates one (`FeatureBuild` has no FK to `ChangeRequest`). `ChangePromotion` is updated on auto-merge only when a `ProductVersion` already exists for the build — usually it does not. So the operator's Change Log is empty for the very builds they shipped, and the timeline has no change/deploy node.
+
+**Fix (BI-DF8537CC):** on ship/merge, create-or-link a `ChangeRequest` (ITIL *standard change*) + `ChangePromotion`, reusing the **source-agnostic `registerChange()` primitive** the self-upgrade change-register work already added at the `run-store.ts` chokepoints (EP-UPGRADE-LIFECYCLE / BI-E53C3466) — expressly built so other subsystems can log changes. No new model expected.
+
+## 5. Gap C — no information architecture (scattered surfaces)
+
+A 2026-06-19 audit enumerated ~14 dev-process surfaces with no coherent IA. The parent spec unifies the *data*; it does not address the *navigation*.
+
+| Route | What it actually is | Lifecycle stage | Discoverability |
+| --- | --- | --- | --- |
+| `/build` (+ hidden `?v=2`) | Build Studio (FeatureBuild) | idea→build→ship | primary; v2 hidden |
+| `/build/work` | Work Capsules (incl. PR fields) | merge prep | hidden |
+| `/admin/platform-development` | dev **config** (policy/DCO/creds/token) | config | mistaken for a dashboard |
+| `/admin/hive` | HiveContributionLedger (knowledge/rules) | governance | nav |
+| `/ops` | Backlog + Epics | intake/triage | primary |
+| `/ops/changes` | ChangeRequest RFCs | change governance | nav (empty for builds — Gap B) |
+| `/ops/promotions` | ChangePromotion + GitPromotionCandidate | deploy/merge | hidden |
+| `/ops/dev-loop` | live RuntimeTarget/leases/worktrees | runtime ops | hidden |
+| `/ops/improvements` | ImprovementProposal | improvement intake | nav |
+| `/ops/self-upgrade` | SelfUpgradeRun + impact summary | portal self-update | nav |
+| `/platform/ai/build-studio` | BS **config** (providers/engines) | config | nav |
+| `/platform/ai/operations-map` | agent routing/execution topology | agent ops | hidden ("Build Runtime"?) |
+| `/admin/build-studio/stall-thresholds` | BS tuning | config | deep/hidden |
+
+**Fix (BI-D3E09880):** one canonical **Delivery** surface = the lifecycle-visibility home, with three lenses over the same WorkCapsule-joined data:
+1. **Pipeline lens** — board of all work by stage (Ideating → Building → In-Review → PR Open → Merging → Deploying → Done); each card shows PR # + live status.
+2. **Thread lens** — one build's end-to-end timeline (the BI-C25374E4 projection + the PR/merge/deploy node from Gap A + the change node from Gap B).
+3. **Attention lens** — only what needs the operator: review pending, PR conflict/behind (BI-7C4FDBF5), deploy-window, `needs-human` escalation (BI-3E0EE3BA `selfFixClass`).
+
+Plus: a consolidated **Development Settings** home for config (Platform Development + `/platform/ai/build-studio` + stall-thresholds); surface the hidden routes in nav; make Hive / Changes / Promotions / Dev-Loop drill-downs from the thread lens.
+
+## 6. Sequencing (folds into the parent spec's phases)
+
+- **Now (shipped):** Gap A keystone — `captureBuildPrOntoCapsule` writer (this change).
+- **Phase 1 (with BI-C25374E4):** render the PR/merge/deploy node on the unified timeline; stand up the Delivery thread lens.
+- **Phase 2 (with BI-7C4FDBF5):** consume the merge-resolution watcher's status into the PR-status field (BI-620261D8); Attention lens.
+- **Phase 3:** delivery→change-record via `registerChange()` (BI-DF8537CC); Change Log shows delivered builds.
+- **Phase 4:** the consolidated Delivery + Development Settings IA (BI-D3E09880); surface hidden routes.
+
+## 7. Principles honored
+
+- `verify-substrate-before-proposing-new` / `schema-audit-before-features` — the keystone added a *writer* to existing columns + existing readers; no new model. The change-record join reuses `registerChange()`. The IA reuses the parent spec's WorkCapsule timeline.
+- `single-source-of-truth` — PR identity + status live on the WorkCapsule (the chosen universal unit), not a fourth parallel store.
+- `structural-verification-is-not-functional` — the keystone ships with a unit test; functional proof = open a BS PR and confirm the capsule's PR fields populate at creation and the PR surfaces in change-lanes (pending live verification post-deploy).


### PR DESCRIPTION
## Operator ask (verbatim)
> "I'm trying to see how the complete runs are tracked with their PRs and what the status of those PRs are… Where are PRs captured? … the Change Log, there is nothing there either. We need a much better design for these surfaces and better visibility. There may be other surfaces I didn't even find."

## The answer: a missing *writer*, not a missing model
`WorkCapsule.pullRequestUrl`/`pullRequestNumber` already **exist** and are **read** by the change-lanes projection ([lane-projection.ts:108](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/apps/web/lib/contributor-change-lanes/lane-projection.ts)), the runtime-target rollup, and the capsule presenters — but `create_portal_pr` opened the PR, logged it as free text, and **never wrote them**. So a shipped build's PR was invisible until a delayed branch-name-matched GitHub inventory snapshot backfilled it (or never).

## Keystone (this PR)
- `apps/web/lib/build/capture-build-pr.ts` — `captureBuildPrOntoCapsule` (pure, unit-tested), wired into `create_portal_pr` right after the PR is confirmed: stamps `prUrl`/`prNumber` onto the build's capsule(s) by `featureBuildId`. **Migration-free** (columns exist); **best-effort** (opening the PR never hinges on it). Lights up the existing readers immediately.

## Design (this PR — docs)
Substrate-first: a concurrent session already designed the unified-timeline backbone ([EP-UNIFIED-TRACKING spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/superpowers/specs)). This PR adds a focused **addendum** closing 3 delivery-visibility gaps that ask did not center, and files them into that epic:
- **BI-620261D8** — live PR-status node on the timeline (this keystone's home; consumes BI-7C4FDBF5's watcher).
- **BI-DF8537CC** — delivery→change-record join (a shipped build creates/links a ChangeRequest+ChangePromotion so the Change Log reflects delivered builds; reuses the self-upgrade `registerChange()` primitive).
- **BI-D3E09880** — one **Delivery** information-architecture unifying the ~14 scattered dev surfaces (Pipeline / Thread / Attention lenses; split lifecycle-visibility from process-config; surface hidden routes).

## Verification
- Unit test for the keystone helper (5 cases incl. no-capsule and bad-input no-ops).
- ⚠️ Local toolchain is absent in this worktree (`next`/`tsc`/`vitest` not installed; `.pnpm` empty) — local typecheck/vitest could not run. **CI's required Typecheck + Unit Tests (clean install) are the gate.**
- Functional proof (post-deploy): open a BS PR, confirm the capsule's PR fields populate at creation and the PR surfaces in change-lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)