### PR TITLE
fix(scheduler): honor cron day-of-month & month — Monthly/Once agent tasks no longer run daily (BI-D72CC945)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -813,6 +813,62 @@ describe("executeScheduledAgentTask — SysML projection reconcile branch", () =
   });
 });
 
+describe("executeScheduledAgentTask one-shot deactivation (BI-D72CC945)", () => {
+  it("deactivates a one-shot (Once) task after it fires instead of re-arming", async () => {
+    arrangeScheduledTask();
+    mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+      taskId: "agent-task-once1",
+      agentId: "platform-engineer",
+      title: "One-shot scan",
+      prompt: "Do the thing once.",
+      routeContext: "/platform",
+      schedule: "0 9 5 7 *", // Once: July 5
+      timezone: "UTC",
+      isActive: true,
+      ownerUserId: "user-1",
+    });
+    mocks.runAgenticLoop.mockResolvedValue({ content: "Done.", executedTools: [] });
+
+    await executeScheduledAgentTask("agent-task-once1");
+
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "agent-task-once1" },
+        data: expect.objectContaining({
+          lastStatus: "ok",
+          isActive: false,
+          nextRunAt: null,
+        }),
+      }),
+    );
+  });
+
+  it("re-arms a recurring (Monthly) task with a real next-run date and leaves it active", async () => {
+    arrangeScheduledTask();
+    mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+      taskId: "agent-task-monthly1",
+      agentId: "platform-engineer",
+      title: "Monthly scan",
+      prompt: "Do the monthly thing.",
+      routeContext: "/platform",
+      schedule: "0 9 1 * *", // Monthly
+      timezone: "UTC",
+      isActive: true,
+      ownerUserId: "user-1",
+    });
+    mocks.runAgenticLoop.mockResolvedValue({ content: "Done.", executedTools: [] });
+
+    await executeScheduledAgentTask("agent-task-monthly1");
+
+    const okUpdate = mocks.prisma.scheduledAgentTask.update.mock.calls.find(
+      ([arg]) => arg.where.taskId === "agent-task-monthly1" && arg.data.lastStatus === "ok",
+    );
+    expect(okUpdate).toBeDefined();
+    expect(okUpdate?.[0].data.nextRunAt).toBeInstanceOf(Date);
+    expect(okUpdate?.[0].data.isActive).toBeUndefined();
+  });
+});
+
 describe("scheduleAgentTask UTC-only timezone", () => {
   it("rejects non-UTC timezone with an explanatory error", async () => {
     mocks.auth.mockResolvedValue({ user: { id: "user-1" } });

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -5,6 +5,7 @@ import { prisma, DATA_MODEL_MIRROR_TASK_ID, SYSML_PROJECTION_TASK_ID } from "@dp
 import { randomUUID } from "crypto";
 import { runDataModelMirror } from "@/lib/ea/run-data-model-mirror";
 import { runArchitectureParitySteward } from "@/lib/ea/architecture-parity-steward";
+import { computeNextCronRun, isOneShotCron } from "@/lib/operate/cron-next-run";
 import { extractScheduledTaskSummary } from "./agent-task-scheduler-summary";
 import {
   createTaskRunForScheduledTask,
@@ -20,42 +21,11 @@ import {
 
 // ─── Cron helpers ───────────────────────────────────────────────────────────
 
-/**
- * Compute the next run time from a cron expression.
- * Supports standard 5-field cron: minute hour day-of-month month day-of-week
- * For simplicity, handles the common patterns directly.
- */
-function computeNextCronRun(cronExpr: string, from: Date): Date {
-  const parts = cronExpr.trim().split(/\s+/);
-  if (parts.length !== 5) return new Date(from.getTime() + 24 * 60 * 60_000); // fallback daily
-
-  const [minPart, hourPart, , , dowPart] = parts;
-  const minute = minPart === "*" ? 0 : parseInt(minPart!, 10);
-  const hour = hourPart === "*" ? from.getHours() : parseInt(hourPart!, 10);
-
-  // Start from the next hour boundary
-  const next = new Date(from);
-  next.setSeconds(0, 0);
-  next.setMinutes(minute);
-  next.setHours(hour);
-
-  // If time already passed today, go to tomorrow
-  if (next <= from) {
-    next.setDate(next.getDate() + 1);
-  }
-
-  // Handle day-of-week constraint
-  if (dowPart && dowPart !== "*") {
-    const targetDays = dowPart.split(",").map((d) => parseInt(d, 10));
-    let safety = 0;
-    while (!targetDays.includes(next.getDay()) && safety < 8) {
-      next.setDate(next.getDate() + 1);
-      safety++;
-    }
-  }
-
-  return next;
-}
+// computeNextCronRun + isOneShotCron now live in @/lib/operate/cron-next-run
+// (BI-D72CC945): the previous inline parser dropped the day-of-month and month
+// fields, so the Calendar "Monthly"/"Once" presets fired daily. The extracted
+// module honors all five cron fields and is unit-tested outside this
+// "use server" file.
 
 function getRequiredProceduralToolForScheduledTask(taskId: string): {
   name: string;
@@ -436,8 +406,10 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       });
     }
 
-    // Update task status and schedule next run
-    const nextRunAt = computeNextCronRun(task.schedule, now);
+    // Update task status and schedule next run. A one-shot ("Once") task
+    // deactivates after firing instead of re-arming a year later (BI-D72CC945).
+    const oneShot = isOneShotCron(task.schedule);
+    const nextRunAt = oneShot ? null : computeNextCronRun(task.schedule, now);
     await prisma.scheduledAgentTask.update({
       where: { taskId },
       data: {
@@ -447,6 +419,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         lastThreadId: thread.id,
         taskRunId: taskRunRef.taskRunId,
         nextRunAt,
+        ...(oneShot ? { isActive: false } : {}),
       },
     });
 

--- a/apps/web/lib/operate/cron-next-run.test.ts
+++ b/apps/web/lib/operate/cron-next-run.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { computeNextCronRun, isOneShotCron } from "./cron-next-run";
+
+// `from` dates are built with the local Date constructor and assertions read
+// local getters; computeNextCronRun uses the same host Date methods, so these
+// tests are timezone-independent. Date month arg is 0-based (5 === June).
+
+describe("computeNextCronRun — day-of-month (the BI-D72CC945 regression)", () => {
+  it("Monthly `0 9 1 * *` from mid-month lands on the 1st of NEXT month, not tomorrow", () => {
+    const from = new Date(2026, 5, 20, 10, 0, 0); // Sat Jun 20 2026, 10:00
+    const next = computeNextCronRun("0 9 1 * *", from);
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(6); // July
+    expect(next.getDate()).toBe(1);
+    expect(next.getHours()).toBe(9);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.getSeconds()).toBe(0);
+    // The pre-fix bug returned Jun 21 (tomorrow) — guard against regressing.
+    expect(next.getMonth() === 5 && next.getDate() === 21).toBe(false);
+  });
+
+  it("Monthly fires the same day when the 1st's time is still ahead", () => {
+    const from = new Date(2026, 5, 1, 8, 0, 0); // Jun 1, 08:00 (before 09:00)
+    const next = computeNextCronRun("0 9 1 * *", from);
+    expect(next.getMonth()).toBe(5); // June
+    expect(next.getDate()).toBe(1);
+    expect(next.getHours()).toBe(9);
+  });
+
+  it("Monthly rolls to next month once the 1st's time has passed", () => {
+    const from = new Date(2026, 5, 1, 10, 0, 0); // Jun 1, 10:00 (after 09:00)
+    const next = computeNextCronRun("0 9 1 * *", from);
+    expect(next.getMonth()).toBe(6); // July
+    expect(next.getDate()).toBe(1);
+  });
+
+  it("honors year rollover (Dec -> Jan)", () => {
+    const from = new Date(2026, 11, 15, 12, 0, 0); // Dec 15 2026
+    const next = computeNextCronRun("0 9 1 * *", from);
+    expect(next.getFullYear()).toBe(2027);
+    expect(next.getMonth()).toBe(0); // January
+    expect(next.getDate()).toBe(1);
+  });
+});
+
+describe("computeNextCronRun — daily / weekly / weekday", () => {
+  it("daily `0 9 * * *` advances to tomorrow once today's time passed", () => {
+    const from = new Date(2026, 5, 20, 10, 0, 0);
+    const next = computeNextCronRun("0 9 * * *", from);
+    expect(next.getDate()).toBe(21);
+    expect(next.getHours()).toBe(9);
+  });
+
+  it("daily fires today when the time is still ahead", () => {
+    const from = new Date(2026, 5, 20, 8, 0, 0);
+    const next = computeNextCronRun("0 9 * * *", from);
+    expect(next.getDate()).toBe(20);
+    expect(next.getHours()).toBe(9);
+  });
+
+  it("weekly `0 9 * * 0` lands on a Sunday in the future", () => {
+    const from = new Date(2026, 5, 20, 10, 0, 0);
+    const next = computeNextCronRun("0 9 * * 0", from);
+    expect(next.getDay()).toBe(0); // Sunday
+    expect(next.getHours()).toBe(9);
+    expect(next.getTime()).toBeGreaterThan(from.getTime());
+  });
+
+  it("weekdays `30 8 * * 1-5` lands on a Mon–Fri at 08:30", () => {
+    const from = new Date(2026, 5, 20, 10, 0, 0); // Saturday
+    const next = computeNextCronRun("30 8 * * 1-5", from);
+    expect(next.getDay()).toBeGreaterThanOrEqual(1);
+    expect(next.getDay()).toBeLessThanOrEqual(5);
+    expect(next.getHours()).toBe(8);
+    expect(next.getMinutes()).toBe(30);
+    expect(next.getTime()).toBeGreaterThan(from.getTime());
+  });
+
+  it("treats day-of-week 7 as Sunday", () => {
+    const from = new Date(2026, 5, 20, 10, 0, 0);
+    const next = computeNextCronRun("0 9 * * 7", from);
+    expect(next.getDay()).toBe(0);
+  });
+});
+
+describe("computeNextCronRun — specific month (Once preset) & union rule", () => {
+  it("`0 9 5 7 *` (Jul 5) lands on the next July 5", () => {
+    const from = new Date(2026, 5, 20, 10, 0, 0); // before Jul 5
+    const next = computeNextCronRun("0 9 5 7 *", from);
+    expect(next.getMonth()).toBe(6); // July
+    expect(next.getDate()).toBe(5);
+    expect(next.getFullYear()).toBe(2026);
+  });
+
+  it("`0 9 5 7 *` rolls to next year once the date has passed", () => {
+    const from = new Date(2026, 7, 1, 10, 0, 0); // Aug 1, after Jul 5
+    const next = computeNextCronRun("0 9 5 7 *", from);
+    expect(next.getFullYear()).toBe(2027);
+    expect(next.getMonth()).toBe(6);
+    expect(next.getDate()).toBe(5);
+  });
+
+  it("applies the cron union rule when BOTH day-of-month and day-of-week are set", () => {
+    const from = new Date(2026, 5, 1, 0, 0, 0);
+    const next = computeNextCronRun("0 9 13 * 5", from); // 13th OR Friday
+    expect(next.getDate() === 13 || next.getDay() === 5).toBe(true);
+  });
+});
+
+describe("computeNextCronRun — malformed input", () => {
+  it("falls back to ~24h ahead for a non-5-field expression", () => {
+    const from = new Date(2026, 5, 20, 10, 0, 0);
+    const next = computeNextCronRun("not a cron", from);
+    const deltaH = (next.getTime() - from.getTime()) / 3_600_000;
+    expect(deltaH).toBeCloseTo(24, 5);
+  });
+});
+
+describe("isOneShotCron", () => {
+  it("is true only when month AND day-of-month are pinned and dow is *", () => {
+    expect(isOneShotCron("0 9 5 7 *")).toBe(true); // Once (Jul 5)
+  });
+
+  it("is false for recurring presets", () => {
+    expect(isOneShotCron("0 9 1 * *")).toBe(false); // Monthly
+    expect(isOneShotCron("0 9 * * 1")).toBe(false); // Weekly
+    expect(isOneShotCron("30 8 * * 1-5")).toBe(false); // Weekdays
+    expect(isOneShotCron("0 9 * * *")).toBe(false); // Daily
+  });
+
+  it("is false for malformed input", () => {
+    expect(isOneShotCron("nope")).toBe(false);
+  });
+});

--- a/apps/web/lib/operate/cron-next-run.ts
+++ b/apps/web/lib/operate/cron-next-run.ts
@@ -1,0 +1,106 @@
+// Cron next-run computation for scheduled agent tasks (BI-D72CC945).
+//
+// The previous hand-rolled parser in agent-task-scheduler.ts destructured
+// `[minute, hour, , , dayOfWeek]` and silently discarded the day-of-month and
+// month fields, so the Calendar "Monthly (1st)" preset (`0 9 1 * *`) actually
+// fired DAILY and "Once" (`m h D M *`) fired daily and never stopped. This
+// module honors all five standard cron fields.
+//
+// Scope: supports the field shapes the scheduler actually emits and stores —
+// concrete minute/hour, and `*` / single value / comma-list / `a-b` range for
+// day-of-month, month, and day-of-week. Minute/hour are treated as concrete
+// (a `*` minute/hour defaults to 0); sub-hourly crons are out of scope here and
+// belong to the named-interval helper (computeNextRunAt). Times use the host
+// Date methods, consistent with the rest of the scheduler (server runs UTC).
+
+/** Parse one cron field into the set of matching integers, or null for `*`. */
+function parseCronField(
+  field: string,
+  min: number,
+  max: number,
+  normalize?: (n: number) => number,
+): number[] | null {
+  if (field === "*") return null;
+  const out = new Set<number>();
+  for (const token of field.split(",")) {
+    const range = token.match(/^(\d+)-(\d+)$/);
+    if (range) {
+      const lo = parseInt(range[1]!, 10);
+      const hi = parseInt(range[2]!, 10);
+      for (let n = lo; n <= hi; n++) add(n);
+    } else if (/^\d+$/.test(token)) {
+      add(parseInt(token, 10));
+    }
+    // Unsupported step/`*` tokens inside a list are ignored — the scheduler
+    // never emits them; a bad token simply contributes no matches.
+  }
+  return out.size ? [...out] : null;
+
+  function add(n: number) {
+    const v = normalize ? normalize(n) : n;
+    if (v >= min && v <= max) out.add(v);
+  }
+}
+
+/**
+ * Compute the next run time strictly after `from` for a 5-field cron
+ * expression (`minute hour day-of-month month day-of-week`).
+ *
+ * Honors all five fields. Follows standard cron semantics for the
+ * day-of-month / day-of-week interaction: when BOTH are restricted the match is
+ * their union (OR); when one is `*` the other governs.
+ *
+ * Falls back to `from + 24h` for a malformed (non-5-field) expression, matching
+ * the previous behavior so a bad value never wedges the dispatcher.
+ */
+export function computeNextCronRun(cronExpr: string, from: Date): Date {
+  const parts = cronExpr.trim().split(/\s+/);
+  if (parts.length !== 5) return new Date(from.getTime() + 24 * 60 * 60_000);
+
+  const [minP, hourP, domP, monP, dowP] = parts as [string, string, string, string, string];
+  const minute = minP === "*" ? 0 : parseInt(minP, 10);
+  const hour = hourP === "*" ? 0 : parseInt(hourP, 10);
+  if (Number.isNaN(minute) || Number.isNaN(hour)) {
+    return new Date(from.getTime() + 24 * 60 * 60_000);
+  }
+
+  const domSet = parseCronField(domP, 1, 31);
+  const monSet = parseCronField(monP, 1, 12);
+  // Day-of-week: accept 0-7 with 7 normalized to 0 (Sunday), as standard cron does.
+  const dowSet = parseCronField(dowP, 0, 6, (n) => (n === 7 ? 0 : n));
+
+  const cand = new Date(from);
+  cand.setHours(hour, minute, 0, 0);
+
+  // Day-granular search. 1500 days covers multi-year day-of-month/month combos
+  // (e.g. Feb 29) without an unbounded loop.
+  for (let i = 0; i < 1500; i++) {
+    if (cand > from) {
+      const monthOk = !monSet || monSet.includes(cand.getMonth() + 1);
+      const domMatch = !domSet || domSet.includes(cand.getDate());
+      const dowMatch = !dowSet || dowSet.includes(cand.getDay());
+      // Both restricted -> union; otherwise the `*` side is already `true`.
+      const dayOk = domSet && dowSet ? domMatch || dowMatch : domMatch && dowMatch;
+      if (monthOk && dayOk) return cand;
+    }
+    cand.setDate(cand.getDate() + 1);
+    cand.setHours(hour, minute, 0, 0);
+  }
+
+  // Unreachable for valid crons; keep the dispatcher live rather than throw.
+  return new Date(from.getTime() + 24 * 60 * 60_000);
+}
+
+/**
+ * True when a cron expression denotes a single calendar occurrence rather than
+ * a recurring cadence — i.e. both month and day-of-month are pinned (and
+ * day-of-week is unconstrained). This is exactly the Calendar "Once" preset
+ * (`m h D M *`); no recurring preset pins the month. Callers use this to
+ * deactivate the task after it fires instead of re-arming it a year later.
+ */
+export function isOneShotCron(cronExpr: string): boolean {
+  const parts = cronExpr.trim().split(/\s+/);
+  if (parts.length !== 5) return false;
+  const [, , domP, monP, dowP] = parts as [string, string, string, string, string];
+  return monP !== "*" && domP !== "*" && dowP === "*";
+}


### PR DESCRIPTION
## Problem

The native scheduled-agent-task surface (workspace Calendar → "Schedule AI coworker") builds a cron per preset, but `computeNextCronRun` in `agent-task-scheduler.ts` destructured `[minute, hour, , , dayOfWeek]` — **silently dropping day-of-month and month**:
- **"Monthly (1st)"** (`0 9 1 * *`) fired **daily** at 09:00 (the `1` ignored).
- **"Once"** (`m h D M *`) fired **daily** and never disabled.

Surfaced by dogfooding: a task scheduled `0 9 1 * *` armed `nextRunAt` to *today* 09:00 instead of the 1st (`ScheduledAgentTask agent-task-fe778ee7`).

## Fix

- Extract the logic into a pure, unit-tested module `apps/web/lib/operate/cron-next-run.ts` that honors **all five cron fields** (with the standard day-of-month / day-of-week union rule). The `"use server"` host file can't export a sync helper for tests, so the extraction is what makes it testable.
- Add `isOneShotCron`; `executeScheduledAgentTask` now **deactivates a "Once" task after it fires** instead of re-arming it a year later. Recurring tasks re-arm with a correct next-run date and stay active.

## Tests

`cron-next-run.test.ts` — monthly→1st-of-next-month regression, Dec→Jan roll, daily, weekly, weekday range, `dow=7`, specific-month "Once" (+ next-year roll), union rule, malformed fallback; executor tests for one-shot deactivation vs recurring re-arm. Algorithm validated locally with Node; **CI Unit Tests + typecheck are the gate** (Docker-based host has no `node_modules`).

## Scope

Bug fix for **BI-D72CC945** (EP-PROACTIVE-OPS). No schema/UI change. Spec/Plan/Doc gate satisfied via `Process-Spine-Decision:` attestation (bugfix correcting existing behavior; no doc documents cron internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)