### PR TITLE
feat(build): surface real cross-surface evidence on the Build Studio timeline (BI-C25374E4)

### DIFF
--- a/apps/web/components/build/UnifiedEvidenceTimeline.tsx
+++ b/apps/web/components/build/UnifiedEvidenceTimeline.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-export type UnifiedEvidenceTimelineEvent = {
-  id: string;
-  source: "build-studio" | "codex" | "local-integration" | "review" | "external";
-  label: string;
-  summary: string;
-  status?: "passed" | "pending" | "failed" | "recorded";
-  timestamp?: string | Date | null;
-};
+import type { UnifiedEvidenceTimelineEvent } from "@/lib/build/evidence-timeline-types";
+
+// Canonical type now lives in lib so server-side projection can produce events
+// (EP-UNIFIED-TRACKING Phase 1). Re-exported here for existing importers.
+export type { UnifiedEvidenceTimelineEvent };
 
 const SOURCE_LABELS: Record<UnifiedEvidenceTimelineEvent["source"], string> = {
   "build-studio": "Build Studio",

--- a/apps/web/components/build/WorkflowStageInspector.test.tsx
+++ b/apps/web/components/build/WorkflowStageInspector.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { normalizeHappyPathState, type FeatureBuildRow } from "@/lib/feature-build-types";
+import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 import { WorkflowStageInspector } from "./WorkflowStageInspector";
 
 afterEach(cleanup);
@@ -40,6 +41,37 @@ describe("WorkflowStageInspector", () => {
     expect(screen.queryByText(/localhost:53601/i)).toBeNull();
     expect(screen.queryByText(/ExternalEvidenceRecord/i)).toBeNull();
     expect(screen.queryByText(/ToolExecutionReceipt/i)).toBeNull();
+  });
+
+  it("renders real cross-surface evidence threaded through progressVisibility", () => {
+    const progressVisibility = {
+      evidenceTimeline: [
+        { id: "external-1", source: "external", label: "Grok", summary: "Implemented the parser", status: "recorded" },
+        {
+          id: "runtime-1",
+          source: "review",
+          label: "Runtime verification",
+          summary: "Verified on the live install.",
+          status: "passed",
+        },
+      ],
+    } as unknown as BuildProgressVisibility;
+
+    render(
+      <WorkflowStageInspector
+        build={makeBuild()}
+        phase="review"
+        status="running"
+        workflowLabel={null}
+        governedBacklogEnabled
+        progressVisibility={progressVisibility}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Grok")).toBeInTheDocument();
+    expect(screen.getByText("Implemented the parser")).toBeInTheDocument();
+    expect(screen.getByText("Runtime verification")).toBeInTheDocument();
   });
 });
 

--- a/apps/web/components/build/WorkflowStageInspector.tsx
+++ b/apps/web/components/build/WorkflowStageInspector.tsx
@@ -125,17 +125,24 @@ function getLocalIntegrationStatus(build: FeatureBuildRow): EnvironmentStatusSum
   return { status: "failed", summary: "Merged-code verification needs attention before release." };
 }
 
-function getEvidenceEvents(phase: BuildPhase, build: FeatureBuildRow): UnifiedEvidenceTimelineEvent[] {
+function getEvidenceEvents(
+  phase: BuildPhase,
+  build: FeatureBuildRow,
+  externalEvents: UnifiedEvidenceTimelineEvent[],
+): UnifiedEvidenceTimelineEvent[] {
   if (!isRuntimePhase(phase)) return [];
 
   const events: UnifiedEvidenceTimelineEvent[] = [];
   const taskCount = build.taskResults ? normalizeTaskResults(build.taskResults).tasks.length : 0;
 
   if (taskCount > 0) {
+    // The coding provider is the engine Build Studio ran inside ITS sandbox — not
+    // an external agent. Label it as Build Studio work; genuinely-external work
+    // arrives via `externalEvents` below (EP-UNIFIED-TRACKING Phase 1).
     events.push({
       id: "implementation-tasks",
-      source: sourceForCodingProvider(build.codingProvider),
-      label: labelForCodingProvider(build.codingProvider),
+      source: "build-studio",
+      label: buildStudioEngineLabel(build.codingProvider),
       summary: `${taskCount} implementation task${taskCount === 1 ? "" : "s"} recorded for review.`,
       status: "recorded",
     });
@@ -173,6 +180,10 @@ function getEvidenceEvents(phase: BuildPhase, build: FeatureBuildRow): UnifiedEv
     });
   }
 
+  // Real cross-surface evidence (external-agent records, runtime verification,
+  // capsule evidence) projected server-side and threaded through progressVisibility.
+  events.push(...externalEvents);
+
   return events;
 }
 
@@ -188,17 +199,14 @@ function getVerificationSummary(verification: NonNullable<FeatureBuildRow["verif
   return `${verification.testsFailed} test warning${verification.testsFailed === 1 ? "" : "s"} need review.`;
 }
 
-function sourceForCodingProvider(provider: string | null): UnifiedEvidenceTimelineEvent["source"] {
-  return provider?.toLowerCase().includes("codex") ? "codex" : "external";
-}
-
-function labelForCodingProvider(provider: string | null): string {
-  if (!provider) return "Implementation";
-  return provider
+function buildStudioEngineLabel(provider: string | null): string {
+  if (!provider) return "Build Studio";
+  const engine = provider
     .split(/[-_\s]+/)
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
     .join(" ");
+  return `Build Studio (${engine})`;
 }
 
 export function WorkflowStageInspector({
@@ -215,7 +223,7 @@ export function WorkflowStageInspector({
   const stageLabel = PHASE_LABELS[phase] ?? phase;
   const artifacts = getArtifactLines(phase, build);
   const environmentReadiness = getEnvironmentReadiness(phase, build);
-  const evidenceEvents = getEvidenceEvents(phase, build);
+  const evidenceEvents = getEvidenceEvents(phase, build, progressVisibility?.evidenceTimeline ?? []);
   const stageGuidance = deriveWorkflowStageGuidance({
     build,
     phase,

--- a/apps/web/lib/build/evidence-timeline-types.ts
+++ b/apps/web/lib/build/evidence-timeline-types.ts
@@ -1,0 +1,17 @@
+// Canonical shape for a single event on the Build Studio unified evidence
+// timeline. Lives in lib (not the client component) so server-side projection
+// code can produce these without importing a "use client" module. The
+// UnifiedEvidenceTimeline component re-exports this type for back-compat.
+//
+// EP-UNIFIED-TRACKING Phase 1 (BI-C25374E4): the timeline must render real
+// cross-surface evidence (external-agent records, runtime verification, capsule
+// evidence), not just FeatureBuild columns.
+
+export type UnifiedEvidenceTimelineEvent = {
+  id: string;
+  source: "build-studio" | "codex" | "local-integration" | "review" | "external";
+  label: string;
+  summary: string;
+  status?: "passed" | "pending" | "failed" | "recorded";
+  timestamp?: string | Date | null;
+};

--- a/apps/web/lib/build/evidence-timeline.test.ts
+++ b/apps/web/lib/build/evidence-timeline.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadBuildEvidenceTimelineEvents,
+  mapBuildEvidenceTimelineEvents,
+  type EvidenceTimelineDb,
+} from "./evidence-timeline";
+
+describe("mapBuildEvidenceTimelineEvents", () => {
+  it("maps external-agent records to an external lane with a title-cased provider label", () => {
+    const events = mapBuildEvidenceTimelineEvents({
+      externalRecords: [
+        {
+          id: "ext-1",
+          provider: "grok",
+          resultSummary: "Implemented the parser",
+          createdAt: new Date("2026-06-19T10:00:00.000Z"),
+        },
+        {
+          id: "ext-2",
+          provider: "claude-code",
+          resultSummary: "Wrote the tests",
+          createdAt: new Date("2026-06-19T09:00:00.000Z"),
+        },
+      ],
+      runtimeVerifications: [],
+      capsuleEvidence: [],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ id: "external-ext-1", source: "external", label: "Grok", status: "recorded" });
+    expect(events[1]).toMatchObject({ source: "external", label: "Claude Code" });
+  });
+
+  it("maps runtime verification with status normalization into the review lane", () => {
+    const [event] = mapBuildEvidenceTimelineEvents({
+      externalRecords: [],
+      runtimeVerifications: [
+        {
+          verificationId: "RV-1",
+          kind: "ux",
+          status: "VERIFIED",
+          completedAt: new Date("2026-06-19T11:00:00.000Z"),
+          result: { summary: "Happy path verified on the live install." },
+        },
+      ],
+      capsuleEvidence: [],
+    });
+
+    expect(event).toMatchObject({
+      id: "runtime-RV-1",
+      source: "review",
+      label: "Runtime verification",
+      status: "passed",
+      summary: "Happy path verified on the live install.",
+    });
+  });
+
+  it("falls back to a kind/status summary when runtime result has no summary, and maps failure", () => {
+    const [event] = mapBuildEvidenceTimelineEvents({
+      externalRecords: [],
+      runtimeVerifications: [
+        { verificationId: "RV-2", kind: "smoke", status: "failed", completedAt: null, result: {} },
+      ],
+      capsuleEvidence: [],
+    });
+
+    expect(event.status).toBe("failed");
+    expect(event.summary).toBe("Runtime smoke failed.");
+  });
+
+  it("maps capsule evidence to the external lane", () => {
+    const [event] = mapBuildEvidenceTimelineEvents({
+      externalRecords: [],
+      runtimeVerifications: [],
+      capsuleEvidence: [
+        { id: "act-1", summary: "Recorded build evidence from Codex", recordedAt: new Date("2026-06-19T08:00:00.000Z") },
+      ],
+    });
+
+    expect(event).toMatchObject({ id: "capsule-act-1", source: "external", label: "Capsule evidence" });
+  });
+
+  it("merges all three sources newest-first across source types", () => {
+    const events = mapBuildEvidenceTimelineEvents({
+      externalRecords: [
+        { id: "e", provider: "grok", resultSummary: "oldest", createdAt: new Date("2026-06-19T01:00:00.000Z") },
+      ],
+      runtimeVerifications: [
+        { verificationId: "RV", kind: "ux", status: "passed", completedAt: new Date("2026-06-19T03:00:00.000Z"), result: {} },
+      ],
+      capsuleEvidence: [
+        { id: "c", summary: "middle", recordedAt: new Date("2026-06-19T02:00:00.000Z") },
+      ],
+    });
+
+    expect(events.map((e) => e.id)).toEqual(["runtime-RV", "capsule-c", "external-e"]);
+  });
+
+  it("returns an empty list when there is no cross-surface evidence", () => {
+    expect(
+      mapBuildEvidenceTimelineEvents({ externalRecords: [], runtimeVerifications: [], capsuleEvidence: [] }),
+    ).toEqual([]);
+  });
+});
+
+describe("loadBuildEvidenceTimelineEvents", () => {
+  it("queries external evidence by FB- buildId and runtime/capsule by the cuid", async () => {
+    const externalFindMany = vi.fn(async () => [
+      { id: "x", provider: "codex", resultSummary: "did work", createdAt: new Date("2026-06-19T05:00:00.000Z") },
+    ]);
+    const runtimeFindMany = vi.fn(async () => [] as unknown[]);
+    const capsuleFindFirst = vi.fn(async () => ({ id: "capsule-cuid" }));
+    const capsuleActivityFindMany = vi.fn(async () => [
+      { id: "a", summary: "capsule note", recordedAt: new Date("2026-06-19T04:00:00.000Z") },
+    ]);
+
+    const db = {
+      externalEvidenceRecord: { findMany: externalFindMany },
+      runtimeVerification: { findMany: runtimeFindMany },
+      workCapsule: { findFirst: capsuleFindFirst },
+      workCapsuleActivity: { findMany: capsuleActivityFindMany },
+    } as unknown as EvidenceTimelineDb;
+
+    const events = await loadBuildEvidenceTimelineEvents({
+      db,
+      build: { id: "fb-cuid", buildId: "FB-123" },
+    });
+
+    expect(externalFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { buildId: "FB-123" } }),
+    );
+    expect(runtimeFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { featureBuildId: "fb-cuid" } }),
+    );
+    expect(capsuleFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { featureBuildId: "fb-cuid" } }),
+    );
+    expect(capsuleActivityFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { workCapsuleId: "capsule-cuid", kind: "evidence-recorded" } }),
+    );
+    expect(events.map((event) => event.id)).toEqual(["external-x", "capsule-a"]);
+  });
+
+  it("skips the capsule-activity query when the build has no linked capsule", async () => {
+    const capsuleActivityFindMany = vi.fn(async () => [] as unknown[]);
+
+    const db = {
+      externalEvidenceRecord: { findMany: vi.fn(async () => [] as unknown[]) },
+      runtimeVerification: { findMany: vi.fn(async () => [] as unknown[]) },
+      workCapsule: { findFirst: vi.fn(async () => null) },
+      workCapsuleActivity: { findMany: capsuleActivityFindMany },
+    } as unknown as EvidenceTimelineDb;
+
+    const events = await loadBuildEvidenceTimelineEvents({
+      db,
+      build: { id: "fb-cuid", buildId: "FB-999" },
+    });
+
+    expect(capsuleActivityFindMany).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+});

--- a/apps/web/lib/build/evidence-timeline.ts
+++ b/apps/web/lib/build/evidence-timeline.ts
@@ -1,0 +1,183 @@
+// Server-side projection of cross-surface development evidence onto the Build
+// Studio unified evidence timeline.
+//
+// EP-UNIFIED-TRACKING Phase 1 (BI-C25374E4). Until now the "external"/"codex"
+// lane on the timeline was FAKED from FeatureBuild.codingProvider (the in-sandbox
+// engine Build Studio itself ran) — genuinely external-agent work was invisible.
+// This module reads the real records keyed to the build and merges them:
+//   - ExternalEvidenceRecord  (record_external_development_evidence) — keyed by FB- buildId
+//   - RuntimeVerification     (record_runtime_verification)         — keyed by FeatureBuild.id (cuid)
+//   - WorkCapsuleActivity     (record_capsule_evidence)             — via the build's linked capsule
+//
+// Read-only: no write-model change. Phase 2 (BI-6357B975) populates the
+// ExternalEvidenceRecord -> capsule/build links that this projection reads.
+//
+// Spec: docs/superpowers/specs/2026-06-19-unified-build-studio-tracking-all-surfaces-design.md §6.1
+
+import type { UnifiedEvidenceTimelineEvent } from "./evidence-timeline-types";
+
+export type ExternalEvidenceRow = {
+  id: string;
+  provider: string;
+  resultSummary: string;
+  createdAt: Date;
+};
+
+export type RuntimeVerificationRow = {
+  verificationId: string;
+  kind: string;
+  status: string;
+  completedAt: Date | null;
+  result: unknown;
+};
+
+export type CapsuleEvidenceActivityRow = {
+  id: string;
+  summary: string;
+  recordedAt: Date;
+};
+
+export type BuildEvidenceSources = {
+  externalRecords: ExternalEvidenceRow[];
+  runtimeVerifications: RuntimeVerificationRow[];
+  capsuleEvidence: CapsuleEvidenceActivityRow[];
+};
+
+/** Title-case a provider slug ("grok" -> "Grok", "claude-code" -> "Claude Code"). */
+function providerLabel(provider: string): string {
+  const trimmed = provider.trim();
+  if (!trimmed) return "External agent";
+  return trimmed
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function runtimeStatusToEventStatus(status: string): UnifiedEvidenceTimelineEvent["status"] {
+  const normalized = status.trim().toLowerCase();
+  if (["passed", "verified", "success", "succeeded", "ok"].includes(normalized)) return "passed";
+  if (["failed", "fail", "error", "errored"].includes(normalized)) return "failed";
+  if (["pending", "running", "in-progress", "in_progress", "started"].includes(normalized)) return "pending";
+  return "recorded";
+}
+
+function runtimeResultSummary(result: unknown): string | null {
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    const summary = (result as Record<string, unknown>).summary;
+    if (typeof summary === "string" && summary.trim()) return summary.trim();
+  }
+  return null;
+}
+
+function msOf(value: Date | null | undefined): number {
+  return value ? value.getTime() : 0;
+}
+
+/**
+ * Pure projection: map fetched cross-surface evidence rows to timeline events,
+ * newest first. Deterministic and side-effect-free — the unit-tested core.
+ */
+export function mapBuildEvidenceTimelineEvents(
+  sources: BuildEvidenceSources,
+): UnifiedEvidenceTimelineEvent[] {
+  const ranked: Array<{ event: UnifiedEvidenceTimelineEvent; ts: number }> = [];
+
+  for (const record of sources.externalRecords) {
+    ranked.push({
+      ts: msOf(record.createdAt),
+      event: {
+        id: `external-${record.id}`,
+        source: "external",
+        label: providerLabel(record.provider),
+        summary: record.resultSummary,
+        status: "recorded",
+        timestamp: record.createdAt,
+      },
+    });
+  }
+
+  for (const verification of sources.runtimeVerifications) {
+    ranked.push({
+      ts: msOf(verification.completedAt),
+      event: {
+        id: `runtime-${verification.verificationId}`,
+        source: "review",
+        label: "Runtime verification",
+        summary:
+          runtimeResultSummary(verification.result)
+          ?? `Runtime ${verification.kind} ${verification.status}.`,
+        status: runtimeStatusToEventStatus(verification.status),
+        timestamp: verification.completedAt,
+      },
+    });
+  }
+
+  for (const activity of sources.capsuleEvidence) {
+    ranked.push({
+      ts: msOf(activity.recordedAt),
+      event: {
+        id: `capsule-${activity.id}`,
+        source: "external",
+        label: "Capsule evidence",
+        summary: activity.summary,
+        status: "recorded",
+        timestamp: activity.recordedAt,
+      },
+    });
+  }
+
+  return ranked.sort((a, b) => b.ts - a.ts).map((entry) => entry.event);
+}
+
+/** Structural DB surface — the real prisma client satisfies it (cf. CapsuleDb). */
+export type EvidenceTimelineDb = {
+  externalEvidenceRecord: { findMany(args: unknown): Promise<unknown[]> };
+  runtimeVerification: { findMany(args: unknown): Promise<unknown[]> };
+  workCapsule: { findFirst(args: unknown): Promise<unknown> };
+  workCapsuleActivity: { findMany(args: unknown): Promise<unknown[]> };
+};
+
+/**
+ * Fetch the three cross-surface evidence sources for a build and project them.
+ * `build.buildId` is the FB- id (ExternalEvidenceRecord.buildId); `build.id` is
+ * the cuid (RuntimeVerification.featureBuildId / WorkCapsule.featureBuildId).
+ */
+export async function loadBuildEvidenceTimelineEvents(args: {
+  db: EvidenceTimelineDb;
+  build: { id: string; buildId: string };
+  limitPerSource?: number;
+}): Promise<UnifiedEvidenceTimelineEvent[]> {
+  const take = args.limitPerSource ?? 25;
+
+  const [externalRecords, runtimeVerifications] = await Promise.all([
+    args.db.externalEvidenceRecord.findMany({
+      where: { buildId: args.build.buildId },
+      orderBy: { createdAt: "desc" },
+      take,
+      select: { id: true, provider: true, resultSummary: true, createdAt: true },
+    }) as Promise<ExternalEvidenceRow[]>,
+    args.db.runtimeVerification.findMany({
+      where: { featureBuildId: args.build.id },
+      orderBy: { completedAt: "desc" },
+      take,
+      select: { verificationId: true, kind: true, status: true, completedAt: true, result: true },
+    }) as Promise<RuntimeVerificationRow[]>,
+  ]);
+
+  const capsule = (await args.db.workCapsule.findFirst({
+    where: { featureBuildId: args.build.id },
+    select: { id: true },
+  })) as { id: string } | null;
+
+  const capsuleEvidence = capsule
+    ? ((await args.db.workCapsuleActivity.findMany({
+      where: { workCapsuleId: capsule.id, kind: "evidence-recorded" },
+      orderBy: { recordedAt: "desc" },
+      take,
+      select: { id: true, summary: true, recordedAt: true },
+    })) as CapsuleEvidenceActivityRow[])
+    : [];
+
+  return mapBuildEvidenceTimelineEvents({ externalRecords, runtimeVerifications, capsuleEvidence });
+}

--- a/apps/web/lib/build/progress-visibility.ts
+++ b/apps/web/lib/build/progress-visibility.ts
@@ -9,6 +9,8 @@ import { getDispatchHistoryForBuild } from "./dispatch-attempts";
 import { getSandboxStateForBuild, type BuildSandboxState } from "./sandbox-state";
 import { getScopedVerificationForBuild, type ScopedVerificationView } from "./scoped-verification";
 import { normalizeTaskResults, type NormalizedTaskResults } from "./task-results";
+import { loadBuildEvidenceTimelineEvents } from "./evidence-timeline";
+import type { UnifiedEvidenceTimelineEvent } from "./evidence-timeline-types";
 
 export type ChatProgressSnapshot = {
   completed: number | null;
@@ -58,6 +60,8 @@ export type BuildProgressVisibility = {
   };
   /** Phase-level cost rollup; empty array when BuildPhaseRun rows don't exist yet */
   phaseRuns: PhaseRunSummary[];
+  /** EP-UNIFIED-TRACKING Phase 1: cross-surface evidence (external-agent, runtime, capsule), newest first. */
+  evidenceTimeline: UnifiedEvidenceTimelineEvent[];
 };
 
 export function buildProgressProjectionFromParts(args: {
@@ -70,6 +74,7 @@ export function buildProgressProjectionFromParts(args: {
   verification: ScopedVerificationView | null;
   lastActivityAt: string | null;
   phaseRuns?: PhaseRunSummary[];
+  evidenceTimeline?: UnifiedEvidenceTimelineEvent[];
 }): BuildProgressVisibility {
   const now = args.now ?? new Date();
   const conflicts = getProgressConflicts(args.dbTasks.source, args.chatSnapshots);
@@ -119,6 +124,7 @@ export function buildProgressProjectionFromParts(args: {
       lastObservableSignalAt,
     },
     phaseRuns: args.phaseRuns ?? [],
+    evidenceTimeline: args.evidenceTimeline ?? [],
   };
 }
 
@@ -127,6 +133,7 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
   const build = await prisma.featureBuild.findUnique({
     where: { buildId },
     select: {
+      id: true,
       buildId: true,
       threadId: true,
       taskResults: true,
@@ -183,6 +190,11 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     inferenceCount: r.inferenceCount,
   }));
 
+  const evidenceTimeline = await loadBuildEvidenceTimelineEvents({
+    db: prisma,
+    build: { id: build.id, buildId: build.buildId },
+  });
+
   return buildProgressProjectionFromParts({
     buildId,
     dbTasks: normalizeTaskResults(build.taskResults),
@@ -192,6 +204,7 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     verification: await getScopedVerificationForBuild(buildId),
     lastActivityAt: build.activities[0]?.createdAt.toISOString() ?? build.updatedAt.toISOString(),
     phaseRuns,
+    evidenceTimeline,
   });
 }
 

--- a/apps/web/lib/build/progress-visibility.ts
+++ b/apps/web/lib/build/progress-visibility.ts
@@ -60,8 +60,12 @@ export type BuildProgressVisibility = {
   };
   /** Phase-level cost rollup; empty array when BuildPhaseRun rows don't exist yet */
   phaseRuns: PhaseRunSummary[];
-  /** EP-UNIFIED-TRACKING Phase 1: cross-surface evidence (external-agent, runtime, capsule), newest first. */
-  evidenceTimeline: UnifiedEvidenceTimelineEvent[];
+  /**
+   * EP-UNIFIED-TRACKING Phase 1: cross-surface evidence (external-agent, runtime,
+   * capsule), newest first. Optional so callers constructing a projection literal
+   * (e.g. tests) need not supply it; getBuildProgressVisibility always populates it.
+   */
+  evidenceTimeline?: UnifiedEvidenceTimelineEvent[];
 };
 
 export function buildProgressProjectionFromParts(args: {

--- a/docs/superpowers/plans/2026-06-19-unified-evidence-timeline-phase1.md
+++ b/docs/superpowers/plans/2026-06-19-unified-evidence-timeline-phase1.md
@@ -1,0 +1,44 @@
+# Plan — Unified Evidence Timeline (EP-UNIFIED-TRACKING Phase 1 / BI-C25374E4)
+
+- **Date:** 2026-06-19
+- **Epic:** EP-UNIFIED-TRACKING
+- **Item:** BI-C25374E4
+- **Design spec:** [`2026-06-19-unified-build-studio-tracking-all-surfaces-design.md`](../specs/2026-06-19-unified-build-studio-tracking-all-surfaces-design.md) §6.1 / §9.3
+
+## Goal
+
+Make **real cross-surface development evidence** visible on the Build Studio evidence timeline, replacing the lane that was **faked** from `FeatureBuild.codingProvider` (the engine Build Studio ran inside its own sandbox — not an external agent). Read-only: no write-model change (Phase 2 / BI-6357B975 populates the links this projection reads).
+
+## Approach (Option C as the read-only subset of the spec's Option A)
+
+Anchor a server-side projection on the build, merge the real records that are keyed to it, and thread the result to the existing `UnifiedEvidenceTimeline` component through the already-wired `progressVisibility` prop.
+
+Three real sources merged (newest first):
+- `ExternalEvidenceRecord` — keyed by the **FB- buildId** (`record_external_development_evidence`).
+- `RuntimeVerification` — keyed by **`FeatureBuild.id`** (cuid).
+- `WorkCapsuleActivity` (`kind="evidence-recorded"`) — via the build's linked `WorkCapsule` (`featureBuildId` = cuid; `record_capsule_evidence`).
+
+The two id spaces matter: external evidence uses the FB- id, runtime/capsule use the cuid.
+
+## File map
+
+| File | Change |
+| --- | --- |
+| `apps/web/lib/build/evidence-timeline-types.ts` | NEW — canonical `UnifiedEvidenceTimelineEvent` type, in lib so server code can produce events without importing a `"use client"` module. |
+| `apps/web/lib/build/evidence-timeline.ts` | NEW — pure `mapBuildEvidenceTimelineEvents` (the unit-tested core) + `loadBuildEvidenceTimelineEvents` (thin fetch over a structural `EvidenceTimelineDb`, satisfied by real prisma à la `CapsuleDb`). |
+| `apps/web/lib/build/evidence-timeline.test.ts` | NEW — unit tests for the mapper (mapping, status normalization, provider labels, newest-first merge) + loader (id-space routing, no-capsule path). |
+| `apps/web/lib/build/progress-visibility.ts` | EDIT — add `evidenceTimeline` to `BuildProgressVisibility`; select `id`; call the loader; thread through `buildProgressProjectionFromParts`. |
+| `apps/web/components/build/UnifiedEvidenceTimeline.tsx` | EDIT — re-export the type from its new lib home (back-compat for existing importers). |
+| `apps/web/components/build/WorkflowStageInspector.tsx` | EDIT — append `progressVisibility.evidenceTimeline` to the timeline; **de-fake** the implementation-tasks lane (label as Build Studio's engine, not "external"). |
+| `apps/web/components/build/WorkflowStageInspector.test.tsx` | EDIT — assert real external + runtime events render. |
+
+## Verification
+
+- **CI unit gate:** `evidence-timeline.test.ts` (projection logic) + the extended `WorkflowStageInspector.test.tsx` (jsdom render of the real events). This cycle the root toolchain is degraded (`.pnpm` empty → no local `vitest`/`tsc`), so the gate runs in CI; the pure mapper + structural-db loader are designed to be fully exercised there.
+- **Live UX verification — PENDING.** Driving `/build` on a live install to see real external-agent evidence render is deferred (no live-portal access + degraded toolchain this session). The logic is unit-tested at every layer; the final live render should be confirmed before marking BI-C25374E4 done.
+
+## Out of scope (follow-on)
+
+- `PhaseHandoff` + `BuildArtifactRevision` lanes (internal provenance; lower-value than the external-origin sources) — deferred within the BI.
+- The phase gate: evidence shows only in runtime phases (`build`/`review`/`ship`), matching existing behavior.
+- Populating `ExternalEvidenceRecord.workCapsuleId`/`buildId` at write time — that is Phase 2 (BI-6357B975); until then the external lane is sparse but correct.


### PR DESCRIPTION
## What

**EP-UNIFIED-TRACKING Phase 1** — make real external-agent work *visible* in the Build Studio evidence timeline.

Until now the timeline's "external"/"codex" lane was **faked** from `FeatureBuild.codingProvider` — the engine Build Studio ran inside *its own* sandbox — so genuinely external-agent work (Claude/Codex/Grok recording via MCP) was invisible. This adds a server-side projection that merges the **real** records keyed to the build and threads them through the existing `progressVisibility` prop into the existing `UnifiedEvidenceTimeline`:

| Source | Keyed by | Tool |
|--------|----------|------|
| `ExternalEvidenceRecord` | FB- buildId | `record_external_development_evidence` |
| `RuntimeVerification` | `FeatureBuild.id` (cuid) | `record_runtime_verification` |
| `WorkCapsuleActivity` (`evidence-recorded`) | linked capsule | `record_capsule_evidence` |

The implementation-tasks lane is **de-faked** — labelled as Build Studio's engine (e.g. "Build Studio (Codex)"), not "external".

Read-only — no write-model change. Phase 2 (BI-6357B975) populates the `ExternalEvidenceRecord` → capsule/build links this projection reads, so the lane is correct-but-sparse until then.

## Files

- `lib/build/evidence-timeline-types.ts` — canonical event type in lib (server-safe); `UnifiedEvidenceTimeline.tsx` re-exports it
- `lib/build/evidence-timeline.ts` — pure `mapBuildEvidenceTimelineEvents` (unit-tested core) + `loadBuildEvidenceTimelineEvents` (structural-`db` loader, à la `CapsuleDb`)
- `lib/build/progress-visibility.ts` — `evidenceTimeline` on `BuildProgressVisibility`, wired in `getBuildProgressVisibility`
- `components/build/WorkflowStageInspector.tsx` — consume + de-fake
- plan: `docs/superpowers/plans/2026-06-19-unified-evidence-timeline-phase1.md`

## Verification

- **CI unit gate:** `evidence-timeline.test.ts` (mapping, status normalization, provider labels, newest-first merge, id-space routing, no-capsule path) + extended `WorkflowStageInspector.test.tsx` (jsdom render of real external + runtime events).
- **Live UX verification — PENDING** (flagged in the plan). Driving `/build` on a live install is deferred: root `node_modules` is degraded this cycle (`.pnpm` empty → no local `vitest`/`tsc`) and no live-portal access this session. Logic is unit-tested at every layer; committed `DPF_SKIP_TYPECHECK=1` per the documented worktree harness path — CI is the typecheck gate.

Implements BI-C25374E4. Design: spec in #2142 §6.1/§9.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)