### PR TITLE
feat(ea-canvas): automatic graph layout, revision history & neighbor-aware placement (BI-D9F9B34F)

### DIFF
--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -7,8 +7,16 @@ import {
   type Node, type Edge, type Connection, type OnNodesChange, type ReactFlowInstance, type Viewport,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import type { SerializedViewElement, SerializedEdge, CanvasState } from "@/lib/ea-types";
+import type { SerializedViewElement, SerializedEdge, CanvasState, CanvasLayoutRevision } from "@/lib/ea-types";
 import { buildStructuredViewElements, filterStructuredEdges } from "@/lib/ea-structure";
+import {
+  computeEaLayout,
+  placeIncremental,
+  EA_LAYOUT_ALGORITHMS,
+  EA_LAYOUT_LABELS,
+  type EaLayoutAlgorithm,
+  type EaLayoutEdge,
+} from "@/lib/ea/canvas-layout";
 import { EaElementNode } from "./EaElementNode";
 import { EaRelationshipEdge } from "./EaRelationshipEdge";
 import { ElementPalette } from "./ElementPalette";
@@ -56,83 +64,122 @@ type Props = {
   isReadOnly: boolean;
 };
 
+const MAX_LAYOUT_REVISIONS = 10;
+
+function defaultLayoutAlgo(): EaLayoutAlgorithm {
+  if (typeof window === "undefined") return "layered";
+  const v = window.localStorage.getItem("ea-layout-algo");
+  return v && (EA_LAYOUT_ALGORITHMS as string[]).includes(v) ? (v as EaLayoutAlgorithm) : "layered";
+}
+
+function makeRevisionId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  return uuid ?? `rev-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+// Append a restore point, dropping the oldest beyond the cap (bounded ring buffer).
+function pushRevision(
+  history: CanvasLayoutRevision[],
+  label: string,
+  nodes: Record<string, { x: number; y: number }>,
+): CanvasLayoutRevision[] {
+  const next = [...history, { id: makeRevisionId(), at: Date.now(), label, nodes }];
+  return next.length > MAX_LAYOUT_REVISIONS ? next.slice(next.length - MAX_LAYOUT_REVISIONS) : next;
+}
+
+// Relationship edges remapped to top-level node ids (structured children collapse to their
+// parent) — used for crossing-minimizing layout and neighbor-aware incremental placement.
+function buildLayoutEdges(
+  visibleElements: SerializedViewElement[],
+  visibleEdges: SerializedEdge[],
+): EaLayoutEdge[] {
+  const parentOf = new Map<string, string | null>();
+  for (const el of visibleElements) parentOf.set(el.viewElementId, el.parentViewElementId);
+  const topAncestor = (id: string): string => {
+    let cur = id;
+    const seen = new Set<string>();
+    while (true) {
+      const parent = parentOf.get(cur);
+      if (!parent || seen.has(cur)) return cur;
+      seen.add(cur);
+      cur = parent;
+    }
+  };
+  const out: EaLayoutEdge[] = [];
+  for (const e of visibleEdges) {
+    const source = topAncestor(e.fromViewElementId);
+    const target = topAncestor(e.toViewElementId);
+    if (source && target && source !== target) out.push({ source, target });
+  }
+  return out;
+}
+
 function buildNodeLayout(
   elements: SerializedViewElement[],
   canvasState: CanvasState | null,
+  layoutEdges: EaLayoutEdge[],
 ): {
   nodes: Record<string, { x: number; y: number }>;
-  shouldPersist: boolean;
+  needsInitialAutoLayout: boolean;
+  backfilled: boolean;
 } {
   const savedNodes = canvasState?.nodes ?? {};
   const elementCount = elements.length;
 
   if (elementCount <= 1) {
     const single = elements[0];
-    if (!single) return { nodes: {}, shouldPersist: false };
+    if (!single) return { nodes: {}, needsInitialAutoLayout: false, backfilled: false };
     return {
       nodes: { [single.viewElementId]: savedNodes[single.viewElementId] ?? { x: 0, y: 0 } },
-      shouldPersist: false,
+      needsInitialAutoLayout: false,
+      backfilled: false,
     };
   }
 
-  const allSavedPresent = elements.every((ve) => Boolean(savedNodes[ve.viewElementId]));
-  const allSavedAtOrigin = allSavedPresent
-    ? elements.every((ve) => {
-        const pos = savedNodes[ve.viewElementId];
-        return pos != null && pos.x === 0 && pos.y === 0;
-      })
-    : false;
+  const savedCount = elements.filter((ve) => Boolean(savedNodes[ve.viewElementId])).length;
+  const allSavedAtOrigin =
+    savedCount === elementCount &&
+    elements.every((ve) => {
+      const pos = savedNodes[ve.viewElementId];
+      return pos != null && pos.x === 0 && pos.y === 0;
+    });
 
-  const shouldLayoutAll = !allSavedPresent || allSavedAtOrigin;
-
-  if (shouldLayoutAll) {
+  // Fresh / auto-generated view (nothing meaningful saved): lay out on a grid as a cheap,
+  // SSR-safe placeholder. The canvas upgrades it to a real crossing-minimizing layout on mount.
+  if (savedCount === 0 || allSavedAtOrigin) {
     const cols = Math.ceil(Math.sqrt(elementCount));
     const xStep = 240;
     const yStep = 150;
     const nodes: Record<string, { x: number; y: number }> = {};
-
     for (let i = 0; i < elementCount; i += 1) {
       const ve = elements[i];
       if (!ve) continue;
-      const col = i % cols;
-      const row = Math.floor(i / cols);
-      nodes[ve.viewElementId] = { x: col * xStep, y: row * yStep };
+      nodes[ve.viewElementId] = { x: (i % cols) * xStep, y: Math.floor(i / cols) * yStep };
     }
-
-    return { nodes, shouldPersist: true };
+    return { nodes, needsInitialAutoLayout: true, backfilled: false };
   }
 
-  // Keep existing saved coordinates, but backfill any missing node positions.
-  const used = new Set<string>();
+  // Existing layout with new elements added: keep every saved position untouched and nestle
+  // the new nodes next to their connected neighbors (minimal disruption), instead of re-gridding.
   const nodes = { ...savedNodes } as Record<string, { x: number; y: number }>;
-  for (const pos of Object.values(savedNodes)) {
-    used.add(`${pos.x},${pos.y}`);
+  const missingIds = elements
+    .filter((ve) => !nodes[ve.viewElementId])
+    .map((ve) => ve.viewElementId);
+  if (missingIds.length > 0) {
+    const placed = placeIncremental(nodes, layoutEdges, missingIds);
+    for (const [id, pos] of Object.entries(placed)) nodes[id] = pos;
   }
-
-  const cols = Math.ceil(Math.sqrt(elementCount));
-  const xStep = 240;
-  const yStep = 150;
-  let fillIndex = 0;
-
-  for (const ve of elements) {
-    if (nodes[ve.viewElementId]) continue;
-    while (true) {
-      const candidate = { x: (fillIndex % cols) * xStep, y: Math.floor(fillIndex / cols) * yStep };
-      const key = `${candidate.x},${candidate.y}`;
-      fillIndex += 1;
-      if (used.has(key)) continue;
-      nodes[ve.viewElementId] = candidate;
-      used.add(key);
-      break;
-    }
-  }
-
-  return { nodes, shouldPersist: false };
+  return { nodes, needsInitialAutoLayout: false, backfilled: missingIds.length > 0 };
 }
 
-function buildNodes(elements: SerializedViewElement[], canvasState: CanvasState | null): {
+function buildNodes(
+  elements: SerializedViewElement[],
+  canvasState: CanvasState | null,
+  layoutEdges: EaLayoutEdge[],
+): {
   nodes: Node[];
-  shouldPersist: boolean;
+  needsInitialAutoLayout: boolean;
+  backfilled: boolean;
 } {
   const structuredChildIds = new Set<string>();
   for (const element of elements) {
@@ -142,7 +189,7 @@ function buildNodes(elements: SerializedViewElement[], canvasState: CanvasState 
   }
 
   const topLevelElements = elements.filter((element) => !structuredChildIds.has(element.viewElementId));
-  const topLevelLayout = buildNodeLayout(topLevelElements, canvasState);
+  const topLevelLayout = buildNodeLayout(topLevelElements, canvasState, layoutEdges);
   const nodes: Node[] = [];
 
   for (const element of topLevelElements) {
@@ -194,7 +241,8 @@ function buildNodes(elements: SerializedViewElement[], canvasState: CanvasState 
   }
 
   return {
-    shouldPersist: topLevelLayout.shouldPersist,
+    needsInitialAutoLayout: topLevelLayout.needsInitialAutoLayout,
+    backfilled: topLevelLayout.backfilled,
     nodes,
   };
 }
@@ -319,10 +367,13 @@ export function EaCanvas({
   );
   const visibleEdges = initialEdges.filter((edge) => visibleEdgeIds.has(edge.id));
 
-  const initialNodeLayout = buildNodes(visibleElements, initialCanvasState);
+  const layoutEdges = buildLayoutEdges(visibleElements, visibleEdges);
+  const initialNodeLayout = buildNodes(visibleElements, initialCanvasState, layoutEdges);
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodeLayout.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(buildEdges(visibleEdges, handleDeleteEdge, edgeVariant));
   const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(null);
+  const [isLayouting, setIsLayouting] = useState(false);
+  const [revMenuOpen, setRevMenuOpen] = useState(false);
   const [pendingDrop, setPendingDrop] = useState<{
     elementId: string; name: string; typeName: string;
     lifecycleStage: string; lifecycleStatus: string;
@@ -345,12 +396,6 @@ export function EaCanvas({
   // Updated by onInit (after fitView) and onMove (during pan/zoom).
   const viewportRef = useRef(initialCanvasState?.viewport ?? { x: 0, y: 0, zoom: 1 });
 
-  useEffect(() => {
-    if (!initialNodeLayout.shouldPersist) return;
-    const nodesRecord = Object.fromEntries(nodes.map((node) => [node.id, node.position]));
-    scheduleAutoSave({ ...latestCanvasStateRef.current, nodes: nodesRecord });
-  }, [nodes, initialNodeLayout.shouldPersist]);
-
   function scheduleAutoSave(state: CanvasState) {
     latestCanvasStateRef.current = state;
     if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
@@ -358,6 +403,102 @@ export function EaCanvas({
       void saveCanvasState({ viewId, canvasState: latestCanvasStateRef.current });
     }, 1500);
   }
+
+  const nodesRef = useRef<Node[]>(nodes);
+  useEffect(() => { nodesRef.current = nodes; }, [nodes]);
+  const rfRef = useRef<ReactFlowInstance | null>(null);
+
+  // Snapshot of every node's current position, keyed by React Flow node id.
+  const currentNodesRecord = useCallback(
+    () =>
+      Object.fromEntries(nodesRef.current.map((n) => [n.id, n.position])) as Record<
+        string,
+        { x: number; y: number }
+      >,
+    [],
+  );
+
+  // Run an automatic layout: optionally snapshot the current arrangement (so it can be
+  // restored later), reposition top-level nodes via the chosen engine, persist, and refit.
+  const runAutoLayout = useCallback(
+    async (algo: EaLayoutAlgorithm, opts?: { snapshot?: boolean; persist?: boolean }) => {
+      const snapshot = opts?.snapshot ?? true;
+      const persist = opts?.persist ?? !isReadOnly;
+      setIsLayouting(true);
+      try {
+        const topLevelNodes = nodesRef.current.filter((n) => !n.parentId).map((n) => ({ id: n.id }));
+        if (topLevelNodes.length < 2) return;
+        const positions = await computeEaLayout(topLevelNodes, layoutEdges, { algorithm: algo });
+
+        const history = snapshot
+          ? pushRevision(
+              latestCanvasStateRef.current.history ?? [],
+              `Before ${EA_LAYOUT_LABELS[algo].split(" · ")[0]} layout`,
+              currentNodesRecord(),
+            )
+          : latestCanvasStateRef.current.history;
+
+        setNodes((nds: Node[]) =>
+          nds.map((n) => (n.parentId ? n : { ...n, position: positions[n.id] ?? n.position })),
+        );
+
+        const nextState: CanvasState = {
+          ...latestCanvasStateRef.current,
+          nodes: { ...currentNodesRecord(), ...positions },
+          ...(history ? { history } : {}),
+        };
+        latestCanvasStateRef.current = nextState;
+        if (persist) await saveCanvasState({ viewId, canvasState: nextState });
+
+        requestAnimationFrame(() => rfRef.current?.fitView({ duration: 400, padding: 0.15 }));
+      } finally {
+        setIsLayouting(false);
+      }
+    },
+    [isReadOnly, layoutEdges, viewId, setNodes, currentNodesRecord],
+  );
+
+  // Restore a previously captured layout revision (the "go back to a previous revision" path).
+  const restoreRevision = useCallback(
+    async (rev: CanvasLayoutRevision) => {
+      setNodes((nds: Node[]) =>
+        nds.map((n) => (rev.nodes[n.id] ? { ...n, position: rev.nodes[n.id]! } : n)),
+      );
+      const nextState: CanvasState = {
+        ...latestCanvasStateRef.current,
+        nodes: { ...currentNodesRecord(), ...rev.nodes },
+      };
+      latestCanvasStateRef.current = nextState;
+      if (!isReadOnly) await saveCanvasState({ viewId, canvasState: nextState });
+      setRevMenuOpen(false);
+      requestAnimationFrame(() => rfRef.current?.fitView({ duration: 400, padding: 0.15 }));
+    },
+    [isReadOnly, viewId, setNodes, currentNodesRecord],
+  );
+
+  // On first mount: upgrade an auto-generated grid placeholder to a real crossing-minimizing
+  // layout, or persist the nestled positions of newly-added nodes. Runs exactly once.
+  const didInitLayoutRef = useRef(false);
+  useEffect(() => {
+    if (didInitLayoutRef.current) return;
+    didInitLayoutRef.current = true;
+    const topLevelCount = nodesRef.current.filter((n) => !n.parentId).length;
+    if (initialNodeLayout.needsInitialAutoLayout) {
+      if (topLevelCount > 1 && layoutEdges.length > 0) {
+        void runAutoLayout(defaultLayoutAlgo(), { snapshot: false, persist: !isReadOnly });
+      } else if (!isReadOnly) {
+        void saveCanvasState({
+          viewId,
+          canvasState: { ...latestCanvasStateRef.current, nodes: currentNodesRecord() },
+        });
+      }
+    } else if (initialNodeLayout.backfilled && !isReadOnly) {
+      void saveCanvasState({
+        viewId,
+        canvasState: { ...latestCanvasStateRef.current, nodes: currentNodesRecord() },
+      });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function getAbsoluteNodePosition(node: Node, nodesById: Map<string, Node>): { x: number; y: number } {
     if (!node.parentId) {
@@ -566,23 +707,104 @@ export function EaCanvas({
             {viewpoint && <span style={{ color: "var(--dpf-muted)", fontSize: 10 }}>Viewpoint: {viewpoint.name}</span>}
           </div>
 
-          {/* Edge style toggle */}
-          <div style={{ display: "flex", gap: 4 }}>
-            {(["straight", "bezier", "step"] as EdgeVariant[]).map((v) => (
-              <button
-                key={v}
-                onClick={() => handleSetEdgeVariant(v)}
-                title={v.charAt(0).toUpperCase() + v.slice(1)}
-                style={{
-                  fontSize: 10, padding: "2px 7px", borderRadius: 3, cursor: "pointer",
-                  background: edgeVariant === v ? "#2a2a50" : "transparent",
-                  border: `1px solid ${edgeVariant === v ? "var(--dpf-accent)" : "#2a2a40"}`,
-                  color: edgeVariant === v ? "var(--dpf-accent)" : "var(--dpf-muted)",
-                }}
-              >
-                {EDGE_VARIANT_LABELS[v]}
-              </button>
-            ))}
+          {/* Right-side controls */}
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            {!isReadOnly && (
+              <div style={{ display: "flex", alignItems: "center", gap: 4, position: "relative" }}>
+                <span style={{ color: "var(--dpf-muted)", fontSize: 10 }}>Arrange:</span>
+                {EA_LAYOUT_ALGORITHMS.map((algo) => (
+                  <button
+                    key={algo}
+                    disabled={isLayouting}
+                    onClick={() => {
+                      try { window.localStorage.setItem("ea-layout-algo", algo); } catch { /* ignore */ }
+                      void runAutoLayout(algo);
+                    }}
+                    title={`Auto-layout — ${EA_LAYOUT_LABELS[algo]}`}
+                    style={{
+                      fontSize: 10, padding: "2px 7px", borderRadius: 3,
+                      cursor: isLayouting ? "wait" : "pointer", opacity: isLayouting ? 0.5 : 1,
+                      background: "transparent", border: "1px solid #2a2a40", color: "var(--dpf-muted)",
+                    }}
+                  >
+                    {EA_LAYOUT_LABELS[algo].split(" · ")[0]}
+                  </button>
+                ))}
+
+                {/* Revisions — restore a previous layout */}
+                {(() => {
+                  const revisions = latestCanvasStateRef.current.history ?? [];
+                  const hasRevisions = revisions.length > 0;
+                  return (
+                    <>
+                      <button
+                        onClick={() => setRevMenuOpen((o) => !o)}
+                        disabled={!hasRevisions}
+                        title={hasRevisions ? "Restore a previous layout" : "No saved layouts yet"}
+                        style={{
+                          fontSize: 10, padding: "2px 7px", borderRadius: 3,
+                          cursor: hasRevisions ? "pointer" : "default",
+                          background: revMenuOpen ? "#2a2a50" : "transparent",
+                          border: `1px solid ${revMenuOpen ? "var(--dpf-accent)" : "#2a2a40"}`,
+                          color: hasRevisions ? "var(--dpf-text)" : "#3a3a4a",
+                        }}
+                      >
+                        ↶ Revisions{hasRevisions ? ` (${revisions.length})` : ""}
+                      </button>
+                      {revMenuOpen && hasRevisions && (
+                        <>
+                          <div onClick={() => setRevMenuOpen(false)} style={{ position: "fixed", inset: 0, zIndex: 40 }} />
+                          <div style={{
+                            position: "absolute", top: "calc(100% + 4px)", right: 0, zIndex: 41,
+                            minWidth: 240, maxHeight: 300, overflowY: "auto",
+                            background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)",
+                            borderRadius: 5, padding: 4, boxShadow: "0 6px 20px #0008",
+                          }}>
+                            {[...revisions].reverse().map((rev) => (
+                              <button
+                                key={rev.id}
+                                onClick={() => void restoreRevision(rev)}
+                                style={{
+                                  display: "block", width: "100%", textAlign: "left",
+                                  fontSize: 10, padding: "5px 7px", borderRadius: 3, cursor: "pointer",
+                                  background: "transparent", border: "none", color: "var(--dpf-text)",
+                                }}
+                                onMouseEnter={(e) => { e.currentTarget.style.background = "#2a2a50"; }}
+                                onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+                              >
+                                <span style={{ color: "var(--dpf-accent)" }}>Restore</span> · {rev.label}
+                                <span style={{ color: "var(--dpf-muted)", marginLeft: 4 }}>
+                                  {new Date(rev.at).toLocaleTimeString()}
+                                </span>
+                              </button>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </>
+                  );
+                })()}
+              </div>
+            )}
+
+            {/* Edge style toggle */}
+            <div style={{ display: "flex", gap: 4 }}>
+              {(["straight", "bezier", "step"] as EdgeVariant[]).map((v) => (
+                <button
+                  key={v}
+                  onClick={() => handleSetEdgeVariant(v)}
+                  title={v.charAt(0).toUpperCase() + v.slice(1)}
+                  style={{
+                    fontSize: 10, padding: "2px 7px", borderRadius: 3, cursor: "pointer",
+                    background: edgeVariant === v ? "#2a2a50" : "transparent",
+                    border: `1px solid ${edgeVariant === v ? "var(--dpf-accent)" : "#2a2a40"}`,
+                    color: edgeVariant === v ? "var(--dpf-accent)" : "var(--dpf-muted)",
+                  }}
+                >
+                  {EDGE_VARIANT_LABELS[v]}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
@@ -610,7 +832,7 @@ export function EaCanvas({
             zoomOnScroll
             zoomOnPinch
             translateExtent={[[-Infinity, -Infinity], [Infinity, Infinity]]}
-            onInit={(rf: ReactFlowInstance) => { viewportRef.current = rf.getViewport(); }}
+            onInit={(rf: ReactFlowInstance) => { rfRef.current = rf; viewportRef.current = rf.getViewport(); }}
             onMove={(_evt: unknown, vp: Viewport) => { viewportRef.current = vp; }}
           >
             <Background color="#2a2a40" gap={20} />

--- a/apps/web/lib/ea/canvas-layout.test.ts
+++ b/apps/web/lib/ea/canvas-layout.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { computeEaLayout, placeIncremental, EA_NODE_W, EA_NODE_H } from "./canvas-layout";
+
+const nodes = (...ids: string[]) => ids.map((id) => ({ id }));
+const edge = (source: string, target: string) => ({ source, target });
+
+const ALGORITHMS = ["layered", "radial", "hierarchical"] as const;
+
+describe("computeEaLayout", () => {
+  it("returns an empty map for no nodes", async () => {
+    expect(await computeEaLayout([], [], { algorithm: "layered" })).toEqual({});
+  });
+
+  it("places a single node", async () => {
+    const result = await computeEaLayout(nodes("a"), [], { algorithm: "radial" });
+    expect(Object.keys(result)).toEqual(["a"]);
+  });
+
+  for (const algorithm of ALGORITHMS) {
+    it(`${algorithm}: positions every node with finite coordinates`, async () => {
+      const result = await computeEaLayout(
+        nodes("a", "b", "c", "d", "e"),
+        [edge("a", "b"), edge("a", "c"), edge("a", "d"), edge("d", "e")],
+        { algorithm },
+      );
+      expect(Object.keys(result).sort()).toEqual(["a", "b", "c", "d", "e"]);
+      for (const pos of Object.values(result)) {
+        expect(Number.isFinite(pos.x)).toBe(true);
+        expect(Number.isFinite(pos.y)).toBe(true);
+      }
+    });
+
+    it(`${algorithm}: is deterministic for identical (connected) input`, async () => {
+      const ns = nodes("a", "b", "c", "d");
+      const es = [edge("a", "b"), edge("b", "c"), edge("c", "d")];
+      const first = await computeEaLayout(ns, es, { algorithm });
+      const second = await computeEaLayout(ns, es, { algorithm });
+      expect(first).toEqual(second);
+    });
+  }
+
+  it("hierarchical: no two nodes overlap (separated by at least the node footprint)", async () => {
+    const result = await computeEaLayout(
+      nodes("a", "b", "c", "d"),
+      [edge("a", "b"), edge("b", "c"), edge("c", "d")],
+      { algorithm: "hierarchical" },
+    );
+    const points = Object.values(result);
+    for (let i = 0; i < points.length; i += 1) {
+      for (let j = i + 1; j < points.length; j += 1) {
+        const overlap =
+          Math.abs(points[i]!.x - points[j]!.x) < EA_NODE_W &&
+          Math.abs(points[i]!.y - points[j]!.y) < EA_NODE_H;
+        expect(overlap).toBe(false);
+      }
+    }
+  });
+});
+
+describe("placeIncremental", () => {
+  it("places a new node nearer its neighbor than the far side of the canvas", () => {
+    const existing = { a: { x: 0, y: 0 }, b: { x: 600, y: 600 } };
+    const result = placeIncremental(existing, [edge("new", "b")], ["new"]);
+    expect(result.new).toBeDefined();
+    const distToB = Math.hypot(result.new!.x - 600, result.new!.y - 600);
+    const distToA = Math.hypot(result.new!.x - 0, result.new!.y - 0);
+    expect(distToB).toBeLessThan(distToA);
+  });
+
+  it("does not overlap an existing node", () => {
+    const existing = { a: { x: 0, y: 0 } };
+    const result = placeIncremental(existing, [edge("new", "a")], ["new"]);
+    const overlap =
+      Math.abs(result.new!.x - 0) < EA_NODE_W && Math.abs(result.new!.y - 0) < EA_NODE_H;
+    expect(overlap).toBe(false);
+  });
+
+  it("parks an unconnected node past the right edge of the existing bbox", () => {
+    const existing = { a: { x: 0, y: 0 }, b: { x: 100, y: 0 } };
+    const result = placeIncremental(existing, [], ["lonely"]);
+    expect(result.lonely!.x).toBeGreaterThan(100);
+  });
+
+  it("returns positions only for the new ids and does not mutate existing", () => {
+    const existing = { a: { x: 0, y: 0 } };
+    const result = placeIncremental(existing, [edge("x", "a"), edge("y", "a")], ["x", "y"]);
+    expect(Object.keys(result).sort()).toEqual(["x", "y"]);
+    expect(existing).toEqual({ a: { x: 0, y: 0 } });
+  });
+});

--- a/apps/web/lib/ea/canvas-layout.ts
+++ b/apps/web/lib/ea/canvas-layout.ts
@@ -1,0 +1,249 @@
+// Automatic layout for the EA views/viewpoints canvas (BI-D9F9B34F, EP-ARCH-GRAPH-LIVE).
+//
+// Reuses the render-agnostic layout engines in `lib/graph/` (dagre / ELK / radial-BFS)
+// rather than introducing a new layout library. EA elements + relationships are adapted
+// to `GraphData`, an engine is run, and the result is normalized to React Flow top-left
+// coordinates keyed by EaViewElement id (the React Flow node id used by EaCanvas).
+//
+// All functions here are pure (the layered path is async only because ELK is) so they can
+// be unit-tested without React Flow or the DB.
+
+import type { GraphData } from "@/lib/actions/graph";
+import { computeHierarchicalLayout } from "@/lib/graph/layout-hierarchical";
+import { computeRadialLayout } from "@/lib/graph/layout-radial";
+import { computeSwimLaneLayout } from "@/lib/graph/layout-swimlane";
+
+export type EaLayoutAlgorithm = "layered" | "radial" | "hierarchical";
+
+export type EaLayoutNode = { id: string };
+export type EaLayoutEdge = { source: string; target: string };
+export type EaPositions = Record<string, { x: number; y: number }>;
+
+// Footprint of a standard EA element node (EaElementNode renders ~120–160px wide).
+// The layout is spaced for this box so auto-laid views don't overlap.
+export const EA_NODE_W = 170;
+export const EA_NODE_H = 80;
+const GAP = 70;
+const PITCH_X = EA_NODE_W + GAP;
+const PITCH_Y = EA_NODE_H + GAP;
+const MARGIN = 40;
+
+export const EA_LAYOUT_LABELS: Record<EaLayoutAlgorithm, string> = {
+  layered: "Layered · fewest crossings",
+  radial: "Radial · hub & spoke",
+  hierarchical: "Hierarchical · top-down",
+};
+
+export const EA_LAYOUT_ALGORITHMS: EaLayoutAlgorithm[] = ["layered", "radial", "hierarchical"];
+
+function toGraphData(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): GraphData {
+  const ids = new Set(nodes.map((n) => n.id));
+  return {
+    nodes: nodes.map((n) => ({ id: n.id, name: n.id, label: n.id, color: "#000", size: 1 })),
+    links: edges
+      .filter((e) => e.source !== e.target && ids.has(e.source) && ids.has(e.target))
+      .map((e) => ({ source: e.source, target: e.target, type: "rel" })),
+  };
+}
+
+function buildAdjacency(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): Map<string, string[]> {
+  const adj = new Map<string, string[]>();
+  for (const n of nodes) adj.set(n.id, []);
+  for (const e of edges) {
+    if (e.source === e.target) continue;
+    if (adj.has(e.source)) adj.get(e.source)!.push(e.target);
+    if (adj.has(e.target)) adj.get(e.target)!.push(e.source);
+  }
+  return adj;
+}
+
+/** Most-connected node — the natural center for a radial layout. */
+function highestDegreeId(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): string {
+  const adj = buildAdjacency(nodes, edges);
+  let best = nodes[0]?.id ?? "";
+  let bestDegree = -1;
+  for (const n of nodes) {
+    const degree = (adj.get(n.id) ?? []).length;
+    if (degree > bestDegree) {
+      bestDegree = degree;
+      best = n.id;
+    }
+  }
+  return best;
+}
+
+/**
+ * Ring spacing wide enough that the densest ring's nodes don't overlap angularly.
+ * `computeRadialLayout` hard-codes 60×30 node sizing, so we size the rings here for the
+ * larger EA node footprint instead of editing the shared graph helper.
+ */
+function radialRingSpacing(nodes: EaLayoutNode[], edges: EaLayoutEdge[], rootId: string): number {
+  const adj = buildAdjacency(nodes, edges);
+  const depth = new Map<string, number>([[rootId, 0]]);
+  const queue: string[] = [rootId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const currentDepth = depth.get(current)!;
+    for (const neighbor of adj.get(current) ?? []) {
+      if (!depth.has(neighbor)) {
+        depth.set(neighbor, currentDepth + 1);
+        queue.push(neighbor);
+      }
+    }
+  }
+  const ringCount = new Map<number, number>();
+  for (const d of depth.values()) {
+    if (d >= 1) ringCount.set(d, (ringCount.get(d) ?? 0) + 1);
+  }
+  const maxRing = ringCount.size > 0 ? Math.max(...ringCount.values()) : 1;
+  // Arc length per node on the innermost ring (radius = ringSpacing) must be >= PITCH_X.
+  const needed = Math.ceil((PITCH_X * maxRing) / (2 * Math.PI));
+  return Math.max(220, needed);
+}
+
+function fromResult(
+  result: { nodes: Array<{ id: string; x: number; y: number }> },
+  centerBased: boolean,
+): EaPositions {
+  const out: EaPositions = {};
+  for (const n of result.nodes) {
+    out[n.id] = centerBased
+      ? { x: n.x - EA_NODE_W / 2, y: n.y - EA_NODE_H / 2 }
+      : { x: n.x, y: n.y };
+  }
+  return out;
+}
+
+/** Shift the whole layout so its top-left corner sits at (MARGIN, MARGIN). */
+function normalize(positions: EaPositions): EaPositions {
+  const values = Object.values(positions);
+  if (values.length === 0) return positions;
+  const minX = Math.min(...values.map((p) => p.x));
+  const minY = Math.min(...values.map((p) => p.y));
+  const out: EaPositions = {};
+  for (const [id, p] of Object.entries(positions)) {
+    out[id] = { x: p.x - minX + MARGIN, y: p.y - minY + MARGIN };
+  }
+  return out;
+}
+
+/**
+ * Compute an automatic layout for the given EA nodes + edges.
+ * Returns React Flow top-left positions keyed by node id (EaViewElement id).
+ */
+export async function computeEaLayout(
+  nodes: EaLayoutNode[],
+  edges: EaLayoutEdge[],
+  opts: { algorithm: EaLayoutAlgorithm; direction?: "TB" | "LR" },
+): Promise<EaPositions> {
+  if (nodes.length === 0) return {};
+  if (nodes.length === 1) return { [nodes[0]!.id]: { x: MARGIN, y: MARGIN } };
+
+  const graphData = toGraphData(nodes, edges);
+
+  if (opts.algorithm === "hierarchical") {
+    const result = computeHierarchicalLayout(graphData, {
+      direction: opts.direction ?? "TB",
+      nodeWidth: EA_NODE_W,
+      nodeHeight: EA_NODE_H,
+      rankSep: PITCH_Y,
+      nodeSep: GAP,
+    });
+    return normalize(fromResult(result, true));
+  }
+
+  if (opts.algorithm === "radial") {
+    const rootId = highestDegreeId(nodes, edges);
+    const result = computeRadialLayout(graphData, {
+      rootId,
+      ringSpacing: radialRingSpacing(nodes, edges, rootId),
+      centerX: 0,
+      centerY: 0,
+    });
+    return normalize(fromResult(result, true));
+  }
+
+  // Default: ELK "layered" with no partitions — strongest edge-crossing minimization.
+  const result = await computeSwimLaneLayout(graphData, () => null, {
+    nodeWidth: EA_NODE_W,
+    nodeHeight: EA_NODE_H,
+    layerSpacing: PITCH_Y,
+    nodeSpacing: GAP,
+  });
+  return normalize(fromResult(result, false)); // ELK reports top-left already
+}
+
+function overlaps(a: { x: number; y: number }, b: { x: number; y: number }): boolean {
+  return Math.abs(a.x - b.x) < EA_NODE_W && Math.abs(a.y - b.y) < EA_NODE_H;
+}
+
+/** Nudge a candidate position outward on an expanding ring until it clears all placed nodes. */
+function resolveCollision(pos: { x: number; y: number }, placed: EaPositions): { x: number; y: number } {
+  const others = Object.values(placed);
+  const collides = (p: { x: number; y: number }) => others.some((o) => overlaps(p, o));
+  if (!collides(pos)) return pos;
+  const step = Math.max(PITCH_X, PITCH_Y) * 0.6;
+  for (let ring = 1; ring <= 12; ring += 1) {
+    const radius = ring * step;
+    const steps = 8 * ring;
+    for (let i = 0; i < steps; i += 1) {
+      const angle = (2 * Math.PI * i) / steps;
+      const candidate = { x: pos.x + radius * Math.cos(angle), y: pos.y + radius * Math.sin(angle) };
+      if (!collides(candidate)) return candidate;
+    }
+  }
+  return pos; // give up — accept overlap rather than loop forever
+}
+
+/**
+ * Place newly-added nodes into an existing layout with minimal disruption.
+ * A new node lands at the centroid of its already-placed neighbors (then nudged to avoid
+ * overlap); a node with no placed neighbors parks just past the layout's right edge.
+ * Existing positions are never moved. Returns positions for `newIds` only.
+ */
+export function placeIncremental(
+  existing: EaPositions,
+  edges: EaLayoutEdge[],
+  newIds: string[],
+): EaPositions {
+  const placed: EaPositions = { ...existing };
+  const result: EaPositions = {};
+
+  const adj = new Map<string, string[]>();
+  for (const e of edges) {
+    if (e.source === e.target) continue;
+    if (!adj.has(e.source)) adj.set(e.source, []);
+    if (!adj.has(e.target)) adj.set(e.target, []);
+    adj.get(e.source)!.push(e.target);
+    adj.get(e.target)!.push(e.source);
+  }
+
+  const existingValues = Object.values(existing);
+  const bbox = existingValues.length
+    ? {
+        maxX: Math.max(...existingValues.map((p) => p.x)),
+        minY: Math.min(...existingValues.map((p) => p.y)),
+      }
+    : { maxX: 0, minY: MARGIN };
+
+  let parked = 0;
+  for (const id of newIds) {
+    if (placed[id]) {
+      result[id] = placed[id]!;
+      continue;
+    }
+    const neighbors = (adj.get(id) ?? []).filter((nid) => placed[nid]);
+    let target: { x: number; y: number };
+    if (neighbors.length > 0) {
+      const cx = neighbors.reduce((sum, n) => sum + placed[n]!.x, 0) / neighbors.length;
+      const cy = neighbors.reduce((sum, n) => sum + placed[n]!.y, 0) / neighbors.length;
+      target = resolveCollision({ x: cx, y: cy }, placed);
+    } else {
+      target = resolveCollision({ x: bbox.maxX + PITCH_X, y: bbox.minY + parked * PITCH_Y }, placed);
+      parked += 1;
+    }
+    placed[id] = target;
+    result[id] = target;
+  }
+  return result;
+}

--- a/apps/web/lib/explore/ea-types.ts
+++ b/apps/web/lib/explore/ea-types.ts
@@ -2,9 +2,20 @@
 
 export type EaViewMode = "new" | "reference" | "propose";
 
+// A captured layout snapshot the author can restore (BI-D9F9B34F). Stored inline in
+// canvasState so it round-trips through the existing saveCanvasState/addElementToView
+// path with no schema change. Bounded to a small ring buffer client-side.
+export type CanvasLayoutRevision = {
+  id: string; // stable id for restore/keying
+  at: number; // epoch ms captured
+  label: string; // e.g. "Before Layered layout"
+  nodes: Record<string, { x: number; y: number }>;
+};
+
 export type CanvasState = {
   viewport: { x: number; y: number; zoom: number };
   nodes: Record<string, { x: number; y: number }>; // key = EaViewElement.id
+  history?: CanvasLayoutRevision[]; // restore points, newest last; optional + bounded
 };
 
 export type ProjectionLayoutRole =

--- a/apps/web/lib/graph/layout-swimlane.ts
+++ b/apps/web/lib/graph/layout-swimlane.ts
@@ -11,11 +11,24 @@ export type PartitionFn = (nodeId: string) => number | string | null;
 export async function computeSwimLaneLayout(
   data: GraphData,
   getPartition: PartitionFn,
-  options?: { partitionLabels?: Map<string | number, string> },
+  options?: {
+    partitionLabels?: Map<string | number, string>;
+    // Optional node footprint + spacing. Defaults preserve the original TopologyGraph
+    // behavior (60×30 nodes); the EA canvas adapter passes its larger node sizing.
+    nodeWidth?: number;
+    nodeHeight?: number;
+    layerSpacing?: number;
+    nodeSpacing?: number;
+  },
 ): Promise<LayoutResult> {
   if (data.nodes.length === 0) {
     return { nodes: [], links: [] };
   }
+
+  const nodeWidth = options?.nodeWidth ?? 60;
+  const nodeHeight = options?.nodeHeight ?? 30;
+  const layerSpacing = options?.layerSpacing ?? 80;
+  const nodeSpacing = options?.nodeSpacing ?? 30;
 
   // Build partition index map for ELK (needs integer partition keys)
   const partitionKeys = new Set<string | number>();
@@ -48,8 +61,8 @@ export async function computeSwimLaneLayout(
       const idx = partition != null ? partitionIndex.get(partition) : undefined;
       return {
         id: node.id,
-        width: 60,
-        height: 30,
+        width: nodeWidth,
+        height: nodeHeight,
         ...(idx != null
           ? { layoutOptions: { "elk.partitioning.partition": String(idx) } }
           : {}),
@@ -70,8 +83,8 @@ export async function computeSwimLaneLayout(
         "elk.algorithm": "layered",
         "elk.direction": "DOWN",
         "elk.partitioning.activate": "true",
-        "elk.layered.spacing.nodeNodeBetweenLayers": "80",
-        "elk.spacing.nodeNode": "30",
+        "elk.layered.spacing.nodeNodeBetweenLayers": String(layerSpacing),
+        "elk.spacing.nodeNode": String(nodeSpacing),
       },
       children,
       edges,

--- a/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
+++ b/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
@@ -1,0 +1,40 @@
+# EA Canvas Auto-Layout — Implementation Plan
+
+**BI:** BI-D9F9B34F · **Epic:** EP-ARCH-GRAPH-LIVE · **Date:** 2026-06-19 · **Mode:** direct (BS re-architecture override)
+
+## Goal (operator /goal)
+
+On the EA views/viewpoints canvas (`EaCanvas`, React Flow), replace the naive sqrt-grid with **automatic layout that minimizes edge crossings**, **save** it, keep **manual editing** afterward, add **revision history / undo** (restore a prior layout if the automatic one looks worse), and **nestle newly-added auto-generated nodes** into the existing layout instead of grid-backfilling.
+
+## Substrate reused (verified — not rebuilt)
+
+- `apps/web/lib/graph/` layout engines (render-agnostic, take `GraphData`→positioned nodes):
+  - `computeHierarchicalLayout` (dagre, crossing-aware) — **hierarchical**
+  - `computeRadialLayout` (BFS rings) — **radial** (matches the founder's hand-built hub-and-spoke)
+  - `computeSwimLaneLayout` (ELK `layered`) — **layered** (gold-standard crossing minimization)
+- `dagre`@0.8.5 + `elkjs`@0.11.1 already in `apps/web` deps; already used client-side by `TopologyGraph`.
+- `EaView.canvasState` + `saveCanvasState` persistence; manual drag→1.5s autosave already works.
+- Original EA-2 spec already drew an "Auto-layout button" and chose React Flow for ELK — never built.
+
+## Changes
+
+1. **`apps/web/lib/graph/layout-swimlane.ts`** — additive optional `nodeWidth/nodeHeight/layerSpacing/nodeSpacing` options (defaults preserve current TopologyGraph behavior). Lets the EA adapter request realistic ~170×80 node spacing.
+2. **`apps/web/lib/ea/canvas-layout.ts`** (new, pure, unit-tested):
+   - `computeEaLayout(nodes, edges, {algorithm})` → `Record<viewElementId,{x,y}>`, adapting EA elements/edges → `GraphData`, calling the existing engines, normalizing each engine's coordinate convention to React Flow top-left.
+   - `placeIncremental(existing, edges, newIds)` → centroid-of-placed-neighbors + collision-avoidance (fallback: parked at bbox edge).
+3. **`apps/web/lib/explore/ea-types.ts`** — extend `CanvasState` with optional bounded `history: CanvasLayoutRevision[]` (restore points). Backward-compatible; `saveCanvasState`/`addElementToView` already round-trip the whole JSON, so no server change.
+4. **`apps/web/components/ea/EaCanvas.tsx`**:
+   - "Auto-layout ▾" control (algorithm picker, remembers last via localStorage) — snapshots current layout into `history` (cap 10), runs `computeEaLayout`, repositions top-level nodes, persists.
+   - "Revisions ▾" menu — list snapshots newest-first; Restore applies a snapshot's positions and persists.
+   - On first mount of a view with no meaningful saved layout, run the default layout (replaces the grid) — SSR-safe (grid placeholder → upgrade on mount); persists only for editors.
+   - Incremental backfill in `buildNodeLayout` uses `placeIncremental` instead of grid-fill.
+
+Layout repositions **top-level** nodes only; structured value-stream children follow their parent (relative positions unchanged).
+
+## Tests
+
+- `apps/web/lib/ea/canvas-layout.test.ts`: each algorithm returns a position per node, no NaN, deterministic for fixed input; `placeIncremental` places a new node near its single neighbor, avoids overlap, and parks an unconnected node clear of the bbox; empty/single-node guards.
+
+## Verification
+
+Local: vitest on the adapter; full web suite before push. CI green. Functional: load an auto-generated EA view, click each algorithm, drag a node, reload (persisted), restore a revision, add an element and confirm it nestles by its neighbor.


### PR DESCRIPTION
## Summary

The EA views/viewpoints canvas laid auto-generated views out on a naive `sqrt`-grid, making it "hard to see what connects to what" — the founder had to hand-arrange a ~80-node view for ~30 min into something readable. This PR adds **one-click automatic layout that minimizes edge crossings**, plus the surrounding workflow the request called for:

1. **Automatic layout** — `Arrange:` buttons (Layered = fewest crossings, Radial = hub & spoke, Hierarchical = top-down).
2. **Save** — the new layout persists through the existing `saveCanvasState` path.
3. **Manual editing after** — unchanged; drag + 1.5 s autosave still work.
4. **Undo / revision history** — every auto-layout first snapshots the current arrangement; the **Revisions** menu restores any prior layout (so hand-tuned work isn't lost if the automatic one looks worse).
5. **Incremental placement** — auto-generated nodes that arrive without a saved position **nestle** next to their connected neighbors instead of grid-backfilling, and a fresh auto-generated view upgrades from the grid placeholder to a real layout on first mount.

## Substrate reuse (no new layout library)

The render-agnostic engines in `apps/web/lib/graph/` (`dagre`, ELK `layered`, radial-BFS) already existed but only served the force-graph `TopologyGraph`. This PR adapts EA elements/edges → `GraphData`, runs those engines, and maps results back to React Flow positions keyed by `EaViewElement` id. `dagre`/`elkjs` were already dependencies. This closes the **"Auto-layout button"** the original Phase EA-2 spec drew but deferred.

## Changes

| File | What |
|---|---|
| `apps/web/lib/ea/canvas-layout.ts` *(new)* | Pure, unit-tested `computeEaLayout` (layered/radial/hierarchical) + `placeIncremental` (centroid-of-placed-neighbors, collision-avoidant). |
| `apps/web/lib/explore/ea-types.ts` | `CanvasState.history` — bounded in-JSON revision ring buffer (restore points). No schema change; rides the existing `canvasState` JSON round-trip. |
| `apps/web/lib/graph/layout-swimlane.ts` | Additive optional node-sizing options; defaults preserve current `TopologyGraph` behavior. |
| `apps/web/components/ea/EaCanvas.tsx` | `Arrange` controls, `Revisions` restore menu, first-mount grid→real-layout upgrade, neighbor-aware backfill (fixes whole-view re-grid when nodes are added). |
| `docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md` *(new)* | Implementation plan. |

Auto-layout repositions **top-level** nodes only; structured value-stream children follow their parent.

## Testing

- `lib/ea/canvas-layout.test.ts`: 13 tests — each algorithm positions every node with finite, deterministic coords; no overlap (hierarchical); `placeIncremental` nestles by neighbor, avoids overlap, parks unconnected nodes, doesn't mutate existing.
- Full EA/graph blast radius re-run after rebase: **208 tests pass** (incl. existing `ea.test.ts`, graph layouts, EA components, `TopologyGraph`).
- `apps/web` typecheck: clean (0 errors).

No DB migration (revision history is in the existing `EaView.canvasState` JSON). No change to `saveCanvasState` / `addElementToView` signatures.

Backlog: **BI-D9F9B34F** · Epic: **EP-ARCH-GRAPH-LIVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
