### PR TITLE
feat(inference): single-generation-model policy — over-commit guard in install + Providers UX

### DIFF
--- a/apps/web/components/platform/OllamaManagement.tsx
+++ b/apps/web/components/platform/OllamaManagement.tsx
@@ -9,6 +9,10 @@ import {
   type OllamaRunningModel,
 } from "@/lib/actions/ollama-management";
 import { discoverModels, profileModels } from "@/lib/actions/ai-providers";
+import {
+  detectLocalModelOverCommit,
+  normaliseModelId,
+} from "@/lib/inference/local-model-policy";
 
 // ── Model Catalog ────────────────────────────────────────────────────────────
 
@@ -137,9 +141,7 @@ function fitsHardware(model: CatalogModel, vramGb: number | null): "fits" | "mar
   return "too-large";
 }
 
-function normaliseModelId(name: string): string {
-  return name.replace(/^docker\.io\//, "").replace(/:latest$/, "");
-}
+// normaliseModelId is imported from local-model-policy (single source of truth).
 
 // ── Component ────────────────────────────────────────────────────────────────
 
@@ -252,6 +254,17 @@ export function OllamaManagement({ canWrite, vramGb, providerId }: Props) {
 
   const installedIds = new Set(models.map((m) => normaliseModelId(m.name)));
 
+  // Single-generation-model policy: flag when more than one generation model is
+  // installed (they over-commit the GPU — one llama-server per model, no DMR
+  // concurrency cap). Source of truth: local-model-policy.ts.
+  const overCommit = detectLocalModelOverCommit({
+    installedModelIds: models.map((m) => normaliseModelId(m.name)),
+    vramGb: vramGb ?? null,
+  });
+  const removeModels = models.filter((m) =>
+    overCommit.removeCandidates.includes(normaliseModelId(m.name)),
+  );
+
   const filteredCatalog = catalogCategory === "all"
     ? CATALOG
     : CATALOG.filter((m) => m.category === catalogCategory);
@@ -322,6 +335,49 @@ export function OllamaManagement({ canWrite, vramGb, providerId }: Props) {
                 <span style={{ color: "var(--dpf-success)", fontWeight: 500 }}>{totalVramGb.toFixed(1)} GB</span>
                 <span style={{ color: "var(--dpf-muted)" }}> ({running.length})</span>
               </span>
+            )}
+          </div>
+        )}
+
+        {/* Over-commit warning: more than one generation model installed. */}
+        {loaded && overCommit.overCommitted && (
+          <div style={{
+            marginBottom: 12,
+            padding: "10px 12px",
+            borderRadius: 5,
+            border: "1px solid color-mix(in srgb, var(--dpf-warning, #d98300) 40%, var(--dpf-border))",
+            background: "color-mix(in srgb, var(--dpf-warning, #d98300) 8%, transparent)",
+          }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", marginBottom: 4 }}>
+              ⚠ More than one AI model is installed
+            </div>
+            <div style={{ fontSize: 11, color: "var(--dpf-muted)", lineHeight: 1.5 }}>
+              {overCommit.reason}
+            </div>
+            {removeModels.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8, alignItems: "center" }}>
+                {overCommit.recommendedKeep && (
+                  <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>
+                    Keep <code style={{ color: "var(--dpf-success)" }}>{normaliseModelId(overCommit.recommendedKeep)}</code> ·
+                  </span>
+                )}
+                {canWrite && removeModels.map((m) => (
+                  <button
+                    key={m.name}
+                    type="button"
+                    onClick={() => handleDelete(m.name)}
+                    disabled={isPending}
+                    style={{
+                      fontSize: 10, padding: "3px 8px", borderRadius: 3, cursor: "pointer",
+                      border: "1px solid color-mix(in srgb, var(--dpf-error) 40%, transparent)",
+                      background: "color-mix(in srgb, var(--dpf-error) 12%, transparent)",
+                      color: "var(--dpf-error)",
+                    }}
+                  >
+                    Remove {normaliseModelId(m.name)}
+                  </button>
+                ))}
+              </div>
             )}
           </div>
         )}
@@ -422,6 +478,11 @@ export function OllamaManagement({ canWrite, vramGb, providerId }: Props) {
                       {isRunning && (
                         <span style={{ fontSize: 9, color: "var(--dpf-success)", padding: "1px 4px", borderRadius: 3, background: "color-mix(in srgb, var(--dpf-success) 15%, transparent)" }}>
                           loaded
+                        </span>
+                      )}
+                      {overCommit.removeCandidates.includes(normId) && (
+                        <span style={{ fontSize: 9, color: "var(--dpf-warning, #d98300)", padding: "1px 4px", borderRadius: 3, background: "color-mix(in srgb, var(--dpf-warning, #d98300) 15%, transparent)" }}>
+                          extra · over-commit
                         </span>
                       )}
                       {catalogEntry && (

--- a/apps/web/lib/inference/bootstrap-first-run.ts
+++ b/apps/web/lib/inference/bootstrap-first-run.ts
@@ -4,6 +4,11 @@ import { getOllamaBaseUrl, getOllamaApiRoot } from "./ollama-url";
 import { isFirstRun, createSetupProgress } from "../actions/setup-progress";
 import { activateProvider } from "@/lib/govern/activate-provider";
 import { syncAgentPrincipal } from "@/lib/identity/principal-linking";
+import {
+  recommendGenerationModel,
+  detectLocalModelOverCommit,
+  normaliseModelId,
+} from "./local-model-policy";
 
 /** Check if first-run bootstrap is needed. */
 export async function checkBootstrapNeeded(): Promise<boolean> {
@@ -73,57 +78,20 @@ export async function seedOnboardingAgent(): Promise<void> {
 }
 
 /**
- * Model tiers ordered largest-first for auto-pull on first run (or when
- * the host hardware profile did not pre-pull a strong model).
- * Each entry specifies the exact Docker Model Runner tag published under
- * the `ai/` namespace and the minimum (unified) memory / VRAM required.
+ * Select the largest generation model that fits available VRAM. The canonical
+ * tier list now lives in local-model-policy.ts (shared with the Providers UX and
+ * mirrored by the install scripts); this wrapper only adds the hardware probe.
  *
- * Sizing from the actual published manifests in the ai/ runner catalog.
- * Tags are case-sensitive and must include the quantization suffix.
- *
- *   - ai/qwen3.6:35B-A3B-UD-Q4_K_M  (Qwen3.6 35B-A3B MoE) → ~22 GB  (high-RAM Apple Silicon "plenty of memory" or 24 GB+ GPU)
- *   - ai/qwen3:14B-Q6_K             (14B dense)          → ~12 GB
- *   - ai/qwen3:8B-Q4_K_M            (8B dense)           → ~5  GB
- *   - ai/qwen3:4B-UD-Q4_K_XL        (4B dense)           → ~3  GB (CPU-OK fallback)
- *
- * Qwen (3 / 3.6) is preferred because of strong tool-calling results
- * (F1 0.93+ at 8B, higher at larger sizes) that the DPF coworker routing
- * and Build Studio agents depend on. The 35B-A3B MoE (what Docker surfaces
- * as ai/qwen3.6:latest) is the current top published option for hosts
- * with plenty of unified RAM — direct successor to the prior 30B-A3B,
- * with better agentic coding while keeping the same efficient ~3B active
- * parameter budget.
- *
- * We never use bare :latest tags in automated paths. The specific
- * quant tag gives a known on-disk size and reproducible behaviour.
- */
-const MODEL_TIERS: { model: string; minVramGb: number }[] = [
-  { model: "ai/qwen3.6:35B-A3B-UD-Q4_K_M", minVramGb: 22 }, // Qwen3.6 35B-A3B MoE — high-RAM Apple (128 GB class) or 24 GB+ discrete
-  { model: "ai/qwen3:14B-Q6_K",            minVramGb: 12 }, // 14B dense
-  { model: "ai/qwen3:8B-Q4_K_M",           minVramGb: 6  }, // 8B dense
-  { model: "ai/qwen3:4B-UD-Q4_K_XL",       minVramGb: 0  }, // 4B dense — CPU fallback
-];
-
-/**
- * Select the largest Qwen3 model that fits available VRAM. Walks the tier
- * list top-down and picks the first model whose minimum VRAM requirement
- * is satisfied by the detected hardware.
+ *   - hwInfo present, vramGb n  → largest tier whose floor n satisfies
+ *   - hwInfo present, vramGb 0  → CPU-only host → 4B tier
+ *   - hwInfo missing / exception → undetectable → broadly-compatible 8B default
  */
 async function selectModelForHardware(baseUrl: string): Promise<string> {
   try {
     const hwInfo = await getOllamaHardwareInfo(baseUrl);
-    const vram = hwInfo?.vramGb ?? 0;
-
-    for (const tier of MODEL_TIERS) {
-      if (vram >= tier.minVramGb) {
-        return tier.model;
-      }
-    }
-    // Should never reach here (last tier has minVramGb=0), but be safe
-    return "ai/qwen3:4B-UD-Q4_K_XL";
+    return recommendGenerationModel(hwInfo?.vramGb ?? 0);
   } catch {
-    // Can't detect hardware — use the broadly compatible mid-range default
-    return "ai/qwen3:8B-Q4_K_M";
+    return recommendGenerationModel(null);
   }
 }
 
@@ -197,6 +165,24 @@ export async function executeFirstRunBootstrap(
           trigger: "bootstrap",
           skipDiscovery: true,
         });
+
+        // Drift guard: the local runtime keeps only ONE generation model
+        // resident, and two large models over-commit the GPU. Warn (best-effort)
+        // if more than one generation model is already installed so the operator
+        // can prune in the Providers UX. See local-model-policy.ts.
+        try {
+          const installed = (tagsData.models ?? []).map((m) => normaliseModelId(m.name));
+          const hw = await getOllamaHardwareInfo(baseUrl);
+          const verdict = detectLocalModelOverCommit({
+            installedModelIds: installed,
+            vramGb: hw?.vramGb ?? null,
+          });
+          if (verdict.overCommitted) {
+            console.warn(`[bootstrap] Local model over-commit — ${verdict.reason}`);
+          }
+        } catch {
+          // best-effort — never block setup on the drift check
+        }
       } else {
         console.warn("[bootstrap] Ollama not reachable — proceeding without local AI");
       }

--- a/apps/web/lib/inference/local-model-policy.test.ts
+++ b/apps/web/lib/inference/local-model-policy.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  isEmbeddingModelId,
+  classifyLocalModelRole,
+  recommendGenerationModel,
+  estimateModelVramGb,
+  recommendKeepGenerationModel,
+  detectLocalModelOverCommit,
+  normaliseModelId,
+  MAX_CONCURRENT_GENERATION_MODELS,
+} from "./local-model-policy";
+
+describe("classifyLocalModelRole / isEmbeddingModelId", () => {
+  it("classifies embedders", () => {
+    expect(isEmbeddingModelId("ai/nomic-embed-text-v1.5")).toBe(true);
+    expect(isEmbeddingModelId("bge-large")).toBe(true);
+    expect(classifyLocalModelRole("nomic-embed-text-v1.5")).toBe("embedding");
+  });
+  it("classifies generation models", () => {
+    expect(isEmbeddingModelId("qwen3-coder")).toBe(false);
+    expect(isEmbeddingModelId("gemma4:12B")).toBe(false);
+    expect(classifyLocalModelRole("ai/qwen3:8B-Q4_K_M")).toBe("generation");
+  });
+});
+
+describe("recommendGenerationModel", () => {
+  it("null VRAM (undetectable) → broadly-compatible 8B default", () => {
+    expect(recommendGenerationModel(null)).toBe("ai/qwen3:8B-Q4_K_M");
+  });
+  it("0 VRAM (CPU-only host) → 4B tier", () => {
+    expect(recommendGenerationModel(0)).toBe("ai/qwen3:4B-UD-Q4_K_XL");
+  });
+  it("picks the largest tier that fits", () => {
+    expect(recommendGenerationModel(24)).toBe("ai/qwen3.6:35B-A3B-UD-Q4_K_M");
+    expect(recommendGenerationModel(22)).toBe("ai/qwen3.6:35B-A3B-UD-Q4_K_M");
+    expect(recommendGenerationModel(12)).toBe("ai/qwen3:14B-Q6_K");
+    expect(recommendGenerationModel(6)).toBe("ai/qwen3:8B-Q4_K_M");
+    expect(recommendGenerationModel(5)).toBe("ai/qwen3:4B-UD-Q4_K_XL");
+  });
+});
+
+describe("estimateModelVramGb", () => {
+  it("estimates known families", () => {
+    expect(estimateModelVramGb("ai/nomic-embed-text-v1.5")).toBe(1);
+    expect(estimateModelVramGb("qwen3-coder")).toBe(16); // 30B-A3B
+    expect(estimateModelVramGb("ai/qwen3.6:35B-A3B-UD-Q4_K_M")).toBe(22);
+    expect(estimateModelVramGb("gemma4:12B")).toBe(8);
+    expect(estimateModelVramGb("ai/gemma4")).toBe(20);
+    expect(estimateModelVramGb("ai/qwen3:8B-Q4_K_M")).toBe(6);
+  });
+  it("returns null when unknown", () => {
+    expect(estimateModelVramGb("some-mystery-model")).toBeNull();
+  });
+});
+
+describe("normaliseModelId", () => {
+  it("strips docker.io prefix and :latest suffix", () => {
+    expect(normaliseModelId("docker.io/ai/qwen3-coder:latest")).toBe("ai/qwen3-coder");
+    expect(normaliseModelId("ai/gemma4:12B")).toBe("ai/gemma4:12B");
+  });
+});
+
+describe("recommendKeepGenerationModel", () => {
+  it("prefers a coder model (Build Studio codegen use)", () => {
+    const keep = recommendKeepGenerationModel(["ai/gemma4:12B", "qwen3-coder"], 24);
+    expect(keep).toBe("qwen3-coder");
+  });
+  it("falls back to the hardware-recommended tier", () => {
+    const keep = recommendKeepGenerationModel(["ai/qwen3:8B-Q4_K_M", "ai/qwen3:14B-Q6_K"], 12);
+    expect(keep).toBe("ai/qwen3:14B-Q6_K");
+  });
+  it("returns the single model unchanged", () => {
+    expect(recommendKeepGenerationModel(["ai/qwen3:8B-Q4_K_M"], 24)).toBe("ai/qwen3:8B-Q4_K_M");
+  });
+});
+
+describe("detectLocalModelOverCommit", () => {
+  it("one generation model + embedder is healthy", () => {
+    const v = detectLocalModelOverCommit({
+      installedModelIds: ["qwen3-coder", "ai/nomic-embed-text-v1.5"],
+      vramGb: 24,
+    });
+    expect(v.overCommitted).toBe(false);
+    expect(v.generationModelIds).toEqual(["qwen3-coder"]);
+    expect(v.embeddingModelIds).toEqual(["ai/nomic-embed-text-v1.5"]);
+    expect(v.removeCandidates).toEqual([]);
+  });
+
+  it("two generation models over-commit; recommends keeping the coder", () => {
+    // The exact scenario from the build host: gemma4 chat + qwen3-coder + embedder.
+    const v = detectLocalModelOverCommit({
+      installedModelIds: ["ai/gemma4:12B", "qwen3-coder", "ai/nomic-embed-text-v1.5"],
+      vramGb: 24,
+    });
+    expect(v.overCommitted).toBe(true);
+    expect(v.recommendedKeep).toBe("qwen3-coder");
+    expect(v.removeCandidates).toEqual(["ai/gemma4:12B"]);
+    expect(v.reason).toContain("generation models are installed");
+  });
+
+  it("flags a single model that exceeds the VRAM budget", () => {
+    const v = detectLocalModelOverCommit({
+      installedModelIds: ["ai/qwen3.6:35B-A3B-UD-Q4_K_M", "ai/nomic-embed-text-v1.5"],
+      vramGb: 12,
+    });
+    expect(v.overCommitted).toBe(true);
+    expect(v.reason).toContain("VRAM");
+  });
+
+  it("honors the single-generation-model ceiling constant", () => {
+    expect(MAX_CONCURRENT_GENERATION_MODELS).toBe(1);
+  });
+
+  it("does not over-flag when VRAM is undetected and only one generation model exists", () => {
+    const v = detectLocalModelOverCommit({
+      installedModelIds: ["ai/qwen3:8B-Q4_K_M"],
+      vramGb: null,
+    });
+    expect(v.overCommitted).toBe(false);
+  });
+});

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -139,11 +139,13 @@ export function recommendKeepGenerationModel(
   const coder = generationModelIds.find((m) => /coder|[-_]code\b|code[-_]/i.test(m));
   if (coder) return coder;
 
-  const recommended = recommendGenerationModel(vramGb);
-  const recNorm = normaliseModelId(recommended);
-  const matchesRecommended = generationModelIds.find(
-    (m) => normaliseModelId(m) === recNorm || m.includes(recNorm.split(":")[0] ?? ""),
-  );
+  // Exact tier match, tolerating a missing/added `ai/` vendor prefix and the
+  // docker.io/ + :latest decorations normaliseModelId strips. Must NOT match on
+  // family alone — every qwen3 tier shares the `ai/qwen3` prefix, so a substring
+  // match would wrongly keep the first (often smallest) tier.
+  const stripVendor = (s: string) => normaliseModelId(s).replace(/^ai\//, "");
+  const recKey = stripVendor(recommendGenerationModel(vramGb));
+  const matchesRecommended = generationModelIds.find((m) => stripVendor(m) === recKey);
   if (matchesRecommended) return matchesRecommended;
 
   // Largest that fits the budget (or just largest when budget unknown).

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -1,0 +1,239 @@
+// apps/web/lib/inference/local-model-policy.ts
+//
+// SINGLE SOURCE OF TRUTH for the bundled local-model policy: which generation
+// model a host should run, how to tell a generation model from an embedder, and
+// — critically — whether the set of installed models OVER-COMMITS the GPU.
+//
+// WHY THIS EXISTS: model selection was duplicated across four places that drifted
+// out of sync, so a host accumulated MULTIPLE large generation models that cannot
+// co-reside on one GPU (e.g. a 12B chat model + a 30B coder model on a 24 GB card):
+//   1. scripts/detect-hardware-host.ts   (install-time selectedModel)
+//   2. install-dpf.ps1 / install-dpf.sh  (install-time pull)
+//   3. bootstrap-first-run.ts            (first-run auto-pull)
+//   4. components/platform/OllamaManagement.tsx (browse/manage catalog)
+// Each picked a model independently; nothing enforced "ONE generation model at a
+// time" or noticed when two had accumulated. Docker Model Runner loads one
+// `llama-server` per model with no concurrency cap, so two big models thrash /
+// OOM the GPU. This module centralises the policy; bootstrap + the Providers UX
+// import it, and the install scripts (which cannot import TS) mirror LOCAL_MODEL_TIERS
+// with a pointer comment. detectLocalModelOverCommit() is the drift safety-net.
+//
+// PURE module — no prisma / fs / network / server-only imports — so the client
+// OllamaManagement component can import it directly.
+
+/**
+ * Policy: the local runtime keeps at most ONE generation (chat/coder) model
+ * resident, plus the small embedder. Two large generation models do not fit a
+ * single consumer GPU and are the root cause of the VRAM-exhaustion this module
+ * guards against.
+ */
+export const MAX_CONCURRENT_GENERATION_MODELS = 1;
+
+/** Canonical embedding model id (OpenAI-tag / DMR pull form). */
+export const EMBEDDING_MODEL_ID = "ai/nomic-embed-text-v1.5";
+
+// Non-chat model families a local OpenAI-compatible endpoint commonly serves
+// (embeddings, rerankers, STT/TTS, vision-embed). These cannot run a chat or
+// coding agent loop, so they do NOT count toward the generation-model budget.
+// Canonical home — opencode-dispatch.ts re-exports isEmbeddingModelId from here.
+export const NON_CHAT_MODEL_RE =
+  /embed|nomic|bge[-_]|rerank|whisper|\bstt\b|\btts\b|clip|vision-embed|minilm|gte|e5/i;
+
+/**
+ * True when a model id looks like an embedding / non-chat model. Used both to
+ * warn an operator who selected one for code generation and to exclude embedders
+ * from the single-generation-model budget.
+ */
+export function isEmbeddingModelId(modelId: string): boolean {
+  return NON_CHAT_MODEL_RE.test(modelId);
+}
+
+export type LocalModelRole = "generation" | "embedding";
+
+/** Classify a model id as a generation (chat/coder) model or an embedder. */
+export function classifyLocalModelRole(modelId: string): LocalModelRole {
+  return isEmbeddingModelId(modelId) ? "embedding" : "generation";
+}
+
+/**
+ * Canonical generation-model tiers, ordered largest-first. Qwen3 — NOT Gemma —
+ * because the platform's Coworkers catalog tiers Qwen3 as `strong + Tool Use`
+ * (F1 0.93 @ 8B, 0.97 @ 14B) while Gemma tiers as `adequate`, and default
+ * coworkers require `minimumTier: strong`.
+ *
+ * `minVramGb` is the discrete-VRAM floor; `approxVramGb` is the resident
+ * footprint used for the over-commit budget. Mirrored (with a pointer comment)
+ * by scripts/detect-hardware-host.ts and install-dpf.{ps1,sh}, which cannot
+ * import TypeScript. Keep those in sync when this changes.
+ */
+export interface LocalModelTier {
+  model: string;
+  minVramGb: number;
+  approxVramGb: number;
+  label: string;
+}
+
+export const LOCAL_MODEL_TIERS: readonly LocalModelTier[] = [
+  { model: "ai/qwen3.6:35B-A3B-UD-Q4_K_M", minVramGb: 22, approxVramGb: 22, label: "Qwen3.6 35B-A3B (MoE)" },
+  { model: "ai/qwen3:14B-Q6_K", minVramGb: 12, approxVramGb: 12, label: "Qwen3 14B" },
+  { model: "ai/qwen3:8B-Q4_K_M", minVramGb: 6, approxVramGb: 6, label: "Qwen3 8B" },
+  { model: "ai/qwen3:4B-UD-Q4_K_XL", minVramGb: 0, approxVramGb: 3, label: "Qwen3 4B" },
+] as const;
+
+/**
+ * Select the largest generation tier that fits available VRAM. Walks the tier
+ * list top-down and returns the first whose `minVramGb` floor is satisfied.
+ *
+ * Semantics (preserve the prior bootstrap behaviour exactly):
+ *   - `null`  → VRAM is UNDETECTABLE → broadly-compatible mid default (8B).
+ *   - `0`     → detected zero VRAM (CPU-only host) → the CPU-OK 4B tier.
+ *   - `n > 0` → largest tier whose floor `n` satisfies.
+ */
+export function recommendGenerationModel(vramGb: number | null): string {
+  if (vramGb === null) return "ai/qwen3:8B-Q4_K_M";
+  for (const tier of LOCAL_MODEL_TIERS) {
+    if (vramGb >= tier.minVramGb) return tier.model;
+  }
+  return "ai/qwen3:4B-UD-Q4_K_XL";
+}
+
+/**
+ * Best-effort resident VRAM estimate (GB) for a model id, from known families /
+ * parameter-size hints. Returns null when the size can't be inferred — callers
+ * must treat null as "unknown, still counts as one generation model" rather than
+ * zero. Approximate by design; used only for the budget heuristic and display.
+ */
+export function estimateModelVramGb(modelId: string): number | null {
+  const id = modelId.toLowerCase();
+  if (isEmbeddingModelId(id)) return 1;
+  // qwen3-coder's short DMR name carries no size hint but is the 30B-A3B build
+  // model (observed ~16.5 GB resident). Match it explicitly before param-size.
+  if (/qwen3-coder/.test(id)) return 16;
+  if (/35b/.test(id)) return 22;
+  if (/30b/.test(id)) return 16; // qwen3 30B-A3B observed ~16.5 GB
+  if (/gemma.?4|gemma.?3/.test(id)) return /12b/.test(id) ? 8 : 20;
+  if (/14b/.test(id)) return /coder|qwen2\.5/.test(id) ? 10 : 12;
+  if (/8b/.test(id)) return 6;
+  if (/7b/.test(id)) return 6;
+  if (/4b/.test(id)) return 3;
+  return null;
+}
+
+/** Strip the `docker.io/` prefix and `:latest` suffix DMR adds, for matching. */
+export function normaliseModelId(name: string): string {
+  return name.replace(/^docker\.io\//, "").replace(/:latest$/, "");
+}
+
+/**
+ * Among installed generation models, choose the single one to KEEP. Prefers a
+ * coder model (Build Studio's code-generation use), then the tier the hardware
+ * recommends, then the largest that still fits the budget, else the first.
+ */
+export function recommendKeepGenerationModel(
+  generationModelIds: string[],
+  vramGb: number | null,
+): string | null {
+  if (generationModelIds.length === 0) return null;
+  if (generationModelIds.length === 1) return generationModelIds[0]!;
+
+  const coder = generationModelIds.find((m) => /coder|[-_]code\b|code[-_]/i.test(m));
+  if (coder) return coder;
+
+  const recommended = recommendGenerationModel(vramGb);
+  const recNorm = normaliseModelId(recommended);
+  const matchesRecommended = generationModelIds.find(
+    (m) => normaliseModelId(m) === recNorm || m.includes(recNorm.split(":")[0] ?? ""),
+  );
+  if (matchesRecommended) return matchesRecommended;
+
+  // Largest that fits the budget (or just largest when budget unknown).
+  const budget = vramGb && vramGb > 0 ? vramGb : Infinity;
+  const sized = generationModelIds
+    .map((m) => ({ m, gb: estimateModelVramGb(m) ?? 0 }))
+    .sort((a, b) => b.gb - a.gb);
+  const largestFitting = sized.find((s) => s.gb <= budget);
+  return (largestFitting ?? sized[0])!.m;
+}
+
+export interface OverCommitVerdict {
+  /** True when the installed model set exceeds the single-generation-model policy or the VRAM budget. */
+  overCommitted: boolean;
+  /** Why — surfaced verbatim in the Providers UX. Empty string when not over-committed. */
+  reason: string;
+  generationModelIds: string[];
+  embeddingModelIds: string[];
+  /** The one generation model to keep (when over-committed by count); null otherwise. */
+  recommendedKeep: string | null;
+  /** Generation models that should be removed to satisfy the policy. */
+  removeCandidates: string[];
+  /** Summed resident estimate (GB) of all generation models, when estimable. */
+  estimatedGenerationVramGb: number | null;
+  /** The VRAM budget used for the check (host VRAM), or null when undetected. */
+  budgetVramGb: number | null;
+}
+
+/**
+ * Decide whether the set of installed local models over-commits the host:
+ *  - more than ONE generation model installed (the policy ceiling), OR
+ *  - the summed resident estimate of generation models exceeds detected VRAM.
+ *
+ * The embedder is always allowed alongside the single generation model. This is
+ * the drift safety-net: regardless of which selection path pulled a second big
+ * model, the Providers UX and bootstrap surface it from here.
+ */
+export function detectLocalModelOverCommit(args: {
+  installedModelIds: string[];
+  vramGb: number | null;
+}): OverCommitVerdict {
+  const { installedModelIds, vramGb } = args;
+  const generationModelIds = installedModelIds.filter((m) => !isEmbeddingModelId(m));
+  const embeddingModelIds = installedModelIds.filter((m) => isEmbeddingModelId(m));
+
+  const estimates = generationModelIds.map((m) => estimateModelVramGb(m));
+  const allKnown = estimates.every((e) => e !== null);
+  const estimatedGenerationVramGb = allKnown
+    ? estimates.reduce((sum, e) => sum + (e ?? 0), 0)
+    : null;
+
+  const tooMany = generationModelIds.length > MAX_CONCURRENT_GENERATION_MODELS;
+  const budgetVramGb = vramGb && vramGb > 0 ? vramGb : null;
+  // Reserve ~1 GB for the embedder when computing headroom.
+  const overBudget =
+    budgetVramGb !== null &&
+    estimatedGenerationVramGb !== null &&
+    estimatedGenerationVramGb + (embeddingModelIds.length > 0 ? 1 : 0) > budgetVramGb;
+
+  const recommendedKeep = tooMany
+    ? recommendKeepGenerationModel(generationModelIds, vramGb)
+    : null;
+  const removeCandidates =
+    tooMany && recommendedKeep
+      ? generationModelIds.filter((m) => m !== recommendedKeep)
+      : [];
+
+  let reason = "";
+  if (tooMany) {
+    const keepLabel = recommendedKeep ? normaliseModelId(recommendedKeep) : "one";
+    reason =
+      `${generationModelIds.length} generation models are installed, but the local runtime ` +
+      `keeps only one resident at a time` +
+      (budgetVramGb ? ` (a ${budgetVramGb} GB GPU cannot hold two large models)` : "") +
+      `. Keep ${keepLabel} and remove the rest to stop them competing for VRAM.`;
+  } else if (overBudget) {
+    reason =
+      `The installed generation model needs about ${estimatedGenerationVramGb} GB but only ` +
+      `${budgetVramGb} GB of VRAM was detected — it will spill to system RAM and run slowly. ` +
+      `Choose a smaller tier for this hardware.`;
+  }
+
+  return {
+    overCommitted: tooMany || overBudget,
+    reason,
+    generationModelIds,
+    embeddingModelIds,
+    recommendedKeep,
+    removeCandidates,
+    estimatedGenerationVramGb,
+    budgetVramGb,
+  };
+}

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -25,6 +25,7 @@
 import type { AssignedTask, SpecialistRole } from "./task-dependency-graph";
 import { getOllamaBaseUrl } from "@/lib/inference/ollama-url";
 import { getServedContextTokens } from "@/lib/inference/dmr-runtime-config";
+import { NON_CHAT_MODEL_RE, isEmbeddingModelId } from "@/lib/inference/local-model-policy";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
 import { sanitizeForLog } from "@/lib/security/safe-log";
@@ -76,18 +77,10 @@ export type LocalEndpointPreflight = {
   warnings?: string[];
 };
 
-// Non-chat model families a local OpenAI-compatible endpoint commonly also
-// serves (embeddings, rerankers, STT/TTS). These cannot run a coding agent
-// loop. Single source of truth for pickDefaultCodingModel + isEmbeddingModelId.
-const NON_CHAT_MODEL_RE = /embed|nomic|bge[-_]|rerank|whisper|\bstt\b|\btts\b|clip|vision-embed|minilm|gte|e5/i;
-
-/**
- * True when a model id looks like an embedding / non-chat model that cannot run
- * a coding agent. Used to warn an operator who selected one explicitly.
- */
-export function isEmbeddingModelId(modelId: string): boolean {
-  return NON_CHAT_MODEL_RE.test(modelId);
-}
+// Embedding / non-chat classification is owned by the canonical local-model
+// policy module (imported above). Re-exported here so existing importers (tests,
+// the Runtime Health view) and this file's own callers keep their import path.
+export { isEmbeddingModelId };
 
 /**
  * Rewrite the portal's view of the local endpoint into one the sandbox

--- a/docs/superpowers/specs/2026-06-19-local-model-policy-single-generation.md
+++ b/docs/superpowers/specs/2026-06-19-local-model-policy-single-generation.md
@@ -1,0 +1,90 @@
+# Single-generation-model policy for the bundled local runtime
+
+**Date:** 2026-06-19
+**Status:** Implemented (runtime surfaces + drift guard); install-script value reconciliation deferred
+**Backlog:** BI-0B893092 (durable platform fix)
+**Related:** `2026-06-10-local-llm-build-agent-design.md` (OpenCode local build agent)
+
+## Problem
+
+The bundled local AI runtime (Docker Model Runner on Docker Desktop; Ollama on
+native Linux) loads **one `llama-server` process per model with no concurrency
+cap**. On a real build host this accumulated **three** models for three jobs —
+`gemma4:12B` (chat), `qwen3-coder` 30B (Build Studio codegen), `nomic-embed`
+(embeddings) — and the two large generation models over-committed a 24 GB GPU
+(18/24 GB resident; `qwen3-coder` alone ~16 GB), thrashing into system RAM.
+
+Root cause: **model selection was duplicated across four mechanisms that drifted
+out of sync**, and nothing enforced "one generation model at a time" or noticed
+when two had accumulated:
+
+1. `scripts/detect-hardware-host.ts` — install-time `selectedModel` (host profile)
+2. `install-dpf.ps1` / `install-dpf.sh` — install-time pull
+3. `apps/web/lib/inference/bootstrap-first-run.ts` — first-run auto-pull
+4. `apps/web/components/platform/OllamaManagement.tsx` — browse/manage catalog
+
+(The host that hit this had `selectedModel = ai/gemma4` from an older detector,
+plus `qwen3-coder` pinned by Build Studio's dispatch config — two large models,
+neither aware of the other.)
+
+## Policy
+
+- The local runtime keeps **at most ONE generation (chat/coder) model** resident,
+  plus the small embedder. `MAX_CONCURRENT_GENERATION_MODELS = 1`.
+- The **same** generation model serves both chat/reasoning fallback and Build
+  Studio code generation — do not run a separate chat model and coder model.
+- The embedder (`ai/nomic-embed-text-v1.5`) is always allowed alongside the one
+  generation model (it is tiny and required for memory/RAG).
+
+## Design — `apps/web/lib/inference/local-model-policy.ts`
+
+A new **pure, client-safe** module is the single source of truth:
+
+- `LOCAL_MODEL_TIERS` — canonical generation tiers (Qwen3 family, largest-first).
+- `recommendGenerationModel(vramGb)` — largest tier that fits; `null` (undetectable)
+  → 8B default, `0` (CPU-only) → 4B.
+- `isEmbeddingModelId` / `classifyLocalModelRole` — generation vs embedder. The
+  canonical `NON_CHAT_MODEL_RE` now lives here; `opencode-dispatch.ts` imports and
+  re-exports it (was a second copy).
+- `estimateModelVramGb(modelId)` — best-effort resident footprint for budgeting.
+- `detectLocalModelOverCommit({ installedModelIds, vramGb })` — the **drift
+  safety-net**: over-committed when more than one generation model is installed,
+  or when the generation footprint exceeds detected VRAM. Returns the model to
+  keep (prefers a coder model) and the ones to remove.
+
+## Surfaces wired
+
+- **Install / first-run** (`bootstrap-first-run.ts`): uses the shared tiers +
+  `recommendGenerationModel` (deleted its private `MODEL_TIERS`), and runs a
+  best-effort `detectLocalModelOverCommit` drift check after activation, logging
+  a warning when a host already has more than one generation model.
+- **Providers UX** (`OllamaManagement.tsx`): renders an over-commit warning banner
+  (which model to keep, one-click Remove for the extras) and an "extra ·
+  over-commit" badge on the redundant model rows. Uses the shared verdict; the
+  duplicate local `normaliseModelId` was removed.
+- **Codegen classifier** (`opencode-dispatch.ts`): `isEmbeddingModelId` /
+  `NON_CHAT_MODEL_RE` now sourced from the policy module (dedupe).
+
+## Deliberately out of scope (follow-ups under BI-0B893092)
+
+- **Install-script values are still mirrored, not imported** — shell / the
+  `@dpf/db`-context detector cannot import the apps/web TS module, so
+  `LOCAL_MODEL_TIERS` is duplicated there with a pointer comment. The over-commit
+  guard catches any resulting drift.
+- **Known tier-value divergence:** the detector's discrete top tier is `qwen3:30B-A3B`
+  (~16 GB, safe headroom on a 24 GB card) while the canonical/bootstrap top tier
+  is `qwen3.6:35B-A3B` (~22 GB, which itself nearly fills a 24 GB card). The tier
+  *headroom* (floor ≈ model size, leaving little for KV cache + embedder) should be
+  recalibrated as a separate change so a recommended model never over-commits.
+- **Real-time loaded-state in the UX:** `getOllamaRunningModels()` returns `[]` on
+  DMR (it predates `docker model ps`); the over-commit check therefore runs on
+  *installed* models, which is sufficient for the policy but does not show live
+  VRAM. Wiring live loaded-state is a follow-up.
+- **DMR concurrency cap / idle-TTL tuning** at the runtime level (vs. the
+  model-set policy enforced here).
+
+## Interim host remediation (already applied)
+
+On the affected build host: removed `gemma4:12B` (qwen3-coder now serves chat +
+codegen), reconciled `.env`/`.host-profile.json` `selectedModel → ai/qwen3-coder`,
+unloaded resident models. VRAM 18 → 1.1 GB used; system RAM freed ~22 GB.

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1558,7 +1558,10 @@ if (-not (Test-StepDone "hardware")) {
     Write-OK $hwSummary
 
     # Select the largest strong tool-calling model that fits available VRAM/RAM.
-    # Mirrors the tiers in bootstrap-first-run.ts + detect-hardware-host.ts.
+    # Mirrors the CANONICAL tiers in apps/web/lib/inference/local-model-policy.ts
+    # (LOCAL_MODEL_TIERS) — PowerShell cannot import TS, so keep this in sync.
+    # The Providers UX over-commit guard (same module) catches any drift that
+    # leaves a host with more than one generation model installed.
     # We now prefer the Qwen3.6 35B-A3B (what the Docker UI calls ai/qwen3.6:latest
     # when you have plenty of memory) for the top tier. It is the current best
     # published option in the ai/ runner namespace for agentic work.

--- a/scripts/detect-hardware-host.ts
+++ b/scripts/detect-hardware-host.ts
@@ -166,8 +166,14 @@ function detectLinux(): HostProfile {
   };
 }
 
-// Model selection mirrors install-dpf.ps1's tiers (verified against the
-// canonical MODEL_TIERS in apps/web/lib/inference/bootstrap-first-run.ts).
+// Model selection mirrors the CANONICAL tiers in
+// apps/web/lib/inference/local-model-policy.ts (LOCAL_MODEL_TIERS). This script
+// runs via tsx in the @dpf/db context and cannot import the apps/web module, so
+// the list is duplicated here — keep it in sync. The Providers UX over-commit
+// guard (same module) catches drift. KNOWN follow-up: the discrete top tier
+// below is 30B-A3B (~16 GB, safe headroom on a 24 GB card) while the canonical
+// top tier is 35B-A3B (~22 GB); reconcile when tier headroom is recalibrated
+// (tracked in BI-0B893092).
 // Qwen3 — NOT Gemma — because the platform's Coworkers catalog tiers Qwen3
 // as `strong + Tool Use` (F1 0.93 @ 8B, 0.97 @ 14B) while Gemma 3/4 tiers
 // as `adequate`. Default coworkers have `minimumTier: strong`, so a Gemma


### PR DESCRIPTION
## Why

The bundled local AI runtime (Docker Model Runner) loads **one `llama-server` per model with no concurrency cap**, and model selection was duplicated across **four mechanisms that drifted out of sync**. A real build host accumulated three models (`gemma4:12B` chat + `qwen3-coder` 30B codegen + `nomic-embed`); the two large generation models over-committed the 24 GB GPU (18/24 GB resident, thrashing into system RAM). A customer on an 8–12 GB GPU would OOM far worse.

This makes the **single-generation-model policy** a first-class, enforced concept across install and the Providers UX, so the over-commit can't silently recur.

Fixes the durable platform half of **BI-0B893092** (the host itself was already remediated by hand).

## What

- **New canonical `apps/web/lib/inference/local-model-policy.ts`** (pure, client-safe) — the single source of truth:
  - `LOCAL_MODEL_TIERS`, `recommendGenerationModel(vramGb)` (null→8B, 0→4B CPU, n→largest fit)
  - `isEmbeddingModelId` / `classifyLocalModelRole`, `estimateModelVramGb`
  - `detectLocalModelOverCommit({ installedModelIds, vramGb })` — the **drift safety-net** (more than one generation model installed, or footprint > VRAM); returns which to keep (prefers a coder model) and which to remove.
- **Install / first-run** (`bootstrap-first-run.ts`): uses the shared tiers + recommender (deleted its private `MODEL_TIERS`); logs a post-activation over-commit warning.
- **Providers UX** (`OllamaManagement.tsx`): over-commit **warning banner** (keep X, one-click Remove the extras) + per-row `extra · over-commit` badge.
- **Codegen classifier** (`opencode-dispatch.ts`): `NON_CHAT_MODEL_RE` / `isEmbeddingModelId` now sourced from the policy module (removed the duplicate copy; re-exported for back-compat).
- **Install scripts** (`install-dpf.ps1`, `detect-hardware-host.ts`): pointer comments to the canonical tiers (shell/`@dpf/db`-context can't import TS); the known `30B`-vs-`35B` discrete-tier divergence is flagged for follow-up.
- **Tests**: unit tests for the policy module (pure functions). **Design note** under `docs/superpowers/specs/`.

## Out of scope (follow-ups under BI-0B893092)

- Install-script tier *values* still mirrored (can't import TS) — the over-commit guard catches drift.
- Tier **headroom recalibration** (a recommended `35B`/22 GB model nearly fills a 24 GB card).
- Real-time loaded-state in the UX (`getOllamaRunningModels()` returns `[]` on DMR; the guard runs on *installed* models).
- DMR runtime concurrency-cap / idle-TTL tuning.

## Verification

Local typecheck/tests couldn't run (worktree `node_modules` is empty — known env regression); committed with `DPF_SKIP_TYPECHECK=1` and relying on CI. The policy module is pure and fully unit-tested; logic traced by hand against the real host scenario (gemma4 + qwen3-coder + nomic → over-committed, keep qwen3-coder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)