### PR TITLE
fix: open-issue sweep — install resilience (#1767) + archetype-reset identity (#1748)

### DIFF
--- a/apps/web/app/api/storefront/admin/archetype-reset/route.test.ts
+++ b/apps/web/app/api/storefront/admin/archetype-reset/route.test.ts
@@ -65,4 +65,20 @@ describe("POST /api/storefront/admin/archetype-reset", () => {
       mode: "replace-seeded-content",
     });
   });
+
+  it("passes operator identity through to the reset when supplied", async () => {
+    const identity = {
+      orgName: "Riverside Electric Co.",
+      slug: "riverside-electric",
+      tagline: "Licensed electricians",
+    };
+    const res = await POST(makeReq({ targetArchetypeId: "electrician", identity }));
+    expect(res.status).toBe(200);
+    expect(mockReset).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      targetArchetypeId: "electrician",
+      mode: "replace-seeded-content",
+      identity,
+    });
+  });
 });

--- a/apps/web/app/api/storefront/admin/archetype-reset/route.ts
+++ b/apps/web/app/api/storefront/admin/archetype-reset/route.ts
@@ -9,9 +9,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { targetArchetypeId } = (await req.json()) as {
+  const body = (await req.json()) as {
     targetArchetypeId?: string;
+    // Optional operator-owned identity to apply during the swap (company name,
+    // URL slug, hero tagline). Omitted fields are preserved and reported back in
+    // result.identity / result.warnings so the operator can update them. (#1748)
+    identity?: { orgName?: string; slug?: string; tagline?: string };
   };
+  const { targetArchetypeId, identity } = body;
 
   if (!targetArchetypeId) {
     return NextResponse.json({ error: "targetArchetypeId is required" }, { status: 400 });
@@ -30,6 +35,7 @@ export async function POST(req: NextRequest) {
       organizationId: organization.id,
       targetArchetypeId,
       mode: "replace-seeded-content",
+      ...(identity ? { identity } : {}),
     });
 
     return NextResponse.json({ success: true, result });

--- a/apps/web/lib/storefront/archetype-reset.test.ts
+++ b/apps/web/lib/storefront/archetype-reset.test.ts
@@ -255,6 +255,199 @@ describe("resetStorefrontArchetype", () => {
     });
   });
 
+  it("preserves operator-owned identity and reports it when none is supplied (AUDIT-R1S-001)", async () => {
+    const tx = {
+      orgSettings: { findFirst: vi.fn().mockResolvedValue({ baseCurrency: "USD" }) },
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "org_1",
+          name: "Riverside Plumbing Solutions",
+          slug: "riverside-plumbing-solutions",
+        }),
+        findFirst: vi.fn().mockResolvedValue(null),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "sf_1",
+          organizationId: "org_1",
+          tagline: "Fast, reliable plumbing for homes and businesses in Riverside",
+        }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      businessContext: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      storefrontArchetype: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "arch_1",
+          archetypeId: "electrician",
+          category: "trades-maintenance",
+          ctaType: "inquiry",
+          sectionTemplates: [{ type: "hero", title: "Hero", sortOrder: 0 }],
+          itemTemplates: [{ name: "Panel upgrade", priceType: "quote", ctaType: "inquiry" }],
+        }),
+      },
+      storefrontSection: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      storefrontItem: {
+        findMany: vi.fn().mockResolvedValue([]),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      providerService: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      bookingHold: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      businessCapability: businessCapabilityProjectionStore(),
+    };
+    mockPrisma.$transaction.mockImplementation(async (fn: (trx: typeof tx) => Promise<unknown>) => fn(tx));
+
+    const result = await resetStorefrontArchetype({
+      organizationId: "org_1",
+      targetArchetypeId: "electrician",
+      mode: "replace-seeded-content",
+    });
+
+    // Identity is operator-owned, so the swap must NOT auto-clobber it...
+    expect(tx.organization.update).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      data: { industry: "trades-maintenance" },
+    });
+    expect(tx.organization.findFirst).not.toHaveBeenCalled();
+    // ...but it MUST be reported so the caller can prompt the operator instead
+    // of silently presenting the prior identity to customers (AUDIT-R1S-001).
+    expect(result.identity.updated).toEqual([]);
+    expect(result.identity.preserved).toEqual(["orgName", "slug", "tagline"]);
+    expect(result.identity.orgName).toBe("Riverside Plumbing Solutions");
+    expect(result.identity.slug).toBe("riverside-plumbing-solutions");
+    expect(result.warnings.some((w) => /preserved across the archetype change/i.test(w))).toBe(true);
+  });
+
+  it("applies supplied identity (name, slug, tagline) and marks them updated", async () => {
+    const tx = {
+      orgSettings: { findFirst: vi.fn().mockResolvedValue({ baseCurrency: "USD" }) },
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "org_1",
+          name: "Riverside Plumbing Solutions",
+          slug: "riverside-plumbing-solutions",
+        }),
+        findFirst: vi.fn().mockResolvedValue(null), // requested slug is free
+        update: vi.fn().mockResolvedValue({}),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn().mockResolvedValue({ id: "sf_1", organizationId: "org_1", tagline: "old" }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      businessContext: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      storefrontArchetype: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "arch_1",
+          archetypeId: "electrician",
+          category: "trades-maintenance",
+          ctaType: "inquiry",
+          sectionTemplates: [{ type: "hero", title: "Hero", sortOrder: 0 }],
+          itemTemplates: [{ name: "Panel upgrade", priceType: "quote", ctaType: "inquiry" }],
+        }),
+      },
+      storefrontSection: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      storefrontItem: {
+        findMany: vi.fn().mockResolvedValue([]),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      providerService: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      bookingHold: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      businessCapability: businessCapabilityProjectionStore(),
+    };
+    mockPrisma.$transaction.mockImplementation(async (fn: (trx: typeof tx) => Promise<unknown>) => fn(tx));
+
+    const result = await resetStorefrontArchetype({
+      organizationId: "org_1",
+      targetArchetypeId: "electrician",
+      mode: "replace-seeded-content",
+      identity: {
+        orgName: "Riverside Electric Co.",
+        slug: "riverside-electric",
+        tagline: "Licensed electricians for homes and businesses",
+      },
+    });
+
+    expect(tx.organization.findFirst).toHaveBeenCalledWith({
+      where: { slug: "riverside-electric", NOT: { id: "org_1" } },
+      select: { id: true },
+    });
+    expect(tx.organization.update).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      data: { industry: "trades-maintenance", name: "Riverside Electric Co.", slug: "riverside-electric" },
+    });
+    expect(tx.storefrontConfig.update).toHaveBeenCalledWith({
+      where: { id: "sf_1" },
+      data: { archetypeId: "arch_1", tagline: "Licensed electricians for homes and businesses" },
+    });
+    expect([...result.identity.updated].sort()).toEqual(["orgName", "slug", "tagline"]);
+    expect(result.identity.preserved).toEqual([]);
+    expect(result.identity.orgName).toBe("Riverside Electric Co.");
+    expect(result.identity.slug).toBe("riverside-electric");
+    expect(result.identity.tagline).toBe("Licensed electricians for homes and businesses");
+  });
+
+  it("does not overwrite a slug already taken by another org", async () => {
+    const tx = {
+      orgSettings: { findFirst: vi.fn().mockResolvedValue({ baseCurrency: "USD" }) },
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({ id: "org_1", name: "Acme", slug: "acme" }),
+        findFirst: vi.fn().mockResolvedValue({ id: "org_2" }), // requested slug is taken
+        update: vi.fn().mockResolvedValue({}),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn().mockResolvedValue({ id: "sf_1", organizationId: "org_1", tagline: null }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      businessContext: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      storefrontArchetype: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "arch_1",
+          archetypeId: "electrician",
+          category: "trades-maintenance",
+          ctaType: "inquiry",
+          sectionTemplates: [],
+          itemTemplates: [],
+        }),
+      },
+      storefrontSection: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      storefrontItem: {
+        findMany: vi.fn().mockResolvedValue([]),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      providerService: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      bookingHold: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      businessCapability: businessCapabilityProjectionStore(),
+    };
+    mockPrisma.$transaction.mockImplementation(async (fn: (trx: typeof tx) => Promise<unknown>) => fn(tx));
+
+    const result = await resetStorefrontArchetype({
+      organizationId: "org_1",
+      targetArchetypeId: "electrician",
+      mode: "replace-seeded-content",
+      identity: { slug: "taken-slug" },
+    });
+
+    expect(tx.organization.update).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      data: { industry: "trades-maintenance" },
+    });
+    expect(result.identity.slug).toBe("acme");
+    expect(result.identity.updated).not.toContain("slug");
+    expect(result.warnings.some((w) => /already in use/i.test(w))).toBe(true);
+  });
+
   it("refuses to run when the target archetype is missing", async () => {
     const tx = {
       organization: {

--- a/apps/web/lib/storefront/archetype-reset.ts
+++ b/apps/web/lib/storefront/archetype-reset.ts
@@ -6,17 +6,35 @@ import { seedBookingScheduleDefaults } from "./seed-booking-defaults";
 
 type ResetMode = "replace-seeded-content";
 
+/** Operator-owned business identity that survives an archetype change. */
+const IDENTITY_FIELDS = ["orgName", "slug", "tagline"] as const;
+type IdentityField = (typeof IDENTITY_FIELDS)[number];
+
 export async function resetStorefrontArchetype(input: {
   organizationId: string;
   targetArchetypeId: string;
   mode: ResetMode;
+  /**
+   * Operator-owned business identity (company name, URL slug, hero tagline).
+   * Archetypes carry NO default values for these, so an archetype swap never
+   * auto-derives them — doing so would clobber the operator's real business
+   * identity (or blank it). When a caller (e.g. a "change archetype" UI) has
+   * collected new values it can pass them here to perform a full swap; anything
+   * omitted is preserved and reported in `result.identity` + `result.warnings`
+   * so the operator can update it themselves. (AUDIT-R1S-001 / #1748)
+   */
+  identity?: {
+    orgName?: string;
+    slug?: string;
+    tagline?: string;
+  };
 }) {
-  const { organizationId, targetArchetypeId, mode } = input;
+  const { organizationId, targetArchetypeId, mode, identity } = input;
 
   return prisma.$transaction(async (tx) => {
     const organization = await tx.organization.findUnique({
       where: { id: organizationId },
-      select: { id: true, name: true },
+      select: { id: true, name: true, slug: true },
     });
 
     if (!organization) {
@@ -25,7 +43,7 @@ export async function resetStorefrontArchetype(input: {
 
     const storefront = await tx.storefrontConfig.findUnique({
       where: { organizationId },
-      select: { id: true, organizationId: true },
+      select: { id: true, organizationId: true, tagline: true },
     });
 
     if (!storefront) {
@@ -48,14 +66,59 @@ export async function resetStorefrontArchetype(input: {
       throw new Error(`Target archetype ${targetArchetypeId} not found`);
     }
 
+    // Resolve operator-owned identity. Only values the caller explicitly
+    // supplied are applied; everything else is preserved and reported below so
+    // the public storefront never silently presents the prior archetype's
+    // identity to customers without the operator being told. (AUDIT-R1S-001)
+    const warnings: string[] = [];
+    const identityUpdated: IdentityField[] = [];
+
+    const organizationData: Prisma.OrganizationUncheckedUpdateInput = {
+      industry: targetArchetype.category,
+    };
+    const storefrontData: Prisma.StorefrontConfigUncheckedUpdateInput = {
+      archetypeId: targetArchetype.id,
+    };
+
+    let finalName = organization.name;
+    let finalSlug = organization.slug;
+    let finalTagline = storefront.tagline ?? null;
+
+    if (identity?.orgName != null && identity.orgName !== organization.name) {
+      organizationData.name = identity.orgName;
+      finalName = identity.orgName;
+      identityUpdated.push("orgName");
+    }
+    if (identity?.tagline != null && identity.tagline !== storefront.tagline) {
+      storefrontData.tagline = identity.tagline;
+      finalTagline = identity.tagline;
+      identityUpdated.push("tagline");
+    }
+    if (identity?.slug != null && identity.slug !== organization.slug) {
+      // slug is @unique — never overwrite another org's slug.
+      const slugTaken = await tx.organization.findFirst({
+        where: { slug: identity.slug, NOT: { id: organizationId } },
+        select: { id: true },
+      });
+      if (slugTaken) {
+        warnings.push(
+          `Requested URL slug "${identity.slug}" is already in use; the storefront still uses "${organization.slug}".`,
+        );
+      } else {
+        organizationData.slug = identity.slug;
+        finalSlug = identity.slug;
+        identityUpdated.push("slug");
+      }
+    }
+
     await tx.storefrontConfig.update({
       where: { id: storefront.id },
-      data: { archetypeId: targetArchetype.id },
+      data: storefrontData,
     });
 
     await tx.organization.update({
       where: { id: organizationId },
-      data: { industry: targetArchetype.category },
+      data: organizationData,
     });
 
     await tx.businessContext.updateMany({
@@ -172,8 +235,20 @@ export async function resetStorefrontArchetype(input: {
       await seedBookingScheduleDefaults(tx, {
         storefrontId: storefront.id,
         archetypeId: targetArchetype.archetypeId,
-        providerName: organization.name ?? "Bookings",
+        providerName: finalName ?? "Bookings",
       });
+    }
+
+    // Identity fields the caller did NOT supply were preserved and may still
+    // reflect the prior archetype/setup — surface them so the operator (or the
+    // calling UI) can update them rather than silently presenting the wrong
+    // business identity to customers. (AUDIT-R1S-001 / #1748)
+    const identityPreserved = IDENTITY_FIELDS.filter((f) => !identityUpdated.includes(f));
+    if (identityPreserved.length > 0) {
+      warnings.push(
+        `Business identity (${identityPreserved.join(", ")}) was preserved across the archetype change and may still reflect your previous setup. ` +
+          `Update it in storefront settings if it no longer fits "${targetArchetype.archetypeId}".`,
+      );
     }
 
     return {
@@ -182,6 +257,14 @@ export async function resetStorefrontArchetype(input: {
       category: targetArchetype.category,
       sectionsCreated,
       itemsCreated,
+      identity: {
+        orgName: finalName,
+        slug: finalSlug,
+        tagline: finalTagline,
+        updated: identityUpdated,
+        preserved: identityPreserved,
+      },
+      warnings,
     };
   });
 }

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -335,6 +335,22 @@ Open Docker Desktop → Settings → Features in development → enable
 "Use Docker Compose v2" and "Docker Model Runner", then re-run
 `bash install-dpf.sh`.
 
+**Install log says "Docker Model Runner isn't available … skipping the AI
+model download".**
+Expected on Docker Desktop older than 4.40 (the `docker model` CLI isn't
+present). The portal installs and runs normally — only the local AI model
+is skipped, and the installer no longer leaks a raw `docker: 'model' is not
+a docker command` error. Update Docker Desktop and re-run
+`bash install-dpf.sh` to pull the model, or point the portal at an external
+LLM provider under Admin → Providers.
+
+**Install log says an "optional sidecar … image is unavailable upstream".**
+The bundled voice speech-to-text sidecar (`dpf-stt`) is pulled from a
+third-party registry that occasionally prunes its image tag. When that
+happens the installer brings the platform up *without* voice input rather
+than failing the whole install — everything else works. Re-run
+`bash install-dpf.sh` later to pick the image up once it's available again.
+
 **`/api/health` returns 500.**
 The portal's database migrations may not have completed. Tail the
 portal-init container:

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -196,6 +196,22 @@ The Docker VM is under-provisioned — see [Docker memory](#docker-memory).
 The database migrations may not have completed. Tail the portal-init
 container: `docker compose logs portal-init`.
 
+**Install log says "Docker Model Runner isn't available … skipping the AI
+model download".**
+Expected on Docker Desktop older than 4.40 (the `docker model` CLI isn't
+present). The portal installs and runs normally — only the local AI model
+is skipped, and the installer no longer leaks a raw `docker: 'model' is not
+a docker command` error. Update Docker Desktop and re-run the installer to
+pull the model, or point the portal at an external LLM provider under
+Admin → Providers.
+
+**Install log says an "optional sidecar … image is unavailable upstream".**
+The bundled voice speech-to-text sidecar (`dpf-stt`) is pulled from a
+third-party registry that occasionally prunes its image tag. When that
+happens the installer brings the platform up *without* voice input rather
+than failing the whole install — everything else works. Re-run the
+installer later to pick the image up once it's available again.
+
 **`install-dpf.bat` closed instantly / "running scripts is disabled".**
 Run it from an elevated prompt; the `.bat` launcher passes
 `-ExecutionPolicy Bypass` for you, so you should not need to change the

--- a/docs/testing/findings/run-1-swap-findings.md
+++ b/docs/testing/findings/run-1-swap-findings.md
@@ -18,6 +18,7 @@
 
 **Observed**: After each archetype-reset call, the portal continued showing "Riverside Plumbing Solutions" name, slug, and hero copy. Only service items swapped.
 **Valid scope**: Post-go-live archetype change via admin API only — not first-time install path.
+**Resolution** ([#1748](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/1748)): `resetStorefrontArchetype` now (a) accepts an optional `identity` (`{ orgName, slug, tagline }`) so a caller — e.g. a future "change archetype" UI — can perform a full identity swap, with the slug uniqueness-guarded; and (b) when identity is not supplied, deliberately **preserves** the operator-owned name/slug/tagline (archetypes carry no defaults for these) and returns `result.identity` + `result.warnings` naming exactly what still reflects the prior setup, so the surface can prompt the operator instead of silently presenting the wrong business identity. See `apps/web/lib/storefront/archetype-reset.ts`.
 
 ### AUDIT-R1S-002 · Important · Inquiry form has no archetype-specific fields on any swap archetype
 

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1861,7 +1861,24 @@ if (-not (Test-StepDone "started")) {
     Write-Action "Starting database and portal..."
     $oldEAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
-    docker compose @coreComposeArgs up -d
+    # Non-critical sidecars (e.g. dpf-stt voice STT) pull from third-party
+    # registries whose mutable tags get pruned upstream: hwdsl2/whisper-server
+    # re-pushes :latest and prunes the prior index digest, so a pinned digest
+    # eventually 404s ("manifest unknown"). A single such failure would otherwise
+    # abort the WHOLE compose up, taking the portal/db/redis down with it (#1767).
+    # Pre-pull them with failure tolerated and, if one is unavailable, scale it to
+    # 0 so the core platform still comes up -- voice degrades, the install does
+    # not. Nothing depends_on these sidecars, so scaling to 0 is safe.
+    $scaleArgs = @()
+    foreach ($svc in @("dpf-stt")) {
+        docker compose @coreComposeArgs pull $svc 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "Optional sidecar '$svc' image is unavailable upstream; bringing up the platform without it."
+            Write-Action "  Voice features needing '$svc' stay inactive until its image returns; re-run the installer to retry."
+            $scaleArgs += @("--scale", "$svc=0")
+        }
+    }
+    docker compose @coreComposeArgs up -d @scaleArgs
     $ErrorActionPreference = $oldEAP
 
     # Voice / TTS sidecar. Spoken output uses the bundled dpf-tts container, but
@@ -2075,11 +2092,13 @@ if (-not (Test-StepDone "model")) {
             if ($listExit -eq 0) { $mrReady = $true; break }
             Start-Sleep -Seconds 2
         }
-        if (-not $mrReady) {
-            Write-Warn "Docker Model Runner did not become ready in 30s. The model pull will likely fail."
-        }
     }
 
+    # Only attempt the pull when Model Runner actually responded. When the
+    # `docker model` CLI is absent (Docker Desktop too old) or not yet running,
+    # attempting it would leak the raw `docker: 'model' is not a docker command`
+    # error and a misleading "may have failed" (#1767); skip cleanly instead.
+    if ($mrReady) {
     Write-Action "Pulling AI model $selectedModel via Docker Model Runner, these may be big..."
     Write-Action "This may take several minutes depending on your internet speed, and size of your video card."
     # Name accuracy: pull with ai/ form; Docker registers under short form (no ai/).
@@ -2131,6 +2150,25 @@ if (-not (Test-StepDone "model")) {
         Write-Warn "You can pull manually later: docker model pull $pullName"
     } else {
         Write-Warn "Model pull reported success but $runtimeModel not listed; retry: docker model pull $pullName"
+    }
+    } else {
+        # Model Runner never became ready. Distinguish "CLI absent" (Docker
+        # Desktop too old) from "present but not started" so we give the right
+        # guidance and never leak the raw `docker: 'model' is not a docker
+        # command` error by attempting a pull that cannot succeed (#1767). The
+        # portal still installs; AI features activate once a model is available.
+        $oldEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        docker model --help 2>&1 | Out-Null
+        $hasModelCmd = ($LASTEXITCODE -eq 0)
+        $ErrorActionPreference = $oldEAP
+        if ($hasModelCmd) {
+            Write-Warn "Docker Model Runner isn't running yet; skipping the AI model download."
+            Write-Warn "Pull it later once Docker Desktop is ready: docker model pull $selectedModel"
+        } else {
+            Write-Warn "Docker Model Runner isn't available (requires Docker Desktop 4.40+); skipping the AI model download."
+            Write-Warn "Update Docker Desktop, then re-run this installer. The portal still works without it."
+        }
     }
     Save-Progress "model"
 } else {

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -507,10 +507,19 @@ if [ "$DPF_PLATFORM" = "darwin" ] && command -v docker >/dev/null 2>&1; then
       sleep 2
     done
     if [ "$mr_ready" -ne 1 ]; then
-      warn "Docker Model Runner did not become ready within 30s. The model pull may fail."
-    fi
-
-    if [ -n "$DPF_SELECTED_MODEL" ]; then
+      # Distinguish "Model Runner CLI absent" (Docker Desktop too old) from
+      # "present but not ready yet" so we give the right guidance and never
+      # leak the raw `docker: 'model' is not a docker command` error by
+      # attempting a pull that cannot succeed (#1767). The portal still
+      # installs either way; AI features activate once a model is available.
+      if docker model --help >/dev/null 2>&1; then
+        warn "Docker Model Runner isn't running yet; skipping the AI model download."
+        info "  Pull it later once it's ready: docker model pull ${DPF_SELECTED_MODEL:-<model>}"
+      else
+        warn "Docker Model Runner isn't available (requires Docker Desktop 4.40+); skipping the AI model download."
+        info "  Update Docker Desktop, then re-run install-dpf.sh. The portal still works without it."
+      fi
+    elif [ -n "$DPF_SELECTED_MODEL" ]; then
       # Skip pull if the EXACT selected model (family + tag/quant) is on
       # disk. The earlier loose check stripped `ai/` and everything after
       # `:`, so any pre-existing qwen3 quant satisfied the grep and the
@@ -826,7 +835,28 @@ if [ "$DPF_INSTALL_MODE" = "contributor" ] && [ -d .git ]; then
     ok "Stamping local build with DPF_PLATFORM_VERSION=$DPF_PLATFORM_VERSION"
   fi
 fi
-docker compose "${DPF_COMPOSE_FILES[@]}" up -d
+# Non-critical sidecars (e.g. dpf-stt voice STT) pull from third-party
+# registries whose mutable tags get pruned upstream: hwdsl2/whisper-server
+# re-pushes :latest and prunes the prior index digest, so a pinned digest
+# eventually 404s ("manifest unknown"). A single such failure would otherwise
+# abort the WHOLE `docker compose up`, taking the portal/db/redis down with it
+# (#1767). Pre-pull them with failure tolerated and, if one is unavailable,
+# scale it to 0 so the core platform still comes up — voice degrades, the
+# install does not. Nothing depends_on these sidecars, so scaling to 0 is safe.
+_noncritical_sidecars="dpf-stt"
+_scale_args=()
+for _svc in $_noncritical_sidecars; do
+  if ! docker compose "${DPF_COMPOSE_FILES[@]}" pull "$_svc" >/dev/null 2>&1; then
+    warn "Optional sidecar '$_svc' image is unavailable upstream; bringing up the platform without it."
+    info "  Voice features needing '$_svc' stay inactive until its image returns; re-run install-dpf.sh to retry."
+    _scale_args+=(--scale "$_svc=0")
+  fi
+done
+if [ "${#_scale_args[@]}" -gt 0 ]; then
+  docker compose "${DPF_COMPOSE_FILES[@]}" up -d "${_scale_args[@]}"
+else
+  docker compose "${DPF_COMPOSE_FILES[@]}" up -d
+fi
 ok "docker compose up returned"
 
 # 10b. Voice / TTS sidecar (Linux hosts with an NVIDIA GPU).


### PR DESCRIPTION
Sweep of the open issue tracker. Two contained, high-value bug fixes shipped here; the rest are triaged below.

## Fixes

### Install resilience — addresses #1767
The community macOS install report surfaced two real, install-blocking defects:

1. **`docker: 'model' is not a docker command` leaked** when Docker Desktop predates 4.40 (no `docker model` CLI). The installer attempted `docker model pull` even after the readiness probe failed. Now the pull is gated on the probe; when Model Runner never responds we distinguish *CLI absent* (update Docker Desktop) from *not running yet* and skip cleanly. **The portal still installs.**
2. **A single pruned third-party sidecar image aborted the WHOLE `docker compose up`**, taking portal/db/redis down with it. `hwdsl2/whisper-server` (voice STT, `dpf-stt`) re-pushes `:latest` and prunes the prior index digest, so the pinned digest eventually 404s (`manifest unknown`). Non-critical sidecars are now pre-pulled with failure tolerated and, when unavailable, scaled to `0` so the **core platform still comes up — voice degrades, the install does not**. Nothing `depends_on` these sidecars, so scaling to 0 is safe.

Both installers (`install-dpf.sh`, `install-dpf.ps1`) fixed symmetrically; macOS/Windows troubleshooting docs updated. *(Marked "addresses" not "fixes" — final closure wants a real-host re-verification run.)*

### Archetype-reset identity — Fixes #1748 (AUDIT-R1S-001)
`resetStorefrontArchetype` swapped services/sections/value-stream but never touched the operator-owned identity — **company name, URL slug, hero tagline** — so a mid-life archetype swap presented the prior identity to customers with no signal. Archetypes carry no defaults for these, so auto-deriving would clobber the operator's real identity. Two-sided fix:

- Optional `identity` (`{ orgName, slug, tagline }`) lets a caller (e.g. a future "change archetype" UI) perform a full swap; slug is uniqueness-guarded.
- When omitted, those fields are **preserved** and `result.identity` + `result.warnings` name exactly what still reflects the prior setup, so the surface can prompt the operator.

Unit tests cover preserve+report, full apply, and slug-collision.

## Verification
- `install-dpf.sh`: `bash -n` clean. `install-dpf.ps1`: PowerShell AST parse clean. Current pinned `dpf-stt` digest verified to still resolve.
- Storefront unit tests added/updated. **Local `node_modules` is degraded in this environment (no `.pnpm`/vitest/Prisma client), so TS tests + typecheck rely on CI** (each test traced against the implementation by hand).

## Triage of the remaining open issues (no code here)
- **#1876** e-signature (DocuSign/HelloSign) for standalone docs — large unstarted integration epic (Phase 1 shipped); needs its own build, not a drive-by.
- **#1724** derive/persist operational value-stream at setup — **substantially already shipped**: setup + reset both call `projectOperationalValueStreamForArchetype`, `/ea/value-streams` renders it, `archimate-xml.ts` emits it. Remaining gap is the WWWD decision-behavior AC; recommend live-verify the shipped ACs and track only that remainder.
- **#1888** bundled email relay — remaining scope is operator-confirmed *near*-zero-config follow-on (per-install limits on operator-run relays; DPF operates none). Largely non-actionable as code.
- **#657 / #658 / #659 / #660** — community hardware-verification asks (real Linux/observability/edge-LAN/cloud-VM pilots). Not code-fixable; need real boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)