### PR TITLE
Fix compliance library applicability context

### DIFF
--- a/apps/web/app/(shell)/compliance/obligations/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/obligations/[id]/page.tsx
@@ -107,14 +107,28 @@ export default async function ObligationDetailPage({ params }: Props) {
       {/* Regulation link */}
       <div className="mb-6">
         <h2 className="text-xs text-[var(--dpf-muted)] uppercase tracking-widest mb-2">Regulation</h2>
-        <Link
-          href={`/compliance/regulations/${obligation.regulation.id}`}
-          className="inline-flex items-center gap-2 p-3 rounded-lg border border-[var(--dpf-border)] hover:border-[var(--dpf-accent)] transition-colors"
-        >
-          <span className="text-sm font-semibold text-[var(--dpf-text)]">{obligation.regulation.shortName}</span>
-          <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{obligation.regulation.jurisdiction}</span>
-          <span className="text-xs text-[var(--dpf-info)]">View</span>
-        </Link>
+        <div className="flex flex-wrap items-center gap-3">
+          <Link
+            href={`/compliance/regulations/${obligation.regulation.id}`}
+            className="inline-flex items-center gap-2 p-3 rounded-lg border border-[var(--dpf-border)] hover:border-[var(--dpf-accent)] transition-colors"
+          >
+            <span className="text-sm font-semibold text-[var(--dpf-text)]">{obligation.regulation.shortName}</span>
+            <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{obligation.regulation.jurisdiction}</span>
+            <span className="text-xs text-[var(--dpf-info)]">View</span>
+          </Link>
+          {obligation.regulation.sourceUrl ? (
+            <a
+              href={obligation.regulation.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs font-medium text-[var(--dpf-info)] hover:underline"
+            >
+              Source document
+            </a>
+          ) : (
+            <StatusBadge intent="warning" label="Source needed" variant="soft" uppercase={false} />
+          )}
+        </div>
       </div>
 
       {/* Linked controls */}

--- a/apps/web/app/(shell)/compliance/obligations/page.tsx
+++ b/apps/web/app/(shell)/compliance/obligations/page.tsx
@@ -1,17 +1,30 @@
 import { prisma } from "@dpf/db";
 import { CreateObligationForm } from "@/components/compliance/CreateObligationForm";
+import { ComplianceLibraryScopeNav } from "@/components/compliance/ComplianceLibraryScopeNav";
+import { ObligationLibraryPanel } from "@/components/compliance/ObligationLibraryPanel";
 import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 import Link from "next/link";
+import {
+  DEFAULT_COMPLIANCE_LIBRARY_SCOPE,
+  addObligationApplicability,
+  complianceLibraryContextLabel,
+  countObligationsByComplianceLibraryScope,
+  filterObligationsByComplianceLibraryScope,
+  parseComplianceLibraryScope,
+  resolveComplianceLibraryContext,
+} from "@/lib/compliance-library";
 
 type Props = {
-  searchParams: Promise<{ regulation?: string; category?: string; status?: string; view?: string }>;
+  searchParams: Promise<{ regulation?: string; category?: string; status?: string; scope?: string; view?: string }>;
 };
 
 export default async function ObligationsPage({ searchParams }: Props) {
   const filters = await searchParams;
   const view = parseSurfaceView(filters.view);
+  const scope = parseComplianceLibraryScope(filters.scope);
 
-  const [obligations, regulations, categories] = await Promise.all([
+  const [context, obligations, regulations, categories] = await Promise.all([
+    resolveComplianceLibraryContext(),
     prisma.obligation.findMany({
       where: {
         ...(filters.regulation && { regulationId: filters.regulation }),
@@ -19,7 +32,18 @@ export default async function ObligationsPage({ searchParams }: Props) {
         ...(filters.status ? { status: filters.status } : { status: "active" }),
       },
       include: {
-        regulation: { select: { id: true, shortName: true, jurisdiction: true } },
+        regulation: {
+          select: {
+            id: true,
+            regulationId: true,
+            name: true,
+            shortName: true,
+            jurisdiction: true,
+            industry: true,
+            sourceType: true,
+            sourceUrl: true,
+          },
+        },
         ownerEmployee: { select: { id: true, displayName: true } },
         _count: { select: { controls: true } },
       },
@@ -42,6 +66,13 @@ export default async function ObligationsPage({ searchParams }: Props) {
     .map((c) => c.category)
     .filter((c): c is string => c !== null);
 
+  const classifiedObligations = obligations.map((obligation) =>
+    addObligationApplicability(obligation, context),
+  );
+  const visibleObligations = filterObligationsByComplianceLibraryScope(classifiedObligations, scope);
+  const scopeCounts = countObligationsByComplianceLibraryScope(classifiedObligations);
+  const contextLabel = complianceLibraryContextLabel(context);
+
   // Build filter URL helper
   function filterUrl(key: string, value: string) {
     const p = new URLSearchParams();
@@ -54,6 +85,9 @@ export default async function ObligationsPage({ searchParams }: Props) {
     if (key === "status" && value) p.set("status", value);
     else if (filters.status) p.set("status", filters.status);
 
+    if (scope !== DEFAULT_COMPLIANCE_LIBRARY_SCOPE) p.set("scope", scope);
+    if (filters.view) p.set("view", filters.view);
+
     const qs = p.toString();
     return `/compliance/obligations${qs ? `?${qs}` : ""}`;
   }
@@ -61,7 +95,8 @@ export default async function ObligationsPage({ searchParams }: Props) {
   const activeFilterCount =
     (filters.regulation ? 1 : 0) +
     (filters.category ? 1 : 0) +
-    (filters.status ? 1 : 0);
+    (filters.status ? 1 : 0) +
+    (scope !== DEFAULT_COMPLIANCE_LIBRARY_SCOPE ? 1 : 0);
 
   return (
     <div>
@@ -69,7 +104,7 @@ export default async function ObligationsPage({ searchParams }: Props) {
         <div>
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">Obligations</h1>
           <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-            {obligations.length} result{obligations.length !== 1 ? "s" : ""}
+            {visibleObligations.length} shown - {obligations.length} result{obligations.length !== 1 ? "s" : ""} - {contextLabel}
           </p>
         </div>
         <CreateObligationForm regulations={regulations} />
@@ -77,6 +112,21 @@ export default async function ObligationsPage({ searchParams }: Props) {
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-3 mb-6">
+        <div className="flex flex-col gap-1">
+          <label className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-widest">Scope</label>
+          <ComplianceLibraryScopeNav
+            basePath="/compliance/obligations"
+            activeScope={scope}
+            counts={scopeCounts}
+            preservedParams={{
+              regulation: filters.regulation,
+              category: filters.category,
+              status: filters.status,
+              view: filters.view,
+            }}
+          />
+        </div>
+
         {/* Regulation filter */}
         <div className="flex flex-col gap-1">
           <label className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-widest">Regulation</label>
@@ -173,39 +223,13 @@ export default async function ObligationsPage({ searchParams }: Props) {
 
       <PlatformGridSection entityType="compliance_obligation" view={view} />
 
-      {!view && (obligations.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No obligations match the current filters.</p>
-      ) : (
-        <div className="space-y-2">
-          {obligations.map((o) => {
-            const coverage = o._count.controls > 0 ? "var(--dpf-success)" : "var(--dpf-error)";
-            return (
-              <Link
-                key={o.id}
-                href={`/compliance/obligations/${o.id}`}
-                className="block p-3 rounded-lg border border-[var(--dpf-border)] hover:border-[var(--dpf-accent)] transition-colors"
-              >
-                <div className="flex items-start justify-between">
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <span className="w-2 h-2 rounded-full" style={{ backgroundColor: coverage }} />
-                      <span className="text-sm text-[var(--dpf-text)]">{o.title}</span>
-                    </div>
-                    <div className="flex gap-2 mt-1">
-                      <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{o.regulation.shortName}</span>
-                      {o.category && <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{o.category}</span>}
-                    </div>
-                  </div>
-                  <div className="text-right text-xs text-[var(--dpf-muted)]">
-                    <p>{o._count.controls} control{o._count.controls !== 1 ? "s" : ""}</p>
-                    {o.ownerEmployee && <p>{o.ownerEmployee.displayName}</p>}
-                  </div>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-      ))}
+      {!view && (
+        <ObligationLibraryPanel
+          rows={visibleObligations}
+          contextLabel={contextLabel}
+          totalCount={classifiedObligations.length}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/app/(shell)/compliance/regulations/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/regulations/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { CreateObligationForm } from "@/components/compliance/CreateObligationForm";
 import { EditRegulationForm } from "@/components/compliance/EditRegulationForm";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -39,11 +40,15 @@ export default async function RegulationDetailPage({ params }: Props) {
           <EditRegulationForm id={regulation.id} regulation={regulation} />
         </div>
         <p className="text-sm text-[var(--dpf-muted)]">{regulation.name}</p>
-        {regulation.sourceUrl && (
+        {regulation.sourceUrl ? (
           <a href={regulation.sourceUrl} target="_blank" rel="noopener noreferrer"
             className="text-xs text-[var(--dpf-info)] hover:underline mt-1 inline-block">
             Source document
           </a>
+        ) : (
+          <div className="mt-2">
+            <StatusBadge intent="warning" label="Source needed" variant="soft" uppercase={false} />
+          </div>
         )}
       </div>
 
@@ -85,7 +90,12 @@ export default async function RegulationDetailPage({ params }: Props) {
               <div key={o.id} className="p-3 rounded-lg border border-[var(--dpf-border)] flex items-start justify-between">
                 <div>
                   <div className="flex items-center gap-2">
-                    <span className="w-2 h-2 rounded-full" style={{ backgroundColor: hasControls ? "var(--dpf-success)" : "var(--dpf-error)" }} />
+                    <StatusBadge
+                      intent={hasControls ? "success" : "warning"}
+                      label={hasControls ? "Covered" : "Needs controls"}
+                      variant="soft"
+                      uppercase={false}
+                    />
                     <span className="text-sm text-[var(--dpf-text)]">{o.title}</span>
                   </div>
                   <div className="flex gap-2 mt-1">

--- a/apps/web/app/(shell)/compliance/regulations/page.tsx
+++ b/apps/web/app/(shell)/compliance/regulations/page.tsx
@@ -1,27 +1,48 @@
 import { prisma } from "@dpf/db";
 import Link from "next/link";
 import { CreateRegulationForm } from "@/components/compliance/CreateRegulationForm";
-import { StatusBadge } from "@/components/ui/report-kit";
+import { RegulationLibraryPanel } from "@/components/compliance/RegulationLibraryPanel";
+import {
+  addRegulationApplicability,
+  complianceLibraryContextLabel,
+  countByComplianceLibraryScope,
+  filterByComplianceLibraryScope,
+  parseComplianceLibraryScope,
+  resolveComplianceLibraryContext,
+} from "@/lib/compliance-library";
 
-type Props = { searchParams: Promise<{ type?: string }> };
+type Props = { searchParams: Promise<{ type?: string; scope?: string }> };
 
 export default async function RegulationsPage({ searchParams }: Props) {
-  const { type } = await searchParams;
+  const { type, scope: rawScope } = await searchParams;
+  const scope = parseComplianceLibraryScope(rawScope);
   const where: Record<string, unknown> = {};
   if (type && type !== "all") where.sourceType = type;
 
-  const regulations = await prisma.regulation.findMany({
-    where,
-    orderBy: { shortName: "asc" },
-    include: { _count: { select: { obligations: true } } },
-  });
+  const [context, regulations] = await Promise.all([
+    resolveComplianceLibraryContext(),
+    prisma.regulation.findMany({
+      where,
+      orderBy: { shortName: "asc" },
+      include: { _count: { select: { obligations: true } } },
+    }),
+  ]);
+
+  const classifiedRegulations = regulations.map((regulation) =>
+    addRegulationApplicability(regulation, context),
+  );
+  const scopeCounts = countByComplianceLibraryScope(classifiedRegulations);
+  const visibleRegulations = filterByComplianceLibraryScope(classifiedRegulations, scope);
+  const contextLabel = complianceLibraryContextLabel(context);
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">Regulations</h1>
-          <p className="text-sm text-[var(--dpf-muted)] mt-0.5">{regulations.length} registered</p>
+          <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+            {visibleRegulations.length} shown - {regulations.length} registered - {contextLabel}
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <Link href="/compliance/onboard" className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90">
@@ -31,36 +52,14 @@ export default async function RegulationsPage({ searchParams }: Props) {
         </div>
       </div>
 
-      {/* Source type filter bar */}
-      <div className="flex gap-2 mb-4">
-        {["all", "external", "standard", "framework", "internal"].map((t) => (
-          <a key={t} href={`/compliance/regulations${t === "all" ? "" : `?type=${t}`}`}
-            className={`px-3 py-1 text-xs rounded-full border ${(!type && t === "all") || type === t ? "bg-[var(--dpf-accent)] text-white border-[var(--dpf-accent)]" : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"}`}>
-            {t === "all" ? "All" : t.charAt(0).toUpperCase() + t.slice(1)}
-          </a>
-        ))}
-      </div>
-
-      {regulations.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No regulations registered yet.</p>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {regulations.map((r) => (
-            <a key={r.id} href={`/compliance/regulations/${r.id}`}
-              className="block p-4 rounded-lg border border-[var(--dpf-border)] hover:border-[var(--dpf-accent)] transition-colors">
-              <div className="flex items-center gap-2 mb-1">
-                <span className="text-sm font-semibold text-[var(--dpf-text)]">{r.shortName}</span>
-                <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{r.jurisdiction}</span>
-                <StatusBadge domain="complianceRegulation" status={r.status} variant="soft" uppercase={false} />
-              </div>
-              <p className="text-xs text-[var(--dpf-muted)] mb-1">{r.name}</p>
-              <p className="text-xs text-[var(--dpf-muted)]">
-                {r._count.obligations} obligation{r._count.obligations !== 1 ? "s" : ""}
-              </p>
-            </a>
-          ))}
-        </div>
-      )}
+      <RegulationLibraryPanel
+        rows={visibleRegulations}
+        totalCount={classifiedRegulations.length}
+        contextLabel={contextLabel}
+        activeScope={scope}
+        activeSourceType={type}
+        scopeCounts={scopeCounts}
+      />
     </div>
   );
 }

--- a/apps/web/components/compliance/ComplianceLibraryScopeNav.tsx
+++ b/apps/web/components/compliance/ComplianceLibraryScopeNav.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+
+import {
+  COMPLIANCE_LIBRARY_SCOPE_FILTERS,
+  DEFAULT_COMPLIANCE_LIBRARY_SCOPE,
+  type ComplianceLibraryScopeFilter,
+} from "@/lib/compliance-library";
+
+const SCOPE_LABEL: Record<ComplianceLibraryScopeFilter, string> = {
+  applies: "Applies",
+  review: "Needs review",
+  reference: "Reference",
+  all: "All",
+};
+
+type Props = {
+  basePath: string;
+  activeScope: ComplianceLibraryScopeFilter;
+  counts: Record<ComplianceLibraryScopeFilter, number>;
+  preservedParams?: Record<string, string | undefined>;
+};
+
+function buildHref(
+  basePath: string,
+  scope: ComplianceLibraryScopeFilter,
+  preservedParams: Record<string, string | undefined>,
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(preservedParams)) {
+    if (value) params.set(key, value);
+  }
+  if (scope !== DEFAULT_COMPLIANCE_LIBRARY_SCOPE) params.set("scope", scope);
+  const qs = params.toString();
+  return `${basePath}${qs ? `?${qs}` : ""}`;
+}
+
+export function ComplianceLibraryScopeNav({
+  basePath,
+  activeScope,
+  counts,
+  preservedParams = {},
+}: Props) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {COMPLIANCE_LIBRARY_SCOPE_FILTERS.map((scope) => {
+        const active = activeScope === scope;
+        return (
+          <Link
+            key={scope}
+            href={buildHref(basePath, scope, preservedParams)}
+            className={[
+              "inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors",
+              active
+                ? "border-[var(--dpf-accent)] bg-[var(--dpf-accent)] text-white"
+                : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)]",
+            ].join(" ")}
+          >
+            <span>{SCOPE_LABEL[scope]}</span>
+            <span className={active ? "text-white" : "text-[var(--dpf-muted)]"}>{counts[scope]}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/compliance/ObligationLibraryPanel.test.tsx
+++ b/apps/web/components/compliance/ObligationLibraryPanel.test.tsx
@@ -1,0 +1,87 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ObligationLibraryPanel, type ObligationLibraryRow } from "./ObligationLibraryPanel";
+
+const ROWS: ObligationLibraryRow[] = [
+  {
+    id: "obl-1",
+    title: "Suspicious Activity Report filing",
+    category: "operational",
+    applicability: "All insured depositories",
+    ownerEmployee: { id: "emp-1", displayName: "Compliance Lead" },
+    _count: { controls: 1 },
+    regulation: {
+      id: "reg-bsa",
+      regulationId: "REG-US-BSA-AML",
+      name: "Bank Secrecy Act / Anti-Money Laundering",
+      shortName: "BSA/AML",
+      jurisdiction: "US-federal",
+      industry: "financial",
+      sourceType: "external",
+      sourceUrl: "https://www.fincen.gov/resources/statutes-and-regulations/bank-secrecy-act",
+      applicability: {
+        scope: "reference",
+        label: "Reference",
+        reason: "Seeded for banking or financial services; installed archetype is Software Platform.",
+      },
+    },
+  },
+  {
+    id: "obl-2",
+    title: "Public notice of meetings within the statutory notice period",
+    category: "governance",
+    applicability: "All public bodies",
+    ownerEmployee: null,
+    _count: { controls: 0 },
+    regulation: {
+      id: "reg-state",
+      regulationId: "REG-US-STATE-OPEN-MEETINGS",
+      name: "State Open Meetings Law (Sunshine Law)",
+      shortName: "Open Meetings",
+      jurisdiction: "US-state",
+      industry: "public-sector",
+      sourceType: "external",
+      sourceUrl: null,
+      applicability: {
+        scope: "review",
+        label: "Needs review",
+        reason: "Matches Public Sector, but the applicable state has not been captured.",
+      },
+    },
+  },
+];
+
+describe("ObligationLibraryPanel", () => {
+  it("renders parent regulation applicability and source actions", () => {
+    const html = renderToStaticMarkup(
+      <ObligationLibraryPanel
+        rows={ROWS}
+        contextLabel="Software Platform (software-platform)"
+        totalCount={2}
+      />,
+    );
+
+    expect(html).toContain("Suspicious Activity Report filing");
+    expect(html).toContain("Reference");
+    expect(html).toContain("Needs review");
+    expect(html).toContain("Details");
+    expect(html).toContain("Source");
+    expect(html).toContain("Source needed");
+    expect(html).toContain("1 control");
+    expect(html).toContain("0 controls");
+  });
+
+  it("renders an honest empty state", () => {
+    const html = renderToStaticMarkup(
+      <ObligationLibraryPanel
+        rows={[]}
+        contextLabel="Software Platform (software-platform)"
+        totalCount={12}
+      />,
+    );
+
+    expect(html).toContain("No obligations in this scope");
+    expect(html).toContain("12 obligations remain");
+  });
+});

--- a/apps/web/components/compliance/ObligationLibraryPanel.tsx
+++ b/apps/web/components/compliance/ObligationLibraryPanel.tsx
@@ -1,0 +1,120 @@
+import Link from "next/link";
+
+import { StatusBadge } from "@/components/ui/report-kit";
+import type {
+  ClassifiableRegulation,
+  ObligationWithApplicability,
+} from "@/lib/compliance-library";
+
+export type ObligationLibraryRow = ObligationWithApplicability<{
+  id: string;
+  title: string;
+  category: string | null;
+  applicability: string | null;
+  ownerEmployee: { id: string; displayName: string } | null;
+  _count: { controls: number };
+  regulation: ClassifiableRegulation & {
+    id: string;
+  };
+}>;
+
+type Props = {
+  rows: ObligationLibraryRow[];
+  contextLabel: string;
+  totalCount: number;
+};
+
+function sourceAction(row: ObligationLibraryRow) {
+  if (!row.regulation.sourceUrl) {
+    return <StatusBadge intent="warning" label="Source needed" variant="soft" uppercase={false} />;
+  }
+
+  return (
+    <a
+      href={row.regulation.sourceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-xs font-medium text-[var(--dpf-info)] hover:underline"
+    >
+      Source
+    </a>
+  );
+}
+
+export function ObligationLibraryPanel({ rows, contextLabel, totalCount }: Props) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-[var(--dpf-border)] p-4">
+        <p className="text-sm font-medium text-[var(--dpf-text)]">No obligations in this scope for {contextLabel}.</p>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          {totalCount} obligation{totalCount !== 1 ? "s" : ""} remain available across the full reference library.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {rows.map((row) => {
+        const hasControls = row._count.controls > 0;
+        return (
+          <div
+            key={row.id}
+            className="rounded-lg border border-[var(--dpf-border)] p-3 transition-colors hover:border-[var(--dpf-accent)]"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusBadge
+                    domain="complianceApplicability"
+                    status={row.regulation.applicability.scope}
+                    label={row.regulation.applicability.label}
+                    variant="soft"
+                    uppercase={false}
+                  />
+                  <span className="text-sm font-medium text-[var(--dpf-text)]">{row.title}</span>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <Link
+                    href={`/compliance/regulations/${row.regulation.id}`}
+                    className="rounded-full bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-[9px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                  >
+                    {row.regulation.shortName}
+                  </Link>
+                  {row.category && (
+                    <span className="rounded-full bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-[9px] text-[var(--dpf-muted)]">
+                      {row.category}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-2 text-xs text-[var(--dpf-text)]">{row.regulation.applicability.reason}</p>
+                {row.applicability && (
+                  <p className="mt-1 text-xs text-[var(--dpf-muted)]">{row.applicability}</p>
+                )}
+              </div>
+
+              <div className="flex shrink-0 items-center gap-3 sm:justify-end">
+                <StatusBadge
+                  intent={hasControls ? "success" : "warning"}
+                  label={`${row._count.controls} control${row._count.controls !== 1 ? "s" : ""}`}
+                  variant="soft"
+                  uppercase={false}
+                />
+                {row.ownerEmployee && (
+                  <span className="text-xs text-[var(--dpf-muted)]">{row.ownerEmployee.displayName}</span>
+                )}
+                <Link
+                  href={`/compliance/obligations/${row.id}`}
+                  className="text-xs font-medium text-[var(--dpf-accent)] hover:underline"
+                >
+                  Details
+                </Link>
+                {sourceAction(row)}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/compliance/RegulationLibraryPanel.test.tsx
+++ b/apps/web/components/compliance/RegulationLibraryPanel.test.tsx
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { RegulationLibraryPanel, type RegulationLibraryRow } from "./RegulationLibraryPanel";
+
+const ROWS: RegulationLibraryRow[] = [
+  {
+    id: "reg-bsa",
+    regulationId: "REG-US-BSA-AML",
+    name: "Bank Secrecy Act / Anti-Money Laundering",
+    shortName: "BSA/AML",
+    jurisdiction: "US-federal",
+    industry: "financial",
+    sourceType: "external",
+    sourceUrl: "https://www.fincen.gov/resources/statutes-and-regulations/bank-secrecy-act",
+    status: "active",
+    _count: { obligations: 5 },
+    applicability: {
+      scope: "reference",
+      label: "Reference",
+      reason: "Seeded for banking or financial services; installed archetype is Software Platform.",
+    },
+  },
+  {
+    id: "reg-state",
+    regulationId: "REG-US-STATE-OPEN-MEETINGS",
+    name: "State Open Meetings Law (Sunshine Law)",
+    shortName: "Open Meetings",
+    jurisdiction: "US-state",
+    industry: "public-sector",
+    sourceType: "external",
+    sourceUrl: null,
+    status: "active",
+    _count: { obligations: 4 },
+    applicability: {
+      scope: "review",
+      label: "Needs review",
+      reason: "Matches Public Sector, but the applicable state has not been captured.",
+    },
+  },
+];
+
+describe("RegulationLibraryPanel", () => {
+  it("renders explicit details and source actions for list rows", () => {
+    const html = renderToStaticMarkup(
+      <RegulationLibraryPanel
+        rows={ROWS}
+        totalCount={2}
+        contextLabel="Software Platform (software-platform)"
+        activeScope="all"
+        scopeCounts={{ applies: 0, review: 1, reference: 1, all: 2 }}
+      />,
+    );
+
+    expect(html).toContain("Details");
+    expect(html).toContain("Source");
+    expect(html).toContain("Source needed");
+    expect(html).toContain("Seeded for banking or financial services");
+    expect(html).toContain("data-intent=\"neutral\"");
+    expect(html).toContain("data-intent=\"warning\"");
+  });
+
+  it("renders a scoped empty state with a path to the full library", () => {
+    const html = renderToStaticMarkup(
+      <RegulationLibraryPanel
+        rows={[]}
+        totalCount={2}
+        contextLabel="Software Platform (software-platform)"
+        activeScope="applies"
+        scopeCounts={{ applies: 0, review: 1, reference: 1, all: 2 }}
+      />,
+    );
+
+    expect(html).toContain("No regulations in this scope");
+    expect(html).toContain("View all");
+  });
+});

--- a/apps/web/components/compliance/RegulationLibraryPanel.tsx
+++ b/apps/web/components/compliance/RegulationLibraryPanel.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+
+import { ComplianceLibraryScopeNav } from "@/components/compliance/ComplianceLibraryScopeNav";
+import { StatusBadge } from "@/components/ui/report-kit";
+import {
+  DEFAULT_COMPLIANCE_LIBRARY_SCOPE,
+  type ClassifiableRegulation,
+  type ComplianceLibraryScopeFilter,
+  type RegulationWithApplicability,
+} from "@/lib/compliance-library";
+
+const SOURCE_TYPES = ["all", "external", "standard", "framework", "internal"];
+
+export type RegulationLibraryRow = RegulationWithApplicability<
+  ClassifiableRegulation & {
+    id: string;
+    status: string;
+    _count: { obligations: number };
+  }
+>;
+
+type Props = {
+  rows: RegulationLibraryRow[];
+  totalCount: number;
+  contextLabel: string;
+  activeScope: ComplianceLibraryScopeFilter;
+  activeSourceType?: string;
+  scopeCounts: Record<ComplianceLibraryScopeFilter, number>;
+};
+
+function labelForSourceType(type: string): string {
+  return type === "all" ? "All" : type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function sourceTypeHref(scope: ComplianceLibraryScopeFilter, type: string): string {
+  const params = new URLSearchParams();
+  if (scope !== DEFAULT_COMPLIANCE_LIBRARY_SCOPE) params.set("scope", scope);
+  if (type !== "all") params.set("type", type);
+  const qs = params.toString();
+  return `/compliance/regulations${qs ? `?${qs}` : ""}`;
+}
+
+function sourceAction(row: RegulationLibraryRow) {
+  if (!row.sourceUrl) {
+    return <StatusBadge intent="warning" label="Source needed" variant="soft" uppercase={false} />;
+  }
+
+  return (
+    <a
+      href={row.sourceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-xs font-medium text-[var(--dpf-info)] hover:underline"
+    >
+      Source
+    </a>
+  );
+}
+
+export function RegulationLibraryPanel({
+  rows,
+  totalCount,
+  contextLabel,
+  activeScope,
+  activeSourceType,
+  scopeCounts,
+}: Props) {
+  const sourceType = activeSourceType ?? "all";
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col gap-3">
+        <ComplianceLibraryScopeNav
+          basePath="/compliance/regulations"
+          activeScope={activeScope}
+          counts={scopeCounts}
+          preservedParams={{ type: activeSourceType }}
+        />
+
+        <div className="flex flex-wrap gap-2">
+          {SOURCE_TYPES.map((type) => {
+            const active = sourceType === type;
+            return (
+              <Link
+                key={type}
+                href={sourceTypeHref(activeScope, type)}
+                className={[
+                  "rounded-full border px-3 py-1 text-xs transition-colors",
+                  active
+                    ? "border-[var(--dpf-accent)] bg-[var(--dpf-accent)] text-white"
+                    : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)]",
+                ].join(" ")}
+              >
+                {labelForSourceType(type)}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="rounded-lg border border-[var(--dpf-border)] p-4">
+          <p className="text-sm font-medium text-[var(--dpf-text)]">No regulations in this scope for {contextLabel}.</p>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            {totalCount} regulation{totalCount !== 1 ? "s" : ""} remain available across the full reference library.
+          </p>
+          {activeScope !== "all" && (
+            <Link
+              href={sourceTypeHref("all", sourceType)}
+              className="mt-3 inline-flex rounded border border-[var(--dpf-border)] px-3 py-1 text-xs text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)]"
+            >
+              View all
+            </Link>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {rows.map((row) => (
+            <div
+              key={row.id}
+              className="flex min-h-[154px] flex-col justify-between rounded-lg border border-[var(--dpf-border)] p-4 transition-colors hover:border-[var(--dpf-accent)]"
+            >
+              <div>
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-semibold text-[var(--dpf-text)]">{row.shortName}</span>
+                  <span className="rounded-full bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-[9px] text-[var(--dpf-muted)]">
+                    {row.jurisdiction}
+                  </span>
+                  <StatusBadge
+                    domain="complianceApplicability"
+                    status={row.applicability.scope}
+                    label={row.applicability.label}
+                    variant="soft"
+                    uppercase={false}
+                  />
+                  <StatusBadge domain="complianceRegulation" status={row.status} variant="soft" uppercase={false} />
+                </div>
+                <p className="text-xs text-[var(--dpf-muted)]">{row.name}</p>
+                <p className="mt-2 text-xs text-[var(--dpf-text)]">{row.applicability.reason}</p>
+              </div>
+
+              <div className="mt-4 flex items-center justify-between gap-3">
+                <span className="text-xs text-[var(--dpf-muted)]">
+                  {row._count.obligations} obligation{row._count.obligations !== 1 ? "s" : ""}
+                </span>
+                <div className="flex items-center gap-3">
+                  <Link
+                    href={`/compliance/regulations/${row.id}`}
+                    className="text-xs font-medium text-[var(--dpf-accent)] hover:underline"
+                  >
+                    Details
+                  </Link>
+                  {sourceAction(row)}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -149,6 +149,11 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     active: "success",
     inactive: "danger",
   },
+  complianceApplicability: {
+    applies: "success",
+    review: "warning",
+    reference: "neutral",
+  },
   // Marketing strategy/work-product lifecycle.
   marketing: {
     draft: "neutral",

--- a/apps/web/lib/compliance-library.test.ts
+++ b/apps/web/lib/compliance-library.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addObligationApplicability,
+  addRegulationApplicability,
+  classifyRegulationForInstall,
+  complianceLibraryContextLabel,
+  countByComplianceLibraryScope,
+  filterByComplianceLibraryScope,
+  parseComplianceLibraryScope,
+  type ClassifiableRegulation,
+  type ComplianceLibraryContext,
+} from "./compliance-library";
+
+const softwareContext: ComplianceLibraryContext = {
+  archetype: {
+    archetypeId: "software-platform",
+    name: "Software Platform",
+    category: "software-platform",
+  },
+  businessContext: {
+    industry: "software-platform",
+    stateCode: null,
+    handlesCardPayments: false,
+  },
+  regional: {
+    archetype: "software-platform",
+    operatesIn: [],
+    sellsTo: [],
+    employsIn: [],
+    dataResidency: [],
+  },
+};
+
+const bankingContext: ComplianceLibraryContext = {
+  ...softwareContext,
+  archetype: {
+    archetypeId: "community-bank",
+    name: "Community Bank",
+    category: "banking-financial-services",
+  },
+  businessContext: {
+    ...softwareContext.businessContext,
+    industry: "financial",
+  },
+  regional: {
+    ...softwareContext.regional,
+    archetype: "banking-financial-services",
+  },
+};
+
+const publicSectorContext: ComplianceLibraryContext = {
+  ...softwareContext,
+  archetype: {
+    archetypeId: "municipal-government",
+    name: "Municipal Government",
+    category: "public-sector",
+  },
+  businessContext: {
+    ...softwareContext.businessContext,
+    industry: "public-sector",
+    stateCode: null,
+  },
+  regional: {
+    ...softwareContext.regional,
+    archetype: "public-sector",
+    operatesIn: ["us"],
+  },
+};
+
+function regulation(overrides: Partial<ClassifiableRegulation>): ClassifiableRegulation {
+  return {
+    regulationId: "REG-US-BSA-AML",
+    name: "Bank Secrecy Act / Anti-Money Laundering",
+    shortName: "BSA/AML",
+    jurisdiction: "US-federal",
+    industry: "financial",
+    sourceType: "external",
+    sourceUrl: "https://www.fincen.gov/resources/statutes-and-regulations/bank-secrecy-act",
+    ...overrides,
+  };
+}
+
+describe("compliance library applicability", () => {
+  it("classifies banking regulations as reference material for a software-platform install", () => {
+    const result = classifyRegulationForInstall(regulation({}), softwareContext);
+
+    expect(result.scope).toBe("reference");
+    expect(result.reason).toContain("Seeded for banking or financial services");
+    expect(result.reason).toContain("Software Platform");
+  });
+
+  it("classifies banking regulations as applicable for a banking archetype", () => {
+    const result = classifyRegulationForInstall(regulation({}), bankingContext);
+
+    expect(result.scope).toBe("applies");
+    expect(result.reason).toContain("Community Bank");
+  });
+
+  it("marks state-law matches for review when the state has not been captured", () => {
+    const result = classifyRegulationForInstall(
+      regulation({
+        regulationId: "REG-US-STATE-OPEN-MEETINGS",
+        name: "State Open Meetings Law (Sunshine Law)",
+        shortName: "Open Meetings",
+        jurisdiction: "US-state",
+        industry: "public-sector",
+        sourceUrl: null,
+      }),
+      publicSectorContext,
+    );
+
+    expect(result.scope).toBe("review");
+    expect(result.reason).toContain("applicable state has not been captured");
+  });
+
+  it("uses the shared CADA regional nexus rule", () => {
+    const cada = regulation({
+      regulationId: "REG-CADA-2026",
+      name: "Cloud and AI Development Act",
+      shortName: "CADA",
+      jurisdiction: "EU",
+      industry: null,
+      sourceUrl: "https://digital-strategy.ec.europa.eu/en/policies/cloud-and-ai-development-act",
+    });
+
+    expect(classifyRegulationForInstall(cada, softwareContext).scope).toBe("review");
+
+    const euSupplier = {
+      ...softwareContext,
+      regional: { ...softwareContext.regional, sellsTo: ["eu"] },
+    };
+    const result = classifyRegulationForInstall(cada, euSupplier);
+    expect(result.scope).toBe("applies");
+    expect(result.reason).toContain("regional nexus");
+  });
+
+  it("filters and counts by applicability scope", () => {
+    const rows = [
+      addRegulationApplicability(regulation({}), softwareContext),
+      addRegulationApplicability(
+        regulation({
+          regulationId: "REG-CADA-2026",
+          name: "Cloud and AI Development Act",
+          shortName: "CADA",
+          jurisdiction: "EU",
+          industry: null,
+        }),
+        softwareContext,
+      ),
+    ];
+
+    expect(filterByComplianceLibraryScope(rows, "applies")).toHaveLength(0);
+    expect(filterByComplianceLibraryScope(rows, "reference")).toHaveLength(1);
+    expect(countByComplianceLibraryScope(rows)).toEqual({
+      applies: 0,
+      review: 1,
+      reference: 1,
+      all: 2,
+    });
+  });
+
+  it("inherits regulation applicability onto obligations", () => {
+    const obligation = addObligationApplicability(
+      {
+        id: "obl-1",
+        title: "Suspicious Activity Report filing",
+        regulation: regulation({}),
+      },
+      softwareContext,
+    );
+
+    expect(obligation.regulation.applicability.scope).toBe("reference");
+  });
+
+  it("parses unknown scope values back to the default applies scope", () => {
+    expect(parseComplianceLibraryScope("review")).toBe("review");
+    expect(parseComplianceLibraryScope("unexpected")).toBe("applies");
+    expect(complianceLibraryContextLabel(softwareContext)).toBe("Software Platform (software-platform)");
+  });
+});

--- a/apps/web/lib/compliance-library.ts
+++ b/apps/web/lib/compliance-library.ts
@@ -1,0 +1,361 @@
+import { prisma } from "@dpf/db";
+import {
+  CADA_APPLICABILITY,
+  regulationApplies,
+  type RegionProfile,
+} from "@dpf/db/regulation-applicability";
+
+export type ComplianceApplicabilityScope = "applies" | "review" | "reference";
+export type ComplianceLibraryScopeFilter = ComplianceApplicabilityScope | "all";
+
+export const DEFAULT_COMPLIANCE_LIBRARY_SCOPE: ComplianceLibraryScopeFilter = "applies";
+export const COMPLIANCE_LIBRARY_SCOPE_FILTERS: ComplianceLibraryScopeFilter[] = [
+  "applies",
+  "review",
+  "reference",
+  "all",
+];
+
+export type ComplianceApplicability = {
+  scope: ComplianceApplicabilityScope;
+  label: string;
+  reason: string;
+};
+
+export type ComplianceLibraryContext = {
+  archetype: {
+    archetypeId: string | null;
+    name: string | null;
+    category: string | null;
+  } | null;
+  businessContext: {
+    industry: string | null;
+    stateCode: string | null;
+    handlesCardPayments: boolean;
+  };
+  regional: RegionProfile;
+};
+
+export type ClassifiableRegulation = {
+  regulationId: string;
+  name: string;
+  shortName: string;
+  jurisdiction: string;
+  industry: string | null;
+  sourceType: string;
+  sourceUrl: string | null;
+};
+
+export type RegulationWithApplicability<T extends ClassifiableRegulation> = T & {
+  applicability: ComplianceApplicability;
+};
+
+export type ClassifiableObligation = {
+  regulation: ClassifiableRegulation;
+};
+
+export type ObligationWithApplicability<T extends ClassifiableObligation> = Omit<T, "regulation"> & {
+  regulation: RegulationWithApplicability<T["regulation"]>;
+};
+
+export type ComplianceLibraryClient = {
+  storefrontConfig: {
+    findFirst(args: {
+      orderBy: { createdAt: "asc" };
+      select: {
+        archetype: {
+          select: { archetypeId: true; name: true; category: true };
+        };
+      };
+    }): Promise<{
+      archetype: {
+        archetypeId: string;
+        name: string;
+        category: string;
+      } | null;
+    } | null>;
+  };
+  businessContext: {
+    findFirst(args: {
+      orderBy: { createdAt: "asc" };
+      select: {
+        industry: true;
+        stateCode: true;
+        operatesIn: true;
+        sellsTo: true;
+        employsIn: true;
+        dataResidency: true;
+        handlesCardPayments: true;
+      };
+    }): Promise<{
+      industry: string | null;
+      stateCode: string | null;
+      operatesIn: string[];
+      sellsTo: string[];
+      employsIn: string[];
+      dataResidency: string[];
+      handlesCardPayments: boolean;
+    } | null>;
+  };
+};
+
+const SCOPE_LABEL: Record<ComplianceApplicabilityScope, string> = {
+  applies: "Applies",
+  review: "Needs review",
+  reference: "Reference",
+};
+
+const INDUSTRY_LABEL: Record<string, string> = {
+  financial: "banking or financial services",
+  "public-sector": "public-sector",
+  "public-safety": "law enforcement or public safety",
+  cooperative: "cooperative",
+};
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function hasAnyRegionalDeclaration(profile: RegionProfile): boolean {
+  return (
+    profile.operatesIn.length > 0 ||
+    profile.sellsTo.length > 0 ||
+    profile.employsIn.length > 0 ||
+    profile.dataResidency.length > 0
+  );
+}
+
+function applicability(scope: ComplianceApplicabilityScope, reason: string): ComplianceApplicability {
+  return { scope, label: SCOPE_LABEL[scope], reason };
+}
+
+function installedArchetypeLabel(context: ComplianceLibraryContext): string {
+  return (
+    context.archetype?.name ||
+    context.archetype?.category ||
+    context.businessContext.industry ||
+    "the installed business"
+  );
+}
+
+function sourceIndustryLabel(industry: string | null): string {
+  return INDUSTRY_LABEL[normalize(industry)] ?? industry ?? "cross-sector";
+}
+
+function matchesRegulationIndustry(
+  regulationIndustry: string,
+  context: ComplianceLibraryContext,
+): boolean {
+  const industry = normalize(regulationIndustry);
+  const category = normalize(context.archetype?.category);
+  const archetypeId = normalize(context.archetype?.archetypeId);
+  const businessIndustry = normalize(context.businessContext.industry);
+
+  if ([category, archetypeId, businessIndustry].includes(industry)) return true;
+
+  if (industry === "financial") {
+    return (
+      category === "banking-financial-services" ||
+      category.includes("financial") ||
+      archetypeId.includes("bank") ||
+      archetypeId.includes("credit-union") ||
+      businessIndustry.includes("financial")
+    );
+  }
+
+  if (industry === "public-sector") {
+    return (
+      category === "public-sector" ||
+      category.includes("public-sector") ||
+      archetypeId.includes("municipal") ||
+      archetypeId.includes("town") ||
+      businessIndustry.includes("public-sector")
+    );
+  }
+
+  if (industry === "public-safety") {
+    return (
+      category === "public-safety" ||
+      archetypeId.includes("law-enforcement") ||
+      archetypeId.includes("public-safety") ||
+      businessIndustry.includes("public-safety")
+    );
+  }
+
+  if (industry === "cooperative") {
+    return (
+      category === "cooperative" ||
+      archetypeId.includes("cooperative") ||
+      businessIndustry.includes("cooperative")
+    );
+  }
+
+  return false;
+}
+
+function isStateLaw(regulation: ClassifiableRegulation): boolean {
+  return normalize(regulation.jurisdiction) === "us-state";
+}
+
+function classifyCada(
+  regulation: ClassifiableRegulation,
+  context: ComplianceLibraryContext,
+): ComplianceApplicability {
+  const result = regulationApplies(CADA_APPLICABILITY, context.regional);
+  if (result.applies) {
+    return applicability("applies", `CADA is in scope because ${result.reason}.`);
+  }
+  if (!hasAnyRegionalDeclaration(context.regional)) {
+    return applicability(
+      "review",
+      "CADA is regional, but no operating/selling/employment/data-residency footprint has been captured yet.",
+    );
+  }
+  return applicability("reference", `CADA is out of scope for this install: ${result.reason}.`);
+}
+
+export function classifyRegulationForInstall(
+  regulation: ClassifiableRegulation,
+  context: ComplianceLibraryContext,
+): ComplianceApplicability {
+  if (regulation.regulationId === "REG-CADA-2026") {
+    return classifyCada(regulation, context);
+  }
+
+  const currentLabel = installedArchetypeLabel(context);
+  const regIndustry = normalize(regulation.industry);
+  if (!regIndustry) {
+    return applicability(
+      "review",
+      "This record is not tied to an industry or archetype, so it needs operator review.",
+    );
+  }
+
+  if (matchesRegulationIndustry(regIndustry, context)) {
+    if (isStateLaw(regulation) && !context.businessContext.stateCode) {
+      return applicability(
+        "review",
+        `Matches ${currentLabel}, but the applicable state has not been captured for state-specific validation.`,
+      );
+    }
+    return applicability(
+      "applies",
+      `Matches the installed ${currentLabel} archetype through the ${sourceIndustryLabel(regulation.industry)} compliance pack.`,
+    );
+  }
+
+  return applicability(
+    "reference",
+    `Seeded for ${sourceIndustryLabel(regulation.industry)}; installed archetype is ${currentLabel}.`,
+  );
+}
+
+export function addRegulationApplicability<T extends ClassifiableRegulation>(
+  regulation: T,
+  context: ComplianceLibraryContext,
+): RegulationWithApplicability<T> {
+  return {
+    ...regulation,
+    applicability: classifyRegulationForInstall(regulation, context),
+  };
+}
+
+export function addObligationApplicability<T extends ClassifiableObligation>(
+  obligation: T,
+  context: ComplianceLibraryContext,
+): ObligationWithApplicability<T> {
+  return {
+    ...obligation,
+    regulation: addRegulationApplicability(obligation.regulation, context),
+  };
+}
+
+export function parseComplianceLibraryScope(
+  value: string | null | undefined,
+): ComplianceLibraryScopeFilter {
+  return COMPLIANCE_LIBRARY_SCOPE_FILTERS.includes(value as ComplianceLibraryScopeFilter)
+    ? (value as ComplianceLibraryScopeFilter)
+    : DEFAULT_COMPLIANCE_LIBRARY_SCOPE;
+}
+
+export function filterByComplianceLibraryScope<T extends { applicability: ComplianceApplicability }>(
+  rows: T[],
+  scope: ComplianceLibraryScopeFilter,
+): T[] {
+  if (scope === "all") return rows;
+  return rows.filter((row) => row.applicability.scope === scope);
+}
+
+export function countByComplianceLibraryScope<T extends { applicability: ComplianceApplicability }>(
+  rows: T[],
+): Record<ComplianceLibraryScopeFilter, number> {
+  return {
+    applies: rows.filter((row) => row.applicability.scope === "applies").length,
+    review: rows.filter((row) => row.applicability.scope === "review").length,
+    reference: rows.filter((row) => row.applicability.scope === "reference").length,
+    all: rows.length,
+  };
+}
+
+export function filterObligationsByComplianceLibraryScope<
+  T extends { regulation: { applicability: ComplianceApplicability } },
+>(rows: T[], scope: ComplianceLibraryScopeFilter): T[] {
+  if (scope === "all") return rows;
+  return rows.filter((row) => row.regulation.applicability.scope === scope);
+}
+
+export function countObligationsByComplianceLibraryScope<
+  T extends { regulation: { applicability: ComplianceApplicability } },
+>(rows: T[]): Record<ComplianceLibraryScopeFilter, number> {
+  return {
+    applies: rows.filter((row) => row.regulation.applicability.scope === "applies").length,
+    review: rows.filter((row) => row.regulation.applicability.scope === "review").length,
+    reference: rows.filter((row) => row.regulation.applicability.scope === "reference").length,
+    all: rows.length,
+  };
+}
+
+export function complianceLibraryContextLabel(context: ComplianceLibraryContext): string {
+  const label = installedArchetypeLabel(context);
+  const category = context.archetype?.category;
+  return category && label !== category ? `${label} (${category})` : label;
+}
+
+export async function resolveComplianceLibraryContext(
+  db: ComplianceLibraryClient = prisma,
+): Promise<ComplianceLibraryContext> {
+  const [storefront, businessContext] = await Promise.all([
+    db.storefrontConfig.findFirst({
+      orderBy: { createdAt: "asc" },
+      select: { archetype: { select: { archetypeId: true, name: true, category: true } } },
+    }),
+    db.businessContext.findFirst({
+      orderBy: { createdAt: "asc" },
+      select: {
+        industry: true,
+        stateCode: true,
+        operatesIn: true,
+        sellsTo: true,
+        employsIn: true,
+        dataResidency: true,
+        handlesCardPayments: true,
+      },
+    }),
+  ]);
+
+  return {
+    archetype: storefront?.archetype ?? null,
+    businessContext: {
+      industry: businessContext?.industry ?? null,
+      stateCode: businessContext?.stateCode ?? null,
+      handlesCardPayments: businessContext?.handlesCardPayments ?? false,
+    },
+    regional: {
+      archetype: storefront?.archetype?.category ?? undefined,
+      operatesIn: businessContext?.operatesIn ?? [],
+      sellsTo: businessContext?.sellsTo ?? [],
+      employsIn: businessContext?.employsIn ?? [],
+      dataResidency: businessContext?.dataResidency ?? [],
+    },
+  };
+}

--- a/docs/superpowers/plans/2026-06-20-regulatory-applicability-library.md
+++ b/docs/superpowers/plans/2026-06-20-regulatory-applicability-library.md
@@ -1,0 +1,49 @@
+# Regulatory Applicability Library Plan
+
+Backlog item: `BI-A6EF7E2C`
+
+## Context
+
+The installed business archetype is `software-platform`, but the Compliance > Library
+regulation and obligation pages show every active seeded compliance record. Most seeded
+records are for banking, credit union, cooperative, public-sector, public-safety, or
+state municipal contexts. The library also hides the canonical source URL until the
+regulation detail page, and many seed records do not currently populate `sourceUrl`.
+
+## Objectives
+
+1. Classify regulations and obligations against the installed business archetype and
+   regional profile before rendering the library.
+2. Default the library to records that apply to the installed business, while keeping
+   reference records reachable for research and onboarding.
+3. Add list-level details and source actions so the operator can validate why a record
+   applies or why it is only reference material.
+4. Backfill official source URLs in seed upserts where the source is stable and
+   canonical.
+5. Preserve theme-aware styling and use report-kit status components for badges.
+
+## Design
+
+- Add a small compliance-library read model in `apps/web/lib/compliance-library.ts`.
+- Reuse `@dpf/db/regulation-applicability` for CADA's regional applicability logic.
+- Map existing seeded industry values to installed archetype categories:
+  - exact category or business context industry matches apply;
+  - `financial` applies to banking/financial archetypes;
+  - `cooperative` applies to cooperative archetypes;
+  - `public-sector` applies to public-sector archetypes;
+  - `public-safety` applies to law-enforcement/public-safety archetypes.
+- Classify each record as `applies`, `review`, or `reference`, with a concise reason.
+- Add scope filters (`Applies`, `Needs review`, `Reference`, `All`) that preserve the
+  existing source-type, regulation, category, and status filters.
+- Convert full-card links to explicit `Details` and `Source` actions.
+- Show missing source metadata explicitly instead of implying it is documented.
+
+## Verification
+
+- Unit tests for applicability classification and scope filtering.
+- Seed invariant tests for source URL coverage on seeded regulations where added.
+- Render-level checks for the library panels so action links and applicability text are
+  present.
+- Source-local tests will run in the worktree if dependencies are available; runtime UI
+  verification and production build require the canonical local install or shared
+  local-CI convergence sandbox because this worktree is currently `source-only`.

--- a/packages/db/src/seed-banking-compliance.ts
+++ b/packages/db/src/seed-banking-compliance.ts
@@ -30,6 +30,7 @@ type RegulationSeed = {
   jurisdiction: string;
   industry: string;
   sourceType: "external";
+  sourceUrl: string | null;
   notes: string;
   obligations: ObligationSeed[];
 };
@@ -42,6 +43,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-federal",
     industry: "financial",
     sourceType: "external",
+    sourceUrl: "https://www.fincen.gov/resources/statutes-and-regulations/bank-secrecy-act",
     notes:
       "The Bank Secrecy Act and its AML program requirements apply to all insured " +
       "depositories — community banks AND credit unions alike. A single shared regime: " +
@@ -113,6 +115,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-federal",
     industry: "financial",
     sourceType: "external",
+    sourceUrl: "https://ncua.gov/regulation-supervision/manuals-guides",
     notes:
       "The National Credit Union Administration regulates and insures federal and most " +
       "state-chartered credit unions: quarterly Call Report (Form 5300), field-of-membership " +
@@ -171,6 +174,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-federal",
     industry: "financial",
     sourceType: "external",
+    sourceUrl: "https://www.ffiec.gov/resources/reporting-forms",
     notes:
       "Community banks file the quarterly FFIEC Call Report and are examined for Community " +
       "Reinvestment Act performance, fair-lending compliance (ECOA/HMDA), insider-lending limits " +
@@ -303,6 +307,8 @@ export async function seedBankingCompliance(prisma: PrismaClient): Promise<void>
         shortName: regData.shortName,
         jurisdiction: regData.jurisdiction,
         industry: regData.industry,
+        sourceType: regData.sourceType,
+        sourceUrl: regData.sourceUrl,
         notes: regData.notes,
       },
       create: regData,

--- a/packages/db/src/seed-cooperative-compliance.ts
+++ b/packages/db/src/seed-cooperative-compliance.ts
@@ -27,6 +27,7 @@ type RegulationSeed = {
   jurisdiction: string;
   industry: string;
   sourceType: "external";
+  sourceUrl: string | null;
   notes: string;
   obligations: ObligationSeed[];
 };
@@ -39,6 +40,7 @@ export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-federal",
     industry: "cooperative",
     sourceType: "external",
+    sourceUrl: "https://uscode.house.gov/view.xhtml?edition=prelim&path=%2Fprelim%40title26%2FsubtitleA%2Fchapter1%2FsubchapterT",
     notes:
       "Internal Revenue Code §§1381–1388 govern how cooperatives deduct patronage dividends: " +
       "allocations must be made on the basis of business done with members, qualified written " +
@@ -100,6 +102,7 @@ export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-state",
     industry: "cooperative",
     sourceType: "external",
+    sourceUrl: null,
     notes:
       "State cooperative statutes and the co-op's own bylaws require democratic member control: " +
       "an annual member meeting, director elections, one-member-one-vote (with limited exceptions), " +
@@ -211,6 +214,8 @@ export async function seedCooperativeCompliance(prisma: PrismaClient): Promise<v
         shortName: regData.shortName,
         jurisdiction: regData.jurisdiction,
         industry: regData.industry,
+        sourceType: regData.sourceType,
+        sourceUrl: regData.sourceUrl,
         notes: regData.notes,
       },
       create: regData,

--- a/packages/db/src/seed-law-enforcement-compliance.ts
+++ b/packages/db/src/seed-law-enforcement-compliance.ts
@@ -28,6 +28,7 @@ type RegulationSeed = {
   jurisdiction: string;
   industry: string;
   sourceType: "external";
+  sourceUrl: string | null;
   notes: string;
   obligations: ObligationSeed[];
 };
@@ -40,6 +41,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-state",
     industry: "public-safety",
     sourceType: "external",
+    sourceUrl: null,
     notes:
       "State Peace Officer Standards and Training (POST) commissions set officer " +
       "certification, mandated annual in-service training hours, firearms and use-of-force " +
@@ -102,6 +104,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-state",
     industry: "public-safety",
     sourceType: "external",
+    sourceUrl: null,
     notes:
       "Agencies must issue, update, and obtain officer attestation to core policies, and " +
       "retain body-worn-camera footage per state schedules. Specifics vary by state and " +
@@ -151,6 +154,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-federal",
     industry: "public-safety",
     sourceType: "external",
+    sourceUrl: "https://le.fbi.gov/cjis-division/cjis-security-policy-resource-center",
     notes:
       "The FBI CJIS Security Policy governs any system that stores, processes, or transmits " +
       "criminal justice information (CJI). DPF Phase 1 for law enforcement stores NO CJI. This " +
@@ -235,6 +239,8 @@ export async function seedLawEnforcementCompliance(prisma: PrismaClient): Promis
         shortName: regData.shortName,
         jurisdiction: regData.jurisdiction,
         industry: regData.industry,
+        sourceType: regData.sourceType,
+        sourceUrl: regData.sourceUrl,
         notes: regData.notes,
       },
       create: regData,

--- a/packages/db/src/seed-public-sector-compliance.ts
+++ b/packages/db/src/seed-public-sector-compliance.ts
@@ -30,6 +30,7 @@ type RegulationSeed = {
   jurisdiction: string;
   industry: string;
   sourceType: "external";
+  sourceUrl: string | null;
   notes: string;
   obligations: ObligationSeed[];
 };
@@ -42,6 +43,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-state",
     industry: "public-sector",
     sourceType: "external",
+    sourceUrl: null,
     notes:
       "All 50 US states require open meetings of public bodies: advance public notice, " +
       "published agendas, public attendance, recorded minutes, and limited executive sessions. " +
@@ -103,6 +105,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-state",
     industry: "public-sector",
     sourceType: "external",
+    sourceUrl: null,
     notes:
       "All 50 states + DC grant public access to government records, with response deadlines " +
       "(commonly 3–10 business days), enumerated exemptions, and fee rules. Retention schedules " +
@@ -154,6 +157,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-state",
     industry: "public-sector",
     sourceType: "external",
+    sourceUrl: null,
     notes:
       "State statutes govern municipal budgeting (annual appropriation), audit/filing with the state " +
       "auditor (annual or biennial by size), and procurement (competitive quotes and sealed-bid " +
@@ -226,6 +230,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-federal",
     industry: "public-sector",
     sourceType: "external",
+    sourceUrl: "https://www.epa.gov/sdwa",
     notes:
       "EPA's Safe Drinking Water Act applies to community water systems through state primacy " +
       "agencies: sampling schedules against maximum contaminant levels, annual Consumer Confidence " +
@@ -289,6 +294,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     jurisdiction: "US-federal",
     industry: "public-sector",
     sourceType: "external",
+    sourceUrl: "https://www.epa.gov/npdes/npdes-permit-basics",
     notes:
       "Wastewater systems discharge under National Pollutant Discharge Elimination System permits " +
       "(EPA or authorized state). The operating loop is the discharge monitoring report cadence and " +
@@ -411,6 +417,8 @@ export async function seedPublicSectorCompliance(prisma: PrismaClient): Promise<
         shortName: regData.shortName,
         jurisdiction: regData.jurisdiction,
         industry: regData.industry,
+        sourceType: regData.sourceType,
+        sourceUrl: regData.sourceUrl,
         notes: regData.notes,
       },
       create: regData,

--- a/packages/db/test/seed-banking-compliance.test.ts
+++ b/packages/db/test/seed-banking-compliance.test.ts
@@ -17,6 +17,7 @@ describe("banking compliance pack data", () => {
     expect(total).toBe(14);
     for (const reg of BANKING_REGULATIONS) {
       expect(reg.industry).toBe("financial");
+      expect(reg.sourceUrl).toMatch(/^https:\/\//);
       expect(reg.obligations.length).toBeGreaterThan(0);
     }
   });

--- a/packages/db/test/seed-cooperative-compliance.test.ts
+++ b/packages/db/test/seed-cooperative-compliance.test.ts
@@ -16,6 +16,11 @@ describe("cooperative compliance pack data", () => {
     expect(total).toBe(8);
     for (const reg of COOPERATIVE_REGULATIONS) {
       expect(reg.industry).toBe("cooperative");
+      if (reg.jurisdiction === "US-federal") {
+        expect(reg.sourceUrl).toMatch(/^https:\/\//);
+      } else {
+        expect(reg.sourceUrl).toBeNull();
+      }
       expect(reg.obligations.length).toBeGreaterThan(0);
     }
   });

--- a/packages/db/test/seed-law-enforcement-compliance.test.ts
+++ b/packages/db/test/seed-law-enforcement-compliance.test.ts
@@ -17,6 +17,11 @@ describe("law-enforcement compliance pack data", () => {
     expect(total).toBe(8);
     for (const reg of LAW_ENFORCEMENT_REGULATIONS) {
       expect(reg.industry).toBe("public-safety");
+      if (reg.jurisdiction === "US-federal") {
+        expect(reg.sourceUrl).toMatch(/^https:\/\//);
+      } else {
+        expect(reg.sourceUrl).toBeNull();
+      }
       expect(reg.obligations.length).toBeGreaterThan(0);
     }
   });

--- a/packages/db/test/seed-public-sector-compliance.test.ts
+++ b/packages/db/test/seed-public-sector-compliance.test.ts
@@ -21,6 +21,11 @@ describe("public-sector compliance pack data", () => {
     expect(total).toBe(18);
     for (const reg of PUBLIC_SECTOR_REGULATIONS) {
       expect(reg.industry).toBe("public-sector");
+      if (reg.jurisdiction === "US-federal") {
+        expect(reg.sourceUrl).toMatch(/^https:\/\//);
+      } else {
+        expect(reg.sourceUrl).toBeNull();
+      }
       expect(reg.obligations.length).toBeGreaterThan(0);
     }
   });


### PR DESCRIPTION
## Summary
- Add an archetype/regional compliance-library read model that classifies regulations as Applies, Needs review, or Reference for the installed business.
- Update regulation and obligation library views to default to applicable records, preserve reference access, and show explicit Details plus Source/Source needed actions.
- Backfill official source URLs for stable federal/EU seeded regulations and add seed invariants for federal vs state-specific source metadata.

## Verification
- `pnpm --filter web exec vitest run lib/compliance-library.test.ts components/compliance/RegulationLibraryPanel.test.tsx components/compliance/ObligationLibraryPanel.test.tsx`
- `pnpm --filter @dpf/db exec vitest run test/seed-banking-compliance.test.ts test/seed-public-sector-compliance.test.ts test/seed-law-enforcement-compliance.test.ts test/seed-cooperative-compliance.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter web build`
- Playwright UX check against `http://127.0.0.1:3011` verified default Applies scope and all-scope details/source affordances.

Backlog item: `BI-A6EF7E2C`
