### PR TITLE
fix(build-studio): stop resume reconciler re-running ideate/review on a build parked at the decompose-required gate (BI-BD4F2D0D)

### DIFF
--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -86,6 +86,88 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     expect(out).toMatchObject({ kind: "resumed", via: "executeTool:reviewDesignDoc" });
   });
 
+  // ── Decompose-gate park guard (BI-BD4F2D0D) ───────────────────────────────
+  // A design that passed review but is sized `decompose-required` is parked at
+  // the Phase-4b gate, not stranded. Resuming it MUST NOT re-dispatch the
+  // ~847s ideate research nor re-run reviewDesignDoc (both just re-fire the
+  // gate forever, burning cloud AI quota) — it proposes candidates once and parks.
+  it("does NOT re-ideate a decompose-required build that passed review — proposes candidates once and parks", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: { decision: "pass", sizeAssessment: { decision: "decompose-required" } },
+    });
+    executeToolMock.mockResolvedValue({ success: true, message: "Proposed 3 candidate decomposition(s) for FB-DR." });
+    const out = await resumePreBuildPhase({ buildId: "FB-DR", phase: "ideate", userId: "uDR" });
+
+    // The expensive pre-build paths are NOT taken.
+    expect(dispatchIdeateMock).not.toHaveBeenCalled();
+    expect(dispatchDesignFixMock).not.toHaveBeenCalled();
+    // It proposes decomposition (the productive alternative), NOT reviewDesignDoc.
+    expect(executeToolMock).toHaveBeenCalledWith(
+      "propose_build_decomposition",
+      { buildId: "FB-DR" },
+      "uDR",
+      { featureBuildId: "FB-DR" },
+    );
+    expect(executeToolMock).not.toHaveBeenCalledWith(
+      "reviewDesignDoc",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(out.kind).toBe("skipped");
+    expect((out as { reason: string }).reason).toContain("decompose-required");
+  });
+
+  it("does NOT re-propose (or re-ideate) when a parked decompose-required build already has candidates", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: {
+        decision: "pass",
+        sizeAssessment: { decision: "decompose-required" },
+        decompositionCandidates: { latest: [{ candidateId: "candidate-1", childScopes: [] }] },
+      },
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-DR2", phase: "ideate", userId: "uDR2" });
+
+    // Pure park: no LLM-bearing work at all (no propose, no review, no ideate).
+    expect(executeToolMock).not.toHaveBeenCalled();
+    expect(dispatchIdeateMock).not.toHaveBeenCalled();
+    expect(dispatchDesignFixMock).not.toHaveBeenCalled();
+    expect(out.kind).toBe("skipped");
+    expect((out as { reason: string }).reason).toContain("candidates already exist");
+  });
+
+  it("does NOT park a decompose-required build once an operator override is recorded — re-runs review so it can advance", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: {
+        decision: "pass",
+        sizeAssessment: { decision: "decompose-required" },
+        decompositionOverride: { justification: "ship monolithically", at: "2026-06-20" },
+      },
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-OV", phase: "ideate", userId: "uOV" });
+    expect(executeToolMock).toHaveBeenCalledWith("reviewDesignDoc", { buildId: "FB-OV" }, "uOV", { featureBuildId: "FB-OV" });
+    expect(executeToolMock).not.toHaveBeenCalledWith("propose_build_decomposition", expect.anything(), expect.anything(), expect.anything());
+    expect(out).toMatchObject({ kind: "resumed", via: "executeTool:reviewDesignDoc" });
+  });
+
+  it("does NOT park a decompose-RECOMMENDED build — it is not gate-blocking, so review re-runs and advances", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: { decision: "pass", sizeAssessment: { decision: "decompose-recommended" } },
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-REC", phase: "ideate", userId: "uREC" });
+    expect(executeToolMock).toHaveBeenCalledWith("reviewDesignDoc", { buildId: "FB-REC" }, "uREC", { featureBuildId: "FB-REC" });
+    expect(executeToolMock).not.toHaveBeenCalledWith("propose_build_decomposition", expect.anything(), expect.anything(), expect.anything());
+    expect(out).toMatchObject({ kind: "resumed", via: "executeTool:reviewDesignDoc" });
+  });
+
   it("runs the design-review fix loop when an existing designDoc's last review FAILED", async () => {
     findUniqueMock.mockResolvedValue({
       designDoc: { problemStatement: "p" },

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -26,6 +26,13 @@
 //     reviewer logic (e.g. the #1976/#1998 chore test-first lenience), so a
 //     review that failed pre-fix can pass on resume.
 //   - Never throws; returns a structured outcome for BuildActivity logging.
+//   - Decompose-gate park (BI-BD4F2D0D): an ideate build whose design PASSED
+//     review but is sized `decompose-required` with no override is parked at the
+//     Phase-4b decomposition gate, not stranded. The resume path detects this
+//     and refuses to re-dispatch ideate / re-run reviewDesignDoc (both just
+//     re-fire the gate and loop, burning cloud AI spend). It instead proposes
+//     decomposition candidates ONCE so the operator can approve_decomposition or
+//     record_decomposition_override, then parks. See isParkedAtDecomposeGate.
 //
 // There is no session on boot, so the caller passes the build's createdById as
 // the actor for the dispatch/review calls.
@@ -44,6 +51,44 @@ function hasPlanTasks(buildPlan: unknown): boolean {
 
 function hasDesignDoc(designDoc: unknown): boolean {
   return designDoc != null && typeof designDoc === "object" && Object.keys(designDoc as object).length > 0;
+}
+
+/** Subset of the persisted designReview JSON the decompose-gate guard reads. */
+type DesignReviewForGate = {
+  decision?: string;
+  sizeAssessment?: { decision?: string } | null;
+  decompositionOverride?: unknown;
+  decompositionCandidates?: { latest?: unknown } | null;
+} | null;
+
+/**
+ * True when a build's persisted designReview shows it is parked at the Phase-4b
+ * `decompose-required` gate: the design PASSED review, the deterministic size
+ * assessment is `decompose-required`, and no operator override was recorded.
+ * This mirrors the exact gate condition in reviewDesignDoc
+ * (apps/web/lib/mcp-tools.ts — `decomposeDecision === "decompose-required" &&
+ * !hasOverride`) so the resume path and the gate agree on what "parked" means.
+ *
+ * Such a build is NOT stranded — it is waiting on a human (`approve_decomposition`
+ * or `record_decomposition_override`). Re-dispatching ideate (≈847s of cloud
+ * ChatGPT/Codex spend) or re-running reviewDesignDoc on it just regenerates /
+ * re-reviews an already-passed design and re-computes the same verdict, re-firing
+ * the gate and looping forever (FB-7930340F burned real AI quota this way for
+ * ~2 days). Only `decompose-required` blocks the gate; `decompose-recommended`
+ * advances to Plan on review, so it is intentionally NOT treated as parked here.
+ */
+function isParkedAtDecomposeGate(dr: DesignReviewForGate): boolean {
+  return (
+    dr?.decision === "pass" &&
+    dr?.sizeAssessment?.decision === "decompose-required" &&
+    dr?.decompositionOverride == null
+  );
+}
+
+/** True when decomposition candidates have already been proposed for this build. */
+function hasDecompositionCandidates(dr: DesignReviewForGate): boolean {
+  const latest = dr?.decompositionCandidates?.latest;
+  return Array.isArray(latest) && latest.length > 0;
 }
 
 /**
@@ -80,6 +125,56 @@ export async function resumePreBuildPhase(params: {
     }
 
     if (phase === "ideate") {
+      // ── Decompose-gate park guard (BI-BD4F2D0D) ──────────────────────────
+      // A build whose design PASSED review but whose deterministic size
+      // assessment is `decompose-required` (with no operator override) is NOT
+      // stranded — it is correctly parked at the Phase-4b decomposition gate,
+      // waiting on a human to call approve_decomposition or
+      // record_decomposition_override. Resuming it the normal way re-dispatches
+      // ideate (≈847s of cloud spend) when the doc is missing, or re-runs
+      // reviewDesignDoc when it is present; either way it regenerates /
+      // re-reviews an already-passed design, re-computes the same
+      // decompose-required verdict, and re-fires the gate — an infinite
+      // resume↔gate-block↔stall loop that burned real ChatGPT/Codex quota for
+      // ~2 days on FB-7930340F. Recognize the parked state up front: ensure the
+      // operator has candidates to act on (propose ONCE, idempotently), then
+      // STOP — never re-run expensive pre-build work for a build whose only
+      // blocker is a pending human decision.
+      const designReviewForGate = build.designReview as DesignReviewForGate;
+      if (isParkedAtDecomposeGate(designReviewForGate)) {
+        if (hasDecompositionCandidates(designReviewForGate)) {
+          return {
+            kind: "skipped",
+            phase,
+            reason:
+              "design passed review but size=decompose-required and candidates already exist — parked awaiting approve_decomposition or record_decomposition_override (NOT re-dispatching ideate or re-running review).",
+          };
+        }
+        // No candidates yet: generate them ONCE so the operator has something to
+        // approve. This is the productive alternative to re-ideating — it never
+        // throws (propose_build_decomposition returns a structured ToolResult)
+        // and is self-idempotent (the branch above short-circuits next time).
+        const { executeTool } = await import("@/lib/mcp-tools");
+        const result = await executeTool(
+          "propose_build_decomposition",
+          { buildId },
+          userId,
+          { featureBuildId: buildId },
+        );
+        const detail = result.success
+          ? `proposed decomposition candidates for operator approval (${
+              typeof result.message === "string" ? result.message.slice(0, 120) : "ok"
+            })`
+          : `propose_build_decomposition produced no candidates (${String(
+              result.error ?? result.message ?? "unknown",
+            ).slice(0, 120)}) — left parked for operator`;
+        return {
+          kind: "skipped",
+          phase,
+          reason: `design passed review but size=decompose-required — ${detail}; parked awaiting approve_decomposition or override (NOT re-dispatching ideate).`,
+        };
+      }
+
       if (!hasDesignDoc(build.designDoc)) {
         // No design doc yet — re-dispatch ideate research to generate it. The
         // dispatcher auto-runs reviewDesignDoc, which advances ideate->plan.

--- a/docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+++ b/docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
@@ -460,6 +460,7 @@ Amendment is intentionally heavyweight. Cheap amendment would turn the parent co
 | Rollup hides a stalled child | D38 trajectory chips operate per child; parent rollup surfaces `needs-attention`. |
 | Contribution semantics break | Execution-organizational Epic becomes the contribution unit; parent design doc is the narrative, child diffs are the evidence. |
 | D31/D35/D36/D37 runtime cluster | Out of scope. Smaller children reduce exposure window but do not replace those fixes. |
+| Resume reconciler re-runs expensive pre-build work on a gate-parked build (BI-BD4F2D0D) | A build parked at the `decompose-required` gate (design passed review, no override) is *waiting on a human*, not stranded. `resumePreBuildPhase` (the boot + periodic resume reconciler, `apps/web/lib/integrate/resume-pre-build-phase.ts`) must NOT re-dispatch Ideate (~847s of cloud spend) or re-run `reviewDesignDoc` (recomputes the same verdict, re-fires the gate) — it detects the parked state via the same condition as §5.1's gate, proposes decomposition candidates once (idempotently) so the operator can `approve_decomposition`/`record_decomposition_override`, then parks. Live repro: FB-7930340F looped for ~2 days, amplified by the #2156 periodic reconciler. |
 
 ## 9. Reduction-gear framing
 


### PR DESCRIPTION
## Problem

A Build Studio build whose design **passed** review but is sized **`decompose-required`** (with no override) is *parked at the Phase-4b decomposition gate* — waiting on a human to call `approve_decomposition` or `record_decomposition_override`. It is **not** stranded.

`resumePreBuildPhase` (the boot **and** periodic resume reconciler, `apps/web/lib/integrate/resume-pre-build-phase.ts`) treated it as stranded, so every resume re-ran expensive pre-build work:
- re-dispatch **Ideate** (~847s of ChatGPT/Codex spend) when the design doc was missing, or
- re-run **`reviewDesignDoc`** when present — which recomputes the *same* `decompose-required` verdict and re-fires the gate (`mcp-tools.ts` → `reviewDesignDoc`).

Nothing ever calls `approve_decomposition`, so the build looped forever:

```
resume → ideate_dispatch (~847s) → reviewDesignDoc "pass"
       → design-size-assessed=decompose-required → phase:gate-blocked
       → watchdog:stall (heartbeat_timeout) → resume → repeat
```

**Live repro:** `FB-7930340F` (BI-WWMD-CONSTRUCTIVE-CONFLICT, xlarge — 6 models ≥ the 5-model threshold) looped for ~2 days, burning real AI quota. Amplified by [#2156](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2156), which made the reconciler run every 10 min instead of only on boot — that change made the loop *continuous*; this is the root-cause stop.

## Fix

Add a **decompose-gate park guard** at the top of the `ideate` branch of `resumePreBuildPhase`, mirroring the gate's own condition (`designReview.decision === "pass"` && `sizeAssessment.decision === "decompose-required"` && no `decompositionOverride`). When a build is parked there, the resume path:

- does **NOT** re-dispatch ideate or re-run `reviewDesignDoc`;
- proposes decomposition candidates **once** (idempotent — skipped when candidates already exist) so the operator has something to approve;
- then parks (returns `skipped`).

`decompose-recommended` is intentionally **not** parked — it is not gate-blocking and advances to Plan on the normal review re-run. An operator override likewise lets the build proceed normally.

## Tests

`resume-pre-build-phase.test.ts` adds cases asserting a `decompose-required` build is **not** re-ideated/re-reviewed on resume (proposes candidates once and parks); no re-propose when candidates already exist; and that an override / `decompose-recommended` still fall through to the normal review re-run.

## Verification

Local unit-test run is **blocked by a degraded dev env** (root clone `packages/types/package.json` missing → workspace install fails; root `node_modules/.pnpm` empty; cold pnpm store with no vitest). Per AGENTS.md §5 this is an *unrun* gate, not a red one — the canonical **Unit Tests** + typecheck gates run in CI. All four new cases plus the three existing ideate cases were verified by static trace against the changed logic.

- Spec/Plan/Doc gate: documented the resume↔gate interaction in `docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md` (§8 failure modes).
- No UI-impacting change (backend resume logic), so the UX-Fit gate does not apply.

Backlog: **BI-BD4F2D0D** (EP-9FC5D2FD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)