### PR TITLE
chore(plugin): bump dpf-platform to 0.2.0 so the bundled hooks reach installs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Digital Product Factory"
   },
   "metadata": {
-    "description": "Project-local marketplace for the DPF-native Claude Code plugin: skills plus MCP wiring.",
+    "description": "Project-local marketplace for the DPF-native Claude Code plugin: skills, MCP wiring, and governance hooks.",
     "version": "0.1.0"
   },
   "plugins": [
@@ -12,7 +12,7 @@
       "name": "dpf-platform",
       "source": "./packages/dpf-skill-pack",
       "description": "DPF-native agent plugin for contributor sessions and in-portal coworker seed source.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Digital Product Factory"
       },

--- a/packages/dpf-skill-pack/.claude-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for both Claude Code contributors (plugin namespace dpf-platform:*) and in-portal coworkers (seeded as SkillDefinition rows by the extended seed-skills.ts loader). Single-source-of-truth contract: superset SKILL.md frontmatter feeds both surfaces from one file per skill. See README.md.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/.codex-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dpf-platform",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "DPF-native agent skills for contributor sessions and in-portal coworkers.",
   "author": {
     "name": "Digital Product Factory",

--- a/packages/dpf-skill-pack/.grok-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for Grok contributors. Single-source-of-truth contract: superset SKILL.md frontmatter feeds both external Grok users and in-portal coworkers. See README.md.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"


### PR DESCRIPTION
## Why

[#2154](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2154) bundled the governance hooks into the `dpf-platform` plugin but **left the version at `0.1.0`**. Existing installs hold a cached `0.1.0` snapshot from *before* the hooks existed, and the agent-toolchain bootstrap treats `0.1.0 → 0.1.0` as a no-op — so the hooks are on `main` but **never reach an already-installed plugin**. This is the "merged ≠ live in your install" gap.

## Fix

Bump the plugin to `0.2.0` across all three surface manifests + the project marketplace. The bootstrap adapter reads the version straight from the manifest — `dpf-bootstrap-agent-toolchain.ps1`: `$expectedVersion = (Get-Content ...\.claude-plugin\plugin.json | ConvertFrom-Json).version` — so the manifest bump is the load-bearing change. On the next install / `git worktree add` / setup, the planner sees `0.1.0 → 0.2.0`, plans an upgrade, and re-caches the plugin **with `hooks/hooks.json`**. Same path covers Claude Code, Codex, and Grok.

## Changes

- `packages/dpf-skill-pack/.claude-plugin/plugin.json` — `0.1.0 → 0.2.0`
- `packages/dpf-skill-pack/.codex-plugin/plugin.json` — `0.1.0 → 0.2.0`
- `packages/dpf-skill-pack/.grok-plugin/plugin.json` — `0.1.0 → 0.2.0`
- `.claude-plugin/marketplace.json` — plugin entry `0.1.0 → 0.2.0`; description now names hooks

## Verification

- Bootstrap reads the version from `plugin.json` at runtime (confirmed in the PS adapter); the planner's upgrade branch fires on `installed !== expected`.
- Bootstrap unit tests use fixture versions (`expectedVersion: "0.1.0"` passed explicitly), so they are unaffected by the real-manifest bump.

Completes the "easy to install" half of BI-CA0ED781 — without this, the hooks from #2154 are dormant in every existing install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
