### PR TITLE
feat(ea-canvas): shape-aware auto-layout for large models + hide RF attribution + back nav (BI-20F95B0E)

### DIFF
--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import {
   ReactFlow, Background, Controls, ConnectionMode, MarkerType,
   useNodesState, useEdgesState,
@@ -67,9 +68,9 @@ type Props = {
 const MAX_LAYOUT_REVISIONS = 10;
 
 function defaultLayoutAlgo(): EaLayoutAlgorithm {
-  if (typeof window === "undefined") return "layered";
+  if (typeof window === "undefined") return "auto";
   const v = window.localStorage.getItem("ea-layout-algo");
-  return v && (EA_LAYOUT_ALGORITHMS as string[]).includes(v) ? (v as EaLayoutAlgorithm) : "layered";
+  return v && (EA_LAYOUT_ALGORITHMS as string[]).includes(v) ? (v as EaLayoutAlgorithm) : "auto";
 }
 
 function makeRevisionId(): string {
@@ -374,6 +375,7 @@ export function EaCanvas({
   const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(null);
   const [isLayouting, setIsLayouting] = useState(false);
   const [revMenuOpen, setRevMenuOpen] = useState(false);
+  const [layoutMenuOpen, setLayoutMenuOpen] = useState(false);
   const [pendingDrop, setPendingDrop] = useState<{
     elementId: string; name: string; typeName: string;
     lifecycleStage: string; lifecycleStatus: string;
@@ -453,6 +455,7 @@ export function EaCanvas({
         requestAnimationFrame(() => rfRef.current?.fitView({ duration: 400, padding: 0.15 }));
       } finally {
         setIsLayouting(false);
+        setLayoutMenuOpen(false);
       }
     },
     [isReadOnly, layoutEdges, viewId, setNodes, currentNodesRecord],
@@ -694,7 +697,8 @@ export function EaCanvas({
         {/* Status bar */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px 14px", background: "var(--dpf-surface-1)", borderBottom: "1px solid var(--dpf-border)" }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span style={{ color: "var(--dpf-muted)", fontSize: 10 }}>EA /</span>
+            <Link href="/ea/views" style={{ color: "var(--dpf-muted)", fontSize: 11, textDecoration: "none" }}>← Views</Link>
+            <span style={{ color: "var(--dpf-muted)", fontSize: 10 }}>/</span>
             <span style={{ color: "var(--dpf-text)", fontSize: 11, fontWeight: 600 }}>{viewName}</span>
             <span style={{
               fontSize: 10, padding: "2px 6px", borderRadius: 3,
@@ -711,25 +715,64 @@ export function EaCanvas({
           <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
             {!isReadOnly && (
               <div style={{ display: "flex", alignItems: "center", gap: 4, position: "relative" }}>
-                <span style={{ color: "var(--dpf-muted)", fontSize: 10 }}>Arrange:</span>
-                {EA_LAYOUT_ALGORITHMS.map((algo) => (
-                  <button
-                    key={algo}
-                    disabled={isLayouting}
-                    onClick={() => {
-                      try { window.localStorage.setItem("ea-layout-algo", algo); } catch { /* ignore */ }
-                      void runAutoLayout(algo);
-                    }}
-                    title={`Auto-layout — ${EA_LAYOUT_LABELS[algo]}`}
-                    style={{
-                      fontSize: 10, padding: "2px 7px", borderRadius: 3,
-                      cursor: isLayouting ? "wait" : "pointer", opacity: isLayouting ? 0.5 : 1,
-                      background: "transparent", border: "1px solid #2a2a40", color: "var(--dpf-muted)",
-                    }}
-                  >
-                    {EA_LAYOUT_LABELS[algo].split(" · ")[0]}
-                  </button>
-                ))}
+                <button
+                  onClick={() => {
+                    try { window.localStorage.setItem("ea-layout-algo", "auto"); } catch { /* ignore */ }
+                    void runAutoLayout("auto");
+                  }}
+                  disabled={isLayouting}
+                  title="Auto-layout — picks the best arrangement for this view's shape"
+                  style={{
+                    fontSize: 10, padding: "2px 9px", borderRadius: 3,
+                    cursor: isLayouting ? "wait" : "pointer", opacity: isLayouting ? 0.6 : 1,
+                    background: "#2a2a50", border: "1px solid var(--dpf-accent)", color: "var(--dpf-accent)",
+                  }}
+                >
+                  {isLayouting ? "Arranging…" : "⤢ Auto-layout"}
+                </button>
+                <button
+                  onClick={() => setLayoutMenuOpen((o) => !o)}
+                  disabled={isLayouting}
+                  title="Choose a specific layout"
+                  style={{
+                    fontSize: 10, padding: "2px 6px", borderRadius: 3,
+                    cursor: isLayouting ? "wait" : "pointer",
+                    background: layoutMenuOpen ? "#2a2a50" : "transparent",
+                    border: `1px solid ${layoutMenuOpen ? "var(--dpf-accent)" : "#2a2a40"}`,
+                    color: "var(--dpf-muted)",
+                  }}
+                >
+                  ▾
+                </button>
+                {layoutMenuOpen && (
+                  <>
+                    <div onClick={() => setLayoutMenuOpen(false)} style={{ position: "fixed", inset: 0, zIndex: 40 }} />
+                    <div style={{
+                      position: "absolute", top: "calc(100% + 4px)", left: 0, zIndex: 41,
+                      minWidth: 200, background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)",
+                      borderRadius: 5, padding: 4, boxShadow: "0 6px 20px #0008",
+                    }}>
+                      {EA_LAYOUT_ALGORITHMS.map((algo) => (
+                        <button
+                          key={algo}
+                          onClick={() => {
+                            try { window.localStorage.setItem("ea-layout-algo", algo); } catch { /* ignore */ }
+                            void runAutoLayout(algo);
+                          }}
+                          style={{
+                            display: "block", width: "100%", textAlign: "left", fontSize: 10,
+                            padding: "5px 7px", borderRadius: 3, cursor: "pointer",
+                            background: "transparent", border: "none", color: "var(--dpf-text)",
+                          }}
+                          onMouseEnter={(e) => { e.currentTarget.style.background = "#2a2a50"; }}
+                          onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+                        >
+                          {EA_LAYOUT_LABELS[algo]}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                )}
 
                 {/* Revisions — restore a previous layout */}
                 {(() => {
@@ -814,6 +857,7 @@ export function EaCanvas({
           onDragOver={(e) => e.preventDefault()}
         >
           <ReactFlow
+            proOptions={{ hideAttribution: true }}
             nodes={nodes}
             edges={edges}
             onNodesChange={handleNodesChange}

--- a/apps/web/lib/ea/canvas-layout.test.ts
+++ b/apps/web/lib/ea/canvas-layout.test.ts
@@ -1,18 +1,25 @@
 import { describe, it, expect } from "vitest";
-import { computeEaLayout, placeIncremental, EA_NODE_W, EA_NODE_H } from "./canvas-layout";
+import {
+  computeEaLayout,
+  placeIncremental,
+  pickAutoAlgorithm,
+  computeMetrics,
+  EA_NODE_W,
+  EA_NODE_H,
+} from "./canvas-layout";
 
 const nodes = (...ids: string[]) => ids.map((id) => ({ id }));
 const edge = (source: string, target: string) => ({ source, target });
 
-const ALGORITHMS = ["layered", "radial", "hierarchical"] as const;
+const ALGORITHMS = ["auto", "organic", "tree", "layered", "radial"] as const;
 
 describe("computeEaLayout", () => {
   it("returns an empty map for no nodes", async () => {
-    expect(await computeEaLayout([], [], { algorithm: "layered" })).toEqual({});
+    expect(await computeEaLayout([], [], { algorithm: "auto" })).toEqual({});
   });
 
   it("places a single node", async () => {
-    const result = await computeEaLayout(nodes("a"), [], { algorithm: "radial" });
+    const result = await computeEaLayout(nodes("a"), [], { algorithm: "organic" });
     expect(Object.keys(result)).toEqual(["a"]);
   });
 
@@ -30,7 +37,7 @@ describe("computeEaLayout", () => {
       }
     });
 
-    it(`${algorithm}: is deterministic for identical (connected) input`, async () => {
+    it(`${algorithm}: is deterministic for identical input`, async () => {
       const ns = nodes("a", "b", "c", "d");
       const es = [edge("a", "b"), edge("b", "c"), edge("c", "d")];
       const first = await computeEaLayout(ns, es, { algorithm });
@@ -39,11 +46,11 @@ describe("computeEaLayout", () => {
     });
   }
 
-  it("hierarchical: no two nodes overlap (separated by at least the node footprint)", async () => {
+  it("layered: no two nodes overlap (ELK respects node spacing)", async () => {
     const result = await computeEaLayout(
       nodes("a", "b", "c", "d"),
       [edge("a", "b"), edge("b", "c"), edge("c", "d")],
-      { algorithm: "hierarchical" },
+      { algorithm: "layered" },
     );
     const points = Object.values(result);
     for (let i = 0; i < points.length; i += 1) {
@@ -54,6 +61,53 @@ describe("computeEaLayout", () => {
         expect(overlap).toBe(false);
       }
     }
+  });
+});
+
+describe("computeMetrics", () => {
+  it("identifies a tree/forest (no cycle)", () => {
+    const m = computeMetrics(nodes("a", "b", "c", "d"), [edge("a", "b"), edge("b", "c"), edge("c", "d")]);
+    expect(m.isForest).toBe(true);
+    expect(m.components).toBe(1);
+    expect(m.maxDegree).toBe(2);
+    expect(m.isolated).toBe(0);
+  });
+
+  it("detects cycles (not a forest) and counts components + isolated nodes", () => {
+    // triangle a-b-c-a (cycle) plus an isolated node d
+    const m = computeMetrics(nodes("a", "b", "c", "d"), [edge("a", "b"), edge("b", "c"), edge("c", "a")]);
+    expect(m.isForest).toBe(false);
+    expect(m.components).toBe(2); // {a,b,c} and {d}
+    expect(m.isolated).toBe(1);
+  });
+
+  it("dedupes parallel edges when counting m", () => {
+    const m = computeMetrics(nodes("a", "b"), [edge("a", "b"), edge("b", "a"), edge("a", "b")]);
+    expect(m.m).toBe(1);
+  });
+});
+
+describe("pickAutoAlgorithm", () => {
+  it("chooses tree for a forest/tree", () => {
+    expect(pickAutoAlgorithm(nodes("a", "b", "c", "d"), [edge("a", "b"), edge("b", "c"), edge("c", "d")])).toBe("tree");
+  });
+
+  it("chooses radial for a star (one dominant hub)", () => {
+    const star = [edge("h", "a"), edge("h", "b"), edge("h", "c"), edge("h", "d"), edge("h", "e")];
+    expect(pickAutoAlgorithm(nodes("h", "a", "b", "c", "d", "e"), star)).toBe("radial");
+  });
+
+  it("chooses organic for a dense, cyclic mesh", () => {
+    const dense = [
+      edge("a", "b"), edge("a", "c"), edge("a", "d"), edge("a", "e"),
+      edge("b", "c"), edge("c", "d"), edge("d", "e"), edge("e", "b"),
+    ]; // n=5, m=8, density 1.6, has cycles
+    expect(pickAutoAlgorithm(nodes("a", "b", "c", "d", "e"), dense)).toBe("organic");
+  });
+
+  it("chooses layered for a sparse cyclic (DAG-like) graph", () => {
+    const diamond = [edge("a", "b"), edge("a", "c"), edge("b", "d"), edge("c", "d")]; // cycle, density 1.0
+    expect(pickAutoAlgorithm(nodes("a", "b", "c", "d"), diamond)).toBe("layered");
   });
 });
 

--- a/apps/web/lib/ea/canvas-layout.ts
+++ b/apps/web/lib/ea/canvas-layout.ts
@@ -1,48 +1,85 @@
-// Automatic layout for the EA views/viewpoints canvas (BI-D9F9B34F, EP-ARCH-GRAPH-LIVE).
+// Automatic layout for the EA views/viewpoints canvas (BI-D9F9B34F, BI-20F95B0E; EP-ARCH-GRAPH-LIVE).
 //
-// Reuses the render-agnostic layout engines in `lib/graph/` (dagre / ELK / radial-BFS)
-// rather than introducing a new layout library. EA elements + relationships are adapted
-// to `GraphData`, an engine is run, and the result is normalized to React Flow top-left
-// coordinates keyed by EaViewElement id (the React Flow node id used by EaCanvas).
+// EA views are SysML/ArchiMate graphs: mostly containment trees/forests (Package⊃Part⊃Port)
+// stored as flat "contains" edges, plus cross-cutting association/flow edges. Many large views
+// are trees (e.g. ~615-node route trees) or dependency meshes with disconnected islands.
 //
-// All functions here are pure (the layered path is async only because ELK is) so they can
-// be unit-tested without React Flow or the DB.
+// We reuse ELK (already a dependency) directly — calling the right algorithm for the graph's
+// shape and ALWAYS separating connected components so disconnected nodes pack tightly instead
+// of sprawling. "radial" stays a hand-rolled BFS (good hub-and-spoke). No new layout library.
+//
+// All functions are pure (ELK paths are async only because ELK is) and unit-testable without
+// React Flow or the DB.
 
 import type { GraphData } from "@/lib/actions/graph";
-import { computeHierarchicalLayout } from "@/lib/graph/layout-hierarchical";
 import { computeRadialLayout } from "@/lib/graph/layout-radial";
-import { computeSwimLaneLayout } from "@/lib/graph/layout-swimlane";
 
-export type EaLayoutAlgorithm = "layered" | "radial" | "hierarchical";
+// "auto" inspects the graph shape and dispatches to the best concrete algorithm.
+export type EaLayoutAlgorithm = "auto" | "organic" | "tree" | "layered" | "radial";
+export type ConcreteLayoutAlgorithm = Exclude<EaLayoutAlgorithm, "auto">;
 
 export type EaLayoutNode = { id: string };
 export type EaLayoutEdge = { source: string; target: string };
 export type EaPositions = Record<string, { x: number; y: number }>;
 
 // Footprint of a standard EA element node (EaElementNode renders ~120–160px wide).
-// The layout is spaced for this box so auto-laid views don't overlap.
 export const EA_NODE_W = 170;
 export const EA_NODE_H = 80;
-const GAP = 70;
+const GAP = 60;
 const PITCH_X = EA_NODE_W + GAP;
 const PITCH_Y = EA_NODE_H + GAP;
 const MARGIN = 40;
 
+export const EA_LAYOUT_ALGORITHMS: EaLayoutAlgorithm[] = ["auto", "organic", "tree", "layered", "radial"];
+
 export const EA_LAYOUT_LABELS: Record<EaLayoutAlgorithm, string> = {
-  layered: "Layered · fewest crossings",
+  auto: "Auto · best fit",
+  organic: "Organic · clustered",
+  tree: "Tree · hierarchy",
+  layered: "Layered · directed flow",
   radial: "Radial · hub & spoke",
-  hierarchical: "Hierarchical · top-down",
 };
 
-export const EA_LAYOUT_ALGORITHMS: EaLayoutAlgorithm[] = ["layered", "radial", "hierarchical"];
+// Shared ELK options: separate + pack disconnected components (the de-sprawl fix), and keep
+// the packed result roughly 16:10 rather than a long strip.
+const ELK_SHARED: Record<string, string> = {
+  "elk.separateConnectedComponents": "true",
+  "elk.spacing.componentComponent": "60",
+  "elk.aspectRatio": "1.6",
+};
 
-function toGraphData(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): GraphData {
-  const ids = new Set(nodes.map((n) => n.id));
+function elkOptionsFor(algo: "organic" | "tree" | "layered"): Record<string, string> {
+  if (algo === "organic") {
+    // ELK stress majorization — the clustered, force-directed "organic" look. iterationLimit
+    // is capped (ELK's default is effectively unbounded) so big views stay responsive.
+    return {
+      ...ELK_SHARED,
+      "elk.algorithm": "stress",
+      "elk.stress.desiredEdgeLength": String(PITCH_X),
+      "elk.stress.iterationLimit": "200",
+      "elk.spacing.nodeNode": String(GAP),
+    };
+  }
+  if (algo === "tree") {
+    // ELK mrtree (Walker's tree layout) — compact, legible trees/forests.
+    return {
+      ...ELK_SHARED,
+      "elk.algorithm": "mrtree",
+      "elk.direction": "DOWN",
+      "elk.spacing.nodeNode": String(GAP),
+    };
+  }
+  // layered — Sugiyama; best for directed flow/DAGs. thoroughness lowered from the default 7
+  // so 600-node views lay out quickly.
   return {
-    nodes: nodes.map((n) => ({ id: n.id, name: n.id, label: n.id, color: "#000", size: 1 })),
-    links: edges
-      .filter((e) => e.source !== e.target && ids.has(e.source) && ids.has(e.target))
-      .map((e) => ({ source: e.source, target: e.target, type: "rel" })),
+    ...ELK_SHARED,
+    "elk.algorithm": "layered",
+    "elk.direction": "DOWN",
+    "elk.layered.spacing.nodeNodeBetweenLayers": String(PITCH_Y),
+    "elk.spacing.nodeNode": String(GAP),
+    "elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
+    "elk.layered.thoroughness": "4",
+    "elk.edgeRouting": "ORTHOGONAL",
   };
 }
 
@@ -57,7 +94,83 @@ function buildAdjacency(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): Map<strin
   return adj;
 }
 
-/** Most-connected node — the natural center for a radial layout. */
+export type GraphMetrics = {
+  n: number;
+  m: number; // unique undirected edges
+  components: number;
+  isForest: boolean; // no cycle → tree/forest
+  maxDegree: number;
+  density: number; // m / n
+  isolated: number; // degree-0 nodes
+};
+
+// Single pass: union-find for components + cycle detection, plus degree stats.
+export function computeMetrics(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): GraphMetrics {
+  const index = new Map<string, number>();
+  nodes.forEach((node, i) => index.set(node.id, i));
+  const parent = nodes.map((_, i) => i);
+  const find = (x: number): number => {
+    let root = x;
+    while (parent[root] !== root) root = parent[root]!;
+    while (parent[x] !== root) {
+      const next = parent[x]!;
+      parent[x] = root;
+      x = next;
+    }
+    return root;
+  };
+
+  const degree = new Map<string, number>(nodes.map((n) => [n.id, 0]));
+  const seen = new Set<string>();
+  let m = 0;
+  let hasCycle = false;
+  for (const e of edges) {
+    if (e.source === e.target) continue;
+    const a = index.get(e.source);
+    const b = index.get(e.target);
+    if (a === undefined || b === undefined) continue;
+    const key = a < b ? `${a}-${b}` : `${b}-${a}`;
+    if (seen.has(key)) continue; // dedupe parallel edges
+    seen.add(key);
+    m += 1;
+    degree.set(e.source, (degree.get(e.source) ?? 0) + 1);
+    degree.set(e.target, (degree.get(e.target) ?? 0) + 1);
+    const ra = find(a);
+    const rb = find(b);
+    if (ra === rb) hasCycle = true;
+    else parent[ra] = rb;
+  }
+
+  const roots = new Set<number>();
+  for (let i = 0; i < nodes.length; i += 1) roots.add(find(i));
+  let maxDegree = 0;
+  let isolated = 0;
+  for (const d of degree.values()) {
+    if (d > maxDegree) maxDegree = d;
+    if (d === 0) isolated += 1;
+  }
+  const n = nodes.length;
+  return { n, m, components: roots.size, isForest: !hasCycle, maxDegree, density: n ? m / n : 0, isolated };
+}
+
+/**
+ * Pick the best concrete algorithm from the graph's shape:
+ * - tree/forest → mrtree (or radial when one node dominates, i.e. a star)
+ * - dense / many isolated / many components → stress (organic)
+ * - otherwise → layered (directed flow)
+ */
+export function pickAutoAlgorithm(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): ConcreteLayoutAlgorithm {
+  if (nodes.length <= 2) return "layered";
+  const x = computeMetrics(nodes, edges);
+  if (x.isForest) {
+    return x.maxDegree / x.n > 0.5 ? "radial" : "tree";
+  }
+  if (x.density > 1.5 || x.isolated > x.n * 0.2 || x.components > Math.max(3, x.n * 0.15)) {
+    return "organic";
+  }
+  return "layered";
+}
+
 function highestDegreeId(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): string {
   const adj = buildAdjacency(nodes, edges);
   let best = nodes[0]?.id ?? "";
@@ -72,11 +185,8 @@ function highestDegreeId(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): string {
   return best;
 }
 
-/**
- * Ring spacing wide enough that the densest ring's nodes don't overlap angularly.
- * `computeRadialLayout` hard-codes 60×30 node sizing, so we size the rings here for the
- * larger EA node footprint instead of editing the shared graph helper.
- */
+// Ring spacing wide enough that the densest ring's nodes don't overlap angularly
+// (computeRadialLayout hard-codes 60×30 sizing, so we size rings for the EA footprint here).
 function radialRingSpacing(nodes: EaLayoutNode[], edges: EaLayoutEdge[], rootId: string): number {
   const adj = buildAdjacency(nodes, edges);
   const depth = new Map<string, number>([[rootId, 0]]);
@@ -96,21 +206,23 @@ function radialRingSpacing(nodes: EaLayoutNode[], edges: EaLayoutEdge[], rootId:
     if (d >= 1) ringCount.set(d, (ringCount.get(d) ?? 0) + 1);
   }
   const maxRing = ringCount.size > 0 ? Math.max(...ringCount.values()) : 1;
-  // Arc length per node on the innermost ring (radius = ringSpacing) must be >= PITCH_X.
   const needed = Math.ceil((PITCH_X * maxRing) / (2 * Math.PI));
   return Math.max(220, needed);
 }
 
-function fromResult(
-  result: { nodes: Array<{ id: string; x: number; y: number }> },
-  centerBased: boolean,
-): EaPositions {
+function toGraphData(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): GraphData {
+  const ids = new Set(nodes.map((n) => n.id));
+  return {
+    nodes: nodes.map((n) => ({ id: n.id, name: n.id, label: n.id, color: "#000", size: 1 })),
+    links: edges
+      .filter((e) => e.source !== e.target && ids.has(e.source) && ids.has(e.target))
+      .map((e) => ({ source: e.source, target: e.target, type: "rel" })),
+  };
+}
+
+function fromCenter(result: { nodes: Array<{ id: string; x: number; y: number }> }): EaPositions {
   const out: EaPositions = {};
-  for (const n of result.nodes) {
-    out[n.id] = centerBased
-      ? { x: n.x - EA_NODE_W / 2, y: n.y - EA_NODE_H / 2 }
-      : { x: n.x, y: n.y };
-  }
+  for (const n of result.nodes) out[n.id] = { x: n.x - EA_NODE_W / 2, y: n.y - EA_NODE_H / 2 };
   return out;
 }
 
@@ -127,6 +239,41 @@ function normalize(positions: EaPositions): EaPositions {
   return out;
 }
 
+async function runElk(
+  nodes: EaLayoutNode[],
+  edges: EaLayoutEdge[],
+  algo: "organic" | "tree" | "layered",
+): Promise<EaPositions> {
+  const ELK = (await import("elkjs/lib/elk.bundled.js")).default;
+  const elk = new ELK();
+  const ids = new Set(nodes.map((n) => n.id));
+  const children = nodes.map((n) => ({ id: n.id, width: EA_NODE_W, height: EA_NODE_H }));
+  const elkEdges = edges
+    .filter((e) => e.source !== e.target && ids.has(e.source) && ids.has(e.target))
+    .map((e, i) => ({ id: `e${i}`, sources: [e.source], targets: [e.target] }));
+
+  const graph = await elk.layout({
+    id: "root",
+    layoutOptions: elkOptionsFor(algo),
+    children,
+    edges: elkEdges,
+  });
+
+  const out: EaPositions = {};
+  for (const child of graph.children ?? []) {
+    out[child.id] = { x: child.x ?? 0, y: child.y ?? 0 }; // ELK reports top-left
+  }
+  // Defensive: ensure every node got a position.
+  let parked = 0;
+  for (const n of nodes) {
+    if (!out[n.id]) {
+      out[n.id] = { x: parked * PITCH_X, y: -PITCH_Y };
+      parked += 1;
+    }
+  }
+  return normalize(out);
+}
+
 /**
  * Compute an automatic layout for the given EA nodes + edges.
  * Returns React Flow top-left positions keyed by node id (EaViewElement id).
@@ -134,43 +281,26 @@ function normalize(positions: EaPositions): EaPositions {
 export async function computeEaLayout(
   nodes: EaLayoutNode[],
   edges: EaLayoutEdge[],
-  opts: { algorithm: EaLayoutAlgorithm; direction?: "TB" | "LR" },
+  opts: { algorithm: EaLayoutAlgorithm },
 ): Promise<EaPositions> {
   if (nodes.length === 0) return {};
   if (nodes.length === 1) return { [nodes[0]!.id]: { x: MARGIN, y: MARGIN } };
 
-  const graphData = toGraphData(nodes, edges);
+  const algo: ConcreteLayoutAlgorithm =
+    opts.algorithm === "auto" ? pickAutoAlgorithm(nodes, edges) : opts.algorithm;
 
-  if (opts.algorithm === "hierarchical") {
-    const result = computeHierarchicalLayout(graphData, {
-      direction: opts.direction ?? "TB",
-      nodeWidth: EA_NODE_W,
-      nodeHeight: EA_NODE_H,
-      rankSep: PITCH_Y,
-      nodeSep: GAP,
-    });
-    return normalize(fromResult(result, true));
-  }
-
-  if (opts.algorithm === "radial") {
+  if (algo === "radial") {
     const rootId = highestDegreeId(nodes, edges);
-    const result = computeRadialLayout(graphData, {
+    const result = computeRadialLayout(toGraphData(nodes, edges), {
       rootId,
       ringSpacing: radialRingSpacing(nodes, edges, rootId),
       centerX: 0,
       centerY: 0,
     });
-    return normalize(fromResult(result, true));
+    return normalize(fromCenter(result));
   }
 
-  // Default: ELK "layered" with no partitions — strongest edge-crossing minimization.
-  const result = await computeSwimLaneLayout(graphData, () => null, {
-    nodeWidth: EA_NODE_W,
-    nodeHeight: EA_NODE_H,
-    layerSpacing: PITCH_Y,
-    nodeSpacing: GAP,
-  });
-  return normalize(fromResult(result, false)); // ELK reports top-left already
+  return runElk(nodes, edges, algo); // organic | tree | layered
 }
 
 function overlaps(a: { x: number; y: number }, b: { x: number; y: number }): boolean {

--- a/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
+++ b/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
@@ -38,3 +38,19 @@ Layout repositions **top-level** nodes only; structured value-stream children fo
 ## Verification
 
 Local: vitest on the adapter; full web suite before push. CI green. Functional: load an auto-generated EA view, click each algorithm, drag a node, reload (persisted), restore a revision, add an element and confirm it nestles by its neighbor.
+
+---
+
+## Addendum — 2026-06-20: shape-aware layouts for large models + 2 UX fixes (BI-20F95B0E)
+
+Live review of the deployed #2151 surfaced that the layouts sprawl into hairballs on large views, plus two UX bugs. Two research passes (web + live-DB) found: the big views are **trees/forests stored as flat "contains" edges** (Application Routes 615n/614e tree; Code Structure 343n star; Data Model 424n/1262e/57 isolated), and the layered path **never set `elk.separateConnectedComponents`**, so disconnected nodes spread. `EaViewElement.parentViewElementId` (containment nesting) is schema-supported but never populated by the generators.
+
+**Shipped (no new dependency — ELK already installed):**
+- Rewrote `apps/web/lib/ea/canvas-layout.ts` to call ELK directly (dropping the swimlane-partitioner detour) with `separateConnectedComponents=true` + component spacing + aspect ratio on every ELK path.
+- Algorithm set is now **`auto` (default) · `organic` (ELK stress, capped iterations) · `tree` (ELK mrtree) · `layered` (ELK, tuned) · `radial` (BFS)** — replaces the old layered/radial/hierarchical trio.
+- `pickAutoAlgorithm` + `computeMetrics` (union-find components + cycle detection + degree stats): tree/forest→tree, star→radial, dense/disconnected→organic, else layered.
+- `EaCanvas` picker → an **Auto-layout** primary button + a layout menu (`▾`) for specific algorithms.
+- **UX fix B:** `proOptions={{ hideAttribution: true }}` removes the React Flow badge (@xyflow/react is MIT).
+- **UX fix C:** added a `← Views` back link (→ `/ea/views`) to the EA top bar, matching the sibling-detail-page pattern.
+
+**Deferred follow-ups (file separately):** populate `parentViewElementId` from "contains" edges + render containment as nested groups (`elk.hierarchyHandling: INCLUDE_CHILDREN` + React Flow parent nodes) — biggest structural ceiling; and move ELK to a Web Worker for 600-node perf.


### PR DESCRIPTION
## Summary

Follow-up to #2151 from live review: the auto-layouts sprawled into hairballs on large views, plus two UX bugs. Two research passes (web + live-DB characterization) found the root causes:

- The big views are **trees/forests stored as flat "contains" edges** — *Application Routes* = 615 nodes/614 edges (a tree), *Code Structure* = 343-node star, *Data Model* = 424 nodes/1262 edges with 57 isolated nodes — but they were laid out by general-graph algorithms.
- The layered path **never set `elk.separateConnectedComponents`**, so ELK packed everything (including disconnected nodes) into one frame and spread it out.

Fixed with **no new dependency** (ELK already shipped):

### Layout — `apps/web/lib/ea/canvas-layout.ts`
- Call ELK **directly** (dropping the swimlane-partitioner detour) with `separateConnectedComponents` + component spacing + aspect ratio on every ELK path — the de-sprawl fix.
- New algorithm set: **`auto` (default) · `organic` (ELK stress, capped iterations) · `tree` (ELK mrtree) · `layered` (ELK, tuned) · `radial` (BFS)** — replaces the old layered/radial/hierarchical trio.
- **`auto`** dispatches on graph shape via `computeMetrics` (union-find components + cycle detection + degree): tree/forest → `tree`, star → `radial`, dense/disconnected → `organic`, else → `layered`. So the user doesn't have to guess, and large trees finally render as trees.

### UX — `apps/web/components/ea/EaCanvas.tsx`
1. **React Flow attribution badge removed** — `proOptions={{ hideAttribution: true }}` (the offsite link in the lower-right). `@xyflow/react` is MIT, so no attribution requirement.
2. **Back navigation added** — a `← Views` link (→ `/ea/views`) in the top bar, matching the sibling detail-page pattern. The EA canvas renders its own top bar, which is why it lacked the shell's back affordance.
3. Layout picker is now an **Auto-layout** primary button + a `▾` menu for specific algorithms.

## Testing
- `lib/ea/canvas-layout.test.ts`: 24 tests — every algorithm positions all nodes (finite, deterministic), no overlap (layered), `computeMetrics` (forest/cycle/components/isolated/dedup), `pickAutoAlgorithm` (tree→tree, star→radial, dense→organic, sparse-cyclic→layered), `placeIncremental`.
- 16 EA component + 52 graph/actions/TopologyGraph tests pass; `apps/web` typecheck clean.

## Deferred follow-ups (will file separately)
- **Containment nesting** — populate `EaViewElement.parentViewElementId` from "contains" edges and render packages/parts as nested groups (`elk.hierarchyHandling: INCLUDE_CHILDREN` + React Flow parent nodes). Biggest structural-readability ceiling; needs a generator change (containment isn't persisted today).
- **ELK web worker** for 600-node layout performance (keep the main thread responsive).

Backlog: **BI-20F95B0E** · Epic: **EP-ARCH-GRAPH-LIVE** · extends #2151 (BI-D9F9B34F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
