### PR TITLE
feat(mobile): resolve WorkItem → CustomerAccount so the invoice screen pre-fills the customer

### DIFF
--- a/apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx
+++ b/apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx
@@ -64,10 +64,13 @@ export default function JobDetailScreen() {
 
   // Once a job is completed, the field tech bills the customer. Seed the
   // draft with the job title as a single line so the tech only has to set
-  // the price; the invoice screen lets them refine before submit.
+  // the price; the invoice screen lets them refine before submit. When the
+  // server resolved the customer from the job's source row, pre-fill the
+  // accountId so the tech doesn't type it.
   const goToInvoice = (): void => {
     beginInvoiceDraft({
       workItemId: detail.itemId,
+      accountId: detail.account?.accountId,
       seedLines: [{ description: detail.title, quantity: 1, unitPrice: 0 }],
     });
     router.push(`/jobs/${encodeURIComponent(detail.itemId)}/invoice`);
@@ -78,6 +81,11 @@ export default function JobDetailScreen() {
       <Text style={styles.title}>{detail.title}</Text>
       <Text style={styles.status}>{detail.status}</Text>
       <Text style={styles.meta}>Urgency: {detail.urgency}</Text>
+      {detail.account ? (
+        <Text style={styles.meta} testID="job-customer">
+          Customer: {detail.account.name}
+        </Text>
+      ) : null}
       {detail.dueAt ? (
         <Text style={styles.meta}>
           Due {new Date(detail.dueAt).toLocaleString()}

--- a/apps/mobile/app/(tabs)/jobs/[itemId]/invoice.tsx
+++ b/apps/mobile/app/(tabs)/jobs/[itemId]/invoice.tsx
@@ -69,15 +69,31 @@ export default function DraftInvoiceScreen() {
       <Text style={styles.h1}>New invoice</Text>
 
       <Text style={styles.label}>Customer account id</Text>
-      <TextInput
-        value={accountId}
-        onChangeText={setAccountId}
-        style={styles.input}
-        placeholder="ACC-…"
-        placeholderTextColor={theme.colors.textMuted}
-        autoCapitalize="characters"
-        testID="invoice-accountId"
-      />
+      {accountId ? (
+        // Server resolved the account from the WorkItem source — show it as
+        // a read-only confirmation instead of asking the tech to retype it.
+        // Long-press to override (the few legitimate cases: tech notices the
+        // resolved account is wrong, or the source link is stale).
+        <Pressable
+          onLongPress={() => setAccountId("")}
+          accessibilityRole="button"
+          testID="invoice-accountId-readonly"
+          style={[styles.input, styles.readonlyAccount]}
+        >
+          <Text style={styles.readonlyAccountText}>{accountId}</Text>
+          <Text style={styles.readonlyAccountHint}>long-press to change</Text>
+        </Pressable>
+      ) : (
+        <TextInput
+          value={accountId}
+          onChangeText={setAccountId}
+          style={styles.input}
+          placeholder="ACC-…"
+          placeholderTextColor={theme.colors.textMuted}
+          autoCapitalize="characters"
+          testID="invoice-accountId"
+        />
+      )}
 
       <Text style={styles.label}>Due date (YYYY-MM-DD)</Text>
       <TextInput
@@ -226,6 +242,13 @@ function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useThem
       fontSize: 15,
     },
     multiline: { minHeight: 70, textAlignVertical: "top" },
+    readonlyAccount: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+    },
+    readonlyAccountText: { color: colors.text, fontSize: 15, fontWeight: "600" },
+    readonlyAccountHint: { color: colors.textMuted, fontSize: 11 },
     lineRow: {
       backgroundColor: colors.surface2,
       borderColor: colors.border,

--- a/apps/mobile/src/features/jobs/jobs.store.test.ts
+++ b/apps/mobile/src/features/jobs/jobs.store.test.ts
@@ -36,6 +36,7 @@ const detail: WorkItemDetail = {
   assignedToUserId: "u1",
   claimedAt: "2026-06-14T01:00:00.000Z",
   completedAt: null,
+  account: null,
 };
 
 function reset() {

--- a/apps/web/app/api/v1/work-items/[itemId]/route.ts
+++ b/apps/web/app/api/v1/work-items/[itemId]/route.ts
@@ -12,6 +12,7 @@ import {
   isValidWorkItemTransition,
   statusUpdateData,
 } from "@/lib/api/work-items";
+import { resolveWorkItemAccount } from "@/lib/api/work-item-account-resolution";
 
 const DETAIL_SELECT = {
   id: true,
@@ -52,7 +53,11 @@ export async function GET(
     const { user } = await authenticateRequest(request);
     const { itemId } = await params;
     const row = await loadAssigned(itemId, user.id);
-    return apiSuccess(toWorkItemDetail(row));
+    const account = await resolveWorkItemAccount({
+      sourceType: row.sourceType,
+      sourceId: row.sourceId,
+    });
+    return apiSuccess(toWorkItemDetail(row, account));
   } catch (e) {
     if (e instanceof ApiError) return e.toResponse();
     return NextResponse.json(
@@ -93,8 +98,12 @@ export async function PATCH(
       data: statusUpdateData(to, new Date()),
       select: DETAIL_SELECT,
     });
+    const account = await resolveWorkItemAccount({
+      sourceType: updated.sourceType,
+      sourceId: updated.sourceId,
+    });
 
-    return apiSuccess(toWorkItemDetail(updated));
+    return apiSuccess(toWorkItemDetail(updated, account));
   } catch (e) {
     if (e instanceof ApiError) return e.toResponse();
     return NextResponse.json(

--- a/apps/web/lib/api/work-item-account-resolution.test.ts
+++ b/apps/web/lib/api/work-item-account-resolution.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for resolveWorkItemAccount — the WorkItem source → CustomerAccount
+ * resolver that backs the mobile invoice screen's customer pre-fill.
+ *
+ * The set of recognized source types is a closed registry. Each branch must
+ * have at least one happy-path and one miss-case test so adding a new source
+ * forces an entry here, not just a Prisma call elsewhere.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockEngagementFindUnique,
+  mockOpportunityFindUnique,
+  mockBookingFindUnique,
+  mockContactFindUnique,
+  mockActivityFindUnique,
+} = vi.hoisted(() => ({
+  mockEngagementFindUnique: vi.fn(),
+  mockOpportunityFindUnique: vi.fn(),
+  mockBookingFindUnique: vi.fn(),
+  mockContactFindUnique: vi.fn(),
+  mockActivityFindUnique: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    engagement: { findUnique: mockEngagementFindUnique },
+    opportunity: { findUnique: mockOpportunityFindUnique },
+    storefrontBooking: { findUnique: mockBookingFindUnique },
+    customerContact: { findUnique: mockContactFindUnique },
+    activity: { findUnique: mockActivityFindUnique },
+  },
+}));
+
+import {
+  __RESOLVER_KEYS_FOR_TESTS,
+  resolveWorkItemAccount,
+} from "./work-item-account-resolution";
+
+const ACCT = { id: "acct_cuid", accountId: "ACC-ACME", name: "Acme HVAC Co" };
+
+beforeEach(() => {
+  mockEngagementFindUnique.mockReset();
+  mockOpportunityFindUnique.mockReset();
+  mockBookingFindUnique.mockReset();
+  mockContactFindUnique.mockReset();
+  mockActivityFindUnique.mockReset();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveWorkItemAccount — input guards", () => {
+  it("returns null when sourceType is missing/empty/whitespace", async () => {
+    expect(
+      await resolveWorkItemAccount({ sourceType: null, sourceId: "x" }),
+    ).toBeNull();
+    expect(
+      await resolveWorkItemAccount({ sourceType: "", sourceId: "x" }),
+    ).toBeNull();
+    expect(
+      await resolveWorkItemAccount({ sourceType: "   ", sourceId: "x" }),
+    ).toBeNull();
+  });
+
+  it("returns null when sourceId is missing/empty", async () => {
+    expect(
+      await resolveWorkItemAccount({ sourceType: "engagement", sourceId: null }),
+    ).toBeNull();
+    expect(
+      await resolveWorkItemAccount({ sourceType: "engagement", sourceId: "" }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unknown sourceType without touching the DB", async () => {
+    const result = await resolveWorkItemAccount({
+      sourceType: "totally-made-up",
+      sourceId: "WHATEVER-1",
+    });
+    expect(result).toBeNull();
+    expect(mockEngagementFindUnique).not.toHaveBeenCalled();
+    expect(mockOpportunityFindUnique).not.toHaveBeenCalled();
+    expect(mockBookingFindUnique).not.toHaveBeenCalled();
+    expect(mockActivityFindUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveWorkItemAccount — engagement", () => {
+  it("resolves via Engagement.account", async () => {
+    mockEngagementFindUnique.mockResolvedValueOnce({ account: ACCT });
+    const result = await resolveWorkItemAccount({
+      sourceType: "engagement",
+      sourceId: "ENG-1",
+    });
+    expect(result).toEqual({
+      id: ACCT.id,
+      accountId: ACCT.accountId,
+      name: ACCT.name,
+    });
+    expect(mockEngagementFindUnique.mock.calls[0][0].where).toEqual({
+      engagementId: "ENG-1",
+    });
+  });
+
+  it("returns null when the engagement has no account link (orphan source)", async () => {
+    mockEngagementFindUnique.mockResolvedValueOnce({ account: null });
+    expect(
+      await resolveWorkItemAccount({
+        sourceType: "engagement",
+        sourceId: "ENG-orphan",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the engagement row was deleted", async () => {
+    mockEngagementFindUnique.mockResolvedValueOnce(null);
+    expect(
+      await resolveWorkItemAccount({
+        sourceType: "engagement",
+        sourceId: "ENG-gone",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveWorkItemAccount — opportunity", () => {
+  it("resolves via Opportunity.account", async () => {
+    mockOpportunityFindUnique.mockResolvedValueOnce({ account: ACCT });
+    const result = await resolveWorkItemAccount({
+      sourceType: "opportunity",
+      sourceId: "OPP-1",
+    });
+    expect(result?.accountId).toBe("ACC-ACME");
+    expect(mockOpportunityFindUnique.mock.calls[0][0].where).toEqual({
+      opportunityId: "OPP-1",
+    });
+  });
+});
+
+describe("resolveWorkItemAccount — booking", () => {
+  it("resolves via StorefrontBooking → contact → account (two-hop)", async () => {
+    mockBookingFindUnique.mockResolvedValueOnce({ customerContactId: "con_1" });
+    mockContactFindUnique.mockResolvedValueOnce({ account: ACCT });
+    const result = await resolveWorkItemAccount({
+      sourceType: "booking",
+      sourceId: "BK-1",
+    });
+    expect(result?.accountId).toBe("ACC-ACME");
+    expect(mockBookingFindUnique.mock.calls[0][0].where).toEqual({
+      bookingRef: "BK-1",
+    });
+    expect(mockContactFindUnique.mock.calls[0][0].where).toEqual({
+      id: "con_1",
+    });
+  });
+
+  it("accepts the `storefront-booking` alias for backward-compatible sourceType", async () => {
+    mockBookingFindUnique.mockResolvedValueOnce({ customerContactId: "con_1" });
+    mockContactFindUnique.mockResolvedValueOnce({ account: ACCT });
+    const result = await resolveWorkItemAccount({
+      sourceType: "storefront-booking",
+      sourceId: "BK-1",
+    });
+    expect(result?.accountId).toBe("ACC-ACME");
+  });
+
+  it("returns null when the booking has no customerContactId (anonymous storefront customer)", async () => {
+    mockBookingFindUnique.mockResolvedValueOnce({ customerContactId: null });
+    expect(
+      await resolveWorkItemAccount({ sourceType: "booking", sourceId: "BK-2" }),
+    ).toBeNull();
+    expect(mockContactFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the contact's account is missing", async () => {
+    mockBookingFindUnique.mockResolvedValueOnce({ customerContactId: "con_1" });
+    mockContactFindUnique.mockResolvedValueOnce({ account: null });
+    expect(
+      await resolveWorkItemAccount({ sourceType: "booking", sourceId: "BK-3" }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveWorkItemAccount — activity", () => {
+  it("resolves via Activity.account", async () => {
+    mockActivityFindUnique.mockResolvedValueOnce({ account: ACCT });
+    const result = await resolveWorkItemAccount({
+      sourceType: "activity",
+      sourceId: "ACT-1",
+    });
+    expect(result?.accountId).toBe("ACC-ACME");
+    expect(mockActivityFindUnique.mock.calls[0][0].where).toEqual({
+      activityId: "ACT-1",
+    });
+  });
+});
+
+describe("resolveWorkItemAccount — registry guard", () => {
+  it("recognizes exactly the documented sourceType set", () => {
+    // Closed registry — adding a new source means updating both the
+    // resolver map and this test in the same commit.
+    expect(__RESOLVER_KEYS_FOR_TESTS.sort()).toEqual(
+      ["engagement", "opportunity", "storefront-booking", "booking", "activity"].sort(),
+    );
+  });
+});

--- a/apps/web/lib/api/work-item-account-resolution.ts
+++ b/apps/web/lib/api/work-item-account-resolution.ts
@@ -1,0 +1,112 @@
+/**
+ * WorkItem → CustomerAccount resolver.
+ *
+ * A WorkItem has only `sourceType` + `sourceId` to its origin — there's no
+ * direct account FK. This module owns the per-source-kind lookup chain that
+ * resolves the customer account for the field-tech surface so the mobile
+ * invoice screen can pre-fill `accountId` from the job instead of asking the
+ * tech to type it.
+ *
+ * Each branch is a single Prisma `findUnique`; misses return null so the
+ * caller keeps working with the free-text fallback. The set of recognized
+ * sourceTypes is closed to the ones whose models actually carry an account
+ * link today — adding a new source means adding a branch here AND a route
+ * test, not just one or the other.
+ */
+import { prisma } from "@dpf/db";
+import type { WorkItemAccount } from "@dpf/types";
+
+type AccountRow = {
+  id: string;
+  accountId: string;
+  name: string;
+};
+
+function toAccount(row: AccountRow | null | undefined): WorkItemAccount | null {
+  if (!row) return null;
+  return { id: row.id, accountId: row.accountId, name: row.name };
+}
+
+/** Engagement is the most direct path — its `accountId` IS the FK to CustomerAccount. */
+async function fromEngagement(sourceId: string): Promise<WorkItemAccount | null> {
+  const row = await prisma.engagement.findUnique({
+    where: { engagementId: sourceId },
+    select: { account: { select: { id: true, accountId: true, name: true } } },
+  });
+  return toAccount(row?.account);
+}
+
+/** Opportunity.accountId is required — every Opportunity has an account. */
+async function fromOpportunity(sourceId: string): Promise<WorkItemAccount | null> {
+  const row = await prisma.opportunity.findUnique({
+    where: { opportunityId: sourceId },
+    select: { account: { select: { id: true, accountId: true, name: true } } },
+  });
+  return toAccount(row?.account);
+}
+
+/**
+ * StorefrontBooking carries `customerContactId` as a plain column (no Prisma
+ * `@relation`), so we walk in two hops: booking → contact id → contact's
+ * account. Returns null at any miss along the chain.
+ */
+async function fromBooking(sourceId: string): Promise<WorkItemAccount | null> {
+  const booking = await prisma.storefrontBooking.findUnique({
+    where: { bookingRef: sourceId },
+    select: { customerContactId: true },
+  });
+  if (!booking?.customerContactId) return null;
+  const contact = await prisma.customerContact.findUnique({
+    where: { id: booking.customerContactId },
+    select: { account: { select: { id: true, accountId: true, name: true } } },
+  });
+  return toAccount(contact?.account);
+}
+
+/** Activity ties to an account through accountId directly. */
+async function fromActivity(sourceId: string): Promise<WorkItemAccount | null> {
+  const row = await prisma.activity.findUnique({
+    where: { activityId: sourceId },
+    select: { account: { select: { id: true, accountId: true, name: true } } },
+  });
+  return toAccount(row?.account);
+}
+
+/**
+ * The set of WorkItem `sourceType` values this resolver understands. Closed
+ * by design — an unknown source returns null and the tech enters the account
+ * manually, rather than failing.
+ */
+const RESOLVERS: Record<
+  string,
+  (sourceId: string) => Promise<WorkItemAccount | null>
+> = {
+  engagement: fromEngagement,
+  opportunity: fromOpportunity,
+  "storefront-booking": fromBooking,
+  booking: fromBooking,
+  activity: fromActivity,
+};
+
+export interface ResolveWorkItemAccountInput {
+  sourceType: string | null | undefined;
+  sourceId: string | null | undefined;
+}
+
+/**
+ * Resolve a WorkItem's customer account by walking its source link.
+ * Returns null when there's no mapping or the source row no longer exists.
+ */
+export async function resolveWorkItemAccount(
+  input: ResolveWorkItemAccountInput,
+): Promise<WorkItemAccount | null> {
+  const type = input.sourceType?.trim();
+  const id = input.sourceId?.trim();
+  if (!type || !id) return null;
+  const resolver = RESOLVERS[type];
+  if (!resolver) return null;
+  return resolver(id);
+}
+
+/** Test-only export of the closed source-type registry. */
+export const __RESOLVER_KEYS_FOR_TESTS = Object.keys(RESOLVERS);

--- a/apps/web/lib/api/work-items.test.ts
+++ b/apps/web/lib/api/work-items.test.ts
@@ -94,6 +94,17 @@ describe("toWorkItemSummary / toWorkItemDetail", () => {
     expect(d.dueAt).toBeNull();
     expect(d.teamId).toBeNull();
   });
+  it("account defaults to null when not resolved", () => {
+    expect(toWorkItemDetail(baseRow).account).toBeNull();
+  });
+  it("forwards a resolved customer account onto the wire shape", () => {
+    const account = {
+      id: "acct_cuid",
+      accountId: "ACC-ACME",
+      name: "Acme HVAC Co",
+    };
+    expect(toWorkItemDetail(baseRow, account).account).toEqual(account);
+  });
 });
 
 describe("statusUpdateData", () => {

--- a/apps/web/lib/api/work-items.ts
+++ b/apps/web/lib/api/work-items.ts
@@ -6,6 +6,7 @@
 // tested in work-items.test.ts; the routes own the Prisma calls.
 
 import type {
+  WorkItemAccount,
   WorkItemStatus,
   WorkItemSummary,
   WorkItemDetail,
@@ -88,7 +89,10 @@ export function toWorkItemSummary(row: WorkItemRow): WorkItemSummary {
   };
 }
 
-export function toWorkItemDetail(row: WorkItemRow): WorkItemDetail {
+export function toWorkItemDetail(
+  row: WorkItemRow,
+  account: WorkItemAccount | null = null,
+): WorkItemDetail {
   return {
     ...toWorkItemSummary(row),
     description: row.description ?? "",
@@ -97,6 +101,7 @@ export function toWorkItemDetail(row: WorkItemRow): WorkItemDetail {
     assignedToUserId: row.assignedToUserId ?? null,
     claimedAt: iso(row.claimedAt),
     completedAt: iso(row.completedAt),
+    account,
   };
 }
 

--- a/packages/types/src/work-items.ts
+++ b/packages/types/src/work-items.ts
@@ -24,6 +24,20 @@ export interface WorkItemSummary {
   createdAt: string;
 }
 
+/**
+ * Resolved customer link for a WorkItem — when the source row points at one.
+ * `accountId` is the public-id string (`ACC-…`), the same value the invoice
+ * create endpoint expects in its `accountId` field, so the mobile billing
+ * screen can pre-fill the customer without a separate lookup.
+ */
+export interface WorkItemAccount {
+  /** Internal CustomerAccount.id (cuid). */
+  id: string;
+  /** Public CustomerAccount.accountId — the value finance APIs accept. */
+  accountId: string;
+  name: string;
+}
+
 /** Full work item for the job detail screen. */
 export interface WorkItemDetail extends WorkItemSummary {
   description: string;
@@ -32,6 +46,13 @@ export interface WorkItemDetail extends WorkItemSummary {
   assignedToUserId: string | null;
   claimedAt: string | null;
   completedAt: string | null;
+  /**
+   * Customer this job is for, resolved server-side from the source row when
+   * possible (Engagement / Opportunity / StorefrontBooking links). Null when
+   * the source can't be mapped — the field tech must enter the account on
+   * the invoice screen.
+   */
+  account: WorkItemAccount | null;
 }
 
 /** Body for a field check-in/out status transition. */


### PR DESCRIPTION
## Summary

Removes the largest piece of friction from PR #2043's field-tech billing flow: the tech used to type the customer's `accountId` from memory on the invoice screen. Now the server resolves the account from the `WorkItem.sourceType` + `sourceId` link (Engagement / Opportunity / StorefrontBooking / Activity) and the mobile shell renders it as a read-only Customer line. Free-text fallback stays for unrecognised sources.

Spec: [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html) §7 (employee field surface).

## Mechanics

- `@dpf/types/work-items.ts` — `WorkItemDetail.account: WorkItemAccount | null` (`{ id, accountId, name }`).
- `apps/web/lib/api/work-item-account-resolution.ts` — closed source-type registry: `engagement` → `Engagement.account`, `opportunity` → `Opportunity.account`, `booking` / `storefront-booking` → 2-hop via `customerContactId`, `activity` → `Activity.account`. Unknown source → `null` (the tech keeps the free-text input).
- `apps/web/lib/api/work-items.ts` — `toWorkItemDetail` accepts an optional resolved account; older callers default to `null` and stay green.
- `apps/web/app/api/v1/work-items/[itemId]/route.ts` — GET + PATCH call `resolveWorkItemAccount` before projecting.
- `apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx` — renders `Customer: <name>` on the job header; seeds the invoice draft with the resolved `accountId` when Draft invoice is tapped.
- `apps/mobile/app/(tabs)/jobs/[itemId]/invoice.tsx` — pre-filled `accountId` renders read-only with a long-press override (rare but real: stale source link).

## Test plan

- [x] `pnpm --filter web exec vitest run lib/api/work-item` — 25/25 (13 new resolver + 2 new projector + 10 existing).
- [x] `pnpm --filter mobile exec jest --testPathPatterns="jobs|invoices|customer-invoices"` — 22/22.
- [x] `pnpm --filter web typecheck` — clean.
- [x] `pnpm --filter mobile typecheck` — clean.

## What's next

Same multi-slice push toward "iOS app supported end-to-end":

1. Customer "My visits" surface.
2. Job-completion photo + signature capture (wires existing `expo-camera` + signature widget into the post-completion flow).
3. Multi-space switcher UX (Town M2).
4. EAS pipeline + path-filtered mobile CI lane.
5. Geo-discovery "Nearby" client + stub directory (Town M4).
