### PR TITLE
feat(inference): headroom-aware + architecture-aware local-model auto-detect

### DIFF
--- a/apps/web/lib/inference/local-model-policy.test.ts
+++ b/apps/web/lib/inference/local-model-policy.test.ts
@@ -96,7 +96,9 @@ describe("recommendKeepGenerationModel", () => {
     expect(keep).toBe("qwen3-coder");
   });
   it("falls back to the hardware-recommended tier", () => {
-    const keep = recommendKeepGenerationModel(["ai/qwen3:8B-Q4_K_M", "ai/qwen3:14B-Q6_K"], 12);
+    // 17 GB budget: the headroom-aware recommendation is the 14B (12+5=17), so
+    // recommendKeep picks it over the also-present 8B.
+    const keep = recommendKeepGenerationModel(["ai/qwen3:8B-Q4_K_M", "ai/qwen3:14B-Q6_K"], 17);
     expect(keep).toBe("ai/qwen3:14B-Q6_K");
   });
   it("returns the single model unchanged", () => {

--- a/apps/web/lib/inference/local-model-policy.test.ts
+++ b/apps/web/lib/inference/local-model-policy.test.ts
@@ -3,6 +3,8 @@ import {
   isEmbeddingModelId,
   classifyLocalModelRole,
   recommendGenerationModel,
+  recommendGenerationModelForHost,
+  computeMemoryBudgetGb,
   estimateModelVramGb,
   recommendKeepGenerationModel,
   detectLocalModelOverCommit,
@@ -23,19 +25,46 @@ describe("classifyLocalModelRole / isEmbeddingModelId", () => {
   });
 });
 
-describe("recommendGenerationModel", () => {
+describe("recommendGenerationModel (discrete, headroom-aware)", () => {
   it("null VRAM (undetectable) → broadly-compatible 8B default", () => {
     expect(recommendGenerationModel(null)).toBe("ai/qwen3:8B-Q4_K_M");
   });
-  it("0 VRAM (CPU-only host) → 4B tier", () => {
+  it("0 VRAM (CPU-only host) → smallest tier", () => {
     expect(recommendGenerationModel(0)).toBe("ai/qwen3:4B-UD-Q4_K_XL");
   });
-  it("picks the largest tier that fits", () => {
-    expect(recommendGenerationModel(24)).toBe("ai/qwen3.6:35B-A3B-UD-Q4_K_M");
-    expect(recommendGenerationModel(22)).toBe("ai/qwen3.6:35B-A3B-UD-Q4_K_M");
-    expect(recommendGenerationModel(12)).toBe("ai/qwen3:14B-Q6_K");
-    expect(recommendGenerationModel(6)).toBe("ai/qwen3:8B-Q4_K_M");
-    expect(recommendGenerationModel(5)).toBe("ai/qwen3:4B-UD-Q4_K_XL");
+  it("reserves headroom so a recommended model never fills the card", () => {
+    // 24 GB card → 30B (16+5=21 fits), NOT the 35B (22+5=27 > 24). This is the
+    // bug the recalibration fixes: the 35B at build context over-commits a 24 GB card.
+    expect(recommendGenerationModel(24)).toBe("ai/qwen3-coder");
+    expect(recommendGenerationModel(21)).toBe("ai/qwen3-coder");
+    expect(recommendGenerationModel(27)).toBe("ai/qwen3.6:35B-A3B-UD-Q4_K_M");
+    expect(recommendGenerationModel(17)).toBe("ai/qwen3:14B-Q6_K");
+    expect(recommendGenerationModel(12)).toBe("ai/qwen3:8B-Q4_K_M");
+    expect(recommendGenerationModel(11)).toBe("ai/qwen3:8B-Q4_K_M");
+    // budget GPUs land on a model that actually fits, not one that over-commits
+    expect(recommendGenerationModel(8)).toBe("ai/qwen3:4B-UD-Q4_K_XL");
+    expect(recommendGenerationModel(6)).toBe("ai/qwen3:4B-UD-Q4_K_XL");
+  });
+});
+
+describe("recommendGenerationModelForHost (architecture-aware) + computeMemoryBudgetGb", () => {
+  it("discrete card uses VRAM directly → the 4090 lands on the 30B coder", () => {
+    expect(recommendGenerationModelForHost({ architecture: "discrete", vramGb: 24 })).toBe("ai/qwen3-coder");
+    expect(computeMemoryBudgetGb({ architecture: "discrete", vramGb: 24 })).toBe(24);
+  });
+  it("unified Apple Silicon runs a far larger model than the same GB of discrete VRAM", () => {
+    // 128 GB unified Mac → 80B MoE (128 * 0.75 = 96 budget; 48+5 fits).
+    expect(recommendGenerationModelForHost({ architecture: "unified", totalRamGb: 128 })).toBe("ai/qwen3-coder-next");
+    expect(recommendGenerationModelForHost({ architecture: "unified", totalRamGb: 32 })).toBe("ai/qwen3-coder");
+    expect(recommendGenerationModelForHost({ architecture: "unified", totalRamGb: 16 })).toBe("ai/qwen3:8B-Q4_K_M");
+  });
+  it("cpu-only reserves more system RAM for the OS", () => {
+    expect(computeMemoryBudgetGb({ architecture: "cpu", totalRamGb: 16 })).toBe(8);
+    expect(recommendGenerationModelForHost({ architecture: "cpu", totalRamGb: 16 })).toBe("ai/qwen3:4B-UD-Q4_K_XL");
+  });
+  it("a budget 8–12 GB discrete GPU never over-commits", () => {
+    expect(recommendGenerationModelForHost({ architecture: "discrete", vramGb: 12 })).toBe("ai/qwen3:8B-Q4_K_M");
+    expect(recommendGenerationModelForHost({ architecture: "discrete", vramGb: 8 })).toBe("ai/qwen3:4B-UD-Q4_K_XL");
   });
 });
 
@@ -43,6 +72,7 @@ describe("estimateModelVramGb", () => {
   it("estimates known families", () => {
     expect(estimateModelVramGb("ai/nomic-embed-text-v1.5")).toBe(1);
     expect(estimateModelVramGb("qwen3-coder")).toBe(16); // 30B-A3B
+    expect(estimateModelVramGb("ai/qwen3-coder-next")).toBe(48); // 80B MoE
     expect(estimateModelVramGb("ai/qwen3.6:35B-A3B-UD-Q4_K_M")).toBe(22);
     expect(estimateModelVramGb("gemma4:12B")).toBe(8);
     expect(estimateModelVramGb("ai/gemma4")).toBe(20);

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -56,45 +56,101 @@ export function classifyLocalModelRole(modelId: string): LocalModelRole {
 }
 
 /**
- * Canonical generation-model tiers, ordered largest-first. Qwen3 — NOT Gemma —
- * because the platform's Coworkers catalog tiers Qwen3 as `strong + Tool Use`
- * (F1 0.93 @ 8B, 0.97 @ 14B) while Gemma tiers as `adequate`, and default
- * coworkers require `minimumTier: strong`.
+ * Headroom (GB) reserved ON TOP OF a model's weights for the context KV cache,
+ * the embedder, and runtime overhead — so a recommended model fits with room to
+ * RUN, not just to load. Grounded in on-box measurement (RTX 4090, 2026-06-20):
+ * qwen3-coder 30B (~16.5 GB weights) at a 24k build context used ~20.7 GB
+ * resident — ~4 GB over weights — and the embedder adds ~1 GB. 5 GB covers both
+ * with margin and is why a 24 GB card lands on the 30B, not the 35B.
+ */
+export const MODEL_HEADROOM_GB = 5;
+
+/**
+ * Fraction of UNIFIED memory (Apple Silicon) usable for the model. macOS lets
+ * Metal address ~70–75% of unified RAM for the GPU; the rest stays for the OS +
+ * the Docker stack. So a 128 GB Mac has a far larger model budget than a 24 GB
+ * discrete card — it can run an 80B where the 4090 runs a 30B.
+ */
+export const UNIFIED_USABLE_FRACTION = 0.75;
+
+/** Fraction of system RAM usable for CPU-only inference (leaves room for OS + stack). */
+export const CPU_USABLE_FRACTION = 0.5;
+
+export type HostArchitecture = "discrete" | "unified" | "cpu";
+
+export interface HostMemory {
+  /** "discrete" = dedicated GPU VRAM; "unified" = Apple Silicon shared RAM; "cpu" = no GPU. */
+  architecture: HostArchitecture;
+  /** Dedicated GPU VRAM in GB (discrete hosts). */
+  vramGb?: number | null;
+  /** Total system RAM in GB (drives the unified + cpu budgets). */
+  totalRamGb?: number | null;
+}
+
+/**
+ * Canonical generation-model tiers, ordered largest-first. Qwen3 family (strong
+ * tool-calling); the `-coder` variants double as the Build Studio code model AND
+ * a capable chat model, so one model serves both. `weightsGb` is the approximate
+ * Q4 resident WEIGHT footprint; the selector adds MODEL_HEADROOM_GB for context +
+ * embedder before deciding what fits.
  *
- * `minVramGb` is the discrete-VRAM floor; `approxVramGb` is the resident
- * footprint used for the over-commit budget. Mirrored (with a pointer comment)
- * by scripts/detect-hardware-host.ts and install-dpf.{ps1,sh}, which cannot
- * import TypeScript. Keep those in sync when this changes.
+ * Mirrored (with a pointer comment) by scripts/detect-hardware-host.ts and
+ * install-dpf.{ps1,sh}, which cannot import TypeScript. Keep those in sync.
  */
 export interface LocalModelTier {
   model: string;
-  minVramGb: number;
-  approxVramGb: number;
+  /** Approximate resident weight footprint, GB (Q4). */
+  weightsGb: number;
   label: string;
 }
 
 export const LOCAL_MODEL_TIERS: readonly LocalModelTier[] = [
-  { model: "ai/qwen3.6:35B-A3B-UD-Q4_K_M", minVramGb: 22, approxVramGb: 22, label: "Qwen3.6 35B-A3B (MoE)" },
-  { model: "ai/qwen3:14B-Q6_K", minVramGb: 12, approxVramGb: 12, label: "Qwen3 14B" },
-  { model: "ai/qwen3:8B-Q4_K_M", minVramGb: 6, approxVramGb: 6, label: "Qwen3 8B" },
-  { model: "ai/qwen3:4B-UD-Q4_K_XL", minVramGb: 0, approxVramGb: 3, label: "Qwen3 4B" },
+  { model: "ai/qwen3-coder-next", weightsGb: 48, label: "Qwen3-Coder-Next 80B (MoE, 3B active)" }, // big unified (Apple 128 GB) / 64 GB+ discrete
+  { model: "ai/qwen3.6:35B-A3B-UD-Q4_K_M", weightsGb: 22, label: "Qwen3.6 35B-A3B (MoE)" },
+  { model: "ai/qwen3-coder", weightsGb: 16, label: "Qwen3-Coder 30B (MoE, 3B active)" }, // the 24 GB-card sweet spot (measured ~20.7 GB @ 24k ctx)
+  { model: "ai/qwen3:14B-Q6_K", weightsGb: 12, label: "Qwen3 14B" },
+  { model: "ai/qwen3:8B-Q4_K_M", weightsGb: 6, label: "Qwen3 8B" },
+  { model: "ai/qwen3:4B-UD-Q4_K_XL", weightsGb: 3, label: "Qwen3 4B" },
 ] as const;
 
+/** Smallest tier — the CPU-OK fallback when nothing larger fits the budget. */
+const SMALLEST_TIER = LOCAL_MODEL_TIERS[LOCAL_MODEL_TIERS.length - 1]!;
+
 /**
- * Select the largest generation tier that fits available VRAM. Walks the tier
- * list top-down and returns the first whose `minVramGb` floor is satisfied.
- *
- * Semantics (preserve the prior bootstrap behaviour exactly):
- *   - `null`  → VRAM is UNDETECTABLE → broadly-compatible mid default (8B).
- *   - `0`     → detected zero VRAM (CPU-only host) → the CPU-OK 4B tier.
- *   - `n > 0` → largest tier whose floor `n` satisfies.
+ * The memory budget (GB) actually available to a local model on this host:
+ *   - discrete → dedicated VRAM (hard ceiling)
+ *   - unified  → a fraction of total RAM (Apple Silicon shares it with the OS)
+ *   - cpu      → a smaller fraction of total RAM
+ */
+export function computeMemoryBudgetGb(host: HostMemory): number {
+  if (host.architecture === "discrete") return host.vramGb && host.vramGb > 0 ? host.vramGb : 0;
+  if (host.architecture === "unified") return Math.max(0, (host.totalRamGb ?? 0) * UNIFIED_USABLE_FRACTION);
+  return Math.max(0, (host.totalRamGb ?? 0) * CPU_USABLE_FRACTION);
+}
+
+/**
+ * Recommend the largest generation model that fits the host's memory budget WITH
+ * headroom for context + embedder. Architecture-aware: a 24 GB discrete card
+ * lands on the 30B (fits at build context), a 128 GB unified Mac lands on the
+ * 80B MoE, and an 8–12 GB budget GPU lands on a model that actually fits instead
+ * of one that fills the card and then over-commits the moment it runs.
+ */
+export function recommendGenerationModelForHost(host: HostMemory): string {
+  const budget = computeMemoryBudgetGb(host);
+  for (const tier of LOCAL_MODEL_TIERS) {
+    if (tier.weightsGb + MODEL_HEADROOM_GB <= budget) return tier.model;
+  }
+  return SMALLEST_TIER.model;
+}
+
+/**
+ * Discrete-VRAM convenience wrapper (the runtime bootstrap path knows only VRAM).
+ * Headroom-aware. `null` = VRAM undetectable → broadly-compatible 8B default;
+ * `0` = detected zero VRAM (CPU-only) → the smallest tier.
  */
 export function recommendGenerationModel(vramGb: number | null): string {
   if (vramGb === null) return "ai/qwen3:8B-Q4_K_M";
-  for (const tier of LOCAL_MODEL_TIERS) {
-    if (vramGb >= tier.minVramGb) return tier.model;
-  }
-  return "ai/qwen3:4B-UD-Q4_K_XL";
+  return recommendGenerationModelForHost({ architecture: "discrete", vramGb });
 }
 
 /**
@@ -106,9 +162,12 @@ export function recommendGenerationModel(vramGb: number | null): string {
 export function estimateModelVramGb(modelId: string): number | null {
   const id = modelId.toLowerCase();
   if (isEmbeddingModelId(id)) return 1;
+  // qwen3-coder-next is the 80B MoE coder — match BEFORE qwen3-coder (substring).
+  if (/coder-next/.test(id)) return 48;
   // qwen3-coder's short DMR name carries no size hint but is the 30B-A3B build
   // model (observed ~16.5 GB resident). Match it explicitly before param-size.
   if (/qwen3-coder/.test(id)) return 16;
+  if (/80b/.test(id)) return 48;
   if (/35b/.test(id)) return 22;
   if (/30b/.test(id)) return 16; // qwen3 30B-A3B observed ~16.5 GB
   if (/gemma.?4|gemma.?3/.test(id)) return /12b/.test(id) ? 8 : 20;

--- a/docs/superpowers/specs/2026-06-19-local-model-policy-single-generation.md
+++ b/docs/superpowers/specs/2026-06-19-local-model-policy-single-generation.md
@@ -65,17 +65,36 @@ A new **pure, client-safe** module is the single source of truth:
 - **Codegen classifier** (`opencode-dispatch.ts`): `isEmbeddingModelId` /
   `NON_CHAT_MODEL_RE` now sourced from the policy module (dedupe).
 
-## Deliberately out of scope (follow-ups under BI-0B893092)
+## Headroom + architecture-aware recalibration (2026-06-20)
 
-- **Install-script values are still mirrored, not imported** — shell / the
-  `@dpf/db`-context detector cannot import the apps/web TS module, so
-  `LOCAL_MODEL_TIERS` is duplicated there with a pointer comment. The over-commit
-  guard catches any resulting drift.
-- **Known tier-value divergence:** the detector's discrete top tier is `qwen3:30B-A3B`
-  (~16 GB, safe headroom on a 24 GB card) while the canonical/bootstrap top tier
-  is `qwen3.6:35B-A3B` (~22 GB, which itself nearly fills a 24 GB card). The tier
-  *headroom* (floor ≈ model size, leaving little for KV cache + embedder) should be
-  recalibrated as a separate change so a recommended model never over-commits.
+The original tiers sized each model to ≈ the card's whole VRAM (`minVramGb` ≈
+model size), so a *recommended* model over-committed the moment it ran with a
+real context window — even the first pull on a fresh install. Recalibrated:
+
+- **Headroom:** selection now reserves `MODEL_HEADROOM_GB` (5 GB) on top of model
+  WEIGHTS for the context KV cache + embedder + overhead. Grounded in on-box
+  measurement (RTX 4090, 2026-06-20): qwen3-coder 30B (~16.5 GB weights) at a 24k
+  build context used ~20.7 GB resident. So a 24 GB card now lands on the **30B**,
+  not the 35B (which needs ~27 GB to run).
+- **Architecture-aware budget** (`computeMemoryBudgetGb` / `recommendGenerationModelForHost`):
+  discrete = dedicated VRAM; **unified (Apple Silicon) = total RAM × 0.75** (the
+  GPU's share, leaving the OS + Docker stack the rest); cpu = RAM × 0.5. So a
+  128 GB Mac runs the **80B MoE** (`ai/qwen3-coder-next`) where the 4090 runs the 30B.
+- **New tiers:** added `ai/qwen3-coder` (30B, the 24 GB sweet spot, serves chat +
+  code) and `ai/qwen3-coder-next` (80B MoE, big-unified / 64 GB+ discrete).
+- **All three copies recalibrated together** — the canonical policy, the
+  Mac/Linux detector (`detect-hardware-host.ts`, unified-aware), and the Windows
+  installer (`install-dpf.ps1`) — resolving the prior 30B-vs-35B divergence.
+
+Per-host result: 8 GB GPU → 4B, 12 GB → 8B, 24 GB → 30B, 27 GB+ → 35B, 53 GB+
+discrete or 64 GB+ unified → 80B. None over-commit at build context.
+
+## Still out of scope (follow-ups under BI-0B893092)
+
+- **Install-script tiers are mirrored, not imported** — shell / the
+  `@dpf/db`-context detector cannot import the apps/web TS module, so the tiers +
+  constants are duplicated (now consistent across all three, with pointer
+  comments). The over-commit guard catches any future drift.
 - **Real-time loaded-state in the UX:** `getOllamaRunningModels()` returns `[]` on
   DMR (it predates `docker model ps`); the over-commit check therefore runs on
   *installed* models, which is sufficient for the policy but does not show live

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1557,32 +1557,37 @@ if (-not (Test-StepDone "hardware")) {
     if ($gpuName) { $hwSummary += ", $gpuName ($gpuVRAM_GB GB VRAM)" }
     Write-OK $hwSummary
 
-    # Select the largest strong tool-calling model that fits available VRAM/RAM.
-    # Mirrors the CANONICAL tiers in apps/web/lib/inference/local-model-policy.ts
-    # (LOCAL_MODEL_TIERS) — PowerShell cannot import TS, so keep this in sync.
-    # The Providers UX over-commit guard (same module) catches any drift that
-    # leaves a host with more than one generation model installed.
-    # We now prefer the Qwen3.6 35B-A3B (what the Docker UI calls ai/qwen3.6:latest
-    # when you have plenty of memory) for the top tier. It is the current best
-    # published option in the ai/ runner namespace for agentic work.
+    # Select the largest model that fits the GPU's VRAM WITH HEADROOM for the
+    # context window + embedder. Mirrors the canonical headroom-aware logic in
+    # apps/web/lib/inference/local-model-policy.ts (LOCAL_MODEL_TIERS) — PowerShell
+    # cannot import TS, so keep this in sync. The Providers UX over-commit guard
+    # (same module) catches any drift.
     #
-    # Pinned specific quant tag (never bare :latest) for size predictability and
-    # reproducibility. The older 30B-A3B remains available for lower tiers.
-    if ($gpuVRAM_GB -ge 22) {
+    # Thresholds = model weights + ~5 GB headroom (measured: a 30B at a 24k build
+    # context uses ~20.7 GB on a 24 GB card). So a 24 GB 4090 lands on the 30B
+    # coder, NOT the 35B — which would fill the card and over-commit the moment a
+    # build runs. Pinned quant tags (never bare :latest) for reproducible sizes.
+    if ($gpuVRAM_GB -ge 53) {
+        $selectedModel = "ai/qwen3-coder-next"
+        $modelReason = "Qwen3-Coder-Next 80B (MoE) -- top agentic coder, fits your $gpuVRAM_GB GB VRAM with headroom"
+    } elseif ($gpuVRAM_GB -ge 27) {
         $selectedModel = "ai/qwen3.6:35B-A3B-UD-Q4_K_M"
-        $modelReason = "Qwen3.6 35B-A3B (MoE) -- current best agentic model, fits your $gpuVRAM_GB GB VRAM"
-    } elseif ($gpuVRAM_GB -ge 12) {
+        $modelReason = "Qwen3.6 35B-A3B (MoE) -- strong agentic model, fits your $gpuVRAM_GB GB VRAM with headroom"
+    } elseif ($gpuVRAM_GB -ge 21) {
+        $selectedModel = "ai/qwen3-coder"
+        $modelReason = "Qwen3-Coder 30B (MoE) -- serves chat + code, fits your $gpuVRAM_GB GB VRAM with headroom"
+    } elseif ($gpuVRAM_GB -ge 17) {
         $selectedModel = "ai/qwen3:14B-Q6_K"
-        $modelReason = "Qwen3 14B -- top local tool calling (F1 0.97, exceeds Haiku)"
-    } elseif ($gpuVRAM_GB -ge 6) {
+        $modelReason = "Qwen3 14B -- top local tool calling (F1 0.97), fits your $gpuVRAM_GB GB VRAM"
+    } elseif ($gpuVRAM_GB -ge 11) {
         $selectedModel = "ai/qwen3:8B-Q4_K_M"
-        $modelReason = "Qwen3 8B -- matches cloud Haiku tool calling (F1 0.93)"
-    } elseif ($totalRAM_GB -ge 16) {
+        $modelReason = "Qwen3 8B -- matches cloud Haiku tool calling (F1 0.93), fits your $gpuVRAM_GB GB VRAM"
+    } elseif ($gpuVRAM_GB -ge 8) {
         $selectedModel = "ai/qwen3:4B-UD-Q4_K_XL"
-        $modelReason = "Qwen3 4B -- fits your RAM (CPU mode)"
+        $modelReason = "Qwen3 4B -- lightweight, fits your $gpuVRAM_GB GB VRAM"
     } else {
         $selectedModel = "ai/qwen3:4B-UD-Q4_K_XL"
-        $modelReason = "Qwen3 4B -- lightweight, runs on your hardware"
+        $modelReason = "Qwen3 4B -- lightweight, runs on your hardware (CPU / low VRAM)"
     }
     Write-Action "Selected AI model: $selectedModel ($modelReason)"
     Write-Action "Models are managed by Docker Model Runner (built into Docker Desktop)."

--- a/scripts/detect-hardware-host.ts
+++ b/scripts/detect-hardware-host.ts
@@ -166,53 +166,54 @@ function detectLinux(): HostProfile {
   };
 }
 
-// Model selection mirrors the CANONICAL tiers in
-// apps/web/lib/inference/local-model-policy.ts (LOCAL_MODEL_TIERS). This script
-// runs via tsx in the @dpf/db context and cannot import the apps/web module, so
-// the list is duplicated here — keep it in sync. The Providers UX over-commit
-// guard (same module) catches drift. KNOWN follow-up: the discrete top tier
-// below is 30B-A3B (~16 GB, safe headroom on a 24 GB card) while the canonical
-// top tier is 35B-A3B (~22 GB); reconcile when tier headroom is recalibrated
-// (tracked in BI-0B893092).
-// Qwen3 — NOT Gemma — because the platform's Coworkers catalog tiers Qwen3
-// as `strong + Tool Use` (F1 0.93 @ 8B, 0.97 @ 14B) while Gemma 3/4 tiers
-// as `adequate`. Default coworkers have `minimumTier: strong`, so a Gemma
-// pick fails routing on first install.
+// Model selection MIRRORS the canonical headroom-aware logic in
+// apps/web/lib/inference/local-model-policy.ts (LOCAL_MODEL_TIERS +
+// recommendGenerationModelForHost). This script runs via tsx in the @dpf/db
+// context and cannot import the apps/web module, so the tiers + constants are
+// duplicated here — KEEP IN SYNC. The Providers UX over-commit guard (same
+// module) catches any drift.
 //
-//   discrete VRAM >= 22GB:  ai/qwen3:30B-A3B-Q4_K_M           (30B MoE, prior gen)
-//   discrete VRAM >= 12GB:  ai/qwen3:14B-Q6_K                (14B dense)
-//   discrete VRAM >=  6GB:  ai/qwen3:8B-Q4_K_M               (8B dense)
-//   unified RAM   >= 32GB:  ai/qwen3.6:35B-A3B-UD-Q4_K_M    (Qwen3.6 35B-A3B MoE — best for high-RAM Apple Silicon)
-//   unified RAM   >= 24GB:  ai/qwen3:14B-Q6_K                (Apple Silicon mid)
-//   unified RAM   >= 16GB:  ai/qwen3:8B-Q4_K_M               (Apple Silicon low-mem)
-//   cpu-only / fallback:    ai/qwen3:4B-UD-Q4_K_XL           (4B dense, CPU-OK)
+// Qwen3 — NOT Gemma — the platform tiers Qwen3 as `strong + Tool Use` while
+// Gemma tiers as `adequate`, and default coworkers require `minimumTier:
+// strong`. The `-coder` variants double as the Build Studio code model AND a
+// capable chat model, so one model serves both.
 //
-// With plenty of unified memory (e.g. your 128 GB M-series), the model
-// Docker UI surfaces as "ai/qwen3.6:latest" (pinned as
-// ai/qwen3.6:35B-A3B-UD-Q4_K_M) is the right top-tier choice. It is the
-// direct successor to the old 30B-A3B: newer agentic coding / tool use,
-// same efficient MoE design (~3B active params), ~22 GB on-disk.
-// We always pin the specific quant tag (never bare :latest) so the
-// installer has a known size and reproducible result.
-//
+// Selection = the largest tier whose (weights + headroom) fits the host's
+// MEMORY BUDGET. Budget = dedicated VRAM (discrete), or a fraction of total RAM
+// (unified Apple Silicon shares it with the OS; CPU-only leaves even more aside).
+// Headroom reserves room for the context window + embedder so a recommended
+// model never fills the whole card and then over-commit the moment it runs.
+//   24 GB discrete  → ai/qwen3-coder (30B)        128 GB unified → ai/qwen3-coder-next (80B MoE)
+//   12 GB discrete  → ai/qwen3:8B                  32 GB unified → ai/qwen3-coder (30B)
+//    8 GB discrete  → ai/qwen3:4B                  16 GB unified → ai/qwen3:8B
 // Tags for the ai/ Docker Model Runner namespace are case-sensitive.
+const MODEL_HEADROOM_GB = 5;            // context KV + embedder + overhead (measured on RTX 4090)
+const UNIFIED_USABLE_FRACTION = 0.75;   // Apple Silicon GPU share of unified RAM
+const CPU_USABLE_FRACTION = 0.5;
+const SELECTION_TIERS: { model: string; weightsGb: number }[] = [
+  { model: "ai/qwen3-coder-next", weightsGb: 48 },          // big unified (Apple 128 GB) / 64 GB+ discrete
+  { model: "ai/qwen3.6:35B-A3B-UD-Q4_K_M", weightsGb: 22 },
+  { model: "ai/qwen3-coder", weightsGb: 16 },               // 24 GB-card sweet spot (measured ~20.7 GB @ 24k ctx)
+  { model: "ai/qwen3:14B-Q6_K", weightsGb: 12 },
+  { model: "ai/qwen3:8B-Q4_K_M", weightsGb: 6 },
+  { model: "ai/qwen3:4B-UD-Q4_K_XL", weightsGb: 3 },
+];
+
 function selectModel(p: {
   architecture: Architecture;
   totalGB: number;
   gpu: HostProfile["gpu"];
 }): string {
+  let budgetGb: number;
   if (p.architecture === "discrete" && p.gpu && typeof p.gpu.vramGB === "number") {
-    if (p.gpu.vramGB >= 22) return "ai/qwen3:30B-A3B-Q4_K_M";
-    if (p.gpu.vramGB >= 12) return "ai/qwen3:14B-Q6_K";
-    if (p.gpu.vramGB >= 6) return "ai/qwen3:8B-Q4_K_M";
+    budgetGb = p.gpu.vramGB;
+  } else if (p.architecture === "unified") {
+    budgetGb = p.totalGB * UNIFIED_USABLE_FRACTION;
+  } else {
+    budgetGb = p.totalGB * CPU_USABLE_FRACTION;
   }
-  if (p.architecture === "unified") {
-    // "Plenty of memory" (64 GB+ unified) → current Qwen3.6 35B-A3B MoE.
-    // The 35B total / ~3B active is still very efficient and the strongest
-    // published option for agentic work in the Docker ai/ runner namespace.
-    if (p.totalGB >= 32) return "ai/qwen3.6:35B-A3B-UD-Q4_K_M";
-    if (p.totalGB >= 24) return "ai/qwen3:14B-Q6_K";
-    if (p.totalGB >= 16) return "ai/qwen3:8B-Q4_K_M";
+  for (const tier of SELECTION_TIERS) {
+    if (tier.weightsGb + MODEL_HEADROOM_GB <= budgetGb) return tier.model;
   }
   return "ai/qwen3:4B-UD-Q4_K_XL";
 }


### PR DESCRIPTION
## Why

The auto-detect tier sizing recommended a model sized to ≈ the **whole** card (the VRAM floor ≈ the model's own size), so a *fresh install* over-committed the moment the model ran with a real context window:

- A **24 GB card** was told to pull the **35B (~22 GB)** — which needs ~27 GB to actually run (weights + context KV + embedder), so it spilled to system RAM.
- **Budget 8–12 GB GPUs** were worse — told to pull a model that fills the card.
- The three copies of the logic also **diverged** (Mac/Linux detector picked the 30B; Windows installer + bootstrap picked the 35B).

This makes the auto-detect pick **the best model that fits *with headroom*** — and accounts for **unified (Apple Silicon) vs discrete** memory, so a big Mac runs a bigger model. Closes the tier-headroom follow-up of **BI-0B893092** (the budget-local keystone).

## Grounded in measurement

On the RTX 4090 (2026-06-20): `qwen3-coder` 30B (~16.5 GB weights) at a **24k build context used ~20.7 GB resident** → ~4 GB over weights, +~1 GB embedder. So `MODEL_HEADROOM_GB = 5`.

## What

- **`recommendGenerationModelForHost({ architecture, vramGb, totalRamGb })`** + `computeMemoryBudgetGb` — the new headroom + architecture-aware selector:
  - discrete = dedicated VRAM
  - **unified (Apple Silicon) = RAM × 0.75** (GPU's share; OS + Docker stack get the rest)
  - cpu = RAM × 0.5
  - pick the largest tier where `weights + 5 GB ≤ budget`.
- **New tiers:** `ai/qwen3-coder` (30B, the 24 GB sweet spot, serves chat + code) and **`ai/qwen3-coder-next` (80B MoE, 3B active)** for big-unified / 64 GB+ discrete.
- **All three copies recalibrated together:** the canonical `local-model-policy.ts`, the Mac/Linux `detect-hardware-host.ts` (unified-aware), and the Windows `install-dpf.ps1` — resolving the prior 30B-vs-35B divergence.
- `recommendGenerationModel(vramGb)` kept as the discrete wrapper (bootstrap + the over-commit guard), now headroom-aware.

### Per-host result (none over-commit at build context)

| Host | Picks |
|---|---|
| 8 GB discrete | Qwen3 4B |
| 12 GB discrete | Qwen3 8B |
| **24 GB discrete (RTX 4090)** | **Qwen3-Coder 30B** |
| 27 GB+ discrete | Qwen3.6 35B |
| 53 GB+ discrete / 64 GB+ unified | Qwen3-Coder-Next 80B |
| 16 GB unified | Qwen3 8B |
| 32 GB unified | Qwen3-Coder 30B |
| **128 GB unified (M-series Mac)** | **Qwen3-Coder-Next 80B** |

## Tests

Unit tests cover the new headroom thresholds and both architectures, including the two real machines (4090 → 30B, 128 GB Mac → 80B) and the budget-GPU cases. Design note updated.

## Verification note

Local typecheck/tests couldn't run (worktree `node_modules` empty — known env regression); committed `DPF_SKIP_TYPECHECK=1`, relying on CI. The selection logic is pure and fully unit-tested; install-script mirrors are value/threshold changes traced by hand against the measurements.

Refs BI-0B893092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)