### PR TITLE
feat(delivery): add an "All work" lens to the cross-surface activity view (BI-D3E09880)

### DIFF
--- a/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.test.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import type { ContributorChangeLane } from "@/lib/contributor-change-lanes/types";
+
+import { filterLanes } from "./ChangeLanesDashboard";
+
+function lane(
+  id: string,
+  status: ContributorChangeLane["status"],
+  source: ContributorChangeLane["source"],
+): ContributorChangeLane {
+  return {
+    id,
+    laneKind: "external-debug",
+    source,
+    status,
+    owner: null,
+    branch: null,
+    worktreePath: null,
+    commitSha: null,
+    servedCommitSha: null,
+    pullRequestUrl: null,
+    runtimeTargetId: null,
+    runtimeUrl: null,
+    workCapsuleId: null,
+    backlogItemId: null,
+    expiresAt: null,
+    lastHeartbeatAt: null,
+    latestVerification: { status: "pending", checkedAt: null, summary: null },
+    blockers: [],
+    nextAction: "",
+  };
+}
+
+describe("filterLanes — All work lens (EP-UNIFIED-TRACKING)", () => {
+  const lanes = [
+    lane("capsule", "claimed", "work-capsule"),
+    lane("branch", "stale", "git-branch"),
+    lane("runtime", "running", "runtime-target"),
+  ];
+
+  it("the 'all' lens returns every lane regardless of status or source", () => {
+    expect(filterLanes(lanes, "all").map((l) => l.id)).toEqual(["capsule", "branch", "runtime"]);
+  });
+
+  it("includes a completed cross-surface capsule (the thing the focused lenses hid)", () => {
+    // A completed external-agent capsule projects to a 'claimed' lane; it is not
+    // surfaced by the worktrees/leases/cleanup lenses, so 'All work' is the lens
+    // that makes finished cross-surface work visible.
+    const completed = lane("WC-CLAUDE-SESSION", "claimed", "work-capsule");
+    expect(filterLanes([completed], "all")).toHaveLength(1);
+  });
+
+  it("the 'active' lens still filters to active statuses only (unchanged behavior)", () => {
+    const ids = filterLanes(lanes, "active").map((l) => l.id);
+    expect(ids).toContain("capsule");
+    expect(ids).toContain("runtime");
+    expect(ids).not.toContain("branch"); // stale is not active
+  });
+});

--- a/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
@@ -9,6 +9,7 @@ import { ChangeLaneSourceSummary } from "./ChangeLaneSourceSummary";
 import { ChangeLaneTable } from "./ChangeLaneTable";
 
 const TABS = [
+  { id: "all", label: "All work" },
   { id: "active", label: "Active lanes" },
   { id: "handoff", label: "Branches needing handoff" },
   { id: "worktrees", label: "Orphan worktrees" },
@@ -45,7 +46,7 @@ export function ChangeLanesDashboard({
   anySnapshotSourceDegraded?: boolean;
   isAdmin?: boolean;
 }) {
-  const [tab, setTab] = useState<TabId>("active");
+  const [tab, setTab] = useState<TabId>("all");
 
   const filteredLanes = useMemo(() => filterLanes(lanes, tab), [lanes, tab]);
 
@@ -56,11 +57,12 @@ export function ChangeLanesDashboard({
     <div className="space-y-4">
       <header className="space-y-1">
         <h1 className="text-xl font-semibold text-[var(--dpf-text)]">
-          Contributor change lanes
+          Development activity — all surfaces
         </h1>
         <p className="text-sm text-[var(--dpf-muted)]">
-          Branches, worktrees, runtimes, and PRs joined into one view so contributor
-          handoff state is visible — read-only for this slice.
+          Every unit of development work — Build Studio, Claude Code, Codex, and Grok —
+          joined into one view: capsules, branches, worktrees, runtimes, and PRs. Start on
+          All work; the other lenses focus on what needs attention. Read-only.
         </p>
         <p className="text-[10px] text-[var(--dpf-muted)]">
           Snapshot at {generatedAt}
@@ -111,11 +113,13 @@ export function ChangeLanesDashboard({
   );
 }
 
-function filterLanes(
+export function filterLanes(
   lanes: ContributorChangeLane[],
   tab: TabId,
 ): ContributorChangeLane[] {
   switch (tab) {
+    case "all":
+      return lanes;
     case "active":
       return lanes.filter((l) => ACTIVE_STATUSES.has(l.status));
     case "handoff":


### PR DESCRIPTION
## What

The cross-surface activity view (`/platform/development/change-lanes`) only had **active/hygiene** lenses — *active lanes*, *branches needing handoff*, *orphan worktrees*, *stale leases*, *cleanup*. So **completed cross-surface work** — a finished Claude Code / Codex / Grok session — appeared in **none** of them. (That's the gap behind "I don't see the threads we have open here.")

Adds an **"All work"** lens (now the default tab) that shows every unit of development work across **all surfaces** in one place, and reframes the header from "Contributor change lanes" to **"Development activity — all surfaces"** to match the operator's mental model.

- Read-only; **no new controls or routes** (a tab button only).
- Exported `filterLanes` + unit test (`ChangeLanesDashboard.test.tsx`).

## Why this, why now

This is the **first concrete slice of the Delivery "Pipeline" lens** designed in BI-D3E09880 / the [delivery-visibility addendum](docs/superpowers/specs/2026-06-19-delivery-visibility-and-pr-capture-addendum.md). It makes the existing surface answer "show me all dev work" today, while the dedicated Delivery surface is built. Paired with the live capsule capture this session (WC-4A136445 — the Claude Code session that shipped EP-UNIFIED-TRACKING Phases 0+1 is now a tracked `claude-desktop` capsule with its 4 PRs), the "All work" lens is where that capsule becomes visible.

## Known follow-ups (not in this PR)

- A completed capsule currently projects to a `claimed` lane (the projection ignores capsule lifecycle status) — it shows, but mislabelled. A `shipped`/`done` lane status is the next refinement.
- The dedicated **Delivery** surface (3 lenses) + nav consolidation remain (BI-D3E09880).
- Durable **auto-capture** so external sessions self-track without a manual `adopt_worktree` (BI-636A11B3).

## Verification

Unit gate in CI (`ChangeLanesDashboard.test.tsx`: all-lens returns everything incl. completed capsules; active-lens unchanged). Root `node_modules` degraded this cycle (no local vitest/tsc) → `DPF_SKIP_TYPECHECK=1`, CI is the gate. **Live UX of the rendered tab is pending portal access.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)