### PR TITLE
feat(delivery): add a 'shipped' lane status for completed cross-surface work (BI-D3E09880)

### DIFF
--- a/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx
@@ -14,6 +14,7 @@ const LANE_INTENT: Record<ContributorLaneStatus, Intent> = {
   available: "neutral",
   released: "neutral",
   stale: "warning",
+  shipped: "success",
 };
 
 export function ChangeLaneStatusBadge({ status }: { status: ContributorLaneStatus }) {

--- a/apps/web/lib/contributor-change-lanes/lane-projection.test.ts
+++ b/apps/web/lib/contributor-change-lanes/lane-projection.test.ts
@@ -386,3 +386,41 @@ describe("projectContributorChangeLanes", () => {
     expect(result.lanes.at(-1)!.source).toBe("git-branch");
   });
 });
+
+describe("shipped lane status — completed cross-surface work (EP-UNIFIED-TRACKING)", () => {
+  it("projects a complete capsule to a 'shipped' lane with no in-flight blockers", () => {
+    const { lanes } = projectContributorChangeLanes(
+      emptyInput({ workCapsules: [capsule({ capsuleId: "WC-DONE", status: "complete" })] }),
+    );
+    expect(lanes).toHaveLength(1);
+    expect(lanes[0]).toMatchObject({
+      workCapsuleId: "WC-DONE",
+      source: "work-capsule",
+      status: "shipped",
+      nextAction: "Shipped — work complete",
+    });
+    expect(lanes[0]!.blockers).toEqual([]);
+  });
+
+  it("treats ready-for-promotion as shipped and raises no 'no branch' blocker", () => {
+    const { lanes } = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [
+          capsule({ capsuleId: "WC-RFP", status: "ready-for-promotion", headBranch: null }),
+        ],
+      }),
+    );
+    expect(lanes[0]!.status).toBe("shipped");
+    expect(lanes[0]!.blockers).toEqual([]);
+  });
+
+  it("leaves an in-flight capsule with no PR/TTL claimed + blocked (unchanged)", () => {
+    const { lanes } = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [capsule({ capsuleId: "WC-WIP", status: "working", leaseExpiresAt: null })],
+      }),
+    );
+    expect(lanes[0]!.status).toBe("claimed");
+    expect(lanes[0]!.blockers).toContain("No open PR and no active WIP TTL");
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/lane-projection.ts
+++ b/apps/web/lib/contributor-change-lanes/lane-projection.ts
@@ -31,6 +31,7 @@ const LANE_STATUS_PRIORITY: Record<ContributorLaneStatus, number> = {
   available: 6,
   released: 7,
   stale: 8,
+  shipped: 9,
 };
 
 export function projectContributorChangeLanes(
@@ -127,27 +128,32 @@ export function projectContributorChangeLanes(
     if (consumedCapsules.has(capsule.capsuleId)) continue;
     if (capsule.status === "released" || capsule.status === "archived") continue;
 
+    const isShipped =
+      capsule.status === "complete" || capsule.status === "ready-for-promotion";
     const pr = capsule.headBranch ? prByBranch.get(capsule.headBranch) ?? null : null;
     const blockers: string[] = [];
     const hasTtl = Boolean(capsule.leaseExpiresAt);
     const isExpired = hasTtl && capsule.leaseExpiresAt! <= now;
-    if (!pr && !hasTtl) {
+    // Completed work needs no PR/TTL — those "blockers" only apply to in-flight capsules.
+    if (!isShipped && !pr && !hasTtl) {
       blockers.push("No open PR and no active WIP TTL");
     }
-    if (isExpired) {
+    if (!isShipped && isExpired) {
       blockers.push(
         `WIP lease expired at ${capsule.leaseExpiresAt?.toISOString() ?? "unknown"}`,
       );
     }
-    if (!capsule.headBranch) {
+    if (!isShipped && !capsule.headBranch) {
       blockers.push("Capsule has no branch");
     }
 
-    const status: ContributorLaneStatus = isExpired
-      ? "stale"
-      : pr?.state === "open"
-        ? "ready-for-review"
-        : "claimed";
+    const status: ContributorLaneStatus = isShipped
+      ? "shipped"
+      : isExpired
+        ? "stale"
+        : pr?.state === "open"
+          ? "ready-for-review"
+          : "claimed";
 
     lanes.push({
       id: capsule.capsuleId,
@@ -366,6 +372,9 @@ function deriveNextActionForCapsule(
   pr: PullRequestSnapshot | null,
   blockers: string[],
 ): string {
+  if (capsule.status === "complete" || capsule.status === "ready-for-promotion") {
+    return "Shipped — work complete";
+  }
   if (capsule.nextAction) return capsule.nextAction;
   if (blockers.length > 0) return blockers[0];
   if (pr?.state === "open") return "Drive ready-for-review verification";

--- a/apps/web/lib/contributor-change-lanes/types.ts
+++ b/apps/web/lib/contributor-change-lanes/types.ts
@@ -18,6 +18,7 @@ export const CONTRIBUTOR_LANE_STATUSES = [
   "ready-for-review",
   "released",
   "stale",
+  "shipped",
 ] as const;
 
 export type ContributorLaneStatus = (typeof CONTRIBUTOR_LANE_STATUSES)[number];


### PR DESCRIPTION
## What

A completed `WorkCapsule` — a finished Claude Code / Codex / Grok session — projected to a **`claimed`** lane: mislabelled as *active*, and decorated with in-flight `"no PR / no TTL / no branch"` blockers that don't apply to done work. (This is the exact mislabel flagged as a follow-up on the [All-work lens PR #2165](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2165).)

Adds a **`shipped`** lane status:
- `complete` + `ready-for-promotion` capsules project to `shipped`, with the in-flight blockers suppressed and `nextAction = "Shipped — work complete"`.
- `shipped` is **excluded from the Active lens** and **sorts last**; it surfaces in the **All work** lens as finished work — so this session's capsule (WC-4A136445) reads correctly instead of looking like an active claim.
- Badge intent → `success`.

## Files
- `types.ts` — `shipped` added to `CONTRIBUTOR_LANE_STATUSES`
- `lane-projection.ts` — capsule lifecycle → `shipped`; suppress in-flight blockers; priority; next-action
- `ChangeLaneStatusBadge.tsx` — `shipped` → success intent (exhaustive `Record` updated)
- `lane-projection.test.ts` — `complete`/`ready-for-promotion` → `shipped` (no blockers); in-flight capsule unchanged

## Verification
Unit gate in CI (3 new projection cases). Root `node_modules` degraded this cycle (no local vitest/tsc) → `DPF_SKIP_TYPECHECK=1`, CI is the gate. Live render pending portal access.

Refinement to the already-specced Delivery IA (BI-D3E09880). Stacks conceptually behind #2165 (independent files; no conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)