### PR TITLE
feat(capture): auto-capture external-agent sessions into WorkCapsules on evidence (BI-636A11B3)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -6826,6 +6826,31 @@ export async function executeTool(
         taskRunId,
         details: details as unknown as import("@dpf/db").Prisma.InputJsonValue,
       });
+
+      // Durable auto-capture (EP-UNIFIED-TRACKING / BI-636A11B3): recording evidence
+      // (which AGENTS.md §17 asks external agents to do) also makes the session a
+      // tracked WorkCapsule, so its work appears in the cross-surface activity view
+      // without a manual adopt_worktree. Idempotent per externalSessionId; best-effort
+      // — a capture failure must never fail the evidence write.
+      let capturedCapsuleId: string | null = null;
+      try {
+        const { captureExternalSessionEvidence } = await import(
+          "@/lib/work-capsules/external-session-capture"
+        );
+        capturedCapsuleId = await captureExternalSessionEvidence({
+          db: prisma,
+          externalSessionId,
+          provider,
+          summary,
+          actor: { userId, agentId: context?.agentId ?? null, principalId: null },
+        });
+      } catch (captureError) {
+        console.warn(
+          "[record_external_development_evidence] auto-capsule capture failed:",
+          captureError instanceof Error ? captureError.message : String(captureError),
+        );
+      }
+
       return {
         success: true,
         entityId: evidence.id,
@@ -6834,6 +6859,7 @@ export async function executeTool(
           evidenceId: evidence.id,
           buildId: buildId ?? null,
           taskRunId: taskRunId ?? null,
+          workCapsuleId: capturedCapsuleId,
         },
       };
     }

--- a/apps/web/lib/work-capsules/external-session-capture.test.ts
+++ b/apps/web/lib/work-capsules/external-session-capture.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreate, mockRecord } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockRecord: vi.fn(),
+}));
+
+vi.mock("./work-capsule-store", () => ({
+  createWorkCapsule: mockCreate,
+  recordWorkCapsuleEvidence: mockRecord,
+}));
+
+import {
+  captureExternalSessionEvidence,
+  providerToExecutorKind,
+} from "./external-session-capture";
+
+const actor = { userId: "user-1", agentId: null, principalId: null };
+const db = {} as never;
+
+describe("captureExternalSessionEvidence (durable auto-capture / BI-636A11B3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue({ capsuleId: "WC-AUTO", id: "row-auto" });
+    mockRecord.mockResolvedValue({});
+  });
+
+  it("creates-or-reuses a capsule keyed by externalSessionId and records the evidence on it", async () => {
+    const capsuleId = await captureExternalSessionEvidence({
+      db,
+      externalSessionId: "sess-9",
+      provider: "claude",
+      summary: "Wrote the parser",
+      actor,
+    });
+
+    expect(capsuleId).toBe("WC-AUTO");
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          idempotencyKey: "external-session:sess-9",
+          executorKind: "claude-desktop",
+          executorRef: "sess-9",
+          source: "external-adoption",
+          objective: "Wrote the parser",
+        }),
+        actor,
+      }),
+    );
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capsuleId: "WC-AUTO",
+        evidence: expect.objectContaining({ kind: "note", summary: "Wrote the parser" }),
+      }),
+    );
+  });
+
+  it("falls back to a generic objective when the summary is blank", async () => {
+    await captureExternalSessionEvidence({
+      db,
+      externalSessionId: "s",
+      provider: "codex",
+      summary: "   ",
+      actor,
+    });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ objective: "External codex development session" }),
+      }),
+    );
+  });
+});
+
+describe("providerToExecutorKind", () => {
+  it("maps known providers and defaults unknown to human", () => {
+    expect(providerToExecutorKind("claude")).toBe("claude-desktop");
+    expect(providerToExecutorKind("Codex CLI")).toBe("codex-desktop");
+    expect(providerToExecutorKind("grok-4")).toBe("grok-desktop");
+    expect(providerToExecutorKind("something-else")).toBe("human");
+  });
+});

--- a/apps/web/lib/work-capsules/external-session-capture.ts
+++ b/apps/web/lib/work-capsules/external-session-capture.ts
@@ -1,0 +1,76 @@
+// Durable auto-capture of external-agent work into a tracked WorkCapsule.
+//
+// EP-UNIFIED-TRACKING / BI-636A11B3. The cross-surface activity view renders
+// WorkCapsules. External agents (Claude Code / Codex / Grok) that work "directly"
+// and never claim a capsule are therefore invisible — exactly the gap behind
+// "I don't see the threads we have open here." This makes the act an external
+// agent IS expected to do — record evidence (AGENTS.md §17) — also the capture
+// trigger: recording evidence ensures the session is a tracked capsule, with no
+// manual adopt_worktree. Idempotent per externalSessionId; the caller invokes it
+// best-effort so it never blocks the evidence write.
+
+import {
+  createWorkCapsule,
+  recordWorkCapsuleEvidence,
+  type CapsuleDb,
+  type WorkCapsuleActor,
+} from "./work-capsule-store";
+import type { WorkCapsuleExecutorKind } from "@/lib/work-capsules";
+
+/** Map a self-declared provider string to the closest desktop executor kind. */
+export function providerToExecutorKind(provider: string): WorkCapsuleExecutorKind {
+  const normalized = provider.trim().toLowerCase();
+  if (normalized.includes("claude")) return "claude-desktop";
+  if (normalized.includes("codex")) return "codex-desktop";
+  if (normalized.includes("grok")) return "grok-desktop";
+  return "human";
+}
+
+function providerLabel(provider: string): string {
+  const trimmed = provider.trim();
+  if (!trimmed) return "External agent";
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
+/**
+ * Ensure the external session is a tracked WorkCapsule and append this evidence
+ * to its timeline. Returns the capsule's semantic id (WC-*). Idempotent: repeated
+ * evidence from the same `externalSessionId` reuses one capsule.
+ */
+export async function captureExternalSessionEvidence(args: {
+  db: CapsuleDb;
+  externalSessionId: string;
+  provider: string;
+  summary: string;
+  actor: WorkCapsuleActor;
+}): Promise<string> {
+  const idempotencyKey = `external-session:${args.externalSessionId}`;
+  const objective =
+    args.summary.trim().slice(0, 500)
+    || `External ${args.provider} development session`;
+
+  const capsule = await createWorkCapsule({
+    db: args.db,
+    input: {
+      title: `${providerLabel(args.provider)} session ${args.externalSessionId}`.slice(0, 120),
+      objective,
+      source: "external-adoption",
+      executorKind: providerToExecutorKind(args.provider),
+      executorRef: args.externalSessionId,
+      idempotencyKey,
+    },
+    actor: args.actor,
+  });
+
+  await recordWorkCapsuleEvidence({
+    db: args.db,
+    capsuleId: capsule.capsuleId,
+    evidence: {
+      kind: "note",
+      summary: args.summary.trim().slice(0, 500) || "External development evidence recorded",
+    },
+    actor: args.actor,
+  });
+
+  return capsule.capsuleId;
+}


### PR DESCRIPTION
## What — the "durably" piece

External agents (Claude Code / Codex / Grok) that work **directly** and never claim a capsule are invisible in the cross-surface activity view. That's the gap behind *"I don't see the threads we have open here"* — and why capturing this session required a **manual** `adopt_worktree`.

This makes the act an external agent is **already asked to do** — record evidence (AGENTS.md §17) — the **capture trigger**: `record_external_development_evidence` now ensures the session is a tracked `WorkCapsule` and lands the evidence on its timeline.

- **Idempotent** per `externalSessionId` (key `external-session:<id>`) — repeated evidence reuses one capsule.
- **Provider → executor kind** (`claude`→`claude-desktop`, `codex`→`codex-desktop`, `grok`→`grok-desktop`, else `human`).
- **Best-effort** — wrapped in try/catch in the handler; a capture failure **never** fails the evidence write.
- **No migration** — reuses `createWorkCapsule` (idempotent) + `recordWorkCapsuleEvidence`.

So a session that follows the contract now **self-tracks** and shows up in the All-work lens — no manual adopt.

## Files
- `lib/work-capsules/external-session-capture.ts` — `captureExternalSessionEvidence` + `providerToExecutorKind`
- `mcp-tools.ts` — best-effort wire into the handler; returns `workCapsuleId`
- `external-session-capture.test.ts` — idempotency key, provider mapping, blank-summary fallback

## Scope / follow-ups
This is the **contract-triggered** capture (fires when an agent records evidence). Two complements remain:
- **Enforcement** so Codex/Grok always record evidence (lease-guard parity, BI-6B02FEE5) — makes capture unconditional.
- **Reconciler from open PRs/worktrees** for the work-directly-*without*-evidence case (the capture-layer design).

## Verification
Unit gate in CI (helper: idempotency, provider mapping, fallback). The handler call is best-effort + try/catch, so it can't regress the existing evidence path. Root `node_modules` degraded this cycle (no local vitest/tsc) → `DPF_SKIP_TYPECHECK=1`, CI is the gate.

Implements BI-636A11B3 (EP-UNIFIED-TRACKING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)