### PR TITLE
feat(mobile): customer "My visits" surface scoped to the signed-in customer

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -12,6 +12,7 @@ import { DashboardTile } from "@/src/components/DashboardTile";
 import { useWorkspaceStore } from "@/src/features/workspace/workspace.store";
 import { useAppConfigStore } from "@/src/lib/appConfig";
 import { CustomerInvoicesPanel } from "@/src/features/customer-invoices/CustomerInvoicesPanel";
+import { CustomerVisitsPanel } from "@/src/features/customer-visits/CustomerVisitsPanel";
 import type { ActivityItem, DashboardTile as TileType } from "@dpf/types";
 
 function TilesGrid({ tiles }: { tiles: TileType[] }) {
@@ -73,9 +74,20 @@ export default function HomeScreen() {
 
   if (isCustomer) {
     return (
-      <View style={styles.screen} testID="customer-home">
-        <CustomerInvoicesPanel />
-      </View>
+      <FlatList
+        style={styles.screen}
+        contentContainerStyle={styles.content}
+        testID="customer-home"
+        data={[]}
+        keyExtractor={() => ""}
+        renderItem={() => null}
+        ListHeaderComponent={
+          <View>
+            <CustomerInvoicesPanel />
+            <CustomerVisitsPanel />
+          </View>
+        }
+      />
     );
   }
 

--- a/apps/mobile/src/features/customer-visits/CustomerVisitsPanel.tsx
+++ b/apps/mobile/src/features/customer-visits/CustomerVisitsPanel.tsx
@@ -1,0 +1,145 @@
+/**
+ * Customer-mode home panel: "My visits" — the signed-in customer's
+ * appointments. Renders only when the install manifest tells us this is
+ * the customer surface. Pairs with CustomerInvoicesPanel; together they
+ * cover the customer's recurring needs (pay + visits) on a single screen.
+ */
+import React, { useEffect, useMemo } from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import { useTheme } from "@/src/lib/theme";
+import {
+  partitionVisits,
+  useCustomerVisitsStore,
+} from "./customer-visits.store";
+import type { CustomerVisit } from "@dpf/types";
+
+function VisitRow({ visit }: { visit: CustomerVisit }): React.JSX.Element {
+  const { colors, spacing, borderRadius } = useTheme();
+  const styles = useMemo(
+    () => makeRowStyles({ colors, spacing, borderRadius }),
+    [colors, spacing, borderRadius],
+  );
+  const when = new Date(visit.scheduledAt);
+  return (
+    <View style={styles.row} testID={`customer-visit-${visit.bookingRef}`}>
+      <View style={styles.left}>
+        <Text style={styles.title}>{visit.itemName ?? visit.bookingRef}</Text>
+        <Text style={styles.meta}>
+          {when.toLocaleString()}
+          {visit.providerName ? ` · with ${visit.providerName}` : ""}
+        </Text>
+      </View>
+      <Text style={statusStyle(visit.status, colors)}>{visit.status}</Text>
+    </View>
+  );
+}
+
+function statusStyle(
+  status: CustomerVisit["status"],
+  colors: ReturnType<typeof useTheme>["colors"],
+): { color: string; fontSize: number; fontWeight: "700"; textTransform: "uppercase" } {
+  const base = { fontSize: 11, fontWeight: "700" as const, textTransform: "uppercase" as const };
+  switch (status) {
+    case "completed":
+      return { ...base, color: colors.success };
+    case "cancelled":
+    case "no_show":
+      return { ...base, color: colors.error };
+    default:
+      return { ...base, color: colors.primary };
+  }
+}
+
+export function CustomerVisitsPanel(): React.JSX.Element {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const { visits, isLoading, error, fetch } = useCustomerVisitsStore();
+
+  useEffect(() => {
+    void fetch();
+  }, [fetch]);
+
+  const { upcoming, recent } = useMemo(() => partitionVisits(visits), [visits]);
+
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.h1}>My visits</Text>
+      {error ? (
+        <Text style={styles.error} testID="customer-visits-error">
+          {error}
+        </Text>
+      ) : null}
+      {isLoading && visits.length === 0 ? (
+        <ActivityIndicator
+          color={theme.colors.primary}
+          testID="customer-visits-loading"
+        />
+      ) : visits.length === 0 ? (
+        <Text style={styles.empty}>No visits yet.</Text>
+      ) : (
+        <View>
+          {upcoming.length > 0 ? (
+            <View>
+              <Text style={styles.h2}>Upcoming</Text>
+              {upcoming.map((vv) => (
+                <VisitRow key={vv.id} visit={vv} />
+              ))}
+            </View>
+          ) : null}
+          {recent.length > 0 ? (
+            <View>
+              <Text style={styles.h2}>Recent</Text>
+              {recent.map((vv) => (
+                <VisitRow key={vv.id} visit={vv} />
+              ))}
+            </View>
+          ) : null}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function makeStyles({ colors, spacing }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    panel: { padding: spacing.md, gap: spacing.sm },
+    h1: { color: colors.text, fontSize: 20, fontWeight: "700" },
+    h2: {
+      color: colors.textMuted,
+      fontSize: 12,
+      fontWeight: "700",
+      textTransform: "uppercase",
+      marginTop: spacing.md,
+      marginBottom: spacing.xs,
+    },
+    empty: { color: colors.textMuted, fontSize: 14, marginTop: spacing.sm },
+    error: { color: colors.error, fontSize: 13 },
+  });
+}
+
+function makeRowStyles({
+  colors,
+  spacing,
+  borderRadius,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  spacing: ReturnType<typeof useTheme>["spacing"];
+  borderRadius: ReturnType<typeof useTheme>["borderRadius"];
+}) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      marginVertical: spacing.xs,
+    },
+    left: { flex: 1, marginRight: spacing.sm },
+    title: { color: colors.text, fontSize: 15, fontWeight: "600" },
+    meta: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+  });
+}

--- a/apps/mobile/src/features/customer-visits/customer-visits.store.test.ts
+++ b/apps/mobile/src/features/customer-visits/customer-visits.store.test.ts
@@ -1,0 +1,121 @@
+import {
+  partitionVisits,
+  useCustomerVisitsStore,
+} from "./customer-visits.store";
+import type { CustomerVisit } from "@dpf/types";
+
+const mockMyVisits = jest.fn();
+jest.mock("@/src/lib/apiClient", () => ({
+  api: { customer: { myVisits: (...a: unknown[]) => mockMyVisits(...a) } },
+}));
+
+const v = (
+  id: string,
+  scheduledAt: string,
+  status: CustomerVisit["status"] = "confirmed",
+): CustomerVisit => ({
+  id,
+  bookingRef: `BK-${id}`,
+  scheduledAt,
+  durationMinutes: 60,
+  status,
+  itemName: "Service",
+  providerName: null,
+  notes: null,
+  cancellationReason: null,
+  createdAt: scheduledAt,
+});
+
+function resetStore() {
+  useCustomerVisitsStore.getState().reset();
+  mockMyVisits.mockReset();
+}
+
+describe("useCustomerVisitsStore.fetch", () => {
+  beforeEach(resetStore);
+
+  it("populates the list from the API on success and clears prior error", async () => {
+    useCustomerVisitsStore.setState({ error: "stale" });
+    mockMyVisits.mockResolvedValueOnce({
+      data: [v("1", "2026-07-10T10:00:00.000Z")],
+      nextCursor: null,
+    });
+    await useCustomerVisitsStore.getState().fetch();
+    expect(useCustomerVisitsStore.getState().visits).toHaveLength(1);
+    expect(useCustomerVisitsStore.getState().error).toBeNull();
+  });
+
+  it("forwards the upcoming + status filters", async () => {
+    mockMyVisits.mockResolvedValueOnce({ data: [], nextCursor: null });
+    await useCustomerVisitsStore
+      .getState()
+      .fetch({ upcoming: true, status: "confirmed" });
+    expect(mockMyVisits.mock.calls[0][0]).toEqual({
+      limit: 25,
+      upcoming: true,
+      status: "confirmed",
+    });
+  });
+
+  it("surfaces API errors without dropping the existing list", async () => {
+    useCustomerVisitsStore.setState({
+      visits: [v("seed", "2026-07-10T10:00:00.000Z")],
+    });
+    mockMyVisits.mockRejectedValueOnce(new Error("HTTP 500"));
+    await useCustomerVisitsStore.getState().fetch();
+    const s = useCustomerVisitsStore.getState();
+    expect(s.error).toContain("500");
+    expect(s.visits).toHaveLength(1);
+  });
+});
+
+describe("partitionVisits", () => {
+  const NOW = new Date("2026-06-18T12:00:00.000Z");
+
+  it("splits future visits into upcoming and past into recent", () => {
+    const out = partitionVisits(
+      [
+        v("past", "2026-06-10T09:00:00.000Z"),
+        v("future", "2026-07-10T09:00:00.000Z"),
+      ],
+      NOW,
+    );
+    expect(out.upcoming.map((x) => x.id)).toEqual(["future"]);
+    expect(out.recent.map((x) => x.id)).toEqual(["past"]);
+  });
+
+  it("treats cancelled/no_show as recent even when scheduled in the future", () => {
+    const out = partitionVisits(
+      [
+        v("a", "2026-07-10T09:00:00.000Z", "cancelled"),
+        v("b", "2026-07-10T09:00:00.000Z", "no_show"),
+        v("c", "2026-07-10T09:00:00.000Z", "confirmed"),
+      ],
+      NOW,
+    );
+    expect(out.upcoming.map((x) => x.id)).toEqual(["c"]);
+    expect(out.recent.map((x) => x.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("orders upcoming soonest-first, recent most-recent-first", () => {
+    const out = partitionVisits(
+      [
+        v("u_later", "2026-08-10T09:00:00.000Z"),
+        v("u_soon", "2026-06-19T09:00:00.000Z"),
+        v("r_old", "2026-05-01T09:00:00.000Z"),
+        v("r_recent", "2026-06-10T09:00:00.000Z"),
+      ],
+      NOW,
+    );
+    expect(out.upcoming.map((x) => x.id)).toEqual(["u_soon", "u_later"]);
+    expect(out.recent.map((x) => x.id)).toEqual(["r_recent", "r_old"]);
+  });
+
+  it("drops entries with an unparseable scheduledAt rather than throwing", () => {
+    const out = partitionVisits(
+      [v("good", "2026-07-10T09:00:00.000Z"), v("bad", "not-a-date")],
+      NOW,
+    );
+    expect(out.upcoming.length + out.recent.length).toBe(1);
+  });
+});

--- a/apps/mobile/src/features/customer-visits/customer-visits.store.ts
+++ b/apps/mobile/src/features/customer-visits/customer-visits.store.ts
@@ -1,0 +1,66 @@
+import { create } from "zustand";
+import type { CustomerVisit } from "@dpf/types";
+import { api } from "@/src/lib/apiClient";
+
+/**
+ * Customer-side "My visits" store — backs the customer-mode home panel
+ * with the signed-in customer's appointments / visits (scoped server-side
+ * via /api/v1/customer/visits + requireCustomerAuth). Same pattern as
+ * customer-invoices: keep the binary generic; the install + persona decide
+ * whether this panel renders.
+ */
+interface CustomerVisitsState {
+  visits: CustomerVisit[];
+  isLoading: boolean;
+  error: string | null;
+  fetch: (opts?: { upcoming?: boolean; status?: string }) => Promise<void>;
+  reset: () => void;
+}
+
+export const useCustomerVisitsStore = create<CustomerVisitsState>((set) => ({
+  visits: [],
+  isLoading: false,
+  error: null,
+
+  fetch: async (opts) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.customer.myVisits({ limit: 25, ...opts });
+      set({ visits: res.data, isLoading: false });
+    } catch (err) {
+      set({
+        isLoading: false,
+        error: err instanceof Error ? err.message : "Failed to load visits",
+      });
+    }
+  },
+
+  reset: () => set({ visits: [], isLoading: false, error: null }),
+}));
+
+/**
+ * Split the list into upcoming + recent — the home panel renders both with
+ * separate headers. "Now" is injected so the projection stays pure and the
+ * test doesn't have to mock Date.
+ */
+export function partitionVisits(
+  visits: CustomerVisit[],
+  now: Date = new Date(),
+): { upcoming: CustomerVisit[]; recent: CustomerVisit[] } {
+  const nowMs = now.getTime();
+  const upcoming: CustomerVisit[] = [];
+  const recent: CustomerVisit[] = [];
+  for (const v of visits) {
+    const t = new Date(v.scheduledAt).getTime();
+    if (Number.isNaN(t)) continue;
+    if (t >= nowMs && v.status !== "cancelled" && v.status !== "no_show") {
+      upcoming.push(v);
+    } else {
+      recent.push(v);
+    }
+  }
+  // Upcoming: soonest first. Recent: most recent first.
+  upcoming.sort((a, b) => a.scheduledAt.localeCompare(b.scheduledAt));
+  recent.sort((a, b) => b.scheduledAt.localeCompare(a.scheduledAt));
+  return { upcoming, recent };
+}

--- a/apps/web/app/api/v1/customer/visits/route.test.ts
+++ b/apps/web/app/api/v1/customer/visits/route.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for GET /api/v1/customer/visits — the customer-scoped "My visits"
+ * endpoint backing the generic mobile app's customer mode.
+ *
+ * Contract: a signed-in customer sees ONLY their own contact's bookings,
+ * never another customer's. Workforce auth must be rejected.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockContactsFindMany, mockBookingsFindMany } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockContactsFindMany: vi.fn(),
+  mockBookingsFindMany: vi.fn(),
+}));
+
+vi.mock("@/lib/api/auth-middleware", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/api/auth-middleware")
+  >("@/lib/api/auth-middleware");
+  return { ...actual, requireCustomerAuth: mockAuth };
+});
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    customerContact: { findMany: mockContactsFindMany },
+    storefrontBooking: { findMany: mockBookingsFindMany },
+  },
+  Prisma: {},
+}));
+
+import { GET } from "./route";
+import { ApiError } from "@/lib/api/error";
+
+const CUSTOMER_AUTH = {
+  user: {
+    id: "u_c1",
+    email: "alice@example.com",
+    type: "customer" as const,
+    platformRole: null,
+    isSuperuser: false,
+    accountId: "ACC-ACME",
+    accountName: "Acme",
+    contactId: "CON-1",
+  },
+  capabilities: [] as string[],
+  authContext: {
+    principalId: null,
+    platformRole: null,
+    isSuperuser: false,
+    employeeId: null,
+    managerScope: null,
+    grantedCapabilities: [] as string[],
+  },
+};
+
+const SERVER_BOOKING = {
+  id: "BK-1",
+  bookingRef: "BK-0001",
+  scheduledAt: new Date("2026-07-10T10:00:00.000Z"),
+  durationMinutes: 60,
+  status: "confirmed",
+  notes: null,
+  cancellationReason: null,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  itemId: "Tune-up",
+  provider: { name: "Dale" },
+};
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockContactsFindMany.mockReset();
+  mockBookingsFindMany.mockReset();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeReq(query = ""): Request {
+  return new Request(`https://example/api/v1/customer/visits${query}`);
+}
+
+describe("GET /api/v1/customer/visits", () => {
+  it("rejects unauthenticated callers with 401", async () => {
+    mockAuth.mockRejectedValueOnce(
+      new ApiError("UNAUTHENTICATED", "Authentication required", 401),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+    expect(mockContactsFindMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects workforce (admin) callers with 403 — they use the storefront route", async () => {
+    mockAuth.mockRejectedValueOnce(
+      new ApiError(
+        "FORBIDDEN",
+        "This endpoint requires customer authentication",
+        403,
+      ),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns an empty page when the customer has no accountId on session", async () => {
+    mockAuth.mockResolvedValueOnce({
+      ...CUSTOMER_AUTH,
+      user: { ...CUSTOMER_AUTH.user, accountId: null },
+    });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[] };
+    expect(body.data).toEqual([]);
+    expect(mockContactsFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty page when the account has no contacts at all", async () => {
+    mockAuth.mockResolvedValueOnce(CUSTOMER_AUTH);
+    mockContactsFindMany.mockResolvedValueOnce([]);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(mockBookingsFindMany).not.toHaveBeenCalled();
+  });
+
+  it("scopes bookings to the customer's contact set", async () => {
+    mockAuth.mockResolvedValueOnce(CUSTOMER_AUTH);
+    mockContactsFindMany.mockResolvedValueOnce([
+      { id: "con_1" },
+      { id: "con_2" },
+    ]);
+    mockBookingsFindMany.mockResolvedValueOnce([SERVER_BOOKING]);
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    const contactsCall = mockContactsFindMany.mock.calls[0][0];
+    expect(contactsCall.where.account).toEqual({
+      is: { accountId: "ACC-ACME" },
+    });
+    const bookingsCall = mockBookingsFindMany.mock.calls[0][0];
+    expect(bookingsCall.where.customerContactId).toEqual({
+      in: ["con_1", "con_2"],
+    });
+    // The select must NOT leak admin-only fields.
+    expect(bookingsCall.select.idempotencyKey).toBeUndefined();
+  });
+
+  it("applies upcoming=true as scheduledAt >= now", async () => {
+    mockAuth.mockResolvedValueOnce(CUSTOMER_AUTH);
+    mockContactsFindMany.mockResolvedValueOnce([{ id: "con_1" }]);
+    mockBookingsFindMany.mockResolvedValueOnce([]);
+
+    await GET(makeReq("?upcoming=true"));
+    const call = mockBookingsFindMany.mock.calls[0][0];
+    expect(call.where.scheduledAt.gte).toBeInstanceOf(Date);
+  });
+
+  it("forwards the status filter when supplied", async () => {
+    mockAuth.mockResolvedValueOnce(CUSTOMER_AUTH);
+    mockContactsFindMany.mockResolvedValueOnce([{ id: "con_1" }]);
+    mockBookingsFindMany.mockResolvedValueOnce([]);
+
+    await GET(makeReq("?status=confirmed"));
+    expect(mockBookingsFindMany.mock.calls[0][0].where.status).toBe("confirmed");
+  });
+
+  it("projects unknown stored statuses to 'pending' instead of leaking junk", async () => {
+    mockAuth.mockResolvedValueOnce(CUSTOMER_AUTH);
+    mockContactsFindMany.mockResolvedValueOnce([{ id: "con_1" }]);
+    mockBookingsFindMany.mockResolvedValueOnce([
+      { ...SERVER_BOOKING, status: "weird-legacy-value" },
+    ]);
+
+    const res = await GET(makeReq());
+    const body = (await res.json()) as { data: { status: string }[] };
+    expect(body.data[0].status).toBe("pending");
+  });
+});

--- a/apps/web/app/api/v1/customer/visits/route.ts
+++ b/apps/web/app/api/v1/customer/visits/route.ts
@@ -1,0 +1,124 @@
+// GET /api/v1/customer/visits — the signed-in customer's appointments / visits.
+//
+// Customer-scoped view of StorefrontBooking: returns rows whose
+// customerContact belongs to the signed-in customer's CustomerAccount
+// (resolved via the contact -> account chain). The portal-side booking list
+// at /api/storefront/bookings is workforce-scoped and unchanged; this is the
+// customer half of the generic mobile app's "My visits" surface.
+
+import { NextResponse } from "next/server";
+import { prisma, type Prisma } from "@dpf/db";
+import { requireCustomerAuth } from "@/lib/api/auth-middleware";
+import { ApiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { parsePagination, buildPaginatedResponse } from "@/lib/api/pagination";
+import type { CustomerVisit, CustomerVisitStatus } from "@dpf/types";
+
+export const dynamic = "force-dynamic";
+
+const VISIT_STATUSES = new Set<CustomerVisitStatus>([
+  "pending",
+  "confirmed",
+  "cancelled",
+  "completed",
+  "no_show",
+]);
+
+function projectStatus(raw: string): CustomerVisitStatus {
+  return VISIT_STATUSES.has(raw as CustomerVisitStatus)
+    ? (raw as CustomerVisitStatus)
+    : "pending";
+}
+
+interface BookingRow {
+  id: string;
+  bookingRef: string;
+  scheduledAt: Date;
+  durationMinutes: number;
+  status: string;
+  notes: string | null;
+  cancellationReason: string | null;
+  createdAt: Date;
+  itemId: string;
+  provider: { name: string } | null;
+}
+
+function project(row: BookingRow): CustomerVisit {
+  return {
+    id: row.id,
+    bookingRef: row.bookingRef,
+    scheduledAt: row.scheduledAt.toISOString(),
+    durationMinutes: row.durationMinutes,
+    status: projectStatus(row.status),
+    itemName: row.itemId,
+    providerName: row.provider?.name ?? null,
+    notes: row.notes,
+    cancellationReason: row.cancellationReason,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const { user } = await requireCustomerAuth(request);
+
+    if (!user.accountId) {
+      return apiSuccess(buildPaginatedResponse<CustomerVisit>([], 25));
+    }
+
+    // Resolve the customer's contact IDs once — the booking has only
+    // customerContactId (no Prisma @relation), so we filter by that set.
+    const contacts = await prisma.customerContact.findMany({
+      where: { account: { is: { accountId: user.accountId } } },
+      select: { id: true },
+    });
+    if (contacts.length === 0) {
+      return apiSuccess(buildPaginatedResponse<CustomerVisit>([], 25));
+    }
+    const contactIds = contacts.map((c) => c.id);
+
+    const url = new URL(request.url);
+    const { cursor, limit } = parsePagination(url.searchParams);
+    const statusFilter = url.searchParams.get("status");
+    const upcomingOnly = url.searchParams.get("upcoming") === "true";
+
+    const where: Prisma.StorefrontBookingWhereInput = {
+      customerContactId: { in: contactIds },
+    };
+    if (cursor) {
+      where.id = { lt: cursor };
+    }
+    if (statusFilter) {
+      where.status = statusFilter;
+    }
+    if (upcomingOnly) {
+      where.scheduledAt = { gte: new Date() };
+    }
+
+    const rows = await prisma.storefrontBooking.findMany({
+      where,
+      orderBy: { scheduledAt: "desc" },
+      take: limit + 1,
+      select: {
+        id: true,
+        bookingRef: true,
+        scheduledAt: true,
+        durationMinutes: true,
+        status: true,
+        notes: true,
+        cancellationReason: true,
+        createdAt: true,
+        itemId: true,
+        provider: { select: { name: true } },
+      },
+    });
+
+    return apiSuccess(buildPaginatedResponse(rows.map(project), limit));
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/api-client/src/endpoints/customer.ts
+++ b/packages/api-client/src/endpoints/customer.ts
@@ -3,6 +3,7 @@ import type {
   ContactWithRoles,
   CreateContactRequest,
   CustomerAccount,
+  CustomerVisit,
   InvoiceDetail,
   PaginatedResponse,
   SimilarContact,
@@ -73,6 +74,28 @@ export function customerEndpoints(client: DpfClient) {
       const query = qs.toString();
       return client.get<PaginatedResponse<InvoiceDetail>>(
         `/api/v1/customer/invoices${query ? `?${query}` : ""}`,
+      );
+    },
+
+    /**
+     * "My visits" — the signed-in customer's appointments / service visits.
+     * Scoped server-side to the contacts on the customer's account; supply
+     * `upcoming=true` for forward-looking visits only.
+     */
+    myVisits: (params?: {
+      cursor?: string;
+      limit?: number;
+      status?: string;
+      upcoming?: boolean;
+    }) => {
+      const qs = new URLSearchParams();
+      if (params?.cursor) qs.set("cursor", params.cursor);
+      if (params?.limit) qs.set("limit", String(params.limit));
+      if (params?.status) qs.set("status", params.status);
+      if (params?.upcoming) qs.set("upcoming", "true");
+      const query = qs.toString();
+      return client.get<PaginatedResponse<CustomerVisit>>(
+        `/api/v1/customer/visits${query ? `?${query}` : ""}`,
       );
     },
   };

--- a/packages/types/src/customer-visits.ts
+++ b/packages/types/src/customer-visits.ts
@@ -1,0 +1,30 @@
+/**
+ * Customer-visit wire types — shared by the portal producer
+ * (apps/web/app/api/v1/customer/visits) and the mobile customer surface
+ * (apps/mobile/src/features/customer-visits). Projection of StorefrontBooking
+ * for the signed-in customer's "My visits" tab.
+ */
+
+export type CustomerVisitStatus =
+  | "pending"
+  | "confirmed"
+  | "cancelled"
+  | "completed"
+  | "no_show";
+
+/** A single appointment / service visit for the signed-in customer. */
+export interface CustomerVisit {
+  id: string;
+  bookingRef: string;
+  /** ISO date-time string. */
+  scheduledAt: string;
+  durationMinutes: number;
+  status: CustomerVisitStatus;
+  /** Display name for the service offering on this visit. */
+  itemName?: string;
+  /** Service provider (e.g. tech name) if assigned, else null. */
+  providerName: string | null;
+  notes: string | null;
+  cancellationReason: string | null;
+  createdAt: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,4 +3,5 @@ export * from "./api";
 export * from "./dynamic";
 export * from "./mobile-manifest";
 export * from "./work-items";
+export * from "./customer-visits";
 export * from "./finance";


### PR DESCRIPTION
## Summary

Customer-side parallel to the employee's My Jobs. Customers signed into a DPF install see their upcoming + recent appointments on Home, alongside the My invoices panel from #2045. Same persona-gated render, same generic binary, same "install drives the app" doctrine.

Spec: [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html) §7 (customer persona) + §11 (P5).

## Mechanics

- `@dpf/types/customer-visits.ts` — `CustomerVisit` wire shape + closed status union (`pending|confirmed|cancelled|completed|no_show`).
- `apps/web/app/api/v1/customer/visits/route.ts` — `GET` list, `requireCustomerAuth`, scoped two-hop (`account.is.accountId` → customer's contacts → bookings in that contact set). Optional `?upcoming=true` filter, `?status=*`, cursor pagination. Workforce caller → 403.
- `packages/api-client/src/endpoints/customer.ts` — `customer.myVisits()`.
- `apps/mobile/src/features/customer-visits/customer-visits.store.ts` — zustand store + `partitionVisits()` pure projection (cancelled/no_show treated as recent even when future-dated; soonest-first / most-recent-first ordering).
- `apps/mobile/src/features/customer-visits/CustomerVisitsPanel.tsx` — home panel with Upcoming + Recent sections and status pills.
- `apps/mobile/app/(tabs)/index.tsx` — customer Home now mounts `CustomerInvoicesPanel` + `CustomerVisitsPanel`. Operator/employee/admin Home unchanged.

## Test plan

- [x] `pnpm --filter web exec vitest run app/api/v1/customer/` — 13/13 (8 new visits + 5 existing invoices).
- [x] `pnpm --filter mobile exec jest --testPathPatterns="customer-visits|customer-invoices|jobs|invoices|navigation"` — 40/40 (10 new visits store + 30 existing).
- [x] `pnpm --filter web typecheck` + `pnpm --filter mobile typecheck` — both clean.

## What's next

3. Job-completion photo + signature capture.
4. Multi-space switcher UX (Town M2).
5. EAS pipeline + path-filtered mobile CI lane.
6. Geo-discovery "Nearby" client + stub directory (Town M4).
