### PR TITLE
docs(architecture): Unified Development Activity Tracking page with at-a-glance diagram

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Domain-specific operating guides (admin, AI workforce, build studio, compliance,
 ## Architecture
 
 - [Platform Overview](architecture/platform-overview.md) — runtime core, deployment models, hardware tiers, and Docker Compose breakdown.
+- [Unified Development Activity Tracking](architecture/unified-development-tracking.md) — how all development work (Build Studio plus external Claude / Codex / Grok agents) is tracked as one WorkCapsule unit and shown in one cross-surface activity view. Includes an at-a-glance diagram.
 - [Autonomy, WWMD, and trusted coworker decisions](architecture/autonomy-and-wwmd.md) — how the founder-kernel wiki, principle vectors, decision profiles, and audit ledgers let coworkers answer ambiguity without silently overreaching.
 - [Trusted AI Kernel (markdown)](architecture/trusted-ai-kernel.md) / [(Word)](architecture/Trusted-AI-Kernel-Architecture.docx) — the layered enforcement, routing, audit, and immutable-directive architecture for agentic work.
 - [AI Coworker Development Principles](architecture/ai-coworker-development-principles.md) — the contract AI coworkers are expected to honor.

--- a/docs/architecture/unified-development-tracking.md
+++ b/docs/architecture/unified-development-tracking.md
@@ -12,16 +12,16 @@ flowchart TD
     cc[Claude Code CLI]
     cx[Codex CLI]
     gk[Grok CLI]
+    wc{{WorkCapsule<br/>the universal unit of work<br/>executor-agnostic, one per effort}}
+    view[Development activity view<br/>all surfaces in one place]
+    tl[Per-effort timeline<br/>progress, evidence, documents, PR + merge]
 
     bs -->|auto-attaches a capsule| wc
     cc -->|records evidence, adopts,<br/>or claims a capsule| wc
     cx -->|records evidence, adopts,<br/>or claims a capsule| wc
     gk -->|records evidence, adopts,<br/>or claims a capsule| wc
-
-    wc{{WorkCapsule<br/>the universal unit of work<br/>executor-agnostic, one per effort}}
-
-    wc --> view[Development activity view<br/>all surfaces in one place]
-    wc --> tl[Per-effort timeline<br/>progress, evidence, documents, PR + merge]
+    wc --> view
+    wc --> tl
 ```
 
 The four surfaces are **peers, not a hierarchy** — none is privileged, and work never depends on any one of them being healthy. They all advance the same evidence‑gated lifecycle (`ideate → plan → build → review → ship`), right‑sized to the work.

--- a/docs/architecture/unified-development-tracking.md
+++ b/docs/architecture/unified-development-tracking.md
@@ -1,0 +1,58 @@
+# Unified Development Activity Tracking
+
+Every piece of development work in the platform — whether it is built by the in‑portal **Build Studio** or by an external AI coding agent (**Claude Code**, **Codex**, or **Grok**) — is tracked the same way. You see all of it, with its progress, evidence, documents, and pull requests, in one cross‑surface view.
+
+This page explains how that works at a glance.
+
+## The structure
+
+```mermaid
+flowchart TD
+    bs[Build Studio<br/>in-portal builds]
+    cc[Claude Code CLI]
+    cx[Codex CLI]
+    gk[Grok CLI]
+
+    bs -->|auto-attaches a capsule| wc
+    cc -->|records evidence, adopts,<br/>or claims a capsule| wc
+    cx -->|records evidence, adopts,<br/>or claims a capsule| wc
+    gk -->|records evidence, adopts,<br/>or claims a capsule| wc
+
+    wc{{WorkCapsule<br/>the universal unit of work<br/>executor-agnostic, one per effort}}
+
+    wc --> view[Development activity view<br/>all surfaces in one place]
+    wc --> tl[Per-effort timeline<br/>progress, evidence, documents, PR + merge]
+```
+
+The four surfaces are **peers, not a hierarchy** — none is privileged, and work never depends on any one of them being healthy. They all advance the same evidence‑gated lifecycle (`ideate → plan → build → review → ship`), right‑sized to the work.
+
+## One unit of work: the WorkCapsule
+
+Every effort — a Build Studio build, a Claude Code session, a Codex or Grok run — is represented by a single **WorkCapsule**. The capsule is *executor‑agnostic*: it does not matter which surface did the work. It holds the effort's identity — its branch, worktree, pull request, lifecycle status, scope claims, and a lease (so two agents do not collide on the same work).
+
+Because the capsule is the shared unit, every surface's work lands in the same place.
+
+## How each surface is captured
+
+| Surface | How it becomes a tracked capsule |
+| --- | --- |
+| **Build Studio** | Auto‑attaches a capsule when a build starts. |
+| **Claude Code / Codex / Grok** | Three ways, in order of least effort: (1) **auto‑capture** — recording development evidence, which agents are asked to do at phase boundaries, creates the capsule automatically; (2) **adopt** an existing branch/worktree; (3) **claim** a capsule explicitly at work‑start. |
+
+Capture degrades gracefully: if the coordination plane is briefly unreachable, the agent still works and the capsule reconciles afterward — work never blocks on the tracker.
+
+## What you see
+
+- **Development activity view** — every surface's work in one list (the **All work** lens), each item showing its status, owner, branch, and PR. Completed work is marked **shipped**.
+- **Per‑effort timeline** — for any single effort: its progress through the lifecycle, its evidence (tests, production build, runtime verification), its documents (brief, design, plan, phase handoffs), and its pull request and merge.
+
+## Why this works
+
+- **The coordination plane is MCP.** Work tracking, claims, and evidence live in one substrate. *If it is not in the plane, it did not happen.*
+- **Governance approves evidence, not provenance.** A quality gate reads the required evidence and never branches on *which* surface produced it. That is exactly what makes the surfaces interchangeable — and what lets one agent start an effort and another finish it (start‑by‑one / finish‑by‑another).
+
+## Where to look / learn more
+
+- **In the portal:** the cross‑surface **Development activity** view (route `/platform/development/change-lanes`), opening on the **All work** lens.
+- **The contract for agents:** [`AGENTS.md`](../../AGENTS.md) §17 — *Delivery Surfaces & Execution Alignment*.
+- **The design:** [Unified Build Studio tracking across all surfaces](../superpowers/specs/2026-06-19-unified-build-studio-tracking-all-surfaces-design.md) and its [delivery‑visibility addendum](../superpowers/specs/2026-06-19-delivery-visibility-and-pr-capture-addendum.md).


### PR DESCRIPTION
## What

Adds a discoverable architecture page so **anyone using the platform understands how development tracking works at a glance** — not just whoever read the specs.

[`docs/architecture/unified-development-tracking.md`](docs/architecture/unified-development-tracking.md) explains, with a **Mermaid diagram**, how every piece of development work — from the in-portal **Build Studio** or an external **Claude Code / Codex / Grok** agent — is tracked as **one `WorkCapsule` unit** and shown in **one cross-surface Development activity view**, with its progress, evidence, documents, and PRs.

The diagram (renders inline on GitHub / in the IDE):

```
four surfaces ──▶ WorkCapsule (universal unit) ──▶ one activity view
                                              └──▶ per-effort timeline
```

Covers: the four peer surfaces; the WorkCapsule as the executor-agnostic unit; how each surface is captured (BS auto-attach; external **auto-capture on evidence / adopt / claim**); what you see (All work lens + per-effort timeline); and why it works (MCP coordination plane; governance approves evidence not provenance). Linked from the docs index ([`docs/README.md`](docs/README.md) Architecture section).

## Why

The structure was only described in design specs and AGENTS.md §17 (agent-facing). This puts the **delivered** architecture (the merged EP-UNIFIED-TRACKING work) into the user/contributor docs with a glanceable diagram.

Docs-only; Mermaid follows the existing `architecture/platform-overview.md` convention; all cross-links verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)