### PR TITLE
feat(inference): auto-set local build context on install so builds don't truncate

### DIFF
--- a/apps/web/lib/inference/bootstrap-first-run.ts
+++ b/apps/web/lib/inference/bootstrap-first-run.ts
@@ -8,7 +8,10 @@ import {
   recommendGenerationModel,
   detectLocalModelOverCommit,
   normaliseModelId,
+  isEmbeddingModelId,
+  RECOMMENDED_BUILD_CONTEXT_TOKENS,
 } from "./local-model-policy";
+import { setServedContextTokens } from "./dmr-runtime-config";
 
 /** Check if first-run bootstrap is needed. */
 export async function checkBootstrapNeeded(): Promise<boolean> {
@@ -182,6 +185,40 @@ export async function executeFirstRunBootstrap(
           }
         } catch {
           // best-effort — never block setup on the drift check
+        }
+
+        // Build-context guard: a fresh DMR pull serves a small default context
+        // (qwen3-coder = 4k), below OpenCode's 22k build floor, so local builds
+        // would silently truncate. Raise the GENERATION model's served context to
+        // a build-appropriate size (the embedder is left alone). Best-effort —
+        // never blocks setup. See local-model-policy.ts + dmr-runtime-config.ts.
+        try {
+          const oaiBase = getOllamaBaseUrl().replace(/\/$/, "");
+          const modelsUrl = oaiBase.endsWith("/v1") ? `${oaiBase}/models` : `${oaiBase}/v1/models`;
+          const modelsRes = await fetch(modelsUrl, { signal: AbortSignal.timeout(3000) });
+          if (modelsRes.ok) {
+            const body = (await modelsRes.json()) as {
+              data?: Array<{ id?: string; dmr?: { context_window?: number } }>;
+            };
+            const gen = (body.data ?? []).find((m) => m.id && !isEmbeddingModelId(m.id));
+            const served = gen?.dmr?.context_window ?? 0;
+            if (gen?.id && served < RECOMMENDED_BUILD_CONTEXT_TOKENS) {
+              const applied = await setServedContextTokens(apiRoot, gen.id, RECOMMENDED_BUILD_CONTEXT_TOKENS);
+              if (applied.ok) {
+                // fix-the-seed: the ModelProfile row is the routing source of truth,
+                // so persist the served context there too (not just in DMR).
+                await prisma.modelProfile.updateMany({
+                  where: { providerId: { in: ["local", "ollama"] }, modelId: gen.id },
+                  data: { maxContextTokens: applied.contextTokens ?? RECOMMENDED_BUILD_CONTEXT_TOKENS },
+                });
+                console.log(`[bootstrap] Raised ${gen.id} served context ${served} → ${RECOMMENDED_BUILD_CONTEXT_TOKENS} for Build Studio.`);
+              } else {
+                console.warn(`[bootstrap] Could not raise ${gen.id} context (${applied.reason ?? "unknown"}); local builds may truncate until set in Build Runtime.`);
+              }
+            }
+          }
+        } catch {
+          // best-effort — never block setup on the context tune
         }
       } else {
         console.warn("[bootstrap] Ollama not reachable — proceeding without local AI");

--- a/apps/web/lib/inference/local-model-policy.test.ts
+++ b/apps/web/lib/inference/local-model-policy.test.ts
@@ -10,6 +10,7 @@ import {
   detectLocalModelOverCommit,
   normaliseModelId,
   MAX_CONCURRENT_GENERATION_MODELS,
+  RECOMMENDED_BUILD_CONTEXT_TOKENS,
 } from "./local-model-policy";
 
 describe("classifyLocalModelRole / isEmbeddingModelId", () => {
@@ -65,6 +66,12 @@ describe("recommendGenerationModelForHost (architecture-aware) + computeMemoryBu
   it("a budget 8–12 GB discrete GPU never over-commits", () => {
     expect(recommendGenerationModelForHost({ architecture: "discrete", vramGb: 12 })).toBe("ai/qwen3:8B-Q4_K_M");
     expect(recommendGenerationModelForHost({ architecture: "discrete", vramGb: 8 })).toBe("ai/qwen3:4B-UD-Q4_K_XL");
+  });
+});
+
+describe("RECOMMENDED_BUILD_CONTEXT_TOKENS", () => {
+  it("clears the OpenCode build floor (22k) so the auto-set context never truncates builds", () => {
+    expect(RECOMMENDED_BUILD_CONTEXT_TOKENS).toBeGreaterThanOrEqual(22_000);
   });
 });
 

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -76,6 +76,16 @@ export const UNIFIED_USABLE_FRACTION = 0.75;
 /** Fraction of system RAM usable for CPU-only inference (leaves room for OS + stack). */
 export const CPU_USABLE_FRACTION = 0.5;
 
+/**
+ * Served context window (tokens) the platform auto-sets for the local GENERATION
+ * model on install, so Build Studio's local builds aren't silently truncated. A
+ * fresh Docker Model Runner pull defaults to a small context (qwen3-coder = 4k),
+ * below OpenCode's 22k build floor (OPENCODE_MIN_CONTEXT_TOKENS). 24k clears the
+ * floor with margin and fits inside the MODEL_HEADROOM_GB the tier selection
+ * already reserves (~2.3 GB of KV cache at this size — measured ~0.1 GB / 1k tokens).
+ */
+export const RECOMMENDED_BUILD_CONTEXT_TOKENS = 24_576;
+
 export type HostArchitecture = "discrete" | "unified" | "cpu";
 
 export interface HostMemory {

--- a/docs/superpowers/specs/2026-06-19-local-model-policy-single-generation.md
+++ b/docs/superpowers/specs/2026-06-19-local-model-policy-single-generation.md
@@ -89,6 +89,21 @@ real context window — even the first pull on a fresh install. Recalibrated:
 Per-host result: 8 GB GPU → 4B, 12 GB → 8B, 24 GB → 30B, 27 GB+ → 35B, 53 GB+
 discrete or 64 GB+ unified → 80B. None over-commit at build context.
 
+## Auto-set build context on install (2026-06-20)
+
+Right-sizing the *model* isn't enough — the served **context window** matters too.
+A fresh DMR pull serves a small default (qwen3-coder = 4k), below OpenCode's 22k
+build floor, so local builds silently truncate until an operator sets it by hand
+in Build Runtime. `bootstrap-first-run` now auto-raises the GENERATION model's
+served context to `RECOMMENDED_BUILD_CONTEXT_TOKENS` (24k) on install: read the
+effective context from `/v1/models`, raise via `setServedContextTokens` only when
+it is below target, persist to the `ModelProfile` row (the routing source of
+truth), and leave the embedder alone. Best-effort — never blocks setup; 24k fits
+inside the headroom the tier selection already reserves (~2.3 GB of KV cache).
+The build preflight's existing "context too small" flag stays as the safety net
+for later model swaps (and for the rare case DMR refuses to reconfigure an
+already-active runner).
+
 ## Still out of scope (follow-ups under BI-0B893092)
 
 - **Install-script tiers are mirrored, not imported** — shell / the


### PR DESCRIPTION
## Why

Completes the local-model right-sizing work. We now pick the right **model** for the hardware (#2164) — but a fresh Docker Model Runner pull serves a **small default context window** (qwen3-coder = **4k tokens**), and OpenCode's build floor is **22k**. So on any **fully-local install**, the build phase silently truncates until an operator digs into Build Runtime and raises it by hand. (I hit this on the build host and had to bump it to 24k manually.)

A context window is the model's working memory while it builds — the task + the code it's editing + its plan. At 4k (~6 pages) it can't hold a real build (~35 pages), so builds garble or fail with no obvious cause.

## What

`bootstrap-first-run` now **auto-raises the generation model's served context to `RECOMMENDED_BUILD_CONTEXT_TOKENS` (24k) on install**:
- read the **effective** context from `/v1/models` (`dmr.context_window`);
- raise via the existing `setServedContextTokens` **only when below target** (never lowers a model that already serves enough);
- persist to the `ModelProfile` row (the routing source of truth), not just DMR;
- the **embedder is left alone** (it has its own small context).

Best-effort — wrapped so it **never blocks setup**. 24k clears the 22k floor with margin and fits inside the `MODEL_HEADROOM_GB` the tier selection already reserves (~2.3 GB of KV cache, measured ~0.1 GB / 1k tokens). The build preflight's existing "context too small" flag stays as the safety net for later model swaps and for the rare case DMR refuses to reconfigure an already-active runner.

## Result

| | Before | After |
|---|---|---|
| Fresh local install | serves ~4k context → builds truncate silently | auto-set to 24k → builds have full working memory |

So a fully-local install now ships with the **right model and the right context**, no manual step.

## Tests

Added an invariant test that `RECOMMENDED_BUILD_CONTEXT_TOKENS ≥ 22k` (the OpenCode floor) so the auto-set value can never regress below what builds need. The setter/`/v1/models` read is IO (best-effort, exercised at runtime).

## Verification note

Local typecheck/tests couldn't run (worktree `node_modules` empty — known env regression); committed `DPF_SKIP_TYPECHECK=1`, relying on CI. The wiring reuses the same `setServedContextTokens` the manual admin action already uses.

Refs BI-0B893092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)