### PR TITLE
feat(ea-canvas): containment (nested) view — Packages as boxes containing their Parts (BI-9E5EA3FF)

### DIFF
--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -13,11 +13,13 @@ import { buildStructuredViewElements, filterStructuredEdges } from "@/lib/ea-str
 import {
   computeEaLayout,
   placeIncremental,
+  computeContainmentLayout,
   EA_LAYOUT_ALGORITHMS,
   EA_LAYOUT_LABELS,
   type EaLayoutAlgorithm,
   type EaLayoutEdge,
 } from "@/lib/ea/canvas-layout";
+import { EaContainerNode } from "./EaContainerNode";
 import { EaElementNode } from "./EaElementNode";
 import { EaRelationshipEdge } from "./EaRelationshipEdge";
 import { ElementPalette } from "./ElementPalette";
@@ -33,7 +35,7 @@ import {
 } from "@/lib/actions/ea";
 import { buildValueStreamGroupLayout, estimateStageWidth } from "./value-stream-layout";
 
-const NODE_TYPES = { eaElement: EaElementNode };
+const NODE_TYPES = { eaElement: EaElementNode, eaContainer: EaContainerNode };
 const EDGE_TYPES = { eaRelationship: EaRelationshipEdge };
 
 const DEFAULT_CANVAS_STATE: CanvasState = {
@@ -308,6 +310,46 @@ function buildEdges(edges: SerializedEdge[], onDelete: (id: string) => void, edg
   }));
 }
 
+// Containment (nested) view: derive the Package⊃Part hierarchy from "contains" edges, lay it
+// out as nested boxes, and draw only the cross-cutting (non-contains) edges. (BI-9E5EA3FF)
+function buildNestedGraph(
+  visibleElements: SerializedViewElement[],
+  visibleEdges: SerializedEdge[],
+  onDelete: (id: string) => void,
+  edgeVariant: EdgeVariant,
+): { nodes: Node[]; edges: Edge[] } {
+  const elementById = new Map(visibleElements.map((el) => [el.viewElementId, el]));
+  const containsEdges = visibleEdges
+    .filter((e) => e.relationshipType.slug === "contains")
+    .map((e) => ({ parent: e.fromViewElementId, child: e.toViewElementId }));
+  const crossEdges = visibleEdges.filter((e) => e.relationshipType.slug !== "contains");
+
+  const layout = computeContainmentLayout(
+    visibleElements.map((el) => el.viewElementId),
+    containsEdges,
+  );
+
+  const nodes: Node[] = layout.map((cn) => {
+    const element = elementById.get(cn.id);
+    const node: Node = {
+      id: cn.id,
+      type: cn.isContainer ? "eaContainer" : "eaElement",
+      position: { x: cn.x, y: cn.y },
+      data: (element ?? {}) as unknown as Record<string, unknown>,
+    };
+    if (cn.parentId) {
+      node.parentId = cn.parentId;
+      node.extent = "parent";
+    }
+    if (cn.isContainer) {
+      node.style = { width: cn.width, height: cn.height };
+    }
+    return node;
+  });
+
+  return { nodes, edges: buildEdges(crossEdges, onDelete, edgeVariant) };
+}
+
 const EDGE_VARIANT_LABELS: Record<EdgeVariant, string> = {
   straight: "━ Straight",
   bezier:   "⌒ Curved",
@@ -376,6 +418,7 @@ export function EaCanvas({
   const [isLayouting, setIsLayouting] = useState(false);
   const [revMenuOpen, setRevMenuOpen] = useState(false);
   const [layoutMenuOpen, setLayoutMenuOpen] = useState(false);
+  const [nestedMode, setNestedMode] = useState(false);
   const [pendingDrop, setPendingDrop] = useState<{
     elementId: string; name: string; typeName: string;
     lifecycleStage: string; lifecycleStatus: string;
@@ -479,12 +522,44 @@ export function EaCanvas({
     [isReadOnly, viewId, setNodes, currentNodesRecord],
   );
 
+  // Containment (nested) view — swap the node/edge set to nested boxes derived from
+  // "contains" edges. Deterministic from data, so it isn't persisted (localStorage toggle only).
+  const enterNested = useCallback(() => {
+    setNestedMode(true);
+    try { window.localStorage.setItem("ea-nested-mode", "1"); } catch { /* ignore */ }
+    const g = buildNestedGraph(visibleElements, visibleEdges, handleDeleteEdge, edgeVariant);
+    setNodes(g.nodes);
+    setEdges(g.edges);
+    setLayoutMenuOpen(false);
+    requestAnimationFrame(() => rfRef.current?.fitView({ duration: 400, padding: 0.1 }));
+  }, [visibleElements, visibleEdges, handleDeleteEdge, edgeVariant, setNodes, setEdges]);
+
+  const exitNested = useCallback(() => {
+    setNestedMode(false);
+    try { window.localStorage.setItem("ea-nested-mode", "0"); } catch { /* ignore */ }
+    setNodes(buildNodes(visibleElements, latestCanvasStateRef.current, layoutEdges).nodes);
+    setEdges(buildEdges(visibleEdges, handleDeleteEdge, edgeVariant));
+    requestAnimationFrame(() => rfRef.current?.fitView({ duration: 400, padding: 0.1 }));
+  }, [visibleElements, visibleEdges, layoutEdges, handleDeleteEdge, edgeVariant, setNodes, setEdges]);
+
+  // Hydrate the nested-view toggle from localStorage once on mount.
+  const didHydrateNestedRef = useRef(false);
+  useEffect(() => {
+    if (didHydrateNestedRef.current) return;
+    didHydrateNestedRef.current = true;
+    if (typeof window !== "undefined" && window.localStorage.getItem("ea-nested-mode") === "1") {
+      enterNested();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // On first mount: upgrade an auto-generated grid placeholder to a real crossing-minimizing
   // layout, or persist the nestled positions of newly-added nodes. Runs exactly once.
   const didInitLayoutRef = useRef(false);
   useEffect(() => {
     if (didInitLayoutRef.current) return;
     didInitLayoutRef.current = true;
+    // Nested view manages its own node set; skip the flat auto-layout.
+    if (typeof window !== "undefined" && window.localStorage.getItem("ea-nested-mode") === "1") return;
     const topLevelCount = nodesRef.current.filter((n) => !n.parentId).length;
     if (initialNodeLayout.needsInitialAutoLayout) {
       if (topLevelCount > 1 && layoutEdges.length > 0) {
@@ -713,7 +788,19 @@ export function EaCanvas({
 
           {/* Right-side controls */}
           <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-            {!isReadOnly && (
+            <button
+              onClick={() => (nestedMode ? exitNested() : enterNested())}
+              title="Containment view — nest Packages/Parts as boxes (from 'contains' relationships)"
+              style={{
+                fontSize: 10, padding: "2px 8px", borderRadius: 3, cursor: "pointer",
+                background: nestedMode ? "#2a2a50" : "transparent",
+                border: `1px solid ${nestedMode ? "var(--dpf-accent)" : "#2a2a40"}`,
+                color: nestedMode ? "var(--dpf-accent)" : "var(--dpf-muted)",
+              }}
+            >
+              ▦ Nest
+            </button>
+            {!isReadOnly && !nestedMode && (
               <div style={{ display: "flex", alignItems: "center", gap: 4, position: "relative" }}>
                 <button
                   onClick={() => {

--- a/apps/web/components/ea/EaContainerNode.tsx
+++ b/apps/web/components/ea/EaContainerNode.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { layerFromNeoLabel, LAYER_COLOURS, type SerializedViewElement } from "@/lib/ea-types";
+
+// A container (Package / Part Definition with children) in the containment view. React Flow
+// sizes the node from node.style width/height; this fills that box with a titled, translucent
+// frame so the nested child nodes render inside it. (BI-9E5EA3FF)
+const HANDLES = [
+  { position: Position.Top, id: "t" },
+  { position: Position.Right, id: "r" },
+  { position: Position.Bottom, id: "b" },
+  { position: Position.Left, id: "l" },
+];
+
+export const EaContainerNode = memo(function EaContainerNode({ data, selected }: NodeProps) {
+  const nodeData = data as SerializedViewElement;
+  const layer = layerFromNeoLabel(nodeData.elementType.neoLabel);
+  const colours = LAYER_COLOURS[layer] ?? { bg: "#CCE5FF", border: "#4a90d9" };
+  const displayName =
+    nodeData.mode === "propose" && nodeData.proposedProperties?.["name"]
+      ? String(nodeData.proposedProperties["name"])
+      : nodeData.element.name;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        border: `1px solid ${selected ? "var(--dpf-accent)" : colours.border}`,
+        borderRadius: 6,
+        background: `${colours.border}0d`, // ~5% tint of the layer colour
+        boxShadow: selected ? `0 0 0 1px var(--dpf-accent)` : undefined,
+        position: "relative",
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          padding: "5px 8px",
+          fontSize: 10,
+          fontWeight: 700,
+          color: "#112",
+          background: colours.bg,
+          borderBottom: `1px solid ${colours.border}`,
+          borderRadius: "5px 5px 0 0",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          userSelect: "none",
+        }}
+        title={`${nodeData.elementType.name} · ${displayName}`}
+      >
+        <span style={{ color: "#557", fontWeight: 600, marginRight: 5 }}>{nodeData.elementType.name}</span>
+        {displayName}
+      </div>
+      {HANDLES.map(({ position, id }) => (
+        <Handle key={id} type="source" id={id} position={position} style={{ width: 6, height: 6, background: colours.border, opacity: 0 }} />
+      ))}
+    </div>
+  );
+});

--- a/apps/web/lib/ea/canvas-layout.test.ts
+++ b/apps/web/lib/ea/canvas-layout.test.ts
@@ -4,6 +4,7 @@ import {
   placeIncremental,
   pickAutoAlgorithm,
   computeMetrics,
+  computeContainmentLayout,
   EA_NODE_W,
   EA_NODE_H,
 } from "./canvas-layout";
@@ -140,5 +141,51 @@ describe("placeIncremental", () => {
     const result = placeIncremental(existing, [edge("x", "a"), edge("y", "a")], ["x", "y"]);
     expect(Object.keys(result).sort()).toEqual(["x", "y"]);
     expect(existing).toEqual({ a: { x: 0, y: 0 } });
+  });
+});
+
+describe("computeContainmentLayout", () => {
+  const c = (parent: string, child: string) => ({ parent, child });
+
+  it("nests children under parents (parentId) and marks containers", () => {
+    const out = computeContainmentLayout(["P", "A", "B", "X"], [c("P", "A"), c("P", "B"), c("A", "X")]);
+    const by = Object.fromEntries(out.map((n) => [n.id, n]));
+    expect(by.P!.parentId).toBeNull();
+    expect(by.P!.isContainer).toBe(true);
+    expect(by.A!.parentId).toBe("P");
+    expect(by.A!.isContainer).toBe(true);
+    expect(by.B!.parentId).toBe("P");
+    expect(by.B!.isContainer).toBe(false);
+    expect(by.X!.parentId).toBe("A");
+    expect(by.X!.isContainer).toBe(false);
+  });
+
+  it("emits parents before their children (React Flow ordering)", () => {
+    const order = computeContainmentLayout(["P", "A", "X"], [c("P", "A"), c("A", "X")]).map((n) => n.id);
+    expect(order.indexOf("P")).toBeLessThan(order.indexOf("A"));
+    expect(order.indexOf("A")).toBeLessThan(order.indexOf("X"));
+  });
+
+  it("sizes a container to enclose its children", () => {
+    const P = computeContainmentLayout(["P", "A", "B"], [c("P", "A"), c("P", "B")]).find((n) => n.id === "P")!;
+    expect(P.width).toBeGreaterThan(EA_NODE_W);
+    expect(P.height).toBeGreaterThan(EA_NODE_H);
+  });
+
+  it("treats nodes with no contains-edges as top-level leaves", () => {
+    const out = computeContainmentLayout(["a", "b", "c"], []);
+    expect(out).toHaveLength(3);
+    expect(out.every((n) => n.parentId === null && !n.isContainer)).toBe(true);
+  });
+
+  it("ignores edges referencing unknown nodes", () => {
+    const out = computeContainmentLayout(["P", "A"], [c("P", "A"), c("P", "ghost")]);
+    expect(out.find((n) => n.id === "ghost")).toBeUndefined();
+    expect(out.find((n) => n.id === "A")!.parentId).toBe("P");
+  });
+
+  it("emits every node even when containment forms a cycle (no hang, none dropped)", () => {
+    const out = computeContainmentLayout(["P", "Q"], [c("P", "Q"), c("Q", "P")]);
+    expect(out.map((n) => n.id).sort()).toEqual(["P", "Q"]);
   });
 });

--- a/apps/web/lib/ea/canvas-layout.ts
+++ b/apps/web/lib/ea/canvas-layout.ts
@@ -377,3 +377,136 @@ export function placeIncremental(
   }
   return result;
 }
+
+// ─── Containment (nested) layout ────────────────────────────────────────────
+// SysML/ArchiMate containment (Package⊃Part⊃Port) is encoded as directed "contains"
+// edges (parent → child). Rather than draw those as edges, the containment view nests
+// children INSIDE their parent as React Flow group nodes. This pure packer derives the
+// forest from the contains-edges and lays each container's children out in a wrapped grid,
+// sizing the container to fit. Coordinates are relative to the parent (React Flow convention).
+
+const HEADER_H = 28; // container title bar
+const INNER_PAD = 16; // padding inside a container
+const INNER_GAP = 24; // gap between siblings inside a container
+
+export type ContainmentEdge = { parent: string; child: string };
+
+export type ContainmentNode = {
+  id: string;
+  parentId: string | null;
+  x: number; // relative to parent (canvas for top-level)
+  y: number;
+  width: number;
+  height: number;
+  isContainer: boolean;
+  depth: number;
+};
+
+type Measured = { width: number; height: number; childPos: Map<string, { x: number; y: number }> };
+
+// Shelf-pack boxes into rows bounded by `target` width; returns each box's top-left + extent.
+function shelfPack(
+  boxes: Array<{ id: string; width: number; height: number }>,
+  target: number,
+  originX: number,
+  originY: number,
+  gap: number,
+): { pos: Map<string, { x: number; y: number }>; width: number; height: number } {
+  const pos = new Map<string, { x: number; y: number }>();
+  let x = originX;
+  let y = originY;
+  let rowHeight = 0;
+  let contentRight = originX;
+  for (const b of boxes) {
+    if (x > originX && x + b.width > originX + target) {
+      x = originX;
+      y += rowHeight + gap;
+      rowHeight = 0;
+    }
+    pos.set(b.id, { x, y });
+    x += b.width + gap;
+    rowHeight = Math.max(rowHeight, b.height);
+    contentRight = Math.max(contentRight, x - gap);
+  }
+  return { pos, width: contentRight - originX, height: y + rowHeight - originY };
+}
+
+/**
+ * Compute a nested (containment) layout from "contains" edges.
+ * Returns one entry per node (parents before children) with parent-relative coordinates and
+ * container sizes. Nodes with children are containers; leaves get the standard node footprint.
+ */
+export function computeContainmentLayout(
+  nodeIds: string[],
+  containsEdges: ContainmentEdge[],
+): ContainmentNode[] {
+  const idset = new Set(nodeIds);
+  const childrenOf = new Map<string, string[]>();
+  const hasParent = new Set<string>();
+  for (const e of containsEdges) {
+    if (!idset.has(e.parent) || !idset.has(e.child) || e.parent === e.child) continue;
+    if (hasParent.has(e.child)) continue; // first parent wins (treat as a forest)
+    if (!childrenOf.has(e.parent)) childrenOf.set(e.parent, []);
+    childrenOf.get(e.parent)!.push(e.child);
+    hasParent.add(e.child);
+  }
+  const roots = nodeIds.filter((id) => !hasParent.has(id));
+
+  const measured = new Map<string, Measured>();
+  const inProgress = new Set<string>();
+  function measure(id: string): { width: number; height: number } {
+    const cached = measured.get(id);
+    if (cached) return { width: cached.width, height: cached.height };
+    const kids = (childrenOf.get(id) ?? []).filter((k) => !inProgress.has(k)); // cycle guard
+    if (kids.length === 0) {
+      measured.set(id, { width: EA_NODE_W, height: EA_NODE_H, childPos: new Map() });
+      return { width: EA_NODE_W, height: EA_NODE_H };
+    }
+    inProgress.add(id);
+    const boxes = kids.map((k) => ({ id: k, ...measure(k) }));
+    inProgress.delete(id);
+    const totalArea = boxes.reduce((s, b) => s + (b.width + INNER_GAP) * (b.height + INNER_GAP), 0);
+    const maxChildW = Math.max(...boxes.map((b) => b.width));
+    const target = Math.max(maxChildW, Math.sqrt(totalArea) * 1.3);
+    const packed = shelfPack(boxes, target, INNER_PAD, HEADER_H, INNER_GAP);
+    const width = Math.max(packed.width + 2 * INNER_PAD, maxChildW + 2 * INNER_PAD, 140);
+    const height = packed.height + HEADER_H + INNER_PAD;
+    measured.set(id, { width, height, childPos: packed.pos });
+    return { width, height };
+  }
+  roots.forEach(measure);
+
+  // Place roots in a top-level shelf.
+  const rootBoxes = roots.map((id) => ({ id, ...measure(id) }));
+  const totalArea = rootBoxes.reduce((s, b) => s + (b.width + GAP) * (b.height + GAP), 0);
+  const target = Math.max(0, ...rootBoxes.map((b) => b.width), Math.sqrt(totalArea) * 1.4);
+  const rootPacked = shelfPack(rootBoxes, target, MARGIN, MARGIN, GAP);
+
+  const out: ContainmentNode[] = [];
+  const emitted = new Set<string>();
+  function emit(id: string, parentId: string | null, pos: { x: number; y: number }, depth: number) {
+    if (emitted.has(id)) return; // each node once (guards cycles / shared descendants)
+    emitted.add(id);
+    const meas = measured.get(id) ?? { width: EA_NODE_W, height: EA_NODE_H, childPos: new Map() };
+    const isContainer = (childrenOf.get(id) ?? []).length > 0;
+    out.push({ id, parentId, x: pos.x, y: pos.y, width: meas.width, height: meas.height, isContainer, depth });
+    for (const k of childrenOf.get(id) ?? []) {
+      const cp = meas.childPos.get(k);
+      if (cp && !emitted.has(k)) emit(k, id, cp, depth + 1); // parent already pushed → RF ordering holds
+    }
+  }
+  for (const id of roots) emit(id, null, rootPacked.pos.get(id) ?? { x: MARGIN, y: MARGIN }, 0);
+
+  // Cycle fallback: nodes whose containment formed a cycle have no root — emit them as
+  // top-level so nothing silently disappears.
+  const leftover = nodeIds.filter((id) => !emitted.has(id));
+  if (leftover.length > 0) {
+    const boxes = leftover.map((id) => ({ id, ...measure(id) }));
+    const area = boxes.reduce((s, b) => s + (b.width + GAP) * (b.height + GAP), 0);
+    const target = Math.max(0, ...boxes.map((b) => b.width), Math.sqrt(area) * 1.4);
+    const baseY = out.reduce((m, n) => (n.parentId ? m : Math.max(m, n.y + n.height)), MARGIN) + GAP;
+    const packed = shelfPack(boxes, target, MARGIN, baseY, GAP);
+    for (const id of leftover) emit(id, null, packed.pos.get(id) ?? { x: MARGIN, y: baseY }, 0);
+  }
+  return out;
+}

--- a/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
+++ b/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
@@ -54,3 +54,15 @@ Live review of the deployed #2151 surfaced that the layouts sprawl into hairball
 - **UX fix C:** added a `← Views` back link (→ `/ea/views`) to the EA top bar, matching the sibling-detail-page pattern.
 
 **Deferred follow-ups (file separately):** populate `parentViewElementId` from "contains" edges + render containment as nested groups (`elk.hierarchyHandling: INCLUDE_CHILDREN` + React Flow parent nodes) — biggest structural ceiling; and move ELK to a Web Worker for 600-node perf.
+
+---
+
+## Addendum — 2026-06-20: containment (nested) view (BI-9E5EA3FF)
+
+Operator /goal "do as recommended with the container view" — built the deferred containment nesting. Rather than the generator/migration route, derive nesting **client-side from `contains` edges** (the dominant relationship: 1887 live; directed parent→child) so it works on existing views with no schema/data change. Custom recursive shelf-packer chosen over ELK compound — simpler + predictable for the pure-`contains` trees that dominate (ELK `INCLUDE_CHILDREN` noted as a future enhancement for cross-edge-heavy containment).
+
+- `apps/web/lib/ea/canvas-layout.ts`: `computeContainmentLayout(nodeIds, containsEdges)` — builds the forest, packs each container's children into a wrapped grid, sizes the container to fit; returns `{id, parentId, x, y (parent-relative), width, height, isContainer, depth}` (parents before children for React Flow ordering). Guards: first-parent-wins (forest), cycle/in-progress, unknown-node, and a cycle-fallback so no node is dropped. Unit-tested.
+- `apps/web/components/ea/EaContainerNode.tsx` (new): titled translucent box, layer-coloured; children render inside via React Flow `parentId`.
+- `apps/web/components/ea/EaCanvas.tsx`: a **▦ Nest** toggle (localStorage-persisted, available to read-only too since nothing is saved) swaps the node/edge set to nested boxes (containers + nested leaves; only cross-cutting edges drawn — `contains` becomes nesting). Flat layout controls hidden while nested; flat auto-layout mount-effect guarded.
+
+Tests: 30 adapter (6 containment) + 16 EA component + 52 graph/actions/topology pass; web typecheck clean.


### PR DESCRIPTION
## Summary

Implements the containment (nested) view recommended after #2161 — render the SysML hierarchy as **nested boxes** (Package contains Part contains Port) instead of a flat node-and-edge hairball. This is the structural step that turns the 615-node "Application Routes" tree and the 343-node "Code Structure" star into legible drill-down diagrams.

**Derived from data, no migration.** Containment is encoded in **`contains`** edges (the dominant relationship — 1887 live, directed parent→child). Rather than a generator change to persist `parentViewElementId`, the view derives the nesting **client-side from those edges at render time**, so it works on existing views with no schema/data/generator change. (Cross-cutting edges — `associated_with`/`connects`/`traces` — are still drawn; `contains` becomes nesting and is not drawn.)

## Changes
- **`apps/web/lib/ea/canvas-layout.ts`** — `computeContainmentLayout(nodeIds, containsEdges)`: a pure recursive shelf-packer that builds the containment forest, packs each container's children into a wrapped grid, and sizes the container to fit. Returns parent-relative geometry with **parents before children** (React Flow ordering). Guards: first-parent-wins (forest), cycle/in-progress, unknown-node, and a cycle-fallback so no node is ever dropped.
- **`apps/web/components/ea/EaContainerNode.tsx`** (new) — a titled, translucent, layer-coloured container box; child nodes render inside it via React Flow's `parentId` (the same nesting mechanism the value-stream nodes already use).
- **`apps/web/components/ea/EaCanvas.tsx`** — a **▦ Nest** toggle (localStorage-persisted; available to read-only users too, since nothing is saved) swaps the node/edge set to the nested layout. Flat layout controls (Auto-layout / Revisions) are hidden while nested, and the flat auto-layout mount-effect is guarded.

Custom packer chosen over ELK compound (`hierarchyHandling: INCLUDE_CHILDREN`): simpler and more predictable for the pure-`contains` trees that dominate these views. ELK compound is noted as a future enhancement for cross-edge-heavy containment.

## Testing
- `lib/ea/canvas-layout.test.ts`: 30 tests (6 new for containment — nesting/parentId, container marking, parent-before-child order, container sizing, leaf-only, unknown-edge, cycle no-drop).
- 16 EA component + 52 graph/actions/TopologyGraph tests pass; `apps/web` typecheck clean.

Backlog: **BI-9E5EA3FF** · Epic: **EP-ARCH-GRAPH-LIVE** · extends #2151 / #2161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
