### PR TITLE
fix(ci): unblock main — version-agnostic checkout guard + stale route manifest

### DIFF
--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 500,
+  "routeCount": 501,
   "routes": [
     {
       "routePath": "/",
@@ -1886,6 +1886,18 @@
         "id"
       ],
       "file": "apps/web/app/api/v1/customer/sales-orders/[id]/route.ts"
+    },
+    {
+      "routePath": "/api/v1/customer/visits",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "customer",
+        "visits"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/customer/visits/route.ts"
     },
     {
       "routePath": "/api/v1/device-catalog",

--- a/packages/db/src/seed-ea-reference-models.test.ts
+++ b/packages/db/src/seed-ea-reference-models.test.ts
@@ -203,6 +203,11 @@ describe("seedEaReferenceModels", () => {
       "utf8"
     );
 
-    expect(workflow).toMatch(/uses:\s*actions\/checkout@v6\s*\n\s*with:\s*\n(?:\s*#.*\n)*\s*lfs:\s*true/);
+    // Version-agnostic on purpose: this guard protects `lfs: true` (so CI fetches
+    // the LFS-backed seed workbooks), NOT a specific checkout major. Pinning @v6
+    // made every legitimate Dependabot actions/checkout bump fail this required
+    // test (e.g. #2169 v6→v7). Match any major so bumps stay green while the
+    // LFS wiring stays enforced.
+    expect(workflow).toMatch(/uses:\s*actions\/checkout@v\d+\s*\n\s*with:\s*\n(?:\s*#.*\n)*\s*lfs:\s*true/);
   });
 });


### PR DESCRIPTION
## Why

Dependabot [#2169](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2169) (bump `actions/checkout` v6→v7) is **BLOCKED**. Investigation shows the bump itself is fine — it exposed **two pre-existing `main`-level CI issues**:

### 1. Required gate failure (the actual blocker for #2169)
`packages/db/src/seed-ea-reference-models.test.ts` has a guard — *"keeps the routing audit checkout wired to fetch LFS-backed seed workbooks"* — whose regex **hard-pinned `actions/checkout@v6`**:

```js
/uses:\s*actions\/checkout@v6\s*\n\s*with:\s*\n(?:\s*#.*\n)*\s*lfs:\s*true/
```

The guard's intent is to keep `lfs: true` wired on the `audit-routing-invariants.yml` checkout (so CI fetches the LFS-backed IT4IT seed workbook). The major version is incidental — but pinning it means **every legitimate Dependabot `actions/checkout` bump fails the required `Unit Tests` gate**. #2169 (v6→v7) is the first to hit it.

**Fix:** make the match version-agnostic (`@v\d+`). Verified it matches both `@v6` and `@v7`, and still fails if `lfs: true` is removed.

### 2. Advisory check red — stale route manifest
`apps/web/lib/ea/route-manifest.json` was stale on `main`: [#2168](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2168) added `apps/web/app/api/v1/customer/visits/route.ts` without regenerating the manifest (committed **500** vs actual **501** routes). `Route Manifest Freshness` (non-required, so it didn't block #2168) goes red on any PR that re-triggers it — #2169 does because it touches the workflow file.

**Fix:** regenerated. The only delta is the one missing route. Reproduction was verified **byte-identical** to the generator for the other 500 routes before writing.

## Effect
Once merged, #2169's required `Unit Tests` go green (after a branch update to pick up this fix), and the advisory route-manifest check clears too. Also durably fixes the guard for **all future `actions/checkout` bumps**. Mirrors the prior `fix(ci): unblock main` precedent (#2060).

## Verification
- `Unit Tests`-relevant change is a string-literal regex + comment (type-safe); regex behavior validated locally against `@v6`/`@v7` and an `lfs:true`-removed negative control.
- Route manifest regenerated via a faithful reproduction of `scripts/build-route-manifest.ts`, proven byte-identical to the committed file minus the one new route.
- Local typecheck skipped (worktree has no `node_modules` — harness limitation per AGENTS.md §5); CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)