### PR TITLE
fix(build-studio): advance review→ship when diff already extracted (stop ship-dispatch loop)

### DIFF
--- a/apps/web/lib/integrate/ship-on-review-approval.test.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression coverage for the review→ship loop fix.
+//
+// Before the fix, `deploy_feature` extracted the sandbox diff but never flipped
+// the phase, and `dispatchShipForVerifiedBuild` skipped whenever a diff already
+// existed — so a review-stranded build was re-entered by the reconciler every
+// tick, hit the "diff already extracted" skip, and looped at review forever
+// (observed live on FB-FD850A2C). The fix advances review→ship (policy-gated)
+// and attempts ship→complete instead of skipping.
+
+type BuildRow = {
+  phase: string;
+  diffPatch: string | null;
+  buildBranch: string | null;
+  sandboxId: string | null;
+  title: string;
+  kind: string;
+  createdById: string | null;
+  brief: unknown;
+  designDoc: unknown;
+  designReview: unknown;
+  plan: unknown;
+  buildPlan: unknown;
+  planReview: unknown;
+  verificationOut: unknown;
+  acceptanceMet: unknown;
+  threadId: string | null;
+};
+
+const state = vi.hoisted(() => ({
+  build: null as Record<string, unknown> | null,
+  updateManyCalls: [] as Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>,
+  updateManyResult: { count: 1 },
+  activity: [] as Array<{ tool: string; summary: string }>,
+  gateAllowed: true,
+  gateReason: undefined as string | undefined,
+  canTransition: true,
+  reconcileResult: false,
+  reconcileCalls: [] as string[],
+  emits: [] as Array<{ threadId: string; evt: Record<string, unknown> }>,
+  executeToolCalls: [] as Array<{ tool: string; params: Record<string, unknown> }>,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    featureBuild: {
+      findUnique: vi.fn(async () => state.build),
+      updateMany: vi.fn(async (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => {
+        state.updateManyCalls.push(args);
+        return state.updateManyResult;
+      }),
+    },
+    buildActivity: {
+      create: vi.fn(async (args: { data: { tool: string; summary: string } }) => {
+        state.activity.push(args.data);
+        return {};
+      }),
+    },
+  },
+}));
+
+vi.mock("@/lib/feature-build-types", () => ({
+  checkPhaseGate: vi.fn(() => ({ allowed: state.gateAllowed, reason: state.gateReason })),
+  canTransitionPhase: vi.fn(() => state.canTransition),
+  normalizeHappyPathState: vi.fn((x: unknown) => x),
+}));
+
+vi.mock("@/lib/build-flow-state", () => ({
+  reconcileBuildCompletion: vi.fn(async (buildId: string) => {
+    state.reconcileCalls.push(buildId);
+    return state.reconcileResult;
+  }),
+}));
+
+vi.mock("@/lib/mcp-tools", () => ({
+  executeTool: vi.fn(async (tool: string, params: Record<string, unknown>) => {
+    state.executeToolCalls.push({ tool, params });
+    return { success: true };
+  }),
+}));
+
+vi.mock("@/lib/agent-event-bus", () => ({
+  agentEventBus: {
+    emit: vi.fn((threadId: string, evt: Record<string, unknown>) => {
+      state.emits.push({ threadId, evt });
+    }),
+  },
+}));
+
+import { dispatchShipForVerifiedBuild } from "./ship-on-review-approval";
+
+function makeBuild(overrides: Partial<BuildRow> = {}): Record<string, unknown> {
+  return {
+    phase: "review",
+    diffPatch: "diff --git a/x b/x\n+truncated",
+    buildBranch: "build/FB-FD850A2C",
+    sandboxId: "sb-1",
+    title: "truncateMiddle helper",
+    kind: "chore",
+    createdById: "usr_creator",
+    brief: null,
+    designDoc: null,
+    designReview: null,
+    plan: null,
+    buildPlan: { steps: [{ title: "add helper" }] },
+    planReview: null,
+    verificationOut: { typecheckPassed: true, testsFailed: 88 },
+    acceptanceMet: true,
+    threadId: "thread-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  state.build = null;
+  state.updateManyCalls.length = 0;
+  state.updateManyResult = { count: 1 };
+  state.activity.length = 0;
+  state.gateAllowed = true;
+  state.gateReason = undefined;
+  state.canTransition = true;
+  state.reconcileResult = false;
+  state.reconcileCalls.length = 0;
+  state.emits.length = 0;
+  state.executeToolCalls.length = 0;
+});
+
+describe("dispatchShipForVerifiedBuild — review→ship loop fix", () => {
+  it("advances review→ship when the diff is already extracted, instead of skipping forever", async () => {
+    state.build = makeBuild();
+
+    const out = await dispatchShipForVerifiedBuild({
+      buildId: "FB-FD850A2C",
+      userId: "usr_caller",
+      verificationStatus: "skipped",
+    });
+
+    // The bug was a permanent "skipped — diff already extracted"; now it advances.
+    expect(out.kind).toBe("dispatched-success");
+    expect(state.updateManyCalls).toHaveLength(1);
+    expect(state.updateManyCalls[0]?.where).toMatchObject({ buildId: "FB-FD850A2C", phase: "review" });
+    expect(state.updateManyCalls[0]?.data).toMatchObject({ phase: "ship" });
+    // deploy_feature must NOT be re-run — the diff already exists.
+    expect(state.executeToolCalls).toHaveLength(0);
+    // Phase-change event emitted for the live UI.
+    expect(state.emits.some((e) => (e.evt as { phase?: string }).phase === "ship")).toBe(true);
+  });
+
+  it("respects the policy review→ship gate — does not advance when the gate blocks", async () => {
+    state.build = makeBuild({ acceptanceMet: null });
+    state.gateAllowed = false;
+    state.gateReason = "Acceptance criteria not evaluated.";
+
+    const out = await dispatchShipForVerifiedBuild({
+      buildId: "FB-GATED",
+      userId: "usr_caller",
+      verificationStatus: "complete",
+    });
+
+    expect(out.kind).toBe("skipped");
+    expect(state.updateManyCalls).toHaveLength(0); // no forced advance
+    expect(state.activity.some((a) => /gate/i.test(a.summary))).toBe(true);
+  });
+
+  it("finishes the build (ship→complete) when the ship forks are terminal + deployed", async () => {
+    state.build = makeBuild();
+    state.reconcileResult = true;
+
+    const out = await dispatchShipForVerifiedBuild({
+      buildId: "FB-DONE",
+      userId: "usr_caller",
+      verificationStatus: "skipped",
+    });
+
+    expect(out.kind).toBe("dispatched-success");
+    expect(state.reconcileCalls).toContain("FB-DONE");
+    expect(state.activity.some((a) => /complete/i.test(a.summary))).toBe(true);
+  });
+
+  it("is idempotent — skips a build already in the ship phase", async () => {
+    state.build = makeBuild({ phase: "ship" });
+
+    const out = await dispatchShipForVerifiedBuild({
+      buildId: "FB-SHIP",
+      userId: "usr_caller",
+      verificationStatus: "complete",
+    });
+
+    expect(out.kind).toBe("skipped");
+    if (out.kind !== "skipped") throw new Error(`expected skipped, got ${out.kind}`);
+    expect(out.reason).toBe("already in ship phase");
+    expect(state.updateManyCalls).toHaveLength(0);
+  });
+
+  it("extracts the diff via deploy_feature, then advances, on the first (no-diff) pass", async () => {
+    state.build = makeBuild({ diffPatch: null });
+
+    const out = await dispatchShipForVerifiedBuild({
+      buildId: "FB-FRESH",
+      userId: "usr_caller",
+      verificationStatus: "complete",
+    });
+
+    expect(state.executeToolCalls.map((c) => c.tool)).toContain("deploy_feature");
+    expect(state.updateManyCalls).toHaveLength(1);
+    expect(state.updateManyCalls[0]?.data).toMatchObject({ phase: "ship" });
+    expect(out.kind).toBe("dispatched-success");
+  });
+
+  it("does not double-advance when a concurrent advance already moved the build (updateMany count 0)", async () => {
+    state.build = makeBuild();
+    state.updateManyResult = { count: 0 };
+
+    const out = await dispatchShipForVerifiedBuild({
+      buildId: "FB-RACE",
+      userId: "usr_caller",
+      verificationStatus: "skipped",
+    });
+
+    expect(out.kind).toBe("skipped");
+    expect(state.reconcileCalls).toHaveLength(0); // no completion attempt on a lost race
+  });
+});

--- a/apps/web/lib/integrate/ship-on-review-approval.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.ts
@@ -80,8 +80,14 @@ export async function dispatchShipForVerifiedBuild(params: {
       return { kind: "skipped", reason: `phase=${build.phase}` };
     }
     if (build.diffPatch && build.diffPatch.trim().length > 0) {
-      await log("Skipped — diff already extracted (deploy_feature ran)");
-      return { kind: "skipped", reason: "diff already extracted" };
+      // deploy_feature already extracted the diff on a prior cycle, but the
+      // phase was never advanced — deploy_feature extracts the diff; it does
+      // NOT flip the phase. Advance review→ship now instead of skipping.
+      // Otherwise the review-phase reconciler (resumeStrandedBuildsOnBoot)
+      // re-enters here every tick, hits this branch, and the build loops at
+      // review forever, never shipping (observed live on FB-FD850A2C: a
+      // ~20-min resume→review-verification→ship-dispatch-skip cycle).
+      return advanceReviewedBuildToShip(buildId, log, t0);
     }
     if (!build.sandboxId) {
       await log("Skipped — no sandbox (nothing to ship)");
@@ -114,20 +120,131 @@ export async function dispatchShipForVerifiedBuild(params: {
       return { kind: "dispatched-failure", error: msg, durationMs: Date.now() - t0 };
     }
 
-    await log("deploy_feature succeeded — diff extracted, phase advanced to ship");
+    await log("deploy_feature succeeded — diff extracted.");
 
-    // deploy_feature extracted the diff and advanced the phase to "ship".
-    // The operator can now see the diff in the Build Studio review panel and
-    // click "Ship to GitHub" — the one remaining intentional human gate.
-    // (PR creation requires a deliberate human decision for the first iteration.)
-    await log("deploy_feature succeeded — diff extracted, phase=ship, awaiting operator review");
-    return {
-      kind: "dispatched-success",
-      durationMs: Date.now() - t0,
-    };
+    // deploy_feature extracts the diff but does NOT advance the phase. Advance
+    // review→ship here (the documented post-condition of this dispatcher) and
+    // attempt ship→complete. Pushing to GitHub stays a human gate, surfaced in
+    // the Review panel — unless the ship forks are already terminal + deployed,
+    // in which case reconcileBuildCompletion finishes the build.
+    return advanceReviewedBuildToShip(buildId, log, t0);
   } catch (err) {
     const msg = String(err instanceof Error ? err.message : err).slice(0, 300);
     try { await log(`Ship dispatch failed: ${msg}`); } catch (_) { /**/ }
     return { kind: "dispatched-failure", error: msg, durationMs: Date.now() - t0 };
   }
+}
+
+/**
+ * Advance a review-phase build (whose diff is already extracted) to the ship
+ * phase, then attempt ship→complete.
+ *
+ * Why this exists: `deploy_feature` extracts the sandbox diff but does NOT flip
+ * the phase, and the original dispatcher assumed it did ("phase advanced to
+ * ship"). The phase therefore stayed at `review`, so on every reconciler tick
+ * `dispatchShipForVerifiedBuild` re-ran, saw the diff, and skipped — the build
+ * looped at review forever and never shipped. This restores the dispatcher's
+ * documented post-condition (advance to ship) as an explicit, gated step.
+ *
+ * The review→ship advance is gated by the policy `checkPhaseGate` (the same
+ * gate the admin advance-phase route enforces) and flipped with a phase-guarded
+ * `updateMany`, so a concurrent reconciler/live-advance can never double-advance.
+ * Pushing to GitHub remains a human gate; this only parks the build at ship —
+ * unless `reconcileBuildCompletion` finds the ship forks already terminal and
+ * the merge SHA deployed, in which case it finishes the build (ship→complete).
+ * Never throws.
+ */
+export async function advanceReviewedBuildToShip(
+  buildId: string,
+  log: (summary: string) => Promise<void>,
+  t0: number,
+): Promise<ShipDispatchOutcome> {
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: {
+      phase: true,
+      kind: true,
+      brief: true,
+      designDoc: true,
+      designReview: true,
+      plan: true,
+      buildPlan: true,
+      planReview: true,
+      verificationOut: true,
+      acceptanceMet: true,
+      threadId: true,
+    },
+  });
+
+  if (!build) {
+    return { kind: "dispatched-failure", error: "Build not found", durationMs: Date.now() - t0 };
+  }
+  if (build.phase !== "review") {
+    // Another path (live advance / a prior tick) already moved it on.
+    return { kind: "skipped", reason: `phase=${build.phase}` };
+  }
+
+  const { checkPhaseGate, canTransitionPhase, normalizeHappyPathState } = await import(
+    "@/lib/feature-build-types"
+  );
+  if (!canTransitionPhase("review", "ship")) {
+    return { kind: "skipped", reason: "transition not allowed" };
+  }
+
+  const brief = build.brief as { fixContext?: unknown } | null;
+  const gate = checkPhaseGate("review", "ship", {
+    kind: build.kind,
+    fixContext: brief?.fixContext,
+    designDoc: build.designDoc,
+    designReview: build.designReview,
+    happyPathState: normalizeHappyPathState(
+      (build.plan as Record<string, unknown> | null)?.happyPathState ?? null,
+    ),
+    buildPlan: build.buildPlan,
+    planReview: build.planReview,
+    verificationOut: build.verificationOut,
+    acceptanceMet: build.acceptanceMet,
+  });
+  if (!gate.allowed) {
+    await log(`Not advanced — review→ship gate: ${gate.reason ?? "blocked"}`);
+    return { kind: "skipped", reason: gate.reason ?? "review→ship gate blocked" };
+  }
+
+  // Phase-guarded flip: only advance if STILL at review, so two concurrent
+  // reconcilers (or a live advance racing this) never double-advance.
+  const flipped = await prisma.featureBuild.updateMany({
+    where: { buildId, phase: "review" },
+    data: { phase: "ship" },
+  });
+  if (flipped.count === 0) {
+    return { kind: "skipped", reason: "already advanced" };
+  }
+  await log(
+    "Advanced review→ship (diff already extracted). Push to GitHub remains a human gate.",
+  );
+
+  // Best-effort: live UI update.
+  try {
+    if (build.threadId) {
+      const { agentEventBus } = await import("@/lib/agent-event-bus");
+      agentEventBus.emit(build.threadId, { type: "phase:change", buildId, phase: "ship" });
+    }
+  } catch {
+    /* best-effort */
+  }
+
+  // If the ship forks are already terminal (private/fork-only mode, or the PR
+  // has merged) AND the deployed runtime carries the merge SHA, finish now.
+  try {
+    const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
+    if (await reconcileBuildCompletion(buildId)) {
+      await log("Ship forks terminal + deployed — advanced ship→complete.");
+    }
+  } catch (err) {
+    await log(
+      `ship→complete check failed: ${String(err instanceof Error ? err.message : err).slice(0, 200)}`,
+    );
+  }
+
+  return { kind: "dispatched-success", durationMs: Date.now() - t0 };
 }


### PR DESCRIPTION
## Problem

Build Studio builds that pass review verification get stuck at `review` and loop forever, never shipping. Diagnosed live on **FB-FD850A2C** (the `truncateMiddle` chore build): every ~20 minutes the continuous-resume reconciler (#2156) re-ran the same dead-end cycle —

- `resumeStrandedBuildsOnBoot` → "Stranded in review phase… auto-resuming"
- `review-verification` → "UX verification skipped: build changed no UI surface" (passes)
- `ship_dispatch` → **"Skipped — diff already extracted (deploy_feature ran)"**
- …phase stays `review`. Repeat indefinitely.

## Root cause

`deploy_feature` extracts the sandbox diff but **does not advance the build phase** (its handler ends with the diff/impact result, no phase update). `dispatchShipForVerifiedBuild` assumed it did (`"phase advanced to ship"`), so:

1. First dispatch: `deploy_feature` extracts the diff; build stays at `review`.
2. Every subsequent reconciler tick: the `if (build.diffPatch) → skip "diff already extracted"` guard returns early **without advancing** → infinite loop.

The caller's own comment states the intended contract — *"dispatchShipForVerifiedBuild only extracts the diff and advances to the ship phase; pushing to GitHub stays a human gate"* — which was never actually happening.

## Fix

Restore the dispatcher's documented post-condition. Both the no-diff (first) pass and the diff-already-extracted (re-entry) pass now converge on a new `advanceReviewedBuildToShip` helper, which:

- Gates `review→ship` with `checkPhaseGate` (the same policy gate the admin advance-phase route enforces) — never a forced transition.
- Flips the phase with a **phase-guarded `updateMany`** (`where: { phase: "review" }`) so concurrent reconcilers can't double-advance.
- Attempts `ship→complete` via `reconcileBuildCompletion` (finishes the build only when the ship forks are already terminal **and** the merge SHA is deployed).
- Emits `phase:change` for the live UI.

Push-to-GitHub remains the intentional human gate; this only stops the loop and parks the build at `ship` (or completes it when it's genuinely done).

## Impact

- Unblocks the live stranded build **FB-FD850A2C** (code already merged via #2096) and any future build that passes review verification — they advance to ship instead of looping at review.
- Pairs with #2156 (continuous resume): the reconciler now carries builds forward instead of spinning every 20 minutes.

## Test

New `ship-on-review-approval.test.ts` — 6 cases: advance-on-re-entry, gate-respected (no forced advance), ship→complete on terminal forks, idempotency (already-ship), fresh `deploy_feature` path, lost-race no-op. All green; scoped typecheck passes (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
