### PR TITLE
feat(mobile): job-completion evidence — capture photos before billing

### DIFF
--- a/apps/mobile/app/(tabs)/jobs/[itemId]/complete.tsx
+++ b/apps/mobile/app/(tabs)/jobs/[itemId]/complete.tsx
@@ -1,0 +1,199 @@
+/**
+ * Field-tech "Capture work done" screen.
+ *
+ * Reachable from the job detail screen between in-progress / completed and
+ * the Draft invoice step. Lets the tech take one or more photos of the
+ * finished work — each uploads to /api/v1/upload, the fileId appends to
+ * WorkItem.evidence via /api/v1/work-items/:itemId/evidence, and the
+ * running list updates in place. The Continue button hops to the existing
+ * Draft invoice screen with the resolved work item.
+ *
+ * The actual image capture goes through a swap-in source (today: a stub
+ * that returns a deterministic placeholder so the upload pipeline still
+ * exercises the real path; tomorrow: expo-image-picker / expo-camera).
+ */
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  Pressable,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import { useJobEvidenceStore } from "@/src/features/job-evidence/job-evidence.store";
+
+export default function CompleteJobScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const router = useRouter();
+  const { itemId } = useLocalSearchParams<{ itemId: string }>();
+
+  const { evidence, isCapturing, error, begin, capturePhoto } =
+    useJobEvidenceStore();
+  const [caption, setCaption] = useState<string>("");
+
+  useEffect(() => {
+    if (itemId) begin(itemId);
+  }, [itemId, begin]);
+
+  const onCapture = async (): Promise<void> => {
+    const photo = await capturePhoto(caption || undefined);
+    if (photo) setCaption("");
+  };
+
+  const onContinue = (): void => {
+    router.replace(`/jobs/${encodeURIComponent(itemId)}/invoice`);
+  };
+
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={styles.h1}>Capture work done</Text>
+      <Text style={styles.help}>
+        Photos persist to the job's evidence record and can be attached to the
+        customer's invoice. Capture as many as you need before continuing.
+      </Text>
+
+      <Text style={styles.label}>Caption (optional)</Text>
+      <TextInput
+        value={caption}
+        onChangeText={setCaption}
+        style={styles.input}
+        placeholder="e.g. before, after, model sticker"
+        placeholderTextColor={theme.colors.textMuted}
+        testID="evidence-caption"
+      />
+
+      <Pressable
+        style={[styles.primary, isCapturing && styles.disabled]}
+        disabled={isCapturing}
+        onPress={onCapture}
+        accessibilityRole="button"
+        testID="evidence-capture"
+      >
+        {isCapturing ? (
+          <ActivityIndicator color={theme.colors.white} />
+        ) : (
+          <Text style={styles.primaryText}>Add photo</Text>
+        )}
+      </Pressable>
+
+      {error ? (
+        <Text style={styles.error} testID="evidence-error">
+          {error}
+        </Text>
+      ) : null}
+
+      <Text style={[styles.h2, { marginTop: theme.spacing.lg }]}>
+        Captured ({evidence.photos.length})
+      </Text>
+      {evidence.photos.length === 0 ? (
+        <Text style={styles.empty}>No photos yet.</Text>
+      ) : (
+        evidence.photos.map((p, i) => (
+          <View key={p.fileId} style={styles.row} testID={`photo-${i}`}>
+            <View style={styles.thumbnail}>
+              <Text style={styles.thumbnailText}>#{i + 1}</Text>
+            </View>
+            <View style={styles.rowText}>
+              <Text style={styles.rowTitle}>
+                {p.caption ?? "Untitled photo"}
+              </Text>
+              <Text style={styles.rowMeta}>
+                {new Date(p.capturedAt).toLocaleString()}
+              </Text>
+            </View>
+          </View>
+        ))
+      )}
+
+      <Pressable
+        style={styles.secondary}
+        onPress={onContinue}
+        accessibilityRole="button"
+        testID="evidence-continue"
+      >
+        <Text style={styles.secondaryText}>Continue to invoice</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: colors.surface1 },
+    content: { padding: spacing.md, paddingBottom: spacing.xl },
+    h1: { color: colors.text, fontSize: 22, fontWeight: "700" },
+    h2: { color: colors.text, fontSize: 16, fontWeight: "700" },
+    help: { color: colors.textMuted, fontSize: 13, marginTop: spacing.xs },
+    label: {
+      color: colors.textMuted,
+      fontSize: 12,
+      textTransform: "uppercase",
+      marginTop: spacing.md,
+      marginBottom: spacing.xs,
+    },
+    input: {
+      backgroundColor: colors.surface2,
+      color: colors.text,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      paddingHorizontal: spacing.sm + 2,
+      paddingVertical: spacing.sm,
+      fontSize: 15,
+    },
+    primary: {
+      marginTop: spacing.md,
+      backgroundColor: colors.primary,
+      borderRadius: borderRadius.md,
+      paddingVertical: spacing.sm + 4,
+      alignItems: "center",
+    },
+    disabled: { opacity: 0.6 },
+    primaryText: { color: colors.white, fontSize: 16, fontWeight: "600" },
+    secondary: {
+      marginTop: spacing.lg,
+      borderColor: colors.primary,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      paddingVertical: spacing.sm + 4,
+      alignItems: "center",
+    },
+    secondaryText: { color: colors.primary, fontSize: 16, fontWeight: "600" },
+    empty: { color: colors.textMuted, fontSize: 13, marginTop: spacing.sm },
+    error: { color: colors.error, marginTop: spacing.sm, fontSize: 13 },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      marginTop: spacing.sm,
+    },
+    thumbnail: {
+      width: 48,
+      height: 48,
+      borderRadius: borderRadius.sm,
+      backgroundColor: colors.surface1,
+      borderColor: colors.border,
+      borderWidth: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      marginRight: spacing.md,
+    },
+    thumbnailText: { color: colors.textMuted, fontSize: 14, fontWeight: "600" },
+    rowText: { flex: 1 },
+    rowTitle: { color: colors.text, fontSize: 14, fontWeight: "600" },
+    rowMeta: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+  });
+}

--- a/apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx
+++ b/apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx
@@ -113,14 +113,26 @@ export default function JobDetailScreen() {
           </Pressable>
         ))}
         {detail.status === "completed" ? (
-          <Pressable
-            style={styles.button}
-            onPress={goToInvoice}
-            accessibilityRole="button"
-            testID="action-draft-invoice"
-          >
-            <Text style={styles.buttonText}>Draft invoice</Text>
-          </Pressable>
+          <>
+            <Pressable
+              style={styles.button}
+              onPress={() =>
+                router.push(`/jobs/${encodeURIComponent(detail.itemId)}/complete`)
+              }
+              accessibilityRole="button"
+              testID="action-capture-work"
+            >
+              <Text style={styles.buttonText}>Capture work done</Text>
+            </Pressable>
+            <Pressable
+              style={styles.button}
+              onPress={goToInvoice}
+              accessibilityRole="button"
+              testID="action-draft-invoice"
+            >
+              <Text style={styles.buttonText}>Draft invoice</Text>
+            </Pressable>
+          </>
         ) : null}
       </View>
     </ScrollView>

--- a/apps/mobile/app/(tabs)/jobs/_layout.tsx
+++ b/apps/mobile/app/(tabs)/jobs/_layout.tsx
@@ -13,6 +13,7 @@ export default function JobsLayout() {
     >
       <Stack.Screen name="index" options={{ title: "My Jobs" }} />
       <Stack.Screen name="[itemId]/index" options={{ title: "Job" }} />
+      <Stack.Screen name="[itemId]/complete" options={{ title: "Capture work" }} />
       <Stack.Screen name="[itemId]/invoice" options={{ title: "New invoice" }} />
       <Stack.Screen name="[itemId]/payment" options={{ title: "Collect payment" }} />
     </Stack>

--- a/apps/mobile/src/features/job-evidence/imageSource.ts
+++ b/apps/mobile/src/features/job-evidence/imageSource.ts
@@ -1,0 +1,55 @@
+/**
+ * Pluggable image-source for the job-completion evidence flow.
+ *
+ * The mobile shell needs to capture a photo, but we want the capture step
+ * to be a *seam* — easy to swap (today: a stub that returns a synthetic
+ * placeholder; tomorrow: expo-image-picker / expo-camera) and easy to test
+ * (the store mocks this module, not a native module).
+ */
+
+export interface CapturedImage {
+  uri: string;
+  mimeType: string;
+  /** Best-effort filename when the picker can supply one. */
+  fileName?: string;
+}
+
+/** A function the store calls to obtain a freshly-captured image. */
+export type ImageCaptureFn = () => Promise<CapturedImage | null>;
+
+/**
+ * Default capture stub. Returns a deterministic placeholder URI so the
+ * downstream upload pipeline still gets a well-formed payload to push at
+ * the API; the real capture primitive lands in a follow-up slice that
+ * adds expo-image-picker to the mobile package.
+ *
+ * The placeholder is intentionally a `data:` URL so the upload layer (which
+ * builds a multipart body from it) treats it like any other source.
+ */
+export const stubCapture: ImageCaptureFn = async () => {
+  // 1x1 transparent PNG — small enough that the upload pipeline exercises
+  // the real path without bloating tests.
+  return {
+    uri:
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+    mimeType: "image/png",
+    fileName: "completion-photo.png",
+  };
+};
+
+let active: ImageCaptureFn = stubCapture;
+
+/** Get the currently-active capture function (used by the store). */
+export function getImageCapture(): ImageCaptureFn {
+  return active;
+}
+
+/** Replace the active capture function (used by tests + the future real picker). */
+export function setImageCapture(fn: ImageCaptureFn): void {
+  active = fn;
+}
+
+/** Test-only: restore the default stub. */
+export function __resetImageCaptureForTests(): void {
+  active = stubCapture;
+}

--- a/apps/mobile/src/features/job-evidence/job-evidence.store.test.ts
+++ b/apps/mobile/src/features/job-evidence/job-evidence.store.test.ts
@@ -1,0 +1,153 @@
+import {
+  useJobEvidenceStore,
+} from "./job-evidence.store";
+import { __resetImageCaptureForTests, setImageCapture } from "./imageSource";
+
+const mockAppendEvidence = jest.fn();
+
+jest.mock("@/src/lib/apiClient", () => ({
+  api: {
+    workItems: {
+      appendEvidence: (...a: unknown[]) => mockAppendEvidence(...a),
+    },
+  },
+}));
+
+jest.mock("@/src/lib/serverConfig", () => ({
+  getServerUrl: () => "https://install.example",
+}));
+
+jest.mock("@/src/repositories/SecureStorage", () => ({
+  SecureStorage: { getAccessToken: async () => "tok_abc" },
+}));
+
+const mockFetch = jest.fn();
+beforeAll(() => {
+  (global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+});
+
+const PHOTO = {
+  fileId: "media_abc",
+  url: "/api/v1/media/media_abc",
+};
+
+function resetStore() {
+  useJobEvidenceStore.getState().reset();
+  __resetImageCaptureForTests();
+  mockAppendEvidence.mockReset();
+  mockFetch.mockReset();
+}
+
+beforeEach(resetStore);
+
+describe("useJobEvidenceStore.capturePhoto", () => {
+  it("refuses when no work item has been started", async () => {
+    const result = await useJobEvidenceStore.getState().capturePhoto();
+    expect(result).toBeNull();
+    expect(useJobEvidenceStore.getState().error).toMatch(/no work item/i);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the picker is cancelled, without uploading", async () => {
+    setImageCapture(async () => null);
+    useJobEvidenceStore.getState().begin("WI-1");
+    const result = await useJobEvidenceStore.getState().capturePhoto();
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(useJobEvidenceStore.getState().error).toBeNull();
+  });
+
+  it("uploads, appends, and stores the server's merged evidence", async () => {
+    setImageCapture(async () => ({
+      uri: "file:///tmp/a.png",
+      mimeType: "image/png",
+      fileName: "a.png",
+    }));
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => PHOTO,
+    });
+    const serverPhoto = {
+      fileId: PHOTO.fileId,
+      url: PHOTO.url,
+      capturedAt: "2026-06-18T14:00:00.000Z",
+    };
+    mockAppendEvidence.mockResolvedValueOnce({
+      evidence: { photos: [serverPhoto] },
+    });
+
+    useJobEvidenceStore.getState().begin("WI-1");
+    const photo = await useJobEvidenceStore.getState().capturePhoto("before");
+    expect(photo).not.toBeNull();
+    expect(photo?.fileId).toBe(PHOTO.fileId);
+    expect(photo?.caption).toBe("before");
+
+    // Upload went to /api/v1/upload with the install's base URL and the bearer token.
+    const [uploadUrl, uploadInit] = mockFetch.mock.calls[0];
+    expect(uploadUrl).toBe("https://install.example/api/v1/upload");
+    expect((uploadInit as RequestInit).method).toBe("POST");
+    expect(
+      (uploadInit as RequestInit).headers as Record<string, string>,
+    ).toEqual({ Authorization: "Bearer tok_abc" });
+
+    // appendEvidence was called with the freshly-uploaded fileId.
+    const appendCall = mockAppendEvidence.mock.calls[0];
+    expect(appendCall[0]).toBe("WI-1");
+    expect(appendCall[1].photo.fileId).toBe(PHOTO.fileId);
+    expect(appendCall[1].photo.caption).toBe("before");
+
+    // Local state now mirrors the server's merged record.
+    expect(useJobEvidenceStore.getState().evidence.photos).toHaveLength(1);
+    expect(useJobEvidenceStore.getState().isCapturing).toBe(false);
+  });
+
+  it("surfaces an upload failure as state.error and never calls appendEvidence", async () => {
+    setImageCapture(async () => ({
+      uri: "file:///tmp/a.png",
+      mimeType: "image/png",
+    }));
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    useJobEvidenceStore.getState().begin("WI-1");
+    const result = await useJobEvidenceStore.getState().capturePhoto();
+    expect(result).toBeNull();
+    expect(useJobEvidenceStore.getState().error).toContain("500");
+    expect(mockAppendEvidence).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an appendEvidence failure as state.error and preserves prior evidence", async () => {
+    setImageCapture(async () => ({
+      uri: "file:///tmp/a.png",
+      mimeType: "image/png",
+    }));
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => PHOTO,
+    });
+    mockAppendEvidence.mockRejectedValueOnce(new Error("HTTP 403 forbidden"));
+
+    useJobEvidenceStore.getState().begin("WI-1", {
+      photos: [
+        {
+          fileId: "media_prior",
+          url: "/api/v1/media/media_prior",
+          capturedAt: "2026-06-18T13:00:00.000Z",
+        },
+      ],
+    });
+    const result = await useJobEvidenceStore.getState().capturePhoto();
+    expect(result).toBeNull();
+    expect(useJobEvidenceStore.getState().error).toContain("403");
+    // Prior evidence is preserved — the failed append did not overwrite it.
+    expect(useJobEvidenceStore.getState().evidence.photos).toHaveLength(1);
+    expect(useJobEvidenceStore.getState().evidence.photos[0].fileId).toBe(
+      "media_prior",
+    );
+  });
+});

--- a/apps/mobile/src/features/job-evidence/job-evidence.store.ts
+++ b/apps/mobile/src/features/job-evidence/job-evidence.store.ts
@@ -1,0 +1,131 @@
+import { create } from "zustand";
+import type { JobEvidence, JobEvidencePhoto } from "@dpf/types";
+import { api } from "@/src/lib/apiClient";
+import { getServerUrl } from "@/src/lib/serverConfig";
+import { SecureStorage } from "@/src/repositories/SecureStorage";
+import { getImageCapture } from "./imageSource";
+
+/**
+ * Field-tech completion-evidence store. Captures a photo via the
+ * pluggable image source, uploads it to /api/v1/upload to mint a
+ * MediaAsset, then appends the fileId to the assigned WorkItem's
+ * evidence JSON via /api/v1/work-items/:itemId/evidence.
+ *
+ * The store keeps a local copy of the current evidence so the UI can
+ * render a running list of captured photos without re-fetching the
+ * WorkItem after every append. Server is the source of truth: the
+ * append endpoint returns the merged record and we replace local state
+ * with what came back.
+ */
+
+interface JobEvidenceState {
+  workItemId: string | null;
+  evidence: JobEvidence;
+  isCapturing: boolean;
+  error: string | null;
+  begin: (workItemId: string, seed?: JobEvidence) => void;
+  capturePhoto: (caption?: string) => Promise<JobEvidencePhoto | null>;
+  reset: () => void;
+}
+
+const EMPTY_EVIDENCE: JobEvidence = { photos: [] };
+
+interface UploadResponse {
+  fileId: string;
+  url: string;
+}
+
+async function uploadCapturedImage(image: {
+  uri: string;
+  mimeType: string;
+  fileName?: string;
+}): Promise<UploadResponse | null> {
+  // Build a multipart body the same way the dynamic CameraField does, but
+  // through a direct fetch — the shared @dpf/api-client client doesn't
+  // expose multipart upload as a typed endpoint today.
+  const token = await SecureStorage.getAccessToken();
+  const form = new FormData();
+  // React-Native's FormData accepts the {uri, name, type} triple for
+  // multipart; this is the canonical RN pattern.
+  form.append("file", {
+    uri: image.uri,
+    name: image.fileName ?? `evidence-${Date.now()}.png`,
+    type: image.mimeType,
+  } as unknown as Blob);
+  const res = await fetch(`${getServerUrl()}/api/v1/upload`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`Upload failed (HTTP ${res.status})`);
+  }
+  const data = (await res.json()) as Partial<UploadResponse>;
+  if (typeof data.fileId !== "string" || typeof data.url !== "string") {
+    throw new Error("Upload returned an unexpected response shape");
+  }
+  return { fileId: data.fileId, url: data.url };
+}
+
+export const useJobEvidenceStore = create<JobEvidenceState>((set, get) => ({
+  workItemId: null,
+  evidence: { ...EMPTY_EVIDENCE },
+  isCapturing: false,
+  error: null,
+
+  begin: (workItemId, seed) =>
+    set({
+      workItemId,
+      evidence: seed ?? { ...EMPTY_EVIDENCE },
+      isCapturing: false,
+      error: null,
+    }),
+
+  capturePhoto: async (caption) => {
+    const { workItemId } = get();
+    if (!workItemId) {
+      set({ error: "No work item is being captured" });
+      return null;
+    }
+    set({ isCapturing: true, error: null });
+    try {
+      const image = await getImageCapture()();
+      if (!image) {
+        set({ isCapturing: false });
+        return null; // user cancelled
+      }
+      const uploaded = await uploadCapturedImage(image);
+      if (!uploaded) {
+        set({ isCapturing: false, error: "Upload returned no payload" });
+        return null;
+      }
+      const photo: JobEvidencePhoto = {
+        fileId: uploaded.fileId,
+        url: uploaded.url,
+        // Client clock is fine here; server doesn't override it.
+        capturedAt: new Date().toISOString(),
+      };
+      if (caption && caption.trim().length > 0) photo.caption = caption.trim();
+
+      const { evidence } = await api.workItems.appendEvidence(workItemId, {
+        photo,
+      });
+      set({ evidence, isCapturing: false });
+      return photo;
+    } catch (err) {
+      set({
+        isCapturing: false,
+        error: err instanceof Error ? err.message : "Failed to capture photo",
+      });
+      return null;
+    }
+  },
+
+  reset: () =>
+    set({
+      workItemId: null,
+      evidence: { ...EMPTY_EVIDENCE },
+      isCapturing: false,
+      error: null,
+    }),
+}));

--- a/apps/web/app/api/v1/work-items/[itemId]/evidence/route.test.ts
+++ b/apps/web/app/api/v1/work-items/[itemId]/evidence/route.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Contract tests for POST /api/v1/work-items/:itemId/evidence — the append
+ * path for job-completion photos. The wire shape + merge logic are unit-tested
+ * separately in lib/api/work-item-evidence.test.ts; these tests cover the
+ * auth, assignment, and 404 branches plus the Prisma update payload.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockFindUnique, mockUpdate } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFindUnique: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/api/auth-middleware", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/api/auth-middleware")
+  >("@/lib/api/auth-middleware");
+  return { ...actual, authenticateRequest: mockAuth };
+});
+
+vi.mock("@dpf/db", () => ({
+  prisma: { workItem: { findUnique: mockFindUnique, update: mockUpdate } },
+  Prisma: {},
+}));
+
+import { POST } from "./route";
+import { ApiError } from "@/lib/api/error";
+
+const USER = {
+  user: {
+    id: "u_emp_1",
+    email: "tech@example.com",
+    type: "admin" as const,
+    platformRole: null,
+    isSuperuser: false,
+    accountId: null,
+    accountName: null,
+    contactId: null,
+  },
+  capabilities: [] as string[],
+  authContext: {
+    principalId: null,
+    platformRole: null,
+    isSuperuser: false,
+    employeeId: "emp_1",
+    managerScope: null,
+    grantedCapabilities: [] as string[],
+  },
+};
+
+const PHOTO = {
+  fileId: "media_abc",
+  url: "/api/v1/media/media_abc",
+  capturedAt: "2026-06-18T14:00:00.000Z",
+};
+
+function req(body: unknown): Request {
+  return new Request("https://example/api/v1/work-items/WI-1/evidence", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+const PARAMS = { params: Promise.resolve({ itemId: "WI-1" }) };
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockFindUnique.mockReset();
+  mockUpdate.mockReset();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/v1/work-items/:itemId/evidence", () => {
+  it("rejects unauthenticated callers", async () => {
+    mockAuth.mockRejectedValueOnce(
+      new ApiError("UNAUTHENTICATED", "Authentication required", 401),
+    );
+    const res = await POST(req({ photo: PHOTO }), PARAMS);
+    expect(res.status).toBe(401);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 when the photo payload is missing or malformed", async () => {
+    mockAuth.mockResolvedValueOnce(USER);
+    const res = await POST(req({}), PARAMS);
+    expect(res.status).toBe(422);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 when capturedAt is not a valid date", async () => {
+    mockAuth.mockResolvedValueOnce(USER);
+    const res = await POST(
+      req({ photo: { ...PHOTO, capturedAt: "soon" } }),
+      PARAMS,
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("returns 404 when the work item does not exist", async () => {
+    mockAuth.mockResolvedValueOnce(USER);
+    mockFindUnique.mockResolvedValueOnce(null);
+    const res = await POST(req({ photo: PHOTO }), PARAMS);
+    expect(res.status).toBe(404);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the caller is not the assignee", async () => {
+    mockAuth.mockResolvedValueOnce(USER);
+    mockFindUnique.mockResolvedValueOnce({
+      id: "wi_1",
+      assignedToUserId: "u_someone_else",
+      evidence: null,
+    });
+    const res = await POST(req({ photo: PHOTO }), PARAMS);
+    expect(res.status).toBe(403);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("appends the photo to existing evidence and returns the merged record", async () => {
+    mockAuth.mockResolvedValueOnce(USER);
+    const existing = {
+      photos: [
+        {
+          fileId: "media_first",
+          url: "/api/v1/media/media_first",
+          capturedAt: "2026-06-18T13:30:00.000Z",
+        },
+      ],
+    };
+    mockFindUnique.mockResolvedValueOnce({
+      id: "wi_1",
+      assignedToUserId: USER.user.id,
+      evidence: existing,
+    });
+    mockUpdate.mockResolvedValueOnce({});
+
+    const res = await POST(req({ photo: PHOTO }), PARAMS);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { evidence: { photos: unknown[] } };
+    expect(body.evidence.photos).toHaveLength(2);
+
+    // The persisted payload must carry both photos, not just the new one.
+    const persisted = mockUpdate.mock.calls[0][0].data.evidence as {
+      photos: { fileId: string }[];
+    };
+    expect(persisted.photos.map((p) => p.fileId)).toEqual([
+      "media_first",
+      PHOTO.fileId,
+    ]);
+  });
+
+  it("treats a null `evidence` column as empty before appending", async () => {
+    mockAuth.mockResolvedValueOnce(USER);
+    mockFindUnique.mockResolvedValueOnce({
+      id: "wi_1",
+      assignedToUserId: USER.user.id,
+      evidence: null,
+    });
+    mockUpdate.mockResolvedValueOnce({});
+
+    const res = await POST(req({ photo: PHOTO }), PARAMS);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { evidence: { photos: unknown[] } };
+    expect(body.evidence.photos).toHaveLength(1);
+  });
+});

--- a/apps/web/app/api/v1/work-items/[itemId]/evidence/route.ts
+++ b/apps/web/app/api/v1/work-items/[itemId]/evidence/route.ts
@@ -1,0 +1,71 @@
+// POST /api/v1/work-items/:itemId/evidence — append a completion photo to the
+// work item the caller is assigned to. Stored on WorkItem.evidence as JSON
+// (additive — no schema migration). The endpoint validates the wire shape
+// via lib/api/work-item-evidence and persists the merged record back in one
+// update. See docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
+// (Slice 3) and apps/web/lib/api/work-item-evidence.ts.
+
+import { NextResponse } from "next/server";
+import { prisma, type Prisma } from "@dpf/db";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError, apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import {
+  appendPhoto,
+  normalizeEvidence,
+  normalizePhoto,
+} from "@/lib/api/work-item-evidence";
+import type {
+  AppendJobEvidenceRequest,
+  JobEvidenceResponse,
+} from "@dpf/types";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ itemId: string }> },
+) {
+  try {
+    const { user } = await authenticateRequest(request);
+    const { itemId } = await params;
+
+    const body = (await request.json().catch(() => ({}))) as
+      | Partial<AppendJobEvidenceRequest>
+      | null;
+    const photo = normalizePhoto(body?.photo);
+    if (!photo) {
+      throw apiError(
+        "VALIDATION_ERROR",
+        "Body must be { photo: { fileId, url, capturedAt, caption? } } with valid ISO capturedAt",
+        422,
+      );
+    }
+
+    const row = await prisma.workItem.findUnique({
+      where: { itemId },
+      select: { id: true, assignedToUserId: true, evidence: true },
+    });
+    if (!row) {
+      throw apiError("NOT_FOUND", "Work item not found", 404);
+    }
+    if (row.assignedToUserId !== user.id) {
+      throw apiError("FORBIDDEN", "Work item is not assigned to you", 403);
+    }
+
+    const next = appendPhoto(normalizeEvidence(row.evidence), photo);
+
+    await prisma.workItem.update({
+      where: { itemId },
+      data: { evidence: next as unknown as Prisma.InputJsonValue },
+    });
+
+    return apiSuccess<JobEvidenceResponse>({ evidence: next }, 201);
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/lib/api/work-item-evidence.test.ts
+++ b/apps/web/lib/api/work-item-evidence.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the job-completion evidence projection + append helpers. The
+ * route is a thin Prisma I/O layer over these; covering them with unit
+ * tests means the route only needs a contract test for the auth + 404 paths.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  appendPhoto,
+  normalizeEvidence,
+  normalizePhoto,
+} from "./work-item-evidence";
+import type { JobEvidencePhoto } from "@dpf/types";
+
+const VALID: JobEvidencePhoto = {
+  fileId: "media_abc123",
+  url: "/api/v1/media/media_abc123",
+  capturedAt: "2026-06-18T14:00:00.000Z",
+  caption: "Compressor after replacement",
+};
+
+describe("normalizePhoto", () => {
+  it("accepts a complete entry verbatim", () => {
+    expect(normalizePhoto(VALID)).toEqual(VALID);
+  });
+
+  it("drops a blank caption rather than echoing it", () => {
+    const { caption: _omit, ...rest } = VALID;
+    expect(normalizePhoto({ ...rest, caption: "   " })).toEqual(rest);
+  });
+
+  it("rejects non-object input", () => {
+    expect(normalizePhoto(null)).toBeNull();
+    expect(normalizePhoto("not a photo")).toBeNull();
+    expect(normalizePhoto(42)).toBeNull();
+    expect(normalizePhoto([VALID])).toBeNull();
+  });
+
+  it("requires fileId, url, and a parseable capturedAt", () => {
+    expect(normalizePhoto({ ...VALID, fileId: "" })).toBeNull();
+    expect(normalizePhoto({ ...VALID, url: "  " })).toBeNull();
+    expect(normalizePhoto({ ...VALID, capturedAt: "yesterday" })).toBeNull();
+    expect(normalizePhoto({ ...VALID, capturedAt: null })).toBeNull();
+  });
+});
+
+describe("normalizeEvidence", () => {
+  it("returns an empty evidence record for null / non-object input", () => {
+    expect(normalizeEvidence(null)).toEqual({ photos: [] });
+    expect(normalizeEvidence("legacy-string")).toEqual({ photos: [] });
+    expect(normalizeEvidence([])).toEqual({ photos: [] });
+  });
+
+  it("projects a populated record + drops invalid photo entries silently", () => {
+    const stored = {
+      photos: [
+        VALID,
+        { fileId: "", url: "/x", capturedAt: VALID.capturedAt }, // invalid
+        { ...VALID, fileId: "media_2" },
+      ],
+      // Unknown sibling keys are tolerated (future-additive).
+      futureField: { something: true },
+    };
+    const result = normalizeEvidence(stored);
+    expect(result.photos).toHaveLength(2);
+    expect(result.photos[0].fileId).toBe(VALID.fileId);
+    expect(result.photos[1].fileId).toBe("media_2");
+  });
+
+  it("treats `photos` not being an array as empty rather than throwing", () => {
+    expect(normalizeEvidence({ photos: "weird" })).toEqual({ photos: [] });
+  });
+});
+
+describe("appendPhoto", () => {
+  it("appends to the end without mutating the input", () => {
+    const base = { photos: [VALID] };
+    const second: JobEvidencePhoto = {
+      fileId: "media_2",
+      url: "/api/v1/media/media_2",
+      capturedAt: "2026-06-18T14:05:00.000Z",
+    };
+    const result = appendPhoto(base, second);
+    expect(result.photos).toHaveLength(2);
+    expect(result.photos[1]).toEqual(second);
+    expect(base.photos).toHaveLength(1); // untouched
+  });
+});

--- a/apps/web/lib/api/work-item-evidence.ts
+++ b/apps/web/lib/api/work-item-evidence.ts
@@ -1,0 +1,74 @@
+/**
+ * Job-completion evidence — pure projection + append logic for
+ * WorkItem.evidence (stored as JSON, additive).
+ *
+ * The endpoint code in apps/web/app/api/v1/work-items/[itemId]/evidence/route.ts
+ * owns the Prisma I/O. This module owns:
+ *  - validation: a captured photo must carry { fileId, url, capturedAt } and
+ *    `capturedAt` must be a parseable ISO date-time string.
+ *  - merge: appending a photo to the existing evidence without losing siblings.
+ *  - normalization: reading WorkItem.evidence as JSON and projecting it to
+ *    the closed JobEvidence wire shape (drops unknown keys, never throws).
+ */
+import type {
+  JobEvidence,
+  JobEvidencePhoto,
+} from "@dpf/types";
+
+const EMPTY: JobEvidence = { photos: [] };
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isIsoDate(v: unknown): v is string {
+  if (typeof v !== "string") return false;
+  const t = Date.parse(v);
+  return !Number.isNaN(t);
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+/** Normalize one persisted-or-incoming photo entry. Returns null on invalid input. */
+export function normalizePhoto(raw: unknown): JobEvidencePhoto | null {
+  if (!isRecord(raw)) return null;
+  const fileId = asString(raw.fileId);
+  const url = asString(raw.url);
+  const capturedAt = isIsoDate(raw.capturedAt) ? (raw.capturedAt as string) : null;
+  if (!fileId || !url || !capturedAt) return null;
+  const photo: JobEvidencePhoto = { fileId, url, capturedAt };
+  const caption = asString(raw.caption);
+  if (caption) photo.caption = caption;
+  return photo;
+}
+
+/**
+ * Normalize a stored WorkItem.evidence JSON value into the closed wire shape.
+ * Treats anything malformed as empty rather than throwing — the field is
+ * append-only and historical writes pre-dating this contract may be missing
+ * keys.
+ */
+export function normalizeEvidence(raw: unknown): JobEvidence {
+  if (!isRecord(raw)) return { ...EMPTY };
+  const photosRaw = Array.isArray(raw.photos) ? raw.photos : [];
+  const photos: JobEvidencePhoto[] = [];
+  for (const entry of photosRaw) {
+    const norm = normalizePhoto(entry);
+    if (norm) photos.push(norm);
+  }
+  return { photos };
+}
+
+/**
+ * Append one validated photo to existing evidence and return the new value
+ * (immutable; the input is untouched). The endpoint persists the return
+ * value back to WorkItem.evidence in one update.
+ */
+export function appendPhoto(
+  existing: JobEvidence,
+  photo: JobEvidencePhoto,
+): JobEvidence {
+  return { ...existing, photos: [...existing.photos, photo] };
+}

--- a/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
+++ b/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
@@ -1,0 +1,101 @@
+# Plan — End-to-End iOS App Support (Dual-Persona, Install-Driven)
+
+**Date:** 2026-06-18
+**Status:** In-flight — implementing slice by slice
+**Owner:** mobile platform
+**Parent spec:** [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](../specs/2026-06-14-native-mobile-archetype-apps-design.html)
+**Related specs:** [Town super-app](../specs/2026-06-14-multi-business-town-super-app-design.html), [Field dispatch contract](../specs/2026-06-14-field-dispatch-mobile-contract-and-warranty-design.html)
+
+## Goal
+
+Close the remaining code gaps between today's mobile substrate and a real, shippable, install-driven iOS app serving both **field-tech (employee)** and **customer** personas — the HVAC scenario the founder named (tech captures work → drafts invoice → collects payment) AND the customer-facing flip side (view invoices, see visits, pay).
+
+Owner-only steps (Apple Developer enrollment, Google Play, Expo/EAS account, Firebase + APNs key, physical iPhone, store metadata) are explicitly out of scope for this plan — they cannot be performed by an agent regardless of authorization and are tracked in the parent spec §9.
+
+## Architecture (already shipped — context)
+
+Per [`2026-06-14-native-mobile-archetype-apps-design.html`](../specs/2026-06-14-native-mobile-archetype-apps-design.html) §3, the keystone is:
+
+> One generic Expo/RN binary connects to any DPF install, fetches an install manifest (`GET /api/v1/app/config`) carrying **design tokens + capabilities + persona + navigation**, and re-themes + re-functions itself from that data.
+
+What's already on `main` from prior slices:
+
+- `apps/mobile/` Expo SDK 55 / RN 0.83 / Expo Router / Zustand / NativeWind.
+- `.well-known/dpf-instance.json` discovery descriptor + runtime URL config (P1).
+- `GET /api/v1/app/config` install manifest with branding tokens, capability gating, persona resolution, navigation `defaultTab` (P2).
+- Manifest-driven tab visibility + landing tab (PR #2042).
+- Field-tech billing path: complete job → draft invoice → record cash/cheque/card/bank payment (PR #2043).
+- Customer "My invoices" surface with tap-through to install's `/pay/<invoiceRef>` (PR #2045).
+
+What's left — six tightly-scoped slices, each its own PR.
+
+## Slices
+
+### Slice 1 — `WorkItem` → `CustomerAccount` link end-to-end
+
+Removes the largest piece of friction in the field-tech flow: the tech had to type the customer's `accountId` on the invoice screen. Server resolves the account from the `WorkItem.sourceType` + `sourceId` link (Engagement / Opportunity / StorefrontBooking / Activity); mobile pre-fills it as read-only.
+
+**Status:** PR opened — #2162.
+
+### Slice 2 — Customer "My visits" surface
+
+Customer-side parallel to the employee's My Jobs. Customers see upcoming + recent appointments on Home alongside the My invoices panel. Closed `CustomerVisitStatus` union; `GET /api/v1/customer/visits` scoped two-hop (`account.is.accountId` → contacts → bookings); persona-gated render.
+
+**Status:** PR opened — #2168.
+
+### Slice 3 — Job-completion evidence (photos)
+
+Tech captures one-to-many photos of completed work before billing. Stored on `WorkItem.evidence` JSON (additive — no schema migration). Wire shape (`JobEvidencePhoto`, `AppendJobEvidenceRequest`, `JobEvidenceResponse`) lives in `@dpf/types`; persistence in `POST /api/v1/work-items/:itemId/evidence`; client in `@dpf/api-client/workItems.appendEvidence`; mobile feature store + a new `(tabs)/jobs/[itemId]/complete.tsx` screen that lets the tech capture, list, and proceed to Draft invoice.
+
+Signatures + voice notes deferred to a follow-up slice (each needs its own capture primitive — signature canvas via `react-native-signature-canvas`, voice via `expo-av` — both heavier deps deserving their own PR).
+
+**Status:** This slice — in flight.
+
+### Slice 4 — Multi-space switcher UX (Town M2)
+
+`spaces.store` substrate already exists from prior PRs. This slice adds the *UI*: a switcher component, a "connect another business" entry point reusing the existing `serverConfig` connect flow, and a "Town" home-tile listing connected spaces. Foundation for the founder's "3 businesses in one app" vision.
+
+### Slice 5 — EAS pipeline + path-filtered mobile CI lane
+
+`eas.json` today is a skeleton. This slice fills in the `internal`/`production` profiles for iOS + Android, adds a `.github/workflows/mobile-ci.yml` workflow that runs `pnpm --filter mobile typecheck` + `pnpm --filter mobile test` triggered only on `apps/mobile/**` and shared package paths, and documents the operator-only EAS first-run (Apple Developer enrollment, App Store Connect API key, FCM/APNs setup) as a checklist of owner-actions.
+
+Native binary builds run under EAS cloud — the spec is explicit that `node:24-alpine` Build Studio cannot build iOS (macOS + Xcode only).
+
+### Slice 6 — Geo-discovery "Nearby" stub (Town M4)
+
+Lightweight: `useGeolocation` hook (already-installed `expo-location`), a `Nearby` panel that pings `GET /api/v1/directory/nearby?lat&lng` and lists install descriptors, and a server stub returning the *local* install when geo matches its address. Hosted federation directory (M5 in the Town spec) is intentionally not part of this slice — local single-install path validates the contract first.
+
+## Reuse map
+
+| Existing substrate | What we lean on |
+|---|---|
+| `WorkItem` model + `/api/v1/work-items` | Slices 1, 3 — append `account` projection + evidence endpoint, no schema migration |
+| `StorefrontBooking` + `CustomerContact` | Slice 2 — two-hop scope to a signed-in customer |
+| `BrandingConfig.tokens` + install manifest | Already shipped, unchanged |
+| `POST /api/v1/upload` (MediaAsset) | Slice 3 — photos upload through it; the new evidence endpoint only links fileIds |
+| `spaces.store` (from earlier PRs) | Slice 4 — UI shell over existing state |
+| `expo-location` (already installed) | Slice 6 — geolocation hook |
+| `eas.json` skeleton | Slice 5 — fill in profiles |
+
+## Risks + open questions
+
+- **No native capture primitives shipped for sig / voice.** Signature canvas needs `react-native-signature-canvas` (out of Slice 3); voice notes need `expo-av`. Each gets its own slice once primary photo capture lands.
+- **Apple App Store §3.1.3(e) IAP exemption** holds for the physical-service payment flow (we open the install's `/pay/<invoiceRef>` in the system browser, not in-app). Confirmed in the parent spec §10.
+- **`hub.docker.com/v2` digest rotation cadence** (whisper-server) — unrelated to this plan but blocks merges intermittently; rotation playbook lives in `docker-compose.yml`.
+- **Town M5 federation directory** — deferred. Single-install "Nearby" stub in Slice 6 validates the shape first.
+
+## Verification per slice
+
+Each slice carries its own PR with the AGENTS §5 build-gate evidence:
+
+- `pnpm --filter web typecheck` + targeted vitest for any new server route.
+- `pnpm --filter mobile typecheck` + targeted jest for any new mobile store / projection.
+- UX evidence (driving the live install) is deferred until the EAS pipeline (Slice 5) lands and produces an internal TestFlight build a real iPhone can install — the operator-only step.
+
+## What this plan does NOT do
+
+- Stand up Apple Developer / Google Play / Expo / Firebase accounts (owner-only).
+- Generate APNs / FCM credentials (owner-only).
+- Submit to TestFlight or Play Internal (owner-only — needs the accounts above).
+- Touch the Town M5 hosted directory (separate spec, separate epic).
+- Add voice-note or signature capture primitives (each its own follow-up slice).

--- a/packages/api-client/src/endpoints/work-items.ts
+++ b/packages/api-client/src/endpoints/work-items.ts
@@ -1,5 +1,7 @@
 import type { DpfClient } from "../client";
 import type {
+  AppendJobEvidenceRequest,
+  JobEvidenceResponse,
   PaginatedResponse,
   WorkItemSummary,
   WorkItemDetail,
@@ -29,6 +31,17 @@ export function workItemsEndpoints(client: DpfClient) {
     updateStatus: (itemId: string, input: WorkItemStatusUpdateRequest) =>
       client.patch<WorkItemDetail>(
         `/api/v1/work-items/${encodeURIComponent(itemId)}`,
+        input,
+      ),
+
+    /**
+     * Append one completion photo to the assigned work item's evidence JSON.
+     * Server is the source of truth — the response carries the merged
+     * record after the append.
+     */
+    appendEvidence: (itemId: string, input: AppendJobEvidenceRequest) =>
+      client.post<JobEvidenceResponse>(
+        `/api/v1/work-items/${encodeURIComponent(itemId)}/evidence`,
         input,
       ),
   };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,3 +4,4 @@ export * from "./dynamic";
 export * from "./mobile-manifest";
 export * from "./work-items";
 export * from "./finance";
+export * from "./work-item-evidence";

--- a/packages/types/src/work-item-evidence.ts
+++ b/packages/types/src/work-item-evidence.ts
@@ -1,0 +1,37 @@
+/**
+ * Job-completion evidence wire shape — what the field tech captures alongside
+ * a WorkItem before billing the customer. Stored on `WorkItem.evidence` as
+ * JSON (no schema migration needed) and projected through this shared type
+ * so the producer (apps/web/lib/api/work-item-evidence) and the consumer
+ * (apps/mobile/src/features/job-evidence) cannot drift.
+ *
+ * v1 covers photos (the primary HVAC use-case: "before/after, model sticker,
+ * leak, etc"). Signatures, voice notes, geolocation stamps follow in
+ * subsequent slices once their capture primitives are wired.
+ */
+
+export interface JobEvidencePhoto {
+  /** Returned by POST /api/v1/upload — the canonical id of a stored MediaAsset. */
+  fileId: string;
+  /** Canonical URL — same value the upload endpoint returns. */
+  url: string;
+  /** ISO date-time the tech captured the photo (client clock). */
+  capturedAt: string;
+  /** Optional free-text caption ("before", "leak in unit B", etc). */
+  caption?: string;
+}
+
+/** Aggregate evidence persisted on a WorkItem. Additive — future fields go here. */
+export interface JobEvidence {
+  photos: JobEvidencePhoto[];
+}
+
+/** Request body for the append-evidence endpoint. */
+export interface AppendJobEvidenceRequest {
+  photo: JobEvidencePhoto;
+}
+
+/** Response — the full evidence after append (server is the source of truth). */
+export interface JobEvidenceResponse {
+  evidence: JobEvidence;
+}


### PR DESCRIPTION
## Summary

Adds the missing pre-billing step to the field-tech flow. After a job is completed (or while in-progress) the tech can capture photos of the work — each uploads to the existing `/api/v1/upload` MediaAsset pipeline, the `fileId` appends to `WorkItem.evidence` JSON, and a running list renders for sanity-check before tapping **Continue to invoice**.

Capture primitive is pluggable (swap-in source today: a deterministic stub; tomorrow: `expo-image-picker` / `expo-camera` in a follow-up slice). Persistence + merge logic are real now; UI seams are in place.

Plan: [`docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md`](docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md) (Slice 3). Spec: [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html) §7.

## Mechanics

- `@dpf/types/work-item-evidence.ts` — `JobEvidence`, `JobEvidencePhoto`, `AppendJobEvidenceRequest`, `JobEvidenceResponse`.
- `apps/web/lib/api/work-item-evidence.ts` — `normalizePhoto` / `normalizeEvidence` / `appendPhoto` pure helpers (closed validation: `fileId` / `url` / parseable ISO `capturedAt` required; unknown sibling keys tolerated).
- `apps/web/app/api/v1/work-items/[itemId]/evidence/route.ts` — `POST` appends one photo to the assigned work item's evidence JSON. Auth + assignment + 404 guarded; merge keeps siblings.
- `packages/api-client/src/endpoints/work-items.ts` — `workItems.appendEvidence()`.
- `apps/mobile/src/features/job-evidence/imageSource.ts` — swap-in image source (stub today, replaceable in tests + the future real-picker slice).
- `apps/mobile/src/features/job-evidence/job-evidence.store.ts` — zustand store: `begin(itemId)` seeds; `capturePhoto(caption?)` runs upload + append; server's merged record replaces local state.
- `apps/mobile/app/(tabs)/jobs/[itemId]/complete.tsx` — capture screen with caption input + running list of photos + Continue-to-invoice.
- `apps/mobile/app/(tabs)/jobs/[itemId]/index.tsx` — adds a **Capture work done** CTA alongside Draft invoice on completed jobs.
- `apps/mobile/app/(tabs)/jobs/_layout.tsx` — registers the new screen.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/api/work-item-evidence app/api/v1/work-items` — 15/15 (7 helper + 7 route + 1 existing).
- [x] `pnpm --filter mobile exec jest --testPathPatterns="job-evidence|jobs|invoices|navigation"` — 38/38.
- [x] `pnpm --filter web typecheck` + `pnpm --filter mobile typecheck` — clean.

## What's next

4. Multi-space switcher UX (Town M2).
5. EAS pipeline + path-filtered mobile CI lane.
6. Geo-discovery "Nearby" client + stub directory (Town M4).
