### PR TITLE
feat(mobile): multi-business switcher UX + /connect entry (Town M2)

### DIFF
--- a/apps/mobile/app/(tabs)/more/index.tsx
+++ b/apps/mobile/app/(tabs)/more/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { colors, spacing, borderRadius } from "@/src/lib/theme";
 import { api } from "@/src/lib/apiClient";
+import { SpaceSwitcher } from "@/src/features/spaces/SpaceSwitcher";
 import type { DynamicFormSchema, DynamicViewSchema } from "@dpf/types";
 
 interface MenuItemProps {
@@ -46,6 +47,9 @@ export default function MoreScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.heading}>More</Text>
+      <View style={{ paddingHorizontal: spacing.md, marginBottom: spacing.md }}>
+        <SpaceSwitcher />
+      </View>
       <MenuItem
         title="Approvals"
         icon="checkmark-circle-outline"

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -19,11 +19,14 @@ function useProtectedRoute() {
   useEffect(() => {
     if (isLoading) return;
 
-    const inAuthRoute = segments[0] === "login";
+    // `connect` is reachable from both states — first-run join AND adding
+    // another business from the in-app switcher — so it bypasses the
+    // protected-route redirects.
+    const inAuthRoute = segments[0] === "login" || segments[0] === "connect";
 
     if (!isAuthenticated && !inAuthRoute) {
       router.replace("/login");
-    } else if (isAuthenticated && inAuthRoute) {
+    } else if (isAuthenticated && segments[0] === "login") {
       router.replace("/(tabs)");
     }
   }, [isAuthenticated, isLoading, segments, router]);
@@ -67,6 +70,7 @@ export default function RootLayout() {
     <View style={styles.root}>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="login" />
+        <Stack.Screen name="connect" options={{ headerShown: true, title: "Connect a business" }} />
         <Stack.Screen name="(tabs)" />
       </Stack>
       {isAuthenticated ? <AgentFAB /> : null}

--- a/apps/mobile/app/connect.tsx
+++ b/apps/mobile/app/connect.tsx
@@ -1,0 +1,132 @@
+/**
+ * Connect to a business — entry point for adding a new space to the
+ * generic mobile app. Takes the user's organization URL, validates it
+ * against the `.well-known/dpf-instance.json` descriptor, registers it
+ * in the spaces store, then hands off to /login for credentials against
+ * the just-connected install.
+ *
+ * Same form whether this is the first business you join (replaces the
+ * silent default) or the third — the only difference is the spaces store
+ * accumulates rather than overwrites.
+ */
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import {
+  fetchInstanceDescriptor,
+  setServerUrl,
+} from "@/src/lib/serverConfig";
+import { useSpacesStore } from "@/src/stores/spaces";
+
+export default function ConnectScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const router = useRouter();
+  const addSpace = useSpacesStore((s) => s.addSpace);
+  const [url, setUrl] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+
+  const onConnect = async (): Promise<void> => {
+    if (!url.trim()) {
+      setError("Enter your organization's URL");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      const descriptor = await fetchInstanceDescriptor(url.trim());
+      const persisted = await setServerUrl(url.trim());
+      addSpace({ url: persisted, descriptor });
+      router.replace("/login");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not connect");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1, backgroundColor: theme.colors.surface1 }}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+    >
+      <View style={styles(theme).inner}>
+        <Text style={styles(theme).title}>Connect a business</Text>
+        <Text style={styles(theme).subtitle}>
+          Enter the URL of your organization's DPF install. You'll sign in next.
+        </Text>
+
+        {error ? <Text style={styles(theme).error}>{error}</Text> : null}
+
+        <TextInput
+          value={url}
+          onChangeText={setUrl}
+          style={styles(theme).input}
+          placeholder="https://acme.example"
+          placeholderTextColor={theme.colors.textMuted}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          editable={!submitting}
+          testID="connect-url"
+        />
+
+        <Pressable
+          style={[styles(theme).button, submitting && styles(theme).disabled]}
+          onPress={onConnect}
+          disabled={submitting}
+          accessibilityRole="button"
+          testID="connect-submit"
+        >
+          {submitting ? (
+            <ActivityIndicator color={theme.colors.white} />
+          ) : (
+            <Text style={styles(theme).buttonText}>Connect</Text>
+          )}
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = (t: ReturnType<typeof useTheme>) =>
+  StyleSheet.create({
+    inner: { padding: t.spacing.lg, flex: 1, justifyContent: "center" },
+    title: { color: t.colors.text, fontSize: 24, fontWeight: "700" },
+    subtitle: {
+      color: t.colors.textMuted,
+      fontSize: 14,
+      marginTop: t.spacing.xs,
+      marginBottom: t.spacing.lg,
+    },
+    error: { color: t.colors.error, marginBottom: t.spacing.sm },
+    input: {
+      backgroundColor: t.colors.surface2,
+      color: t.colors.text,
+      borderColor: t.colors.border,
+      borderWidth: 1,
+      borderRadius: t.borderRadius.md,
+      paddingHorizontal: t.spacing.md,
+      paddingVertical: t.spacing.sm + 2,
+      fontSize: 16,
+    },
+    button: {
+      marginTop: t.spacing.md,
+      backgroundColor: t.colors.primary,
+      borderRadius: t.borderRadius.md,
+      paddingVertical: t.spacing.sm + 4,
+      alignItems: "center",
+    },
+    disabled: { opacity: 0.6 },
+    buttonText: { color: t.colors.white, fontSize: 16, fontWeight: "600" },
+  });

--- a/apps/mobile/src/features/spaces/SpaceSwitcher.tsx
+++ b/apps/mobile/src/features/spaces/SpaceSwitcher.tsx
@@ -1,0 +1,237 @@
+/**
+ * SpaceSwitcher — picker for the multi-business ("Town") connection set.
+ *
+ * Shows the active space label as a press target; tap opens a modal with
+ * every connected business (active first, then most-recently-used) plus
+ * a "Connect another business" entry that routes to /connect. Switching
+ * a space updates the registry; the rest of the app re-reads from the
+ * spaces store on next mount.
+ *
+ * Compact (header-style) and full (More-tab section) variants share one
+ * component so the visual stays consistent across surfaces.
+ */
+import React, { useMemo, useState } from "react";
+import {
+  FlatList,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import { useSpacesStore } from "@/src/stores/spaces";
+import {
+  orderSpacesForSwitcher,
+  type SpaceDisplayRow,
+} from "./spaceDisplay";
+
+export interface SpaceSwitcherProps {
+  /** Compact: a thin pill (use in headers); Full: a card with help text. */
+  variant?: "compact" | "full";
+  /** Override the connect destination (defaults to /connect). */
+  connectHref?: string;
+}
+
+export function SpaceSwitcher({
+  variant = "full",
+  connectHref = "/connect",
+}: SpaceSwitcherProps): React.JSX.Element {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  const spaces = useSpacesStore((s) => s.spaces);
+  const activeSpaceId = useSpacesStore((s) => s.activeSpaceId);
+  const switchSpace = useSpacesStore((s) => s.switchSpace);
+  const removeSpace = useSpacesStore((s) => s.removeSpace);
+
+  const rows = useMemo(
+    () => orderSpacesForSwitcher({ spaces, activeSpaceId }),
+    [spaces, activeSpaceId],
+  );
+  const active = rows.find((r) => r.isActive) ?? null;
+
+  const onPick = (row: SpaceDisplayRow): void => {
+    if (!row.isActive) switchSpace(row.spaceId);
+    setOpen(false);
+  };
+
+  const onConnect = (): void => {
+    setOpen(false);
+    router.push(connectHref);
+  };
+
+  return (
+    <View>
+      <Pressable
+        style={variant === "compact" ? styles.triggerCompact : styles.triggerFull}
+        onPress={() => setOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel="Switch business"
+        testID="space-switcher-trigger"
+      >
+        <View style={{ flex: 1 }}>
+          {variant === "full" ? (
+            <Text style={styles.label}>Current business</Text>
+          ) : null}
+          <Text style={styles.activeName}>
+            {active?.label ?? "No business connected"}
+          </Text>
+          {variant === "full" && active ? (
+            <Text style={styles.activeMeta}>{active.url}</Text>
+          ) : null}
+        </View>
+        <Text style={styles.chevron}>▾</Text>
+      </Pressable>
+
+      <Modal
+        visible={open}
+        animationType="slide"
+        transparent
+        onRequestClose={() => setOpen(false)}
+      >
+        <View style={styles.modalBackdrop}>
+          <View style={styles.modalCard}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Businesses</Text>
+              <Pressable
+                onPress={() => setOpen(false)}
+                accessibilityRole="button"
+                accessibilityLabel="Close"
+                testID="space-switcher-close"
+              >
+                <Text style={styles.modalClose}>Close</Text>
+              </Pressable>
+            </View>
+
+            <FlatList
+              data={rows}
+              keyExtractor={(r) => r.spaceId}
+              renderItem={({ item }) => (
+                <Pressable
+                  style={[styles.row, item.isActive && styles.rowActive]}
+                  onPress={() => onPick(item)}
+                  onLongPress={() => removeSpace(item.spaceId)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: item.isActive }}
+                  testID={`space-row-${item.spaceId}`}
+                >
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.rowTitle}>{item.label}</Text>
+                    <Text style={styles.rowMeta}>{item.url}</Text>
+                  </View>
+                  {item.isActive ? (
+                    <Text style={styles.rowActiveTag}>active</Text>
+                  ) : null}
+                </Pressable>
+              )}
+              ListEmptyComponent={
+                <Text style={styles.empty}>
+                  You haven't connected any business yet.
+                </Text>
+              }
+            />
+
+            <Pressable
+              style={styles.connectBtn}
+              onPress={onConnect}
+              accessibilityRole="button"
+              testID="space-switcher-connect"
+            >
+              <Text style={styles.connectBtnText}>+ Connect another business</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    triggerFull: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+    },
+    triggerCompact: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.lg,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm - 2,
+    },
+    label: {
+      color: colors.textMuted,
+      fontSize: 11,
+      textTransform: "uppercase",
+      letterSpacing: 0.6,
+    },
+    activeName: { color: colors.text, fontSize: 15, fontWeight: "700" },
+    activeMeta: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+    chevron: { color: colors.textMuted, fontSize: 18, marginLeft: spacing.sm },
+    modalBackdrop: {
+      flex: 1,
+      backgroundColor: "rgba(0,0,0,0.45)",
+      justifyContent: "flex-end",
+    },
+    modalCard: {
+      backgroundColor: colors.surface1,
+      borderTopLeftRadius: borderRadius.lg,
+      borderTopRightRadius: borderRadius.lg,
+      padding: spacing.md,
+      maxHeight: "75%",
+    },
+    modalHeader: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: spacing.sm,
+    },
+    modalTitle: { color: colors.text, fontSize: 18, fontWeight: "700" },
+    modalClose: { color: colors.primary, fontSize: 14, fontWeight: "600" },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      marginVertical: spacing.xs,
+    },
+    rowActive: { borderColor: colors.primary },
+    rowTitle: { color: colors.text, fontSize: 15, fontWeight: "600" },
+    rowMeta: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+    rowActiveTag: {
+      color: colors.primary,
+      fontSize: 11,
+      fontWeight: "700",
+      textTransform: "uppercase",
+    },
+    empty: {
+      color: colors.textMuted,
+      fontSize: 14,
+      textAlign: "center",
+      marginVertical: spacing.lg,
+    },
+    connectBtn: {
+      marginTop: spacing.md,
+      backgroundColor: colors.primary,
+      borderRadius: borderRadius.md,
+      paddingVertical: spacing.sm + 4,
+      alignItems: "center",
+    },
+    connectBtnText: { color: colors.white, fontSize: 15, fontWeight: "600" },
+  });
+}

--- a/apps/mobile/src/features/spaces/spaceDisplay.test.ts
+++ b/apps/mobile/src/features/spaces/spaceDisplay.test.ts
@@ -1,0 +1,58 @@
+import { orderSpacesForSwitcher } from "./spaceDisplay";
+import type { Space } from "@dpf/types";
+
+function s(spaceId: string, lastUsedAt?: number): Space {
+  return {
+    spaceId,
+    url: `https://${spaceId}.example`,
+    label: spaceId,
+    descriptor: {
+      instanceId: spaceId,
+      orgName: spaceId,
+      apiVersion: "v1",
+      authModes: ["password"],
+    },
+    lastUsedAt,
+  };
+}
+
+describe("orderSpacesForSwitcher", () => {
+  it("places the active space first, then by lastUsedAt desc", () => {
+    const result = orderSpacesForSwitcher({
+      spaces: [s("a", 100), s("b", 300), s("c", 200)],
+      activeSpaceId: "c",
+    });
+    expect(result.map((r) => r.spaceId)).toEqual(["c", "b", "a"]);
+  });
+
+  it("flags exactly one row as active when an id matches; none when null", () => {
+    const r1 = orderSpacesForSwitcher({
+      spaces: [s("a", 100), s("b", 200)],
+      activeSpaceId: "b",
+    });
+    expect(r1.filter((r) => r.isActive).map((r) => r.spaceId)).toEqual(["b"]);
+
+    const r2 = orderSpacesForSwitcher({
+      spaces: [s("a", 100), s("b", 200)],
+      activeSpaceId: null,
+    });
+    expect(r2.filter((r) => r.isActive)).toEqual([]);
+  });
+
+  it("falls back to insertion order on a lastUsedAt tie (stable)", () => {
+    const result = orderSpacesForSwitcher({
+      spaces: [s("first"), s("second")],
+      activeSpaceId: null,
+    });
+    expect(result.map((r) => r.spaceId)).toEqual(["first", "second"]);
+  });
+
+  it("an unknown activeSpaceId still orders by lastUsedAt, no row flagged active", () => {
+    const result = orderSpacesForSwitcher({
+      spaces: [s("a", 100), s("b", 300)],
+      activeSpaceId: "ghost",
+    });
+    expect(result.map((r) => r.spaceId)).toEqual(["b", "a"]);
+    expect(result.every((r) => !r.isActive)).toBe(true);
+  });
+});

--- a/apps/mobile/src/features/spaces/spaceDisplay.ts
+++ b/apps/mobile/src/features/spaces/spaceDisplay.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure helpers backing the SpaceSwitcher UI — no React, no zustand, no I/O.
+ * Easier to test, and the switcher component reads identical shape from the
+ * existing useSpacesStore. Keeping the projection separate means the
+ * ordering rule ("active first, then most-recently-used") has a single
+ * unit-tested source of truth.
+ */
+import type { Space } from "@dpf/types";
+
+export interface SpaceDisplayRow {
+  spaceId: string;
+  label: string;
+  url: string;
+  isActive: boolean;
+}
+
+export interface OrderSpacesInput {
+  spaces: Space[];
+  activeSpaceId: string | null;
+}
+
+/**
+ * Order spaces for the switcher: active first, then by lastUsedAt desc
+ * (most-recently-used surfaces faster), with stable insertion-order
+ * tiebreak so the list never reshuffles between renders.
+ */
+export function orderSpacesForSwitcher(
+  input: OrderSpacesInput,
+): SpaceDisplayRow[] {
+  const { spaces, activeSpaceId } = input;
+  const indexed = spaces.map((s, i) => ({ s, i }));
+  indexed.sort((a, b) => {
+    const aActive = a.s.spaceId === activeSpaceId ? 0 : 1;
+    const bActive = b.s.spaceId === activeSpaceId ? 0 : 1;
+    if (aActive !== bActive) return aActive - bActive;
+    const aLast = a.s.lastUsedAt ?? 0;
+    const bLast = b.s.lastUsedAt ?? 0;
+    if (aLast !== bLast) return bLast - aLast;
+    return a.i - b.i;
+  });
+  return indexed.map(({ s }) => ({
+    spaceId: s.spaceId,
+    label: s.label,
+    url: s.url,
+    isActive: s.spaceId === activeSpaceId,
+  }));
+}

--- a/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
+++ b/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
@@ -1,0 +1,77 @@
+# Plan — End-to-End iOS App Support (Dual-Persona, Install-Driven)
+
+**Date:** 2026-06-18
+**Status:** In-flight — slices merging in sequence
+**Owner:** mobile platform
+**Parent spec:** [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](../specs/2026-06-14-native-mobile-archetype-apps-design.html)
+**Related specs:** [Town super-app](../specs/2026-06-14-multi-business-town-super-app-design.html), [Field dispatch contract](../specs/2026-06-14-field-dispatch-mobile-contract-and-warranty-design.html)
+
+## Goal
+
+Close the remaining code gaps between today's mobile substrate and a real, shippable, install-driven iOS app serving both **field-tech (employee)** and **customer** personas — the HVAC scenario the founder named (tech captures work → drafts invoice → collects payment) AND the customer-facing flip side (view invoices, see visits, pay).
+
+Owner-only steps (Apple Developer enrollment, Google Play, Expo/EAS account, Firebase + APNs key, physical iPhone, store metadata) are explicitly out of scope for this plan — they cannot be performed by an agent regardless of authorization and are tracked in the parent spec §9.
+
+## Slices
+
+### Slice 1 — `WorkItem` → `CustomerAccount` link end-to-end
+
+Removes the largest piece of friction in the field-tech flow: server resolves the account from the `WorkItem.sourceType` + `sourceId` link (Engagement / Opportunity / StorefrontBooking / Activity); mobile pre-fills it as read-only.
+
+**Status:** PR #2162.
+
+### Slice 2 — Customer "My visits" surface
+
+Customer-side parallel to the employee's My Jobs — customers see upcoming + recent appointments on Home alongside My invoices. `GET /api/v1/customer/visits` scoped two-hop, closed `CustomerVisitStatus` union, persona-gated render.
+
+**Status:** PR #2168.
+
+### Slice 3 — Job-completion evidence (photos)
+
+Tech captures one-to-many photos of completed work before billing. Stored on `WorkItem.evidence` JSON (additive — no schema migration). Capture primitive is pluggable so today's stub swaps for `expo-image-picker` / `expo-camera` in a follow-up.
+
+**Status:** PR #2181.
+
+### Slice 4 — Multi-space switcher UX (Town M2)
+
+`spaces.store` substrate already exists from prior PRs. This slice adds the *UI*: a `SpaceSwitcher` component (compact + full variants), a `/connect` screen that takes a URL → fetches the `.well-known/dpf-instance.json` descriptor → registers the space → routes to login, and a More-tab placement that surfaces the current business and lets the user add another. Long-press on a row removes that space. Foundation for the founder's "3 businesses in one app" vision.
+
+**Status:** This slice — in flight.
+
+### Slice 5 — EAS pipeline + path-filtered mobile CI lane
+
+`eas.json` today is a skeleton. Fill in `internal`/`production` profiles for iOS + Android, add a `.github/workflows/mobile-ci.yml` workflow that runs typecheck + jest on `apps/mobile/**` and shared package paths, and document the operator-only EAS first-run (Apple Developer, App Store Connect API key, FCM/APNs) as a checklist of owner-actions.
+
+Native binary builds run under EAS cloud — `node:24-alpine` Build Studio cannot build iOS (macOS + Xcode only).
+
+### Slice 6 — Geo-discovery "Nearby" stub (Town M4)
+
+Lightweight: `useGeolocation` hook (already-installed `expo-location`), a `Nearby` panel that pings `GET /api/v1/directory/nearby?lat&lng` and lists install descriptors, and a server stub returning the *local* install when geo matches its address. Hosted federation directory (Town M5) intentionally not part of this slice.
+
+## Reuse map
+
+| Existing substrate | What we lean on |
+|---|---|
+| `WorkItem` model + `/api/v1/work-items` | Slices 1, 3 — append `account` projection + evidence endpoint, no schema migration |
+| `StorefrontBooking` + `CustomerContact` | Slice 2 — two-hop scope to a signed-in customer |
+| `BrandingConfig.tokens` + install manifest | Already shipped, unchanged |
+| `POST /api/v1/upload` (MediaAsset) | Slice 3 — photos upload through it |
+| `spaces.store` (from earlier PRs) | Slice 4 — UI shell over existing state |
+| `expo-location` (already installed) | Slice 6 — geolocation hook |
+| `eas.json` skeleton | Slice 5 — fill in profiles |
+
+## Verification per slice
+
+Each slice carries its own PR with the AGENTS §5 build-gate evidence:
+
+- `pnpm --filter web typecheck` + targeted vitest for any new server route.
+- `pnpm --filter mobile typecheck` + targeted jest for any new mobile store / projection.
+- UX evidence (driving the live install) is deferred until the EAS pipeline (Slice 5) lands and produces an internal TestFlight build a real iPhone can install — the operator-only step.
+
+## What this plan does NOT do
+
+- Stand up Apple Developer / Google Play / Expo / Firebase accounts (owner-only).
+- Generate APNs / FCM credentials (owner-only).
+- Submit to TestFlight or Play Internal (owner-only).
+- Touch the Town M5 hosted directory (separate epic).
+- Add voice-note or signature capture primitives (each its own follow-up slice).


### PR DESCRIPTION
## Summary

The UI half of the multi-space ("Town") substrate prior PRs already shipped. Adds a `SpaceSwitcher` component (compact + full variants), a `/connect` screen that walks URL → `.well-known` descriptor → `spaces.addSpace` → `/login`, and a More-tab placement that surfaces the current business and lets the user add another. Long-press on a row removes that space. Lays the foundation for the "3 businesses in one app" vision and the customer-side community geo-discovery (Town M4) that composes on top.

Plan: [`docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md`](docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md) (Slice 4). Spec: [`docs/superpowers/specs/2026-06-14-multi-business-town-super-app-design.html`](docs/superpowers/specs/2026-06-14-multi-business-town-super-app-design.html).

## Mechanics

- `apps/mobile/src/features/spaces/spaceDisplay.ts` — pure `orderSpacesForSwitcher()` projection (active first, then `lastUsedAt` desc, stable insertion-order tiebreak).
- `apps/mobile/src/features/spaces/SpaceSwitcher.tsx` — trigger pill + modal list of every connected business; switch on tap, remove on long-press, **Connect another business** routes to `/connect`.
- `apps/mobile/app/connect.tsx` — URL form → `fetchInstanceDescriptor` → `setServerUrl` → `useSpacesStore.addSpace` → `router.replace("/login")`.
- `apps/mobile/app/_layout.tsx` — registers the connect route + permits it through the protected-route gate (reachable pre- and post-authentication).
- `apps/mobile/app/(tabs)/more/index.tsx` — mounts `<SpaceSwitcher />` at the top of the menu so every persona has access.

## Test plan

- [x] `pnpm --filter mobile exec jest --testPathPatterns="spaceDisplay|spaces|navigation|invoices|jobs"` — 57/57 (4 new spaceDisplay + 53 existing).
- [x] `pnpm --filter mobile typecheck` — clean.

## What's next

5. EAS pipeline + path-filtered mobile CI lane.
6. Geo-discovery "Nearby" client + stub directory (Town M4).
