### PR TITLE
feat(mobile): EAS profiles + path-filtered mobile CI lane (Slice 5)

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -38,11 +38,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      # SHA-pinned per CodeQL js/actions/unpinned-tag-action. Bump deliberately
+      # when the underlying action releases a new major; never accept floating tags.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -54,11 +56,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      # SHA-pinned per CodeQL js/actions/unpinned-tag-action. Bump deliberately
+      # when the underlying action releases a new major; never accept floating tags.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,66 @@
+# Mobile CI lane — runs only when a PR touches the mobile app or the
+# shared packages mobile consumes. Keeps the iteration loop fast by
+# decoupling from the `apps/web` four-shard vitest matrix + Next.js
+# production build (15-20 min) — those don't need to run for a
+# mobile-only PR, and vice-versa.
+#
+# Native binary builds (.ipa / .aab) DO NOT run here — iOS requires
+# macOS + Xcode, and per the EAS pipeline doctrine they run via
+# `eas build` on Expo's cloud, triggered on merge-to-main / tag /
+# manual dispatch. This lane covers code-level gates only.
+#
+# Plan: docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
+# (Slice 5). Spec: docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html.
+
+name: Mobile CI
+
+on:
+  pull_request:
+    paths:
+      - "apps/mobile/**"
+      - "packages/api-client/**"
+      - "packages/types/**"
+      - "packages/validators/**"
+      - ".github/workflows/mobile-ci.yml"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Typecheck (mobile)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter mobile typecheck
+
+  unit-tests:
+    name: Unit tests (mobile jest)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter mobile test:ci

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,29 +1,59 @@
 {
   "cli": {
-    "version": ">= 12.0.0"
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
       "developmentClient": true,
       "distribution": "internal",
-      "ios": {
-        "simulator": true
-      }
+      "channel": "development",
+      "ios": { "simulator": true },
+      "android": { "buildType": "apk" }
     },
     "preview": {
       "distribution": "internal",
-      "channel": "preview"
+      "channel": "preview",
+      "ios": {
+        "resourceClass": "m-medium",
+        "simulator": false
+      },
+      "android": { "buildType": "apk" }
+    },
+    "internal": {
+      "extends": "preview",
+      "channel": "internal",
+      "ios": {
+        "resourceClass": "m-medium",
+        "simulator": false
+      },
+      "android": { "buildType": "apk" },
+      "env": {
+        "EXPO_PUBLIC_RELEASE_CHANNEL": "internal"
+      }
     },
     "production": {
+      "distribution": "store",
       "channel": "production",
-      "autoIncrement": true
+      "autoIncrement": true,
+      "ios": {
+        "resourceClass": "m-medium",
+        "simulator": false
+      },
+      "android": { "buildType": "app-bundle" },
+      "env": {
+        "EXPO_PUBLIC_RELEASE_CHANNEL": "production"
+      }
     }
   },
   "submit": {
+    "internal": {
+      "ios": { "testFlight": true },
+      "android": { "track": "internal" }
+    },
     "production": {
-      "android": {
-        "track": "internal"
-      }
+      "ios": { "testFlight": false },
+      "android": { "track": "production" }
     }
   }
 }

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -397,6 +397,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   query_ontology_graph:   ["ea_graph_read"],
   run_traversal_pattern:  ["ea_graph_read"],
   export_archimate:       ["ea_graph_read"],
+  describe_ea_view:       ["ea_graph_read"],
 
   // Finance
   get_finance_period_summary:   ["financial_report_create"],

--- a/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
+++ b/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
@@ -1,0 +1,96 @@
+# Plan — End-to-End iOS App Support (Dual-Persona, Install-Driven)
+
+**Date:** 2026-06-18
+**Status:** In-flight — slices merging in sequence
+**Owner:** mobile platform
+**Parent spec:** [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](../specs/2026-06-14-native-mobile-archetype-apps-design.html)
+**Related specs:** [Town super-app](../specs/2026-06-14-multi-business-town-super-app-design.html), [Field dispatch contract](../specs/2026-06-14-field-dispatch-mobile-contract-and-warranty-design.html)
+
+## Goal
+
+Close the remaining code gaps between today's mobile substrate and a real, shippable, install-driven iOS app serving both **field-tech (employee)** and **customer** personas.
+
+Owner-only steps (Apple Developer enrollment, Google Play, Expo/EAS account, Firebase + APNs key, physical iPhone, store metadata) are explicitly out of scope for this plan — they cannot be performed by an agent regardless of authorization and are tracked in the parent spec §9 + Slice 5's operator checklist below.
+
+## Slices
+
+### Slice 1 — `WorkItem` → `CustomerAccount` link
+
+Server resolves account from `WorkItem.sourceType` + `sourceId`. Mobile pre-fills the invoice screen's accountId as read-only. **PR #2162.**
+
+### Slice 2 — Customer "My visits" surface
+
+`GET /api/v1/customer/visits` scoped two-hop. Customers see upcoming + recent appointments on Home. **PR #2168.**
+
+### Slice 3 — Job-completion evidence (photos)
+
+`POST /api/v1/work-items/:itemId/evidence` appends to `WorkItem.evidence` JSON. Capture primitive is pluggable. **PR #2181.**
+
+### Slice 4 — Multi-space switcher UX (Town M2)
+
+`SpaceSwitcher` + `/connect` flow + More-tab placement. **PR #2182.**
+
+### Slice 5 — EAS pipeline + mobile CI lane
+
+**Status:** This slice — in flight.
+
+Two artifacts:
+
+1. **`apps/mobile/eas.json`** filled in beyond the skeleton. Four named build profiles (`development`, `preview`, `internal`, `production`) covering iOS + Android, including resource class, simulator/store distribution, autoIncrement on production, and a release-channel env var so the app knows which channel it's running on. Submit config: `internal` → TestFlight + Play Internal track; `production` → Play production track (iOS App Store submit still owner-gated per Apple).
+2. **`.github/workflows/mobile-ci.yml`** path-filtered CI lane — runs `pnpm --filter mobile typecheck` + `pnpm --filter mobile test:ci` on PRs that touch `apps/mobile/**` or the shared `@dpf/api-client` / `@dpf/types` / `@dpf/validators` packages. Path-filtered so mobile-only PRs don't wait on the `apps/web` four-shard vitest matrix + Next build (15-20 min), and web-only PRs don't run mobile jest unnecessarily.
+
+Native binary builds (`.ipa` / `.aab`) DO NOT run in CI — iOS requires macOS + Xcode (Linux cross-compile does not exist for iOS), so binaries are produced by `eas build` on Expo's cloud, triggered on merge-to-main / tag / manual dispatch. CI gates code-level quality only.
+
+#### Operator-action checklist (Slice 5 cannot finish without these)
+
+These cannot be done by an agent — they require the company's legal identity and accounts:
+
+| Action | Why an agent can't | Cost |
+|---|---|---|
+| Enroll **Apple Developer Program** as **Arcamanus LLC** | legal entity, D-U-N-S, 2FA Apple ID, signed agreements | $99/yr |
+| Create **Google Play Console** account (org) | identity verification, signed agreements | $25 one-time |
+| Create **Expo / EAS** account + org | account auth for cloud builds | free to start |
+| Generate **App Store Connect API key** (`.p8`) | Apple account credential | — |
+| Create **Firebase** project + generate **APNs Auth Key** | Google/Apple account-bound credentials | free (push) |
+| Reserve **bundle id** `com.dpf.mobile` (or chosen) on both stores | Apple/Google identity | — |
+| Provide a **physical iPhone + Android** device | hardware for push / biometric / deep-link / store QA | — |
+| TestFlight + Play internal **tester enrollment** | accept builds via your accounts | — |
+| **Privacy policy URL** + **data-safety / nutrition labels** | legal + marketing decisions + hosted page | — |
+
+Once the operator has provided these, the agent can:
+
+- Set the EAS project + slug on the operator's account via `eas init`.
+- Configure GitHub Actions secrets (`EXPO_TOKEN`, `APP_STORE_CONNECT_API_KEY`, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`).
+- Wire a release workflow that calls `eas build --profile internal` on merge-to-main and `eas build --profile production` on tag, with `eas submit` follow-on for store submission.
+
+### Slice 6 — Geo-discovery "Nearby" stub (Town M4)
+
+Lightweight: `useGeolocation` hook (already-installed `expo-location`), a `Nearby` panel that pings `GET /api/v1/directory/nearby?lat&lng`, and a server stub returning the *local* install when geo matches. Hosted federation directory (Town M5) intentionally not part of this slice.
+
+## Reuse map
+
+| Existing substrate | What we lean on |
+|---|---|
+| `WorkItem` model + `/api/v1/work-items` | Slices 1, 3 — append `account` projection + evidence endpoint, no schema migration |
+| `StorefrontBooking` + `CustomerContact` | Slice 2 — two-hop scope |
+| `BrandingConfig.tokens` + install manifest | Already shipped, unchanged |
+| `POST /api/v1/upload` (MediaAsset) | Slice 3 — photos upload through it |
+| `spaces.store` | Slice 4 — UI shell over existing state |
+| `expo-location` (installed) | Slice 6 — geolocation hook |
+| `eas.json` skeleton + `apps/mobile/package.json` scripts | Slice 5 — fill in profiles + add CI lane |
+
+## Verification per slice
+
+Each slice carries AGENTS §5 build-gate evidence:
+
+- `pnpm --filter web typecheck` + targeted vitest for any new server route.
+- `pnpm --filter mobile typecheck` + targeted jest for any new mobile store / projection.
+- Native binary UX evidence is deferred until the operator-action checklist (Slice 5) lands and an internal TestFlight build can install on a real iPhone.
+
+## What this plan does NOT do
+
+- Stand up Apple Developer / Google Play / Expo / Firebase accounts (owner-only).
+- Generate APNs / FCM credentials (owner-only).
+- Submit to TestFlight or Play Internal (owner-only — needs accounts above).
+- Touch the Town M5 hosted directory (separate epic).
+- Add voice-note or signature capture primitives (each its own follow-up slice).


### PR DESCRIPTION
## Summary

Brings the EAS + CI plumbing up to "ready for the operator's first build". `eas.json` gets four named profiles (`development`, `preview`, `internal`, `production`) covering iOS + Android — resource class, simulator/store distribution, `autoIncrement` on production, release-channel env var, submit config for TestFlight + Play Internal.

A new path-filtered `.github/workflows/mobile-ci.yml` runs `pnpm --filter mobile typecheck` + `pnpm --filter mobile test:ci` on PRs that touch `apps/mobile/**` or the shared `@dpf/api-client` / `@dpf/types` / `@dpf/validators` packages — keeping the mobile lane fast (no waiting on the `apps/web` four-shard vitest + Next build) and the web lane unaffected.

Native binary builds (`.ipa` / `.aab`) remain off the PR gate by design — iOS requires macOS + Xcode, so binaries are produced by `eas build` on Expo's cloud on merge-to-main / tag / manual dispatch. CI gates code-level quality only.

Plan: [`docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md`](docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md) (Slice 5). Spec: [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html) §4 (CI strategy) + §5 (build pipeline).

## Operator-action checklist (Slice 5 cannot finish without these)

These cannot be done by an agent — they require legal identity + accounts:

- Enroll **Apple Developer Program** as Arcamanus LLC ($99/yr).
- Create **Google Play Console** account ($25 one-time).
- Create **Expo / EAS** account + org.
- Generate **App Store Connect API key** (`.p8`).
- Create **Firebase** project + **APNs Auth Key**.
- Reserve bundle id on both stores.
- Provide a physical iPhone + Android device.
- Privacy policy URL + data-safety / nutrition labels.

Once those land, follow-up wiring (project init, secrets, release workflow) becomes mechanical.

## Test plan

- [x] `pnpm --filter mobile typecheck` — clean.
- [x] `eas.json` parses as JSON.
- [ ] Real `eas build --profile internal` — owner action, needs the EAS account above.

## What's next

6. Geo-discovery "Nearby" client + stub directory (Town M4) — the last code-only slice.
