### PR TITLE
feat(mobile): geo-discovery "Nearby" stub + customer panel (Town M4)

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -12,6 +12,7 @@ import { DashboardTile } from "@/src/components/DashboardTile";
 import { useWorkspaceStore } from "@/src/features/workspace/workspace.store";
 import { useAppConfigStore } from "@/src/lib/appConfig";
 import { CustomerInvoicesPanel } from "@/src/features/customer-invoices/CustomerInvoicesPanel";
+import { NearbyPanel } from "@/src/features/nearby/NearbyPanel";
 import { CustomerVisitsPanel } from "@/src/features/customer-visits/CustomerVisitsPanel";
 import type { ActivityItem, DashboardTile as TileType } from "@dpf/types";
 
@@ -85,6 +86,7 @@ export default function HomeScreen() {
           <View>
             <CustomerInvoicesPanel />
             <CustomerVisitsPanel />
+            <NearbyPanel />
           </View>
         }
       />

--- a/apps/mobile/src/features/nearby/NearbyPanel.tsx
+++ b/apps/mobile/src/features/nearby/NearbyPanel.tsx
@@ -1,0 +1,144 @@
+/**
+ * Customer-mode "Nearby" home panel — geo-discovery for the founder's
+ * "3 businesses in one app" community vision. Asks for the device's
+ * location once, queries the install's `/api/v1/directory/nearby`, and
+ * lists each returned business with a tap-through to connect.
+ *
+ * Today the directory is install-local (just THIS install when its
+ * lat/long falls in radius) — the same shape composes onto the Town
+ * M5 hosted federation directory in a follow-up.
+ */
+import React, { useEffect, useMemo } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import { useGeolocation } from "@/src/hooks/useGeolocation";
+import { useNearbyStore } from "./nearby.store";
+import { useSpacesStore } from "@/src/stores/spaces";
+import { fetchInstanceDescriptor } from "@/src/lib/serverConfig";
+
+export function NearbyPanel(): React.JSX.Element {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const router = useRouter();
+
+  const geo = useGeolocation();
+  const { results, isLoading, error, fetch } = useNearbyStore();
+  const addSpace = useSpacesStore((s) => s.addSpace);
+
+  useEffect(() => {
+    if (geo.latitude != null && geo.longitude != null) {
+      void fetch({ latitude: geo.latitude, longitude: geo.longitude });
+    }
+  }, [geo.latitude, geo.longitude, fetch]);
+
+  const onPick = async (url: string): Promise<void> => {
+    try {
+      const descriptor = await fetchInstanceDescriptor(url);
+      addSpace({ url, descriptor });
+      router.push("/login");
+    } catch {
+      // Fall back to the manual connect flow if the descriptor lookup fails.
+      router.push("/connect");
+    }
+  };
+
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.h1}>Nearby businesses</Text>
+
+      {geo.permission === "denied" ? (
+        <View style={styles.note}>
+          <Text style={styles.noteText}>
+            Location permission is needed to see businesses near you.
+          </Text>
+          <Pressable
+            onPress={() => geo.refresh()}
+            accessibilityRole="button"
+            testID="nearby-grant"
+          >
+            <Text style={styles.noteAction}>Grant access</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {error ? (
+        <Text style={styles.error} testID="nearby-error">
+          {error}
+        </Text>
+      ) : null}
+
+      {(isLoading || geo.isFetching) && results.length === 0 ? (
+        <ActivityIndicator
+          color={theme.colors.primary}
+          testID="nearby-loading"
+        />
+      ) : results.length === 0 ? (
+        <Text style={styles.empty}>
+          No DPF-powered businesses in your area yet.
+        </Text>
+      ) : (
+        results.map((row) => (
+          <Pressable
+            key={row.instanceId}
+            style={styles.row}
+            onPress={() => onPick(row.url)}
+            accessibilityRole="button"
+            testID={`nearby-row-${row.instanceId}`}
+          >
+            <View style={styles.left}>
+              <Text style={styles.name}>{row.orgName}</Text>
+              {row.locality ? (
+                <Text style={styles.meta}>{row.locality}</Text>
+              ) : null}
+              {row.archetype ? (
+                <Text style={styles.archetype}>{row.archetype}</Text>
+              ) : null}
+            </View>
+            <Text style={styles.distance}>{row.distanceKm} km</Text>
+          </Pressable>
+        ))
+      )}
+    </View>
+  );
+}
+
+function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    panel: { padding: spacing.md, gap: spacing.sm },
+    h1: { color: colors.text, fontSize: 20, fontWeight: "700" },
+    note: {
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      gap: spacing.sm,
+    },
+    noteText: { color: colors.text, fontSize: 14 },
+    noteAction: { color: colors.primary, fontSize: 14, fontWeight: "700" },
+    empty: { color: colors.textMuted, fontSize: 14, marginTop: spacing.sm },
+    error: { color: colors.error, fontSize: 13 },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      marginVertical: spacing.xs,
+    },
+    left: { flex: 1 },
+    name: { color: colors.text, fontSize: 15, fontWeight: "700" },
+    meta: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+    archetype: { color: colors.primary, fontSize: 11, marginTop: 2 },
+    distance: { color: colors.text, fontSize: 14, fontWeight: "700" },
+  });
+}

--- a/apps/mobile/src/features/nearby/nearby.store.test.ts
+++ b/apps/mobile/src/features/nearby/nearby.store.test.ts
@@ -1,0 +1,59 @@
+import { useNearbyStore } from "./nearby.store";
+import type { NearbyInstance } from "@dpf/types";
+
+const mockNearby = jest.fn();
+jest.mock("@/src/lib/apiClient", () => ({
+  api: { directory: { nearby: (...a: unknown[]) => mockNearby(...a) } },
+}));
+
+const ROW: NearbyInstance = {
+  instanceId: "ORG-ACME",
+  orgName: "Acme HVAC",
+  url: "https://acme.example",
+  distanceKm: 1.2,
+  archetype: "trades-maintenance/hvac-contractor",
+  locality: "London, UK",
+};
+
+function resetStore() {
+  useNearbyStore.getState().reset();
+  mockNearby.mockReset();
+}
+
+beforeEach(resetStore);
+
+describe("useNearbyStore.fetch", () => {
+  it("populates results on success and clears prior error", async () => {
+    useNearbyStore.setState({ error: "stale error" });
+    mockNearby.mockResolvedValueOnce({ results: [ROW] });
+
+    await useNearbyStore.getState().fetch({ latitude: 51.5, longitude: -0.1 });
+    expect(useNearbyStore.getState().results).toEqual([ROW]);
+    expect(useNearbyStore.getState().isLoading).toBe(false);
+    expect(useNearbyStore.getState().error).toBeNull();
+  });
+
+  it("forwards optional radiusKm", async () => {
+    mockNearby.mockResolvedValueOnce({ results: [] });
+    await useNearbyStore.getState().fetch({
+      latitude: 51.5,
+      longitude: -0.1,
+      radiusKm: 10,
+    });
+    expect(mockNearby.mock.calls[0][0]).toEqual({
+      latitude: 51.5,
+      longitude: -0.1,
+      radiusKm: 10,
+    });
+  });
+
+  it("surfaces server errors without dropping prior results", async () => {
+    useNearbyStore.setState({ results: [ROW] });
+    mockNearby.mockRejectedValueOnce(new Error("HTTP 503 service unavailable"));
+
+    await useNearbyStore.getState().fetch({ latitude: 51.5, longitude: -0.1 });
+    expect(useNearbyStore.getState().error).toContain("503");
+    expect(useNearbyStore.getState().results).toEqual([ROW]);
+    expect(useNearbyStore.getState().isLoading).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/nearby/nearby.store.ts
+++ b/apps/mobile/src/features/nearby/nearby.store.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import type { NearbyInstance } from "@dpf/types";
+import { api } from "@/src/lib/apiClient";
+
+/**
+ * Customer-side "Nearby businesses" store. Calls the public directory
+ * endpoint on demand with a (lat, lng) pair; the install + the future
+ * federation directory both return rows in the same shape. The store
+ * keeps the last fetched list so the panel renders instantly on
+ * re-entry while a background refresh runs.
+ */
+interface NearbyState {
+  results: NearbyInstance[];
+  isLoading: boolean;
+  error: string | null;
+  fetch: (input: {
+    latitude: number;
+    longitude: number;
+    radiusKm?: number;
+  }) => Promise<void>;
+  reset: () => void;
+}
+
+export const useNearbyStore = create<NearbyState>((set) => ({
+  results: [],
+  isLoading: false,
+  error: null,
+
+  fetch: async ({ latitude, longitude, radiusKm }) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.directory.nearby({ latitude, longitude, radiusKm });
+      set({ results: res.results, isLoading: false });
+    } catch (err) {
+      set({
+        isLoading: false,
+        error: err instanceof Error ? err.message : "Nearby lookup failed",
+      });
+    }
+  },
+
+  reset: () => set({ results: [], isLoading: false, error: null }),
+}));

--- a/apps/mobile/src/hooks/useGeolocation.ts
+++ b/apps/mobile/src/hooks/useGeolocation.ts
@@ -1,0 +1,72 @@
+/**
+ * Thin wrapper around expo-location for the Nearby surface — requests
+ * foreground permission once, then returns the device's current position
+ * (or an error). Wrapped in a hook so React components don't need to
+ * branch on permission state directly.
+ *
+ * Tests mock this hook rather than the native module — see
+ * src/features/nearby/nearby.store.test.ts.
+ */
+import { useCallback, useEffect, useState } from "react";
+import * as Location from "expo-location";
+
+export interface GeoLocationState {
+  /** Captured WGS84 position, null until we have one. */
+  latitude: number | null;
+  longitude: number | null;
+  /** Reactive permission state — drives a "Grant location" CTA when "denied". */
+  permission: "granted" | "denied" | "unknown";
+  isFetching: boolean;
+  error: string | null;
+  /** Trigger a permission request + a single fix; safe to call repeatedly. */
+  refresh: () => Promise<void>;
+}
+
+export function useGeolocation(): GeoLocationState {
+  const [latitude, setLatitude] = useState<number | null>(null);
+  const [longitude, setLongitude] = useState<number | null>(null);
+  const [permission, setPermission] = useState<GeoLocationState["permission"]>(
+    "unknown",
+  );
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setIsFetching(true);
+    setError(null);
+    try {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        setPermission("denied");
+        setIsFetching(false);
+        return;
+      }
+      setPermission("granted");
+      const position = await Location.getCurrentPositionAsync({
+        accuracy: Location.Accuracy.Balanced,
+      });
+      setLatitude(position.coords.latitude);
+      setLongitude(position.coords.longitude);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Location unavailable");
+    } finally {
+      setIsFetching(false);
+    }
+  }, []);
+
+  // Try once on first mount. The user can always tap a Refresh action to
+  // re-request if they revoked the permission in iOS Settings between
+  // launches.
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    latitude,
+    longitude,
+    permission,
+    isFetching,
+    error,
+    refresh,
+  };
+}

--- a/apps/web/app/api/v1/directory/nearby/route.test.ts
+++ b/apps/web/app/api/v1/directory/nearby/route.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Contract tests for GET /api/v1/directory/nearby. Geo math is unit-tested
+ * separately in lib/api/nearby-geo.test.ts; these tests cover the public
+ * endpoint's auth-free path, validation, the publicUrl gate, and the
+ * "install too far away → empty results" branch.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockOrgFindFirst, mockStorefrontFindFirst } = vi.hoisted(() => ({
+  mockOrgFindFirst: vi.fn(),
+  mockStorefrontFindFirst: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: { findFirst: mockOrgFindFirst },
+    storefrontConfig: { findFirst: mockStorefrontFindFirst },
+  },
+}));
+
+import { GET } from "./route";
+
+// London (within ~5 km of the seeded install) and Sydney (a continent away).
+const LONDON = { lat: 51.5074, lng: -0.1278 };
+const SYDNEY = { lat: -33.8688, lng: 151.2093 };
+
+const ORG = {
+  orgId: "ORG-ACME",
+  name: "Acme HVAC",
+  industry: "trades",
+  address: { latitude: 51.51, longitude: -0.13, city: "London", region: "UK" },
+};
+
+function req(q: { lat?: number; lng?: number; radiusKm?: number }): Request {
+  const params = new URLSearchParams();
+  if (q.lat !== undefined) params.set("lat", String(q.lat));
+  if (q.lng !== undefined) params.set("lng", String(q.lng));
+  if (q.radiusKm !== undefined) params.set("radiusKm", String(q.radiusKm));
+  return new Request(
+    `https://install.example/api/v1/directory/nearby?${params.toString()}`,
+  );
+}
+
+const originalEnv = process.env.PUBLIC_URL;
+
+beforeEach(() => {
+  mockOrgFindFirst.mockReset();
+  mockStorefrontFindFirst.mockReset();
+  process.env.PUBLIC_URL = "https://acme.example";
+});
+afterEach(() => {
+  process.env.PUBLIC_URL = originalEnv;
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/v1/directory/nearby", () => {
+  it("returns 422 when lat / lng are missing or invalid", async () => {
+    const r1 = await GET(req({ lat: LONDON.lat }));
+    expect(r1.status).toBe(422);
+    const r2 = await GET(req({ lat: 200, lng: 0 }));
+    expect(r2.status).toBe(422);
+    expect(mockOrgFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns this install when its lat/long falls in radius and PUBLIC_URL is set", async () => {
+    mockOrgFindFirst.mockResolvedValueOnce(ORG);
+    mockStorefrontFindFirst.mockResolvedValueOnce({
+      archetypeId: "trades-maintenance/hvac-contractor",
+    });
+
+    const res = await GET(req({ lat: LONDON.lat, lng: LONDON.lng }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{
+        instanceId: string;
+        orgName: string;
+        url: string;
+        archetype?: string;
+        distanceKm: number;
+        locality?: string;
+      }>;
+    };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].instanceId).toBe("ORG-ACME");
+    expect(body.results[0].url).toBe("https://acme.example");
+    expect(body.results[0].archetype).toBe(
+      "trades-maintenance/hvac-contractor",
+    );
+    expect(body.results[0].distanceKm).toBeLessThan(5);
+    expect(body.results[0].locality).toBe("London, UK");
+  });
+
+  it("returns an empty list when the query point is outside the radius", async () => {
+    mockOrgFindFirst.mockResolvedValueOnce(ORG);
+    mockStorefrontFindFirst.mockResolvedValueOnce(null);
+
+    const res = await GET(req({ lat: SYDNEY.lat, lng: SYDNEY.lng }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+  });
+
+  it("returns an empty list when PUBLIC_URL is not configured", async () => {
+    delete process.env.PUBLIC_URL;
+    mockOrgFindFirst.mockResolvedValueOnce(ORG);
+    mockStorefrontFindFirst.mockResolvedValueOnce(null);
+
+    const res = await GET(req({ lat: LONDON.lat, lng: LONDON.lng }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+  });
+
+  it("returns an empty list when the install has no lat/long seeded", async () => {
+    mockOrgFindFirst.mockResolvedValueOnce({
+      ...ORG,
+      address: { city: "London" },
+    });
+    mockStorefrontFindFirst.mockResolvedValueOnce(null);
+
+    const res = await GET(req({ lat: LONDON.lat, lng: LONDON.lng }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+  });
+
+  it("clamps an extreme radius without returning every install on the planet", async () => {
+    mockOrgFindFirst.mockResolvedValueOnce(ORG);
+    mockStorefrontFindFirst.mockResolvedValueOnce(null);
+
+    // 999_999 → clamps to 500 km. The query point is Sydney → London is
+    // ~17_000 km away → still excluded.
+    const res = await GET(req({ lat: SYDNEY.lat, lng: SYDNEY.lng, radiusKm: 999_999 }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+  });
+});

--- a/apps/web/app/api/v1/directory/nearby/route.ts
+++ b/apps/web/app/api/v1/directory/nearby/route.ts
@@ -1,0 +1,97 @@
+// GET /api/v1/directory/nearby?lat=…&lng=…&radiusKm=… — geo-discovery stub.
+//
+// Public (unauthenticated) endpoint that lets a mobile customer's "Nearby"
+// surface discover the install IF its own seeded lat/long falls inside the
+// query radius. This is the single-install path that validates the
+// contract; the hosted federation directory across many installs (Town M5)
+// is a separate epic and reuses this exact wire shape.
+//
+// PUBLIC_URL must be configured for the result row's `url` field to be a
+// reachable target; when it isn't, the row is omitted so the client never
+// sees an unreachable install in the results.
+//
+// Plan: docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md (Slice 6).
+
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { apiSuccess } from "@/lib/api/response";
+import {
+  clampRadiusKm,
+  extractOrgLatLng,
+  haversineKm,
+  parseQueryPoint,
+  roundKm,
+} from "@/lib/api/nearby-geo";
+import type { NearbyInstance, NearbyResponse } from "@dpf/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const query = parseQueryPoint(url.searchParams);
+    if (!query) {
+      return NextResponse.json(
+        {
+          code: "VALIDATION_ERROR",
+          message:
+            "Required query params: lat (-90..90), lng (-180..180). Optional: radiusKm.",
+        },
+        { status: 422 },
+      );
+    }
+    const radiusKm = clampRadiusKm(
+      url.searchParams.get("radiusKm")
+        ? Number(url.searchParams.get("radiusKm"))
+        : undefined,
+    );
+
+    const publicUrl =
+      process.env.PUBLIC_URL?.trim() && process.env.PUBLIC_URL.trim().length > 0
+        ? process.env.PUBLIC_URL.trim()
+        : null;
+
+    const org = await prisma.organization.findFirst({
+      select: { orgId: true, name: true, address: true, industry: true },
+    });
+    const storefront = await prisma.storefrontConfig.findFirst({
+      select: { archetypeId: true },
+    });
+
+    const results: NearbyInstance[] = [];
+
+    const orgPoint = org ? extractOrgLatLng(org.address) : null;
+    const distanceKm = haversineKm(query, orgPoint);
+
+    if (publicUrl && org && orgPoint && distanceKm <= radiusKm) {
+      const row: NearbyInstance = {
+        instanceId: org.orgId,
+        orgName: org.name,
+        url: publicUrl,
+        distanceKm: roundKm(distanceKm),
+      };
+      if (storefront?.archetypeId) row.archetype = storefront.archetypeId;
+      // Locality is best-effort — only populate from the address blob; never
+      // synthesize a label that misrepresents where the install actually is.
+      if (
+        org.address &&
+        typeof org.address === "object" &&
+        !Array.isArray(org.address)
+      ) {
+        const addr = org.address as Record<string, unknown>;
+        const locality = [addr.city, addr.region]
+          .filter((v): v is string => typeof v === "string" && v.length > 0)
+          .join(", ");
+        if (locality) row.locality = locality;
+      }
+      results.push(row);
+    }
+
+    return apiSuccess<NearbyResponse>({ results });
+  } catch {
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/lib/api/nearby-geo.test.ts
+++ b/apps/web/lib/api/nearby-geo.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampRadiusKm,
+  extractOrgLatLng,
+  haversineKm,
+  parseQueryPoint,
+  roundKm,
+} from "./nearby-geo";
+
+describe("haversineKm", () => {
+  // London (51.5074, -0.1278) to Paris (48.8566, 2.3522) ≈ 343.5 km
+  it("computes a known London–Paris distance within 1%", () => {
+    const km = haversineKm(
+      { latitude: 51.5074, longitude: -0.1278 },
+      { latitude: 48.8566, longitude: 2.3522 },
+    );
+    expect(km).toBeGreaterThan(340);
+    expect(km).toBeLessThan(347);
+  });
+
+  it("returns 0 for identical points", () => {
+    const p = { latitude: 40, longitude: -75 };
+    expect(haversineKm(p, p)).toBeCloseTo(0);
+  });
+
+  it("returns Infinity when either endpoint is null", () => {
+    expect(haversineKm(null, { latitude: 0, longitude: 0 })).toBe(Infinity);
+    expect(haversineKm({ latitude: 0, longitude: 0 }, null)).toBe(Infinity);
+  });
+
+  it("returns Infinity for NaN / non-finite coordinates", () => {
+    expect(
+      haversineKm(
+        { latitude: NaN, longitude: 0 },
+        { latitude: 0, longitude: 0 },
+      ),
+    ).toBe(Infinity);
+  });
+});
+
+describe("roundKm", () => {
+  it("rounds to one decimal", () => {
+    expect(roundKm(3.14159)).toBe(3.1);
+    expect(roundKm(2.95)).toBe(3);
+  });
+  it("passes Infinity through", () => {
+    expect(roundKm(Infinity)).toBe(Infinity);
+  });
+});
+
+describe("clampRadiusKm", () => {
+  it("defaults to 25 km for missing / non-positive values", () => {
+    expect(clampRadiusKm(undefined)).toBe(25);
+    expect(clampRadiusKm(0)).toBe(25);
+    expect(clampRadiusKm(-12)).toBe(25);
+    expect(clampRadiusKm(Number.NaN)).toBe(25);
+  });
+  it("clamps to 0.1 .. 500", () => {
+    expect(clampRadiusKm(0.05)).toBe(0.1);
+    expect(clampRadiusKm(1200)).toBe(500);
+    expect(clampRadiusKm(10)).toBe(10);
+  });
+});
+
+describe("parseQueryPoint", () => {
+  function qs(input: string): URLSearchParams {
+    return new URLSearchParams(input);
+  }
+  it("returns null when either coordinate is missing or NaN", () => {
+    expect(parseQueryPoint(qs("lat=51.5"))).toBeNull();
+    expect(parseQueryPoint(qs("lng=-0.1"))).toBeNull();
+    expect(parseQueryPoint(qs("lat=abc&lng=-0.1"))).toBeNull();
+  });
+  it("rejects out-of-range coordinates rather than silently clamping", () => {
+    expect(parseQueryPoint(qs("lat=200&lng=0"))).toBeNull();
+    expect(parseQueryPoint(qs("lat=0&lng=-181"))).toBeNull();
+  });
+  it("accepts the geographic extremes (north/south pole, antimeridian)", () => {
+    expect(parseQueryPoint(qs("lat=90&lng=180"))).toEqual({
+      latitude: 90,
+      longitude: 180,
+    });
+  });
+});
+
+describe("extractOrgLatLng", () => {
+  it("returns null for non-object inputs", () => {
+    expect(extractOrgLatLng(null)).toBeNull();
+    expect(extractOrgLatLng("legacy-string")).toBeNull();
+    expect(extractOrgLatLng(42)).toBeNull();
+  });
+  it("reads canonical { latitude, longitude } pairs", () => {
+    expect(extractOrgLatLng({ latitude: 51.5, longitude: -0.1 })).toEqual({
+      latitude: 51.5,
+      longitude: -0.1,
+    });
+  });
+  it("accepts short aliases (lat / lng / long) so seed conventions work", () => {
+    expect(extractOrgLatLng({ lat: 40, lng: -75 })).toEqual({
+      latitude: 40,
+      longitude: -75,
+    });
+    expect(extractOrgLatLng({ lat: 40, long: -75 })).toEqual({
+      latitude: 40,
+      longitude: -75,
+    });
+  });
+  it("returns null when coordinates are absent / out of range / non-numeric", () => {
+    expect(extractOrgLatLng({ city: "London" })).toBeNull();
+    expect(extractOrgLatLng({ lat: 200, lng: 0 })).toBeNull();
+    expect(extractOrgLatLng({ lat: "north", lng: 0 })).toBeNull();
+  });
+});

--- a/apps/web/lib/api/nearby-geo.ts
+++ b/apps/web/lib/api/nearby-geo.ts
@@ -1,0 +1,99 @@
+/**
+ * Geo helpers for the Nearby directory endpoint — kept separate from the
+ * route so the math is unit-testable without spinning up Prisma.
+ *
+ * Distances are computed via the haversine formula (great-circle distance
+ * on a sphere). DPF's Nearby radii are ≤ 500 km, well inside the regime
+ * where haversine is accurate to < 0.5% even at the equator-vs-poles
+ * Earth-shape edge cases.
+ */
+
+const EARTH_RADIUS_KM = 6371;
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+export interface GeoPoint {
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * Distance in km between two WGS84 points. Returns `Infinity` if either
+ * point is missing valid coordinates, so callers using `<= radiusKm` filter
+ * out malformed rows automatically.
+ */
+export function haversineKm(a: GeoPoint | null, b: GeoPoint | null): number {
+  if (!a || !b) return Infinity;
+  if (
+    !Number.isFinite(a.latitude) ||
+    !Number.isFinite(a.longitude) ||
+    !Number.isFinite(b.latitude) ||
+    !Number.isFinite(b.longitude)
+  ) {
+    return Infinity;
+  }
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+  const h =
+    sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng;
+  const c = 2 * Math.asin(Math.min(1, Math.sqrt(h)));
+  return EARTH_RADIUS_KM * c;
+}
+
+/** Round km to one decimal place — the row-display precision. */
+export function roundKm(km: number): number {
+  if (!Number.isFinite(km)) return km;
+  return Math.round(km * 10) / 10;
+}
+
+/** Clamp the radius to the server's safe operating range. */
+export function clampRadiusKm(input: number | undefined): number {
+  const v = Number(input);
+  if (!Number.isFinite(v) || v <= 0) return 25;
+  return Math.min(Math.max(v, 0.1), 500);
+}
+
+/** Parse + validate { latitude, longitude } from a URL searchParams set. */
+export function parseQueryPoint(
+  params: URLSearchParams,
+): GeoPoint | null {
+  // `URLSearchParams.get` returns `null` when the key is absent and `""`
+  // when present-but-empty. Both are missing for our purposes — and we
+  // must reject before Number() coercion, since Number("") is 0 and would
+  // happily pass a -180..180 range check.
+  const latRaw = params.get("lat");
+  const lngRaw = params.get("lng");
+  if (latRaw == null || latRaw.length === 0) return null;
+  if (lngRaw == null || lngRaw.length === 0) return null;
+  const lat = Number(latRaw);
+  const lng = Number(lngRaw);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat < -90 || lat > 90) return null;
+  if (lng < -180 || lng > 180) return null;
+  return { latitude: lat, longitude: lng };
+}
+
+/**
+ * Extract a latitude/longitude pair from the Organization.address JSON
+ * blob. The Prisma column is `Json?` (free-form) — we accept both top-level
+ * lat/lng and snake-/camel-cased variants so the install operator's seed
+ * can use whichever convention without code changes.
+ */
+export function extractOrgLatLng(addressJson: unknown): GeoPoint | null {
+  if (!addressJson || typeof addressJson !== "object") return null;
+  const obj = addressJson as Record<string, unknown>;
+  const latRaw = (obj.latitude ?? obj.lat) as unknown;
+  const lngRaw = (obj.longitude ?? obj.lng ?? obj.long) as unknown;
+  const lat = typeof latRaw === "number" ? latRaw : Number(latRaw);
+  const lng = typeof lngRaw === "number" ? lngRaw : Number(lngRaw);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat < -90 || lat > 90) return null;
+  if (lng < -180 || lng > 180) return null;
+  return { latitude: lat, longitude: lng };
+}

--- a/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
+++ b/docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md
@@ -1,0 +1,92 @@
+# Plan — End-to-End iOS App Support (Dual-Persona, Install-Driven)
+
+**Date:** 2026-06-18
+**Status:** In-flight — slices merging in sequence
+**Owner:** mobile platform
+**Parent spec:** [`docs/superpowers/specs/2026-06-14-native-mobile-archetype-apps-design.html`](../specs/2026-06-14-native-mobile-archetype-apps-design.html)
+**Related specs:** [Town super-app](../specs/2026-06-14-multi-business-town-super-app-design.html), [Field dispatch contract](../specs/2026-06-14-field-dispatch-mobile-contract-and-warranty-design.html)
+
+## Goal
+
+Close the remaining code gaps between today's mobile substrate and a real, shippable, install-driven iOS app serving both **field-tech (employee)** and **customer** personas.
+
+Owner-only steps (Apple Developer enrollment, Google Play, Expo/EAS account, Firebase + APNs key, physical iPhone, store metadata) are explicitly out of scope for this plan — they cannot be performed by an agent regardless of authorization. They live in the parent spec §9 and Slice 5's operator checklist.
+
+## Slices
+
+### Slice 1 — `WorkItem` → `CustomerAccount` link
+
+Server resolves account from `WorkItem.sourceType` + `sourceId`. Mobile pre-fills the invoice screen's accountId as read-only. **PR #2162.**
+
+### Slice 2 — Customer "My visits" surface
+
+`GET /api/v1/customer/visits` scoped two-hop. Customers see upcoming + recent appointments on Home. **PR #2168.**
+
+### Slice 3 — Job-completion evidence (photos)
+
+`POST /api/v1/work-items/:itemId/evidence` appends to `WorkItem.evidence` JSON. Capture primitive is pluggable. **PR #2181.**
+
+### Slice 4 — Multi-space switcher UX (Town M2)
+
+`SpaceSwitcher` + `/connect` flow + More-tab placement. **PR #2182.**
+
+### Slice 5 — EAS pipeline + mobile CI lane
+
+`eas.json` filled out (4 profiles, submit config); `.github/workflows/mobile-ci.yml` path-filtered. **PR #2183.**
+
+### Slice 6 — Geo-discovery "Nearby" stub (Town M4)
+
+**Status:** This slice — in flight.
+
+Customer-facing geo discovery for the "3 businesses in one app" community vision. Three artifacts:
+
+1. **`GET /api/v1/directory/nearby?lat=…&lng=…&radiusKm=…`** — public (unauthenticated) endpoint. Returns the install IF its own `Organization.address` lat/long falls inside the query radius AND `PUBLIC_URL` is configured (so the row points at a reachable target). Same wire shape (`NearbyResponse` → `NearbyInstance[]`) the future hosted federation directory (Town M5) will return.
+2. **`apps/mobile/src/hooks/useGeolocation.ts`** — thin `expo-location` wrapper that requests foreground permission once and exposes `{ latitude, longitude, permission, isFetching, error, refresh }`.
+3. **`apps/mobile/src/features/nearby/NearbyPanel.tsx`** — customer-mode home panel. On location, fires `api.directory.nearby({lat, lng})`, lists each row with distance; tapping a row pulls the descriptor and connects via the existing `spaces.addSpace` flow before handing off to `/login`.
+
+Single-install path (no federation) validates the contract. Town M5 — hosted directory aggregating many installs — is intentionally a separate epic.
+
+## Reuse map
+
+| Existing substrate | What we lean on |
+|---|---|
+| `WorkItem` model + `/api/v1/work-items` | Slices 1, 3 — append `account` projection + evidence endpoint, no schema migration |
+| `StorefrontBooking` + `CustomerContact` | Slice 2 — two-hop scope |
+| `BrandingConfig.tokens` + install manifest | Already shipped, unchanged |
+| `POST /api/v1/upload` (MediaAsset) | Slice 3 — photos upload through it |
+| `spaces.store` | Slice 4 — UI shell over existing state |
+| `expo-location` (installed) | Slice 6 — geolocation hook |
+| `Organization.address` JSON | Slice 6 — install's own lat/long for the stub |
+| `eas.json` skeleton | Slice 5 — fill in profiles + CI lane |
+
+## Operator-action checklist (Slice 5 cannot finish without these)
+
+These cannot be done by an agent — they require legal identity + accounts:
+
+| Action | Why an agent can't | Cost |
+|---|---|---|
+| Enroll **Apple Developer Program** as **Arcamanus LLC** | legal entity, D-U-N-S, 2FA Apple ID, signed agreements | $99/yr |
+| Create **Google Play Console** account | identity verification, signed agreements | $25 one-time |
+| Create **Expo / EAS** account + org | account auth for cloud builds | free to start |
+| Generate **App Store Connect API key** (`.p8`) | Apple account credential | — |
+| Create **Firebase** project + **APNs Auth Key** | Google/Apple account-bound credentials | free |
+| Reserve **bundle id** on both stores | Apple/Google identity | — |
+| Provide physical iPhone + Android device | hardware for push / biometric / deep-link / store QA | — |
+| TestFlight + Play internal **tester enrollment** | accept builds via your accounts | — |
+| **Privacy policy URL** + data-safety / nutrition labels | legal + marketing decisions + hosted page | — |
+
+## Verification per slice
+
+Each slice carries AGENTS §5 build-gate evidence:
+
+- `pnpm --filter web typecheck` + targeted vitest for any new server route.
+- `pnpm --filter mobile typecheck` + targeted jest for any new mobile store / projection.
+- Native binary UX evidence is deferred until the operator-action checklist lands.
+
+## What this plan does NOT do
+
+- Stand up Apple Developer / Google Play / Expo / Firebase accounts.
+- Generate APNs / FCM credentials.
+- Submit to TestFlight or Play Internal.
+- Touch the Town M5 hosted federation directory (separate epic).
+- Add voice-note or signature capture primitives (follow-up slices).

--- a/packages/api-client/src/endpoints/directory.ts
+++ b/packages/api-client/src/endpoints/directory.ts
@@ -1,0 +1,28 @@
+import type { DpfClient } from "../client";
+import type { NearbyResponse } from "@dpf/types";
+
+/**
+ * Directory endpoints — public geo discovery for the mobile customer
+ * surface. Today single-install (the install reports itself when the
+ * query point is within its radius); the same shape works once the
+ * Town M5 hosted federation directory lands.
+ */
+export function directoryEndpoints(client: DpfClient) {
+  return {
+    nearby: (input: {
+      latitude: number;
+      longitude: number;
+      radiusKm?: number;
+    }) => {
+      const qs = new URLSearchParams();
+      qs.set("lat", String(input.latitude));
+      qs.set("lng", String(input.longitude));
+      if (input.radiusKm !== undefined) {
+        qs.set("radiusKm", String(input.radiusKm));
+      }
+      return client.get<NearbyResponse>(
+        `/api/v1/directory/nearby?${qs.toString()}`,
+      );
+    },
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -13,6 +13,7 @@ import { dynamicEndpoints } from "./endpoints/dynamic";
 import { uploadEndpoints } from "./endpoints/upload";
 import { workItemsEndpoints } from "./endpoints/work-items";
 import { financeEndpoints } from "./endpoints/finance";
+import { directoryEndpoints } from "./endpoints/directory";
 
 export function createApiClient(config: ApiClientConfig) {
   const client = new DpfClient(config);
@@ -30,6 +31,7 @@ export function createApiClient(config: ApiClientConfig) {
     upload: uploadEndpoints(client),
     workItems: workItemsEndpoints(client),
     finance: financeEndpoints(client),
+    directory: directoryEndpoints(client),
   };
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,3 +5,4 @@ export * from "./mobile-manifest";
 export * from "./work-items";
 export * from "./customer-visits";
 export * from "./finance";
+export * from "./nearby";

--- a/packages/types/src/nearby.ts
+++ b/packages/types/src/nearby.ts
@@ -1,0 +1,37 @@
+/**
+ * Geo-discovery ("Nearby") wire types — the customer-facing community
+ * lookup for "what DPF-powered businesses are local to me right now?"
+ *
+ * Today the directory endpoint is install-local (single-org: it returns
+ * THIS install if its own lat/long falls in the queried radius). The
+ * hosted federation directory across many installs is Town M5 — separate
+ * spec, deferred. Shape is forward-compatible: federated entries map onto
+ * the same NearbyInstance row.
+ */
+
+export interface NearbyInstance {
+  /** The install's stable instanceId (matches InstanceDescriptor.instanceId). */
+  instanceId: string;
+  orgName: string;
+  /** Public URL of the install — what the mobile app uses to connect. */
+  url: string;
+  /** Archetype slug (e.g. "trades-maintenance/hvac-contractor"). */
+  archetype?: string;
+  /** Distance in km from the query point, rounded to one decimal. */
+  distanceKm: number;
+  /** Display address line for the row (city + region). */
+  locality?: string;
+}
+
+export interface NearbyQuery {
+  /** Latitude in WGS84 decimal degrees. */
+  latitude: number;
+  /** Longitude in WGS84 decimal degrees. */
+  longitude: number;
+  /** Search radius in km; clamp 0.1–500, server default 25. */
+  radiusKm?: number;
+}
+
+export interface NearbyResponse {
+  results: NearbyInstance[];
+}


### PR DESCRIPTION
## Summary

The customer-side leg of the founder's "3 businesses in one app" community vision. A public `GET /api/v1/directory/nearby` endpoint, a `useGeolocation` hook, and a `NearbyPanel` on customer Home that asks for location, lists DPF-powered businesses in radius, and connects via the existing `spaces.addSpace` flow.

Single-install path today — the install reports itself when its own `Organization.address` lat/long is within the queried radius AND `PUBLIC_URL` is configured. The hosted federation directory across many installs (Town M5) is a separate epic — same wire shape, drop-in.

Plan: [`docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md`](docs/superpowers/plans/2026-06-18-ios-app-end-to-end-support.md) (Slice 6). Spec: [`docs/superpowers/specs/2026-06-14-multi-business-town-super-app-design.html`](docs/superpowers/specs/2026-06-14-multi-business-town-super-app-design.html) (M4).

## Mechanics

- `@dpf/types/nearby.ts` — `NearbyInstance` + `NearbyQuery` + `NearbyResponse`.
- `apps/web/lib/api/nearby-geo.ts` — `haversineKm`, `roundKm`, `clampRadiusKm` (0.1..500), `parseQueryPoint` (range-checked, rejects `""` before Number coercion since `Number("")` is 0), `extractOrgLatLng` (canonical + short-alias keys).
- `apps/web/app/api/v1/directory/nearby/route.ts` — public `GET`. 422 on missing/invalid coords; returns the install IFF lat/long is in the `Organization.address` blob, `PUBLIC_URL` is set, and distance ≤ radius. Locality derived from address.city/region — never synthesized.
- `packages/api-client/endpoints/directory.ts` — `api.directory.nearby()`.
- `apps/mobile/src/hooks/useGeolocation.ts` — `expo-location` wrapper — requests foreground permission once, returns `{ lat, lng, permission, isFetching, error, refresh }`.
- `apps/mobile/src/features/nearby/nearby.store.ts` — zustand store.
- `apps/mobile/src/features/nearby/NearbyPanel.tsx` — customer-mode home panel. Asks for location, lists each result with distance, tap-to-connect routes through `fetchInstanceDescriptor` + `spaces.addSpace` + `/login` (with `/connect` fallback).
- `apps/mobile/app/(tabs)/index.tsx` — customer Home now mounts `CustomerInvoicesPanel` + `CustomerVisitsPanel` + `NearbyPanel`.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/api/nearby-geo app/api/v1/directory` — 21/21 (16 helper + 5 route).
- [x] `pnpm --filter mobile exec jest --testPathPatterns="nearby|customer-invoices|customer-visits|navigation"` — 27/27.
- [x] `pnpm --filter web typecheck` + `pnpm --filter mobile typecheck` — clean.

## What's next (post-slice-6)

All six code slices in the plan are now PR-opened. Remaining is **owner-action only** per the plan's operator checklist:
- Apple Developer + Google Play + Expo/EAS + Firebase enrollment (Arcamanus LLC).
- App Store Connect API key + APNs Auth Key + bundle id reservation.
- Physical iPhone + tester enrollment.
- Privacy policy URL + data-safety labels.

Once those land, the `eas build --profile internal` first-run + TestFlight submit are mechanical follow-ups against the pipeline shipped in Slice 5 (PR #2183).
