### PR TITLE
fix(ea-canvas): organic layout overlap removal + AI-coworker EA-authoring epic spec

### DIFF
--- a/apps/web/lib/ea/canvas-layout.test.ts
+++ b/apps/web/lib/ea/canvas-layout.test.ts
@@ -47,12 +47,7 @@ describe("computeEaLayout", () => {
     });
   }
 
-  it("layered: no two nodes overlap (ELK respects node spacing)", async () => {
-    const result = await computeEaLayout(
-      nodes("a", "b", "c", "d"),
-      [edge("a", "b"), edge("b", "c"), edge("c", "d")],
-      { algorithm: "layered" },
-    );
+  const assertNoOverlap = (result: Record<string, { x: number; y: number }>) => {
     const points = Object.values(result);
     for (let i = 0; i < points.length; i += 1) {
       for (let j = i + 1; j < points.length; j += 1) {
@@ -62,6 +57,33 @@ describe("computeEaLayout", () => {
         expect(overlap).toBe(false);
       }
     }
+  };
+
+  it("layered: no two nodes overlap (ELK respects node spacing)", async () => {
+    assertNoOverlap(
+      await computeEaLayout(
+        nodes("a", "b", "c", "d"),
+        [edge("a", "b"), edge("b", "c"), edge("c", "d")],
+        { algorithm: "layered" },
+      ),
+    );
+  });
+
+  it("organic: no two nodes overlap after the separation pass (dense mesh)", async () => {
+    const ns = nodes("a", "b", "c", "d", "e", "f");
+    const es = [
+      edge("a", "b"), edge("a", "c"), edge("a", "d"), edge("a", "e"), edge("a", "f"),
+      edge("b", "c"), edge("c", "d"), edge("d", "e"), edge("e", "f"), edge("f", "b"),
+    ];
+    assertNoOverlap(await computeEaLayout(ns, es, { algorithm: "organic" }));
+  });
+
+  it("radial: no two nodes overlap (dense star)", async () => {
+    const center = "h";
+    const leaves = Array.from({ length: 14 }, (_, i) => `n${i}`);
+    const ns = nodes(center, ...leaves);
+    const es = leaves.map((l) => edge(center, l));
+    assertNoOverlap(await computeEaLayout(ns, es, { algorithm: "radial" }));
   });
 });
 

--- a/apps/web/lib/ea/canvas-layout.ts
+++ b/apps/web/lib/ea/canvas-layout.ts
@@ -52,12 +52,14 @@ function elkOptionsFor(algo: "organic" | "tree" | "layered"): Record<string, str
   if (algo === "organic") {
     // ELK stress majorization — the clustered, force-directed "organic" look. iterationLimit
     // is capped (ELK's default is effectively unbounded) so big views stay responsive.
+    // desiredEdgeLength is wide (stress treats nodes as points); a separateOverlaps post-pass
+    // then guarantees boxes don't overlap.
     return {
       ...ELK_SHARED,
       "elk.algorithm": "stress",
-      "elk.stress.desiredEdgeLength": String(PITCH_X),
-      "elk.stress.iterationLimit": "200",
-      "elk.spacing.nodeNode": String(GAP),
+      "elk.stress.desiredEdgeLength": String(Math.round(PITCH_X * 1.8)),
+      "elk.stress.iterationLimit": "240",
+      "elk.spacing.nodeNode": String(EA_NODE_W),
     };
   }
   if (algo === "tree") {
@@ -239,6 +241,52 @@ function normalize(positions: EaPositions): EaPositions {
   return out;
 }
 
+const OVERLAP_GAP = 28;
+
+/**
+ * Remove node-box overlaps by minimal axis-aligned separation, preserving the overall
+ * arrangement. Force/stress and the radial packer treat nodes as points, so dense clusters
+ * collide; this pushes overlapping pairs apart on their least-penetrating axis until every
+ * pair clears a readable gap. O(n^2) per pass, iteration-capped — skipped above ~2k nodes.
+ */
+function separateOverlaps(positions: EaPositions, iterations = 30): EaPositions {
+  const ids = Object.keys(positions);
+  if (ids.length < 2 || ids.length > 2000) return positions;
+  const p: EaPositions = {};
+  for (const id of ids) p[id] = { x: positions[id]!.x, y: positions[id]!.y };
+  const minDX = EA_NODE_W + OVERLAP_GAP;
+  const minDY = EA_NODE_H + OVERLAP_GAP;
+  for (let iter = 0; iter < iterations; iter += 1) {
+    let moved = false;
+    for (let a = 0; a < ids.length; a += 1) {
+      for (let b = a + 1; b < ids.length; b += 1) {
+        const A = p[ids[a]!]!;
+        const B = p[ids[b]!]!;
+        let dx = B.x - A.x;
+        let dy = B.y - A.y;
+        const overlapX = minDX - Math.abs(dx);
+        const overlapY = minDY - Math.abs(dy);
+        if (overlapX > 0 && overlapY > 0) {
+          moved = true;
+          if (overlapX <= overlapY) {
+            if (dx === 0) dx = (a + b) % 2 === 0 ? 1 : -1; // break ties deterministically
+            const shift = (overlapX / 2 + 0.5) * (dx < 0 ? -1 : 1);
+            A.x -= shift;
+            B.x += shift;
+          } else {
+            if (dy === 0) dy = (a + b) % 2 === 0 ? 1 : -1;
+            const shift = (overlapY / 2 + 0.5) * (dy < 0 ? -1 : 1);
+            A.y -= shift;
+            B.y += shift;
+          }
+        }
+      }
+    }
+    if (!moved) break;
+  }
+  return normalize(p);
+}
+
 async function runElk(
   nodes: EaLayoutNode[],
   edges: EaLayoutEdge[],
@@ -297,10 +345,12 @@ export async function computeEaLayout(
       centerX: 0,
       centerY: 0,
     });
-    return normalize(fromCenter(result));
+    return separateOverlaps(normalize(fromCenter(result)));
   }
 
-  return runElk(nodes, edges, algo); // organic | tree | layered
+  const positions = await runElk(nodes, edges, algo); // organic | tree | layered
+  // Stress (organic) treats nodes as points and can overlap; layered/mrtree already space.
+  return algo === "organic" ? separateOverlaps(positions) : positions;
 }
 
 function overlaps(a: { x: number; y: number }, b: { x: number; y: number }): boolean {

--- a/docs/superpowers/specs/2026-06-20-ai-coworker-ea-authoring-design.md
+++ b/docs/superpowers/specs/2026-06-20-ai-coworker-ea-authoring-design.md
@@ -1,0 +1,60 @@
+# AI Coworker EA Authoring — Design Spec
+
+**Date:** 2026-06-20 · **Epic:** EP-EA-COWORKER-AUTHORING · **Author:** Claude (operator /goal, Mark) · **Status:** Draft
+
+## Motivation
+
+Mark asked: *"should the AI coworker be able to adjust these things live while looking at the diagram?"* — while reviewing the EA canvas (auto-layout, containment, etc., shipped in #2151/#2161/#2174).
+
+**Answer: yes — as governed editing of the structured model, not pixel co-presence.** An LLM reasons far better over the EA graph (nodes, edges, types, positions, viewpoint rules) than over a rendered screenshot, so "looking at the diagram" is best realized as the coworker reading + writing the structured view, with results reflected on the human's canvas.
+
+## Current substrate (verified 2026-06-20)
+
+- The coworker already has an **EA-architect persona** (`prompts/route-persona/ea-architect.prompt.md`) + architecture-definition/guardrail specialist agents.
+- It can **READ** the architecture graph: `query_ontology_graph`, `export_archimate`, `run_traversal_pattern`, `search_code_graph`.
+- It **cannot edit** the EA canvas: `addElementToView`, `createEaRelationship`, `moveStructuredViewElement`, `saveCanvasState`, `updateProposedProperties` are **UI-only server actions** in `apps/web/lib/actions/ea.ts` — none is exposed as an MCP tool.
+- Governance already exists to lean on: **viewpoint rules** (allowed element/relationship type slugs, enforced in the actions), the **DRAFT→SUBMITTED→APPROVED** lifecycle on `EaView`, `EaSnapshot` (model snapshots), and the **layout revision history** (`CanvasState.history`) + pure layout engines (`computeEaLayout`, `computeContainmentLayout`) shipped in the layout work.
+- Real-time multi-user co-editing was an **explicit EA-2 non-goal** — phase it, don't lead with it.
+
+## Design principles
+
+1. **Edit the model, not pixels.** Coworker operates on view elements / relationships / canvasState via governed capabilities; never "drives" the canvas as a user.
+2. **Governed by construction.** Every edit respects viewpoint rules, honors the view's lifecycle, is **attributed** to the coworker, and is **reversible** (layout → revision history; model → `EaSnapshot` / proposed-mode).
+3. **Reuse, don't rebuild.** Wrap the existing EA actions + layout engines; add an MCP surface, not new layout math or a new persistence model.
+4. **Phased, each shippable.** Stop after any phase.
+
+## Phase 1 — READ: explain / critique a view (lowest risk)
+
+A read-only coworker capability: given a `viewId`, return a structured digest (elements by type, relationships, containment summary, isolated/hub nodes, viewpoint conformance, layout density) so the coworker can **explain or critique** the view ("this view has 57 orphaned data objects; the Auth cluster is dense; consider splitting…").
+
+- **MCP tool** `describe_ea_view(viewId)` (read; authority = `view_ea_modeler`) → JSON digest computed from `getEaView` + `computeMetrics` (already built) + viewpoint rules. No writes.
+- Deliverable: tool + wiring into the EA-architect persona prompt. No canvas change.
+
+## Phase 2 — GOVERN-EDIT: apply model & layout changes
+
+Expose governed MCP tools that wrap the existing actions; each checks authority (`manage_ea_model`), viewpoint rules, and records attribution + a restore point.
+
+- `arrange_ea_view(viewId, algorithm)` — run `computeEaLayout`/`computeContainmentLayout` server-side, push a `CanvasState.history` revision, save. (Reversible by construction.)
+- `add_ea_element(viewId, …)` / `link_ea_elements(viewId, from, to, relType)` — wrap `addElementToView` / `createEaRelationship`; viewpoint-validated; new elements placed via `placeIncremental`.
+- `propose_ea_change(viewElementId, properties)` — wrap `updateProposedProperties` (uses the existing **propose** mode so coworker edits land as proposals, not silent mutations of operational elements).
+- All writes are attributed (a `createdById`/actor field) and emit an audit row; destructive edits require the view be in DRAFT.
+
+## Phase 3 — LIVE REFLECT: real-time canvas updates (optional)
+
+When the human has the view open, reflect coworker edits without a manual reload by pushing a canvas-changed event over the **existing SSE channel** (`useResilientEventSource`); the canvas re-fetches/merges. Still not multi-user co-editing — it's one-way reflection of governed edits. Defer until phases 1–2 prove the value.
+
+## Non-goals
+
+- Multi-user simultaneous co-editing / cursors / presence (EA-2 non-goal).
+- The coworker consuming canvas **screenshots** as primary input (structured graph is higher-signal; a screenshot may be added later only for visual-density judgment).
+- A new persistence model — reuse `canvasState` + `EaSnapshot` + revision history.
+
+## Risks
+
+- **Unbounded edits.** Mitigate with authority gating + viewpoint validation + DRAFT-only destructive edits + reversibility.
+- **Attribution gaps.** Ensure coworker writes carry an actor id and audit trail before enabling Phase 2.
+- **Scale.** `arrange_ea_view` reuses the capped/iteration-bounded layout engines; consider the deferred ELK web worker for 600-node views.
+
+## Phasing → backlog
+
+BI per phase under EP-EA-COWORKER-AUTHORING (read → govern-edit → live-reflect). Phase 1 is the safe first slice.


### PR DESCRIPTION
## Summary

Two things from the live review:

### 1. Fix: organic layout boxes overlap (unreadable)
ELK `stress` (the **Organic** layout) positions nodes to match graph-theoretic distances but treats them as **points** — so dense clusters pulled node boxes on top of each other and `spacing.nodeNode` didn't prevent it. Fix:
- A deterministic **overlap-removal post-pass** (`separateOverlaps`): pushes overlapping pairs apart along their least-penetrating axis until every pair clears a readable gap. Minimal movement, so the organic clustering shape is preserved. Iteration-capped + O(n²) with a ~2k-node guard.
- Applied to **organic** and **radial** (the point-based layouts); `layered`/`tree` already space via ELK and are untouched.
- Wider stress `desiredEdgeLength`/`spacing` for a better starting spread.
- **"No overlap" is now a tested guarantee** for organic (dense mesh) and radial (dense star).

### 2. Spec: AI Coworker EA Authoring (EP-EA-COWORKER-AUTHORING)
Answers "should the coworker adjust diagrams live?" — yes, as **governed editing of the structured model, not pixel co-presence**. Today the EA-architect coworker can *read* the graph but has no MCP write path (the EA edits are UI-only server actions). Spec phases it: **(1) READ** (`describe_ea_view` — explain/critique), **(2) GOVERN-EDIT** (MCP tools wrapping the EA actions: arrange via the shipped layout engine, add/link/propose — viewpoint-validated, attributed, reversible via the new revision history), **(3) LIVE-REFLECT** (push edits over the existing SSE channel). Real-time multi-user co-editing stays a non-goal. Phase BIs filed: BI-B9B77BBF / BI-849F38D1 / BI-EAFE92C3.

## Testing
- `lib/ea/canvas-layout.test.ts`: 32 tests (added organic + radial no-overlap guarantees). Web typecheck clean.

Backlog: overlap fix follows BI-20F95B0E; spec opens **EP-EA-COWORKER-AUTHORING** · Epic context: EP-ARCH-GRAPH-LIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
