### PR TITLE
fix(ea-canvas): keep nested-view edges attached to boxes

### DIFF
--- a/apps/web/components/ea/EaRelationshipEdge.tsx
+++ b/apps/web/components/ea/EaRelationshipEdge.tsx
@@ -8,6 +8,7 @@ import {
   type EdgeProps,
 } from "@xyflow/react";
 import type { SerializedEdge } from "@/lib/ea-types";
+import { resolveAbsolutePositions } from "@/lib/ea/node-geometry";
 
 type EaEdgeData = Pick<SerializedEdge, "relationshipType"> & {
   onDelete?: () => void;
@@ -96,15 +97,21 @@ export function EaRelationshipEdge({ id, source, target, selected, data, markerE
   const nodes = useNodes();
   const allEdges = useEdges();
 
-  // Build nodeInfo map once per nodes update.
+  // Build nodeInfo map once per nodes update. Use ABSOLUTE positions — nested (containment-view)
+  // child nodes store positions relative to their container, so edges must resolve the parent
+  // chain or they detach from the boxes.
   const nodeInfo = useMemo(() => {
+    const absolute = resolveAbsolutePositions(
+      nodes.map((n) => ({ id: n.id, position: n.position, parentId: n.parentId })),
+    );
     const map = new Map<string, NodeInfo>();
     for (const n of nodes) {
       const w = n.measured?.width ?? 150;
       const h = n.measured?.height ?? 60;
+      const pos = absolute.get(n.id) ?? n.position;
       map.set(n.id, {
-        x: n.position.x, y: n.position.y,
-        cx: n.position.x + w / 2, cy: n.position.y + h / 2,
+        x: pos.x, y: pos.y,
+        cx: pos.x + w / 2, cy: pos.y + h / 2,
         w, h,
       });
     }

--- a/apps/web/lib/ea/node-geometry.test.ts
+++ b/apps/web/lib/ea/node-geometry.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { resolveAbsolutePositions } from "./node-geometry";
+
+describe("resolveAbsolutePositions", () => {
+  it("returns flat (top-level) node positions unchanged", () => {
+    const m = resolveAbsolutePositions([
+      { id: "a", position: { x: 10, y: 20 } },
+      { id: "b", position: { x: 30, y: 40 } },
+    ]);
+    expect(m.get("a")).toEqual({ x: 10, y: 20 });
+    expect(m.get("b")).toEqual({ x: 30, y: 40 });
+  });
+
+  it("adds the parent offset for a nested child", () => {
+    const m = resolveAbsolutePositions([
+      { id: "P", position: { x: 100, y: 200 } },
+      { id: "c", position: { x: 5, y: 8 }, parentId: "P" },
+    ]);
+    expect(m.get("c")).toEqual({ x: 105, y: 208 });
+  });
+
+  it("sums offsets across multi-level nesting", () => {
+    const m = resolveAbsolutePositions([
+      { id: "P", position: { x: 100, y: 100 } },
+      { id: "Q", position: { x: 10, y: 10 }, parentId: "P" },
+      { id: "r", position: { x: 1, y: 2 }, parentId: "Q" },
+    ]);
+    expect(m.get("r")).toEqual({ x: 111, y: 112 });
+  });
+
+  it("falls back to the raw position when the parent is missing", () => {
+    const m = resolveAbsolutePositions([{ id: "c", position: { x: 5, y: 5 }, parentId: "ghost" }]);
+    expect(m.get("c")).toEqual({ x: 5, y: 5 });
+  });
+
+  it("terminates on a pathological parent cycle", () => {
+    const m = resolveAbsolutePositions([
+      { id: "a", position: { x: 1, y: 1 }, parentId: "b" },
+      { id: "b", position: { x: 2, y: 2 }, parentId: "a" },
+    ]);
+    expect(m.size).toBe(2);
+  });
+});

--- a/apps/web/lib/ea/node-geometry.ts
+++ b/apps/web/lib/ea/node-geometry.ts
@@ -1,0 +1,34 @@
+// React Flow stores a child node's `position` RELATIVE to its parent container. The floating
+// edge renderer needs ABSOLUTE canvas coordinates to anchor edges on node borders — otherwise
+// edges to nested (containment-view) children detach and bunch near the canvas origin
+// (BI-9E5EA3FF regression). This resolves each node's absolute position by summing the
+// offsets of its parent chain. Flat nodes (no parentId) are returned unchanged.
+
+export type GeomNode = { id: string; position: { x: number; y: number }; parentId?: string };
+
+export function resolveAbsolutePositions(nodes: GeomNode[]): Map<string, { x: number; y: number }> {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const cache = new Map<string, { x: number; y: number }>();
+  const resolving = new Set<string>();
+
+  function abs(node: GeomNode): { x: number; y: number } {
+    const cached = cache.get(node.id);
+    if (cached) return cached;
+    let { x, y } = node.position;
+    const parent = node.parentId ? byId.get(node.parentId) : undefined;
+    if (parent && !resolving.has(node.id)) {
+      resolving.add(node.id); // guard against pathological parent cycles
+      const parentAbs = abs(parent);
+      resolving.delete(node.id);
+      x += parentAbs.x;
+      y += parentAbs.y;
+    }
+    const result = { x, y };
+    cache.set(node.id, result);
+    return result;
+  }
+
+  const out = new Map<string, { x: number; y: number }>();
+  for (const n of nodes) out.set(n.id, abs(n));
+  return out;
+}

--- a/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
+++ b/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
@@ -66,3 +66,9 @@ Operator /goal "do as recommended with the container view" — built the deferre
 - `apps/web/components/ea/EaCanvas.tsx`: a **▦ Nest** toggle (localStorage-persisted, available to read-only too since nothing is saved) swaps the node/edge set to nested boxes (containers + nested leaves; only cross-cutting edges drawn — `contains` becomes nesting). Flat layout controls hidden while nested; flat auto-layout mount-effect guarded.
 
 Tests: 30 adapter (6 containment) + 16 EA component + 52 graph/actions/topology pass; web typecheck clean.
+
+---
+
+## Addendum — 2026-06-20: fix nested-view edge detachment
+
+Live-review regression on the containment view: cross-cutting edges detached from the boxes (bunched near the canvas origin) and didn't follow a container when moved. Cause: the floating `EaRelationshipEdge` built node geometry from `node.position`, which for nested children is **relative to the container** — fine in flat mode (all nodes top-level) but wrong when nested. Fix: new pure `apps/web/lib/ea/node-geometry.ts` `resolveAbsolutePositions` (sums the parent chain, cycle-guarded, unit-tested); `EaRelationshipEdge` now anchors edges on absolute positions, so they stay attached and track container moves (`useNodes()` re-fires on drag). Tests: +5 node-geometry; web typecheck clean.


### PR DESCRIPTION
## Summary

Live-review regression on the containment (Nest) view: **cross-cutting edges detached from the boxes** — they bunched near the top of the canvas and didn't follow a container when it was moved (see the screenshot Mark shared).

**Cause:** the floating `EaRelationshipEdge` computed node geometry from `node.position`. React Flow stores a **child node's position relative to its parent container**, so for nested nodes that value isn't the canvas-absolute position. In flat mode every node is top-level (relative == absolute), which is why only the nested view broke.

**Fix:** resolve absolute positions by summing the parent chain.
- `apps/web/lib/ea/node-geometry.ts` (new): `resolveAbsolutePositions` — pure, cycle-guarded, unit-tested.
- `EaRelationshipEdge` now anchors edges on absolute positions, so they stay attached to the boxes and track container drags (`useNodes()` re-fires on every position change, keeping it reactive).

## Testing
- `lib/ea/node-geometry.test.ts`: 5 tests (flat unchanged, single + multi-level nesting offsets, missing-parent fallback, cycle termination).
- 16 EA component tests pass; `apps/web` typecheck clean.

Backlog: fixes a regression from #2174 (BI-9E5EA3FF) · Epic: EP-ARCH-GRAPH-LIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
