### PR TITLE
feat(build-studio): autonomous build completion via self-upgrade (flag-gated, default OFF)

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   advanceStrandedBuildToReview,
+  reconcileDeployedShipBuilds,
   areOptionalStartupTasksEnabled,
   isInngestSelfSyncOnBootEnabled,
   isStartupModelRevalidationEnabled,
@@ -24,6 +25,10 @@ const featureBuildUpdateManyMock = vi.fn();
 const buildActivityCreateMock = vi.fn();
 const getScopedVerificationForBuildMock = vi.fn();
 const queueBuildReviewVerificationMock = vi.fn();
+const productVersionFindManyMock = vi.fn();
+const changePromotionUpdateManyMock = vi.fn();
+const isFeatureBuildDeployedMock = vi.fn();
+const reconcileBuildCompletionMock = vi.fn();
 
 vi.mock("@/lib/platform/version-config", () => ({
   syncPlatformVersionConfig: (...args: unknown[]) => syncPlatformVersionConfigMock(...args),
@@ -31,6 +36,11 @@ vi.mock("@/lib/platform/version-config", () => ({
 
 vi.mock("@/lib/self-upgrade/completion", () => ({
   getDeployedSha: () => getDeployedShaMock(),
+  isFeatureBuildDeployed: (...args: unknown[]) => isFeatureBuildDeployedMock(...args),
+}));
+
+vi.mock("@/lib/build-flow-state", () => ({
+  reconcileBuildCompletion: (...args: unknown[]) => reconcileBuildCompletionMock(...args),
 }));
 
 vi.mock("@/lib/self-upgrade/run-store", () => ({
@@ -51,6 +61,12 @@ vi.mock("@dpf/db", () => ({
     },
     buildActivity: {
       create: (...args: unknown[]) => buildActivityCreateMock(...args),
+    },
+    productVersion: {
+      findMany: (...args: unknown[]) => productVersionFindManyMock(...args),
+    },
+    changePromotion: {
+      updateMany: (...args: unknown[]) => changePromotionUpdateManyMock(...args),
     },
   },
   // Sentinels — the reconcilers only need identity equality, not real Prisma.
@@ -77,10 +93,62 @@ beforeEach(() => {
   buildActivityCreateMock.mockReset();
   getScopedVerificationForBuildMock.mockReset();
   queueBuildReviewVerificationMock.mockReset();
+  productVersionFindManyMock.mockReset();
+  changePromotionUpdateManyMock.mockReset();
+  isFeatureBuildDeployedMock.mockReset();
+  reconcileBuildCompletionMock.mockReset();
   featureBuildUpdateMock.mockResolvedValue({});
   featureBuildUpdateManyMock.mockResolvedValue({ count: 1 });
   buildActivityCreateMock.mockResolvedValue({});
   queueBuildReviewVerificationMock.mockResolvedValue(undefined);
+  productVersionFindManyMock.mockResolvedValue([]);
+  changePromotionUpdateManyMock.mockResolvedValue({ count: 0 });
+  reconcileBuildCompletionMock.mockResolvedValue(false);
+  delete process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS;
+});
+
+describe("reconcileDeployedShipBuilds — autonomous ship→complete (flag-gated)", () => {
+  afterEach(() => {
+    delete process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS;
+  });
+
+  it("is a no-op (returns null) when the auto-complete flag is off", async () => {
+    delete process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS;
+    const result = await reconcileDeployedShipBuilds({ log: vi.fn(), error: vi.fn() });
+    expect(result).toBeNull();
+    expect(featureBuildFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("completes a ship-phase build once its merged code is live, marking the promotion deployed", async () => {
+    process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS = "1";
+    featureBuildFindManyMock.mockResolvedValue([{ id: "fb-1", buildId: "FB-1" }]);
+    isFeatureBuildDeployedMock.mockResolvedValue(true);
+    productVersionFindManyMock.mockResolvedValue([{ id: "pv-1" }]);
+    changePromotionUpdateManyMock.mockResolvedValue({ count: 1 });
+    reconcileBuildCompletionMock.mockResolvedValue(true);
+
+    const result = await reconcileDeployedShipBuilds({ log: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ completed: 1 });
+    expect(changePromotionUpdateManyMock).toHaveBeenCalledTimes(1);
+    const updateArg = changePromotionUpdateManyMock.mock.calls[0]?.[0] as {
+      data: { status: string };
+    };
+    expect(updateArg.data.status).toBe("deployed");
+    expect(reconcileBuildCompletionMock).toHaveBeenCalledWith("FB-1");
+  });
+
+  it("skips a ship-phase build whose merged code is not live yet", async () => {
+    process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS = "on";
+    featureBuildFindManyMock.mockResolvedValue([{ id: "fb-2", buildId: "FB-2" }]);
+    isFeatureBuildDeployedMock.mockResolvedValue(false);
+
+    const result = await reconcileDeployedShipBuilds({ log: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ completed: 0 });
+    expect(changePromotionUpdateManyMock).not.toHaveBeenCalled();
+    expect(reconcileBuildCompletionMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("warnIfLegacyHiveTokenEnvSet", () => {

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -388,6 +388,85 @@ export async function advanceStrandedBuildToReview(buildId: string): Promise<boo
 }
 
 /**
+ * Periodic ship→complete reconciler for the autonomous-completion path
+ * (operator opt-in via DPF_AUTO_COMPLETE_VERIFIED_BUILDS, default OFF).
+ *
+ * A verified build that reached `ship` — with its forks set up by
+ * `autoResolveShipForks` (community PR pushed + product/promotion registered) —
+ * completes once its merged code is LIVE via the platform self-upgrade (the
+ * deploy the operator already runs; NOT the per-build promoter). This loop
+ * detects that: for each `ship`-phase build whose merged SHA is now in the
+ * deployed runtime (`isFeatureBuildDeployed`), it marks the build's still-open
+ * promotion(s) `deployed` — the self-upgrade WAS the deploy — so the promote
+ * fork becomes terminal, then runs `reconcileBuildCompletion` to advance
+ * ship→complete.
+ *
+ * No-op (and cheap) when the flag is off or no ship build is deployed yet.
+ * Idempotent + non-throwing. Exported for tests.
+ */
+export async function reconcileDeployedShipBuilds(
+  logger: Pick<Console, "log" | "error"> = console,
+): Promise<{ completed: number } | null> {
+  const { isAutoCompleteEnabled } = await import("@/lib/integrate/ship-on-review-approval");
+  if (!isAutoCompleteEnabled()) return null;
+  try {
+    const { prisma } = await import("@dpf/db");
+    const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
+    const { isFeatureBuildDeployed } = await import("@/lib/self-upgrade/completion");
+
+    const shipBuilds = await prisma.featureBuild.findMany({
+      where: { phase: "ship" },
+      select: { id: true, buildId: true },
+    });
+    let completed = 0;
+    for (const build of shipBuilds) {
+      try {
+        if (!(await isFeatureBuildDeployed(build.buildId))) continue;
+        // Merged code is live via self-upgrade → mark the build's still-open
+        // promotion(s) deployed so the promote fork is terminal. The platform
+        // self-upgrade IS the deploy here (the per-build promoter is not used).
+        const pvs = await prisma.productVersion.findMany({
+          where: { featureBuildId: build.id },
+          select: { id: true },
+        });
+        if (pvs.length > 0) {
+          await prisma.changePromotion.updateMany({
+            where: {
+              productVersionId: { in: pvs.map((p) => p.id) },
+              status: { in: ["pending", "approved", "scheduled", "awaiting_operator"] },
+            },
+            data: {
+              status: "deployed",
+              deployedAt: new Date(),
+              rationale: "Deployed via platform self-upgrade (autonomous build completion)",
+            },
+          });
+        }
+        if (await reconcileBuildCompletion(build.buildId)) {
+          completed++;
+          logger.log(
+            `[auto-complete] ${build.buildId} completed — merged code live via self-upgrade`,
+          );
+        }
+      } catch (err) {
+        logger.error(
+          "[auto-complete] ship reconcile failed for %s: %s",
+          JSON.stringify(build.buildId),
+          err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
+        );
+      }
+    }
+    return { completed };
+  } catch (err) {
+    logger.error(
+      "[auto-complete] reconcileDeployedShipBuilds failed: %s",
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
+    );
+    return null;
+  }
+}
+
+/**
  * FIX 2 (spec §3.1 engine-first) — Restart-resume for stranded build rows. The
  * pipeline is dispatched fire-and-forget (`autoExecuteBuild(...).catch(...)`),
  * so a portal recycle silently kills it mid-flight, leaving a row in the `build`
@@ -718,6 +797,10 @@ export async function register() {
     void (async () => {
       await recoverContradictoryBuildExecStatesOnBoot();
       await resumeStrandedBuildsOnBoot();
+      // Complete any ship-phase builds whose merged code went live in the
+      // self-upgrade that just (re)started this portal (autonomous-completion
+      // path; no-op when the flag is off).
+      await reconcileDeployedShipBuilds();
     })();
 
     // Periodic build-resume (cron-independent) — the boot reconcile above runs
@@ -737,6 +820,7 @@ export async function register() {
         void (async () => {
           await recoverContradictoryBuildExecStatesOnBoot();
           await resumeStrandedBuildsOnBoot({ staleAfterMs: 20 * 60 * 1000 });
+          await reconcileDeployedShipBuilds();
         })();
       },
       10 * 60 * 1000,

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -1291,8 +1291,18 @@ export async function shipBuild(input: {
   name: string;
   portfolioSlug: string;
   versionBump?: VersionBump;
+  /**
+   * Explicit actor for autonomous (session-less) ship — the resolved build
+   * owner. When provided, the HTTP-session auth (`requireBuildAccess`) is
+   * skipped, because it throws in a background/reconciler context that has no
+   * session (`auth()` → Unauthorized). The build-ownership check
+   * (`createdById === userId`) below still applies, so a build can only be
+   * shipped by its own creator. UI callers omit this and authenticate via the
+   * session exactly as before — fully backward-compatible.
+   */
+  actorUserId?: string;
 }): Promise<{ productId: string; productInternalId: string; portfolioInternalId: string | null; promotionId: string | null; message: string }> {
-  const userId = await requireBuildAccess();
+  const userId = input.actorUserId ?? await requireBuildAccess();
 
   const build = await prisma.featureBuild.findUnique({ where: { buildId: input.buildId } });
   if (!build) throw new Error("Build not found");

--- a/apps/web/lib/integrate/ship-on-review-approval.test.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.test.ts
@@ -40,6 +40,10 @@ const state = vi.hoisted(() => ({
   reconcileCalls: [] as string[],
   emits: [] as Array<{ threadId: string; evt: Record<string, unknown> }>,
   executeToolCalls: [] as Array<{ tool: string; params: Record<string, unknown> }>,
+  featurePackRow: null as { id: string } | null,
+  productVersionRow: null as { id: string } | null,
+  portfolioRow: { slug: "platform" } as { slug: string } | null,
+  ownerResolveCount: 0,
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -57,7 +61,23 @@ vi.mock("@dpf/db", () => ({
         return {};
       }),
     },
+    featurePack: {
+      findFirst: vi.fn(async () => state.featurePackRow),
+    },
+    productVersion: {
+      findFirst: vi.fn(async () => state.productVersionRow),
+    },
+    portfolio: {
+      findUnique: vi.fn(async () => state.portfolioRow),
+    },
   },
+}));
+
+vi.mock("@/lib/queue/scheduled-owner", () => ({
+  resolveScheduledOwnerUserId: vi.fn(async () => {
+    state.ownerResolveCount++;
+    return "usr_owner";
+  }),
 }));
 
 vi.mock("@/lib/feature-build-types", () => ({
@@ -88,10 +108,16 @@ vi.mock("@/lib/agent-event-bus", () => ({
   },
 }));
 
-import { dispatchShipForVerifiedBuild } from "./ship-on-review-approval";
+import {
+  dispatchShipForVerifiedBuild,
+  autoResolveShipForks,
+  isAutoCompleteEnabled,
+} from "./ship-on-review-approval";
 
-function makeBuild(overrides: Partial<BuildRow> = {}): Record<string, unknown> {
+function makeBuild(overrides: Partial<BuildRow> & { id?: string; portfolioId?: string | null } = {}): Record<string, unknown> {
   return {
+    id: "fb-cuid-1",
+    portfolioId: "pf-1",
     phase: "review",
     diffPatch: "diff --git a/x b/x\n+truncated",
     buildBranch: "build/FB-FD850A2C",
@@ -124,6 +150,11 @@ beforeEach(() => {
   state.reconcileCalls.length = 0;
   state.emits.length = 0;
   state.executeToolCalls.length = 0;
+  state.featurePackRow = null;
+  state.productVersionRow = null;
+  state.portfolioRow = { slug: "platform" };
+  state.ownerResolveCount = 0;
+  delete process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS;
 });
 
 describe("dispatchShipForVerifiedBuild — review→ship loop fix", () => {
@@ -220,5 +251,86 @@ describe("dispatchShipForVerifiedBuild — review→ship loop fix", () => {
 
     expect(out.kind).toBe("skipped");
     expect(state.reconcileCalls).toHaveLength(0); // no completion attempt on a lost race
+  });
+});
+
+describe("isAutoCompleteEnabled — operator opt-in flag (default OFF)", () => {
+  it("is off when the env var is unset", () => {
+    delete process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS;
+    expect(isAutoCompleteEnabled()).toBe(false);
+  });
+
+  it.each(["1", "true", "on", "TRUE", " On "])("is on for %j", (v) => {
+    process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS = v;
+    expect(isAutoCompleteEnabled()).toBe(true);
+  });
+
+  it.each(["0", "false", "off", "", "nope"])("is off for %j", (v) => {
+    process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS = v;
+    expect(isAutoCompleteEnabled()).toBe(false);
+  });
+});
+
+describe("autoResolveShipForks — sets up both ship forks toward autonomous completion", () => {
+  const log = async () => {};
+
+  it("pushes the PR + registers the product, then reconciles, when neither fork exists yet", async () => {
+    state.build = makeBuild({ phase: "ship" });
+    state.featurePackRow = null; // no PR yet
+    state.productVersionRow = null; // not registered yet
+
+    await autoResolveShipForks("FB-SHIP", log);
+
+    const tools = state.executeToolCalls.map((c) => c.tool);
+    expect(tools).toContain("contribute_to_hive");
+    expect(tools).toContain("register_digital_product_from_build");
+    expect(state.reconcileCalls).toContain("FB-SHIP");
+  });
+
+  it("is idempotent — does not re-push the PR when a FeaturePack with a prUrl already exists", async () => {
+    state.build = makeBuild({ phase: "ship" });
+    state.featurePackRow = { id: "pack-1" }; // PR already pushed
+    state.productVersionRow = null;
+
+    await autoResolveShipForks("FB-SHIP", log);
+
+    const tools = state.executeToolCalls.map((c) => c.tool);
+    expect(tools).not.toContain("contribute_to_hive");
+    expect(tools).toContain("register_digital_product_from_build");
+  });
+
+  it("is idempotent — does not re-register when a ProductVersion already exists, but still reconciles", async () => {
+    state.build = makeBuild({ phase: "ship" });
+    state.featurePackRow = { id: "pack-1" };
+    state.productVersionRow = { id: "pv-1" }; // already registered
+
+    await autoResolveShipForks("FB-SHIP", log);
+
+    const tools = state.executeToolCalls.map((c) => c.tool);
+    expect(tools).not.toContain("contribute_to_hive");
+    expect(tools).not.toContain("register_digital_product_from_build");
+    expect(state.reconcileCalls).toContain("FB-SHIP");
+  });
+
+  it("no-ops when the build is not at the ship phase", async () => {
+    state.build = makeBuild({ phase: "review" });
+
+    await autoResolveShipForks("FB-REVIEW", log);
+
+    expect(state.executeToolCalls).toHaveLength(0);
+    expect(state.reconcileCalls).toHaveLength(0);
+  });
+
+  it("resolves the install owner as the actor for an ownerless (system) build", async () => {
+    state.build = makeBuild({ phase: "ship", createdById: null });
+    state.featurePackRow = null;
+    state.productVersionRow = null;
+
+    await autoResolveShipForks("FB-SYS", log);
+
+    expect(state.ownerResolveCount).toBe(1);
+    expect(state.executeToolCalls.map((c) => c.tool)).toContain(
+      "register_digital_product_from_build",
+    );
   });
 });

--- a/apps/web/lib/integrate/ship-on-review-approval.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.ts
@@ -233,18 +233,143 @@ export async function advanceReviewedBuildToShip(
     /* best-effort */
   }
 
-  // If the ship forks are already terminal (private/fork-only mode, or the PR
-  // has merged) AND the deployed runtime carries the merge SHA, finish now.
-  try {
-    const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
-    if (await reconcileBuildCompletion(buildId)) {
-      await log("Ship forks terminal + deployed — advanced ship→complete.");
+  // Resolve the ship forks toward completion. When autonomous completion is
+  // enabled (operator opt-in), set up the forks — push the community PR and
+  // register the product/promotion — so the build completes once its merged
+  // code is live via the platform self-upgrade. Otherwise just attempt
+  // completion in case the forks are already resolved (operator-driven ship).
+  if (isAutoCompleteEnabled()) {
+    await autoResolveShipForks(buildId, log);
+  } else {
+    try {
+      const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
+      if (await reconcileBuildCompletion(buildId)) {
+        await log("Ship forks terminal + deployed — advanced ship→complete.");
+      }
+    } catch (err) {
+      await log(
+        `ship→complete check failed: ${String(err instanceof Error ? err.message : err).slice(0, 200)}`,
+      );
     }
-  } catch (err) {
-    await log(
-      `ship→complete check failed: ${String(err instanceof Error ? err.message : err).slice(0, 200)}`,
-    );
   }
 
   return { kind: "dispatched-success", durationMs: Date.now() - t0 };
+}
+
+/**
+ * Autonomous build completion — operator opt-in, DEFAULT OFF.
+ *
+ * When enabled, a verified build that reaches `ship` auto-resolves its ship
+ * forks (pushes the community PR + registers the product/promotion) and
+ * completes once its merged code is live via the platform self-upgrade (the
+ * deploy you already run — NOT the per-build promoter). Off by default so an
+ * operator enables it deliberately and watches the first autonomous delivery
+ * before leaving it on. This is the "auto-push PR + complete-via-self-upgrade"
+ * path chosen by the operator (2026-06-20).
+ *
+ *   DPF_AUTO_COMPLETE_VERIFIED_BUILDS = "1" | "true" | "on"
+ */
+export function isAutoCompleteEnabled(): boolean {
+  const v = (process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS ?? "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "on";
+}
+
+/**
+ * Set up both ship forks for a build at `ship` so it can complete autonomously:
+ *   - upstream (community PR) via `contribute_to_hive` (idempotent: skipped if a
+ *     PR already exists; a no-op/"install is private" result is fine — the
+ *     upstream fork auto-skips in that mode);
+ *   - promote (product + promotion) via `register_digital_product_from_build`
+ *     (idempotent: skipped if a ProductVersion already exists).
+ * Then attempts completion. reconcileBuildCompletion gates on the forks being
+ * terminal AND the merged SHA being live (`isFeatureBuildDeployed`), so this is
+ * a no-op until the PR merges and the next self-upgrade deploys it — the
+ * periodic ship reconciler (instrumentation.ts) finishes it then. Never throws;
+ * any unresolved fork simply parks the build at `ship` for an operator.
+ */
+export async function autoResolveShipForks(
+  buildId: string,
+  log: (summary: string) => Promise<void>,
+): Promise<void> {
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { id: true, phase: true, title: true, portfolioId: true, createdById: true },
+  });
+  if (!build || build.phase !== "ship") return;
+
+  // Resolve the actor: the build's creator, or the install owner for ownerless
+  // (system-created) builds — mirrors autoDispatchShipForCompletedVerification.
+  let actorUserId = build.createdById;
+  if (!actorUserId) {
+    try {
+      const { resolveScheduledOwnerUserId } = await import("@/lib/queue/scheduled-owner");
+      actorUserId = await resolveScheduledOwnerUserId();
+    } catch {
+      /* fall through to the null guard */
+    }
+  }
+  if (!actorUserId) {
+    await log("auto-complete: no resolvable actor — parked at ship for operator");
+    return;
+  }
+
+  const { executeTool } = await import("@/lib/mcp-tools");
+
+  // ── Upstream fork (community PR) — idempotent: skip if a PR already exists.
+  const existingPack = await prisma.featurePack.findFirst({
+    where: { buildId: build.id, prUrl: { not: null } },
+    select: { id: true },
+  });
+  if (!existingPack) {
+    try {
+      const pr = await executeTool("contribute_to_hive", { buildId }, actorUserId);
+      await log(
+        `auto-complete PR: ${pr.success ? "pushed upstream" : `not pushed — ${String(pr.message ?? pr.error ?? "").slice(0, 140)}`}`,
+      );
+    } catch (err) {
+      await log(`auto-complete PR failed: ${String(err instanceof Error ? err.message : err).slice(0, 140)}`);
+    }
+  }
+
+  // ── Promote fork — register product + promotion. Idempotent: skip if a
+  //    ProductVersion already exists for this build.
+  const existingPv = await prisma.productVersion.findFirst({
+    where: { featureBuildId: build.id },
+    select: { id: true },
+  });
+  if (!existingPv) {
+    let portfolioSlug = "";
+    if (build.portfolioId) {
+      const pf = await prisma.portfolio.findUnique({
+        where: { id: build.portfolioId },
+        select: { slug: true },
+      });
+      portfolioSlug = pf?.slug ?? "";
+    }
+    try {
+      const reg = await executeTool(
+        "register_digital_product_from_build",
+        { buildId, name: build.title, portfolioSlug },
+        actorUserId,
+      );
+      await log(
+        `auto-complete promote: ${reg.success ? "product + promotion registered" : `failed — ${String(reg.message ?? reg.error ?? "").slice(0, 140)}`}`,
+      );
+    } catch (err) {
+      await log(`auto-complete promote failed: ${String(err instanceof Error ? err.message : err).slice(0, 140)}`);
+    }
+  }
+
+  // ── Attempt completion. No-op until the PR is merged AND the self-upgrade
+  //    carries the merge SHA live; the periodic ship reconciler finishes it.
+  try {
+    const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
+    if (await reconcileBuildCompletion(buildId)) {
+      await log("auto-complete: build COMPLETE (merged code live).");
+    } else {
+      await log("auto-complete: forks set up; completes after PR merge + self-upgrade.");
+    }
+  } catch (err) {
+    await log(`auto-complete reconcile failed: ${String(err instanceof Error ? err.message : err).slice(0, 140)}`);
+  }
 }

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7688,6 +7688,10 @@ export async function executeTool(
           name: String(params["name"]),
           portfolioSlug: String(params["portfolioSlug"]),
           versionBump: (params["versionBump"] as "major" | "minor" | "patch") ?? "minor",
+          // Thread the MCP actor through so this works in a session-less context
+          // (autonomous ship from the reconciler). UI callers go through the
+          // session as before; shipBuild falls back to requireBuildAccess().
+          actorUserId: userId,
         });
         return {
           success: true,


### PR DESCRIPTION
## What

Closes the last mile of autonomous Build Studio delivery. After the review→ship loop fix ([#2180](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2180)), verified builds reach `ship` but never `complete`: in `contributionMode=contributing`, completion requires **both** ship forks resolved (a pushed PR **and** a deployed promotion) **and** the merged SHA live in the runtime. The PR-push was a manual gate — which is why nothing has completed in ~5 days (whole cohort parked at ship).

This wires it up **behind an off-by-default switch**:

```
DPF_AUTO_COMPLETE_VERIFIED_BUILDS = "1" | "true" | "on"     # default OFF
```

## How (operator-chosen path, 2026-06-20)

Auto-push PR + **complete-via-self-upgrade** — *not* the per-build `dpf-promoter` (which is live on this install and would really deploy each build). The platform self-upgrade the operator already runs **is** the deploy.

When enabled, a build reaching `ship` (`ship-on-review-approval.ts` → `autoResolveShipForks`):
- **Upstream fork** — pushes the community PR via `contribute_to_hive`. Idempotent (skipped if a `FeaturePack` with a `prUrl` already exists); honors all existing prereqs (DCO accepted, hive token, sandbox readiness, build ownership, private-path stripping).
- **Promote fork** — registers the product + promotion via `register_digital_product_from_build`. Idempotent (skipped if a `ProductVersion` already exists).
- Attempts completion (`reconcileBuildCompletion`).

A **periodic ship reconciler** (`instrumentation.ts`, added to the existing 10-min loop + boot reconcile) finishes the job: for each `ship`-phase build whose merged code is now live (`isFeatureBuildDeployed` — the self-upgrade carried the SHA), it marks the build's still-open promotion(s) `deployed` (the self-upgrade *was* the deploy) so the promote fork is terminal, then completes the build (`ship → complete`).

So end-to-end: build reaches ship → PR pushed + promotion created → PR merges (merge queue) → next **self-upgrade** makes the code live → reconciler completes the build. The operator stays in control via the self-upgrade and the switch.

## Enabler

`shipBuild` gains an optional `actorUserId` so it runs **session-less** (the reconciler is a background `setInterval` with no HTTP session; `requireBuildAccess()` → `auth()` would throw `Unauthorized`). The build-ownership check (`createdById === actor`) still applies, and UI callers are unchanged (omit it → session auth as before). `register_digital_product_from_build` threads the MCP actor through.

## Safety

- **Default OFF.** Nothing fires until an operator sets the env var. Recommend enabling it and **watching the first autonomous delivery** before leaving it on (it pushes real GitHub PRs).
- No per-build promoter / auto-deploy — completion follows the self-upgrade you already run.
- Every step is idempotent + non-throwing; an unresolved fork simply parks the build at `ship` for an operator.

## Tests

- `ship-on-review-approval.test.ts` (+11): flag parsing, idempotent fork setup (skip PR when pack exists, skip register when ProductVersion exists), ownerless-build actor resolution, no-op when not at ship. **22 green.**
- `instrumentation.test.ts` (+3): flag-off no-op, complete-on-deployed (marks promotion deployed + completes), skip-when-not-deployed. **34 green.**
- Scoped typecheck passes (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
