### PR TITLE
feat(ea-coworker): describe_ea_view MCP tool — Phase 1 of EP-EA-COWORKER-AUTHORING (BI-B9B77BBF)

### DIFF
--- a/apps/web/lib/mcp-tools-ea.test.ts
+++ b/apps/web/lib/mcp-tools-ea.test.ts
@@ -11,7 +11,10 @@ vi.mock("@dpf/db", () => ({
   },
 }));
 
+vi.mock("@/lib/ea-data", () => ({ getEaView: vi.fn() }));
+
 import { prisma } from "@dpf/db";
+import { getEaView } from "@/lib/ea-data";
 import { executeTool } from "./mcp-tools";
 
 describe("create_ea_element", () => {
@@ -87,5 +90,44 @@ describe("query_ontology_graph", () => {
     const result = await executeTool("query_ontology_graph", { elementTypeSlugs: ["digital_product"], limit: 5 }, "u-1");
     expect(result.success).toBe(true);
     expect(result.data?.elements).toHaveLength(1);
+  });
+});
+
+describe("describe_ea_view", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns an error when the view is not found", async () => {
+    vi.mocked(getEaView).mockResolvedValue(null as never);
+    const result = await executeTool("describe_ea_view", { viewId: "v-missing" }, "u-1");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ViewNotFound");
+  });
+
+  it("summarizes elements, relationships, containment, and shape", async () => {
+    vi.mocked(getEaView).mockResolvedValue({
+      id: "v-1",
+      name: "Routes",
+      notationSlug: "archimate4",
+      viewpoint: { name: "Decomp", allowedElementTypeSlugs: ["package", "part_definition"] },
+      elements: [
+        { viewElementId: "ve-p", element: { name: "Pkg" }, elementType: { slug: "package", name: "Package" } },
+        { viewElementId: "ve-a", element: { name: "PartA" }, elementType: { slug: "part_definition", name: "Part Definition" } },
+        { viewElementId: "ve-b", element: { name: "PartB" }, elementType: { slug: "part_definition", name: "Part Definition" } },
+      ],
+      edges: [
+        { fromViewElementId: "ve-p", toViewElementId: "ve-a", relationshipType: { slug: "contains", name: "Contains" } },
+        { fromViewElementId: "ve-p", toViewElementId: "ve-b", relationshipType: { slug: "contains", name: "Contains" } },
+      ],
+    } as never);
+
+    const result = await executeTool("describe_ea_view", { viewId: "v-1" }, "u-1");
+    expect(result.success).toBe(true);
+    expect(result.data?.elementCount).toBe(3);
+    expect(result.data?.relationshipCount).toBe(2);
+    expect((result.data?.elementsByType as Record<string, number>)["Part Definition"]).toBe(2);
+    expect((result.data?.containment as { roots: number }).roots).toBe(1);
+    expect(result.data?.shape).toBe("tree");
+    expect(result.data?.nonConformingElements).toBe(0);
+    expect((result.data?.hubs as Array<{ name: string; degree: number }>)[0]?.name).toBe("Pkg");
   });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4477,6 +4477,19 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "view_ea_modeler",
     sideEffect: false,
   },
+  {
+    name: "describe_ea_view",
+    description: "Summarize an EA view so a coworker can explain or critique it (read-only). Returns element counts by type, relationship counts by type, connected components, isolated and highest-degree (hub) nodes, containment structure derived from 'contains' edges, viewpoint conformance, and layout density/shape (tree/forest/mesh). Use before suggesting how to arrange or restructure a view.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        viewId: { type: "string", description: "EaView id to describe" },
+      },
+      required: ["viewId"],
+    },
+    requiredCapability: "view_ea_modeler",
+    sideEffect: false,
+  },
   // ─── Agent Thread Spawning Tools ─────────────────────────────────────────────
   {
     name: "spawn_work_thread",
@@ -14903,6 +14916,104 @@ export async function executeTool(
       });
       if (!result.ok) return { success: false, message: result.error ?? "Traversal failed", error: result.error };
       return { success: true, message: `Traversal complete: ${result.data!.summary.nodesTraversed} nodes`, data: result.data as Record<string, unknown> };
+    }
+
+    case "describe_ea_view": {
+      const viewId = String(params["viewId"] ?? "");
+      if (!viewId) return { success: false, message: "viewId is required", error: "MissingViewId" };
+      const { getEaView } = await import("@/lib/ea-data");
+      const view = await getEaView(viewId);
+      if (!view) return { success: false, message: "View not found", error: "ViewNotFound" };
+
+      const elements = view.elements;
+      const edges = view.edges;
+      const n = elements.length;
+
+      const elementsByType: Record<string, number> = {};
+      for (const el of elements) {
+        elementsByType[el.elementType.name] = (elementsByType[el.elementType.name] ?? 0) + 1;
+      }
+      const relationshipsByType: Record<string, number> = {};
+      for (const e of edges) {
+        relationshipsByType[e.relationshipType.name] = (relationshipsByType[e.relationshipType.name] ?? 0) + 1;
+      }
+
+      // Degree + connected components (union-find) over de-duplicated undirected edges.
+      const index = new Map(elements.map((el, i) => [el.viewElementId, i]));
+      const parent = elements.map((_, i) => i);
+      const find = (x: number): number => {
+        let root = x;
+        while (parent[root] !== root) root = parent[root]!;
+        while (parent[x] !== root) { const next = parent[x]!; parent[x] = root; x = next; }
+        return root;
+      };
+      const degree = new Map<string, number>(elements.map((el) => [el.viewElementId, 0]));
+      const seenPair = new Set<string>();
+      let hasCycle = false;
+      for (const e of edges) {
+        const a = index.get(e.fromViewElementId);
+        const b = index.get(e.toViewElementId);
+        if (a === undefined || b === undefined || a === b) continue;
+        const key = a < b ? `${a}-${b}` : `${b}-${a}`;
+        if (seenPair.has(key)) continue;
+        seenPair.add(key);
+        degree.set(e.fromViewElementId, (degree.get(e.fromViewElementId) ?? 0) + 1);
+        degree.set(e.toViewElementId, (degree.get(e.toViewElementId) ?? 0) + 1);
+        const ra = find(a);
+        const rb = find(b);
+        if (ra === rb) hasCycle = true; else parent[ra] = rb;
+      }
+      const components = new Set(elements.map((_, i) => find(i))).size;
+      const edgeCount = seenPair.size;
+      const nameByVe = new Map(elements.map((el) => [el.viewElementId, el.element.name]));
+      const byDegree = [...degree.entries()].sort((x, y) => y[1] - x[1]);
+      const hubs = byDegree.filter(([, d]) => d > 0).slice(0, 5).map(([ve, d]) => ({ name: nameByVe.get(ve) ?? ve, degree: d }));
+      const isolatedNodes = byDegree.filter(([, d]) => d === 0).length;
+
+      // Containment derived from "contains" edges (parent → child).
+      const childSet = new Set<string>();
+      const containerSet = new Set<string>();
+      for (const e of edges) {
+        if (e.relationshipType.slug !== "contains") continue;
+        containerSet.add(e.fromViewElementId);
+        childSet.add(e.toViewElementId);
+      }
+      const containmentRoots = [...containerSet].filter((id) => !childSet.has(id)).length;
+
+      const allowed = (view.viewpoint as { allowedElementTypeSlugs?: string[] } | null)?.allowedElementTypeSlugs ?? null;
+      const nonConformingElements = allowed
+        ? elements.filter((el) => !allowed.includes(el.elementType.slug)).length
+        : null;
+
+      const density = n > 0 ? Number((edgeCount / n).toFixed(2)) : 0;
+      const shape = edgeCount === 0
+        ? "no relationships"
+        : !hasCycle
+        ? (components === 1 ? "tree" : "forest")
+        : density > 1.5
+        ? "dense mesh"
+        : "general graph";
+
+      return {
+        success: true,
+        message: `View "${view.name}" — ${n} elements, ${edgeCount} relationships, ${components} component(s); shape: ${shape}${isolatedNodes ? `, ${isolatedNodes} isolated` : ""}.`,
+        data: {
+          viewId,
+          name: view.name,
+          viewpoint: view.viewpoint?.name ?? null,
+          elementCount: n,
+          relationshipCount: edgeCount,
+          elementsByType,
+          relationshipsByType,
+          connectedComponents: components,
+          isolatedNodes,
+          hubs,
+          containment: { containerCount: containerSet.size, roots: containmentRoots },
+          nonConformingElements,
+          densityEdgesPerNode: density,
+          shape,
+        },
+      };
     }
 
     // ── EA file tools ─────────────────────────────────────────────────────────

--- a/docs/superpowers/specs/2026-06-20-ai-coworker-ea-authoring-design.md
+++ b/docs/superpowers/specs/2026-06-20-ai-coworker-ea-authoring-design.md
@@ -27,8 +27,10 @@ Mark asked: *"should the AI coworker be able to adjust these things live while l
 
 A read-only coworker capability: given a `viewId`, return a structured digest (elements by type, relationships, containment summary, isolated/hub nodes, viewpoint conformance, layout density) so the coworker can **explain or critique** the view ("this view has 57 orphaned data objects; the Auth cluster is dense; consider splitting…").
 
-- **MCP tool** `describe_ea_view(viewId)` (read; authority = `view_ea_modeler`) → JSON digest computed from `getEaView` + `computeMetrics` (already built) + viewpoint rules. No writes.
+- **MCP tool** `describe_ea_view(viewId)` (read; authority = `view_ea_modeler`) → JSON digest computed from `getEaView` + viewpoint rules. No writes.
 - Deliverable: tool + wiring into the EA-architect persona prompt. No canvas change.
+
+**Status: SHIPPED (BI-B9B77BBF).** `describe_ea_view` is registered in `apps/web/lib/mcp-tools.ts` (def + `executeTool` case) and tested in `mcp-tools-ea.test.ts`. The digest returns element/relationship counts by type, connected components, isolated + hub (highest-degree) nodes, containment structure (containers + roots from `contains` edges), viewpoint conformance, and density/shape (tree/forest/mesh). No persona-prompt edit was needed — the EA-architect persona surfaces MCP tools by description rather than an enumerated list, so registration is sufficient for the coworker to discover and use it.
 
 ## Phase 2 — GOVERN-EDIT: apply model & layout changes
 


### PR DESCRIPTION
## Summary

Phase 1 of **EP-EA-COWORKER-AUTHORING** — the first slice of letting the AI coworker work with EA diagrams. This is the **read-only** capability: the EA-architect coworker can now *explain or critique* a view, operating on the **structured graph** (not screenshots).

New MCP tool **`describe_ea_view(viewId)`** (authority `view_ea_modeler`, no writes) returns a digest:
- element counts by type, relationship counts by type
- connected components, isolated nodes, and the highest-degree **hub** nodes
- **containment** structure (container count + roots, derived from `contains` edges)
- **viewpoint conformance** (elements whose type isn't allowed by the view's viewpoint)
- **density + shape** classification (tree / forest / dense mesh / general graph)

So the coworker can say things like *"this view is a 615-node tree with one hub and 57 orphaned data objects; consider the Tree layout and splitting the Auth cluster."* It reuses `getEaView`; no canvas change.

Registration is sufficient for the coworker to use it — the EA-architect persona surfaces MCP tools by description, not an enumerated list (so no prompt edit needed).

## Testing
- `mcp-tools-ea.test.ts`: not-found error + a digest test (counts, containment roots, tree shape, hub ordering, viewpoint conformance). 8 EA MCP tests pass; `apps/web` typecheck clean.

Backlog: **BI-B9B77BBF** · Epic: **EP-EA-COWORKER-AUTHORING**. Phases 2 (governed edits) and 3 (live reflect) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
