### PR TITLE
fix(routing): local DMR coder model wrongly flagged non-tool-capable (BI-B6DEBFFE)

### DIFF
--- a/apps/web/lib/inference/ai-provider-internals.test.ts
+++ b/apps/web/lib/inference/ai-provider-internals.test.ts
@@ -18,6 +18,7 @@ import {
   buildAutoDiscoveryEvalEvents,
   extractTokenUsage,
   providerHasConfiguredCredential,
+  resolveSyncedToolUse,
 } from "./ai-provider-internals";
 
 describe("extractTokenUsage", () => {
@@ -111,5 +112,82 @@ describe("providerHasConfiguredCredential", () => {
     expect(await providerHasConfiguredCredential("p", "oauth2_client_credentials")).toBe(true);
     credState.row = { secretRef: null, clientSecret: null, cachedToken: null, refreshToken: null };
     expect(await providerHasConfiguredCredential("p", "oauth2_client_credentials")).toBe(false);
+  });
+});
+
+describe("resolveSyncedToolUse (sticky-false trap — BI-B6DEBFFE)", () => {
+  it("provider floor of false floors everything", () => {
+    expect(
+      resolveSyncedToolUse({
+        providerToolFloor: false,
+        extractedToolUse: true,
+        existing: { profileSource: "evaluated", supportsToolUse: true, capabilityOverrides: { toolUse: true } },
+      }),
+    ).toBe(false);
+  });
+
+  it("admin override wins over a stale stored false (the live qwen3-coder relief)", () => {
+    expect(
+      resolveSyncedToolUse({
+        providerToolFloor: true,
+        extractedToolUse: null,
+        existing: { profileSource: "evaluated", supportsToolUse: false, capabilityOverrides: { toolUse: true } },
+      }),
+    ).toBe(true);
+  });
+
+  it("admin override can also pin OFF a capable model", () => {
+    expect(
+      resolveSyncedToolUse({
+        providerToolFloor: true,
+        extractedToolUse: true,
+        existing: { profileSource: "seed", supportsToolUse: true, capabilityOverrides: { toolUse: false } },
+      }),
+    ).toBe(false);
+  });
+
+  it("HEALS a stale discovery-owned false when the adapter now extracts true (the core bug)", () => {
+    // qwen3-coder: stored false from before the adapter recognised the coder family,
+    // seed/auto-discover profile, no override. The fresh true must win — previously
+    // the existing===false branch re-pinned it false forever.
+    expect(
+      resolveSyncedToolUse({
+        providerToolFloor: true,
+        extractedToolUse: true,
+        existing: { profileSource: "seed", supportsToolUse: false, capabilityOverrides: null },
+      }),
+    ).toBe(true);
+  });
+
+  it("a measured eval (no override) is NOT clobbered by a low-confidence re-discovery", () => {
+    // An evaluated profile that legitimately measured non-tool-use keeps its value
+    // when the optimistic adapter prior disagrees and there is no admin override.
+    expect(
+      resolveSyncedToolUse({
+        providerToolFloor: true,
+        extractedToolUse: true,
+        existing: { profileSource: "evaluated", supportsToolUse: false, capabilityOverrides: null },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps an embedding model false (adapter extracts a definitive false)", () => {
+    expect(
+      resolveSyncedToolUse({
+        providerToolFloor: true,
+        extractedToolUse: false,
+        existing: { profileSource: "seed", supportsToolUse: false, capabilityOverrides: null },
+      }),
+    ).toBe(false);
+  });
+
+  it("unknown with no signal falls back to the provider floor, not false", () => {
+    expect(
+      resolveSyncedToolUse({
+        providerToolFloor: true,
+        extractedToolUse: null,
+        existing: null,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -20,6 +20,65 @@ import {
   canQueueBackgroundModelEvals,
 } from "@/lib/routing/provider-eligibility";
 
+/**
+ * Resolve the `supportsToolUse` value a metadata-sync should persist for a model,
+ * given the provider floor, the freshly-extracted adapter value, and the existing
+ * stored profile. Pure + exported for unit tests.
+ *
+ * Precedence (BI-B6DEBFFE — closes the "sticky false" trap that permanently pinned a
+ * once-false local model, e.g. qwen3-coder, as non-tool-capable on every re-sync):
+ *   1. provider-level false       — hard backend floor (no model can exceed it)
+ *   2. admin field-level override — capabilityOverrides.toolUse is the ONLY durable
+ *                                   manual pin, in either direction
+ *   3. manual profile (evaluated/admin) — preserve the measured/decided value so a
+ *      low-confidence re-discovery never clobbers a real eval
+ *   4. fresh definitive extracted value — discovery-owned (seed/auto-discover)
+ *      profiles HEAL a stale/incorrect stored `false` on re-sync
+ *   5. existing stored value, else provider floor, else null (unknown — NOT false;
+ *      never permanently disables tools on an undiscovered model)
+ *
+ * The old inline chain pinned ANY existing `false` (step 2 was `existing===false`),
+ * so once a model was wrongly stored false it could never recover from discovery —
+ * only an admin override or a successful eval could flip it. A deliberate non-tool
+ * pin now lives in capabilityOverrides, not the raw column.
+ */
+export function resolveSyncedToolUse(input: {
+  providerToolFloor: boolean | null | undefined;
+  extractedToolUse: boolean | null | undefined;
+  existing: {
+    profileSource: string | null;
+    supportsToolUse: boolean | null;
+    capabilityOverrides: unknown;
+  } | null;
+}): boolean | null {
+  const { providerToolFloor, extractedToolUse, existing } = input;
+
+  // 1. Hard backend floor — a provider that cannot do tools floors every model.
+  if (providerToolFloor === false) return false;
+
+  // 2. Admin field-level override — authoritative manual pin in either direction.
+  const overrides = existing?.capabilityOverrides as Record<string, unknown> | null | undefined;
+  if (overrides && typeof overrides === "object" && "toolUse" in overrides) {
+    return overrides.toolUse as boolean;
+  }
+
+  // 3. A measured/admin decision is authoritative — re-discovery must not clobber it.
+  const isManuallySet =
+    existing?.profileSource === "evaluated" || existing?.profileSource === "admin";
+  if (isManuallySet) {
+    return existing!.supportsToolUse ?? extractedToolUse ?? providerToolFloor ?? null;
+  }
+
+  // 4. Discovery-owned: a fresh, definitive extracted value wins, so a stale or
+  //    incorrect stored `false` self-heals on the next sync.
+  if (extractedToolUse !== null && extractedToolUse !== undefined) {
+    return extractedToolUse;
+  }
+
+  // 5. No fresh signal: keep the existing value, else the provider floor, else unknown.
+  return existing?.supportsToolUse ?? providerToolFloor ?? null;
+}
+
 // ─── Shared helpers (exported for use by ai-providers.ts server actions) ─────
 
 /** Decrypt the API key / client secret for a provider (server-only).
@@ -681,7 +740,7 @@ export async function profileModelsInternal(
     // EP-INF-003: Drift detection — check if provider metadata changed
     const existingProfile = await prisma.modelProfile.findUnique({
       where: { providerId_modelId: { providerId, modelId: m.modelId } },
-      select: { rawMetadataHash: true, profileSource: true, supportsToolUse: true },
+      select: { rawMetadataHash: true, profileSource: true, supportsToolUse: true, capabilityOverrides: true },
     });
     const driftDetected = existingProfile?.rawMetadataHash != null
       && existingProfile.rawMetadataHash !== card.rawMetadataHash;
@@ -706,28 +765,25 @@ export async function profileModelsInternal(
     }
 
     // EP-INF-003: ModelCard metadata fields — always safe to overwrite on re-sync.
-    // supportsToolUse uses a fallback chain:
-    //   1. provider-level false — hard backend floor
-    //   2. existing DB false — explicit profile-level floor
-    //   3. extracted value (non-null) — authoritative from provider metadata
-    //   4. existing DB value when profileSource is evaluated/admin — preserves manual overrides
-    //   5. provider-level supportsToolUse flag — permissive provider fallback
-    //   6. null — unknown (not false); prevents permanent tool disabling on undiscovered models
-    const providerToolFloor = provider!.supportsToolUse;
-    const extractedToolUse = card.capabilities.toolUse;
-    const isManuallySet = existingProfile?.profileSource === "evaluated" || existingProfile?.profileSource === "admin";
-    const resolvedToolUse = providerToolFloor === false
-      ? false
-      : existingProfile?.supportsToolUse === false
-      ? false
-      : extractedToolUse !== null && extractedToolUse !== undefined
-      ? extractedToolUse
-      : isManuallySet
-        ? (existingProfile.supportsToolUse ?? providerToolFloor ?? null)
-        : (providerToolFloor ?? null);
-    const resolvedCapabilities = providerToolFloor === false || existingProfile?.supportsToolUse === false
-      ? { ...card.capabilities, toolUse: false }
-      : card.capabilities;
+    // supportsToolUse precedence lives in the pure resolveSyncedToolUse helper so the
+    // "sticky false" trap (BI-B6DEBFFE) is unit-tested and can never silently re-pin a
+    // healed model. A deliberate non-tool pin lives in capabilityOverrides, not the raw
+    // column, so a stale/incorrect discovery-owned `false` self-heals on re-sync.
+    const resolvedToolUse = resolveSyncedToolUse({
+      providerToolFloor: provider!.supportsToolUse,
+      extractedToolUse: card.capabilities.toolUse as boolean | null | undefined,
+      existing: existingProfile
+        ? {
+            profileSource: existingProfile.profileSource,
+            supportsToolUse: existingProfile.supportsToolUse,
+            capabilityOverrides: existingProfile.capabilityOverrides,
+          }
+        : null,
+    });
+    // Keep capabilities.toolUse consistent with the resolved boolean so the two
+    // capability representations can never disagree (the original defect surfaced as a
+    // row with capabilities.toolUse=false yet toolFidelity=100).
+    const resolvedCapabilities = { ...card.capabilities, toolUse: resolvedToolUse };
 
     const metadataFields = {
       modelFamily: card.modelFamily,

--- a/apps/web/lib/routing/adapter-ollama.test.ts
+++ b/apps/web/lib/routing/adapter-ollama.test.ts
@@ -167,6 +167,31 @@ describe("ollamaAdapter", () => {
       });
     });
 
+    // ── Capabilities driven by the shared local-model prior (BI-B6DEBFFE) ──
+    // The adapter must agree with deriveLocalModelCapabilityPrior (the same prior
+    // the seed uses): coder/chat models are tool-capable; embedding models are not.
+    // Regression guard for the bug where the installed coder model (qwen3-coder)
+    // was flagged non-tool-capable while the embedding model (nomic-embed) was
+    // flagged tool-capable.
+    describe("capabilities — local prior (coder vs embedding)", () => {
+      it("flags qwen3-coder tool-capable (was the missed family)", () => {
+        const card = ollamaAdapter.extractModelCard("docker.io/ai/qwen3-coder:latest", {});
+        expect(card.capabilities.toolUse).toBe(true);
+        expect(card.capabilities.structuredOutput).toBe(true);
+      });
+
+      it("flags qwen2.5-coder tool-capable", () => {
+        const card = ollamaAdapter.extractModelCard("ai/qwen2.5-coder:7B", {});
+        expect(card.capabilities.toolUse).toBe(true);
+      });
+
+      it("flags an embedding model NOT tool-capable (definitive false, not null)", () => {
+        const card = ollamaAdapter.extractModelCard("docker.io/ai/nomic-embed-text-v1.5:latest", {});
+        expect(card.capabilities.toolUse).toBe(false);
+        expect(card.capabilities.structuredOutput).toBe(false);
+      });
+    });
+
     // ── modelFamily extraction ────────────────────────────────────────
 
     describe("modelFamily extraction", () => {

--- a/apps/web/lib/routing/adapter-ollama.ts
+++ b/apps/web/lib/routing/adapter-ollama.ts
@@ -13,6 +13,7 @@ import {
 } from "./model-card-types";
 import { classifyModel } from "./model-classifier";
 import { computeMetadataHash } from "./metadata-hash";
+import { deriveLocalModelCapabilityPrior } from "@dpf/db/local-model-capabilities";
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -29,29 +30,15 @@ function extractModelFamily(modelId: string): string | null {
   return colon > 0 ? bare.substring(0, colon) : bare || null;
 }
 
-/**
- * Known model families that support tool/function calling via the
- * OpenAI-compatible API. These models return proper `tool_calls` in
- * their responses when tools are provided in the request.
- *
- * This is necessary because Docker Model Runner and Ollama don't
- * advertise per-model capabilities — we must infer from the model name.
- */
-const TOOL_CAPABLE_FAMILIES = new Set([
-  "llama3.1", "llama3.2", "llama3.3", "llama4",
-  "qwen2.5", "qwen3",
-  "mistral", "mixtral", "mistral-small", "mistral-nemo",
-  "gemma2", "gemma3", "gemma4",
-  "phi4",
-  "command-r",
-  "deepseek-v2", "deepseek-v3",
-]);
-
-function isToolCapableFamily(modelId: string): boolean {
-  const family = extractModelFamily(modelId);
-  if (!family) return false;
-  return TOOL_CAPABLE_FAMILIES.has(family.toLowerCase());
-}
+// Tool/function-calling capability for locally-served models is derived from the
+// SINGLE shared prior `deriveLocalModelCapabilityPrior` (@dpf/db/local-model-capabilities)
+// — the same function the seed uses (packages/db/src/seed.ts). Docker Model Runner
+// and Ollama don't advertise per-model capabilities, so it is inferred from the
+// model family. Keeping ONE prior for both the seed and this discovery adapter
+// closes the seed-vs-runtime fork that wrongly flagged the installed coder model
+// (qwen3-coder) non-tool-capable while leaving the embedding model (nomic-embed)
+// tool-capable (BI-B6DEBFFE). The old local allowlist (qwen2.5/qwen3 but not
+// qwen3-coder; phi4 but not phi3) lived here and disagreed with the prior.
 
 /**
  * Local models are free.
@@ -101,6 +88,7 @@ export const ollamaAdapter: ProviderAdapter = {
     const raw = rawMetadata as Record<string, unknown>;
     const bareId = extractModelFamily(modelId) ?? modelId;
     const created = typeof raw.created === "number" ? new Date(raw.created * 1000) : null;
+    const prior = deriveLocalModelCapabilityPrior(modelId);
 
     return {
       providerId: "ollama",
@@ -123,7 +111,13 @@ export const ollamaAdapter: ProviderAdapter = {
 
       capabilities: {
         ...EMPTY_CAPABILITIES,
-        ...(isToolCapableFamily(modelId) ? { toolUse: true, structuredOutput: true } : {}),
+        // Definitive booleans from the shared prior (never null): a coder/chat model
+        // resolves toolUse=true, an embedding model resolves toolUse=false. Emitting an
+        // explicit false (rather than leaving it null) stops the permissive
+        // provider-floor fallback in metadata-sync from making an embedding model
+        // tool-capable.
+        toolUse: prior.supportsToolUse,
+        structuredOutput: prior.supportsToolUse,
       },
       pricing: { ...LOCAL_FREE_PRICING },
 

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -85,10 +85,11 @@ export function getExclusionReasonV2(
 
   // Required capabilities — tools.
   // Use ep.supportsToolUse (the resolved fallback chain from loader.ts) rather than
-  // ep.capabilities.toolUse directly, because the capabilities JSON blob may not
-  // have toolUse set even when the model is known to support tools (e.g. gemma4
-  // via TOOL_CAPABLE_FAMILIES in adapter-ollama.ts writes supportsToolUse: true
-  // to the ModelProfile but doesn't populate capabilities.toolUse in the JSON blob).
+  // ep.capabilities.toolUse directly: the capabilities JSON blob may lag the resolved
+  // boolean. For local models the discovery adapter derives both from the shared
+  // deriveLocalModelCapabilityPrior (@dpf/db/local-model-capabilities) — the same
+  // prior the seed uses — so a coder model (qwen3-coder) resolves supportsToolUse: true
+  // and an embedding model (nomic-embed) resolves false.
   if (contract.requiresTools && !ep.supportsToolUse) {
     return "Missing required capability: toolUse";
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
     "./discovery-collectors-arp-scan": "./src/discovery-collectors/arp-scan.ts",
     "./discovery-collectors-snmp": "./src/discovery-collectors/snmp.ts",
     "./discovery-collectors-unifi": "./src/discovery-collectors/unifi.ts",
+    "./local-model-capabilities": "./src/local-model-capabilities.ts",
     "./location-normalize": "./src/location-normalize.ts",
     "./eu-jurisdictions": "./src/eu-jurisdictions.ts",
     "./sovereignty-assessment": "./src/sovereignty-assessment.ts",


### PR DESCRIPTION
## Symptom (operator-reported, AI Workforce view)
Coworker chat returns **"No AI model that supports tools is active right now"** (and "The AI providers are momentarily busy"), while the **Docker Model Runner** provider page shows `qwen3-coder` with a green **"Tool Use"** badge. The contradiction was confusing — and it blocked *every* coworker, since with no tool-capable model the agentic loop can't run tools.

## Root cause — three disagreeing capability sources
| Source | Value for qwen3-coder | Read by |
|---|---|---|
| Hardcoded `CATALOG` in `OllamaManagement.tsx` | **true** (correct) | the UI badge |
| `ModelProfile.supportsToolUse` (`loader.resolveToolUse` → `pipeline-v2.ts:92`) | **false** (wrong) | the **router** |
| `deriveLocalModelCapabilityPrior` (qwen-coder ⇒ true) | **true** (correct) | the **seed only** |

The router gates on `ModelProfile.supportsToolUse`; the live row was `false` (yet `toolFidelity=100` — internally contradictory), so routing returned `No eligible endpoints … toolUse` → `describeToolRouteFailure` → the coworker message. Two compounding bugs:

1. **Adapter family gap** — `adapter-ollama.ts` `TOOL_CAPABLE_FAMILIES` had `qwen3` but not `qwen3-coder` (and `phi4` but not `phi3`), so discovery extracted `toolUse=null`; the permissive provider-floor fallback then made even the **embedding** model (`nomic-embed`) tool-capable.
2. **Sticky-false trap** — `ai-provider-internals.ts` re-pinned *any* existing `false` on every metadata-sync (`existing===false ? false`), so a wrong value could never heal.

The correct prior existed but was applied **only in the seed**, never on the runtime metadata-sync path → a seed-vs-runtime fork.

## Fix
- **`adapter-ollama.ts`** — derive local tool/structured-output capability from the **single shared prior** `deriveLocalModelCapabilityPrior` (the same fn the seed uses), emitting a *definitive* boolean (coder ⇒ true, embedding ⇒ false). Closes the fork.
- **`@dpf/db`** — expose the prior as a clean subpath (`./local-model-capabilities`).
- **`ai-provider-internals.ts`** — extract pure, unit-tested `resolveSyncedToolUse()`: a deliberate non-tool pin now lives in `capabilityOverrides`, so a stale *discovery-owned* `false` self-heals on re-sync while a *measured eval* is preserved. `capabilities.toolUse` now mirrors the resolved boolean.
- **`pipeline-v2.ts`** — refresh the stale comment.

## Immediate live relief (already applied on the running install)
Set `qwen3-coder` `capabilityOverrides={"toolUse":true}` (+ column/caps) and corrected `nomic-embed` to non-tool. Verified with `resolve_model_selection`: verdict **all-local**, **0 endpoints excluded**, qwen3-coder ranked for all phases. `resolveToolUse` honours the override (step 1), so it survives re-sync until this deploys.

## Tests
- `adapter-ollama.test.ts` — qwen3-coder/qwen2.5-coder ⇒ toolUse true; embedding ⇒ definitive false.
- `ai-provider-internals.test.ts` — `resolveSyncedToolUse` precedence (override wins, stale discovery false heals, measured eval preserved, embedding stays false).

## Verification substrate
Source-only worktree (`.pnpm` empty) — local typecheck/build/tests could not run here; **CI gates** them. Live routing behaviour verified via `resolve_model_selection` against the running install.

## Follow-ups (separate concern, not in this PR)
`resolve_model_selection` also flags `embedding-model-first` for the OpenCode **build** phase (it picks the first served DMR model); and the AI Workforce **corpus%/blockers** measures are read-only dead-ends — tracked separately under EP-COWORKER-RT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)