### PR TITLE
chore(ci): shift-left guard for the decision baseline (prevent late golden-decisions catches)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -152,6 +152,31 @@ if [ -n "$STAGED_SCHEMA" ]; then
   fi
 fi
 
+# ─── Guard 6: decision baseline (golden-decisions) ──────────────────────────
+# When a founder-kernel principle is staged, a new/edited principleDimensionVector
+# (or principleWeight) can perturb the canonical decision baseline below its margin
+# floor — a commandment loads into EVERY principle_decide call. PR #2157 only
+# surfaced this at merge_group after hours of queue churn. Run the vitest-free
+# scorer over the working-tree corpus so the regression is caught at commit. CI
+# re-runs it against the merge-state corpus. Override (verified only):
+# DPF_SKIP_DECISION_BASELINE=1.
+
+STAGED_PRINCIPLES=$(git diff --cached --name-only --diff-filter=ACMR \
+  | grep -E '^docs/founder-kernel/wiki/principles/.*\.md$' || true)
+
+if [ -n "$STAGED_PRINCIPLES" ] && [ "$DPF_SKIP_DECISION_BASELINE" != "1" ]; then
+  echo "[pre-commit] kernel principle staged — checking the decision baseline..."
+  if ! node scripts/check-golden-decisions.mjs; then
+    echo ""
+    echo "Commit rejected. A kernel-principle change moved a canonical decision below its"
+    echo "margin floor. Recalibrate the principleDimensionVector / principleWeight (see the"
+    echo "guidance above and docs/founder-kernel/AUTHORING.md — a procedural meta-principle"
+    echo "wants a focused vector + low principleWeight). Override: DPF_SKIP_DECISION_BASELINE=1 git commit ..."
+    echo ""
+    exit 1
+  fi
+fi
+
 # ─── Guard 4: typecheck gate ────────────────────────────────────────────────
 
 if [ "$DPF_SKIP_TYPECHECK" = "1" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,38 @@ jobs:
       - name: Run guard
         run: node scripts/check-no-raw-event-source.mjs
 
+  decision-baseline:
+    name: Decision Baseline
+    runs-on: ubuntu-latest
+    # PR #2157. A new/edited founder-kernel principle loads into EVERY
+    # principle_decide call (commandments at weight 1.0), so its dimension vector
+    # can drag a canonical decision below its margin floor. The authoritative test
+    # (apps/web/lib/decision/golden-decisions.test.ts) runs under vitest deep in a
+    # web shard and first FAILED #2157 only at merge_group, after hours of queue
+    # churn. This job runs the same check vitest-free against the MERGE-STATE
+    # corpus (merge latest main first), so a baseline regression shows as a named
+    # red check on the PR, not three queue cycles later. Mirrors the pre-commit
+    # decision-baseline guard; merge_group stays covered by the canonical test.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Merge latest main (score merge-state, not the stale branch)
+        run: |
+          git config user.email "dpf-ci@users.noreply.github.com"
+          git config user.name "dpf-ci"
+          git fetch --no-tags --quiet origin main
+          git merge --no-edit origin/main || { echo "::error::This PR conflicts with main — merge/rebase main and re-push."; exit 1; }
+      - name: Decision-baseline guard (golden-decisions, vitest-free)
+        run: node scripts/check-golden-decisions.mjs
+      - name: Drift-guard — guard mirrors the canonical golden-decisions test
+        run: node --test scripts/check-golden-decisions.test.mjs
+
   ux-fit-gate:
     name: UX-Fit Gate
     runs-on: ubuntu-latest

--- a/scripts/check-golden-decisions.mjs
+++ b/scripts/check-golden-decisions.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// scripts/check-golden-decisions.mjs
+//
+// Shift-left guard for the corpus-aware decision baseline (BI: golden-decisions
+// shift-left guard). A new or edited kernel principle loads into EVERY
+// principle_decide call (commandments at weight 1.0), so its dimension vector
+// shifts ALL canonical decisions. The authoritative test is
+// apps/web/lib/decision/golden-decisions.test.ts — but it only runs under
+// vitest (unavailable in degraded worktrees) and, in practice, first FAILED a
+// change at merge_group time after hours of queue churn (PR #2157). This guard
+// is the same check with NO vitest dependency: pure node, ~50ms, reads the real
+// docs/founder-kernel/wiki/principles/*.md corpus and gates on each canonical
+// decision's winner + margin floor. Wired as a pre-push hook (fires before the
+// push leaves the machine) and a fast CI job that merges main first so it scores
+// the MERGE-STATE corpus — catching the "green alone, red merged" gap on the PR
+// instead of in the queue.
+//
+// Math + scenarios MIRROR apps/web/lib/decision/{option-scoring,golden-decisions}.ts.
+// The formula (alignment = Σ option·vec / Σ|vec|; contribution = weight × alignment;
+// composite = Σ) is the core decision algorithm and is intentionally stable. The
+// SCENARIOS below mirror GOLDEN_SCENARIOS; scripts/check-golden-decisions.test.mjs
+// is a drift-guard that fails CI if the ids / margin floors / winners diverge, and
+// both engines (this scorer + the canonical vitest test) run in CI against the same
+// corpus, so any behavioral divergence surfaces as one going red.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PRINCIPLES_DIR = join(HERE, "..", "docs", "founder-kernel", "wiki", "principles");
+const POPULATION = "in_platform_coworker"; // universal-ring caller; population filter only
+const TIER_DEFAULT_WEIGHT = { commandment: 1.0, core: 0.4, contextual: 0.1 };
+
+// ─── Canonical scenario panel — MIRRORS GOLDEN_SCENARIOS in golden-decisions.ts ──
+// Kept in sync by scripts/check-golden-decisions.test.mjs (drift-guard).
+export const SCENARIOS = [
+  {
+    id: "quick-vs-proper-normal",
+    expectedWinner: "proper-seed-fix",
+    marginFloor: 0.3,
+    options: {
+      "quick-runtime-patch": { long_term_maintainability: 0.2, schema_grounding: 0.2, reusability: 0.2, blast_radius: 0.1, speed_to_value: 0.9, evidence_density: 0.85, governance_compliance: 0.85, public_safety: 0.5, human_cognitive_load: 0.3 },
+      "proper-seed-fix": { long_term_maintainability: 0.95, schema_grounding: 0.85, reusability: 0.7, blast_radius: 0.55, speed_to_value: 0.15, evidence_density: 0.5, governance_compliance: 0.5, human_cognitive_load: 0.4 },
+    },
+  },
+  {
+    id: "cheap-sound-vs-rebuild-guard",
+    expectedWinner: "cheap-sound-additive",
+    marginFloor: 0.1,
+    options: {
+      "cheap-sound-additive": { long_term_maintainability: 0.85, schema_grounding: 0.8, reusability: 0.6, blast_radius: 0.2, speed_to_value: 0.75, evidence_density: 0.9, governance_compliance: 0.6, cost_efficiency: 0.9, human_cognitive_load: 0.3 },
+      "expensive-rebuild": { long_term_maintainability: 0.9, schema_grounding: 0.85, reusability: 0.7, blast_radius: 0.95, speed_to_value: 0.05, evidence_density: 0.4, governance_compliance: 0.5, cost_efficiency: 0.2, human_cognitive_load: 0.1 },
+    },
+  },
+];
+
+// ─── Minimal principle-frontmatter parse (mirrors parsePrinciplePage) ────────
+function parsePrinciple(raw, slug) {
+  const fm = (raw.replace(/\r\n/g, "\n").match(/^---\n([\s\S]*?)\n---/) || [, ""])[1];
+  const scalar = (k) => {
+    const m = fm.match(new RegExp(`^${k}:(.*)$`, "m"));
+    if (!m) return undefined;
+    const v = m[1].trim().replace(/^["']|["']$/g, "");
+    return v.length ? v : undefined;
+  };
+  const blockList = (k) => {
+    const lines = fm.split("\n");
+    const idx = lines.findIndex((l) => l === `${k}:` || l.startsWith(`${k}:`));
+    if (idx < 0) return [];
+    const inline = lines[idx].match(new RegExp(`^${k}:\\s*\\[(.*)\\]`));
+    if (inline) return inline[1].split(",").map((s) => s.trim().replace(/['"]/g, "")).filter(Boolean);
+    const out = [];
+    for (let j = idx + 1; j < lines.length; j++) {
+      const m = lines[j].match(/^\s+-\s+(.+?)\s*$/);
+      if (!m) { if (/^\S/.test(lines[j])) break; else continue; }
+      out.push(m[1].replace(/['"]/g, ""));
+    }
+    return out;
+  };
+  let vec;
+  const vm = fm.match(/^principleDimensionVector:\s*(\{.*\})\s*$/m);
+  if (vm) { try { vec = JSON.parse(vm[1]); } catch { /* leave undefined */ } }
+  const w = scalar("principleWeight");
+  return {
+    slug,
+    pageKind: scalar("pageKind"),
+    status: scalar("status"),
+    tier: scalar("principleTier"),
+    appliesTo: blockList("principleAppliesTo"),
+    vec,
+    weight: w !== undefined ? Number(w) : undefined,
+  };
+}
+
+export function loadCommandments(dir = PRINCIPLES_DIR) {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => parsePrinciple(readFileSync(join(dir, f), "utf8"), f.replace(/\.md$/, "")))
+    .filter((p) => p.pageKind === "principle" && (!p.status || p.status === "published"))
+    .filter((p) => p.tier === "commandment")
+    .filter((p) => !p.appliesTo?.length || p.appliesTo.includes(POPULATION))
+    .map((p) => ({ id: p.slug, weight: typeof p.weight === "number" ? p.weight : TIER_DEFAULT_WEIGHT.commandment, vec: p.vec ?? {} }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+// ─── Scoring (mirrors option-scoring.ts) ─────────────────────────────────────
+function alignment(features, vec) {
+  const dims = Object.keys(vec);
+  if (!dims.length) return 0; // empty vector -> semantic fallback -> 0 (no embeddings here)
+  let num = 0, den = 0;
+  for (const d of dims) { den += Math.abs(vec[d]); const f = features[d]; if (typeof f === "number") num += f * vec[d]; }
+  return den === 0 ? 0 : num / den;
+}
+function composite(features, commandments) {
+  return commandments.reduce((s, p) => s + p.weight * alignment(features, p.vec), 0);
+}
+
+export function runCheck(dir = PRINCIPLES_DIR) {
+  const commandments = loadCommandments(dir);
+  const results = SCENARIOS.map((s) => {
+    const scored = Object.entries(s.options)
+      .map(([id, f]) => [id, composite(f, commandments)])
+      .sort((a, b) => b[1] - a[1]);
+    const margin = scored[0][1] - scored[1][1];
+    const winnerOk = scored[0][0] === s.expectedWinner;
+    const marginOk = margin >= s.marginFloor;
+    return { id: s.id, winner: scored[0][0], expectedWinner: s.expectedWinner, margin, marginFloor: s.marginFloor, winnerOk, marginOk, ok: winnerOk && marginOk };
+  });
+  return { commandmentCount: commandments.length, results, ok: results.every((r) => r.ok) };
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+const invokedDirectly = process.argv[1] && process.argv[1].replace(/\\/g, "/").endsWith("check-golden-decisions.mjs");
+if (invokedDirectly) {
+  const { commandmentCount, results, ok } = runCheck();
+  console.log(`[golden-decisions] scored ${results.length} canonical decisions against ${commandmentCount} commandments`);
+  for (const r of results) {
+    const status = r.ok ? "OK" : "FAIL";
+    console.log(`  [${status}] ${r.id}: winner=${r.winner}${r.winnerOk ? "" : ` (WANT ${r.expectedWinner})`} margin=${r.margin.toFixed(4)} floor=${r.marginFloor}${r.marginOk ? "" : " BELOW FLOOR"}`);
+  }
+  if (!ok) {
+    console.error(
+      "\n[golden-decisions] A canonical decision regressed. A kernel-principle change moved the\n" +
+      "decision baseline below its margin floor (or flipped a winner). If the change is a new/edited\n" +
+      "principle: recalibrate its principleDimensionVector / principleWeight (a procedural meta-principle\n" +
+      "wants a focused vector + low weight) so it does not perturb decisions it has no bearing on. See\n" +
+      "docs/founder-kernel/AUTHORING.md and the worked example in PR #2157.",
+    );
+    process.exit(1);
+  }
+  console.log("[golden-decisions] all canonical decisions hold. OK");
+}

--- a/scripts/check-golden-decisions.test.mjs
+++ b/scripts/check-golden-decisions.test.mjs
@@ -1,0 +1,59 @@
+// scripts/check-golden-decisions.test.mjs
+//
+// Drift-guard for the vitest-free decision-baseline guard. check-golden-decisions.mjs
+// inlines the canonical scenarios from apps/web/lib/decision/golden-decisions.ts so it
+// can run without vitest (degraded worktrees / pre-commit). This test fails CI if the
+// two diverge — same ids, margin floors, expected winners, and scenario count — and
+// asserts the guard passes on the real corpus. node --test (no vitest needed), so it
+// runs in the same vitest-free contexts the guard targets.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SCENARIOS, runCheck } from "./check-golden-decisions.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CANON = readFileSync(
+  join(HERE, "..", "apps", "web", "lib", "decision", "golden-decisions.ts"),
+  "utf8",
+);
+
+test("guard scenarios mirror GOLDEN_SCENARIOS in golden-decisions.ts (no drift)", () => {
+  for (const s of SCENARIOS) {
+    assert.ok(CANON.includes(`id: "${s.id}"`), `scenario id "${s.id}" missing from golden-decisions.ts`);
+    assert.ok(
+      CANON.includes(`expectedWinner: "${s.expectedWinner}"`),
+      `expectedWinner "${s.expectedWinner}" for ${s.id} missing from golden-decisions.ts`,
+    );
+    assert.ok(
+      new RegExp(`marginFloor:\\s*${s.marginFloor}\\b`).test(CANON),
+      `marginFloor ${s.marginFloor} for ${s.id} missing from golden-decisions.ts`,
+    );
+  }
+});
+
+test("guard covers every canonical scenario (count matches golden-decisions.ts)", () => {
+  // Match scenario entries (marginFloor: <number>), not the `marginFloor: number;`
+  // type-field declaration on GoldenScenario.
+  const canonCount = (CANON.match(/marginFloor:\s*[\d.]/g) || []).length;
+  assert.equal(
+    SCENARIOS.length,
+    canonCount,
+    `golden-decisions.ts defines ${canonCount} scenarios but the guard covers ${SCENARIOS.length}. ` +
+      `Add the new scenario to SCENARIOS in scripts/check-golden-decisions.mjs.`,
+  );
+});
+
+test("guard passes on the real principle corpus", () => {
+  const { results, ok } = runCheck();
+  for (const r of results) {
+    assert.ok(
+      r.ok,
+      `${r.id}: winner=${r.winner} (want ${r.expectedWinner}) margin=${r.margin} floor=${r.marginFloor}`,
+    );
+  }
+  assert.ok(ok);
+});


### PR DESCRIPTION
## Problem

#2157 broke the corpus-aware `golden-decisions` baseline and was only caught at **merge_group** — then churned the queue for *hours*. Root cause: the catching test runs only under **vitest, deep in a web shard**, scored against the **stale branch** corpus. There was no fast, vitest-free, point-of-action check.

WWMD (`principle_decide`): **`local-guard-shift-left`** — composite 8.95, high confidence; the "just document it" option scored *negative* on Architecture-Over-Shortcuts (doctrine alone has failed this class twice this session).

## Fix — catch it at the point of action, against merge-state

A vitest-free ~50ms scorer that reads the real `docs/founder-kernel/wiki/principles/*.md` corpus and gates on each canonical decision's winner + margin floor:

- **`scripts/check-golden-decisions.mjs`** — standalone scorer; mirrors the math + scenarios of `apps/web/lib/decision/{option-scoring,golden-decisions}.ts`.
- **`scripts/check-golden-decisions.test.mjs`** — drift-guard: fails if the scorer's scenarios / floors / winners / count diverge from the canonical, and asserts the guard holds on the real corpus. *(It already caught a stale scenario count during authoring.)*
- **`.githooks/pre-commit` Guard 6** — runs the scorer when a principle is staged → a bad calibration is rejected **at commit** (override `DPF_SKIP_DECISION_BASELINE=1`).
- **`.github/workflows/ci.yml` `Decision Baseline` job** — merges latest `main` first (**merge-state**, not stale branch), runs scorer + drift-guard → a regression is a **named red check on the PR**, not three queue cycles later. `merge_group` stays covered by the canonical vitest test.

## Verification (vitest unavailable in worktree → standalone node)

- Passes current corpus: `quick-vs-proper 0.4533 ≥ 0.3`, `cheap-vs-rebuild 3.3056 ≥ 0.1`, exit 0.
- **Blocks** the original bad #2157 vector: `0.2281 < 0.3`, exit 1 — i.e. it would have caught #2157 at the first push.
- Drift-guard: 3/3 pass.

## Follow-ups (complementary, not in this PR)

1. **Make `Decision Baseline` a required status check** (branch-protection setting) so it blocks, not just reports. *(Admin action — I can't set it from code.)*
2. **Queue-churn visibility** — surface a PR removed from the merge queue ≥2× (the thing that made #2157 take *long*).
3. **AUTHORING.md calibration note** — already a tracked chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
