### PR TITLE
fix(build-studio): give the planner the founder-kernel lens the reviewer enforces (BI-C2CB3073)

### DIFF
--- a/apps/web/lib/integrate/build-agent-prompts.test.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.test.ts
@@ -274,4 +274,44 @@ describe("getBuildContextSection", () => {
     });
     expect(section).not.toContain("Feature Brief:");
   });
+
+  it("injects the founder-kernel design standard into the plan phase (BI-C2CB3073)", async () => {
+    const section = await getBuildContextSection({
+      buildId: "FB-KERNEL-1",
+      phase: "plan",
+      title: "WWMD record_outcome tool",
+      brief: null,
+      plan: null,
+      portfolioId: null,
+    });
+    expect(section).toContain("Design Standard (the architecture reviewer WILL hold");
+    expect(section).toContain("never trust input"); // input-validation commandment
+    expect(section).toContain("least privilege"); // authz commandment
+    expect(section).toContain("CONCRETE TEST-FIRST");
+    expect(section).toContain("GROUNDED FILE PATHS");
+    expect(section).toContain("packages/db/prisma/schema.prisma"); // the real path the planner kept missing
+  });
+  it("injects the design standard into the ideate phase too", async () => {
+    const section = await getBuildContextSection({
+      buildId: "FB-KERNEL-2",
+      phase: "ideate",
+      title: "Decision ledger inspector",
+      brief: null,
+      plan: null,
+      portfolioId: null,
+    });
+    expect(section).toContain("Design Standard (the architecture reviewer WILL hold");
+    expect(section).toContain("never trust input");
+  });
+  it("does NOT inject the design standard at build phase (design-time guidance only)", async () => {
+    const section = await getBuildContextSection({
+      buildId: "FB-KERNEL-3",
+      phase: "build",
+      title: "Implement record_outcome",
+      brief: null,
+      plan: null,
+      portfolioId: null,
+    });
+    expect(section).not.toContain("Design Standard (the architecture reviewer WILL hold");
+  });
 });

--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -825,6 +825,25 @@ function formatCodeIntelligenceSection(phase: BuildPhase): string[] {
   ];
 }
 
+/**
+ * The founder-kernel lens the architecture reviewer already measures plans
+ * against (build-reviewers.ts `ARCHITECTURE_REVIEW_REFERENCES`). The planner did
+ * not carry it, so plans were rejected on kernel grounds the planner never
+ * consulted and the build escalated `needs-human` for guidance the kernel
+ * already mandates (BI-C2CB3073 / the issue-report surface design §5.3). Injected
+ * into ideate/plan so the planner designs to the same standard up front. These
+ * four are the recurring rejections that stranded a whole WWMD initiative.
+ */
+export const PLAN_DESIGN_STANDARD = `--- Design Standard (the architecture reviewer WILL hold your design/plan to this) ---
+Measured against the DPF founder kernel (docs/founder-kernel/wiki/principles/) and AGENTS.md. Satisfy these IN the design/plan or the review rejects it and the build stalls. The recurring failures:
+
+1. INPUT VALIDATION & SANITIZATION (kernel commandment "never trust input - validate, encode, parameterize"). For every new field, parameter, and external input, state how it is validated, length/format-constrained, and encoded. Unbounded String columns and unvalidated request bodies are automatic rejections.
+2. AUTHORIZATION, least privilege (kernel commandment "least privilege, deny by default"). For every new API route, MCP tool, mutation, or sensitive read, state the auth/ownership check. A new endpoint or tool with no stated authz is an automatic rejection.
+3. CONCRETE TEST-FIRST. Each task's testFirst must name the real test file and the specific failing case it asserts (e.g. "apps/web/lib/x/y.test.ts - asserts validateRationale() rejects a 5000-char body"), not a vague "write a test".
+4. GROUNDED FILE PATHS. Every fileStructure path and modify target must be a REAL path in this repo - verify before listing. Frequent misses: it is "packages/db/prisma/schema.prisma" (not "packages/db/schema.prisma"); source files are kebab-case (e.g. "build-orchestrator.ts", not "build_orchestrator.ts"). A plan referencing a non-existent modify target is rejected.
+
+Design to this up front - it is the same lens the reviewer applies, so meeting it here is how the plan passes WITHOUT a needs-human escalation.`;
+
 export async function getBuildContextSection(ctx: BuildContext): Promise<string> {
   const lines: string[] = [
     "",
@@ -984,6 +1003,17 @@ export async function getBuildContextSection(ctx: BuildContext): Promise<string>
   if (ctx.deliberationReason && ctx.deliberationReason.trim()) {
     lines.push("");
     lines.push(`DELIBERATION: ${ctx.deliberationReason.trim()}`);
+  }
+
+  // BI-C2CB3073: give the planner the SAME founder-kernel lens the architecture
+  // reviewer measures against. The recurring rejections that strand builds at
+  // ideate/plan with a needs-human escalation (missing input validation, missing
+  // authz, vague test-first, invented file paths) are kernel-commandment matters
+  // the planner can satisfy up front instead of escalating for them. Ideate/plan
+  // only - this is design-time guidance, not build-time.
+  if (ctx.phase === "ideate" || ctx.phase === "plan") {
+    lines.push("");
+    lines.push(PLAN_DESIGN_STANDARD);
   }
 
   lines.push("");


### PR DESCRIPTION
## Why

A whole WWMD subsystem initiative — 19 builds — self-abandoned at ideate/plan in a single day, each escalating "Build Studio needs a human." Root cause (verified in code): the **architecture reviewer** measures every plan against the founder kernel (`build-reviewers.ts` `ARCHITECTURE_REVIEW_REFERENCES` → `docs/founder-kernel/wiki/principles/`), but the **planner had no kernel lens** (`build-agent-prompts.ts` referenced none). So the reviewer rejected on kernel grounds the planner never consulted, the automated revision rounds couldn't close it, and the build escalated to a human — for guidance the kernel already mandates. ~12 of the 19 blockers were kernel-commandment matters:

- "lacks input validation" → *never trust input — validate, encode, parameterize*
- "lacks authz/RBAC" → *least privilege, deny by default*
- "no real failing test" → repro / TDD doctrine

(~5 were grounding bugs — invented file paths; ~2 context gaps.)

## What

Inject `PLAN_DESIGN_STANDARD` into the ideate/plan system prompt (`getBuildContextSection`): the four recurring rejections framed as **the same lens the reviewer applies** — input validation/sanitization, authorization/least-privilege, concrete test-first (name the file + the failing case), and grounded file paths (e.g. it's `packages/db/prisma/schema.prisma`, not `packages/db/schema.prisma`). The planner now designs to the standard up front instead of escalating for it. Design-time only — not injected at the build phase.

This is **Slice 1** of the trusted-escalation-routing design ([#2190](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2190) §5.3): the planner's "consult the governed scopes before escalating to a human" lens — the cheapest, root-cause slice. The dynamic `principle_decide` consult at the `needs-human` boundary, the responder, receipts, and the UI attention lens are later slices.

## Verification

- **Unit:** `getBuildContextSection` injects the standard at `ideate` + `plan` and **not** at `build`; asserts the four rejection classes + the real `schema.prisma` path. Existing `getBuildPhasePrompt` / `getBuildContextSection` tests unchanged.
- **Substrate:** local toolchain degraded (`.pnpm` empty) → unit + typecheck + build gates run in **CI**, not the worktree (AGENTS §5).

No UI change (prompt constant), so no UX-Fit gate. `Process-Spine-Decision` trailer points at the design spec (#2190) + BI-C2CB3073.

## Effect

The 19 stalled WWMD builds become re-dispatchable once this deploys (they'd then pass review). Re-dispatch is a follow-on (and goes through the self-upgrade deploy first) — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
