### PR TITLE
fix(grants): map describe_ea_view to ea_graph_read (Routing Invariants Audit INV-1)

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -397,6 +397,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   query_ontology_graph:   ["ea_graph_read"],
   run_traversal_pattern:  ["ea_graph_read"],
   export_archimate:       ["ea_graph_read"],
+  describe_ea_view:       ["ea_graph_read"],
 
   // Finance
   get_finance_period_summary:   ["financial_report_create"],


### PR DESCRIPTION
## What

`describe_ea_view` — the read-only EA-view explain/critique MCP tool added by [#2192](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2192) — was added to `PLATFORM_TOOLS` (`mcp-tools.ts`) **without** a `TOOL_TO_GRANTS` entry. The Routing Invariants Audit flags this as **INV-1** ("1 PLATFORM_TOOLS entry has no TOOL_TO_GRANTS mapping") on every PR, and an unmapped tool is default-denied / unreachable from coworker chat.

Map it to `["ea_graph_read"]` — it is a read tool, sitting between `export_archimate` and `query_ontology_graph` in `mcp-tools.ts`, both of which map to `ea_graph_read`.

## Why a standalone PR

This surfaced as a failing Routing Invariants Audit on an unrelated PR (#2195, planner kernel-lens). That PR merged (the audit is advisory, not a required merge gate), so the drift is now on `main` and will keep flagging every PR until fixed. This is the one-line correct fix.

## Verification

Replicated the audit's INV-1 check (`scripts/audit-routing-spec-boot-invariants.ts`) against the changed tree: **0 unmapped tools** after this change (was 1: `describe_ea_view`). Local toolchain degraded (`.pnpm` empty) → CI runs the real audit + gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
