### PR TITLE
fix(self-upgrade): don't false-fail a run when the portal boots mid-swap on the pre-upgrade SHA

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -328,6 +328,41 @@ describe("reconcileSelfUpgradeRunsOnBoot", () => {
       expect.stringContaining("dispatch never started"),
     );
   });
+
+  it("on boot, leaves a run 'running' (no false-fail) when still on the pre-upgrade currentSha (swap pending)", async () => {
+    // Mid-swap: the old portal booted on its pre-upgrade SHA before the promoter recreated
+    // it on the target. Must NOT be failed — the swap may still land (SUR-F4209F75 regression).
+    getDeployedShaMock.mockResolvedValueOnce("current-sha");
+    selfUpgradeRunFindManyMock.mockResolvedValueOnce([
+      { runId: "SUR-PENDING", deployedSha: "expected-sha", targetSha: "upstream-sha", currentSha: "current-sha" },
+    ]);
+
+    const result = await reconcileSelfUpgradeRunsOnBoot({ log: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ succeeded: 0, failed: 0 });
+    expect(failRunMock).not.toHaveBeenCalled();
+    expect(completeRunMock).not.toHaveBeenCalled();
+  });
+
+  it("in periodic (watchdog) mode, still fails a run stuck on its currentSha past the window", async () => {
+    // The pending-skip is boot-only: a run that never swapped and is still on currentSha after
+    // the staleness window IS a genuine hang and must be reaped.
+    getDeployedShaMock.mockResolvedValueOnce("current-sha");
+    selfUpgradeRunFindManyMock
+      .mockResolvedValueOnce([
+        { runId: "SUR-HUNG", deployedSha: "expected-sha", targetSha: "upstream-sha", currentSha: "current-sha" },
+      ])
+      .mockResolvedValueOnce([]);
+    failRunMock.mockResolvedValueOnce({});
+
+    const result = await reconcileSelfUpgradeRunsOnBoot(
+      { log: vi.fn(), error: vi.fn() },
+      { staleAfterMs: 30 * 60 * 1000, now: () => new Date("2026-06-14T01:00:00.000Z") },
+    );
+
+    expect(result).toEqual({ succeeded: 0, failed: 1 });
+    expect(failRunMock).toHaveBeenCalledWith("SUR-HUNG", expect.stringContaining("watchdog"));
+  });
 });
 
 describe("isStartupModelRevalidationEnabled", () => {

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -153,16 +153,34 @@ export async function reconcileSelfUpgradeRunsOnBoot(
         await completeRun(run.runId);
         succeeded++;
         logger.log(`[self-upgrade-reconcile] ${run.runId} -> succeeded (deployed ${deployedSha})`);
-      } else {
-        await failRun(
-          run.runId,
-          staleAfterMs > 0
-            ? `Reconciled by watchdog (stuck "running" > ${Math.round(staleAfterMs / 60000)}m): orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`
-            : `Reconciled on boot: orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`,
-        );
-        failed++;
-        logger.log(`[self-upgrade-reconcile] ${run.runId} -> failed (orphaned)`);
+        continue;
       }
+      // Swap PENDING, not orphaned. On boot (staleAfterMs===0) we may come up still on the
+      // run's PRE-upgrade SHA — e.g. the old portal restarted mid-swap before the promoter
+      // recreated it on the target. Failing here is a false negative: the promoter may still
+      // complete the swap (it did for SUR-F4209F75 — failed on a mid-swap boot although the
+      // portal then came up healthy on the target). Leave the run "running"; the staleness-
+      // guarded periodic watchdog (staleAfterMs>0) fails it only if the swap genuinely never
+      // lands. The watchdog path never takes this branch, so a truly stuck run is still reaped.
+      if (
+        staleAfterMs === 0 &&
+        deployedSha &&
+        run.currentSha &&
+        run.currentSha.toLowerCase() === deployedSha.toLowerCase()
+      ) {
+        logger.log(
+          `[self-upgrade-reconcile] ${run.runId} -> swap pending (still on pre-upgrade SHA ${deployedSha}); leaving "running" for the watchdog`,
+        );
+        continue;
+      }
+      await failRun(
+        run.runId,
+        staleAfterMs > 0
+          ? `Reconciled by watchdog (stuck "running" > ${Math.round(staleAfterMs / 60000)}m): orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`
+          : `Reconciled on boot: orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`,
+      );
+      failed++;
+      logger.log(`[self-upgrade-reconcile] ${run.runId} -> failed (orphaned)`);
     }
 
     // In PERIODIC mode, also fail runs stuck "queued"/"pending" that never


### PR DESCRIPTION
## Summary

The operator's self-upgrade (carrying the EA-canvas work) showed **failed**, but the swap had actually **succeeded** — the portal came up healthy on the target merge SHA (`802275402`) and `dpf/install` advanced to it. The failure was a **false negative in boot reconciliation**, not a deploy failure.

**Root cause:** `reconcileSelfUpgradeRunsOnBoot` marks a "running" run **failed** on boot whenever the deployed SHA ≠ the expected target. But if the OLD portal restarts mid-swap (before the promoter recreates it on the target), it boots still on the run's **pre-upgrade `currentSha`** — the swap is *pending*, not orphaned. The reconcile couldn't distinguish the two, so it failed the run prematurely (`deployed=26e07b32 == currentSha`, `expected=80227540`), 2 minutes before the swapped container was even created. The swap then completed normally.

**Fix:** on boot (`staleAfterMs===0`), if `deployed === run.currentSha` (and ≠ expected), leave the run **"running"** rather than failing it. The staleness-guarded periodic **watchdog** (`staleAfterMs>0`) still reaps a run that genuinely never swaps, so a real hang is not masked. The success and orphan paths are unchanged.

Also corrected the affected run record (`SUR-F4209F75` → `succeeded`), since the portal is verifiably on its expected SHA.

## Testing
- `instrumentation.test.ts`: 36 pass, incl. two new cases — boot leaves a pre-upgrade-SHA run "running" (no false-fail); watchdog mode still reaps a genuinely-stuck run. `apps/web` typecheck clean.

## Why it surfaced now
The prior 3 self-upgrades succeeded; this one raced because a manual `redeploy-portal.ps1` had recreated the portal just before, making a mid-swap restart more likely. The fix makes reconciliation robust to that regardless of trigger.

Epic: EP-UPGRADE-LIFECYCLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
