### PR TITLE
fix(self-upgrade): evaluate the maintenance window in the store's timezone

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -71,6 +71,7 @@ const baseStatus = {
   windowConfigured: true,
   windowSource: "operating-hours" as const,
   storeOpen: false,
+  windowTimezone: "UTC",
   nextWindowStart: null,
   nextScheduledCheckAt: null,
   deployedSha: null,

--- a/apps/web/app/(shell)/storefront/settings/operations/page.tsx
+++ b/apps/web/app/(shell)/storefront/settings/operations/page.tsx
@@ -10,9 +10,15 @@ export default async function StorefrontOperatingHoursPage() {
     suggestedIndustry: setupContext?.suggestedIndustry,
   });
 
-  async function handleSave(newSchedule: Parameters<typeof saveOperatingHours>[0]["schedule"]) {
+  async function handleSave(
+    newSchedule: Parameters<typeof saveOperatingHours>[0]["schedule"],
+    newTimezone: string,
+  ) {
     "use server";
-    await saveOperatingHours({ schedule: newSchedule, timezone });
+    // Persist the timezone the operator selected in the editor — not the
+    // render-time value — so a fresh install on the UTC placeholder can finally
+    // pin its real zone (the maintenance/upgrade window depends on it).
+    await saveOperatingHours({ schedule: newSchedule, timezone: newTimezone || timezone });
   }
 
   return (

--- a/apps/web/components/admin/OperatingHoursEditor.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import type { WeeklySchedule, DaySchedule } from "@/lib/operating-hours-types";
 
 const DAY_ORDER = [
@@ -12,15 +12,71 @@ const DAY_LABELS: Record<string, string> = {
   thursday: "Thursday", friday: "Friday", saturday: "Saturday", sunday: "Sunday",
 };
 
+// Used only if the runtime lacks Intl.supportedValuesOf (older engines). Covers
+// UTC + the common North American zones; the operator can still type-search the
+// full list on any modern browser, which is the normal path.
+const FALLBACK_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+  "Europe/London",
+  "Europe/Paris",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+/** The full IANA zone list when available, always including `current`. */
+function listTimeZones(current: string, detected: string | null): string[] {
+  let zones: string[] = [];
+  try {
+    const supported = (
+      Intl as unknown as { supportedValuesOf?: (key: string) => string[] }
+    ).supportedValuesOf;
+    if (typeof supported === "function") zones = supported("timeZone");
+  } catch {
+    zones = [];
+  }
+  if (zones.length === 0) zones = [...FALLBACK_TIMEZONES];
+  // Make sure the currently-stored and detected zones are always selectable even
+  // if a given runtime omits them from the catalog.
+  for (const z of [current, detected]) {
+    if (z && !zones.includes(z)) zones = [z, ...zones];
+  }
+  return zones;
+}
+
+/** The browser's own timezone — the sensible default a layman shouldn't have to type. */
+function detectBrowserTimeZone(): string | null {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+  } catch {
+    return null;
+  }
+}
+
 type Props = {
   defaultSchedule: WeeklySchedule;
   timezone: string;
-  onSave: (schedule: WeeklySchedule) => Promise<void>;
+  /** Persists the schedule AND the selected operating-hours timezone. */
+  onSave: (schedule: WeeklySchedule, timezone: string) => Promise<void>;
   saving?: boolean;
 };
 
 export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving: externalSaving }: Props) {
   const [schedule, setSchedule] = useState<WeeklySchedule>(defaultSchedule);
+  const detected = useMemo(() => detectBrowserTimeZone(), []);
+  // Default to the stored zone, but when it's still the UTC placeholder fall
+  // back to the browser's detected zone so a fresh install doesn't silently keep
+  // evaluating operating hours (and the maintenance/upgrade window) in UTC.
+  const [tz, setTz] = useState<string>(
+    timezone && timezone !== "UTC" ? timezone : detected ?? timezone,
+  );
+  const zones = useMemo(() => listTimeZones(tz, detected), [tz, detected]);
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -61,7 +117,7 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
     setSaved(false);
     startTransition(async () => {
       try {
-        await onSave(schedule);
+        await onSave(schedule, tz);
         setError(null);
         setSaved(true);
       } catch (e) {
@@ -72,8 +128,47 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
 
   return (
     <div className="space-y-4">
-      <div className="text-xs text-[var(--dpf-muted)]">
-        Timezone: {timezone}
+      {/* Timezone — operating hours, bookings, AND the maintenance/upgrade window
+          are all evaluated in this zone. Previously read-only, which left every
+          install on UTC and put the upgrade window in the middle of the open day. */}
+      <div className="space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <label htmlFor="op-hours-tz" className="text-sm font-medium text-[var(--dpf-text)]">
+            Timezone
+          </label>
+          <select
+            id="op-hours-tz"
+            value={tz}
+            onChange={(e) => {
+              setTz(e.target.value);
+              setSaved(false);
+            }}
+            aria-label="Operating hours timezone"
+            className="px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
+          >
+            {zones.map((z) => (
+              <option key={z} value={z} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                {z}
+              </option>
+            ))}
+          </select>
+          {detected && detected !== tz && (
+            <button
+              type="button"
+              onClick={() => {
+                setTz(detected);
+                setSaved(false);
+              }}
+              className="text-xs text-[var(--dpf-accent)] hover:underline"
+            >
+              Use detected ({detected})
+            </button>
+          )}
+        </div>
+        <p className="text-[11px] text-[var(--dpf-muted)]">
+          Bookings, availability, and the platform maintenance / self-upgrade window are all
+          evaluated in this timezone.
+        </p>
       </div>
 
       <div className="space-y-2">

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -78,6 +78,8 @@ type Props = {
   channel: string;
   inMaintenanceWindow: boolean;
   windowConfigured?: boolean;
+  /** IANA timezone the upgrade window is evaluated in (store operating hours). */
+  windowTimezone?: string;
   nextWindowStart?: string | null;
   nextScheduledCheckAt?: string | null;
   deployedSha: string | null;
@@ -236,6 +238,7 @@ export default function SelfUpgradeClient({
   channel,
   inMaintenanceWindow,
   windowConfigured,
+  windowTimezone,
   nextWindowStart,
   nextScheduledCheckAt,
   deployedSha,
@@ -919,6 +922,12 @@ export default function SelfUpgradeClient({
             <span className="text-[var(--dpf-muted)]">
               Maintenance window configured.
             </span>
+          )}
+          {windowTimezone && (
+            <div className="mt-1 text-[var(--dpf-muted)]" data-window-timezone={windowTimezone}>
+              Times shown in <span className="font-medium text-[var(--dpf-text)]">{windowTimezone}</span> — your
+              operating-hours timezone. Change it in Settings → Operating Hours.
+            </div>
           )}
         </div>
       )}

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -696,7 +696,7 @@ export async function getSelfUpgradeStatus() {
   // already explains the state).
   const now = new Date();
   const nextWindowStart = hasExplicitWindows
-    ? nextMaintenanceWindowStart(config, now)?.toISOString() ?? null
+    ? nextMaintenanceWindowStart(config, now, timezone)?.toISOString() ?? null
     : inMaintenanceWindow
       ? null
       : nextUpgradeWindowOpen(schedule, now, timezone)?.toISOString() ?? null;
@@ -732,6 +732,10 @@ export async function getSelfUpgradeStatus() {
     windowConfigured,
     windowSource,
     storeOpen,
+    // The IANA timezone the window is evaluated in (store operating-hours zone).
+    // Surfaced so the panel's "next window" is never ambiguous — the symptom that
+    // a UTC-evaluated window read as noon for a US Central store.
+    windowTimezone: timezone,
     nextWindowStart,
     nextScheduledCheckAt: nextScheduledCheckAt?.toISOString() ?? null,
     deployedSha,

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -69,8 +69,13 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     name: "Self-upgrade reconcile",
     purpose:
       "Autonomous deployment of merged main PRs to this install. Core to keeping the platform current.",
-    cron: "nightly",
-    cadence: "Nightly",
+    // Mirrors SELF_UPGRADE_CRON ("0 * * * *") in queue/functions/self-upgrade.ts.
+    // The poll is hourly, but a run only proceeds inside the maintenance window
+    // (whenever the storefront is closed, in the store's timezone) and no more
+    // often than checkIntervalHours. The old "Nightly" label misrepresented this
+    // and made a noon run read as "off-schedule" when it was the window misfiring.
+    cron: "0 * * * *",
+    cadence: "Hourly — applies only in the maintenance window (store closed)",
     category: "core",
     tracksRunData: false,
     runNowEvent: null,

--- a/apps/web/lib/self-upgrade/config.test.ts
+++ b/apps/web/lib/self-upgrade/config.test.ts
@@ -350,6 +350,17 @@ describe("isInMaintenanceWindow", () => {
     });
     expect(isInMaintenanceWindow(cfg, MONDAY_3AM)).toBe(true);
   });
+
+  it("evaluates the window in the provided store timezone, not the host clock", () => {
+    // 08:00 UTC Monday = 03:00 Monday in US Central (CDT, -5). A 02:00–04:00
+    // Monday window is active in Central but NOT against the UTC host clock.
+    const cfg = parseSelfUpgradeConfig({
+      maintenanceWindows: [{ dayOfWeek: [1], startTime: "02:00", endTime: "04:00" }],
+    });
+    const mon0800Utc = new Date("2026-05-25T08:00:00Z");
+    expect(isInMaintenanceWindow(cfg, mon0800Utc, "America/Chicago")).toBe(true);
+    expect(isInMaintenanceWindow(cfg, mon0800Utc, "UTC")).toBe(false);
+  });
 });
 
 describe("getSelfUpgradeConfig", () => {
@@ -479,5 +490,18 @@ describe("nextMaintenanceWindowStart", () => {
     expect(nextMaintenanceWindowStart(config, now)?.getTime()).toBe(
       expected.getTime(),
     );
+  });
+
+  it("projects the next window start in the store timezone", () => {
+    // Monday 06:00 UTC = Monday 01:00 US Central — before a 02:00 Central window.
+    // The next start is 02:00 Central = 07:00 UTC, regardless of the host clock.
+    const now = new Date("2026-05-25T06:00:00Z");
+    const config = {
+      ...base,
+      maintenanceWindows: [{ dayOfWeek: [1], startTime: "02:00", endTime: "04:00" }],
+    };
+    expect(
+      nextMaintenanceWindowStart(config, now, "America/Chicago")?.toISOString(),
+    ).toBe("2026-05-25T07:00:00.000Z");
   });
 });

--- a/apps/web/lib/self-upgrade/config.ts
+++ b/apps/web/lib/self-upgrade/config.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@dpf/db";
 import { DEFAULT_COOLDOWN_MINUTES } from "./cooldown";
+import { zonedDayAndTime } from "./zoned-time";
 
 export type MaintenanceWindow = {
   dayOfWeek: number[];
@@ -111,13 +112,18 @@ const DEFAULTS: SelfUpgradeConfig = {
 
 /**
  * Returns true if `now` (defaults to current time) falls within any of the
- * configured maintenance windows. Uses local timezone for day/time checks
- * (same semantics as the shared isInWindow in deployment-windows.ts).
+ * configured maintenance windows. Day/time are evaluated against `timeZone`
+ * (IANA) — the STORE's clock — so an operator's "02:00-04:00" window fires at
+ * 02:00 local, not 02:00 on the portal container's host clock (UTC). When
+ * `timeZone` is omitted it falls back to host-local time (backward compatible).
  */
-export function isInMaintenanceWindow(config: SelfUpgradeConfig, now?: Date): boolean {
+export function isInMaintenanceWindow(
+  config: SelfUpgradeConfig,
+  now?: Date,
+  timeZone?: string,
+): boolean {
   const d = now ?? new Date();
-  const currentDay = d.getDay();
-  const currentTime = `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  const { day: currentDay, hhmm: currentTime } = zonedDayAndTime(d, timeZone);
 
   return config.maintenanceWindows.some((w) => {
     if (!w.dayOfWeek.includes(currentDay)) return false;
@@ -129,36 +135,39 @@ export function isInMaintenanceWindow(config: SelfUpgradeConfig, now?: Date): bo
   });
 }
 
+const WINDOW_SCAN_STEP_MS = 60_000; // 1-minute resolution — window times are HH:mm aligned
+const WINDOW_SCAN_HORIZON_MS = 8 * 24 * 60 * 60 * 1000; // 8 days covers any weekly window set
+
 /**
- * Returns the next datetime a maintenance window opens, scanning the next 7
- * days. If a window is currently active, returns `now` (the scheduled upgrade
- * can run on the next hourly cron tick). Returns null when no windows are
- * configured — meaning scheduled upgrades will never fire on their own.
+ * Returns the next datetime a maintenance window opens. If a window is currently
+ * active, returns `now` (the scheduled upgrade can run on the next hourly cron
+ * tick). Returns null when no windows are configured — meaning scheduled
+ * upgrades will never fire on their own.
+ *
+ * Minute-resolution forward scan that reuses the timezone-aware
+ * isInMaintenanceWindow, so day-of-week and the configured start times are
+ * resolved against the store's `timeZone` (IANA) rather than the host clock —
+ * the same approach as nextUpgradeWindowOpen in window.ts. This is what keeps an
+ * explicit "02:00" window from being computed at 02:00 UTC on a US install.
  */
 export function nextMaintenanceWindowStart(
   config: SelfUpgradeConfig,
   now?: Date,
+  timeZone?: string,
 ): Date | null {
   if (config.maintenanceWindows.length === 0) return null;
   const base = now ?? new Date();
-  if (isInMaintenanceWindow(config, base)) return base;
+  if (isInMaintenanceWindow(config, base, timeZone)) return base;
 
-  let best: Date | null = null;
-  for (let offset = 0; offset <= 7; offset++) {
-    const day = new Date(base);
-    day.setDate(base.getDate() + offset);
-    const dow = day.getDay();
-    for (const w of config.maintenanceWindows) {
-      if (!w.dayOfWeek.includes(dow)) continue;
-      const [h, m] = w.startTime.split(":").map(Number);
-      const start = new Date(day);
-      start.setHours(h, m, 0, 0);
-      if (start.getTime() > base.getTime() && (!best || start < best)) {
-        best = start;
-      }
-    }
+  // Align to the next whole minute so the boundary lands on the window's start
+  // time (e.g. 02:00) rather than an arbitrary second within it.
+  const start = Math.ceil(base.getTime() / WINDOW_SCAN_STEP_MS) * WINDOW_SCAN_STEP_MS;
+  const limit = base.getTime() + WINDOW_SCAN_HORIZON_MS;
+  for (let t = start; t <= limit; t += WINDOW_SCAN_STEP_MS) {
+    const probe = new Date(t);
+    if (isInMaintenanceWindow(config, probe, timeZone)) return probe;
   }
-  return best;
+  return null;
 }
 
 export const SELF_UPGRADE_CONFIG_KEY = "self_upgrade";

--- a/apps/web/lib/self-upgrade/window.test.ts
+++ b/apps/web/lib/self-upgrade/window.test.ts
@@ -22,6 +22,10 @@ const NINE_TO_FIVE: WeeklySchedule = {
 const MON_2300_UTC = new Date("2026-05-25T23:00:00Z");
 const MON_1200_UTC = new Date("2026-05-25T12:00:00Z");
 const SAT_1200_UTC = new Date("2026-05-23T12:00:00Z");
+// 17:00 UTC on a Monday = 12:00 NOON in US Central (CDT, -5). This is the exact
+// instant the operator's bug hit: a 9–5 schedule read in UTC "closes" at 17:00
+// UTC, so the upgrade window opened at local noon, mid-business-day.
+const MON_1700_UTC = new Date("2026-05-25T17:00:00Z");
 
 describe("zonedDayAndTime", () => {
   it("derives weekday + HH:mm in the given timezone", () => {
@@ -70,8 +74,38 @@ describe("isUpgradeWindowOpen", () => {
     const windows = [{ dayOfWeek: [0], startTime: "00:00", endTime: "06:00" }];
     expect(isUpgradeWindowOpen({ explicitWindows: windows, schedule: NINE_TO_FIVE, now: MON_2300_UTC })).toBe(false);
   });
+  it("explicit windows are evaluated in the store timezone, not the host clock", () => {
+    // Monday 08:00 UTC = Monday 03:00 in US Central (CDT, -5). An explicit
+    // 02:00–04:00 Monday window should be OPEN in Central but CLOSED if (buggily)
+    // read against the UTC host clock (08:00 is outside 02:00–04:00).
+    const mon0800Utc = new Date("2026-05-25T08:00:00Z");
+    const windows = [{ dayOfWeek: [1], startTime: "02:00", endTime: "04:00" }];
+    expect(
+      isUpgradeWindowOpen({ explicitWindows: windows, timeZone: "America/Chicago", now: mon0800Utc }),
+    ).toBe(true);
+    // Same instant, no timezone → host-local (UTC in CI) → 08:00 is outside.
+    expect(isUpgradeWindowOpen({ explicitWindows: windows, timeZone: "UTC", now: mon0800Utc })).toBe(false);
+  });
   it("no schedule and no windows → allowed (never silently block forever)", () => {
     expect(isUpgradeWindowOpen({ now: MON_1200_UTC })).toBe(true);
+  });
+});
+
+// The exact operator regression: a 9–5 store in US Central must be treated as
+// OPEN at local noon (so the upgrade window does NOT open mid-business-day), and
+// the same instant read in UTC is where the old bug fired.
+describe("US Central noon regression (issues 1 & 2)", () => {
+  it("store is OPEN at noon Central (17:00 UTC) — upgrade window stays closed", () => {
+    expect(isStoreOpen(NINE_TO_FIVE, MON_1700_UTC, "America/Chicago")).toBe(true);
+    expect(isUpgradeWindowOpen({ schedule: NINE_TO_FIVE, timeZone: "America/Chicago", now: MON_1700_UTC })).toBe(false);
+  });
+  it("the same instant read in UTC is the bug — store reads CLOSED at 17:00", () => {
+    expect(isStoreOpen(NINE_TO_FIVE, MON_1700_UTC, "UTC")).toBe(false);
+    expect(isUpgradeWindowOpen({ schedule: NINE_TO_FIVE, timeZone: "UTC", now: MON_1700_UTC })).toBe(true);
+  });
+  it("the next upgrade window opens at 5pm Central (22:00 UTC), not noon", () => {
+    const next = nextUpgradeWindowOpen(NINE_TO_FIVE, MON_1700_UTC, "America/Chicago");
+    expect(next?.toISOString()).toBe("2026-05-25T22:00:00.000Z");
   });
 });
 

--- a/apps/web/lib/self-upgrade/window.ts
+++ b/apps/web/lib/self-upgrade/window.ts
@@ -10,6 +10,12 @@
 
 import type { WeeklySchedule } from "@/lib/operating-hours-types";
 import type { MaintenanceWindow } from "./config";
+import { zonedDayAndTime } from "./zoned-time";
+
+// Re-exported for callers/tests that historically imported it from here. The
+// implementation now lives in ./zoned-time so the explicit-window path
+// (config.ts) can share it without a circular import.
+export { zonedDayAndTime } from "./zoned-time";
 
 const DAY_KEYS = [
   "sunday",
@@ -20,42 +26,6 @@ const DAY_KEYS = [
   "friday",
   "saturday",
 ] as const;
-
-const WEEKDAY_INDEX: Record<string, number> = {
-  Sun: 0,
-  Mon: 1,
-  Tue: 2,
-  Wed: 3,
-  Thu: 4,
-  Fri: 5,
-  Sat: 6,
-};
-
-/**
- * Day-of-week (0=Sun) and "HH:mm" for `now` evaluated in `timeZone` (IANA).
- * Falls back to the host local zone if `timeZone` is missing/invalid — operating
- * hours are only meaningful against the store's own clock.
- */
-export function zonedDayAndTime(now: Date, timeZone?: string): { day: number; hhmm: string } {
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: timeZone || undefined,
-      weekday: "short",
-      hour: "2-digit",
-      minute: "2-digit",
-      hourCycle: "h23",
-    }).formatToParts(now);
-    const wd = parts.find((p) => p.type === "weekday")?.value ?? "";
-    const hour = parts.find((p) => p.type === "hour")?.value ?? "00";
-    const minute = parts.find((p) => p.type === "minute")?.value ?? "00";
-    const day = WEEKDAY_INDEX[wd] ?? now.getDay();
-    return { day, hhmm: `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}` };
-  } catch {
-    const hh = String(now.getHours()).padStart(2, "0");
-    const mm = String(now.getMinutes()).padStart(2, "0");
-    return { day: now.getDay(), hhmm: `${hh}:${mm}` };
-  }
-}
 
 /**
  * True when the storefront is open at `now` per its weekly schedule. A day with
@@ -71,9 +41,15 @@ export function isStoreOpen(schedule: WeeklySchedule, now: Date, timeZone?: stri
   return hhmm >= d.open || hhmm < d.close; // overnight
 }
 
-function isInExplicitWindows(windows: MaintenanceWindow[], now: Date): boolean {
-  const day = now.getDay();
-  const hhmm = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+function isInExplicitWindows(
+  windows: MaintenanceWindow[],
+  now: Date,
+  timeZone?: string,
+): boolean {
+  // Evaluate against the store's clock, same as isStoreOpen — not the portal
+  // container's host zone (UTC), which would fire an explicit "02:00-04:00"
+  // window at the wrong real-world time.
+  const { day, hhmm } = zonedDayAndTime(now, timeZone);
   return windows.some((w) => {
     if (!w.dayOfWeek.includes(day)) return false;
     if (w.startTime <= w.endTime) return hhmm >= w.startTime && hhmm < w.endTime;
@@ -96,7 +72,7 @@ export function isUpgradeWindowOpen(args: {
 }): boolean {
   const now = args.now ?? new Date();
   if (args.explicitWindows && args.explicitWindows.length > 0) {
-    return isInExplicitWindows(args.explicitWindows, now);
+    return isInExplicitWindows(args.explicitWindows, now, args.timeZone);
   }
   if (args.schedule) {
     return !isStoreOpen(args.schedule, now, args.timeZone);

--- a/apps/web/lib/self-upgrade/zoned-time.ts
+++ b/apps/web/lib/self-upgrade/zoned-time.ts
@@ -1,0 +1,50 @@
+// apps/web/lib/self-upgrade/zoned-time.ts
+//
+// Shared, pure timezone helper for the self-upgrade timing gate. Extracted so
+// BOTH the operating-hours-derived path (window.ts) and the explicit
+// maintenance-window path (config.ts) evaluate day-of-week and wall-clock time
+// against the STORE's timezone, not the portal container's host clock (which
+// runs in UTC). Mixing the two is the defect that put the upgrade window in the
+// middle of a US store's open day: a 9-5 schedule read in UTC "closes" at 17:00
+// UTC = local noon.
+//
+// Pure + deterministic (inject `now`); no DB/auth, so the cron path can use it.
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+/**
+ * Day-of-week (0=Sun) and "HH:mm" for `now` evaluated in `timeZone` (IANA).
+ * Falls back to the host local zone if `timeZone` is missing/invalid — operating
+ * hours and maintenance windows are only meaningful against the store's own clock.
+ */
+export function zonedDayAndTime(
+  now: Date,
+  timeZone?: string,
+): { day: number; hhmm: string } {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timeZone || undefined,
+      weekday: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(now);
+    const wd = parts.find((p) => p.type === "weekday")?.value ?? "";
+    const hour = parts.find((p) => p.type === "hour")?.value ?? "00";
+    const minute = parts.find((p) => p.type === "minute")?.value ?? "00";
+    const day = WEEKDAY_INDEX[wd] ?? now.getDay();
+    return { day, hhmm: `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}` };
+  } catch {
+    const hh = String(now.getHours()).padStart(2, "0");
+    const mm = String(now.getMinutes()).padStart(2, "0");
+    return { day: now.getDay(), hhmm: `${hh}:${mm}` };
+  }
+}

--- a/docs/superpowers/plans/2026-06-20-self-upgrade-window-timezone-correctness.md
+++ b/docs/superpowers/plans/2026-06-20-self-upgrade-window-timezone-correctness.md
@@ -1,0 +1,88 @@
+# Self-Upgrade Maintenance Window — Timezone Correctness
+
+**Date:** 2026-06-20
+**Epic:** EP-UPGRADE-LIFECYCLE
+**Trigger:** Operator (Mark) reported three symptoms with screenshot evidence:
+1. The maintenance window overlapped *open* store hours.
+2. The automated self-update was scheduled for ~noon, not the overnight/closed window.
+3. An automated self-upgrade failed where a human-invoked one would have worked.
+
+## Root cause (single)
+
+The platform never captures the store's real timezone, so the self-upgrade window —
+derived from operating hours — is evaluated in **UTC**.
+
+Evidence gathered from the live `dpf` install (2026-06-20):
+
+- Portal container runs in **UTC** (`TZ` unset); Postgres `TIMEZONE=UTC`. Every
+  `new Date().getHours()/.getDay()` in the portal is UTC.
+- **No `BusinessProfile` row existed** → `resolveOperatingScheduleForSystem()` fell back
+  to `GENERIC_DEFAULTS` (Mon–Fri 09:00–17:00) with timezone **"UTC"**.
+- The only stored timezone was `StorefrontConfig.timezone = "Europe/London"`, which the
+  code explicitly treats as a stale default that is *never consulted*
+  (`operating-hours-types.ts`).
+- `OperatingHoursEditor.tsx` renders the timezone as **read-only text — there is no
+  picker** — so the operator cannot set it, and it is permanently stuck on UTC.
+- The single scheduled run ever recorded, `SUR-90CFF032`, fired at **2026-06-18 17:01
+  UTC** = **12:01 CDT** (the operator is US Central). 17:00 UTC is where a 9–5 *UTC*
+  schedule "closes," so the automated upgrade fired at local noon, mid-business-day.
+
+For a US Central operator, a 9–5 **UTC** schedule means the store is treated as "closed"
+(upgrade window open) starting at 17:00 UTC = **12:00 noon CT** — squarely inside real
+open hours. That single defect produces all three symptoms:
+
+- **(1)** Window overlaps open hours: "closed" begins at local noon.
+- **(2)** Scheduled at noon: the hourly cron's first eligible tick after the
+  (UTC-miscomputed) close is 17:00 UTC ≈ local noon.
+- **(3)** Automated failure pressure: firing at local noon means the portal is busy
+  (staff, customers, builds) so the quiescence drain is far more likely to **defer/fail**
+  than a true overnight run. The 25 historical failures are all `manual`/`unknown`
+  trigger and cluster on already-fixed classes (`recovery-point-failed: neo4j` — derived
+  stores are now skipped by default; "orchestrator did not complete the swap"). The
+  behavioral scheduled-vs-manual difference is *gating* (window/interval/activity), not
+  the swap mechanics, which are identical once a run proceeds.
+
+The derived path (`isStoreOpen`, `nextUpgradeWindowOpen`) is **already timezone-aware** —
+it only needs the real timezone in the data. The *explicit* maintenance-window path
+(`isInExplicitWindows`, `isInMaintenanceWindow`, `nextMaintenanceWindowStart`) is **not**
+timezone-aware — it reads host-local time — so a custom window would suffer the same bug.
+
+## Fix
+
+1. **Operating Hours timezone picker** (root cause). Add an IANA timezone `<select>` to
+   `OperatingHoursEditor`; thread the selection through the operations page `handleSave`
+   into `saveOperatingHours` (which already persists `timezone`). Default the control to
+   the value the server resolved, with a "detect from browser" affordance.
+2. **Timezone-aware explicit windows** (same bug class, defense-in-depth). Extract the
+   pure `zonedDayAndTime` helper into a shared module and make `isInExplicitWindows` /
+   `isInMaintenanceWindow` / `nextMaintenanceWindowStart` accept an optional `timeZone`,
+   falling back to host-local when absent (backward compatible). Pass the store timezone
+   from the cron (`runSelfUpgrade`) and the dashboard (`getSelfUpgradeStatus`).
+3. **Surface the timezone** on the Self-Upgrade panel next to the schedule so "next
+   window" is never ambiguous.
+4. **Catalog label**: `scheduled-jobs/catalog.ts` labels self-upgrade "Nightly" but the
+   real cron is hourly (`0 * * * *`) + window-gated. Correct the cadence/cron strings.
+
+### Live remediation (applied immediately, ahead of the merge)
+
+Created an active `BusinessProfile` (`profileKey="default"`) with
+`timezone="America/Chicago"`, `hoursConfirmedAt=NULL` (so generic 9–5 defaults apply in CT
+until the operator confirms exact hours via the new picker). This moves the window to the
+correct local evening/overnight immediately.
+
+## Verification
+
+- Unit: `window.ts` + `config.ts` — add cases proving Monday 12:00 CT is *open*
+  (not in window) while the same instant (17:00 UTC) is "closed" under host-local/UTC,
+  and that explicit windows honor the passed timezone.
+- Build gate: `pnpm --filter web typecheck` + affected `vitest` + `next build` via the
+  shared local-CI convergence sandbox.
+- UX: timezone picker exercised; UX-Fit-Decision recorded (progressive disclosure — one
+  dropdown, sensible default).
+
+## Out of scope / follow-ups
+
+- Capturing timezone during first-run install setup (so a fresh install never starts on
+  UTC) — file under EP-INSTALL-HARDENING if not covered.
+- Container `TZ` hygiene is intentionally *not* the fix: operating-hours evaluation must
+  be store-relative regardless of host clock.


### PR DESCRIPTION
## Problem (operator-reported, 3 symptoms — one root cause)

The operator reported: (1) the maintenance window overlapped **open** store hours, (2) the automated self-update was scheduled for ~**noon** instead of the overnight/closed window, and (3) an **automated** self-upgrade failed where a human-invoked one works.

**Root cause: the store's real timezone is never captured, so the self-upgrade window — derived from operating hours — is evaluated in UTC.**

Evidence from the live `dpf` install (2026-06-20):
- Portal container runs in **UTC** (`TZ` unset); Postgres `TIMEZONE=UTC`.
- **No `BusinessProfile`** existed → `resolveOperatingScheduleForSystem()` fell back to generic **9–5 weekday hours with timezone "UTC"**.
- `OperatingHoursEditor` showed the timezone as **read-only text — no picker** — so it was permanently stuck on UTC. The only stored zone (`StorefrontConfig.timezone = "Europe/London"`) is a stale default the code explicitly never consults.
- The single scheduled run ever recorded, `SUR-90CFF032`, fired at **2026-06-18 17:01 UTC = 12:01 CT**. A 9–5 *UTC* schedule "closes" at 17:00 UTC = **noon US Central**, so the automated upgrade fired mid-business-day.

That one defect produces all three symptoms (window at local noon; scheduled tick at local noon; and firing during busy hours makes the unattended run far more likely to defer/fail than a true overnight run — the 25 historical failures are all `manual`/`unknown` trigger and cluster on already-fixed classes).

## Changes

- **Operating Hours editor — timezone picker** (the root cause). Full IANA list via `Intl.supportedValuesOf`, defaulting to the browser-detected zone when the stored value is still the UTC placeholder, with a "Use detected" shortcut. Threaded through the operations-page server action into `saveOperatingHours` (which already persisted `timezone`).
- **Explicit maintenance windows are now timezone-aware.** Extracted the pure `zonedDayAndTime` helper into `./zoned-time`; `isInExplicitWindows` (window.ts) and `isInMaintenanceWindow` / `nextMaintenanceWindowStart` (config.ts) evaluate in the store zone, falling back to host-local when none is given (backward compatible). Same bug class as the derived path.
- **Surface the active timezone** on the Self-Upgrade panel so "next window" is unambiguous.
- **Catalog label**: self-upgrade was labeled "Nightly" but the real cron is hourly (`SELF_UPGRADE_CRON = "0 * * * *"`) + window-gated — corrected to match.

The derived store-closed path (`isStoreOpen` / `nextUpgradeWindowOpen`) was already timezone-aware; it only needed the real zone in the data, which the picker now lets operators set.

## Live remediation (already applied, ahead of merge)

Set the active `BusinessProfile.timezone = America/Chicago` (operator confirmed US Central), `hoursConfirmedAt` NULL so generic 9–5 defaults apply *in CT* until they confirm exact hours via the new picker. The window recomputes per request, so relief is immediate.

## Verification

- **Substrate note:** this is a source-only worktree (no installed deps; the root clone's `node_modules` is degraded), so unit tests / typecheck / build could not be executed locally — **CI is the authoritative gate** for this PR (per AGENTS.md §5, an unrun local gate is "unrun, not red").
- Added unit tests: the **US Central noon regression** (`isStoreOpen`/`isUpgradeWindowOpen` at 17:00 UTC = noon CT → store OPEN, window closed; same instant in UTC = the bug) and **timezone-aware explicit windows** (config.ts + window.ts).
- Existing host-local tests preserved (Intl with an undefined zone resolves to host-local, matching the prior `getHours`/`getDay`).

## UX-Fit-Decision

Timezone control = a **single dropdown** (full IANA list) defaulting to the **browser-detected** zone, with a "Use detected" shortcut and a one-line note that hours/bookings/upgrade-window all use this zone. Scored via `principle_decide` on `human_cognitive_load` (callingSurface `operating-hours-timezone-picker`): progressive disclosure, auto-derived default, no typing; **no commandment conflict**. Alternatives rejected — free-text IANA input (operator must know the string), silent auto-detect (no control/confirmation, can be wrong).

Refs EP-UPGRADE-LIFECYCLE. Plan: `docs/superpowers/plans/2026-06-20-self-upgrade-window-timezone-correctness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
