### PR TITLE
feat(operating-hours): derive timezone from the captured business location (state-accurate)

### DIFF
--- a/apps/web/lib/actions/operating-hours.ts
+++ b/apps/web/lib/actions/operating-hours.ts
@@ -4,8 +4,13 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
-import { GENERIC_DEFAULTS, resolveOperatingHoursTimezone } from "@/lib/operating-hours-types";
+import {
+  DEFAULT_OPERATING_HOURS_TIMEZONE,
+  GENERIC_DEFAULTS,
+  resolveOperatingHoursTimezone,
+} from "@/lib/operating-hours-types";
 import type { DaySchedule, WeeklySchedule } from "@/lib/operating-hours-types";
+import { deriveTimezoneFromBusinessLocation } from "@/lib/operating-hours-read";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const;
 type DayName = (typeof DAY_NAMES)[number];
@@ -175,11 +180,19 @@ export async function getOperatingHours(opts?: {
     select: { businessHours: true, timezone: true, hoursConfirmedAt: true },
   });
 
-  // Resolve timezone: confirmed profile > suggested from URL import > UTC fallback.
-  // Shared with the public booking calendar so the two never diverge.
+  // Resolve timezone: confirmed profile > location-derived (state-accurate) >
+  // suggested from URL import (coarse, country-level) > UTC fallback. When the
+  // profile is still on the UTC placeholder, derive from the captured business
+  // location so the editor (and the maintenance window) default to the right
+  // zone instead of UTC. Shared with the public booking calendar so the two
+  // never diverge.
+  const locationTimezone =
+    !profile?.timezone || profile.timezone === DEFAULT_OPERATING_HOURS_TIMEZONE
+      ? await deriveTimezoneFromBusinessLocation()
+      : null;
   const resolvedTimezone = resolveOperatingHoursTimezone(
     profile?.timezone,
-    opts?.suggestedTimezone,
+    locationTimezone ?? opts?.suggestedTimezone,
   );
 
   // Priority 1: Existing confirmed hours

--- a/apps/web/lib/operating-hours-read.ts
+++ b/apps/web/lib/operating-hours-read.ts
@@ -8,11 +8,36 @@
 // BusinessProfile.businessHours → WeeklySchedule mapping.
 
 import { prisma } from "@dpf/db";
-import { GENERIC_DEFAULTS } from "@/lib/operating-hours-types";
+import { DEFAULT_OPERATING_HOURS_TIMEZONE, GENERIC_DEFAULTS } from "@/lib/operating-hours-types";
 import type { DaySchedule, WeeklySchedule } from "@/lib/operating-hours-types";
+import { resolveTimezoneFromLocation } from "@/lib/timezone-from-location";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const;
 const CLOSED_DAY: DaySchedule = { enabled: false, open: "09:00", close: "17:00" };
+
+/**
+ * Best-effort IANA timezone derived from the captured business location, used
+ * when the operator hasn't pinned a timezone on the active BusinessProfile (the
+ * UTC placeholder). Prefers the precise US state code; falls back to a country
+ * code found in the operating jurisdictions. Returns null when nothing resolves.
+ * The platform captures these at setup, so the self-upgrade window should follow
+ * them rather than silently evaluating in UTC (BI-0C000AB3).
+ */
+export async function deriveTimezoneFromBusinessLocation(): Promise<string | null> {
+  // Fail-open: a best-effort default must never throw into the caller (the cron
+  // window check or the settings page), and it keeps callers that mock only
+  // businessProfile working.
+  try {
+    const ctx = await prisma.businessContext.findFirst({
+      select: { stateCode: true, operatesIn: true },
+    });
+    if (!ctx) return null;
+    const countryCode = (ctx.operatesIn ?? []).find((c) => /^[A-Za-z]{2}$/.test(c)) ?? null;
+    return resolveTimezoneFromLocation({ stateCode: ctx.stateCode, countryCode });
+  } catch {
+    return null;
+  }
+}
 
 /** Map the BusinessProfile.businessHours JSON to a full WeeklySchedule. */
 export function profileHoursToSchedule(
@@ -41,7 +66,17 @@ export async function resolveOperatingScheduleForSystem(): Promise<{
     where: { isActive: true },
     select: { businessHours: true, timezone: true, hoursConfirmedAt: true },
   });
-  const timezone = profile?.timezone && profile.timezone.length > 0 ? profile.timezone : "UTC";
+  // Prefer the operator-pinned profile timezone; when it's unset or still the UTC
+  // placeholder, derive from the captured business location so the upgrade window
+  // is correct from day one rather than evaluating in UTC.
+  let timezone =
+    profile?.timezone && profile.timezone.length > 0
+      ? profile.timezone
+      : DEFAULT_OPERATING_HOURS_TIMEZONE;
+  if (timezone === DEFAULT_OPERATING_HOURS_TIMEZONE) {
+    const derived = await deriveTimezoneFromBusinessLocation();
+    if (derived) timezone = derived;
+  }
   if (profile?.hoursConfirmedAt && profile.businessHours) {
     const businessHours = profile.businessHours as Record<string, { open: string; close: string } | null>;
     return { schedule: profileHoursToSchedule(businessHours), timezone };

--- a/apps/web/lib/public-web-tools.ts
+++ b/apps/web/lib/public-web-tools.ts
@@ -726,38 +726,10 @@ export const ARCHETYPE_TO_INDUSTRY: Record<string, string> = {
 };
 
 /** Maps ISO 3166-1 alpha-2 country code → primary IANA timezone. */
-export const COUNTRY_TO_TIMEZONE: Record<string, string> = {
-  GB: "Europe/London",
-  IE: "Europe/Dublin",
-  DE: "Europe/Berlin",
-  FR: "Europe/Paris",
-  ES: "Europe/Madrid",
-  IT: "Europe/Rome",
-  NL: "Europe/Amsterdam",
-  BE: "Europe/Brussels",
-  AT: "Europe/Vienna",
-  PT: "Europe/Lisbon",
-  CH: "Europe/Zurich",
-  SE: "Europe/Stockholm",
-  NO: "Europe/Oslo",
-  DK: "Europe/Copenhagen",
-  FI: "Europe/Helsinki",
-  PL: "Europe/Warsaw",
-  CZ: "Europe/Prague",
-  AU: "Australia/Sydney",
-  NZ: "Pacific/Auckland",
-  CA: "America/Toronto",
-  US: "America/New_York",
-  JP: "Asia/Tokyo",
-  CN: "Asia/Shanghai",
-  IN: "Asia/Kolkata",
-  SG: "Asia/Singapore",
-  ZA: "Africa/Johannesburg",
-  AE: "Asia/Dubai",
-  BR: "America/Sao_Paulo",
-  MX: "America/Mexico_City",
-  EU: "Europe/Brussels",
-};
+// Canonical home is @/lib/timezone-from-location (dependency-light, importable
+// from the unattended cron path). Re-exported here so the brand-import path
+// (branding.ts) and any existing importers keep working unchanged.
+export { COUNTRY_TO_TIMEZONE } from "@/lib/timezone-from-location";
 
 export function analyzePublicWebsiteBranding(
   evidence: PublicWebsiteEvidence,

--- a/apps/web/lib/timezone-from-location.test.ts
+++ b/apps/web/lib/timezone-from-location.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveTimezoneFromLocation } from "./timezone-from-location";
+
+describe("resolveTimezoneFromLocation", () => {
+  it("resolves US states to their predominant zone (state-accurate, six US zones)", () => {
+    expect(resolveTimezoneFromLocation({ stateCode: "IL" })).toBe("America/Chicago");
+    expect(resolveTimezoneFromLocation({ stateCode: "TX" })).toBe("America/Chicago");
+    expect(resolveTimezoneFromLocation({ stateCode: "CA" })).toBe("America/Los_Angeles");
+    expect(resolveTimezoneFromLocation({ stateCode: "NY" })).toBe("America/New_York");
+    expect(resolveTimezoneFromLocation({ stateCode: "CO" })).toBe("America/Denver");
+    expect(resolveTimezoneFromLocation({ stateCode: "AZ" })).toBe("America/Phoenix");
+  });
+
+  it("normalizes case and accepts ISO 'US-IL' subdivision form", () => {
+    expect(resolveTimezoneFromLocation({ stateCode: "il" })).toBe("America/Chicago");
+    expect(resolveTimezoneFromLocation({ stateCode: "US-IL" })).toBe("America/Chicago");
+  });
+
+  it("prefers the state code over the country code (state is more precise)", () => {
+    // A US store with country=US would resolve to Eastern via country alone; the
+    // Illinois state code must win and yield Central — the exact operator case.
+    expect(resolveTimezoneFromLocation({ stateCode: "IL", countryCode: "US" })).toBe(
+      "America/Chicago",
+    );
+  });
+
+  it("falls back to the country zone when there is no usable state", () => {
+    expect(resolveTimezoneFromLocation({ countryCode: "GB" })).toBe("Europe/London");
+    expect(resolveTimezoneFromLocation({ countryCode: "US" })).toBe("America/New_York");
+    expect(resolveTimezoneFromLocation({ stateCode: "ZZ", countryCode: "DE" })).toBe(
+      "Europe/Berlin",
+    );
+  });
+
+  it("returns null when nothing resolves, so callers can fall back safely", () => {
+    expect(resolveTimezoneFromLocation({})).toBeNull();
+    expect(resolveTimezoneFromLocation({ stateCode: "ZZ" })).toBeNull();
+    expect(resolveTimezoneFromLocation({ stateCode: "", countryCode: "" })).toBeNull();
+    expect(resolveTimezoneFromLocation({ countryCode: "ZZ" })).toBeNull();
+  });
+});

--- a/apps/web/lib/timezone-from-location.ts
+++ b/apps/web/lib/timezone-from-location.ts
@@ -1,0 +1,153 @@
+// apps/web/lib/timezone-from-location.ts
+//
+// Derive an IANA timezone from a captured business location. The platform
+// already captures location signals at setup (BusinessContext.stateCode, the
+// brand-import country code), so the operating-hours / self-upgrade-window
+// timezone should be DERIVED from them rather than asked for or left on the UTC
+// placeholder — which is what put the maintenance window at local noon for a US
+// Central store (BI-6DA3B06F / BI-0C000AB3).
+//
+// Country granularity is not enough for large countries: the US spans six zones,
+// so a country-only map resolves every US store to Eastern. State-level
+// resolution fixes that. Pure data + a pure function, intentionally free of any
+// heavy/server-only imports so the unattended cron path
+// (resolveOperatingScheduleForSystem) can use it without a bundle-boundary risk.
+
+/**
+ * Predominant IANA timezone per US state / territory. States that span more than
+ * one zone resolve to their most-populous ("majority") zone as a sensible
+ * default the operator can still override in Operating Hours — e.g. Texas →
+ * Chicago (El Paso is Mountain), Florida → New_York (the panhandle is Central),
+ * Tennessee → Chicago (eastern TN is Eastern). Arizona uses Phoenix (no DST).
+ */
+export const US_STATE_TO_TIMEZONE: Record<string, string> = {
+  AL: "America/Chicago",
+  AK: "America/Anchorage",
+  AZ: "America/Phoenix",
+  AR: "America/Chicago",
+  CA: "America/Los_Angeles",
+  CO: "America/Denver",
+  CT: "America/New_York",
+  DE: "America/New_York",
+  DC: "America/New_York",
+  FL: "America/New_York",
+  GA: "America/New_York",
+  HI: "Pacific/Honolulu",
+  ID: "America/Boise",
+  IL: "America/Chicago",
+  IN: "America/Indiana/Indianapolis",
+  IA: "America/Chicago",
+  KS: "America/Chicago",
+  KY: "America/New_York",
+  LA: "America/Chicago",
+  ME: "America/New_York",
+  MD: "America/New_York",
+  MA: "America/New_York",
+  MI: "America/Detroit",
+  MN: "America/Chicago",
+  MS: "America/Chicago",
+  MO: "America/Chicago",
+  MT: "America/Denver",
+  NE: "America/Chicago",
+  NV: "America/Los_Angeles",
+  NH: "America/New_York",
+  NJ: "America/New_York",
+  NM: "America/Denver",
+  NY: "America/New_York",
+  NC: "America/New_York",
+  ND: "America/Chicago",
+  OH: "America/New_York",
+  OK: "America/Chicago",
+  OR: "America/Los_Angeles",
+  PA: "America/New_York",
+  RI: "America/New_York",
+  SC: "America/New_York",
+  SD: "America/Chicago",
+  TN: "America/Chicago",
+  TX: "America/Chicago",
+  UT: "America/Denver",
+  VT: "America/New_York",
+  VA: "America/New_York",
+  WA: "America/Los_Angeles",
+  WV: "America/New_York",
+  WI: "America/Chicago",
+  WY: "America/Denver",
+  // Territories
+  PR: "America/Puerto_Rico",
+  VI: "America/Puerto_Rico",
+  GU: "Pacific/Guam",
+  MP: "Pacific/Guam",
+  AS: "Pacific/Pago_Pago",
+};
+
+/**
+ * Country (ISO 3166-1 alpha-2) → a representative IANA timezone. Canonical home;
+ * re-exported from public-web-tools for the brand-import path. Coarse by nature
+ * (one zone per country), so US derivation should prefer US_STATE_TO_TIMEZONE.
+ */
+export const COUNTRY_TO_TIMEZONE: Record<string, string> = {
+  GB: "Europe/London",
+  IE: "Europe/Dublin",
+  DE: "Europe/Berlin",
+  FR: "Europe/Paris",
+  ES: "Europe/Madrid",
+  IT: "Europe/Rome",
+  NL: "Europe/Amsterdam",
+  BE: "Europe/Brussels",
+  AT: "Europe/Vienna",
+  PT: "Europe/Lisbon",
+  CH: "Europe/Zurich",
+  SE: "Europe/Stockholm",
+  NO: "Europe/Oslo",
+  DK: "Europe/Copenhagen",
+  FI: "Europe/Helsinki",
+  PL: "Europe/Warsaw",
+  CZ: "Europe/Prague",
+  AU: "Australia/Sydney",
+  NZ: "Pacific/Auckland",
+  CA: "America/Toronto",
+  US: "America/New_York",
+  JP: "Asia/Tokyo",
+  CN: "Asia/Shanghai",
+  IN: "Asia/Kolkata",
+  SG: "Asia/Singapore",
+  ZA: "Africa/Johannesburg",
+  AE: "Asia/Dubai",
+  BR: "America/Sao_Paulo",
+  MX: "America/Mexico_City",
+  EU: "Europe/Brussels",
+};
+
+function normalizeCode(value: string | null | undefined): string | null {
+  const v = value?.trim().toUpperCase();
+  return v && v.length > 0 ? v : null;
+}
+
+/**
+ * Resolve an IANA timezone from a captured business location, preferring the
+ * most precise signal available:
+ *   1. US state code → state-level zone (handles the six US zones correctly).
+ *   2. Country code → representative country zone (for non-US installs).
+ * Returns null when neither resolves, so callers can fall back (browser-detected
+ * zone at the editor, UTC as the last resort) without being handed a wrong guess.
+ *
+ * Accepts a bare state code (`"IL"`) or a hyphenated subdivision (`"US-IL"`), and
+ * tolerates a country code passed in the state slot for convenience.
+ */
+export function resolveTimezoneFromLocation(args: {
+  stateCode?: string | null;
+  countryCode?: string | null;
+}): string | null {
+  const rawState = normalizeCode(args.stateCode);
+  // Accept "US-IL" style subdivisions by taking the part after the hyphen.
+  const stateCode = rawState?.includes("-") ? rawState.split("-").pop() ?? rawState : rawState;
+  if (stateCode && US_STATE_TO_TIMEZONE[stateCode]) {
+    return US_STATE_TO_TIMEZONE[stateCode];
+  }
+
+  const countryCode = normalizeCode(args.countryCode);
+  if (countryCode && COUNTRY_TO_TIMEZONE[countryCode]) {
+    return COUNTRY_TO_TIMEZONE[countryCode];
+  }
+  return null;
+}

--- a/docs/superpowers/plans/2026-06-20-derive-operating-hours-timezone-from-location.md
+++ b/docs/superpowers/plans/2026-06-20-derive-operating-hours-timezone-from-location.md
@@ -1,0 +1,65 @@
+# Derive Operating-Hours Timezone from the Captured Business Location
+
+**Date:** 2026-06-20
+**Epic:** EP-UPGRADE-LIFECYCLE
+**Item:** BI-0C000AB3 (follows BI-6DA3B06F / the self-upgrade window timezone fix)
+
+## Why
+
+Operator feedback on the self-upgrade window fix: *"we provided the business
+location at install, so the timezone should be derived from that"* — rather than
+asking, or falling back to UTC (which is what put the maintenance window at local
+noon for a US Central store).
+
+Two real gaps today:
+
+1. **Timezone is only derived at brand-URL import**, and only at **country**
+   granularity (`COUNTRY_TO_TIMEZONE` in `public-web-tools.ts`, used by
+   `branding.ts`). For the US that map returns `America/New_York` — so even when
+   it fires, a Central store lands on Eastern. Country granularity cannot resolve
+   a US timezone (six zones).
+2. **The structured location signal that IS captured — `BusinessContext.stateCode`
+   — is never used to derive a timezone.** And on a fresh/reset install with no
+   confirmed `BusinessProfile`, the operating-hours timezone falls back to UTC.
+
+## Design
+
+- New pure module `apps/web/lib/timezone-from-location.ts`:
+  - `US_STATE_TO_TIMEZONE` — predominant IANA zone per US state/territory (split
+    states default to their majority zone; operator can override via the picker).
+  - `COUNTRY_TO_TIMEZONE` — **moved here as the canonical home**; re-exported from
+    `public-web-tools.ts` so `branding.ts` and the brand-import path are unchanged.
+  - `resolveTimezoneFromLocation({ stateCode, countryCode })` — US state first
+    (precise), then country; `null` when unresolvable so callers fall back safely.
+  - Intentionally dependency-light (pure data + function) so the unattended cron
+    path can import it without a bundle-boundary violation.
+- Wire it into the timezone resolution, preferring the most precise signal:
+  **confirmed profile tz → location-derived (state, then country) → brand-import
+  suggestion → browser-detected (editor only) → UTC.**
+  - `resolveOperatingScheduleForSystem` (cron / system path): when the active
+    `BusinessProfile.timezone` is missing or the UTC placeholder, derive from
+    `BusinessContext.stateCode` / jurisdiction so the **self-upgrade window is
+    correct from the captured location even before the operator confirms hours.**
+  - `getOperatingHours` (editor path): return the location-derived zone as the
+    resolved default so the Operating Hours editor shows the right zone, not UTC.
+
+The Operating Hours timezone **picker** (BI-6DA3B06F) remains the override /
+confirmation; this change only makes the **default** correct from captured data.
+
+## Research / accuracy note
+
+Split-zone US states resolve to their majority zone (TX→Chicago, FL→New_York,
+TN→Chicago, MI→Detroit, ID→Boise). This is a sane default, not a claim of
+per-address precision; the picker covers the minority-zone exceptions.
+
+## Verification
+
+- Unit tests for `resolveTimezoneFromLocation`: US state precision (IL/TX→Chicago,
+  CA→Los_Angeles, NY→New_York), `US-IL` subdivision form, country fallback
+  (GB→London), and `null` when unresolvable.
+- Build gate via CI (source-only worktree cannot run it locally).
+
+## Out of scope
+
+- Per-address (sub-state) precision — the picker handles exceptions.
+- Changing the brand-import country detection itself.


### PR DESCRIPTION
## Why

Operator feedback on the self-upgrade window fix ([#2199](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2199) / BI-6DA3B06F):

> "we provided the business location at install, so the timezone should be derived from that"

Correct — and it exposed two gaps:

1. **Timezone is only derived at brand-URL import, at country granularity.** `COUNTRY_TO_TIMEZONE["US"] = "America/New_York"`, so even when it fires a US Central store lands on **Eastern**. Country granularity can't resolve a US timezone (six zones).
2. **The structured `BusinessContext.stateCode` signal is never used**, and a fresh/reset install with no confirmed `BusinessProfile` falls back to **UTC** — which is exactly what put the maintenance window at local noon.

## Changes

- **New pure module `apps/web/lib/timezone-from-location.ts`:**
  - `US_STATE_TO_TIMEZONE` — predominant IANA zone per US state/territory. Split-zone states default to their majority zone (TX→Chicago, FL→New_York, TN→Chicago, MI→Detroit, ID→Boise); the picker covers exceptions.
  - `COUNTRY_TO_TIMEZONE` — **moved here as the canonical home** and re-exported from `public-web-tools.ts`, so `branding.ts` / the brand-import path are unchanged.
  - `resolveTimezoneFromLocation({ stateCode, countryCode })` — state first (precise), then country, `null` when unresolvable. Dependency-light so the unattended cron path imports it without a bundle-boundary violation.
- **Wired into both timezone resolution paths**, preferring the most precise signal — confirmed profile tz → **location-derived (state, then country)** → brand-import suggestion → browser-detected (editor only) → UTC:
  - `resolveOperatingScheduleForSystem` (cron/system): derives from `BusinessContext` when the active `BusinessProfile` is still on the UTC placeholder, so the **self-upgrade window is correct from captured location even before hours are confirmed**.
  - `getOperatingHours` (editor): returns the location-derived zone as the default, so the editor shows the right zone, not UTC. Derivation is **fail-open**.

The Operating Hours timezone **picker** ([#2199](https://github.com/OpenDigitalProductfactory/opendigitalproductfactory/pull/2199)) remains the override/confirmation; this only makes the **default** correct from captured data — so neither the operator nor an agent is asked when location is known.

## Verification

- Unit tests for `resolveTimezoneFromLocation`: US state precision (IL/TX→Chicago, CA→Los_Angeles, NY→New_York, CO→Denver, AZ→Phoenix), case + `US-IL` subdivision form, **state-over-country precedence** (`{IL, US}`→Chicago, the exact operator case), country fallback (GB→London, US→New_York), and `null` when unresolvable.
- **Substrate note:** source-only worktree (no local deps) — CI is the authoritative typecheck/build/test gate.

This is an independent change from [#2199](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2199) (no file overlap). Refs EP-UPGRADE-LIFECYCLE, BI-0C000AB3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
