### PR TITLE
feat(ea-canvas): crossing-minimizing layered default + relationship-aware nested (ELK compound)

### DIFF
--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -14,6 +14,7 @@ import {
   computeEaLayout,
   placeIncremental,
   computeContainmentLayout,
+  pickAutoAlgorithm,
   EA_LAYOUT_ALGORITHMS,
   EA_LAYOUT_LABELS,
   type EaLayoutAlgorithm,
@@ -312,21 +313,24 @@ function buildEdges(edges: SerializedEdge[], onDelete: (id: string) => void, edg
 
 // Containment (nested) view: derive the Package⊃Part hierarchy from "contains" edges, lay it
 // out as nested boxes, and draw only the cross-cutting (non-contains) edges. (BI-9E5EA3FF)
-function buildNestedGraph(
+async function buildNestedGraph(
   visibleElements: SerializedViewElement[],
   visibleEdges: SerializedEdge[],
   onDelete: (id: string) => void,
   edgeVariant: EdgeVariant,
-): { nodes: Node[]; edges: Edge[] } {
+): Promise<{ nodes: Node[]; edges: Edge[] }> {
   const elementById = new Map(visibleElements.map((el) => [el.viewElementId, el]));
   const containsEdges = visibleEdges
     .filter((e) => e.relationshipType.slug === "contains")
     .map((e) => ({ parent: e.fromViewElementId, child: e.toViewElementId }));
   const crossEdges = visibleEdges.filter((e) => e.relationshipType.slug !== "contains");
+  // Cross-cutting edges drive the ELK-compound layout of children INSIDE each container.
+  const crossLayoutEdges = crossEdges.map((e) => ({ source: e.fromViewElementId, target: e.toViewElementId }));
 
-  const layout = computeContainmentLayout(
+  const layout = await computeContainmentLayout(
     visibleElements.map((el) => el.viewElementId),
     containsEdges,
+    crossLayoutEdges,
   );
 
   const nodes: Node[] = layout.map((cn) => {
@@ -475,6 +479,11 @@ export function EaCanvas({
         if (topLevelNodes.length < 2) return;
         const positions = await computeEaLayout(topLevelNodes, layoutEdges, { algorithm: algo });
 
+        // Drive edge style from the layout: orthogonal layouts (layered/tree) read cleanest with
+        // right-angle (step) edges; organic/radial with straight. Curved/bezier looks chaotic.
+        const resolved = algo === "auto" ? pickAutoAlgorithm(topLevelNodes, layoutEdges) : algo;
+        handleSetEdgeVariant(resolved === "layered" || resolved === "tree" ? "step" : "straight");
+
         const history = snapshot
           ? pushRevision(
               latestCanvasStateRef.current.history ?? [],
@@ -524,15 +533,22 @@ export function EaCanvas({
 
   // Containment (nested) view — swap the node/edge set to nested boxes derived from
   // "contains" edges. Deterministic from data, so it isn't persisted (localStorage toggle only).
-  const enterNested = useCallback(() => {
+  const enterNested = useCallback(async () => {
     setNestedMode(true);
     try { window.localStorage.setItem("ea-nested-mode", "1"); } catch { /* ignore */ }
-    const g = buildNestedGraph(visibleElements, visibleEdges, handleDeleteEdge, edgeVariant);
-    setNodes(g.nodes);
-    setEdges(g.edges);
+    // ELK compound routes orthogonally → right-angle (step) edges read cleanest.
+    handleSetEdgeVariant("step");
+    setIsLayouting(true);
+    try {
+      const g = await buildNestedGraph(visibleElements, visibleEdges, handleDeleteEdge, "step");
+      setNodes(g.nodes);
+      setEdges(g.edges);
+    } finally {
+      setIsLayouting(false);
+    }
     setLayoutMenuOpen(false);
     requestAnimationFrame(() => rfRef.current?.fitView({ duration: 400, padding: 0.1 }));
-  }, [visibleElements, visibleEdges, handleDeleteEdge, edgeVariant, setNodes, setEdges]);
+  }, [visibleElements, visibleEdges, handleDeleteEdge, setNodes, setEdges]);
 
   const exitNested = useCallback(() => {
     setNestedMode(false);
@@ -548,7 +564,7 @@ export function EaCanvas({
     if (didHydrateNestedRef.current) return;
     didHydrateNestedRef.current = true;
     if (typeof window !== "undefined" && window.localStorage.getItem("ea-nested-mode") === "1") {
-      enterNested();
+      void enterNested();
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -789,7 +805,7 @@ export function EaCanvas({
           {/* Right-side controls */}
           <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
             <button
-              onClick={() => (nestedMode ? exitNested() : enterNested())}
+              onClick={() => { if (nestedMode) exitNested(); else void enterNested(); }}
               title="Containment view — nest Packages/Parts as boxes (from 'contains' relationships)"
               style={{
                 fontSize: 10, padding: "2px 8px", borderRadius: 3, cursor: "pointer",

--- a/apps/web/lib/ea/canvas-layout.test.ts
+++ b/apps/web/lib/ea/canvas-layout.test.ts
@@ -120,12 +120,12 @@ describe("pickAutoAlgorithm", () => {
     expect(pickAutoAlgorithm(nodes("h", "a", "b", "c", "d", "e"), star)).toBe("radial");
   });
 
-  it("chooses organic for a dense, cyclic mesh", () => {
+  it("chooses layered (crossing-min) for a dense, cyclic mesh", () => {
     const dense = [
       edge("a", "b"), edge("a", "c"), edge("a", "d"), edge("a", "e"),
       edge("b", "c"), edge("c", "d"), edge("d", "e"), edge("e", "b"),
-    ]; // n=5, m=8, density 1.6, has cycles
-    expect(pickAutoAlgorithm(nodes("a", "b", "c", "d", "e"), dense)).toBe("organic");
+    ]; // n=5, m=8, has cycles → mesh → layered minimizes crossings (organic does not)
+    expect(pickAutoAlgorithm(nodes("a", "b", "c", "d", "e"), dense)).toBe("layered");
   });
 
   it("chooses layered for a sparse cyclic (DAG-like) graph", () => {
@@ -169,8 +169,8 @@ describe("placeIncremental", () => {
 describe("computeContainmentLayout", () => {
   const c = (parent: string, child: string) => ({ parent, child });
 
-  it("nests children under parents (parentId) and marks containers", () => {
-    const out = computeContainmentLayout(["P", "A", "B", "X"], [c("P", "A"), c("P", "B"), c("A", "X")]);
+  it("nests children under parents (parentId) and marks containers", async () => {
+    const out = await computeContainmentLayout(["P", "A", "B", "X"], [c("P", "A"), c("P", "B"), c("A", "X")]);
     const by = Object.fromEntries(out.map((n) => [n.id, n]));
     expect(by.P!.parentId).toBeNull();
     expect(by.P!.isContainer).toBe(true);
@@ -182,32 +182,50 @@ describe("computeContainmentLayout", () => {
     expect(by.X!.isContainer).toBe(false);
   });
 
-  it("emits parents before their children (React Flow ordering)", () => {
-    const order = computeContainmentLayout(["P", "A", "X"], [c("P", "A"), c("A", "X")]).map((n) => n.id);
+  it("emits parents before their children (React Flow ordering)", async () => {
+    const order = (await computeContainmentLayout(["P", "A", "X"], [c("P", "A"), c("A", "X")])).map((n) => n.id);
     expect(order.indexOf("P")).toBeLessThan(order.indexOf("A"));
     expect(order.indexOf("A")).toBeLessThan(order.indexOf("X"));
   });
 
-  it("sizes a container to enclose its children", () => {
-    const P = computeContainmentLayout(["P", "A", "B"], [c("P", "A"), c("P", "B")]).find((n) => n.id === "P")!;
+  it("sizes a container to enclose its children", async () => {
+    const P = (await computeContainmentLayout(["P", "A", "B"], [c("P", "A"), c("P", "B")])).find((n) => n.id === "P")!;
     expect(P.width).toBeGreaterThan(EA_NODE_W);
     expect(P.height).toBeGreaterThan(EA_NODE_H);
   });
 
-  it("treats nodes with no contains-edges as top-level leaves", () => {
-    const out = computeContainmentLayout(["a", "b", "c"], []);
+  it("lays children out by their cross-edges inside the container (compound)", async () => {
+    const out = await computeContainmentLayout(
+      ["P", "A", "B", "C"],
+      [c("P", "A"), c("P", "B"), c("P", "C")],
+      [edge("A", "B"), edge("B", "C")], // cross-edges among siblings drive the inner layout
+    );
+    const by = Object.fromEntries(out.map((n) => [n.id, n]));
+    expect(by.P!.isContainer).toBe(true);
+    for (const id of ["A", "B", "C"]) {
+      expect(by[id]!.parentId).toBe("P");
+      expect(Number.isFinite(by[id]!.x)).toBe(true);
+      expect(Number.isFinite(by[id]!.y)).toBe(true);
+    }
+    // children laid out at distinct positions (not stacked at one point)
+    const pts = ["A", "B", "C"].map((id) => `${Math.round(by[id]!.x)},${Math.round(by[id]!.y)}`);
+    expect(new Set(pts).size).toBe(3);
+  });
+
+  it("treats nodes with no contains-edges as top-level leaves", async () => {
+    const out = await computeContainmentLayout(["a", "b", "c"], []);
     expect(out).toHaveLength(3);
     expect(out.every((n) => n.parentId === null && !n.isContainer)).toBe(true);
   });
 
-  it("ignores edges referencing unknown nodes", () => {
-    const out = computeContainmentLayout(["P", "A"], [c("P", "A"), c("P", "ghost")]);
+  it("ignores edges referencing unknown nodes", async () => {
+    const out = await computeContainmentLayout(["P", "A"], [c("P", "A"), c("P", "ghost")]);
     expect(out.find((n) => n.id === "ghost")).toBeUndefined();
     expect(out.find((n) => n.id === "A")!.parentId).toBe("P");
   });
 
-  it("emits every node even when containment forms a cycle (no hang, none dropped)", () => {
-    const out = computeContainmentLayout(["P", "Q"], [c("P", "Q"), c("Q", "P")]);
+  it("emits every node even when containment forms a cycle (no hang, none dropped)", async () => {
+    const out = await computeContainmentLayout(["P", "Q"], [c("P", "Q"), c("Q", "P")]);
     expect(out.map((n) => n.id).sort()).toEqual(["P", "Q"]);
   });
 });

--- a/apps/web/lib/ea/canvas-layout.ts
+++ b/apps/web/lib/ea/canvas-layout.ts
@@ -34,9 +34,9 @@ export const EA_LAYOUT_ALGORITHMS: EaLayoutAlgorithm[] = ["auto", "organic", "tr
 
 export const EA_LAYOUT_LABELS: Record<EaLayoutAlgorithm, string> = {
   auto: "Auto · best fit",
-  organic: "Organic · clustered",
+  organic: "Organic · clustered (not crossing-min)",
   tree: "Tree · hierarchy",
-  layered: "Layered · directed flow",
+  layered: "Layered · fewest crossings",
   radial: "Radial · hub & spoke",
 };
 
@@ -48,7 +48,7 @@ const ELK_SHARED: Record<string, string> = {
   "elk.aspectRatio": "1.6",
 };
 
-function elkOptionsFor(algo: "organic" | "tree" | "layered"): Record<string, string> {
+function elkOptionsFor(algo: "organic" | "tree" | "layered", nodeCount = 0): Record<string, string> {
   if (algo === "organic") {
     // ELK stress majorization — the clustered, force-directed "organic" look. iterationLimit
     // is capped (ELK's default is effectively unbounded) so big views stay responsive.
@@ -71,17 +71,22 @@ function elkOptionsFor(algo: "organic" | "tree" | "layered"): Record<string, str
       "elk.spacing.nodeNode": String(GAP),
     };
   }
-  // layered — Sugiyama; best for directed flow/DAGs. thoroughness lowered from the default 7
-  // so 600-node views lay out quickly.
+  // layered — Sugiyama; ELK's crossing-MINIMIZING layout. It is not DAG-only: cyclic EA
+  // meshes are handled via cycle-breaking, so this is the "least chaotic" choice for dense
+  // graphs (unlike stress, which optimizes distance and ignores crossings). thoroughness is
+  // ELK's default 7 for crossing quality, dropped to 4 only for very large views (perf).
   return {
     ...ELK_SHARED,
     "elk.algorithm": "layered",
     "elk.direction": "DOWN",
+    "elk.edgeRouting": "ORTHOGONAL",
     "elk.layered.spacing.nodeNodeBetweenLayers": String(PITCH_Y),
     "elk.spacing.nodeNode": String(GAP),
+    "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
     "elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
-    "elk.layered.thoroughness": "4",
-    "elk.edgeRouting": "ORTHOGONAL",
+    "elk.layered.nodePlacement.bk.edgeStraightening": "IMPROVE_STRAIGHTNESS",
+    "elk.layered.cycleBreaking.strategy": "GREEDY",
+    "elk.layered.thoroughness": nodeCount > 400 ? "4" : "7",
   };
 }
 
@@ -156,10 +161,12 @@ export function computeMetrics(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): Gr
 }
 
 /**
- * Pick the best concrete algorithm from the graph's shape:
+ * Pick the best concrete algorithm from the graph's shape, optimizing for "least chaotic":
  * - tree/forest → mrtree (or radial when one node dominates, i.e. a star)
- * - dense / many isolated / many components → stress (organic)
- * - otherwise → layered (directed flow)
+ * - anything with cycles (a dependency mesh) → layered, ELK's crossing MINIMIZER
+ *
+ * Note: "organic" (ELK stress) is intentionally NOT auto-selected — it clusters by distance
+ * but does not reduce edge crossings, so it stays visually busy. It remains a manual choice.
  */
 export function pickAutoAlgorithm(nodes: EaLayoutNode[], edges: EaLayoutEdge[]): ConcreteLayoutAlgorithm {
   if (nodes.length <= 2) return "layered";
@@ -167,9 +174,7 @@ export function pickAutoAlgorithm(nodes: EaLayoutNode[], edges: EaLayoutEdge[]):
   if (x.isForest) {
     return x.maxDegree / x.n > 0.5 ? "radial" : "tree";
   }
-  if (x.density > 1.5 || x.isolated > x.n * 0.2 || x.components > Math.max(3, x.n * 0.15)) {
-    return "organic";
-  }
+  // Non-forest (has cycles / dependency mesh): layered minimizes crossings → least chaotic.
   return "layered";
 }
 
@@ -302,7 +307,7 @@ async function runElk(
 
   const graph = await elk.layout({
     id: "root",
-    layoutOptions: elkOptionsFor(algo),
+    layoutOptions: elkOptionsFor(algo, nodes.length),
     children,
     edges: elkEdges,
   });
@@ -481,12 +486,121 @@ function shelfPack(
   return { pos, width: contentRight - originX, height: y + rowHeight - originY };
 }
 
+type ElkInputNode = {
+  id: string;
+  width?: number;
+  height?: number;
+  layoutOptions?: Record<string, string>;
+  children?: ElkInputNode[];
+};
+
 /**
- * Compute a nested (containment) layout from "contains" edges.
- * Returns one entry per node (parents before children) with parent-relative coordinates and
- * container sizes. Nodes with children are containers; leaves get the standard node footprint.
+ * Relationship-aware nested layout via ELK compound (`hierarchyHandling: INCLUDE_CHILDREN`).
+ * Children are laid out INSIDE their container by the cross-cutting edges between them (so the
+ * structure among siblings is visible), with crossing minimization, and containers sized to fit.
+ * ELK reports parent-relative child coords + computed container sizes — exactly React Flow's
+ * model. Falls back to the shelf packer (cross-edge-agnostic) if ELK errors. (BI-6333C6BC)
  */
-export function computeContainmentLayout(
+async function runElkCompound(
+  nodeIds: string[],
+  containsEdges: ContainmentEdge[],
+  crossEdges: EaLayoutEdge[],
+): Promise<ContainmentNode[]> {
+  const idset = new Set(nodeIds);
+  const childrenOf = new Map<string, string[]>();
+  const hasParent = new Set<string>();
+  for (const e of containsEdges) {
+    if (!idset.has(e.parent) || !idset.has(e.child) || e.parent === e.child) continue;
+    if (hasParent.has(e.child)) continue; // first parent wins (forest)
+    if (!childrenOf.has(e.parent)) childrenOf.set(e.parent, []);
+    childrenOf.get(e.parent)!.push(e.child);
+    hasParent.add(e.child);
+  }
+  const roots = nodeIds.filter((id) => !hasParent.has(id));
+  if (roots.length === 0) throw new Error("containment is a pure cycle — no roots");
+
+  const building = new Set<string>(); // cycle guard for the recursive build
+  function buildNode(id: string): ElkInputNode {
+    const kids = (childrenOf.get(id) ?? []).filter((k) => !building.has(k));
+    if (kids.length === 0) return { id, width: EA_NODE_W, height: EA_NODE_H };
+    building.add(id);
+    const children = kids.map(buildNode);
+    building.delete(id);
+    return {
+      id,
+      // Reserve the title bar + inner margin; let ELK grow the container to fit its children.
+      layoutOptions: {
+        "elk.padding": `[top=${HEADER_H + 10},left=${INNER_PAD},bottom=${INNER_PAD},right=${INNER_PAD}]`,
+        "elk.spacing.nodeNode": String(INNER_GAP),
+        "elk.nodeSize.constraints": "MINIMUM_SIZE",
+        "elk.nodeSize.minimum": `(${EA_NODE_W},${EA_NODE_H})`,
+      },
+      children,
+    };
+  }
+
+  const elkEdges = crossEdges
+    .filter((e) => e.source !== e.target && idset.has(e.source) && idset.has(e.target))
+    .map((e, i) => ({ id: `c${i}`, sources: [e.source], targets: [e.target] }));
+
+  const ELK = (await import("elkjs/lib/elk.bundled.js")).default;
+  const elk = new ELK();
+  const graph = await elk.layout({
+    id: "root",
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.hierarchyHandling": "INCLUDE_CHILDREN", // lay out all depths in one pass + route cross-hierarchy edges
+      "elk.direction": "DOWN",
+      "elk.edgeRouting": "ORTHOGONAL",
+      "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
+      "elk.layered.thoroughness": nodeIds.length > 400 ? "4" : "7",
+      "elk.separateConnectedComponents": "true",
+      "elk.spacing.componentComponent": String(GAP),
+      "elk.spacing.nodeNode": String(GAP),
+    },
+    children: roots.map(buildNode),
+    edges: elkEdges,
+  });
+
+  type ElkResultNode = { id: string; x?: number; y?: number; width?: number; height?: number; children?: ElkResultNode[] };
+  const out: ContainmentNode[] = [];
+  function walk(node: ElkResultNode, parentId: string | null, depth: number) {
+    out.push({
+      id: node.id,
+      parentId,
+      x: node.x ?? MARGIN, // ELK child coords are already parent-relative
+      y: node.y ?? MARGIN,
+      width: node.width ?? EA_NODE_W,
+      height: node.height ?? EA_NODE_H,
+      isContainer: (node.children?.length ?? 0) > 0,
+      depth,
+    });
+    for (const c of node.children ?? []) walk(c, node.id, depth + 1); // parent before children → RF ordering
+  }
+  for (const c of (graph as { children?: ElkResultNode[] }).children ?? []) walk(c, null, 0);
+  if (out.length === 0) throw new Error("ELK compound returned no nodes");
+  return out;
+}
+
+/**
+ * Nested (containment) layout. Lays children out INSIDE their container by their relationships
+ * (ELK compound, crossing-minimized); falls back to a cross-edge-agnostic shelf/grid packer.
+ * Returns one entry per node (parents before children) with parent-relative coords + sizes.
+ */
+export async function computeContainmentLayout(
+  nodeIds: string[],
+  containsEdges: ContainmentEdge[],
+  crossEdges: EaLayoutEdge[] = [],
+): Promise<ContainmentNode[]> {
+  try {
+    return await runElkCompound(nodeIds, containsEdges, crossEdges);
+  } catch {
+    return shelfPackContainment(nodeIds, containsEdges);
+  }
+}
+
+// Fallback packer: nests children in a wrapped grid, ignoring cross-edges. Pure + synchronous.
+function shelfPackContainment(
   nodeIds: string[],
   containsEdges: ContainmentEdge[],
 ): ContainmentNode[] {

--- a/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
+++ b/docs/superpowers/plans/2026-06-19-ea-canvas-auto-layout.md
@@ -72,3 +72,16 @@ Tests: 30 adapter (6 containment) + 16 EA component + 52 graph/actions/topology 
 ## Addendum — 2026-06-20: fix nested-view edge detachment
 
 Live-review regression on the containment view: cross-cutting edges detached from the boxes (bunched near the canvas origin) and didn't follow a container when moved. Cause: the floating `EaRelationshipEdge` built node geometry from `node.position`, which for nested children is **relative to the container** — fine in flat mode (all nodes top-level) but wrong when nested. Fix: new pure `apps/web/lib/ea/node-geometry.ts` `resolveAbsolutePositions` (sums the parent chain, cycle-guarded, unit-tested); `EaRelationshipEdge` now anchors edges on absolute positions, so they stay attached and track container moves (`useNodes()` re-fires on drag). Tests: +5 node-geometry; web typecheck clean.
+
+---
+
+## Addendum — 2026-06-20: crossing-minimizing layouts + relationship-aware nesting (BI-6333C6BC)
+
+Live review (research-backed): "organic" stays chaotic, and the nested view's inner layout ignored sibling relationships.
+
+- **Crossing minimization (flat):** research confirmed ELK `stress` ("organic") optimizes distance, not crossings; **ELK `layered` (Sugiyama) is the crossing minimizer** and handles cyclic graphs via cycle-breaking. `pickAutoAlgorithm` now routes any non-forest (dependency mesh) to **layered** (not organic); layered tuned with `crossingMinimization.strategy=LAYER_SWEEP`, `nodePlacement=BRANDES_KOEPF`+`bk.edgeStraightening`, `cycleBreaking=GREEDY`, `edgeRouting=ORTHOGONAL`, and `thoroughness` restored to 7 (4 only for n>400). "Organic" relabeled honestly and kept as a manual option.
+- **Edge style from layout:** layered/tree → step (right-angle), organic/radial → straight — driven automatically when a layout runs (curved/bezier looked chaotic on dense graphs).
+- **Relationship-aware nesting (compound):** `computeContainmentLayout` now uses ELK compound (`hierarchyHandling: INCLUDE_CHILDREN`) — children are laid out INSIDE their container by their cross-cutting edges (crossing-minimized; e.g. MCP Tool Authority's 271 Traces among 308 children), containers sized to fit. ELK's parent-relative coords + sizes map straight onto React Flow `parentId`/`extent`/`style`. The shelf packer is retained as a resilient fallback (and for the pure-cycle case). Nested edges render orthogonally (step).
+- **Deferred follow-up:** persist nested manual edits (drag) across reload (canvasState nesting schema) — nodes are draggable in-session today.
+
+Tests: 33 adapter (incl. compound + dense→layered) + 40 component/graph; web typecheck clean. No new dependency.


### PR DESCRIPTION
## Summary

Two research-backed layout-quality fixes from live review.

### 1. Less chaotic flat layouts — route the mesh to crossing-minimizing `layered`
Research confirmed the operator's read: ELK **`stress` ("organic") optimizes node distance, not edge crossings**, so it stays busy. ELK **`layered` (Sugiyama) is the crossing minimizer** and handles cyclic/non-hierarchical EA graphs via cycle-breaking. Changes:
- `pickAutoAlgorithm` now sends any non-forest (dependency mesh, e.g. the 424-node Data Model) to **layered**, not organic.
- `layered` tuned for crossing reduction: `crossingMinimization.strategy=LAYER_SWEEP`, `nodePlacement=BRANDES_KOEPF` + `bk.edgeStraightening`, `cycleBreaking=GREEDY`, `edgeRouting=ORTHOGONAL`, and **`thoroughness` restored to 7** (4 only for n>400, for perf).
- **Edge style is driven by the layout**: layered/tree → step (right-angle), organic/radial → straight. Curved/bezier looked chaotic on dense graphs (operator's "straight is easier" was correct).
- "Organic" relabeled honestly ("clustered (not crossing-min)") and kept as a manual option.

### 2. Nested view — lay children out *by their relationships* (ELK compound)
The containment view's shelf-packer grid-packed children and ignored the edges between them, so sibling structure was invisible. Replaced with ELK **compound layout (`hierarchyHandling: INCLUDE_CHILDREN`)**: children are laid out *inside* their container by their cross-cutting edges (crossing-minimized) — e.g. *MCP Tool Authority*'s 271 `Traces` among its 308 children now drive the inner arrangement — and containers are sized to fit. ELK's parent-relative coords + computed sizes map straight onto React Flow `parentId`/`extent`/`style`. The shelf packer is kept as a resilient fallback (and for the pure-cycle case); nested edges render orthogonally.

This "combines the two" (containment + relationship layout) the operator asked for.

## Testing
- `canvas-layout.test.ts`: 33 (incl. a compound test — children laid out by cross-edges; dense→layered auto-pick; async containment). 40 EA component/graph tests pass; `apps/web` typecheck clean. **No new dependency** (ELK already covers both; fcose/Cytoscape not worth it).

## Deferred follow-up
Persist nested *manual* edits across reload (a canvasState nesting schema) — nested nodes are draggable in-session today, but drags don't yet persist.

Backlog: **BI-6333C6BC** · Epic: **EP-ARCH-GRAPH-LIVE** (extends BI-20F95B0E / BI-9E5EA3FF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
