### PR TITLE
feat(quality): issue-report stream classifier — receiving-loop Slice 1 (BI-0ACD9AB2)

### DIFF
--- a/apps/web/lib/quality/issue-report-stream.test.ts
+++ b/apps/web/lib/quality/issue-report-stream.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { classifyIssueReportStream, isResponderStream } from "./issue-report-stream";
+import { ISSUE_REPORT_STATUS } from "./issue-report-status";
+
+describe("classifyIssueReportStream", () => {
+  it("classifies a self-fix escalation by selfFixClass", () => {
+    expect(classifyIssueReportStream({ source: "build-studio", selfFixClass: "needs-human" }))
+      .toBe("self-fix-escalation");
+  });
+
+  it("classifies a self-fix escalation by type", () => {
+    expect(classifyIssueReportStream({ type: "build-stall-escalation", source: "build-studio" }))
+      .toBe("self-fix-escalation");
+  });
+
+  it("keeps a guarded escalation as self-fix even when born in a support-flow status", () => {
+    // The projection guard births escalations in awaiting_escalation_ack (a
+    // SUPPORT_FLOW status). Self-fix must win over the support-status rule, or a
+    // guarded escalation would mis-route to the support pipeline.
+    expect(
+      classifyIssueReportStream({
+        type: "build-stall-escalation",
+        status: ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK,
+        selfFixClass: "needs-human",
+      }),
+    ).toBe("self-fix-escalation");
+  });
+
+  it("routes support-flow statuses to support vs upstream", () => {
+    expect(classifyIssueReportStream({ status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE }))
+      .toBe("support-feedback");
+    expect(classifyIssueReportStream({ status: ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK }))
+      .toBe("support-feedback");
+    expect(classifyIssueReportStream({ status: ISSUE_REPORT_STATUS.UPSTREAM_PENDING }))
+      .toBe("upstream-feedback");
+    expect(classifyIssueReportStream({ status: ISSUE_REPORT_STATUS.UPSTREAM_FILED }))
+      .toBe("upstream-feedback");
+  });
+
+  it("classifies automated noise sources as digest", () => {
+    expect(classifyIssueReportStream({ source: "warmup" })).toBe("noise-digest");
+    expect(classifyIssueReportStream({ source: "log-signature-scanner", severity: "low" }))
+      .toBe("noise-digest");
+  });
+
+  it("classifies crashes and digest-bearing reports as runtime-fault", () => {
+    expect(classifyIssueReportStream({ source: "crash_boundary" })).toBe("runtime-fault");
+    expect(classifyIssueReportStream({ source: "manual", errorDigest: "abc123" }))
+      .toBe("runtime-fault");
+  });
+
+  it("fails safe to runtime-fault for unknown/high-severity reports (never suppresses)", () => {
+    expect(classifyIssueReportStream({ source: "manual", severity: "high" }))
+      .toBe("runtime-fault");
+    expect(classifyIssueReportStream({})).toBe("runtime-fault");
+  });
+
+  it("a high-severity escalation never falls through to noise", () => {
+    // selfFixClass wins even if a future noise source were also set.
+    expect(
+      classifyIssueReportStream({ source: "warmup", selfFixClass: "needs-human", severity: "high" }),
+    ).toBe("self-fix-escalation");
+  });
+});
+
+describe("isResponderStream", () => {
+  it("only self-fix-escalation is a responder stream", () => {
+    expect(isResponderStream("self-fix-escalation")).toBe(true);
+    expect(isResponderStream("runtime-fault")).toBe(false);
+    expect(isResponderStream("noise-digest")).toBe(false);
+    expect(isResponderStream("support-feedback")).toBe(false);
+    expect(isResponderStream("upstream-feedback")).toBe(false);
+  });
+});

--- a/apps/web/lib/quality/issue-report-stream.ts
+++ b/apps/web/lib/quality/issue-report-stream.ts
@@ -1,0 +1,90 @@
+// ─── Issue-Report Stream Classifier ─────────────────────────────────────────
+// EP-INTAKE-UNIFY / BI-0ACD9AB2 — Slice 1 (§5.1 of the trusted-escalation-routing
+// design, docs/superpowers/specs/2026-06-20-issue-report-surface-attendance-design.md).
+//
+// A PlatformIssueReport is NOT automatically generic bug work. This pure
+// classifier decides which STREAM a report belongs to, so the projection path
+// and (later) the escalation responder route it correctly instead of converting
+// every OPEN report into a backlog item. Both the immediate projection event and
+// the 15-minute safety-net cron MUST consume this single classifier — a future
+// writer must not have to remember which path skips which status.
+//
+// Pure + dependency-free so it is trivially unit-testable and safe to call from
+// any writer/handler. Wiring (the projection guard + responder) lands in the
+// coupled follow-on slices; this module changes no behaviour on its own.
+
+import { ISSUE_REPORT_STATUS, isSupportFlowStatus } from "./issue-report-status";
+
+export type IssueReportStream =
+  | "noise-digest"
+  | "runtime-fault"
+  | "self-fix-escalation"
+  | "support-feedback"
+  | "upstream-feedback";
+
+/** The report fields the stream decision reads. A structural subset of
+ *  PlatformIssueReport so callers can pass a row or a create-input alike. */
+export interface IssueReportStreamInput {
+  type?: string | null;
+  source?: string | null;
+  severity?: string | null;
+  selfFixClass?: string | null;
+  errorDigest?: string | null;
+  status?: string | null;
+}
+
+/** Automated, low-value producers whose output is digest/aggregate material, not
+ *  per-report backlog work. Real spikes are still caught by spike detection. */
+const NOISE_SOURCES = new Set<string>(["warmup", "log-signature-scanner"]);
+
+/**
+ * Classify a report into its handling stream. Rule order is significant:
+ *
+ *  1. self-fix-escalation — a build that could not self-repair (selfFixClass set,
+ *     or type="build-stall-escalation"). Highest priority and checked BEFORE the
+ *     support-status rule, because the projection guard births these in
+ *     awaiting_escalation_ack (a support-flow status) and they must still classify
+ *     as self-fix so the responder — not the generic projector — receives them.
+ *  2. support-feedback / upstream-feedback — reports already in a SUPPORT_FLOW
+ *     status, owned by the capacity-aware support pipeline.
+ *  3. noise-digest — warmup probes + recurring log signatures.
+ *  4. runtime-fault — crashes and digest-bearing fault evidence.
+ *  5. fail-safe default — anything else (incl. unknown / high-severity) becomes
+ *     runtime-fault so it is reviewed, never silently suppressed (design §5.1).
+ */
+export function classifyIssueReportStream(input: IssueReportStreamInput): IssueReportStream {
+  const type = input.type ?? "";
+  const source = input.source ?? "";
+  const status = input.status ?? "";
+
+  if (input.selfFixClass || type === "build-stall-escalation") {
+    return "self-fix-escalation";
+  }
+
+  if (status && isSupportFlowStatus(status)) {
+    if (
+      status === ISSUE_REPORT_STATUS.UPSTREAM_PENDING ||
+      status === ISSUE_REPORT_STATUS.UPSTREAM_FILED
+    ) {
+      return "upstream-feedback";
+    }
+    return "support-feedback";
+  }
+
+  if (NOISE_SOURCES.has(source)) {
+    return "noise-digest";
+  }
+
+  if (source === "crash_boundary" || input.errorDigest) {
+    return "runtime-fault";
+  }
+
+  // Fail safe: never suppress an unclassified or high-severity signal.
+  return "runtime-fault";
+}
+
+/** True when the stream must be attended by the escalation responder rather than
+ *  generic-projected into the backlog (the projection guard predicate). */
+export function isResponderStream(stream: IssueReportStream): boolean {
+  return stream === "self-fix-escalation";
+}


### PR DESCRIPTION
## What

The pure stream classifier (§5.1 of the trusted-escalation-routing design, [#2190](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2190)) — **Slice 1** of the receiving loop (BI-0ACD9AB2).

`classifyIssueReportStream(report)` → `noise-digest | runtime-fault | self-fix-escalation | support-feedback | upstream-feedback`. This is the foundation both the projection guard and the escalation responder will consume, so a `PlatformIssueReport` is routed by **stream** instead of every OPEN report being converted into a generic backlog item.

Rule order is significant and tested:
1. **self-fix-escalation** (`selfFixClass` set, or `type="build-stall-escalation"`) — checked *before* the support-status rule, because the guard will birth escalations in `awaiting_escalation_ack` (a support-flow status) and they must still classify as self-fix so the **responder** receives them, not the support pipeline.
2. **support / upstream** — reports already in a `SUPPORT_FLOW_STATUS`.
3. **noise-digest** — `warmup` + `log-signature-scanner`.
4. **runtime-fault** — crashes + digest-bearing evidence.
5. **fail-safe default** → runtime-fault (reviewed, never silently suppressed).

## Safety / scope

**Pure and dependency-free — changes no behaviour on its own.** It's the first, safe brick; the wiring (projection guard + responder, which are *coupled* per BI-0ACD9AB2 to avoid an interim visibility regression) lands in the follow-on slices, built **HITL-first** per design §14 (the trust dial — ships dial-low / propose-and-review, earns autonomy as evidence justifies).

## Verification

Unit tests cover every rule, the self-fix-over-support priority, the fail-safe default, and `isResponderStream`. Local toolchain degraded (`.pnpm` empty) → gates run in CI. `Process-Spine-Decision` trailer points at the design (#2190 + §14 in #2205) and BI-0ACD9AB2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
