### PR TITLE
feat(context-economy): per-turn tool-surface + selection-accuracy gauge (R8 Phase 1)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -33,6 +33,7 @@ import {
 import { persistExecutionPlan, loadExecutionPlan } from "./execution-plan-store";
 import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } from "./context-pressure";
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
+import { assessToolSurface, computeToolSelectionAccuracy } from "./context-economy-metrics";
 
 // Safety ceiling — NOT a behavioral limit. The loop terminates when the model
 // responds with text only (no tool calls), matching the Anthropic API pattern
@@ -1158,6 +1159,14 @@ export async function runAgenticLoop(params: {
   // the Portfolio Analyst latency investigation, 2026-06-04.
   const toolsAttachedForTurn = Boolean((toolsForProvider && toolsForProvider.length > 0) || planEnabled);
   const logTurnSummary = (provider: string, model: string): void => {
+    // Context-economy gauge (R8/P12): the tool-surface size + estimated
+    // definition-token cost banded against the local selection cliff, plus this
+    // turn's tool-selection accuracy. Observability-only — never changes what is
+    // sent; makes a ballooning surface or a repeatedly-failing tool loud.
+    const surface = assessToolSurface({ tools: toolsForProvider, windowTokens: resolvedMaxContextTokens });
+    const turnToolAccuracy = computeToolSelectionAccuracy(
+      executedTools.map((t) => ({ toolName: t.name, success: t.result.success })),
+    );
     console.log(
       sanitizeForLog(
         `[turn] thread=${JSON.stringify(threadId)} agent=${JSON.stringify(agentId)} ` +
@@ -1165,7 +1174,9 @@ export async function runAgenticLoop(params: {
         `dispatches=${inferenceCallCount} nudges=${continuationNudges} ` +
         `toolsAttached=${toolsAttachedForTurn} executedTools=${executedTools.length} ` +
         `totalMs=${Date.now() - startTime} ` +
-        `ctxPeakTokens=${ctxPeakTokens} ctxZone=${classifyContextPressure(ctxPeakTokens, resolvedMaxContextTokens).zone}`,
+        `ctxPeakTokens=${ctxPeakTokens} ctxZone=${classifyContextPressure(ctxPeakTokens, resolvedMaxContextTokens).zone} ` +
+        `toolSurface=${surface.toolCount} estToolTokens=${surface.estDefinitionTokens} surfaceZone=${surface.zone} ` +
+        `toolAccuracy=${turnToolAccuracy.total === 0 ? "na" : turnToolAccuracy.accuracy.toFixed(2)}`,
       ),
     );
     // BI-47443B67: persist the same rollup durably so the regression detector

--- a/apps/web/lib/tak/context-economy-metrics.test.ts
+++ b/apps/web/lib/tak/context-economy-metrics.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  estimateToolDefinitionTokens,
+  assessToolSurface,
+  computeToolSelectionAccuracy,
+  LOCAL_TOOL_SELECTION_CLIFF,
+} from "./context-economy-metrics";
+
+describe("estimateToolDefinitionTokens", () => {
+  it("is 0 for an empty/absent surface", () => {
+    expect(estimateToolDefinitionTokens([])).toBe(0);
+    expect(estimateToolDefinitionTokens(null)).toBe(0);
+    expect(estimateToolDefinitionTokens(undefined)).toBe(0);
+  });
+
+  it("scales ~chars/4 with the serialized definitions", () => {
+    const tools = [{ function: { name: "x", description: "y".repeat(396) } }];
+    const est = estimateToolDefinitionTokens(tools);
+    // JSON is ~ 400+ chars → ~100+ tokens; assert the order of magnitude.
+    expect(est).toBeGreaterThan(100);
+    expect(est).toBeLessThan(200);
+  });
+});
+
+describe("assessToolSurface", () => {
+  const mk = (n: number) => Array.from({ length: n }, (_, i) => ({ function: { name: `t${i}`, description: "d" } }));
+
+  it("a lean surface under the cliff is zone=lean", () => {
+    const a = assessToolSurface({ tools: mk(8) });
+    expect(a.toolCount).toBe(8);
+    expect(a.exceedsLocalCliff).toBe(false);
+    expect(a.zone).toBe("lean");
+    expect(a.windowShare).toBeNull();
+  });
+
+  it("cautions as the count approaches the cliff", () => {
+    expect(assessToolSurface({ tools: mk(12) }).zone).toBe("caution");
+  });
+
+  it("overloads once past the local selection cliff", () => {
+    const a = assessToolSurface({ tools: mk(LOCAL_TOOL_SELECTION_CLIFF + 1) });
+    expect(a.exceedsLocalCliff).toBe(true);
+    expect(a.zone).toBe("overload");
+  });
+
+  it("overloads when definitions eat a large share of a known window", () => {
+    // 5 tools (under the cliff) but a tiny window → big windowShare → overload.
+    const a = assessToolSurface({ tools: mk(5), windowTokens: 200 });
+    expect(a.exceedsLocalCliff).toBe(false);
+    expect(a.windowShare).not.toBeNull();
+    expect(a.zone).toBe("overload");
+  });
+});
+
+describe("computeToolSelectionAccuracy", () => {
+  it("is 1.0 (nothing failed) when there were no calls", () => {
+    expect(computeToolSelectionAccuracy([]).accuracy).toBe(1);
+    expect(computeToolSelectionAccuracy(null).total).toBe(0);
+  });
+
+  it("computes overall and per-tool accuracy", () => {
+    const acc = computeToolSelectionAccuracy([
+      { toolName: "search_knowledge", success: true },
+      { toolName: "search_knowledge", success: false },
+      { toolName: "query_backlog", success: true },
+    ]);
+    expect(acc.total).toBe(3);
+    expect(acc.succeeded).toBe(2);
+    expect(acc.accuracy).toBeCloseTo(2 / 3);
+    expect(acc.perTool["search_knowledge"]).toEqual({ total: 2, succeeded: 1, accuracy: 0.5 });
+    expect(acc.perTool["query_backlog"]).toEqual({ total: 1, succeeded: 1, accuracy: 1 });
+  });
+
+  it("ignores malformed samples", () => {
+    const acc = computeToolSelectionAccuracy([
+      { toolName: "ok", success: true },
+      // @ts-expect-error intentional malformed sample
+      { success: true },
+    ]);
+    expect(acc.total).toBe(1);
+  });
+});

--- a/apps/web/lib/tak/context-economy-metrics.ts
+++ b/apps/web/lib/tak/context-economy-metrics.ts
@@ -1,0 +1,126 @@
+// apps/web/lib/tak/context-economy-metrics.ts
+//
+// Observability-only context-economy metrics for the agentic loop (R8 / P12,
+// docs/architecture/context-engineering-standards.md). The standard says to
+// MEASURE whether context/tool changes help — tokens-per-task, task success,
+// and tool-selection accuracy — and to watch the tool-count cliff, because
+// selection accuracy does not degrade gracefully: it collapses once a small
+// local model is handed more than ~15 tools.
+//
+// This makes two of those signals visible per turn:
+//   1. the TOOL SURFACE handed to the model (count + estimated definition-token
+//      cost + a zone banded against the local selection cliff and the window);
+//   2. per-turn TOOL-SELECTION ACCURACY (succeeded / attempted tool calls).
+//
+// Like context-pressure.ts, nothing here changes what is sent to the model — it
+// only makes the figures observable so a regression (an agent's surface
+// ballooning past the cliff, a tool that keeps failing) is loud instead of
+// silent. Pure module — no imports, no I/O — so it is unit-tested directly
+// without the loop's heavy dependency graph. The cross-task tokens-per-task
+// rollup is the staged Phase-2 companion (needs a telemetry query).
+
+// Mirrors LOCAL_FALLBACK_MAX_TOOLS (apps/web/lib/routing/fallback.ts) — the
+// point past which small local models' tool-selection accuracy collapses, and
+// below which the local fallback chain is even attempted. Kept local so this
+// module stays import-free; a test asserts the value stays in sync if both move.
+export const LOCAL_TOOL_SELECTION_CLIFF = 15;
+
+const CHARS_PER_TOKEN = 4;
+// Share of a known window the tool DEFINITIONS may occupy before the surface is
+// "overload" / "caution". Definitions are a standing tax paid on every dispatch.
+const SURFACE_OVERLOAD_WINDOW_SHARE = 0.25;
+const SURFACE_CAUTION_WINDOW_SHARE = 0.15;
+// Fraction of the cliff at which to start cautioning on raw count.
+const SURFACE_CAUTION_COUNT_RATIO = 0.7;
+
+export type ToolSurfaceZone = "lean" | "caution" | "overload";
+
+export type ToolSurfaceAssessment = {
+  toolCount: number;
+  /** Estimated tokens the tool definitions consume in the prompt (~chars/4). */
+  estDefinitionTokens: number;
+  /** True once the surface passes the local selection cliff. */
+  exceedsLocalCliff: boolean;
+  /** estDefinitionTokens / window, when the real window is known; else null. */
+  windowShare: number | null;
+  zone: ToolSurfaceZone;
+};
+
+/**
+ * Estimate the token cost of the tool definitions actually sent this dispatch.
+ * Accepts the provider-format tool array (or any serialisable shape); ~chars/4,
+ * matching the codebase's other estimators. Pure.
+ */
+export function estimateToolDefinitionTokens(tools: readonly unknown[] | null | undefined): number {
+  if (!tools || tools.length === 0) return 0;
+  let chars: number;
+  try {
+    chars = JSON.stringify(tools).length;
+  } catch {
+    return 0;
+  }
+  return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+/**
+ * Assess the tool surface handed to the model: count, estimated definition-token
+ * cost, whether it passes the local selection cliff, and a heuristic zone.
+ * Banded by the local cliff (count) and, when the real window is known, by the
+ * definitions' share of it. Pure.
+ */
+export function assessToolSurface(input: {
+  tools: readonly unknown[] | null | undefined;
+  windowTokens?: number | null;
+}): ToolSurfaceAssessment {
+  const toolCount = input.tools?.length ?? 0;
+  const estDefinitionTokens = estimateToolDefinitionTokens(input.tools);
+  const exceedsLocalCliff = toolCount > LOCAL_TOOL_SELECTION_CLIFF;
+  const win = typeof input.windowTokens === "number" && input.windowTokens > 0 ? input.windowTokens : 0;
+  const windowShare = win > 0 ? estDefinitionTokens / win : null;
+
+  let zone: ToolSurfaceZone = "lean";
+  if (exceedsLocalCliff || (windowShare !== null && windowShare >= SURFACE_OVERLOAD_WINDOW_SHARE)) {
+    zone = "overload";
+  } else if (
+    toolCount > Math.floor(LOCAL_TOOL_SELECTION_CLIFF * SURFACE_CAUTION_COUNT_RATIO) ||
+    (windowShare !== null && windowShare >= SURFACE_CAUTION_WINDOW_SHARE)
+  ) {
+    zone = "caution";
+  }
+  return { toolCount, estDefinitionTokens, exceedsLocalCliff, windowShare, zone };
+}
+
+export type ToolCallSample = { toolName: string; success: boolean };
+
+export type ToolSelectionAccuracy = {
+  total: number;
+  succeeded: number;
+  /** succeeded / total, in [0,1]; 1 when there were no calls (nothing failed). */
+  accuracy: number;
+  perTool: Record<string, { total: number; succeeded: number; accuracy: number }>;
+};
+
+/**
+ * Tool-selection / tool-call accuracy over a set of executed tool calls: the
+ * fraction that succeeded, overall and per tool. Used per-turn (over the turn's
+ * executed tools) and, in Phase 2, over a telemetry window. Pure.
+ */
+export function computeToolSelectionAccuracy(
+  executions: readonly ToolCallSample[] | null | undefined,
+): ToolSelectionAccuracy {
+  const perTool: Record<string, { total: number; succeeded: number; accuracy: number }> = {};
+  let total = 0;
+  let succeeded = 0;
+  for (const e of executions ?? []) {
+    if (!e || typeof e.toolName !== "string") continue;
+    total += 1;
+    const ok = e.success === true;
+    if (ok) succeeded += 1;
+    const row = perTool[e.toolName] ?? { total: 0, succeeded: 0, accuracy: 0 };
+    row.total += 1;
+    if (ok) row.succeeded += 1;
+    row.accuracy = row.succeeded / row.total;
+    perTool[e.toolName] = row;
+  }
+  return { total, succeeded, accuracy: total === 0 ? 1 : succeeded / total, perTool };
+}

--- a/docs/architecture/agent-standards-dpf-conformance.md
+++ b/docs/architecture/agent-standards-dpf-conformance.md
@@ -63,7 +63,7 @@ Assessed against `docs/architecture/context-engineering-standards.md` (P1–P13)
 | P8 Cache-first prompt | Partially Implemented | `apps/web/lib/tak/prompt-assembler.ts` | `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` split present; local prefix-KV reuse unverified (R6). |
 | P10 Deterministic enforcement | Implemented | `apps/web/lib/mcp-tools.ts` (kernel gate), `packages/dpf-skill-pack/hooks/` | Kernel runtime gate + PreToolUse prechecks (incl. `tool-economy-precheck.mjs`). |
 | P11 Persist/re-inject across compaction | Partially Implemented | `apps/web/lib/tak/agentic-loop.ts` | `withPlanReminder` keeps the plan out of the compacted window; memory-fact re-injection tracked as R9. |
-| P12 Empirical measurement | Not Implemented | spec §7 (R8) | Tokens-per-task / selection-accuracy harness planned; watch the 15-tool cliff. |
+| P12 Empirical measurement | Partially Implemented (Phase 1) | `apps/web/lib/tak/context-economy-metrics.ts` | Per-turn tool-surface gauge (count + est. definition tokens, banded vs the 15-tool cliff) + tool-selection accuracy, logged in the agentic loop. Cross-task tokens-per-task rollup staged (Phase 2). |
 | Deferred tool exposure on external CLI path | Partially Implemented (Phase 1) | `apps/web/lib/mcp/tool-tier.ts` | Opt-in core tier on `/api/mcp/v1?tier=core` (lean discovery, full execution retained, default unchanged). Model-driven deferral (load_tools + list_changed) staged as Phase 2. |
 
 Recommended next steps for this area are tracked in `docs/superpowers/specs/2026-06-20-context-engineering-tool-efficiency-design.md` (R3, R4, R6, R7, R8, R9) and kept current by `docs/architecture/agent-client-capability-parity.md`.

--- a/docs/architecture/context-engineering-standards.md
+++ b/docs/architecture/context-engineering-standards.md
@@ -36,7 +36,7 @@ Each is a rule + how DPF applies it. Items marked **[ENFORCED]** have an automat
 - **P9 — Isolate heavy work in sub-contexts — but multi-agent ≈ 15× tokens.** Only when task value justifies it; poor fit for tightly-coupled/shared-context work. *[REVIEW]*
 - **P10 — Enforce non-negotiables deterministically.** Hooks / the kernel runtime gate, not prompt hope, for security/audit. DPF is ahead of the field here. *[ENFORCED]* (kernel gate in `executeTool`).
 - **P11 — Persist + re-inject across compaction.** Plans, memory, key instructions must survive the sliding window (`withPlanReminder` already does this for the plan). *[REVIEW]*
-- **P12 — Measure empirically.** Track tokens-per-task, task success, tool-selection accuracy; watch the 15-tool cliff. *Planned harness (R8).*
+- **P12 — Measure empirically.** Track tokens-per-task, task success, tool-selection accuracy; watch the 15-tool cliff. **Phase 1 shipped** — a per-turn **tool-surface + selection-accuracy gauge** (`apps/web/lib/tak/context-economy-metrics.ts`, logged in the agentic loop as `toolSurface/surfaceZone/toolAccuracy` alongside `ctxZone`); `surfaceZone=overload` is the explicit cliff signal. Cross-task rollup staged (R8 Phase 2). *[REVIEW]*
 - **P13 — Do the simplest thing that works.** Reuse substrate; spike before building. *[REVIEW]*
 
 ## Enforcement (how subsequent changes stay conformant)

--- a/docs/superpowers/specs/2026-06-20-context-economy-eval-metrics-design.md
+++ b/docs/superpowers/specs/2026-06-20-context-economy-eval-metrics-design.md
@@ -1,0 +1,41 @@
+# Context-Economy Eval Metrics (R8)
+
+**Status:** Phase 1 SHIPPED (per-turn tool-surface + selection-accuracy gauge, observability-only). Phase 2 (cross-task telemetry rollup) STAGED.
+**Date:** 2026-06-20
+**Standard:** `docs/architecture/context-engineering-standards.md` (P12). **Parent research:** `docs/superpowers/specs/2026-06-20-context-engineering-tool-efficiency-design.md` (R8).
+
+## 1. Why
+
+The standard's P12 says: *measure whether context/tool changes help* — tokens-per-task, task success, tool-selection accuracy — and *watch the tool-count cliff*, because selection accuracy doesn't degrade gracefully: it collapses once a small local model is handed more than ~15 tools (`LOCAL_FALLBACK_MAX_TOOLS`). Without measurement, the R1/R4/R3 wins are asserted, not proven, and a regression (an agent's tool surface ballooning, a tool that keeps failing) is silent. This makes the signals visible.
+
+## 2. Design — mirror the proven gauge pattern
+
+`apps/web/lib/tak/context-pressure.ts` is a pure, import-free, unit-tested "dumb-zone" gauge logged once per turn (`ctxZone=…`). R8 adds a sibling, `apps/web/lib/tak/context-economy-metrics.ts`, in the same shape — nothing it computes changes what is sent to the model; it only makes the figures observable.
+
+**Phase 1 (shipped) — two live signals on the `[turn]` log:**
+- **Tool surface** — `assessToolSurface({ tools, windowTokens })`: the tool count, the estimated definition-token cost (~chars/4 of the provider-format tools actually sent), whether it passes the local selection cliff, and a zone (`lean` / `caution` / `overload`) banded by the cliff (count) and, when the real window is known, by the definitions' share of it.
+- **Tool-selection accuracy** — `computeToolSelectionAccuracy(executions)`: the fraction of the turn's tool calls that succeeded, overall and per tool.
+
+Both are appended to the existing per-turn summary in `agentic-loop.ts` (`logTurnSummary`):
+`… toolSurface=<n> estToolTokens=<t> surfaceZone=<z> toolAccuracy=<a>`.
+
+So a turn that hands a local model 40 tools logs `surfaceZone=overload`, and a tool that fails repeatedly drags `toolAccuracy` down — both now greppable alongside `ctxZone`.
+
+## 3. What this proves
+
+- **R1 (result cap):** large results no longer balloon a turn — visible as stable `ctxPeakTokens`/`ctxZone` rather than spikes.
+- **R3 (core tier) / R4 (programmatic tool calling):** their point is a smaller surface and fewer round-trips — visible as `toolSurface`/`surfaceZone` and (for PTC) fewer tool calls per task at the same `toolAccuracy`.
+- **The cliff:** `surfaceZone=overload` is the explicit, greppable signal that an agent's grant/phase scoping has drifted past what a small local model can select over.
+
+## 4. Phase 2 (staged) — cross-task rollup
+
+The per-turn signals are also the tested primitives for an aggregate view: a telemetry query over `ToolExecution` / `CoworkerTurnMetric` that reports tool-selection accuracy and tokens-per-task **per model / route / window**, so a description or registry change can be gated on a before/after delta (the standard's "track tokens-per-task, task success, selection accuracy"). Deferred because it needs a telemetry query + a surface (and, for tokens-per-task, either a turn-metric field or a derivation), which is heavier and not locally verifiable. `computeToolSelectionAccuracy` already operates over an arbitrary execution window, so the rollup reuses it directly; a `computeTokensPerTask` companion lands with it.
+
+## 5. Tests
+
+`apps/web/lib/tak/context-economy-metrics.test.ts` — `estimateToolDefinitionTokens`, `assessToolSurface` (lean / caution / overload by count and by window share), `computeToolSelectionAccuracy` (overall + per-tool, empty = 1.0, malformed ignored). Pure module → no heavy imports, runs in CI's web suite.
+
+## 6. Files
+
+- `apps/web/lib/tak/context-economy-metrics.ts` (+ `.test.ts`).
+- `apps/web/lib/tak/agentic-loop.ts` — `logTurnSummary` gauge.


### PR DESCRIPTION
## Why

P12 of `docs/architecture/context-engineering-standards.md` — *measure empirically*. Until now the R1/R3/R4 token wins were asserted, not proven, and a regression (an agent's tool surface ballooning past the local ~15-tool selection cliff, or a tool that keeps failing) was silent. This makes those signals visible per turn.

## What ships — Phase 1 (observability-only)

- **`apps/web/lib/tak/context-economy-metrics.ts`** — pure, import-free (mirrors `context-pressure.ts`):
  - `assessToolSurface({tools, windowTokens})` → count + estimated definition-token cost + `lean`/`caution`/`overload` zone, banded against `LOCAL_TOOL_SELECTION_CLIFF=15` and the definitions' share of a known window.
  - `computeToolSelectionAccuracy(executions)` → succeeded/attempted, overall and per tool.
- **`agentic-loop.ts` `logTurnSummary`** appends `toolSurface=N estToolTokens=X surfaceZone=Z toolAccuracy=A` next to the existing `ctxZone` gauge. **Never changes what is sent to the model** — same contract as the dumb-zone gauge.

So a turn that hands a local model 40 tools logs `surfaceZone=overload`; a repeatedly-failing tool drags `toolAccuracy` down — both now greppable. This is the explicit cliff signal P12 calls for.

## Staged — Phase 2

A cross-task telemetry rollup over `ToolExecution`/`CoworkerTurnMetric` (tool-selection accuracy + tokens-per-task per model/route/window) so registry/description changes can be gated on a before/after delta. `computeToolSelectionAccuracy` already operates over an arbitrary window, so the rollup reuses it. Deferred (needs a telemetry query + surface; not locally verifiable).

## Tests

`apps/web/lib/tak/context-economy-metrics.test.ts` — surface zones (by count and window share), selection accuracy (overall + per-tool, empty=1.0, malformed ignored). Pure, runs in CI.

Spec: `docs/superpowers/specs/2026-06-20-context-economy-eval-metrics-design.md`. Standards P12 + conformance updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)