### PR TITLE
fix(self-upgrade): stop a successful upgrade reporting "Upgrade postponed, failed"

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -6,6 +6,7 @@ import {
   isInngestSelfSyncOnBootEnabled,
   isStartupModelRevalidationEnabled,
   reconcileSelfUpgradeRunsOnBoot,
+  reconcileQuiescenceRunsOnBoot,
   recoverContradictoryBuildExecStatesOnBoot,
   resumeStrandedBuildsOnBoot,
   scheduleInitialCodeGraphBootstrap,
@@ -29,6 +30,7 @@ const productVersionFindManyMock = vi.fn();
 const changePromotionUpdateManyMock = vi.fn();
 const isFeatureBuildDeployedMock = vi.fn();
 const reconcileBuildCompletionMock = vi.fn();
+const reconcileQuiescenceOnBootMock = vi.fn();
 
 vi.mock("@/lib/platform/version-config", () => ({
   syncPlatformVersionConfig: (...args: unknown[]) => syncPlatformVersionConfigMock(...args),
@@ -41,6 +43,10 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
 
 vi.mock("@/lib/build-flow-state", () => ({
   reconcileBuildCompletion: (...args: unknown[]) => reconcileBuildCompletionMock(...args),
+}));
+
+vi.mock("@/lib/self-upgrade/quiescence", () => ({
+  reconcileQuiescenceOnBoot: (...args: unknown[]) => reconcileQuiescenceOnBootMock(...args),
 }));
 
 vi.mock("@/lib/self-upgrade/run-store", () => ({
@@ -97,6 +103,8 @@ beforeEach(() => {
   changePromotionUpdateManyMock.mockReset();
   isFeatureBuildDeployedMock.mockReset();
   reconcileBuildCompletionMock.mockReset();
+  reconcileQuiescenceOnBootMock.mockReset();
+  reconcileQuiescenceOnBootMock.mockResolvedValue({ reconciled: 0, failed: 0 });
   featureBuildUpdateMock.mockResolvedValue({});
   featureBuildUpdateManyMock.mockResolvedValue({ count: 1 });
   buildActivityCreateMock.mockResolvedValue({});
@@ -362,6 +370,44 @@ describe("reconcileSelfUpgradeRunsOnBoot", () => {
 
     expect(result).toEqual({ succeeded: 0, failed: 1 });
     expect(failRunMock).toHaveBeenCalledWith("SUR-HUNG", expect.stringContaining("watchdog"));
+  });
+});
+
+describe("reconcileQuiescenceRunsOnBoot (wrapper)", () => {
+  it("passes the deployed SHA as BOTH currentVersion and currentBundleHash", async () => {
+    // The runtime identity (DEPLOYED_SHA) equals the self-upgrade's stored
+    // targetBundleHash; passing it for both fields makes the lib reconciler's
+    // match robust regardless of which field a row populated.
+    getDeployedShaMock.mockResolvedValueOnce("deployed-sha");
+    reconcileQuiescenceOnBootMock.mockResolvedValueOnce({ reconciled: 1, failed: 0 });
+
+    const result = await reconcileQuiescenceRunsOnBoot({ log: vi.fn(), warn: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ reconciled: 1, failed: 0 });
+    expect(reconcileQuiescenceOnBootMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentVersion: "deployed-sha",
+        currentBundleHash: "deployed-sha",
+        staleAfterMs: 0,
+      }),
+    );
+  });
+
+  it("forwards staleAfterMs in periodic mode", async () => {
+    getDeployedShaMock.mockResolvedValueOnce("deployed-sha");
+    await reconcileQuiescenceRunsOnBoot(
+      { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      { staleAfterMs: 30 * 60 * 1000 },
+    );
+    expect(reconcileQuiescenceOnBootMock).toHaveBeenCalledWith(
+      expect.objectContaining({ staleAfterMs: 30 * 60 * 1000 }),
+    );
+  });
+
+  it("is non-fatal: returns null when resolving the deployed SHA throws", async () => {
+    getDeployedShaMock.mockRejectedValueOnce(new Error("boom"));
+    const result = await reconcileQuiescenceRunsOnBoot({ log: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    expect(result).toBeNull();
   });
 });
 

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -220,6 +220,40 @@ export async function reconcileSelfUpgradeRunsOnBoot(
 }
 
 /**
+ * Boot/periodic reconcile for QuiescenceRun rows orphaned by a self-swap — the
+ * quiescence-coordinator counterpart to reconcileSelfUpgradeRunsOnBoot. A real
+ * upgrade recreates this very portal, killing the orchestrator before it can
+ * deliver the coordinator's swap-complete handshake; the coordinator (suspended
+ * in Inngest) then runs out its full 10-minute wait and falsely records
+ * `outcome=failed`, which the operator banner renders as "Upgrade postponed,
+ * failed" even though the swap SUCCEEDED. The surviving portal resolves the
+ * running bundle identity and lets the lib reconciler close the loop. Non-fatal.
+ */
+export async function reconcileQuiescenceRunsOnBoot(
+  logger: Pick<Console, "log" | "warn" | "error"> = console,
+  opts: { staleAfterMs?: number; now?: () => Date } = {},
+): Promise<{ reconciled: number; failed: number } | null> {
+  try {
+    const { getDeployedSha } = await import("@/lib/self-upgrade/completion");
+    const { reconcileQuiescenceOnBoot } = await import("@/lib/self-upgrade/quiescence");
+    const deployedSha = await getDeployedSha();
+    return await reconcileQuiescenceOnBoot({
+      // A self-upgrade stores the deployed/merge identity in targetBundleHash;
+      // the runtime exposes that same identity as DEPLOYED_SHA. Pass it for both
+      // fields so the match is robust across upstream- and local-mode rows.
+      currentVersion: deployedSha,
+      currentBundleHash: deployedSha,
+      staleAfterMs: opts.staleAfterMs ?? 0,
+      now: opts.now?.(),
+      logger,
+    });
+  } catch (err) {
+    logger.error("[quiescence-reconcile] wrapper failed (non-fatal):", err);
+    return null;
+  }
+}
+
+/**
  * Self-heal a stuck quiescence level on boot. A real upgrade flips the level to
  * "draining"/"swapping" and recreates the portal — killing both the
  * orchestrator and the coordinator before either can flip it back to "normal".
@@ -788,6 +822,19 @@ export async function register() {
     setInterval(
       () => {
         void reconcileSelfUpgradeRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
+      },
+      20 * 60 * 1000,
+    );
+
+    // Close the SAME self-swap gap for the quiescence coordinator. A succeeded
+    // upgrade whose swap kills the orchestrator leaves the coordinator to time
+    // out and falsely emit `failed`, surfacing as a bogus "Upgrade postponed,
+    // failed" banner. The surviving portal completes the swap-complete handshake
+    // here (boot), plus a periodic net for the portal-stays-up orphan case.
+    void reconcileQuiescenceRunsOnBoot();
+    setInterval(
+      () => {
+        void reconcileQuiescenceRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
       },
       20 * 60 * 1000,
     );

--- a/apps/web/lib/self-upgrade/quiescence.test.ts
+++ b/apps/web/lib/self-upgrade/quiescence.test.ts
@@ -18,6 +18,7 @@ const prismaMock = vi.hoisted(() => ({
   toolExecutionFindMany: vi.fn(),
   quiescenceRunFindUnique: vi.fn(),
   quiescenceRunUpdate: vi.fn(),
+  quiescenceRunFindMany: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -36,6 +37,7 @@ vi.mock("@dpf/db", () => ({
     quiescenceRun: {
       findUnique: (...args: unknown[]) => prismaMock.quiescenceRunFindUnique(...args),
       update: (...args: unknown[]) => prismaMock.quiescenceRunUpdate(...args),
+      findMany: (...args: unknown[]) => prismaMock.quiescenceRunFindMany(...args),
     },
   },
 }));
@@ -43,6 +45,11 @@ vi.mock("@dpf/db", () => ({
 const inngestSendMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/queue/inngest-client", () => ({
   inngest: { send: (...args: unknown[]) => inngestSendMock(...args) },
+}));
+
+const broadcastSystemMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/tak/agent-event-bus", () => ({
+  agentEventBus: { broadcastSystem: (...args: unknown[]) => broadcastSystemMock(...args) },
 }));
 
 import {
@@ -58,6 +65,8 @@ import {
   pickPrimaryBlocker,
   QuiescingError,
   QUIESCENCE_RUN_STATUSES,
+  quiescenceTargetMatchesRunningBundle,
+  reconcileQuiescenceOnBoot,
   reconcileTerminalBuildPhaseRuns,
   signalSwapComplete,
   TERMINAL_QUIESCENCE_STATUSES,
@@ -74,6 +83,158 @@ beforeEach(() => {
   prismaMock.toolExecutionFindMany.mockResolvedValue([]);
   prismaMock.quiescenceRunFindUnique.mockResolvedValue(null);
   prismaMock.quiescenceRunUpdate.mockResolvedValue({});
+  prismaMock.quiescenceRunFindMany.mockResolvedValue([]);
+});
+
+const DEPLOYED = "b9bfac549e2723ff1ae903c80ef4b29849e693b5";
+const UPSTREAM = "cf3dd6546c1dbc5aa1ade8bb4c8ecf0153030053";
+const OTHER = "c513c5dd210f488d0bbe113394bdfd4589586630";
+
+function swapCompleteCalls(outcome: "succeeded" | "failed") {
+  return inngestSendMock.mock.calls.filter(
+    (c) =>
+      (c[0] as { name?: string; data?: { outcome?: string } })?.name ===
+        "ops/quiescence.swap-complete" &&
+      (c[0] as { data?: { outcome?: string } })?.data?.outcome === outcome,
+  );
+}
+
+describe("quiescenceTargetMatchesRunningBundle", () => {
+  it("matches when the running SHA equals targetBundleHash (the deploy identity)", () => {
+    // A self-upgrade stores the upstream lineage marker in targetVersion and the
+    // deployed/merge identity in targetBundleHash — the running SHA is the latter.
+    expect(
+      quiescenceTargetMatchesRunningBundle(
+        { targetVersion: UPSTREAM, targetBundleHash: DEPLOYED },
+        DEPLOYED,
+        DEPLOYED,
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT match a row whose target bundle we did not boot onto (real failure)", () => {
+    expect(
+      quiescenceTargetMatchesRunningBundle(
+        { targetVersion: "x", targetBundleHash: OTHER },
+        DEPLOYED,
+        DEPLOYED,
+      ),
+    ).toBe(false);
+  });
+
+  it("is case-insensitive and never matches on empty fields", () => {
+    expect(
+      quiescenceTargetMatchesRunningBundle(
+        { targetVersion: null, targetBundleHash: DEPLOYED.toUpperCase() },
+        DEPLOYED,
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      quiescenceTargetMatchesRunningBundle({ targetVersion: null, targetBundleHash: null }, DEPLOYED, DEPLOYED),
+    ).toBe(false);
+    expect(
+      quiescenceTargetMatchesRunningBundle({ targetVersion: UPSTREAM, targetBundleHash: DEPLOYED }, null, null),
+    ).toBe(false);
+  });
+});
+
+describe("reconcileQuiescenceOnBoot (false-negative 'Upgrade postponed, failed' fix)", () => {
+  it("completes the swap-complete handshake for an in-flight run we booted onto", async () => {
+    prismaMock.quiescenceRunFindMany
+      // in-flight query
+      .mockResolvedValueOnce([
+        { runId: "QR-1", targetVersion: UPSTREAM, targetBundleHash: DEPLOYED, triggerRefId: "SUR-1" },
+      ])
+      // stale-failed query
+      .mockResolvedValueOnce([]);
+
+    const res = await reconcileQuiescenceOnBoot({
+      currentVersion: DEPLOYED,
+      currentBundleHash: DEPLOYED,
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    expect(res).toEqual({ reconciled: 1, failed: 0 });
+    // Drove the LIVE coordinator's success path (it owns the cleared/succeeded emit).
+    expect(swapCompleteCalls("succeeded")).toHaveLength(1);
+    expect(swapCompleteCalls("failed")).toHaveLength(0);
+  });
+
+  it("fails an in-flight run whose target we did NOT boot onto (orphaned)", async () => {
+    prismaMock.quiescenceRunFindMany
+      .mockResolvedValueOnce([
+        { runId: "QR-2", targetVersion: "x", targetBundleHash: OTHER, triggerRefId: "SUR-2" },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const res = await reconcileQuiescenceOnBoot({
+      currentVersion: DEPLOYED,
+      currentBundleHash: DEPLOYED,
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    expect(res).toEqual({ reconciled: 0, failed: 1 });
+    expect(swapCompleteCalls("failed")).toHaveLength(1);
+    expect(swapCompleteCalls("succeeded")).toHaveLength(0);
+  });
+
+  it("corrects a false-negative terminal `failed` run we actually booted onto", async () => {
+    prismaMock.quiescenceRunFindUnique.mockResolvedValue({ enteredStateAt: {} });
+    prismaMock.quiescenceRunUpdate.mockResolvedValue({ status: "completed", enteredStateAt: {} });
+    prismaMock.quiescenceRunFindMany
+      // in-flight query — none
+      .mockResolvedValueOnce([])
+      // stale-failed query — one false negative + one genuine failure
+      .mockResolvedValueOnce([
+        { runId: "QR-3", targetVersion: UPSTREAM, targetBundleHash: DEPLOYED, triggerRefId: "SUR-3" },
+        { runId: "QR-4", targetVersion: "x", targetBundleHash: OTHER, triggerRefId: "SUR-4" },
+      ]);
+
+    const res = await reconcileQuiescenceOnBoot({
+      currentVersion: DEPLOYED,
+      currentBundleHash: DEPLOYED,
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    // Only the matching false negative is corrected; the genuine failure is left alone.
+    expect(res).toEqual({ reconciled: 1, failed: 0 });
+    const update = prismaMock.quiescenceRunUpdate.mock.calls[0]![0] as {
+      where: { runId: string };
+      data: { status: string; outcome: string; completionSource: string };
+    };
+    expect(update.where.runId).toBe("QR-3");
+    expect(update.data.status).toBe("completed");
+    expect(update.data.outcome).toBe("succeeded");
+    expect(update.data.completionSource).toBe("boot-reconciler");
+    // Re-announced a truthful cleared/succeeded so the banner corrects.
+    expect(broadcastSystemMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "system:quiescence", level: "cleared", outcome: "succeeded" }),
+    );
+  });
+
+  it("periodic mode (staleAfterMs>0) scopes the in-flight query by startedAt so a live drain is untouched", async () => {
+    prismaMock.quiescenceRunFindMany.mockResolvedValue([]);
+    await reconcileQuiescenceOnBoot({
+      currentVersion: DEPLOYED,
+      currentBundleHash: DEPLOYED,
+      staleAfterMs: 30 * 60 * 1000,
+      now: new Date("2026-06-20T18:00:00.000Z"),
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const inFlightWhere = (prismaMock.quiescenceRunFindMany.mock.calls[0]![0] as { where: Record<string, unknown> }).where;
+    expect(inFlightWhere).toHaveProperty("startedAt");
+  });
+
+  it("is non-fatal: a DB error returns zero counts instead of throwing", async () => {
+    prismaMock.quiescenceRunFindMany.mockRejectedValue(new Error("db down"));
+    const res = await reconcileQuiescenceOnBoot({
+      currentVersion: DEPLOYED,
+      currentBundleHash: DEPLOYED,
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    expect(res).toEqual({ reconciled: 0, failed: 0 });
+  });
 });
 
 describe("escalateQuiescenceToForced (BI-4F3B2FA9)", () => {

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -578,32 +578,206 @@ export async function isShipForceEscalated(runId: string): Promise<boolean> {
 }
 
 /**
- * Called from app boot (BI-QUIESCE-010 integration). Scans for QuiescenceRun
- * rows that were in flight when the previous bundle died. If the running
- * bundle's version matches `targetVersion`, marks as completed via
- * boot-reconciler. Otherwise marks as failed so caller can decide what to do.
- *
- * Either way, level is forced to normal and platform.quiescence-cleared
- * fires so the new bundle starts in a clean state.
- *
- * BI-QUIESCE-010 wires this into the app startup sequence; v1 is a stub
- * that just returns the candidate runs without action.
+ * Broadcast a `platform.quiescence-cleared` terminal event from OUTSIDE the
+ * coordinator (the boot reconciler). Mirrors quiescence-run.ts:emitCleared:
+ * SSE first so any connected operator banner dismisses immediately, then the
+ * Inngest event so suspended functions wake. Best-effort on the SSE leg.
  */
-export async function reconcileQuiescenceOnBoot(_opts: {
-  currentVersion: string;
-  currentBundleHash: string;
+async function broadcastQuiescenceCleared(payload: {
+  runId: string;
+  outcome: "succeeded" | "failed";
+  triggerRefId: string | null;
+  reason?: string | null;
+}): Promise<void> {
+  invalidateQuiescenceCache();
+  try {
+    const { agentEventBus } = await import("@/lib/tak/agent-event-bus");
+    agentEventBus.broadcastSystem({
+      type: "system:quiescence",
+      level: "cleared",
+      runId: payload.runId,
+      swapEtaSeconds: null,
+      deferReason: null,
+      deferSurface: null,
+      outcome: payload.outcome,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(sanitizeForLog(`[quiescence-reconcile] broadcastSystem failed: ${msg}`));
+  }
+  const { inngest } = await import("@/lib/queue/inngest-client");
+  await inngest.send({
+    name: "platform.quiescence-cleared",
+    data: {
+      runId: payload.runId,
+      outcome: payload.outcome,
+      triggerRefId: payload.triggerRefId,
+      deferSurface: null,
+      reason: payload.reason ?? null,
+    },
+  });
+}
+
+/**
+ * True when the running bundle is the one this QuiescenceRun was draining
+ * toward — i.e. the swap it coordinated actually landed and we booted on its
+ * target. A self-upgrade stores the merge/deploy identity in `targetBundleHash`
+ * (the upstream lineage marker lives in `targetVersion`, which is NOT the
+ * runtime identity), so the deployed SHA is matched against EITHER field to be
+ * robust to local-mode rows where they coincide. Case-insensitive; empty
+ * fields never match.
+ */
+export function quiescenceTargetMatchesRunningBundle(
+  run: { targetVersion: string | null; targetBundleHash: string | null },
+  currentVersion: string | null,
+  currentBundleHash: string | null,
+): boolean {
+  const candidates = [currentVersion, currentBundleHash]
+    .filter((s): s is string => !!s)
+    .map((s) => s.toLowerCase());
+  if (candidates.length === 0) return false;
+  const targets = [run.targetVersion, run.targetBundleHash]
+    .filter((s): s is string => !!s)
+    .map((s) => s.toLowerCase());
+  return targets.some((t) => candidates.includes(t));
+}
+
+const NON_TERMINAL_QUIESCENCE_STATUSES = QUIESCENCE_RUN_STATUSES.filter(
+  (s) => !TERMINAL_QUIESCENCE_STATUSES.has(s),
+);
+
+/**
+ * Reconcile QuiescenceRun rows on boot (and on a periodic safety tick). The
+ * counterpart to instrumentation.ts:reconcileSelfUpgradeRunsOnBoot, closing the
+ * SAME self-swap gap for the quiescence coordinator: a real upgrade recreates
+ * this very portal, killing the orchestrator before it can deliver the
+ * swap-complete handshake — so the coordinator (suspended in Inngest) runs out
+ * its full 10-minute `waitForEvent` and falsely records `outcome=failed`, which
+ * the operator banner renders as "Upgrade postponed, failed" even though the
+ * swap succeeded. The surviving (new) portal closes the loop here.
+ *
+ * Two cases, both keyed on "are we running this run's target bundle?":
+ *
+ *  1. In-flight rows (non-terminal status). The coordinator is still suspended
+ *     at `waitForEvent`. If we booted on its target, the swap landed → send the
+ *     swap-complete signal so the LIVE coordinator finishes through its own
+ *     success path (transition completed + flip level normal + emit
+ *     quiescence-cleared/succeeded). If we did NOT boot on its target, the swap
+ *     never landed → drive the coordinator's failure path so it stops waiting.
+ *
+ *  2. Already-`failed` rows whose target we ARE running (within `failedLookbackMs`).
+ *     The coordinator timed out before this portal booted (slow boot), so its
+ *     terminal `failed` is a false negative. Correct it to `completed`
+ *     (completionSource='boot-reconciler') and re-emit a truthful
+ *     quiescence-cleared/succeeded so the banner is accurate.
+ *
+ * `staleAfterMs` mirrors the self-upgrade reconciler: 0 (boot default) touches
+ * every in-flight row because a boot means any in-flight coordinator is orphaned;
+ * >0 (periodic mode) only touches in-flight rows older than the window, so a
+ * legitimately in-flight drain on a still-running portal is never reconciled out
+ * from under itself. Note the target-match guard already prevents failing a live
+ * drain: a drain that has not swapped yet does not match the running bundle.
+ *
+ * Non-fatal; returns counts. Level normalisation is also handled independently
+ * by resetStuckQuiescenceLevelOnBoot, so a throw here never strands the level.
+ */
+export async function reconcileQuiescenceOnBoot(opts: {
+  currentVersion: string | null;
+  currentBundleHash: string | null;
+  staleAfterMs?: number;
+  failedLookbackMs?: number;
   now?: Date;
+  logger?: Pick<Console, "log" | "warn" | "error">;
 }): Promise<{ reconciled: number; failed: number }> {
-  // Stub for BI-QUIESCE-010. Real implementation will:
-  //   1. Query QuiescenceRun WHERE status IN (pending, preparing, draining,
-  //      ready-to-swap, swapping)
-  //   2. Per row: if targetVersion matches currentVersion AND
-  //      targetBundleHash matches → transition to completed
-  //      (completionSource='boot-reconciler')
-  //      Otherwise → transition to failed (completionSource='boot-reconciler')
-  //   3. Force level to normal
-  //   4. Emit platform.quiescence-cleared for each
-  return { reconciled: 0, failed: 0 };
+  const logger = opts.logger ?? console;
+  const now = opts.now ?? new Date();
+  const staleAfterMs = opts.staleAfterMs ?? 0;
+  const failedLookbackMs = opts.failedLookbackMs ?? 30 * 60 * 1000;
+
+  let reconciled = 0;
+  let failed = 0;
+
+  try {
+    // ── Case 1: in-flight coordinators orphaned by the swap ──────────────
+    const inFlight = await prisma.quiescenceRun.findMany({
+      where:
+        staleAfterMs > 0
+          ? {
+              status: { in: [...NON_TERMINAL_QUIESCENCE_STATUSES] },
+              startedAt: { lt: new Date(now.getTime() - staleAfterMs) },
+            }
+          : { status: { in: [...NON_TERMINAL_QUIESCENCE_STATUSES] } },
+      select: { runId: true, targetVersion: true, targetBundleHash: true, triggerRefId: true },
+    });
+    for (const run of inFlight) {
+      if (quiescenceTargetMatchesRunningBundle(run, opts.currentVersion, opts.currentBundleHash)) {
+        // We booted on this run's target → the swap landed. Complete the
+        // handshake the dying portal couldn't: the live coordinator resumes
+        // through success and emits quiescence-cleared/succeeded itself.
+        await signalSwapComplete(run.runId);
+        reconciled++;
+        logger.log(
+          sanitizeForLog(
+            `[quiescence-reconcile] ${run.runId} -> swap-complete (booted on target ${opts.currentVersion ?? "?"})`,
+          ),
+        );
+      } else {
+        // Not running its target → the swap did not land; the row is orphaned.
+        await failQuiescenceSwap(
+          run.runId,
+          `Reconciled on boot: running bundle does not match target (deployed=${opts.currentBundleHash ?? opts.currentVersion ?? "unknown"} targetBundle=${run.targetBundleHash ?? "unknown"})`,
+        );
+        failed++;
+        logger.log(`[quiescence-reconcile] ${run.runId} -> failed (orphaned, target mismatch)`);
+      }
+    }
+
+    // ── Case 2: false-negative `failed` rows we actually booted onto ─────
+    // The coordinator timed out before this portal came up, so its terminal
+    // `failed` is wrong (we are running its target). Correct + re-announce.
+    const staleFailed = await prisma.quiescenceRun.findMany({
+      where: {
+        status: "failed",
+        completedAt: { gte: new Date(now.getTime() - failedLookbackMs) },
+      },
+      select: { runId: true, targetVersion: true, targetBundleHash: true, triggerRefId: true },
+    });
+    for (const run of staleFailed) {
+      if (!quiescenceTargetMatchesRunningBundle(run, opts.currentVersion, opts.currentBundleHash)) {
+        continue;
+      }
+      await transitionState(
+        run.runId,
+        "completed",
+        {
+          completedAt: now,
+          swapCompletedAt: now,
+          outcome: "succeeded",
+          completionSource: "boot-reconciler",
+          outcomeNotes:
+            "Reconciled on boot: swap landed (running bundle matches target); the coordinator had falsely timed out before this portal booted.",
+        },
+        now,
+      );
+      await broadcastQuiescenceCleared({
+        runId: run.runId,
+        outcome: "succeeded",
+        triggerRefId: run.triggerRefId,
+      });
+      reconciled++;
+      logger.log(
+        sanitizeForLog(`[quiescence-reconcile] ${run.runId} -> corrected failed→completed (false negative)`),
+      );
+    }
+
+    if (reconciled || failed) {
+      logger.log(`[quiescence-reconcile] resolved ${reconciled} reconciled, ${failed} failed`);
+    }
+    return { reconciled, failed };
+  } catch (err) {
+    logger.error("[quiescence-reconcile] failed (non-fatal):", err);
+    return { reconciled, failed };
+  }
 }
 
 // ─── Active session blockers — evidence capture ──────────────────────────

--- a/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
@@ -405,6 +405,27 @@ export async function abortQuiescence(runId: string, operatorUserId: string): Pr
 
 // Called during platform-version boot reconciliation. Completes or fails a
 // swapping run left behind by a process/container replacement.
+//
+// LANDED (2026-06-20). Implemented in apps/web/lib/self-upgrade/quiescence.ts
+// and wired at boot + on a 20-min periodic safety net in
+// apps/web/instrumentation.ts (alongside reconcileSelfUpgradeRunsOnBoot). It
+// matches a run's stored target against the running bundle identity
+// (DEPLOYED_SHA, compared to targetBundleHash/targetVersion), then: in-flight +
+// match -> signalSwapComplete (drive the live coordinator's success path);
+// in-flight + no-match -> failQuiescenceSwap; recently-`failed` + match ->
+// transition completed (completionSource="boot-reconciler") + re-emit a
+// truthful quiescence-cleared/succeeded.
+//
+// Why it was load-bearing: until it landed, the stub returned `{reconciled:0}`
+// and was never called, so EVERY successful self-upgrade whose swap recreated
+// the portal orphaned the coordinator, which then ran out its full 10-minute
+// waitForEvent and emitted `outcome=failed`. The PlatformBanner rendered that
+// as "Upgrade postponed, failed. You can continue working." even though the
+// SelfUpgradeRun was `succeeded` and DEPLOYED_SHA matched the target — a
+// false-negative observed on the live install for the 2026-06-18 and
+// 2026-06-20 upgrades (QuiescenceRun.outcomeNotes = "swap-complete signal never
+// received within 10m"). The new portal now completes the handshake the dying
+// portal could not.
 export async function reconcileQuiescenceOnBoot(): Promise<void>;
 
 type QuiescenceOutcome =


### PR DESCRIPTION
## Problem

A successful self-upgrade surfaces a false **"Upgrade postponed, failed. You can continue working."** banner to the operator.

Confirmed on the live install: the 2026-06-18 and 2026-06-20 upgrades both have `SelfUpgradeRun.status = succeeded` with `DEPLOYED_SHA` matching the target, yet their `QuiescenceRun.outcome = failed` (`outcomeNotes = "swap-complete signal never received within 10m"`). `PlatformBanner` reads that `outcome=failed` over SSE and renders the bogus banner.

## Root cause

A real upgrade recreates the portal container that runs the upgrade orchestrator, so the **dying portal can't deliver the coordinator's `swap-complete` handshake**. The quiescence coordinator (suspended in Inngest) runs out its full 10-minute `waitForEvent` and emits `outcome=failed`.

The intended durable fallback — `reconcileQuiescenceOnBoot()` — was an **unimplemented stub** (`return {reconciled:0, failed:0}`) and **was never wired into boot**. Its sibling `reconcileSelfUpgradeRunsOnBoot()` already closes the same self-swap gap for the `SelfUpgradeRun` (which is why the run shows `succeeded`), leaving the asymmetry that produces the false banner.

## Fix

Implement `reconcileQuiescenceOnBoot()` and wire it at boot + a 20-min periodic safety net in `instrumentation.ts`, alongside `reconcileSelfUpgradeRunsOnBoot()`. It matches the running bundle identity (`DEPLOYED_SHA`) against each run's `targetBundleHash`/`targetVersion`:

- **in-flight + match** → `signalSwapComplete` (drives the live coordinator's own success path → emits `quiescence-cleared/succeeded`; the surviving portal completes the handshake the dying one couldn't)
- **in-flight + no-match** → `failQuiescenceSwap` (genuine orphan; stops the wait)
- **recently-failed + match** → correct to `completed` (`completionSource="boot-reconciler"`) + re-emit a truthful `quiescence-cleared/succeeded` (slow-boot case where the coordinator timed out before the new portal booted)

The target-match guard inherently prevents racing a live drain (a drain that hasn't swapped yet doesn't match the running bundle); periodic mode adds a `staleAfterMs` window mirroring the self-upgrade reconciler.

## Verification

- `apps/web/lib/self-upgrade/quiescence.test.ts` — 6 new unit tests (match helper + all reconcile branches + non-fatal). **PASS** (53/53).
- `apps/web/instrumentation.test.ts` — 3 new wrapper tests. **PASS** (combined 92/92).
- `pnpm --filter web typecheck` — **PASS** (exit 0).
- Substrate: source-local gates (worktree); `next build` / live UX verification route through the canonical install on deploy.
- Spec `2026-05-24-activity-quiescence-protocol-design.md` updated: `reconcileQuiescenceOnBoot` marked **LANDED** with the false-negative evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)