### PR TITLE
fix(build-runtime): correct over-stated embedding-model-first diagnostic (BI-9AAE9C15)

### DIFF
--- a/apps/web/lib/inference/phase-model-resolution.ts
+++ b/apps/web/lib/inference/phase-model-resolution.ts
@@ -368,12 +368,17 @@ async function resolveBuildPhase(
         });
       }
       if (pre.models.length > 0 && isLikelyNonChatModel(pre.models[0]!)) {
+        // Informational, not a failure: when no model is pinned the build resolves
+        // via pickDefaultCodingModel (opencode-dispatch.ts), which filters OUT
+        // non-chat models and prefers a coder — so a leading embedding model is
+        // auto-skipped, never selected for code generation. The served order is a
+        // config nit worth surfacing, not a routing risk (BI-9AAE9C15).
         flags.push({
-          severity: "warning",
+          severity: "info",
           code: "embedding-model-first",
-          message: `The local endpoint lists a non-chat model ("${pre.models[0]}") first. If no model is pinned, an embedding model can be selected for code generation.`,
+          message: `The local endpoint lists a non-chat model ("${pre.models[0]}") first. The build auto-selects a coding model and skips non-chat models, so this is not a failure — pin the OpenCode model in Build Runtime to make the choice explicit.`,
           remediation:
-            "Pin the OpenCode model in Build Runtime, or reorder the served models so a coder model is first.",
+            "Optional: pin the OpenCode model in Build Runtime, or reorder the served models so a coder model is first.",
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Finding
While verifying [BI-9AAE9C15], the build-phase model resolution turned out to be **already safe**: both the diagnostic resolver (`preflightLocalEndpoint`) and the real dispatch (`dispatchOpencodeTask:374`) resolve the local model via `pickDefaultCodingModel` (`opencode-dispatch.ts:136`), which **filters out non-chat models and prefers a coder**. A leading embedding model (`nomic-embed`) is auto-skipped — it cannot be selected for code generation.

So the `embedding-model-first` flag in `resolve_model_selection` was **inaccurate**: it told the operator "an embedding model can be selected for code generation," implying a failure mode that cannot occur — which would make a working build path look broken.

## Fix
- Downgrade the flag to `severity: "info"` and reword to reflect reality: the served order is a config nit (pin to be explicit), not a routing risk.
- The genuine guardrail — an operator *explicitly pinning* an embedding model — keeps its real warning at `opencode-dispatch.ts:199`.
- The existing test asserts only the flag `code`, so it stays green.

No behavior change to model selection (it was already correct); this is diagnostic-copy accuracy so the operator trusts the runtime-health surface.

## Substrate
Source-only worktree (`.pnpm` empty) — typecheck/tests rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)