### PR TITLE
feat(self-upgrade): auto-pick an overnight maintenance window for 24/7 stores (BI-A6382FB9)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -70,6 +70,7 @@ const baseStatus = {
   inMaintenanceWindow: false,
   windowConfigured: true,
   windowSource: "operating-hours" as const,
+  autoWindowSummary: null,
   storeOpen: false,
   windowTimezone: "UTC",
   nextWindowStart: null,

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -168,6 +168,35 @@ describe("SelfUpgradeClient – enabled", () => {
     expect(html).toContain("next scheduled check");
     expect(html).toContain("May 24, 2026");
   });
+
+  // BI-A6382FB9 — a 24/7 store auto-runs overnight; the panel explains the
+  // schedule in plain language instead of asking the operator to configure cron.
+  it("shows the 24/7 overnight note when windowSource is auto-overnight", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        windowConfigured={true}
+        windowSource="auto-overnight"
+        autoWindowSummary="2:00 AM–4:00 AM"
+        windowTimezone="America/Chicago"
+        nextWindowStart="2026-05-26T02:00:00.000Z"
+      />,
+    );
+    expect(html).toContain("runs 24/7");
+    expect(html).toContain("2:00 AM–4:00 AM");
+    expect(html).toContain("America/Chicago");
+  });
+
+  // BI-A6382FB9 — only when a timezone genuinely can't be derived does the panel
+  // ask, and it points at the EXISTING Operating Hours timezone picker.
+  it("prompts for a timezone when windowSource is needs-timezone", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient {...baseStatus} windowConfigured={true} windowSource="needs-timezone" />,
+    );
+    expect(html).toContain("Set your timezone");
+    expect(html).toContain("/storefront/settings/operations");
+    expect(html).toContain('data-window-source="needs-timezone"');
+  });
 });
 
 // ─── Running ──────────────────────────────────────────────────────────────────

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -78,6 +78,14 @@ type Props = {
   channel: string;
   inMaintenanceWindow: boolean;
   windowConfigured?: boolean;
+  /**
+   * Which model produced the upgrade window. "auto-overnight" = 24/7 store, auto-
+   * picked overnight slot; "needs-timezone" = 24/7 store with no known timezone,
+   * so the panel asks for one instead of guessing. (BI-A6382FB9)
+   */
+  windowSource?: "explicit" | "operating-hours" | "auto-overnight" | "needs-timezone";
+  /** Friendly window-time range (e.g. "2:00 AM-4:00 AM") for the auto-overnight note. */
+  autoWindowSummary?: string | null;
   /** IANA timezone the upgrade window is evaluated in (store operating hours). */
   windowTimezone?: string;
   nextWindowStart?: string | null;
@@ -238,6 +246,8 @@ export default function SelfUpgradeClient({
   channel,
   inMaintenanceWindow,
   windowConfigured,
+  windowSource,
+  autoWindowSummary,
   windowTimezone,
   nextWindowStart,
   nextScheduledCheckAt,
@@ -885,7 +895,15 @@ export default function SelfUpgradeClient({
           data-window-configured={windowConfigured ? "true" : "false"}
         >
           <span className="font-medium text-[var(--dpf-text)]">Schedule:</span>{" "}
-          {!windowConfigured ? (
+          {windowSource === "needs-timezone" ? (
+            <span className="text-[var(--dpf-warning)]" data-window-source="needs-timezone">
+              Your business runs 24/7. Set your timezone in{" "}
+              <a className="underline" href="/storefront/settings/operations">
+                Settings → Operating Hours
+              </a>{" "}
+              so upgrades can run automatically overnight, or choose a maintenance window.
+            </span>
+          ) : !windowConfigured ? (
             <span className="text-[var(--dpf-warning)]">
               No maintenance window configured — scheduled upgrades will not run
               on their own. Use Emergency override to run now.
@@ -922,6 +940,13 @@ export default function SelfUpgradeClient({
             <span className="text-[var(--dpf-muted)]">
               Maintenance window configured.
             </span>
+          )}
+          {windowSource === "auto-overnight" && autoWindowSummary && (
+            <div className="mt-1 text-[var(--dpf-muted)]" data-window-source="auto-overnight">
+              Your business runs 24/7, so upgrades run overnight (around{" "}
+              <span className="font-medium text-[var(--dpf-text)]">{autoWindowSummary}</span>
+              {windowTimezone ? ` ${windowTimezone}` : ""}).
+            </div>
           )}
           {windowTimezone && (
             <div className="mt-1 text-[var(--dpf-muted)]" data-window-timezone={windowTimezone}>

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -61,8 +61,18 @@ vi.mock("@/lib/self-upgrade/window", () => ({
   nextUpgradeWindowOpen: vi.fn().mockReturnValue(null),
 }));
 
+// 24/7 auto-window resolution (BI-A6382FB9). Default "operating-hours" so the
+// existing (non-24/7) status tests are unaffected; the 24/7 tests override it.
+vi.mock("@/lib/self-upgrade/auto-window", () => ({
+  resolveAutoUpgradeWindow: vi.fn().mockReturnValue({ kind: "operating-hours" }),
+  nextAutoWindowOpen: vi.fn().mockReturnValue(null),
+  describeWindows: vi.fn().mockReturnValue("2:00 AM–4:00 AM"),
+}));
+
 vi.mock("@/lib/operating-hours-read", () => ({
-  resolveOperatingScheduleForSystem: vi.fn().mockResolvedValue({ schedule: {}, timezone: "UTC" }),
+  resolveOperatingScheduleForSystem: vi
+    .fn()
+    .mockResolvedValue({ schedule: {}, timezone: "UTC", timezoneKnown: false, lowTrafficWindows: [] }),
 }));
 
 vi.mock("@/lib/self-upgrade/last-check", () => ({
@@ -148,6 +158,7 @@ import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { createRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
 import { getCurrentImpactSummaryId } from "@/lib/self-upgrade/impact";
 import { isUpgradeWindowOpen, nextUpgradeWindowOpen } from "@/lib/self-upgrade/window";
+import { resolveAutoUpgradeWindow, nextAutoWindowOpen } from "@/lib/self-upgrade/auto-window";
 import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import { inngest } from "@/lib/queue/inngest-client";
 import { revalidatePath } from "next/cache";
@@ -215,6 +226,10 @@ beforeEach(() => {
   vi.mocked(getCurrentImpactSummaryId).mockResolvedValue(null);
   vi.mocked(getLastCheckedAt).mockResolvedValue(null);
   vi.mocked(nextUpgradeWindowOpen).mockReturnValue(null);
+  // Default the 24/7 resolver back to "operating-hours" each test (clearAllMocks
+  // leaves return values intact, so a prior 24/7 test would otherwise leak).
+  vi.mocked(resolveAutoUpgradeWindow).mockReturnValue({ kind: "operating-hours" });
+  vi.mocked(nextAutoWindowOpen).mockReturnValue(null);
   // Default: treat triggers as in-window so dispatch tests exercise the happy
   // path. Tests that care about the window gate override this explicitly.
   vi.mocked(isUpgradeWindowOpen).mockReturnValue(true);
@@ -450,6 +465,57 @@ describe("getSelfUpgradeStatus", () => {
     expect(result.inMaintenanceWindow).toBe(false);
     // Explicit windows present → windowSource reflects the override.
     expect(result.windowSource).toBe("explicit");
+  });
+
+  // BI-A6382FB9 — a 24/7 store auto-picks an overnight window; the panel shows a
+  // read-only schedule note and the next 02:00 local, not the dead-end "configured".
+  it("auto-selects an overnight window for a 24/7 store (windowSource=auto-overnight)", async () => {
+    const autoWindows = [
+      { dayOfWeek: [0, 1, 2, 3, 4, 5, 6], startTime: "02:00", endTime: "04:00" },
+    ];
+    vi.mocked(resolveAutoUpgradeWindow).mockReturnValue({
+      kind: "auto-overnight",
+      windows: autoWindows,
+      source: "default",
+    });
+    vi.mocked(nextAutoWindowOpen).mockReturnValue(new Date("2026-05-26T02:00:00.000Z"));
+    vi.mocked(isUpgradeWindowOpen).mockReturnValue(false); // not currently in the 2-4am window
+    vi.mocked(getDeployedSha).mockResolvedValue("abc1234");
+    vi.mocked(resolveTargetSha).mockResolvedValue("def5678");
+    vi.mocked(isShaFresh).mockReturnValue(false);
+    vi.mocked(getLatestRun).mockResolvedValue(null);
+
+    const result = await getSelfUpgradeStatus();
+
+    expect(result.windowSource).toBe("auto-overnight");
+    expect(result.autoWindowSummary).toBe("2:00 AM–4:00 AM");
+    // nextWindowStart comes from the auto window, not the (null) operating-hours derivation.
+    expect(result.nextWindowStart).toBe("2026-05-26T02:00:00.000Z");
+    // The gate is evaluated against the auto windows.
+    expect(isUpgradeWindowOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ explicitWindows: autoWindows }),
+    );
+  });
+
+  // BI-A6382FB9 — a 24/7 store with no derivable timezone prompts the operator
+  // instead of guessing an overnight window in an unknown zone.
+  it("prompts for a timezone on a 24/7 store with no known timezone (windowSource=needs-timezone)", async () => {
+    vi.mocked(resolveAutoUpgradeWindow).mockReturnValue({ kind: "needs-timezone" });
+    vi.mocked(isUpgradeWindowOpen).mockReturnValue(false);
+    vi.mocked(getDeployedSha).mockResolvedValue("abc1234");
+    vi.mocked(resolveTargetSha).mockResolvedValue("def5678");
+    vi.mocked(isShaFresh).mockReturnValue(false);
+    vi.mocked(getLatestRun).mockResolvedValue(null);
+
+    const result = await getSelfUpgradeStatus();
+
+    expect(result.windowSource).toBe("needs-timezone");
+    expect(result.autoWindowSummary).toBeNull();
+    expect(result.nextWindowStart).toBeNull();
+    // No window is handed to the gate (24/7 + unknown tz → not auto-runnable).
+    expect(isUpgradeWindowOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ explicitWindows: undefined }),
+    );
   });
 
   it("passes channel and source config to resolveTargetSha", async () => {

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -18,6 +18,11 @@ import {
   isUpgradeWindowOpen,
   nextUpgradeWindowOpen,
 } from "@/lib/self-upgrade/window";
+import {
+  resolveAutoUpgradeWindow,
+  nextAutoWindowOpen,
+  describeWindows,
+} from "@/lib/self-upgrade/auto-window";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import {
@@ -672,34 +677,62 @@ export async function getSelfUpgradeStatus() {
   ]);
 
   // Upgrade timing follows the storefront's open/closed state (single source of
-  // truth: operating hours). inMaintenanceWindow = "upgrades may run now" =
-  // store closed (or inside an explicit override window). storeOpen lets the
-  // panel explain WHY truthfully.
-  const { schedule, timezone } = await resolveOperatingScheduleForSystem();
+  // truth: operating hours). inMaintenanceWindow = "upgrades may run now" = store
+  // closed (or inside an explicit override / auto-overnight window). storeOpen
+  // lets the panel explain WHY truthfully.
+  const { schedule, timezone, timezoneKnown, lowTrafficWindows } =
+    await resolveOperatingScheduleForSystem();
   const hasExplicitWindows = config.maintenanceWindows.length > 0;
   const storeOpen = isStoreOpen(schedule, new Date(), timezone);
+  const now = new Date();
+  // A 24/7 store has no derived "closed" window. With a known timezone we
+  // auto-pick a low-traffic overnight window (observed trough if available, else
+  // ~02:00-04:00 local); with no known timezone we surface a prompt instead of
+  // guessing. Explicit operator windows still win. (BI-A6382FB9)
+  const auto = hasExplicitWindows
+    ? null
+    : resolveAutoUpgradeWindow({ schedule, timeZone: timezone, timezoneKnown, lowTrafficWindows, now });
+  const effectiveWindows = hasExplicitWindows
+    ? config.maintenanceWindows
+    : auto?.kind === "auto-overnight"
+      ? auto.windows
+      : undefined;
   const inMaintenanceWindow = isUpgradeWindowOpen({
-    explicitWindows: config.maintenanceWindows,
+    explicitWindows: effectiveWindows,
     schedule,
     timeZone: timezone,
   });
-  // The window is always defined now (derived from operating hours), so it is
-  // never "unconfigured". windowSource tells the panel which model is in play.
+  // The window is always defined now (operating-hours or auto-overnight), so it
+  // is never "unconfigured". windowSource tells the panel which model is in play;
+  // "needs-timezone" is the only state that asks the operator for input.
   const windowConfigured = true;
-  const windowSource: "explicit" | "operating-hours" = hasExplicitWindows
-    ? "explicit"
-    : "operating-hours";
+  const windowSource: "explicit" | "operating-hours" | "auto-overnight" | "needs-timezone" =
+    hasExplicitWindows
+      ? "explicit"
+      : auto?.kind === "auto-overnight"
+        ? "auto-overnight"
+        : auto?.kind === "needs-timezone"
+          ? "needs-timezone"
+          : "operating-hours";
+  // Friendly "2:00 AM-4:00 AM" summary for the auto-overnight schedule note (display only).
+  const autoWindowSummary =
+    auto?.kind === "auto-overnight" ? describeWindows(auto.windows) : null;
   // Next time the upgrade window opens, so the panel can show WHEN scheduled
-  // upgrades will next be eligible. Explicit windows use their configured start;
-  // the operating-hours model derives it from the next store-close transition
-  // (null only while already in-window or for a 24/7 store, where the panel
-  // already explains the state).
-  const now = new Date();
+  // upgrades will next be eligible. Explicit + auto-overnight windows use their
+  // configured/derived start; the operating-hours model derives it from the next
+  // store-close transition (null while already in-window, or for needs-timezone,
+  // where the panel asks for a timezone instead).
   const nextWindowStart = hasExplicitWindows
     ? nextMaintenanceWindowStart(config, now, timezone)?.toISOString() ?? null
-    : inMaintenanceWindow
-      ? null
-      : nextUpgradeWindowOpen(schedule, now, timezone)?.toISOString() ?? null;
+    : auto?.kind === "auto-overnight"
+      ? inMaintenanceWindow
+        ? null
+        : nextAutoWindowOpen(auto.windows, now, timezone)?.toISOString() ?? null
+      : auto?.kind === "needs-timezone"
+        ? null
+        : inMaintenanceWindow
+          ? null
+          : nextUpgradeWindowOpen(schedule, now, timezone)?.toISOString() ?? null;
   const nextWindowStartDate = nextWindowStart ? new Date(nextWindowStart) : null;
   const nextScheduledCheckAt = computeNextScheduledUpgradeCheckAt({
     enabled: config.enabled,
@@ -731,6 +764,8 @@ export async function getSelfUpgradeStatus() {
     inMaintenanceWindow,
     windowConfigured,
     windowSource,
+    // Friendly window-time summary for the auto-overnight note (null otherwise).
+    autoWindowSummary,
     storeOpen,
     // The IANA timezone the window is evaluated in (store operating-hours zone).
     // Surfaced so the panel's "next window" is never ambiguous — the symptom that

--- a/apps/web/lib/operating-hours-read.ts
+++ b/apps/web/lib/operating-hours-read.ts
@@ -12,6 +12,7 @@ import { DEFAULT_OPERATING_HOURS_TIMEZONE, GENERIC_DEFAULTS } from "@/lib/operat
 import type { DaySchedule, WeeklySchedule } from "@/lib/operating-hours-types";
 import { resolveTimezoneFromAddress, resolveTimezoneFromLocation } from "@/lib/timezone-from-location";
 import { parseOrgAddress } from "@/lib/shared/org-address";
+import type { LowTrafficWindow } from "@/lib/self-upgrade/auto-window";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const;
 const CLOSED_DAY: DaySchedule = { enabled: false, open: "09:00", close: "17:00" };
@@ -62,35 +63,74 @@ export function profileHoursToSchedule(
   return schedule;
 }
 
+/** Defensive parse of the BusinessProfile.lowTrafficWindows JSON column. */
+function parseLowTrafficWindows(raw: unknown): LowTrafficWindow[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (w): w is LowTrafficWindow =>
+      !!w &&
+      typeof w === "object" &&
+      typeof (w as { dayOfWeek?: unknown }).dayOfWeek === "number" &&
+      typeof (w as { start?: unknown }).start === "string" &&
+      typeof (w as { end?: unknown }).end === "string",
+  );
+}
+
 /**
  * Resolve the active storefront's weekly schedule + timezone for system callers.
  * Mirrors getOperatingHours' confirmed-hours and generic-default priorities, but
  * without the auth guard or the setup-only archetype/URL suggestions (irrelevant
  * to an unattended upgrade decision). Returns the generic 9–5 weekday default
  * when no confirmed hours exist, so the upgrade window is always well-defined.
+ *
+ * Also surfaces the inputs the 24/7 auto-window decision needs (BI-A6382FB9):
+ * - `timezoneKnown`: true when the timezone is a real, location-grounded/pinned
+ *   zone, false when it fell back to the UTC placeholder (so a 24/7 store with no
+ *   known zone is prompted rather than scheduled at a guessed local hour).
+ * - `lowTrafficWindows`: the observed/derived troughs, preferred over the default
+ *   overnight window when a valid one exists.
  */
 export async function resolveOperatingScheduleForSystem(): Promise<{
   schedule: WeeklySchedule;
   timezone: string;
+  timezoneKnown: boolean;
+  lowTrafficWindows: LowTrafficWindow[];
 }> {
   const profile = await prisma.businessProfile.findFirst({
     where: { isActive: true },
-    select: { businessHours: true, timezone: true, hoursConfirmedAt: true },
+    select: {
+      businessHours: true,
+      timezone: true,
+      hoursConfirmedAt: true,
+      lowTrafficWindows: true,
+    },
   });
   // Prefer the operator-pinned profile timezone; when it's unset or still the UTC
   // placeholder, derive from the captured business location so the upgrade window
-  // is correct from day one rather than evaluating in UTC.
+  // is correct from day one rather than evaluating in UTC. resolveTimezoneFromLocation
+  // never yields "UTC" and a pinned "UTC" is treated as the placeholder, so
+  // "timezone !== placeholder" is a sound "we actually know the store's clock" signal.
   let timezone =
     profile?.timezone && profile.timezone.length > 0
       ? profile.timezone
       : DEFAULT_OPERATING_HOURS_TIMEZONE;
-  if (timezone === DEFAULT_OPERATING_HOURS_TIMEZONE) {
+  let timezoneKnown = timezone !== DEFAULT_OPERATING_HOURS_TIMEZONE;
+  if (!timezoneKnown) {
     const derived = await deriveTimezoneFromBusinessLocation();
-    if (derived) timezone = derived;
+    if (derived) {
+      timezone = derived;
+      timezoneKnown = true;
+    }
   }
+  const lowTrafficWindows = parseLowTrafficWindows(profile?.lowTrafficWindows);
   if (profile?.hoursConfirmedAt && profile.businessHours) {
     const businessHours = profile.businessHours as Record<string, { open: string; close: string } | null>;
-    return { schedule: profileHoursToSchedule(businessHours), timezone };
+    return {
+      schedule: profileHoursToSchedule(businessHours),
+      timezone,
+      timezoneKnown,
+      lowTrafficWindows,
+    };
   }
-  return { schedule: { ...GENERIC_DEFAULTS }, timezone };
+  return { schedule: { ...GENERIC_DEFAULTS }, timezone, timezoneKnown, lowTrafficWindows };
 }

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -38,6 +38,10 @@ const mocks = vi.hoisted(() => ({
   // Activity precheck snapshot (BI-F36E7510). Default empty so existing tests
   // proceed to the drain exactly as before; the new skip-path test overrides it.
   captureActiveSessionBlockers: vi.fn().mockResolvedValue({ surfaces: [] }),
+  // 24/7 auto-window resolution (BI-A6382FB9). Default "operating-hours" so the
+  // gate behaves exactly as before (falls through to the mocked isUpgradeWindowOpen);
+  // the 24/7 tests override it.
+  resolveAutoUpgradeWindow: vi.fn().mockReturnValue({ kind: "operating-hours" }),
 }));
 
 vi.mock("@/lib/self-upgrade/config", () => ({
@@ -50,6 +54,10 @@ vi.mock("@/lib/self-upgrade/window", () => ({
 
 vi.mock("@/lib/operating-hours-read", () => ({
   resolveOperatingScheduleForSystem: mocks.resolveOperatingScheduleForSystem,
+}));
+
+vi.mock("@/lib/self-upgrade/auto-window", () => ({
+  resolveAutoUpgradeWindow: mocks.resolveAutoUpgradeWindow,
 }));
 
 vi.mock("@/lib/self-upgrade/last-check", () => ({
@@ -621,6 +629,10 @@ describe("pre-upgrade recovery point gate", () => {
 describe("maintenance window gate + emergency override", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default the 24/7 resolver back to "operating-hours" (clearAllMocks leaves a
+    // prior describe's return value / one-shot queue intact); the 24/7 tests below
+    // override per-call with mockReturnValueOnce.
+    mocks.resolveAutoUpgradeWindow.mockReturnValue({ kind: "operating-hours" });
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.getDeployedSha.mockResolvedValue("oldsha1");
     setupSourceReady();
@@ -655,6 +667,45 @@ describe("maintenance window gate + emergency override", () => {
     const result = await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true, force: true });
     expect(result).toMatchObject({ ok: true, status: "succeeded" });
     expect(mocks.runPromoter).toHaveBeenCalled();
+  });
+
+  // BI-A6382FB9 — a 24/7 store has no derived "closed" window. With a known
+  // timezone the scheduled gate evaluates against the auto-selected overnight
+  // window instead of the (never-open) operating-hours derivation, so scheduled
+  // upgrades actually run.
+  it("SCHEDULED run on a 24/7 store evaluates the auto-selected overnight window", async () => {
+    const autoWindows = [
+      { dayOfWeek: [0, 1, 2, 3, 4, 5, 6], startTime: "02:00", endTime: "04:00" },
+    ];
+    mocks.resolveAutoUpgradeWindow.mockReturnValueOnce({
+      kind: "auto-overnight",
+      windows: autoWindows,
+      source: "default",
+    });
+    mocks.isUpgradeWindowOpen.mockReturnValue(true); // currently inside the overnight window
+
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true });
+
+    // The gate evaluates the AUTO windows, not the empty operating-hours derivation.
+    expect(mocks.isUpgradeWindowOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ explicitWindows: autoWindows }),
+    );
+    expect(result).toMatchObject({ ok: true, status: "succeeded" });
+  });
+
+  // BI-A6382FB9 — a 24/7 store with no derivable timezone can't be scheduled
+  // safely. It skips cleanly (no drain, no run, no cooldown) with a distinct
+  // reason; the Upgrade Center prompts for a timezone rather than guessing.
+  it("SCHEDULED run on a 24/7 store with no known timezone skips with no-window-needs-timezone", async () => {
+    mocks.resolveAutoUpgradeWindow.mockReturnValueOnce({ kind: "needs-timezone" });
+
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true });
+
+    expect(result).toMatchObject({ skipped: true, reason: "no-window-needs-timezone" });
+    // Never consults the window gate, never drains, never creates a run.
+    expect(mocks.isUpgradeWindowOpen).not.toHaveBeenCalled();
+    expect(mocks.createRun).not.toHaveBeenCalled();
+    expect(mocks.startQuiescence).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -2,6 +2,7 @@ import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
+import { resolveAutoUpgradeWindow } from "@/lib/self-upgrade/auto-window";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { getLastCheckedAt, recordCheckedAt, isCheckIntervalElapsed } from "@/lib/self-upgrade/last-check";
 import { buildFetchCommand, buildRemoteHeadCommand } from "@/lib/self-upgrade/version";
@@ -127,15 +128,33 @@ export async function runSelfUpgrade(
   // operating hours) gates ONLY the unattended scheduled poll. A manual operator
   // trigger means "upgrade now" — the operator has explicitly chosen this moment,
   // so it is NOT window-gated (it still drains via quiescence below unless force).
-  // An explicit maintenanceWindows config overrides the derived window for the
-  // scheduled path. force never set by the cron.
+  // force is never set by the cron.
+  //
+  // Effective-window precedence: an explicit operator-configured maintenanceWindows
+  // array wins; otherwise, for an effectively-24/7 store with a known timezone, an
+  // auto-selected low-traffic overnight window (BI-A6382FB9) — without which a 24/7
+  // store would never open a window and scheduled upgrades would never run; otherwise
+  // the operating-hours "store closed" derivation. A 24/7 store with no derivable
+  // timezone can't be scheduled safely (any local hour could be peak), so it skips
+  // with a distinct reason and the Upgrade Center prompts for a timezone — a clean
+  // no-op (no drain, no cooldown), never a silent never-runs.
   if (params.scheduled && !params.force) {
-    const { schedule, timezone } = await resolveOperatingScheduleForSystem();
-    const allowed = isUpgradeWindowOpen({
-      explicitWindows: config.maintenanceWindows,
-      schedule,
-      timeZone: timezone,
-    });
+    const { schedule, timezone, timezoneKnown, lowTrafficWindows } =
+      await resolveOperatingScheduleForSystem();
+    const auto =
+      config.maintenanceWindows.length > 0
+        ? null
+        : resolveAutoUpgradeWindow({ schedule, timeZone: timezone, timezoneKnown, lowTrafficWindows });
+    if (auto?.kind === "needs-timezone") {
+      return await skipAttempt("no-window-needs-timezone");
+    }
+    const explicitWindows =
+      config.maintenanceWindows.length > 0
+        ? config.maintenanceWindows
+        : auto?.kind === "auto-overnight"
+          ? auto.windows
+          : undefined;
+    const allowed = isUpgradeWindowOpen({ explicitWindows, schedule, timeZone: timezone });
     if (!allowed) return await skipAttempt("outside-window");
   }
 

--- a/apps/web/lib/self-upgrade/auto-window.test.ts
+++ b/apps/web/lib/self-upgrade/auto-window.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_OVERNIGHT_WINDOW,
+  describeWindows,
+  formatWindowClock,
+  isEffectively247,
+  nextAutoWindowOpen,
+  resolveAutoUpgradeWindow,
+  selectTroughWindows,
+  type LowTrafficWindow,
+} from "./auto-window";
+import type { WeeklySchedule } from "@/lib/operating-hours-types";
+
+// A genuine 24/7 store: every day open 00:00-24:00 (isStoreOpen always true), so
+// the operating-hours model never opens a window. Matches window.test.ts.
+const ALL_DAY: WeeklySchedule = {
+  monday: { enabled: true, open: "00:00", close: "24:00" },
+  tuesday: { enabled: true, open: "00:00", close: "24:00" },
+  wednesday: { enabled: true, open: "00:00", close: "24:00" },
+  thursday: { enabled: true, open: "00:00", close: "24:00" },
+  friday: { enabled: true, open: "00:00", close: "24:00" },
+  saturday: { enabled: true, open: "00:00", close: "24:00" },
+  sunday: { enabled: true, open: "00:00", close: "24:00" },
+};
+
+const NINE_TO_FIVE: WeeklySchedule = {
+  monday: { enabled: true, open: "09:00", close: "17:00" },
+  tuesday: { enabled: true, open: "09:00", close: "17:00" },
+  wednesday: { enabled: true, open: "09:00", close: "17:00" },
+  thursday: { enabled: true, open: "09:00", close: "17:00" },
+  friday: { enabled: true, open: "09:00", close: "17:00" },
+  saturday: { enabled: false, open: "09:00", close: "17:00" },
+  sunday: { enabled: false, open: "09:00", close: "17:00" },
+};
+
+// 2026-05-25 is a Monday.
+const MON_1200_UTC = new Date("2026-05-25T12:00:00Z");
+// 08:00 UTC Monday = 03:00 Monday in US Central (CDT, -5) — inside 02:00-04:00 local.
+const MON_0800_UTC = new Date("2026-05-25T08:00:00Z");
+
+describe("isEffectively247", () => {
+  it("is true for a store that never closes (open 00:00-24:00 every day)", () => {
+    expect(isEffectively247(ALL_DAY, MON_1200_UTC, "UTC")).toBe(true);
+  });
+
+  it("is false for a 9-5 store (it closes every evening)", () => {
+    expect(isEffectively247(NINE_TO_FIVE, MON_1200_UTC, "UTC")).toBe(false);
+  });
+
+  it("is false when even one day has real closed hours (not truly 24/7)", () => {
+    const almost: WeeklySchedule = {
+      ...ALL_DAY,
+      sunday: { enabled: false, open: "00:00", close: "24:00" },
+    };
+    expect(isEffectively247(almost, MON_1200_UTC, "UTC")).toBe(false);
+  });
+});
+
+describe("resolveAutoUpgradeWindow", () => {
+  it("returns operating-hours for a non-24/7 store", () => {
+    const r = resolveAutoUpgradeWindow({
+      schedule: NINE_TO_FIVE,
+      timeZone: "America/Chicago",
+      timezoneKnown: true,
+      now: MON_1200_UTC,
+    });
+    expect(r).toEqual({ kind: "operating-hours" });
+  });
+
+  it("auto-picks the default overnight window for a 24/7 store with a known timezone", () => {
+    const r = resolveAutoUpgradeWindow({
+      schedule: ALL_DAY,
+      timeZone: "America/Chicago",
+      timezoneKnown: true,
+      now: MON_1200_UTC,
+    });
+    expect(r).toEqual({
+      kind: "auto-overnight",
+      source: "default",
+      windows: [DEFAULT_OVERNIGHT_WINDOW],
+    });
+  });
+
+  it("asks for a timezone when the store is 24/7 but no timezone is known", () => {
+    const r = resolveAutoUpgradeWindow({
+      schedule: ALL_DAY,
+      timeZone: "UTC",
+      timezoneKnown: false,
+      now: MON_1200_UTC,
+    });
+    expect(r).toEqual({ kind: "needs-timezone" });
+  });
+
+  it("prefers a valid observed low-traffic trough over the default", () => {
+    const lowTrafficWindows: LowTrafficWindow[] = [0, 1, 2, 3, 4, 5, 6].map((d) => ({
+      dayOfWeek: d,
+      start: "03:00",
+      end: "05:00",
+    }));
+    const r = resolveAutoUpgradeWindow({
+      schedule: ALL_DAY,
+      timeZone: "America/Chicago",
+      timezoneKnown: true,
+      lowTrafficWindows,
+      now: MON_1200_UTC,
+    });
+    expect(r).toEqual({
+      kind: "auto-overnight",
+      source: "trough",
+      windows: [{ dayOfWeek: [0, 1, 2, 3, 4, 5, 6], startTime: "03:00", endTime: "05:00" }],
+    });
+  });
+
+  it("falls back to the default when the only troughs are the malformed 24/7-derived artifacts", () => {
+    // deriveLowTrafficWindows emits {start:"24:00", end:"23:59"} for a 24/7 day.
+    const lowTrafficWindows: LowTrafficWindow[] = [0, 1, 2, 3, 4, 5, 6].map((d) => ({
+      dayOfWeek: d,
+      start: "24:00",
+      end: "23:59",
+    }));
+    const r = resolveAutoUpgradeWindow({
+      schedule: ALL_DAY,
+      timeZone: "America/Chicago",
+      timezoneKnown: true,
+      lowTrafficWindows,
+      now: MON_1200_UTC,
+    });
+    expect(r).toMatchObject({ kind: "auto-overnight", source: "default" });
+  });
+});
+
+describe("selectTroughWindows", () => {
+  it("groups identical ranges across days into one window", () => {
+    const windows = selectTroughWindows([
+      { dayOfWeek: 1, start: "02:00", end: "04:00" },
+      { dayOfWeek: 2, start: "02:00", end: "04:00" },
+    ]);
+    expect(windows).toEqual([{ dayOfWeek: [1, 2], startTime: "02:00", endTime: "04:00" }]);
+  });
+
+  it("rejects malformed times (hour > 23), zero-length, and over-long (> 6h) slots", () => {
+    expect(selectTroughWindows([{ dayOfWeek: 1, start: "24:00", end: "23:59" }])).toBeNull();
+    expect(selectTroughWindows([{ dayOfWeek: 1, start: "03:00", end: "03:00" }])).toBeNull();
+    // 00:00-08:00 is 8h > 6h cap.
+    expect(selectTroughWindows([{ dayOfWeek: 1, start: "00:00", end: "08:00" }])).toBeNull();
+    // out-of-range day index.
+    expect(selectTroughWindows([{ dayOfWeek: 9, start: "02:00", end: "04:00" }])).toBeNull();
+  });
+
+  it("accepts an overnight quiet slot that wraps midnight (23:00-02:00 = 3h)", () => {
+    const windows = selectTroughWindows([{ dayOfWeek: 6, start: "23:00", end: "02:00" }]);
+    expect(windows).toEqual([{ dayOfWeek: [6], startTime: "23:00", endTime: "02:00" }]);
+  });
+});
+
+describe("nextAutoWindowOpen", () => {
+  it("returns the next 02:00 local for the default overnight window", () => {
+    // Monday noon UTC, window 02:00-04:00 every day in UTC -> next open Tue 02:00 UTC.
+    const next = nextAutoWindowOpen([DEFAULT_OVERNIGHT_WINDOW], MON_1200_UTC, "UTC");
+    expect(next?.toISOString()).toBe("2026-05-26T02:00:00.000Z");
+  });
+
+  it("returns `now` when currently inside the window, evaluated in the store timezone", () => {
+    // 08:00 UTC = 03:00 US Central, inside 02:00-04:00 local.
+    const next = nextAutoWindowOpen([DEFAULT_OVERNIGHT_WINDOW], MON_0800_UTC, "America/Chicago");
+    expect(next).toBe(MON_0800_UTC);
+  });
+});
+
+describe("formatWindowClock / describeWindows", () => {
+  it("formats 24h HH:mm as 12h clock", () => {
+    expect(formatWindowClock("02:00")).toBe("2:00 AM");
+    expect(formatWindowClock("00:00")).toBe("12:00 AM");
+    expect(formatWindowClock("12:00")).toBe("12:00 PM");
+    expect(formatWindowClock("13:30")).toBe("1:30 PM");
+  });
+
+  it("describes the default overnight window as a friendly range", () => {
+    expect(describeWindows([DEFAULT_OVERNIGHT_WINDOW])).toBe("2:00 AM–4:00 AM");
+  });
+});

--- a/apps/web/lib/self-upgrade/auto-window.ts
+++ b/apps/web/lib/self-upgrade/auto-window.ts
@@ -1,0 +1,172 @@
+// apps/web/lib/self-upgrade/auto-window.ts
+//
+// 24/7 self-upgrade window selection (BI-A6382FB9). The upgrade window is
+// normally derived as "any time the store is CLOSED" (window.ts). A 24/7 store
+// has no closed hours, so that model never opens a window and scheduled
+// upgrades never run. This module fills that gap: when a store is effectively
+// 24/7, it auto-selects a low-traffic OVERNIGHT window in the store's timezone
+// (an observed trough from BusinessProfile.lowTrafficWindows when a valid one
+// exists, else a default ~02:00-04:00 local), and only asks the operator when
+// there is a genuine need (no timezone known / derivable).
+//
+// Pure + prisma-free (inject `now`), so the unattended cron path and the unit
+// tests can use it without a DB/auth round-trip. Explicit operator-configured
+// maintenance windows take priority over this resolution and are handled by the
+// caller; this module only decides the auto / operating-hours / ask split.
+
+import type { WeeklySchedule } from "@/lib/operating-hours-types";
+import type { MaintenanceWindow } from "./config";
+import { nextWindowStartForWindows } from "./windows-eval";
+import { nextUpgradeWindowOpen } from "./window";
+
+/**
+ * Default low-traffic overnight window used when no valid observed trough is
+ * available: 02:00-04:00 local, every day. Two whole hours give the hourly cron
+ * (`0 * * * *`) the 02:00 and 03:00 ticks to start an upgrade.
+ */
+export const DEFAULT_OVERNIGHT_WINDOW: MaintenanceWindow = {
+  dayOfWeek: [0, 1, 2, 3, 4, 5, 6],
+  startTime: "02:00",
+  endTime: "04:00",
+};
+
+/** A schedule-derived or telemetry-observed low-traffic slot (BusinessProfile.lowTrafficWindows). */
+export type LowTrafficWindow = {
+  dayOfWeek: number;
+  start: string;
+  end: string;
+};
+
+// An upgrade window should be a quiet slot, not "all day"; reject anything longer.
+const MAX_TROUGH_MINUTES = 6 * 60;
+
+export type AutoUpgradeWindowResult =
+  | { kind: "operating-hours" }
+  | { kind: "auto-overnight"; windows: MaintenanceWindow[]; source: "trough" | "default" }
+  | { kind: "needs-timezone" };
+
+/**
+ * True when the store never closes within the 8-day scan horizon, i.e. the
+ * operating-hours model produces no window — exactly when nextUpgradeWindowOpen
+ * returns null. A store with even a short real closed window is NOT 24/7 and
+ * keeps the operating-hours model.
+ */
+export function isEffectively247(
+  schedule: WeeklySchedule,
+  now: Date,
+  timeZone?: string,
+): boolean {
+  return nextUpgradeWindowOpen(schedule, now, timeZone) === null;
+}
+
+function toMinutes(hhmm: string): number | null {
+  const m = /^(\d{2}):(\d{2})$/.exec(hhmm);
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/** Window length in minutes, handling an overnight wrap (end <= start). null when malformed. */
+function windowDurationMinutes(start: string, end: string): number | null {
+  const s = toMinutes(start);
+  const e = toMinutes(end);
+  if (s === null || e === null) return null;
+  if (s === e) return 0;
+  return e > s ? e - s : 24 * 60 - s + e;
+}
+
+/**
+ * Pick usable overnight maintenance windows from observed/derived low-traffic
+ * slots. Accepts only well-formed, non-degenerate, quiet slots (<= 6h) and
+ * groups identical ranges across days into MaintenanceWindow[]. Returns null
+ * when none qualify -- which is the case for a 24/7 schedule, whose derived
+ * lowTrafficWindows are the malformed "24:00"-"23:59" artifacts
+ * deriveLowTrafficWindows emits -- so the caller falls back to the default.
+ */
+export function selectTroughWindows(
+  lowTrafficWindows: LowTrafficWindow[],
+): MaintenanceWindow[] | null {
+  const byRange = new Map<string, { startTime: string; endTime: string; days: number[] }>();
+  for (const w of lowTrafficWindows) {
+    if (!w || typeof w.dayOfWeek !== "number" || w.dayOfWeek < 0 || w.dayOfWeek > 6) continue;
+    const dur = windowDurationMinutes(w.start, w.end);
+    if (dur === null || dur <= 0 || dur > MAX_TROUGH_MINUTES) continue;
+    const key = `${w.start}|${w.end}`;
+    const entry = byRange.get(key) ?? { startTime: w.start, endTime: w.end, days: [] };
+    if (!entry.days.includes(w.dayOfWeek)) entry.days.push(w.dayOfWeek);
+    byRange.set(key, entry);
+  }
+  if (byRange.size === 0) return null;
+  return Array.from(byRange.values()).map((entry) => ({
+    dayOfWeek: entry.days.sort((a, b) => a - b),
+    startTime: entry.startTime,
+    endTime: entry.endTime,
+  }));
+}
+
+/**
+ * Resolve how the self-upgrade window should be derived for a store:
+ *  - not effectively-24/7 -> "operating-hours" (the existing store-closed model).
+ *  - 24/7 + known timezone -> "auto-overnight": a low-traffic overnight window in
+ *    the store tz (observed trough if a valid one exists, else ~02:00-04:00).
+ *  - 24/7 + no known timezone -> "needs-timezone": an overnight window in an
+ *    unknown zone could land at peak, so the caller prompts the operator instead
+ *    of guessing.
+ * Explicit operator-configured windows are handled by the caller and take
+ * priority over this resolution.
+ */
+export function resolveAutoUpgradeWindow(args: {
+  schedule: WeeklySchedule;
+  timeZone: string;
+  timezoneKnown: boolean;
+  lowTrafficWindows?: LowTrafficWindow[];
+  now?: Date;
+}): AutoUpgradeWindowResult {
+  const now = args.now ?? new Date();
+  if (!isEffectively247(args.schedule, now, args.timeZone)) {
+    return { kind: "operating-hours" };
+  }
+  if (!args.timezoneKnown) {
+    return { kind: "needs-timezone" };
+  }
+  const trough = selectTroughWindows(args.lowTrafficWindows ?? []);
+  if (trough && trough.length > 0) {
+    return { kind: "auto-overnight", windows: trough, source: "trough" };
+  }
+  return { kind: "auto-overnight", windows: [DEFAULT_OVERNIGHT_WINDOW], source: "default" };
+}
+
+/** Next instant one of the auto-selected windows opens (store tz). */
+export function nextAutoWindowOpen(
+  windows: MaintenanceWindow[],
+  now: Date,
+  timeZone?: string,
+): Date | null {
+  return nextWindowStartForWindows(windows, now, timeZone);
+}
+
+/** "02:00" -> "2:00 AM". For the read-only schedule summary in the Upgrade Center. */
+export function formatWindowClock(hhmm: string): string {
+  const m = /^(\d{2}):(\d{2})$/.exec(hhmm);
+  if (!m) return hhmm;
+  let h = Number(m[1] ?? "0");
+  const min = m[2] ?? "00";
+  const meridiem = h < 12 ? "AM" : "PM";
+  h = h % 12;
+  if (h === 0) h = 12;
+  return `${h}:${min} ${meridiem}`;
+}
+
+/** Distinct window ranges as a friendly string, e.g. "2:00 AM-4:00 AM". */
+export function describeWindows(windows: MaintenanceWindow[]): string {
+  const ranges = Array.from(
+    new Set(
+      windows.map(
+        (w) => `${formatWindowClock(w.startTime)}–${formatWindowClock(w.endTime)}`,
+      ),
+    ),
+  );
+  return ranges.join(", ");
+}

--- a/apps/web/lib/self-upgrade/config.ts
+++ b/apps/web/lib/self-upgrade/config.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@dpf/db";
 import { DEFAULT_COOLDOWN_MINUTES } from "./cooldown";
-import { zonedDayAndTime } from "./zoned-time";
+import { isWithinWindows, nextWindowStartForWindows } from "./windows-eval";
 
 export type MaintenanceWindow = {
   dayOfWeek: number[];
@@ -116,58 +116,31 @@ const DEFAULTS: SelfUpgradeConfig = {
  * (IANA) — the STORE's clock — so an operator's "02:00-04:00" window fires at
  * 02:00 local, not 02:00 on the portal container's host clock (UTC). When
  * `timeZone` is omitted it falls back to host-local time (backward compatible).
+ * Delegates to the pure {@link isWithinWindows} primitive (windows-eval.ts),
+ * shared with the auto-selected 24/7 overnight window (auto-window.ts).
  */
 export function isInMaintenanceWindow(
   config: SelfUpgradeConfig,
   now?: Date,
   timeZone?: string,
 ): boolean {
-  const d = now ?? new Date();
-  const { day: currentDay, hhmm: currentTime } = zonedDayAndTime(d, timeZone);
-
-  return config.maintenanceWindows.some((w) => {
-    if (!w.dayOfWeek.includes(currentDay)) return false;
-    if (w.startTime <= w.endTime) {
-      return currentTime >= w.startTime && currentTime < w.endTime;
-    }
-    // Overnight window: e.g. 22:00-06:00 → matches >= 22:00 OR < 06:00
-    return currentTime >= w.startTime || currentTime < w.endTime;
-  });
+  return isWithinWindows(config.maintenanceWindows, now ?? new Date(), timeZone);
 }
-
-const WINDOW_SCAN_STEP_MS = 60_000; // 1-minute resolution — window times are HH:mm aligned
-const WINDOW_SCAN_HORIZON_MS = 8 * 24 * 60 * 60 * 1000; // 8 days covers any weekly window set
 
 /**
  * Returns the next datetime a maintenance window opens. If a window is currently
  * active, returns `now` (the scheduled upgrade can run on the next hourly cron
  * tick). Returns null when no windows are configured — meaning scheduled
- * upgrades will never fire on their own.
- *
- * Minute-resolution forward scan that reuses the timezone-aware
- * isInMaintenanceWindow, so day-of-week and the configured start times are
- * resolved against the store's `timeZone` (IANA) rather than the host clock —
- * the same approach as nextUpgradeWindowOpen in window.ts. This is what keeps an
- * explicit "02:00" window from being computed at 02:00 UTC on a US install.
+ * upgrades will never fire on their own. Delegates to the pure
+ * {@link nextWindowStartForWindows} primitive (windows-eval.ts) so day-of-week
+ * and start times resolve against the store's `timeZone`, not the host clock.
  */
 export function nextMaintenanceWindowStart(
   config: SelfUpgradeConfig,
   now?: Date,
   timeZone?: string,
 ): Date | null {
-  if (config.maintenanceWindows.length === 0) return null;
-  const base = now ?? new Date();
-  if (isInMaintenanceWindow(config, base, timeZone)) return base;
-
-  // Align to the next whole minute so the boundary lands on the window's start
-  // time (e.g. 02:00) rather than an arbitrary second within it.
-  const start = Math.ceil(base.getTime() / WINDOW_SCAN_STEP_MS) * WINDOW_SCAN_STEP_MS;
-  const limit = base.getTime() + WINDOW_SCAN_HORIZON_MS;
-  for (let t = start; t <= limit; t += WINDOW_SCAN_STEP_MS) {
-    const probe = new Date(t);
-    if (isInMaintenanceWindow(config, probe, timeZone)) return probe;
-  }
-  return null;
+  return nextWindowStartForWindows(config.maintenanceWindows, now ?? new Date(), timeZone);
 }
 
 export const SELF_UPGRADE_CONFIG_KEY = "self_upgrade";

--- a/apps/web/lib/self-upgrade/window.ts
+++ b/apps/web/lib/self-upgrade/window.ts
@@ -10,6 +10,7 @@
 
 import type { WeeklySchedule } from "@/lib/operating-hours-types";
 import type { MaintenanceWindow } from "./config";
+import { isWithinWindows } from "./windows-eval";
 import { zonedDayAndTime } from "./zoned-time";
 
 // Re-exported for callers/tests that historically imported it from here. The
@@ -41,22 +42,6 @@ export function isStoreOpen(schedule: WeeklySchedule, now: Date, timeZone?: stri
   return hhmm >= d.open || hhmm < d.close; // overnight
 }
 
-function isInExplicitWindows(
-  windows: MaintenanceWindow[],
-  now: Date,
-  timeZone?: string,
-): boolean {
-  // Evaluate against the store's clock, same as isStoreOpen — not the portal
-  // container's host zone (UTC), which would fire an explicit "02:00-04:00"
-  // window at the wrong real-world time.
-  const { day, hhmm } = zonedDayAndTime(now, timeZone);
-  return windows.some((w) => {
-    if (!w.dayOfWeek.includes(day)) return false;
-    if (w.startTime <= w.endTime) return hhmm >= w.startTime && hhmm < w.endTime;
-    return hhmm >= w.startTime || hhmm < w.endTime; // overnight
-  });
-}
-
 /**
  * Is an upgrade allowed to run right now?
  * - Explicit maintenance windows configured → honor them (advanced override).
@@ -72,7 +57,10 @@ export function isUpgradeWindowOpen(args: {
 }): boolean {
   const now = args.now ?? new Date();
   if (args.explicitWindows && args.explicitWindows.length > 0) {
-    return isInExplicitWindows(args.explicitWindows, now, args.timeZone);
+    // Evaluated against the store's clock (shared with the explicit-override and
+    // auto-overnight paths) — not the portal container's UTC host zone, which
+    // would fire a "02:00-04:00" window at the wrong real-world time.
+    return isWithinWindows(args.explicitWindows, now, args.timeZone);
   }
   if (args.schedule) {
     return !isStoreOpen(args.schedule, now, args.timeZone);

--- a/apps/web/lib/self-upgrade/windows-eval.ts
+++ b/apps/web/lib/self-upgrade/windows-eval.ts
@@ -1,0 +1,62 @@
+// apps/web/lib/self-upgrade/windows-eval.ts
+//
+// Pure, prisma-free evaluation primitives for a set of maintenance windows.
+// Extracted so the three window paths share ONE day-of-week + overnight-span +
+// store-timezone implementation instead of three copies:
+//   - the explicit operator-configured override (config.ts / window.ts), and
+//   - the auto-selected 24/7 overnight window (auto-window.ts).
+// Kept free of any DB/auth import (the `MaintenanceWindow` type is imported
+// type-only, so nothing here pulls in @dpf/db) so the unattended cron path and
+// the pure unit tests can use it without a Prisma client.
+
+import { zonedDayAndTime } from "./zoned-time";
+import type { MaintenanceWindow } from "./config";
+
+const WINDOW_SCAN_STEP_MS = 60_000; // 1-minute resolution — window times are HH:mm aligned
+const WINDOW_SCAN_HORIZON_MS = 8 * 24 * 60 * 60 * 1000; // 8 days covers any weekly window set
+
+/**
+ * True when `now` falls within any of `windows`, evaluated against `timeZone`
+ * (IANA) — the STORE's clock, not the portal container's UTC host clock (which
+ * would fire a "02:00-04:00" window at the wrong real-world time). Handles
+ * overnight spans (start > end, e.g. 22:00-06:00).
+ */
+export function isWithinWindows(
+  windows: MaintenanceWindow[],
+  now: Date,
+  timeZone?: string,
+): boolean {
+  const { day: currentDay, hhmm: currentTime } = zonedDayAndTime(now, timeZone);
+  return windows.some((w) => {
+    if (!w.dayOfWeek.includes(currentDay)) return false;
+    if (w.startTime <= w.endTime) {
+      return currentTime >= w.startTime && currentTime < w.endTime;
+    }
+    return currentTime >= w.startTime || currentTime < w.endTime; // overnight
+  });
+}
+
+/**
+ * Next instant any of `windows` opens, evaluated in `timeZone`. Returns `now`
+ * when a window is already active, null when none open within an 8-day horizon
+ * or `windows` is empty. Minute-resolution forward scan that reuses
+ * {@link isWithinWindows} so all timezone/overnight handling stays in one place.
+ */
+export function nextWindowStartForWindows(
+  windows: MaintenanceWindow[],
+  now: Date,
+  timeZone?: string,
+): Date | null {
+  if (windows.length === 0) return null;
+  if (isWithinWindows(windows, now, timeZone)) return now;
+
+  // Align to the next whole minute so the boundary lands on the window's start
+  // time (e.g. 02:00) rather than an arbitrary second within it.
+  const start = Math.ceil(now.getTime() / WINDOW_SCAN_STEP_MS) * WINDOW_SCAN_STEP_MS;
+  const limit = now.getTime() + WINDOW_SCAN_HORIZON_MS;
+  for (let t = start; t <= limit; t += WINDOW_SCAN_STEP_MS) {
+    const probe = new Date(t);
+    if (isWithinWindows(windows, probe, timeZone)) return probe;
+  }
+  return null;
+}

--- a/docs/superpowers/plans/2026-06-20-self-upgrade-24-7-overnight-window.md
+++ b/docs/superpowers/plans/2026-06-20-self-upgrade-24-7-overnight-window.md
@@ -1,0 +1,169 @@
+# 24/7 self-upgrade window: auto-pick an overnight window in the store timezone
+
+- **BI:** BI-A6382FB9 — "24/7 businesses: auto-pick a low-traffic overnight self-upgrade window in the store timezone; prompt only when needed"
+- **Epic:** EP-UPGRADE-LIFECYCLE
+- **Predecessors:** BI-6DA3B06F / [#2199](https://github.com/) (window timezone correctness), BI-0C000AB3 / #2201 (derive operating-hours tz from location). Timezone source: BI-A077E0F5, BI-AAAA0691.
+- **Date:** 2026-06-20
+- **Author:** Claude Code (external coding agent)
+
+## 1. Problem
+
+The self-upgrade maintenance window is derived as "any time the store is CLOSED"
+(`apps/web/lib/self-upgrade/window.ts`: `isUpgradeWindowOpen` / `isStoreOpen` /
+`nextUpgradeWindowOpen`, evaluated in the store's IANA timezone via `zoned-time.ts`).
+
+A 24/7 storefront is represented as every day `{ enabled: true, open: "00:00", close: "24:00" }`
+(`isStoreOpen` returns `true` for all instants — confirmed by `window.test.ts`). For such a
+store:
+
+- `isUpgradeWindowOpen({ schedule })` returns `!isStoreOpen` = **always false** → the scheduled
+  cron (`apps/web/lib/queue/functions/self-upgrade.ts`) skips with `outside-window` **forever**;
+  scheduled self-upgrades never run.
+- `nextUpgradeWindowOpen` returns **null** → the Upgrade Center
+  (`getSelfUpgradeStatus` → `SelfUpgradeClient.tsx`) shows the unhelpful "Maintenance window
+  configured." with no actual schedule and `nextScheduledCheckAt = null`.
+
+The only current escape is a manually-authored explicit `maintenanceWindows` array
+(`config.ts`) — exactly the raw-config dead-end a layman cannot navigate. This gap was left by
+the window-timezone fixes (#2199 / #2201).
+
+## 2. Desired behavior (founder requirement, Mark 2026-06-20)
+
+- When a store is **effectively 24/7** (no derived closed window), **auto-select** a sensible
+  low-traffic **overnight** window in the store's timezone (~02:00–04:00 local) and use it as the
+  upgrade window. Do **not** ask the operator unless there is a genuine need.
+- "Need to ask" cases: **no timezone known and none derivable**; genuinely global / round-the-clock
+  with no clear trough (future, telemetry-gated); or the operator wants to override.
+- Prefer the **observed low-traffic trough** from usage telemetry (`BusinessProfile.lowTrafficWindows`)
+  when a valid one exists; else a **default overnight window** in the store tz.
+- UX: progressive disclosure — auto-pick and surface "upgrades run overnight, ~2–4 AM <tz>";
+  show a control only when there is a real need (reuse the existing Operating Hours timezone
+  picker from #2199 / the existing explicit-window override). Never make a layman hand-configure cron.
+
+## 3. Research & benchmarking
+
+- **Overnight maintenance windows are the universal default** for unattended self-update systems:
+  Windows Update "Active Hours" (updates outside the hours you say you're active), WSUS/SCCM
+  maintenance windows, Kubernetes node-pool auto-upgrade windows, and managed-DB patch windows all
+  pick a low-traffic overnight slot the operator can override. DPF already mirrors this with the
+  "store closed = upgrade window" model; the 24/7 case is the one slot the operating-hours
+  derivation cannot fill, so an explicit overnight default is the standard fill.
+- **Pattern adopted:** auto-derive from what the platform already captures (timezone + schedule +
+  `lowTrafficWindows`), reuse the existing `MaintenanceWindow` evaluation machinery, and only prompt
+  when a required input (timezone) is genuinely missing. This matches AGENTS.md §12 progressive
+  disclosure and the kernel "Do the work; don't task the operator."
+- **Anti-pattern rejected:** a cron/time picker for every 24/7 store (forces raw config on a layman —
+  the #2004 raw-token-input mistake the UX-Fit Gate exists to stop) and "do nothing / keep gap"
+  (silent never-runs — the defect itself).
+
+## 4. Design
+
+A new pure module owns the 24/7 decision; both the cron gate and the status action consume it so
+the runtime and the UI never diverge (single source of truth). Explicit operator windows keep
+top priority. No schema change, no migration — `BusinessProfile.lowTrafficWindows` already exists.
+
+### 4.1 New: `apps/web/lib/self-upgrade/auto-window.ts` (pure, cron-safe)
+
+- `DEFAULT_OVERNIGHT_WINDOW: MaintenanceWindow` = `{ dayOfWeek: [0..6], startTime: "02:00", endTime: "04:00" }`.
+- `isEffectively247(schedule, now, timeZone)` — true when `nextUpgradeWindowOpen(schedule, now, timeZone) === null`
+  (no closed minute within the 8-day horizon). Reuses the tested scan; "near-24/7" stores with a
+  real (even short) closed window keep the operating-hours model — explicitly out of scope.
+- `LowTrafficWindow` type (`{ dayOfWeek: number; start: string; end: string }`, matching
+  `deriveLowTrafficWindows`) + `selectTroughWindows(lowTrafficWindows)`:
+  - strict validation: `HH` 00–23, `MM` 00–59, `start !== end`, duration > 0 and ≤ ~6h
+    (a quiet slot, not "all day"); rejects the malformed `{start:"24:00", end:"23:59"}` artifacts a
+    24/7 schedule's `deriveLowTrafficWindows` produces → those fall through to the default.
+  - groups valid per-day troughs by `(start,end)` into `MaintenanceWindow[]`; returns `null` when none qualify.
+- `resolveAutoUpgradeWindow({ schedule, timeZone, timezoneKnown, lowTrafficWindows, now })`:
+  - not effectively-247 → `{ kind: "operating-hours" }`.
+  - 247 **and** `!timezoneKnown` → `{ kind: "needs-timezone" }` (an overnight window in an unknown
+    zone could land at peak; ask instead).
+  - 247 **and** `timezoneKnown` → `{ kind: "auto-overnight", windows, source }` where `windows` =
+    `selectTroughWindows(...)` (`source: "trough"`) when valid, else `[DEFAULT_OVERNIGHT_WINDOW]`
+    (`source: "default"`).
+- `nextAutoWindowOpen(windows, now, timeZone)` — thin convenience over the config-extracted pure
+  helper (4.2) so `promotions.ts` imports only from `auto-window`.
+
+### 4.2 `apps/web/lib/self-upgrade/config.ts` — extract reusable pure helpers (DRY)
+
+- Add `isWithinWindows(windows: MaintenanceWindow[], now, timeZone)` and
+  `nextWindowStartForWindows(windows, now, timeZone)` (the current bodies of `isInMaintenanceWindow`
+  / `nextMaintenanceWindowStart`, which now delegate). Lets `auto-window.ts` reuse the exact
+  overnight-span + store-tz evaluation instead of a parallel copy. `window.ts`'s private
+  `isInExplicitWindows` also collapses onto `isWithinWindows` (removes existing duplication).
+
+### 4.3 `apps/web/lib/operating-hours-read.ts` — feed the new inputs
+
+- `resolveOperatingScheduleForSystem()` additionally returns `timezoneKnown: boolean` (true when the
+  profile tz is a pinned non-placeholder zone OR was derived from location; false when it fell back
+  to the `DEFAULT_OPERATING_HOURS_TIMEZONE` placeholder) and `lowTrafficWindows: LowTrafficWindow[]`
+  (parsed defensively from `BusinessProfile.lowTrafficWindows` JSON; `[]` when absent/invalid).
+  Add `lowTrafficWindows` to the `select`. Additive — existing `{ schedule, timezone }` destructures
+  keep working.
+
+### 4.4 `apps/web/lib/queue/functions/self-upgrade.ts` — cron gate
+
+Replace the scheduled gate block so the effective window is: explicit operator windows >
+auto-overnight (247 + tz known) > operating-hours derivation. `needs-timezone` skips cleanly with a
+distinct reason `no-window-needs-timezone` (no drain, no cooldown — the next tick re-checks once a tz
+is set). The decision point stays `isUpgradeWindowOpen` (existing tested fn), called with the
+resolved windows as `explicitWindows`.
+
+### 4.5 `apps/web/lib/actions/promotions.ts` — status action
+
+`getSelfUpgradeStatus` consumes the same `resolveAutoUpgradeWindow`. `windowSource` gains
+`"auto-overnight" | "needs-timezone"`; `inMaintenanceWindow` and `nextWindowStart` compute against
+the auto windows for the auto-overnight case (via `nextAutoWindowOpen`), so `nextScheduledCheckAt`
+flows through the existing `computeNextScheduledUpgradeCheckAt` unchanged. Add a short
+`autoWindowSummary` string (e.g. "2:00–4:00 AM") for display.
+
+### 4.6 `apps/web/components/ops/SelfUpgradeClient.tsx` — progressive-disclosure copy
+
+Declare the `windowSource` + `autoWindowSummary` props (already arrive via `{...status}` spread).
+Add two Schedule-panel branches:
+- `auto-overnight` → muted note "Your business runs 24/7, so upgrades run overnight (around {summary}
+  {tz}). Next: <LocalTime>." (reuses existing `nextWindowStart`/`inMaintenanceWindow` rendering).
+- `needs-timezone` → warning "Your business runs 24/7. Set your timezone in Settings → Operating
+  Hours so upgrades can run automatically overnight (or choose a maintenance window)." with a link to
+  `/storefront` operating hours. No new control. All copy uses `--dpf-*` tokens.
+
+## 5. Phases
+
+| Phase | Deliverable | Files | Verification |
+| --- | --- | --- | --- |
+| 1 | Pure `auto-window.ts` + config helper extraction | `auto-window.ts` (new), `config.ts` | `auto-window.test.ts` + `config.test.ts` (vitest): 247 detection (`00:00–24:00` all days → 247; one closed day/short slot → not), default-overnight pick, valid-trough preference, malformed-trough rejection, `needs-timezone`, store-tz overnight-span correctness. **Ships independently.** |
+| 2 | System reader returns `timezoneKnown` + `lowTrafficWindows` | `operating-hours-read.ts` | `operating-hours-read.test.ts` (if present) / new cases: placeholder→`timezoneKnown:false`, derived/pinned→`true`, JSON parse safety. |
+| 3 | Cron gate uses the resolver | `self-upgrade.ts` | `self-upgrade.test.ts`: add auto-overnight (gate passes auto windows), `needs-timezone`→`no-window-needs-timezone` skip; existing window-gate tests stay green (mock `auto-window`). |
+| 4 | Status action + UI copy | `promotions.ts`, `SelfUpgradeClient.tsx` | `promotions.self-upgrade.test.ts` (mock `auto-window`): `windowSource` values + `nextWindowStart` for auto case; `SelfUpgradeClient.test.tsx`: auto-overnight note + needs-timezone prompt render; existing "maintenance window" test stays green. |
+| 5 | Build gate | — | `pnpm --filter web typecheck`, affected `vitest run`, `pnpm --filter web build` via shared local-CI sandbox / canonical install (worktree is source-only). |
+
+## 6. Risks, blast radius, rollback
+
+- **Blast radius:** self-upgrade timing only. Pure additive module + additive return fields +
+  two extracted-then-delegated helpers. Non-24/7 stores: `resolveAutoUpgradeWindow` →
+  `operating-hours` → identical behavior to today (regression-guarded by the existing tests).
+- **Risk: a 24/7 store with an unknown tz silently stops scheduled upgrades.** Mitigation: distinct
+  `no-window-needs-timezone` skip reason + an explicit Upgrade Center prompt linking the existing tz
+  picker — surfaced, not silent. This is strictly better than today's silent never-runs.
+- **Risk: cross-module test mocks.** `self-upgrade.test.ts` and `promotions.self-upgrade.test.ts`
+  mock `@/lib/self-upgrade/window`; importing the new module there would route real `auto-window`
+  through the mocked `window.ts`. Mitigation: mock `@/lib/self-upgrade/auto-window` in both
+  (default `{ kind: "operating-hours" }`), and verify real behavior in the dedicated
+  `auto-window.test.ts` against the real `window.ts`/`config.ts`.
+- **Risk: telemetry trough is actually schedule-derived garbage for 24/7.** Mitigation: strict
+  validation rejects malformed/full-day windows → default overnight fires. The trough path is
+  future-proofing for real telemetry; documented as such.
+- **Rollback:** revert the PR. No migration, no data change, no config default change
+  (`maintenanceWindows` default stays `[]`).
+- **Out of scope:** ITIL `DeploymentWindow` / `check_deployment_windows` (separate change-window
+  concept); "global, no clear trough" telemetry-gated need-to-ask (no real usage telemetry exists
+  yet — known-tz always yields a default overnight pick for now).
+
+## 7. UX-Fit decision
+
+See §7 attestation in the PR body. Decision: `fits-with-guardrails`, `auto-overnight-progressive`
+(progressive disclosure; no new control on the happy path; `needs-timezone` reuses the existing
+Operating Hours timezone picker). Governed by AGENTS.md §12 + kernel "Do the work; don't task the
+operator" + "Never ask the user to run commands"; binding founder requirement in BI-A6382FB9.
+`principle_decide` was run (advisory, low-confidence/non-discriminating here — relevant cognitive-load
+commandments carry no option feature scores; retrieval surfaced unrelated infra principles).


### PR DESCRIPTION
## What & why

Closes the 24/7-business gap in the self-upgrade maintenance window (**BI-A6382FB9**, EP-UPGRADE-LIFECYCLE).

The upgrade window is derived as *"any time the store is CLOSED"* (`lib/self-upgrade/window.ts`). A 24/7 storefront (every day open `00:00`–`24:00`) is never closed → `isUpgradeWindowOpen` is always `false` and `nextUpgradeWindowOpen` returns `null`, so **scheduled self-upgrades never run** and the Upgrade Center shows a dead-end *"Maintenance window configured."* with no schedule. The only escape was a hand-authored explicit `maintenanceWindows` array — exactly the raw config a layman can't manage. This is the gap left by the window-timezone work (#2199 / #2201).

## Approach

A new pure, prisma-free resolver decides the window source; both the cron gate and the status action consume it (single source of truth). **Explicit operator windows still win.**

- **`lib/self-upgrade/auto-window.ts`** (new) — `resolveAutoUpgradeWindow`:
  - not effectively-24/7 → `operating-hours` (unchanged behaviour),
  - 24/7 **+ known timezone** → `auto-overnight`: a low-traffic overnight window in the store tz — an observed `BusinessProfile.lowTrafficWindows` trough when a valid one exists, else a default **02:00–04:00 local**,
  - 24/7 **+ no derivable timezone** → `needs-timezone`: skip safely and prompt, rather than guess an overnight slot in an unknown zone.
- **`lib/self-upgrade/windows-eval.ts`** (new) — pure window-evaluation primitives (`isWithinWindows`, `nextWindowStartForWindows`) extracted from `config.ts` so `config.ts`, `window.ts`, and `auto-window.ts` share **one** store-tz + overnight-span implementation and `window.ts`/`auto-window.ts` stay prisma-free. Removes the duplicated `isInExplicitWindows`.
- **Cron** (`queue/functions/self-upgrade.ts`) — scheduled gate evaluates against the resolved windows; `needs-timezone` skips with a distinct `no-window-needs-timezone` reason (no drain, no cooldown).
- **Status + UI** (`actions/promotions.ts`, `components/ops/SelfUpgradeClient.tsx`) — `windowSource` gains `auto-overnight | needs-timezone`; the panel shows a read-only *"runs overnight, ~2:00 AM–4:00 AM <tz>"* note for the happy path, and the timezone prompt (linking the **existing** Operating Hours picker) only in the `needs-timezone` case.
- **`lib/operating-hours-read.ts`** — `resolveOperatingScheduleForSystem` now also returns `timezoneKnown` + `lowTrafficWindows`. (Rebased onto #2208's `Organization.address` derivation; imports unioned.)

No schema change, no migration — `BusinessProfile.lowTrafficWindows` already exists.

## Tests

- `auto-window.test.ts` (new): 24/7 detection, default-overnight pick, valid-trough preference, malformed-trough rejection (`24:00`/`>6h`/zero-length), `needs-timezone`, store-tz overnight correctness, clock formatting.
- `self-upgrade.test.ts`: 24/7 gate evaluates auto windows; `needs-timezone` → `no-window-needs-timezone` clean skip. Existing window-gate tests preserved.
- `promotions.self-upgrade.test.ts`: `windowSource=auto-overnight` (+ next 02:00 + summary) and `=needs-timezone` (+ no window handed to the gate).
- `SelfUpgradeClient.test.tsx`: overnight note + timezone prompt render. `page.test.tsx`: status shape updated.

## Verification

⚠️ This worktree **and** the root clone are dependency-degraded (no `node_modules`/`pnpm`), so the build gate (typecheck + unit tests + production build) could not run locally — an **unrun gate, not a red gate** (AGENTS.md §5). It runs in **CI**, which the merge queue enforces green before merge. Self-reviewed for type-correctness (split-undefined hardening, prisma-free import graph verified, mocks updated so existing suites stay green).

## UX-Fit-Decision

fits-with-guardrails. The 24/7 happy path adds **no new control** (auto-pick + a read-only status line); a control appears only in the `needs-timezone` case and reuses the **existing** Operating Hours timezone picker (#2199) — never a raw cron/time form for a layman. Progressive disclosure per AGENTS.md §12 and kernel *"Do the work; don't task the operator"* / *"Never ask the user to run commands"*; implements the binding founder requirement in BI-A6382FB9. `principle_decide` was run on `human_cognitive_load` (advisory; its composite was low-confidence/non-discriminating here — the relevant cognitive-load commandments carry no option feature scores and retrieval surfaced unrelated infra principles).

Plan: `docs/superpowers/plans/2026-06-20-self-upgrade-24-7-overnight-window.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)