### PR TITLE
fix(build-studio): complete fully-local (private/fork_only) builds instead of parking at ship

### DIFF
--- a/apps/web/lib/build-flow-state.test.ts
+++ b/apps/web/lib/build-flow-state.test.ts
@@ -390,4 +390,24 @@ describe("reconcileBuildCompletion", () => {
     expect(changed).toBe(false);
     expect(prisma.featureBuild.update).not.toHaveBeenCalled();
   });
+
+  it("completes a fully-local (fork_only) build on forks-terminal even when NOT deployed", async () => {
+    // Fully-local install: contributionMode fork_only → the upstream fork is
+    // "skipped" (the change is never PR'd / merged / re-deployed), so
+    // isFeatureBuildDeployed can never become true. Without this path the build
+    // parks at ship forever and clogs the WIP cap. The promote fork (the
+    // registered ProductVersion) is the delivery, so the build must complete.
+    mockDevConfig("fork_only");
+    mockBuild({
+      phase: "ship",
+      productVersions: [{ id: "pv-1", promotions: [{ promotionId: "CP-1", status: "deployed", deployedAt: new Date(), rollbackReason: null, deploymentLog: null, createdAt: new Date() }] }],
+    });
+    vi.mocked(isFeatureBuildDeployed).mockResolvedValue(false);
+    const changed = await reconcileBuildCompletion("FB-TEST-001");
+    expect(changed).toBe(true);
+    expect(prisma.featureBuild.update).toHaveBeenCalledWith({
+      where: { buildId: "FB-TEST-001" },
+      data: { phase: "complete" },
+    });
+  });
 });

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -437,8 +437,19 @@ export async function reconcileBuildCompletion(buildId: string): Promise<boolean
   if (!state) return false;
   if (state.currentPhase !== "ship") return false;
   if (!state.allApplicableForksTerminal) return false;
-  // Confirm the deployed runtime includes the build's merge SHA before completing.
-  if (!await isFeatureBuildDeployed(buildId)) return false;
+  // Confirm the deployed runtime includes the build's merge SHA before
+  // completing — UNLESS there is no upstream deploy path at all. When the
+  // install's contributionMode is private/fork_only the upstream fork resolves
+  // to "skipped": the change is never PR'd, merged, or re-deployed, so
+  // isFeatureBuildDeployed can NEVER become true and the build parks at ship
+  // forever (holding a WIP slot — the throughput blocker for a fully-local
+  // install running its backlog). For these installs the promote fork (the
+  // registered ProductVersion) IS the delivery, so completion follows
+  // forks-terminal. A real upstream PR ("shipped"/in-flight) keeps the
+  // deploy-confirmation gate (#2188: complete once the merged SHA is live).
+  if (state.upstream.state !== "skipped" && !(await isFeatureBuildDeployed(buildId))) {
+    return false;
+  }
 
   await prisma.featureBuild.update({
     where: { buildId },


### PR DESCRIPTION
## Problem
On a **fully-local install** (`contributionMode` = `private`/`fork_only`, no `HIVE_CONTRIBUTION_TOKEN`), a verified build flows ideate→…→ship, the **promote fork resolves** (a `ProductVersion` is registered), but the **upstream fork resolves to `skipped`** (the change is never PR'd, merged, or re-deployed). `reconcileBuildCompletion` then hard-requires `isFeatureBuildDeployed` (the build's merge SHA present in the running image), which can **never** become true with no deploy path — so the build **parks at `ship` forever**, holding a WIP slot. With the cap (3) full of parked builds, autonomous backlog throughput stalls.

Observed live: FB-6E8F4BA4 produced real code, reached ship, promote registered, then "completes after PR merge + self-upgrade" — a merge that never comes for a private change.

## Fix
In `reconcileBuildCompletion`, when the upstream fork is `skipped` (no deploy path exists), complete on **forks-terminal** — the promote fork (registered `ProductVersion`) *is* the delivery. A real upstream PR (`shipped`/in-flight) still keeps the deploy-confirmation gate, so **#2188 contributing-mode semantics are unchanged**.

## Test
`build-flow-state.test.ts`: new case "completes a fully-local (fork_only) build on forks-terminal even when NOT deployed"; the existing "returns false when deployed SHA does not contain the merge SHA" (real PR → upstream `shipped`) still passes. **30/30 pass.**