### PR TITLE
fix(build-studio): auto-run design review after ideate so builds advance hands-off

### DIFF
--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -213,6 +213,15 @@ describe("dispatchIdeateForApprovedBuild", () => {
       "u-1",
       expect.any(Object),
     );
+    // Auto-chain (autonomous-flow fix): the design review fires immediately after
+    // the designDoc save so the build advances ideate->plan without waiting ~20
+    // min for the stranded-build reconciler at each handoff.
+    expect(mockExecuteTool).toHaveBeenCalledWith(
+      "reviewDesignDoc",
+      { buildId: "FB-X" },
+      "u-1",
+      expect.any(Object),
+    );
     // Should write at least two activity rows: the "Dispatching..." log and the "Auto-dispatched..." success log.
     expect(mockPrisma.buildActivity.create).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -266,6 +266,33 @@ export async function dispatchIdeateForApprovedBuild(params: {
       durationMs,
     };
     await logActivity(`Auto-dispatched and saved designDoc in ${(durationMs / 1000).toFixed(1)}s (fields: ${designDocKeys.slice(0, 8).join(", ")})`);
+
+    // Auto-advance the happy path: run the design review now so the build moves
+    // ideate -> plan immediately instead of stranding at ideate until the 20-min
+    // stranded-build reconciler heals it. That stall is the autonomous-flow
+    // throughput gap — a backlog cannot drain if every build waits ~20 min at
+    // each pre-build handoff for the reconciler. Once the design review passes,
+    // the plan phase auto-chains on its own (dispatch plan -> reviewBuildPlan ->
+    // build), so this single missing link is all that blocks end-to-end
+    // hands-off progress (verified live: a one-shot reviewDesignDoc nudge drove a
+    // stalled build ideate -> plan -> build automatically).
+    //
+    // reviewDesignDoc is gate-aware (it correctly PARKS a `decompose-required`
+    // design rather than advancing it), so this never bulldozes the
+    // decomposition gate. Skipped on a fix-loop regeneration (priorReviewFeedback
+    // set): dispatchDesignReviewFixLoop runs the review itself, so auto-reviewing
+    // here would double-review. Best-effort — a review hiccup must not fail the
+    // fire-and-forget ideate dispatch; the reconciler/fix-loop stays the backstop.
+    if (!priorReviewFeedback) {
+      try {
+        const { executeTool } = await import("@/lib/mcp-tools");
+        await executeTool("reviewDesignDoc", { buildId }, userId, { featureBuildId: buildId });
+      } catch (err) {
+        await logActivity(
+          `Auto design-review after ideate did not complete: ${String(err instanceof Error ? err.message : err).slice(0, 160)} — stranded-build reconciler will retry.`,
+        );
+      }
+    }
     return outcome;
 
   } catch (err) {


### PR DESCRIPTION
## Problem
A backlog-promoted build is auto-approved → `dispatchIdeateForApprovedBuild` generates + saves the designDoc → **returns without running `reviewDesignDoc`**. The build then strands at `ideate` until the **20-min** stranded-build reconciler heals it. That per-handoff stall is the autonomous-flow throughput gap: a backlog can't drain if every build waits ~20 min just to advance ideate→plan.

Observed live: FB-8E5BD3A8 sat at `ideate` (designDoc saved, `designReview` NULL) for 10+ min; a single manual `reviewDesignDoc` then drove it ideate→plan→**build** automatically.

## Fix
After the initial designDoc save, auto-run `reviewDesignDoc`. It's gate-aware (still PARKS a `decompose-required` design), and once it passes the plan phase auto-chains on its own (dispatch plan → reviewBuildPlan → build). Skipped on a fix-loop regeneration (`priorReviewFeedback` set) so `dispatchDesignReviewFixLoop` isn't double-reviewed. Best-effort — a review hiccup can't fail the fire-and-forget ideate dispatch (reconciler stays the backstop).

## Test
`ideate-on-approval.test.ts`: happy path now asserts `reviewDesignDoc` is called after the save. **15/15 pass.**