### PR TITLE
fix(build-studio): refresh stall heartbeat per durable step so long codegen isn't falsely reaped

### DIFF
--- a/apps/web/lib/integrate/build-execute-helpers.ts
+++ b/apps/web/lib/integrate/build-execute-helpers.ts
@@ -198,7 +198,20 @@ export async function runPipelineStepDurable(params: {
   if (decision !== "run") return state;
 
   const { executeStep, nextStep } = await import("@/lib/integrate/build-pipeline");
-  const { withHeartbeatTicker, heartbeat } = await import("@/lib/observability/heartbeat");
+  const { withHeartbeatTicker, heartbeat, markTaskRunWorking } = await import("@/lib/observability/heartbeat");
+
+  // Refresh the stall heartbeat at the START of each step so the watchdog's
+  // timeout window is measured per-step, not from taskrun creation. The in-step
+  // heartbeat ticker (withHeartbeatTicker's setInterval) does NOT fire inside
+  // the Inngest step.run execution context, so without this a long step (local
+  // codegen ~100s+) accumulates the ENTIRE build phase's elapsed time against a
+  // single heartbeat window and is falsely reaped as a `heartbeat_timeout`
+  // stall — observed live reaping every durable codegen (FB-6E8F4BA4,
+  // FB-8E5BD3A8 each failed at code_generated with the taskrun heartbeat never
+  // advancing past creation). markTaskRunWorking also re-asserts
+  // status="working" so heartbeat() writes land even when ensureBuildTaskRun
+  // reused a row that was not in the working state.
+  await markTaskRunWorking(taskRunId).catch(() => {});
 
   await emitForBuild(buildId, { type: "phase:change", buildId, phase: step });
 


### PR DESCRIPTION
## Problem
Every durable codegen step was falsely reaped as a `heartbeat_timeout` stall. Observed live: FB-6E8F4BA4 and FB-8E5BD3A8 both failed at `code_generated`, with the taskrun's `lastHeartbeatAt` never advancing past creation (heartbeat span `00:00:00`).

Root cause: `withHeartbeatTicker`'s `setInterval` does **not** fire inside the Inngest `step.run` execution context, so the heartbeat is written once (at taskrun creation) and the **entire** build phase's elapsed time (workspace+db+deps+codegen) accumulates against a single 180s window. A ~100s+ local codegen step tips it over → the watchdog reaps a healthy build.

## Fix
Call `markTaskRunWorking` at the **start of each durable step** in `runPipelineStepDurable`. The heartbeat-timeout window is now measured **per step** instead of from taskrun creation, and `status="working"` is re-asserted so `heartbeat()` writes land even if `ensureBuildTaskRun` reused a non-working row.

## Validation
Live: with the window made per-step (a DB band-aid raised `phase.build` heartbeat 180→900s pending this deploy), FB-8E5BD3A8 completed codegen **2/2 tasks with no reap**. `build-execute-helpers.test.ts` 10/10 pass.