### PR TITLE
fix(build-studio): treat an opencode fatal error (e.g. ContextOverflowError) as a task failure

### DIFF
--- a/apps/web/lib/integrate/opencode-dispatch.test.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.test.ts
@@ -8,7 +8,35 @@ import {
   summarizeOpencodeEvent,
   extractOpencodeResult,
   buildOpencodeInstructions,
+  detectOpencodeFatalError,
 } from "./opencode-dispatch";
+
+describe("detectOpencodeFatalError", () => {
+  it("detects a llama.cpp ContextOverflowError in the stream", () => {
+    // The exact shape observed live when a codegen prompt exceeded the served
+    // context window — opencode emitted this AND still exited 0.
+    const stdout = [
+      '{"type":"step_start","time":1}',
+      '{"type":"error","timestamp":1782014385749,"error":{"name":"ContextOverflowError","data":{"message":"request (24792 tokens) exceeds the available context size (24576 tokens), try increasing it"}}}',
+    ].join("\n");
+    const err = detectOpencodeFatalError(stdout);
+    expect(err).toContain("ContextOverflowError");
+    expect(err).toContain("24792");
+  });
+
+  it("returns null for a clean stream with no error event", () => {
+    const stdout = [
+      '{"type":"step_start"}',
+      '{"type":"tool","tool":"write","path":"a.ts"}',
+      '{"type":"result","text":"done"}',
+    ].join("\n");
+    expect(detectOpencodeFatalError(stdout)).toBeNull();
+  });
+
+  it("tolerates non-JSON / empty lines", () => {
+    expect(detectOpencodeFatalError("plain log line\n\nnot json")).toBeNull();
+  });
+});
 
 describe("sandboxReachableUrl", () => {
   it("rewrites localhost to host.docker.internal preserving port", () => {

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -510,6 +510,43 @@ export async function dispatchOpencodeTask(params: {
     });
 
     const content = extractOpencodeResult(stdout);
+
+    // Detect a FATAL model/runtime error event in the stream. opencode emits
+    // these as {"type":"error",...} JSON to stdout and STILL exits 0, so the
+    // process-close check above (code===0 || stdout.trim()) classified a failed
+    // run as a SUCCESS — the build then advanced with zero code produced and
+    // shipped an empty diff ("No releasable source changes"). The classic case
+    // is a llama.cpp ContextOverflowError when the prompt exceeds the served
+    // context window. Treat any fatal error event as a task FAILURE so the
+    // orchestrator's fix/retry/escalate path engages instead of silently
+    // shipping nothing.
+    const fatalError = detectOpencodeFatalError(stdout);
+    if (fatalError) {
+      console.error(
+        sanitizeForLog(`[opencode-dispatch] Task "${task.title}" reported a fatal error: ${fatalError}`),
+      );
+      await recordBuildDispatchAttempt({
+        buildId: params.buildId,
+        taskTitle: task.title,
+        specialist: role,
+        providerId,
+        model,
+        startedAt,
+        completedAt: new Date(),
+        durationMs: elapsed,
+        exitCode: 0,
+        success: false,
+        stdout: content,
+        stderr: fatalError,
+      });
+      return {
+        content: `OpenCode task failed: ${fatalError}`,
+        success: false,
+        executedTools: [],
+        durationMs: elapsed,
+      };
+    }
+
     console.log(
       sanitizeForLog(
         `[opencode-dispatch] Task "${task.title}" completed in ${(elapsed / 1000).toFixed(1)}s (${content.length} chars)`,
@@ -564,6 +601,37 @@ export async function dispatchOpencodeTask(params: {
       durationMs,
     };
   }
+}
+
+/**
+ * Scan an `opencode run --format json` stdout stream for a FATAL error event.
+ * opencode emits these as {"type":"error","error":{"name":...,"data":{"message":...}}}
+ * for model/runtime failures (e.g. a llama.cpp ContextOverflowError /
+ * exceed_context_size_error when the prompt exceeds the served context window)
+ * yet STILL exits 0 — so without this the dispatcher's exit-code/non-empty-stdout
+ * success check mis-reads the run as a success that produced no code, and the
+ * build advances to ship with an empty diff ("No releasable source changes").
+ * Returns a short "Name: message" for the first fatal error, or null when the
+ * stream has none. Tolerant of format drift: non-JSON / unknown lines are skipped.
+ */
+export function detectOpencodeFatalError(stdout: string): string | null {
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    let evt: Record<string, unknown>;
+    try {
+      evt = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (evt.type === "error") {
+      const err = evt.error as { name?: string; data?: { message?: string } } | undefined;
+      const name = typeof err?.name === "string" ? err.name : "OpencodeError";
+      const message = typeof err?.data?.message === "string" ? err.data.message : "";
+      return `${name}${message ? `: ${message}` : ""}`.slice(0, 300);
+    }
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Problem
opencode emits `{"type":"error",...}` for model/runtime failures — most notably a llama.cpp **ContextOverflowError** when the codegen prompt exceeds the served context window — yet **still exits 0** and writes the error JSON to stdout. The dispatcher's success check (`exitCode===0 || stdout.trim()`) therefore classified a failed run as a **success that produced no code**, and the build advanced to ship with an empty diff (`No releasable source changes`) — the silent dead-end behind the autonomous-delivery stall (3/3 tasks "complete", zero diff).

## Fix
`detectOpencodeFatalError(stdout)` scans the JSON stream; a fatal error event makes the task return `success: false` (recorded on `BuildDispatchAttempt`) so the orchestrator's fix/retry/escalate path engages instead of silently shipping nothing.

Complements the live DMR context bump (24k→32k) that prevents the overflow in the first place — this is the safety net for *any* fatal model/runtime error.

## Test
`opencode-dispatch.test.ts`: 3 new cases (detects the exact live ContextOverflowError shape; null on a clean stream; tolerates non-JSON). **38/38 pass.**