### PR TITLE
fix(build-studio): complete fully-local builds whose promote fork lands non-terminal

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -30,6 +30,7 @@ const productVersionFindManyMock = vi.fn();
 const changePromotionUpdateManyMock = vi.fn();
 const isFeatureBuildDeployedMock = vi.fn();
 const reconcileBuildCompletionMock = vi.fn();
+const completeLocalDeliveryBuildMock = vi.fn();
 const reconcileQuiescenceOnBootMock = vi.fn();
 
 vi.mock("@/lib/platform/version-config", () => ({
@@ -43,6 +44,7 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
 
 vi.mock("@/lib/build-flow-state", () => ({
   reconcileBuildCompletion: (...args: unknown[]) => reconcileBuildCompletionMock(...args),
+  completeLocalDeliveryBuild: (...args: unknown[]) => completeLocalDeliveryBuildMock(...args),
 }));
 
 vi.mock("@/lib/self-upgrade/quiescence", () => ({
@@ -103,6 +105,7 @@ beforeEach(() => {
   changePromotionUpdateManyMock.mockReset();
   isFeatureBuildDeployedMock.mockReset();
   reconcileBuildCompletionMock.mockReset();
+  completeLocalDeliveryBuildMock.mockReset();
   reconcileQuiescenceOnBootMock.mockReset();
   reconcileQuiescenceOnBootMock.mockResolvedValue({ reconciled: 0, failed: 0 });
   featureBuildUpdateMock.mockResolvedValue({});
@@ -112,6 +115,7 @@ beforeEach(() => {
   productVersionFindManyMock.mockResolvedValue([]);
   changePromotionUpdateManyMock.mockResolvedValue({ count: 0 });
   reconcileBuildCompletionMock.mockResolvedValue(false);
+  completeLocalDeliveryBuildMock.mockResolvedValue(false);
   delete process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS;
 });
 
@@ -155,6 +159,23 @@ describe("reconcileDeployedShipBuilds — autonomous ship→complete (flag-gated
 
     expect(result).toEqual({ completed: 0 });
     expect(changePromotionUpdateManyMock).not.toHaveBeenCalled();
+    expect(reconcileBuildCompletionMock).not.toHaveBeenCalled();
+    // Non-deployed builds now route to completeLocalDeliveryBuild, which no-ops
+    // (returns false) for a build that has a real upstream deploy path.
+    expect(completeLocalDeliveryBuildMock).toHaveBeenCalledWith("FB-2");
+  });
+
+  it("completes a non-deployed fully-local build via completeLocalDeliveryBuild", async () => {
+    process.env.DPF_AUTO_COMPLETE_VERIFIED_BUILDS = "1";
+    featureBuildFindManyMock.mockResolvedValue([{ id: "fb-3", buildId: "FB-3" }]);
+    isFeatureBuildDeployedMock.mockResolvedValue(false); // never deployed (fully-local)
+    completeLocalDeliveryBuildMock.mockResolvedValue(true); // private/fork_only → delivered locally
+
+    const result = await reconcileDeployedShipBuilds({ log: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ completed: 1 });
+    expect(completeLocalDeliveryBuildMock).toHaveBeenCalledWith("FB-3");
+    // The deployed-path reconcile is not used for a fully-local build.
     expect(reconcileBuildCompletionMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -463,7 +463,7 @@ export async function reconcileDeployedShipBuilds(
   if (!isAutoCompleteEnabled()) return null;
   try {
     const { prisma } = await import("@dpf/db");
-    const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
+    const { reconcileBuildCompletion, completeLocalDeliveryBuild } = await import("@/lib/build-flow-state");
     const { isFeatureBuildDeployed } = await import("@/lib/self-upgrade/completion");
 
     const shipBuilds = await prisma.featureBuild.findMany({
@@ -473,7 +473,21 @@ export async function reconcileDeployedShipBuilds(
     let completed = 0;
     for (const build of shipBuilds) {
       try {
-        if (!(await isFeatureBuildDeployed(build.buildId))) continue;
+        if (!(await isFeatureBuildDeployed(build.buildId))) {
+          // Not deployed: a fully-local (private/fork_only) build still completes
+          // here — its local ProductVersion registration IS the delivery (there
+          // is no upstream PR or remote deploy to wait on). completeLocalDeliveryBuild
+          // no-ops for a build that has a real upstream deploy path (those wait
+          // for their merged code to go live). This is the backstop for builds
+          // that parked at ship because the promote fork was still `approved`.
+          if (await completeLocalDeliveryBuild(build.buildId)) {
+            completed++;
+            logger.log(
+              `[auto-complete] ${build.buildId} completed — delivered locally (fully-local install)`,
+            );
+          }
+          continue;
+        }
         // Merged code is live via self-upgrade → mark the build's still-open
         // promotion(s) deployed so the promote fork is terminal. The platform
         // self-upgrade IS the deploy here (the per-build promoter is not used).

--- a/apps/web/lib/build-flow-state.test.ts
+++ b/apps/web/lib/build-flow-state.test.ts
@@ -6,6 +6,8 @@ vi.mock("@dpf/db", () => ({
     featurePack:       { findFirst: vi.fn() },
     platformDevConfig: { findUnique: vi.fn() },
     buildActivity:     { findFirst: vi.fn() },
+    productVersion:    { findMany: vi.fn() },
+    changePromotion:   { updateMany: vi.fn() },
   },
 }));
 
@@ -19,7 +21,7 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
 
 import { prisma } from "@dpf/db";
 import { isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
-import { getBuildFlowState, reconcileBuildCompletion } from "./build-flow-state";
+import { getBuildFlowState, reconcileBuildCompletion, completeLocalDeliveryBuild } from "./build-flow-state";
 
 // ─── Fixture helpers ────────────────────────────────────────────────────────
 
@@ -88,6 +90,8 @@ beforeEach(() => {
   mockPack(null);
   mockActivity(null);
   vi.mocked(isFeatureBuildDeployed).mockResolvedValue(true);
+  vi.mocked(prisma.productVersion.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.changePromotion.updateMany).mockResolvedValue({ count: 0 } as never);
 });
 
 // ─── Main-track substep counts (A.3) ────────────────────────────────────────
@@ -409,5 +413,44 @@ describe("reconcileBuildCompletion", () => {
       where: { buildId: "FB-TEST-001" },
       data: { phase: "complete" },
     });
+  });
+});
+
+describe("completeLocalDeliveryBuild", () => {
+  it("marks the local promotion delivered and completes a fork_only build (no deploy needed)", async () => {
+    mockDevConfig("fork_only"); // upstream fork resolves to "skipped"
+    mockBuild({
+      phase: "ship",
+      productVersions: [{ id: "pv-1", promotions: [{ promotionId: "CP-1", status: "deployed", deployedAt: new Date(), rollbackReason: null, deploymentLog: null, createdAt: new Date() }] }],
+    });
+    vi.mocked(prisma.productVersion.findMany).mockResolvedValue([{ id: "pv-1" }] as never);
+    vi.mocked(prisma.changePromotion.updateMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(isFeatureBuildDeployed).mockResolvedValue(false);
+    vi.mocked(prisma.featureBuild.update).mockResolvedValue({} as never);
+
+    const changed = await completeLocalDeliveryBuild("FB-TEST-001");
+
+    expect(changed).toBe(true);
+    // The still-open promotion is marked delivered — the local registration IS the delivery.
+    expect(prisma.changePromotion.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "deployed" }) }),
+    );
+    expect(prisma.featureBuild.update).toHaveBeenCalledWith({
+      where: { buildId: "FB-TEST-001" },
+      data: { phase: "complete" },
+    });
+  });
+
+  it("is a no-op for a build with a real upstream fork (not skipped)", async () => {
+    mockDevConfig("selective");
+    mockPack({ packId: "FP-1", prUrl: "https://github.com/org/repo/pull/9", prNumber: 9 }); // upstream "shipped"
+    mockBuild({
+      phase: "ship",
+      productVersions: [{ id: "pv-1", promotions: [{ promotionId: "CP-1", status: "approved", deployedAt: null, rollbackReason: null, deploymentLog: null, createdAt: new Date() }] }],
+    });
+    const changed = await completeLocalDeliveryBuild("FB-TEST-001");
+    expect(changed).toBe(false);
+    expect(prisma.changePromotion.updateMany).not.toHaveBeenCalled();
+    expect(prisma.featureBuild.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -470,3 +470,54 @@ export async function reconcileBuildCompletion(buildId: string): Promise<boolean
 
   return true;
 }
+
+/**
+ * Complete a fully-local build whose only "delivery" is the local ProductVersion
+ * registration. A private/fork_only install has no upstream PR and no remote
+ * deploy step, so the registered promotion IS the delivery — but the promote
+ * fork lands as `approved` (not terminal), so `reconcileBuildCompletion` alone
+ * leaves the build parked at `ship` forever (the WIP-clogging throughput blocker
+ * for a fully-local backlog). This marks any still-open promotion delivered (so
+ * the promote fork becomes terminal) and then advances ship→complete via
+ * reconcileBuildCompletion (whose skipped-upstream gate no longer requires a
+ * live deploy).
+ *
+ * No-op for a build with a real (shipped/in-flight) upstream fork — that one
+ * completes only once its merged code is live. Idempotent + safe to call
+ * repeatedly. Returns true iff the build advanced to complete.
+ */
+export async function completeLocalDeliveryBuild(buildId: string): Promise<boolean> {
+  const state = await getBuildFlowState(buildId);
+  if (!state || state.currentPhase !== "ship") return false;
+  // A "skipped" upstream fork means contributionMode is private/fork_only: no PR
+  // to merge, no remote deploy — ours to finalize locally. Anything else has a
+  // real deploy path and is NOT ours to force.
+  if (state.upstream.state !== "skipped") return false;
+
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { id: true },
+  });
+  if (build) {
+    const pvs = await prisma.productVersion.findMany({
+      where: { featureBuildId: build.id },
+      select: { id: true },
+    });
+    if (pvs.length > 0) {
+      await prisma.changePromotion.updateMany({
+        where: {
+          productVersionId: { in: pvs.map((p) => p.id) },
+          status: { in: ["pending", "approved", "scheduled", "awaiting_operator"] },
+        },
+        data: {
+          status: "deployed",
+          deployedAt: new Date(),
+          rationale:
+            "Delivered locally — fully-local install (private/fork_only); no upstream deploy path.",
+        },
+      });
+    }
+  }
+
+  return reconcileBuildCompletion(buildId);
+}

--- a/apps/web/lib/integrate/ship-on-review-approval.test.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.test.ts
@@ -91,6 +91,10 @@ vi.mock("@/lib/build-flow-state", () => ({
     state.reconcileCalls.push(buildId);
     return state.reconcileResult;
   }),
+  // Fully-local completion fallback (called by autoResolveShipForks when
+  // reconcileBuildCompletion returns false). Default: no-op returning false so
+  // the existing reconcileBuildCompletion assertions are unaffected.
+  completeLocalDeliveryBuild: vi.fn(async () => false),
 }));
 
 vi.mock("@/lib/mcp-tools", () => ({

--- a/apps/web/lib/integrate/ship-on-review-approval.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.ts
@@ -360,12 +360,17 @@ export async function autoResolveShipForks(
     }
   }
 
-  // ── Attempt completion. No-op until the PR is merged AND the self-upgrade
-  //    carries the merge SHA live; the periodic ship reconciler finishes it.
+  // ── Attempt completion. For a fully-local (private/fork_only) build the local
+  //    promotion IS the delivery, so completeLocalDeliveryBuild finishes it now
+  //    (no upstream PR / remote deploy will ever come). Otherwise this is a
+  //    no-op until the PR merges AND the self-upgrade carries the merge SHA
+  //    live; the periodic ship reconciler finishes that case.
   try {
-    const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
+    const { reconcileBuildCompletion, completeLocalDeliveryBuild } = await import("@/lib/build-flow-state");
     if (await reconcileBuildCompletion(buildId)) {
       await log("auto-complete: build COMPLETE (merged code live).");
+    } else if (await completeLocalDeliveryBuild(buildId)) {
+      await log("auto-complete: build COMPLETE (delivered locally — fully-local install).");
     } else {
       await log("auto-complete: forks set up; completes after PR merge + self-upgrade.");
     }


### PR DESCRIPTION
## Problem
#2220 made `reconcileBuildCompletion` skip the live-deploy gate for skipped-upstream (private/fork_only) builds — but they **still parked at ship**. The promote fork lands as `approved` (not terminal), so `allApplicableForksTerminal` is false and completion never fires. Live: FB-6E8F4BA4 / FB-FD850A2C sat at ship for an hour+ with promote status `approved`; the periodic reconciler `continue`d past them (it only handles *deployed* builds).

For a fully-local install the local `ProductVersion` registration **is** the delivery — there is no upstream PR or remote deploy to make the promotion `deployed`.

## Fix
`completeLocalDeliveryBuild(buildId)`: for a build whose upstream fork is `skipped`, mark any still-open promotion delivered (promote fork → terminal) then advance ship→complete via `reconcileBuildCompletion`. No-op for a build with a real upstream deploy path. Wired into:
- **`autoResolveShipForks`** (ship-time, so new builds complete immediately), and
- **`reconcileDeployedShipBuilds`** (periodic backstop — previously skipped every non-deployed build, so private builds never completed).

This is what actually drains a fully-local backlog — builds were clogging the WIP cap at ship forever.

## Test
`build-flow-state.test.ts`: completes a fork_only build (marks promotion delivered); no-op for a real upstream fork. **32/32 pass.**