### PR TITLE
fix(build-studio): synthetic QA verification task failure must not block build->review

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -1658,7 +1658,18 @@ export async function runBuildOrchestrator(params: {
   try {
     const { checkPhaseGate, canTransitionPhase } = await import("@/lib/feature-build-types");
     const updatedBuild = await prisma.featureBuild.findUnique({ where: { buildId } });
-    const hasBlockingTasks = allResults.some((r) => r.outcome === "BLOCKED" || r.outcome === "NEEDS_CONTEXT");
+    // The synthetic QA task (taskIndex === -1, "Full verification: tests +
+    // typecheck") is dispatched to the model, which runs the full suite via
+    // opencode — flaky and slow on a local model (observed: 61s pass for one
+    // build, then a 301s rate-limit FAILURE for the next) and REDUNDANT: the
+    // authoritative verification is the scoped checkPhaseGate below, which reads
+    // the saved verificationOut. A failed model-run QA task must NOT block the
+    // build→review advance, or ~half of all builds strand at `build` forever.
+    const hasBlockingTasks = allResults.some(
+      (r) =>
+        (r.outcome === "BLOCKED" || r.outcome === "NEEDS_CONTEXT") &&
+        r.task.taskIndex !== -1,
+    );
     if (!hasBlockingTasks && updatedBuild && updatedBuild.phase === "build" && canTransitionPhase("build", "review")) {
       // Scope the verification to THIS build's changed files before gating.
       // A pre-existing typecheck/test failure ELSEWHERE in the repo (e.g. an
@@ -1703,8 +1714,12 @@ export async function runBuildOrchestrator(params: {
   }
 
   // Synthesize final result (include skipped tasks in completed count)
-  const completedTasks = allResults.filter(r => r.success).length + completedTaskTitles.size;
-  const failedTasks = allResults.filter(r => !r.success).length;
+  // The synthetic QA task (taskIndex === -1) is advisory — its model-run failure
+  // is not a build failure (the authoritative verification is the phase gate).
+  // Count it as completed, never failed, so the summary + "needs attention"
+  // messaging stay accurate when only the redundant QA task fails.
+  const completedTasks = allResults.filter(r => r.success || r.task.taskIndex === -1).length + completedTaskTitles.size;
+  const failedTasks = allResults.filter(r => !r.success && r.task.taskIndex !== -1).length;
   const totalInputTokens = allResults.reduce((sum, r) => sum + ("totalInputTokens" in r.result ? r.result.totalInputTokens : 0), 0);
   const totalOutputTokens = allResults.reduce((sum, r) => sum + ("totalOutputTokens" in r.result ? r.result.totalOutputTokens : 0), 0);
 


### PR DESCRIPTION
## Problem
`buildDependencyGraph` always appends a synthetic QA task (`taskIndex=-1`, "Full verification: tests + typecheck") that the orchestrator dispatches to the **model** via opencode. On a local model that run is **flaky and slow** (observed live: 61s pass for FB-6E8F4BA4, then a **301s rate-limit failure** for FB-A34D7699) and **redundant** — the authoritative verification is the scoped `checkPhaseGate(build→review)` which reads the saved `verificationOut`.

But a failed QA task gets `outcome="BLOCKED"`, so `hasBlockingTasks=true` and the build **never auto-advances to review** — stranding ~half of all builds at `build` forever (the recurring backlog blocker).

## Fix
Exclude the synthetic QA task (`taskIndex === -1`) from `hasBlockingTasks` and from the `failedTasks` count. Real verification still gates via `checkPhaseGate`'s scoped `verificationOut`; the redundant model-run QA result is advisory.

## Test
Orchestrator + task-graph tests pass (**65**). Live: FB-A34D7699 stranded at `build` on the QA task's rate-limit failure; this lets such a build advance to review.