### PR TITLE
feat(self-upgrade): dodge the platform's own scheduled work in the 24/7 overnight window (BI-963B9D47)

### DIFF
--- a/apps/web/lib/self-upgrade/auto-window.test.ts
+++ b/apps/web/lib/self-upgrade/auto-window.test.ts
@@ -5,10 +5,13 @@ import {
   formatWindowClock,
   isEffectively247,
   nextAutoWindowOpen,
+  pickOvernightWindow,
   resolveAutoUpgradeWindow,
   selectTroughWindows,
   type LowTrafficWindow,
 } from "./auto-window";
+import { isWithinWindows } from "./windows-eval";
+import { isHeavyMaintenanceBusyAtUtc } from "./maintenance-calendar";
 import type { WeeklySchedule } from "@/lib/operating-hours-types";
 
 // A genuine 24/7 store: every day open 00:00-24:00 (isStoreOpen always true), so
@@ -78,6 +81,23 @@ describe("resolveAutoUpgradeWindow", () => {
       kind: "auto-overnight",
       source: "default",
       windows: [DEFAULT_OVERNIGHT_WINDOW],
+    });
+  });
+
+  it("shifts the overnight window off the 03:00-04:00 UTC maintenance cluster for a UTC store (BI-963B9D47)", () => {
+    // For a UTC store, the default 02:00-04:00 local IS 02:00-04:00 UTC, which
+    // overlaps the backup/maintenance cluster — so it shifts to the first clear
+    // candidate, 01:00-03:00.
+    const r = resolveAutoUpgradeWindow({
+      schedule: ALL_DAY,
+      timeZone: "UTC",
+      timezoneKnown: true,
+      now: MON_1200_UTC,
+    });
+    expect(r).toMatchObject({
+      kind: "auto-overnight",
+      source: "default",
+      windows: [{ startTime: "01:00", endTime: "03:00" }],
     });
   });
 
@@ -177,5 +197,31 @@ describe("formatWindowClock / describeWindows", () => {
 
   it("describes the default overnight window as a friendly range", () => {
     expect(describeWindows([DEFAULT_OVERNIGHT_WINDOW])).toBe("2:00 AM–4:00 AM");
+  });
+});
+
+describe("pickOvernightWindow (avoids platform heavy maintenance, BI-963B9D47)", () => {
+  it("keeps 02:00-04:00 when it is clear (US-Central: 02:00-04:00 local = 07:00-09:00 UTC)", () => {
+    const w = pickOvernightWindow({ timeZone: "America/Chicago", now: MON_1200_UTC });
+    expect(w).toMatchObject({ startTime: "02:00", endTime: "04:00" });
+  });
+
+  it("shifts earlier for a UTC store whose 02:00-04:00 hits the 03:00-04:00 UTC cluster", () => {
+    const w = pickOvernightWindow({ timeZone: "UTC", now: MON_1200_UTC });
+    expect(w).toMatchObject({ startTime: "01:00", endTime: "03:00" });
+  });
+
+  it("never returns a window overlapping heavy maintenance, across timezones (invariant)", () => {
+    // Half-hour and whole-hour offsets, both hemispheres.
+    for (const tz of ["UTC", "America/Chicago", "Europe/London", "Asia/Kolkata", "Asia/Tokyo"]) {
+      const w = pickOvernightWindow({ timeZone: tz, now: MON_1200_UTC });
+      let overlap = 0;
+      const limit = MON_1200_UTC.getTime() + 7 * 24 * 60 * 60 * 1000;
+      for (let t = MON_1200_UTC.getTime(); t <= limit; t += 30 * 60_000) {
+        const probe = new Date(t);
+        if (isWithinWindows([w], probe, tz) && isHeavyMaintenanceBusyAtUtc(probe)) overlap++;
+      }
+      expect(overlap).toBe(0);
+    }
   });
 });

--- a/apps/web/lib/self-upgrade/auto-window.ts
+++ b/apps/web/lib/self-upgrade/auto-window.ts
@@ -16,8 +16,9 @@
 
 import type { WeeklySchedule } from "@/lib/operating-hours-types";
 import type { MaintenanceWindow } from "./config";
-import { nextWindowStartForWindows } from "./windows-eval";
+import { isWithinWindows, nextWindowStartForWindows } from "./windows-eval";
 import { nextUpgradeWindowOpen } from "./window";
+import { isHeavyMaintenanceBusyAtUtc } from "./maintenance-calendar";
 
 /**
  * Default low-traffic overnight window used when no valid observed trough is
@@ -29,6 +30,68 @@ export const DEFAULT_OVERNIGHT_WINDOW: MaintenanceWindow = {
   startTime: "02:00",
   endTime: "04:00",
 };
+
+const EVERY_DAY = [0, 1, 2, 3, 4, 5, 6];
+
+/**
+ * Candidate overnight slots (store-local) in preference order, deepest-sleep
+ * first. `pickOvernightWindow` returns the first one that is clear of the
+ * platform's heavy UTC maintenance for this store's timezone — so a store whose
+ * default 02:00-04:00 maps onto the 03:00-04:00 UTC backup/maintenance cluster
+ * shifts to a neighbouring clear slot instead of contending (BI-963B9D47).
+ */
+export const CANDIDATE_OVERNIGHT_WINDOWS: MaintenanceWindow[] = [
+  DEFAULT_OVERNIGHT_WINDOW, // 02:00-04:00
+  { dayOfWeek: EVERY_DAY, startTime: "01:00", endTime: "03:00" },
+  { dayOfWeek: EVERY_DAY, startTime: "03:00", endTime: "05:00" },
+  { dayOfWeek: EVERY_DAY, startTime: "00:00", endTime: "02:00" },
+  { dayOfWeek: EVERY_DAY, startTime: "04:00", endTime: "06:00" },
+];
+
+const OVERLAP_SCAN_STEP_MS = 30 * 60_000; // 30-min resolution (heavy windows are >= 30 min)
+const OVERLAP_SCAN_HORIZON_MS = 7 * 24 * 60 * 60 * 1000; // 7 days covers weekly jobs + DST
+
+/**
+ * How many horizon instants have `window` (store-local) open WHILE heavy
+ * platform maintenance is running (UTC) — the two reconciled on the absolute
+ * timeline. 0 = no contention.
+ */
+function maintenanceOverlapScore(
+  window: MaintenanceWindow,
+  timeZone: string,
+  now: Date,
+): number {
+  let score = 0;
+  const limit = now.getTime() + OVERLAP_SCAN_HORIZON_MS;
+  for (let t = now.getTime(); t <= limit; t += OVERLAP_SCAN_STEP_MS) {
+    const probe = new Date(t);
+    if (isWithinWindows([window], probe, timeZone) && isHeavyMaintenanceBusyAtUtc(probe)) {
+      score++;
+    }
+  }
+  return score;
+}
+
+/**
+ * The overnight window (store tz) that best avoids the platform's heavy
+ * scheduled maintenance: the first candidate with zero overlap (preference
+ * order, deepest-sleep first), else the minimum-overlap candidate. Never null —
+ * soft-prefer, never block (the quiescence drain is the runtime backstop).
+ */
+export function pickOvernightWindow(args: { timeZone: string; now?: Date }): MaintenanceWindow {
+  const now = args.now ?? new Date();
+  let best: MaintenanceWindow = DEFAULT_OVERNIGHT_WINDOW;
+  let bestScore = Infinity;
+  for (const candidate of CANDIDATE_OVERNIGHT_WINDOWS) {
+    const score = maintenanceOverlapScore(candidate, args.timeZone, now);
+    if (score === 0) return candidate; // first clear candidate in preference order
+    if (score < bestScore) {
+      best = candidate;
+      bestScore = score;
+    }
+  }
+  return best;
+}
 
 /** A schedule-derived or telemetry-observed low-traffic slot (BusinessProfile.lowTrafficWindows). */
 export type LowTrafficWindow = {
@@ -135,7 +198,10 @@ export function resolveAutoUpgradeWindow(args: {
   if (trough && trough.length > 0) {
     return { kind: "auto-overnight", windows: trough, source: "trough" };
   }
-  return { kind: "auto-overnight", windows: [DEFAULT_OVERNIGHT_WINDOW], source: "default" };
+  // No observed trough → a default overnight slot that also dodges the platform's
+  // own heavy maintenance (backups/retention/batch), not just a fixed 02:00-04:00.
+  const overnight = pickOvernightWindow({ timeZone: args.timeZone, now });
+  return { kind: "auto-overnight", windows: [overnight], source: "default" };
 }
 
 /** Next instant one of the auto-selected windows opens (store tz). */

--- a/apps/web/lib/self-upgrade/maintenance-calendar.test.ts
+++ b/apps/web/lib/self-upgrade/maintenance-calendar.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  HEAVY_MAINTENANCE,
+  isHeavyMaintenanceBusyAtUtc,
+  parseSimpleCron,
+  type HeavyMaintenanceWindow,
+} from "./maintenance-calendar";
+import { POSTGRES_BACKUP_CRON } from "@/lib/operate/backups/constants";
+import { DATA_RETENTION_CRON } from "@/lib/operate/retention/constants";
+
+// 2026-05-25 is a Monday; 2026-05-31 is a Sunday.
+const MON_0315_UTC = new Date("2026-05-25T03:15:00Z");
+const MON_0430_UTC = new Date("2026-05-25T04:30:00Z");
+const MON_0230_UTC = new Date("2026-05-25T02:30:00Z");
+const MON_0530_UTC = new Date("2026-05-25T05:30:00Z");
+const MON_1200_UTC = new Date("2026-05-25T12:00:00Z");
+const SUN_0315_UTC = new Date("2026-05-31T03:15:00Z");
+
+describe("parseSimpleCron", () => {
+  it("parses a daily cron", () => {
+    expect(parseSimpleCron("0 3 * * *")).toEqual({ minute: 0, hour: 3, daysOfWeek: null });
+  });
+  it("parses a weekly (day-of-week) cron", () => {
+    expect(parseSimpleCron("0 3 * * 0")).toEqual({ minute: 0, hour: 3, daysOfWeek: [0] });
+  });
+  it("returns null for unsupported shapes (intervals, day-of-month, month)", () => {
+    expect(parseSimpleCron("*/5 * * * *")).toBeNull();
+    expect(parseSimpleCron("0 3 5 * *")).toBeNull();
+    expect(parseSimpleCron("0 3 * 6 *")).toBeNull();
+    expect(parseSimpleCron("0 25 * * *")).toBeNull();
+    expect(parseSimpleCron("0 3 * *")).toBeNull(); // wrong field count
+  });
+});
+
+describe("isHeavyMaintenanceBusyAtUtc (default calendar)", () => {
+  it("is busy during the 03:00-04:00 UTC backup/maintenance cluster", () => {
+    expect(isHeavyMaintenanceBusyAtUtc(MON_0315_UTC)).toBe(true);
+  });
+  it("is busy during the 04:00-05:00 UTC retention sweep", () => {
+    expect(isHeavyMaintenanceBusyAtUtc(MON_0430_UTC)).toBe(true);
+  });
+  it("is clear before the cluster (02:30 UTC), after it (05:30 UTC), and midday", () => {
+    expect(isHeavyMaintenanceBusyAtUtc(MON_0230_UTC)).toBe(false);
+    expect(isHeavyMaintenanceBusyAtUtc(MON_0530_UTC)).toBe(false);
+    expect(isHeavyMaintenanceBusyAtUtc(MON_1200_UTC)).toBe(false);
+  });
+});
+
+describe("isHeavyMaintenanceBusyAtUtc (day-of-week + wrap)", () => {
+  const weeklyPrune: HeavyMaintenanceWindow[] = [
+    { label: "infra prune", cron: "0 3 * * 0", durationMin: 30 },
+  ];
+  it("a weekly Sunday window is busy on Sunday and clear on Monday", () => {
+    expect(isHeavyMaintenanceBusyAtUtc(SUN_0315_UTC, weeklyPrune)).toBe(true);
+    expect(isHeavyMaintenanceBusyAtUtc(MON_0315_UTC, weeklyPrune)).toBe(false);
+  });
+  it("a window wrapping past midnight marks the next UTC day's early minutes busy", () => {
+    const wrap: HeavyMaintenanceWindow[] = [{ label: "late", cron: "0 23 * * *", durationMin: 120 }];
+    expect(isHeavyMaintenanceBusyAtUtc(new Date("2026-05-25T00:30:00Z"), wrap)).toBe(true); // 23:00+120 = 01:00
+    expect(isHeavyMaintenanceBusyAtUtc(new Date("2026-05-25T01:30:00Z"), wrap)).toBe(false);
+  });
+});
+
+describe("calendar is anchored to the exported cron constants (drift guard)", () => {
+  it("decodes the backup + retention constants to their documented UTC hours", () => {
+    expect(parseSimpleCron(POSTGRES_BACKUP_CRON)?.hour).toBe(3);
+    expect(parseSimpleCron(DATA_RETENTION_CRON)?.hour).toBe(4);
+  });
+  it("includes the backup + retention crons in the heavy calendar", () => {
+    const crons = HEAVY_MAINTENANCE.map((w) => w.cron);
+    expect(crons).toContain(POSTGRES_BACKUP_CRON);
+    expect(crons).toContain(DATA_RETENTION_CRON);
+  });
+});

--- a/apps/web/lib/self-upgrade/maintenance-calendar.ts
+++ b/apps/web/lib/self-upgrade/maintenance-calendar.ts
@@ -1,0 +1,98 @@
+// apps/web/lib/self-upgrade/maintenance-calendar.ts
+//
+// The platform's own HEAVY recurring maintenance jobs, so the self-upgrade
+// overnight window can avoid running its quiescence drain + recovery-point
+// backup + portal rebuild on top of them (BI-963B9D47). Contention here is
+// acute on budget / small-GPU local deployments.
+//
+// Only heavy batch/backup jobs are listed — the lightweight pollers
+// (*/1, */5, */15 crons) run continuously and are not a contention source, so
+// avoiding them is neither possible nor useful.
+//
+// Inngest crons fire in UTC (no tz arg), so this calendar is evaluated in UTC
+// and the window scorer reconciles the store-local candidate windows against it
+// on the absolute timeline. Pure + prisma-free (only Date UTC accessors + pure
+// constant imports) so the cron path and unit tests can use it without a DB.
+
+import { POSTGRES_BACKUP_CRON } from "@/lib/operate/backups/constants";
+import { DATA_RETENTION_CRON } from "@/lib/operate/retention/constants";
+
+export type HeavyMaintenanceWindow = {
+  label: string;
+  /** "M H * * D" — D is "*" or a comma-list of 0-6 (Sun=0). The only shapes used here. */
+  cron: string;
+  /** Approximate run length; sizes the busy interval [H:00, H:00 + durationMin). */
+  durationMin: number;
+};
+
+/**
+ * Heavy recurring platform maintenance, clustered at 03:00-04:00 UTC. Backup +
+ * retention crons reuse their exported constants; the rest are inline literals
+ * that MUST be kept in sync with their function files (cited per entry).
+ */
+export const HEAVY_MAINTENANCE: HeavyMaintenanceWindow[] = [
+  { label: "postgres + all-services backups", cron: POSTGRES_BACKUP_CRON, durationMin: 60 },
+  { label: "data-retention sweep", cron: DATA_RETENTION_CRON, durationMin: 60 },
+  // keep in sync with apps/web/lib/queue/functions/model-discovery-refresh.ts
+  { label: "model-discovery refresh", cron: "0 3 * * *", durationMin: 30 },
+  // keep in sync with apps/web/lib/queue/functions/material-freshness-decay.ts
+  { label: "material-freshness decay", cron: "0 3 * * *", durationMin: 30 },
+  // keep in sync with apps/web/lib/queue/functions/infra-prune.ts (weekly, Sun)
+  { label: "infra prune", cron: "0 3 * * 0", durationMin: 30 },
+];
+
+export type SimpleCron = { minute: number; hour: number; daysOfWeek: number[] | null };
+
+/**
+ * Parse the limited `"M H * * D"` cron shape this calendar uses (daily or
+ * day-of-week). Returns null for anything outside that shape (intervals, ranges,
+ * day-of-month, month constraints) rather than guessing.
+ */
+export function parseSimpleCron(cron: string): SimpleCron | null {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [minRaw, hourRaw, dom, mon, dowRaw] = parts;
+  const minute = Number(minRaw);
+  const hour = Number(hourRaw);
+  if (!Number.isInteger(minute) || minute < 0 || minute > 59) return null;
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) return null;
+  if (dom !== "*" || mon !== "*") return null; // only daily/weekly shapes
+  let daysOfWeek: number[] | null = null;
+  if (dowRaw !== "*") {
+    const days = (dowRaw ?? "").split(",").map((d) => Number(d));
+    if (days.some((d) => !Number.isInteger(d) || d < 0 || d > 6)) return null;
+    daysOfWeek = days;
+  }
+  return { minute, hour, daysOfWeek };
+}
+
+/**
+ * True when `date` (an absolute instant) falls inside a heavy maintenance
+ * window, evaluated in UTC. A job at H:M for `durationMin` is busy during
+ * [start, start + durationMin); a window spilling past midnight marks the early
+ * minutes of the following UTC day busy too (day-of-week aware).
+ */
+export function isHeavyMaintenanceBusyAtUtc(
+  date: Date,
+  windows: HeavyMaintenanceWindow[] = HEAVY_MAINTENANCE,
+): boolean {
+  const utcDow = date.getUTCDay();
+  const minuteOfDay = date.getUTCHours() * 60 + date.getUTCMinutes();
+  return windows.some((w) => {
+    const c = parseSimpleCron(w.cron);
+    if (!c) return false;
+    const start = c.hour * 60 + c.minute;
+    const end = start + w.durationMin;
+    const matchesDay = c.daysOfWeek === null || c.daysOfWeek.includes(utcDow);
+    if (matchesDay && minuteOfDay >= start && minuteOfDay < Math.min(end, 1440)) {
+      return true;
+    }
+    // Window wrapping past midnight: its tail belongs to the next UTC day.
+    if (end > 1440) {
+      const prevDow = (utcDow + 6) % 7;
+      const startedPrevDay = c.daysOfWeek === null || c.daysOfWeek.includes(prevDow);
+      if (startedPrevDay && minuteOfDay < end - 1440) return true;
+    }
+    return false;
+  });
+}

--- a/docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md
+++ b/docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md
@@ -1,0 +1,111 @@
+# Self-upgrade window avoids the platform's own scheduled work
+
+- **BI:** BI-963B9D47 — "Self-upgrade window should avoid the platform's own scheduled work, not just customer low-traffic"
+- **Epic:** EP-UPGRADE-LIFECYCLE
+- **Extends:** BI-A6382FB9 (PR #2217, merged a2fbe26de) — the 24/7 auto-overnight window
+- **Date:** 2026-06-20
+- **Author:** Claude Code
+
+## 1. Problem
+
+The 24/7 auto-overnight window (BI-A6382FB9) picks a slot by **customer** traffic
+(`lowTrafficWindows` trough else a fixed default **02:00–04:00 store-tz**). Founder
+(Mark, 2026-06-20): *"the low traffic is an indicator, and we want to make sure other
+scheduled work is not occurring as well."* The upgrade's quiescence drain +
+recovery-point backup + portal rebuild must not contend with the platform's own heavy
+batch jobs — acute on budget / small-GPU local deployments.
+
+The platform's heavy maintenance clusters at **03:00–04:00 UTC**:
+`POSTGRES_BACKUP_CRON`/`ALL_BACKUPS_CRON` (`0 3 * * *`), `model-discovery-refresh`
+(`0 3 * * *`), `material-freshness-decay` (`0 3 * * *`), weekly `infra-prune`
+(`0 3 * * 0`), and `DATA_RETENTION_CRON` (`0 4 * * *`). The fixed default of
+`02:00–04:00` **store-local** therefore collides with this cluster for stores whose
+local night maps onto 03:00–04:00 UTC (a UTC/London store sits right on it; a
+US-Central store's `02:00–04:00` local = `07:00–09:00` UTC, clear). The lightweight
+pollers (`*/1`, `*/5`, `*/15`) run continuously and are NOT the concern.
+
+**Key constraint:** Inngest crons fire in **UTC** (no `tz` arg) while the window is
+evaluated in **store tz** — so collision must be judged on one absolute (UTC) timeline.
+
+## 2. Research / substrate
+
+- Heavy maintenance cron times are already **exported constants** (`operate/backups/constants.ts`,
+  `operate/retention/constants.ts`) with explicit "UTC daily" docs — reuse, don't hardcode.
+- Existing change-window substrate to compose with (Phase 2): `DeploymentWindow` +
+  `BlackoutPeriod` (per-org, `BusinessProfile` relations), `deployment-window-utils.ts`,
+  `check_deployment_windows`; per-org `ScheduledAgentTask` (cron + tz + nextRunAt).
+- Reactive backstop already exists: quiescence coordinator + `captureActiveSessionBlockers`
+  defer if work is in flight at upgrade time. This BI adds **proactive** avoidance.
+- Pattern (industry): managed-DB/K8s patch windows pick a slot clear of the provider's own
+  maintenance, not just user traffic. Same idea, applied to the platform's batch jobs.
+
+## 3. Decisions
+
+- **Curated maintenance calendar, not a cron registry.** Crons are scattered inline as
+  `cron("…")` across ~20 function files. A central registry would touch all of them for a
+  single consumer (this window) — speculative generality. A small, contained
+  `maintenance-calendar.ts` enumerating the few HEAVY overnight jobs (reusing the exported
+  cron constants) is the architecturally-appropriate choice; promote to a registry only if
+  more consumers need cron introspection. (Reverses the initial "lean registry" once blast
+  radius was weighed.)
+- **Soft-prefer, never hard-block.** Pick the least-conflicting overnight slot; never refuse
+  to schedule because every slot has some overlap — "never silently block forever" is the
+  principle BI-A6382FB9 embodies, and the quiescence defer is the runtime backstop. (Phase 2
+  `BlackoutPeriod` is the only hard "no".)
+- **Customer trough still primary.** A valid observed `lowTrafficWindows` trough still wins;
+  maintenance-avoidance governs the **default** path (where there is no live trough today).
+
+## 4. Phase 1 (this PR) — avoid platform heavy maintenance
+
+### 4.1 `apps/web/lib/self-upgrade/maintenance-calendar.ts` (new, pure)
+- `HEAVY_MAINTENANCE: { label; cron; durationMin }[]` — backups (`POSTGRES_BACKUP_CRON`),
+  retention (`DATA_RETENTION_CRON`), model-discovery (`0 3 * * *`), material-decay (`0 3 * * *`),
+  infra-prune (`0 3 * * 0`). Inline-literal crons carry a `// keep in sync with <file>` note.
+- `parseSimpleCron(cron)` — supports the `"M H * * D"` shape used here (`D` = `*` or digit list).
+- `isHeavyMaintenanceBusyAtUtc(date): boolean` — true when `date` (UTC) falls in any entry's
+  `[H:00, H:00 + durationMin)` interval on a matching UTC day-of-week (handles >60-min wrap).
+- Pure (only `Date` UTC accessors + pure constant imports) → cron-safe + unit-testable.
+
+### 4.2 `apps/web/lib/self-upgrade/auto-window.ts`
+- `CANDIDATE_OVERNIGHT_WINDOWS: MaintenanceWindow[]` — 2h slots across the sleep band, in
+  preference order: `02:00–04:00` (current default, deepest sleep) → `01:00–03:00` →
+  `03:00–05:00` → `00:00–02:00` → `04:00–06:00`.
+- `pickOvernightWindow({ timeZone, now })` — for each candidate in order, scan a 7-day horizon
+  at 30-min steps counting instants where `isWithinWindows([cand], instant, tz)` AND
+  `isHeavyMaintenanceBusyAtUtc(instant)`; return the first candidate with **zero** overlap,
+  else the minimum-overlap candidate (preference order breaks ties). `DEFAULT_OVERNIGHT_WINDOW`
+  stays the first candidate + ultimate fallback.
+- `resolveAutoUpgradeWindow`'s default branch returns `[pickOvernightWindow(...)]` instead of
+  the fixed default; the trough branch is unchanged. `source` stays `"default"`.
+
+### 4.3 Behavior
+- US-Central 24/7 store → `02:00–04:00` local (`07:00–09:00` UTC) is clear → keeps the default.
+- UTC/London 24/7 store → `02:00–04:00` local overlaps the 03:00–04:00 UTC cluster → shifts to
+  the first clear candidate (`01:00–03:00` local = `01:00–03:00` UTC, clear).
+
+## 5. Phase 2 (staged, follow-up) — per-org + change windows
+
+Compose `ScheduledAgentTask` crons (per-org, with their own tz), `BlackoutPeriod` (hard avoid),
+and `DeploymentWindow` allowed bands into the scorer via a DB-backed collector that passes
+busy-intervals into the pure picker (keeps `auto-window.ts` prisma-free). Deferred to keep this
+PR one-concern; tracked under the same BI.
+
+## 6. Phases & verification
+
+| Phase | Deliverable | Files | Verification |
+| --- | --- | --- | --- |
+| 1a | maintenance-calendar | `maintenance-calendar.ts` (new) | `maintenance-calendar.test.ts`: busy at 03:15/04:15 UTC daily, clear at 12:00 UTC, infra-prune Sunday-only, cron-parse, guard tying decoded hour to `POSTGRES_BACKUP_CRON`/`DATA_RETENTION_CRON`. |
+| 1b | UTC-aware overnight pick | `auto-window.ts` | `auto-window.test.ts`: US-Central keeps `02:00–04:00`; UTC store shifts off the cluster; picked window never overlaps maintenance; existing 24/7 default/trough tests stay green. |
+| 1c | build gate | — | typecheck + affected vitest + production build via CI (worktree dependency-degraded → source-only; CI is canonical evidence). |
+
+## 7. Risks / rollback
+
+- **Blast radius:** self-upgrade window selection only; pure additive module + a changed default
+  branch. Non-24/7 + trough paths unchanged. US-offset stores keep today's behavior (default clear).
+- **Drift:** an inline heavy cron changes and the calendar lags → window may overlap. Mitigation:
+  guard test on the exported constants + `keep in sync` comments; Phase-2 registry is the durable fix.
+- **Perf:** `pickOvernightWindow` short-circuits on the first zero-overlap candidate (1 candidate ×
+  336 `Intl` calls for the common clear-default case). Bounded.
+- **Rollback:** revert the PR; no schema/migration/config change.
+- **UX:** none — still auto-pick + the existing read-only "runs overnight ~HH:MM <tz>" line; the
+  picked time may differ. No new control.


### PR DESCRIPTION
## What & why

Extends BI-A6382FB9 ([#2217](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2217)) per founder follow-up (Mark): *"the low traffic is an indicator, and we want to make sure other scheduled work is not occurring as well."* (**BI-963B9D47**, EP-UPGRADE-LIFECYCLE.)

The 24/7 auto-overnight window picked a slot by **customer traffic** only, defaulting to a fixed **02:00–04:00 store-local**. That collides with the platform's **own heavy maintenance**, which clusters at **03:00–04:00 UTC**: postgres + all backups (`0 3 * * *`), `model-discovery-refresh`, `material-freshness-decay`, weekly `infra-prune`, and `data-retention-sweep` (`0 4 * * *`). Running the upgrade's quiescence drain + recovery-point backup + portal rebuild on top of nightly backups/batch jobs is exactly the contention to avoid on budget / local boxes.

**Key subtlety:** those Inngest crons fire in **UTC**, while the window is evaluated in **store tz** — so the collision is on the absolute timeline and depends on the store's offset. A UTC / winter-London store's `02:00–04:00` local sits on the cluster; a US-Central store's `02:00–04:00` local = `07:00–09:00` UTC, already clear. A blind default shift would only move *which* offset band collides — so the fix reconciles both onto one timeline.

## Approach (Phase 1)

- **`maintenance-calendar.ts`** (new, pure/prisma-free): `HEAVY_MAINTENANCE` (reuses the exported `POSTGRES_BACKUP_CRON` / `DATA_RETENTION_CRON` constants + the inline 03:00 batch crons) and `isHeavyMaintenanceBusyAtUtc(date)`. Lightweight pollers (`*/1`, `*/5`, `*/15`) are intentionally excluded — they run continuously and aren't a contention source.
- **`auto-window.ts`**: `CANDIDATE_OVERNIGHT_WINDOWS` (deepest-sleep first) + `pickOvernightWindow`, which scans a 7-day horizon and returns the **first candidate clear of heavy maintenance** for the store tz (else least-overlap). **Soft-prefer, never block** — the quiescence drain stays the runtime backstop. The observed-trough path and explicit operator windows are unchanged and still take priority.

**Effect:** a US-offset store keeps `02:00–04:00`; a UTC store shifts to `01:00–03:00` (clear of the cluster). No UI change — same read-only "runs overnight ~HH:MM <tz>" line, possibly a different time. No schema/migration.

## Design decisions (in the plan)

- **Curated calendar, not a cron registry.** Crons are scattered inline across ~20 function files; a central registry would touch all of them for a single consumer (speculative generality). A small contained calendar reusing the exported constants is the right call now; promote to a registry if more consumers need cron introspection. (Reversed my initial "lean registry" once blast radius was weighed.)
- **Soft-prefer, never hard-block** — "never silently block forever" (the principle BI-A6382FB9 embodies).

## Tests

- `maintenance-calendar.test.ts`: busy during the 03:00–04:00 / 04:00–05:00 UTC cluster, clear before/after/midday, weekly Sunday-only, midnight-wrap, `parseSimpleCron` shapes, and a drift guard tying the calendar to `POSTGRES_BACKUP_CRON` / `DATA_RETENTION_CRON`.
- `auto-window.test.ts`: US-Central keeps `02:00–04:00`; UTC store shifts to `01:00–03:00`; cross-timezone **invariant** that the picked window never overlaps heavy maintenance; existing 24/7 default/trough tests stay green.

## Verification

⚠️ Worktree + root clone are dependency-degraded (no `node_modules`/`pnpm`) → the build gate runs in **CI** (the merge queue enforces green before merge) — an unrun-not-red gate per AGENTS.md §5. `auto-window.ts` / `maintenance-calendar.ts` stay prisma-free (verified by inspection: only `Date` UTC accessors + pure constant imports), so the new unit tests need no DB. No UI files touched (UX-Fit gate N/A).

## Staged (Phase 2, same BI)

Compose per-org `ScheduledAgentTask` crons + `BlackoutPeriod` (hard avoid) / `DeploymentWindow` allowed bands via a DB-backed collector that feeds busy-intervals into the pure picker — kept out of this PR to stay one-concern.

Plan: `docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)