### PR TITLE
fix(scheduled-jobs): catalog 3 invisible crons + real parity guard; scheduling-surface review spec

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -18,7 +18,12 @@
 // human label at runtime, and "is this job essential to platform integrity?"
 // is a governance judgement that belongs in reviewed code, not inferred.
 // When a new cron is added to scheduledFunctions, add it here too — the
-// catalog drift test (scheduled-jobs.test.ts) fails the build otherwise.
+// catalog<->registry parity test (queue/functions/index.test.ts) matches each
+// scheduled function's id() against these inngestIds and fails the build on any
+// gap in either direction. That guard did NOT exist when logSignatureScanner /
+// alertDeliveryBridge / releaseHealthCheck shipped, so they ran uncatalogued —
+// invisible on the admin Scheduled Jobs surface — until this catalog was
+// reconciled (scheduling-surface review, 2026-06-21). Keep the parity test real.
 
 import { CODE_GRAPH_JOB_ID } from "@/lib/integrate/code-graph/constants";
 
@@ -182,6 +187,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     tracksRunData: false,
     runNowEvent: null,
   },
+  {
+    jobId: "alert-delivery-bridge",
+    inngestId: "ops/alert-delivery-bridge",
+    name: "Alert delivery bridge",
+    purpose:
+      "Delivers firing Prometheus/Loki alerts into the quality-issue inbox (the platform runs no Alertmanager). If it stops, firing alerts evaluate but never reach an operator — silent blindness. Core-locked for that reason.",
+    cron: "*/1 * * * *",
+    cadence: "Every minute",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
   // ── Editable (operationally tunable) ──────────────────────────────────────
   {
     jobId: "data-retention-sweep",
@@ -312,6 +329,30 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     purpose: "Curates / proposes skill improvements. Cadence is tunable.",
     cron: "0 7 * * *",
     cadence: "Daily at 07:00",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "log-signature-scanner",
+    inngestId: "ops/log-signature-scanner",
+    name: "Log signature scanner",
+    purpose:
+      "Scans container logs (Loki) for novel error signatures and files one issue per new signature. If it stops, novel log anomalies surface to no one. Cadence and noise threshold are tunable.",
+    cron: "*/15 * * * *",
+    cadence: "Every 15 minutes",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "release-health-check",
+    inngestId: "ops/release-health-check",
+    name: "Release health check",
+    purpose:
+      "Polls the latest release's verify-gate outcome and keeps the operator notification + health card in sync. If it stops, a red release can go unnoticed. Cadence is tunable.",
+    cron: "*/15 * * * *",
+    cadence: "Every 15 minutes",
     category: "editable",
     tracksRunData: false,
     runNowEvent: null,

--- a/apps/web/lib/queue/functions/index.test.ts
+++ b/apps/web/lib/queue/functions/index.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./index";
 import { issueReportTriage } from "./issue-report-triage";
 import { routeWorkItem } from "./route-work-item";
+import { SCHEDULED_JOB_CATALOG } from "@/lib/operate/scheduled-jobs/catalog";
 
 describe("getInngestFunctionsForRuntime", () => {
   it("omits scheduled cron functions unless explicitly enabled", () => {
@@ -23,5 +24,26 @@ describe("getInngestFunctionsForRuntime", () => {
 
     expect(functions).toEqual(allFunctions);
     expect(functions).toEqual(expect.arrayContaining(scheduledFunctions));
+  });
+});
+
+describe("scheduled cron <-> catalog parity (drift guard)", () => {
+  // The admin Scheduled Jobs surface renders from SCHEDULED_JOB_CATALOG, so a
+  // cron in `scheduledFunctions` with no catalog entry runs invisibly — the gap
+  // that hid logSignatureScanner / alertDeliveryBridge / releaseHealthCheck.
+  // This asserts the two registries agree exactly, in both directions. fn.id()
+  // returns the raw Inngest id (e.g. "ops/self-upgrade-scheduled"), which is the
+  // value stored as catalog `inngestId`.
+  it("describes every scheduled Inngest cron, with no orphan entries", () => {
+    const fnIds = scheduledFunctions
+      .map((fn) => (fn as { id: () => string }).id())
+      .sort();
+    const catalogIds = SCHEDULED_JOB_CATALOG.map((e) => e.inngestId).sort();
+
+    const uncatalogued = fnIds.filter((id) => !catalogIds.includes(id));
+    const orphaned = catalogIds.filter((id) => !fnIds.includes(id));
+
+    expect(uncatalogued).toEqual([]);
+    expect(orphaned).toEqual([]);
   });
 });

--- a/docs/superpowers/specs/2026-06-21-scheduling-surface-review-design.md
+++ b/docs/superpowers/specs/2026-06-21-scheduling-surface-review-design.md
@@ -1,0 +1,103 @@
+# Scheduling surface — review & design
+
+- Status: Draft (review complete; phased build proposed)
+- Date: 2026-06-21
+- Epic: `EP-SCHEDULING-SURFACE`
+- Source: Founder `/goal` — "review and optimize the schedule jobs we have setup, both out of the box and that are scheduled automatically based on other activities… make sure we have a tight approach and don't overlap scheduled work significantly… I'm not sure if it's a surface in its own right in the code graph."
+- Related epics: `EP-ARCH-GRAPH-LIVE` (graph projection pattern), `EP-PROACTIVE-OPS` (owns the scheduled-jobs catalog + admin surface), `EP-FULL-OBS` (origin of the 3 uncatalogued crons).
+
+## 1. Summary
+
+Scheduling in DPF is real, load-bearing, and **architecturally unmodeled**. There are **8 scheduling substrates**; only **3 fire autonomous work**. The recurring jobs are well-governed where the catalog reaches, but the catalog reaches only Inngest crons, its drift guard was imaginary (3 crons had silently drifted out of view), and the whole surface is **invisible to the living architecture graph** — there is no scheduling capability, surface, SysML package, or cross-layer edge. The "overlap" the founder sensed is **temporal contention** (thundering herd), not duplicated work.
+
+The design makes scheduling a first-class surface:
+
+1. Project the scheduled-job catalog into the code graph as operational/process nodes with `traces` edges (the `EP-ARCH-GRAPH-LIVE` extractor pattern). **This is the keystone — it is what "a surface in its own right" means.**
+2. Widen the catalog from "Inngest crons" into the **canonical scheduling map** across all mechanisms, so new scheduled work has one front door and overlap is machine-detectable.
+3. Stagger cadences to remove the 03:00-UTC and every-15m pile-ups.
+4. Resolve dormant substrates (wire / document / remove) and delete superseded scheduling code.
+
+Two low-risk fixes are **shipped with this spec** (catalog completeness + a real parity guard).
+
+## 2. Inventory (what is running today)
+
+### 2.1 The 8 substrates
+
+| Substrate | Backing model | Fires? | How |
+|---|---|---|---|
+| Inngest crons | (Inngest registry) | ✅ | 26 cron functions in `scheduledFunctions` (`apps/web/lib/queue/functions/index.ts:57`); master switch `DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED` |
+| `ScheduledAgentTask` | `ScheduledAgentTask` | ✅ | polled every 5m by `agent-task-dispatch`; 4 seeded (discovery-triage 08:00, data-model-mirror 03:00, hive-scout 08:17, sysml-projection 04:00) |
+| `SelfUpgradeRun` | `SelfUpgradeRun` | ✅ | hourly poll, window-gated (acts only when the store is closed) |
+| `ScheduledJob` | `ScheduledJob` | projection | admin/calendar view + operator cadence overrides; not a dispatcher |
+| `ScheduledOutboundAction` (marketing) | `ScheduledOutboundAction` | ⚠️ dormant | `scheduledFor` exists, but fires only via the **manual** `tick_marketing_scheduler` MCP tool — no cron |
+| `TaxRemittanceRun` | `TaxRemittanceRun` | ⚠️ dormant | `scheduledFor` exists, **no poller** |
+| `RecurringSchedule` (invoicing) | `RecurringSchedule` | ⚠️ dormant | `nextInvoiceDate` exists, **no poller** |
+| `ChangeRequest` + `DeploymentWindow` | `ChangeRequest` | manual/audit | operator-driven; self-upgrade mirrors into it for ITIL audit |
+
+### 2.2 The 26 Inngest crons (catalog is now complete)
+
+Authoritative registry: `apps/web/lib/operate/scheduled-jobs/catalog.ts` (`SCHEDULED_JOB_CATALOG`). Core = platform-integrity, operator read-only; editable = operator-tunable cadence.
+
+Daily/weekly clustering (UTC): **03:00** model-discovery-refresh + material-freshness-decay + postgres backup + all-backups + (seeded) data-model-mirror, plus infra-prune on Sundays; **03:30** wiki-lint; **04:00** data-retention-sweep + (seeded) sysml-projection; 05:00 skill-metrics; 07:00 skill-curator; 08:00/08:17 discovery-triage/hive-scout; 09:00 token-expiry (+ research on Mondays); 14:00 governed-backlog-tee-up.
+
+Sub-hourly: every minute — taskrun-watchdog, alert-delivery-bridge; every 5m — agent-task-dispatch; every 10m — contributor-inventory-sync; **every 15m (same tick) — code-graph-reconcile, issue-report-triage, coworker-regression-detect, log-signature-scanner, release-health-check**; hourly `:00` — prometheus-poll, full-discovery-sweep, runtime-target-janitor, self-upgrade poll; hourly `:23` — backlog-triage-drain.
+
+## 3. Findings
+
+1. **Live invisibility + an imaginary guard.** Three crons — `ops/log-signature-scanner` (15m), `ops/alert-delivery-bridge` (1m), `ops/release-health-check` (15m) — ran with no catalog entry. The admin Scheduled Jobs surface renders from the catalog (`apps/web/lib/operate/scheduled-jobs/core.ts:164`), so they were invisible to operators. The catalog header claimed "the catalog drift test fails the build otherwise," but `scheduled-jobs.test.ts` never compared the catalog against `scheduledFunctions` — the guard did not exist. **Fixed in this PR** (§5).
+2. **Overlap is temporal, not duplicated.** De-dup guards on the firing jobs are sound (concurrency:1 on code-graph reconcile / discovery sweep / data-retention; cooldown+window on self-upgrade; `nextRunAt` on agent tasks). The cost is a thundering herd: 5 jobs share each `:00/:15/:30/:45` tick, and a heavy DB batch stacks at 03:00 sharp. The one genuine "should these be two jobs?" candidate is prometheus-poll vs full-discovery-sweep (both hourly `:00`).
+3. **Dormant substrates.** Marketing/tax/recurring-invoicing look scheduled (fields + models) but nothing fires them on a timer. Each is a "why is this here?" until wired or documented.
+4. **Superseded code.** In-memory `setTimeout` rate-recovery (now Inngest `step.sleep`) and the `activity.ts` Phase-0 quiescence stopgap (now the quiescence protocol) are dead-code candidates — **confirm before removal**.
+5. **Not a surface in the code graph.** The 8 models appear only as isolated Prisma-mirror data objects with zero `traces`/`realizes`/`allocates` edges. No capability, no surface, no operational/process node, no `PKG-*` package. None of the 11 EA extractors read the catalog or the cron functions. The richest scheduling registry in the codebase (`scheduled-jobs/catalog.ts`) is consumed by no extractor. DPF also has no formal "surface" taxonomy at all — "surface" is informal prose; the closest modeled surface is the route tree.
+
+## 4. Design
+
+### 4.1 Keystone — scheduled-job EA extractor (`BI-SCHED-GRAPH-EXTRACTOR`)
+
+A parity extractor under `apps/web/lib/ea/` that reads `SCHEDULED_JOB_CATALOG` (and the seeded `ScheduledAgentTask`s) and projects each scheduled job as an **operational/process node**, with:
+
+- `traces` edges to its `ScheduledJob` / `ScheduledAgentTask` data object;
+- `traces`/`allocates` edges to the capability or system it serves (e.g. backups → DR capability; code-graph-reconcile → code-intelligence);
+- properties: cadence, category (core/editable), substrate, last-run health where `tracksRunData`.
+
+Mirrors `operational-bridge-extract.ts` / `route-extract.ts` (build-time manifest walk; the catalog is the manifest, sidestepping the runtime-cron-opacity constraint the catalog header documents). Reconcile nightly via the existing parity-engine path. **Outcome: scheduling becomes a navigable surface in the graph; `cross_layer_impact` can answer "what breaks if this job stops."**
+
+### 4.2 Canonical scheduling map (`BI-SCHED-CANONICAL-MAP`)
+
+Widen the catalog model from "code-defined Inngest crons" to "every mechanism that runs work on a schedule." Each mechanism registers (keeping its own storage): Inngest crons (today), `ScheduledAgentTask`, `SelfUpgradeRun`, and the dormant ones once resolved. The map carries cadence + owning capability so the extractor (4.1) and a contention check (4.3) read one source. **No new substrate** — this is a widened registry + the extractor, consistent with substrate-first doctrine.
+
+### 4.3 Stagger to remove contention (`BI-SCHED-STAGGER`)
+
+Spread the every-15m collision (offset the 5 jobs across `:00/:03/:06/:09/:12`) and the 03:00 batch (keep DR backups first; push model-discovery / material-freshness / wiki-lint to staggered minutes after a backup completes — preserve the data-retention-after-backup ordering invariant in `retention/constants.ts:24`). Add a test/contention check (fed by 4.2) that fails if N core jobs share an exact tick. Decide prometheus-poll vs full-discovery-sweep consolidation.
+
+### 4.4 Resolve dormant substrates (`BI-SCHED-DORMANT`)
+
+For `ScheduledOutboundAction`, `TaxRemittanceRun.scheduledFor`, `RecurringSchedule.nextInvoiceDate`: per substrate, either wire a dispatcher (mirror `agent-task-dispatch`'s poll pattern) **or** document it as manual and remove the misleading scheduling affordance. Marketing is the most likely "wire it" (an Inngest `tickMarketingScheduler` cron); tax/recurring likely "document as manual" until the feature is live.
+
+### 4.5 Remove superseded code (`BI-SCHED-DEADCODE`)
+
+Confirm-then-remove the `setTimeout` rate-recovery path and `activity.ts` Phase-0 quiescence stopgap. Verify-substrate-first: grep for live imports before deleting.
+
+## 5. Shipped with this spec (quick wins — `BI-SCHED-CATALOG-PARITY`)
+
+- `catalog.ts`: added the 3 uncatalogued crons — `alert-delivery-bridge` (core; sole alert-delivery path), `log-signature-scanner` (editable), `release-health-check` (editable). They are now visible on `/admin/scheduled-jobs`. Category rationale is in each entry's `purpose`; trivially flippable on review.
+- `queue/functions/index.test.ts`: a real **catalog↔registry parity guard** — asserts `scheduledFunctions.map(fn.id())` equals `SCHEDULED_JOB_CATALOG.map(inngestId)` in both directions, so a new cron can no longer ship uncatalogued/invisible. Catalog header comment corrected (the guard is now real and named).
+
+Risk: low — additive catalog data + one test; `fn.id()` is the established accessor (`substrate-audit.test.ts`). Validated by hand that all 26 function ids match the catalog (CI runs the parity test).
+
+## 6. Phasing
+
+| BI | Title | Type | Size |
+|---|---|---|---|
+| `BI-SCHED-CATALOG-PARITY` | Catalog completeness + real parity guard (shipped) | bug | small |
+| `BI-SCHED-GRAPH-EXTRACTOR` | Scheduled-job EA extractor — scheduling as a graph surface | feature | large |
+| `BI-SCHED-CANONICAL-MAP` | Widen catalog into the canonical scheduling map (all mechanisms) | feature | medium |
+| `BI-SCHED-STAGGER` | Stagger cadences + same-tick contention check | chore | medium |
+| `BI-SCHED-DORMANT` | Resolve dormant substrates (marketing / tax / recurring) | refactor | medium |
+| `BI-SCHED-DEADCODE` | Confirm-and-remove superseded scheduling code | refactor | small |
+
+## 7. Open decisions
+
+- **Category of `alert-delivery-bridge`**: shipped as `core` (operator cannot disable the sole alert path). Confirm or flip to editable.
+- **Marketing scheduler**: wire an Inngest cron, or keep manual-by-design? (`BI-SCHED-DORMANT`.)
+- **Dedup-guard hardening** (token-expiry tier-change, work-queue bridges) surfaced in review as low-severity; folded into `BI-SCHED-CANONICAL-MAP` rather than separate BIs unless a real duplicate is observed.


### PR DESCRIPTION
## What

Founder `/goal`: review and optimize all scheduled work (out-of-box + activity-triggered), ensure a tight non-overlapping approach, and treat scheduling as a surface in its own right (incl. the code graph). This PR is the **review spec + the two verified low-risk quick wins**; the rest is filed as a phased backlog under `EP-SCHEDULING-SURFACE`.

### Quick wins (shipped here — `BI-SCHED-CATALOG-PARITY`)

Three Inngest crons ran **uncatalogued and therefore invisible** on `/admin/scheduled-jobs`: `ops/log-signature-scanner` (15m), `ops/alert-delivery-bridge` (**1m**), `ops/release-health-check` (15m). The catalog header claimed a drift guard ("fails the build otherwise"), but `scheduled-jobs.test.ts` only checked the catalog's internal consistency — it never compared against `scheduledFunctions`, so the guard did not exist.

- `catalog.ts`: add the 3 entries (`alert-delivery-bridge` = **core**, sole alert-delivery path; `log-signature-scanner` & `release-health-check` = **editable**). Header comment corrected to name the real guard.
- `queue/functions/index.test.ts`: a **real catalog↔registry parity guard** — `scheduledFunctions.map(fn.id())` must equal `SCHEDULED_JOB_CATALOG` `inngestId`s in both directions. A new cron can no longer ship invisible. (Verified by hand that all 26 ids match; `fn.id()` is the established accessor, see `substrate-audit.test.ts`.)

### Spec

`docs/superpowers/specs/2026-06-21-scheduling-surface-review-design.md` — full inventory (8 substrates, 3 firing), findings (invisibility, temporal thundering-herd overlap, dormant substrates, superseded code, **scheduling absent from the architecture graph**), and the design: a scheduled-job EA extractor (the "make it a surface" keystone), catalog widened into the canonical scheduling map, cadence staggering, and dormant/dead-code resolution.

## Backlog (`EP-SCHEDULING-SURFACE`)

| BI | Scope |
|---|---|
| `BI-SCHED-CATALOG-PARITY` | this PR |
| `BI-SCHED-GRAPH-EXTRACTOR` | project the catalog into the code graph (keystone) |
| `BI-SCHED-CANONICAL-MAP` | widen catalog to all scheduling mechanisms |
| `BI-SCHED-STAGGER` | stagger cadences + same-tick contention check |
| `BI-SCHED-DORMANT` | wire/document marketing, tax, recurring-invoicing |
| `BI-SCHED-DEADCODE` | confirm-and-remove superseded scheduling code |

## Risk

Low — additive catalog data + one test + a doc. No runtime behavior change. The new parity test is green at 26 = 26.

## Open decision

`alert-delivery-bridge` shipped as `core` (operators can't disable the only alert-delivery path). Confirm, or flip to `editable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
