### PR TITLE
refactor(self-upgrade): derive heavy-maintenance calendar from the canonical scheduled-jobs catalog (BI-59591B14 Part A)

### DIFF
--- a/apps/web/lib/self-upgrade/maintenance-calendar.test.ts
+++ b/apps/web/lib/self-upgrade/maintenance-calendar.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  HEAVY_JOB_IDS,
   HEAVY_MAINTENANCE,
   isHeavyMaintenanceBusyAtUtc,
   parseSimpleCron,
   type HeavyMaintenanceWindow,
 } from "./maintenance-calendar";
+import { getCatalogEntry } from "@/lib/operate/scheduled-jobs/catalog";
 import { POSTGRES_BACKUP_CRON } from "@/lib/operate/backups/constants";
 import { DATA_RETENTION_CRON } from "@/lib/operate/retention/constants";
 
@@ -61,14 +63,28 @@ describe("isHeavyMaintenanceBusyAtUtc (day-of-week + wrap)", () => {
   });
 });
 
-describe("calendar is anchored to the exported cron constants (drift guard)", () => {
-  it("decodes the backup + retention constants to their documented UTC hours", () => {
-    expect(parseSimpleCron(POSTGRES_BACKUP_CRON)?.hour).toBe(3);
-    expect(parseSimpleCron(DATA_RETENTION_CRON)?.hour).toBe(4);
+describe("calendar derives from SCHEDULED_JOB_CATALOG (single source of truth + drift guard)", () => {
+  it("every tracked heavy job id resolves to a catalog entry (none silently dropped)", () => {
+    for (const jobId of HEAVY_JOB_IDS) {
+      expect(
+        getCatalogEntry(jobId),
+        `heavy job '${jobId}' is missing from SCHEDULED_JOB_CATALOG`,
+      ).toBeDefined();
+    }
+    expect(HEAVY_MAINTENANCE).toHaveLength(HEAVY_JOB_IDS.length);
   });
-  it("includes the backup + retention crons in the heavy calendar", () => {
+
+  it("pins the backup + retention timing to the runtime cron constants", () => {
+    // The catalog shows "daily" for backups; the constant pins the real 03:00 UTC.
     const crons = HEAVY_MAINTENANCE.map((w) => w.cron);
     expect(crons).toContain(POSTGRES_BACKUP_CRON);
     expect(crons).toContain(DATA_RETENTION_CRON);
+    expect(parseSimpleCron(POSTGRES_BACKUP_CRON)?.hour).toBe(3);
+    expect(parseSimpleCron(DATA_RETENTION_CRON)?.hour).toBe(4);
+  });
+
+  it("labels come from the catalog (not hand-written)", () => {
+    const labels = HEAVY_MAINTENANCE.map((w) => w.label);
+    expect(labels).toContain(getCatalogEntry("infra-prune")?.name);
   });
 });

--- a/apps/web/lib/self-upgrade/maintenance-calendar.ts
+++ b/apps/web/lib/self-upgrade/maintenance-calendar.ts
@@ -14,7 +14,8 @@
 // on the absolute timeline. Pure + prisma-free (only Date UTC accessors + pure
 // constant imports) so the cron path and unit tests can use it without a DB.
 
-import { POSTGRES_BACKUP_CRON } from "@/lib/operate/backups/constants";
+import { getCatalogEntry } from "@/lib/operate/scheduled-jobs/catalog";
+import { ALL_BACKUPS_CRON, POSTGRES_BACKUP_CRON } from "@/lib/operate/backups/constants";
 import { DATA_RETENTION_CRON } from "@/lib/operate/retention/constants";
 
 export type HeavyMaintenanceWindow = {
@@ -26,20 +27,59 @@ export type HeavyMaintenanceWindow = {
 };
 
 /**
- * Heavy recurring platform maintenance, clustered at 03:00-04:00 UTC. Backup +
- * retention crons reuse their exported constants; the rest are inline literals
- * that MUST be kept in sync with their function files (cited per entry).
+ * Which catalog jobs are HEAVY enough that a self-upgrade rebuild should avoid
+ * running on top of them, keyed by SCHEDULED_JOB_CATALOG jobId. The cron/time is
+ * resolved FROM the catalog (single source of truth — operate/scheduled-jobs/catalog.ts,
+ * which carries a build-failing catalog<->registry parity guard and backs the
+ * /admin/scheduled-jobs surface); only the "is this heavy" judgement + an
+ * approximate duration live here, because the catalog carries neither (its
+ * `category` is operator-tunability, not resource weight — taskrun-watchdog is
+ * `core` yet a 1-minute poller). This is a deliberately CONSERVATIVE set:
+ * backups + retention + the 03:00 batch jobs that actually contend with a portal
+ * rebuild. Lighter jobs (wiki-lint, skill-metrics/curator) are excluded — adding
+ * them would broaden the busy band enough to push even a deep-sleep slot off a
+ * clear window for no real contention benefit.
+ *
+ * `cronOverride` pins the precise UTC cron for entries whose catalog `cron` is a
+ * display cadence word ("daily" for the backups) and for the jobs that own a
+ * runtime cron CONSTANT (the constant is the true runtime source; the catalog
+ * string is hand-maintained for display). Entries with no override use the
+ * catalog's own cron.
  */
-export const HEAVY_MAINTENANCE: HeavyMaintenanceWindow[] = [
-  { label: "postgres + all-services backups", cron: POSTGRES_BACKUP_CRON, durationMin: 60 },
-  { label: "data-retention sweep", cron: DATA_RETENTION_CRON, durationMin: 60 },
-  // keep in sync with apps/web/lib/queue/functions/model-discovery-refresh.ts
-  { label: "model-discovery refresh", cron: "0 3 * * *", durationMin: 30 },
-  // keep in sync with apps/web/lib/queue/functions/material-freshness-decay.ts
-  { label: "material-freshness decay", cron: "0 3 * * *", durationMin: 30 },
-  // keep in sync with apps/web/lib/queue/functions/infra-prune.ts (weekly, Sun)
-  { label: "infra prune", cron: "0 3 * * 0", durationMin: 30 },
+type HeavyJobSpec = { jobId: string; durationMin: number; cronOverride?: string };
+
+const HEAVY_JOB_SPECS: HeavyJobSpec[] = [
+  { jobId: "postgres-daily-backup", durationMin: 60, cronOverride: POSTGRES_BACKUP_CRON },
+  { jobId: "all-backups-daily", durationMin: 60, cronOverride: ALL_BACKUPS_CRON },
+  { jobId: "data-retention-sweep", durationMin: 60, cronOverride: DATA_RETENTION_CRON },
+  { jobId: "model-discovery-refresh", durationMin: 30 }, // catalog cron "0 3 * * *"
+  { jobId: "material-freshness-decay", durationMin: 30 }, // catalog cron "0 3 * * *"
+  { jobId: "infra-prune", durationMin: 30 }, // catalog cron "0 3 * * 0" (weekly, Sun)
 ];
+
+/** The heavy-job ids this calendar tracks — exposed for the drift guard test. */
+export const HEAVY_JOB_IDS: readonly string[] = HEAVY_JOB_SPECS.map((s) => s.jobId);
+
+/**
+ * Resolve the heavy maintenance windows from the catalog at module load. A spec
+ * whose jobId is absent from the catalog, or whose resolved cron is unparseable,
+ * is dropped — the drift guard (maintenance-calendar.test.ts) asserts every spec
+ * resolves, so a renamed / removed / re-shaped job fails CI rather than silently
+ * dropping out of the avoidance set.
+ */
+function resolveHeavyMaintenance(): HeavyMaintenanceWindow[] {
+  const out: HeavyMaintenanceWindow[] = [];
+  for (const spec of HEAVY_JOB_SPECS) {
+    const entry = getCatalogEntry(spec.jobId);
+    if (!entry) continue;
+    const cron = spec.cronOverride ?? entry.cron;
+    if (!parseSimpleCron(cron)) continue;
+    out.push({ label: entry.name, cron, durationMin: spec.durationMin });
+  }
+  return out;
+}
+
+export const HEAVY_MAINTENANCE: HeavyMaintenanceWindow[] = resolveHeavyMaintenance();
 
 export type SimpleCron = { minute: number; hour: number; daysOfWeek: number[] | null };
 

--- a/docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md
+++ b/docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md
@@ -83,12 +83,30 @@ evaluated in **store tz** — so collision must be judged on one absolute (UTC) 
 - UTC/London 24/7 store → `02:00–04:00` local overlaps the 03:00–04:00 UTC cluster → shifts to
   the first clear candidate (`01:00–03:00` local = `01:00–03:00` UTC, clear).
 
-## 5. Phase 2 (staged, follow-up) — per-org + change windows
+## 5. Phase 2 (BI-59591B14) — catalog SSoT + per-org windows
 
-Compose `ScheduledAgentTask` crons (per-org, with their own tz), `BlackoutPeriod` (hard avoid),
-and `DeploymentWindow` allowed bands into the scorer via a DB-backed collector that passes
-busy-intervals into the pure picker (keeps `auto-window.ts` prisma-free). Deferred to keep this
-PR one-concern; tracked under the same BI.
+### Part A — derive the heavy set from the authoritative catalog (SSoT) — **DONE** (this PR)
+
+Phase 1 hand-listed the heavy crons. The authoritative registry already exists:
+`SCHEDULED_JOB_CATALOG` (`apps/web/lib/operate/scheduled-jobs/catalog.ts`) — every cron, with a
+build-failing catalog↔registry parity guard (#2227) and the `/admin/scheduled-jobs` surface.
+`maintenance-calendar.ts` now resolves its heavy windows FROM the catalog by `jobId`
+(`HEAVY_JOB_SPECS`), keeping only the "which jobs are heavy" judgement + a duration locally
+(the catalog has no contention flag — `category` is operator-tunability). `cronOverride` pins
+the backups/retention to their runtime cron CONSTANTS (the catalog shows `"daily"` for backups);
+other entries use the catalog cron. A drift guard test asserts every heavy `jobId` resolves, so a
+renamed/removed/retimed job fails CI. **Behaviour-preserving:** the heavy set is the same
+conservative 6 (backups ×2, retention, model-discovery, material-decay, infra-prune) → same
+03:00–05:00 UTC busy band → Phase-1 window picks unchanged. Lighter jobs (wiki-lint,
+skill-metrics/curator) are deliberately NOT included — adding them broadens the busy band enough
+to push even a deep-sleep slot off a clear window for no real contention benefit.
+
+### Part B — per-org scheduled work (staged, same BI)
+
+Compose `BlackoutPeriod` (hard avoid), `DeploymentWindow` allowed bands, and `ScheduledAgentTask`
+crons (per-org tz) into the scorer via a DB-backed collector that passes busy-intervals into the
+pure picker (keeps `auto-window.ts`/`maintenance-calendar.ts` prisma-free). Deferred to keep each
+PR one-concern.
 
 ## 6. Phases & verification
 


### PR DESCRIPTION
## What & why

Part A of **BI-59591B14** (EP-UPGRADE-LIFECYCLE) — the single-source-of-truth half of the self-upgrade scheduled-work avoidance.

Phase 1 ([#2226](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2226)) hand-listed the heavy platform crons in `maintenance-calendar.ts`. But the authoritative registry already exists — `SCHEDULED_JOB_CATALOG` (`apps/web/lib/operate/scheduled-jobs/catalog.ts`): every cron, with a build-failing catalog↔registry parity guard ([#2227](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2227)) and the `/admin/scheduled-jobs` surface. The hand-list was a SSoT duplication (a substrate-verification miss in Phase 1, owned).

## Change

`maintenance-calendar.ts` now resolves its heavy windows **from the catalog** by `jobId` (`HEAVY_JOB_SPECS`). Only the "which jobs are heavy" judgement + an approximate duration stay local — the catalog has no contention flag (its `category` is operator-tunability, not resource weight: `taskrun-watchdog` is `core` yet a 1-minute poller). `cronOverride` pins the backups/retention to their runtime cron **constants** (`POSTGRES_BACKUP_CRON` etc.; the catalog shows `"daily"` for backups); other entries use the catalog cron. A **drift-guard test** asserts every heavy `jobId` resolves, so a renamed/removed/retimed job fails CI instead of silently dropping out of the avoidance set.

## Behaviour-preserving

The heavy set is the same conservative six (backups ×2, retention, model-discovery, material-decay, infra-prune) → same **03:00–05:00 UTC** busy band → Phase-1 window picks unchanged (US-offset stores keep `02:00–04:00`, UTC stores shift to `01:00–03:00`). Lighter jobs (`wiki-lint`, `skill-metrics`/`curator`) are **deliberately excluded**: adding them broadens the busy band enough to push even a deep-sleep slot off a clear window for no real contention benefit. No behaviour change, no schema, no UI.

## Tests

`maintenance-calendar.test.ts`: drift guard (every heavy `jobId` resolves to a catalog entry; `HEAVY_MAINTENANCE.length === HEAVY_JOB_IDS.length`), backups/retention pinned to the constants, labels sourced from the catalog; existing busy-at / day-of-week / wrap / `parseSimpleCron` tests unchanged. `auto-window.test.ts` (unchanged) still green — same busy band.

## Verification

⚠️ Worktree + root clone dependency-degraded → gates run in **CI** (merge queue enforces green). `maintenance-calendar.ts` stays prisma-free: it imports only the catalog (whose sole import is the pure `CODE_GRAPH_JOB_ID` constant) + the backup/retention constant modules (pure) — verified by inspection.

## Staged (Part B, same BI)

Per-org `BlackoutPeriod` (hard avoid) + `DeploymentWindow` + `ScheduledAgentTask` via a DB-backed collector feeding the pure picker — next PR.

Plan: `docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md` (§5 Part A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)