### PR TITLE
fix(build-studio): report the real build-stall reason, not a fabricated 'portal restart'

### DIFF
--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -1018,6 +1018,38 @@ describe("deriveWorkflowStageGuidance", () => {
     expect(action.message).toMatch(/stalled|interrupted/i);
   });
 
+  it("surfaces the real error breadcrumb on a stalled no-step build instead of guessing portal restart", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({
+        phase: "build",
+        draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        taskResults: null,
+        verificationOut: null,
+        buildExecState: {
+          // No `step`, but the pipeline left a real error breadcrumb — the UX
+          // must surface THIS, not fabricate "portal restart".
+          error:
+            "Build build phase stalled (heartbeat_timeout) — no heartbeat within 1800s (codegen context overflow)",
+          sourceCurrency: {
+            dirty: false,
+            branch: "build/FB-REALREASON",
+            status: "current",
+            aheadBy: 0,
+            headSha: "41c46682a3f9df4b4963cb749842765f8371f27f",
+            behindBy: 0,
+            checkedAt: "2026-05-20T02:20:08.893Z",
+          } as unknown as never,
+        } as unknown as FeatureBuildRow["buildExecState"],
+      }),
+      governedBacklogEnabled: true,
+    });
+
+    expect(action.kind).toBe("reset-build");
+    expect(action.primaryLabel).toBe("Reset Build");
+    expect(action.message).toContain("heartbeat_timeout");
+    expect(action.message).not.toMatch(/portal restart/i);
+  });
+
   it("does NOT surface Reset Build for a legitimate step=failed state — that path uses Retry Sandbox Launch", () => {
     const action = deriveBuildStudioWorkflowAction({
       build: makeBuild({

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -581,11 +581,25 @@ export function deriveBuildStudioWorkflowAction({
         build.buildExecState?.step === "complete" &&
         (build.buildExecState?.error == null && build.buildExecState?.failedAt == null) &&
         build.verificationOut == null;
+      // Don't fabricate a cause. A null-step checkpoint can come from a failed
+      // dispatch, an early crash, an OOM / codegen context-overflow, a watchdog
+      // reap, OR a process restart. If the pipeline left an actual error
+      // breadcrumb, surface THAT verbatim instead of guessing "portal restart"
+      // — the old copy sent operators chasing restarts that never happened.
+      const stalledReason =
+        typeof build.buildExecState?.error === "string" && build.buildExecState.error.trim()
+          ? build.buildExecState.error.trim()
+          : null;
+      const stalledReasonShort = stalledReason
+        ? stalledReason.slice(0, 240) + (stalledReason.length > 240 ? "…" : "")
+        : null;
       return {
         kind: "reset-build",
         title: "Build Pipeline Needs Reset",
         message: isStalledAtPending
-          ? "The build pipeline stalled before it could start — the process was likely interrupted (e.g. portal restart) before the first step completed. Reset will restart the pipeline from scratch."
+          ? (stalledReasonShort
+              ? `The build pipeline stalled without a resumable step. Recorded reason: ${stalledReasonShort} — Reset will restart the pipeline from scratch.`
+              : "The build pipeline stalled with no recorded step and no error breadcrumb — it was interrupted before the first step completed (e.g. a failed dispatch, an early crash, or a process restart). Reset will restart the pipeline from scratch.")
           : isSilentComplete
             ? "The pipeline reported completion but verification results are missing — the sandbox likely ran but tests were never captured. Reset will restart the full build from the beginning."
             : "The build pipeline checkpoint is in a contradictory shape (a prior run left an error breadcrumb on a non-failed step). Clear the checkpoint and re-run the pipeline from the start.",
@@ -594,7 +608,9 @@ export function deriveBuildStudioWorkflowAction({
         disabledReason: null,
         coworkerLabel: "Diagnose with coworker",
         coworkerPrompt: isStalledAtPending
-          ? "The build pipeline has no recorded step — it was likely interrupted before the first step completed. Confirm whether a Reset Build is safe to restart the pipeline from scratch."
+          ? (stalledReasonShort
+              ? `The build pipeline stalled without a resumable step. The recorded reason was: ${stalledReasonShort}. Confirm whether a Reset Build is safe, or whether that root cause needs investigating first.`
+              : "The build pipeline has no recorded step and no error breadcrumb — it was interrupted before the first step (a failed dispatch, an early crash, or a process restart). Confirm whether a Reset Build is safe to restart the pipeline from scratch.")
           : isSilentComplete
             ? "The build shows step=complete but verificationOut is null, meaning tests never ran or the result was not captured. Explain what likely happened and confirm whether a full Reset Build is the right recovery."
             : "The build's execution checkpoint is contradictory (step says complete but an error breadcrumb is set). Read buildExecState and tell me whether a Reset Build is safe or if the original error needs investigation first.",


### PR DESCRIPTION
**Problem (operator-reported):** A build that stalled — almost always the codegen context overflow → watchdog reap, or a silent dispatch failure — showed a Reset-Build message asserting it was *"likely interrupted (e.g. portal restart)."* No restart had happened. The fabricated cause sent the operator chasing the wrong thing and eroded trust in the build-status UX.

**Root cause:** `deriveBuildStudioWorkflowAction` treats any null-step exec checkpoint (`missing-step`) as a portal restart and ignores the actual error breadcrumb `buildExecState` carries (e.g. `heartbeat_timeout`, `ContextOverflowError`).

**Fix:** When the checkpoint has no resumable step, surface `buildExecState.error` verbatim if present; fall back to an honest multi-cause message ("interrupted before the first step — a failed dispatch, an early crash, or a process restart") only when there is genuinely no breadcrumb. Same for the coworker diagnose prompt.

**Test:** +1 case asserting the real `heartbeat_timeout` reason is surfaced and "portal restart" is not; the existing no-breadcrumb test still matches /stalled|interrupted/. 33/33 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)