### PR TITLE
feat(scheduling): operator timeline + creation-time de-confliction (EP-SCHEDULING-SURFACE)

### DIFF
--- a/apps/web/app/(shell)/admin/scheduled-jobs/SchedulingTimeline.tsx
+++ b/apps/web/app/(shell)/admin/scheduled-jobs/SchedulingTimeline.tsx
@@ -1,0 +1,109 @@
+// BI-SCHED-TIMELINE / EP-SCHEDULING-SURFACE — daily-schedule visual for the
+// Scheduled Jobs admin page. Server component: a read-only projection of the
+// canonical scheduling map onto a 24h UTC clock, so an operator can see what
+// runs when and where work clusters. Live status + controls stay in the table.
+
+import type { SchedulingMapEntry } from "@/lib/operate/scheduled-jobs/scheduling-map";
+import {
+  buildTimelineModel,
+  type TimelineJob,
+} from "@/lib/operate/scheduled-jobs/scheduling-timeline";
+
+const CAT_COLOR: Record<"core" | "editable", string> = {
+  core: "#fbbf24",
+  editable: "#818cf8",
+};
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+function Chip({ job, showTime }: { job: TimelineJob; showTime?: boolean }) {
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 rounded inline-flex items-center gap-1.5"
+      style={{ background: "var(--dpf-bg)", border: "1px solid var(--dpf-border)", color: "var(--dpf-text)" }}
+      title={`${job.name} · ${job.label}`}
+    >
+      <span style={{ width: 6, height: 6, borderRadius: 9999, background: CAT_COLOR[job.category], flexShrink: 0 }} />
+      {showTime && <span className="font-mono" style={{ color: "var(--dpf-muted)" }}>{job.label}</span>}
+      {job.name}
+    </span>
+  );
+}
+
+function Section({ title, jobs, showTime }: { title: string; jobs: TimelineJob[]; showTime?: boolean }) {
+  if (jobs.length === 0) return null;
+  return (
+    <div className="mt-3">
+      <div className="text-[10px] uppercase font-medium mb-1.5" style={{ color: "var(--dpf-muted)" }}>
+        {title} ({jobs.length})
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {jobs.map((j) => (
+          <Chip key={j.id} job={j} showTime={showTime} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SchedulingTimeline({ entries }: { entries: readonly SchedulingMapEntry[] }) {
+  const model = buildTimelineModel(entries);
+  const timed = model.hourBuckets.flatMap((b) => b.jobs);
+  const BAR_AREA = 88; // px
+  const seg =
+    model.maxBucket > 0 ? Math.max(4, Math.min(16, Math.floor(BAR_AREA / model.maxBucket))) : 16;
+
+  return (
+    <div className="mt-6 rounded p-4" style={{ border: "1px solid var(--dpf-border)" }}>
+      <div className="flex items-baseline justify-between mb-3 gap-4">
+        <div>
+          <h2 className="text-sm font-bold" style={{ color: "var(--dpf-text)" }}>
+            Daily schedule (UTC)
+          </h2>
+          <p className="text-[11px] mt-0.5" style={{ color: "var(--dpf-muted)" }}>
+            Code-defined schedule across all substrates. Hover a bar for the jobs in that hour.
+          </p>
+        </div>
+        <div className="flex gap-3 text-[10px] whitespace-nowrap" style={{ color: "var(--dpf-muted)" }}>
+          <span className="inline-flex items-center gap-1">
+            <span style={{ width: 8, height: 8, borderRadius: 9999, background: CAT_COLOR.core }} />core
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <span style={{ width: 8, height: 8, borderRadius: 9999, background: CAT_COLOR.editable }} />editable
+          </span>
+        </div>
+      </div>
+
+      {/* 24h bar chart — one column per UTC hour, one segment per timed job */}
+      <div className="flex items-end gap-[2px]" style={{ height: BAR_AREA }}>
+        {model.hourBuckets.map((b) => (
+          <div
+            key={b.hour}
+            className="flex-1 flex flex-col justify-end items-stretch gap-[2px]"
+            title={
+              b.jobs.length
+                ? b.jobs.map((j) => `${j.label}  ${j.name}`).join("\n")
+                : `${pad(b.hour)}:00 — nothing scheduled`
+            }
+          >
+            {b.jobs.map((j) => (
+              <div key={j.id} style={{ height: seg, background: CAT_COLOR[j.category], borderRadius: 2 }} />
+            ))}
+          </div>
+        ))}
+      </div>
+      {/* hour axis */}
+      <div className="flex gap-[2px] mt-1">
+        {model.hourBuckets.map((b) => (
+          <div key={b.hour} className="flex-1 text-center text-[9px]" style={{ color: "var(--dpf-muted)" }}>
+            {b.hour % 3 === 0 ? pad(b.hour) : ""}
+          </div>
+        ))}
+      </div>
+
+      <Section title="Timed jobs" jobs={timed} showTime />
+      <Section title="Runs continuously" jobs={model.frequent} />
+      <Section title="Daily — time set in code" jobs={model.unpinned} />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/admin/scheduled-jobs/page.tsx
+++ b/apps/web/app/(shell)/admin/scheduled-jobs/page.tsx
@@ -1,8 +1,10 @@
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 
 import { listScheduledJobsAction } from "@/lib/actions/scheduled-jobs";
+import { SCHEDULING_MAP } from "@/lib/operate/scheduled-jobs/scheduling-map";
 
 import { ScheduledJobsClient } from "./ScheduledJobsClient";
+import { SchedulingTimeline } from "./SchedulingTimeline";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +35,8 @@ export default async function ScheduledJobsAdminPage() {
       </div>
 
       <AdminTabNav />
+
+      <SchedulingTimeline entries={SCHEDULING_MAP} />
 
       <ScheduledJobsClient initialJobs={jobs} />
     </div>

--- a/apps/web/components/workspace/CalendarAgentScheduler.tsx
+++ b/apps/web/components/workspace/CalendarAgentScheduler.tsx
@@ -57,6 +57,7 @@ export function CalendarAgentScheduler({ defaultDate, onClose }: Props) {
     time: "09:00",
   });
   const [message, setMessage] = useState<string | null>(null);
+  const [created, setCreated] = useState(false);
 
   const selectedAgent = AGENTS.find((a) => a.id === form.agentId);
 
@@ -75,8 +76,15 @@ export function CalendarAgentScheduler({ defaultDate, onClose }: Props) {
         schedule: cronExpr,
       });
       if (result.success) {
-        onClose();
         router.refresh();
+        if (result.note) {
+          // BI-SCHED-ALLOCATE: the time was auto-staggered to avoid a collision —
+          // tell the operator before closing instead of silently moving it.
+          setCreated(true);
+          setMessage(result.note);
+        } else {
+          onClose();
+        }
       } else {
         setMessage(result.error ?? "Failed to schedule");
       }
@@ -166,32 +174,48 @@ export function CalendarAgentScheduler({ defaultDate, onClose }: Props) {
         </div>
 
         {message && (
-          <p style={{ fontSize: 11, color: "var(--dpf-error)", marginTop: 8 }}>{message}</p>
+          <p style={{ fontSize: 11, color: created ? "#14b8a6" : "var(--dpf-error)", marginTop: 8 }}>{message}</p>
         )}
 
         <div style={{ display: "flex", gap: 6, marginTop: 12, justifyContent: "flex-end" }}>
-          <button
-            type="button" onClick={onClose}
-            style={{
-              padding: "6px 14px", fontSize: 12, borderRadius: 4,
-              border: "1px solid var(--dpf-border)", background: "transparent",
-              color: "var(--dpf-muted)", cursor: "pointer",
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            type="button" onClick={handleSubmit} disabled={isPending}
-            style={{
-              padding: "6px 14px", fontSize: 12, borderRadius: 4,
-              border: "1px solid color-mix(in srgb, #14b8a6 40%, transparent)",
-              background: "color-mix(in srgb, #14b8a6 15%, transparent)",
-              color: "#14b8a6", cursor: "pointer", fontWeight: 600,
-              opacity: isPending ? 0.5 : 1,
-            }}
-          >
-            {isPending ? "Scheduling..." : "Schedule"}
-          </button>
+          {created ? (
+            <button
+              type="button" onClick={onClose}
+              style={{
+                padding: "6px 14px", fontSize: 12, borderRadius: 4,
+                border: "1px solid color-mix(in srgb, #14b8a6 40%, transparent)",
+                background: "color-mix(in srgb, #14b8a6 15%, transparent)",
+                color: "#14b8a6", cursor: "pointer", fontWeight: 600,
+              }}
+            >
+              Done
+            </button>
+          ) : (
+            <>
+              <button
+                type="button" onClick={onClose}
+                style={{
+                  padding: "6px 14px", fontSize: 12, borderRadius: 4,
+                  border: "1px solid var(--dpf-border)", background: "transparent",
+                  color: "var(--dpf-muted)", cursor: "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button" onClick={handleSubmit} disabled={isPending}
+                style={{
+                  padding: "6px 14px", fontSize: 12, borderRadius: 4,
+                  border: "1px solid color-mix(in srgb, #14b8a6 40%, transparent)",
+                  background: "color-mix(in srgb, #14b8a6 15%, transparent)",
+                  color: "#14b8a6", cursor: "pointer", fontWeight: 600,
+                  opacity: isPending ? 0.5 : 1,
+                }}
+              >
+                {isPending ? "Scheduling..." : "Schedule"}
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -2,6 +2,8 @@
 
 import { auth } from "@/lib/auth";
 import { prisma, DATA_MODEL_MIRROR_TASK_ID, SYSML_PROJECTION_TASK_ID } from "@dpf/db";
+import { SCHEDULING_MAP } from "@/lib/operate/scheduled-jobs/scheduling-map";
+import { occupiedTicks, deconflictCron } from "@/lib/operate/scheduled-jobs/scheduling-allocator";
 import { randomUUID } from "crypto";
 import { runDataModelMirror } from "@/lib/ea/run-data-model-mirror";
 import { runArchitectureParitySteward } from "@/lib/ea/architecture-parity-steward";
@@ -54,7 +56,7 @@ export type ScheduleAgentTaskInput = {
 
 export async function scheduleAgentTask(
   input: ScheduleAgentTaskInput,
-): Promise<{ success: true; taskId: string } | { success: false; error: string }> {
+): Promise<{ success: true; taskId: string; note?: string } | { success: false; error: string }> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, error: "Unauthorized" };
 
@@ -67,7 +69,22 @@ export async function scheduleAgentTask(
 
   const taskId = `agent-task-${randomUUID().slice(0, 8)}`;
   const now = new Date();
-  const nextRunAt = computeNextCronRun(input.schedule, now);
+
+  // BI-SCHED-ALLOCATE: de-conflict at creation so a new task does not pile onto
+  // a tick already in use. Occupied ticks = the canonical scheduling map (code
+  // crons + seeded tasks) plus other live agent tasks. Interval cadences pass
+  // through untouched (those are governed by the CI contention guard).
+  const liveTasks = await prisma.scheduledAgentTask.findMany({
+    where: { isActive: true },
+    select: { schedule: true },
+  });
+  const occupied = occupiedTicks([
+    ...SCHEDULING_MAP.map((e) => e.cron),
+    ...liveTasks.map((t) => t.schedule),
+  ]);
+  const { cron: schedule, note } = deconflictCron(input.schedule, occupied);
+
+  const nextRunAt = computeNextCronRun(schedule, now);
 
   await prisma.scheduledAgentTask.create({
     data: {
@@ -76,7 +93,7 @@ export async function scheduleAgentTask(
       title: input.title,
       prompt: input.prompt,
       routeContext: input.routeContext,
-      schedule: input.schedule,
+      schedule,
       timezone: input.timezone ?? "UTC",
       ownerUserId: session.user.id,
       nextRunAt,
@@ -89,17 +106,17 @@ export async function scheduleAgentTask(
     create: {
       jobId: taskId,
       name: `Agent: ${input.title}`,
-      schedule: input.schedule,
+      schedule,
       nextRunAt,
     },
     update: {
       name: `Agent: ${input.title}`,
-      schedule: input.schedule,
+      schedule,
       nextRunAt,
     },
   });
 
-  return { success: true, taskId };
+  return note ? { success: true, taskId, note } : { success: true, taskId };
 }
 
 export async function cancelAgentTask(

--- a/apps/web/lib/operate/scheduled-jobs/scheduling-allocator.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/scheduling-allocator.test.ts
@@ -1,0 +1,46 @@
+// BI-SCHED-ALLOCATE / EP-SCHEDULING-SURFACE — creation-time de-confliction tests.
+
+import { describe, it, expect } from "vitest";
+
+import { tickOf, occupiedTicks, deconflictCron } from "./scheduling-allocator";
+
+describe("tickOf", () => {
+  it("returns the HH:MM tick for a specific-time cron", () => {
+    expect(tickOf("0 3 * * *")).toBe("03:00");
+    expect(tickOf("10 3 * * *")).toBe("03:10");
+    expect(tickOf("0 3 * * 0")).toBe("03:00"); // weekly still occupies 03:00
+  });
+
+  it("returns null for interval / frequent / null crons", () => {
+    expect(tickOf("*/15 * * * *")).toBeNull();
+    expect(tickOf("9,24,39,54 * * * *")).toBeNull();
+    expect(tickOf(null)).toBeNull();
+    expect(tickOf("daily")).toBeNull();
+  });
+});
+
+describe("deconflictCron", () => {
+  it("leaves a non-colliding specific-time cron unchanged", () => {
+    const occ = occupiedTicks(["0 3 * * *"]);
+    expect(deconflictCron("0 9 * * *", occ)).toEqual({ cron: "0 9 * * *", moved: false, note: null });
+  });
+
+  it("nudges a colliding cron to the nearest free minute and reports it", () => {
+    const occ = occupiedTicks(["0 3 * * *", "10 3 * * *"]); // 03:00 and 03:10 taken
+    const res = deconflictCron("0 3 * * *", occ); // wants 03:00 — taken
+    expect(res.moved).toBe(true);
+    expect(res.cron).toBe("1 3 * * *"); // nearest free is 03:01
+    expect(res.note).toMatch(/03:00.*03:01/);
+  });
+
+  it("skips occupied minutes to find the next free one (preserves day fields)", () => {
+    const occ = occupiedTicks(["0 3 * * *", "1 3 * * *", "2 3 * * *"]);
+    const res = deconflictCron("0 3 5 6 *", occ); // a "Once" on Jun 5, 03:00
+    expect(res.cron).toBe("3 3 5 6 *"); // 03:03, day-of-month/month preserved
+  });
+
+  it("passes interval cadences through untouched", () => {
+    const occ = occupiedTicks(["*/15 * * * *"]);
+    expect(deconflictCron("*/15 * * * *", occ).moved).toBe(false);
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/scheduling-allocator.ts
+++ b/apps/web/lib/operate/scheduled-jobs/scheduling-allocator.ts
@@ -1,0 +1,81 @@
+// BI-SCHED-ALLOCATE / EP-SCHEDULING-SURFACE — creation-time de-confliction.
+//
+// The contention guard (scheduling-map.test.ts) is a CI-time check over
+// code-defined crons. Runtime-created ScheduledAgentTasks bypass it entirely:
+// scheduleAgentTask() stored the operator's cron verbatim, so a new task could
+// pile straight onto a tick already in use (e.g. another job at 03:00). This
+// allocator de-conflicts AT CREATION: given the ticks already in use (the
+// canonical map + live tasks), it nudges a colliding specific-time task to the
+// nearest free minute within its hour and reports the move.
+//
+// Scope: specific-time crons (concrete hour). Interval/"frequent" cadences
+// (hour `*`) are passed through — those come from code and are covered by the
+// CI contention guard, not operator task creation.
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/** The "HH:MM" tick a specific-time cron fires at, or null if it is not a
+ *  single concrete tick (interval/frequent, malformed, or null). */
+export function tickOf(cron: string | null): string | null {
+  if (!cron) return null;
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [minP, hourP] = parts as [string, string, string, string, string];
+  if (hourP === "*") return null;
+  const hour = parseInt(hourP, 10);
+  const minute = minP === "*" ? 0 : parseInt(minP, 10);
+  if (Number.isNaN(hour) || Number.isNaN(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return null;
+  }
+  return `${pad(hour)}:${pad(minute)}`;
+}
+
+/** Build the set of occupied "HH:MM" ticks from a list of crons. */
+export function occupiedTicks(crons: ReadonlyArray<string | null>): Set<string> {
+  const set = new Set<string>();
+  for (const cron of crons) {
+    const tick = tickOf(cron);
+    if (tick) set.add(tick);
+  }
+  return set;
+}
+
+export type DeconflictResult = {
+  /** The schedule to use — unchanged, or nudged to a free minute. */
+  cron: string;
+  moved: boolean;
+  /** Operator-facing note when moved (null otherwise). */
+  note: string | null;
+};
+
+/**
+ * If `desired` is a specific-time cron whose tick is already occupied, nudge its
+ * minute forward to the nearest free minute within the same hour (preserving
+ * day-of-month / month / day-of-week). Otherwise return it unchanged.
+ */
+export function deconflictCron(desired: string, occupied: ReadonlySet<string>): DeconflictResult {
+  const parts = desired.trim().split(/\s+/);
+  if (parts.length !== 5) return { cron: desired, moved: false, note: null };
+  const [minP, hourP, domP, monP, dowP] = parts as [string, string, string, string, string];
+  if (hourP === "*") return { cron: desired, moved: false, note: null }; // interval — leave to CI guard
+  const hour = parseInt(hourP, 10);
+  const minute = minP === "*" ? 0 : parseInt(minP, 10);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return { cron: desired, moved: false, note: null };
+
+  const tick = (m: number) => `${pad(hour)}:${pad(m)}`;
+  if (!occupied.has(tick(minute))) return { cron: desired, moved: false, note: null };
+
+  for (let delta = 1; delta <= 59; delta++) {
+    const m = (minute + delta) % 60;
+    if (!occupied.has(tick(m))) {
+      return {
+        cron: `${m} ${hour} ${domP} ${monP} ${dowP}`,
+        moved: true,
+        note: `Auto-staggered ${tick(minute)} → ${tick(m)} UTC to avoid colliding with an existing scheduled job.`,
+      };
+    }
+  }
+  // Hour fully booked (60 jobs in one hour) — unreachable in practice; keep the
+  // operator's choice rather than fail.
+  return { cron: desired, moved: false, note: null };
+}

--- a/apps/web/lib/operate/scheduled-jobs/scheduling-timeline.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/scheduling-timeline.test.ts
@@ -1,0 +1,44 @@
+// BI-SCHED-TIMELINE / EP-SCHEDULING-SURFACE — daily-schedule model tests.
+
+import { describe, it, expect } from "vitest";
+
+import { fireProfile, buildTimelineModel } from "./scheduling-timeline";
+import { SCHEDULING_MAP } from "./scheduling-map";
+
+describe("fireProfile", () => {
+  it("classifies a concrete daily time as timed", () => {
+    expect(fireProfile("10 3 * * *")).toEqual({ kind: "timed", hour: 3, minute: 10, weekly: false });
+  });
+
+  it("flags a day-of-week restriction as weekly", () => {
+    expect(fireProfile("0 3 * * 0")).toEqual({ kind: "timed", hour: 3, minute: 0, weekly: true });
+  });
+
+  it("classifies an every-hour cron as frequent", () => {
+    expect(fireProfile("9,24,39,54 * * * *").kind).toBe("frequent");
+    expect(fireProfile("*/15 * * * *").kind).toBe("frequent");
+    expect(fireProfile("* * * * *").kind).toBe("frequent");
+  });
+
+  it("treats a null or non-cron token as unpinned", () => {
+    expect(fireProfile(null).kind).toBe("unpinned");
+    expect(fireProfile("daily").kind).toBe("unpinned");
+  });
+});
+
+describe("buildTimelineModel", () => {
+  it("places every map entry into exactly one of timed / frequent / unpinned", () => {
+    const m = buildTimelineModel(SCHEDULING_MAP);
+    const timed = m.hourBuckets.reduce((n, b) => n + b.jobs.length, 0);
+    expect(timed + m.frequent.length + m.unpinned.length).toBe(SCHEDULING_MAP.length);
+    expect(m.hourBuckets).toHaveLength(24);
+  });
+
+  it("buckets the 03:00 cluster (model-discovery + material-freshness land in hour 3)", () => {
+    const m = buildTimelineModel(SCHEDULING_MAP);
+    expect(m.maxBucket).toBeGreaterThanOrEqual(1);
+    const hour3 = m.hourBuckets[3]!.jobs.map((j) => j.id);
+    expect(hour3.some((id) => id.includes("model-discovery"))).toBe(true);
+    expect(hour3.some((id) => id.includes("material-freshness"))).toBe(true);
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/scheduling-timeline.ts
+++ b/apps/web/lib/operate/scheduled-jobs/scheduling-timeline.ts
@@ -1,0 +1,86 @@
+// BI-SCHED-TIMELINE / EP-SCHEDULING-SURFACE — pure model for the daily-schedule
+// visual on /admin/scheduled-jobs. Classifies each scheduled unit (from the
+// canonical scheduling map) onto the 24h UTC clock: a concrete time-of-day, a
+// frequent/always-on cadence, or a daily job whose exact time lives in code.
+
+import type { SchedulingMapEntry } from "./scheduling-map";
+
+export type TimelineJob = {
+  id: string;
+  name: string;
+  category: "core" | "editable";
+  /** Display label: "03:10" / "03:00 (weekly)" for timed; the cadence otherwise. */
+  label: string;
+};
+
+export type TimelineProfile =
+  | { kind: "timed"; hour: number; minute: number; weekly: boolean }
+  | { kind: "frequent" }
+  | { kind: "unpinned" };
+
+function parseFirstInt(field: string): number | null {
+  const m = field.match(/^(\d+)/);
+  return m ? parseInt(m[1]!, 10) : null;
+}
+
+/**
+ * Classify a 5-field cron (or null) by where it sits on the daily clock:
+ *   - hour `*`        -> fires within every hour (frequent / always-on)
+ *   - concrete hour   -> timed at that hour:minute (weekly if day-of-week is set)
+ *   - null / non-cron -> unpinned (e.g. the "daily" backup tokens whose real
+ *                        time is an env constant, not in the catalog string)
+ * A comma/range hour list uses its first value for placement.
+ */
+export function fireProfile(cron: string | null): TimelineProfile {
+  if (!cron) return { kind: "unpinned" };
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return { kind: "unpinned" };
+  const [minP, hourP, , , dowP] = parts as [string, string, string, string, string];
+  if (hourP === "*") return { kind: "frequent" };
+  const hour = parseFirstInt(hourP);
+  if (hour === null || hour < 0 || hour > 23) return { kind: "unpinned" };
+  const minute = minP === "*" ? 0 : parseFirstInt(minP) ?? 0;
+  return { kind: "timed", hour, minute, weekly: dowP !== "*" };
+}
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+export type TimelineModel = {
+  /** length 24, indexed by UTC hour 0..23. */
+  hourBuckets: { hour: number; jobs: TimelineJob[] }[];
+  /** sub-hourly / always-on jobs (hour `*`). */
+  frequent: TimelineJob[];
+  /** daily jobs whose exact time is code-defined (the "daily" tokens). */
+  unpinned: TimelineJob[];
+  /** busiest single hour's job count, for bar scaling. */
+  maxBucket: number;
+};
+
+export function buildTimelineModel(entries: readonly SchedulingMapEntry[]): TimelineModel {
+  const hourBuckets = Array.from({ length: 24 }, (_, hour) => ({ hour, jobs: [] as TimelineJob[] }));
+  const frequent: TimelineJob[] = [];
+  const unpinned: TimelineJob[] = [];
+
+  for (const e of entries) {
+    const profile = fireProfile(e.cron);
+    if (profile.kind === "timed") {
+      hourBuckets[profile.hour]!.jobs.push({
+        id: e.id,
+        name: e.name,
+        category: e.category,
+        label: `${pad(profile.hour)}:${pad(profile.minute)}${profile.weekly ? " (weekly)" : ""}`,
+      });
+    } else if (profile.kind === "frequent") {
+      frequent.push({ id: e.id, name: e.name, category: e.category, label: e.cadence });
+    } else {
+      unpinned.push({ id: e.id, name: e.name, category: e.category, label: e.cadence });
+    }
+  }
+
+  for (const bucket of hourBuckets) bucket.jobs.sort((a, b) => a.label.localeCompare(b.label));
+  frequent.sort((a, b) => a.name.localeCompare(b.name));
+  unpinned.sort((a, b) => a.name.localeCompare(b.name));
+
+  const maxBucket = hourBuckets.reduce((m, b) => Math.max(m, b.jobs.length), 0);
+  return { hourBuckets, frequent, unpinned, maxBucket };
+}

--- a/docs/superpowers/plans/2026-06-21-scheduling-surface-buildout-plan.md
+++ b/docs/superpowers/plans/2026-06-21-scheduling-surface-buildout-plan.md
@@ -31,3 +31,10 @@ Implements the five remaining BIs from the scheduling-surface review in one PR. 
 ## Validation
 - Local vitest: scheduled-jobs (map/contention/parity), EA (extractor/projection/steward), queue/functions index — all green.
 - Full `apps/web` typecheck.
+
+## Follow-on (same epic, 2026-06-21)
+
+Two operator-facing additions after the buildout merged:
+
+- `BI-SCHED-TIMELINE` — a daily-schedule visual on `/admin/scheduled-jobs`. Pure model `scheduling-timeline.ts` (classifies each map entry onto the 24h UTC clock: timed / frequent / unpinned) + `SchedulingTimeline.tsx` server component (24h bar chart + chips), fed by `SCHEDULING_MAP`. An operator sees what runs when and where work clusters without reading crons.
+- `BI-SCHED-ALLOCATE` — creation-time de-confliction. `scheduling-allocator.ts` (`occupiedTicks` + `deconflictCron`) nudges a colliding specific-time task to the nearest free minute; wired into `scheduleAgentTask()` (occupied = canonical map + live tasks) and surfaced in the Calendar scheduler. Interval cadences pass through (covered by the CI contention guard). Turns the static guard into active de-confliction at the moment a task is created.

--- a/docs/superpowers/specs/2026-06-21-scheduling-surface-review-design.md
+++ b/docs/superpowers/specs/2026-06-21-scheduling-surface-review-design.md
@@ -101,3 +101,10 @@ Risk: low — additive catalog data + one test; `fn.id()` is the established acc
 - **Category of `alert-delivery-bridge`**: shipped as `core` (operator cannot disable the sole alert path). Confirm or flip to editable.
 - **Marketing scheduler**: wire an Inngest cron, or keep manual-by-design? (`BI-SCHED-DORMANT`.)
 - **Dedup-guard hardening** (token-expiry tier-change, work-queue bridges) surfaced in review as low-severity; folded into `BI-SCHED-CANONICAL-MAP` rather than separate BIs unless a real duplicate is observed.
+
+## 8. Follow-on — operator timeline + active de-confliction (2026-06-21)
+
+Two additions after the buildout, closing the gap between the *static* contention guard and *runtime* task creation:
+
+- **Daily-schedule timeline** (`BI-SCHED-TIMELINE`): a read-only 24h UTC visual on `/admin/scheduled-jobs`, projecting `SCHEDULING_MAP` onto the clock (timed / frequent / unpinned). `scheduling-timeline.ts` (pure model) + `SchedulingTimeline.tsx`. Answers "what's scheduled when" at a glance.
+- **Creation-time de-confliction** (`BI-SCHED-ALLOCATE`): `scheduling-allocator.ts` de-conflicts a new task *at creation* — `scheduleAgentTask()` nudges a colliding specific-time task to the nearest free minute (occupied = map + live tasks) and the Calendar UI notifies. Interval cadences pass through to the CI guard. The active counterpart to the static contention guard: new scheduled work de-conflicts immediately rather than piling up and being caught later.


### PR DESCRIPTION
Two operator-facing follow-ons to the scheduling surface (after the buildout merged in [#2229](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2229)), both requested by the founder.

## `BI-SCHED-TIMELINE` — daily-schedule visual on `/admin/scheduled-jobs`

> "the daily job graph should be on the scheduled task page to easily see what jobs are scheduled when as a visual."

A read-only 24h UTC visual that projects the canonical `SCHEDULING_MAP` onto the clock so an operator sees **what runs when** without reading crons.
- `scheduling-timeline.ts` — pure model: `fireProfile` classifies each entry as **timed** (concrete hour), **frequent** (sub-hourly), or **unpinned** (daily token whose time is code-defined); `buildTimelineModel` buckets into the 24h clock.
- `SchedulingTimeline.tsx` — server component: 24h bar chart (segments coloured by core/editable, hover for the jobs in each hour) + "Timed jobs / Runs continuously / Daily — time set in code" chips. Rendered above the existing controls table.

The 03:00 cluster visibly dominates the chart — the same shape the contention work flattened.

## `BI-SCHED-ALLOCATE` — de-conflict at creation, not in CI

> "when a new scheduled item is created, we should de-conflict at that time rather than let them pile up."

The contention guard is CI-time over code-defined crons; runtime-created tasks bypassed it (`scheduleAgentTask` stored the operator's cron verbatim).
- `scheduling-allocator.ts` — `occupiedTicks` + `deconflictCron`: nudges a colliding specific-time task to the nearest free minute within its hour; interval cadences pass through (still covered by the CI guard).
- Wired into `scheduleAgentTask()` — occupied set = canonical map + live `ScheduledAgentTask` rows. Returns a note; `CalendarAgentScheduler` surfaces it ("Auto-staggered 03:00 → 03:01 UTC…") so a moved time is **notified, never silent**.

Default per the earlier question: auto-stagger intervals; nudge-and-notify on specific-time collisions. Easy to change if you'd rather chosen times never move.

## Validation

Full `apps/web` typecheck **green**; targeted `vitest` (timeline, allocator, agent-task-scheduler, scheduled-jobs) **41 passed**. No runtime behaviour change beyond the two features.

Spec §8 + plan follow-on updated. BIs filed under `EP-SCHEDULING-SURFACE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
