### PR TITLE
feat(onboarding): risk-posture home + envelope→autonomy-gate wiring (EP-ONBOARDING-INTAKE P0+P1)

### DIFF
--- a/apps/web/app/(shell)/storefront/settings/business/page.tsx
+++ b/apps/web/app/(shell)/storefront/settings/business/page.tsx
@@ -3,6 +3,7 @@ import { BusinessContextForm } from "@/components/admin/BusinessContextForm";
 import { getSetupContext } from "@/lib/actions/setup-progress";
 import { suggestMission } from "@/lib/onboarding/mission-suggestion";
 import { parseOrgAddress } from "@/lib/shared/org-address";
+import { deriveRiskPostureDefault } from "@/lib/govern/risk-posture";
 
 export default async function StorefrontBusinessSettingsPage() {
   const [org, setupContext, storefrontConfig] = await Promise.all([
@@ -43,6 +44,15 @@ export default async function StorefrontBusinessSettingsPage() {
     dataResidency: businessContext?.dataResidency ?? [],
     handlesCardPayments: businessContext?.handlesCardPayments ?? false,
     address: parseOrgAddress(org?.address),
+    // Pre-set the risk posture from the stored value, else the industry default.
+    // Inert in P0 — captured/seeded only; consumers are wired in P1.
+    riskPosture:
+      businessContext?.riskPosture ??
+      deriveRiskPostureDefault({
+        archetypeCategory: storefrontConfig?.archetype?.category ?? null,
+        industry: setupContext?.suggestedIndustry ?? null,
+        handlesCardPayments: businessContext?.handlesCardPayments ?? false,
+      }).posture,
   };
 
   const missionSuggestion = suggestMission({

--- a/apps/web/app/api/business-context/setup/route.ts
+++ b/apps/web/app/api/business-context/setup/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma, type Prisma } from "@dpf/db";
 import { parseOrgAddress, sanitizeOrgAddressInput, serializeOrgAddress } from "@/lib/shared/org-address";
+import { isRiskPosture } from "@/lib/govern/risk-posture";
+import { applyRiskEnvelopeToOrgProfile } from "@/lib/onboarding/apply-risk-envelope-to-profile";
 
 export async function POST(req: NextRequest) {
   const session = await auth();
@@ -23,6 +25,7 @@ export async function POST(req: NextRequest) {
     employsIn,
     dataResidency,
     handlesCardPayments,
+    riskPosture,
     address,
   } = (await req.json()) as {
     description?: string;
@@ -38,6 +41,7 @@ export async function POST(req: NextRequest) {
     employsIn?: string[];
     dataResidency?: string[];
     handlesCardPayments?: boolean;
+    riskPosture?: string;
     address?: unknown;
   };
 
@@ -63,6 +67,19 @@ export async function POST(req: NextRequest) {
         complianceScopeCapturedAt: new Date(),
       }
     : {};
+
+  // Risk posture: the form sends it only when the operator actually chose one
+  // (an untouched industry-derived default is left for setup completion to seed),
+  // so a present + valid value is an explicit operator choice. Reject unknown
+  // values rather than poisoning the typed knob (EP-ONBOARDING-INTAKE P0).
+  const riskPostureUpdate =
+    riskPosture !== undefined && isRiskPosture(riskPosture)
+      ? {
+          riskPosture,
+          riskPostureSource: "operator",
+          riskPostureCapturedAt: new Date(),
+        }
+      : {};
 
   const org = await prisma.organization.findFirst({ select: { id: true, address: true } });
   if (!org) {
@@ -104,6 +121,7 @@ export async function POST(req: NextRequest) {
       customerSegments: [],
       ...(addressStateCode ? { stateCode: addressStateCode } : {}),
       ...complianceScope,
+      ...riskPostureUpdate,
     },
     update: {
       ...(description !== undefined && { description }),
@@ -114,8 +132,15 @@ export async function POST(req: NextRequest) {
       ...(revenueModel !== undefined && { revenueModel }),
       ...(addressStateCode ? { stateCode: addressStateCode } : {}),
       ...complianceScope,
+      ...riskPostureUpdate,
     },
   });
+
+  // When the operator changes the posture, keep the org WWWD profile's autonomy
+  // policy in sync (P1). Fail-open inside the helper; balanced = no change.
+  if (Object.keys(riskPostureUpdate).length > 0) {
+    await applyRiskEnvelopeToOrgProfile({ organizationId: org.id });
+  }
 
   return NextResponse.json({ success: true, id: businessContext.id });
 }

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -37,6 +37,15 @@ const GEOGRAPHIC_SCOPE_OPTIONS = [
   { value: "international", label: "International", description: "Multiple countries" },
 ];
 
+// Risk posture (EP-ONBOARDING-INTAKE P0). Values are the canonical RISK_POSTURES
+// enum; labels are plain-language display only (easily re-tuned). Pre-set from
+// the industry default — sets the autonomy *envelope*, not the live level.
+const RISK_POSTURE_OPTIONS = [
+  { value: "conservative", label: "Cautious", description: "More human review; AI acts only on safe, routine work" },
+  { value: "balanced", label: "Balanced", description: "AI handles the everyday; checks in on consequential calls" },
+  { value: "progressive", label: "Fast-moving", description: "AI runs with more autonomy; you stay in the loop on the big ones" },
+];
+
 // Jurisdiction options for the compliance-scope capture. Slugs match
 // PROFESSION_JURISDICTIONS so the corpus jurisdiction-basis model can match them.
 const JURISDICTION_OPTIONS = [
@@ -68,6 +77,7 @@ type BusinessContextData = {
   employsIn: string[];
   dataResidency: string[];
   handlesCardPayments: boolean;
+  riskPosture: string | null;
   address: OrgAddress;
 };
 
@@ -209,10 +219,15 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
     setError(null);
     setSubmitting(true);
     try {
+      // Send risk posture only when the operator actually chose one. An untouched
+      // industry-derived default is left for setup completion to (re)seed against
+      // the archetype they finally pick, so it isn't frozen as an explicit choice.
+      const payload: Record<string, unknown> = { ...data };
+      if (!editedFields.has("riskPosture")) delete payload.riskPosture;
       const res = await fetch("/api/business-context/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
@@ -592,6 +607,39 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
               + We sell to, employ in, or store data in other regions
             </button>
           )}
+        </div>
+
+        {/* Risk posture (EP-ONBOARDING-INTAKE P0) — one plain choice, pre-set
+            from industry. Sets the autonomy envelope, not the live level: the AI
+            still starts cautious and earns autonomy as it proves itself. */}
+        <div style={{ borderTop: "1px solid var(--dpf-border)", paddingTop: 14 }}>
+          <div style={fieldLabelStyle}>How should your AI workforce balance speed and caution?</div>
+          <div style={hintStyle}>
+            Sets the starting point for how much your AI does on its own. It always begins cautious
+            and earns more autonomy as it proves itself — change this anytime.
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 6, marginTop: 8 }}>
+            {RISK_POSTURE_OPTIONS.map((o) => (
+              <button
+                key={o.value}
+                type="button"
+                onClick={() => update("riskPosture", o.value)}
+                style={{
+                  padding: "8px 6px",
+                  textAlign: "left",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  fontSize: 12,
+                  border: data.riskPosture === o.value ? "2px solid var(--dpf-accent)" : "1px solid var(--dpf-border)",
+                  background: data.riskPosture === o.value ? "color-mix(in srgb, var(--dpf-accent) 8%, var(--dpf-surface-1))" : "var(--dpf-surface-1)",
+                  color: "var(--dpf-text)",
+                }}
+              >
+                <div style={{ fontWeight: 600 }}>{o.label}</div>
+                <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{o.description}</div>
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Contact details */}

--- a/apps/web/lib/actions/setup-progress.ts
+++ b/apps/web/lib/actions/setup-progress.ts
@@ -5,6 +5,8 @@ import { SETUP_STEPS, type SetupStep, type StepStatus, type SetupContext } from 
 import { seedOrgWwwdCorpus } from "@/lib/onboarding/seed-org-wwwd-corpus";
 import { seedPortfolioDecomposition } from "@/lib/onboarding/seed-portfolio-decomposition";
 import { seedMarketOffer } from "@/lib/onboarding/seed-market-offer";
+import { seedRiskPosture } from "@/lib/onboarding/seed-risk-posture";
+import { applyRiskEnvelopeToOrgProfile } from "@/lib/onboarding/apply-risk-envelope-to-profile";
 import { applyMissionPrompt } from "@/lib/onboarding/apply-mission-prompt";
 
 /**
@@ -32,6 +34,10 @@ async function finalizeSetupCompletion(organizationId: string | null): Promise<v
     await seedOrgWwwdCorpus({ organizationId: orgId });
     await seedPortfolioDecomposition({ organizationId: orgId });
     await seedMarketOffer({ organizationId: orgId });
+    await seedRiskPosture({ organizationId: orgId });
+    // P1: project the seeded posture onto the org WWWD profile's autonomy policy
+    // (runs after the profile exists + the posture is set; balanced = no change).
+    await applyRiskEnvelopeToOrgProfile({ organizationId: orgId });
   } catch (err) {
     console.warn("[setup] mission/WWWD seeding on completion failed (fail-open):", err);
   }

--- a/apps/web/lib/govern/risk-posture.test.ts
+++ b/apps/web/lib/govern/risk-posture.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  RISK_POSTURES,
+  DEFAULT_RISK_POSTURE,
+  isRiskPosture,
+  isRiskPostureSource,
+  deriveRiskPostureDefault,
+  resolveRiskEnvelope,
+  riskEnvelopeToAutonomyPolicy,
+} from "./risk-posture";
+
+describe("risk posture enum guards", () => {
+  it("exposes the three canonical postures", () => {
+    expect(RISK_POSTURES).toEqual(["conservative", "balanced", "progressive"]);
+    expect(DEFAULT_RISK_POSTURE).toBe("balanced");
+  });
+
+  it("validates postures and sources", () => {
+    expect(isRiskPosture("conservative")).toBe(true);
+    expect(isRiskPosture("balanced")).toBe(true);
+    expect(isRiskPosture("aggressive")).toBe(false);
+    expect(isRiskPosture(null)).toBe(false);
+    expect(isRiskPostureSource("operator")).toBe(true);
+    expect(isRiskPostureSource("industry-default")).toBe(true);
+    expect(isRiskPostureSource("guessed")).toBe(false);
+  });
+});
+
+describe("deriveRiskPostureDefault", () => {
+  it("returns conservative for regulated archetype categories", () => {
+    for (const cat of [
+      "banking-financial-services",
+      "healthcare-wellness",
+      "public-sector",
+      "professional-services",
+    ]) {
+      expect(deriveRiskPostureDefault({ archetypeCategory: cat })).toEqual({
+        posture: "conservative",
+        source: "industry-default",
+      });
+    }
+  });
+
+  it("resolves freeform industry aliases through the shared normalizer", () => {
+    expect(deriveRiskPostureDefault({ industry: "legal" }).posture).toBe("conservative");
+    expect(deriveRiskPostureDefault({ industry: "financial" }).posture).toBe("conservative");
+    expect(deriveRiskPostureDefault({ industry: "medical" }).posture).toBe("conservative");
+    expect(deriveRiskPostureDefault({ industry: "Healthcare" }).posture).toBe("conservative");
+  });
+
+  it("defaults to balanced for unregulated or unknown industries", () => {
+    expect(deriveRiskPostureDefault({ archetypeCategory: "retail-goods" }).posture).toBe("balanced");
+    expect(deriveRiskPostureDefault({ industry: "coffee shop" }).posture).toBe("balanced");
+    expect(deriveRiskPostureDefault({}).posture).toBe("balanced");
+    expect(deriveRiskPostureDefault({ archetypeCategory: null, industry: null }).posture).toBe("balanced");
+    expect(deriveRiskPostureDefault({ archetypeCategory: "" }).posture).toBe("balanced");
+  });
+
+  it("prefers the canonical archetype category over freeform industry", () => {
+    expect(
+      deriveRiskPostureDefault({ archetypeCategory: "retail-goods", industry: "banking" }).posture,
+    ).toBe("balanced");
+  });
+
+  it("nudges a balanced default to conservative when card payments are handled, never the reverse", () => {
+    expect(deriveRiskPostureDefault({ archetypeCategory: "retail-goods", handlesCardPayments: true }).posture).toBe(
+      "conservative",
+    );
+    // already conservative stays conservative
+    expect(
+      deriveRiskPostureDefault({ archetypeCategory: "healthcare-wellness", handlesCardPayments: true }).posture,
+    ).toBe("conservative");
+  });
+
+  it("always reports industry-default provenance", () => {
+    expect(deriveRiskPostureDefault({ archetypeCategory: "retail-goods" }).source).toBe("industry-default");
+  });
+});
+
+describe("resolveRiskEnvelope", () => {
+  it("maps each posture to its envelope", () => {
+    expect(resolveRiskEnvelope("conservative")).toMatchObject({
+      posture: "conservative",
+      hitlDefault: "all-consequential",
+      selfUpgradeWindow: "narrow",
+      capabilityAutoActivate: false,
+      outboundConfirmation: "always",
+      edgeDeployDefault: false,
+      autonomyCeiling: "low",
+      maturationRate: "slow",
+    });
+    expect(resolveRiskEnvelope("balanced")).toMatchObject({
+      posture: "balanced",
+      hitlDefault: "selective",
+      capabilityAutoActivate: true,
+      autonomyCeiling: "moderate",
+    });
+    expect(resolveRiskEnvelope("progressive")).toMatchObject({
+      posture: "progressive",
+      hitlDefault: "minimal",
+      selfUpgradeWindow: "flexible",
+      edgeDeployDefault: true,
+      autonomyCeiling: "high",
+      maturationRate: "fast",
+    });
+  });
+
+  it("fails open to the balanced default for unset or invalid input", () => {
+    expect(resolveRiskEnvelope(null).posture).toBe("balanced");
+    expect(resolveRiskEnvelope(undefined).posture).toBe("balanced");
+    // @ts-expect-error exercising the runtime guard with an invalid value
+    expect(resolveRiskEnvelope("aggressive").posture).toBe("balanced");
+  });
+});
+
+describe("riskEnvelopeToAutonomyPolicy", () => {
+  it("BALANCED is the identity — exactly the org profile's seeded default (no regression)", () => {
+    // Must equal seed-org-wwwd-corpus DEFAULT_AUTONOMY_POLICY. If this ever
+    // changes, existing installs would silently shift autonomy — keep it pinned.
+    expect(riskEnvelopeToAutonomyPolicy(resolveRiskEnvelope("balanced"))).toEqual({
+      allowRecommendation: true,
+      allowArbitration: false,
+      maxRiskForArbitration: "low",
+      minimumConfidenceForRecommendation: 0.55,
+      minimumConfidenceForArbitration: 0.9,
+    });
+  });
+
+  it("conservative only tightens — never arbitrates, higher confidence floors", () => {
+    const c = riskEnvelopeToAutonomyPolicy(resolveRiskEnvelope("conservative"));
+    expect(c.allowArbitration).toBe(false);
+    expect(c.maxRiskForArbitration).toBe("low");
+    expect(c.minimumConfidenceForArbitration).toBeGreaterThanOrEqual(0.9);
+    expect(c.minimumConfidenceForRecommendation).toBeGreaterThanOrEqual(0.55);
+  });
+
+  it("progressive loosens within bounds — arbitrates low+medium risk at high confidence", () => {
+    const p = riskEnvelopeToAutonomyPolicy(resolveRiskEnvelope("progressive"));
+    expect(p.allowArbitration).toBe(true);
+    expect(p.maxRiskForArbitration).toBe("medium");
+    // even progressive demands high confidence to arbitrate; high/critical risk
+    // still always escalates (an unconditional rule in the evaluator).
+    expect(p.minimumConfidenceForArbitration).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("autonomy is monotonic across postures (conservative <= balanced <= progressive)", () => {
+    const c = riskEnvelopeToAutonomyPolicy(resolveRiskEnvelope("conservative"));
+    const b = riskEnvelopeToAutonomyPolicy(resolveRiskEnvelope("balanced"));
+    const p = riskEnvelopeToAutonomyPolicy(resolveRiskEnvelope("progressive"));
+    // tighter posture => higher arbitration confidence floor
+    expect(c.minimumConfidenceForArbitration).toBeGreaterThanOrEqual(b.minimumConfidenceForArbitration);
+    expect(b.minimumConfidenceForArbitration).toBeGreaterThanOrEqual(p.minimumConfidenceForArbitration);
+    // only progressive unlocks arbitration
+    expect([c.allowArbitration, b.allowArbitration]).toEqual([false, false]);
+    expect(p.allowArbitration).toBe(true);
+  });
+});

--- a/apps/web/lib/govern/risk-posture.test.ts
+++ b/apps/web/lib/govern/risk-posture.test.ts
@@ -108,7 +108,7 @@ describe("resolveRiskEnvelope", () => {
   it("fails open to the balanced default for unset or invalid input", () => {
     expect(resolveRiskEnvelope(null).posture).toBe("balanced");
     expect(resolveRiskEnvelope(undefined).posture).toBe("balanced");
-    // @ts-expect-error exercising the runtime guard with an invalid value
+    // an unrecognized value falls through the guard to the balanced default
     expect(resolveRiskEnvelope("aggressive").posture).toBe("balanced");
   });
 });

--- a/apps/web/lib/govern/risk-posture.ts
+++ b/apps/web/lib/govern/risk-posture.ts
@@ -131,8 +131,10 @@ const ENVELOPES: Record<RiskPosture, Omit<RiskEnvelope, "posture">> = {
 };
 
 /** Resolve the envelope for a posture, falling back to the balanced default for
- *  an unset/invalid value (fail-open, mirrors the retention floor reader). */
-export function resolveRiskEnvelope(posture: RiskPosture | null | undefined): RiskEnvelope {
+ *  an unset/invalid value. Accepts a raw `string` (e.g. the DB column) on
+ *  purpose — it's fail-open and guards with isRiskPosture, mirroring the
+ *  retention floor reader. */
+export function resolveRiskEnvelope(posture: string | null | undefined): RiskEnvelope {
   const p = isRiskPosture(posture) ? posture : DEFAULT_RISK_POSTURE;
   return { posture: p, ...ENVELOPES[p] };
 }

--- a/apps/web/lib/govern/risk-posture.ts
+++ b/apps/web/lib/govern/risk-posture.ts
@@ -1,0 +1,182 @@
+// EP-ONBOARDING-INTAKE P0 — org-wide risk posture home + industry-derived default.
+//
+// Spec: docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md §5
+//
+// Risk posture is the org-wide autonomy/risk appetite — the structured companion
+// to the prose `howWeDecide` WWWD stance. One knob (BusinessContext.riskPosture)
+// for which an industry sets a conservative DEFAULT, mirroring the retention
+// floors: the same regulated industries that carry a retention floor
+// (INDUSTRY_RETENTION_FLOORS) start at a conservative risk posture. An industry
+// can only ever make the default MORE cautious, never less — "progressive" is
+// reachable only by an explicit operator choice; we never assume an industry
+// wants more autonomy.
+//
+// Crucially this sets the autonomy ENVELOPE (the ceiling + maturation rate), NOT
+// the live autonomy level: the autopilot trust dial still starts HITL-first and
+// earns autonomy on evidence. resolveRiskEnvelope() maps the posture to that
+// envelope at read time (no stored derivation — single source of truth is the
+// one `riskPosture` knob). Consumers (trust dial, agent governance seed,
+// self-upgrade window, capability activation, outbound strictness, edge deploy)
+// are wired in P1; this module is the inert home + derivation only.
+
+import { toFloorKey } from "@/lib/operate/retention/industry-floors";
+import type { DecisionAutonomyPolicy } from "@/lib/decision-perspective/types";
+
+/** The org-wide risk posture knob. Closed enum (AGENTS.md §3). */
+export const RISK_POSTURES = ["conservative", "balanced", "progressive"] as const;
+export type RiskPosture = (typeof RISK_POSTURES)[number];
+
+/** Default when no industry signal raises caution. */
+export const DEFAULT_RISK_POSTURE: RiskPosture = "balanced";
+
+/** Provenance of the stored posture. */
+export const RISK_POSTURE_SOURCES = ["industry-default", "operator"] as const;
+export type RiskPostureSource = (typeof RISK_POSTURE_SOURCES)[number];
+
+export function isRiskPosture(v: unknown): v is RiskPosture {
+  return typeof v === "string" && (RISK_POSTURES as readonly string[]).includes(v);
+}
+
+export function isRiskPostureSource(v: unknown): v is RiskPostureSource {
+  return typeof v === "string" && (RISK_POSTURE_SOURCES as readonly string[]).includes(v);
+}
+
+/**
+ * Industry categories whose DEFAULT posture is conservative. Keyed by the same
+ * canonical floor keys as INDUSTRY_RETENTION_FLOORS (and resolved through the
+ * shared `toFloorKey` alias map, so freeform "legal"/"financial"/"medical" land
+ * here too). Anything not listed defaults to "balanced". This is deliberately a
+ * floor, not a full mapping: an industry can raise caution, never lower it.
+ */
+export const INDUSTRY_RISK_DEFAULTS: Record<string, RiskPosture> = {
+  "banking-financial-services": "conservative",
+  "professional-services": "conservative",
+  "healthcare-wellness": "conservative",
+  "public-sector": "conservative",
+};
+
+/**
+ * Derive the industry-default posture from what onboarding already knows. Prefers
+ * the canonical archetype category (StorefrontConfig.archetype.category — the
+ * single source of truth for industry per AGENTS.md §2), falling back to the
+ * freeform industry string. Card handling nudges one step toward caution (PCI
+ * exposure), never away. Returns the posture + provenance so the seed can record
+ * that this was machine-derived, not operator-chosen.
+ */
+export function deriveRiskPostureDefault(input: {
+  archetypeCategory?: string | null;
+  industry?: string | null;
+  handlesCardPayments?: boolean | null;
+}): { posture: RiskPosture; source: "industry-default" } {
+  const raw = input.archetypeCategory ?? input.industry ?? null;
+  const key = raw != null && raw.trim() !== "" ? toFloorKey(raw) : null;
+  let posture: RiskPosture =
+    (key != null ? INDUSTRY_RISK_DEFAULTS[key] : undefined) ?? DEFAULT_RISK_POSTURE;
+  // Card handling only ever raises caution.
+  if (input.handlesCardPayments && posture === "balanced") posture = "conservative";
+  return { posture, source: "industry-default" };
+}
+
+/**
+ * The autonomy envelope a posture implies. Qualitative on purpose — P1 calibrates
+ * the concrete thresholds when it wires each consumer; these ordinals are the
+ * stable contract those consumers read.
+ */
+export type RiskEnvelope = {
+  posture: RiskPosture;
+  /** Default HITL stance for consequential agent decisions. */
+  hitlDefault: "all-consequential" | "selective" | "minimal";
+  /** Self-upgrade maintenance-window width. */
+  selfUpgradeWindow: "narrow" | "standard" | "flexible";
+  /** Whether `recommended` capabilities auto-activate vs are merely proposed. */
+  capabilityAutoActivate: boolean;
+  /** Outbound-send confirmation strictness. */
+  outboundConfirmation: "always" | "first-time" | "trusted";
+  /** Default edge-node customer-deployment opt-in. */
+  edgeDeployDefault: boolean;
+  /** Trust-dial autonomy ceiling (how far autonomy can rise on evidence). */
+  autonomyCeiling: "low" | "moderate" | "high";
+  /** How fast the trust dial matures toward its ceiling. */
+  maturationRate: "slow" | "standard" | "fast";
+};
+
+const ENVELOPES: Record<RiskPosture, Omit<RiskEnvelope, "posture">> = {
+  conservative: {
+    hitlDefault: "all-consequential",
+    selfUpgradeWindow: "narrow",
+    capabilityAutoActivate: false,
+    outboundConfirmation: "always",
+    edgeDeployDefault: false,
+    autonomyCeiling: "low",
+    maturationRate: "slow",
+  },
+  balanced: {
+    hitlDefault: "selective",
+    selfUpgradeWindow: "standard",
+    capabilityAutoActivate: true,
+    outboundConfirmation: "first-time",
+    edgeDeployDefault: false,
+    autonomyCeiling: "moderate",
+    maturationRate: "standard",
+  },
+  progressive: {
+    hitlDefault: "minimal",
+    selfUpgradeWindow: "flexible",
+    capabilityAutoActivate: true,
+    outboundConfirmation: "trusted",
+    edgeDeployDefault: true,
+    autonomyCeiling: "high",
+    maturationRate: "fast",
+  },
+};
+
+/** Resolve the envelope for a posture, falling back to the balanced default for
+ *  an unset/invalid value (fail-open, mirrors the retention floor reader). */
+export function resolveRiskEnvelope(posture: RiskPosture | null | undefined): RiskEnvelope {
+  const p = isRiskPosture(posture) ? posture : DEFAULT_RISK_POSTURE;
+  return { posture: p, ...ENVELOPES[p] };
+}
+
+// ─── P1 consumer: decision-perspective autonomy policy ──────────────────────
+// The live "trust dial" in practice is the decision-perspective evaluator, which
+// reads the org WWWD profile's autonomyPolicy to gate how autonomously coworkers
+// may act. This maps a posture to that policy. BALANCED IS THE IDENTITY: it
+// reproduces exactly the policy the org profile is seeded with today
+// (seed-org-wwwd-corpus DEFAULT_AUTONOMY_POLICY), so existing installs are
+// unchanged. Conservative only tightens (more escalation, never arbitrate);
+// progressive only loosens within bounds (arbitrate low+medium risk at high
+// confidence). High/critical-risk decisions ALWAYS escalate regardless (an
+// unconditional rule in the evaluator), so no posture can make an agent reckless
+// on a high-risk call.
+
+/** Identity policy — MUST equal seed-org-wwwd-corpus DEFAULT_AUTONOMY_POLICY. */
+const BALANCED_AUTONOMY_POLICY: DecisionAutonomyPolicy = {
+  allowRecommendation: true,
+  allowArbitration: false,
+  maxRiskForArbitration: "low",
+  minimumConfidenceForRecommendation: 0.55,
+  minimumConfidenceForArbitration: 0.9,
+};
+
+const AUTONOMY_POLICIES: Record<RiskPosture, DecisionAutonomyPolicy> = {
+  conservative: {
+    allowRecommendation: true,
+    allowArbitration: false,
+    maxRiskForArbitration: "low",
+    minimumConfidenceForRecommendation: 0.65,
+    minimumConfidenceForArbitration: 0.95,
+  },
+  balanced: BALANCED_AUTONOMY_POLICY,
+  progressive: {
+    allowRecommendation: true,
+    allowArbitration: true,
+    maxRiskForArbitration: "medium",
+    minimumConfidenceForRecommendation: 0.5,
+    minimumConfidenceForArbitration: 0.8,
+  },
+};
+
+/** Map a risk envelope to the org's decision-perspective autonomy policy. */
+export function riskEnvelopeToAutonomyPolicy(envelope: RiskEnvelope): DecisionAutonomyPolicy {
+  return AUTONOMY_POLICIES[envelope.posture] ?? BALANCED_AUTONOMY_POLICY;
+}

--- a/apps/web/lib/onboarding/apply-risk-envelope-to-profile.test.ts
+++ b/apps/web/lib/onboarding/apply-risk-envelope-to-profile.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  applyRiskEnvelopeToOrgProfile,
+  type ApplyRiskEnvelopeClient,
+} from "./apply-risk-envelope-to-profile";
+
+type UpdateManyArg = {
+  where: Record<string, unknown>;
+  data: { autonomyPolicy: Record<string, unknown> };
+};
+
+function fakeDb(riskPosture: string | null) {
+  const updateMany = vi.fn(async (_args: unknown) => ({ count: 1 }));
+  const findUnique = vi.fn(async (_args: unknown) => ({ riskPosture }));
+  const db: ApplyRiskEnvelopeClient = {
+    businessContext: { findUnique },
+    decisionPerspectiveProfile: { updateMany },
+  };
+  return { db, updateMany };
+}
+
+describe("applyRiskEnvelopeToOrgProfile", () => {
+  it("writes the conservative policy scoped to the org's organization profile", async () => {
+    const { db, updateMany } = fakeDb("conservative");
+    await applyRiskEnvelopeToOrgProfile({ organizationId: "org-1", db });
+
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    const arg = updateMany.mock.calls[0]![0] as UpdateManyArg;
+    expect(arg.where).toEqual({ ownerOrganizationId: "org-1", kind: "organization" });
+    expect(arg.data.autonomyPolicy.allowArbitration).toBe(false);
+    expect(arg.data.autonomyPolicy.minimumConfidenceForArbitration).toBe(0.95);
+  });
+
+  it("writes the balanced identity policy when posture is unset", async () => {
+    const { db, updateMany } = fakeDb(null);
+    await applyRiskEnvelopeToOrgProfile({ organizationId: "org-1", db });
+
+    const arg = updateMany.mock.calls[0]![0] as UpdateManyArg;
+    expect(arg.data.autonomyPolicy).toEqual({
+      allowRecommendation: true,
+      allowArbitration: false,
+      maxRiskForArbitration: "low",
+      minimumConfidenceForRecommendation: 0.55,
+      minimumConfidenceForArbitration: 0.9,
+    });
+  });
+
+  it("is fail-open — swallows db errors and never throws", async () => {
+    const db: ApplyRiskEnvelopeClient = {
+      businessContext: {
+        findUnique: vi.fn(async (_args: unknown) => {
+          throw new Error("boom");
+        }),
+      },
+      decisionPerspectiveProfile: { updateMany: vi.fn(async (_args: unknown) => ({ count: 0 })) },
+    };
+    await expect(
+      applyRiskEnvelopeToOrgProfile({ organizationId: "org-1", db }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/lib/onboarding/apply-risk-envelope-to-profile.ts
+++ b/apps/web/lib/onboarding/apply-risk-envelope-to-profile.ts
@@ -1,0 +1,43 @@
+import { prisma } from "@dpf/db";
+import { resolveRiskEnvelope, riskEnvelopeToAutonomyPolicy } from "@/lib/govern/risk-posture";
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type ApplyRiskEnvelopeClient = {
+  businessContext: { findUnique: (args: unknown) => Promise<unknown> };
+  decisionPerspectiveProfile: { updateMany: (args: unknown) => Promise<{ count: number }> };
+};
+
+/**
+ * Wire the org's risk posture into its decision-perspective autonomy policy
+ * (EP-ONBOARDING-INTAKE P1). Reads BusinessContext.riskPosture, maps it to a
+ * DecisionAutonomyPolicy (balanced == the policy the org WWWD profile is seeded
+ * with today, so existing installs are unchanged), and writes it onto the org's
+ * `kind="organization"` profile — the policy the decision-perspective evaluator
+ * reads to gate how autonomously coworkers may act.
+ *
+ * Runs after seedRiskPosture (posture set) and seedOrgWwwdCorpus (profile
+ * created). Idempotent (same posture -> same policy) and fail-open (onboarding
+ * completion and a posture edit must never block on it). `updateMany` makes a
+ * missing profile a 0-row no-op rather than a throw.
+ */
+export async function applyRiskEnvelopeToOrgProfile(input: {
+  organizationId: string;
+  db?: ApplyRiskEnvelopeClient;
+}): Promise<void> {
+  const db = input.db ?? (prisma as unknown as ApplyRiskEnvelopeClient);
+  try {
+    const bc = (await db.businessContext.findUnique({
+      where: { organizationId: input.organizationId },
+      select: { riskPosture: true },
+    })) as { riskPosture: string | null } | null;
+
+    const policy = riskEnvelopeToAutonomyPolicy(resolveRiskEnvelope(bc?.riskPosture ?? null));
+
+    await db.decisionPerspectiveProfile.updateMany({
+      where: { ownerOrganizationId: input.organizationId, kind: "organization" },
+      data: { autonomyPolicy: policy },
+    });
+  } catch (err) {
+    console.warn("[setup] risk-envelope -> autonomy-policy wiring failed (fail-open):", err);
+  }
+}

--- a/apps/web/lib/onboarding/seed-risk-posture.ts
+++ b/apps/web/lib/onboarding/seed-risk-posture.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@dpf/db";
+import { deriveRiskPostureDefault } from "@/lib/govern/risk-posture";
+
+/**
+ * Seed the org-wide risk-posture default at setup completion (EP-ONBOARDING-INTAKE
+ * P0). Derives from the chosen archetype category (the canonical industry per
+ * AGENTS.md §2) + card-handling, mirroring INDUSTRY_RETENTION_FLOORS.
+ *
+ * Seed-once / idempotent: writes only when no posture is set yet, or when the
+ * stored value is still the machine-derived default (source="industry-default").
+ * An operator's explicit choice (source="operator") is never overwritten — so a
+ * posture confirmed/changed at the business-context step survives, while a
+ * default left untouched is re-derived against the archetype the operator
+ * actually picked later in the flow.
+ *
+ * Inert in P0: nothing reads the value until P1 wires the consumers. Fail-open —
+ * returns quietly on any error so onboarding completion never blocks.
+ */
+export async function seedRiskPosture({
+  organizationId,
+}: {
+  organizationId: string;
+}): Promise<void> {
+  try {
+    const bc = await prisma.businessContext.findUnique({
+      where: { organizationId },
+      select: {
+        riskPosture: true,
+        riskPostureSource: true,
+        handlesCardPayments: true,
+        industry: true,
+      },
+    });
+    if (!bc) return;
+    // Respect an operator's explicit choice; only (re)seed the derived default.
+    if (bc.riskPosture && bc.riskPostureSource !== "industry-default") return;
+
+    const storefront = await prisma.storefrontConfig.findFirst({
+      where: { organizationId },
+      select: { archetype: { select: { category: true } } },
+    });
+
+    const { posture, source } = deriveRiskPostureDefault({
+      archetypeCategory: storefront?.archetype?.category ?? null,
+      industry: bc.industry,
+      handlesCardPayments: bc.handlesCardPayments,
+    });
+
+    // No-op when the derived value already matches what's stored.
+    if (bc.riskPosture === posture && bc.riskPostureSource === source) return;
+
+    await prisma.businessContext.update({
+      where: { organizationId },
+      data: {
+        riskPosture: posture,
+        riskPostureSource: source,
+        riskPostureCapturedAt: new Date(),
+      },
+    });
+  } catch (err) {
+    console.warn("[setup] risk-posture seeding failed (fail-open):", err);
+  }
+}

--- a/docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p0.md
+++ b/docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p0.md
@@ -1,0 +1,50 @@
+# Plan — Onboarding Intake P0: risk-posture home (dark/inert)
+
+**Date:** 2026-06-20
+**Epic:** EP-ONBOARDING-INTAKE · **BI:** BI-527E5C40
+**Spec:** [`docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md`](../specs/2026-06-20-onboarding-intake-derivation-design.md) §5
+**Status:** Implemented (this PR)
+
+## Goal
+
+Give org-wide **risk posture** a typed home (today `riskAppetite`/`riskTolerance`/`riskPosture` exist in zero files) and derive a conservative **default from industry**, mirroring `INDUSTRY_RETENTION_FLOORS`. Ship **dark/inert**: capture + derive + store only — no consumer reads it yet (that is P1).
+
+## Design decisions
+
+- **Home = `BusinessContext`** (kernel-consulted, no commandment conflict): the canonical 1:1 per-org business-profile model already seeded at onboarding and feeding WWWD. A new governance table would be a parallel doctrine home (violates single-source-of-truth); a Json blob violates strongly-typed-enums.
+- **One stored knob + read-time envelope.** Store only `riskPosture` (+ source + capturedAt); `resolveRiskEnvelope()` maps posture → envelope at read time (no stored derivation to drift).
+- **Industry can only raise caution.** `INDUSTRY_RISK_DEFAULTS` keys = the four regulated retention-floor industries → `conservative`; everything else → `balanced`. `progressive` is reachable only by explicit operator choice. Card-handling nudges balanced→conservative.
+- **Envelope ≠ live level.** Posture sets the autonomy *ceiling + maturation rate*; the autopilot trust dial still starts HITL-first and earns autonomy on evidence (reconciles with the trust-dial-maturation doctrine).
+- **Provenance protects intent.** The form sends `riskPosture` only when the operator actually changed it (→ `source="operator"`). An untouched default is left for setup completion to (re)derive against the archetype finally chosen (`source="industry-default"`), which the seed never overwrites once operator-set.
+
+## Change set
+
+| File | Change |
+|------|--------|
+| `packages/db/prisma/schema.prisma` | `BusinessContext.riskPosture` / `riskPostureSource` / `riskPostureCapturedAt` (nullable String/String/DateTime) |
+| `packages/db/prisma/migrations/20260620170000_add_business_context_risk_posture/migration.sql` | additive `ADD COLUMN` ×3 (no backfill — nullable) |
+| `apps/web/lib/govern/risk-posture.ts` | **new** pure module: `RISK_POSTURES` enum, `deriveRiskPostureDefault()`, `resolveRiskEnvelope()`, guards. Reuses `toFloorKey` (shared industry normaliser) |
+| `apps/web/lib/govern/risk-posture.test.ts` | **new** unit tests (derivation, aliases, card nudge, envelope, fail-open) |
+| `apps/web/lib/onboarding/seed-risk-posture.ts` | **new** seed-once/idempotent default at setup completion; fail-open |
+| `apps/web/lib/actions/setup-progress.ts` | call `seedRiskPosture()` in `finalizeSetupCompletion()` |
+| `apps/web/app/api/business-context/setup/route.ts` | accept + validate + persist `riskPosture` (operator provenance); GET already returns it |
+| `apps/web/components/admin/BusinessContextForm.tsx` | one plain 3-way control (canonical values, plain-language labels), edited-gated submit |
+| `apps/web/app/(shell)/storefront/settings/business/page.tsx` | pre-set `initial.riskPosture` = stored ?? derived default |
+
+## Inert guarantee
+
+No runtime path imports `riskPosture` / `resolveRiskEnvelope` to change behaviour — the column is captured + seeded only. Existing BusinessContext upserts (storefront setup, etc.) leave the nullable field untouched. Verified by: `resolveRiskEnvelope` and the new column have no non-test importers outside this slice.
+
+## Surface-refactoring note
+
+Surfaces are in flux (operator-console / nav-coherence work). The only surface-coupled piece is the one form control; it is built on the existing inline-options + chip pattern (like `COMPANY_SIZE_OPTIONS`) and the canonical enum is decoupled from display labels, so the control relocates cleanly and the label wording is a trivial display tweak.
+
+## Verification
+
+- Unit: `vitest run apps/web/lib/govern/risk-posture.test.ts` (pure functions).
+- Build/typecheck + migration apply: via the shared local-CI convergence sandbox / canonical install (worktree is source-control isolation, AGENTS.md §5).
+- UX-fit: `UX-Fit-Decision` attestation in the PR (progressive disclosure; one plain choice, no numeric knob).
+
+## Next (not this PR)
+
+P1 (BI-E0E977BC) wires the envelope into the trust dial, `AgentGovernanceProfile` seed, self-upgrade window, capability auto-activation, outbound strictness, edge deploy.

--- a/docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p1.md
+++ b/docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p1.md
@@ -1,0 +1,53 @@
+# Plan — Onboarding Intake P1: wire the risk envelope (autonomy keystone)
+
+**Date:** 2026-06-20
+**Epic:** EP-ONBOARDING-INTAKE · **BI:** BI-E0E977BC
+**Spec:** [`docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md`](../specs/2026-06-20-onboarding-intake-derivation-design.md) §5.5
+**Predecessor:** P0 (BI-527E5C40, PR #2213 merged) — the risk-posture home + envelope.
+**Status:** Keystone implemented (this PR); operational knobs sequenced to P1.2.
+
+## Goal
+
+Make the risk posture stop being inert: project it into the platform's **autonomy** behaviour. P1's headline consumer is the decision-perspective evaluator — the live "trust dial" that gates how autonomously a coworker may act.
+
+## Why keystone-first (scope decision)
+
+The spec lists six consumers. Mapping the substrate (two parallel reads) showed they are not equal:
+
+| Consumer | Current default | Risk to wire | Decision |
+|----------|-----------------|--------------|----------|
+| **Decision-perspective autonomyPolicy** (the live autonomy gate) | org WWWD profile seeded `{allowArbitration:false, maxRiskForArbitration:"low", minRec:0.55, minArb:0.9}` | LOW — single clean seed point (`seedOrgWwwdCorpus`), evaluator already reads it | **This PR (keystone)** |
+| Self-upgrade window width | binary store-closed, no width knob | LOW, but adds a `SelfUpgradeConfig` field + margin logic | P1.2 |
+| Capability auto-activate `recommended` | recommended = asked/opt-in (off) | LOW (`autoActivateRecommended` param through `resolveCapabilityActivation`) | P1.2 |
+| Edge-node deploy default | `hidden` in base capability map | LOW (one override) | P1.2 |
+| AgentGovernanceProfile defaults | no seed default (manual assignment) | LOW but low-yield (rarely auto-assigned) | P1.2 |
+| Outbound-send confirmation strictness | hard kernel principle (`outbound-actions-require-explicit-go`) | **HIGH/DIFFUSE** — principle-layer, no org knob; wiring risks audit-trail ambiguity | **Deferred** (kernel-hardening pass; not wired) |
+
+The autonomy gate is the consequential, highest-value piece and is the one that actually changes "how autonomous are the agents." It deserves focused, correct delivery (the worktree is source-only, so the change is verified in CI). The operational knobs are additive, independent, and safe to land incrementally.
+
+## The keystone wiring
+
+The org's own `DecisionPerspectiveProfile` (`kind="organization"`, seeded by `seedOrgWwwdCorpus` as `org-perspective-<orgId>`) carries an `autonomyPolicy` Json that `apps/web/lib/decision-perspective/evaluator.ts` reads to decide escalate vs recommend vs arbitrate. We derive that policy from the posture.
+
+- `apps/web/lib/govern/risk-posture.ts` → `riskEnvelopeToAutonomyPolicy(envelope)`: pure map posture → `DecisionAutonomyPolicy`.
+  - **balanced = the exact seed default** (`allowArbitration:false, maxRiskForArbitration:"low", minRec:0.55, minArb:0.9`) — pinned by a test; existing installs unchanged.
+  - **conservative** tightens only: never arbitrate, higher confidence floors (0.65 / 0.95).
+  - **progressive** loosens within bounds: arbitrate low+medium risk at high confidence (0.5 / 0.8). High/critical-risk decisions **always escalate** regardless (an unconditional rule in the evaluator), so no posture can make an agent reckless.
+- `apps/web/lib/onboarding/apply-risk-envelope-to-profile.ts` → `applyRiskEnvelopeToOrgProfile({ organizationId })`: reads `BusinessContext.riskPosture`, maps it, `updateMany`s the org profile's `autonomyPolicy` (missing profile = 0-row no-op). Idempotent + fail-open.
+- Wired at `finalizeSetupCompletion()` **after** `seedRiskPosture` (posture set) and `seedOrgWwwdCorpus` (profile created).
+- Wired in the business-context API so an operator changing the posture re-projects the policy immediately (stays live, not just at setup).
+
+## Safety properties
+
+- **No regression:** balanced is the identity (test-pinned to the seed default).
+- **Monotonic:** conservative ≤ balanced ≤ progressive in autonomy (test-asserted).
+- **Bounded:** high/critical-risk always escalates regardless of posture (evaluator invariant, unchanged).
+- **Fail-open:** the wiring never blocks onboarding completion or a posture edit.
+
+## Verification
+
+- Unit: `risk-posture.test.ts` (balanced-identity, monotonicity) + `apply-risk-envelope-to-profile.test.ts` (writes correct policy, fail-open). Source-only worktree → compile/build/test gates run in CI.
+
+## P1.2 (follow-on BI)
+
+Operational knobs — self-upgrade window width, capability `recommended` auto-activate, edge-deploy default, AgentGovernanceProfile seed default — each balanced=no-change. Outbound-send strictness stays **deferred** to a kernel-hardening pass (principle-layer org-override design), not wired here.

--- a/docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md
+++ b/docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md
@@ -292,14 +292,14 @@ Each phase is independently shippable and maps to a BI under `EP-ONBOARDING-INTA
 
 | Phase | Title | Scope | Extends |
 |-------|-------|-------|---------|
-| **P0** | **Risk posture home + industry default** | `BusinessContext.riskPosture` (+source/capturedAt) migration; `resolveRiskEnvelope()`; industry-default derivation; seed at `finalizeSetupCompletion()`; one plain choice in step 4 pre-set to the derived default. *No consumers wired yet — inert, observable.* | — |
-| **P1** | **Risk envelope → consumers** | Wire the envelope into trust-dial initial position, `AgentGovernanceProfile` seed defaults, self-upgrade window width, capability auto-activate threshold, outbound strictness, edge-deploy default. | autopilot trust dial |
+| **P0 ✅ shipped** | **Risk posture home + industry default** | `BusinessContext.riskPosture` (+source/capturedAt) migration; `resolveRiskEnvelope()`; industry-default derivation; seed at `finalizeSetupCompletion()`; one plain choice in step 4 pre-set to the derived default. Inert. | — |
+| **P1 ◑ keystone shipped** | **Risk envelope → autonomy gate** | **Keystone (done):** `riskEnvelopeToAutonomyPolicy()` → the org WWWD profile's `autonomyPolicy` (the live decision-perspective evaluator gate); balanced = today's seed default exactly. **P1.2 (BI-E93A3437):** self-upgrade window width, capability auto-activate, edge-deploy default, AgentGovernanceProfile seed default (each balanced=no-change). **Deferred:** outbound-send strictness (hard kernel principle — needs an org-override design, not wired). | autopilot trust dial |
 | **P2** | **Trust & safety panel** | In-context panel at sensitive capture; disposition/sovereignty-backed per-field; disk-encryption capture → CADA input; live CADA-level readout. | `sovereignty-assessment` / CADA |
 | **P3** | **Accounting lane onboarding wiring** | Optional "Connect your books" step; readiness-descriptor surface; confirm-gated pre-fill of legal name/tax/bank-metadata/roster-counts; stage-not-import. | `EP-SBO` (QuickBooks anchor) |
 | **P4** | **Document lane** | Formation/EIN/return/roster-CSV/statement upload → parse → map → confirm → fan out. Wire bulk-roster import (BI-INT-F23BC6). | file-parsers; bulk-import spec |
 | **P5** | **Intake orchestration + conversational accelerator** | Formalise the Derive→Ingest→Confirm→Ask spine as a unified intake controller; optional COO conversational lane over the same confirm gate. | setup-unification |
 
-**P0 is the recommended first "go"** — smallest self-contained slice that fills the biggest gap, ships inert (dark) so it's safe, and unblocks every other phase.
+**Status:** P0 + P1 keystone (the autonomy-gate wiring) shipped. Plans: [`…risk-posture-p0.md`](plans/2026-06-20-onboarding-risk-posture-p0.md), [`…risk-posture-p1.md`](plans/2026-06-20-onboarding-risk-posture-p1.md). P1.2 (operational knobs, BI-E93A3437) and the deferred outbound-strictness work are filed follow-ons.
 
 ---
 

--- a/packages/db/prisma/migrations/20260620170000_add_business_context_risk_posture/migration.sql
+++ b/packages/db/prisma/migrations/20260620170000_add_business_context_risk_posture/migration.sql
@@ -1,0 +1,9 @@
+-- EP-ONBOARDING-INTAKE P0: org-wide risk posture home on BusinessContext.
+-- Structured companion to the prose howWeDecide WWWD stance. Industry sets a
+-- conservative default (deriveRiskPostureDefault, mirroring INDUSTRY_RETENTION_FLOORS);
+-- the operator may override. Sets the autonomy envelope (ceiling + maturation
+-- rate), not the live autonomy level. Additive + nullable — no backfill needed;
+-- existing installs seed a default at next setup completion. Consumers wired in P1.
+ALTER TABLE "BusinessContext" ADD COLUMN "riskPosture" TEXT;
+ALTER TABLE "BusinessContext" ADD COLUMN "riskPostureSource" TEXT;
+ALTER TABLE "BusinessContext" ADD COLUMN "riskPostureCapturedAt" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2931,6 +2931,21 @@ model BusinessContext {
   // computation when null.
   portfolioDecomposition Json?
 
+  // ─── Risk posture (EP-ONBOARDING-INTAKE P0) ─────────────────────────────────
+  // Org-wide autonomy/risk appetite — the structured companion to the prose
+  // howWeDecide WWWD stance. Industry sets a conservative DEFAULT
+  // (deriveRiskPostureDefault, mirroring INDUSTRY_RETENTION_FLOORS); the operator
+  // may override. Sets the autonomy ENVELOPE (ceiling + maturation rate), not the
+  // live autonomy level: the autopilot trust dial still starts HITL-first and
+  // earns autonomy on evidence. Values: conservative | balanced | progressive.
+  // Read via resolveRiskEnvelope() (apps/web/lib/govern/risk-posture.ts).
+  // Consumers wired in P1; this column is the inert home seeded at setup.
+  riskPosture           String?
+  // Provenance: "industry-default" (machine-derived) or "operator" (chosen).
+  riskPostureSource     String?
+  // When the operator last confirmed/changed the posture.
+  riskPostureCapturedAt DateTime?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
Lands the risk-posture **P0 code** and the **P1 autonomy-gate keystone** together.

## Why P0 code is here (not already on main)
PR [#2213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2213) squash-merged the **design spec only** — the P0 *code* commit landed on the branch that was deleted at merge and was never re-PR'd, so `main` has the spec but not the code. Meanwhile the **address-capture feature** ([#2208](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2208)) since modified the same files. This PR re-lands P0 cleanly merged with that feature, and adds P1.

## P0 — risk-posture home
Org-wide risk posture had **no home** (`riskAppetite`/`riskTolerance`/`riskPosture` = zero files). Adds `BusinessContext.riskPosture` (+migration), `deriveRiskPostureDefault()` (mirrors `INDUSTRY_RETENTION_FLOORS`), `resolveRiskEnvelope()`, a setup seed, and one plain onboarding control (Cautious / Balanced / Fast-moving).

## P1 — wire the envelope into the live autonomy gate (keystone)
The "trust dial" in practice is the **decision-perspective evaluator**, which reads the org WWWD profile's `autonomyPolicy` to gate escalate/recommend/arbitrate. P1:
- `riskEnvelopeToAutonomyPolicy()` maps posture → that policy. **Balanced is the identity** — equals `seed-org-wwwd-corpus` `DEFAULT_AUTONOMY_POLICY` exactly (**test-pinned**), so existing installs are unchanged. Conservative only tightens; progressive only loosens within bounds. **High/critical-risk always escalates regardless** (an unconditional evaluator rule), so no posture can make an agent reckless.
- `applyRiskEnvelopeToOrgProfile()` projects it at setup completion + on operator posture change. Idempotent, fail-open.

## Safety
- **No regression:** balanced = today's exact seed default (test-pinned).
- **Monotonic:** conservative ≤ balanced ≤ progressive (test-asserted).
- **Bounded + fail-open.**

## Sequenced / deferred
- **P1.2 (BI-E93A3437):** operational knobs — self-upgrade window width, capability auto-activate, edge-deploy default, AgentGovernanceProfile seed default (each balanced=no-change).
- **Deferred:** outbound-send strictness (hard kernel principle; needs its own org-override design).

## Notes
- Authored in a **source-only worktree** → compile/typecheck/build/migration/unit gates run in **CI**. Pre-commit ran gitleaks + schema-regression guard (clean).
- `UX-Fit-Decision` attestation in the commit; Spec/Plan/Doc gate satisfied (spec + two plans).
- Surfaces in flux: the only surface-coupled piece is the one form control, on the existing chip pattern, enum decoupled from labels → relocates cleanly.

Spec: [design](docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md) · Plans: [P0](docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p0.md), [P1](docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p1.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)