### PR TITLE
feat(portfolio): archetype supplier/goods projector (BI-PORTCOV-P5)

### DIFF
--- a/apps/web/lib/actions/setup-progress.test.ts
+++ b/apps/web/lib/actions/setup-progress.test.ts
@@ -16,6 +16,7 @@ vi.mock("@dpf/db", () => ({
       findFirst: vi.fn(),
     },
   },
+  projectArchetypeSupply: vi.fn(),
 }));
 
 import { prisma } from "@dpf/db";

--- a/apps/web/lib/actions/setup-progress.ts
+++ b/apps/web/lib/actions/setup-progress.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { prisma } from "@dpf/db";
+import { prisma, projectArchetypeSupply } from "@dpf/db";
 import { SETUP_STEPS, type SetupStep, type StepStatus, type SetupContext } from "./setup-constants";
 import { seedOrgWwwdCorpus } from "@/lib/onboarding/seed-org-wwwd-corpus";
 import { seedPortfolioDecomposition } from "@/lib/onboarding/seed-portfolio-decomposition";
@@ -34,6 +34,7 @@ async function finalizeSetupCompletion(organizationId: string | null): Promise<v
     await seedOrgWwwdCorpus({ organizationId: orgId });
     await seedPortfolioDecomposition({ organizationId: orgId });
     await seedMarketOffer({ organizationId: orgId });
+    await projectArchetypeSupply({ organizationId: orgId });
     await seedRiskPosture({ organizationId: orgId });
     // P1: project the seeded posture onto the org WWWD profile's autonomy policy
     // (runs after the profile exists + the posture is set; balanced = no change).

--- a/docs/superpowers/specs/2026-06-21-portfolio-coverage-multisource-projection-design.md
+++ b/docs/superpowers/specs/2026-06-21-portfolio-coverage-multisource-projection-design.md
@@ -174,7 +174,7 @@ Ordered by dependency; each filed via the governed path (size → triage → lin
 - **P2 — Integration projector + seed the catalog.** Seed `McpIntegration` from the benchmark metadata; project credentials (`available`/`used`) + catalog (`potential`), category-routed, with pricing. *(large)*
 - **P3 — AI-provider projector → Foundational.** Configured = `used`, catalogued = `potential`; local-first surfaces Docker Model Runner. *(medium)*
 - **P4 — SBOM component projector.** Project `BomComponent` as the component layer of `dpf-meta`/`dpf-platform-standard` with supplier/license/PURL + paid flag; compose with EP-ASSURANCE-LEDGER. *(medium)*
-- **P5 — Archetype supplier/goods projector.** Extend `seed-market-offer.ts` with suppliers (vendor_management) + goods; plumber exemplar. *(medium)*
+- **P5 — Archetype supplier/goods projector.** Extend `seed-market-offer.ts` with suppliers (vendor_management) + goods; plumber exemplar. *(medium)* — **landed**: `packages/db/src/portfolio-sources/archetype-supply-manifest.ts` (per-category starters) + `project-archetype-supply.ts` (reuses the projector writer), wired into onboarding `setup-progress.ts` alongside `seedMarketOffer`. Suppliers → Manufacturing & Delivery (`used`), goods → Products & Services Sold (`sold`), source `archetype`; non-destructive + idempotent.
 - **P6 — Coverage surface UX.** Coverage filter/legend + provenance chip + "Enable" deep-link on `potential` rows; UX-fit gated; no new route. *(medium)*
 - **P7 — Coverage/source parity guard.** A test asserting the projected portfolio stays in sync with the live substrates (mirrors the EP-SCHEDULING-SURFACE catalog↔registry parity guard) — so a new integration/capability/dependency can't silently fall out of the portfolio. *(small)*
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -272,6 +272,7 @@ export * from "./discovery-fingerprint-rules";
 export * from "./discovery-mac-classification";
 export * from "./discovery-fingerprint-observation";
 export * from "./device-placement";
+export * from "./portfolio-sources";
 export * from "./device-investigation";
 export * from "./device-fingerprint-contribution";
 export * from "./hive-contribution-settings";

--- a/packages/db/src/portfolio-sources/archetype-supply-manifest.ts
+++ b/packages/db/src/portfolio-sources/archetype-supply-manifest.ts
@@ -1,0 +1,111 @@
+// Per-archetype-category starter suppliers + goods (BI-PORTCOV-P5; spec §4.4.5).
+//
+// seed-market-offer.ts already seeds the SERVICES an archetype sells into
+// Products & Services Sold. This manifest adds the buy-side and the goods-side
+// the archetype implies but never seeds: the SUPPLIERS a business manages to
+// deliver (a plumber's trade merchants — "a missing part means a second trip")
+// and the GOODS it sells distinct from its services. These are broad, true,
+// EDITABLE starters keyed by archetype category — the same day-one-understanding
+// discipline as archetype-business-context.ts; the operator refines them.
+//
+// Categories with no starter are simply not seeded (the projector no-ops), so
+// adding a category here is purely additive.
+
+import type { ArchetypeCategory } from "@dpf/storefront-templates";
+
+export interface ArchetypeSupplyItem {
+  name: string;
+  description: string;
+}
+
+export interface ArchetypeSupplyStarter {
+  /** Vendors the business manages to deliver — projected into Manufacturing & Delivery (coverage=used). */
+  suppliers: ArchetypeSupplyItem[];
+  /** Physical goods sold, distinct from services — projected into Products & Services Sold (coverage=sold). */
+  goods: ArchetypeSupplyItem[];
+}
+
+export const ARCHETYPE_SUPPLY_MANIFEST: Partial<
+  Record<ArchetypeCategory, ArchetypeSupplyStarter>
+> = {
+  "trades-maintenance": {
+    suppliers: [
+      {
+        name: "Trade Merchants & Wholesalers",
+        description:
+          "Parts and materials suppliers (plumbing/electrical/HVAC merchants). Much is carried as van stock so common jobs are first-visit fixes; matching parts to the day's jobs is the discipline.",
+      },
+      { name: "Tool & Equipment Hire", description: "Hire of specialist tools and plant for larger jobs." },
+      { name: "PPE & Safety Supplier", description: "Personal protective equipment and site-safety consumables." },
+    ],
+    goods: [
+      {
+        name: "Parts & Materials (van stock)",
+        description: "Parts and fittings supplied and billed alongside labour — the goods side of a service call.",
+      },
+      { name: "Fixtures & Fittings", description: "Customer-selected fixtures supplied as part of an installation." },
+    ],
+  },
+  "retail-goods": {
+    suppliers: [
+      { name: "Wholesale Distributor", description: "Primary supplier of merchandise inventory for resale." },
+      { name: "Dropship Supplier", description: "Supplier fulfilling orders directly to the customer without held stock." },
+      { name: "Packaging & Fulfilment Supplier", description: "Packaging materials and fulfilment consumables." },
+    ],
+    goods: [
+      { name: "Retail Merchandise", description: "The sold-inventory product lines — the core of a goods business." },
+    ],
+  },
+  "food-hospitality": {
+    suppliers: [
+      { name: "Food & Beverage Wholesaler", description: "Core supplier of ingredients, drinks, and kitchen consumables." },
+      { name: "Fresh Produce Supplier", description: "Perishable produce on a frequent delivery cadence." },
+    ],
+    goods: [
+      { name: "Menu Items & Packaged Food", description: "Prepared and packaged food sold to customers." },
+    ],
+  },
+  "automotive-services": {
+    suppliers: [
+      { name: "Auto Parts Distributor", description: "VIN-to-part parts supply for repairs and replacements." },
+      { name: "Fluids & Consumables Supplier", description: "Oils, fluids, and shop consumables." },
+    ],
+    goods: [
+      { name: "Replacement Parts", description: "Parts supplied and billed with the service." },
+    ],
+  },
+  "moving-and-logistics": {
+    suppliers: [
+      { name: "Packing Materials Supplier", description: "Boxes, wrap, and protective materials for moves." },
+      { name: "Fleet Fuel & Maintenance", description: "Fuel and vehicle maintenance keeping the crew+truck running." },
+    ],
+    goods: [
+      { name: "Packing Supplies (sold)", description: "Boxes and materials sold to customers ahead of a move." },
+    ],
+  },
+  "beauty-personal-care": {
+    suppliers: [
+      { name: "Salon Products Distributor", description: "Professional-use products and back-bar supply." },
+    ],
+    goods: [
+      { name: "Retail Hair & Skin Products", description: "Take-home products sold to clients." },
+    ],
+  },
+  "pet-services": {
+    suppliers: [
+      { name: "Pet Food & Supplies Distributor", description: "Food, treats, and supplies for service delivery and resale." },
+    ],
+    goods: [
+      { name: "Retail Pet Products", description: "Food, toys, and accessories sold to owners." },
+    ],
+  },
+  "asset-rental": {
+    suppliers: [
+      { name: "Equipment Manufacturer / Distributor", description: "Source of the rental fleet assets." },
+      { name: "Maintenance & Parts Supplier", description: "Spares and servicing that keep pooled assets rentable." },
+    ],
+    goods: [
+      { name: "Consumables & Accessories", description: "Consumables and accessories sold alongside a rental." },
+    ],
+  },
+};

--- a/packages/db/src/portfolio-sources/index.ts
+++ b/packages/db/src/portfolio-sources/index.ts
@@ -5,3 +5,5 @@
 export * from "./types";
 export * from "./platform-capability-manifest";
 export * from "./project-portfolio-source";
+export * from "./archetype-supply-manifest";
+export * from "./project-archetype-supply";

--- a/packages/db/src/portfolio-sources/project-archetype-supply.test.ts
+++ b/packages/db/src/portfolio-sources/project-archetype-supply.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+
+import { ARCHETYPE_SUPPLY_MANIFEST } from "./archetype-supply-manifest";
+import {
+  projectArchetypeSupply,
+  type ProjectArchetypeSupplyClient,
+} from "./project-archetype-supply";
+import { PORTFOLIO_PROJECTION_KEYS, PROJECTED_BY } from "./types";
+
+type ProductRow = {
+  id: string;
+  productId: string;
+  name: string;
+  description: string | null;
+  portfolioId: string | null;
+  taxonomyNodeId: string | null;
+  lifecycleStage: string;
+  lifecycleStatus: string;
+  observationConfig: unknown;
+};
+
+const ALL_PORTFOLIOS = [
+  "foundational",
+  "manufacturing_and_delivery",
+  "for_employees",
+  "products_and_services_sold",
+];
+
+function makeFakeDb(opts: {
+  archetypeId: string | null;
+  portfolios?: string[];
+}): ProjectArchetypeSupplyClient & { products: Map<string, ProductRow> } {
+  const portfolios = new Map(
+    (opts.portfolios ?? ALL_PORTFOLIOS).map((slug) => [slug, { id: `pf-${slug}` }]),
+  );
+  const products = new Map<string, ProductRow>();
+  let seq = 0;
+
+  return {
+    products,
+    storefrontConfig: {
+      findFirst: async () => ({ archetypeId: opts.archetypeId }),
+    },
+    portfolio: {
+      findUnique: async (args: unknown) => {
+        const slug = (args as { where: { slug: string } }).where.slug;
+        return portfolios.get(slug) ?? null;
+      },
+    },
+    taxonomyNode: {
+      findUnique: async () => null,
+    },
+    digitalProduct: {
+      findUnique: async (args: unknown) => {
+        const productId = (args as { where: { productId: string } }).where.productId;
+        const row = products.get(productId);
+        return row ? { id: row.id, observationConfig: row.observationConfig } : null;
+      },
+      create: async (args: unknown) => {
+        const data = (args as { data: Record<string, unknown> }).data;
+        const row: ProductRow = {
+          id: `dp-${seq++}`,
+          productId: data.productId as string,
+          name: (data.name as string) ?? "",
+          description: (data.description as string | null) ?? null,
+          portfolioId: (data.portfolioId as string | null) ?? null,
+          taxonomyNodeId: (data.taxonomyNodeId as string | null) ?? null,
+          lifecycleStage: (data.lifecycleStage as string) ?? "plan",
+          lifecycleStatus: (data.lifecycleStatus as string) ?? "draft",
+          observationConfig: data.observationConfig ?? null,
+        };
+        products.set(row.productId, row);
+        return row;
+      },
+      update: async (args: unknown) => {
+        const a = args as { where: { productId: string }; data: Record<string, unknown> };
+        const row = products.get(a.where.productId);
+        if (!row) throw new Error(`update: not found ${a.where.productId}`);
+        Object.assign(row, a.data);
+        return row;
+      },
+    },
+  };
+}
+
+describe("ARCHETYPE_SUPPLY_MANIFEST", () => {
+  it("covers the plumber's trades-maintenance category with suppliers + goods", () => {
+    const trades = ARCHETYPE_SUPPLY_MANIFEST["trades-maintenance"];
+    expect(trades).toBeTruthy();
+    expect(trades!.suppliers.length).toBeGreaterThan(0);
+    expect(trades!.suppliers.some((s) => /merchant|wholesal/i.test(s.name))).toBe(true);
+    expect(trades!.goods.length).toBeGreaterThan(0);
+  });
+
+  it("every starter item has a non-empty name", () => {
+    for (const starter of Object.values(ARCHETYPE_SUPPLY_MANIFEST)) {
+      for (const item of [...starter!.suppliers, ...starter!.goods]) {
+        expect(item.name.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("projectArchetypeSupply", () => {
+  it("projects plumber suppliers → Manufacturing & Delivery and goods → Products & Services Sold", async () => {
+    const db = makeFakeDb({ archetypeId: "plumber" });
+    const res = await projectArchetypeSupply({ organizationId: "org-1", db });
+
+    expect(res.archetypeId).toBe("plumber");
+    expect(res.created).toBeGreaterThan(0);
+
+    const suppliers = [...db.products.values()].filter((p) => p.productId.startsWith("sup-org-1-"));
+    expect(suppliers.length).toBeGreaterThan(0);
+    expect(suppliers.every((r) => r.portfolioId === "pf-manufacturing_and_delivery")).toBe(true);
+    const supCfg = suppliers[0].observationConfig as Record<string, string>;
+    expect(supCfg[PORTFOLIO_PROJECTION_KEYS.sourceKind]).toBe("archetype");
+    expect(supCfg[PORTFOLIO_PROJECTION_KEYS.coverageStatus]).toBe("used");
+    expect(supCfg[PORTFOLIO_PROJECTION_KEYS.projectedBy]).toBe(PROJECTED_BY);
+
+    const goods = [...db.products.values()].filter((p) => p.productId.startsWith("good-org-1-"));
+    expect(goods.length).toBeGreaterThan(0);
+    expect(goods.every((r) => r.portfolioId === "pf-products_and_services_sold")).toBe(true);
+    expect((goods[0].observationConfig as Record<string, string>)[PORTFOLIO_PROJECTION_KEYS.coverageStatus]).toBe("sold");
+  });
+
+  it("no-ops when the org has no archetype", async () => {
+    const db = makeFakeDb({ archetypeId: null });
+    const res = await projectArchetypeSupply({ organizationId: "org-1", db });
+    expect(res.archetypeId).toBeNull();
+    expect(res.created).toBe(0);
+    expect(db.products.size).toBe(0);
+  });
+
+  it("no-ops for an archetype with no starter manifest", async () => {
+    const db = makeFakeDb({ archetypeId: "does-not-exist-xyz" });
+    const res = await projectArchetypeSupply({ organizationId: "org-1", db });
+    expect(res.archetypeId).toBe("does-not-exist-xyz");
+    expect(res.created).toBe(0);
+    expect(db.products.size).toBe(0);
+  });
+
+  it("is idempotent — re-projection updates owned rows and creates no duplicates", async () => {
+    const db = makeFakeDb({ archetypeId: "plumber" });
+    await projectArchetypeSupply({ organizationId: "org-1", db });
+    const sizeAfterFirst = db.products.size;
+
+    const second = await projectArchetypeSupply({ organizationId: "org-1", db });
+    expect(second.created).toBe(0);
+    expect(second.updated).toBeGreaterThan(0);
+    expect(db.products.size).toBe(sizeAfterFirst);
+  });
+});

--- a/packages/db/src/portfolio-sources/project-archetype-supply.ts
+++ b/packages/db/src/portfolio-sources/project-archetype-supply.ts
@@ -1,0 +1,94 @@
+// Archetype supplier/goods projector (BI-PORTCOV-P5; spec §4.4.5).
+//
+// Per-org, authoritative source: read the org's chosen archetype, look up its
+// category's starter suppliers/goods, and project them as portfolio entries —
+// suppliers into Manufacturing & Delivery (the supply chain managed to deliver,
+// coverage=used), goods into Products & Services Sold (distinct from services,
+// coverage=sold). Reuses the projectPortfolioEntries writer so coverage/source
+// markers and non-destructive behaviour are identical to the other projectors.
+// Idempotent and editable: re-running never clobbers operator-refined rows.
+//
+// Called at onboarding completion alongside seedMarketOffer (apps/web
+// setup-progress finalizeSetupCompletion).
+
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+
+import { prisma } from "../client";
+import { ARCHETYPE_SUPPLY_MANIFEST } from "./archetype-supply-manifest";
+import {
+  projectPortfolioEntries,
+  type ProjectPortfolioClient,
+  type ProjectPortfolioResult,
+} from "./project-portfolio-source";
+import type { ProjectedPortfolioEntry } from "./types";
+
+/** Structural client — the writer client plus the storefrontConfig read. */
+export type ProjectArchetypeSupplyClient = ProjectPortfolioClient & {
+  storefrontConfig: { findFirst: (args: unknown) => Promise<unknown> };
+};
+
+export type ProjectArchetypeSupplyInput = {
+  organizationId: string;
+  db?: ProjectArchetypeSupplyClient;
+};
+
+export type ProjectArchetypeSupplyResult = ProjectPortfolioResult & {
+  /** The archetype that drove the projection, or null when none is set. */
+  archetypeId: string | null;
+};
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const EMPTY = { total: 0, created: 0, updated: 0, skipped: 0 } as const;
+
+/**
+ * Project the org's archetype-implied suppliers + goods into the portfolio.
+ * No-op (archetypeId echoed) when the org has no archetype or the archetype's
+ * category has no starter manifest.
+ */
+export async function projectArchetypeSupply(
+  input: ProjectArchetypeSupplyInput,
+): Promise<ProjectArchetypeSupplyResult> {
+  const db = input.db ?? (prisma as unknown as ProjectArchetypeSupplyClient);
+
+  const sf = (await db.storefrontConfig.findFirst({
+    where: { organizationId: input.organizationId },
+    select: { archetypeId: true },
+  })) as { archetypeId: string | null } | null;
+
+  const archetypeId = sf?.archetypeId ?? null;
+  if (!archetypeId) return { ...EMPTY, archetypeId: null };
+
+  const def = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  const starter = def ? ARCHETYPE_SUPPLY_MANIFEST[def.category] : undefined;
+  if (!starter) return { ...EMPTY, archetypeId };
+
+  const entries: ProjectedPortfolioEntry[] = [
+    ...starter.suppliers.map((s) => ({
+      productId: `sup-${input.organizationId}-${slugify(s.name)}`,
+      name: s.name,
+      description: `${s.description} (archetype-seeded starter; refine as suppliers are confirmed).`,
+      portfolioSlug: "manufacturing_and_delivery" as const,
+      taxonomyNodeId: null,
+      coverageStatus: "used" as const,
+      sourceKind: "archetype" as const,
+    })),
+    ...starter.goods.map((g) => ({
+      productId: `good-${input.organizationId}-${slugify(g.name)}`,
+      name: g.name,
+      description: `${g.description} (archetype-seeded starter; refine as the catalog evolves).`,
+      portfolioSlug: "products_and_services_sold" as const,
+      taxonomyNodeId: null,
+      coverageStatus: "sold" as const,
+      sourceKind: "archetype" as const,
+    })),
+  ];
+
+  const result = await projectPortfolioEntries(entries, { db });
+  return { ...result, archetypeId };
+}


### PR DESCRIPTION
## Why

Continues the multi-source portfolio projection (spec [`2026-06-21-portfolio-coverage-multisource-projection-design.md`](docs/superpowers/specs/2026-06-21-portfolio-coverage-multisource-projection-design.md), **EP-BOM-WIRING**). P1 populated Manufacturing & Delivery + Foundational from the platform's own subsystems. **P5** adds the **buy-side and goods-side an archetype implies but never seeded**: `seedMarketOffer` already seeds the *services* a business sells; this seeds the **suppliers it manages to deliver** (a plumber's trade merchants — "a missing part means a second trip") and the **goods it sells** distinct from services.

Item: **BI-PORTCOV-P5**.

## What

- **`archetype-supply-manifest.ts`** — per-archetype-category editable starters (trades-maintenance, retail-goods, food-hospitality, automotive-services, moving-and-logistics, beauty-personal-care, pet-services, asset-rental). Categories without a starter simply no-op.
- **`project-archetype-supply.ts`** — reads the org's chosen archetype → its category's starters → projects **suppliers → Manufacturing & Delivery (`used`)** and **goods → Products & Services Sold (`sold`)**, `source=archetype`. Reuses the `projectPortfolioEntries` writer (idempotent, non-destructive, coverage/source markers in `observationConfig`). Mirrors the existing `archetype-value-stream-projection.ts` db-module pattern.
- Wired into onboarding (`setup-progress.ts` `finalizeSetupCompletion`) next to `seedMarketOffer`; exported from `@dpf/db`.
- Tests: manifest invariants + projector (plumber path, no-archetype no-op, unknown-archetype no-op, idempotent).

## Verification (local, pre-push)

Real gates this time (deps installed in-worktree):
- `@dpf/db` vitest `src/portfolio-sources` — **14 passed** (P1 + P5)
- `@dpf/db` typecheck — **clean**
- `web` `setup-progress` vitest — **13 passed**
- `web` typecheck (`next typegen && tsc --noEmit`) — **clean**
- pre-commit gate: gitleaks clean + scoped typecheck (apps/web + packages/db) ok

No migration (coverage/source ride in `observationConfig`, per the spec's staged plan; typed columns remain BI-PORTCOV-P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)