### PR TITLE
feat(quality): projection guard — hold self-fix escalations for the responder (BI-0ACD9AB2 Slice 1)

### DIFF
--- a/apps/web/lib/build/escalate-build-to-human.ts
+++ b/apps/web/lib/build/escalate-build-to-human.ts
@@ -11,9 +11,11 @@
 //   resume-restall forever. The honest outcome is to:
 //     1. CAPTURE a durable, human-facing escalation record (root cause, what was
 //        attempted, why blocked, and a self-fix-feasibility class);
-//     2. RAISE it to humans — reuse createPlatformIssueReport(), whose OPEN rows
-//        auto-project into the backlog/triage intake (EP-INTAKE-UNIFY), so the
-//        escalation surfaces without any new notification plumbing;
+//     2. RAISE it for attendance — reuse createPlatformIssueReport(). A self-fix
+//        escalation is born in awaiting_escalation_ack and HELD for the
+//        escalation responder (BI-0ACD9AB2 §5.2), NOT generic-projected into a
+//        BI: the responder consults WWMD/WWWD/WSID and escalates only the
+//        residue a human truly needs, so the signal is received, not drowned;
 //     3. FREE the WIP slot — mark the build abandoned (wip-cap counts only
 //        abandonedAt-null builds), so the jam clears;
 //     4. RE-QUEUE without re-stalling — park the originating backlog item as
@@ -48,9 +50,10 @@ export type SelfFixClass = (typeof SELF_FIX_CLASS)[keyof typeof SELF_FIX_CLASS];
 /** Minimal shape of a blocking review issue (structurally matches PlanReviewIssue). */
 export type EscalationIssue = { severity: string; description: string };
 
-/** Stable idempotency key — one open escalation per build (partial-unique on
- *  PlatformIssueReport.dedupeKey for open rows). Re-escalation while still open
- *  is a no-op; it can re-file once the prior escalation is resolved. */
+/** Stable idempotency key — one NON-RESOLVED escalation per build (partial-unique
+ *  on PlatformIssueReport.dedupeKey WHERE status NOT IN resolved/suppressed, so it
+ *  covers the awaiting_escalation_ack birth status). Re-escalation while one is
+ *  still open/awaiting is a no-op; it re-files once the prior one is resolved. */
 export function buildEscalationDedupeKey(buildId: string): string {
   return `build-escalation:${buildId}`;
 }
@@ -157,9 +160,10 @@ export async function escalateBuildToHuman(args: EscalateBuildArgs): Promise<Esc
     buildId, featureTitle, biTitle, phase, rounds, issues, selfFixClass,
   });
 
-  // 1. CAPTURE + RAISE — durable report; OPEN rows auto-project into intake.
-  //    Best-effort: a duplicate (partial-unique dedupeKey on open rows) or any
-  //    failure must not stop us freeing the WIP slot.
+  // 1. CAPTURE + RAISE — durable report. A self-fix escalation (selfFixClass set)
+  //    is born in awaiting_escalation_ack and held for the responder, NOT generic-
+  //    projected (BI-0ACD9AB2 §5.2). Best-effort: a duplicate (per-dedupeKey "one
+  //    non-resolved report" partial-unique) or any failure must not stop WIP free-up.
   let reportId: string | null = null;
   try {
     const r = await createPlatformIssueReport({

--- a/apps/web/lib/operate/issue-report-triage-runner.ts
+++ b/apps/web/lib/operate/issue-report-triage-runner.ts
@@ -60,6 +60,7 @@ export async function runIssueReportTriage(opts: { reportId?: string } = {}) {
           errorStack: true,
           source: true,
           errorDigest: true,
+          selfFixClass: true,
         },
       }),
 
@@ -101,6 +102,16 @@ export async function runIssueReportTriage(opts: { reportId?: string } = {}) {
       await prisma.platformIssueReport.update({
         where: { id },
         data: { status: ISSUE_REPORT_STATUS.TRIAGED_LOCAL },
+      });
+    },
+
+    // BI-0ACD9AB2 §5.2: a self-fix escalation is held for the responder, never
+    // generic-projected. Move any legacy OPEN self-fix row into the support-flow
+    // status so the cron stops re-selecting it and the responder receives it.
+    holdForResponder: async (id) => {
+      await prisma.platformIssueReport.update({
+        where: { id },
+        data: { status: ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK },
       });
     },
 

--- a/apps/web/lib/operate/issue-report-triage.test.ts
+++ b/apps/web/lib/operate/issue-report-triage.test.ts
@@ -185,6 +185,70 @@ describe("triageIssueReports", () => {
   });
 });
 
+describe("triageIssueReports — self-fix escalation projection guard (BI-0ACD9AB2)", () => {
+  const escalationReport = {
+    id: "r-esc",
+    reportId: "PIR-ESC01",
+    type: "build-stall-escalation",
+    severity: "high",
+    title: 'Build Studio needs a human: "X" stuck at plan review',
+    description: "blocked",
+    routeContext: null,
+    errorStack: null,
+    source: "build-studio",
+    selfFixClass: "needs-human",
+  };
+
+  it("does NOT generic-project a self-fix escalation — holds it for the responder", async () => {
+    const created: unknown[] = [];
+    const acknowledged: string[] = [];
+    const held: string[] = [];
+
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [escalationReport],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      acknowledgeReport: async (id: string) => { acknowledged.push(id); },
+      holdForResponder: async (id: string) => { held.push(id); },
+    }));
+
+    expect(result.created).toBe(0);
+    expect(created).toHaveLength(0);   // no BI-PIR-* created
+    expect(acknowledged).toEqual([]);  // not marked triaged_local
+    expect(held).toEqual(["r-esc"]);   // held for the responder instead
+  });
+
+  it("classifies by selfFixClass even when the type is not build-stall-escalation", async () => {
+    const created: unknown[] = [];
+    const held: string[] = [];
+
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [
+        { ...escalationReport, id: "r-esc2", reportId: "PIR-ESC02", type: "runtime_error" },
+      ],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      holdForResponder: async (id: string) => { held.push(id); },
+    }));
+
+    expect(result.created).toBe(0);
+    expect(held).toEqual(["r-esc2"]);
+  });
+
+  it("is per-report — a normal runtime report in the same batch still projects", async () => {
+    const created: unknown[] = [];
+    const held: string[] = [];
+
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [escalationReport, report],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      holdForResponder: async (id: string) => { held.push(id); },
+    }));
+
+    expect(result.created).toBe(1);    // the runtime report still projects
+    expect(created).toHaveLength(1);
+    expect(held).toEqual(["r-esc"]);   // only the escalation is held
+  });
+});
+
 describe("triageIssueReports — crash_boundary gate (BI-B4F401B3)", () => {
   const crashReport = {
     id: "rc1",

--- a/apps/web/lib/operate/issue-report-triage.ts
+++ b/apps/web/lib/operate/issue-report-triage.ts
@@ -12,6 +12,10 @@ import {
   isDuplicate,
   type BacklogItemData,
 } from "./process-observer-triage";
+import {
+  classifyIssueReportStream,
+  isResponderStream,
+} from "@/lib/quality/issue-report-stream";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -29,6 +33,9 @@ interface IssueReport {
   // to dedup a whole crash incident (same real error across routes) and to
   // anchor the operator's diagnostic prompt.
   errorDigest?: string | null;
+  // BI-0ACD9AB2: self-fix-feasibility class. When set, the report is a self-fix
+  // escalation the responder attends — the projection guard skips + holds it.
+  selfFixClass?: string | null;
 }
 
 // BI-B4F401B3: reports filed by the production crash boundary carry only a
@@ -183,6 +190,10 @@ export async function triageIssueReports(deps: {
   createBacklogItem: (data: BacklogItemData) => Promise<void>;
   incrementOccurrence: (title: string) => Promise<void>;
   acknowledgeReport: (id: string) => Promise<void>;
+  /** BI-0ACD9AB2 §5.2: hold a self-fix escalation for the responder
+   *  (awaiting_escalation_ack) instead of generic-projecting it. Optional so
+   *  pure-function tests may omit it; the runner always provides it. */
+  holdForResponder?: (id: string) => Promise<void>;
   /** BI-B4F401B3: returns the title of an existing crash BI that already
    *  captured this error digest, or null. Powers cross-route incident dedup so
    *  one underlying error reported from N routes folds into one BI. */
@@ -209,6 +220,17 @@ export async function triageIssueReports(deps: {
   let llmEnhanced = 0;
 
   for (const report of reports) {
+    // Projection guard (BI-0ACD9AB2 §5.2): a self-fix escalation is attended by
+    // the escalation responder, never generic-projected. Hold it for the
+    // responder (awaiting_escalation_ack) and skip. New escalations are born in
+    // that status (createPlatformIssueReport) and never reach this OPEN pool;
+    // this self-heals any legacy OPEN self-fix row — e.g. the stalled
+    // build-stall-escalation reports filed before the front-door guard existed.
+    if (isResponderStream(classifyIssueReportStream(report))) {
+      if (deps.holdForResponder) await deps.holdForResponder(report.id);
+      continue;
+    }
+
     const isCrashBoundary = report.source === CRASH_BOUNDARY_SOURCE;
 
     // ── Step 1: Try LLM-enhanced triage ──────────────────────────────────

--- a/apps/web/lib/quality/platform-issue-reports.test.ts
+++ b/apps/web/lib/quality/platform-issue-reports.test.ts
@@ -257,6 +257,48 @@ describe("createPlatformIssueReport", () => {
     expect(inngestMock.send).not.toHaveBeenCalled();
   });
 
+  // BI-0ACD9AB2 §5.2: projection guard — a self-fix escalation is born in
+  // awaiting_escalation_ack and held for the responder, never generic-projected.
+  it("births a build-stall-escalation in awaiting_escalation_ack and does NOT emit", async () => {
+    await createPlatformIssueReport({
+      type: "build-stall-escalation",
+      source: "build-studio",
+      severity: "high",
+      title: "Build Studio needs a human",
+      selfFixClass: "needs-human",
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.status).toBe("awaiting_escalation_ack");
+    expect(inngestMock.send).not.toHaveBeenCalled();
+  });
+
+  it("births a selfFixClass report in awaiting_escalation_ack even without the build-stall type", async () => {
+    await createPlatformIssueReport({
+      type: "runtime_error",
+      source: "coworker_runtime",
+      title: "Coworker could not self-repair",
+      selfFixClass: "needs-external-capability",
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.status).toBe("awaiting_escalation_ack");
+    expect(inngestMock.send).not.toHaveBeenCalled();
+  });
+
+  it("does NOT over-trigger: a generic crash report still defaults to open and emits", async () => {
+    const { reportId } = await createPlatformIssueReport({
+      type: "runtime_error",
+      source: "crash_boundary",
+      title: "A crash",
+      errorDigest: "deadbeef",
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.status).toBeUndefined(); // schema default ("open")
+    expect(inngestMock.send).toHaveBeenCalledWith({
+      name: "quality/issue-report.created",
+      data: { reportId },
+    });
+  });
+
   it("is non-fatal when the projection event fails to send", async () => {
     inngestMock.send.mockRejectedValueOnce(new Error("inngest down"));
     const result = await createPlatformIssueReport({

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@dpf/db";
 import { inngest } from "@/lib/queue/inngest-client";
 import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "./issue-report-status";
+import { classifyIssueReportStream, isResponderStream } from "./issue-report-stream";
 
 // Field length limits — matched to existing writers and Prisma schema column widths.
 const LIMITS = {
@@ -106,6 +107,9 @@ export interface CreatePlatformIssueReportInput {
  *  - Validates status against ISSUE_REPORT_STATUS; rejects unknown values.
  *  - Leaves status undefined when not provided so the Prisma schema default
  *    ("open") applies — supports cron contract.
+ *  - Projection guard (BI-0ACD9AB2 §5.2): a self-fix escalation (build-stall /
+ *    selfFixClass) with no pinned status is born in awaiting_escalation_ack so it
+ *    is held for the escalation responder, not generic-projected into a BI.
  *
  * Privacy / non-identifiability transforms (redactHostnames, secret scan,
  * coworker-synthesized summaries) are intentionally OUT of scope for Phase 0
@@ -117,6 +121,28 @@ export async function createPlatformIssueReport(
   if (input.status !== undefined && !VALID_STATUSES.has(input.status)) {
     throw new Error(`createPlatformIssueReport: unknown status "${input.status}"`);
   }
+
+  // Projection guard (BI-0ACD9AB2 §5.2 — trusted escalation routing): a self-fix
+  // escalation (type="build-stall-escalation" / selfFixClass set) is attended by
+  // the escalation responder, never generic-projected into a BI. When the caller
+  // did not pin a status, birth it in awaiting_escalation_ack — a non-resolved
+  // support-flow status — so it (a) is held for the responder, not the generic
+  // projector, (b) never fires the immediate projection event below (status !=
+  // open), and (c) is still covered by the per-dedupeKey "one non-resolved
+  // report" partial-unique. Every writer is guarded at this one front door.
+  const status: IssueReportStatus | undefined =
+    input.status ??
+    (isResponderStream(
+      classifyIssueReportStream({
+        type: input.type,
+        source: input.source,
+        severity: input.severity,
+        selfFixClass: input.selfFixClass,
+        errorDigest: input.errorDigest,
+      }),
+    )
+      ? ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK
+      : undefined);
 
   const digitalProductId =
     input.digitalProductId ??
@@ -162,7 +188,7 @@ export async function createPlatformIssueReport(
       source: input.source.slice(0, LIMITS.source),
       portfolioId,
       digitalProductId,
-      ...(input.status !== undefined ? { status: input.status } : {}),
+      ...(status !== undefined ? { status } : {}),
     },
   });
 
@@ -171,7 +197,7 @@ export async function createPlatformIssueReport(
   // triage cron. Support-flow reports (status !== open) are owned by the support
   // pipeline and skipped. Best-effort — the cron remains the safety net, so a
   // send failure never loses the projection.
-  const effectiveStatus = input.status ?? ISSUE_REPORT_STATUS.OPEN;
+  const effectiveStatus = status ?? ISSUE_REPORT_STATUS.OPEN;
   if (effectiveStatus === ISSUE_REPORT_STATUS.OPEN) {
     try {
       await inngest.send({ name: "quality/issue-report.created", data: { reportId } });


### PR DESCRIPTION
## What

**Slice 1 of the trusted escalation responder** ([design](docs/superpowers/specs/2026-06-20-issue-report-surface-attendance-design.md) §5.2). The user gave the go for the responder track; this is its foundation — the projection guard that makes the responder safe to build.

**The defect** (design §1): a build that exhausts self-repair files an `open` `PlatformIssueReport` via `escalateBuildToHuman`. The generic projection path then converts it into a `BI-PIR-*` — *evidence conversion without a responder*. 19 stalled WWMD-build escalations sat `open`, generic-projected, with nobody receiving them.

## How — one classifier, two guard points

The stream classifier shipped in #2209; this wires it into the projection path so self-fix escalations bypass generic BI projection and enter the escalation status, **held for the responder** (Slice 2):

- **Front-door guard** (`createPlatformIssueReport`): a self-fix escalation (`type=build-stall-escalation` / `selfFixClass` set) with no pinned status is **born in `awaiting_escalation_ack`** (the spec's *"prefer at write time"*). It never fires the immediate projection event and never enters the `open` cron pool. **Dedup preserved** — the per-`dedupeKey` partial-unique covers all *non-resolved* statuses, so `awaiting_escalation_ack` is still one-per-build.
- **Triage-loop guard** (`triageIssueReports`, consumed by **both** the immediate event and the 15-min cron via the shared runner): each `open` report is classified; a self-fix report is **held for the responder and skipped** — self-healing any legacy `open` escalation (the 19) out of generic projection. Per-report: a normal runtime report in the same batch still projects.

## Acceptance criteria met (design §9)

- ✅ A new self-fix escalation is **not** projected as a generic `BI-PIR-*` before a responder claims it.
- ✅ Stream-1/2 behavior intact — runtime/crash reports still project with existing dedup; the guard does not over-trigger (test included).

## Test

- `createPlatformIssueReport`: births `awaiting_escalation_ack` + no projection event for build-stall **and** bare-`selfFixClass`; generic crash still defaults `open` + emits.
- `triageIssueReports`: self-fix report skipped + `holdForResponder` called; `selfFixClass`-only path; per-report batch (escalation held, runtime projected).

## Next

**Slice 2** — the responder `TaskRun` that claims `awaiting_escalation_ack` reports, consults WWMD/WWWD/WSID, and dispositions. **HITL-first** per §14 trust dial: it proposes and records, a human reviews; autonomy grows per decision-class only as the scopes prove correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)