### PR TITLE
feat(build-studio): P1 ideate-phase tier-routing (EP-MODEL-TIER-ROUTING)

### DIFF
--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -94,6 +94,11 @@ export interface RouteAndCallOptions {
   requiresComputerUse?: boolean;
   /** Budget posture override. */
   budgetClass?: "minimize_cost" | "balanced" | "quality_first";
+  /** EP-MODEL-TIER-ROUTING: capability tier for this call. "local" forces
+   *  residencyPolicy=local_only (keeps small/simple work on the on-box model);
+   *  "robust" leaves routing free to prefer a frontier endpoint. Unset = today's
+   *  behavior (governed only by the global local-only switch). */
+  modelTier?: "local" | "robust";
   /** Minimum dimension scores (0-100) models must meet. Models below any threshold are excluded. */
   minimumDimensions?: Record<string, number>;
   /** EP-INF-009c: Route to a specific model class (e.g., "image_gen", "embedding"). */
@@ -228,7 +233,13 @@ async function prepareRoute(
       requiresComputerUse: options?.requiresComputerUse,
       budgetClass: options?.budgetClass,
       requiredModelClass: options?.requiredModelClass,
-      ...(localOnlyInference ? { residencyPolicy: "local_only" as const } : {}),
+      // EP-MODEL-TIER-ROUTING: a "local"-tier call forces local_only (keep
+      // small/simple work on-box) even when the global switch is off; "robust"
+      // leaves routing free to prefer a frontier endpoint. The global local-only
+      // switch still wins for every call (the sovereign master toggle).
+      ...(options?.modelTier === "local" || localOnlyInference
+        ? { residencyPolicy: "local_only" as const }
+        : {}),
     },
   );
 

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -412,6 +412,10 @@ export async function dispatchIdeateResearch(params: {
   providerId?: string;
   model?: string;
   dispatchEngine?: "claude" | "codex" | "grok" | "opencode" | "agentic";
+  /** EP-MODEL-TIER-ROUTING: capability tier for the local routeAndCall ideate
+   *  path. "robust" lets routing prefer a frontier endpoint for large designs;
+   *  "local"/undefined keeps it on the on-box model. */
+  modelTier?: "local" | "robust";
   onProgress?: (message: string) => void;
 }): Promise<IdeateResult> {
   const dispatchEngine = params.dispatchEngine ?? "codex";
@@ -445,7 +449,7 @@ export async function dispatchIdeateResearch(params: {
         [{ role: "user" as const, content: prompt }],
         "You are a senior software architect producing a structured design document. Respond with the design document content only — no preamble.",
         "internal",
-        { budgetClass: "quality_first" },
+        { budgetClass: "quality_first", ...(params.modelTier ? { modelTier: params.modelTier } : {}) },
       );
       const rawOutput = (response.content ?? "").trim();
       const designDoc = parseDesignDoc(rawOutput);

--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -22,6 +22,7 @@ vi.mock("./ideate-dispatch", () => ({
 
 vi.mock("@/lib/integrate/build-studio-config", () => ({
   getBuildStudioConfig: mockGetBuildStudioConfig,
+  isModelTierRoutingEnabled: () => false,
 }));
 
 vi.mock("@/lib/mcp-tools", () => ({

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -122,7 +122,7 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // that PR #1030 fixed in this same file.
     const bi = await prisma.backlogItem.findUnique({
       where: { id: build.originatingBacklogItemId },
-      select: { title: true, body: true },
+      select: { title: true, body: true, effortSize: true },
     });
 
     if (!bi) {
@@ -182,6 +182,17 @@ export async function dispatchIdeateForApprovedBuild(params: {
     const startedAt = Date.now();
     await logActivity(`Dispatching ideate research via ${config.provider} (provider=${providerId}, model=${model || "default"})`);
 
+    // EP-MODEL-TIER-ROUTING: route this build's ideate design generation to the
+    // model tier its size deserves — local for small/medium, robust/frontier for
+    // large/xlarge. Flag-gated; inert until DPF_BUILD_MODEL_TIER_ROUTING is on
+    // (and a robust endpoint + the global local-only switch off make robust route
+    // to cloud; otherwise it gracefully stays local).
+    const { getModelTier } = await import("@/lib/explore/build-process-matrix");
+    const { isModelTierRoutingEnabled } = await import("@/lib/integrate/build-studio-config");
+    const modelTier = isModelTierRoutingEnabled()
+      ? getModelTier(null, bi.effortSize) // tier is size-derived (P1); build.kind isn't in this select
+      : undefined;
+
     const { dispatchIdeateResearch } = await import("./ideate-dispatch");
     const ideateResult = await dispatchIdeateResearch({
       featureTitle,
@@ -194,6 +205,7 @@ export async function dispatchIdeateForApprovedBuild(params: {
       providerId,
       model,
       dispatchEngine: config.provider,
+      modelTier,
     });
 
     const durationMs = Date.now() - startedAt;


### PR DESCRIPTION
**P1 ideate-phase tier-routing** — follows the merged foundation #2243.

Adds the reasoning-phase routing hook + threads it into ideate (the weak-design→review-fail stall):
- `RouteAndCallOptions.modelTier`: `local` forces `residencyPolicy=local_only` (small/medium stay on-box even when the global local-only switch is off); `robust` lets routing prefer a frontier endpoint.
- Ideate design generation (`ideate-dispatch` ← `ideate-on-approval`) computes `getModelTier` from the BI effortSize and passes it, flag-gated by `DPF_BUILD_MODEL_TIER_ROUTING`.
- Large-build ideate → robust tier (good design clears the local review gate); small/medium stay local. Codegen robust path is covered by the merged foundation.

**Activation (inert until then):** set `DPF_BUILD_MODEL_TIER_ROUTING=1`, turn the global local-only switch off, ensure a robust endpoint (Codex is active, or add an Anthropic key) → large→robust, small→local.

**Follow-up (same pattern):** thread plan + design-review + plan-review `routeAndCall` sites so small builds' reviews also stay local when the global switch is off.

**Tests:** 63/63 (ideate-on-approval mock updated for isModelTierRoutingEnabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)