### PR TITLE
feat(onboarding): risk posture → capability auto-activation (EP-ONBOARDING-INTAKE P1.2)

### DIFF
--- a/apps/web/lib/govern/org-risk-envelope.ts
+++ b/apps/web/lib/govern/org-risk-envelope.ts
@@ -1,0 +1,29 @@
+import { prisma } from "@dpf/db";
+import { resolveRiskEnvelope, type RiskEnvelope } from "@/lib/govern/risk-posture";
+
+/**
+ * Resolve the install's org risk envelope (EP-ONBOARDING-INTAKE P1.2 — the read
+ * side of the posture). Reads `BusinessContext.riskPosture` and maps it via
+ * `resolveRiskEnvelope`. DPF is single-org-per-install, so `organizationId` is
+ * optional — omit it to read the one org.
+ *
+ * Fail-open: any read failure (or an unset posture) resolves to the balanced
+ * envelope, which every consumer treats as today's no-change behavior. A
+ * consumer must never block or change behavior because the posture was
+ * unreadable.
+ */
+export async function resolveOrgRiskEnvelope(
+  organizationId?: string | null,
+): Promise<RiskEnvelope> {
+  try {
+    const bc = organizationId
+      ? await prisma.businessContext.findUnique({
+          where: { organizationId },
+          select: { riskPosture: true },
+        })
+      : await prisma.businessContext.findFirst({ select: { riskPosture: true } });
+    return resolveRiskEnvelope(bc?.riskPosture ?? null);
+  } catch {
+    return resolveRiskEnvelope(null);
+  }
+}

--- a/apps/web/lib/govern/risk-posture.test.ts
+++ b/apps/web/lib/govern/risk-posture.test.ts
@@ -92,9 +92,12 @@ describe("resolveRiskEnvelope", () => {
     expect(resolveRiskEnvelope("balanced")).toMatchObject({
       posture: "balanced",
       hitlDefault: "selective",
-      capabilityAutoActivate: true,
+      capabilityAutoActivate: false,
       autonomyCeiling: "moderate",
     });
+    // only progressive auto-activates recommended capabilities
+    expect(resolveRiskEnvelope("conservative").capabilityAutoActivate).toBe(false);
+    expect(resolveRiskEnvelope("progressive").capabilityAutoActivate).toBe(true);
     expect(resolveRiskEnvelope("progressive")).toMatchObject({
       posture: "progressive",
       hitlDefault: "minimal",

--- a/apps/web/lib/govern/risk-posture.ts
+++ b/apps/web/lib/govern/risk-posture.ts
@@ -113,7 +113,10 @@ const ENVELOPES: Record<RiskPosture, Omit<RiskEnvelope, "posture">> = {
   balanced: {
     hitlDefault: "selective",
     selfUpgradeWindow: "standard",
-    capabilityAutoActivate: true,
+    // false = today's behavior: `recommended` capabilities are asked at setup,
+    // not auto-enabled. Only `progressive` auto-activates. Keeps balanced a
+    // strict no-change baseline for the capability-activation consumer (P1.2).
+    capabilityAutoActivate: false,
     outboundConfirmation: "first-time",
     edgeDeployDefault: false,
     autonomyCeiling: "moderate",

--- a/apps/web/lib/storefront/capability-activation.test.ts
+++ b/apps/web/lib/storefront/capability-activation.test.ts
@@ -6,6 +6,10 @@ vi.mock("@dpf/db", () => ({
       findMany: vi.fn(),
       upsert: vi.fn(),
     },
+    businessContext: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
   },
 }));
 
@@ -18,10 +22,15 @@ import {
 
 const findMany = prisma.organizationCapabilityActivation.findMany as ReturnType<typeof vi.fn>;
 const upsert = prisma.organizationCapabilityActivation.upsert as ReturnType<typeof vi.fn>;
+const bcFindUnique = prisma.businessContext.findUnique as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   findMany.mockReset();
   upsert.mockReset();
+  // Default: no posture stored → resolveOrgRiskEnvelope fails open to balanced
+  // (capabilityAutoActivate=false), i.e. today's behavior.
+  bcFindUnique.mockReset();
+  bcFindUnique.mockResolvedValue(null);
 });
 
 describe("getOrgCapabilityChoices", () => {
@@ -46,6 +55,29 @@ describe("getEffectiveCapabilityActivations", () => {
     const byKey = Object.fromEntries(effective.map((e) => [e.capabilityKey, e]));
     expect(byKey["partner-program"]).toMatchObject({ active: true, source: "org-choice" });
     expect(byKey["customer-accounts"]).toMatchObject({ active: true, source: "required" });
+  });
+
+  it("auto-activates un-decided recommended capabilities under a progressive posture", async () => {
+    findMany.mockResolvedValue([{ capabilityKey: "point-of-sale", choice: "disabled" }]);
+    bcFindUnique.mockResolvedValue({ riskPosture: "progressive" });
+    const effective = await getEffectiveCapabilityActivations("org_1", [
+      { capabilityKey: "partner-program", applicability: "recommended" }, // no choice → auto-on
+      { capabilityKey: "point-of-sale", applicability: "recommended" }, // explicit disable wins
+      { capabilityKey: "customer-accounts", applicability: "required" },
+    ]);
+    const byKey = Object.fromEntries(effective.map((e) => [e.capabilityKey, e]));
+    expect(byKey["partner-program"]).toMatchObject({ active: true, source: "posture-default" });
+    expect(byKey["point-of-sale"]).toMatchObject({ active: false, source: "org-choice" });
+    expect(byKey["customer-accounts"]).toMatchObject({ active: true });
+  });
+
+  it("leaves recommended off under the default balanced posture (no-change baseline)", async () => {
+    findMany.mockResolvedValue([]);
+    bcFindUnique.mockResolvedValue({ riskPosture: "balanced" });
+    const effective = await getEffectiveCapabilityActivations("org_1", [
+      { capabilityKey: "partner-program", applicability: "recommended" },
+    ]);
+    expect(effective[0]).toMatchObject({ active: false, source: "default-off" });
   });
 });
 

--- a/apps/web/lib/storefront/capability-activation.ts
+++ b/apps/web/lib/storefront/capability-activation.ts
@@ -6,6 +6,7 @@ import {
   type CapabilityApplicability,
   type EffectiveCapabilityActivation,
 } from "@dpf/storefront-templates";
+import { resolveOrgRiskEnvelope } from "@/lib/govern/org-risk-envelope";
 
 /**
  * Server data-access for the generic per-organization capability-activation
@@ -49,8 +50,14 @@ export async function getEffectiveCapabilityActivations(
   organizationId: string,
   derived: ReadonlyArray<{ capabilityKey: string; applicability: CapabilityApplicability }>,
 ): Promise<EffectiveCapabilityActivation[]> {
-  const choices = await getOrgCapabilityChoices(organizationId);
-  return resolveOrgCapabilityActivations(derived, choices);
+  // P1.2: a progressive risk posture auto-activates un-decided `recommended`
+  // capabilities; balanced/conservative (and the fail-open default) leave today's
+  // ask-at-setup behavior. Resolved here, the single fold every consumer shares.
+  const [choices, envelope] = await Promise.all([
+    getOrgCapabilityChoices(organizationId),
+    resolveOrgRiskEnvelope(organizationId),
+  ]);
+  return resolveOrgCapabilityActivations(derived, choices, envelope.capabilityAutoActivate);
 }
 
 /**

--- a/docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p1-2.md
+++ b/docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p1-2.md
@@ -1,0 +1,48 @@
+# Plan — Onboarding Intake P1.2: capability auto-activate (first envelope knob)
+
+**Date:** 2026-06-20
+**Epic:** EP-ONBOARDING-INTAKE · **BI:** BI-E93A3437
+**Spec:** [`docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md`](../specs/2026-06-20-onboarding-intake-derivation-design.md) §5.5
+**Predecessor:** P1 keystone (BI-E0E977BC, PR #2248) — the autonomy-gate wiring + the read-time `RiskEnvelope`.
+**Status:** capability-auto-activate shipped (this PR); other knobs sequenced below.
+
+## Goal
+
+Wire the read side of the risk envelope into the operational defaults, each with **balanced = no change** so existing installs are untouched. This slice ships the cleanest, highest-leverage knob — **capability auto-activate** — plus the shared read helper, and fixes a correctness bug found while mapping.
+
+## Correctness fix (found during mapping)
+
+The P0 envelope set `balanced.capabilityAutoActivate = true`, but **today `recommended` capabilities are asked at setup and default OFF** (`capability-activation.ts` `resolveCapabilityActivation`). Wiring that as-is would have flipped every balanced (default) install to auto-enable recommended capabilities — a silent regression. Fix: `balanced.capabilityAutoActivate = false`; **only `progressive` auto-activates**. This restores the balanced=no-change contract (test-pinned). `conservative` was already false.
+
+## Change set (this PR)
+
+| File | Change |
+|------|--------|
+| `apps/web/lib/govern/risk-posture.ts` | `balanced.capabilityAutoActivate` → `false` (correctness). |
+| `apps/web/lib/govern/org-risk-envelope.ts` | **new** `resolveOrgRiskEnvelope(organizationId?)` — reads `BusinessContext.riskPosture` (single-org-per-install), fail-open to balanced. The read side of the posture. |
+| `packages/storefront-templates/src/capability-activation.ts` | `resolveCapabilityActivation` / `resolveOrgCapabilityActivations` gain `autoActivateRecommended` (default `false` = no-change). An un-decided `recommended` defaults ON only when set; an explicit `disabled` still wins. New `source` value `posture-default`. |
+| `apps/web/lib/storefront/capability-activation.ts` | `getEffectiveCapabilityActivations` resolves the org envelope and passes `envelope.capabilityAutoActivate`. This is the **single fold** the setup wizard, admin toggle, and route/UI gating all share — one injection point, no threading. |
+
+## Why this injection point
+
+`getEffectiveCapabilityActivations` is the documented single source of truth for "is this capability on for this org?" — every consumer flows through it. Resolving the envelope there means the posture default is consistent everywhere with no per-call-site threading. Fail-open: an unreadable/unset posture → balanced → today's behavior (the existing test exercises this).
+
+## Safety
+
+- **No regression:** balanced (and the fail-open default) → `capabilityAutoActivate=false` → recommended stays ask-at-setup (test-pinned).
+- **Explicit choice wins:** an org `disabled` is never overridden by the posture default.
+- **Scope:** only `recommended` auto-activates (not `optional`/`required`); only `progressive` posture.
+
+## Sequenced (remaining P1.2 knobs — not this PR)
+
+- **Self-upgrade window width** (`selfUpgradeWindow`): modulate `isUpgradeWindowOpen` (`apps/web/lib/self-upgrade/window.ts`, prisma-free → caller resolves + passes). Non-trivial margin math + existing tests → its own slice.
+- **Edge-deploy default** (`edgeDeployDefault`): posture override appended at the `deriveCapabilityApplicability` callsite. Niche (estate-ops archetypes only).
+- **AgentGovernanceProfile seed default**: low-yield (no seed default exists today; manual assignment).
+
+## Deferred (separate)
+
+Outbound-send confirmation strictness — a hard kernel principle (`outbound-actions-require-explicit-go`) with no org knob; needs a principle org-override / tool-policy design, not wired here.
+
+## Verification
+
+Unit: `risk-posture.test.ts` (balanced=false pinned), `capability-activation.test.ts` (package: auto-activate + explicit-disable-wins), `apps/web/lib/storefront/capability-activation.test.ts` (progressive auto-on, balanced no-change). Source-only worktree → compile/build gates run in CI.

--- a/packages/storefront-templates/src/capability-activation.test.ts
+++ b/packages/storefront-templates/src/capability-activation.test.ts
@@ -72,6 +72,29 @@ describe("resolveCapabilityActivation", () => {
     // Pure channel/reseller archetype derives partner-program = required → on by default.
     expect(resolveCapabilityActivation("required").active).toBe(true);
   });
+
+  it("auto-activates an un-decided recommended capability under a progressive posture; explicit disable still wins", () => {
+    // autoActivateRecommended (progressive risk posture): recommended defaults ON.
+    expect(resolveCapabilityActivation("recommended", null, true)).toMatchObject({
+      active: true,
+      promptAtSetup: true,
+      source: "posture-default",
+    });
+    // an explicit opt-out still wins over the posture default.
+    expect(resolveCapabilityActivation("recommended", "disabled", true)).toMatchObject({
+      active: false,
+      source: "org-choice",
+    });
+    // an explicit opt-in is unchanged.
+    expect(resolveCapabilityActivation("recommended", "enabled", true).source).toBe("org-choice");
+    // optional capabilities are NOT auto-activated (only recommended).
+    expect(resolveCapabilityActivation("optional", null, true)).toMatchObject({
+      active: false,
+      source: "default-off",
+    });
+    // required is unaffected by the flag.
+    expect(resolveCapabilityActivation("required", null, true).source).toBe("required");
+  });
 });
 
 describe("resolveOrgCapabilityActivations", () => {
@@ -102,5 +125,15 @@ describe("resolveOrgCapabilityActivations", () => {
     const effective = resolveOrgCapabilityActivations(derived);
     const partner = effective.find((e) => e.capabilityKey === "partner-program");
     expect(partner).toMatchObject({ active: false, promptAtSetup: true, source: "default-off" });
+  });
+
+  it("auto-activates un-decided recommended capabilities when the posture flag is set", () => {
+    const effective = resolveOrgCapabilityActivations(derived, {}, true);
+    const byKey = Object.fromEntries(effective.map((e) => [e.capabilityKey, e]));
+    // recommended with no choice → on, by posture default.
+    expect(byKey["partner-program"]).toMatchObject({ active: true, source: "posture-default" });
+    // optional is not auto-activated; required is unchanged.
+    expect(byKey["point-of-sale"]).toMatchObject({ active: false });
+    expect(byKey["customer-accounts"]).toMatchObject({ active: true, source: "required" });
   });
 });

--- a/packages/storefront-templates/src/capability-activation.ts
+++ b/packages/storefront-templates/src/capability-activation.ts
@@ -4,12 +4,15 @@ import type { CapabilityActivationChoice, CapabilityApplicability } from "./type
  * Why a capability resolved to its current active/inactive state.
  * - `required`: core to the chosen business model; on by default, no org opt-in needed.
  * - `org-choice`: the org made an explicit enabled/disabled decision.
+ * - `posture-default`: on by a progressive risk posture (auto-activated `recommended`),
+ *   not an explicit org choice.
  * - `default-off`: offered (recommended/optional) but the org has not opted in yet.
  * - `not-applicable`: the business model does not support this capability.
  */
 export type CapabilityActivationSource =
   | "required"
   | "org-choice"
+  | "posture-default"
   | "default-off"
   | "not-applicable";
 
@@ -48,12 +51,15 @@ export interface CapabilityActivationResolution {
  * - `required` → active unless the org explicitly disabled it; confirmed (not
  *   silently applied) at setup; can be re-enabled later.
  * - `recommended` → opt-in: off until the org enables it; **asked at setup**; can
- *   be enabled later.
+ *   be enabled later. When `autoActivateRecommended` is set (a progressive risk
+ *   posture), an un-decided `recommended` capability defaults ON instead of being
+ *   asked — an explicit `disabled` choice still wins.
  * - `optional` → opt-in: off until enabled; not surfaced at setup; **can be added later**.
  */
 export function resolveCapabilityActivation(
   applicability: CapabilityApplicability,
   choice?: CapabilityActivationChoice | null,
+  autoActivateRecommended?: boolean,
 ): CapabilityActivationResolution {
   if (applicability === "not-applicable" || applicability === "hidden") {
     return {
@@ -73,12 +79,16 @@ export function resolveCapabilityActivation(
     };
   }
 
-  // recommended | optional → opt-in; off until the org turns it on.
+  // recommended | optional → opt-in; off until the org turns it on. A progressive
+  // risk posture flips an un-decided `recommended` capability ON by default
+  // (autoActivateRecommended); an explicit `disabled` choice still wins.
+  const autoOn =
+    autoActivateRecommended === true && applicability === "recommended" && choice == null;
   return {
-    active: choice === "enabled",
+    active: choice === "enabled" || autoOn,
     promptAtSetup: applicability === "recommended",
     canEnableLater: true,
-    source: choice ? "org-choice" : "default-off",
+    source: choice ? "org-choice" : autoOn ? "posture-default" : "default-off",
   };
 }
 
@@ -97,13 +107,16 @@ export interface EffectiveCapabilityActivation extends CapabilityActivationResol
  * @param derived  the org's archetype-derived capability activations (each carries a
  *                 `capabilityKey` and `applicability`) — e.g. `NormalizedActivationProfile.capabilityActivations`.
  * @param choices  map of `capabilityKey → CapabilityActivationChoice` for this org.
+ * @param autoActivateRecommended  when true (a progressive risk posture), un-decided
+ *                 `recommended` capabilities default ON. Defaults false = today's behavior.
  */
 export function resolveOrgCapabilityActivations(
   derived: ReadonlyArray<{ capabilityKey: string; applicability: CapabilityApplicability }>,
   choices: Readonly<Record<string, CapabilityActivationChoice>> = {},
+  autoActivateRecommended = false,
 ): EffectiveCapabilityActivation[] {
   return derived.map(({ capabilityKey, applicability }) => ({
     capabilityKey,
-    ...resolveCapabilityActivation(applicability, choices[capabilityKey] ?? null),
+    ...resolveCapabilityActivation(applicability, choices[capabilityKey] ?? null, autoActivateRecommended),
   }));
 }


### PR DESCRIPTION
First operational knob of the risk envelope (P1.2, BI-E93A3437): a **progressive** risk posture auto-activates un-decided `recommended` capabilities at setup; balanced/conservative keep today's ask-at-setup behavior. Surface-free backend wiring.

## Correctness fix (found while mapping)
P0's `balanced.capabilityAutoActivate` was `true`, but `recommended` capabilities are **asked / default-off today**. Wiring that as-is would have silently flipped **every balanced (default) install** to auto-enable recommended capabilities. Fixed: `balanced=false`; **only `progressive` auto-activates**. Balanced stays a strict no-change baseline (test-pinned).

## Change
- `resolveOrgRiskEnvelope()` — the read side of the posture (`BusinessContext.riskPosture`, single-org-per-install, **fail-open** to balanced).
- `resolveCapabilityActivation` / `resolveOrgCapabilityActivations` gain `autoActivateRecommended` (default `false` = no-change). An explicit `disabled` choice **still wins**; new `source` value `posture-default`.
- `getEffectiveCapabilityActivations` — the **single fold** the setup wizard, admin toggle, and all route/UI gating share — resolves the org envelope and passes the flag. One injection point, no threading, fail-open.

## Safety
- **No regression:** balanced + the fail-open default → `capabilityAutoActivate=false` → recommended stays ask-at-setup (test-pinned).
- **Explicit choice wins:** an org `disabled` is never overridden by the posture default.
- **Scope:** only `recommended` auto-activates; only `progressive` posture.

## Sequenced / deferred (remaining P1.2)
- Self-upgrade window width, edge-deploy default, AgentGovernanceProfile seed default — stay under BI-E93A3437.
- Outbound-send strictness — deferred (hard kernel principle).

Plan: [P1.2](docs/superpowers/plans/2026-06-20-onboarding-risk-posture-p1-2.md). Source-only worktree → gates run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)