### PR TITLE
feat(nav): wire worker/operator rail mode — condensed view (EP-NAV-COHERENCE P4)

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -15,7 +15,8 @@ import { PlatformBanner } from "@/components/platform/PlatformBanner";
 import { ShellBannerOverlay } from "@/components/shell/ShellBannerOverlay";
 import { ModelWarmup } from "@/components/shell/ModelWarmup";
 import { SetupOverlay } from "@/components/setup/SetupOverlay";
-import { getShellNavSections } from "@/lib/permissions";
+import { getShellNavSections, type PortalAudienceMode } from "@/lib/permissions";
+import { cookies } from "next/headers";
 import { getActiveOrgCapabilities } from "@/lib/storefront/civic-surfaces.server";
 import { AppRail } from "@/components/shell/AppRail";
 import { ShellBreadcrumb } from "@/components/shell/ShellBreadcrumb";
@@ -135,6 +136,12 @@ export default async function ShellLayout({ children }: { children: React.ReactN
       });
 
   const brandingCss = buildBrandingStyleTag(activeBranding?.tokens ?? null);
+  // Worker/operator rail mode (EP-NAV-COHERENCE P4). Default "operator" = the full rail
+  // (no behavior change); a user opts into the condensed "worker" rail via the rail's mode
+  // toggle, which sets this cookie. Operator is always one toggle away, so worker mode
+  // never strands a user away from a surface their role can reach.
+  const navModeCookie = (await cookies()).get("dpf-nav-mode")?.value;
+  const navMode: PortalAudienceMode = navModeCookie === "worker" ? "worker" : "operator";
   const shellNavSections = activeSetup
     ? []
     : getShellNavSections(
@@ -143,7 +150,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
           platformRole: user.platformRole,
           isSuperuser: user.isSuperuser,
         },
-        { activeOrgCapabilities },
+        { activeOrgCapabilities, mode: navMode },
       );
 
   return (
@@ -183,7 +190,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
           {shellNavSections.length > 0 && (
             <aside className="shrink-0 border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] lg:w-[248px] lg:border-b-0 lg:border-r">
               <div className="mx-auto w-full max-w-[1600px] lg:max-w-none">
-                <AppRail sections={shellNavSections} />
+                <AppRail sections={shellNavSections} mode={navMode} />
               </div>
             </aside>
           )}

--- a/apps/web/components/shell/AppRail.test.tsx
+++ b/apps/web/components/shell/AppRail.test.tsx
@@ -5,6 +5,7 @@ let pathname = "/finance";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => pathname,
+  useRouter: () => ({ refresh: () => {} }),
 }));
 
 vi.mock("next/link", () => ({
@@ -40,6 +41,7 @@ const sections: ShellNavSection[] = [
         sectionKey: "workspace",
         capabilityKey: null,
         orgCapabilityKey: null,
+        audienceModes: ["worker", "operator"],
       },
     ],
   },
@@ -56,6 +58,7 @@ const sections: ShellNavSection[] = [
         sectionKey: "business",
         capabilityKey: "view_finance",
         orgCapabilityKey: null,
+        audienceModes: ["worker", "operator"],
       },
       {
         key: "compliance",
@@ -65,6 +68,7 @@ const sections: ShellNavSection[] = [
         sectionKey: "business",
         capabilityKey: "view_compliance",
         orgCapabilityKey: null,
+        audienceModes: ["worker", "operator"],
       },
     ],
   },
@@ -98,5 +102,25 @@ describe("AppRail", () => {
     expect(html).toContain("overflow-x-auto");
     expect(html).toContain("lg:grid");
     expect(html).toContain("whitespace-nowrap");
+  });
+
+  it("renders the worker/operator mode toggle reflecting the active mode", () => {
+    pathname = "/finance";
+    const html = renderToStaticMarkup(<AppRail sections={sections} mode="worker" />);
+
+    expect(html).toContain(">Simple<");
+    expect(html).toContain(">Full<");
+    // In worker mode, "Simple" is the pressed control.
+    const simpleIdx = html.indexOf(">Simple<");
+    const buttonStart = html.lastIndexOf("<button", simpleIdx);
+    expect(html.slice(buttonStart, simpleIdx)).toContain('aria-pressed="true"');
+  });
+
+  it("defaults to operator (full) mode when no mode is passed", () => {
+    pathname = "/finance";
+    const html = renderToStaticMarkup(<AppRail sections={sections} />);
+    const fullIdx = html.indexOf(">Full<");
+    const buttonStart = html.lastIndexOf("<button", fullIdx);
+    expect(html.slice(buttonStart, fullIdx)).toContain('aria-pressed="true"');
   });
 });

--- a/apps/web/components/shell/AppRail.tsx
+++ b/apps/web/components/shell/AppRail.tsx
@@ -1,65 +1,111 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import type { ShellNavSection } from "@/lib/permissions";
+import { usePathname, useRouter } from "next/navigation";
+import type { PortalAudienceMode, ShellNavSection } from "@/lib/permissions";
 
 type Props = {
   sections: ShellNavSection[];
+  mode?: PortalAudienceMode;
 };
 
 function matchesPath(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
-export function AppRail({ sections }: Props) {
+const MODE_COOKIE = "dpf-nav-mode";
+
+export function AppRail({ sections, mode = "operator" }: Props) {
   const pathname = usePathname();
+  const router = useRouter();
   const activeHref = sections
     .flatMap((section) => section.items)
     .filter((item) => matchesPath(pathname, item.href))
     .sort((left, right) => right.href.length - left.href.length)[0]?.href;
 
-  return (
-    <nav
-      aria-label="Primary"
-      className="flex gap-3 overflow-x-auto p-3 lg:grid lg:overflow-visible lg:p-4"
-    >
-      {sections.map((section) => (
-        <section key={section.key} className="min-w-max shrink-0 lg:min-w-0">
-          <p className="px-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--dpf-muted)]">
-            {section.label}
-          </p>
+  // EP-NAV-COHERENCE P4: worker/operator rail mode. "Simple" (worker) hides operator /
+  // platform chrome for day-to-day business work; "Full" (operator) restores everything.
+  // Operator is the default and is always one click away, so worker mode never strands a
+  // user away from a surface their role can reach. Persisted in a cookie the shell reads.
+  function setMode(next: PortalAudienceMode) {
+    if (next === mode) return;
+    document.cookie = `${MODE_COOKIE}=${next}; path=/; max-age=31536000; samesite=lax`;
+    router.refresh();
+  }
 
-          <div className="mt-1 flex gap-1 lg:block lg:space-y-1">
-            {section.items.map((item) => {
-              const isActive = activeHref === item.href;
-              return (
-                <Link
-                  key={item.key}
-                  href={item.href}
-                  className={[
-                    "block whitespace-nowrap rounded-lg border px-3 py-2 transition-colors",
-                    isActive
-                      ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)]"
-                      : "border-transparent hover:border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)]",
-                  ].join(" ")}
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-semibold text-[var(--dpf-text)]">
-                      {item.label}
-                    </span>
-                    {isActive && (
-                      <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-[var(--dpf-accent)]">
-                        Here
+  return (
+    <nav aria-label="Primary" className="flex flex-col gap-3 p-3 lg:p-4">
+      <div
+        role="group"
+        aria-label="Navigation detail"
+        className="flex items-center gap-1 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-1 text-[11px] font-medium"
+      >
+        <button
+          type="button"
+          onClick={() => setMode("worker")}
+          aria-pressed={mode === "worker"}
+          className={[
+            "flex-1 rounded-md px-2 py-1 transition-colors",
+            mode === "worker"
+              ? "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+          ].join(" ")}
+        >
+          Simple
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("operator")}
+          aria-pressed={mode === "operator"}
+          className={[
+            "flex-1 rounded-md px-2 py-1 transition-colors",
+            mode === "operator"
+              ? "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+          ].join(" ")}
+        >
+          Full
+        </button>
+      </div>
+
+      <div className="flex gap-3 overflow-x-auto lg:grid lg:overflow-visible">
+        {sections.map((section) => (
+          <section key={section.key} className="min-w-max shrink-0 lg:min-w-0">
+            <p className="px-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--dpf-muted)]">
+              {section.label}
+            </p>
+
+            <div className="mt-1 flex gap-1 lg:block lg:space-y-1">
+              {section.items.map((item) => {
+                const isActive = activeHref === item.href;
+                return (
+                  <Link
+                    key={item.key}
+                    href={item.href}
+                    className={[
+                      "block whitespace-nowrap rounded-lg border px-3 py-2 transition-colors",
+                      isActive
+                        ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)]"
+                        : "border-transparent hover:border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)]",
+                    ].join(" ")}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-semibold text-[var(--dpf-text)]">
+                        {item.label}
                       </span>
-                    )}
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
-        </section>
-      ))}
+                      {isActive && (
+                        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-[var(--dpf-accent)]">
+                          Here
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
     </nav>
   );
 }

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -94,6 +94,28 @@ describe("getShellNavSections()", () => {
     expect(sections.find((section) => section.key === "platform")?.items.map((item) => item.key)).toContain("ai_workforce");
   });
 
+  it("worker mode condenses the rail to day-to-day surfaces, hiding operator/platform chrome", () => {
+    const keys = (sections: ReturnType<typeof getShellNavSections>) =>
+      sections.flatMap((section) => section.items.map((item) => item.key));
+
+    const operator = getShellNavSections(hr000, { mode: "operator" });
+    const worker = getShellNavSections(hr000, { mode: "worker" });
+
+    // Operator mode keeps the operator/platform surfaces…
+    expect(keys(operator)).toEqual(expect.arrayContaining(["platform", "admin", "ai_workforce", "backlog"]));
+    // …worker mode hides them and keeps the business/workspace day-to-day surfaces.
+    expect(keys(worker)).not.toContain("platform");
+    expect(keys(worker)).not.toContain("admin");
+    expect(keys(worker)).not.toContain("ai_workforce");
+    expect(keys(worker)).toEqual(expect.arrayContaining(["workspace", "customer", "finance"]));
+  });
+
+  it("treats no mode as the full operator rail (backward compatible)", () => {
+    const keys = (sections: ReturnType<typeof getShellNavSections>) =>
+      sections.flatMap((section) => section.items.map((item) => item.key));
+    expect(keys(getShellNavSections(hr000))).toEqual(keys(getShellNavSections(hr000, { mode: "operator" })));
+  });
+
   it("omits empty sections for more limited roles", () => {
     const sections = getShellNavSections(hr500);
 

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -5,8 +5,11 @@ import { canAccessEmployeeScope } from "./manager-scope";
 import {
   getShellNavEntries,
   getSectionNavEntries,
+  type PortalAudienceMode,
   type PortalShellSectionKey,
 } from "../navigation/portal-navigation-model";
+
+export type { PortalAudienceMode } from "../navigation/portal-navigation-model";
 
 export type PlatformRoleId =
   | "HR-000" | "HR-100" | "HR-200"
@@ -135,6 +138,10 @@ export type ShellNavItem = {
   capabilityKey: CapabilityKey | null;
   /** Archetype-capability gate (any-of when array) — see PortalNavRecord.orgCapabilityKey. */
   orgCapabilityKey: string | readonly string[] | null;
+  /** Audience modes this item belongs to (worker | operator | …). The rail filters on
+   *  this when a mode is active, so "worker" mode shows only the day-to-day business
+   *  surfaces and hides operator/platform chrome (EP-NAV-COHERENCE P4). */
+  audienceModes: readonly PortalAudienceMode[];
 };
 
 export type SectionNavItem = {
@@ -210,6 +217,7 @@ const SHELL_ITEMS: ShellNavItem[] = getShellNavEntries().map((entry) => ({
   sectionKey: entry.sectionKey,
   capabilityKey: entry.capabilityKey,
   orgCapabilityKey: entry.orgCapabilityKey,
+  audienceModes: entry.audienceModes,
 }));
 
 const WORKSPACE_SECTION_BLUEPRINTS: Array<{
@@ -272,9 +280,13 @@ export function getShellNavSections(
      * hidden — the safe default for callers without org context.
      */
     activeOrgCapabilities?: ReadonlySet<string>;
+    /** When set, only items whose audienceModes include this mode render — "worker"
+     *  yields the condensed day-to-day rail; "operator" (or undefined) the full rail. */
+    mode?: PortalAudienceMode;
   },
 ): ShellNavSection[] {
   const activeOrgCapabilities = options?.activeOrgCapabilities;
+  const mode = options?.mode;
   const orgGateOpen = (gate: string | readonly string[] | null): boolean => {
     if (gate === null) return true;
     if (!activeOrgCapabilities) return false;
@@ -287,7 +299,8 @@ export function getShellNavSections(
       (item) =>
         item.sectionKey === section.key &&
         isAllowed(user, item.capabilityKey) &&
-        orgGateOpen(item.orgCapabilityKey),
+        orgGateOpen(item.orgCapabilityKey) &&
+        (mode === undefined || item.audienceModes.includes(mode)),
     ),
   })).filter((section) => section.items.length > 0);
 }

--- a/apps/web/lib/permissions.ts
+++ b/apps/web/lib/permissions.ts
@@ -19,6 +19,7 @@ import {
 
 export type {
   PlatformRoleId,
+  PortalAudienceMode,
   SectionNavItem,
   ShellNavItem,
   ShellNavSection,


### PR DESCRIPTION
Wires the (previously dead) `PortalAudienceMode` infrastructure as the cognitive-load lever — the condensed rail for non-technical users.

- `getShellNavSections(user, { mode })` filters items by `audienceModes`: **worker** = the condensed day-to-day rail (workspace/business/knowledge), hiding operator/platform chrome (platform/admin/build/products); **operator** (or undefined) = the full rail. `ShellNavItem` + `SHELL_ITEMS` now carry `audienceModes`.
- The shell layout resolves the mode from a `dpf-nav-mode` cookie, **defaulting to operator** — so there's **no behavior change by default and no regression**.
- `AppRail` renders a **Simple/Full** toggle (cookie + `router.refresh`). Operator is the default and always one click away, so worker mode **never strands** a user away from a surface their role can reach.

Tests: `getShellNavSections` worker-mode filtering + backward-compat (no mode == full rail); `AppRail` toggle render + operator default.

Follow-up (live-verified): smart default-by-role (auto-worker for non-operator roles). **Live UX verification** on a deployed build is the remaining gate.

UX-Fit-Decision + Process-Spine-Decision in the commit body (design authored; spec impl-log update deferred to avoid conflicting with the in-flight P3/P1 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)