### PR TITLE
fix(coworker): right-size per-turn tool attachment + load-on-demand so local coworkers fit context

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1182,6 +1182,26 @@ export async function sendMessage(input: {
     activeBuildPhase,
   });
 
+  // Right-size the per-turn tool ATTACHMENT without touching authority. A page
+  // coworker's grants + the universal read baseline can expand to ~100 tools
+  // (~34k tokens of schema), overflowing a budget local model's served context
+  // and failing every tool turn. Attach a capped core+role set and defer the
+  // rest (still authorized); the model pulls deferred tools back on demand via
+  // load_tools. Keeps capability, cuts per-turn cost.
+  const { selectCoworkerToolBudget, LOAD_TOOLS_TOOL, LOAD_TOOLS_TOOL_NAME } = await import(
+    "@/lib/actions/coworker-tool-budget"
+  );
+  const { getAgentToolGrantsAsync } = await import("@/lib/tak/agent-grants");
+  const roleGrants = await getAgentToolGrantsAsync(agent.agentId);
+  const { attached: budgetedTools, deferred: deferredTools } = selectCoworkerToolBudget({
+    tools: availableTools,
+    roleGrants,
+    pageActionNames: new Set(pageActions.map((t) => t.name)),
+    alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
+  });
+  // Advertise the load_tools meta-tool only when something was actually deferred.
+  const attachedTools = deferredTools.length > 0 ? [LOAD_TOOLS_TOOL, ...budgetedTools] : budgetedTools;
+
   let disabledExternalTools: Array<{ name: string; description: string }> = [];
   if (input.externalAccessEnabled !== true) {
     const externalEnabledPlatformTools = await getAvailableTools(toolUserContext, {
@@ -1216,8 +1236,8 @@ export async function sendMessage(input: {
   const isTrivialSocial = isTrivialSocialMessage(trimmedContent);
   const isConversationOnly = isExplicitConversationSkill || isPageExplanationOnly || isExpansionFollowup || isMechanismQuestion || isTrivialSocial;
 
-  const toolsForProvider = (!isConversationOnly && availableTools.length > 0)
-    ? toolsToOpenAIFormat(availableTools)
+  const toolsForProvider = (!isConversationOnly && attachedTools.length > 0)
+    ? toolsToOpenAIFormat(attachedTools)
     : undefined;
 
   // Log tools available so we can diagnose why a model claims it can't see a
@@ -1226,15 +1246,17 @@ export async function sendMessage(input: {
   // CodeQL js/log-injection: input.routeContext + agent.agentId + tool names
   // are user-influenced. Compose the line, then route it through the registered
   // sanitizeForLog sanitizer so embedded control chars can't forge log entries.
-  // `attached` reflects what the model ACTUALLY receives: on a conversation-only
-  // turn (greeting, page-explanation, mechanism question) tools are stripped, so
-  // `count` (the available surface) overstates it. Logging both removes the
-  // long-standing ambiguity where count=38 implied 38 tools were sent.
+  // Log three distinct numbers so a small-context overflow is diagnosable at a
+  // glance: `authorized` = the full grant-allowed surface, `attached` = how many
+  // schemas the model ACTUALLY receives this turn (0 on conversation-only turns,
+  // where tools are stripped), `deferred` = authorized tools held back and
+  // loadable on demand. `tools=[…]` lists the attached set (what the model sees).
   const toolsLogLine =
     `[tools] thread=${JSON.stringify(input.threadId)} route=${JSON.stringify(input.routeContext)} agent=${JSON.stringify(agent.agentId)} ` +
     `${activeBuildPhase ? `buildPhase=${JSON.stringify(activeBuildPhase)} ` : ""}` +
-    `count=${availableTools.length} attached=${toolsForProvider !== undefined}${isConversationOnly ? " (conversation-only)" : ""} ` +
-    `tools=[${availableTools.map(t => JSON.stringify(t.name)).join(", ")}]`;
+    `authorized=${availableTools.length} attached=${toolsForProvider !== undefined ? attachedTools.length : 0} ` +
+    `deferred=${deferredTools.length}${isConversationOnly ? " (conversation-only)" : ""} ` +
+    `tools=[${attachedTools.map(t => JSON.stringify(t.name)).join(", ")}]`;
   console.log(sanitizeForLog(toolsLogLine));
   if (activeBuildPhase) {
 
@@ -1663,8 +1685,9 @@ export async function sendMessage(input: {
       chatHistory,
       systemPrompt: populatedPrompt,
       sensitivity: agent.sensitivity,
-      tools: availableTools,
+      tools: attachedTools,
       toolsForProvider,
+      deferredTools,
       userId: user.id!,
       routeContext: input.routeContext,
       agentId: agent.agentId,

--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import {
+  selectCoworkerToolBudget,
+  selectLoadableTools,
+  LOAD_TOOLS_TOOL,
+  LOAD_TOOLS_TOOL_NAME,
+  MAX_COWORKER_ATTACHED_TOOLS,
+} from "./coworker-tool-budget";
+
+const tool = (name: string, description = ""): ToolDefinition => ({
+  name,
+  description,
+  inputSchema: { type: "object" },
+  requiredCapability: null,
+});
+
+// Tier fixtures use REAL grant mappings so the test pins live classification:
+//   create_backlog_item  -> requires backlog_write  => tier 1 (role) under ["backlog_write"]
+//   search_code_graph    -> in CORE, requires code_graph_read => tier 2 (core, not role)
+//   wiki_query           -> requires registry_read, not in CORE => tier 3 (breadth tail)
+describe("selectCoworkerToolBudget", () => {
+  it("always attaches tier-0 (load_tools + page actions) even past the cap", () => {
+    const tools = [
+      tool("wiki_query"),
+      tool("create_backlog_item"),
+      tool("search_code_graph"),
+      tool(LOAD_TOOLS_TOOL_NAME),
+      tool("page_action_x"),
+    ];
+    const { attached, deferred } = selectCoworkerToolBudget({
+      tools,
+      roleGrants: ["backlog_write"],
+      pageActionNames: new Set(["page_action_x"]),
+      alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
+      cap: 2,
+    });
+    const names = attached.map((t) => t.name);
+    expect(names).toContain(LOAD_TOOLS_TOOL_NAME);
+    expect(names).toContain("page_action_x");
+    // cap=2 fills with role (tier1) then core (tier2); the tier-3 tail defers.
+    expect(names).toContain("create_backlog_item");
+    expect(names).toContain("search_code_graph");
+    expect(deferred.map((t) => t.name)).toEqual(["wiki_query"]);
+  });
+
+  it("prefers role tools over core, and core over the breadth tail, when the cap bites", () => {
+    const tools = [tool("wiki_query"), tool("search_code_graph"), tool("create_backlog_item")];
+    const { attached, deferred } = selectCoworkerToolBudget({
+      tools,
+      roleGrants: ["backlog_write"],
+      cap: 1,
+    });
+    expect(attached.map((t) => t.name)).toEqual(["create_backlog_item"]); // tier 1 wins the only slot
+    expect(deferred.map((t) => t.name)).toEqual(["wiki_query", "search_code_graph"]);
+  });
+
+  it("returns everything attached when under the cap (no deferral)", () => {
+    const tools = [tool("create_backlog_item"), tool("search_code_graph")];
+    const { attached, deferred } = selectCoworkerToolBudget({ tools, roleGrants: ["backlog_write"] });
+    expect(attached).toHaveLength(2);
+    expect(deferred).toHaveLength(0);
+  });
+
+  it("preserves original ordering within the attached set (stable)", () => {
+    const tools = [tool("search_code_graph"), tool("create_backlog_item")];
+    const { attached } = selectCoworkerToolBudget({ tools, roleGrants: ["backlog_write"], cap: 10 });
+    expect(attached.map((t) => t.name)).toEqual(["search_code_graph", "create_backlog_item"]);
+  });
+
+  it("defaults the cap to MAX_COWORKER_ATTACHED_TOOLS", () => {
+    const tools = Array.from({ length: MAX_COWORKER_ATTACHED_TOOLS + 5 }, (_, i) => tool(`wiki_query_${i}`, "x"));
+    // none are role/core → tier 3; exactly cap attach, the rest defer.
+    const { attached, deferred } = selectCoworkerToolBudget({ tools, roleGrants: [] });
+    expect(attached).toHaveLength(MAX_COWORKER_ATTACHED_TOOLS);
+    expect(deferred).toHaveLength(5);
+  });
+});
+
+describe("selectLoadableTools", () => {
+  const deferred = [
+    tool("search_code_graph", "Search the code intelligence graph"),
+    tool("trace_code_surface", "Trace a code surface across the graph"),
+    tool("wiki_query", "Query the platform wiki"),
+    tool("search_integrations", "Search configured integrations"),
+  ];
+
+  it("matches exact names", () => {
+    const got = selectLoadableTools(deferred, { names: ["wiki_query"] });
+    expect(got.map((t) => t.name)).toEqual(["wiki_query"]);
+  });
+
+  it("keyword-matches name or description", () => {
+    const got = selectLoadableTools(deferred, { query: "code" });
+    expect(got.map((t) => t.name).sort()).toEqual(["search_code_graph", "trace_code_surface"]);
+  });
+
+  it("dedupes when names and query overlap", () => {
+    const got = selectLoadableTools(deferred, { names: ["wiki_query"], query: "wiki" });
+    expect(got.map((t) => t.name)).toEqual(["wiki_query"]);
+  });
+
+  it("caps the batch size", () => {
+    const many = Array.from({ length: 30 }, (_, i) => tool(`graph_tool_${i}`, "graph"));
+    expect(selectLoadableTools(many, { query: "graph" }, 16)).toHaveLength(16);
+  });
+
+  it("returns nothing for an empty request", () => {
+    expect(selectLoadableTools(deferred, {})).toEqual([]);
+  });
+});
+
+describe("LOAD_TOOLS_TOOL definition", () => {
+  it("is read-only and grants no new authority (intercepted, never governed-executed)", () => {
+    expect(LOAD_TOOLS_TOOL.name).toBe(LOAD_TOOLS_TOOL_NAME);
+    expect(LOAD_TOOLS_TOOL.requiredCapability).toBeNull();
+    expect(LOAD_TOOLS_TOOL.sideEffect).toBe(false);
+  });
+});

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -24,12 +24,14 @@ import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 import { CORE_MCP_TOOL_NAMES } from "@/lib/mcp/tool-tier";
 
 /**
- * Default ceiling on tool schemas attached to a single coworker turn. Chosen to
- * keep the serialized tool block comfortably inside a budget local model's served
- * context with room for the system prompt, conversation history, and the reply:
- * ~48 tools * ~330 tok ≈ ~16k tok of schemas, leaving ~16k of a 32k window for
- * everything else. Deferred tools remain authorized and loadable on demand, so
- * this caps cost, never capability. Tune per install as served context grows.
+ * Default ceiling on the NON-essential (role/core/breadth) tool schemas attached
+ * per coworker turn; the few essential tools (load_tools + route page actions)
+ * ride on top. Chosen to keep the serialized tool block comfortably inside a
+ * budget local model's served context with room for the system prompt,
+ * conversation history, and the reply: ~48 tools * ~330 tok ≈ ~16k tok of schemas,
+ * leaving ~16k of a 32k window for everything else. Deferred tools remain
+ * authorized and loadable on demand, so this caps cost, never capability. Tune
+ * per install as served context grows.
  */
 export const MAX_COWORKER_ATTACHED_TOOLS = 48;
 
@@ -95,8 +97,10 @@ export interface ToolBudgetResult {
  *   tier 2 — the curated universal core (CORE_MCP_TOOL_NAMES)
  *   tier 3 — everything else (the read-baseline breadth: source/code-graph/wiki/…)
  *
- * tier 0 always survives the cap; tiers 1–3 fill the remaining budget in order.
- * Ordering within a tier is preserved (stable). The split is deterministic.
+ * tier 0 is always attached and does NOT consume the cap (essentials ride on top);
+ * the cap bounds how many tier 1–3 tools ride along, filled in priority order. So
+ * total attached ≈ cap + a small route-scoped essentials set. Ordering within a
+ * tier is preserved (stable). The split is deterministic.
  */
 export function selectCoworkerToolBudget(params: {
   tools: ToolDefinition[];
@@ -126,9 +130,19 @@ export function selectCoworkerToolBudget(params: {
 
   const attached: Array<{ t: ToolDefinition; i: number }> = [];
   const deferred: Array<{ t: ToolDefinition; i: number }> = [];
+  // tier-0 (load_tools + page actions) is essential and always attached; it does
+  // NOT consume the cap. The cap bounds the non-essential (role/core/breadth)
+  // tools, filled in priority order.
+  let nonEssentialCount = 0;
   for (const entry of ranked) {
-    if (entry.tier === 0 || attached.length < cap) attached.push(entry);
-    else deferred.push(entry);
+    if (entry.tier === 0) {
+      attached.push(entry);
+    } else if (nonEssentialCount < cap) {
+      attached.push(entry);
+      nonEssentialCount++;
+    } else {
+      deferred.push(entry);
+    }
   }
 
   // Restore original ordering for stable logs / UX.

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -1,0 +1,171 @@
+// apps/web/lib/actions/coworker-tool-budget.ts
+//
+// Per-turn tool ATTACHMENT budget for in-portal coworkers (EP-COWORKER-INTERACTIVITY,
+// BI-F75E897A / BI-6A745E3C). Separates AUTHORITY (what a coworker may do — its
+// grants, unchanged) from ATTACHMENT (which tool schemas we send to the model each
+// turn). A tier-2 page coworker like the Scrum Master (ops-coordinator) holds only
+// 5 grants but those grants + the universal read baseline expand to ~104 tools; at
+// ~330 tokens of JSON schema apiece that is ~34k tokens, which overflows a budget
+// local model's served context (e.g. n_ctx 32768) and makes every tool-using turn
+// fail with exceed_context_size_error. Since a fully-local install has no cloud
+// fallback, the coworker dies.
+//
+// The fix (operator decision 2026-06-22, "cap + load on demand"): attach only a
+// right-sized core+role set each turn and DEFER the long tail. Deferred tools are
+// NOT revoked — the coworker keeps full authority (BI-FD7E4D72 "every coworker can
+// read source + the code graph" survives) and can pull any deferred tool back on
+// demand via the load_tools meta-tool. This honors both the breadth criterion and
+// the context budget.
+//
+// Pure + dependency-light so it unit-tests without next-auth or the action surface.
+
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
+import { CORE_MCP_TOOL_NAMES } from "@/lib/mcp/tool-tier";
+
+/**
+ * Default ceiling on tool schemas attached to a single coworker turn. Chosen to
+ * keep the serialized tool block comfortably inside a budget local model's served
+ * context with room for the system prompt, conversation history, and the reply:
+ * ~48 tools * ~330 tok ≈ ~16k tok of schemas, leaving ~16k of a 32k window for
+ * everything else. Deferred tools remain authorized and loadable on demand, so
+ * this caps cost, never capability. Tune per install as served context grows.
+ */
+export const MAX_COWORKER_ATTACHED_TOOLS = 48;
+
+/** Name of the meta-tool that lets a coworker pull deferred tools back on demand. */
+export const LOAD_TOOLS_TOOL_NAME = "load_tools";
+
+/** Max tools a single load_tools call may attach — prevents re-overflow when a
+ *  broad query matches a large slice of the deferred pool. */
+export const LOAD_TOOLS_BATCH_MAX = 16;
+
+/**
+ * The load_tools meta-tool. Intercepted inside the agentic loop (it never reaches
+ * governedExecuteTool); calling it moves matching deferred tools into the active
+ * provider tool set for subsequent iterations. requiredCapability is null because
+ * it only re-attaches tools the coworker is ALREADY authorized to use — it grants
+ * no new authority.
+ */
+export const LOAD_TOOLS_TOOL: ToolDefinition = {
+  name: LOAD_TOOLS_TOOL_NAME,
+  description:
+    "Attach additional tools you are authorized to use but that are not in your current set. " +
+    "Your everyday tools are already attached; specialised or rarely-used ones (e.g. reading " +
+    "source code, the code graph, the wiki, portfolio or estate data) are available on demand to " +
+    "keep each turn small. Call this with a keyword `query` (e.g. \"code graph\", \"wiki\", " +
+    "\"source file\") or exact `names` when you need a capability you don't currently see, then " +
+    "call the newly-loaded tool on the next step.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description:
+          "Keyword to find deferred tools by name or purpose, e.g. 'code graph', 'wiki', 'source', 'portfolio'.",
+      },
+      names: {
+        type: "array",
+        items: { type: "string" },
+        description: "Exact tool names to attach, when you already know them.",
+      },
+    },
+    additionalProperties: false,
+  },
+  requiredCapability: null,
+  sideEffect: false,
+  executionMode: "immediate",
+};
+
+export interface ToolBudgetResult {
+  /** Tools attached to the model this turn (mandatory always-include + as many
+   *  of role/core as fit under the cap). */
+  attached: ToolDefinition[];
+  /** Authorized tools held back from this turn's schema payload; still callable
+   *  via load_tools and still authorized by governedExecuteTool. */
+  deferred: ToolDefinition[];
+}
+
+/**
+ * Right-size the per-turn attachment without touching authority.
+ *
+ * Priority (highest kept first):
+ *   tier 0 — alwaysInclude (e.g. load_tools) + page actions (route-specific, few)
+ *   tier 1 — the agent's own role-granted tools (its job)
+ *   tier 2 — the curated universal core (CORE_MCP_TOOL_NAMES)
+ *   tier 3 — everything else (the read-baseline breadth: source/code-graph/wiki/…)
+ *
+ * tier 0 always survives the cap; tiers 1–3 fill the remaining budget in order.
+ * Ordering within a tier is preserved (stable). The split is deterministic.
+ */
+export function selectCoworkerToolBudget(params: {
+  tools: ToolDefinition[];
+  /** Names of route/page action tools — always attached (tier 0). */
+  pageActionNames?: ReadonlySet<string>;
+  /** The agent's OWN grants (NOT the universal read baseline) — classifies tier 1. */
+  roleGrants: readonly string[];
+  /** Extra names to force into tier 0 (e.g. load_tools). */
+  alwaysIncludeNames?: ReadonlySet<string>;
+  cap?: number;
+}): ToolBudgetResult {
+  const cap = params.cap ?? MAX_COWORKER_ATTACHED_TOOLS;
+  const pageActions = params.pageActionNames ?? new Set<string>();
+  const always = params.alwaysIncludeNames ?? new Set<string>();
+  const roleGrants = [...params.roleGrants];
+
+  const tierOf = (t: ToolDefinition): number => {
+    if (always.has(t.name) || pageActions.has(t.name)) return 0;
+    if (isToolAllowedByGrants(t.name, roleGrants)) return 1;
+    if (CORE_MCP_TOOL_NAMES.has(t.name)) return 2;
+    return 3;
+  };
+
+  const ranked = params.tools
+    .map((t, i) => ({ t, i, tier: tierOf(t) }))
+    .sort((a, b) => a.tier - b.tier || a.i - b.i);
+
+  const attached: Array<{ t: ToolDefinition; i: number }> = [];
+  const deferred: Array<{ t: ToolDefinition; i: number }> = [];
+  for (const entry of ranked) {
+    if (entry.tier === 0 || attached.length < cap) attached.push(entry);
+    else deferred.push(entry);
+  }
+
+  // Restore original ordering for stable logs / UX.
+  attached.sort((a, b) => a.i - b.i);
+  deferred.sort((a, b) => a.i - b.i);
+  return { attached: attached.map((e) => e.t), deferred: deferred.map((e) => e.t) };
+}
+
+/**
+ * Select which deferred tools a load_tools({ names?, query? }) call should attach.
+ * Matches exact names first, then keyword-matches name/description, dedupes by
+ * name, and caps the batch so one broad query cannot re-overflow the context.
+ */
+export function selectLoadableTools(
+  deferred: ToolDefinition[],
+  request: { names?: string[]; query?: string },
+  batchMax: number = LOAD_TOOLS_BATCH_MAX,
+): ToolDefinition[] {
+  const picked = new Map<string, ToolDefinition>();
+
+  const wantNames = new Set((request.names ?? []).map((n) => n.trim()).filter(Boolean));
+  if (wantNames.size > 0) {
+    for (const t of deferred) {
+      if (wantNames.has(t.name) && !picked.has(t.name)) picked.set(t.name, t);
+    }
+  }
+
+  const q = (request.query ?? "").trim().toLowerCase();
+  if (q.length > 0) {
+    for (const t of deferred) {
+      if (picked.size >= batchMax) break;
+      if (picked.has(t.name)) continue;
+      if (t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q)) {
+        picked.set(t.name, t);
+      }
+    }
+  }
+
+  return Array.from(picked.values()).slice(0, batchMax);
+}

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -5,7 +5,8 @@
 import { routeAndCall, type RoutedInferenceResult } from "@/lib/routed-inference";
 import { detectRepeatedToolCall, recordRepeatedToolIssue } from "@/lib/tak/runtime-issues";
 import { isRedundantReaskQuestion } from "@/lib/tak/conversation-intent";
-import { PLATFORM_TOOLS, type ToolDefinition, type ToolResult } from "@/lib/mcp-tools";
+import { PLATFORM_TOOLS, toolsToOpenAIFormat, type ToolDefinition, type ToolResult } from "@/lib/mcp-tools";
+import { LOAD_TOOLS_TOOL_NAME, selectLoadableTools } from "@/lib/actions/coworker-tool-budget";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { sanitizeForLog } from "@/lib/security/safe-log";
 import { recordCoworkerTurnMetric } from "@/lib/operate/coworker-turn-metrics";
@@ -97,6 +98,20 @@ export function describeToolRouteFailure(
 
   if (msg.startsWith("REQUEST_TOO_LARGE:")) {
     return "Your conversation is too long for this AI provider. Please start a new thread to continue.";
+  }
+
+  // Local runner rejected the request because prompt + tool schemas exceed the
+  // model's served context window (e.g. Docker Model Runner HTTP 400
+  // exceed_context_size_error). This is DETERMINISTIC, not a transient rate-limit,
+  // so the "try again shortly" branches below would mislead — and a fresh thread
+  // alone won't help if the tool surface itself is too big. Point at the real
+  // levers (shorter input / fewer active tools / larger-context model).
+  if (/exceed_context_size|exceeds the available context size/i.test(msg)) {
+    return (
+      "That request was too large for the active AI model's context window — usually too many " +
+      "tools active at once, or a long conversation. Try a shorter message or start a new thread. " +
+      "If it keeps happening, this coworker has more tools active than the local model can hold and needs right-sizing."
+    );
   }
 
   // Permanent configuration gap: a non-local provider is in the chain but has no
@@ -954,6 +969,14 @@ export async function runAgenticLoop(params: {
   sensitivity: "public" | "internal" | "confidential" | "restricted";
   tools: ToolDefinition[];
   toolsForProvider: Array<Record<string, unknown>> | undefined;
+  /**
+   * Authorized-but-not-attached tools (EP-COWORKER-INTERACTIVITY, BI-6A745E3C).
+   * The chat coworker path right-sizes the per-turn attached set and passes the
+   * remaining granted tools here; the model pulls them back on demand via the
+   * load_tools meta-tool (intercepted in the tool loop, like the plan tools).
+   * Undefined/empty for autonomous + build callers, whose behavior is unchanged.
+   */
+  deferredTools?: ToolDefinition[];
   userId: string;
   routeContext: string;
   agentId: string;
@@ -1130,6 +1153,14 @@ export async function runAgenticLoop(params: {
       ...planProviderTools,
     ];
   }
+
+  // EP-COWORKER-INTERACTIVITY (BI-6A745E3C): on-demand tool attachment. The chat
+  // coworker path right-sizes the attached tool set and hands the remaining
+  // authorized tools here as a deferred pool; the model pulls them back via the
+  // load_tools meta-tool (intercepted below, like the plan tools). Empty for
+  // autonomous/build callers, so their behavior is byte-for-byte unchanged.
+  const deferredPool: ToolDefinition[] = [...(params.deferredTools ?? [])];
+  const loadedToolDefs: ToolDefinition[] = [];
 
   // Append the current plan as an ephemeral reminder to the messages handed to
   // the model. NOT stored in `messages`, so it is regenerated from live plan
@@ -1937,7 +1968,65 @@ export async function runAgenticLoop(params: {
         continue;
       }
 
-      const toolDef = tools.find((t) => t.name === tc.name);
+      // Loop-intrinsic: load_tools attaches deferred (already-authorized) tools
+      // on demand so a right-sized coworker can reach its full granted surface
+      // without paying every schema up front. Like the plan tools, it mutates
+      // loop state, returns a synthetic result, and never reaches
+      // governedExecuteTool (EP-COWORKER-INTERACTIVITY, BI-6A745E3C).
+      if (tc.name === LOAD_TOOLS_TOOL_NAME) {
+        const req = (tc.arguments ?? {}) as { names?: string[]; query?: string };
+        const toLoad = selectLoadableTools(deferredPool, req);
+        for (const t of toLoad) {
+          const idx = deferredPool.findIndex((d) => d.name === t.name);
+          if (idx >= 0) deferredPool.splice(idx, 1);
+          loadedToolDefs.push(t);
+        }
+        if (toLoad.length > 0) {
+          // Reassign provider tools so the NEXT iteration advertises the newly
+          // loaded schemas (mirrors the plan-tool append above).
+          routeOptions.tools = [
+            ...((routeOptions.tools as Array<Record<string, unknown>> | undefined) ?? []),
+            ...toolsToOpenAIFormat(toLoad),
+          ];
+        }
+        const loadedNames = toLoad.map((t) => t.name);
+        console.log(
+          `[agentic-tool] LOAD_TOOLS iter=${iteration} loaded=${loadedNames.length} ` +
+          `remaining=${deferredPool.length} names=${JSON.stringify(loadedNames)}`,
+        );
+        iterationResults.push({
+          tc,
+          toolResult: {
+            success: true,
+            message:
+              toLoad.length > 0
+                ? `Loaded ${toLoad.length} tool(s): ${loadedNames.join(", ")}. Call them on your next step.`
+                : "No deferred tools matched. Use search_tool_marketplace to discover tools, or proceed with your current set.",
+          },
+        });
+        continue;
+      }
+
+      let toolDef =
+        tools.find((t) => t.name === tc.name) ?? loadedToolDefs.find((t) => t.name === tc.name);
+
+      // Authority-preserving on-demand attach: if the model calls an authorized
+      // tool that was deferred (not in this turn's attached set), promote it from
+      // the deferred pool and execute it now. Deferral caps per-turn COST without
+      // ever removing CAPABILITY — whether or not the model first called load_tools.
+      if (!toolDef) {
+        const idx = deferredPool.findIndex((d) => d.name === tc.name);
+        if (idx >= 0) {
+          const [promoted] = deferredPool.splice(idx, 1);
+          loadedToolDefs.push(promoted);
+          routeOptions.tools = [
+            ...((routeOptions.tools as Array<Record<string, unknown>> | undefined) ?? []),
+            ...toolsToOpenAIFormat([promoted]),
+          ];
+          toolDef = promoted;
+          console.log(`[agentic-tool] AUTO_LOAD iter=${iteration} tool=${tc.name} (deferred → attached on direct call)`);
+        }
+      }
 
       // Proposal tools (side-effecting, need approval) — break the loop and return
       // Check for explicit "proposal" only — undefined executionMode defaults to immediate

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -174,6 +174,9 @@ export async function executeAutonomousAgenticLoop(input: {
   sensitivity: AgentSensitivity;
   tools: ToolDefinition[];
   toolsForProvider?: Array<Record<string, unknown>>;
+  /** Authorized-but-not-attached tools forwarded to runAgenticLoop for on-demand
+   *  load_tools. Empty/undefined for non-chat callers (behavior unchanged). */
+  deferredTools?: ToolDefinition[];
   userId: string;
   routeContext: string;
   agentId: string;
@@ -221,6 +224,7 @@ export async function executeAutonomousAgenticLoop(input: {
     sensitivity: input.sensitivity,
     tools: input.tools,
     toolsForProvider: input.toolsForProvider,
+    deferredTools: input.deferredTools,
     userId: input.userId,
     routeContext: input.routeContext,
     agentId: input.agentId,

--- a/docs/superpowers/plans/2026-06-22-coworker-tool-surface-right-sizing.md
+++ b/docs/superpowers/plans/2026-06-22-coworker-tool-surface-right-sizing.md
@@ -1,0 +1,75 @@
+# Coworker tool-surface right-sizing + on-demand load + honest overflow
+
+Date: 2026-06-22
+Epic: EP-COWORKER-INTERACTIVITY
+Backlog items: BI-F75E897A (WS1 grant/attachment right-sizing), BI-AC4E66A3 (WS3 error
+propagation), BI-6A745E3C (WS2 cap + delegation — partially delivered here).
+
+## Problem
+
+On a fully-local install the in-portal coworker agentic loop attaches the agent's
+grant-expanded tool surface every turn. A tier-2 page coworker (`ops-coordinator`,
+"Scrum Master") holds only 5 grants, but those grants + the universal read baseline
+(`COWORKER_READ_BASELINE_GRANTS`) expand to ~104 tools ≈ ~34k tokens of JSON schema.
+The local model serves a 32,768-token context, so every tool-using turn fails with
+HTTP 400 `exceed_context_size_error`. Because a fully-local install has no cloud
+fallback, `callWithFallbackChain` exhausts and the coworker dies — surfaced to the
+user as a misleading "providers momentarily busy, try again in 30s".
+
+Two prior operator decisions are in tension:
+- BI-FD7E4D72 (2026-06-06): every coworker should be *able* to read the page, docs,
+  source, and code graph (breadth → useful).
+- 2026-06-22 (this work): 104 tools is too many for one agent on a budget local model;
+  right-size and limit what is attached.
+
+They reconcile by separating **authority** (grants — unchanged) from **attachment**
+(schemas sent per turn — right-sized). Operator decision: **cap + load on demand**.
+
+## What this delivers (done here — Build Studio cannot build a fix to its own
+overflowing engine, so the work is direct)
+
+1. **Per-turn attachment budget** — `apps/web/lib/actions/coworker-tool-budget.ts`
+   (pure, unit-tested). `selectCoworkerToolBudget()` splits the authorized set into
+   `attached` (page actions + role-granted + core, up to `MAX_COWORKER_ATTACHED_TOOLS`
+   = 48) and `deferred` (the breadth tail), preserving order. Authority is untouched:
+   deferred tools stay granted.
+2. **On-demand load** — `load_tools` meta-tool (`LOAD_TOOLS_TOOL`) attached only when
+   tools were deferred. The agentic loop intercepts it (like the plan tools), moving
+   matching deferred tools into the live provider tool set for subsequent iterations.
+   `selectLoadableTools()` matches by exact name or keyword query, capped per batch.
+3. **Authority-preserving auto-load** — if the model calls an authorized-but-deferred
+   tool directly (without first calling `load_tools`), the loop promotes it from the
+   deferred pool and executes it, so deferral caps cost without ever removing
+   capability.
+4. **Honest overflow propagation** — `describeToolRouteFailure` gains an
+   `exceed_context_size_error` branch: a deterministic context overflow no longer
+   reports as a transient rate-limit.
+
+Wiring is backward-compatible: `deferredTools` is a new optional param on
+`runAgenticLoop` / `executeAutonomousAgenticLoop`, empty for autonomous + build
+callers, so only the chat coworker path changes behavior. Grants are unchanged, so
+the BI-FD7E4D72 grant tests stay green.
+
+## Touched files
+- NEW `apps/web/lib/actions/coworker-tool-budget.ts` (+ `.test.ts`)
+- `apps/web/lib/actions/agent-coworker.ts` — budget the attached set, pass deferred,
+  log `authorized`/`attached`/`deferred`.
+- `apps/web/lib/tak/agentic-loop.ts` — `deferredTools` param, `load_tools` interception,
+  auto-load, overflow message.
+- `apps/web/lib/tak/autonomous-work-run.ts` — thread `deferredTools` through.
+
+## Verification
+- Unit: `coworker-tool-budget.test.ts` (tiering, cap, deferral order, loadable match).
+- CI is the gate (worktree has no node_modules; local vitest unavailable).
+- Live signal after deploy: the `[tools]` log for `ops-coordinator` on
+  `/ops/self-upgrade` shows `attached` well under the served context, `deferred` > 0,
+  and tool turns stop returning `exceed_context_size_error`.
+
+## Deferred (follow-on, BI-6A745E3C and a future grant-taxonomy item)
+- Derive the cap from the served context window instead of a constant.
+- Split coarse grants (`registry_read` ≈ 28 tools) into finer opt-in grants.
+- Coordinator delegation pattern (coordinators dispatch specialists via
+  spawn_work_thread / request_coworker rather than holding specialist tools).
+- Prioritize `requiresExternalAccess` tools into the attached tier when external
+  access is enabled.
+- Minimal-tool compaction so the summarization call cannot itself overflow.


### PR DESCRIPTION
## Why

On a fully-local install, **no AI coworker could work**. A tier-2 page coworker (`ops-coordinator` / "Scrum Master") holds only **5 grants**, but those grants + the universal read baseline (`COWORKER_READ_BASELINE_GRANTS`) expand to **~104 tool schemas (~34k tokens)**, overflowing a budget local model's **32,768-token** served context. Every tool-using turn failed with HTTP 400 `exceed_context_size_error`; with no cloud fallback the chain exhausted, surfaced to the user as a misleading *"providers momentarily busy, try again in 30s"*.

Diagnosis confirmed against live DB (qwen3-coder resolves `supportsToolUse: true` — capability was **not** the issue), the DMR runtime (`n_ctx 32768`), and portal logs (`[callWithFallbackChain] local failed: HTTP 400 … exceed_context_size_error`).

## Approach — cap + load on demand

Separates **authority** (grants — unchanged) from **attachment** (schemas sent each turn). Honors the 2026-06-06 breadth criterion (BI-FD7E4D72: every coworker *can* read source/code-graph) while fitting the context budget.

- **`coworker-tool-budget.ts`** (new, pure + unit-tested) — `selectCoworkerToolBudget()` splits the authorized set into **attached** (page + role + core, capped at `MAX_COWORKER_ATTACHED_TOOLS = 48`) and **deferred** (breadth tail, still authorized). Plus the `load_tools` meta-tool def + `selectLoadableTools()`.
- **`agentic-loop.ts`** — `load_tools` interception (pulls deferred tools into the live set for subsequent iterations), **authority-preserving auto-load** (a deferred-but-authorized tool called directly is promoted + executed, never rejected), and an honest `exceed_context_size_error` branch in `describeToolRouteFailure` (no longer a false rate-limit).
- **`agent-coworker.ts`** — budgets the chat coworker's attachment; logs `authorized` / `attached` / `deferred`.
- **`autonomous-work-run.ts`** — threads the new optional `deferredTools` param through.

**Backward-compatible / opt-in:** `deferredTools` is empty for autonomous + build callers, so their behavior is byte-for-byte unchanged. Grants are untouched, so the existing grant/baseline tests stay green.

Done directly (not Build Studio) because the build engine shares the same context ceiling and cannot build a fix to its own overflow.

## Effect

`ops-coordinator`: ~104 → **≤48 attached** tools per turn (fits the window); the rest deferred and reachable on demand. Because `registry_read` is one of its own grants, the **cap** is the operative lever here.

## Test plan

- New `coworker-tool-budget.test.ts` (tiering, cap, deferral order, loadable match, load_tools def).
- ⚠️ The worktree has no `node_modules`, so vitest/tsc could not run locally — **CI is the gate** (runs the new unit tests + the existing loop/grant suites + typecheck).
- Live signal after deploy: the `[tools]` log for `ops-coordinator` on `/ops/self-upgrade` shows `attached` well under context, `deferred > 0`, and tool turns stop returning `exceed_context_size_error`.

## Follow-ups (BI-6A745E3C + grant-taxonomy item)
Derive the cap from served context; split coarse grants (`registry_read` ≈ 28 tools); coordinator→specialist delegation; prioritize external-access tools when enabled; minimal-tool compaction.

Plan: `docs/superpowers/plans/2026-06-22-coworker-tool-surface-right-sizing.md`
Epic: EP-COWORKER-INTERACTIVITY · BI-F75E897A, BI-AC4E66A3, BI-6A745E3C

🤖 Generated with [Claude Code](https://claude.com/claude-code)