### PR TITLE
feat(ops): operator-triggered WWMD consult on escalations (BI-0ACD9AB2 Slice 2, dial-low)

### DIFF
--- a/apps/web/components/ops/EscalationConsult.tsx
+++ b/apps/web/components/ops/EscalationConsult.tsx
@@ -1,0 +1,73 @@
+// Operator-triggered WWMD consult widget for an escalation card (BI-0ACD9AB2).
+// HITL-first (§14 dial-low): the operator clicks, the governed decision runs with
+// THEIR principal, and the kernel's recommendation is shown for the operator to
+// act on — no autonomous side effects. The autonomous sweep (dial-up) layers on
+// later once a system responder principal is designed.
+"use client";
+
+import { useState, useTransition } from "react";
+import { consultEscalation } from "@/lib/actions/quality";
+import {
+  escalationConsultStatusLabel,
+  type ConsultEscalationResult,
+} from "@/lib/quality/escalation-responder";
+
+export function EscalationConsult({ reportId }: { reportId: string }) {
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<ConsultEscalationResult | null>(null);
+
+  const run = () =>
+    startTransition(async () => {
+      setResult(await consultEscalation(reportId));
+    });
+
+  if (result?.ok) {
+    const r = result.result;
+    return (
+      <div className="mt-1.5 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[10px] font-semibold text-[var(--dpf-accent)]">
+            WWMD: {escalationConsultStatusLabel(r.status)}
+          </span>
+          <span className="text-[10px] text-[var(--dpf-text)]">→ {r.operatorActionLabel}</span>
+          <button
+            type="button"
+            onClick={run}
+            disabled={pending}
+            className="ml-auto text-[10px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-50"
+          >
+            {pending ? "…" : "Re-consult"}
+          </button>
+        </div>
+        <p className="mt-1 text-[11px] leading-snug text-[var(--dpf-muted)]">{r.reasonSummary}</p>
+      </div>
+    );
+  }
+
+  if (result && !result.ok) {
+    return (
+      <div className="mt-1 flex items-center gap-2">
+        <span className="text-[10px] text-[var(--dpf-muted)]">{result.error}</span>
+        <button
+          type="button"
+          onClick={run}
+          disabled={pending}
+          className="text-[10px] font-semibold text-[var(--dpf-accent)] hover:opacity-80 disabled:opacity-50"
+        >
+          {pending ? "…" : "Retry"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={run}
+      disabled={pending}
+      className="mt-1 text-[10px] font-semibold text-[var(--dpf-accent)] hover:opacity-80 disabled:opacity-50"
+    >
+      {pending ? "Consulting WWMD…" : "Consult WWMD"}
+    </button>
+  );
+}

--- a/apps/web/components/ops/EscalationsAttention.tsx
+++ b/apps/web/components/ops/EscalationsAttention.tsx
@@ -11,6 +11,7 @@ import {
   escalationAgeLabel,
   type OpenEscalation,
 } from "@/lib/quality/escalation-attention";
+import { EscalationConsult } from "./EscalationConsult";
 
 export function EscalationsAttention({ escalations }: { escalations: OpenEscalation[] }) {
   if (escalations.length === 0) return null;
@@ -55,6 +56,7 @@ export function EscalationsAttention({ escalations }: { escalations: OpenEscalat
                 <span className="text-[10px] text-[var(--dpf-muted)]">· {e.reportId}</span>
               </div>
               <p className="mt-1 truncate text-xs text-[var(--dpf-text)]">{e.title}</p>
+              <EscalationConsult reportId={e.reportId} />
             </div>
             {e.buildId ? (
               <Link

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -12,6 +12,11 @@ import {
   type IssueReportStatus,
 } from "@/lib/quality/issue-report-status";
 import { LEGACY_ISSUE_REPORT_STATUS, type LegacyIssueReportStatus } from "@/lib/quality/issue-report-queue";
+import { evaluateBuildStudioDecision } from "@/lib/build/decision-service";
+import {
+  buildEscalationDecisionRequest,
+  type ConsultEscalationResult,
+} from "@/lib/quality/escalation-responder";
 
 export async function reportQualityIssue(input: {
   type: "runtime_error" | "user_report" | "feedback";
@@ -172,6 +177,46 @@ export async function updateIssueReportStatus(
     where: { reportId },
     data: { status },
   });
+}
+
+/**
+ * Operator-triggered WWMD consult for a held escalation (BI-0ACD9AB2 §5.3 /
+ * §14 dial-low). Runs the governed decision with the OPERATOR's own principal —
+ * HITL-first by construction: the human asks, the kernel advises, the human
+ * decides. Returns the operator-safe recommendation for the /ops attention lens.
+ * No autonomous side effects; a system-principal sweep (dial-up) layers on later.
+ */
+export async function consultEscalation(reportId: string): Promise<ConsultEscalationResult> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user?.id ||
+    !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")
+  ) {
+    return { ok: false, error: "Not authorized." };
+  }
+
+  const report = await prisma.platformIssueReport.findUnique({
+    where: { reportId },
+    select: {
+      reportId: true,
+      title: true,
+      description: true,
+      selfFixClass: true,
+      featureBuildId: true,
+    },
+  });
+  if (!report) return { ok: false, error: "Escalation not found." };
+
+  try {
+    const result = await evaluateBuildStudioDecision({
+      userId: user.id,
+      request: buildEscalationDecisionRequest(report),
+    });
+    return { ok: true, result };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Consult failed." };
+  }
 }
 
 // ─── Send to Build Studio as a fix ────────────────────────────────────────────

--- a/apps/web/lib/quality/escalation-responder.test.ts
+++ b/apps/web/lib/quality/escalation-responder.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEscalationDecisionRequest,
+  escalationOptionLabel,
+  escalationConsultStatusLabel,
+  ESCALATION_DECISION_OPTIONS,
+} from "./escalation-responder";
+
+describe("buildEscalationDecisionRequest", () => {
+  const base = {
+    reportId: "PIR-ESC01",
+    title: 'Build Studio needs a human: "X" stuck at plan review',
+    description: "Missing input validation on the import endpoint.",
+    selfFixClass: "needs-human",
+    featureBuildId: "fb-cuid-1",
+  };
+
+  it("routes to WWMD (source=claude → external_coding_agent / founder kernel)", () => {
+    expect(buildEscalationDecisionRequest(base).source).toBe("claude");
+  });
+
+  it("offers the three governed dispositions", () => {
+    const req = buildEscalationDecisionRequest(base);
+    expect(req.options.map((o) => o.id)).toEqual(["resume", "defer", "escalate-human"]);
+  });
+
+  it("carries the build id into trace context and the blocker into the question", () => {
+    const req = buildEscalationDecisionRequest(base);
+    expect(req.buildId).toBe("fb-cuid-1");
+    expect(req.question).toContain("Missing input validation");
+    expect(req.question).toContain("self-fix class: needs-human");
+  });
+
+  it("falls back to the title when there is no description, and omits buildId when unlinked", () => {
+    const req = buildEscalationDecisionRequest({
+      ...base,
+      description: null,
+      selfFixClass: null,
+      featureBuildId: null,
+    });
+    expect(req.buildId).toBeUndefined();
+    expect(req.question).toContain(base.title);
+    expect(req.question).not.toContain("self-fix class");
+  });
+
+  it("truncates a very long blocker", () => {
+    const req = buildEscalationDecisionRequest({ ...base, description: "x".repeat(5000) });
+    // 1500-char blocker cap keeps the prompt bounded.
+    expect(req.question.length).toBeLessThan(1900);
+  });
+});
+
+describe("escalationOptionLabel", () => {
+  it("labels each option id, with a safe fallback", () => {
+    expect(escalationOptionLabel("resume")).toBe("Resume the build");
+    expect(escalationOptionLabel("escalate-human")).toBe("Escalate to a human");
+    expect(escalationOptionLabel(null)).toBe("Review");
+    expect(escalationOptionLabel("bogus")).toBe("Review");
+  });
+
+  it("every option exposes an operator label", () => {
+    for (const o of ESCALATION_DECISION_OPTIONS) {
+      expect(escalationOptionLabel(o.id)).toBe(o.operatorLabel);
+    }
+  });
+});
+
+describe("escalationConsultStatusLabel", () => {
+  it("maps each decision status to an operator label", () => {
+    expect(escalationConsultStatusLabel("recommended")).toBe("Kernel recommends");
+    expect(escalationConsultStatusLabel("needs-human")).toBe("Needs human review");
+    expect(escalationConsultStatusLabel("blocked")).toBe("Blocked by a commandment");
+    expect(escalationConsultStatusLabel("captured-gap")).toBe("No governed decision");
+    expect(escalationConsultStatusLabel("whatever")).toBe("Consulted");
+  });
+});

--- a/apps/web/lib/quality/escalation-responder.ts
+++ b/apps/web/lib/quality/escalation-responder.ts
@@ -1,0 +1,107 @@
+// ─── Escalation Responder — WWMD consult for a held escalation (BI-0ACD9AB2) ──
+// The trusted receiving loop (design §5.3, §14): before a build-stall escalation
+// reaches a human cold, route its blocker through the governed decision scopes.
+// ~12 of every ~19 live escalations are kernel-commandment matters the planner
+// missed (input validation = "never trust input"; authz = "least privilege";
+// failing tests = TDD) — exactly what WWMD already mandates. The consult tells
+// the operator whether the kernel can resolve the blocker (resume), it is not
+// worth continuing (defer), or it is a genuine human decision.
+//
+// HITL-FIRST (dial-low, §14): the OPERATOR triggers this from the /ops attention
+// lens and reviews the recommendation; the kernel advises, the human decides. An
+// autonomous sweep (dial-up) layers on later, once a system responder principal
+// is designed. This module is the pure request shape; the call + auth live in the
+// server action (lib/actions/quality.ts consultEscalation).
+
+import type {
+  BuildStudioDecisionRequest,
+  BuildStudioDecisionResult,
+} from "@/lib/build/decision-service";
+
+export type ConsultEscalationResult =
+  | { ok: true; result: BuildStudioDecisionResult }
+  | { ok: false; error: string };
+
+export interface EscalationDecisionInput {
+  reportId: string;
+  title: string;
+  description: string | null;
+  selfFixClass: string | null;
+  /** FeatureBuild.id (cuid) — carried into the decision trace context. */
+  featureBuildId: string | null;
+}
+
+/** The three governed dispositions the responder weighs. Stable ids so the UI
+ *  can label the kernel's recommendation; the descriptions are what the decision
+ *  engine scores (semantic alignment against the principles). */
+export const ESCALATION_DECISION_OPTIONS = [
+  {
+    id: "resume",
+    operatorLabel: "Resume the build",
+    description:
+      "Resume the build — the blocker is resolvable by the governed scopes (for example a kernel commandment the planner missed: inject it as a hard plan requirement and re-plan), so no human judgement is required.",
+  },
+  {
+    id: "defer",
+    operatorLabel: "Defer or stop",
+    description:
+      "Defer or stop the build — it is not worth continuing now; park the work rather than spend more effort on it.",
+  },
+  {
+    id: "escalate-human",
+    operatorLabel: "Escalate to a human",
+    description:
+      "Escalate to a human — this is a genuine product or judgement call the governed scopes do not cover, so a person must decide.",
+  },
+] as const;
+
+/**
+ * Build the governed decision request for a held escalation. Pure.
+ *
+ * `source: "claude"` routes the consult to WWMD (the founder kernel) rather than
+ * WWWD: the founder kernel is the scope the build reviewer already enforces and
+ * where the relevant commandments (input-validation / least-privilege / TDD)
+ * live, and the escalations are largely kernel-commandment matters.
+ */
+export function buildEscalationDecisionRequest(
+  input: EscalationDecisionInput,
+): BuildStudioDecisionRequest {
+  const blocker = (input.description ?? input.title).slice(0, 1500);
+  const selfFix = input.selfFixClass ? ` (self-fix class: ${input.selfFixClass})` : "";
+  return {
+    source: "claude",
+    routeContext: "/ops",
+    ...(input.featureBuildId ? { buildId: input.featureBuildId } : {}),
+    question:
+      `A build could not self-repair${selfFix} and was escalated: "${input.title}". ` +
+      `Given the blocker below, should the build resume (the governed scopes can resolve it), ` +
+      `be deferred/stopped, or is this a genuine human decision?\n\nBlocker:\n${blocker}`,
+    options: ESCALATION_DECISION_OPTIONS.map((o) => ({
+      id: o.id,
+      description: o.description,
+      operatorLabel: o.operatorLabel,
+    })),
+  };
+}
+
+/** Operator label for a recommended option id. Pure. */
+export function escalationOptionLabel(optionId: string | undefined | null): string {
+  const opt = ESCALATION_DECISION_OPTIONS.find((o) => o.id === optionId);
+  return opt?.operatorLabel ?? "Review";
+}
+
+/** Short, operator-facing label for the consult's overall verdict. Pure. */
+export function escalationConsultStatusLabel(status: string): string {
+  switch (status) {
+    case "recommended":
+      return "Kernel recommends";
+    case "needs-human":
+      return "Needs human review";
+    case "blocked":
+      return "Blocked by a commandment";
+    case "captured-gap":
+      return "No governed decision";
+    default:
+      return "Consulted";
+  }
+}

--- a/docs/superpowers/specs/2026-06-20-issue-report-surface-attendance-design.md
+++ b/docs/superpowers/specs/2026-06-20-issue-report-surface-attendance-design.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 | ----- | ----- |
-| Status | Draft - chief architect review applied 2026-06-20; responder WWMD-consult mechanism + unified decision front door (5.7) + trust dial / autopilot maturation (§14, operator doctrine) completed 2026-06-20. Root-cause prevention (planner kernel-lens, BI-C2CB3073) shipped #2195. **Slice 1 (classifier + projection guard) shipped #2265.** **Slice 4 first cut (surface convergence): the Attention lens now surfaces in /ops; /admin/issue-reports reframed as evidence.** Receiving loop (BI-0ACD9AB2) is HITL-first per §14. Responder disposition (Slice 2) next. |
+| Status | Draft - chief architect review applied 2026-06-20; responder WWMD-consult mechanism + unified decision front door (5.7) + trust dial / autopilot maturation (§14, operator doctrine) completed 2026-06-20. Root-cause prevention (planner kernel-lens, BI-C2CB3073) shipped #2195. **Slice 1 (classifier + projection guard) shipped #2265.** **Slice 4 first cut (surface convergence): the Attention lens now surfaces in /ops; /admin/issue-reports reframed as evidence.** Receiving loop (BI-0ACD9AB2) is HITL-first per §14. **Slice 2 first cut: operator-triggered WWMD consult (dial-low / HITL-first) on each /ops escalation card — `consultEscalation` action runs the governed decision with the operator's own principal.** Autonomous system-principal sweep (dial-up) follows. |
 | Date | 2026-06-20 |
 | Trigger | Operator asked: "what process is working `/admin/issue-reports`, and what progress is made daily?" Live investigation found: no human or agent is actively attending the surface. |
 | Related epic | `EP-INTAKE-UNIFY`, especially BI-EDFBE081, re-scoped here as provenance and routing convergence. This surface is not a redundant backlog queue. |
@@ -323,6 +323,8 @@ This is an operational cleanup, not proof that the design is implemented.
 Refactor budget: shared classifier + shared status helpers replace local if/else checks in the writer, event handler, and cron.
 
 ### Slice 2 - Responder Task and SLA
+
+**Dial-low first cut shipped (§14):** an OPERATOR-triggered WWMD consult on each escalation in the `/ops` attention lens — `consultEscalation` action → `buildEscalationDecisionRequest` → `evaluateBuildStudioDecision`, run with the operator's own principal so it needs no system-responder identity and clears the system-user-sentinel guard. The kernel returns resume / defer / escalate-human with confidence + reasoning (operator-sanitized); the human decides, no autonomous side effects. The autonomous, system-principal version below is the dial-up step (its principal/authority is the careful TAK design the dial-low cut deliberately defers).
 
 - Create/claim one responder `TaskRun` per stream-3 report.
 - Link `reportId`, `featureBuildId`, `taskRunId`, trace id, and responder agent id.


### PR DESCRIPTION
## What

Turns the `/ops` escalation attention lens (#2277) from a *relocated queue* into the **trusted receiving loop**. Each escalation card gets a **Consult WWMD** action that routes the build's blocker through the governed decision (the founder kernel) and shows the kernel's recommendation: **resume / defer / escalate-human**, with confidence + operator-sanitized reasoning.

This is the load-bearing idea of the whole design — *consult the governed scopes before escalating to a human.* ~12 of every ~19 live escalations are kernel-commandment matters the planner missed (input validation, least privilege, TDD); the consult surfaces that so the operator isn't asked cold.

## HITL-first by construction (§14 dial-low)

The **operator** triggers the consult, and the decision runs with **their own principal** — so it needs no system-responder identity and cleanly clears the `system-user-sentinel` CI guard. The human asks, the kernel advises, the human decides; **no autonomous side effects.**

The autonomous, system-principal sweep (dial-up) is deliberately deferred — its principal/authority is the careful TAK design, and the dial-low cut delivers the value now without that risk. This is exactly the §14 maturation: start HITL-first, earn autonomy later.

## How

- **`buildEscalationDecisionRequest`** (pure): the three-option governed request. `source=claude` routes to **WWMD** (the founder kernel) — the scope the build reviewer already enforces and where the relevant commandments live.
- **`consultEscalation`** server action: `auth(view_platform)` → fetch the report → `evaluateBuildStudioDecision` (the server-callable `decide()` wrapper) with the operator's `userId`.
- **`EscalationConsult`** client widget: button → result (verdict + recommended action + reasoning), with re-consult / retry. Rendered per card in the attention lens.
- Spec §5.3 / Slice 2 + status updated; pure helpers (`buildEscalationDecisionRequest`, `escalationOptionLabel`, `escalationConsultStatusLabel`) unit-tested.

## Note on scope

Queue **consolidation** completed with #2277 (the goal). This PR is the **enhancement** on top — the decision-front-door quality layer that makes the converged surface trustworthy rather than merely consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)