### PR TITLE
feat(assurance): auto-file gate findings with reconcile + fold findings panel (BI-91D1524F)

### DIFF
--- a/apps/web/components/build/AssuranceFindingsList.test.tsx
+++ b/apps/web/components/build/AssuranceFindingsList.test.tsx
@@ -39,6 +39,8 @@ const baseFinding = {
     version: "1.2.0",
     packageUrl: "pkg:npm/vulnerable-lib@1.2.0",
   },
+  backlogItemId: null,
+  autoFileReason: null,
 };
 
 describe("AssuranceFindingsList", () => {
@@ -91,5 +93,29 @@ describe("AssuranceFindingsList", () => {
 
     expect(screen.queryByTestId("assurance-finding-status-select")).not.toBeInTheDocument();
     expect(screen.queryByTestId("assurance-finding-create-backlog")).not.toBeInTheDocument();
+  });
+
+  it("shows the linked backlog item in read-only mode when auto-filed", () => {
+    render(
+      <AssuranceFindingsList
+        findings={[{ ...baseFinding, backlogItemId: "BI-AUTO-1", autoFileReason: "auto-file:critical" }]}
+        readOnly
+      />,
+    );
+
+    expect(screen.getByTestId("assurance-finding-linked")).toHaveTextContent("Linked BI-AUTO-1");
+  });
+
+  it("shows a friendly disposition label when a finding is suppressed", () => {
+    render(
+      <AssuranceFindingsList
+        findings={[{ ...baseFinding, autoFileReason: "stale-sandbox: hono@4.12.19 not resolved on main (main: 4.12.25)" }]}
+        readOnly
+      />,
+    );
+
+    const disposition = screen.getByTestId("assurance-finding-disposition");
+    expect(disposition).toHaveTextContent("Resolved on main (stale build)");
+    expect(disposition).toHaveAttribute("title", expect.stringContaining("stale-sandbox"));
   });
 });

--- a/apps/web/components/build/AssuranceFindingsList.tsx
+++ b/apps/web/components/build/AssuranceFindingsList.tsx
@@ -54,6 +54,17 @@ function componentLabel(finding: ActiveAssuranceFindingRow): string {
   return finding.affectedId;
 }
 
+/** Turn a raw auto-file disposition reason into a short, friendly label. */
+function dispositionLabel(reason: string): string {
+  if (reason.startsWith("accepted-in-baseline")) return "Accepted (baseline)";
+  if (reason.startsWith("stale-sandbox")) return "Resolved on main (stale build)";
+  if (reason.startsWith("below-auto-file-threshold")) return "Tracked as evidence";
+  if (reason.startsWith("reconcile-context-unavailable")) return "Pending verification";
+  if (reason.startsWith("already-linked")) return "Linked";
+  if (reason.startsWith("auto-file")) return "Auto-filed";
+  return reason;
+}
+
 interface FindingRowProps {
   finding: ActiveAssuranceFindingRow;
   readOnly?: boolean;
@@ -89,9 +100,25 @@ function FindingRow({ finding, readOnly }: FindingRowProps) {
       </div>
 
       {readOnly ? (
-        <p className="text-[var(--dpf-muted)]">
-          Status: <span className="font-medium text-[var(--dpf-text)]">{status}</span>
-        </p>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[var(--dpf-muted)]">
+          {finding.backlogItemId ? (
+            <span
+              data-testid="assurance-finding-linked"
+              className="inline-flex items-center gap-1 font-medium text-[var(--dpf-text)]"
+            >
+              <FilePlus className="h-3.5 w-3.5" aria-hidden="true" />
+              Linked {finding.backlogItemId}
+            </span>
+          ) : finding.autoFileReason ? (
+            <span data-testid="assurance-finding-disposition" title={finding.autoFileReason}>
+              {dispositionLabel(finding.autoFileReason)}
+            </span>
+          ) : (
+            <span>
+              Status: <span className="font-medium text-[var(--dpf-text)]">{status}</span>
+            </span>
+          )}
+        </div>
       ) : (
         <div className="flex flex-wrap items-center gap-2">
           <label className="flex items-center gap-2">

--- a/apps/web/components/build/BuildAssuranceGateCard.test.tsx
+++ b/apps/web/components/build/BuildAssuranceGateCard.test.tsx
@@ -280,6 +280,8 @@ describe("BuildAssuranceGateCard", () => {
               version: "1.2.0",
               packageUrl: "pkg:npm/vulnerable-lib@1.2.0",
             },
+            backlogItemId: null,
+            autoFileReason: null,
           },
         ]}
       />,

--- a/apps/web/components/build/BuildAssuranceGateCard.tsx
+++ b/apps/web/components/build/BuildAssuranceGateCard.tsx
@@ -186,9 +186,13 @@ export function BuildAssuranceGateCard({
 
       <div className="mt-3 border-t border-[var(--dpf-border)] pt-3">
         <p className="text-xs font-semibold text-[var(--dpf-text)]">Active findings</p>
+        <p className="mt-0.5 text-[11px] text-[var(--dpf-muted)]">
+          Genuine findings file backlog items automatically; accepted and already-fixed-on-main advisories are suppressed.
+        </p>
         <div className="mt-2">
           <AssuranceFindingsList
             findings={findings}
+            readOnly
             emptyLabel={emptyFindingsLabel(summary, hasBom)}
           />
         </div>

--- a/apps/web/components/product/ProductSupplyChainPanel.test.tsx
+++ b/apps/web/components/product/ProductSupplyChainPanel.test.tsx
@@ -172,6 +172,8 @@ describe("ProductSupplyChainPanel", () => {
               version: "1.2.0",
               packageUrl: "pkg:npm/vulnerable-lib@1.2.0",
             },
+            backlogItemId: null,
+            autoFileReason: null,
           },
         ]}
       />,

--- a/apps/web/lib/assurance/advisory-context.test.ts
+++ b/apps/web/lib/assurance/advisory-context.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReconcileContext,
+  parseAcceptedAdvisoryIds,
+  parseResolvedVersions,
+} from "./advisory-context";
+
+const SAMPLE_LOCK = `importers:
+
+  apps/web:
+    dependencies:
+      hono:
+        specifier: ^4.12.25
+        version: 4.12.25
+
+packages:
+
+  hono@4.12.25:
+    resolution: {integrity: sha512-aaa}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-bbb}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-ccc}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-ddd}
+
+snapshots:
+
+  '@auth/core@0.41.2(nodemailer@9.0.1)':
+    dependencies: {}
+
+  hono@4.12.25: {}
+`;
+
+describe("parseResolvedVersions", () => {
+  it("collects every resolved version per package, scoped and unscoped", () => {
+    const map = parseResolvedVersions(SAMPLE_LOCK);
+    expect(map.get("hono")).toEqual(new Set(["4.12.25"]));
+    expect(map.get("@babel/core")).toEqual(new Set(["7.29.7"]));
+    expect(map.get("undici")).toEqual(new Set(["7.28.0", "8.5.0"]));
+  });
+
+  it("skips peer-suffixed snapshot keys and importer paths", () => {
+    const map = parseResolvedVersions(SAMPLE_LOCK);
+    expect(map.has("@auth/core")).toBe(false);
+    expect(map.has("apps/web")).toBe(false);
+  });
+
+  it("handles CRLF line endings", () => {
+    const map = parseResolvedVersions(SAMPLE_LOCK.replace(/\n/g, "\r\n"));
+    expect(map.get("hono")).toEqual(new Set(["4.12.25"]));
+  });
+});
+
+const SAMPLE_BASELINE = JSON.stringify({
+  accepted: [
+    { id: "GHSA-h67p-54hq-rp68", aliases: ["CVE-2026-53550"], expires: "2026-12-31" },
+    { id: "GHSA-expired", aliases: ["CVE-OLD"], expires: "2020-01-01" },
+    { id: "GHSA-noexpiry" },
+  ],
+});
+
+describe("parseAcceptedAdvisoryIds", () => {
+  it("includes unexpired ids and their aliases", () => {
+    const ids = parseAcceptedAdvisoryIds(SAMPLE_BASELINE, "2026-06-22");
+    expect(ids.has("GHSA-h67p-54hq-rp68")).toBe(true);
+    expect(ids.has("CVE-2026-53550")).toBe(true);
+    expect(ids.has("GHSA-noexpiry")).toBe(true);
+  });
+
+  it("excludes advisories past their expiry (they re-surface)", () => {
+    const ids = parseAcceptedAdvisoryIds(SAMPLE_BASELINE, "2026-06-22");
+    expect(ids.has("GHSA-expired")).toBe(false);
+    expect(ids.has("CVE-OLD")).toBe(false);
+  });
+
+  it("returns an empty set on malformed JSON", () => {
+    expect(parseAcceptedAdvisoryIds("{not json", "2026-06-22").size).toBe(0);
+  });
+});
+
+describe("buildReconcileContext", () => {
+  it("is available with accepted ids + resolved versions when both sources load", () => {
+    const ctx = buildReconcileContext({
+      readLock: () => SAMPLE_LOCK,
+      readBaseline: () => SAMPLE_BASELINE,
+      today: "2026-06-22",
+    });
+    expect(ctx.available).toBe(true);
+    expect(ctx.acceptedAdvisoryIds.has("CVE-2026-53550")).toBe(true);
+    expect(ctx.resolvedVersionsByPackage.get("hono")).toEqual(new Set(["4.12.25"]));
+  });
+
+  it("fails closed (available=false) when the lockfile cannot be read", () => {
+    const ctx = buildReconcileContext({
+      readLock: () => null,
+      readBaseline: () => SAMPLE_BASELINE,
+      today: "2026-06-22",
+    });
+    expect(ctx.available).toBe(false);
+  });
+
+  it("tolerates a missing baseline (lock present → still available, no accepts)", () => {
+    const ctx = buildReconcileContext({
+      readLock: () => SAMPLE_LOCK,
+      readBaseline: () => null,
+      today: "2026-06-22",
+    });
+    expect(ctx.available).toBe(true);
+    expect(ctx.acceptedAdvisoryIds.size).toBe(0);
+  });
+
+  it("fails closed when a reader throws", () => {
+    const ctx = buildReconcileContext({
+      readLock: () => {
+        throw new Error("boom");
+      },
+      readBaseline: () => SAMPLE_BASELINE,
+      today: "2026-06-22",
+    });
+    expect(ctx.available).toBe(false);
+  });
+});

--- a/apps/web/lib/assurance/advisory-context.ts
+++ b/apps/web/lib/assurance/advisory-context.ts
@@ -1,0 +1,123 @@
+// apps/web/lib/assurance/advisory-context.ts
+//
+// Builds the ReconcileContext (apps/web/lib/assurance/finding-reconcile.ts) the
+// Assurance Gate uses to decide which sandbox findings are genuine on MAIN:
+//   - accepted advisories  ← sbom/vuln-baseline.json (the same ledger the OSV
+//     script scripts/sbom/scan-dependencies.mjs honors; the in-platform pnpm-
+//     audit path previously ignored it, which re-filed accepted advisories).
+//   - main's resolved versions ← pnpm-lock.yaml (full tree, incl. transitive).
+//
+// CARRIER DECISION (BI-91D1524F): read from the platform PROJECT_ROOT at scan
+// time (where the portal runs from main), behind injectable readers. If either
+// source is unreadable the context reports available=false and auto-file FAILS
+// CLOSED — never auto-creating work it cannot verify. Follow-up: bundle a
+// generated snapshot so verification also works inside a stripped image.
+//
+// SERVER-ONLY (uses node:fs); imported by the scan job, never by client code.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ReconcileContext } from "./finding-reconcile";
+
+export interface AdvisoryContextReaders {
+  /** Returns sbom/vuln-baseline.json text, or null if unreadable. */
+  readBaseline: () => string | null;
+  /** Returns pnpm-lock.yaml text, or null if unreadable. */
+  readLock: () => string | null;
+  /** YYYY-MM-DD; defaults to today. Injected in tests for deterministic expiry. */
+  today?: string;
+}
+
+/**
+ * Extract every resolved version per package from a pnpm v9 lockfile, including
+ * transitive deps. Scans the canonical `name@version:` keys (the `packages:`
+ * map). Scoped names are quoted (`'@babel/core@7.29.7':`); peer-suffixed
+ * `snapshots:` keys (which contain `(`) are skipped — their versions also appear
+ * unsuffixed in `packages:`, so coverage is complete and de-duplicated.
+ */
+export function parseResolvedVersions(lockText: string): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  const lines = lockText.replace(/\r\n/g, "\n").split("\n");
+  // Two-space indent, optional surrounding quotes, name@version, trailing colon.
+  // The version group starts with a digit so the LAST '@' splits scope from version.
+  const re = /^ {2}'?(.+?)@([0-9][^()':\s]*?)'?:$/;
+  for (const line of lines) {
+    if (line.includes("(")) continue;
+    const m = re.exec(line);
+    if (!m) continue;
+    const name = m[1];
+    const version = m[2];
+    if (!name || !version) continue;
+    let set = out.get(name);
+    if (!set) {
+      set = new Set<string>();
+      out.set(name, set);
+    }
+    set.add(version);
+  }
+  return out;
+}
+
+/** Accepted + unexpired advisory ids (id + aliases) from vuln-baseline.json. */
+export function parseAcceptedAdvisoryIds(baselineText: string, today: string): Set<string> {
+  const ids = new Set<string>();
+  let parsed: { accepted?: Array<{ id?: string; aliases?: string[]; expires?: string }> };
+  try {
+    parsed = JSON.parse(baselineText) as typeof parsed;
+  } catch {
+    return ids;
+  }
+  for (const entry of parsed.accepted ?? []) {
+    // An entry past its expiry re-surfaces (mirrors scan-dependencies.mjs).
+    if (entry.expires && entry.expires < today) continue;
+    if (entry.id) ids.add(entry.id);
+    for (const alias of entry.aliases ?? []) {
+      if (alias) ids.add(alias);
+    }
+  }
+  return ids;
+}
+
+function safe<T>(fn: () => T): T | null {
+  try {
+    return fn();
+  } catch {
+    return null;
+  }
+}
+
+export function buildReconcileContext(readers: AdvisoryContextReaders): ReconcileContext {
+  const today = readers.today ?? new Date().toISOString().slice(0, 10);
+  const lockText = safe(() => readers.readLock());
+  const resolvedVersionsByPackage = lockText ? parseResolvedVersions(lockText) : new Map<string, Set<string>>();
+  const baselineText = safe(() => readers.readBaseline());
+  const acceptedAdvisoryIds = baselineText ? parseAcceptedAdvisoryIds(baselineText, today) : new Set<string>();
+
+  // The staleness oracle (main's resolved versions) is the load-bearing input;
+  // without it we cannot verify a finding against main, so fail closed.
+  const available = resolvedVersionsByPackage.size > 0;
+
+  return { available, acceptedAdvisoryIds, resolvedVersionsByPackage };
+}
+
+function readTextOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function defaultAdvisoryReaders(
+  root: string = process.env.PROJECT_ROOT ?? process.cwd(),
+): AdvisoryContextReaders {
+  return {
+    readLock: () => readTextOrNull(join(root, "pnpm-lock.yaml")),
+    readBaseline: () => readTextOrNull(join(root, "sbom", "vuln-baseline.json")),
+  };
+}
+
+/** Convenience: build the context from the platform project root. */
+export function loadReconcileContext(root?: string): ReconcileContext {
+  return buildReconcileContext(defaultAdvisoryReaders(root));
+}

--- a/apps/web/lib/assurance/auto-file-findings.test.ts
+++ b/apps/web/lib/assurance/auto-file-findings.test.ts
@@ -34,7 +34,9 @@ function finding(overrides: Partial<NormalizedAssuranceFinding> = {}): Normalize
 
 function createDb() {
   return {
-    assuranceFinding: { update: vi.fn(async () => ({ id: "x" })) },
+    assuranceFinding: {
+      update: vi.fn(async (_args: { where: unknown; data: Record<string, unknown> }) => ({ id: "x" })),
+    },
   };
 }
 
@@ -115,7 +117,7 @@ describe("autoFileFindingsFromScan", () => {
 
     expect(totals).toEqual({ filed: 0, suppressed: 1, evidenceOnly: 0 });
     expect(ingest).not.toHaveBeenCalled();
-    const call = db.assuranceFinding.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    const call = db.assuranceFinding.update.mock.calls[0]![0];
     expect(call.data.status).toBe("accepted");
     expect(call.data.resolvedAt).toBeUndefined();
   });
@@ -134,7 +136,7 @@ describe("autoFileFindingsFromScan", () => {
 
     expect(totals).toEqual({ filed: 0, suppressed: 0, evidenceOnly: 1 });
     expect(ingest).not.toHaveBeenCalled();
-    const call = db.assuranceFinding.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    const call = db.assuranceFinding.update.mock.calls[0]![0];
     expect(call.data.status).toBeUndefined();
     expect(call.data.evidence).toMatchObject({ autoFile: { action: "evidence-only" } });
   });

--- a/apps/web/lib/assurance/auto-file-findings.test.ts
+++ b/apps/web/lib/assurance/auto-file-findings.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { autoFileFindingsFromScan } from "./auto-file-findings";
+import type { ReconcileContext } from "./finding-reconcile";
+import type { NormalizedAssuranceFinding } from "./types";
+
+function ctx(overrides: Partial<ReconcileContext> = {}): ReconcileContext {
+  return {
+    available: true,
+    acceptedAdvisoryIds: new Set<string>(),
+    resolvedVersionsByPackage: new Map<string, Set<string>>(),
+    ...overrides,
+  };
+}
+
+function finding(overrides: Partial<NormalizedAssuranceFinding> = {}): NormalizedAssuranceFinding {
+  return {
+    adapterKey: "pnpm-audit",
+    findingKind: "vulnerability",
+    affectedType: "bom-component",
+    affectedId: "pkg:npm/hono@4.12.25",
+    vendorIdentifier: "GHSA-aaaa",
+    findingKey: "fk-1",
+    title: "hono: something",
+    policySeverity: "high",
+    releaseImpact: "block",
+    reachability: "unknown",
+    exposure: "unknown",
+    identifierStability: "strong",
+    evidence: { moduleName: "hono", observedVersion: "4.12.25", cves: ["CVE-1"] },
+    remediationHint: { patchedVersions: ">=4.12.25" },
+    ...overrides,
+  };
+}
+
+function createDb() {
+  return {
+    assuranceFinding: { update: vi.fn(async () => ({ id: "x" })) },
+  };
+}
+
+function fakeIngest() {
+  let n = 0;
+  return vi.fn(async () => ({ itemId: `BI-NEW-${++n}`, id: `cuid-${n}`, created: true }));
+}
+
+describe("autoFileFindingsFromScan", () => {
+  it("files a genuine high finding through ingest and links it on the finding", async () => {
+    const db = createDb();
+    const ingest = fakeIngest();
+    const totals = await autoFileFindingsFromScan({
+      db: db as never,
+      findings: [finding()],
+      context: ctx({ resolvedVersionsByPackage: new Map([["hono", new Set(["4.12.25"])]]) }),
+      buildId: "FB-1",
+      digitalProductId: "prod-1",
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      ingest,
+    });
+
+    expect(totals).toEqual({ filed: 1, suppressed: 0, evidenceOnly: 0 });
+    expect(ingest).toHaveBeenCalledTimes(1);
+    expect(ingest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Remediate: hono: something",
+        workType: "bug",
+        source: "automated-detection",
+        proposedOutcome: "build",
+        epicId: "EP-ASSURANCE-LEDGER",
+        origin: { kind: "assuranceFinding", id: "fk-1" },
+      }),
+    );
+    expect(db.assuranceFinding.update).toHaveBeenCalledWith({
+      where: { findingKey: "fk-1" },
+      data: expect.objectContaining({
+        status: "planned",
+        evidence: expect.objectContaining({ backlogItemId: "BI-NEW-1" }),
+      }),
+    });
+  });
+
+  it("suppresses a stale finding as false-positive without filing", async () => {
+    const db = createDb();
+    const ingest = fakeIngest();
+    const totals = await autoFileFindingsFromScan({
+      db: db as never,
+      findings: [finding({ evidence: { moduleName: "hono", observedVersion: "4.12.19" } })],
+      context: ctx({ resolvedVersionsByPackage: new Map([["hono", new Set(["4.12.25"])]]) }),
+      buildId: "FB-1",
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      ingest,
+    });
+
+    expect(totals).toEqual({ filed: 0, suppressed: 1, evidenceOnly: 0 });
+    expect(ingest).not.toHaveBeenCalled();
+    expect(db.assuranceFinding.update).toHaveBeenCalledWith({
+      where: { findingKey: "fk-1" },
+      data: expect.objectContaining({
+        status: "false-positive",
+        resolvedAt: new Date("2026-06-22T00:00:00.000Z"),
+      }),
+    });
+  });
+
+  it("suppresses an accepted-baseline finding as accepted (not terminal)", async () => {
+    const db = createDb();
+    const ingest = fakeIngest();
+    const totals = await autoFileFindingsFromScan({
+      db: db as never,
+      findings: [finding({ vendorIdentifier: "GHSA-acc", evidence: { moduleName: "js-yaml", observedVersion: "3.14.2" } })],
+      context: ctx({ acceptedAdvisoryIds: new Set(["GHSA-acc"]) }),
+      buildId: "FB-1",
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      ingest,
+    });
+
+    expect(totals).toEqual({ filed: 0, suppressed: 1, evidenceOnly: 0 });
+    expect(ingest).not.toHaveBeenCalled();
+    const call = db.assuranceFinding.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(call.data.status).toBe("accepted");
+    expect(call.data.resolvedAt).toBeUndefined();
+  });
+
+  it("keeps a low finding as evidence-only and never files", async () => {
+    const db = createDb();
+    const ingest = fakeIngest();
+    const totals = await autoFileFindingsFromScan({
+      db: db as never,
+      findings: [finding({ policySeverity: "low", evidence: { moduleName: "pkg", observedVersion: "1.0.0" } })],
+      context: ctx({ resolvedVersionsByPackage: new Map([["pkg", new Set(["1.0.0"])]]) }),
+      buildId: "FB-1",
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      ingest,
+    });
+
+    expect(totals).toEqual({ filed: 0, suppressed: 0, evidenceOnly: 1 });
+    expect(ingest).not.toHaveBeenCalled();
+    const call = db.assuranceFinding.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(call.data.status).toBeUndefined();
+    expect(call.data.evidence).toMatchObject({ autoFile: { action: "evidence-only" } });
+  });
+
+  it("fails closed: no filing when the reconcile context is unavailable", async () => {
+    const db = createDb();
+    const ingest = fakeIngest();
+    const totals = await autoFileFindingsFromScan({
+      db: db as never,
+      findings: [finding(), finding({ findingKey: "fk-2", policySeverity: "critical" })],
+      context: ctx({ available: false }),
+      buildId: "FB-1",
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      ingest,
+    });
+
+    expect(totals).toEqual({ filed: 0, suppressed: 0, evidenceOnly: 2 });
+    expect(ingest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/assurance/auto-file-findings.ts
+++ b/apps/web/lib/assurance/auto-file-findings.ts
@@ -1,0 +1,144 @@
+// apps/web/lib/assurance/auto-file-findings.ts
+//
+// The auto-file step the Assurance Gate runs after persisting findings. It closes
+// the "lost queue" (findings that only became backlog items via a manual per-
+// finding button) by filing GENUINE findings through the shared ingestBacklogItem
+// front door (EP-INTAKE-UNIFY) — no operator click — while reconciling against
+// main first so stale/accepted findings never spawn phantom work.
+//
+// Disposition (apps/web/lib/assurance/finding-reconcile.ts, founder-kernel policy):
+//   file          → ingest a BI (high/critical=build, moderate=deferred); status→planned
+//   suppress      → accepted-in-baseline (status→accepted) | stale-on-main (status→false-positive)
+//   evidence-only → already-linked | low/info | reconcile-context-unavailable (fail-closed)
+//
+// Every finding is annotated with `evidence.autoFile` so the read-only panel can
+// show "Linked BI-…" or "suppressed: <reason>".
+
+import {
+  decideFindingDisposition,
+  emptyDispositionTotals,
+  type DispositionTotals,
+  type ReconcileContext,
+} from "./finding-reconcile";
+import {
+  ingestBacklogItem,
+  type BacklogIngestInput,
+  type BacklogIngestResult,
+} from "@/lib/operate/backlog-ingest";
+import type { AssuranceFindingStatus, NormalizedAssuranceFinding } from "./types";
+
+export const ASSURANCE_AUTO_FILE_EPIC = "EP-ASSURANCE-LEDGER";
+
+const TERMINAL_STATUSES = new Set<AssuranceFindingStatus>(["resolved", "false-positive"]);
+
+export interface AutoFileFindingsDb {
+  assuranceFinding: {
+    update(args: unknown): Promise<unknown>;
+  };
+}
+
+export interface AutoFileFindingsInput {
+  db: AutoFileFindingsDb;
+  findings: NormalizedAssuranceFinding[];
+  context: ReconcileContext;
+  buildId: string;
+  digitalProductId?: string | null;
+  now: Date;
+  epicId?: string;
+  /** Injectable for tests; defaults to the shared backlog front door. */
+  ingest?: (input: BacklogIngestInput) => Promise<BacklogIngestResult>;
+}
+
+function severityLabel(severity: string): string {
+  return severity ? severity.toUpperCase() : "UNKNOWN";
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function autoFileBody(
+  finding: NormalizedAssuranceFinding,
+  buildId: string,
+  digitalProductId: string | null | undefined,
+  reason: string,
+): string {
+  const moduleName = asString(finding.evidence.moduleName);
+  const observed = asString(finding.evidence.observedVersion);
+  const patched = asString(finding.remediationHint?.patchedVersions);
+  return [
+    `Auto-filed by the Build Studio Assurance Gate from finding ${finding.findingKey} (${finding.vendorIdentifier}).`,
+    "",
+    `Severity: ${severityLabel(finding.policySeverity)}`,
+    `Build: ${buildId}`,
+    digitalProductId ? `Product: ${digitalProductId}` : null,
+    moduleName && observed ? `Observed: ${moduleName}@${observed}` : null,
+    patched ? `Patched: ${patched}` : null,
+    `Disposition: ${reason}`,
+    "",
+    "Reconciled against main before filing (accepted-baseline + stale-version checks); the finding evidence carries the back-link.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Apply the auto-file policy to a freshly-persisted set of normalized findings.
+ * Returns how many were filed, suppressed, or retained as evidence.
+ */
+export async function autoFileFindingsFromScan(input: AutoFileFindingsInput): Promise<DispositionTotals> {
+  const ingest = input.ingest ?? ingestBacklogItem;
+  const epicId = input.epicId ?? ASSURANCE_AUTO_FILE_EPIC;
+  const totals = emptyDispositionTotals();
+
+  for (const finding of input.findings) {
+    const disposition = decideFindingDisposition(finding, input.context);
+    let backlogItemId: string | null = null;
+
+    if (disposition.action === "file") {
+      const item = await ingest({
+        title: `Remediate: ${finding.title}`.slice(0, 180),
+        body: autoFileBody(finding, input.buildId, input.digitalProductId, disposition.reason),
+        type: "product",
+        workType: "bug",
+        source: "automated-detection",
+        proposedOutcome: disposition.proposedOutcome,
+        effortSize: "medium",
+        epicId,
+        digitalProductId: input.digitalProductId ?? undefined,
+        ...(typeof disposition.priority === "number" ? { priority: disposition.priority } : {}),
+        origin: { kind: "assuranceFinding", id: finding.findingKey },
+      });
+      backlogItemId = item.itemId;
+      totals.filed += 1;
+    } else if (disposition.action === "suppress") {
+      totals.suppressed += 1;
+    } else {
+      totals.evidenceOnly += 1;
+    }
+
+    const data: Record<string, unknown> = {
+      evidence: {
+        ...finding.evidence,
+        ...(backlogItemId ? { backlogItemId } : {}),
+        autoFile: {
+          action: disposition.action,
+          reason: disposition.reason,
+          at: input.now.toISOString(),
+          ...(backlogItemId ? { backlogItemId } : {}),
+        },
+      },
+    };
+    if (disposition.findingStatus) {
+      data.status = disposition.findingStatus;
+      if (TERMINAL_STATUSES.has(disposition.findingStatus)) data.resolvedAt = input.now;
+    }
+
+    await input.db.assuranceFinding.update({
+      where: { findingKey: finding.findingKey },
+      data,
+    });
+  }
+
+  return totals;
+}

--- a/apps/web/lib/assurance/finding-read.ts
+++ b/apps/web/lib/assurance/finding-read.ts
@@ -29,6 +29,10 @@ export interface ActiveAssuranceFindingRow {
     version: string | null;
     packageUrl: string | null;
   };
+  /** Linked backlog item (set once the finding is filed / auto-filed). */
+  backlogItemId: string | null;
+  /** Auto-file disposition reason (e.g. "suppressed: stale-sandbox …"). */
+  autoFileReason: string | null;
 }
 
 type FindingSummaryRow = {
@@ -134,12 +138,28 @@ type FindingListRow = {
   affectedType: string;
   affectedId: string;
   lastSeenAt: Date;
+  evidence?: unknown;
   bomComponent?: null | {
     name: string;
     version: string | null;
     packageUrl: string | null;
   };
 };
+
+function readEvidenceLinks(evidence: unknown): { backlogItemId: string | null; autoFileReason: string | null } {
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
+    return { backlogItemId: null, autoFileReason: null };
+  }
+  const e = evidence as Record<string, unknown>;
+  const backlogItemId = typeof e.backlogItemId === "string" && e.backlogItemId ? e.backlogItemId : null;
+  let autoFileReason: string | null = null;
+  const autoFile = e.autoFile;
+  if (autoFile && typeof autoFile === "object" && !Array.isArray(autoFile)) {
+    const reason = (autoFile as Record<string, unknown>).reason;
+    if (typeof reason === "string" && reason) autoFileReason = reason;
+  }
+  return { backlogItemId, autoFileReason };
+}
 
 type FindingListDb = {
   assuranceFinding?: {
@@ -161,6 +181,7 @@ function toActiveFindingRow(row: FindingListRow): ActiveAssuranceFindingRow {
   const severity = ASSURANCE_POLICY_SEVERITIES.includes(row.policySeverity as AssurancePolicySeverity)
     ? (row.policySeverity as AssurancePolicySeverity)
     : "info";
+  const { backlogItemId, autoFileReason } = readEvidenceLinks(row.evidence);
   return {
     findingKey: row.findingKey,
     findingKind: row.findingKind,
@@ -178,6 +199,8 @@ function toActiveFindingRow(row: FindingListRow): ActiveAssuranceFindingRow {
       version: row.bomComponent.version,
       packageUrl: row.bomComponent.packageUrl,
     } : null,
+    backlogItemId,
+    autoFileReason,
   };
 }
 
@@ -217,6 +240,7 @@ async function listActiveFindings(
       affectedType: true,
       affectedId: true,
       lastSeenAt: true,
+      evidence: true,
       bomComponent: {
         select: {
           name: true,

--- a/apps/web/lib/assurance/finding-reconcile.test.ts
+++ b/apps/web/lib/assurance/finding-reconcile.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideFindingDisposition,
+  linkedBacklogItemId,
+  MODERATE_AUTO_FILE_PRIORITY,
+  type ReconcileContext,
+  type ReconcileFindingInput,
+} from "./finding-reconcile";
+
+function ctx(overrides: Partial<ReconcileContext> = {}): ReconcileContext {
+  return {
+    available: true,
+    acceptedAdvisoryIds: new Set<string>(),
+    resolvedVersionsByPackage: new Map<string, Set<string>>(),
+    ...overrides,
+  };
+}
+
+function finding(overrides: Partial<ReconcileFindingInput> = {}): ReconcileFindingInput {
+  return {
+    findingKey: "fk-1",
+    vendorIdentifier: "GHSA-aaaa-bbbb-cccc",
+    policySeverity: "high",
+    evidence: { moduleName: "hono", observedVersion: "4.12.25", cves: ["CVE-2026-0001"] },
+    ...overrides,
+  };
+}
+
+describe("decideFindingDisposition", () => {
+  it("fails closed (evidence-only) when the reconcile context is unavailable", () => {
+    const d = decideFindingDisposition(finding(), ctx({ available: false }));
+    expect(d.action).toBe("evidence-only");
+    expect(d.reason).toContain("fail-closed");
+  });
+
+  it("never re-files an already-linked finding", () => {
+    const d = decideFindingDisposition(
+      finding({ evidence: { moduleName: "hono", observedVersion: "4.12.25", backlogItemId: "BI-EXISTING" } }),
+      ctx({ resolvedVersionsByPackage: new Map([["hono", new Set(["4.12.25"])]]) }),
+    );
+    expect(d.action).toBe("evidence-only");
+    expect(d.reason).toBe("already-linked:BI-EXISTING");
+  });
+
+  it("suppresses an advisory accepted in the baseline by vendor identifier", () => {
+    const d = decideFindingDisposition(
+      finding({ vendorIdentifier: "GHSA-h67p-54hq-rp68" }),
+      ctx({ acceptedAdvisoryIds: new Set(["GHSA-h67p-54hq-rp68"]) }),
+    );
+    expect(d.action).toBe("suppress");
+    expect(d.reason).toContain("accepted-in-baseline:GHSA-h67p-54hq-rp68");
+  });
+
+  it("suppresses an advisory accepted in the baseline by aliased CVE", () => {
+    const d = decideFindingDisposition(
+      finding({ vendorIdentifier: "GHSA-zzzz", evidence: { moduleName: "js-yaml", observedVersion: "3.14.2", cves: ["CVE-2026-53550"] } }),
+      ctx({ acceptedAdvisoryIds: new Set(["CVE-2026-53550"]) }),
+    );
+    expect(d.action).toBe("suppress");
+    expect(d.reason).toContain("CVE-2026-53550");
+  });
+
+  it("suppresses a stale-sandbox finding whose version main does not resolve", () => {
+    const d = decideFindingDisposition(
+      finding({ policySeverity: "high", evidence: { moduleName: "hono", observedVersion: "4.12.19" } }),
+      ctx({ resolvedVersionsByPackage: new Map([["hono", new Set(["4.12.25"])]]) }),
+    );
+    expect(d.action).toBe("suppress");
+    expect(d.reason).toContain("stale-sandbox");
+    expect(d.reason).toContain("4.12.19");
+  });
+
+  it("files a genuine high finding whose version main actually resolves", () => {
+    const d = decideFindingDisposition(
+      finding({ policySeverity: "high", evidence: { moduleName: "hono", observedVersion: "4.12.25" } }),
+      ctx({ resolvedVersionsByPackage: new Map([["hono", new Set(["4.12.25"])]]) }),
+    );
+    expect(d.action).toBe("file");
+    expect(d.proposedOutcome).toBe("build");
+  });
+
+  it("does NOT suppress on staleness when main's versions for the package are unknown", () => {
+    const d = decideFindingDisposition(
+      finding({ policySeverity: "critical", evidence: { moduleName: "obscure-pkg", observedVersion: "1.0.0" } }),
+      ctx(), // empty resolved map → cannot prove stale → must not hide
+    );
+    expect(d.action).toBe("file");
+    expect(d.proposedOutcome).toBe("build");
+  });
+
+  it("files moderate findings as deferred, low-priority", () => {
+    const d = decideFindingDisposition(
+      finding({ policySeverity: "medium", evidence: { moduleName: "pkg", observedVersion: "1.0.0" } }),
+      ctx({ resolvedVersionsByPackage: new Map([["pkg", new Set(["1.0.0"])]]) }),
+    );
+    expect(d.action).toBe("file");
+    expect(d.proposedOutcome).toBe("defer");
+    expect(d.priority).toBe(MODERATE_AUTO_FILE_PRIORITY);
+  });
+
+  it("keeps low/info findings as evidence only", () => {
+    for (const severity of ["low", "info"] as const) {
+      const d = decideFindingDisposition(
+        finding({ policySeverity: severity, evidence: { moduleName: "pkg", observedVersion: "1.0.0" } }),
+        ctx({ resolvedVersionsByPackage: new Map([["pkg", new Set(["1.0.0"])]]) }),
+      );
+      expect(d.action).toBe("evidence-only");
+      expect(d.reason).toContain("below-auto-file-threshold");
+    }
+  });
+});
+
+describe("linkedBacklogItemId", () => {
+  it("returns the id when present and null otherwise", () => {
+    expect(linkedBacklogItemId(finding({ evidence: { backlogItemId: "BI-1" } }))).toBe("BI-1");
+    expect(linkedBacklogItemId(finding({ evidence: {} }))).toBeNull();
+  });
+});

--- a/apps/web/lib/assurance/finding-reconcile.ts
+++ b/apps/web/lib/assurance/finding-reconcile.ts
@@ -1,0 +1,163 @@
+// apps/web/lib/assurance/finding-reconcile.ts
+//
+// Reconcile + auto-file policy for Build Studio Assurance Gate findings.
+//
+// WHY: the gate's pnpm-audit runs in the build SANDBOX, whose lockfile can lag
+// main's security overrides — so it surfaces vulnerabilities that main already
+// floors (build FB-12D1D4FE filed 24 such phantom findings, all stale). Auto-
+// filing every finding would auto-manufacture that noise. So a finding only
+// becomes a backlog item if it survives reconciliation AND clears the severity
+// policy the founder kernel ruled on (principle_decide 2026-06-22: SEVERITY-
+// TIERED, composite 9.55, margin 0.40, high confidence, no commandment conflict).
+//
+// This module is PURE and deterministic — the I/O (reading the accepted-advisory
+// baseline + main's resolved versions) lives in advisory-context.ts so this layer
+// is fully unit-testable.
+
+import type { AssurancePolicySeverity, AssuranceFindingStatus } from "./types";
+
+/** The canonical "is this finding genuine on main?" context, built once per scan. */
+export interface ReconcileContext {
+  /**
+   * False when the canonical context (main's resolved versions) could not be
+   * loaded. Auto-file FAILS CLOSED in that case: we never auto-create a BI we
+   * cannot verify against main, so a stripped image can't manufacture phantom
+   * work. Findings still persist as evidence.
+   */
+  available: boolean;
+  /** Advisory ids (GHSA + CVE) accepted + unexpired in sbom/vuln-baseline.json. */
+  acceptedAdvisoryIds: Set<string>;
+  /** packageName -> set of versions main currently resolves (incl. transitive). */
+  resolvedVersionsByPackage: Map<string, Set<string>>;
+}
+
+export type AutoFileAction = "file" | "evidence-only" | "suppress";
+
+export interface AutoFileDisposition {
+  action: AutoFileAction;
+  /** Stable, human-readable reason, persisted onto the finding for the panel. */
+  reason: string;
+  /** The status to set on the finding, when the disposition implies one. */
+  findingStatus?: AssuranceFindingStatus;
+  /** Set when action="file": the advisory outcome to propose at triage. */
+  proposedOutcome?: "build" | "defer";
+  /** Set when action="file": ranked priority (higher number = lower priority). */
+  priority?: number;
+}
+
+/** Minimal finding shape the policy reads — NormalizedAssuranceFinding satisfies it. */
+export interface ReconcileFindingInput {
+  findingKey: string;
+  vendorIdentifier: string;
+  policySeverity: AssurancePolicySeverity;
+  evidence: Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function evidenceAdvisoryIds(finding: ReconcileFindingInput): string[] {
+  const ids = new Set<string>();
+  if (finding.vendorIdentifier) ids.add(finding.vendorIdentifier);
+  const cves = finding.evidence.cves;
+  if (Array.isArray(cves)) {
+    for (const cve of cves) {
+      if (typeof cve === "string" && cve.trim()) ids.add(cve);
+    }
+  }
+  return [...ids];
+}
+
+/** A finding already converted to a BI carries the id on its evidence. */
+export function linkedBacklogItemId(finding: ReconcileFindingInput): string | null {
+  return asString(finding.evidence.backlogItemId);
+}
+
+/** The vulnerable package + the version the sandbox audit observed. */
+function observedComponent(finding: ReconcileFindingInput): { name: string | null; version: string | null } {
+  return {
+    name: asString(finding.evidence.moduleName),
+    version: asString(finding.evidence.observedVersion),
+  };
+}
+
+const AUTO_FILE_SEVERITIES = new Set<AssurancePolicySeverity>(["critical", "high"]);
+const DEFERRED_AUTO_FILE_SEVERITIES = new Set<AssurancePolicySeverity>(["medium"]);
+/** Low-priority rank for auto-filed moderate findings (higher number = lower). */
+export const MODERATE_AUTO_FILE_PRIORITY = 900;
+
+/**
+ * Decide whether a single finding should auto-file a backlog item, be retained as
+ * promotable evidence, or be suppressed as not-genuine-on-main.
+ *
+ * Order matters: cheap/safe checks first, then the staleness oracle, then policy.
+ */
+export function decideFindingDisposition(
+  finding: ReconcileFindingInput,
+  ctx: ReconcileContext,
+): AutoFileDisposition {
+  // Fail-closed: without a verifiable context we never auto-create work.
+  if (!ctx.available) {
+    return { action: "evidence-only", reason: "reconcile-context-unavailable (fail-closed: not auto-filed)" };
+  }
+
+  // Already converted — never double-file.
+  const linked = linkedBacklogItemId(finding);
+  if (linked) {
+    return { action: "evidence-only", reason: `already-linked:${linked}` };
+  }
+
+  // (a) Accepted in the platform vuln-baseline (e.g. js-yaml CVE-2026-53550).
+  for (const id of evidenceAdvisoryIds(finding)) {
+    if (ctx.acceptedAdvisoryIds.has(id)) {
+      return { action: "suppress", reason: `accepted-in-baseline:${id}`, findingStatus: "accepted" };
+    }
+  }
+
+  // (c) Stale sandbox: the audited version is not what main resolves. Only
+  // suppress when we positively know main's versions for the package AND the
+  // observed version is absent — never hide a vuln on uncertainty.
+  const { name, version } = observedComponent(finding);
+  if (name && version) {
+    const mainVersions = ctx.resolvedVersionsByPackage.get(name);
+    if (mainVersions && mainVersions.size > 0 && !mainVersions.has(version)) {
+      const sample = [...mainVersions].slice(0, 4).join(", ");
+      return {
+        action: "suppress",
+        reason: `stale-sandbox: ${name}@${version} not resolved on main (main: ${sample})`,
+        findingStatus: "false-positive",
+      };
+    }
+  }
+
+  // Severity-tiered policy (founder kernel ruling).
+  if (AUTO_FILE_SEVERITIES.has(finding.policySeverity)) {
+    return {
+      action: "file",
+      reason: `auto-file:${finding.policySeverity}`,
+      findingStatus: "planned",
+      proposedOutcome: "build",
+    };
+  }
+  if (DEFERRED_AUTO_FILE_SEVERITIES.has(finding.policySeverity)) {
+    return {
+      action: "file",
+      reason: `auto-file:moderate(deferred)`,
+      findingStatus: "planned",
+      proposedOutcome: "defer",
+      priority: MODERATE_AUTO_FILE_PRIORITY,
+    };
+  }
+  return { action: "evidence-only", reason: `below-auto-file-threshold:${finding.policySeverity}` };
+}
+
+export interface DispositionTotals {
+  filed: number;
+  suppressed: number;
+  evidenceOnly: number;
+}
+
+export function emptyDispositionTotals(): DispositionTotals {
+  return { filed: 0, suppressed: 0, evidenceOnly: 0 };
+}

--- a/apps/web/lib/assurance/scan-job.test.ts
+++ b/apps/web/lib/assurance/scan-job.test.ts
@@ -167,4 +167,49 @@ describe("runBuildAssuranceScan", () => {
 
     expect(db.toolExecution.create).not.toHaveBeenCalled();
   });
+
+  it("does not auto-file by default (no backlog writes without opt-in)", async () => {
+    const db = createDb();
+    const runAudit = vi.fn(async () => ({ stdout: SAMPLE_AUDIT_JSON, exitCode: 1 }));
+
+    const result = await runBuildAssuranceScan({
+      db: db as never,
+      buildId: "BUILD-1",
+      requestedByUserId: "user-1",
+      projectRoot: "/app",
+      now: new Date("2026-05-22T00:00:00.000Z"),
+      runAudit,
+    });
+
+    expect(result).toEqual(expect.objectContaining({ autoFiled: 0, suppressed: 0, evidenceOnly: 0 }));
+  });
+
+  it("auto-files genuine findings through the injected front door when enabled", async () => {
+    const db = createDb();
+    const runAudit = vi.fn(async () => ({ stdout: SAMPLE_AUDIT_JSON, exitCode: 1 }));
+    const ingest = vi.fn(async () => ({ itemId: "BI-AF-1", id: "cuid-af-1", created: true }));
+
+    const result = await runBuildAssuranceScan({
+      db: db as never,
+      buildId: "BUILD-1",
+      requestedByUserId: "user-1",
+      projectRoot: "/app",
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      runAudit,
+      autoFile: {
+        enabled: true,
+        context: { available: true, acceptedAdvisoryIds: new Set(), resolvedVersionsByPackage: new Map() },
+        ingest,
+      },
+    });
+
+    expect(result).toEqual(expect.objectContaining({ skipped: false, autoFiled: 1, suppressed: 0, evidenceOnly: 0 }));
+    expect(ingest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Remediate: Critical issue in alpha",
+        workType: "bug",
+        origin: { kind: "assuranceFinding", id: expect.any(String) },
+      }),
+    );
+  });
 });

--- a/apps/web/lib/assurance/scan-job.ts
+++ b/apps/web/lib/assurance/scan-job.ts
@@ -7,6 +7,10 @@ import {
   type PnpmAuditComponentLookup,
 } from "./pnpm-audit-adapter";
 import { persistAssuranceFindings, type AssuranceFindingPersistenceDb } from "./finding-persistence";
+import { autoFileFindingsFromScan } from "./auto-file-findings";
+import { loadReconcileContext } from "./advisory-context";
+import { emptyDispositionTotals, type ReconcileContext } from "./finding-reconcile";
+import type { BacklogIngestInput, BacklogIngestResult } from "@/lib/operate/backlog-ingest";
 
 export interface ScanJobBomDocumentRow {
   id: string;
@@ -91,6 +95,21 @@ export const defaultRunPnpmAudit: RunPnpmAuditCommand = ({ projectRoot, signal }
     });
   });
 
+/**
+ * Auto-file configuration. Disabled by default so unit tests (which run from a
+ * cwd that DOES have a real lockfile) never reach the real backlog front door —
+ * the production caller opts in explicitly. See auto-file-findings.ts.
+ */
+export interface ScanAutoFileConfig {
+  enabled?: boolean;
+  /** Pre-built context (tests inject a deterministic one). */
+  context?: ReconcileContext;
+  /** Canonical root for the reconcile context (default: PROJECT_ROOT/cwd). */
+  root?: string;
+  /** Injectable backlog front door (defaults to ingestBacklogItem). */
+  ingest?: (input: BacklogIngestInput) => Promise<BacklogIngestResult>;
+}
+
 export interface RunBuildScanInput {
   db: ScanJobDb;
   buildId: string;
@@ -98,6 +117,7 @@ export interface RunBuildScanInput {
   projectRoot: string;
   now: Date;
   runAudit?: RunPnpmAuditCommand;
+  autoFile?: ScanAutoFileConfig;
 }
 
 export type RunBuildScanResult =
@@ -110,6 +130,9 @@ export type RunBuildScanResult =
       reopened: number;
       blockingCount: number;
       findingCount: number;
+      autoFiled: number;
+      suppressed: number;
+      evidenceOnly: number;
     };
 
 function buildLookup(document: ScanJobBomDocumentRow): PnpmAuditComponentLookup {
@@ -268,11 +291,29 @@ export async function runBuildAssuranceScan(input: RunBuildScanInput): Promise<R
     componentIdsByAffectedId: adapterOutput.componentIdsByAffectedId,
   });
 
+  // Auto-file: turn GENUINE findings into backlog items with no manual click,
+  // reconciling against main first so stale/accepted findings never spawn
+  // phantom work. Opt-in (the production caller enables it); fails closed when
+  // the reconcile context cannot be loaded.
+  let dispositions = emptyDispositionTotals();
+  if (input.autoFile?.enabled) {
+    const context = input.autoFile.context ?? loadReconcileContext(input.autoFile.root);
+    dispositions = await autoFileFindingsFromScan({
+      db: input.db,
+      findings: adapterOutput.findings,
+      context,
+      buildId: build.buildId,
+      digitalProductId: build.digitalProductId,
+      now: input.now,
+      ingest: input.autoFile.ingest,
+    });
+  }
+
   await input.db.buildActivity?.create({
     data: {
       buildId: build.buildId,
       tool: "assurance-scan",
-      summary: `pnpm audit scan: ${adapterOutput.findings.length} findings (${Number(adapterOutput.summary.blockingCount ?? 0)} blocking, ${persistResult.reopened} reopened).`,
+      summary: `pnpm audit scan: ${adapterOutput.findings.length} findings (${Number(adapterOutput.summary.blockingCount ?? 0)} blocking, ${persistResult.reopened} reopened) · auto-filed ${dispositions.filed}, suppressed ${dispositions.suppressed}, evidence ${dispositions.evidenceOnly}.`,
     },
   });
 
@@ -293,5 +334,8 @@ export async function runBuildAssuranceScan(input: RunBuildScanInput): Promise<R
     reopened: persistResult.reopened,
     blockingCount: Number(adapterOutput.summary.blockingCount ?? 0),
     findingCount: adapterOutput.findings.length,
+    autoFiled: dispositions.filed,
+    suppressed: dispositions.suppressed,
+    evidenceOnly: dispositions.evidenceOnly,
   };
 }

--- a/apps/web/lib/queue/functions/assurance-scan.ts
+++ b/apps/web/lib/queue/functions/assurance-scan.ts
@@ -20,6 +20,11 @@ export const assuranceScanRun = inngest.createFunction(
         requestedByUserId,
         projectRoot: process.env.PROJECT_ROOT ?? process.cwd(),
         now: new Date(),
+        // Close the "lost queue": genuine findings auto-file as backlog items
+        // through the shared front door — no manual per-finding click. Reconciled
+        // against main first (accepted-baseline + stale-version) so stale/accepted
+        // findings never spawn phantom work; fails closed if context is missing.
+        autoFile: { enabled: true },
       });
     });
   },

--- a/docs/architecture/dependency-reduction-routine.md
+++ b/docs/architecture/dependency-reduction-routine.md
@@ -182,6 +182,32 @@ scripts here are written to be that reusable engine (importable, no install). Th
 assurance-ledger design already anticipates this — scanners are *adapters* that
 read the BOM (`adapterKey`, e.g. `osv-scanner`) and emit `AssuranceFinding`s.
 
+## In-platform Assurance Gate: auto-file + reconcile (BI-91D1524F)
+
+The scripts above are the GitHub-side routine. Inside the platform runtime the
+**Build Studio Assurance Gate** runs the same OSV/pnpm-audit idea per build
+(`apps/web/lib/assurance/*`). Its findings used to convert to backlog items only
+via a **manual per-finding button**, so they accumulated as an invisible parallel
+queue, and it did not honor `sbom/vuln-baseline.json` — so an accepted advisory
+(js-yaml) was re-filed, and a build whose tree lagged main's overrides filed 24
+already-fixed "Remediate" items.
+
+The gate now **auto-files genuine findings** through the shared `ingestBacklogItem`
+front door (EP-INTAKE-UNIFY) after a **reconcile** step, and the findings panel is
+read-only evidence (linked BI / disposition, no manual button):
+
+- **Reconcile before filing** (`finding-reconcile.ts` + `advisory-context.ts`):
+  suppress findings that are accepted+unexpired in `sbom/vuln-baseline.json`,
+  already linked, or whose vulnerable version main no longer resolves
+  (`pnpm-lock.yaml`). **Fails closed** — if the canonical context can't be loaded
+  it does not auto-create work.
+- **Severity policy** (founder kernel `principle_decide`, 2026-06-22, severity-
+  tiered): high/critical → build BI, moderate → deferred BI, low/info → evidence.
+
+Plan: `docs/superpowers/plans/2026-06-22-assurance-gate-auto-file-fold-plan.md`.
+The script-side baseline (`vuln-baseline.json`) is the shared accept ledger both
+the OSV script and the in-platform gate honor.
+
 ## Backlog
 
 Under `EP-ASSURANCE-LEDGER`.

--- a/docs/superpowers/plans/2026-06-22-assurance-gate-auto-file-fold-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-gate-auto-file-fold-plan.md
@@ -1,0 +1,69 @@
+# Plan — Fold the Assurance-Findings queue into the backlog (auto-file + reconcile)
+
+_Status: implemented · BI-91D1524F · EP-ASSURANCE-LEDGER · 2026-06-22_
+
+## Problem
+
+The Build Studio Assurance Gate was an **un-folded parallel queue**. The scan
+persisted findings into a panel with its own `Status` lifecycle, and findings
+only became backlog items via a **manual per-finding button**
+(`requestBacklogFromAssuranceFinding`). If no operator clicked, the findings were
+a lost queue invisible to the backlog — found only by manually exploring a build.
+The queue-reduction sweep did not flag it.
+
+Compounding it: build FB-12D1D4FE filed 24 "Remediate:" findings that were **all
+stale false positives** — the audit ran against a tree (the deployed portal,
+lagging main during the self-upgrade window) whose lockfile predated main's
+security overrides (it observed `hono@4.12.19`, `protobufjs@7.5.8`, `undici@8.3.0`
+while main floors `4.12.25` / `7.6.4` / `7.28.0` & `8.5.0`). `pnpm scan:deps`
+(OSV) over main = 0 active. So naive auto-file would **auto-manufacture** that
+noise. Auto-file is therefore only safe coupled with reconcile.
+
+## Founder-kernel ruling (auto-file scope)
+
+`principle_decide` (in_platform_coworker, 2026-06-22) → **severity-tiered**
+(composite 9.55, margin 0.40, confidence high, no commandment conflict):
+
+- high / critical → auto-file as build BIs
+- moderate → auto-file as deferred / low-priority BIs
+- low / info → evidence only (rolled up, promotable)
+
+## Design (EP-INTAKE-UNIFY pattern — mirrors the improvements→backlog fold)
+
+1. **`finding-reconcile.ts`** (pure) — `decideFindingDisposition(finding, ctx)`:
+   fail-closed when context unavailable → already-linked → accepted-in-baseline →
+   stale-on-main → severity policy.
+2. **`advisory-context.ts`** (server I/O) — builds the `ReconcileContext`
+   (accepted advisory ids from `sbom/vuln-baseline.json`; main's resolved
+   versions parsed from `pnpm-lock.yaml`) behind injectable readers.
+   **Carrier decision:** read from the platform `PROJECT_ROOT` at scan time;
+   `available=false` when unreadable → **auto-file fails closed** (never creates
+   work it cannot verify).
+3. **`auto-file-findings.ts`** — applies dispositions: files genuine findings via
+   the shared `ingestBacklogItem` front door (origin `assuranceFinding`), links
+   them on the finding, suppresses accepted (→`accepted`) / stale (→`false-positive`),
+   annotates `evidence.autoFile` for the panel.
+4. **`scan-job.ts`** — runs the auto-file step after persist; opt-in via
+   `autoFile.enabled` (production caller `queue/functions/assurance-scan.ts`
+   enables it; default off keeps unit tests off the real backlog).
+5. **UI fold** — `BuildAssuranceGateCard` renders `AssuranceFindingsList` in
+   `readOnly` mode: no per-finding button, no parallel status dropdown; each row
+   shows its linked BI or a friendly disposition label. `finding-read.ts` exposes
+   `backlogItemId` + `autoFileReason` from evidence.
+
+## Tests
+
+`finding-reconcile.test.ts`, `advisory-context.test.ts`, `auto-file-findings.test.ts`,
+additions to `scan-job.test.ts` (default-off + enabled paths) and
+`AssuranceFindingsList.test.tsx` (linked + disposition display).
+
+## Follow-ups (not in this PR)
+
+- Point the reconcile root at **current origin/main** (vs the deployed tree) so the
+  stale-version check (c) eliminates deploy-lag false-highs; today it bites only
+  when the canonical root is more current than the audited tree.
+- Bundle a generated advisory-context snapshot so verification also works inside a
+  stripped standalone image (otherwise it fails closed there — no regression).
+- Auto-resolve findings absent from a later clean scan (clear transient BIs).
+- Queue-reduction sweep heuristic: flag any surface with a manual "convert to BI"
+  action + its own status lifecycle as a parallel queue.

--- a/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
@@ -1,0 +1,61 @@
+# Plan — Autonomous assurance remediation loop (off-hours, budgeted, WWMD-gated)
+
+_Status: planned · EP-ASSURANCE-LEDGER · P1 BI-7C121CCF / P2 BI-204EE70B / P3 BI-4D5C702F · 2026-06-22_
+
+## Goal (founder directive)
+
+Auto-created assurance BIs (PR #2290) must actually get **worked**, not pile up.
+Make remediation **autonomous, but with four rails**: (1) WWMD-gated — any
+uncertain decision the kernel can't resolve **escalates to a human**; (2) a
+**budget cap**; (3) **incremental** (a few at a time); (4) **off-hours, flexible
+timing** (not a fixed clock slot).
+
+## Reuse map (don't reinvent)
+
+| Rail | Existing substrate |
+| --- | --- |
+| incremental + promote→build | `governed-backlog-tee-up.ts` (`promoteBacklogItemToBuildDraft` → auto-approve → Ideate; cap `backlogTeeUpDailyCap`) |
+| off-hours / flexible | `self-upgrade/auto-window.ts` + `windows-eval.ts` (low-traffic trough resolver) + `quiescence-gates.gateAtEntry` |
+| WWMD-gate + escalate | `build/decision-service.ts` (principle_decide) + `build/escalate-build-to-human.ts` + capture-kernel-gap |
+| scheduling visibility | scheduled-jobs catalog + `scheduling-map.ts` |
+
+The only gap is an **assurance-specific lane** wiring these together. Today
+auto-file lands BIs in `triaging` (no `triageOutcome`), so the tee-up (which
+selects `status=open` + `triageOutcome=build`) never picks them up.
+
+## Phase 1 — get them building (BI-7C121CCF)
+
+- New scheduled inngest fn `assurance-remediation-teeup`, gated to the low-traffic
+  window via `auto-window` + `gateAtEntry` (fire on a frequent cron, only act
+  off-hours; no fixed slot).
+- Pure selector `selectAssuranceRemediationCandidates`: origin `assuranceFinding`,
+  EP-ASSURANCE-LEDGER, `proposedOutcome=build` (high/critical), `activeBuildId=null`,
+  severest/oldest first, up to a **dedicated remediation budget cap** (own knob,
+  not the shared `backlogTeeUpDailyCap`).
+- Per item (within budget): set `status=open` + `triageOutcome=build`, then
+  `promoteBacklogItemToBuildDraft` → Ideate → BS builds the override bump → PR.
+  **No auto-merge here** (awaits P2).
+- General 14:00 tee-up **excludes assurance-origin BIs** so this lane stays
+  off-hours + own-budget.
+- Tests: selector matrix + off-hours gating. Register in the scheduling catalog.
+
+## Phase 2 — WWMD-gated autonomous merge + escalate (BI-204EE70B)
+
+The supply-chain-sensitive far end. Each remediation's merge decision runs through
+`decision-service` (principle_decide). Confident + gates pass (CI green +
+release-age cooldown + OSV-clean target) → **auto-merge**; uncertain (low margin /
+commandment conflict / kernel can't resolve) → **escalate to the responder**
+(`escalate-build-to-human`), never auto-merge. Honors the founder's group-only
+Dependabot merge posture as the conservative default until WWMD clears a class.
+
+## Phase 3 — close the loop (BI-4D5C702F)
+
+When a later scan no longer reports a finding, mark previously-open findings
+**absent from the latest scan** as `resolved` (scoped to the same build+adapter)
+and close the linked BI. Makes the loop converge instead of leaving transient BIs.
+
+## Sequencing
+
+Land PR #2290 (the create-side foundation) first; then P1 → P3. P1 is safe
+(produces PRs, gated by `governedBacklogEnabled` + off-hours + budget; reversible).
+P2 is the one to build most carefully (autonomous merge of dependency changes).


### PR DESCRIPTION
## Why
The Build Studio Assurance Gate was an **un-folded parallel queue**: findings only became backlog items via a **manual per-finding button**, and the in-platform pnpm-audit path never reconciled against `sbom/vuln-baseline.json`. So accepted advisories got re-filed, and a tree lagging main's security overrides filed **24 already-fixed "Remediate" items** (build FB-12D1D4FE) that an operator had to either click through or never discover. (Those 24 were verified stale via `pnpm scan:deps` = 0 active over main, and retired.)

Closes the gap for **BI-91D1524F**.

## What
Genuine findings now **auto-file** through the shared `ingestBacklogItem` front door (no click), after a **reconcile** step:
- **suppress** findings that are accepted+unexpired in `vuln-baseline.json`, already-linked, or whose vulnerable version main no longer resolves (stale/already-fixed);
- **fail closed** — never auto-create work when the reconcile context can't be loaded.

Auto-file scope per the **founder kernel** (`principle_decide` 2026-06-22 → **severity-tiered**, composite 9.55, margin 0.40, high confidence, no commandment conflict): high/critical → build BI, moderate → deferred BI, low/info → evidence only.

The findings panel is now **read-only evidence** (linked BI / friendly disposition label), replacing the manual button and the parallel status dropdown.

## Changes
- New (pure + tested): `finding-reconcile.ts`, `advisory-context.ts`, `auto-file-findings.ts`
- `scan-job.ts` runs the auto-file step (opt-in `autoFile.enabled`; default off so unit tests never reach the real backlog); `queue/functions/assurance-scan.ts` enables it in production
- `finding-read.ts` exposes `backlogItemId` + `autoFileReason`; UI fold in `BuildAssuranceGateCard` / `AssuranceFindingsList`
- Plan: `docs/superpowers/plans/2026-06-22-assurance-gate-auto-file-fold-plan.md`; `docs/architecture/dependency-reduction-routine.md` updated

## Verification
- Lockfile resolved-version parser validated against the real `pnpm-lock.yaml` (1735 packages; hono 4.12.25 / protobufjs 7.6.4 / undici 7.28.0,8.5.0 / @babel/core 7.29.7 etc.)
- Unit tests added for reconcile policy, advisory-context, auto-file orchestration, scan-job wiring (default-off + enabled), and the read-only UI display
- Worktree lacks node_modules (vitest unavailable locally) → relying on CI for the full suite + typecheck

## Carrier decision & follow-ups
The reconcile reads accepted-advisories + main's resolved versions from `PROJECT_ROOT`. Since the gate audits the deployed tree (which lags main during the self-upgrade window), the stale-version check (c) bites only when the canonical root is more current than the audited tree; the load-bearing v1 wins are baseline-suppress (a) + dedup (b) + severity policy + fail-closed + the panel fold. Follow-ups (noted in the plan): point the reconcile root at current origin/main; bundle a generated snapshot so verification works in a stripped image; auto-resolve findings absent from a later clean scan; queue-reduction sweep heuristic for manual "convert to BI" surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)