### PR TITLE
feat(golden-triangle): Slice 2 — elegant posture-selector control + priority surface (BI-D48EB34C)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/priority/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/priority/page.tsx
@@ -1,0 +1,21 @@
+// apps/web/app/(shell)/platform/ai/priority/page.tsx
+// EP-GOLDEN-TRIANGLE Slice 2 — the Golden Triangle priority control surface.
+// A non-technical operator sets a Cost / Quality / Time posture; the platform
+// compiles it into model tier, effort, verification, and retries.
+import { GoldenTrianglePriorityPanel } from "@/components/golden-triangle/GoldenTrianglePriorityPanel";
+
+export default function GoldenTrianglePriorityPage() {
+  return (
+    <div>
+      <div style={{ marginBottom: 16 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>Priority</h1>
+        <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2 }}>
+          Set the Cost / Quality / Time priority for AI work. Pick a preset or fine-tune the triangle — the
+          platform compiles it into the right model, effort, and verification, and shows in plain language
+          exactly what it configured.
+        </p>
+      </div>
+      <GoldenTrianglePriorityPanel />
+    </div>
+  );
+}

--- a/apps/web/components/golden-triangle/GoldenTriangleControl.test.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import "./test-setup";
+import { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import { GoldenTriangleControl } from "./GoldenTriangleControl";
+import { preferenceFromPreset } from "./posture-display";
+
+function Harness({ initial }: { initial: GoldenTrianglePreference }) {
+  const [v, setV] = useState<GoldenTrianglePreference>(initial);
+  return <GoldenTriangleControl value={v} onChange={setV} />;
+}
+
+describe("GoldenTriangleControl", () => {
+  it("renders the four one-click presets", () => {
+    render(<Harness initial={preferenceFromPreset("balanced")} />);
+    for (const name of ["Fast", "Balanced", "Assured", "Frugal"]) {
+      expect(screen.getByRole("radio", { name: new RegExp(name) })).toBeInTheDocument();
+    }
+  });
+
+  it("marks the active preset with aria-checked", () => {
+    render(<Harness initial={preferenceFromPreset("balanced")} />);
+    expect(screen.getByRole("radio", { name: /Balanced/ })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: /Assured/ })).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("switches posture on a preset click and updates the configured readout", () => {
+    render(<Harness initial={preferenceFromPreset("balanced")} />);
+    fireEvent.click(screen.getByRole("radio", { name: /Assured/ }));
+    expect(screen.getByRole("radio", { name: /Assured/ })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByText(/Frontier tier/)).toBeInTheDocument();
+  });
+
+  it("shows a plain-language summary for the active posture", () => {
+    render(<Harness initial={preferenceFromPreset("frugal")} />);
+    expect(screen.getByText(/May take a little longer/)).toBeInTheDocument();
+  });
+
+  it("exposes three numeric weight inputs (canonical accessible control)", () => {
+    render(<Harness initial={preferenceFromPreset("balanced")} />);
+    expect(screen.getByLabelText(/Quality priority percent/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Cost priority percent/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Time priority percent/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -1,0 +1,259 @@
+"use client";
+// EP-GOLDEN-TRIANGLE Slice 2 (BI-D48EB34C) — the canonical, reusable posture
+// control. Presets are the primary, one-click path; the triangle is an opt-in
+// fine-tune; three numeric inputs are the canonical accessible control (a 2D
+// drag surface is not a 1-D ARIA slider). Everything the posture configures is
+// shown in plain language, driven by the real Slice 1 compiler.
+import { useId, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
+
+import type { GoldenTrianglePreference, GoldenTrianglePreset } from "@/lib/golden-triangle";
+
+import {
+  PRESET_META,
+  PRESET_ORDER,
+  decodePostureForDisplay,
+  pointToWeights,
+  preferenceFromPreset,
+  weightsToPoint,
+} from "./posture-display";
+
+export interface GoldenTriangleControlProps {
+  value: GoldenTrianglePreference;
+  onChange: (next: GoldenTrianglePreference) => void;
+  taskClass?: string;
+  authorityScopeKind?: string;
+  className?: string;
+}
+
+const INSET = 12; // viewBox units of padding so vertex labels fit
+const SPAN = 100 - 2 * INSET;
+const STEP = 0.05;
+
+type AxisKey = "qualityWeight" | "costWeight" | "timeWeight";
+
+function normalize(p: GoldenTrianglePreference): Record<AxisKey, number> {
+  const q = Math.max(0, p.qualityWeight);
+  const c = Math.max(0, p.costWeight);
+  const t = Math.max(0, p.timeWeight);
+  const s = q + c + t || 1;
+  return { qualityWeight: q / s, costWeight: c / s, timeWeight: t / s };
+}
+
+/** Set one axis to `val`, rebalancing the other two by their current ratio. */
+function rebalance(p: GoldenTrianglePreference, axis: AxisKey, val: number): GoldenTrianglePreference {
+  const w = normalize(p);
+  const v = Math.min(1, Math.max(0, val));
+  const others = (["qualityWeight", "costWeight", "timeWeight"] as AxisKey[]).filter((k) => k !== axis);
+  const otherSum = others.reduce((s, k) => s + w[k], 0);
+  const rem = 1 - v;
+  const out: Record<AxisKey, number> = { qualityWeight: 0, costWeight: 0, timeWeight: 0 };
+  out[axis] = v;
+  if (otherSum <= 0) {
+    others.forEach((k) => (out[k] = rem / 2));
+  } else {
+    others.forEach((k) => (out[k] = (w[k] / otherSum) * rem));
+  }
+  return { preset: "custom", ...out };
+}
+
+function unitToVb(ux: number, uy: number) {
+  return { x: INSET + ux * SPAN, y: INSET + uy * SPAN };
+}
+
+const AXES: Array<{ key: AxisKey; label: string }> = [
+  { key: "qualityWeight", label: "Quality" },
+  { key: "costWeight", label: "Cost" },
+  { key: "timeWeight", label: "Time" },
+];
+
+export function GoldenTriangleControl({
+  value,
+  onChange,
+  taskClass,
+  authorityScopeKind,
+  className = "",
+}: GoldenTriangleControlProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const draggingRef = useRef(false);
+  const labelId = useId();
+
+  const w = normalize(value);
+  const { plain, chips } = decodePostureForDisplay(value, taskClass, authorityScopeKind);
+  const point = weightsToPoint(w.qualityWeight, w.costWeight, w.timeWeight);
+  const thumb = unitToVb(point.x, point.y);
+  const vQuality = unitToVb(0.5, 0);
+  const vCost = unitToVb(0, 1);
+  const vTime = unitToVb(1, 1);
+  const activeLabel = value.preset === "custom" ? "Custom" : PRESET_META[value.preset].label;
+
+  function setFromEvent(clientX: number, clientY: number) {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    const vx = ((clientX - rect.left) / rect.width) * 100;
+    const vy = ((clientY - rect.top) / rect.height) * 100;
+    const ux = (vx - INSET) / SPAN;
+    const uy = (vy - INSET) / SPAN;
+    const next = pointToWeights(ux, uy);
+    onChange({ preset: "custom", ...next });
+  }
+
+  function onThumbKeyDown(e: ReactKeyboardEvent) {
+    let handled = true;
+    if (e.key === "ArrowLeft") onChange(rebalance(value, "costWeight", w.costWeight + STEP));
+    else if (e.key === "ArrowRight") onChange(rebalance(value, "timeWeight", w.timeWeight + STEP));
+    else if (e.key === "ArrowUp") onChange(rebalance(value, "qualityWeight", w.qualityWeight + STEP));
+    else if (e.key === "ArrowDown") onChange(rebalance(value, "qualityWeight", w.qualityWeight - STEP));
+    else if (e.key === "Home") onChange(preferenceFromPreset("balanced"));
+    else handled = false;
+    if (handled) e.preventDefault();
+  }
+
+  const pct = (n: number) => Math.round(n * 100);
+
+  return (
+    <div
+      className={[
+        "rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      aria-labelledby={labelId}
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <span id={labelId} className="text-[14px] font-medium text-[var(--dpf-text)]">
+          Priority for this work
+        </span>
+        <span className="rounded-md bg-[var(--dpf-accent-soft)] px-2.5 py-1 text-[12px] font-medium text-[var(--dpf-accent)]">
+          {activeLabel}
+        </span>
+      </div>
+
+      {/* Layer 1 (primary): one-click presets */}
+      <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-4" role="radiogroup" aria-label="Priority preset">
+        {PRESET_ORDER.map((preset) => {
+          const sel = value.preset === preset;
+          const meta = PRESET_META[preset];
+          return (
+            <button
+              key={preset}
+              type="button"
+              role="radio"
+              aria-checked={sel}
+              onClick={() => onChange(preferenceFromPreset(preset))}
+              className={[
+                "rounded-lg border px-3 py-2 text-left transition-colors",
+                sel
+                  ? "border-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)]"
+                  : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] hover:bg-[var(--dpf-surface-2)]",
+              ].join(" ")}
+            >
+              <span className={["block text-[13px] font-medium", sel ? "text-[var(--dpf-accent)]" : "text-[var(--dpf-text)]"].join(" ")}>
+                {meta.label}
+              </span>
+              <span className="mt-0.5 block text-[11px] leading-snug text-[var(--dpf-text-secondary)]">{meta.effect}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-[200px_1fr]">
+        {/* Layer 2 (fine-tune): the triangle */}
+        <div>
+          <svg
+            ref={svgRef}
+            viewBox="0 0 100 100"
+            className="h-auto w-full max-w-[220px] touch-none select-none"
+            role="img"
+            aria-label={`Cost, quality and time priority triangle. Quality ${pct(w.qualityWeight)} percent, cost ${pct(
+              w.costWeight,
+            )} percent, time ${pct(w.timeWeight)} percent. Drag the point or use the inputs below to fine-tune.`}
+            onPointerDown={(e) => {
+              draggingRef.current = true;
+              (e.target as Element).setPointerCapture?.(e.pointerId);
+              setFromEvent(e.clientX, e.clientY);
+            }}
+            onPointerMove={(e) => {
+              if (draggingRef.current) setFromEvent(e.clientX, e.clientY);
+            }}
+            onPointerUp={() => {
+              draggingRef.current = false;
+            }}
+          >
+            <polygon
+              points={`${vQuality.x},${vQuality.y} ${vCost.x},${vCost.y} ${vTime.x},${vTime.y}`}
+              fill="var(--dpf-surface-2)"
+              stroke="var(--dpf-border-strong)"
+              strokeWidth={0.8}
+            />
+            <text x={vQuality.x} y={vQuality.y - 3} textAnchor="middle" fontSize={6} fill="var(--dpf-text-secondary)">
+              Quality
+            </text>
+            <text x={vCost.x - 2} y={vCost.y + 6} textAnchor="start" fontSize={6} fill="var(--dpf-text-secondary)">
+              Cost
+            </text>
+            <text x={vTime.x + 2} y={vTime.y + 6} textAnchor="end" fontSize={6} fill="var(--dpf-text-secondary)">
+              Time
+            </text>
+            <circle
+              cx={thumb.x}
+              cy={thumb.y}
+              r={4.5}
+              fill="var(--dpf-accent)"
+              stroke="var(--dpf-surface-1)"
+              strokeWidth={1.6}
+              tabIndex={0}
+              role="slider"
+              aria-label="Fine-tune priority point"
+              aria-valuetext={`Quality ${pct(w.qualityWeight)}%, cost ${pct(w.costWeight)}%, time ${pct(w.timeWeight)}%`}
+              onKeyDown={onThumbKeyDown}
+              style={{ cursor: "grab", outline: "none" }}
+            />
+          </svg>
+        </div>
+
+        {/* Canonical accessible control + live readout */}
+        <div>
+          <div className="mb-3 grid grid-cols-3 gap-2">
+            {AXES.map(({ key, label }) => (
+              <label key={key} className="block text-[11px] text-[var(--dpf-text-secondary)]">
+                {label}
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={5}
+                  value={pct(w[key])}
+                  onChange={(e) => {
+                    const raw = Number(e.target.value);
+                    if (!Number.isFinite(raw)) return;
+                    onChange(rebalance(value, key, raw / 100));
+                  }}
+                  className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[13px] text-[var(--dpf-text)]"
+                  aria-label={`${label} priority percent`}
+                />
+              </label>
+            ))}
+          </div>
+
+          <div className="text-[11px] text-[var(--dpf-text-secondary)]">This configures</div>
+          <p className="mb-2 mt-0.5 text-[14px] font-medium leading-snug text-[var(--dpf-text)]" aria-live="polite">
+            {plain}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {chips.map((chip, i) => (
+              <span
+                key={`${chip.label}-${i}`}
+                className="rounded-md bg-[var(--dpf-surface-2)] px-2 py-1 text-[11px] text-[var(--dpf-text-secondary)]"
+              >
+                {chip.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/golden-triangle/GoldenTrianglePriorityPanel.tsx
+++ b/apps/web/components/golden-triangle/GoldenTrianglePriorityPanel.tsx
@@ -1,0 +1,24 @@
+"use client";
+// EP-GOLDEN-TRIANGLE Slice 2 — a self-contained, stateful host for the posture
+// control, suitable for a settings/preview surface. Holds the preference in
+// view-local state; persistence per scope (Slice 4) and the receipt view
+// (Slice 3b) wire in later.
+import { useState } from "react";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import { GoldenTriangleControl } from "./GoldenTriangleControl";
+import { preferenceFromPreset } from "./posture-display";
+
+export function GoldenTrianglePriorityPanel() {
+  const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
+  return (
+    <div style={{ maxWidth: 680 }}>
+      <GoldenTriangleControl value={pref} onChange={setPref} taskClass="conversation" authorityScopeKind="wwmd" />
+      <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 10 }}>
+        Preview — your choice is held in this view only for now. Saving a default per scope (Slice 4) and the
+        receipt that shows what actually ran (Slice 3b) wire in next.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/golden-triangle/README.md
+++ b/apps/web/components/golden-triangle/README.md
@@ -1,0 +1,20 @@
+# Golden Triangle — posture control (UI)
+
+`EP-GOLDEN-TRIANGLE` · Slice 2 (`BI-D48EB34C`). The canonical, reusable control for setting a Cost / Quality / Time posture. Design: [`docs/design/golden-triangle-design.md`](../../../../docs/design/golden-triangle-design.md) §6.
+
+## Components
+
+- **`GoldenTriangleControl`** — the control. Controlled (`value` + `onChange`). Three coordinated layers, by design:
+  1. **Presets (primary, one click):** Fast / Balanced / Assured / Frugal, each with a plain-language effect line.
+  2. **Triangle (opt-in fine-tune):** a draggable point inside a Cost / Quality / Time triangle (pointer + keyboard on the thumb).
+  3. **Numeric inputs (canonical accessible control):** three labelled percent inputs — a 2D drag surface is *not* a 1-D ARIA slider, so the numeric/preset layer is the accessible source of truth.
+- **`GoldenTrianglePriorityPanel`** — a stateful host (view-local state) for a settings/preview surface.
+- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, and `describeConfigured()` / `plainSummary()` which derive the readout from the **real Slice 1 compiler** so the UI never drifts from what gets configured.
+
+## Surface
+
+Live at **`/platform/ai/priority`** (preview). Per-scope persistence (Slice 4) and the receipt/outcome view (Slice 3b) are not wired yet.
+
+## Ease-of-use stance
+
+One gesture sets everything, and the control always shows—in plain words—what it configured (model tier, effort, verification, retries). That transparency-with-simplicity is the differentiator over platforms that expose dozens of raw model/parameter knobs. Progressive disclosure per AGENTS.md §12: presets first; the triangle and numeric inputs are there when wanted, never required.

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { compileGoldenTrianglePolicy } from "@/lib/golden-triangle";
+
+import {
+  PRESET_WEIGHTS,
+  decodePostureForDisplay,
+  describeConfigured,
+  plainSummary,
+  pointToWeights,
+  preferenceFromPreset,
+  weightsToPoint,
+} from "./posture-display";
+
+describe("posture-display geometry", () => {
+  it("weights -> point -> weights round-trips for every preset", () => {
+    for (const preset of ["fast", "balanced", "assured", "frugal"] as const) {
+      const [q, c, t] = PRESET_WEIGHTS[preset];
+      const p = weightsToPoint(q, c, t);
+      const back = pointToWeights(p.x, p.y);
+      expect(back.qualityWeight).toBeCloseTo(q, 5);
+      expect(back.costWeight).toBeCloseTo(c, 5);
+      expect(back.timeWeight).toBeCloseTo(t, 5);
+    }
+  });
+
+  it("the quality vertex maps to the apex (0.5, 0)", () => {
+    const p = weightsToPoint(1, 0, 0);
+    expect(p.x).toBeCloseTo(0.5, 5);
+    expect(p.y).toBeCloseTo(0, 5);
+  });
+
+  it("normalizes unnormalized weights", () => {
+    const a = weightsToPoint(2, 1, 1);
+    const b = weightsToPoint(0.5, 0.25, 0.25);
+    expect(a.x).toBeCloseTo(b.x, 6);
+    expect(a.y).toBeCloseTo(b.y, 6);
+  });
+});
+
+describe("describeConfigured (driven by the real compiler)", () => {
+  it("Assured surfaces frontier tier + deep verification", () => {
+    const decoded = compileGoldenTrianglePolicy({
+      preference: preferenceFromPreset("assured"),
+      taskClass: "code-gen",
+      authorityScope: { kind: "wwmd" },
+    });
+    const labels = describeConfigured(decoded).map((c) => c.label);
+    expect(labels).toContain("Frontier tier");
+    expect(labels.some((l) => /Deep verification/.test(l))).toBe(true);
+  });
+
+  it("Balanced shows the platform-defaults chip (no deltas)", () => {
+    const decoded = compileGoldenTrianglePolicy({
+      preference: preferenceFromPreset("balanced"),
+      taskClass: "conversation",
+      authorityScope: { kind: "wwmd" },
+    });
+    expect(describeConfigured(decoded)).toEqual([{ icon: "adjustments-horizontal", label: "Platform defaults" }]);
+  });
+});
+
+describe("plainSummary", () => {
+  it("uses the preset line for named presets", () => {
+    expect(plainSummary(preferenceFromPreset("fast"))).toMatch(/Quickest/);
+    expect(plainSummary(preferenceFromPreset("frugal"))).toMatch(/least/i);
+  });
+
+  it("describes a moderate custom lean", () => {
+    expect(plainSummary({ preset: "custom", qualityWeight: 0.45, costWeight: 0.3, timeWeight: 0.25 })).toMatch(/right/i);
+  });
+
+  it("falls back to balanced for an unfocused custom posture", () => {
+    expect(plainSummary({ preset: "custom", qualityWeight: 0.34, costWeight: 0.33, timeWeight: 0.33 })).toMatch(/balance/i);
+  });
+});
+
+describe("decodePostureForDisplay", () => {
+  it("returns decoded policy + plain + chips together", () => {
+    const view = decodePostureForDisplay(preferenceFromPreset("frugal"));
+    expect(view.decoded.postureOverride.budgetClass).toBe("minimize_cost");
+    expect(view.plain).toMatch(/least/i);
+    expect(view.chips.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -1,0 +1,179 @@
+/**
+ * EP-GOLDEN-TRIANGLE Slice 2 (BI-D48EB34C) — pure display helpers for the
+ * posture control: triangle geometry (weights <-> point in a 0..1 unit space)
+ * and a human-readable summary of what a compiled DecodedPolicy configures.
+ *
+ * Pure: no React, no I/O. The decode chips are derived from the real Slice 1
+ * compiler so the UI never drifts from what actually gets configured.
+ */
+import { compileGoldenTrianglePolicy } from "@/lib/golden-triangle";
+import type {
+  DecodedPolicy,
+  GoldenTrianglePreference,
+  GoldenTrianglePreset,
+} from "@/lib/golden-triangle";
+
+// ── Triangle geometry (unit space; the component scales to its SVG size) ──────
+// Quality = top, Cost = bottom-left, Time = bottom-right.
+const V = {
+  quality: { x: 0.5, y: 0 },
+  cost: { x: 0, y: 1 },
+  time: { x: 1, y: 1 },
+} as const;
+
+export interface UnitPoint {
+  x: number;
+  y: number;
+}
+
+export function weightsToPoint(qualityWeight: number, costWeight: number, timeWeight: number): UnitPoint {
+  const q = Math.max(0, qualityWeight);
+  const c = Math.max(0, costWeight);
+  const t = Math.max(0, timeWeight);
+  const s = q + c + t || 1;
+  const nq = q / s;
+  const nc = c / s;
+  const nt = t / s;
+  return {
+    x: nq * V.quality.x + nc * V.cost.x + nt * V.time.x,
+    y: nq * V.quality.y + nc * V.cost.y + nt * V.time.y,
+  };
+}
+
+export interface Weights {
+  qualityWeight: number;
+  costWeight: number;
+  timeWeight: number;
+}
+
+/** Barycentric inverse: a unit point inside the triangle → normalized weights. */
+export function pointToWeights(x: number, y: number): Weights {
+  const denom = (V.cost.y - V.time.y) * (V.quality.x - V.time.x) + (V.time.x - V.cost.x) * (V.quality.y - V.time.y);
+  let q = ((V.cost.y - V.time.y) * (x - V.time.x) + (V.time.x - V.cost.x) * (y - V.time.y)) / denom;
+  let c = ((V.time.y - V.quality.y) * (x - V.time.x) + (V.quality.x - V.time.x) * (y - V.time.y)) / denom;
+  let t = 1 - q - c;
+  q = Math.max(0, q);
+  c = Math.max(0, c);
+  t = Math.max(0, t);
+  const s = q + c + t || 1;
+  return { qualityWeight: q / s, costWeight: c / s, timeWeight: t / s };
+}
+
+// ── Presets ───────────────────────────────────────────────────────────────
+// [quality, cost, time] — mirrors the Slice 1 compiler's canonical postures.
+export const PRESET_WEIGHTS: Record<Exclude<GoldenTrianglePreset, "custom">, [number, number, number]> = {
+  fast: [0.1, 0.1, 0.8],
+  balanced: [0.34, 0.33, 0.33],
+  assured: [0.8, 0.1, 0.1],
+  frugal: [0.1, 0.8, 0.1],
+};
+
+export const PRESET_ORDER: Array<Exclude<GoldenTrianglePreset, "custom">> = [
+  "fast",
+  "balanced",
+  "assured",
+  "frugal",
+];
+
+export const PRESET_META: Record<Exclude<GoldenTrianglePreset, "custom">, { label: string; icon: string; effect: string }> = {
+  fast: { label: "Fast", icon: "clock", effect: "Quickest. Less checking." },
+  balanced: { label: "Balanced", icon: "scale", effect: "A sensible mix." },
+  assured: { label: "Assured", icon: "diamond", effect: "Most checking." },
+  frugal: { label: "Frugal", icon: "coin", effect: "Spends the least." },
+};
+
+export function preferenceFromPreset(preset: Exclude<GoldenTrianglePreset, "custom">): GoldenTrianglePreference {
+  const [qualityWeight, costWeight, timeWeight] = PRESET_WEIGHTS[preset];
+  return { preset, qualityWeight, costWeight, timeWeight };
+}
+
+// ── Plain-language summary ──────────────────────────────────────────────────
+const PLAIN: Record<Exclude<GoldenTrianglePreset, "custom">, string> = {
+  fast: "Quickest result. Less checking.",
+  balanced: "A sensible balance — platform defaults.",
+  assured: "Strongest model, deeper review. Higher cost and time.",
+  frugal: "Spends the least. May take a little longer.",
+};
+
+function dominantAxis(p: GoldenTrianglePreference): { axis: "quality" | "cost" | "time"; weight: number } {
+  const s = Math.max(0, p.qualityWeight) + Math.max(0, p.costWeight) + Math.max(0, p.timeWeight) || 1;
+  const q = Math.max(0, p.qualityWeight) / s;
+  const c = Math.max(0, p.costWeight) / s;
+  const t = Math.max(0, p.timeWeight) / s;
+  let axis: "quality" | "cost" | "time" = "quality";
+  let weight = q;
+  if (c > weight) {
+    axis = "cost";
+    weight = c;
+  }
+  if (t > weight) {
+    axis = "time";
+    weight = t;
+  }
+  return { axis, weight };
+}
+
+export function plainSummary(pref: GoldenTrianglePreference): string {
+  if (pref.preset !== "custom") return PLAIN[pref.preset];
+  const { axis, weight } = dominantAxis(pref);
+  if (weight < 0.4) return PLAIN.balanced;
+  if (axis === "quality") return weight >= 0.55 ? PLAIN.assured : "Leaning toward getting it right.";
+  if (axis === "cost") return weight >= 0.55 ? PLAIN.frugal : "Leaning toward saving money.";
+  return weight >= 0.55 ? PLAIN.fast : "Leaning toward speed.";
+}
+
+// ── Configured-chips (driven by the real compiler output) ────────────────────
+export interface ConfigChip {
+  /** Tabler-style icon key (the component prefixes with `ti ti-`). */
+  icon: string;
+  label: string;
+}
+
+function cap(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function budgetLabel(b: string): string {
+  if (b === "minimize_cost") return "Cost-first";
+  if (b === "quality_first") return "Quality-first";
+  return "Balanced cost";
+}
+
+export function describeConfigured(decoded: DecodedPolicy): ConfigChip[] {
+  const po = decoded.postureOverride;
+  const ob = decoded.orchestrationBudget;
+  const chips: ConfigChip[] = [];
+  if (po.minimumTier) chips.push({ icon: "diamond", label: `${cap(po.minimumTier)} tier` });
+  if (po.effort) chips.push({ icon: "bolt", label: `${cap(po.effort)} effort` });
+  if (po.budgetClass) chips.push({ icon: "coin", label: budgetLabel(po.budgetClass) });
+  if (ob.verificationDepth && ob.verificationDepth !== "none") {
+    chips.push({ icon: "checks", label: `${cap(ob.verificationDepth)} verification` });
+  }
+  if (ob.deliberationPattern) chips.push({ icon: "users", label: cap(ob.deliberationPattern) });
+  if (ob.retryBudget !== undefined) {
+    chips.push({ icon: "refresh", label: `${ob.retryBudget} ${ob.retryBudget === 1 ? "retry" : "retries"}` });
+  }
+  if (po.maxLatencyMs !== undefined) chips.push({ icon: "clock", label: `${Math.round(po.maxLatencyMs / 1000)}s target` });
+  if (chips.length === 0) chips.push({ icon: "adjustments-horizontal", label: "Platform defaults" });
+  return chips;
+}
+
+export interface PostureView {
+  decoded: DecodedPolicy;
+  plain: string;
+  chips: ConfigChip[];
+}
+
+/** Compile a preference and produce everything the control needs to display. */
+export function decodePostureForDisplay(
+  pref: GoldenTrianglePreference,
+  taskClass = "conversation",
+  authorityScopeKind = "wwmd",
+): PostureView {
+  const decoded = compileGoldenTrianglePolicy({
+    preference: pref,
+    taskClass,
+    authorityScope: { kind: authorityScopeKind },
+  });
+  return { decoded, plain: plainSummary(pref), chips: describeConfigured(decoded) };
+}

--- a/apps/web/components/golden-triangle/test-setup.ts
+++ b/apps/web/components/golden-triangle/test-setup.ts
@@ -1,0 +1,12 @@
+// Test setup for golden-triangle component tests.
+// Loads @testing-library/jest-dom matchers into Vitest's `expect`.
+// Activated per-file via `import "./test-setup"`.
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Vitest runs with `globals: false`, so testing-library's auto-cleanup does not
+// fire on its own — wire it up explicitly.
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
**Slice 2** of `EP-GOLDEN-TRIANGLE` (`BI-D48EB34C`) — the elegant, click-first posture control, and the surface to use it. Builds on Slice 1 (the compiler).

### The control
`GoldenTriangleControl` — three coordinated layers, by design:
1. **Presets (primary, one click):** Fast / Balanced / Assured / Frugal, each with a plain effect line.
2. **Triangle (opt-in fine-tune):** a draggable point in a Cost / Quality / Time triangle (pointer + keyboard on the thumb).
3. **Numeric inputs (canonical accessible control):** three labelled percent inputs — a 2D drag surface is not a 1-D ARIA slider, so this layer is the accessible source of truth.

It always shows, **in plain language, exactly what the posture configured** (tier, effort, verification, retries) — derived from the real Slice 1 compiler, so the UI can't drift from behaviour.

### Why it matters (the ease-of-use bet)
One gesture sets everything, with a plain-language readout of what it did — versus platforms that confuse customers with dozens of raw model/parameter knobs. Progressive disclosure (AGENTS.md §12): presets first; triangle and numbers are there when wanted, never required.

### Surface
Live at **`/platform/ai/priority`** (preview — view-local state; per-scope persistence is Slice 4, the receipt/outcome view is Slice 3b).

### Verification
14 tests green locally (`posture-display` geometry/decode in node; `GoldenTriangleControl` interaction in jsdom). Pre-commit typecheck passed. Tailwind + `--dpf-*` tokens; no new deps.

UX-Fit-Decision: Presets-first progressive disclosure — 4 plain choices, one click; triangle + numeric inputs are opt-in fine-tune; never asks a layman for token counts or raw endpoints; the readout states what was configured in plain words. The human_cognitive_load axis is unscorable by principle_decide today (no carrying kernel principle — design §0.1), so decided on merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
