### PR TITLE
feat(assurance): singleton-safety guard — gate dual-package-hazard libs in prod runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,27 @@ jobs:
       - name: Run guard
         run: node scripts/sbom/check-new-dependencies.mjs
 
+  singleton-safety-guard:
+    name: Singleton Safety Guard
+    runs-on: ubuntu-latest
+    # Dual-package-hazard gate. Most duplicate packages are harmless utilities,
+    # but a singleton / instanceof / global-state library (react, react-dom, zod,
+    # redux, immer, graphql, emotion, @tanstack/react-query, ...) breaks when two
+    # copies load in one runtime: instanceof fails across them and state desyncs.
+    # Fails when such a library goes MULTI-MAJOR in the PRODUCTION-RUNTIME closure
+    # (where it bites — not build/dev tooling, not apps/mobile's separate
+    # react-native renderer). Ignores the ~200 harmless utility dups. Reviewed
+    # exceptions live in sbom/singleton-baseline.json. Pure Node, network-free.
+    # See docs/architecture/dependency-reduction-routine.md.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Run guard
+        run: node scripts/sbom/check-singleton-safety.mjs
+
   decision-baseline:
     name: Decision Baseline
     runs-on: ubuntu-latest

--- a/docs/architecture/dependency-reduction-routine.md
+++ b/docs/architecture/dependency-reduction-routine.md
@@ -156,10 +156,29 @@ Renting safely means validating versions as they *change*, not just at acquisiti
   signature), provenance continuity, and OSV-clean target.
 - The daily OSV re-scan keeps watching everything already resolved.
 
+## Dual-package-hazard guard (singleton safety)
+
+Most duplicate package versions are harmless — pure utilities where multiple
+copies are just bytes that never disagree at runtime. The exception is
+**singleton / `instanceof` / global-state** libraries (`react`, `react-dom`,
+`zod`, `redux`, `immer`, `graphql`, emotion, `@tanstack/react-query`, …): two
+copies in one runtime cause `instanceof` failures and state desync — the
+duplication that actually "causes disparities over time." `scripts/sbom/check-singleton-safety.mjs`
+(`pnpm check:singletons`, CI job **Singleton Safety Guard**) fails when such a
+library goes **multi-major in the production-runtime closure** (where it bites —
+not build/dev tooling, not apps/mobile's separate react-native renderer),
+ignoring the ~200 harmless utility dups. Reviewed exceptions (currently `immer`
+10/11 and `react-is` 16/19 — both assessed contained) live in
+`sbom/singleton-baseline.json`. This is *why* a blanket "eliminate all
+duplication" refactor is the wrong tool: only this small class causes real
+disparities, and it's guarded; the rest is the irreducible nature of a
+transitive dependency tree.
+
 ## Schedules
 
 - **Reduction guard** — every PR / push / merge_group (`ci.yml` → `SBOM Divergence Guard`).
 - **New Dependency Gate** — every PR / push / merge_group (`ci.yml` → `New Dependency Gate`).
+- **Singleton safety guard** — every PR / push / merge_group (`ci.yml` → `Singleton Safety Guard`).
 - **Platform SBOM** — weekly Mon 07:17 UTC + lockfile change + dispatch (`sbom-platform.yml`).
 - **Vulnerability scan** — daily 06:41 UTC + dep-change PRs + dispatch (`dependency-scan.yml`).
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "audit:provenance": "node scripts/sbom/audit-provenance.mjs",
     "surface": "node scripts/sbom/runtime-surface.mjs",
     "candidates": "node scripts/sbom/internalization-candidates.mjs",
+    "check:singletons": "node scripts/sbom/check-singleton-safety.mjs",
     "security:secrets": "node scripts/security/run-gitleaks-local.mjs --tree",
     "security:secrets:staged": "node scripts/security/run-gitleaks-local.mjs --staged",
     "docs:tak": "node docs/architecture/generate-tak-docx.mjs",

--- a/sbom/singleton-baseline.json
+++ b/sbom/singleton-baseline.json
@@ -1,0 +1,17 @@
+{
+  "note": "Accepted dual-package-hazard duplicates for scripts/sbom/check-singleton-safety.mjs. A singleton/instanceof/state library at multiple MAJORS in the production-runtime closure (apps/web + services/adp + services/edge-node) is gated; entries here are reviewed exceptions. The guard's value is catching a NEW hazard (e.g. react/react-dom/zod/redux going multi-major in prod), not the accepted set below. See docs/architecture/dependency-reduction-routine.md.",
+  "accepted": [
+    {
+      "name": "react-is",
+      "versions": ["16.13.1", "19.2.7"],
+      "majors": [16, 19],
+      "reason": "Harmless by design: react-is identifies elements via Symbol.for('react.*'), a realm-global symbol registry, so its checks work ACROSS copies — there is no instanceof-identity hazard regardless of version. The 16.x is a transitive of an older consumer. No action needed."
+    },
+    {
+      "name": "immer",
+      "versions": ["10.2.0", "11.1.8"],
+      "majors": [10, 11],
+      "reason": "Assessed contained, pending confirmation: 10.x is transitive, first-party state uses 11.x. The hazard only fires if an immer draft is created by one copy and finalized by the other; consumers don't pass drafts across that boundary. Follow-up: trace the 10.x consumer and align to 11 if its range allows. Not an active bug."
+    }
+  ]
+}

--- a/scripts/sbom/check-singleton-safety.mjs
+++ b/scripts/sbom/check-singleton-safety.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// scripts/sbom/check-singleton-safety.mjs
+//
+// Dual-package-hazard guard. Most duplicate packages are harmless — pure
+// utilities where multiple copies are just bytes. But a small class of
+// SINGLETON / instanceof / global-state libraries breaks when two copies load
+// in one runtime: React's hook dispatcher, zod/immer/redux instanceof + state,
+// graphql/apollo schema identity, emotion/styled-components context caches, the
+// query-client context. Two versions => two physical modules => instanceof
+// fails across them and state desyncs. This is the duplication that actually
+// "causes disparities over time"; the rest doesn't.
+//
+// Fails CI when a known dual-hazard library goes MULTI-MAJOR in the
+// PRODUCTION-RUNTIME closure (where the hazard bites — not build/dev tooling,
+// and not apps/mobile's separate react-native renderer tree). Ignores the ~200
+// harmless utility dups. Reviewed exceptions live in sbom/singleton-baseline.json.
+// See docs/architecture/dependency-reduction-routine.md.
+//
+// Usage:
+//   node scripts/sbom/check-singleton-safety.mjs                    # gate
+//   node scripts/sbom/check-singleton-safety.mjs --update-baseline  # accept current
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadGraph, collectProdRoots, closureFromKeys, baseKey, DEPLOYED_WORKSPACES } from "./runtime-surface.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BASELINE_PATH = join(ROOT, "sbom", "singleton-baseline.json");
+const update = process.argv.includes("--update-baseline");
+
+// Libraries that break when two copies share a runtime (instanceof / singleton
+// / global state). Curated — only genuine hazards, not every dependency.
+const DUAL_HAZARD = new Set([
+  "react", "react-dom", "react-is", "scheduler", "react-reconciler",
+  "zod", "immer", "mobx", "mobx-react-lite", "redux", "react-redux", "@reduxjs/toolkit",
+  "rxjs", "graphql", "@apollo/client", "@tanstack/react-query", "valtio", "jotai", "recoil",
+  "styled-components", "@emotion/react", "@emotion/styled", "@emotion/core",
+]);
+
+function splitNameVersion(key) {
+  const base = key.split("(")[0];
+  const at = base.lastIndexOf("@");
+  if (at <= 0) return null;
+  return { name: base.slice(0, at), version: base.slice(at + 1) };
+}
+const major = (v) => {
+  const n = parseInt(v.split(".")[0], 10);
+  return Number.isNaN(n) ? v.split(".")[0] : n;
+};
+
+function loadBaseline() {
+  try { return JSON.parse(readFileSync(BASELINE_PATH, "utf8")); } catch { return null; }
+}
+
+// dual-hazard packages present at >1 version in the production-runtime closure
+function computeHazards() {
+  const { importers, snapshots } = loadGraph(ROOT);
+  const runtimeKeys = closureFromKeys(snapshots, collectProdRoots(importers, DEPLOYED_WORKSPACES));
+  const byName = new Map();
+  for (const key of runtimeKeys) {
+    const nv = splitNameVersion(baseKey(key));
+    if (!nv || !DUAL_HAZARD.has(nv.name)) continue;
+    if (!byName.has(nv.name)) byName.set(nv.name, new Set());
+    byName.get(nv.name).add(nv.version);
+  }
+  return [...byName.entries()]
+    .map(([name, set]) => {
+      const versions = [...set].sort();
+      const majors = [...new Set(versions.map(major))];
+      return { name, versions, majorCount: majors.length, majors };
+    })
+    .filter((h) => h.versions.length > 1)
+    .sort((a, b) => b.majorCount - a.majorCount || a.name.localeCompare(b.name));
+}
+
+function main() {
+  const hazards = computeHazards();
+  const multiMajor = hazards.filter((h) => h.majorCount > 1);
+
+  if (update) {
+    const baseline = {
+      note: "Accepted dual-package-hazard duplicates for scripts/sbom/check-singleton-safety.mjs. A singleton/instanceof/state library at multiple MAJORS in the production-runtime closure is gated; entries here are reviewed exceptions (contained: transitive-only and/or behind a separate renderer/realm boundary). Each needs a real `reason`. See docs/architecture/dependency-reduction-routine.md.",
+      accepted: multiMajor.map((h) => ({ name: h.name, versions: h.versions, majors: h.majors, reason: "REVIEW — confirm the copies never exchange instances across the boundary" })),
+    };
+    writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + "\n");
+    process.stdout.write(`Baseline updated: ${BASELINE_PATH} (${baseline.accepted.length} accepted)\n`);
+    return;
+  }
+
+  const baseline = loadBaseline() || { accepted: [] };
+  const accepted = new Set((baseline.accepted || []).map((a) => a.name));
+
+  const sameMajor = hazards.filter((h) => h.majorCount === 1);
+  if (sameMajor.length) {
+    process.stdout.write("Advisory — dual-hazard packages duplicated within one major:\n");
+    for (const h of sameMajor) process.stdout.write(`  ${h.name}: ${h.versions.join(", ")}\n`);
+  }
+
+  const newHazards = multiMajor.filter((h) => !accepted.has(h.name));
+  if (newHazards.length) {
+    process.stderr.write(
+      [
+        `::error::${newHazards.length} singleton / dual-package-hazard library(ies) at MULTIPLE MAJORS in the production runtime:`,
+        ...newHazards.map((h) => `    - ${h.name}: ${h.versions.join(", ")} (majors ${h.majors.join("/")})`),
+        "",
+        "  Two copies of a singleton/instanceof library in one runtime cause instanceof",
+        "  failures + state desync. Resolve to ONE major (align consumers, or pin via",
+        "  pnpm-workspace overrides). If the copies are provably isolated (transitive-only,",
+        "  separate renderer/realm), accept with a reason:",
+        "    node scripts/sbom/check-singleton-safety.mjs --update-baseline",
+        "",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+  process.stdout.write(`OK — no new dual-package hazards (${multiMajor.length} accepted multi-major, ${hazards.length} hazard-class dups in runtime).\n`);
+}
+
+main();


### PR DESCRIPTION
The proportionate answer to "does the duplication cause disparities — do we need a refactor?": **no blanket refactor**, but a targeted guard on the *only* duplication that actually causes disparities.

Most duplicate package versions are harmless — pure utilities (`chalk`, `semver`, `ansi-*`) where multiple copies are just bytes. The hazard is **singleton / `instanceof` / global-state** libraries (`react`, `react-dom`, `zod`, `redux`, `immer`, `graphql`, emotion, `@tanstack/react-query`): two copies in one runtime cause `instanceof` failures + state desync.

`scripts/sbom/check-singleton-safety.mjs` (`pnpm check:singletons`, CI job **Singleton Safety Guard**) fails when such a library goes **multi-major in the production-runtime closure** — reusing the `runtime-surface` graph so it ignores build/dev tooling, apps/mobile's separate react-native renderer, and the ~200 harmless utility dups.

Current state (baselined, both assessed contained): `immer` 10/11, `react-is` 16/19. Notably `zod` is **correctly not flagged** — its 3.x copies are dev/build-only, not in the deployed-server runtime (a whole-tree check would have false-flagged it). The guard's real value is catching a *new* hazard — e.g. a dep dragging a second `react`/`redux`/`zod` major into prod.

Pure Node, network-free. Reviewed exceptions in `sbom/singleton-baseline.json`. Docs updated (`dependency-reduction-routine.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
