### PR TITLE
feat(golden-triangle): triangle balance colours + coworker-dialog priority chip + route-manifest fix

### DIFF
--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -3,6 +3,7 @@
 import type { AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { AgentSkillsDropdown } from "./AgentSkillsDropdown";
+import { CoworkerPriorityControl } from "@/components/golden-triangle/CoworkerPriorityControl";
 
 function formatSensitivityLabel(value: AgentInfo["sensitivity"]): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
@@ -133,6 +134,7 @@ export function AgentPanelHeader({
           )}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", marginLeft: 12 }}>
+          <CoworkerPriorityControl />
           <span
             style={{
               fontSize: 9,

--- a/apps/web/components/golden-triangle/CoworkerPriorityControl.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityControl.tsx
@@ -1,0 +1,82 @@
+"use client";
+// EP-GOLDEN-TRIANGLE Slice 2 — a small, self-contained posture area for the AI
+// coworker dialog header. A balance-coloured chip (green centred → yellow → red
+// as axes get starved) opens the compact control. View-local state for now;
+// per-coworker persistence wires in with Slice 4.
+import { useState } from "react";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import { GoldenTriangleControl } from "./GoldenTriangleControl";
+import { PRESET_META, balanceState, preferenceFromPreset } from "./posture-display";
+
+export function CoworkerPriorityControl() {
+  const [open, setOpen] = useState(false);
+  const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
+
+  const balance = balanceState(pref.qualityWeight, pref.costWeight, pref.timeWeight);
+  const activeLabel = pref.preset === "custom" ? "Custom" : PRESET_META[pref.preset].label;
+  const color = `var(${balance.token})`;
+
+  return (
+    <div style={{ position: "relative" }} onMouseDown={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        title={`Priority: ${activeLabel} — ${balance.label}. Click to balance cost, quality and time for this coworker.`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          fontSize: 9,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "var(--dpf-muted)",
+          background: "transparent",
+          border: "1px solid var(--dpf-border)",
+          borderRadius: 999,
+          padding: "2px 6px",
+          cursor: "pointer",
+          lineHeight: 1.2,
+        }}
+      >
+        <span
+          style={{ width: 8, height: 8, borderRadius: "50%", background: color, flex: "0 0 auto" }}
+          aria-hidden="true"
+        />
+        Priority: {activeLabel}
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Set work priority"
+          style={{
+            position: "absolute",
+            top: "calc(100% + 8px)",
+            left: 0,
+            zIndex: 5,
+            width: 320,
+            maxWidth: "calc(100vw - 32px)",
+            background: "var(--dpf-surface-1)",
+            border: "1px solid var(--dpf-border)",
+            borderRadius: 12,
+            boxShadow: "0 10px 28px rgba(0,0,0,0.35)",
+          }}
+        >
+          <GoldenTriangleControl
+            value={pref}
+            onChange={setPref}
+            compact
+            taskClass="conversation"
+            authorityScopeKind="wwwd"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -2,16 +2,20 @@
 // EP-GOLDEN-TRIANGLE Slice 2 (BI-D48EB34C) — the canonical, reusable posture
 // control. Presets are the primary, one-click path; the triangle is an opt-in
 // fine-tune; three numeric inputs are the canonical accessible control (a 2D
-// drag surface is not a 1-D ARIA slider). Everything the posture configures is
-// shown in plain language, driven by the real Slice 1 compiler.
+// drag surface is not a 1-D ARIA slider). The triangle is colour-coded by
+// balance — green when centred, shading to yellow then red as one or two axes
+// get starved — and every posture shows, in plain language, what it configures
+// (driven by the real Slice 1 compiler so the UI never drifts).
 import { useId, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
-import type { GoldenTrianglePreference, GoldenTrianglePreset } from "@/lib/golden-triangle";
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
 import {
   PRESET_META,
   PRESET_ORDER,
+  balanceState,
   decodePostureForDisplay,
+  isAxisStarved,
   pointToWeights,
   preferenceFromPreset,
   weightsToPoint,
@@ -22,6 +26,8 @@ export interface GoldenTriangleControlProps {
   onChange: (next: GoldenTrianglePreference) => void;
   taskClass?: string;
   authorityScopeKind?: string;
+  /** Tighter layout for a small embedded area (e.g. the coworker dialog). */
+  compact?: boolean;
   className?: string;
 }
 
@@ -71,6 +77,7 @@ export function GoldenTriangleControl({
   onChange,
   taskClass,
   authorityScopeKind,
+  compact = false,
   className = "",
 }: GoldenTriangleControlProps) {
   const svgRef = useRef<SVGSVGElement>(null);
@@ -79,12 +86,19 @@ export function GoldenTriangleControl({
 
   const w = normalize(value);
   const { plain, chips } = decodePostureForDisplay(value, taskClass, authorityScopeKind);
+  const balance = balanceState(w.qualityWeight, w.costWeight, w.timeWeight);
   const point = weightsToPoint(w.qualityWeight, w.costWeight, w.timeWeight);
   const thumb = unitToVb(point.x, point.y);
   const vQuality = unitToVb(0.5, 0);
   const vCost = unitToVb(0, 1);
   const vTime = unitToVb(1, 1);
   const activeLabel = value.preset === "custom" ? "Custom" : PRESET_META[value.preset].label;
+
+  const balanceColor = `var(${balance.token})`;
+  const triFill = `color-mix(in srgb, ${balanceColor} 12%, var(--dpf-surface-2))`;
+  const triStroke = `color-mix(in srgb, ${balanceColor} 45%, var(--dpf-border-strong))`;
+  const vertexColor = (axis: "Quality" | "Cost" | "Time") =>
+    isAxisStarved(balance, axis) ? "var(--dpf-error)" : "var(--dpf-text-secondary)";
 
   function setFromEvent(clientX: number, clientY: number) {
     const svg = svgRef.current;
@@ -95,8 +109,7 @@ export function GoldenTriangleControl({
     const vy = ((clientY - rect.top) / rect.height) * 100;
     const ux = (vx - INSET) / SPAN;
     const uy = (vy - INSET) / SPAN;
-    const next = pointToWeights(ux, uy);
-    onChange({ preset: "custom", ...next });
+    onChange({ preset: "custom", ...pointToWeights(ux, uy) });
   }
 
   function onThumbKeyDown(e: ReactKeyboardEvent) {
@@ -112,10 +125,117 @@ export function GoldenTriangleControl({
 
   const pct = (n: number) => Math.round(n * 100);
 
+  const balancePill = (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11px] font-medium"
+      style={{ color: balanceColor, background: `color-mix(in srgb, ${balanceColor} 14%, transparent)` }}
+    >
+      <span className="inline-block h-2 w-2 rounded-full" style={{ background: balanceColor }} aria-hidden="true" />
+      {balance.label}
+    </span>
+  );
+
+  const triangle = (
+    <svg
+      ref={svgRef}
+      viewBox="0 0 100 100"
+      className={["h-auto w-full touch-none select-none", compact ? "max-w-[150px]" : "max-w-[220px]"].join(" ")}
+      role="img"
+      aria-label={`Cost, quality and time priority triangle. Quality ${pct(w.qualityWeight)} percent, cost ${pct(
+        w.costWeight,
+      )} percent, time ${pct(w.timeWeight)} percent. Balance: ${balance.label}. Drag the point or use the inputs to fine-tune.`}
+      onPointerDown={(e) => {
+        draggingRef.current = true;
+        (e.target as Element).setPointerCapture?.(e.pointerId);
+        setFromEvent(e.clientX, e.clientY);
+      }}
+      onPointerMove={(e) => {
+        if (draggingRef.current) setFromEvent(e.clientX, e.clientY);
+      }}
+      onPointerUp={() => {
+        draggingRef.current = false;
+      }}
+    >
+      <polygon
+        points={`${vQuality.x},${vQuality.y} ${vCost.x},${vCost.y} ${vTime.x},${vTime.y}`}
+        fill={triFill}
+        stroke={triStroke}
+        strokeWidth={0.9}
+      />
+      <text x={vQuality.x} y={vQuality.y - 3} textAnchor="middle" fontSize={6} fill={vertexColor("Quality")}>
+        Quality
+      </text>
+      <text x={vCost.x - 2} y={vCost.y + 6} textAnchor="start" fontSize={6} fill={vertexColor("Cost")}>
+        Cost
+      </text>
+      <text x={vTime.x + 2} y={vTime.y + 6} textAnchor="end" fontSize={6} fill={vertexColor("Time")}>
+        Time
+      </text>
+      <circle
+        cx={thumb.x}
+        cy={thumb.y}
+        r={4.5}
+        fill={balanceColor}
+        stroke="var(--dpf-surface-1)"
+        strokeWidth={1.6}
+        tabIndex={0}
+        role="slider"
+        aria-label="Fine-tune priority point"
+        aria-valuetext={`Quality ${pct(w.qualityWeight)}%, cost ${pct(w.costWeight)}%, time ${pct(w.timeWeight)}%`}
+        onKeyDown={onThumbKeyDown}
+        style={{ cursor: "grab", outline: "none" }}
+      />
+    </svg>
+  );
+
+  const readout = (
+    <div>
+      {!compact && (
+        <div className="mb-3 grid grid-cols-3 gap-2">
+          {AXES.map(({ key, label }) => (
+            <label key={key} className="block text-[11px] text-[var(--dpf-text-secondary)]">
+              {label}
+              <input
+                type="number"
+                min={0}
+                max={100}
+                step={5}
+                value={pct(w[key])}
+                onChange={(e) => {
+                  const raw = Number(e.target.value);
+                  if (!Number.isFinite(raw)) return;
+                  onChange(rebalance(value, key, raw / 100));
+                }}
+                className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[13px] text-[var(--dpf-text)]"
+                aria-label={`${label} priority percent`}
+              />
+            </label>
+          ))}
+        </div>
+      )}
+
+      <div className="mb-1.5">{balancePill}</div>
+      <p className="mb-2 text-[14px] font-medium leading-snug text-[var(--dpf-text)]" aria-live="polite">
+        {plain}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {chips.map((chip, i) => (
+          <span
+            key={`${chip.label}-${i}`}
+            className="rounded-md bg-[var(--dpf-surface-2)] px-2 py-1 text-[11px] text-[var(--dpf-text-secondary)]"
+          >
+            {chip.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+
   return (
     <div
       className={[
-        "rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4",
+        "rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]",
+        compact ? "p-3" : "p-4",
         className,
       ]
         .filter(Boolean)
@@ -132,7 +252,11 @@ export function GoldenTriangleControl({
       </div>
 
       {/* Layer 1 (primary): one-click presets */}
-      <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-4" role="radiogroup" aria-label="Priority preset">
+      <div
+        className={["mb-4 grid gap-2", compact ? "grid-cols-2" : "grid-cols-2 sm:grid-cols-4"].join(" ")}
+        role="radiogroup"
+        aria-label="Priority preset"
+      >
         {PRESET_ORDER.map((preset) => {
           const sel = value.preset === preset;
           const meta = PRESET_META[preset];
@@ -150,7 +274,12 @@ export function GoldenTriangleControl({
                   : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] hover:bg-[var(--dpf-surface-2)]",
               ].join(" ")}
             >
-              <span className={["block text-[13px] font-medium", sel ? "text-[var(--dpf-accent)]" : "text-[var(--dpf-text)]"].join(" ")}>
+              <span
+                className={[
+                  "block text-[13px] font-medium",
+                  sel ? "text-[var(--dpf-accent)]" : "text-[var(--dpf-text)]",
+                ].join(" ")}
+              >
                 {meta.label}
               </span>
               <span className="mt-0.5 block text-[11px] leading-snug text-[var(--dpf-text-secondary)]">{meta.effect}</span>
@@ -159,100 +288,9 @@ export function GoldenTriangleControl({
         })}
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-[200px_1fr]">
-        {/* Layer 2 (fine-tune): the triangle */}
-        <div>
-          <svg
-            ref={svgRef}
-            viewBox="0 0 100 100"
-            className="h-auto w-full max-w-[220px] touch-none select-none"
-            role="img"
-            aria-label={`Cost, quality and time priority triangle. Quality ${pct(w.qualityWeight)} percent, cost ${pct(
-              w.costWeight,
-            )} percent, time ${pct(w.timeWeight)} percent. Drag the point or use the inputs below to fine-tune.`}
-            onPointerDown={(e) => {
-              draggingRef.current = true;
-              (e.target as Element).setPointerCapture?.(e.pointerId);
-              setFromEvent(e.clientX, e.clientY);
-            }}
-            onPointerMove={(e) => {
-              if (draggingRef.current) setFromEvent(e.clientX, e.clientY);
-            }}
-            onPointerUp={() => {
-              draggingRef.current = false;
-            }}
-          >
-            <polygon
-              points={`${vQuality.x},${vQuality.y} ${vCost.x},${vCost.y} ${vTime.x},${vTime.y}`}
-              fill="var(--dpf-surface-2)"
-              stroke="var(--dpf-border-strong)"
-              strokeWidth={0.8}
-            />
-            <text x={vQuality.x} y={vQuality.y - 3} textAnchor="middle" fontSize={6} fill="var(--dpf-text-secondary)">
-              Quality
-            </text>
-            <text x={vCost.x - 2} y={vCost.y + 6} textAnchor="start" fontSize={6} fill="var(--dpf-text-secondary)">
-              Cost
-            </text>
-            <text x={vTime.x + 2} y={vTime.y + 6} textAnchor="end" fontSize={6} fill="var(--dpf-text-secondary)">
-              Time
-            </text>
-            <circle
-              cx={thumb.x}
-              cy={thumb.y}
-              r={4.5}
-              fill="var(--dpf-accent)"
-              stroke="var(--dpf-surface-1)"
-              strokeWidth={1.6}
-              tabIndex={0}
-              role="slider"
-              aria-label="Fine-tune priority point"
-              aria-valuetext={`Quality ${pct(w.qualityWeight)}%, cost ${pct(w.costWeight)}%, time ${pct(w.timeWeight)}%`}
-              onKeyDown={onThumbKeyDown}
-              style={{ cursor: "grab", outline: "none" }}
-            />
-          </svg>
-        </div>
-
-        {/* Canonical accessible control + live readout */}
-        <div>
-          <div className="mb-3 grid grid-cols-3 gap-2">
-            {AXES.map(({ key, label }) => (
-              <label key={key} className="block text-[11px] text-[var(--dpf-text-secondary)]">
-                {label}
-                <input
-                  type="number"
-                  min={0}
-                  max={100}
-                  step={5}
-                  value={pct(w[key])}
-                  onChange={(e) => {
-                    const raw = Number(e.target.value);
-                    if (!Number.isFinite(raw)) return;
-                    onChange(rebalance(value, key, raw / 100));
-                  }}
-                  className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[13px] text-[var(--dpf-text)]"
-                  aria-label={`${label} priority percent`}
-                />
-              </label>
-            ))}
-          </div>
-
-          <div className="text-[11px] text-[var(--dpf-text-secondary)]">This configures</div>
-          <p className="mb-2 mt-0.5 text-[14px] font-medium leading-snug text-[var(--dpf-text)]" aria-live="polite">
-            {plain}
-          </p>
-          <div className="flex flex-wrap gap-1.5">
-            {chips.map((chip, i) => (
-              <span
-                key={`${chip.label}-${i}`}
-                className="rounded-md bg-[var(--dpf-surface-2)] px-2 py-1 text-[11px] text-[var(--dpf-text-secondary)]"
-              >
-                {chip.label}
-              </span>
-            ))}
-          </div>
-        </div>
+      <div className={compact ? "grid gap-3" : "grid gap-4 sm:grid-cols-[200px_1fr]"}>
+        <div>{triangle}</div>
+        {readout}
       </div>
     </div>
   );

--- a/apps/web/components/golden-triangle/README.md
+++ b/apps/web/components/golden-triangle/README.md
@@ -9,11 +9,19 @@
   2. **Triangle (opt-in fine-tune):** a draggable point inside a Cost / Quality / Time triangle (pointer + keyboard on the thumb).
   3. **Numeric inputs (canonical accessible control):** three labelled percent inputs — a 2D drag surface is *not* a 1-D ARIA slider, so the numeric/preset layer is the accessible source of truth.
 - **`GoldenTrianglePriorityPanel`** — a stateful host (view-local state) for a settings/preview surface.
-- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, and `describeConfigured()` / `plainSummary()` which derive the readout from the **real Slice 1 compiler** so the UI never drifts from what gets configured.
+- **`CoworkerPriorityControl`** — a small, self-contained posture chip for the AI coworker dialog header: a balance-coloured dot + active preset that opens the compact control in a popover.
+- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, `describeConfigured()` / `plainSummary()` (derived from the **real Slice 1 compiler** so the UI never drifts), and `balanceState()` for the colour cue.
 
-## Surface
+## Balance colouring
 
-Live at **`/platform/ai/priority`** (preview). Per-scope persistence (Slice 4) and the receipt/outcome view (Slice 3b) are not wired yet.
+The triangle shades by balance: **green** when the three axes are centred, through **yellow** to **red** as one or two axes get starved (the posture pushes toward an edge or vertex). A starved axis's vertex label turns red, and a balance pill names the state ("Well balanced" / "Starving Time"). It is an at-a-glance cue that you are trading something away.
+
+## Surfaces
+
+- **`/platform/ai/priority`** — the full control (preview).
+- **AI coworker dialog header** — `CoworkerPriorityControl`, a compact chip + popover.
+
+Per-scope persistence (Slice 4) and the receipt/outcome view (Slice 3b) are not wired yet; state is view-local.
 
 ## Ease-of-use stance
 

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -4,6 +4,7 @@ import { compileGoldenTrianglePolicy } from "@/lib/golden-triangle";
 
 import {
   PRESET_WEIGHTS,
+  balanceState,
   decodePostureForDisplay,
   describeConfigured,
   plainSummary,
@@ -81,5 +82,35 @@ describe("decodePostureForDisplay", () => {
     expect(view.decoded.postureOverride.budgetClass).toBe("minimize_cost");
     expect(view.plain).toMatch(/least/i);
     expect(view.chips.length).toBeGreaterThan(0);
+  });
+});
+
+describe("balanceState (triangle colouring)", () => {
+  it("a centred posture is green with nothing starved", () => {
+    const b = balanceState(0.34, 0.33, 0.33);
+    expect(b.level).toBe("balanced");
+    expect(b.token).toBe("--dpf-success");
+    expect(b.starved).toEqual([]);
+  });
+
+  it("a near-vertex posture is red and starves the two low axes", () => {
+    const b = balanceState(0.9, 0.05, 0.05);
+    expect(b.level).toBe("starved");
+    expect(b.token).toBe("--dpf-error");
+    expect(b.starved).toEqual(["Cost", "Time"]);
+    expect(b.label).toMatch(/Starving Cost & Time/);
+  });
+
+  it("an edge posture starves one axis (red)", () => {
+    const b = balanceState(0.5, 0.45, 0.05);
+    expect(b.token).toBe("--dpf-error");
+    expect(b.starved).toEqual(["Time"]);
+  });
+
+  it("a moderate lean is yellow with nothing starved", () => {
+    const b = balanceState(0.5, 0.3, 0.2);
+    expect(b.level).toBe("leaning");
+    expect(b.token).toBe("--dpf-warning");
+    expect(b.starved).toEqual([]);
   });
 });

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -177,3 +177,58 @@ export function decodePostureForDisplay(
   });
   return { decoded, plain: plainSummary(pref), chips: describeConfigured(decoded) };
 }
+
+// ── Balance / starvation colouring ──────────────────────────────────────────
+// Green when the three axes are in balance (centre), shading through yellow to
+// red as one or two axes get starved (the posture pushes toward an edge/vertex).
+export type BalanceLevel = "balanced" | "leaning" | "starved";
+
+export interface BalanceState {
+  level: BalanceLevel;
+  /** A `--dpf-*` token name (without `var()`) for the level's colour. */
+  token: "--dpf-success" | "--dpf-warning" | "--dpf-error";
+  label: string;
+  /** Axis labels currently starved (weight below the floor). */
+  starved: Array<"Quality" | "Cost" | "Time">;
+}
+
+const STARVE_FLOOR = 0.12;
+
+export function balanceState(qualityWeight: number, costWeight: number, timeWeight: number): BalanceState {
+  const q = Math.max(0, qualityWeight);
+  const c = Math.max(0, costWeight);
+  const t = Math.max(0, timeWeight);
+  const s = q + c + t || 1;
+  const nq = q / s;
+  const nc = c / s;
+  const nt = t / s;
+
+  const starved: Array<"Quality" | "Cost" | "Time"> = [];
+  if (nq < STARVE_FLOOR) starved.push("Quality");
+  if (nc < STARVE_FLOOR) starved.push("Cost");
+  if (nt < STARVE_FLOOR) starved.push("Time");
+
+  // 1 = perfectly balanced (1/3 each); 0 = an axis fully starved (a vertex/edge).
+  const score = Math.min(nq, nc, nt) * 3;
+  let level: BalanceLevel;
+  let token: BalanceState["token"];
+  if (score >= 0.66) {
+    level = "balanced";
+    token = "--dpf-success";
+  } else if (score >= 0.33) {
+    level = "leaning";
+    token = "--dpf-warning";
+  } else {
+    level = "starved";
+    token = "--dpf-error";
+  }
+
+  const label =
+    level === "balanced" ? "Well balanced" : starved.length > 0 ? `Starving ${starved.join(" & ")}` : "Leaning";
+
+  return { level, token, label, starved };
+}
+
+export function isAxisStarved(b: BalanceState, axis: "Quality" | "Cost" | "Time"): boolean {
+  return b.starved.includes(axis);
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 505,
+  "routeCount": 506,
   "routes": [
     {
       "routePath": "/",
@@ -4525,6 +4525,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/platform/ai/operations-map/page.tsx"
+    },
+    {
+      "routePath": "/platform/ai/priority",
+      "kind": "page",
+      "segments": [
+        "platform",
+        "ai",
+        "priority"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/platform/ai/priority/page.tsx"
     },
     {
       "routePath": "/platform/ai/prompts",

--- a/docs/design/golden-triangle-design.md
+++ b/docs/design/golden-triangle-design.md
@@ -2,13 +2,15 @@
 
 **Cost | Quality | Time as a governed preference-to-policy compiler for trusted AI agents**
 
-*Design review draft v0.3.2 - 2026-06-21*
+*Design review draft v0.3.3 - 2026-06-22*
 
 > **v0.3 changelog.** Integrates a multi-thread review (UX/accessibility, ethos/culture fit, strategy/completeness) plus a competitive-benchmarking pass. Headline changes: **presets are the primary control** (the triangle becomes a fine-tune visualization); a corrected **2-degrees-of-freedom accessibility contract** (a 2D control is not the WAI-ARIA *slider* pattern); the triangle is framed as **cognitive-load migration** and connected to the **kernel principle system**; and three factual corrections to the v0.2 control-layers analysis — the `effort` lever already exists end-to-end, perspective/review count's home is the **deliberation engine**, and `MAX_ITERATIONS` is a *safety ceiling*, not the dominant cost lever. Adds cold-start defaults, the composition point with `inferContract()`, and success metrics.
 >
 > **v0.3.1 architect/usability pass.** Tightens the enterprise architecture decision, adds a one-screen executive capsule, strengthens the UX navigation and component contract, makes the standards basis explicit (WCAG 2.2 + APG radio/spinbutton patterns), and replaces success-metric placeholders with initial launch guardrails to validate in Slice 0.
 >
 > **v0.3.2 Slice 0 close-out.** Folds the Slice 0 substrate-audit findings (companion doc [`golden-triangle-slice0-substrate-audit.md`](golden-triangle-slice0-substrate-audit.md)): the saved-defaults home already exists (`DecisionInteraction.profileId` → `DecisionPerspectiveProfile`, **extend it** — resolves Open Decision 1); the orchestration budget is **GO** as JSON on the receipt path (not `AgentModelConfig`, not a new table — resolves Open Decision 7); plus two corrections — `TaskRequirement.minimumTier` is code-side (`BUILT_IN_TASK_REQUIREMENTS`), not a DB column, and `verificationDepth` is inert until a verify step is wired.
+>
+> **v0.3.3 implementation underway.** Shipped: Slice 1 (pure compiler), Slice 3a (posture → `inferContract()` composition + additive caller overrides), and Slice 2 (the elegant posture control + `/platform/ai/priority` page). UX refinements: the control is surfaced in the **AI coworker dialog** as a compact, balance-coloured chip (`CoworkerPriorityControl`), and the triangle is **colour-coded by balance** — green when centred, yellow→red as one or two axes get starved, with the starved axis's vertex reddened. Remaining: receipts / outcome-diff (Slice 3b) and per-scope persistence (Slice 4) — both can be **migration-free** in v1 via the existing `DecisionInteraction.outcomePayload` and `DecisionPerspectiveProfile.autonomyPolicy` JSON fields (no schema change), which also sidesteps the no-`datasource.url`-in-worktree migration constraint.
 
 ---
 


### PR DESCRIPTION
Follow-on to Slice 2 (#2292, merged) — the two operator-requested refinements, plus a route-manifest repair.

### 1. Coworker-dialog surface
`CoworkerPriorityControl` — a small, self-contained, balance-coloured posture chip in the AI coworker dialog header (`AgentPanelHeader`): `● Priority: Balanced`, click to open the **compact** triangle control in a popover. One additive component + a one-line header insert; no shell prop-threading; view-local state.

### 2. Triangle balance colours
`balanceState()` shades the triangle **green when centred → yellow → red** as one or two axes get starved (toward an edge/vertex): the thumb + a subtle fill tint take the level colour, the **starved axis's vertex label turns red**, and a balance pill names it ("Well balanced" / "Starving Time"). An at-a-glance "you're trading something away" cue. Adds a `compact` mode to `GoldenTriangleControl`.

### 3. Route-manifest repair
Regenerated `apps/web/lib/ea/route-manifest.json` to register `/platform/ai/priority`. #2292 merged that page **without** the manifest update (the Route Manifest Freshness check is non-blocking), leaving `main`'s manifest stale and the check red — this fixes it.

Local: 24 tests green (geometry/decode/**balance** + jsdom interaction + AgentPanelHeader render); `check:route-manifest` up to date; typecheck passed on the balance/coworker commit. Tailwind + `--dpf` tokens; no new deps.

UX-Fit-Decision: Reinforces progressive disclosure — the coworker surface is a one-glance chip (preset + balance colour) that opens the same presets-first control on demand; nothing new to learn, no token/endpoint typing. The balance colour is an at-a-glance trade-off cue. human_cognitive_load remains unscorable by principle_decide (no carrying kernel principle, design §0.1) — decided on merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
