### PR TITLE
feat(portfolio): product dependency graph — the priority-cascade rail (BI-PORTPRIO-2)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-portfolio-prioritization-cascade.md
+++ b/docs/superpowers/plans/2026-06-22-portfolio-prioritization-cascade.md
@@ -1,0 +1,33 @@
+# Portfolio Budgets, Per-Portfolio Prioritization & Dependency Cascade — Plan
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-22 |
+| **Author** | Claude (Opus 4.8) with founder (Mark Bodman) |
+| **Epic** | EP-BOM-WIRING (extends the 2026-06-07 BOM-wiring spec §7/§12.3 + the just-shipped portfolio-coverage projection) |
+| **Items** | BI-PORTPRIO-1..4 (this plan) under BI-30EE393B (the governed Phase-4 dispatcher), reusing EP-LIFECYCLE gap→backlog |
+
+## Why
+
+The portfolio-coverage work populated the four portfolios (DigitalProduct entries) from every substrate. The next layer is **investment**: set per-portfolio budgets, prioritize each portfolio's backlog within its envelope, and let priority **cascade from customer-sold offerings back through their dependencies** (DPPM line-of-sight). Verified gaps: backlog→portfolio is only indirect (no `portfolioId`), `Portfolio.budgetKUsd` is an inert placeholder, prioritization is a single global flat int (no WSJF/value), and — the blocker for the cascade — **product→product dependency edges are not persisted** (the registry's `depends_on_product_ids` is dropped at seed).
+
+## Slices
+
+1. **BI-PORTPRIO-1 — backlog→portfolio attribution.** `resolveBacklogPortfolio()` (digitalProduct→taxonomyNode→epic precedence) + denormalized `BacklogItem.portfolioId` (additive) + per-portfolio grouping read. *Enabler.*
+2. **BI-PORTPRIO-2 — persist the product dependency graph (THIS PR, keystone).** New `ProductDependency` model (`relationType` depends_on|part_of, `source`), `linkProductDependency` writer (idempotent, resolves public productId→internal id, skips missing/self), registry backfill (`depends_on_product_ids`/`is_part_of_product_ids`) + platform-capability manifest `dependsOn` edges emitted by the projectors, and cycle-safe transitive traversal (`getProductDependencies` / `getProductDependents`). Wired into the seed (`productDependencyGraph` step). This is the rail the cascade runs on. The seeded graph already yields a real cascade case: `dpf-platform-standard` (Products & Services Sold) → `dpf-meta` → `infra-neo4j-core`/`infra-docker-runtime`.
+3. **BI-PORTPRIO-3 — budgets as real funding envelopes.** Operator-set, persisted `Portfolio.budgetKUsd` (provenance flips demo→live) + budget-vs-allocated surfaced on the portfolio root.
+4. **BI-PORTPRIO-4 — per-portfolio ranking + the cascade.** Rank backlog within each portfolio's envelope; a CASCADE pass traverses the dependency graph from sold offerings and **floors** (not overrides) the priority/criticality of their dependencies + dependency-linked backlog; explainable. Composes under BI-30EE393B (WSJF×theme / MoAR / guardrails, PAR-gated, WWWD-governed).
+
+## Build order
+
+1 + 2 (enablers) → 3 (envelopes) → 4 (ranking + cascade) → BI-30EE393B (governed composite engine on top).
+
+## Substrate decisions (verified)
+
+- **Dependency edges:** dedicated `ProductDependency` join (not EaRelationship) — the EA graph is a separate concern; the cascade wants a clean product→product traversal. Edges address products by public `productId`, resolved to the internal FK.
+- **Migration:** additive new table only; generated via `prisma migrate dev` on a throwaway Postgres then trimmed to the table (the repo's schema has pre-existing finance/contract drift that `migrate dev` would otherwise fold in — out of scope).
+- **No new prioritization substrate yet:** ranking/WSJF live in BI-30EE393B; this plan only adds the graph + (later) the cascade pass + envelope grouping.
+
+## Acceptance (BI-PORTPRIO-2, this PR)
+
+`ProductDependency` table exists; registry + platform-capability edges are persisted by the seed (idempotent); traversal returns transitive deps/dependents and is cycle-safe; unit tests green; migration applies on a fresh Postgres (CI).

--- a/packages/db/prisma/migrations/20260623023833_add_product_dependency/migration.sql
+++ b/packages/db/prisma/migrations/20260623023833_add_product_dependency/migration.sql
@@ -1,0 +1,29 @@
+-- Product-to-product dependency graph (BI-PORTPRIO-2) — the rail for the DPPM
+-- line-of-sight priority cascade. Additive: a new table only.
+
+-- CreateTable
+CREATE TABLE "ProductDependency" (
+    "id" TEXT NOT NULL,
+    "fromProductId" TEXT NOT NULL,
+    "toProductId" TEXT NOT NULL,
+    "relationType" TEXT NOT NULL,
+    "source" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProductDependency_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProductDependency_fromProductId_idx" ON "ProductDependency"("fromProductId");
+
+-- CreateIndex
+CREATE INDEX "ProductDependency_toProductId_idx" ON "ProductDependency"("toProductId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductDependency_fromProductId_toProductId_relationType_key" ON "ProductDependency"("fromProductId", "toProductId", "relationType");
+
+-- AddForeignKey
+ALTER TABLE "ProductDependency" ADD CONSTRAINT "ProductDependency_fromProductId_fkey" FOREIGN KEY ("fromProductId") REFERENCES "DigitalProduct"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductDependency" ADD CONSTRAINT "ProductDependency_toProductId_fkey" FOREIGN KEY ("toProductId") REFERENCES "DigitalProduct"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -616,6 +616,28 @@ model DigitalProduct {
   knowledgeArticles             KnowledgeArticleProduct[]
   workQueues                    WorkQueue[]
   businessCapabilityLinks       BusinessCapabilityTraceLink[]  @relation("BusinessCapabilityProductLinks")
+  dependencyEdgesFrom           ProductDependency[]            @relation("ProductDependencyFrom")
+  dependencyEdgesTo             ProductDependency[]            @relation("ProductDependencyTo")
+}
+
+/// Product-to-product dependency graph (BI-PORTPRIO-2) — the rail for the DPPM
+/// line-of-sight priority cascade: a Products & Services Sold offering's priority
+/// floors the priority of the Foundational / Manufacturing & Delivery products it
+/// depends on. relationType: "depends_on" | "part_of". source = the
+/// PortfolioSourceKind that asserted the edge (registry backfill, projector, …).
+model ProductDependency {
+  id            String         @id @default(cuid())
+  fromProductId String
+  toProductId   String
+  relationType  String
+  source        String?
+  createdAt     DateTime       @default(now())
+  fromProduct   DigitalProduct @relation("ProductDependencyFrom", fields: [fromProductId], references: [id], onDelete: Cascade)
+  toProduct     DigitalProduct @relation("ProductDependencyTo", fields: [toProductId], references: [id], onDelete: Cascade)
+
+  @@unique([fromProductId, toProductId, relationType])
+  @@index([fromProductId])
+  @@index([toProductId])
 }
 
 model BusinessModel {

--- a/packages/db/src/portfolio-sources/index.ts
+++ b/packages/db/src/portfolio-sources/index.ts
@@ -11,3 +11,4 @@ export * from "./supported-integrations-manifest";
 export * from "./project-external-supply";
 export * from "./licensed-dependencies-manifest";
 export * from "./project-sbom";
+export * from "./product-dependency";

--- a/packages/db/src/portfolio-sources/platform-capability-manifest.ts
+++ b/packages/db/src/portfolio-sources/platform-capability-manifest.ts
@@ -24,6 +24,8 @@ export interface PlatformCapabilityManifestEntry {
   /** Existing taxonomy nodeId, or null to place at the portfolio root. */
   taxonomyNodeId: string | null;
   coverageStatus: PortfolioCoverageStatus;
+  /** Public productIds this capability depends on (BI-PORTPRIO-2 dependency edges). */
+  dependsOn?: string[];
 }
 
 /** "foundational/platform_services" exists (seeded; used by dpf-meta). */
@@ -39,6 +41,7 @@ export const PLATFORM_CAPABILITY_MANIFEST: readonly PlatformCapabilityManifestEn
     portfolioSlug: "manufacturing_and_delivery",
     taxonomyNodeId: null,
     coverageStatus: "used",
+    dependsOn: ["cap-build-sandbox", "cap-local-ai-inference", "cap-github-delivery"],
   },
   {
     productId: "cap-github-delivery",

--- a/packages/db/src/portfolio-sources/product-dependency.test.ts
+++ b/packages/db/src/portfolio-sources/product-dependency.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getProductDependencies,
+  getProductDependents,
+  linkProductDependency,
+  platformCapabilityDependencyEdges,
+  projectProductDependencyGraph,
+  registryDependencyEdges,
+  type DependencyTraversalClient,
+  type ProductDependencyClient,
+} from "./product-dependency";
+
+type EdgeRow = {
+  id: string;
+  fromProductId: string;
+  toProductId: string;
+  relationType: string;
+  source: string | null;
+};
+
+function makeFakeDb(
+  productIds: Record<string, string>,
+  seedEdges: Array<{ from: string; to: string; rel: string }> = [],
+): ProductDependencyClient & DependencyTraversalClient & { edges: EdgeRow[] } {
+  const edges: EdgeRow[] = seedEdges.map((e, i) => ({
+    id: `e-seed-${i}`,
+    fromProductId: e.from,
+    toProductId: e.to,
+    relationType: e.rel,
+    source: null,
+  }));
+  let seq = 0;
+  return {
+    edges,
+    digitalProduct: {
+      findUnique: async (args: unknown) => {
+        const pid = (args as { where: { productId: string } }).where.productId;
+        const id = productIds[pid];
+        return id ? { id } : null;
+      },
+    },
+    productDependency: {
+      findUnique: async (args: unknown) => {
+        const w = (
+          args as {
+            where: {
+              fromProductId_toProductId_relationType: {
+                fromProductId: string;
+                toProductId: string;
+                relationType: string;
+              };
+            };
+          }
+        ).where.fromProductId_toProductId_relationType;
+        const found = edges.find(
+          (e) =>
+            e.fromProductId === w.fromProductId &&
+            e.toProductId === w.toProductId &&
+            e.relationType === w.relationType,
+        );
+        return found ? { id: found.id } : null;
+      },
+      create: async (args: unknown) => {
+        const data = (
+          args as {
+            data: { fromProductId: string; toProductId: string; relationType: string; source: string | null };
+          }
+        ).data;
+        const row: EdgeRow = { id: `e-${seq++}`, ...data };
+        edges.push(row);
+        return row;
+      },
+      findMany: async (args: unknown) => {
+        const where = (
+          args as { where: { fromProductId?: { in: string[] }; toProductId?: { in: string[] } } }
+        ).where;
+        if (where.fromProductId?.in) {
+          const set = new Set(where.fromProductId.in);
+          return edges.filter((e) => set.has(e.fromProductId)).map((e) => ({ toProductId: e.toProductId }));
+        }
+        if (where.toProductId?.in) {
+          const set = new Set(where.toProductId.in);
+          return edges.filter((e) => set.has(e.toProductId)).map((e) => ({ fromProductId: e.fromProductId }));
+        }
+        return [];
+      },
+    },
+  };
+}
+
+describe("linkProductDependency", () => {
+  it("creates an edge, is idempotent, and skips missing endpoints + self-loops", async () => {
+    const db = makeFakeDb({ "cap-a": "id-a", "cap-b": "id-b" });
+    expect(
+      await linkProductDependency({ fromProductId: "cap-a", toProductId: "cap-b", relationType: "depends_on", db }),
+    ).toBe("created");
+    expect(db.edges.length).toBe(1);
+    expect(
+      await linkProductDependency({ fromProductId: "cap-a", toProductId: "cap-b", relationType: "depends_on", db }),
+    ).toBe("exists");
+    expect(
+      await linkProductDependency({ fromProductId: "cap-a", toProductId: "nope", relationType: "depends_on", db }),
+    ).toBe("skipped");
+    expect(
+      await linkProductDependency({ fromProductId: "cap-a", toProductId: "cap-a", relationType: "depends_on", db }),
+    ).toBe("skipped");
+    expect(db.edges.length).toBe(1);
+  });
+});
+
+describe("edge sources", () => {
+  it("registryDependencyEdges maps depends_on + is_part_of (and ignores empties)", () => {
+    const edges = registryDependencyEdges([
+      { product_id: "p1", depends_on_product_ids: ["d1", "d2"], is_part_of_product_ids: ["parent1"] },
+      { product_id: "p2" },
+    ]);
+    expect(edges).toContainEqual({ fromProductId: "p1", toProductId: "d1", relationType: "depends_on", source: "manual_entry" });
+    expect(edges).toContainEqual({ fromProductId: "p1", toProductId: "parent1", relationType: "part_of", source: "manual_entry" });
+    expect(edges.some((e) => e.fromProductId === "p2")).toBe(false);
+  });
+
+  it("platformCapabilityDependencyEdges emits cap edges from the manifest", () => {
+    const edges = platformCapabilityDependencyEdges();
+    expect(
+      edges.some(
+        (e) =>
+          e.fromProductId === "cap-build-studio" &&
+          e.toProductId === "cap-build-sandbox" &&
+          e.relationType === "depends_on" &&
+          e.source === "platform_capability",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("projectProductDependencyGraph", () => {
+  it("links registry + manifest edges and is idempotent", async () => {
+    const db = makeFakeDb({
+      "dpf-meta": "id-meta",
+      "infra-neo4j-core": "id-neo",
+      "infra-docker-runtime": "id-docker",
+      "cap-build-studio": "id-bs",
+      "cap-build-sandbox": "id-sandbox",
+      "cap-local-ai-inference": "id-ai",
+      "cap-github-delivery": "id-gh",
+    });
+    const reg = [
+      { product_id: "dpf-meta", depends_on_product_ids: ["infra-neo4j-core", "infra-docker-runtime"] },
+      { product_id: "infra-docker-runtime", is_part_of_product_ids: ["dpf-meta"] },
+    ];
+    const r1 = await projectProductDependencyGraph({ registryProducts: reg, db });
+    expect(r1.created).toBeGreaterThan(0);
+    const before = db.edges.length;
+    const r2 = await projectProductDependencyGraph({ registryProducts: reg, db });
+    expect(r2.created).toBe(0);
+    expect(db.edges.length).toBe(before);
+  });
+});
+
+describe("traversal", () => {
+  it("getProductDependencies returns transitive deps and is cycle-safe", async () => {
+    const db = makeFakeDb({}, [
+      { from: "a", to: "b", rel: "depends_on" },
+      { from: "b", to: "c", rel: "depends_on" },
+      { from: "c", to: "a", rel: "depends_on" }, // cycle back to root
+    ]);
+    const deps = await getProductDependencies("a", { db });
+    expect(new Set(deps)).toEqual(new Set(["b", "c"]));
+  });
+
+  it("getProductDependents returns transitive dependents", async () => {
+    const db = makeFakeDb({}, [
+      { from: "a", to: "b", rel: "depends_on" },
+      { from: "b", to: "c", rel: "depends_on" },
+    ]);
+    const dependents = await getProductDependents("c", { db });
+    expect(new Set(dependents)).toEqual(new Set(["a", "b"]));
+  });
+});

--- a/packages/db/src/portfolio-sources/product-dependency.ts
+++ b/packages/db/src/portfolio-sources/product-dependency.ts
@@ -1,0 +1,229 @@
+// Product-to-product dependency graph (BI-PORTPRIO-2) — the rail for the DPPM
+// line-of-sight priority cascade (BI-PORTPRIO-4): a Products & Services Sold
+// offering's priority floors the priority of the Foundational / Manufacturing &
+// Delivery products it depends on.
+//
+// Edges are persisted in ProductDependency (relationType "depends_on" | "part_of",
+// source = the projector/backfill that asserted it). Emitters address products by
+// their public productId; this module resolves to the internal FK id. Idempotent
+// (the @@unique([from,to,relationType]) makes re-runs safe).
+
+import { prisma } from "../client";
+import {
+  PLATFORM_CAPABILITY_MANIFEST,
+  type PlatformCapabilityManifestEntry,
+} from "./platform-capability-manifest";
+
+export type ProductDependencyRelation = "depends_on" | "part_of";
+
+export interface ProductDependencyEdge {
+  /** Public productId of the dependent (the "from"). */
+  fromProductId: string;
+  /** Public productId of the dependency (the "to"). */
+  toProductId: string;
+  relationType: ProductDependencyRelation;
+  /** Source kind that asserted the edge (e.g. "manual_entry", "platform_capability"). */
+  source?: string;
+}
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type ProductDependencyClient = {
+  digitalProduct: { findUnique: (args: unknown) => Promise<unknown> };
+  productDependency: {
+    findUnique: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+    findMany: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export type LinkOutcome = "created" | "exists" | "skipped";
+
+/**
+ * Link two products by public productId. Resolves both to internal ids; skips if
+ * either is missing or the edge is a self-loop. Idempotent on (from,to,relation).
+ */
+export async function linkProductDependency(input: {
+  fromProductId: string;
+  toProductId: string;
+  relationType: ProductDependencyRelation;
+  source?: string;
+  db?: ProductDependencyClient;
+}): Promise<LinkOutcome> {
+  const db = input.db ?? (prisma as unknown as ProductDependencyClient);
+
+  const [from, to] = (await Promise.all([
+    db.digitalProduct.findUnique({
+      where: { productId: input.fromProductId },
+      select: { id: true },
+    }),
+    db.digitalProduct.findUnique({
+      where: { productId: input.toProductId },
+      select: { id: true },
+    }),
+  ])) as Array<{ id: string } | null>;
+
+  if (!from || !to || from.id === to.id) return "skipped";
+
+  const existing = (await db.productDependency.findUnique({
+    where: {
+      fromProductId_toProductId_relationType: {
+        fromProductId: from.id,
+        toProductId: to.id,
+        relationType: input.relationType,
+      },
+    },
+    select: { id: true },
+  })) as { id: string } | null;
+  if (existing) return "exists";
+
+  await db.productDependency.create({
+    data: {
+      fromProductId: from.id,
+      toProductId: to.id,
+      relationType: input.relationType,
+      source: input.source ?? null,
+    },
+  });
+  return "created";
+}
+
+export type ProjectDependencyResult = {
+  total: number;
+  created: number;
+  exists: number;
+  skipped: number;
+};
+
+/** Link a batch of edges, accumulating outcomes. */
+export async function linkProductDependencies(
+  edges: ProductDependencyEdge[],
+  options: { db?: ProductDependencyClient } = {},
+): Promise<ProjectDependencyResult> {
+  const result: ProjectDependencyResult = {
+    total: edges.length,
+    created: 0,
+    exists: 0,
+    skipped: 0,
+  };
+  for (const edge of edges) {
+    const outcome = await linkProductDependency({ ...edge, db: options.db });
+    result[outcome]++;
+  }
+  return result;
+}
+
+// ── Edge sources (pure) ──────────────────────────────────────────────────────
+
+type RegistryProduct = {
+  product_id: string;
+  depends_on_product_ids?: string[];
+  is_part_of_product_ids?: string[];
+};
+
+/** Derive dependency edges from the digital_product_registry.json shape. */
+export function registryDependencyEdges(products: RegistryProduct[]): ProductDependencyEdge[] {
+  const edges: ProductDependencyEdge[] = [];
+  for (const p of products) {
+    for (const dep of p.depends_on_product_ids ?? []) {
+      if (dep) edges.push({ fromProductId: p.product_id, toProductId: dep, relationType: "depends_on", source: "manual_entry" });
+    }
+    for (const parent of p.is_part_of_product_ids ?? []) {
+      if (parent) edges.push({ fromProductId: p.product_id, toProductId: parent, relationType: "part_of", source: "manual_entry" });
+    }
+  }
+  return edges;
+}
+
+/** Derive dependency edges from the platform-capability manifest's dependsOn. */
+export function platformCapabilityDependencyEdges(
+  manifest: readonly PlatformCapabilityManifestEntry[] = PLATFORM_CAPABILITY_MANIFEST,
+): ProductDependencyEdge[] {
+  const edges: ProductDependencyEdge[] = [];
+  for (const entry of manifest) {
+    for (const dep of entry.dependsOn ?? []) {
+      if (dep) edges.push({ fromProductId: entry.productId, toProductId: dep, relationType: "depends_on", source: "platform_capability" });
+    }
+  }
+  return edges;
+}
+
+/**
+ * Materialize the product dependency graph: registry-declared edges + the
+ * platform-capability manifest's edges. Idempotent; missing endpoints skip.
+ */
+export async function projectProductDependencyGraph(input: {
+  registryProducts: RegistryProduct[];
+  db?: ProductDependencyClient;
+}): Promise<ProjectDependencyResult> {
+  const edges = [
+    ...registryDependencyEdges(input.registryProducts),
+    ...platformCapabilityDependencyEdges(),
+  ];
+  return linkProductDependencies(edges, { db: input.db });
+}
+
+// ── Traversal (for the cascade) ──────────────────────────────────────────────
+
+/** Internal-id reader subset. */
+export type DependencyTraversalClient = {
+  productDependency: { findMany: (args: unknown) => Promise<unknown> };
+};
+
+/**
+ * Transitive dependencies of a product (everything it depends on / is part of),
+ * following from→to edges. Returns internal ids. Cycle-safe + depth-bounded.
+ */
+export async function getProductDependencies(
+  rootInternalId: string,
+  options: { db?: DependencyTraversalClient; maxDepth?: number } = {},
+): Promise<string[]> {
+  const db = options.db ?? (prisma as unknown as DependencyTraversalClient);
+  const maxDepth = options.maxDepth ?? 12;
+  const visited = new Set<string>();
+  let frontier = [rootInternalId];
+  let depth = 0;
+
+  while (frontier.length > 0 && depth < maxDepth) {
+    const edges = (await db.productDependency.findMany({
+      where: { fromProductId: { in: frontier } },
+      select: { toProductId: true },
+    })) as Array<{ toProductId: string }>;
+    const next = edges
+      .map((e) => e.toProductId)
+      .filter((id) => id !== rootInternalId && !visited.has(id));
+    for (const id of next) visited.add(id);
+    frontier = Array.from(new Set(next));
+    depth++;
+  }
+  return Array.from(visited);
+}
+
+/**
+ * Transitive dependents of a product (everything that depends on it), following
+ * to→from edges. The cascade direction: a sold offering's dependents are upstream;
+ * its DEPENDENCIES (getProductDependencies) are what its priority floors.
+ */
+export async function getProductDependents(
+  rootInternalId: string,
+  options: { db?: DependencyTraversalClient; maxDepth?: number } = {},
+): Promise<string[]> {
+  const db = options.db ?? (prisma as unknown as DependencyTraversalClient);
+  const maxDepth = options.maxDepth ?? 12;
+  const visited = new Set<string>();
+  let frontier = [rootInternalId];
+  let depth = 0;
+
+  while (frontier.length > 0 && depth < maxDepth) {
+    const edges = (await db.productDependency.findMany({
+      where: { toProductId: { in: frontier } },
+      select: { fromProductId: true },
+    })) as Array<{ fromProductId: string }>;
+    const next = edges
+      .map((e) => e.fromProductId)
+      .filter((id) => id !== rootInternalId && !visited.has(id));
+    for (const id of next) visited.add(id);
+    frontier = Array.from(new Set(next));
+    depth++;
+  }
+  return Array.from(visited);
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -19,6 +19,7 @@ import { seedEaSysmlDataAuthority } from "./seed-ea-sysml-data-authority.js";
 import { projectPlatformCapabilities } from "./portfolio-sources/project-portfolio-source.js";
 import { projectAiProviders, projectIntegrations } from "./portfolio-sources/project-external-supply.js";
 import { projectSupplyChain } from "./portfolio-sources/project-sbom.js";
+import { projectProductDependencyGraph } from "./portfolio-sources/product-dependency.js";
 import {
   seedViewpointsForNotation,
   ARCHIMATE_VIEWPOINTS,
@@ -2443,6 +2444,16 @@ async function main(): Promise<void> {
   await step("aiProviderPortfolio", () => projectAiProviders());
   await step("integrationPortfolio", () => projectIntegrations());
   await step("supplyChainPortfolio", () => projectSupplyChain());
+  await step("productDependencyGraph", async () => {
+    const depRegistry = readJson<{
+      digital_products: Array<{
+        product_id: string;
+        depends_on_product_ids?: string[];
+        is_part_of_product_ids?: string[];
+      }>;
+    }>("digital_product_registry.json");
+    await projectProductDependencyGraph({ registryProducts: depRegistry.digital_products });
+  });
   // Invariant asserts — isolated so a violation is surfaced in the summary
   // rather than aborting the whole seed (they run after all seeding).
   await step("assert:activeProvidersHaveClearance", () => assertActiveProvidersHaveClearance());


### PR DESCRIPTION
## Why

First slice of the **per-portfolio budgets + prioritization + dependency-cascade** layer (Mark's direction; plan: [`2026-06-22-portfolio-prioritization-cascade.md`](docs/superpowers/plans/2026-06-22-portfolio-prioritization-cascade.md), **EP-BOM-WIRING**). The cascade Mark described — a customer-sold offering's priority flowing back to its Foundational / Manufacturing & Delivery dependencies — had **no rail**: product→product dependency edges weren't persisted (`digital_product_registry.json`'s `depends_on_product_ids` is dropped at seed; `FeatureBuildDependency`/`EaRelationship`/`InventoryRelationship` are separate concerns). This builds it. Closes **BI-PORTPRIO-2**.

## What

- **`ProductDependency`** model + additive migration (new table; `relationType` `depends_on`|`part_of`; `source`-attributed).
- **`linkProductDependency`** writer — idempotent on `(from, to, relationType)`; resolves public `productId` → internal FK id; skips missing endpoints + self-loops.
- **Edge sources**, emitted by the seed (`productDependencyGraph` step): registry backfill (`depends_on_product_ids` / `is_part_of_product_ids`) + the platform-capability manifest's new `dependsOn`. The seeded graph already yields a real cascade case: **`dpf-platform-standard` (Products & Services Sold) → `dpf-meta` → `infra-neo4j-core` / `infra-docker-runtime`**.
- **Traversal** for the cascade: cycle-safe, depth-bounded `getProductDependencies` / `getProductDependents`.

## Design notes

- Dedicated `ProductDependency` join (not `EaRelationship`) — the EA graph is a separate concern; the cascade wants a clean product→product traversal.
- The cascade itself (priority *floor*, not override) + per-portfolio ranking land in **BI-PORTPRIO-4**, on top of this rail and the budget envelopes (**BI-PORTPRIO-3**) and backlog→portfolio attribution (**BI-PORTPRIO-1**), under the governed dispatcher **BI-30EE393B**.

## Verification

- `@dpf/db` vitest `src/portfolio-sources` — **36 passed** (incl. new dependency writer/traversal/edge-source tests)
- `@dpf/db` typecheck + prisma generate — clean
- **Migration created + applied on a throwaway Postgres** (full migration history replayed) — verified; re-verified by CI on a fresh Postgres.
- pre-commit: gitleaks + **schema regression guard (no regressions)** + scoped typecheck — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)