### PR TITLE
feat(golden-triangle): Slice 4 — migration-free posture persistence + save-as-platform-default (BI-85B2E96C)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/priority/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/priority/page.tsx
@@ -1,10 +1,13 @@
 // apps/web/app/(shell)/platform/ai/priority/page.tsx
-// EP-GOLDEN-TRIANGLE Slice 2 — the Golden Triangle priority control surface.
+// EP-GOLDEN-TRIANGLE Slice 2/4 — the Golden Triangle priority control surface.
 // A non-technical operator sets a Cost / Quality / Time posture; the platform
-// compiles it into model tier, effort, verification, and retries.
+// compiles it into model tier, effort, verification, and retries. Seeds from the
+// saved WWMD/platform default (migration-free, on the platform profile).
 import { GoldenTrianglePriorityPanel } from "@/components/golden-triangle/GoldenTrianglePriorityPanel";
+import { getGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
 
-export default function GoldenTrianglePriorityPage() {
+export default async function GoldenTrianglePriorityPage() {
+  const saved = await getGoldenTrianglePosture({ kind: "platform" });
   return (
     <div>
       <div style={{ marginBottom: 16 }}>
@@ -12,10 +15,10 @@ export default function GoldenTrianglePriorityPage() {
         <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2 }}>
           Set the Cost / Quality / Time priority for AI work. Pick a preset or fine-tune the triangle — the
           platform compiles it into the right model, effort, and verification, and shows in plain language
-          exactly what it configured.
+          exactly what it configured. Save it as the platform default for new work.
         </p>
       </div>
-      <GoldenTrianglePriorityPanel />
+      <GoldenTrianglePriorityPanel initial={saved ?? undefined} />
     </div>
   );
 }

--- a/apps/web/components/golden-triangle/GoldenTrianglePriorityPanel.tsx
+++ b/apps/web/components/golden-triangle/GoldenTrianglePriorityPanel.tsx
@@ -1,24 +1,55 @@
 "use client";
-// EP-GOLDEN-TRIANGLE Slice 2 — a self-contained, stateful host for the posture
-// control, suitable for a settings/preview surface. Holds the preference in
-// view-local state; persistence per scope (Slice 4) and the receipt view
-// (Slice 3b) wire in later.
+// EP-GOLDEN-TRIANGLE Slice 2/4 — stateful host for the posture control on the
+// /platform/ai/priority surface. Seeds from the saved WWMD/platform default and
+// saves edits back via the server action (migration-free; stored on the platform
+// DecisionPerspectiveProfile's autonomyPolicy JSON).
 import { useState } from "react";
 
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
+import { saveGoldenTrianglePlatformDefault } from "@/lib/actions/golden-triangle";
+
 import { GoldenTriangleControl } from "./GoldenTriangleControl";
 import { preferenceFromPreset } from "./posture-display";
 
-export function GoldenTrianglePriorityPanel() {
-  const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
+export function GoldenTrianglePriorityPanel({ initial }: { initial?: GoldenTrianglePreference }) {
+  const [pref, setPref] = useState<GoldenTrianglePreference>(initial ?? preferenceFromPreset("balanced"));
+  const [saved, setSaved] = useState<"idle" | "saved" | "error">("idle");
+  const [pending, setPending] = useState(false);
+
+  function onChange(next: GoldenTrianglePreference) {
+    setPref(next);
+    setSaved("idle");
+  }
+
+  async function save() {
+    setPending(true);
+    setSaved("idle");
+    try {
+      const res = await saveGoldenTrianglePlatformDefault(pref);
+      setSaved(res.ok ? "saved" : "error");
+    } catch {
+      setSaved("error");
+    } finally {
+      setPending(false);
+    }
+  }
+
   return (
     <div style={{ maxWidth: 680 }}>
-      <GoldenTriangleControl value={pref} onChange={setPref} taskClass="conversation" authorityScopeKind="wwmd" />
-      <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 10 }}>
-        Preview — your choice is held in this view only for now. Saving a default per scope (Slice 4) and the
-        receipt that shows what actually ran (Slice 3b) wire in next.
-      </p>
+      <GoldenTriangleControl value={pref} onChange={onChange} taskClass="conversation" authorityScopeKind="wwmd" />
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 12 }}>
+        <button
+          type="button"
+          onClick={save}
+          disabled={pending}
+          className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-[13px] font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] disabled:opacity-50"
+        >
+          {pending ? "Saving..." : "Save as platform default"}
+        </button>
+        {saved === "saved" && <span style={{ fontSize: 12, color: "var(--dpf-success)" }}>Saved</span>}
+        {saved === "error" && <span style={{ fontSize: 12, color: "var(--dpf-error)" }}>Could not save</span>}
+      </div>
     </div>
   );
 }

--- a/apps/web/lib/actions/golden-triangle.ts
+++ b/apps/web/lib/actions/golden-triangle.ts
@@ -1,0 +1,24 @@
+"use server";
+// EP-GOLDEN-TRIANGLE Slice 4 (BI-85B2E96C) — server action to save the WWMD /
+// platform default posture. Gated by `view_platform` (the same capability that
+// guards decision-perspective writes). Platform scope only for v1; org-scoped
+// (WWWD) saving needs org-membership authz and lands with Slice 5.
+import { revalidatePath } from "next/cache";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+import { setGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
+
+export async function saveGoldenTrianglePlatformDefault(
+  preference: GoldenTrianglePreference,
+): Promise<{ ok: boolean }> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")) {
+    throw new Error("Unauthorized");
+  }
+  const ok = await setGoldenTrianglePosture({ kind: "platform" }, preference);
+  if (ok) revalidatePath("/platform/ai/priority");
+  return { ok };
+}

--- a/apps/web/lib/golden-triangle/persistence.test.ts
+++ b/apps/web/lib/golden-triangle/persistence.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import {
+  getGoldenTrianglePosture,
+  isGoldenTrianglePreference,
+  setGoldenTrianglePosture,
+  type GoldenTrianglePersistenceClient,
+} from "./persistence";
+
+const ASSURED: GoldenTrianglePreference = { preset: "assured", qualityWeight: 0.8, costWeight: 0.1, timeWeight: 0.1 };
+
+interface Calls {
+  findFirst: unknown[];
+  updateMany: Array<{ where: unknown; data: { autonomyPolicy: Record<string, unknown> } }>;
+}
+
+function makeClient(initialPolicy: unknown = null) {
+  let policy: unknown = initialPolicy;
+  const calls: Calls = { findFirst: [], updateMany: [] };
+  const client: GoldenTrianglePersistenceClient = {
+    decisionPerspectiveProfile: {
+      findFirst: async (args) => {
+        calls.findFirst.push(args);
+        return policy === null ? null : { autonomyPolicy: policy };
+      },
+      updateMany: async (args) => {
+        const a = args as { where: unknown; data: { autonomyPolicy: Record<string, unknown> } };
+        calls.updateMany.push(a);
+        policy = a.data.autonomyPolicy;
+        return { count: 1 };
+      },
+    },
+  };
+  return { client, calls, getPolicy: () => policy };
+}
+
+function throwingClient(): GoldenTrianglePersistenceClient {
+  return {
+    decisionPerspectiveProfile: {
+      findFirst: async () => {
+        throw new Error("db down");
+      },
+      updateMany: async () => {
+        throw new Error("db down");
+      },
+    },
+  };
+}
+
+describe("setGoldenTrianglePosture", () => {
+  it("writes the posture onto the platform profile under goldenTriangle", async () => {
+    const { client, calls } = makeClient();
+    const ok = await setGoldenTrianglePosture({ kind: "platform" }, ASSURED, client);
+    expect(ok).toBe(true);
+    expect(calls.updateMany[0]?.where).toEqual({ profileId: "mark-dpf-platform" });
+    expect(calls.updateMany[0]?.data.autonomyPolicy.goldenTriangle).toEqual(ASSURED);
+  });
+
+  it("preserves existing autonomyPolicy keys when merging", async () => {
+    const { client, getPolicy } = makeClient({ allowRecommendation: true, allowArbitration: false });
+    await setGoldenTrianglePosture({ kind: "platform" }, ASSURED, client);
+    expect(getPolicy()).toMatchObject({
+      allowRecommendation: true,
+      allowArbitration: false,
+      goldenTriangle: ASSURED,
+    });
+  });
+
+  it("targets the org profile for an organization scope", async () => {
+    const { client, calls } = makeClient();
+    await setGoldenTrianglePosture({ kind: "organization", organizationId: "org_1" }, ASSURED, client);
+    expect(calls.updateMany[0]?.where).toEqual({ ownerOrganizationId: "org_1", kind: "organization" });
+  });
+
+  it("is fail-open: returns false when the db throws", async () => {
+    const ok = await setGoldenTrianglePosture({ kind: "platform" }, ASSURED, throwingClient());
+    expect(ok).toBe(false);
+  });
+});
+
+describe("getGoldenTrianglePosture", () => {
+  it("reads a previously saved posture back", async () => {
+    const { client } = makeClient({ goldenTriangle: ASSURED });
+    expect(await getGoldenTrianglePosture({ kind: "platform" }, client)).toEqual(ASSURED);
+  });
+
+  it("returns null when no posture is stored", async () => {
+    const { client } = makeClient({ allowRecommendation: true });
+    expect(await getGoldenTrianglePosture({ kind: "platform" }, client)).toBeNull();
+  });
+
+  it("returns null for a malformed stored value", async () => {
+    const { client } = makeClient({ goldenTriangle: { preset: "assured" } });
+    expect(await getGoldenTrianglePosture({ kind: "platform" }, client)).toBeNull();
+  });
+
+  it("is fail-open: returns null when the db throws", async () => {
+    expect(await getGoldenTrianglePosture({ kind: "platform" }, throwingClient())).toBeNull();
+  });
+});
+
+describe("isGoldenTrianglePreference", () => {
+  it("accepts a well-formed preference", () => {
+    expect(isGoldenTrianglePreference(ASSURED)).toBe(true);
+  });
+  it("rejects wrong shapes", () => {
+    expect(isGoldenTrianglePreference(null)).toBe(false);
+    expect(isGoldenTrianglePreference({ preset: "assured" })).toBe(false);
+    expect(isGoldenTrianglePreference({ ...ASSURED, preset: "nope" })).toBe(false);
+    expect(isGoldenTrianglePreference({ ...ASSURED, costWeight: "x" })).toBe(false);
+  });
+});

--- a/apps/web/lib/golden-triangle/persistence.ts
+++ b/apps/web/lib/golden-triangle/persistence.ts
@@ -1,0 +1,94 @@
+// EP-GOLDEN-TRIANGLE Slice 4 (BI-85B2E96C) — migration-free persistence of a
+// saved posture per authority scope.
+//
+// The posture is stored under the `goldenTriangle` key of a
+// DecisionPerspectiveProfile's `autonomyPolicy` JSON column — the home the
+// Slice 0 audit identified (no schema change; sidesteps the missing
+// `datasource.url` migration constraint in worktrees). Reads/writes preserve the
+// other autonomyPolicy keys (e.g. the risk-envelope policy). Fail-open: a
+// settings read/write must never throw into a page render or an action.
+import { prisma } from "@dpf/db";
+
+import type { GoldenTrianglePreference, GoldenTrianglePreset } from "@/lib/golden-triangle";
+
+/** WWMD/platform default lives on the seeded platform profile; WWWD on the org profile. */
+export type GoldenTriangleScope =
+  | { kind: "platform" }
+  | { kind: "organization"; organizationId: string };
+
+const PLATFORM_PROFILE_ID = "mark-dpf-platform";
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type GoldenTrianglePersistenceClient = {
+  decisionPerspectiveProfile: {
+    findFirst: (args: unknown) => Promise<{ autonomyPolicy: unknown } | null>;
+    updateMany: (args: unknown) => Promise<{ count: number }>;
+  };
+};
+
+const PRESETS: GoldenTrianglePreset[] = ["fast", "frugal", "assured", "balanced", "custom"];
+
+function whereForScope(scope: GoldenTriangleScope): Record<string, unknown> {
+  return scope.kind === "platform"
+    ? { profileId: PLATFORM_PROFILE_ID }
+    : { ownerOrganizationId: scope.organizationId, kind: "organization" };
+}
+
+/** Narrow an unknown JSON value to a valid preference (defensive — JSON is untyped). */
+export function isGoldenTrianglePreference(v: unknown): v is GoldenTrianglePreference {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.costWeight === "number" &&
+    typeof o.qualityWeight === "number" &&
+    typeof o.timeWeight === "number" &&
+    typeof o.preset === "string" &&
+    PRESETS.includes(o.preset as GoldenTrianglePreset)
+  );
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+}
+
+export async function getGoldenTrianglePosture(
+  scope: GoldenTriangleScope,
+  db?: GoldenTrianglePersistenceClient,
+): Promise<GoldenTrianglePreference | null> {
+  const client = db ?? (prisma as unknown as GoldenTrianglePersistenceClient);
+  try {
+    const row = await client.decisionPerspectiveProfile.findFirst({
+      where: whereForScope(scope),
+      select: { autonomyPolicy: true },
+    });
+    const gt = asRecord(row?.autonomyPolicy).goldenTriangle;
+    return isGoldenTrianglePreference(gt) ? gt : null;
+  } catch (err) {
+    console.warn("[golden-triangle] posture read failed (fail-open):", err);
+    return null;
+  }
+}
+
+/** Merge the posture into the scoped profile's autonomyPolicy. Returns true if a row was updated. */
+export async function setGoldenTrianglePosture(
+  scope: GoldenTriangleScope,
+  preference: GoldenTrianglePreference,
+  db?: GoldenTrianglePersistenceClient,
+): Promise<boolean> {
+  const client = db ?? (prisma as unknown as GoldenTrianglePersistenceClient);
+  try {
+    const row = await client.decisionPerspectiveProfile.findFirst({
+      where: whereForScope(scope),
+      select: { autonomyPolicy: true },
+    });
+    const nextPolicy = { ...asRecord(row?.autonomyPolicy), goldenTriangle: preference };
+    const res = await client.decisionPerspectiveProfile.updateMany({
+      where: whereForScope(scope),
+      data: { autonomyPolicy: nextPolicy },
+    });
+    return res.count > 0;
+  } catch (err) {
+    console.warn("[golden-triangle] posture write failed (fail-open):", err);
+    return false;
+  }
+}


### PR DESCRIPTION
**Slice 4** of `EP-GOLDEN-TRIANGLE` (`BI-85B2E96C`) — the posture now **persists**, with **no schema change**.

- **`persistence.ts`** — `get`/`setGoldenTrianglePosture(scope)` store the posture under the `goldenTriangle` key of a `DecisionPerspectiveProfile.autonomyPolicy` JSON column (the home the Slice 0 audit identified). Merge-preserving (keeps the risk-envelope policy), fail-open, structural client for tests. **This sidesteps the worktree's missing `datasource.url`** — no `prisma migrate` needed.
- **`saveGoldenTrianglePlatformDefault`** server action — `view_platform`-gated (the same capability guarding decision-perspective writes); **platform scope only** for v1 (org/WWWD saving needs membership authz → Slice 5).
- **`/platform/ai/priority`** now loads the saved WWMD/platform default server-side and the panel has a **Save as platform default** button.

Verification: 34 golden-triangle lib tests green (incl. 10 new persistence tests: scope targeting, merge-preservation, fail-open, the JSON guard); pre-commit typecheck passed (client→server-action wiring + the prisma-backed page).

UX-Fit-Decision: adds only a Save button + seeds the control from the saved default; the presets-first control is unchanged. human_cognitive_load unscorable by principle_decide (design §0.1) — decided on merits.

Note: stacks conceptually on Slice 2b (#2297, balance/coworker) but is independent of it (touches different files); both are migration-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
