### PR TITLE
feat(assurance): off-hours budget-capped remediation lane — auto-promote findings to Build Studio (BI-7C121CCF)

### DIFF
--- a/apps/web/lib/assurance/remediation-teeup.test.ts
+++ b/apps/web/lib/assurance/remediation-teeup.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_ASSURANCE_REMEDIATION_BUDGET,
+  isAssuranceRemediationWindowOpen,
+  resolveRemediationBudget,
+  runAssuranceRemediationTeeUp,
+  selectAssuranceRemediationCandidates,
+  type RemediationCandidate,
+} from "./remediation-teeup";
+
+function candidate(overrides: Partial<RemediationCandidate> = {}): RemediationCandidate {
+  return {
+    id: "cuid-1",
+    itemId: "BI-1",
+    title: "Remediate: hono X",
+    body: "Severity: HIGH\n\n[origin:assuranceFinding:fk-1]",
+    status: "triaging",
+    proposedOutcome: "build",
+    activeBuildId: null,
+    effortSize: "medium",
+    createdAt: new Date("2026-06-22T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("selectAssuranceRemediationCandidates", () => {
+  it("keeps only triaging, build-proposed, unbuilt, assurance-origin items", () => {
+    const items = [
+      candidate({ itemId: "ok" }),
+      candidate({ itemId: "not-triaging", status: "open" }),
+      candidate({ itemId: "not-build", proposedOutcome: "defer" }),
+      candidate({ itemId: "has-build", activeBuildId: "fb-1" }),
+      candidate({ itemId: "not-assurance", body: "Severity: HIGH\n\nsome other BI" }),
+      candidate({ itemId: "null-body", body: null }),
+    ];
+    const got = selectAssuranceRemediationCandidates(items, 10).map((c) => c.itemId);
+    expect(got).toEqual(["ok"]);
+  });
+
+  it("orders critical before high, then oldest first", () => {
+    const items = [
+      candidate({ itemId: "high-old", body: "Severity: HIGH [origin:assuranceFinding:a]", createdAt: new Date("2026-06-20T00:00:00Z") }),
+      candidate({ itemId: "crit-new", body: "Severity: CRITICAL [origin:assuranceFinding:b]", createdAt: new Date("2026-06-22T00:00:00Z") }),
+      candidate({ itemId: "crit-old", body: "Severity: CRITICAL [origin:assuranceFinding:c]", createdAt: new Date("2026-06-21T00:00:00Z") }),
+    ];
+    expect(selectAssuranceRemediationCandidates(items, 10).map((c) => c.itemId)).toEqual([
+      "crit-old",
+      "crit-new",
+      "high-old",
+    ]);
+  });
+
+  it("caps at the budget", () => {
+    const items = [candidate({ itemId: "a" }), candidate({ itemId: "b" }), candidate({ itemId: "c" })];
+    expect(selectAssuranceRemediationCandidates(items, 2)).toHaveLength(2);
+  });
+
+  it("returns nothing for a zero/negative budget", () => {
+    expect(selectAssuranceRemediationCandidates([candidate()], 0)).toEqual([]);
+    expect(selectAssuranceRemediationCandidates([candidate()], -1)).toEqual([]);
+  });
+});
+
+describe("isAssuranceRemediationWindowOpen", () => {
+  it("is open inside the 02:00–06:00 UTC window", () => {
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T03:00:00Z"))).toBe(true);
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T05:59:00Z"))).toBe(true);
+  });
+
+  it("is closed outside the window", () => {
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T12:00:00Z"))).toBe(false);
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T06:00:00Z"))).toBe(false);
+  });
+});
+
+describe("resolveRemediationBudget", () => {
+  it("defaults when unset or invalid", () => {
+    expect(resolveRemediationBudget({})).toBe(DEFAULT_ASSURANCE_REMEDIATION_BUDGET);
+    expect(resolveRemediationBudget({ ASSURANCE_REMEDIATION_BUDGET: "abc" })).toBe(DEFAULT_ASSURANCE_REMEDIATION_BUDGET);
+  });
+
+  it("honors a valid env override (including 0)", () => {
+    expect(resolveRemediationBudget({ ASSURANCE_REMEDIATION_BUDGET: "5" })).toBe(5);
+    expect(resolveRemediationBudget({ ASSURANCE_REMEDIATION_BUDGET: "0" })).toBe(0);
+  });
+});
+
+describe("runAssuranceRemediationTeeUp", () => {
+  function prismaWith(items: RemediationCandidate[], governed: boolean) {
+    return {
+      platformDevConfig: { findUnique: vi.fn(async () => ({ governedBacklogEnabled: governed })) },
+      backlogItem: { findMany: vi.fn(async () => items) },
+      $transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
+    };
+  }
+
+  it("does nothing when governed backlog is disabled", async () => {
+    const prisma = prismaWith([candidate()], false);
+    const promote = vi.fn();
+    const result = await runAssuranceRemediationTeeUp({ prisma: prisma as never, userId: "u1", budget: 5, promote });
+    expect(result.enabled).toBe(false);
+    expect(promote).not.toHaveBeenCalled();
+  });
+
+  it("promotes a budgeted batch and returns counts", async () => {
+    const prisma = prismaWith(
+      [candidate({ itemId: "a" }), candidate({ itemId: "b" }), candidate({ itemId: "c" })],
+      true,
+    );
+    let n = 0;
+    const promote = vi.fn(async ({ itemId }: { prisma: unknown; itemId: string; userId: string }) => ({
+      kind: "success" as const,
+      build: { id: `cuid-${++n}`, buildId: `FB-${itemId}` },
+      backlogItemId: itemId,
+      capsuleId: `WC-${itemId}`,
+      autoApprovedDispatchEligible: true,
+    }));
+
+    const result = await runAssuranceRemediationTeeUp({ prisma: prisma as never, userId: "u1", budget: 2, promote });
+
+    expect(result.enabled).toBe(true);
+    expect(result.selectedCount).toBe(2);
+    expect(result.promotedCount).toBe(2);
+    expect(result.builds).toEqual([
+      { backlogItemId: "a", buildId: "FB-a" },
+      { backlogItemId: "b", buildId: "FB-b" },
+    ]);
+    expect(promote).toHaveBeenCalledTimes(2);
+  });
+
+  it("counts promote failures as skipped", async () => {
+    const prisma = prismaWith([candidate({ itemId: "a" })], true);
+    const promote = vi.fn(async () => ({ kind: "error" as const, error: "x", message: "nope" }));
+    const result = await runAssuranceRemediationTeeUp({ prisma: prisma as never, userId: "u1", budget: 5, promote });
+    expect(result.promotedCount).toBe(0);
+    expect(result.skippedCount).toBe(1);
+  });
+});

--- a/apps/web/lib/assurance/remediation-teeup.ts
+++ b/apps/web/lib/assurance/remediation-teeup.ts
@@ -1,0 +1,225 @@
+// apps/web/lib/assurance/remediation-teeup.ts
+//
+// P1 of the assurance remediation loop (BI-7C121CCF): get auto-filed assurance
+// findings WORKED, not just created. The assurance gate (PR #2290) auto-files
+// genuine high/critical findings as backlog items in status=triaging — but the
+// general governed tee-up only promotes status=open + triageOutcome=build items
+// at a fixed 14:00 cron, so the auto-filed BIs sit unworked.
+//
+// This is a DEDICATED off-hours, budget-capped lane that promotes them into
+// Build Studio (which builds the dependency-override bump → PR). NO auto-merge
+// here — that is P2 (WWMD-gated). Founder rails: off-hours/flexible, incremental,
+// budget cap. Reuses promoteBacklogItemToBuildDraft (don't reinvent) + the
+// self-upgrade off-hours window primitives.
+
+import type { MaintenanceWindow } from "@/lib/self-upgrade/config";
+import { isWithinWindows } from "@/lib/self-upgrade/windows-eval";
+import { promoteBacklogItemToBuildDraft } from "@/lib/governed-backlog-tee-up";
+
+/** Body marker the shared backlog front door stamps on assurance-gate auto-files. */
+export const ASSURANCE_ORIGIN_MARKER = "[origin:assuranceFinding:";
+
+// Platform off-hours (UTC). An hourly cron acts only inside this window, so the
+// lane runs "off-hours, flexible, not a single fixed slot" (founder rail). The
+// dispatcher itself is light (DB writes + an event); the builds it triggers are
+// concurrency-capped by the build pipeline, so window overlap with maintenance
+// is acceptable.
+const PLATFORM_OFFHOURS_UTC: MaintenanceWindow = {
+  dayOfWeek: [0, 1, 2, 3, 4, 5, 6],
+  startTime: "02:00",
+  endTime: "06:00",
+};
+
+/** True when `now` is inside the platform off-hours window (evaluated in UTC). */
+export function isAssuranceRemediationWindowOpen(now: Date): boolean {
+  return isWithinWindows([PLATFORM_OFFHOURS_UTC], now, "UTC");
+}
+
+/** Default per-run budget: how many remediations to promote on one tick. */
+export const DEFAULT_ASSURANCE_REMEDIATION_BUDGET = 2;
+
+/** Per-run budget cap (founder rail: budget control). Env-tunable; a richer
+ *  spend-based budget (spend-intelligence) is a later phase. */
+export function resolveRemediationBudget(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.ASSURANCE_REMEDIATION_BUDGET;
+  const n = raw != null && raw !== "" ? Number(raw) : NaN;
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : DEFAULT_ASSURANCE_REMEDIATION_BUDGET;
+}
+
+export interface RemediationCandidate {
+  id: string;
+  itemId: string;
+  title: string;
+  body: string | null;
+  status: string;
+  proposedOutcome: string | null;
+  activeBuildId: string | null;
+  effortSize: string | null;
+  createdAt: Date;
+}
+
+/** Severity rank parsed from the auto-file body ("Severity: HIGH"); lower = first. */
+function severityRank(body: string | null): number {
+  const m = /Severity:\s*(CRITICAL|HIGH|MEDIUM|LOW)/i.exec(body ?? "");
+  switch ((m?.[1] ?? "").toUpperCase()) {
+    case "CRITICAL":
+      return 0;
+    case "HIGH":
+      return 1;
+    case "MEDIUM":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+function isEligible(item: RemediationCandidate): boolean {
+  return (
+    item.status === "triaging" &&
+    item.proposedOutcome === "build" &&
+    item.activeBuildId == null &&
+    typeof item.body === "string" &&
+    item.body.includes(ASSURANCE_ORIGIN_MARKER)
+  );
+}
+
+/**
+ * Rank eligible assurance-remediation candidates (critical first, then oldest,
+ * then id for determinism) and cap at the budget. Pure — the heart of the lane.
+ */
+export function selectAssuranceRemediationCandidates(
+  items: RemediationCandidate[],
+  budget: number,
+): RemediationCandidate[] {
+  if (budget <= 0) return [];
+  return items
+    .filter(isEligible)
+    .sort((a, b) => {
+      const sev = severityRank(a.body) - severityRank(b.body);
+      if (sev !== 0) return sev;
+      const created = a.createdAt.getTime() - b.createdAt.getTime();
+      if (created !== 0) return created;
+      return a.itemId.localeCompare(b.itemId);
+    })
+    .slice(0, budget);
+}
+
+// ── orchestration ───────────────────────────────────────────────────────────
+
+type PromoteResult = Awaited<ReturnType<typeof promoteBacklogItemToBuildDraft>>;
+type PromoteTx = Parameters<typeof promoteBacklogItemToBuildDraft>[0]["tx"];
+
+// `any` args mirror the proven governed-backlog-tee-up.ts prisma shim so the real
+// PrismaClient is assignable when the inngest fn passes it; returns stay typed.
+type RemediationPrisma = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  platformDevConfig: { findUnique(args: any): Promise<{ governedBacklogEnabled: boolean | null } | null> };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  backlogItem: { findMany(args: any): Promise<RemediationCandidate[]> };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  $transaction<T>(cb: (tx: any) => Promise<T>): Promise<T>;
+};
+
+export type PromoteRemediationItem = (args: {
+  prisma: RemediationPrisma;
+  itemId: string;
+  userId: string;
+}) => Promise<PromoteResult>;
+
+// Default promote: set the triaging auto-file BI to open + triageOutcome=build
+// (the governed triage decision for this lane), then reuse the shared promote
+// path — ATOMICALLY, so a promote failure rolls the triage transition back and
+// never leaves an orphaned open+build BI the general 14:00 tee-up could grab.
+const defaultPromote: PromoteRemediationItem = ({ prisma, itemId, userId }) =>
+  prisma.$transaction(async (tx) => {
+    const t = tx as PromoteTx;
+    await t.backlogItem.update({
+      where: { itemId },
+      data: { status: "open", triageOutcome: "build" },
+    });
+    return promoteBacklogItemToBuildDraft({
+      tx: t,
+      itemId,
+      userId,
+      governedBacklogEnabled: true,
+      activity: {
+        tool: "assurance_remediation_tee_up",
+        summary: `Auto-promoted assurance remediation ${itemId} (off-hours lane).`,
+      },
+    });
+  });
+
+export interface RunAssuranceRemediationTeeUpResult {
+  enabled: boolean;
+  selectedCount: number;
+  promotedCount: number;
+  skippedCount: number;
+  builds: Array<{ backlogItemId: string; buildId: string }>;
+}
+
+/**
+ * Select + promote a budgeted batch of auto-filed assurance remediations into
+ * Build Studio. Gated on governedBacklogEnabled (the same opt-in the general
+ * tee-up uses). The caller gates the off-hours window + quiescence.
+ */
+export async function runAssuranceRemediationTeeUp(input: {
+  prisma: RemediationPrisma;
+  userId: string;
+  budget: number;
+  promote?: PromoteRemediationItem;
+}): Promise<RunAssuranceRemediationTeeUpResult> {
+  const { prisma, userId, budget } = input;
+  const promote = input.promote ?? defaultPromote;
+
+  const config = await prisma.platformDevConfig.findUnique({
+    where: { id: "singleton" },
+    select: { governedBacklogEnabled: true },
+  });
+  if (config?.governedBacklogEnabled !== true || budget <= 0) {
+    return { enabled: false, selectedCount: 0, promotedCount: 0, skippedCount: 0, builds: [] };
+  }
+
+  const items = await prisma.backlogItem.findMany({
+    where: {
+      status: "triaging",
+      proposedOutcome: "build",
+      activeBuildId: null,
+      body: { contains: ASSURANCE_ORIGIN_MARKER },
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      itemId: true,
+      title: true,
+      body: true,
+      status: true,
+      proposedOutcome: true,
+      activeBuildId: true,
+      effortSize: true,
+      createdAt: true,
+    },
+  });
+
+  const selected = selectAssuranceRemediationCandidates(items, budget);
+  const builds: Array<{ backlogItemId: string; buildId: string }> = [];
+  let skippedCount = 0;
+
+  for (const item of selected) {
+    const result = await promote({ prisma, itemId: item.itemId, userId });
+    if (result.kind === "success") {
+      builds.push({ backlogItemId: result.backlogItemId, buildId: result.build.buildId });
+    } else {
+      skippedCount += 1;
+    }
+  }
+
+  return {
+    enabled: true,
+    selectedCount: selected.length,
+    promotedCount: builds.length,
+    skippedCount,
+    builds,
+  };
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -279,6 +279,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "assurance-remediation-tee-up",
+    inngestId: "assurance/remediation-tee-up-scheduled",
+    name: "Assurance remediation tee-up",
+    purpose:
+      "Off-hours, budget-capped auto-promotion of genuine high/critical assurance findings into Build Studio remediation builds. If it stops, auto-filed vulnerability BIs sit unworked.",
+    cron: "41 * * * *",
+    cadence: "Hourly at :41 — acts only in the 02:00–06:00 UTC off-hours window",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "material-freshness-decay",
     inngestId: "decision/material-freshness-decay",
     name: "Material freshness decay",

--- a/apps/web/lib/queue/functions/assurance-remediation-teeup.ts
+++ b/apps/web/lib/queue/functions/assurance-remediation-teeup.ts
@@ -1,0 +1,56 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+// Assurance remediation lane P1 (BI-7C121CCF). Hourly poll that, only inside the
+// platform off-hours window, promotes a budgeted batch of auto-filed assurance
+// findings (PR #2290) into Build Studio remediation builds. Founder rails:
+// off-hours/flexible (hourly cron, window-gated — not a fixed slot), incremental
+// + budget-capped (per-run cap), and gated on governedBacklogEnabled. NO
+// auto-merge here — the resulting PRs wait for P2's WWMD-gated merge.
+//
+// Cron is :41 (a free minute) to stay off the shared ticks the contention guard
+// watches (scheduling-map.test.ts).
+export const assuranceRemediationTeeUpScheduled = inngest.createFunction(
+  {
+    id: "assurance/remediation-tee-up-scheduled",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("41 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("assurance-remediation-tee-up", async () => {
+      const { prisma } = await import("@dpf/db");
+      const {
+        runAssuranceRemediationTeeUp,
+        isAssuranceRemediationWindowOpen,
+        resolveRemediationBudget,
+      } = await import("@/lib/assurance/remediation-teeup");
+      const { dispatchApprovedIdeateBuilds } = await import("@/lib/integrate/ideate-on-approval");
+      const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
+
+      const now = new Date();
+      // Off-hours rail: hourly cron, but only act inside the low-traffic window.
+      if (!isAssuranceRemediationWindowOpen(now)) {
+        return { skipped: true, reason: "outside-off-hours-window" };
+      }
+
+      const userId = await resolveScheduledOwnerUserId();
+      const teeUp = await runAssuranceRemediationTeeUp({
+        prisma,
+        userId,
+        budget: resolveRemediationBudget(),
+      });
+
+      // Fire Ideate for the drafts this run auto-approved (mirrors the governed
+      // tee-up) so promoted remediation builds are not dead-on-arrival at ideate.
+      const ideateDispatch =
+        teeUp.promotedCount > 0 ? await dispatchApprovedIdeateBuilds({ userId }) : null;
+
+      return { ...teeUp, ideateDispatch };
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -25,6 +25,7 @@ import {
   governedBacklogTeeUpRequested,
   governedBacklogTeeUpScheduled,
 } from "./governed-backlog-tee-up";
+import { assuranceRemediationTeeUpScheduled } from "./assurance-remediation-teeup";
 import { tokenExpiryMonitor } from "./token-expiry-monitor";
 import {
   contributorInventorySyncCron,
@@ -68,6 +69,7 @@ export const scheduledFunctions = [
   agentTaskDispatch,
   taskrunWatchdog,
   governedBacklogTeeUpScheduled,
+  assuranceRemediationTeeUpScheduled, // BI-7C121CCF: off-hours, budget-capped assurance remediation lane
   tokenExpiryMonitor,
   contributorInventorySyncCron,
   wikiLint,

--- a/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
@@ -35,9 +35,22 @@ selects `status=open` + `triageOutcome=build`) never picks them up.
 - Per item (within budget): set `status=open` + `triageOutcome=build`, then
   `promoteBacklogItemToBuildDraft` → Ideate → BS builds the override bump → PR.
   **No auto-merge here** (awaits P2).
-- General 14:00 tee-up **excludes assurance-origin BIs** so this lane stays
-  off-hours + own-budget.
+- General 14:00 tee-up: no exclusion needed — the triage transition + promote run
+  in ONE transaction (rollback on failure) and `promoteBacklogItemToBuildDraft`
+  sets `activeBuildId`, which the general tee-up's `activeBuildId: null` filter
+  already excludes. So an assurance BI is never visible to the general lane as a
+  bare open+build item.
 - Tests: selector matrix + off-hours gating. Register in the scheduling catalog.
+
+**Implemented (BI-7C121CCF):** `apps/web/lib/assurance/remediation-teeup.ts`
+(`selectAssuranceRemediationCandidates` + `isAssuranceRemediationWindowOpen` +
+`resolveRemediationBudget` + `runAssuranceRemediationTeeUp`) + test;
+`apps/web/lib/queue/functions/assurance-remediation-teeup.ts` (inngest cron
+`assurance/remediation-tee-up-scheduled`, `41 * * * *`, gated to 02:00–06:00 UTC +
+quiescence); registered in `queue/functions/index.ts` + the scheduled-jobs catalog
+(parity test). Budget: per-run cap `ASSURANCE_REMEDIATION_BUDGET` (default 2);
+gated on `governedBacklogEnabled`. A spend-based budget (spend-intelligence) is a
+later refinement.
 
 ## Phase 2 — WWMD-gated autonomous merge + escalate (BI-204EE70B)
 


### PR DESCRIPTION
## Why
P1 of the assurance remediation loop (**BI-7C121CCF**). Auto-filed assurance findings (PR #2290) land in `triaging` and sat unworked — the general governed tee-up only promotes `status=open`+`triageOutcome=build` at a fixed 14:00 cron. Auto-*creating* findings without a remediation loop just relocates the lost queue.

## What
A dedicated **off-hours, budget-capped** lane that promotes genuine high/critical findings into Build Studio (which builds the dependency-override bump → PR). **No auto-merge** — that's P2 (WWMD-gated).

Founder rails:
- **Off-hours / flexible** — hourly cron `41 * * * *`, acts only inside the 02:00–06:00 UTC window (not a fixed slot).
- **Incremental + budget** — per-run cap `ASSURANCE_REMEDIATION_BUDGET` (default 2).
- **Gated** — only runs when `governedBacklogEnabled`; quiescence-gated (no work during a self-upgrade drain).

Reuses `promoteBacklogItemToBuildDraft` (the triage→open+build transition + promote run **atomically**, so a failure can't leak a bare open+build BI to the general lane), the self-upgrade off-hours window primitives, and the quiescence gate.

## Files
- `apps/web/lib/assurance/remediation-teeup.ts` (+ test) — pure selector (severity-ranked, budget-capped), off-hours predicate, budget resolver, orchestration (injectable promote for tests).
- `apps/web/lib/queue/functions/assurance-remediation-teeup.ts` — the inngest cron.
- Registered in `queue/functions/index.ts` + the scheduled-jobs catalog (catalog↔registry parity test).
- Plan updated.

## Verification
Unit tests for the selector matrix, off-hours window, budget resolver, and orchestration (governed-off, budget cap, skip-on-failure). Worktree lacks `node_modules` → relying on CI for the full suite + typecheck + the catalog/scheduling parity tests.

## Next
P2 [BI-204EE70B] WWMD-gated autonomous merge + escalate-on-uncertain; P3 [BI-4D5C702F] auto-resolve on clean re-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)