### PR TITLE
fix(seed): package profession corpus in portal image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,7 @@ apps/web/.next/**
 !README.md
 !docs/user-guide/**/*.md
 !docs/user-guide/**/index.md
+!docs/professions/**/*.md
 docs/superpowers/
 docs/Reference/
 # IT4IT functional criteria workbook is needed at seed time; the rest of

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,7 @@ COPY --from=init /app/scripts ./scripts
 RUN chmod +x ./scripts/*.sh
 COPY --from=init /app/docs/user-guide ./docs/user-guide
 COPY --from=init /app/docs/founder-kernel ./docs/founder-kernel
+COPY --from=init /app/docs/professions ./docs/professions
 COPY --from=init /app/prompts ./prompts
 COPY --from=init /app/skills ./skills
 # Deliberation pattern sources must reach the runtime image too — the seed
@@ -162,7 +163,7 @@ COPY version.json ./version.json
 # Decoupling it from DPF_VERSION is the fix for BI-C8E90A79 — a stamped label
 # can no longer mask which source was built. Exclusions keep it reproducible
 # across builds of the same source (node_modules / .next / generated / tsbuildinfo).
-RUN (find /app/apps/web-src /app/packages-src /app/scripts -type f \
+RUN (find /app/apps/web-src /app/packages-src /app/scripts /app/docs/professions -type f \
       -not -path '*/node_modules/*' \
       -not -path '*/.pnpm-store/*' \
       -not -path '*/.next/*' \

--- a/docs/superpowers/plans/2026-06-23-profession-corpus-image-packaging.md
+++ b/docs/superpowers/plans/2026-06-23-profession-corpus-image-packaging.md
@@ -1,0 +1,35 @@
+# Profession Corpus Image Packaging Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure production portal images include the profession registry and corpus markdown that seed the AI Workforce profession profiles and wiki pages.
+
+**Architecture:** Keep `docs/professions/` as the single source of truth. The init/build stages already receive it; the runner stage must also copy it because `portal-init` runs the seed from the unified runner image. `.dockerignore` must re-include the corpus markdown, and a source-local Dockerfile packaging test must fail if either contract regresses.
+
+**Tech Stack:** Dockerfile, `.dockerignore`, Node `node:test`.
+
+---
+
+### Task 1: Pin the Packaging Contract
+
+**Files:**
+- Modify: `scripts/lib/dockerfile-portal-build.test.mjs`
+
+- [x] Add a failing test that requires the runner stage to copy `/app/docs/professions` into `/app/docs/professions`.
+- [x] Add a failing test that requires `.dockerignore` to re-include `docs/professions/**/*.md`.
+- [x] Refresh the stale builder assertion so the targeted Dockerfile test matches the current Next 16 default-builder Dockerfile.
+
+### Task 2: Fix the Image Inputs
+
+**Files:**
+- Modify: `Dockerfile`
+- Modify: `.dockerignore`
+
+- [x] Copy `docs/professions` from the init stage into the runner image next to `docs/founder-kernel`.
+- [x] Re-include profession corpus markdown in `.dockerignore` so the init-stage copy has the wiki pages, not only `registry.json`.
+
+### Task 3: Verify
+
+- [x] Run `node --test scripts/lib/dockerfile-portal-build.test.mjs`.
+- [x] Run targeted profession/seed invariants if the worktree toolchain permits.
+- [ ] Re-run live DB checks after a governed image refresh applies this source fix.

--- a/scripts/lib/dockerfile-portal-build.test.mjs
+++ b/scripts/lib/dockerfile-portal-build.test.mjs
@@ -3,11 +3,25 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
+const dockerignore = readFileSync(new URL("../../.dockerignore", import.meta.url), "utf8");
 
-test("portal image build uses the webpack builder under Docker", () => {
+test("portal image build uses the default Next builder under Docker", () => {
+  assert.match(dockerfile, /pnpm --filter web exec next build/);
+  assert.doesNotMatch(dockerfile, /pnpm --filter web exec next build --webpack/);
+  assert.doesNotMatch(dockerfile, /NEXT_TURBOPACK_USE_WORKER=0/);
+});
+
+test("runner image carries profession corpus seed assets", () => {
   assert.match(
     dockerfile,
-    /pnpm --filter web exec next build --webpack/
+    /COPY --from=init \/app\/docs\/professions \.\/docs\/professions/,
   );
-  assert.doesNotMatch(dockerfile, /NEXT_TURBOPACK_USE_WORKER=0/);
+});
+
+test("docker build context includes profession corpus markdown", () => {
+  assert.match(dockerignore, /!docs\/professions\/\*\*\/\*\.md/);
+});
+
+test("source content hash includes bundled profession corpus assets", () => {
+  assert.match(dockerfile, /find \/app\/apps\/web-src \/app\/packages-src \/app\/scripts \/app\/docs\/professions -type f/);
 });


### PR DESCRIPTION
## Summary
- Copy `docs/professions` into the portal runner image so `portal-init` can seed profession profiles and wiki corpus pages.
- Re-include `docs/professions/**/*.md` in the Docker build context and include profession corpus files in the source-content hash.
- Add a Dockerfile packaging regression test and a durable plan artifact for the seed/image contract.

## Root Cause
The live install had the source-side profession mapping fix, but `portal-init` logged `ENOENT` for `/app/docs/professions/registry.json`; the production runner image did not carry the profession corpus assets, so the seed could not create WSID profession pages/profiles.

## Verification
- `node --test scripts/lib/dockerfile-portal-build.test.mjs` -> 4 passed
- `pnpm --filter @dpf/db exec vitest run src/seed.test.ts` -> 12 passed
- `pnpm --filter web exec vitest run lib/decision-perspective/resolve-profession-profile.test.ts lib/coworker-record/coverage.test.ts lib/coworker-record/roster-filter.test.ts` -> 30 passed
- `pnpm --filter web build` -> exit 0, compiled successfully, TypeScript completed, 125 static pages generated; existing Turbopack Edge-runtime/NFT warnings remain
- `docker build --target runner --progress=plain -t dpf-portal:profession-corpus-packaging-test .` -> exit 0
- `docker run --rm --entrypoint sh dpf-portal:profession-corpus-packaging-test -c "test -f /app/docs/professions/registry.json && find /app/docs/professions -path '*/wiki/*.md' -type f | wc -l"` -> `158`

Work Capsule: `WC-6F1E8024`