### PR TITLE
feat(golden-triangle): Slice 3b foundation — pure outcome-receipt comparison logic (BI-CF28CCF0)

### DIFF
--- a/apps/web/lib/golden-triangle/receipt.test.ts
+++ b/apps/web/lib/golden-triangle/receipt.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { compileGoldenTrianglePolicy } from "@/lib/golden-triangle";
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import { buildGoldenTriangleReceipt } from "./receipt";
+
+const ASSURED: GoldenTrianglePreference = { preset: "assured", qualityWeight: 0.8, costWeight: 0.1, timeWeight: 0.1 };
+const BALANCED: GoldenTrianglePreference = { preset: "balanced", qualityWeight: 0.34, costWeight: 0.33, timeWeight: 0.33 };
+
+function decode(pref: GoldenTrianglePreference) {
+  return compileGoldenTrianglePolicy({ preference: pref, taskClass: "code-gen", authorityScope: { kind: "wwmd" } });
+}
+
+describe("buildGoldenTriangleReceipt", () => {
+  it("matches when the actual model meets the requested frontier tier", () => {
+    const r = buildGoldenTriangleReceipt(ASSURED, decode(ASSURED), {
+      modelId: "claude-opus-4-7-20250514",
+      costUsd: 0.12,
+      latencyMs: 14000,
+    });
+    expect(r.requested.minimumTier).toBe("frontier");
+    expect(r.actual.tier).toBe("frontier");
+    expect(r.matchedRequest).toBe(true);
+    expect(r.summary).toMatch(/matched/);
+    expect(r.summary).toMatch(/\$0\.120/);
+    expect(r.summary).toMatch(/14\.0s/);
+  });
+
+  it("flags a tier downgrade when the actual model is below the requested tier", () => {
+    const r = buildGoldenTriangleReceipt(ASSURED, decode(ASSURED), {
+      modelId: "gpt-4o-mini",
+      costUsd: 0.002,
+      latencyMs: 3000,
+    });
+    expect(r.actual.tier).toBe("adequate");
+    expect(r.matchedRequest).toBe(false);
+    expect(r.deviations.some((d) => d.field === "tier" && d.kind === "downgrade")).toBe(true);
+    expect(r.summary).toMatch(/below the requested tier/);
+  });
+
+  it("distinguishes an infra failover from a posture downgrade", () => {
+    const r = buildGoldenTriangleReceipt(ASSURED, decode(ASSURED), {
+      modelId: "claude-opus-4-7-20250514", // tier still meets frontier
+      costUsd: 0.1,
+      latencyMs: 11000,
+      fallbackOccurred: true,
+    });
+    expect(r.deviations.some((d) => d.field === "tier" && d.kind === "match")).toBe(true);
+    expect(r.deviations.some((d) => d.field === "routing" && d.kind === "downgrade")).toBe(true);
+    expect(r.matchedRequest).toBe(false);
+    expect(r.summary).toMatch(/downgraded by failover/);
+  });
+
+  it("Balanced has no tier requirement, so any healthy run matches", () => {
+    const r = buildGoldenTriangleReceipt(BALANCED, decode(BALANCED), {
+      modelId: "gpt-4o-mini",
+      costUsd: 0.001,
+      latencyMs: 2500,
+    });
+    expect(r.requested.minimumTier).toBeUndefined();
+    expect(r.matchedRequest).toBe(true);
+    expect(r.deviations.some((d) => d.kind === "downgrade")).toBe(false);
+  });
+
+  it("derives the actual tier from the model id and handles missing cost", () => {
+    const r = buildGoldenTriangleReceipt(BALANCED, decode(BALANCED), { modelId: "claude-haiku-4-5-20251001" });
+    expect(r.actual.tier).toBe("strong");
+    expect(r.actual.costUsd).toBeNull();
+    expect(r.summary).toMatch(/cost n\/a/);
+  });
+});

--- a/apps/web/lib/golden-triangle/receipt.ts
+++ b/apps/web/lib/golden-triangle/receipt.ts
@@ -1,0 +1,127 @@
+// EP-GOLDEN-TRIANGLE Slice 3b (BI-CF28CCF0) — pure receipt logic.
+//
+// "See the difference in outcome when adjusted": compare a requested posture
+// (the decoded policy) against what actually ran (route facts already captured
+// in RouteOutcome / telemetry). Pure — no I/O — so it is fully snapshot-testable
+// and reusable by both the capture path and the comparison view. Persistence is
+// migration-free (the receipt rides `DecisionInteraction.outcomePayload`).
+import type { DecodedPolicy, GoldenTrianglePreference, GoldenTrianglePreset } from "@/lib/golden-triangle";
+import { assignTierFromModelId, type QualityTier } from "@/lib/routing/quality-tiers";
+
+const TIER_RANK: Record<QualityTier, number> = { basic: 0, adequate: 1, strong: 2, frontier: 3 };
+
+/** What actually happened on a run — sourced from RouteOutcome / AdapterRunTelemetry. */
+export interface ActualRun {
+  modelId: string;
+  /** Derived from `modelId` when absent. */
+  tier?: QualityTier;
+  costUsd?: number | null;
+  latencyMs?: number | null;
+  /** Preferred provider failed over to a backup (an infra downgrade, not a posture choice). */
+  fallbackOccurred?: boolean;
+  verificationPassed?: boolean | null;
+  accepted?: boolean | null;
+}
+
+export type DeviationKind = "match" | "downgrade" | "info";
+
+export interface Deviation {
+  field: string;
+  requested: string;
+  actual: string;
+  kind: DeviationKind;
+}
+
+export interface GoldenTriangleReceipt {
+  preset: GoldenTrianglePreset;
+  requested: {
+    minimumTier?: QualityTier;
+    effort?: string;
+    budgetClass?: string;
+    verificationDepth?: string;
+  };
+  actual: {
+    modelId: string;
+    tier: QualityTier;
+    costUsd: number | null;
+    latencyMs: number | null;
+    fallbackOccurred: boolean;
+    verificationPassed: boolean | null;
+    accepted: boolean | null;
+  };
+  deviations: Deviation[];
+  /** True when nothing the user asked for was downgraded. */
+  matchedRequest: boolean;
+  /** Plain-language one-liner for the receipt row / decode panel. */
+  summary: string;
+}
+
+function fmtCost(c: number | null): string {
+  return c === null ? "cost n/a" : `$${c < 0.01 ? c.toFixed(4) : c.toFixed(3)}`;
+}
+
+function fmtLatency(ms: number | null): string {
+  return ms === null ? "" : `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function buildGoldenTriangleReceipt(
+  preference: GoldenTrianglePreference,
+  decoded: DecodedPolicy,
+  actual: ActualRun,
+): GoldenTriangleReceipt {
+  const po = decoded.postureOverride;
+  const ob = decoded.orchestrationBudget;
+  const actualTier = actual.tier ?? assignTierFromModelId(actual.modelId);
+  const costUsd = actual.costUsd ?? null;
+  const latencyMs = actual.latencyMs ?? null;
+  const fallbackOccurred = actual.fallbackOccurred ?? false;
+  const verificationPassed = actual.verificationPassed ?? null;
+  const accepted = actual.accepted ?? null;
+
+  const deviations: Deviation[] = [];
+
+  if (po.minimumTier) {
+    const met = TIER_RANK[actualTier] >= TIER_RANK[po.minimumTier];
+    deviations.push({
+      field: "tier",
+      requested: po.minimumTier,
+      actual: actualTier,
+      kind: met ? "match" : "downgrade",
+    });
+  }
+  if (fallbackOccurred) {
+    deviations.push({ field: "routing", requested: "preferred route", actual: "backup (failover)", kind: "downgrade" });
+  }
+  if (verificationPassed === false) {
+    deviations.push({ field: "verification", requested: ob.verificationDepth ?? "—", actual: "failed", kind: "info" });
+  }
+
+  const matchedRequest = !deviations.some((d) => d.kind === "downgrade");
+
+  const reqParts: string[] = [];
+  if (po.minimumTier) reqParts.push(`${po.minimumTier} tier`);
+  if (po.effort) reqParts.push(`${po.effort} effort`);
+  const presetLabel = preference.preset.charAt(0).toUpperCase() + preference.preset.slice(1);
+  const reqStr = reqParts.length ? `${presetLabel} (${reqParts.join(", ")})` : presetLabel;
+  const costLat = [fmtCost(costUsd), fmtLatency(latencyMs)].filter(Boolean).join(", ");
+  const verdict = matchedRequest
+    ? `ran on ${actual.modelId} (${actualTier} tier) — matched`
+    : fallbackOccurred
+      ? `ran on ${actual.modelId} (${actualTier} tier) — downgraded by failover`
+      : `ran on ${actual.modelId} (${actualTier} tier) — below the requested tier`;
+  const summary = `${reqStr}: ${verdict}. ${costLat}.`;
+
+  return {
+    preset: preference.preset,
+    requested: {
+      ...(po.minimumTier ? { minimumTier: po.minimumTier } : {}),
+      ...(po.effort ? { effort: po.effort } : {}),
+      ...(po.budgetClass ? { budgetClass: po.budgetClass } : {}),
+      ...(ob.verificationDepth ? { verificationDepth: ob.verificationDepth } : {}),
+    },
+    actual: { modelId: actual.modelId, tier: actualTier, costUsd, latencyMs, fallbackOccurred, verificationPassed, accepted },
+    deviations,
+    matchedRequest,
+    summary,
+  };
+}


### PR DESCRIPTION
**Slice 3b foundation** (`BI-CF28CCF0`) — the pure core of "see the difference in outcome when adjusted."

`buildGoldenTriangleReceipt(preference, decodedPolicy, actualRun)` ([receipt.ts](apps/web/lib/golden-triangle/receipt.ts)) compares the **requested** posture against **what actually ran** (model → tier, cost, latency, fallback): it flags tier downgrades, **distinguishes an infra failover from a posture downgrade**, and emits a plain-language summary ("Assured (frontier tier): ran on claude-opus (frontier) — matched. $0.120, 14.0s").

Pure, no I/O, **5 tests** (matched / tier-downgrade / failover-distinct / no-requirement / missing-cost). This is the reusable core for the receipt **store** (records into `DecisionInteraction.outcomePayload`, migration-free) + the **comparison view** + the capture wiring — which land next. **No behaviour change to routing.**

Process-Spine-Decision: implements doc-specced receipts (design §8/§10); pure additive logic, no contract surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
