### PR TITLE
feat(golden-triangle): Slice 3b — receipt store + read-only Outcomes view (BI-CF28CCF0)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/priority/outcomes/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/priority/outcomes/page.tsx
@@ -1,0 +1,25 @@
+// apps/web/app/(shell)/platform/ai/priority/outcomes/page.tsx
+// EP-GOLDEN-TRIANGLE Slice 3b — the "see the difference in outcome" surface.
+// Reads recent Golden Triangle receipts (fail-open) and shows, in plain language,
+// what each run actually did versus what the saved priority asked for.
+import { GoldenTriangleOutcomes } from "@/components/golden-triangle/GoldenTriangleOutcomes";
+import { listGoldenTriangleReceipts } from "@/lib/golden-triangle/receipt-store";
+
+export const dynamic = "force-dynamic";
+
+export default async function GoldenTriangleOutcomesPage() {
+  const receipts = await listGoldenTriangleReceipts(25);
+  return (
+    <div>
+      <div style={{ marginBottom: 16 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>Priority — Outcomes</h1>
+        <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2 }}>
+          What actually ran versus what each saved priority asked for. A green &ldquo;Matched&rdquo; means the platform
+          delivered the tier, effort, and verification you chose; &ldquo;Deviated&rdquo; flags a downgrade — and tells
+          you whether it was a posture trade-off or an infrastructure failover.
+        </p>
+      </div>
+      <GoldenTriangleOutcomes receipts={receipts} />
+    </div>
+  );
+}

--- a/apps/web/components/golden-triangle/GoldenTriangleOutcomes.test.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleOutcomes.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import "./test-setup";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { StoredReceipt } from "@/lib/golden-triangle/receipt-store";
+
+import { GoldenTriangleOutcomes } from "./GoldenTriangleOutcomes";
+
+function stored(overrides: Partial<StoredReceipt["receipt"]> = {}, top: Partial<StoredReceipt> = {}): StoredReceipt {
+  return {
+    interactionId: top.interactionId ?? "i1",
+    routeContext: top.routeContext ?? "build-studio",
+    at: top.at ?? "2026-06-22T10:00:00.000Z",
+    receipt: {
+      preset: "assured",
+      requested: { minimumTier: "frontier" },
+      actual: { modelId: "claude-opus-4-7", tier: "frontier", costUsd: 0.12, latencyMs: 14000, fallbackOccurred: false, verificationPassed: null, accepted: null },
+      deviations: [],
+      matchedRequest: true,
+      summary: "Assured (frontier tier): ran on claude-opus-4-7 (frontier tier) — matched. $0.120, 14.0s.",
+      ...overrides,
+    },
+  };
+}
+
+describe("GoldenTriangleOutcomes", () => {
+  it("shows an honest empty state when there are no receipts", () => {
+    render(<GoldenTriangleOutcomes receipts={[]} />);
+    expect(screen.getByText(/No outcome receipts yet/)).toBeTruthy();
+  });
+
+  it("renders a matched receipt with its summary and surface", () => {
+    render(<GoldenTriangleOutcomes receipts={[stored()]} />);
+    expect(screen.getByText("Matched")).toBeTruthy();
+    expect(screen.getByText(/ran on claude-opus-4-7/)).toBeTruthy();
+    expect(screen.getByText(/surface: build-studio/)).toBeTruthy();
+  });
+
+  it("labels a downgraded run as Deviated", () => {
+    const r = stored({ matchedRequest: false, summary: "Assured (frontier tier): ran on gpt-4o-mini (adequate tier) — below the requested tier. $0.002, 3.0s." }, { interactionId: "i2" });
+    render(<GoldenTriangleOutcomes receipts={[r]} />);
+    expect(screen.getByText("Deviated")).toBeTruthy();
+  });
+});

--- a/apps/web/components/golden-triangle/GoldenTriangleOutcomes.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleOutcomes.tsx
@@ -1,0 +1,89 @@
+// EP-GOLDEN-TRIANGLE Slice 3b — read-only "see the difference in outcome" view.
+// Presentational only (no hooks / no I/O): renders stored receipts so it is
+// trivially testable and safe in either a server or client tree. Data is fed by
+// the server wrapper via listGoldenTriangleReceipts().
+import type { StoredReceipt } from "@/lib/golden-triangle/receipt-store";
+
+function tone(matched: boolean): { token: string; label: string } {
+  return matched ? { token: "--dpf-success", label: "Matched" } : { token: "--dpf-warning", label: "Deviated" };
+}
+
+function reqLine(r: StoredReceipt["receipt"]): string {
+  const parts: string[] = [];
+  if (r.requested.minimumTier) parts.push(`${r.requested.minimumTier} tier`);
+  if (r.requested.effort) parts.push(`${r.requested.effort} effort`);
+  if (r.requested.verificationDepth) parts.push(`${r.requested.verificationDepth} verify`);
+  return parts.length ? parts.join(" · ") : "no hard floor";
+}
+
+function presetLabel(p: string): string {
+  return p.charAt(0).toUpperCase() + p.slice(1);
+}
+
+function EmptyState() {
+  return (
+    <div
+      style={{
+        border: "1px dashed var(--dpf-border)",
+        borderRadius: 10,
+        padding: "18px 16px",
+        color: "var(--dpf-muted)",
+        fontSize: 12,
+        lineHeight: 1.5,
+      }}
+    >
+      <strong style={{ color: "var(--dpf-text)", fontSize: 13 }}>No outcome receipts yet.</strong>
+      <p style={{ margin: "6px 0 0" }}>
+        Once AI work runs under a saved priority, each run records a receipt here — what you asked for (model tier,
+        effort, verification) versus what actually ran, with cost, time, and any failover. Adjust the triangle above and
+        the difference shows up in this list.
+      </p>
+    </div>
+  );
+}
+
+export function GoldenTriangleOutcomes({ receipts }: { receipts: StoredReceipt[] }) {
+  if (!receipts.length) return <EmptyState />;
+  return (
+    <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 8 }}>
+      {receipts.map((row) => {
+        const r = row.receipt;
+        const t = tone(r.matchedRequest);
+        return (
+          <li
+            key={row.interactionId}
+            style={{
+              border: "1px solid var(--dpf-border)",
+              borderLeft: `3px solid var(${t.token})`,
+              borderRadius: 10,
+              padding: "10px 12px",
+              background: "var(--dpf-surface)",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12 }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--dpf-text)" }}>
+                {presetLabel(r.preset)}
+                <span style={{ fontWeight: 400, color: "var(--dpf-muted)" }}> · {reqLine(r)}</span>
+              </span>
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: `var(${t.token})`,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {t.label}
+              </span>
+            </div>
+            <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--dpf-text)" }}>{r.summary}</p>
+            <div style={{ marginTop: 4, fontSize: 11, color: "var(--dpf-muted)", display: "flex", gap: 10, flexWrap: "wrap" }}>
+              {row.routeContext ? <span>surface: {row.routeContext}</span> : null}
+              <span>{new Date(row.at).toLocaleString()}</span>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 506,
+  "routeCount": 507,
   "routes": [
     {
       "routePath": "/",
@@ -4556,6 +4556,18 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/platform/ai/priority/page.tsx"
+    },
+    {
+      "routePath": "/platform/ai/priority/outcomes",
+      "kind": "page",
+      "segments": [
+        "platform",
+        "ai",
+        "priority",
+        "outcomes"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/platform/ai/priority/outcomes/page.tsx"
     },
     {
       "routePath": "/platform/ai/prompts",

--- a/apps/web/lib/golden-triangle/receipt-store.test.ts
+++ b/apps/web/lib/golden-triangle/receipt-store.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTriangleReceipt } from "./receipt";
+import { listGoldenTriangleReceipts, recordGoldenTriangleReceipt, type ReceiptStoreClient } from "./receipt-store";
+
+function receipt(tag: string): GoldenTriangleReceipt {
+  return {
+    preset: "assured",
+    requested: { minimumTier: "frontier" },
+    actual: { modelId: tag, tier: "frontier", costUsd: 0.1, latencyMs: 1000, fallbackOccurred: false, verificationPassed: null, accepted: null },
+    deviations: [],
+    matchedRequest: true,
+    summary: `summary-${tag}`,
+  };
+}
+
+type Row = { interactionId: string; outcomePayload: unknown; createdAt: Date; routeContext: string | null };
+
+function fakeClient(rows: Row[]): ReceiptStoreClient {
+  return {
+    decisionInteraction: {
+      findUnique: async ({ where }) => {
+        const r = rows.find((x) => x.interactionId === where.interactionId);
+        return r ? { outcomePayload: r.outcomePayload } : null;
+      },
+      updateMany: async ({ where, data }) => {
+        const r = rows.find((x) => x.interactionId === where.interactionId);
+        if (!r) return { count: 0 };
+        r.outcomePayload = data.outcomePayload;
+        return { count: 1 };
+      },
+      findMany: async ({ take }) => rows.slice(0, take).map((r) => ({ ...r })),
+    },
+  };
+}
+
+describe("recordGoldenTriangleReceipt", () => {
+  it("merges the receipt onto outcomePayload, preserving other keys", async () => {
+    const rows: Row[] = [{ interactionId: "i1", outcomePayload: { existing: 7 }, createdAt: new Date(), routeContext: null }];
+    const ok = await recordGoldenTriangleReceipt("i1", receipt("opus"), fakeClient(rows));
+    expect(ok).toBe(true);
+    const payload = rows[0].outcomePayload as Record<string, unknown>;
+    expect(payload.existing).toBe(7);
+    expect((payload.goldenTriangleReceipt as GoldenTriangleReceipt).summary).toBe("summary-opus");
+  });
+
+  it("returns false when the interaction does not exist", async () => {
+    expect(await recordGoldenTriangleReceipt("nope", receipt("x"), fakeClient([]))).toBe(false);
+  });
+
+  it("is fail-open when the client throws", async () => {
+    const throwing: ReceiptStoreClient = {
+      decisionInteraction: {
+        findUnique: async () => {
+          throw new Error("db down");
+        },
+        updateMany: async () => ({ count: 0 }),
+        findMany: async () => [],
+      },
+    };
+    expect(await recordGoldenTriangleReceipt("i1", receipt("x"), throwing)).toBe(false);
+  });
+});
+
+describe("listGoldenTriangleReceipts", () => {
+  it("returns only rows carrying a receipt, newest first, capped at the limit", async () => {
+    const rows: Row[] = [
+      { interactionId: "a", outcomePayload: { goldenTriangleReceipt: receipt("a") }, createdAt: new Date(3000), routeContext: "build-studio" },
+      { interactionId: "b", outcomePayload: { other: 1 }, createdAt: new Date(2000), routeContext: null },
+      { interactionId: "c", outcomePayload: { goldenTriangleReceipt: receipt("c") }, createdAt: new Date(1000), routeContext: "marketing" },
+    ];
+    const out = await listGoldenTriangleReceipts(2, fakeClient(rows));
+    expect(out.map((r) => r.interactionId)).toEqual(["a", "c"]);
+    expect(out[0].routeContext).toBe("build-studio");
+    expect(out[0].receipt.summary).toBe("summary-a");
+    expect(typeof out[0].at).toBe("string");
+  });
+
+  it("is fail-open, returning [] when the client throws", async () => {
+    const throwing: ReceiptStoreClient = {
+      decisionInteraction: {
+        findUnique: async () => null,
+        updateMany: async () => ({ count: 0 }),
+        findMany: async () => {
+          throw new Error("db down");
+        },
+      },
+    };
+    expect(await listGoldenTriangleReceipts(10, throwing)).toEqual([]);
+  });
+});

--- a/apps/web/lib/golden-triangle/receipt-store.ts
+++ b/apps/web/lib/golden-triangle/receipt-store.ts
@@ -1,0 +1,101 @@
+// EP-GOLDEN-TRIANGLE Slice 3b (BI-CF28CCF0) — additive, migration-free receipt store.
+//
+// Records a Golden Triangle outcome receipt onto the existing
+// DecisionInteraction.outcomePayload JSON (no schema change), and reads recent
+// receipts for the comparison view. Structural client + fail-open so a missing
+// DB or shape drift never breaks the caller — this is observability, never a gate.
+import { prisma } from "@dpf/db";
+
+import type { GoldenTriangleReceipt } from "./receipt";
+
+const RECEIPT_KEY = "goldenTriangleReceipt";
+
+/** Minimal structural shape of the prisma surface we touch — lets tests inject a fake. */
+export interface ReceiptStoreClient {
+  decisionInteraction: {
+    findUnique: (args: {
+      where: { interactionId: string };
+      select: { outcomePayload: true };
+    }) => Promise<{ outcomePayload: unknown } | null>;
+    updateMany: (args: {
+      where: { interactionId: string };
+      data: { outcomePayload: unknown };
+    }) => Promise<{ count: number }>;
+    findMany: (args: {
+      orderBy: { createdAt: "desc" };
+      take: number;
+      select: { interactionId: true; outcomePayload: true; createdAt: true; routeContext: true };
+    }) => Promise<Array<{ interactionId: string; outcomePayload: unknown; createdAt: Date; routeContext: string | null }>>;
+  };
+}
+
+export interface StoredReceipt {
+  interactionId: string;
+  routeContext: string | null;
+  at: string; // ISO timestamp
+  receipt: GoldenTriangleReceipt;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+function defaultClient(db?: ReceiptStoreClient): ReceiptStoreClient {
+  return db ?? (prisma as unknown as ReceiptStoreClient);
+}
+
+/**
+ * Merge a receipt onto an existing DecisionInteraction's outcomePayload.
+ * Additive (preserves every other key) and fail-open (returns false on any error).
+ */
+export async function recordGoldenTriangleReceipt(
+  interactionId: string,
+  receipt: GoldenTriangleReceipt,
+  db?: ReceiptStoreClient,
+): Promise<boolean> {
+  const client = defaultClient(db);
+  try {
+    const existing = await client.decisionInteraction.findUnique({
+      where: { interactionId },
+      select: { outcomePayload: true },
+    });
+    if (!existing) return false;
+    const merged = { ...asRecord(existing.outcomePayload), [RECEIPT_KEY]: receipt };
+    const res = await client.decisionInteraction.updateMany({
+      where: { interactionId },
+      data: { outcomePayload: merged },
+    });
+    return res.count > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Read recent stored receipts for the comparison view. Fail-open: returns [] on error. */
+export async function listGoldenTriangleReceipts(limit = 25, db?: ReceiptStoreClient): Promise<StoredReceipt[]> {
+  const client = defaultClient(db);
+  const cap = Math.max(1, Math.min(200, limit));
+  try {
+    const rows = await client.decisionInteraction.findMany({
+      orderBy: { createdAt: "desc" },
+      // Overscan: most interactions carry no GT receipt, so fetch a wider window then filter.
+      take: cap * 4,
+      select: { interactionId: true, outcomePayload: true, createdAt: true, routeContext: true },
+    });
+    const out: StoredReceipt[] = [];
+    for (const row of rows) {
+      const raw = asRecord(row.outcomePayload)[RECEIPT_KEY];
+      if (!raw || typeof raw !== "object") continue;
+      out.push({
+        interactionId: row.interactionId,
+        routeContext: row.routeContext,
+        at: row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt),
+        receipt: raw as GoldenTriangleReceipt,
+      });
+      if (out.length >= cap) break;
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/docs/design/golden-triangle-design.md
+++ b/docs/design/golden-triangle-design.md
@@ -2,7 +2,7 @@
 
 **Cost | Quality | Time as a governed preference-to-policy compiler for trusted AI agents**
 
-*Design review draft v0.3.3 - 2026-06-22*
+*Design review draft v0.3.4 - 2026-06-22*
 
 > **v0.3 changelog.** Integrates a multi-thread review (UX/accessibility, ethos/culture fit, strategy/completeness) plus a competitive-benchmarking pass. Headline changes: **presets are the primary control** (the triangle becomes a fine-tune visualization); a corrected **2-degrees-of-freedom accessibility contract** (a 2D control is not the WAI-ARIA *slider* pattern); the triangle is framed as **cognitive-load migration** and connected to the **kernel principle system**; and three factual corrections to the v0.2 control-layers analysis — the `effort` lever already exists end-to-end, perspective/review count's home is the **deliberation engine**, and `MAX_ITERATIONS` is a *safety ceiling*, not the dominant cost lever. Adds cold-start defaults, the composition point with `inferContract()`, and success metrics.
 >
@@ -11,6 +11,8 @@
 > **v0.3.2 Slice 0 close-out.** Folds the Slice 0 substrate-audit findings (companion doc [`golden-triangle-slice0-substrate-audit.md`](golden-triangle-slice0-substrate-audit.md)): the saved-defaults home already exists (`DecisionInteraction.profileId` → `DecisionPerspectiveProfile`, **extend it** — resolves Open Decision 1); the orchestration budget is **GO** as JSON on the receipt path (not `AgentModelConfig`, not a new table — resolves Open Decision 7); plus two corrections — `TaskRequirement.minimumTier` is code-side (`BUILT_IN_TASK_REQUIREMENTS`), not a DB column, and `verificationDepth` is inert until a verify step is wired.
 >
 > **v0.3.3 implementation underway.** Shipped: Slice 1 (pure compiler), Slice 3a (posture → `inferContract()` composition + additive caller overrides), and Slice 2 (the elegant posture control + `/platform/ai/priority` page). UX refinements: the control is surfaced in the **AI coworker dialog** as a compact, balance-coloured chip (`CoworkerPriorityControl`), and the triangle is **colour-coded by balance** — green when centred, yellow→red as one or two axes get starved, with the starved axis's vertex reddened. Remaining: receipts / outcome-diff (Slice 3b) and per-scope persistence (Slice 4) — both can be **migration-free** in v1 via the existing `DecisionInteraction.outcomePayload` and `DecisionPerspectiveProfile.autonomyPolicy` JSON fields (no schema change), which also sidesteps the no-`datasource.url`-in-worktree migration constraint.
+
+> **v0.3.4 Slice 3b + 4 land (data + view).** Slice 3b ships the **outcome receipt**: a pure comparator (`buildGoldenTriangleReceipt`) that diffs the requested posture against what actually ran — flagging tier downgrades and, crucially, **distinguishing an infrastructure failover from a posture trade-off** — plus a **migration-free store** (rides `DecisionInteraction.outcomePayload`, structural-client + fail-open) and a read-only **Outcomes view** (`/platform/ai/priority/outcomes`) with an honest empty state. Slice 4 ships per-scope persistence (`getGoldenTrianglePosture`/`setGoldenTrianglePosture` on `DecisionPerspectiveProfile.autonomyPolicy.goldenTriangle`, `view_platform`-gated save). The one remaining piece is the **hot-path capture wiring** that records a receipt against each live run — a supervised step requiring a runtime DB, flagged rather than shipped blind.
 
 ---
 


### PR DESCRIPTION
**Slice 3b — the user-visible half** (`BI-CF28CCF0`), building on the receipt comparator merged in #2304.

- **Migration-free store** ([receipt-store.ts](apps/web/lib/golden-triangle/receipt-store.ts)) — `recordGoldenTriangleReceipt` / `listGoldenTriangleReceipts` ride the existing `DecisionInteraction.outcomePayload` JSON (no schema change). Structural client + **fail-open** (a settings read/write never throws into a render). 5 tests.
- **Read-only Outcomes view** ([GoldenTriangleOutcomes.tsx](apps/web/components/golden-triangle/GoldenTriangleOutcomes.tsx)) at **`/platform/ai/priority/outcomes`** — renders requested-vs-actual per run with balance-coloured **Matched / Deviated** tones and an honest empty state. 3 tests.
- Design doc → **v0.3.4** documenting the Slice 3b/4 landing.

This is the **"see the difference in outcome when adjusted"** surface Mark asked for. The one remaining piece — the **live hot-path capture** that writes a receipt per real run — is a supervised, runtime-DB step (flagged in the doc), not shipped blind. **No routing behaviour change.** 65 golden-triangle tests green.

Process-Spine-Decision: doc-specced (design v0.3.4 §8/§10 + implementation plan); additive store + read-only view.
UX-Fit-Decision: read-only outcome view, progressive disclosure — a separate `/priority/outcomes` surface keeps the set-posture screen uncluttered; Matched/Deviated reuse the established balance palette (success/warning tokens) and the receipt's own plain-language summary; honest empty state explains what will appear. Decided on merits (the gate's `human_cognitive_load` axis has no kernel-principle scorer — known degenerate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
