### PR TITLE
feat(assurance): P2 WWMD-gated remediation merge decision engine + orchestration (BI-204EE70B)

### DIFF
--- a/apps/web/lib/assurance/remediation-merge-gate.test.ts
+++ b/apps/web/lib/assurance/remediation-merge-gate.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyDepChange,
+  decideRemediationMerge,
+  type RemediationMergeFacts,
+} from "./remediation-merge-gate";
+
+describe("classifyDepChange", () => {
+  it("classifies patch / minor / major forward bumps", () => {
+    expect(classifyDepChange("4.12.19", "4.12.25")).toBe("patch");
+    expect(classifyDepChange("7.5.8", "7.6.4")).toBe("minor");
+    expect(classifyDepChange("8.3.0", "9.0.1")).toBe("major");
+  });
+
+  it("tolerates range prefixes on either side", () => {
+    expect(classifyDepChange("^4.12.19", "4.12.25")).toBe("patch");
+    expect(classifyDepChange("4.12.19", ">=4.13.0")).toBe("minor");
+  });
+
+  it("returns unknown for equal, downgrade, or unparseable versions", () => {
+    expect(classifyDepChange("1.0.0", "1.0.0")).toBe("unknown");
+    expect(classifyDepChange("2.0.0", "1.0.0")).toBe("unknown");
+    expect(classifyDepChange("latest", "1.0.0")).toBe("unknown");
+    expect(classifyDepChange("1.0.0", "garbage")).toBe("unknown");
+  });
+});
+
+describe("decideRemediationMerge", () => {
+  const green: RemediationMergeFacts = {
+    changeClass: "patch",
+    ciGreen: true,
+    cooldownMet: true,
+    osvClean: true,
+    hasConflict: false,
+  };
+
+  it("auto-merges a patch bump when all preconditions pass", () => {
+    expect(decideRemediationMerge(green)).toEqual({
+      action: "auto-merge",
+      reason: expect.stringContaining("patch"),
+    });
+  });
+
+  it("escalates minor and major bumps even when green", () => {
+    expect(decideRemediationMerge({ ...green, changeClass: "minor" }).action).toBe("escalate");
+    expect(decideRemediationMerge({ ...green, changeClass: "major" }).action).toBe("escalate");
+  });
+
+  it("escalates an unclassifiable change (uncertainty)", () => {
+    const d = decideRemediationMerge({ ...green, changeClass: "unknown" });
+    expect(d.action).toBe("escalate");
+    expect(d.reason).toContain("uncertain");
+  });
+
+  it("escalates on any failed precondition, even for a patch", () => {
+    expect(decideRemediationMerge({ ...green, ciGreen: false }).reason).toContain("ci-not-green");
+    expect(decideRemediationMerge({ ...green, osvClean: false }).reason).toContain("osv-target-not-clean");
+    expect(decideRemediationMerge({ ...green, cooldownMet: false }).reason).toContain("cooldown-not-met");
+    expect(decideRemediationMerge({ ...green, hasConflict: true }).reason).toContain("merge-conflict");
+  });
+
+  it("checks merge-conflict before anything else", () => {
+    const d = decideRemediationMerge({
+      changeClass: "patch",
+      ciGreen: false,
+      cooldownMet: false,
+      osvClean: false,
+      hasConflict: true,
+    });
+    expect(d.reason).toContain("merge-conflict");
+  });
+});

--- a/apps/web/lib/assurance/remediation-merge-gate.ts
+++ b/apps/web/lib/assurance/remediation-merge-gate.ts
@@ -1,0 +1,91 @@
+// apps/web/lib/assurance/remediation-merge-gate.ts
+//
+// P2 of the assurance remediation loop (BI-204EE70B): the WWMD-gated decision for
+// whether a Build-Studio-produced remediation PR may merge AUTONOMOUSLY, or must
+// escalate to the human responder.
+//
+// Founder-kernel ruling (principle_decide 2026-06-22, surface
+// "assurance-remediation-merge-gate"): PATCH-ONLY-AUTO (composite 6.27, margin
+// 0.41, high confidence, no commandment conflict) — auto-merge only patch bumps
+// when every hard precondition passes; escalate every minor/major and anything
+// uncertain. This is the supply-chain-careful far end of the loop.
+//
+// This module is PURE: the semver classifier + the decision policy. The live
+// GitHub actuation (read PR checks, read the diff, arm auto-merge) lives behind
+// injectable adapters in the orchestration so this gate stays fully unit-testable
+// and free of irreversible side effects.
+
+export type DepChangeClass = "patch" | "minor" | "major" | "unknown";
+
+type Semver = { major: number; minor: number; patch: number };
+
+/** Strip a range/prefix to a bare x.y.z and parse it; null when not parseable. */
+function parseSemver(raw: string): Semver | null {
+  const m = /(\d+)\.(\d+)\.(\d+)/.exec(raw ?? "");
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+/**
+ * Classify the semver distance of a dependency bump from `from` to `to`. Inputs
+ * may carry range prefixes (e.g. "^4.12.19" → "4.12.25"); the first x.y.z wins.
+ * Returns "unknown" when either side is unparseable or `to` is not strictly
+ * greater than `from` (we never auto-merge a change we cannot positively classify
+ * as a forward patch).
+ */
+export function classifyDepChange(from: string, to: string): DepChangeClass {
+  const a = parseSemver(from);
+  const b = parseSemver(to);
+  if (!a || !b) return "unknown";
+  if (b.major !== a.major) return b.major > a.major ? "major" : "unknown";
+  if (b.minor !== a.minor) return b.minor > a.minor ? "minor" : "unknown";
+  if (b.patch !== a.patch) return b.patch > a.patch ? "patch" : "unknown";
+  return "unknown"; // equal versions — nothing to merge
+}
+
+export type MergeGateAction = "auto-merge" | "escalate";
+
+export interface RemediationMergeFacts {
+  /** Semver class of the dependency bump in the PR. */
+  changeClass: DepChangeClass;
+  /** All required CI checks green on the PR head. */
+  ciGreen: boolean;
+  /** Release-age cooldown observed for the bumped version (hijacked-release guard). */
+  cooldownMet: boolean;
+  /** The OSV target (the version being bumped TO) is clean. */
+  osvClean: boolean;
+  /** The PR has a merge conflict / is not mergeable. */
+  hasConflict: boolean;
+}
+
+export interface MergeGateDecision {
+  action: MergeGateAction;
+  reason: string;
+}
+
+/**
+ * Decide whether a remediation PR may auto-merge. Hard preconditions are checked
+ * first (any failure escalates); then the WWMD class ceiling (patch-only). Anything
+ * unclassifiable escalates — never auto-merge on uncertainty.
+ */
+export function decideRemediationMerge(facts: RemediationMergeFacts): MergeGateDecision {
+  if (facts.hasConflict) {
+    return { action: "escalate", reason: "merge-conflict — PR is not cleanly mergeable" };
+  }
+  if (!facts.ciGreen) {
+    return { action: "escalate", reason: "ci-not-green — required checks have not all passed" };
+  }
+  if (!facts.osvClean) {
+    return { action: "escalate", reason: "osv-target-not-clean — the bumped version still has an advisory" };
+  }
+  if (!facts.cooldownMet) {
+    return { action: "escalate", reason: "cooldown-not-met — bumped release is younger than the release-age cooldown" };
+  }
+  if (facts.changeClass === "patch") {
+    return { action: "auto-merge", reason: "patch bump, all preconditions met (WWMD patch-only-auto)" };
+  }
+  if (facts.changeClass === "minor" || facts.changeClass === "major") {
+    return { action: "escalate", reason: `${facts.changeClass}-bump requires human review (WWMD patch-only-auto ceiling)` };
+  }
+  return { action: "escalate", reason: "unclassified change — cannot confirm a forward patch; escalating on uncertainty" };
+}

--- a/apps/web/lib/assurance/remediation-merge-orchestrator.test.ts
+++ b/apps/web/lib/assurance/remediation-merge-orchestrator.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  runRemediationMergeGate,
+  type MergeGateAdapters,
+  type PrReadiness,
+  type ReadyRemediationPR,
+} from "./remediation-merge-orchestrator";
+
+function pr(overrides: Partial<ReadyRemediationPR> = {}): ReadyRemediationPR {
+  return {
+    buildId: "FB-1",
+    buildPk: "cuid-1",
+    backlogItemId: "BI-1",
+    prNumber: 100,
+    title: "Remediate: hono",
+    fromVersion: "4.12.19",
+    toVersion: "4.12.25",
+    ...overrides,
+  };
+}
+
+const allGreen: PrReadiness = { ciGreen: true, cooldownMet: true, osvClean: true, hasConflict: false };
+
+function adapters(
+  prs: ReadyRemediationPR[],
+  readiness: PrReadiness,
+  actuationEnabled: boolean,
+): MergeGateAdapters & {
+  armAutoMerge: ReturnType<typeof vi.fn>;
+  escalate: ReturnType<typeof vi.fn>;
+} {
+  return {
+    listReadyRemediationPRs: vi.fn(async () => prs),
+    getReadiness: vi.fn(async () => readiness),
+    armAutoMerge: vi.fn(async () => undefined),
+    escalate: vi.fn(async () => undefined),
+    actuationEnabled,
+  };
+}
+
+describe("runRemediationMergeGate", () => {
+  it("does nothing for a zero budget", async () => {
+    const a = adapters([pr()], allGreen, true);
+    const r = await runRemediationMergeGate({ adapters: a, budget: 0 });
+    expect(r.processed).toBe(0);
+    expect(a.listReadyRemediationPRs).not.toHaveBeenCalled();
+  });
+
+  it("arms auto-merge for a green patch when actuation is enabled", async () => {
+    const a = adapters([pr()], allGreen, true);
+    const r = await runRemediationMergeGate({ adapters: a, budget: 5 });
+    expect(r).toMatchObject({ processed: 1, merged: 1, escalated: 0, dryRun: 0 });
+    expect(a.armAutoMerge).toHaveBeenCalledTimes(1);
+    expect(a.escalate).not.toHaveBeenCalled();
+  });
+
+  it("dark-runs (records, does not actuate) when actuation is disabled", async () => {
+    const a = adapters([pr()], allGreen, false);
+    const r = await runRemediationMergeGate({ adapters: a, budget: 5 });
+    expect(r).toMatchObject({ processed: 1, merged: 0, dryRun: 1 });
+    expect(a.armAutoMerge).not.toHaveBeenCalled();
+    expect(r.outcomes[0]?.reason).toContain("dark");
+  });
+
+  it("escalates a minor bump (and still escalates when actuation is off)", async () => {
+    const a = adapters([pr({ toVersion: "4.13.0" })], allGreen, false);
+    const r = await runRemediationMergeGate({ adapters: a, budget: 5 });
+    expect(r).toMatchObject({ escalated: 1, merged: 0, dryRun: 0 });
+    expect(a.escalate).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 100 }), expect.stringContaining("minor"));
+  });
+
+  it("escalates a green patch whose CI is not green", async () => {
+    const a = adapters([pr()], { ...allGreen, ciGreen: false }, true);
+    const r = await runRemediationMergeGate({ adapters: a, budget: 5 });
+    expect(r.escalated).toBe(1);
+    expect(a.armAutoMerge).not.toHaveBeenCalled();
+  });
+
+  it("escalates when the version delta is unknown", async () => {
+    const a = adapters([pr({ fromVersion: null, toVersion: null })], allGreen, true);
+    const r = await runRemediationMergeGate({ adapters: a, budget: 5 });
+    expect(r.escalated).toBe(1);
+  });
+
+  it("caps work at the budget", async () => {
+    const a = adapters([pr({ prNumber: 1 }), pr({ prNumber: 2 }), pr({ prNumber: 3 })], allGreen, true);
+    const r = await runRemediationMergeGate({ adapters: a, budget: 2 });
+    expect(r.processed).toBe(2);
+    expect(a.armAutoMerge).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/assurance/remediation-merge-orchestrator.ts
+++ b/apps/web/lib/assurance/remediation-merge-orchestrator.ts
@@ -1,0 +1,101 @@
+// apps/web/lib/assurance/remediation-merge-orchestrator.ts
+//
+// P2 orchestration: walk the ready assurance-remediation PRs, run each through the
+// WWMD-gated decision (remediation-merge-gate.ts), and either arm auto-merge or
+// escalate to the human responder.
+//
+// The merge actuation is the ONLY irreversible step, so it is behind two seams:
+//   1. injectable adapters (live GitHub I/O is supplied by the caller, never
+//      imported here) → fully unit-testable;
+//   2. `actuationEnabled` (DARK-LAUNCH gate) → when false, an auto-merge decision
+//      is RECORDED but not actuated, so the gate can run and be observed against
+//      real PRs before it is allowed to merge anything autonomously.
+// Escalation always actuates (filing an issue report is safe and the whole point).
+
+import {
+  classifyDepChange,
+  decideRemediationMerge,
+  type DepChangeClass,
+} from "./remediation-merge-gate";
+
+export interface ReadyRemediationPR {
+  buildId: string;
+  buildPk: string;
+  backlogItemId: string;
+  prNumber: number;
+  title: string;
+  /** Old → new dependency version from the PR diff (null when not extractable). */
+  fromVersion: string | null;
+  toVersion: string | null;
+}
+
+export interface PrReadiness {
+  ciGreen: boolean;
+  cooldownMet: boolean;
+  osvClean: boolean;
+  hasConflict: boolean;
+}
+
+export interface MergeGateAdapters {
+  listReadyRemediationPRs: () => Promise<ReadyRemediationPR[]>;
+  getReadiness: (pr: ReadyRemediationPR) => Promise<PrReadiness>;
+  /** Arm GitHub auto-merge on the PR. Only invoked when actuationEnabled. */
+  armAutoMerge: (pr: ReadyRemediationPR) => Promise<void>;
+  /** File a human escalation (e.g. createPlatformIssueReport). Always invoked. */
+  escalate: (pr: ReadyRemediationPR, reason: string) => Promise<void>;
+  /** DARK-LAUNCH gate: when false, auto-merge is decided but not actuated. */
+  actuationEnabled: boolean;
+}
+
+export interface MergeGateOutcome {
+  buildId: string;
+  prNumber: number;
+  decision: "auto-merge" | "escalate";
+  actuated: boolean;
+  reason: string;
+}
+
+export interface RunMergeGateResult {
+  processed: number;
+  merged: number;
+  escalated: number;
+  dryRun: number;
+  outcomes: MergeGateOutcome[];
+}
+
+export async function runRemediationMergeGate(input: {
+  adapters: MergeGateAdapters;
+  budget: number;
+}): Promise<RunMergeGateResult> {
+  const { adapters, budget } = input;
+  const result: RunMergeGateResult = { processed: 0, merged: 0, escalated: 0, dryRun: 0, outcomes: [] };
+  if (budget <= 0) return result;
+
+  const prs = (await adapters.listReadyRemediationPRs()).slice(0, budget);
+  result.processed = prs.length;
+
+  for (const pr of prs) {
+    const readiness = await adapters.getReadiness(pr);
+    const changeClass: DepChangeClass =
+      pr.fromVersion && pr.toVersion ? classifyDepChange(pr.fromVersion, pr.toVersion) : "unknown";
+    const decision = decideRemediationMerge({ changeClass, ...readiness });
+
+    if (decision.action === "auto-merge") {
+      if (adapters.actuationEnabled) {
+        await adapters.armAutoMerge(pr);
+        result.merged += 1;
+        result.outcomes.push({ buildId: pr.buildId, prNumber: pr.prNumber, decision: "auto-merge", actuated: true, reason: decision.reason });
+      } else {
+        result.dryRun += 1;
+        result.outcomes.push({ buildId: pr.buildId, prNumber: pr.prNumber, decision: "auto-merge", actuated: false, reason: `${decision.reason} [dark: actuation disabled]` });
+      }
+      continue;
+    }
+
+    await adapters.escalate(pr, decision.reason);
+    result.escalated += 1;
+    result.outcomes.push({ buildId: pr.buildId, prNumber: pr.prNumber, decision: "escalate", actuated: true, reason: decision.reason });
+  }
+
+  return result;
+}

--- a/apps/web/lib/assurance/remediation-teeup.test.ts
+++ b/apps/web/lib/assurance/remediation-teeup.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_ASSURANCE_REMEDIATION_BUDGET,
+  isAssuranceRemediationWindowOpen,
+  resolveRemediationBudget,
+  runAssuranceRemediationTeeUp,
+  selectAssuranceRemediationCandidates,
+  type RemediationCandidate,
+} from "./remediation-teeup";
+
+function candidate(overrides: Partial<RemediationCandidate> = {}): RemediationCandidate {
+  return {
+    id: "cuid-1",
+    itemId: "BI-1",
+    title: "Remediate: hono X",
+    body: "Severity: HIGH\n\n[origin:assuranceFinding:fk-1]",
+    status: "triaging",
+    proposedOutcome: "build",
+    activeBuildId: null,
+    effortSize: "medium",
+    createdAt: new Date("2026-06-22T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("selectAssuranceRemediationCandidates", () => {
+  it("keeps only triaging, build-proposed, unbuilt, assurance-origin items", () => {
+    const items = [
+      candidate({ itemId: "ok" }),
+      candidate({ itemId: "not-triaging", status: "open" }),
+      candidate({ itemId: "not-build", proposedOutcome: "defer" }),
+      candidate({ itemId: "has-build", activeBuildId: "fb-1" }),
+      candidate({ itemId: "not-assurance", body: "Severity: HIGH\n\nsome other BI" }),
+      candidate({ itemId: "null-body", body: null }),
+    ];
+    const got = selectAssuranceRemediationCandidates(items, 10).map((c) => c.itemId);
+    expect(got).toEqual(["ok"]);
+  });
+
+  it("orders critical before high, then oldest first", () => {
+    const items = [
+      candidate({ itemId: "high-old", body: "Severity: HIGH [origin:assuranceFinding:a]", createdAt: new Date("2026-06-20T00:00:00Z") }),
+      candidate({ itemId: "crit-new", body: "Severity: CRITICAL [origin:assuranceFinding:b]", createdAt: new Date("2026-06-22T00:00:00Z") }),
+      candidate({ itemId: "crit-old", body: "Severity: CRITICAL [origin:assuranceFinding:c]", createdAt: new Date("2026-06-21T00:00:00Z") }),
+    ];
+    expect(selectAssuranceRemediationCandidates(items, 10).map((c) => c.itemId)).toEqual([
+      "crit-old",
+      "crit-new",
+      "high-old",
+    ]);
+  });
+
+  it("caps at the budget", () => {
+    const items = [candidate({ itemId: "a" }), candidate({ itemId: "b" }), candidate({ itemId: "c" })];
+    expect(selectAssuranceRemediationCandidates(items, 2)).toHaveLength(2);
+  });
+
+  it("returns nothing for a zero/negative budget", () => {
+    expect(selectAssuranceRemediationCandidates([candidate()], 0)).toEqual([]);
+    expect(selectAssuranceRemediationCandidates([candidate()], -1)).toEqual([]);
+  });
+});
+
+describe("isAssuranceRemediationWindowOpen", () => {
+  it("is open inside the 02:00–06:00 UTC window", () => {
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T03:00:00Z"))).toBe(true);
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T05:59:00Z"))).toBe(true);
+  });
+
+  it("is closed outside the window", () => {
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T12:00:00Z"))).toBe(false);
+    expect(isAssuranceRemediationWindowOpen(new Date("2026-06-23T06:00:00Z"))).toBe(false);
+  });
+});
+
+describe("resolveRemediationBudget", () => {
+  it("defaults when unset or invalid", () => {
+    expect(resolveRemediationBudget({})).toBe(DEFAULT_ASSURANCE_REMEDIATION_BUDGET);
+    expect(resolveRemediationBudget({ ASSURANCE_REMEDIATION_BUDGET: "abc" })).toBe(DEFAULT_ASSURANCE_REMEDIATION_BUDGET);
+  });
+
+  it("honors a valid env override (including 0)", () => {
+    expect(resolveRemediationBudget({ ASSURANCE_REMEDIATION_BUDGET: "5" })).toBe(5);
+    expect(resolveRemediationBudget({ ASSURANCE_REMEDIATION_BUDGET: "0" })).toBe(0);
+  });
+});
+
+describe("runAssuranceRemediationTeeUp", () => {
+  function prismaWith(items: RemediationCandidate[], governed: boolean) {
+    return {
+      platformDevConfig: { findUnique: vi.fn(async () => ({ governedBacklogEnabled: governed })) },
+      backlogItem: { findMany: vi.fn(async () => items) },
+      $transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
+    };
+  }
+
+  it("does nothing when governed backlog is disabled", async () => {
+    const prisma = prismaWith([candidate()], false);
+    const promote = vi.fn();
+    const result = await runAssuranceRemediationTeeUp({ prisma: prisma as never, userId: "u1", budget: 5, promote });
+    expect(result.enabled).toBe(false);
+    expect(promote).not.toHaveBeenCalled();
+  });
+
+  it("promotes a budgeted batch and returns counts", async () => {
+    const prisma = prismaWith(
+      [candidate({ itemId: "a" }), candidate({ itemId: "b" }), candidate({ itemId: "c" })],
+      true,
+    );
+    let n = 0;
+    const promote = vi.fn(async ({ itemId }: { prisma: unknown; itemId: string; userId: string }) => ({
+      kind: "success" as const,
+      build: { id: `cuid-${++n}`, buildId: `FB-${itemId}` },
+      backlogItemId: itemId,
+      capsuleId: `WC-${itemId}`,
+      autoApprovedDispatchEligible: true,
+    }));
+
+    const result = await runAssuranceRemediationTeeUp({ prisma: prisma as never, userId: "u1", budget: 2, promote });
+
+    expect(result.enabled).toBe(true);
+    expect(result.selectedCount).toBe(2);
+    expect(result.promotedCount).toBe(2);
+    expect(result.builds).toEqual([
+      { backlogItemId: "a", buildId: "FB-a" },
+      { backlogItemId: "b", buildId: "FB-b" },
+    ]);
+    expect(promote).toHaveBeenCalledTimes(2);
+  });
+
+  it("counts promote failures as skipped", async () => {
+    const prisma = prismaWith([candidate({ itemId: "a" })], true);
+    const promote = vi.fn(async () => ({ kind: "error" as const, error: "x", message: "nope" }));
+    const result = await runAssuranceRemediationTeeUp({ prisma: prisma as never, userId: "u1", budget: 5, promote });
+    expect(result.promotedCount).toBe(0);
+    expect(result.skippedCount).toBe(1);
+  });
+});

--- a/apps/web/lib/assurance/remediation-teeup.ts
+++ b/apps/web/lib/assurance/remediation-teeup.ts
@@ -1,0 +1,225 @@
+// apps/web/lib/assurance/remediation-teeup.ts
+//
+// P1 of the assurance remediation loop (BI-7C121CCF): get auto-filed assurance
+// findings WORKED, not just created. The assurance gate (PR #2290) auto-files
+// genuine high/critical findings as backlog items in status=triaging — but the
+// general governed tee-up only promotes status=open + triageOutcome=build items
+// at a fixed 14:00 cron, so the auto-filed BIs sit unworked.
+//
+// This is a DEDICATED off-hours, budget-capped lane that promotes them into
+// Build Studio (which builds the dependency-override bump → PR). NO auto-merge
+// here — that is P2 (WWMD-gated). Founder rails: off-hours/flexible, incremental,
+// budget cap. Reuses promoteBacklogItemToBuildDraft (don't reinvent) + the
+// self-upgrade off-hours window primitives.
+
+import type { MaintenanceWindow } from "@/lib/self-upgrade/config";
+import { isWithinWindows } from "@/lib/self-upgrade/windows-eval";
+import { promoteBacklogItemToBuildDraft } from "@/lib/governed-backlog-tee-up";
+
+/** Body marker the shared backlog front door stamps on assurance-gate auto-files. */
+export const ASSURANCE_ORIGIN_MARKER = "[origin:assuranceFinding:";
+
+// Platform off-hours (UTC). An hourly cron acts only inside this window, so the
+// lane runs "off-hours, flexible, not a single fixed slot" (founder rail). The
+// dispatcher itself is light (DB writes + an event); the builds it triggers are
+// concurrency-capped by the build pipeline, so window overlap with maintenance
+// is acceptable.
+const PLATFORM_OFFHOURS_UTC: MaintenanceWindow = {
+  dayOfWeek: [0, 1, 2, 3, 4, 5, 6],
+  startTime: "02:00",
+  endTime: "06:00",
+};
+
+/** True when `now` is inside the platform off-hours window (evaluated in UTC). */
+export function isAssuranceRemediationWindowOpen(now: Date): boolean {
+  return isWithinWindows([PLATFORM_OFFHOURS_UTC], now, "UTC");
+}
+
+/** Default per-run budget: how many remediations to promote on one tick. */
+export const DEFAULT_ASSURANCE_REMEDIATION_BUDGET = 2;
+
+/** Per-run budget cap (founder rail: budget control). Env-tunable; a richer
+ *  spend-based budget (spend-intelligence) is a later phase. */
+export function resolveRemediationBudget(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.ASSURANCE_REMEDIATION_BUDGET;
+  const n = raw != null && raw !== "" ? Number(raw) : NaN;
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : DEFAULT_ASSURANCE_REMEDIATION_BUDGET;
+}
+
+export interface RemediationCandidate {
+  id: string;
+  itemId: string;
+  title: string;
+  body: string | null;
+  status: string;
+  proposedOutcome: string | null;
+  activeBuildId: string | null;
+  effortSize: string | null;
+  createdAt: Date;
+}
+
+/** Severity rank parsed from the auto-file body ("Severity: HIGH"); lower = first. */
+function severityRank(body: string | null): number {
+  const m = /Severity:\s*(CRITICAL|HIGH|MEDIUM|LOW)/i.exec(body ?? "");
+  switch ((m?.[1] ?? "").toUpperCase()) {
+    case "CRITICAL":
+      return 0;
+    case "HIGH":
+      return 1;
+    case "MEDIUM":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+function isEligible(item: RemediationCandidate): boolean {
+  return (
+    item.status === "triaging" &&
+    item.proposedOutcome === "build" &&
+    item.activeBuildId == null &&
+    typeof item.body === "string" &&
+    item.body.includes(ASSURANCE_ORIGIN_MARKER)
+  );
+}
+
+/**
+ * Rank eligible assurance-remediation candidates (critical first, then oldest,
+ * then id for determinism) and cap at the budget. Pure — the heart of the lane.
+ */
+export function selectAssuranceRemediationCandidates(
+  items: RemediationCandidate[],
+  budget: number,
+): RemediationCandidate[] {
+  if (budget <= 0) return [];
+  return items
+    .filter(isEligible)
+    .sort((a, b) => {
+      const sev = severityRank(a.body) - severityRank(b.body);
+      if (sev !== 0) return sev;
+      const created = a.createdAt.getTime() - b.createdAt.getTime();
+      if (created !== 0) return created;
+      return a.itemId.localeCompare(b.itemId);
+    })
+    .slice(0, budget);
+}
+
+// ── orchestration ───────────────────────────────────────────────────────────
+
+type PromoteResult = Awaited<ReturnType<typeof promoteBacklogItemToBuildDraft>>;
+type PromoteTx = Parameters<typeof promoteBacklogItemToBuildDraft>[0]["tx"];
+
+// `any` args mirror the proven governed-backlog-tee-up.ts prisma shim so the real
+// PrismaClient is assignable when the inngest fn passes it; returns stay typed.
+type RemediationPrisma = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  platformDevConfig: { findUnique(args: any): Promise<{ governedBacklogEnabled: boolean | null } | null> };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  backlogItem: { findMany(args: any): Promise<RemediationCandidate[]> };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  $transaction<T>(cb: (tx: any) => Promise<T>): Promise<T>;
+};
+
+export type PromoteRemediationItem = (args: {
+  prisma: RemediationPrisma;
+  itemId: string;
+  userId: string;
+}) => Promise<PromoteResult>;
+
+// Default promote: set the triaging auto-file BI to open + triageOutcome=build
+// (the governed triage decision for this lane), then reuse the shared promote
+// path — ATOMICALLY, so a promote failure rolls the triage transition back and
+// never leaves an orphaned open+build BI the general 14:00 tee-up could grab.
+const defaultPromote: PromoteRemediationItem = ({ prisma, itemId, userId }) =>
+  prisma.$transaction(async (tx) => {
+    const t = tx as PromoteTx;
+    await t.backlogItem.update({
+      where: { itemId },
+      data: { status: "open", triageOutcome: "build" },
+    });
+    return promoteBacklogItemToBuildDraft({
+      tx: t,
+      itemId,
+      userId,
+      governedBacklogEnabled: true,
+      activity: {
+        tool: "assurance_remediation_tee_up",
+        summary: `Auto-promoted assurance remediation ${itemId} (off-hours lane).`,
+      },
+    });
+  });
+
+export interface RunAssuranceRemediationTeeUpResult {
+  enabled: boolean;
+  selectedCount: number;
+  promotedCount: number;
+  skippedCount: number;
+  builds: Array<{ backlogItemId: string; buildId: string }>;
+}
+
+/**
+ * Select + promote a budgeted batch of auto-filed assurance remediations into
+ * Build Studio. Gated on governedBacklogEnabled (the same opt-in the general
+ * tee-up uses). The caller gates the off-hours window + quiescence.
+ */
+export async function runAssuranceRemediationTeeUp(input: {
+  prisma: RemediationPrisma;
+  userId: string;
+  budget: number;
+  promote?: PromoteRemediationItem;
+}): Promise<RunAssuranceRemediationTeeUpResult> {
+  const { prisma, userId, budget } = input;
+  const promote = input.promote ?? defaultPromote;
+
+  const config = await prisma.platformDevConfig.findUnique({
+    where: { id: "singleton" },
+    select: { governedBacklogEnabled: true },
+  });
+  if (config?.governedBacklogEnabled !== true || budget <= 0) {
+    return { enabled: false, selectedCount: 0, promotedCount: 0, skippedCount: 0, builds: [] };
+  }
+
+  const items = await prisma.backlogItem.findMany({
+    where: {
+      status: "triaging",
+      proposedOutcome: "build",
+      activeBuildId: null,
+      body: { contains: ASSURANCE_ORIGIN_MARKER },
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      itemId: true,
+      title: true,
+      body: true,
+      status: true,
+      proposedOutcome: true,
+      activeBuildId: true,
+      effortSize: true,
+      createdAt: true,
+    },
+  });
+
+  const selected = selectAssuranceRemediationCandidates(items, budget);
+  const builds: Array<{ backlogItemId: string; buildId: string }> = [];
+  let skippedCount = 0;
+
+  for (const item of selected) {
+    const result = await promote({ prisma, itemId: item.itemId, userId });
+    if (result.kind === "success") {
+      builds.push({ backlogItemId: result.backlogItemId, buildId: result.build.buildId });
+    } else {
+      skippedCount += 1;
+    }
+  }
+
+  return {
+    enabled: true,
+    selectedCount: selected.length,
+    promotedCount: builds.length,
+    skippedCount,
+    builds,
+  };
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -279,6 +279,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "assurance-remediation-tee-up",
+    inngestId: "assurance/remediation-tee-up-scheduled",
+    name: "Assurance remediation tee-up",
+    purpose:
+      "Off-hours, budget-capped auto-promotion of genuine high/critical assurance findings into Build Studio remediation builds. If it stops, auto-filed vulnerability BIs sit unworked.",
+    cron: "41 * * * *",
+    cadence: "Hourly at :41 — acts only in the 02:00–06:00 UTC off-hours window",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "material-freshness-decay",
     inngestId: "decision/material-freshness-decay",
     name: "Material freshness decay",

--- a/apps/web/lib/queue/functions/assurance-remediation-teeup.ts
+++ b/apps/web/lib/queue/functions/assurance-remediation-teeup.ts
@@ -1,0 +1,56 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+// Assurance remediation lane P1 (BI-7C121CCF). Hourly poll that, only inside the
+// platform off-hours window, promotes a budgeted batch of auto-filed assurance
+// findings (PR #2290) into Build Studio remediation builds. Founder rails:
+// off-hours/flexible (hourly cron, window-gated — not a fixed slot), incremental
+// + budget-capped (per-run cap), and gated on governedBacklogEnabled. NO
+// auto-merge here — the resulting PRs wait for P2's WWMD-gated merge.
+//
+// Cron is :41 (a free minute) to stay off the shared ticks the contention guard
+// watches (scheduling-map.test.ts).
+export const assuranceRemediationTeeUpScheduled = inngest.createFunction(
+  {
+    id: "assurance/remediation-tee-up-scheduled",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("41 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("assurance-remediation-tee-up", async () => {
+      const { prisma } = await import("@dpf/db");
+      const {
+        runAssuranceRemediationTeeUp,
+        isAssuranceRemediationWindowOpen,
+        resolveRemediationBudget,
+      } = await import("@/lib/assurance/remediation-teeup");
+      const { dispatchApprovedIdeateBuilds } = await import("@/lib/integrate/ideate-on-approval");
+      const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
+
+      const now = new Date();
+      // Off-hours rail: hourly cron, but only act inside the low-traffic window.
+      if (!isAssuranceRemediationWindowOpen(now)) {
+        return { skipped: true, reason: "outside-off-hours-window" };
+      }
+
+      const userId = await resolveScheduledOwnerUserId();
+      const teeUp = await runAssuranceRemediationTeeUp({
+        prisma,
+        userId,
+        budget: resolveRemediationBudget(),
+      });
+
+      // Fire Ideate for the drafts this run auto-approved (mirrors the governed
+      // tee-up) so promoted remediation builds are not dead-on-arrival at ideate.
+      const ideateDispatch =
+        teeUp.promotedCount > 0 ? await dispatchApprovedIdeateBuilds({ userId }) : null;
+
+      return { ...teeUp, ideateDispatch };
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -25,6 +25,7 @@ import {
   governedBacklogTeeUpRequested,
   governedBacklogTeeUpScheduled,
 } from "./governed-backlog-tee-up";
+import { assuranceRemediationTeeUpScheduled } from "./assurance-remediation-teeup";
 import { tokenExpiryMonitor } from "./token-expiry-monitor";
 import {
   contributorInventorySyncCron,
@@ -68,6 +69,7 @@ export const scheduledFunctions = [
   agentTaskDispatch,
   taskrunWatchdog,
   governedBacklogTeeUpScheduled,
+  assuranceRemediationTeeUpScheduled, // BI-7C121CCF: off-hours, budget-capped assurance remediation lane
   tokenExpiryMonitor,
   contributorInventorySyncCron,
   wikiLint,

--- a/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
@@ -35,9 +35,22 @@ selects `status=open` + `triageOutcome=build`) never picks them up.
 - Per item (within budget): set `status=open` + `triageOutcome=build`, then
   `promoteBacklogItemToBuildDraft` → Ideate → BS builds the override bump → PR.
   **No auto-merge here** (awaits P2).
-- General 14:00 tee-up **excludes assurance-origin BIs** so this lane stays
-  off-hours + own-budget.
+- General 14:00 tee-up: no exclusion needed — the triage transition + promote run
+  in ONE transaction (rollback on failure) and `promoteBacklogItemToBuildDraft`
+  sets `activeBuildId`, which the general tee-up's `activeBuildId: null` filter
+  already excludes. So an assurance BI is never visible to the general lane as a
+  bare open+build item.
 - Tests: selector matrix + off-hours gating. Register in the scheduling catalog.
+
+**Implemented (BI-7C121CCF):** `apps/web/lib/assurance/remediation-teeup.ts`
+(`selectAssuranceRemediationCandidates` + `isAssuranceRemediationWindowOpen` +
+`resolveRemediationBudget` + `runAssuranceRemediationTeeUp`) + test;
+`apps/web/lib/queue/functions/assurance-remediation-teeup.ts` (inngest cron
+`assurance/remediation-tee-up-scheduled`, `41 * * * *`, gated to 02:00–06:00 UTC +
+quiescence); registered in `queue/functions/index.ts` + the scheduled-jobs catalog
+(parity test). Budget: per-run cap `ASSURANCE_REMEDIATION_BUDGET` (default 2);
+gated on `governedBacklogEnabled`. A spend-based budget (spend-intelligence) is a
+later refinement.
 
 ## Phase 2 — WWMD-gated autonomous merge + escalate (BI-204EE70B)
 

--- a/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
@@ -61,6 +61,28 @@ commandment conflict / kernel can't resolve) → **escalate to the responder**
 (`escalate-build-to-human`), never auto-merge. Honors the founder's group-only
 Dependabot merge posture as the conservative default until WWMD clears a class.
 
+**WWMD ruling** (principle_decide 2026-06-22, surface `assurance-remediation-merge-gate`):
+**PATCH-ONLY-AUTO** (composite 6.27, margin 0.41, high confidence, no commandment
+conflict) — auto-merge only patch bumps when every precondition passes; escalate
+every minor/major and anything uncertain.
+
+**Implemented — gate + orchestration (BI-204EE70B):**
+`apps/web/lib/assurance/remediation-merge-gate.ts` (`classifyDepChange` semver
+classifier + `decideRemediationMerge` policy: patch-only ceiling + hard
+preconditions [CI green, release-age cooldown, OSV-clean, no conflict] +
+escalate-on-uncertain) + test; `apps/web/lib/assurance/remediation-merge-orchestrator.ts`
+(`runRemediationMergeGate` over injectable adapters, budget-capped, with a
+**dark-launch** `actuationEnabled` gate — an auto-merge is decided-but-not-actuated
+until enabled) + test.
+
+**Staged — live actuation (P2.2, dark-by-default):** the live GitHub adapters
+(read PR checks/mergeability via the existing github-rest reader; classify the bump
+from the PR diff; arm auto-merge) + the off-hours scheduled job + the escalation
+adapter (`createPlatformIssueReport`). Built once P1 has produced a real
+remediation PR to verify against; ships with `actuationEnabled=false` so the gate
+runs observably (escalates + dark-records) before it merges anything autonomously.
+This is the most irreversible step in the loop — it does not blind-launch.
+
 ## Phase 3 — close the loop (BI-4D5C702F)
 
 When a later scan no longer reports a finding, mark previously-open findings


### PR DESCRIPTION
## Why
P2 of the assurance remediation loop — the **supply-chain-careful far end**: decide whether a Build-Studio-produced remediation PR may merge **autonomously** or must **escalate to a human**.

> Stacked on #2301 (P1). Until P1 lands, this PR's diff also shows P1's commit; it narrows to P2-only once P1 merges from the queue.

## Kernel ruling
`principle_decide` (2026-06-22, surface `assurance-remediation-merge-gate`) → **PATCH-ONLY-AUTO** (composite 6.27, margin 0.41, **high** confidence, no commandment conflict): auto-merge only **patch** bumps when every hard precondition passes; **escalate every minor/major** and anything uncertain. Consistent with your group-only-manual Dependabot posture, tightened because these merge autonomously.

## What (this PR — the verified-safe core)
- `remediation-merge-gate.ts` (pure + tested): `classifyDepChange` (semver classifier) + `decideRemediationMerge` — patch-only ceiling + hard preconditions (CI green, release-age cooldown, OSV-clean target, no conflict), **escalate-on-uncertain** (an unclassifiable change never auto-merges).
- `remediation-merge-orchestrator.ts` (pure + tested): `runRemediationMergeGate` over **injectable adapters**, budget-capped, with a **dark-launch `actuationEnabled` gate** — an auto-merge is *decided but not actuated* until explicitly enabled; escalation always actuates.

## Staged for P2.2 (deliberately NOT in this PR)
The live actuation — GitHub adapters (read PR checks via the existing github-rest reader, classify the bump from the diff, **arm auto-merge**), the off-hours scheduled job, and the `createPlatformIssueReport` escalation adapter. This is the only irreversible step in the whole loop, so it **does not blind-launch**: it's built + verified against a real P1-produced remediation PR and ships with **actuation dark-by-default** (runs observably — escalates + dark-records — before it's allowed to merge anything).

## Verification
Unit tests for the classifier, the decision policy (precondition order + class ceiling + uncertainty), and the orchestrator (arm/dark-run/escalate/budget). Worktree has no `node_modules` → CI runs the full suite + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)