### PR TITLE
feat(onboarding): roster import via the Universal Grid — load XLS/CSV → edit → create employees

### DIFF
--- a/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
+++ b/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
@@ -13,6 +13,7 @@ import { WorkbookGrid } from "@/components/workbooks/Grid";
 import { CreateTableButton } from "@/components/workbooks/CreateTableButton";
 import { AddColumnButton } from "@/components/workbooks/AddColumnButton";
 import { ImportSheetButton } from "@/components/workbooks/ImportSheetButton";
+import { CreateEmployeesButton } from "@/components/workbooks/CreateEmployeesButton";
 
 export const dynamic = "force-dynamic";
 
@@ -102,11 +103,16 @@ export default async function WorkbookDetailPage({ params, searchParams }: Props
       ) : (
         <div className="flex min-h-0 flex-1 flex-col gap-3">
           {canManage && activeTableId && (
-            <AddColumnButton
-              workbookId={workbookId}
-              tableId={activeTableId}
-              columns={grid.schema.columns}
-            />
+            <div className="flex flex-wrap items-center gap-2">
+              <AddColumnButton
+                workbookId={workbookId}
+                tableId={activeTableId}
+                columns={grid.schema.columns}
+              />
+              {grid.schema.dataSource === "custom" && (
+                <CreateEmployeesButton tableId={activeTableId} />
+              )}
+            </div>
           )}
           <div className="min-h-0 flex-1">
             <WorkbookGrid

--- a/apps/web/components/admin/RosterImport.tsx
+++ b/apps/web/components/admin/RosterImport.tsx
@@ -1,68 +1,34 @@
 "use client";
 
-import { useRef, useState } from "react";
-import type { ProposedEmployee } from "@/lib/onboarding/roster-import";
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { startTeamSheetImportAction } from "@/lib/actions/workbooks";
 
-// Optional onboarding accelerator (EP-ONBOARDING-INTAKE P4): upload an employee
-// roster CSV, review the proposed people, and create them in one confirm step —
-// "employees entered quickly" instead of one-by-one. Independent of the rest of
-// the form; failure here never blocks setup.
-
-type Preview = { proposed: ProposedEmployee[]; summary: string; truncated: boolean };
-type ImportResult = { created: number; skippedExisting: number; failed: number };
-
-const PREVIEW_LIMIT = 25;
-
+// Optional onboarding accelerator (EP-ONBOARDING-INTAKE P4): upload a team
+// spreadsheet (CSV or Excel) and open it in the in-platform editable grid. The
+// operator fixes anything in the grid, then clicks "Create employees from this
+// sheet" — load → edit → save, reusing the Universal Grid rather than a
+// read-only preview. Failure here never blocks setup.
 export function RosterImport() {
+  const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
-  const [busy, setBusy] = useState(false);
-  const [preview, setPreview] = useState<Preview | null>(null);
-  const [result, setResult] = useState<ImportResult | null>(null);
+  const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
-  async function onFile(file: File) {
+  function onFile(file: File) {
     setError(null);
-    setResult(null);
-    setPreview(null);
-    setBusy(true);
-    try {
-      const body = new FormData();
-      body.append("file", file);
-      const res = await fetch("/api/onboarding/roster", { method: "POST", body });
-      const data = (await res.json().catch(() => ({}))) as Partial<Preview> & { error?: string };
-      if (!res.ok) throw new Error(data.error ?? "Could not read that file");
-      setPreview({ proposed: data.proposed ?? [], summary: data.summary ?? "", truncated: !!data.truncated });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Upload failed");
-    } finally {
-      setBusy(false);
+    const fd = new FormData();
+    fd.append("file", file);
+    startTransition(async () => {
+      const res = await startTeamSheetImportAction(fd);
       if (inputRef.current) inputRef.current.value = "";
-    }
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      router.push(`/workbooks/${res.data.workbookId}?table=${res.data.tableId}`);
+    });
   }
-
-  async function onImport() {
-    if (!preview) return;
-    setError(null);
-    setBusy(true);
-    try {
-      const res = await fetch("/api/onboarding/roster/import", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ confirmed: preview.proposed }),
-      });
-      const data = (await res.json().catch(() => ({}))) as Partial<ImportResult> & { error?: string };
-      if (!res.ok) throw new Error(data.error ?? "Import failed");
-      setResult({ created: data.created ?? 0, skippedExisting: data.skippedExisting ?? 0, failed: data.failed ?? 0 });
-      setPreview(null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Import failed");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  const hint: React.CSSProperties = { fontSize: 11, color: "var(--dpf-muted)", marginTop: 4 };
-  const cell: React.CSSProperties = { padding: "4px 8px", fontSize: 12, color: "var(--dpf-text)", borderBottom: "1px solid var(--dpf-border)", textAlign: "left" };
 
   return (
     <div style={{ fontSize: 13 }}>
@@ -73,85 +39,20 @@ export function RosterImport() {
       <input
         ref={inputRef}
         type="file"
-        accept=".csv,.tsv"
-        disabled={busy}
+        accept=".csv,.tsv,.xlsx"
+        disabled={pending}
         onChange={(e) => {
           const f = e.target.files?.[0];
-          if (f) void onFile(f);
+          if (f) onFile(f);
         }}
         style={{ fontSize: 13, color: "var(--dpf-text)" }}
       />
-      <div style={hint}>
-        Upload a CSV with your people (name, email, title, department, start date). We&apos;ll show you
-        what we found — nothing is created until you confirm.
+      <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 4 }}>
+        Upload a CSV or Excel file of your people. It opens in an editable grid — fix anything that
+        looks off, then click &quot;Create employees from this sheet&quot;. Nothing is created until you do.
       </div>
-
-      {busy && <p style={{ color: "var(--dpf-muted)", fontSize: 12, margin: "6px 0 0" }}>Working…</p>}
+      {pending && <p style={{ color: "var(--dpf-muted)", fontSize: 12, margin: "6px 0 0" }}>Opening the grid…</p>}
       {error && <p style={{ color: "var(--dpf-error)", fontSize: 12, margin: "6px 0 0" }}>{error}</p>}
-
-      {preview && preview.proposed.length > 0 && (
-        <div style={{ marginTop: 10, border: "1px solid var(--dpf-border)", borderRadius: 8, overflow: "hidden", background: "var(--dpf-surface-1)" }}>
-          <div style={{ padding: "8px 10px", fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", borderBottom: "1px solid var(--dpf-border)" }}>
-            {preview.summary}
-            {preview.truncated ? " — showing the first 2000 rows" : ""}
-          </div>
-          <div style={{ maxHeight: 240, overflowY: "auto" }}>
-            <table style={{ width: "100%", borderCollapse: "collapse" }}>
-              <thead>
-                <tr>
-                  <th style={{ ...cell, fontWeight: 600 }}>Name</th>
-                  <th style={{ ...cell, fontWeight: 600 }}>Email</th>
-                  <th style={{ ...cell, fontWeight: 600 }}>Role</th>
-                  <th style={{ ...cell, fontWeight: 600 }}>Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {preview.proposed.slice(0, PREVIEW_LIMIT).map((e) => (
-                  <tr key={e.sourceRow}>
-                    <td style={cell}>{e.displayName}</td>
-                    <td style={cell}>{e.workEmail ?? "—"}</td>
-                    <td style={cell}>{[e.title, e.department].filter(Boolean).join(" · ") || "—"}</td>
-                    <td style={{ ...cell, color: e.issues.length ? "var(--dpf-accent)" : "var(--dpf-muted)" }}>
-                      {e.issues.length ? e.issues.join("; ") : "ok"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            {preview.proposed.length > PREVIEW_LIMIT && (
-              <div style={{ padding: "6px 10px", fontSize: 11, color: "var(--dpf-muted)" }}>
-                …and {preview.proposed.length - PREVIEW_LIMIT} more
-              </div>
-            )}
-          </div>
-          <div style={{ padding: "8px 10px", borderTop: "1px solid var(--dpf-border)", display: "flex", gap: 8, alignItems: "center" }}>
-            <button
-              type="button"
-              onClick={() => void onImport()}
-              disabled={busy}
-              style={{ padding: "6px 16px", borderRadius: 6, border: "none", background: "var(--dpf-accent)", color: "#fff", cursor: busy ? "wait" : "pointer", fontSize: 12, fontWeight: 600, opacity: busy ? 0.7 : 1 }}
-            >
-              Add {preview.proposed.length} {preview.proposed.length === 1 ? "person" : "people"}
-            </button>
-            <button
-              type="button"
-              onClick={() => setPreview(null)}
-              disabled={busy}
-              style={{ padding: "6px 12px", borderRadius: 6, border: "1px solid var(--dpf-border)", background: "var(--dpf-surface-1)", color: "var(--dpf-text)", cursor: "pointer", fontSize: 12 }}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
-
-      {result && (
-        <p style={{ color: "var(--dpf-success)", fontSize: 12, margin: "8px 0 0" }}>
-          Added {result.created} {result.created === 1 ? "person" : "people"}
-          {result.skippedExisting > 0 ? `, skipped ${result.skippedExisting} already on file` : ""}
-          {result.failed > 0 ? `, ${result.failed} could not be added` : ""}.
-        </p>
-      )}
     </div>
   );
 }

--- a/apps/web/components/workbooks/CreateEmployeesButton.tsx
+++ b/apps/web/components/workbooks/CreateEmployeesButton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createEmployeesFromTableAction } from "@/lib/actions/workbooks";
+
+// EP-ONBOARDING-INTAKE P4 (grid convergence): commit the rows of an edited
+// workbook table into EmployeeProfile records. Shown on custom tables so a roster
+// imported + fixed in the grid becomes real employees in one click. The grid edit
+// is the review step; this is the explicit "create" action.
+export function CreateEmployeesButton({ tableId }: { tableId: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const [isError, setIsError] = useState(false);
+
+  function onClick() {
+    setMessage(null);
+    setIsError(false);
+    startTransition(async () => {
+      const res = await createEmployeesFromTableAction(tableId);
+      if (!res.ok) {
+        setIsError(true);
+        setMessage(res.error);
+        return;
+      }
+      const d = res.data;
+      setMessage(
+        `Added ${d.created} ${d.created === 1 ? "person" : "people"}` +
+          (d.skippedExisting ? `, skipped ${d.skippedExisting} already on file` : "") +
+          (d.failed ? `, ${d.failed} could not be added` : "") +
+          ".",
+      );
+      router.refresh();
+    });
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        disabled={pending}
+        onClick={onClick}
+        className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-50"
+      >
+        {pending ? "Creating…" : "Create employees from this sheet"}
+      </button>
+      {message && (
+        <span className={`text-sm ${isError ? "text-[var(--dpf-error)]" : "text-[var(--dpf-muted)]"}`}>
+          {message}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/workbooks/ImportSheetButton.tsx
+++ b/apps/web/components/workbooks/ImportSheetButton.tsx
@@ -4,7 +4,8 @@ import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { importSheetAction } from "@/lib/actions/workbooks";
 
-/** Upload an .xlsx and create a new workbook table from it (columns + rows inferred). */
+/** Upload a spreadsheet (.xlsx or .csv/.tsv) and create a new workbook table from
+ *  it (columns + rows inferred). */
 export function ImportSheetButton({ workbookId }: { workbookId: string }) {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -43,12 +44,12 @@ export function ImportSheetButton({ workbookId }: { workbookId: string }) {
         onClick={() => inputRef.current?.click()}
         className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-50"
       >
-        {pending ? "Importing…" : "Import .xlsx"}
+        {pending ? "Importing…" : "Import sheet"}
       </button>
       <input
         ref={inputRef}
         type="file"
-        accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        accept=".xlsx,.csv,.tsv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
         className="hidden"
         onChange={onFile}
       />

--- a/apps/web/lib/actions/workbooks.ts
+++ b/apps/web/lib/actions/workbooks.ts
@@ -26,6 +26,8 @@ import {
   updateCells as svcUpdateCells,
   deleteRow as svcDeleteRow,
   getTableGridData as svcGetTableGridData,
+  getTableSchema as svcGetTableSchema,
+  queryRows as svcQueryRows,
 } from "@/lib/workbooks/workbook-service";
 import {
   type PlatformUser,
@@ -37,7 +39,10 @@ import {
   getReferenceTargetFields,
 } from "@/lib/workbooks/platform-tables";
 import { inferTableFromSheet, type SheetCell } from "@/lib/workbooks/sheet-import";
-import type { CellValue, ColumnDefinition, FieldType, FieldConfig } from "@/lib/workbooks/types";
+import { parseDelimitedGrid } from "@/lib/onboarding/roster-import";
+import { mapGridToEmployees } from "@/lib/onboarding/roster-from-grid";
+import { importRoster } from "@/lib/onboarding/roster-import-actions";
+import type { CellValue, ColumnDefinition, FieldType, FieldConfig, GridRow } from "@/lib/workbooks/types";
 
 export type ActionResult<T = void> =
   | ({ ok: true } & (T extends void ? Record<string, never> : { data: T }))
@@ -277,9 +282,18 @@ export async function importSheetAction(
     const user = await requireUser("manage_workbooks");
     const file = formData.get("file");
     if (!(file instanceof File)) throw new WorkbookError("No file uploaded", 400);
-    const buffer = await file.arrayBuffer();
-    const { readSheet } = await import(/* turbopackIgnore: true */ "read-excel-file/browser");
-    const matrix = (await readSheet(buffer)) as SheetCell[][];
+    const lower = file.name.toLowerCase();
+    let matrix: SheetCell[][];
+    if (lower.endsWith(".csv") || lower.endsWith(".tsv") || file.type === "text/csv") {
+      // CSV/TSV: parse to a string matrix (header row + data rows).
+      const text = Buffer.from(await file.arrayBuffer()).toString("utf-8");
+      const { columns, rows } = parseDelimitedGrid(text);
+      matrix = [columns, ...rows];
+    } else {
+      const buffer = await file.arrayBuffer();
+      const { readSheet } = await import(/* turbopackIgnore: true */ "read-excel-file/browser");
+      matrix = (await readSheet(buffer)) as SheetCell[][];
+    }
 
     const { columns, rows, truncated } = inferTableFromSheet(matrix);
     if (columns.length === 0) throw new WorkbookError("The sheet has no columns to import", 400);
@@ -307,6 +321,74 @@ export async function importSheetAction(
       ok: true,
       data: { tableId: table.tableId, columnCount: columns.length, rowCount: rows.length, truncated },
     };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+// EP-ONBOARDING-INTAKE P4 (grid convergence): create EmployeeProfile rows from a
+// workbook table the operator imported + edited in the grid. Reads the table's
+// current columns + rows, maps them with the same roster mapper as the CSV path,
+// and creates employees (dedup by work email, fail-soft). The grid edit IS the
+// review step — nothing is created until the operator clicks "Create employees".
+export async function createEmployeesFromTableAction(
+  tableId: string,
+): Promise<
+  ActionResult<{ created: number; skippedExisting: number; failed: number; proposed: number; summary: string }>
+> {
+  try {
+    const user = await requireUser("manage_workbooks");
+    const schema = await svcGetTableSchema(user, tableId);
+
+    // Read every row (paged), capped so a giant sheet can't run unbounded.
+    const MAX_ROWS = 5000;
+    const rows: GridRow[] = [];
+    let cursor: string | null = null;
+    do {
+      const page = await svcQueryRows(user, tableId, { cursor, limit: 200 });
+      rows.push(...page.data);
+      cursor = page.nextCursor;
+    } while (cursor && rows.length < MAX_ROWS);
+
+    const mapped = mapGridToEmployees(schema.columns, rows.slice(0, MAX_ROWS));
+    const result = await importRoster(mapped.proposed);
+    return {
+      ok: true,
+      data: {
+        created: result.created,
+        skippedExisting: result.skippedExisting,
+        failed: result.failed,
+        proposed: mapped.proposed.length,
+        summary: mapped.summary,
+      },
+    };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+// Onboarding entry for the roster→grid flow (EP-ONBOARDING-INTAKE P4): drop an
+// uploaded team spreadsheet into a "Team" workbook as an editable grid table and
+// return its ids so the caller can open the grid. The operator then edits and
+// clicks "Create employees from this sheet". Find-or-creates the workbook so
+// repeat imports land in the same place.
+export async function startTeamSheetImportAction(
+  formData: FormData,
+): Promise<ActionResult<{ workbookId: string; tableId: string }>> {
+  try {
+    const user = await requireUser("manage_workbooks");
+    const existing = await svcListWorkbooks(user);
+    let workbookId = existing.find((w) => w.name === "Team")?.workbookId;
+    if (!workbookId) {
+      const wb = await svcCreateWorkbook(user, {
+        name: "Team",
+        description: "Imported team rosters — edit in the grid, then create employees.",
+      });
+      workbookId = wb.workbookId;
+    }
+    const imported = await importSheetAction(workbookId, formData);
+    if (!imported.ok) return imported;
+    return { ok: true, data: { workbookId, tableId: imported.data.tableId } };
   } catch (e) {
     return fail(e);
   }

--- a/apps/web/lib/onboarding/roster-from-grid.test.ts
+++ b/apps/web/lib/onboarding/roster-from-grid.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { cellToString, mapGridToEmployees } from "./roster-from-grid";
+import type { ColumnDefinition, GridRow, FieldType } from "@/lib/workbooks/types";
+
+function col(columnId: string, name: string, fieldType: FieldType = "text"): ColumnDefinition {
+  return { columnId, name, fieldType, position: 0, required: false, editable: true };
+}
+
+describe("cellToString", () => {
+  it("flattens every grid cell variant to a plain string", () => {
+    expect(cellToString(null)).toBe("");
+    expect(cellToString("Ada")).toBe("Ada");
+    expect(cellToString(42)).toBe("42");
+    expect(cellToString(true)).toBe("true");
+    expect(cellToString(false)).toBe("false");
+    // reference cell → display label (falls back to id)
+    expect(cellToString({ referenceId: "EMP-1", referenceType: "employee", label: "Ada L" })).toBe("Ada L");
+    expect(cellToString({ referenceId: "EMP-1", referenceType: "employee" })).toBe("EMP-1");
+    // multi-value cell → joined
+    expect(cellToString(["Sales", "East"])).toBe("Sales; East");
+  });
+});
+
+describe("mapGridToEmployees", () => {
+  it("maps an edited grid table to proposed employees via the roster mapper", () => {
+    const columns = [col("COL-1", "First Name"), col("COL-2", "Last Name"), col("COL-3", "Work Email")];
+    const rows: GridRow[] = [
+      { rowId: "ROW-1", cells: { "COL-1": "Ada", "COL-2": "Lovelace", "COL-3": "ada@acme.io" } },
+      { rowId: "ROW-2", cells: { "COL-1": "Grace", "COL-2": "Hopper", "COL-3": "grace@navy.mil" } },
+    ];
+    const res = mapGridToEmployees(columns, rows);
+    expect(res.proposed).toHaveLength(2);
+    expect(res.proposed[0]).toMatchObject({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      displayName: "Ada Lovelace",
+      workEmail: "ada@acme.io",
+    });
+  });
+
+  it("tolerates absent cells and a single full-name column", () => {
+    const columns = [col("COL-1", "Name"), col("COL-2", "Start Date", "date")];
+    const rows: GridRow[] = [{ rowId: "ROW-1", cells: { "COL-1": "Cher" } }]; // COL-2 absent
+    const res = mapGridToEmployees(columns, rows);
+    expect(res.proposed[0]).toMatchObject({ firstName: "Cher", displayName: "Cher", startDate: null });
+  });
+
+  it("detects roles from edited column NAMES (operator can rename headers in the grid)", () => {
+    // an operator renamed the email column to 'e-mail' in the grid — still detected
+    const columns = [col("COL-1", "Full Name"), col("COL-2", "e-mail")];
+    const rows: GridRow[] = [{ rowId: "ROW-1", cells: { "COL-1": "Ada Lovelace", "COL-2": "ada@x.io" } }];
+    const res = mapGridToEmployees(columns, rows);
+    expect(res.proposed[0]).toMatchObject({ displayName: "Ada Lovelace", workEmail: "ada@x.io" });
+  });
+});

--- a/apps/web/lib/onboarding/roster-from-grid.ts
+++ b/apps/web/lib/onboarding/roster-from-grid.ts
@@ -19,7 +19,7 @@ export function cellToString(v: CellValue): string {
     return v.map((it) => cellToString(it as CellValue)).filter(Boolean).join("; ");
   }
   if (typeof v === "object") {
-    const o = v as Record<string, unknown>;
+    const o = v as unknown as Record<string, unknown>;
     if (typeof o.label === "string" && o.label) return o.label; // reference / link label
     if (typeof o.referenceId === "string") return o.referenceId;
     if (typeof o.name === "string") return o.name; // attachment

--- a/apps/web/lib/onboarding/roster-from-grid.ts
+++ b/apps/web/lib/onboarding/roster-from-grid.ts
@@ -1,0 +1,43 @@
+// EP-ONBOARDING-INTAKE P4 (grid convergence) — bridge the Universal Grid
+// (EP-GRID-WORKBOOKS) to the employee-roster mapper. A roster the operator
+// uploaded and EDITED in the live grid (a custom WorkbookTable) is read back as
+// columns + rows and run through the same deterministic `mapRosterToEmployees`
+// that powers the CSV path — so "load XLS/CSV -> fix in the grid -> create
+// employees" reuses one mapping contract. Pure: no DB, fully testable.
+
+import type { CellValue, ColumnDefinition, GridRow } from "@/lib/workbooks/types";
+import { mapRosterToEmployees, type RosterMappingResult } from "./roster-import";
+
+/** Flatten any grid CellValue to the plain string the roster mapper expects. */
+export function cellToString(v: CellValue): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  if (typeof v === "number") return Number.isFinite(v) ? String(v) : "";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (Array.isArray(v)) {
+    // multi_select (string[]) or link (ReferenceValue[]) — join the display parts.
+    return v.map((it) => cellToString(it as CellValue)).filter(Boolean).join("; ");
+  }
+  if (typeof v === "object") {
+    const o = v as Record<string, unknown>;
+    if (typeof o.label === "string" && o.label) return o.label; // reference / link label
+    if (typeof o.referenceId === "string") return o.referenceId;
+    if (typeof o.name === "string") return o.name; // attachment
+    return "";
+  }
+  return String(v);
+}
+
+/**
+ * Map an edited grid table (its columns + rows) to proposed employees by reusing
+ * the CSV roster mapper. Column NAMES drive role detection (same fuzzy header
+ * matching), grid cells become the plain-string row values.
+ */
+export function mapGridToEmployees(
+  columns: ColumnDefinition[],
+  rows: GridRow[],
+): RosterMappingResult {
+  const columnNames = columns.map((c) => c.name);
+  const grid = rows.map((r) => columns.map((c) => cellToString(r.cells[c.columnId] ?? null)));
+  return mapRosterToEmployees(columnNames, grid);
+}

--- a/docs/superpowers/plans/2026-06-22-roster-import-grid-convergence.md
+++ b/docs/superpowers/plans/2026-06-22-roster-import-grid-convergence.md
@@ -1,0 +1,48 @@
+# Plan — Roster import via the Universal Grid (load → edit → save)
+
+**Date:** 2026-06-22
+**Epic:** EP-ONBOARDING-INTAKE · **BI:** BI-9B1E403D (relates EP-GRID-WORKBOOKS)
+**Spec:** [`docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md`](../specs/2026-06-20-onboarding-intake-derivation-design.md) §7.3
+**Supersedes:** the read-only roster preview shipped in P4 slice 1 (BI-C024582F).
+**Status:** built (this PR); live UX verification to follow.
+
+## Goal
+
+Founder `/goal`: make the in-platform **Universal Grid** (Smartsheet-like, EP-GRID-WORKBOOKS) the **load → edit → save** surface for the roster import. Upload XLS/CSV → it opens as an **editable grid** → the operator fixes rows → **"Create employees from this sheet"** → `EmployeeProfile`. Adds XLSX for free; unifies on one mapping contract. Verify live with a multi-employee load and confirm the grid editor works well.
+
+## Why (the gap this closes)
+
+Two half-flows existed: the grid loaded+edited XLSX but committed to a *generic* `WorkbookTable`; my roster importer committed to typed `EmployeeProfile` but only offered a *read-only* preview (CSV-only). This converges them — the grid is the edit surface, a new bridge commits the edited rows to employees.
+
+## Change set (maximal reuse)
+
+| File | Change |
+|------|--------|
+| `apps/web/lib/onboarding/roster-from-grid.ts` | **new pure bridge:** `cellToString` (any grid `CellValue` → string) + `mapGridToEmployees(columns, rows)` → reuses the existing `mapRosterToEmployees`. Column **names** drive role detection, so renaming a header *in the grid* still works. |
+| `apps/web/lib/onboarding/roster-from-grid.test.ts` | unit tests (cell flattening, grid→employees, edited headers). |
+| `apps/web/lib/actions/workbooks.ts` | `createEmployeesFromTableAction(tableId)` — read the table (`getTableSchema` + paged `queryRows`) → `mapGridToEmployees` → `importRoster`. **CSV/TSV support** added to `importSheetAction` (was XLSX-only). `startTeamSheetImportAction` — find-or-create a "Team" workbook + import + return ids (onboarding entry). |
+| `apps/web/components/workbooks/ImportSheetButton.tsx` | accept `.csv/.tsv` + relabel "Import sheet". |
+| `apps/web/components/workbooks/CreateEmployeesButton.tsx` | **new:** the commit affordance, shown on custom tables. |
+| `apps/web/app/(shell)/workbooks/[workbookId]/page.tsx` | render `CreateEmployeesButton` next to Add-column for `dataSource==="custom"` tables. |
+| `apps/web/components/admin/RosterImport.tsx` | **rewritten:** upload → `startTeamSheetImportAction` → redirect to the grid (replaces the read-only preview). |
+
+Reuses unchanged: the live grid editor (`CustomTableAdapter.updateCells`), `mapRosterToEmployees`, `importRoster` (dedup by work email, fail-soft), the grid import inference (`inferTableFromSheet`).
+
+## Flow
+
+1. Onboarding "Add your team" (business-context page) → upload CSV/XLSX → lands in the **Team** workbook as an editable grid.
+2. Operator edits in the grid (fix names, emails, headers) — the real Universal Grid.
+3. "Create employees from this sheet" → `EmployeeProfile` rows (dedup, fail-soft) + a result summary.
+
+The grid edit **is** the review step; nothing is created until the explicit click.
+
+## Notes / scope
+
+- **No new routes** — all libs/components/action edits, so the route-manifest gate doesn't fire.
+- The P4-slice-1 `/api/onboarding/roster*` API handlers are now UI-orphaned but remain valid endpoints (left to avoid manifest churn; flagged for later cleanup).
+- Identity baseline only (name/email/phone/start date); title/department are visible in the grid, FK resolution is a follow-on.
+- **Verification:** unit (`roster-from-grid.test.ts`, plus the existing roster tests). **Live UX (the goal's bar):** deploy via self-upgrade, then load a multi-row roster, edit a cell in the grid, click create, and confirm `EmployeeProfile` rows + that the grid editor works well.
+
+## UX-Fit
+
+Optional accelerator; progressive disclosure (upload appears as one optional control; the grid is the platform's existing edit surface; commit is one plain button). No numeric/raw inputs, no native dialogs, theme tokens. `UX-Fit-Decision:` attested in the PR.


### PR DESCRIPTION
Founder `/goal`: make the in-platform **Universal Grid** (Smartsheet-like, EP-GRID-WORKBOOKS) the **load → edit → save** surface for the roster import. Supersedes the read-only preview (P4 slice 1).

## Flow
Onboarding "Add your team" → upload **CSV or Excel** → opens as an **editable grid** (a "Team" workbook table) → operator fixes rows/headers in the grid → **"Create employees from this sheet"** → `EmployeeProfile` rows (dedup by work email, fail-soft). The grid edit *is* the review step.

## Maximal reuse
- `roster-from-grid.ts` (pure, tested): `cellToString` + `mapGridToEmployees` — reads a grid table's columns+rows and runs the **same `mapRosterToEmployees`** as the CSV path. Column **names** drive detection, so renaming a header *in the grid* still works.
- `workbooks.ts`: `createEmployeesFromTableAction` (read table → map → `importRoster`); **CSV/TSV added to `importSheetAction`** (was XLSX-only); `startTeamSheetImportAction` (find-or-create "Team" workbook + import → ids).
- `CreateEmployeesButton` on custom tables; `ImportSheetButton` accepts `.csv/.tsv`; `RosterImport` rewritten to hand off to the grid.
- **Unchanged:** the live grid editor (`CustomTableAdapter.updateCells`), `inferTableFromSheet`, `importRoster`.

## Notes
- **No new routes** — route-manifest gate unaffected. The P4 `/api/onboarding/roster*` handlers are now UI-orphaned (left to avoid manifest churn; flagged for cleanup).
- Identity baseline (name/email/phone/start date); title/department visible in the grid, FK resolution is a follow-on.
- Source-only worktree → compile/build/test in CI. **Live multi-employee UX + grid-editor verification to follow on the canonical install** (the goal's bar).

Plan: [grid convergence](docs/superpowers/plans/2026-06-22-roster-import-grid-convergence.md). BI-9B1E403D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)