### PR TITLE
feat(golden-triangle): Slice 5 — org (WWWD) default + effective-posture resolver (BI-FC527806)

### DIFF
--- a/apps/web/lib/actions/golden-triangle.ts
+++ b/apps/web/lib/actions/golden-triangle.ts
@@ -1,24 +1,51 @@
 "use server";
-// EP-GOLDEN-TRIANGLE Slice 4 (BI-85B2E96C) — server action to save the WWMD /
-// platform default posture. Gated by `view_platform` (the same capability that
-// guards decision-perspective writes). Platform scope only for v1; org-scoped
-// (WWWD) saving needs org-membership authz and lands with Slice 5.
+// EP-GOLDEN-TRIANGLE Slices 4/5 (BI-85B2E96C / BI-FC527806) — server actions to
+// save a default posture. The WWMD/platform default (Slice 4) is the shipped
+// seed; the WWWD/organization default (Slice 5) is the org's own override, which
+// the effective-posture resolver layers ABOVE the platform default. Both are
+// gated by `view_platform` (the capability that guards decision-perspective
+// writes), the standard pattern for platform-admin surfaces.
 import { revalidatePath } from "next/cache";
+
+import { prisma } from "@dpf/db";
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 import { setGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
 
-export async function saveGoldenTrianglePlatformDefault(
-  preference: GoldenTrianglePreference,
-): Promise<{ ok: boolean }> {
+async function requirePlatformAdmin() {
   const session = await auth();
   const user = session?.user;
   if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")) {
     throw new Error("Unauthorized");
   }
+  return user;
+}
+
+export async function saveGoldenTrianglePlatformDefault(
+  preference: GoldenTrianglePreference,
+): Promise<{ ok: boolean }> {
+  await requirePlatformAdmin();
   const ok = await setGoldenTrianglePosture({ kind: "platform" }, preference);
+  if (ok) revalidatePath("/platform/ai/priority");
+  return { ok };
+}
+
+/**
+ * Save the organization-wide (WWWD) default posture. DPF runs single-org installs
+ * today, so the org is resolved implicitly (the one Organization row) — the same
+ * pattern as wiki-edit / capability-activation. When multi-org lands, this takes
+ * an explicit `organizationId` from route context plus an org-membership check;
+ * the `view_platform` gate already scopes writes to platform admins of the install.
+ */
+export async function saveGoldenTriangleOrgDefault(
+  preference: GoldenTrianglePreference,
+): Promise<{ ok: boolean }> {
+  await requirePlatformAdmin();
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) throw new Error("No organization found");
+  const ok = await setGoldenTrianglePosture({ kind: "organization", organizationId: org.id }, preference);
   if (ok) revalidatePath("/platform/ai/priority");
   return { ok };
 }

--- a/apps/web/lib/golden-triangle/persistence.test.ts
+++ b/apps/web/lib/golden-triangle/persistence.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
 import {
+  getEffectiveGoldenTrianglePosture,
   getGoldenTrianglePosture,
   isGoldenTrianglePreference,
   setGoldenTrianglePosture,
@@ -10,6 +11,21 @@ import {
 } from "./persistence";
 
 const ASSURED: GoldenTrianglePreference = { preset: "assured", qualityWeight: 0.8, costWeight: 0.1, timeWeight: 0.1 };
+const FRUGAL: GoldenTrianglePreference = { preset: "frugal", qualityWeight: 0.1, costWeight: 0.8, timeWeight: 0.1 };
+
+/** A where-aware fake: returns different stored postures for the platform vs org profile rows. */
+function scopedClient(byScope: { platform?: GoldenTrianglePreference; org?: GoldenTrianglePreference }): GoldenTrianglePersistenceClient {
+  return {
+    decisionPerspectiveProfile: {
+      findFirst: async (args) => {
+        const where = (args as { where: Record<string, unknown> }).where;
+        const pref = "profileId" in where ? byScope.platform : byScope.org;
+        return pref ? { autonomyPolicy: { goldenTriangle: pref } } : null;
+      },
+      updateMany: async () => ({ count: 1 }),
+    },
+  };
+}
 
 interface Calls {
   findFirst: unknown[];
@@ -98,6 +114,31 @@ describe("getGoldenTrianglePosture", () => {
 
   it("is fail-open: returns null when the db throws", async () => {
     expect(await getGoldenTrianglePosture({ kind: "platform" }, throwingClient())).toBeNull();
+  });
+});
+
+describe("getEffectiveGoldenTrianglePosture", () => {
+  it("prefers the organization posture when one is set (WWWD over WWMD)", async () => {
+    const client = scopedClient({ platform: ASSURED, org: FRUGAL });
+    expect(await getEffectiveGoldenTrianglePosture("org_1", client)).toEqual({ preference: FRUGAL, source: "organization" });
+  });
+
+  it("falls back to the platform default when the org has none", async () => {
+    const client = scopedClient({ platform: ASSURED });
+    expect(await getEffectiveGoldenTrianglePosture("org_1", client)).toEqual({ preference: ASSURED, source: "platform" });
+  });
+
+  it("skips the org lookup entirely when organizationId is null", async () => {
+    const client = scopedClient({ platform: ASSURED, org: FRUGAL });
+    expect(await getEffectiveGoldenTrianglePosture(null, client)).toEqual({ preference: ASSURED, source: "platform" });
+  });
+
+  it("returns null when neither scope has a saved posture (caller uses Balanced)", async () => {
+    expect(await getEffectiveGoldenTrianglePosture("org_1", scopedClient({}))).toBeNull();
+  });
+
+  it("is fail-open: returns null when the db throws", async () => {
+    expect(await getEffectiveGoldenTrianglePosture("org_1", throwingClient())).toBeNull();
   });
 });
 

--- a/apps/web/lib/golden-triangle/persistence.ts
+++ b/apps/web/lib/golden-triangle/persistence.ts
@@ -92,3 +92,31 @@ export async function setGoldenTrianglePosture(
     return false;
   }
 }
+
+/** The scope a resolved posture came from — surfaced so the UI can show "why this default". */
+export type ResolvedPostureSource = "organization" | "platform";
+
+export interface ResolvedPosture {
+  preference: GoldenTrianglePreference;
+  source: ResolvedPostureSource;
+}
+
+/**
+ * Resolve the posture that should apply, layering scopes most-specific first:
+ * organization (WWWD, the org's own choice) → platform (WWMD, the shipped seed
+ * default) → null (the caller falls back to Balanced, the byte-identical-to-off
+ * cold start). Pure composition over the fail-open reader, so it inherits
+ * fail-open behaviour. `organizationId` may be null when there is no org context.
+ */
+export async function getEffectiveGoldenTrianglePosture(
+  organizationId: string | null,
+  db?: GoldenTrianglePersistenceClient,
+): Promise<ResolvedPosture | null> {
+  if (organizationId) {
+    const org = await getGoldenTrianglePosture({ kind: "organization", organizationId }, db);
+    if (org) return { preference: org, source: "organization" };
+  }
+  const platform = await getGoldenTrianglePosture({ kind: "platform" }, db);
+  if (platform) return { preference: platform, source: "platform" };
+  return null;
+}


### PR DESCRIPTION
**Slice 5 — organization (WWWD) default + effective-posture resolver** (`BI-FC527806`). Backend only; additive; no behaviour change to existing callers.

- **`saveGoldenTriangleOrgDefault(preference)`** ([actions/golden-triangle.ts](apps/web/lib/actions/golden-triangle.ts)) — saves the org's own default. DPF is single-org today, so the org is resolved implicitly (the one `Organization` row), mirroring the established `wiki-edit` / `capability-activation` pattern; `view_platform`-gated. The multi-org path (explicit `organizationId` + membership check) is documented for when it lands.
- **`getEffectiveGoldenTrianglePosture(orgId)`** ([persistence.ts](apps/web/lib/golden-triangle/persistence.ts)) — layers **organization (WWWD) → platform (WWMD seed) → null→Balanced**, returning the resolved preference plus its `source` (for a future "why this default"). Pure composition over the fail-open reader, so it inherits fail-open. 5 new resolver tests (15 total in the suite).
- Refactored the shared authz into `requirePlatformAdmin()`; `saveGoldenTrianglePlatformDefault` is byte-equivalent.

**Deliberately NOT in this PR:** exposing a platform-vs-organization **scope toggle** on the non-technical `/platform/ai/priority` page. On a single-org install that distinction risks adding cognitive load to a surface whose whole point is simplicity — a genuine product call I'm flagging for @markdbodman rather than guessing. The resolver + action make either choice (implicit-org or explicit-toggle) a small follow-up.

Process-Spine-Decision: doc-specced (design §"Slice 5: org" + implementation plan); additive backend, existing callers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
