### PR TITLE
feat(assurance): P3 auto-resolve findings absent from a clean re-scan (BI-4D5C702F)

### DIFF
--- a/apps/web/lib/assurance/finding-persistence.test.ts
+++ b/apps/web/lib/assurance/finding-persistence.test.ts
@@ -45,7 +45,7 @@ describe("persistAssuranceFindings", () => {
       observedAt,
     });
 
-    expect(result).toEqual({ created: 1, updated: 0, reopened: 0 });
+    expect(result).toEqual({ created: 1, updated: 0, reopened: 0, resolved: 0, resolvedBacklogItemIds: [] });
     expect(db.assuranceFinding.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         findingKey: "finding-key-1",
@@ -79,7 +79,7 @@ describe("persistAssuranceFindings", () => {
       observedAt,
     });
 
-    expect(result).toEqual({ created: 0, updated: 1, reopened: 0 });
+    expect(result).toEqual({ created: 0, updated: 1, reopened: 0, resolved: 0, resolvedBacklogItemIds: [] });
     expect(db.assuranceFinding.update).toHaveBeenCalledWith({
       where: { findingKey: "finding-key-1" },
       data: expect.not.objectContaining({ status: expect.any(String) }),
@@ -101,7 +101,7 @@ describe("persistAssuranceFindings", () => {
       observedAt: new Date("2026-05-22T05:00:00.000Z"),
     });
 
-    expect(result).toEqual({ created: 0, updated: 1, reopened: 1 });
+    expect(result).toEqual({ created: 0, updated: 1, reopened: 1, resolved: 0, resolvedBacklogItemIds: [] });
     expect(db.assuranceFinding.update).toHaveBeenCalledWith({
       where: { findingKey: "finding-key-1" },
       data: expect.objectContaining({
@@ -110,5 +110,92 @@ describe("persistAssuranceFindings", () => {
         reopenCount: { increment: 1 },
       }),
     });
+  });
+
+  it("auto-resolves findings absent from the latest scan and returns their linked BIs (P3)", async () => {
+    const update = vi.fn();
+    const db = {
+      assuranceFinding: {
+        findMany: vi
+          .fn()
+          .mockResolvedValueOnce([]) // main upsert query (present finding is new)
+          .mockResolvedValueOnce([   // absent sweep
+            { findingKey: "gone-1", evidence: { backlogItemId: "BI-OLD-1" } },
+            { findingKey: "gone-2", evidence: {} },
+          ]),
+        create: vi.fn(async () => ({ id: "af" })),
+        update,
+      },
+    };
+    const observedAt = new Date("2026-06-23T03:00:00.000Z");
+
+    const result = await persistAssuranceFindings(db, {
+      assuranceRunId: "run",
+      buildId: "FB-1",
+      findings: [normalizedFinding({ findingKey: "present-1" })],
+      observedAt,
+      resolveAbsent: { adapterKey: "pnpm-audit" },
+    });
+
+    expect(result.resolved).toBe(2);
+    expect(result.resolvedBacklogItemIds).toEqual(["BI-OLD-1"]);
+    expect(update).toHaveBeenCalledWith({
+      where: { findingKey: "gone-1" },
+      data: expect.objectContaining({ status: "resolved", resolvedAt: observedAt }),
+    });
+    expect(db.assuranceFinding.findMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          buildId: "FB-1",
+          adapterKey: "pnpm-audit",
+          findingKey: { notIn: ["present-1"] },
+        }),
+      }),
+    );
+  });
+
+  it("resolves all active findings on an empty all-clear scan", async () => {
+    const db = {
+      assuranceFinding: {
+        findMany: vi.fn(async () => [{ findingKey: "gone-1", evidence: {} }]),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+    const result = await persistAssuranceFindings(db, {
+      assuranceRunId: "run",
+      buildId: "FB-1",
+      findings: [],
+      observedAt: new Date("2026-06-23T03:00:00.000Z"),
+      resolveAbsent: { adapterKey: "pnpm-audit" },
+    });
+    expect(result.resolved).toBe(1);
+    expect(result.created).toBe(0);
+  });
+
+  it("skips the absent-sweep without resolveAbsent or without a buildId", async () => {
+    const noOpts = {
+      assuranceFinding: { findMany: vi.fn(async () => []), create: vi.fn(async () => ({ id: "x" })), update: vi.fn() },
+    };
+    const r1 = await persistAssuranceFindings(noOpts, {
+      assuranceRunId: "r",
+      buildId: "FB-1",
+      findings: [normalizedFinding()],
+      observedAt: new Date(),
+    });
+    expect(r1.resolved).toBe(0);
+    expect(noOpts.assuranceFinding.findMany).toHaveBeenCalledTimes(1);
+
+    const noBuild = {
+      assuranceFinding: { findMany: vi.fn(async () => []), create: vi.fn(async () => ({ id: "x" })), update: vi.fn() },
+    };
+    const r2 = await persistAssuranceFindings(noBuild, {
+      assuranceRunId: "r",
+      findings: [normalizedFinding()],
+      observedAt: new Date(),
+      resolveAbsent: { adapterKey: "pnpm-audit" },
+    });
+    expect(r2.resolved).toBe(0);
+    expect(noBuild.assuranceFinding.findMany).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/assurance/finding-persistence.ts
+++ b/apps/web/lib/assurance/finding-persistence.ts
@@ -8,12 +8,25 @@ export interface PersistAssuranceFindingsInput {
   digitalProductId?: string | null;
   bomDocumentId?: string | null;
   componentIdsByAffectedId?: Record<string, string>;
+  /**
+   * P3 (BI-4D5C702F) — close the remediation loop's far end. When set, auto-resolve
+   * previously-open findings for this build+adapter scope that are ABSENT from the
+   * current scan: the remediation deployed and the vuln is gone. Without this,
+   * persist only ever touches findings PRESENT in the scan, so a resolved finding
+   * (and the gate's blocking state) lingers forever. Scoped strictly to
+   * buildId + adapterKey so one adapter's clean scan can't false-resolve another's.
+   */
+  resolveAbsent?: { adapterKey: string };
 }
 
 export interface PersistAssuranceFindingsResult {
   created: number;
   updated: number;
   reopened: number;
+  /** Findings auto-resolved because they vanished from the latest scan (P3). */
+  resolved: number;
+  /** Linked BI ids of the auto-resolved findings, for downstream BI close-out. */
+  resolvedBacklogItemIds: string[];
 }
 
 type ExistingFinding = {
@@ -22,8 +35,13 @@ type ExistingFinding = {
   reopenCount: number;
 };
 
+type AbsentFinding = {
+  findingKey: string;
+  evidence: unknown;
+};
+
 type AssuranceFindingDelegate = {
-  findMany(args: unknown): Promise<ExistingFinding[]>;
+  findMany(args: unknown): Promise<unknown[]>;
   create(args: unknown): Promise<unknown>;
   update(args: unknown): Promise<unknown>;
 };
@@ -33,6 +51,10 @@ export type AssuranceFindingPersistenceDb = {
 };
 
 const REOPEN_STATUSES = new Set(["resolved"]);
+
+/** Non-terminal statuses an absent finding may be auto-resolved FROM. `accepted`
+ *  (intentional) and `deferred` (parked) are deliberately left alone. */
+const ACTIVE_RESOLVABLE_STATUSES = ["open", "planned", "blocked"];
 
 function componentIdFor(input: PersistAssuranceFindingsInput, finding: NormalizedAssuranceFinding): string | null {
   if (finding.affectedType !== "bom-component") return null;
@@ -69,52 +91,93 @@ function baseFindingData(input: PersistAssuranceFindingsInput, finding: Normaliz
   };
 }
 
+function readBacklogItemId(evidence: unknown): string | null {
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return null;
+  const value = (evidence as Record<string, unknown>).backlogItemId;
+  return typeof value === "string" && value ? value : null;
+}
+
+function withAutoResolved(evidence: unknown, at: Date): Record<string, unknown> {
+  const base =
+    evidence && typeof evidence === "object" && !Array.isArray(evidence)
+      ? { ...(evidence as Record<string, unknown>) }
+      : {};
+  return { ...base, autoResolved: { reason: "not-seen-in-scan", at: at.toISOString() } };
+}
+
 export async function persistAssuranceFindings(
   db: AssuranceFindingPersistenceDb,
   input: PersistAssuranceFindingsInput,
 ): Promise<PersistAssuranceFindingsResult> {
-  if (input.findings.length === 0) {
-    return { created: 0, updated: 0, reopened: 0 };
-  }
+  const result: PersistAssuranceFindingsResult = {
+    created: 0,
+    updated: 0,
+    reopened: 0,
+    resolved: 0,
+    resolvedBacklogItemIds: [],
+  };
 
   const keys = input.findings.map((finding) => finding.findingKey);
-  const existingRows = await db.assuranceFinding.findMany({
-    where: { findingKey: { in: keys } },
-    select: { findingKey: true, status: true, reopenCount: true },
-  });
-  const existingByKey = new Map(existingRows.map((row) => [row.findingKey, row]));
-  const result: PersistAssuranceFindingsResult = { created: 0, updated: 0, reopened: 0 };
 
-  for (const finding of input.findings) {
-    const existing = existingByKey.get(finding.findingKey);
-    const data = baseFindingData(input, finding);
+  // Upsert the findings present in this scan (create new, reopen resolved).
+  if (input.findings.length > 0) {
+    const existingRows = (await db.assuranceFinding.findMany({
+      where: { findingKey: { in: keys } },
+      select: { findingKey: true, status: true, reopenCount: true },
+    })) as ExistingFinding[];
+    const existingByKey = new Map(existingRows.map((row) => [row.findingKey, row]));
 
-    if (!existing) {
-      await db.assuranceFinding.create({
+    for (const finding of input.findings) {
+      const existing = existingByKey.get(finding.findingKey);
+      const data = baseFindingData(input, finding);
+
+      if (!existing) {
+        await db.assuranceFinding.create({
+          data: { findingKey: finding.findingKey, ...data, status: "open", firstSeenAt: input.observedAt },
+        });
+        result.created += 1;
+        continue;
+      }
+
+      const updateData: Record<string, unknown> = { ...data };
+      if (REOPEN_STATUSES.has(existing.status)) {
+        updateData.status = "open";
+        updateData.resolvedAt = null;
+        updateData.reopenCount = { increment: 1 };
+        result.reopened += 1;
+      }
+
+      await db.assuranceFinding.update({ where: { findingKey: finding.findingKey }, data: updateData });
+      result.updated += 1;
+    }
+  }
+
+  // P3: auto-resolve findings that vanished from this scan (build+adapter scope).
+  // Runs even when the scan is empty (everything fixed → resolve all active).
+  if (input.resolveAbsent && input.buildId) {
+    const absent = (await db.assuranceFinding.findMany({
+      where: {
+        buildId: input.buildId,
+        adapterKey: input.resolveAbsent.adapterKey,
+        status: { in: ACTIVE_RESOLVABLE_STATUSES },
+        findingKey: { notIn: keys },
+      },
+      select: { findingKey: true, evidence: true },
+    })) as AbsentFinding[];
+
+    for (const row of absent) {
+      await db.assuranceFinding.update({
+        where: { findingKey: row.findingKey },
         data: {
-          findingKey: finding.findingKey,
-          ...data,
-          status: "open",
-          firstSeenAt: input.observedAt,
+          status: "resolved",
+          resolvedAt: input.observedAt,
+          evidence: withAutoResolved(row.evidence, input.observedAt),
         },
       });
-      result.created += 1;
-      continue;
+      result.resolved += 1;
+      const backlogItemId = readBacklogItemId(row.evidence);
+      if (backlogItemId) result.resolvedBacklogItemIds.push(backlogItemId);
     }
-
-    const updateData: Record<string, unknown> = { ...data };
-    if (REOPEN_STATUSES.has(existing.status)) {
-      updateData.status = "open";
-      updateData.resolvedAt = null;
-      updateData.reopenCount = { increment: 1 };
-      result.reopened += 1;
-    }
-
-    await db.assuranceFinding.update({
-      where: { findingKey: finding.findingKey },
-      data: updateData,
-    });
-    result.updated += 1;
   }
 
   return result;

--- a/apps/web/lib/assurance/scan-job.ts
+++ b/apps/web/lib/assurance/scan-job.ts
@@ -133,6 +133,7 @@ export type RunBuildScanResult =
       autoFiled: number;
       suppressed: number;
       evidenceOnly: number;
+      resolved: number;
     };
 
 function buildLookup(document: ScanJobBomDocumentRow): PnpmAuditComponentLookup {
@@ -289,6 +290,9 @@ export async function runBuildAssuranceScan(input: RunBuildScanInput): Promise<R
     digitalProductId: build.digitalProductId,
     bomDocumentId: document.id,
     componentIdsByAffectedId: adapterOutput.componentIdsByAffectedId,
+    // P3 (BI-4D5C702F): close the loop — auto-resolve findings for this
+    // build+adapter scope that vanished from this scan (the remediation landed).
+    resolveAbsent: { adapterKey: PNPM_AUDIT_ADAPTER_KEY },
   });
 
   // Auto-file: turn GENUINE findings into backlog items with no manual click,
@@ -313,7 +317,7 @@ export async function runBuildAssuranceScan(input: RunBuildScanInput): Promise<R
     data: {
       buildId: build.buildId,
       tool: "assurance-scan",
-      summary: `pnpm audit scan: ${adapterOutput.findings.length} findings (${Number(adapterOutput.summary.blockingCount ?? 0)} blocking, ${persistResult.reopened} reopened) · auto-filed ${dispositions.filed}, suppressed ${dispositions.suppressed}, evidence ${dispositions.evidenceOnly}.`,
+      summary: `pnpm audit scan: ${adapterOutput.findings.length} findings (${Number(adapterOutput.summary.blockingCount ?? 0)} blocking, ${persistResult.reopened} reopened) · auto-filed ${dispositions.filed}, suppressed ${dispositions.suppressed}, evidence ${dispositions.evidenceOnly}, resolved ${persistResult.resolved}.`,
     },
   });
 
@@ -334,6 +338,7 @@ export async function runBuildAssuranceScan(input: RunBuildScanInput): Promise<R
     reopened: persistResult.reopened,
     blockingCount: Number(adapterOutput.summary.blockingCount ?? 0),
     findingCount: adapterOutput.findings.length,
+    resolved: persistResult.resolved,
     autoFiled: dispositions.filed,
     suppressed: dispositions.suppressed,
     evidenceOnly: dispositions.evidenceOnly,

--- a/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
@@ -89,6 +89,19 @@ When a later scan no longer reports a finding, mark previously-open findings
 **absent from the latest scan** as `resolved` (scoped to the same build+adapter)
 and close the linked BI. Makes the loop converge instead of leaving transient BIs.
 
+**Implemented — finding auto-resolve (BI-4D5C702F):** `finding-persistence.ts` gains
+an opt-in `resolveAbsent: { adapterKey }` — after upserting the present findings it
+resolves previously-open findings (status open/planned/blocked) for the
+build+adapter scope that are ABSENT from the current scan (`findingKey notIn` the
+scanned keys; runs even on an empty all-clear scan), stamps `evidence.autoResolved`,
+and returns the resolved count + the linked BI ids. Wired in `scan-job.ts` (passes
+`resolveAbsent`, surfaces `resolved`). + tests.
+
+**Staged — linked-BI close-out (P3.2):** the auto-resolved findings return their
+`backlogItemId`s; closing those remediation BIs should go through the proper backlog
+lifecycle (status→done + activity + epic rollup), not a raw persist write — a clean
+follow-on rather than coupling persist to the backlog.
+
 ## Sequencing
 
 Land PR #2290 (the create-side foundation) first; then P1 → P3. P1 is safe


### PR DESCRIPTION
## Why
P3 — close the remediation loop's far end. `finding-persistence.ts` only ever touched findings **present** in a scan, so once a remediation deployed and the vuln vanished, the finding (and the gate's blocking state) lingered forever.

## What
Opt-in `resolveAbsent: { adapterKey }` on `persistAssuranceFindings`: after upserting the present findings, resolve previously-open findings (status open/planned/blocked) for the **build+adapter scope** that are **absent** from the current scan (`findingKey notIn` the scanned keys; runs even on an empty all-clear scan), stamp `evidence.autoResolved`, and return the resolved count + the linked BI ids. Scoped strictly to `buildId` + `adapterKey` so one adapter's clean scan can't false-resolve another's. Wired into `scan-job.ts` (passes `resolveAbsent`, surfaces `resolved` in the activity + result).

## Staged (P3.2)
Linked-BI close-out: the auto-resolved findings return their `backlogItemId`s, but closing those remediation BIs belongs in the proper backlog lifecycle (status→done + activity + epic rollup), not a raw persist write — a clean follow-on rather than coupling persist to the backlog.

## Verification
Tests: absent→resolved (and returns the linked BIs), empty all-clear scan resolves all active findings, scope guards (no `resolveAbsent` / no `buildId` → no sweep). Existing persist tests updated for the two new result fields. Worktree has no node_modules → CI runs the full suite + typecheck.

## The loop, complete
#2290 *file* → P1 #2301 *promote* → P2 #2307 *decide* → **P3 (this) *resolve***. (The live merge actuation is P2.2, dark-by-default.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)