### PR TITLE
feat(golden-triangle): Slice 7 — federated hive contribution (BI-6E01FE69)

### DIFF
--- a/apps/web/lib/actions/golden-triangle.ts
+++ b/apps/web/lib/actions/golden-triangle.ts
@@ -12,7 +12,8 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
-import { setGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
+import { contributePostureDefault } from "@/lib/golden-triangle/hive";
+import { getEffectiveGoldenTrianglePosture, setGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
 
 async function requirePlatformAdmin() {
   const session = await auth();
@@ -48,4 +49,20 @@ export async function saveGoldenTriangleOrgDefault(
   const ok = await setGoldenTrianglePosture({ kind: "organization", organizationId: org.id }, preference);
   if (ok) revalidatePath("/platform/ai/priority");
   return { ok };
+}
+
+/**
+ * EP-GOLDEN-TRIANGLE Slice 7 — explicitly contribute the effective posture default
+ * to the hive (the federated learning commons). Deliberately an EXPLICIT operator
+ * action, not automatic on save: sharing a default is a privacy decision, so it is
+ * gated by both `view_platform` AND the hive consent surface (the "improvement"
+ * opt-in + master pause inside contributePostureDefault, which is fail-closed and
+ * shares only the anonymized preset + weights — never an org identity).
+ */
+export async function contributeGoldenTrianglePostureToHive(): Promise<{ contributed: boolean; reason: string }> {
+  await requirePlatformAdmin();
+  const resolved = await getEffectiveGoldenTrianglePosture(null);
+  if (!resolved) return { contributed: false, reason: "no_posture_set" };
+  const res = await contributePostureDefault(resolved.preference);
+  return { contributed: res.contributed, reason: res.reason };
 }

--- a/apps/web/lib/golden-triangle/hive.test.ts
+++ b/apps/web/lib/golden-triangle/hive.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import {
+  aggregatePostureContributions,
+  anonymizePosture,
+  contributePostureDefault,
+  getHivePostureSuggestion,
+  storeHivePostureSuggestion,
+  type AnonymizedPosture,
+  type HiveContributeClient,
+  type HivePostureConsensus,
+  type HiveSuggestionClient,
+} from "./hive";
+
+const ASSURED: GoldenTrianglePreference = { preset: "assured", qualityWeight: 0.8, costWeight: 0.1, timeWeight: 0.1 };
+
+function ap(preset: AnonymizedPosture["preset"], q: number, c: number, t: number): AnonymizedPosture {
+  return { preset, qualityWeight: q, costWeight: c, timeWeight: t };
+}
+
+describe("anonymizePosture", () => {
+  it("keeps only preset + weights (nothing identifying)", () => {
+    expect(anonymizePosture(ASSURED)).toEqual({ preset: "assured", qualityWeight: 0.8, costWeight: 0.1, timeWeight: 0.1 });
+  });
+});
+
+describe("aggregatePostureContributions", () => {
+  it("returns null for no contributions", () => {
+    expect(aggregatePostureContributions([])).toBeNull();
+  });
+
+  it("picks the modal preset, means the weights, and reports confidence", () => {
+    const out = aggregatePostureContributions([
+      ap("frugal", 0.2, 0.6, 0.2),
+      ap("frugal", 0.2, 0.6, 0.2),
+      ap("assured", 0.8, 0.1, 0.1),
+    ]);
+    expect(out).not.toBeNull();
+    expect(out?.preset).toBe("frugal");
+    expect(out?.peerCount).toBe(3);
+    expect(out?.confidence).toBe(0.67); // 2 of 3
+    expect(out?.qualityWeight).toBe(0.4); // (0.2 + 0.2 + 0.8) / 3
+  });
+});
+
+describe("contributePostureDefault", () => {
+  function client(mode: string, paused: boolean, capture?: (data: Record<string, unknown>) => void): HiveContributeClient {
+    return {
+      platformDevConfig: {
+        findUnique: async () => ({ deviceFingerprintOptIn: true, hiveContributionsPaused: paused, contributionMode: mode }),
+      },
+      hiveContributionLedger: {
+        create: async ({ data }) => {
+          capture?.(data as Record<string, unknown>);
+          return { id: "ledger_1" };
+        },
+      },
+    };
+  }
+
+  it("contributes (as an 'improvement') when sharing is enabled", async () => {
+    let recorded: Record<string, unknown> | undefined;
+    const res = await contributePostureDefault(ASSURED, client("selective", false, (d) => (recorded = d)));
+    expect(res.contributed).toBe(true);
+    expect(res.ledgerId).toBe("ledger_1");
+    expect(recorded?.contributionType).toBe("improvement");
+    expect(recorded?.payloadHash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("is fail-closed when contributionMode is fork_only", async () => {
+    expect(await contributePostureDefault(ASSURED, client("fork_only", false))).toEqual({
+      contributed: false,
+      reason: "contribution_disabled",
+    });
+  });
+
+  it("respects the master pause", async () => {
+    expect((await contributePostureDefault(ASSURED, client("contribute_all", true))).contributed).toBe(false);
+  });
+});
+
+describe("hive posture suggestion seam", () => {
+  function client(initial: unknown): HiveSuggestionClient {
+    let policy = initial;
+    return {
+      decisionPerspectiveProfile: {
+        findFirst: async () => (policy === null ? null : { autonomyPolicy: policy }),
+        updateMany: async (args) => {
+          policy = (args as { data: { autonomyPolicy: unknown } }).data.autonomyPolicy;
+          return { count: 1 };
+        },
+      },
+    };
+  }
+
+  const consensus: HivePostureConsensus = {
+    preset: "frugal",
+    qualityWeight: 0.2,
+    costWeight: 0.6,
+    timeWeight: 0.2,
+    peerCount: 5,
+    confidence: 0.8,
+  };
+
+  it("returns null when nothing is stored", async () => {
+    expect(await getHivePostureSuggestion(client({}))).toBeNull();
+  });
+
+  it("stores then reads back a consensus, preserving other autonomyPolicy keys", async () => {
+    const c = client({ goldenTriangle: ASSURED });
+    expect(await storeHivePostureSuggestion(consensus, c)).toBe(true);
+    expect(await getHivePostureSuggestion(c)).toEqual(consensus);
+  });
+});

--- a/apps/web/lib/golden-triangle/hive.ts
+++ b/apps/web/lib/golden-triangle/hive.ts
@@ -1,0 +1,233 @@
+// EP-GOLDEN-TRIANGLE Slice 7 (BI-6E01FE69) — federated hive contribution of
+// learned posture defaults.
+//
+// A learned posture default is a platform LEARNING (the WWWD lane of the Learning
+// Commons), so it rides the EXISTING "improvement" contribution type through the
+// one consent gate (isContributionEnabled) and the one ledger
+// (HiveContributionLedger) — pseudonymously and PII-free, with no new substrate
+// and no schema change. What leaves the install is only the anonymized posture
+// (preset + weights); never an org id, name, or any identifier.
+//
+// Aggregation of peer-contributed postures into a consensus is pure and ready for
+// when the federated ingest supplies peer data; the suggestion read/store seam
+// rides the platform profile's autonomyPolicy JSON (migration-free). Until a
+// federation of installs feeds postures back, getHivePostureSuggestion() returns
+// null — the cross-install transport is hive-network infrastructure, external to
+// a single install.
+import { createHash } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+import { buildLedgerEntry, isContributionEnabled, type HiveContributionConfig } from "@dpf/db/hive-contribution-settings";
+
+import type { GoldenTrianglePreference, GoldenTrianglePreset } from "@/lib/golden-triangle";
+import { getDisplayPseudonym } from "@/lib/integrate/identity-privacy";
+
+const PLATFORM_PROFILE_ID = "mark-dpf-platform";
+const PRESETS: GoldenTrianglePreset[] = ["fast", "frugal", "assured", "balanced", "custom"];
+
+// ─── Anonymization ───────────────────────────────────────────────────────────
+
+/** Exactly what may leave the install — the posture shape, nothing identifying. */
+export interface AnonymizedPosture {
+  preset: GoldenTrianglePreset;
+  qualityWeight: number;
+  costWeight: number;
+  timeWeight: number;
+}
+
+export function anonymizePosture(p: GoldenTrianglePreference): AnonymizedPosture {
+  return { preset: p.preset, qualityWeight: p.qualityWeight, costWeight: p.costWeight, timeWeight: p.timeWeight };
+}
+
+// ─── Contribution (outbound) ─────────────────────────────────────────────────
+
+export interface ContributePostureResult {
+  contributed: boolean;
+  reason: string;
+  ledgerId?: string;
+}
+
+/** Structural client for the contribution path — satisfied by PrismaClient + test fakes. */
+export interface HiveContributeClient {
+  platformDevConfig: {
+    findUnique: (args: unknown) => Promise<{
+      deviceFingerprintOptIn: boolean;
+      hiveContributionsPaused: boolean;
+      contributionMode: string;
+    } | null>;
+  };
+  hiveContributionLedger: {
+    create: (args: { data: unknown }) => Promise<{ id: string }>;
+  };
+}
+
+/**
+ * Contribute a posture default to the hive, honoring the §6.1 consent surface
+ * (the "improvement" opt-in via contributionMode + the master pause). Fail-closed:
+ * returns { contributed:false } when contribution is disabled. Only the anonymized
+ * posture is hashed into the ledger; the cross-install transport is the curation
+ * pipeline. Safe to fire-and-forget after a save.
+ */
+export async function contributePostureDefault(
+  preference: GoldenTrianglePreference,
+  db?: HiveContributeClient,
+): Promise<ContributePostureResult> {
+  const client = db ?? (prisma as unknown as HiveContributeClient);
+  try {
+    const row = await client.platformDevConfig.findUnique({
+      where: { id: "singleton" },
+      select: { deviceFingerprintOptIn: true, hiveContributionsPaused: true, contributionMode: true },
+    });
+    const config: HiveContributionConfig = {
+      deviceFingerprintOptIn: row?.deviceFingerprintOptIn ?? true,
+      hiveContributionsPaused: row?.hiveContributionsPaused ?? false,
+      contributionMode: row?.contributionMode ?? "selective",
+    };
+    if (!isContributionEnabled("improvement", config)) {
+      return { contributed: false, reason: "contribution_disabled" };
+    }
+    const contributor = await getDisplayPseudonym().catch(() => "dpf-anon");
+    const payload = anonymizePosture(preference);
+    const payloadHash = createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 16);
+    const entry = await client.hiveContributionLedger.create({
+      data: buildLedgerEntry({
+        contributionType: "improvement",
+        contributor,
+        ruleKey: `golden-triangle:posture:${preference.preset}`,
+        summary: `Golden Triangle posture default → ${preference.preset}`,
+        payloadHash,
+        redactionStatus: "not_required", // a posture carries no PII
+      }),
+    });
+    return { contributed: true, reason: "ready", ledgerId: entry.id };
+  } catch {
+    return { contributed: false, reason: "error" };
+  }
+}
+
+// ─── Aggregation (pure) ──────────────────────────────────────────────────────
+
+export interface HivePostureConsensus {
+  /** The most-contributed preset across peers. */
+  preset: GoldenTrianglePreset;
+  /** Mean axis weights across peers (2dp). */
+  qualityWeight: number;
+  costWeight: number;
+  timeWeight: number;
+  /** How many peers informed the consensus. */
+  peerCount: number;
+  /** Share of peers on the winning preset (0–1, 2dp) — how strong the consensus is. */
+  confidence: number;
+}
+
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+/**
+ * Roll peer-contributed postures into a single consensus: the modal preset and
+ * the mean axis weights, with a confidence = the winning preset's share. Pure +
+ * deterministic (ties resolve to the first-seen preset). Returns null for an
+ * empty set.
+ */
+export function aggregatePostureContributions(contributions: AnonymizedPosture[]): HivePostureConsensus | null {
+  const n = contributions.length;
+  if (n === 0) return null;
+
+  const counts = new Map<GoldenTrianglePreset, number>();
+  for (const c of contributions) counts.set(c.preset, (counts.get(c.preset) ?? 0) + 1);
+  let preset = contributions[0].preset;
+  let winnerCount = 0;
+  for (const [p, count] of counts) {
+    if (count > winnerCount) {
+      preset = p;
+      winnerCount = count;
+    }
+  }
+
+  const sum = contributions.reduce(
+    (a, c) => ({ q: a.q + c.qualityWeight, co: a.co + c.costWeight, t: a.t + c.timeWeight }),
+    { q: 0, co: 0, t: 0 },
+  );
+
+  return {
+    preset,
+    qualityWeight: round2(sum.q / n),
+    costWeight: round2(sum.co / n),
+    timeWeight: round2(sum.t / n),
+    peerCount: n,
+    confidence: round2(winnerCount / n),
+  };
+}
+
+// ─── Suggestion read/store seam (migration-free) ─────────────────────────────
+
+/** Structural client for the suggestion seam — rides the platform profile JSON. */
+export interface HiveSuggestionClient {
+  decisionPerspectiveProfile: {
+    findFirst: (args: unknown) => Promise<{ autonomyPolicy: unknown } | null>;
+    updateMany: (args: unknown) => Promise<{ count: number }>;
+  };
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+function isConsensus(v: unknown): v is HivePostureConsensus {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.preset === "string" &&
+    PRESETS.includes(o.preset as GoldenTrianglePreset) &&
+    typeof o.qualityWeight === "number" &&
+    typeof o.costWeight === "number" &&
+    typeof o.timeWeight === "number" &&
+    typeof o.peerCount === "number" &&
+    typeof o.confidence === "number"
+  );
+}
+
+/**
+ * Read the hive-suggested posture consensus (the federated ingest writes it here).
+ * Returns null until a federation supplies peer postures. Fail-open. This is a
+ * SUGGESTION only — it never enters the resolution chain (org → platform →
+ * Balanced); the priority surface may show it as "recommended by N peers."
+ */
+export async function getHivePostureSuggestion(db?: HiveSuggestionClient): Promise<HivePostureConsensus | null> {
+  const client = db ?? (prisma as unknown as HiveSuggestionClient);
+  try {
+    const row = await client.decisionPerspectiveProfile.findFirst({
+      where: { profileId: PLATFORM_PROFILE_ID },
+      select: { autonomyPolicy: true },
+    });
+    const v = asRecord(row?.autonomyPolicy).hiveDefaultSuggestion;
+    return isConsensus(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a freshly-aggregated consensus for the suggestion surface. This is the
+ * step the federated ingest calls once it has peer postures (aggregate → store).
+ * Merge-preserving + fail-open, mirroring the posture persistence pattern.
+ */
+export async function storeHivePostureSuggestion(
+  consensus: HivePostureConsensus,
+  db?: HiveSuggestionClient,
+): Promise<boolean> {
+  const client = db ?? (prisma as unknown as HiveSuggestionClient);
+  try {
+    const row = await client.decisionPerspectiveProfile.findFirst({
+      where: { profileId: PLATFORM_PROFILE_ID },
+      select: { autonomyPolicy: true },
+    });
+    const nextPolicy = { ...asRecord(row?.autonomyPolicy), hiveDefaultSuggestion: consensus };
+    const res = await client.decisionPerspectiveProfile.updateMany({
+      where: { profileId: PLATFORM_PROFILE_ID },
+      data: { autonomyPolicy: nextPolicy },
+    });
+    return res.count > 0;
+  } catch {
+    return false;
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,6 +18,7 @@
     "./discovery-collectors-snmp": "./src/discovery-collectors/snmp.ts",
     "./discovery-collectors-unifi": "./src/discovery-collectors/unifi.ts",
     "./local-model-capabilities": "./src/local-model-capabilities.ts",
+    "./hive-contribution-settings": "./src/hive-contribution-settings.ts",
     "./location-normalize": "./src/location-normalize.ts",
     "./eu-jurisdictions": "./src/eu-jurisdictions.ts",
     "./sovereignty-assessment": "./src/sovereignty-assessment.ts",


### PR DESCRIPTION
**Slice 7 — federated hive contribution of posture defaults** (`BI-6E01FE69`). The final slice. Additive, fail-closed, migration-free.

A learned posture default is a **platform learning** (the WWWD lane of the Learning Commons), so it rides the **existing `"improvement"` contribution type** through the one consent gate and the one ledger — **no new substrate, no schema change**. What leaves the install is only the **anonymized posture** (preset + weights); never an org id, name, or any identifier.

[hive.ts](apps/web/lib/golden-triangle/hive.ts):
- **`contributePostureDefault`** — consent-gated (`isContributionEnabled("improvement", …)` + master pause), **fail-closed**, pseudonymous (`getDisplayPseudonym`), records a PII-free `HiveContributionLedger` row (payload hashed).
- **`aggregatePostureContributions`** — pure: modal preset + mean axis weights + a confidence score (the first cross-org aggregator; ready for peer data).
- **`getHivePostureSuggestion` / `storeHivePostureSuggestion`** — migration-free seam on the platform profile `autonomyPolicy` JSON. A **suggestion only** — never enters the resolution chain (org → platform → Balanced).

Contribution is an **explicit, `view_platform`-gated action** (`contributeGoldenTrianglePostureToHive`), **not automatic on save** — sharing a default is a privacy decision left deliberate. The cross-install transport + live peer ingest is hive-network infrastructure external to a single install; `getHivePostureSuggestion` returns null until a federation supplies postures.

Also adds the `@dpf/db/hive-contribution-settings` subpath export so the pure consent/ledger helpers resolve under both the Next build and vitest. **8 hive tests; 95 golden-triangle tests green; full `tsc` clean.**

**This completes the Golden Triangle — all 7 slices shipped.**

Process-Spine-Decision: doc-specced (design "Slice 7: federated hive"); additive, fail-closed, migration-free, dormant until federation + explicit opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
