### PR TITLE
fix(build-studio): null-guard reusabilityAnalysis in design review prompt (BI-699EA362)

### DIFF
--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -33,6 +33,33 @@ describe("buildDesignReviewPrompt", () => {
     expect(prompt).toContain("JSON FORMAT");
   });
 
+  // BI-699EA362 — reviewDesignDoc crashed with "Cannot read properties of
+  // undefined (reading 'map')" when the loosely-typed designDoc JSON carried a
+  // reusabilityAnalysis that was a string, or an object missing its
+  // domainEntities array (an operator-saved / migrated / partial doc — the exact
+  // shape that wedged FB-8F8E2CE6 in ideate). The prompt builder must degrade
+  // gracefully instead of throwing and leaving the build with no review verdict.
+  it("does not throw and degrades gracefully when reusabilityAnalysis is malformed (BI-699EA362)", () => {
+    // Object present but missing the domainEntities array -> Entities=none.
+    const objPrompt = buildDesignReviewPrompt({
+      problemStatement: "x",
+      proposedApproach: "y",
+      acceptanceCriteria: ["z"],
+      reusabilityAnalysis: { scope: "parameterizable" } as never,
+    }, "ctx");
+    expect(objPrompt).toContain("Entities=none");
+
+    // reusabilityAnalysis stored as a bare string -> section omitted, no crash.
+    const strPrompt = buildDesignReviewPrompt({
+      problemStatement: "x",
+      proposedApproach: "y",
+      acceptanceCriteria: ["z"],
+      reusabilityAnalysis: "parameterizable" as never,
+    }, "ctx");
+    expect(strPrompt).toContain("JSON FORMAT");
+    expect(strPrompt).not.toContain("Reusability Analysis");
+  });
+
   it("gates on whole-outcome alignment per the Optimize for the Whole commandment", () => {
     const prompt = buildDesignReviewPrompt({
       problemStatement: "Users need filtering",

--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -16,7 +16,7 @@ import {
   mapCompactSummaryToBuildEntry,
   type ReviewBranchInput,
 } from "./build-reviewers";
-import type { ReviewResult } from "@/lib/feature-build-types";
+import type { ReviewResult, BuildDesignDoc } from "@/lib/feature-build-types";
 
 describe("buildDesignReviewPrompt", () => {
   it("includes all design doc sections", () => {
@@ -45,8 +45,8 @@ describe("buildDesignReviewPrompt", () => {
       problemStatement: "x",
       proposedApproach: "y",
       acceptanceCriteria: ["z"],
-      reusabilityAnalysis: { scope: "parameterizable" } as never,
-    }, "ctx");
+      reusabilityAnalysis: { scope: "parameterizable" },
+    } as unknown as BuildDesignDoc, "ctx");
     expect(objPrompt).toContain("Entities=none");
 
     // reusabilityAnalysis stored as a bare string -> section omitted, no crash.
@@ -54,8 +54,8 @@ describe("buildDesignReviewPrompt", () => {
       problemStatement: "x",
       proposedApproach: "y",
       acceptanceCriteria: ["z"],
-      reusabilityAnalysis: "parameterizable" as never,
-    }, "ctx");
+      reusabilityAnalysis: "parameterizable",
+    } as unknown as BuildDesignDoc, "ctx");
     expect(strPrompt).toContain("JSON FORMAT");
     expect(strPrompt).not.toContain("Reusability Analysis");
   });

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -53,7 +53,7 @@ export function buildDesignReviewPrompt(
   // The value is read from a JSON column (`build.designDoc as unknown as
   // BuildDesignDoc`), so its real runtime shape is unknown — model that here so
   // every guard below is genuinely load-bearing rather than `unknown`-narrowed.
-  const ra = doc.reusabilityAnalysis as
+  const ra = doc.reusabilityAnalysis as unknown as
     | {
         scope?: string;
         domainEntities?: ReadonlyArray<{ hardcodedValue?: string; parameterName?: string }>;

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -44,6 +44,34 @@ export function buildDesignReviewPrompt(
     ? `\n\nPRIOR REVIEW CONTEXT (this is review round ${prior.round + 1}):\nThe immediately-prior review of this design surfaced these ${prior.issues.length} issues:\n${prior.issues.map((i, idx) => `  ${idx + 1}. [${i.severity}] ${i.description}`).join("\n")}\n\nDelta-aware review protocol:\n- For each prior issue, judge whether the new design addresses it. If yes, do NOT re-surface it.\n- If a prior issue is still present, re-surface it but reuse the SAME description so the operator sees persistence.\n- Only add NEW issues that this revision genuinely introduces or that the prior round missed.\n- Goal: convergence, not re-litigation. Avoid trading one set of issues for another.\n`
     : "";
 
+  // BI-699EA362 — null-guard the reusabilityAnalysis section. designDoc comes
+  // from a loosely-typed JSON column, so reusabilityAnalysis can be a string or
+  // an object missing its domainEntities array (an operator-saved, migrated, or
+  // partial doc). Mapping domainEntities unguarded threw "Cannot read properties
+  // of undefined (reading 'map')"; executeTool swallowed it, so reviewDesignDoc
+  // persisted no verdict and the build wedged in ideate with a watchdog stall.
+  // The value is read from a JSON column (`build.designDoc as unknown as
+  // BuildDesignDoc`), so its real runtime shape is unknown — model that here so
+  // every guard below is genuinely load-bearing rather than `unknown`-narrowed.
+  const ra = doc.reusabilityAnalysis as
+    | {
+        scope?: string;
+        domainEntities?: ReadonlyArray<{ hardcodedValue?: string; parameterName?: string }>;
+        abstractionBoundary?: string;
+        contributionReadiness?: string;
+      }
+    | string
+    | null
+    | undefined;
+  const reusabilitySection =
+    ra && typeof ra === "object"
+      ? `Reusability Analysis: Scope=${ra.scope ?? "?"}, Entities=${
+          (Array.isArray(ra.domainEntities) ? ra.domainEntities : [])
+            .map((e) => `${e.hardcodedValue ?? "?"}->${e.parameterName ?? "?"}`)
+            .join(", ") || "none"
+        }, Boundary="${ra.abstractionBoundary ?? ""}", Readiness=${ra.contributionReadiness ?? "?"}`
+      : "";
+
   return `You are reviewing a design document for a platform feature.
 
 DESIGN DOCUMENT:
@@ -53,7 +81,7 @@ Existing Code Audit: ${doc.existingCodeAudit ?? doc.existingFunctionalityAudit ?
 Reuse Plan: ${doc.reusePlan ?? "Not provided"}
 Proposed Approach: ${doc.proposedApproach ?? "Not provided"}
 Acceptance Criteria: ${Array.isArray(doc.acceptanceCriteria) ? doc.acceptanceCriteria.join("; ") : (doc.acceptanceCriteria ?? "Not specified")}
-${doc.reusabilityAnalysis ? `Reusability Analysis: Scope=${doc.reusabilityAnalysis.scope}, Entities=${doc.reusabilityAnalysis.domainEntities.map((e) => `${e.hardcodedValue}->${e.parameterName}`).join(", ") || "none"}, Boundary="${doc.reusabilityAnalysis.abstractionBoundary}", Readiness=${doc.reusabilityAnalysis.contributionReadiness}` : ""}
+${reusabilitySection}
 ${(doc as { accessibility?: string }).accessibility ? `Accessibility: ${(doc as { accessibility?: string }).accessibility}` : ""}
 
 PROJECT CONTEXT:


### PR DESCRIPTION
## What

`reviewDesignDoc` threw `Cannot read properties of undefined (reading 'map')` and the exception was swallowed by `executeTool`, so **no `designReview` persisted and the build wedged in ideate behind a watchdog stall** (observed driving FB-8F8E2CE6 during the Build Studio overseer work).

Root cause: `buildDesignReviewPrompt` ([build-reviewers.ts](apps/web/lib/integrate/build-reviewers.ts)) mapped `doc.reusabilityAnalysis.domainEntities` with no null-guard. `designDoc` is a loosely-typed JSON column, so `reusabilityAnalysis` can legitimately be a bare string or an object missing `domainEntities` (an operator-saved, migrated, or partial doc).

## Fix

- Guard `domainEntities` with `Array.isArray` and omit the section entirely for non-object values.
- Model the column's real loose shape (`as unknown as …`) so every guard is load-bearing (and lint-clean).
- Regression test feeding both malformed shapes (object-missing-`domainEntities`, and a bare string).

## Why direct (not Build Studio)

This is a Build Studio engine reliability bug that *prevents* Build Studio from completing builds — it can't fix itself out of it (same precedent as #2285). Filed as **BI-699EA362**; this is the fix.

## Verification

Source-only worktree (no `node_modules`) → typecheck/vitest are CI-gated. The change is a small, type-reasoned null-guard with a regression test. Not UI-impacting (prompt-string builder), so no UX-Fit gate applies.

Part of the "make Build Studio solid" thread; the larger reliability gap (stall + no-auto-recovery + re-dispatch) is tracked separately as BI-DCC660A8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
