### PR TITLE
feat(assurance): P2.2 live WWMD merge gate (DARK) — escalate-only until actuation enabled (BI-204EE70B)

### DIFF
--- a/apps/web/lib/assurance/remediation-merge-live.test.ts
+++ b/apps/web/lib/assurance/remediation-merge-live.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLiveMergeGateAdapters,
+  mapMergeStateToReadiness,
+  parseRemediationVersions,
+} from "./remediation-merge-live";
+
+describe("mapMergeStateToReadiness", () => {
+  it("treats only 'clean' as green and 'dirty' as a conflict", () => {
+    expect(mapMergeStateToReadiness("clean")).toEqual({ ciGreen: true, hasConflict: false });
+    expect(mapMergeStateToReadiness("CLEAN")).toEqual({ ciGreen: true, hasConflict: false });
+    expect(mapMergeStateToReadiness("dirty")).toEqual({ ciGreen: false, hasConflict: true });
+  });
+
+  it("escalates every other state (not green, not conflict)", () => {
+    for (const s of ["blocked", "unstable", "behind", "has_hooks", "unknown", null]) {
+      expect(mapMergeStateToReadiness(s)).toEqual({ ciGreen: false, hasConflict: false });
+    }
+  });
+});
+
+describe("parseRemediationVersions", () => {
+  it("extracts from/to from an auto-filed remediation body", () => {
+    expect(
+      parseRemediationVersions("Severity: HIGH\nObserved: hono@4.12.19\nPatched: >=4.12.25\n[origin:assuranceFinding:fk]"),
+    ).toEqual({ from: "4.12.19", to: "4.12.25" });
+  });
+
+  it("handles scoped package names and bare patched versions", () => {
+    expect(parseRemediationVersions("Observed: @babel/core@7.29.0\nPatched: 7.29.6")).toEqual({
+      from: "7.29.0",
+      to: "7.29.6",
+    });
+  });
+
+  it("returns nulls when the markers are absent", () => {
+    expect(parseRemediationVersions("no version lines here")).toEqual({ from: null, to: null });
+    expect(parseRemediationVersions(null)).toEqual({ from: null, to: null });
+  });
+});
+
+describe("createLiveMergeGateAdapters.listReadyRemediationPRs", () => {
+  function prismaWith(bis: unknown[], capsules: unknown[], builds: unknown[]) {
+    return {
+      backlogItem: { findMany: async () => bis },
+      workCapsule: { findMany: async () => capsules },
+      featureBuild: { findMany: async () => builds },
+    };
+  }
+
+  it("joins assurance BIs → build → capsule PR into ready PRs", async () => {
+    const prisma = prismaWith(
+      [{ itemId: "BI-1", title: "Remediate hono", body: "Observed: hono@4.12.19\nPatched: >=4.12.25\n[origin:assuranceFinding:fk]", activeBuildId: "cuid-b1" }],
+      [{ featureBuildId: "cuid-b1", pullRequestNumber: 123, pullRequestUrl: "https://gh/pr/123" }],
+      [{ id: "cuid-b1", buildId: "FB-1" }],
+    );
+    const adapters = await createLiveMergeGateAdapters({ prisma: prisma as never, actuationEnabled: false });
+    expect(await adapters.listReadyRemediationPRs()).toEqual([
+      {
+        buildId: "FB-1",
+        buildPk: "cuid-b1",
+        backlogItemId: "BI-1",
+        prNumber: 123,
+        title: "Remediate hono",
+        fromVersion: "4.12.19",
+        toVersion: "4.12.25",
+      },
+    ]);
+  });
+
+  it("excludes BIs whose build has no captured PR", async () => {
+    const prisma = prismaWith(
+      [{ itemId: "BI-2", title: "x", body: "[origin:assuranceFinding:fk]", activeBuildId: "cuid-b2" }],
+      [], // no capsule PR
+      [{ id: "cuid-b2", buildId: "FB-2" }],
+    );
+    const adapters = await createLiveMergeGateAdapters({ prisma: prisma as never, actuationEnabled: false });
+    expect(await adapters.listReadyRemediationPRs()).toEqual([]);
+  });
+});
+
+describe("createLiveMergeGateAdapters.armAutoMerge", () => {
+  it("throws — actuation is not implemented (hard backstop against early enable)", async () => {
+    const prisma = {
+      backlogItem: { findMany: async () => [] },
+      workCapsule: { findMany: async () => [] },
+      featureBuild: { findMany: async () => [] },
+    };
+    const adapters = await createLiveMergeGateAdapters({ prisma: prisma as never, actuationEnabled: true });
+    await expect(
+      adapters.armAutoMerge({
+        buildId: "FB-1",
+        buildPk: "cuid-b1",
+        backlogItemId: "BI-1",
+        prNumber: 1,
+        title: "x",
+        fromVersion: "1.0.0",
+        toVersion: "1.0.1",
+      }),
+    ).rejects.toThrow(/not implemented/i);
+  });
+});

--- a/apps/web/lib/assurance/remediation-merge-live.ts
+++ b/apps/web/lib/assurance/remediation-merge-live.ts
@@ -1,0 +1,157 @@
+// apps/web/lib/assurance/remediation-merge-live.ts
+//
+// P2.2 — LIVE (dark-by-default) adapters for the WWMD merge gate
+// (remediation-merge-orchestrator.ts). Reads ready assurance-remediation PRs and
+// their GitHub readiness, runs the gate, and escalates the non-auto ones.
+//
+// SAFETY: the merge actuation is the only irreversible step and is NOT implemented
+// here — `armAutoMerge` throws. While `actuationEnabled` is false (the default),
+// the orchestrator dark-records auto-merge decisions instead of calling it, so this
+// lane does ONLY reads + escalation (filing an issue report). Enabling actuation
+// (P2.2b) MUST first implement `armAutoMerge` (GitHub GraphQL enablePullRequestAutoMerge)
+// AND wire real cooldown/OSV verifiers (see getReadiness) — verified against a real
+// remediation PR. The throw is a hard backstop against flipping the flag early.
+
+import { readGithubPullRequests } from "@/lib/contributor-change-lanes/github-rest-reader";
+import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+import { ASSURANCE_ORIGIN_MARKER } from "./remediation-teeup";
+import type { MergeGateAdapters, PrReadiness, ReadyRemediationPR } from "./remediation-merge-orchestrator";
+
+/** Map GitHub's mergeable_state to the gate's CI/conflict signals. Only "clean"
+ *  (mergeable + required checks passing) counts as green; everything else
+ *  (blocked/unstable/behind/unknown) escalates, and "dirty" is a conflict. Pure. */
+export function mapMergeStateToReadiness(mergeStateStatus: string | null): {
+  ciGreen: boolean;
+  hasConflict: boolean;
+} {
+  const s = (mergeStateStatus ?? "").toLowerCase();
+  return { ciGreen: s === "clean", hasConflict: s === "dirty" };
+}
+
+/** Extract the from/to versions from an auto-filed remediation BI body
+ *  ("Observed: pkg@X" → from; "Patched: <range>" → to). Pure; null when absent. */
+export function parseRemediationVersions(body: string | null): { from: string | null; to: string | null } {
+  const text = body ?? "";
+  const observed = /Observed:\s*\S+?@([0-9][^\s)]*)/i.exec(text);
+  const patched = /Patched:[^0-9\n]*([0-9][^\s,)]*)/i.exec(text);
+  return { from: observed?.[1] ?? null, to: patched?.[1] ?? null };
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type LiveMergeGatePrisma = {
+  backlogItem: { findMany(args: any): Promise<any[]> };
+  workCapsule: { findMany(args: any): Promise<any[]> };
+  featureBuild: { findMany(args: any): Promise<any[]> };
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export interface LiveMergeGateDeps {
+  prisma: LiveMergeGatePrisma;
+  actuationEnabled: boolean;
+  fetchImpl?: typeof fetch;
+}
+
+/** Assemble the live merge-gate adapters. armAutoMerge is intentionally a
+ *  throwing stub (see file header) — unreachable while dark. */
+export async function createLiveMergeGateAdapters(deps: LiveMergeGateDeps): Promise<MergeGateAdapters> {
+  const { prisma, actuationEnabled } = deps;
+
+  // Fetch the open-PR list once; getReadiness reads from this map.
+  let prMap: Map<number, string | null> | null = null;
+  const ensurePrMap = async (): Promise<Map<number, string | null>> => {
+    if (prMap) return prMap;
+    const map = new Map<number, string | null>();
+    const res = await readGithubPullRequests({ fetchImpl: deps.fetchImpl });
+    if (res.ok) {
+      for (const row of res.rows) {
+        const p = row.payload as { number?: number; mergeStateStatus?: string | null };
+        if (typeof p?.number === "number") map.set(p.number, p.mergeStateStatus ?? null);
+      }
+    }
+    prMap = map;
+    return map;
+  };
+
+  return {
+    actuationEnabled,
+
+    listReadyRemediationPRs: async (): Promise<ReadyRemediationPR[]> => {
+      const bis = await prisma.backlogItem.findMany({
+        where: {
+          body: { contains: ASSURANCE_ORIGIN_MARKER },
+          activeBuildId: { not: null },
+          status: { in: ["open", "in-progress"] },
+        },
+        select: { itemId: true, title: true, body: true, activeBuildId: true },
+      });
+      if (bis.length === 0) return [];
+
+      const buildPks = bis.map((b) => b.activeBuildId).filter((v): v is string => typeof v === "string");
+      const capsules = await prisma.workCapsule.findMany({
+        where: { featureBuildId: { in: buildPks }, pullRequestNumber: { not: null } },
+        select: { featureBuildId: true, pullRequestNumber: true, pullRequestUrl: true },
+      });
+      const capByBuild = new Map<string, { pullRequestNumber: number | null; pullRequestUrl: string | null }>(
+        capsules.map((c) => [c.featureBuildId as string, { pullRequestNumber: c.pullRequestNumber, pullRequestUrl: c.pullRequestUrl }]),
+      );
+      const builds = await prisma.featureBuild.findMany({
+        where: { id: { in: buildPks } },
+        select: { id: true, buildId: true },
+      });
+      const buildIdByPk = new Map<string, string>(builds.map((b) => [b.id as string, b.buildId as string]));
+
+      const out: ReadyRemediationPR[] = [];
+      for (const bi of bis) {
+        const buildPk = bi.activeBuildId as string | null;
+        if (!buildPk) continue;
+        const cap = capByBuild.get(buildPk);
+        if (!cap || typeof cap.pullRequestNumber !== "number") continue;
+        const { from, to } = parseRemediationVersions(bi.body);
+        out.push({
+          buildId: buildIdByPk.get(buildPk) ?? buildPk,
+          buildPk,
+          backlogItemId: bi.itemId,
+          prNumber: cap.pullRequestNumber,
+          title: bi.title,
+          fromVersion: from,
+          toVersion: to,
+        });
+      }
+      return out;
+    },
+
+    getReadiness: async (pr): Promise<PrReadiness> => {
+      const map = await ensurePrMap();
+      const { ciGreen, hasConflict } = mapMergeStateToReadiness(map.get(pr.prNumber) ?? null);
+      // TODO(P2.2b): wire real verifiers BEFORE enabling actuation —
+      //   cooldownMet: npm-registry release age of pr.toVersion (anti-hijack);
+      //   osvClean:    OSV query that pr.toVersion has no advisory.
+      // Until then these are optimistic; the dark gate + the armAutoMerge throw
+      // keep it from merging anything.
+      return { ciGreen, hasConflict, cooldownMet: true, osvClean: true };
+    },
+
+    armAutoMerge: async (): Promise<void> => {
+      throw new Error(
+        "assurance auto-merge actuation not implemented (P2.2b) — implement GitHub auto-merge + cooldown/OSV verifiers and verify against a real PR before enabling DPF_ASSURANCE_AUTOMERGE_ENABLED",
+      );
+    },
+
+    escalate: async (pr, reason): Promise<void> => {
+      await createPlatformIssueReport({
+        type: "build-stall-escalation",
+        source: "build-studio",
+        severity: "high",
+        title: `Assurance remediation needs a human merge decision: PR #${pr.prNumber}`,
+        description:
+          `Remediation PR #${pr.prNumber} ("${pr.title}") for ${pr.backlogItemId} was NOT auto-merged by the ` +
+          `assurance merge gate.\n\nReason: ${reason}\n\nDecide the merge manually. ` +
+          `(Assurance remediation lane P2 — WWMD patch-only-auto gate, BI-204EE70B.)`,
+        featureBuildId: pr.buildPk,
+        triggerKind: "assurance-remediation-merge-gate",
+        dedupeKey: `assurance-merge-escalation:${pr.prNumber}`,
+        selfFixClass: "needs-human",
+      });
+    },
+  };
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -291,6 +291,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "assurance-merge-gate",
+    inngestId: "assurance/merge-gate-scheduled",
+    name: "Assurance merge gate",
+    purpose:
+      "Off-hours WWMD-gated merge decision for assurance remediation PRs (patch-only-auto): escalates non-auto PRs to a human. Auto-merge actuation is dark (DPF_ASSURANCE_AUTOMERGE_ENABLED, default off). If it stops, remediation PRs await manual merge.",
+    cron: "47 * * * *",
+    cadence: "Hourly at :47 — acts only in the 02:00–06:00 UTC off-hours window",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "material-freshness-decay",
     inngestId: "decision/material-freshness-decay",
     name: "Material freshness decay",

--- a/apps/web/lib/queue/functions/assurance-merge-gate-teeup.ts
+++ b/apps/web/lib/queue/functions/assurance-merge-gate-teeup.ts
@@ -1,0 +1,45 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+// Assurance remediation lane P2.2 (BI-204EE70B) — the WWMD merge gate, running
+// LIVE but DARK by default. Off-hours, budget-capped: it reads ready remediation
+// PRs, runs each through the patch-only-auto gate, and ESCALATES the non-auto ones
+// (files an issue report). It does NOT merge: auto-merge actuation is gated behind
+// `DPF_ASSURANCE_AUTOMERGE_ENABLED` (default off) AND the armAutoMerge adapter is a
+// throwing stub until P2.2b implements it + the cooldown/OSV verifiers and verifies
+// against a real PR. So while dark this lane does only reads + escalation.
+//
+// Cron :47 (a free minute, off the contention ticks); only acts in the 02:00–06:00
+// UTC off-hours window (shared with the P1 promote lane).
+export const assuranceMergeGateScheduled = inngest.createFunction(
+  {
+    id: "assurance/merge-gate-scheduled",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("47 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("assurance-merge-gate", async () => {
+      const { prisma } = await import("@dpf/db");
+      const { isAssuranceRemediationWindowOpen, resolveRemediationBudget } = await import(
+        "@/lib/assurance/remediation-teeup"
+      );
+      const { runRemediationMergeGate } = await import("@/lib/assurance/remediation-merge-orchestrator");
+      const { createLiveMergeGateAdapters } = await import("@/lib/assurance/remediation-merge-live");
+      const { envFlagEnabled } = await import("@/lib/runtime/env-flags");
+
+      const now = new Date();
+      if (!isAssuranceRemediationWindowOpen(now)) {
+        return { skipped: true, reason: "outside-off-hours-window" };
+      }
+
+      const actuationEnabled = envFlagEnabled(process.env, "DPF_ASSURANCE_AUTOMERGE_ENABLED");
+      const adapters = await createLiveMergeGateAdapters({ prisma, actuationEnabled });
+      return runRemediationMergeGate({ adapters, budget: resolveRemediationBudget() });
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -26,6 +26,7 @@ import {
   governedBacklogTeeUpScheduled,
 } from "./governed-backlog-tee-up";
 import { assuranceRemediationTeeUpScheduled } from "./assurance-remediation-teeup";
+import { assuranceMergeGateScheduled } from "./assurance-merge-gate-teeup";
 import { tokenExpiryMonitor } from "./token-expiry-monitor";
 import {
   contributorInventorySyncCron,
@@ -70,6 +71,7 @@ export const scheduledFunctions = [
   taskrunWatchdog,
   governedBacklogTeeUpScheduled,
   assuranceRemediationTeeUpScheduled, // BI-7C121CCF: off-hours, budget-capped assurance remediation lane
+  assuranceMergeGateScheduled, // BI-204EE70B P2.2: WWMD merge gate (dark — escalate-only until actuation enabled)
   tokenExpiryMonitor,
   contributorInventorySyncCron,
   wikiLint,

--- a/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
@@ -75,13 +75,23 @@ escalate-on-uncertain) + test; `apps/web/lib/assurance/remediation-merge-orchest
 **dark-launch** `actuationEnabled` gate — an auto-merge is decided-but-not-actuated
 until enabled) + test.
 
-**Staged — live actuation (P2.2, dark-by-default):** the live GitHub adapters
-(read PR checks/mergeability via the existing github-rest reader; classify the bump
-from the PR diff; arm auto-merge) + the off-hours scheduled job + the escalation
-adapter (`createPlatformIssueReport`). Built once P1 has produced a real
-remediation PR to verify against; ships with `actuationEnabled=false` so the gate
-runs observably (escalates + dark-records) before it merges anything autonomously.
-This is the most irreversible step in the loop — it does not blind-launch.
+**Implemented — live merge gate, DARK (P2.2):**
+`apps/web/lib/assurance/remediation-merge-live.ts` (`mapMergeStateToReadiness` +
+`parseRemediationVersions` pure mappers + `createLiveMergeGateAdapters`: lists ready
+remediation PRs from assurance-origin BIs → build → capsule PR, reads GitHub
+mergeability via the existing `readGithubPullRequests`, escalates via
+`createPlatformIssueReport`) + the off-hours scheduled fn
+`queue/functions/assurance-merge-gate-teeup.ts` (cron `47 * * * *`, 02:00–06:00 UTC,
+`gateAtEntry`, budget) + catalog entry + tests. Ships **DARK**: `actuationEnabled`
+reads `DPF_ASSURANCE_AUTOMERGE_ENABLED` (default off) and `armAutoMerge` is a
+throwing stub — so while dark the lane does ONLY reads + escalation (zero
+irreversible action; the orchestrator dark-records the auto-merge decisions).
+
+**Staged — actuation enable (P2.2b):** implement `armAutoMerge` (GitHub GraphQL
+`enablePullRequestAutoMerge`) AND wire the real `cooldownMet` (npm release-age) +
+`osvClean` (OSV) verifiers in `getReadiness` (currently optimistic), verify against a
+real P1-produced remediation PR, THEN flip the flag. The most irreversible step in
+the loop — it does not blind-launch.
 
 ## Phase 3 — close the loop (BI-4D5C702F)
 


### PR DESCRIPTION
## Why
P2.2 — the live actuation for the P2 WWMD merge gate, running **DARK by default**. The decision engine (patch-only-auto) shipped in #2307; this wires it to live adapters + an off-hours scheduled job so it runs against real remediation PRs — but **merges nothing** until explicitly enabled + verified.

## What
- `remediation-merge-live.ts` — pure mappers (`mapMergeStateToReadiness`, `parseRemediationVersions`, tested) + `createLiveMergeGateAdapters`: lists ready remediation PRs (assurance-origin BIs → build → capsule PR), reads GitHub mergeability via the existing `readGithubPullRequests`, escalates non-auto PRs via `createPlatformIssueReport`.
- `assurance-merge-gate-teeup.ts` — off-hours (cron `47 * * * *`, 02:00–06:00 UTC), budget-capped, governed, quiescence-gated scheduled fn. Registered in `queue/functions/index.ts` + the scheduled-jobs catalog (parity test).

## Safety — two layers, nothing merges
1. `actuationEnabled` reads `DPF_ASSURANCE_AUTOMERGE_ENABLED` (**default off**) → the orchestrator **dark-records** auto-merge decisions instead of arming.
2. `armAutoMerge` is a **throwing stub** — even if the flag were flipped, it cannot merge.

So while dark this lane does only **reads + escalation** (zero irreversible action): it escalates non-auto remediation PRs to a human and dark-records the patch candidates.

## Staged — actuation enable (P2.2b, NOT in this PR)
Implement `armAutoMerge` (GitHub GraphQL `enablePullRequestAutoMerge`) + the real `cooldownMet` (npm release-age) + `osvClean` (OSV) verifiers in `getReadiness` (currently optimistic), **verify against a real P1-produced remediation PR**, then flip the flag.

## Verification
Tests: merge-state→readiness mapping, version parsing, the ready-PR join (fake prisma), and the armAutoMerge throw. Worktree has no node_modules → CI runs the full suite + typecheck + catalog parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)