### PR TITLE
fix(golden-triangle): surface Priority in AI Operations nav + link to Outcomes

### DIFF
--- a/apps/web/app/(shell)/platform/ai/priority/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/priority/page.tsx
@@ -3,6 +3,8 @@
 // A non-technical operator sets a Cost / Quality / Time posture; the platform
 // compiles it into model tier, effort, verification, and retries. Seeds from the
 // saved WWMD/platform default (migration-free, on the platform profile).
+import Link from "next/link";
+
 import { GoldenTrianglePriorityPanel } from "@/components/golden-triangle/GoldenTrianglePriorityPanel";
 import { getGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
 
@@ -10,13 +12,21 @@ export default async function GoldenTrianglePriorityPage() {
   const saved = await getGoldenTrianglePosture({ kind: "platform" });
   return (
     <div>
-      <div style={{ marginBottom: 16 }}>
-        <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>Priority</h1>
-        <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2 }}>
-          Set the Cost / Quality / Time priority for AI work. Pick a preset or fine-tune the triangle — the
-          platform compiles it into the right model, effort, and verification, and shows in plain language
-          exactly what it configured. Save it as the platform default for new work.
-        </p>
+      <div style={{ marginBottom: 16, display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
+        <div>
+          <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>Priority</h1>
+          <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2 }}>
+            Set the Cost / Quality / Time priority for AI work. Pick a preset or fine-tune the triangle — the
+            platform compiles it into the right model, effort, and verification, and shows in plain language
+            exactly what it configured. Save it as the platform default for new work.
+          </p>
+        </div>
+        <Link
+          href="/platform/ai/priority/outcomes"
+          style={{ flex: "0 0 auto", fontSize: 12, color: "var(--dpf-accent)", whiteSpace: "nowrap", marginTop: 2 }}
+        >
+          See outcomes →
+        </Link>
       </div>
       <GoldenTrianglePriorityPanel initial={saved ?? undefined} />
     </div>

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -54,6 +54,9 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
     matchPrefixes: ["/platform/ai"],
     subItems: [
       { label: "Overview", href: "/platform/ai" },
+      // EP-GOLDEN-TRIANGLE: the Cost/Quality/Time priority surface. Without this
+      // tab the page was reachable only by typing /platform/ai/priority.
+      { label: "Priority", href: "/platform/ai/priority" },
       { label: "Operations Map", href: "/platform/ai/operations-map" },
       { label: "Capacity Continuity", href: "/platform/ai/capacity-continuity" },
       { label: "Assignments", href: "/platform/ai/assignments" },

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -562,6 +562,16 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     capabilityKey: "view_platform",
   },
   {
+    key: "platform-ai-priority",
+    label: "Priority",
+    path: "/platform/ai/priority",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
     key: "platform-ai-capacity-continuity",
     label: "Capacity Continuity",
     path: "/platform/ai/capacity-continuity",


### PR DESCRIPTION
**Discoverability fix.** The Golden Triangle priority control (`/platform/ai/priority`) shipped in Slice 2/4 but **no nav tab pointed to it** — it was reachable only by typing the URL. That's the "where do I set this?" gap.

- Adds a **Priority** tab under **Platform → AI Operations** (right after Overview). Its active state covers both `/priority` and `/priority/outcomes` (startsWith).
- Adds a **"See outcomes →"** link on the priority page so the read-only Outcomes view is reachable.

The page itself already persists (Slice 4 — loads the saved platform default + Save button), so once found it works end-to-end. No new route/module; nav data + one link.

Process-Spine-Decision: discoverability fix for a shipped surface.
UX-Fit-Decision: one secondary-nav tab within an existing family (no cross-section teleport) + an in-page link; reuses existing styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
