### PR TITLE
feat(golden-triangle): make the coworker priority chip persist (load + save)

### DIFF
--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -6,6 +6,13 @@ vi.mock("./AgentSkillsDropdown", () => ({
   AgentSkillsDropdown: () => <span>Skills</span>,
 }));
 
+// The coworker priority chip now loads/saves the platform default via server
+// actions; stub them so this header render test doesn't pull server-only modules.
+vi.mock("@/lib/actions/golden-triangle", () => ({
+  getGoldenTrianglePlatformDefault: async () => null,
+  saveGoldenTrianglePlatformDefault: async () => ({ ok: true }),
+}));
+
 const baseProps = {
   agent: {
     agentId: "agent-1",

--- a/apps/web/components/golden-triangle/CoworkerPriorityControl.test.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityControl.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import "./test-setup";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDefault = vi.fn();
+const saveDefault = vi.fn();
+
+vi.mock("@/lib/actions/golden-triangle", () => ({
+  getGoldenTrianglePlatformDefault: () => getDefault(),
+  saveGoldenTrianglePlatformDefault: (p: unknown) => saveDefault(p),
+}));
+
+import { CoworkerPriorityControl } from "./CoworkerPriorityControl";
+
+describe("CoworkerPriorityControl", () => {
+  beforeEach(() => {
+    getDefault.mockReset();
+    saveDefault.mockReset();
+  });
+
+  it("reflects the saved platform default once it loads", async () => {
+    getDefault.mockResolvedValueOnce({ preset: "frugal", qualityWeight: 0.1, costWeight: 0.8, timeWeight: 0.1 });
+    render(<CoworkerPriorityControl />);
+    await waitFor(() => expect(screen.getByText(/Priority: Frugal/)).toBeTruthy());
+  });
+
+  it("falls back to Balanced when nothing is saved", async () => {
+    getDefault.mockResolvedValueOnce(null);
+    render(<CoworkerPriorityControl />);
+    await waitFor(() => expect(getDefault).toHaveBeenCalled());
+    expect(screen.getByText(/Priority: Balanced/)).toBeTruthy();
+  });
+
+  it("saves the posture as the platform default and confirms", async () => {
+    getDefault.mockResolvedValueOnce(null);
+    saveDefault.mockResolvedValueOnce({ ok: true });
+    render(<CoworkerPriorityControl />);
+    await waitFor(() => expect(getDefault).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: /Priority:/ }));
+    fireEvent.click(screen.getByText("Save as default"));
+    await waitFor(() => expect(saveDefault).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText("Saved")).toBeTruthy());
+  });
+
+  it("shows a failure note when the save is rejected (e.g. non-admin)", async () => {
+    getDefault.mockResolvedValueOnce(null);
+    saveDefault.mockRejectedValueOnce(new Error("Unauthorized"));
+    render(<CoworkerPriorityControl />);
+    await waitFor(() => expect(getDefault).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: /Priority:/ }));
+    fireEvent.click(screen.getByText("Save as default"));
+    await waitFor(() => expect(screen.getByText(/Couldn’t save/)).toBeTruthy());
+  });
+});

--- a/apps/web/components/golden-triangle/CoworkerPriorityControl.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityControl.tsx
@@ -1,11 +1,15 @@
 "use client";
-// EP-GOLDEN-TRIANGLE Slice 2 — a small, self-contained posture area for the AI
-// coworker dialog header. A balance-coloured chip (green centred → yellow → red
-// as axes get starved) opens the compact control. View-local state for now;
-// per-coworker persistence wires in with Slice 4.
-import { useState } from "react";
+// EP-GOLDEN-TRIANGLE Slice 2/4 — a small posture area for the AI coworker header.
+// A balance-coloured chip (green centred → yellow → red as axes get starved) opens
+// the compact control. It LOADS the saved platform (WWMD) default so the chip shows
+// what actually governs AI work, and SAVES edits back via the same server action as
+// the /platform/ai/priority page — so the two surfaces stay in sync. Saving is
+// view_platform-gated server-side; a non-admin simply sees "Couldn't save".
+import { useEffect, useState } from "react";
 
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import { getGoldenTrianglePlatformDefault, saveGoldenTrianglePlatformDefault } from "@/lib/actions/golden-triangle";
 
 import { GoldenTriangleControl } from "./GoldenTriangleControl";
 import { PRESET_META, balanceState, preferenceFromPreset } from "./posture-display";
@@ -13,10 +17,43 @@ import { PRESET_META, balanceState, preferenceFromPreset } from "./posture-displ
 export function CoworkerPriorityControl() {
   const [open, setOpen] = useState(false);
   const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
+  const [saved, setSaved] = useState<"idle" | "saved" | "error">("idle");
+  const [pending, setPending] = useState(false);
+
+  // Reflect the active platform default (fail-open: stay on Balanced if it can't load).
+  useEffect(() => {
+    let alive = true;
+    getGoldenTrianglePlatformDefault()
+      .then((p) => {
+        if (alive && p) setPref(p);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   const balance = balanceState(pref.qualityWeight, pref.costWeight, pref.timeWeight);
   const activeLabel = pref.preset === "custom" ? "Custom" : PRESET_META[pref.preset].label;
   const color = `var(${balance.token})`;
+
+  function onChange(next: GoldenTrianglePreference) {
+    setPref(next);
+    setSaved("idle");
+  }
+
+  async function save() {
+    setPending(true);
+    setSaved("idle");
+    try {
+      const res = await saveGoldenTrianglePlatformDefault(pref);
+      setSaved(res.ok ? "saved" : "error");
+    } catch {
+      setSaved("error");
+    } finally {
+      setPending(false);
+    }
+  }
 
   return (
     <div style={{ position: "relative" }} onMouseDown={(e) => e.stopPropagation()}>
@@ -28,7 +65,7 @@ export function CoworkerPriorityControl() {
         }}
         aria-expanded={open}
         aria-haspopup="dialog"
-        title={`Priority: ${activeLabel} — ${balance.label}. Click to balance cost, quality and time for this coworker.`}
+        title={`Priority for AI work: ${activeLabel} — ${balance.label}. Click to balance cost, quality and time.`}
         style={{
           display: "inline-flex",
           alignItems: "center",
@@ -70,11 +107,33 @@ export function CoworkerPriorityControl() {
         >
           <GoldenTriangleControl
             value={pref}
-            onChange={setPref}
+            onChange={onChange}
             compact
             taskClass="conversation"
-            authorityScopeKind="wwwd"
+            authorityScopeKind="wwmd"
           />
+          <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "0 12px 12px" }}>
+            <button
+              type="button"
+              onClick={save}
+              disabled={pending}
+              style={{
+                fontSize: 12,
+                fontWeight: 500,
+                color: "var(--dpf-text)",
+                background: "var(--dpf-surface-2)",
+                border: "1px solid var(--dpf-border)",
+                borderRadius: 6,
+                padding: "4px 10px",
+                cursor: pending ? "default" : "pointer",
+                opacity: pending ? 0.5 : 1,
+              }}
+            >
+              {pending ? "Saving…" : "Save as default"}
+            </button>
+            {saved === "saved" && <span style={{ fontSize: 11, color: "var(--dpf-success)" }}>Saved</span>}
+            {saved === "error" && <span style={{ fontSize: 11, color: "var(--dpf-error)" }}>Couldn’t save</span>}
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/lib/actions/golden-triangle.ts
+++ b/apps/web/lib/actions/golden-triangle.ts
@@ -13,7 +13,24 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 import { contributePostureDefault } from "@/lib/golden-triangle/hive";
-import { getEffectiveGoldenTrianglePosture, setGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
+import {
+  getEffectiveGoldenTrianglePosture,
+  getGoldenTrianglePosture,
+  setGoldenTrianglePosture,
+} from "@/lib/golden-triangle/persistence";
+
+/**
+ * Read the saved platform (WWMD) default so a client surface (e.g. the coworker
+ * header chip) can reflect what actually governs AI work. Read-only and only
+ * requires a session — any signed-in user may SEE the active priority; changing
+ * it stays gated by `view_platform` on the save actions. Returns null when unset
+ * (the caller shows Balanced).
+ */
+export async function getGoldenTrianglePlatformDefault(): Promise<GoldenTrianglePreference | null> {
+  const session = await auth();
+  if (!session?.user) return null;
+  return getGoldenTrianglePosture({ kind: "platform" });
+}
 
 async function requirePlatformAdmin() {
   const session = await auth();


### PR DESCRIPTION
**Makes the coworker priority chip real.** It was view-local — always showed "Balanced" and edits never persisted (the "persistence wires in with Slice 4" TODO that landed for the page but not the chip). Now:

- **Loads** the saved platform (WWMD) default on mount, so the chip reflects what actually governs AI work.
- **Saves** edits via the same `saveGoldenTrianglePlatformDefault` action as `/platform/ai/priority` — the two surfaces stay in sync.
- Adds a read-only `getGoldenTrianglePlatformDefault` action (session-gated; saving stays `view_platform`-gated — a non-admin sees "Couldn't save").
- Honest title: **"Priority for AI work"** (per-coworker isn't a v1 scope).

4 new chip tests (load / fallback / save / failure); the header render test stubs the actions so it doesn't pull server-only modules under jsdom. **99 golden-triangle tests green; `tsc` clean.**

Process-Spine-Decision: completes the Slice 4 chip-persistence TODO; reuses the existing save action + persistence.
UX-Fit-Decision: chip reflects real state + gains a Save affordance in its existing popover; reuses the page's pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
