### PR TITLE
feat(assurance): P2.2b actuation — real GitHub auto-merge + cooldown/OSV verifiers (flag still off) (BI-204EE70B)

### DIFF
--- a/apps/web/lib/assurance/remediation-merge-live.test.ts
+++ b/apps/web/lib/assurance/remediation-merge-live.test.ts
@@ -1,59 +1,111 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  ASSURANCE_REMEDIATION_COOLDOWN_DAYS,
   createLiveMergeGateAdapters,
+  fetchOsvClean,
+  fetchReleaseCooldownMet,
+  isReleaseAgedEnough,
   mapMergeStateToReadiness,
+  osvBatchClean,
+  parseObservedPackage,
   parseRemediationVersions,
 } from "./remediation-merge-live";
+
+function okJson(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
 
 describe("mapMergeStateToReadiness", () => {
   it("treats only 'clean' as green and 'dirty' as a conflict", () => {
     expect(mapMergeStateToReadiness("clean")).toEqual({ ciGreen: true, hasConflict: false });
-    expect(mapMergeStateToReadiness("CLEAN")).toEqual({ ciGreen: true, hasConflict: false });
     expect(mapMergeStateToReadiness("dirty")).toEqual({ ciGreen: false, hasConflict: true });
-  });
-
-  it("escalates every other state (not green, not conflict)", () => {
-    for (const s of ["blocked", "unstable", "behind", "has_hooks", "unknown", null]) {
+    for (const s of ["blocked", "unstable", "behind", null]) {
       expect(mapMergeStateToReadiness(s)).toEqual({ ciGreen: false, hasConflict: false });
     }
   });
 });
 
-describe("parseRemediationVersions", () => {
-  it("extracts from/to from an auto-filed remediation body", () => {
-    expect(
-      parseRemediationVersions("Severity: HIGH\nObserved: hono@4.12.19\nPatched: >=4.12.25\n[origin:assuranceFinding:fk]"),
-    ).toEqual({ from: "4.12.19", to: "4.12.25" });
-  });
-
-  it("handles scoped package names and bare patched versions", () => {
-    expect(parseRemediationVersions("Observed: @babel/core@7.29.0\nPatched: 7.29.6")).toEqual({
-      from: "7.29.0",
-      to: "7.29.6",
+describe("parse helpers", () => {
+  it("parseRemediationVersions extracts from/to", () => {
+    expect(parseRemediationVersions("Observed: hono@4.12.19\nPatched: >=4.12.25")).toEqual({
+      from: "4.12.19",
+      to: "4.12.25",
     });
   });
 
-  it("returns nulls when the markers are absent", () => {
-    expect(parseRemediationVersions("no version lines here")).toEqual({ from: null, to: null });
-    expect(parseRemediationVersions(null)).toEqual({ from: null, to: null });
+  it("parseObservedPackage extracts the package name (incl. scope)", () => {
+    expect(parseObservedPackage("Observed: hono@4.12.19")).toBe("hono");
+    expect(parseObservedPackage("Observed: @babel/core@7.29.0")).toBe("@babel/core");
+    expect(parseObservedPackage("no observed line")).toBeNull();
+  });
+});
+
+describe("isReleaseAgedEnough", () => {
+  const now = new Date("2026-06-23T00:00:00.000Z");
+  it("is true only when the publish date is at least minDays old", () => {
+    expect(isReleaseAgedEnough("2026-06-10T00:00:00.000Z", now, ASSURANCE_REMEDIATION_COOLDOWN_DAYS)).toBe(true);
+    expect(isReleaseAgedEnough("2026-06-22T12:00:00.000Z", now, ASSURANCE_REMEDIATION_COOLDOWN_DAYS)).toBe(false);
+  });
+  it("is false for unknown/invalid dates", () => {
+    expect(isReleaseAgedEnough(null, now, 3)).toBe(false);
+    expect(isReleaseAgedEnough("not-a-date", now, 3)).toBe(false);
+  });
+});
+
+describe("osvBatchClean", () => {
+  it("is clean only when a result is present with no vulns", () => {
+    expect(osvBatchClean({ results: [{}] })).toBe(true);
+    expect(osvBatchClean({ results: [{ vulns: [] }] })).toBe(true);
+    expect(osvBatchClean({ results: [{ vulns: [{ id: "GHSA-x" }] }] })).toBe(false);
+    expect(osvBatchClean({ results: [] })).toBe(false);
+    expect(osvBatchClean({})).toBe(false);
+  });
+});
+
+describe("fetchReleaseCooldownMet", () => {
+  const now = new Date("2026-06-23T00:00:00.000Z");
+  it("returns true when the bumped version is aged past the cooldown", async () => {
+    const fetchImpl = vi.fn(async () => okJson({ time: { "4.12.25": "2026-06-01T00:00:00.000Z" } }));
+    expect(await fetchReleaseCooldownMet(fetchImpl as never, "hono", "4.12.25", now)).toBe(true);
+  });
+  it("returns false for a too-fresh release, missing inputs, or a bad response", async () => {
+    const fresh = vi.fn(async () => okJson({ time: { "4.12.25": "2026-06-22T20:00:00.000Z" } }));
+    expect(await fetchReleaseCooldownMet(fresh as never, "hono", "4.12.25", now)).toBe(false);
+    expect(await fetchReleaseCooldownMet(fresh as never, null, "4.12.25", now)).toBe(false);
+    const bad = vi.fn(async () => ({ ok: false, status: 500 }) as unknown as Response);
+    expect(await fetchReleaseCooldownMet(bad as never, "hono", "4.12.25", now)).toBe(false);
+  });
+  it("encodes scoped package names for the registry path", async () => {
+    const fetchImpl = vi.fn(async () => okJson({ time: { "7.29.6": "2026-01-01T00:00:00.000Z" } }));
+    await fetchReleaseCooldownMet(fetchImpl as never, "@babel/core", "7.29.6", now);
+    expect(fetchImpl).toHaveBeenCalledWith(expect.stringContaining("@babel%2Fcore"), expect.anything());
+  });
+});
+
+describe("fetchOsvClean", () => {
+  it("returns true when OSV reports no vulns for the bump target", async () => {
+    const fetchImpl = vi.fn(async () => okJson({ results: [{}] }));
+    expect(await fetchOsvClean(fetchImpl as never, "hono", "4.12.25")).toBe(true);
+  });
+  it("returns false when OSV reports a vuln or the request fails", async () => {
+    const vuln = vi.fn(async () => okJson({ results: [{ vulns: [{ id: "GHSA-x" }] }] }));
+    expect(await fetchOsvClean(vuln as never, "hono", "4.12.25")).toBe(false);
+    const bad = vi.fn(async () => ({ ok: false, status: 500 }) as unknown as Response);
+    expect(await fetchOsvClean(bad as never, "hono", "4.12.25")).toBe(false);
   });
 });
 
 describe("createLiveMergeGateAdapters.listReadyRemediationPRs", () => {
-  function prismaWith(bis: unknown[], capsules: unknown[], builds: unknown[]) {
-    return {
-      backlogItem: { findMany: async () => bis },
-      workCapsule: { findMany: async () => capsules },
-      featureBuild: { findMany: async () => builds },
+  it("joins assurance BIs → build → capsule PR, with the package name", async () => {
+    const prisma = {
+      backlogItem: {
+        findMany: async () => [
+          { itemId: "BI-1", title: "Remediate hono", body: "Observed: hono@4.12.19\nPatched: >=4.12.25\n[origin:assuranceFinding:fk]", activeBuildId: "cuid-b1" },
+        ],
+      },
+      workCapsule: { findMany: async () => [{ featureBuildId: "cuid-b1", pullRequestNumber: 123, pullRequestUrl: "https://gh/pr/123" }] },
+      featureBuild: { findMany: async () => [{ id: "cuid-b1", buildId: "FB-1" }] },
     };
-  }
-
-  it("joins assurance BIs → build → capsule PR into ready PRs", async () => {
-    const prisma = prismaWith(
-      [{ itemId: "BI-1", title: "Remediate hono", body: "Observed: hono@4.12.19\nPatched: >=4.12.25\n[origin:assuranceFinding:fk]", activeBuildId: "cuid-b1" }],
-      [{ featureBuildId: "cuid-b1", pullRequestNumber: 123, pullRequestUrl: "https://gh/pr/123" }],
-      [{ id: "cuid-b1", buildId: "FB-1" }],
-    );
     const adapters = await createLiveMergeGateAdapters({ prisma: prisma as never, actuationEnabled: false });
     expect(await adapters.listReadyRemediationPRs()).toEqual([
       {
@@ -62,41 +114,64 @@ describe("createLiveMergeGateAdapters.listReadyRemediationPRs", () => {
         backlogItemId: "BI-1",
         prNumber: 123,
         title: "Remediate hono",
+        packageName: "hono",
         fromVersion: "4.12.19",
         toVersion: "4.12.25",
       },
     ]);
   });
-
-  it("excludes BIs whose build has no captured PR", async () => {
-    const prisma = prismaWith(
-      [{ itemId: "BI-2", title: "x", body: "[origin:assuranceFinding:fk]", activeBuildId: "cuid-b2" }],
-      [], // no capsule PR
-      [{ id: "cuid-b2", buildId: "FB-2" }],
-    );
-    const adapters = await createLiveMergeGateAdapters({ prisma: prisma as never, actuationEnabled: false });
-    expect(await adapters.listReadyRemediationPRs()).toEqual([]);
-  });
 });
 
-describe("createLiveMergeGateAdapters.armAutoMerge", () => {
-  it("throws — actuation is not implemented (hard backstop against early enable)", async () => {
-    const prisma = {
+describe("createLiveMergeGateAdapters.armAutoMerge (P2.2b)", () => {
+  const pr = {
+    buildId: "FB-1",
+    buildPk: "cuid-b1",
+    backlogItemId: "BI-1",
+    prNumber: 123,
+    title: "Remediate hono",
+    packageName: "hono",
+    fromVersion: "4.12.19",
+    toVersion: "4.12.25",
+  };
+
+  function tokenPrisma() {
+    return {
       backlogItem: { findMany: async () => [] },
       workCapsule: { findMany: async () => [] },
       featureBuild: { findMany: async () => [] },
+      credentialEntry: { findUnique: async () => ({ secretRef: "ghtok", status: "active" }) },
+      platformDevConfig: { findUnique: async () => ({ upstreamRemoteUrl: "https://github.com/o/r" }) },
     };
-    const adapters = await createLiveMergeGateAdapters({ prisma: prisma as never, actuationEnabled: true });
-    await expect(
-      adapters.armAutoMerge({
-        buildId: "FB-1",
-        buildPk: "cuid-b1",
-        backlogItemId: "BI-1",
-        prNumber: 1,
-        title: "x",
-        fromVersion: "1.0.0",
-        toVersion: "1.0.1",
-      }),
-    ).rejects.toThrow(/not implemented/i);
+  }
+
+  it("resolves the PR node id and calls enablePullRequestAutoMerge", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ data: { repository: { pullRequest: { id: "PR_NODE_1" } } } }))
+      .mockResolvedValueOnce(okJson({ data: { enablePullRequestAutoMerge: { pullRequest: { number: 123 } } } }));
+
+    const adapters = await createLiveMergeGateAdapters({
+      prisma: tokenPrisma() as never,
+      actuationEnabled: true,
+      fetchImpl: fetchImpl as never,
+    });
+    await expect(adapters.armAutoMerge(pr)).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const mutationCall = (fetchImpl.mock.calls[1]![1] as { body: string }).body;
+    expect(mutationCall).toContain("enablePullRequestAutoMerge");
+    expect(mutationCall).toContain("PR_NODE_1");
+  });
+
+  it("throws when no GitHub token is configured", async () => {
+    const noToken = {
+      ...tokenPrisma(),
+      credentialEntry: { findUnique: async () => null },
+    };
+    const adapters = await createLiveMergeGateAdapters({
+      prisma: noToken as never,
+      actuationEnabled: true,
+      fetchImpl: (vi.fn() as never),
+    });
+    await expect(adapters.armAutoMerge(pr)).rejects.toThrow(/no GitHub token/i);
   });
 });

--- a/apps/web/lib/assurance/remediation-merge-live.ts
+++ b/apps/web/lib/assurance/remediation-merge-live.ts
@@ -88,8 +88,10 @@ export async function fetchReleaseCooldownMet(
   now: Date,
 ): Promise<boolean> {
   if (!pkg || !version) return false;
-  // Scoped names keep the leading @, only the slash is percent-encoded for the registry path.
-  const path = pkg.startsWith("@") ? pkg.replace("/", "%2F") : pkg;
+  // Scoped names keep the leading @, with EVERY slash percent-encoded for the
+  // registry path (global replace — a single-occurrence replace is an incomplete
+  // escape, CodeQL js/incomplete-sanitization).
+  const path = pkg.startsWith("@") ? pkg.replace(/\//g, "%2F") : pkg;
   try {
     const res = await fetchImpl(`${NPM_REGISTRY_BASE}/${path}`, { headers: { Accept: "application/json" } });
     if (!res.ok) return false;

--- a/apps/web/lib/assurance/remediation-merge-live.ts
+++ b/apps/web/lib/assurance/remediation-merge-live.ts
@@ -1,25 +1,43 @@
 // apps/web/lib/assurance/remediation-merge-live.ts
 //
-// P2.2 — LIVE (dark-by-default) adapters for the WWMD merge gate
-// (remediation-merge-orchestrator.ts). Reads ready assurance-remediation PRs and
-// their GitHub readiness, runs the gate, and escalates the non-auto ones.
+// P2.2 / P2.2b — LIVE adapters for the WWMD merge gate
+// (remediation-merge-orchestrator.ts). Reads ready assurance-remediation PRs +
+// their readiness, runs the gate, and either ARMS auto-merge (P2.2b) or escalates.
 //
-// SAFETY: the merge actuation is the only irreversible step and is NOT implemented
-// here — `armAutoMerge` throws. While `actuationEnabled` is false (the default),
-// the orchestrator dark-records auto-merge decisions instead of calling it, so this
-// lane does ONLY reads + escalation (filing an issue report). Enabling actuation
-// (P2.2b) MUST first implement `armAutoMerge` (GitHub GraphQL enablePullRequestAutoMerge)
-// AND wire real cooldown/OSV verifiers (see getReadiness) — verified against a real
-// remediation PR. The throw is a hard backstop against flipping the flag early.
+// SAFETY: merge actuation stays behind ONE switch — `actuationEnabled`
+// (DPF_ASSURANCE_AUTOMERGE_ENABLED, default off). While off, the orchestrator
+// dark-records auto-merge decisions and never calls armAutoMerge, so the lane does
+// only reads + escalation. The decision gate is also strict (patch-only + CI-green
+// + release-age cooldown + OSV-clean + no-conflict), so even when the flag is on,
+// only a fully-verified patch bump is ever auto-merged.
 
-import { readGithubPullRequests } from "@/lib/contributor-change-lanes/github-rest-reader";
+import {
+  readGithubPullRequests,
+  resolveGithubToken,
+  resolveRepoIdentity,
+} from "@/lib/contributor-change-lanes/github-rest-reader";
 import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
 import { ASSURANCE_ORIGIN_MARKER } from "./remediation-teeup";
 import type { MergeGateAdapters, PrReadiness, ReadyRemediationPR } from "./remediation-merge-orchestrator";
 
+const NPM_REGISTRY_BASE = process.env.NPM_REGISTRY_BASE ?? "https://registry.npmjs.org";
+const OSV_BASE = process.env.OSV_BASE_URL ?? "https://api.osv.dev";
+const GITHUB_GRAPHQL = "https://api.github.com/graphql";
+
+/** Release-age cooldown for an auto-mergeable bump (hijacked-release guard; mirrors
+ *  the Dependabot patch cooldown). The bumped release must be at least this old. */
+export const ASSURANCE_REMEDIATION_COOLDOWN_DAYS = 3;
+
+const PR_ID_QUERY =
+  "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id}}}";
+const ENABLE_AUTOMERGE_MUTATION =
+  "mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id}){pullRequest{number}}}";
+
+// ─── pure helpers ─────────────────────────────────────────────────────────────
+
 /** Map GitHub's mergeable_state to the gate's CI/conflict signals. Only "clean"
- *  (mergeable + required checks passing) counts as green; everything else
- *  (blocked/unstable/behind/unknown) escalates, and "dirty" is a conflict. Pure. */
+ *  (mergeable + required checks passing) counts as green; "dirty" is a conflict;
+ *  everything else (blocked/unstable/behind/unknown) escalates. Pure. */
 export function mapMergeStateToReadiness(mergeStateStatus: string | null): {
   ciGreen: boolean;
   hasConflict: boolean;
@@ -28,13 +46,102 @@ export function mapMergeStateToReadiness(mergeStateStatus: string | null): {
   return { ciGreen: s === "clean", hasConflict: s === "dirty" };
 }
 
-/** Extract the from/to versions from an auto-filed remediation BI body
- *  ("Observed: pkg@X" → from; "Patched: <range>" → to). Pure; null when absent. */
+/** Extract from/to versions from an auto-filed body ("Observed: pkg@X" / "Patched: <range>"). Pure. */
 export function parseRemediationVersions(body: string | null): { from: string | null; to: string | null } {
   const text = body ?? "";
   const observed = /Observed:\s*\S+?@([0-9][^\s)]*)/i.exec(text);
   const patched = /Patched:[^0-9\n]*([0-9][^\s,)]*)/i.exec(text);
   return { from: observed?.[1] ?? null, to: patched?.[1] ?? null };
+}
+
+/** Package name from an auto-filed body ("Observed: NAME@ver", incl. @scope/name). Pure. */
+export function parseObservedPackage(body: string | null): string | null {
+  const m = /Observed:\s*(\S+?)@[0-9]/i.exec(body ?? "");
+  return m?.[1] ?? null;
+}
+
+/** True if `publishedAtIso` is at least `minDays` old as of `now`. Unknown → false. Pure. */
+export function isReleaseAgedEnough(publishedAtIso: string | null, now: Date, minDays: number): boolean {
+  if (!publishedAtIso) return false;
+  const t = Date.parse(publishedAtIso);
+  if (Number.isNaN(t)) return false;
+  return now.getTime() - t >= minDays * 24 * 60 * 60 * 1000;
+}
+
+/** Interpret an OSV /v1/querybatch response (single query): clean only when the
+ *  result is present and carries no vulns; malformed/empty → not clean (escalate). Pure. */
+export function osvBatchClean(response: unknown): boolean {
+  const results = (response as { results?: Array<{ vulns?: unknown[] }> } | null)?.results;
+  if (!Array.isArray(results) || results.length === 0) return false;
+  const vulns = results[0]?.vulns;
+  return !Array.isArray(vulns) || vulns.length === 0;
+}
+
+// ─── live readiness checks (injectable fetch) ─────────────────────────────────
+
+/** npm release-age cooldown check for `pkg@version`. Conservative: any
+ *  missing input / fetch failure → false (→ the gate escalates). */
+export async function fetchReleaseCooldownMet(
+  fetchImpl: typeof fetch,
+  pkg: string | null,
+  version: string | null,
+  now: Date,
+): Promise<boolean> {
+  if (!pkg || !version) return false;
+  // Scoped names keep the leading @, only the slash is percent-encoded for the registry path.
+  const path = pkg.startsWith("@") ? pkg.replace("/", "%2F") : pkg;
+  try {
+    const res = await fetchImpl(`${NPM_REGISTRY_BASE}/${path}`, { headers: { Accept: "application/json" } });
+    if (!res.ok) return false;
+    const json = (await res.json()) as { time?: Record<string, string> };
+    return isReleaseAgedEnough(json.time?.[version] ?? null, now, ASSURANCE_REMEDIATION_COOLDOWN_DAYS);
+  } catch {
+    return false;
+  }
+}
+
+/** OSV-clean check for `pkg@version` (the bump target). Conservative: missing
+ *  input / fetch failure → false. */
+export async function fetchOsvClean(
+  fetchImpl: typeof fetch,
+  pkg: string | null,
+  version: string | null,
+): Promise<boolean> {
+  if (!pkg || !version) return false;
+  try {
+    const res = await fetchImpl(`${OSV_BASE}/v1/querybatch`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ queries: [{ package: { ecosystem: "npm", name: pkg }, version }] }),
+    });
+    if (!res.ok) return false;
+    return osvBatchClean(await res.json());
+  } catch {
+    return false;
+  }
+}
+
+async function githubGraphql(
+  fetchImpl: typeof fetch,
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<Record<string, unknown> | null> {
+  const res = await fetchImpl(GITHUB_GRAPHQL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "User-Agent": "dpf-assurance-merge-gate",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`GitHub GraphQL HTTP ${res.status}`);
+  const json = (await res.json()) as { data?: Record<string, unknown>; errors?: unknown[] };
+  if (Array.isArray(json.errors) && json.errors.length > 0) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(json.errors).slice(0, 200)}`);
+  }
+  return json.data ?? null;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -49,19 +156,20 @@ export interface LiveMergeGateDeps {
   prisma: LiveMergeGatePrisma;
   actuationEnabled: boolean;
   fetchImpl?: typeof fetch;
+  now?: Date;
 }
 
-/** Assemble the live merge-gate adapters. armAutoMerge is intentionally a
- *  throwing stub (see file header) — unreachable while dark. */
 export async function createLiveMergeGateAdapters(deps: LiveMergeGateDeps): Promise<MergeGateAdapters> {
   const { prisma, actuationEnabled } = deps;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? new Date();
 
-  // Fetch the open-PR list once; getReadiness reads from this map.
+  // Fetch the open-PR list once; getReadiness reads mergeStateStatus from this map.
   let prMap: Map<number, string | null> | null = null;
   const ensurePrMap = async (): Promise<Map<number, string | null>> => {
     if (prMap) return prMap;
     const map = new Map<number, string | null>();
-    const res = await readGithubPullRequests({ fetchImpl: deps.fetchImpl });
+    const res = await readGithubPullRequests({ fetchImpl });
     if (res.ok) {
       for (const row of res.rows) {
         const p = row.payload as { number?: number; mergeStateStatus?: string | null };
@@ -91,8 +199,8 @@ export async function createLiveMergeGateAdapters(deps: LiveMergeGateDeps): Prom
         where: { featureBuildId: { in: buildPks }, pullRequestNumber: { not: null } },
         select: { featureBuildId: true, pullRequestNumber: true, pullRequestUrl: true },
       });
-      const capByBuild = new Map<string, { pullRequestNumber: number | null; pullRequestUrl: string | null }>(
-        capsules.map((c) => [c.featureBuildId as string, { pullRequestNumber: c.pullRequestNumber, pullRequestUrl: c.pullRequestUrl }]),
+      const capByBuild = new Map<string, { pullRequestNumber: number | null }>(
+        capsules.map((c) => [c.featureBuildId as string, { pullRequestNumber: c.pullRequestNumber }]),
       );
       const builds = await prisma.featureBuild.findMany({
         where: { id: { in: buildPks } },
@@ -113,6 +221,7 @@ export async function createLiveMergeGateAdapters(deps: LiveMergeGateDeps): Prom
           backlogItemId: bi.itemId,
           prNumber: cap.pullRequestNumber,
           title: bi.title,
+          packageName: parseObservedPackage(bi.body),
           fromVersion: from,
           toVersion: to,
         });
@@ -123,18 +232,32 @@ export async function createLiveMergeGateAdapters(deps: LiveMergeGateDeps): Prom
     getReadiness: async (pr): Promise<PrReadiness> => {
       const map = await ensurePrMap();
       const { ciGreen, hasConflict } = mapMergeStateToReadiness(map.get(pr.prNumber) ?? null);
-      // TODO(P2.2b): wire real verifiers BEFORE enabling actuation —
-      //   cooldownMet: npm-registry release age of pr.toVersion (anti-hijack);
-      //   osvClean:    OSV query that pr.toVersion has no advisory.
-      // Until then these are optimistic; the dark gate + the armAutoMerge throw
-      // keep it from merging anything.
-      return { ciGreen, hasConflict, cooldownMet: true, osvClean: true };
+      const [cooldownMet, osvClean] = await Promise.all([
+        fetchReleaseCooldownMet(fetchImpl, pr.packageName ?? null, pr.toVersion, now),
+        fetchOsvClean(fetchImpl, pr.packageName ?? null, pr.toVersion),
+      ]);
+      return { ciGreen, hasConflict, cooldownMet, osvClean };
     },
 
-    armAutoMerge: async (): Promise<void> => {
-      throw new Error(
-        "assurance auto-merge actuation not implemented (P2.2b) — implement GitHub auto-merge + cooldown/OSV verifiers and verify against a real PR before enabling DPF_ASSURANCE_AUTOMERGE_ENABLED",
-      );
+    // P2.2b: real actuation — GitHub GraphQL enablePullRequestAutoMerge. Reached
+    // only when actuationEnabled AND the strict gate passed for this PR.
+    armAutoMerge: async (pr): Promise<void> => {
+      const tokenPrisma = prisma as unknown as Parameters<typeof resolveGithubToken>[0];
+      const token = await resolveGithubToken(tokenPrisma);
+      if (!token) {
+        throw new Error("assurance auto-merge: no GitHub token (github-pr-sync credential not active)");
+      }
+      const repo = await resolveRepoIdentity(tokenPrisma);
+      const idData = await githubGraphql(fetchImpl, token, PR_ID_QUERY, {
+        owner: repo.owner,
+        name: repo.name,
+        number: pr.prNumber,
+      });
+      const nodeId = (idData as { repository?: { pullRequest?: { id?: unknown } } } | null)?.repository?.pullRequest?.id;
+      if (typeof nodeId !== "string" || !nodeId) {
+        throw new Error(`assurance auto-merge: could not resolve node id for PR #${pr.prNumber}`);
+      }
+      await githubGraphql(fetchImpl, token, ENABLE_AUTOMERGE_MUTATION, { id: nodeId });
     },
 
     escalate: async (pr, reason): Promise<void> => {

--- a/apps/web/lib/assurance/remediation-merge-orchestrator.ts
+++ b/apps/web/lib/assurance/remediation-merge-orchestrator.ts
@@ -24,6 +24,9 @@ export interface ReadyRemediationPR {
   backlogItemId: string;
   prNumber: number;
   title: string;
+  /** Dependency package name (null when not extractable). Used by the live
+   *  cooldown/OSV verifiers in P2.2b. */
+  packageName?: string | null;
   /** Old → new dependency version from the PR diff (null when not extractable). */
   fromVersion: string | null;
   toVersion: string | null;

--- a/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
+++ b/docs/superpowers/plans/2026-06-22-assurance-remediation-autoheal-loop-plan.md
@@ -87,11 +87,20 @@ reads `DPF_ASSURANCE_AUTOMERGE_ENABLED` (default off) and `armAutoMerge` is a
 throwing stub — so while dark the lane does ONLY reads + escalation (zero
 irreversible action; the orchestrator dark-records the auto-merge decisions).
 
-**Staged — actuation enable (P2.2b):** implement `armAutoMerge` (GitHub GraphQL
-`enablePullRequestAutoMerge`) AND wire the real `cooldownMet` (npm release-age) +
-`osvClean` (OSV) verifiers in `getReadiness` (currently optimistic), verify against a
-real P1-produced remediation PR, THEN flip the flag. The most irreversible step in
-the loop — it does not blind-launch.
+**Implemented — actuation built, flag-gated OFF (P2.2b):** `armAutoMerge` now does
+the real GitHub GraphQL `enablePullRequestAutoMerge` (resolve the PR node id → enable
+mutation, via `resolveGithubToken` / `resolveRepoIdentity`); `getReadiness` now does
+the real `cooldownMet` (npm release-age ≥ 3d) + `osvClean` (OSV querybatch) checks for
+the bump target — conservative: any missing input / fetch failure → escalate. Pure +
+IO helpers (`isReleaseAgedEnough`, `osvBatchClean`, `fetchReleaseCooldownMet`,
+`fetchOsvClean`, `parseObservedPackage`) are exported + tested; `ReadyRemediationPR`
+gained `packageName`.
+
+The ONLY remaining gate is `DPF_ASSURANCE_AUTOMERGE_ENABLED` (still default **OFF**) —
+the lane keeps running dark (escalate + dark-record) until an operator flips it after
+verifying the dark-records against a real P1-produced PR. Even flipped, only a patch +
+CI-green + aged + OSV-clean + conflict-free PR is ever armed. This is the loop's only
+irreversible step; the flip is a human decision, not a code default.
 
 ## Phase 3 — close the loop (BI-4D5C702F)
 


### PR DESCRIPTION
## Why
P2.2b — the **actuation** for the merge gate (real GitHub auto-merge + cooldown/OSV verifiers), so the loop *can* self-heal — kept **flag-gated off** (default) until verified against a real PR.

> Supersedes #2321, which was stacked on #2317; #2317 squash-merged, orphaning that base and causing a phantom merge conflict. This is the same commit recreated cleanly off current `main`.

## What
- `armAutoMerge` → real GitHub GraphQL `enablePullRequestAutoMerge` (resolve PR node id → enable mutation), via the existing `resolveGithubToken` / `resolveRepoIdentity`.
- `getReadiness` → real `cooldownMet` (npm release-age ≥ 3d, anti-hijack) + `osvClean` (OSV querybatch on the bump target). Conservative: any missing input / fetch failure → escalate.
- `ReadyRemediationPR` gains `packageName`; pure + IO helpers exported and tested.

## Safety — one off-switch, strict gate
- `DPF_ASSURANCE_AUTOMERGE_ENABLED` is still **default OFF** → the lane runs dark (escalate + dark-record); `armAutoMerge` is never called while off.
- Even when flipped, only a **patch + CI-green + release-aged + OSV-clean + conflict-free** PR is ever armed.
- The flip is a deliberate human decision after reviewing the dark-records against a real P1-produced PR.

## Verification
Tests: mergeState→readiness mapping, version + package parsing, release-age + OSV interpretation, the cooldown/OSV fetchers (injected fetch), the ready-PR join (incl. `packageName`), and `armAutoMerge` (fake prisma + injected fetch — resolves node id → enable mutation; throws with no token). CI runs the full suite + typecheck + catalog parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)