### PR TITLE
feat(ci): merge-queue churn watch - flag a PR kicked from the queue >=2x

### DIFF
--- a/.github/workflows/merge-queue-churn-watch.yml
+++ b/.github/workflows/merge-queue-churn-watch.yml
@@ -1,0 +1,38 @@
+name: Merge Queue Churn Watch
+
+# When a PR fails merge_group CI it is silently removed from the merge queue;
+# re-enabling auto-merge on the same commit churns it again. PR #2157 did this
+# for hours before a human noticed. This scheduled watch comments ONCE on a PR
+# that has been kicked from the queue >= 2x in 24h, so the churn is visible and
+# the author knows to push a fix instead of re-queueing. Pairs with the
+# shift-left decision-baseline guard (PR #2194), which prevents the most common
+# cause; this catches drift that breaks a PR while it sits in the queue.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # every 30 minutes
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write # post the churn comment
+  actions: read # list merge_group workflow runs
+
+concurrency:
+  group: merge-queue-churn-watch
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: Watch merge-queue churn
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Flag PRs churning in the merge queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/check-merge-queue-churn.mjs

--- a/scripts/check-merge-queue-churn.mjs
+++ b/scripts/check-merge-queue-churn.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// scripts/check-merge-queue-churn.mjs
+//
+// Merge-queue churn watch. When a PR fails its merge_group CI it is silently
+// removed from the merge queue; if auto-merge is re-enabled on the same commit
+// it just churns again. PR #2157 did this for HOURS before a human noticed —
+// the shift-left decision-baseline guard (PR #2194) catches the regression
+// class, but NOT drift that breaks a PR while it sits in the queue. This watch
+// closes that gap: it counts distinct failed queue attempts per PR in a recent
+// window and, at a threshold, posts ONE comment so the churn is visible and the
+// author knows to push a FIX rather than re-queue the same commit.
+//
+// Pure `analyzeChurn()` (unit-tested) + a thin gh CLI wrapper. Run on a schedule
+// by .github/workflows/merge-queue-churn-watch.yml. `--dry-run` prints the
+// analysis without commenting.
+
+import { execFileSync } from "node:child_process";
+
+const COMMENT_MARKER = "<!-- merge-queue-churn-watch -->";
+
+/**
+ * Group merge_group CI runs by PR and flag those with >= thresholdAttempts
+ * DISTINCT failed queue attempts (distinct head SHAs) inside the window. A
+ * queue attempt is one `gh-readonly-queue/<base>/pr-<n>-<sha>` ref; it counts
+ * as failed if ANY of its runs failed (CI or DCO both kick the PR). Pure.
+ *
+ * @param {Array<{headBranch?:string, conclusion?:string, createdAt?:string}>} runs
+ * @param {{thresholdAttempts?:number, windowHours?:number, now?:number}} [opts]
+ * @returns {Array<{pr:number, failedAttempts:number, latestSha:string, latestAt:string}>}
+ */
+export function analyzeChurn(runs, { thresholdAttempts = 2, windowHours = 24, now = Date.now() } = {}) {
+  const cutoff = now - windowHours * 3600 * 1000;
+  const byPr = new Map(); // pr -> Map(sha -> latest ISO time of a failed run)
+  for (const r of runs ?? []) {
+    if (r?.conclusion !== "failure") continue;
+    const t = Date.parse(r.createdAt ?? "");
+    if (Number.isNaN(t) || t < cutoff) continue;
+    const m = /\/pr-(\d+)-([0-9a-f]+)/.exec(r.headBranch ?? "");
+    if (!m) continue;
+    const [, pr, sha] = m;
+    if (!byPr.has(pr)) byPr.set(pr, new Map());
+    const shas = byPr.get(pr);
+    if (!shas.has(sha) || Date.parse(shas.get(sha)) < t) shas.set(sha, r.createdAt);
+  }
+  const flagged = [];
+  for (const [pr, shas] of byPr) {
+    if (shas.size < thresholdAttempts) continue;
+    const latest = [...shas.entries()].sort((a, b) => Date.parse(b[1]) - Date.parse(a[1]))[0];
+    flagged.push({ pr: Number(pr), failedAttempts: shas.size, latestSha: latest[0], latestAt: latest[1] });
+  }
+  return flagged.sort((a, b) => b.failedAttempts - a.failedAttempts);
+}
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+}
+
+function commentBody(f) {
+  return (
+    `${COMMENT_MARKER}\n` +
+    `⚠️ **Merge-queue churn detected.** This PR has been removed from the merge queue ` +
+    `**${f.failedAttempts}×** (failing \`merge_group\` CI) in the last 24h. Re-enabling auto-merge ` +
+    `on the same commit will just churn again — it needs a **fix, not a retry**.\n\n` +
+    `Open the latest \`merge_group\` CI run, address the failure, push the fix, then re-queue. ` +
+    `A fast local reproduction often beats the queue loop (e.g. \`node scripts/check-golden-decisions.mjs\` ` +
+    `for decision-baseline failures).`
+  );
+}
+
+function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  let runs;
+  try {
+    // Wide limit: at high merge volume a few hundred runs can be only a couple
+    // hours of history, so pull generously to keep the 24h window meaningful for
+    // a PR that has been churning a while. analyzeChurn() does the time filtering.
+    runs = JSON.parse(gh(["run", "list", "--event", "merge_group", "--limit", "500", "--json", "headBranch,conclusion,createdAt"]));
+  } catch (err) {
+    console.error("[merge-queue-churn] could not list merge_group runs:", err.message);
+    process.exit(0); // never fail the scheduled job on a transient gh/API error
+  }
+
+  const flagged = analyzeChurn(runs);
+  if (flagged.length === 0) {
+    console.log("[merge-queue-churn] no churning PRs in the window.");
+    return;
+  }
+
+  if (dryRun) {
+    for (const f of flagged) console.log(`[merge-queue-churn] (dry-run) PR #${f.pr}: ${f.failedAttempts} failed attempts (latest ${f.latestSha})`);
+    return;
+  }
+
+  for (const f of flagged) {
+    let view;
+    try {
+      view = JSON.parse(gh(["pr", "view", String(f.pr), "--json", "state,comments"]));
+    } catch {
+      console.log(`[merge-queue-churn] PR #${f.pr}: could not read — skip`);
+      continue;
+    }
+    if (view.state !== "OPEN") {
+      console.log(`[merge-queue-churn] PR #${f.pr} is ${view.state} — skip`);
+      continue;
+    }
+    if ((view.comments ?? []).some((c) => (c.body ?? "").includes(COMMENT_MARKER))) {
+      console.log(`[merge-queue-churn] PR #${f.pr} already flagged — skip`);
+      continue;
+    }
+    gh(["pr", "comment", String(f.pr), "--body", commentBody(f)]);
+    console.log(`[merge-queue-churn] flagged PR #${f.pr} (${f.failedAttempts} failed attempts).`);
+  }
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].replace(/\\/g, "/").endsWith("check-merge-queue-churn.mjs");
+if (invokedDirectly) main();

--- a/scripts/check-merge-queue-churn.test.mjs
+++ b/scripts/check-merge-queue-churn.test.mjs
@@ -1,0 +1,62 @@
+// scripts/check-merge-queue-churn.test.mjs
+// node --test (no vitest). Covers the pure analyzeChurn() — grouping by PR,
+// distinct-failed-attempt counting, window + threshold, and noise rejection.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { analyzeChurn } from "./check-merge-queue-churn.mjs";
+
+const NOW = Date.parse("2026-06-20T12:00:00Z");
+const ago = (h) => new Date(NOW - h * 3600 * 1000).toISOString();
+
+test("flags a PR with >= 2 distinct failed queue attempts in window", () => {
+  const runs = [
+    { headBranch: "gh-readonly-queue/main/pr-2157-aaaa111", conclusion: "failure", createdAt: ago(1) },
+    { headBranch: "gh-readonly-queue/main/pr-2157-bbbb222", conclusion: "failure", createdAt: ago(2) },
+    // same sha as a failure, but a DCO success — still one attempt, not two:
+    { headBranch: "gh-readonly-queue/main/pr-2157-bbbb222", conclusion: "success", createdAt: ago(2) },
+  ];
+  const flagged = analyzeChurn(runs, { now: NOW });
+  assert.equal(flagged.length, 1);
+  assert.equal(flagged[0].pr, 2157);
+  assert.equal(flagged[0].failedAttempts, 2);
+  assert.equal(flagged[0].latestSha, "aaaa111"); // most-recent failed attempt
+});
+
+test("does NOT flag a single failed attempt (below threshold)", () => {
+  const runs = [{ headBranch: "gh-readonly-queue/main/pr-99-deadbee", conclusion: "failure", createdAt: ago(1) }];
+  assert.equal(analyzeChurn(runs, { now: NOW }).length, 0);
+});
+
+test("ignores failures outside the window", () => {
+  const runs = [
+    { headBranch: "gh-readonly-queue/main/pr-5-aaa", conclusion: "failure", createdAt: ago(30) },
+    { headBranch: "gh-readonly-queue/main/pr-5-bbb", conclusion: "failure", createdAt: ago(40) },
+  ];
+  assert.equal(analyzeChurn(runs, { now: NOW, windowHours: 24 }).length, 0);
+});
+
+test("ignores non-merge_group branches and all-success PRs", () => {
+  const runs = [
+    { headBranch: "feature/foo", conclusion: "failure", createdAt: ago(1) },
+    { headBranch: "gh-readonly-queue/main/pr-7-aaa", conclusion: "success", createdAt: ago(1) },
+    { headBranch: "gh-readonly-queue/main/pr-7-bbb", conclusion: "success", createdAt: ago(1) },
+  ];
+  assert.equal(analyzeChurn(runs, { now: NOW }).length, 0);
+});
+
+test("sorts most-churned PRs first", () => {
+  const runs = [
+    { headBranch: "gh-readonly-queue/main/pr-1-a1", conclusion: "failure", createdAt: ago(1) },
+    { headBranch: "gh-readonly-queue/main/pr-1-b2", conclusion: "failure", createdAt: ago(2) },
+    { headBranch: "gh-readonly-queue/main/pr-2-c3", conclusion: "failure", createdAt: ago(1) },
+    { headBranch: "gh-readonly-queue/main/pr-2-d4", conclusion: "failure", createdAt: ago(2) },
+    { headBranch: "gh-readonly-queue/main/pr-2-e5", conclusion: "failure", createdAt: ago(3) },
+  ];
+  const flagged = analyzeChurn(runs, { now: NOW });
+  assert.equal(flagged.length, 2);
+  assert.equal(flagged[0].pr, 2); // 3 attempts
+  assert.equal(flagged[0].failedAttempts, 3);
+  assert.equal(flagged[1].pr, 1); // 2 attempts
+});


### PR DESCRIPTION
## What

Closes the one gap the shift-left decision-baseline guard (#2194) doesn't cover: **drift that breaks a PR while it sits in the merge queue.** #2157 churned the queue for hours before a human noticed — the thing that made it take *long*.

## How

- **`scripts/check-merge-queue-churn.mjs`** — pure `analyzeChurn()` groups `merge_group` runs by `pr-<n>-<sha>`, dedupes by sha, counts distinct *failed* queue attempts in a 24h window, flags any PR ≥2. A thin `gh` wrapper posts an **idempotent** (marker-gated) comment only on **OPEN** PRs, and **fails safe (exit 0)** on any API error so the scheduled job never red-flags.
- **`scripts/check-merge-queue-churn.test.mjs`** — `node --test`, 5 cases (threshold, window, distinct-sha dedupe, noise rejection, sort).
- **`.github/workflows/merge-queue-churn-watch.yml`** — every 30m + manual dispatch; least-privilege (`pull-requests: write`, `actions: read`).

## Verified

- Unit **5/5**.
- Dry-run against **live** `merge_group` data: parses + correctly finds no *active* churn (nothing currently stuck).

Completes the queue-churn follow-up noted in BI-41A4E701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
