### PR TITLE
feat(self-upgrade): respect operator blackout periods in the scheduled upgrade (BI-59591B14 Part B)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -71,6 +71,8 @@ const baseStatus = {
   windowConfigured: true,
   windowSource: "operating-hours" as const,
   autoWindowSummary: null,
+  blackoutUntil: null,
+  blackoutName: null,
   storeOpen: false,
   windowTimezone: "UTC",
   nextWindowStart: null,

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -197,6 +197,22 @@ describe("SelfUpgradeClient – enabled", () => {
     expect(html).toContain("/storefront/settings/operations");
     expect(html).toContain('data-window-source="needs-timezone"');
   });
+
+  // BI-59591B14 — an active operator blackout pauses scheduled upgrades; the panel
+  // explains it (with the blackout name + end) instead of leaving the schedule opaque.
+  it("shows a paused-schedule note during an active blackout", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        windowConfigured={true}
+        blackoutUntil="2026-07-08T00:00:00.000Z"
+        blackoutName="Launch week freeze"
+      />,
+    );
+    expect(html).toContain("Scheduled upgrades paused");
+    expect(html).toContain("Launch week freeze");
+    expect(html).toContain('data-blackout="true"');
+  });
 });
 
 // ─── Running ──────────────────────────────────────────────────────────────────

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -86,6 +86,10 @@ type Props = {
   windowSource?: "explicit" | "operating-hours" | "auto-overnight" | "needs-timezone";
   /** Friendly window-time range (e.g. "2:00 AM-4:00 AM") for the auto-overnight note. */
   autoWindowSummary?: string | null;
+  /** End of an active operator blackout pausing scheduled upgrades, or null (BI-59591B14). */
+  blackoutUntil?: string | null;
+  /** Name of the active blackout, for the paused-schedule note. */
+  blackoutName?: string | null;
   /** IANA timezone the upgrade window is evaluated in (store operating hours). */
   windowTimezone?: string;
   nextWindowStart?: string | null;
@@ -248,6 +252,8 @@ export default function SelfUpgradeClient({
   windowConfigured,
   windowSource,
   autoWindowSummary,
+  blackoutUntil,
+  blackoutName,
   windowTimezone,
   nextWindowStart,
   nextScheduledCheckAt,
@@ -895,7 +901,19 @@ export default function SelfUpgradeClient({
           data-window-configured={windowConfigured ? "true" : "false"}
         >
           <span className="font-medium text-[var(--dpf-text)]">Schedule:</span>{" "}
-          {windowSource === "needs-timezone" ? (
+          {blackoutUntil ? (
+            <span className="text-[var(--dpf-warning)]" data-blackout="true">
+              Scheduled upgrades paused
+              {blackoutName ? (
+                <>
+                  {" "}— blackout{" "}
+                  <span className="font-medium text-[var(--dpf-text)]">{blackoutName}</span>
+                </>
+              ) : null}{" "}
+              until <LocalTime className="font-mono" value={blackoutUntil} />. They resume
+              automatically; use Emergency override to run now.
+            </span>
+          ) : windowSource === "needs-timezone" ? (
             <span className="text-[var(--dpf-warning)]" data-window-source="needs-timezone">
               Your business runs 24/7. Set your timezone in{" "}
               <a className="underline" href="/storefront/settings/operations">

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -69,6 +69,11 @@ vi.mock("@/lib/self-upgrade/auto-window", () => ({
   describeWindows: vi.fn().mockReturnValue("2:00 AM–4:00 AM"),
 }));
 
+// Operator blackout (BI-59591B14). Default null = no active blackout.
+vi.mock("@/lib/self-upgrade/blackout", () => ({
+  getActiveSelfUpgradeBlackout: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@/lib/operating-hours-read", () => ({
   resolveOperatingScheduleForSystem: vi
     .fn()
@@ -159,6 +164,7 @@ import { createRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgra
 import { getCurrentImpactSummaryId } from "@/lib/self-upgrade/impact";
 import { isUpgradeWindowOpen, nextUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { resolveAutoUpgradeWindow, nextAutoWindowOpen } from "@/lib/self-upgrade/auto-window";
+import { getActiveSelfUpgradeBlackout } from "@/lib/self-upgrade/blackout";
 import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import { inngest } from "@/lib/queue/inngest-client";
 import { revalidatePath } from "next/cache";
@@ -230,6 +236,7 @@ beforeEach(() => {
   // leaves return values intact, so a prior 24/7 test would otherwise leak).
   vi.mocked(resolveAutoUpgradeWindow).mockReturnValue({ kind: "operating-hours" });
   vi.mocked(nextAutoWindowOpen).mockReturnValue(null);
+  vi.mocked(getActiveSelfUpgradeBlackout).mockResolvedValue(null); // no blackout by default
   // Default: treat triggers as in-window so dispatch tests exercise the happy
   // path. Tests that care about the window gate override this explicitly.
   vi.mocked(isUpgradeWindowOpen).mockReturnValue(true);
@@ -516,6 +523,35 @@ describe("getSelfUpgradeStatus", () => {
     expect(isUpgradeWindowOpen).toHaveBeenCalledWith(
       expect.objectContaining({ explicitWindows: undefined }),
     );
+  });
+
+  // BI-59591B14 — surface an active operator blackout so the panel can explain a
+  // paused schedule instead of leaving it opaque.
+  it("surfaces an active operator blackout (blackoutUntil + blackoutName)", async () => {
+    vi.mocked(getActiveSelfUpgradeBlackout).mockResolvedValue({
+      name: "Launch week freeze",
+      endAt: new Date("2026-07-08T00:00:00Z"),
+    });
+    vi.mocked(getDeployedSha).mockResolvedValue("abc1234");
+    vi.mocked(resolveTargetSha).mockResolvedValue("def5678");
+    vi.mocked(isShaFresh).mockReturnValue(false);
+    vi.mocked(getLatestRun).mockResolvedValue(null);
+
+    const result = await getSelfUpgradeStatus();
+
+    expect(result.blackoutUntil).toBe("2026-07-08T00:00:00.000Z");
+    expect(result.blackoutName).toBe("Launch week freeze");
+  });
+
+  it("leaves blackout fields null when no blackout is active", async () => {
+    vi.mocked(getDeployedSha).mockResolvedValue("abc1234");
+    vi.mocked(resolveTargetSha).mockResolvedValue(null);
+    vi.mocked(getLatestRun).mockResolvedValue(null);
+
+    const result = await getSelfUpgradeStatus();
+
+    expect(result.blackoutUntil).toBeNull();
+    expect(result.blackoutName).toBeNull();
   });
 
   it("passes channel and source config to resolveTargetSha", async () => {

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -23,6 +23,7 @@ import {
   nextAutoWindowOpen,
   describeWindows,
 } from "@/lib/self-upgrade/auto-window";
+import { getActiveSelfUpgradeBlackout } from "@/lib/self-upgrade/blackout";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import {
@@ -657,6 +658,7 @@ export async function getSelfUpgradeStatus() {
     quiescence,
     cooldownUntil,
     jobEngine,
+    selfUpgradeBlackout,
   ] = await Promise.all([
     getSelfUpgradeConfig(),
     getLatestRun(),
@@ -674,6 +676,9 @@ export async function getSelfUpgradeStatus() {
     // Background-job-engine (Inngest) registration health — a self-upgrade
     // can't dispatch without it, so the panel must surface a dead job engine.
     getJobEngineHealth(),
+    // Active operator blackout that pauses scheduled upgrades (BI-59591B14), so
+    // the panel explains a paused schedule instead of leaving it opaque.
+    getActiveSelfUpgradeBlackout(),
   ]);
 
   // Upgrade timing follows the storefront's open/closed state (single source of
@@ -766,6 +771,9 @@ export async function getSelfUpgradeStatus() {
     windowSource,
     // Friendly window-time summary for the auto-overnight note (null otherwise).
     autoWindowSummary,
+    // Active operator blackout pausing scheduled upgrades, or null (BI-59591B14).
+    blackoutUntil: selfUpgradeBlackout?.endAt.toISOString() ?? null,
+    blackoutName: selfUpgradeBlackout?.name ?? null,
     storeOpen,
     // The IANA timezone the window is evaluated in (store operating-hours zone).
     // Surfaced so the panel's "next window" is never ambiguous — the symptom that

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -42,6 +42,9 @@ const mocks = vi.hoisted(() => ({
   // gate behaves exactly as before (falls through to the mocked isUpgradeWindowOpen);
   // the 24/7 tests override it.
   resolveAutoUpgradeWindow: vi.fn().mockReturnValue({ kind: "operating-hours" }),
+  // Operator blackout gate (BI-59591B14). Default null = no active blackout, so
+  // every existing scheduled test proceeds exactly as before.
+  getActiveSelfUpgradeBlackout: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/self-upgrade/config", () => ({
@@ -58,6 +61,10 @@ vi.mock("@/lib/operating-hours-read", () => ({
 
 vi.mock("@/lib/self-upgrade/auto-window", () => ({
   resolveAutoUpgradeWindow: mocks.resolveAutoUpgradeWindow,
+}));
+
+vi.mock("@/lib/self-upgrade/blackout", () => ({
+  getActiveSelfUpgradeBlackout: mocks.getActiveSelfUpgradeBlackout,
 }));
 
 vi.mock("@/lib/self-upgrade/last-check", () => ({
@@ -633,6 +640,7 @@ describe("maintenance window gate + emergency override", () => {
     // prior describe's return value / one-shot queue intact); the 24/7 tests below
     // override per-call with mockReturnValueOnce.
     mocks.resolveAutoUpgradeWindow.mockReturnValue({ kind: "operating-hours" });
+    mocks.getActiveSelfUpgradeBlackout.mockResolvedValue(null); // no blackout by default
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.getDeployedSha.mockResolvedValue("oldsha1");
     setupSourceReady();
@@ -703,6 +711,28 @@ describe("maintenance window gate + emergency override", () => {
 
     expect(result).toMatchObject({ skipped: true, reason: "no-window-needs-timezone" });
     // Never consults the window gate, never drains, never creates a run.
+    expect(mocks.isUpgradeWindowOpen).not.toHaveBeenCalled();
+    expect(mocks.createRun).not.toHaveBeenCalled();
+    expect(mocks.startQuiescence).not.toHaveBeenCalled();
+  });
+
+  // BI-59591B14 — an operator-declared blackout pauses the unattended scheduled
+  // upgrade. Clean no-op: the blackout gate runs FIRST, so no window check, no
+  // drain, no run. It resumes automatically once the blackout ends. (force, tested
+  // above, bypasses the whole scheduled-gate block including this.)
+  it("SCHEDULED run skips with blackout-period during an active operator blackout", async () => {
+    mocks.getActiveSelfUpgradeBlackout.mockResolvedValueOnce({
+      name: "Launch week freeze",
+      endAt: new Date("2026-07-08T00:00:00Z"),
+    });
+
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true });
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: "blackout-period",
+      blackoutUntil: "2026-07-08T00:00:00.000Z",
+    });
     expect(mocks.isUpgradeWindowOpen).not.toHaveBeenCalled();
     expect(mocks.createRun).not.toHaveBeenCalled();
     expect(mocks.startQuiescence).not.toHaveBeenCalled();

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -3,6 +3,7 @@ import { inngest } from "../inngest-client";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { resolveAutoUpgradeWindow } from "@/lib/self-upgrade/auto-window";
+import { getActiveSelfUpgradeBlackout } from "@/lib/self-upgrade/blackout";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { getLastCheckedAt, recordCheckedAt, isCheckIntervalElapsed } from "@/lib/self-upgrade/last-check";
 import { buildFetchCommand, buildRemoteHeadCommand } from "@/lib/self-upgrade/version";
@@ -139,6 +140,21 @@ export async function runSelfUpgrade(
   // with a distinct reason and the Upgrade Center prompts for a timezone — a clean
   // no-op (no drain, no cooldown), never a silent never-runs.
   if (params.scheduled && !params.force) {
+    // Operator blackout gate (BI-59591B14): a declared no-change period pauses the
+    // unattended upgrade. A self-upgrade is a disruptive (standard) change, so it
+    // respects the same blackouts that gate other changes — unless the blackout
+    // excepts self-upgrade. Manual / force bypass. Clean no-op skip (no drain, no
+    // cooldown); it resumes automatically once the blackout ends. This is the
+    // proactive guard quiescence can't provide (a blackout may be declared ahead
+    // of time with nothing yet running).
+    const blackout = await getActiveSelfUpgradeBlackout(now);
+    if (blackout) {
+      return await skipAttempt(
+        "blackout-period",
+        `blackout-period: ${blackout.name} until ${blackout.endAt.toISOString()}`,
+        { blackoutUntil: blackout.endAt.toISOString() },
+      );
+    }
     const { schedule, timezone, timezoneKnown, lowTrafficWindows } =
       await resolveOperatingScheduleForSystem();
     const auto =

--- a/apps/web/lib/self-upgrade/blackout.test.ts
+++ b/apps/web/lib/self-upgrade/blackout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+// blackout.ts imports the prisma client for its DB reader; the pure predicate
+// under test never touches it, so stub the module to keep this unit test hermetic.
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { findActiveSelfUpgradeBlackout } from "./blackout";
+
+const NOW = new Date("2026-07-04T12:00:00Z");
+
+function blackout(overrides: Partial<{ name: string; startAt: Date; endAt: Date; exceptions: string[] }> = {}) {
+  return {
+    name: "Launch week freeze",
+    startAt: new Date("2026-07-01T00:00:00Z"),
+    endAt: new Date("2026-07-08T00:00:00Z"),
+    exceptions: [] as string[],
+    ...overrides,
+  };
+}
+
+describe("findActiveSelfUpgradeBlackout", () => {
+  it("returns the active blackout that covers now", () => {
+    expect(findActiveSelfUpgradeBlackout([blackout()], NOW)).toEqual({
+      name: "Launch week freeze",
+      endAt: new Date("2026-07-08T00:00:00Z"),
+    });
+  });
+
+  it("returns null when no blackout covers now (past / future)", () => {
+    const past = blackout({ startAt: new Date("2026-06-01T00:00:00Z"), endAt: new Date("2026-06-02T00:00:00Z") });
+    const future = blackout({ startAt: new Date("2026-08-01T00:00:00Z"), endAt: new Date("2026-08-02T00:00:00Z") });
+    expect(findActiveSelfUpgradeBlackout([past, future], NOW)).toBeNull();
+  });
+
+  it("treats the start and end instants as inclusive", () => {
+    const atStart = blackout({ startAt: NOW, endAt: new Date("2026-07-05T00:00:00Z") });
+    const atEnd = blackout({ startAt: new Date("2026-07-01T00:00:00Z"), endAt: NOW });
+    expect(findActiveSelfUpgradeBlackout([atStart], NOW)).not.toBeNull();
+    expect(findActiveSelfUpgradeBlackout([atEnd], NOW)).not.toBeNull();
+  });
+
+  it("does NOT block when the blackout excepts self-upgrade or standard changes", () => {
+    expect(findActiveSelfUpgradeBlackout([blackout({ exceptions: ["self-upgrade"] })], NOW)).toBeNull();
+    expect(findActiveSelfUpgradeBlackout([blackout({ exceptions: ["standard"] })], NOW)).toBeNull();
+  });
+
+  it("still blocks when the exceptions are for unrelated change types", () => {
+    expect(
+      findActiveSelfUpgradeBlackout([blackout({ exceptions: ["emergency", "normal"] })], NOW),
+    ).not.toBeNull();
+  });
+
+  it("returns the first blocking blackout when several are active", () => {
+    const excepted = blackout({ name: "ok", exceptions: ["standard"] });
+    const blocking = blackout({ name: "freeze" });
+    expect(findActiveSelfUpgradeBlackout([excepted, blocking], NOW)?.name).toBe("freeze");
+  });
+});

--- a/apps/web/lib/self-upgrade/blackout.ts
+++ b/apps/web/lib/self-upgrade/blackout.ts
@@ -1,0 +1,72 @@
+// apps/web/lib/self-upgrade/blackout.ts
+//
+// Whether an operator-declared BlackoutPeriod currently pauses the UNATTENDED
+// scheduled self-upgrade (BI-59591B14). A self-upgrade drains + restarts the
+// customer's portal and registers as a (standard) ChangeRequest, so it respects
+// the same operator blackout windows that gate other changes (deployment-windows.ts)
+// — UNLESS the blackout explicitly excepts self-upgrade. Manual / forced upgrades
+// bypass (the operator is choosing this moment), exactly like the maintenance-window
+// gate. Quiescence already defers an upgrade that collides with ACTIVE work; this
+// adds the proactive "operator declared a no-change period" guard quiescence
+// cannot see (the period may be declared days ahead, with nothing yet running).
+//
+// Pure predicate + a fail-open DB reader (a best-effort guard must never throw
+// into the cron gate or the status read).
+
+import { prisma } from "@dpf/db";
+
+export type ActiveBlackout = { name: string; endAt: Date };
+
+type BlackoutRow = {
+  name: string;
+  startAt: Date;
+  endAt: Date;
+  exceptions: string[];
+};
+
+// Change-type labels that, when present in a blackout's `exceptions`, let the
+// self-upgrade proceed during that blackout. Mirrors the exceptions rule in
+// deployment-windows.ts (a blackout blocks a change unless its type is excepted);
+// self-upgrade registers as a "standard" change.
+const SELF_UPGRADE_EXCEPTION_KEYS = ["self-upgrade", "standard"];
+
+/**
+ * The active blackout blocking a scheduled self-upgrade at `now`, or null. A
+ * blackout is active when `startAt <= now <= endAt`; it blocks unless its
+ * `exceptions` opt self-upgrade out. Pure + deterministic.
+ */
+export function findActiveSelfUpgradeBlackout(
+  blackouts: BlackoutRow[],
+  now: Date,
+): ActiveBlackout | null {
+  for (const b of blackouts) {
+    if (b.startAt <= now && now <= b.endAt) {
+      const excepted = b.exceptions.some((e) => SELF_UPGRADE_EXCEPTION_KEYS.includes(e));
+      if (!excepted) return { name: b.name, endAt: b.endAt };
+    }
+  }
+  return null;
+}
+
+/**
+ * System (no-auth) reader: the active self-upgrade blackout for the active
+ * business profile at `now`, or null. Fail-open.
+ */
+export async function getActiveSelfUpgradeBlackout(now?: Date): Promise<ActiveBlackout | null> {
+  const at = now ?? new Date();
+  try {
+    const profile = await prisma.businessProfile.findFirst({
+      where: { isActive: true },
+      select: {
+        blackoutPeriods: {
+          where: { endAt: { gte: at } },
+          select: { name: true, startAt: true, endAt: true, exceptions: true },
+        },
+      },
+    });
+    if (!profile) return null;
+    return findActiveSelfUpgradeBlackout(profile.blackoutPeriods, at);
+  } catch {
+    return null;
+  }
+}

--- a/docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md
+++ b/docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md
@@ -101,12 +101,40 @@ conservative 6 (backups ×2, retention, model-discovery, material-decay, infra-p
 skill-metrics/curator) are deliberately NOT included — adding them broadens the busy band enough
 to push even a deep-sleep slot off a clear window for no real contention benefit.
 
-### Part B — per-org scheduled work (staged, same BI)
+### Part B — per-org blackout gate — **DONE** (this PR)
 
-Compose `BlackoutPeriod` (hard avoid), `DeploymentWindow` allowed bands, and `ScheduledAgentTask`
-crons (per-org tz) into the scorer via a DB-backed collector that passes busy-intervals into the
-pure picker (keeps `auto-window.ts`/`maintenance-calendar.ts` prisma-free). Deferred to keep each
-PR one-concern.
+An operator `BlackoutPeriod` ("no changes during our launch week") now pauses the *unattended
+scheduled* self-upgrade. A self-upgrade drains + restarts the customer's portal and registers as a
+`standard` `ChangeRequest`, so it respects the same blackouts that gate other changes
+(`deployment-windows.ts`) — **unless** the blackout excepts self-upgrade (`exceptions` includes
+`self-upgrade`/`standard`, mirroring the existing exceptions rule; no new scope policy invented).
+
+- `apps/web/lib/self-upgrade/blackout.ts` (new): pure `findActiveSelfUpgradeBlackout(blackouts, now)`
+  + fail-open DB reader `getActiveSelfUpgradeBlackout(now)`.
+- Cron gate (`self-upgrade.ts`, scheduled + non-force): skips with reason `blackout-period` BEFORE
+  the window resolution — a clean no-op (no drain, no run, no cooldown) that resumes automatically
+  when the blackout ends. Manual / Emergency-override bypasses (the operator chose this moment).
+- Status (`promotions.ts`) + Upgrade Center note (`SelfUpgradeClient.tsx`): surface
+  `blackoutUntil`/`blackoutName` so a paused schedule is explained, not opaque (a scheduled skip
+  writes no run row, so without this the pause would be invisible).
+- This is the **proactive** guard quiescence can't give: a blackout may be declared days ahead with
+  nothing yet running, so the reactive drain would never see it.
+
+### Part B — `ScheduledAgentTask` / `DeploymentWindow` — evaluated, intentionally NOT built
+
+Decided against (responsible-capacity / architecture-over-shortcuts), documented so it isn't left
+ambiguously "staged forever":
+- **`ScheduledAgentTask` proactive avoidance:** per-org agent jobs use *arbitrary* operator crons
+  (not the limited shape the calendar parses) and are typically business-hours + light (LLM prompts,
+  not heavy I/O). The quiescence coordinator already defers an upgrade that collides with an
+  *actively running* agent task, so proactively shifting the overnight window to dodge a rare
+  overnight agent job is complexity for negligible benefit.
+- **`DeploymentWindow` "allowed bands":** for a 24/7 store the derived deployment windows are empty,
+  and the inverse "constrain to allowed bands" semantics conflict with the auto-overnight model; the
+  blackout gate already covers the "don't deploy now" governance need.
+
+If real demand appears (e.g. an install that schedules heavy overnight agent jobs), reopen under a
+fresh BI — the pure picker already accepts an injected busy predicate shape, so it's an additive change.
 
 ## 6. Phases & verification
 


### PR DESCRIPTION
## What & why

Part B (final) of **BI-59591B14** (EP-UPGRADE-LIFECYCLE), completing the "don't collide with other scheduled work" effort.

An operator `BlackoutPeriod` ("no changes during our launch week") now pauses the **unattended scheduled** self-upgrade. A self-upgrade drains + restarts the customer's portal and registers as a `standard` `ChangeRequest`, so it respects the same blackouts that gate other changes (`deployment-windows.ts`) — **unless** the blackout excepts self-upgrade (`exceptions` includes `self-upgrade`/`standard`, mirroring the existing exceptions rule; no new scope policy invented). Manual / Emergency override bypasses (the operator chose this moment).

This is the **proactive** guard quiescence can't give: a blackout may be declared days ahead with nothing yet running, so the reactive drain would never see it.

## Change

- **`blackout.ts`** (new): pure `findActiveSelfUpgradeBlackout(blackouts, now)` + fail-open DB reader `getActiveSelfUpgradeBlackout(now)`.
- **Cron gate** (`self-upgrade.ts`, scheduled + non-force): skips with reason `blackout-period` **before** window resolution — a clean no-op (no drain, no run, no cooldown) that resumes automatically once the blackout ends.
- **Status** (`promotions.ts`) + **Upgrade Center note** (`SelfUpgradeClient.tsx`): surface `blackoutUntil`/`blackoutName` so a paused schedule is explained, not opaque (a scheduled skip writes no run row, so without this the pause would be invisible).

## Deliberately NOT built (evaluated, documented in the plan)

- **`ScheduledAgentTask` proactive avoidance** — per-org agent jobs use arbitrary operator crons and are typically light + business-hours; quiescence already defers an upgrade that collides with an *actively running* agent task, so proactively dodging a rare overnight one is complexity for negligible benefit.
- **`DeploymentWindow` allowed-bands** — empty for 24/7 stores, and the inverse "constrain to bands" semantics conflict with the auto-overnight model; the blackout gate covers the "don't deploy now" need.

Keeping these out is the responsible-capacity call, not an oversight — if real demand appears, reopen under a fresh BI (the pure picker already accepts an injected busy predicate shape).

## Tests

`blackout.test.ts` (pure: active/inclusive-bounds/excepted/multiple); `self-upgrade.test.ts` (scheduled skips `blackout-period`, no window check / drain / run; default null preserves all existing tests); `promotions.self-upgrade.test.ts` (status surfaces `blackoutUntil`/`blackoutName`; null when none); `SelfUpgradeClient.test.tsx` (paused-schedule note renders); `page.test.tsx` status shape updated.

## Verification

⚠️ Worktree + root clone dependency-degraded → gates run in **CI** (merge queue enforces green). `blackout.ts`'s pure predicate is unit-tested hermetically (`@dpf/db` stubbed); the DB reader is fail-open.

## UX-Fit-Decision

fits. The only UI change is an informational paused-schedule line in the existing Schedule panel, shown only when a blackout is active — no new control, no new route, no layman configuration; it surfaces an existing concept (blackout) to explain why upgrades paused (progressive disclosure).

Plan: `docs/superpowers/plans/2026-06-20-self-upgrade-avoid-scheduled-work.md` (§5 Part B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)