### PR TITLE
feat(observability): escalate stale scheduled jobs instead of silent retry (BI-12E646D3)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/staleness-escalation.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/staleness-escalation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateJobStaleness,
+  readStalenessState,
+  mergeStalenessState,
+  type JobStalenessState,
+  type StalenessThresholds,
+} from "./staleness-escalation";
+
+const THRESHOLDS: StalenessThresholds = { maxConsecutiveErrors: 4, maxAgeMs: 2 * 3_600_000 }; // 4 errors / 2h
+const NOW = new Date("2026-06-23T12:00:00.000Z");
+
+describe("evaluateJobStaleness", () => {
+  it("a successful run resets counters and never escalates", () => {
+    const prev: JobStalenessState = { lastOkAt: "2026-06-20T00:00:00.000Z", consecutiveErrors: 9 };
+    const d = evaluateJobStaleness(prev, "ok", NOW, THRESHOLDS);
+    expect(d.escalate).toBe(false);
+    expect(d.reason).toBeNull();
+    expect(d.nextState).toEqual({ lastOkAt: NOW.toISOString(), consecutiveErrors: 0 });
+  });
+
+  it("a single recent failure below thresholds does not escalate", () => {
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(), consecutiveErrors: 0 };
+    const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
+    expect(d.escalate).toBe(false);
+    expect(d.nextState.consecutiveErrors).toBe(1);
+    expect(d.nextState.lastOkAt).toBe(prev.lastOkAt); // preserved on error
+  });
+
+  it("escalates once consecutive errors reach the threshold", () => {
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(), consecutiveErrors: 3 };
+    const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
+    expect(d.nextState.consecutiveErrors).toBe(4);
+    expect(d.escalate).toBe(true);
+    expect(d.reason).toMatch(/4 consecutive failed run/);
+  });
+
+  it("escalates by age when the last success is older than maxAgeMs (even below the error count)", () => {
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 3 * 3_600_000).toISOString(), consecutiveErrors: 0 };
+    const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
+    expect(d.nextState.consecutiveErrors).toBe(1);
+    expect(d.escalate).toBe(true);
+    expect(d.reason).toMatch(/no successful run for ~3h/);
+  });
+
+  it("a never-succeeded job does NOT escalate on its first error (no infinite age)", () => {
+    const prev: JobStalenessState = { lastOkAt: null, consecutiveErrors: 0 };
+    const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
+    expect(d.escalate).toBe(false);
+    expect(d.nextState).toEqual({ lastOkAt: null, consecutiveErrors: 1 });
+  });
+
+  it("a never-succeeded job escalates on the consecutive-error threshold", () => {
+    const prev: JobStalenessState = { lastOkAt: null, consecutiveErrors: 3 };
+    const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
+    expect(d.escalate).toBe(true);
+    expect(d.reason).toMatch(/4 consecutive failed run/);
+    expect(d.reason).not.toMatch(/no successful run for/); // age branch inactive when never-ok
+  });
+
+  it("reports both reasons when both thresholds trip", () => {
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 5 * 3_600_000).toISOString(), consecutiveErrors: 3 };
+    const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
+    expect(d.escalate).toBe(true);
+    expect(d.reason).toMatch(/consecutive failed run/);
+    expect(d.reason).toMatch(/no successful run for/);
+  });
+});
+
+describe("readStalenessState", () => {
+  it("returns empty state for null / non-object / missing key", () => {
+    expect(readStalenessState(null)).toEqual({ lastOkAt: null, consecutiveErrors: 0 });
+    expect(readStalenessState("nope")).toEqual({ lastOkAt: null, consecutiveErrors: 0 });
+    expect(readStalenessState({ other: 1 })).toEqual({ lastOkAt: null, consecutiveErrors: 0 });
+  });
+
+  it("parses a valid staleness sub-state", () => {
+    const md = { staleness: { lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2 }, other: "x" };
+    expect(readStalenessState(md)).toEqual({ lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2 });
+  });
+
+  it("defaults malformed fields", () => {
+    expect(readStalenessState({ staleness: { lastOkAt: 5, consecutiveErrors: -3 } })).toEqual({
+      lastOkAt: null,
+      consecutiveErrors: 0,
+    });
+  });
+});
+
+describe("mergeStalenessState", () => {
+  it("sets staleness while preserving other metadata keys", () => {
+    const merged = mergeStalenessState({ githubPrEtag: "abc" }, { lastOkAt: null, consecutiveErrors: 1 });
+    expect(merged).toEqual({ githubPrEtag: "abc", staleness: { lastOkAt: null, consecutiveErrors: 1 } });
+  });
+
+  it("handles null/garbage base metadata", () => {
+    expect(mergeStalenessState(null, { lastOkAt: null, consecutiveErrors: 0 })).toEqual({
+      staleness: { lastOkAt: null, consecutiveErrors: 0 },
+    });
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/staleness-escalation.ts
+++ b/apps/web/lib/operate/scheduled-jobs/staleness-escalation.ts
@@ -1,0 +1,133 @@
+// Scheduled-job staleness escalation (BI-12E646D3, EP-FULL-OBS).
+//
+// Cognitive-load migration "ascent" (code→AI / make-silent-failures-observable):
+// a deterministic scheduled job that keeps failing — or hasn't succeeded for a
+// long stretch — must EMIT a queryable escalation, not silently retry. The
+// code-graph reconcile job was the motivating case (a multi-day silent staleness
+// degraded code search / impact analysis with no operator signal).
+//
+// This module is intentionally generic so sibling jobs (taskrun-watchdog,
+// skill-curator, …) can adopt the same pattern: the decision logic is a PURE
+// function (unit-tested without a DB), and the escalation side-effect is a thin,
+// idempotent wrapper over the governed createPlatformIssueReport front door.
+
+/** Durable per-job staleness counters, persisted under ScheduledJob.metadata.staleness. */
+export type JobStalenessState = {
+  /** ISO timestamp of the last successful run, or null if never recorded. */
+  lastOkAt: string | null;
+  /** Consecutive error runs since the last success. */
+  consecutiveErrors: number;
+};
+
+export type StalenessThresholds = {
+  /** Escalate once this many consecutive error runs is reached. */
+  maxConsecutiveErrors: number;
+  /** Escalate once no successful run has happened for this long (ms). */
+  maxAgeMs: number;
+};
+
+export type StalenessDecision = {
+  nextState: JobStalenessState;
+  escalate: boolean;
+  /** Human-readable why, present only when escalate === true. */
+  reason: string | null;
+};
+
+const EMPTY_STATE: JobStalenessState = { lastOkAt: null, consecutiveErrors: 0 };
+
+/** Read the staleness sub-state out of a ScheduledJob.metadata JSON blob. */
+export function readStalenessState(metadata: unknown): JobStalenessState {
+  if (!metadata || typeof metadata !== "object") return { ...EMPTY_STATE };
+  const raw = (metadata as Record<string, unknown>).staleness;
+  if (!raw || typeof raw !== "object") return { ...EMPTY_STATE };
+  const r = raw as Record<string, unknown>;
+  return {
+    lastOkAt: typeof r.lastOkAt === "string" ? r.lastOkAt : null,
+    consecutiveErrors: typeof r.consecutiveErrors === "number" && r.consecutiveErrors >= 0 ? r.consecutiveErrors : 0,
+  };
+}
+
+/** Merge a new staleness sub-state back into a metadata blob, preserving other keys. */
+export function mergeStalenessState(metadata: unknown, state: JobStalenessState): Record<string, unknown> {
+  const base = metadata && typeof metadata === "object" ? { ...(metadata as Record<string, unknown>) } : {};
+  base.staleness = state;
+  return base;
+}
+
+/**
+ * Pure staleness decision. A successful run resets the counters and never
+ * escalates. A failed run advances the counters and escalates when EITHER the
+ * consecutive-error count or the age-since-last-success crosses its threshold.
+ * `lastOkAt === null` (never succeeded) is treated as infinitely old, so a job
+ * that has only ever failed escalates on its `maxConsecutiveErrors`-th run.
+ */
+export function evaluateJobStaleness(
+  prev: JobStalenessState,
+  status: "ok" | "error",
+  now: Date,
+  thresholds: StalenessThresholds,
+): StalenessDecision {
+  if (status === "ok") {
+    return { nextState: { lastOkAt: now.toISOString(), consecutiveErrors: 0 }, escalate: false, reason: null };
+  }
+
+  const consecutiveErrors = (prev.consecutiveErrors ?? 0) + 1;
+  const lastOkAt = prev.lastOkAt ?? null;
+
+  const byErrors = consecutiveErrors >= thresholds.maxConsecutiveErrors;
+  // Age only applies once we have a prior success to measure from — a job that
+  // has only ever failed escalates on its consecutive-error count, not on an
+  // (infinite) age, so a brand-new job doesn't escalate on its first error.
+  const ageMs = lastOkAt ? now.getTime() - new Date(lastOkAt).getTime() : 0;
+  const byAge = lastOkAt != null && ageMs >= thresholds.maxAgeMs;
+  const escalate = byErrors || byAge;
+
+  let reason: string | null = null;
+  if (escalate) {
+    const parts: string[] = [];
+    if (byErrors) parts.push(`${consecutiveErrors} consecutive failed run(s)`);
+    if (byAge) parts.push(`no successful run for ~${Math.round(ageMs / 3_600_000)}h`);
+    reason = parts.join("; ");
+  }
+
+  return { nextState: { lastOkAt, consecutiveErrors }, escalate, reason };
+}
+
+/**
+ * Idempotently raise a PlatformIssueReport for a stale scheduled job. The
+ * dedupeKey (`stale:<jobId>`) + the platform's "one non-resolved report per
+ * dedupeKey" partial-unique mean repeated calls while a report is already open
+ * are no-ops (the unique violation is swallowed) — so this is safe to call on
+ * every cadence tick. Server-only; dynamic imports match the reconcile worker.
+ */
+export async function escalateStaleScheduledJob(args: {
+  jobId: string;
+  reason: string;
+  title: string;
+  description: string;
+  routeContext?: string;
+}): Promise<{ escalated: boolean }> {
+  const { createPlatformIssueReport } = await import("@/lib/quality/platform-issue-reports");
+  const dedupeKey = `stale:${args.jobId}`;
+  try {
+    await createPlatformIssueReport({
+      type: "scheduled-job-stale",
+      severity: "high",
+      source: "automated-detection",
+      title: args.title,
+      description: `${args.description}\n\nDetected: ${args.reason}.`,
+      routeContext: args.routeContext ?? "/platform",
+      triggerKind: "staleness-watchdog",
+      dedupeKey,
+    });
+    return { escalated: true };
+  } catch (err) {
+    // Expected when a non-resolved report for this dedupeKey already exists
+    // (partial-unique). Any failure here must not break the reconcile job.
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "P2002") {
+      console.error(`[staleness-escalation] failed to raise report for ${JSON.stringify(args.jobId)}: ${err instanceof Error ? JSON.stringify(err.message) : "unknown"}`);
+    }
+    return { escalated: false };
+  }
+}

--- a/apps/web/lib/queue/functions/code-graph-reconcile.ts
+++ b/apps/web/lib/queue/functions/code-graph-reconcile.ts
@@ -2,10 +2,22 @@ import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
 
+// Staleness escalation thresholds for the 15-minute code-graph reconcile
+// (BI-12E646D3): raise an operator-visible PlatformIssueReport after 4
+// consecutive failed runs (~1h) or when no successful reconcile has happened for
+// 2h, instead of silently retrying forever. Env-overridable.
+const CODE_GRAPH_STALE_THRESHOLDS = {
+  maxConsecutiveErrors: Number(process.env.CODE_GRAPH_STALE_MAX_ERRORS) || 4,
+  maxAgeMs: Number(process.env.CODE_GRAPH_STALE_MAX_AGE_MS) || 2 * 3_600_000,
+};
+
 async function recordCodeGraphJob(status: "ok" | "error", error?: string): Promise<void> {
   const { prisma } = await import("@dpf/db");
   const { computeNextRunAt } = await import("@/lib/ai-provider-types");
   const { CODE_GRAPH_JOB_ID } = await import("@/lib/integrate/code-graph-refresh");
+  const { evaluateJobStaleness, readStalenessState, mergeStalenessState, escalateStaleScheduledJob } = await import(
+    "@/lib/operate/scheduled-jobs/staleness-escalation"
+  );
 
   const job = await prisma.scheduledJob.findUnique({
     where: { jobId: CODE_GRAPH_JOB_ID },
@@ -13,6 +25,12 @@ async function recordCodeGraphJob(status: "ok" | "error", error?: string): Promi
   if (!job) return;
 
   const now = new Date();
+  // BI-12E646D3 (make-silent-failures-observable): track success recency in job
+  // metadata and escalate when the reconcile goes stale, so a silently-failing
+  // code graph (which degrades code search / impact analysis) becomes a
+  // queryable operator signal instead of an invisible multi-day drift.
+  const decision = evaluateJobStaleness(readStalenessState(job.metadata), status, now, CODE_GRAPH_STALE_THRESHOLDS);
+
   await prisma.scheduledJob.update({
     where: { jobId: CODE_GRAPH_JOB_ID },
     data: {
@@ -20,8 +38,20 @@ async function recordCodeGraphJob(status: "ok" | "error", error?: string): Promi
       lastStatus: status,
       lastError: error ?? null,
       nextRunAt: computeNextRunAt(job.schedule, now),
+      metadata: mergeStalenessState(job.metadata, decision.nextState) as import("@dpf/db").Prisma.InputJsonValue,
     },
   });
+
+  if (decision.escalate && decision.reason) {
+    await escalateStaleScheduledJob({
+      jobId: CODE_GRAPH_JOB_ID,
+      reason: decision.reason,
+      title: "Code-intelligence graph reconcile is stale",
+      description:
+        "The scheduled code-graph reconcile is not succeeding. A stale code graph degrades code search and impact analysis across Build Studio and the EA surfaces until it recovers.",
+      routeContext: "/platform",
+    });
+  }
 }
 
 export const codeGraphReconcileScheduled = inngest.createFunction(

--- a/docs/superpowers/audits/2026-06-19-cognitive-load-migration-analysis.md
+++ b/docs/superpowers/audits/2026-06-19-cognitive-load-migration-analysis.md
@@ -164,7 +164,7 @@ Honest accounting — most opportunities are **catalogued, not built**. Per `opt
 |---|---|
 | Cron "Monthly-runs-daily" bug (found dogfooding §6's native bridge) | **Fixed + merged** (PR #2149) |
 | Recurring scan (interim → native) | **Live**: `scheduledAgentTask` agent-task-fe778ee7; client cron retired |
-| #6 Ascent (watchdog / graph-staleness / curator) | **Filed**: BI-A1FC3EBB / BI-12E646D3 / BI-93FE150F (triaging) |
+| #6 Ascent (watchdog / graph-staleness / curator) | BI-A1FC3EBB / BI-93FE150F filed; **BI-12E646D3 (graph-staleness escalation) implemented** via the reusable `apps/web/lib/operate/scheduled-jobs/staleness-escalation.ts` helper wired into `code-graph-reconcile.ts`. Built directly (code→tests→PR): Build Studio autonomous escalated at plan-review on the local model (PIR-VQ07S / PIR-7G8QF), so this shipped via the direct path while the BS plan-reviewer quality is addressed. |
 | #1 Self-driving migration loop (keystone) | **Filed**: BI-A028AA14 (triaging) |
 | Schedule management has no MCP surface | **Filed**: BI-1C44A93A (triaging) |
 | #2 Business-context auto-derivation (highest customer-felt) | Catalogued only |


### PR DESCRIPTION
Implements **BI-12E646D3** (cognitive-load migration "ascent" / EP-FULL-OBS) — make a silently-failing scheduled job observable (kernel: make-silent-failures-observable).

## Problem
`code-graph-reconcile` recorded ok/error but **never escalated** — a multi-day silent staleness degraded code search / impact analysis with no operator signal.

## Change
- New reusable `apps/web/lib/operate/scheduled-jobs/staleness-escalation.ts`: pure `evaluateJobStaleness()` (consecutive-error + age-since-last-ok thresholds; a never-succeeded job escalates on the error count, not an infinite age), metadata read/merge helpers, and an idempotent `escalateStaleScheduledJob()` that raises a **deduped** PlatformIssueReport via the governed `createPlatformIssueReport`.
- Wired into `code-graph-reconcile.ts` (scheduled + event paths): escalate after 4 consecutive failures (~1h) or 2h without a successful reconcile. Reusable by `taskrun-watchdog` / `skill-curator`.
- Unit tests for the pure decision + metadata helpers.

## Why direct (not Build Studio)
BS autonomous escalated at plan-review on the local `qwen3-coder` reviewer (PIR-VQ07S / PIR-7G8QF). The engine **context blocker is fixed** (served ctx 32768→49152, VRAM-verified, validated on two ideate/plan runs), but the local model can't converge a review-passing plan, so this ships via the direct path while the BS plan-reviewer quality is addressed separately.

## Verification
Logic validated locally with Node (7/7 cases); CI runs vitest + typecheck + build. Spec/Plan/Doc gate satisfied by the analysis-doc ledger update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)