### PR TITLE
fix(build-studio): round-aware test-first relaxation so feature plans converge on the local reviewer (BI-5ED28E2D)

### DIFF
--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -8,6 +8,7 @@ import {
   ARCHITECTURE_REVIEW_REFERENCES,
   parseReviewResponse,
   applyTestFirstLenienceForKind,
+  relaxTestFirstAfterRounds,
   extractClaimsFromReview,
   buildReviewBranchArtifacts,
   collectReviewerVerdicts,
@@ -235,7 +236,49 @@ describe("applyTestFirstLenienceForKind", () => {
     expect(out.decision).toBe("fail");
     expect(out.issues[0].severity).toBe("critical");
   });
+});
 
+describe("relaxTestFirstAfterRounds (round-aware, kind-agnostic)", () => {
+  const featureTestFirst = {
+    decision: "fail" as const,
+    issues: [
+      { severity: "critical" as const, description: "Task 2 does not specify a real failing test to write first for the new counter." },
+      { severity: "important" as const, description: "Task 1 omits the expected function signature." },
+    ],
+    summary: "test-first on a feature",
+  };
+
+  it("relaxes test-first criticals for a FEATURE plan once rounds are exhausted → decision flips to pass", () => {
+    const out = relaxTestFirstAfterRounds(featureTestFirst, 3);
+    expect(out.decision).toBe("pass");
+    expect(out.issues.find((i) => i.description.includes("test to write first"))?.severity).toBe("minor");
+    // unrelated non-test-first issues are preserved as-is
+    expect(out.issues.find((i) => i.description.includes("function signature"))?.severity).toBe("important");
+  });
+
+  it("annotates the downgrade with the round so the review trail stays legible", () => {
+    const out = relaxTestFirstAfterRounds(featureTestFirst, 4);
+    expect(out.issues.find((i) => i.severity === "minor")?.description).toMatch(/after 4 plan-review rounds/);
+  });
+
+  it("does NOT relax a genuine non-test-first blocker — stays failing so the build still escalates", () => {
+    const realBlocker = {
+      decision: "fail" as const,
+      issues: [{ severity: "critical" as const, description: "Plan refers to a missing modify target: lib/gone.ts" }],
+      summary: "missing file",
+    };
+    const out = relaxTestFirstAfterRounds(realBlocker, 3);
+    expect(out.decision).toBe("fail");
+    expect(out.issues[0].severity).toBe("critical");
+  });
+
+  it("returns the same review unchanged when there are no test-first criticals", () => {
+    const clean = { decision: "pass" as const, issues: [], summary: "ok" };
+    expect(relaxTestFirstAfterRounds(clean, 5)).toBe(clean);
+  });
+});
+
+describe("buildPlanReviewPrompt (task context + delta-aware)", () => {
   it("includes task count for reviewer context", () => {
     const prompt = buildPlanReviewPrompt({
       fileStructure: [],

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -482,21 +482,55 @@ export function applyTestFirstLenienceForKind(
   kind: string | null | undefined,
 ): ReviewResult {
   if (!kind || !TEST_FIRST_LENIENT_KINDS.has(kind)) return review;
+  return downgradeTestFirstCriticals(
+    review,
+    `[non-blocking for a ${kind} build — test-first is a feature-grade gate]`,
+  );
+}
+
+/**
+ * Core downgrade: turn every test-first *critical* into a non-blocking *minor*
+ * and recompute the severity-driven decision. `note` is appended to each
+ * downgraded issue so the reason stays visible in the review trail. Genuine
+ * blockers (missing files, broken logic, oversized tasks) never match the
+ * test-first matchers and are left untouched. Pure + side-effect-free.
+ */
+function downgradeTestFirstCriticals(review: ReviewResult, note: string): ReviewResult {
   let changed = false;
   const issues = review.issues.map((i) => {
     if (i.severity === "critical" && (TEST_FIRST_ISSUE_RE.test(i.description) || TEST_BEFORE_IMPL_RE.test(i.description))) {
       changed = true;
-      return {
-        ...i,
-        severity: "minor" as const,
-        description: `${i.description} [non-blocking for a ${kind} build — test-first is a feature-grade gate]`,
-      };
+      return { ...i, severity: "minor" as const, description: `${i.description} ${note}` };
     }
     return i;
   });
   if (!changed) return review;
   const decision: "pass" | "fail" = issues.some((i) => i.severity === "critical") ? "fail" : "pass";
   return { ...review, issues, decision };
+}
+
+/**
+ * BI-5ED28E2D — Round-aware test-first relaxation (kind-agnostic).
+ *
+ * applyTestFirstLenienceForKind above EXCLUDES feature builds by design —
+ * features should carry tests. But a weak reviewer (notably the on-host local
+ * model) over-applies test-first to feature *plans* and invents non-requirements
+ * ("add a test that a function is exported"), wedging the plan gate so a feature
+ * can never converge and escalates to a human forever.
+ *
+ * This relaxes test-first criticals for ANY kind. The CALLER gates it on round:
+ * only after a plan has cycled through its genuine fix rounds and the ONLY
+ * remaining blockers are test-first complaints does it apply — and the test-first
+ * requirement is still enforced downstream at the build/build-review gates (which
+ * review the actual code, not the plan's prose). Real (non-test-first) blockers
+ * never match the matchers, so they keep failing the gate and the build still
+ * escalates. Pure + side-effect-free so it is trivially unit-testable.
+ */
+export function relaxTestFirstAfterRounds(review: ReviewResult, round: number): ReviewResult {
+  return downgradeTestFirstCriticals(
+    review,
+    `[downgraded after ${round} plan-review rounds — only test-first complaints remained; downstream build + review gates still enforce tests]`,
+  );
 }
 
 // ─── Response Parsing ────────────────────────────────────────────────────────

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -9003,7 +9003,7 @@ export async function executeTool(
           data: { review, blocked: true, action: "revise_and_resubmit" },
         };
       }
-      const { buildPlanReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews, applyTestFirstLenienceForKind, collectReviewerVerdicts } = await import("@/lib/build-reviewers");
+      const { buildPlanReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews, applyTestFirstLenienceForKind, relaxTestFirstAfterRounds, collectReviewerVerdicts } = await import("@/lib/build-reviewers");
       // BI-4396EFEC (D38) — Compute the iteration context up front so we can
       // (a) feed prior issues into the reviewer prompt and (b) populate
       // ReviewResult.iteration on the output. Round is 1-based: first
@@ -9061,7 +9061,27 @@ export async function executeTool(
       // feature-grade gate). Enforced in code so it does not depend on the
       // reviewer model honoring the rubric's prose exemption — the local model
       // in particular over-applies TDD to comment/chore tasks.
-      const mergedReview = applyTestFirstLenienceForKind(rawMergedReview, build.kind);
+      let mergedReview = applyTestFirstLenienceForKind(rawMergedReview, build.kind);
+      // Round-aware test-first relaxation. The kind-lenience above excludes
+      // feature builds by design, but a weak reviewer (notably the on-host local
+      // model) over-applies test-first to feature plans and invents
+      // non-requirements ("add a test that a function is exported"), wedging the
+      // gate so a feature can never converge and escalates forever. Once a plan
+      // has cycled through its genuine fix rounds (currentRound >= the relax
+      // floor; default 3 = the initial review + 2 PLAN_FIX_MAX_ROUNDS fix rounds)
+      // and the ONLY remaining blockers are test-first complaints, downgrade them
+      // so the build proceeds — the test-first requirement is still enforced
+      // downstream at the build/build-review gates (which review the actual code).
+      // Real blockers never match the matchers, so a genuinely-broken plan still
+      // fails and escalates. Early rounds (1..2) are completely unaffected.
+      const testFirstRelaxFloor = Number(process.env.FEATURE_TESTFIRST_RELAX_ROUND) || 3;
+      if (mergedReview.decision === "fail" && currentRound >= testFirstRelaxFloor) {
+        const relaxed = relaxTestFirstAfterRounds(mergedReview, currentRound);
+        if (relaxed.decision === "pass") {
+          mergedReview = relaxed;
+          logBuildActivity(buildId, "reviewBuildPlan", `Round ${currentRound}: remaining plan-review blockers were test-first-only — downgraded so the build proceeds; downstream gates still enforce tests.`);
+        }
+      }
       // BI-4396EFEC (D38) — Compute the iteration delta against the prior
       // round and attach to the ReviewResult. computeReviewDelta + isOscillating
       // live in feature-build-types so they're independently unit-testable.


### PR DESCRIPTION
## Problem
Autonomous Build Studio cannot complete **feature** builds on a fully-local deployment. After the engine context blocker was fixed (qwen3-coder ctx 32768→49152), builds clear ideate/design and generate a plan, then **escalate at plan-review forever** (PIR-VQ07S, PIR-7G8QF): the on-host local reviewer over-applies test-first to feature *plans* and invents non-requirements (e.g. *"add a test that a function is exported"*). The bounded plan-fix loop (`PLAN_FIX_MAX_ROUNDS`) can't converge against a reviewer that re-raises an unsatisfiable demand, so every feature escalates to a human.

The existing deterministic lenience (`applyTestFirstLenienceForKind`) **excludes `feature` by design** — features should carry tests — so it doesn't help here.

## Fix
A **round-aware**, **kind-agnostic** `relaxTestFirstAfterRounds`, applied in the `reviewBuildPlan` handler and gated on `currentRound`:

- Triggers only at `currentRound >= FEATURE_TESTFIRST_RELAX_ROUND` (default **3** = the initial review + 2 `PLAN_FIX_MAX_ROUNDS` fix rounds) — i.e. **after** the build has had its genuine fix attempts. Early rounds (1–2) are completely unaffected.
- Adopted **only if it flips the decision to `pass`** — meaning the *only* remaining blockers were test-first complaints. A feature then proceeds to build on its final attempt instead of escalating.
- **Genuine (non-test-first) blockers never match the matchers**, so a truly-broken plan still fails the gate and still escalates.
- The test-first requirement remains enforced **downstream** at the build / build-review gates, which review the actual code (not the plan's prose).

This is **additive and opt-in by round** — zero behavior change for normal early-round reviews and for chore/fix/docs (which keep the existing kind-lenience).

## Implementation
- `build-reviewers.ts`: extract the shared downgrade core out of `applyTestFirstLenienceForKind` (no behavior change for chore/fix/docs) + add the pure, unit-tested `relaxTestFirstAfterRounds(review, round)`.
- `mcp-tools.ts`: in the `reviewBuildPlan` handler, after the kind-lenience, relax test-first for any kind once `currentRound` reaches the floor, adopting the result only when it flips to pass; logs a build-activity line so the downgrade is legible.
- `build-reviewers.test.ts`: 4 unit tests (feature relaxed → pass; round annotated; real blocker still fails; clean review unchanged). Logic validated locally via Node (8/8) since the worktree's node_modules is degraded; CI runs the full suite + typecheck.

## Risk
Bounded: only test-first issues, only after genuine fix rounds, only when it flips to pass, with downstream test gates intact. Closes the wall that blocks autonomous Build Studio completion of the cognitive-load ascent BIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)