### PR TITLE
fix(crm): equip Customer Success Manager with CRM tools, drop dangerous backlog_write

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/quotes/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/quotes/page.tsx
@@ -79,7 +79,11 @@ export default async function QuotesPage({ searchParams }: { searchParams?: Prom
       </div>
 
       {quotes.length === 0 && (
-        <p className="text-sm text-[var(--dpf-muted)]">No quotes created yet.</p>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          No quotes yet. Ask the Customer Success Manager (top right) to draft one —
+          it can set up the account, opportunity, and quote for you. A quote is built
+          against an opportunity, so it will create that first if the pipeline is empty.
+        </p>
       )}
       </>)}
     </div>

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -21,6 +21,7 @@ export type CapabilityKey =
   | "view_inventory"
   | "view_employee"
   | "view_customer"
+  | "operate_customer"
   | "view_operations"
   | "view_platform"
   | "view_admin"
@@ -58,6 +59,10 @@ export const PERMISSIONS: Record<CapabilityKey, Permission> = {
   view_inventory:              { roles: ["HR-000", "HR-300"] },
   view_employee:               { roles: ["HR-000", "HR-100", "HR-200", "HR-300", "HR-400", "HR-500"] },
   view_customer:               { roles: ["HR-000", "HR-200"] },
+  // CRM write (draft opportunities/quotes/accounts) — same role tier as
+  // view_customer; the Customer Success Manager coworker drafts internal,
+  // reversible records (status=draft), never external sends.
+  operate_customer:            { roles: ["HR-000", "HR-200"] },
   view_operations:             { roles: ["HR-000", "HR-500"] },
   view_platform:               { roles: ["HR-000", "HR-200", "HR-300"] },
   view_admin:                  { roles: ["HR-000"] },

--- a/apps/web/lib/mcp-tools-crm-handlers.test.ts
+++ b/apps/web/lib/mcp-tools-crm-handlers.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Exercises the CRM tool handler bodies in executeTool: param marshalling,
+// validation, message formatting, and delegation to the crm.ts actions.
+// prisma (read handlers) and @/lib/actions/crm (write handlers) are mocked.
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    customerAccount: { findMany: vi.fn() },
+    opportunity: { findMany: vi.fn(), findFirst: vi.fn() },
+    quote: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+  DISCOVERY_TRIAGE_AGENT_ID: "discovery-triage",
+}));
+
+const { mockCrm } = vi.hoisted(() => ({
+  mockCrm: {
+    createCustomerAccount: vi.fn(),
+    createOpportunity: vi.fn(),
+    createQuote: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/actions/crm", () => mockCrm);
+
+import { executeTool } from "./mcp-tools";
+
+afterEach(() => vi.clearAllMocks());
+
+describe("CRM tool handlers", () => {
+  it("list_customer_accounts summarizes accounts with their counts", async () => {
+    mockPrisma.customerAccount.findMany.mockResolvedValue([
+      { id: "a1", accountId: "ACCT-1", name: "Acme", status: "prospect", industry: "Tech", _count: { opportunities: 2, quotes: 1 } },
+    ]);
+    const res = await executeTool("list_customer_accounts", {}, "user_test");
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/Acme \(ACCT-1\) — prospect, Tech/);
+  });
+
+  it("list_opportunities formats rows and excludes dormant opportunities by default", async () => {
+    mockPrisma.opportunity.findMany.mockResolvedValue([
+      { id: "o1", opportunityId: "OPP-1", title: "Acme renewal", stage: "proposal", probability: 60, expectedValue: "12000", currency: "USD", expectedClose: null, account: { name: "Acme" } },
+    ]);
+    const res = await executeTool("list_opportunities", {}, "user_test");
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/Acme renewal \(OPP-1\) — proposal 60%/);
+    expect(mockPrisma.opportunity.findMany.mock.calls[0][0].where.isDormant).toBe(false);
+  });
+
+  it("list_opportunities returns an explicit empty-pipeline message", async () => {
+    mockPrisma.opportunity.findMany.mockResolvedValue([]);
+    const res = await executeTool("list_opportunities", {}, "user_test");
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/No opportunities in the pipeline yet/);
+  });
+
+  it("create_opportunity requires title and accountId and does not call the action without them", async () => {
+    const res = await executeTool("create_opportunity", { title: "X" }, "user_test");
+    expect(res.success).toBe(false);
+    expect(res.message).toMatch(/accountId/);
+    expect(mockCrm.createOpportunity).not.toHaveBeenCalled();
+  });
+
+  it("create_opportunity delegates to the CRM action, threads the userId, and reports the new id", async () => {
+    mockCrm.createOpportunity.mockResolvedValue({ id: "o9", opportunityId: "OPP-9", title: "New deal", stage: "qualification", account: { name: "Acme" } });
+    const res = await executeTool("create_opportunity", { title: "New deal", accountId: "a1", expectedValue: 5000 }, "user_test");
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/OPP-9/);
+    expect(mockCrm.createOpportunity).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "New deal", accountId: "a1", expectedValue: 5000, userId: "user_test" }),
+    );
+  });
+
+  it("create_quote validates that at least one line item is present", async () => {
+    const res = await executeTool("create_quote", { opportunityId: "o1", validUntil: "2026-07-31", lineItems: [] }, "user_test");
+    expect(res.success).toBe(false);
+    expect(mockCrm.createQuote).not.toHaveBeenCalled();
+  });
+
+  it("create_quote drafts a quote, passes line items through, and surfaces the computed total", async () => {
+    mockCrm.createQuote.mockResolvedValue({ quoteId: "QUO-1", quoteNumber: "QUO-2026-0001", status: "draft", currency: "USD", totalAmount: "1100" });
+    const res = await executeTool(
+      "create_quote",
+      { opportunityId: "o1", validUntil: "2026-07-31", lineItems: [{ description: "Setup", quantity: 1, unitPrice: 1000, taxPercent: 10 }] },
+      "user_test",
+    );
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/QUO-2026-0001/);
+    expect(res.message).toMatch(/draft and has not been sent/);
+    expect(mockCrm.createQuote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        opportunityId: "o1",
+        validUntil: "2026-07-31",
+        userId: "user_test",
+        lineItems: [expect.objectContaining({ description: "Setup", quantity: 1, unitPrice: 1000, taxPercent: 10 })],
+      }),
+    );
+  });
+});

--- a/apps/web/lib/mcp-tools-crm.test.ts
+++ b/apps/web/lib/mcp-tools-crm.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { getAvailableTools } from "./mcp-tools";
+import { getAgentToolGrants, isToolAllowedByGrants } from "./tak/agent-grants";
+
+// EP-CRM-COWORKER. The Customer Success Manager (customer-advisor) previously
+// resolved to a backlog/build tool surface with no CRM tools and a dangerous
+// backlog_write grant (it retired live backlog items while flailing). These
+// tests pin the re-scoped surface: CRM read/write in, backlog mutation out.
+
+const adminUser = { userId: "user-1", platformRole: "HR-000", isSuperuser: false };
+const inventoryUser = { userId: "user-2", platformRole: "HR-300", isSuperuser: false };
+
+const CRM_READ_TOOLS = ["list_customer_accounts", "list_opportunities", "get_opportunity", "list_quotes"];
+const CRM_WRITE_TOOLS = ["create_customer_account", "create_opportunity", "create_quote"];
+
+describe("CRM coworker tools", () => {
+  it("exposes the CRM read + write tools to the customer-advisor coworker", async () => {
+    const tools = await getAvailableTools(adminUser, {
+      externalAccessEnabled: false,
+      agentId: "customer-advisor",
+    });
+    const names = tools.map((t) => t.name);
+    for (const t of [...CRM_READ_TOOLS, ...CRM_WRITE_TOOLS]) {
+      expect(names, `expected ${t} on the customer-advisor surface`).toContain(t);
+    }
+  });
+
+  it("CRM read tools require only view_customer and are not side-effecting", async () => {
+    const tools = await getAvailableTools(adminUser, { externalAccessEnabled: false, agentId: "customer-advisor" });
+    for (const name of CRM_READ_TOOLS) {
+      const tool = tools.find((t) => t.name === name)!;
+      expect(tool, name).toBeDefined();
+      expect(tool.requiredCapability).toBe("view_customer");
+      expect(tool.sideEffect ?? false).toBe(false);
+    }
+  });
+
+  it("CRM draft-create tools are coworkerArtifacts so they survive advise (hands-off) mode", async () => {
+    const tools = await getAvailableTools(adminUser, { externalAccessEnabled: false, agentId: "customer-advisor" });
+    for (const name of CRM_WRITE_TOOLS) {
+      const tool = tools.find((t) => t.name === name)!;
+      expect(tool, name).toBeDefined();
+      expect(tool.requiredCapability).toBe("operate_customer");
+      expect(tool.sideEffect).toBe(true);
+      expect(tool.coworkerArtifact).toBe(true);
+    }
+  });
+
+  it("a user without view_customer does not see CRM tools even via the agent", async () => {
+    const tools = await getAvailableTools(inventoryUser, { externalAccessEnabled: false, agentId: "customer-advisor" });
+    const names = tools.map((t) => t.name);
+    for (const t of [...CRM_READ_TOOLS, ...CRM_WRITE_TOOLS]) {
+      expect(names).not.toContain(t);
+    }
+  });
+
+  it("drops the dangerous backlog-mutation tools from the customer-advisor surface", async () => {
+    const tools = await getAvailableTools(adminUser, { externalAccessEnabled: false, agentId: "customer-advisor" });
+    const names = tools.map((t) => t.name);
+    for (const t of ["retire_backlog_item", "create_backlog_item", "create_epic", "propose_build_decomposition"]) {
+      expect(names, `${t} must NOT be on the customer-advisor surface`).not.toContain(t);
+    }
+  });
+
+  it("customer-advisor registry grants drop backlog_write and add crm grants", () => {
+    const grants = getAgentToolGrants("customer-advisor");
+    expect(grants).toBeTruthy();
+    expect(grants).not.toContain("backlog_write");
+    expect(grants).toEqual(expect.arrayContaining(["crm_read", "crm_write", "backlog_read", "registry_read"]));
+  });
+
+  it("crm_write authorizes CRM writes and implies crm_read; backlog_write does not couple in", () => {
+    expect(isToolAllowedByGrants("create_quote", ["crm_write"])).toBe(true);
+    expect(isToolAllowedByGrants("create_opportunity", ["crm_write"])).toBe(true);
+    expect(isToolAllowedByGrants("create_customer_account", ["crm_write"])).toBe(true);
+    // crm_write → crm_read implication: a writer can always read the pipeline it drafts against
+    expect(isToolAllowedByGrants("list_opportunities", ["crm_write"])).toBe(true);
+    // crm_read alone is read-only — never authorizes a write
+    expect(isToolAllowedByGrants("create_quote", ["crm_read"])).toBe(false);
+    // no accidental coupling: the engineering backlog grant must not open CRM writes
+    expect(isToolAllowedByGrants("create_quote", ["backlog_write"])).toBe(false);
+    // and the CRM grant must not open the backlog
+    expect(isToolAllowedByGrants("retire_backlog_item", ["crm_write"])).toBe(false);
+  });
+
+  it("crm_read authorizes CRM reads but not writes", () => {
+    for (const t of CRM_READ_TOOLS) {
+      expect(isToolAllowedByGrants(t, ["crm_read"])).toBe(true);
+    }
+    for (const t of CRM_WRITE_TOOLS) {
+      expect(isToolAllowedByGrants(t, ["crm_read"])).toBe(false);
+    }
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1455,6 +1455,138 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "list_customer_accounts",
+    description: "List customer accounts in the CRM (name, status, industry, and open-opportunity count). Use this on the Customer workspace to see who the accounts/prospects are before qualifying opportunities or drafting a quote.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", description: "Optional status filter, e.g. prospect, active, at_risk, closed." },
+        limit: { type: "number", description: "Max rows (default 25, max 100)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_customer",
+    sideEffect: false,
+  },
+  {
+    name: "list_opportunities",
+    description: "List sales-pipeline opportunities (title, stage, probability, expected value, account). Use this to review the pipeline and find the strongest candidates to qualify. Stages: qualification, discovery, proposal, negotiation, closed_won, closed_lost.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        stage: { type: "string", description: "Optional stage filter." },
+        accountId: { type: "string", description: "Filter to one account (CustomerAccount.id)." },
+        includeDormant: { type: "boolean", description: "Include dormant opportunities (default false)." },
+        limit: { type: "number", description: "Max rows (default 25, max 100)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_customer",
+    sideEffect: false,
+  },
+  {
+    name: "get_opportunity",
+    description: "Get one opportunity with its account, contact, and existing quotes. Use this to confirm an opportunity's details and its id before drafting a quote against it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        opportunityId: { type: "string", description: "Opportunity.id or the OPP-… opportunityId." },
+      },
+      required: ["opportunityId"],
+    },
+    requiredCapability: "view_customer",
+    sideEffect: false,
+  },
+  {
+    name: "list_quotes",
+    description: "List quotes (number, status, total, account, opportunity). Use this to see existing quotes before drafting a new one. Quote statuses: draft, sent, accepted, rejected, expired, superseded.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", description: "Optional status filter, e.g. draft, sent, accepted." },
+        opportunityId: { type: "string", description: "Filter to one opportunity (Opportunity.id)." },
+        limit: { type: "number", description: "Max rows (default 25, max 100)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_customer",
+    sideEffect: false,
+  },
+  {
+    name: "create_customer_account",
+    description: "Create a customer account (a company or prospect) in the CRM. This is the first step when the CRM is empty — an account is required before an opportunity or quote can exist. Creates an internal record only; nothing is sent to the customer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Company / account name." },
+        website: { type: "string", description: "Optional website URL." },
+        industry: { type: "string", description: "Optional industry." },
+        status: { type: "string", description: "prospect (default) | active | at_risk | closed." },
+        notes: { type: "string", description: "Optional free-text notes." },
+      },
+      required: ["name"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+    coworkerArtifact: true,
+  },
+  {
+    name: "create_opportunity",
+    description: "Create (propose) a sales-pipeline opportunity against an existing account. Use this to turn a qualified lead into a tracked opportunity. Defaults to the 'qualification' stage. Creates an internal record for human review; nothing is sent externally.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Short opportunity title." },
+        accountId: { type: "string", description: "CustomerAccount.id this opportunity belongs to (from list_customer_accounts)." },
+        stage: { type: "string", description: "qualification (default) | discovery | proposal | negotiation." },
+        expectedValue: { type: "number", description: "Estimated deal value." },
+        currency: { type: "string", description: "ISO currency code, default USD." },
+        expectedClose: { type: "string", description: "ISO date the deal is expected to close." },
+        notes: { type: "string", description: "Optional qualification notes." },
+      },
+      required: ["title", "accountId"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+    coworkerArtifact: true,
+  },
+  {
+    name: "create_quote",
+    description: "Draft a quote against an existing opportunity with one or more line items. Line totals, subtotal, discount, tax, and grand total are computed automatically and the quote is saved in 'draft' status — it is NOT sent to the customer. Get the opportunity id from list_opportunities / get_opportunity first.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        opportunityId: { type: "string", description: "Opportunity.id the quote is for (from list_opportunities)." },
+        validUntil: { type: "string", description: "ISO date the quote is valid until, e.g. 2026-07-31." },
+        lineItems: {
+          type: "array",
+          description: "One or more quote line items.",
+          items: {
+            type: "object",
+            properties: {
+              description: { type: "string", description: "Line description." },
+              quantity: { type: "number", description: "Quantity (default 1)." },
+              unitPrice: { type: "number", description: "Unit price." },
+              discountPercent: { type: "number", description: "Optional per-line discount %." },
+              taxPercent: { type: "number", description: "Optional per-line tax %." },
+              productId: { type: "string", description: "Optional DigitalProduct id." },
+            },
+            required: ["description", "quantity", "unitPrice"],
+          },
+        },
+        currency: { type: "string", description: "ISO currency code, default USD." },
+        discountType: { type: "string", description: "percentage (default) | fixed — header-level discount." },
+        discountValue: { type: "number", description: "Header discount amount (percent or fixed per discountType)." },
+        terms: { type: "string", description: "Optional terms text." },
+        notes: { type: "string", description: "Optional notes." },
+      },
+      required: ["opportunityId", "validUntil", "lineItems"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+    coworkerArtifact: true,
+  },
+  {
     name: "get_finance_period_summary",
     description: "Return verified income, expenses, and net for a finance period (defaults to month-to-date). Income = sum of paid invoices; expenses = sum of paid bills + paid expense claims; net = income - expenses. Includes pending receivables/payables, multi-currency flags, source paths, and explicit gap descriptions when activity is missing. Use this whenever the user asks for a P&L figure, income vs expenses, or net cash position for a period - it is the canonical numeric answer for the Finance Specialist coworker.",
     inputSchema: {
@@ -15159,6 +15291,181 @@ export async function executeTool(
           };
         case "error":
           return { success: false, message: result.message, error: result.message };
+      }
+    }
+
+    case "list_customer_accounts": {
+      const status = typeof params["status"] === "string" ? params["status"].trim() : undefined;
+      const take = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
+      const accounts = await prisma.customerAccount.findMany({
+        where: status ? { status } : undefined,
+        orderBy: { createdAt: "desc" },
+        take,
+        select: {
+          id: true, accountId: true, name: true, status: true, industry: true,
+          _count: { select: { opportunities: true, quotes: true } },
+        },
+      });
+      if (accounts.length === 0) {
+        return { success: true, message: "No customer accounts yet. Use create_customer_account to add the first one.", data: { accounts: [] } };
+      }
+      const lines = accounts.map((a) =>
+        `${a.name} (${a.accountId}) — ${a.status}${a.industry ? `, ${a.industry}` : ""} · ${a._count.opportunities} opp / ${a._count.quotes} quote`);
+      return { success: true, message: `${accounts.length} account(s):\n${lines.join("\n")}`, data: { accounts } };
+    }
+
+    case "list_opportunities": {
+      const stage = typeof params["stage"] === "string" ? params["stage"].trim() : undefined;
+      const accountId = typeof params["accountId"] === "string" ? params["accountId"].trim() : undefined;
+      const includeDormant = params["includeDormant"] === true;
+      const take = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
+      const opportunities = await prisma.opportunity.findMany({
+        where: {
+          ...(stage ? { stage } : {}),
+          ...(accountId ? { accountId } : {}),
+          ...(includeDormant ? {} : { isDormant: false }),
+        },
+        orderBy: { stageChangedAt: "desc" },
+        take,
+        select: {
+          id: true, opportunityId: true, title: true, stage: true, probability: true,
+          expectedValue: true, currency: true, expectedClose: true,
+          account: { select: { name: true } },
+        },
+      });
+      if (opportunities.length === 0) {
+        return { success: true, message: "No opportunities in the pipeline yet. Use create_opportunity to add one against an account.", data: { opportunities: [] } };
+      }
+      const lines = opportunities.map((o) =>
+        `${o.title} (${o.opportunityId}) — ${o.stage} ${o.probability}% · ${o.account.name}${o.expectedValue != null ? ` · ${o.currency} ${Number(o.expectedValue).toLocaleString()}` : ""}`);
+      return { success: true, message: `${opportunities.length} opportunit${opportunities.length === 1 ? "y" : "ies"}:\n${lines.join("\n")}`, data: { opportunities } };
+    }
+
+    case "get_opportunity": {
+      const idRaw = typeof params["opportunityId"] === "string" ? params["opportunityId"].trim() : "";
+      if (!idRaw) return { success: false, error: "missing_opportunityId", message: "opportunityId is required." };
+      const opp = await prisma.opportunity.findFirst({
+        where: { OR: [{ id: idRaw }, { opportunityId: idRaw }] },
+        include: {
+          account: { select: { id: true, accountId: true, name: true } },
+          quotes: { select: { quoteNumber: true, status: true, totalAmount: true, currency: true } },
+        },
+      });
+      if (!opp) return { success: false, error: "not_found", message: `Opportunity ${idRaw} not found.` };
+      const quoteLine = opp.quotes.length
+        ? `\nQuotes: ${opp.quotes.map((q) => `${q.quoteNumber} (${q.status}, ${q.currency} ${Number(q.totalAmount).toLocaleString()})`).join("; ")}`
+        : "\nQuotes: none yet";
+      return {
+        success: true,
+        message: `${opp.title} (${opp.opportunityId}) — ${opp.stage} ${opp.probability}% · account ${opp.account.name} (id ${opp.account.id})${opp.expectedValue != null ? ` · ${opp.currency} ${Number(opp.expectedValue).toLocaleString()}` : ""}${quoteLine}`,
+        data: { opportunity: opp },
+      };
+    }
+
+    case "list_quotes": {
+      const status = typeof params["status"] === "string" ? params["status"].trim() : undefined;
+      const opportunityId = typeof params["opportunityId"] === "string" ? params["opportunityId"].trim() : undefined;
+      const take = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
+      const quotes = await prisma.quote.findMany({
+        where: { ...(status ? { status } : {}), ...(opportunityId ? { opportunityId } : {}) },
+        orderBy: { createdAt: "desc" },
+        take,
+        select: {
+          quoteId: true, quoteNumber: true, status: true, totalAmount: true, currency: true, version: true,
+          account: { select: { name: true } },
+          opportunity: { select: { title: true } },
+        },
+      });
+      if (quotes.length === 0) {
+        return { success: true, message: "No quotes yet. Use create_quote to draft one against an opportunity.", data: { quotes: [] } };
+      }
+      const lines = quotes.map((q) =>
+        `${q.quoteNumber} v${q.version} — ${q.status} · ${q.currency} ${Number(q.totalAmount).toLocaleString()} · ${q.account.name} / ${q.opportunity.title}`);
+      return { success: true, message: `${quotes.length} quote(s):\n${lines.join("\n")}`, data: { quotes } };
+    }
+
+    case "create_customer_account": {
+      const name = typeof params["name"] === "string" ? params["name"].trim() : "";
+      if (!name) return { success: false, error: "missing_name", message: "name is required to create a customer account." };
+      const { createCustomerAccount } = await import("@/lib/actions/crm");
+      try {
+        const account = await createCustomerAccount({
+          name,
+          website: typeof params["website"] === "string" ? params["website"] : undefined,
+          industry: typeof params["industry"] === "string" ? params["industry"] : undefined,
+          status: typeof params["status"] === "string" ? params["status"] : undefined,
+          notes: typeof params["notes"] === "string" ? params["notes"] : undefined,
+        });
+        return { success: true, message: `Created customer account "${account.name}" (${account.accountId}). Use its id ${account.id} as accountId when creating an opportunity.`, data: { accountId: account.id, accountRef: account.accountId } };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { success: false, error: "create_failed", message: `create_customer_account failed: ${msg}` };
+      }
+    }
+
+    case "create_opportunity": {
+      const title = typeof params["title"] === "string" ? params["title"].trim() : "";
+      const accountId = typeof params["accountId"] === "string" ? params["accountId"].trim() : "";
+      if (!title || !accountId) {
+        return { success: false, error: "missing_fields", message: "title and accountId are required. Use list_customer_accounts to find the accountId." };
+      }
+      const { createOpportunity } = await import("@/lib/actions/crm");
+      try {
+        const opp = await createOpportunity({
+          title,
+          accountId,
+          stage: typeof params["stage"] === "string" ? params["stage"] : undefined,
+          expectedValue: typeof params["expectedValue"] === "number" ? params["expectedValue"] : undefined,
+          currency: typeof params["currency"] === "string" ? params["currency"] : undefined,
+          expectedClose: typeof params["expectedClose"] === "string" ? params["expectedClose"] : undefined,
+          notes: typeof params["notes"] === "string" ? params["notes"] : undefined,
+          userId,
+        });
+        return { success: true, message: `Created opportunity "${opp.title}" (${opp.opportunityId}) in ${opp.stage} for ${opp.account.name}. Use its id ${opp.id} as opportunityId when drafting a quote.`, data: { opportunityId: opp.id, opportunityRef: opp.opportunityId } };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { success: false, error: "create_failed", message: `create_opportunity failed: ${msg}` };
+      }
+    }
+
+    case "create_quote": {
+      const opportunityId = typeof params["opportunityId"] === "string" ? params["opportunityId"].trim() : "";
+      const validUntil = typeof params["validUntil"] === "string" ? params["validUntil"].trim() : "";
+      const rawLines = Array.isArray(params["lineItems"]) ? params["lineItems"] : [];
+      if (!opportunityId || !validUntil || rawLines.length === 0) {
+        return { success: false, error: "missing_fields", message: "opportunityId, validUntil, and at least one lineItem are required." };
+      }
+      const lineItems = rawLines.map((li) => {
+        const o = (li ?? {}) as Record<string, unknown>;
+        return {
+          description: typeof o["description"] === "string" ? o["description"] : "",
+          quantity: typeof o["quantity"] === "number" ? o["quantity"] : 1,
+          unitPrice: typeof o["unitPrice"] === "number" ? o["unitPrice"] : 0,
+          discountPercent: typeof o["discountPercent"] === "number" ? o["discountPercent"] : undefined,
+          taxPercent: typeof o["taxPercent"] === "number" ? o["taxPercent"] : undefined,
+          productId: typeof o["productId"] === "string" ? o["productId"] : undefined,
+        };
+      });
+      if (lineItems.some((l) => !l.description)) {
+        return { success: false, error: "invalid_line", message: "every lineItem needs a description." };
+      }
+      const { createQuote } = await import("@/lib/actions/crm");
+      try {
+        const quote = await createQuote({
+          opportunityId,
+          validUntil,
+          lineItems,
+          discountType: typeof params["discountType"] === "string" ? params["discountType"] : undefined,
+          discountValue: typeof params["discountValue"] === "number" ? params["discountValue"] : undefined,
+          currency: typeof params["currency"] === "string" ? params["currency"] : undefined,
+          terms: typeof params["terms"] === "string" ? params["terms"] : undefined,
+          notes: typeof params["notes"] === "string" ? params["notes"] : undefined,
+          userId,
+        });
+        return { success: true, message: `Drafted quote ${quote.quoteNumber} — ${quote.currency} ${Number(quote.totalAmount).toLocaleString()} (status ${quote.status}). It is a draft and has not been sent to the customer.`, data: { quoteId: quote.quoteId, quoteNumber: quote.quoteNumber, totalAmount: Number(quote.totalAmount) } };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { success: false, error: "create_failed", message: `create_quote failed: ${msg}` };
       }
     }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -33,6 +33,10 @@ export const GRANT_IMPLICATIONS: Readonly<Record<string, readonly string[]>> = {
   // `browser_read` (navigate / extract / screenshot). One-way, as ever —
   // `browser_read` alone never implies the drive grant.
   browser_drive: ["browser_read"],
+  // CRM drafting (crm_write) implies CRM inspection (crm_read): a coworker that
+  // can draft an opportunity or quote can always read the accounts/pipeline it
+  // is drafting against. One-way — crm_read alone never implies crm_write.
+  crm_write: ["crm_read"],
 };
 
 /** Expand a list of held grants by applying GRANT_IMPLICATIONS one-way.
@@ -402,6 +406,22 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   run_traversal_pattern:  ["ea_graph_read"],
   export_archimate:       ["ea_graph_read"],
   describe_ea_view:       ["ea_graph_read"],
+
+  // Customer / CRM (EP-CRM-COWORKER). The customer workspace (accounts,
+  // engagements, pipeline, opportunities, quotes, orders) had a rich backend
+  // (lib/actions/crm.ts) and read-only pages but NO coworker tools — so the
+  // Customer Success Manager (customer-advisor) was left with only generic
+  // backlog/registry grants and flailed (it had no way to qualify an
+  // opportunity or draft a quote). These two finer grants carry the CRM tool
+  // surface: `crm_read` for inspection, `crm_write` for drafting internal
+  // records (draft opportunities/quotes — reversible, not external sends).
+  list_customer_accounts: ["crm_read"],
+  list_opportunities:     ["crm_read"],
+  get_opportunity:        ["crm_read"],
+  list_quotes:            ["crm_read"],
+  create_customer_account: ["crm_write"],
+  create_opportunity:      ["crm_write"],
+  create_quote:            ["crm_write"],
 
   // Finance
   get_finance_period_summary:   ["financial_report_create"],

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -174,7 +174,7 @@ ON THIS PAGE: The user sees role assignments, team structures, HITL tiers, deleg
   "/customer": {
     agentId: "customer-advisor",
     agentName: "Customer Success Manager",
-    agentDescription: "Customer journey, service adoption, and satisfaction analysis",
+    agentDescription: "Customer accounts, pipeline, opportunities, quotes, and satisfaction",
     capability: "view_customer",
     sensitivity: "confidential",
     systemPrompt: `You are the Customer Success Manager.
@@ -189,10 +189,18 @@ HEURISTICS:
 
 INTERPRETIVE MODEL: You optimize for customer satisfaction and service adoption. Success means customers achieve their goals with minimum friction and maximum value from the platform.
 
-ON THIS PAGE: The user sees customer accounts and service relationships.`,
+ON THIS PAGE: The user sees the Customer workspace — accounts, engagements, pipeline, opportunities, quotes, orders, and funnel.
+
+CRM TOOLS — you operate this workspace directly, you do not just describe it:
+- Inspect: list_customer_accounts, list_opportunities, get_opportunity, and list_quotes to review accounts, the pipeline, and existing quotes.
+- Act: create_customer_account, create_opportunity (turn a qualified lead into a tracked opportunity), and create_quote (draft a quote against an opportunity, with line items). These are internal, reversible drafts — a quote is saved in draft status and is NOT sent to the customer.
+- Chaining: a quote needs an opportunity, and an opportunity needs an account. When the CRM is empty, create the account first, then the opportunity, then the quote.
+- When the user asks how to do something (for example "how do I enter a quote?"), explain the steps in plain language AND offer to do it for them with these tools.
+- Never claim a record was created unless the tool result confirms it. Sending a quote to a customer is a human action — you only draft.`,
     skills: [
-      { label: "Account overview", description: "Summarize a customer account", capability: "view_customer", prompt: "Give me an overview of this customer account" },
-      { label: "Friction analysis", description: "Where are customers struggling?", capability: "view_customer", prompt: "Where are customers experiencing friction?" },
+      { label: "Review pipeline", description: "Summarize opportunities, find the strongest", capability: "view_customer", prompt: "Review the pipeline. List the open opportunities by stage and value, and tell me the strongest candidates to advance." },
+      { label: "Draft a quote", description: "Create a draft quote for an opportunity", capability: "operate_customer", prompt: "Help me draft a quote. Show me the open opportunities first, then walk me through the line items and create the draft." },
+      { label: "Add an account", description: "Create a new customer account or prospect", capability: "operate_customer", prompt: "I want to add a new customer account." },
       { label: "Report an issue", description: "Report a bug or give feedback", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -2615,8 +2615,10 @@
         "concurrency_limit": 2,
         "tool_grants": [
           "backlog_read",
-          "backlog_write",
-          "registry_read"
+          "registry_read",
+          "consumer_read",
+          "crm_read",
+          "crm_write"
         ]
       }
     },

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -377,6 +377,33 @@
       "implies": []
     },
     {
+      "key": "crm_read",
+      "description": "Read CRM records: customer accounts, sales-pipeline opportunities, and quotes.",
+      "category": "consume",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "list_customer_accounts",
+        "list_opportunities",
+        "get_opportunity",
+        "list_quotes"
+      ],
+      "implies": []
+    },
+    {
+      "key": "crm_write",
+      "description": "Draft internal CRM records: customer accounts, opportunities, and draft quotes. Does not send quotes to customers.",
+      "category": "consume",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "create_customer_account",
+        "create_opportunity",
+        "create_quote"
+      ],
+      "implies": [
+        "crm_read"
+      ]
+    },
+    {
       "key": "contract_read",
       "description": "Read contract.",
       "category": "explore",


### PR DESCRIPTION
## Problem
The Customer Success Manager coworker (`customer-advisor`) reported *"I'm on a local AI that wasn't strong enough"* and could not enter a quote. Root cause (verified against live logs + DB) was **not** a weak local model — qwen3-coder is tool-capable and was calling tools correctly:

1. **Wrong + dangerous grants.** Its live grants were `backlog_read, backlog_write, consumer_read, marketing_read, registry_read` → 106 tools, all backlog/build/marketing/HR, **zero CRM tools**. With no domain tool it flailed — the logs show it **retiring live backlog items** (`BI-938BF2AF`, `BI-2F6F4CE9`) and filing junk BIs before tripping the local-model spin guard. `backlog_write` on a customer coworker was an actively-harmful over-grant.
2. **CRM write path not exposed.** The CRM backend (`Quote`/`Opportunity` models, `createQuote`/`createOpportunity` in `lib/actions/crm.ts`, API routes, validators, tests) was fully built but **never surfaced as coworker tools**, and the Quotes page had no create affordance. So neither the coworker nor a human had a path to enter a quote.

This is the same class as the earlier coworker tool-surface overflow — the 48-tool cap was a band-aid; this fixes the underlying division of labor.

## Fix
- **7 CRM MCP tools** (`list_customer_accounts`, `list_opportunities`, `get_opportunity`, `list_quotes`, `create_customer_account`, `create_opportunity`, `create_quote`) wired to the existing `crm.ts` actions. Create tools are `coworkerArtifact` drafts (`status=draft`, not a customer send) so they work in advise/hands-off mode; `send_quote` is deliberately **not** exposed.
- New **`crm_read`/`crm_write`** grants (`crm_write` ⇒ `crm_read`) and **`operate_customer`** capability.
- Re-scoped `customer-advisor`: dropped `backlog_write` + `marketing_read`, added `crm_read`/`crm_write`/`consumer_read` — across the registry JSON, grant catalog, and **both** live DB `Agent` rows (the duplicate-row divergence is now consistent).
- Coworker **system prompt** now names the CRM tools + adds a "draft a quote" skill (it named no tools before, so it never used any).
- Quotes empty-state points at the coworker.

## Testing
- New `mcp-tools-crm.test.ts` (tool exposure / grants / capability gating) and `mcp-tools-crm-handlers.test.ts` (handler bodies via mocked prisma/crm).
- **203 vitest pass** (incl. agent-grants, permissions, mcp-tools, tool-description-hygiene, tool-budget regressions).
- **`tsc --noEmit` clean** across `apps/web`.

## Notes / follow-ups (not in scope)
- Duplicate `Agent` rows (`AGT-WS-CUSTOMER` vs `customer-advisor`) — set to the same grants here; full dedup is a separate cleanup.
- qwen3-coder is currently served at a **4096** DMR context window (regressed from 24k) — not the cause of this bug, but worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)