### PR TITLE
feat(golden-triangle): per-coworker posture that tunes the coworker's runs (real)

### DIFF
--- a/apps/web/lib/actions/golden-triangle.ts
+++ b/apps/web/lib/actions/golden-triangle.ts
@@ -15,7 +15,9 @@ import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 import { contributePostureDefault } from "@/lib/golden-triangle/hive";
 import {
   getEffectiveGoldenTrianglePosture,
+  getEffectivePostureForAgent,
   getGoldenTrianglePosture,
+  setAgentGoldenTrianglePosture,
   setGoldenTrianglePosture,
 } from "@/lib/golden-triangle/persistence";
 
@@ -30,6 +32,33 @@ export async function getGoldenTrianglePlatformDefault(): Promise<GoldenTriangle
   const session = await auth();
   if (!session?.user) return null;
   return getGoldenTrianglePosture({ kind: "platform" });
+}
+
+/**
+ * Read the EFFECTIVE posture for a coworker (agent → org → platform), so the
+ * coworker chip reflects what actually governs that coworker's runs even before
+ * it has its own override. Session-gated read.
+ */
+export async function getCoworkerGoldenTrianglePosture(agentId: string): Promise<GoldenTrianglePreference | null> {
+  const session = await auth();
+  if (!session?.user) return null;
+  const resolved = await getEffectivePostureForAgent(agentId, null);
+  return resolved?.preference ?? null;
+}
+
+/**
+ * Save a coworker's OWN (per-agent) posture. This is what makes the priority real
+ * per coworker: the saved posture layers above org/platform and tunes that
+ * coworker's dispatch. `view_platform`-gated (a per-agent setting is shared, not
+ * per-user); a non-admin caller gets "Couldn't save" client-side.
+ */
+export async function saveCoworkerGoldenTrianglePosture(
+  agentId: string,
+  preference: GoldenTrianglePreference,
+): Promise<{ ok: boolean }> {
+  await requirePlatformAdmin();
+  const ok = await setAgentGoldenTrianglePosture(agentId, preference);
+  return { ok };
 }
 
 async function requirePlatformAdmin() {

--- a/apps/web/lib/golden-triangle/dispatch.test.ts
+++ b/apps/web/lib/golden-triangle/dispatch.test.ts
@@ -6,12 +6,18 @@ import { resolveDispatchPosture } from "./dispatch";
 import type { GoldenTrianglePersistenceClient } from "./persistence";
 
 const ASSURED: GoldenTrianglePreference = { preset: "assured", qualityWeight: 0.8, costWeight: 0.1, timeWeight: 0.1 };
+const FRUGAL: GoldenTrianglePreference = { preset: "frugal", qualityWeight: 0.1, costWeight: 0.8, timeWeight: 0.1 };
 const BALANCED: GoldenTrianglePreference = { preset: "balanced", qualityWeight: 0.34, costWeight: 0.33, timeWeight: 0.33 };
 
-function clientWith(platform: GoldenTrianglePreference | null): GoldenTrianglePersistenceClient {
+/** Fake client over the single platform-profile row that holds both the platform
+ *  default (goldenTriangle) and the per-agent map (goldenTrianglePerAgent). */
+function client(opts: { platform?: GoldenTrianglePreference; perAgent?: Record<string, GoldenTrianglePreference> }): GoldenTrianglePersistenceClient {
+  const policy: Record<string, unknown> = {};
+  if (opts.platform) policy.goldenTriangle = opts.platform;
+  if (opts.perAgent) policy.goldenTrianglePerAgent = opts.perAgent;
   return {
     decisionPerspectiveProfile: {
-      findFirst: async () => (platform ? { autonomyPolicy: { goldenTriangle: platform } } : null),
+      findFirst: async () => (Object.keys(policy).length ? { autonomyPolicy: policy } : null),
       updateMany: async () => ({ count: 0 }),
     },
   };
@@ -19,19 +25,31 @@ function clientWith(platform: GoldenTrianglePreference | null): GoldenTrianglePe
 
 describe("resolveDispatchPosture", () => {
   it("returns null when no default is saved (inert)", async () => {
-    expect(await resolveDispatchPosture(null, "conversation", clientWith(null))).toBeNull();
+    expect(await resolveDispatchPosture(null, "conversation", null, client({}))).toBeNull();
   });
 
   it("returns null for a Balanced default — byte-identical to flag-off", async () => {
-    expect(await resolveDispatchPosture(null, "conversation", clientWith(BALANCED))).toBeNull();
+    expect(await resolveDispatchPosture(null, "conversation", null, client({ platform: BALANCED }))).toBeNull();
   });
 
-  it("applies a non-Balanced posture as routing overrides", async () => {
-    const p = await resolveDispatchPosture(null, "conversation", clientWith(ASSURED));
-    expect(p).not.toBeNull();
+  it("applies the platform posture for a non-coworker run", async () => {
+    const p = await resolveDispatchPosture(null, "conversation", null, client({ platform: ASSURED }));
     expect(p?.preset).toBe("assured");
     expect(p?.source).toBe("platform");
     expect(p?.routeContext.minimumTier).toBe("frontier");
+  });
+
+  it("lets a coworker's own posture override the platform default", async () => {
+    const p = await resolveDispatchPosture("agent-x", "conversation", null, client({ platform: BALANCED, perAgent: { "agent-x": ASSURED } }));
+    expect(p?.source).toBe("agent");
+    expect(p?.preset).toBe("assured");
+    expect(p?.routeContext.minimumTier).toBe("frontier");
+  });
+
+  it("falls back to the platform default when the coworker has no own posture", async () => {
+    const p = await resolveDispatchPosture("agent-x", "conversation", null, client({ platform: ASSURED, perAgent: { other: FRUGAL } }));
+    expect(p?.source).toBe("platform");
+    expect(p?.preset).toBe("assured");
   });
 
   it("is fail-open: returns null when the db throws", async () => {
@@ -43,6 +61,6 @@ describe("resolveDispatchPosture", () => {
         updateMany: async () => ({ count: 0 }),
       },
     };
-    expect(await resolveDispatchPosture(null, "conversation", throwing)).toBeNull();
+    expect(await resolveDispatchPosture("agent-x", "conversation", null, throwing)).toBeNull();
   });
 });

--- a/apps/web/lib/golden-triangle/dispatch.ts
+++ b/apps/web/lib/golden-triangle/dispatch.ts
@@ -12,27 +12,30 @@
 // It only FEEDS routing (the compiler never re-implements routing).
 import { compileGoldenTrianglePolicy } from "./compile";
 import { applyPostureToRouteContext, type AppliedPosture } from "./compose";
-import { getEffectiveGoldenTrianglePosture, type GoldenTrianglePersistenceClient } from "./persistence";
+import { getEffectivePostureForAgent, type GoldenTrianglePersistenceClient } from "./persistence";
 import type { GoldenTrianglePreset } from "./types";
 
 export interface DispatchPosture extends AppliedPosture {
   preset: GoldenTrianglePreset;
   /** Which scope supplied the posture — for telemetry/explanation, never routing. */
-  source: "organization" | "platform";
+  source: "agent" | "organization" | "platform";
 }
 
 /**
  * Resolve the posture to apply to a dispatch, or null when nothing should change.
- * `organizationId` is null in single-org installs (falls back to the platform
- * default). Returns null for Balanced/no-op postures so callers can skip work.
+ * Layers the calling coworker's own posture ABOVE org/platform: agent → org →
+ * platform → null. `agentId` is the dispatching coworker (null for non-coworker
+ * runs); `organizationId` is null in single-org installs. Returns null for
+ * Balanced/no-op postures so callers can skip work.
  */
 export async function resolveDispatchPosture(
-  organizationId: string | null = null,
+  agentId: string | null = null,
   taskClass = "conversation",
+  organizationId: string | null = null,
   db?: GoldenTrianglePersistenceClient,
 ): Promise<DispatchPosture | null> {
   try {
-    const resolved = await getEffectiveGoldenTrianglePosture(organizationId, db);
+    const resolved = await getEffectivePostureForAgent(agentId, organizationId, db);
     if (!resolved) return null;
     const decoded = compileGoldenTrianglePolicy({
       preference: resolved.preference,

--- a/apps/web/lib/golden-triangle/persistence.test.ts
+++ b/apps/web/lib/golden-triangle/persistence.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
 import {
+  getAgentGoldenTrianglePosture,
   getEffectiveGoldenTrianglePosture,
+  getEffectivePostureForAgent,
   getGoldenTrianglePosture,
   isGoldenTrianglePreference,
+  setAgentGoldenTrianglePosture,
   setGoldenTrianglePosture,
   type GoldenTrianglePersistenceClient,
 } from "./persistence";
@@ -139,6 +142,33 @@ describe("getEffectiveGoldenTrianglePosture", () => {
 
   it("is fail-open: returns null when the db throws", async () => {
     expect(await getEffectiveGoldenTrianglePosture("org_1", throwingClient())).toBeNull();
+  });
+});
+
+describe("per-coworker (per-agent) posture", () => {
+  it("writes a coworker posture into the per-agent map, preserving other keys", async () => {
+    const { client, getPolicy } = makeClient({ goldenTriangle: FRUGAL });
+    expect(await setAgentGoldenTrianglePosture("agent-x", ASSURED, client)).toBe(true);
+    const pol = getPolicy() as Record<string, Record<string, unknown>>;
+    expect(pol.goldenTriangle).toEqual(FRUGAL);
+    expect(pol.goldenTrianglePerAgent["agent-x"]).toEqual(ASSURED);
+  });
+
+  it("reads a coworker's own posture back; null for an unset coworker", async () => {
+    const { client } = makeClient({ goldenTrianglePerAgent: { "agent-x": ASSURED } });
+    expect(await getAgentGoldenTrianglePosture("agent-x", client)).toEqual(ASSURED);
+    expect(await getAgentGoldenTrianglePosture("agent-y", client)).toBeNull();
+  });
+
+  it("layers agent over platform (the coworker's own choice wins)", async () => {
+    const { client } = makeClient({ goldenTriangle: FRUGAL, goldenTrianglePerAgent: { "agent-x": ASSURED } });
+    expect(await getEffectivePostureForAgent("agent-x", null, client)).toEqual({ preference: ASSURED, source: "agent" });
+    expect(await getEffectivePostureForAgent("agent-y", null, client)).toEqual({ preference: FRUGAL, source: "platform" });
+  });
+
+  it("is fail-open on read and write", async () => {
+    expect(await getAgentGoldenTrianglePosture("a", throwingClient())).toBeNull();
+    expect(await setAgentGoldenTrianglePosture("a", ASSURED, throwingClient())).toBe(false);
   });
 });
 

--- a/apps/web/lib/golden-triangle/persistence.ts
+++ b/apps/web/lib/golden-triangle/persistence.ts
@@ -94,7 +94,7 @@ export async function setGoldenTrianglePosture(
 }
 
 /** The scope a resolved posture came from — surfaced so the UI can show "why this default". */
-export type ResolvedPostureSource = "organization" | "platform";
+export type ResolvedPostureSource = "agent" | "organization" | "platform";
 
 export interface ResolvedPosture {
   preference: GoldenTrianglePreference;
@@ -119,4 +119,77 @@ export async function getEffectiveGoldenTrianglePosture(
   const platform = await getGoldenTrianglePosture({ kind: "platform" }, db);
   if (platform) return { preference: platform, source: "platform" };
   return null;
+}
+
+// ─── Per-coworker (per-agent) posture ────────────────────────────────────────
+//
+// Each AI coworker can remember its OWN Cost/Quality/Time posture. Stored
+// migration-free as a map keyed by agentId under the platform profile's
+// autonomyPolicy.goldenTrianglePerAgent — a single existing JSON column, no new
+// rows or schema. The per-agent posture layers ABOVE org/platform at dispatch so
+// a coworker's own choice tunes its runs (see getEffectivePostureForAgent).
+
+const PER_AGENT_KEY = "goldenTrianglePerAgent";
+
+/** Read a coworker's own saved posture, or null if it has none. Fail-open. */
+export async function getAgentGoldenTrianglePosture(
+  agentId: string,
+  db?: GoldenTrianglePersistenceClient,
+): Promise<GoldenTrianglePreference | null> {
+  const client = db ?? (prisma as unknown as GoldenTrianglePersistenceClient);
+  try {
+    const row = await client.decisionPerspectiveProfile.findFirst({
+      where: whereForScope({ kind: "platform" }),
+      select: { autonomyPolicy: true },
+    });
+    const map = asRecord(asRecord(row?.autonomyPolicy)[PER_AGENT_KEY]);
+    const gt = map[agentId];
+    return isGoldenTrianglePreference(gt) ? gt : null;
+  } catch (err) {
+    console.warn("[golden-triangle] per-agent posture read failed (fail-open):", err);
+    return null;
+  }
+}
+
+/** Merge a coworker's posture into the per-agent map. Returns true if a row was updated. */
+export async function setAgentGoldenTrianglePosture(
+  agentId: string,
+  preference: GoldenTrianglePreference,
+  db?: GoldenTrianglePersistenceClient,
+): Promise<boolean> {
+  const client = db ?? (prisma as unknown as GoldenTrianglePersistenceClient);
+  try {
+    const row = await client.decisionPerspectiveProfile.findFirst({
+      where: whereForScope({ kind: "platform" }),
+      select: { autonomyPolicy: true },
+    });
+    const policy = asRecord(row?.autonomyPolicy);
+    const nextMap = { ...asRecord(policy[PER_AGENT_KEY]), [agentId]: preference };
+    const res = await client.decisionPerspectiveProfile.updateMany({
+      where: whereForScope({ kind: "platform" }),
+      data: { autonomyPolicy: { ...policy, [PER_AGENT_KEY]: nextMap } },
+    });
+    return res.count > 0;
+  } catch (err) {
+    console.warn("[golden-triangle] per-agent posture write failed (fail-open):", err);
+    return false;
+  }
+}
+
+/**
+ * Resolve the posture for a specific coworker, layering most-specific first:
+ * agent (the coworker's own choice) → organization (WWWD) → platform (WWMD) →
+ * null (caller falls back to Balanced). This is what dispatch consults so a
+ * coworker's posture actually tunes its runs.
+ */
+export async function getEffectivePostureForAgent(
+  agentId: string | null,
+  organizationId: string | null,
+  db?: GoldenTrianglePersistenceClient,
+): Promise<ResolvedPosture | null> {
+  if (agentId) {
+    const agent = await getAgentGoldenTrianglePosture(agentId, db);
+    if (agent) return { preference: agent, source: "agent" };
+  }
+  return getEffectiveGoldenTrianglePosture(organizationId, db);
 }

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -226,8 +226,10 @@ async function prepareRoute(
   // feed it into routing as DEFAULTS (caller options + the local-only sovereignty
   // switch below still win). Fail-open + Balanced-inert: null when no non-Balanced
   // default is set, so this is byte-identical to flag-off until a posture is chosen.
-  // Single-org install → null org id resolves the platform (WWMD) default.
-  const posture = await resolveDispatchPosture(null, taskType);
+  // The calling coworker's own posture (if any) layers above org/platform, so a
+  // per-coworker priority actually tunes that coworker's runs. Single-org install
+  // → null org id; non-coworker runs pass null agentId (platform default).
+  const posture = await resolveDispatchPosture(options?.agentId ?? null, taskType);
 
   // 1. Infer contract
   const contract = await inferContract(


### PR DESCRIPTION
**Per-coworker posture that actually tunes the coworker's runs** — the "make these settings real, per coworker" ask.

- **Per-coworker memory (migration-free):** a map keyed by `agentId` under the platform profile's `autonomyPolicy.goldenTrianglePerAgent` — one existing JSON column, no new rows or schema. `getAgentGoldenTrianglePosture` / `setAgentGoldenTrianglePosture`.
- **Resolution chain:** `getEffectivePostureForAgent` layers **agent → org → platform → Balanced**, so a coworker's own choice wins.
- **It's real:** `resolveDispatchPosture` now takes the calling `agentId`, and `prepareRoute` passes `options.agentId`, so a coworker's saved posture flows into `inferContract` (tier / effort) for *that coworker's* inference. Fail-open + Balanced-inert (byte-identical to off until a non-Balanced posture is set).
- **Actions:** `saveCoworkerGoldenTrianglePosture` (`view_platform`-gated) + `getCoworkerGoldenTrianglePosture` (returns the *effective* posture so the chip shows what governs the coworker).

79 golden-triangle tests green (incl. agent-over-platform layering); `tsc` clean. **The UI half — the red→yellow→green gradient triangle + the compact, auto-collapsing, colour-coded per-coworker chip — follows in the next PR** (mockup already aligned with the founder).

Process-Spine-Decision: realizes the per-coworker (WSID-scope) posture the design deferred from v1, per founder request; additive, fail-open, migration-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
