### PR TITLE
fix(security): guard agentId against remote-property-injection in per-coworker posture

### DIFF
--- a/apps/web/lib/golden-triangle/persistence.test.ts
+++ b/apps/web/lib/golden-triangle/persistence.test.ts
@@ -170,6 +170,17 @@ describe("per-coworker (per-agent) posture", () => {
     expect(await getAgentGoldenTrianglePosture("a", throwingClient())).toBeNull();
     expect(await setAgentGoldenTrianglePosture("a", ASSURED, throwingClient())).toBe(false);
   });
+
+  it("rejects prototype-pollution / malformed agent keys (js/remote-property-injection)", async () => {
+    const { client, calls } = makeClient({});
+    for (const bad of ["__proto__", "constructor", "prototype", "has space", "a/b", ""]) {
+      expect(await setAgentGoldenTrianglePosture(bad, ASSURED, client)).toBe(false);
+      expect(await getAgentGoldenTrianglePosture(bad, client)).toBeNull();
+    }
+    // No write reached the store, and the prototype is intact.
+    expect(calls.updateMany).toHaveLength(0);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });
 
 describe("isGoldenTrianglePreference", () => {

--- a/apps/web/lib/golden-triangle/persistence.ts
+++ b/apps/web/lib/golden-triangle/persistence.ts
@@ -131,11 +131,30 @@ export async function getEffectiveGoldenTrianglePosture(
 
 const PER_AGENT_KEY = "goldenTrianglePerAgent";
 
+/**
+ * Guard the agentId before it is used as an object property name, so a hostile
+ * value can never inject into Object.prototype (CWE-915 / js/remote-property-
+ * injection). Rejects the prototype-pollution keys outright and constrains the
+ * shape to the real agentId charset (e.g. "build-specialist", "coo").
+ */
+function isSafeAgentKey(agentId: string): boolean {
+  return (
+    typeof agentId === "string" &&
+    agentId.length > 0 &&
+    agentId.length <= 128 &&
+    agentId !== "__proto__" &&
+    agentId !== "prototype" &&
+    agentId !== "constructor" &&
+    /^[A-Za-z0-9_.:-]+$/.test(agentId)
+  );
+}
+
 /** Read a coworker's own saved posture, or null if it has none. Fail-open. */
 export async function getAgentGoldenTrianglePosture(
   agentId: string,
   db?: GoldenTrianglePersistenceClient,
 ): Promise<GoldenTrianglePreference | null> {
+  if (!isSafeAgentKey(agentId)) return null;
   const client = db ?? (prisma as unknown as GoldenTrianglePersistenceClient);
   try {
     const row = await client.decisionPerspectiveProfile.findFirst({
@@ -157,6 +176,7 @@ export async function setAgentGoldenTrianglePosture(
   preference: GoldenTrianglePreference,
   db?: GoldenTrianglePersistenceClient,
 ): Promise<boolean> {
+  if (!isSafeAgentKey(agentId)) return false;
   const client = db ?? (prisma as unknown as GoldenTrianglePersistenceClient);
   try {
     const row = await client.decisionPerspectiveProfile.findFirst({


### PR DESCRIPTION
**Security fix (high).** CodeQL flagged the per-coworker posture write merged in #2333 as `js/remote-property-injection` (high) — `agentId` is a user-provided value used as an object property name in the per-agent map, a prototype-pollution risk (CWE-915). The non-required check didn't block the queue, so the fix lands as a fast follow.

Adds `isSafeAgentKey()` — rejects `__proto__` / `constructor` / `prototype` outright and constrains to the real agentId charset (`/^[A-Za-z0-9_.:-]+$/`, ≤128) — applied **before both the read and the write**. Unsafe keys no-op (return `null` / `false`) and never reach the store. Test covers the rejection and confirms no prototype pollution.

20 persistence tests green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
