### PR TITLE
feat(golden-triangle): gradient triangle + compact auto-collapsing per-coworker chip

### DIFF
--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -447,7 +447,7 @@ export function AgentPanelHeader({
                 }}
               >
                 <span style={{ fontSize: 12, color: "var(--dpf-text)" }}>Priority</span>
-                <CoworkerPriorityControl />
+                <CoworkerPriorityControl agentId={agent.agentId} />
               </div>
             </div>
           )}

--- a/apps/web/components/golden-triangle/CoworkerPriorityControl.test.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityControl.test.tsx
@@ -3,53 +3,65 @@ import "./test-setup";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getDefault = vi.fn();
-const saveDefault = vi.fn();
+const getPosture = vi.fn();
+const savePosture = vi.fn();
 
 vi.mock("@/lib/actions/golden-triangle", () => ({
-  getGoldenTrianglePlatformDefault: () => getDefault(),
-  saveGoldenTrianglePlatformDefault: (p: unknown) => saveDefault(p),
+  getCoworkerGoldenTrianglePosture: (agentId: string) => getPosture(agentId),
+  saveCoworkerGoldenTrianglePosture: (agentId: string, pref: unknown) => savePosture(agentId, pref),
 }));
 
 import { CoworkerPriorityControl } from "./CoworkerPriorityControl";
 
-describe("CoworkerPriorityControl", () => {
+describe("CoworkerPriorityControl (per-coworker)", () => {
   beforeEach(() => {
-    getDefault.mockReset();
-    saveDefault.mockReset();
+    getPosture.mockReset();
+    savePosture.mockReset();
+    savePosture.mockResolvedValue({ ok: true });
   });
 
-  it("reflects the saved platform default once it loads", async () => {
-    getDefault.mockResolvedValueOnce({ preset: "frugal", qualityWeight: 0.1, costWeight: 0.8, timeWeight: 0.1 });
-    render(<CoworkerPriorityControl />);
+  it("loads this coworker's own saved posture", async () => {
+    getPosture.mockResolvedValueOnce({ preset: "frugal", qualityWeight: 0.1, costWeight: 0.8, timeWeight: 0.1 });
+    render(<CoworkerPriorityControl agentId="agent-1" />);
+    await waitFor(() => expect(getPosture).toHaveBeenCalledWith("agent-1"));
     await waitFor(() => expect(screen.getByText(/Priority: Frugal/)).toBeTruthy());
   });
 
-  it("falls back to Balanced when nothing is saved", async () => {
-    getDefault.mockResolvedValueOnce(null);
-    render(<CoworkerPriorityControl />);
-    await waitFor(() => expect(getDefault).toHaveBeenCalled());
+  it("falls back to Balanced when the coworker has no posture", async () => {
+    getPosture.mockResolvedValueOnce(null);
+    render(<CoworkerPriorityControl agentId="agent-1" />);
+    await waitFor(() => expect(getPosture).toHaveBeenCalled());
     expect(screen.getByText(/Priority: Balanced/)).toBeTruthy();
   });
 
-  it("saves the posture as the platform default and confirms", async () => {
-    getDefault.mockResolvedValueOnce(null);
-    saveDefault.mockResolvedValueOnce({ ok: true });
-    render(<CoworkerPriorityControl />);
-    await waitFor(() => expect(getDefault).toHaveBeenCalled());
+  it("saves the coworker's own posture on Done after a change", async () => {
+    getPosture.mockResolvedValueOnce(null);
+    render(<CoworkerPriorityControl agentId="agent-1" />);
+    await waitFor(() => expect(getPosture).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Priority:/ }));
-    fireEvent.click(screen.getByText("Save as default"));
-    await waitFor(() => expect(saveDefault).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(screen.getByText("Saved")).toBeTruthy());
+    fireEvent.click(screen.getByRole("radio", { name: /Assured/ }));
+    fireEvent.click(screen.getByText("Done"));
+    await waitFor(() => expect(savePosture).toHaveBeenCalledTimes(1));
+    expect(savePosture.mock.calls[0][0]).toBe("agent-1");
+    expect((savePosture.mock.calls[0][1] as { preset: string }).preset).toBe("assured");
   });
 
-  it("shows a failure note when the save is rejected (e.g. non-admin)", async () => {
-    getDefault.mockResolvedValueOnce(null);
-    saveDefault.mockRejectedValueOnce(new Error("Unauthorized"));
-    render(<CoworkerPriorityControl />);
-    await waitFor(() => expect(getDefault).toHaveBeenCalled());
+  it("does not save on Done when nothing changed", async () => {
+    getPosture.mockResolvedValueOnce(null);
+    render(<CoworkerPriorityControl agentId="agent-1" />);
+    await waitFor(() => expect(getPosture).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Priority:/ }));
-    fireEvent.click(screen.getByText("Save as default"));
-    await waitFor(() => expect(screen.getByText(/Couldn’t save/)).toBeTruthy());
+    fireEvent.click(screen.getByText("Done"));
+    expect(savePosture).not.toHaveBeenCalled();
+  });
+
+  it("auto-collapses on click-away", async () => {
+    getPosture.mockResolvedValueOnce(null);
+    render(<CoworkerPriorityControl agentId="agent-1" />);
+    await waitFor(() => expect(getPosture).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: /Priority:/ }));
+    expect(screen.getByText("Done")).toBeTruthy();
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByText("Done")).toBeNull());
   });
 });

--- a/apps/web/components/golden-triangle/CoworkerPriorityControl.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityControl.tsx
@@ -1,75 +1,88 @@
 "use client";
-// EP-GOLDEN-TRIANGLE Slice 2/4 — a small posture area for the AI coworker header.
-// A balance-coloured chip (green centred → yellow → red as axes get starved) opens
-// the compact control. It LOADS the saved platform (WWMD) default so the chip shows
-// what actually governs AI work, and SAVES edits back via the same server action as
-// the /platform/ai/priority page — so the two surfaces stay in sync. Saving is
-// view_platform-gated server-side; a non-admin simply sees "Couldn't save".
-import { useEffect, useState } from "react";
+// EP-GOLDEN-TRIANGLE — the per-coworker priority chip for the AI coworker header.
+// Compact at rest (a small colour-graded triangle glyph + label), it expands to
+// the full control on click and AUTO-COLLAPSES on click-away / Done — replacing
+// the model + effort pickers with one higher-level control. It loads and saves
+// THIS coworker's own posture (per-agent), so each coworker remembers its
+// priority and that posture tunes its runs.
+import { useEffect, useRef, useState } from "react";
 
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
-import { getGoldenTrianglePlatformDefault, saveGoldenTrianglePlatformDefault } from "@/lib/actions/golden-triangle";
+import { getCoworkerGoldenTrianglePosture, saveCoworkerGoldenTrianglePosture } from "@/lib/actions/golden-triangle";
 
 import { GoldenTriangleControl } from "./GoldenTriangleControl";
-import { PRESET_META, balanceState, preferenceFromPreset } from "./posture-display";
+import { GoldenTriangleGradient } from "./GoldenTriangleGradient";
+import { PRESET_META, preferenceFromPreset } from "./posture-display";
 
-export function CoworkerPriorityControl() {
+export function CoworkerPriorityControl({ agentId }: { agentId: string }) {
   const [open, setOpen] = useState(false);
   const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
-  const [saved, setSaved] = useState<"idle" | "saved" | "error">("idle");
-  const [pending, setPending] = useState(false);
+  const savedRef = useRef<string>(JSON.stringify(preferenceFromPreset("balanced")));
+  const rootRef = useRef<HTMLDivElement>(null);
+  const prefRef = useRef(pref);
+  prefRef.current = pref;
 
-  // Reflect the active platform default (fail-open: stay on Balanced if it can't load).
   useEffect(() => {
     let alive = true;
-    getGoldenTrianglePlatformDefault()
+    getCoworkerGoldenTrianglePosture(agentId)
       .then((p) => {
-        if (alive && p) setPref(p);
+        if (alive && p) {
+          setPref(p);
+          savedRef.current = JSON.stringify(p);
+        }
       })
       .catch(() => {});
     return () => {
       alive = false;
     };
-  }, []);
+  }, [agentId]);
 
-  const balance = balanceState(pref.qualityWeight, pref.costWeight, pref.timeWeight);
   const activeLabel = pref.preset === "custom" ? "Custom" : PRESET_META[pref.preset].label;
-  const color = `var(${balance.token})`;
 
-  function onChange(next: GoldenTrianglePreference) {
-    setPref(next);
-    setSaved("idle");
-  }
-
-  async function save() {
-    setPending(true);
-    setSaved("idle");
-    try {
-      const res = await saveGoldenTrianglePlatformDefault(pref);
-      setSaved(res.ok ? "saved" : "error");
-    } catch {
-      setSaved("error");
-    } finally {
-      setPending(false);
+  function close() {
+    setOpen(false);
+    const cur = JSON.stringify(prefRef.current);
+    if (cur !== savedRef.current) {
+      savedRef.current = cur;
+      // Persist this coworker's own posture; fail-open (non-admins simply can't save).
+      saveCoworkerGoldenTrianglePosture(agentId, prefRef.current).catch(() => {});
     }
   }
 
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) close();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") close();
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
   return (
-    <div style={{ position: "relative" }} onMouseDown={(e) => e.stopPropagation()}>
+    <div ref={rootRef} style={{ position: "relative" }} onMouseDown={(e) => e.stopPropagation()}>
       <button
         type="button"
         onClick={(e) => {
           e.stopPropagation();
-          setOpen((o) => !o);
+          if (open) close();
+          else setOpen(true);
         }}
         aria-expanded={open}
         aria-haspopup="dialog"
-        title={`Priority for AI work: ${activeLabel} — ${balance.label}. Click to balance cost, quality and time.`}
+        title={`Priority for this coworker: ${activeLabel}. Click to balance cost, quality and time — it tunes how this coworker works.`}
         style={{
           display: "inline-flex",
           alignItems: "center",
-          gap: 5,
+          gap: 6,
           fontSize: 9,
           textTransform: "uppercase",
           letterSpacing: "0.08em",
@@ -77,21 +90,24 @@ export function CoworkerPriorityControl() {
           background: "transparent",
           border: "1px solid var(--dpf-border)",
           borderRadius: 999,
-          padding: "2px 6px",
+          padding: "2px 7px 2px 4px",
           cursor: "pointer",
           lineHeight: 1.2,
         }}
       >
-        <span
-          style={{ width: 8, height: 8, borderRadius: "50%", background: color, flex: "0 0 auto" }}
-          aria-hidden="true"
-        />
+        <span style={{ width: 16, height: 14, flex: "0 0 auto", display: "inline-block" }} aria-hidden="true">
+          <GoldenTriangleGradient
+            qualityWeight={pref.qualityWeight}
+            costWeight={pref.costWeight}
+            timeWeight={pref.timeWeight}
+          />
+        </span>
         Priority: {activeLabel}
       </button>
       {open && (
         <div
           role="dialog"
-          aria-label="Set work priority"
+          aria-label="Set this coworker's priority"
           style={{
             position: "absolute",
             top: "calc(100% + 8px)",
@@ -107,16 +123,15 @@ export function CoworkerPriorityControl() {
         >
           <GoldenTriangleControl
             value={pref}
-            onChange={onChange}
+            onChange={setPref}
             compact
             taskClass="conversation"
-            authorityScopeKind="wwmd"
+            authorityScopeKind="wsid"
           />
-          <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "0 12px 12px" }}>
+          <div style={{ display: "flex", justifyContent: "flex-end", padding: "0 12px 12px" }}>
             <button
               type="button"
-              onClick={save}
-              disabled={pending}
+              onClick={close}
               style={{
                 fontSize: 12,
                 fontWeight: 500,
@@ -124,15 +139,12 @@ export function CoworkerPriorityControl() {
                 background: "var(--dpf-surface-2)",
                 border: "1px solid var(--dpf-border)",
                 borderRadius: 6,
-                padding: "4px 10px",
-                cursor: pending ? "default" : "pointer",
-                opacity: pending ? 0.5 : 1,
+                padding: "4px 12px",
+                cursor: "pointer",
               }}
             >
-              {pending ? "Saving…" : "Save as default"}
+              Done
             </button>
-            {saved === "saved" && <span style={{ fontSize: 11, color: "var(--dpf-success)" }}>Saved</span>}
-            {saved === "error" && <span style={{ fontSize: 11, color: "var(--dpf-error)" }}>Couldn’t save</span>}
           </div>
         </div>
       )}

--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -10,6 +10,7 @@ import { useId, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
+import { GoldenTriangleGradient } from "./GoldenTriangleGradient";
 import {
   PRESET_META,
   PRESET_ORDER,
@@ -95,7 +96,6 @@ export function GoldenTriangleControl({
   const activeLabel = value.preset === "custom" ? "Custom" : PRESET_META[value.preset].label;
 
   const balanceColor = `var(${balance.token})`;
-  const triFill = `color-mix(in srgb, ${balanceColor} 12%, var(--dpf-surface-2))`;
   const triStroke = `color-mix(in srgb, ${balanceColor} 45%, var(--dpf-border-strong))`;
   const vertexColor = (axis: "Quality" | "Cost" | "Time") =>
     isAxisStarved(balance, axis) ? "var(--dpf-error)" : "var(--dpf-text-secondary)";
@@ -136,11 +136,21 @@ export function GoldenTriangleControl({
   );
 
   const triangle = (
-    <svg
-      ref={svgRef}
-      viewBox="0 0 100 100"
-      className={["h-auto w-full touch-none select-none", compact ? "max-w-[150px]" : "max-w-[220px]"].join(" ")}
-      role="img"
+    <div
+      className={["relative h-auto w-full", compact ? "max-w-[150px]" : "max-w-[220px]"].join(" ")}
+      style={{ aspectRatio: "1 / 1" }}
+    >
+      <GoldenTriangleGradient
+        qualityWeight={w.qualityWeight}
+        costWeight={w.costWeight}
+        timeWeight={w.timeWeight}
+        className="absolute inset-0"
+      />
+      <svg
+        ref={svgRef}
+        viewBox="0 0 100 100"
+        className="absolute inset-0 h-full w-full touch-none select-none"
+        role="img"
       aria-label={`Cost, quality and time priority triangle. Quality ${pct(w.qualityWeight)} percent, cost ${pct(
         w.costWeight,
       )} percent, time ${pct(w.timeWeight)} percent. Balance: ${balance.label}. Drag the point or use the inputs to fine-tune.`}
@@ -158,7 +168,7 @@ export function GoldenTriangleControl({
     >
       <polygon
         points={`${vQuality.x},${vQuality.y} ${vCost.x},${vCost.y} ${vTime.x},${vTime.y}`}
-        fill={triFill}
+        fill="transparent"
         stroke={triStroke}
         strokeWidth={0.9}
       />
@@ -185,7 +195,8 @@ export function GoldenTriangleControl({
         onKeyDown={onThumbKeyDown}
         style={{ cursor: "grab", outline: "none" }}
       />
-    </svg>
+      </svg>
+    </div>
   );
 
   const readout = (

--- a/apps/web/components/golden-triangle/GoldenTriangleGradient.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleGradient.tsx
@@ -1,0 +1,74 @@
+"use client";
+// EP-GOLDEN-TRIANGLE — the colour-graded triangle fill. A canvas Gouraud-shades
+// the triangle from each vertex's health colour (red→yellow→green per axis
+// weight): a dominant corner reads green, the starved corners red, dead-centre
+// pure yellow, an edge yellow-near / red-far. Decorative (aria-hidden) — the SVG
+// thumb + the numeric inputs carry the accessible control. Geometry matches the
+// SVG triangle (INSET 12 / SPAN 76 of a 100-unit box): Quality top-centre, Cost
+// bottom-left, Time bottom-right.
+import { useEffect, useRef } from "react";
+
+import { postureAxisColor } from "./posture-display";
+
+const RES = 220;
+const Q: [number, number] = [0.5, 0.12];
+const C: [number, number] = [0.12, 0.88];
+const T: [number, number] = [0.88, 0.88];
+
+export function GoldenTriangleGradient({
+  qualityWeight,
+  costWeight,
+  timeWeight,
+  className = "",
+}: {
+  qualityWeight: number;
+  costWeight: number;
+  timeWeight: number;
+  className?: string;
+}) {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const cv = ref.current;
+    if (!cv) return;
+    const ctx = cv.getContext("2d");
+    if (!ctx) return; // jsdom / unsupported — render nothing, no crash
+
+    const W = RES, H = RES;
+    const qx = Q[0] * W, qy = Q[1] * H, cx = C[0] * W, cy = C[1] * H, tx = T[0] * W, ty = T[1] * H;
+    const det = (cy - ty) * (qx - tx) + (tx - cx) * (qy - ty);
+    if (!det) return;
+    const Vq = postureAxisColor(qualityWeight), Vc = postureAxisColor(costWeight), Vt = postureAxisColor(timeWeight);
+
+    const img = ctx.createImageData(W, H);
+    const d = img.data;
+    const minX = Math.floor(Math.min(qx, cx, tx)), maxX = Math.ceil(Math.max(qx, cx, tx));
+    const minY = Math.floor(Math.min(qy, cy, ty)), maxY = Math.ceil(Math.max(qy, cy, ty));
+    for (let y = minY; y < maxY; y++) {
+      for (let x = minX; x < maxX; x++) {
+        const a = ((cy - ty) * (x - tx) + (tx - cx) * (y - ty)) / det;
+        const b = ((ty - qy) * (x - tx) + (qx - tx) * (y - ty)) / det;
+        const g = 1 - a - b;
+        if (a < -0.004 || b < -0.004 || g < -0.004) continue;
+        const i = (y * W + x) * 4;
+        d[i] = a * Vq[0] + b * Vc[0] + g * Vt[0];
+        d[i + 1] = a * Vq[1] + b * Vc[1] + g * Vt[1];
+        d[i + 2] = a * Vq[2] + b * Vc[2] + g * Vt[2];
+        d[i + 3] = 236;
+      }
+    }
+    ctx.clearRect(0, 0, W, H);
+    ctx.putImageData(img, 0, 0);
+  }, [qualityWeight, costWeight, timeWeight]);
+
+  return (
+    <canvas
+      ref={ref}
+      width={RES}
+      height={RES}
+      aria-hidden="true"
+      className={className}
+      style={{ width: "100%", height: "100%", display: "block" }}
+    />
+  );
+}

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -114,3 +114,41 @@ describe("balanceState (triangle colouring)", () => {
     expect(b.starved).toEqual([]);
   });
 });
+
+import { postureAxisColor, postureBlendColor } from "./posture-display";
+
+describe("postureAxisColor (red→yellow→green ramp)", () => {
+  it("is red when an axis is starved (0)", () => {
+    const [r, g] = postureAxisColor(0);
+    expect(r).toBeGreaterThan(200);
+    expect(g).toBeLessThan(120);
+  });
+  it("is yellow at a fair/balanced share (~0.42)", () => {
+    const [r, g, b] = postureAxisColor(0.42);
+    expect(r).toBeGreaterThan(200);
+    expect(g).toBeGreaterThan(150);
+    expect(b).toBeLessThan(60);
+  });
+  it("is green when an axis dominates (1)", () => {
+    const [r, g] = postureAxisColor(1);
+    expect(g).toBeGreaterThan(150);
+    expect(r).toBeLessThan(120);
+  });
+  it("clamps out-of-range weights", () => {
+    expect(postureAxisColor(-1)).toEqual(postureAxisColor(0));
+    expect(postureAxisColor(2)).toEqual(postureAxisColor(1));
+  });
+});
+
+describe("postureBlendColor", () => {
+  it("reads green-dominant when one axis is maxed (corner)", () => {
+    const [r, g] = postureBlendColor(1, 0, 0);
+    expect(g).toBeGreaterThan(r);
+  });
+  it("reads yellow-ish when balanced (centre)", () => {
+    const [r, g, b] = postureBlendColor(0.34, 0.33, 0.33);
+    expect(r).toBeGreaterThan(150);
+    expect(g).toBeGreaterThan(150);
+    expect(b).toBeLessThan(100);
+  });
+});

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -232,3 +232,38 @@ export function balanceState(qualityWeight: number, costWeight: number, timeWeig
 export function isAxisStarved(b: BalanceState, axis: "Quality" | "Cost" | "Time"): boolean {
   return b.starved.includes(axis);
 }
+
+// EP-GOLDEN-TRIANGLE — per-axis health colour for the gradient triangle.
+// A single axis weight maps to a red→yellow→green ramp: starved (0) is red, a
+// fair/­balanced share (~0.42) is yellow, a dominant axis (→1) is green. Pure +
+// deterministic so it can be unit-tested and reused by the canvas renderer.
+export type PostureRGB = [number, number, number];
+
+const RAMP_RED: PostureRGB = [239, 68, 68];
+const RAMP_YELLOW: PostureRGB = [234, 179, 8];
+const RAMP_GREEN: PostureRGB = [34, 197, 94];
+const RAMP_MID = 0.42; // weight that reads as pure yellow (centre ≈ 0.33, edge ≈ 0.5 both read yellow-ish)
+
+function mixRGB(a: PostureRGB, b: PostureRGB, t: number): PostureRGB {
+  return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t];
+}
+
+/** Map one axis weight (0–1) to its health colour on the red→yellow→green ramp. */
+export function postureAxisColor(weight: number): PostureRGB {
+  const w = Math.max(0, Math.min(1, weight));
+  return w <= RAMP_MID ? mixRGB(RAMP_RED, RAMP_YELLOW, w / RAMP_MID) : mixRGB(RAMP_YELLOW, RAMP_GREEN, (w - RAMP_MID) / (1 - RAMP_MID));
+}
+
+/** The blended colour at the selected point — the barycentric mix of the three
+ *  vertex colours, used for the collapsed chip glyph/dot. */
+export function postureBlendColor(qualityWeight: number, costWeight: number, timeWeight: number): PostureRGB {
+  const s = qualityWeight + costWeight + timeWeight || 1;
+  const q = qualityWeight / s, c = costWeight / s, t = timeWeight / s;
+  const Vq = postureAxisColor(q), Vc = postureAxisColor(c), Vt = postureAxisColor(t);
+  return [q * Vq[0] + c * Vc[0] + t * Vt[0], q * Vq[1] + c * Vc[1] + t * Vt[1], q * Vq[2] + c * Vc[2] + t * Vt[2]];
+}
+
+/** `rgb(...)` string for inline styles. */
+export function postureRgbCss(c: PostureRGB): string {
+  return `rgb(${Math.round(c[0])}, ${Math.round(c[1])}, ${Math.round(c[2])})`;
+}


### PR DESCRIPTION
**The UI half of the per-coworker priority** (builds on the backend in #2333). Matches the mockup the founder approved.

### Gradient triangle
The triangle is now a red→yellow→green **Gouraud gradient** ([GoldenTriangleGradient.tsx](apps/web/components/golden-triangle/GoldenTriangleGradient.tsx), a canvas behind the SVG thumb), driven by pure, tested `postureAxisColor`:
- a **dominant corner reads green**, the **starved corners red**, **dead-centre pure yellow**, an **edge yellow-near / red-far** — exactly the founder's spec.

### Compact, auto-collapsing, per-coworker chip
[CoworkerPriorityControl](apps/web/components/golden-triangle/CoworkerPriorityControl.tsx) is compact at rest — a small colour-graded triangle glyph + label — **expands on click** and **auto-collapses on click-away / Done**, replacing the model + effort pickers with one higher-level control. It **loads and saves THIS coworker's own posture** (`agentId`) so each coworker remembers its priority (and, via #2333, that posture tunes its runs).

Accessibility preserved: the SVG thumb + the numeric inputs/presets remain the accessible path (the gradient canvas is `aria-hidden`). **119 golden-triangle tests green; `tsc` clean.**

Process-Spine-Decision: doc-specced UI for the per-coworker posture; additive, no contract change.
UX-Fit-Decision: one higher-level control replacing model/effort; compact-by-default + auto-collapse keeps the composer uncluttered; gradient encodes balance health; accessible via inputs/presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
