### PR TITLE
feat(voice): surface TTS service-offline state on the Voice page (BI-107833AC)

### DIFF
--- a/apps/web/app/api/voice/service-status/route.test.ts
+++ b/apps/web/app/api/voice/service-status/route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(async () => ({ user: { id: "user-1" } })),
+}))
+
+// Keep defaultProvider real (env-driven) so the route resolves the probe URL
+// exactly as production does.
+import { auth } from "@/lib/auth"
+import { GET } from "./route"
+
+describe("GET /api/voice/service-status", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never)
+    vi.stubEnv("DPF_TTS_URL", "")
+    vi.stubEnv("TTS_PROVIDER", "chatterbox")
+  })
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it("reports available when the chatterbox sidecar /health is healthy", async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ status: "healthy", model_loaded: true }), { status: 200 }),
+    ) as typeof fetch
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ available: true, provider: "chatterbox", reason: null })
+    // Probes the default Docker-network sidecar address.
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://dpf-tts:8000/health",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it("reports unavailable when the sidecar is unreachable", async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED")
+    }) as typeof fetch
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.available).toBe(false)
+    expect(body.reason).toMatch(/not running/i)
+  })
+
+  it("reports unavailable while the model is still loading", async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ status: "loading", model_loaded: false }), { status: 200 }),
+    ) as typeof fetch
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(body.available).toBe(false)
+    expect(body.reason).toMatch(/still loading/i)
+  })
+
+  it("does not probe managed providers and reports them available", async () => {
+    vi.stubEnv("TTS_PROVIDER", "cartesia")
+    global.fetch = vi.fn() as typeof fetch
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(body).toEqual({ available: true, provider: "cartesia", reason: null })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it("respects DPF_TTS_URL override for the mlx sidecar", async () => {
+    vi.stubEnv("TTS_PROVIDER", "mlx")
+    vi.stubEnv("DPF_TTS_URL", "http://host.docker.internal:8771")
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ status: "healthy", model_loaded: true }), { status: 200 }),
+    ) as typeof fetch
+
+    await GET()
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://host.docker.internal:8771/health",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+})

--- a/apps/web/app/api/voice/service-status/route.test.ts
+++ b/apps/web/app/api/voice/service-status/route.test.ts
@@ -14,7 +14,8 @@ describe("GET /api/voice/service-status", () => {
     vi.restoreAllMocks()
     vi.unstubAllEnvs()
     vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never)
-    vi.stubEnv("DPF_TTS_URL", "")
+    // DPF_TTS_URL intentionally left unset so the route's `?? default` applies;
+    // the mlx test below stubs it explicitly. (Stubbing "" would defeat `??`.)
     vi.stubEnv("TTS_PROVIDER", "chatterbox")
   })
 

--- a/apps/web/app/api/voice/service-status/route.ts
+++ b/apps/web/app/api/voice/service-status/route.ts
@@ -1,0 +1,83 @@
+// GET /api/voice/service-status
+// Lightweight liveness probe for the active TTS provider, so the UI can show an
+// honest "voice service offline" state instead of presenting a "ready" profile
+// whose Preview button only reveals the failure AFTER a click (the click-to-
+// discover latch in useVoiceSynth). No synthesis is performed.
+//
+// Self-hosted providers (chatterbox / mlx) are probed via their sidecar /health.
+// Managed providers (cartesia / fish-audio / elevenlabs) are not proactively
+// probed — a call would incur cost, and a bad key surfaces at synth time with
+// its own message — so they are reported available and left to call-time errors.
+
+import { NextResponse } from "next/server"
+import { auth } from "@/lib/auth"
+import { defaultProvider } from "@/lib/voice-synthesis/voice-service"
+
+export const dynamic = "force-dynamic"
+
+const HEALTH_TIMEOUT_MS = 3000
+
+interface ServiceStatus {
+  available: boolean
+  provider: string
+  reason: string | null
+}
+
+/** Health-check URL for self-hosted sidecars, or null for providers we don't probe. */
+function selfHostedHealthUrl(provider: string): string | null {
+  if (provider === "chatterbox") {
+    return `${process.env.DPF_TTS_URL ?? "http://dpf-tts:8000"}/health`
+  }
+  if (provider === "mlx") {
+    return `${process.env.DPF_TTS_URL ?? "http://host.docker.internal:8771"}/health`
+  }
+  return null
+}
+
+export async function GET(): Promise<NextResponse<ServiceStatus | { error: string }>> {
+  const session = await auth()
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const provider = defaultProvider()
+  const healthUrl = selfHostedHealthUrl(provider)
+
+  // Managed / hosted providers: not proactively probed (see file header).
+  if (!healthUrl) {
+    return NextResponse.json({ available: true, provider, reason: null })
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS)
+  try {
+    const res = await fetch(healthUrl, { signal: controller.signal })
+    if (!res.ok) {
+      return NextResponse.json({
+        available: false,
+        provider,
+        reason: "The text-to-speech service is reachable but not ready.",
+      })
+    }
+    // Chatterbox / mlx return { status, model_loaded, ... }. A present-and-false
+    // model_loaded means the model is still warming up after start.
+    const body = (await res.json().catch(() => ({}))) as { model_loaded?: boolean }
+    if (body.model_loaded === false) {
+      return NextResponse.json({
+        available: false,
+        provider,
+        reason: "The text-to-speech model is still loading. Try again shortly.",
+      })
+    }
+    return NextResponse.json({ available: true, provider, reason: null })
+  } catch {
+    // Unreachable (sidecar not running) or timed out.
+    return NextResponse.json({
+      available: false,
+      provider,
+      reason: "The text-to-speech service is not running.",
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/apps/web/components/wiki/VoiceProfileSetup.tsx
+++ b/apps/web/components/wiki/VoiceProfileSetup.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useTransition, useRef, useCallback } from "react"
+import { useState, useTransition, useRef, useCallback, useEffect } from "react"
 import { VoiceConsentForm } from "@/components/admin/VoiceConsentForm"
 import { setVoiceEnabled, resetVoiceProfile, saveVoiceSettings } from "@/lib/actions/voice-profile"
 import { resolveRecordingBlobMimeType, selectSupportedMimeType } from "@/components/agent/hooks/mime-probe"
@@ -75,6 +75,35 @@ export function VoiceProfileSetup({
     voiceProfile?.consentRecord &&
     !voiceProfile.consentRecord.revokedAt &&
     new Date(voiceProfile.consentRecord.expiresAt) > new Date()
+
+  // Proactive TTS service liveness — surface an "offline" notice instead of a
+  // "ready" profile whose Preview only reveals the failure after a click (the
+  // click-to-discover latch in useVoiceSynth).
+  const [serviceStatus, setServiceStatus] = useState<{ available: boolean; reason: string | null } | null>(null)
+
+  useEffect(() => {
+    if (voiceProfile?.status !== "ready") return
+    let cancelled = false
+    fetch("/api/voice/service-status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!cancelled && d) setServiceStatus({ available: !!d.available, reason: d.reason ?? null })
+      })
+      .catch(() => {
+        /* leave unknown — the button still falls back to call-time detection */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [voiceProfile?.status])
+
+  // "Offline" only once the probe returns negative; while unknown (null) or
+  // positive, defer to the hook's call-time availability.
+  const serviceOffline = serviceStatus?.available === false
+  const previewAvailable = voiceSynth.available && !serviceOffline
+  const previewReason = serviceOffline
+    ? serviceStatus?.reason ?? "The text-to-speech service is not running."
+    : voiceSynth.unavailableReason
 
   const handleToggle = () => {
     const next = !enabled
@@ -162,6 +191,14 @@ export function VoiceProfileSetup({
           <p className="text-sm text-muted-foreground pl-8">Complete step 1 first.</p>
         ) : voiceProfile?.status === "ready" ? (
           <>
+          {serviceOffline && (
+            <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3 text-sm">
+              <p className="font-medium text-[var(--dpf-text)]">Voice service offline</p>
+              <p className="mt-1 text-[var(--dpf-muted)]">
+                {previewReason} The profile is ready, but narration cannot play until the service is running again.
+              </p>
+            </div>
+          )}
           <div className="rounded-md border border-green-500/20 bg-green-500/5 px-4 py-3 text-sm flex flex-wrap items-center gap-3">
             <span>
               Voice profile ready.
@@ -174,29 +211,29 @@ export function VoiceProfileSetup({
             <button
               type="button"
               onClick={() => {
-                if (!voiceSynth.available) return
+                if (!previewAvailable) return
                 if (voiceSynth.isPlaying) {
                   voiceSynth.stop()
                 } else {
                   voiceSynth.synthesize(PREVIEW_TEXT, profileId, tuning)
                 }
               }}
-              disabled={!voiceSynth.available || voiceSynth.isSynthesizing}
+              disabled={!previewAvailable || voiceSynth.isSynthesizing}
               aria-label={
-                !voiceSynth.available
+                !previewAvailable
                   ? "Voice preview unavailable"
                   : voiceSynth.isPlaying
                     ? "Stop voice preview"
                     : "Preview voice"
               }
               title={
-                !voiceSynth.available
-                  ? voiceSynth.unavailableReason ?? "Voice preview unavailable. Start the text-to-speech service or replace the voice sample."
+                !previewAvailable
+                  ? previewReason ?? "Voice preview unavailable. Start the text-to-speech service or replace the voice sample."
                   : undefined
               }
               className="inline-flex items-center gap-1.5 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
             >
-              {!voiceSynth.available ? (
+              {!previewAvailable ? (
                 <>
                   <VolumeX aria-hidden="true" size={13} strokeWidth={2} />
                   Voice unavailable

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 507,
+  "routeCount": 508,
   "routes": [
     {
       "routePath": "/",
@@ -2947,6 +2947,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/voice/reference/route.ts"
+    },
+    {
+      "routePath": "/api/voice/service-status",
+      "kind": "route",
+      "segments": [
+        "api",
+        "voice",
+        "service-status"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/voice/service-status/route.ts"
     },
     {
       "routePath": "/api/voice/synthesize",

--- a/docs/superpowers/specs/2026-05-19-persona-voice-layer-wwtd-design.md
+++ b/docs/superpowers/specs/2026-05-19-persona-voice-layer-wwtd-design.md
@@ -46,6 +46,7 @@ The STT input path extends this to full voice interaction: operators can speak t
 - **TTS output** for `DecisionInteraction.rationale` — async synthesis job after each gate invocation
 - **Voice profile management** — upload samples, run training job, store provider voice ID, linked to `DecisionPerspectiveProfile`
 - **Audio player** in `DecisionPerspectiveGatePanel` — plays synthesized rationale audio
+- **Service health surfacing** (added 2026-06-24) — the Voice profile page probes `GET /api/voice/service-status` (a cheap, provider-aware liveness check of the self-hosted `dpf-tts` sidecar's `/health`) and shows an explicit "voice service offline" notice instead of a "ready" profile whose Preview only reveals the failure after a click. The `dpf-tts` sidecar is profile-gated and can be down on a given install; proactively ensuring an enabled-but-down profile is running (runtime reconcile) is tracked separately under BI-264565A4. This surfaces the dependency rather than letting it fail silently (the 2026-06-24 incident: voice was dead for ~a month while the page showed "ready").
 - **Voice tier config** — cloud (Cartesia Sonic 3 default) vs. self-hosted (Fish Audio S2 / XTTS v2) provider setting, mirroring the existing LLM provider tier pattern
 - **WWTD profile kind** — new `kind` values on `DecisionPerspectiveProfile`: `persona-real`, `persona-fictional`, `persona-synthetic`
 - **Generation style field** — `personaConfig.systemPrompt` added to profiles; LLM rationale generation uses this as a style layer


### PR DESCRIPTION
## What & why

The Voice Profile page showed **"Voice profile ready"** + an enabled **Preview** button whenever the profile row was `status=ready` — regardless of whether the `dpf-tts` synthesis sidecar was actually running. A down service was only revealed **after a click** (`useVoiceSynth` flips to "Voice unavailable" once a synth POST returns `tts_unavailable`), so a silently-dead voice service looked ready and the breakage was click-to-discover.

Live incident 2026-06-24: voice playback was dead for ~a month (the profile-gated `dpf-tts` sidecar was never running) while the page showed a green "ready" — nothing surfaced the dependency.

## Changes
- **New `GET /api/voice/service-status`** — a cheap, provider-aware liveness probe of the self-hosted sidecar's `/health` (chatterbox / mlx), with a 3s timeout and no synthesis. Managed providers (cartesia / fish-audio) are reported available (a key problem surfaces at synth time).
- **`VoiceProfileSetup`** probes it on load and renders an explicit **"Voice service offline"** notice, disabling Preview with an honest reason when the service is down.
- **Unit tests** for the endpoint (healthy / unreachable / still-loading / managed / mlx-override / auth).
- **Doc note** in the persona-voice spec's V1 surface list.

## Scope
Implements **BI-107833AC**. Complements (not duplicates):
- **BI-3C812E4E** — installer auto-starts `dpf-tts` on GPU detect (install-time only).
- **BI-264565A4** — runtime reconcile so an *enabled* profile is ensured running at boot/self-upgrade (the platform half).

Follow-up (noted, not in this PR): apply the same indicator to the build-gate audio card.

## Verification
Source-only worktree (no `node_modules`), so local typecheck/build/vitest could not run here — **CI is the gate substrate** (typecheck, Unit Tests, UX-Fit, Spec/Plan/Doc). The pre-commit gitleaks scan ran clean; typecheck was skipped locally with `DPF_SKIP_TYPECHECK=1`.

UX-Fit-Decision: Progressive disclosure / cognitive-load reducing — the offline notice renders only when the probe returns negative; it replaces a cryptic post-click latch with a plain-language state, adds no always-on control/field/route, and requires no layman input. principle_decide on human_cognitive_load is degenerate for this axis (no kernel principle scores it; documented), so decided on merits: honest-state-over-silent-failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
