### PR TITLE
feat(golden-triangle): drop on-triangle vertex labels — colour conveys the state

### DIFF
--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -16,7 +16,6 @@ import {
   PRESET_ORDER,
   balanceState,
   decodePostureForDisplay,
-  isAxisStarved,
   pointToWeights,
   preferenceFromPreset,
   weightsToPoint,
@@ -97,8 +96,6 @@ export function GoldenTriangleControl({
 
   const balanceColor = `var(${balance.token})`;
   const triStroke = `color-mix(in srgb, ${balanceColor} 45%, var(--dpf-border-strong))`;
-  const vertexColor = (axis: "Quality" | "Cost" | "Time") =>
-    isAxisStarved(balance, axis) ? "var(--dpf-error)" : "var(--dpf-text-secondary)";
 
   function setFromEvent(clientX: number, clientY: number) {
     const svg = svgRef.current;
@@ -166,21 +163,14 @@ export function GoldenTriangleControl({
         draggingRef.current = false;
       }}
     >
+      {/* No vertex labels — the gradient colour conveys the state (founder direction).
+          Axis identity stays accessible via the SVG aria-label + the numeric inputs. */}
       <polygon
         points={`${vQuality.x},${vQuality.y} ${vCost.x},${vCost.y} ${vTime.x},${vTime.y}`}
         fill="transparent"
         stroke={triStroke}
         strokeWidth={0.9}
       />
-      <text x={vQuality.x} y={vQuality.y - 3} textAnchor="middle" fontSize={6} fill={vertexColor("Quality")}>
-        Quality
-      </text>
-      <text x={vCost.x - 2} y={vCost.y + 6} textAnchor="start" fontSize={6} fill={vertexColor("Cost")}>
-        Cost
-      </text>
-      <text x={vTime.x + 2} y={vTime.y + 6} textAnchor="end" fontSize={6} fill={vertexColor("Time")}>
-        Time
-      </text>
       <circle
         cx={thumb.x}
         cy={thumb.y}


### PR DESCRIPTION
**Founder direction:** the triangle doesn't need to say anything — the red→yellow→green gradient already shows what's going on.

Removes the `Quality` / `Cost` / `Time` text labels from the triangle graphic (and the now-unused `vertexColor` helper). The triangle reads as pure colour.

Not a colour-only regression: axis identity stays accessible via the SVG `aria-label` (still "Quality X%, cost Y%, time Z%…") and the labelled numeric inputs + presets, so screen-reader and keyboard users are unaffected.

33 golden-triangle component tests green; `tsc` clean.

Process-Spine-Decision: visual simplification; additive.
UX-Fit-Decision: removes redundant on-graphic text in favour of the colour encoding; a11y preserved via aria-label + inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
