### PR TITLE
feat(golden-triangle): rigor ladder (debate) + reconcile budget with Assignments

### DIFF
--- a/apps/web/lib/golden-triangle/compile.test.ts
+++ b/apps/web/lib/golden-triangle/compile.test.ts
@@ -101,6 +101,22 @@ describe("compileGoldenTrianglePolicy — custom positions", () => {
     expect(out.orchestrationBudget).toEqual({});
   });
 
+  it("extreme quality lean (0.05/0.9/0.05) → debate + max effort (top of the rigor ladder)", () => {
+    const out = compileGoldenTrianglePolicy(
+      input(pref("custom", { costWeight: 0.05, qualityWeight: 0.9, timeWeight: 0.05 })),
+    );
+    expect(out.postureOverride.effort).toBe("max");
+    expect(out.postureOverride.minimumTier).toBe("frontier");
+    expect(out.orchestrationBudget.deliberationPattern).toBe("debate");
+  });
+
+  it("strong-but-not-extreme quality (0.2/0.6/0.2) stays review, not debate", () => {
+    const out = compileGoldenTrianglePolicy(
+      input(pref("custom", { costWeight: 0.2, qualityWeight: 0.6, timeWeight: 0.2 })),
+    );
+    expect(out.orchestrationBudget.deliberationPattern).toBe("review");
+  });
+
   it("moderate quality lean (0.25/0.45/0.30) → strong tier, not frontier", () => {
     const out = compileGoldenTrianglePolicy(
       input(pref("custom", { costWeight: 0.25, qualityWeight: 0.45, timeWeight: 0.3 })),

--- a/apps/web/lib/golden-triangle/compile.ts
+++ b/apps/web/lib/golden-triangle/compile.ts
@@ -31,6 +31,11 @@ export const GOLDEN_TRIANGLE_PRESET_VERSION = "presets@1";
 
 const TIER_RANK: Record<QualityTier, number> = { basic: 0, adequate: 1, strong: 2, frontier: 3 };
 
+// The rigor ladder's top rung: a Quality weight at/above this drags past "review"
+// (Assured) into a "debate" (multi-perspective) deliberation. Kept high so only an
+// extreme, deliberate Quality posture buys the heaviest pass.
+const QUALITY_DEBATE_FLOOR = 0.85;
+
 function tierRank(t: QualityTier): number {
   return TIER_RANK[t];
 }
@@ -104,6 +109,15 @@ function deriveCustomPolicy(p: GoldenTrianglePreference): BasePolicy {
   const strong = weight >= 0.55;
 
   if (axis === "quality") {
+    // The top rung of the rigor ladder: an extreme Quality posture buys not just a
+    // frontier model at max effort but a DEBATE pass (multi-perspective), above the
+    // single review the Assured preset buys. (See the work-orchestration design.)
+    if (weight >= QUALITY_DEBATE_FLOOR) {
+      return {
+        postureOverride: { budgetClass: "quality_first", reasoningDepth: "high", effort: "max", minimumTier: "frontier" },
+        orchestrationBudget: { verificationDepth: "deep", retryBudget: 3, deliberationPattern: "debate" },
+      };
+    }
     return strong
       ? cloneBase(PRESET_POLICIES.assured)
       : {

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -246,7 +246,15 @@ async function prepareRoute(
       requiresCodeExecution: options?.requiresCodeExecution,
       requiresWebSearch: options?.requiresWebSearch,
       requiresComputerUse: options?.requiresComputerUse,
-      budgetClass: options?.budgetClass ?? posture?.routeContext.budgetClass,
+      // EP-GOLDEN-TRIANGLE reconciliation: the posture (the everyday Cost/Quality
+      // lever) OWNS budgetClass. AgentModelConfig.budgetClass (which defaults to
+      // "balanced" and is always sent) applies only as the fallback when no
+      // non-Balanced posture is set — so dragging the triangle toward Cost or
+      // Quality is never silently overridden by the Assignments default. (Tier is
+      // already reconciled: AgentModelConfig.minimumTier acts as a floor via the
+      // per-dimension max-merge in inferContract, which the posture can raise but
+      // not drop below. See docs/design/2026-06-25-coworker-work-orchestration.md.)
+      budgetClass: posture?.routeContext.budgetClass ?? options?.budgetClass,
       requiredModelClass: options?.requiredModelClass,
       // EP-MODEL-TIER-ROUTING: a "local"-tier call forces local_only (keep
       // small/simple work on-box) even when the global switch is off; "robust"

--- a/docs/design/2026-06-25-coworker-work-orchestration.md
+++ b/docs/design/2026-06-25-coworker-work-orchestration.md
@@ -1,0 +1,83 @@
+# Coworker Work Orchestration — one control, a rigor ladder, fewer surfaces
+
+*Design note — 2026-06-25. Status: approved direction (founder /goal), implementing in slices.*
+
+## Problem
+
+Managing "how an AI coworker does work" is spread across competing surfaces, and the
+rigor patterns we already have (review, debate) are not leveraged by the everyday control:
+
+1. **Two surfaces set the same knobs.** The Golden Triangle per-coworker posture compiles to
+   `minimumTier` + `budgetClass` (among others); the **Assignments** page (`AgentModelConfig`)
+   *also* sets `minimumTier` + `budgetClass` per agent. At dispatch they collide with no owner:
+   - `budgetClass`: `AgentModelConfig` (defaults `balanced`, always sent) **silently overrides**
+     the posture → the triangle's Cost/Quality budget lever is dead for configured agents.
+   - `minimumTier`: stricter-of-the-two wins via per-dimension max; the compiler's
+     `policyConstraints.minimumTierFloor` exists but is **never fed** from `AgentModelConfig`.
+2. **Review/debate are invisible to coworkers.** The compiler emits `deliberationPattern: "review"`
+   for the quality posture, but **nothing consumes it** on a coworker turn — review/debate only
+   run inside Build Studio. So "more rigor at higher effort" doesn't happen where you'd expect it.
+3. **Too many surfaces.** `/platform/ai` carries Priority, Assignments, Prompts, Skills, Providers,
+   … to manage one thing — how a coworker works. The operator shouldn't hunt across tabs.
+
+## Doctrine
+
+**One everyday control; one expert backstop; effort buys a ladder of rigor.**
+
+- **Golden Triangle = the everyday, high-level control** (per coworker). Cost/Quality/Time → the
+  full ladder below. This is what an operator touches.
+- **`AgentModelConfig` = the expert guardrail/floor**, not a competing everyday control. It holds
+  what the triangle *can't* express and what must *bound* it: a hard **tier floor**, a **pinned
+  provider/model**, **capability** and **context-window** floors. Precedence is the design's
+  existing rule: **hard policy > AgentModelConfig floor > posture > model availability.**
+- **Effort buys rigor, in a ladder** — the Quality/effort axis doesn't just pick a bigger model,
+  it escalates *how hard the coworker checks its own work*:
+
+  | Posture (Quality/effort) | Model tier | Reasoning effort | Verification | Deliberation |
+  |--------------------------|-----------|------------------|--------------|--------------|
+  | Fast / Frugal (low)      | adequate  | low              | none         | none |
+  | Balanced                 | default   | default          | none         | none |
+  | Assured (high)           | frontier  | high             | shallow→deep | **review** (reviewer ≠ author) |
+  | Assured · max (top)      | frontier  | max              | deep         | **debate** (multi-perspective) |
+
+## Execution context decides the mechanism (the key constraint)
+
+The full deliberation engine (`startDeliberation`) runs in **minutes** (review ~5–15, debate
+~10–30) — appropriate for build artifacts, **not** an interactive chat reply. So effort picks the
+*rigor*; the run context picks the *mechanism*:
+
+- **Interactive chat turn** → a **lightweight inline review**: one reviewer-persona pass (distinct
+  from the author) that critiques the draft and revises it, bounded to a single extra model call.
+  Debate is *not* run inline (too slow); a high-stakes chat answer can offer "escalate to a full
+  review" rather than blocking the reply.
+- **Autonomous / long-running coworker work** (and builds) → the **full deliberation engine**
+  (`startDeliberation`, review/debate, multi-branch), which already exists and is the precedent.
+
+Both are **fail-open**: if the review pass errors or times out, the original draft is returned.
+Both are **off unless the posture asks for them** (Balanced and below = today's behaviour exactly).
+
+## Surface reduction
+
+Collapse the per-coworker "how it works" management into **one surface with two layers**:
+
+- **Priority (everyday)** — the Golden Triangle, primary. Shows the compiled ladder in plain
+  language (tier, effort, verification, review/debate) so the operator sees what each posture buys.
+- **Advanced (expert)** — the former Assignments controls, reframed as **guardrails**: tier *floor*,
+  pinned model, capability/context floors. Not a second everyday control.
+
+Net: the operator manages a coworker's work from the **triangle at the composer** + one Advanced
+backstop, instead of hunting across Priority + Assignments (+ scattered deliberation buried in builds).
+
+## Slices
+
+1. **Compiler ladder** *(pure, tested)* — extend `OrchestrationBudget` so deliberation escalates
+   none → review → **debate** by Quality/effort intensity (debate at the top); keep Balanced inert.
+2. **Reconcile the overlap** *(additive, tested)* — feed `AgentModelConfig.minimumTier` into the
+   compiler as `minimumTierFloor`; let the posture own `budgetClass`; record the precedence so it's
+   never a silent override.
+3. **Leverage review (interactive)** *(supervised)* — a lightweight inline reviewer-pass on the
+   coworker turn when the posture calls for review; fail-open, single extra call, off by default.
+4. **Leverage review/debate (autonomous)** — route autonomous/long-running coworker work to the
+   full deliberation engine, mirroring the build precedent.
+5. **Surface consolidation** *(UI)* — fold Assignments into the Priority surface as the Advanced
+   guardrail layer; show the rigor ladder on the triangle.


### PR DESCRIPTION
**Foundation for the coworker-work-orchestration goal** (design note: [2026-06-25-coworker-work-orchestration.md](docs/design/2026-06-25-coworker-work-orchestration.md)). Make "how a coworker works" easy to manage from one control, and actually leverage review/debate at higher effort.

**Rigor ladder (compiler).** The Quality/effort axis now buys escalating rigor, not just a bigger model: an **extreme Quality posture (weight ≥ 0.85)** compiles to **max effort + a `debate` deliberation**, above the single `review` the Assured preset buys — `none → review → debate`. Pure + tested; Balanced stays inert.

**Reconcile the overlap with Assignments.** The posture now **owns `budgetClass`** at dispatch (`posture.budgetClass ?? AgentModelConfig.budgetClass`). Previously `AgentModelConfig`'s always-present `balanced` silently overrode the triangle's Cost/Quality budget. Tier was already reconciled — `AgentModelConfig.minimumTier` floors the posture via the `inferContract` per-dimension max-merge (posture can raise, not drop below). Doctrine documented: **one everyday control (triangle) + one expert guardrail (AgentModelConfig); effort buys rigor; execution context picks the mechanism** (lightweight inline review for chat, full deliberation engine for autonomous/build).

82 golden-triangle tests green; `tsc` clean. Next slices: inline review on high-effort chat turns, full-engine review/debate for autonomous runs, and folding Assignments into the Priority surface as the Advanced guardrail layer.

Process-Spine-Decision: doc-specced; compiler pure/additive; budget flip is Balanced-inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
