### PR TITLE
feat(attention): "Needs you" inbox — a kernels-first attention surface, separate from the backlog (EP-ATTENTION-SURFACE)

### DIFF
--- a/apps/web/app/(shell)/ops/page.tsx
+++ b/apps/web/app/(shell)/ops/page.tsx
@@ -2,11 +2,9 @@
 import { getBacklogItems, getDigitalProductsForSelect, getTaxonomyNodesFlat, getEpics, getPortfoliosForSelect } from "@/lib/backlog-data";
 import { reconcileImprovementBacklog } from "@/lib/evaluate/improvement-backlog-reconcile";
 import { reconcileCapabilityNeedBacklog } from "@/lib/coworker-self-assessment/capability-backlog-reconcile";
-import { getOpenEscalations } from "@/lib/quality/escalation-attention";
 import { runEscalationHygiene } from "@/lib/quality/escalation-hygiene-runner";
 import { OpsClient } from "@/components/ops/OpsClient";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
-import { EscalationsAttention } from "@/components/ops/EscalationsAttention";
 import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
 import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 
@@ -29,21 +27,19 @@ export default async function OpsPage({ searchParams }: Props) {
   await Promise.all([
     reconcileImprovementBacklog().catch(() => {}),
     reconcileCapabilityNeedBacklog().catch(() => {}),
-    // BI-467E8F8D: clear stale build-stall escalations on render so /ops stays a
-    // trustworthy attention queue without waiting for the 15-min cron. Non-fatal;
-    // zero-write once converged.
+    // BI-467E8F8D: clear stale build-stall escalations so the queue stays trustworthy
+    // without waiting for the 15-min cron. The escalation BAND moved to the /workspace
+    // "Needs you" inbox (EP-ATTENTION-SURFACE: attention ≠ backlog); the hygiene stays
+    // here too since /ops still reconciles work. Non-fatal; zero-write once converged.
     runEscalationHygiene().catch(() => {}),
   ]);
 
-  const [items, digitalProducts, taxonomyNodes, epics, portfolios, escalations] = await Promise.all([
+  const [items, digitalProducts, taxonomyNodes, epics, portfolios] = await Promise.all([
     getBacklogItems(),
     getDigitalProductsForSelect(),
     getTaxonomyNodesFlat(),
     getEpics(),
     getPortfoliosForSelect(),
-    // Surface convergence (BI-0ACD9AB2): self-fix escalations held for a responder
-    // are attended HERE, in the one operator surface — not a separate /admin queue.
-    getOpenEscalations().catch(() => []),
   ]);
 
   return (
@@ -56,8 +52,6 @@ export default async function OpsPage({ searchParams }: Props) {
       </div>
 
       <OpsTabNav />
-
-      <EscalationsAttention escalations={escalations} />
 
       <SurfaceViewSwitcher entityType="backlog_item" current={view ?? "list"} />
 

--- a/apps/web/app/(shell)/workspace/inbox/page.tsx
+++ b/apps/web/app/(shell)/workspace/inbox/page.tsx
@@ -1,0 +1,39 @@
+// /workspace/inbox — the "Needs you" attention queue (full view).
+// EP-ATTENTION-SURFACE keystone (BI-D39484E7). A workspace-section sibling, so no
+// cross-rail teleport (EP-NAV-COHERENCE). Spec §6.
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { loadAttentionItems, filterAttentionForAudience } from "@/lib/attention/aggregate";
+import { runEscalationHygiene } from "@/lib/quality/escalation-hygiene-runner";
+import { AttentionInbox } from "@/components/attention/AttentionInbox";
+
+export const dynamic = "force-dynamic";
+
+export default async function WorkspaceInboxPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  // Best-effort auto-resolve so settled escalations clear when the inbox is viewed
+  // (re-homed from /ops with the band; the 15-min cron still covers it). Idempotent,
+  // zero-write once converged.
+  await runEscalationHygiene().catch(() => {});
+
+  const { items, failedSources } = await loadAttentionItems(prisma);
+  // V1 operator-view; worker scoping (own approvals only) is BI-AS-4.
+  const visible = filterAttentionForAudience(items, { operator: true });
+
+  return (
+    <main className="space-y-4 text-[var(--dpf-text)]">
+      <div>
+        <h1 className="text-lg font-semibold">Needs you</h1>
+        <p className="mt-1 max-w-prose text-sm text-[var(--dpf-muted)]">
+          Decisions routed to you after the governed scopes couldn&apos;t resolve them — escalations,
+          approvals, paused coworkers — ordered by what&apos;s most pressing, each with why it needs
+          you. The work backlog lives in Operations.
+        </p>
+      </div>
+      <AttentionInbox items={visible} failedSources={failedSources} nowMs={Date.now()} />
+    </main>
+  );
+}

--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
 import { PlatformWorkspaceHome } from "@/components/workspace-home/PlatformWorkspaceHome";
+import { NeedsYouBand } from "@/components/attention/NeedsYouBand";
 import { LocalOnlyProviderNotice } from "@/components/workspace-home/LocalOnlyProviderNotice";
 import { UnconfiguredWorkspaceHomeNotice } from "@/components/workspace-home/UnconfiguredWorkspaceHomeNotice";
 import { loadPlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
@@ -40,6 +41,10 @@ export default async function WorkspacePage() {
       {workspaceHomeResolution.mode !== "unconfigured" && !hasCloudProvider && (
         <LocalOnlyProviderNotice />
       )}
+      {/* The "Needs you" attention band — first-viewport decisions that need a human
+          now, separate from the work backlog (EP-ATTENTION-SURFACE). Renders nothing
+          when the queue is empty. */}
+      <NeedsYouBand />
       <PlatformWorkspaceHome data={platformHomeData} />
     </div>
   );

--- a/apps/web/components/attention/AttentionInbox.tsx
+++ b/apps/web/components/attention/AttentionInbox.tsx
@@ -21,6 +21,11 @@ const SOURCE_LABEL: Record<AttentionSource, string> = {
   "ai-decision": "AI decision",
   "paused-ai": "Paused AI",
   "agent-proposal": "Approval",
+  "approval-outbound": "Marketing",
+  "approval-bill": "Bill",
+  "approval-expense": "Expense",
+  "compliance-submission": "Compliance",
+  "research-proposal": "Research",
 };
 
 export function AttentionInbox({

--- a/apps/web/components/attention/AttentionInbox.tsx
+++ b/apps/web/components/attention/AttentionInbox.tsx
@@ -7,7 +7,6 @@
 import Link from "next/link";
 import type { AttentionItem, AttentionSource } from "@/lib/attention/types";
 import {
-  orderReason,
   residueReasonLabel,
   riskLabel,
   decideEffortLabel,

--- a/apps/web/components/attention/AttentionInbox.tsx
+++ b/apps/web/components/attention/AttentionInbox.tsx
@@ -1,0 +1,122 @@
+// The "Needs you" inbox — the full attention queue on /workspace/inbox.
+// Presentational + server-rendered: takes the ordered projector output and renders
+// each item with its triage CONTEXT (why it's here, what's blocked, how urgent),
+// never a composite priority number. Deep-links out to the owning surface for
+// heavy context. Spec §4.4, §6. nowMs is injected so age is deterministic.
+
+import Link from "next/link";
+import type { AttentionItem, AttentionSource } from "@/lib/attention/types";
+import {
+  orderReason,
+  residueReasonLabel,
+  riskLabel,
+  decideEffortLabel,
+  attentionAgeLabel,
+  isOverrideTier,
+  overrideReason,
+} from "@/lib/attention/triage";
+
+const SOURCE_LABEL: Record<AttentionSource, string> = {
+  escalation: "Build escalation",
+  "ai-decision": "AI decision",
+  "paused-ai": "Paused AI",
+  "agent-proposal": "Approval",
+};
+
+export function AttentionInbox({
+  items,
+  failedSources,
+  nowMs,
+}: {
+  items: AttentionItem[];
+  failedSources: AttentionSource[];
+  nowMs: number;
+}) {
+  return (
+    <div className="space-y-3">
+      {failedSources.length > 0 ? (
+        <p className="rounded border border-[var(--dpf-warning)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[11px] text-[var(--dpf-muted)]">
+          Couldn&apos;t load: {failedSources.map((s) => SOURCE_LABEL[s]).join(", ")}. The rest of your
+          queue is shown.
+        </p>
+      ) : null}
+
+      {items.length === 0 ? (
+        <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6 text-center">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Nothing needs you right now</h2>
+          <p className="mx-auto mt-1 max-w-prose text-sm text-[var(--dpf-muted)]">
+            When the AI can&apos;t resolve a decision on its own — an escalation, an approval, a paused
+            coworker — it lands here with the context to act. Until then, you&apos;re clear.
+          </p>
+        </section>
+      ) : (
+        <ul className="divide-y divide-[var(--dpf-border)] overflow-hidden rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+          {items.map((item) => (
+            <AttentionRow key={item.id} item={item} nowMs={nowMs} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function AttentionRow({ item, nowMs }: { item: AttentionItem; nowMs: number }) {
+  const override = isOverrideTier(item);
+  const pin = override ? overrideReason(item) : null;
+  return (
+    <li className="flex items-start gap-3 px-4 py-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+            {SOURCE_LABEL[item.source]}
+          </span>
+          {item.riskClass === "high-risk" ? (
+            <span className="rounded border border-[var(--dpf-error)] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--dpf-error)]">
+              {riskLabel(item.riskClass)}
+            </span>
+          ) : null}
+          {pin ? (
+            <span className="rounded border border-[var(--dpf-accent)] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--dpf-accent)]">
+              Pinned · {pin}
+            </span>
+          ) : null}
+          <span className="text-[10px] text-[var(--dpf-muted)]">
+            {attentionAgeLabel(item.createdAtIso, nowMs)}
+          </span>
+        </div>
+
+        <p className="mt-1 text-sm font-medium text-[var(--dpf-text)]">{item.title}</p>
+        {item.context ? (
+          <p className="mt-0.5 text-[12px] leading-snug text-[var(--dpf-muted)]">{item.context}</p>
+        ) : null}
+
+        {/* Why this / why now — the context that makes the order legible. */}
+        <p className="mt-1 text-[11px] text-[var(--dpf-muted)]">
+          <span className="text-[var(--dpf-text)]">Why it&apos;s here:</span>{" "}
+          {residueReasonLabel(item.triage.residueReason)}
+          {item.triage.blastRadius ? (
+            <>
+              {" · "}
+              <span className="text-[var(--dpf-text)]">Blocks:</span> {item.triage.blastRadius}
+            </>
+          ) : null}
+          {" · "}needs {decideEffortLabel(item.triage.decideEffort)}
+        </p>
+      </div>
+
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        {item.actions.map((action) =>
+          action.href ? (
+            <Link
+              key={action.kind + action.label}
+              href={action.href}
+              className="text-[11px] font-semibold text-[var(--dpf-accent)] hover:opacity-80"
+            >
+              {action.label} →
+            </Link>
+          ) : null,
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/web/components/attention/AttentionInbox.tsx
+++ b/apps/web/components/attention/AttentionInbox.tsx
@@ -14,6 +14,7 @@ import {
   attentionAgeLabel,
   isOverrideTier,
   overrideReason,
+  summarizeAttention,
 } from "@/lib/attention/triage";
 
 const SOURCE_LABEL: Record<AttentionSource, string> = {
@@ -55,12 +56,35 @@ export function AttentionInbox({
           </p>
         </section>
       ) : (
-        <ul className="divide-y divide-[var(--dpf-border)] overflow-hidden rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          {items.map((item) => (
-            <AttentionRow key={item.id} item={item} nowMs={nowMs} />
-          ))}
-        </ul>
+        <>
+          <AttentionSummaryHeader items={items} />
+          <ul className="divide-y divide-[var(--dpf-border)] overflow-hidden rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+            {items.map((item) => (
+              <AttentionRow key={item.id} item={item} nowMs={nowMs} />
+            ))}
+          </ul>
+        </>
       )}
+    </div>
+  );
+}
+
+/** The at-a-glance overview — total, the "act first" override count, high-risk
+ *  count, and grouped per-source counts. Counts only, never a composite score. */
+function AttentionSummaryHeader({ items }: { items: AttentionItem[] }) {
+  const summary = summarizeAttention(items);
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1 text-[11px] text-[var(--dpf-muted)]">
+      <span className="font-semibold text-[var(--dpf-text)]">{summary.total} need you</span>
+      {summary.pinned > 0 ? <span>· {summary.pinned} pinned</span> : null}
+      {summary.highRisk > 0 ? <span>· {summary.highRisk} high-risk</span> : null}
+      <span className="ml-auto flex flex-wrap gap-x-2">
+        {summary.bySource.map((s) => (
+          <span key={s.source}>
+            {SOURCE_LABEL[s.source]} {s.count}
+          </span>
+        ))}
+      </span>
     </div>
   );
 }

--- a/apps/web/components/attention/NeedsYouBand.tsx
+++ b/apps/web/components/attention/NeedsYouBand.tsx
@@ -1,0 +1,76 @@
+// "Needs you" — the first-viewport attention band on /workspace.
+// An async server component: it projects the residue across the scattered queues
+// (read-only) and shows the top few, tiered, with a one-line "why now" each, then
+// links to the full /workspace/inbox. Renders NOTHING when the queue is empty so a
+// clear workspace stays clear (mirrors EscalationsAttention). Spec §6.1.
+//
+// V1 is operator-view — consistent with the command-center already on this page;
+// worker scoping (own approvals only) is the BI-AS-4 fast-follow.
+
+import Link from "next/link";
+import { prisma } from "@dpf/db";
+import { loadAttentionItems, filterAttentionForAudience } from "@/lib/attention/aggregate";
+import { orderReason, attentionAgeLabel, isOverrideTier, overrideReason } from "@/lib/attention/triage";
+
+const PREVIEW_COUNT = 5;
+
+export async function NeedsYouBand() {
+  const { items, failedSources } = await loadAttentionItems(prisma);
+  const visible = filterAttentionForAudience(items, { operator: true });
+  if (visible.length === 0 && failedSources.length === 0) return null;
+
+  const nowMs = Date.now();
+  const top = visible.slice(0, PREVIEW_COUNT);
+
+  return (
+    <section className="mb-6 overflow-hidden rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]">
+      <div className="flex items-center gap-2 border-b border-[var(--dpf-border)] px-3 py-2">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--dpf-text)]">
+          Needs you
+        </h2>
+        <span className="text-[10px] font-semibold text-[var(--dpf-accent)]">{visible.length}</span>
+        <Link
+          href="/workspace/inbox"
+          className="ml-auto text-[10px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+        >
+          {visible.length > top.length ? `View all ${visible.length}` : "Open inbox"} →
+        </Link>
+      </div>
+
+      <p className="px-3 pt-2 text-[11px] text-[var(--dpf-muted)]">
+        Decisions the AI couldn&apos;t make on its own — ordered by what&apos;s most pressing, each with
+        why it needs you. The work backlog lives in Operations; this is only what needs a decision now.
+      </p>
+
+      <ul className="mt-1 divide-y divide-[var(--dpf-border)]">
+        {top.map((item) => {
+          const pin = isOverrideTier(item) ? overrideReason(item) : null;
+          return (
+            <li key={item.id} className="flex items-start gap-3 px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  {pin ? (
+                    <span className="rounded border border-[var(--dpf-accent)] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--dpf-accent)]">
+                      Pinned · {pin}
+                    </span>
+                  ) : null}
+                  <span className="text-[10px] text-[var(--dpf-muted)]">
+                    {attentionAgeLabel(item.createdAtIso, nowMs)}
+                  </span>
+                </div>
+                <p className="mt-0.5 truncate text-xs font-medium text-[var(--dpf-text)]">{item.title}</p>
+                <p className="mt-0.5 text-[11px] leading-snug text-[var(--dpf-muted)]">{orderReason(item)}</p>
+              </div>
+              <Link
+                href={item.deepLink}
+                className="shrink-0 self-center text-[10px] font-semibold text-[var(--dpf-accent)] hover:opacity-80"
+              >
+                Open →
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/lib/attention/aggregate.test.ts
+++ b/apps/web/lib/attention/aggregate.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { aggregateAttention, filterAttentionForAudience } from "./aggregate";
+import type { AttentionItem } from "./types";
+
+function item(id: string, over: Partial<AttentionItem> = {}): AttentionItem {
+  return {
+    id,
+    source: "escalation",
+    title: id,
+    context: "",
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: { timeToAct: "none", residueReason: "self-fix-exhausted", decideEffort: "judgment", irreversible: false },
+    createdAtIso: "2026-06-23T12:00:00.000Z",
+    actions: [],
+    deepLink: "/build",
+    audience: { operator: true },
+    ...over,
+  };
+}
+
+describe("aggregateAttention", () => {
+  it("collects items from every source and orders them by the tiered rule", async () => {
+    const result = await aggregateAttention([
+      { source: "escalation", load: async () => [item("escalation:1", { riskClass: "read" })] },
+      {
+        source: "paused-ai",
+        load: async () => [item("paused-ai:1", { riskClass: "high-risk", triage: { timeToAct: "overdue", residueReason: "input-required", decideEffort: "judgment", irreversible: false } })],
+      },
+    ]);
+    expect(result.failedSources).toEqual([]);
+    // The overdue (override-tier) paused-ai item sorts ahead of the read escalation.
+    expect(result.items.map((i) => i.id)).toEqual(["paused-ai:1", "escalation:1"]);
+  });
+
+  it("degrades a throwing source to failedSources instead of a blank inbox", async () => {
+    const result = await aggregateAttention([
+      { source: "escalation", load: async () => [item("escalation:1")] },
+      {
+        source: "ai-decision",
+        load: async () => {
+          throw new Error("db down");
+        },
+      },
+    ]);
+    expect(result.items.map((i) => i.id)).toEqual(["escalation:1"]);
+    expect(result.failedSources).toEqual(["ai-decision"]);
+  });
+});
+
+describe("filterAttentionForAudience", () => {
+  const operatorOnly = item("op", { audience: { operator: true } });
+  const workerOwned = item("worker", { audience: { operator: true, assigneePrincipalId: "p-7" } });
+  const items = [operatorOnly, workerOwned];
+
+  it("shows operators the full residue", () => {
+    expect(filterAttentionForAudience(items, { operator: true }).map((i) => i.id)).toEqual(["op", "worker"]);
+  });
+
+  it("shows a worker only items assigned to their principal", () => {
+    expect(filterAttentionForAudience(items, { operator: false, principalId: "p-7" }).map((i) => i.id)).toEqual([
+      "worker",
+    ]);
+  });
+
+  it("shows a worker nothing when no item is assigned to them", () => {
+    expect(filterAttentionForAudience(items, { operator: false, principalId: "p-99" })).toEqual([]);
+  });
+});

--- a/apps/web/lib/attention/aggregate.ts
+++ b/apps/web/lib/attention/aggregate.ts
@@ -10,6 +10,13 @@ import { loadEscalationItems } from "./sources/escalation";
 import { loadAiDecisionItems } from "./sources/ai-decision";
 import { loadPausedAiItems } from "./sources/paused-ai";
 import { loadAgentProposalItems } from "./sources/agent-proposal";
+import {
+  loadOutboundItems,
+  loadBillItems,
+  loadExpenseItems,
+  loadRegulatoryItems,
+  loadResearchItems,
+} from "./sources/business-approvals";
 
 type Db = typeof prisma;
 
@@ -68,5 +75,10 @@ export async function loadAttentionItems(db: Db): Promise<AttentionResult> {
     { source: "ai-decision", load: () => loadAiDecisionItems(db) },
     { source: "paused-ai", load: () => loadPausedAiItems(db) },
     { source: "agent-proposal", load: () => loadAgentProposalItems(db) },
+    { source: "approval-outbound", load: () => loadOutboundItems(db) },
+    { source: "approval-bill", load: () => loadBillItems(db) },
+    { source: "approval-expense", load: () => loadExpenseItems(db) },
+    { source: "compliance-submission", load: () => loadRegulatoryItems(db) },
+    { source: "research-proposal", load: () => loadResearchItems(db) },
   ]);
 }

--- a/apps/web/lib/attention/aggregate.ts
+++ b/apps/web/lib/attention/aggregate.ts
@@ -1,0 +1,72 @@
+// The aggregator — fan out the source adapters, order by the tiered triage rule,
+// scope by audience. Read-only and idempotent; never mutates a source row.
+// A failing source degrades to `failedSources` — never a blank inbox (spec §6.3).
+// Spec: docs/superpowers/specs/2026-06-23-human-attention-surface-design.md §4.1, §6.2.
+
+import type { prisma } from "@dpf/db";
+import type { AttentionItem, AttentionSource } from "./types";
+import { orderAttention } from "./triage";
+import { loadEscalationItems } from "./sources/escalation";
+import { loadAiDecisionItems } from "./sources/ai-decision";
+import { loadPausedAiItems } from "./sources/paused-ai";
+import { loadAgentProposalItems } from "./sources/agent-proposal";
+
+type Db = typeof prisma;
+
+export type AttentionSourceLoader = {
+  source: AttentionSource;
+  load: () => Promise<AttentionItem[]>;
+};
+
+export type AttentionResult = {
+  /** Ordered by the tiered triage rule (override → time → risk → blast → age). */
+  items: AttentionItem[];
+  /** Sources whose adapter threw — surfaced as a "couldn't load <source>" note. */
+  failedSources: AttentionSource[];
+};
+
+/** Fan out the source loaders in parallel, collect, and order. Deps-injected so
+ *  the fan-out + resilience is unit-testable without a live database. */
+export async function aggregateAttention(loaders: AttentionSourceLoader[]): Promise<AttentionResult> {
+  const settled = await Promise.all(
+    loaders.map(async (l) => {
+      try {
+        return { source: l.source, items: await l.load() };
+      } catch {
+        return { source: l.source, items: null };
+      }
+    }),
+  );
+
+  const items: AttentionItem[] = [];
+  const failedSources: AttentionSource[] = [];
+  for (const r of settled) {
+    if (r.items === null) failedSources.push(r.source);
+    else items.push(...r.items);
+  }
+  return { items: orderAttention(items), failedSources };
+}
+
+export type AttentionAudienceQuery = { operator: boolean; principalId?: string };
+
+/** Audience scoping (pure). Operators see the full residue; a worker sees only
+ *  the items assigned to their principal. Spec §6.2. */
+export function filterAttentionForAudience(
+  items: AttentionItem[],
+  q: AttentionAudienceQuery,
+): AttentionItem[] {
+  if (q.operator) return items.filter((i) => i.audience.operator);
+  return items.filter(
+    (i) => q.principalId != null && i.audience.assigneePrincipalId === q.principalId,
+  );
+}
+
+/** Production entry point — wires the real source loaders over the db client. */
+export async function loadAttentionItems(db: Db): Promise<AttentionResult> {
+  return aggregateAttention([
+    { source: "escalation", load: () => loadEscalationItems() },
+    { source: "ai-decision", load: () => loadAiDecisionItems(db) },
+    { source: "paused-ai", load: () => loadPausedAiItems(db) },
+    { source: "agent-proposal", load: () => loadAgentProposalItems(db) },
+  ]);
+}

--- a/apps/web/lib/attention/sources/agent-proposal.ts
+++ b/apps/web/lib/attention/sources/agent-proposal.ts
@@ -1,0 +1,53 @@
+// Agent-proposal source — AgentActionProposal rows awaiting a human decision.
+// Today these are reachable only through /api/v1/governance/approvals (no UI);
+// the inbox is their first human surface. Spec §1 (queue #8), §4.1.
+
+import type { prisma } from "@dpf/db";
+import type { AttentionItem } from "../types";
+
+type Db = typeof prisma;
+
+export type AgentActionProposalRow = {
+  proposalId: string;
+  actionType: string;
+  proposedAt: Date;
+};
+
+/** "create_invoice" → "Create invoice". Light humanization of the action slug. */
+function humanizeActionType(actionType: string): string {
+  const words = actionType.replace(/[_-]+/g, " ").trim();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : "an action";
+}
+
+/** Pure projection of one proposed agent action into an attention item. */
+export function agentProposalToAttentionItem(row: AgentActionProposalRow): AttentionItem {
+  return {
+    id: `agent-proposal:${row.proposalId}`,
+    source: "agent-proposal",
+    title: `Approve: ${humanizeActionType(row.actionType)}`,
+    context: "A coworker proposed an action and is waiting on your approval.",
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: {
+      timeToAct: "none",
+      residueReason: "policy-approval",
+      blastRadius: "a coworker waiting on approval",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: row.proposedAt.toISOString(),
+    actions: [{ kind: "open-in-context", label: "Review in AI Workforce", href: "/platform/ai" }],
+    deepLink: "/platform/ai",
+    audience: { operator: true },
+  };
+}
+
+export async function loadAgentProposalItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.agentActionProposal.findMany({
+    where: { status: "proposed" },
+    orderBy: { proposedAt: "desc" },
+    take: 50,
+    select: { proposalId: true, actionType: true, proposedAt: true },
+  });
+  return rows.map(agentProposalToAttentionItem);
+}

--- a/apps/web/lib/attention/sources/ai-decision.ts
+++ b/apps/web/lib/attention/sources/ai-decision.ts
@@ -1,0 +1,94 @@
+// AI-decision source — the residue the governed scopes could not resolve.
+// DecisionInteraction rows with outcomeType escalate/defer and humanOutcome null
+// (exactly what /platform/ai/founder-review reads). These came FROM the kernel
+// cascade, so they are unscorable residue — show the honest reason, never a
+// verdict. Spec §3.1, §4.1; founder-review becomes a lens of this source (BI-AS-6).
+
+import { Prisma } from "@dpf/db";
+import type { prisma } from "@dpf/db";
+import type { AttentionItem, AttentionRiskClass, ResidueReason } from "../types";
+
+type Db = typeof prisma;
+
+export type DecisionInteractionRow = {
+  interactionId: string;
+  question: string;
+  outcomeType: string;
+  riskTier: string;
+  principleConflict: boolean;
+  rationale: string | null;
+  buildId: string | null;
+  taskRunId: string | null;
+  createdAt: Date;
+};
+
+function clip(s: string, max = 120): string {
+  return s.length > max ? `${s.slice(0, max - 1).trimEnd()}…` : s;
+}
+
+function riskFromTier(tier: string): AttentionRiskClass {
+  switch (tier) {
+    case "low":
+      return "read";
+    case "medium":
+      return "bounded-write";
+    case "high":
+    case "critical":
+      return "high-risk";
+    default:
+      return "unknown";
+  }
+}
+
+function residueFor(row: DecisionInteractionRow): ResidueReason {
+  if (row.principleConflict) return "principle-conflict";
+  if (row.outcomeType === "defer") return "coverage-gap";
+  return "high-risk-gate"; // escalate: the cascade escalated on risk/low-confidence
+}
+
+/** Pure projection of one unresolved decision into an attention item. */
+export function aiDecisionToAttentionItem(row: DecisionInteractionRow): AttentionItem {
+  const blast = row.buildId ? `build ${row.buildId}` : row.taskRunId ? "a coworker task" : undefined;
+  return {
+    id: `ai-decision:${row.interactionId}`,
+    source: "ai-decision",
+    title: clip(row.question),
+    context: row.rationale ?? "The governed scopes could not resolve this decision.",
+    decisionClass: { scorability: "unscorable" },
+    riskClass: riskFromTier(row.riskTier),
+    triage: {
+      timeToAct: "none",
+      residueReason: residueFor(row),
+      blastRadius: blast,
+      decideEffort: "judgment",
+      irreversible: false,
+    },
+    createdAtIso: row.createdAt.toISOString(),
+    actions: [
+      { kind: "open-in-context", label: "Review decision", href: "/platform/ai/founder-review" },
+    ],
+    deepLink: "/platform/ai/founder-review",
+    audience: { operator: true },
+  };
+}
+
+export async function loadAiDecisionItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.decisionInteraction.findMany({
+    // humanOutcome IS NULL == still unresolved residue (Json? → DB NULL).
+    where: { outcomeType: { in: ["escalate", "defer"] }, humanOutcome: { equals: Prisma.DbNull } },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      interactionId: true,
+      question: true,
+      outcomeType: true,
+      riskTier: true,
+      principleConflict: true,
+      rationale: true,
+      buildId: true,
+      taskRunId: true,
+      createdAt: true,
+    },
+  });
+  return rows.map(aiDecisionToAttentionItem);
+}

--- a/apps/web/lib/attention/sources/business-approvals.test.ts
+++ b/apps/web/lib/attention/sources/business-approvals.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  outboundToAttentionItem,
+  billToAttentionItem,
+  expenseToAttentionItem,
+  regulatoryToAttentionItem,
+  researchToAttentionItem,
+} from "./business-approvals";
+import { isOverrideTier } from "../triage";
+
+const NOW = new Date("2026-06-23T12:00:00.000Z").getTime();
+
+describe("billToAttentionItem", () => {
+  const base = {
+    billRef: "BILL-2026-0001",
+    currency: "GBP",
+    amountDue: "500.00",
+    createdAt: new Date("2026-06-20T10:00:00.000Z"),
+  };
+
+  it("floats an overdue bill into the override tier with the amount as context", () => {
+    const item = billToAttentionItem({ ...base, dueDate: new Date("2026-06-22T10:00:00.000Z") }, NOW);
+    expect(item.source).toBe("approval-bill");
+    expect(item.triage.timeToAct).toBe("overdue");
+    expect(item.triage.deadlineIso).toBe("2026-06-22T10:00:00.000Z");
+    expect(isOverrideTier(item)).toBe(true);
+    expect(item.context).toBe("GBP 500.00 due");
+    expect(item.triage.residueReason).toBe("policy-approval");
+  });
+
+  it("leaves a far-off bill in the normal tier", () => {
+    const item = billToAttentionItem({ ...base, dueDate: new Date("2026-08-01T10:00:00.000Z") }, NOW);
+    expect(item.triage.timeToAct).toBe("none");
+    expect(isOverrideTier(item)).toBe(false);
+  });
+});
+
+describe("regulatoryToAttentionItem", () => {
+  const base = {
+    submissionId: "RS-1",
+    title: "Quarterly VAT return",
+    recipientBody: "HMRC",
+    submissionType: "tax-return",
+    createdAt: new Date("2026-06-20T10:00:00.000Z"),
+  };
+
+  it("is high-risk and floats to the override tier when due today", () => {
+    const item = regulatoryToAttentionItem({ ...base, dueDate: new Date("2026-06-23T20:00:00.000Z") }, NOW);
+    expect(item.source).toBe("compliance-submission");
+    expect(item.riskClass).toBe("high-risk");
+    expect(item.triage.timeToAct).toBe("due-today");
+    expect(isOverrideTier(item)).toBe(true);
+  });
+
+  it("handles a submission with no deadline", () => {
+    const item = regulatoryToAttentionItem({ ...base, dueDate: null }, NOW);
+    expect(item.triage.timeToAct).toBe("none");
+    expect(item.triage.deadlineIso).toBeUndefined();
+  });
+});
+
+describe("the no-deadline business approvals", () => {
+  it("maps an outbound draft", () => {
+    const item = outboundToAttentionItem({
+      draftId: "OD-1",
+      channelId: "linkedin",
+      assetType: "linkedin-post",
+      body: "Big news this week...",
+      createdAt: new Date("2026-06-23T09:00:00.000Z"),
+    });
+    expect(item.source).toBe("approval-outbound");
+    expect(item.riskClass).toBe("bounded-write");
+    expect(item.title).toBe("Approve linkedin-post for linkedin");
+  });
+
+  it("maps an expense claim, preferring submittedAt for age", () => {
+    const item = expenseToAttentionItem({
+      claimId: "EC-1",
+      title: "Client dinner",
+      currency: "USD",
+      totalAmount: "82.50",
+      submittedAt: new Date("2026-06-22T18:00:00.000Z"),
+      createdAt: new Date("2026-06-21T18:00:00.000Z"),
+    });
+    expect(item.id).toBe("approval-expense:EC-1");
+    expect(item.createdAtIso).toBe("2026-06-22T18:00:00.000Z");
+    expect(item.context).toBe("USD 82.50");
+  });
+
+  it("maps a research proposal as low-risk", () => {
+    const item = researchToAttentionItem({
+      proposalId: "RP-1",
+      topic: "competitive-landscape",
+      query: "Who are the top 5 competitors and their pricing?",
+      proposedAt: new Date("2026-06-23T07:00:00.000Z"),
+    });
+    expect(item.source).toBe("research-proposal");
+    expect(item.riskClass).toBe("read");
+    expect(item.title).toBe("Approve research: competitive-landscape");
+  });
+});

--- a/apps/web/lib/attention/sources/business-approvals.ts
+++ b/apps/web/lib/attention/sources/business-approvals.ts
@@ -1,0 +1,237 @@
+// Business-approval sources — outbound / bill / expense / compliance / research.
+// These are the DEADLINE-bearing queues, so they exercise the §4.4 override tier:
+// a bill or regulatory filing due today floats to the top, shown with its reason.
+// Pure mappers (nowMs injected for the deadline tier). Operator-view in this slice
+// — worker-principal scoping needs approver-role resolution (follow-on).
+// Spec §1 (queues 3-7), §4.1, §4.4. Partially delivers BI-8EA88797.
+
+import type { prisma } from "@dpf/db";
+import type { AttentionItem } from "../types";
+import { timeToActFromDeadline } from "../triage";
+
+type Db = typeof prisma;
+
+function clip(s: string, max = 120): string {
+  return s.length > max ? `${s.slice(0, max - 1).trimEnd()}…` : s;
+}
+
+// ─── Outbound drafts (marketing) — no deadline ───────────────────────────────
+
+export type OutboundDraftRow = {
+  draftId: string;
+  channelId: string;
+  assetType: string;
+  body: string;
+  createdAt: Date;
+};
+
+export function outboundToAttentionItem(row: OutboundDraftRow): AttentionItem {
+  return {
+    id: `approval-outbound:${row.draftId}`,
+    source: "approval-outbound",
+    title: `Approve ${row.assetType} for ${row.channelId}`,
+    context: clip(row.body),
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: {
+      timeToAct: "none",
+      residueReason: "policy-approval",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: row.createdAt.toISOString(),
+    actions: [{ kind: "open-in-context", label: "Review draft", href: "/customer/marketing" }],
+    deepLink: "/customer/marketing",
+    audience: { operator: true },
+  };
+}
+
+export async function loadOutboundItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.outboundDraft.findMany({
+    where: { status: "pending-review" },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: { draftId: true, channelId: true, assetType: true, body: true, createdAt: true },
+  });
+  return rows.map(outboundToAttentionItem);
+}
+
+// ─── Bills (AP) — hard dueDate ───────────────────────────────────────────────
+
+export type BillRow = {
+  billRef: string;
+  currency: string;
+  amountDue: string;
+  dueDate: Date;
+  createdAt: Date;
+};
+
+export function billToAttentionItem(row: BillRow, nowMs: number): AttentionItem {
+  const deadlineIso = row.dueDate.toISOString();
+  return {
+    id: `approval-bill:${row.billRef}`,
+    source: "approval-bill",
+    title: `Approve bill ${row.billRef}`,
+    context: `${row.currency} ${row.amountDue} due`,
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: {
+      timeToAct: timeToActFromDeadline(deadlineIso, nowMs),
+      deadlineIso,
+      residueReason: "policy-approval",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: row.createdAt.toISOString(),
+    actions: [{ kind: "open-in-context", label: "Review bill", href: "/finance/bills" }],
+    deepLink: "/finance/bills",
+    audience: { operator: true },
+  };
+}
+
+export async function loadBillItems(db: Db): Promise<AttentionItem[]> {
+  const nowMs = Date.now();
+  const rows = await db.bill.findMany({
+    where: { status: "awaiting_approval" },
+    orderBy: { dueDate: "asc" },
+    take: 50,
+    select: { billRef: true, currency: true, amountDue: true, dueDate: true, createdAt: true },
+  });
+  return rows.map((r) =>
+    billToAttentionItem({ ...r, amountDue: r.amountDue.toString() }, nowMs),
+  );
+}
+
+// ─── Expense claims — no hard deadline ───────────────────────────────────────
+
+export type ExpenseClaimRow = {
+  claimId: string;
+  title: string;
+  currency: string;
+  totalAmount: string;
+  submittedAt: Date | null;
+  createdAt: Date;
+};
+
+export function expenseToAttentionItem(row: ExpenseClaimRow): AttentionItem {
+  return {
+    id: `approval-expense:${row.claimId}`,
+    source: "approval-expense",
+    title: `Approve expense: ${row.title}`,
+    context: `${row.currency} ${row.totalAmount}`,
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: {
+      timeToAct: "none",
+      residueReason: "policy-approval",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: (row.submittedAt ?? row.createdAt).toISOString(),
+    actions: [{ kind: "open-in-context", label: "Review claim", href: "/finance/expense-claims" }],
+    deepLink: "/finance/expense-claims",
+    audience: { operator: true },
+  };
+}
+
+export async function loadExpenseItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.expenseClaim.findMany({
+    where: { status: "submitted" },
+    orderBy: { submittedAt: "desc" },
+    take: 50,
+    select: { claimId: true, title: true, currency: true, totalAmount: true, submittedAt: true, createdAt: true },
+  });
+  return rows.map((r) => expenseToAttentionItem({ ...r, totalAmount: r.totalAmount.toString() }));
+}
+
+// ─── Regulatory submissions — hard dueDate, high stakes ──────────────────────
+
+export type RegulatorySubmissionRow = {
+  submissionId: string;
+  title: string;
+  recipientBody: string;
+  submissionType: string;
+  dueDate: Date | null;
+  createdAt: Date;
+};
+
+export function regulatoryToAttentionItem(row: RegulatorySubmissionRow, nowMs: number): AttentionItem {
+  const deadlineIso = row.dueDate ? row.dueDate.toISOString() : undefined;
+  return {
+    id: `compliance-submission:${row.submissionId}`,
+    source: "compliance-submission",
+    title: `File: ${row.title}`,
+    context: `${row.submissionType} to ${row.recipientBody}`,
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "high-risk", // a missed regulatory deadline is high-stakes
+    triage: {
+      timeToAct: timeToActFromDeadline(deadlineIso, nowMs),
+      deadlineIso,
+      residueReason: "policy-approval",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: row.createdAt.toISOString(),
+    actions: [{ kind: "open-in-context", label: "Open submission", href: "/compliance/submissions" }],
+    deepLink: "/compliance/submissions",
+    audience: { operator: true },
+  };
+}
+
+export async function loadRegulatoryItems(db: Db): Promise<AttentionItem[]> {
+  const nowMs = Date.now();
+  const rows = await db.regulatorySubmission.findMany({
+    where: { status: "draft" },
+    orderBy: { dueDate: "asc" },
+    take: 50,
+    select: {
+      submissionId: true,
+      title: true,
+      recipientBody: true,
+      submissionType: true,
+      dueDate: true,
+      createdAt: true,
+    },
+  });
+  return rows.map((r) => regulatoryToAttentionItem(r, nowMs));
+}
+
+// ─── Research proposals — low risk, no deadline ──────────────────────────────
+
+export type ResearchProposalRow = {
+  proposalId: string;
+  topic: string;
+  query: string;
+  proposedAt: Date;
+};
+
+export function researchToAttentionItem(row: ResearchProposalRow): AttentionItem {
+  return {
+    id: `research-proposal:${row.proposalId}`,
+    source: "research-proposal",
+    title: `Approve research: ${row.topic}`,
+    context: clip(row.query),
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "read",
+    triage: {
+      timeToAct: "none",
+      residueReason: "policy-approval",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: row.proposedAt.toISOString(),
+    actions: [{ kind: "open-in-context", label: "Review proposal", href: "/admin/research" }],
+    deepLink: "/admin/research",
+    audience: { operator: true },
+  };
+}
+
+export async function loadResearchItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.researchProposal.findMany({
+    where: { status: "pending" },
+    orderBy: { proposedAt: "desc" },
+    take: 50,
+    select: { proposalId: true, topic: true, query: true, proposedAt: true },
+  });
+  return rows.map(researchToAttentionItem);
+}

--- a/apps/web/lib/attention/sources/escalation.ts
+++ b/apps/web/lib/attention/sources/escalation.ts
@@ -1,0 +1,49 @@
+// Escalation source — build-stall escalations RE-HOMED off /ops into the inbox.
+// Reuses the #2315 escalation-attention reader verbatim (single-source-of-truth);
+// this adapter only PROJECTS OpenEscalation → AttentionItem. Spec §4.1, §6.4.
+
+import {
+  getOpenEscalations,
+  escalationBlockerSummary,
+  type OpenEscalation,
+} from "@/lib/quality/escalation-attention";
+import type { AttentionItem, AttentionRiskClass } from "../types";
+
+function riskFromSeverity(severity: string): AttentionRiskClass {
+  const s = severity.toLowerCase();
+  if (s === "high" || s === "critical") return "high-risk";
+  if (s === "low") return "read";
+  return "bounded-write";
+}
+
+/** Pure projection of one held escalation into an attention item. */
+export function escalationToAttentionItem(e: OpenEscalation): AttentionItem {
+  const blocker = escalationBlockerSummary(e.description);
+  return {
+    id: `escalation:${e.reportId}`,
+    source: "escalation",
+    title: e.title,
+    context: blocker ?? "Build Studio could not self-repair this build.",
+    decisionClass: { scorability: "unscorable" }, // resume/defer ops call — honest facts, no ledger (#2315)
+    riskClass: riskFromSeverity(e.severity),
+    triage: {
+      timeToAct: "none", // build-stall escalations carry no hard deadline; age + risk order them
+      residueReason: "self-fix-exhausted",
+      blastRadius: e.backlogItemId ?? undefined,
+      decideEffort: "judgment",
+      irreversible: false,
+    },
+    createdAtIso: e.createdAt,
+    actions: e.buildId
+      ? [{ kind: "open-in-context", label: "View build", href: `/build?buildId=${encodeURIComponent(e.buildId)}` }]
+      : [{ kind: "open-in-context", label: "Evidence trail", href: "/admin/issue-reports" }],
+    deepLink: e.buildId ? `/build?buildId=${encodeURIComponent(e.buildId)}` : "/admin/issue-reports",
+    audience: { operator: true },
+  };
+}
+
+/** Load + project all held escalations. Reads through the existing #2315 query. */
+export async function loadEscalationItems(): Promise<AttentionItem[]> {
+  const rows = await getOpenEscalations();
+  return rows.map(escalationToAttentionItem);
+}

--- a/apps/web/lib/attention/sources/paused-ai.ts
+++ b/apps/web/lib/attention/sources/paused-ai.ts
@@ -1,0 +1,90 @@
+// Paused-AI source — coworker TaskRuns paused at input-required / auth-required.
+// auth-required means a missing credential/authority, NOT human judgment (paused-
+// work plan Locked Decision 5); input-required is a real judgment pause. The
+// owning surface deep-links to operations-map until /platform/ai/paused-work
+// lands. Spec §4.1; subsumes the unbuilt paused-work inbox.
+
+import type { prisma } from "@dpf/db";
+import type { AttentionItem, AttentionRiskClass } from "../types";
+
+type Db = typeof prisma;
+
+export type TaskRunRow = {
+  taskRunId: string;
+  title: string;
+  status: string;
+  userId: string;
+  a2aMetadata: unknown;
+  progressPayload: unknown;
+  startedAt: Date;
+};
+
+const RISK_VALUES: AttentionRiskClass[] = ["read", "bounded-write", "high-risk", "unknown"];
+
+function readRisk(meta: unknown): AttentionRiskClass {
+  if (meta && typeof meta === "object" && "riskClass" in meta) {
+    const v = (meta as Record<string, unknown>).riskClass;
+    if (typeof v === "string" && (RISK_VALUES as string[]).includes(v)) return v as AttentionRiskClass;
+  }
+  return "unknown";
+}
+
+function readSummary(payload: unknown): string | null {
+  if (payload && typeof payload === "object") {
+    const p = payload as Record<string, unknown>;
+    const s = p.decisionBrief ?? p.summary;
+    if (typeof s === "string" && s.trim()) return s.trim();
+  }
+  return null;
+}
+
+/** Pure projection of one paused coworker run into an attention item. */
+export function pausedAiToAttentionItem(row: TaskRunRow): AttentionItem {
+  const authRequired = row.status === "auth-required";
+  const risk = readRisk(row.a2aMetadata);
+  return {
+    id: `paused-ai:${row.taskRunId}`,
+    source: "paused-ai",
+    title: row.title,
+    context:
+      readSummary(row.progressPayload) ??
+      (authRequired
+        ? "A coworker is blocked on a missing credential or authority."
+        : "A coworker paused and needs your input to continue."),
+    decisionClass: { scorability: "unscorable" },
+    riskClass: risk,
+    triage: {
+      timeToAct: "none",
+      residueReason: authRequired ? "needs-credential" : "input-required",
+      blastRadius: "a coworker task",
+      decideEffort: authRequired ? "review" : "judgment",
+      // A high-risk run pauses BEFORE its side effect — resuming it is the
+      // irreversible-high-risk call the override tier is meant to surface.
+      irreversible: risk === "high-risk" && !authRequired,
+    },
+    createdAtIso: row.startedAt.toISOString(),
+    actions: [
+      { kind: "open-in-context", label: "Open run", href: "/platform/ai/operations-map" },
+    ],
+    deepLink: "/platform/ai/operations-map",
+    audience: { operator: true, assigneePrincipalId: row.userId },
+  };
+}
+
+export async function loadPausedAiItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.taskRun.findMany({
+    where: { status: { in: ["input-required", "auth-required"] }, archivedAt: null },
+    orderBy: { startedAt: "desc" },
+    take: 50,
+    select: {
+      taskRunId: true,
+      title: true,
+      status: true,
+      userId: true,
+      a2aMetadata: true,
+      progressPayload: true,
+      startedAt: true,
+    },
+  });
+  return rows.map(pausedAiToAttentionItem);
+}

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { escalationToAttentionItem } from "./escalation";
+import { aiDecisionToAttentionItem, type DecisionInteractionRow } from "./ai-decision";
+import { pausedAiToAttentionItem, type TaskRunRow } from "./paused-ai";
+import { agentProposalToAttentionItem, type AgentActionProposalRow } from "./agent-proposal";
+import type { OpenEscalation } from "@/lib/quality/escalation-attention";
+
+describe("escalationToAttentionItem", () => {
+  const base: OpenEscalation = {
+    reportId: "PIR-1",
+    title: "Build stalled on auth",
+    description: "Unresolved blocking issues\n- missing authz on the route",
+    severity: "high",
+    selfFixClass: "needs-human",
+    status: "awaiting_escalation_ack",
+    createdAt: "2026-06-23T10:00:00.000Z",
+    buildId: "FB-9",
+    backlogItemId: "BI-42",
+    backlogItemStatus: "in-progress",
+  };
+
+  it("projects an escalation as unscorable self-fix-exhausted residue with the blocker as context", () => {
+    const item = escalationToAttentionItem(base);
+    expect(item.id).toBe("escalation:PIR-1");
+    expect(item.source).toBe("escalation");
+    expect(item.decisionClass.scorability).toBe("unscorable");
+    expect(item.triage.residueReason).toBe("self-fix-exhausted");
+    expect(item.riskClass).toBe("high-risk"); // severity high
+    expect(item.triage.blastRadius).toBe("BI-42");
+    expect(item.context).toContain("missing authz");
+    expect(item.deepLink).toBe("/build?buildId=FB-9");
+  });
+
+  it("falls back to the evidence trail when no build is linked", () => {
+    const item = escalationToAttentionItem({ ...base, buildId: null });
+    expect(item.deepLink).toBe("/admin/issue-reports");
+  });
+});
+
+describe("aiDecisionToAttentionItem", () => {
+  const base: DecisionInteractionRow = {
+    interactionId: "DI-1",
+    question: "Should we adopt approach A or B for the migration?",
+    outcomeType: "escalate",
+    riskTier: "high",
+    principleConflict: false,
+    rationale: "Confidence below threshold for a high-risk call.",
+    buildId: "FB-3",
+    taskRunId: null,
+    createdAt: new Date("2026-06-23T08:00:00.000Z"),
+  };
+
+  it("maps an escalated high-risk decision", () => {
+    const item = aiDecisionToAttentionItem(base);
+    expect(item.id).toBe("ai-decision:DI-1");
+    expect(item.decisionClass.scorability).toBe("unscorable"); // residue — never a verdict
+    expect(item.riskClass).toBe("high-risk");
+    expect(item.triage.residueReason).toBe("high-risk-gate");
+    expect(item.triage.blastRadius).toBe("build FB-3");
+    expect(item.deepLink).toBe("/platform/ai/founder-review");
+  });
+
+  it("maps a principle conflict ahead of the outcome type", () => {
+    expect(aiDecisionToAttentionItem({ ...base, principleConflict: true }).triage.residueReason).toBe(
+      "principle-conflict",
+    );
+  });
+
+  it("maps a defer to a coverage gap and medium risk to bounded-write", () => {
+    const item = aiDecisionToAttentionItem({ ...base, outcomeType: "defer", riskTier: "medium" });
+    expect(item.triage.residueReason).toBe("coverage-gap");
+    expect(item.riskClass).toBe("bounded-write");
+  });
+});
+
+describe("pausedAiToAttentionItem", () => {
+  const base: TaskRunRow = {
+    taskRunId: "TR-1",
+    title: "Send the campaign",
+    status: "input-required",
+    userId: "principal-7",
+    a2aMetadata: { riskClass: "high-risk" },
+    progressPayload: { summary: "Ready to send to 4,000 recipients." },
+    startedAt: new Date("2026-06-23T09:30:00.000Z"),
+  };
+
+  it("treats a high-risk input-required pause as irreversible (override-eligible)", () => {
+    const item = pausedAiToAttentionItem(base);
+    expect(item.riskClass).toBe("high-risk");
+    expect(item.triage.residueReason).toBe("input-required");
+    expect(item.triage.irreversible).toBe(true);
+    expect(item.context).toContain("4,000 recipients");
+    expect(item.audience.assigneePrincipalId).toBe("principal-7");
+  });
+
+  it("treats auth-required as a missing-credential review, not judgment or irreversible", () => {
+    const item = pausedAiToAttentionItem({ ...base, status: "auth-required" });
+    expect(item.triage.residueReason).toBe("needs-credential");
+    expect(item.triage.decideEffort).toBe("review");
+    expect(item.triage.irreversible).toBe(false);
+  });
+
+  it("defaults risk to unknown when metadata carries none", () => {
+    const item = pausedAiToAttentionItem({ ...base, a2aMetadata: null, progressPayload: null });
+    expect(item.riskClass).toBe("unknown");
+    expect(item.context).toContain("needs your input");
+  });
+});
+
+describe("agentProposalToAttentionItem", () => {
+  it("projects a proposed action as policy-approval residue with a humanized title", () => {
+    const row: AgentActionProposalRow = {
+      proposalId: "AP-1",
+      actionType: "create_invoice",
+      proposedAt: new Date("2026-06-23T07:00:00.000Z"),
+    };
+    const item = agentProposalToAttentionItem(row);
+    expect(item.id).toBe("agent-proposal:AP-1");
+    expect(item.title).toBe("Approve: Create invoice");
+    expect(item.triage.residueReason).toBe("policy-approval");
+    expect(item.decisionClass.scorability).toBe("unscorable");
+  });
+});

--- a/apps/web/lib/attention/triage.test.ts
+++ b/apps/web/lib/attention/triage.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  isOverrideTier,
+  overrideReason,
+  compareAttention,
+  orderAttention,
+  orderReason,
+  residueReasonLabel,
+  attentionAgeLabel,
+  timeToActFromDeadline,
+} from "./triage";
+import type { AttentionItem, AttentionTriage } from "./types";
+
+// ─── Fixture helper ──────────────────────────────────────────────────────────
+
+let seq = 0;
+function item(overrides: Omit<Partial<AttentionItem>, "triage"> & { triage?: Partial<AttentionTriage> } = {}): AttentionItem {
+  const { triage: triageOverrides, ...rest } = overrides;
+  seq += 1;
+  return {
+    id: rest.id ?? `escalation:PIR-${seq}`,
+    source: rest.source ?? "escalation",
+    title: rest.title ?? "An item",
+    context: rest.context ?? "context",
+    decisionClass: rest.decisionClass ?? { scorability: "unscorable" },
+    riskClass: rest.riskClass ?? "bounded-write",
+    createdAtIso: rest.createdAtIso ?? "2026-06-23T12:00:00.000Z",
+    actions: rest.actions ?? [],
+    deepLink: rest.deepLink ?? "/build",
+    audience: rest.audience ?? { operator: true },
+    triage: {
+      timeToAct: "none",
+      residueReason: "self-fix-exhausted",
+      decideEffort: "judgment",
+      irreversible: false,
+      ...triageOverrides,
+    },
+  };
+}
+
+// ─── Override tier ───────────────────────────────────────────────────────────
+
+describe("isOverrideTier", () => {
+  it("floats an overdue deadline to the override tier", () => {
+    expect(isOverrideTier(item({ triage: { timeToAct: "overdue" } }))).toBe(true);
+  });
+  it("floats a due-today deadline to the override tier", () => {
+    expect(isOverrideTier(item({ triage: { timeToAct: "due-today" } }))).toBe(true);
+  });
+  it("does NOT float a due-soon deadline", () => {
+    expect(isOverrideTier(item({ triage: { timeToAct: "due-soon" } }))).toBe(false);
+  });
+  it("floats an irreversible high-risk item even with no deadline", () => {
+    expect(
+      isOverrideTier(item({ riskClass: "high-risk", triage: { irreversible: true } })),
+    ).toBe(true);
+  });
+  it("does NOT float a reversible high-risk item", () => {
+    expect(
+      isOverrideTier(item({ riskClass: "high-risk", triage: { irreversible: false } })),
+    ).toBe(false);
+  });
+  it("does NOT float an irreversible but low-risk item", () => {
+    expect(
+      isOverrideTier(item({ riskClass: "read", triage: { irreversible: true } })),
+    ).toBe(false);
+  });
+});
+
+describe("overrideReason", () => {
+  it("explains an overdue override", () => {
+    expect(overrideReason(item({ triage: { timeToAct: "overdue" } }))).toBe("deadline passed");
+  });
+  it("explains a due-today override", () => {
+    expect(overrideReason(item({ triage: { timeToAct: "due-today" } }))).toBe("deadline today");
+  });
+  it("explains an irreversible-high-risk override", () => {
+    expect(
+      overrideReason(item({ riskClass: "high-risk", triage: { irreversible: true } })),
+    ).toBe("irreversible, high-risk");
+  });
+  it("returns null for a non-override item", () => {
+    expect(overrideReason(item())).toBeNull();
+  });
+});
+
+// ─── Tiered ordering ─────────────────────────────────────────────────────────
+
+describe("orderAttention", () => {
+  it("puts override-tier items before everything else", () => {
+    const normal = item({ id: "a:normal", riskClass: "high-risk", triage: { blastRadius: "delivery" } });
+    const override = item({ id: "a:override", riskClass: "read", triage: { timeToAct: "overdue" } });
+    const ordered = orderAttention([normal, override]);
+    expect(ordered.map((i) => i.id)).toEqual(["a:override", "a:normal"]);
+  });
+
+  it("orders by risk within the same time tier", () => {
+    const read = item({ id: "r:read", riskClass: "read" });
+    const high = item({ id: "r:high", riskClass: "high-risk" });
+    const bounded = item({ id: "r:bounded", riskClass: "bounded-write" });
+    const ordered = orderAttention([read, high, bounded]);
+    expect(ordered.map((i) => i.id)).toEqual(["r:high", "r:bounded", "r:read"]);
+  });
+
+  it("orders something-blocked before nothing-blocked within the same risk", () => {
+    const blocked = item({ id: "b:blocked", triage: { blastRadius: "BI-123" } });
+    const free = item({ id: "b:free" });
+    expect(orderAttention([free, blocked]).map((i) => i.id)).toEqual(["b:blocked", "b:free"]);
+  });
+
+  it("breaks ties by age (oldest first, FIFO)", () => {
+    const newer = item({ id: "age:new", createdAtIso: "2026-06-23T15:00:00.000Z" });
+    const older = item({ id: "age:old", createdAtIso: "2026-06-23T09:00:00.000Z" });
+    expect(orderAttention([newer, older]).map((i) => i.id)).toEqual(["age:old", "age:new"]);
+  });
+
+  it("is deterministic and does not mutate the input", () => {
+    const input = [item({ id: "z" }), item({ id: "a" })];
+    const snapshot = input.map((i) => i.id);
+    const ordered = orderAttention(input);
+    expect(input.map((i) => i.id)).toEqual(snapshot); // input untouched
+    // Same risk/time/blast/age → final id tiebreak is stable.
+    expect(ordered.map((i) => i.id)).toEqual(["a", "z"]);
+  });
+
+  it("a deadline override outranks an irreversible-high-risk override (time tier within override)", () => {
+    const irreversible = item({ id: "o:irrev", riskClass: "high-risk", triage: { irreversible: true } });
+    const overdue = item({ id: "o:overdue", riskClass: "read", triage: { timeToAct: "overdue" } });
+    expect(orderAttention([irreversible, overdue]).map((i) => i.id)).toEqual(["o:overdue", "o:irrev"]);
+  });
+});
+
+// ─── Explainability ──────────────────────────────────────────────────────────
+
+describe("orderReason", () => {
+  it("leads with the pin reason for an override", () => {
+    expect(orderReason(item({ triage: { timeToAct: "overdue" } }))).toContain("pinned to top: deadline passed");
+  });
+  it("names high risk and what is blocked", () => {
+    const reason = orderReason(item({ riskClass: "high-risk", triage: { blastRadius: "delivery" } }));
+    expect(reason).toContain("high risk");
+    expect(reason).toContain("blocks delivery");
+  });
+  it("falls back to the residue reason when nothing else is salient", () => {
+    expect(orderReason(item({ triage: { residueReason: "coverage-gap" } }))).toBe(
+      residueReasonLabel("coverage-gap"),
+    );
+  });
+});
+
+// ─── Deadline mapping ────────────────────────────────────────────────────────
+
+describe("timeToActFromDeadline", () => {
+  const now = new Date("2026-06-23T12:00:00.000Z").getTime();
+  it("returns none when there is no deadline", () => {
+    expect(timeToActFromDeadline(null, now)).toBe("none");
+    expect(timeToActFromDeadline(undefined, now)).toBe("none");
+  });
+  it("returns overdue for a past deadline", () => {
+    expect(timeToActFromDeadline("2026-06-23T06:00:00.000Z", now)).toBe("overdue");
+  });
+  it("returns due-today within the 24h window", () => {
+    expect(timeToActFromDeadline("2026-06-24T06:00:00.000Z", now)).toBe("due-today");
+  });
+  it("returns due-soon within the week", () => {
+    expect(timeToActFromDeadline("2026-06-27T12:00:00.000Z", now)).toBe("due-soon");
+  });
+  it("returns none for a far-off deadline", () => {
+    expect(timeToActFromDeadline("2026-08-01T12:00:00.000Z", now)).toBe("none");
+  });
+});
+
+describe("attentionAgeLabel", () => {
+  const now = new Date("2026-06-23T12:00:00.000Z").getTime();
+  it("reads just now under a minute", () => {
+    expect(attentionAgeLabel("2026-06-23T11:59:30.000Z", now)).toBe("just now");
+  });
+  it("reads minutes, hours, and days", () => {
+    expect(attentionAgeLabel("2026-06-23T11:30:00.000Z", now)).toBe("30m ago");
+    expect(attentionAgeLabel("2026-06-23T09:00:00.000Z", now)).toBe("3h ago");
+    expect(attentionAgeLabel("2026-06-21T12:00:00.000Z", now)).toBe("2d ago");
+  });
+});

--- a/apps/web/lib/attention/triage.test.ts
+++ b/apps/web/lib/attention/triage.test.ts
@@ -8,6 +8,7 @@ import {
   residueReasonLabel,
   attentionAgeLabel,
   timeToActFromDeadline,
+  summarizeAttention,
 } from "./triage";
 import type { AttentionItem, AttentionTriage } from "./types";
 
@@ -179,5 +180,25 @@ describe("attentionAgeLabel", () => {
     expect(attentionAgeLabel("2026-06-23T11:30:00.000Z", now)).toBe("30m ago");
     expect(attentionAgeLabel("2026-06-23T09:00:00.000Z", now)).toBe("3h ago");
     expect(attentionAgeLabel("2026-06-21T12:00:00.000Z", now)).toBe("2d ago");
+  });
+});
+
+describe("summarizeAttention", () => {
+  it("counts total, pinned (override tier), high-risk, and groups by source", () => {
+    const items = [
+      item({ id: "e1", source: "escalation", riskClass: "high-risk" }),
+      item({ id: "e2", source: "escalation" }),
+      item({ id: "b1", source: "approval-bill", triage: { timeToAct: "overdue" } }),
+      item({ id: "r1", source: "research-proposal", riskClass: "read" }),
+    ];
+    const s = summarizeAttention(items);
+    expect(s.total).toBe(4);
+    expect(s.pinned).toBe(1); // the overdue bill
+    expect(s.highRisk).toBe(1);
+    expect(s.bySource[0]).toEqual({ source: "escalation", count: 2 }); // highest count first
+  });
+
+  it("is empty-safe", () => {
+    expect(summarizeAttention([])).toEqual({ total: 0, pinned: 0, highRisk: 0, bySource: [] });
   });
 });

--- a/apps/web/lib/attention/triage.test.ts
+++ b/apps/web/lib/attention/triage.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   isOverrideTier,
   overrideReason,
-  compareAttention,
   orderAttention,
   orderReason,
   residueReasonLabel,

--- a/apps/web/lib/attention/triage.ts
+++ b/apps/web/lib/attention/triage.ts
@@ -1,0 +1,177 @@
+// Triage & prioritization — the pure ordering for the Attention Surface.
+// Spec: docs/superpowers/specs/2026-06-23-human-attention-surface-design.md §4.4.
+//
+// Integrity rule (the scorability caveat applied to RANKING): there is NO single
+// composite "priority" number. Incommensurable items are made comparable by the
+// SAME objective factors and ordered by a TRANSPARENT TIERED RULE, so every
+// position is explainable in one line. A fabricated cross-axis 0.73 would be the
+// #2315 0.000-theater in a precise-looking costume — forbidden.
+//
+// Tiered order:
+//   override tier (hard-deadline-imminent OR irreversible-high-risk, shown with reason)
+//     → time-to-act → risk → blast-radius (blocked?) → age (FIFO)
+//
+// Mirrors the paused-work plan's proven shape ("high-risk → bounded-write → read,
+// FIFO within tier") and the command-center SEVERITY_RANK / ATTENTION_RANK idiom.
+
+import type {
+  AttentionItem,
+  AttentionRiskClass,
+  DecideEffort,
+  ResidueReason,
+  TimeToAct,
+} from "./types";
+
+// ─── Ranks (lower sorts first) ───────────────────────────────────────────────
+
+const TIME_RANK: Record<TimeToAct, number> = {
+  overdue: 0,
+  "due-today": 1,
+  "due-soon": 2,
+  none: 3,
+};
+
+const RISK_RANK: Record<AttentionRiskClass, number> = {
+  "high-risk": 0,
+  "bounded-write": 1,
+  read: 2,
+  unknown: 3,
+};
+
+/** The narrow override set: a hard deadline is imminent, OR the action is
+ *  irreversible AND high-risk. These float above the tiered order — and the UI
+ *  must show WHY (never a silent jump). Pure. */
+export function isOverrideTier(item: AttentionItem): boolean {
+  const deadlineImminent = item.triage.timeToAct === "overdue" || item.triage.timeToAct === "due-today";
+  const irreversibleHighRisk = item.riskClass === "high-risk" && item.triage.irreversible;
+  return deadlineImminent || irreversibleHighRisk;
+}
+
+/** The one-line reason an item is in the override tier, for the "pinned to top: …"
+ *  affordance. Null when the item is not an override. Pure. */
+export function overrideReason(item: AttentionItem): string | null {
+  if (!isOverrideTier(item)) return null;
+  if (item.triage.timeToAct === "overdue") return "deadline passed";
+  if (item.triage.timeToAct === "due-today") return "deadline today";
+  return "irreversible, high-risk";
+}
+
+// ─── Comparator ──────────────────────────────────────────────────────────────
+
+/** Total-order comparator over attention items. Pure and deterministic — the age
+ *  tie-break uses the stored ISO string, never the wall clock. Sort a COPY. */
+export function compareAttention(a: AttentionItem, b: AttentionItem): number {
+  // Override tier first.
+  const ao = isOverrideTier(a) ? 0 : 1;
+  const bo = isOverrideTier(b) ? 0 : 1;
+  if (ao !== bo) return ao - bo;
+
+  // Time-to-act tier.
+  const at = TIME_RANK[a.triage.timeToAct];
+  const bt = TIME_RANK[b.triage.timeToAct];
+  if (at !== bt) return at - bt;
+
+  // Risk within tier.
+  const ar = RISK_RANK[a.riskClass];
+  const br = RISK_RANK[b.riskClass];
+  if (ar !== br) return ar - br;
+
+  // Blast radius: something blocked sorts before nothing blocked.
+  const ab = a.triage.blastRadius ? 0 : 1;
+  const bb = b.triage.blastRadius ? 0 : 1;
+  if (ab !== bb) return ab - bb;
+
+  // Age: oldest first (FIFO). Lexicographic ISO compare == chronological.
+  if (a.createdAtIso !== b.createdAtIso) return a.createdAtIso < b.createdAtIso ? -1 : 1;
+
+  // Stable final tiebreak so the order is fully deterministic across sources.
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/** Order a list of attention items by the tiered rule. Returns a new array. */
+export function orderAttention(items: AttentionItem[]): AttentionItem[] {
+  return [...items].sort(compareAttention);
+}
+
+// ─── Explainability ──────────────────────────────────────────────────────────
+
+const RESIDUE_LABEL: Record<ResidueReason, string> = {
+  "coverage-gap": "the kernel had no applicable principle",
+  "principle-conflict": "principles conflict on this call",
+  "high-risk-gate": "policy requires a human for this risk",
+  "self-fix-exhausted": "Build Studio could not self-repair",
+  "input-required": "a coworker needs your input to continue",
+  "needs-credential": "a credential or authority is missing",
+  "policy-approval": "an agent action is awaiting your approval",
+};
+
+/** Human label for the residue reason — the honest "why it's here" line. Pure. */
+export function residueReasonLabel(reason: ResidueReason): string {
+  return RESIDUE_LABEL[reason];
+}
+
+const RISK_LABEL: Record<AttentionRiskClass, string> = {
+  "high-risk": "High risk",
+  "bounded-write": "Bounded write",
+  read: "Read-only",
+  unknown: "Unclassified risk",
+};
+
+export function riskLabel(risk: AttentionRiskClass): string {
+  return RISK_LABEL[risk];
+}
+
+const EFFORT_LABEL: Record<DecideEffort, string> = {
+  "one-tap": "one tap",
+  review: "quick review",
+  judgment: "your judgment",
+};
+
+export function decideEffortLabel(effort: DecideEffort): string {
+  return EFFORT_LABEL[effort];
+}
+
+/** A single explainable sentence for WHY an item sits where it does — the
+ *  legibility the founder needs to trust (or override) the order. Pure. */
+export function orderReason(item: AttentionItem): string {
+  const parts: string[] = [];
+  const override = overrideReason(item);
+  if (override) parts.push(`pinned to top: ${override}`);
+  if (item.triage.timeToAct !== "none" && !override) {
+    parts.push(item.triage.timeToAct.replace("-", " "));
+  }
+  if (item.riskClass === "high-risk") parts.push("high risk");
+  if (item.triage.blastRadius) parts.push(`blocks ${item.triage.blastRadius}`);
+  if (parts.length === 0) parts.push(residueReasonLabel(item.triage.residueReason));
+  return parts.join(" · ");
+}
+
+/** Compact relative age, now injected for purity (mirrors escalation-attention.ts). */
+export function attentionAgeLabel(iso: string, nowMs: number): string {
+  const ms = nowMs - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 60_000) return "just now";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+// ─── Deadline → time-to-act tier ─────────────────────────────────────────────
+
+/** Map an optional hard deadline to the objective time-to-act tier. `dueSoonH`
+ *  (default 24h) is the override window for "due-today". Pure (now injected). */
+export function timeToActFromDeadline(
+  deadlineIso: string | null | undefined,
+  nowMs: number,
+  dueSoonH = 24,
+): TimeToAct {
+  if (!deadlineIso) return "none";
+  const due = new Date(deadlineIso).getTime();
+  if (!Number.isFinite(due)) return "none";
+  const hoursLeft = (due - nowMs) / 3_600_000;
+  if (hoursLeft < 0) return "overdue";
+  if (hoursLeft <= dueSoonH) return "due-today";
+  if (hoursLeft <= dueSoonH * 7) return "due-soon";
+  return "none";
+}

--- a/apps/web/lib/attention/triage.ts
+++ b/apps/web/lib/attention/triage.ts
@@ -17,6 +17,7 @@
 import type {
   AttentionItem,
   AttentionRiskClass,
+  AttentionSource,
   DecideEffort,
   ResidueReason,
   TimeToAct,
@@ -174,4 +175,32 @@ export function timeToActFromDeadline(
   if (hoursLeft <= dueSoonH) return "due-today";
   if (hoursLeft <= dueSoonH * 7) return "due-soon";
   return "none";
+}
+
+// ─── At-a-glance summary (the lightweight reviewer-of-evidence overview) ──────
+
+export type AttentionSummary = {
+  total: number;
+  /** Items in the override tier — the "act first" count. */
+  pinned: number;
+  highRisk: number;
+  /** Per-source counts, highest first, for the grouped overview chips. */
+  bySource: { source: AttentionSource; count: number }[];
+};
+
+/** Summarize the queue for the overview header. Counts only — no composite score.
+ *  Pure (override membership is computed from the item's own factors). */
+export function summarizeAttention(items: AttentionItem[]): AttentionSummary {
+  const counts = new Map<AttentionSource, number>();
+  let pinned = 0;
+  let highRisk = 0;
+  for (const item of items) {
+    counts.set(item.source, (counts.get(item.source) ?? 0) + 1);
+    if (isOverrideTier(item)) pinned += 1;
+    if (item.riskClass === "high-risk") highRisk += 1;
+  }
+  const bySource = [...counts.entries()]
+    .map(([source, count]) => ({ source, count }))
+    .sort((a, b) => b.count - a.count || (a.source < b.source ? -1 : 1));
+  return { total: items.length, pinned, highRisk, bySource };
 }

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -13,7 +13,12 @@ export type AttentionSource =
   | "escalation" // PlatformIssueReport awaiting_escalation_ack (build-stall) — re-homed off /ops
   | "ai-decision" // DecisionInteraction outcomeType escalate/defer, humanOutcome null
   | "paused-ai" // TaskRun input-required / auth-required
-  | "agent-proposal"; // AgentActionProposal status=proposed
+  | "agent-proposal" // AgentActionProposal status=proposed
+  | "approval-outbound" // OutboundDraft pending-review (marketing)
+  | "approval-bill" // Bill awaiting_approval (AP — carries a dueDate)
+  | "approval-expense" // ExpenseClaim submitted
+  | "compliance-submission" // RegulatorySubmission draft (carries a dueDate)
+  | "research-proposal"; // ResearchProposal pending
 
 /** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
 export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -1,0 +1,98 @@
+// The Attention Surface — projector output types (EP-ATTENTION-SURFACE, BI-D39484E7 + BI-61B9EB88).
+// Spec: docs/superpowers/specs/2026-06-23-human-attention-surface-design.md §4.1, §4.4.
+//
+// `AttentionItem` is a READ-MODEL projection, NOT a persisted entity. Each queue's
+// truth stays in its owning model (single-source-of-truth); the inbox projects over
+// them, exactly as command-center.ts projects WorkspaceAttentionItem[]. There is
+// deliberately NO single composite "priority" number on this type — incommensurable
+// items are made comparable by the SAME objective factors (triage) + a tiered order,
+// never a fabricated score (the #2315 0.000-theater rule, applied to ranking).
+
+/** Which scattered queue an item was projected from. */
+export type AttentionSource =
+  | "escalation" // PlatformIssueReport awaiting_escalation_ack (build-stall) — re-homed off /ops
+  | "ai-decision" // DecisionInteraction outcomeType escalate/defer, humanOutcome null
+  | "paused-ai" // TaskRun input-required / auth-required
+  | "agent-proposal"; // AgentActionProposal status=proposed
+
+/** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
+export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";
+
+/** The primary, objective triage key. Deadline-bearing sources (bills/expenses/
+ *  compliance, BI-AS-4) populate the imminent tiers; the keystone sources have no
+ *  hard deadline, so they resolve to "none" and are ordered by risk→blast→age. */
+export type TimeToAct = "overdue" | "due-today" | "due-soon" | "none";
+
+/** WHY the governed scopes couldn't resolve it — the honest "why it's here" line.
+ *  An inclusive, source-honest superset of the §4.4 illustrative list. */
+export type ResidueReason =
+  | "coverage-gap" // kernel had no applicable material (DecisionInteraction defer)
+  | "principle-conflict" // kernel torn (DecisionInteraction principleConflict)
+  | "high-risk-gate" // policy requires a human for this risk (DecisionInteraction escalate)
+  | "self-fix-exhausted" // Build Studio could not self-repair (escalation)
+  | "input-required" // a coworker needs human input to continue (TaskRun)
+  | "needs-credential" // missing credential / authority, NOT judgment (TaskRun auth-required)
+  | "policy-approval"; // an agent action awaits approval (AgentActionProposal)
+
+/** How much the human must do. The human_cognitive_load cost axis. */
+export type DecideEffort = "one-tap" | "review" | "judgment";
+
+/** A bounded, source-specific action. Rendered as a control on the card; the
+ *  actual mutation is owned by the source's surface (deep-link) until the decision
+ *  modules land (BI-AS-5/6). `open` and `dismiss`/`snooze` are safe in the keystone. */
+export type AttentionActionKind =
+  | "open-in-context"
+  | "dismiss"
+  | "snooze"
+  | "approve"
+  | "reject"
+  | "request-changes"
+  | "answer";
+
+export type AttentionAction = {
+  kind: AttentionActionKind;
+  label: string;
+  /** Present for navigations; absent for in-place mutations wired in later slices. */
+  href?: string;
+};
+
+/** The SAME comparable factors on every item, surfaced AS context. No composite score. */
+export type AttentionTriage = {
+  timeToAct: TimeToAct;
+  /** ISO deadline when a hard one exists (bill due, filing deadline, SLA breach). */
+  deadlineIso?: string;
+  residueReason: ResidueReason;
+  /** What/who is blocked until decided — the "if you don't act…" line. */
+  blastRadius?: string;
+  decideEffort: DecideEffort;
+  /** True for actions that cannot be undone — feeds the irreversible-high-risk override. */
+  irreversible: boolean;
+};
+
+export type AttentionAudience = {
+  /** Visible to operators (founder/admin) — the full residue. */
+  operator: boolean;
+  /** When set, also visible to this principal as their own/role item (worker scope). */
+  assigneePrincipalId?: string;
+};
+
+export type AttentionItem = {
+  /** Stable per source row, e.g. "escalation:PIR-…", "ai-decision:DI-…". */
+  id: string;
+  source: AttentionSource;
+  title: string;
+  /** The honest one-liner: top blocker / question / what + why-paused. */
+  context: string;
+  /** Scorability governs rendering: kernel-scorable → ledger; unscorable → honest
+   *  facts (never a 0.000 verdict). All keystone sources are residue the kernel
+   *  already could not decide, so they are "unscorable" by construction. */
+  decisionClass: { scorability: "kernel-scorable" | "unscorable" | "org-business" };
+  riskClass: AttentionRiskClass;
+  triage: AttentionTriage;
+  /** ISO creation time — drives the age tie-break and the relative-age label. */
+  createdAtIso: string;
+  actions: AttentionAction[];
+  /** To the owning surface for heavy context; never reimplemented in the inbox. */
+  deepLink: string;
+  audience: AttentionAudience;
+};

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 508,
+  "routeCount": 509,
   "routes": [
     {
       "routePath": "/",

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -5969,6 +5969,16 @@
       "file": "apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx"
     },
     {
+      "routePath": "/workspace/inbox",
+      "kind": "page",
+      "segments": [
+        "workspace",
+        "inbox"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/workspace/inbox/page.tsx"
+    },
+    {
       "routePath": "/workspace/my-queue",
       "kind": "page",
       "segments": [

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -94,7 +94,21 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
       sectionKey: "workspace",
       description: "See what needs attention next.",
     },
-    sectionSiblings: ["/workspace", "/workspace/documents"],
+    sectionSiblings: ["/workspace", "/workspace/inbox", "/workspace/documents"],
+  },
+  {
+    // EP-ATTENTION-SURFACE keystone (BI-D39484E7): the "Needs you" attention inbox.
+    // A workspace-section SIBLING, not a new rail destination (kernel-ratified
+    // elevate-workspace 0.69 vs new-rail 0.06) — so no cross-rail-section teleport
+    // (EP-NAV-COHERENCE hard rule). Audience-aware: operator-primary, worker later.
+    key: "workspace-inbox",
+    label: "Needs you",
+    path: "/workspace/inbox",
+    parentPath: "/workspace",
+    domain: "workspace",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: null,
   },
   {
     key: "documents",

--- a/docs/superpowers/plans/2026-06-23-attention-surface-keystone-implementation.md
+++ b/docs/superpowers/plans/2026-06-23-attention-surface-keystone-implementation.md
@@ -6,7 +6,7 @@
 | Date | 2026-06-23 |
 | Spec | [2026-06-23 human attention surface design](../specs/2026-06-23-human-attention-surface-design.md) (§4, §4.4, §6) |
 | Epic | `EP-ATTENTION-SURFACE` |
-| Delivers | BI-D39484E7 (keystone), BI-61B9EB88 (triage model) |
+| Delivers | BI-D39484E7 (keystone), BI-61B9EB88 (triage model), BI-8EA88797 (business-approval adapters — partial: adapters + deadline triage; worker-principal scoping deferred) |
 
 ## What shipped
 
@@ -16,7 +16,8 @@ The decisions plane (escalations / AI-decision residue / paused-AI / agent-propo
 - `types.ts` — `AttentionItem` projector contract incl. `triage{}` (time-to-act, residue-reason, blast-radius, decide-effort, irreversible). No persisted entity, no priority number.
 - `triage.ts` — the tiered order: **override tier** (hard-deadline-imminent OR irreversible-high-risk, shown with reason) → time-to-act → risk → blast → age (FIFO). Pure; reuses the `command-center` rank idiom. Plus explainability helpers (`orderReason`, residue/risk/effort labels, `attentionAgeLabel`, `timeToActFromDeadline`).
 - `sources/{escalation,ai-decision,paused-ai,agent-proposal}.ts` — pure mappers + loaders over the verified source models. **All four are `unscorable` residue** (the kernel already could not decide them) → honest facts, never a 0.000 ledger.
-- `aggregate.ts` — `Promise.all` fan-out, tiered ordering, audience filter; a failing source degrades to `failedSources` (never a blank inbox).
+- `sources/business-approvals.ts` — the five business-approval queues (outbound / bill / expense / regulatory / research). **Bill and regulatory carry real `dueDate`s**, so they exercise the override tier (a bill or filing due today floats to the top with its reason). Each is registered as its own degradable source.
+- `aggregate.ts` — `Promise.all` fan-out over **all nine sources**, tiered ordering, audience filter; a failing source degrades to `failedSources` (never a blank inbox).
 
 ### Surface
 - `components/attention/{AttentionInbox,NeedsYouBand}.tsx` — full inbox + first-viewport band (renders nothing when empty); theme tokens only; "why it's here / what's blocked" context per row; "Pinned · reason" affordance for the override tier.
@@ -27,20 +28,21 @@ The decisions plane (escalations / AI-decision residue / paused-AI / agent-propo
 ### Re-home
 - `app/(shell)/ops/page.tsx` — the escalation band is **removed from `/ops`** (it now projects into the inbox via the `escalation` source). `runEscalationHygiene` (auto-resolve) stays; `/ops` is work-only.
 
-## Tests (40, green)
+## Tests (47, green)
 - `triage.test.ts` — override tier, tiered ordering, FIFO tie-break, determinism, `orderReason`, deadline mapping, age labels.
-- `sources/sources.test.ts` — each mapper: residue reason, risk mapping, unscorable, irreversible-high-risk pause, auth-required ≠ judgment.
+- `sources/sources.test.ts` — each keystone mapper: residue reason, risk mapping, unscorable, irreversible-high-risk pause, auth-required ≠ judgment.
+- `sources/business-approvals.test.ts` — bill/regulatory deadline → override tier, regulatory high-risk, the no-deadline approvals (outbound/expense/research).
 - `aggregate.test.ts` — fan-out collection + ordering, failing-source degradation, operator vs worker audience scoping.
 
 ## Verification
 - `pnpm --filter web typecheck` — 0 errors.
-- `pnpm --filter web exec vitest run lib/attention` — 3 files, 40 tests pass.
+- `pnpm --filter web exec vitest run lib/attention` — 4 files, 47 tests pass.
 - `pnpm --filter web build:route-manifest` — 508 routes, `/workspace/inbox` present.
 
 ## Not in this slice (the remaining filed BIs)
 - BI-04ECEE9F (`decisionClass.scorability` routing tag + 0.000-guard test for kernel-scorable build decisions) — the keystone sources are all unscorable, so this lands with the first kernel-scorable source.
 - BI-094A124F (`Notification`/`HitlNotificationEvent` spine + badge + SSE).
-- BI-8EA88797 (finance/business adapters: outbound/bill/expense/compliance/research — these carry real deadlines, exercising the override tier + worker audience scoping).
+- BI-8EA88797 — adapters + deadline triage are **delivered**; the remaining part is **worker-principal scoping** for finance approvals (needs approver-role → principal resolution; the `audience` field + `filterAttentionForAudience` are in place and tested, so this is a population step, not new substrate).
 - BI-C7D25599 (email/message channel), BI-7D99B25C (record-outcome write-back), BI-C1B96972 (trust-dial overview).
 
 ## Notes

--- a/docs/superpowers/plans/2026-06-23-attention-surface-keystone-implementation.md
+++ b/docs/superpowers/plans/2026-06-23-attention-surface-keystone-implementation.md
@@ -1,0 +1,49 @@
+# Attention Surface — keystone + triage implementation
+
+| Field | Value |
+| ----- | ----- |
+| Status | **Implemented in this branch** (keystone BI-D39484E7 + triage model BI-61B9EB88). Verified: `pnpm --filter web typecheck` clean, 40 vitest tests green, route-manifest regenerated. |
+| Date | 2026-06-23 |
+| Spec | [2026-06-23 human attention surface design](../specs/2026-06-23-human-attention-surface-design.md) (§4, §4.4, §6) |
+| Epic | `EP-ATTENTION-SURFACE` |
+| Delivers | BI-D39484E7 (keystone), BI-61B9EB88 (triage model) |
+
+## What shipped
+
+The decisions plane (escalations / AI-decision residue / paused-AI / agent-proposals) is now a single **"Needs you"** inbox on `/workspace`, separate from the `/ops` work backlog, kernels-first and triaged — with **no composite priority score** (the #2315 discipline applied to ranking).
+
+### Pure core (`apps/web/lib/attention/`)
+- `types.ts` — `AttentionItem` projector contract incl. `triage{}` (time-to-act, residue-reason, blast-radius, decide-effort, irreversible). No persisted entity, no priority number.
+- `triage.ts` — the tiered order: **override tier** (hard-deadline-imminent OR irreversible-high-risk, shown with reason) → time-to-act → risk → blast → age (FIFO). Pure; reuses the `command-center` rank idiom. Plus explainability helpers (`orderReason`, residue/risk/effort labels, `attentionAgeLabel`, `timeToActFromDeadline`).
+- `sources/{escalation,ai-decision,paused-ai,agent-proposal}.ts` — pure mappers + loaders over the verified source models. **All four are `unscorable` residue** (the kernel already could not decide them) → honest facts, never a 0.000 ledger.
+- `aggregate.ts` — `Promise.all` fan-out, tiered ordering, audience filter; a failing source degrades to `failedSources` (never a blank inbox).
+
+### Surface
+- `components/attention/{AttentionInbox,NeedsYouBand}.tsx` — full inbox + first-viewport band (renders nothing when empty); theme tokens only; "why it's here / what's blocked" context per row; "Pinned · reason" affordance for the override tier.
+- `app/(shell)/workspace/inbox/page.tsx` — the full queue (operator-view V1).
+- `app/(shell)/workspace/page.tsx` — `<NeedsYouBand/>` wired into the first viewport.
+- `lib/navigation/portal-navigation-model.ts` — `/workspace/inbox` as a **workspace-section sibling** (no new rail destination, no cross-section teleport); route-manifest regenerated.
+
+### Re-home
+- `app/(shell)/ops/page.tsx` — the escalation band is **removed from `/ops`** (it now projects into the inbox via the `escalation` source). `runEscalationHygiene` (auto-resolve) stays; `/ops` is work-only.
+
+## Tests (40, green)
+- `triage.test.ts` — override tier, tiered ordering, FIFO tie-break, determinism, `orderReason`, deadline mapping, age labels.
+- `sources/sources.test.ts` — each mapper: residue reason, risk mapping, unscorable, irreversible-high-risk pause, auth-required ≠ judgment.
+- `aggregate.test.ts` — fan-out collection + ordering, failing-source degradation, operator vs worker audience scoping.
+
+## Verification
+- `pnpm --filter web typecheck` — 0 errors.
+- `pnpm --filter web exec vitest run lib/attention` — 3 files, 40 tests pass.
+- `pnpm --filter web build:route-manifest` — 508 routes, `/workspace/inbox` present.
+
+## Not in this slice (the remaining filed BIs)
+- BI-04ECEE9F (`decisionClass.scorability` routing tag + 0.000-guard test for kernel-scorable build decisions) — the keystone sources are all unscorable, so this lands with the first kernel-scorable source.
+- BI-094A124F (`Notification`/`HitlNotificationEvent` spine + badge + SSE).
+- BI-8EA88797 (finance/business adapters: outbound/bill/expense/compliance/research — these carry real deadlines, exercising the override tier + worker audience scoping).
+- BI-C7D25599 (email/message channel), BI-7D99B25C (record-outcome write-back), BI-C1B96972 (trust-dial overview).
+
+## Notes
+- V1 is operator-view, consistent with the command-center already on `/workspace`; worker scoping (the `audience` field + `filterAttentionForAudience` are in place and tested) wires up with the finance adapters (BI-8EA88797).
+- `components/ops/EscalationsAttention.tsx` is now unused on `/ops` (kept, not deleted — it may compose into the inbox's escalation row later).
+- `paused-ai` deep-links to `/platform/ai/operations-map` until `/platform/ai/paused-work` lands; `agent-proposal` deep-links to `/platform/ai` (no governance UI exists yet).

--- a/docs/superpowers/specs/2026-06-23-human-attention-surface-design.md
+++ b/docs/superpowers/specs/2026-06-23-human-attention-surface-design.md
@@ -1,0 +1,333 @@
+# The Attention Surface — a kernels-first "Needs you" inbox, separate from the work backlog
+
+| Field | Value |
+| ----- | ----- |
+| Status | **Design-first (spec only, no feature code).** For founder review. Keystone + slices filed under new epic `EP-ATTENTION-SURFACE`. |
+| Date | 2026-06-23 |
+| Trigger | Founder (Mark): the escalation band lives on the `/ops` Backlog (a category error); model the real home on mature HITL products — a question queue + email/message to approve-or-ask — with kernels-first routing so a human only sees the residue. |
+| Predecessor | [2026-06-23 escalation surface honest-context + auto-resolve](2026-06-23-escalation-surface-honest-context-and-auto-resolve-design.md) (PR #2315, commit d813ee67a) — made the band legible; this spec gives it the right home. |
+| Anchor doctrine | [2026-06-20 issue-report surface attendance](2026-06-20-issue-report-surface-attendance-design.md) §5.7 (two front doors: work vs decisions), §14 (trust dial). `BI-0ACD9AB2` is the OPEN receiving-loop BI this composes with. |
+| Related substrate | [`Notification`](../../../packages/db/prisma/schema.prisma) (schema.prisma:4362), [`/api/v1/notifications`](../../../apps/web/app/api/v1/notifications/route.ts), [`/api/v1/governance/approvals`](../../../apps/web/app/api/v1/governance/approvals/route.ts), [`command-center`](../../../apps/web/lib/workspace/command-center.ts), [`escalation-attention`](../../../apps/web/lib/quality/escalation-attention.ts), [`evaluateDecisionPerspective`](../../../apps/web/lib/decision-perspective/evaluator.ts), [`evaluateBuildStudioDecision`](../../../apps/web/lib/build/decision-service.ts), [`option-scoring`](../../../apps/web/lib/decision/option-scoring.ts), [`founder-review`](../../../apps/web/app/(shell)/platform/ai/founder-review/page.tsx), [`portal-navigation-model`](../../../apps/web/lib/navigation/portal-navigation-model.ts). |
+| Related designs | [Paused AI work approval surface](../plans/2026-05-13-paused-ai-work-approval-surface.md), [Realtime HITL + mobile companion](2026-05-13-realtime-hitl-mobile-companion-design.md), [Portal UX simplification spine](../plans/2026-05-26-portal-ux-simplification-spine.md), [Build Studio overseer UX](2026-06-22-build-studio-overseer-ux-design.md). |
+| Composes epics | `EP-INTAKE-UNIFY` (the WORK front door — peer), `EP-WWMD-MCP` (record-outcome write-back), `EP-HITL-MOBILE` (channels), `EP-COWORKER-INTERACTIVITY` (cross-page HITL handoff), `EP-LEARNING-COMMONS` (trust-dial tuning), `EP-BUILD-STUDIO-UX` (BI-FD796419 "Where we need you" band), `EP-NAV-COHERENCE` (DONE — nav rules to obey). |
+
+---
+
+## 0. Thesis — two planes, not one queue
+
+DPF has been folding "a human must decide this **now**" into the `/ops` Backlog because of the 2026-06-20 "converge everything into /ops" directive. That conflated two planes that have different cadence, different owners, and different half-lives:
+
+| Plane | Cargo | Question it answers | Cadence | Home today | Home it needs |
+| ----- | ----- | ------------------- | ------- | ---------- | ------------- |
+| **Backlog** | Work to **schedule** — features, bugs, chores | "What should we build next?" | Planned, prioritized, eventually built | `/ops` (✓ correct) | `/ops` (unchanged) |
+| **Attention** | Decisions to **make now** — escalations, approvals, reviews, paused AI | "What needs *me*, and why can't the AI finish it?" | Blocking, time-sensitive, perishable | Scattered across ~10 routes; escalations wrongly on `/ops` | **One "Needs you" inbox on `/workspace`** |
+
+The 2026-06-20 design already named the principle — **two front doors, one drain each**: `ingestBacklogItem` drains *work* queues into the backlog; **WWMD/the governed scopes** drain *decision* queues before they reach a human (§5.7). The backlog front door was built. The decision front door was specified but never given a room. This spec builds the room and wires the door.
+
+The room is **kernels-first by construction**: every decision is routed through the governed scopes (WWMD / WWWD / WSID) *first*; the inbox holds only the **residue** the scopes genuinely cannot resolve — and only when that residue is one the kernel can honestly speak to. That last clause is the hard-won lesson of PR #2315, and §3.2 makes it load-bearing rather than aspirational.
+
+And aggregating the residue is necessary but **not sufficient**. Each topic carries its *own* rationale for why it needs attention — an overdue bill, a five-minute-old paused build, a compliance filing due tomorrow — and those rationales are incommensurable: a human cannot rank them by gut, and prioritizing one over another is hard without **triage and context**. So the room must triage, not just list. §4.4 is the triage model: it makes heterogeneous items comparable by decomposing each into the *same* objective factors and ordering by a transparent, explainable rule — and it does this **without fabricating a single cross-axis "priority" score**, which would be the #2315 0.000-theater wearing a precise-looking costume.
+
+### Non-goals
+
+- Do **not** build a second backlog, ticket tracker, or work queue. The backlog stays the work SSoT.
+- Do **not** create a new identity-bearing entity or a materialized `AttentionItem` table — the inbox is a **projector** over each queue's own model (§4.1).
+- Do **not** re-introduce the degenerate WWMD verdict on cards (§3.2). Honest context or a real score — never 0.000 theater.
+- Do **not** fabricate a single magic cross-axis "priority: 0.73" to rank incommensurable items — surface the comparable factors and order by an explainable tiered rule instead (§4.4).
+- Do **not** add a new top-level rail destination (the kernel scored this 0.061 vs 0.69; §6.1) or any cross-rail-section secondary nav (EP-NAV-COHERENCE hard rule).
+- Do **not** let any external channel one-tap-approve high-risk work (§5).
+
+---
+
+## 1. Live finding — the attention plane is real, scattered, and mostly invisible
+
+A human-decision item can land in at least **ten** places today. Verified against the live codebase (routes, models, pending-status sentinels):
+
+| # | Queue | Canonical route | Model · pending-state | How a human learns of it | Writes `Notification`? |
+| - | ----- | --------------- | --------------------- | ------------------------ | ---------------------- |
+| 1 | Build-stall escalations | `/ops` band | `PlatformIssueReport` · `status=awaiting_escalation_ack` / `type=build-stall-escalation` | Band on the **wrong plane** (Backlog) — the category error | No |
+| 2 | Founder-review (AI decision residue) | `/platform/ai/founder-review` | `DecisionInteraction` · `outcomeType∈{defer,escalate}`, `humanOutcome=null` | Buried page; **"Record outcome" is disabled** (gated on EP-WWMD-MCP) | No |
+| 3 | Marketing / outbound approvals | `/customer/marketing` | `OutboundDraft` · `status=pending-review` (`ApprovalQueuePanel`) | In-page band only | No |
+| 4 | Bill approvals | `/finance/bills`, `/s/approve/[token]` | `BillApproval` · `pending` / `Bill` · `awaiting_approval` | Status-filter pill + **email token page** | No |
+| 5 | Expense approvals | `/finance/expense-claims`, `/s/expense-approve/[token]` | `ExpenseClaim` · `submitted` | Banner + **email token page** | No |
+| 6 | Compliance submissions | `/compliance/submissions` | `RegulatorySubmission` · `draft` | Status-filter grid | No |
+| 7 | Research proposals | `/admin/research` | `ResearchProposal` · `pending` | Admin-only panel | No |
+| 8 | Agent action proposals | `/api/v1/governance/approvals` | `AgentActionProposal` · `proposed` | **API only — no UI built** | No |
+| 9 | Capability needs | folded into `/ops` | `CoworkerCapabilityNeed` · `submitted/reviewing` | Auto-filed to backlog (a *work* item, correct) | No |
+| 10 | Paused AI work | `/platform/ai/paused-work` | `TaskRun` · `input-required` / `auth-required` | **Surface unbuilt** — only watchdog/Ops-Map monitoring | partial (TaskRun-stall) |
+
+Two structural defects:
+
+1. **No single place to look.** A founder cannot answer "what needs me right now?" without visiting ten routes — three of which (paused-AI, agent-proposals, founder-review-resolution) have no working human surface at all. The `Notification` model, `/api/v1/notifications`, and `/api/v1/governance/approvals` exist — a clear signal an inbox was *intended* — but **only `TaskRun`-stall and tax-remittance paths actually write `Notification`**. The backbone is laid; nothing rides it.
+2. **The escalation band is on the wrong plane.** PR #2315 made it legible (honest blocker context, conservative auto-resolve, manual Dismiss). But legible-and-misfiled is still misfiled: it sits in the Backlog's `products` rail section, competing with work it has nothing to do with.
+
+The bones exist (per [`command-center.ts`](../../../apps/web/lib/workspace/command-center.ts) `buildAttentionItems`, which *already* reads `pendingActionProposalCount`, `blockedTaskRunCount`, and improvements as read-only diagnostics). The "room" — an actionable, kernels-routed, channel-delivered inbox — was never built.
+
+---
+
+## 2. Research & precedent
+
+### 2.1 Internal precedent (reuse, don't reinvent)
+
+| Source | Adopt | Caveat |
+| ------ | ----- | ------ |
+| [Issue-report attendance §5.7/§14](2026-06-20-issue-report-surface-attendance-design.md) | Two front doors (work vs decisions); trust dial = HITL-first, earn autonomy per decision-class via evidence; "attention lens, not a new dashboard". | §5.3/§14 WWMD-pre-consult **mechanism** was degenerate (superseded by #2315). Keep the **doctrine**, fix the **mechanism** (§5.2). |
+| [Escalation honest-context (#2315)](2026-06-23-escalation-surface-honest-context-and-auto-resolve-design.md) | Cards show facts (top blocker, self-fix class, originating BI) not a verdict; conservative auto-resolve frees the queue. | "If a future need arises to have WWMD adjudicate, it must first be given structured features that map a blocker to principle dimensions." This spec honors that literally (§5.2). |
+| [Paused AI work plan](../plans/2026-05-13-paused-ai-work-approval-surface.md) | `TaskRun` is the paused-work record; decisions audit through `AuthorizationDecisionLog` + `TaskMessage`; **`auth-required` ≠ human judgment** (it's missing credential); OWASP "Lies in the Loop" → raw action shown beside the AI brief. | Unbuilt. This spec subsumes its inbox as one producer of the unified surface. |
+| [Realtime HITL + mobile companion](2026-05-13-realtime-hitl-mobile-companion-design.md) | Canonical `HitlNotificationEvent` contract; channel-policy table; portal is canonical, push/email carry **deep links** not decisions; `Notification`/`PushDeviceRegistration`/`notification-adapter.ts`/`agent-event-bus.ts`/`/api/agent/stream` all exist. | Channel strategy (§7) is lifted directly from here; `EP-HITL-MOBILE` already owns it (4/6 done). |
+| [Founder-review surface](../../../apps/web/app/(shell)/platform/ai/founder-review/page.tsx) | The closest existing "AI needs a human decision" queue — already reads the `escalate/defer` residue and groups by gap reason. | Buried route; resolution loop disabled. The new inbox **subsumes** it as a lens (§8.5). |
+| [Command-center](../../../apps/web/lib/workspace/command-center.ts) | `WorkspaceAttentionItem[]` + `buildAttentionItems` already project several queues; `/workspace` is `primaryOrder:10` and labelled "See what needs attention next". | Read-only diagnostics today; this spec makes them **actionable** and **complete**. |
+
+### 2.2 External HITL product precedent (the shape Mark asked for)
+
+Mature human-in-the-loop products converge on two delivery shapes, and DPF should match both:
+
+- **A question/approval queue** — one inbox, newest-or-highest-stakes first, each item = a small accountable decision with prepared context and bounded actions (approve / reject / request-changes / answer). This is the dominant pattern in agent-ops tooling (OpenAI Agents SDK durable pause/resume; Azure agent-orchestration HITL gates that are explicit about approve-vs-refine-vs-redirect; the "interrupt → human → resume" loop in LangGraph-style runtimes).
+- **Email / message to approve-or-ask** — the human is reached *where they are* (email, chat) with a secure link back into the authenticated decision. DPF already ships this for **bills and expenses** (`/s/approve/[token]`), proving the pattern is house-native.
+
+Security constraints carried from OWASP agentic guidance (already cited in the paused-work plan): no unauthenticated one-tap approval of high-risk/irreversible actions; the AI-written brief is never the *only* evidence (raw action shown beside it); every decision is audited; the channel must resist summary-forging ("Lies in the Loop").
+
+---
+
+## 3. The kernels-first routing pipeline (the spine)
+
+The inbox is the **last** stop, not the first. Every decision is routed through the governed scopes before a human sees it. The good news from substrate verification: **this cascade already exists in code.** The work is to make it the universal front door, persist its residue uniformly, and surface that residue in one place.
+
+### 3.1 The cascade that already runs
+
+[`evaluateDecisionPerspective`](../../../apps/web/lib/decision-perspective/evaluator.ts) is the kernels-first cascade:
+
+```
+WSID (profession profile) ──▶ WWWD (org autonomyPolicy) ──▶ DPF doctrine ──▶ defer
+        orderedProfileChain() walks the fallback chain; first profile with confidence>0 wins
+```
+
+It returns `outcomeType ∈ {recommend, arbitrate, escalate, defer}` (types.ts:16). It **escalates** on principle conflict, on high/critical risk, and when confidence falls below the profile's `autonomyPolicy.minimumConfidenceForRecommendation`; it **defers** with `coverageGap=true, gapReason="no-applicable-material"` when no profile has applicable material. At the WWMD layer, [`evaluateBuildStudioDecision`](../../../apps/web/lib/build/decision-service.ts) calls `principle_decide` and returns `needs-human` when `!recommendation || confidence !== "high"` (decision-service.ts:148), or `captured-gap` → "Send to founder review" on tool failure. And [`decide()`](../../../apps/web/lib/decision/option-scoring.ts) already returns `recommendation: null` with reasoning *"the decision needs human judgment instead of advisory math"* when no principles apply.
+
+**The residue is already typed.** `escalate`, `defer`, `needs-human`, `captured-gap`, `recommendation:null`, `principleConflict`, and the paused-`TaskRun` states are all the cascade saying "a human is required." `DecisionInteraction` already persists the `{escalate, defer}` residue (that is exactly what the founder-review page reads). The pipeline does not need inventing — it needs **a single residue contract and a single home.**
+
+### 3.2 The scorability caveat — kernels-first only works on decisions the kernel can score
+
+This is the load-bearing constraint and the reason the predecessor (#2315) had to rip out a WWMD button.
+
+A kernel consult is only meaningful when the decision maps to dimensions the kernel actually carries. The `PRINCIPLE_DIMENSIONS` registry (`packages/db/src/wiki-taxonomy.ts`, 14 keys: `long_term_maintainability`, `blast_radius`, `reusability`, `evidence_density`, `human_cognitive_load`, `capacity_utilization`, `governance_compliance`, `public_safety`, `speed_to_value`, `schema_grounding`, `operational_independence`, `data_privacy`, `cost_efficiency`, `vendor_lock_in`) has **no axis for a resume/defer/escalate operations call**. So when #2315 ran `principle_decide` on "resume vs defer vs escalate" with no structured features, `buildOptionScores` found nothing to grip: every option's composite was `0.000`, margin `0.000`, confidence forced `low`, and the "strongest contributors" were just the two highest-weight commandments in retrieval order — **identical and decision-independent on every card.** That is theater, and it taught the queue's users to ignore it.
+
+**The rule this design enforces** — every routed decision-class is tagged at the routing layer as one of:
+
+| Class | Meaning | Pipeline behavior | Inbox rendering |
+| ----- | ------- | ----------------- | --------------- |
+| **kernel-scorable** | Maps to ≥1 `PRINCIPLE_DIMENSIONS` axis with real `features` (e.g. plan-readiness, architecture trade-off — what Build Studio review already scores). | Run `principle_decide` / `evaluateDecisionPerspective` with structured features. Residue reaches the human only on low margin / conflict / coverage-gap. | Show the **contribution ledger** — recommended option, top ± contributors, confidence. |
+| **unscorable-by-construction** | No dimension carries the axis (resume/defer/escalate ops calls; pure ops judgement; `human_cognitive_load`-only UX-fit calls — see [nav-coherence](../specs/2026-06-21-nav-coherence-operator-console-design.md)). | **Do not run `principle_decide`.** Route straight to the human with honest context. | Show **facts** (top blocker, self-fix class, what was attempted, originating BI + status) — the #2315 pattern. **Never a 0.000 verdict.** |
+| **org-business** | A customer-business call the org has a stance on. | Route through the org WWWD corpus (`wiki_query` org-overlay stance/principle); WWMD doctrine only if the org corpus is silent. | Show the WWWD source + confidence. |
+
+**This spec eats its own dog food.** The genuine IA fork in §8 (elevate `/workspace` vs new rail) is *kernel-scorable* — it maps to `long_term_maintainability`, `reusability`, `human_cognitive_load` (cost), `speed_to_value`, `blast_radius`. Run through `principle_decide` with real features, it returned a **clean, high-confidence margin of 0.630** — no theater — because those axes exist. The contrast is the whole point: **the kernel can decide an architecture question (axes exist) and cannot decide a resume/defer escalation (no axis) — and the design must know the difference at the routing layer, not discover it on every card.**
+
+A `decisionClass.scorability` tag (`kernel-scorable | unscorable | org-business`) is the one piece of new typed metadata the pipeline needs; it lives on the residue contract (§6.2), not on a new table.
+
+### 3.3 The trust dial (HITL-first; autonomy earned per decision-class)
+
+From the attendance design §14, kept as a first-class acceptance constraint, not later polish:
+
+- HITL is a **function of confidence**, not an always-on gate. Low confidence / below-tie-margin / commandment conflict / novel context → **propose-and-review** (human approves/overrides; the override is a labeled correction). High confidence, repeatedly-correct-in-context → **autopilot** (executes, human reviews after the fact).
+- The dial is **per decision-class and per scope**, and starts low. As evidence accrues it rises and HITL recedes to genuine novelty + high stakes.
+- The human shifts from *approver-of-each* to **reviewer-of-evidence**: an overview (counts, classes, outcomes, anomalies) with drill-in, because every decision is on record (what was decided, which scope, the ledger, evidence refs, outcome). "Acknowledged" is never terminal; "reviewed-with-evidence" is.
+- **The tuning loop closes through `EP-LEARNING-COMMONS`** (already in-flight): a human override or a went-awry outcome is a labeled correction that refines the WWMD principle / WWWD doctrine / WSID technique (or its `dimensionVector`/weight). Decide → evidence → outcome → tune the scope. This spec **emits** the correction signal; the Commons epic owns the refinement. Do not build a parallel tuner.
+
+For V1 the dial is **conservative everywhere**: every consequential item is propose-and-review. Autonomy graduates per decision-class only as evidence earns it. This is the same posture the escalation auto-resolve took in #2315 (resolve only on provably-settled state).
+
+---
+
+## 4. The aggregator — a projector over existing queues, riding the Notification backbone
+
+### 4.1 No new table — project, don't materialize
+
+Each queue's truth stays in its owning model (single-source-of-truth). The inbox is a **read-model projector** — `AttentionItem[]` — exactly as `command-center.ts` already projects `WorkspaceAttentionItem[]`. A materialized `AttentionItem` table would create dual-write drift the moment a bill is approved in `/finance` without the mirror row updating. Rejected.
+
+```ts
+// lib/attention/types.ts — projector output, NOT a persisted entity
+type AttentionItem = {
+  id: string;                         // stable per source row, e.g. "decision:DI-…", "escalation:PIR-…"
+  source: AttentionSource;            // "escalation" | "ai-decision" | "paused-ai" | "agent-proposal"
+                                      //  | "approval-outbound" | "approval-bill" | "approval-expense"
+                                      //  | "compliance-submission" | "research-proposal"
+  title: string;
+  context: string;                    // the honest one-liner (blocker / question / what + why-paused)
+  decisionClass: {
+    scorability: "kernel-scorable" | "unscorable" | "org-business";
+    ledger?: ContributionLedger;      // present iff kernel-scorable
+  };
+  riskClass: "read" | "bounded-write" | "high-risk" | "unknown";
+  triage: {                           // §4.4 — the SAME comparable factors on every item, surfaced AS context.
+                                      //  There is deliberately NO single composite "priority" number here.
+    timeToAct: "overdue" | "due-today" | "due-soon" | "none";   // primary, objective sort key
+    deadlineIso?: string;             // present when a hard deadline exists (bill due, filing deadline, SLA breach)
+    residueReason:                    // WHY the kernel couldn't resolve it — typed by the §3.1 cascade outcome
+      "coverage-gap" | "principle-conflict" | "high-risk-gate" | "auth-required" | "needs-credential" | "policy-approval";
+    blastRadius?: string;             // what/who is blocked until decided — the "if you don't act…" line
+    decideEffort: "one-tap" | "review" | "judgment";            // the human_cognitive_load cost axis
+  };
+  age: { createdAtIso: string };      // SLA age computed in the view (escalation-attention.ts pattern)
+  actions: AttentionAction[];         // bounded, source-specific: approve | reject | request-changes
+                                      //  | answer | dismiss | snooze | pin | open-in-context
+  deepLink: string;                   // to the owning surface for heavy context
+  audience: { operator: boolean; assigneePrincipalId?: string };
+};
+```
+
+Each source is a small pure adapter (`lib/attention/sources/<source>.ts`) returning `AttentionItem[]` from its model's pending-state query — the verified sentinels in §1. The aggregator fans out across adapters in parallel (the `command-center.ts` `Promise.all` pattern) and is **read-only and idempotent**; it never mutates the source rows.
+
+### 4.2 The `Notification` model as the event + delivery spine
+
+The projector answers "what's in the inbox right now." `Notification` answers "tell the human a *new* thing arrived" and carries the cross-channel delivery (§7). The `HitlNotificationEvent` contract from the mobile-companion spec is the canonical event:
+
+- When a source row enters a pending-human state (an escalation is filed, a `TaskRun` pauses, a `DecisionInteraction` records `escalate/defer`, a bill needs approval), the producer emits a `HitlNotificationEvent` and writes one user-targeted `Notification` row (`type`, `title`, `body`, `deepLink` to the inbox item, `read`). This is the under-used backbone from §1 finally carrying traffic.
+- The inbox list reads the **projector** (live truth); the notification feed + badges read **`Notification`** (the "new since you last looked" signal). One is state, the other is event. Per the mobile spec, add a narrow `NotificationDelivery` table **only if** per-channel retry/state is required — not in V1.
+- `agent-event-bus.ts` + `/api/agent/stream` (SSE) already exist for live portal refresh; reuse, don't add a transport.
+
+### 4.3 What stays home (deep-link, don't duplicate)
+
+The inbox shows the **decision**, not the domain lifecycle. A bill's full ledger lives in `/finance`; a build's progress lives in `/build`; a marketing draft's editor lives in `/customer/marketing`. The `AttentionItem.deepLink` carries the human to the owning surface for heavy context. The inbox never reimplements `/finance` or `/build`. This is the "attention lens, not a second dashboard" rule from the attendance design, applied to every source.
+
+### 4.4 Triage & prioritization — "why this, why now"
+
+Aggregation is necessary but not sufficient. A founder looking at a bill, a paused build, and a compliance filing cannot rank them by gut: **each topic carries its own rationale for needing attention, and those rationales are incommensurable.** The surface's job is to make them comparable *and* show the context that justifies the order — because, as the founder put it, prioritizing one over another is hard without triage and context.
+
+**The integrity rule (the scorability caveat, applied to ranking).** Do **not** collapse incommensurable axes into a single fabricated `priority: 0.73`. A precise-looking number with no honest basis is exactly the #2315 0.000-theater in a new costume — it *looks* authoritative and means nothing, and it trains the user to distrust the order. Instead: decompose every item into the **same** small set of comparable, mostly-objective factors, order by a **transparent tiered rule**, and surface the factors **as the context**. The order must be explainable in one sentence per item, never "because the model said 0.73."
+
+**The triage factors — the same axes on every item, each derived from real data (never invented):**
+
+| Factor | What it measures | Source examples (verified) | Objective? |
+| ------ | ---------------- | -------------------------- | ---------- |
+| **Time-to-act** | Hard deadline / SLA: overdue → due-today → due-soon → none | `Bill`/`ExpenseClaim` due date; `RegulatorySubmission` deadline; `ValueStreamHitlGate.escalationTimeoutMinutes`; escalation age vs SLA | **Yes — the primary key** |
+| **Risk / stakes** | `riskClass` (read / bounded-write / high-risk) × value-at-stake (amount, irreversibility) | `TaskRun.riskClass`; bill amount; outbound-send reach | Mostly |
+| **Blast radius** | What / who is blocked until this is decided | a paused build blocks delivery; an agent-proposal blocks a coworker; an escalation blocks its originating BI | Mostly (maps to the `blast_radius` dimension) |
+| **Residue reason** | *Why* the kernel couldn't resolve it — the rationale itself | the §3.1 cascade outcome: coverage-gap / principle-conflict / high-risk-gate / auth-required / needs-credential / policy-approval | **Yes — already typed** |
+| **Decide-effort** | How much the human must do: one-tap vs judgment call needing context | the action set + whether an AI brief exists | Mostly (the `human_cognitive_load` cost axis) |
+
+**The ordering rule (tiered / lexicographic, explainable — not a magic composite).** A small, deliberately narrow **override tier** floats above everything: a topic jumps to the top only when a **hard deadline is imminent** (within a configurable window, default 24h — a regulatory filing, a payment due) **or** the action is **irreversible *and* high-risk** — and it is always shown *with its reason* (*"pinned to top: filing due in 6h"*), never silently. Below the override, sort primarily by **time-to-act** tier (overdue → due-today → due-soon → none); within a tier by **risk**; within risk by **blast-radius**; ties broken by **age** (FIFO). This is the paused-work plan's proven shape ("high-risk → bounded-write → read, FIFO within tier") generalized across sources, and it reuses the existing `command-center.ts` `SEVERITY_RANK` / `ATTENTION_RANK` / `selectReadinessAttention` ordering primitives. Every position is then defensible in a line: *"first because it's overdue, high-risk, and blocks delivery."* Where two items genuinely **are** commensurable on scorable axes — e.g. two financial approvals both mapping to `cost_efficiency` / `governance_compliance` — the kernel **may** rank *those two* and show the ledger (kernel-scorable, §3.2). Where they are **not** (a bill vs a build), the tiered rule orders them honestly and the human re-triages. The system never claims a precision it does not have.
+
+**Context on every card — what makes the order legible.** Each item answers "why this, why now" by surfacing its factors, plus two one-liners the founder specifically needs: **"what's blocked / what happens if you don't act"** (the consequence) and **"why it's here"** (the residue reason — the kernel's honest *"I couldn't decide this because…"*). That is the context without which prioritization is guesswork.
+
+**Triage controls — the human keeps the final call.** Pin, **snooze / defer-until** (a date; the item re-surfaces then), **group-by** (source / deadline / risk), and a per-item "not now" that records a *labeled triage decision*. The tiered order is a strong, explainable default; the human re-ranks with full context. And the trust dial (§3.3) applies to **triage** exactly as to decisions: as the AI's ordering proves correct (the human rarely re-orders a class), it earns the right to auto-snooze low-priority items and batch low-risk classes — triage autonomy earned by evidence, never asserted.
+
+**Distinct from the Golden Triangle.** `/platform/ai/priority` (the Golden Triangle, `EP-GOLDEN-TRIANGLE`) prioritizes AI *work effort* — a Cost/Quality/Time posture compiled into model tier, effort, and verification. Attention-triage prioritizes *human decisions* — which residue to address first. Different planes (like backlog vs attention): **compose the vocabulary, do not merge the surfaces.**
+
+---
+
+## 5. Channel strategy — in-app question queue + email/message (Mark's non-negotiable #1)
+
+The portal inbox is **canonical and always required**. Email/message is a **reach** layer that links back to the authenticated decision — never a replacement, never an unauthenticated high-risk approval. Channel selection is rule-driven by risk (lifted from the mobile-companion spec §7):
+
+| Item risk / kind | In-app inbox | Email / message | Push (mobile, later) |
+| ---------------- | ------------ | --------------- | -------------------- |
+| High-risk / irreversible (resume a build, high-risk MCP, large outbound send) | **Required** | Secure **deep link** to authenticated decision only | Deep-link only |
+| `auth-required` (missing credential, not judgment) | **Required** | Deep link | Deep-link only |
+| Bounded-write, reversible (request-changes, clarify) | **Required** | Deep link; **answer-by-reply** later | Optional |
+| Low-risk, reversible, policy-classified (a routine bill/expense under threshold) | **Required** | **Signed one-click approve/reject** — the pattern bills/expenses already ship (`/s/approve/[token]`) | Optional |
+| Resolved / FYI | History row | Optional summary | Optional |
+
+Hard rules (OWASP "Lies in the Loop" + paused-work locked decisions): (1) no external channel approves high-risk work directly; (2) the AI-prepared brief is shown **beside** the raw requested action, never instead of it; (3) every decision — in-app, email, or mobile — calls the **same** decision module and writes the **same** `AuthorizationDecisionLog` + `TaskMessage` audit; (4) push/email payloads carry no raw prompt/business content.
+
+This directly satisfies Mark's shape: a **question queue** (the in-app inbox) **and** **email/message to approve-or-ask** (deep-link for anything consequential; signed one-click only for the low-risk reversible class DPF already trusts to email).
+
+---
+
+## 6. IA placement — elevate `/workspace`, audience-aware, nav-coherent
+
+### 6.1 Decision (kernel-ratified)
+
+The home is **`/workspace`** — its first viewport becomes the **"Needs you"** inbox band, backed by a **`/workspace/inbox`** section page (full queue with filters) that is a sibling in the **same `workspace` shell section**. Not a new rail destination.
+
+Run through `principle_decide` as a *kernel-scorable* interface-surface decision (real features on `long_term_maintainability`, `reusability`, `human_cognitive_load`-cost, `speed_to_value`, `blast_radius`):
+
+- **Recommendation: `elevate-workspace`** — composite **0.691**, margin **0.630**, confidence **high**, no commandment conflict, strong structured coverage (0% semantic fallback).
+- Top contributors: *Architecture Over Shortcuts* (+0.25), *Never Assume — Verify* (+0.23). The `new-inbox-rail` option scored **0.061**, pulled down by *Consult the Governed Scopes Before Asking a Human* and *Do the work; don't task the operator*.
+
+Why it holds: `/workspace` is already `primaryOrder:10` (the first thing every operator and worker sees) with the shellNav description literally **"See what needs attention next."** The bones (`command-center.ts` `buildAttentionItems`) already live there. A new rail peer would compete with the designated attention home and re-open the nav fragmentation `EP-NAV-COHERENCE` just closed. Keeping `/workspace/inbox` inside the `workspace` section (siblings: `/workspace`, `/workspace/documents`) means **no cross-rail-section secondary nav** — obeying the hard rule that reverted the P1 operator-console teleport.
+
+### 6.2 Audience-awareness
+
+`PortalAudienceMode` is live (`worker | operator | customer | diagnostic`; AppRail Simple/Full toggle; cookie `dpf-nav-mode`). The inbox is **audience-scoped**:
+
+- **Operator** (founder/admin) sees the full residue: escalations, AI-decision residue, approvals, paused-AI, agent-proposals. This is the primary persona.
+- **Worker** sees only items assigned to them or their role (e.g. a finance worker's bill/expense approvals) — `AttentionItem.audience.assigneePrincipalId`. No platform-internal escalations.
+- The first-viewport band renders in both worker and operator modes (matching `/workspace`'s existing `audienceModes: ["worker","operator"]`); `/workspace/inbox` full view is operator-first with a worker-scoped subset.
+
+### 6.3 UX Feature-Fit Gate (per `dpf-ux-fit-review`, captured here)
+
+- **Decision:** `fits-with-guardrails`.
+- **Owning area:** Workspace.
+- **Route family:** `/workspace` (first-viewport band) + `/workspace/inbox` (section page). No new rail destination.
+- **Primary persona:** founder/operator — "what needs me right now, and why couldn't the AI finish it?"; secondary: domain worker (own approvals only).
+- **Navigation layer touched:** section nav inside Workspace + the existing first-viewport command strip. One layer.
+- **Reuse/convergence:** extend `command-center.ts` `buildAttentionItems` into the `AttentionItem` projector; reuse `escalation-attention.ts` (age/blocker-summary), `report-kit` `StatusBadge`/`DataTable`/`StatCard`, the founder-review grouping projector. New primitives must retire the per-queue bespoke panels (`ApprovalQueuePanel`, the founder-review cards) by converging them onto the inbox item, not add a dialect.
+- **Source truth:** each source model's pending-state query (§1) — no new owning model; `Notification` owns the "new" signal.
+- **Empty/failure behavior:** empty = "Nothing needs you right now" with a link to recent decisions (not a wall of zeros). A source adapter that errors degrades to a "couldn't load <source>" row, never a blank inbox.
+- **AI boundary:** inbox items that *start* coworker work (e.g. "let the AI retry") require preview + explicit confirmation; navigation/answer actions do not. No metric tile sends a prompt.
+- **Evidence before merge:** route tests for the projector + each adapter; theme-token scan; browser exercise of `/workspace` + `/workspace/inbox` at desktop and mobile widths; fixtures for each source's pending state and for empty/error states.
+
+### 6.4 Migration off the Backlog
+
+The escalation band (`escalation-attention.ts` / `EscalationsAttention` / `getOpenEscalations`, shipped by #2315) **moves from `/ops` to the `/workspace` inbox** as the `escalation` source adapter — unchanged logic, new home. `/ops` returns to **work only** (backlog items, improvements, capability needs as *work*). `/platform/ai/founder-review` becomes a **filtered lens of the same inbox** (the `ai-decision` source), and its disabled "Record outcome" loop is realized via the `EP-WWMD-MCP` `wwmd_record_outcome` handler (§7 composition). `/admin/issue-reports` stays the evidence/audit trail (already reframed by the attendance design). No queue is deleted; each is **re-homed or re-framed** so there is exactly one place a human looks.
+
+---
+
+## 7. Composition map — what this owns vs what it wires
+
+This surface is an **aggregator + router + home**. It deliberately owns very little net-new substrate; it wires existing planes together. Relate-not-duplicate:
+
+| Concern | Owner | This spec's relationship |
+| ------- | ----- | ------------------------ |
+| Work intake → backlog | `EP-INTAKE-UNIFY` (`ingestBacklogItem`) | **Peer plane.** We are the *decisions* front door; that is the *work* front door. We compose `BI-0ACD9AB2` (receiving loop) — its classified escalations are our `escalation` source. |
+| Record the human's decision back to the kernel | `EP-WWMD-MCP` (`wwmd_record_outcome`, BI-WWMD-MCP-08/09, currently deferred) | **Consume + unblock.** Our inbox is the surface that *needs* the disabled "Record outcome"; this spec is the demand signal to land that handler. |
+| Channels (push/email/mobile, event contract) | `EP-HITL-MOBILE` (4/6 done) | **Reuse.** `HitlNotificationEvent`, channel policy, `notification-adapter.ts` come from here. We are the portal surface those channels deep-link into. |
+| Cross-page HITL handoff, PUC envelope | `EP-COWORKER-INTERACTIVITY` | **Reuse.** A coworker handing a decision to a human routes into our inbox. |
+| Trust-dial tuning (override → refine scope) | `EP-LEARNING-COMMONS` (in-flight) | **Emit, don't build.** We emit the labeled-correction signal; the Commons refines WWMD/WWWD/WSID. |
+| Build "Where we need you" band | `EP-BUILD-STUDIO-UX` BI-FD796419 | **Compose.** The build overseer band is the build-scoped view of the same residue; it should render the inbox's build items, not a parallel queue. |
+| Nav rules | `EP-NAV-COHERENCE` (done) | **Obey.** No new rail; no cross-section secondary nav; audience-aware. |
+
+---
+
+## 8. Risks & mitigations
+
+| Risk | Why it matters | Mitigation |
+| ---- | -------------- | ---------- |
+| **Re-degeneracy** — a future card runs `principle_decide` on an unscorable axis | The exact #2315 failure; trains users to ignore the queue | `decisionClass.scorability` tag at the routing layer (§3.2); `unscorable` items never call `principle_decide`; a test asserts no inbox card renders a `0.000`-composite ledger |
+| **False-precision priority** — a single fabricated cross-axis `priority: 0.73` to rank incommensurable items | The same 0.000-theater failure in a new costume: an authoritative-looking order with no honest basis | No composite priority number (§4.4); decompose into the same objective factors, order by an explainable tiered rule, surface the factors as context; the kernel ranks only items genuinely commensurable on scored axes |
+| **Alert fatigue** — the inbox becomes a wall of low-value items | OWASP "Overwhelming HITL"; the failure the paused-work plan warns of | Kernels-first means only residue arrives; conservative auto-resolve (#2315 pattern) clears settled items; the §4.4 tiered triage surfaces the few that matter first; snooze + digest low-risk classes |
+| **Dual-queue drift** — projector and a cached/materialized copy disagree | Single-source-of-truth violation | No materialized `AttentionItem` table — pure projector over owning models (§4.1) |
+| **Cross-section teleport** — inbox reachable from a foreign rail section | Reverted once already (P1 operator console) | `/workspace/inbox` is a `workspace`-section sibling only; nav-reachability test |
+| **Projector latency** — fanning ~10 source queries on every `/workspace` render | `/workspace` is the landing page; slowness is felt by everyone | `Promise.all` fan-out + per-source count caps; promote hot counts to indexed columns only if p95 query budget is exceeded (mobile-spec deferral pattern) |
+| **Unauthenticated approval leak** via email/push | High-risk actions approved without portal auth | Channel policy (§5): high-risk = deep-link only; signed one-click strictly limited to the low-risk reversible class bills/expenses already use |
+| **Escalation rate masks itself** — making the queue legible hides that too many builds escalate | The band is mostly real, not ghosts (#2315 finding) | Out of scope here (legibility ≠ rate-tuning, per #2315 §4); surface a rate metric for the trust-dial overview but do not auto-suppress |
+
+---
+
+## 9. Backlog (filed under new epic `EP-ATTENTION-SURFACE`; keystone first)
+
+Substrate verification for the epic: `EP-INTAKE-UNIFY` is the *work* front door (its done `BI-196693D6` = "one place to see queued **work**"); `EP-WWMD-MCP`/`EP-HITL-MOBILE`/`EP-COWORKER-INTERACTIVITY` each own a *piece* (record-outcome / channels / handoff) but **none owns the unified attention plane**. A peer epic is justified and composes the four — it does not duplicate them. Filing the attention work under the backlog epic would re-commit the category error this design corrects.
+
+| # | BI | Title | Size | Why |
+| - | -- | ----- | ---- | --- |
+| **Keystone** | BI-AS-1 | `AttentionItem` projector + `/workspace` "Needs you" band + `/workspace/inbox` page — escalation + ai-decision + paused-ai + agent-proposal sources, audience-scoped, **triaged (tiered order, no composite score)** + deep-link out | L | The room. Re-homes the #2315 escalation band off `/ops`; reuses `command-center`/`escalation-attention`/report-kit. |
+| 2 | BI-AS-2 | `decisionClass.scorability` routing tag + the "never render a 0.000 ledger" guard test; render kernel-scorable items with the contribution ledger, unscorable with honest facts | M | Makes kernels-first real without re-degeneracy (§3.2). |
+| 3 | BI-AS-3 | Wire the `Notification`/`HitlNotificationEvent` spine — producers emit on pending-human entry; inbox badge + feed read `Notification`; SSE live refresh | M | Lights up the under-used backbone (§4.2); composes `EP-HITL-MOBILE`. |
+| 4 | BI-AS-4 | Finance + business approval source adapters (outbound, bill, expense, compliance-submission, research-proposal) into the projector, worker-audience-scoped | M | Completes aggregation; converges `ApprovalQueuePanel` et al onto the inbox. |
+| 5 | BI-AS-5 | Email/message channel: secure deep-link for consequential items + signed one-click for the low-risk reversible class; same decision module + audit | M | Mark's non-negotiable #2 (§5); composes bills/expenses token pattern + `EP-HITL-MOBILE`. |
+| 6 | BI-AS-6 | Realize the founder-review **resolution** loop: `wwmd_record_outcome` write-back from the inbox; founder-review becomes the `ai-decision` lens | M | Unblocks the disabled "Record outcome"; composes `EP-WWMD-MCP`; emits the `EP-LEARNING-COMMONS` correction signal. |
+| 7 | BI-AS-7 | Trust-dial overview: per-decision-class counts/outcomes/anomalies with drill-in; emit labeled-correction signal on override | M | §3.3 reviewer-of-evidence posture; feeds the Commons tuning loop. |
+| 8 | BI-AS-8 | **Triage & prioritization model** — per-item factors (time-to-act, risk, blast-radius, residue-reason, decide-effort), tiered ordering, "why this / why now" + "what's blocked" context lines, and snooze/pin/group-by controls. **No composite priority score**; the kernel ranks only genuinely-commensurable items | M | §4.4 — makes heterogeneous topics comparable *with the context that justifies the order* (Mark: prioritizing one over another is hard without triage + context). |
+
+Keystone BI-AS-1 ships the split, the home, and a basic tiered order; 2–3 make it kernels-first and live; 4–5 complete aggregation + channels; 6–7 close the resolution + tuning loops; 8 makes the queue genuinely triable (the founder's prioritization need) on top of the keystone's tiered baseline. Each is design-first input for Mark's review — **no feature code in this task.**
+
+---
+
+## 10. Open decisions (for Mark)
+
+1. **`/workspace/inbox` vs inbox-as-`/workspace`-home.** This spec recommends a first-viewport band on `/workspace` **plus** a dedicated `/workspace/inbox` full page (both in the workspace section). Alternative: make `/workspace` *itself* the inbox and demote the command-center matrix. Recommendation: keep the band-plus-page split so the readiness matrix survives; revisit if telemetry shows the matrix is ignored.
+2. **Worker-audience rollout.** V1 can ship operator-only and add the worker-scoped subset (own approvals) in a fast-follow. Recommendation: operator-first, worker subset in BI-AS-4 alongside the finance adapters (since those are the worker-relevant ones).
+3. **Signed one-click email scope.** Limit to bill/expense-style low-risk reversible items in V1 (proven pattern), or extend to other reversible approvals? Recommendation: V1 = bills/expenses only; widen per-class only after a security review of each class.
+4. **Escalation-rate metric placement.** Surface "why N builds escalate" on the trust-dial overview (BI-AS-7) or leave to a separate ops-health surface? Recommendation: a read-only tile on the overview; rate-*tuning* stays out of scope per #2315.
+5. **Triage depth in the keystone vs BI-AS-8 — RESOLVED (2026-06-23, founder go-ahead).** Keystone BI-AS-1 ships the tiered baseline (override tier → time-to-act → risk → blast → age) + the residue-reason line so the inbox is usable on day one; BI-AS-8 layers the full factor decomposition, the "why this / why now" + "what's blocked" context lines, and snooze/pin/group-by controls on top. Reflected in §4.4 and §9.
+6. **Auto-pin override — RESOLVED (2026-06-23, founder go-ahead).** A topic floats above the tiered order only when a hard deadline is imminent (configurable window, default 24h) **or** the action is irreversible-and-high-risk, always shown with its reason ("pinned to top: filing due in 6h"); everything else stays in the tiered order. Folded into the §4.4 ordering rule as the override tier.
+```


### PR DESCRIPTION
Separates the **human-attention plane from the work backlog**: a kernels-first "Needs you" inbox on `/workspace` that aggregates the ~10 scattered decision queues, triaged by an explainable tiered rule — **never a composite priority score** (the #2315 0.000-theater discipline, applied to ranking).

Spec: `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md` · Plan: `docs/superpowers/plans/2026-06-23-attention-surface-keystone-implementation.md`

## What this delivers (BI-D39484E7 keystone, BI-61B9EB88 triage, BI-8EA88797 adapters)
- **`lib/attention/`** — a pure read-model **projector** (no new table) over each queue's own model: 4 keystone sources (escalation / ai-decision residue / paused-AI / agent-proposal) + 5 business approvals (outbound / bill / expense / regulatory / research). A failing source degrades gracefully, never a blank inbox.
- **Triage** — override tier (hard-deadline-imminent **or** irreversible-high-risk, shown with its reason) → time-to-act → risk → blast → age. Bills and regulatory filings carry real `dueDate`s, so they exercise the override tier. Pure + unit-tested.
- **UI** — `NeedsYouBand` (first-viewport on `/workspace`) + `AttentionInbox` (`/workspace/inbox`, a workspace-section sibling — **no new rail destination, no cross-section teleport**) with an at-a-glance overview.
- **Re-home** — the escalation band is **removed from `/ops`** (now projected into the inbox); `/ops` keeps the auto-resolve hygiene and is work-only.
- **Scorability by construction** — all keystone sources are `unscorable` residue → honest facts, never a `0.000` ledger.

## Verification
- `pnpm --filter web typecheck` — **0 errors**
- `pnpm --filter web exec vitest run lib/attention` — **49 tests green** (4 files)
- `pnpm --filter web build:route-manifest` — `/workspace/inbox` registered

## How to test
- Open `/workspace` → the "Needs you" band shows the top items (renders nothing when the queue is empty).
- Open `/workspace/inbox` → the full queue with per-item "why it's here / what's blocked" context and the overview header.
- Confirm `/ops` no longer shows the escalation band (it's now in the inbox).

## Deferred (filed, sequenced; see the plan)
Notification spine (BI-094A124F), email channel (BI-C7D25599), record-outcome write-back (BI-7D99B25C — blocked on the deferred EP-WWMD-MCP `wwmd_record_outcome` handler), trust-dial overview (BI-C1B96972), and worker-principal scoping for finance approvals.

> Note: branch is currently behind `main` — happy to rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

UX-Fit-Decision: fits-with-guardrails — `/workspace/inbox` is a workspace-section sibling (no new rail destination; `principle_decide` elevate-workspace 0.69 vs new-rail 0.06, margin 0.63, high confidence), operator-primary persona, reuses the command-center + report-kit primitives, theme-token-only (no hardcoded colors), renders nothing when the queue is empty. Full review in spec §6.3.


---

## Runtime verification (governed lease evidence)

Both runtime-bound gates ran through the `local-integration-ci` lease (§5–§6) — substrate named per §6:

- **Production build — PASS.** `pnpm --filter web build` under lease `NPEL-D8533A4F87` (`pnpm run pregate`, evidence recorded via `record_local_integration_result`, lease released). `/workspace/inbox` is in the production route manifest (`ƒ /workspace/inbox`).
- **Live UX — PASS.** `dev-portal` `:3001` against the live DB under lease `NPEL-8CBDEDAC43`:
  - `/workspace/inbox` renders **20 real items** — 18 re-homed build-stall escalations (HIGH RISK, with blocker context + "Blocks: BI-…"), plus real bill `BILL-2026-0001` ("USD 249.99 due") and a marketing draft — with the overview header "20 need you · 18 high-risk · Build escalation 18 · Bill 1 · Marketing 1", tiered high-risk-first.
  - `/workspace` first viewport shows the **"NEEDS YOU · 20 · View all 20 →"** band above the command-center, top-5 with order reasons.
  - `/ops` **no longer shows the escalation band** (work-only) — the re-home is confirmed.
  - Clean render, no errors; lease released + container torn down after.
