### PR TITLE
feat(golden-triangle): run a review pass on high-effort coworker turns

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -39,6 +39,8 @@ import type { QuestionPacket } from "@/lib/tak/question-packet";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 import type { PortalContextEnvelope, PortalObjectAnchor } from "@/lib/portal-context";
 import { formatCoworkerOperationalCloseout } from "@/lib/tak/coworker-interaction-contract";
+import { resolveCoworkerReviewPattern } from "@/lib/golden-triangle/coworker-review";
+import { reviewCoworkerDraft } from "@/lib/tak/coworker-inline-review";
 import {
   extractInvokedSkillId,
   getSkillsForAgent,
@@ -1740,9 +1742,28 @@ export async function sendMessage(input: {
       return { userMessage: serializeMessage(userMsg), agentMessage: serializeMessage(agentMsg, proposal) };
     }
 
+    // EP-GOLDEN-TRIANGLE: leverage the "review" rung of the rigor ladder. When this
+    // coworker's posture sits high on Quality/effort, run ONE lightweight reviewer
+    // pass over the draft before it's sent. Fail-open (original draft on any issue);
+    // skipped for Balanced/low postures. "debate" is intentionally NOT run inline
+    // (too slow for an interactive reply) — it's reserved for autonomous runs.
+    let reviewedContent = agenticResult.content;
+    try {
+      if ((await resolveCoworkerReviewPattern(agent.agentId)) === "review") {
+        const verdict = await reviewCoworkerDraft({
+          userRequest: input.content,
+          draft: agenticResult.content,
+          sensitivity: agent.sensitivity,
+        });
+        reviewedContent = verdict.content;
+      }
+    } catch (err) {
+      console.warn("[golden-triangle] coworker review wrap failed (fail-open):", err);
+    }
+
     // Map agentic result to the shape downstream code expects
     const result = {
-      content: agenticResult.content,
+      content: reviewedContent,
       providerId: agenticResult.providerId,
       modelId: agenticResult.modelId,
       downgraded: agenticResult.downgraded,

--- a/apps/web/lib/golden-triangle/coworker-review.test.ts
+++ b/apps/web/lib/golden-triangle/coworker-review.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+
+import {
+  buildReviewerUserPrompt,
+  interpretReviewVerdict,
+  resolveCoworkerReviewPattern,
+  REVIEW_APPROVED,
+} from "./coworker-review";
+import type { GoldenTrianglePersistenceClient } from "./persistence";
+
+function client(perAgent: Record<string, GoldenTrianglePreference>): GoldenTrianglePersistenceClient {
+  return {
+    decisionPerspectiveProfile: {
+      findFirst: async () => ({ autonomyPolicy: { goldenTrianglePerAgent: perAgent } }),
+      updateMany: async () => ({ count: 0 }),
+    },
+  };
+}
+
+const ASSURED: GoldenTrianglePreference = { preset: "assured", qualityWeight: 0.8, costWeight: 0.1, timeWeight: 0.1 };
+const EXTREME: GoldenTrianglePreference = { preset: "custom", qualityWeight: 0.9, costWeight: 0.05, timeWeight: 0.05 };
+const FRUGAL: GoldenTrianglePreference = { preset: "frugal", qualityWeight: 0.1, costWeight: 0.8, timeWeight: 0.1 };
+
+describe("resolveCoworkerReviewPattern", () => {
+  it("returns review for an Assured coworker", async () => {
+    expect(await resolveCoworkerReviewPattern("a", client({ a: ASSURED }))).toBe("review");
+  });
+  it("returns debate for an extreme-quality coworker", async () => {
+    expect(await resolveCoworkerReviewPattern("a", client({ a: EXTREME }))).toBe("debate");
+  });
+  it("returns none for a frugal coworker", async () => {
+    expect(await resolveCoworkerReviewPattern("a", client({ a: FRUGAL }))).toBe("none");
+  });
+  it("returns none when the coworker has no posture", async () => {
+    expect(await resolveCoworkerReviewPattern("a", client({}))).toBe("none");
+  });
+});
+
+describe("interpretReviewVerdict", () => {
+  const draft = "The answer is 42.";
+  it("keeps the draft on APPROVED (tolerating case/punctuation)", () => {
+    expect(interpretReviewVerdict(draft, REVIEW_APPROVED)).toEqual({ content: draft, revised: false });
+    expect(interpretReviewVerdict(draft, "Approved.")).toEqual({ content: draft, revised: false });
+  });
+  it("keeps the draft on an empty/blank verdict", () => {
+    expect(interpretReviewVerdict(draft, "")).toEqual({ content: draft, revised: false });
+    expect(interpretReviewVerdict(draft, null)).toEqual({ content: draft, revised: false });
+  });
+  it("uses the reviewer text when it actually revises", () => {
+    const better = "The answer is 42, per Hitchhiker's Guide.";
+    expect(interpretReviewVerdict(draft, better)).toEqual({ content: better, revised: true });
+  });
+  it("treats an identical revision as no change", () => {
+    expect(interpretReviewVerdict(draft, "The answer is 42.")).toEqual({ content: draft, revised: false });
+  });
+});
+
+describe("buildReviewerUserPrompt", () => {
+  it("includes the request and the draft", () => {
+    const p = buildReviewerUserPrompt("what is 6x7?", "42");
+    expect(p).toContain("what is 6x7?");
+    expect(p).toContain("42");
+  });
+});

--- a/apps/web/lib/golden-triangle/coworker-review.ts
+++ b/apps/web/lib/golden-triangle/coworker-review.ts
@@ -1,0 +1,80 @@
+// EP-GOLDEN-TRIANGLE — leverage the "review" pattern on a coworker turn.
+//
+// When a coworker's posture sits high on the Quality/effort axis, the compiler
+// emits deliberationPattern "review" (or "debate"). For an INTERACTIVE chat turn
+// the full deliberation engine is too slow (minutes), so we run a single
+// lightweight reviewer pass: a distinct reviewer persona critiques the draft and
+// either approves it or returns an improved reply. This module is the pure core —
+// resolve the pattern, build the reviewer prompt, interpret the verdict — so it is
+// fully testable; the executor (which makes the extra model call) lives in
+// lib/tak/coworker-inline-review.ts. See the work-orchestration design note.
+import { compileGoldenTrianglePolicy } from "./compile";
+import { getEffectivePostureForAgent, type GoldenTrianglePersistenceClient } from "./persistence";
+
+export type CoworkerReviewPattern = "review" | "debate" | "none";
+
+/**
+ * Resolve the deliberation pattern the coworker's effective posture calls for
+ * (agent → org → platform → Balanced). Returns "none" when no posture, Balanced,
+ * or anything below the review rung. Fail-open.
+ */
+export async function resolveCoworkerReviewPattern(
+  agentId: string,
+  db?: GoldenTrianglePersistenceClient,
+): Promise<CoworkerReviewPattern> {
+  try {
+    const resolved = await getEffectivePostureForAgent(agentId, null, db);
+    if (!resolved) return "none";
+    const decoded = compileGoldenTrianglePolicy({
+      preference: resolved.preference,
+      taskClass: "conversation",
+      authorityScope: { kind: "wsid" },
+    });
+    const p = decoded.orchestrationBudget.deliberationPattern;
+    return p === "review" || p === "debate" ? p : "none";
+  } catch {
+    return "none";
+  }
+}
+
+/** The sentinel a reviewer returns when the draft needs no change. */
+export const REVIEW_APPROVED = "APPROVED";
+
+export const REVIEWER_SYSTEM_PROMPT =
+  "You are a senior reviewer checking another AI coworker's draft reply before it is sent to the user. " +
+  "Judge it for correctness, completeness, and clarity — you are a second pair of eyes, not the author. " +
+  `If the draft is accurate and complete, reply with exactly "${REVIEW_APPROVED}" and nothing else. ` +
+  "Otherwise reply with an improved version of the reply only — no preamble, no explanation, just the better reply.";
+
+/** Pure: the reviewer's user-turn content for a given request + draft. */
+export function buildReviewerUserPrompt(userRequest: string, draft: string): string {
+  return [
+    "The user asked:",
+    userRequest.trim(),
+    "",
+    "The draft reply is:",
+    draft.trim(),
+    "",
+    `Review it. Reply "${REVIEW_APPROVED}" if it is already good, otherwise return the improved reply.`,
+  ].join("\n");
+}
+
+export interface ReviewVerdict {
+  content: string;
+  revised: boolean;
+}
+
+/**
+ * Pure: interpret the reviewer's raw output against the draft. Approval (or an
+ * empty/blank verdict) keeps the draft; anything else is treated as the revised
+ * reply. A revision that is effectively identical to the draft counts as not
+ * revised (so callers don't surface a no-op "revised" flag).
+ */
+export function interpretReviewVerdict(draft: string, reviewerOutput: string | null | undefined): ReviewVerdict {
+  const out = (reviewerOutput ?? "").trim();
+  if (!out) return { content: draft, revised: false };
+  // Approval sentinel — tolerate trailing punctuation/case ("approved.", "Approved").
+  if (/^approved\b[.!]?$/i.test(out)) return { content: draft, revised: false };
+  if (out === draft.trim()) return { content: draft, revised: false };
+  return { content: out, revised: true };
+}

--- a/apps/web/lib/tak/coworker-inline-review.ts
+++ b/apps/web/lib/tak/coworker-inline-review.ts
@@ -1,0 +1,46 @@
+// EP-GOLDEN-TRIANGLE — the executor for the inline coworker review pass.
+//
+// Runs ONE lightweight reviewer call over a coworker's draft reply when the
+// posture calls for "review" (the high-effort rung). Kept out of the pure core
+// (lib/golden-triangle/coworker-review.ts) because it touches the inference layer.
+// Safety: fail-open (original draft on any error), single extra call, and it
+// passes NO agentId — so the reviewer call neither re-resolves the author's
+// posture nor recurses into another review.
+import type { RouteSensitivity } from "@/lib/agent-sensitivity";
+import type { ChatMessage } from "@/lib/ai-inference";
+import {
+  buildReviewerUserPrompt,
+  interpretReviewVerdict,
+  REVIEWER_SYSTEM_PROMPT,
+  type ReviewVerdict,
+} from "@/lib/golden-triangle/coworker-review";
+import { routeAndCall } from "@/lib/inference/routed-inference";
+
+export interface InlineReviewInput {
+  /** The user's request the draft is answering (for the reviewer's context). */
+  userRequest: string;
+  /** The coworker's draft reply to review. */
+  draft: string;
+  sensitivity: RouteSensitivity;
+}
+
+export async function reviewCoworkerDraft(input: InlineReviewInput): Promise<ReviewVerdict> {
+  const draft = input.draft;
+  if (!draft || !draft.trim()) return { content: draft, revised: false };
+  try {
+    const messages: ChatMessage[] = [
+      { role: "user", content: buildReviewerUserPrompt(input.userRequest, draft) },
+    ];
+    const result = await routeAndCall(messages, REVIEWER_SYSTEM_PROMPT, input.sensitivity, {
+      taskType: "review",
+      // Capable reviewer; deliberately NO agentId so this call does not re-resolve
+      // the author coworker's posture and cannot recurse into another review.
+      modelTier: "robust",
+      routingActor: { kind: "system", id: "golden-triangle-coworker-review" },
+    });
+    return interpretReviewVerdict(draft, result.content);
+  } catch (err) {
+    console.warn("[golden-triangle] inline coworker review failed (fail-open):", err);
+    return { content: draft, revised: false };
+  }
+}


### PR DESCRIPTION
**Make the "review" rung actually fire** (builds on the rigor ladder in #2341). The "I don't see review/debate at all" fix for interactive work.

When a coworker's posture sits high on Quality/effort (compiler emits `deliberationPattern: "review"`), the chat turn now runs **one lightweight reviewer pass** over the draft before it's sent — a distinct reviewer persona that approves it or returns an improved reply.

- **Pure core** ([coworker-review.ts](apps/web/lib/golden-triangle/coworker-review.ts)): `resolveCoworkerReviewPattern` (agent → org → platform posture → none/review/debate), the reviewer prompt, and verdict interpretation (`APPROVED` keeps the draft). 9 tests.
- **Executor** ([coworker-inline-review.ts](apps/web/lib/tak/coworker-inline-review.ts)): one `routeAndCall` with the reviewer prompt — passes **no agentId** so it neither re-resolves the author's posture nor recurses; **fail-open**.
- Wired at the agent-coworker seam, gated on `review`, fail-open (original draft on any error).
- **`debate` is deliberately NOT run inline** (minutes-long) — reserved for autonomous runs (next slice). Balanced/low postures are unchanged.

91 golden-triangle tests green; `tsc` clean. Live latency/quality of the review pass is the supervised step; the fail-open design bounds the worst case to today's behaviour.

Process-Spine-Decision: doc-specced (design slice 3); additive + fail-open; off unless a high-effort posture is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
