### PR TITLE
fix(coworker): context-aware tool cap sized from the DMR served-context truth

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1188,16 +1188,30 @@ export async function sendMessage(input: {
   // and failing every tool turn. Attach a capped core+role set and defer the
   // rest (still authorized); the model pulls deferred tools back on demand via
   // load_tools. Keeps capability, cuts per-turn cost.
-  const { selectCoworkerToolBudget, LOAD_TOOLS_TOOL, LOAD_TOOLS_TOOL_NAME } = await import(
+  const { selectCoworkerToolBudget, deriveCoworkerToolCap, LOAD_TOOLS_TOOL, LOAD_TOOLS_TOOL_NAME } = await import(
     "@/lib/actions/coworker-tool-budget"
   );
   const { getAgentToolGrantsAsync } = await import("@/lib/tak/agent-grants");
   const roleGrants = await getAgentToolGrantsAsync(agent.agentId);
+  // Size the per-turn attachment cap to the LOCAL model's served context. The
+  // 48-tool default assumes a ~32k window; a VRAM-constrained local model served
+  // at ~24.5k overflows (exceed_context_size_error) with 48 tool schemas (~16k
+  // tokens) plus a long thread. This binds on the local context even when a cloud
+  // provider is preferred — the cloud→local FALLBACK is exactly where the overflow
+  // bites — at the cost of only a few extra load_tools round-trips on a cloud turn.
+  // Reads the DMR served-context TRUTH (not ModelProfile, which model discovery can
+  // reset to null); no reachable local generation model → the full 48.
+  const { resolveLocalServedContextTokens } = await import(
+    "@/lib/inference/local-model-context-reconcile"
+  );
+  const localServedContext = await resolveLocalServedContextTokens();
+  const toolCap = deriveCoworkerToolCap(localServedContext);
   const { attached: budgetedTools, deferred: deferredTools } = selectCoworkerToolBudget({
     tools: availableTools,
     roleGrants,
     pageActionNames: new Set(pageActions.map((t) => t.name)),
     alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
+    cap: toolCap,
   });
   // Advertise the load_tools meta-tool only when something was actually deferred.
   const attachedTools = deferredTools.length > 0 ? [LOAD_TOOLS_TOOL, ...budgetedTools] : budgetedTools;
@@ -1255,7 +1269,7 @@ export async function sendMessage(input: {
     `[tools] thread=${JSON.stringify(input.threadId)} route=${JSON.stringify(input.routeContext)} agent=${JSON.stringify(agent.agentId)} ` +
     `${activeBuildPhase ? `buildPhase=${JSON.stringify(activeBuildPhase)} ` : ""}` +
     `authorized=${availableTools.length} attached=${toolsForProvider !== undefined ? attachedTools.length : 0} ` +
-    `deferred=${deferredTools.length}${isConversationOnly ? " (conversation-only)" : ""} ` +
+    `cap=${toolCap} deferred=${deferredTools.length}${isConversationOnly ? " (conversation-only)" : ""} ` +
     `tools=[${attachedTools.map(t => JSON.stringify(t.name)).join(", ")}]`;
   console.log(sanitizeForLog(toolsLogLine));
   if (activeBuildPhase) {

--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -3,10 +3,49 @@ import type { ToolDefinition } from "@/lib/mcp-tools";
 import {
   selectCoworkerToolBudget,
   selectLoadableTools,
+  deriveCoworkerToolCap,
   LOAD_TOOLS_TOOL,
   LOAD_TOOLS_TOOL_NAME,
   MAX_COWORKER_ATTACHED_TOOLS,
+  MIN_COWORKER_ATTACHED_TOOLS,
 } from "./coworker-tool-budget";
+
+describe("deriveCoworkerToolCap", () => {
+  it("keeps the full 48 ceiling at a 32k window (unchanged behavior)", () => {
+    expect(deriveCoworkerToolCap(32_768)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+  });
+
+  it("shrinks the cap on a VRAM-constrained 24,576 window so a long thread fits", () => {
+    // (24576 - 12000 reserve) / 330 ≈ 38 — below 48, leaving room for prompt+history+reply.
+    const cap = deriveCoworkerToolCap(24_576);
+    expect(cap).toBeLessThan(MAX_COWORKER_ATTACHED_TOOLS);
+    expect(cap).toBe(38);
+    // The observed overflow (49 tools → 24,730 prompt) now fits: 38 tools is ~3.6k
+    // fewer tokens, dropping the prompt well under the 24,576 window.
+    expect(cap * 330).toBeLessThan(24_576 - 8_000);
+  });
+
+  it("floors the cap rather than returning zero on a tiny window", () => {
+    expect(deriveCoworkerToolCap(4_096)).toBe(MIN_COWORKER_ATTACHED_TOOLS);
+    expect(deriveCoworkerToolCap(1_000)).toBe(MIN_COWORKER_ATTACHED_TOOLS);
+  });
+
+  it("returns the full ceiling when there is no small-context local model", () => {
+    expect(deriveCoworkerToolCap(null)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+    expect(deriveCoworkerToolCap(undefined)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+    expect(deriveCoworkerToolCap(0)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+  });
+
+  it("never exceeds the 48 ceiling even for a huge cloud window", () => {
+    expect(deriveCoworkerToolCap(200_000)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+  });
+
+  it("is monotonic — a larger window never yields fewer tools", () => {
+    const sizes = [4_096, 12_000, 16_000, 20_000, 24_576, 28_000, 32_768, 64_000];
+    const caps = sizes.map(deriveCoworkerToolCap);
+    for (let i = 1; i < caps.length; i++) expect(caps[i]).toBeGreaterThanOrEqual(caps[i - 1]);
+  });
+});
 
 const tool = (name: string, description = ""): ToolDefinition => ({
   name,

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -35,6 +35,43 @@ import { CORE_MCP_TOOL_NAMES } from "@/lib/mcp/tool-tier";
  */
 export const MAX_COWORKER_ATTACHED_TOOLS = 48;
 
+/** Rough serialized-JSON token cost of one tool schema. The 48-tool default was
+ *  sized against ~330 tok apiece. */
+export const TOOL_SCHEMA_TOKEN_ESTIMATE = 330;
+
+/** Tokens reserved per turn for everything that is NOT tool schemas — the system
+ *  prompt, accumulated conversation history, and the model's reply. The default
+ *  48-tool ceiling implicitly assumed a ~32k window (16k tools + ~16k else); on a
+ *  smaller window we must reserve this explicitly or a long thread overflows. */
+export const COWORKER_NON_TOOL_RESERVE_TOKENS = 12_000;
+
+/** Never attach fewer than this — below it a coworker is too crippled to be
+ *  useful, and the agentic loop's overflow handling covers the pathological case. */
+export const MIN_COWORKER_ATTACHED_TOOLS = 12;
+
+/**
+ * Derive the per-turn tool-attachment cap from the served context window of the
+ * model that will run the turn. The hardcoded 48 was sized for a ~32k window;
+ * on a VRAM-constrained local model served at 24,576 tokens, 48 tool schemas
+ * (~16k tokens) plus a long conversation overflow `exceed_context_size_error`.
+ * This scales the cap down so the tool block always leaves room for the prompt,
+ * history, and reply — and back up to the 48 ceiling once the window is large.
+ *
+ * It binds on the LOCAL model's served context even when a cloud provider is
+ * preferred, because the cloud→local FALLBACK path is exactly where these
+ * overflows happen; the cost on a cloud turn is only a few extra load_tools
+ * round-trips, never a failure. `null`/unknown (no small-context local model)
+ * → the full 48.
+ *
+ *   32_768 → 48 (ceiling; unchanged)   24_576 → 38   16_000 → 12 (floor)   null → 48
+ */
+export function deriveCoworkerToolCap(servedContextTokens: number | null | undefined): number {
+  if (!servedContextTokens || servedContextTokens <= 0) return MAX_COWORKER_ATTACHED_TOOLS;
+  const toolBudgetTokens = servedContextTokens - COWORKER_NON_TOOL_RESERVE_TOKENS;
+  const fitted = Math.floor(toolBudgetTokens / TOOL_SCHEMA_TOKEN_ESTIMATE);
+  return Math.max(MIN_COWORKER_ATTACHED_TOOLS, Math.min(MAX_COWORKER_ATTACHED_TOOLS, fitted));
+}
+
 /** Name of the meta-tool that lets a coworker pull deferred tools back on demand. */
 export const LOAD_TOOLS_TOOL_NAME = "load_tools";
 

--- a/apps/web/lib/inference/local-model-context-reconcile.test.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.test.ts
@@ -5,7 +5,7 @@ const { mockPrisma } = vi.hoisted(() => ({
 }));
 vi.mock("@dpf/db", () => ({ prisma: mockPrisma, DISCOVERY_TRIAGE_AGENT_ID: "discovery-triage" }));
 
-import { reconcileLocalModelContext } from "./local-model-context-reconcile";
+import { reconcileLocalModelContext, resolveLocalServedContextTokens } from "./local-model-context-reconcile";
 import { RECOMMENDED_BUILD_CONTEXT_TOKENS } from "./local-model-policy";
 
 afterEach(() => vi.clearAllMocks());
@@ -106,5 +106,50 @@ describe("reconcileLocalModelContext", () => {
     const r = await reconcileLocalModelContext(f.fetchImpl);
     expect(r.status).toBe("unreachable");
     expect(f.calls.post).toBe(0);
+  });
+});
+
+function makeResolveFetch(opts: {
+  models?: Array<{ id: string; dmr?: { context_window?: number } }>;
+  override?: number | null;
+  modelsStatus?: number;
+}) {
+  return (async (url: string) => {
+    const u = String(url);
+    if (u.includes("_configure")) {
+      const entry = opts.override == null ? {} : { Config: { "context-size": opts.override } };
+      return { ok: true, status: 200, json: async () => [entry] } as unknown as Response;
+    }
+    if (u.includes("/models")) {
+      const status = opts.modelsStatus ?? 200;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => ({ data: opts.models ?? [{ id: GEN, dmr: { context_window: 4096 } }] }),
+      } as unknown as Response;
+    }
+    throw new Error(`unexpected url ${u}`);
+  }) as unknown as typeof fetch;
+}
+
+describe("resolveLocalServedContextTokens", () => {
+  it("returns the DMR runtime override when one is set (the steady state)", async () => {
+    const f = makeResolveFetch({ models: [{ id: GEN, dmr: { context_window: 4096 } }], override: 24_576 });
+    expect(await resolveLocalServedContextTokens(f)).toBe(24_576);
+  });
+
+  it("falls back to the model-card default when no override is set (regressed state)", async () => {
+    const f = makeResolveFetch({ models: [{ id: GEN, dmr: { context_window: 4096 } }], override: null });
+    expect(await resolveLocalServedContextTokens(f)).toBe(4096);
+  });
+
+  it("returns null when only an embedding model is installed", async () => {
+    const f = makeResolveFetch({ models: [{ id: EMBED, dmr: { context_window: 2048 } }], override: null });
+    expect(await resolveLocalServedContextTokens(f)).toBeNull();
+  });
+
+  it("returns null (best-effort) when the models endpoint is unreachable", async () => {
+    const f = makeResolveFetch({ modelsStatus: 503 });
+    expect(await resolveLocalServedContextTokens(f)).toBeNull();
   });
 });

--- a/apps/web/lib/inference/local-model-context-reconcile.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.ts
@@ -111,3 +111,48 @@ export async function reconcileLocalModelContext(
     return none("unreachable", `context reconcile failed: ${(err as Error).message}`);
   }
 }
+
+/**
+ * The local generation model's EFFECTIVE served context in tokens — the DMR
+ * runtime `_configure` override when set, else the model-card default (what DMR
+ * actually serves with no override). Returns null when there is no reachable
+ * local generation model (caller then applies no cap shrink).
+ *
+ * Read this — NOT `ModelProfile.maxContextTokens` — when sizing the per-turn
+ * coworker tool cap: model discovery/profiling can reset the ModelProfile column
+ * to null, which silently defeats the cap (it reads null → full 48 → overflow).
+ * DMR is the source of truth. Best-effort with short timeouts; never throws.
+ */
+export async function resolveLocalServedContextTokens(
+  fetchImpl: typeof fetch = fetch,
+): Promise<number | null> {
+  // Wrap so getServedContextTokens' internal GET also gets a timeout (it issues
+  // its own fetch without a signal), so a hung DMR can never stall a coworker turn.
+  const withTimeout: typeof fetch = (url, init) =>
+    fetchImpl(url, { ...init, signal: init?.signal ?? AbortSignal.timeout(2500) });
+  try {
+    const oaiBase = getOllamaBaseUrl().replace(/\/$/, "");
+    const apiRoot = getOllamaApiRoot();
+    const modelsUrl = oaiBase.endsWith("/v1") ? `${oaiBase}/models` : `${oaiBase}/v1/models`;
+    let modelId: string | null = null;
+    let cardDefault: number | null = null;
+    try {
+      const res = await withTimeout(modelsUrl, {});
+      if (!res.ok) return null;
+      const body = (await res.json()) as {
+        data?: Array<{ id?: string; dmr?: { context_window?: number } }>;
+      };
+      const gen = (body.data ?? []).find((m) => m.id && !isEmbeddingModelId(m.id));
+      modelId = gen?.id ?? null;
+      cardDefault = typeof gen?.dmr?.context_window === "number" ? gen.dmr.context_window : null;
+    } catch {
+      return null;
+    }
+    if (!modelId) return null;
+    const served = await getServedContextTokens(apiRoot, modelId, withTimeout);
+    // Override wins; else the card default is what DMR actually serves right now.
+    return served.contextTokens ?? cardDefault ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem
After #2339 restored the local model's 24,576 served context, I **drove the live Scrum Master** (`ops-coordinator`) and it *still* overflowed:

```
[tools] agent="ops-coordinator" attached=49
local failed: request (24730 tokens) exceeds the available context size (24576 tokens)
```

49 attached tool schemas (~16k tokens) + a long thread > the 24,576 window. VRAM has only ~2.6 GB free, so the window can't go higher — the **tool surface** must fit it. Two issues:

1. The 48-tool cap was hardcoded for a ~32k window.
2. **The cap commit was dropped from the #2339 squash-merge** (the PR only captured the durable-context commit), so `origin/main` had no cap logic at all.

…and the first cut of the cap had a latent bug I only caught by driving it live (see below).

## Fix
- **`deriveCoworkerToolCap(servedContext)`** — reserve tokens for prompt + history + reply, fit the rest to tool schemas, clamp `[12, 48]`. **32k → 48** (unchanged), **24,576 → 38**.
- **`resolveLocalServedContextTokens()`** — read the **DMR `_configure` override** (else the model-card default) as the *effective* served context. `agent-coworker` uses this, **not** `ModelProfile.maxContextTokens`.
  - Why it matters: model discovery/profiling resets `ModelProfile.maxContextTokens` to **null**, which silently defeated the cap — it read null → full 48 → still overflowed. The unit test passed (`deriveCoworkerToolCap(24576)=38`) but the *wiring* read a column that gets wiped. **Driving the live coworker is what exposed it:** `cap=48` with the ModelProfile source, `cap=38` with the DMR source.
- Log `cap=` in the `[tools]` line.

## Live verification (the whole point)
Drove the Scrum Master on the preview running this code:

```
[tools] agent="ops-coordinator" authorized=104 attached=39 cap=38 deferred=66
exceed_context_size_error: 0
```

`attached` dropped **49 → 39**, `cap=38`, **zero overflow**, and it ran a full multi-iteration turn — versus the `24730 > 24576` failure beforehand.

## Tests
- `deriveCoworkerToolCap` (ceiling / shrink-to-38 / floor / null / monotonic) and `resolveLocalServedContextTokens` (override / card-default fallback / embedder-only / unreachable). `tsc --noEmit` clean.

> Separate finding (out of scope, not fixed here): the Scrum Master's `search_code_graph` call is **attached** (via the read-baseline at attach time) but **rejected at execution** (`ops-coordinator lacks a required grant`). An attach-vs-execute grant mismatch — worth its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)