### PR TITLE
feat(golden-triangle): unify review seam across chat + autonomous coworker turns

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -39,8 +39,6 @@ import type { QuestionPacket } from "@/lib/tak/question-packet";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 import type { PortalContextEnvelope, PortalObjectAnchor } from "@/lib/portal-context";
 import { formatCoworkerOperationalCloseout } from "@/lib/tak/coworker-interaction-contract";
-import { resolveCoworkerReviewPattern } from "@/lib/golden-triangle/coworker-review";
-import { reviewCoworkerDraft } from "@/lib/tak/coworker-inline-review";
 import {
   extractInvokedSkillId,
   getSkillsForAgent,
@@ -1742,28 +1740,12 @@ export async function sendMessage(input: {
       return { userMessage: serializeMessage(userMsg), agentMessage: serializeMessage(agentMsg, proposal) };
     }
 
-    // EP-GOLDEN-TRIANGLE: leverage the "review" rung of the rigor ladder. When this
-    // coworker's posture sits high on Quality/effort, run ONE lightweight reviewer
-    // pass over the draft before it's sent. Fail-open (original draft on any issue);
-    // skipped for Balanced/low postures. "debate" is intentionally NOT run inline
-    // (too slow for an interactive reply) — it's reserved for autonomous runs.
-    let reviewedContent = agenticResult.content;
-    try {
-      if ((await resolveCoworkerReviewPattern(agent.agentId)) === "review") {
-        const verdict = await reviewCoworkerDraft({
-          userRequest: input.content,
-          draft: agenticResult.content,
-          sensitivity: agent.sensitivity,
-        });
-        reviewedContent = verdict.content;
-      }
-    } catch (err) {
-      console.warn("[golden-triangle] coworker review wrap failed (fail-open):", err);
-    }
-
-    // Map agentic result to the shape downstream code expects
+    // Map agentic result to the shape downstream code expects. (The Golden Triangle
+    // "review" pass now runs inside executeAutonomousAgenticLoop — the single seam
+    // for both chat and autonomous turns — so agenticResult.content is already
+    // reviewed when the coworker's posture calls for it.)
     const result = {
-      content: reviewedContent,
+      content: agenticResult.content,
       providerId: agenticResult.providerId,
       modelId: agenticResult.modelId,
       downgraded: agenticResult.downgraded,

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -1,8 +1,19 @@
 import { randomUUID } from "crypto";
 import { prisma } from "@dpf/db";
 import type { ChatMessage } from "@/lib/ai-inference";
+import { resolveCoworkerReviewPattern } from "@/lib/golden-triangle/coworker-review";
+import { reviewCoworkerDraft } from "@/lib/tak/coworker-inline-review";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { AgentEvent } from "@/lib/tak/agent-event-bus";
+
+/** Best-effort latest user-turn text, for the reviewer's context. */
+function lastUserRequest(history: ChatMessage[]): string {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const m = history[i];
+    if (m && m.role === "user" && typeof m.content === "string") return m.content;
+  }
+  return "";
+}
 
 export type AutonomousWorkTrigger =
   | "interactive"
@@ -241,6 +252,29 @@ export async function executeAutonomousAgenticLoop(input: {
     ...(input.modelRequirements ? { modelRequirements: input.modelRequirements } : {}),
     onProgress: input.onProgress,
   });
+
+  // EP-GOLDEN-TRIANGLE: leverage the "review" rung of the rigor ladder. This is the
+  // SINGLE seam for both chat and autonomous coworker turns. When the coworker's
+  // posture sits high on Quality/effort, run one lightweight reviewer pass over the
+  // draft before it's returned. Fail-open (original draft on any error); skipped for
+  // proposals and for Balanced/low postures. (Full multi-perspective debate via the
+  // deliberation engine — minutes-long — is reserved for a follow-up; the lightweight
+  // pass is the floor for both review and debate postures here.)
+  if (result.content && !result.proposal) {
+    try {
+      const pattern = await resolveCoworkerReviewPattern(input.agentId);
+      if (pattern === "review" || pattern === "debate") {
+        const verdict = await reviewCoworkerDraft({
+          userRequest: lastUserRequest(input.chatHistory),
+          draft: result.content,
+          sensitivity: input.sensitivity,
+        });
+        if (verdict.revised) result.content = verdict.content;
+      }
+    } catch (err) {
+      console.warn("[golden-triangle] coworker review (unified seam) failed (fail-open):", err);
+    }
+  }
 
   // Governed Hermes learning Slice 2: fire-and-forget reflection trigger.
   // Inspects PlatformIssueReport rows produced during this run and emits


### PR DESCRIPTION
**Unify the review seam — chat + autonomous.** `executeAutonomousAgenticLoop` is the single chokepoint for *both* chat and autonomous coworker turns, so the Golden Triangle "review" rung now runs there:

- Covers **autonomous / long-running** work too, not just chat — high-effort autonomous runs now get a reviewer pass.
- The chat-only copy from #2344 is **removed** (DRY — no double review).
- Gated on the coworker's posture (`review` | `debate`), **fail-open**, skipped for proposals; the reviewer's context is the latest user turn.
- The lightweight reviewer pass is the floor for both review and debate postures here; **full multi-perspective debate** via the deliberation engine (minutes-long) remains the follow-up for autonomous runs.

91 golden-triangle tests green; `tsc` clean. Balanced/low postures unchanged.

Process-Spine-Decision: doc-specced (design slice 4); additive + fail-open; off unless a high-effort posture is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
