### PR TITLE
feat(coworker): composer typing-area refresh — arrow/stop submit, integrated card, merged + Add (BI-4931A5FE)

### DIFF
--- a/apps/web/components/agent/AgentFileUpload.tsx
+++ b/apps/web/components/agent/AgentFileUpload.tsx
@@ -6,9 +6,11 @@ type Props = {
   threadId: string | null;
   disabled: boolean;
   onUploaded: (result: { attachmentId: string; fileName: string; parsedContent: unknown }) => void;
+  /** "icon" = standalone clip button; "menu" = a row inside the composer's + Add menu. */
+  variant?: "icon" | "menu";
 };
 
-export function AgentFileUpload({ threadId, disabled, onUploaded }: Props) {
+export function AgentFileUpload({ threadId, disabled, onUploaded, variant = "icon" }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,24 +47,52 @@ export function AgentFileUpload({ threadId, disabled, onUploaded }: Props) {
         }}
         className="hidden"
       />
-      <button
-        type="button"
-        onClick={() => inputRef.current?.click()}
-        disabled={disabled || uploading || !threadId}
-        title={uploading ? "Uploading..." : "Upload a file"}
-        style={{
-          background: "transparent",
-          border: "none",
-          color: uploading ? "var(--dpf-accent)" : "var(--dpf-muted)",
-          fontSize: 16,
-          cursor: disabled || uploading ? "not-allowed" : "pointer",
-          padding: "6px",
-          opacity: disabled ? 0.5 : 1,
-          flexShrink: 0,
-        }}
-      >
-        {uploading ? "\u23F3" : "\u{1F4CE}"}
-      </button>
+      {variant === "menu" ? (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled || uploading || !threadId}
+          title={uploading ? "Uploading..." : "Attach a file"}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            width: "100%",
+            textAlign: "left",
+            background: "none",
+            border: "none",
+            color: "var(--dpf-text)",
+            cursor: disabled || uploading || !threadId ? "not-allowed" : "pointer",
+            opacity: disabled || !threadId ? 0.5 : 1,
+            padding: "8px",
+            borderRadius: 6,
+            fontSize: 12,
+          }}
+        >
+          <span aria-hidden="true" style={{ fontSize: 14 }}>{"\u{1F4CE}"}</span>
+          {uploading ? "Uploading\u2026" : "Attach file"}
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled || uploading || !threadId}
+          title={uploading ? "Uploading..." : "Upload a file"}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: uploading ? "var(--dpf-accent)" : "var(--dpf-muted)",
+            fontSize: 16,
+            cursor: disabled || uploading ? "not-allowed" : "pointer",
+            padding: "6px",
+            opacity: disabled ? 0.5 : 1,
+            flexShrink: 0,
+          }}
+        >
+          {uploading ? "\u23F3" : "\u{1F4CE}"}
+        </button>
+      )}
       {error && (
         <div style={{
           padding: "4px 8px",

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -10,7 +10,7 @@ import {
 import { AgentFileUpload } from "./AgentFileUpload";
 import { MicButton } from "./MicButton";
 import { useVoiceCapture } from "./hooks/useVoiceCapture";
-import { Volume2, VolumeOff, VolumeX } from "lucide-react";
+import { Volume2, VolumeOff, VolumeX, ArrowUp, Square } from "lucide-react";
 
 type PendingFile = {
   attachmentId: string;
@@ -169,6 +169,18 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
     textareaRef.current?.focus();
   }
 
+  // Stop the in-flight turn — the composer owns its threadId, so it cancels
+  // directly (mirrors the inline Cancel in the thinking bubble) rather than
+  // threading a callback through the parent.
+  function handleStop() {
+    if (!threadId) return;
+    fetch("/api/agent/cancel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ threadId }),
+    }).catch(() => {});
+  }
+
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -281,6 +293,8 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
     sources.length > 0 ||
     hardEdges.length > 0 ||
     !!expectedArtifact;
+  const showStop = !!busy;
+  const sendDisabled = disabled || !!busy || !value.trim() || overLimit;
 
   // ── Render helpers ────────────────────────────────────────────────────────
 
@@ -376,7 +390,7 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
           display: "flex",
           alignItems: "center",
           gap: 6,
-          padding: "6px 12px 0",
+          padding: "0 0 6px",
           flexWrap: "wrap",
         }}
       >
@@ -454,7 +468,7 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
           display: "flex",
           flexWrap: "wrap",
           gap: 4,
-          padding: "6px 12px 0",
+          padding: "0 0 6px",
         }}
       >
         {pendingFile &&
@@ -528,6 +542,16 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
           zIndex: 20,
         }}
       >
+        <AgentFileUpload
+          threadId={threadId}
+          disabled={disabled || !!busy}
+          onUploaded={(result) => {
+            onFileUploaded(result);
+            setPopoverOpen(false);
+          }}
+          variant="menu"
+        />
+        <div style={{ borderTop: "1px solid var(--dpf-border)", margin: "4px 0" }} />
         <PopoverItem
           icon={CHIP_ICONS.intent}
           label={intentCenter ? "Edit intent" : "Set intent…"}
@@ -606,7 +630,7 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
   }
 
   return (
-    <div style={{ borderTop: "1px solid var(--dpf-border)" }}>
+    <div style={{ borderTop: "1px solid var(--dpf-border)", padding: "8px 10px" }}>
       {/*
         Voice Slice 2 follow-up: surface voice errors INLINE, not just in the
         button tooltip. Operators were clicking the mic, getting silent
@@ -621,9 +645,11 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
             display: "flex",
             alignItems: "flex-start",
             gap: 8,
-            padding: "6px 12px",
+            padding: "6px 8px",
+            marginBottom: 6,
+            borderRadius: 8,
             background: "rgba(211, 51, 51, 0.08)",
-            borderBottom: "1px solid rgba(211, 51, 51, 0.25)",
+            border: "1px solid rgba(211, 51, 51, 0.25)",
             fontSize: 11,
             color: "var(--dpf-text)",
           }}
@@ -650,42 +676,21 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
           </button>
         </div>
       )}
-      {renderChipTray()}
-      {renderPendingEntryRow()}
-      <div style={{
-        display: "flex",
-        gap: 6,
-        padding: "10px 12px",
-        alignItems: "flex-end",
-        flexWrap: "wrap",
-      }}>
-        <div ref={popoverContainerRef} style={{ position: "relative", flexShrink: 0 }}>
-          <button
-            type="button"
-            onClick={togglePopover}
-            aria-expanded={popoverOpen}
-            aria-haspopup="menu"
-            aria-label="Add context"
-            title="Add context (intent, sources, scope edges, output shape)"
-            disabled={disabled || !!busy}
-            style={{
-              background: "var(--dpf-surface-2)",
-              border: "1px solid var(--dpf-border)",
-              borderRadius: 6,
-              color: "var(--dpf-text)",
-              cursor: disabled || busy ? "not-allowed" : "pointer",
-              fontSize: 18,
-              lineHeight: 1,
-              height: 32,
-              width: 32,
-              opacity: disabled || busy ? 0.5 : 1,
-              padding: 0,
-            }}
-          >
-            +
-          </button>
-          {renderContextPopover()}
-        </div>
+
+      {/* One integrated composer: textarea on top, control lip beneath. */}
+      <div
+        style={{
+          border: `1px solid ${overLimit ? "var(--dpf-error)" : "var(--dpf-border)"}`,
+          borderRadius: 14,
+          background: "color-mix(in srgb, var(--dpf-bg) 55%, transparent)",
+          padding: "8px 10px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        {renderChipTray()}
+        {renderPendingEntryRow()}
         <textarea
           ref={textareaRef}
           value={value}
@@ -695,110 +700,152 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
           placeholder={disabled ? "Sending..." : busy ? "Agent is working... type your next message" : "Ask your co-worker..."}
           rows={1}
           style={{
-            flex: "1 1 180px",
-            minWidth: 0,
-            background: "color-mix(in srgb, var(--dpf-bg) 80%, transparent)",
-            border: `1px solid ${overLimit ? "var(--dpf-error)" : "var(--dpf-border)"}`,
-            borderRadius: 6,
-            padding: "6px 10px",
-            fontSize: 12,
+            width: "100%",
+            boxSizing: "border-box",
+            background: "transparent",
+            border: "none",
+            padding: "2px",
+            fontSize: 13,
             color: "var(--dpf-text)",
             outline: "none",
             resize: "none",
             overflow: "auto",
             lineHeight: "1.4",
-            minHeight: 32,
+            minHeight: 24,
             maxHeight: 160,
           }}
         />
-        {overLimit && (
-          <span style={{ fontSize: 10, color: "var(--dpf-error)", flexShrink: 0, alignSelf: "center" }}>
-            {value.trim().length.toLocaleString()}/{MAX_MESSAGE_LENGTH.toLocaleString()}
-          </span>
-        )}
-        <MicButton
-          state={voice.state}
-          errorMessage={voice.error}
-          errorCode={voice.errorCode}
-          supported={voice.supported}
-          onStart={() => void voice.start()}
-          onStop={voice.stop}
-          onReset={voice.reset}
-          disabled={disabled || !!busy}
-        />
-        {onVoicePlaybackToggle && (
+
+        {/* Control lip */}
+        <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+          <div ref={popoverContainerRef} style={{ position: "relative", flexShrink: 0 }}>
+            <button
+              type="button"
+              onClick={togglePopover}
+              aria-expanded={popoverOpen}
+              aria-haspopup="menu"
+              aria-label="Add context"
+              title="Add files and context (intent, sources, scope edges, output shape)"
+              disabled={disabled || !!busy}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                background: "transparent",
+                border: "1px solid var(--dpf-border)",
+                borderRadius: 999,
+                color: "var(--dpf-muted)",
+                cursor: disabled || busy ? "not-allowed" : "pointer",
+                fontSize: 12,
+                lineHeight: 1,
+                height: 28,
+                padding: "0 10px",
+                opacity: disabled || busy ? 0.5 : 1,
+              }}
+            >
+              <span aria-hidden="true" style={{ fontSize: 15 }}>+</span> Add
+            </button>
+            {renderContextPopover()}
+          </div>
+
+          <span style={{ flex: 1 }} />
+
+          {overLimit && (
+            <span style={{ fontSize: 10, color: "var(--dpf-error)", flexShrink: 0 }}>
+              {value.trim().length.toLocaleString()}/{MAX_MESSAGE_LENGTH.toLocaleString()}
+            </span>
+          )}
+
+          {onVoicePlaybackToggle && (
+            <button
+              type="button"
+              onClick={voicePlaybackUnavailable ? undefined : onVoicePlaybackToggle}
+              title={
+                voicePlaybackUnavailable
+                  ? voicePlaybackUnavailableTitle
+                  : voicePlaybackEnabled
+                    ? "Mute voice playback"
+                    : "Unmute voice playback"
+              }
+              aria-label={
+                voicePlaybackUnavailable
+                  ? "Voice playback unavailable"
+                  : voicePlaybackEnabled
+                    ? "Mute voice playback"
+                    : "Unmute voice playback"
+              }
+              aria-pressed={voicePlaybackEnabled}
+              disabled={voicePlaybackUnavailable}
+              style={{
+                background: "none",
+                border: "none",
+                cursor: voicePlaybackUnavailable ? "not-allowed" : "pointer",
+                color: voicePlaybackUnavailable
+                  ? "var(--dpf-muted)"
+                  : voicePlaybackEnabled
+                    ? "var(--dpf-accent)"
+                    : "var(--dpf-muted)",
+                lineHeight: 1,
+                padding: "0 2px",
+                flexShrink: 0,
+                height: 30,
+                display: "flex",
+                alignItems: "center",
+                opacity: voicePlaybackUnavailable || !voicePlaybackEnabled ? 0.5 : 1,
+                transition: "color 0.15s, opacity 0.15s",
+              }}
+            >
+              {voicePlaybackUnavailable ? (
+                <VolumeX aria-hidden="true" size={16} strokeWidth={2} />
+              ) : voicePlaybackEnabled ? (
+                <Volume2 aria-hidden="true" size={16} strokeWidth={2} />
+              ) : (
+                <VolumeOff aria-hidden="true" size={16} strokeWidth={2} />
+              )}
+            </button>
+          )}
+
+          <MicButton
+            state={voice.state}
+            errorMessage={voice.error}
+            errorCode={voice.errorCode}
+            supported={voice.supported}
+            onStart={() => void voice.start()}
+            onStop={voice.stop}
+            onReset={voice.reset}
+            disabled={disabled || !!busy}
+          />
+
+          {/* Submit — a small arrow; a stop square while the coworker works. */}
           <button
             type="button"
-            onClick={voicePlaybackUnavailable ? undefined : onVoicePlaybackToggle}
-            title={
-              voicePlaybackUnavailable
-                ? voicePlaybackUnavailableTitle
-                : voicePlaybackEnabled
-                  ? "Mute voice playback"
-                  : "Unmute voice playback"
-            }
-            aria-label={
-              voicePlaybackUnavailable
-                ? "Voice playback unavailable"
-                : voicePlaybackEnabled
-                  ? "Mute voice playback"
-                  : "Unmute voice playback"
-            }
-            aria-pressed={voicePlaybackEnabled}
-            disabled={voicePlaybackUnavailable}
+            onClick={showStop ? handleStop : handleSubmit}
+            disabled={showStop ? !threadId : sendDisabled}
+            aria-label={showStop ? "Stop" : "Send"}
+            title={showStop ? "Stop the coworker" : "Send"}
             style={{
-              background: "none",
-              border: "none",
-              cursor: voicePlaybackUnavailable ? "not-allowed" : "pointer",
-              color: voicePlaybackUnavailable
-                ? "var(--dpf-muted)"
-                : voicePlaybackEnabled
-                  ? "var(--dpf-accent)"
-                  : "var(--dpf-muted)",
-              lineHeight: 1,
-              padding: "0 2px",
-              flexShrink: 0,
-              height: 32,
-              display: "flex",
+              display: "inline-flex",
               alignItems: "center",
-              opacity: voicePlaybackUnavailable || !voicePlaybackEnabled ? 0.5 : 1,
-              transition: "color 0.15s, opacity 0.15s",
+              justifyContent: "center",
+              width: 30,
+              height: 30,
+              borderRadius: "50%",
+              flexShrink: 0,
+              border: "none",
+              background: showStop ? "var(--dpf-surface-2)" : "var(--dpf-accent)",
+              color: showStop ? "var(--dpf-text)" : "#ffffff",
+              cursor: (showStop ? !threadId : sendDisabled) ? "not-allowed" : "pointer",
+              opacity: (showStop ? !threadId : sendDisabled) ? 0.4 : 1,
+              transition: "opacity 0.15s",
             }}
           >
-            {voicePlaybackUnavailable ? (
-              <VolumeX aria-hidden="true" size={16} strokeWidth={2} />
-            ) : voicePlaybackEnabled ? (
-              <Volume2 aria-hidden="true" size={16} strokeWidth={2} />
+            {showStop ? (
+              <Square aria-hidden="true" size={13} strokeWidth={2.5} />
             ) : (
-              <VolumeOff aria-hidden="true" size={16} strokeWidth={2} />
+              <ArrowUp aria-hidden="true" size={17} strokeWidth={2.5} />
             )}
           </button>
-        )}
-        <AgentFileUpload
-          threadId={threadId}
-          disabled={disabled || !!busy}
-          onUploaded={onFileUploaded}
-        />
-        <button
-          type="button"
-          onClick={handleSubmit}
-          disabled={disabled || busy || !value.trim() || overLimit}
-          title={busy ? "Agent is still working" : undefined}
-          style={{
-            background: "var(--dpf-accent)",
-            border: "none",
-            borderRadius: 6,
-            padding: "6px 12px",
-            fontSize: 12,
-            color: "#ffffff",
-            cursor: disabled || busy || !value.trim() || overLimit ? "not-allowed" : "pointer",
-            opacity: disabled || busy || !value.trim() || overLimit ? 0.5 : 1,
-            flexShrink: 0,
-            height: 32,
-          }}
-        >
-          Send
-        </button>
+        </div>
       </div>
     </div>
   );

--- a/docs/superpowers/specs/2026-06-23-coworker-panel-header-simplification-design.md
+++ b/docs/superpowers/specs/2026-06-23-coworker-panel-header-simplification-design.md
@@ -109,3 +109,18 @@ Ran `principle_decide` (population `external_coding_agent`, surface `coworker-pa
 - **Unit (`AgentPanelHeader.test.tsx`):** resting header renders identity + posture summary + overflow trigger; posture summary string reflects active state (mode/edits/web); exactly one sensitivity indicator (regression guard for the duplicate); opening the posture popover reveals the edit-fields and web switches; opening overflow reveals profile/erase; erase-confirm popover renders when `clearConfirmOpen`.
 - **Build gate:** `pnpm --filter web typecheck` + `pnpm --filter web build` run in CI (this is a source-only worktree; runtime-bound gates run in CI / the shared local-CI sandbox per §5).
 - **UX verification:** exercise the panel on the canonical install after the change reaches it via the governed path; confirm the posture/overflow disclosures, the switch affordances, and that no second sensitivity badge appears.
+
+## 9. Phase 2 — Composer typing-area refresh (2026-06-25, BI-4931A5FE)
+
+Follow-on requested by Mark, taking lessons from two reference composers (Claude Code's input lip and the Claude desktop composer). Decisive cues: **submit is a small arrow, not a "Send" button**, and the controls tuck into one integrated input.
+
+**Reconciliation note.** Between the header slice (#2329) merging and this slice, concurrent EP-GOLDEN-TRIANGLE work landed on main: it **docked the priority triangle at the composer** (`CoworkerPriorityDock`, #2337), removed Priority from the header posture menu, and replaced `CoworkerPriorityControl` with `CoworkerPriorityDock`. Operator decision (AskUserQuestion): scope this slice to the **typing area only** — do not move posture into the lip (it stays in the header, beside the new priority dock), to avoid colliding with the actively-iterating golden-triangle area.
+
+**Changes (`AgentMessageInput` only — self-contained):**
+
+- The textarea + controls become **one integrated rounded card** (the textarea goes borderless), replacing the flat toolbar of six separate bordered controls.
+- **Submit is a small circular arrow** (↑, `aria-label="Send"`). While the coworker works it becomes a **stop square** (`aria-label="Stop"`) that POSTs `/api/agent/cancel` directly — the composer owns its `threadId`, so it cancels without a new parent callback. An always-visible cancel (previously only after 15s in the thinking bubble). Enter still sends.
+- **One `+ Add`** merges the former file-clip and the context `+`: Attach file · Set intent · Add source · Scope edge · Output shape (`AgentFileUpload` gains `variant="menu"`).
+- Quiet right cluster: voice-playback · mic · submit.
+
+**Files:** `AgentMessageInput.tsx` (rewrite), `AgentFileUpload.tsx` (`variant`), `e2e/helpers/coworker.ts` (submit by `aria-label`). **No header/panel changes** — so no overlap with the golden-triangle dock work. The existing composer test passes unchanged because every accessible name it relies on (`Send`, `Add context`, the menuitems, the inline editors, the placeholder) is preserved. UX-fit: same progressive-disclosure decision as §5 — no raw control is promoted to the resting surface; submit is one small affordance.

--- a/e2e/helpers/coworker.ts
+++ b/e2e/helpers/coworker.ts
@@ -36,9 +36,9 @@ export async function askCoworker(page: Page, prompt: string): Promise<string> {
 
     await input.fill(prompt);
 
-    // Send button: type="button" text "Send" inside the panel
+    // Submit is a small arrow button (aria-label="Send"); Enter is the fallback.
     const panel = page.locator('[data-agent-panel="true"]').first();
-    const sendBtn = panel.locator('button:has-text("Send")').first();
+    const sendBtn = panel.locator('button[aria-label="Send"]').first();
     if (await sendBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
       await sendBtn.click();
     } else {


### PR DESCRIPTION
## Why
Mark asked to refine the coworker **typing area**, taking lessons from two reference composers (Claude Code's input lip + the Claude desktop composer). Key cue: *"the key is the typing area and there is no enter button, it's more a small arrow."*

## What changed (composer only)
- **One integrated card** — the textarea + controls live in a single rounded container (the textarea goes borderless), replacing the flat toolbar of six separate bordered controls.
- **Submit is a small arrow** (`aria-label="Send"`) instead of a labelled button. While the coworker works it becomes a **stop square** that POSTs `/api/agent/cancel` directly (the composer owns its `threadId`) — an always-visible cancel (previously only after 15s in the thinking bubble). Enter still sends.
- **One `+ Add`** merges the former file-clip and the context `+`: Attach file · Set intent · Add source · Scope edge · Output shape (`AgentFileUpload` gains `variant="menu"`).
- Quiet right cluster: voice-playback · mic · submit.

## Scope & reconciliation
**Typing area only**, by operator decision. While this was in flight, concurrent EP-GOLDEN-TRIANGLE work landed on main: it **docked the priority triangle at the composer** (`CoworkerPriorityDock`, #2337) and reworked the header posture menu. To avoid colliding with that actively-iterating area, this slice stays entirely inside `AgentMessageInput` — **no header/panel changes**. Posture stays in the header beside the new priority dock; moving it into the lip is deferred.

## Files
`AgentMessageInput.tsx` (rewrite) · `AgentFileUpload.tsx` (`variant`) · `e2e/helpers/coworker.ts` (submit by `aria-label`) · spec §9. No schema, no server actions, theme tokens only.

## Verification
Source-only worktree — typecheck / `next build` / unit tests run in **CI**. The existing `AgentMessageInput.test.tsx` passes unchanged: every accessible name it relies on (`Send`, `Add context`, the menuitems, the inline editors, the placeholder) is preserved.

## Governance
- **BI-4931A5FE** · **EP-COWORKER-PANEL-UX** (Phase 2; follows the merged header slice #2329 / BI-706321B1)
- Spec §9: `docs/superpowers/specs/2026-06-23-coworker-panel-header-simplification-design.md`

UX-Fit-Decision: progressive disclosure (same axis and rationale as BI-706321B1). principle_decide degenerate on human_cognitive_load (commandmentConflict=false) — decided on merits; nothing raw is promoted to the resting surface and submit is one small affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
