### PR TITLE
feat(golden-triangle): debate posture runs a real debate pass (steelman + synthesize)

### DIFF
--- a/apps/web/lib/golden-triangle/coworker-review.test.ts
+++ b/apps/web/lib/golden-triangle/coworker-review.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from "vitest";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
 import {
+  buildDeliberationPrompt,
   buildReviewerUserPrompt,
+  DEBATER_SYSTEM_PROMPT,
   interpretReviewVerdict,
   resolveCoworkerReviewPattern,
   REVIEW_APPROVED,
+  REVIEWER_SYSTEM_PROMPT,
 } from "./coworker-review";
 import type { GoldenTrianglePersistenceClient } from "./persistence";
 
@@ -62,5 +65,20 @@ describe("buildReviewerUserPrompt", () => {
     const p = buildReviewerUserPrompt("what is 6x7?", "42");
     expect(p).toContain("what is 6x7?");
     expect(p).toContain("42");
+  });
+});
+
+describe("buildDeliberationPrompt", () => {
+  it("uses the reviewer prompts for the review pattern", () => {
+    const { system, user } = buildDeliberationPrompt("review", "q", "draft");
+    expect(system).toBe(REVIEWER_SYSTEM_PROMPT);
+    expect(user).toContain("draft");
+  });
+  it("uses the debater prompts for the debate pattern", () => {
+    const { system, user } = buildDeliberationPrompt("debate", "q", "draft");
+    expect(system).toBe(DEBATER_SYSTEM_PROMPT);
+    expect(system).toMatch(/debate/i);
+    expect(user).toMatch(/for vs\.? against|Debate it/i);
+    expect(user).toContain("draft");
   });
 });

--- a/apps/web/lib/golden-triangle/coworker-review.ts
+++ b/apps/web/lib/golden-triangle/coworker-review.ts
@@ -59,6 +59,37 @@ export function buildReviewerUserPrompt(userRequest: string, draft: string): str
   ].join("\n");
 }
 
+export const DEBATER_SYSTEM_PROMPT =
+  "You are running a fast structured debate over another AI coworker's draft reply before it is sent to the user. " +
+  "Internally steelman the strongest case FOR the draft and the strongest case AGAINST it, find the decisive tension, " +
+  "then decide. You are an adversarial second mind, not the author. " +
+  `If the draft still wins the debate, reply with exactly "${REVIEW_APPROVED}" and nothing else. ` +
+  "Otherwise reply with the strongest synthesized reply only — no preamble, no 'for/against' notes, just the better reply.";
+
+/** Pure: the debater's user-turn content for a given request + draft. */
+export function buildDebaterUserPrompt(userRequest: string, draft: string): string {
+  return [
+    "The user asked:",
+    userRequest.trim(),
+    "",
+    "The draft reply is:",
+    draft.trim(),
+    "",
+    `Debate it (for vs. against), then reply "${REVIEW_APPROVED}" if it already wins, otherwise return the strongest synthesized reply.`,
+  ].join("\n");
+}
+
+/** Pure: pick the system + user prompt for a deliberation pattern. */
+export function buildDeliberationPrompt(
+  pattern: "review" | "debate",
+  userRequest: string,
+  draft: string,
+): { system: string; user: string } {
+  return pattern === "debate"
+    ? { system: DEBATER_SYSTEM_PROMPT, user: buildDebaterUserPrompt(userRequest, draft) }
+    : { system: REVIEWER_SYSTEM_PROMPT, user: buildReviewerUserPrompt(userRequest, draft) };
+}
+
 export interface ReviewVerdict {
   content: string;
   revised: boolean;

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -253,13 +253,14 @@ export async function executeAutonomousAgenticLoop(input: {
     onProgress: input.onProgress,
   });
 
-  // EP-GOLDEN-TRIANGLE: leverage the "review" rung of the rigor ladder. This is the
-  // SINGLE seam for both chat and autonomous coworker turns. When the coworker's
-  // posture sits high on Quality/effort, run one lightweight reviewer pass over the
-  // draft before it's returned. Fail-open (original draft on any error); skipped for
-  // proposals and for Balanced/low postures. (Full multi-perspective debate via the
-  // deliberation engine — minutes-long — is reserved for a follow-up; the lightweight
-  // pass is the floor for both review and debate postures here.)
+  // EP-GOLDEN-TRIANGLE: leverage the rigor ladder. This is the SINGLE seam for both
+  // chat and autonomous coworker turns. When the coworker's posture sits high on
+  // Quality/effort, run one deliberation pass over the draft before it's returned —
+  // a "review" (critique → improve) or a "debate" (steelman for/against → synthesize),
+  // per the compiled posture. Fail-open (original draft on any error); skipped for
+  // proposals and for Balanced/low postures. (The full multi-agent deliberation
+  // engine — minutes-long, build-artifact-coupled — stays the build-phase mechanism;
+  // this is the synchronous, output-revising leverage for coworker turns.)
   if (result.content && !result.proposal) {
     try {
       const pattern = await resolveCoworkerReviewPattern(input.agentId);
@@ -268,11 +269,12 @@ export async function executeAutonomousAgenticLoop(input: {
           userRequest: lastUserRequest(input.chatHistory),
           draft: result.content,
           sensitivity: input.sensitivity,
+          pattern,
         });
         if (verdict.revised) result.content = verdict.content;
       }
     } catch (err) {
-      console.warn("[golden-triangle] coworker review (unified seam) failed (fail-open):", err);
+      console.warn("[golden-triangle] coworker deliberation (unified seam) failed (fail-open):", err);
     }
   }
 

--- a/apps/web/lib/tak/coworker-inline-review.ts
+++ b/apps/web/lib/tak/coworker-inline-review.ts
@@ -1,46 +1,52 @@
-// EP-GOLDEN-TRIANGLE — the executor for the inline coworker review pass.
+// EP-GOLDEN-TRIANGLE — the executor for the inline coworker deliberation pass.
 //
-// Runs ONE lightweight reviewer call over a coworker's draft reply when the
-// posture calls for "review" (the high-effort rung). Kept out of the pure core
+// Runs ONE extra model call over a coworker's draft reply when the posture calls
+// for "review" (critique → improve) or "debate" (steelman for/against → synthesize)
+// — the high-effort rungs of the rigor ladder. Kept out of the pure core
 // (lib/golden-triangle/coworker-review.ts) because it touches the inference layer.
-// Safety: fail-open (original draft on any error), single extra call, and it
-// passes NO agentId — so the reviewer call neither re-resolves the author's
-// posture nor recurses into another review.
+// Safety: fail-open (original draft on any error), a single bounded extra call, and
+// it passes NO agentId — so the call neither re-resolves the author's posture nor
+// recurses into another review. (The full multi-agent deliberation engine —
+// minutes-long, build-artifact-coupled — stays the build-phase mechanism; this is
+// the synchronous, output-revising leverage for coworker turns.)
 import type { RouteSensitivity } from "@/lib/agent-sensitivity";
 import type { ChatMessage } from "@/lib/ai-inference";
 import {
-  buildReviewerUserPrompt,
+  buildDeliberationPrompt,
   interpretReviewVerdict,
-  REVIEWER_SYSTEM_PROMPT,
   type ReviewVerdict,
 } from "@/lib/golden-triangle/coworker-review";
 import { routeAndCall } from "@/lib/inference/routed-inference";
 
 export interface InlineReviewInput {
-  /** The user's request the draft is answering (for the reviewer's context). */
+  /** The user's request the draft is answering (for the reviewer/debater context). */
   userRequest: string;
-  /** The coworker's draft reply to review. */
+  /** The coworker's draft reply to deliberate over. */
   draft: string;
   sensitivity: RouteSensitivity;
+  /** Which pattern the posture calls for. Defaults to "review". */
+  pattern?: "review" | "debate";
 }
 
 export async function reviewCoworkerDraft(input: InlineReviewInput): Promise<ReviewVerdict> {
   const draft = input.draft;
   if (!draft || !draft.trim()) return { content: draft, revised: false };
+  const pattern = input.pattern ?? "review";
   try {
-    const messages: ChatMessage[] = [
-      { role: "user", content: buildReviewerUserPrompt(input.userRequest, draft) },
-    ];
-    const result = await routeAndCall(messages, REVIEWER_SYSTEM_PROMPT, input.sensitivity, {
-      taskType: "review",
-      // Capable reviewer; deliberately NO agentId so this call does not re-resolve
-      // the author coworker's posture and cannot recurse into another review.
+    const { system, user } = buildDeliberationPrompt(pattern, input.userRequest, draft);
+    const messages: ChatMessage[] = [{ role: "user", content: user }];
+    const result = await routeAndCall(messages, system, input.sensitivity, {
+      taskType: pattern,
+      // Debate is the top rung — give it max effort; review uses high. Capable
+      // model either way; deliberately NO agentId so this call does not re-resolve
+      // the author coworker's posture and cannot recurse into another deliberation.
       modelTier: "robust",
-      routingActor: { kind: "system", id: "golden-triangle-coworker-review" },
+      effort: pattern === "debate" ? "max" : "high",
+      routingActor: { kind: "system", id: `golden-triangle-coworker-${pattern}` },
     });
     return interpretReviewVerdict(draft, result.content);
   } catch (err) {
-    console.warn("[golden-triangle] inline coworker review failed (fail-open):", err);
+    console.warn(`[golden-triangle] inline coworker ${pattern} failed (fail-open):`, err);
     return { content: draft, revised: false };
   }
 }


### PR DESCRIPTION
**Closes the honest gap from the last review:** a `debate`-level posture now runs a **real debate pass distinct from review**.

When a coworker's posture sits at the top of the Quality axis (the `debate` rung), the deliberation pass **steelmans the strongest case for and against** the draft, finds the decisive tension, and **synthesizes the strongest reply** (or `APPROVED`) — vs. the `review` pass which critiques and improves. The unified seam passes the compiled pattern through, so review→critique, debate→debate; both output-revising, fail-open, a single bounded call (debate at max effort).

**Why not the full multi-agent engine inline:** `startDeliberation` is build-artifact-coupled and runs 10–30 min — unsuited to awaiting on a coworker turn. It stays the build-phase mechanism; this is the synchronous, output-revising leverage for coworker work.

93 golden-triangle tests green; `tsc` clean.

Process-Spine-Decision: doc-specced (the review/debate ladder); additive + fail-open; off unless a high-effort posture is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
