### PR TITLE
feat(it4it): IT4IT coverage projection + activate dormant scoring path (BI-A05FD3ED)

### DIFF
--- a/apps/web/lib/ea/architecture-parity-steward.test.ts
+++ b/apps/web/lib/ea/architecture-parity-steward.test.ts
@@ -29,6 +29,7 @@ function projectionResult(overrides: Partial<SysmlProjectionsResult> = {}): Sysm
     networkTopology: healthy,
     integrations: healthy,
     scheduledJobs: healthy,
+    it4itCoverage: healthy,
     ...overrides,
   };
 }

--- a/apps/web/lib/ea/architecture-parity-steward.ts
+++ b/apps/web/lib/ea/architecture-parity-steward.ts
@@ -62,6 +62,7 @@ const DOMAIN_LABELS: Record<ProjectionDomain, string> = {
   networkTopology: "network topology (discovered)",
   integrations: "connected-application integrations",
   scheduledJobs: "scheduling surface (all scheduled work)",
+  it4itCoverage: "IT4IT functional-criteria coverage",
 };
 
 function projectionEntries(result: SysmlProjectionsResult): Array<[ProjectionDomain, ProjectionStatus]> {

--- a/apps/web/lib/ea/it4it-coverage-extract.test.ts
+++ b/apps/web/lib/ea/it4it-coverage-extract.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildIt4itCoverageModel,
+  PROJECTION_RATIONALE_PREFIX,
+  DERIVED_CONFIDENCE,
+  type It4itCoverageFacts,
+  type It4itElementFact,
+} from "./it4it-coverage-extract";
+
+// Minimal synthetic IT4IT tree: two capability groups, each with one function + component.
+// S2P/Enterprise Architecture has a required + an optional criterion; D2C/Problem has one
+// required criterion.
+function tree(): It4itElementFact[] {
+  return [
+    { id: "cg-s2p", kind: "capability_group", slug: "s2p", name: "Strategy to Portfolio", parentId: null, normativeClass: null, sourceReference: null },
+    { id: "fn-s2p", kind: "function", slug: "fn-s2p", name: "Strategy Function", parentId: "cg-s2p", normativeClass: null, sourceReference: null },
+    { id: "comp-ea", kind: "component", slug: "enterprise-architecture", name: "Enterprise Architecture", parentId: "fn-s2p", normativeClass: null, sourceReference: null },
+    { id: "crit-ea-1", kind: "criterion", slug: "ea-1", name: "EA shall align to strategy", parentId: "comp-ea", normativeClass: "required", sourceReference: "6.1.1" },
+    { id: "crit-ea-2", kind: "criterion", slug: "ea-2", name: "EA may publish a roadmap", parentId: "comp-ea", normativeClass: "optional", sourceReference: "6.1.2" },
+    { id: "cg-d2c", kind: "capability_group", slug: "d2c", name: "Detect to Correct", parentId: null, normativeClass: null, sourceReference: null },
+    { id: "fn-d2c", kind: "function", slug: "fn-d2c", name: "Detect Function", parentId: "cg-d2c", normativeClass: null, sourceReference: null },
+    { id: "comp-problem", kind: "component", slug: "problem", name: "Problem", parentId: "fn-d2c", normativeClass: null, sourceReference: null },
+    { id: "crit-problem-1", kind: "criterion", slug: "problem-1", name: "Problem shall track root cause", parentId: "comp-problem", normativeClass: "required", sourceReference: "8.3.1" },
+  ];
+}
+
+function baseFacts(overrides: Partial<It4itCoverageFacts> = {}): It4itCoverageFacts {
+  return {
+    elements: tree(),
+    agents: [
+      { valueStream: "evaluate", it4itSections: ["6.1.1"] },
+      { valueStream: "Strategy to Portfolio", it4itSections: [] }, // legacy -> evaluate -> S2P
+      { valueStream: null, it4itSections: [] }, // hygiene: unset
+    ],
+    capabilities: [{ it4itValueStreams: ["evaluate"], hasBuiltTraceLink: true }],
+    existingAssessments: [],
+    ...overrides,
+  };
+}
+
+describe("buildIt4itCoverageModel — derivation", () => {
+  it("marks a component implemented when it has built capability + agent evidence", () => {
+    const m = buildIt4itCoverageModel(baseFacts());
+    const ea = m.components.find((c) => c.componentSlug === "enterprise-architecture")!;
+    expect(ea.status).toBe("implemented");
+    expect(ea.capabilityGroup).toBe("Strategy to Portfolio");
+    expect(ea.score).toBe(100);
+    expect(ea.evidence.agents).toBe(2); // evaluate + legacy "Strategy to Portfolio"
+    expect(ea.evidence.capabilitiesWithBuilds).toBe(1);
+    expect(ea.requiredCriteriaCount).toBe(1);
+  });
+
+  it("marks a component not_started with no evidence and records a gap", () => {
+    const m = buildIt4itCoverageModel(baseFacts());
+    const problem = m.components.find((c) => c.componentSlug === "problem")!;
+    expect(problem.status).toBe("not_started");
+    expect(problem.score).toBe(0);
+    expect(m.gaps.map((g) => g.componentSlug)).toContain("problem");
+  });
+
+  it("derives partial from agent-only or capability-only evidence", () => {
+    const agentOnly = buildIt4itCoverageModel(
+      baseFacts({ capabilities: [], agents: [{ valueStream: "operate", it4itSections: [] }] }),
+    );
+    expect(agentOnly.components.find((c) => c.componentSlug === "problem")!.status).toBe("partial");
+
+    const capOnly = buildIt4itCoverageModel(
+      baseFacts({ agents: [], capabilities: [{ it4itValueStreams: ["operate"], hasBuiltTraceLink: false }] }),
+    );
+    expect(capOnly.components.find((c) => c.componentSlug === "problem")!.status).toBe("partial");
+  });
+
+  it("requires BOTH built capability and agent evidence for implemented (built without agents is partial)", () => {
+    const m = buildIt4itCoverageModel(
+      baseFacts({ agents: [], capabilities: [{ it4itValueStreams: ["evaluate"], hasBuiltTraceLink: true }] }),
+    );
+    expect(m.components.find((c) => c.componentSlug === "enterprise-architecture")!.status).toBe("partial");
+  });
+
+  it("elevates a no-evidence component to partial when an agent section matches its criteria", () => {
+    // Agent cites section 8.3, which covers Problem's criterion 8.3.1.
+    const m = buildIt4itCoverageModel(
+      baseFacts({ agents: [{ valueStream: "cross-cutting", it4itSections: ["8.3"] }], capabilities: [] }),
+    );
+    const problem = m.components.find((c) => c.componentSlug === "problem")!;
+    expect(problem.evidence.sectionMatches).toBeGreaterThan(0);
+    expect(problem.status).toBe("partial");
+  });
+});
+
+describe("buildIt4itCoverageModel — write plan + no-clobber", () => {
+  it("writes a derived row for each component and inherited criteria", () => {
+    const m = buildIt4itCoverageModel(baseFacts());
+    // 2 components + 3 criteria = 5 rows.
+    expect(m.writePlan).toHaveLength(5);
+    for (const row of m.writePlan) {
+      expect(row.confidence).toBe(DERIVED_CONFIDENCE);
+      expect(row.rationale.startsWith(PROJECTION_RATIONALE_PREFIX)).toBe(true);
+    }
+    const eaCriterion = m.writePlan.find((r) => r.modelElementId === "crit-ea-1")!;
+    expect(eaCriterion.coverageStatus).toBe("implemented"); // inherited from component
+  });
+
+  it("preserves verified operator rows and does not include them in the write plan", () => {
+    const m = buildIt4itCoverageModel(
+      baseFacts({
+        existingAssessments: [
+          { modelElementId: "comp-ea", coverageStatus: "implemented", confidence: "verified", rationale: "operator confirmed" },
+        ],
+      }),
+    );
+    expect(m.writePlan.find((r) => r.modelElementId === "comp-ea")).toBeUndefined();
+    expect(m.preservedVerified).toBeGreaterThanOrEqual(1);
+  });
+
+  it("treats a non-derived, non-projection row as human-owned and preserves it", () => {
+    const m = buildIt4itCoverageModel(
+      baseFacts({
+        existingAssessments: [
+          { modelElementId: "comp-problem", coverageStatus: "planned", confidence: "high", rationale: "roadmap" },
+        ],
+      }),
+    );
+    expect(m.writePlan.find((r) => r.modelElementId === "comp-problem")).toBeUndefined();
+  });
+
+  it("re-derives (overwrites) its own derived rows", () => {
+    const m = buildIt4itCoverageModel(
+      baseFacts({
+        existingAssessments: [
+          { modelElementId: "comp-ea", coverageStatus: "not_started", confidence: DERIVED_CONFIDENCE, rationale: `${PROJECTION_RATIONALE_PREFIX} stale` },
+        ],
+      }),
+    );
+    const row = m.writePlan.find((r) => r.modelElementId === "comp-ea");
+    expect(row).toBeDefined();
+    expect(row!.coverageStatus).toBe("implemented");
+  });
+});
+
+describe("buildIt4itCoverageModel — rollups, hygiene, determinism", () => {
+  it("computes a weighted platform score over functional criteria", () => {
+    const m = buildIt4itCoverageModel(baseFacts());
+    // EA implemented: weight 2(required)+0.5(optional)=2.5, value 1 -> 2.5
+    // Problem not_started: weight 2(required), value 0 -> 0
+    // score = 2.5 / 4.5 = 56%
+    expect(m.platformScore).toBe(56);
+  });
+
+  it("counts hygiene findings for legacy and unset agent streams", () => {
+    const m = buildIt4itCoverageModel(baseFacts());
+    expect(m.hygiene.legacyStreamAgents).toBe(1);
+    expect(m.hygiene.nullStreamAgents).toBe(1);
+    expect(m.hygiene.unknownStreamAgents).toBe(0);
+  });
+
+  it("reports honest summary counts", () => {
+    const m = buildIt4itCoverageModel(baseFacts());
+    expect(m.summary.componentsTotal).toBe(2);
+    expect(m.summary.componentsWithEvidence).toBe(1);
+    expect(m.summary.requiredCriteriaTotal).toBe(2);
+    expect(m.summary.requiredCriteriaImplemented).toBe(1);
+    expect(m.summary.requiredCriteriaNotStarted).toBe(1);
+  });
+
+  it("is deterministic for identical facts", () => {
+    expect(buildIt4itCoverageModel(baseFacts())).toEqual(buildIt4itCoverageModel(baseFacts()));
+  });
+});

--- a/apps/web/lib/ea/it4it-coverage-extract.ts
+++ b/apps/web/lib/ea/it4it-coverage-extract.ts
@@ -1,0 +1,515 @@
+// apps/web/lib/ea/it4it-coverage-extract.ts
+//
+// Pure, deterministic IT4IT coverage extractor. Joins the seeded IT4IT functional-criteria
+// tree against live DPF evidence (agents, business capabilities) and derives an
+// evidence-derived coverage status + transparent rollup score per functional component,
+// with criteria inheriting their component status at derived confidence. No IO, no prisma.
+//
+// Honesty discipline (spec section 2): the automated unit is the functional COMPONENT, not
+// the individual normative criterion. Derived statuses are limited to what coarse evidence
+// can actually support (implemented / partial / not_started). "planned" and promotion to
+// "verified" are operator/coworker judgments applied through the override path, never
+// fabricated here. No-data is not_started, never a passing or failing colour.
+//
+// The reconcile shell (reconcile-it4it-coverage.ts) supplies facts and persists the write
+// plan; this module owns all the math so it is unit-testable in isolation.
+// Spec: docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md (sections 2, 4).
+
+import {
+  type ReferenceCoverageStatus,
+  type It4itCapabilityGroup,
+  evidenceStreamToCapabilityGroup,
+  normalizeIt4itEvidenceStream,
+  extractSectionToken,
+  sectionCovers,
+  IT4IT_LEGACY_STREAM_LABELS,
+} from "./it4it-crosswalk";
+
+// Stable marker convention used in lieu of a schema provenance field (spec section 1). A
+// row the projection owns carries confidence === DERIVED_CONFIDENCE and a rationale that
+// begins with PROJECTION_RATIONALE_PREFIX. Operator/coworker rows use a VERIFIED_CONFIDENCE
+// and are never overwritten.
+export const PROJECTION_RATIONALE_PREFIX = "it4it-coverage-projection:";
+export const DERIVED_CONFIDENCE = "derived";
+export const VERIFIED_CONFIDENCES = ["verified", "high"] as const;
+
+// Transparent rollup weights. Surfaced in evidenceSummary + UI so an enterprise architect
+// can challenge the number (spec section 2).
+export const STATUS_ROLLUP_VALUE: Record<ReferenceCoverageStatus, number | null> = {
+  implemented: 1,
+  partial: 0.5,
+  planned: 0.25,
+  not_started: 0,
+  out_of_mvp: null, // excluded from the denominator
+};
+
+export function normativeWeight(normativeClass: string | null | undefined): number {
+  switch ((normativeClass ?? "").toLowerCase()) {
+    case "required":
+      return 2;
+    case "recommended":
+      return 1;
+    case "optional":
+      return 0.5;
+    default:
+      return 0.5; // unset
+  }
+}
+
+export const ROLLUP_METHOD =
+  "score = sum(status_value * normative_weight) / sum(normative_weight); " +
+  "status_value implemented=1 partial=0.5 planned=0.25 not_started=0 out_of_mvp=excluded; " +
+  "normative_weight required=2 recommended=1 optional=0.5 unset=0.5";
+
+// Per-component evidence score (0..100) -> status. Uses only signals that are actually
+// populated in live data: workforce presence (agents tagged to the component's value
+// stream), capability coverage, built capability trace links (future signal; currently
+// sparse), and DIRECT component-level evidence (agent it4itSections that cover the
+// component's criteria source references). The weights are deliberately transparent so an
+// architect can challenge them, and confidence stays "derived" so even "implemented" reads
+// as evidence-suggested-not-certified until an operator verifies.
+export const EVIDENCE_WEIGHTS = {
+  agentsPresent: 35,
+  capabilitiesPresent: 30,
+  builtCapabilities: 20,
+  perSectionMatch: 25,
+  maxSectionMatches: 2,
+} as const;
+
+export const EVIDENCE_SCORE_METHOD =
+  "evidence_score = 35*(agents>0) + 30*(capabilities>0) + 20*(built_capabilities>0) + " +
+  "25*min(section_matches,2), capped at 100; status: score>=70 implemented, score>0 partial, score=0 not_started";
+
+// ── Fact inputs (all plain data; the reconcile shell maps live rows onto these) ──────────
+
+export interface It4itElementFact {
+  id: string;
+  kind: string; // capability_group | function | component | criterion | value_stream | value_stream_stage
+  slug: string;
+  name: string;
+  parentId: string | null;
+  normativeClass: string | null;
+  sourceReference: string | null;
+}
+
+export interface It4itAgentFact {
+  valueStream: string | null;
+  it4itSections: string[];
+}
+
+export interface It4itCapabilityFact {
+  it4itValueStreams: string[];
+  hasBuiltTraceLink: boolean; // links to a built digitalProduct / eaElement (not just a backlog item)
+}
+
+export interface It4itExistingAssessmentFact {
+  modelElementId: string;
+  coverageStatus: string;
+  confidence: string | null;
+  rationale: string | null;
+}
+
+export interface It4itCoverageFacts {
+  elements: It4itElementFact[];
+  agents: It4itAgentFact[];
+  capabilities: It4itCapabilityFact[];
+  existingAssessments: It4itExistingAssessmentFact[];
+}
+
+// ── Outputs ──────────────────────────────────────────────────────────────────────────
+
+export interface It4itComponentCoverage {
+  componentId: string;
+  componentSlug: string;
+  componentName: string;
+  capabilityGroup: It4itCapabilityGroup | null;
+  status: ReferenceCoverageStatus;
+  score: number; // 0..100, rounded
+  criteriaCount: number;
+  requiredCriteriaCount: number;
+  evidence: {
+    agents: number;
+    capabilities: number;
+    capabilitiesWithBuilds: number;
+    sectionMatches: number;
+  };
+}
+
+export interface It4itGroupRollup {
+  group: It4itCapabilityGroup;
+  status: ReferenceCoverageStatus;
+  score: number; // 0..100, rounded
+  componentCount: number;
+  componentsWithEvidence: number;
+}
+
+export interface It4itWritePlanRow {
+  modelElementId: string;
+  kind: "component" | "criterion";
+  coverageStatus: ReferenceCoverageStatus;
+  confidence: string;
+  rationale: string;
+  evidenceSummary: string;
+}
+
+export interface It4itCoverageGap {
+  componentId: string;
+  componentSlug: string;
+  componentName: string;
+  capabilityGroup: It4itCapabilityGroup | null;
+  requiredCriteriaCount: number;
+}
+
+export interface It4itCoverageModel {
+  components: It4itComponentCoverage[];
+  groupRollups: It4itGroupRollup[];
+  platformScore: number; // 0..100, rounded — weighted over functional criteria
+  writePlan: It4itWritePlanRow[]; // platform-scope rows to upsert (no-clobber already applied)
+  preservedVerified: number; // rows skipped because an operator/coworker verified them
+  gaps: It4itCoverageGap[]; // not_started components that carry required criteria
+  hygiene: {
+    unknownStreamAgents: number;
+    legacyStreamAgents: number;
+    nullStreamAgents: number;
+  };
+  summary: {
+    componentsTotal: number;
+    componentsAssessed: number;
+    componentsWithEvidence: number;
+    requiredCriteriaTotal: number;
+    requiredCriteriaImplemented: number;
+    requiredCriteriaPartial: number;
+    requiredCriteriaNotStarted: number;
+  };
+  method: string;
+}
+
+interface GroupEvidence {
+  agents: number;
+  capabilities: number;
+  capabilitiesWithBuilds: number;
+}
+
+function emptyGroupEvidence(): GroupEvidence {
+  return { agents: 0, capabilities: 0, capabilitiesWithBuilds: 0 };
+}
+
+function isVerified(a: It4itExistingAssessmentFact): boolean {
+  const c = (a.confidence ?? "").toLowerCase();
+  return (VERIFIED_CONFIDENCES as readonly string[]).includes(c);
+}
+
+// A row is owned by (writable by) the projection when it is absent, or carries derived
+// confidence, or its rationale begins with the projection prefix. Otherwise it is an
+// operator/coworker assessment and must be preserved.
+function isProjectionWritable(a: It4itExistingAssessmentFact | undefined): boolean {
+  if (!a) return true;
+  if (isVerified(a)) return false;
+  if ((a.confidence ?? "").toLowerCase() === DERIVED_CONFIDENCE) return true;
+  if ((a.rationale ?? "").startsWith(PROJECTION_RATIONALE_PREFIX)) return true;
+  // Has a non-derived confidence and is not projection-authored -> treat as human-owned.
+  return false;
+}
+
+function deriveComponentEvidence(
+  ev: GroupEvidence,
+  sectionMatches: number,
+): { status: ReferenceCoverageStatus; evidenceScore: number } {
+  let score = 0;
+  if (ev.agents > 0) score += EVIDENCE_WEIGHTS.agentsPresent;
+  if (ev.capabilities > 0) score += EVIDENCE_WEIGHTS.capabilitiesPresent;
+  if (ev.capabilitiesWithBuilds > 0) score += EVIDENCE_WEIGHTS.builtCapabilities;
+  score += EVIDENCE_WEIGHTS.perSectionMatch * Math.min(sectionMatches, EVIDENCE_WEIGHTS.maxSectionMatches);
+  score = Math.min(score, 100);
+  const status: ReferenceCoverageStatus =
+    score >= 70 ? "implemented" : score > 0 ? "partial" : "not_started";
+  return { status, evidenceScore: score };
+}
+
+/**
+ * Build the IT4IT coverage model from live facts. Pure and deterministic: identical facts
+ * always yield an identical model (important for steward idempotency).
+ *
+ * @example
+ * const model = buildIt4itCoverageModel({
+ *   elements, agents, capabilities, existingAssessments: [],
+ * });
+ * // model.writePlan -> rows to upsert on the platform scope
+ * // model.platformScore -> evidence-derived headline (0..100)
+ */
+export function buildIt4itCoverageModel(facts: It4itCoverageFacts): It4itCoverageModel {
+  const byId = new Map<string, It4itElementFact>();
+  for (const e of facts.elements) byId.set(e.id, e);
+
+  // Resolve the capability group for any element by walking parents up to a capability_group.
+  const groupCache = new Map<string, It4itCapabilityGroup | null>();
+  function resolveGroup(elementId: string | null): It4itCapabilityGroup | null {
+    if (!elementId) return null;
+    if (groupCache.has(elementId)) return groupCache.get(elementId) ?? null;
+    const el = byId.get(elementId);
+    if (!el) {
+      groupCache.set(elementId, null);
+      return null;
+    }
+    let group: It4itCapabilityGroup | null = null;
+    if (el.kind === "capability_group") {
+      const name = el.name as It4itCapabilityGroup;
+      group = name;
+    } else {
+      group = resolveGroup(el.parentId);
+    }
+    groupCache.set(elementId, group);
+    return group;
+  }
+
+  // ── Aggregate evidence per capability group ──────────────────────────────────────────
+  const groupEvidence = new Map<It4itCapabilityGroup, GroupEvidence>();
+  function bumpGroup(group: It4itCapabilityGroup, key: keyof GroupEvidence, by = 1) {
+    const ev = groupEvidence.get(group) ?? emptyGroupEvidence();
+    ev[key] += by;
+    groupEvidence.set(group, ev);
+  }
+
+  const hygiene = { unknownStreamAgents: 0, legacyStreamAgents: 0, nullStreamAgents: 0 };
+
+  for (const agent of facts.agents) {
+    const raw = agent.valueStream;
+    if (!raw || !raw.trim()) {
+      hygiene.nullStreamAgents += 1;
+      continue;
+    }
+    if (IT4IT_LEGACY_STREAM_LABELS.has(raw.trim().toLowerCase())) {
+      hygiene.legacyStreamAgents += 1;
+    }
+    const normalized = normalizeIt4itEvidenceStream(raw);
+    if (!normalized) {
+      hygiene.unknownStreamAgents += 1;
+      continue;
+    }
+    const group = evidenceStreamToCapabilityGroup(raw);
+    if (group) bumpGroup(group, "agents");
+    // cross-cutting normalizes fine but maps to no group -> platform context only.
+  }
+
+  for (const cap of facts.capabilities) {
+    // De-duplicate group hits per capability: one capability counts once per group.
+    const groupsForCap = new Set<It4itCapabilityGroup>();
+    for (const stream of cap.it4itValueStreams) {
+      const group = evidenceStreamToCapabilityGroup(stream);
+      if (group) groupsForCap.add(group);
+    }
+    for (const group of groupsForCap) {
+      bumpGroup(group, "capabilities");
+      if (cap.hasBuiltTraceLink) bumpGroup(group, "capabilitiesWithBuilds");
+    }
+  }
+
+  // ── Component-level section evidence (agent it4itSections -> criteria sourceReference) ─
+  // Map each component to the set of section tokens carried by its criteria, then count how
+  // many agent sections cover any of them.
+  const agentSectionTokens: string[] = [];
+  for (const agent of facts.agents) {
+    for (const s of agent.it4itSections) {
+      const tok = extractSectionToken(s);
+      if (tok) agentSectionTokens.push(tok);
+    }
+  }
+  const criteriaByComponent = new Map<string, It4itElementFact[]>();
+  for (const el of facts.elements) {
+    if (el.kind === "criterion" && el.parentId) {
+      const arr = criteriaByComponent.get(el.parentId) ?? [];
+      arr.push(el);
+      criteriaByComponent.set(el.parentId, arr);
+    }
+  }
+  function sectionMatchesForComponent(componentId: string): number {
+    const criteria = criteriaByComponent.get(componentId) ?? [];
+    const compTokens = new Set<string>();
+    for (const c of criteria) {
+      const tok = extractSectionToken(c.sourceReference);
+      if (tok) compTokens.add(tok);
+    }
+    if (compTokens.size === 0) return 0;
+    let matches = 0;
+    for (const at of agentSectionTokens) {
+      for (const ct of compTokens) {
+        if (sectionCovers(at, ct) || sectionCovers(ct, at)) {
+          matches += 1;
+          break;
+        }
+      }
+    }
+    return matches;
+  }
+
+  // ── Per-component coverage ───────────────────────────────────────────────────────────
+  const existingByElement = new Map<string, It4itExistingAssessmentFact>();
+  for (const a of facts.existingAssessments) existingByElement.set(a.modelElementId, a);
+
+  const components: It4itComponentCoverage[] = [];
+  const writePlan: It4itWritePlanRow[] = [];
+  const gaps: It4itCoverageGap[] = [];
+  let preservedVerified = 0;
+
+  const componentEls = facts.elements.filter((e) => e.kind === "component");
+  for (const comp of componentEls) {
+    const group = resolveGroup(comp.id);
+    const ev = (group && groupEvidence.get(group)) || emptyGroupEvidence();
+    const sectionMatches = sectionMatchesForComponent(comp.id);
+    const { status, evidenceScore } = deriveComponentEvidence(ev, sectionMatches);
+    const score = evidenceScore;
+
+    const criteria = criteriaByComponent.get(comp.id) ?? [];
+    const requiredCriteriaCount = criteria.filter(
+      (c) => (c.normativeClass ?? "").toLowerCase() === "required",
+    ).length;
+
+    const evidenceSummary = JSON.stringify({
+      source: "it4it-coverage-projection",
+      capabilityGroup: group,
+      status,
+      evidenceScore,
+      evidence: {
+        agents: ev.agents,
+        capabilities: ev.capabilities,
+        capabilitiesWithBuilds: ev.capabilitiesWithBuilds,
+        sectionMatches,
+      },
+      method: EVIDENCE_SCORE_METHOD,
+    });
+    const rationale = `${PROJECTION_RATIONALE_PREFIX} ${status} for "${comp.name}" (group ${group ?? "n/a"}); agents=${ev.agents} capabilities=${ev.capabilities} built=${ev.capabilitiesWithBuilds} sections=${sectionMatches}`;
+
+    // No-clobber: skip component + its criteria rows the operator owns.
+    const compExisting = existingByElement.get(comp.id);
+    if (isProjectionWritable(compExisting)) {
+      writePlan.push({
+        modelElementId: comp.id,
+        kind: "component",
+        coverageStatus: status,
+        confidence: DERIVED_CONFIDENCE,
+        rationale,
+        evidenceSummary,
+      });
+    } else {
+      preservedVerified += 1;
+    }
+
+    for (const c of criteria) {
+      const cExisting = existingByElement.get(c.id);
+      if (!isProjectionWritable(cExisting)) {
+        preservedVerified += 1;
+        continue;
+      }
+      writePlan.push({
+        modelElementId: c.id,
+        kind: "criterion",
+        coverageStatus: status, // inherited
+        confidence: DERIVED_CONFIDENCE,
+        rationale: `${PROJECTION_RATIONALE_PREFIX} inherited ${status} from component "${comp.name}"`,
+        evidenceSummary,
+      });
+    }
+
+    components.push({
+      componentId: comp.id,
+      componentSlug: comp.slug,
+      componentName: comp.name,
+      capabilityGroup: group,
+      status,
+      score,
+      criteriaCount: criteria.length,
+      requiredCriteriaCount,
+      evidence: {
+        agents: ev.agents,
+        capabilities: ev.capabilities,
+        capabilitiesWithBuilds: ev.capabilitiesWithBuilds,
+        sectionMatches,
+      },
+    });
+
+    if (status === "not_started" && requiredCriteriaCount > 0) {
+      gaps.push({
+        componentId: comp.id,
+        componentSlug: comp.slug,
+        componentName: comp.name,
+        capabilityGroup: group,
+        requiredCriteriaCount,
+      });
+    }
+  }
+
+  // ── Rollups ──────────────────────────────────────────────────────────────────────────
+  // Weighted over the functional criteria (the criteria under components).
+  let platformNum = 0;
+  let platformDen = 0;
+  const groupAgg = new Map<It4itCapabilityGroup, { num: number; den: number; comps: number; withEv: number }>();
+
+  for (const comp of components) {
+    const statusValue = STATUS_ROLLUP_VALUE[comp.status];
+    if (statusValue === null) continue; // out_of_mvp excluded (not produced by v0 derivation)
+    const criteria = criteriaByComponent.get(comp.componentId) ?? [];
+    let compWeight = 0;
+    for (const c of criteria) compWeight += normativeWeight(c.normativeClass);
+    if (compWeight === 0) compWeight = normativeWeight(null); // component with no criteria still counts minimally
+    platformNum += statusValue * compWeight;
+    platformDen += compWeight;
+
+    if (comp.capabilityGroup) {
+      const g = groupAgg.get(comp.capabilityGroup) ?? { num: 0, den: 0, comps: 0, withEv: 0 };
+      g.num += statusValue * compWeight;
+      g.den += compWeight;
+      g.comps += 1;
+      if (comp.status !== "not_started") g.withEv += 1;
+      groupAgg.set(comp.capabilityGroup, g);
+    }
+  }
+
+  const platformScore = platformDen > 0 ? Math.round((platformNum / platformDen) * 100) : 0;
+
+  const groupRollups: It4itGroupRollup[] = [];
+  for (const [group, g] of groupAgg) {
+    const score = g.den > 0 ? Math.round((g.num / g.den) * 100) : 0;
+    const status: ReferenceCoverageStatus =
+      g.withEv === 0 ? "not_started" : g.withEv === g.comps && score >= 75 ? "implemented" : "partial";
+    groupRollups.push({
+      group,
+      status,
+      score,
+      componentCount: g.comps,
+      componentsWithEvidence: g.withEv,
+    });
+  }
+  groupRollups.sort((a, b) => a.group.localeCompare(b.group));
+
+  // ── Summary counts ───────────────────────────────────────────────────────────────────
+  let requiredImplemented = 0;
+  let requiredPartial = 0;
+  let requiredNotStarted = 0;
+  let componentsWithEvidence = 0;
+  for (const comp of components) {
+    if (comp.status !== "not_started") componentsWithEvidence += 1;
+    if (comp.status === "implemented") requiredImplemented += comp.requiredCriteriaCount;
+    else if (comp.status === "partial") requiredPartial += comp.requiredCriteriaCount;
+    else requiredNotStarted += comp.requiredCriteriaCount;
+  }
+
+  return {
+    components,
+    groupRollups,
+    platformScore,
+    writePlan,
+    preservedVerified,
+    gaps,
+    hygiene,
+    summary: {
+      componentsTotal: components.length,
+      componentsAssessed: components.length,
+      componentsWithEvidence,
+      requiredCriteriaTotal: requiredImplemented + requiredPartial + requiredNotStarted,
+      requiredCriteriaImplemented: requiredImplemented,
+      requiredCriteriaPartial: requiredPartial,
+      requiredCriteriaNotStarted: requiredNotStarted,
+    },
+    method: ROLLUP_METHOD,
+  };
+}

--- a/apps/web/lib/ea/it4it-crosswalk.test.ts
+++ b/apps/web/lib/ea/it4it-crosswalk.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeIt4itEvidenceStream,
+  evidenceStreamToCapabilityGroup,
+  extractSectionToken,
+  sectionCovers,
+  IT4IT_V3_STREAMS,
+  IT4IT_CAPABILITY_GROUPS,
+} from "./it4it-crosswalk";
+
+describe("normalizeIt4itEvidenceStream", () => {
+  it("passes through canonical v3 streams", () => {
+    for (const s of IT4IT_V3_STREAMS) {
+      expect(normalizeIt4itEvidenceStream(s)).toBe(s);
+    }
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(normalizeIt4itEvidenceStream("  Evaluate ")).toBe("evaluate");
+  });
+
+  it("normalizes legacy v2 labels to a v3 stream", () => {
+    expect(normalizeIt4itEvidenceStream("Strategy to Portfolio")).toBe("evaluate");
+    expect(normalizeIt4itEvidenceStream("Request to Deploy")).toBe("deploy");
+    expect(normalizeIt4itEvidenceStream("Requirement to Deploy")).toBe("integrate");
+  });
+
+  it("keeps governance and cross-cutting distinct", () => {
+    expect(normalizeIt4itEvidenceStream("governance")).toBe("governance");
+    expect(normalizeIt4itEvidenceStream("cross-cutting")).toBe("cross-cutting");
+    expect(normalizeIt4itEvidenceStream("cross cutting")).toBe("cross-cutting");
+  });
+
+  it("returns null for null, empty, and unknown labels", () => {
+    expect(normalizeIt4itEvidenceStream(null)).toBeNull();
+    expect(normalizeIt4itEvidenceStream("")).toBeNull();
+    expect(normalizeIt4itEvidenceStream("   ")).toBeNull();
+    expect(normalizeIt4itEvidenceStream("nonsense")).toBeNull();
+  });
+});
+
+describe("evidenceStreamToCapabilityGroup", () => {
+  it("maps the four delivery streams to their capability groups", () => {
+    expect(evidenceStreamToCapabilityGroup("evaluate")).toBe("Strategy to Portfolio");
+    expect(evidenceStreamToCapabilityGroup("explore")).toBe("Strategy to Portfolio");
+    expect(evidenceStreamToCapabilityGroup("integrate")).toBe("Requirement to Deploy");
+    expect(evidenceStreamToCapabilityGroup("deploy")).toBe("Requirement to Deploy");
+    expect(evidenceStreamToCapabilityGroup("release")).toBe("Requirement to Deploy");
+    expect(evidenceStreamToCapabilityGroup("consume")).toBe("Request to Fulfill");
+    expect(evidenceStreamToCapabilityGroup("operate")).toBe("Detect to Correct");
+  });
+
+  it("maps governance to Supporting Functions and cross-cutting to null", () => {
+    expect(evidenceStreamToCapabilityGroup("governance")).toBe("Supporting Functions");
+    expect(evidenceStreamToCapabilityGroup("cross-cutting")).toBeNull();
+  });
+
+  it("maps legacy labels through to the right group", () => {
+    expect(evidenceStreamToCapabilityGroup("Strategy to Portfolio")).toBe("Strategy to Portfolio");
+    expect(evidenceStreamToCapabilityGroup("Request to Deploy")).toBe("Requirement to Deploy");
+  });
+
+  it("returns null for unknown labels", () => {
+    expect(evidenceStreamToCapabilityGroup("nonsense")).toBeNull();
+  });
+
+  it("only ever returns a canonical capability group or null", () => {
+    const allowed = new Set<string | null>([...IT4IT_CAPABILITY_GROUPS, null]);
+    for (const s of [...IT4IT_V3_STREAMS, "governance", "cross-cutting", "bogus"]) {
+      expect(allowed.has(evidenceStreamToCapabilityGroup(s))).toBe(true);
+    }
+  });
+});
+
+describe("section helpers", () => {
+  it("extracts a dotted section token from messy references", () => {
+    expect(extractSectionToken("6.1.1")).toBe("6.1.1");
+    expect(extractSectionToken("section 6.1.1 Policy")).toBe("6.1.1");
+    expect(extractSectionToken("5.1.1-5.1.6")).toBe("5.1.1");
+    expect(extractSectionToken("Evaluate Value Stream")).toBeNull();
+    expect(extractSectionToken(null)).toBeNull();
+  });
+
+  it("treats a dotted prefix as covering, at dot boundaries only", () => {
+    expect(sectionCovers("6.1", "6.1.1")).toBe(true);
+    expect(sectionCovers("6.1.1", "6.1.1")).toBe(true);
+    expect(sectionCovers("6.1", "6.11")).toBe(false);
+    expect(sectionCovers("6.1.1", "6.1")).toBe(false);
+  });
+});

--- a/apps/web/lib/ea/it4it-crosswalk.ts
+++ b/apps/web/lib/ea/it4it-crosswalk.ts
@@ -1,0 +1,130 @@
+// apps/web/lib/ea/it4it-crosswalk.ts
+//
+// Canonical IT4IT crosswalk + evidence normalization for the coverage projection.
+// Two alignment languages are in use across DPF substrate:
+//   - IT4IT v3 stream slugs on capability tags + UI: evaluate/explore/integrate/
+//     deploy/release/consume/operate
+//   - Legacy/governance labels on the agent registry: "Strategy to Portfolio",
+//     "Request to Deploy", governance, cross-cutting, and null.
+// The functional CRITERIA are organized by the four v2 capability groups (+ Supporting
+// Functions); evidence is tagged with v3 streams. This module is the one place that
+// normalizes evidence streams and maps them to capability groups so v3-tagged evidence
+// can score v2-organized components.
+//
+// This crosswalk is a DPF modeling decision, NOT a substitute for the IT4IT standard.
+// It must be unit-tested and named in the UI when switching to the value-stream lens.
+// Spec: docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md (section 3).
+
+export const IT4IT_V3_STREAMS = [
+  "evaluate",
+  "explore",
+  "integrate",
+  "deploy",
+  "release",
+  "consume",
+  "operate",
+] as const;
+export type It4itV3Stream = (typeof IT4IT_V3_STREAMS)[number];
+
+// Coverage statuses already stored by the EA reference-model substrate. Centralized here
+// so callers share one source of truth; values are NOT renamed by this feature.
+export const IT4IT_REFERENCE_COVERAGE_STATUSES = [
+  "implemented",
+  "partial",
+  "planned",
+  "not_started",
+  "out_of_mvp",
+] as const;
+export type ReferenceCoverageStatus = (typeof IT4IT_REFERENCE_COVERAGE_STATUSES)[number];
+
+// Capability group names exactly as seeded in EaReferenceModelElement (kind=capability_group).
+export const IT4IT_CAPABILITY_GROUPS = [
+  "Strategy to Portfolio",
+  "Requirement to Deploy",
+  "Request to Fulfill",
+  "Detect to Correct",
+  "Supporting Functions",
+] as const;
+export type It4itCapabilityGroup = (typeof IT4IT_CAPABILITY_GROUPS)[number];
+
+// A normalized evidence stream is a v3 stream, or one of the two cross-cutting kinds that
+// agents carry but that are not themselves value streams.
+export type NormalizedEvidenceStream = It4itV3Stream | "governance" | "cross-cutting";
+
+// Free-text agent / capability stream label -> normalized token. Keys are lower-cased and
+// trimmed before lookup. Legacy v2 labels normalize to the v3 stream that lands them in the
+// correct capability group via IT4IT_V3_TO_CAPABILITY_GROUP. Unknown/empty -> null (the
+// caller raises a hygiene finding rather than silently inventing alignment).
+export const IT4IT_AGENT_VALUE_STREAM_NORMALIZATION: Record<string, NormalizedEvidenceStream> = {
+  evaluate: "evaluate",
+  explore: "explore",
+  integrate: "integrate",
+  deploy: "deploy",
+  release: "release",
+  consume: "consume",
+  operate: "operate",
+  governance: "governance",
+  "cross-cutting": "cross-cutting",
+  "cross cutting": "cross-cutting",
+  crosscutting: "cross-cutting",
+  // Legacy v2 labels observed live in agent_registry.json.
+  "strategy to portfolio": "evaluate",
+  "request to deploy": "deploy",
+  "requirement to deploy": "integrate",
+};
+
+// Is a raw label one of the known legacy/non-canonical forms (for hygiene reporting)?
+export const IT4IT_LEGACY_STREAM_LABELS = new Set([
+  "strategy to portfolio",
+  "request to deploy",
+  "requirement to deploy",
+]);
+
+export function normalizeIt4itEvidenceStream(
+  value: string | null | undefined,
+): NormalizedEvidenceStream | null {
+  if (!value) return null;
+  const key = value.trim().toLowerCase();
+  if (!key) return null;
+  return IT4IT_AGENT_VALUE_STREAM_NORMALIZATION[key] ?? null;
+}
+
+// Normalized stream -> capability group. cross-cutting maps to null: it is platform-wide
+// context, not evidence for one specific group, so it is excluded from group scoring.
+export const IT4IT_V3_TO_CAPABILITY_GROUP: Record<NormalizedEvidenceStream, It4itCapabilityGroup | null> = {
+  evaluate: "Strategy to Portfolio",
+  explore: "Strategy to Portfolio",
+  integrate: "Requirement to Deploy",
+  deploy: "Requirement to Deploy",
+  release: "Requirement to Deploy",
+  consume: "Request to Fulfill",
+  operate: "Detect to Correct",
+  governance: "Supporting Functions",
+  "cross-cutting": null,
+};
+
+// Map any raw evidence stream label to its capability group, or null when the label is
+// unknown (hygiene) or genuinely cross-cutting (not group-specific).
+export function evidenceStreamToCapabilityGroup(
+  value: string | null | undefined,
+): It4itCapabilityGroup | null {
+  const normalized = normalizeIt4itEvidenceStream(value);
+  if (!normalized) return null;
+  return IT4IT_V3_TO_CAPABILITY_GROUP[normalized];
+}
+
+// Pull a dotted-section token (e.g. "6.1.1") out of a free-text reference such as
+// "6.1.1", "section 6.1.1 Policy", or "5.1.1-5.1.6". Returns the first dotted number, or
+// null. Used to match agent it4itSections to a component's criteria sourceReferences.
+export function extractSectionToken(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const match = value.match(/\d+(?:\.\d+)+/);
+  return match ? match[0] : null;
+}
+
+// True when section `a` covers section `b` (equal, or a is a dotted prefix of b at a dot
+// boundary). "6.1" covers "6.1.1"; "6.1" does not cover "6.11".
+export function sectionCovers(a: string, b: string): boolean {
+  if (a === b) return true;
+  return b.startsWith(a + ".");
+}

--- a/apps/web/lib/ea/reconcile-it4it-coverage.ts
+++ b/apps/web/lib/ea/reconcile-it4it-coverage.ts
@@ -1,0 +1,220 @@
+// apps/web/lib/ea/reconcile-it4it-coverage.ts
+//
+// Steward shell for the IT4IT coverage projection (Parity Engine). Runtime-safe: reads the
+// seeded IT4IT reference model + live evidence (agents, business capabilities), calls the
+// pure builder, and upserts an evidence-derived coverage baseline into EaReferenceAssessment
+// on a platform scope. Re-derives every run, so the baseline cannot drift. Verified
+// operator/coworker rows are preserved (no-clobber). db injected for tests.
+//
+// Activates the previously dormant scoring path: EaReferenceAssessment had no create path in
+// the codebase (only a manual .update), so the table was empty in production. This is the
+// create/upsert path. No schema change — provenance uses the confidence + rationale-prefix
+// convention from the pure builder (spec section 1).
+//
+// Spec: docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md (sections 1, 4).
+
+import { prisma, type Prisma } from "@dpf/db";
+import type { SysmlSeedResult } from "./sysml-model-seed";
+import {
+  buildIt4itCoverageModel,
+  type It4itCoverageFacts,
+  type It4itElementFact,
+} from "./it4it-coverage-extract";
+
+const IT4IT_MODEL_SLUG = "it4it_v3_0_1";
+const PLATFORM_SCOPE_TYPE = "platform";
+const PLATFORM_SCOPE_REF = "dpf";
+const GAP_ISSUE_TYPE = "it4it-coverage-gap";
+const HYGIENE_ISSUE_TYPE = "it4it-evidence-hygiene";
+
+// Trace-link target types that count as built/operational evidence (vs a planned backlog item).
+const BUILT_TARGET_TYPES = new Set(["digitalProduct", "eaElement"]);
+
+type Db = typeof prisma;
+
+export async function reconcileIt4itCoverage(opts: { db?: Db } = {}): Promise<SysmlSeedResult> {
+  const db = opts.db ?? prisma;
+
+  const model = await db.eaReferenceModel.findUnique({
+    where: { slug: IT4IT_MODEL_SLUG },
+    select: { id: true },
+  });
+  if (!model) {
+    console.warn(`[it4it-coverage] IT4IT reference model "${IT4IT_MODEL_SLUG}" not seeded - skipping`);
+    return { status: "skipped", created: 0, updated: 0, removed: 0 };
+  }
+
+  // Ensure the platform assessment scope exists (the four portfolio scopes are seeded
+  // separately; platform is the headline "is the platform conformant" reading).
+  const scope = await db.eaAssessmentScope.upsert({
+    where: { scopeType_scopeRef: { scopeType: PLATFORM_SCOPE_TYPE, scopeRef: PLATFORM_SCOPE_REF } },
+    create: {
+      scopeType: PLATFORM_SCOPE_TYPE,
+      scopeRef: PLATFORM_SCOPE_REF,
+      name: "DPF Platform",
+      description: "Platform-wide IT4IT coverage baseline (evidence-derived).",
+    },
+    update: {},
+    select: { id: true },
+  });
+
+  const [elements, agents, capabilities, existing] = await Promise.all([
+    db.eaReferenceModelElement.findMany({
+      where: { modelId: model.id },
+      select: {
+        id: true,
+        kind: true,
+        slug: true,
+        name: true,
+        parentId: true,
+        normativeClass: true,
+        sourceReference: true,
+      },
+    }),
+    db.agent.findMany({
+      where: { archived: false },
+      select: { valueStream: true, it4itSections: true },
+    }),
+    db.businessCapability.findMany({
+      select: { it4itValueStreams: true, traceLinks: { select: { targetType: true } } },
+    }),
+    db.eaReferenceAssessment.findMany({
+      where: { scopeId: scope.id, modelId: model.id },
+      select: { modelElementId: true, coverageStatus: true, confidence: true, rationale: true },
+    }),
+  ]);
+
+  const facts: It4itCoverageFacts = {
+    elements: elements as It4itElementFact[],
+    agents: agents.map((a) => ({ valueStream: a.valueStream, it4itSections: a.it4itSections })),
+    capabilities: capabilities.map((c) => ({
+      it4itValueStreams: c.it4itValueStreams,
+      hasBuiltTraceLink: c.traceLinks.some((t) => BUILT_TARGET_TYPES.has(t.targetType)),
+    })),
+    existingAssessments: existing.map((e) => ({
+      modelElementId: e.modelElementId,
+      coverageStatus: e.coverageStatus,
+      confidence: e.confidence,
+      rationale: e.rationale,
+    })),
+  };
+
+  const coverage = buildIt4itCoverageModel(facts);
+
+  const existingIds = new Set(existing.map((e) => e.modelElementId));
+  let created = 0;
+  let updated = 0;
+  for (const row of coverage.writePlan) {
+    await db.eaReferenceAssessment.upsert({
+      where: { scopeId_modelElementId: { scopeId: scope.id, modelElementId: row.modelElementId } },
+      create: {
+        scopeId: scope.id,
+        modelId: model.id,
+        modelElementId: row.modelElementId,
+        coverageStatus: row.coverageStatus,
+        confidence: row.confidence,
+        rationale: row.rationale,
+        evidenceSummary: row.evidenceSummary,
+        mvpIncluded: true,
+      },
+      update: {
+        coverageStatus: row.coverageStatus,
+        confidence: row.confidence,
+        rationale: row.rationale,
+        evidenceSummary: row.evidenceSummary,
+      },
+    });
+    if (existingIds.has(row.modelElementId)) updated += 1;
+    else created += 1;
+  }
+
+  await reconcileConformanceIssues(db, coverage.gaps, coverage.hygiene);
+
+  const status: SysmlSeedResult["status"] = created + updated > 0 ? "applied" : "noop";
+  console.info(
+    `[it4it-coverage] reconcile ${status}: created=${created} updated=${updated} preserved=${coverage.preservedVerified} ` +
+      `platformScore=${coverage.platformScore}% componentsWithEvidence=${coverage.summary.componentsWithEvidence}/${coverage.summary.componentsTotal} gaps=${coverage.gaps.length}`,
+  );
+  return { status, created, updated, removed: 0 };
+}
+
+// Idempotently reconcile the it4it coverage-gap + evidence-hygiene conformance findings.
+// EaConformanceIssue has no unique key and cannot FK to a reference-model element, so we
+// match on a stable detailsJson.key and resolve issues that no longer apply.
+async function reconcileConformanceIssues(
+  db: Db,
+  gaps: ReturnType<typeof buildIt4itCoverageModel>["gaps"],
+  hygiene: ReturnType<typeof buildIt4itCoverageModel>["hygiene"],
+): Promise<void> {
+  type Desired = {
+    key: string;
+    issueType: string;
+    severity: string;
+    message: string;
+    detailsJson: Record<string, unknown>;
+  };
+
+  const desired: Desired[] = gaps.map((g) => ({
+    key: `gap:${g.componentSlug}`,
+    issueType: GAP_ISSUE_TYPE,
+    severity: "warn",
+    message: `IT4IT coverage gap: no evidence for functional component "${g.componentName}" (${g.capabilityGroup ?? "n/a"}); ${g.requiredCriteriaCount} required criteria uncovered.`,
+    detailsJson: {
+      key: `gap:${g.componentSlug}`,
+      componentSlug: g.componentSlug,
+      componentName: g.componentName,
+      capabilityGroup: g.capabilityGroup,
+      requiredCriteriaCount: g.requiredCriteriaCount,
+    },
+  }));
+
+  const hygieneTotal = hygiene.unknownStreamAgents + hygiene.nullStreamAgents + hygiene.legacyStreamAgents;
+  if (hygieneTotal > 0) {
+    desired.push({
+      key: "hygiene:agent-value-stream",
+      issueType: HYGIENE_ISSUE_TYPE,
+      severity: "info",
+      message: `IT4IT evidence hygiene: ${hygiene.legacyStreamAgents} legacy, ${hygiene.unknownStreamAgents} unknown, and ${hygiene.nullStreamAgents} unset agent value-stream labels weaken coverage attribution.`,
+      detailsJson: { key: "hygiene:agent-value-stream", ...hygiene },
+    });
+  }
+
+  const open = await db.eaConformanceIssue.findMany({
+    where: { issueType: { in: [GAP_ISSUE_TYPE, HYGIENE_ISSUE_TYPE] }, status: "open" },
+    select: { id: true, detailsJson: true },
+  });
+  const openByKey = new Map<string, string>();
+  for (const issue of open) {
+    const key = (issue.detailsJson as { key?: string } | null)?.key;
+    if (key) openByKey.set(key, issue.id);
+  }
+
+  const desiredKeys = new Set(desired.map((d) => d.key));
+
+  for (const d of desired) {
+    const existingId = openByKey.get(d.key);
+    if (existingId) {
+      await db.eaConformanceIssue.update({
+        where: { id: existingId },
+        data: { severity: d.severity, message: d.message, detailsJson: d.detailsJson as Prisma.InputJsonObject },
+      });
+    } else {
+      await db.eaConformanceIssue.create({
+        data: {
+          issueType: d.issueType,
+          severity: d.severity,
+          message: d.message,
+          status: "open",
+          detailsJson: d.detailsJson as Prisma.InputJsonObject,
+        },
+      });
+    }
+  }
+
+  // Resolve issues that are open but no longer desired (gap closed / hygiene cleared).
+  for (const [key, id] of openByKey) {
+    if (!desiredKeys.has(key)) {
+      await db.eaConformanceIssue.update({ where: { id }, data: { status: "resolved" } });
+    }
+  }
+}

--- a/apps/web/lib/ea/reconcile-sysml-projections.test.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.test.ts
@@ -33,11 +33,13 @@ describe("reconcileSysmlProjections", () => {
     expect(r.networkTopology.status).toBe("skipped"); // no EdgeNode/InventoryEntity rows
     expect(r.integrations.status).toBe("skipped"); // no IntegrationCredential rows
     expect(r.scheduledJobs.status).toBe("skipped"); // notation null -> applySysmlModel skips
+    expect(r.it4itCoverage.status).toBe("skipped"); // IT4IT reference model absent -> skips
     // mcp + coworker + routes + navigation + process + scheduling are notation-backed
-    // (all sysml2 except process=bpmn20); value-streams checks the reference model
-    // first; code-structure checks graph freshness first.
+    // (all sysml2 except process=bpmn20); value-streams + it4it-coverage check the
+    // reference model first; code-structure checks graph freshness first.
     expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(6);
-    expect(db.eaReferenceModel.findUnique).toHaveBeenCalledTimes(1);
+    // value-streams and it4it-coverage both look up the IT4IT reference model.
+    expect(db.eaReferenceModel.findUnique).toHaveBeenCalledTimes(2);
     expect(getFreshness).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -24,6 +24,7 @@ import { reconcileOperationalGraph } from "./reconcile-operational-bridge";
 import { reconcileNetworkTopology } from "./reconcile-network-bridge";
 import { reconcileIntegrations } from "./reconcile-integration-bridge";
 import { reconcileScheduledJobs } from "./reconcile-scheduled-jobs";
+import { reconcileIt4itCoverage } from "./reconcile-it4it-coverage";
 import type { SysmlSeedResult } from "./sysml-model-seed";
 
 export interface SysmlProjectionsResult {
@@ -43,6 +44,9 @@ export interface SysmlProjectionsResult {
   integrations: SysmlSeedResult;
   // Scheduling surface — all scheduled work, across substrates (EP-SCHEDULING-SURFACE).
   scheduledJobs: SysmlSeedResult;
+  // IT4IT conformance coverage — evidence-derived baseline vs the IT4IT functional
+  // criteria, persisted to EaReferenceAssessment (EP-IT4IT-CONFORMANCE).
+  it4itCoverage: SysmlSeedResult;
 }
 
 export async function reconcileSysmlProjections(
@@ -60,8 +64,9 @@ export async function reconcileSysmlProjections(
   const networkTopology = await reconcileNetworkTopology({ db: opts.db });
   const integrations = await reconcileIntegrations({ db: opts.db });
   const scheduledJobs = await reconcileScheduledJobs({ db: opts.db });
+  const it4itCoverage = await reconcileIt4itCoverage({ db: opts.db });
   return {
     mcpAuthority, coworkerAuthority, valueStreams, routes, navigation, codeStructure, processModels, skillToolchain,
-    operationalGraph, networkTopology, integrations, scheduledJobs,
+    operationalGraph, networkTopology, integrations, scheduledJobs, it4itCoverage,
   };
 }

--- a/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
@@ -1,0 +1,491 @@
+# IT4IT Conformance Coverage Heatmap Design
+
+- **Status:** Draft, architecture-reviewed
+- **Date:** 2026-06-24
+- **Reviewed:** 2026-06-25
+- **Epic:** EP-IT4IT-CONFORMANCE
+- **Primary audience:** Founder/operator, enterprise architecture reviewers, business-development partners, and implementation agents
+- **Authoring goal:** Measure DPF's current platform against the IT4IT functional criteria, establish a maintainable baseline, keep it current as functionality lands, and present the result as an elegant coverage heatmap using DPF's existing EA and report-kit primitives.
+- **Composes:** EP-PARITY-ENGINE, EP-ARCH-GRAPH-LIVE, EP-BOM-WIRING, the EA Reference-Model Assessment Foundation, and `2026-03-26-build-studio-it4it-value-stream-alignment-design.md`.
+
+## Executive Decision
+
+DPF already has the yardstick, the scoring table, the steward cadence, and the UI primitives. The design should therefore activate the existing architecture instead of creating an IT4IT-specific sidecar.
+
+**Decision:** Implement IT4IT coverage as a derived projection over live platform evidence, refreshed by the architecture parity steward, persisted into the existing `EaReferenceAssessment` table, and refined through an operator/coworker verified override layer.
+
+This is the right enterprise architecture shape because it keeps the baseline current without a manual scorecard, preserves human judgment where automated evidence is too coarse, and reuses DPF's existing EA substrate:
+
+- `EaReferenceModelElement` already stores the IT4IT model `it4it_v3_0_1`.
+- `EaReferenceAssessment` already stores coverage status, MVP inclusion, confidence, rationale, and evidence summary per assessment scope and model element.
+- `reconcile-sysml-projections.ts` already orchestrates drift-proof EA projections.
+- `/ea/models/[slug]` already owns reference-model detail, artifacts, element tree, value-stream projection action, and portfolio rollup.
+- `CapabilityMapTiles`, `deriveCapabilityOverlayState`, and report-kit `statusColors`, `StatCard`, `DataTable`, and `ExportButton` already provide the theme-aware UI building blocks.
+
+**Kernel decision:** `principle_decide` on 2026-06-25 recommended `derived-projection-with-verified-overrides` with composite `9.709`, margin `2.769`, high confidence, and no commandment conflict. Manual-only scoring failed maintainability and live-state requirements; derived-only scoring failed the honesty and human-verification requirements; a new IT4IT-specific model failed single-source-of-truth and schema-grounding requirements.
+
+## Business Value
+
+This feature is more than an internal architecture dashboard. It gives DPF a boardroom-safe answer to three buyer questions:
+
+- **Enterprise architecture credibility:** "Can you show how the platform maps to an industry operating-model standard?"
+- **Delivery assurance:** "Which areas are built, partial, planned, or intentionally out of scope, and what evidence supports that?"
+- **Partner and MSP enablement:** "Can a reseller or managed-services partner explain the platform's IT operating-model coverage without reading the whole codebase?"
+
+The output is a **coverage baseline**, not a certification claim. It should be usable in sales engineering, architecture review, implementation planning, and partner enablement, while staying honest enough that it never implies Open Group certification or formal conformance unless that process has actually happened.
+
+## Standards And Licensing Boundary
+
+The Open Group is the authority for IT4IT. Public Open Group pages describe IT4IT as a value-stream-based standard for digital business improvement and publish IT4IT certification paths and licensed downloads, including Version 3.0 and Version 3.0.1 license surfaces. DPF's implementation must treat the local workbook as a licensed/internal reference artifact, not as public marketing copy.
+
+Implementation rules:
+
+- The UI says **"IT4IT coverage baseline"** or **"IT4IT functional-criteria coverage"**, not "certified", "Open Group conformant", or "passed IT4IT".
+- Do not expose large excerpts of IT4IT text in public/customer-facing surfaces. Display local element names, section references, short criteria labels where license permits, and internal evidence summaries.
+- Before any external packaging, reseller material, public demo, or export that includes IT4IT criteria text, verify the applicable Open Group license and document the permission boundary.
+- Store source references and local element identifiers in DPF. Do not create a second public taxonomy file derived from the workbook.
+- If a formal conformance/certification claim is desired later, create a separate certification workstream with legal/licensing review and Open Group process evidence.
+
+Sources checked on 2026-06-25:
+
+- The Open Group IT4IT page: https://www.opengroup.org/it4it
+- IT4IT certification: https://www.opengroup.org/certifications/it4it
+- IT4IT Standard licensed downloads: https://www.opengroup.org/IT4IT/downloads
+- IT4IT Reference Architecture Version 3.0.1 evaluation license: https://www.opengroup.org/it4it/ra/license_eval
+- IT4IT Version 3.0 commercial license: https://www.opengroup.org/it4it/ra/license_comm
+
+## Verified Current Substrate
+
+Live substrate was checked on 2026-06-25 in the local DPF install and the target worktree.
+
+| Concern | Verified state | Implication |
+| --- | --- | --- |
+| IT4IT model | `EaReferenceModel` slug `it4it_v3_0_1` exists. | Use this as the canonical yardstick. |
+| Criteria tree | Live DB has 604 criteria, 35 components, 9 functions, 5 capability groups, 7 value streams, and 28 value-stream stages. | The standard structure is already queryable. |
+| Normativity | Criteria classes: 390 `required`, 34 `recommended`, 94 `optional`, 86 unset. | Rollups can weight required criteria without inventing metadata. |
+| Scoring table | `EaReferenceAssessment` has 0 rows live, including 0 IT4IT rows. | The baseline is unmeasured; an upsert/create path is required. |
+| Assessment scopes | `EaAssessmentScope` has 4 live rows. | Existing portfolio scopes should be reused; add or seed platform scope only if missing. |
+| Existing write path | `updateReferenceAssessment` uses `.update` by `assessmentId`. | Operators cannot initialize assessment rows today. Convert to upsert/create-capable flow. |
+| Existing read path | `getReferenceModelPortfolioRollup` reads criterion assessments by portfolio scope. | It will render useful data once assessments exist. |
+| EA element stream tags | `EaElement.itValueStream` is 0 of 2,579 populated. | Do not depend on this signal for v0 scoring; backfill as refactoring. |
+| Business capabilities | 28 of 28 `BusinessCapability` rows have `it4itValueStreams`. | Strong v0 evidence signal. |
+| Agent registry | Live `Agent.valueStream` values include the seven canonical streams, `governance`, `cross-cutting`, legacy labels `Strategy to Portfolio` and `Request to Deploy`, and one null. | Normalize explicitly; do not treat arbitrary strings as standards-aligned streams. |
+| UI primitives | `CapabilityMapTiles`, `CapabilityDetailPanel`, report-kit `statusColors`, `StatCard`, `DataTable`, and `ExportButton` exist. | Build an EA-native heatmap without a charting dependency. |
+
+The current baseline is therefore precise:
+
+**Recorded coverage today is 0 of 604 IT4IT criteria and 0 of 35 IT4IT functional components assessed.** DPF has the standard loaded, but no recorded measurement exists yet.
+
+## Gap
+
+The gap is not "we need an IT4IT model." The gap is that DPF has the model but no durable, self-refreshing assessment of the model against platform reality.
+
+Specific gaps:
+
+- No assessment rows are created for the existing IT4IT criteria or components.
+- The only assessment action is a manual `.update`, which assumes a row already exists.
+- No steward-owned projection turns live evidence into coverage statuses.
+- No no-clobber rule protects human-verified assessments from automated overwrites.
+- No canonical crosswalk normalizes v3 stream evidence, legacy v2 labels, governance, and cross-cutting values.
+- No UI distinguishes derived coverage from verified coverage.
+- No license guard prevents a useful internal standard view from becoming an accidental external conformance claim.
+- The richest EA signal, `EaElement.itValueStream`, is empty and needs refactoring/backfill before it can carry scoring weight.
+
+## Architecture
+
+### 1. Derived Projection Plus Verified Override
+
+```mermaid
+flowchart LR
+    yardstick["IT4IT reference model<br/>EaReferenceModelElement"]
+    evidence["Live DPF evidence<br/>agents, capabilities, portfolios,<br/>EA elements, products, builds"]
+    builder["buildIt4itCoverageModel<br/>pure extractor"]
+    reconcile["reconcileIt4itCoverage<br/>steward shell"]
+    assessments["EaReferenceAssessment<br/>coverage baseline"]
+    issues["EaConformanceIssue<br/>gaps and hygiene findings"]
+    ui["/ea/models/it4it_v3_0_1<br/>coverage heatmap"]
+    operator["Operator/coworker override<br/>verified evidence"]
+
+    yardstick --> builder
+    evidence --> builder
+    builder --> reconcile
+    reconcile --> assessments
+    reconcile --> issues
+    assessments --> ui
+    operator --> assessments
+```
+
+The projection owns derived rows. Operator and coworker reviews promote or correct rows to verified status. The projection must not overwrite verified rows.
+
+Because `EaReferenceAssessment` currently has `assessedById` rather than a projection-source field, implementation should start with a zero-schema convention:
+
+- `confidence = "derived"` for steward-owned rows.
+- `rationale` begins with a stable prefix such as `it4it-coverage-projection:` for steward-owned rows.
+- `evidenceSummary` stores compact JSON or structured prose listing evidence IDs and rollup method.
+- `confidence = "verified"` or `"high"` identifies operator/coworker-confirmed rows.
+- The projection updates only rows with the steward prefix or derived confidence.
+
+If implementation proves this convention too brittle, add a tiny provenance field to `EaReferenceAssessment` in the same PR that proves the need. Do not start with a new table.
+
+### 2. Unit Of Measure Honesty
+
+Automated evidence is component-grained, not criterion-grained. The system must avoid pretending that a value-stream tag proves every normative "shall" criterion under a component.
+
+Automated scoring rules:
+
+- **Primary automated unit:** IT4IT functional component.
+- **Inherited criterion status:** Criteria inherit the component status at `confidence = "derived"` until reviewed.
+- **Verified criterion status:** An operator or coworker can set a specific criterion with higher confidence and evidence.
+- **No data:** Render as `not_started` or neutral, never as a failing red or passing green.
+- **No certification score:** Rollups are "evidence-derived coverage", not conformance certification.
+
+Existing coverage statuses are:
+
+- `implemented`
+- `partial`
+- `planned`
+- `not_started`
+- `out_of_mvp`
+
+Those values already exist in `apps/web/lib/actions/ea.ts`, `apps/web/lib/explore/ea-data.ts`, and `apps/web/components/ea/ReferenceModelPortfolioTable.tsx`. The implementation should centralize them into one shared module if it touches more than one surface, but it should not rename stored values in this feature.
+
+Suggested transparent rollup:
+
+```text
+status value:
+implemented = 1.00
+partial = 0.50
+planned = 0.25
+not_started = 0.00
+out_of_mvp = excluded from denominator
+
+normative weight:
+required = 2.00
+recommended = 1.00
+optional = 0.50
+unset = 0.50
+
+score = sum(status_value * normative_weight) / sum(normative_weight)
+```
+
+The formula must be shown in the drill-down or export metadata so an enterprise architect can understand and challenge the number.
+
+### 3. Crosswalk And Normalization
+
+DPF has two alignment languages in use:
+
+- IT4IT v3 stream language in UI and capability tags: `evaluate`, `explore`, `integrate`, `deploy`, `release`, `consume`, `operate`.
+- Legacy or governance labels in agent registry: `Strategy to Portfolio`, `Request to Deploy`, `governance`, `cross-cutting`, and null.
+
+Create one canonical module, for example `apps/web/lib/ea/it4it-crosswalk.ts`, that exports:
+
+- `IT4IT_V3_STREAMS`
+- `IT4IT_REFERENCE_COVERAGE_STATUSES`
+- `IT4IT_AGENT_VALUE_STREAM_NORMALIZATION`
+- `IT4IT_V3_TO_CAPABILITY_GROUP`
+- `normalizeIt4itEvidenceStream(value)`
+
+Initial crosswalk:
+
+| Evidence value | Capability group mapping |
+| --- | --- |
+| `evaluate`, `explore`, `Strategy to Portfolio` | Strategy to Portfolio |
+| `integrate`, `deploy`, `release`, `Request to Deploy` | Requirement to Deploy |
+| `consume` | Request to Fulfill |
+| `operate` | Detect to Correct |
+| `governance`, `cross-cutting`, null | Supporting Functions or cross-cutting evidence only |
+
+The crosswalk is a DPF modeling decision, not a substitute for the IT4IT standard. It must be unit-tested and named in the UI when the user switches from the functional-component view to the value-stream lens.
+
+### 4. Extractor And Reconcile
+
+Add a pure extractor and a thin reconcile shell in the existing EA projection pattern.
+
+Proposed files:
+
+- `apps/web/lib/ea/it4it-coverage-extract.ts`
+- `apps/web/lib/ea/it4it-crosswalk.ts`
+- `apps/web/lib/ea/reconcile-it4it-coverage.ts`
+- Tests beside each file.
+
+`buildIt4itCoverageModel(facts)` is pure and deterministic. It accepts:
+
+- IT4IT model elements for `it4it_v3_0_1`.
+- Current `EaAssessmentScope` rows.
+- Agent value-stream and IT4IT section tags.
+- Business capability IT4IT stream tags and trace links.
+- Portfolio IT4IT references.
+- Existing assessments, so verified rows are preserved.
+- Optional `EaElement.itValueStream` evidence when populated.
+
+It returns:
+
+- Platform-wide component rollups.
+- Portfolio-scoped component and criterion rollups.
+- Criterion inherited statuses.
+- Evidence lists.
+- Gap and hygiene findings.
+- A no-clobber write plan.
+
+`reconcileIt4itCoverage({ db })` performs IO:
+
+- Ensure a platform assessment scope exists, for example `scopeType = "platform"` and `scopeRef = "dpf"`.
+- Read live facts.
+- Call the pure builder.
+- Upsert assessment rows by existing unique key `[scopeId, modelElementId]`.
+- Preserve verified rows.
+- File or update `EaConformanceIssue` rows for required coverage gaps and evidence hygiene.
+- Return a `SysmlSeedResult`-shaped summary.
+
+Register the reconcile in `apps/web/lib/ea/reconcile-sysml-projections.ts` so it runs with the existing architecture parity steward. Do not create a new scheduler.
+
+### 5. Heatmap UX
+
+Primary home: `/ea/models/it4it_v3_0_1`.
+
+The first viewport should remain an EA reference-model page, not a dashboard or marketing landing page. Add a new section after the reference-model element tree and before the existing portfolio table:
+
+**IT4IT Functional Coverage**
+
+Controls:
+
+- Segmented control: `By component` and `By value stream`.
+- Scope selector: `Platform` and existing portfolio scopes.
+- Toggle: `Derived` / `Verified` / `All`.
+- Export CSV button.
+
+Summary strip:
+
+- `Components assessed`: `n/35`
+- `Required criteria covered`: `n/390`
+- `Verified assessments`: `n`
+- `Open coverage gaps`: `n`
+
+Heatmap:
+
+- Reuse the nested capability-map visual language.
+- Band = capability group.
+- Tile = functional component.
+- Fill/tone = `coverageStatus` mapped through report-kit status intent.
+- Intensity = transparent rollup score.
+- Badge = `derived` or `verified`.
+- No-data tile = neutral with clear copy, not red.
+
+Drill-down:
+
+- Click a component to open a right rail.
+- Show criteria with `normativeClass`, status, confidence, source reference, last updated, and evidence summary.
+- Include "Promote to verified" / "Correct assessment" action for users with `manage_ea_model`.
+- Use report-kit `DataTable` for criteria rows.
+
+Secondary surfaces:
+
+- Add only a compact card on the EA/platform overview after the heatmap exists.
+- Do not add a new global nav item.
+- Do not place raw IT4IT criteria in the workspace home.
+
+Accessibility and visual design:
+
+- Use `statusColors` only; no raw hex.
+- Every tile has visible text and an accessible label.
+- Color is never the only signal; status text and confidence badge are always present.
+- Stable tile dimensions prevent layout shift.
+- Empty state says: "No IT4IT assessments have been generated yet. Run architecture parity refresh to establish the baseline." Authorized users get the refresh action; others get read-only context.
+
+### 6. Business-Development Output
+
+The heatmap should support one export and one narrative view:
+
+- **CSV export:** one row per component or criterion with scope, status, confidence, score, normative class, evidence count, and source references.
+- **Architecture review brief:** generated copy block that says what is covered, what is partial, what is planned, and where evidence is missing.
+
+The brief must include this disclaimer:
+
+```text
+This is a DPF evidence-derived IT4IT coverage baseline. It is not an Open Group certification or formal conformance claim.
+```
+
+This lets business development use the output responsibly in enterprise conversations without overselling it.
+
+## Research And Benchmarking
+
+### Standards
+
+- **The Open Group IT4IT:** Adopt the standard as the reference architecture and use the local seeded model as DPF's canonical internal yardstick. Reject copying or republishing criteria text beyond the license boundary.
+- **Open Group certification model:** Adopt the distinction between internal learning/assessment and formal certification. Reject any UI wording that implies certification without process evidence.
+
+### Open-source and open-source-adjacent comparators
+
+- **Backstage community Tech Insights:** Adopts facts plus checks plus scorecards for software catalog health. DPF adopts the "facts drive checks" pattern, but stores evidence on EA assessments rather than adding a second catalog.
+- **DataHub Assertions and Data Health Dashboard:** Uses assertions and data-health views to monitor coverage and quality from live metadata. DPF adopts the assertion-style evidence trail and coverage trend idea; rejects a data-platform-specific substrate.
+- **OpenMetadata Data Quality:** Uses tests and quality workflows to monitor completeness, freshness, and accuracy. DPF adopts "quality as code" discipline for deterministic extractor tests; rejects a separate quality-tool workflow for IT4IT.
+
+### Commercial comparators
+
+- **SAP LeanIX Business Capability Map:** Strong benchmark for capability maps, three-level capability hierarchy, and technology-to-business alignment. DPF adopts the grouped heatmap idiom and keeps the hierarchy shallow; rejects survey-only maturity as the source of truth.
+- **Ardoq Capability Maturity:** Strong benchmark for capability maturity as a business-case and improvement-planning artifact. DPF adopts maturity as a planning conversation, but distinguishes maturity from evidence-derived IT4IT coverage.
+- **Atlassian Compass scorecards:** Useful benchmark for weighted criteria and component health. DPF adopts visible weighted criteria, but avoids a generic "health score" headline that would hide standard-specific gaps.
+- **Spotify Soundcheck/Tech Insights:** Useful benchmark for leadership-facing, real-time filtering, hierarchy, summary tiles, and drill-down. DPF adopts progressive disclosure from summary to details.
+
+## Refactoring Allocation
+
+Allocate approximately 20 percent of implementation effort to refactoring and substrate hygiene before adding UI breadth. The refactor is not optional polish; it is what keeps the heatmap from becoming a brittle demo.
+
+Refactoring tasks:
+
+- Centralize reference coverage statuses in one shared module.
+- Add and test `it4it-crosswalk.ts`.
+- Normalize agent value-stream evidence, including legacy labels and null.
+- Backfill or steward `EaElement.itValueStream` so EA elements can become a real scoring signal.
+- Convert `updateReferenceAssessment` from update-only to create/upsert-capable behavior.
+- Add no-clobber assessment ownership helpers.
+- Add license-safe display helpers for IT4IT labels and references.
+- Add tests for empty evidence, derived evidence, verified override, status normalization, and export rows.
+
+## Phasing
+
+### Phase 0 - Substrate And Refactor
+
+- Add shared constants for coverage statuses and IT4IT stream normalization.
+- Add platform scope seeding/upsert.
+- Add create/upsert assessment helper.
+- Add no-clobber helper for derived versus verified rows.
+- Add license-safe display helpers.
+- Tests: constants, normalization, upsert, no-clobber.
+
+### Phase 1 - Projection
+
+- Implement `buildIt4itCoverageModel`.
+- Implement `reconcileIt4itCoverage`.
+- Register in `reconcile-sysml-projections.ts`.
+- Persist platform and portfolio assessments.
+- File `EaConformanceIssue` for required gaps and hygiene findings.
+- Tests: idempotency, first-run baseline creation, verified-row preservation, no-data neutral, crosswalk correctness.
+
+### Phase 2 - Heatmap
+
+- Add `it4itCoverage` domain to report-kit `STATUS_INTENT`.
+- Add an IT4IT coverage view model for `/ea/models/[slug]`.
+- Add nested-tile heatmap section for `it4it_v3_0_1`.
+- Add summary strip, scope selector, confidence filter, drill-down rail, and CSV export.
+- Tests: render empty state, render populated state, confidence badges, no raw colors, CSV output.
+
+### Phase 3 - Override UX
+
+- Add create/correct/promote actions behind `manage_ea_model`.
+- Record evidence/rationale and confidence.
+- Make projection preserve verified rows.
+- Tests: authorization, create new row, promote derived row, preserve verified row after reconcile.
+
+### Phase 4 - Business And Partner Artifact
+
+- Add compact overview card after the heatmap exists.
+- Add architecture review brief export with disclaimer.
+- Add product/partner documentation that explains the baseline without reproducing standard text.
+
+### Optional Phase 5 - Participation Matrix
+
+- Build a reusable report-kit `CoverageGrid` if the nested-tile view does not satisfy value-stream-stage by functional-component analysis.
+- Use the workbook participation matrix only inside the license boundary.
+
+## Acceptance Criteria
+
+- A fresh install with the IT4IT model loaded can create a platform assessment baseline without manual seed rows.
+- Re-running the steward pass is idempotent.
+- Verified operator/coworker assessments are not overwritten by the projection.
+- The heatmap renders all 35 functional components with stable dimensions, labels, status, and confidence.
+- Empty evidence renders neutral and is never treated as implemented.
+- The rollup formula is visible in the UI or export metadata.
+- CSV export includes status, confidence, scope, normative class, evidence count, and source reference.
+- UI uses report-kit/statusColors and DPF tokens only.
+- No public/customer-facing surface claims certification or republishes IT4IT standard text beyond the verified license boundary.
+- Tests cover extractor math, status normalization, no-clobber behavior, empty state, populated state, and CSV export.
+
+## Verification Plan
+
+Docs-only review:
+
+- Markdown file has no non-ASCII characters.
+- Markdown file has no trailing whitespace.
+- The spec references existing substrate paths and live DB counts checked on 2026-06-25.
+
+Implementation PR:
+
+- `pnpm --filter web exec vitest run` for affected unit tests.
+- `pnpm --filter web build`.
+- UX verification on `/ea/models/it4it_v3_0_1` at desktop and mobile widths.
+- Live or shared local-CI steward pass evidence showing assessment rows created and second pass idempotent.
+- Manual verification that a verified override survives a subsequent steward pass.
+- Accessibility check that color is not the only status signal.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Automated evidence overclaims conformance. | Use component-grained derived scoring, confidence labels, and verified overrides. |
+| IT4IT licensing is accidentally violated. | Add explicit license-safe display helpers and public wording guardrails. |
+| Manual correction gets clobbered by the steward. | Add no-clobber helper and tests before projection write logic. |
+| The heatmap becomes a vanity score. | Lead with counts, gaps, confidence, and evidence; avoid a single "maturity percent" hero. |
+| Agent value-stream labels pollute scoring. | Normalize through one tested crosswalk; unknown values become hygiene findings. |
+| `EaElement.itValueStream` remains empty. | Treat it as refactoring/backfill, not a v0 scoring dependency. |
+| The page becomes crowded. | Put summary, heatmap, and drill-down on the IT4IT model page; use progressive disclosure and no new global nav. |
+
+## UX Fit Decision
+
+Owning route: `/ea/models/it4it_v3_0_1`.
+
+Persona fit:
+
+- Enterprise architect: needs traceable criteria, evidence, confidence, and export.
+- Founder/operator: needs an honest baseline and gaps without reading the taxonomy.
+- Business-development partner: needs a responsible proof artifact and disclaimer.
+- Build/EA steward: needs deterministic refresh and explainable gaps.
+
+Surface fit:
+
+- The IT4IT model detail page already owns artifacts, reference elements, and portfolio coverage. The heatmap belongs there.
+- The EA overview can get a compact card later, but it should link into the model page.
+- Workspace home should not carry raw IT4IT details.
+
+UI fit:
+
+- Report-kit and capability-map primitives are the design system.
+- Summary first, heatmap second, criteria drill-down third.
+- Derived versus verified confidence is visible on every assessment.
+- No raw hex, no decorative chart library, no new dashboard shell.
+
+## Open Questions
+
+- Should platform scope be `scopeType = "platform", scopeRef = "dpf"` or should it reuse an existing organization/install identifier? Default to `platform/dpf` unless implementation finds a canonical scope key.
+- Should `confidence` use `derived`, `verified`, and `high`, or should the implementation preserve existing free-text confidence and add a separate provenance field? Default to no schema change first.
+- How much IT4IT text can be shown in internal-only UI under the current workbook/license? Implementation must verify before exposing long criteria text outside the internal model detail page.
+- Should the first projection initialize all criteria rows or only component rows plus inherited criteria on read? Default to persisted criterion rows for rollup compatibility, but keep inherited confidence explicit.
+
+## Source Notes
+
+External sources checked:
+
+- The Open Group IT4IT: https://www.opengroup.org/it4it
+- IT4IT certification: https://www.opengroup.org/certifications/it4it
+- IT4IT licensed downloads: https://www.opengroup.org/IT4IT/downloads
+- SAP LeanIX business capability map: https://www.leanix.net/en/sap-leanix-business-capability-map
+- Roadie Backstage Tech Insights: https://roadie.io/docs/tech-insights/introduction/
+- Backstage community Tech Insights search result and backend docs: https://github.com/backstage/community-plugins/tree/main/workspaces/tech-insights
+- Spotify Soundcheck Tech Insights: https://backstage.spotify.com/docs/plugins/soundcheck/core-concepts/tech-insights
+- Atlassian Compass scorecards: https://support.atlassian.com/compass/docs/what-are-scorecards/
+- Ardoq capability maturity: https://help.ardoq.com/en/articles/43921-introduction-to-capability-maturity
+- DataHub assertions and data health: https://docs.datahub.com/docs/managed-datahub/observe/assertions and https://docs.datahub.com/docs/managed-datahub/observe/data-health-dashboard
+- OpenMetadata data quality: https://docs.open-metadata.org/v1.12.x/how-to-guides/data-quality-observability/quality
+
+Local substrate checked:
+
+- `packages/db/prisma/schema.prisma`
+- `packages/db/src/seed-ea-reference-models.ts`
+- `apps/web/lib/actions/ea.ts`
+- `apps/web/lib/explore/ea-data.ts`
+- `apps/web/lib/ea/reconcile-sysml-projections.ts`
+- `apps/web/lib/business-capabilities/types.ts`
+- `apps/web/lib/business-capabilities/view-model.ts`
+- `apps/web/components/portfolio/architecture/CapabilityMapTiles.tsx`
+- `apps/web/components/ui/report-kit/statusColors.ts`
+- `apps/web/app/(shell)/ea/models/[slug]/page.tsx`


### PR DESCRIPTION
## Keystone of EP-IT4IT-CONFORMANCE

DPF already seeds the full **IT4IT v3.0.1 functional-criteria taxonomy** (688 elements / 604 criteria) into `EaReferenceModelElement`, but the `EaReferenceAssessment` scoring table had **no create path anywhere in the codebase** (only a manual `.update`), so coverage was unmeasured — **0 rows in production, the gap invisible**. This PR activates the measurement as a drift-proof projection on the existing architecture-parity steward cadence, plus an operator override convention.

### What changed
- **`it4it-crosswalk.ts`** — canonical v3-stream ↔ v2-capability-group crosswalk + evidence normalization (legacy `Strategy to Portfolio` / `Request to Deploy`, `governance`, `cross-cutting`, null agent labels). Unit-tested.
- **`it4it-coverage-extract.ts`** — pure, deterministic `buildIt4itCoverageModel(facts)`. Joins the seeded criteria tree with live evidence (agents' `valueStream` + `it4itSections`, business-capability stream tags + trace links) into a **transparent evidence score → coverage status** per functional component; criteria inherit at `confidence=derived`. Emits a no-clobber write plan that preserves operator-verified rows.
- **`reconcile-it4it-coverage.ts`** — steward shell. Ensures a `platform`/`dpf` assessment scope, reads facts, **upserts `EaReferenceAssessment` (the create path the table never had)**, files `EaConformanceIssue` for coverage gaps + evidence hygiene. Registered in `reconcile-sysml-projections.ts` → runs on the existing steward pass (no new scheduler).

### Honesty discipline
Component-grained (not fabricated per-criterion), no-data = neutral/not_started (never green), `confidence=derived` until an operator verifies. **No schema change** — provenance uses a `confidence` + rationale-prefix convention (spec §1).

### Baseline computed on live data
54% platform coverage (status-weighted); 4 components implemented (Strategy-to-Portfolio, where agents carry direct section evidence), 31 partial; 3 legacy + 1 null agent labels flagged as hygiene. Two evidence signals confirmed empty (`EaElement.itValueStream` 0/2,579; capability built trace links 0/28) → addressed by follow-on BI-B431D1D1.

### Verification
- ✅ **Unit tests:** 28 vitest pass (`it4it-crosswalk` 12, `it4it-coverage-extract` 13, `architecture-parity-steward` 3).
- ✅ **Typecheck:** `pnpm --filter web typecheck` clean.
- ✅ **Builder validated on live data** (real 688-element tree + 82 agents + 28 capabilities) — deterministic, idempotent, no-clobber.
- ⏳ **`next build` + the live steward write** are CI / canonical-install gated (this worktree is source-only; per AGENTS.md §5 these are unrun-not-red here). No migration (no schema change).

### Scope
This is the keystone (Phase 0 + 1). The heatmap UI (BI-03B950CC), operator override UX (BI-25066DD8), executive card (BI-BDA1A04F), evidence hygiene + EaElement backfill (BI-B431D1D1), and optional 2-D CoverageGrid (BI-D51A5A4A) are follow-on items. No UI changed here (pure lib + projection).

Spec: `docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md`
Epic: `EP-IT4IT-CONFORMANCE` · Item: `BI-A05FD3ED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)