### PR TITLE
feat(obs): close EP-FULL-OBS coverage gaps (BI-573438C1/963DBB05/264565A4/994B504C)

### DIFF
--- a/apps/web/app/api/metrics/route.ts
+++ b/apps/web/app/api/metrics/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { metricsRegistry } from "@/lib/metrics";
 import { refreshVoiceTtsMetrics } from "@/lib/voice-synthesis/service-status";
+import { refreshDependencyMetrics } from "@/lib/operate/dependency-health";
 
 // Force dynamic: each scrape must reflect current state, and we refresh
 // point-in-time health gauges below before serializing.
@@ -10,7 +11,7 @@ export async function GET() {
   // Refresh point-in-time service-health gauges (dpf_voice_tts_up/_enabled)
   // before serializing so a down /health-only sidecar (which can't be its own
   // scrape target) is visible to Prometheus. Fully guarded internally.
-  await refreshVoiceTtsMetrics();
+  await Promise.all([refreshVoiceTtsMetrics(), refreshDependencyMetrics()]);
 
   const metrics = await metricsRegistry.metrics();
   return new NextResponse(metrics, {

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -805,6 +805,28 @@ export async function enqueueFirstBootEvals(providerId: string): Promise<{
   }
 }
 
+/**
+ * Next.js global error hook — fires for every unhandled server-side error.
+ * Counts them into dpf_http_unhandled_errors_total{route,method} so the
+ * UnhandledServerErrors alert can fire. The portal has no per-request HTTP
+ * instrumentation, so this is the zero-route-change global error signal.
+ * [BI-994B504C]
+ */
+export async function onRequestError(
+  _error: unknown,
+  request: { path?: string; method?: string },
+  context: { routePath?: string },
+): Promise<void> {
+  try {
+    const { httpUnhandledErrors } = await import("@/lib/metrics");
+    const route = context?.routePath || request?.path || "unknown";
+    const method = request?.method || "unknown";
+    httpUnhandledErrors.labels(route, method).inc();
+  } catch {
+    /* never let metrics bookkeeping interfere with error reporting */
+  }
+}
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs" && process.env.NEXT_PHASE !== "phase-production-build") {
     // Fire the deprecation warning up front so operators see it on first
@@ -828,6 +850,18 @@ export async function register() {
       const { assertDbContinuityOnBoot } = await import("@/lib/operate/db-continuity");
       await assertDbContinuityOnBoot();
     }
+
+    // Voice-service desired-state fail-loud (BI-264565A4): if narration is
+    // enabled but the TTS sidecar is down, log CRITICAL at boot — Prometheus
+    // can't scrape a /health-only sidecar, and this beats the VoiceServiceDown
+    // alert's scrape+2m delay. Non-fatal; detection only (self-heal is a
+    // separate follow-up).
+    void (async () => {
+      const { assertVoiceServiceOnBoot } = await import(
+        "@/lib/operate/voice-service-continuity"
+      );
+      await assertVoiceServiceOnBoot();
+    })();
 
     // Self-heal a quiescence level left stuck by a swap that killed the
     // coordinator mid-protocol — otherwise the portal refuses gated requests

--- a/apps/web/lib/operate/dependency-health.test.ts
+++ b/apps/web/lib/operate/dependency-health.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  probeNeo4j,
+  probeModelRunner,
+  probeStt,
+  refreshDependencyMetrics,
+} from "./dependency-health"
+import { dependencyUp } from "@/lib/metrics"
+
+async function gaugeValue(service: string): Promise<number | undefined> {
+  const m = await dependencyUp.get()
+  return m.values.find((v) => v.labels.service === service)?.value
+}
+
+describe("dependency-health probes", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it("probeNeo4j hits the neo4j HTTP API and returns true on 200", async () => {
+    global.fetch = vi.fn(async () => new Response("ok", { status: 200 })) as typeof fetch
+    expect(await probeNeo4j()).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://neo4j:7474/",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it("probeStt hits the Speaches /v1/models endpoint", async () => {
+    global.fetch = vi.fn(async () => new Response("[]", { status: 200 })) as typeof fetch
+    expect(await probeStt()).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://dpf-stt:9000/v1/models",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it("probeModelRunner probes the local /models list", async () => {
+    global.fetch = vi.fn(async () => new Response("{}", { status: 200 })) as typeof fetch
+    expect(await probeModelRunner()).toBe(true)
+    const calledUrl = vi.mocked(global.fetch).mock.calls[0]?.[0]
+    expect(String(calledUrl)).toMatch(/\/models$/)
+  })
+
+  it("returns false when a probe is unreachable", async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED")
+    }) as typeof fetch
+    expect(await probeNeo4j()).toBe(false)
+  })
+
+  it("refreshDependencyMetrics sets dpf_dependency_up for every service", async () => {
+    global.fetch = vi.fn(async () => new Response("ok", { status: 200 })) as typeof fetch
+    await refreshDependencyMetrics()
+    expect(await gaugeValue("neo4j")).toBe(1)
+    expect(await gaugeValue("model-runner")).toBe(1)
+    expect(await gaugeValue("stt")).toBe(1)
+
+    global.fetch = vi.fn(async () => {
+      throw new Error("down")
+    }) as typeof fetch
+    await refreshDependencyMetrics()
+    expect(await gaugeValue("neo4j")).toBe(0)
+    expect(await gaugeValue("model-runner")).toBe(0)
+    expect(await gaugeValue("stt")).toBe(0)
+  })
+})

--- a/apps/web/lib/operate/dependency-health.ts
+++ b/apps/web/lib/operate/dependency-health.ts
@@ -1,0 +1,63 @@
+// Liveness probes for core dependencies that expose NO Prometheus /metrics
+// endpoint, so they cannot be scrape targets and `ContainerDown` (up==0) can
+// never see them: neo4j (graph DB), the local model runner (DMR), and STT
+// (Speaches). Sets the dpf_dependency_up{service} gauge, refreshed on each
+// /api/metrics scrape. Mirrors the TTS probe in
+// lib/voice-synthesis/service-status.ts (BI-B2E777EB). [BI-963DBB05]
+
+import { dependencyUp } from "@/lib/metrics"
+import { getOllamaBaseUrl } from "@/lib/inference/ollama-url"
+
+const PROBE_TIMEOUT_MS = 3000
+
+async function probe(url: string): Promise<boolean> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** neo4j exposes no Prometheus metrics; community edition serves an HTTP API on 7474. */
+export async function probeNeo4j(): Promise<boolean> {
+  return probe(process.env.NEO4J_HTTP_URL ?? "http://neo4j:7474/")
+}
+
+/** Local model runner (DMR / Ollama) — probe the OpenAI-compatible /models list. */
+export async function probeModelRunner(): Promise<boolean> {
+  return probe(`${getOllamaBaseUrl().replace(/\/$/, "")}/models`)
+}
+
+/** STT (Speaches) exposes /v1/models but no Prometheus metrics. */
+export async function probeStt(): Promise<boolean> {
+  const base = (process.env.STT_BASE_URL ?? "http://dpf-stt:9000").replace(/\/$/, "")
+  return probe(`${base}/v1/models`)
+}
+
+const SERVICES: Array<readonly [string, () => Promise<boolean>]> = [
+  ["neo4j", probeNeo4j],
+  ["model-runner", probeModelRunner],
+  ["stt", probeStt],
+]
+
+/**
+ * Refresh dpf_dependency_up{service} for every /metrics-less core dependency.
+ * Fully guarded — never throws, so a probe hiccup cannot break the /api/metrics
+ * scrape. Probes run in parallel with a short timeout each.
+ */
+export async function refreshDependencyMetrics(): Promise<void> {
+  await Promise.all(
+    SERVICES.map(async ([service, fn]) => {
+      try {
+        dependencyUp.labels(service).set((await fn()) ? 1 : 0)
+      } catch {
+        dependencyUp.labels(service).set(0)
+      }
+    }),
+  )
+}

--- a/apps/web/lib/operate/metrics.ts
+++ b/apps/web/lib/operate/metrics.ts
@@ -364,6 +364,27 @@ export const voiceTtsEnabled = new Gauge({
   registers: [metricsRegistry],
 });
 
+// --- Dependency health (BI-963DBB05) ---
+// /metrics-less core services (neo4j, model-runner, stt) probed per /api/metrics
+// scrape by lib/operate/dependency-health.ts. up==0 => unreachable. These cannot
+// be Prometheus scrape targets, so ContainerDown (up==0) can never see them.
+export const dependencyUp = new Gauge({
+  name: "dpf_dependency_up",
+  help: "1 when a /metrics-less core dependency is reachable, 0 when down. Labelled by service (neo4j | model-runner | stt).",
+  labelNames: ["service"] as const,
+  registers: [metricsRegistry],
+});
+
+// --- Unhandled server errors (BI-994B504C) ---
+// Incremented by the Next.js onRequestError instrumentation hook — the global,
+// zero-route-change error signal (the portal has no per-request HTTP wrapper yet).
+export const httpUnhandledErrors = new Counter({
+  name: "dpf_http_unhandled_errors_total",
+  help: "Unhandled server errors caught by the Next.js onRequestError hook, labelled by route + method.",
+  labelNames: ["route", "method"] as const,
+  registers: [metricsRegistry],
+});
+
 // ─── Voice Slice 2 — Transcript Cleanup ─────────────────────────────────────
 // Spec: docs/superpowers/specs/2026-05-16-voice-input-and-transcription-design.md §9
 

--- a/apps/web/lib/operate/voice-service-continuity.test.ts
+++ b/apps/web/lib/operate/voice-service-continuity.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/voice-synthesis/service-status", () => ({
+  isVoiceNarrationEnabled: vi.fn(),
+  resolveTtsServiceUp: vi.fn(),
+}))
+
+import { isVoiceNarrationEnabled, resolveTtsServiceUp } from "@/lib/voice-synthesis/service-status"
+import { assertVoiceServiceOnBoot } from "./voice-service-continuity"
+
+describe("assertVoiceServiceOnBoot", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("no-ops (no CRITICAL) when narration is not enabled", async () => {
+    vi.mocked(isVoiceNarrationEnabled).mockResolvedValue(false)
+    const logger = { log: vi.fn(), error: vi.fn() }
+    const r = await assertVoiceServiceOnBoot(logger)
+    expect(r).toEqual({ enabled: false, up: true })
+    expect(resolveTtsServiceUp).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it("logs CRITICAL when narration is enabled but the sidecar is down", async () => {
+    vi.mocked(isVoiceNarrationEnabled).mockResolvedValue(true)
+    vi.mocked(resolveTtsServiceUp).mockResolvedValue({
+      provider: "chatterbox",
+      up: false,
+      reason: "The text-to-speech service is not running.",
+    })
+    const logger = { log: vi.fn(), error: vi.fn() }
+    const r = await assertVoiceServiceOnBoot(logger)
+    expect(r).toEqual({ enabled: true, up: false })
+    expect(logger.error).toHaveBeenCalledTimes(1)
+    expect(logger.error.mock.calls[0][0]).toMatch(/CRITICAL/)
+  })
+
+  it("stays quiet when narration is enabled and the sidecar is up", async () => {
+    vi.mocked(isVoiceNarrationEnabled).mockResolvedValue(true)
+    vi.mocked(resolveTtsServiceUp).mockResolvedValue({ provider: "chatterbox", up: true, reason: null })
+    const logger = { log: vi.fn(), error: vi.fn() }
+    const r = await assertVoiceServiceOnBoot(logger)
+    expect(r).toEqual({ enabled: true, up: true })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/lib/operate/voice-service-continuity.ts
+++ b/apps/web/lib/operate/voice-service-continuity.ts
@@ -1,0 +1,36 @@
+// Boot-time desired-state check for the voice (TTS) service. [BI-264565A4]
+//
+// A /health-only sidecar cannot be a Prometheus scrape target, and a profile-
+// gated sidecar that is enabled in config but never actuated is invisible — the
+// 2026-06-24 incident, where voice was dead for ~a month while the page showed
+// "ready". This mirrors db-continuity's fail-loud pattern: if narration is
+// enabled but the sidecar is unreachable AT BOOT, log CRITICAL immediately
+// (before the first Prometheus scrape + the VoiceServiceDown alert's 2m wait).
+// Non-fatal. Self-healing (auto-starting the sidecar) needs host exec and is a
+// separate follow-up — this is the detection/fail-loud half.
+
+export async function assertVoiceServiceOnBoot(
+  logger: Pick<Console, "log" | "error"> = console,
+): Promise<{ enabled: boolean; up: boolean } | null> {
+  try {
+    const { isVoiceNarrationEnabled, resolveTtsServiceUp } = await import(
+      "@/lib/voice-synthesis/service-status"
+    )
+    const enabled = await isVoiceNarrationEnabled()
+    if (!enabled) return { enabled: false, up: true }
+
+    const status = await resolveTtsServiceUp()
+    if (!status.up) {
+      logger.error(
+        `[voice-continuity] CRITICAL: voice narration is enabled but the TTS service (${status.provider}) is unreachable: ${status.reason ?? "down"}. ` +
+          `WWMD narration and voice previews will fail until the dpf-tts sidecar is running.`,
+      )
+    } else {
+      logger.log("[voice-continuity] voice narration enabled and TTS service reachable")
+    }
+    return { enabled: true, up: status.up }
+  } catch (err) {
+    logger.error("[voice-continuity] boot check failed (non-fatal):", err)
+    return null
+  }
+}

--- a/docs/operations/observability-coverage.md
+++ b/docs/operations/observability-coverage.md
@@ -1,0 +1,68 @@
+# Observability Coverage
+
+What the Prometheus/Grafana stack actually monitors, where the gaps are, and which
+alert fires on which platform. Written after the 2026-06-24 review ("doesn't
+Prometheus catch this?") that found a down voice sidecar — and ~9 of 17 alerts —
+were silently unmonitored. Epic: **EP-FULL-OBS**.
+
+## The core principle (why outages were missed)
+
+Prometheus alerts on **"a known scrape target went down"** (`up == 0`), not on
+**"a service that should exist is absent."** The `up` series exists only for
+configured scrape targets, so:
+
+- A service with **no `/metrics` endpoint** can't be a scrape target → `ContainerDown`
+  (`up == 0`) can never see it.
+- A service **enabled in config but never instantiated** produces no series at all →
+  nothing to alert on.
+
+The fix pattern for `/metrics`-less services: the **portal probes them** and exports
+the result as a gauge on its own `/api/metrics` (already a scrape target), plus a
+boot-time fail-loud for desired-state drift.
+
+## Scrape targets
+
+`monitoring/prometheus/prometheus.yml` scrapes: `portal`, `sandbox`, `postgres`
+(exporter), `redis` (exporter), `qdrant`, `inngest`, `loki`, `alloy`, `windows-host`
+(windows_exporter), `prometheus`. **Not scrapeable** (no `/metrics`): `dpf-tts`,
+`dpf-stt`, `neo4j`, the model runner (DMR) — covered by portal-side probes below.
+
+## Portal-side health gauges (`/api/metrics`, refreshed per scrape)
+
+| Gauge | Source | Alert |
+| --- | --- | --- |
+| `dpf_voice_tts_up` / `dpf_voice_tts_enabled` | `lib/voice-synthesis/service-status.ts` | `VoiceServiceDown` (enabled && down) |
+| `dpf_dependency_up{service="neo4j"}` | `lib/operate/dependency-health.ts` | `Neo4jDown` |
+| `dpf_dependency_up{service="model-runner"}` | same | gauge only (see follow-ups) |
+| `dpf_dependency_up{service="stt"}` | same | gauge only (see follow-ups) |
+| `dpf_http_unhandled_errors_total` | `instrumentation.ts` `onRequestError` | `UnhandledServerErrors` |
+
+## Platform split — Linux vs Windows host/infra alerts
+
+The `dpf_infrastructure` Container*/Host* rules key on **cAdvisor (`container_*`)**
+and **node-exporter (`node_*`)**, both gated behind the `linux-monitoring` compose
+profile — so on the **Windows GA host they collect nothing and never fire**. The
+`dpf_windows_host` group mirrors the Host CPU/mem/disk rules using **windows_exporter
+(`windows_*`)** series, which the `windows-host` job already scrapes. Linux installs
+keep the `node_*` rules; Windows installs get the `windows_*` rules.
+
+## Known follow-ups (deliberately not yet done)
+
+- **HTTP latency / error-ratio** (`HighRequestLatency`, `HighErrorRate`) need
+  per-request timing+status instrumentation (`dpf_http_request_duration_seconds`,
+  `dpf_http_requests_total` are *defined* in `lib/operate/metrics.ts` but never
+  `.observe()`d). A route wrapper rollout is the remaining half of **BI-994B504C**;
+  `UnhandledServerErrors` (via `onRequestError`) is the zero-route-change interim.
+- **model-runner / stt ServiceDown alerts** — gauges ship now; alerting is gated on
+  install-type detection (a cloud install has no local model runner), to avoid
+  cross-install false positives. Follow-up under EP-FULL-OBS.
+- **Per-container restart/CPU/memory on Windows** — needs a cAdvisor-equivalent for
+  WSL2 (e.g. an alloy cadvisor exporter); a deployment-doctrine decision.
+- **TTS/voice self-heal at boot** — `assertVoiceServiceOnBoot` (BI-264565A4) is
+  detection/fail-loud only; auto-starting the sidecar needs host exec.
+
+## Alert delivery
+
+Prometheus has no Alertmanager here; firing alerts reach the portal via the Inngest
+poll-bridge (`apps/web/lib/queue/functions/alert-delivery-bridge.ts`) and surface in
+the System Health UI. The Grafana dashboard UI is opt-in (`observability-ui` profile).

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -106,6 +106,16 @@ groups:
         annotations:
           summary: "Qdrant vector DB is unreachable -- AI Coworker memory offline"
 
+      # neo4j exposes no Prometheus metrics, so it cannot be a scrape target;
+      # the portal probes its HTTP API and exports dpf_dependency_up{service}. [BI-963DBB05]
+      - alert: Neo4jDown
+        expr: dpf_dependency_up{service="neo4j"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Neo4j graph DB is unreachable -- code graph + architecture views offline"
+
   - name: dpf_application
     rules:
       - alert: HighRequestLatency
@@ -159,6 +169,18 @@ groups:
           summary: "Voice narration enabled but the TTS service is down"
           description: "A voice profile has narration enabled but the text-to-speech sidecar (dpf-tts) is unreachable -- WWMD decision narration and voice previews will fail."
 
+      # Global unhandled-error signal via the Next.js onRequestError hook (the
+      # portal has no per-request HTTP instrumentation). NOTE: HighRequestLatency
+      # / HighErrorRate above additionally need per-request timing+status wiring
+      # (a route wrapper) to go live -- the remaining half of BI-994B504C.
+      - alert: UnhandledServerErrors
+        expr: sum(rate(dpf_http_unhandled_errors_total[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Portal is throwing unhandled server errors (sustained > 3/min)"
+
       # ─── Log Aggregation (EP-FULL-OBS Tier 2) ──────────────────
       # Loki drops lines when a container floods stdout past the per-stream
       # rate cap (disk-safety). A throttle is itself a strong "something is
@@ -172,3 +194,44 @@ groups:
           severity: warning
         annotations:
           summary: "Loki is dropping logs -- a container is flooding stdout past the rate cap"
+
+  # ─── Windows Host Resources (windows_exporter) ─────────────────
+  # The dpf_infrastructure Host* rules key on node_exporter (node_*) metrics,
+  # which are NOT collected on Windows (node-exporter is linux-monitoring-
+  # profiled). windows_exporter IS scraped (job windows-host) but no rule used
+  # it -- so host CPU/mem/disk on the Windows GA platform had ZERO alerting.
+  # These mirror the node_* rules using windows_* series; Linux installs keep
+  # the node_* rules. [BI-573438C1]
+  - name: dpf_windows_host
+    rules:
+      - alert: WindowsHostHighCPU
+        expr: 100 - (avg(rate(windows_cpu_time_total{mode="idle"}[5m])) * 100) > 85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Windows host CPU above 85% for 10 minutes"
+
+      - alert: WindowsHostHighMemory
+        expr: (1 - windows_memory_available_bytes / windows_cs_physical_memory_bytes) * 100 > 85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Windows host memory above 85%"
+
+      - alert: WindowsHostDiskPressure
+        expr: (1 - windows_logical_disk_free_bytes{volume=~"[A-Z]:"} / windows_logical_disk_size_bytes{volume=~"[A-Z]:"}) * 100 > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Windows host disk {{ $labels.volume }} above 80%"
+
+      - alert: WindowsHostDiskCritical
+        expr: (1 - windows_logical_disk_free_bytes{volume=~"[A-Z]:"} / windows_logical_disk_size_bytes{volume=~"[A-Z]:"}) * 100 > 90
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Windows host disk {{ $labels.volume }} above 90% -- immediate attention required"


### PR DESCRIPTION
Closes the monitoring blind spots from the "doesn't Prometheus catch this?" review — **~9 of 17 alerts were dead on the Windows host**, and several core services were unmonitored. Four BIs, one bundle so it can be self-upgraded and tested together. Full map: `docs/operations/observability-coverage.md`.

## BI-573438C1 — Windows host alerts were dead
`Container*`/`Host*` rules key on cAdvisor (`container_*`) + node-exporter (`node_*`), both `linux-monitoring`-profiled and absent on Windows; `windows_exporter` was scraped but **no rule used it**. New `dpf_windows_host` group (CPU/mem/disk via `windows_*`). Linux installs keep the `node_*` rules.

## BI-963DBB05 — /metrics-less services unmonitored
neo4j / model-runner / STT can't be scrape targets. New `dpf_dependency_up{service}` gauge (portal-side probe, `lib/operate/dependency-health.ts`, refreshed per `/api/metrics` scrape) + **`Neo4jDown`** alert. model-runner/STT ship as gauges now; their alerts are gated on install-type (follow-up) to avoid false positives on cloud installs.

## BI-264565A4 — boot-time fail-loud
`lib/operate/voice-service-continuity.ts` (wired into `instrumentation.register`): if narration is enabled but the TTS sidecar is down, log **CRITICAL** at boot — Prometheus can't scrape a `/health`-only sidecar, and this beats the alert's scrape+2m delay.

## BI-994B504C — unhandled-error signal
Global server errors now counted via Next's `onRequestError` hook (`dpf_http_unhandled_errors_total`) + **`UnhandledServerErrors`** alert — zero route-path risk. The ratio/latency alerts (`HighErrorRate`/`HighRequestLatency`) still need a per-request timing+status wrapper; that rollout is the documented remaining half (best done with live verification, not blind from a source-only worktree).

## Verification
Source-only worktree (no node_modules) → **CI is the gate** (typecheck, build, unit tests, Spec/Doc). Unit tests added for both new modules. No new route (manifest unchanged). gitleaks clean pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
