### PR TITLE
feat(patch-mgmt): patch-intelligence core (EP-PATCH-MANAGEMENT P0 slice 1)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
+++ b/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
@@ -1,0 +1,56 @@
+# Estate Patch Management — P0 implementation plan
+
+- **Date:** 2026-06-25
+- **Status:** In progress (slice 1 landed)
+- **Spec:** `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`
+- **Epic:** `EP-PATCH-MANAGEMENT`
+- **Backlog:** BI-CAA0043C (version-intel feed), BI-489A8BB4 (assessment projector), BI-676A7960 (identity convergence), BI-020EE402 (posture UX)
+
+This plan sequences the **read-only P0 wedge** — estate patch posture with zero execution risk — built locally (not Build Studio, per operator direction). It deliberately starts with pure, unit-testable logic and defers the high-stakes schema migration until the existing identity substrate is mapped.
+
+## Substrate corrections discovered while planning (verify-first)
+
+These reshaped the sequence and are recorded so the next session does not re-derive them:
+
+1. **No `CatalogIdentity` model exists.** The `2026-04-18-lifecycle-evidence-specialist-design.md` spec proposes it, but what actually landed is a *device-oriented* fingerprint subsystem: `DiscoveryFingerprintRule`, `DiscoveryFingerprintCatalogVersion`, `DiscoveryFingerprintObservation`, `DiscoveryFingerprintReview` (`packages/db/prisma/schema.prisma:3642–3731`, migration `20260425113500_discovery_fingerprint_foundation`). The canonical *software*-identity spine is genuinely unbuilt and **intersects** this subsystem — so the identity-convergence slice must map it first, not invent a parallel model.
+2. **`DiscoveredSoftwareEvidence.softwareIdentityId` (`schema.prisma:3633`) is still a dangling `String?`** with no relation — confirmed live.
+3. **The worktree is source-only** (no `node_modules`). Per AGENTS.md §5, targeted unit tests run source-local once deps are installed; runtime-bound gates (Prisma migrate, `next build`, UX) route through the shared local-CI sandbox lease or the canonical install. A blind, immutable-after-commit identity migration is therefore **not** the right first slice.
+
+## Slices (ordered, value-early)
+
+### Slice 1 — Patch-intelligence core (this PR)
+`packages/db/src/patch/patch-intel.ts` (+ `.test.ts`). Pure, prisma-free, no new dependency (a small self-contained semver comparator — DPF has no `semver` dep and we are not adding one). Provides:
+- `compareVersions` / `parseVersion` — semver-ish comparison that returns `"unknown"` for non-semver OS strings rather than guessing.
+- `assessPatchState` — classifies a `(host, software)` pair into `vulnerability | end-of-life | patch-gap | none` with precedence advisories → EOL → behind → none; **CISA KEV escalates severity and routes urgently**; emits the `remediationHint` shape (`targetVersion`, `applyVia`, `rebootLikely`, `cisaKev`, `confidence`).
+
+This is the shared brain for both BI-CAA0043C and BI-489A8BB4 and is independently verifiable.
+
+### Slice 2 — Version-intelligence adapters → feed (BI-CAA0043C)
+Adapter interfaces + implementations that produce `assessPatchState` inputs, each gated by the Tool Evaluation Pipeline before embed:
+- `osv` adapter — generalize the existing npm OSV usage (`scripts/sbom/scan-dependencies.mjs`) to all ecosystems incl. OS packages and container images; returns advisories with `fixedVersion`.
+- `cisa-kev` adapter — KEV catalog membership for CVE ids.
+- `native-manager` adapter — the Edge Node's on-host "installed → available" output (`winget show`, `apt-cache policy`, `dnf check-update`, `brew outdated`).
+- `eol` adapter — end-of-life dates.
+Scheduled projector entry in `SCHEDULED_JOB_CATALOG`.
+
+### Slice 3 — Assessment projector → AssuranceFinding (BI-489A8BB4)
+For each in-use `(InventoryEntity, DiscoveredSoftwareEvidence)`, run `assessPatchState` and upsert `AssuranceFinding` rows (`findingKind` ∈ patch-gap|vulnerability|end-of-life; `adapterKey` patch-intel|osv|cisa-kev|native-manager; `vendorIdentifier` = primary advisory; `remediationHint` JSON; `acceptedUntil` preserved). **No new findings table** — composes the Assurance Ledger (`schema.prisma:4968`). Carries a coverage metric so missing inventory is not read as clean.
+
+### Slice 4 — Identity convergence (BI-676A7960) — gated
+Map the `DiscoveryFingerprint*` subsystem first; decide whether the software-identity spine extends it or lands a focused `CatalogIdentity` + `SoftwarePatchProfile`. Then the reviewable migration for `softwareIdentityId` (rename→`legacy…` + add `catalogIdentityId`, or drop-with-evidence) per the lifecycle-evidence spec §7.4. Runs through Prisma in the sandbox/canonical install, never blind. Until then, slice 3 keys findings on `DiscoveredSoftwareEvidence`/`InventoryEntity` directly.
+
+### Slice 5 — Posture read model + MCP tool + UX (BI-020EE402)
+`list_patch_posture` MCP tool (capped/paginated/provenance-free) and the `/ops/patches` surface composed from report-kit (`StatusBadge`/`DataTable`/`StatCard`), with the "needs you" items routing to the Attention Surface. Carries the UX-Fit attestation.
+
+## Verification
+
+- **Slice 1:** `pnpm --filter @dpf/db exec vitest run src/patch/patch-intel.test.ts` (source-local; deps installed in-worktree, or via the local-CI sandbox lease).
+- **Slices 2–3:** unit tests for adapters/projector; projector integration verified against a leased nonprod environment (writes real `AssuranceFinding` rows).
+- **Slice 4:** migration apply/rollback evidence via the sandbox/canonical install — not the worktree.
+- **Slice 5:** `next build` + UX exercise of `/ops/patches` via the canonical install per AGENTS.md §13.
+
+## Risks
+
+- Identity convergence touching the live `DiscoveryFingerprint*` subsystem — mitigated by the mapping pass in slice 4 and keeping slices 1–3 identity-agnostic.
+- OSV/native coverage gaps for niche apps — surfaced as low-confidence `none`/`patch-gap`, never a false-clean.
+- Source-only worktree limits local runtime gates — routed to the sandbox per doctrine.

--- a/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
+++ b/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
@@ -1,7 +1,7 @@
 # Estate Patch Management — P0 implementation plan
 
 - **Date:** 2026-06-25
-- **Status:** In progress (slice 1 landed)
+- **Status:** In progress (slice 1 + OSV/KEV advisory extractors landed)
 - **Spec:** `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`
 - **Epic:** `EP-PATCH-MANAGEMENT`
 - **Backlog:** BI-CAA0043C (version-intel feed), BI-489A8BB4 (assessment projector), BI-676A7960 (identity convergence), BI-020EE402 (posture UX)
@@ -27,11 +27,11 @@ This is the shared brain for both BI-CAA0043C and BI-489A8BB4 and is independent
 
 ### Slice 2 — Version-intelligence adapters → feed (BI-CAA0043C)
 Adapter interfaces + implementations that produce `assessPatchState` inputs, each gated by the Tool Evaluation Pipeline before embed:
-- `osv` adapter — generalize the existing npm OSV usage (`scripts/sbom/scan-dependencies.mjs`) to all ecosystems incl. OS packages and container images; returns advisories with `fixedVersion`.
-- `cisa-kev` adapter — KEV catalog membership for CVE ids.
-- `native-manager` adapter — the Edge Node's on-host "installed → available" output (`winget show`, `apt-cache policy`, `dnf check-update`, `brew outdated`).
-- `eol` adapter — end-of-life dates.
-Scheduled projector entry in `SCHEDULED_JOB_CATALOG`.
+- **`osv` adapter — LANDED (pure):** `packages/db/src/patch/osv-adapter.ts` turns OSV vuln objects into `AdvisoryInput` (severity band, lowest fixed version, CVE/GHSA aliases), generalized beyond npm to any ecosystem. Mirrors the proven shape in `scripts/sbom/scan-dependencies.mjs`.
+- **`cisa-kev` adapter — LANDED (pure):** `parseKevCatalog` + KEV enrichment in `osvVulnToAdvisory` mark an advisory exploited when its CVE alias is in the catalog.
+- `native-manager` adapter — the Edge Node's on-host "installed → available" output (`winget show`, `apt-cache policy`, `dnf check-update`, `brew outdated`). **Remaining — depends on the Edge Node software-inventory capability.**
+- `eol` adapter — end-of-life dates. **Remaining.**
+- Live fetch (OSV `querybatch` + `/vulns/{id}`, KEV catalog download) + scheduled projector entry in `SCHEDULED_JOB_CATALOG`. **Remaining — runtime-bound, verified via the sandbox.**
 
 ### Slice 3 — Assessment projector → AssuranceFinding (BI-489A8BB4)
 For each in-use `(InventoryEntity, DiscoveredSoftwareEvidence)`, run `assessPatchState` and upsert `AssuranceFinding` rows (`findingKind` ∈ patch-gap|vulnerability|end-of-life; `adapterKey` patch-intel|osv|cisa-kev|native-manager; `vendorIdentifier` = primary advisory; `remediationHint` JSON; `acceptedUntil` preserved). **No new findings table** — composes the Assurance Ledger (`schema.prisma:4968`). Carries a coverage metric so missing inventory is not read as clean.

--- a/packages/db/src/patch/osv-adapter.test.ts
+++ b/packages/db/src/patch/osv-adapter.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { assessPatchState } from "./patch-intel";
+import {
+  mapOsvSeverity,
+  osvAliases,
+  osvFixedVersion,
+  osvVulnsToAdvisories,
+  osvVulnToAdvisory,
+  parseKevCatalog,
+  type OsvVuln,
+} from "./osv-adapter";
+
+const VULN: OsvVuln = {
+  id: "GHSA-aaaa-bbbb-cccc",
+  aliases: ["CVE-2026-1234"],
+  summary: "Prototype pollution in left-pad",
+  database_specific: { severity: "HIGH" },
+  affected: [
+    {
+      package: { ecosystem: "npm", name: "left-pad" },
+      ranges: [{ type: "SEMVER", events: [{ introduced: "0" }, { fixed: "1.3.0" }] }],
+    },
+  ],
+};
+
+describe("mapOsvSeverity", () => {
+  it("maps GHSA bands, translating moderate -> medium", () => {
+    expect(mapOsvSeverity({ id: "x", database_specific: { severity: "CRITICAL" } })).toBe("critical");
+    expect(mapOsvSeverity({ id: "x", database_specific: { severity: "High" } })).toBe("high");
+    expect(mapOsvSeverity({ id: "x", database_specific: { severity: "MODERATE" } })).toBe("medium");
+    expect(mapOsvSeverity({ id: "x", database_specific: { severity: "low" } })).toBe("low");
+  });
+
+  it("returns null when only a CVSS vector is present", () => {
+    expect(mapOsvSeverity({ id: "x", severity: [{ type: "CVSS_V3", score: "CVSS:3.1/AV:N" }] })).toBeNull();
+    expect(mapOsvSeverity({ id: "x" })).toBeNull();
+  });
+});
+
+describe("osvAliases", () => {
+  it("extracts CVE and GHSA ids including the vuln id", () => {
+    expect(osvAliases(VULN)).toEqual({ cve: ["CVE-2026-1234"], ghsa: ["GHSA-aaaa-bbbb-cccc"] });
+  });
+});
+
+describe("osvFixedVersion", () => {
+  it("returns the fixed version for the matching package", () => {
+    expect(osvFixedVersion(VULN, "npm", "left-pad")).toBe("1.3.0");
+  });
+
+  it("filters by ecosystem and name", () => {
+    expect(osvFixedVersion(VULN, "Debian", "left-pad")).toBeNull();
+    expect(osvFixedVersion(VULN, "npm", "right-pad")).toBeNull();
+  });
+
+  it("returns the lowest of multiple fixed events", () => {
+    const multi: OsvVuln = {
+      id: "OSV-1",
+      affected: [
+        {
+          package: { ecosystem: "npm", name: "pkg" },
+          ranges: [
+            { events: [{ introduced: "0" }, { fixed: "2.0.5" }] },
+            { events: [{ introduced: "1.0.0" }, { fixed: "1.4.9" }] },
+          ],
+        },
+      ],
+    };
+    expect(osvFixedVersion(multi, "npm", "pkg")).toBe("1.4.9");
+  });
+
+  it("returns null when no fix is published", () => {
+    expect(osvFixedVersion({ id: "x", affected: [{ ranges: [{ events: [{ introduced: "0" }] }] }] })).toBeNull();
+  });
+});
+
+describe("osvVulnToAdvisory", () => {
+  it("prefers the CVE id and maps severity + fixed version", () => {
+    const adv = osvVulnToAdvisory(VULN, { ecosystem: "npm", packageName: "left-pad" });
+    expect(adv).toEqual({
+      id: "CVE-2026-1234",
+      severity: "high",
+      fixedVersion: "1.3.0",
+      cisaKev: false,
+    });
+  });
+
+  it("marks cisaKev when a CVE alias is in the KEV set", () => {
+    const kev = new Set(["CVE-2026-1234"]);
+    const adv = osvVulnToAdvisory(VULN, { ecosystem: "npm", packageName: "left-pad", kevCves: kev });
+    expect(adv.cisaKev).toBe(true);
+  });
+
+  it("falls back to GHSA then OSV id when no CVE alias exists", () => {
+    expect(osvVulnToAdvisory({ id: "GHSA-zzzz" }).id).toBe("GHSA-zzzz");
+    expect(osvVulnToAdvisory({ id: "OSV-2026-9" }).id).toBe("OSV-2026-9");
+  });
+});
+
+describe("parseKevCatalog", () => {
+  it("builds a CVE id set from the catalog", () => {
+    const set = parseKevCatalog({
+      vulnerabilities: [{ cveID: "CVE-2026-1234" }, { cveID: "CVE-2025-0001" }, {}],
+    });
+    expect(set.has("CVE-2026-1234")).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it("tolerates a missing or empty catalog", () => {
+    expect(parseKevCatalog(null).size).toBe(0);
+    expect(parseKevCatalog({}).size).toBe(0);
+  });
+});
+
+describe("compose: OSV advisories -> classifier", () => {
+  it("an OSV vuln in the KEV catalog drives an urgent vulnerability verdict", () => {
+    const kev = parseKevCatalog({ vulnerabilities: [{ cveID: "CVE-2026-1234" }] });
+    const advisories = osvVulnsToAdvisories([VULN], { ecosystem: "npm", packageName: "left-pad", kevCves: kev });
+    const verdict = assessPatchState({
+      installedVersion: "1.2.0",
+      advisories,
+      defaultApplyVia: "winget",
+      now: new Date("2026-06-25T00:00:00.000Z"),
+    });
+    expect(verdict.findingKind).toBe("vulnerability");
+    expect(verdict.cisaKev).toBe(true);
+    expect(verdict.policySeverity).toBe("high");
+    expect(verdict.primaryAdvisoryId).toBe("CVE-2026-1234");
+    expect(verdict.remediationHint.targetVersion).toBe("1.3.0");
+  });
+});

--- a/packages/db/src/patch/osv-adapter.ts
+++ b/packages/db/src/patch/osv-adapter.ts
@@ -1,0 +1,145 @@
+// Pure adapters that turn external advisory data into the AdvisoryInput shape the
+// patch classifier consumes. No network, no database — the live fetch + scheduling
+// lives in the projector slice; these are the transforms, kept pure and testable.
+//
+// The OSV vuln object shape and severity/fixed/alias extraction mirror the existing,
+// proven npm scanner (scripts/sbom/scan-dependencies.mjs) so the two stay consistent;
+// this generalizes it to any ecosystem and adds CISA KEV enrichment.
+
+import type { AdvisoryInput, PatchSeverity } from "./patch-intel";
+
+interface OsvEvent {
+  introduced?: string;
+  fixed?: string;
+  last_affected?: string;
+}
+
+interface OsvRange {
+  type?: string;
+  events?: OsvEvent[];
+}
+
+interface OsvAffectedPackage {
+  ecosystem?: string;
+  name?: string;
+  purl?: string;
+}
+
+interface OsvAffected {
+  package?: OsvAffectedPackage;
+  ranges?: OsvRange[];
+  versions?: string[];
+}
+
+/** Minimal OSV vulnerability object (https://ossf.github.io/osv-schema/). */
+export interface OsvVuln {
+  id: string;
+  aliases?: string[];
+  summary?: string;
+  details?: string;
+  severity?: Array<{ type?: string; score?: string }>;
+  database_specific?: { severity?: string } & Record<string, unknown>;
+  affected?: OsvAffected[];
+}
+
+export interface OsvAdapterOptions {
+  /** Restrict fixed-version extraction to this ecosystem (e.g. "npm", "Debian"). */
+  ecosystem?: string | null;
+  /** Restrict fixed-version extraction to this package name. */
+  packageName?: string | null;
+  /** CISA KEV CVE ids; an advisory whose CVE alias is in this set is marked exploited. */
+  kevCves?: ReadonlySet<string> | null;
+}
+
+// OSV / GHSA use "moderate"; the platform severity vocabulary uses "medium".
+const OSV_SEVERITY_TO_PATCH: Record<string, PatchSeverity> = {
+  critical: "critical",
+  high: "high",
+  moderate: "medium",
+  medium: "medium",
+  low: "low",
+};
+
+/**
+ * Map an OSV vuln's coarse severity band. Returns null when only a CVSS vector is
+ * present (we do not parse the vector here — GHSA almost always sets a band), letting
+ * the classifier fall back to its own default rather than fabricate a level.
+ */
+export function mapOsvSeverity(vuln: OsvVuln): PatchSeverity | null {
+  const band = vuln.database_specific?.severity;
+  if (typeof band === "string") {
+    const mapped = OSV_SEVERITY_TO_PATCH[band.toLowerCase()];
+    if (mapped) return mapped;
+  }
+  return null;
+}
+
+/** CVE and GHSA aliases for a vuln, including its own id. */
+export function osvAliases(vuln: OsvVuln): { cve: string[]; ghsa: string[] } {
+  const ids = [vuln.id, ...(vuln.aliases ?? [])];
+  return {
+    cve: ids.filter((x) => /^CVE-/i.test(x)),
+    ghsa: ids.filter((x) => /^GHSA-/i.test(x)),
+  };
+}
+
+/**
+ * Lowest "fixed" version across the matching affected entries, or null if none is
+ * published. Optionally filtered by ecosystem + package name. Sort is lexical to
+ * match the existing scanner; the classifier treats this as a hint, not gospel.
+ */
+export function osvFixedVersion(
+  vuln: OsvVuln,
+  ecosystem?: string | null,
+  packageName?: string | null,
+): string | null {
+  const fixed = new Set<string>();
+  for (const aff of vuln.affected ?? []) {
+    if (ecosystem && aff.package?.ecosystem !== ecosystem) continue;
+    if (packageName && aff.package?.name !== packageName) continue;
+    for (const range of aff.ranges ?? []) {
+      for (const event of range.events ?? []) {
+        if (event.fixed) fixed.add(event.fixed);
+      }
+    }
+  }
+  const sorted = [...fixed].sort();
+  return sorted[0] ?? null;
+}
+
+/**
+ * Convert one OSV vuln into an AdvisoryInput. Prefers a CVE id (so KEV matching and
+ * operator-facing references line up), then GHSA, then the raw OSV id.
+ */
+export function osvVulnToAdvisory(vuln: OsvVuln, options: OsvAdapterOptions = {}): AdvisoryInput {
+  const { cve, ghsa } = osvAliases(vuln);
+  const id = cve[0] ?? ghsa[0] ?? vuln.id;
+  const cisaKev = options.kevCves ? cve.some((c) => options.kevCves!.has(c)) : false;
+  return {
+    id,
+    severity: mapOsvSeverity(vuln),
+    fixedVersion: osvFixedVersion(vuln, options.ecosystem, options.packageName),
+    cisaKev,
+  };
+}
+
+/** Convert a list of OSV vulns (e.g. the `vulns` array for one package) into advisories. */
+export function osvVulnsToAdvisories(vulns: OsvVuln[], options: OsvAdapterOptions = {}): AdvisoryInput[] {
+  return vulns.map((v) => osvVulnToAdvisory(v, options));
+}
+
+interface KevCatalog {
+  vulnerabilities?: Array<{ cveID?: string }>;
+}
+
+/**
+ * Parse the CISA Known Exploited Vulnerabilities catalog
+ * (https://www.cisa.gov/.../known_exploited_vulnerabilities.json) into a CVE id set.
+ */
+export function parseKevCatalog(catalog: KevCatalog | null | undefined): Set<string> {
+  const set = new Set<string>();
+  for (const entry of catalog?.vulnerabilities ?? []) {
+    if (entry?.cveID) set.add(entry.cveID);
+  }
+  return set;
+}

--- a/packages/db/src/patch/patch-intel.test.ts
+++ b/packages/db/src/patch/patch-intel.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assessPatchState,
+  compareVersions,
+  isActionable,
+  parseVersion,
+  type PatchAssessmentInput,
+} from "./patch-intel";
+
+const NOW = new Date("2026-06-25T00:00:00.000Z");
+
+describe("parseVersion", () => {
+  it("parses plain semver", () => {
+    expect(parseVersion("1.2.3")).toEqual({ release: [1, 2, 3], prerelease: [] });
+  });
+
+  it("strips a leading v and build metadata", () => {
+    expect(parseVersion("v1.2.3+build.5")).toEqual({ release: [1, 2, 3], prerelease: [] });
+  });
+
+  it("captures prerelease identifiers", () => {
+    expect(parseVersion("1.0.0-rc.2")).toEqual({ release: [1, 0, 0], prerelease: ["rc", 2] });
+  });
+
+  it("accepts non-three-part numeric versions (2024.06)", () => {
+    expect(parseVersion("2024.06")).toEqual({ release: [2024, 6], prerelease: [] });
+  });
+
+  it("returns null for non-semver OS package strings", () => {
+    expect(parseVersion("1:2.30-1ubuntu2")).toBeNull();
+    expect(parseVersion("")).toBeNull();
+    expect(parseVersion(null)).toBeNull();
+    expect(parseVersion("notaversion")).toBeNull();
+  });
+});
+
+describe("compareVersions", () => {
+  it("detects behind / current / ahead", () => {
+    expect(compareVersions("1.2.0", "1.2.3")).toBe("behind");
+    expect(compareVersions("1.2.3", "1.2.3")).toBe("current");
+    expect(compareVersions("1.3.0", "1.2.3")).toBe("ahead");
+  });
+
+  it("treats missing trailing segments as zero", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe("current");
+    expect(compareVersions("1.2", "1.2.1")).toBe("behind");
+  });
+
+  it("orders prerelease below the release", () => {
+    expect(compareVersions("1.0.0-rc.1", "1.0.0")).toBe("behind");
+    expect(compareVersions("1.0.0", "1.0.0-rc.1")).toBe("ahead");
+    expect(compareVersions("1.0.0-rc.1", "1.0.0-rc.2")).toBe("behind");
+  });
+
+  it("returns unknown when either side is not parseable", () => {
+    expect(compareVersions("1:2.30-1ubuntu2", "2.31")).toBe("unknown");
+    expect(compareVersions("1.2.3", "stable")).toBe("unknown");
+  });
+});
+
+describe("assessPatchState — vulnerabilities", () => {
+  it("flags an open advisory with no known fix as a vulnerability", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "1.2.3",
+      advisories: [{ id: "CVE-2026-0001", severity: "high" }],
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("vulnerability");
+    expect(r.policySeverity).toBe("high");
+    expect(r.primaryAdvisoryId).toBe("CVE-2026-0001");
+  });
+
+  it("ignores an advisory already resolved by the installed version", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "1.2.5",
+      advisories: [{ id: "CVE-2026-0002", severity: "critical", fixedVersion: "1.2.4" }],
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("none");
+  });
+
+  it("keeps an advisory open when installed is below the fix and targets the fix", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "1.2.0",
+      advisories: [{ id: "CVE-2026-0003", severity: "medium", fixedVersion: "1.2.4" }],
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("vulnerability");
+    expect(r.remediationHint.targetVersion).toBe("1.2.4");
+  });
+
+  it("flags a vulnerability even when the version is current", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "3.0.0",
+      latestStableVersion: "3.0.0",
+      advisories: [{ id: "GHSA-xxxx", severity: "high" }],
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("vulnerability");
+    expect(r.versionComparison).toBe("current");
+  });
+
+  it("escalates and routes CISA KEV advisories urgently", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "1.0.0",
+      advisories: [
+        { id: "CVE-2026-LOW", severity: "low" },
+        { id: "CVE-2026-KEV", severity: "medium", cisaKev: true, fixedVersion: "1.0.1" },
+      ],
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.cisaKev).toBe(true);
+    // KEV floors severity to at least high even though the advisory said medium.
+    expect(r.policySeverity).toBe("high");
+    // KEV advisory is picked as primary over the low one.
+    expect(r.primaryAdvisoryId).toBe("CVE-2026-KEV");
+    expect(r.remediationHint.cisaKev).toBe(true);
+    expect(r.rationale).toMatch(/KEV/);
+  });
+
+  it("classifies a vulnerability on an unparseable OS version", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "1:2.30-1ubuntu2",
+      advisories: [{ id: "CVE-2026-OS", severity: "critical" }],
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("vulnerability");
+    expect(r.versionComparison).toBe("unknown");
+    expect(r.policySeverity).toBe("critical");
+  });
+});
+
+describe("assessPatchState — end-of-life", () => {
+  it("flags EOL when the date is in the past and there is no open advisory", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "8.0.0",
+      latestStableVersion: "12.0.0",
+      eolDate: "2025-01-01",
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("end-of-life");
+    expect(r.policySeverity).toBe("high");
+    expect(r.remediationHint.targetVersion).toBe("12.0.0");
+  });
+
+  it("does not flag EOL when the date is in the future", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "8.0.0",
+      latestStableVersion: "8.0.0",
+      eolDate: "2027-01-01",
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("none");
+  });
+});
+
+describe("assessPatchState — version hygiene gaps", () => {
+  it("flags behind-on-safe-version as a medium patch gap", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "1.0.0",
+      latestSafeVersion: "1.4.0",
+      latestStableVersion: "1.4.0",
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("patch-gap");
+    expect(r.policySeverity).toBe("medium");
+    expect(r.remediationHint.targetVersion).toBe("1.4.0");
+  });
+
+  it("downgrades to low when only the stable (not the safe) version is ahead", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "1.4.0",
+      latestSafeVersion: "1.4.0",
+      latestStableVersion: "1.5.0",
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    // Comparison uses latestSafe first (current), so no behind verdict -> none.
+    expect(r.findingKind).toBe("none");
+  });
+
+  it("returns none when up to date with no advisories", () => {
+    const input: PatchAssessmentInput = {
+      installedVersion: "2.0.0",
+      latestSafeVersion: "2.0.0",
+      latestStableVersion: "2.0.0",
+      now: NOW,
+    };
+    const r = assessPatchState(input);
+    expect(r.findingKind).toBe("none");
+    expect(r.policySeverity).toBe("info");
+  });
+});
+
+describe("remediationHint + isActionable", () => {
+  it("propagates applyVia, reboot, and confidence", () => {
+    const r = assessPatchState({
+      installedVersion: "1.0.0",
+      latestSafeVersion: "2.0.0",
+      defaultApplyVia: "winget",
+      rebootLikely: true,
+      confidence: "verified",
+      now: NOW,
+    });
+    expect(r.remediationHint).toMatchObject({
+      applyVia: "winget",
+      rebootLikely: true,
+      confidence: "verified",
+      targetVersion: "2.0.0",
+    });
+  });
+
+  it("isActionable is false only for the none verdict", () => {
+    expect(isActionable(assessPatchState({ installedVersion: "1.0.0", latestSafeVersion: "1.0.0", now: NOW }))).toBe(
+      false,
+    );
+    expect(
+      isActionable(assessPatchState({ installedVersion: "1.0.0", latestSafeVersion: "2.0.0", now: NOW })),
+    ).toBe(true);
+  });
+});

--- a/packages/db/src/patch/patch-intel.ts
+++ b/packages/db/src/patch/patch-intel.ts
@@ -1,0 +1,333 @@
+// Pure, prisma-free patch-intelligence core.
+//
+// Shared brain for the two read-only P0 legs of estate patch management:
+//   - the version-intelligence feed (resolves "latest safe version" + advisories), and
+//   - the assessment projector (writes AssuranceFinding rows).
+//
+// Everything here is a pure function of its inputs so it is fully unit-testable
+// without a database, an Edge Node, or a network call. It mirrors the prisma-free
+// pure-logic pattern already used by self-upgrade/windows-eval.ts and auto-window.ts.
+//
+// Design notes:
+//   - Advisory-first classification: a host that is "version current" can still be
+//     vulnerable, and a host on an unparseable distro version (e.g. "1:2.30-1ubuntu2")
+//     can still carry a CVE. So advisories drive the verdict before version math.
+//   - CISA KEV (Known Exploited Vulnerabilities) is a routing/severity multiplier, not
+//     a separate finding kind — an exploited CVE is still a vulnerability, just an urgent one.
+//   - Version comparison returns "unknown" rather than guessing when a string is not
+//     semver-shaped; the verdict then leans on advisories and the native "available" signal.
+
+export type VersionComparison = "behind" | "current" | "ahead" | "unknown";
+
+export type PatchFindingKind = "patch-gap" | "vulnerability" | "end-of-life" | "none";
+
+export type PatchSeverity = "critical" | "high" | "medium" | "low" | "info";
+
+export type ApplyVia =
+  | "winget"
+  | "wua"
+  | "apt"
+  | "dnf"
+  | "brew"
+  | "manual"
+  | "vendor-adapter"
+  | "unknown";
+
+export type PatchConfidence = "unverified" | "inferred" | "verified" | "vendor-confirmed";
+
+export interface AdvisoryInput {
+  /** CVE / GHSA / OSV / vendor-advisory id. */
+  id: string;
+  /** Source severity if the feed provided one. */
+  severity?: PatchSeverity | null;
+  /** Lowest version that resolves this advisory, if known. */
+  fixedVersion?: string | null;
+  /** Whether this CVE is in the CISA Known Exploited Vulnerabilities catalog. */
+  cisaKev?: boolean | null;
+}
+
+export interface PatchAssessmentInput {
+  installedVersion?: string | null;
+  /** Latest version on the tracked channel, ignoring vulnerability state. */
+  latestStableVersion?: string | null;
+  /** Latest version with no known open advisories (preferred patch target). */
+  latestSafeVersion?: string | null;
+  /** Advisories believed to affect the installed version. */
+  advisories?: AdvisoryInput[] | null;
+  /** End-of-life / end-of-support date for the installed line. */
+  eolDate?: string | Date | null;
+  /** Injected for determinism; defaults to current time in app code. */
+  now?: Date;
+  defaultApplyVia?: ApplyVia | null;
+  rebootLikely?: boolean | null;
+  /** How trustworthy the catalog identity + version match is. */
+  confidence?: PatchConfidence | null;
+}
+
+export interface RemediationHint {
+  targetVersion: string | null;
+  applyVia: ApplyVia;
+  rebootLikely: boolean;
+  cisaKev: boolean;
+  confidence: PatchConfidence;
+}
+
+export interface PatchAssessment {
+  findingKind: PatchFindingKind;
+  policySeverity: PatchSeverity;
+  versionComparison: VersionComparison;
+  /** Highest-priority advisory id, surfaced as AssuranceFinding.vendorIdentifier. */
+  primaryAdvisoryId: string | null;
+  /** True if any affecting advisory is in the CISA KEV catalog. */
+  cisaKev: boolean;
+  remediationHint: RemediationHint;
+  /** Plain-language reason, safe to show a non-technical operator. */
+  rationale: string;
+}
+
+interface ParsedVersion {
+  release: number[];
+  prerelease: Array<string | number>;
+}
+
+const SEVERITY_RANK: Record<PatchSeverity, number> = {
+  info: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+const SEVERITY_BY_RANK: PatchSeverity[] = ["info", "low", "medium", "high", "critical"];
+
+/**
+ * Parse a semver-ish version into comparable parts, or return null when the string
+ * is not numeric-dotted (common for OS package versions, which we then treat as
+ * incomparable rather than guess).
+ */
+export function parseVersion(input: string | null | undefined): ParsedVersion | null {
+  if (!input) return null;
+  let v = input.trim();
+  if (!v) return null;
+  // Strip a leading "v" (v1.2.3) and any build metadata (1.2.3+build).
+  if (v[0] === "v" || v[0] === "V") v = v.slice(1);
+  const plus = v.indexOf("+");
+  if (plus !== -1) v = v.slice(0, plus);
+
+  const dash = v.indexOf("-");
+  const corePart = dash === -1 ? v : v.slice(0, dash);
+  const prePart = dash === -1 ? "" : v.slice(dash + 1);
+
+  const coreSegments = corePart.split(".");
+  const release: number[] = [];
+  for (const seg of coreSegments) {
+    if (seg === "" || !/^\d+$/.test(seg)) return null;
+    release.push(Number(seg));
+  }
+  if (release.length === 0) return null;
+
+  const prerelease: Array<string | number> = [];
+  if (prePart) {
+    for (const id of prePart.split(".")) {
+      if (id === "") return null;
+      prerelease.push(/^\d+$/.test(id) ? Number(id) : id);
+    }
+  }
+  return { release, prerelease };
+}
+
+function compareReleaseArrays(a: number[], b: number[]): number {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+function comparePrerelease(a: Array<string | number>, b: Array<string | number>): number {
+  // Per semver: a version WITH prerelease has lower precedence than one without.
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1; // a is the release, b is a prerelease -> a is higher
+  if (b.length === 0) return -1;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const av = a[i];
+    const bv = b[i];
+    if (av === undefined) return -1; // shorter set of identifiers is lower
+    if (bv === undefined) return 1;
+    const aNum = typeof av === "number";
+    const bNum = typeof bv === "number";
+    if (aNum && bNum) {
+      if (av !== bv) return (av as number) < (bv as number) ? -1 : 1;
+    } else if (aNum !== bNum) {
+      return aNum ? -1 : 1; // numeric identifiers are lower than alphanumeric
+    } else if (av !== bv) {
+      return (av as string) < (bv as string) ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Compare the installed version against an available version.
+ * Returns "unknown" when either side is not a parseable semver-ish string.
+ */
+export function compareVersions(
+  installed: string | null | undefined,
+  available: string | null | undefined,
+): VersionComparison {
+  const a = parseVersion(installed);
+  const b = parseVersion(available);
+  if (!a || !b) return "unknown";
+  const rel = compareReleaseArrays(a.release, b.release);
+  const cmp = rel !== 0 ? rel : comparePrerelease(a.prerelease, b.prerelease);
+  if (cmp === 0) return "current";
+  return cmp < 0 ? "behind" : "ahead";
+}
+
+function maxSeverity(values: Array<PatchSeverity | null | undefined>): PatchSeverity | null {
+  let best = -1;
+  for (const v of values) {
+    if (v && SEVERITY_RANK[v] > best) best = SEVERITY_RANK[v];
+  }
+  return best === -1 ? null : SEVERITY_BY_RANK[best];
+}
+
+function atLeast(sev: PatchSeverity, floor: PatchSeverity): PatchSeverity {
+  return SEVERITY_RANK[sev] >= SEVERITY_RANK[floor] ? sev : floor;
+}
+
+function isEol(eolDate: string | Date | null | undefined, now: Date): boolean {
+  if (!eolDate) return false;
+  const d = eolDate instanceof Date ? eolDate : new Date(eolDate);
+  if (Number.isNaN(d.getTime())) return false;
+  return d.getTime() <= now.getTime();
+}
+
+/**
+ * Among advisories that still affect the installed version, pick the one that should
+ * drive routing: CISA KEV first, then highest severity, then the one with a known fix.
+ * An advisory is "open" if no fixedVersion is given, or the installed version is still
+ * below the fix.
+ */
+function openAdvisories(input: PatchAssessmentInput): AdvisoryInput[] {
+  const advisories = input.advisories ?? [];
+  return advisories.filter((adv) => {
+    if (!adv.fixedVersion) return true; // no known fix -> treat as open
+    const cmp = compareVersions(input.installedVersion, adv.fixedVersion);
+    // installed is "behind" the fix -> still vulnerable; "unknown" -> keep (be conservative).
+    return cmp === "behind" || cmp === "unknown";
+  });
+}
+
+function pickPrimaryAdvisory(advisories: AdvisoryInput[]): AdvisoryInput | null {
+  if (advisories.length === 0) return null;
+  return [...advisories].sort((x, y) => {
+    const kev = Number(Boolean(y.cisaKev)) - Number(Boolean(x.cisaKev));
+    if (kev !== 0) return kev;
+    const sev = (y.severity ? SEVERITY_RANK[y.severity] : -1) - (x.severity ? SEVERITY_RANK[x.severity] : -1);
+    if (sev !== 0) return sev;
+    return Number(Boolean(y.fixedVersion)) - Number(Boolean(x.fixedVersion));
+  })[0];
+}
+
+/**
+ * Classify a single (host, software) pair into a patch verdict. Pure and deterministic.
+ *
+ * Precedence: open vulnerabilities -> end-of-life -> behind-on-version -> none.
+ * CISA KEV membership escalates severity and is always surfaced on the hint.
+ */
+export function assessPatchState(input: PatchAssessmentInput): PatchAssessment {
+  const now = input.now ?? new Date();
+  const applyVia: ApplyVia = input.defaultApplyVia ?? "unknown";
+  const confidence: PatchConfidence = input.confidence ?? "unverified";
+  const rebootLikely = Boolean(input.rebootLikely);
+
+  const versionComparison = compareVersions(
+    input.installedVersion,
+    input.latestSafeVersion ?? input.latestStableVersion,
+  );
+
+  const open = openAdvisories(input);
+  const anyKev = open.some((a) => Boolean(a.cisaKev));
+
+  const baseHint = (targetVersion: string | null): RemediationHint => ({
+    targetVersion,
+    applyVia,
+    rebootLikely,
+    cisaKev: anyKev,
+    confidence,
+  });
+
+  // 1) Open vulnerabilities win — even when version math is "current" or "unknown".
+  if (open.length > 0) {
+    const primary = pickPrimaryAdvisory(open);
+    const target =
+      primary?.fixedVersion ?? input.latestSafeVersion ?? input.latestStableVersion ?? null;
+    let severity = maxSeverity(open.map((a) => a.severity)) ?? "high";
+    if (anyKev) severity = atLeast(severity, "high"); // exploited-in-the-wild is never below high
+    return {
+      findingKind: "vulnerability",
+      policySeverity: severity,
+      versionComparison,
+      primaryAdvisoryId: primary?.id ?? null,
+      cisaKev: anyKev,
+      remediationHint: baseHint(target),
+      rationale: anyKev
+        ? `Affected by ${open.length} advisory(ies) including a CISA KEV (actively exploited): ${primary?.id ?? "unknown"}.`
+        : `Affected by ${open.length} known vulnerability(ies); highest severity ${severity}.`,
+    };
+  }
+
+  // 2) End-of-life software is a standing risk even with no open CVE today.
+  if (isEol(input.eolDate, now)) {
+    return {
+      findingKind: "end-of-life",
+      policySeverity: "high",
+      versionComparison,
+      primaryAdvisoryId: null,
+      cisaKev: false,
+      remediationHint: baseHint(input.latestStableVersion ?? null),
+      rationale: "Installed version is past its end-of-life / end-of-support date.",
+    };
+  }
+
+  // 3) Behind on version but no known vulnerability -> hygiene gap.
+  if (versionComparison === "behind") {
+    const behindSafe =
+      input.latestSafeVersion != null &&
+      compareVersions(input.installedVersion, input.latestSafeVersion) === "behind";
+    return {
+      findingKind: "patch-gap",
+      policySeverity: behindSafe ? "medium" : "low",
+      versionComparison,
+      primaryAdvisoryId: null,
+      cisaKev: false,
+      remediationHint: baseHint(input.latestSafeVersion ?? input.latestStableVersion ?? null),
+      rationale: `A newer version is available (${input.latestSafeVersion ?? input.latestStableVersion}).`,
+    };
+  }
+
+  // 4) Nothing to do (current/ahead/unknown with no advisories or EOL).
+  return {
+    findingKind: "none",
+    policySeverity: "info",
+    versionComparison,
+    primaryAdvisoryId: null,
+    cisaKev: false,
+    remediationHint: baseHint(null),
+    rationale:
+      versionComparison === "unknown"
+        ? "No advisories known and version could not be compared; no action inferred."
+        : "Up to date with no known advisories.",
+  };
+}
+
+/**
+ * Whether an assessment represents real work (a finding the assessment surface should show).
+ */
+export function isActionable(assessment: PatchAssessment): boolean {
+  return assessment.findingKind !== "none";
+}


### PR DESCRIPTION
First **local** implementation slice of `EP-PATCH-MANAGEMENT` (read-only P0 wedge). Spec: `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`. Plan: `docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md`.

## What

`packages/db/src/patch/patch-intel.ts` — a **pure, prisma-free, dependency-free** patch-intelligence classifier, the shared brain for both P0 BIs (the version-intelligence feed BI-CAA0043C and the assessment projector BI-489A8BB4). Mirrors the existing pure-logic pattern (`windows-eval.ts`, `auto-window.ts`).

- `parseVersion` / `compareVersions` — semver-ish comparison that returns `"unknown"` for non-semver OS package strings (e.g. `1:2.30-1ubuntu2`) rather than guessing. No `semver` dependency added (DPF has none; small self-contained comparator).
- `assessPatchState` — classifies a `(host, software)` pair into `vulnerability | end-of-life | patch-gap | none`, advisory-first (a version-current host can still be vulnerable). **CISA KEV** membership escalates severity (floors to `high`) and routes urgently. Emits the `remediationHint` shape (`targetVersion`, `applyVia`, `rebootLikely`, `cisaKev`, `confidence`).

## Why this slice first

The spec's identity-convergence step (`CatalogIdentity`) is genuinely unbuilt **and** intersects an existing device-oriented `DiscoveryFingerprint*` subsystem (`schema.prisma:3642–3731`) — so a blind, immutable schema migration is the wrong place to start, especially in a source-only worktree. This pure core is independently verifiable, identity-agnostic, and the foundation slices 2–5 compose. The plan records the substrate corrections so they aren't re-derived.

## Verification

- `pnpm --filter @dpf/db exec vitest run src/patch/patch-intel.test.ts` → **22/22 passed**.
- `pnpm --filter @dpf/db typecheck` → clean.
- packages/db-only, purely additive (no existing code or exports touched) → no web build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)