### PR TITLE
feat(patch-mgmt): assessment projector core (EP-PATCH-MANAGEMENT P0 slice 3)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
+++ b/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
@@ -1,7 +1,7 @@
 # Estate Patch Management — P0 implementation plan
 
 - **Date:** 2026-06-25
-- **Status:** In progress (slice 1 + OSV/KEV advisory extractors landed)
+- **Status:** In progress (slices 1–2a + projector core landed; runtime binding next)
 - **Spec:** `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`
 - **Epic:** `EP-PATCH-MANAGEMENT`
 - **Backlog:** BI-CAA0043C (version-intel feed), BI-489A8BB4 (assessment projector), BI-676A7960 (identity convergence), BI-020EE402 (posture UX)
@@ -34,7 +34,8 @@ Adapter interfaces + implementations that produce `assessPatchState` inputs, eac
 - Live fetch (OSV `querybatch` + `/vulns/{id}`, KEV catalog download) + scheduled projector entry in `SCHEDULED_JOB_CATALOG`. **Remaining — runtime-bound, verified via the sandbox.**
 
 ### Slice 3 — Assessment projector → AssuranceFinding (BI-489A8BB4)
-For each in-use `(InventoryEntity, DiscoveredSoftwareEvidence)`, run `assessPatchState` and upsert `AssuranceFinding` rows (`findingKind` ∈ patch-gap|vulnerability|end-of-life; `adapterKey` patch-intel|osv|cisa-kev|native-manager; `vendorIdentifier` = primary advisory; `remediationHint` JSON; `acceptedUntil` preserved). **No new findings table** — composes the Assurance Ledger (`schema.prisma:4968`). Carries a coverage metric so missing inventory is not read as clean.
+- **Pure core — LANDED:** `packages/db/src/patch/patch-projector.ts`. A `PatchAssessmentStore` port + `runPatchAssessment` orchestration (read evidence → `assessEvidence` → `evidenceToPatchFinding` → upsert actionable findings → resolve now-clean ones → posture summary), plus `applyViaForPackageManager`. Decoupled from Prisma so the whole read→assess→upsert→resolve flow is unit-tested against an in-memory fake store. Emits the AssuranceFinding upsert shape (`findingKind` ∈ patch-gap|vulnerability|end-of-life; `adapterKey` patch-intel|osv|cisa-kev; stable `findingKey` = `patch:<evidenceKey>`). **No new findings table** — composes the Assurance Ledger (`schema.prisma:4968`).
+- **Prisma binding — remaining (runtime-bound):** a `PatchAssessmentStore` adapter in `apps/web/lib/patch/` that lists `DiscoveredSoftwareEvidence` and **delegates finding writes to the existing `apps/web/lib/assurance/finding-persistence.ts`** (single source of truth for `AssuranceFinding` create/update/reopen — do not hand-roll a parallel upsert). Verified via the local-CI sandbox lease. Carries a coverage metric so missing inventory is not read as clean.
 
 ### Slice 4 — Identity convergence (BI-676A7960) — gated
 Map the `DiscoveryFingerprint*` subsystem first; decide whether the software-identity spine extends it or lands a focused `CatalogIdentity` + `SoftwarePatchProfile`. Then the reviewable migration for `softwareIdentityId` (rename→`legacy…` + add `catalogIdentityId`, or drop-with-evidence) per the lifecycle-evidence spec §7.4. Runs through Prisma in the sandbox/canonical install, never blind. Until then, slice 3 keys findings on `DiscoveredSoftwareEvidence`/`InventoryEntity` directly.

--- a/packages/db/src/patch/patch-projector.test.ts
+++ b/packages/db/src/patch/patch-projector.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyViaForPackageManager,
+  assessEvidence,
+  evidenceToPatchFinding,
+  runPatchAssessment,
+  type PatchAssessmentStore,
+  type PatchFindingUpsert,
+  type PatchIntel,
+  type PatchIntelProvider,
+  type SoftwareEvidenceLike,
+} from "./patch-projector";
+
+const NOW = new Date("2026-06-25T00:00:00.000Z");
+
+class FakeStore implements PatchAssessmentStore {
+  findings = new Map<string, PatchFindingUpsert>();
+  resolvedCount = 0;
+
+  constructor(
+    private readonly evidence: SoftwareEvidenceLike[],
+    seed: PatchFindingUpsert[] = [],
+  ) {
+    for (const f of seed) this.findings.set(f.findingKey, f);
+  }
+
+  async listSoftwareEvidence(): Promise<SoftwareEvidenceLike[]> {
+    return this.evidence;
+  }
+
+  async upsertFinding(finding: PatchFindingUpsert): Promise<void> {
+    this.findings.set(finding.findingKey, finding);
+  }
+
+  async resolveFindingsExcept(activeKeys: string[]): Promise<number> {
+    const active = new Set(activeKeys);
+    let resolved = 0;
+    for (const key of [...this.findings.keys()]) {
+      if (key.startsWith("patch:") && !active.has(key)) {
+        this.findings.delete(key);
+        resolved += 1;
+      }
+    }
+    this.resolvedCount = resolved;
+    return resolved;
+  }
+}
+
+describe("applyViaForPackageManager", () => {
+  it("maps package managers to apply backends", () => {
+    expect(applyViaForPackageManager("dpkg")).toBe("apt");
+    expect(applyViaForPackageManager("rpm")).toBe("dnf");
+    expect(applyViaForPackageManager("brew")).toBe("brew");
+    expect(applyViaForPackageManager("powershell")).toBe("winget");
+    expect(applyViaForPackageManager("npm")).toBe("vendor-adapter");
+    expect(applyViaForPackageManager("something-else")).toBe("unknown");
+    expect(applyViaForPackageManager(null)).toBe("unknown");
+  });
+});
+
+describe("assessEvidence", () => {
+  it("derives applyVia from the package manager when intel omits it", () => {
+    const ev: SoftwareEvidenceLike = {
+      evidenceKey: "e1",
+      inventoryEntityId: "host1",
+      rawVersion: "1.0.0",
+      packageManager: "dpkg",
+    };
+    const r = assessEvidence(ev, { latestSafeVersion: "1.4.0" }, NOW);
+    expect(r.findingKind).toBe("patch-gap");
+    expect(r.remediationHint.applyVia).toBe("apt");
+  });
+});
+
+describe("evidenceToPatchFinding", () => {
+  const baseEv: SoftwareEvidenceLike = {
+    evidenceKey: "ev-firefox",
+    inventoryEntityId: "host-1",
+    rawProductName: "Firefox",
+    rawPackageName: "firefox",
+    rawVersion: "120.0",
+    packageManager: "winget",
+    customerAccountId: "acct-9",
+  };
+
+  it("returns null for a clean (none) verdict", () => {
+    const assessment = assessEvidence(baseEv, { latestSafeVersion: "120.0" }, NOW);
+    expect(evidenceToPatchFinding(baseEv, assessment)).toBeNull();
+  });
+
+  it("maps a KEV vulnerability to a cisa-kev finding keyed on the CVE", () => {
+    const intel: PatchIntel = {
+      advisories: [{ id: "CVE-2026-9999", severity: "high", cisaKev: true, fixedVersion: "120.1" }],
+    };
+    const assessment = assessEvidence(baseEv, intel, NOW);
+    const finding = evidenceToPatchFinding(baseEv, assessment)!;
+    expect(finding.findingKind).toBe("vulnerability");
+    expect(finding.adapterKey).toBe("cisa-kev");
+    expect(finding.vendorIdentifier).toBe("CVE-2026-9999");
+    expect(finding.policySeverity).toBe("high");
+    expect(finding.findingKey).toBe("patch:ev-firefox");
+    expect(finding.affectedType).toBe("DiscoveredSoftwareEvidence");
+    expect(finding.title).toContain("CVE-2026-9999");
+    expect(finding.remediationHint.targetVersion).toBe("120.1");
+    expect(finding.source.customerAccountId).toBe("acct-9");
+  });
+
+  it("maps a plain patch gap to a patch-intel finding with a synthetic identifier", () => {
+    const assessment = assessEvidence(baseEv, { latestSafeVersion: "121.0" }, NOW);
+    const finding = evidenceToPatchFinding(baseEv, assessment)!;
+    expect(finding.findingKind).toBe("patch-gap");
+    expect(finding.adapterKey).toBe("patch-intel");
+    expect(finding.vendorIdentifier).toBe("winget:firefox");
+    expect(finding.remediationHint.targetVersion).toBe("121.0");
+  });
+});
+
+describe("runPatchAssessment", () => {
+  const evidence: SoftwareEvidenceLike[] = [
+    { evidenceKey: "vuln", inventoryEntityId: "h1", rawProductName: "openssl", rawVersion: "3.0.0", packageManager: "dpkg" },
+    { evidenceKey: "gap", inventoryEntityId: "h1", rawProductName: "curl", rawVersion: "8.0.0", packageManager: "dpkg" },
+    { evidenceKey: "clean", inventoryEntityId: "h2", rawProductName: "bash", rawVersion: "5.2.0", packageManager: "dpkg" },
+  ];
+
+  const provider: PatchIntelProvider = (ev) => {
+    switch (ev.evidenceKey) {
+      case "vuln":
+        return { advisories: [{ id: "CVE-2026-1", severity: "critical" }] };
+      case "gap":
+        return { latestSafeVersion: "8.8.0" };
+      default:
+        return { latestSafeVersion: ev.rawVersion };
+    }
+  };
+
+  it("assesses all evidence, upserts actionable findings, and skips clean ones", async () => {
+    const store = new FakeStore(evidence);
+    const summary = await runPatchAssessment(store, provider, { now: NOW });
+    expect(summary.assessed).toBe(3);
+    expect(summary.actionable).toBe(2);
+    expect(summary.byKind).toEqual({ vulnerability: 1, "patch-gap": 1 });
+    expect(summary.bySeverity).toEqual({ critical: 1, medium: 1 });
+    expect(store.findings.has("patch:vuln")).toBe(true);
+    expect(store.findings.has("patch:gap")).toBe(true);
+    expect(store.findings.has("patch:clean")).toBe(false);
+  });
+
+  it("resolves a previously-open finding that is now clean", async () => {
+    const stale: PatchFindingUpsert = {
+      findingKey: "patch:was-vulnerable",
+      findingKind: "vulnerability",
+      title: "old",
+      description: "",
+      affectedType: "DiscoveredSoftwareEvidence",
+      affectedId: "old",
+      adapterKey: "osv",
+      vendorIdentifier: "CVE-old",
+      policySeverity: "high",
+      remediationHint: {},
+      source: {},
+    };
+    const store = new FakeStore(evidence, [stale]);
+    const summary = await runPatchAssessment(store, provider, { now: NOW });
+    expect(summary.resolved).toBe(1);
+    expect(store.findings.has("patch:was-vulnerable")).toBe(false);
+  });
+});

--- a/packages/db/src/patch/patch-projector.ts
+++ b/packages/db/src/patch/patch-projector.ts
@@ -1,0 +1,231 @@
+// Assessment projector: turns discovered installed-software evidence into patch
+// findings on the Assurance Ledger. This is the read-only P0 payoff — "what is out
+// of date / vulnerable across the estate" — with no execution and no new findings table.
+//
+// The projector is decoupled from Prisma behind a small port (PatchAssessmentStore)
+// so the read -> assess -> upsert -> resolve orchestration is fully unit-testable with
+// a fake store. The real Prisma binding is a thin adapter over this port.
+
+import {
+  assessPatchState,
+  isActionable,
+  type AdvisoryInput,
+  type ApplyVia,
+  type PatchAssessment,
+  type PatchConfidence,
+} from "./patch-intel";
+
+/** The fields of a DiscoveredSoftwareEvidence row the projector reads. */
+export interface SoftwareEvidenceLike {
+  id?: string;
+  evidenceKey: string;
+  inventoryEntityId: string;
+  rawVendor?: string | null;
+  rawProductName?: string | null;
+  rawPackageName?: string | null;
+  rawVersion?: string | null;
+  packageManager?: string | null;
+  /** Optional MSP scope carried from the owning InventoryEntity. */
+  customerAccountId?: string | null;
+  customerSiteId?: string | null;
+}
+
+/** Version + advisory intelligence for one software item (produced by the feed slice). */
+export interface PatchIntel {
+  latestStableVersion?: string | null;
+  latestSafeVersion?: string | null;
+  advisories?: AdvisoryInput[] | null;
+  eolDate?: string | Date | null;
+  defaultApplyVia?: ApplyVia | null;
+  rebootLikely?: boolean | null;
+  confidence?: PatchConfidence | null;
+}
+
+/** Resolves intelligence for a piece of evidence; returns null when nothing is known. */
+export type PatchIntelProvider = (
+  evidence: SoftwareEvidenceLike,
+) => PatchIntel | null | Promise<PatchIntel | null>;
+
+/** AssuranceFinding upsert payload (composes the existing Assurance Ledger model). */
+export interface PatchFindingUpsert {
+  findingKey: string;
+  findingKind: string;
+  title: string;
+  description: string;
+  affectedType: string;
+  affectedId: string;
+  adapterKey: string;
+  vendorIdentifier: string;
+  policySeverity: string;
+  remediationHint: Record<string, unknown>;
+  source: Record<string, unknown>;
+}
+
+/** Port over the persistence layer — kept minimal so the projector is testable. */
+export interface PatchAssessmentStore {
+  listSoftwareEvidence(): Promise<SoftwareEvidenceLike[]>;
+  upsertFinding(finding: PatchFindingUpsert): Promise<void>;
+  /** Resolve previously-open patch findings whose key is no longer active (now clean). */
+  resolveFindingsExcept(activeFindingKeys: string[]): Promise<number>;
+}
+
+export interface PatchAssessmentSummary {
+  assessed: number;
+  actionable: number;
+  resolved: number;
+  byKind: Record<string, number>;
+  bySeverity: Record<string, number>;
+}
+
+const FINDING_KEY_PREFIX = "patch:";
+
+/** Map a discovered package manager to the backend that would apply its updates. */
+export function applyViaForPackageManager(pm: string | null | undefined): ApplyVia {
+  switch ((pm ?? "").toLowerCase()) {
+    case "dpkg":
+    case "apt":
+      return "apt";
+    case "rpm":
+    case "dnf":
+    case "yum":
+      return "dnf";
+    case "brew":
+    case "homebrew":
+      return "brew";
+    case "winget":
+    case "msi":
+    case "powershell":
+    case "registry":
+      return "winget";
+    case "wua":
+    case "windows-update":
+      return "wua";
+    case "npm":
+    case "pip":
+    case "pypi":
+    case "gem":
+    case "cargo":
+      return "vendor-adapter";
+    default:
+      return "unknown";
+  }
+}
+
+function displayName(evidence: SoftwareEvidenceLike): string {
+  return (
+    evidence.rawProductName ||
+    evidence.rawPackageName ||
+    evidence.rawVendor ||
+    evidence.evidenceKey
+  );
+}
+
+/** Compose evidence + intelligence into a patch verdict. Pure. */
+export function assessEvidence(
+  evidence: SoftwareEvidenceLike,
+  intel: PatchIntel | null,
+  now?: Date,
+): PatchAssessment {
+  return assessPatchState({
+    installedVersion: evidence.rawVersion,
+    latestStableVersion: intel?.latestStableVersion ?? null,
+    latestSafeVersion: intel?.latestSafeVersion ?? null,
+    advisories: intel?.advisories ?? null,
+    eolDate: intel?.eolDate ?? null,
+    defaultApplyVia: intel?.defaultApplyVia ?? applyViaForPackageManager(evidence.packageManager),
+    rebootLikely: intel?.rebootLikely ?? null,
+    confidence: intel?.confidence ?? null,
+    now,
+  });
+}
+
+function adapterKeyFor(assessment: PatchAssessment): string {
+  if (assessment.cisaKev) return "cisa-kev";
+  if (assessment.findingKind === "vulnerability") return "osv";
+  return "patch-intel";
+}
+
+function titleFor(evidence: SoftwareEvidenceLike, assessment: PatchAssessment): string {
+  const name = displayName(evidence);
+  const installed = evidence.rawVersion ?? "unknown";
+  const target = assessment.remediationHint.targetVersion;
+  switch (assessment.findingKind) {
+    case "vulnerability":
+      return `${name} ${installed} — ${assessment.primaryAdvisoryId ?? "known vulnerability"}`;
+    case "end-of-life":
+      return `${name} ${installed} is end-of-life`;
+    case "patch-gap":
+      return `${name} ${installed}${target ? ` → ${target}` : ""}`;
+    default:
+      return `${name} ${installed}`;
+  }
+}
+
+/**
+ * Build the AssuranceFinding upsert for an actionable assessment, or null when there
+ * is nothing to do. Stable findingKey so re-runs upsert rather than duplicate.
+ */
+export function evidenceToPatchFinding(
+  evidence: SoftwareEvidenceLike,
+  assessment: PatchAssessment,
+): PatchFindingUpsert | null {
+  if (!isActionable(assessment)) return null;
+  const affectedId = evidence.id ?? evidence.evidenceKey;
+  const vendorIdentifier =
+    assessment.primaryAdvisoryId ??
+    `${evidence.packageManager ?? "sw"}:${evidence.rawPackageName ?? evidence.rawProductName ?? "unknown"}`;
+  return {
+    findingKey: `${FINDING_KEY_PREFIX}${evidence.evidenceKey}`,
+    findingKind: assessment.findingKind,
+    title: titleFor(evidence, assessment),
+    description: assessment.rationale,
+    affectedType: "DiscoveredSoftwareEvidence",
+    affectedId,
+    adapterKey: adapterKeyFor(assessment),
+    vendorIdentifier,
+    policySeverity: assessment.policySeverity,
+    remediationHint: { ...assessment.remediationHint },
+    source: {
+      installedVersion: evidence.rawVersion ?? null,
+      packageManager: evidence.packageManager ?? null,
+      inventoryEntityId: evidence.inventoryEntityId,
+      customerAccountId: evidence.customerAccountId ?? null,
+      customerSiteId: evidence.customerSiteId ?? null,
+      versionComparison: assessment.versionComparison,
+      cisaKev: assessment.cisaKev,
+    },
+  };
+}
+
+/**
+ * Run the read-only patch assessment across all discovered software: assess each
+ * piece of evidence, upsert the actionable findings, and resolve findings that have
+ * become clean. Returns a posture summary. Pure orchestration over the injected store.
+ */
+export async function runPatchAssessment(
+  store: PatchAssessmentStore,
+  provider: PatchIntelProvider,
+  options: { now?: Date } = {},
+): Promise<PatchAssessmentSummary> {
+  const evidence = await store.listSoftwareEvidence();
+  const byKind: Record<string, number> = {};
+  const bySeverity: Record<string, number> = {};
+  const activeFindingKeys: string[] = [];
+  let actionable = 0;
+
+  for (const ev of evidence) {
+    const intel = await provider(ev);
+    const assessment = assessEvidence(ev, intel, options.now);
+    const finding = evidenceToPatchFinding(ev, assessment);
+    if (!finding) continue;
+    actionable += 1;
+    byKind[finding.findingKind] = (byKind[finding.findingKind] ?? 0) + 1;
+    bySeverity[finding.policySeverity] = (bySeverity[finding.policySeverity] ?? 0) + 1;
+    activeFindingKeys.push(finding.findingKey);
+    await store.upsertFinding(finding);
+  }
+
+  const resolved = await store.resolveFindingsExcept(activeFindingKeys);
+
+  return { assessed: evidence.length, actionable, resolved, byKind, bySeverity };
+}


### PR DESCRIPTION
Builds on #2356 (classifier + OSV/KEV extractors, merged). The **read-only estate-posture projection** — the P0 payoff (BI-489A8BB4). Spec: `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`. Plan: `docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md`.

## What

`packages/db/src/patch/patch-projector.ts` — turns discovered installed-software evidence into patch findings on the **existing Assurance Ledger** (no new findings table). Decoupled from Prisma behind a `PatchAssessmentStore` port so the full **read → assess → upsert → resolve** flow is unit-tested against an in-memory fake store:

- `runPatchAssessment` — assess each `DiscoveredSoftwareEvidence`, upsert actionable `AssuranceFinding` rows (stable `findingKey` = `patch:<evidenceKey>`), **resolve** findings that have become clean, return a posture summary (`assessed / actionable / byKind / bySeverity / resolved`).
- `evidenceToPatchFinding` — maps a verdict to the AssuranceFinding upsert shape (`findingKind` patch-gap|vulnerability|end-of-life; `adapterKey` patch-intel|osv|cisa-kev; `remediationHint`; scope carried from the host).
- `applyViaForPackageManager` — dpkg→apt, rpm→dnf, brew→brew, powershell→winget, …

## Selected by the governance kernel

`principle_decide` (population external_coding_agent, `ringScope` external-coordination + universal-ring + ring-2-workflow, structured features) ranked **projector 9.18 (high confidence, no commandment conflict)** over identity 7.01, live-feed 7.01, pause 5.64 — matching the spec's "read-only value first, identity migration gated to later."

## Why the Prisma binding is NOT here

The real `PatchAssessmentStore` adapter belongs in `apps/web/lib/patch/`, delegating finding writes to the existing `apps/web/lib/assurance/finding-persistence.ts` (single source of truth for `AssuranceFinding` create/update/reopen) — `packages/db` must not hand-roll a parallel upsert, and can't depend on `apps/web`. That binding + the scheduled job + `/ops/patches` UX are the runtime-bound follow-ups, verified via the local-CI sandbox.

## Verification

- `pnpm --filter @dpf/db exec vitest run src/patch/` → **42/42 passed** (incl. projector orchestration + resolution against a fake store).
- `pnpm --filter @dpf/db typecheck` → clean.
- packages/db-only, purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)