### PR TITLE
feat(it4it): IT4IT functional-coverage heatmap on /ea/models/[slug] (BI-03B950CC)

### DIFF
--- a/apps/web/app/(shell)/ea/models/[slug]/page.tsx
+++ b/apps/web/app/(shell)/ea/models/[slug]/page.tsx
@@ -5,11 +5,13 @@ import { ReferenceModelPortfolioTable } from "@/components/ea/ReferenceModelPort
 import { ReferenceModelElementTree } from "@/components/ea/ReferenceModelElementTree";
 import { ReferenceProjectionActions } from "@/components/ea/ReferenceProjectionActions";
 import { ReferenceProposalQueue } from "@/components/ea/ReferenceProposalQueue";
+import { It4itCoverageHeatmap } from "@/components/ea/It4itCoverageHeatmap";
 import { projectReferenceModelValueStreams } from "@/lib/actions/ea";
 import {
   getReferenceModelDetail,
   getReferenceModelElements,
   getReferenceModelPortfolioRollup,
+  getIt4itCoverageHeatmap,
 } from "@/lib/ea-data";
 
 type Props = {
@@ -20,10 +22,11 @@ export default async function ReferenceModelPage({ params }: Props) {
   const { slug } = await params;
 
   try {
-    const [detail, rollup, elements] = await Promise.all([
+    const [detail, rollup, elements, coverage] = await Promise.all([
       getReferenceModelDetail(slug),
       getReferenceModelPortfolioRollup(slug),
       getReferenceModelElements(slug),
+      getIt4itCoverageHeatmap(slug),
     ]);
 
     async function loadValueStreamProjection(formData: FormData) {
@@ -85,6 +88,8 @@ export default async function ReferenceModelPage({ params }: Props) {
         </section>
 
         <ReferenceModelElementTree elements={elements} />
+
+        {coverage.groups.length > 0 && <It4itCoverageHeatmap data={coverage} />}
 
         <section className="mb-6">
           <div className="mb-3">

--- a/apps/web/components/ea/It4itCoverageHeatmap.tsx
+++ b/apps/web/components/ea/It4itCoverageHeatmap.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+// apps/web/components/ea/It4itCoverageHeatmap.tsx
+//
+// IT4IT functional-coverage heatmap (EP-IT4IT-CONFORMANCE). Renders the platform-scope
+// coverage projection as nested capability-group bands of functional-component tiles,
+// coloured through the report-kit status intent registry (no raw hex; color-mix tints).
+// Click a tile to drill into its criteria. Empty state until the steward projection has
+// written assessments. Honesty: no-data is neutral (never green); confidence (derived vs
+// verified) is shown on every tile; the rollup method + a non-certification disclaimer are
+// always visible.
+
+import { useState } from "react";
+import { StatCard } from "@/components/ui/report-kit/StatCard";
+import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
+import { DataTable, type Column } from "@/components/ui/report-kit/DataTable";
+import { ExportButton } from "@/components/ui/report-kit/ExportButton";
+import { intentStyle, resolveIntent } from "@/components/ui/report-kit/statusColors";
+import type {
+  It4itCoverageHeatmap as It4itCoverageHeatmapData,
+  It4itComponentCoverage,
+  It4itCriterionCoverage,
+} from "@/lib/explore/reference-model-types";
+
+const DISCLAIMER =
+  "This is a DPF evidence-derived IT4IT coverage baseline. It is not an Open Group certification or formal conformance claim.";
+
+function tileColors(status: string, score: number) {
+  const intent = resolveIntent("it4itCoverage", status);
+  const style = intentStyle(intent);
+  if (intent === "neutral") {
+    return { background: "var(--dpf-surface-2)", borderColor: "var(--dpf-border)" };
+  }
+  const pct = Math.round(10 + (Math.max(0, Math.min(100, score)) / 100) * 18); // 10–28%
+  return {
+    background: `color-mix(in srgb, ${style.fg} ${pct}%, transparent)`,
+    borderColor: `color-mix(in srgb, ${style.border} 42%, transparent)`,
+  };
+}
+
+function ConfidenceBadge({ confidence }: { confidence: string | null }) {
+  const verified = confidence === "verified" || confidence === "high";
+  return (
+    <span
+      className="rounded px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide"
+      style={{
+        color: verified ? "var(--dpf-success)" : "var(--dpf-muted)",
+        background: verified
+          ? "color-mix(in srgb, var(--dpf-success) 14%, transparent)"
+          : "var(--dpf-surface-2)",
+      }}
+    >
+      {verified ? "verified" : "derived"}
+    </span>
+  );
+}
+
+export function It4itCoverageHeatmap({ data }: { data: It4itCoverageHeatmapData }) {
+  const allComponents = data.groups.flatMap((g) => g.components);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = allComponents.find((c) => c.id === selectedId) ?? null;
+
+  if (!data.hasData) {
+    return (
+      <section className="mb-6">
+        <div className="mb-3">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">IT4IT Functional Coverage</h2>
+          <p className="text-xs text-[var(--dpf-muted)]">
+            Evidence-derived coverage of the IT4IT functional criteria, refreshed by the architecture
+            parity steward.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6 text-center">
+          <p className="text-sm text-[var(--dpf-text)]">No IT4IT assessments have been generated yet.</p>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            Run an architecture parity refresh to establish the baseline. {DISCLAIMER}
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const exportRows = allComponents.map((c) => ({
+    capabilityGroup: c.capabilityGroup,
+    component: c.name,
+    status: c.status,
+    score: c.score,
+    confidence: c.confidence ?? "derived",
+    criteria: c.criteriaCount,
+    requiredCriteria: c.requiredCriteriaCount,
+  }));
+
+  const criteriaColumns: Column<It4itCriterionCoverage>[] = [
+    { key: "name", header: "Criterion", cell: (r) => r.name },
+    {
+      key: "normativeClass",
+      header: "Class",
+      cell: (r) => (
+        <span className="text-xs text-[var(--dpf-muted)]">{r.normativeClass ?? "unset"}</span>
+      ),
+    },
+    { key: "sourceReference", header: "Ref", mono: true, cell: (r) => r.sourceReference ?? "—" },
+    {
+      key: "status",
+      header: "Coverage",
+      cell: (r) => <StatusBadge domain="it4itCoverage" status={r.status} size="sm" />,
+    },
+  ];
+
+  return (
+    <section className="mb-6">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">IT4IT Functional Coverage</h2>
+          <p className="text-xs text-[var(--dpf-muted)]">
+            Evidence-derived coverage of {data.summary.componentsTotal} functional components, refreshed by
+            the architecture parity steward. Colour = coverage status; intensity = evidence score.
+          </p>
+        </div>
+        <ExportButton
+          rows={exportRows}
+          columns={[
+            { key: "capabilityGroup", header: "Capability Group" },
+            { key: "component", header: "Functional Component" },
+            { key: "status", header: "Coverage Status" },
+            { key: "score", header: "Evidence Score" },
+            { key: "confidence", header: "Confidence" },
+            { key: "criteria", header: "Criteria" },
+            { key: "requiredCriteria", header: "Required Criteria" },
+          ]}
+          filename={`${data.modelSlug}-coverage.csv`}
+        />
+      </div>
+
+      <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatCard label="Platform coverage" value={`${data.platformScore}%`} hint="status-weighted, evidence-derived" />
+        <StatCard
+          label="Components with evidence"
+          value={`${data.summary.componentsWithEvidence}/${data.summary.componentsTotal}`}
+          hint={`${data.summary.implemented} implemented · ${data.summary.partial} partial`}
+        />
+        <StatCard
+          label="Required criteria covered"
+          value={`${data.summary.requiredCriteriaImplemented + data.summary.requiredCriteriaPartial}/${data.summary.requiredCriteriaTotal}`}
+          hint={`${data.summary.requiredCriteriaImplemented} implemented`}
+        />
+        <StatCard
+          label="Verified assessments"
+          value={data.summary.verifiedCount}
+          hint={data.summary.verifiedCount === 0 ? "all evidence-derived" : "operator-confirmed"}
+          intent={data.summary.verifiedCount > 0 ? "success" : "neutral"}
+        />
+      </div>
+
+      <div className="space-y-3">
+        {data.groups.map((group) => (
+          <div
+            key={group.group}
+            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+          >
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold text-[var(--dpf-text)]">{group.group}</h3>
+              <span className="text-xs text-[var(--dpf-muted)]">
+                {group.score}% · {group.componentsWithEvidence}/{group.componentCount}
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+              {group.components.map((c) => {
+                const colors = tileColors(c.status, c.score);
+                const isSelected = c.id === selectedId;
+                return (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => setSelectedId(isSelected ? null : c.id)}
+                    aria-pressed={isSelected}
+                    aria-label={`${c.name}: ${c.status.replace("_", " ")}, evidence score ${c.score}`}
+                    className="flex flex-col gap-1 rounded-md border p-2 text-left transition-shadow hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+                    style={{
+                      background: colors.background,
+                      borderColor: isSelected ? "var(--dpf-accent)" : colors.borderColor,
+                    }}
+                  >
+                    <span className="text-xs font-medium leading-tight text-[var(--dpf-text)]">{c.name}</span>
+                    <span className="flex items-center justify-between gap-1">
+                      <span className="text-[10px] capitalize text-[var(--dpf-muted)]">
+                        {c.status.replace("_", " ")}
+                      </span>
+                      <ConfidenceBadge confidence={c.confidence} />
+                    </span>
+                    <span className="text-[10px] text-[var(--dpf-muted)]">
+                      {c.criteriaCount} criteria · {c.requiredCriteriaCount} required
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {selected && (
+        <div className="mt-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <div>
+              <h3 className="text-sm font-semibold text-[var(--dpf-text)]">{selected.name}</h3>
+              <p className="text-xs text-[var(--dpf-muted)]">
+                {selected.capabilityGroup} · <StatusBadgeInline component={selected} /> · evidence score {selected.score}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setSelectedId(null)}
+              className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+            >
+              Close
+            </button>
+          </div>
+          <DataTable<It4itCriterionCoverage>
+            columns={criteriaColumns}
+            rows={selected.criteria}
+            getRowKey={(r) => r.id}
+            pageSize={10}
+            empty="No criteria recorded for this component."
+          />
+        </div>
+      )}
+
+      <p className="mt-3 text-[10px] leading-relaxed text-[var(--dpf-muted)]">
+        {DISCLAIMER} Rollup: {data.method}
+        {data.generatedAt ? ` · last refreshed ${new Date(data.generatedAt).toLocaleString()}` : ""}
+      </p>
+    </section>
+  );
+}
+
+function StatusBadgeInline({ component }: { component: It4itComponentCoverage }) {
+  return <StatusBadge domain="it4itCoverage" status={component.status} size="sm" />;
+}

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -305,6 +305,15 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     "in-motion": "accent",
     unknown: "neutral",
   },
+  // IT4IT functional-criteria coverage (EP-IT4IT-CONFORMANCE). not_started/no-data is
+  // neutral (never green); out_of_mvp is an intentional exclusion, also neutral.
+  it4itCoverage: {
+    implemented: "success",
+    partial: "warning",
+    planned: "info",
+    not_started: "neutral",
+    out_of_mvp: "neutral",
+  },
 };
 
 /**

--- a/apps/web/lib/explore/ea-data.ts
+++ b/apps/web/lib/explore/ea-data.ts
@@ -1,8 +1,10 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
+import { shapeIt4itCoverageHeatmap } from "./it4it-coverage-view";
 import type { SerializedViewElement, SerializedEdge, CanvasState } from "./ea-types";
 import type {
   CoverageStatus,
+  It4itCoverageHeatmap,
   ReferenceModelDetail,
   ReferenceModelElementNode,
   ReferenceModelPortfolioRollup,
@@ -381,4 +383,35 @@ export const getReferenceModelDetail = cache(
       },
     };
   }
+);
+
+// ── IT4IT functional-coverage heatmap (EP-IT4IT-CONFORMANCE) ──────────────────
+// Cached query over the platform-scope EaReferenceAssessment rows written by the
+// it4it-coverage steward projection; the grouping + rollup math lives in the pure,
+// unit-tested it4it-coverage-view module. Renders an empty state until the first steward
+// pass has written assessments.
+export const getIt4itCoverageHeatmap = cache(
+  async (slug: string): Promise<It4itCoverageHeatmap> => {
+    const model = await prisma.eaReferenceModel.findUnique({
+      where: { slug },
+      select: { id: true, name: true },
+    });
+    if (!model) throw new Error("Reference model not found");
+
+    const [elements, assessments] = await Promise.all([
+      prisma.eaReferenceModelElement.findMany({
+        where: {
+          modelId: model.id,
+          kind: { in: ["capability_group", "function", "component", "criterion"] },
+        },
+        select: { id: true, parentId: true, kind: true, name: true, normativeClass: true, sourceReference: true },
+      }),
+      prisma.eaReferenceAssessment.findMany({
+        where: { modelId: model.id, scope: { scopeType: "platform" } },
+        select: { modelElementId: true, coverageStatus: true, confidence: true, evidenceSummary: true, updatedAt: true },
+      }),
+    ]);
+
+    return shapeIt4itCoverageHeatmap({ slug, modelName: model.name, elements, assessments });
+  },
 );

--- a/apps/web/lib/explore/it4it-coverage-view.test.ts
+++ b/apps/web/lib/explore/it4it-coverage-view.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  shapeIt4itCoverageHeatmap,
+  it4itCoverageStatus,
+  parseEvidenceScore,
+  type It4itElementRow,
+  type It4itAssessmentRow,
+} from "./it4it-coverage-view";
+
+const NOW = new Date("2026-06-25T00:00:00Z");
+
+function elements(): It4itElementRow[] {
+  return [
+    { id: "cg-s2p", parentId: null, kind: "capability_group", name: "Strategy to Portfolio", normativeClass: null, sourceReference: null },
+    { id: "fn-s2p", parentId: "cg-s2p", kind: "function", name: "Strategy Function", normativeClass: null, sourceReference: null },
+    { id: "ea", parentId: "fn-s2p", kind: "component", name: "Enterprise Architecture", normativeClass: null, sourceReference: null },
+    { id: "ea-1", parentId: "ea", kind: "criterion", name: "shall align", normativeClass: "required", sourceReference: "6.1.1" },
+    { id: "ea-2", parentId: "ea", kind: "criterion", name: "may publish", normativeClass: "optional", sourceReference: "6.1.2" },
+    { id: "cg-d2c", parentId: null, kind: "capability_group", name: "Detect to Correct", normativeClass: null, sourceReference: null },
+    { id: "fn-d2c", parentId: "cg-d2c", kind: "function", name: "Detect Function", normativeClass: null, sourceReference: null },
+    { id: "pr", parentId: "fn-d2c", kind: "component", name: "Problem", normativeClass: null, sourceReference: null },
+    { id: "pr-1", parentId: "pr", kind: "criterion", name: "shall track", normativeClass: "required", sourceReference: "8.3.1" },
+  ];
+}
+
+function assessments(): It4itAssessmentRow[] {
+  return [
+    { modelElementId: "ea", coverageStatus: "implemented", confidence: "derived", evidenceSummary: JSON.stringify({ evidenceScore: 100 }), updatedAt: NOW },
+    { modelElementId: "ea-1", coverageStatus: "implemented", confidence: "derived", evidenceSummary: null, updatedAt: NOW },
+    { modelElementId: "ea-2", coverageStatus: "implemented", confidence: "derived", evidenceSummary: null, updatedAt: NOW },
+    { modelElementId: "pr", coverageStatus: "partial", confidence: "verified", evidenceSummary: JSON.stringify({ evidenceScore: 50 }), updatedAt: NOW },
+    { modelElementId: "pr-1", coverageStatus: "partial", confidence: "derived", evidenceSummary: null, updatedAt: NOW },
+  ];
+}
+
+describe("it4itCoverageStatus", () => {
+  it("passes through valid statuses and defaults unknown to not_started", () => {
+    expect(it4itCoverageStatus("implemented")).toBe("implemented");
+    expect(it4itCoverageStatus("out_of_mvp")).toBe("out_of_mvp");
+    expect(it4itCoverageStatus(null)).toBe("not_started");
+    expect(it4itCoverageStatus("garbage")).toBe("not_started");
+  });
+});
+
+describe("parseEvidenceScore", () => {
+  it("reads evidenceScore from JSON, tolerates null/garbage", () => {
+    expect(parseEvidenceScore(JSON.stringify({ evidenceScore: 65 }))).toBe(65);
+    expect(parseEvidenceScore(null)).toBeNull();
+    expect(parseEvidenceScore("not json")).toBeNull();
+    expect(parseEvidenceScore(JSON.stringify({ other: 1 }))).toBeNull();
+  });
+});
+
+describe("shapeIt4itCoverageHeatmap", () => {
+  it("renders an empty state when there are no assessments", () => {
+    const m = shapeIt4itCoverageHeatmap({ slug: "it4it_v3_0_1", modelName: "IT4IT", elements: elements(), assessments: [] });
+    expect(m.hasData).toBe(false);
+    expect(m.assessmentCount).toBe(0);
+    expect(m.platformScore).toBe(0);
+    // components still enumerated, all not_started
+    expect(m.summary.componentsTotal).toBe(2);
+    expect(m.summary.componentsWithEvidence).toBe(0);
+  });
+
+  it("groups components by capability group in canonical order", () => {
+    const m = shapeIt4itCoverageHeatmap({ slug: "it4it_v3_0_1", modelName: "IT4IT", elements: elements(), assessments: assessments() });
+    expect(m.hasData).toBe(true);
+    expect(m.groups.map((g) => g.group)).toEqual(["Strategy to Portfolio", "Detect to Correct"]);
+  });
+
+  it("derives component status, score, and confidence from assessments", () => {
+    const m = shapeIt4itCoverageHeatmap({ slug: "it4it_v3_0_1", modelName: "IT4IT", elements: elements(), assessments: assessments() });
+    const ea = m.groups.flatMap((g) => g.components).find((c) => c.id === "ea")!;
+    expect(ea.status).toBe("implemented");
+    expect(ea.score).toBe(100);
+    expect(ea.criteriaCount).toBe(2);
+    expect(ea.requiredCriteriaCount).toBe(1);
+    const pr = m.groups.flatMap((g) => g.components).find((c) => c.id === "pr")!;
+    expect(pr.status).toBe("partial");
+    expect(pr.confidence).toBe("verified");
+  });
+
+  it("computes a status-weighted platform score over functional criteria", () => {
+    const m = shapeIt4itCoverageHeatmap({ slug: "it4it_v3_0_1", modelName: "IT4IT", elements: elements(), assessments: assessments() });
+    // EA implemented(1.0) weight 2(req)+0.5(opt)=2.5 -> 2.5; Problem partial(0.5) weight 2 -> 1.0
+    // score = 3.5 / 4.5 = 78%
+    expect(m.platformScore).toBe(78);
+  });
+
+  it("counts verified assessments and honest summary totals", () => {
+    const m = shapeIt4itCoverageHeatmap({ slug: "it4it_v3_0_1", modelName: "IT4IT", elements: elements(), assessments: assessments() });
+    expect(m.summary.implemented).toBe(1);
+    expect(m.summary.partial).toBe(1);
+    expect(m.summary.requiredCriteriaTotal).toBe(2);
+    expect(m.summary.requiredCriteriaImplemented).toBe(1);
+    expect(m.summary.requiredCriteriaPartial).toBe(1);
+    expect(m.summary.verifiedCount).toBe(1); // Problem component is verified
+    expect(m.generatedAt).toBe(NOW.toISOString());
+  });
+
+  it("falls back to a status-derived score when evidenceScore is absent", () => {
+    const a: It4itAssessmentRow[] = [
+      { modelElementId: "ea", coverageStatus: "implemented", confidence: "derived", evidenceSummary: null, updatedAt: NOW },
+    ];
+    const m = shapeIt4itCoverageHeatmap({ slug: "it4it_v3_0_1", modelName: "IT4IT", elements: elements(), assessments: a });
+    const ea = m.groups.flatMap((g) => g.components).find((c) => c.id === "ea")!;
+    expect(ea.score).toBe(100); // fallback for implemented
+  });
+});

--- a/apps/web/lib/explore/it4it-coverage-view.ts
+++ b/apps/web/lib/explore/it4it-coverage-view.ts
@@ -1,0 +1,205 @@
+// apps/web/lib/explore/it4it-coverage-view.ts
+//
+// Pure view-shaping for the IT4IT coverage heatmap (EP-IT4IT-CONFORMANCE). Takes the raw
+// IT4IT element tree + platform-scope assessment rows and produces the grouped, rolled-up
+// It4itCoverageHeatmap the UI renders. No IO — the cached query lives in ea-data.ts and
+// delegates here so the grouping/rollup math is unit-testable in isolation.
+
+import { STATUS_ROLLUP_VALUE, normativeWeight, ROLLUP_METHOD } from "@/lib/ea/it4it-coverage-extract";
+import type {
+  CoverageStatus,
+  It4itCoverageHeatmap,
+  It4itCoverageGroup,
+  It4itComponentCoverage,
+  It4itCriterionCoverage,
+} from "./reference-model-types";
+
+export interface It4itElementRow {
+  id: string;
+  parentId: string | null;
+  kind: string;
+  name: string;
+  normativeClass: string | null;
+  sourceReference: string | null;
+}
+
+export interface It4itAssessmentRow {
+  modelElementId: string;
+  coverageStatus: string;
+  confidence: string | null;
+  evidenceSummary: string | null;
+  updatedAt: Date;
+}
+
+const IT4IT_GROUP_ORDER = [
+  "Strategy to Portfolio",
+  "Requirement to Deploy",
+  "Request to Fulfill",
+  "Detect to Correct",
+  "Supporting Functions",
+];
+
+const IT4IT_STATUS_FALLBACK_SCORE: Record<CoverageStatus, number> = {
+  implemented: 100,
+  partial: 50,
+  planned: 25,
+  not_started: 0,
+  out_of_mvp: 0,
+};
+
+const IT4IT_VERIFIED_CONFIDENCES = new Set(["verified", "high"]);
+
+export function it4itCoverageStatus(value: string | null | undefined): CoverageStatus {
+  const allowed: CoverageStatus[] = ["implemented", "partial", "planned", "not_started", "out_of_mvp"];
+  return allowed.includes(value as CoverageStatus) ? (value as CoverageStatus) : "not_started";
+}
+
+export function parseEvidenceScore(evidenceSummary: string | null): number | null {
+  if (!evidenceSummary) return null;
+  try {
+    const parsed = JSON.parse(evidenceSummary) as { evidenceScore?: unknown };
+    return typeof parsed.evidenceScore === "number" ? parsed.evidenceScore : null;
+  } catch {
+    return null;
+  }
+}
+
+export function shapeIt4itCoverageHeatmap(params: {
+  slug: string;
+  modelName: string;
+  elements: It4itElementRow[];
+  assessments: It4itAssessmentRow[];
+}): It4itCoverageHeatmap {
+  const { slug, modelName, elements, assessments } = params;
+
+  const byId = new Map(elements.map((e) => [e.id, e]));
+  const assessmentByElement = new Map(assessments.map((a) => [a.modelElementId, a]));
+
+  const groupCache = new Map<string, string | null>();
+  function resolveGroup(elementId: string | null): string | null {
+    if (!elementId) return null;
+    if (groupCache.has(elementId)) return groupCache.get(elementId) ?? null;
+    const el = byId.get(elementId);
+    if (!el) {
+      groupCache.set(elementId, null);
+      return null;
+    }
+    const g = el.kind === "capability_group" ? el.name : resolveGroup(el.parentId);
+    groupCache.set(elementId, g);
+    return g;
+  }
+
+  const criteriaByComponent = new Map<string, It4itElementRow[]>();
+  for (const el of elements) {
+    if (el.kind === "criterion" && el.parentId) {
+      const arr = criteriaByComponent.get(el.parentId) ?? [];
+      arr.push(el);
+      criteriaByComponent.set(el.parentId, arr);
+    }
+  }
+
+  let verifiedCount = 0;
+  const components: It4itComponentCoverage[] = [];
+  for (const comp of elements.filter((e) => e.kind === "component")) {
+    const group = resolveGroup(comp.id) ?? "Supporting Functions";
+    const a = assessmentByElement.get(comp.id);
+    const status = it4itCoverageStatus(a?.coverageStatus);
+    const score = parseEvidenceScore(a?.evidenceSummary ?? null) ?? IT4IT_STATUS_FALLBACK_SCORE[status];
+    if (a?.confidence && IT4IT_VERIFIED_CONFIDENCES.has(a.confidence.toLowerCase())) verifiedCount += 1;
+
+    const critEls = criteriaByComponent.get(comp.id) ?? [];
+    const criteria: It4itCriterionCoverage[] = critEls
+      .map((c) => {
+        const ca = assessmentByElement.get(c.id);
+        if (ca?.confidence && IT4IT_VERIFIED_CONFIDENCES.has(ca.confidence.toLowerCase())) verifiedCount += 1;
+        return {
+          id: c.id,
+          name: c.name,
+          normativeClass: c.normativeClass,
+          sourceReference: c.sourceReference,
+          status: it4itCoverageStatus(ca?.coverageStatus),
+          confidence: ca?.confidence ?? null,
+        };
+      })
+      .sort((x, y) => (x.sourceReference ?? "").localeCompare(y.sourceReference ?? ""));
+
+    components.push({
+      id: comp.id,
+      name: comp.name,
+      capabilityGroup: group,
+      status,
+      score,
+      confidence: a?.confidence ?? null,
+      criteriaCount: critEls.length,
+      requiredCriteriaCount: critEls.filter((c) => (c.normativeClass ?? "").toLowerCase() === "required").length,
+      criteria,
+    });
+  }
+
+  function weightedScore(comps: It4itComponentCoverage[]): number {
+    let num = 0;
+    let den = 0;
+    for (const c of comps) {
+      const sv = STATUS_ROLLUP_VALUE[c.status];
+      if (sv === null) continue; // out_of_mvp excluded
+      const critEls = criteriaByComponent.get(c.id) ?? [];
+      let weight = 0;
+      for (const ce of critEls) weight += normativeWeight(ce.normativeClass);
+      if (weight === 0) weight = normativeWeight(null);
+      num += sv * weight;
+      den += weight;
+    }
+    return den > 0 ? Math.round((num / den) * 100) : 0;
+  }
+
+  const groupsMap = new Map<string, It4itComponentCoverage[]>();
+  for (const c of components) {
+    const arr = groupsMap.get(c.capabilityGroup) ?? [];
+    arr.push(c);
+    groupsMap.set(c.capabilityGroup, arr);
+  }
+
+  const groups: It4itCoverageGroup[] = [];
+  for (const [group, comps] of groupsMap) {
+    comps.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+    groups.push({
+      group,
+      score: weightedScore(comps),
+      componentCount: comps.length,
+      componentsWithEvidence: comps.filter((c) => c.status !== "not_started").length,
+      components: comps,
+    });
+  }
+  groups.sort((a, b) => {
+    const ia = IT4IT_GROUP_ORDER.indexOf(a.group);
+    const ib = IT4IT_GROUP_ORDER.indexOf(b.group);
+    return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib) || a.group.localeCompare(b.group);
+  });
+
+  const latest = assessments.reduce<Date | null>((m, a) => (!m || a.updatedAt > m ? a.updatedAt : m), null);
+
+  return {
+    modelSlug: slug,
+    modelName,
+    hasData: assessments.length > 0,
+    assessmentCount: assessments.length,
+    generatedAt: latest ? latest.toISOString() : null,
+    platformScore: weightedScore(components),
+    groups,
+    summary: {
+      componentsTotal: components.length,
+      componentsWithEvidence: components.filter((c) => c.status !== "not_started").length,
+      implemented: components.filter((c) => c.status === "implemented").length,
+      partial: components.filter((c) => c.status === "partial").length,
+      requiredCriteriaTotal: components.reduce((s, c) => s + c.requiredCriteriaCount, 0),
+      requiredCriteriaImplemented: components
+        .filter((c) => c.status === "implemented")
+        .reduce((s, c) => s + c.requiredCriteriaCount, 0),
+      requiredCriteriaPartial: components
+        .filter((c) => c.status === "partial")
+        .reduce((s, c) => s + c.requiredCriteriaCount, 0),
+      verifiedCount,
+    },
+    method: ROLLUP_METHOD,
+  };
+}

--- a/apps/web/lib/explore/reference-model-types.ts
+++ b/apps/web/lib/explore/reference-model-types.ts
@@ -43,6 +43,60 @@ export type ReferenceModelElementNode = {
   properties: Record<string, unknown>;
 };
 
+export type It4itCriterionCoverage = {
+  id: string;
+  name: string;
+  normativeClass: string | null;
+  sourceReference: string | null;
+  status: CoverageStatus;
+  confidence: string | null;
+};
+
+export type It4itComponentCoverage = {
+  id: string;
+  name: string;
+  capabilityGroup: string;
+  status: CoverageStatus;
+  /** Evidence score 0..100 (drives heatmap intensity); 0 when unassessed. */
+  score: number;
+  confidence: string | null;
+  criteriaCount: number;
+  requiredCriteriaCount: number;
+  criteria: It4itCriterionCoverage[];
+};
+
+export type It4itCoverageGroup = {
+  group: string;
+  /** Status-weighted coverage rollup 0..100 over the group's functional criteria. */
+  score: number;
+  componentCount: number;
+  componentsWithEvidence: number;
+  components: It4itComponentCoverage[];
+};
+
+export type It4itCoverageHeatmap = {
+  modelSlug: string;
+  modelName: string;
+  /** True once the steward projection has written platform-scope assessments. */
+  hasData: boolean;
+  assessmentCount: number;
+  generatedAt: string | null;
+  /** Status-weighted coverage rollup 0..100 over all functional criteria. */
+  platformScore: number;
+  groups: It4itCoverageGroup[];
+  summary: {
+    componentsTotal: number;
+    componentsWithEvidence: number;
+    implemented: number;
+    partial: number;
+    requiredCriteriaTotal: number;
+    requiredCriteriaImplemented: number;
+    requiredCriteriaPartial: number;
+    verifiedCount: number;
+  };
+  method: string;
+};
+
 export type ReferenceModelDetail = {
   id: string;
   slug: string;

--- a/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
@@ -1,6 +1,6 @@
 # IT4IT Conformance Coverage Heatmap Design
 
-- **Status:** Draft, architecture-reviewed
+- **Status:** In progress — Phase 0+1 (projection) shipped in PR #2354 (merged); Phase 2 (heatmap) landing now
 - **Date:** 2026-06-24
 - **Reviewed:** 2026-06-25
 - **Epic:** EP-IT4IT-CONFORMANCE
@@ -353,7 +353,7 @@ Refactoring tasks:
 - Add license-safe display helpers.
 - Tests: constants, normalization, upsert, no-clobber.
 
-### Phase 1 - Projection
+### Phase 1 - Projection (shipped, PR #2354)
 
 - Implement `buildIt4itCoverageModel`.
 - Implement `reconcileIt4itCoverage`.
@@ -362,13 +362,14 @@ Refactoring tasks:
 - File `EaConformanceIssue` for required gaps and hygiene findings.
 - Tests: idempotency, first-run baseline creation, verified-row preservation, no-data neutral, crosswalk correctness.
 
-### Phase 2 - Heatmap
+### Phase 2 - Heatmap (landing now)
 
-- Add `it4itCoverage` domain to report-kit `STATUS_INTENT`.
-- Add an IT4IT coverage view model for `/ea/models/[slug]`.
-- Add nested-tile heatmap section for `it4it_v3_0_1`.
-- Add summary strip, scope selector, confidence filter, drill-down rail, and CSV export.
-- Tests: render empty state, render populated state, confidence badges, no raw colors, CSV output.
+- Add `it4itCoverage` domain to report-kit `STATUS_INTENT`. [done]
+- Add an IT4IT coverage view model for `/ea/models/[slug]` — pure `shapeIt4itCoverageHeatmap` in `lib/explore/it4it-coverage-view.ts` + cached `getIt4itCoverageHeatmap` query. [done]
+- Add nested-tile heatmap section for `it4it_v3_0_1` (`components/ea/It4itCoverageHeatmap.tsx`), rendered on the model page only when the model has functional components. [done]
+- Summary StatCards, capability-group bands, colour-mix intensity by evidence score, tile drill-down to a criteria DataTable, CSV export, empty state, non-certification disclaimer. [done]
+- Tests: pure view-shaping (`it4it-coverage-view.test.ts`) — grouping, ordering, status/score/confidence derivation, weighted rollup, empty state, evidence-score fallback. [done]
+- Deferred follow-ups: by-value-stream lens (needs the crosswalk inverse), per-portfolio scope selector, operator override actions (BI-25066DD8). Live UX verification against populated data runs after this deploys and the steward writes the baseline.
 
 ### Phase 3 - Override UX
 


### PR DESCRIPTION
## Phase 2 of EP-IT4IT-CONFORMANCE — the heatmap view

Renders the platform-scope IT4IT coverage projection (shipped in [#2354](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2354)) as an elegant, theme-aware heatmap on the IT4IT reference-model page — **reusing the report-kit colour engine and the capability-map tile idiom**, not a new charting dependency.

### What changed
- **`statusColors.ts`** — one new `it4itCoverage` intent domain (`implemented→success`, `partial→warning`, `planned→info`, `not_started`/`out_of_mvp→neutral`). No-data is neutral, never green.
- **`lib/explore/it4it-coverage-view.ts`** — pure, unit-tested `shapeIt4itCoverageHeatmap`: groups functional components by capability group, inherits each criterion's status, rolls up a status-weighted coverage score, drives tile intensity by evidence score, counts verified assessments. **`ea-data.ts`** adds a cached `getIt4itCoverageHeatmap` query that delegates to it.
- **`components/ea/It4itCoverageHeatmap.tsx`** — summary StatCards → capability-group bands of `color-mix`-tinted component tiles → click-a-tile drill-down to a criteria `DataTable`; CSV export; empty state; and a **non-certification disclaimer** (Open Group licensing boundary, per the reviewed spec).
- Wired into `/ea/models/[slug]`; the section renders only for models that have functional components (i.e. IT4IT), so BIAN etc. are unaffected.

### Honesty discipline (from the reviewed spec)
No-data tiles are neutral; **confidence (derived vs verified) is shown on every tile**; the rollup method + the "not an Open Group certification" disclaimer are always visible. Until the steward writes the baseline post-deploy, the section shows a clear empty state with a refresh hint.

### Verification
- ✅ **Unit tests:** 8 new view-shaping tests (`it4it-coverage-view.test.ts`) + 239 report-kit/explore tests green.
- ✅ **Typecheck:** `pnpm --filter web typecheck` clean.
- ✅ **Production build:** `next build` clean (exercises the new client/server boundary).
- ⏳ **Live UX against populated data** runs after this deploys and the steward writes the platform-scope baseline; today it renders the verified empty state.

### Scope / deferred
First heatmap is capability-group-primary (where the functional criteria live). Deferred follow-ups: by-value-stream lens (needs the crosswalk inverse), per-portfolio scope selector, and the operator override actions (BI-25066DD8).

Spec: `docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md` (Phase 2 marked landed)
Epic: `EP-IT4IT-CONFORMANCE` · Item: `BI-03B950CC` · builds on #2354

UX-Fit-Decision: Progressive disclosure — summary StatCards → capability-group heatmap bands → tile drill-down. Colour carries the signal via the report-kit `it4itCoverage` intent domain (theme-aware `--dpf-*` tokens, no raw hex, no-data neutral). Reuses the capability-map tile idiom + report-kit primitives; no new dashboard shell, no new global nav, no raw numeric inputs; sits on the existing `/ea/models/[slug]` route. `human_cognitive_load`: low (read-only, one section on an expert EA surface). `principle_decide` is degenerate on that axis (no kernel principle scores it), so decided on merits per the EP-NAV-COHERENCE precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)