### PR TITLE
fix(coworker): honor COWORKER_READ_BASELINE_GRANTS at tool-execution time

### DIFF
--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -428,3 +428,86 @@ describe("governedExecuteTool — JSON-string arg coercion (BI-16A80690)", () =>
     expect(dispatchedParams.callingPopulation).toBe("human");
   });
 });
+
+// BI-FD7E4D72: in-portal coworker chat turns attach COWORKER_READ_BASELINE_GRANTS
+// to the tool surface (agent-coworker.ts), so the execution-time agent-grant check
+// must honour the SAME baseline when context.coworkerReadBaseline is set —
+// otherwise a coworker whose own role grants omit a baseline grant (e.g.
+// ops-coordinator without code_graph_read) gets the read tool attached but
+// rejected on call. These tests use the REAL isToolAllowedByGrants (no predicate
+// override) so the actual grant merge + TOOL_TO_GRANTS mapping are exercised.
+describe("governedExecuteTool — coworker read-baseline at execution time", () => {
+  // ops-coordinator-style grants: backlog reads only, NO code_graph_read and NO
+  // backlog_write. search_code_graph requires code_graph_read (in the baseline);
+  // create_backlog_item requires backlog_write (NOT in the baseline).
+  const ROLE_GRANTS_WITHOUT_BASELINE = ["backlog_read"];
+
+  it("ALLOWS a baseline-only read tool when coworkerReadBaseline is set, even though the agent's own grants lack code_graph_read", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ROLE_GRANTS_WITHOUT_BASELINE,
+      // No isAllowedByGrants override → real isToolAllowedByGrants runs, so the
+      // baseline merge in governedExecuteTool is what makes this pass.
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "search_code_graph",
+      rawParams: { query: "coworker tool-attachment cap" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "ops-coordinator", coworkerReadBaseline: true },
+      source: "agentic-loop",
+    });
+
+    expect(result.error).not.toBe("forbidden_grant");
+    expect(result.success).toBe(true);
+    expect(executeMock).toHaveBeenCalledOnce();
+    expect(auditRows[0]?.success).toBe(true);
+  });
+
+  it("still DENIES a tool whose required grant is in neither the agent's grants nor the baseline (backlog_write)", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ROLE_GRANTS_WITHOUT_BASELINE, // no backlog_write
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "x", type: "product", source: "user-request" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "ops-coordinator", coworkerReadBaseline: true },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("forbidden_grant");
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(auditRows[0]?.success).toBe(false);
+  });
+
+  it("does NOT widen authority when coworkerReadBaseline is unset (autonomous/build scope unchanged)", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ROLE_GRANTS_WITHOUT_BASELINE,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "search_code_graph",
+      rawParams: { query: "coworker tool-attachment cap" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      // No coworkerReadBaseline flag — an autonomous turn that never attached the
+      // baseline must not gain it at execution time.
+      context: { agentId: "ops-coordinator" },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("forbidden_grant");
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -48,6 +48,19 @@ export type GovernedExecuteContext = {
    * skill metrics can attribute action evidence to the originating skill.
    */
   skillId?: string;
+  /**
+   * In-portal coworker chat turns surface COWORKER_READ_BASELINE_GRANTS on the
+   * attached tool set (getAvailableTools' `additionalGrants` option, called from
+   * actions/agent-coworker.ts — BI-FD7E4D72). Set true by runAgenticLoop for
+   * interactive `chat` turns so the execution-time agent-grant check honours the
+   * SAME baseline the attach side used; without it a coworker whose own role
+   * grants omit a baseline read grant (e.g. ops-coordinator without
+   * code_graph_read) gets search_code_graph / read_project_file attached but
+   * rejected on call. Left unset for autonomous/build turns so their authority is
+   * unchanged. The baseline is read-only and still bounded by the user-capability
+   * gate, so honouring it here never escalates beyond what the operator may see.
+   */
+  coworkerReadBaseline?: boolean;
 };
 
 export type GovernedExecuteArgs = {
@@ -416,7 +429,20 @@ export async function governedExecuteTool(
   // Agent grant check — when an agentId is in the context, the agent must
   // have a grant that authorises this tool.
   if (args.context?.agentId) {
-    const grants = await resolveGrants(args.context.agentId);
+    let grants = await resolveGrants(args.context.agentId);
+    // In-portal coworker chat turns attach COWORKER_READ_BASELINE_GRANTS to the
+    // tool surface at resolution time (getAvailableTools' `additionalGrants` in
+    // actions/agent-coworker.ts, BI-FD7E4D72). Mirror that here so the same
+    // baseline reads the model was offered are also executable — otherwise a
+    // coworker whose own role grants omit a baseline grant gets a read tool
+    // (search_code_graph, read_project_file, doc_search, …) attached but rejected
+    // on call. Read-only by construction and already bounded by the
+    // user-capability gate above; scoped to coworker chat turns (runAgenticLoop
+    // sets the flag), so autonomous/build authority is unchanged.
+    if (args.context.coworkerReadBaseline) {
+      const { COWORKER_READ_BASELINE_GRANTS } = await import("./tak/agent-grants");
+      grants = Array.from(new Set([...grants, ...COWORKER_READ_BASELINE_GRANTS]));
+    }
     const allowed = await isAllowedByGrants(args.toolName, grants);
     if (!allowed) {
       const result = rejectionResult(

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -2109,6 +2109,13 @@ export async function runAgenticLoop(params: {
             taskRunId: taskRunId ?? undefined,
             apiTokenId: apiTokenId ?? undefined,
             skillId: activeSkillId ?? undefined,
+            // In-portal coworker chat turns attach COWORKER_READ_BASELINE_GRANTS
+            // to the tool surface (actions/agent-coworker.ts). Flag the turn so
+            // the governed grant check honours the same baseline at execution
+            // time (BI-FD7E4D72) — otherwise a coworker whose own grants lack a
+            // baseline read grant gets the tool attached but rejected on call.
+            // Autonomous turns leave this false, so their authority is unchanged.
+            coworkerReadBaseline: interactionMode === "chat",
             // BI-F4A30FCB (Dale dogfood 2026-05-24): plumb the build the
             // user is messaging from into tool context so phase-scoped
             // tools (start_ideate_research, start_scout_research) can


### PR DESCRIPTION
## Problem
In-portal coworker chat turns **attach** `COWORKER_READ_BASELINE_GRANTS` to the tool surface (`getAvailableTools(..., additionalGrants)` in `apps/web/lib/actions/agent-coworker.ts`), but the **execution-time** agent-grant check in `governedExecuteTool` resolved only the agent's own grants (`resolveGrants → getAgentToolGrantsAsync`). Every baseline-only read tool (`search_code_graph`, `read_project_file`, `doc_search`, work-capsule reads) was therefore **attached then rejected** with `forbidden_grant` when the coworker actually called it.

**Live repro:** the Scrum Master (`ops-coordinator`) called `search_code_graph` and got `rejected: agent ops-coordinator lacks a required grant for search_code_graph` — its own grants omit `code_graph_read`; it held that grant only via the baseline at attach time — then fell back to filing a junk backlog item (BI-BEA624BA). This defeated BI-FD7E4D72 ("every coworker can read source + the code graph") at the execution layer.

**Blast radius:** all **63** registry coworkers lack ≥1 baseline grant in their own `tool_grants`, so the gap silently affected every coworker — not just `ops-coordinator`.

## Fix
Mirror the attach side at execution time, scoped to in-portal coworker chat turns:
- `runAgenticLoop` flags interactive chat turns (`interactionMode === "chat"` — set only by `agent-coworker.ts sendMessage`, the same call site that attaches the baseline) via a new `context.coworkerReadBaseline`.
- `governedExecuteTool` merges `COWORKER_READ_BASELINE_GRANTS` into the resolved grants when that flag is set, before `isAllowedByGrants`.

**Scoping preserved:** autonomous coworker runtime (`resolveAutonomousWorkTools` never attaches the baseline; loop defaults to `"autonomous"`), build agents, and external MCP/REST/JSON-RPC paths never set the flag → authority unchanged. The merge is read-only and still sits **below** the user-capability gate (`can(...)` runs first), so it can never escalate beyond what the operator may see — exactly the attach-side invariant.

## Files
- `apps/web/lib/mcp-governed-execute.ts` — new `coworkerReadBaseline` context field + baseline merge in the agent-grant check.
- `apps/web/lib/tak/agentic-loop.ts` — set `coworkerReadBaseline: interactionMode === "chat"`.
- `apps/web/lib/mcp-governed-execute.test.ts` — 3 regression tests.

## Tests / verification (substrate: topic worktree, source-local gates after `pnpm install`)
- `vitest` — 126 passed across `mcp-governed-execute.test.ts` + `agent-grants.test.ts`. New tests: baseline tool execution-**ALLOWED** for an agent lacking `code_graph_read` but holding the baseline; still **DENIED** for a genuinely-lacked non-baseline grant (`backlog_write`); **not widened** when the flag is absent.
- `pnpm --filter web typecheck` — clean.
- Production build / live UX gate not applicable (server-side governance logic, no UI surface).

Process-Spine-Decision: localized governance bugfix (attach/execute grant-parity), no contract or doc surface changed; the fix and its rationale are captured in code comments referencing BI-FD7E4D72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
