### PR TITLE
refactor(contracts): invert @dpf/types away from Prisma payloads (BI-ARCH-CONTRACTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,24 @@ jobs:
       - name: Run guard
         run: node scripts/check-no-raw-event-source.mjs
 
+  package-boundary-guard:
+    name: Package Boundary Guard
+    runs-on: ubuntu-latest
+    # BI-ARCH-PACKAGES. The portable contract/client packages (@dpf/types,
+    # @dpf/validators, @dpf/api-client) are shared with the mobile app and must
+    # never depend on server persistence. This guard fails any PR that makes a
+    # portable package declare or import @dpf/db / Prisma. The same check runs as
+    # a web unit test (apps/web/lib/contracts/package-boundaries.test.ts). See
+    # docs/architecture/package-boundaries.md.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Run guard
+        run: node scripts/check-package-boundaries.mjs
+
   sbom-divergence-guard:
     name: SBOM Divergence Guard
     runs-on: ubuntu-latest

--- a/apps/web/lib/contracts/entity-contract-drift.ts
+++ b/apps/web/lib/contracts/entity-contract-drift.ts
@@ -1,0 +1,106 @@
+// Server-side contract drift guard.
+//
+// Asserts that each portable entity DTO in `@dpf/types` stays structurally
+// compatible with the Prisma payload it mirrors. `@dpf/types` may no longer
+// import Prisma — it is a portable contract shared with the mobile app and the
+// API client (see docs/architecture/package-boundaries.md) — so this check
+// lives here in the web app, which legitimately depends on both `@dpf/db` and
+// `@dpf/types`.
+//
+// If the Prisma schema changes such that a payload no longer satisfies its DTO
+// (a renamed, removed, or retyped column the wire contract still promises), one
+// of the assertions below stops compiling and `pnpm --filter web typecheck`
+// (and the production build) fails — surfacing the drift before it ships to a
+// portable consumer.
+//
+// Two columns serialize differently from their in-memory Prisma type, so the
+// `Wire<>` helper maps them to the shape the DTO promises:
+//   * `Decimal`  -> `number`      (validators use `z.number()`)
+//   * `Json`     -> contract `JsonValue` (the two recursive JSON types are
+//                                   normalized so optional-member nuances in
+//                                   Prisma's `JsonValue` do not cause a false
+//                                   mismatch)
+// `DateTime` is intentionally left as `Date` to match the DTOs exactly.
+
+import type { Prisma } from "@dpf/db";
+import type {
+  AgentActionProposal,
+  AgentMessage,
+  AgentThread,
+  AuthorizationDecisionLog,
+  BacklogItem,
+  CustomerAccount,
+  Epic,
+  Notification,
+  Portfolio,
+} from "@dpf/types";
+
+// Map a single Prisma payload field to its over-the-wire form. Only `Decimal`
+// diverges (Decimal -> number); JSON needs no mapping because the contract
+// `JsonValue` is a structural supertype of Prisma's, and `Date` is carried
+// as-is to match the DTOs.
+type WireField<V> = [V] extends [Prisma.Decimal]
+  ? number
+  : [V] extends [Prisma.Decimal | null]
+    ? number | null
+    : V;
+
+type Wire<T> = { [K in keyof T]: WireField<T[K]> };
+
+// Compiles only if `Actual` is assignable to `Expected`; the constraint is the
+// assertion. A drift makes the type argument violate the constraint and tsc
+// reports it at the offending alias.
+type AssertWireSatisfiesContract<Expected, _Actual extends Expected> = true;
+
+type _Portfolio = AssertWireSatisfiesContract<
+  Portfolio,
+  Wire<Prisma.PortfolioGetPayload<{ include: { products: true; epicPortfolios: true } }>>
+>;
+
+type _Epic = AssertWireSatisfiesContract<
+  Epic,
+  Wire<Prisma.EpicGetPayload<{ include: { portfolios: { include: { portfolio: true } }; items: true } }>>
+>;
+
+type _BacklogItem = AssertWireSatisfiesContract<
+  BacklogItem,
+  Wire<Prisma.BacklogItemGetPayload<{ include: { epic: true; digitalProduct: true; taxonomyNode: true } }>>
+>;
+
+type _CustomerAccount = AssertWireSatisfiesContract<
+  CustomerAccount,
+  Wire<Prisma.CustomerAccountGetPayload<{ include: { contacts: true } }>>
+>;
+
+type _AgentThread = AssertWireSatisfiesContract<
+  AgentThread,
+  Wire<Prisma.AgentThreadGetPayload<{ include: { messages: true } }>>
+>;
+
+type _AgentMessage = AssertWireSatisfiesContract<AgentMessage, Wire<Prisma.AgentMessageGetPayload<object>>>;
+
+type _AgentActionProposal = AssertWireSatisfiesContract<
+  AgentActionProposal,
+  Wire<Prisma.AgentActionProposalGetPayload<object>>
+>;
+
+type _Notification = AssertWireSatisfiesContract<Notification, Wire<Prisma.NotificationGetPayload<object>>>;
+
+type _AuthorizationDecisionLog = AssertWireSatisfiesContract<
+  AuthorizationDecisionLog,
+  Wire<Prisma.AuthorizationDecisionLogGetPayload<object>>
+>;
+
+// Surface the checks as a single exported tuple so no `noUnusedLocals`-style
+// setting can strip them and silently disable the guard.
+export type EntityContractDriftChecks = [
+  _Portfolio,
+  _Epic,
+  _BacklogItem,
+  _CustomerAccount,
+  _AgentThread,
+  _AgentMessage,
+  _AgentActionProposal,
+  _Notification,
+  _AuthorizationDecisionLog,
+];

--- a/apps/web/lib/contracts/package-boundaries.test.ts
+++ b/apps/web/lib/contracts/package-boundaries.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+// Enforces docs/architecture/package-boundaries.md: the portable contract /
+// client packages (consumed by the mobile app) must never depend on `@dpf/db`
+// or Prisma. Reuses the same checker the standalone CI script runs so the rule
+// has a single implementation.
+import {
+  PORTABLE_PACKAGES,
+  checkPackageBoundaries,
+} from "../../../../scripts/check-package-boundaries.mjs";
+
+describe("portable package boundaries", () => {
+  it("keeps portable packages free of @dpf/db / Prisma", () => {
+    const violations = checkPackageBoundaries();
+    expect(violations, `\n${violations.join("\n")}`).toEqual([]);
+  });
+
+  it("guards the contract and client packages", () => {
+    expect(PORTABLE_PACKAGES).toEqual([
+      "packages/types",
+      "packages/validators",
+      "packages/api-client",
+    ]);
+  });
+});

--- a/docs/architecture/package-boundaries.md
+++ b/docs/architecture/package-boundaries.md
@@ -1,0 +1,84 @@
+# Package & Service Boundaries
+
+Status: standard (BI-ARCH-PACKAGES, EP-PLATFORM-CONSOLIDATION)
+Spec: [`docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md`](../superpowers/specs/2026-06-25-platform-consolidation-spine-design.md)
+
+DPF is a hybrid platform — business OS, AI coworker runtime, Build Studio, delivery
+control plane, architecture graph, mobile companion, install/runtime substrate — in one
+monorepo. The workspace (`pnpm-workspace.yaml`) holds `apps/*`, `packages/*`, and
+`services/*`. Not every seam is real. This document is the durable rule for which package
+boundaries DPF keeps and which it collapses.
+
+## The rule
+
+> **Collapse accidental seams; preserve runtime, deployment, distribution, and trust boundaries.**
+
+A boundary is *real* when crossing it has a runtime, deployment, distribution, or trust
+consequence (a server process, a shipped artifact, a security perimeter). A boundary is
+*accidental* when it only exists because of how a type or file happened to be placed, and
+removing it changes nothing a user or operator can observe.
+
+Contract inversion comes before package deletion: it is safer to remove a server
+dependency from a portable package than to merge the portable package into the server.
+
+## Portable contract layer (enforced)
+
+The contract/client layer is shared with the mobile app and external consumers, so it
+**must not depend on server persistence**. These packages may not declare or import
+`@dpf/db`, `@prisma/client`, or `.prisma/client`:
+
+| Package | Role |
+| --- | --- |
+| `@dpf/types` (`packages/types`) | Portable DTOs and shared contract types. |
+| `@dpf/validators` (`packages/validators`) | Pure Zod schemas (validation is part of the contract). |
+| `@dpf/api-client` (`packages/api-client`) | Typed isomorphic API client for mobile / external consumers. |
+
+Why this is the load-bearing seam: `@dpf/types` is consumed by `apps/mobile`. When it
+re-exported `Prisma.*GetPayload` aliases it dragged the entire server persistence layer
+into the shape of a mobile-facing contract, and any model-facing surface that grows with
+each AI-first capability inherited that coupling.
+
+Server-shaped helper types (`Prisma.*GetPayload`, payloads with relation includes used
+only by route handlers) stay **server-only** under `@dpf/db` or `apps/web/lib/server-*` —
+never in a portable package.
+
+### How the contract stays honest
+
+- **DTOs are hand-written, explicit, and stable** (`packages/types/src/entities.ts`). They
+  are not generated from Prisma — a generated mirror would re-couple the contract to the
+  schema shape, which is exactly what this boundary removes. `Decimal` columns are carried
+  as `number` (validators use `z.number()`); `Json` columns as the contract `JsonValue`.
+- **Schema drift is caught server-side** by
+  [`apps/web/lib/contracts/entity-contract-drift.ts`](../../apps/web/lib/contracts/entity-contract-drift.ts):
+  a type-level assertion that each Prisma payload (with `Decimal` mapped to its wire form)
+  stays assignable to the matching DTO. A renamed, removed, or retyped column that the wire
+  contract still promises fails `pnpm --filter web typecheck`.
+- **The boundary itself is guarded** by
+  [`scripts/check-package-boundaries.mjs`](../../scripts/check-package-boundaries.mjs),
+  run both as a CI job (`Package Boundary Guard`) and as a web unit test
+  ([`apps/web/lib/contracts/package-boundaries.test.ts`](../../apps/web/lib/contracts/package-boundaries.test.ts)).
+
+## Keep / reshape / evaluate table
+
+| Area | Direction | Rationale |
+| --- | --- | --- |
+| `@dpf/db` | Keep | Persistence and Prisma ownership are a real server boundary. |
+| `@dpf/types` | Reshaped | Was leaking Prisma into portable consumers; now Prisma-free DTOs. |
+| `@dpf/validators` | Keep | Pure validation is portable. Merge into a contracts package only if it simplifies ownership. |
+| `@dpf/api-client` | Keep | Mobile and external consumers need a stable client boundary. |
+| `@dpf/dpf-bootstrap` | Keep | Distribution / install tooling is not app runtime. |
+| `@dpf/dpf-skill-pack` | Keep | Plugin / skill payload is a distribution artifact. |
+| `storefront-templates`, `finance-templates` | Evaluate | Could become one template/archetype registry once contracts are clean. |
+| `services/adp` | Keep | Runtime service boundary. |
+| `services/edge-node` | Keep | Deployment / runtime boundary. |
+| `services/integration-test-harness` | Keep | Verification harness boundary. |
+
+## Adding a new package
+
+Every new package must declare its boundary reason — the runtime, deployment,
+distribution, or trust consequence that justifies the seam. If the only reason is "these
+files are related," it is an accidental seam: put the code in an existing package behind a
+module boundary instead. If a new package is portable (consumed by mobile / external
+clients), add it to `PORTABLE_PACKAGES` in
+[`scripts/check-package-boundaries.mjs`](../../scripts/check-package-boundaries.mjs) so the
+Prisma-free invariant is enforced from day one.

--- a/docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md
+++ b/docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md
@@ -1,0 +1,388 @@
+# Platform Consolidation Spine - Design
+
+**Date:** 2026-06-25
+**Status:** Draft for operator review
+**Author:** Codex code review and refactoring assessment
+**Epic:** EP-PLATFORM-CONSOLIDATION
+**Backlog items:** BI-ARCH-CONTRACTS, BI-ARCH-TOOLPACKS, BI-ARCH-DELIVERY-IA, BI-ARCH-BUILDSTUDIO-NS, BI-ARCH-SECTIONNAV, BI-ARCH-UI-PRIMS, BI-ARCH-PACKAGES
+
+## 1. Goal
+
+DPF is becoming a true hybrid platform: business operating system, AI coworker runtime, Build Studio, delivery control plane, architecture graph, mobile companion, and install/runtime substrate in one product. The next wave of functionality will be healthier if it lands on fewer, stronger platform seams.
+
+This spec defines the consolidation spine for that work. The intent is not to merge every package or flatten every feature into one module. The intent is to correct the boundaries that are currently accidental, duplicated, or leaking implementation detail across web, mobile, services, AI tooling, and UI.
+
+## 2. Operator Intent
+
+The request that produced this spec was a code review and refactoring assessment:
+
+- As more functionality is added, combine and collapse functionality where it tightens how features work together.
+- Reassess the many packages and decide where DPF should keep independent packages versus bring code together.
+- Preserve the larger product vision: an AI-first platform that hybridizes many capabilities instead of feeling like a set of unrelated tools.
+- Spend a meaningful refactor budget, especially on excellent UI design and architecture.
+
+## 3. Current-State Evidence
+
+### 3.1 Shared contract layer leaks Prisma into portable consumers
+
+`packages/types/package.json` depends on `@dpf/db`, and `packages/types/src/entities.ts` exports `Prisma.*GetPayload` aliases. `apps/mobile/package.json` consumes `@dpf/types`, so the mobile-facing contract layer is shaped by server persistence instead of a portable API contract.
+
+Evidence:
+
+- `packages/types/package.json:12`
+- `packages/types/src/entities.ts:1`
+- `apps/mobile/package.json:16-18`
+
+### 3.2 MCP tools are still registered and dispatched through a mega-module
+
+`apps/web/lib/mcp-tools.ts` owns `PLATFORM_TOOLS` and the primary `executeTool` dispatch switch. The current file is still the choke point even though several domains already delegate to smaller handlers.
+
+Evidence:
+
+- `apps/web/lib/mcp-tools.ts:433`
+- `apps/web/lib/mcp-tools.ts:5413`
+- `docs/architecture/context-engineering-standards.md:15`
+- `apps/web/lib/routing/fallback.ts:211`
+
+This is now a product risk, not just a code-style issue. DPF's local model path encodes a 15-tool local fallback threshold, while the registry surface keeps growing with every AI-first capability.
+
+### 3.3 Delivery IA is not yet one mental home
+
+The canonical nav model marks Build Studio as `domain: "delivery"` but places it under the `platform` shell section. Other delivery/process surfaces live under `/build`, `/build/work`, `/platform/development/change-lanes`, `/ops/dev-loop`, `/ops/promotions`, and self-upgrade views.
+
+Evidence:
+
+- `apps/web/lib/navigation/portal-navigation-model.ts:424-435`
+- `apps/web/components/platform/platform-nav.ts:71`
+- `apps/web/components/ops/OpsTabNav.tsx:7-13`
+
+This overlaps live EP-UNIFIED-TRACKING work, especially BI-D3E09880. This spec should coordinate with that work instead of replacing it.
+
+### 3.4 Build Studio has two production-adjacent component namespaces
+
+The `/build` route imports both `components/build/BuildStudio` and `components/build-studio/BuildStudioV2`. Build-plan normalization still rewrites legacy `components/build-studio/*` paths to `components/build/*`.
+
+Evidence:
+
+- `apps/web/app/(shell)/build/page.tsx:7-8`
+- `apps/web/app/(shell)/build/page.tsx:38`
+- `apps/web/app/(shell)/build/page.tsx:77`
+- `apps/web/app/(shell)/build/page.tsx:252`
+- `apps/web/lib/integrate/build-plan-paths.ts:18-22`
+
+That makes Build Studio a high-risk area for new WIP divergence.
+
+### 3.5 Section navigation is implemented many times
+
+The app has multiple `*TabNav` components and local nav data sets for Platform, Admin, Finance, Ops, Customer, EA, Storefront, Compliance, Marketing, Product, Employee, and Identity surfaces. There is already a regression test for duplicate platform tools nav, which is useful but also proves the rendering contract is distributed.
+
+Evidence:
+
+- `apps/web/components/platform/PlatformTabNav.tsx`
+- `apps/web/components/admin/AdminTabNav.tsx`
+- `apps/web/components/finance/FinanceTabNav.tsx`
+- `apps/web/components/ops/OpsTabNav.tsx`
+- `apps/web/app/(shell)/platform/tools/layout.test.tsx`
+
+### 3.6 UI styling is uneven across operational surfaces
+
+DPF has a useful operational UI kit in `apps/web/components/ui/report-kit`, including `StatusBadge`, `DataTable`, `FilterBar`, `StatCard`, `ExportButton`, and `Chart`. But active surfaces still contain many inline style objects and hard-coded colors.
+
+Evidence:
+
+- `apps/web/components/ui/report-kit/StatusBadge.tsx:51`
+- `apps/web/components/ui/report-kit/DataTable.tsx:97`
+- `apps/web/components/ui/report-kit/FilterBar.tsx:117`
+- `apps/web/components/ui/report-kit/StatCard.tsx:44`
+- `apps/web/components/storefront-admin/SetupWizard.tsx:226`
+- `apps/web/components/platform/BuildStudioConfigForm.tsx:197`
+- `apps/web/components/workspace/WorkspaceCalendar.tsx:18-25`
+
+### 3.7 Package seams are mixed: some are real, some are accidental
+
+The workspace includes `apps/*`, `packages/*`, and runtime services.
+
+Evidence:
+
+- `pnpm-workspace.yaml:1-6`
+- Current scan on `origin/main`: `apps/web/lib` 2585 files, `apps/web/components` 928 files, `apps/web/app` 689 files, `packages` 933 files, `services` 143 files.
+
+The platform should not collapse every seam. `@dpf/db`, `@dpf/api-client`, bootstrap tooling, the skill pack, edge services, ADP, and the integration harness all have runtime or distribution reasons to remain independent. The accidental seam is the portable contract layer depending on server persistence.
+
+## 4. Research and Benchmarking
+
+### 4.1 Open-source and standards references
+
+| Reference | Relevant pattern | Adopt | Reject |
+| --- | --- | --- | --- |
+| Nx module boundaries, https://nx.dev/docs/features/enforce-module-boundaries | Enforce import boundaries with tags and dependency constraints. | Add explicit package-boundary rules and tests so portable contracts cannot depend on server DB packages. | Do not adopt Nx wholesale just to get the rule; DPF can implement a smaller local check first. |
+| Backstage architecture and plugins, https://backstage.io/docs/overview/architecture-overview/ and https://backstage.io/docs/plugins/ | A developer portal can integrate many tools while keeping a cohesive catalog and plugin model. | Keep DPF domain surfaces modular, but render them through shared shell, nav, catalog, and UI primitives. | Do not let every domain ship its own navigation and UI idioms like an unrelated plugin marketplace. |
+| Model Context Protocol tools spec, https://modelcontextprotocol.io/specification/2025-06-18/server/tools | Tools are named capabilities with schemas and metadata exposed to model clients. | Treat DPF tool packs as domain-owned MCP manifests with definitions, handlers, annotations, grants, and result-budget policy. | Do not keep growing one unscoped registry because the protocol permits many tools. |
+
+### 4.2 Commercial product references
+
+| Reference | Relevant pattern | Adopt | Reject |
+| --- | --- | --- | --- |
+| Atlassian navigation redesign, https://www.atlassian.com/blog/design/designing-atlassians-new-navigation | Dense work products need a durable sidebar/area navigation model, not a wide top-bar map. | Move Delivery into one primary home and use area navigation for build/work/evidence/release surfaces. | Do not duplicate the same destinations in multiple chrome layers. |
+| Microsoft Fluent tabs guidance, https://learn.microsoft.com/en-us/fluent-ui/web-components/components/tabs | Tabs are for related panels/views, not whole product sprawl. | Replace large cloned tab strips with a shared section-nav renderer and grouped area navigation. | Do not use tabs as the default answer for every section hierarchy. |
+| GitHub Checks/status and reusable workflow docs, https://docs.github.com/articles/about-status-checks and https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows | Evidence and reusable process definitions can be producer-agnostic while still rendering in one timeline/check surface. | Treat Delivery evidence and tool-pack process as reusable, surface-agnostic contracts. | Do not fork Build Studio flows by producing surface or AI client. |
+| Jira workflow schemes, https://www.atlassian.com/software/jira/guides/workflows/overview | Work types can share a system while following different process schemes. | Let Delivery expose one home while different work types keep their appropriate lifecycle policy. | Do not make separate products for build, dev loop, release, and evidence just because their workflows differ. |
+
+## 5. Architectural Decision
+
+DPF should consolidate around four platform substrates:
+
+1. **Portable contracts.** DTOs, Zod schemas, and API client types that web, mobile, services, and AI tools can share without importing Prisma.
+2. **Scoped AI tool packs.** Domain-owned tool manifests that compose into the MCP registry by route, grant, execution mode, and build phase.
+3. **Delivery as a first-class area.** One operator home for builds, work capsules, evidence, external-agent tracking, change lanes, promotion, and upgrade/release status.
+4. **Operational UI primitives.** Shared navigation, status, table, filter, card, chart, form, and tokenized styling primitives for the dense operational surfaces DPF actually is.
+
+The package consolidation rule is:
+
+> Collapse accidental seams; preserve runtime, deployment, distribution, and trust boundaries.
+
+That means contract inversion comes before package deletion. It is safer to remove `@dpf/db` from portable packages than to merge portable packages into the web app. It is safer to split `mcp-tools.ts` by domain than to move all MCP behavior into a new giant "platform" module.
+
+## 6. Target Design
+
+### 6.1 Portable contracts
+
+Introduce or reshape a pure contract layer. The final package name can be `@dpf/contracts` or a cleaned `@dpf/types` plus `@dpf/validators`; the invariant matters more than the name:
+
+- No portable package may import `@dpf/db` or Prisma payload types.
+- API DTOs are explicit and stable across web, mobile, services, and MCP.
+- Zod schemas live with DTOs where validation is part of the contract.
+- Prisma payload helper types remain server-only under `@dpf/db` or `apps/web/lib/server-*`.
+- `@dpf/api-client` consumes contract DTOs, not raw Prisma aliases.
+
+Recommended migration:
+
+1. Create contract DTOs for the highest-use mobile/API types first.
+2. Replace mobile imports from Prisma-derived entities with DTOs.
+3. Keep temporary server-side mappers from Prisma payloads to contract DTOs.
+4. Add a dependency guard that fails if the portable contract package imports `@dpf/db`.
+
+### 6.2 Scoped MCP tool packs
+
+`mcp-tools.ts` should become a composition layer, not the domain implementation. Each tool pack owns:
+
+- tool definitions
+- handler map
+- required capability and grant metadata
+- optional route context, build phase, and execution-mode exposure rules
+- concise result policy and pagination expectations
+- tests for definition hygiene, grant gating, and handler parity
+
+Candidate first packs:
+
+- `backlog`
+- `build`
+- `work-capsules`
+- `runtime-coordination`
+- `platform-admin`
+- `tool-marketplace`
+- `wiki/principles`
+- `screen/pseudo-user-contract`
+
+The external MCP route and native coworker loop should both select small, scoped catalogs. The local fallback path should not receive a tool surface that exceeds the 15-tool threshold unless it intentionally skips local fallback with a clear reason.
+
+### 6.3 Delivery area
+
+Create one Delivery home and nav group. The home should route the operator to:
+
+- Build Studio
+- Work control / capsules
+- Unified evidence timeline
+- Change lanes
+- External agent work tracking
+- Promotions and release readiness
+- Governed self-upgrade status where it represents delivery/release evidence
+
+Platform AI should keep Build Studio configuration under Platform because model/provider configuration is platform administration. The operator path for doing delivery work should be Delivery.
+
+Deep links must be preserved:
+
+- `/build`
+- `/build/work`
+- `/platform/development/change-lanes`
+- `/ops/dev-loop`
+- `/ops/promotions`
+- relevant self-upgrade evidence/status paths
+
+This design extends EP-UNIFIED-TRACKING. It should not create a second timeline model.
+
+### 6.4 Build Studio namespace convergence
+
+There should be one production Build Studio component namespace.
+
+Decision path:
+
+- If `BuildStudioV2` is the future shell, graduate it into `apps/web/components/build` and wire it to production data.
+- If it is a prototype, move it to an explicit prototype/demo home and remove accidental `/build` access.
+- Remove `LEGACY_BUILD_STUDIO_PATH_ALIASES` once Build Studio plans no longer generate stale `components/build-studio/*` paths.
+
+Acceptance is not "fewer folders"; acceptance is that Build Studio plans, tests, docs, and agent-generated file paths all point to the same production namespace.
+
+### 6.5 Shared SectionNav renderer
+
+Replace cloned `*TabNav` rendering with one shared renderer:
+
+- `SectionNav` renders top-level families, sibling links, sub-items, active state, overflow, responsive behavior, and duplicate-subnav prevention.
+- Section data can remain domain-owned, but it must be converted into a shared shape.
+- The canonical portal navigation model should own shell-level facts. Domain nav modules should own only domain-specific grouping labels when needed.
+
+First migration candidates:
+
+1. Platform
+2. Admin
+3. Finance
+4. Ops
+
+These have enough overlap to prove the abstraction without touching every domain at once.
+
+### 6.6 Operational UI primitive adoption
+
+DPF should look and feel like a sophisticated operational tool, not a collection of page-local demos. The existing `report-kit` is a good starting point. Expand and standardize around:
+
+- status badges
+- stat cards
+- dense data tables
+- filter bars
+- charts
+- form rows and settings sections
+- action bars
+- empty/loading/error states
+- color/status token maps
+
+Initial slices:
+
+- Build Studio configuration form
+- Storefront setup wizard or operating-model wizard
+- Workspace calendar/status colors
+
+Add a lightweight guard for new hard-coded hex colors and large inline style blocks outside approved token or chart-theme files. Existing pages should be migrated as they are touched; do not run a blind mass rewrite.
+
+### 6.7 Package and service boundary table
+
+| Area | Direction | Rationale |
+| --- | --- | --- |
+| `@dpf/db` | Keep | Persistence and Prisma ownership are a real server boundary. |
+| `@dpf/types` | Reshape or replace | Current shape leaks Prisma into portable consumers. |
+| `@dpf/validators` | Keep or merge into contracts | Pure validation is portable; merge only if it simplifies contract ownership. |
+| `@dpf/api-client` | Keep | Mobile and external consumers need a stable client boundary. |
+| `@dpf/dpf-bootstrap` | Keep | Distribution/install tooling is not app runtime. |
+| `@dpf/dpf-skill-pack` | Keep | Plugin/skill payload is a distribution artifact, not normal web code. |
+| `storefront-templates` and `finance-templates` | Evaluate | Could become one template/archetype registry if contracts are clean first. |
+| `services/adp` | Keep | Runtime service boundary. |
+| `services/edge-node` | Keep | Deployment/runtime boundary. |
+| `services/integration-test-harness` | Keep | Verification harness boundary. |
+
+## 7. Backlog Filed
+
+| BI | Title | Size | Dependency notes |
+| --- | --- | --- | --- |
+| BI-ARCH-CONTRACTS | Invert shared contracts away from Prisma payload types | Large | Should start before mobile/API expansion. |
+| BI-ARCH-TOOLPACKS | Split the MCP registry into scoped domain tool packs | XLarge | Coordinates with context-engineering standards and coworker grants work. |
+| BI-ARCH-DELIVERY-IA | Create one Delivery home for builds, work, evidence, change lanes, and dev-loop status | Large | Must coordinate with EP-UNIFIED-TRACKING and BI-D3E09880. |
+| BI-ARCH-BUILDSTUDIO-NS | Converge Build Studio component namespaces and retire legacy path aliases | Large | Should land before more Build Studio UX WIP. |
+| BI-ARCH-SECTIONNAV | Replace per-section TabNav clones with a canonical SectionNav renderer | Large | Can begin with Platform/Admin/Finance/Ops. |
+| BI-ARCH-UI-PRIMS | Adopt operational UI primitives and tokenized styling on active surfaces | Large | Pair with active UI work; requires screenshot verification. |
+| BI-ARCH-PACKAGES | Define package/service boundary rules and collapse only accidental package seams | Medium | Depends on contract inversion for the first real enforcement. |
+
+## 8. Phasing
+
+### Phase 0 - Guardrails and planning
+
+- Attach this spec path to EP-PLATFORM-CONSOLIDATION.
+- Confirm BI ownership and priorities against active WIP.
+- Add a package-boundary check plan.
+- Identify which active Build Studio/Delivery work should be redirected to this spine instead of opening new parallel BIs.
+
+### Phase 1 - Contract inversion
+
+- Create or reshape the portable contract layer.
+- Remove the `@dpf/db` dependency from portable/mobile-facing types.
+- Add mappers at server boundaries.
+- Update mobile and API client imports.
+- Add dependency guard tests.
+
+### Phase 2 - MCP tool packs
+
+- Define `ToolPack` shape.
+- Extract backlog/build/capsule/runtime packs first.
+- Keep `mcp-tools.ts` as a thin compatibility composition layer during migration.
+- Prove parity through current MCP route tests and grant-filter tests.
+- Keep local fallback tool surfaces below the context threshold where possible.
+
+### Phase 3 - Delivery and Build Studio convergence
+
+- Add the Delivery home/section.
+- Preserve deep links and redirects.
+- Move or graduate `BuildStudioV2`.
+- Remove legacy Build Studio path aliases after plan-generation tests stop needing them.
+- UX verify the Delivery path and Build Studio path across desktop and mobile widths.
+
+### Phase 4 - Navigation and UI primitives
+
+- Build shared `SectionNav`.
+- Migrate Platform/Admin/Finance/Ops.
+- Expand operational UI primitives where needed.
+- Migrate Build Studio config plus one setup/calendar surface.
+- Add visual evidence and style drift guard.
+
+### Phase 5 - Package boundary cleanup
+
+- Document the package keep/merge/split table as a durable architecture standard.
+- Evaluate template registry consolidation.
+- Add a future-package checklist: every new package must declare its boundary reason.
+
+## 9. Verification Gates
+
+All implementation PRs under this epic must satisfy the normal DPF build gate:
+
+- targeted unit tests for affected packages
+- `pnpm --filter web build` when touching web/runtime-bound code
+- UX verification for Delivery, Build Studio, nav, or UI primitive changes
+- migration apply evidence when schema changes are added
+- MCP/backlog evidence updates when BIs are completed
+
+Additional gates:
+
+- Contract work must prove no portable package imports `@dpf/db`.
+- Tool-pack work must prove definition discovery and execute dispatch parity.
+- Delivery IA work must prove legacy deep links still resolve.
+- SectionNav work must include duplicate-subnav regression coverage.
+- UI primitive work must include before/after screenshots and token/style drift checks.
+
+## 10. Risks
+
+### R1. The epic is broad enough to become a dumping ground
+
+Mitigation: keep the BIs as independent slices. Do not add unrelated cleanup because it feels like "consolidation."
+
+### R2. Package consolidation could erase useful runtime boundaries
+
+Mitigation: collapse only accidental seams. Runtime, deployment, distribution, and trust boundaries stay unless a later spec proves otherwise.
+
+### R3. Tool-pack extraction can break authority controls
+
+Mitigation: move metadata with the handler, not after it. Every extracted pack must keep grant, token-scope, phase, route-context, and execution-mode tests.
+
+### R4. Navigation changes can strand existing users and agents
+
+Mitigation: preserve links and redirects. Update route context and coworker assumptions in the same slice as nav moves.
+
+### R5. UI cleanup can become decorative polish instead of workflow improvement
+
+Mitigation: migrate active operational workflows first and verify actual interaction paths, not isolated component screenshots only.
+
+## 11. Open Decisions
+
+1. Should `@dpf/contracts` be a new package, or should `@dpf/types` be repaired in place?
+2. Should Delivery become a new top-level shell rail item immediately, or first ship as a grouped route under the current shell while nav data converges?
+3. Should `BuildStudioV2` graduate, be retired, or be quarantined as a prototype?
+4. Should the initial style drift guard be advisory-only or fail CI for new inline hex/style additions outside approved files?
+
+## 12. Recommended Next Step
+
+Start with BI-ARCH-CONTRACTS and BI-ARCH-TOOLPACKS. They address the two deepest architectural risks: persistence leaking into portable contracts and model-facing tools growing beyond the local context economy. BI-ARCH-DELIVERY-IA and BI-ARCH-BUILDSTUDIO-NS should run next or in parallel with active Build Studio UX work so future UI investment lands on the converged surface.

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    // Isomorphic fetch client: declare the Web platform libs it uses (fetch,
+    // Response, FormData, URLSearchParams, File) directly instead of leaning on
+    // a transitive @types/node leak from the (now removed) @dpf/db dependency.
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,9 +8,6 @@
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "@dpf/db": "workspace:*"
-  },
   "devDependencies": {
     "typescript": "^6.0.3"
   }

--- a/packages/types/src/entities.ts
+++ b/packages/types/src/entities.ts
@@ -1,82 +1,315 @@
-import type { Prisma } from "@dpf/db";
+// Portable entity contracts.
+//
+// Hand-written DTOs that mirror the over-the-wire shape of the platform's core
+// entities. They are consumed by the mobile app (`apps/mobile`) and the typed
+// API client (`@dpf/api-client`), so this file MUST stay free of any Prisma /
+// `@dpf/db` import — a portable contract cannot depend on server persistence
+// (see docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md
+// §6.1 and docs/architecture/package-boundaries.md).
+//
+// Two tiers mirror Prisma's `GetPayload` semantics:
+//   * `*Base` types are the scalar-only shape of a model (what `relation: true`
+//     yields when a relation is included — Prisma returns the base record, not a
+//     further-included payload).
+//   * The exported names compose a base with the specific relations the server
+//     includes today, so a value that satisfied the previous `Prisma.*GetPayload`
+//     alias still satisfies the DTO.
+//
+// Drift against the live schema is caught server-side by
+// apps/web/lib/contracts/entity-contract-drift.ts, which asserts each Prisma
+// payload stays assignable to the matching DTO (with `Decimal` mapped to its
+// wire form, `number`).
 
-export type Epic = Prisma.EpicGetPayload<{
-  include: {
-    portfolios: { include: { portfolio: true } };
-    items: true;
-  };
-}>;
+/**
+ * A JSON value carried verbatim from a Prisma `Json` column over the wire.
+ * Object members are `| undefined` so this stays a structural supertype of
+ * Prisma's own `JsonValue` (whose object members are optional), letting server
+ * code hand a Prisma JSON value straight to a DTO without a cast.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue | undefined };
 
-export type BacklogItem = Prisma.BacklogItemGetPayload<{
-  include: { epic: true; digitalProduct: true; taxonomyNode: true };
-}>;
+// ── Base scalar shapes (no relations included) ──────────────────────────────
 
-export type Portfolio = Prisma.PortfolioGetPayload<{
-  include: { products: true; epicPortfolios: true };
-}>;
+export interface PortfolioBase {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  rootNodeId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  budgetKUsd: number | null;
+}
 
-export type CustomerAccount = Prisma.CustomerAccountGetPayload<{
-  include: { contacts: true };
-}>;
+export interface DigitalProductBase {
+  id: string;
+  productId: string;
+  name: string;
+  portfolioId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  taxonomyNodeId: string | null;
+  lifecycleStage: string;
+  lifecycleStatus: string;
+  version: string;
+  description: string | null;
+  observationConfig: JsonValue | null;
+  coverageStatus: string | null;
+  sourceKind: string | null;
+}
 
-export type CustomerAccountWithRoles = Prisma.CustomerAccountGetPayload<{
-  include: {
-    contacts: true;
-    contactRoles: { include: { contact: true } };
-  };
-}>;
+export interface TaxonomyNodeBase {
+  id: string;
+  nodeId: string;
+  name: string;
+  portfolioId: string | null;
+  parentId: string | null;
+  status: string;
+  governance: JsonValue | null;
+  description: string | null;
+  enrichment: JsonValue | null;
+}
 
-export type ContactAccountRole = Prisma.ContactAccountRoleGetPayload<{
-  include: { contact: true; account: true };
-}>;
+export interface EpicPortfolioBase {
+  epicId: string;
+  portfolioId: string;
+}
 
-export type Engagement = Prisma.EngagementGetPayload<{
-  include: {
-    contact: true;
-    account: true;
-    assignedTo: { select: { id: true; email: true } };
-  };
-}>;
+export interface EpicBase {
+  id: string;
+  epicId: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+  submittedById: string | null;
+  agentId: string | null;
+  completedAt: Date | null;
+  accountableEmployeeId: string | null;
+  claimedById: string | null;
+  claimedByAgentId: string | null;
+  claimedAt: Date | null;
+  claimStatus: string | null;
+  upstreamIssueNumber: number | null;
+  upstreamIssueUrl: string | null;
+  upstreamSyncedAt: Date | null;
+  designDoc: JsonValue | null;
+  designReview: JsonValue | null;
+  decompositionState: JsonValue | null;
+  originatingBacklogItemId: string | null;
+}
 
-export type Opportunity = Prisma.OpportunityGetPayload<{
-  include: {
-    account: true;
-    contact: true;
-    assignedTo: { select: { id: true; email: true } };
-    activities: true;
-  };
-}>;
+export interface BacklogItemBase {
+  id: string;
+  itemId: string;
+  title: string;
+  status: string;
+  type: string;
+  body: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  priority: number | null;
+  digitalProductId: string | null;
+  taxonomyNodeId: string | null;
+  epicId: string | null;
+  portfolioId: string | null;
+  source: string | null;
+  workType: string | null;
+  triageOutcome: string | null;
+  effortSize: string | null;
+  proposedOutcome: string | null;
+  activeBuildId: string | null;
+  activeEpicId: string | null;
+  duplicateOfId: string | null;
+  resolution: string | null;
+  abandonReason: string | null;
+  stalenessDetectedAt: Date | null;
+  occurrenceCount: number;
+  lastSeenAt: Date | null;
+  submittedById: string | null;
+  completedAt: Date | null;
+  agentId: string | null;
+  accountableEmployeeId: string | null;
+  claimedById: string | null;
+  claimedByAgentId: string | null;
+  claimedAt: Date | null;
+  claimStatus: string | null;
+  upstreamIssueNumber: number | null;
+  upstreamIssueUrl: string | null;
+  upstreamSyncedAt: Date | null;
+}
 
-export type Activity = Prisma.ActivityGetPayload<{
-  include: {
-    account: { select: { id: true; accountId: true; name: true } };
-    contact: { select: { id: true; email: true; firstName: true; lastName: true } };
-    opportunity: { select: { id: true; opportunityId: true; title: true } };
-    createdBy: { select: { id: true; email: true } };
-  };
-}>;
+export interface CustomerAccountBase {
+  id: string;
+  accountId: string;
+  name: string;
+  status: string;
+  website: string | null;
+  industry: string | null;
+  employeeCount: number | null;
+  /** `Decimal?` in Prisma; serialized to a number on the wire (validators use `z.number()`). */
+  annualRevenue: number | null;
+  currency: string;
+  notes: string | null;
+  sourceSystem: string | null;
+  sourceId: string | null;
+  parentAccountId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
 
-export type AgentThread = Prisma.AgentThreadGetPayload<{
-  include: { messages: true };
-}>;
+export interface CustomerContactBase {
+  id: string;
+  email: string;
+  accountId: string;
+  isActive: boolean;
+  createdAt: Date;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  phone: string | null;
+  jobTitle: string | null;
+  linkedinUrl: string | null;
+  source: string | null;
+  doNotContact: boolean;
+  avatarUrl: string | null;
+  updatedAt: Date;
+  // `passwordHash` exists on the model but is intentionally omitted from this
+  // client-facing contract — it must never travel to a portable consumer.
+}
 
-export type AgentMessage = Prisma.AgentMessageGetPayload<{}>;
+export interface AgentThreadBase {
+  id: string;
+  userId: string;
+  contextKey: string;
+  createdAt: Date;
+  updatedAt: Date;
+  cliSessionId: string | null;
+  cliSessionAdapterKind: string | null;
+  cliSessionContainerId: string | null;
+  cliSessionLastUsedAt: Date | null;
+  cliSessionWorkdir: string | null;
+  parentThreadId: string | null;
+  childCount: number;
+  cancelledAt: Date | null;
+  idempotencyKey: string | null;
+  terminalError: JsonValue | null;
+  executionPlan: JsonValue | null;
+}
 
-export type AgentActionProposal = Prisma.AgentActionProposalGetPayload<{}>;
+export interface AgentMessageBase {
+  id: string;
+  threadId: string;
+  taskRunId: string | null;
+  role: string;
+  content: string;
+  tone: string | null;
+  createdAt: Date;
+  agentId: string | null;
+  routeContext: string | null;
+  providerId: string | null;
+  taskType: string | null;
+  routedEndpointId: string | null;
+}
 
-export type Notification = Prisma.NotificationGetPayload<{}>;
+export interface AgentActionProposalBase {
+  id: string;
+  proposalId: string;
+  threadId: string;
+  taskRunId: string | null;
+  messageId: string;
+  agentId: string;
+  actionType: string;
+  parameters: JsonValue;
+  status: string;
+  proposedAt: Date;
+  decidedAt: Date | null;
+  decidedById: string | null;
+  executedAt: Date | null;
+  resultEntityId: string | null;
+  resultError: string | null;
+  gitCommitHash: string | null;
+  toolEvaluationId: string | null;
+}
 
-export type AuthorizationDecisionLog = Prisma.AuthorizationDecisionLogGetPayload<{}>;
+export interface NotificationBase {
+  id: string;
+  userId: string;
+  type: string;
+  title: string;
+  body: string | null;
+  deepLink: string | null;
+  read: boolean;
+  createdAt: Date;
+}
 
-export type TaskRun = Prisma.TaskRunGetPayload<{
-  include: { nodes: true };
-}>;
+export interface AuthorizationDecisionLogBase {
+  id: string;
+  decisionId: string;
+  actorType: string;
+  actorRef: string;
+  humanContextRef: string | null;
+  agentContextRef: string | null;
+  delegationGrantId: string | null;
+  authorityBindingId: string | null;
+  actionKey: string;
+  objectRef: string | null;
+  decision: string;
+  rationale: JsonValue;
+  createdAt: Date;
+  endpointUsed: string | null;
+  mode: string | null;
+  routeContext: string | null;
+  sensitivityLevel: string | null;
+  sensitivityOverride: boolean | null;
+}
 
-export type TaskNode = Prisma.TaskNodeGetPayload<{
-  include: { childNodes: true };
-}>;
+// ── Exported entities (base + the relations the server includes) ────────────
 
-export type TaskNodeEdge = Prisma.TaskNodeEdgeGetPayload<{}>;
+/** Portfolio with its products and epic links. */
+export interface Portfolio extends PortfolioBase {
+  products: DigitalProductBase[];
+  epicPortfolios: EpicPortfolioBase[];
+}
+
+/** Epic with its portfolio links (each carrying the portfolio) and backlog items. */
+export interface Epic extends EpicBase {
+  portfolios: Array<EpicPortfolioBase & { portfolio: PortfolioBase }>;
+  items: BacklogItemBase[];
+}
+
+/** Backlog item with its epic, product, and taxonomy node. */
+export interface BacklogItem extends BacklogItemBase {
+  epic: EpicBase | null;
+  digitalProduct: DigitalProductBase | null;
+  taxonomyNode: TaxonomyNodeBase | null;
+}
+
+/** Customer account with its contacts. */
+export interface CustomerAccount extends CustomerAccountBase {
+  contacts: CustomerContactBase[];
+}
+
+/** Agent conversation thread with its messages. */
+export interface AgentThread extends AgentThreadBase {
+  messages: AgentMessageBase[];
+}
+
+export type AgentMessage = AgentMessageBase;
+
+export type AgentActionProposal = AgentActionProposalBase;
+
+export type Notification = NotificationBase;
+
+export type AuthorizationDecisionLog = AuthorizationDecisionLogBase;
 
 export interface BookingConfig {
   durationMinutes: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,10 +525,6 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/types:
-    dependencies:
-      '@dpf/db':
-        specifier: workspace:*
-        version: link:../db
     devDependencies:
       typescript:
         specifier: ^6.0.3

--- a/scripts/check-package-boundaries.mjs
+++ b/scripts/check-package-boundaries.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Package boundary guard — BI-ARCH-PACKAGES first enforcement.
+//
+// The portable contract/client layer shared with the mobile app must not depend
+// on server persistence. This check fails if any portable package declares or
+// imports `@dpf/db` / Prisma. It is the executable form of the invariant in
+// docs/architecture/package-boundaries.md ("Portable contract layer").
+//
+// Run directly:   node scripts/check-package-boundaries.mjs
+// Or as a test:   apps/web/lib/contracts/package-boundaries.test.ts imports
+//                 `checkPackageBoundaries()` so it runs in the Unit Tests CI job.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Packages that MUST stay free of server persistence (Prisma / @dpf/db). */
+export const PORTABLE_PACKAGES = ["packages/types", "packages/validators", "packages/api-client"];
+
+/** Module specifiers that couple a package to server persistence. */
+const FORBIDDEN_IMPORTS = ["@dpf/db", "@prisma/client", ".prisma/client"];
+
+/** package.json dependency names that couple a package to server persistence. */
+const FORBIDDEN_DEPS = ["@dpf/db", "@prisma/client", "prisma"];
+
+const FROM_RE = /\bfrom\s*["']([^"']+)["']/g;
+const REQUIRE_RE = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+
+function listSourceFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === "dist" || entry === ".turbo") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...listSourceFiles(full));
+    else if (/\.(ts|tsx|mts|cts)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+function isForbidden(spec) {
+  return FORBIDDEN_IMPORTS.some((f) => spec === f || spec.startsWith(`${f}/`));
+}
+
+/** Returns a list of human-readable boundary violations (empty when clean). */
+export function checkPackageBoundaries() {
+  const violations = [];
+  for (const pkgDir of PORTABLE_PACKAGES) {
+    const abs = join(REPO_ROOT, pkgDir);
+
+    // 1) package.json must not declare a forbidden dependency.
+    const pkg = JSON.parse(readFileSync(join(abs, "package.json"), "utf8"));
+    for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+      for (const dep of Object.keys(pkg[field] || {})) {
+        if (FORBIDDEN_DEPS.includes(dep)) {
+          violations.push(`${pkgDir}/package.json declares forbidden dependency "${dep}" (${field})`);
+        }
+      }
+    }
+
+    // 2) no source file may import a forbidden module.
+    for (const file of listSourceFiles(join(abs, "src"))) {
+      const text = readFileSync(file, "utf8");
+      const rel = relative(REPO_ROOT, file).replace(/\\/g, "/");
+      for (const re of [FROM_RE, REQUIRE_RE]) {
+        re.lastIndex = 0;
+        let m;
+        while ((m = re.exec(text)) !== null) {
+          if (isForbidden(m[1])) {
+            violations.push(`${rel} imports forbidden module "${m[1]}"`);
+          }
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+// CLI entry — only when executed directly, not when imported by a test.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const violations = checkPackageBoundaries();
+  if (violations.length > 0) {
+    console.error("Package boundary violations — portable packages must not depend on @dpf/db / Prisma:");
+    for (const v of violations) console.error(`  - ${v}`);
+    console.error("\nSee docs/architecture/package-boundaries.md");
+    process.exit(1);
+  }
+  console.log(
+    `Package boundaries OK — ${PORTABLE_PACKAGES.length} portable packages are free of @dpf/db / Prisma.`,
+  );
+}


### PR DESCRIPTION
First implementation slice of **EP-PLATFORM-CONSOLIDATION** (the platform consolidation spine). Delivered locally per operator request (not Build Studio). The spec rides in this PR as the first commit.

## Why
The consolidation spec's deepest *accidental* seam (§3.1): `@dpf/types` depended on `@dpf/db` and re-exported `Prisma.*GetPayload` aliases. Since `apps/mobile` consumes `@dpf/types`, the mobile-facing contract was shaped by server persistence — and that coupling grew with every AI-first capability. This inverts it.

## What changed
- **`packages/types/src/entities.ts`** — the 17 `Prisma.*GetPayload` aliases become hand-written wire DTOs. Two tiers mirror Prisma's `GetPayload` semantics (scalar `*Base` types + the relation-included exported types), so any value that satisfied the old alias still satisfies the DTO. The **8 unused server-only aliases** (`Engagement, Opportunity, Activity, ContactAccountRole, CustomerAccountWithRoles, TaskRun, TaskNode, TaskNodeEdge`) were dead exports (imported nowhere) and are deleted. `Decimal` → `number` (matches the existing `validators`/`api.ts` contract); `Json` → a contract `JsonValue`.
- **`packages/types/package.json` + lockfile** — drop the `@dpf/db` dependency. `@dpf/types` is now a pure leaf consumed by `apps/mobile` and `@dpf/api-client`.
- **`packages/api-client/tsconfig.json`** — declare the DOM lib it actually uses (`fetch`/`Response`/`FormData`/`URLSearchParams`/`File`) instead of leaning on a transitive `@types/node` leak the removed `@dpf/db` dep had been providing. (Surfaced by this change; api-client never declared those types itself.)
- **`apps/web/lib/contracts/entity-contract-drift.ts`** — server-side type guard asserting each Prisma payload stays assignable to its DTO (with `Decimal` mapped to its wire form). Schema drift that breaks the wire contract now fails `web typecheck`.
- **`scripts/check-package-boundaries.mjs` + web unit test + `Package Boundary Guard` CI job** — fail if any portable package (`@dpf/types`, `@dpf/validators`, `@dpf/api-client`) declares or imports `@dpf/db` / Prisma. This is the first real enforcement for **BI-ARCH-PACKAGES**.
- **`docs/architecture/package-boundaries.md`** — the durable keep/collapse standard + the package boundary table.

## Verification
Ran on the canonical worktree (`D:/DPF-worktrees/platform-consolidation-spec`, `pnpm install` → compile-ready — a source-local gate, not canonical-runtime evidence):
- `@dpf/types`, `@dpf/api-client`, `mobile`, `web` typecheck — **clean**
- `pnpm --filter web build` (production) — **clean (exit 0)**
- `@dpf/api-client` tests (3) + package-boundary test (2) — **pass**
- Boundary guard CLI — `Package boundaries OK — 3 portable packages are free of @dpf/db / Prisma`
- The drift guard is demonstrably **live**: it caught a real JSON-shape mismatch during development (fixed by making the contract `JsonValue` a structural supertype of Prisma's), proving it is not a no-op.

## Scope
This is BI-ARCH-CONTRACTS (the spec's #1 recommended next step) plus the seed of BI-ARCH-PACKAGES enforcement — they belong together (the guard without the inversion would fail; the inversion without the guard could regress). The other 5 BIs (tool packs, Delivery IA, Build Studio NS, SectionNav, UI primitives) remain as separate slices.

## How to test
- Read the inverted contract: `packages/types/src/entities.ts` (now zero Prisma).
- `node scripts/check-package-boundaries.mjs` → exits 0 with the OK line; flip any portable package's `package.json` to add `@dpf/db` and it fails loudly.
- CI runs the full gate set (typecheck, build, unit tests, the new Package Boundary Guard).

EP-PLATFORM-CONSOLIDATION · spec: `docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)