### PR TITLE
feat(federation): exchange runtime — receiving + outbound halves (EP-MSP-FEDERATION runtime R3+R4)

### DIFF
--- a/apps/web/app/api/v1/federation/incident/route.ts
+++ b/apps/web/app/api/v1/federation/incident/route.ts
@@ -1,0 +1,69 @@
+// POST /api/v1/federation/incident
+//
+// EP-MSP-FEDERATION · B3 receiving route. A managed customer's DPF pushes a
+// minimized, source-correlated incident over the FederationLink; we (the MSP)
+// mirror it as a ServiceTicket. Authenticates with the peer's dpflink_ token
+// (dual-approved trusted link required). Flag-gated by
+// DPF_FEDERATION_EXCHANGE_ENABLED.
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { prisma } from "@dpf/db";
+
+import { resolveFederationLinkAuth } from "@/lib/auth/federation-link-token";
+import {
+  handleIncomingIncident,
+  type IncidentExchangeDb,
+  type IncomingIncident,
+} from "@/lib/federation/exchange-handlers";
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
+
+const ERROR_STATUS: Record<string, number> = {
+  missing_authorization: 401,
+  invalid_scheme: 401,
+  invalid_token_format: 401,
+  token_not_found: 401,
+  link_not_trusted: 403,
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!envFlagEnabled(process.env, "DPF_FEDERATION_EXCHANGE_ENABLED")) {
+    return NextResponse.json({ ok: false, error: "federation_exchange_disabled" }, { status: 404 });
+  }
+  const authz = await resolveFederationLinkAuth(request.headers.get("authorization"));
+  if (!authz.ok) {
+    return NextResponse.json(
+      { ok: false, error: authz.error, message: authz.message },
+      { status: ERROR_STATUS[authz.error] ?? 401 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid_json" }, { status: 400 });
+  }
+
+  // CloudEvents envelope: the payload rides in `data`.
+  const data = (body as { data?: unknown })?.data as Partial<IncomingIncident> | undefined;
+  if (
+    !data ||
+    typeof data.incidentKey !== "string" ||
+    typeof data.payloadHash !== "string" ||
+    typeof data.summary !== "string"
+  ) {
+    return NextResponse.json({ ok: false, error: "invalid_body" }, { status: 422 });
+  }
+
+  const result = await handleIncomingIncident(prisma as unknown as IncidentExchangeDb, authz.linkId, {
+    incidentKey: data.incidentKey,
+    summary: data.summary,
+    highestSeverity: typeof data.highestSeverity === "string" ? data.highestSeverity : "warn",
+    alertCount: typeof data.alertCount === "number" ? data.alertCount : 1,
+    payloadHash: data.payloadHash,
+    ...(typeof data.baseVersion === "number" ? { baseVersion: data.baseVersion } : {}),
+  });
+
+  return NextResponse.json({ ok: true, ...result }, { status: 200 });
+}

--- a/apps/web/app/api/v1/federation/proposal/route.ts
+++ b/apps/web/app/api/v1/federation/proposal/route.ts
@@ -1,0 +1,71 @@
+// POST /api/v1/federation/proposal
+//
+// EP-MSP-FEDERATION · B4 receiving route. The MSP's DPF pushes a remediation
+// proposal over the FederationLink; we (the sovereign customer) re-evaluate it
+// through OUR OWN consent gate and land it as a FederatedRemediationProposal —
+// proposed (Attention Surface) or rejected. The MSP never gains standing execute
+// rights; nothing auto-executes unless our own policy permits it (§15.4 default
+// off). Authenticates with the peer's dpflink_ token; flag-gated.
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { prisma } from "@dpf/db";
+
+import { resolveFederationLinkAuth } from "@/lib/auth/federation-link-token";
+import {
+  handleIncomingProposal,
+  type ProposalExchangeDb,
+} from "@/lib/federation/exchange-handlers";
+import type { RemediationProposalDraft } from "@/lib/service-desk/remediation-authority";
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
+
+const ERROR_STATUS: Record<string, number> = {
+  missing_authorization: 401,
+  invalid_scheme: 401,
+  invalid_token_format: 401,
+  token_not_found: 401,
+  link_not_trusted: 403,
+};
+
+function isProposalDraft(v: unknown): v is RemediationProposalDraft {
+  if (!v || typeof v !== "object") return false;
+  const d = v as Record<string, unknown>;
+  return (
+    typeof d.incidentKey === "string" &&
+    Array.isArray(d.actions) &&
+    typeof d.overallDecision === "string"
+  );
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!envFlagEnabled(process.env, "DPF_FEDERATION_EXCHANGE_ENABLED")) {
+    return NextResponse.json({ ok: false, error: "federation_exchange_disabled" }, { status: 404 });
+  }
+  const authz = await resolveFederationLinkAuth(request.headers.get("authorization"));
+  if (!authz.ok) {
+    return NextResponse.json(
+      { ok: false, error: authz.error, message: authz.message },
+      { status: ERROR_STATUS[authz.error] ?? 401 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid_json" }, { status: 400 });
+  }
+
+  const data = (body as { data?: unknown })?.data;
+  if (!isProposalDraft(data)) {
+    return NextResponse.json({ ok: false, error: "invalid_body" }, { status: 422 });
+  }
+
+  // The customer's own policy decides auto-execution; default is conservative.
+  // (A future slice resolves this from the link's AuthorityBinding band.)
+  const result = await handleIncomingProposal(prisma as unknown as ProposalExchangeDb, authz.linkId, data, {
+    customerAllowsAuto: false,
+  });
+
+  return NextResponse.json({ ok: true, ...result }, { status: 200 });
+}

--- a/apps/web/lib/auth/federation-link-token.ts
+++ b/apps/web/lib/auth/federation-link-token.ts
@@ -1,0 +1,84 @@
+// EP-MSP-FEDERATION · B1 — Bearer-token validation for /api/v1/federation/*
+// receiving routes. Resolves a presented Authorization: Bearer dpflink_<secret>
+// against FederationLink.tokenHash. Mirrors lib/auth/edge-node-token.ts, with the
+// dual-approval gate: a link may exchange projections / incidents / proposals
+// ONLY when it is fully trusted (both sides approved) and not quarantined/revoked.
+// Never logs the plaintext token; never mutates the link row.
+
+import { prisma } from "@dpf/db";
+import { canExchangeOverLink } from "@dpf/db/federation-link-types";
+
+import { classifyFederationToken, hashToken } from "@/lib/federation/tokens";
+
+export type ResolveFederationAuthFailure = {
+  ok: false;
+  error:
+    | "missing_authorization"
+    | "invalid_scheme"
+    | "invalid_token_format"
+    | "token_not_found"
+    | "link_not_trusted";
+  message: string;
+};
+
+export type ResolvedFederationAuth = {
+  ok: true;
+  /** FederationLink.linkId (stable external id). */
+  linkId: string;
+  /** This deployment's role on the link: "manages" | "managed-by". */
+  role: string;
+  linkState: string;
+  peerOrganizationRef: string | null;
+  projectionContractId: string | null;
+  authorityBindingId: string | null;
+};
+
+export async function resolveFederationLinkAuth(
+  authorizationHeader: string | null | undefined,
+): Promise<ResolvedFederationAuth | ResolveFederationAuthFailure> {
+  if (!authorizationHeader) {
+    return { ok: false, error: "missing_authorization", message: "Authorization header is required" };
+  }
+  const match = /^Bearer\s+(.+)$/.exec(authorizationHeader.trim());
+  if (!match) {
+    return { ok: false, error: "invalid_scheme", message: "Authorization must use the Bearer scheme" };
+  }
+  const presented = match[1]?.trim();
+  if (!presented) {
+    return { ok: false, error: "invalid_scheme", message: "Bearer token is empty" };
+  }
+  if (classifyFederationToken(presented) !== "link") {
+    return { ok: false, error: "invalid_token_format", message: "Federation tokens must use the dpflink_ prefix" };
+  }
+
+  const link = await prisma.federationLink.findUnique({ where: { tokenHash: hashToken(presented) } });
+  if (!link) {
+    return { ok: false, error: "token_not_found", message: "Federation link token does not match any link" };
+  }
+
+  // Dual-approval gate — exchange requires a fully trusted (both-approved) link.
+  if (
+    !canExchangeOverLink({
+      approvedAtLocal: link.approvedAtLocal,
+      approvedAtPeer: link.approvedAtPeer,
+      revokedAt: link.revokedAt,
+      quarantinedAt: link.quarantinedAt,
+    })
+  ) {
+    return {
+      ok: false,
+      error: "link_not_trusted",
+      message: `Federation link state '${link.linkState}' cannot exchange (requires dual approval)`,
+    };
+  }
+
+  return {
+    ok: true,
+    linkId: link.linkId,
+    role: link.role,
+    linkState: link.linkState,
+    peerOrganizationRef: link.peerOrganizationRef,
+    projectionContractId: link.projectionContractId,
+    authorityBindingId: link.authorityBindingId,
+  };
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 510,
+  "routeCount": 512,
   "routes": [
     {
       "routePath": "/",
@@ -2140,6 +2140,30 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/v1/federation/enroll/route.ts"
+    },
+    {
+      "routePath": "/api/v1/federation/incident",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "federation",
+        "incident"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/federation/incident/route.ts"
+    },
+    {
+      "routePath": "/api/v1/federation/proposal",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "federation",
+        "proposal"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/federation/proposal/route.ts"
     },
     {
       "routePath": "/api/v1/finance/assets",

--- a/apps/web/lib/federation/client.test.ts
+++ b/apps/web/lib/federation/client.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { postToPeer, sendIncidentToPeer } from "./client";
+
+function mockFetch(res: { ok?: boolean; status?: number; json?: unknown } = {}) {
+  return vi.fn().mockResolvedValue({
+    ok: res.ok ?? true,
+    status: res.status ?? 200,
+    json: async () => res.json ?? { ok: true },
+  }) as unknown as typeof fetch;
+}
+
+describe("postToPeer", () => {
+  it("POSTs to peerUrl+path with Bearer auth and a JSON body; strips trailing slash", async () => {
+    const f = mockFetch({ status: 200, json: { ok: true, action: "created" } });
+    const result = await postToPeer({
+      peerAuthorityUrl: "https://peer.example/",
+      linkToken: "dpflink_secret",
+      path: "/api/v1/federation/incident",
+      cloudEvent: { specversion: "1.0", data: { x: 1 } },
+      fetchImpl: f,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    const [url, init] = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    expect(url).toBe("https://peer.example/api/v1/federation/incident");
+    expect((init.headers as Record<string, string>).authorization).toBe("Bearer dpflink_secret");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string).data).toEqual({ x: 1 });
+  });
+
+  it("returns a soft failure on a network error (no throw)", async () => {
+    const f = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof fetch;
+    const result = await postToPeer({
+      peerAuthorityUrl: "https://peer.example",
+      linkToken: "dpflink_secret",
+      path: "/api/v1/federation/incident",
+      cloudEvent: {},
+      fetchImpl: f,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(0);
+    expect(result.error).toContain("ECONNREFUSED");
+  });
+});
+
+describe("sendIncidentToPeer", () => {
+  it("wraps the incident in a CloudEvent and posts to the incident route", async () => {
+    const f = mockFetch();
+    await sendIncidentToPeer(
+      { peerAuthorityUrl: "https://peer.example", linkToken: "dpflink_x", linkId: "link_1", fetchImpl: f },
+      { incidentKey: "k", summary: "s", payloadHash: "h" },
+    );
+    const [url, init] = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    expect(url).toBe("https://peer.example/api/v1/federation/incident");
+    const sent = JSON.parse(init.body as string);
+    expect(sent.specversion).toBe("1.0");
+    expect(sent.type).toBe("dpf.federation.incident");
+    expect(sent.dpflinkid).toBe("link_1");
+    expect(sent.data.incidentKey).toBe("k");
+  });
+});

--- a/apps/web/lib/federation/client.ts
+++ b/apps/web/lib/federation/client.ts
@@ -1,0 +1,86 @@
+// EP-MSP-FEDERATION · B1/B3/B4 — federation outbound client.
+//
+// Pushes a CloudEvents-wrapped payload to a peer DPF's /api/v1/federation/*
+// receiving routes, authenticating with the peer-issued link token. Outbound-
+// only HTTPS; the peer token is supplied by the caller (its encrypted-at-rest
+// storage is a separate slice). Injected `fetchImpl` keeps it unit-testable.
+
+import { toCloudEvent } from "@dpf/db/projection-serialization";
+
+export interface PeerPostResult {
+  ok: boolean;
+  status: number;
+  body?: unknown;
+  error?: string;
+}
+
+export async function postToPeer(input: {
+  peerAuthorityUrl: string;
+  linkToken: string;
+  path: string;
+  cloudEvent: unknown;
+  fetchImpl?: typeof fetch;
+}): Promise<PeerPostResult> {
+  const f = input.fetchImpl ?? fetch;
+  const url = input.peerAuthorityUrl.replace(/\/+$/, "") + input.path;
+  try {
+    const res = await f(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${input.linkToken}`,
+      },
+      body: JSON.stringify(input.cloudEvent),
+    });
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      body = undefined;
+    }
+    return { ok: res.ok, status: res.status, body };
+  } catch (err) {
+    return { ok: false, status: 0, error: err instanceof Error ? err.message : "network error" };
+  }
+}
+
+export interface PeerLinkTarget {
+  peerAuthorityUrl: string;
+  /** Plaintext peer-issued link token (we authenticate to them with it). */
+  linkToken: string;
+  linkId: string;
+  fetchImpl?: typeof fetch;
+}
+
+function envelope(linkId: string, type: string, data: unknown) {
+  return toCloudEvent({
+    id: `${linkId}:${type}:${Date.now()}`,
+    source: "/dpf",
+    type,
+    time: new Date().toISOString(),
+    linkId,
+    data,
+  });
+}
+
+/** Push a (minimized, source-correlated) incident to the managing peer (B3). */
+export async function sendIncidentToPeer(target: PeerLinkTarget, incident: unknown): Promise<PeerPostResult> {
+  return postToPeer({
+    peerAuthorityUrl: target.peerAuthorityUrl,
+    linkToken: target.linkToken,
+    path: "/api/v1/federation/incident",
+    cloudEvent: envelope(target.linkId, "dpf.federation.incident", incident),
+    ...(target.fetchImpl ? { fetchImpl: target.fetchImpl } : {}),
+  });
+}
+
+/** Push a remediation proposal to the sovereign customer (B4). */
+export async function sendProposalToPeer(target: PeerLinkTarget, proposal: unknown): Promise<PeerPostResult> {
+  return postToPeer({
+    peerAuthorityUrl: target.peerAuthorityUrl,
+    linkToken: target.linkToken,
+    path: "/api/v1/federation/proposal",
+    cloudEvent: envelope(target.linkId, "dpf.federation.proposal", proposal),
+    ...(target.fetchImpl ? { fetchImpl: target.fetchImpl } : {}),
+  });
+}

--- a/apps/web/lib/federation/exchange-handlers.test.ts
+++ b/apps/web/lib/federation/exchange-handlers.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildRemediationProposal } from "@/lib/service-desk/remediation-authority";
+import {
+  federatedTicketId,
+  handleIncomingIncident,
+  handleIncomingProposal,
+  type IncidentExchangeDb,
+  type IncomingIncident,
+  type ProposalExchangeDb,
+} from "./exchange-handlers";
+
+const incident: IncomingIncident = {
+  incidentKey: "edge-incident|peer-node|deploy|t",
+  summary: "3 alerts after deploy",
+  highestSeverity: "critical",
+  alertCount: 3,
+  payloadHash: "h1",
+};
+
+function incidentDb(existing: { version: number; syncStatus: string; payloadHash?: string | null } | null) {
+  const mirrorUpsert = vi.fn().mockResolvedValue({});
+  const ticketUpsert = vi.fn().mockResolvedValue({});
+  const db = {
+    federatedRecordMirror: { findFirst: vi.fn().mockResolvedValue(existing), upsert: mirrorUpsert },
+    serviceTicket: { upsert: ticketUpsert },
+  } as unknown as IncidentExchangeDb;
+  return { db, mirrorUpsert, ticketUpsert };
+}
+
+describe("federatedTicketId", () => {
+  it("is deterministic, link-scoped, ST-FED-prefixed", () => {
+    const a = federatedTicketId("link_1", incident.incidentKey);
+    expect(a).toBe(federatedTicketId("link_1", incident.incidentKey));
+    expect(a).not.toBe(federatedTicketId("link_2", incident.incidentKey));
+    expect(a).toMatch(/^ST-FED-[0-9A-F]{8}$/);
+  });
+});
+
+describe("handleIncomingIncident (B3 mirror)", () => {
+  it("creates a ticket + mirror for a new federated incident", async () => {
+    const { db, mirrorUpsert, ticketUpsert } = incidentDb(null);
+    const res = await handleIncomingIncident(db, "link_1", incident);
+    expect(res.action).toBe("created");
+    const ticket = (ticketUpsert.mock.calls[0][0] as { create: Record<string, unknown> }).create;
+    expect(ticket.ticketKind).toBe("incident");
+    expect(ticket.priority).toBe("urgent"); // critical
+    expect(ticket.correlatedIncidentKey).toBe(incident.incidentKey);
+    expect(mirrorUpsert).toHaveBeenCalledOnce();
+  });
+
+  it("noops when the same payload arrives again (idempotent)", async () => {
+    const { db, mirrorUpsert, ticketUpsert } = incidentDb({ version: 1, syncStatus: "synced", payloadHash: "h1" });
+    const res = await handleIncomingIncident(db, "link_1", incident);
+    expect(res.action).toBe("noop");
+    expect(ticketUpsert).not.toHaveBeenCalled();
+    expect(mirrorUpsert).not.toHaveBeenCalled();
+  });
+
+  it("updates on a new payload based on the current version", async () => {
+    const { db } = incidentDb({ version: 1, syncStatus: "synced", payloadHash: "h0" });
+    const res = await handleIncomingIncident(db, "link_1", { ...incident, payloadHash: "h2", baseVersion: 1 });
+    expect(res.action).toBe("updated");
+  });
+
+  it("flags a conflict on a stale base version", async () => {
+    const { db, ticketUpsert } = incidentDb({ version: 3, syncStatus: "synced", payloadHash: "h0" });
+    const res = await handleIncomingIncident(db, "link_1", { ...incident, payloadHash: "h2", baseVersion: 1 });
+    expect(res.action).toBe("conflict");
+    expect(ticketUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleIncomingProposal (B4 consent gate)", () => {
+  function proposalDb() {
+    const create = vi.fn().mockResolvedValue({ proposalId: "x" });
+    const db = { federatedRemediationProposal: { create } } as unknown as ProposalExchangeDb;
+    return { db, create };
+  }
+  function draft(risk: "read-only" | "medium" | "destructive") {
+    return buildRemediationProposal({ incidentKey: "k", edgeNodeId: "n", boundaryRef: "link_1" }, [
+      { actionType: "act", parameters: {}, riskClass: risk, rationale: "r" },
+    ]);
+  }
+
+  it("rejects a band-refused proposal", async () => {
+    const { db } = proposalDb();
+    const res = await handleIncomingProposal(db, "link_1", draft("destructive"));
+    expect(res.landing).toBe("refused");
+    expect(res.status).toBe("rejected");
+  });
+
+  it("routes a mutating proposal to the customer Attention Surface (proposed)", async () => {
+    const { db, create } = proposalDb();
+    const res = await handleIncomingProposal(db, "link_1", draft("medium"));
+    expect(res.landing).toBe("customer-attention-surface");
+    expect(res.status).toBe("proposed");
+    expect((create.mock.calls[0][0] as { data: { status: string } }).data.status).toBe("proposed");
+  });
+
+  it("auto-executes a read-only proposal only when the customer opts in", async () => {
+    const { db } = proposalDb();
+    expect((await handleIncomingProposal(db, "link_1", draft("read-only"), { customerAllowsAuto: true })).landing).toBe(
+      "auto-execute-on-customer",
+    );
+    expect((await handleIncomingProposal(db, "link_1", draft("read-only"), { customerAllowsAuto: false })).landing).toBe(
+      "customer-attention-surface",
+    );
+  });
+});

--- a/apps/web/lib/federation/exchange-handlers.ts
+++ b/apps/web/lib/federation/exchange-handlers.ts
@@ -98,7 +98,7 @@ export async function handleIncomingIncident(
       priority,
       severity: incident.highestSeverity,
       title: incident.summary,
-      description: `Federated incident from peer (link ${linkId}). ${incident.alertCount} alert(s).`,
+      description: `Federated incident from peer (link ${linkId}). ${incident.alertCount} alerts.`,
       correlatedIncidentKey: incident.incidentKey,
     },
     update: { priority, severity: incident.highestSeverity, title: incident.summary },

--- a/apps/web/lib/federation/exchange-handlers.ts
+++ b/apps/web/lib/federation/exchange-handlers.ts
@@ -1,0 +1,189 @@
+// EP-MSP-FEDERATION · B3 + B4 — federation exchange handlers (receiving side).
+//
+// What a peer DPF sends us, turned into local records:
+//   - handleIncomingIncident (B3): a peer's correlated incident becomes a
+//     FederatedRecordMirror + a local ServiceTicket. The peer is canonical;
+//     reconcileMirror does idempotency + conflict detection.
+//   - handleIncomingProposal (B4): an MSP's remediation proposal lands on us
+//     (the customer) as a FederatedRemediationProposal, routed by the consent
+//     gate. Conservative default (§15.4): nothing auto-executes until the
+//     customer opts in; above-band lands for human approval.
+//
+// DB-injected so the logic is unit-tested with a mock. The route layer supplies
+// the real prisma client. Control-runner execution is intentionally a boundary
+// stub (EP-CTRL-5E21A4 is the executing substrate, separate).
+
+import { createHash } from "crypto";
+
+import { reconcileMirror, type MirrorSyncStatus } from "@dpf/db/federated-record-sync";
+import { priorityFromSeverity } from "@dpf/db/service-ticket-types";
+
+import {
+  buildFederatedProposalRecord,
+  routeRemediationProposal,
+  type ProposalLanding,
+} from "@/lib/federation/remediation-consent";
+import type { RemediationProposalDraft } from "@/lib/service-desk/remediation-authority";
+
+// ── B3: incoming incident → mirror + ticket ──────────────────────────────────
+
+export interface IncomingIncident {
+  /** The peer's incident key (canonical id on the peer side). */
+  incidentKey: string;
+  summary: string;
+  highestSeverity: string;
+  alertCount: number;
+  /** Hash of the projected (minimized) incident payload — drives idempotency. */
+  payloadHash: string;
+  /** The peer's version this update is based on (optimistic concurrency). */
+  baseVersion?: number;
+}
+
+export interface IncidentExchangeDb {
+  federatedRecordMirror: {
+    findFirst(args: unknown): Promise<{ version: number; syncStatus: string; payloadHash?: string | null } | null>;
+    upsert(args: unknown): Promise<unknown>;
+  };
+  serviceTicket: { upsert(args: unknown): Promise<unknown> };
+}
+
+/** Deterministic, link-scoped ticket id for a federated incident. */
+export function federatedTicketId(linkId: string, incidentKey: string): string {
+  return "ST-FED-" + createHash("sha1").update(`${linkId}:${incidentKey}`).digest("hex").slice(0, 8).toUpperCase();
+}
+
+export type IncidentExchangeResult =
+  | { action: "created" | "updated"; ticketId: string }
+  | { action: "noop"; ticketId: string }
+  | { action: "conflict"; ticketId: string; reason: string };
+
+export async function handleIncomingIncident(
+  db: IncidentExchangeDb,
+  linkId: string,
+  incident: IncomingIncident,
+): Promise<IncidentExchangeResult> {
+  const ticketId = federatedTicketId(linkId, incident.incidentKey);
+  const existing = await db.federatedRecordMirror.findFirst({
+    where: { federationLinkId: linkId, recordType: "incident", localRecordRef: ticketId },
+  });
+
+  const decision = reconcileMirror(
+    existing
+      ? {
+          version: existing.version,
+          syncStatus: existing.syncStatus as MirrorSyncStatus,
+          canonicalSide: "peer",
+          payloadHash: existing.payloadHash ?? null,
+        }
+      : null,
+    {
+      fromSide: "peer",
+      baseVersion: incident.baseVersion ?? existing?.version ?? 1,
+      payloadHash: incident.payloadHash,
+    },
+  );
+
+  if (decision.action === "conflict") return { action: "conflict", ticketId, reason: decision.reason };
+  if (decision.action === "noop") return { action: "noop", ticketId };
+
+  const nextVersion = decision.action === "update" ? decision.nextVersion : 1;
+  const priority = priorityFromSeverity(incident.highestSeverity);
+
+  await db.serviceTicket.upsert({
+    where: { ticketId },
+    create: {
+      ticketId,
+      ticketKind: "incident",
+      status: "open",
+      priority,
+      severity: incident.highestSeverity,
+      title: incident.summary,
+      description: `Federated incident from peer (link ${linkId}). ${incident.alertCount} alert(s).`,
+      correlatedIncidentKey: incident.incidentKey,
+    },
+    update: { priority, severity: incident.highestSeverity, title: incident.summary },
+  });
+
+  await db.federatedRecordMirror.upsert({
+    where: {
+      federationLinkId_recordType_localRecordRef: {
+        federationLinkId: linkId,
+        recordType: "incident",
+        localRecordRef: ticketId,
+      },
+    },
+    create: {
+      mirrorId: `mir_${ticketId}`,
+      federationLinkId: linkId,
+      recordType: "incident",
+      canonicalSide: "peer",
+      localRecordRef: ticketId,
+      peerRecordRef: incident.incidentKey,
+      syncStatus: "synced",
+      version: nextVersion,
+      payload: { payloadHash: incident.payloadHash },
+      lastSyncedAt: new Date(),
+    },
+    update: {
+      syncStatus: "synced",
+      version: nextVersion,
+      payload: { payloadHash: incident.payloadHash },
+      lastSyncedAt: new Date(),
+    },
+  });
+
+  return { action: decision.action === "create" ? "created" : "updated", ticketId };
+}
+
+// ── B4: incoming remediation proposal → consent gate ─────────────────────────
+
+export interface ProposalExchangeDb {
+  federatedRemediationProposal: { create(args: unknown): Promise<{ proposalId: string }> };
+}
+
+export interface ProposalExchangePolicy {
+  /** The CUSTOMER's own policy: does it permit auto-execution for this band?
+   *  Default false (§15.4) — nothing auto-executes until the customer opts in. */
+  customerAllowsAuto?: boolean;
+}
+
+export interface ProposalExchangeResult {
+  proposalId: string;
+  landing: ProposalLanding;
+  status: "proposed" | "rejected";
+}
+
+export async function handleIncomingProposal(
+  db: ProposalExchangeDb,
+  linkId: string,
+  proposal: RemediationProposalDraft,
+  policy: ProposalExchangePolicy = {},
+): Promise<ProposalExchangeResult> {
+  // The link auth already proved the link is trusted before we get here.
+  const landing = routeRemediationProposal({
+    proposal,
+    linkTrusted: true,
+    customerAllowsAuto: policy.customerAllowsAuto ?? false,
+  });
+
+  const record = buildFederatedProposalRecord(linkId, proposal, landing);
+  const status: "proposed" | "rejected" = landing === "refused" ? "rejected" : "proposed";
+  const proposalId = `frp_${createHash("sha1").update(`${linkId}:${proposal.incidentKey}`).digest("hex").slice(0, 12)}`;
+
+  await db.federatedRemediationProposal.create({
+    data: {
+      proposalId,
+      federationLinkId: linkId,
+      incidentKey: record.incidentKey,
+      edgeNodeId: record.edgeNodeId,
+      actions: record.actions as unknown as object,
+      overallDecision: record.overallDecision,
+      status,
+      // attentionItemRef stays null until the Attention Surface posting lands
+      // (EP-ATTENTION-SURFACE); execution stays gated on the control runner
+      // (EP-CTRL-5E21A4). The MSP never gains standing execute rights here.
+    },
+  });
+
+  return { proposalId, landing, status };
+}

--- a/apps/web/lib/federation/federation-outbound.test.ts
+++ b/apps/web/lib/federation/federation-outbound.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { encryptSecret } from "@/lib/govern/credential-crypto";
+import { decryptPeerToken, enrollWithPeer } from "./outbound";
+import { incidentPayloadHash, pushIncidentsToManagingPeer, type OutboundPushDb } from "./push";
+
+function mockFetch(res: { ok?: boolean; status?: number; json?: unknown }) {
+  return vi.fn().mockResolvedValue({
+    ok: res.ok ?? true,
+    status: res.status ?? 200,
+    json: async () => res.json ?? {},
+  }) as unknown as typeof fetch;
+}
+
+describe("decryptPeerToken", () => {
+  it("round-trips through encryptSecret and handles null", () => {
+    const stored = encryptSecret("dpflink_peertoken");
+    expect(decryptPeerToken(stored)).toBe("dpflink_peertoken");
+    expect(decryptPeerToken(null)).toBeNull();
+    expect(decryptPeerToken(undefined)).toBeNull();
+  });
+});
+
+describe("incidentPayloadHash", () => {
+  it("is deterministic", () => {
+    const i = { incidentKey: "k", summary: "s", highestSeverity: "critical", alertCount: 3 };
+    expect(incidentPayloadHash(i)).toBe(incidentPayloadHash({ ...i }));
+  });
+});
+
+describe("pushIncidentsToManagingPeer", () => {
+  const incidents = [{ incidentKey: "k1", summary: "s1", highestSeverity: "critical", alertCount: 3 }];
+
+  it("skips when there is no trusted managing link", async () => {
+    const db = { federationLink: { findFirst: vi.fn().mockResolvedValue(null) } } as unknown as OutboundPushDb;
+    expect(await pushIncidentsToManagingPeer(db, incidents)).toEqual({ pushed: 0, skipped: 1, reason: "no-trusted-managing-link" });
+  });
+
+  it("skips when the link has no stored peer token", async () => {
+    const db = {
+      federationLink: { findFirst: vi.fn().mockResolvedValue({ linkId: "l", peerAuthorityUrl: "https://msp", peerTokenEnc: null }) },
+    } as unknown as OutboundPushDb;
+    expect(await pushIncidentsToManagingPeer(db, incidents)).toEqual({ pushed: 0, skipped: 1, reason: "no-peer-token" });
+  });
+
+  it("pushes each incident to the peer with the decrypted token", async () => {
+    const f = mockFetch({ ok: true, json: { ok: true } });
+    const db = {
+      federationLink: {
+        findFirst: vi.fn().mockResolvedValue({ linkId: "link_1", peerAuthorityUrl: "https://msp.example", peerTokenEnc: "dpflink_peertoken" }),
+      },
+    } as unknown as OutboundPushDb;
+    const res = await pushIncidentsToManagingPeer(db, incidents, { fetchImpl: f });
+    expect(res).toEqual({ pushed: 1, skipped: 0 });
+    const [url, init] = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    expect(url).toBe("https://msp.example/api/v1/federation/incident");
+    expect((init.headers as Record<string, string>).authorization).toBe("Bearer dpflink_peertoken");
+    expect(JSON.parse(init.body as string).data.payloadHash).toBe(incidentPayloadHash(incidents[0]));
+  });
+
+  it("no-ops on empty input", async () => {
+    const db = { federationLink: { findFirst: vi.fn() } } as unknown as OutboundPushDb;
+    expect(await pushIncidentsToManagingPeer(db, [])).toEqual({ pushed: 0, skipped: 0 });
+  });
+});
+
+describe("enrollWithPeer (error paths, no prisma)", () => {
+  const base = {
+    peerAuthorityUrl: "https://msp.example",
+    bootstrapToken: "dpffboot_x",
+    localAuthorityUrl: "https://customer.example",
+    displayName: "Customer LLP",
+  };
+
+  it("fails when the peer rejects the invitation", async () => {
+    const f = mockFetch({ ok: false, status: 401, json: { ok: false, error: "token_not_found", message: "bad" } });
+    const res = await enrollWithPeer({ ...base, fetchImpl: f });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe("token_not_found");
+  });
+
+  it("fails when the peer returns no usable token/role", async () => {
+    const f = mockFetch({ ok: true, json: { ok: true } });
+    const res = await enrollWithPeer({ ...base, fetchImpl: f });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe("invalid_peer_response");
+  });
+});

--- a/apps/web/lib/federation/outbound.ts
+++ b/apps/web/lib/federation/outbound.ts
@@ -1,0 +1,116 @@
+// EP-MSP-FEDERATION · R4 — outbound federation enrollment.
+//
+// The other half of the handshake: THIS deployment redeems a peer's invitation
+// to establish our side of a FederationLink and store the peer-issued link token
+// (encrypted at rest) so we can later call the peer's receiving routes.
+//
+// Role semantics: the peer's bootstrap offered US a role; the peer's enroll
+// response carries the PEER's own role, so ours is the inverse. Both sides land
+// `pending` — dual approval still applies (our operator approves locally; the
+// peer-approval relay that flips approvedAtPeer is a separate protocol slice).
+
+import { randomUUID } from "crypto";
+
+import { prisma } from "@dpf/db";
+import {
+  FEDERATION_PEER_ALIAS_TYPE,
+  FEDERATION_PEER_PRINCIPAL_KIND,
+  inverseRole,
+  isFederationRole,
+} from "@dpf/db/federation-link-types";
+
+import { decryptSecret, encryptSecret } from "@/lib/govern/credential-crypto";
+
+import { postToPeer } from "./client";
+
+export interface EnrollWithPeerInput {
+  /** The peer Authority Core base URL. */
+  peerAuthorityUrl: string;
+  /** The single-use dpffboot_ invitation the peer's operator gave us. */
+  bootstrapToken: string;
+  /** Our own Authority Core base URL (so the peer can reach us). */
+  localAuthorityUrl: string;
+  /** How the peer should label us. */
+  displayName: string;
+  localOrganizationId?: string | null;
+  peerOrganizationRef?: string | null;
+  fetchImpl?: typeof fetch;
+}
+
+export type EnrollWithPeerResult =
+  | { ok: true; linkId: string; linkState: string; role: string }
+  | { ok: false; error: string; message: string };
+
+interface PeerEnrollResponse {
+  ok?: boolean;
+  linkId?: string;
+  linkToken?: string;
+  role?: string;
+  linkState?: string;
+  error?: string;
+  message?: string;
+}
+
+export async function enrollWithPeer(input: EnrollWithPeerInput): Promise<EnrollWithPeerResult> {
+  // Reuse the generic peer-POST. The enroll body fields are from the RECEIVER's
+  // POV, so we send OUR url/org as the "peer" the receiver records.
+  const res = await postToPeer({
+    peerAuthorityUrl: input.peerAuthorityUrl,
+    linkToken: input.bootstrapToken,
+    path: "/api/v1/federation/enroll",
+    cloudEvent: {
+      peerAuthorityUrl: input.localAuthorityUrl,
+      displayName: input.displayName,
+      ...(input.localOrganizationId ? { peerOrganizationRef: input.localOrganizationId } : {}),
+    },
+    ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {}),
+  });
+
+  if (!res.ok) {
+    const body = res.body as PeerEnrollResponse | undefined;
+    return { ok: false, error: body?.error ?? "peer_unreachable", message: body?.message ?? `peer responded ${res.status}` };
+  }
+  const body = res.body as PeerEnrollResponse | undefined;
+  if (!body?.linkToken || !body.role || !isFederationRole(body.role)) {
+    return { ok: false, error: "invalid_peer_response", message: "peer did not return a usable link token/role" };
+  }
+
+  const ourRole = inverseRole(body.role);
+  const linkId = `link_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const now = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    const principal = await tx.principal.create({
+      data: {
+        principalId: `principal_${linkId}`,
+        kind: FEDERATION_PEER_PRINCIPAL_KIND,
+        displayName: input.displayName,
+      },
+    });
+    await tx.principalAlias.create({
+      data: { principalId: principal.id, aliasType: FEDERATION_PEER_ALIAS_TYPE, aliasValue: linkId },
+    });
+    await tx.federationLink.create({
+      data: {
+        linkId,
+        principalId: principal.id,
+        role: ourRole,
+        peerAuthorityUrl: input.peerAuthorityUrl,
+        peerOrganizationRef: input.peerOrganizationRef ?? null,
+        localOrganizationId: input.localOrganizationId ?? null,
+        linkState: "pending",
+        // Outbound token (peer-issued) encrypted at rest; no inbound token here.
+        peerTokenEnc: encryptSecret(body.linkToken!),
+        enrolledAt: now,
+      },
+    });
+  });
+
+  return { ok: true, linkId, linkState: "pending", role: ourRole };
+}
+
+/** Decrypt a stored peer link token for an outbound call. Null if absent/undecryptable. */
+export function decryptPeerToken(peerTokenEnc: string | null | undefined): string | null {
+  if (!peerTokenEnc) return null;
+  return decryptSecret(peerTokenEnc);
+}

--- a/apps/web/lib/federation/push.ts
+++ b/apps/web/lib/federation/push.ts
@@ -1,0 +1,67 @@
+// EP-MSP-FEDERATION · R4 — outbound incident push (building block).
+//
+// When THIS deployment is the managed-by (customer) side of a trusted link, push
+// our correlated incidents to the managing peer (MSP). DB + fetch injected so the
+// routing is unit-tested. Wiring this into the correlation job is gated on a
+// trusted link, which in turn needs the dual-approval relay (a separate slice).
+
+import { createHash } from "crypto";
+
+import { sendIncidentToPeer } from "./client";
+import { decryptPeerToken } from "./outbound";
+
+export interface OutboundPushDb {
+  federationLink: {
+    findFirst(args: unknown): Promise<{
+      linkId: string;
+      peerAuthorityUrl: string;
+      peerTokenEnc: string | null;
+    } | null>;
+  };
+}
+
+export interface PushableIncident {
+  incidentKey: string;
+  summary: string;
+  highestSeverity: string;
+  alertCount: number;
+}
+
+/** Stable hash of the minimized incident payload — the peer uses it for idempotency. */
+export function incidentPayloadHash(i: PushableIncident): string {
+  return createHash("sha1")
+    .update(`${i.incidentKey}|${i.summary}|${i.highestSeverity}|${i.alertCount}`)
+    .digest("hex");
+}
+
+export async function pushIncidentsToManagingPeer(
+  db: OutboundPushDb,
+  incidents: PushableIncident[],
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<{ pushed: number; skipped: number; reason?: string }> {
+  if (incidents.length === 0) return { pushed: 0, skipped: 0 };
+
+  // A trusted (dual-approved) link where WE are managed by a peer.
+  const link = await db.federationLink.findFirst({
+    where: { role: "managed-by", linkState: "trusted" },
+  });
+  if (!link) return { pushed: 0, skipped: incidents.length, reason: "no-trusted-managing-link" };
+
+  const token = decryptPeerToken(link.peerTokenEnc);
+  if (!token) return { pushed: 0, skipped: incidents.length, reason: "no-peer-token" };
+
+  let pushed = 0;
+  for (const incident of incidents) {
+    const res = await sendIncidentToPeer(
+      {
+        peerAuthorityUrl: link.peerAuthorityUrl,
+        linkToken: token,
+        linkId: link.linkId,
+        ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+      },
+      { ...incident, payloadHash: incidentPayloadHash(incident) },
+    );
+    if (res.ok) pushed++;
+  }
+  return { pushed, skipped: incidents.length - pushed };
+}

--- a/docs/superpowers/plans/2026-06-25-federation-exchange-runtime.md
+++ b/docs/superpowers/plans/2026-06-25-federation-exchange-runtime.md
@@ -1,0 +1,54 @@
+# Implementation Plan — Federation Exchange Runtime
+
+**Date:** 2026-06-25
+**Parent spec:** `docs/superpowers/specs/2026-06-24-managed-services-delivery-and-cross-org-federation-design.md`
+**Parent plan:** `docs/superpowers/plans/2026-06-24-managed-services-delivery-and-cross-org-federation-plan.md`
+**Epic:** `EP-MSP-FEDERATION` (runtime wiring, post-merge)
+
+Makes Topology B (sovereign-peer federation) actually exchange data over the merged
+substrate. Flag-gated by `DPF_FEDERATION_EXCHANGE_ENABLED` (default off).
+
+## R3 — receiving half (this slice)
+
+The complete inbound contract: a peer DPF can push to us, authenticated by the
+peer-issued `dpflink_` token, and we turn it into local records.
+
+- **`lib/auth/federation-link-token.ts`** — resolve a `dpflink_` bearer → FederationLink;
+  dual-approval gate (`canExchangeOverLink`): exchange requires a fully trusted link.
+  Mirrors `edge-node-token.ts`.
+- **`lib/federation/exchange-handlers.ts`** (DB-injected, unit-tested):
+  - `handleIncomingIncident` (B3): peer incident → `FederatedRecordMirror` (peer
+    canonical, `reconcileMirror` idempotency/conflict) + a local `ServiceTicket`.
+  - `handleIncomingProposal` (B4): MSP proposal → re-routed through OUR consent gate
+    (`routeRemediationProposal`, customer-allows-auto default off, §15.4) →
+    `FederatedRemediationProposal` (proposed / rejected).
+- **`lib/federation/client.ts`** — outbound `postToPeer` + `sendIncidentToPeer` /
+  `sendProposalToPeer` (CloudEvents envelope). Injected `fetchImpl` for tests. The
+  peer token is a CALLER input here (see R4 storage gap).
+- **Routes** `POST /api/v1/federation/{incident,proposal}` — flag-gate + link auth +
+  handler. Receiving is complete and deployable.
+
+Boundary stubs (intentional — separate substrate, not yet built):
+- **Control-runner execution** (EP-CTRL-5E21A4): a proposal lands as `proposed`;
+  the MSP never gains standing execute rights. Approved-execution wiring is deferred.
+- **Attention Surface posting** (EP-ATTENTION-SURFACE): `attentionItemRef` stays null
+  until that surface lands.
+
+## R4 — outbound half + agent loop (next)
+
+- **Peer-token storage**: the outbound client needs the peer-ISSUED link token. That
+  is a secret-at-rest (encrypt, not hash, since we must replay it) — add an encrypted
+  `peerTokenEnc` column on `FederationLink` + the enroll-acceptor flow that stores it.
+- **Outbound triggers**: when R1 creates a correlated incident on a `managed-by`
+  estate, push it to the managing peer (`sendIncidentToPeer`). When the MSP agent
+  produces a proposal, `sendProposalToPeer`.
+- **In-org agent loop (A4)**: operate-orchestrator diagnoses incidents and produces
+  remediation proposals (reusing `remediation-authority`).
+- **Approval relay + execution**: customer approval → relay to MSP; approved actions
+  execute on the customer's own control runner (when EP-CTRL-5E21A4 lands).
+
+## Verification
+
+- Pure handlers + client: vitest (DB / fetch injected).
+- Routes: `tsc --noEmit`. Two-instance end-to-end is the founder's live test once the
+  outbound half (R4) lands.

--- a/docs/superpowers/plans/2026-06-25-federation-exchange-runtime.md
+++ b/docs/superpowers/plans/2026-06-25-federation-exchange-runtime.md
@@ -34,18 +34,32 @@ Boundary stubs (intentional — separate substrate, not yet built):
 - **Attention Surface posting** (EP-ATTENTION-SURFACE): `attentionItemRef` stays null
   until that surface lands.
 
-## R4 — outbound half + agent loop (next)
+## R4 — outbound half (landed in this slice)
 
-- **Peer-token storage**: the outbound client needs the peer-ISSUED link token. That
-  is a secret-at-rest (encrypt, not hash, since we must replay it) — add an encrypted
-  `peerTokenEnc` column on `FederationLink` + the enroll-acceptor flow that stores it.
-- **Outbound triggers**: when R1 creates a correlated incident on a `managed-by`
-  estate, push it to the managing peer (`sendIncidentToPeer`). When the MSP agent
-  produces a proposal, `sendProposalToPeer`.
-- **In-org agent loop (A4)**: operate-orchestrator diagnoses incidents and produces
-  remediation proposals (reusing `remediation-authority`).
-- **Approval relay + execution**: customer approval → relay to MSP; approved actions
-  execute on the customer's own control runner (when EP-CTRL-5E21A4 lands).
+- **Peer-token storage (LANDED)**: encrypted `peerTokenEnc` column on `FederationLink`
+  (AES-256-GCM via credential-crypto — we must replay the token, not hash it) + migration.
+- **Outbound enrollment (LANDED)**: `enrollWithPeer` redeems a peer's invitation,
+  creates our side of the link (`role = inverse` of the peer's), and stores the
+  peer-issued token encrypted. Error paths unit-tested; success path typecheck-validated.
+- **Outbound push building block (LANDED)**: `pushIncidentsToManagingPeer` — when we are
+  the managed-by side of a trusted link, push our incidents to the managing peer
+  (`sendIncidentToPeer`, idempotent via a payload hash the peer reconciles). DB + fetch
+  injected; unit-tested.
+
+## Genuine remaining boundaries (need other epics or two-instance design)
+
+- **Dual-approval RELAY**: a link only reaches `trusted` when both sides approve AND the
+  peer-approval is relayed to flip our `approvedAtPeer`. That relay is a two-instance
+  protocol best designed + verified against two live installs — not built blind here.
+  Until it lands, the push building block stays dormant (no trusted managing link).
+- **Control-runner execution** (`EP-CTRL-5E21A4`): approved remediation executes on the
+  customer's own runner — owned by that epic. Proposals stay `proposed`.
+- **Attention-Surface approval UI** (`EP-ATTENTION-SURFACE`): where above-band proposals
+  surface for human approval — owned by that epic.
+- **LLM agent diagnosis (A4)**: operate-orchestrator producing proposals via the coworker
+  runtime (vs. the deterministic authority-band path already built).
+- **Connect-to-peer admin button**: a small form on the `/platform/federation-links`
+  surface (R2) to call `enrollWithPeer` — follow-up once R2 merges.
 
 ## Verification
 

--- a/packages/db/prisma/migrations/20260625120000_add_federation_peer_token/migration.sql
+++ b/packages/db/prisma/migrations/20260625120000_add_federation_peer_token/migration.sql
@@ -1,0 +1,4 @@
+-- EP-MSP-FEDERATION · R4 — outbound peer token at rest. The peer-issued link
+-- token WE use to call the peer (encrypted, AES-256-GCM, since we must replay it
+-- rather than hash it). Set when this deployment enrolls outbound with a peer.
+ALTER TABLE "FederationLink" ADD COLUMN "peerTokenEnc" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10537,9 +10537,14 @@ model FederationLink {
   revokedAt             DateTime?
   revocationReason      String?
   // Auth: dpflink_* link token, hashed at rest, rotating (mirrors EdgeNode).
+  // tokenHash is the INBOUND token (the one we issued for the peer to call us).
   tokenHash             String?                    @unique
   tokenPrefix           String?
   tokenRotatedAt        DateTime?
+  // The OUTBOUND token: the peer-issued link token WE use to call the peer.
+  // Encrypted at rest (AES-256-GCM, credential-crypto) because we must replay it,
+  // not hash it. Set when this deployment enrolled outbound with the peer.
+  peerTokenEnc          String?
   // Negotiated scope + authority (soft refs to ProjectionContract (B2) and
   // AuthorityBinding (the band) to keep cross-model blast radius low).
   projectionContractId  String?


### PR DESCRIPTION
The **inbound half of Topology B exchange** — a peer DPF can push over a `FederationLink` and we turn it into local records. Flag-gated by `DPF_FEDERATION_EXCHANGE_ENABLED` (default off).

## What
- **`lib/auth/federation-link-token.ts`** — resolve a `dpflink_` bearer → `FederationLink`, with the **dual-approval gate** (`canExchangeOverLink`): exchange requires a fully trusted (both-sides-approved) link. Mirrors `edge-node-token.ts`.
- **`lib/federation/exchange-handlers.ts`** (DB-injected, unit-tested):
  - `handleIncomingIncident` (B3): a peer's correlated incident → `FederatedRecordMirror` (peer canonical, `reconcileMirror` idempotency + conflict detection) + a local `ServiceTicket`.
  - `handleIncomingProposal` (B4): an MSP proposal → **re-routed through OUR consent gate** (`routeRemediationProposal`; customer-allows-auto default **off**, §15.4) → `FederatedRemediationProposal` (`proposed` / `rejected`).
- **`lib/federation/client.ts`** — outbound `postToPeer` + `sendIncident/ProposalToPeer` (CloudEvents envelope), injected-`fetch` testable.
- **`POST /api/v1/federation/{incident,proposal}`** — flag-gate + link auth + handler.

## Boundary stubs (intentional — separate substrate)
- Control-runner execution (`EP-CTRL-5E21A4`): proposals land as `proposed`; **the MSP never gains standing execute rights**.
- Attention-Surface posting (`EP-ATTENTION-SURFACE`): `attentionItemRef` stays null until it lands.
- The **outbound peer-token storage** (encrypt-at-rest) + outbound triggers + in-org agent loop are R4 (documented in the plan).

## Validation
11 new unit tests (handlers + client); `apps/web` typecheck clean; route manifest regenerated.
Plan: `docs/superpowers/plans/2026-06-25-federation-exchange-runtime.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)