### PR TITLE
feat(patch-mgmt): Prisma binding for the assessment projector (EP-PATCH-MANAGEMENT P0)

### DIFF
--- a/apps/web/lib/patch/finding-mapping.test.ts
+++ b/apps/web/lib/patch/finding-mapping.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { PatchFindingUpsert } from "@dpf/db/patch";
+
+import { toNormalizedAssuranceFinding } from "./finding-mapping";
+
+function upsert(overrides: Partial<PatchFindingUpsert> = {}): PatchFindingUpsert {
+  return {
+    findingKey: "patch:ev1",
+    findingKind: "patch-gap",
+    title: "Firefox 120.0 → 121.0",
+    description: "A newer version is available (121.0).",
+    affectedType: "DiscoveredSoftwareEvidence",
+    affectedId: "ev1",
+    adapterKey: "patch-intel",
+    vendorIdentifier: "winget:firefox",
+    policySeverity: "medium",
+    remediationHint: { targetVersion: "121.0", applyVia: "winget" },
+    source: { inventoryEntityId: "host-1", installedVersion: "120.0" },
+    ...overrides,
+  };
+}
+
+describe("toNormalizedAssuranceFinding", () => {
+  it("maps patch-gap -> missing-patch on the host with a weak identifier", () => {
+    const n = toNormalizedAssuranceFinding(upsert());
+    expect(n.findingKind).toBe("missing-patch");
+    expect(n.affectedType).toBe("inventory-entity");
+    expect(n.affectedId).toBe("host-1");
+    expect(n.identifierStability).toBe("weak");
+    expect(n.releaseImpact).toBe("track");
+    expect(n.findingKey).toBe("patch:ev1");
+    expect(n.evidence).toMatchObject({ installedVersion: "120.0" });
+    expect(n.remediationHint).toMatchObject({ targetVersion: "121.0" });
+  });
+
+  it("maps a CVE-backed vulnerability to a strong identifier", () => {
+    const n = toNormalizedAssuranceFinding(
+      upsert({ findingKind: "vulnerability", vendorIdentifier: "CVE-2026-1", policySeverity: "high" }),
+    );
+    expect(n.findingKind).toBe("vulnerability");
+    expect(n.identifierStability).toBe("strong");
+    expect(n.policySeverity).toBe("high");
+  });
+
+  it("maps end-of-life -> unsupported-component", () => {
+    expect(toNormalizedAssuranceFinding(upsert({ findingKind: "end-of-life" })).findingKind).toBe(
+      "unsupported-component",
+    );
+  });
+
+  it("falls back to the projector affectedId when the host id is absent", () => {
+    expect(toNormalizedAssuranceFinding(upsert({ source: {} })).affectedId).toBe("ev1");
+  });
+
+  it("coerces an out-of-vocabulary severity to info", () => {
+    expect(toNormalizedAssuranceFinding(upsert({ policySeverity: "bogus" })).policySeverity).toBe("info");
+  });
+});

--- a/apps/web/lib/patch/finding-mapping.ts
+++ b/apps/web/lib/patch/finding-mapping.ts
@@ -1,0 +1,67 @@
+// Translate a patch-domain finding (from the packages/db projector) into the canonical
+// NormalizedAssuranceFinding vocabulary before it is persisted to the Assurance Ledger.
+//
+// The projector speaks patch terms (findingKind patch-gap|vulnerability|end-of-life,
+// affectedType DiscoveredSoftwareEvidence). The Assurance Ledger has its own closed
+// enums (AGENTS.md §3). This pure mapper is the only place that bridge happens.
+
+import type { PatchFindingUpsert } from "@dpf/db/patch";
+
+import type {
+  AssuranceAffectedType,
+  AssuranceFindingKind,
+  AssurancePolicySeverity,
+  NormalizedAssuranceFinding,
+} from "../assurance/types";
+
+// patch-domain findingKind -> canonical AssuranceFindingKind.
+const FINDING_KIND_MAP: Record<string, AssuranceFindingKind> = {
+  vulnerability: "vulnerability",
+  "patch-gap": "missing-patch",
+  "end-of-life": "unsupported-component",
+};
+
+const POLICY_SEVERITIES = new Set<AssurancePolicySeverity>(["critical", "high", "medium", "low", "info"]);
+
+function readString(source: Record<string, unknown>, key: string): string | null {
+  const value = source[key];
+  return typeof value === "string" && value ? value : null;
+}
+
+function toPolicySeverity(value: string): AssurancePolicySeverity {
+  return POLICY_SEVERITIES.has(value as AssurancePolicySeverity) ? (value as AssurancePolicySeverity) : "info";
+}
+
+/** A CVE/GHSA-backed identifier is stable; a synthetic `pm:pkg` one is weak. */
+function identifierStability(vendorIdentifier: string): "strong" | "weak" {
+  return /^(CVE-|GHSA-)/i.test(vendorIdentifier) ? "strong" : "weak";
+}
+
+/**
+ * Map a projector finding to a NormalizedAssuranceFinding. The affected entity is the
+ * host (`inventory-entity`); the specific software + version live in evidence and the
+ * stable `findingKey` (`patch:<evidenceKey>`), so multiple software findings per host
+ * stay distinct.
+ */
+export function toNormalizedAssuranceFinding(finding: PatchFindingUpsert): NormalizedAssuranceFinding {
+  const findingKind = FINDING_KIND_MAP[finding.findingKind] ?? "missing-patch";
+  const affectedId = readString(finding.source, "inventoryEntityId") ?? finding.affectedId;
+  const affectedType: AssuranceAffectedType = "inventory-entity";
+  return {
+    findingKey: finding.findingKey,
+    adapterKey: finding.adapterKey,
+    findingKind,
+    affectedType,
+    affectedId,
+    vendorIdentifier: finding.vendorIdentifier,
+    title: finding.title,
+    description: finding.description,
+    policySeverity: toPolicySeverity(finding.policySeverity),
+    releaseImpact: "track", // estate patch posture informs; it does not gate releases
+    reachability: "unknown",
+    exposure: "unknown",
+    identifierStability: identifierStability(finding.vendorIdentifier),
+    evidence: { ...finding.source },
+    remediationHint: { ...finding.remediationHint },
+  };
+}

--- a/apps/web/lib/patch/patch-assessment-store.test.ts
+++ b/apps/web/lib/patch/patch-assessment-store.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import type { PatchIntelProvider, SoftwareEvidenceLike } from "@dpf/db/patch";
+
+import { runEstatePatchAssessment, type PatchStoreDb } from "./patch-assessment-store";
+
+const NOW = new Date("2026-06-25T00:00:00.000Z");
+
+interface StoredFinding {
+  findingKey: string;
+  status: string;
+  [k: string]: unknown;
+}
+
+/** In-memory db faithfully implementing the slices of Prisma the store + persistence use. */
+class FakeDb implements PatchStoreDb {
+  runCreates: Array<Record<string, unknown>> = [];
+  runUpdates: Array<{ data: Record<string, unknown> }> = [];
+  findingCreates: Array<Record<string, unknown>> = [];
+  findings = new Map<string, StoredFinding>();
+
+  constructor(
+    private readonly evidence: Array<Record<string, unknown>>,
+    seed: StoredFinding[] = [],
+  ) {
+    for (const f of seed) this.findings.set(f.findingKey, f);
+  }
+
+  discoveredSoftwareEvidence = {
+    findMany: async (): Promise<unknown[]> => this.evidence,
+  };
+
+  assuranceRun = {
+    create: async (args: { data: Record<string, unknown> }) => {
+      this.runCreates.push(args.data);
+      return { id: "run-1" };
+    },
+    update: async (args: { data: Record<string, unknown> }) => {
+      this.runUpdates.push(args);
+      return {};
+    },
+  };
+
+  assuranceFinding = {
+    findMany: async (args: { where?: { findingKey?: { in?: string[] } } }): Promise<unknown[]> => {
+      const keys = args?.where?.findingKey?.in ?? [];
+      return keys.filter((k) => this.findings.has(k)).map((k) => this.findings.get(k)!);
+    },
+    create: async (args: { data: StoredFinding }) => {
+      this.findings.set(args.data.findingKey, { ...args.data });
+      this.findingCreates.push(args.data);
+      return {};
+    },
+    update: async (args: { where: { findingKey: string }; data: Record<string, unknown> }) => {
+      const key = args.where.findingKey;
+      const prev = this.findings.get(key) ?? { findingKey: key, status: "open" };
+      this.findings.set(key, { ...prev, ...args.data } as StoredFinding);
+      return {};
+    },
+    updateMany: async (args: {
+      where: { AND: Array<{ findingKey: { startsWith?: string; notIn?: string[] } }>; status: { in: string[] } };
+      data: Record<string, unknown>;
+    }) => {
+      const prefix = args.where.AND[0].findingKey.startsWith ?? "";
+      const notIn = new Set(args.where.AND[1].findingKey.notIn ?? []);
+      const statusIn = new Set(args.where.status.in);
+      let count = 0;
+      for (const [key, val] of this.findings) {
+        if (key.startsWith(prefix) && !notIn.has(key) && statusIn.has(val.status)) {
+          this.findings.set(key, { ...val, status: "resolved" });
+          count += 1;
+        }
+      }
+      return { count };
+    },
+  };
+}
+
+const EVIDENCE: Array<Record<string, unknown>> = [
+  { id: "e-vuln", evidenceKey: "vuln", inventoryEntityId: "host-1", rawProductName: "openssl", rawPackageName: "openssl", rawVersion: "3.0.0", packageManager: "dpkg" },
+  { id: "e-gap", evidenceKey: "gap", inventoryEntityId: "host-1", rawProductName: "curl", rawPackageName: "curl", rawVersion: "8.0.0", packageManager: "dpkg" },
+  { id: "e-clean", evidenceKey: "clean", inventoryEntityId: "host-2", rawProductName: "bash", rawPackageName: "bash", rawVersion: "5.2.0", packageManager: "dpkg" },
+];
+
+const provider: PatchIntelProvider = (ev: SoftwareEvidenceLike) => {
+  switch (ev.evidenceKey) {
+    case "vuln":
+      return { advisories: [{ id: "CVE-2026-1", severity: "critical" }] };
+    case "gap":
+      return { latestSafeVersion: "8.8.0" };
+    default:
+      return { latestSafeVersion: ev.rawVersion };
+  }
+};
+
+describe("runEstatePatchAssessment", () => {
+  it("opens an estate AssuranceRun, writes actionable findings, and closes it", async () => {
+    const db = new FakeDb(EVIDENCE);
+    const summary = await runEstatePatchAssessment(db, provider, { now: NOW });
+
+    expect(db.runCreates[0]).toMatchObject({
+      scopeType: "estate",
+      scopeId: "platform",
+      adapterKey: "patch-intel",
+      status: "running",
+    });
+    expect(summary.assessed).toBe(3);
+    expect(summary.actionable).toBe(2);
+
+    const created = db.findingCreates.map((d) => d.findingKey).sort();
+    expect(created).toEqual(["patch:gap", "patch:vuln"]);
+
+    const vuln = db.findingCreates.find((d) => d.findingKey === "patch:vuln")!;
+    expect(vuln.findingKind).toBe("vulnerability");
+    expect(vuln.affectedType).toBe("inventory-entity");
+    expect(vuln.affectedId).toBe("host-1");
+
+    const gap = db.findingCreates.find((d) => d.findingKey === "patch:gap")!;
+    expect(gap.findingKind).toBe("missing-patch");
+
+    expect(db.runUpdates[0].data).toMatchObject({ status: "passed" });
+  });
+
+  it("resolves a previously-open patch finding that is now clean", async () => {
+    const db = new FakeDb(EVIDENCE, [{ findingKey: "patch:stale", status: "open" }]);
+    const summary = await runEstatePatchAssessment(db, provider, { now: NOW });
+    expect(summary.resolved).toBe(1);
+    expect(db.findings.get("patch:stale")!.status).toBe("resolved");
+  });
+});

--- a/apps/web/lib/patch/patch-assessment-store.ts
+++ b/apps/web/lib/patch/patch-assessment-store.ts
@@ -1,0 +1,136 @@
+// Prisma binding for the estate patch-assessment projector.
+//
+// Implements the packages/db PatchAssessmentStore port against the live database:
+//   - listSoftwareEvidence  -> DiscoveredSoftwareEvidence rows
+//   - upsertFinding         -> the canonical persistAssuranceFindings writer
+//   - resolveFindingsExcept -> resolve now-clean patch findings (patch:* key scope)
+//
+// Decoupled behind a minimal db subset (the house "Prisma read/write subset" pattern)
+// so the whole flow is unit-testable with a fake db; the real PrismaClient satisfies it
+// structurally via a single boundary cast in the scheduled job.
+
+import {
+  runPatchAssessment,
+  type PatchAssessmentStore,
+  type PatchAssessmentSummary,
+  type PatchFindingUpsert,
+  type PatchIntelProvider,
+  type SoftwareEvidenceLike,
+} from "@dpf/db/patch";
+
+import { persistAssuranceFindings } from "../assurance/finding-persistence";
+import { toNormalizedAssuranceFinding } from "./finding-mapping";
+
+const PATCH_ADAPTER_KEY = "patch-intel";
+const PATCH_ADAPTER_VERSION = "1.0.0";
+const PATCH_FINDING_KEY_PREFIX = "patch:";
+// Non-terminal statuses a now-clean patch finding may be auto-resolved FROM. `accepted`
+// (intentional risk) and `deferred` (parked) are left alone — mirrors finding-persistence.
+const ACTIVE_RESOLVABLE_STATUSES = ["open", "planned", "blocked"];
+
+/** Minimal db surface the store needs; satisfied by PrismaClient and test fakes. */
+export interface PatchStoreDb {
+  discoveredSoftwareEvidence: { findMany(args: unknown): Promise<unknown[]> };
+  assuranceRun: {
+    create(args: unknown): Promise<{ id: string }>;
+    update(args: unknown): Promise<unknown>;
+  };
+  assuranceFinding: {
+    findMany(args: unknown): Promise<unknown[]>;
+    create(args: unknown): Promise<unknown>;
+    update(args: unknown): Promise<unknown>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+}
+
+interface EvidenceRow {
+  id: string;
+  evidenceKey: string;
+  inventoryEntityId: string;
+  rawVendor: string | null;
+  rawProductName: string | null;
+  rawPackageName: string | null;
+  rawVersion: string | null;
+  packageManager: string | null;
+}
+
+/** Build a store bound to a specific AssuranceRun. */
+export function createPrismaPatchStore(
+  db: PatchStoreDb,
+  options: { assuranceRunId: string; now: Date },
+): PatchAssessmentStore {
+  return {
+    async listSoftwareEvidence(): Promise<SoftwareEvidenceLike[]> {
+      const rows = (await db.discoveredSoftwareEvidence.findMany({
+        select: {
+          id: true,
+          evidenceKey: true,
+          inventoryEntityId: true,
+          rawVendor: true,
+          rawProductName: true,
+          rawPackageName: true,
+          rawVersion: true,
+          packageManager: true,
+        },
+      })) as EvidenceRow[];
+      return rows.map((row) => ({ ...row }));
+    },
+
+    async upsertFinding(finding: PatchFindingUpsert): Promise<void> {
+      await persistAssuranceFindings(db, {
+        assuranceRunId: options.assuranceRunId,
+        findings: [toNormalizedAssuranceFinding(finding)],
+        observedAt: options.now,
+      });
+    },
+
+    async resolveFindingsExcept(activeFindingKeys: string[]): Promise<number> {
+      const result = await db.assuranceFinding.updateMany({
+        where: {
+          AND: [
+            { findingKey: { startsWith: PATCH_FINDING_KEY_PREFIX } },
+            { findingKey: { notIn: activeFindingKeys } },
+          ],
+          status: { in: ACTIVE_RESOLVABLE_STATUSES },
+        },
+        data: { status: "resolved", resolvedAt: options.now },
+      });
+      return result.count;
+    },
+  };
+}
+
+/**
+ * Run a full estate patch assessment: open an AssuranceRun, project discovered software
+ * into patch findings via the injected intelligence provider, and close the run with a
+ * posture summary. Returns the summary. The provider is injected so the live OSV/KEV feed
+ * (and a test stub) plug in without changing this orchestration.
+ */
+export async function runEstatePatchAssessment(
+  db: PatchStoreDb,
+  provider: PatchIntelProvider,
+  options: { now: Date; scopeId?: string },
+): Promise<PatchAssessmentSummary> {
+  const at = options.now;
+  const run = await db.assuranceRun.create({
+    data: {
+      runId: `assurance_patch_${at.toISOString()}`,
+      scopeType: "estate",
+      scopeId: options.scopeId ?? "platform",
+      adapterKey: PATCH_ADAPTER_KEY,
+      adapterVersion: PATCH_ADAPTER_VERSION,
+      status: "running",
+      startedAt: at,
+    },
+  });
+
+  const store = createPrismaPatchStore(db, { assuranceRunId: run.id, now: at });
+  const summary = await runPatchAssessment(store, provider, { now: at });
+
+  await db.assuranceRun.update({
+    where: { id: run.id },
+    data: { status: "passed", completedAt: at, summary },
+  });
+
+  return summary;
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -62,6 +62,12 @@ export default defineConfig({
         replacement: resolve(rootDir, "packages/db/src/discovery-collectors/snmp.ts"),
       },
       {
+        // Barrel subpath: maps to patch/index.ts, not patch.ts, so it must precede
+        // the generic regex below (which would resolve to a nonexistent patch.ts).
+        find: "@dpf/db/patch",
+        replacement: resolve(rootDir, "packages/db/src/patch/index.ts"),
+      },
+      {
         find: /^@dpf\/db\/(.+)$/,
         replacement: resolve(rootDir, "packages/db/src/$1.ts"),
       },

--- a/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
+++ b/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
@@ -1,7 +1,7 @@
 # Estate Patch Management — P0 implementation plan
 
 - **Date:** 2026-06-25
-- **Status:** In progress (slices 1–2a + projector core landed; runtime binding next)
+- **Status:** In progress (slices 1–2a merged; projector core + Prisma binding landed; live feed + scheduled job next)
 - **Spec:** `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`
 - **Epic:** `EP-PATCH-MANAGEMENT`
 - **Backlog:** BI-CAA0043C (version-intel feed), BI-489A8BB4 (assessment projector), BI-676A7960 (identity convergence), BI-020EE402 (posture UX)
@@ -35,7 +35,7 @@ Adapter interfaces + implementations that produce `assessPatchState` inputs, eac
 
 ### Slice 3 — Assessment projector → AssuranceFinding (BI-489A8BB4)
 - **Pure core — LANDED:** `packages/db/src/patch/patch-projector.ts`. A `PatchAssessmentStore` port + `runPatchAssessment` orchestration (read evidence → `assessEvidence` → `evidenceToPatchFinding` → upsert actionable findings → resolve now-clean ones → posture summary), plus `applyViaForPackageManager`. Decoupled from Prisma so the whole read→assess→upsert→resolve flow is unit-tested against an in-memory fake store. Emits the AssuranceFinding upsert shape (`findingKind` ∈ patch-gap|vulnerability|end-of-life; `adapterKey` patch-intel|osv|cisa-kev; stable `findingKey` = `patch:<evidenceKey>`). **No new findings table** — composes the Assurance Ledger (`schema.prisma:4968`).
-- **Prisma binding — remaining (runtime-bound):** a `PatchAssessmentStore` adapter in `apps/web/lib/patch/` that lists `DiscoveredSoftwareEvidence` and **delegates finding writes to the existing `apps/web/lib/assurance/finding-persistence.ts`** (single source of truth for `AssuranceFinding` create/update/reopen — do not hand-roll a parallel upsert). Verified via the local-CI sandbox lease. Carries a coverage metric so missing inventory is not read as clean.
+- **Prisma binding — LANDED (unit-verified):** `apps/web/lib/patch/patch-assessment-store.ts` (`createPrismaPatchStore` + `runEstatePatchAssessment`) implements the port against the live DB: lists `DiscoveredSoftwareEvidence`, **delegates finding writes to the existing `apps/web/lib/assurance/finding-persistence.ts`** (single source of truth — no parallel upsert), opens/closes an `AssuranceRun` (`scopeType=estate`), and resolves now-clean findings scoped by the `patch:` key prefix. `apps/web/lib/patch/finding-mapping.ts` translates the patch vocabulary to the canonical Assurance enums (patch-gap→`missing-patch`, end-of-life→`unsupported-component`, affected→`inventory-entity`) — verified by 7 apps/web vitest cases against an in-memory fake db; both `@dpf/db` and `web` typecheck clean. Pure modules exposed via the new `@dpf/db/patch` subpath. **Remaining:** a real-DB write smoke via the local-CI sandbox lease, and a coverage metric.
 
 ### Slice 4 — Identity convergence (BI-676A7960) — gated
 Map the `DiscoveryFingerprint*` subsystem first; decide whether the software-identity spine extends it or lands a focused `CatalogIdentity` + `SoftwarePatchProfile`. Then the reviewable migration for `softwareIdentityId` (rename→`legacy…` + add `catalogIdentityId`, or drop-with-evidence) per the lifecycle-evidence spec §7.4. Runs through Prisma in the sandbox/canonical install, never blind. Until then, slice 3 keys findings on `DiscoveredSoftwareEvidence`/`InventoryEntity` directly.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -36,7 +36,8 @@
     "./wiki-store": "./src/wiki-store.ts",
     "./wiki-frontmatter": "./src/wiki-frontmatter.ts",
     "./capability-maturity": "./src/capability-maturity.ts",
-    "./business-capability-perspectives": "./src/business-capability-perspectives.ts"
+    "./business-capability-perspectives": "./src/business-capability-perspectives.ts",
+    "./patch": "./src/patch/index.ts"
   },
   "scripts": {
     "postinstall": "prisma generate",

--- a/packages/db/src/patch/index.ts
+++ b/packages/db/src/patch/index.ts
@@ -1,0 +1,7 @@
+// Estate patch management — lightweight, prisma-free barrel (EP-PATCH-MANAGEMENT).
+// Exposed as the "@dpf/db/patch" subpath so apps/web can consume the pure classifier,
+// advisory extractors, and assessment projector without pulling the heavy package index
+// (which instantiates Prisma/neo4j/qdrant clients).
+export * from "./patch-intel";
+export * from "./osv-adapter";
+export * from "./patch-projector";


### PR DESCRIPTION
Builds on #2359 (projector core, merged). Wires the packages/db projector to the live database so the read-only estate patch posture writes real findings. Plan: `docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md`.

## What

- **`apps/web/lib/patch/finding-mapping.ts`** — pure translation from the patch vocabulary to the **canonical Assurance enums** (AGENTS.md §3): `patch-gap`→`missing-patch`, `end-of-life`→`unsupported-component`, affected→`inventory-entity` (the host; the software + version live in `evidence` + the stable `findingKey`). CVE/GHSA identifiers are `strong`, synthetic ones `weak`.
- **`apps/web/lib/patch/patch-assessment-store.ts`** — `createPrismaPatchStore` + `runEstatePatchAssessment`: opens an estate `AssuranceRun`, **delegates finding writes to the existing `apps/web/lib/assurance/finding-persistence.ts`** (single source of truth — no parallel upsert), and resolves now-clean findings scoped by the `patch:` key prefix. The db is an injectable port, so the whole flow is unit-tested with an in-memory fake.
- **`@dpf/db/patch`** subpath barrel — exposes the pure packages/db modules without pulling the heavy package index (which instantiates Prisma/neo4j/qdrant). `apps/web/vitest.config.ts` gets the matching alias, declared before the generic `@dpf/db/*` regex (same pattern as the `discovery-collectors-*` entries).

## No new findings table, no parallel writer

A patch gap is an `AssuranceFinding`; persistence goes through the one canonical writer. The projector stays in patch-domain terms; this layer is the only place the vocabulary is bridged.

## Verification

- `pnpm --filter web exec vitest run lib/patch/` → **7/7 passed** (mapping + full `runEstatePatchAssessment` orchestration incl. resolution, against a fake db).
- `pnpm --filter @dpf/db typecheck` and `pnpm --filter web typecheck` → clean.
- **Next:** a real-DB write smoke via the local-CI sandbox lease (the store's db port is loosely typed for testability, so live Prisma query shapes are exercised there), then the live OSV/KEV provider + scheduled job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)