### PR TITLE
feat(patch-mgmt): live OSV/KEV feed + daily estate patch-assessment sweep (EP-PATCH-MANAGEMENT P0)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -429,6 +429,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     tracksRunData: false,
     runNowEvent: null,
   },
+  {
+    jobId: "patch-assessment-sweep",
+    inngestId: "ops/patch-assessment-sweep",
+    name: "Estate patch assessment",
+    purpose:
+      "EP-PATCH-MANAGEMENT P0: projects discovered installed software into patch findings (OSV vulnerabilities + CISA KEV prioritization) on the Assurance Ledger, and resolves findings that became clean. If it stops, estate patch posture goes stale.",
+    cron: "0 5 * * *",
+    cadence: "Daily at 05:00",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
 ] as const;
 
 const CATALOG_BY_JOB_ID = new Map<string, ScheduledJobCatalogEntry>(

--- a/apps/web/lib/patch/ecosystem-map.test.ts
+++ b/apps/web/lib/patch/ecosystem-map.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { osvEcosystemFor } from "./ecosystem-map";
+
+describe("osvEcosystemFor", () => {
+  it("maps language package managers to OSV ecosystems", () => {
+    expect(osvEcosystemFor("npm")).toBe("npm");
+    expect(osvEcosystemFor("pip")).toBe("PyPI");
+    expect(osvEcosystemFor("PyPI")).toBe("PyPI");
+    expect(osvEcosystemFor("cargo")).toBe("crates.io");
+    expect(osvEcosystemFor("nuget")).toBe("NuGet");
+  });
+
+  it("returns null for OS package managers that need distro context", () => {
+    expect(osvEcosystemFor("dpkg")).toBeNull();
+    expect(osvEcosystemFor("rpm")).toBeNull();
+    expect(osvEcosystemFor("brew")).toBeNull();
+    expect(osvEcosystemFor("powershell")).toBeNull();
+    expect(osvEcosystemFor(null)).toBeNull();
+    expect(osvEcosystemFor(undefined)).toBeNull();
+  });
+});

--- a/apps/web/lib/patch/ecosystem-map.ts
+++ b/apps/web/lib/patch/ecosystem-map.ts
@@ -1,0 +1,24 @@
+// Map a discovered package manager (as recorded on DiscoveredSoftwareEvidence) to the
+// OSV ecosystem used to query advisories. Returns null when OSV cannot be queried
+// reliably for it: OS package managers (dpkg/rpm/brew) need distribution context
+// (e.g. "Debian:12") that host inventory does not capture today, so those are the
+// native-manager adapter's job (Edge Node on-host "installed -> available"), not OSV's.
+
+const OSV_ECOSYSTEM_BY_MANAGER: Record<string, string> = {
+  npm: "npm",
+  pip: "PyPI",
+  pypi: "PyPI",
+  gem: "RubyGems",
+  cargo: "crates.io",
+  go: "Go",
+  composer: "Packagist",
+  nuget: "NuGet",
+  maven: "Maven",
+  pub: "Pub",
+  hex: "Hex",
+};
+
+/** OSV ecosystem for a package manager, or null when OSV is not a reliable source. */
+export function osvEcosystemFor(packageManager: string | null | undefined): string | null {
+  return OSV_ECOSYSTEM_BY_MANAGER[(packageManager ?? "").toLowerCase()] ?? null;
+}

--- a/apps/web/lib/patch/kev-client.ts
+++ b/apps/web/lib/patch/kev-client.ts
@@ -1,0 +1,23 @@
+// Live CISA Known Exploited Vulnerabilities (KEV) catalog client. Returns the set of
+// exploited CVE ids used to escalate/route patch findings. CISA_KEV_URL can point at a
+// mirror for air-gapped installs.
+
+import { parseKevCatalog } from "@dpf/db/patch";
+
+const KEV_URL =
+  process.env.CISA_KEV_URL ??
+  "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json";
+const TIMEOUT_MS = Number(process.env.CISA_KEV_TIMEOUT_MS ?? 20000);
+
+/** Fetch the CISA KEV catalog and return its CVE id set (empty on any failure path). */
+export async function fetchKevCves(): Promise<Set<string>> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(KEV_URL, { signal: controller.signal });
+    if (!res.ok) throw new Error(`CISA KEV HTTP ${res.status}`);
+    return parseKevCatalog(await res.json());
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/web/lib/patch/osv-client.ts
+++ b/apps/web/lib/patch/osv-client.ts
@@ -1,0 +1,27 @@
+// Live OSV.dev client for one package@version. Uses the single /v1/query endpoint,
+// which returns full vulnerability objects (severity, affected ranges, aliases) in one
+// call — no separate detail fetch. Air-gapped installs can point OSV_BASE_URL at a mirror.
+
+import type { OsvVuln } from "@dpf/db/patch";
+
+const OSV_BASE = process.env.OSV_BASE_URL ?? "https://api.osv.dev";
+const TIMEOUT_MS = Number(process.env.OSV_TIMEOUT_MS ?? 20000);
+
+/** Query OSV for vulnerabilities affecting `name@version` in `ecosystem`. */
+export async function fetchOsvVulns(ecosystem: string, name: string, version: string): Promise<OsvVuln[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(`${OSV_BASE}/v1/query`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ package: { ecosystem, name }, version }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`OSV HTTP ${res.status}`);
+    const json = (await res.json()) as { vulns?: OsvVuln[] };
+    return json.vulns ?? [];
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/web/lib/patch/patch-intel-provider.test.ts
+++ b/apps/web/lib/patch/patch-intel-provider.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import type { OsvVuln, SoftwareEvidenceLike } from "@dpf/db/patch";
+
+import { createOsvPatchIntelProvider } from "./patch-intel-provider";
+
+const VULN: OsvVuln = {
+  id: "GHSA-aaaa",
+  aliases: ["CVE-2026-1"],
+  database_specific: { severity: "HIGH" },
+  affected: [
+    { package: { ecosystem: "npm", name: "left-pad" }, ranges: [{ events: [{ introduced: "0" }, { fixed: "1.3.0" }] }] },
+  ],
+};
+
+function ev(overrides: Partial<SoftwareEvidenceLike> = {}): SoftwareEvidenceLike {
+  return {
+    evidenceKey: "e1",
+    inventoryEntityId: "host-1",
+    packageManager: "npm",
+    rawPackageName: "left-pad",
+    rawVersion: "1.0.0",
+    ...overrides,
+  };
+}
+
+describe("createOsvPatchIntelProvider", () => {
+  it("returns OSV advisories (with KEV flag) for a language-ecosystem package", async () => {
+    const provider = createOsvPatchIntelProvider({
+      fetchVulns: async () => [VULN],
+      kevCves: new Set(["CVE-2026-1"]),
+    });
+    const intel = await provider(ev());
+    expect(intel?.advisories?.[0]).toMatchObject({
+      id: "CVE-2026-1",
+      severity: "high",
+      fixedVersion: "1.3.0",
+      cisaKev: true,
+    });
+  });
+
+  it("does not even call OSV for OS package managers it can't query reliably", async () => {
+    let called = false;
+    const provider = createOsvPatchIntelProvider({
+      fetchVulns: async () => {
+        called = true;
+        return [];
+      },
+      kevCves: new Set(),
+    });
+    expect(await provider(ev({ packageManager: "dpkg" }))).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  it("returns null when name or version is missing", async () => {
+    const provider = createOsvPatchIntelProvider({ fetchVulns: async () => [VULN], kevCves: new Set() });
+    expect(await provider(ev({ rawPackageName: null, rawProductName: null }))).toBeNull();
+    expect(await provider(ev({ rawVersion: null }))).toBeNull();
+  });
+
+  it("returns null when OSV finds nothing", async () => {
+    const provider = createOsvPatchIntelProvider({ fetchVulns: async () => [], kevCves: new Set() });
+    expect(await provider(ev())).toBeNull();
+  });
+
+  it("returns null (no fabrication) when OSV errors", async () => {
+    const provider = createOsvPatchIntelProvider({
+      fetchVulns: async () => {
+        throw new Error("network");
+      },
+      kevCves: new Set(),
+    });
+    expect(await provider(ev())).toBeNull();
+  });
+});

--- a/apps/web/lib/patch/patch-intel-provider.ts
+++ b/apps/web/lib/patch/patch-intel-provider.ts
@@ -1,0 +1,57 @@
+// Live version-intelligence provider for the patch projector.
+//
+// For each piece of discovered software, resolves OSV advisories (vulnerabilities)
+// for the ecosystems OSV can query reliably, and marks CISA KEV membership. The OSV
+// fetcher is injected so this composition is unit-testable without a network call.
+//
+// Scope (v1): OSV gives "is this version vulnerable + fixed-in", which yields
+// vulnerability findings (the highest-value posture signal). It does NOT give "latest
+// available version", so plain behind-on-version (`patch-gap`) and end-of-life findings
+// come later from the native-manager adapter (Edge Node on-host "installed -> available").
+
+import {
+  osvVulnsToAdvisories,
+  type OsvVuln,
+  type PatchIntel,
+  type PatchIntelProvider,
+  type SoftwareEvidenceLike,
+} from "@dpf/db/patch";
+
+import { osvEcosystemFor } from "./ecosystem-map";
+
+/** Fetch OSV vulns for one package@version in an OSV ecosystem. */
+export type OsvVulnFetcher = (ecosystem: string, name: string, version: string) => Promise<OsvVuln[]>;
+
+export interface OsvProviderOptions {
+  fetchVulns: OsvVulnFetcher;
+  /** CISA KEV CVE ids; advisories whose CVE alias is in this set are flagged exploited. */
+  kevCves: ReadonlySet<string>;
+}
+
+/**
+ * Build a PatchIntelProvider backed by OSV + CISA KEV. Returns null intel (no finding)
+ * when the manager is not an OSV ecosystem, identity/version is missing, OSV finds
+ * nothing, or OSV is unreachable for that item — never fabricates a verdict.
+ */
+export function createOsvPatchIntelProvider(options: OsvProviderOptions): PatchIntelProvider {
+  return async (evidence: SoftwareEvidenceLike): Promise<PatchIntel | null> => {
+    const ecosystem = osvEcosystemFor(evidence.packageManager);
+    const name = evidence.rawPackageName ?? evidence.rawProductName ?? null;
+    if (!ecosystem || !name || !evidence.rawVersion) return null;
+
+    let vulns: OsvVuln[];
+    try {
+      vulns = await options.fetchVulns(ecosystem, name, evidence.rawVersion);
+    } catch {
+      return null; // OSV unreachable for this item — skip rather than fabricate
+    }
+    if (vulns.length === 0) return null;
+
+    const advisories = osvVulnsToAdvisories(vulns, {
+      ecosystem,
+      packageName: name,
+      kevCves: options.kevCves,
+    });
+    return { advisories };
+  };
+}

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -58,6 +58,7 @@ import { releaseHealthCheck } from "./release-health-check";
 import { marketingSchedulerDispatch } from "./marketing-scheduler-dispatch";
 import { recurringInvoiceDispatch } from "./recurring-invoice-dispatch";
 import { siemCorrelationSweep } from "./siem-correlation-sweep";
+import { patchAssessmentSweep } from "./patch-assessment-sweep";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 export const scheduledFunctions = [
@@ -93,6 +94,7 @@ export const scheduledFunctions = [
   marketingSchedulerDispatch, // BI-SCHED-DORMANT: wire ScheduledOutboundAction dispatch, every 30m
   recurringInvoiceDispatch,   // BI-SCHED-DORMANT: wire recurring-invoice generation, daily 06:30
   siemCorrelationSweep,       // BI-6D9496F1: EP-SOVEREIGN-SOC P1 — project internal audit -> SecurityEvent + run detection rules, every 15m
+  patchAssessmentSweep,       // EP-PATCH-MANAGEMENT P0: daily estate patch posture sweep (OSV+KEV -> AssuranceFinding), 05:00
 ];
 
 export const eventFunctions = [

--- a/apps/web/lib/queue/functions/patch-assessment-sweep.ts
+++ b/apps/web/lib/queue/functions/patch-assessment-sweep.ts
@@ -1,0 +1,50 @@
+// apps/web/lib/queue/functions/patch-assessment-sweep.ts
+// EP-PATCH-MANAGEMENT P0 — estate patch posture sweep.
+//
+// Daily: project every discovered software item into patch findings on the Assurance
+// Ledger. Resolves OSV advisories (with CISA KEV prioritization) for the ecosystems OSV
+// can query, writes/reopens AssuranceFinding rows via the canonical finding-persistence
+// writer, and resolves findings that have become clean. The estate "what is vulnerable"
+// posture stays current with no operator watching.
+//
+// Mirrors log-signature-scanner.ts: a pure exported sweep (tests drive it without the
+// Inngest harness) + a thin wrapper with the quiescence gate. KEV/OSV are best-effort —
+// an unreachable feed degrades coverage, it does not fail the job or fabricate findings.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import { runEstatePatchAssessment, type PatchStoreDb } from "@/lib/patch/patch-assessment-store";
+import { createOsvPatchIntelProvider } from "@/lib/patch/patch-intel-provider";
+import { fetchOsvVulns } from "@/lib/patch/osv-client";
+import { fetchKevCves } from "@/lib/patch/kev-client";
+import type { PatchAssessmentSummary } from "@dpf/db/patch";
+
+/**
+ * Run one estate patch assessment. Exported so tests can drive it directly. The DB and
+ * feed clients are resolved here so the sweep is self-contained for the Inngest wrapper.
+ */
+export async function runPatchAssessmentSweep(): Promise<PatchAssessmentSummary> {
+  const { prisma } = await import("@dpf/db");
+
+  let kevCves: Set<string>;
+  try {
+    kevCves = await fetchKevCves();
+  } catch (err) {
+    console.error("[patch-assessment-sweep] CISA KEV unreachable; proceeding without KEV", err);
+    kevCves = new Set();
+  }
+
+  const provider = createOsvPatchIntelProvider({ fetchVulns: fetchOsvVulns, kevCves });
+  return runEstatePatchAssessment(prisma as unknown as PatchStoreDb, provider, { now: new Date() });
+}
+
+export const patchAssessmentSweep = inngest.createFunction(
+  { id: "ops/patch-assessment-sweep", retries: 2, triggers: [cron("0 5 * * *")] },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return await step.run("patch-assessment", runPatchAssessmentSweep);
+  },
+);

--- a/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
+++ b/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
@@ -1,7 +1,7 @@
 # Estate Patch Management — P0 implementation plan
 
 - **Date:** 2026-06-25
-- **Status:** In progress (slices 1–2a merged; projector core + Prisma binding landed; live feed + scheduled job next)
+- **Status:** Read-only posture pipeline complete (feed → projector → binding → daily sweep wired); posture UX next
 - **Spec:** `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`
 - **Epic:** `EP-PATCH-MANAGEMENT`
 - **Backlog:** BI-CAA0043C (version-intel feed), BI-489A8BB4 (assessment projector), BI-676A7960 (identity convergence), BI-020EE402 (posture UX)
@@ -29,9 +29,9 @@ This is the shared brain for both BI-CAA0043C and BI-489A8BB4 and is independent
 Adapter interfaces + implementations that produce `assessPatchState` inputs, each gated by the Tool Evaluation Pipeline before embed:
 - **`osv` adapter — LANDED (pure):** `packages/db/src/patch/osv-adapter.ts` turns OSV vuln objects into `AdvisoryInput` (severity band, lowest fixed version, CVE/GHSA aliases), generalized beyond npm to any ecosystem. Mirrors the proven shape in `scripts/sbom/scan-dependencies.mjs`.
 - **`cisa-kev` adapter — LANDED (pure):** `parseKevCatalog` + KEV enrichment in `osvVulnToAdvisory` mark an advisory exploited when its CVE alias is in the catalog.
-- `native-manager` adapter — the Edge Node's on-host "installed → available" output (`winget show`, `apt-cache policy`, `dnf check-update`, `brew outdated`). **Remaining — depends on the Edge Node software-inventory capability.**
-- `eol` adapter — end-of-life dates. **Remaining.**
-- Live fetch (OSV `querybatch` + `/vulns/{id}`, KEV catalog download) + scheduled projector entry in `SCHEDULED_JOB_CATALOG`. **Remaining — runtime-bound, verified via the sandbox.**
+- **Live OSV + KEV fetch + provider — LANDED:** `apps/web/lib/patch/osv-client.ts` (OSV `/v1/query` per package), `kev-client.ts` (CISA KEV catalog), `ecosystem-map.ts` (package-manager → OSV ecosystem, null for OS managers needing distro context), `patch-intel-provider.ts` (`createOsvPatchIntelProvider` — injected fetch, unit-tested; returns null rather than fabricate when OSV is unreachable/empty). v1 yields **vulnerability + KEV** findings for language ecosystems; OS-package version-gaps + EOL await the native-manager adapter.
+- **Scheduled job — LANDED:** `apps/web/lib/queue/functions/patch-assessment-sweep.ts` (`ops/patch-assessment-sweep`, daily 05:00) runs `runEstatePatchAssessment` behind the quiescence gate; registered in `scheduledFunctions` + `SCHEDULED_JOB_CATALOG` (parity-test guarded). Exercises the real DB writes end-to-end on the deployed install — the self-upgrade is the integration test.
+- `native-manager` adapter (Edge Node on-host "installed → available") + `eol` adapter — **Remaining**, depend on the Edge Node software-inventory capability.
 
 ### Slice 3 — Assessment projector → AssuranceFinding (BI-489A8BB4)
 - **Pure core — LANDED:** `packages/db/src/patch/patch-projector.ts`. A `PatchAssessmentStore` port + `runPatchAssessment` orchestration (read evidence → `assessEvidence` → `evidenceToPatchFinding` → upsert actionable findings → resolve now-clean ones → posture summary), plus `applyViaForPackageManager`. Decoupled from Prisma so the whole read→assess→upsert→resolve flow is unit-tested against an in-memory fake store. Emits the AssuranceFinding upsert shape (`findingKind` ∈ patch-gap|vulnerability|end-of-life; `adapterKey` patch-intel|osv|cisa-kev; stable `findingKey` = `patch:<evidenceKey>`). **No new findings table** — composes the Assurance Ledger (`schema.prisma:4968`).


### PR DESCRIPTION
Completes the **read-only P0 estate patch posture pipeline** on top of the now-merged projector (#2359) + binding (#2365): discovered software → live intelligence → findings on the Assurance Ledger, on a daily cadence. Plan: `docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md`.

## What

- **Version-intelligence provider** (`apps/web/lib/patch/`): `ecosystem-map.ts` (package-manager → OSV ecosystem; null for OS managers that need distro context), `osv-client.ts` (OSV `/v1/query` per package), `kev-client.ts` (CISA KEV catalog), `patch-intel-provider.ts` (`createOsvPatchIntelProvider` — the OSV fetch is **injected**, so the composition is unit-tested without network; returns null rather than fabricate when OSV is unreachable/empty).
- **Scheduled sweep** (`apps/web/lib/queue/functions/patch-assessment-sweep.ts`): `ops/patch-assessment-sweep`, **daily 05:00**, runs `runEstatePatchAssessment` behind the quiescence gate. Registered in `scheduledFunctions` + `SCHEDULED_JOB_CATALOG` (the catalog↔function **parity test** guards the pair).

## Scope (honest)

v1 yields **vulnerability + CISA KEV** findings for language ecosystems (npm/PyPI/crates/…), which is the highest-value posture signal and reuses the OSV capability DPF already trusts. OS-package version-gaps and end-of-life findings await the **native-manager adapter** (Edge Node on-host "installed → available") — flagged in the plan, not faked here.

## Verification

- `pnpm --filter web exec vitest run lib/patch/ lib/queue/functions/index.test.ts` → **17/17** (provider, ecosystem map, mapping, store orchestration, **+ catalog↔function parity**).
- `pnpm --filter web typecheck` → clean.
- The real DB writes run end-to-end on the **deployed install** when the daily sweep fires (gated by `DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED`) — exercised by the self-upgrade, observable in the assurance findings surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)