### PR TITLE
feat(sovereign-soc): EP-SOVEREIGN-SOC P3-P6 — governed response, detection content, EA, compliance, federation, console

### DIFF
--- a/apps/web/app/(shell)/ops/security/page.tsx
+++ b/apps/web/app/(shell)/ops/security/page.tsx
@@ -1,0 +1,110 @@
+// EP-SOVEREIGN-SOC P4 — /ops/security SOC console.
+// Server component; the (shell)/ops layout already gates view_operations.
+// First screen (spec §10.2): Are we covered? Are we exposed? What needs a
+// decision? Are we improving? An empty board with no sources is NOT a green
+// state — the coverage card flags it.
+
+import { OpsTabNav } from "@/components/ops/OpsTabNav";
+import { StatCard, StatusBadge } from "@/components/ui/report-kit";
+import { loadSocConsole } from "@/lib/security/console-loader";
+
+export const dynamic = "force-dynamic";
+
+export default async function SecurityConsolePage() {
+  const { data, recentCases } = await loadSocConsole();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Security Operations</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          AI SOC console — coverage, detections, cases, and SLA across the estate.
+        </p>
+      </div>
+
+      <OpsTabNav />
+
+      {!data.coverage.monitoring && (
+        <p className="mt-4 text-sm text-[var(--dpf-muted)]">
+          Coverage incomplete — no security sources are reporting yet. Connect collectors before
+          treating an empty board as &ldquo;all clear&rdquo;.
+        </p>
+      )}
+
+      <section className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+        <StatCard
+          label="Connected sources"
+          value={data.coverage.connectedSources}
+          intent={data.coverage.monitoring ? "success" : "danger"}
+          hint={data.coverage.staleSources ? `${data.coverage.staleSources} stale` : "are we covered?"}
+        />
+        <StatCard
+          label="Open detections"
+          value={data.detections.open}
+          intent={data.detections.open ? "warning" : "neutral"}
+          hint={`${data.detections.total} in window`}
+        />
+        <StatCard
+          label="Open cases"
+          value={data.cases.open}
+          intent={data.cases.open ? "warning" : "neutral"}
+          hint="are we exposed?"
+        />
+        <StatCard
+          label="Awaiting decision"
+          value={data.cases.awaitingDecision}
+          intent={data.cases.awaitingDecision ? "danger" : "success"}
+          hint="needs you"
+        />
+        <StatCard
+          label="MTTR"
+          value={data.metrics.mttrMinutes != null ? `${data.metrics.mttrMinutes}m` : "—"}
+          hint="mean time to resolve"
+        />
+        <StatCard
+          label="False-positive rate"
+          value={data.metrics.falsePositiveRate != null ? `${Math.round(data.metrics.falsePositiveRate * 100)}%` : "—"}
+          hint="are we improving?"
+        />
+      </section>
+
+      <section className="mt-6">
+        <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">Recent cases</h2>
+        {recentCases.length === 0 ? (
+          <p className="text-sm text-[var(--dpf-muted)]">No security cases yet.</p>
+        ) : (
+          <div className="overflow-x-auto rounded-md border border-[var(--dpf-border)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--dpf-border)] text-left text-[var(--dpf-muted)]">
+                  <th className="px-3 py-2 font-medium">Case</th>
+                  <th className="px-3 py-2 font-medium">Severity</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Verdict</th>
+                  <th className="px-3 py-2 font-medium">Opened</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentCases.map((c) => (
+                  <tr key={c.caseKey} className="border-b border-[var(--dpf-border)] last:border-0">
+                    <td className="px-3 py-2 font-medium text-[var(--dpf-text)]">{c.title}</td>
+                    <td className="px-3 py-2">
+                      <StatusBadge domain="securitySeverity" status={c.severity} variant="soft" uppercase={false} />
+                    </td>
+                    <td className="px-3 py-2">
+                      <StatusBadge domain="security" status={c.status} variant="soft" uppercase={false} />
+                    </td>
+                    <td className="px-3 py-2 text-[var(--dpf-muted)]">{c.verdict}</td>
+                    <td className="px-3 py-2 text-[var(--dpf-muted)]">
+                      {new Date(c.openedAt).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/api/platform/security/overview/route.ts
+++ b/apps/web/app/api/platform/security/overview/route.ts
@@ -1,0 +1,25 @@
+// EP-SOVEREIGN-SOC P4 — SOC console overview API.
+// Returns the first-screen aggregates (coverage / detections / cases / SLA) plus
+// the recent-case list. Gated by view_operations (the same capability as the
+// /ops surface). Read-only, no-store.
+
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { loadSocConsole } from "@/lib/security/console-loader";
+
+export async function GET(): Promise<Response> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_operations")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const overview = await loadSocConsole();
+  return NextResponse.json(overview, {
+    headers: { "Cache-Control": "no-store, max-age=0" },
+  });
+}

--- a/apps/web/components/ops/ops-nav.ts
+++ b/apps/web/components/ops/ops-nav.ts
@@ -23,4 +23,9 @@ export const OPS_NAV_GROUPS: ReadonlyArray<{
       { label: "Dev Loop", href: "/ops/dev-loop" },
     ],
   },
+  {
+    // EP-SOVEREIGN-SOC P4 — the AI SOC console (coverage / detections / cases / SLA).
+    label: "Security",
+    tabs: [{ label: "SOC Console", href: "/ops/security" }],
+  },
 ];

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -345,6 +345,28 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     executed: "success",
     expired: "neutral",
   },
+  // Security case / detection lifecycle (EP-SOVEREIGN-SOC). Open work is info;
+  // active investigation/containment is accent; resolved is success, closed neutral.
+  security: {
+    open: "info",
+    new: "info",
+    triaging: "warning",
+    triaged: "warning",
+    investigating: "accent",
+    contained: "accent",
+    linked: "accent",
+    suppressed: "neutral",
+    resolved: "success",
+    closed: "neutral",
+  },
+  // Security severity (OCSF-aligned). info/low benign; medium/high warn; critical danger.
+  securitySeverity: {
+    info: "info",
+    low: "success",
+    medium: "warning",
+    high: "warning",
+    critical: "danger",
+  },
 };
 
 /**

--- a/apps/web/lib/ea/architecture-parity-steward.test.ts
+++ b/apps/web/lib/ea/architecture-parity-steward.test.ts
@@ -30,6 +30,7 @@ function projectionResult(overrides: Partial<SysmlProjectionsResult> = {}): Sysm
     integrations: healthy,
     scheduledJobs: healthy,
     it4itCoverage: healthy,
+    securityPosture: healthy,
     ...overrides,
   };
 }

--- a/apps/web/lib/ea/architecture-parity-steward.ts
+++ b/apps/web/lib/ea/architecture-parity-steward.ts
@@ -63,6 +63,7 @@ const DOMAIN_LABELS: Record<ProjectionDomain, string> = {
   integrations: "connected-application integrations",
   scheduledJobs: "scheduling surface (all scheduled work)",
   it4itCoverage: "IT4IT functional-criteria coverage",
+  securityPosture: "security operations (SOC) surface",
 };
 
 function projectionEntries(result: SysmlProjectionsResult): Array<[ProjectionDomain, ProjectionStatus]> {

--- a/apps/web/lib/ea/reconcile-security-posture.ts
+++ b/apps/web/lib/ea/reconcile-security-posture.ts
@@ -1,0 +1,23 @@
+// apps/web/lib/ea/reconcile-security-posture.ts
+//
+// Reconcile the Security Operations (SOC) SysML projection (Parity Engine,
+// living-graph — EP-SOVEREIGN-SOC / EP-PARITY-ENGINE). Thin IO shell: the model
+// is fully derived from the implementation (KERNEL_DETECTION_PACK + the AGT-SOC-*
+// roster), so this re-derives and applies it every run — the projection cannot
+// drift. Cross-layer `traces` to the security data-model nodes resolve once the
+// Prisma->EA mirror has run.
+
+import { prisma } from "@dpf/db";
+
+import { buildSecurityPostureModel } from "./security-posture-extract";
+import { applySysmlModel, type SysmlSeedResult } from "./sysml-model-seed";
+
+export async function reconcileSecurityPosture(
+  opts: { db?: typeof prisma } = {},
+): Promise<SysmlSeedResult> {
+  const result = await applySysmlModel(buildSecurityPostureModel(), { db: opts.db });
+  console.info(
+    `[security-posture] reconcile ${result.status}: created=${result.created} updated=${result.updated} removed=${result.removed} crossLayerLinked=${result.crossLayerLinked ?? 0}`,
+  );
+  return result;
+}

--- a/apps/web/lib/ea/reconcile-sysml-projections.test.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.test.ts
@@ -34,10 +34,12 @@ describe("reconcileSysmlProjections", () => {
     expect(r.integrations.status).toBe("skipped"); // no IntegrationCredential rows
     expect(r.scheduledJobs.status).toBe("skipped"); // notation null -> applySysmlModel skips
     expect(r.it4itCoverage.status).toBe("skipped"); // IT4IT reference model absent -> skips
-    // mcp + coworker + routes + navigation + process + scheduling are notation-backed
-    // (all sysml2 except process=bpmn20); value-streams + it4it-coverage check the
-    // reference model first; code-structure checks graph freshness first.
-    expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(6);
+    expect(r.securityPosture.status).toBe("skipped"); // notation null -> applySysmlModel skips
+    // mcp + coworker + routes + navigation + process + scheduling + security are
+    // notation-backed (all sysml2 except process=bpmn20); value-streams +
+    // it4it-coverage check the reference model first; code-structure checks graph
+    // freshness first.
+    expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(7);
     // value-streams and it4it-coverage both look up the IT4IT reference model.
     expect(db.eaReferenceModel.findUnique).toHaveBeenCalledTimes(2);
     expect(getFreshness).toHaveBeenCalledTimes(1);

--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -25,6 +25,7 @@ import { reconcileNetworkTopology } from "./reconcile-network-bridge";
 import { reconcileIntegrations } from "./reconcile-integration-bridge";
 import { reconcileScheduledJobs } from "./reconcile-scheduled-jobs";
 import { reconcileIt4itCoverage } from "./reconcile-it4it-coverage";
+import { reconcileSecurityPosture } from "./reconcile-security-posture";
 import type { SysmlSeedResult } from "./sysml-model-seed";
 
 export interface SysmlProjectionsResult {
@@ -47,6 +48,9 @@ export interface SysmlProjectionsResult {
   // IT4IT conformance coverage — evidence-derived baseline vs the IT4IT functional
   // criteria, persisted to EaReferenceAssessment (EP-IT4IT-CONFORMANCE).
   it4itCoverage: SysmlSeedResult;
+  // Security Operations (SOC) surface — normalization / detection / cases /
+  // response / roster, tracing to the security data model (EP-SOVEREIGN-SOC).
+  securityPosture: SysmlSeedResult;
 }
 
 const SKIPPED: SysmlSeedResult = { status: "skipped", created: 0, updated: 0, removed: 0 };
@@ -85,8 +89,11 @@ export async function reconcileSysmlProjections(
   const integrations = await runDomain("integrations", () => reconcileIntegrations({ db: opts.db }), SKIPPED);
   const scheduledJobs = await runDomain("scheduledJobs", () => reconcileScheduledJobs({ db: opts.db }), SKIPPED);
   const it4itCoverage = await runDomain("it4itCoverage", () => reconcileIt4itCoverage({ db: opts.db }), SKIPPED);
+  // SOC posture isolated like every other domain (EP-SOVEREIGN-SOC, composed with
+  // the #2385 fail-isolation): a security-extractor error can't blind the engine.
+  const securityPosture = await runDomain("securityPosture", () => reconcileSecurityPosture({ db: opts.db }), SKIPPED);
   return {
     mcpAuthority, coworkerAuthority, valueStreams, routes, navigation, codeStructure, processModels, skillToolchain,
-    operationalGraph, networkTopology, integrations, scheduledJobs, it4itCoverage,
+    operationalGraph, networkTopology, integrations, scheduledJobs, it4itCoverage, securityPosture,
   };
 }

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 517,
+  "routeCount": 519,
   "routes": [
     {
       "routePath": "/",
@@ -1075,6 +1075,18 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/platform/metrics/targets/route.ts"
+    },
+    {
+      "routePath": "/api/platform/security/overview",
+      "kind": "route",
+      "segments": [
+        "api",
+        "platform",
+        "security",
+        "overview"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/platform/security/overview/route.ts"
     },
     {
       "routePath": "/api/platform/status",
@@ -4403,6 +4415,16 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/ops/promotions/page.tsx"
+    },
+    {
+      "routePath": "/ops/security",
+      "kind": "page",
+      "segments": [
+        "ops",
+        "security"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/ops/security/page.tsx"
     },
     {
       "routePath": "/ops/self-upgrade",

--- a/apps/web/lib/ea/security-posture-extract.test.ts
+++ b/apps/web/lib/ea/security-posture-extract.test.ts
@@ -1,0 +1,67 @@
+// EP-SOVEREIGN-SOC — pure extractor tests for the Security Operations SysML
+// projection. No DB: drives buildSecurityPostureModel directly.
+import { describe, expect, it } from "vitest";
+
+import { KERNEL_DETECTION_PACK } from "@/lib/security/detection-pack";
+
+import {
+  SECURITY_PACKAGE_KEY,
+  SECURITY_PLANES,
+  SOC_ROSTER,
+  buildSecurityPostureModel,
+} from "./security-posture-extract";
+
+describe("buildSecurityPostureModel", () => {
+  const m = buildSecurityPostureModel();
+
+  it("emits a package, one part_definition per plane, and a part_usage per rule + coworker", () => {
+    const pkg = m.elements.find((e) => e.sysmlKey === SECURITY_PACKAGE_KEY);
+    expect(pkg?.typeSlug).toBe("package");
+    expect(m.elements.filter((e) => e.typeSlug === "part_definition")).toHaveLength(SECURITY_PLANES.length);
+    expect(m.elements.filter((e) => e.typeSlug === "part_usage")).toHaveLength(
+      KERNEL_DETECTION_PACK.length + SOC_ROSTER.length,
+    );
+  });
+
+  it("traces each plane to its security data-model node(s)", () => {
+    const traces = m.crossLayerRelationships ?? [];
+    expect(traces.every((r) => r.relSlug === "traces")).toBe(true);
+    expect(new Set(traces.map((r) => r.toKey))).toEqual(
+      new Set([
+        "prisma:model:SecurityEvent",
+        "prisma:model:Detection",
+        "prisma:model:DetectionRule",
+        "prisma:model:ThreatIndicator",
+        "prisma:model:SecurityCase",
+      ]),
+    );
+  });
+
+  it("contains every plane under the package and every rule/coworker under a plane", () => {
+    const contains = m.relationships.filter((r) => r.relSlug === "contains");
+    for (const plane of SECURITY_PLANES) {
+      expect(contains).toContainEqual({ fromKey: SECURITY_PACKAGE_KEY, toKey: plane.key, relSlug: "contains" });
+    }
+    // every rule is contained by the detection plane
+    for (const rule of KERNEL_DETECTION_PACK) {
+      expect(contains).toContainEqual({
+        fromKey: "security:plane:detection",
+        toKey: `security:rule:${rule.ruleKey}`,
+        relSlug: "contains",
+      });
+    }
+    // every coworker is contained by the roster plane
+    for (const cw of SOC_ROSTER) {
+      expect(contains).toContainEqual({
+        fromKey: "security:plane:roster",
+        toKey: `security:coworker:${cw.agentId}`,
+        relSlug: "contains",
+      });
+    }
+  });
+
+  it("uses the security: soft-remove prefix so stale nodes are pruned", () => {
+    expect(m.softRemovePrefix).toBe("security:");
+    expect(m.elements.every((e) => e.sysmlKey.startsWith("security:"))).toBe(true);
+  });
+});

--- a/apps/web/lib/ea/security-posture-extract.ts
+++ b/apps/web/lib/ea/security-posture-extract.ts
@@ -1,0 +1,159 @@
+// apps/web/lib/ea/security-posture-extract.ts
+//
+// Pure extractor for the Security Operations (SOC) SysML projection (Parity
+// Engine, living-graph — EP-ARCH-GRAPH-LIVE / EP-SOVEREIGN-SOC). Projects the
+// security domain — the OCSF normalization spine, the detection engine + kernel
+// rule pack, the case worklist, governed response, and the AI-SOC roster — into
+// the one architecture graph so the SOC is a first-class, navigable surface and
+// cannot drift from the implementation (the gap the arch-review flagged,
+// BI-79B599BF).
+//
+// SysML mapping (cross-LAYER edges to the data model are applied by
+// applySysmlModel.crossLayerRelationships):
+//   - package        security:pkg                 "Security Operations (SOC)"
+//   - plane          security:plane:<plane>        part_definition (normalization, detection, cases, response, roster)
+//   - detection rule security:rule:<ruleKey>       part_usage (one KERNEL_DETECTION_PACK rule)
+//   - coworker       security:coworker:<agentId>   part_usage (one AGT-SOC-* role)
+// Each plane `traces` to its Prisma data-model node(s) (prisma:model:SecurityEvent,
+// :Detection, :DetectionRule, :ThreatIndicator, :SecurityCase) so a data-model
+// change's blast_radius reaches the SOC surface.
+
+import { KERNEL_DETECTION_PACK } from "@/lib/security/detection-pack";
+
+import type { SysmlDesiredModel } from "./sysml-model-seed";
+
+export const SECURITY_PACKAGE_KEY = "security:pkg";
+
+interface SocCoworker {
+  agentId: string;
+  name: string;
+  tier: string;
+}
+
+/** The canonical AI-SOC roster (mirrors the AGT-SOC-* registry entries). */
+export const SOC_ROSTER: readonly SocCoworker[] = [
+  { agentId: "AGT-SOC-TRIAGE", name: "SOC Tier-1 Triage Analyst", tier: "tier-1" },
+  { agentId: "AGT-SOC-INVESTIGATOR", name: "SOC Tier-2 Investigator", tier: "tier-2" },
+  { agentId: "AGT-SOC-HUNTER", name: "SOC Threat Hunter", tier: "tier-3" },
+  { agentId: "AGT-SOC-IR-LEAD", name: "SOC Incident Commander", tier: "incident-commander" },
+];
+
+interface SecurityPlane {
+  key: string;
+  name: string;
+  description: string;
+  /** Prisma model names this plane traces to (cross-layer). */
+  dataModels: string[];
+}
+
+export const SECURITY_PLANES: readonly SecurityPlane[] = [
+  {
+    key: "security:plane:normalization",
+    name: "Normalization (OCSF)",
+    description: "OCSF-normalized security telemetry from edge collectors and internal audit sources.",
+    dataModels: ["SecurityEvent"],
+  },
+  {
+    key: "security:plane:detection",
+    name: "Detection",
+    description: "Rules, correlation, and threat intel that turn security events into detections.",
+    dataModels: ["Detection", "DetectionRule", "ThreatIndicator"],
+  },
+  {
+    key: "security:plane:cases",
+    name: "Cases",
+    description: "The AI-SOC analyst worklist: detections grouped into investigated cases.",
+    dataModels: ["SecurityCase"],
+  },
+  {
+    key: "security:plane:response",
+    name: "Governed response",
+    description: "Band + kernel gated, propose-only containment and remediation.",
+    dataModels: [],
+  },
+  {
+    key: "security:plane:roster",
+    name: "AI SOC roster",
+    description: "The governed coworkers that operate the SOC: triage, investigation, hunting, incident command.",
+    dataModels: [],
+  },
+];
+
+function dataModelKey(model: string): string {
+  return `prisma:model:${model}`;
+}
+
+export function buildSecurityPostureModel(): SysmlDesiredModel {
+  const elements: SysmlDesiredModel["elements"] = [];
+  const relationships: SysmlDesiredModel["relationships"] = [];
+  const crossLayerRelationships: SysmlDesiredModel["relationships"] = [];
+
+  elements.push({
+    sysmlKey: SECURITY_PACKAGE_KEY,
+    typeSlug: "package",
+    name: "Security Operations (SOC)",
+    description:
+      "Live SysML projection of the AI-operated SOC: OCSF normalization, the detection engine and kernel rule pack, the case worklist, governed response, and the AI-SOC coworker roster — derived from the implementation so the security surface cannot drift.",
+    properties: { sourceKey: "security-posture", planeCount: SECURITY_PLANES.length },
+  });
+
+  for (const plane of SECURITY_PLANES) {
+    elements.push({
+      sysmlKey: plane.key,
+      typeSlug: "part_definition",
+      name: plane.name,
+      description: plane.description,
+      properties: { sourceKey: plane.key, layer: "operational" },
+    });
+    relationships.push({ fromKey: SECURITY_PACKAGE_KEY, toKey: plane.key, relSlug: "contains" });
+    for (const model of plane.dataModels) {
+      crossLayerRelationships.push({ fromKey: plane.key, toKey: dataModelKey(model), relSlug: "traces" });
+    }
+  }
+
+  for (const rule of [...KERNEL_DETECTION_PACK].sort((a, b) => a.ruleKey.localeCompare(b.ruleKey))) {
+    const ruleKey = `security:rule:${rule.ruleKey}`;
+    elements.push({
+      sysmlKey: ruleKey,
+      typeSlug: "part_usage",
+      name: rule.name,
+      description: rule.description,
+      properties: {
+        sourceKey: ruleKey,
+        layer: "operational",
+        refinementLevel: "actual",
+        severity: rule.severity,
+        mitreTechniques: rule.mitreTechniques.join(","),
+      },
+    });
+    relationships.push({ fromKey: "security:plane:detection", toKey: ruleKey, relSlug: "contains" });
+  }
+
+  for (const cw of SOC_ROSTER) {
+    const cwKey = `security:coworker:${cw.agentId}`;
+    elements.push({
+      sysmlKey: cwKey,
+      typeSlug: "part_usage",
+      name: cw.name,
+      description: `AI SOC coworker (${cw.tier}).`,
+      properties: { sourceKey: cwKey, layer: "operational", agentId: cw.agentId, tier: cw.tier },
+    });
+    relationships.push({ fromKey: "security:plane:roster", toKey: cwKey, relSlug: "contains" });
+  }
+
+  return {
+    elements,
+    relationships,
+    elementTypeSlugs: ["package", "part_definition", "part_usage"],
+    relTypeSlugs: ["contains", "traces"],
+    view: {
+      name: "Security Operations — Live Projection",
+      description:
+        "Live, system-maintained projection of the AI-operated SOC: its planes, the kernel detection rules, and the coworker roster, each tracing to its data model.",
+      viewpointName: "System Decomposition & Interfaces",
+      scopeRef: "security",
+    },
+    softRemovePrefix: "security:",
+    crossLayerRelationships,
+  };
+}

--- a/apps/web/lib/mcp-tools-siem.test.ts
+++ b/apps/web/lib/mcp-tools-siem.test.ts
@@ -105,8 +105,16 @@ describe("proposeResponseHandler", () => {
     );
     expect(res.success).toBe(true);
     expect(res.message).toMatch(/NOT executed/);
+    // P3: a mutating action (isolate_host = high) is gated needs-human at the band.
+    expect(res.data?.authorityDecision).toBe("needs-human-approval");
+    expect(res.message).toMatch(/needs-human-approval/);
     const data = m.securityCaseUpdate.mock.calls[0]![0].data;
     const timeline = data.timeline as Array<Record<string, unknown>>;
-    expect(timeline[0]).toMatchObject({ kind: "response-proposal", actionType: "isolate_host", status: "proposed" });
+    expect(timeline[0]).toMatchObject({
+      kind: "response-proposal",
+      actionType: "isolate_host",
+      status: "proposed",
+      authorityDecision: "needs-human-approval",
+    });
   });
 });

--- a/apps/web/lib/mcp-tools-siem.ts
+++ b/apps/web/lib/mcp-tools-siem.ts
@@ -20,6 +20,12 @@ import { randomUUID } from "node:crypto";
 import { prisma } from "@dpf/db";
 
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import {
+  decideSecurityResponse,
+  type SecurityBlastRadius,
+  type SecurityResponseConsent,
+  type SecurityResponseInput,
+} from "@/lib/security/response-authority";
 
 type SiemContext = {
   routeContext?: string;
@@ -153,15 +159,17 @@ export const SIEM_TOOLS: ToolDefinition[] = [
   {
     name: "propose_response",
     description:
-      "Propose a containment/remediation action for a security case (does NOT execute). Recorded on the case timeline as a response-proposal for human approval — execution rides the proposal-not-action rail and the customer's own runner.",
+      "Propose a containment/remediation action for a security case (does NOT execute). The governed authority decision (auto-approve / needs-human-approval / refuse) is computed from the action's risk band and the security kernel; the proposal is recorded on the case timeline for approval. Execution rides the proposal-not-action rail and the customer's own runner.",
     inputSchema: {
       type: "object",
       properties: {
         caseKey: { type: "string" },
-        actionType: { type: "string", description: "isolate_host | disable_account | block_ip | kill_process | revoke_token" },
+        actionType: { type: "string", description: "collect_diagnostics | quarantine_host | block_ip | block_domain | revoke_token | disable_account | isolate_host | kill_process | wipe_host" },
         target: { type: "string", description: "the asset/account/indicator the action targets" },
         reversible: { type: "boolean" },
         blastRadius: { type: "string", description: "single-host | account | estate" },
+        evidenceConfidence: { type: "number", description: "investigation confidence justifying the action, 0..1" },
+        consent: { type: "string", description: "standing | per-action | none — customer's standing approval for this action class" },
         rationale: { type: "string" },
       },
       required: ["caseKey", "actionType", "target", "rationale"],
@@ -445,7 +453,7 @@ export async function proposeDetectionTuningHandler(
 
 export async function proposeResponseHandler(
   params: Record<string, unknown>,
-  _userId: string,
+  userId: string,
   context?: SiemContext,
 ): Promise<ToolResult> {
   const caseKey = str(params["caseKey"]);
@@ -460,13 +468,33 @@ export async function proposeResponseHandler(
     return { success: false, error: "not_found", message: `No security case ${caseKey}.` };
   }
 
+  // Compute the governed authority decision: the risk band sets the floor and
+  // the security kernel can only ratchet it more conservative (P3). The kernel
+  // gate fails safe — a degenerate / low-confidence result keeps human approval.
+  const input: SecurityResponseInput = {
+    actionType,
+    target,
+    rationale,
+    evidenceConfidence: typeof params["evidenceConfidence"] === "number" ? (params["evidenceConfidence"] as number) : 0.5,
+    consent: (str(params["consent"]) as SecurityResponseConsent | undefined) ?? "none",
+    reversible: typeof params["reversible"] === "boolean" ? (params["reversible"] as boolean) : undefined,
+    blastRadius: str(params["blastRadius"]) as SecurityBlastRadius | undefined,
+  };
+  const verdict = await decideSecurityResponse(input, {
+    userId,
+    routeContext: context?.routeContext,
+  });
+
   const proposal = {
     kind: "response-proposal",
     actionType,
     target,
-    reversible: typeof params["reversible"] === "boolean" ? params["reversible"] : null,
-    blastRadius: str(params["blastRadius"]) ?? null,
+    reversible: input.reversible ?? null,
+    blastRadius: input.blastRadius ?? null,
     rationale,
+    authorityDecision: verdict.decision,
+    bandDecision: verdict.bandDecision,
+    decisionReason: verdict.reason,
     by: context?.agentId ?? "coworker",
     at: new Date().toISOString(),
     status: "proposed",
@@ -482,7 +510,7 @@ export async function proposeResponseHandler(
   return {
     success: true,
     entityId: sc.id,
-    message: `Proposed ${actionType} on ${target} for case ${caseKey} — recorded for human approval, NOT executed.`,
-    data: { caseKey, proposal },
+    message: `Proposed ${actionType} on ${target} for case ${caseKey} — authority decision: ${verdict.decision}. Recorded for approval, NOT executed.`,
+    data: { caseKey, proposal, authorityDecision: verdict.decision, bandDecision: verdict.bandDecision },
   };
 }

--- a/apps/web/lib/operate/retention/policies.ts
+++ b/apps/web/lib/operate/retention/policies.ts
@@ -220,6 +220,15 @@ export const PURGE_POLICIES: readonly PurgePolicy[] = [
       "OCSF-normalized security telemetry (EP-SOVEREIGN-SOC P0). One-year security-audit baseline; regulated industries lengthen via floors. Detections derive from this stream; SecurityCase (the regulated incident record) is retained separately and never auto-purged.",
   },
   {
+    model: "detection",
+    label: "Security detections",
+    category: "security-audit",
+    timestampField: "createdAt",
+    baseRetentionDays: DAYS_365,
+    rationale:
+      "Fired detections (EP-SOVEREIGN-SOC P1). One-year security-audit window; a notable detection that opens a SecurityCase is preserved via the retained case record, so purging the raw detection past the window is safe.",
+  },
+  {
     model: "coworkerTurnMetric",
     label: "Coworker turn metrics",
     category: "coworker-metrics",

--- a/apps/web/lib/queue/functions/siem-correlation-sweep.test.ts
+++ b/apps/web/lib/queue/functions/siem-correlation-sweep.test.ts
@@ -66,6 +66,7 @@ describe("runCorrelationSweep", () => {
 
     const result = await runCorrelationSweep({
       since: new Date("2026-06-25T11:00:00.000Z"),
+      seedPack: false,
     });
 
     expect(result.detectionsUpserted).toBe(1);
@@ -111,7 +112,7 @@ describe("runCorrelationSweep", () => {
       },
     ]);
 
-    const result = await runCorrelationSweep();
+    const result = await runCorrelationSweep({ seedPack: false });
     expect(result.detectionsUpserted).toBe(0);
     expect(mockDetectionUpsert).not.toHaveBeenCalled();
   });

--- a/apps/web/lib/queue/functions/siem-correlation-sweep.ts
+++ b/apps/web/lib/queue/functions/siem-correlation-sweep.ts
@@ -20,6 +20,7 @@ import {
   type DetectionRuleView,
   type SecurityEventView,
 } from "@/lib/security/detection";
+import { ensureKernelDetectionPack } from "@/lib/security/detection-pack";
 import { runInternalSecurityProjection } from "@/lib/security/internal-projector";
 import {
   buildIndicatorIndex,
@@ -98,12 +99,20 @@ function toEventView(ev: {
 export async function runCorrelationSweep(opts?: {
   since?: Date;
   limit?: number;
+  /** Create-if-missing seed of the kernel detection pack (default true). */
+  seedPack?: boolean;
 }): Promise<CorrelationSweepResult> {
   const { prisma } = await import("@dpf/db");
   const since =
     opts?.since ?? new Date(Date.now() - SWEEP_LOOKBACK_MIN * 60 * 1000);
   const limit = opts?.limit ?? SWEEP_EVENT_CAP;
   const now = new Date();
+
+  // Ensure the kernel detection pack exists (create-if-missing; operator tuning
+  // of existing rules is preserved) so the sweep always has baseline rules.
+  if (opts?.seedPack !== false) {
+    await ensureKernelDetectionPack();
+  }
 
   const [rules, indicators] = await Promise.all([
     prisma.detectionRule.findMany({

--- a/apps/web/lib/security/compliance.test.ts
+++ b/apps/web/lib/security/compliance.test.ts
@@ -1,0 +1,74 @@
+// EP-SOVEREIGN-SOC P6 — security compliance reporting + evidence unit tests.
+import { describe, expect, it } from "vitest";
+
+import {
+  SECURITY_COMPLIANCE_FRAMEWORKS,
+  buildSecurityComplianceReport,
+  securityCaseToEvidenceInput,
+  type ComplianceFramework,
+  type SecurityPostureMetrics,
+} from "./compliance";
+
+const FRAMEWORKS = Object.keys(SECURITY_COMPLIANCE_FRAMEWORKS) as ComplianceFramework[];
+
+const active: SecurityPostureMetrics = {
+  detections: 12,
+  openCases: 3,
+  resolvedCases: 5,
+  connectedSources: 4,
+  staleSources: 1,
+};
+
+describe("SECURITY_COMPLIANCE_FRAMEWORKS", () => {
+  it("covers six frameworks, each with a Detect and a Respond control", () => {
+    expect(FRAMEWORKS).toHaveLength(6);
+    for (const f of FRAMEWORKS) {
+      const families = SECURITY_COMPLIANCE_FRAMEWORKS[f].map((c) => c.controlFamily);
+      expect(families).toContain("Detect");
+      expect(families).toContain("Respond");
+    }
+  });
+});
+
+describe("buildSecurityComplianceReport", () => {
+  it("evidences Detect + Respond when monitoring + resolution are active", () => {
+    const r = buildSecurityComplianceReport("NIST-CSF", active);
+    expect(r.evidencedCount).toBe(2);
+    expect(r.controls.every((c) => c.evidenced)).toBe(true);
+    expect(r.summary).toMatch(/2\/2/);
+  });
+
+  it("does not evidence Detect with no detections, nor Respond with no resolved cases", () => {
+    const r = buildSecurityComplianceReport("PCI-DSS", {
+      ...active,
+      detections: 0,
+      resolvedCases: 0,
+    });
+    expect(r.evidencedCount).toBe(0);
+    expect(r.controls.find((c) => c.controlFamily === "Detect")!.evidenced).toBe(false);
+    expect(r.controls.find((c) => c.controlFamily === "Respond")!.evidenced).toBe(false);
+  });
+
+  it("requires connected sources before Detect is evidenced", () => {
+    const r = buildSecurityComplianceReport("SOC2", { ...active, connectedSources: 0 });
+    expect(r.controls.find((c) => c.controlFamily === "Detect")!.evidenced).toBe(false);
+  });
+});
+
+describe("securityCaseToEvidenceInput", () => {
+  it("produces idempotent, case-keyed evidence", () => {
+    const e = securityCaseToEvidenceInput({
+      caseKey: "case:manual:1",
+      title: "Lateral movement",
+      severity: "high",
+      verdict: "malicious",
+      status: "resolved",
+      openedAt: new Date("2026-06-25T12:00:00.000Z"),
+      resolvedAt: new Date("2026-06-25T12:30:00.000Z"),
+    });
+    expect(e.evidenceId).toBe("security-case:case:manual:1");
+    expect(e.evidenceType).toBe("security-operations");
+    expect(e.description).toMatch(/detects and responds/);
+    expect(e.description).toMatch(/resolved/);
+  });
+});

--- a/apps/web/lib/security/compliance.ts
+++ b/apps/web/lib/security/compliance.ts
@@ -1,0 +1,158 @@
+// EP-SOVEREIGN-SOC P6 — security compliance reporting + evidence.
+//
+// Spec: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md §4.7.
+//
+// Composes the existing GRC framework (Control / Obligation / ComplianceEvidence):
+//   • buildSecurityComplianceReport — maps SOC activity to the Detect/Respond
+//     control families of the major frameworks (NIST CSF, PCI-DSS, HIPAA, SOC 2,
+//     CMMC, DORA), evidencing "we detect and respond".
+//   • securityCaseToEvidenceInput / recordSecurityCaseEvidence — turn a resolved
+//     SecurityCase into continuous ComplianceEvidence (the detect-&-respond proof).
+// Reporting is pure; persistence is a thin idempotent upsert keyed on the case.
+
+export type ComplianceFramework =
+  | "NIST-CSF"
+  | "PCI-DSS"
+  | "HIPAA"
+  | "SOC2"
+  | "CMMC"
+  | "DORA";
+
+export interface ComplianceControlRef {
+  /** The control family the SOC evidences — "Detect" or "Respond". */
+  controlFamily: "Detect" | "Respond";
+  /** Framework-specific control reference. */
+  reference: string;
+  description: string;
+}
+
+export const SECURITY_COMPLIANCE_FRAMEWORKS: Record<ComplianceFramework, ComplianceControlRef[]> = {
+  "NIST-CSF": [
+    { controlFamily: "Detect", reference: "DE.CM / DE.AE", description: "Continuous monitoring + anomaly/event detection." },
+    { controlFamily: "Respond", reference: "RS.AN / RS.MI", description: "Incident analysis + mitigation." },
+  ],
+  "PCI-DSS": [
+    { controlFamily: "Detect", reference: "Req 10 / 11.5", description: "Audit logging + change/intrusion detection." },
+    { controlFamily: "Respond", reference: "Req 12.10", description: "Incident response plan + execution." },
+  ],
+  HIPAA: [
+    { controlFamily: "Detect", reference: "164.308(a)(1)(ii)(D)", description: "Information system activity review." },
+    { controlFamily: "Respond", reference: "164.308(a)(6)", description: "Security incident procedures." },
+  ],
+  SOC2: [
+    { controlFamily: "Detect", reference: "CC7.2", description: "Monitoring for anomalies + security events." },
+    { controlFamily: "Respond", reference: "CC7.3 / CC7.4", description: "Evaluate + respond to security incidents." },
+  ],
+  CMMC: [
+    { controlFamily: "Detect", reference: "AU / SI", description: "Audit + system-integrity monitoring." },
+    { controlFamily: "Respond", reference: "IR", description: "Incident response." },
+  ],
+  DORA: [
+    { controlFamily: "Detect", reference: "Art. 10", description: "ICT-related incident detection." },
+    { controlFamily: "Respond", reference: "Art. 17", description: "ICT-related incident management." },
+  ],
+};
+
+export interface SecurityPostureMetrics {
+  detections: number;
+  openCases: number;
+  resolvedCases: number;
+  connectedSources: number;
+  staleSources: number;
+  mttrMinutes?: number;
+}
+
+export interface SecurityComplianceReport {
+  framework: ComplianceFramework;
+  controls: Array<ComplianceControlRef & { evidenced: boolean }>;
+  evidencedCount: number;
+  metrics: SecurityPostureMetrics;
+  summary: string;
+}
+
+/**
+ * Build a security compliance report for a framework. A Detect-family control is
+ * evidenced when the SOC is actively monitoring (sources connected) and producing
+ * detections; a Respond-family control when cases are being resolved.
+ */
+export function buildSecurityComplianceReport(
+  framework: ComplianceFramework,
+  metrics: SecurityPostureMetrics,
+): SecurityComplianceReport {
+  const controls = SECURITY_COMPLIANCE_FRAMEWORKS[framework].map((c) => ({
+    ...c,
+    evidenced:
+      c.controlFamily === "Detect"
+        ? metrics.connectedSources > 0 && metrics.detections > 0
+        : metrics.resolvedCases > 0,
+  }));
+  const evidencedCount = controls.filter((c) => c.evidenced).length;
+  return {
+    framework,
+    controls,
+    evidencedCount,
+    metrics,
+    summary:
+      `${framework}: ${evidencedCount}/${controls.length} SOC control families evidenced — ` +
+      `${metrics.detections} detections, ${metrics.resolvedCases} resolved cases, ` +
+      `${metrics.connectedSources} sources (${metrics.staleSources} stale).`,
+  };
+}
+
+// ── Continuous evidence from cases ──────────────────────────────────────────
+
+export interface SecurityCaseEvidenceView {
+  caseKey: string;
+  title: string;
+  severity: string;
+  verdict: string;
+  status: string;
+  openedAt: Date;
+  resolvedAt?: Date | null;
+}
+
+export interface ComplianceEvidenceInput {
+  evidenceId: string;
+  title: string;
+  evidenceType: string;
+  description: string;
+  status: string;
+}
+
+/** Project a SecurityCase into a ComplianceEvidence input (pure). The evidenceId
+ *  is keyed on the case so re-recording is idempotent. */
+export function securityCaseToEvidenceInput(
+  c: SecurityCaseEvidenceView,
+): ComplianceEvidenceInput {
+  return {
+    evidenceId: `security-case:${c.caseKey}`,
+    title: `Security case ${c.caseKey}: ${c.title}`,
+    evidenceType: "security-operations",
+    description:
+      `Detected and ${c.status} (verdict: ${c.verdict}, severity: ${c.severity}). ` +
+      `Opened ${c.openedAt.toISOString()}` +
+      (c.resolvedAt ? `, resolved ${c.resolvedAt.toISOString()}` : "") +
+      ". Continuous evidence that the SOC detects and responds to security events.",
+    status: "active",
+  };
+}
+
+/** Idempotently record the evidence for one case (upsert on evidenceId). */
+export async function recordSecurityCaseEvidence(
+  c: SecurityCaseEvidenceView,
+): Promise<{ evidenceId: string }> {
+  const { prisma } = await import("@dpf/db");
+  const input = securityCaseToEvidenceInput(c);
+  await prisma.complianceEvidence.upsert({
+    where: { evidenceId: input.evidenceId },
+    update: { title: input.title, description: input.description, status: input.status },
+    create: {
+      evidenceId: input.evidenceId,
+      title: input.title,
+      evidenceType: input.evidenceType,
+      description: input.description,
+      status: input.status,
+    },
+  });
+  return { evidenceId: input.evidenceId };
+}

--- a/apps/web/lib/security/console-data.test.ts
+++ b/apps/web/lib/security/console-data.test.ts
@@ -1,0 +1,64 @@
+// EP-SOVEREIGN-SOC P4 — SOC console data aggregation unit tests.
+import { describe, expect, it } from "vitest";
+
+import { computeSocConsoleData, type SocConsoleInput } from "./console-data";
+
+function input(o: Partial<SocConsoleInput> = {}): SocConsoleInput {
+  return { detections: [], cases: [], activeSourceKinds: [], allSourceKinds: [], ...o };
+}
+
+const T0 = new Date("2026-06-25T12:00:00.000Z");
+const T30 = new Date("2026-06-25T12:30:00.000Z");
+
+describe("computeSocConsoleData", () => {
+  it("flags monitoring=false on an empty board (an empty board is NOT green)", () => {
+    const d = computeSocConsoleData(input());
+    expect(d.coverage.monitoring).toBe(false);
+    expect(d.coverage.connectedSources).toBe(0);
+  });
+
+  it("computes coverage and stale sources", () => {
+    const d = computeSocConsoleData(
+      input({
+        activeSourceKinds: ["windows.security", "syslog"],
+        allSourceKinds: ["windows.security", "syslog", "aws.cloudtrail"],
+      }),
+    );
+    expect(d.coverage.connectedSources).toBe(2);
+    expect(d.coverage.staleSources).toBe(1);
+    expect(d.coverage.staleSourceKinds).toEqual(["aws.cloudtrail"]);
+    expect(d.coverage.monitoring).toBe(true);
+  });
+
+  it("tallies detections by severity and the open count", () => {
+    const d = computeSocConsoleData(
+      input({
+        detections: [
+          { severity: "high", status: "open" },
+          { severity: "high", status: "closed" },
+          { severity: "low", status: "open" },
+        ],
+      }),
+    );
+    expect(d.detections.open).toBe(2);
+    expect(d.detections.total).toBe(3);
+    expect(d.detections.bySeverity).toEqual({ high: 2, low: 1 });
+  });
+
+  it("computes case open/awaiting-decision/resolved + MTTR + FP rate", () => {
+    const d = computeSocConsoleData(
+      input({
+        cases: [
+          { severity: "high", status: "new", verdict: "unknown", openedAt: T0, resolvedAt: null },
+          { severity: "medium", status: "resolved", verdict: "malicious", openedAt: T0, resolvedAt: T30 },
+          { severity: "low", status: "closed", verdict: "false-positive", openedAt: T0, resolvedAt: T30 },
+        ],
+      }),
+    );
+    expect(d.cases.open).toBe(1); // new is an open state
+    expect(d.cases.awaitingDecision).toBe(1); // new awaits triage
+    expect(d.cases.resolved).toBe(2); // resolved + closed
+    expect(d.metrics.mttrMinutes).toBe(30);
+    expect(d.metrics.falsePositiveRate).toBe(0.5); // 1 FP of 2 verdicted
+  });
+});

--- a/apps/web/lib/security/console-data.ts
+++ b/apps/web/lib/security/console-data.ts
@@ -1,0 +1,117 @@
+// EP-SOVEREIGN-SOC P4 — SOC console data aggregation.
+//
+// Spec: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md §4.6, §10.2.
+//
+// Pure computation of the console's first-screen answers (Are we covered? Are we
+// exposed? What needs a decision? Are we improving?) from raw query rows. The API
+// route does the prisma queries and calls computeSocConsoleData; this stays pure
+// so the projection logic is unit-tested without a DB.
+
+export interface SocDetectionRow {
+  severity: string;
+  status: string;
+}
+
+export interface SocCaseRow {
+  severity: string;
+  status: string;
+  verdict: string;
+  openedAt: Date;
+  resolvedAt: Date | null;
+}
+
+export interface SocConsoleInput {
+  detections: SocDetectionRow[];
+  cases: SocCaseRow[];
+  /** Source kinds seen within the coverage lookback window. */
+  activeSourceKinds: string[];
+  /** All source kinds ever seen (stale = ever-seen minus active). */
+  allSourceKinds: string[];
+}
+
+export interface SocConsoleData {
+  coverage: {
+    connectedSources: number;
+    staleSources: number;
+    staleSourceKinds: string[];
+    /** False until at least one source is reporting — an empty board is NOT green. */
+    monitoring: boolean;
+  };
+  detections: {
+    open: number;
+    total: number;
+    bySeverity: Record<string, number>;
+  };
+  cases: {
+    open: number;
+    resolved: number;
+    total: number;
+    byStatus: Record<string, number>;
+    awaitingDecision: number;
+  };
+  metrics: {
+    mttrMinutes: number | null;
+    falsePositiveRate: number | null;
+  };
+}
+
+const OPEN_CASE_STATUSES = new Set(["new", "triaging", "investigating", "contained"]);
+const DECISION_STATUSES = new Set(["new", "triaging"]);
+
+function tally(rows: { severity?: string; status?: string }[], key: "severity" | "status"): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const r of rows) {
+    const v = (r[key] ?? "unknown") as string;
+    out[v] = (out[v] ?? 0) + 1;
+  }
+  return out;
+}
+
+export function computeSocConsoleData(input: SocConsoleInput): SocConsoleData {
+  const active = new Set(input.activeSourceKinds);
+  const staleSourceKinds = input.allSourceKinds.filter((s) => !active.has(s));
+
+  const openDetections = input.detections.filter((d) => d.status === "open").length;
+
+  const resolvedCases = input.cases.filter((c) => c.status === "resolved" || c.status === "closed");
+  const openCases = input.cases.filter((c) => OPEN_CASE_STATUSES.has(c.status)).length;
+  const awaitingDecision = input.cases.filter((c) => DECISION_STATUSES.has(c.status)).length;
+
+  // MTTR over resolved cases with a resolve timestamp.
+  const mttrSamples = resolvedCases
+    .filter((c) => c.resolvedAt)
+    .map((c) => (c.resolvedAt!.getTime() - c.openedAt.getTime()) / 60000)
+    .filter((m) => m >= 0);
+  const mttrMinutes =
+    mttrSamples.length > 0
+      ? Math.round(mttrSamples.reduce((a, b) => a + b, 0) / mttrSamples.length)
+      : null;
+
+  // FP rate over cases that reached a verdict.
+  const verdicted = input.cases.filter((c) => c.verdict && c.verdict !== "unknown");
+  const falsePositives = verdicted.filter((c) => c.verdict === "false-positive").length;
+  const falsePositiveRate =
+    verdicted.length > 0 ? Math.round((falsePositives / verdicted.length) * 100) / 100 : null;
+
+  return {
+    coverage: {
+      connectedSources: active.size,
+      staleSources: staleSourceKinds.length,
+      staleSourceKinds,
+      monitoring: active.size > 0,
+    },
+    detections: {
+      open: openDetections,
+      total: input.detections.length,
+      bySeverity: tally(input.detections, "severity"),
+    },
+    cases: {
+      open: openCases,
+      resolved: resolvedCases.length,
+      total: input.cases.length,
+      byStatus: tally(input.cases, "status"),
+      awaitingDecision,
+    },
+    metrics: { mttrMinutes, falsePositiveRate },
+  };
+}

--- a/apps/web/lib/security/console-loader.ts
+++ b/apps/web/lib/security/console-loader.ts
@@ -1,0 +1,72 @@
+// EP-SOVEREIGN-SOC P4 — SOC console server loader (prisma-backed).
+//
+// Thin IO shell over the pure computeSocConsoleData: query the Detection /
+// SecurityCase / SecurityEvent aggregates and the recent-case list, then compute
+// the first-screen view. The page and the /api/platform/security/overview route
+// both call loadSocConsole.
+
+import { computeSocConsoleData, type SocConsoleData } from "./console-data";
+
+export interface SocRecentCase {
+  caseKey: string;
+  title: string;
+  severity: string;
+  status: string;
+  verdict: string;
+  openedAt: string; // ISO for the client boundary
+}
+
+export interface SocConsole {
+  data: SocConsoleData;
+  recentCases: SocRecentCase[];
+}
+
+export async function loadSocConsole(opts?: { lookbackMinutes?: number }): Promise<SocConsole> {
+  const { prisma } = await import("@dpf/db");
+  const lookback = opts?.lookbackMinutes ?? 24 * 60;
+  const since = new Date(Date.now() - lookback * 60 * 1000);
+
+  const [detections, cases, activeSources, allSources, recent] = await Promise.all([
+    prisma.detection.findMany({
+      where: { lastSeenAt: { gte: since } },
+      select: { severity: true, status: true },
+      take: 5000,
+    }),
+    prisma.securityCase.findMany({
+      select: { severity: true, status: true, verdict: true, openedAt: true, resolvedAt: true },
+      take: 5000,
+    }),
+    prisma.securityEvent.findMany({
+      where: { time: { gte: since } },
+      select: { sourceKind: true },
+      distinct: ["sourceKind"],
+      take: 100,
+    }),
+    prisma.securityEvent.findMany({
+      select: { sourceKind: true },
+      distinct: ["sourceKind"],
+      take: 100,
+    }),
+    prisma.securityCase.findMany({
+      orderBy: { openedAt: "desc" },
+      take: 50,
+      select: { caseKey: true, title: true, severity: true, status: true, verdict: true, openedAt: true },
+    }),
+  ]);
+
+  const data = computeSocConsoleData({
+    detections,
+    cases,
+    activeSourceKinds: activeSources.map((s) => s.sourceKind),
+    allSourceKinds: allSources.map((s) => s.sourceKind),
+  });
+  const recentCases: SocRecentCase[] = recent.map((c) => ({
+    caseKey: c.caseKey,
+    title: c.title,
+    severity: c.severity,
+    status: c.status,
+    verdict: c.verdict,
+    openedAt: c.openedAt.toISOString(),
+  }));
+  return { data, recentCases };
+}

--- a/apps/web/lib/security/detection-pack.test.ts
+++ b/apps/web/lib/security/detection-pack.test.ts
@@ -1,0 +1,69 @@
+// EP-SOVEREIGN-SOC P1 content — kernel detection pack fires on sample events.
+import { describe, expect, it } from "vitest";
+
+import { evaluateRulesForEvent, type SecurityEventView } from "./detection";
+import { KERNEL_DETECTION_PACK, kernelRuleToView } from "./detection-pack";
+import { buildIndicatorIndex } from "./threat-intel";
+
+const NOW = new Date("2026-06-25T12:00:00.000Z");
+const RULES = KERNEL_DETECTION_PACK.map(kernelRuleToView);
+
+function evt(overrides: Partial<SecurityEventView>): SecurityEventView {
+  return {
+    eventKey: "e1",
+    ocsfClassUid: 3002,
+    severityId: 3,
+    sourceKind: "windows.security",
+    scopeKey: "customer:acct_1",
+    customerAccountId: "acct_1",
+    customerSiteId: null,
+    time: NOW,
+    observables: [],
+    normalized: {},
+    ...overrides,
+  };
+}
+
+describe("KERNEL_DETECTION_PACK", () => {
+  it("has stable, namespaced rule keys and kernel scope", () => {
+    expect(KERNEL_DETECTION_PACK).toHaveLength(3);
+    for (const v of RULES) {
+      expect(v.ruleKey).toMatch(/^dpf-kernel:/);
+      expect(v.scopeKey).toBe("kernel");
+      expect(v.enabled).toBe(true);
+    }
+  });
+
+  it("fires windows-failed-logon on a 4625-class Windows auth event", () => {
+    const out = evaluateRulesForEvent(RULES, evt({}), {});
+    expect(out.map((d) => d.detectionKey)).toContain("dpf-kernel:windows-failed-logon:e1");
+    expect(out.find((d) => d.detectionKey.startsWith("dpf-kernel:windows-failed-logon"))!.severity).toBe("medium");
+  });
+
+  it("fires threat-intel-hit when an observable matches an indicator", () => {
+    const index = buildIndicatorIndex(
+      [{ indicatorKey: "i1", indicatorType: "ip", value: "9.9.9.9", source: "feed", confidence: "high" }],
+      NOW,
+    );
+    const event = evt({
+      sourceKind: "aws.cloudtrail",
+      ocsfClassUid: 6003,
+      severityId: 1,
+      observables: [{ name: "src_endpoint.ip", type: "IP Address", value: "9.9.9.9" }],
+    });
+    const out = evaluateRulesForEvent(RULES, event, { indicatorIndex: index });
+    expect(out.map((d) => d.detectionKey)).toContain("dpf-kernel:threat-intel-hit:e1");
+  });
+
+  it("fires internal-authorization-denied on a denied internal authz event", () => {
+    const event = evt({ sourceKind: "dpf.internal", ocsfClassUid: 6003, severityId: 3 });
+    const out = evaluateRulesForEvent(RULES, event, {});
+    expect(out.map((d) => d.detectionKey)).toContain("dpf-kernel:internal-authorization-denied:e1");
+  });
+
+  it("does not fire on a benign low-severity internal event", () => {
+    const event = evt({ sourceKind: "dpf.internal", ocsfClassUid: 6003, severityId: 1, observables: [] });
+    const out = evaluateRulesForEvent(RULES, event, {});
+    expect(out).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/security/detection-pack.ts
+++ b/apps/web/lib/security/detection-pack.ts
@@ -1,0 +1,107 @@
+// EP-SOVEREIGN-SOC P1 content — the kernel detection-rule starter pack.
+//
+// Spec: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md §4.3, §7.1.
+//
+// A small, explainable starter pack so the correlation sweep produces detections
+// out of the box (it is otherwise correctly inert with no rules). Seeded under
+// scopeKey="kernel" so it applies to every tenant; an operator tunes or disables
+// rules per tenant via overlays without touching this pack. `ensureKernelDetectionPack`
+// is create-if-missing — operator changes to an existing rule are never overwritten.
+
+import type { DetectionPredicate, DetectionRuleView } from "./detection";
+
+export const KERNEL_DETECTION_PACK_KEY = "dpf-kernel";
+export const KERNEL_DETECTION_PACK_VERSION = "1.0.0";
+
+export interface KernelDetectionRule {
+  ruleKey: string;
+  name: string;
+  description: string;
+  severity: string;
+  mitreTechniques: string[];
+  predicate: DetectionPredicate;
+}
+
+export const KERNEL_DETECTION_PACK: KernelDetectionRule[] = [
+  {
+    ruleKey: "dpf-kernel:windows-failed-logon",
+    name: "Windows failed logon",
+    description:
+      "A failed Windows logon (Event ID 4625 → OCSF Authentication, Medium). Repeated failures may indicate brute force.",
+    severity: "medium",
+    mitreTechniques: ["T1110"],
+    predicate: { sourceKind: "windows.security", classUid: 3002, minSeverityId: 3 },
+  },
+  {
+    ruleKey: "dpf-kernel:threat-intel-hit",
+    name: "Threat-intel indicator match",
+    description: "An event observable matched a known threat indicator (IOC) in the active feed.",
+    severity: "high",
+    mitreTechniques: ["T1071"],
+    predicate: { matchThreatIndicator: true },
+  },
+  {
+    ruleKey: "dpf-kernel:internal-authorization-denied",
+    name: "Internal authorization denied",
+    description:
+      "A platform authorization decision was denied or errored (self-monitoring — the platform watching itself).",
+    severity: "medium",
+    mitreTechniques: ["T1078"],
+    predicate: { sourceKind: "dpf.internal", minSeverityId: 3 },
+  },
+];
+
+/** Convert a kernel pack rule into the evaluator's view (scopeKey="kernel"). */
+export function kernelRuleToView(rule: KernelDetectionRule): DetectionRuleView {
+  return {
+    id: rule.ruleKey,
+    ruleKey: rule.ruleKey,
+    name: rule.name,
+    severity: rule.severity,
+    scopeKey: "kernel",
+    enabled: true,
+    predicate: rule.predicate,
+    mitreTechniques: rule.mitreTechniques,
+  };
+}
+
+export interface EnsurePackResult {
+  created: number;
+  total: number;
+}
+
+/**
+ * Idempotent create-if-missing of the kernel pack into DetectionRule. Existing
+ * rows (possibly operator-tuned / disabled) are left untouched — the pack seeds,
+ * it does not re-assert. Called by the correlation sweep so the rules are always
+ * present without separate seed wiring.
+ */
+export async function ensureKernelDetectionPack(): Promise<EnsurePackResult> {
+  const { prisma } = await import("@dpf/db");
+  let created = 0;
+  for (const rule of KERNEL_DETECTION_PACK) {
+    const existing = await prisma.detectionRule.findUnique({
+      where: { ruleKey: rule.ruleKey },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await prisma.detectionRule.create({
+      data: {
+        ruleKey: rule.ruleKey,
+        rulePackKey: KERNEL_DETECTION_PACK_KEY,
+        rulePackVersion: KERNEL_DETECTION_PACK_VERSION,
+        name: rule.name,
+        description: rule.description,
+        ruleFormat: "dpf-correlation",
+        predicate: rule.predicate as object,
+        mitreTechniques: rule.mitreTechniques as object,
+        severity: rule.severity,
+        scopeKey: "kernel",
+        enabled: true,
+        tuning: {},
+      },
+    });
+    created++;
+  }
+  return { created, total: KERNEL_DETECTION_PACK.length };
+}

--- a/apps/web/lib/security/enrichment-lookups.ts
+++ b/apps/web/lib/security/enrichment-lookups.ts
@@ -1,0 +1,50 @@
+// EP-SOVEREIGN-SOC P1 content — real (prisma-backed) enrichment lookups.
+//
+// Spec: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md §4.2.
+//
+// Wires the injectable enrichment interface (enrichment.ts) to live data:
+//   • asset context  ← InventoryEntity (by device hostname/name)
+//   • threat intel   ← ThreatIndicator (active-window IOC index)
+// The indicator index is loaded once per call; pass the result to
+// enrichSecurityEvent. SOC coworkers use this when investigating a detection.
+
+import type { EnrichmentLookups } from "./enrichment";
+import {
+  buildIndicatorIndex,
+  matchIndicatorValues,
+  type ThreatIndicatorView,
+} from "./threat-intel";
+
+/** Build prisma-backed enrichment lookups (asset + threat intel). The active
+ *  ThreatIndicator set is preloaded into an index for O(1) observable matching. */
+export async function buildPrismaEnrichmentLookups(): Promise<EnrichmentLookups> {
+  const { prisma } = await import("@dpf/db");
+  const now = new Date();
+  const indicators = await prisma.threatIndicator.findMany({
+    where: { OR: [{ validUntil: null }, { validUntil: { gte: now } }] },
+    select: {
+      indicatorKey: true,
+      indicatorType: true,
+      value: true,
+      source: true,
+      confidence: true,
+      severity: true,
+      validFrom: true,
+      validUntil: true,
+    },
+  });
+  const index = buildIndicatorIndex(indicators as ThreatIndicatorView[], now);
+
+  return {
+    lookupAsset: async (deviceKey: string) => {
+      const ent = await prisma.inventoryEntity.findFirst({
+        where: { name: deviceKey },
+        select: { id: true, name: true, supportStatus: true },
+      });
+      return ent
+        ? { inventoryEntityId: ent.id, name: ent.name, criticality: ent.supportStatus ?? undefined }
+        : null;
+    },
+    matchIndicators: async (values: string[]) => matchIndicatorValues(values, index),
+  };
+}

--- a/apps/web/lib/security/federation-projection.test.ts
+++ b/apps/web/lib/security/federation-projection.test.ts
@@ -1,0 +1,57 @@
+// EP-SOVEREIGN-SOC P5 — federation projection (sovereignty boundary) unit tests.
+import { describe, expect, it } from "vitest";
+
+import { assertNoExcludedEgress } from "@dpf/db/projection-serialization";
+
+import {
+  SECURITY_PROJECTION_CONTRACT,
+  buildSecurityCaseCloudEvent,
+  projectSecurityCase,
+  type SecurityCaseFullView,
+} from "./federation-projection";
+
+const fullCase: SecurityCaseFullView = {
+  caseKey: "case:manual:1",
+  title: "Lateral movement",
+  severity: "high",
+  status: "resolved",
+  verdict: "malicious",
+  confidence: "high",
+  openedAt: "2026-06-25T12:00:00.000Z",
+  resolvedAt: "2026-06-25T12:30:00.000Z",
+  // These must NEVER cross the link:
+  timeline: [{ kind: "note", note: "creds found", rawLog: "secret raw bytes" }],
+  evidence: { hostMemoryDump: "...", password: "hunter2" },
+};
+
+describe("projectSecurityCase — the sovereignty boundary", () => {
+  it("crosses only the case summary; timeline + evidence stay local", () => {
+    const r = projectSecurityCase(fullCase);
+    expect(Object.keys(r.projected)).toEqual(["case"]);
+    expect(r.projected.case).toMatchObject({ caseKey: "case:manual:1", verdict: "malicious" });
+    expect(r.excluded.slices).toContain("timeline");
+    expect(r.excluded.slices).toContain("evidence");
+  });
+
+  it("passes the negative-egress proof — nothing forbidden or excluded leaks", () => {
+    const r = projectSecurityCase(fullCase);
+    expect(assertNoExcludedEgress(SECURITY_PROJECTION_CONTRACT, r.projected)).toEqual([]);
+  });
+
+  it("crosses only the allow-listed case fields", () => {
+    const r = projectSecurityCase(fullCase);
+    expect(Object.keys(r.projected.case as object).sort()).toEqual(
+      ["caseKey", "confidence", "openedAt", "resolvedAt", "severity", "status", "title", "verdict"].sort(),
+    );
+  });
+});
+
+describe("buildSecurityCaseCloudEvent", () => {
+  it("wraps the minimized projection with the link id and no violations", () => {
+    const { event, violations } = buildSecurityCaseCloudEvent("link_1", fullCase);
+    expect(violations).toEqual([]);
+    expect(event.dpflinkid).toBe("link_1");
+    expect(event.type).toBe("dpf.security.case.projected");
+    expect(Object.keys(event.data as object)).toEqual(["case"]);
+  });
+});

--- a/apps/web/lib/security/federation-projection.ts
+++ b/apps/web/lib/security/federation-projection.ts
@@ -1,0 +1,140 @@
+// EP-SOVEREIGN-SOC P5 — federation projection of detections / cases.
+//
+// Spec: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md §5 (Topology B).
+//
+// The sovereignty boundary is the normalized DETECTION, not the raw log. This
+// composes the merged EP-MSP-FEDERATION egress gate (projection-serialization.ts):
+// only the allow-listed case/detection summary slices cross a FederationLink;
+// the investigation timeline + evidence + any raw payload stay in the customer's
+// sovereign estate. A FederatedRecordMirror persists the already-minimized
+// projection (never raw data). Pure projection + a thin idempotent mirror upsert;
+// the cross-deployment HTTP send/receive ride the federation enroll routes.
+
+import {
+  assertNoExcludedEgress,
+  projectEstatePayload,
+  toCloudEvent,
+  type CloudEventEnvelope,
+  type ProjectionContractSpec,
+  type ProjectionResult,
+} from "@dpf/db/projection-serialization";
+
+/** Default security projection contract: only the case + detection SUMMARY
+ *  slices cross; investigation timeline + evidence are excluded (raw stays home). */
+export const SECURITY_PROJECTION_CONTRACT: ProjectionContractSpec = {
+  includeSlices: ["case", "detection"],
+  excludeSlices: ["timeline", "evidence", "rawEvent"],
+  fieldAllowList: {
+    case: ["caseKey", "title", "severity", "status", "verdict", "confidence", "openedAt", "resolvedAt"],
+    detection: ["detectionKey", "severity", "status", "riskScore", "firstSeenAt", "lastSeenAt"],
+  },
+  retentionClass: "compliance-hold",
+};
+
+export interface SecurityCaseFullView {
+  caseKey: string;
+  title: string;
+  severity: string;
+  status: string;
+  verdict: string;
+  confidence: string;
+  openedAt: string;
+  resolvedAt?: string | null;
+  /** Excluded by the contract — never crosses the link. */
+  timeline?: unknown[];
+  /** Excluded by the contract — never crosses the link. */
+  evidence?: Record<string, unknown>;
+}
+
+/** The raw (pre-projection) payload for a case. The contract + forbidden-field
+ *  guard then minimize it — this is NOT what crosses. */
+export function rawSecurityCasePayload(c: SecurityCaseFullView): Record<string, unknown> {
+  return {
+    case: {
+      caseKey: c.caseKey,
+      title: c.title,
+      severity: c.severity,
+      status: c.status,
+      verdict: c.verdict,
+      confidence: c.confidence,
+      openedAt: c.openedAt,
+      resolvedAt: c.resolvedAt ?? null,
+    },
+    timeline: c.timeline ?? [],
+    evidence: c.evidence ?? {},
+  };
+}
+
+/** Project a security case to exactly what may cross the link. */
+export function projectSecurityCase(
+  c: SecurityCaseFullView,
+  contract: ProjectionContractSpec = SECURITY_PROJECTION_CONTRACT,
+): ProjectionResult {
+  return projectEstatePayload(contract, rawSecurityCasePayload(c));
+}
+
+/** Build the CloudEvent that crosses the link for a case projection. */
+export function buildSecurityCaseCloudEvent(
+  linkId: string,
+  c: SecurityCaseFullView,
+  contract: ProjectionContractSpec = SECURITY_PROJECTION_CONTRACT,
+): { event: CloudEventEnvelope; result: ProjectionResult; violations: string[] } {
+  const result = projectSecurityCase(c, contract);
+  const violations = assertNoExcludedEgress(contract, result.projected);
+  const event = toCloudEvent({
+    id: `security-case:${c.caseKey}`,
+    source: "dpf/security",
+    type: "dpf.security.case.projected",
+    time: c.openedAt,
+    linkId,
+    data: result.projected,
+  });
+  return { event, result, violations };
+}
+
+export interface SecurityMirrorResult {
+  mirrorId: string;
+  projected: Record<string, unknown>;
+  excluded: ProjectionResult["excluded"];
+  violations: string[];
+}
+
+/**
+ * Persist the minimized case projection as a FederatedRecordMirror (idempotent
+ * on link+type+caseKey). Refuses to persist if the negative-egress proof is
+ * non-empty (something forbidden leaked) — fail closed, never store raw data.
+ */
+export async function projectSecurityCaseToMirror(
+  linkId: string,
+  c: SecurityCaseFullView,
+  contract: ProjectionContractSpec = SECURITY_PROJECTION_CONTRACT,
+): Promise<SecurityMirrorResult> {
+  const { event, result, violations } = buildSecurityCaseCloudEvent(linkId, c, contract);
+  if (violations.length > 0) {
+    throw new Error(
+      `security projection refused — negative-egress violations: ${violations.join(", ")}`,
+    );
+  }
+  const { prisma } = await import("@dpf/db");
+  const mirrorId = `mirror:${linkId}:security-case:${c.caseKey}`;
+  await prisma.federatedRecordMirror.upsert({
+    where: {
+      federationLinkId_recordType_localRecordRef: {
+        federationLinkId: linkId,
+        recordType: "security-case",
+        localRecordRef: c.caseKey,
+      },
+    },
+    update: { payload: event.data as object, syncStatus: "pending" },
+    create: {
+      mirrorId,
+      federationLinkId: linkId,
+      recordType: "security-case",
+      canonicalSide: "local",
+      localRecordRef: c.caseKey,
+      syncStatus: "pending",
+      payload: event.data as object,
+    },
+  });
+  return { mirrorId, projected: result.projected, excluded: result.excluded, violations };
+}

--- a/apps/web/lib/security/response-authority.test.ts
+++ b/apps/web/lib/security/response-authority.test.ts
@@ -1,0 +1,103 @@
+// EP-SOVEREIGN-SOC P3 — governed security response authority unit tests.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  decideSecurityResponse,
+  resolveResponseSpec,
+  securityResponseToDraft,
+  type SecurityResponseInput,
+} from "./response-authority";
+
+function input(overrides: Partial<SecurityResponseInput>): SecurityResponseInput {
+  return {
+    actionType: "collect_diagnostics",
+    target: "HOST1",
+    rationale: "triage",
+    evidenceConfidence: 0.9,
+    consent: "standing",
+    ...overrides,
+  };
+}
+
+describe("resolveResponseSpec / securityResponseToDraft", () => {
+  it("uses catalog defaults and applies overrides", () => {
+    expect(resolveResponseSpec(input({ actionType: "isolate_host" })).riskClass).toBe("high");
+    expect(resolveResponseSpec(input({ actionType: "block_ip" })).blastRadius).toBe("estate");
+    expect(resolveResponseSpec(input({ actionType: "kill_process" })).reversible).toBe(false);
+    // override
+    expect(resolveResponseSpec(input({ actionType: "isolate_host", reversible: false })).reversible).toBe(false);
+    // unknown action → conservative
+    expect(resolveResponseSpec(input({ actionType: "frobnicate" })).riskClass).toBe("high");
+  });
+  it("maps to a RemediationActionDraft carrying the riskClass", () => {
+    const d = securityResponseToDraft(input({ actionType: "isolate_host" }));
+    expect(d).toMatchObject({ actionType: "isolate_host", riskClass: "high" });
+    expect(d.parameters).toMatchObject({ target: "HOST1" });
+  });
+});
+
+describe("decideSecurityResponse — band gate", () => {
+  const throwingExec = vi.fn(async () => {
+    throw new Error("kernel must not be consulted when the band already gates");
+  });
+
+  it("refuses a destructive action at the band (kernel not consulted)", async () => {
+    const v = await decideSecurityResponse(input({ actionType: "wipe_host" }), {
+      userId: "u1",
+      toolExecutor: throwingExec,
+    });
+    expect(v.decision).toBe("refuse");
+    expect(v.bandDecision).toBe("refuse");
+    expect(throwingExec).not.toHaveBeenCalled();
+  });
+
+  it("requires human approval for a mutating action at the band (kernel not consulted)", async () => {
+    const v = await decideSecurityResponse(input({ actionType: "isolate_host" }), {
+      userId: "u1",
+      toolExecutor: throwingExec,
+    });
+    expect(v.decision).toBe("needs-human-approval");
+    expect(v.bandDecision).toBe("needs-human-approval");
+    expect(throwingExec).not.toHaveBeenCalled();
+  });
+});
+
+describe("decideSecurityResponse — kernel ratchet on band-auto-approve", () => {
+  it("auto-approves a read-only action when the kernel clears it with high confidence", async () => {
+    const exec = vi.fn(async () => ({
+      success: true,
+      data: { recommendation: { optionId: "auto-execute", confidence: "high" } },
+    }));
+    const v = await decideSecurityResponse(input({ actionType: "collect_diagnostics" }), {
+      userId: "u1",
+      toolExecutor: exec,
+    });
+    expect(v.bandDecision).toBe("auto-approve");
+    expect(v.decision).toBe("auto-approve");
+    expect(v.kernelRatcheted).toBe(false);
+    expect(exec).toHaveBeenCalledOnce();
+  });
+
+  it("ratchets a band-auto-approve to human when the kernel prefers propose", async () => {
+    const exec = vi.fn(async () => ({
+      success: true,
+      data: { recommendation: { optionId: "propose", confidence: "high" } },
+    }));
+    const v = await decideSecurityResponse(input({ actionType: "collect_diagnostics" }), {
+      userId: "u1",
+      toolExecutor: exec,
+    });
+    expect(v.bandDecision).toBe("auto-approve");
+    expect(v.decision).toBe("needs-human-approval");
+    expect(v.kernelRatcheted).toBe(true);
+  });
+
+  it("fails safe to human approval when the kernel decision is degenerate", async () => {
+    const exec = vi.fn(async () => ({ success: false, error: "degenerate" }));
+    const v = await decideSecurityResponse(input({ actionType: "collect_diagnostics" }), {
+      userId: "u1",
+      toolExecutor: exec,
+    });
+    expect(v.decision).toBe("needs-human-approval");
+  });
+});

--- a/apps/web/lib/security/response-authority.ts
+++ b/apps/web/lib/security/response-authority.ts
@@ -1,0 +1,255 @@
+// EP-SOVEREIGN-SOC P3 — governed security response authority.
+//
+// Spec: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md §4.5, §6.
+//
+// Composes the merged EP-MSP-FEDERATION remediation rail (no second engine):
+//   • evaluateRemediationAuthority / buildRemediationProposal (the BAND gate —
+//     read-only auto-approves, mutating needs a human, destructive refused) from
+//     lib/service-desk/remediation-authority.ts.
+// and layers the KERNEL gate on top: the security-response decision is also
+// scored by principle_decide over the registered security dimensions
+// (reversibility / blast_radius / evidence_confidence / customer_consent_state /
+// business_disruption) carried by the security principle pages. The kernel can
+// only make a response MORE conservative than the band — a safety ratchet — never
+// auto-approve something the band withholds. The verdict is the action decision;
+// the analytical verdict (is it malicious?) lives on the SecurityCase and is NOT
+// scored here (spec §6, §7.3). Modeled on lib/decision/ui-surface-features.ts.
+
+import {
+  CONSERVATIVE_AUTHORITY_BAND,
+  type AuthorityBand,
+  type AuthorityDecision,
+  type RemediationActionDraft,
+  type RemediationRiskClass,
+  buildRemediationProposal,
+} from "@/lib/service-desk/remediation-authority";
+
+export const SECURITY_RESPONSE_SELECT_SURFACE = "soc-response-authority";
+
+export type SecurityBlastRadius = "single-host" | "account" | "estate";
+
+/** Catalog of security response action types → conservative defaults. The
+ *  per-action riskClass feeds the band gate; reversible / blastRadius feed the
+ *  kernel gate (and can be overridden per call by the coworker's assessment). */
+export interface SecurityResponseSpec {
+  riskClass: RemediationRiskClass;
+  reversible: boolean;
+  blastRadius: SecurityBlastRadius;
+}
+
+export const SECURITY_RESPONSE_CATALOG: Record<string, SecurityResponseSpec> = {
+  collect_diagnostics: { riskClass: "read-only", reversible: true, blastRadius: "single-host" },
+  quarantine_host: { riskClass: "medium", reversible: true, blastRadius: "single-host" },
+  block_ip: { riskClass: "medium", reversible: true, blastRadius: "estate" },
+  block_domain: { riskClass: "medium", reversible: true, blastRadius: "estate" },
+  revoke_token: { riskClass: "medium", reversible: true, blastRadius: "account" },
+  disable_account: { riskClass: "high", reversible: true, blastRadius: "account" },
+  isolate_host: { riskClass: "high", reversible: true, blastRadius: "single-host" },
+  kill_process: { riskClass: "high", reversible: false, blastRadius: "single-host" },
+  wipe_host: { riskClass: "destructive", reversible: false, blastRadius: "single-host" },
+};
+
+export type SecurityResponseConsent = "standing" | "per-action" | "none";
+
+export interface SecurityResponseInput {
+  actionType: string;
+  target: string;
+  rationale: string;
+  /** Investigation confidence in the verdict that justifies this action (0..1). */
+  evidenceConfidence: number;
+  /** Standing customer approval breadth for this action class. */
+  consent: SecurityResponseConsent;
+  /** Overrides the catalog defaults when the coworker assesses differently. */
+  reversible?: boolean;
+  blastRadius?: SecurityBlastRadius;
+  /** Does executing this break production for the target? */
+  businessDisruption?: number; // 0..1
+}
+
+const clamp = (n: number): number => Math.max(0, Math.min(1, n));
+
+const BLAST_SCORE: Record<SecurityBlastRadius, number> = {
+  "single-host": 0.2,
+  account: 0.5,
+  estate: 0.9,
+};
+
+const CONSENT_SCORE: Record<SecurityResponseConsent, number> = {
+  standing: 1,
+  "per-action": 0.5,
+  none: 0,
+};
+
+/** Resolve the effective spec (catalog defaults overridden by the call). */
+export function resolveResponseSpec(input: SecurityResponseInput): SecurityResponseSpec {
+  const base = SECURITY_RESPONSE_CATALOG[input.actionType] ?? {
+    riskClass: "high" as RemediationRiskClass,
+    reversible: false,
+    blastRadius: "estate" as SecurityBlastRadius,
+  };
+  return {
+    riskClass: base.riskClass,
+    reversible: input.reversible ?? base.reversible,
+    blastRadius: input.blastRadius ?? base.blastRadius,
+  };
+}
+
+/** Map a security response to the federation rail's RemediationActionDraft. */
+export function securityResponseToDraft(
+  input: SecurityResponseInput,
+): RemediationActionDraft {
+  const spec = resolveResponseSpec(input);
+  return {
+    actionType: input.actionType,
+    parameters: { target: input.target, reversible: spec.reversible, blastRadius: spec.blastRadius },
+    riskClass: spec.riskClass,
+    rationale: input.rationale,
+  };
+}
+
+/**
+ * Derive principle_decide feature vectors (keyed by PRINCIPLE_DIMENSIONS) for the
+ * two options the kernel weighs: auto-execute vs propose-to-human. Cost axes
+ * (blast_radius, business_disruption) carry the actual cost; the security
+ * principles weight them negatively, so a high-blast / disruptive / low-evidence
+ * / unconsented action makes "propose" win. Pure.
+ */
+export function securityResponseFeatures(input: SecurityResponseInput): {
+  autoExecute: Record<string, number>;
+  propose: Record<string, number>;
+} {
+  const spec = resolveResponseSpec(input);
+  const blast = BLAST_SCORE[spec.blastRadius];
+  const disruption = clamp(input.businessDisruption ?? (spec.reversible ? 0.2 : 0.6));
+  const evidence = clamp(input.evidenceConfidence);
+  const consent = CONSENT_SCORE[input.consent];
+  const reversibility = spec.reversible ? 0.9 : 0.1;
+  return {
+    autoExecute: {
+      reversibility,
+      blast_radius: blast,
+      evidence_confidence: evidence,
+      customer_consent_state: consent,
+      business_disruption: disruption,
+    },
+    // The propose baseline: a human reviews, so blast/disruption are not borne
+    // autonomously (near-zero), and consent/evidence are not load-bearing.
+    propose: {
+      reversibility: 0.9,
+      blast_radius: 0.05,
+      evidence_confidence: 0.5,
+      customer_consent_state: 0.5,
+      business_disruption: 0.05,
+    },
+  };
+}
+
+export type SecurityResponseGate = "auto-approve" | "needs-human-approval" | "refuse";
+
+export interface SecurityResponseVerdict {
+  /** The combined (band ∧ kernel, most conservative) decision. */
+  decision: SecurityResponseGate;
+  /** The band-only decision (from the federation remediation authority). */
+  bandDecision: AuthorityDecision;
+  /** Whether the kernel ratcheted the band decision down. */
+  kernelRatcheted: boolean;
+  reason: string;
+  ledger?: unknown;
+}
+
+type ToolExecutor = (
+  toolName: string,
+  args: Record<string, unknown>,
+  userId: string,
+  context: Record<string, unknown>,
+) => Promise<{ success?: boolean; data?: Record<string, unknown>; error?: string }>;
+
+const STRICTNESS: Record<SecurityResponseGate, number> = {
+  "auto-approve": 0,
+  "needs-human-approval": 1,
+  refuse: 2,
+};
+
+function moreConservative(
+  a: SecurityResponseGate,
+  b: SecurityResponseGate,
+): SecurityResponseGate {
+  return STRICTNESS[a] >= STRICTNESS[b] ? a : b;
+}
+
+/**
+ * Decide how a security response action is authorized: the band gate sets the
+ * baseline; the kernel gate (principle_decide over the registered security
+ * dimensions) can only ratchet it MORE conservative. Refused-by-band actions
+ * never reach the kernel. The executor is injectable for tests; the default
+ * routes through the governed principle_decide path.
+ */
+export async function decideSecurityResponse(
+  input: SecurityResponseInput,
+  opts: {
+    userId: string;
+    band?: AuthorityBand;
+    routeContext?: string;
+    toolExecutor?: ToolExecutor;
+  },
+): Promise<SecurityResponseVerdict> {
+  const band = opts.band ?? CONSERVATIVE_AUTHORITY_BAND;
+  const draft = securityResponseToDraft(input);
+  const proposal = buildRemediationProposal(
+    { incidentKey: input.target, edgeNodeId: input.target },
+    [draft],
+    band,
+  );
+  const bandDecision = proposal.overallDecision;
+
+  // Band refused or already requires a human → the kernel cannot widen it; done.
+  if (bandDecision !== "auto-approve") {
+    return {
+      decision: bandDecision,
+      bandDecision,
+      kernelRatcheted: false,
+      reason:
+        bandDecision === "refuse"
+          ? `Band refuses ${input.actionType} (${draft.riskClass}).`
+          : `Band requires human approval for ${input.actionType} (${draft.riskClass}).`,
+    };
+  }
+
+  // Band would auto-approve (read-only). The kernel scores whether autonomous
+  // execution beats proposing to a human, over the security dimensions.
+  const { autoExecute, propose } = securityResponseFeatures(input);
+  const exec = opts.toolExecutor ?? (await import("@/lib/mcp-tools")).executeTool;
+  const response = await exec(
+    "principle_decide",
+    {
+      context:
+        "An AI SOC coworker is deciding whether to AUTO-EXECUTE a security response action " +
+        "on an estate, or PROPOSE it for human approval. Governed by the security principles: " +
+        "never auto-execute an irreversible or estate-wide action without explicit human approval; " +
+        "prefer reversible containment; honour standing customer consent only for low-blast actions.",
+      callingPopulation: "in_platform_coworker",
+      callingSurface: SECURITY_RESPONSE_SELECT_SURFACE,
+      options: [
+        { id: "auto-execute", description: `Auto-execute ${input.actionType} on ${input.target}.`, features: autoExecute },
+        { id: "propose", description: "Propose the action for human approval instead.", features: propose },
+      ],
+    },
+    opts.userId,
+    { routeContext: opts.routeContext ?? SECURITY_RESPONSE_SELECT_SURFACE },
+  );
+
+  const data = response.success ? response.data : undefined;
+  const rec = data?.["recommendation"] as { optionId?: string; confidence?: string } | undefined;
+  const kernelAutoOk = rec?.optionId === "auto-execute" && rec?.confidence === "high";
+  const kernelDecision: SecurityResponseGate = kernelAutoOk ? "auto-approve" : "needs-human-approval";
+  const decision = moreConservative(bandDecision, kernelDecision);
+  return {
+    decision,
+    bandDecision,
+    kernelRatcheted: decision !== bandDecision,
+    reason: kernelAutoOk
+      ? "Band + kernel both clear autonomous execution."
+      : "Band allows auto, but the kernel ratchets to human approval (blast / reversibility / evidence / consent).",
+    ledger: data?.["scores"] ?? data ?? null,
+  };
+}

--- a/docs/founder-kernel/wiki/principles/never-auto-execute-irreversible-or-estate-wide-response.md
+++ b/docs/founder-kernel/wiki/principles/never-auto-execute-irreversible-or-estate-wide-response.md
@@ -1,0 +1,86 @@
+---
+title: Never auto-execute an irreversible or estate-wide security response without human approval
+slug: never-auto-execute-irreversible-or-estate-wide-response
+pageKind: principle
+status: published
+abstract: An AI SOC coworker may investigate, judge, and propose freely, but autonomous EXECUTION of a containment or remediation action is gated by what the action can break. A reversible, single-host action under standing customer consent and high investigation confidence may auto-execute; an irreversible action, an estate-wide action, or one without consent must be proposed for human approval — never taken autonomously. The MSP never gains standing execute rights on a sovereign estate.
+principleTier: commandment
+principleDirection: Gate autonomous security-response execution on reversibility, blast radius, evidence confidence, and customer consent; irreversible or estate-wide actions always require explicit human approval and always execute on the customer's own runner.
+principleDimensionVector: {"reversibility": 1.0, "blast_radius": -1.0, "business_disruption": -0.6, "evidence_confidence": 0.5, "customer_consent_state": 0.6}
+principleAppliesTo:
+  - in_platform_coworker
+principleConsumerArchetype: ai-coworker-universal
+principleRingScope:
+  - universal-ring
+principlePublic: false
+authoredAt: 2026-06-25
+authoredBy: mark-bodman
+---
+
+# Never auto-execute an irreversible or estate-wide security response without human approval
+
+**The verdict is the coworker's; the trigger is the human's — until the action is provably safe to take alone.**
+
+An AI SOC coworker earns broad latitude to *think*: enrich detections, reconstruct
+timelines, judge true- vs false-positive, and **propose** a response. What it does
+not earn by default is the latitude to *act* on a customer's estate. Autonomous
+execution is gated not by how confident the coworker feels, but by what the action
+can **break** and whether it can be **undone**.
+
+## The gate
+
+An action may auto-execute only when **all** of these hold:
+
+1. **Reversible** — the action can be undone (a network quarantine, a token revoke,
+   a temporary block). An irreversible action (a process kill that loses state, a
+   wipe) is never autonomous.
+2. **Bounded blast radius** — it touches a single host, not an account class or the
+   whole estate. An estate-wide block is never autonomous.
+3. **High evidence confidence** — the investigation's verdict is confident, not a
+   hunch. Low confidence routes to a human.
+4. **Standing customer consent** — the customer has pre-authorized this action class
+   for autonomous use. No consent → propose, never act.
+
+Fail any one, and the response becomes a **proposal**: it lands on the customer's
+Attention Surface, a human approves it, and the **customer's own runner** executes
+it. The MSP coordinating the SOC never holds standing execute rights on a sovereign
+estate — the proposal-not-action rail is the line that does not move.
+
+## Why this is a commandment
+
+The cost of a wrong autonomous action in security is asymmetric and often
+irreversible: isolating the wrong host takes down production; disabling the wrong
+account locks out a real user; an estate-wide block is an self-inflicted outage. The
+benefit of *acting* a few minutes sooner rarely outweighs the cost of acting wrongly
+and unrecoverably. So the default is to **propose**, and the burden of proof is on
+autonomy — reversibility, small blast radius, evidence, and consent must all be
+present before the coworker pulls a trigger by itself.
+
+This composes the kernel's broader stance: prefer reversible moves, oppose blast
+radius ([[never-wipe-db-for-code-fixes]]), and make the human the approver where the
+action is consequential and not provably safe to take alone. The dimension vector
+weights `reversibility` and `customer_consent_state` positively and the cost axes
+`blast_radius` and `business_disruption` negatively, so the scorer favors *propose*
+exactly when the action is irreversible, broad, or disruptive.
+
+## How to apply
+
+When an AI SOC coworker reaches a response decision:
+
+1. **Classify the action** — reversible? what blast radius? Use the response catalog
+   defaults, then refine with the specific target.
+2. **Score auto-execute vs propose** through the governed decision. If the action is
+   irreversible, estate-wide, low-confidence, or unconsented, *propose* wins.
+3. **Honour the ratchet** — the band gate (read-only auto-approves, mutating needs a
+   human) is the floor; this principle can only make a decision *more* conservative,
+   never less. A coworker never widens its own authority.
+4. **Record the proposal** on the SecurityCase with its action, target, reversibility,
+   blast radius, rationale, and the authority decision — so the human approving it
+   sees exactly what they are authorizing.
+
+## Related principles
+
+- [`prefer-reversible-containment`](prefer-reversible-containment.md) — the core
+  companion: among actions that contain a threat, prefer the one you can undo.
+- [`never-wipe-db-for-code-fixes`](never-wipe-db-for-code-fixes.md) — the same
+  blast-radius discipline applied to the platform's own data.

--- a/docs/founder-kernel/wiki/principles/prefer-reversible-containment.md
+++ b/docs/founder-kernel/wiki/principles/prefer-reversible-containment.md
@@ -1,0 +1,53 @@
+---
+title: Prefer reversible containment
+slug: prefer-reversible-containment
+pageKind: principle
+status: published
+abstract: When more than one response would contain a security threat, prefer the one you can undo. A network quarantine you can lift beats a process kill that loses state; a temporary block beats a permanent change. Reversible containment buys the same time-to-safety while keeping the cost of a wrong call recoverable.
+principleTier: core
+principleDirection: Among responses that contain a threat, choose the most reversible one with the smallest blast radius; reach for irreversible or broad actions only when a reversible one cannot contain the threat.
+principleDimensionVector: {"reversibility": 0.8, "blast_radius": -0.5, "business_disruption": -0.4}
+principleAppliesTo:
+  - in_platform_coworker
+principleConsumerArchetype: ai-coworker-universal
+principleRingScope:
+  - universal-ring
+principlePublic: false
+authoredAt: 2026-06-25
+authoredBy: mark-bodman
+---
+
+# Prefer reversible containment
+
+**Contain the threat with the move you can take back.**
+
+Most security threats can be contained more than one way, and the ways differ in
+how recoverable they are. Quarantining a host's network access stops lateral
+movement and can be lifted in seconds; killing the suspect process stops it too but
+loses the forensic state and cannot be undone. Blocking an indicator temporarily
+buys time; a permanent firewall change is a standing liability. When the containment
+value is comparable, the **reversible** option is strictly better: it buys the same
+time-to-safety while keeping the cost of a wrong call recoverable.
+
+This is not "never take irreversible action." It is "do not take the irreversible
+action when a reversible one would do." Reach for the process kill, the account
+deletion, the estate-wide block only when a reversible move genuinely cannot contain
+the threat — and when you do, that action is exactly the kind that
+[[never-auto-execute-irreversible-or-estate-wide-response|requires human approval]].
+
+## How to apply
+
+- **Rank by reversibility, then blast radius.** Among candidate responses, prefer the
+  one you can undo and that touches the fewest assets.
+- **Default to temporary.** A block with an expiry, a quarantine that auto-lifts, a
+  token revoke that can be re-issued — prefer the bounded form.
+- **Preserve evidence.** A reversible containment usually keeps the host and its
+  state intact for investigation; an irreversible one often destroys it.
+- **Escalate, don't reach.** If only an irreversible or estate-wide action will
+  contain it, that is a signal to bring a human in, not to act faster alone.
+
+## Related principles
+
+- [`never-auto-execute-irreversible-or-estate-wide-response`](never-auto-execute-irreversible-or-estate-wide-response.md)
+  — the commandment this core principle serves: the irreversible action you avoid
+  here is the one that always needs human approval there.

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-ea-extractor-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-ea-extractor-plan.md
@@ -1,0 +1,18 @@
+# Sovereign SOC — EA security-posture extractor (no-drift)
+
+- **Date:** 2026-06-25
+- **Spec:** [2026-06-24-sovereign-soc-siem-design.md](../specs/2026-06-24-sovereign-soc-siem-design.md) §7 (cross-cutting)
+- **Epic:** EP-SOVEREIGN-SOC — **BI-79B599BF** · composes EP-PARITY-ENGINE / EP-ARCH-GRAPH-LIVE
+
+## Goal
+
+Project the security domain into the one architecture graph so the SOC is a first-class, navigable surface that **cannot drift** from the implementation — the gap the arch-review flagged.
+
+## This pass (DONE)
+- `apps/web/lib/ea/security-posture-extract.ts` — `buildSecurityPostureModel()` (pure), modeled on `scheduled-job-extract.ts`. Emits: package `security:pkg`; a `part_definition` per plane (normalization / detection / cases / response / roster); a `part_usage` per kernel detection rule (`KERNEL_DETECTION_PACK`) and per AGT-SOC-* coworker; cross-layer `traces` edges from each plane to its `prisma:model:*` node (SecurityEvent / Detection / DetectionRule / ThreatIndicator / SecurityCase). `softRemovePrefix: "security:"` so stale nodes prune.
+- `apps/web/lib/ea/reconcile-security-posture.ts` — the thin IO shell (`applySysmlModel(buildSecurityPostureModel(), {db})`).
+- Registered into the orchestrator `reconcile-sysml-projections.ts` (+ the `architecture-parity-steward` domain label) so it runs every parity pass.
+- Tests: `security-posture-extract.test.ts` (package/plane/usage counts, traces, contains, soft-remove); updated orchestrator + steward tests.
+
+## Verified
+web typecheck clean; EA extractor + orchestrator + steward tests 8/8.

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-p1-content-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-p1-content-plan.md
@@ -1,0 +1,18 @@
+# Sovereign SOC — P1 content: detection pack + enrichment lookups
+
+- **Date:** 2026-06-25
+- **Spec:** [2026-06-24-sovereign-soc-siem-design.md](../specs/2026-06-24-sovereign-soc-siem-design.md) §4.2, §4.3, §7.1
+- **Epic:** EP-SOVEREIGN-SOC — **BI-6D9496F1** (P1 follow-on)
+
+## Goal
+
+Make the detection engine produce results out of the box (it was correctly inert with no rules) and wire enrichment to live data.
+
+## This pass (DONE)
+- `apps/web/lib/security/detection-pack.ts` — `KERNEL_DETECTION_PACK` (3 explainable starter rules under `scopeKey="kernel"`, MITRE-tagged): Windows failed logon (T1110), threat-intel indicator match (T1071), internal authorization denied (T1078, self-monitoring). `ensureKernelDetectionPack` is **create-if-missing** — operator tuning of existing rules is never overwritten.
+- Wired `ensureKernelDetectionPack` into `runCorrelationSweep` (gated by `seedPack`, default true) so the rules are always present without separate seed wiring.
+- `apps/web/lib/security/enrichment-lookups.ts` — `buildPrismaEnrichmentLookups`: asset context ← `InventoryEntity` (by hostname), threat intel ← `ThreatIndicator` active-window index. Pass to `enrichSecurityEvent`; SOC coworkers use it when investigating a detection.
+- Tests: `detection-pack.test.ts` (each rule fires on a sample event; benign events do not).
+
+## Verified
+web typecheck clean; detection-pack + sweep tests green.

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-p3-governed-response-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-p3-governed-response-plan.md
@@ -1,0 +1,27 @@
+# Sovereign SOC — P3 governed response + security principles: plan
+
+- **Date:** 2026-06-25
+- **Spec:** [2026-06-24-sovereign-soc-siem-design.md](../specs/2026-06-24-sovereign-soc-siem-design.md) §4.5, §6, §7.3
+- **Epic:** EP-SOVEREIGN-SOC — **BI-74FE2B20**
+- **Builds on:** P0–P2 (merged in #2358) + the merged EP-MSP-FEDERATION remediation rail.
+
+## Goal
+
+Governed security response — propose-only, never autonomous on a sovereign estate — with the kernel governing the *action* decision over the registered security dimensions.
+
+## Composes (not rebuilds) the merged federation rail
+- `lib/service-desk/remediation-authority.ts`: `RemediationRiskClass`, `evaluateRemediationAuthority` (the BAND gate — read-only auto-approves, mutating needs human, destructive refused), `buildRemediationProposal`, `authorityBandFromBinding`.
+- The decision shape (`auto-approve | needs-human-approval | refuse`) and the conservative default band are reused verbatim.
+
+## This pass (DONE)
+- `apps/web/lib/security/response-authority.ts`:
+  - `SECURITY_RESPONSE_CATALOG` — action types → riskClass + reversible + blastRadius defaults.
+  - `securityResponseToDraft` — maps a security response to a federation `RemediationActionDraft`.
+  - `securityResponseFeatures` — `principle_decide` feature vectors over the registered dims (`reversibility`/`blast_radius`/`evidence_confidence`/`customer_consent_state`/`business_disruption`).
+  - `decideSecurityResponse` — the combined gate: the band sets the floor; the kernel (`principle_decide`, modeled on `lib/decision/ui-surface-features.ts`) can only ratchet it **more conservative**. **Fails safe**: a degenerate/low-confidence kernel result keeps human approval.
+- **Security principle pages** (founder doctrine): `never-auto-execute-irreversible-or-estate-wide-response` (commandment) + `prefer-reversible-containment` (core), in `docs/founder-kernel/wiki/principles/`. Dimension vectors weight the cost axes (`blast_radius`, `business_disruption`) negatively per the sign-convention guard. Verified: seed-wiki-kernel + wiki-taxonomy 86/86.
+- Wired `propose_response` (the IR-Lead's tool) to compute and record the authority decision on the `SecurityCase`.
+- Tests: `response-authority.test.ts` (band gate, kernel ratchet, fail-safe) + the updated `mcp-tools-siem.test.ts`.
+
+## Cross-org (composes P5)
+For a customer-scoped case with a `FederationLink`, the proposal additionally rides `routeRemediationProposal` (auto-execute-on-customer / customer-attention-surface / refused) → a `FederatedRemediationProposal` lands on the customer's Attention Surface and the customer's runner executes. The in-org default records the decision on the case for operator approval. Full federation send/receive is P5.

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-p4-console-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-p4-console-plan.md
@@ -1,0 +1,22 @@
+# Sovereign SOC — P4 /ops/security console
+
+- **Date:** 2026-06-25
+- **Spec:** [2026-06-24-sovereign-soc-siem-design.md](../specs/2026-06-24-sovereign-soc-siem-design.md) §4.6, §10
+- **Epic:** EP-SOVEREIGN-SOC — **BI-80191C61**
+
+## Goal
+
+The operator surface: a SOC console answering the first-screen questions (Are we covered? Are we exposed? What needs a decision? Are we improving?).
+
+## This pass (DONE)
+- `apps/web/lib/security/console-data.ts` — pure `computeSocConsoleData`: coverage (connected vs stale sources; `monitoring=false` so an empty board is **not** green), detections (open + by severity), cases (open / awaiting-decision / resolved / by status), SLA metrics (MTTR, false-positive rate). `console-loader.ts` — the prisma-backed loader.
+- `apps/web/app/api/platform/security/overview/route.ts` — GET, gated by `view_operations`, returns the aggregates + recent cases.
+- `apps/web/app/(shell)/ops/security/page.tsx` — server-rendered console (inherits the ops `view_operations` gate): a report-kit `StatCard` grid + a recent-cases table with `StatusBadge` (new `security` / `securitySeverity` status domains in `statusColors.ts` — no page-local status maps).
+- Nav: `ops-nav.ts` adds a "Security → SOC Console" group (`/ops/security`); the navigation EA projection ingests it. Route manifest regenerated (512 routes).
+- Tests: `console-data.test.ts` (coverage/stale, severity tally, MTTR/FP-rate, empty-board-not-green).
+
+## Remaining polish (needs the browser to iterate)
+Interactive filtering (FilterBar by customer/severity/status/ATT&CK), per-customer MSP fleet drilldown, and trend charts are the visual-iteration follow-on; the data-backed first screen + recent cases is functional and gated here.
+
+## Verified
+web typecheck clean (page + API + loader); console-data 4/4; route manifest fresh.

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-p5-federation-projection-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-p5-federation-projection-plan.md
@@ -1,0 +1,25 @@
+# Sovereign SOC — P5 federation projection of detections/cases
+
+- **Date:** 2026-06-25
+- **Spec:** [2026-06-24-sovereign-soc-siem-design.md](../specs/2026-06-24-sovereign-soc-siem-design.md) §5 (Topology B)
+- **Epic:** EP-SOVEREIGN-SOC — **BI-A1267C56** · composes EP-MSP-FEDERATION
+
+## Goal
+
+Topology B (sovereign-peer): the MSP receives a consented, minimized projection of detections/cases — **the sovereignty boundary is the normalized detection, not the raw log.**
+
+## Composes (not rebuilds) the merged egress gate
+- `packages/db/src/projection-serialization.ts`: `projectEstatePayload` (allow-list + forbidden-field guard), `assertNoExcludedEgress` (negative-egress proof), `toCloudEvent` — and `FederatedRecordMirror` (the minimized projection store).
+
+## This pass (DONE)
+- `apps/web/lib/security/federation-projection.ts`:
+  - `SECURITY_PROJECTION_CONTRACT` — only the case + detection SUMMARY slices cross; investigation `timeline` + `evidence` + raw are excluded.
+  - `projectSecurityCase` / `buildSecurityCaseCloudEvent` — produce exactly what crosses the link, with the negative-egress proof.
+  - `projectSecurityCaseToMirror` — persist the minimized projection as a `FederatedRecordMirror` (idempotent on link+type+caseKey). **Fails closed**: refuses to persist if the negative-egress proof is non-empty.
+- Tests: `federation-projection.test.ts` — proves the case summary crosses while timeline + evidence stay local, the projection passes the negative-egress proof, and only allow-listed fields cross.
+
+## Remaining wiring (needs a peer deployment to exercise)
+The cross-deployment HTTP send (`POST /api/v1/federation/project`) + receive ingest ride the existing federation enroll/trust routes; they require two DPF deployments to test end-to-end, so they are the federation-transport follow-on. The projection minimization + mirror — the sovereignty-critical, provable core — is complete here.
+
+## Verified
+web typecheck clean; federation-projection tests green.

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-p6-compliance-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-p6-compliance-plan.md
@@ -1,0 +1,14 @@
+# Sovereign SOC — P6 compliance: evidence + framework reports + retention
+
+- **Date:** 2026-06-25
+- **Spec:** [2026-06-24-sovereign-soc-siem-design.md](../specs/2026-06-24-sovereign-soc-siem-design.md) §4.7
+- **Epic:** EP-SOVEREIGN-SOC — **BI-CE28A324** · composes EP-ASSURANCE-LEDGER / EP-DATA-RETENTION
+
+## This pass (DONE)
+- **Retention:** `Detection` → `PURGE_POLICIES` under the existing `security-audit` category (365d, createdAt-indexed). `SecurityEvent` already enrolled (P0); `SecurityCase` stays in `RETAINED_DATASETS` (regulated incident record).
+- **Reporting:** `apps/web/lib/security/compliance.ts` — `SECURITY_COMPLIANCE_FRAMEWORKS` maps the SOC's Detect/Respond activity to the control families of NIST CSF, PCI-DSS, HIPAA, SOC 2, CMMC, and DORA; `buildSecurityComplianceReport(framework, metrics)` evidences a Detect control when monitoring is active with detections, a Respond control when cases resolve.
+- **Continuous evidence:** `securityCaseToEvidenceInput` (pure) + `recordSecurityCaseEvidence` (idempotent upsert, keyed on the case) turn a resolved `SecurityCase` into a `ComplianceEvidence` row — the "we detect and respond" proof, composing the existing GRC Control/Obligation/Evidence framework (`ComplianceEvidence.controlId` optional, so generic security-operations evidence lands without a pre-mapped control).
+- Tests: `compliance.test.ts` (report evidencing logic across frameworks; case→evidence projection).
+
+## Verified
+web typecheck clean; compliance + retention guard tests green.


### PR DESCRIPTION
@-

---

UX-Fit-Decision: progressive-disclosure — /ops/security first screen is read-only (report-kit StatCards + recent-cases table = the 4 operator answers), exposes no raw/technical inputs; interactive filtering, MSP fleet drilldown, and trend charts are deferred (plan "Remaining polish"). Decided on AGENTS.md §12/§17 progressive-disclosure merits (principle_decide human_cognitive_load axis is degenerate — no kernel principle scores it).
