### PR TITLE
feat(obs): complete EP-FULL-OBS coverage — model-runner/stt + flapping alerts, retire dead HTTP alerts

### DIFF
--- a/docs/operations/observability-coverage.md
+++ b/docs/operations/observability-coverage.md
@@ -46,20 +46,36 @@ profile — so on the **Windows GA host they collect nothing and never fire**. T
 (`windows_*`)** series, which the `windows-host` job already scrapes. Linux installs
 keep the `node_*` rules; Windows installs get the `windows_*` rules.
 
-## Known follow-ups (deliberately not yet done)
+## Status & decisions (2026-06-25 — objective completed)
 
-- **HTTP latency / error-ratio** (`HighRequestLatency`, `HighErrorRate`) need
-  per-request timing+status instrumentation (`dpf_http_request_duration_seconds`,
-  `dpf_http_requests_total` are *defined* in `lib/operate/metrics.ts` but never
-  `.observe()`d). A route wrapper rollout is the remaining half of **BI-994B504C**;
-  `UnhandledServerErrors` (via `onRequestError`) is the zero-route-change interim.
-- **model-runner / stt ServiceDown alerts** — gauges ship now; alerting is gated on
-  install-type detection (a cloud install has no local model runner), to avoid
-  cross-install false positives. Follow-up under EP-FULL-OBS.
-- **Per-container restart/CPU/memory on Windows** — needs a cAdvisor-equivalent for
-  WSL2 (e.g. an alloy cadvisor exporter); a deployment-doctrine decision.
-- **TTS/voice self-heal at boot** — `assertVoiceServiceOnBoot` (BI-264565A4) is
-  detection/fail-loud only; auto-starting the sidecar needs host exec.
+- **model-runner / stt alerts** — DONE. `ModelRunnerDown` / `SttDown` fire on
+  `dpf_dependency_up{service} == 0 and max_over_time(...[6h]) == 1` — i.e. only when
+  a service that was working in the last 6h drops. Install-agnostic, so a cloud
+  install that never runs a local model runner / STT never false-fires.
+- **Restart-loop detection (all platforms)** — DONE via `ServiceFlapping`
+  (`changes(up[15m]) > 5`), which catches a crashing+recovering scraped service
+  (the qdrant loop `ContainerRestarting` missed) using the `up` series.
+- **Per-container CPU/memory + restart_count on Windows** — NOT POSSIBLE, by
+  platform constraint. cAdvisor/node-exporter require `/proc`, `/sys`,
+  `/var/lib/docker` host mounts that Docker Desktop (WSL2/macOS) does not provide
+  (see the `monitoring/alloy/config.alloy` header — exactly why log capture uses
+  the socket, not bind mounts). The `dpf_infrastructure` Container*/Host(`node_*`)
+  rules remain for Linux installs; Windows is covered by `dpf_windows_host` (host)
+  + `up`-based `ContainerDown` / `ServiceFlapping` + the portal-side
+  `dpf_dependency_up` / `dpf_voice_tts_*` probes.
+- **HTTP latency / error-ratio alerts** — RETIRED (BI-994B504C). `HighRequestLatency`
+  / `HighErrorRate` keyed on per-request metrics Next App Router cannot populate
+  without a shared route wrapper (none exists in DPF) or a custom server — a
+  separate architecture decision, unsafe to retrofit blind. Removed rather than
+  left as permanently-dead rules. Error detection is `UnhandledServerErrors`
+  (`onRequestError`); AI latency is `AIInferenceHighLatency`. Re-add with real
+  per-request instrumentation if general HTTP SLOs are ever needed.
+- **TTS/voice runtime self-heal** — BY DESIGN NOT DONE (BI-264565A4).
+  `assertVoiceServiceOnBoot` detects + fails loud at boot; auto-*starting* the
+  sidecar would require the portal to exec host Docker, crossing the portal's
+  security/governance boundary. First-run actuation is owned by the installer
+  (BI-3C812E4E, GPU-gated auto-start); a governed runtime host-action rail is the
+  proper future path if runtime auto-recovery is ever wanted.
 
 ## Alert delivery
 

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -116,23 +116,52 @@ groups:
         annotations:
           summary: "Neo4j graph DB is unreachable -- code graph + architecture views offline"
 
+      # model-runner + stt have no /metrics; the portal probes them into
+      # dpf_dependency_up{service}. Gate on "was up in the last 6h" so these never
+      # false-fire on installs that don't run a local model runner / STT (e.g. a
+      # cloud install) -- only alert when a previously-working service drops. [BI-963DBB05]
+      - alert: ModelRunnerDown
+        expr: dpf_dependency_up{service="model-runner"} == 0 and max_over_time(dpf_dependency_up{service="model-runner"}[6h]) == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Local model runner is unreachable -- local AI inference offline"
+
+      - alert: SttDown
+        expr: dpf_dependency_up{service="stt"} == 0 and max_over_time(dpf_dependency_up{service="stt"}[6h]) == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Speech-to-text service is unreachable -- voice input offline"
+
+      # Restart-loop / scrape-flap detection -- Windows-viable (keys on `up`,
+      # collected for every scraped target). cAdvisor's container_restart_count
+      # is NOT collectable on Docker Desktop (no /proc,/sys,/var/lib/docker
+      # mounts -- see monitoring/alloy/config.alloy), so this is how a crashing+
+      # recovering service is caught on Windows -- the 2026-06-24 qdrant loop that
+      # ContainerRestarting missed. [BI-573438C1]
+      - alert: ServiceFlapping
+        expr: changes(up{job!~"prometheus|windows-host"}[15m]) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Service {{ $labels.job }} is flapping (restart loop) -- >5 up/down transitions in 15m"
+
   - name: dpf_application
     rules:
-      - alert: HighRequestLatency
-        expr: histogram_quantile(0.95, rate(dpf_http_request_duration_seconds_bucket[5m])) > 5
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "95th percentile request latency above 5s"
-
-      - alert: HighErrorRate
-        expr: rate(dpf_http_requests_total{status_code=~"5.."}[5m]) / rate(dpf_http_requests_total[5m]) * 100 > 5
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "HTTP 5xx error rate above 5%"
+      # HighRequestLatency / HighErrorRate (RETIRED 2026-06-25, BI-994B504C):
+      # both keyed on dpf_http_request_duration_seconds / dpf_http_requests_total,
+      # which are defined but never observed -- Next App Router has no global
+      # per-request hook and DPF has no shared route-handler wrapper, so
+      # populating them would mean wrapping every route or running a custom server
+      # (a separate architecture decision, unsafe to retrofit blind). They could
+      # never fire, so they are removed rather than left as dead rules. The real
+      # error signal is UnhandledServerErrors (below, via the onRequestError
+      # instrumentation hook); AI latency is AIInferenceHighLatency. Re-add WITH
+      # per-request instrumentation if general HTTP SLOs are ever needed.
 
       # AIInferenceDown was removed: Docker Model Runner does not expose a
       # Prometheus metrics endpoint, so `up{job="model-runner"}` was always 0.


### PR DESCRIPTION
Final completion of the observability objective (EP-FULL-OBS). **Alerts + docs only — no app-code change**, so nothing runtime-bound to break on self-upgrade. Follows #2336 / #2345 / #2355 (all merged).

## Completions
- **BI-963DBB05 (done)** — `ModelRunnerDown` + `SttDown` alerts on `dpf_dependency_up{service}`, gated `== 0 and max_over_time(...[6h]) == 1` so they fire only when a service that was working in the last 6h drops. Install-agnostic → no false positives on cloud installs without a local model runner / STT.
- **BI-573438C1 (done)** — `ServiceFlapping` (`changes(up[15m]) > 5`) catches restart loops on Windows via the `up` series — the qdrant-style crash loop `ContainerRestarting` missed. cAdvisor can't run on Docker Desktop (no `/proc`,`/sys`,`/var/lib/docker` mounts), so this is the Windows-viable path.
- **BI-994B504C (resolved)** — retire `HighRequestLatency` + `HighErrorRate`: both key on per-request metrics Next App Router can't populate without a shared route wrapper (none exists) or a custom server. Removed rather than left as dead rules; `UnhandledServerErrors` (onRequestError) is the real error signal and `AIInferenceHighLatency` covers AI latency.
- **BI-264565A4 (decision)** — runtime self-heal is **by-design not done**: the portal must not exec host Docker (security boundary). Boot fail-loud (shipped) + installer GPU-gated auto-start (BI-3C812E4E) are the actuation path.

## Rationale & platform constraints
`docs/operations/observability-coverage.md` updated with the final status — including that per-container CPU/mem/restart on Windows is a **hard platform limitation** (cAdvisor/node-exporter need host mounts Docker Desktop lacks), and the `ServiceFlapping` / `up`-based coverage that compensates.

## Verification
Alerts/docs only; CI gates (incl. any promtool/alert lint). gitleaks clean pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
