### PR TITLE
refactor(build): converge on one production Build Studio namespace (BI-ARCH-BUILDSTUDIO-NS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,24 @@ jobs:
       - name: Run guard
         run: node scripts/check-package-boundaries.mjs
 
+  build-studio-namespace-guard:
+    name: Build Studio Namespace Guard
+    runs-on: ubuntu-latest
+    # BI-ARCH-BUILDSTUDIO-NS. components/build is the single production Build
+    # Studio namespace. components/build-studio is a quarantined, stale V2
+    # prototype (reachable only via /build?v=2). This guard fails any PR that
+    # adds a NEW production import of @/components/build-studio beyond the two
+    # known frozen importers, so new Build Studio UI lands in components/build.
+    # See docs/architecture/build-studio-namespace.md.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Run guard
+        run: node scripts/check-build-namespace.mjs
+
   sbom-divergence-guard:
     name: SBOM Divergence Guard
     runs-on: ubuntu-latest

--- a/apps/web/lib/integrate/build-plan-paths.test.ts
+++ b/apps/web/lib/integrate/build-plan-paths.test.ts
@@ -91,4 +91,39 @@ describe("normalizeBuildPlanPaths", () => {
     const normalized = normalizeBuildPlanPaths(plan, { exists: () => false });
     expect(normalized.plan.fileStructure[0]?.path).toBe("");
   });
+
+  // BI-ARCH-BUILDSTUDIO-NS: any agent-generated path under the quarantined
+  // `components/build-studio` prototype converges on the single production
+  // namespace `components/build` via the folder fallback — not just the three
+  // hardcoded legacy names. This is the contract that keeps build plans pointing
+  // at one namespace. See docs/architecture/build-studio-namespace.md.
+  it("converges arbitrary components/build-studio paths onto components/build", () => {
+    const plan = makePlan({
+      fileStructure: [
+        {
+          path: "apps/web/components/build-studio/SomeNewPanel.tsx",
+          action: "modify",
+          purpose: "agent picked the wrong namespace",
+        },
+      ],
+      tasks: [
+        {
+          title: "Edit the panel",
+          testFirst: "inspect apps/web/components/build-studio/SomeNewPanel.tsx",
+          implement: "Edit apps/web/components/build-studio/SomeNewPanel.tsx",
+          verify: "renders",
+        },
+      ],
+    });
+
+    const normalized = normalizeBuildPlanPaths(plan, {
+      // Only the production-namespace path exists in the repo.
+      exists: (absolutePath) =>
+        absolutePath.replace(/\\/g, "/").endsWith("/apps/web/components/build/SomeNewPanel.tsx"),
+    });
+
+    expect(normalized.plan.fileStructure[0]?.path).toBe("apps/web/components/build/SomeNewPanel.tsx");
+    expect(normalized.plan.tasks[0]?.implement).toContain("apps/web/components/build/SomeNewPanel.tsx");
+    expect(normalized.plan.tasks[0]?.implement).not.toContain("components/build-studio");
+  });
 });

--- a/docs/architecture/build-studio-namespace.md
+++ b/docs/architecture/build-studio-namespace.md
@@ -1,0 +1,51 @@
+# Build Studio Component Namespace
+
+Status: standard (BI-ARCH-BUILDSTUDIO-NS, EP-PLATFORM-CONSOLIDATION)
+Spec: [`docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md`](../superpowers/specs/2026-06-25-platform-consolidation-spine-design.md) §6.4
+
+There is **one production Build Studio component namespace: `apps/web/components/build`.**
+Build plans, the build agent's generated file paths, tests, and docs all point there.
+
+`apps/web/components/build-studio` is a **quarantined prototype** — a chat-first "V2"
+shell (HeaderBar / ConversationPane / ArtifactPane / cards) last touched 2026-05-10. It is
+reachable only via the dev-only `/build?v=2` query param and renders largely demo data. It
+is **not** a build target and **not** the production surface. Its disposition (graduate
+into `components/build`, or retire) is an open operator decision the spec flagged; until
+then it is frozen, not grown.
+
+## Why this matters
+
+The `/build` route importing two production-adjacent shells was, per the spec, a
+"high-risk area for new WIP divergence": new work could land in either namespace, build
+plans could target either, and the two could drift. The risk is neutralized by making the
+production namespace singular and enforcing it.
+
+## Enforcement
+
+- **Plan-path convergence.** `apps/web/lib/integrate/build-plan-paths.ts` rewrites any
+  agent-generated `components/build-studio/*` path onto `components/build/*` (a folder
+  fallback plus three legacy exact aliases). `build-plan-paths.test.ts` asserts arbitrary
+  build-studio paths converge — so a model that picks the wrong namespace is corrected
+  before the build runs.
+- **Footprint freeze.** [`scripts/check-build-namespace.mjs`](../../scripts/check-build-namespace.mjs)
+  (CI job `Build Studio Namespace Guard`) fails if any NEW production file imports
+  `@/components/build-studio` beyond the two known, frozen importers
+  (`app/(shell)/build/page.tsx`'s `?v=2` branch and `lib/build-studio-demo.ts`). New Build
+  Studio UI must land in `components/build`.
+
+## Legacy plan-path aliases — intentionally retained
+
+`LEGACY_BUILD_STUDIO_PATH_ALIASES` / `LEGACY_BUILD_STUDIO_TEXT_ALIASES` in
+`build-plan-paths.ts` map three pre-refactor component names
+(`BuildWorkspace`/`WorkflowGraphPanel`/`DetailsPreviewPanel`) onto current
+`components/build` files. Modern plan generation never emits these (the build agent prompt
+only references `components/build`), but **historical build plans persisted in the DB
+still can**, so the aliases stay as defensive normalization. They can be removed once a
+sweep confirms no stored plan references the old names.
+
+## Recommended follow-up (operator decision)
+
+Retire the `components/build-studio` prototype (and its `/build?v=2` access) or graduate
+its chat-first ideas into `components/build`. Either way the production namespace is
+already singular and enforced; this is a cleanup of dead/quarantined code, not a
+divergence risk.

--- a/scripts/check-build-namespace.mjs
+++ b/scripts/check-build-namespace.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Build Studio namespace freeze guard — BI-ARCH-BUILDSTUDIO-NS.
+//
+// `apps/web/components/build` is the single PRODUCTION Build Studio namespace —
+// where builds, build plans, and agent-generated file paths all land.
+// `apps/web/components/build-studio` is a stale (last touched 2026-05-10),
+// quarantined V2 chat-shell prototype, reachable only via `/build?v=2`. To stop
+// the "two production-adjacent namespaces" divergence the spec flags (§3.4), this
+// guard freezes the prototype's production footprint: no NEW production code may
+// import `@/components/build-studio` beyond the known wiring below. New Build
+// Studio UI belongs in `components/build`. See
+// docs/architecture/build-studio-namespace.md.
+//
+// Run: node scripts/check-build-namespace.mjs
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const WEB = join(REPO_ROOT, "apps", "web");
+const SCAN_DIRS = ["app", "components", "lib", "hooks"].map((d) => join(WEB, d));
+
+// The quarantined prototype's known production wiring. Removing an entry is fine
+// (the set only tightens); ADDING a new importer must be a deliberate decision.
+const ALLOWED_IMPORTERS = new Set([
+  "apps/web/app/(shell)/build/page.tsx",
+  "apps/web/lib/build-studio-demo.ts",
+]);
+
+const QUARANTINED = "components/build-studio";
+const FROM_RE = /\bfrom\s*["']([^"']+)["']/g;
+const REQUIRE_RE = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+
+function listSourceFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === ".next" || entry === "dist" || entry === ".turbo") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...listSourceFiles(full));
+    else if (/\.(ts|tsx|mts|cts)$/.test(entry) && !/\.(test|spec)\.(ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+function importsQuarantined(text) {
+  for (const re of [FROM_RE, REQUIRE_RE]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      if (m[1].includes(QUARANTINED)) return true;
+    }
+  }
+  return false;
+}
+
+const violations = [];
+for (const dir of SCAN_DIRS) {
+  for (const file of listSourceFiles(dir)) {
+    const rel = relative(REPO_ROOT, file).replace(/\\/g, "/");
+    // Files inside the prototype may import their own siblings.
+    if (rel.startsWith("apps/web/components/build-studio/")) continue;
+    if (!importsQuarantined(readFileSync(file, "utf8"))) continue;
+    if (!ALLOWED_IMPORTERS.has(rel)) {
+      violations.push(rel);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Build Studio namespace violations — new production imports of the quarantined");
+  console.error("`components/build-studio` prototype. New Build Studio UI belongs in `components/build`:");
+  for (const v of violations) console.error(`  - ${v}`);
+  console.error("\nSee docs/architecture/build-studio-namespace.md");
+  process.exit(1);
+}
+
+console.log(
+  `Build Studio namespace OK — components/build is the sole production namespace; the build-studio prototype has ${ALLOWED_IMPORTERS.size} known (frozen) importers.`,
+);


### PR DESCRIPTION
EP-PLATFORM-CONSOLIDATION slice. Delivered locally per operator request.

## Why
The `/build` route imported two production-adjacent Build Studio shells — `components/build` (V1, production) and `components/build-studio` (V2 chat prototype, via `/build?v=2`). The spec (§3.4) flags this as a "high-risk area for new WIP divergence."

## Evidence that shaped the call (non-destructive)
- `components/build-studio` is **6 weeks stale** (last commit 2026-05-10), reachable only via the dev-only `?v=2` param, renders demo data, and has exactly **two** production importers.
- All recent Build Studio work + the build agent's generated file paths already target `components/build`.

So rather than delete a substantial prototype (may still be wanted) or do risky surgery on the crown-jewel `/build` route, this takes the spec's sanctioned **"quarantine"** outcome: make the production namespace singular, freeze the prototype, and document — leaving the graduate-vs-retire disposition as an operator decision.

## What changed
- **`scripts/check-build-namespace.mjs` + CI `Build Studio Namespace Guard` job** — fails any NEW production import of `@/components/build-studio` beyond the two known frozen importers. New Build Studio UI must land in `components/build`.
- **`build-plan-paths.test.ts`** — asserts *arbitrary* `components/build-studio/*` paths converge onto `components/build/*` (not just the 3 legacy exact aliases), so a model that picks the wrong namespace is corrected before the build runs.
- **`docs/architecture/build-studio-namespace.md`** — the standard, why the legacy plan-path aliases are intentionally retained (defensive for historical stored DB plans), and the recommended operator follow-up.

Net effect: production Build Studio namespace is singular (`components/build`) and enforced; the V2 prototype is preserved but frozen and clearly documented as quarantined.

## Verification (web worktree)
- `build-plan-paths` tests (4, incl. the new convergence test) — **pass**
- `node scripts/check-build-namespace.mjs` — exits 0

## Recommended follow-up (operator)
Retire `components/build-studio` (+ its `?v=2` access) or graduate its chat-first ideas into `components/build`. Either is now safe cleanup, not a divergence risk.

EP-PLATFORM-CONSOLIDATION · spec §6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)