### PR TITLE
feat(delivery): one Delivery operator home (BI-ARCH-DELIVERY-IA)

### DIFF
--- a/apps/web/app/(shell)/delivery/page.tsx
+++ b/apps/web/app/(shell)/delivery/page.tsx
@@ -1,0 +1,79 @@
+// apps/web/app/(shell)/delivery/page.tsx
+//
+// BI-ARCH-DELIVERY-IA: one operator home for delivery work. This is a HUB — it
+// launches the existing delivery surfaces; it does not own a second tracking or
+// timeline model (work tracking + evidence live in change lanes / the unified
+// tracking work of EP-UNIFIED-TRACKING). Every link points at a route that
+// already exists, so all deep links are preserved.
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+type DeliveryLink = { label: string; href: string; description: string };
+
+const GROUPS: Array<{ title: string; blurb: string; items: DeliveryLink[] }> = [
+  {
+    title: "Build & ship",
+    blurb: "Compose and deliver new capability.",
+    items: [
+      { label: "Build Studio", href: "/build", description: "Create and ship new capability with AI help." },
+      { label: "Work control", href: "/build/work", description: "Work capsules across every surface and agent." },
+    ],
+  },
+  {
+    title: "Plan",
+    blurb: "Decide what gets built next.",
+    items: [
+      { label: "Backlog", href: "/ops", description: "Cross-cutting work queues and improvements." },
+    ],
+  },
+  {
+    title: "Track & release",
+    blurb: "Follow work to production.",
+    items: [
+      {
+        label: "Change lanes",
+        href: "/platform/development/change-lanes",
+        description: "Active work + evidence across Claude, Codex, and Build Studio.",
+      },
+      { label: "Promotions", href: "/ops/promotions", description: "Release orchestration and readiness." },
+      { label: "Dev loop", href: "/ops/dev-loop", description: "Build-runtime worktrees, sandboxes, and leases." },
+      { label: "Self-upgrade", href: "/ops/self-upgrade", description: "Governed portal image lifecycle and health." },
+    ],
+  },
+];
+
+export default function DeliveryHome() {
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 p-6" data-component="delivery-home">
+      <header className="space-y-1">
+        <h1 className="text-xl font-semibold text-[var(--dpf-text)]">Delivery</h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          Build, ship, and track delivery work from one operator home. Model and provider
+          configuration stays under Platform.
+        </p>
+      </header>
+
+      {GROUPS.map((group) => (
+        <section key={group.title} className="space-y-3">
+          <div className="space-y-0.5">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{group.title}</h2>
+            <p className="text-xs text-[var(--dpf-muted)]">{group.blurb}</p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {group.items.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="flex flex-col gap-1 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:border-[var(--dpf-accent)]"
+              >
+                <span className="text-sm font-medium text-[var(--dpf-text)]">{item.label}</span>
+                <span className="text-xs text-[var(--dpf-muted)]">{item.description}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 516,
+  "routeCount": 517,
   "routes": [
     {
       "routePath": "/",
@@ -3566,6 +3566,15 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/customer/(crm)/sales-orders/page.tsx"
+    },
+    {
+      "routePath": "/delivery",
+      "kind": "page",
+      "segments": [
+        "delivery"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/delivery/page.tsx"
     },
     {
       "routePath": "/docs/[[...slug]]",

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -86,6 +86,7 @@ describe("getShellNavSections()", () => {
       "workspace",
       "business",
       "products",
+      "delivery",
       "platform",
       "knowledge",
     ]);

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -203,6 +203,11 @@ const SHELL_SECTIONS: Array<Pick<ShellNavSection, "key" | "label" | "description
     description: "Guide product lifecycle work from portfolio through delivery.",
   },
   {
+    key: "delivery",
+    label: "Delivery",
+    description: "Build, ship, and track delivery work from one operator home.",
+  },
+  {
     key: "platform",
     label: "Platform",
     description: "Direct AI coworkers and operate the platform itself.",

--- a/apps/web/lib/navigation/portal-navigation-model.test.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.test.ts
@@ -82,4 +82,24 @@ describe("portal navigation model", () => {
       expect(getRouteNavRecord(href), href).toBeDefined();
     }
   });
+
+  it("groups the Delivery home and Build Studio under a Delivery section (BI-ARCH-DELIVERY-IA)", () => {
+    const delivery = getRouteNavRecord("/delivery");
+    expect(delivery?.domain).toBe("delivery");
+    expect(delivery?.shellNav?.sectionKey).toBe("delivery");
+
+    const sections = getShellNavSections(adminUser);
+    const deliverySection = sections.find((section) => section.key === "delivery");
+    expect(deliverySection, "Delivery shell section should exist").toBeDefined();
+
+    const deliveryHrefs = deliverySection?.items.map((item) => item.href) ?? [];
+    expect(deliveryHrefs).toContain("/delivery");
+    expect(deliveryHrefs).toContain("/build");
+
+    // Build Studio's work surface moved out of the Platform rail section into
+    // Delivery (its model/provider config stays under Platform at
+    // /platform/ai/build-studio).
+    const platformSection = sections.find((section) => section.key === "platform");
+    expect(platformSection?.items.map((item) => item.href) ?? []).not.toContain("/build");
+  });
 });

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -24,6 +24,7 @@ export type PortalShellSectionKey =
   | "workspace"
   | "business"
   | "products"
+  | "delivery"
   | "platform"
   | "knowledge";
 
@@ -435,6 +436,27 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     },
   },
   {
+    // BI-ARCH-DELIVERY-IA: one operator home for delivery work. A hub that
+    // launches the delivery surfaces (Build Studio, work capsules, change lanes,
+    // promotions, dev loop, self-upgrade status) — it does not own a second
+    // tracking model; it links to the existing surfaces. Build Studio *config*
+    // stays under Platform (/platform/ai/build-studio); the operator path for
+    // *doing* delivery work is here (spec §6.3).
+    key: "delivery",
+    label: "Delivery",
+    path: "/delivery",
+    parentPath: "/delivery",
+    domain: "delivery",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_platform",
+    primaryOrder: 65,
+    shellNav: {
+      sectionKey: "delivery",
+      description: "Build, ship, and track delivery work from one operator home.",
+    },
+  },
+  {
     key: "build",
     label: "Build Studio",
     path: "/build",
@@ -445,7 +467,10 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     capabilityKey: "view_platform",
     primaryOrder: 70,
     shellNav: {
-      sectionKey: "platform",
+      // BI-ARCH-DELIVERY-IA: the Build Studio *work* surface belongs to the
+      // Delivery rail section (it is already domain:"delivery"); model/provider
+      // configuration stays under Platform at /platform/ai/build-studio.
+      sectionKey: "delivery",
       description: "Create and ship new capability with AI help.",
     },
   },

--- a/docs/architecture/delivery-ia.md
+++ b/docs/architecture/delivery-ia.md
@@ -1,0 +1,51 @@
+# Delivery — one operator home
+
+Status: standard (BI-ARCH-DELIVERY-IA, EP-PLATFORM-CONSOLIDATION)
+Spec: [`docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md`](../superpowers/specs/2026-06-25-platform-consolidation-spine-design.md) §6.3
+
+Delivery work used to be scattered: Build Studio under the Platform rail section, the
+backlog under Products, change lanes under `/platform/development`, and
+promotion/dev-loop/self-upgrade under `/ops`. There was no single operator home for "build,
+ship, and track."
+
+`/delivery` is that home — a **hub**, not a new system.
+
+## What it is
+
+- A new **Delivery** rail section (`apps/web/lib/govern/permissions.ts` `SHELL_SECTIONS` +
+  the `PortalShellSectionKey` union).
+- `/delivery` ([`apps/web/app/(shell)/delivery/page.tsx`](../../apps/web/app/(shell)/delivery/page.tsx))
+  — a launcher that groups the existing delivery surfaces: Build & ship (Build Studio,
+  Work control), Plan (Backlog), Track & release (Change lanes, Promotions, Dev loop,
+  Self-upgrade).
+- The **Build Studio work surface (`/build`)** moves into the Delivery rail section. It is
+  already `domain: "delivery"`; this aligns the rail grouping with the domain. Build Studio
+  **configuration** (models/providers) stays under Platform at `/platform/ai/build-studio`
+  — that is platform administration (spec §6.3).
+
+## What it deliberately is NOT
+
+- **Not a second timeline / tracking model.** Work tracking + evidence remain in change
+  lanes and the EP-UNIFIED-TRACKING work; the hub *links* to them. When the unified
+  timeline projection lands, a `/delivery/timeline` surface can render it — this PR does not
+  pre-empt that.
+- **Not a re-route.** Every link targets a route that already exists; all deep links
+  (`/build`, `/build/work`, `/ops`, `/ops/promotions`, `/ops/dev-loop`, `/ops/self-upgrade`,
+  `/platform/development/change-lanes`) are preserved.
+
+## UX / cognitive-load rationale
+
+Per Open Decision #2 this ships as a grouped route under the current shell (a new section +
+home), not a disruptive re-home of every surface. It is a net cognitive-load **reduction**
+for delivery work — one home instead of hunting across Platform/Ops/Products — and is
+operator-only (workers never see it, so no added chrome for day-to-day users). It honors
+EP-NAV-COHERENCE: Delivery is its own rail section, so moving between it and other sections
+is the rail's job (no cross-section secondary-nav teleport).
+
+## Follow-ups (operator-verified)
+
+- Move the Backlog (`/ops`) and the work-tracking surfaces fully into the Delivery section
+  once the `/ops` Runtime & Releases grouping is re-homed (coordinates with the OpsTabNav
+  groups).
+- Add `/delivery/timeline` rendering the EP-UNIFIED-TRACKING unified projection when it
+  lands.


### PR DESCRIPTION
EP-PLATFORM-CONSOLIDATION slice. Delivered locally per operator request.

## Why
Delivery work was scattered — Build Studio under Platform, Backlog under Products, change lanes under `/platform/development`, promotions/dev-loop/self-upgrade under `/ops`. No single operator home (spec §3.3 / §6.3).

## What changed
- **New "Delivery" rail section** (`PortalShellSectionKey` + `SHELL_SECTIONS`).
- **`/delivery`** — a **hub** that launches the existing delivery surfaces: Build & ship (Build Studio, Work control), Plan (Backlog), Track & release (Change lanes, Promotions, Dev loop, Self-upgrade). Every link targets an existing route — **all deep links preserved**.
- **Build Studio's work surface (`/build`)** moves into the Delivery rail section (it is already `domain: "delivery"` — this aligns the rail grouping with the domain). Build Studio **config** stays under Platform at `/platform/ai/build-studio` (spec §6.3).
- Nav-model test covers the new section + the `/build` move.
- `docs/architecture/delivery-ia.md`.

## Deliberately NOT
- **Not a second timeline.** The hub *links* to change lanes / the EP-UNIFIED-TRACKING surfaces; it owns no new tracking model. A `/delivery/timeline` can render the unified projection when it lands.
- **Conservative** per Open Decision #2 — a grouped route under the shell, not a disruptive re-home of every delivery surface (Backlog/`ops` stay put for now; follow-up).

## Verification (web worktree)
- `portal-navigation-model` test (8, incl. new Delivery-section assertion) — **pass**
- `pnpm --filter web typecheck` — **clean**

UX-Fit attested in the commit trailer (net cognitive-load reduction; operator-only; plain link cards; honors EP-NAV-COHERENCE).

## How to test
- Operators get a new **Delivery** section in the left rail → `/delivery` hub → cards to every delivery surface. Build Studio now lives under Delivery (its config stays under Platform).

EP-PLATFORM-CONSOLIDATION · spec §6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)