### PR TITLE
feat(it4it): executive conformance card on the EA home (BI-BDA1A04F)

### DIFF
--- a/apps/web/app/(shell)/ea/page.tsx
+++ b/apps/web/app/(shell)/ea/page.tsx
@@ -4,7 +4,8 @@ import { prisma } from "@dpf/db";
 import { EaTabNav } from "@/components/ea/EaTabNav";
 import { ReferenceModelSummary } from "@/components/ea/ReferenceModelSummary";
 import { CreateViewButton } from "@/components/ea/CreateViewButton";
-import { getReferenceModelsSummary } from "@/lib/ea-data";
+import { It4itConformanceCard } from "@/components/ea/It4itConformanceCard";
+import { getReferenceModelsSummary, getIt4itCoverageHeatmap } from "@/lib/ea-data";
 
 const LAYOUT_LABELS: Record<string, string> = {
   graph:    "Graph",
@@ -20,7 +21,7 @@ const SCOPE_LABELS: Record<string, string> = {
 };
 
 export default async function EaPage() {
-  const [views, models] = await Promise.all([
+  const [views, models, it4itCoverage] = await Promise.all([
     prisma.eaView.findMany({
       orderBy: [{ createdAt: "desc" }],
       select: {
@@ -35,6 +36,7 @@ export default async function EaPage() {
       },
     }),
     getReferenceModelsSummary(),
+    getIt4itCoverageHeatmap("it4it_v3_0_1").catch(() => null),
   ]);
 
   return (
@@ -65,6 +67,8 @@ export default async function EaPage() {
         </div>
         <ReferenceModelSummary models={models} />
       </section>
+
+      {it4itCoverage && <It4itConformanceCard data={it4itCoverage} />}
 
       {views.length > 0 ? (
         <>

--- a/apps/web/components/ea/It4itConformanceCard.tsx
+++ b/apps/web/components/ea/It4itConformanceCard.tsx
@@ -1,0 +1,76 @@
+// apps/web/components/ea/It4itConformanceCard.tsx
+//
+// Compact IT4IT conformance summary for the EA home (EP-IT4IT-CONFORMANCE, BI-BDA1A04F).
+// Server component: honest headline counts (no single vanity score in isolation), deep-links
+// to the full heatmap on the model page. Renders a neutral not-generated state until the
+// steward writes the baseline. Reuses report-kit StatCard; no charting dependency, no hex.
+
+import Link from "next/link";
+import { StatCard } from "@/components/ui/report-kit/StatCard";
+import type { It4itCoverageHeatmap } from "@/lib/explore/reference-model-types";
+
+const MODEL_HREF = "/ea/models/it4it_v3_0_1";
+const DISCLAIMER = "Evidence-derived coverage baseline, not an Open Group certification.";
+
+function Header() {
+  return (
+    <div className="mb-3 flex items-center justify-between gap-3">
+      <div>
+        <p className="text-xs uppercase tracking-[0.2em] text-[var(--dpf-muted)]">IT4IT Conformance</p>
+        <h2 className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">Functional Coverage</h2>
+      </div>
+      <Link
+        href={MODEL_HREF}
+        className="text-xs font-medium text-[var(--dpf-accent)] hover:text-[var(--dpf-text)]"
+      >
+        View heatmap
+      </Link>
+    </div>
+  );
+}
+
+export function It4itConformanceCard({ data }: { data: It4itCoverageHeatmap }) {
+  if (!data.hasData) {
+    return (
+      <section className="mb-6">
+        <Header />
+        <div className="rounded-lg border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm text-[var(--dpf-muted)]">
+          IT4IT coverage baseline not generated yet — run an architecture parity refresh. {DISCLAIMER}
+        </div>
+      </section>
+    );
+  }
+
+  const requiredCovered = data.summary.requiredCriteriaImplemented + data.summary.requiredCriteriaPartial;
+
+  return (
+    <section className="mb-6">
+      <Header />
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatCard
+          label="Platform coverage"
+          value={`${data.platformScore}%`}
+          hint="status-weighted"
+          href={MODEL_HREF}
+        />
+        <StatCard
+          label="Components w/ evidence"
+          value={`${data.summary.componentsWithEvidence}/${data.summary.componentsTotal}`}
+          hint={`${data.summary.implemented} implemented · ${data.summary.partial} partial`}
+        />
+        <StatCard
+          label="Required criteria covered"
+          value={`${requiredCovered}/${data.summary.requiredCriteriaTotal}`}
+          hint={`${data.summary.requiredCriteriaImplemented} implemented`}
+        />
+        <StatCard
+          label="Verified"
+          value={data.summary.verifiedCount}
+          hint={data.summary.verifiedCount > 0 ? "operator-confirmed" : "all derived"}
+          intent={data.summary.verifiedCount > 0 ? "success" : "neutral"}
+        />
+      </div>
+      <p className="mt-2 text-[10px] text-[var(--dpf-muted)]">{DISCLAIMER}</p>
+    </section>
+  );
+}

--- a/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
@@ -380,9 +380,9 @@ Refactoring tasks:
 
 ### Phase 4 - Business And Partner Artifact
 
-- Add compact overview card after the heatmap exists.
-- Add architecture review brief export with disclaimer.
-- Add product/partner documentation that explains the baseline without reproducing standard text.
+- Add compact overview card after the heatmap exists. [done, BI-BDA1A04F — `It4itConformanceCard` (server component) on the EA home (`/ea`): honest headline counts (platform coverage %, components with evidence, required criteria covered, verified count) + deep-link to the heatmap; neutral not-generated state; non-certification disclaimer; report-kit `StatCard`, no charting dependency. Defensive fetch so a missing model never breaks `/ea`.]
+- Add architecture review brief export with disclaimer. [deferred — the heatmap CSV export + disclaimer already cover the responsible-export need; a prose "brief" generator is a later enhancement.]
+- Add product/partner documentation that explains the baseline without reproducing standard text. [deferred — follow-up doc task; the spec + disclaimers define the boundary in the meantime.]
 
 ### Optional Phase 5 - Participation Matrix
 


### PR DESCRIPTION
## Phase 4 of EP-IT4IT-CONFORMANCE — executive summary

A compact, real-time IT4IT conformance summary on the EA home (`/ea`) that deep-links to the full heatmap.

- **`components/ea/It4itConformanceCard.tsx`** — server component: honest headline counts (platform coverage %, components with evidence, required criteria covered, verified count) via report-kit `StatCard`; neutral not-generated state; non-certification disclaimer; no charting dependency, no hex.
- **`/ea/page.tsx`** — defensive `getIt4itCoverageHeatmap("it4it_v3_0_1").catch(() => null)` so a missing/unseeded model never breaks the EA home; renders the card after Reference Models when present.

Refreshes automatically as the steward re-derives. Reads the same platform-scope projection as the heatmap.

### Verification
- ✅ web typecheck clean · production build (`next build`) clean.

Spec: `docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md` (Phase 4)
Epic: `EP-IT4IT-CONFORMANCE` · Item: `BI-BDA1A04F`

UX-Fit-Decision: One compact summary card (4 `StatCard`s + a "View heatmap" link) on the existing `/ea` home after Reference Models — no new route, tab, nav item, or input. Honest counts (not a lone vanity score); deep-links to the detail surface; neutral empty state; themed `--dpf-*` tokens. `human_cognitive_load`: low (read-only overview tile). `principle_decide` degenerate on that axis — decided on merits per EP-NAV-COHERENCE precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)