### PR TITLE
feat(golden-triangle): merge Priority + Assignments into one "Priority & Models" surface

### DIFF
--- a/apps/web/app/(shell)/platform/ai/assignments/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/assignments/page.test.tsx
@@ -35,6 +35,12 @@ vi.mock("@dpf/db", () => ({
     agentToolGrant: {
       groupBy: vi.fn(),
     },
+    // EP-GOLDEN-TRIANGLE surface consolidation: the page now loads the platform
+    // posture (getGoldenTrianglePosture → decisionPerspectiveProfile) for the
+    // embedded priority panel. Default to no saved posture.
+    decisionPerspectiveProfile: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
   },
 }));
 
@@ -96,7 +102,12 @@ describe("AssignmentsPage", () => {
     const { default: AssignmentsPage } = await import("./page");
     const html = renderToStaticMarkup(await AssignmentsPage({ searchParams: Promise.resolve({}) }));
 
-    expect(html).toContain("AI Coworker Model Assignment");
+    // EP-GOLDEN-TRIANGLE surface consolidation: the page is now the unified
+    // "Priority & Models" surface — the everyday priority panel on top, the
+    // model-assignment guardrails below, bindings below that. All still present.
+    expect(html).toContain("AI Coworker Priority");
+    expect(html).toContain("Everyday priority");
+    expect(html).toContain("Advanced guardrails per coworker");
     expect(html).toContain("Resource Bindings");
     expect(html).toContain("Filter bindings");
     expect(html).toContain("Refresh inferred bindings");

--- a/apps/web/app/(shell)/platform/ai/assignments/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/assignments/page.tsx
@@ -1,10 +1,17 @@
 // apps/web/app/(shell)/platform/ai/assignments/page.tsx
-// EP-INF-012: Admin UI for AI Coworker Model Assignment
+// EP-INF-012: Admin UI for AI Coworker Model Assignment.
+// EP-GOLDEN-TRIANGLE surface consolidation: this is now the single "Coworker
+// Priority & Models" surface. It hosts BOTH the everyday Cost/Quality/Time
+// priority (the platform default — formerly its own /platform/ai/priority tab,
+// which now redirects here) and the advanced per-coworker guardrails below it.
+// One surface to tune how coworkers work, instead of two competing tabs.
 
 import Link from "next/link";
 
 import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
+import { GoldenTrianglePriorityPanel } from "@/components/golden-triangle/GoldenTrianglePriorityPanel";
+import { getGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
 import { BindingBootstrapPanel } from "@/components/platform/authority/BindingBootstrapPanel";
 import { BootstrapBindingsButton } from "@/components/platform/authority/BootstrapBindingsButton";
 import { BindingDetailDrawer } from "@/components/platform/authority/BindingDetailDrawer";
@@ -132,6 +139,10 @@ export default async function AssignmentsPage({ searchParams }: Props) {
   ]);
   const bindingFilterOptions = getAuthorityBindingFilterOptions(bindingRecords);
 
+  // EP-GOLDEN-TRIANGLE: the everyday Cost/Quality/Time platform default, seeded
+  // into the priority panel embedded at the top of this surface. Fail-open.
+  const platformPosture = await getGoldenTrianglePosture({ kind: "platform" }).catch(() => null);
+
   // Build provider name lookup
   const providerNames: Record<string, string> = {};
   for (const p of providers) {
@@ -220,34 +231,56 @@ export default async function AssignmentsPage({ searchParams }: Props) {
 
       <div style={{ marginBottom: 20 }}>
         <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>
-          AI Coworker Model Assignment
+          AI Coworker Priority &amp; Models
         </h1>
         <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, maxWidth: 760, lineHeight: 1.5 }}>
-          Advanced guardrails per coworker: a minimum-quality <strong>floor</strong>, an optional pinned model, and
-          capability requirements. For the everyday Cost / Quality / Time priority — which a coworker can raise{" "}
-          <em>above</em> this floor — use{" "}
-          <Link href="/platform/ai/priority" style={{ color: "var(--dpf-accent)" }}>
-            Priority
-          </Link>{" "}
-          (or the triangle on each coworker). Changes take effect on the next routing decision.
+          One place to tune how AI coworkers work. Set the everyday Cost / Quality / Time priority — the platform
+          default every coworker inherits — then set the hard per-coworker guardrails below: a minimum-quality{" "}
+          <strong>floor</strong>, an optional pinned model, and capability requirements. Each coworker can raise its
+          own priority <em>above</em> the floor from the triangle at its composer. Changes take effect on the next
+          routing decision.
         </p>
       </div>
 
-      <div
-        style={{
-          background: "var(--dpf-surface-1)",
-          borderRadius: 8,
-          border: "1px solid var(--dpf-border)",
-          padding: 16,
-        }}
-      >
-        <AgentModelAssignmentTable
-          agents={agents}
-          providers={providerList}
-          canWrite={canWrite}
-          capabilityGapCount={capabilityGapAgents.length}
-        />
-      </div>
+      {/* Everyday priority — the platform default (Cost / Quality / Time). */}
+      <section className="space-y-3">
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
+          <div>
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Everyday priority</h2>
+            <p className="text-xs text-[var(--dpf-muted)]">
+              The platform-default Cost / Quality / Time posture. The platform compiles it into the right model,
+              effort, verification, and review/debate — shown below in plain language.
+            </p>
+          </div>
+          <Link
+            href="/platform/ai/priority/outcomes"
+            style={{ flex: "0 0 auto", fontSize: 12, color: "var(--dpf-accent)", whiteSpace: "nowrap", marginTop: 2 }}
+          >
+            See outcomes →
+          </Link>
+        </div>
+        <GoldenTrianglePriorityPanel initial={platformPosture ?? undefined} />
+      </section>
+
+      {/* Advanced guardrails — the hard per-coworker floor / pinned model. */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Advanced guardrails per coworker</h2>
+        <div
+          style={{
+            background: "var(--dpf-surface-1)",
+            borderRadius: 8,
+            border: "1px solid var(--dpf-border)",
+            padding: 16,
+          }}
+        >
+          <AgentModelAssignmentTable
+            agents={agents}
+            providers={providerList}
+            canWrite={canWrite}
+            capabilityGapCount={capabilityGapAgents.length}
+          />
+        </div>
+      </section>
 
       <section className="space-y-3">
         <div>

--- a/apps/web/app/(shell)/platform/ai/priority/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/priority/page.tsx
@@ -1,39 +1,10 @@
 // apps/web/app/(shell)/platform/ai/priority/page.tsx
-// EP-GOLDEN-TRIANGLE Slice 2/4 — the Golden Triangle priority control surface.
-// A non-technical operator sets a Cost / Quality / Time posture; the platform
-// compiles it into model tier, effort, verification, and retries. Seeds from the
-// saved WWMD/platform default (migration-free, on the platform profile).
-import Link from "next/link";
+// EP-GOLDEN-TRIANGLE surface consolidation: the Cost/Quality/Time priority control
+// merged into the single "AI Coworker Priority & Models" surface at
+// /platform/ai/assignments (everyday priority on top, advanced guardrails below).
+// This route now redirects to the canonical URL — mirrors the model-assignment shim.
+import { permanentRedirect } from "next/navigation";
 
-import { GoldenTrianglePriorityPanel } from "@/components/golden-triangle/GoldenTrianglePriorityPanel";
-import { getGoldenTrianglePosture } from "@/lib/golden-triangle/persistence";
-
-export default async function GoldenTrianglePriorityPage() {
-  const saved = await getGoldenTrianglePosture({ kind: "platform" });
-  return (
-    <div>
-      <div style={{ marginBottom: 16, display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
-        <div>
-          <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>Priority</h1>
-          <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, maxWidth: 720, lineHeight: 1.5 }}>
-            Set the Cost / Quality / Time priority for AI work — the everyday control. Pick a preset or fine-tune the
-            triangle; the platform compiles it into the right model, effort, verification, and review/debate, and shows
-            in plain language exactly what it configured. This is the platform default; each coworker can override it
-            from its own priority chip at the composer, and hard model guardrails (a tier floor, a pinned model) live in{" "}
-            <Link href="/platform/ai/assignments" style={{ color: "var(--dpf-accent)" }}>
-              Assignments
-            </Link>
-            .
-          </p>
-        </div>
-        <Link
-          href="/platform/ai/priority/outcomes"
-          style={{ flex: "0 0 auto", fontSize: 12, color: "var(--dpf-accent)", whiteSpace: "nowrap", marginTop: 2 }}
-        >
-          See outcomes →
-        </Link>
-      </div>
-      <GoldenTrianglePriorityPanel initial={saved ?? undefined} />
-    </div>
-  );
+export default function GoldenTrianglePriorityRedirect() {
+  permanentRedirect("/platform/ai/assignments");
 }

--- a/apps/web/components/golden-triangle/GoldenTrianglePriorityPanel.tsx
+++ b/apps/web/components/golden-triangle/GoldenTrianglePriorityPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
-// EP-GOLDEN-TRIANGLE Slice 2/4 — stateful host for the posture control on the
-// /platform/ai/priority surface. Seeds from the saved WWMD/platform default and
+// EP-GOLDEN-TRIANGLE Slice 2/4 — stateful host for the posture control, embedded
+// on the unified "Priority & Models" surface (/platform/ai/assignments). Seeds
+// from the saved WWMD/platform default and
 // saves edits back via the server action (migration-free; stored on the platform
 // DecisionPerspectiveProfile's autonomyPolicy JSON).
 import { useState } from "react";

--- a/apps/web/components/golden-triangle/README.md
+++ b/apps/web/components/golden-triangle/README.md
@@ -18,10 +18,13 @@ The triangle shades by balance: **green** when the three axes are centred, throu
 
 ## Surfaces
 
-- **`/platform/ai/priority`** — the full control (preview).
-- **AI coworker dialog header** — `CoworkerPriorityControl`, a compact chip + popover.
+- **`/platform/ai/assignments`** (the unified **"Priority & Models"** surface) — the full platform-default
+  control, embedded on top of the advanced per-coworker guardrails. `/platform/ai/priority` redirects here.
+- **AI coworker composer** — `CoworkerPriorityDock`, a compact chip + popover that sets the per-coworker posture.
 
-Per-scope persistence (Slice 4) and the receipt/outcome view (Slice 3b) are not wired yet; state is view-local.
+Per-scope persistence (Slice 4) and the receipt/outcome view (Slice 3b) are wired: posture is stored
+migration-free on the platform `DecisionPerspectiveProfile.autonomyPolicy`, and outcomes render at
+`/platform/ai/priority/outcomes`.
 
 ## Ease-of-use stance
 

--- a/apps/web/components/platform/platform-nav.test.ts
+++ b/apps/web/components/platform/platform-nav.test.ts
@@ -70,6 +70,23 @@ describe("platform-nav", () => {
     expect(toolsFamily.subItems.some((item) => item.label === "Built-in Tools")).toBe(true);
   });
 
+  it("merges Priority into a single 'Priority & Models' coworker-tuning tab (EP-GOLDEN-TRIANGLE)", () => {
+    // The everyday Cost/Quality/Time priority and the advanced per-coworker model
+    // guardrails were two competing tabs. They consolidated into ONE surface, so
+    // there is no standalone "Priority" tab and no separate "Assignments" tab —
+    // just "Priority & Models" pointing at the unified /platform/ai/assignments.
+    const aiFamily = getPlatformFamily("/platform/ai/assignments");
+    const labels = aiFamily.subItems.map((item) => item.label);
+
+    expect(labels).not.toContain("Priority");
+    expect(labels).not.toContain("Assignments");
+    expect(labels).toContain("Priority & Models");
+    const unified = aiFamily.subItems.find((item) => item.label === "Priority & Models");
+    expect(unified?.href).toBe("/platform/ai/assignments");
+    // No subItem still points at the now-redirect-only /platform/ai/priority route.
+    expect(aiFamily.subItems.some((item) => item.href === "/platform/ai/priority")).toBe(false);
+  });
+
   it("removes redirect-only audit items from the AI family", () => {
     const aiFamily = getPlatformFamily("/platform/ai");
 

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -54,12 +54,14 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
     matchPrefixes: ["/platform/ai"],
     subItems: [
       { label: "Overview", href: "/platform/ai" },
-      // EP-GOLDEN-TRIANGLE: the Cost/Quality/Time priority surface. Without this
-      // tab the page was reachable only by typing /platform/ai/priority.
-      { label: "Priority", href: "/platform/ai/priority" },
       { label: "Operations Map", href: "/platform/ai/operations-map" },
       { label: "Capacity Continuity", href: "/platform/ai/capacity-continuity" },
-      { label: "Assignments", href: "/platform/ai/assignments" },
+      // EP-GOLDEN-TRIANGLE surface consolidation: the everyday Cost/Quality/Time
+      // priority and the advanced per-coworker model guardrails were two competing
+      // tabs ("Priority" + "Assignments"). They merged into ONE surface — everyday
+      // priority on top, advanced guardrails below — so there's one place to tune
+      // how coworkers work. /platform/ai/priority now redirects here.
+      { label: "Priority & Models", href: "/platform/ai/assignments" },
       { label: "Prompts", href: "/platform/ai/prompts" },
       { label: "Skills", href: "/platform/ai/skills" },
       // No "Capability Needs" tab: coworker capability needs converged into the Backlog

--- a/apps/web/lib/actions/golden-triangle.ts
+++ b/apps/web/lib/actions/golden-triangle.ts
@@ -75,7 +75,7 @@ export async function saveGoldenTrianglePlatformDefault(
 ): Promise<{ ok: boolean }> {
   await requirePlatformAdmin();
   const ok = await setGoldenTrianglePosture({ kind: "platform" }, preference);
-  if (ok) revalidatePath("/platform/ai/priority");
+  if (ok) revalidatePath("/platform/ai/assignments");
   return { ok };
 }
 
@@ -93,7 +93,7 @@ export async function saveGoldenTriangleOrgDefault(
   const org = await prisma.organization.findFirst({ select: { id: true } });
   if (!org) throw new Error("No organization found");
   const ok = await setGoldenTrianglePosture({ kind: "organization", organizationId: org.id }, preference);
-  if (ok) revalidatePath("/platform/ai/priority");
+  if (ok) revalidatePath("/platform/ai/assignments");
   return { ok };
 }
 

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -4614,7 +4614,8 @@
         "priority"
       ],
       "dynamicParams": [],
-      "file": "apps/web/app/(shell)/platform/ai/priority/page.tsx"
+      "file": "apps/web/app/(shell)/platform/ai/priority/page.tsx",
+      "redirectTo": "/platform/ai/assignments"
     },
     {
       "routePath": "/platform/ai/priority/outcomes",

--- a/apps/web/lib/golden-triangle/dispatch.ts
+++ b/apps/web/lib/golden-triangle/dispatch.ts
@@ -8,7 +8,7 @@
 //     so dispatch proceeds exactly as it does today.
 //   • Balanced-inert — a Balanced (no-op) posture produces no overrides and
 //     returns null, so merging this in is byte-identical to flag-off until a
-//     non-Balanced default is explicitly chosen on /platform/ai/priority.
+//     non-Balanced default is explicitly chosen on the Priority & Models surface.
 // It only FEEDS routing (the compiler never re-implements routing).
 import { compileGoldenTrianglePolicy } from "./compile";
 import { applyPostureToRouteContext, type AppliedPosture } from "./compose";

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -575,16 +575,11 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     destinationKind: "section-page",
     capabilityKey: "view_platform",
   },
-  {
-    key: "platform-ai-priority",
-    label: "Priority",
-    path: "/platform/ai/priority",
-    parentPath: "/platform/ai",
-    domain: "platform",
-    audienceModes: ["operator"],
-    destinationKind: "section-page",
-    capabilityKey: "view_platform",
-  },
+  // EP-GOLDEN-TRIANGLE surface consolidation: no "platform-ai-priority" record —
+  // /platform/ai/priority is now a redirect-only shim into the unified
+  // "Priority & Models" surface (mirrors /platform/ai/model-assignment, which
+  // likewise has no nav record). Redirect-only routes carry neither a nav subItem
+  // nor a record.
   {
     key: "platform-ai-capacity-continuity",
     label: "Capacity Continuity",
@@ -597,7 +592,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   },
   {
     key: "platform-ai-assignments",
-    label: "Assignments",
+    label: "Priority & Models",
     path: "/platform/ai/assignments",
     parentPath: "/platform/ai",
     domain: "platform",

--- a/docs/design/2026-06-25-coworker-work-orchestration.md
+++ b/docs/design/2026-06-25-coworker-work-orchestration.md
@@ -81,3 +81,35 @@ backstop, instead of hunting across Priority + Assignments (+ scattered delibera
    full deliberation engine, mirroring the build precedent.
 5. **Surface consolidation** *(UI)* — fold Assignments into the Priority surface as the Advanced
    guardrail layer; show the rigor ladder on the triangle.
+
+## Implementation status — 2026-06-25
+
+All five slices shipped (plus the autonomous half of slice 4):
+
+- **Slice 1 — compiler ladder** ✅ `#2341`. `compile.ts` emits `deliberationPattern`
+  none → `review` → `debate` (debate at `qualityWeight ≥ 0.85`); Balanced inert.
+- **Slice 2 — reconcile the overlap** ✅ `#2341`. Posture owns `budgetClass` in `routed-inference.ts`;
+  tier floor max-merges. No more silent override.
+- **Slice 3 — leverage review (interactive)** ✅ `#2344`, unified at `executeAutonomousAgenticLoop` `#2347`.
+- **Slice 4 — leverage review/debate** ✅. The unified seam (`#2347`) is the SINGLE path for chat
+  *and* autonomous; the debate pass (`#2353`) gives a `debate` posture a real debate (steelman
+  for/against → synthesize), distinct from review. **Mechanism note:** the synchronous inline pass
+  is the leverage for *coworker turns* (a coworker reply has no build artifact for the multi-agent
+  `startDeliberation` engine to debate, and that engine runs 10–30 min — unsuited to a chat turn);
+  the full engine stays the *build-phase* mechanism.
+- **Slice 5 — surface consolidation** ✅ *(this change)*. The everyday Cost/Quality/Time priority
+  and the advanced per-coworker model guardrails are now **one surface**: `/platform/ai/assignments`,
+  re-titled **"Priority & Models"** — everyday priority panel on top, advanced guardrails below.
+  The standalone **Priority** tab is gone and `/platform/ai/priority` **redirects** here.
+
+  **Host decision — Assignments-as-host (not Priority-as-host).** The design sketch said "fold
+  Assignments into the Priority surface", but the realized direction is the reverse, for three
+  concrete reasons: (1) the Assignments page already carries the heavy server data (model-config
+  table, authority bindings, capability-gap detection) — embedding the light priority *panel* there
+  moves far less code than relocating all of that into the Priority page; (2) `/platform/ai/model-assignment`
+  **already** `permanentRedirect`s to `/assignments`, establishing it as the canonical model-tuning
+  URL — Priority joining it is consistent; (3) redirect-only routes in this codebase carry neither a
+  nav subItem nor a `PortalNavRecord` (the model-assignment precedent), so `/priority` collapses to a
+  clean shim. The doctrine is unchanged — **one surface, two layers** (everyday priority + advanced
+  guardrails); only the hosting URL differs from the sketch. Net: `AI Operations` drops from 9 tabs
+  to 8, and a coworker's work is managed from the **triangle at its composer** + this one backstop.

--- a/docs/user-guide/platform/ai-operations.md
+++ b/docs/user-guide/platform/ai-operations.md
@@ -12,7 +12,7 @@ order: 2
 - `/platform/ai/operations-map`
 - `/platform/ai/capability-needs`
 - `/platform/ai/history`
-- `/platform/ai/assignments`
+- `/platform/ai/assignments` — **Priority & Models**: the everyday Cost / Quality / Time priority (platform default) and the advanced per-coworker guardrails on one surface (`/platform/ai/priority` redirects here)
 
 ## Workflow
 
@@ -20,7 +20,7 @@ order: 2
 2. Review Capacity Continuity when paid AI capacity is idle, blocked, or expected to keep working during holidays, vacations, business events, after-hours windows, or owner inactivity.
 3. Review Capability Needs when coworkers surface missing tools, prompts, permissions, or product gaps that need governed follow-up.
 4. Review history when a result looks wrong, slow, or inconsistent.
-5. Adjust assignments only after you understand whether the problem is role design, model selection, tool access, standing orders, or calendar state.
+5. Adjust **Priority & Models** only after you understand whether the problem is role design, model selection, tool access, standing orders, or calendar state. Set the everyday Cost / Quality / Time priority at the top of that surface (or per coworker from the triangle at its composer); reserve the advanced guardrails below — a tier floor, a pinned model — for hard limits the priority must not cross.
 
 ## What To Watch
 


### PR DESCRIPTION
**The literal "reduction of surfaces" from the coworker-work-orchestration goal (slice 5).**

The everyday Cost / Quality / Time **priority** and the advanced per-coworker model **guardrails** were two competing tabs in AI Operations. They now live on **one surface** — `/platform/ai/assignments`, re-titled **"Priority & Models"**:

- **Everyday priority** on top — the Golden Triangle platform default + "See outcomes" link.
- **Advanced guardrails** below — tier floor, pinned model, capability requirements.

The standalone **Priority** tab is gone; `/platform/ai/priority` **redirects** here (mirroring the existing `model-assignment` shim). **AI Operations drops 9 → 8 tabs.** A coworker's work is now managed from the **triangle at its composer** + this one backstop.

**Host = Assignments (not Priority).** The assignments page already carries the heavy model-config/bindings data, `/platform/ai/model-assignment` already redirects there, and redirect-only routes carry no nav record — so `/priority` collapses to a clean shim with minimal code movement. Doctrine unchanged: one surface, two layers.

### Verification
- `37` nav/manifest tests (`platform-nav`, `portal-navigation-model`, `navigation-inventory-gate`, `route-extract`) + `93` golden-triangle tests green.
- Web `tsc` clean (after Prisma regen — the only errors were stale-client artifacts from federation/SIEM models, unrelated).
- Route-manifest regenerated; records `/priority → redirectTo /assignments`.
- New nav test locks the merge (no "Priority"/"Assignments" tabs; single "Priority & Models" → `/assignments`).

UX-Fit-Decision and Process-Spine-Decision attestations are in the commit trailer; docs updated in the same change (design note slice status, AI-operations user guide, component README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
