### PR TITLE
refactor(mcp): scoped tool-pack foundation + first pack (BI-ARCH-TOOLPACKS)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -36,12 +36,8 @@ import {
   DELIBERATION_STRATEGY_PROFILES,
   DELIBERATION_TRIGGER_SOURCES,
 } from "@/lib/deliberation/types";
+import { deliberateOnMcpHandler } from "@/lib/mcp-tools-deliberation";
 import {
-  DELIBERATION_TOOLS,
-  deliberateOnMcpHandler,
-} from "@/lib/mcp-tools-deliberation";
-import {
-  SIEM_TOOLS,
   querySecurityEventsHandler,
   queryDetectionsHandler,
   getSecurityCaseHandler,
@@ -50,6 +46,10 @@ import {
   proposeDetectionTuningHandler,
   proposeResponseHandler,
 } from "@/lib/mcp-tools-siem";
+// BI-ARCH-TOOLPACKS: deliberation + SIEM tool DEFINITIONS now compose from the
+// first scoped tool pack (the handlers above stay wired into the executeTool
+// switch; dispatch migrates onto the pack registry in a follow-up).
+import { deliberationSiemPack } from "@/lib/mcp/packs/deliberation-siem-pack";
 import {
   createLicenseReadinessIssue,
   saveLicensingInvestigationFinding,
@@ -441,8 +441,7 @@ const WORK_CAPSULE_TOOL_ENUMS = workCapsuleToolEnums();
 const RUNTIME_COORDINATION_TOOL_ENUMS = runtimeCoordinationToolEnums();
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
-  ...DELIBERATION_TOOLS,
-  ...SIEM_TOOLS,
+  ...deliberationSiemPack.definitions,
   {
     name: "create_backlog_item",
     description: "Create a new backlog item in the ops backlog. Use this tool to add new items — do NOT use update_backlog_item for items that do not exist yet. New items default to status=triaging; supply status+triageOutcome together only when explicitly skipping triage (e.g. Build Studio brief intake). When triageOutcome=build, effortSize is required.",

--- a/apps/web/lib/mcp/packs/deliberation-siem-pack.ts
+++ b/apps/web/lib/mcp/packs/deliberation-siem-pack.ts
@@ -1,0 +1,50 @@
+// First scoped tool pack — BI-ARCH-TOOLPACKS.
+//
+// Deliberation + SIEM are the cleanest first extraction: both already live in
+// self-contained sibling modules (mcp-tools-deliberation.ts / mcp-tools-siem.ts)
+// that mcp-tools.ts spreads into PLATFORM_TOOLS and dispatches by name. This pack
+// bundles their definitions, handlers, and grant metadata behind the ToolPack
+// shape so mcp-tools.ts composes the definitions from here instead of importing
+// the two modules directly. Grants mirror agent-grants.ts TOOL_TO_GRANTS exactly
+// (asserted by tool-registry.test.ts).
+
+import {
+  DELIBERATION_TOOLS,
+  deliberateOnMcpHandler,
+} from "@/lib/mcp-tools-deliberation";
+import {
+  SIEM_TOOLS,
+  getSecurityCaseHandler,
+  openSecurityCaseHandler,
+  proposeDetectionTuningHandler,
+  proposeResponseHandler,
+  queryDetectionsHandler,
+  querySecurityEventsHandler,
+  updateSecurityCaseHandler,
+} from "@/lib/mcp-tools-siem";
+import type { ToolPack } from "../tool-pack";
+
+export const deliberationSiemPack: ToolPack = {
+  packId: "deliberation-siem",
+  definitions: [...DELIBERATION_TOOLS, ...SIEM_TOOLS],
+  handlers: {
+    deliberate_on: deliberateOnMcpHandler,
+    query_security_events: querySecurityEventsHandler,
+    query_detections: queryDetectionsHandler,
+    get_security_case: getSecurityCaseHandler,
+    open_security_case: openSecurityCaseHandler,
+    update_security_case: updateSecurityCaseHandler,
+    propose_detection_tuning: proposeDetectionTuningHandler,
+    propose_response: proposeResponseHandler,
+  },
+  grants: {
+    deliberate_on: ["deliberation_create"],
+    query_security_events: ["siem_read"],
+    query_detections: ["siem_read"],
+    get_security_case: ["siem_read"],
+    open_security_case: ["siem_investigate"],
+    update_security_case: ["siem_investigate"],
+    propose_detection_tuning: ["siem_tune"],
+    propose_response: ["incident_respond"],
+  },
+};

--- a/apps/web/lib/mcp/tool-pack.ts
+++ b/apps/web/lib/mcp/tool-pack.ts
@@ -1,0 +1,41 @@
+// Scoped MCP tool pack — BI-ARCH-TOOLPACKS.
+//
+// `apps/web/lib/mcp-tools.ts` is a 16k-line mega-module that both declares the
+// full PLATFORM_TOOLS registry and dispatches every tool. The spec (§6.2) calls
+// for splitting it into domain-owned "tool packs", each owning its tool
+// definitions, handler map, and grant metadata — with mcp-tools.ts reduced to a
+// thin composition layer over time. This is the shape those packs converge on.
+//
+// A pack bundles the three things that previously lived in three different
+// places (definitions inline in mcp-tools.ts, handlers in a sibling module,
+// grants in agent-grants.ts), so domain metadata travels together. Grant gating
+// still resolves through agent-grants.ts `TOOL_TO_GRANTS`; the pack mirrors it so
+// a test can assert the two never drift (the R3 authority-control safeguard).
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+
+/**
+ * A tool handler, with the context shape common to every dispatch site
+ * (`routeContext` + `threadId`). Handlers may accept additional optional context
+ * fields; this is the structural minimum the registry passes through.
+ */
+export type ToolPackHandler = (
+  params: Record<string, unknown>,
+  userId: string,
+  context?: { routeContext?: string; threadId?: string },
+) => Promise<ToolResult>;
+
+export type ToolPack = {
+  /** Domain identifier, e.g. "deliberation-siem", "backlog", "work-capsules". */
+  packId: string;
+  /** Tool definitions this pack owns (name, schema, requiredCapability, …). */
+  definitions: ToolDefinition[];
+  /** Tool name -> handler. The registry composes these for dispatch. */
+  handlers: Record<string, ToolPackHandler>;
+  /**
+   * Agent-grant categories per tool, mirroring agent-grants.ts `TOOL_TO_GRANTS`
+   * (which stays the gating source). Co-located so the metadata travels with the
+   * pack; `tool-registry.test.ts` asserts it matches the gating source.
+   */
+  grants: Record<string, readonly string[]>;
+};

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { DELIBERATION_TOOLS } from "@/lib/mcp-tools-deliberation";
+import { SIEM_TOOLS } from "@/lib/mcp-tools-siem";
+import { PLATFORM_TOOLS } from "@/lib/mcp-tools";
+import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
+
+import { deliberationSiemPack } from "./packs/deliberation-siem-pack";
+import { composeToolPacks } from "./tool-registry";
+
+// BI-ARCH-TOOLPACKS parity guard: the first extracted pack must stay
+// behaviourally identical to the inline registration it replaced.
+
+describe("deliberation-siem tool pack", () => {
+  it("bundles exactly the deliberation + SIEM definitions", () => {
+    const expected = [...DELIBERATION_TOOLS, ...SIEM_TOOLS].map((t) => t.name).sort();
+    expect(deliberationSiemPack.definitions.map((t) => t.name).sort()).toEqual(expected);
+  });
+
+  it("has a handler for every definition it owns", () => {
+    for (const def of deliberationSiemPack.definitions) {
+      expect(deliberationSiemPack.handlers[def.name], def.name).toBeTypeOf("function");
+    }
+  });
+
+  it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
+    for (const [name, grants] of Object.entries(deliberationSiemPack.grants)) {
+      expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
+    }
+  });
+
+  it("keeps every pack tool present in the live PLATFORM_TOOLS registry", () => {
+    const platformNames = new Set(PLATFORM_TOOLS.map((t) => t.name));
+    for (const def of deliberationSiemPack.definitions) {
+      expect(platformNames.has(def.name), def.name).toBe(true);
+    }
+  });
+});
+
+describe("composeToolPacks", () => {
+  it("composes definitions + handler/grant lookup from packs", () => {
+    const registry = composeToolPacks([deliberationSiemPack]);
+    expect(registry.definitions).toHaveLength(deliberationSiemPack.definitions.length);
+    expect(registry.getHandler("deliberate_on")).toBeTypeOf("function");
+    expect(registry.getHandler("not_a_tool")).toBeUndefined();
+    expect(registry.getGrants("open_security_case")).toEqual(["siem_investigate"]);
+  });
+
+  it("rejects the same tool name claimed by two packs", () => {
+    expect(() => composeToolPacks([deliberationSiemPack, deliberationSiemPack])).toThrow(
+      /Duplicate tool/,
+    );
+  });
+});

--- a/apps/web/lib/mcp/tool-registry.ts
+++ b/apps/web/lib/mcp/tool-registry.ts
@@ -1,0 +1,49 @@
+// Tool pack registry — BI-ARCH-TOOLPACKS.
+//
+// Composes scoped tool packs into the flat surfaces mcp-tools.ts consumes: the
+// combined definition list (spread into PLATFORM_TOOLS) and a name -> handler
+// lookup (the dispatch path the executeTool switch migrates onto pack by pack).
+// Composition fails fast on a duplicate tool name across packs so two packs can
+// never silently claim the same tool.
+
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import type { ToolPack, ToolPackHandler } from "./tool-pack";
+
+export type ToolRegistry = {
+  packs: ToolPack[];
+  definitions: ToolDefinition[];
+  toolNames: string[];
+  getHandler: (toolName: string) => ToolPackHandler | undefined;
+  getGrants: (toolName: string) => readonly string[] | undefined;
+};
+
+export function composeToolPacks(packs: ToolPack[]): ToolRegistry {
+  const definitions: ToolDefinition[] = [];
+  const handlers: Record<string, ToolPackHandler> = {};
+  const grants: Record<string, readonly string[]> = {};
+  const seen = new Set<string>();
+
+  for (const pack of packs) {
+    for (const def of pack.definitions) {
+      if (seen.has(def.name)) {
+        throw new Error(`Duplicate tool "${def.name}" registered across tool packs`);
+      }
+      seen.add(def.name);
+      definitions.push(def);
+    }
+    for (const [name, handler] of Object.entries(pack.handlers)) {
+      handlers[name] = handler;
+    }
+    for (const [name, grant] of Object.entries(pack.grants)) {
+      grants[name] = grant;
+    }
+  }
+
+  return {
+    packs,
+    definitions,
+    toolNames: definitions.map((def) => def.name),
+    getHandler: (toolName) => handlers[toolName],
+    getGrants: (toolName) => grants[toolName],
+  };
+}

--- a/docs/architecture/mcp-tool-packs.md
+++ b/docs/architecture/mcp-tool-packs.md
@@ -1,0 +1,59 @@
+# Scoped MCP Tool Packs
+
+Status: standard, in migration (BI-ARCH-TOOLPACKS, EP-PLATFORM-CONSOLIDATION)
+Spec: [`docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md`](../superpowers/specs/2026-06-25-platform-consolidation-spine-design.md) §6.2
+
+`apps/web/lib/mcp-tools.ts` is a ~17k-line mega-module: it declares the entire
+`PLATFORM_TOOLS` registry (251 tools) and dispatches every one through a single giant
+`executeTool` switch. That single growing surface is a product risk, not just a style one —
+the local-model path can only carry ~15 tools (`LOCAL_FALLBACK_MAX_TOOLS`), so an unscoped
+registry that grows with every AI capability erodes the local economy.
+
+The target is **domain-owned tool packs** that compose into the registry, with
+`mcp-tools.ts` reduced to a thin composition layer over time.
+
+## The shape
+
+A [`ToolPack`](../../apps/web/lib/mcp/tool-pack.ts) bundles the three things that used to
+live in three places:
+
+- **definitions** — the `ToolDefinition[]` (was inline in `mcp-tools.ts`),
+- **handlers** — `name -> handler` (was a sibling module + a switch case),
+- **grants** — agent-grant categories per tool (was only in `agent-grants.ts`).
+
+[`composeToolPacks`](../../apps/web/lib/mcp/tool-registry.ts) merges packs into the flat
+surfaces `mcp-tools.ts` consumes (the combined definition list + a `name -> handler`
+lookup) and throws on a duplicate tool name across packs.
+
+## Migration discipline (parity first)
+
+Extraction is incremental and **parity-preserving** — never a behavior change:
+
+1. **Definitions first.** A pack owns the definitions; `mcp-tools.ts` spreads
+   `pack.definitions` into `PLATFORM_TOOLS`. The resulting array is identical, so tool
+   discovery, grant filtering, phase/route exposure, and the local-fallback budget are
+   unchanged.
+2. **Dispatch next.** The `executeTool` switch migrates onto `registry.getHandler(name)`
+   pack by pack. Until a pack's dispatch is migrated, its handlers stay wired in the switch.
+3. **Authority travels with the handler (R3).** Grant gating still resolves through
+   `agent-grants.ts` `TOOL_TO_GRANTS` (the single gating source). The pack mirrors those
+   entries so the metadata lives with the pack, and `tool-registry.test.ts` asserts the two
+   never drift. Tool definitions carry their own `requiredCapability`, so moving a
+   definition into a pack moves its capability gate with it.
+
+## First pack
+
+[`deliberation-siem-pack`](../../apps/web/lib/mcp/packs/deliberation-siem-pack.ts) — the
+Deliberation + SIEM tools were the cleanest first extraction (already self-contained
+sibling modules with their own handlers). `mcp-tools.ts` now composes their definitions
+from the pack; their dispatch still runs through the existing switch cases (step 2 is the
+follow-up). `tool-registry.test.ts` proves: the pack bundles exactly those definitions, a
+handler exists per definition, the grant metadata matches `TOOL_TO_GRANTS`, and every pack
+tool is still present in the live `PLATFORM_TOOLS`.
+
+## Next packs
+
+Per the spec, the highest-value next extractions are the largest cohesive clusters:
+`backlog` + `build-evidence`, `work-capsules` + `runtime-coordination`, `sandbox`, then
+`wiki/knowledge`. Each follows the same parity-first discipline and keeps the existing
+MCP-route, grant-filter, and `mcp-governed-execute` tests green.


### PR DESCRIPTION
EP-PLATFORM-CONSOLIDATION slice (XLarge BI — this is the parity-proven foundation + first pack). Delivered locally per operator request.

## Why
`apps/web/lib/mcp-tools.ts` is a ~17k-line mega-module: it declares all 251 tools (`PLATFORM_TOOLS`) and dispatches every one through one giant `executeTool` switch. That unscoped, ever-growing surface is a product risk — the local-model path can only carry ~15 tools (`LOCAL_FALLBACK_MAX_TOOLS`) (spec §3.2 / §6.2).

## What changed (parity-first — zero behavioral change)
- **`lib/mcp/tool-pack.ts`** — the `ToolPack` shape: definitions + handlers + grant metadata bundled together (they used to live in three places).
- **`lib/mcp/tool-registry.ts`** — `composeToolPacks()` merges packs into the flat definition list + a `name -> handler` lookup; throws on a duplicate tool name across packs.
- **`lib/mcp/packs/deliberation-siem-pack.ts`** — the first pack (Deliberation + SIEM — already self-contained sibling modules, the cleanest extraction).
- **`mcp-tools.ts`** — `PLATFORM_TOOLS` now spreads `deliberationSiemPack.definitions` instead of importing the two definition arrays directly. **The array is identical and the `executeTool` switch is unchanged** (dispatch still runs the same handlers). Dispatch migrates onto the registry pack-by-pack in a follow-up.
- **`lib/mcp/tool-registry.test.ts`** — parity guard.
- **`docs/architecture/mcp-tool-packs.md`** — the pattern + the parity-first migration discipline.

## Authority controls (R3)
Grant gating still resolves through `agent-grants.ts` `TOOL_TO_GRANTS` (the single gating source). The pack **mirrors** those entries and the test asserts **no drift**. Tool definitions carry their own `requiredCapability`, so the capability gate travels with the definition.

## Verification (web worktree, `prisma generate`)
- `pnpm --filter web typecheck` — **clean**
- `tool-registry` (6) + `mcp-tools` (34, tool visibility/grant filtering) + `mcp-tools-siem` + `mcp-tools-deliberation` — **all pass**

## Scope
This is the foundation + first pack of an XLarge BI. Further domain packs (backlog/build-evidence, work-capsules/runtime, sandbox, wiki/knowledge) and the dispatch-via-registry migration follow the same parity discipline, each keeping the MCP-route + grant-filter + `mcp-governed-execute` tests green.

EP-PLATFORM-CONSOLIDATION · spec §6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)