### PR TITLE
feat(it4it): IT4IT participation matrix grid (BI-D51A5A4A)

### DIFF
--- a/apps/web/app/(shell)/ea/models/[slug]/page.tsx
+++ b/apps/web/app/(shell)/ea/models/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { ReferenceModelElementTree } from "@/components/ea/ReferenceModelElement
 import { ReferenceProjectionActions } from "@/components/ea/ReferenceProjectionActions";
 import { ReferenceProposalQueue } from "@/components/ea/ReferenceProposalQueue";
 import { It4itCoverageHeatmap } from "@/components/ea/It4itCoverageHeatmap";
+import { It4itParticipationGrid } from "@/components/ea/It4itParticipationGrid";
 import { projectReferenceModelValueStreams } from "@/lib/actions/ea";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
@@ -14,6 +15,7 @@ import {
   getReferenceModelElements,
   getReferenceModelPortfolioRollup,
   getIt4itCoverageHeatmap,
+  getIt4itParticipationGrid,
 } from "@/lib/ea-data";
 
 type Props = {
@@ -24,11 +26,12 @@ export default async function ReferenceModelPage({ params }: Props) {
   const { slug } = await params;
 
   try {
-    const [detail, rollup, elements, coverage, session] = await Promise.all([
+    const [detail, rollup, elements, coverage, participation, session] = await Promise.all([
       getReferenceModelDetail(slug),
       getReferenceModelPortfolioRollup(slug),
       getReferenceModelElements(slug),
       getIt4itCoverageHeatmap(slug),
+      getIt4itParticipationGrid(slug),
       auth(),
     ]);
 
@@ -96,6 +99,8 @@ export default async function ReferenceModelPage({ params }: Props) {
         <ReferenceModelElementTree elements={elements} />
 
         {coverage.groups.length > 0 && <It4itCoverageHeatmap data={coverage} canOverride={canOverride} />}
+
+        {participation.hasData && <It4itParticipationGrid data={participation} />}
 
         <section className="mb-6">
           <div className="mb-3">

--- a/apps/web/components/ea/It4itParticipationGrid.tsx
+++ b/apps/web/components/ea/It4itParticipationGrid.tsx
@@ -1,0 +1,104 @@
+// apps/web/components/ea/It4itParticipationGrid.tsx
+//
+// IT4IT participation matrix (EP-IT4IT-CONFORMANCE, BI-D51A5A4A). A 2-D cross-grid of the
+// 35 functional components (rows, grouped by capability group) x the 7 value streams
+// (columns), from the seeded FC Participation Matrix, tinted by each component's coverage
+// status. Server component, read-only; the nested-tile heatmap remains the primary view.
+// Participation is shown by a filled cell vs a middot (not colour alone); colour adds the
+// coverage status. Tokens only, no hex.
+
+import { Fragment } from "react";
+import { intentStyle, resolveIntent } from "@/components/ui/report-kit/statusColors";
+import type { It4itParticipationGrid as It4itParticipationGridData } from "@/lib/explore/it4it-participation-view";
+
+export function It4itParticipationGrid({ data }: { data: It4itParticipationGridData }) {
+  if (!data.hasData) return null;
+
+  return (
+    <section className="mb-6">
+      <div className="mb-3">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">IT4IT Participation Matrix</h2>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          Which functional components participate in each value stream (IT4IT FC Participation Matrix),
+          tinted by coverage status. Filled cell = participates.
+        </p>
+      </div>
+      <div className="overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+        <table className="w-full border-collapse text-xs">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 bg-[var(--dpf-surface-1)] px-2 py-2 text-left font-medium text-[var(--dpf-muted)]">
+                Functional component
+              </th>
+              {data.streams.map((s) => (
+                <th key={s} className="px-2 py-2 text-center font-medium text-[var(--dpf-muted)] whitespace-nowrap">
+                  {s}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.groups.map((group) => (
+              <Fragment key={group.group}>
+                <tr>
+                  <td
+                    colSpan={data.streams.length + 1}
+                    className="bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]"
+                  >
+                    {group.group}
+                  </td>
+                </tr>
+                {group.rows.map((row) => {
+                  const intent = resolveIntent("it4itCoverage", row.status);
+                  const fg = intentStyle(intent).fg;
+                  const neutral = intent === "neutral";
+                  return (
+                    <tr key={row.componentId} className="border-t border-[var(--dpf-border)]">
+                      <td className="sticky left-0 z-10 bg-[var(--dpf-surface-1)] px-2 py-1 whitespace-nowrap text-[var(--dpf-text)]">
+                        <span className="inline-flex items-center gap-1.5">
+                          <span
+                            className="inline-block h-2 w-2 rounded-full"
+                            style={{ background: neutral ? "var(--dpf-border)" : fg }}
+                            aria-hidden="true"
+                          />
+                          {row.componentName}
+                        </span>
+                      </td>
+                      {data.streams.map((s) => {
+                        const participates = row.participatesIn[s];
+                        return (
+                          <td key={s} className="px-2 py-1 text-center">
+                            {participates ? (
+                              <span
+                                title={`${row.componentName} participates in ${s} (coverage: ${row.status.replace("_", " ")})`}
+                                className="inline-block h-3 w-3 rounded-sm align-middle"
+                                style={{
+                                  background: neutral
+                                    ? "var(--dpf-surface-2)"
+                                    : `color-mix(in srgb, ${fg} 55%, transparent)`,
+                                  border: `0.5px solid ${neutral ? "var(--dpf-border)" : `color-mix(in srgb, ${fg} 70%, transparent)`}`,
+                                }}
+                              />
+                            ) : (
+                              <span className="text-[var(--dpf-muted)] opacity-30" aria-hidden="true">
+                                ·
+                              </span>
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-2 text-[10px] text-[var(--dpf-muted)]">
+        Cell = component participates in that value stream; colour = the component&apos;s coverage status.
+        Evidence-derived baseline, not an Open Group certification.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/lib/explore/ea-data.ts
+++ b/apps/web/lib/explore/ea-data.ts
@@ -1,6 +1,11 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
 import { shapeIt4itCoverageHeatmap } from "./it4it-coverage-view";
+import {
+  shapeIt4itParticipationGrid,
+  type It4itParticipationGrid,
+  type It4itStageParticipationRow,
+} from "./it4it-participation-view";
 import type { SerializedViewElement, SerializedEdge, CanvasState } from "./ea-types";
 import type {
   CoverageStatus,
@@ -413,5 +418,40 @@ export const getIt4itCoverageHeatmap = cache(
     ]);
 
     return shapeIt4itCoverageHeatmap({ slug, modelName: model.name, elements, assessments });
+  },
+);
+
+// ── IT4IT participation grid (EP-IT4IT-CONFORMANCE, BI-D51A5A4A) ──────────────
+// Cross-tabs functional components against the 7 value streams using the seeded FC
+// Participation Matrix (participationByColumn on each value-stream stage), tinted by each
+// component's coverage status. Grouping/collapse math lives in it4it-participation-view.
+export const getIt4itParticipationGrid = cache(
+  async (slug: string): Promise<It4itParticipationGrid> => {
+    const heatmap = await getIt4itCoverageHeatmap(slug);
+    const components = heatmap.groups.flatMap((g) => g.components);
+
+    const model = await prisma.eaReferenceModel.findUnique({ where: { slug }, select: { id: true } });
+    if (!model) return { hasData: false, streams: [], groups: [] };
+
+    const elements = await prisma.eaReferenceModelElement.findMany({
+      where: { modelId: model.id, kind: { in: ["value_stream", "value_stream_stage"] } },
+      select: { id: true, kind: true, name: true, parentId: true, properties: true },
+    });
+
+    const streamNameById = new Map<string, string>();
+    for (const e of elements) if (e.kind === "value_stream") streamNameById.set(e.id, e.name);
+    const valueStreams = elements.filter((e) => e.kind === "value_stream").map((e) => e.name);
+
+    const stageParticipation: It4itStageParticipationRow[] = [];
+    for (const e of elements) {
+      if (e.kind !== "value_stream_stage" || !e.parentId) continue;
+      const stream = streamNameById.get(e.parentId);
+      if (!stream) continue;
+      const props =
+        (e.properties as { participationByColumn?: Record<string, string | null> } | null) ?? {};
+      stageParticipation.push({ stream, participation: props.participationByColumn ?? {} });
+    }
+
+    return shapeIt4itParticipationGrid({ components, valueStreams, stageParticipation });
   },
 );

--- a/apps/web/lib/explore/it4it-participation-view.test.ts
+++ b/apps/web/lib/explore/it4it-participation-view.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { shapeIt4itParticipationGrid, type It4itStageParticipationRow } from "./it4it-participation-view";
+import type { It4itComponentCoverage } from "./reference-model-types";
+
+function component(over: Partial<It4itComponentCoverage> & { id: string; name: string; capabilityGroup: string }): It4itComponentCoverage {
+  return {
+    status: "partial",
+    score: 50,
+    confidence: null,
+    criteriaCount: 0,
+    requiredCriteriaCount: 0,
+    criteria: [],
+    ...over,
+  };
+}
+
+const components: It4itComponentCoverage[] = [
+  component({ id: "ea", name: "Enterprise Architecture", capabilityGroup: "Strategy to Portfolio", status: "implemented", score: 100 }),
+  component({ id: "pr", name: "Problem", capabilityGroup: "Detect to Correct", status: "partial", score: 65 }),
+];
+
+const stages: It4itStageParticipationRow[] = [
+  { stream: "Evaluate", participation: { "Enterprise Architecture": "●", Problem: null } },
+  { stream: "Evaluate", participation: { "Enterprise Architecture": "●" } }, // second Evaluate stage, union
+  { stream: "Operate", participation: { Problem: "●", "Enterprise Architecture": null } },
+];
+
+describe("shapeIt4itParticipationGrid", () => {
+  it("returns empty when there are no components", () => {
+    const g = shapeIt4itParticipationGrid({ components: [], valueStreams: ["Evaluate"], stageParticipation: stages });
+    expect(g.hasData).toBe(false);
+  });
+
+  it("de-duplicates streams and orders groups canonically", () => {
+    const g = shapeIt4itParticipationGrid({
+      components,
+      valueStreams: ["Evaluate", "Operate", "Evaluate"],
+      stageParticipation: stages,
+    });
+    expect(g.hasData).toBe(true);
+    expect(g.streams).toEqual(["Evaluate", "Operate"]);
+    expect(g.groups.map((x) => x.group)).toEqual(["Strategy to Portfolio", "Detect to Correct"]);
+  });
+
+  it("collapses stage participation up to the value stream and cross-tabs by component", () => {
+    const g = shapeIt4itParticipationGrid({ components, valueStreams: ["Evaluate", "Operate"], stageParticipation: stages });
+    const ea = g.groups.flatMap((x) => x.rows).find((r) => r.componentId === "ea")!;
+    expect(ea.participatesIn).toEqual({ Evaluate: true, Operate: false });
+    expect(ea.streamCount).toBe(1);
+    expect(ea.status).toBe("implemented");
+    const pr = g.groups.flatMap((x) => x.rows).find((r) => r.componentId === "pr")!;
+    expect(pr.participatesIn).toEqual({ Evaluate: false, Operate: true });
+  });
+
+  it("treats null / blank marks as non-participation", () => {
+    const g = shapeIt4itParticipationGrid({
+      components: [component({ id: "ea", name: "Enterprise Architecture", capabilityGroup: "Strategy to Portfolio" })],
+      valueStreams: ["Evaluate"],
+      stageParticipation: [{ stream: "Evaluate", participation: { "Enterprise Architecture": null } }],
+    });
+    expect(g.groups[0].rows[0].participatesIn.Evaluate).toBe(false);
+    expect(g.groups[0].rows[0].streamCount).toBe(0);
+  });
+});

--- a/apps/web/lib/explore/it4it-participation-view.ts
+++ b/apps/web/lib/explore/it4it-participation-view.ts
@@ -1,0 +1,104 @@
+// apps/web/lib/explore/it4it-participation-view.ts
+//
+// Pure view-shaping for the IT4IT participation grid (EP-IT4IT-CONFORMANCE, BI-D51A5A4A).
+// The IT4IT FC Participation Matrix (seeded as participationByColumn on each value-stream
+// stage) says which functional components participate in which value stream. This collapses
+// the 28 stages up to the 7 value streams and cross-tabs them against the 35 functional
+// components, tinted by each component's coverage status. No IO — the cached query in
+// ea-data.ts feeds it; the math is unit-tested here.
+
+import type { CoverageStatus, It4itComponentCoverage } from "./reference-model-types";
+
+export interface It4itStageParticipationRow {
+  /** Value-stream name the stage belongs to. */
+  stream: string;
+  /** participationByColumn: component name -> "●" (participates) or null. */
+  participation: Record<string, string | null>;
+}
+
+export interface It4itParticipationCell {
+  componentId: string;
+  componentName: string;
+  status: CoverageStatus;
+  score: number;
+  /** stream name -> participates. */
+  participatesIn: Record<string, boolean>;
+  /** count of streams this component participates in. */
+  streamCount: number;
+}
+
+export interface It4itParticipationGroup {
+  group: string;
+  rows: It4itParticipationCell[];
+}
+
+export interface It4itParticipationGrid {
+  hasData: boolean;
+  streams: string[];
+  groups: It4itParticipationGroup[];
+}
+
+const GROUP_ORDER = [
+  "Strategy to Portfolio",
+  "Requirement to Deploy",
+  "Request to Fulfill",
+  "Detect to Correct",
+  "Supporting Functions",
+];
+
+export function shapeIt4itParticipationGrid(params: {
+  components: It4itComponentCoverage[];
+  valueStreams: string[];
+  stageParticipation: It4itStageParticipationRow[];
+}): It4itParticipationGrid {
+  const { components, valueStreams, stageParticipation } = params;
+
+  // Order streams by the seeded order (stable), de-duplicated.
+  const streams = Array.from(new Set(valueStreams));
+
+  // component name -> set of streams it participates in (union across that stream's stages).
+  const participationByComponent = new Map<string, Set<string>>();
+  for (const stage of stageParticipation) {
+    for (const [componentName, mark] of Object.entries(stage.participation)) {
+      if (mark == null || String(mark).trim() === "") continue;
+      const set = participationByComponent.get(componentName) ?? new Set<string>();
+      set.add(stage.stream);
+      participationByComponent.set(componentName, set);
+    }
+  }
+
+  const groupsMap = new Map<string, It4itParticipationCell[]>();
+  for (const c of components) {
+    const streamsForComp = participationByComponent.get(c.name) ?? new Set<string>();
+    const participatesIn: Record<string, boolean> = {};
+    for (const s of streams) participatesIn[s] = streamsForComp.has(s);
+    const cell: It4itParticipationCell = {
+      componentId: c.id,
+      componentName: c.name,
+      status: c.status,
+      score: c.score,
+      participatesIn,
+      streamCount: streams.filter((s) => participatesIn[s]).length,
+    };
+    const arr = groupsMap.get(c.capabilityGroup ?? "Supporting Functions") ?? [];
+    arr.push(cell);
+    groupsMap.set(c.capabilityGroup ?? "Supporting Functions", arr);
+  }
+
+  const groups: It4itParticipationGroup[] = [];
+  for (const [group, rows] of groupsMap) {
+    rows.sort((a, b) => b.streamCount - a.streamCount || a.componentName.localeCompare(b.componentName));
+    groups.push({ group, rows });
+  }
+  groups.sort((a, b) => {
+    const ia = GROUP_ORDER.indexOf(a.group);
+    const ib = GROUP_ORDER.indexOf(b.group);
+    return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib) || a.group.localeCompare(b.group);
+  });
+
+  return {
+    hasData: components.length > 0 && streams.length > 0,
+    streams,
+    groups,
+  };
+}

--- a/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md
@@ -385,10 +385,11 @@ Refactoring tasks:
 - Add architecture review brief export with disclaimer. [deferred — the heatmap CSV export + disclaimer already cover the responsible-export need; a prose "brief" generator is a later enhancement.]
 - Add product/partner documentation that explains the baseline without reproducing standard text. [deferred — follow-up doc task; the spec + disclaimers define the boundary in the meantime.]
 
-### Optional Phase 5 - Participation Matrix
+### Optional Phase 5 - Participation Matrix (landing, BI-D51A5A4A)
 
-- Build a reusable report-kit `CoverageGrid` if the nested-tile view does not satisfy value-stream-stage by functional-component analysis.
-- Use the workbook participation matrix only inside the license boundary.
+- Build a reusable grid if the nested-tile view does not satisfy value-stream-stage by functional-component analysis. [done — `It4itParticipationGrid` (server component) cross-tabs the 35 functional components (rows, grouped by capability group) x the 7 value streams (columns) from the seeded FC Participation Matrix (`participationByColumn`), tinted by coverage status. Pure `shapeIt4itParticipationGrid` (`it4it-participation-view.ts`, collapses the 28 stages up to streams) + cached `getIt4itParticipationGrid`. Rendered on the model page below the heatmap.]
+- Use the workbook participation matrix only inside the license boundary. [done — participation marks + local element names only; non-certification disclaimer on the grid; no raw criteria text exported.]
+- Scope choice: collapsed stage->stream (35x7) rather than the raw 28x35 stage grid, for a renderable matrix; participation is shown by a filled cell vs a middot (not colour alone) for accessibility.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Optional Phase 5 of EP-IT4IT-CONFORMANCE — the participation matrix

A 2-D cross-grid of the **35 functional components** (rows, grouped by capability group) × the **7 value streams** (columns), from the seeded FC Participation Matrix, tinted by each component's coverage status. The nested-tile heatmap stays the primary view; this is the power-user analytical lens.

- **`lib/explore/it4it-participation-view.ts`** — pure `shapeIt4itParticipationGrid` collapses the 28 value-stream stages' `participationByColumn` up to the 7 streams and cross-tabs against components. **`ea-data.ts`** — cached `getIt4itParticipationGrid`.
- **`components/ea/It4itParticipationGrid.tsx`** — server-component table; participation shown by **filled cell vs middot** (not colour alone); colour = coverage status via the `it4itCoverage` intent domain; horizontal scroll; non-certification disclaimer; tokens only.
- Rendered on `/ea/models/[slug]` below the heatmap, only when participation data exists.

Scope: collapsed stage→stream (35×7) rather than the raw 28×35 stage grid, for a renderable matrix.

### Verification
- ✅ 4 shaper unit tests · typecheck clean · production build clean (pre-rebase; CI re-runs).

Spec: `docs/superpowers/specs/2026-06-24-it4it-conformance-coverage-heatmap-design.md` (Phase 5)
Epic: `EP-IT4IT-CONFORMANCE` · Item: `BI-D51A5A4A`

UX-Fit-Decision: One read-only matrix section appended below the heatmap on the existing `/ea/models/[slug]` surface — no new route, tab, nav, dialog, or input. Horizontal-scroll table; participation encoded by filled-cell vs middot (colour is a secondary cue); themed `--dpf-*` tokens. `human_cognitive_load`: low-moderate (wide grid, expert EA audience, progressive after the heatmap). `principle_decide` degenerate on that axis — decided on merits per EP-NAV-COHERENCE precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)