### PR TITLE
feat(build-studio): quality-first defaults + deliverable-sensitivity risk axis (EP-QUALITY-RIGHTSIZING P1)

### DIFF
--- a/apps/web/lib/explore/build-process-matrix.test.ts
+++ b/apps/web/lib/explore/build-process-matrix.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   BUILD_PROCESS_TYPE_VALUES,
   BUILD_PROCESS_SIZES,
+  DELIVERABLE_SENSITIVITIES,
   deriveBuildProcessSize,
   deriveBuildProcessType,
+  deriveDeliverableSensitivity,
   describePolicy,
   getModelTier,
   getProcessPolicy,
@@ -354,6 +356,101 @@ describe("getModelTier (EP-MODEL-TIER-ROUTING)", () => {
     expect(getModelTier("feature", null)).toBe("local");
     expect(getModelTier("feature", undefined)).toBe("local");
     expect(getModelTier(null, "bogus")).toBe("local");
+  });
+});
+
+// ─── EP-QUALITY-RIGHTSIZING: quality-first + sensitivity axis ────────────────
+
+describe("DELIVERABLE_SENSITIVITIES", () => {
+  it("is a closed low/elevated/high ordinal", () => {
+    expect(DELIVERABLE_SENSITIVITIES).toEqual(["low", "elevated", "high"]);
+  });
+});
+
+describe("deriveDeliverableSensitivity", () => {
+  it("flags auth/billing/security/kernel keywords as high", () => {
+    expect(deriveDeliverableSensitivity({ text: "Add OAuth login + password reset" })).toBe("high");
+    expect(deriveDeliverableSensitivity({ text: "Fix the billing invoice charge bug" })).toBe("high");
+    expect(deriveDeliverableSensitivity({ text: "Harden the decision kernel governance gate" })).toBe("high");
+    expect(deriveDeliverableSensitivity({ text: "Encrypt customer PII at rest" })).toBe("high");
+  });
+  it("flags integration/schema keywords as elevated", () => {
+    expect(deriveDeliverableSensitivity({ text: "Add a Prisma migration for the new schema" })).toBe("elevated");
+    expect(deriveDeliverableSensitivity({ text: "Wire an outbound webhook integration" })).toBe("elevated");
+  });
+  it("defaults benign copy to low", () => {
+    expect(deriveDeliverableSensitivity({ text: "Tweak the dashboard card spacing" })).toBe("low");
+    expect(deriveDeliverableSensitivity({ text: "" })).toBe("low");
+  });
+  it("treats a conservative org posture as a floor (low → elevated) but never lowers", () => {
+    expect(deriveDeliverableSensitivity({ text: "spacing tweak" }, "conservative")).toBe("elevated");
+    expect(deriveDeliverableSensitivity({ text: "OAuth token" }, "conservative")).toBe("high");
+    expect(deriveDeliverableSensitivity({ text: "spacing tweak" }, "balanced")).toBe("low");
+    expect(deriveDeliverableSensitivity({ text: "spacing tweak" }, "progressive")).toBe("low");
+  });
+});
+
+describe("getModelTier — quality-first opts (byte-identical without)", () => {
+  it("is unchanged (size-based) when no opts are supplied", () => {
+    expect(getModelTier("feature", "small")).toBe("local");
+    expect(getModelTier("feature", "medium")).toBe("local");
+    expect(getModelTier("feature", "large")).toBe("robust");
+  });
+  it("inert opts (qualityFirst off, no sensitivity) stay size-based", () => {
+    expect(getModelTier("feature", "small", { qualityFirst: false })).toBe("local");
+  });
+  it("quality-first routes substantive work to robust, trivial tail stays local", () => {
+    expect(getModelTier("feature", "small", { qualityFirst: true })).toBe("robust");
+    expect(getModelTier("feature", "medium", { qualityFirst: true })).toBe("robust");
+    expect(getModelTier("doc", "small", { qualityFirst: true })).toBe("local"); // trivial tail
+    expect(getModelTier("chore", "small", { qualityFirst: true })).toBe("local"); // trivial tail
+    expect(getModelTier("doc", "medium", { qualityFirst: true })).toBe("robust"); // not trivial
+  });
+  it("a HIGH-sensitivity deliverable is always robust regardless of size/type", () => {
+    expect(getModelTier("doc", "small", { sensitivity: "high" })).toBe("robust");
+    expect(getModelTier("feature", "small", { qualityFirst: false, sensitivity: "high" })).toBe("robust");
+  });
+});
+
+describe("getProcessPolicy — monotonic escalation (byte-identical without)", () => {
+  it("returns the exact base cell with no/inert opts", () => {
+    const base = getProcessPolicy("feature", "medium");
+    expect(getProcessPolicy("feature", "medium", undefined)).toBe(base);
+    expect(getProcessPolicy("feature", "medium", { sensitivity: "low" })).toBe(base);
+    expect(getProcessPolicy("feature", "medium", { qualityFirst: false })).toBe(base);
+  });
+  it("quality-first bumps the substantive cell's review (standard → thorough), trivial tail stays light", () => {
+    expect(getProcessPolicy("feature", "medium").reviewIntensity).toBe("standard");
+    expect(getProcessPolicy("feature", "medium", { qualityFirst: true }).reviewIntensity).toBe("thorough");
+    // doc/small is minimal — quality-first leaves the trivial tail alone.
+    expect(getProcessPolicy("doc", "small", { qualityFirst: true }).reviewIntensity).toBe("minimal");
+  });
+  it("HIGH sensitivity escalates to full phases + thorough review, monotonically", () => {
+    const escalated = getProcessPolicy("chore", "small", { sensitivity: "high" });
+    expect(escalated.phases).toEqual(["ideate", "plan", "build", "review", "ship"]);
+    expect(escalated.reviewIntensity).toBe("thorough");
+    // Union of gates — the chore/small ideate->plan (empty) gains the feature-full set.
+    expect(escalated.gates["ideate->plan"]).toContain("designDoc-present");
+  });
+  it("never lowers a base that is already thorough/full (monotonic)", () => {
+    const base = getProcessPolicy("feature", "large"); // already thorough
+    const escalated = getProcessPolicy("feature", "large", { qualityFirst: true });
+    expect(escalated.reviewIntensity).toBe("thorough");
+    expect(escalated.phases).toEqual(base.phases);
+  });
+});
+
+describe("checkPhaseGate — honors threaded sensitivity (byte-identical without)", () => {
+  it("a chore/small ideate->plan auto-passes today (no rightsizing evidence)", () => {
+    expect(checkPhaseGate("ideate", "plan", { kind: "chore", processSize: "small" }).allowed).toBe(true);
+  });
+  it("a HIGH-sensitivity chore/small ideate->plan now demands the escalated gates", () => {
+    const result = checkPhaseGate("ideate", "plan", {
+      kind: "chore",
+      processSize: "small",
+      deliverableSensitivity: "high",
+    });
+    expect(result.allowed).toBe(false); // designDoc-present now required
   });
 });
 

--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -353,6 +353,129 @@ const DEFAULT_LIFECYCLE_MATRIX: Readonly<
   },
 };
 
+// ─── Quality-first + risk axis (EP-QUALITY-RIGHTSIZING) ──────────────────────
+//
+// Spec: docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
+//
+// A second axis — deliverableSensitivity — rides alongside (type, size). It can
+// only ever RAISE process (more review, fuller phases, deeper tier), never lower
+// it (MONOTONIC). Both the quality-first bump and the sensitivity escalation are
+// opt-in via `RightsizingOpts`; when no opts are supplied (or they are inert) the
+// matrix is BYTE-IDENTICAL to today — the default-cell contract test still holds.
+
+/** Risk/sensitivity of what a build touches. Orthogonal to effort size. */
+export const DELIVERABLE_SENSITIVITIES = ["low", "elevated", "high"] as const;
+export type DeliverableSensitivity = (typeof DELIVERABLE_SENSITIVITIES)[number];
+
+const SENSITIVITY_RANK: Record<DeliverableSensitivity, number> = { low: 0, elevated: 1, high: 2 };
+const REVIEW_RANK: Record<ReviewIntensity, number> = { minimal: 0, standard: 1, thorough: 2 };
+
+export type RightsizingOpts = {
+  /** DPF_BUILD_QUALITY_FIRST_RIGHTSIZING is on: substantive work gets thorough
+   *  review + the robust tier; the trivial tail (doc/chore × small) stays light. */
+  qualityFirst?: boolean;
+  /** Derived sensitivity of the deliverable; HIGH escalates to the deepest
+   *  policy for the type regardless of size. */
+  sensitivity?: DeliverableSensitivity;
+};
+
+/** Quality-first raises the substantive cell's review one notch (standard →
+ *  thorough); the trivial tail (minimal) is left light on purpose. Monotonic. */
+function raiseReviewForQuality(r: ReviewIntensity): ReviewIntensity {
+  return r === "standard" ? "thorough" : r;
+}
+
+/** The fullest gate set for a TYPE — used to escalate a high-sensitivity build
+ *  to the most ceremony its type allows, without cross-typing (a fix stays a fix). */
+const FULL_GATES_BY_TYPE: Record<BuildProcessType, LifecyclePolicy["gates"]> = {
+  feature: FEATURE_FULL_GATES,
+  fix: FIX_FULL_GATES,
+  chore: FEATURE_FULL_GATES, // refactor-grade chores already promote to feature gates
+  doc: DOC_GATES,
+};
+
+/** Monotonic union of two gate maps: per transition, the required list is the
+ *  union of both (never drops a requirement the base already enforced). */
+function unionGates(
+  base: LifecyclePolicy["gates"],
+  add: LifecyclePolicy["gates"],
+): LifecyclePolicy["gates"] {
+  const out: LifecyclePolicy["gates"] = { ...base };
+  for (const key of Object.keys(add) as BuildTransition[]) {
+    const merged = new Set<GateRequirement>([...(base[key] ?? []), ...(add[key] ?? [])]);
+    out[key] = Array.from(merged);
+  }
+  return out;
+}
+
+/** Apply the quality-first bump + monotonic sensitivity escalation to a base
+ *  cell. Returns the base UNCHANGED when nothing actually escalates, so an inert
+ *  opts object is byte-identical to no opts at all. */
+function escalatePolicy(
+  base: LifecyclePolicy,
+  type: BuildProcessType,
+  opts: RightsizingOpts,
+): LifecyclePolicy {
+  const sens = opts.sensitivity ?? "low";
+  let phases = base.phases;
+  let reviewIntensity = base.reviewIntensity;
+  let gates = base.gates;
+  const tags: string[] = [];
+
+  if (opts.qualityFirst) {
+    reviewIntensity = raiseReviewForQuality(reviewIntensity);
+    if (reviewIntensity !== base.reviewIntensity) tags.push("quality");
+  }
+  if (SENSITIVITY_RANK[sens] >= SENSITIVITY_RANK.elevated && REVIEW_RANK[reviewIntensity] < REVIEW_RANK.standard) {
+    reviewIntensity = "standard";
+  }
+  if (sens === "high") {
+    phases = PHASES_FULL;
+    reviewIntensity = "thorough";
+    gates = unionGates(base.gates, FULL_GATES_BY_TYPE[type]);
+    tags.push("high-sensitivity");
+  } else if (SENSITIVITY_RANK[sens] >= SENSITIVITY_RANK.elevated && reviewIntensity !== base.reviewIntensity) {
+    tags.push("elevated");
+  }
+
+  if (phases === base.phases && reviewIntensity === base.reviewIntensity && gates === base.gates) {
+    return base; // nothing escalated → byte-identical
+  }
+  return { ...base, phases, reviewIntensity, gates, label: `${base.label} · ${tags.join(" · ")}` };
+}
+
+/**
+ * Derive a deliverable's sensitivity from a path/keyword heuristic over its text
+ * (BI title/body + brief) plus the org risk posture as a FLOOR. The result is
+ * `max(keyword-signal, posture-floor)` — monotonic. This is the P1 interim;
+ * BI-CFEB2B22 (P3) replaces the heuristic with code-graph blast-radius.
+ *
+ * `riskPosture` is accepted as a plain string (conservative|balanced|progressive)
+ * to keep this module decoupled from govern/risk-posture; an unknown value is
+ * treated as the balanced (no-floor) default.
+ */
+// Bare "card"/"charge" are deliberately excluded — they over-match benign UI
+// copy ("dashboard card", "charge up"). Payment exposure is caught by the
+// billing/payment/PCI/cardholder/credit-card terms instead.
+const HIGH_SENSITIVITY_PATTERN =
+  /\b(auth|authn|authz|authentication|authorization|login|sign[- ]?in|password|credential|secret|token|api[- ]?key|billing|payment|invoice|pci|cardholder|credit[- ]?card|debit[- ]?card|customer[- ]?data|pii|personal[- ]?data|gdpr|hipaa|security|vulnerab|encrypt|crypto|kernel|governance|rbac|permission|access[- ]?control|compliance)\b/i;
+const ELEVATED_SENSITIVITY_PATTERN =
+  /\b(database|migration|schema|prisma|integration|external|webhook|email|outbound|federation|edge|endpoint|deploy|infrastructure)\b/i;
+
+export function deriveDeliverableSensitivity(
+  input: { text?: string | null; workType?: string | null },
+  riskPosture?: string | null,
+): DeliverableSensitivity {
+  const text = input.text ?? "";
+  let keyword: DeliverableSensitivity = "low";
+  if (HIGH_SENSITIVITY_PATTERN.test(text)) keyword = "high";
+  else if (ELEVATED_SENSITIVITY_PATTERN.test(text)) keyword = "elevated";
+  // Org posture is a floor that can only RAISE caution: a conservative org
+  // starts everything at least "elevated". Balanced/progressive add no floor.
+  const postureFloor: DeliverableSensitivity = riskPosture === "conservative" ? "elevated" : "low";
+  return SENSITIVITY_RANK[keyword] >= SENSITIVITY_RANK[postureFloor] ? keyword : postureFloor;
+}
+
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 /**
@@ -360,14 +483,22 @@ const DEFAULT_LIFECYCLE_MATRIX: Readonly<
  * to "feature"; unknown / absent size defaults to "medium". This is the
  * back-compat contract — pre-existing call sites that pass nothing get the
  * exact same policy as before.
+ *
+ * `opts` (EP-QUALITY-RIGHTSIZING) is additive + monotonic: it can only raise the
+ * resolved policy. Absent/inert opts → the exact base cell (byte-identical).
  */
 export function getProcessPolicy(
   type: BuildProcessType | FeatureBuildKind | string | null | undefined,
   size: BuildProcessSize | string | null | undefined,
+  opts?: RightsizingOpts,
 ): LifecyclePolicy {
   const t = normalizeType(type);
   const s = normalizeSize(size);
-  return DEFAULT_LIFECYCLE_MATRIX[t][s];
+  const base = DEFAULT_LIFECYCLE_MATRIX[t][s];
+  if (!opts || (!opts.qualityFirst && (opts.sensitivity ?? "low") === "low")) {
+    return base;
+  }
+  return escalatePolicy(base, t, opts);
 }
 
 export function normalizeType(
@@ -449,12 +580,23 @@ export type BuildModelTier = "local" | "robust";
 export function getModelTier(
   type: BuildProcessType | FeatureBuildKind | string | null | undefined,
   size: BuildProcessSize | string | null | undefined,
+  opts?: RightsizingOpts,
 ): BuildModelTier {
-  // `type` is accepted for forward-compat (per-cell refinement) but P1 routes
-  // purely on size. normalizeType keeps the signature total + lint-clean.
-  void normalizeType(type);
+  const t = normalizeType(type);
   const s = normalizeSize(size);
-  return s === "large" || s === "xlarge" ? "robust" : "local";
+  // Legacy (EP-MODEL-TIER-ROUTING): route purely on size. This is the
+  // byte-identical behavior when no quality-first/sensitivity opts are supplied.
+  const legacy: BuildModelTier = s === "large" || s === "xlarge" ? "robust" : "local";
+  if (!opts) return legacy;
+  // A HIGH-sensitivity deliverable is always robust, regardless of size.
+  if (opts.sensitivity === "high") return "robust";
+  // Quality-first (EP-QUALITY-RIGHTSIZING §4.1): robust for all substantive work;
+  // local ONLY for the trivial tail (small doc/chore).
+  if (opts.qualityFirst) {
+    const trivialTail = (t === "doc" || t === "chore") && s === "small";
+    return trivialTail ? "local" : "robust";
+  }
+  return legacy;
 }
 
 // ─── Requirement check primitive ────────────────────────────────────────────
@@ -627,6 +769,17 @@ import type { PhaseGateResult } from "./feature-build-types";
  *                          happyPathIntake-ready reason string only)
  *   (everything else)    — same as before
  */
+/** Read the additive rightsizing opts a caller threaded through the gate
+ *  evidence. Returns undefined when neither field is present, so gates for
+ *  callers that don't set them are byte-identical (EP-QUALITY-RIGHTSIZING). */
+function rightsizingOptsFromEvidence(evidence: GateEvidence): RightsizingOpts | undefined {
+  const qualityFirst = evidence.qualityFirst === true;
+  const sensitivity = evidence.deliverableSensitivity as DeliverableSensitivity | undefined;
+  const hasSensitivity = sensitivity != null && (DELIVERABLE_SENSITIVITIES as readonly string[]).includes(sensitivity);
+  if (!qualityFirst && !hasSensitivity) return undefined;
+  return { qualityFirst, ...(hasSensitivity ? { sensitivity } : {}) };
+}
+
 export function checkPhaseGate(
   from: BuildPhase,
   to: BuildPhase,
@@ -638,6 +791,7 @@ export function checkPhaseGate(
   const policy = getProcessPolicy(
     evidence.kind as string | undefined,
     evidence.processSize as string | undefined,
+    rightsizingOptsFromEvidence(evidence),
   );
   const transition = `${from}->${to}` as BuildTransition;
   const required = policy.gates[transition] ?? [];

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -459,13 +459,41 @@ async function stepGenerateCode(
   // parses the local model's native <function=…> tool format itself and drives
   // the read-edit-write loop in the sandbox. Gated on provider === "opencode"
   // so installs with a frontier CLI/provider keep the existing agentic path.
-  const { getBuildStudioConfig } = await import("./build-studio-config");
-  const { getModelTier } = await import("@/lib/explore/build-process-matrix");
+  const { getBuildStudioConfig, isQualityFirstRightsizingEnabled } = await import("./build-studio-config");
+  const { getModelTier, deriveDeliverableSensitivity } = await import("@/lib/explore/build-process-matrix");
   // EP-MODEL-TIER-ROUTING: route this build's codegen to the model tier its
   // size deserves — local (opencode) for small/medium, the configured robust
   // (frontier) engine for large/xlarge. Inert unless DPF_BUILD_MODEL_TIER_ROUTING
   // is enabled; falls back to local when no robust engine is configured.
-  const modelTier = getModelTier(build.kind, processSize);
+  //
+  // EP-QUALITY-RIGHTSIZING (§4.1/§4.2): when DPF_BUILD_QUALITY_FIRST_RIGHTSIZING
+  // is on, derive the deliverable's sensitivity (keyword heuristic over the brief
+  // + org risk posture as a floor) and pass quality-first opts — substantive work
+  // routes to robust by default, and a HIGH-sensitivity deliverable always does.
+  // Off-flag → rightsizing is undefined → getModelTier is byte-identical (size-only).
+  let rightsizing: Parameters<typeof getModelTier>[2];
+  if (isQualityFirstRightsizingEnabled()) {
+    const riskPosture = await prisma.businessContext
+      .findFirst({ select: { riskPosture: true } })
+      .then((r) => r?.riskPosture ?? null)
+      .catch(() => null);
+    const sensitivityText = [
+      brief?.title,
+      brief?.description,
+      build.title,
+      build.description,
+      ...(Array.isArray(brief?.acceptanceCriteria) ? brief.acceptanceCriteria : []),
+    ]
+      .filter(Boolean)
+      .join(" ");
+    const sensitivity = deriveDeliverableSensitivity(
+      { text: sensitivityText, workType: build.kind },
+      riskPosture,
+    );
+    rightsizing = { qualityFirst: true, sensitivity };
+    console.log("[build-pipeline] quality-first rightsizing:", { buildId, processSize, sensitivity });
+  }
+  const modelTier = getModelTier(build.kind, processSize, rightsizing);
   const dispatchConfig = await getBuildStudioConfig({ modelTier });
   if (dispatchConfig.provider === "opencode") {
     const { dispatchOpencodeTask } = await import("./opencode-dispatch");

--- a/apps/web/lib/integrate/build-studio-config.ts
+++ b/apps/web/lib/integrate/build-studio-config.ts
@@ -140,6 +140,20 @@ export function isModelTierRoutingEnabled(): boolean {
 }
 
 /**
+ * EP-QUALITY-RIGHTSIZING: quality-first defaults + the deliverable-sensitivity
+ * risk axis are opt-in (default off) so the change merges inert and byte-identical
+ * to today. Set DPF_BUILD_QUALITY_FIRST_RIGHTSIZING=1 to route substantive work
+ * to the robust tier by default (local only for the trivial doc/chore tail) and
+ * to let a HIGH-sensitivity deliverable escalate its build process regardless of
+ * size. Honored in tandem with DPF_BUILD_MODEL_TIER_ROUTING — the tier decision
+ * is still only acted on when routing is enabled + a robust engine is configured.
+ */
+export function isQualityFirstRightsizingEnabled(): boolean {
+  const v = process.env.DPF_BUILD_QUALITY_FIRST_RIGHTSIZING;
+  return v === "1" || v === "true";
+}
+
+/**
  * Resolve the first available robust (frontier) provider, preferring Claude >
  * Codex > Grok. Only active + credentialed providers qualify (the same
  * findConfiguredProvider gate the auto-detect uses). Returns null when no robust

--- a/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
+++ b/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
@@ -1,0 +1,99 @@
+# Quality-first, risk-aware Build Studio right-sizing
+
+*Design — 2026-06-23. Epic: EP-QUALITY-RIGHTSIZING. Status: approved direction (WWMD HIGH-confidence, composite 11.19 / margin 4.62).*
+
+> **Provenance note (2026-06-25):** this spec was reconstructed from the BI bodies
+> (BI-163B4D28 / BI-9AF9595A / BI-CFEB2B22) and the live code after the original
+> file was lost in the 2026-06-23 disk/DB revert. The design is unchanged; the
+> reconstruction is grounded in the current `build-process-matrix.ts`,
+> `govern/risk-posture.ts`, the golden-triangle compiler, and `integrate/change-impact.ts`.
+
+## Problem
+
+Build Studio right-sizes a build by **(work-type, size)** only
+(`apps/web/lib/explore/build-process-matrix.ts`). Two gaps:
+
+1. **Size is not risk.** A *small* change to authentication, billing, customer
+   data, security, or the decision kernel is far higher-stakes than a *large*
+   cosmetic refactor — but today both are sized purely by effort, so the risky
+   small change gets the *least* ceremony. There is no sensitivity/risk axis.
+2. **The default leans cheap, not quality.** `getModelTier` routes small/medium
+   work to the local model and only large/xlarge to the robust tier; the review
+   matrix tops out at "standard" for the dominant feature cell. For an
+   owner-operated factory where correctness dominates cost, the default should be
+   **quality-first** — robust model + meaningful review for substantive work —
+   with the cheap local tier reserved for the trivial tail (small doc/chore).
+
+## Doctrine
+
+- **Quality-first defaults.** Substantive work gets the robust tier and real
+  review by default; the local/minimal path is the explicit exception for the
+  trivial tail, not the default.
+- **Risk is a second axis, monotonic.** A `deliverableSensitivity` (low |
+  elevated | high) rides alongside size. It can only ever **raise** process
+  (more review, deeper tier, fuller phases) — never lower it. A HIGH-sensitivity
+  deliverable (auth / billing / customer-data / security / kernel / governance)
+  escalates to the deepest policy **regardless of size**.
+- **One dial on top.** The golden-triangle Cost/Quality/Time posture is the
+  operator's everyday lever; it compiles into the same knobs (tier, review,
+  deliberation) but is **floored by the risk axis** — Cost/Speed can never
+  discount a HIGH-sensitivity deliverable below its sensitivity floor.
+- **Flag-gated, byte-identical off-flag.** Every change is gated behind
+  `DPF_BUILD_QUALITY_FIRST_RIGHTSIZING`; with the flag off and no sensitivity
+  supplied, the matrix is byte-identical to today (the existing contract test
+  on the default `(feature, medium)` cell still holds).
+
+## §4.1 — Quality-first defaults (P1: BI-163B4D28)
+
+- **`getModelTier` flip (flag-on):** robust for all substantive work; `local`
+  **only** for the trivial tail (`doc`/`chore` × `small`). A HIGH-sensitivity
+  deliverable is always robust. Flag-off → today's size-based routing, unchanged.
+- **Review-intensity bump (flag-on):** the dominant cells move toward quality
+  (e.g. `feature`/`medium` standard → thorough). Implemented as a *monotonic
+  escalation transform* over the existing matrix cell, not a second matrix — so
+  off-flag is provably the base cell.
+
+## §4.2 — Sensitivity axis (P1 heuristic; P3 proper)
+
+- **`deriveDeliverableSensitivity(text, workType, riskPosture)`** → low | elevated
+  | high. P1 uses a **path/keyword heuristic** over the BI title/body + brief
+  (auth, credential, token, billing, payment, card/PCI, customer-data/PII,
+  security, encryption, kernel, governance, RBAC/permission → **high**;
+  database/migration/schema/integration/outbound/federation/edge → **elevated**;
+  else **low**). The org **risk posture** (`govern/risk-posture.ts`,
+  conservative|balanced|progressive) is a *floor*: a conservative org raises the
+  baseline (low → elevated). The result is `max(keyword, posture-floor)` —
+  monotonic.
+- **Escalation is monotonic.** Given the base `(type, size)` policy, HIGH raises
+  reviewIntensity → thorough, phases → full, model tier → robust, and pulls the
+  strict gate set; it never removes a phase or relaxes a gate the base already
+  required.
+
+## §4.3 — Golden-triangle live dial (P2: BI-9AF9595A)
+
+Wire an OrchestrationBudget-style Cost/Quality/Time setting — **global default in
+PlatformConfig + per-deliverable override** — that compiles (via the existing
+golden-triangle compiler + `inferContract`) into model-tier + review-intensity +
+deliberation depth for a build. **Default pinned to Quality.** Cost/Speed are
+**capped by the §4.2 risk axis**: the compiled policy is `max(dial, sensitivityFloor)`,
+so the dial can raise rigor but never discount a HIGH-sensitivity deliverable
+below its floor. Threads the derived sensitivity through the gate evidence so the
+phase gates escalate per-deliverable, completing the wiring P1 lands as pure
+capability. Depends on P1.
+
+## §6 — Blast-radius sensitivity (P3: BI-CFEB2B22)
+
+Replace P1's path/keyword heuristic with **code-graph blast-radius derivation**
+(`apps/web/lib/integrate/change-impact.ts`): sensitivity is a function of *what
+the change actually reaches* — the set of downstream modules/contracts impacted —
+not a keyword guess. Satisfies Architecture-Over-Shortcuts: the heuristic is an
+honest interim that lets P1 ship; this is the accurate version. Same
+`DeliverableSensitivity` output contract, so it drops in behind the same callers.
+Depends on P1.
+
+## Sequencing
+
+P1 (matrix capability + flag + live model-tier flip + heuristic sensitivity) →
+P2 (live dial + per-deliverable gate threading, floored by sensitivity) →
+P3 (blast-radius sensitivity replaces the heuristic). Each is flag-gated and
+independently shippable; off-flag is byte-identical throughout.


### PR DESCRIPTION
**EP-QUALITY-RIGHTSIZING P1 (BI-163B4D28).** Build Studio sizes a build by `(work-type, size)` only — so a *small* change to auth/billing/customer-data/security/the kernel gets the **least** ceremony, and the default leans cheap (local model, standard review). P1 adds a **quality-first default** + a second, **monotonic risk axis**.

### `build-process-matrix.ts` (pure core)
- **`deliverableSensitivity`** (low|elevated|high) — path/keyword heuristic over the BI/brief text + **org risk posture as a floor** (a conservative org starts ≥ elevated). `max(keyword, posture)` — monotonic.
- **`getModelTier(type, size, opts?)`** — quality-first routes **all substantive work to robust**; `local` only for the trivial tail (doc/chore × small); a HIGH-sensitivity deliverable is always robust.
- **`getProcessPolicy(type, size, opts?)`** — monotonic escalation: quality-first bumps the substantive cell's review (standard → thorough); HIGH escalates to full phases + thorough + the type's fullest gate set (union — never drops a requirement).
- **`checkPhaseGate`** honors `evidence.qualityFirst` + `evidence.deliverableSensitivity`.

### Wiring
- `isQualityFirstRightsizingEnabled()` — gated on **`DPF_BUILD_QUALITY_FIRST_RIGHTSIZING`** (default off).
- The build-pipeline dispatch derives sensitivity (brief text + org posture) and passes quality-first opts to `getModelTier` when the flag is on.

### Safety
**Flag OFF (default) is byte-identical to today** — `getModelTier` is size-only, the matrix returns the base cell *by reference*, gates unchanged. Proven by the existing default-cell contract test + new `.toBe(base)` assertions. **53 matrix + 200 explore/config tests green; web `tsc` clean.**

The design spec was lost in the 2026-06-23 disk/DB revert; this PR **reconstructs it** (`docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md`). **P2** (golden-triangle live dial, floored by this axis) and **P3** (blast-radius sensitivity) follow and depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
