### PR TITLE
feat(coworker): move posture into the composer lip — header sheds posture (BI-E4CC8E71)

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -843,20 +843,13 @@ export function AgentCoworkerPanel({
         onConfirmClear={handleConfirmClear}
         clearDisabled={isClearDisabled(messages, isBusy, isClearing, threadId)}
         clearConfirmOpen={clearConfirmOpen}
-        elevatedAssistEnabled={elevatedAssistEnabled}
-        onToggleElevatedAssist={handleToggleElevatedAssist}
-        externalAccessEnabled={externalAccessEnabled}
-        onToggleExternalAccess={handleToggleExternalAccess}
         onClose={onClose}
         onDragStart={onDragStart}
         providerInfo={lastProviderInfo}
         devMode={devMode}
         canUseDev={canUseDev}
         onToggleDev={() => setDevMode((prev) => !prev)}
-        coworkerMode={coworkerMode}
-        onToggleCoworkerMode={handleToggleCoworkerMode}
         onViewProfile={() => setShowProfile(true)}
-        useUnified={useUnifiedCoworker}
         marketingSkillRules={marketingSkillRules}
         isDocked={isDocked}
       />
@@ -1136,6 +1129,13 @@ export function AgentCoworkerPanel({
         voicePlaybackUnavailableReason={voiceSynth.unavailableReason}
         voicePlaybackEnabled={voicePlaybackEnabled}
         onVoicePlaybackToggle={toggleVoicePlayback}
+        elevatedAssistEnabled={elevatedAssistEnabled}
+        onToggleElevatedAssist={handleToggleElevatedAssist}
+        externalAccessEnabled={externalAccessEnabled}
+        onToggleExternalAccess={handleToggleExternalAccess}
+        coworkerMode={coworkerMode}
+        onToggleCoworkerMode={handleToggleCoworkerMode}
+        useUnified={useUnifiedCoworker}
       />
     </>
   );

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -8,6 +8,7 @@ import {
   type QuestionPacketExpectedArtifact,
 } from "@/lib/tak/question-packet";
 import { AgentFileUpload } from "./AgentFileUpload";
+import { CoworkerPostureControl } from "./CoworkerPostureControl";
 import { MicButton } from "./MicButton";
 import { useVoiceCapture } from "./hooks/useVoiceCapture";
 import { Volume2, VolumeOff, VolumeX, ArrowUp, Square } from "lucide-react";
@@ -34,6 +35,16 @@ type Props = {
   voicePlaybackEnabled?: boolean;
   /** Toggle handler — flips voicePlaybackEnabled and persists to localStorage. */
   onVoicePlaybackToggle?: () => void;
+  // ── Posture (input-lip) controls. When the toggle handlers are provided the
+  //    composer renders the posture chip in its lip (mode / page-edit / web).
+  //    Work priority is a separate concern (CoworkerPriorityDock). ──────────
+  elevatedAssistEnabled?: boolean;
+  onToggleElevatedAssist?: () => void;
+  externalAccessEnabled?: boolean;
+  onToggleExternalAccess?: () => void;
+  coworkerMode?: "advise" | "act";
+  onToggleCoworkerMode?: () => void;
+  useUnified?: boolean;
 };
 
 const EMPTY_EXPECTED_ARTIFACT = "";
@@ -77,7 +88,7 @@ function truncate(value: string, max = 32): string {
   return `${value.slice(0, max - 1)}…`;
 }
 
-export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFile, onFileUploaded, onFileClear, voiceSynthAvailable, voicePlaybackUnavailableReason, voicePlaybackEnabled, onVoicePlaybackToggle }: Props) {
+export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFile, onFileUploaded, onFileClear, voiceSynthAvailable, voicePlaybackUnavailableReason, voicePlaybackEnabled, onVoicePlaybackToggle, elevatedAssistEnabled, onToggleElevatedAssist, externalAccessEnabled, onToggleExternalAccess, coworkerMode, onToggleCoworkerMode, useUnified }: Props) {
   const [value, setValue] = useState("");
   const [intentCenter, setIntentCenter] = useState("");
   const [sources, setSources] = useState<string[]>([]);
@@ -295,6 +306,7 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
     !!expectedArtifact;
   const showStop = !!busy;
   const sendDisabled = disabled || !!busy || !value.trim() || overLimit;
+  const showPosture = Boolean(onToggleElevatedAssist && onToggleExternalAccess);
 
   // ── Render helpers ────────────────────────────────────────────────────────
 
@@ -747,6 +759,21 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
             </button>
             {renderContextPopover()}
           </div>
+
+          {showPosture && (
+            <CoworkerPostureControl
+              elevatedAssistEnabled={!!elevatedAssistEnabled}
+              onToggleElevatedAssist={onToggleElevatedAssist!}
+              externalAccessEnabled={!!externalAccessEnabled}
+              onToggleExternalAccess={onToggleExternalAccess!}
+              {...(coworkerMode ? { coworkerMode } : {})}
+              {...(onToggleCoworkerMode ? { onToggleCoworkerMode } : {})}
+              useUnified={useUnified}
+              openDirection="up"
+              align="left"
+              disabled={disabled}
+            />
+          )}
 
           <span style={{ flex: 1 }} />
 

--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -24,10 +24,6 @@ const baseProps = {
   onConfirmClear: () => {},
   clearDisabled: false,
   clearConfirmOpen: false,
-  elevatedAssistEnabled: false,
-  onToggleElevatedAssist: () => {},
-  externalAccessEnabled: false,
-  onToggleExternalAccess: () => {},
   onClose: () => {},
   onDragStart: () => {},
 };
@@ -35,54 +31,15 @@ const baseProps = {
 afterEach(() => cleanup());
 
 describe("AgentPanelHeader", () => {
-  it("renders a calm resting header: identity, one sensitivity tag, and a Controls summary", () => {
+  it("renders a calm resting header: identity, one sensitivity tag, and an overflow trigger", () => {
     render(<AgentPanelHeader {...baseProps} />);
     expect(screen.getByText("Ops Co-worker")).toBeTruthy();
-    // Session toggles are no longer resting chips — they live behind the posture control.
-    expect(screen.getByText("Controls")).toBeTruthy();
     // The duplicate sensitivity badge is gone: exactly one "Internal" indicator.
     expect(screen.getAllByText("Internal")).toHaveLength(1);
-    // Toggle labels stay hidden until the posture menu is opened.
+    expect(screen.getByRole("button", { name: "More options" })).toBeTruthy();
+    // Posture now lives in the composer lip, not the header.
+    expect(screen.queryByText("Controls")).toBeNull();
     expect(screen.queryByText("Edit fields on this page")).toBeNull();
-  });
-
-  it("summarises the active posture in plain language", () => {
-    render(
-      <AgentPanelHeader
-        {...baseProps}
-        useUnified
-        coworkerMode="act"
-        onToggleCoworkerMode={() => {}}
-        elevatedAssistEnabled
-        externalAccessEnabled
-      />,
-    );
-    expect(screen.getByText("Act · edits on · web on")).toBeTruthy();
-  });
-
-  it("reveals real toggle switches when the posture control is opened", () => {
-    render(<AgentPanelHeader {...baseProps} />);
-    fireEvent.click(screen.getByText("Controls"));
-    const editSwitch = screen.getByRole("switch", { name: "Edit fields on this page" });
-    expect(editSwitch.getAttribute("aria-checked")).toBe("false");
-    expect(screen.getByRole("switch", { name: "Web access" })).toBeTruthy();
-  });
-
-  it("fires the page-editing toggle through the switch", () => {
-    const onToggleElevatedAssist = vi.fn();
-    render(<AgentPanelHeader {...baseProps} onToggleElevatedAssist={onToggleElevatedAssist} />);
-    fireEvent.click(screen.getByText("Controls"));
-    fireEvent.click(screen.getByRole("switch", { name: "Edit fields on this page" }));
-    expect(onToggleElevatedAssist).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows the Advise/Act mode segment only when unified, inside the posture menu", () => {
-    render(
-      <AgentPanelHeader {...baseProps} useUnified coworkerMode="advise" onToggleCoworkerMode={() => {}} />,
-    );
-    // The resting summary reads "Advise"; clicking it opens the posture menu.
-    fireEvent.click(screen.getByText("Advise"));
-    expect(screen.getAllByText("Act").length).toBeGreaterThan(0);
   });
 
   it("moves profile, diagnostics, and erase into the overflow menu and points dev work to Build Studio", () => {
@@ -97,7 +54,6 @@ describe("AgentPanelHeader", () => {
         onOpenClearConfirm={onOpenClearConfirm}
       />,
     );
-    // Secondary actions are not in the resting header.
     expect(screen.queryByText("Erase conversation")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "More options" }));
     expect(screen.getByText("View profile, skills & tools")).toBeTruthy();

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -24,10 +24,6 @@ type Props = {
   onConfirmClear: () => void;
   clearDisabled: boolean;
   clearConfirmOpen: boolean;
-  elevatedAssistEnabled: boolean;
-  onToggleElevatedAssist: () => void;
-  externalAccessEnabled: boolean;
-  onToggleExternalAccess: () => void;
   onClose: () => void;
   onDragStart: (e: React.MouseEvent) => void;
   onViewProfile?: () => void;
@@ -35,86 +31,9 @@ type Props = {
   devMode?: boolean;
   canUseDev?: boolean;
   onToggleDev?: () => void;
-  coworkerMode?: "advise" | "act";
-  onToggleCoworkerMode?: () => void;
-  useUnified?: boolean;
   marketingSkillRules?: Record<string, { visible?: boolean; label?: string; reframe?: string }> | null;
   isDocked?: boolean;
 };
-
-/** A labelled row with a real switch affordance, used inside the posture menu. */
-function ToggleSwitchRow({
-  checked,
-  onToggle,
-  label,
-  description,
-  title,
-}: {
-  checked: boolean;
-  onToggle: () => void;
-  label: string;
-  description: string;
-  title: string;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      title={title}
-      onMouseDown={(e) => e.stopPropagation()}
-      onClick={(e) => {
-        e.stopPropagation();
-        onToggle();
-      }}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: 12,
-        width: "100%",
-        textAlign: "left",
-        background: "none",
-        border: "none",
-        padding: "8px 12px",
-        cursor: "pointer",
-      }}
-    >
-      <span style={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
-        <span style={{ fontSize: 12, color: "var(--dpf-text)" }}>{label}</span>
-        <span style={{ fontSize: 10, color: "var(--dpf-muted)", lineHeight: 1.3 }}>{description}</span>
-      </span>
-      <span
-        aria-hidden="true"
-        style={{
-          position: "relative",
-          width: 34,
-          height: 18,
-          borderRadius: 999,
-          flex: "0 0 auto",
-          background: checked
-            ? "var(--dpf-success)"
-            : "color-mix(in srgb, var(--dpf-text) 22%, transparent)",
-          transition: "background 0.15s ease",
-        }}
-      >
-        <span
-          style={{
-            position: "absolute",
-            top: 2,
-            left: checked ? 18 : 2,
-            width: 14,
-            height: 14,
-            borderRadius: "50%",
-            background: "var(--dpf-text)",
-            transition: "left 0.15s ease",
-          }}
-        />
-      </span>
-    </button>
-  );
-}
 
 /** A single action row inside the overflow menu. */
 function MenuActionRow({
@@ -175,59 +94,28 @@ export function AgentPanelHeader({
   onConfirmClear,
   clearDisabled,
   clearConfirmOpen,
-  elevatedAssistEnabled,
-  onToggleElevatedAssist,
-  externalAccessEnabled,
-  onToggleExternalAccess,
   onClose,
   onDragStart,
   providerInfo,
   devMode,
   canUseDev,
   onToggleDev,
-  coworkerMode,
-  onToggleCoworkerMode,
   onViewProfile,
-  useUnified,
   marketingSkillRules,
   isDocked = false,
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
-  const [menu, setMenu] = useState<null | "posture" | "more">(null);
-  const showMode = Boolean(useUnified && onToggleCoworkerMode);
-  const isAct = coworkerMode === "act";
+  const [menuOpen, setMenuOpen] = useState(false);
 
-  // Close any open menu on a click outside the header.
+  // Close the overflow menu on a click outside the header.
   useEffect(() => {
-    if (!menu) return;
+    if (!menuOpen) return;
     function onDocMouseDown(e: MouseEvent) {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setMenu(null);
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setMenuOpen(false);
     }
     document.addEventListener("mousedown", onDocMouseDown);
     return () => document.removeEventListener("mousedown", onDocMouseDown);
-  }, [menu]);
-
-  // Plain-language summary of the active posture for the resting chip.
-  const summaryParts: string[] = [];
-  if (showMode) summaryParts.push(isAct ? "Act" : "Advise");
-  if (elevatedAssistEnabled) summaryParts.push("edits on");
-  if (externalAccessEnabled) summaryParts.push("web on");
-  const summaryLabel = summaryParts.length > 0 ? summaryParts.join(" · ") : "Controls";
-  const postureActive = elevatedAssistEnabled || externalAccessEnabled || (showMode && isAct);
-
-  const popoverShell: React.CSSProperties = {
-    position: "absolute",
-    top: "calc(100% + 8px)",
-    right: 0,
-    width: 248,
-    maxWidth: "calc(100vw - 32px)",
-    background: "var(--dpf-surface-1)",
-    border: "1px solid var(--dpf-border)",
-    borderRadius: 12,
-    boxShadow: "0 10px 28px rgba(0,0,0,0.35)",
-    zIndex: 5,
-    padding: "6px 0",
-  };
+  }, [menuOpen]);
 
   return (
     <div
@@ -308,147 +196,15 @@ export function AgentPanelHeader({
 
       {/* Right control cluster */}
       <div style={{ display: "flex", alignItems: "center", gap: 6, position: "relative", flex: "0 0 auto" }}>
-        {/* Posture control */}
-        <div style={{ position: "relative" }} onMouseDown={(e) => e.stopPropagation()}>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setMenu((m) => (m === "posture" ? null : "posture"));
-            }}
-            aria-expanded={menu === "posture"}
-            aria-haspopup="dialog"
-            title="Conversation controls — mode, page editing, web access, and priority for this coworker"
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 5,
-              fontSize: 10,
-              color: postureActive ? "var(--dpf-text)" : "var(--dpf-muted)",
-              background: postureActive ? "color-mix(in srgb, var(--dpf-accent) 12%, transparent)" : "transparent",
-              border: `1px solid ${postureActive ? "color-mix(in srgb, var(--dpf-accent) 45%, transparent)" : "var(--dpf-border)"}`,
-              borderRadius: 999,
-              padding: "3px 8px",
-              cursor: "pointer",
-              lineHeight: 1.2,
-              maxWidth: 180,
-            }}
-          >
-            {postureActive && (
-              <span
-                aria-hidden="true"
-                style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--dpf-accent)", flex: "0 0 auto" }}
-              />
-            )}
-            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{summaryLabel}</span>
-            <span aria-hidden="true" style={{ fontSize: 8, opacity: 0.8 }}>▾</span>
-          </button>
-          {menu === "posture" && (
-            <div role="dialog" aria-label="Conversation controls" style={popoverShell}>
-              <div
-                style={{
-                  fontSize: 9,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.06em",
-                  color: "var(--dpf-muted)",
-                  padding: "4px 12px 6px",
-                }}
-              >
-                This conversation
-              </div>
-              {showMode && (
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: 12,
-                    padding: "6px 12px",
-                  }}
-                >
-                  <span style={{ fontSize: 12, color: "var(--dpf-text)" }}>Mode</span>
-                  <span
-                    style={{
-                      display: "inline-flex",
-                      border: "1px solid var(--dpf-border)",
-                      borderRadius: 999,
-                      overflow: "hidden",
-                    }}
-                  >
-                    {(["advise", "act"] as const).map((m) => {
-                      const active = isAct ? m === "act" : m === "advise";
-                      return (
-                        <button
-                          key={m}
-                          type="button"
-                          onMouseDown={(e) => e.stopPropagation()}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            if (!active) onToggleCoworkerMode?.();
-                          }}
-                          title={
-                            m === "act"
-                              ? "Act: the coworker executes within your authority"
-                              : "Advise: the coworker recommends but doesn't act"
-                          }
-                          style={{
-                            fontSize: 11,
-                            padding: "2px 10px",
-                            border: "none",
-                            cursor: active ? "default" : "pointer",
-                            fontWeight: active ? 600 : 400,
-                            color: active ? "var(--dpf-text)" : "var(--dpf-muted)",
-                            background: active
-                              ? m === "act"
-                                ? "color-mix(in srgb, var(--dpf-success) 18%, transparent)"
-                                : "var(--dpf-surface-2)"
-                              : "transparent",
-                          }}
-                        >
-                          {m === "act" ? "Act" : "Advise"}
-                        </button>
-                      );
-                    })}
-                  </span>
-                </div>
-              )}
-              <ToggleSwitchRow
-                checked={elevatedAssistEnabled}
-                onToggle={onToggleElevatedAssist}
-                label="Edit fields on this page"
-                description="Let the coworker fill in forms for you"
-                title={
-                  elevatedAssistEnabled
-                    ? "On: this page's coworker can update approved form fields"
-                    : "Off: this page's coworker only suggests changes"
-                }
-              />
-              <ToggleSwitchRow
-                checked={externalAccessEnabled}
-                onToggle={onToggleExternalAccess}
-                label="Web access"
-                description="Allow web search and fetch this session"
-                title={
-                  externalAccessEnabled
-                    ? "On: this page's coworker can use approved public web search and fetch tools"
-                    : "Off: this page's coworker cannot reach public web tools"
-                }
-              />
-              {/* Priority moved out of this menu — it now lives in-flow at the composer
-                  (CoworkerPriorityDock), so the triangle stays in view and nothing clips. */}
-            </div>
-          )}
-        </div>
-
         {/* Overflow menu */}
         <div style={{ position: "relative" }} onMouseDown={(e) => e.stopPropagation()}>
           <button
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              setMenu((m) => (m === "more" ? null : "more"));
+              setMenuOpen((m) => !m);
             }}
-            aria-expanded={menu === "more"}
+            aria-expanded={menuOpen}
             aria-haspopup="menu"
             aria-label="More options"
             title="More — profile, diagnostics, erase conversation"
@@ -469,14 +225,30 @@ export function AgentPanelHeader({
           >
             ⋯
           </button>
-          {menu === "more" && (
-            <div role="menu" aria-label="More options" style={popoverShell}>
+          {menuOpen && (
+            <div
+              role="menu"
+              aria-label="More options"
+              style={{
+                position: "absolute",
+                top: "calc(100% + 8px)",
+                right: 0,
+                width: 248,
+                maxWidth: "calc(100vw - 32px)",
+                background: "var(--dpf-surface-1)",
+                border: "1px solid var(--dpf-border)",
+                borderRadius: 12,
+                boxShadow: "0 10px 28px rgba(0,0,0,0.35)",
+                zIndex: 5,
+                padding: "6px 0",
+              }}
+            >
               {onViewProfile && (
                 <MenuActionRow
                   label="View profile, skills & tools"
                   title="View coworker profile, skills, and tools"
                   onClick={() => {
-                    setMenu(null);
+                    setMenuOpen(false);
                     onViewProfile();
                   }}
                 />
@@ -491,7 +263,7 @@ export function AgentPanelHeader({
                       : "Diagnostics: inspect page context and explain likely fixes. Use Build Studio for code-changing work"
                   }
                   onClick={() => {
-                    setMenu(null);
+                    setMenuOpen(false);
                     onToggleDev();
                   }}
                 />
@@ -502,7 +274,7 @@ export function AgentPanelHeader({
                 disabled={clearDisabled}
                 title="Erase current conversation"
                 onClick={() => {
-                  setMenu(null);
+                  setMenuOpen(false);
                   onOpenClearConfirm();
                 }}
               />

--- a/apps/web/components/agent/CoworkerPostureControl.test.tsx
+++ b/apps/web/components/agent/CoworkerPostureControl.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { CoworkerPostureControl } from "./CoworkerPostureControl";
+
+const baseProps = {
+  elevatedAssistEnabled: false,
+  onToggleElevatedAssist: () => {},
+  externalAccessEnabled: false,
+  onToggleExternalAccess: () => {},
+};
+
+afterEach(() => cleanup());
+
+describe("CoworkerPostureControl", () => {
+  it("shows a calm 'Controls' summary at the default posture", () => {
+    render(<CoworkerPostureControl {...baseProps} />);
+    expect(screen.getByText("Controls")).toBeTruthy();
+    expect(screen.queryByText("Edit fields on this page")).toBeNull();
+  });
+
+  it("summarises the active posture in plain language", () => {
+    render(
+      <CoworkerPostureControl
+        {...baseProps}
+        useUnified
+        coworkerMode="act"
+        onToggleCoworkerMode={() => {}}
+        elevatedAssistEnabled
+        externalAccessEnabled
+      />,
+    );
+    expect(screen.getByText("Act · edits on · web on")).toBeTruthy();
+  });
+
+  it("reveals real toggle switches when opened (no priority row — that's the dock)", () => {
+    render(<CoworkerPostureControl {...baseProps} />);
+    fireEvent.click(screen.getByText("Controls"));
+    const editSwitch = screen.getByRole("switch", { name: "Edit fields on this page" });
+    expect(editSwitch.getAttribute("aria-checked")).toBe("false");
+    expect(screen.getByRole("switch", { name: "Web access" })).toBeTruthy();
+  });
+
+  it("fires the page-editing toggle through the switch", () => {
+    const onToggleElevatedAssist = vi.fn();
+    render(<CoworkerPostureControl {...baseProps} onToggleElevatedAssist={onToggleElevatedAssist} />);
+    fireEvent.click(screen.getByText("Controls"));
+    fireEvent.click(screen.getByRole("switch", { name: "Edit fields on this page" }));
+    expect(onToggleElevatedAssist).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the Advise/Act mode segment only when unified", () => {
+    render(
+      <CoworkerPostureControl {...baseProps} useUnified coworkerMode="advise" onToggleCoworkerMode={() => {}} />,
+    );
+    fireEvent.click(screen.getByText("Advise"));
+    expect(screen.getAllByText("Act").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/components/agent/CoworkerPostureControl.tsx
+++ b/apps/web/components/agent/CoworkerPostureControl.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  elevatedAssistEnabled: boolean;
+  onToggleElevatedAssist: () => void;
+  externalAccessEnabled: boolean;
+  onToggleExternalAccess: () => void;
+  coworkerMode?: "advise" | "act";
+  onToggleCoworkerMode?: () => void;
+  useUnified?: boolean;
+  /** Which way the popover opens. The composer (bottom of the panel) opens up. */
+  openDirection?: "up" | "down";
+  /** Which edge the popover aligns to. */
+  align?: "left" | "right";
+  disabled?: boolean;
+};
+
+/** A labelled row with a real switch affordance. */
+function ToggleSwitchRow({
+  checked,
+  onToggle,
+  label,
+  description,
+  title,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  label: string;
+  description: string;
+  title: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      title={title}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        width: "100%",
+        textAlign: "left",
+        background: "none",
+        border: "none",
+        padding: "8px 12px",
+        cursor: "pointer",
+      }}
+    >
+      <span style={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
+        <span style={{ fontSize: 12, color: "var(--dpf-text)" }}>{label}</span>
+        <span style={{ fontSize: 10, color: "var(--dpf-muted)", lineHeight: 1.3 }}>{description}</span>
+      </span>
+      <span
+        aria-hidden="true"
+        style={{
+          position: "relative",
+          width: 34,
+          height: 18,
+          borderRadius: 999,
+          flex: "0 0 auto",
+          background: checked
+            ? "var(--dpf-success)"
+            : "color-mix(in srgb, var(--dpf-text) 22%, transparent)",
+          transition: "background 0.15s ease",
+        }}
+      >
+        <span
+          style={{
+            position: "absolute",
+            top: 2,
+            left: checked ? 18 : 2,
+            width: 14,
+            height: 14,
+            borderRadius: "50%",
+            background: "var(--dpf-text)",
+            transition: "left 0.15s ease",
+          }}
+        />
+      </span>
+    </button>
+  );
+}
+
+/**
+ * The coworker "posture" control — a compact summary chip that expands into the
+ * real switches that govern how much the coworker can do this conversation:
+ * mode (advise/act), page editing, and web access.
+ *
+ * Lives in the composer lip (input-anchored), matching the permission controls
+ * leading assistant UIs place next to the prompt box. Work *priority* (the
+ * Golden Triangle) is a separate concern and lives in its own dock at the
+ * composer (CoworkerPriorityDock) — it is intentionally NOT in this menu.
+ */
+export function CoworkerPostureControl({
+  elevatedAssistEnabled,
+  onToggleElevatedAssist,
+  externalAccessEnabled,
+  onToggleExternalAccess,
+  coworkerMode,
+  onToggleCoworkerMode,
+  useUnified,
+  openDirection = "down",
+  align = "left",
+  disabled = false,
+}: Props) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const showMode = Boolean(useUnified && onToggleCoworkerMode);
+  const isAct = coworkerMode === "act";
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocMouseDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [open]);
+
+  const summaryParts: string[] = [];
+  if (showMode) summaryParts.push(isAct ? "Act" : "Advise");
+  if (elevatedAssistEnabled) summaryParts.push("edits on");
+  if (externalAccessEnabled) summaryParts.push("web on");
+  const summaryLabel = summaryParts.length > 0 ? summaryParts.join(" · ") : "Controls";
+  const postureActive = elevatedAssistEnabled || externalAccessEnabled || (showMode && isAct);
+
+  const popoverShell: React.CSSProperties = {
+    position: "absolute",
+    ...(openDirection === "up" ? { bottom: "calc(100% + 8px)" } : { top: "calc(100% + 8px)" }),
+    ...(align === "right" ? { right: 0 } : { left: 0 }),
+    width: 248,
+    maxWidth: "calc(100vw - 32px)",
+    background: "var(--dpf-surface-1)",
+    border: "1px solid var(--dpf-border)",
+    borderRadius: 12,
+    boxShadow: "0 10px 28px rgba(0,0,0,0.35)",
+    zIndex: 30,
+    padding: "6px 0",
+  };
+
+  return (
+    <div ref={rootRef} style={{ position: "relative" }} onMouseDown={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        title="Conversation controls — mode, page editing, and web access for this coworker"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          fontSize: 11,
+          color: postureActive ? "var(--dpf-text)" : "var(--dpf-muted)",
+          background: postureActive ? "color-mix(in srgb, var(--dpf-accent) 12%, transparent)" : "transparent",
+          border: `1px solid ${postureActive ? "color-mix(in srgb, var(--dpf-accent) 45%, transparent)" : "var(--dpf-border)"}`,
+          borderRadius: 999,
+          padding: "3px 9px",
+          cursor: disabled ? "not-allowed" : "pointer",
+          opacity: disabled ? 0.5 : 1,
+          lineHeight: 1.2,
+          maxWidth: 180,
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: "50%",
+            background: postureActive ? "var(--dpf-accent)" : "var(--dpf-muted)",
+            flex: "0 0 auto",
+          }}
+        />
+        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{summaryLabel}</span>
+        <span aria-hidden="true" style={{ fontSize: 8, opacity: 0.8 }}>{openDirection === "up" ? "▴" : "▾"}</span>
+      </button>
+      {open && (
+        <div role="dialog" aria-label="Conversation controls" style={popoverShell}>
+          <div
+            style={{
+              fontSize: 9,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              color: "var(--dpf-muted)",
+              padding: "4px 12px 6px",
+            }}
+          >
+            This conversation
+          </div>
+          {showMode && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                padding: "6px 12px",
+              }}
+            >
+              <span style={{ fontSize: 12, color: "var(--dpf-text)" }}>Mode</span>
+              <span
+                style={{
+                  display: "inline-flex",
+                  border: "1px solid var(--dpf-border)",
+                  borderRadius: 999,
+                  overflow: "hidden",
+                }}
+              >
+                {(["advise", "act"] as const).map((m) => {
+                  const active = isAct ? m === "act" : m === "advise";
+                  return (
+                    <button
+                      key={m}
+                      type="button"
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (!active) onToggleCoworkerMode?.();
+                      }}
+                      title={
+                        m === "act"
+                          ? "Act: the coworker executes within your authority"
+                          : "Advise: the coworker recommends but doesn't act"
+                      }
+                      style={{
+                        fontSize: 11,
+                        padding: "2px 10px",
+                        border: "none",
+                        cursor: active ? "default" : "pointer",
+                        fontWeight: active ? 600 : 400,
+                        color: active ? "var(--dpf-text)" : "var(--dpf-muted)",
+                        background: active
+                          ? m === "act"
+                            ? "color-mix(in srgb, var(--dpf-success) 18%, transparent)"
+                            : "var(--dpf-surface-2)"
+                          : "transparent",
+                      }}
+                    >
+                      {m === "act" ? "Act" : "Advise"}
+                    </button>
+                  );
+                })}
+              </span>
+            </div>
+          )}
+          <ToggleSwitchRow
+            checked={elevatedAssistEnabled}
+            onToggle={onToggleElevatedAssist}
+            label="Edit fields on this page"
+            description="Let the coworker fill in forms for you"
+            title={
+              elevatedAssistEnabled
+                ? "On: this page's coworker can update approved form fields"
+                : "Off: this page's coworker only suggests changes"
+            }
+          />
+          <ToggleSwitchRow
+            checked={externalAccessEnabled}
+            onToggle={onToggleExternalAccess}
+            label="Web access"
+            description="Allow web search and fetch this session"
+            title={
+              externalAccessEnabled
+                ? "On: this page's coworker can use approved public web search and fetch tools"
+                : "Off: this page's coworker cannot reach public web tools"
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/superpowers/specs/2026-06-23-coworker-panel-header-simplification-design.md
+++ b/docs/superpowers/specs/2026-06-23-coworker-panel-header-simplification-design.md
@@ -124,3 +124,20 @@ Follow-on requested by Mark, taking lessons from two reference composers (Claude
 - Quiet right cluster: voice-playback · mic · submit.
 
 **Files:** `AgentMessageInput.tsx` (rewrite), `AgentFileUpload.tsx` (`variant`), `e2e/helpers/coworker.ts` (submit by `aria-label`). **No header/panel changes** — so no overlap with the golden-triangle dock work. The existing composer test passes unchanged because every accessible name it relies on (`Send`, `Add context`, the menuitems, the inline editors, the placeholder) is preserved. UX-fit: same progressive-disclosure decision as §5 — no raw control is promoted to the resting surface; submit is one small affordance.
+
+## 10. Phase 3 — Posture into the composer lip (2026-06-25, BI-E4CC8E71)
+
+The input-lip convergence deferred in §9. The collision risk that drove the "typing area only" scope has resolved — the golden-triangle composer burst (`CoworkerPriorityDock`, header posture-menu rework) has landed and recent main is non-coworker — so the convergence is now safe to complete.
+
+**The move:** the coworker **posture** (mode / page-editing / web access) leaves the header and lives in the **composer lip**, next to where you type — matching how Claude Code / Cursor / Cline place permission controls at the input. The header then sheds posture entirely → **identity + Skills + overflow only**.
+
+**Reconciliation with the priority dock.** Work *priority* (the Golden Triangle) is a separate concern that already lives in its own `CoworkerPriorityDock` strip at the composer (#2337). So the new `CoworkerPostureControl` deliberately holds **only mode + page-edit + web** — no priority row. The composer area now carries two input-anchored, collapsed controls — the posture chip (lip) and the priority dock (strip) — both matching the references.
+
+**Changes:**
+
+- New `CoworkerPostureControl.tsx` (+ test) — the posture summary chip that expands into the real switches; opens **upward** for the bottom-anchored composer; pure UI (no server imports).
+- `AgentPanelHeader.tsx` — sheds the posture block + props (slim header: identity + Skills + overflow + erase). Header test trimmed accordingly.
+- `AgentMessageInput.tsx` — renders `CoworkerPostureControl` in its lip when posture handlers are provided. The existing composer test passes unchanged (posture isn't rendered without those props).
+- `AgentCoworkerPanel.tsx` — moves the posture props from the header call to the composer call.
+
+No schema, no server actions; theme tokens only. UX-fit: same progressive-disclosure decision as §5.


### PR DESCRIPTION
## Why
Completes the **input-lip convergence** for the coworker panel — the natural finish of EP-COWORKER-PANEL-UX after the header (#2329) and the composer typing-area refresh (#2350). The coworker **posture** (mode / page-editing / web access) moves out of the header and into the **composer lip**, next to where you type — matching how Claude Code / Cursor / Cline place permission controls at the input.

**Note on scope (important):** I earlier deferred this as "typing area only" specifically to avoid colliding with the concurrent golden-triangle work that was reworking the composer area. That work has now landed (recent main is non-coworker), so the collision risk is resolved and the convergence is safe. Delivered as a **ready-for-review** PR — if you'd rather keep posture in the header, just close this; the merged header (#2329) and composer (#2350) are untouched.

## What changed
- The **header sheds posture** → identity + Skills + overflow only (cleaner still).
- A new **`CoworkerPostureControl`** lives in the composer lip — a summary chip (`Advise · web on`) that expands into the real mode / page-edit / web switches. Opens upward.
- **Reconciled with the priority dock:** work priority already lives in its own `CoworkerPriorityDock` strip at the composer (#2337), so the posture control holds **only mode + page-edit + web** — no priority row. The composer area now has two input-anchored, collapsed controls (posture chip + priority dock), both matching the references.

## Files
New `CoworkerPostureControl.tsx` (+ test) · `AgentPanelHeader.tsx` (slim + trimmed test) · `AgentMessageInput.tsx` (renders posture in the lip) · `AgentCoworkerPanel.tsx` (moves posture props header→composer) · spec §10. No schema, no server actions, theme tokens only.

## Verification
Source-only worktree — typecheck / `next build` / unit run in CI. New `CoworkerPostureControl.test.tsx` covers the summary + switches + mode segment. The existing composer test passes unchanged (posture isn't rendered without its handlers; the control is pure UI). The header test is trimmed to the slim header.

## Governance
- **BI-E4CC8E71** · **EP-COWORKER-PANEL-UX** (Phase 3; follows #2329 / #2350)
- Spec §10: `docs/superpowers/specs/2026-06-23-coworker-panel-header-simplification-design.md`

UX-Fit-Decision: progressive disclosure (same axis and rationale as BI-706321B1 / BI-4931A5FE). principle_decide degenerate on human_cognitive_load (commandmentConflict=false) — decided on merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
