### PR TITLE
feat(build-studio): golden-triangle live dial for build right-sizing (EP-QUALITY-RIGHTSIZING P2)

### DIFF
--- a/apps/web/lib/explore/build-rightsizing-dial.test.ts
+++ b/apps/web/lib/explore/build-rightsizing-dial.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle/types";
+
+import {
+  DEFAULT_BUILD_POSTURE,
+  coerceBuildPosture,
+  resolveBuildSizing,
+  sensitivityToTierFloor,
+} from "./build-rightsizing-dial";
+
+const QUALITY = DEFAULT_BUILD_POSTURE; // assured / quality-weighted
+const COST: GoldenTrianglePreference = { preset: "frugal", costWeight: 0.8, qualityWeight: 0.1, timeWeight: 0.1 };
+const SPEED: GoldenTrianglePreference = { preset: "fast", timeWeight: 0.8, costWeight: 0.1, qualityWeight: 0.1 };
+
+describe("DEFAULT_BUILD_POSTURE", () => {
+  it("is pinned to Quality (BI-9AF9595A)", () => {
+    expect(DEFAULT_BUILD_POSTURE.preset).toBe("assured");
+    expect(DEFAULT_BUILD_POSTURE.qualityWeight).toBeGreaterThan(DEFAULT_BUILD_POSTURE.costWeight);
+    expect(DEFAULT_BUILD_POSTURE.qualityWeight).toBeGreaterThan(DEFAULT_BUILD_POSTURE.timeWeight);
+  });
+});
+
+describe("sensitivityToTierFloor", () => {
+  it("maps sensitivity to a compiler tier floor", () => {
+    expect(sensitivityToTierFloor("high")).toBe("frontier");
+    expect(sensitivityToTierFloor("elevated")).toBe("strong");
+    expect(sensitivityToTierFloor("low")).toBeUndefined();
+  });
+});
+
+describe("coerceBuildPosture", () => {
+  it("accepts a well-formed preference", () => {
+    expect(coerceBuildPosture(COST)).toEqual(COST);
+  });
+  it("rejects malformed input", () => {
+    expect(coerceBuildPosture(null)).toBeNull();
+    expect(coerceBuildPosture({ preset: "frugal" })).toBeNull(); // missing weights
+    expect(coerceBuildPosture("frugal")).toBeNull();
+    expect(coerceBuildPosture({ costWeight: 1, qualityWeight: 0, timeWeight: 0 })).toBeNull(); // missing preset
+  });
+});
+
+describe("resolveBuildSizing — dial composes with the risk axis", () => {
+  it("a Quality posture lifts a feature/medium build to robust + thorough", () => {
+    const r = resolveBuildSizing({ type: "feature", size: "medium", posture: QUALITY, sensitivity: "low" });
+    expect(r.modelTier).toBe("robust");
+    expect(r.policy.reviewIntensity).toBe("thorough");
+  });
+
+  it("a Cost posture keeps a benign small build cheap (local)", () => {
+    const r = resolveBuildSizing({ type: "feature", size: "small", posture: COST, sensitivity: "low" });
+    expect(r.modelTier).toBe("local");
+  });
+
+  it("a Speed posture keeps a benign small build cheap (local)", () => {
+    const r = resolveBuildSizing({ type: "feature", size: "small", posture: SPEED, sensitivity: "low" });
+    expect(r.modelTier).toBe("local");
+  });
+
+  it("the risk axis FLOORS a Cost posture — a HIGH-sensitivity build can't be cheaped out", () => {
+    const r = resolveBuildSizing({ type: "feature", size: "small", posture: COST, sensitivity: "high" });
+    // Even with the cheapest dial, sensitivity forces robust + the deepest process.
+    expect(r.modelTier).toBe("robust");
+    expect(r.policy.reviewIntensity).toBe("thorough");
+    expect(r.policy.phases).toEqual(["ideate", "plan", "build", "review", "ship"]);
+  });
+
+  it("an ELEVATED-sensitivity build is floored to robust even under a Cost dial", () => {
+    const r = resolveBuildSizing({ type: "feature", size: "small", posture: COST, sensitivity: "elevated" });
+    expect(r.modelTier).toBe("robust"); // strong floor → robust
+  });
+
+  it("is monotonic — never below the matrix/sensitivity baseline", () => {
+    // A large feature is already thorough in the matrix; a Cost dial can't lower it.
+    const r = resolveBuildSizing({ type: "feature", size: "large", posture: COST, sensitivity: "low" });
+    expect(r.policy.reviewIntensity).toBe("thorough");
+  });
+
+  it("surfaces a plain-language posture explanation", () => {
+    const r = resolveBuildSizing({ type: "feature", size: "medium", posture: QUALITY, sensitivity: "low" });
+    expect(typeof r.postureExplanation).toBe("string");
+    expect(r.postureExplanation.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/explore/build-rightsizing-dial.ts
+++ b/apps/web/lib/explore/build-rightsizing-dial.ts
@@ -1,0 +1,158 @@
+// apps/web/lib/explore/build-rightsizing-dial.ts
+//
+// EP-QUALITY-RIGHTSIZING P2 (BI-9AF9595A) — the golden-triangle live dial for
+// Build Studio right-sizing.
+//
+// Spec: docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md §4.3
+//
+// A build carries a Cost/Quality/Time posture (global default in PlatformConfig,
+// optional per-deliverable override). This module COMPOSES the existing
+// golden-triangle compiler with P1's deliverable-sensitivity axis to produce the
+// final build sizing — it never re-implements routing or the matrix:
+//
+//   matrix cell (type, size)          ── P1 baseline
+//     ⊔ sensitivity escalation         ── P1, monotonic (HIGH → deepest)
+//       ⊔ golden-triangle dial         ── P2, the operator's Cost/Quality/Time
+//
+// Every layer can only RAISE rigor (monotonic ⊔ = max). Crucially the sensitivity
+// is fed to the compiler as a `minimumTierFloor`, so a Cost/Speed dial CANNOT
+// discount a sensitive deliverable below its floor — "Cost/Speed capped by the
+// risk axis", implemented through the compiler's own precedence rather than a
+// second clamp. Pure + deterministic (no I/O); the PlatformConfig read lives in
+// build-studio-config.ts.
+
+import { compileGoldenTrianglePolicy } from "@/lib/golden-triangle/compile";
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle/types";
+import type { QualityTier } from "@/lib/routing/quality-tiers";
+
+import {
+  getModelTier,
+  getProcessPolicy,
+  type BuildModelTier,
+  type BuildProcessSize,
+  type BuildProcessType,
+  type DeliverableSensitivity,
+  type LifecyclePolicy,
+  type ReviewIntensity,
+} from "./build-process-matrix";
+
+/**
+ * The default build posture — PINNED to Quality (BI-9AF9595A): a build defaults
+ * to the strongest model + thorough review unless the operator dials it down.
+ * This is the global default returned when PlatformConfig holds no override.
+ */
+export const DEFAULT_BUILD_POSTURE: GoldenTrianglePreference = {
+  preset: "assured",
+  qualityWeight: 0.8,
+  costWeight: 0.1,
+  timeWeight: 0.1,
+};
+
+/** Validate an untrusted value (PlatformConfig JSON / a per-build plan override)
+ *  as a GoldenTrianglePreference. Returns null when the shape is wrong, so callers
+ *  fall back to the Quality default. */
+export function coerceBuildPosture(value: unknown): GoldenTrianglePreference | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.qualityWeight === "number" &&
+    typeof v.costWeight === "number" &&
+    typeof v.timeWeight === "number" &&
+    typeof v.preset === "string"
+  ) {
+    return {
+      qualityWeight: v.qualityWeight,
+      costWeight: v.costWeight,
+      timeWeight: v.timeWeight,
+      preset: v.preset as GoldenTrianglePreference["preset"],
+    };
+  }
+  return null;
+}
+
+const REVIEW_RANK: Record<ReviewIntensity, number> = { minimal: 0, standard: 1, thorough: 2 };
+const TIER_RANK: Record<QualityTier, number> = { basic: 0, adequate: 1, strong: 2, frontier: 3 };
+
+function maxReview(a: ReviewIntensity, b: ReviewIntensity): ReviewIntensity {
+  return REVIEW_RANK[a] >= REVIEW_RANK[b] ? a : b;
+}
+
+/**
+ * Map a deliverable's sensitivity to the compiler's tier FLOOR. The dial's
+ * Cost/Speed axes compile to a lower `minimumTier`, but the compiler raises it
+ * back to at least this floor — so a sensitive deliverable keeps a capable model
+ * regardless of the posture. `low` adds no floor (undefined).
+ */
+export function sensitivityToTierFloor(s: DeliverableSensitivity): QualityTier | undefined {
+  if (s === "high") return "frontier";
+  if (s === "elevated") return "strong";
+  return undefined;
+}
+
+/** A compiled QualityTier → the build's coarse local|robust tier (strong+ = robust). */
+function tierToBuildTier(t: QualityTier | undefined): BuildModelTier {
+  return t != null && TIER_RANK[t] >= TIER_RANK.strong ? "robust" : "local";
+}
+
+/** The dial's review intensity, read off the compiled orchestration budget. */
+function budgetToReview(
+  deliberationPattern: string | undefined,
+  verificationDepth: string | undefined,
+): ReviewIntensity {
+  if (deliberationPattern === "debate" || verificationDepth === "deep") return "thorough";
+  if (deliberationPattern === "review" || verificationDepth === "shallow") return "standard";
+  return "minimal";
+}
+
+export type BuildSizingResolution = {
+  modelTier: BuildModelTier;
+  policy: LifecyclePolicy;
+  /** Plain-language account of what the dial compiled to (for the operator UI). */
+  postureExplanation: string;
+};
+
+/**
+ * Resolve the final build sizing by composing the (type, size) matrix baseline,
+ * P1's sensitivity escalation, and the golden-triangle dial — monotonically.
+ *
+ * The DIAL provides the quality-first lift (a Quality posture → robust + thorough;
+ * the default), so this does NOT pass P1's `qualityFirst` boolean — the operator's
+ * posture is the control. Sensitivity is applied twice, both monotonic and
+ * mutually reinforcing: once via P1 (gate/phase escalation for HIGH) and once as
+ * the compiler's tier floor (so Cost/Speed can't undercut it).
+ */
+export function resolveBuildSizing(input: {
+  type: BuildProcessType | string | null | undefined;
+  size: BuildProcessSize | string | null | undefined;
+  posture: GoldenTrianglePreference;
+  sensitivity: DeliverableSensitivity;
+}): BuildSizingResolution {
+  const { type, size, posture, sensitivity } = input;
+
+  // 1. P1 baseline: the matrix cell escalated by sensitivity (no qualityFirst —
+  //    the dial owns the quality lift).
+  const p1Opts = { sensitivity };
+  const basePolicy = getProcessPolicy(type, size, p1Opts);
+  const baseTier = getModelTier(type, size, p1Opts);
+
+  // 2. The dial: compile the posture, FLOORED by the sensitivity tier.
+  const compiled = compileGoldenTrianglePolicy({
+    preference: posture,
+    taskClass: "build",
+    authorityScope: { kind: "wsid" },
+    policyConstraints: { minimumTierFloor: sensitivityToTierFloor(sensitivity) },
+  });
+  const dialTier = tierToBuildTier(compiled.postureOverride.minimumTier);
+  const dialReview = budgetToReview(
+    compiled.orchestrationBudget.deliberationPattern,
+    compiled.orchestrationBudget.verificationDepth,
+  );
+
+  // 3. Monotonic ⊔: each layer can only raise rigor.
+  const modelTier: BuildModelTier = baseTier === "robust" || dialTier === "robust" ? "robust" : "local";
+  const reviewIntensity = maxReview(basePolicy.reviewIntensity, dialReview);
+  const policy =
+    reviewIntensity !== basePolicy.reviewIntensity ? { ...basePolicy, reviewIntensity } : basePolicy;
+
+  return { modelTier, policy, postureExplanation: compiled.explanation };
+}

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -459,20 +459,23 @@ async function stepGenerateCode(
   // parses the local model's native <function=…> tool format itself and drives
   // the read-edit-write loop in the sandbox. Gated on provider === "opencode"
   // so installs with a frontier CLI/provider keep the existing agentic path.
-  const { getBuildStudioConfig, isQualityFirstRightsizingEnabled } = await import("./build-studio-config");
+  const { getBuildStudioConfig, isQualityFirstRightsizingEnabled, getBuildGoldenTrianglePosture } =
+    await import("./build-studio-config");
   const { getModelTier, deriveDeliverableSensitivity } = await import("@/lib/explore/build-process-matrix");
-  // EP-MODEL-TIER-ROUTING: route this build's codegen to the model tier its
-  // size deserves — local (opencode) for small/medium, the configured robust
-  // (frontier) engine for large/xlarge. Inert unless DPF_BUILD_MODEL_TIER_ROUTING
-  // is enabled; falls back to local when no robust engine is configured.
+  // EP-MODEL-TIER-ROUTING: route this build's codegen to the model tier it
+  // deserves — local (opencode) for the trivial tail, the configured robust
+  // (frontier) engine otherwise. Inert unless DPF_BUILD_MODEL_TIER_ROUTING is
+  // enabled; falls back to local when no robust engine is configured.
   //
-  // EP-QUALITY-RIGHTSIZING (§4.1/§4.2): when DPF_BUILD_QUALITY_FIRST_RIGHTSIZING
-  // is on, derive the deliverable's sensitivity (keyword heuristic over the brief
-  // + org risk posture as a floor) and pass quality-first opts — substantive work
-  // routes to robust by default, and a HIGH-sensitivity deliverable always does.
-  // Off-flag → rightsizing is undefined → getModelTier is byte-identical (size-only).
-  let rightsizing: Parameters<typeof getModelTier>[2];
+  // EP-QUALITY-RIGHTSIZING (§4.1–4.3): when DPF_BUILD_QUALITY_FIRST_RIGHTSIZING is
+  // on, the build's golden-triangle dial — the per-build plan override, else the
+  // global default (pinned to Quality) — compiles, FLOORED by the deliverable's
+  // derived sensitivity, into the model tier (P2 composes the compiler with P1's
+  // risk axis; Cost/Speed cannot discount a sensitive deliverable below its floor).
+  // Off-flag → plain size-based routing (byte-identical).
+  let modelTier: "local" | "robust";
   if (isQualityFirstRightsizingEnabled()) {
+    const { resolveBuildSizing, coerceBuildPosture } = await import("@/lib/explore/build-rightsizing-dial");
     const riskPosture = await prisma.businessContext
       .findFirst({ select: { riskPosture: true } })
       .then((r) => r?.riskPosture ?? null)
@@ -490,10 +493,21 @@ async function stepGenerateCode(
       { text: sensitivityText, workType: build.kind },
       riskPosture,
     );
-    rightsizing = { qualityFirst: true, sensitivity };
-    console.log("[build-pipeline] quality-first rightsizing:", { buildId, processSize, sensitivity });
+    const posture =
+      coerceBuildPosture(plan["goldenTrianglePosture"]) ?? (await getBuildGoldenTrianglePosture());
+    const resolved = resolveBuildSizing({ type: build.kind, size: processSize, posture, sensitivity });
+    modelTier = resolved.modelTier;
+    console.log("[build-pipeline] golden-triangle dial:", {
+      buildId,
+      processSize,
+      sensitivity,
+      preset: posture.preset,
+      modelTier,
+      review: resolved.policy.reviewIntensity,
+    });
+  } else {
+    modelTier = getModelTier(build.kind, processSize);
   }
-  const modelTier = getModelTier(build.kind, processSize, rightsizing);
   const dispatchConfig = await getBuildStudioConfig({ modelTier });
   if (dispatchConfig.provider === "opencode") {
     const { dispatchOpencodeTask } = await import("./opencode-dispatch");

--- a/apps/web/lib/integrate/build-studio-config.ts
+++ b/apps/web/lib/integrate/build-studio-config.ts
@@ -5,6 +5,8 @@
 import { prisma } from "@dpf/db";
 
 import type { BuildModelTier } from "@/lib/explore/build-process-matrix";
+import { DEFAULT_BUILD_POSTURE, coerceBuildPosture } from "@/lib/explore/build-rightsizing-dial";
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle/types";
 
 export type BuildStudioDispatchConfig = {
   provider: "claude" | "codex" | "grok" | "opencode" | "agentic";
@@ -151,6 +153,26 @@ export function isModelTierRoutingEnabled(): boolean {
 export function isQualityFirstRightsizingEnabled(): boolean {
   const v = process.env.DPF_BUILD_QUALITY_FIRST_RIGHTSIZING;
   return v === "1" || v === "true";
+}
+
+/** PlatformConfig key for the global build Cost/Quality/Time posture (P2). */
+export const BUILD_GOLDEN_TRIANGLE_POSTURE_KEY = "BUILD_GOLDEN_TRIANGLE_POSTURE";
+
+/**
+ * EP-QUALITY-RIGHTSIZING P2 (BI-9AF9595A): the global default build posture — the
+ * operator's Cost/Quality/Time dial for Build Studio. Stored migration-free in
+ * PlatformConfig; absent/malformed → DEFAULT_BUILD_POSTURE (pinned to Quality).
+ * Fail-open: any read error returns the Quality default rather than throwing.
+ */
+export async function getBuildGoldenTrianglePosture(): Promise<GoldenTrianglePreference> {
+  try {
+    const cfg = await prisma.platformConfig.findUnique({
+      where: { key: BUILD_GOLDEN_TRIANGLE_POSTURE_KEY },
+    });
+    return coerceBuildPosture(cfg?.value) ?? DEFAULT_BUILD_POSTURE;
+  } catch {
+    return DEFAULT_BUILD_POSTURE;
+  }
 }
 
 /**

--- a/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
+++ b/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
@@ -91,6 +91,22 @@ honest interim that lets P1 ship; this is the accurate version. Same
 `DeliverableSensitivity` output contract, so it drops in behind the same callers.
 Depends on P1.
 
+## Implementation status
+
+- **P1 (BI-163B4D28)** — shipped (#2386). Matrix capability + flag + live model-tier
+  flip + heuristic sensitivity.
+- **P2 (BI-9AF9595A)** — engine shipped: `build-rightsizing-dial.ts` composes the
+  golden-triangle compiler with the sensitivity floor (`resolveBuildSizing`,
+  `sensitivityToTierFloor`, `coerceBuildPosture`), `getBuildGoldenTrianglePosture`
+  reads the global default (pinned Quality) from PlatformConfig, and the build
+  dispatch resolves the dial (per-build plan override → global default), floored by
+  sensitivity. Same `DPF_BUILD_QUALITY_FIRST_RIGHTSIZING` flag; off-flag unchanged.
+  *Follow-up (P2.1):* the operator UI to set the global default / per-build override
+  (reuses `GoldenTrianglePriorityPanel` on the Priority & Models surface) + threading
+  the dial's `reviewIntensity` into the build-orchestrator's deliberation choice.
+- **P3 (BI-CFEB2B22)** — pending: blast-radius sensitivity behind the same
+  `deriveDeliverableSensitivity` contract.
+
 ## Sequencing
 
 P1 (matrix capability + flag + live model-tier flip + heuristic sensitivity) →

--- a/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
+++ b/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
@@ -87,9 +87,30 @@ Replace P1's path/keyword heuristic with **code-graph blast-radius derivation**
 (`apps/web/lib/integrate/change-impact.ts`): sensitivity is a function of *what
 the change actually reaches* — the set of downstream modules/contracts impacted —
 not a keyword guess. Satisfies Architecture-Over-Shortcuts: the heuristic is an
-honest interim that lets P1 ship; this is the accurate version. Same
-`DeliverableSensitivity` output contract, so it drops in behind the same callers.
-Depends on P1.
+honest interim that lets P1 ship; this is the accurate version.
+
+**Design constraint discovered during P2 (2026-06-25):** `analyzeChangeImpact()`
+computes blast-radius **from a git diff**, which only exists *after* codegen. At
+build-sizing time (dispatch — where P1's keyword heuristic runs) there is **no
+diff yet**. So P3 is **not** a drop-in swap at sizing time; it is a **two-phase**
+design:
+
+1. **Pre-codegen (size):** keep P1's keyword heuristic — the best signal before any
+   code exists. Unchanged.
+2. **Post-codegen (verify):** at the review/ship gate, where the build's diff
+   exists, run `analyzeChangeImpact(diff)`, map its `riskLevel`
+   (`critical|high → high`, `medium → elevated`, `low → low`) plus route/schema
+   counts via a pure `changeImpactToSensitivity(report): DeliverableSensitivity`,
+   and **monotonically raise** the build's process if the *actual* reach exceeds
+   the keyword guess (`max(keywordSensitivity, blastSensitivity)`). This catches the
+   "small styling tweak that actually edits a shared util imported by auth + billing"
+   case: keyword said low, the diff reveals high reach → escalate review before ship.
+
+So the `DeliverableSensitivity` output contract is preserved (the pure mapper drops
+in behind the same callers), but the *integration point* is the verify gate, not
+dispatch — a more involved wiring than P1/P2 (find the review-time diff, thread the
+monotonic escalation into the review intensity / gate). Depends on P1; should land
+on merged P2 (which calls `deriveDeliverableSensitivity`).
 
 ## Implementation status
 


### PR DESCRIPTION
**EP-QUALITY-RIGHTSIZING P2 (BI-9AF9595A).** A build's **Cost/Quality/Time posture** now drives its right-sizing — by **composing** the golden-triangle compiler with P1's sensitivity axis, not re-implementing either.

### `build-rightsizing-dial.ts` (pure)
`resolveBuildSizing()` = matrix baseline `(type,size)` ⊔ P1 sensitivity escalation ⊔ the golden-triangle dial — **all monotonic** (`⊔` = max rigor). It feeds the posture through `compileGoldenTrianglePolicy` with the **sensitivity mapped to the compiler's `minimumTierFloor`**, then maps the `DecodedPolicy` onto the build knobs (`minimumTier` → robust/local, `deliberationPattern`/`verificationDepth` → review intensity).

**The headline property falls out of the compiler's own precedence:** a Cost/Speed dial **cannot** discount a HIGH/ELEVATED-sensitivity deliverable below its tier floor. Tested directly — a `frugal` posture on a HIGH-sensitivity build still resolves to **robust + thorough + full phases**.

- `DEFAULT_BUILD_POSTURE` pinned to **Quality**; `sensitivityToTierFloor`; `coerceBuildPosture`.

### Storage + wiring
- `getBuildGoldenTrianglePosture()` — global default from PlatformConfig, fail-open to Quality.
- The build dispatch resolves the dial (per-build plan override → global default), floored by the derived sensitivity, when `DPF_BUILD_QUALITY_FIRST_RIGHTSIZING` is on. **Off-flag is byte-identical.**

**11 dial tests + 211 explore/config tests green; web `tsc` clean.**

**Follow-up (P2.1, in the spec):** operator UI to set the global/per-build posture (reuses `GoldenTrianglePriorityPanel`) + threading the dial's `reviewIntensity` into the build-orchestrator's deliberation choice. **P3** (blast-radius sensitivity) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
