### PR TITLE
feat(build-studio): blast-radius sensitivity at the verify gate (EP-QUALITY-RIGHTSIZING P3)

### DIFF
--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -90,7 +90,7 @@ export async function reconcileSysmlProjections(
   const scheduledJobs = await runDomain("scheduledJobs", () => reconcileScheduledJobs({ db: opts.db }), SKIPPED);
   const it4itCoverage = await runDomain("it4itCoverage", () => reconcileIt4itCoverage({ db: opts.db }), SKIPPED);
   // SOC posture isolated like every other domain (EP-SOVEREIGN-SOC, composed with
-  // the #2385 fail-isolation): a security-extractor error can't blind the engine.
+  // the PR-2385 fail-isolation): a security-extractor error can't blind the engine.
   const securityPosture = await runDomain("securityPosture", () => reconcileSecurityPosture({ db: opts.db }), SKIPPED);
   return {
     mcpAuthority, coworkerAuthority, valueStreams, routes, navigation, codeStructure, processModels, skillToolchain,

--- a/apps/web/lib/integrate/change-impact.test.ts
+++ b/apps/web/lib/integrate/change-impact.test.ts
@@ -19,7 +19,13 @@ vi.mock("./code-graph/graph-queries", () => ({
 import { prisma } from "@dpf/db";
 import { summarizeCodeGraphCoverage } from "./code-graph-access";
 import { findRelatedTests } from "./code-graph/graph-queries";
-import { analyzeChangeImpact, formatImpactForChat } from "./change-impact";
+import {
+  analyzeChangeImpact,
+  changeImpactToSensitivity,
+  deriveBlastRadiusSensitivity,
+  formatImpactForChat,
+  type ChangeImpactReport,
+} from "./change-impact";
 import { buildCodeGraphFreshnessTrust } from "@/lib/trust-vector/adapters/code-graph";
 
 beforeEach(() => {
@@ -190,5 +196,75 @@ describe("formatImpactForChat", () => {
 
     expect(chat).toContain("Code graph trust: **Low trust**");
     expect(chat).toContain("Code graph index is 16 days old.");
+  });
+});
+
+// ─── EP-QUALITY-RIGHTSIZING P3: blast-radius sensitivity ─────────────────────
+
+function reportWithRisk(riskLevel: ChangeImpactReport["riskLevel"]): ChangeImpactReport {
+  return {
+    routes: { new: [], modified: [], deleted: [] },
+    schemaChanges: [],
+    impactedRoles: [],
+    blastRadius: { newRoutes: 0, modifiedRoutes: 0, deletedRoutes: 0, schemaChanges: 0, totalFilesChanged: 0 },
+    riskLevel,
+    rollbackComplexity: "simple",
+    summary: "",
+  };
+}
+
+describe("changeImpactToSensitivity", () => {
+  it("maps blast-radius risk to deliverable sensitivity", () => {
+    expect(changeImpactToSensitivity(reportWithRisk("critical"))).toBe("high");
+    expect(changeImpactToSensitivity(reportWithRisk("high"))).toBe("high");
+    expect(changeImpactToSensitivity(reportWithRisk("medium"))).toBe("elevated");
+    expect(changeImpactToSensitivity(reportWithRisk("low"))).toBe("low");
+  });
+});
+
+describe("deriveBlastRadiusSensitivity", () => {
+  it("returns low for an empty diff (fail-open, no analysis)", async () => {
+    expect(await deriveBlastRadiusSensitivity("")).toBe("low");
+    expect(await deriveBlastRadiusSensitivity("   ")).toBe("low");
+  });
+
+  it("flags a schema-changing diff as HIGH sensitivity", async () => {
+    vi.mocked(summarizeCodeGraphCoverage).mockResolvedValue({
+      graphKey: "source-code",
+      available: false,
+      indexStatus: "unavailable",
+      indexedFiles: [],
+      warnings: [],
+      summary: "",
+    } as never);
+    const schemaDiff = [
+      "diff --git a/packages/db/prisma/schema.prisma b/packages/db/prisma/schema.prisma",
+      "--- a/packages/db/prisma/schema.prisma",
+      "+++ b/packages/db/prisma/schema.prisma",
+      "@@ -1,2 +1,5 @@",
+      "+model Invoice {",
+      "+  id String @id",
+      "+}",
+    ].join("\n");
+    expect(await deriveBlastRadiusSensitivity(schemaDiff)).toBe("high");
+  });
+
+  it("keeps a new-page-only diff at LOW sensitivity", async () => {
+    vi.mocked(summarizeCodeGraphCoverage).mockResolvedValue({
+      graphKey: "source-code",
+      available: false,
+      indexStatus: "unavailable",
+      indexedFiles: [],
+      warnings: [],
+      summary: "",
+    } as never);
+    const newRouteDiff = [
+      "diff --git a/apps/web/app/(shell)/foo/page.tsx b/apps/web/app/(shell)/foo/page.tsx",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/apps/web/app/(shell)/foo/page.tsx",
+      "+export default function Foo() { return null; }",
+    ].join("\n");
+    expect(await deriveBlastRadiusSensitivity(newRouteDiff)).toBe("low");
   });
 });

--- a/apps/web/lib/integrate/change-impact.ts
+++ b/apps/web/lib/integrate/change-impact.ts
@@ -9,6 +9,7 @@ import { prisma } from "@dpf/db";
 import type { CodeGraphCoverageSummary } from "./code-graph-access";
 import { summarizeCodeGraphCoverage } from "./code-graph-access";
 import { findRelatedTests } from "./code-graph/graph-queries";
+import type { DeliverableSensitivity } from "@/lib/explore/build-process-matrix";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -364,6 +365,49 @@ export async function analyzeChangeImpact(diff: string): Promise<ChangeImpactRep
     summary: summaryParts.join("\n"),
     codeGraph,
   };
+}
+
+// ─── Blast-radius sensitivity (EP-QUALITY-RIGHTSIZING P3 / BI-CFEB2B22) ──────
+//
+// Spec §6: the accurate version of the deliverable-sensitivity signal — what the
+// change ACTUALLY reaches (from the diff), not P1's pre-codegen keyword guess.
+// Same DeliverableSensitivity output contract, so it drops in behind the same
+// callers. Because blast-radius needs a diff, this is a VERIFY-TIME signal
+// (post-codegen), not a sizing-time one — see the design note in the spec.
+
+/**
+ * Map a change-impact report's blast-radius to a deliverable sensitivity (pure).
+ * Destructive schema / deleted models or routes (critical/high risk) are HIGH;
+ * other schema changes (medium) are ELEVATED; new-routes / code-only (low) is LOW.
+ */
+export function changeImpactToSensitivity(report: ChangeImpactReport): DeliverableSensitivity {
+  switch (report.riskLevel) {
+    case "critical":
+    case "high":
+      return "high";
+    case "medium":
+      return "elevated";
+    case "low":
+    default:
+      return "low";
+  }
+}
+
+/**
+ * Derive a deliverable's sensitivity from the ACTUAL blast-radius of its diff
+ * (post-codegen). Fail-open: an empty or unparseable diff returns "low" rather
+ * than throwing, so a verify-time caller can always fall back to the keyword
+ * sensitivity. The heavier graph coverage in analyzeChangeImpact is tolerated —
+ * this runs once per build at the review gate, not in a hot loop.
+ */
+export async function deriveBlastRadiusSensitivity(diff: string): Promise<DeliverableSensitivity> {
+  if (!diff || !diff.trim()) return "low";
+  try {
+    const report = await analyzeChangeImpact(diff);
+    return changeImpactToSensitivity(report);
+  } catch {
+    return "low";
+  }
 }
 
 /**

--- a/apps/web/lib/integrate/ship-on-review-approval.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.ts
@@ -173,6 +173,7 @@ export async function advanceReviewedBuildToShip(
       verificationOut: true,
       acceptanceMet: true,
       threadId: true,
+      diffPatch: true,
     },
   });
 
@@ -222,6 +223,51 @@ export async function advanceReviewedBuildToShip(
   await log(
     "Advanced review→ship (diff already extracted). Push to GitHub remains a human gate.",
   );
+
+  // EP-QUALITY-RIGHTSIZING P3 (BI-CFEB2B22): the diff now exists, so derive the
+  // ACTUAL blast-radius sensitivity and compare it to the pre-codegen keyword
+  // sizing. When the real reach EXCEEDS the keyword guess — the "keyword miss"
+  // (e.g. a styling tweak that edited a shared module imported by auth/billing) —
+  // surface it at this human ship gate so the change gets the scrutiny its real
+  // blast radius warrants. Non-blocking + fail-open; gated on the same flag.
+  try {
+    const { isQualityFirstRightsizingEnabled } = await import("./build-studio-config");
+    if (isQualityFirstRightsizingEnabled()) {
+      const { deriveBlastRadiusSensitivity } = await import("./change-impact");
+      const { deriveDeliverableSensitivity, DELIVERABLE_SENSITIVITIES } = await import(
+        "@/lib/explore/build-process-matrix"
+      );
+      const blast = await deriveBlastRadiusSensitivity((build.diffPatch as string | null) ?? "");
+      const briefObj = build.brief as
+        | { title?: string; description?: string; acceptanceCriteria?: unknown }
+        | null;
+      const sensitivityText = [
+        briefObj?.title,
+        briefObj?.description,
+        ...(Array.isArray(briefObj?.acceptanceCriteria) ? briefObj.acceptanceCriteria : []),
+      ]
+        .filter(Boolean)
+        .join(" ");
+      const riskPosture = await prisma.businessContext
+        .findFirst({ select: { riskPosture: true } })
+        .then((r) => r?.riskPosture ?? null)
+        .catch(() => null);
+      const keyword = deriveDeliverableSensitivity(
+        { text: sensitivityText, workType: build.kind },
+        riskPosture,
+      );
+      if (DELIVERABLE_SENSITIVITIES.indexOf(blast) > DELIVERABLE_SENSITIVITIES.indexOf(keyword)) {
+        await log(
+          `⚠ Blast-radius check: this change actually reaches ${blast}-sensitivity scope — above the "${keyword}" it was sized for. Recommend extra review before pushing to GitHub.`,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn(
+      "[ship-on-review-approval] blast-radius sensitivity check failed (non-blocking):",
+      err instanceof Error ? err.message : err,
+    );
+  }
 
   // Best-effort: live UI update.
   try {

--- a/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
+++ b/docs/superpowers/specs/2026-06-23-quality-first-risk-aware-build-rightsizing-design.md
@@ -125,8 +125,16 @@ on merged P2 (which calls `deriveDeliverableSensitivity`).
   *Follow-up (P2.1):* the operator UI to set the global default / per-build override
   (reuses `GoldenTrianglePriorityPanel` on the Priority & Models surface) + threading
   the dial's `reviewIntensity` into the build-orchestrator's deliberation choice.
-- **P3 (BI-CFEB2B22)** — pending: blast-radius sensitivity behind the same
-  `deriveDeliverableSensitivity` contract.
+- **P3 (BI-CFEB2B22)** — derivation + surfacing shipped: `changeImpactToSensitivity`
+  (pure, `riskLevel → sensitivity`) + `deriveBlastRadiusSensitivity(diff)` (fail-open)
+  in `change-impact.ts`. Wired at the review→ship advance (`ship-on-review-approval.ts`)
+  — once the diff exists, the ACTUAL blast-radius sensitivity is compared to the
+  pre-codegen keyword sizing, and a "keyword miss" (real reach > sized) is surfaced
+  at the human ship gate. Non-blocking, fail-open, flag-gated. *Follow-up (P3.1):* the
+  loop-safe **enforcement** action — auto-hold or force a thorough re-review on a
+  keyword miss — needs a persistent flag (a build field / attention signal) to avoid
+  re-triggering the reconciler each tick; the derivation + surfacing land first so the
+  signal is proven before it gates anything.
 
 ## Sequencing
 


### PR DESCRIPTION
**EP-QUALITY-RIGHTSIZING P3 (BI-CFEB2B22).** Replace P1's keyword **guess** with what the change **actually reaches**.

### The design finding (surfaced while building P2)
`analyzeChangeImpact` needs a **git diff**, which only exists *after* codegen. So blast-radius is a **verify-time** signal, not a sizing-time one — P3 is two-phase, **not** a drop-in swap at dispatch.

### `change-impact.ts`
- **`changeImpactToSensitivity(report)`** — pure: `critical/high → high`, `medium → elevated`, `low → low`.
- **`deriveBlastRadiusSensitivity(diff)`** — runs `analyzeChangeImpact` + maps; **fail-open** (`""`/unparseable → `low`).

### `ship-on-review-approval.ts` (the review→ship advance — where the diff exists)
Once advanced, derive the **actual** blast-radius sensitivity and compare it to the pre-codegen keyword sizing. A **"keyword miss"** — real reach > what it was sized for (e.g. a styling tweak that edited a shared module imported by auth/billing) — is **surfaced at the human ship gate** with a recommendation for extra review. **Non-blocking, fail-open, flag-gated.**

### Scope
This lands the **derivation + surfacing**. The loop-safe **enforcement** (auto-hold / forced re-review on a keyword miss) needs a persistent flag to avoid re-triggering the reconciler each tick — scoped as **P3.1** in the spec, so the signal is proven before it gates anything.

**8 change-impact tests (4 new) green; web `tsc` clean.** Completes the EP-QUALITY-RIGHTSIZING trio (P1 #2386, P2 #2389, P3 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
