### PR TITLE
feat(remote-action): governed RemoteAction primitive + proposal→execution seam (EP-REMOTE-ACTION P1)

### DIFF
--- a/apps/web/lib/actions/federation-proposals.ts
+++ b/apps/web/lib/actions/federation-proposals.ts
@@ -2,9 +2,10 @@
 
 // EP-MSP-FEDERATION · B4 operator surface — decide on cross-org remediation
 // proposals. The customer's human approval/rejection of an MSP proposal. On
-// approve we record intent; the actual execution dispatches via the control
-// runner (EP-CTRL-5E21A4) when that substrate lands — the MSP never gains
-// standing execute rights, and nothing runs here.
+// approve we materialize the governed RemoteAction rows the proposal becomes
+// (EP-REMOTE-ACTION P1, on the CUSTOMER's side): read-only actions reach
+// `approved`, mutating ones reach `proposed`, and NOTHING dispatches — there is no
+// platform→Edge channel yet (P2). The MSP never gains standing execute rights.
 
 import { revalidatePath } from "next/cache";
 
@@ -13,6 +14,11 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { syncUserPrincipal } from "@/lib/identity/principal-linking";
 import { can } from "@/lib/permissions";
+import {
+  materializeRemoteActionsForProposal,
+  type RemoteActionDb,
+} from "@/lib/service-desk/remote-action-execution";
+import { type StoredProposalAction } from "@/lib/service-desk/remote-action-planning";
 
 const ADMIN_PATH = "/platform/federation-proposals";
 
@@ -54,25 +60,51 @@ export async function decideFederatedProposalAction(
   }
   const proposal = await prisma.federatedRemediationProposal.findUnique({
     where: { proposalId },
-    select: { proposalId: true, status: true },
+    select: { proposalId: true, status: true, actions: true, federationLinkId: true, edgeNodeId: true },
   });
   if (!proposal) return { ok: false, error: "not_found", message: "Proposal not found" };
   if (proposal.status !== "proposed") {
     return { ok: false, error: "invalid_transition", message: `proposal is already ${proposal.status}` };
   }
 
-  const status = decision === "approve" ? "approved" : "rejected";
+  if (decision === "reject") {
+    await prisma.federatedRemediationProposal.update({
+      where: { proposalId },
+      data: { status: "rejected", decidedAt: new Date(), decidedByPrincipalId: gate.principalId },
+    });
+    revalidatePath(ADMIN_PATH);
+    return { ok: true, proposalId, status: "rejected" };
+  }
+
+  // Approve: materialize the governed RemoteAction rows (the proposal→RemoteAction
+  // seam, EP-REMOTE-ACTION P1). The MSP that proposed is recorded as the requester,
+  // the link as origin; read-only actions land `approved`, mutating ones `proposed`.
+  // Conservative band for P1 — per-agreement bands (AuthorityBinding) widen it once
+  // the founder sets the §15.4 pilot bands. Nothing dispatches (no P2 channel).
+  const link = await prisma.federationLink.findUnique({
+    where: { linkId: proposal.federationLinkId },
+    select: { principalId: true },
+  });
+  const actions = Array.isArray(proposal.actions)
+    ? (proposal.actions as unknown as StoredProposalAction[])
+    : [];
+  const result = await materializeRemoteActionsForProposal(prisma as unknown as RemoteActionDb, {
+    proposalId: proposal.proposalId,
+    federationLinkId: proposal.federationLinkId,
+    edgeNodeId: proposal.edgeNodeId,
+    actions,
+    approverPrincipalId: gate.principalId,
+    requestedByPrincipalId: link?.principalId ?? `federated-peer:${proposal.federationLinkId}`,
+  });
   await prisma.federatedRemediationProposal.update({
     where: { proposalId },
     data: {
-      status,
+      status: "approved",
       decidedAt: new Date(),
       decidedByPrincipalId: gate.principalId,
-      // Execution dispatches on the customer's own control runner when
-      // EP-CTRL-5E21A4 lands; until then approval records intent only.
-      ...(decision === "approve" ? { executionEvidenceRef: "pending-control-runner" } : {}),
+      executionEvidenceRef: result.evidenceRef,
     },
   });
   revalidatePath(ADMIN_PATH);
-  return { ok: true, proposalId, status };
+  return { ok: true, proposalId, status: "approved" };
 }

--- a/apps/web/lib/service-desk/remote-action-execution.test.ts
+++ b/apps/web/lib/service-desk/remote-action-execution.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { materializeRemoteActionsForProposal, type RemoteActionDb } from "./remote-action-execution";
+
+function db() {
+  const create = vi.fn().mockResolvedValue({ actionKey: "ra_x" });
+  return { db: { remoteAction: { create } } as unknown as RemoteActionDb, create };
+}
+
+const baseInput = {
+  proposalId: "prop_1",
+  federationLinkId: "link_1",
+  edgeNodeId: "node_1",
+  approverPrincipalId: "principal_customer",
+  requestedByPrincipalId: "principal_msp",
+  actions: [
+    { actionType: "collect-service-diagnostics", riskClass: "read-only", rationale: "look" },
+    { actionType: "restart-service", riskClass: "medium", rationale: "bounce" },
+    { actionType: "wipe", riskClass: "destructive", rationale: "no" },
+  ],
+};
+
+describe("materializeRemoteActionsForProposal", () => {
+  it("materializes dispatchable actions, withholds refused, and returns an evidence ref", async () => {
+    const { db: d, create } = db();
+    const res = await materializeRemoteActionsForProposal(d, baseInput);
+    // 2 dispatchable (read-only + medium); destructive refused under conservative.
+    expect(res.created).toBe(2);
+    expect(res.refusedCount).toBe(1);
+    expect(res.evidenceRef).toBe("remoteactions:2:proposal:prop_1");
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("records provenance + sovereignty fields and only approves the read-only action", async () => {
+    const { db: d, create } = db();
+    await materializeRemoteActionsForProposal(d, baseInput);
+    const rows = create.mock.calls.map((c) => (c[0] as { data: Record<string, unknown> }).data);
+
+    const diag = rows.find((r) => r.actionType === "diagnostics.collect")!;
+    expect(diag.approvalState).toBe("approved");
+    expect(diag.approvedByPrincipalId).toBe("principal_customer");
+    expect(diag.status).toBe("queued");
+    expect(diag.originProposalRef).toBe("prop_1");
+    expect(diag.originLinkId).toBe("link_1");
+    expect(diag.requestedByPrincipalId).toBe("principal_msp");
+
+    const restart = rows.find((r) => r.actionType === "service.restart")!;
+    // mutating action is NOT approved by the proposal click — awaits per-action approval.
+    expect(restart.approvalState).toBe("proposed");
+    expect(restart.approvedByPrincipalId).toBeNull();
+    expect(restart.status).toBe("queued");
+  });
+
+  it("a widened band approves the mutating action too", async () => {
+    const { db: d, create } = db();
+    await materializeRemoteActionsForProposal(d, {
+      ...baseInput,
+      band: { autoApproveCeiling: "medium", humanApprovalCeiling: "high" },
+    });
+    const restart = create.mock.calls
+      .map((c) => (c[0] as { data: Record<string, unknown> }).data)
+      .find((r) => r.actionType === "service.restart")!;
+    expect(restart.approvalState).toBe("approved");
+  });
+});

--- a/apps/web/lib/service-desk/remote-action-execution.ts
+++ b/apps/web/lib/service-desk/remote-action-execution.ts
@@ -1,0 +1,95 @@
+// EP-REMOTE-ACTION · P1 — the proposal→RemoteAction seam (DB-injected).
+//
+// Spec: docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md §4.
+// When a customer APPROVES a FederatedRemediationProposal, materialize the governed
+// RemoteAction rows its actions become — on the CUSTOMER's side, under the
+// CUSTOMER's authority. Nothing is dispatched or executed here: there is no
+// platform→Edge channel yet (P2), so every row rests at status="queued". This
+// replaces the dead `executionEvidenceRef = "pending-control-runner"` stub with
+// real, auditable execution intent.
+//
+// Sovereignty (spec §6): the MSP is recorded as `requestedByPrincipalId` and the
+// link as `originLinkId`; only the customer's per-action approver may move a
+// mutating action past `proposed`. Read-only actions arrive `approved` (the
+// customer's proposal decision authorizes the auto class); mutating ones arrive
+// `proposed` and wait.
+
+import { randomUUID } from "crypto";
+
+import { CONSERVATIVE_AUTHORITY_BAND, type AuthorityBand } from "./remediation-authority";
+import { planRemoteActionsForProposal, type StoredProposalAction } from "./remote-action-planning";
+
+export interface RemoteActionDb {
+  remoteAction: {
+    create(args: { data: Record<string, unknown> }): Promise<{ actionKey: string }>;
+  };
+}
+
+export interface MaterializeProposalInput {
+  proposalId: string;
+  federationLinkId: string;
+  edgeNodeId?: string | null;
+  customerAccountId?: string | null;
+  customerSiteId?: string | null;
+  /** The proposal's stored actions (RemediationActionDraft[] with riskClass). */
+  actions: StoredProposalAction[];
+  /** The customer principal who approved the proposal (the per-action auto approver). */
+  approverPrincipalId: string;
+  /** The MSP (federated-peer) principal that proposed — recorded as the requester. */
+  requestedByPrincipalId: string;
+  /** Authority band (from the link's AuthorityBinding); defaults conservative. */
+  band?: AuthorityBand;
+}
+
+export interface MaterializeProposalResult {
+  created: number;
+  /** Goes onto FederatedRemediationProposal.executionEvidenceRef. */
+  evidenceRef: string;
+  summary: string;
+  refusedCount: number;
+}
+
+export async function materializeRemoteActionsForProposal(
+  db: RemoteActionDb,
+  input: MaterializeProposalInput,
+): Promise<MaterializeProposalResult> {
+  const band = input.band ?? CONSERVATIVE_AUTHORITY_BAND;
+  const plan = planRemoteActionsForProposal(input.actions, band);
+
+  let created = 0;
+  for (const a of plan.toMaterialize) {
+    const actionKey = `ra_${randomUUID().replace(/-/g, "").slice(0, 20)}`;
+    await db.remoteAction.create({
+      data: {
+        actionKey,
+        actionType: a.actionType,
+        riskClass: a.riskClass,
+        parameters: a.parameters,
+        originProposalRef: input.proposalId,
+        originLinkId: input.federationLinkId,
+        edgeNodeId: input.edgeNodeId ?? null,
+        customerAccountId: input.customerAccountId ?? null,
+        customerSiteId: input.customerSiteId ?? null,
+        requestedByPrincipalId: input.requestedByPrincipalId,
+        approvalState: a.approvalState,
+        // Only the auto class is approved by the proposal decision; mutating
+        // actions stay `proposed` with no approver until a per-action approval.
+        approvedByPrincipalId: a.approvalState === "approved" ? input.approverPrincipalId : null,
+        status: "queued",
+        evidence: {
+          sourceActionType: a.sourceActionType,
+          rationale: a.rationale,
+          dispatch: "deferred-P2-no-edge-channel",
+        },
+      },
+    });
+    created++;
+  }
+
+  return {
+    created,
+    evidenceRef: `remoteactions:${created}:proposal:${input.proposalId}`,
+    summary: plan.summary,
+    refusedCount: plan.refused.length,
+  };
+}

--- a/apps/web/lib/service-desk/remote-action-planning.test.ts
+++ b/apps/web/lib/service-desk/remote-action-planning.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { CONSERVATIVE_AUTHORITY_BAND } from "./remediation-authority";
+import { mapToRemoteActionType, planRemoteActionsForProposal } from "./remote-action-planning";
+
+describe("mapToRemoteActionType", () => {
+  it("maps A4 verbs to the convergent RemoteAction vocabulary", () => {
+    expect(mapToRemoteActionType("collect-interface-diagnostics")).toBe("diagnostics.collect");
+    expect(mapToRemoteActionType("collect-disk-usage")).toBe("diagnostics.collect");
+    expect(mapToRemoteActionType("restart-service")).toBe("service.restart");
+    expect(mapToRemoteActionType("restart-interface")).toBe("interface.restart");
+    expect(mapToRemoteActionType("rotate-certificate")).toBe("cert.rotate");
+    expect(mapToRemoteActionType("apply-patch")).toBe("patch.apply");
+  });
+
+  it("passes unknown verbs through faithfully (riskClass still governs)", () => {
+    expect(mapToRemoteActionType("frobnicate-widget")).toBe("frobnicate-widget");
+  });
+});
+
+describe("planRemoteActionsForProposal", () => {
+  it("read-only → approved, mutating → proposed, destructive → refused (conservative band)", () => {
+    const plan = planRemoteActionsForProposal(
+      [
+        { actionType: "collect-service-diagnostics", riskClass: "read-only", rationale: "look first" },
+        { actionType: "restart-service", riskClass: "medium", rationale: "bounce it" },
+        { actionType: "wipe-and-reimage", riskClass: "destructive", rationale: "nuke" },
+      ],
+      CONSERVATIVE_AUTHORITY_BAND,
+    );
+    expect(plan.toMaterialize).toHaveLength(2);
+    const byType = Object.fromEntries(plan.toMaterialize.map((a) => [a.actionType, a.approvalState]));
+    expect(byType["diagnostics.collect"]).toBe("approved");
+    expect(byType["service.restart"]).toBe("proposed");
+    expect(plan.refused.map((r) => r.actionType)).toEqual(["wipe-and-reimage"]);
+  });
+
+  it("re-checks risk from the action, NOT a frozen decision — a mutating action never auto-approves under conservative", () => {
+    // Even if the wire claimed auto-approve, riskClass medium re-evaluates to needs-human.
+    const plan = planRemoteActionsForProposal(
+      [{ actionType: "restart-service", riskClass: "medium", rationale: "x" }],
+      CONSERVATIVE_AUTHORITY_BAND,
+    );
+    expect(plan.toMaterialize[0]?.approvalState).toBe("proposed");
+  });
+
+  it("coerces an unknown/missing riskClass to high (fail-safe: never auto-approve)", () => {
+    const plan = planRemoteActionsForProposal(
+      [{ actionType: "mystery", riskClass: "bogus", rationale: "?" }],
+      CONSERVATIVE_AUTHORITY_BAND,
+    );
+    expect(plan.toMaterialize[0]?.approvalState).toBe("proposed");
+    expect(plan.toMaterialize[0]?.riskClass).toBe("high");
+  });
+
+  it("a widened band can auto-approve a higher class", () => {
+    const plan = planRemoteActionsForProposal(
+      [{ actionType: "restart-service", riskClass: "medium", rationale: "x" }],
+      { autoApproveCeiling: "medium", humanApprovalCeiling: "high" },
+    );
+    expect(plan.toMaterialize[0]?.approvalState).toBe("approved");
+  });
+});

--- a/apps/web/lib/service-desk/remote-action-planning.ts
+++ b/apps/web/lib/service-desk/remote-action-planning.ts
@@ -1,0 +1,107 @@
+// EP-REMOTE-ACTION · P1 — pure planning for the proposal→RemoteAction seam.
+//
+// Spec: docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md.
+// Turns a customer-APPROVED FederatedRemediationProposal's actions into the
+// RemoteAction rows the customer's estate will (eventually) execute. Pure + tested;
+// the DB orchestrator (remote-action-execution) wraps it.
+//
+// Two invariants live here:
+//   1. Consent RE-CHECK — every action is re-evaluated against the CURRENT band,
+//      never the decision frozen at proposal time (the band may have narrowed).
+//   2. Per-action approval — read-only/auto-approve actions reach `approved`;
+//      anything mutating reaches `proposed` and waits for an explicit per-action
+//      customer approval. Approving "fix this incident" never blanket-authorizes a
+//      reboot. (spec §4)
+
+import {
+  evaluateRemediationAuthority,
+  REMEDIATION_RISK_CLASSES,
+  type AuthorityBand,
+  type RemediationRiskClass,
+} from "./remediation-authority";
+
+/** Map an A4 diagnosis verb onto the convergent RemoteAction.actionType vocabulary. */
+export function mapToRemoteActionType(a4ActionType: string): string {
+  const t = a4ActionType.toLowerCase();
+  if (t.startsWith("collect") || t.includes("diagnostic") || t.includes("snapshot") || t.includes("usage")) {
+    return "diagnostics.collect";
+  }
+  if (t.includes("restart-service") || t === "service.restart") return "service.restart";
+  if (t.includes("restart-interface")) return "interface.restart";
+  if (t.includes("rotate-cert") || t.includes("certificate")) return "cert.rotate";
+  if (t.includes("patch") || t.includes("apply")) return "patch.apply";
+  if (t.includes("reboot")) return "reboot";
+  return a4ActionType; // faithful passthrough; riskClass still governs.
+}
+
+/** Coerce an untrusted stored riskClass; unknown ⇒ "high" (fail-safe: never auto). */
+function coerceRiskClass(value: unknown): RemediationRiskClass {
+  return (REMEDIATION_RISK_CLASSES as readonly string[]).includes(value as string)
+    ? (value as RemediationRiskClass)
+    : "high";
+}
+
+export interface StoredProposalAction {
+  actionType: string;
+  parameters?: Record<string, unknown>;
+  riskClass: RemediationRiskClass | string;
+  rationale?: string;
+}
+
+export interface PlannedRemoteAction {
+  /** The mapped RemoteAction.actionType. */
+  actionType: string;
+  /** The original A4 verb, kept for audit. */
+  sourceActionType: string;
+  riskClass: RemediationRiskClass;
+  parameters: Record<string, unknown>;
+  /** approved (auto class) | proposed (mutating — awaits per-action approval). */
+  approvalState: "approved" | "proposed";
+  rationale: string;
+}
+
+export interface RemoteActionPlan {
+  toMaterialize: PlannedRemoteAction[];
+  refused: Array<{ actionType: string; riskClass: RemediationRiskClass; reason: string }>;
+  summary: string;
+}
+
+/**
+ * Plan the RemoteActions a customer-approved proposal materializes. Re-checks each
+ * action against the CURRENT band; `refuse` actions are withheld (never
+ * materialized). Pure — the caller persists the result and stamps the proposal's
+ * executionEvidenceRef.
+ */
+export function planRemoteActionsForProposal(
+  actions: StoredProposalAction[],
+  band: AuthorityBand,
+): RemoteActionPlan {
+  const toMaterialize: PlannedRemoteAction[] = [];
+  const refused: RemoteActionPlan["refused"] = [];
+
+  for (const a of actions) {
+    const riskClass = coerceRiskClass(a.riskClass);
+    const decision = evaluateRemediationAuthority(riskClass, band); // RE-CHECK, not the frozen decision
+    if (decision === "refuse") {
+      refused.push({ actionType: a.actionType, riskClass, reason: "band-refused-at-execution" });
+      continue;
+    }
+    toMaterialize.push({
+      actionType: mapToRemoteActionType(a.actionType),
+      sourceActionType: a.actionType,
+      riskClass,
+      parameters: a.parameters ?? {},
+      approvalState: decision === "auto-approve" ? "approved" : "proposed",
+      rationale: a.rationale ?? "",
+    });
+  }
+
+  const approvedCount = toMaterialize.filter((a) => a.approvalState === "approved").length;
+  const pendingCount = toMaterialize.length - approvedCount;
+  const summary =
+    `${toMaterialize.length} action(s): ${approvedCount} approved (read-only), ` +
+    `${pendingCount} awaiting per-action approval, ${refused.length} refused. ` +
+    `Dispatch deferred — Edge action channel (P2) not yet available.`;
+
+  return { toMaterialize, refused, summary };
+}

--- a/docs/superpowers/plans/2026-06-25-convergent-remote-action-execution-plan.md
+++ b/docs/superpowers/plans/2026-06-25-convergent-remote-action-execution-plan.md
@@ -1,0 +1,46 @@
+# Implementation Plan — Convergent Governed RemoteAction Execution
+
+**Date:** 2026-06-25
+**Spec:** `docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md`
+**Proposed epic:** `EP-REMOTE-ACTION`
+**Converges:** `EP-MSP-FEDERATION` · `EP-PATCH-MANAGEMENT` (§7.3 RemoteAction) · clarifies vs `EP-CTRL-5E21A4`
+**Mode:** Direct in-worktree (founder-directed 2026-06-25, continuing the federation work). Founder reviews each PR; remote-mutation phases (P2/P3) are GATED on founder sign-off + a threat model.
+
+## Sequencing principle
+
+One primitive, two consumers. Build the **governance + record + seam** before any executor, so the dangerous capability (remote mutation on a customer estate) is the *last* thing added, behind hard gates — not the first. P1 is valuable and honest on its own: the proposal→execution lifecycle becomes real and auditable while nothing actually runs.
+
+## Verified substrate (compose, do not duplicate)
+
+- **Band kernel — shared, pure, done.** `apps/web/lib/service-desk/remediation-authority.ts` (`evaluateRemediationAuthority`, `buildRemediationProposal`, `authorityBandFromBinding`, `CONSERVATIVE_AUTHORITY_BAND`). No second approval engine.
+- **`RemoteAction` shape — specced in EP-PATCH-MANAGEMENT §7.3** (generic on purpose; "patching is the first consumer… service restart… can reuse it"). Adopted, not reinvented.
+- **`FederatedRemediationProposal`** (schema.prisma:10652) — the cross-org proposal whose `executionEvidenceRef` was the dead `"pending-control-runner"` stub.
+- **`AuthorityBinding`** (2183) / **`ChangeRequest`** (755) — authority source + change audit anchor.
+- **Edge dispatch channel: ZERO today** (verified) — the Edge is push/pull-only; no `action:dispatch`/`action:report` scope, no downward route. This is *why* P2 is a hard gate, not an oversight.
+
+## Phasing
+
+- **P1 — governance + record + seam (this PR; safe, no remote mutation).**
+  - `RemoteAction` model (patch §7.3 shape + `originProposalRef` / `originLinkId` convergence fields) + additive migration.
+  - Pure planner `remote-action-planning.ts`: A4-verb→`actionType` map; **consent re-check** against the current band (never the frozen decision); read-only→`approved`, mutating→`proposed`, refuse→withheld; unknown riskClass→`high` (fail-safe).
+  - DB orchestrator `remote-action-execution.ts`: materialize the rows on the customer's side; MSP recorded as `requestedByPrincipalId`, link as `originLinkId`; `status="queued"` (nothing dispatches — no P2 channel).
+  - Wire into `decideFederatedProposalAction`: approve materializes + stamps a real `executionEvidenceRef`; reject unchanged.
+- **P2 — Edge dispatch channel (GATED on founder sign-off + threat model).** `action:dispatch`/`action:report` token scopes, machine-bound Edge trust (mTLS/DPoP/attested key), the downward dispatch + result-ingest routes, the focused threat model (command injection, package-manager abuse, token theft/replay, confused deputy, downgrade, rollback failure, compromised Edge). This is where execution becomes real.
+- **P3 — mutating backends.** Native package managers (patch), `service.restart` (federation), reboot policy — each behind P2 + per-node action-type allow-list + `ChangeRequest` + maintenance window.
+
+## Cross-cutting
+
+- Conservative band default until the founder sets §15.4 pilot bands — only read-only auto-approves; everything mutating waits for a human.
+- The §6 sovereignty rule (`originLinkId != null` ⇒ no autonomous transition past `proposed`) is enforced structurally at materialization and (in P2) at dispatch.
+- Additive migration only; applied on the canonical install (source-only worktree cannot `migrate dev`).
+
+## Verification
+
+- Pure libs: vitest (planner, no DB).
+- Orchestrator: vitest with an injected `RemoteAction` create mock (provenance, sovereignty, approval partitioning, evidence ref).
+- Action wiring: `tsc --noEmit`; `prisma validate`.
+- Founder reviews the PR; no remote execution ships in P1.
+
+## Progress log
+
+- **P1 — RemoteAction model + proposal→RemoteAction seam.** `RemoteAction` model + `20260625130000_add_remote_action` migration; pure `remote-action-planning` (map + consent re-check + partition) and DB-injected `remote-action-execution` (materialize); `decideFederatedProposalAction` now replaces `"pending-control-runner"` with real, governed RemoteAction rows (read-only `approved`, mutating `proposed`, all `queued` — nothing dispatches). 9 unit tests; `@dpf/db` + `apps/web` typecheck; `prisma validate` clean.

--- a/docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md
+++ b/docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md
@@ -1,0 +1,114 @@
+# Convergent Governed RemoteAction Execution — Design
+
+**Date:** 2026-06-25
+**Status:** Draft (for founder review — gates the build)
+**Author:** Claude (Opus 4.8) with founder direction
+**Proposed epic:** `EP-REMOTE-ACTION` — *Governed Remote Execution: one primitive for federated remediation + estate patching*
+**Converges:** `EP-MSP-FEDERATION` (federated remediation execution) · `EP-PATCH-MANAGEMENT` (estate patch apply) · `EP-CTRL-5E21A4` (relationship clarified, §11)
+
+---
+
+## 1. Why this exists
+
+Two in-flight epics independently reached the **same missing primitive**: a governed way to *execute an approved action on a host the platform reaches through an Edge Node*, with proof.
+
+- **EP-MSP-FEDERATION** closed the loop incident → diagnose → propose → **decide**, but an approved `FederatedRemediationProposal` currently stops at `executionEvidenceRef = "pending-control-runner"` ([federation-proposals.ts:73](apps/web/lib/actions/federation-proposals.ts)). Nothing runs.
+- **EP-PATCH-MANAGEMENT** specced a generic `RemoteAction` model — *"generic on purpose. Patching is the first consumer; future inventory-on-demand, service restart, or controlled script execution can reuse it"* ([estate-patch-management-design.md §7.3](docs/superpowers/specs/2026-06-24-estate-patch-management-design.md)) — and the proposal-not-action MSP rule (§9.2) that **already names `EP-MSP-FEDERATION`** as the thing it must stay compatible with.
+
+Building a federation-only executor now would duplicate `RemoteAction`. The decision this design records: **`RemoteAction` is the single governed execution primitive; federated remediation is a second consumer of it, not a second executor.** This is the DPF "converge, don't duplicate" discipline applied to the most security-sensitive surface in the platform — remote code execution on a customer's estate.
+
+## 2. Substrate reality (grounded)
+
+What exists today:
+
+- **The band/decision kernel — shared, pure, done.** [remediation-authority.ts](apps/web/lib/service-desk/remediation-authority.ts): `REMEDIATION_RISK_CLASSES` (read-only < low < medium < high < destructive), `evaluateRemediationAuthority`, `buildRemediationProposal`, `authorityBandFromBinding`. Already used by both A4 (in-org) and B4 (cross-org). **No second approval engine is needed.**
+- **The authority source.** `AuthorityBinding` (schema.prisma:2183 — `approvalMode` + `sensitivityCeiling`) → `authorityBandFromBinding` → an `AuthorityBand`. **Fail-closed** to `CONSERVATIVE_AUTHORITY_BAND` (only read-only auto-approves).
+- **The change-audit anchor.** `ChangeRequest` (schema.prisma:755) — mutating actions hang off it.
+- **The cross-org proposal.** `FederatedRemediationProposal` (schema.prisma:10652) — `actions` Json (RemediationActionDraft[] + per-action decision), `status: proposed|approved|rejected|executed|expired`, `executedAt`, `executionEvidenceRef`.
+- **`RemoteAction` itself: specced, not built.** The patch spec §7.3 defines the model; **no `RemoteAction` model exists in the schema yet** (verified).
+
+What is **zero** today — and is the security crux:
+
+- **No platform → Edge Node dispatch channel.** Every `/api/v1/edge/*` route is the Edge pushing *up* (enroll, heartbeat, discovery-runs, events, metrics) or pulling config (adapters). There is no downward action dispatch, no `action:dispatch` / `action:report` token scope, no `capability.action.execute`. The Edge is **outbound/pull-only** ([edge-node-types.ts](packages/db/src/edge-node-types.ts): `mcp.gateway`/`a2a.gateway`/`policy.enforcement` are *reserved* names, not implemented).
+
+**Consequence:** the *record + governance + seam* is buildable safely now; the *actual execution* requires opening an Edge dispatch channel, which the patch spec §8 already gates behind machine-bound trust + a threat model. That gate is real and stays shut until §7 of this doc is satisfied.
+
+## 3. The shared primitive — adopt `RemoteAction` (patch §7.3)
+
+We adopt the patch spec's `RemoteAction` verbatim as the convergent primitive (one migration, owned by `EP-REMOTE-ACTION`, consumed by both epics). Salient fields: `actionType` (`inventory.collect | diagnostics.collect | patch.apply | service.restart | reboot | script.run`), `parameters`, `requestedByPrincipalId`, `approvalState` (`proposed|approved|rejected|cancelled`), `approvedByPrincipalId`, `changeRequestId`, `deploymentWindowId`, `customerAccountId`/`customerSiteId` (tenant isolation), `status` (`queued|dispatched|running|succeeded|failed|rolled-back|timed-out`), `result`, `evidence`, `rollbackOf`.
+
+Two convergence additions to the patch shape:
+
+1. **`originProposalRef String?`** — back-reference to the `FederatedRemediationProposal` (or in-org `AgentActionProposal`) that produced this action, so evidence flows back to the proposal that the customer decided on.
+2. **`originLinkId String?`** — the `FederationLink` an MSP-originated action came across, so the §6 sovereignty rule ("MSP-originated actions never leave `proposed` autonomously") is enforceable at the row.
+
+## 4. The federation seam (the novel part — replaces `pending-control-runner`)
+
+Today's stub becomes a real materialization, **on the customer's side, under the customer's authority**:
+
+```
+FederatedRemediationProposal (customer side, status=approved)
+   └─ for each dispatchable action (decision ≠ refuse):
+        materialize a RemoteAction on the CUSTOMER's estate
+          actionType   ← vocabulary map (§5)
+          originProposalRef ← proposal.proposalId
+          originLinkId      ← proposal.federationLinkId
+          requestedByPrincipalId ← the federated-peer (MSP) principal
+          approvalState ←
+              auto-approve   → "approved"   (band permits, within the customer's binding)
+              needs-human    → "proposed"   (waits for the customer's per-action approval)
+        evidenceRef on the proposal ← rollup ref over the RemoteAction(s)
+   └─ when every RemoteAction reaches a terminal status, proposal.status → "executed"
+```
+
+The §9.2 rule is enforced structurally: an action with `originLinkId != null` **may not transition past `proposed` without a customer-side `approvedByPrincipalId`** — the MSP cannot self-approve across the link. (Schema-level guard + the dispatcher refuses it.)
+
+## 5. Action-vocabulary reconciliation
+
+The A4 diagnosis emits its own verbs ([remediation-suggestions.ts](apps/web/lib/service-desk/remediation-suggestions.ts)); they map onto `RemoteAction.actionType` + risk:
+
+| A4 actionType | RemoteAction.actionType | riskClass | class |
+| --- | --- | --- | --- |
+| `collect-*-diagnostics`, `collect-*` | `diagnostics.collect` / `inventory.collect` | read-only | **safe** |
+| `restart-service`, `restart-interface` | `service.restart` | medium | gated |
+| `rotate-certificate` | `service.restart`-class (cert) | low | gated |
+| (patch consumer) | `patch.apply`, `reboot` | high | gated |
+
+The **read-only class is the only one that can auto-approve** under the conservative band — and even it executes only once the Edge dispatch channel (§7) is open. `script.run` stays out of scope (patch §7.3) until its own threat model.
+
+## 6. Reuse, not reinvention
+
+- **Decision:** `buildRemediationProposal` / `evaluateRemediationAuthority` / `authorityBandFromBinding` — unchanged, called before any dispatch. The band is resolved from the customer's `AuthorityBinding`; absent one, conservative (read-only only).
+- **Audit:** mutating `RemoteAction`s require a `ChangeRequest`; reboots/applies require a `DeploymentWindow`.
+- **No new proposal/approval engine, no new identity table** (federated-peer/operator are `PrincipalAlias`es already, AGENTS.md §11).
+
+## 7. Security model — the gated part (do not build blind)
+
+Executing a mutating `RemoteAction` on a customer host is the highest-stakes capability in DPF. The patch spec §8 prerequisites are adopted **as hard gates**, and remote mutation stays unbuilt until all are met and the founder signs off:
+
+1. `capability.action.execute` disabled by default; **action-type allow-listed per node** (`inventory.collect` can be on while `patch.apply` is off).
+2. Split token scopes: `action:dispatch` (delivery) + `action:report` (results).
+3. **Machine-bound Edge trust (mTLS / DPoP / attested key)** — bearer-token-only nodes may *collect* but never *mutate*.
+4. Mutating action ⇒ capability + scope + policy approval + `ChangeRequest` + valid maintenance window, no blackout.
+5. Rollback-impossible actions must declare it before approval and store compensating evidence; reboot is a first-class action, never a side effect.
+6. **A focused threat model runs before any P2 execution work** — command injection, package-manager abuse, token theft/replay, confused-deputy across customer scope, downgrade, rollback failure, malicious/compromised Edge reporting.
+
+## 8. Phasing
+
+- **P1 — Governance + record + seam (safe, migration-light, no remote mutation).** Add `RemoteAction`; materialize it from an approved proposal (§4) with consent re-check; record evidence; replace `pending-control-runner` with real `RemoteAction` refs. Read-only/diagnostic actions reach `approved`; mutating actions reach `proposed` and **stop** (no dispatch channel exists, so nothing runs — the record is honest, the boundary explicit). Pure libs + tests. *This is the safe slice I can build immediately on your go.*
+- **P2 — Edge dispatch channel (GATED on §7 + founder sign-off).** `action:dispatch`/`action:report` scopes, machine-bound trust, the downward dispatch + result-ingest routes, threat model. This is where execution becomes real — and where it must not be rushed.
+- **P3 — Mutating backends.** Native package managers (patch), `service.restart` (federation), reboot policy — each behind P2 + per-action allow-list.
+
+## 9. What I am NOT proposing to do autonomously
+
+Build P2/P3 (anything that actually dispatches to or mutates a host) without (a) the threat model, (b) machine-bound Edge trust, and (c) your explicit go. The design deliberately makes P1 valuable on its own (the proposal→execution lifecycle becomes real and auditable) while the dangerous capability stays gated.
+
+## 10. Open decisions for the founder
+
+1. **Epic shape:** new `EP-REMOTE-ACTION` owning the shared primitive (recommended), vs. landing `RemoteAction` under EP-PATCH-MANAGEMENT and having federation consume it.
+2. **Authority bands (§15.4 carryover):** the conservative default means *nothing auto-executes* across a federation link. Setting per-agreement bands is what lets even read-only diagnostics auto-run. Still your call.
+3. **P1 now?** Whether I build the safe P1 governance+record+seam slice next, or hold the whole epic for Build Studio.
+
+## 11. Relationship to EP-CTRL-5E21A4
+
+`EP-CTRL-5E21A4` ("Automated Control Utility") is **desktop/interactive control** — driving a Windows desktop for install/QA and supervised remote assist. It is a *different executor* (interactive desktop) from `RemoteAction` (headless, governed, Edge-mediated host actions). The `"pending-control-runner"` stub was named loosely; the correct home for federated **remediation** execution is `RemoteAction`, not the desktop utility. The two may later share the governed-action lifecycle vocabulary, but they target different surfaces and should not be merged.

--- a/packages/db/prisma/migrations/20260625130000_add_remote_action/migration.sql
+++ b/packages/db/prisma/migrations/20260625130000_add_remote_action/migration.sql
@@ -1,0 +1,41 @@
+-- EP-REMOTE-ACTION · P1 — the convergent governed remote-execution primitive.
+-- Spec: docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md.
+-- One primitive consumed by federated remediation (EP-MSP-FEDERATION) + estate
+-- patch-apply (EP-PATCH-MANAGEMENT §7.3). Additive only — no platform→Edge dispatch
+-- channel ships here (that is P2, gated on machine-bound trust + a threat model), so
+-- a materialized action rests at status='queued' and nothing executes.
+CREATE TABLE "RemoteAction" (
+    "id" TEXT NOT NULL,
+    "actionKey" TEXT NOT NULL,
+    "edgeNodeId" TEXT,
+    "inventoryEntityId" TEXT,
+    "customerAccountId" TEXT,
+    "customerSiteId" TEXT,
+    "actionType" TEXT NOT NULL,
+    "parameters" JSONB NOT NULL DEFAULT '{}',
+    "riskClass" TEXT NOT NULL DEFAULT 'read-only',
+    "originProposalRef" TEXT,
+    "originLinkId" TEXT,
+    "requestedByPrincipalId" TEXT NOT NULL,
+    "approvalState" TEXT NOT NULL DEFAULT 'proposed',
+    "approvedByPrincipalId" TEXT,
+    "changeRequestId" TEXT,
+    "deploymentWindowId" TEXT,
+    "patchPlanId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'queued',
+    "result" JSONB NOT NULL DEFAULT '{}',
+    "evidence" JSONB NOT NULL DEFAULT '{}',
+    "rollbackOf" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "RemoteAction_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "RemoteAction_actionKey_key" ON "RemoteAction"("actionKey");
+CREATE INDEX "RemoteAction_originProposalRef_idx" ON "RemoteAction"("originProposalRef");
+CREATE INDEX "RemoteAction_originLinkId_idx" ON "RemoteAction"("originLinkId");
+CREATE INDEX "RemoteAction_approvalState_idx" ON "RemoteAction"("approvalState");
+CREATE INDEX "RemoteAction_status_idx" ON "RemoteAction"("status");
+CREATE INDEX "RemoteAction_customerAccountId_customerSiteId_idx" ON "RemoteAction"("customerAccountId", "customerSiteId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10675,6 +10675,60 @@ model FederatedRemediationProposal {
   @@index([incidentKey])
 }
 
+// ─── EP-REMOTE-ACTION · the convergent governed remote-execution primitive ───
+// Spec: docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md.
+// ONE primitive, two consumers: federated remediation (EP-MSP-FEDERATION) + estate
+// patch-apply (EP-PATCH-MANAGEMENT, which specced this shape in §7.3). P1 = the
+// governed RECORD + the approved-proposal→RemoteAction seam. There is NO platform→
+// Edge dispatch channel yet (P2, gated on machine-bound trust + a threat model), so
+// a materialized action rests at status="queued" and nothing executes — the record
+// is the honest, auditable intent, not a side effect.
+model RemoteAction {
+  id                     String    @id @default(cuid())
+  actionKey              String    @unique
+  // The Edge Node that will execute this (resolved at dispatch, P2); nullable
+  // because a federated proposal names a host, not yet an enrolled Edge node.
+  edgeNodeId             String?
+  inventoryEntityId      String?
+  customerAccountId      String?
+  customerSiteId         String?
+  // inventory.collect | diagnostics.collect | patch.apply | service.restart | reboot | script.run
+  actionType             String
+  parameters             Json      @default("{}")
+  // read-only | low | medium | high | destructive (remediation-authority risk class).
+  riskClass              String    @default("read-only")
+
+  // Convergence provenance: which proposal produced this, and (for MSP-originated
+  // cross-org actions) which link it came across — the sovereignty guard reads
+  // originLinkId to forbid autonomous execution of an action the MSP merely proposed.
+  originProposalRef      String?
+  originLinkId           String?
+
+  requestedByPrincipalId String
+  // proposed | approved | rejected | cancelled
+  approvalState          String    @default("proposed")
+  approvedByPrincipalId  String?
+  changeRequestId        String?
+  deploymentWindowId     String?
+  patchPlanId            String?
+
+  // queued | dispatched | running | succeeded | failed | rolled-back | timed-out
+  status                 String    @default("queued")
+  result                 Json      @default("{}")
+  evidence               Json      @default("{}")
+  rollbackOf             String?
+  createdAt              DateTime  @default(now())
+  startedAt              DateTime?
+  completedAt            DateTime?
+  updatedAt              DateTime  @updatedAt
+
+  @@index([originProposalRef])
+  @@index([originLinkId])
+  @@index([approvalState])
+  @@index([status])
+  @@index([customerAccountId, customerSiteId])
+}
+
 // ─── Security telemetry (OCSF-normalized) ───────────────────────────────────
 // EP-SOVEREIGN-SOC P0 keystone — append-only OCSF-aligned security telemetry.
 // Spec: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md §6.1.


### PR DESCRIPTION
## EP-REMOTE-ACTION · P1 — governance + record + seam (no remote execution)

You chose **design-first**, then **build the safe P1 slice**. This is P1. The full design is in [the spec](docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md); [the plan](docs/superpowers/plans/2026-06-25-convergent-remote-action-execution-plan.md) phases it.

### The finding that shaped it
"Control-runner execution" was greenfield — but **EP-PATCH-MANAGEMENT had already specced the right primitive**: a deliberately generic governed `RemoteAction` (§7.3), with the proposal-not-action MSP rule (§9.2) that *already names EP-MSP-FEDERATION*. So this is **one primitive, two consumers** (federated-remediation + patch-apply), not two executors. (`EP-CTRL-5E21A4` is a *desktop*-QA utility — a different surface; the `pending-control-runner` stub was named loosely.)

### What P1 builds (safe — nothing executes)
- **`RemoteAction` model** (patch §7.3 shape + `originProposalRef`/`originLinkId` convergence fields) + additive migration.
- **Pure planner** (`remote-action-planning.ts`): A4-verb→`actionType` map; **consent re-check** against the current band (never the frozen decision); `read-only → approved`, `mutating → proposed`, `refuse → withheld`; unknown riskClass → `high` (fail-safe).
- **DB orchestrator** (`remote-action-execution.ts`): materialize rows **on the customer's side**; MSP recorded as `requestedByPrincipalId`, link as `originLinkId` (the sovereignty guard); only the auto class is approved by the proposal click.
- **`decideFederatedProposalAction`** now replaces the dead `"pending-control-runner"` stub with real, governed, auditable `RemoteAction` rows.

**Nothing dispatches or executes.** There is no platform→Edge channel yet — every materialized action rests at `status="queued"`. The record is honest, auditable intent.

### Verification
- **9** new unit tests (planner 6 + orchestrator 3); **51** federation/service-desk tests green (no regression).
- `@dpf/db` + `apps/web` typecheck; `prisma validate` clean; schema-regression guard clean. No new routes.

### Explicitly NOT in this PR (gated on your sign-off)
**P2** — the Edge dispatch channel (`action:dispatch`/`action:report` scopes, machine-bound trust, the downward routes) + a focused **threat model**. **P3** — mutating backends (patch apply, service restart, reboot). Remote mutation on a customer estate does not ship until those gates are met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)