### PR TITLE
refactor(mcp): second tool pack — runtime-coordination (lazy handlers) (BI-ARCH-TOOLPACKS)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -40,6 +40,7 @@ import {
 // pack — their definitions compose into PLATFORM_TOOLS and their handlers dispatch
 // through the registry (no per-tool handler imports or switch cases here anymore).
 import { deliberationSiemPack } from "@/lib/mcp/packs/deliberation-siem-pack";
+import { runtimeCoordinationPack } from "@/lib/mcp/packs/runtime-coordination-pack";
 import { composeToolPacks } from "@/lib/mcp/tool-registry";
 import {
   createLicenseReadinessIssue,
@@ -66,7 +67,6 @@ import {
 } from "@/lib/coworker-self-assessment/assessment-service";
 import { inferProviderIdFromRouteContext } from "@/lib/ai-provider-route-context";
 import { workCapsuleToolEnums } from "@/lib/work-capsules/mcp-handlers";
-import { runtimeCoordinationToolEnums } from "@/lib/runtime-coordination/mcp-handlers";
 import {
   COWORKER_ASSESSMENT_CONFIDENCE,
   COWORKER_ASSESSMENT_VERDICTS,
@@ -429,11 +429,10 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 
 const WORK_CAPSULE_TOOL_ENUMS = workCapsuleToolEnums();
-const RUNTIME_COORDINATION_TOOL_ENUMS = runtimeCoordinationToolEnums();
 
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,
@@ -945,119 +944,6 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: "manage_backlog",
     sideEffect: true,
-  },
-  // ─── Runtime coordination (plan 2026-05-18) ────────────────────────────────
-  {
-    name: "register_runtime_target",
-    description: "Register or refresh the governed runtime surface where work is being verified. Source ownership is read through Work Capsule, FeatureBuild, Sandbox, or GitPromotionCandidate links.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        targetId: { type: "string", description: "Stable runtime target id, e.g. RT-ROOT-PORTAL or RT-SANDBOX-<sandboxRowId>." },
-        kind: { type: "string", enum: RUNTIME_COORDINATION_TOOL_ENUMS.targetKinds, description: "Runtime target kind." },
-        status: { type: "string", enum: RUNTIME_COORDINATION_TOOL_ENUMS.targetStatuses, description: "Runtime target status." },
-        capsuleId: { type: "string", description: "Optional semantic Work Capsule id (WC-*)." },
-        workCapsuleId: { type: "string", description: "Optional internal WorkCapsule row id; prefer capsuleId for external agents." },
-        buildId: { type: "string", description: "Optional semantic FeatureBuild id (FB-*)." },
-        featureBuildId: { type: "string", description: "Optional internal FeatureBuild row id; prefer buildId for external agents." },
-        sandboxId: { type: "string", description: "Optional Sandbox row id." },
-        slotId: { type: "string", description: "Optional SandboxSlot row id." },
-        composeProjectName: { type: "string", description: "Compose project name when applicable." },
-        serviceName: { type: "string", description: "Compose service name when applicable." },
-        containerName: { type: "string", description: "Docker container name when applicable." },
-        hostUrl: { type: "string", description: "Host-reachable URL." },
-        internalUrl: { type: "string", description: "Container/internal URL." },
-        port: { type: "number", description: "Host port when applicable." },
-        serviceVersion: { type: "string", description: "OpenTelemetry service.version style artifact string, e.g. image + git SHA." },
-        acceptanceRoleOverride: { type: "string", enum: ["debug-only"], description: "Rare override. Most roles are derived from kind." },
-        debugReason: { type: "string", description: "Required for ad-hoc-debug targets." },
-        expiresAt: { type: "string", description: "Optional ISO timestamp for temporary targets." },
-        metadata: { type: "object", description: "Free-form snapshot data; never the source of truth." },
-      },
-      required: ["targetId", "kind", "status"],
-    },
-    requiredCapability: "manage_backlog",
-    executionMode: "immediate",
-    sideEffect: true,
-  },
-  {
-    name: "heartbeat_runtime_target",
-    description: "Refresh the heartbeat for a governed runtime target.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        targetId: { type: "string", description: "Stable runtime target id." },
-      },
-      required: ["targetId"],
-    },
-    requiredCapability: "manage_backlog",
-    executionMode: "immediate",
-    sideEffect: true,
-  },
-  {
-    name: "release_runtime_target",
-    description: "Mark a governed runtime target released so another thread can safely use the surface.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        targetId: { type: "string", description: "Stable runtime target id." },
-      },
-      required: ["targetId"],
-    },
-    requiredCapability: "manage_backlog",
-    executionMode: "immediate",
-    sideEffect: true,
-  },
-  {
-    name: "record_runtime_verification",
-    description: "Record a typed verification event against exactly one primary runtime/build/promotion attach point, with optional evidence links.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        verificationId: { type: "string", description: "Stable verification id." },
-        kind: { type: "string", enum: RUNTIME_COORDINATION_TOOL_ENUMS.verificationKinds, description: "Verification kind." },
-        status: { type: "string", enum: RUNTIME_COORDINATION_TOOL_ENUMS.verificationStatuses, description: "Verification status." },
-        targetId: { type: "string", description: "Optional stable RuntimeTarget id (RT-*)." },
-        runtimeTargetId: { type: "string", description: "Optional RuntimeTarget row id; RT-* targetId is also accepted for compatibility." },
-        capsuleId: { type: "string", description: "Optional semantic Work Capsule id (WC-*) for capsule-only or mirrored evidence." },
-        workCapsuleId: { type: "string", description: "Optional WorkCapsule row id; prefer capsuleId for external agents." },
-        buildId: { type: "string", description: "Optional semantic FeatureBuild id (FB-*)." },
-        featureBuildId: { type: "string", description: "Optional FeatureBuild row id; prefer buildId for external agents." },
-        candidateId: { type: "string", description: "Optional semantic GitPromotionCandidate id." },
-        gitPromotionCandidateId: { type: "string", description: "Optional GitPromotionCandidate row id; prefer candidateId for external agents." },
-        command: { type: "string", description: "Command that produced the verification." },
-        url: { type: "string", description: "URL checked." },
-        evidenceUrl: { type: "string", description: "Evidence URL." },
-        screenshotUrl: { type: "string", description: "Screenshot URL." },
-        toolExecutionId: { type: "string", description: "ToolExecution row id." },
-        buildActivityId: { type: "string", description: "BuildActivity row id." },
-        backlogActivityId: { type: "string", description: "BacklogItemActivity row id." },
-        capsuleActivityId: { type: "string", description: "WorkCapsuleActivity row id." },
-        startedAt: { type: "string", description: "Optional ISO start timestamp." },
-        completedAt: { type: "string", description: "Optional ISO completion timestamp." },
-        result: { type: "object", description: "Structured result payload." },
-      },
-      required: ["verificationId", "kind", "status"],
-    },
-    requiredCapability: "manage_backlog",
-    executionMode: "immediate",
-    sideEffect: true,
-  },
-  {
-    name: "get_runtime_coordination_map",
-    description: "List governed runtime targets with recent verification events so operators can see what is deployed where and what is safe to merge.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        kind: { type: "string", enum: RUNTIME_COORDINATION_TOOL_ENUMS.targetKinds, description: "Filter by target kind." },
-        status: { type: "string", enum: RUNTIME_COORDINATION_TOOL_ENUMS.targetStatuses, description: "Filter by target status." },
-        limit: { type: "number", description: "Max targets (default 50, max 100)." },
-      },
-      required: [],
-    },
-    requiredCapability: "view_platform",
-    executionMode: "immediate",
-    sideEffect: false,
   },
   // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────────
   {
@@ -5603,26 +5489,6 @@ export async function executeTool(
     case "record_capsule_evidence": {
       const { recordCapsuleEvidenceTool } = await import("@/lib/work-capsules/mcp-handlers");
       return recordCapsuleEvidenceTool(params, userId, context);
-    }
-    case "register_runtime_target": {
-      const { registerRuntimeTargetTool } = await import("@/lib/runtime-coordination/mcp-handlers");
-      return registerRuntimeTargetTool(params, userId, context);
-    }
-    case "heartbeat_runtime_target": {
-      const { heartbeatRuntimeTargetTool } = await import("@/lib/runtime-coordination/mcp-handlers");
-      return heartbeatRuntimeTargetTool(params);
-    }
-    case "release_runtime_target": {
-      const { releaseRuntimeTargetTool } = await import("@/lib/runtime-coordination/mcp-handlers");
-      return releaseRuntimeTargetTool(params, userId, context);
-    }
-    case "record_runtime_verification": {
-      const { recordRuntimeVerificationTool } = await import("@/lib/runtime-coordination/mcp-handlers");
-      return recordRuntimeVerificationTool(params, userId, context);
-    }
-    case "get_runtime_coordination_map": {
-      const { getRuntimeCoordinationMapTool } = await import("@/lib/runtime-coordination/mcp-handlers");
-      return getRuntimeCoordinationMapTool(params);
     }
     case "spawn_work_thread": {
       if (!context?.threadId) {

--- a/apps/web/lib/mcp/packs/runtime-coordination-pack.ts
+++ b/apps/web/lib/mcp/packs/runtime-coordination-pack.ts
@@ -1,0 +1,157 @@
+// Runtime-coordination tool pack — BI-ARCH-TOOLPACKS.
+//
+// Second extraction, and the first with LAZY handlers: the handlers live in
+// @/lib/runtime-coordination/mcp-handlers and were dynamically imported per
+// switch case, so the pack's handler map preserves that exactly — each handler
+// is a thin wrapper that lazy-imports the module only when the tool is called
+// (and passes the same arguments the switch case did). Definitions are moved
+// verbatim from mcp-tools.ts; grants mirror agent-grants.ts TOOL_TO_GRANTS.
+
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import { runtimeCoordinationToolEnums } from "@/lib/runtime-coordination/mcp-handlers";
+import type { ToolPack } from "../tool-pack";
+
+const ENUMS = runtimeCoordinationToolEnums();
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "register_runtime_target",
+    description:
+      "Register or refresh the governed runtime surface where work is being verified. Source ownership is read through Work Capsule, FeatureBuild, Sandbox, or GitPromotionCandidate links.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        targetId: { type: "string", description: "Stable runtime target id, e.g. RT-ROOT-PORTAL or RT-SANDBOX-<sandboxRowId>." },
+        kind: { type: "string", enum: ENUMS.targetKinds, description: "Runtime target kind." },
+        status: { type: "string", enum: ENUMS.targetStatuses, description: "Runtime target status." },
+        capsuleId: { type: "string", description: "Optional semantic Work Capsule id (WC-*)." },
+        workCapsuleId: { type: "string", description: "Optional internal WorkCapsule row id; prefer capsuleId for external agents." },
+        buildId: { type: "string", description: "Optional semantic FeatureBuild id (FB-*)." },
+        featureBuildId: { type: "string", description: "Optional internal FeatureBuild row id; prefer buildId for external agents." },
+        sandboxId: { type: "string", description: "Optional Sandbox row id." },
+        slotId: { type: "string", description: "Optional SandboxSlot row id." },
+        composeProjectName: { type: "string", description: "Compose project name when applicable." },
+        serviceName: { type: "string", description: "Compose service name when applicable." },
+        containerName: { type: "string", description: "Docker container name when applicable." },
+        hostUrl: { type: "string", description: "Host-reachable URL." },
+        internalUrl: { type: "string", description: "Container/internal URL." },
+        port: { type: "number", description: "Host port when applicable." },
+        serviceVersion: { type: "string", description: "OpenTelemetry service.version style artifact string, e.g. image + git SHA." },
+        acceptanceRoleOverride: { type: "string", enum: ["debug-only"], description: "Rare override. Most roles are derived from kind." },
+        debugReason: { type: "string", description: "Required for ad-hoc-debug targets." },
+        expiresAt: { type: "string", description: "Optional ISO timestamp for temporary targets." },
+        metadata: { type: "object", description: "Free-form snapshot data; never the source of truth." },
+      },
+      required: ["targetId", "kind", "status"],
+    },
+    requiredCapability: "manage_backlog",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "heartbeat_runtime_target",
+    description: "Refresh the heartbeat for a governed runtime target.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        targetId: { type: "string", description: "Stable runtime target id." },
+      },
+      required: ["targetId"],
+    },
+    requiredCapability: "manage_backlog",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "release_runtime_target",
+    description: "Mark a governed runtime target released so another thread can safely use the surface.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        targetId: { type: "string", description: "Stable runtime target id." },
+      },
+      required: ["targetId"],
+    },
+    requiredCapability: "manage_backlog",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "record_runtime_verification",
+    description:
+      "Record a typed verification event against exactly one primary runtime/build/promotion attach point, with optional evidence links.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        verificationId: { type: "string", description: "Stable verification id." },
+        kind: { type: "string", enum: ENUMS.verificationKinds, description: "Verification kind." },
+        status: { type: "string", enum: ENUMS.verificationStatuses, description: "Verification status." },
+        targetId: { type: "string", description: "Optional stable RuntimeTarget id (RT-*)." },
+        runtimeTargetId: { type: "string", description: "Optional RuntimeTarget row id; RT-* targetId is also accepted for compatibility." },
+        capsuleId: { type: "string", description: "Optional semantic Work Capsule id (WC-*) for capsule-only or mirrored evidence." },
+        workCapsuleId: { type: "string", description: "Optional WorkCapsule row id; prefer capsuleId for external agents." },
+        buildId: { type: "string", description: "Optional semantic FeatureBuild id (FB-*)." },
+        featureBuildId: { type: "string", description: "Optional FeatureBuild row id; prefer buildId for external agents." },
+        candidateId: { type: "string", description: "Optional semantic GitPromotionCandidate id." },
+        gitPromotionCandidateId: { type: "string", description: "Optional GitPromotionCandidate row id; prefer candidateId for external agents." },
+        command: { type: "string", description: "Command that produced the verification." },
+        url: { type: "string", description: "URL checked." },
+        evidenceUrl: { type: "string", description: "Evidence URL." },
+        screenshotUrl: { type: "string", description: "Screenshot URL." },
+        toolExecutionId: { type: "string", description: "ToolExecution row id." },
+        buildActivityId: { type: "string", description: "BuildActivity row id." },
+        backlogActivityId: { type: "string", description: "BacklogItemActivity row id." },
+        capsuleActivityId: { type: "string", description: "WorkCapsuleActivity row id." },
+        startedAt: { type: "string", description: "Optional ISO start timestamp." },
+        completedAt: { type: "string", description: "Optional ISO completion timestamp." },
+        result: { type: "object", description: "Structured result payload." },
+      },
+      required: ["verificationId", "kind", "status"],
+    },
+    requiredCapability: "manage_backlog",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "get_runtime_coordination_map",
+    description:
+      "List governed runtime targets with recent verification events so operators can see what is deployed where and what is safe to merge.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kind: { type: "string", enum: ENUMS.targetKinds, description: "Filter by target kind." },
+        status: { type: "string", enum: ENUMS.targetStatuses, description: "Filter by target status." },
+        limit: { type: "number", description: "Max targets (default 50, max 100)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+];
+
+const HANDLERS = () => import("@/lib/runtime-coordination/mcp-handlers");
+
+export const runtimeCoordinationPack: ToolPack = {
+  packId: "runtime-coordination",
+  definitions,
+  handlers: {
+    register_runtime_target: (params, userId, context) =>
+      HANDLERS().then((m) => m.registerRuntimeTargetTool(params, userId, context)),
+    heartbeat_runtime_target: (params) => HANDLERS().then((m) => m.heartbeatRuntimeTargetTool(params)),
+    release_runtime_target: (params, userId, context) =>
+      HANDLERS().then((m) => m.releaseRuntimeTargetTool(params, userId, context)),
+    record_runtime_verification: (params, userId, context) =>
+      HANDLERS().then((m) => m.recordRuntimeVerificationTool(params, userId, context)),
+    get_runtime_coordination_map: (params) =>
+      HANDLERS().then((m) => m.getRuntimeCoordinationMapTool(params)),
+  },
+  grants: {
+    register_runtime_target: ["work_capsule_write"],
+    heartbeat_runtime_target: ["work_capsule_write"],
+    release_runtime_target: ["work_capsule_write"],
+    record_runtime_verification: ["work_capsule_write"],
+    get_runtime_coordination_map: ["work_capsule_read"],
+  },
+};

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -6,6 +6,7 @@ import { PLATFORM_TOOLS } from "@/lib/mcp-tools";
 import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
 
 import { deliberationSiemPack } from "./packs/deliberation-siem-pack";
+import { runtimeCoordinationPack } from "./packs/runtime-coordination-pack";
 import { composeToolPacks } from "./tool-registry";
 
 // BI-ARCH-TOOLPACKS parity guard: the first extracted pack must stay
@@ -37,6 +38,34 @@ describe("deliberation-siem tool pack", () => {
   });
 });
 
+describe("runtime-coordination tool pack", () => {
+  it("bundles its five runtime tools, each with a (lazy) handler", () => {
+    expect(runtimeCoordinationPack.definitions.map((t) => t.name).sort()).toEqual([
+      "get_runtime_coordination_map",
+      "heartbeat_runtime_target",
+      "record_runtime_verification",
+      "register_runtime_target",
+      "release_runtime_target",
+    ]);
+    for (const def of runtimeCoordinationPack.definitions) {
+      expect(runtimeCoordinationPack.handlers[def.name], def.name).toBeTypeOf("function");
+    }
+  });
+
+  it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
+    for (const [name, grants] of Object.entries(runtimeCoordinationPack.grants)) {
+      expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
+    }
+  });
+
+  it("keeps every pack tool present in the live PLATFORM_TOOLS registry", () => {
+    const platformNames = new Set(PLATFORM_TOOLS.map((t) => t.name));
+    for (const def of runtimeCoordinationPack.definitions) {
+      expect(platformNames.has(def.name), def.name).toBe(true);
+    }
+  });
+});
+
 describe("composeToolPacks", () => {
   it("composes definitions + handler/grant lookup from packs", () => {
     const registry = composeToolPacks([deliberationSiemPack]);
@@ -44,6 +73,14 @@ describe("composeToolPacks", () => {
     expect(registry.getHandler("deliberate_on")).toBeTypeOf("function");
     expect(registry.getHandler("not_a_tool")).toBeUndefined();
     expect(registry.getGrants("open_security_case")).toEqual(["siem_investigate"]);
+  });
+
+  it("composes the two real packs without collision", () => {
+    const registry = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack]);
+    expect(registry.definitions).toHaveLength(
+      deliberationSiemPack.definitions.length + runtimeCoordinationPack.definitions.length,
+    );
+    expect(registry.getHandler("register_runtime_target")).toBeTypeOf("function");
   });
 
   it("rejects the same tool name claimed by two packs", () => {

--- a/docs/architecture/mcp-tool-packs.md
+++ b/docs/architecture/mcp-tool-packs.md
@@ -56,9 +56,22 @@ grant metadata matches `TOOL_TO_GRANTS`, and every pack tool is still present in
 `PLATFORM_TOOLS`; `mcp-tools-{siem,deliberation}.test.ts` + `mcp-governed-execute.test.ts`
 keep the dispatch path honest.
 
+## Second pack — lazy handlers
+
+[`runtime-coordination-pack`](../../apps/web/lib/mcp/packs/runtime-coordination-pack.ts)
+proves the pattern handles **lazy** handlers. Unlike Deliberation/SIEM (static imports), the
+runtime handlers live in a sibling module that the switch cases `await import(...)`-ed per
+call. The pack preserves that: each handler is a thin wrapper that lazy-imports the module
+only when the tool is invoked (passing the same arguments the switch case did, including the
+mixed arities). Its five definitions were moved verbatim out of the inline `PLATFORM_TOOLS`
+array (and the now-unused `RUNTIME_COORDINATION_TOOL_ENUMS` plumbing removed); they compose
+back through the registry, dispatch through `registry.getHandler(...)`, and the five switch
+cases are gone. `tool-registry.test.ts` + `mcp-tools-runtime-coordination.test.ts` prove
+parity. This de-risks the remaining lazy domains (work-capsules, workbooks).
+
 ## Next packs
 
-Per the spec, the highest-value next extractions are the largest cohesive clusters:
-`backlog` + `build-evidence`, `work-capsules` + `runtime-coordination`, `sandbox`, then
-`wiki/knowledge`. Each follows the same parity-first discipline and keeps the existing
-MCP-route, grant-filter, and `mcp-governed-execute` tests green.
+Per the spec, the highest-value remaining extractions are the largest cohesive clusters:
+`backlog` + `build-evidence`, `work-capsules`, `sandbox`, then `wiki/knowledge`. Each follows
+the same parity-first discipline and keeps the existing MCP-route, grant-filter, and
+`mcp-governed-execute` tests green.


### PR DESCRIPTION
Continues the toolpacks split here. Second domain pack, and the **first with lazy handlers** — proving the pattern handles the lazy-imported domains too (which de-risks work-capsules / workbooks).

## What
- **`lib/mcp/packs/runtime-coordination-pack.ts`** — the 5 runtime-coordination tools. Definitions moved **verbatim** out of the inline `PLATFORM_TOOLS` array; each handler is a thin wrapper that `await import(...)`s `@/lib/runtime-coordination/mcp-handlers` only when the tool is called, passing the same arguments the switch cases did (including the mixed 1-arg / 3-arg call sites). Grants mirror `TOOL_TO_GRANTS`.
- **`mcp-tools.ts`** — register the pack in the registry; remove the inline runtime definitions, the 5 switch cases, and the now-unused `RUNTIME_COORDINATION_TOOL_ENUMS` + its import. Definitions compose back through the registry; dispatch routes through `registry.getHandler(...)` (after the kernel gate). **Zero behavioral change.**
- **`tool-registry.test.ts`** — runtime-pack parity (5 tools, handler-per-def, grants match `TOOL_TO_GRANTS`, all present in `PLATFORM_TOOLS`) + two-pack composition.
- **`docs/architecture/mcp-tool-packs.md`** — the second-pack / lazy-handler note.

## Verification (web worktree, `prisma generate`)
- `pnpm --filter web typecheck` — **clean**
- `tool-registry` (10) + `mcp-tools-runtime-coordination` + `mcp-tools` (34) + `mcp-governed-execute` — **63+ tests pass**

Two packs down (deliberation+SIEM static, runtime-coordination lazy). Next, same parity-first path: backlog/build-evidence, work-capsules, sandbox, wiki/knowledge.

EP-PLATFORM-CONSOLIDATION · spec §6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)