### PR TITLE
refactor(mcp): fourth tool pack — workbooks (lazy) (BI-ARCH-TOOLPACKS)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -41,6 +41,7 @@ import {
 // through the registry (no per-tool handler imports or switch cases here anymore).
 import { deliberationSiemPack } from "@/lib/mcp/packs/deliberation-siem-pack";
 import { runtimeCoordinationPack } from "@/lib/mcp/packs/runtime-coordination-pack";
+import { workCapsulesPack } from "@/lib/mcp/packs/work-capsules-pack";
 import { composeToolPacks } from "@/lib/mcp/tool-registry";
 import {
   createLicenseReadinessIssue,
@@ -66,7 +67,6 @@ import {
   submitCoworkerSelfAssessment,
 } from "@/lib/coworker-self-assessment/assessment-service";
 import { inferProviderIdFromRouteContext } from "@/lib/ai-provider-route-context";
-import { workCapsuleToolEnums } from "@/lib/work-capsules/mcp-handlers";
 import {
   COWORKER_ASSESSMENT_CONFIDENCE,
   COWORKER_ASSESSMENT_VERDICTS,
@@ -428,11 +428,10 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 
-const WORK_CAPSULE_TOOL_ENUMS = workCapsuleToolEnums();
 
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,
@@ -760,189 +759,6 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: "manage_workbooks",
     executionMode: "immediate",
-    sideEffect: true,
-  },
-  {
-    name: "list_work_capsules",
-    description: "List Work Capsule coordination records for active portal, Build Studio, and external agent work. Read-only.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        status: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.statuses, description: "Filter by Work Capsule status." },
-        limit: { type: "number", description: "Max results (default 50, max 100)." },
-      },
-      required: [],
-    },
-    requiredCapability: "view_platform",
-    executionMode: "immediate",
-    sideEffect: false,
-  },
-  {
-    name: "get_work_capsule",
-    description: "Fetch one Work Capsule with its recent activity timeline. Read-only.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
-      },
-      required: ["capsuleId"],
-    },
-    requiredCapability: "view_platform",
-    executionMode: "immediate",
-    sideEffect: false,
-  },
-  {
-    name: "create_work_capsule",
-    description: "Create a Work Capsule coordination record for planned work. Idempotency key is required so retries do not duplicate capsule activity.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        title: { type: "string", description: "Short capsule title." },
-        objective: { type: "string", description: "Outcome this capsule coordinates." },
-        source: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.sources, description: "Origin of the capsule." },
-        idempotencyKey: { type: "string", description: "Stable caller-provided key used to make create retries idempotent." },
-        executorKind: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.executors, description: "Optional executor expected to work the capsule." },
-      },
-      required: ["title", "objective", "source", "idempotencyKey"],
-    },
-    requiredCapability: "manage_backlog",
-    sideEffect: true,
-  },
-  {
-    name: "plan_capsule_worktree",
-    description: "Generate and persist the deterministic branch and worktree-path plan for a Work Capsule. Idempotent: re-planning returns the existing plan and refuses to propose the root clone.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
-        taxonomy: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.taxonomies, description: "AGENTS.md branch prefix." },
-      },
-      required: ["capsuleId", "taxonomy"],
-    },
-    requiredCapability: "manage_backlog",
-    executionMode: "immediate",
-    sideEffect: true,
-  },
-  {
-    name: "adopt_worktree",
-    description: "Adopt an existing local branch/worktree pair into a Work Capsule without creating a new worktree.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        title: { type: "string", description: "Short capsule title." },
-        objective: { type: "string", description: "Outcome this adopted work should reach." },
-        repositoryFullName: { type: "string", description: "GitHub repository full name, for example OpenDigitalProductFactory/opendigitalproductfactory." },
-        headBranch: { type: "string", description: "Existing branch to adopt." },
-        worktreePath: { type: "string", description: "Local worktree path for the branch." },
-        baseBranch: { type: "string", description: "Optional base branch (defaults to main)." },
-        baseSha: { type: "string", description: "Optional current base SHA." },
-        headSha: { type: "string", description: "Optional current head SHA." },
-        executorKind: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.executors, description: "Optional executor adopting the worktree." },
-      },
-      required: ["title", "objective", "repositoryFullName", "headBranch", "worktreePath"],
-    },
-    requiredCapability: "manage_backlog",
-    sideEffect: true,
-  },
-  {
-    name: "claim_capsule_scope",
-    description: "Claim path/module/package/route/skill/prompt scope for a Work Capsule. Repeated claims refresh the existing scope entry. Rejected with error=scope_conflict if another active Work Capsule already holds an overlapping edit claim — coordinate, claim different scope, or pass force=true to deliberately co-claim.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
-        claims: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              kind: { type: "string", enum: ["path", "module", "package", "route", "skill", "prompt"] },
-              value: { type: "string", description: "Claimed scope value." },
-              intent: { type: "string", enum: ["edit", "read"] },
-            },
-            required: ["kind", "value", "intent"],
-          },
-          description: "Scope claims to add or refresh.",
-        },
-        force: { type: "boolean", description: "Deliberately co-claim scope despite an active overlap on another Work Capsule (default false). The override is recorded on the capsule activity log." },
-      },
-      required: ["capsuleId", "claims"],
-    },
-    requiredCapability: "manage_backlog",
-    sideEffect: true,
-  },
-  {
-    name: "heartbeat_capsule",
-    description: "Renew the active lease for a Work Capsule so other agents can see that work is in flight.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
-      },
-      required: ["capsuleId"],
-    },
-    requiredCapability: "manage_backlog",
-    sideEffect: true,
-  },
-  {
-    name: "update_work_capsule_status",
-    description: "Set a Work Capsule status and record a temporary operator-visible status override reason.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
-        status: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.statuses, description: "Next Work Capsule status." },
-        reason: { type: "string", description: "Reason for the status update or override." },
-      },
-      required: ["capsuleId", "status", "reason"],
-    },
-    requiredCapability: "manage_backlog",
-    sideEffect: true,
-  },
-  {
-    name: "release_capsule_scope",
-    description: "Release previously claimed Work Capsule scope items by kind and value.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
-        claims: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              kind: { type: "string", enum: ["path", "module", "package", "route", "skill", "prompt"] },
-              value: { type: "string", description: "Scope value to release." },
-            },
-            required: ["kind", "value"],
-          },
-          description: "Scope claims to release.",
-        },
-      },
-      required: ["capsuleId", "claims"],
-    },
-    requiredCapability: "manage_backlog",
-    sideEffect: true,
-  },
-  {
-    name: "record_capsule_evidence",
-    description: "Append an evidence entry to a Work Capsule activity timeline.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
-        kind: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.evidenceKinds, description: "Evidence kind." },
-        summary: { type: "string", description: "Evidence summary." },
-        command: { type: "string", description: "Optional command that produced the evidence." },
-        url: { type: "string", description: "Optional URL for PRs, CI runs, screenshots, or external evidence." },
-        targetId: { type: "string", description: "Optional stable RuntimeTarget id (RT-*)." },
-        runtimeTargetId: { type: "string", description: "Optional RuntimeTarget row id." },
-        verificationId: { type: "string", description: "Optional RuntimeVerification id (RV-*)." },
-        result: { type: "object", description: "Optional structured result payload." },
-      },
-      required: ["capsuleId", "summary"],
-    },
-    requiredCapability: "manage_backlog",
     sideEffect: true,
   },
   // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────────
@@ -5449,46 +5265,6 @@ export async function executeTool(
     case "workbook_update_cells": {
       const { workbookUpdateCellsTool } = await import("@/lib/workbooks/mcp-handlers");
       return workbookUpdateCellsTool(params, userId);
-    }
-    case "list_work_capsules": {
-      const { listWorkCapsulesTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return listWorkCapsulesTool(params);
-    }
-    case "get_work_capsule": {
-      const { getWorkCapsuleTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return getWorkCapsuleTool(params);
-    }
-    case "create_work_capsule": {
-      const { createWorkCapsuleTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return createWorkCapsuleTool(params, userId, context);
-    }
-    case "plan_capsule_worktree": {
-      const { planCapsuleWorktreeTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return planCapsuleWorktreeTool(params, userId, context);
-    }
-    case "adopt_worktree": {
-      const { adoptWorktreeTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return adoptWorktreeTool(params, userId, context);
-    }
-    case "claim_capsule_scope": {
-      const { claimCapsuleScopeTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return claimCapsuleScopeTool(params, userId, context);
-    }
-    case "heartbeat_capsule": {
-      const { heartbeatCapsuleTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return heartbeatCapsuleTool(params, userId, context);
-    }
-    case "update_work_capsule_status": {
-      const { updateWorkCapsuleStatusTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return updateWorkCapsuleStatusTool(params, userId, context);
-    }
-    case "release_capsule_scope": {
-      const { releaseCapsuleScopeTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return releaseCapsuleScopeTool(params, userId, context);
-    }
-    case "record_capsule_evidence": {
-      const { recordCapsuleEvidenceTool } = await import("@/lib/work-capsules/mcp-handlers");
-      return recordCapsuleEvidenceTool(params, userId, context);
     }
     case "spawn_work_thread": {
       if (!context?.threadId) {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -42,6 +42,7 @@ import {
 import { deliberationSiemPack } from "@/lib/mcp/packs/deliberation-siem-pack";
 import { runtimeCoordinationPack } from "@/lib/mcp/packs/runtime-coordination-pack";
 import { workCapsulesPack } from "@/lib/mcp/packs/work-capsules-pack";
+import { workbooksPack } from "@/lib/mcp/packs/workbooks-pack";
 import { composeToolPacks } from "@/lib/mcp/tool-registry";
 import {
   createLicenseReadinessIssue,
@@ -431,7 +432,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,
@@ -673,93 +674,6 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "immediate",
     sideEffect: false,
     buildPhases: ["ideate"],
-  },
-  // ─── Work Capsule control harness (spec 2026-05-14) ────────────────────────
-  {
-    name: "workbook_list_tables",
-    description: "List the Workbook tables the agent can access (grid/spreadsheet data). Read-only. Pass workbookId to scope to one workbook.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        workbookId: { type: "string", description: "Optional semantic workbook id (WB-*) to scope to." },
-      },
-      required: [],
-    },
-    requiredCapability: "view_workbooks",
-    executionMode: "immediate",
-    sideEffect: false,
-  },
-  {
-    name: "workbook_get_schema",
-    description: "Get a Workbook table's column definitions and the agent's capabilities on it. Read-only.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
-      },
-      required: ["tableId"],
-    },
-    requiredCapability: "view_workbooks",
-    executionMode: "immediate",
-    sideEffect: false,
-  },
-  {
-    name: "workbook_query_rows",
-    description: "Query rows from a Workbook table with optional sort/filter and cursor pagination. Read-only. Cells are keyed by columnId (COL-*).",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
-        limit: { type: "number", description: "Max rows (default 50, max 200)." },
-        cursor: { type: "string", description: "Pagination cursor (rowId of the last row from the previous page)." },
-        sort: {
-          type: "array",
-          description: "Sort specs.",
-          items: {
-            type: "object",
-            properties: {
-              columnId: { type: "string" },
-              direction: { type: "string", enum: ["asc", "desc"] },
-            },
-          },
-        },
-      },
-      required: ["tableId"],
-    },
-    requiredCapability: "view_workbooks",
-    executionMode: "immediate",
-    sideEffect: false,
-  },
-  {
-    name: "workbook_create_row",
-    description: "Insert a new row into a custom Workbook table. cells is a map of columnId (COL-*) to value; values are validated against each column's field type.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
-        cells: { type: "object", description: "Map of columnId -> value.", additionalProperties: true },
-      },
-      required: ["tableId"],
-    },
-    requiredCapability: "manage_workbooks",
-    executionMode: "immediate",
-    sideEffect: true,
-  },
-  {
-    name: "workbook_update_cells",
-    description: "Update specific cells in a Workbook row. cells is a map of columnId (COL-*) to new value, validated against each column's field type.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
-        rowId: { type: "string", description: "Semantic row id (ROW-*)." },
-        cells: { type: "object", description: "Map of columnId -> new value.", additionalProperties: true },
-      },
-      required: ["tableId", "rowId"],
-    },
-    requiredCapability: "manage_workbooks",
-    executionMode: "immediate",
-    sideEffect: true,
   },
   // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────────
   {
@@ -5245,26 +5159,6 @@ export async function executeTool(
         success: true,
         message: "probe tool body — should not be reached when gate is wired and DPF_TEST_MCP_REFUSE_PROBE=1",
       };
-    }
-    case "workbook_list_tables": {
-      const { workbookListTablesTool } = await import("@/lib/workbooks/mcp-handlers");
-      return workbookListTablesTool(params, userId);
-    }
-    case "workbook_get_schema": {
-      const { workbookGetSchemaTool } = await import("@/lib/workbooks/mcp-handlers");
-      return workbookGetSchemaTool(params, userId);
-    }
-    case "workbook_query_rows": {
-      const { workbookQueryRowsTool } = await import("@/lib/workbooks/mcp-handlers");
-      return workbookQueryRowsTool(params, userId);
-    }
-    case "workbook_create_row": {
-      const { workbookCreateRowTool } = await import("@/lib/workbooks/mcp-handlers");
-      return workbookCreateRowTool(params, userId);
-    }
-    case "workbook_update_cells": {
-      const { workbookUpdateCellsTool } = await import("@/lib/workbooks/mcp-handlers");
-      return workbookUpdateCellsTool(params, userId);
     }
     case "spawn_work_thread": {
       if (!context?.threadId) {

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -1,0 +1,232 @@
+// Work-capsules tool pack — BI-ARCH-TOOLPACKS.
+//
+// Third domain pack, second lazy one. Handlers live in
+// @/lib/work-capsules/mcp-handlers and were dynamically imported per switch
+// case; each handler here is a thin wrapper that lazy-imports the module only
+// when the tool is called, passing the same arguments the switch case did (the
+// two read tools take params only; the write tools take params + userId +
+// context). Definitions were moved verbatim out of the inline PLATFORM_TOOLS
+// array; grants mirror agent-grants.ts TOOL_TO_GRANTS.
+
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import { workCapsuleToolEnums } from "@/lib/work-capsules/mcp-handlers";
+import type { ToolPack } from "../tool-pack";
+
+const ENUMS = workCapsuleToolEnums();
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "list_work_capsules",
+    description: "List Work Capsule coordination records for active portal, Build Studio, and external agent work. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ENUMS.statuses, description: "Filter by Work Capsule status." },
+        limit: { type: "number", description: "Max results (default 50, max 100)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "get_work_capsule",
+    description: "Fetch one Work Capsule with its recent activity timeline. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+      },
+      required: ["capsuleId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "create_work_capsule",
+    description: "Create a Work Capsule coordination record for planned work. Idempotency key is required so retries do not duplicate capsule activity.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Short capsule title." },
+        objective: { type: "string", description: "Outcome this capsule coordinates." },
+        source: { type: "string", enum: ENUMS.sources, description: "Origin of the capsule." },
+        idempotencyKey: { type: "string", description: "Stable caller-provided key used to make create retries idempotent." },
+        executorKind: { type: "string", enum: ENUMS.executors, description: "Optional executor expected to work the capsule." },
+      },
+      required: ["title", "objective", "source", "idempotencyKey"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "plan_capsule_worktree",
+    description: "Generate and persist the deterministic branch and worktree-path plan for a Work Capsule. Idempotent: re-planning returns the existing plan and refuses to propose the root clone.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+        taxonomy: { type: "string", enum: ENUMS.taxonomies, description: "AGENTS.md branch prefix." },
+      },
+      required: ["capsuleId", "taxonomy"],
+    },
+    requiredCapability: "manage_backlog",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "adopt_worktree",
+    description: "Adopt an existing local branch/worktree pair into a Work Capsule without creating a new worktree.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Short capsule title." },
+        objective: { type: "string", description: "Outcome this adopted work should reach." },
+        repositoryFullName: { type: "string", description: "GitHub repository full name, for example OpenDigitalProductFactory/opendigitalproductfactory." },
+        headBranch: { type: "string", description: "Existing branch to adopt." },
+        worktreePath: { type: "string", description: "Local worktree path for the branch." },
+        baseBranch: { type: "string", description: "Optional base branch (defaults to main)." },
+        baseSha: { type: "string", description: "Optional current base SHA." },
+        headSha: { type: "string", description: "Optional current head SHA." },
+        executorKind: { type: "string", enum: ENUMS.executors, description: "Optional executor adopting the worktree." },
+      },
+      required: ["title", "objective", "repositoryFullName", "headBranch", "worktreePath"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "claim_capsule_scope",
+    description: "Claim path/module/package/route/skill/prompt scope for a Work Capsule. Repeated claims refresh the existing scope entry. Rejected with error=scope_conflict if another active Work Capsule already holds an overlapping edit claim — coordinate, claim different scope, or pass force=true to deliberately co-claim.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+        claims: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              kind: { type: "string", enum: ["path", "module", "package", "route", "skill", "prompt"] },
+              value: { type: "string", description: "Claimed scope value." },
+              intent: { type: "string", enum: ["edit", "read"] },
+            },
+            required: ["kind", "value", "intent"],
+          },
+          description: "Scope claims to add or refresh.",
+        },
+        force: { type: "boolean", description: "Deliberately co-claim scope despite an active overlap on another Work Capsule (default false). The override is recorded on the capsule activity log." },
+      },
+      required: ["capsuleId", "claims"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "heartbeat_capsule",
+    description: "Renew the active lease for a Work Capsule so other agents can see that work is in flight.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+      },
+      required: ["capsuleId"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "update_work_capsule_status",
+    description: "Set a Work Capsule status and record a temporary operator-visible status override reason.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+        status: { type: "string", enum: ENUMS.statuses, description: "Next Work Capsule status." },
+        reason: { type: "string", description: "Reason for the status update or override." },
+      },
+      required: ["capsuleId", "status", "reason"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "release_capsule_scope",
+    description: "Release previously claimed Work Capsule scope items by kind and value.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+        claims: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              kind: { type: "string", enum: ["path", "module", "package", "route", "skill", "prompt"] },
+              value: { type: "string", description: "Scope value to release." },
+            },
+            required: ["kind", "value"],
+          },
+          description: "Scope claims to release.",
+        },
+      },
+      required: ["capsuleId", "claims"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "record_capsule_evidence",
+    description: "Append an evidence entry to a Work Capsule activity timeline.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+        kind: { type: "string", enum: ENUMS.evidenceKinds, description: "Evidence kind." },
+        summary: { type: "string", description: "Evidence summary." },
+        command: { type: "string", description: "Optional command that produced the evidence." },
+        url: { type: "string", description: "Optional URL for PRs, CI runs, screenshots, or external evidence." },
+        targetId: { type: "string", description: "Optional stable RuntimeTarget id (RT-*)." },
+        runtimeTargetId: { type: "string", description: "Optional RuntimeTarget row id." },
+        verificationId: { type: "string", description: "Optional RuntimeVerification id (RV-*)." },
+        result: { type: "object", description: "Optional structured result payload." },
+      },
+      required: ["capsuleId", "summary"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+];
+
+const HANDLERS = () => import("@/lib/work-capsules/mcp-handlers");
+
+export const workCapsulesPack: ToolPack = {
+  packId: "work-capsules",
+  definitions,
+  handlers: {
+    list_work_capsules: (params) => HANDLERS().then((m) => m.listWorkCapsulesTool(params)),
+    get_work_capsule: (params) => HANDLERS().then((m) => m.getWorkCapsuleTool(params)),
+    create_work_capsule: (params, userId, context) => HANDLERS().then((m) => m.createWorkCapsuleTool(params, userId, context)),
+    plan_capsule_worktree: (params, userId, context) => HANDLERS().then((m) => m.planCapsuleWorktreeTool(params, userId, context)),
+    adopt_worktree: (params, userId, context) => HANDLERS().then((m) => m.adoptWorktreeTool(params, userId, context)),
+    claim_capsule_scope: (params, userId, context) => HANDLERS().then((m) => m.claimCapsuleScopeTool(params, userId, context)),
+    heartbeat_capsule: (params, userId, context) => HANDLERS().then((m) => m.heartbeatCapsuleTool(params, userId, context)),
+    update_work_capsule_status: (params, userId, context) => HANDLERS().then((m) => m.updateWorkCapsuleStatusTool(params, userId, context)),
+    release_capsule_scope: (params, userId, context) => HANDLERS().then((m) => m.releaseCapsuleScopeTool(params, userId, context)),
+    record_capsule_evidence: (params, userId, context) => HANDLERS().then((m) => m.recordCapsuleEvidenceTool(params, userId, context)),
+  },
+  grants: {
+    list_work_capsules: ["work_capsule_read"],
+    get_work_capsule: ["work_capsule_read"],
+    create_work_capsule: ["work_capsule_write"],
+    plan_capsule_worktree: ["work_capsule_write"],
+    adopt_worktree: ["work_capsule_adopt"],
+    claim_capsule_scope: ["work_capsule_write"],
+    heartbeat_capsule: ["work_capsule_write"],
+    update_work_capsule_status: ["work_capsule_write"],
+    release_capsule_scope: ["work_capsule_write"],
+    record_capsule_evidence: ["work_capsule_write"],
+  },
+};

--- a/apps/web/lib/mcp/packs/workbooks-pack.ts
+++ b/apps/web/lib/mcp/packs/workbooks-pack.ts
@@ -1,0 +1,120 @@
+// Workbooks tool pack — BI-ARCH-TOOLPACKS.
+//
+// Fourth domain pack (third lazy one), and the last clean lazy domain. Handlers
+// live in @/lib/workbooks/mcp-handlers and were dynamically imported per switch
+// case; each handler here is a thin wrapper that lazy-imports the module only
+// when the tool is called (all five take params + userId). Definitions moved
+// verbatim out of the inline PLATFORM_TOOLS array; grants mirror TOOL_TO_GRANTS.
+
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "workbook_list_tables",
+    description: "List the Workbook tables the agent can access (grid/spreadsheet data). Read-only. Pass workbookId to scope to one workbook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        workbookId: { type: "string", description: "Optional semantic workbook id (WB-*) to scope to." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_workbooks",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "workbook_get_schema",
+    description: "Get a Workbook table's column definitions and the agent's capabilities on it. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
+      },
+      required: ["tableId"],
+    },
+    requiredCapability: "view_workbooks",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "workbook_query_rows",
+    description: "Query rows from a Workbook table with optional sort/filter and cursor pagination. Read-only. Cells are keyed by columnId (COL-*).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
+        limit: { type: "number", description: "Max rows (default 50, max 200)." },
+        cursor: { type: "string", description: "Pagination cursor (rowId of the last row from the previous page)." },
+        sort: {
+          type: "array",
+          description: "Sort specs.",
+          items: {
+            type: "object",
+            properties: {
+              columnId: { type: "string" },
+              direction: { type: "string", enum: ["asc", "desc"] },
+            },
+          },
+        },
+      },
+      required: ["tableId"],
+    },
+    requiredCapability: "view_workbooks",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "workbook_create_row",
+    description: "Insert a new row into a custom Workbook table. cells is a map of columnId (COL-*) to value; values are validated against each column's field type.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
+        cells: { type: "object", description: "Map of columnId -> value.", additionalProperties: true },
+      },
+      required: ["tableId"],
+    },
+    requiredCapability: "manage_workbooks",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "workbook_update_cells",
+    description: "Update specific cells in a Workbook row. cells is a map of columnId (COL-*) to new value, validated against each column's field type.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tableId: { type: "string", description: "Semantic table id (TBL-*)." },
+        rowId: { type: "string", description: "Semantic row id (ROW-*)." },
+        cells: { type: "object", description: "Map of columnId -> new value.", additionalProperties: true },
+      },
+      required: ["tableId", "rowId"],
+    },
+    requiredCapability: "manage_workbooks",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+];
+
+const HANDLERS = () => import("@/lib/workbooks/mcp-handlers");
+
+export const workbooksPack: ToolPack = {
+  packId: "workbooks",
+  definitions,
+  handlers: {
+    workbook_list_tables: (params, userId) => HANDLERS().then((m) => m.workbookListTablesTool(params, userId)),
+    workbook_get_schema: (params, userId) => HANDLERS().then((m) => m.workbookGetSchemaTool(params, userId)),
+    workbook_query_rows: (params, userId) => HANDLERS().then((m) => m.workbookQueryRowsTool(params, userId)),
+    workbook_create_row: (params, userId) => HANDLERS().then((m) => m.workbookCreateRowTool(params, userId)),
+    workbook_update_cells: (params, userId) => HANDLERS().then((m) => m.workbookUpdateCellsTool(params, userId)),
+  },
+  grants: {
+    workbook_list_tables: ["workbook_read"],
+    workbook_get_schema: ["workbook_read"],
+    workbook_query_rows: ["workbook_read"],
+    workbook_create_row: ["workbook_write"],
+    workbook_update_cells: ["workbook_write"],
+  },
+};

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -8,6 +8,7 @@ import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
 import { deliberationSiemPack } from "./packs/deliberation-siem-pack";
 import { runtimeCoordinationPack } from "./packs/runtime-coordination-pack";
 import { workCapsulesPack } from "./packs/work-capsules-pack";
+import { workbooksPack } from "./packs/workbooks-pack";
 import { composeToolPacks } from "./tool-registry";
 
 // BI-ARCH-TOOLPACKS parity guard: the first extracted pack must stay
@@ -88,6 +89,27 @@ describe("work-capsules tool pack", () => {
   });
 });
 
+describe("workbooks tool pack", () => {
+  it("has a (lazy) handler for every definition", () => {
+    for (const def of workbooksPack.definitions) {
+      expect(workbooksPack.handlers[def.name], def.name).toBeTypeOf("function");
+    }
+  });
+
+  it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
+    for (const [name, grants] of Object.entries(workbooksPack.grants)) {
+      expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
+    }
+  });
+
+  it("keeps every pack tool present in the live PLATFORM_TOOLS registry", () => {
+    const platformNames = new Set(PLATFORM_TOOLS.map((t) => t.name));
+    for (const def of workbooksPack.definitions) {
+      expect(platformNames.has(def.name), def.name).toBe(true);
+    }
+  });
+});
+
 describe("composeToolPacks", () => {
   it("composes definitions + handler/grant lookup from packs", () => {
     const registry = composeToolPacks([deliberationSiemPack]);
@@ -97,15 +119,22 @@ describe("composeToolPacks", () => {
     expect(registry.getGrants("open_security_case")).toEqual(["siem_investigate"]);
   });
 
-  it("composes all three real packs without collision", () => {
-    const registry = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack]);
+  it("composes all four real packs without collision", () => {
+    const registry = composeToolPacks([
+      deliberationSiemPack,
+      runtimeCoordinationPack,
+      workCapsulesPack,
+      workbooksPack,
+    ]);
     expect(registry.definitions).toHaveLength(
       deliberationSiemPack.definitions.length +
         runtimeCoordinationPack.definitions.length +
-        workCapsulesPack.definitions.length,
+        workCapsulesPack.definitions.length +
+        workbooksPack.definitions.length,
     );
     expect(registry.getHandler("register_runtime_target")).toBeTypeOf("function");
     expect(registry.getHandler("create_work_capsule")).toBeTypeOf("function");
+    expect(registry.getHandler("workbook_list_tables")).toBeTypeOf("function");
   });
 
   it("rejects the same tool name claimed by two packs", () => {

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -7,6 +7,7 @@ import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
 
 import { deliberationSiemPack } from "./packs/deliberation-siem-pack";
 import { runtimeCoordinationPack } from "./packs/runtime-coordination-pack";
+import { workCapsulesPack } from "./packs/work-capsules-pack";
 import { composeToolPacks } from "./tool-registry";
 
 // BI-ARCH-TOOLPACKS parity guard: the first extracted pack must stay
@@ -66,6 +67,27 @@ describe("runtime-coordination tool pack", () => {
   });
 });
 
+describe("work-capsules tool pack", () => {
+  it("has a (lazy) handler for every definition", () => {
+    for (const def of workCapsulesPack.definitions) {
+      expect(workCapsulesPack.handlers[def.name], def.name).toBeTypeOf("function");
+    }
+  });
+
+  it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
+    for (const [name, grants] of Object.entries(workCapsulesPack.grants)) {
+      expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
+    }
+  });
+
+  it("keeps every pack tool present in the live PLATFORM_TOOLS registry", () => {
+    const platformNames = new Set(PLATFORM_TOOLS.map((t) => t.name));
+    for (const def of workCapsulesPack.definitions) {
+      expect(platformNames.has(def.name), def.name).toBe(true);
+    }
+  });
+});
+
 describe("composeToolPacks", () => {
   it("composes definitions + handler/grant lookup from packs", () => {
     const registry = composeToolPacks([deliberationSiemPack]);
@@ -75,12 +97,15 @@ describe("composeToolPacks", () => {
     expect(registry.getGrants("open_security_case")).toEqual(["siem_investigate"]);
   });
 
-  it("composes the two real packs without collision", () => {
-    const registry = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack]);
+  it("composes all three real packs without collision", () => {
+    const registry = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack]);
     expect(registry.definitions).toHaveLength(
-      deliberationSiemPack.definitions.length + runtimeCoordinationPack.definitions.length,
+      deliberationSiemPack.definitions.length +
+        runtimeCoordinationPack.definitions.length +
+        workCapsulesPack.definitions.length,
     );
     expect(registry.getHandler("register_runtime_target")).toBeTypeOf("function");
+    expect(registry.getHandler("create_work_capsule")).toBeTypeOf("function");
   });
 
   it("rejects the same tool name claimed by two packs", () => {

--- a/docs/architecture/mcp-tool-packs.md
+++ b/docs/architecture/mcp-tool-packs.md
@@ -67,11 +67,14 @@ mixed arities). Its five definitions were moved verbatim out of the inline `PLAT
 array (and the now-unused `RUNTIME_COORDINATION_TOOL_ENUMS` plumbing removed); they compose
 back through the registry, dispatch through `registry.getHandler(...)`, and the five switch
 cases are gone. `tool-registry.test.ts` + `mcp-tools-runtime-coordination.test.ts` prove
-parity. This de-risks the remaining lazy domains (work-capsules, workbooks).
+parity.
+[`work-capsules-pack`](../../apps/web/lib/mcp/packs/work-capsules-pack.ts) followed it as the
+third pack on the same lazy pattern (10 tools, mixed handler arities); `workbooks` is the one
+remaining small lazy domain.
 
 ## Next packs
 
 Per the spec, the highest-value remaining extractions are the largest cohesive clusters:
-`backlog` + `build-evidence`, `work-capsules`, `sandbox`, then `wiki/knowledge`. Each follows
-the same parity-first discipline and keeps the existing MCP-route, grant-filter, and
+`backlog` + `build-evidence`, `workbooks`, `sandbox`, then `wiki/knowledge`. Each follows the
+same parity-first discipline and keeps the existing MCP-route, grant-filter, and
 `mcp-governed-execute` tests green.

--- a/docs/architecture/mcp-tool-packs.md
+++ b/docs/architecture/mcp-tool-packs.md
@@ -68,13 +68,15 @@ array (and the now-unused `RUNTIME_COORDINATION_TOOL_ENUMS` plumbing removed); t
 back through the registry, dispatch through `registry.getHandler(...)`, and the five switch
 cases are gone. `tool-registry.test.ts` + `mcp-tools-runtime-coordination.test.ts` prove
 parity.
-[`work-capsules-pack`](../../apps/web/lib/mcp/packs/work-capsules-pack.ts) followed it as the
-third pack on the same lazy pattern (10 tools, mixed handler arities); `workbooks` is the one
-remaining small lazy domain.
+[`work-capsules-pack`](../../apps/web/lib/mcp/packs/work-capsules-pack.ts) (10 tools, mixed
+arities) and [`workbooks-pack`](../../apps/web/lib/mcp/packs/workbooks-pack.ts) (5 tools)
+followed on the same lazy pattern as the third and fourth packs — **every sibling-module
+domain (static + lazy) is now extracted.**
 
 ## Next packs
 
-Per the spec, the highest-value remaining extractions are the largest cohesive clusters:
-`backlog` + `build-evidence`, `workbooks`, `sandbox`, then `wiki/knowledge`. Each follows the
-same parity-first discipline and keeps the existing MCP-route, grant-filter, and
-`mcp-governed-execute` tests green.
+The remaining tools have **inline handler bodies** (giant `case` blocks in `mcp-tools.ts`),
+not sibling modules — a larger extraction than the four sibling-module packs done so far. The
+highest-value clusters are `backlog` + `build-evidence`, `sandbox`, then `wiki/knowledge`:
+extract each handler body into a domain module first, then pack it the same parity-first way,
+keeping the existing MCP-route, grant-filter, and `mcp-governed-execute` tests green.


### PR DESCRIPTION
Fourth domain pack — **completes the sibling-module domains** (static + lazy).

> **Stacks on #2393 → #2392.** Merge order: #2392, #2393, then this. Each rebases clean as the prior lands.

## What
- **`lib/mcp/packs/workbooks-pack.ts`** — the 5 workbook grid tools (definitions moved verbatim out of the inline `PLATFORM_TOOLS` array). Each handler is a thin lazy wrapper over `@/lib/workbooks/mcp-handlers` (all five take `params + userId`). Grants mirror `TOOL_TO_GRANTS`.
- **`mcp-tools.ts`** — register the pack; remove the inline definitions + the 5 switch cases. Compose through the registry; dispatch via `registry.getHandler` (after the kernel gate). **Zero behavioral change.**
- **`tool-registry.test.ts`** — workbooks parity + four-pack composition.
- **`docs/architecture/mcp-tool-packs.md`** updated.

## Verification (web worktree, `prisma generate`)
- `pnpm --filter web typecheck` — **clean**
- `tool-registry` (16) + `mcp-tools` (34) + `mcp-governed-execute` + `lib/workbooks` (13) — **all pass**

**Four packs now** (deliberation+SIEM static; runtime, work-capsules, workbooks lazy) — every sibling-module domain is extracted. Remaining = the inline-handler clusters (backlog/build-evidence, sandbox, wiki), which need their handler bodies lifted into modules first.

EP-PLATFORM-CONSOLIDATION · spec §6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)