### PR TITLE
refactor(mcp): fifth tool pack — feedback domain (first inline extraction) (BI-ARCH-TOOLPACKS)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -20,8 +20,6 @@ import { promoteBacklogItemToBuildDraft } from "@/lib/governed-backlog-tee-up";
 import type { BacklogIngestInput } from "@/lib/operate/backlog-ingest";
 import { activeBrandExtractionWhere } from "@/lib/brand/active-extraction";
 import { recordExternalEvidence } from "@/lib/actions/external-evidence";
-import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
-import { escalateReportUpstream } from "@/lib/actions/feedback-escalation";
 import {
   MARKETING_CHANNELS,
   MARKETING_REVIEW_CADENCE,
@@ -43,6 +41,7 @@ import { deliberationSiemPack } from "@/lib/mcp/packs/deliberation-siem-pack";
 import { runtimeCoordinationPack } from "@/lib/mcp/packs/runtime-coordination-pack";
 import { workCapsulesPack } from "@/lib/mcp/packs/work-capsules-pack";
 import { workbooksPack } from "@/lib/mcp/packs/workbooks-pack";
+import { feedbackPack } from "@/lib/mcp/packs/feedback-pack";
 import { composeToolPacks } from "@/lib/mcp/tool-registry";
 import {
   createLicenseReadinessIssue,
@@ -432,7 +431,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,
@@ -1044,36 +1043,6 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "view_operations",
     executionMode: "immediate",
     sideEffect: false,
-  },
-  {
-    name: "report_quality_issue",
-    description: "Report a bug, suggestion, or question about the platform. Available to ALL employees regardless of role — anyone can report a problem.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        type: { type: "string", enum: ["runtime_error", "user_report", "feedback"], description: "Issue type" },
-        title: { type: "string", description: "Short summary" },
-        description: { type: "string", description: "Detailed description" },
-        severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
-      },
-      required: ["type", "title"],
-    },
-    requiredCapability: null,
-    sideEffect: true,
-  },
-  {
-    name: "escalate_feedback_upstream",
-    description:
-      "Send a previously-captured platform issue report to the upstream project team as a GitHub issue, if this install has opted in to upstream feedback. Use after a user asks to share their report/feedback with the platform maintainers. Submitted under the install's anonymous handle with machine names redacted; respects opt-in consent, fork_only, and the contributions pause. Idempotent per report.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        reportId: { type: "string", description: "The PlatformIssueReport id (e.g. PIR-AB12C) to escalate." },
-      },
-      required: ["reportId"],
-    },
-    requiredCapability: null,
-    sideEffect: true,
   },
   {
     name: "list_customer_accounts",
@@ -1843,22 +1812,6 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "immediate",
     sideEffect: false,
     buildPhases: ["ideate"],
-  },
-  {
-    name: "register_tech_debt",
-    description: "Log a technical shortcut as a refactoring backlog item.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        title: { type: "string" },
-        description: { type: "string" },
-        severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
-      },
-      required: ["title", "description"],
-    },
-    requiredCapability: "view_platform",
-    executionMode: "immediate",
-    sideEffect: true,
   },
   // ─── Build Notes Tool ───────────────────────────────────────────────────
   {
@@ -7008,44 +6961,6 @@ export async function executeTool(
       };
     }
 
-    case "report_quality_issue": {
-      const { reportId } = await createPlatformIssueReport({
-        type: String(params["type"] ?? "user_report"),
-        title: String(params["title"] ?? "Untitled"),
-        source: "ai_assisted",
-        ...(typeof params["description"] === "string"
-          ? { description: params["description"] }
-          : {}),
-        severity: String(params["severity"] ?? "medium"),
-        reportedById: userId,
-        ...(typeof context?.routeContext === "string"
-          ? { routeContext: context.routeContext }
-          : {}),
-      });
-      return { success: true, entityId: reportId, message: `Filed report ${reportId}` };
-    }
-
-    case "escalate_feedback_upstream": {
-      const reportId = String(params["reportId"] ?? "").trim();
-      if (!reportId) {
-        return { success: false, error: "reportId is required", message: "reportId is required" };
-      }
-      const result = await escalateReportUpstream({ reportId });
-      if (result.ok) {
-        return {
-          success: true,
-          ...(result.status === "filed" || result.status === "already-filed"
-            ? { entityId: String(result.issueNumber ?? reportId) }
-            : {}),
-          message:
-            result.status === "already-filed"
-              ? `Report ${reportId} was already sent to the project team${result.url ? ` (${result.url})` : ""}.`
-              : `Sent ${reportId} to the project team${result.url ? ` (${result.url})` : ""}.`,
-        };
-      }
-      return { success: false, error: result.reason, message: result.reason };
-    }
-
     case "search_public_web": {
       const query = String(params["query"] ?? "").trim();
       let results: Awaited<ReturnType<typeof searchPublicWeb>>;
@@ -7581,16 +7496,6 @@ export async function executeTool(
         message: `Reusability: ${userScope} — ${domainEntities.length} parameterizable concept(s), contribution readiness: ${contributionReadiness}.${primitiveHint}`,
         data: analysis as unknown as Record<string, unknown>,
       };
-    }
-
-    case "register_tech_debt": {
-      const { createTechDebtItem } = await import("@/lib/decomposition");
-      const item = createTechDebtItem({ title: String(params["title"] ?? ""), description: String(params["description"] ?? ""), severity: String(params["severity"] ?? "medium") });
-      const refactorEpic = await prisma.epic.findUnique({ where: { epicId: "EP-REFACTOR-001" } });
-      await prisma.backlogItem.create({
-        data: { itemId: item.itemId, title: item.title, type: item.type, status: item.status, body: item.body, priority: item.priority, submittedById: userId, agentId: context?.agentId ?? null, ...(refactorEpic ? { epicId: refactorEpic.id } : {}) },
-      });
-      return { success: true, entityId: item.itemId, message: `Tech debt logged: ${item.itemId}` };
     }
 
     case "save_build_notes": {

--- a/apps/web/lib/mcp/packs/feedback-pack.ts
+++ b/apps/web/lib/mcp/packs/feedback-pack.ts
@@ -1,0 +1,149 @@
+// Feedback tool pack — BI-ARCH-TOOLPACKS.
+//
+// Fifth domain pack, and the first extraction of *inline* handler bodies (the
+// four prior packs each wrapped a sibling handler module). The three
+// platform-feedback tools were inline switch cases:
+//   - report_quality_issue        -> createPlatformIssueReport (thin delegation)
+//   - escalate_feedback_upstream  -> escalateReportUpstream    (thin delegation)
+//   - register_tech_debt          -> createTechDebtItem + a direct prisma write
+// Each handler lazy-imports its dependency and reproduces the former switch case
+// verbatim. register_tech_debt reads context.agentId, so ToolPackHandler's context
+// was widened to expose it (the registry already forwards the full runtime
+// ToolExecutionContext). Definitions moved verbatim out of the inline
+// PLATFORM_TOOLS array; grants mirror TOOL_TO_GRANTS.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "report_quality_issue",
+    description: "Report a bug, suggestion, or question about the platform. Available to ALL employees regardless of role — anyone can report a problem.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: ["runtime_error", "user_report", "feedback"], description: "Issue type" },
+        title: { type: "string", description: "Short summary" },
+        description: { type: "string", description: "Detailed description" },
+        severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
+      },
+      required: ["type", "title"],
+    },
+    requiredCapability: null,
+    sideEffect: true,
+  },
+  {
+    name: "escalate_feedback_upstream",
+    description:
+      "Send a previously-captured platform issue report to the upstream project team as a GitHub issue, if this install has opted in to upstream feedback. Use after a user asks to share their report/feedback with the platform maintainers. Submitted under the install's anonymous handle with machine names redacted; respects opt-in consent, fork_only, and the contributions pause. Idempotent per report.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        reportId: { type: "string", description: "The PlatformIssueReport id (e.g. PIR-AB12C) to escalate." },
+      },
+      required: ["reportId"],
+    },
+    requiredCapability: null,
+    sideEffect: true,
+  },
+  {
+    name: "register_tech_debt",
+    description: "Log a technical shortcut as a refactoring backlog item.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        description: { type: "string" },
+        severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
+      },
+      required: ["title", "description"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+];
+
+async function reportQualityIssue(
+  params: Record<string, unknown>,
+  userId: string,
+  context?: { routeContext?: string; threadId?: string },
+): Promise<ToolResult> {
+  const { createPlatformIssueReport } = await import("@/lib/quality/platform-issue-reports");
+  const { reportId } = await createPlatformIssueReport({
+    type: String(params["type"] ?? "user_report"),
+    title: String(params["title"] ?? "Untitled"),
+    source: "ai_assisted",
+    ...(typeof params["description"] === "string" ? { description: params["description"] } : {}),
+    severity: String(params["severity"] ?? "medium"),
+    reportedById: userId,
+    ...(typeof context?.routeContext === "string" ? { routeContext: context.routeContext } : {}),
+  });
+  return { success: true, entityId: reportId, message: `Filed report ${reportId}` };
+}
+
+async function escalateFeedbackUpstream(params: Record<string, unknown>): Promise<ToolResult> {
+  const reportId = String(params["reportId"] ?? "").trim();
+  if (!reportId) {
+    return { success: false, error: "reportId is required", message: "reportId is required" };
+  }
+  const { escalateReportUpstream } = await import("@/lib/actions/feedback-escalation");
+  const result = await escalateReportUpstream({ reportId });
+  if (result.ok) {
+    return {
+      success: true,
+      ...(result.status === "filed" || result.status === "already-filed"
+        ? { entityId: String(result.issueNumber ?? reportId) }
+        : {}),
+      message:
+        result.status === "already-filed"
+          ? `Report ${reportId} was already sent to the project team${result.url ? ` (${result.url})` : ""}.`
+          : `Sent ${reportId} to the project team${result.url ? ` (${result.url})` : ""}.`,
+    };
+  }
+  return { success: false, error: result.reason, message: result.reason };
+}
+
+async function registerTechDebt(
+  params: Record<string, unknown>,
+  userId: string,
+  context?: { routeContext?: string; threadId?: string; agentId?: string },
+): Promise<ToolResult> {
+  const { createTechDebtItem } = await import("@/lib/decomposition");
+  const { prisma } = await import("@dpf/db");
+  const item = createTechDebtItem({
+    title: String(params["title"] ?? ""),
+    description: String(params["description"] ?? ""),
+    severity: String(params["severity"] ?? "medium"),
+  });
+  const refactorEpic = await prisma.epic.findUnique({ where: { epicId: "EP-REFACTOR-001" } });
+  await prisma.backlogItem.create({
+    data: {
+      itemId: item.itemId,
+      title: item.title,
+      type: item.type,
+      status: item.status,
+      body: item.body,
+      priority: item.priority,
+      submittedById: userId,
+      agentId: context?.agentId ?? null,
+      ...(refactorEpic ? { epicId: refactorEpic.id } : {}),
+    },
+  });
+  return { success: true, entityId: item.itemId, message: `Tech debt logged: ${item.itemId}` };
+}
+
+export const feedbackPack: ToolPack = {
+  packId: "feedback",
+  definitions,
+  handlers: {
+    report_quality_issue: (params, userId, context) => reportQualityIssue(params, userId, context),
+    escalate_feedback_upstream: (params) => escalateFeedbackUpstream(params),
+    register_tech_debt: (params, userId, context) => registerTechDebt(params, userId, context),
+  },
+  grants: {
+    report_quality_issue: ["backlog_write"],
+    escalate_feedback_upstream: ["backlog_write"],
+    register_tech_debt: ["backlog_write"],
+  },
+};

--- a/apps/web/lib/mcp/tool-pack.ts
+++ b/apps/web/lib/mcp/tool-pack.ts
@@ -15,14 +15,15 @@
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 
 /**
- * A tool handler, with the context shape common to every dispatch site
- * (`routeContext` + `threadId`). Handlers may accept additional optional context
- * fields; this is the structural minimum the registry passes through.
+ * A tool handler, with the context fields the dispatch site (executeTool) passes
+ * through from its `ToolExecutionContext` — `routeContext`, `threadId`, and the
+ * acting coworker's `agentId`. The registry forwards the full runtime context;
+ * this is the structural subset packs may rely on. Handlers may ignore any of it.
  */
 export type ToolPackHandler = (
   params: Record<string, unknown>,
   userId: string,
-  context?: { routeContext?: string; threadId?: string },
+  context?: { routeContext?: string; threadId?: string; agentId?: string },
 ) => Promise<ToolResult>;
 
 export type ToolPack = {

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -9,6 +9,7 @@ import { deliberationSiemPack } from "./packs/deliberation-siem-pack";
 import { runtimeCoordinationPack } from "./packs/runtime-coordination-pack";
 import { workCapsulesPack } from "./packs/work-capsules-pack";
 import { workbooksPack } from "./packs/workbooks-pack";
+import { feedbackPack } from "./packs/feedback-pack";
 import { composeToolPacks } from "./tool-registry";
 
 // BI-ARCH-TOOLPACKS parity guard: the first extracted pack must stay
@@ -110,6 +111,32 @@ describe("workbooks tool pack", () => {
   });
 });
 
+describe("feedback tool pack", () => {
+  it("bundles its three feedback tools, each with a handler", () => {
+    expect(feedbackPack.definitions.map((t) => t.name).sort()).toEqual([
+      "escalate_feedback_upstream",
+      "register_tech_debt",
+      "report_quality_issue",
+    ]);
+    for (const def of feedbackPack.definitions) {
+      expect(feedbackPack.handlers[def.name], def.name).toBeTypeOf("function");
+    }
+  });
+
+  it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
+    for (const [name, grants] of Object.entries(feedbackPack.grants)) {
+      expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
+    }
+  });
+
+  it("keeps every pack tool present in the live PLATFORM_TOOLS registry", () => {
+    const platformNames = new Set(PLATFORM_TOOLS.map((t) => t.name));
+    for (const def of feedbackPack.definitions) {
+      expect(platformNames.has(def.name), def.name).toBe(true);
+    }
+  });
+});
+
 describe("composeToolPacks", () => {
   it("composes definitions + handler/grant lookup from packs", () => {
     const registry = composeToolPacks([deliberationSiemPack]);
@@ -119,22 +146,25 @@ describe("composeToolPacks", () => {
     expect(registry.getGrants("open_security_case")).toEqual(["siem_investigate"]);
   });
 
-  it("composes all four real packs without collision", () => {
+  it("composes all five real packs without collision", () => {
     const registry = composeToolPacks([
       deliberationSiemPack,
       runtimeCoordinationPack,
       workCapsulesPack,
       workbooksPack,
+      feedbackPack,
     ]);
     expect(registry.definitions).toHaveLength(
       deliberationSiemPack.definitions.length +
         runtimeCoordinationPack.definitions.length +
         workCapsulesPack.definitions.length +
-        workbooksPack.definitions.length,
+        workbooksPack.definitions.length +
+        feedbackPack.definitions.length,
     );
     expect(registry.getHandler("register_runtime_target")).toBeTypeOf("function");
     expect(registry.getHandler("create_work_capsule")).toBeTypeOf("function");
     expect(registry.getHandler("workbook_list_tables")).toBeTypeOf("function");
+    expect(registry.getHandler("report_quality_issue")).toBeTypeOf("function");
   });
 
   it("rejects the same tool name claimed by two packs", () => {

--- a/docs/architecture/mcp-tool-packs.md
+++ b/docs/architecture/mcp-tool-packs.md
@@ -73,10 +73,27 @@ arities) and [`workbooks-pack`](../../apps/web/lib/mcp/packs/workbooks-pack.ts) 
 followed on the same lazy pattern as the third and fourth packs — **every sibling-module
 domain (static + lazy) is now extracted.**
 
+## Fifth pack — first inline extraction
+
+[`feedback-pack`](../../apps/web/lib/mcp/packs/feedback-pack.ts) is the first pack whose
+handlers came from **inline** `case` bodies rather than a sibling handler module. It owns the
+three platform-feedback tools — `report_quality_issue` (→ `createPlatformIssueReport`),
+`escalate_feedback_upstream` (→ `escalateReportUpstream`), and `register_tech_debt`
+(`createTechDebtItem` + a direct `prisma` write). Each handler lazy-imports its dependency and
+reproduces the former switch case verbatim; the three definitions and switch cases (and the
+now-unused helper imports) are gone from `mcp-tools.ts`.
+
+`register_tech_debt` reads `context.agentId`, which the original pack-handler context
+(`{ routeContext, threadId }`) didn't expose — even though the registry already forwards the
+full runtime `ToolExecutionContext` to every handler. So `ToolPackHandler`'s context type was
+widened to `{ routeContext?, threadId?, agentId? }` (a purely additive, type-only change). The
+two thin-delegation tools plus the one prisma-writing tool prove the inline path across both
+shapes before the larger clusters.
+
 ## Next packs
 
-The remaining tools have **inline handler bodies** (giant `case` blocks in `mcp-tools.ts`),
-not sibling modules — a larger extraction than the four sibling-module packs done so far. The
-highest-value clusters are `backlog` + `build-evidence`, `sandbox`, then `wiki/knowledge`:
-extract each handler body into a domain module first, then pack it the same parity-first way,
-keeping the existing MCP-route, grant-filter, and `mcp-governed-execute` tests green.
+The remaining tools have **inline handler bodies with real logic** (not thin delegations) in
+`mcp-tools.ts` — a larger extraction than the five packs done so far. The highest-value
+clusters are `backlog` + `build-evidence`, `sandbox`, then `wiki/knowledge`: extract each
+handler body into a domain module first, then pack it the same parity-first way, keeping the
+existing MCP-route, grant-filter, and `mcp-governed-execute` tests green.


### PR DESCRIPTION
The **first** pack whose handlers came from inline switch cases rather than a sibling handler module — and it proves the inline path across **both** handler shapes (thin delegation + a direct prisma write) before the larger clusters.

> **Stacks on #2394 → #2393 → #2392.** Merge order: #2392, #2393, #2394, then this. Each rebases clean as the prior lands.

## What — the three platform-feedback tools
- **`lib/mcp/packs/feedback-pack.ts`**:
  - `report_quality_issue` → `createPlatformIssueReport` (thin delegation)
  - `escalate_feedback_upstream` → `escalateReportUpstream` (thin delegation)
  - `register_tech_debt` → `createTechDebtItem` + a direct `prisma` write
  
  Each handler lazy-imports its dependency and reproduces the former switch case **verbatim**. Definitions moved verbatim out of the inline `PLATFORM_TOOLS` array; grants mirror `TOOL_TO_GRANTS` (all `backlog_write`).
- **`lib/mcp/tool-pack.ts`** — widen `ToolPackHandler` context to expose `agentId` (`{ routeContext?, threadId?, agentId? }`). **Additive, type-only:** the registry already forwards the full runtime `ToolExecutionContext` to every handler; `register_tech_debt` needs `agentId` for the backlog row, and this just makes the already-passed field visible to the type.
- **`mcp-tools.ts`** — register the pack; remove the 3 inline definitions, the 3 switch cases, and the 2 now-unused helper imports. Dispatch routes through `registry.getHandler` after the kernel gate. **Zero behavioral change.**
- **`tool-registry.test.ts`** — feedback parity (3 tools) + five-pack composition.
- **`docs/architecture/mcp-tool-packs.md`** — fifth-pack section.

## Verification (web worktree)
- `pnpm --filter web typecheck` — **clean**
- `tool-registry` + `mcp-governed-execute` + `mcp-tools` — **71 pass**

EP-PLATFORM-CONSOLIDATION · spec §6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)