### PR TITLE
fix(ea): clear Style Drift Guard false-positive on a PR-ref comment (unblocks merge queue)

### DIFF
--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -90,7 +90,7 @@ export async function reconcileSysmlProjections(
   const scheduledJobs = await runDomain("scheduledJobs", () => reconcileScheduledJobs({ db: opts.db }), SKIPPED);
   const it4itCoverage = await runDomain("it4itCoverage", () => reconcileIt4itCoverage({ db: opts.db }), SKIPPED);
   // SOC posture isolated like every other domain (EP-SOVEREIGN-SOC, composed with
-  // the #2385 fail-isolation): a security-extractor error can't blind the engine.
+  // the runDomain fail-isolation from PR 2385): a security-extractor error can't blind the engine.
   const securityPosture = await runDomain("securityPosture", () => reconcileSecurityPosture({ db: opts.db }), SKIPPED);
   return {
     mcpAuthority, coworkerAuthority, valueStreams, routes, navigation, codeStructure, processModels, skillToolchain,


### PR DESCRIPTION
**main is currently red on the Style Drift Guard**, which blocks every PR branched off it (the merge queue treats the guard as required).

## Root cause
`apps/web/lib/ea/reconcile-sysml-projections.ts` has a code comment referencing `#2385`. The Style Drift Guard's hex-color regex (`#[0-9a-fA-F]{3,8}`) matches it — **every `#NNNN` PR reference is valid hex** — so the guard counted it as a *new hardcoded hex* and failed. The comment landed on main via #2372, so the guard has been red on `origin/main` itself.

## Fix
Reword the reference `#2385` → `PR 2385` in the comment. **Comment-only, zero behavior change.** Guard passes locally (`Style drift OK — 257 files / 1353 known hex`).

## Follow-up (not in this PR)
`scripts/check-style-drift.mjs` should ignore hex inside comments / `#NNNN` PR refs so this can't recur on the next PR-number reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)