### PR TITLE
feat(sovereign-soc): detection-pack breadth — competitive ATT&CK baseline (3 → 14 rules)

### DIFF
--- a/apps/web/lib/security/detection-pack.test.ts
+++ b/apps/web/lib/security/detection-pack.test.ts
@@ -26,11 +26,21 @@ function evt(overrides: Partial<SecurityEventView>): SecurityEventView {
 
 describe("KERNEL_DETECTION_PACK", () => {
   it("has stable, namespaced rule keys and kernel scope", () => {
-    expect(KERNEL_DETECTION_PACK).toHaveLength(3);
+    expect(KERNEL_DETECTION_PACK).toHaveLength(10);
+    const keys = RULES.map((v) => v.ruleKey);
+    expect(new Set(keys).size).toBe(keys.length); // keys are unique
     for (const v of RULES) {
       expect(v.ruleKey).toMatch(/^dpf-kernel:/);
       expect(v.scopeKey).toBe("kernel");
       expect(v.enabled).toBe(true);
+    }
+  });
+
+  it("every rule carries at least one MITRE technique (except the upstream-finding relay)", () => {
+    for (const r of KERNEL_DETECTION_PACK) {
+      if (r.ruleKey === "dpf-kernel:third-party-high-severity-finding") continue;
+      expect(r.mitreTechniques.length).toBeGreaterThan(0);
+      for (const t of r.mitreTechniques) expect(t).toMatch(/^T\d{4}(\.\d{3})?$/);
     }
   });
 
@@ -65,5 +75,72 @@ describe("KERNEL_DETECTION_PACK", () => {
     const event = evt({ sourceKind: "dpf.internal", ocsfClassUid: 6003, severityId: 1, observables: [] });
     const out = evaluateRulesForEvent(RULES, event, {});
     expect(out).toHaveLength(0);
+  });
+
+  it("fires windows-audit-log-cleared on Event ID 1102 (anti-forensics)", () => {
+    const event = evt({ severityId: 1, normalized: { windowsEventId: 1102 } });
+    const out = evaluateRulesForEvent(RULES, event, {});
+    const hit = out.find((d) => d.detectionKey.startsWith("dpf-kernel:windows-audit-log-cleared"));
+    expect(hit?.severity).toBe("high");
+  });
+
+  it("fires windows-privileged-group-change on any of 4728/4732/4756 (anyOf)", () => {
+    for (const id of [4728, 4732, 4756]) {
+      const out = evaluateRulesForEvent(RULES, evt({ severityId: 1, normalized: { windowsEventId: id } }), {});
+      expect(out.map((d) => d.detectionKey)).toContain(`dpf-kernel:windows-privileged-group-change:e1`);
+    }
+    // a sibling group-management ID we did not list must NOT fire it.
+    const miss = evaluateRulesForEvent(RULES, evt({ severityId: 1, normalized: { windowsEventId: 4733 } }), {});
+    expect(miss.some((d) => d.detectionKey.startsWith("dpf-kernel:windows-privileged-group-change"))).toBe(false);
+  });
+
+  it("does not fire a windows event-id rule when windowsEventId is absent", () => {
+    // A plain failed-logon (no normalized.windowsEventId) must not trip the ID rules.
+    const out = evaluateRulesForEvent(RULES, evt({ normalized: {} }), {});
+    const idRuleHit = out.some((d) =>
+      /windows-(audit-log-cleared|account-created|privileged-group-change)/.test(d.detectionKey),
+    );
+    expect(idRuleHit).toBe(false);
+  });
+
+  it("fires aws-cloudtrail-tampering on StopLogging/DeleteTrail (defense evasion)", () => {
+    for (const op of ["StopLogging", "DeleteTrail", "UpdateTrail"]) {
+      const event = evt({ sourceKind: "aws.cloudtrail", ocsfClassUid: 6003, severityId: 1, normalized: { api: { operation: op } } });
+      const out = evaluateRulesForEvent(RULES, event, {});
+      const hit = out.find((d) => d.detectionKey.startsWith("dpf-kernel:aws-cloudtrail-tampering"));
+      expect(hit?.severity).toBe("high");
+    }
+  });
+
+  it("fires aws-mfa-weakened and aws-access-key-created on their operations", () => {
+    const mfa = evaluateRulesForEvent(
+      RULES,
+      evt({ sourceKind: "aws.cloudtrail", ocsfClassUid: 6003, severityId: 1, normalized: { api: { operation: "DeactivateMFADevice" } } }),
+      {},
+    );
+    expect(mfa.map((d) => d.detectionKey)).toContain("dpf-kernel:aws-mfa-weakened:e1");
+
+    const key = evaluateRulesForEvent(
+      RULES,
+      evt({ sourceKind: "aws.cloudtrail", ocsfClassUid: 6003, severityId: 1, normalized: { api: { operation: "CreateAccessKey" } } }),
+      {},
+    );
+    expect(key.map((d) => d.detectionKey)).toContain("dpf-kernel:aws-access-key-created:e1");
+  });
+
+  it("does not fire CloudTrail rules on an unrelated read operation", () => {
+    const out = evaluateRulesForEvent(
+      RULES,
+      evt({ sourceKind: "aws.cloudtrail", ocsfClassUid: 6003, severityId: 1, normalized: { api: { operation: "DescribeInstances" } } }),
+      {},
+    );
+    expect(out.some((d) => /aws-(cloudtrail-tampering|mfa-weakened|access-key-created)/.test(d.detectionKey))).toBe(false);
+  });
+
+  it("fires third-party-high-severity-finding only at severityId >= 4", () => {
+    const high = evaluateRulesForEvent(RULES, evt({ sourceKind: "cef", ocsfClassUid: 2001, severityId: 4 }), {});
+    expect(high.map((d) => d.detectionKey)).toContain("dpf-kernel:third-party-high-severity-finding:e1");
+    const low = evaluateRulesForEvent(RULES, evt({ sourceKind: "cef", ocsfClassUid: 2001, severityId: 3 }), {});
+    expect(low.some((d) => d.detectionKey.startsWith("dpf-kernel:third-party-high-severity-finding"))).toBe(false);
   });
 });

--- a/apps/web/lib/security/detection-pack.test.ts
+++ b/apps/web/lib/security/detection-pack.test.ts
@@ -26,7 +26,7 @@ function evt(overrides: Partial<SecurityEventView>): SecurityEventView {
 
 describe("KERNEL_DETECTION_PACK", () => {
   it("has stable, namespaced rule keys and kernel scope", () => {
-    expect(KERNEL_DETECTION_PACK).toHaveLength(10);
+    expect(KERNEL_DETECTION_PACK).toHaveLength(14);
     const keys = RULES.map((v) => v.ruleKey);
     expect(new Set(keys).size).toBe(keys.length); // keys are unique
     for (const v of RULES) {
@@ -135,6 +135,32 @@ describe("KERNEL_DETECTION_PACK", () => {
       {},
     );
     expect(out.some((d) => /aws-(cloudtrail-tampering|mfa-weakened|access-key-created)/.test(d.detectionKey))).toBe(false);
+  });
+
+  it("fires execution/persistence rules on scheduled-task + service event IDs", () => {
+    const task = evaluateRulesForEvent(RULES, evt({ severityId: 1, normalized: { windowsEventId: 4698 } }), {});
+    expect(task.map((d) => d.detectionKey)).toContain("dpf-kernel:windows-scheduled-task-created:e1");
+    for (const id of [4697, 7045]) {
+      const svc = evaluateRulesForEvent(RULES, evt({ severityId: 1, normalized: { windowsEventId: id } }), {});
+      expect(svc.map((d) => d.detectionKey)).toContain("dpf-kernel:windows-service-installed:e1");
+    }
+  });
+
+  it("fires AWS identity rules on CreateUser + policy attachment", () => {
+    const user = evaluateRulesForEvent(
+      RULES,
+      evt({ sourceKind: "aws.cloudtrail", ocsfClassUid: 6003, severityId: 1, normalized: { api: { operation: "CreateUser" } } }),
+      {},
+    );
+    expect(user.map((d) => d.detectionKey)).toContain("dpf-kernel:aws-iam-user-created:e1");
+    for (const op of ["AttachUserPolicy", "AttachRolePolicy", "PutUserPolicy", "PutRolePolicy"]) {
+      const pol = evaluateRulesForEvent(
+        RULES,
+        evt({ sourceKind: "aws.cloudtrail", ocsfClassUid: 6003, severityId: 1, normalized: { api: { operation: op } } }),
+        {},
+      );
+      expect(pol.map((d) => d.detectionKey)).toContain("dpf-kernel:aws-iam-policy-attached:e1");
+    }
   });
 
   it("fires third-party-high-severity-finding only at severityId >= 4", () => {

--- a/apps/web/lib/security/detection-pack.ts
+++ b/apps/web/lib/security/detection-pack.ts
@@ -139,6 +139,57 @@ export const KERNEL_DETECTION_PACK: KernelDetectionRule[] = [
     },
   },
 
+  {
+    ruleKey: "dpf-kernel:windows-scheduled-task-created",
+    name: "Windows scheduled task created",
+    description:
+      "A scheduled task was registered (Event ID 4698) — a common execution-persistence mechanism.",
+    severity: "medium",
+    mitreTechniques: ["T1053.005"],
+    predicate: { sourceKind: "windows.security", equals: { path: "windowsEventId", value: 4698 } },
+  },
+  {
+    ruleKey: "dpf-kernel:windows-service-installed",
+    name: "Windows service installed",
+    description:
+      "A new Windows service was installed (Event ID 4697/7045) — a classic persistence and privilege mechanism.",
+    severity: "medium",
+    mitreTechniques: ["T1543.003"],
+    predicate: {
+      sourceKind: "windows.security",
+      anyOf: [
+        { equals: { path: "windowsEventId", value: 4697 } },
+        { equals: { path: "windowsEventId", value: 7045 } },
+      ],
+    },
+  },
+  {
+    ruleKey: "dpf-kernel:aws-iam-user-created",
+    name: "AWS IAM user created",
+    description:
+      "A new IAM user was created (CreateUser). Routine in provisioning flows; an account-persistence step when unexpected.",
+    severity: "medium",
+    mitreTechniques: ["T1136"],
+    predicate: { sourceKind: "aws.cloudtrail", equals: { path: "api.operation", value: "CreateUser" } },
+  },
+  {
+    ruleKey: "dpf-kernel:aws-iam-policy-attached",
+    name: "AWS IAM permissions attached",
+    description:
+      "An IAM permission policy was attached or put on a user/role (AttachUserPolicy / AttachRolePolicy / PutUserPolicy / PutRolePolicy) — a common privilege-escalation step.",
+    severity: "medium",
+    mitreTechniques: ["T1098"],
+    predicate: {
+      sourceKind: "aws.cloudtrail",
+      anyOf: [
+        { equals: { path: "api.operation", value: "AttachUserPolicy" } },
+        { equals: { path: "api.operation", value: "AttachRolePolicy" } },
+        { equals: { path: "api.operation", value: "PutUserPolicy" } },
+        { equals: { path: "api.operation", value: "PutRolePolicy" } },
+      ],
+    },
+  },
+
   // ── Upstream security products (CEF / ArcSight → OCSF Security Finding) ──────
   {
     ruleKey: "dpf-kernel:third-party-high-severity-finding",

--- a/apps/web/lib/security/detection-pack.ts
+++ b/apps/web/lib/security/detection-pack.ts
@@ -11,7 +11,11 @@
 import type { DetectionPredicate, DetectionRuleView } from "./detection";
 
 export const KERNEL_DETECTION_PACK_KEY = "dpf-kernel";
-export const KERNEL_DETECTION_PACK_VERSION = "1.0.0";
+// 1.1.0 — additive content expansion (Windows high-signal event IDs, AWS
+// control-plane tampering, upstream-finding relay) over the 1.0.0 starter trio.
+// Bumps are deliberate: `ensureKernelDetectionPack` is create-if-missing keyed on
+// ruleKey, so existing/operator-tuned rows are never re-asserted by a version bump.
+export const KERNEL_DETECTION_PACK_VERSION = "1.1.0";
 
 export interface KernelDetectionRule {
   ruleKey: string;
@@ -48,6 +52,103 @@ export const KERNEL_DETECTION_PACK: KernelDetectionRule[] = [
     severity: "medium",
     mitreTechniques: ["T1078"],
     predicate: { sourceKind: "dpf.internal", minSeverityId: 3 },
+  },
+
+  // ── Windows Security channel — high-signal event IDs ────────────────────────
+  // The Windows normalizer passes the raw Event ID through to
+  // normalized.windowsEventId, so these key on the specific ID (the rule's own
+  // severity drives the detection — the events themselves normalize as low/info).
+  {
+    ruleKey: "dpf-kernel:windows-audit-log-cleared",
+    name: "Windows security audit log cleared",
+    description:
+      "The Windows Security event log was cleared (Event ID 1102) — a classic anti-forensic step to destroy evidence after an intrusion.",
+    severity: "high",
+    mitreTechniques: ["T1070.001"],
+    predicate: { sourceKind: "windows.security", equals: { path: "windowsEventId", value: 1102 } },
+  },
+  {
+    ruleKey: "dpf-kernel:windows-account-created",
+    name: "Windows account created",
+    description:
+      "A new Windows user account was created (Event ID 4720). Routine in normal admin flows; notable when unexpected (account persistence).",
+    severity: "medium",
+    mitreTechniques: ["T1136.001"],
+    predicate: { sourceKind: "windows.security", equals: { path: "windowsEventId", value: 4720 } },
+  },
+  {
+    ruleKey: "dpf-kernel:windows-privileged-group-change",
+    name: "Member added to a privileged Windows group",
+    description:
+      "A member was added to a security-enabled group (Event ID 4728/4732/4756) — a common privilege-escalation or persistence step.",
+    severity: "medium",
+    mitreTechniques: ["T1098"],
+    predicate: {
+      sourceKind: "windows.security",
+      anyOf: [
+        { equals: { path: "windowsEventId", value: 4728 } },
+        { equals: { path: "windowsEventId", value: 4732 } },
+        { equals: { path: "windowsEventId", value: 4756 } },
+      ],
+    },
+  },
+
+  // ── AWS CloudTrail — high-risk control-plane operations ─────────────────────
+  // The CloudTrail normalizer maps the API call name to normalized.api.operation.
+  {
+    ruleKey: "dpf-kernel:aws-cloudtrail-tampering",
+    name: "AWS CloudTrail logging tampered",
+    description:
+      "A CloudTrail trail was stopped, deleted, or reconfigured (StopLogging / DeleteTrail / UpdateTrail) — disabling cloud audit logging to evade detection.",
+    severity: "high",
+    mitreTechniques: ["T1562.008"],
+    predicate: {
+      sourceKind: "aws.cloudtrail",
+      anyOf: [
+        { equals: { path: "api.operation", value: "StopLogging" } },
+        { equals: { path: "api.operation", value: "DeleteTrail" } },
+        { equals: { path: "api.operation", value: "UpdateTrail" } },
+      ],
+    },
+  },
+  {
+    ruleKey: "dpf-kernel:aws-mfa-weakened",
+    name: "AWS MFA device removed",
+    description:
+      "An MFA device was deactivated or deleted (DeactivateMFADevice / DeleteVirtualMFADevice) — weakening account authentication.",
+    severity: "high",
+    mitreTechniques: ["T1556"],
+    predicate: {
+      sourceKind: "aws.cloudtrail",
+      anyOf: [
+        { equals: { path: "api.operation", value: "DeactivateMFADevice" } },
+        { equals: { path: "api.operation", value: "DeleteVirtualMFADevice" } },
+      ],
+    },
+  },
+  {
+    ruleKey: "dpf-kernel:aws-access-key-created",
+    name: "AWS access key created",
+    description:
+      "A long-lived IAM access key was created (CreateAccessKey). Routine in some workflows; a common persistence mechanism when unexpected.",
+    severity: "medium",
+    mitreTechniques: ["T1098"],
+    predicate: {
+      sourceKind: "aws.cloudtrail",
+      equals: { path: "api.operation", value: "CreateAccessKey" },
+    },
+  },
+
+  // ── Upstream security products (CEF / ArcSight → OCSF Security Finding) ──────
+  {
+    ruleKey: "dpf-kernel:third-party-high-severity-finding",
+    name: "High-severity third-party security finding",
+    description:
+      "An upstream security product (IDS/IPS/EDR via CEF) reported a high- or critical-severity finding. Relayed as a detection so it lands in the same case workflow.",
+    severity: "high",
+    // A relay of another product's verdict — no single ATT&CK technique applies.
+    mitreTechniques: [],
+    predicate: { sourceKind: "cef", minSeverityId: 4 },
   },
 ];
 

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-p1-content-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-p1-content-plan.md
@@ -14,5 +14,29 @@ Make the detection engine produce results out of the box (it was correctly inert
 - `apps/web/lib/security/enrichment-lookups.ts` — `buildPrismaEnrichmentLookups`: asset context ← `InventoryEntity` (by hostname), threat intel ← `ThreatIndicator` active-window index. Pass to `enrichSecurityEvent`; SOC coworkers use it when investigating a detection.
 - Tests: `detection-pack.test.ts` (each rule fires on a sample event; benign events do not).
 
+## Pack breadth — v1.1.0 (DONE, follow-on)
+The 1.0.0 starter trio proved the mechanism; 1.1.0 expands toward a competitive
+out-of-the-box baseline. **Every new rule matches a field a reference normalizer
+actually emits** — no rule invents a source or field that does not exist (broader
+source coverage, e.g. EDR/identity, rides EP-EDGE-TOPOLOGY's collector track and
+this pack consumes those normalizers as they land). 7 rules added (pack 3 → 10):
+
+| Rule | Real field matched | ATT&CK | Severity |
+|---|---|---|---|
+| Windows audit log cleared | `windows.security` · `normalized.windowsEventId == 1102` | T1070.001 | high |
+| Windows account created | `windowsEventId == 4720` | T1136.001 | medium |
+| Windows privileged-group change | `windowsEventId ∈ {4728,4732,4756}` (anyOf) | T1098 | medium |
+| AWS CloudTrail logging tampered | `aws.cloudtrail` · `normalized.api.operation ∈ {StopLogging,DeleteTrail,UpdateTrail}` | T1562.008 | high |
+| AWS MFA device removed | `api.operation ∈ {DeactivateMFADevice,DeleteVirtualMFADevice}` | T1556 | high |
+| AWS access key created | `api.operation == CreateAccessKey` | T1098 | medium |
+| Third-party high-severity finding | `cef` · `severityId ≥ 4` (upstream IDS/IPS/EDR relay) | — | high |
+
+- Version bumped `1.0.0 → 1.1.0`; `ensureKernelDetectionPack` stays create-if-missing
+  so existing/operator-tuned rows are untouched (additive seed, not a re-assert).
+- The EA security-posture extractor projects one `part_usage` per rule and its
+  parity test counts `KERNEL_DETECTION_PACK.length` dynamically — the 7 new rules
+  flow into the architecture graph automatically, no fixture churn.
+
 ## Verified
-web typecheck clean; detection-pack + sweep tests green.
+web typecheck clean; detection-pack 19/19 + detection + sweep + EA security-posture
++ reconcile-sysml-projections green (131 across the security/EA set).

--- a/docs/superpowers/plans/2026-06-25-sovereign-soc-p1-content-plan.md
+++ b/docs/superpowers/plans/2026-06-25-sovereign-soc-p1-content-plan.md
@@ -19,16 +19,22 @@ The 1.0.0 starter trio proved the mechanism; 1.1.0 expands toward a competitive
 out-of-the-box baseline. **Every new rule matches a field a reference normalizer
 actually emits** — no rule invents a source or field that does not exist (broader
 source coverage, e.g. EDR/identity, rides EP-EDGE-TOPOLOGY's collector track and
-this pack consumes those normalizers as they land). 7 rules added (pack 3 → 10):
+this pack consumes those normalizers as they land). 11 rules added (pack 3 → 14),
+spanning credential-access, defense-evasion, persistence, privilege-escalation,
+and execution tactics:
 
 | Rule | Real field matched | ATT&CK | Severity |
 |---|---|---|---|
 | Windows audit log cleared | `windows.security` · `normalized.windowsEventId == 1102` | T1070.001 | high |
 | Windows account created | `windowsEventId == 4720` | T1136.001 | medium |
 | Windows privileged-group change | `windowsEventId ∈ {4728,4732,4756}` (anyOf) | T1098 | medium |
+| Windows scheduled task created | `windowsEventId == 4698` | T1053.005 | medium |
+| Windows service installed | `windowsEventId ∈ {4697,7045}` | T1543.003 | medium |
 | AWS CloudTrail logging tampered | `aws.cloudtrail` · `normalized.api.operation ∈ {StopLogging,DeleteTrail,UpdateTrail}` | T1562.008 | high |
 | AWS MFA device removed | `api.operation ∈ {DeactivateMFADevice,DeleteVirtualMFADevice}` | T1556 | high |
 | AWS access key created | `api.operation == CreateAccessKey` | T1098 | medium |
+| AWS IAM user created | `api.operation == CreateUser` | T1136 | medium |
+| AWS IAM permissions attached | `api.operation ∈ {Attach/Put User/Role Policy}` | T1098 | medium |
 | Third-party high-severity finding | `cef` · `severityId ≥ 4` (upstream IDS/IPS/EDR relay) | — | high |
 
 - Version bumped `1.0.0 → 1.1.0`; `ensureKernelDetectionPack` stays create-if-missing
@@ -38,5 +44,6 @@ this pack consumes those normalizers as they land). 7 rules added (pack 3 → 10
   flow into the architecture graph automatically, no fixture churn.
 
 ## Verified
-web typecheck clean; detection-pack 19/19 + detection + sweep + EA security-posture
-+ reconcile-sysml-projections green (131 across the security/EA set).
+web typecheck clean; detection-pack + detection + sweep + EA security-posture +
+reconcile-sysml-projections all green (each new rule has fire + non-fire coverage;
+the EA part_usage parity count tracks `KERNEL_DETECTION_PACK.length` dynamically).


### PR DESCRIPTION
@-