### PR TITLE
fix(golden-triangle): priority dock defaults collapsed (was opening on every load/refresh)

### DIFF
--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx
@@ -20,12 +20,15 @@ describe("CoworkerPriorityDock", () => {
     savePosture.mockResolvedValue({ ok: true });
   });
 
-  it("shows the triangle in view by default (no popover, nothing to open)", async () => {
+  it("is collapsed by default — the resting state is the chip, triangle hidden until opened", async () => {
     getPosture.mockResolvedValueOnce(null);
     render(<CoworkerPriorityDock agentId="agent-1" />);
     await waitFor(() => expect(getPosture).toHaveBeenCalledWith("agent-1"));
-    // The control's presets render without any click — it's docked open.
-    expect(screen.getByRole("radio", { name: /Assured/ })).toBeTruthy();
+    // Resting state: the Priority chip shows; the control (presets) does NOT.
+    const header = screen.getByRole("button", { name: /Priority/ });
+    expect(header).toBeTruthy();
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("radio", { name: /Assured/ })).toBeNull();
   });
 
   it("loads this coworker's own posture into the docked header", async () => {
@@ -34,21 +37,22 @@ describe("CoworkerPriorityDock", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: /Priority.*Frugal/ })).toBeTruthy());
   });
 
-  it("collapses and re-expands in place", async () => {
+  it("expands on open and re-collapses in place", async () => {
     getPosture.mockResolvedValueOnce(null);
     render(<CoworkerPriorityDock agentId="agent-1" />);
     await waitFor(() => expect(getPosture).toHaveBeenCalled());
+    expect(screen.queryByRole("radio", { name: /Assured/ })).toBeNull(); // collapsed by default
+    fireEvent.click(screen.getByRole("button", { name: /Priority/ })); // open
     expect(screen.getByRole("radio", { name: /Assured/ })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: /Priority/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Priority/ })); // close
     expect(screen.queryByRole("radio", { name: /Assured/ })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /Priority/ }));
-    expect(screen.getByRole("radio", { name: /Assured/ })).toBeTruthy();
   });
 
   it("saves the coworker's posture (debounced) after a change", async () => {
     getPosture.mockResolvedValueOnce(null);
     render(<CoworkerPriorityDock agentId="agent-1" />);
     await waitFor(() => expect(getPosture).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: /Priority/ })); // open the dock first
     fireEvent.click(screen.getByRole("radio", { name: /Assured/ }));
     await waitFor(() => expect(savePosture).toHaveBeenCalledTimes(1), { timeout: 2000 });
     expect(savePosture.mock.calls[0][0]).toBe("agent-1");

--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
@@ -2,10 +2,12 @@
 // EP-GOLDEN-TRIANGLE — the per-coworker priority docked at the composer. Unlike
 // the old header chip (a popover that clipped off the panel edge), this lives
 // IN-FLOW just above the message input, so the triangle stays in view where you
-// type and nothing overflows the window. Collapsible (default open) to reclaim
-// space; the collapsed header still shows the colour-graded glyph + preset. Loads
-// and saves THIS coworker's own posture (debounced), so each coworker remembers
-// its priority and that posture tunes its runs.
+// type and nothing overflows the window. Collapsible and COLLAPSED BY DEFAULT —
+// the resting state is just the colour-graded glyph + preset chip in the header;
+// it expands to the full triangle only when the operator opens it, and returns to
+// collapsed on the next load/refresh (the everyday state is the compact chip, not
+// the open control). Loads and saves THIS coworker's own posture (debounced), so
+// each coworker remembers its priority and that posture tunes its runs.
 import { useEffect, useRef, useState } from "react";
 
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
@@ -18,7 +20,10 @@ import { PRESET_META, preferenceFromPreset } from "./posture-display";
 
 export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
   const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
-  const [collapsed, setCollapsed] = useState(false);
+  // Collapsed by default: the resting state is the compact colour-graded chip in
+  // the header, not the open triangle. Re-initializes collapsed on every load so a
+  // refresh never leaves the control hanging open (founder report 2026-06-26).
+  const [collapsed, setCollapsed] = useState(true);
   const savedRef = useRef<string>(JSON.stringify(preferenceFromPreset("balanced")));
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 


### PR DESCRIPTION
**Founder report:** the priority control at the composer keeps coming open by default and on every screen refresh — it should rest **closed**.

**Cause:** the dock initialized `collapsed = useState(false)`, so it rendered **expanded** on mount and re-expanded on each load.

**Fix:** default to collapsed. The resting state is now the compact colour-graded **chip** in the header (the color tells the story at a glance); the full triangle opens only on click. The per-coworker posture is unchanged — still loaded/saved per coworker; only the expand/collapse default moved.

Tests updated to assert default-collapsed (chip shown, `aria-expanded=false`, triangle hidden until opened; open→close still works). **4 dock tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)