### PR TITLE
feat(patch-mgmt): estate patch-posture surface — read model + /ops/patches (EP-PATCH-MANAGEMENT P0)

### DIFF
--- a/apps/web/app/(shell)/ops/patches/page.tsx
+++ b/apps/web/app/(shell)/ops/patches/page.tsx
@@ -1,0 +1,169 @@
+import Link from "next/link";
+import { prisma } from "@dpf/db";
+
+import { OpsTabNav } from "@/components/ops/OpsTabNav";
+import { StatusBadge } from "@/components/ui/report-kit";
+import {
+  getPatchPosture,
+  type PatchPostureDb,
+  type PatchPostureFinding,
+} from "@/lib/patch/patch-posture";
+
+// Live posture — never statically cached.
+export const dynamic = "force-dynamic";
+
+type Props = {
+  searchParams: Promise<{ severity?: string; kind?: string; status?: string }>;
+};
+
+const SEVERITIES = ["critical", "high", "medium", "low", "info"] as const;
+
+const KIND_LABEL: Record<string, string> = {
+  vulnerability: "Vulnerability",
+  "missing-patch": "Update available",
+  "unsupported-component": "End of life",
+};
+
+const SELECT_CLASS =
+  "text-xs px-2 py-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] focus:outline-none focus:border-[var(--dpf-accent)]";
+const OPTION_CLASS = "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]";
+
+export default async function PatchesPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const posture = await getPatchPosture(prisma as unknown as PatchPostureDb, {
+    status: sp.status === "all" ? "all" : "open",
+    limit: 500,
+  });
+
+  let findings = posture.findings;
+  if (sp.severity) findings = findings.filter((f) => f.policySeverity === sp.severity);
+  if (sp.kind) findings = findings.filter((f) => f.findingKind === sp.kind);
+
+  const totals = posture.totals;
+  const hasFilter = Boolean(sp.severity || sp.kind || sp.status);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Operations</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          Estate patch posture — what is out of date or exposed across discovered software.
+        </p>
+      </div>
+
+      <OpsTabNav />
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 my-6">
+        <SummaryTile label="Open findings" value={totals.findings} />
+        <SummaryTile label="Critical / High" value={(totals.bySeverity.critical ?? 0) + (totals.bySeverity.high ?? 0)} />
+        <SummaryTile label="Actively exploited (KEV)" value={totals.kev} />
+        <SummaryTile label="Affected hosts" value={totals.hosts} />
+      </div>
+
+      <form className="flex flex-wrap gap-3 mb-6">
+        <select name="severity" defaultValue={sp.severity ?? ""} className={SELECT_CLASS}>
+          <option value="" className={OPTION_CLASS}>
+            All severities
+          </option>
+          {SEVERITIES.map((s) => (
+            <option key={s} value={s} className={OPTION_CLASS}>
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </option>
+          ))}
+        </select>
+
+        <select name="kind" defaultValue={sp.kind ?? ""} className={SELECT_CLASS}>
+          <option value="" className={OPTION_CLASS}>
+            All types
+          </option>
+          {Object.entries(KIND_LABEL).map(([value, label]) => (
+            <option key={value} value={value} className={OPTION_CLASS}>
+              {label}
+            </option>
+          ))}
+        </select>
+
+        <select name="status" defaultValue={sp.status ?? ""} className={SELECT_CLASS}>
+          <option value="" className={OPTION_CLASS}>
+            Open only
+          </option>
+          <option value="all" className={OPTION_CLASS}>
+            All (incl. resolved)
+          </option>
+        </select>
+
+        <button
+          type="submit"
+          className="text-xs px-3 py-1.5 rounded-md bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity"
+        >
+          Filter
+        </button>
+
+        {hasFilter && (
+          <Link
+            href="/ops/patches"
+            className="text-xs px-3 py-1.5 rounded-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+          >
+            Clear
+          </Link>
+        )}
+      </form>
+
+      {findings.length === 0 ? (
+        <p className="text-sm text-[var(--dpf-muted)]">
+          {totals.findings === 0
+            ? "No patch findings from the latest assessment. Posture is clean for everything assessed."
+            : "No findings match the current filters."}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {findings.map((finding) => (
+            <FindingRow key={finding.findingKey} finding={finding} />
+          ))}
+        </div>
+      )}
+
+      {posture.capped && (
+        <p className="text-[10px] text-[var(--dpf-muted)] mt-3">
+          Showing the first 500 findings. Narrow with the filters above.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function SummaryTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="p-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+      <p className="text-[11px] text-[var(--dpf-muted)]">{label}</p>
+      <p className="text-2xl font-bold text-[var(--dpf-text)]">{value}</p>
+    </div>
+  );
+}
+
+function FindingRow({ finding }: { finding: PatchPostureFinding }) {
+  return (
+    <div className="p-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <span className="text-sm text-[var(--dpf-text)] break-words">{finding.title}</span>
+          <div className="flex flex-wrap items-center gap-2 mt-1">
+            <StatusBadge domain="severity" status={finding.policySeverity} variant="soft" uppercase={false} />
+            <span className="text-[10px] text-[var(--dpf-muted)]">
+              {KIND_LABEL[finding.findingKind] ?? finding.findingKind}
+            </span>
+            {finding.cisaKev && (
+              <StatusBadge domain="severity" status="critical" label="KEV" variant="solid" uppercase={false} />
+            )}
+            <span className="text-[10px] text-[var(--dpf-muted)] break-words">{finding.vendorIdentifier}</span>
+          </div>
+        </div>
+        <div className="text-right text-[10px] text-[var(--dpf-muted)] shrink-0">
+          {finding.installedVersion && <p>installed {finding.installedVersion}</p>}
+          {finding.targetVersion && <p>&rarr; {finding.targetVersion}</p>}
+          {finding.status !== "open" && <p>{finding.status}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ops/ops-nav.ts
+++ b/apps/web/components/ops/ops-nav.ts
@@ -20,6 +20,7 @@ export const OPS_NAV_GROUPS: ReadonlyArray<{
       { label: "Changes", href: "/ops/changes" },
       { label: "Promotions", href: "/ops/promotions" },
       { label: "Self-upgrade", href: "/ops/self-upgrade" },
+      { label: "Patches", href: "/ops/patches" },
       { label: "Dev Loop", href: "/ops/dev-loop" },
     ],
   },

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 519,
+  "routeCount": 520,
   "routes": [
     {
       "routePath": "/",
@@ -4405,6 +4405,16 @@
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/ops/improvements/page.tsx",
       "redirectTo": "/ops"
+    },
+    {
+      "routePath": "/ops/patches",
+      "kind": "page",
+      "segments": [
+        "ops",
+        "patches"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/ops/patches/page.tsx"
     },
     {
       "routePath": "/ops/promotions",

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -3941,6 +3941,21 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: false,
   },
   {
+    name: "list_patch_posture",
+    description:
+      "Summarize estate patch posture: open patch findings (vulnerabilities, available updates, end-of-life) across discovered software, ranked by severity and active exploitation (CISA KEV).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        severity: { type: "string", description: "Filter to one severity: critical|high|medium|low|info (optional)" },
+        status: { type: "string", description: "open (default) or all to include resolved (optional)" },
+      },
+      required: [],
+    },
+    requiredCapability: "view_inventory",
+    sideEffect: false,
+  },
+  {
     name: "review_estate_identity",
     description: "Explain what an estate item most likely is, who made it, how confident the identity evidence is, and what still needs review.",
     inputSchema: {
@@ -14150,6 +14165,30 @@ export async function executeTool(
         proposedBy: userId,
       });
       return { success: true, entityId: evalId, message: `Tool evaluation created: ${evalId}. The evaluation pipeline will review this tool for security, architecture fit, compliance, and integration.` };
+    }
+
+    case "list_patch_posture": {
+      const { prisma } = await import("@dpf/db");
+      const { getPatchPosture } = await import("@/lib/patch/patch-posture");
+      const status = params["status"] === "all" ? "all" : "open";
+      const posture = await getPatchPosture(
+        prisma as unknown as Parameters<typeof getPatchPosture>[0],
+        { status, limit: 200 },
+      );
+      const severity = typeof params["severity"] === "string" ? params["severity"] : undefined;
+      const findings = severity
+        ? posture.findings.filter((finding) => finding.policySeverity === severity)
+        : posture.findings;
+      const totals = posture.totals;
+      return {
+        success: true,
+        message: `Estate patch posture: ${totals.findings} open finding(s) across ${totals.hosts} host(s) — ${totals.bySeverity.critical ?? 0} critical, ${totals.bySeverity.high ?? 0} high, ${totals.kev} actively exploited (KEV).`,
+        data: {
+          totals,
+          capped: posture.capped,
+          findings: findings.slice(0, 50),
+        },
+      };
     }
 
     case "summarize_estate_posture": {

--- a/apps/web/lib/patch/patch-posture.test.ts
+++ b/apps/web/lib/patch/patch-posture.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { getPatchPosture, type PatchPostureDb } from "./patch-posture";
+
+interface Row {
+  findingKey: string;
+  findingKind: string;
+  policySeverity: string;
+  status: string;
+  title: string;
+  affectedId: string;
+  vendorIdentifier: string;
+  evidence: Record<string, unknown>;
+  remediationHint: Record<string, unknown>;
+  lastSeenAt: Date | string;
+}
+
+class FakeDb implements PatchPostureDb {
+  constructor(private readonly rows: Row[]) {}
+  assuranceFinding = {
+    findMany: async (args: {
+      where: { findingKey: { startsWith: string }; status?: { in: string[] } };
+      take: number;
+    }): Promise<unknown[]> => {
+      let rows = this.rows.filter((r) => r.findingKey.startsWith(args.where.findingKey.startsWith));
+      if (args.where.status?.in) rows = rows.filter((r) => args.where.status!.in.includes(r.status));
+      return rows.slice(0, args.take);
+    },
+  };
+}
+
+function row(overrides: Partial<Row>): Row {
+  return {
+    findingKey: "patch:e",
+    findingKind: "vulnerability",
+    policySeverity: "high",
+    status: "open",
+    title: "t",
+    affectedId: "host-1",
+    vendorIdentifier: "CVE-x",
+    evidence: {},
+    remediationHint: {},
+    lastSeenAt: new Date("2026-06-25T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("getPatchPosture", () => {
+  it("summarizes totals and sorts critical/KEV first", async () => {
+    const db = new FakeDb([
+      row({ findingKey: "patch:a", policySeverity: "medium", findingKind: "missing-patch", affectedId: "host-1", remediationHint: { targetVersion: "2.0" } }),
+      row({ findingKey: "patch:b", policySeverity: "critical", vendorIdentifier: "CVE-1", affectedId: "host-2", evidence: { cisaKev: true, installedVersion: "1.0" } }),
+      row({ findingKey: "patch:c", policySeverity: "high", affectedId: "host-2" }),
+    ]);
+    const posture = await getPatchPosture(db);
+    expect(posture.totals.findings).toBe(3);
+    expect(posture.totals.bySeverity).toEqual({ critical: 1, high: 1, medium: 1 });
+    expect(posture.totals.byKind).toEqual({ vulnerability: 2, "missing-patch": 1 });
+    expect(posture.totals.kev).toBe(1);
+    expect(posture.totals.hosts).toBe(2);
+    // critical (and KEV) first
+    expect(posture.findings[0].findingKey).toBe("patch:b");
+    expect(posture.findings[0].cisaKev).toBe(true);
+    expect(posture.findings[0].installedVersion).toBe("1.0");
+    const gap = posture.findings.find((f) => f.findingKey === "patch:a")!;
+    expect(gap.targetVersion).toBe("2.0");
+  });
+
+  it("excludes resolved findings by default and includes them with status=all", async () => {
+    const db = new FakeDb([
+      row({ findingKey: "patch:open" }),
+      row({ findingKey: "patch:done", status: "resolved" }),
+    ]);
+    expect((await getPatchPosture(db)).totals.findings).toBe(1);
+    expect((await getPatchPosture(db, { status: "all" })).totals.findings).toBe(2);
+  });
+
+  it("flags a capped list when more findings exist than the limit", async () => {
+    const db = new FakeDb([
+      row({ findingKey: "patch:1" }),
+      row({ findingKey: "patch:2" }),
+      row({ findingKey: "patch:3" }),
+    ]);
+    const posture = await getPatchPosture(db, { limit: 2 });
+    expect(posture.capped).toBe(true);
+    expect(posture.findings).toHaveLength(2);
+  });
+});

--- a/apps/web/lib/patch/patch-posture.ts
+++ b/apps/web/lib/patch/patch-posture.ts
@@ -1,0 +1,133 @@
+// Read model for estate patch posture: a projection over the patch findings the sweep
+// writes to the Assurance Ledger (findingKey `patch:*`). Powers the MCP tool and the
+// operator surface. db is an injected port so it is unit-testable without Prisma.
+
+const PATCH_FINDING_KEY_PREFIX = "patch:";
+const OPEN_STATUSES = ["open", "planned", "blocked"];
+const DEFAULT_LIMIT = 500;
+
+export interface PatchPostureFinding {
+  findingKey: string;
+  findingKind: string; // vulnerability | missing-patch | unsupported-component
+  policySeverity: string; // critical | high | medium | low | info
+  status: string;
+  title: string;
+  affectedId: string; // the host (InventoryEntity id)
+  vendorIdentifier: string; // CVE/GHSA or synthetic pm:pkg id
+  cisaKev: boolean;
+  targetVersion: string | null;
+  installedVersion: string | null;
+  lastSeenAt: Date | string;
+}
+
+export interface PatchPosture {
+  totals: {
+    findings: number;
+    bySeverity: Record<string, number>;
+    byKind: Record<string, number>;
+    kev: number;
+    hosts: number;
+  };
+  /** True when more findings exist than were returned (list capped). */
+  capped: boolean;
+  findings: PatchPostureFinding[];
+}
+
+interface AssuranceFindingRow {
+  findingKey: string;
+  findingKind: string;
+  policySeverity: string;
+  status: string;
+  title: string;
+  affectedId: string;
+  vendorIdentifier: string;
+  evidence: unknown;
+  remediationHint: unknown;
+  lastSeenAt: Date | string;
+}
+
+export interface PatchPostureDb {
+  assuranceFinding: { findMany(args: unknown): Promise<unknown[]> };
+}
+
+function readBool(obj: unknown, key: string): boolean {
+  return Boolean(obj && typeof obj === "object" && (obj as Record<string, unknown>)[key] === true);
+}
+
+function readStr(obj: unknown, key: string): string | null {
+  if (!obj || typeof obj !== "object") return null;
+  const v = (obj as Record<string, unknown>)[key];
+  return typeof v === "string" && v ? v : null;
+}
+
+const SEVERITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+
+/**
+ * Fetch and summarize the current patch posture. Defaults to open findings; pass
+ * `status: "all"` to include resolved/accepted. List is capped (default 500) but totals
+ * reflect the fetched set — the daily sweep keeps the open set bounded by estate size.
+ */
+export async function getPatchPosture(
+  db: PatchPostureDb,
+  options: { status?: "open" | "all"; limit?: number } = {},
+): Promise<PatchPosture> {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const statusFilter = options.status === "all" ? undefined : { status: { in: OPEN_STATUSES } };
+
+  const rows = (await db.assuranceFinding.findMany({
+    where: { findingKey: { startsWith: PATCH_FINDING_KEY_PREFIX }, ...statusFilter },
+    select: {
+      findingKey: true,
+      findingKind: true,
+      policySeverity: true,
+      status: true,
+      title: true,
+      affectedId: true,
+      vendorIdentifier: true,
+      evidence: true,
+      remediationHint: true,
+      lastSeenAt: true,
+    },
+    take: limit + 1,
+  })) as AssuranceFindingRow[];
+
+  const capped = rows.length > limit;
+  const visible = capped ? rows.slice(0, limit) : rows;
+
+  const findings: PatchPostureFinding[] = visible.map((row) => ({
+    findingKey: row.findingKey,
+    findingKind: row.findingKind,
+    policySeverity: row.policySeverity,
+    status: row.status,
+    title: row.title,
+    affectedId: row.affectedId,
+    vendorIdentifier: row.vendorIdentifier,
+    cisaKev: readBool(row.evidence, "cisaKev"),
+    targetVersion: readStr(row.remediationHint, "targetVersion"),
+    installedVersion: readStr(row.evidence, "installedVersion"),
+    lastSeenAt: row.lastSeenAt,
+  }));
+
+  findings.sort(
+    (a, b) =>
+      (SEVERITY_ORDER[a.policySeverity] ?? 9) - (SEVERITY_ORDER[b.policySeverity] ?? 9) ||
+      Number(b.cisaKev) - Number(a.cisaKev),
+  );
+
+  const bySeverity: Record<string, number> = {};
+  const byKind: Record<string, number> = {};
+  const hosts = new Set<string>();
+  let kev = 0;
+  for (const f of findings) {
+    bySeverity[f.policySeverity] = (bySeverity[f.policySeverity] ?? 0) + 1;
+    byKind[f.findingKind] = (byKind[f.findingKind] ?? 0) + 1;
+    if (f.affectedId) hosts.add(f.affectedId);
+    if (f.cisaKev) kev += 1;
+  }
+
+  return {
+    totals: { findings: findings.length, bySeverity, byKind, kev, hosts: hosts.size },
+    capped,
+    findings,
+  };
+}

--- a/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
+++ b/docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md
@@ -1,7 +1,7 @@
 # Estate Patch Management — P0 implementation plan
 
 - **Date:** 2026-06-25
-- **Status:** Read-only posture pipeline complete (feed → projector → binding → daily sweep wired); posture UX next
+- **Status:** Read-only posture COMPLETE — feed → projector → binding → daily sweep → `/ops/patches` surface. (MCP tool + Attention-Surface routing are optional follow-ups.)
 - **Spec:** `docs/superpowers/specs/2026-06-24-estate-patch-management-design.md`
 - **Epic:** `EP-PATCH-MANAGEMENT`
 - **Backlog:** BI-CAA0043C (version-intel feed), BI-489A8BB4 (assessment projector), BI-676A7960 (identity convergence), BI-020EE402 (posture UX)
@@ -40,8 +40,10 @@ Adapter interfaces + implementations that produce `assessPatchState` inputs, eac
 ### Slice 4 — Identity convergence (BI-676A7960) — gated
 Map the `DiscoveryFingerprint*` subsystem first; decide whether the software-identity spine extends it or lands a focused `CatalogIdentity` + `SoftwarePatchProfile`. Then the reviewable migration for `softwareIdentityId` (rename→`legacy…` + add `catalogIdentityId`, or drop-with-evidence) per the lifecycle-evidence spec §7.4. Runs through Prisma in the sandbox/canonical install, never blind. Until then, slice 3 keys findings on `DiscoveredSoftwareEvidence`/`InventoryEntity` directly.
 
-### Slice 5 — Posture read model + MCP tool + UX (BI-020EE402)
-`list_patch_posture` MCP tool (capped/paginated/provenance-free) and the `/ops/patches` surface composed from report-kit (`StatusBadge`/`DataTable`/`StatCard`), with the "needs you" items routing to the Attention Surface. Carries the UX-Fit attestation.
+### Slice 5 — Posture surface (BI-020EE402)
+- **Read model — LANDED:** `apps/web/lib/patch/patch-posture.ts` (`getPatchPosture`) projects the `patch:*` findings into totals (by severity/kind, KEV count, host count) + a severity/KEV-sorted, capped finding list; db injected for unit testing.
+- **`/ops/patches` surface — LANDED:** `apps/web/app/(shell)/ops/patches/page.tsx` — summary tiles (open findings, critical/high, KEV, affected hosts) + a filterable finding list using report-kit `StatusBadge` (severity colors via `statusColors`); added the **Patches** tab to the Ops nav; route manifest regenerated. Progressive disclosure (derived counts + three plain filters); UX-Fit attested in the commit.
+- **Remaining (optional follow-ups):** a `list_patch_posture` MCP tool (coworker/agent access) and routing critical/KEV items to the Attention Surface "needs you" inbox.
 
 ## Verification
 


### PR DESCRIPTION
The operator-facing posture surface (BI-020EE402) over the patch findings the daily sweep writes to the Assurance Ledger. Completes the read-only P0 capability end-to-end. Plan: `docs/superpowers/plans/2026-06-25-estate-patch-management-p0-plan.md`.

## What

- **Read model** (`apps/web/lib/patch/patch-posture.ts`): `getPatchPosture` projects the `patch:*` `AssuranceFinding` rows into totals (by severity/kind, KEV count, host count) + a severity/KEV-sorted, capped finding list. db injected → unit-tested.
- **`/ops/patches` page** (`app/(shell)/ops/patches/page.tsx`): summary tiles (open findings · critical/high · actively-exploited KEV · affected hosts) + a filterable finding list with report-kit `StatusBadge`. Adds the **Patches** tab to the Ops "Runtime & Releases" nav; route manifest regenerated (517 routes).

## Verification

- `pnpm --filter web exec vitest run lib/patch/ lib/ea/navigation-inventory-gate.test.ts` → **21/21** (read model + the nav↔route inventory gate).
- `pnpm --filter web typecheck` → clean.
- Live data renders on the deployed install once the daily `ops/patch-assessment-sweep` has run (your self-upgrade is the integration test).

## UX-Fit-Decision

Progressive disclosure: the platform **derives** the four summary counts and the finding list from `AssuranceFinding` — the operator types nothing. The only controls are three plain dropdowns (severity / type / open-vs-all); no raw token or endpoint input. The default view answers "are we exposed / where / what type" on one screen. Severity color resolves through report-kit `statusColors`, never a local map (AGENTS.md §12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)