### PR TITLE
fix(infra): rotate hwdsl2/whisper-server pin to current reachable digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -864,13 +864,17 @@ services:
   # No profile gate — voice ships working on `docker compose up`.
   dpf-stt:
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-06-18 (the prior 3f109fa1… digest was deleted from the
+    # resolved on 2026-06-25 (the prior 008ef78e… digest was deleted from the
     # registry — Release Image Manifest Guard caught it again). The registry
     # owner re-pushes :latest periodically and prunes the previous index, so
     # this digest must be re-resolved every time the guard fails. Bump
     # deliberately; never reach for `:latest` in shipped compose because it
     # makes the install non-reproducible.
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:008ef78e8164be1a52d3c16a0a4702af4190bc355c057e481ceb35af739ab184}
+    # OPERATOR RECOVERY (immediate, per-install): if this digest has rotted and
+    # the sidecar won't start, set DPF_STT_IMAGE in .env to a reachable ref
+    # (e.g. hwdsl2/whisper-server:latest) then `docker compose up -d dpf-stt`,
+    # and open a PR re-resolving the digest here (this is that PR's pattern).
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:10af319a81e81d03535e94b364b0103e8132d205b46438b4f469da9746fa8462}
     restart: unless-stopped
     logging: *default-logging
     environment:


### PR DESCRIPTION
## What
`dpf-stt` pins `hwdsl2/whisper-server` to a multi-arch index digest. The `008ef78e…` digest (resolved 2026-06-18) was **pruned from Docker Hub** when the registry owner re-pushed `:latest`, so the sidecar fails to start with `failed to resolve reference … not found`.

## Fix
- Re-resolved `hwdsl2/whisper-server:latest` to the current reachable index digest **`10af319a…`** — the documented re-resolution process; same class as #2050.
- Added an **OPERATOR RECOVERY** comment pointing operators at the existing `DPF_STT_IMAGE` `.env` override for immediate per-install recovery (no compose edit needed in the moment).

## Verification
- Digest reachability confirmed via `docker buildx imagetools inspect` (Release Image Manifest Guard should pass).
- Live install already recovered out-of-band via `DPF_STT_IMAGE=hwdsl2/whisper-server:latest`; sidecar healthy (`/v1/models → 200`).

## Durable follow-up (out of scope here)
This digest will rot again on the next upstream `:latest` re-push. A lasting fix — mirror the image into an org-controlled registry (GHCR) and pin that — is worth a separate BI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)