### PR TITLE
fix(golden-triangle): triangle corners snap to their preset (was reading as Custom)

### DIFF
--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -18,6 +18,7 @@ import {
   decodePostureForDisplay,
   pointToWeights,
   preferenceFromPreset,
+  snapToPreset,
   weightsToPoint,
 } from "./posture-display";
 
@@ -45,8 +46,10 @@ function normalize(p: GoldenTrianglePreference): Record<AxisKey, number> {
   return { qualityWeight: q / s, costWeight: c / s, timeWeight: t / s };
 }
 
-/** Set one axis to `val`, rebalancing the other two by their current ratio. */
-function rebalance(p: GoldenTrianglePreference, axis: AxisKey, val: number): GoldenTrianglePreference {
+/** Set one axis to `val`, rebalancing the other two by their current ratio.
+ *  Returns raw weights; the caller runs them through `emit` so a posture that
+ *  lands on a preset's region snaps to that preset. */
+function rebalance(p: GoldenTrianglePreference, axis: AxisKey, val: number): Record<AxisKey, number> {
   const w = normalize(p);
   const v = Math.min(1, Math.max(0, val));
   const others = (["qualityWeight", "costWeight", "timeWeight"] as AxisKey[]).filter((k) => k !== axis);
@@ -59,7 +62,7 @@ function rebalance(p: GoldenTrianglePreference, axis: AxisKey, val: number): Gol
   } else {
     others.forEach((k) => (out[k] = (w[k] / otherSum) * rem));
   }
-  return { preset: "custom", ...out };
+  return out;
 }
 
 function unitToVb(ux: number, uy: number) {
@@ -97,6 +100,14 @@ export function GoldenTriangleControl({
   const balanceColor = `var(${balance.token})`;
   const triStroke = `color-mix(in srgb, ${balanceColor} 45%, var(--dpf-border-strong))`;
 
+  // Snap-aware commit: a posture that lands clearly on a preset's region becomes
+  // that preset (so dragging the dot into a corner reads like clicking the preset
+  // button — same label + description), otherwise it stays a custom fine-tune.
+  function emit(next: Record<AxisKey, number>) {
+    const preset = snapToPreset(next);
+    onChange(preset ? preferenceFromPreset(preset) : { preset: "custom", ...next });
+  }
+
   function setFromEvent(clientX: number, clientY: number) {
     const svg = svgRef.current;
     if (!svg) return;
@@ -106,15 +117,15 @@ export function GoldenTriangleControl({
     const vy = ((clientY - rect.top) / rect.height) * 100;
     const ux = (vx - INSET) / SPAN;
     const uy = (vy - INSET) / SPAN;
-    onChange({ preset: "custom", ...pointToWeights(ux, uy) });
+    emit(pointToWeights(ux, uy));
   }
 
   function onThumbKeyDown(e: ReactKeyboardEvent) {
     let handled = true;
-    if (e.key === "ArrowLeft") onChange(rebalance(value, "costWeight", w.costWeight + STEP));
-    else if (e.key === "ArrowRight") onChange(rebalance(value, "timeWeight", w.timeWeight + STEP));
-    else if (e.key === "ArrowUp") onChange(rebalance(value, "qualityWeight", w.qualityWeight + STEP));
-    else if (e.key === "ArrowDown") onChange(rebalance(value, "qualityWeight", w.qualityWeight - STEP));
+    if (e.key === "ArrowLeft") emit(rebalance(value, "costWeight", w.costWeight + STEP));
+    else if (e.key === "ArrowRight") emit(rebalance(value, "timeWeight", w.timeWeight + STEP));
+    else if (e.key === "ArrowUp") emit(rebalance(value, "qualityWeight", w.qualityWeight + STEP));
+    else if (e.key === "ArrowDown") emit(rebalance(value, "qualityWeight", w.qualityWeight - STEP));
     else if (e.key === "Home") onChange(preferenceFromPreset("balanced"));
     else handled = false;
     if (handled) e.preventDefault();
@@ -205,7 +216,7 @@ export function GoldenTriangleControl({
                 onChange={(e) => {
                   const raw = Number(e.target.value);
                   if (!Number.isFinite(raw)) return;
-                  onChange(rebalance(value, key, raw / 100));
+                  emit(rebalance(value, key, raw / 100));
                 }}
                 className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[13px] text-[var(--dpf-text)]"
                 aria-label={`${label} priority percent`}

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -10,8 +10,42 @@ import {
   plainSummary,
   pointToWeights,
   preferenceFromPreset,
+  snapToPreset,
   weightsToPoint,
 } from "./posture-display";
+
+describe("snapToPreset — corners resolve to their preset, not Custom", () => {
+  it("snaps each extreme corner to that corner's preset", () => {
+    expect(snapToPreset({ qualityWeight: 1, costWeight: 0, timeWeight: 0 })).toBe("assured");
+    expect(snapToPreset({ qualityWeight: 0, costWeight: 1, timeWeight: 0 })).toBe("frugal");
+    expect(snapToPreset({ qualityWeight: 0, costWeight: 0, timeWeight: 1 })).toBe("fast");
+  });
+
+  it("snaps each preset's own weights back to itself (consistent with the buttons)", () => {
+    for (const preset of ["fast", "balanced", "assured", "frugal"] as const) {
+      const [q, c, t] = PRESET_WEIGHTS[preset];
+      expect(snapToPreset({ qualityWeight: q, costWeight: c, timeWeight: t })).toBe(preset);
+    }
+  });
+
+  it("snaps a near-centroid posture to Balanced", () => {
+    expect(snapToPreset({ qualityWeight: 0.34, costWeight: 0.33, timeWeight: 0.33 })).toBe("balanced");
+    expect(snapToPreset({ qualityWeight: 0.36, costWeight: 0.32, timeWeight: 0.32 })).toBe("balanced");
+  });
+
+  it("leaves a genuine in-between (a mild lean) as a custom fine-tune (null)", () => {
+    expect(snapToPreset({ qualityWeight: 0.5, costWeight: 0.3, timeWeight: 0.2 })).toBeNull();
+    expect(snapToPreset({ qualityWeight: 0.45, costWeight: 0.45, timeWeight: 0.1 })).toBeNull();
+  });
+
+  it("a corner reached by dragging (point→weights) snaps to the preset", () => {
+    // The Quality vertex is the unit point (0.5, 0); dragging the dot there should
+    // read as Assured — the same as clicking the Assured button.
+    expect(snapToPreset(pointToWeights(0.5, 0))).toBe("assured");
+    expect(snapToPreset(pointToWeights(0, 1))).toBe("frugal"); // Cost vertex
+    expect(snapToPreset(pointToWeights(1, 1))).toBe("fast"); // Time vertex
+  });
+});
 
 describe("posture-display geometry", () => {
   it("weights -> point -> weights round-trips for every preset", () => {

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -87,6 +87,35 @@ export function preferenceFromPreset(preset: Exclude<GoldenTrianglePreset, "cust
   return { preset, qualityWeight, costWeight, timeWeight };
 }
 
+/**
+ * Snap dragged/typed weights to a preset when the posture lands clearly on that
+ * preset's region — so the CORNERS of the triangle resolve to the SAME preset
+ * (label + description) as the one-click button, instead of reading as "Custom".
+ * A clearly dominant axis (>= the snap floor) snaps to that axis's preset; a
+ * near-centroid posture snaps to Balanced; everything in between stays a custom
+ * fine-tune. Pure + deterministic. Returns null when nothing should snap.
+ */
+const SNAP_DOMINANT = 0.6; // a dominant axis at/above this owns its corner-ward region
+const SNAP_BALANCED_MAX = 0.42; // no axis above this …
+const SNAP_BALANCED_MIN = 0.24; // … and none below this → the centroid (Balanced)
+
+export function snapToPreset(w: Weights): Exclude<GoldenTrianglePreset, "custom"> | null {
+  const q = Math.max(0, w.qualityWeight);
+  const c = Math.max(0, w.costWeight);
+  const t = Math.max(0, w.timeWeight);
+  const s = q + c + t || 1;
+  const nq = q / s;
+  const nc = c / s;
+  const nt = t / s;
+  if (nq >= SNAP_DOMINANT && nq >= nc && nq >= nt) return "assured";
+  if (nc >= SNAP_DOMINANT && nc >= nq && nc >= nt) return "frugal";
+  if (nt >= SNAP_DOMINANT && nt >= nq && nt >= nc) return "fast";
+  const max = Math.max(nq, nc, nt);
+  const min = Math.min(nq, nc, nt);
+  if (max <= SNAP_BALANCED_MAX && min >= SNAP_BALANCED_MIN) return "balanced";
+  return null;
+}
+
 // ── Plain-language summary ──────────────────────────────────────────────────
 const PLAIN: Record<Exclude<GoldenTrianglePreset, "custom">, string> = {
   fast: "Quickest result. Less checking.",


### PR DESCRIPTION
**Founder report:** pushing the dot to a corner reads as **"Custom"**, but clicking the preset that sits in that same corner shows the preset's name + description. *"The extreme movement control should be the same as the default for that same position."*

**Cause:** presets sit at `0.8`-dominant positions, but the triangle's corners are the `1.0` extremes, and every drag/keyboard/input emitted `preset: "custom"` — so a corner never resolved to the preset that owns it.

**Fix:** a pure `snapToPreset(weights)` — a clearly dominant axis (≥ 0.6) snaps to that axis's preset, a near-centroid posture snaps to **Balanced**, the in-between stays a custom fine-tune. Drag, keyboard, and the number inputs all route through one snap-aware `emit()`, so a corner now reads exactly like clicking its preset button (same label + description).

**Heads-up (separate decision):** the triangle's heaviest reachable posture is now **Assured** (deep review). The extra **"debate"** rung only ever triggered by dragging to an extreme custom quality (≥ 0.85), so it's no longer drag-reachable. If debate should be first-class, it wants its own preset — flagged, not silently dropped.

**24 posture-display tests (5 new) + 5 control tests green; web `tsc` clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)