### PR TITLE
fix(golden-triangle): maxing a dimension = its full setting (Quality-max → debate) + axis explainer

### DIFF
--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -14,9 +14,11 @@ import { GoldenTriangleGradient } from "./GoldenTriangleGradient";
 import {
   PRESET_META,
   PRESET_ORDER,
+  TRIANGLE_AXIS_GUIDE,
   balanceState,
   decodePostureForDisplay,
   pointToWeights,
+  postureLabel,
   preferenceFromPreset,
   weightsToPoint,
 } from "./posture-display";
@@ -92,7 +94,9 @@ export function GoldenTriangleControl({
   const vQuality = unitToVb(0.5, 0);
   const vCost = unitToVb(0, 1);
   const vTime = unitToVb(1, 1);
-  const activeLabel = value.preset === "custom" ? "Custom" : PRESET_META[value.preset].label;
+  // A meaningful label at every position — an extreme reads as e.g. "Max Quality"
+  // (the corner = that dimension's full setting), never a bare "Custom".
+  const activeLabel = postureLabel(value);
 
   const balanceColor = `var(${balance.token})`;
   const triStroke = `color-mix(in srgb, ${balanceColor} 45%, var(--dpf-border-strong))`;
@@ -229,6 +233,7 @@ export function GoldenTriangleControl({
           </span>
         ))}
       </div>
+      <p className="mt-2 text-[10px] leading-snug text-[var(--dpf-text-secondary)]">{TRIANGLE_AXIS_GUIDE}</p>
     </div>
   );
 

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -9,9 +9,28 @@ import {
   describeConfigured,
   plainSummary,
   pointToWeights,
+  postureLabel,
   preferenceFromPreset,
   weightsToPoint,
 } from "./posture-display";
+
+describe("postureLabel — every position reads meaningfully (never bare 'Custom')", () => {
+  it("uses the preset name for a preset", () => {
+    expect(postureLabel(preferenceFromPreset("assured"))).toBe("Assured");
+    expect(postureLabel(preferenceFromPreset("frugal"))).toBe("Frugal");
+  });
+  it("labels the maxed corner as 'Max <dimension>'", () => {
+    expect(postureLabel({ preset: "custom", qualityWeight: 1, costWeight: 0, timeWeight: 0 })).toBe("Max Quality");
+    expect(postureLabel({ preset: "custom", qualityWeight: 0, costWeight: 1, timeWeight: 0 })).toBe("Max Cost");
+    expect(postureLabel({ preset: "custom", qualityWeight: 0, costWeight: 0, timeWeight: 1 })).toBe("Max Speed");
+  });
+  it("labels a strong-but-not-max lean as '<dimension>-first'", () => {
+    expect(postureLabel({ preset: "custom", qualityWeight: 0.7, costWeight: 0.2, timeWeight: 0.1 })).toBe("Quality-first");
+  });
+  it("labels a near-centroid custom posture 'Balanced'", () => {
+    expect(postureLabel({ preset: "custom", qualityWeight: 0.34, costWeight: 0.33, timeWeight: 0.33 })).toBe("Balanced");
+  });
+});
 
 describe("posture-display geometry", () => {
   it("weights -> point -> weights round-trips for every preset", () => {
@@ -69,6 +88,10 @@ describe("plainSummary", () => {
 
   it("describes a moderate custom lean", () => {
     expect(plainSummary({ preset: "custom", qualityWeight: 0.45, costWeight: 0.3, timeWeight: 0.25 })).toMatch(/right/i);
+  });
+
+  it("maxing Quality describes a debate (the top of the rigor ladder)", () => {
+    expect(plainSummary({ preset: "custom", qualityWeight: 0.9, costWeight: 0.05, timeWeight: 0.05 })).toMatch(/debate/i);
   });
 
   it("falls back to balanced for an unfocused custom posture", () => {

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -113,14 +113,49 @@ function dominantAxis(p: GoldenTrianglePreference): { axis: "quality" | "cost" |
   return { axis, weight };
 }
 
+// The work scales continuously with the triangle: maxing an axis is that
+// dimension's FULL setting. For Quality, the top of the rigor ladder is a
+// multi-perspective debate (the compiler emits it at qualityWeight >= 0.85, the
+// same QUALITY_DEBATE_FLOOR) — above the single review the Assured preset buys.
+const QUALITY_DEBATE_FLOOR = 0.85;
+
 export function plainSummary(pref: GoldenTrianglePreference): string {
   if (pref.preset !== "custom") return PLAIN[pref.preset];
   const { axis, weight } = dominantAxis(pref);
   if (weight < 0.4) return PLAIN.balanced;
-  if (axis === "quality") return weight >= 0.55 ? PLAIN.assured : "Leaning toward getting it right.";
+  if (axis === "quality") {
+    if (weight >= QUALITY_DEBATE_FLOOR) {
+      return "Maxed for quality: strongest model, max effort, deep review, and a multi-perspective debate. Highest cost and time.";
+    }
+    return weight >= 0.55 ? PLAIN.assured : "Leaning toward getting it right.";
+  }
   if (axis === "cost") return weight >= 0.55 ? PLAIN.frugal : "Leaning toward saving money.";
   return weight >= 0.55 ? PLAIN.fast : "Leaning toward speed.";
 }
+
+/**
+ * A short, meaningful label for ANY posture — the preset name for a preset, or a
+ * dimension + intensity descriptor for a custom one. So an extreme reads as e.g.
+ * "Max Quality" (never a bare "Custom"), conveying that a corner is that
+ * dimension's full setting.
+ */
+export function postureLabel(pref: GoldenTrianglePreference): string {
+  if (pref.preset !== "custom") return PRESET_META[pref.preset].label;
+  const { axis, weight } = dominantAxis(pref);
+  if (weight < 0.4) return "Balanced";
+  const dim = axis === "quality" ? "Quality" : axis === "cost" ? "Cost" : "Speed";
+  if (weight >= QUALITY_DEBATE_FLOOR) return `Max ${dim}`;
+  if (weight >= 0.55) return `${dim}-first`;
+  return `${dim}-leaning`;
+}
+
+/**
+ * Plain explanation of what min/maxing each axis does — shown beneath the control
+ * so an operator knows what pulling toward a corner buys. The work + resources
+ * scale continuously with the triangle; a corner is that dimension at full.
+ */
+export const TRIANGLE_AXIS_GUIDE =
+  "Each corner is that dimension at full strength: Quality → strongest model, deepest review, up to a debate · Cost → cheapest capable model, least checking · Time → fastest, least deliberation. The middle blends them — the model, effort, and review all scale with the dot.";
 
 // ── Configured-chips (driven by the real compiler output) ────────────────────
 export interface ConfigChip {


### PR DESCRIPTION
**Founder direction (supersedes the snap PR #2403):** pushing the dot to a corner should mean that dimension at **full strength** — **Quality-max = a debate** (top of the rigor ladder), not a bare "Custom" — and the control should **explain** what min/maxing an axis includes, since the model + effort + review scale continuously with the triangle.

The compiler already reaches debate at extreme Quality (`qualityWeight >= 0.85`); the gap was purely the **readout**. So — no snapping, the triangle stays continuous:

- **`postureLabel()`** — every position reads meaningfully: the preset name for a preset, else **"Max Quality" / "Quality-first" / "Quality-leaning" / "Balanced"**. An extreme is never a bare "Custom" again.
- **`plainSummary()`** — maxing Quality (≥ 0.85) now says *"strongest model, max effort, deep review, and a multi-perspective debate"* — surfacing the debate rung the config chips already show.
- **`TRIANGLE_AXIS_GUIDE`** — a plain line beneath the control: *"Each corner is that dimension at full strength: Quality → … up to a debate · Cost → cheapest, least checking · Time → fastest …"*

**Why not snap** (the closed #2403): snapping the corner to the Assured preset would cap Quality at *review* and block the debate max — the opposite of the intent.

**29 posture-display + control tests green; web `tsc` clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)