### PR TITLE
fix+docs(sovereign-soc): wire Detection → Case auto-grouping + user guide for the AI SOC

### DIFF
--- a/apps/web/lib/queue/functions/siem-correlation-sweep.test.ts
+++ b/apps/web/lib/queue/functions/siem-correlation-sweep.test.ts
@@ -6,11 +6,21 @@ const {
   mockThreatIndicatorFindMany,
   mockSecurityEventFindMany,
   mockDetectionUpsert,
+  mockDetectionFindMany,
+  mockDetectionUpdateMany,
+  mockSecurityCaseFindUnique,
+  mockSecurityCaseCreate,
+  mockSecurityCaseUpdate,
 } = vi.hoisted(() => ({
   mockDetectionRuleFindMany: vi.fn(),
   mockThreatIndicatorFindMany: vi.fn(),
   mockSecurityEventFindMany: vi.fn(),
   mockDetectionUpsert: vi.fn(),
+  mockDetectionFindMany: vi.fn(),
+  mockDetectionUpdateMany: vi.fn(),
+  mockSecurityCaseFindUnique: vi.fn(),
+  mockSecurityCaseCreate: vi.fn(),
+  mockSecurityCaseUpdate: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -18,7 +28,16 @@ vi.mock("@dpf/db", () => ({
     detectionRule: { findMany: mockDetectionRuleFindMany },
     threatIndicator: { findMany: mockThreatIndicatorFindMany },
     securityEvent: { findMany: mockSecurityEventFindMany },
-    detection: { upsert: mockDetectionUpsert },
+    detection: {
+      upsert: mockDetectionUpsert,
+      findMany: mockDetectionFindMany,
+      updateMany: mockDetectionUpdateMany,
+    },
+    securityCase: {
+      findUnique: mockSecurityCaseFindUnique,
+      create: mockSecurityCaseCreate,
+      update: mockSecurityCaseUpdate,
+    },
   },
 }));
 
@@ -30,6 +49,11 @@ beforeEach(() => {
   vi.resetAllMocks();
   mockThreatIndicatorFindMany.mockResolvedValue([]);
   mockDetectionUpsert.mockResolvedValue({ id: "det_1" });
+  // Default: no un-cased detections to group (tests opt in below).
+  mockDetectionFindMany.mockResolvedValue([]);
+  mockDetectionUpdateMany.mockResolvedValue({ count: 0 });
+  mockSecurityCaseFindUnique.mockResolvedValue(null);
+  mockSecurityCaseCreate.mockResolvedValue({ id: "case_1" });
 });
 
 describe("runCorrelationSweep", () => {
@@ -115,5 +139,79 @@ describe("runCorrelationSweep", () => {
     const result = await runCorrelationSweep({ seedPack: false });
     expect(result.detectionsUpserted).toBe(0);
     expect(mockDetectionUpsert).not.toHaveBeenCalled();
+    expect(result.casesOpened).toBe(0); // nothing un-cased to group
+  });
+
+  it("groups open, un-cased detections into a SecurityCase (Detection --> Case)", async () => {
+    mockDetectionRuleFindMany.mockResolvedValue([]); // no scan this test
+    mockSecurityEventFindMany.mockResolvedValue([]);
+    // Two open, un-cased detections about the same host + ATT&CK family → one case.
+    mockDetectionFindMany.mockResolvedValue([
+      {
+        detectionKey: "dpf-kernel:windows-audit-log-cleared:e1",
+        scopeKey: "organization:internal",
+        customerAccountId: null,
+        customerSiteId: null,
+        severity: "high",
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+        enrichment: { ruleKey: "dpf-kernel:windows-audit-log-cleared", ruleName: "Windows audit log cleared", mitreTechniques: ["T1070.001"], entityKey: "HOST-1" },
+      },
+      {
+        detectionKey: "dpf-kernel:windows-audit-log-cleared:e2",
+        scopeKey: "organization:internal",
+        customerAccountId: null,
+        customerSiteId: null,
+        severity: "high",
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+        enrichment: { ruleKey: "dpf-kernel:windows-audit-log-cleared", ruleName: "Windows audit log cleared", mitreTechniques: ["T1070.001"], entityKey: "HOST-1" },
+      },
+    ]);
+
+    const result = await runCorrelationSweep({ seedPack: false });
+
+    expect(result.casesOpened).toBe(1);
+    expect(mockSecurityCaseCreate).toHaveBeenCalledTimes(1);
+    const created = mockSecurityCaseCreate.mock.calls[0]![0].data;
+    expect(created).toMatchObject({
+      scopeKey: "organization:internal",
+      severity: "high",
+      status: "new",
+      verdict: "unknown",
+    });
+    expect(created.caseKey).toContain("attack:T1070.001");
+    expect(created.title).toContain("HOST-1");
+    // Both detections linked to the new case, exactly once.
+    expect(mockDetectionUpdateMany).toHaveBeenCalledTimes(1);
+    const link = mockDetectionUpdateMany.mock.calls[0]![0];
+    expect(link.data).toEqual({ securityCaseId: "case_1" });
+    expect(link.where.detectionKey.in).toHaveLength(2);
+  });
+
+  it("merges into an existing case and ratchets severity, no duplicate", async () => {
+    mockDetectionRuleFindMany.mockResolvedValue([]);
+    mockSecurityEventFindMany.mockResolvedValue([]);
+    mockDetectionFindMany.mockResolvedValue([
+      {
+        detectionKey: "dpf-kernel:aws-mfa-weakened:e9",
+        scopeKey: "organization:internal",
+        customerAccountId: null,
+        customerSiteId: null,
+        severity: "high",
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+        enrichment: { ruleKey: "dpf-kernel:aws-mfa-weakened", ruleName: "AWS MFA removed", mitreTechniques: ["T1556"], entityKey: "arn:aws:iam::1:user/x" },
+      },
+    ]);
+    mockSecurityCaseFindUnique.mockResolvedValue({ id: "case_existing", severity: "medium" });
+
+    const result = await runCorrelationSweep({ seedPack: false });
+
+    expect(result.casesOpened).toBe(0); // merged, not opened
+    expect(mockSecurityCaseCreate).not.toHaveBeenCalled();
+    expect(mockSecurityCaseUpdate).toHaveBeenCalledTimes(1); // medium -> high
+    expect(mockSecurityCaseUpdate.mock.calls[0]![0].data).toEqual({ severity: "high" });
+    expect(mockDetectionUpdateMany).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/queue/functions/siem-correlation-sweep.ts
+++ b/apps/web/lib/queue/functions/siem-correlation-sweep.ts
@@ -21,6 +21,12 @@ import {
   type SecurityEventView,
 } from "@/lib/security/detection";
 import { ensureKernelDetectionPack } from "@/lib/security/detection-pack";
+import {
+  detectionRowToGroupingInput,
+  groupDetectionsIntoCases,
+  maxSeverity,
+  type DetectionRowForGrouping,
+} from "@/lib/security/case-grouping";
 import { runInternalSecurityProjection } from "@/lib/security/internal-projector";
 import {
   buildIndicatorIndex,
@@ -40,6 +46,22 @@ export interface CorrelationSweepResult {
   indicators: number;
   eventsScanned: number;
   detectionsUpserted: number;
+  /** SecurityCases opened this cycle from open, un-cased detections (§6.4). */
+  casesOpened: number;
+}
+
+/**
+ * The asset/actor a detection is "about", for case grouping. Device hostname
+ * first (host-scoped events), then the acting user/principal, else "unknown"
+ * (the detection still groups by scope + family). Json-safe.
+ */
+function deriveEntityKey(device: unknown, actor: unknown): string {
+  const host = (device as { hostname?: unknown } | null)?.hostname;
+  if (typeof host === "string" && host) return host;
+  const a = (actor ?? {}) as { user?: { name?: unknown }; name?: unknown; uid?: unknown };
+  const user = a.user?.name ?? a.name ?? a.uid;
+  if (typeof user === "string" && user) return user;
+  return "unknown";
 }
 
 function toRuleView(rule: {
@@ -163,6 +185,8 @@ export async function runCorrelationSweep(opts?: {
       time: true,
       observables: true,
       normalized: true,
+      device: true,
+      actor: true,
     },
   });
 
@@ -171,7 +195,11 @@ export async function runCorrelationSweep(opts?: {
     const candidates = evaluateRulesForEvent(ruleViews, toEventView(ev), {
       indicatorIndex: index,
     });
+    // Stamp the matched entity onto the detection so case grouping can run off
+    // the persisted row without re-joining to the event (case-grouping.ts).
+    const entityKey = deriveEntityKey(ev.device, ev.actor);
     for (const c of candidates) {
+      const enrichment = { ...c.enrichment, entityKey };
       await prisma.detection.upsert({
         where: { detectionKey: c.detectionKey },
         create: {
@@ -184,7 +212,7 @@ export async function runCorrelationSweep(opts?: {
           status: "open",
           riskScore: c.riskScore,
           matchedEventRefs: c.matchedEventRefs as object,
-          enrichment: c.enrichment as object,
+          enrichment: enrichment as object,
           firstSeenAt: c.firstSeenAt,
           lastSeenAt: c.lastSeenAt,
         },
@@ -193,7 +221,7 @@ export async function runCorrelationSweep(opts?: {
         update: {
           severity: c.severity,
           riskScore: c.riskScore,
-          enrichment: c.enrichment as object,
+          enrichment: enrichment as object,
           lastSeenAt: c.lastSeenAt,
         },
       });
@@ -201,12 +229,99 @@ export async function runCorrelationSweep(opts?: {
     }
   }
 
+  // ── Detection --> Case (spec §6.4): group open, un-cased detections into
+  //    SecurityCases so the AI SOC has a case to triage without a human first
+  //    opening one. Idempotent: the grouping key is stable, so a re-run merges
+  //    into the same case rather than spawning duplicates. Coworkers can still
+  //    open cases manually (open_security_case) — both edges feed one model.
+  const casesOpened = await groupOpenDetectionsIntoCases(prisma, now);
+
   return {
     rules: rules.length,
     indicators: index.size,
     eventsScanned: events.length,
     detectionsUpserted,
+    casesOpened,
   };
+}
+
+/**
+ * Group every OPEN, un-cased Detection into a SecurityCase. Detections already
+ * linked to a case (securityCaseId set) are excluded, so each detection is
+ * grouped exactly once; an existing case absorbs new same-key detections and
+ * ratchets to the max severity. Returns the count of NEW cases opened.
+ */
+async function groupOpenDetectionsIntoCases(
+  prisma: typeof import("@dpf/db").prisma,
+  now: Date,
+): Promise<number> {
+  const ungrouped = await prisma.detection.findMany({
+    where: { status: "open", securityCaseId: null },
+    select: {
+      detectionKey: true,
+      scopeKey: true,
+      customerAccountId: true,
+      customerSiteId: true,
+      severity: true,
+      firstSeenAt: true,
+      lastSeenAt: true,
+      enrichment: true,
+    },
+    take: SWEEP_EVENT_CAP,
+  });
+  if (ungrouped.length === 0) return 0;
+
+  const candidates = groupDetectionsIntoCases(
+    ungrouped.map((d) =>
+      detectionRowToGroupingInput(d as unknown as DetectionRowForGrouping),
+    ),
+  );
+
+  let casesOpened = 0;
+  for (const cand of candidates) {
+    const existing = await prisma.securityCase.findUnique({
+      where: { caseKey: cand.caseKey },
+      select: { id: true, severity: true },
+    });
+    let caseId: string;
+    if (existing) {
+      caseId = existing.id;
+      const merged = maxSeverity(existing.severity, cand.severity);
+      if (merged !== existing.severity) {
+        await prisma.securityCase.update({ where: { id: caseId }, data: { severity: merged } });
+      }
+    } else {
+      const created = await prisma.securityCase.create({
+        data: {
+          caseKey: cand.caseKey,
+          scopeKey: cand.scopeKey,
+          customerAccountId: cand.customerAccountId,
+          customerSiteId: cand.customerSiteId,
+          title: cand.title,
+          severity: cand.severity,
+          status: "new",
+          verdict: "unknown",
+          timeline: [
+            {
+              at: now.toISOString(),
+              kind: "auto-opened",
+              note: `Opened by the correlation sweep from ${cand.detectionKeys.length} detection(s).`,
+            },
+          ] as object,
+          openedAt: cand.firstSeenAt,
+        },
+        select: { id: true },
+      });
+      caseId = created.id;
+      casesOpened++;
+    }
+    // Link the grouped detections (only those still un-cased — idempotent).
+    await prisma.detection.updateMany({
+      where: { detectionKey: { in: cand.detectionKeys }, securityCaseId: null },
+      data: { securityCaseId: caseId },
+    });
+  }
+  return casesOpened;
 }
 
 export const siemCorrelationSweep = inngest.createFunction(

--- a/apps/web/lib/security/case-grouping.test.ts
+++ b/apps/web/lib/security/case-grouping.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   deriveGroupingKey,
+  detectionFamily,
+  detectionRowToGroupingInput,
   groupDetectionsIntoCases,
   maxSeverity,
   type DetectionForGrouping,
+  type DetectionRowForGrouping,
 } from "./case-grouping";
 
 const T0 = new Date("2026-06-25T12:00:00.000Z");
@@ -75,5 +78,56 @@ describe("groupDetectionsIntoCases", () => {
     expect(forward.title).toBe("b");
     expect(reverse.title).toBe("b");
     expect(forward.detectionKeys.sort()).toEqual(reverse.detectionKeys.sort());
+  });
+});
+
+describe("detectionFamily / detectionRowToGroupingInput (the sweep bridge)", () => {
+  function row(overrides: Partial<DetectionRowForGrouping>): DetectionRowForGrouping {
+    return {
+      detectionKey: "dpf-kernel:windows-audit-log-cleared:e1",
+      scopeKey: "organization:internal",
+      customerAccountId: null,
+      customerSiteId: null,
+      severity: "high",
+      firstSeenAt: T0,
+      lastSeenAt: T0,
+      enrichment: {
+        ruleKey: "dpf-kernel:windows-audit-log-cleared",
+        ruleName: "Windows audit log cleared",
+        mitreTechniques: ["T1070.001"],
+        entityKey: "HOST-1",
+      },
+      ...overrides,
+    };
+  }
+
+  it("families by primary ATT&CK technique, else rule key", () => {
+    expect(detectionFamily({ mitreTechniques: ["T1110"], ruleKey: "r" })).toBe("attack:T1110");
+    expect(detectionFamily({ ruleKey: "dpf-kernel:x" })).toBe("rule:dpf-kernel:x");
+    expect(detectionFamily({})).toBe("uncategorized");
+  });
+
+  it("maps a detection row to a grouping input with entity + family in the key", () => {
+    const g = detectionRowToGroupingInput(row({}));
+    expect(g.groupingKey).toBe("organization:internal|HOST-1|attack:T1070.001");
+    expect(g.title).toBe("Windows audit log cleared — HOST-1");
+    expect(g.severity).toBe("high");
+    expect(g.detectionKey).toBe("dpf-kernel:windows-audit-log-cleared:e1");
+  });
+
+  it("falls back to entity 'unknown' (group by scope+family) when entity is absent", () => {
+    const g = detectionRowToGroupingInput(row({ enrichment: { ruleKey: "r", mitreTechniques: ["T1098"] } }));
+    expect(g.groupingKey).toBe("organization:internal|unknown|attack:T1098");
+    expect(g.title).toBe("r"); // no entity qualifier
+  });
+
+  it("two same-host same-technique detections collapse to one case via the bridge", () => {
+    const inputs = [
+      detectionRowToGroupingInput(row({ detectionKey: "k:e1" })),
+      detectionRowToGroupingInput(row({ detectionKey: "k:e2" })),
+    ];
+    const cases = groupDetectionsIntoCases(inputs);
+    expect(cases).toHaveLength(1);
+    expect(cases[0]!.detectionKeys).toEqual(["k:e1", "k:e2"]);
   });
 });

--- a/apps/web/lib/security/case-grouping.ts
+++ b/apps/web/lib/security/case-grouping.ts
@@ -110,3 +110,68 @@ export function groupDetectionsIntoCases(
   // Stable output order: by caseKey.
   return [...byKey.values()].sort((a, b) => a.caseKey.localeCompare(b.caseKey));
 }
+
+// ── Persisted-detection → grouping input (the sweep's bridge) ────────────────
+//
+// The correlation sweep stores the matched entity on each Detection's enrichment
+// (entityKey) plus the rule's name + ATT&CK techniques. These pure helpers turn a
+// persisted Detection row back into a `DetectionForGrouping` so the sweep can
+// group OPEN, un-cased detections into cases (the spec's Detection --> Case edge,
+// §6.4) without re-joining to the source events.
+
+/** Enrichment fields the grouping bridge reads off a Detection row. */
+export interface DetectionEnrichmentForGrouping {
+  ruleKey?: string;
+  ruleName?: string;
+  mitreTechniques?: string[];
+  /** The asset/actor the detection is about (hostname, user, account). */
+  entityKey?: string;
+}
+
+export interface DetectionRowForGrouping {
+  detectionKey: string;
+  scopeKey: string;
+  customerAccountId: string | null;
+  customerSiteId: string | null;
+  severity: string;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+  enrichment: DetectionEnrichmentForGrouping | null;
+}
+
+/**
+ * The grouping family — what KIND of activity the case is about. Primary ATT&CK
+ * technique when known (so e.g. all credential-access on a host coalesce), else
+ * the rule pack/key. Stable: the same rule always yields the same family.
+ */
+export function detectionFamily(enr: DetectionEnrichmentForGrouping): string {
+  const technique = enr.mitreTechniques?.[0];
+  if (technique) return `attack:${technique}`;
+  return enr.ruleKey ? `rule:${enr.ruleKey}` : "uncategorized";
+}
+
+/**
+ * Map a persisted Detection row to the pure grouping input. entityKey defaults to
+ * "unknown" (detections still group by scope + family); the title prefers the
+ * rule name, qualified by the entity when known.
+ */
+export function detectionRowToGroupingInput(
+  row: DetectionRowForGrouping,
+): DetectionForGrouping {
+  const enr = row.enrichment ?? {};
+  const entityKey = enr.entityKey && enr.entityKey.length ? enr.entityKey : "unknown";
+  const family = detectionFamily(enr);
+  const ruleName = enr.ruleName ?? enr.ruleKey ?? "Security detection";
+  const title = entityKey !== "unknown" ? `${ruleName} — ${entityKey}` : ruleName;
+  return {
+    detectionKey: row.detectionKey,
+    scopeKey: row.scopeKey,
+    customerAccountId: row.customerAccountId,
+    customerSiteId: row.customerSiteId,
+    severity: row.severity,
+    groupingKey: deriveGroupingKey({ scopeKey: row.scopeKey, entityKey, family }),
+    title,
+    firstSeenAt: row.firstSeenAt,
+    lastSeenAt: row.lastSeenAt,
+  };
+}


### PR DESCRIPTION
@-

---

## Also in this PR: user documentation

Mark asked to capture the process so any user can set up and manage the SOC. Added a plain-language user guide under `docs/user-guide/security/` (bundled into in-app help):
- **index** — what the SOC is, the three differentiators, the autonomous loop.
- **setup** — what works out of the box, connecting sources via edge collectors, threat intel, autonomy posture.
- **operating** — the console, the case lifecycle, the AI SOC coworkers, tuning, approving governed responses, compliance reports, MSP federation.

Grounded in live verification: the console, the 14-rule pack, the sweep, and the detection path were all confirmed on the running install before being documented.
