### PR TITLE
feat(attention): notification spine — proactive 'Needs you' signal (BI-094A124F slice 1)

### DIFF
--- a/apps/web/lib/attention/notify-live.ts
+++ b/apps/web/lib/attention/notify-live.ts
@@ -1,0 +1,59 @@
+// Production binding of the attention notification spine (BI-094A124F).
+// Wires the pure notifyAttention core (notify.ts) to prisma (the Notification
+// row) and the agent-event-bus (realtime SSE refresh), and resolves the operator
+// recipient. Server-only. Every entry point is BEST-EFFORT — it never throws, so
+// a notification failure can never break the producer path it hooks into.
+
+import { prisma } from "@dpf/db";
+import { agentEventBus } from "@/lib/tak/agent-event-bus";
+import { resolveScheduledOwnerUserId } from "@/lib/queue/scheduled-owner";
+import { notifyAttention, type NotifyAttentionDeps, type NotifyAttentionInput } from "./notify";
+
+const liveDeps: NotifyAttentionDeps = {
+  hasUnread: async (userId, type) =>
+    (await prisma.notification.findFirst({
+      where: { userId, type, read: false },
+      select: { id: true },
+    })) != null,
+  createNotification: async (data) => {
+    await prisma.notification.create({ data });
+  },
+  emit: (event) => {
+    agentEventBus.broadcastSystem({
+      type: "attention:created",
+      source: event.source,
+      itemKey: event.itemKey,
+      userId: event.userId,
+      title: event.title,
+      deepLink: event.deepLink,
+      riskClass: event.riskClass,
+    });
+  },
+  nowIso: () => new Date().toISOString(),
+};
+
+/**
+ * Production notify — fire-and-forget from a producer path. Best-effort: any
+ * failure (DB, bus, resolver) is swallowed so the producer it hooks never breaks.
+ */
+export async function notifyAttentionLive(input: NotifyAttentionInput): Promise<void> {
+  try {
+    await notifyAttention(liveDeps, input);
+  } catch {
+    // Best-effort by contract — the producer path must not fail on a notify error.
+  }
+}
+
+/**
+ * The recipient for operator-facing attention items (escalations, AI-decision
+ * residue, agent proposals): the bootstrap install owner. Paused-AI items use the
+ * owning `TaskRun.userId` directly instead. Returns null if no owner resolves, in
+ * which case the caller skips the notification (still best-effort).
+ */
+export async function resolveOperatorRecipient(): Promise<string | null> {
+  try {
+    return await resolveScheduledOwnerUserId();
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/attention/notify.test.ts
+++ b/apps/web/lib/attention/notify.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  notifyAttention,
+  attentionNotificationType,
+  isAttentionNotificationType,
+  type NotifyAttentionDeps,
+  type HitlAttentionEvent,
+} from "./notify";
+
+function harness(opts: { unread?: boolean } = {}) {
+  const created: Array<Record<string, unknown>> = [];
+  const emitted: HitlAttentionEvent[] = [];
+  const deps: NotifyAttentionDeps = {
+    hasUnread: async () => opts.unread ?? false,
+    createNotification: async (data) => {
+      created.push(data);
+    },
+    emit: (event) => {
+      emitted.push(event);
+    },
+    nowIso: () => "2026-06-26T00:00:00.000Z",
+  };
+  return { deps, created, emitted };
+}
+
+const baseInput = {
+  source: "escalation" as const,
+  itemKey: "PIR-1",
+  userId: "principal-7",
+  title: "Build Studio needs a human",
+  deepLink: "/build?buildId=FB-9",
+  riskClass: "high-risk",
+};
+
+describe("attentionNotificationType", () => {
+  it("encodes source + item and is recognized by the prefix guard", () => {
+    const type = attentionNotificationType("escalation", "PIR-1");
+    expect(type).toBe("attention:escalation:PIR-1");
+    expect(isAttentionNotificationType(type)).toBe(true);
+    expect(isAttentionNotificationType("taskrun.escalated")).toBe(false);
+  });
+});
+
+describe("notifyAttention", () => {
+  it("writes one notification and emits the event for a new item", async () => {
+    const { deps, created, emitted } = harness();
+    const result = await notifyAttention(deps, baseInput);
+
+    expect(result.created).toBe(true);
+    expect(created).toHaveLength(1);
+    expect(created[0]).toEqual({
+      userId: "principal-7",
+      type: "attention:escalation:PIR-1",
+      title: "Build Studio needs a human",
+      body: null,
+      deepLink: "/build?buildId=FB-9",
+    });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      eventType: "attention.created",
+      source: "escalation",
+      itemKey: "PIR-1",
+      userId: "principal-7",
+      riskClass: "high-risk",
+      occurredAtIso: "2026-06-26T00:00:00.000Z",
+    });
+  });
+
+  it("dedups: no write and no emit when an unread notification already exists", async () => {
+    const { deps, created, emitted } = harness({ unread: true });
+    const result = await notifyAttention(deps, baseInput);
+
+    expect(result.created).toBe(false);
+    expect(created).toHaveLength(0);
+    expect(emitted).toHaveLength(0);
+  });
+
+  it("passes the body through when provided", async () => {
+    const { deps, created } = harness();
+    await notifyAttention(deps, { ...baseInput, body: "missing authz on the route" });
+    expect(created[0].body).toBe("missing authz on the route");
+  });
+
+  it("works without an emit sink (bus optional)", async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const deps: NotifyAttentionDeps = {
+      hasUnread: async () => false,
+      createNotification: async (d) => {
+        created.push(d);
+      },
+      nowIso: () => "2026-06-26T00:00:00.000Z",
+    };
+    const result = await notifyAttention(deps, baseInput);
+    expect(result.created).toBe(true);
+    expect(created).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/attention/notify.ts
+++ b/apps/web/lib/attention/notify.ts
@@ -1,0 +1,105 @@
+// The Attention Surface notification spine (EP-ATTENTION-SURFACE, BI-094A124F).
+// Spec: docs/superpowers/specs/2026-06-23-human-attention-surface-design.md §4.2.
+//
+// One canonical way to say "a NEW pending-human item appeared" — write a single
+// deduped `Notification` row (the inbox bell/feed + badge signal) AND emit a
+// realtime event (so the inbox refreshes live over the existing SSE stream).
+// Today every producer hand-rolls its own Notification shape, and most don't
+// notify at all (taskrun-recovery + tax only); this replaces that scatter.
+//
+// Pure core — deps are injected so the dedup + emit logic is unit-tested without
+// a database. Best-effort BY CONTRACT: callers wrap in try/catch so a notify
+// failure can never break the producer path it hooks into.
+
+import type { AttentionSource } from "./types";
+
+/** The realtime event broadcast when a new pending-human item appears. Generalizes
+ *  the mobile-companion spec's `HitlNotificationEvent` across all attention sources
+ *  (not just TaskRun). Consumed by the SSE stream for live inbox refresh. */
+export type HitlAttentionEvent = {
+  eventType: "attention.created";
+  source: AttentionSource;
+  /** Stable per source row — PIR-…, DI-…, TR-…, AP-…, BILL-…, etc. */
+  itemKey: string;
+  /** Recipient principal. */
+  userId: string;
+  title: string;
+  deepLink: string;
+  riskClass?: string;
+  occurredAtIso: string;
+};
+
+export type NotifyAttentionInput = {
+  source: AttentionSource;
+  itemKey: string;
+  userId: string;
+  title: string;
+  body?: string;
+  deepLink: string;
+  riskClass?: string;
+};
+
+export type NotifyAttentionDeps = {
+  /** True iff an unread attention Notification of this exact type already exists
+   *  for the user — the dedup probe (no dedup column on Notification, so the
+   *  `type` carries the key; see attentionNotificationType). */
+  hasUnread: (userId: string, type: string) => Promise<boolean>;
+  createNotification: (data: {
+    userId: string;
+    type: string;
+    title: string;
+    body: string | null;
+    deepLink: string;
+  }) => Promise<void>;
+  /** Broadcast the realtime event. Optional so the core works without a bus. */
+  emit?: (event: HitlAttentionEvent) => void;
+  nowIso: () => string;
+};
+
+const TYPE_PREFIX = "attention";
+
+/** The `Notification.type` that encodes source + item. Doubles as the dedup key
+ *  (migration-free — no dedup column on the model). The inbox feed filters on the
+ *  `attention:` prefix to separate these from other notification kinds. */
+export function attentionNotificationType(source: AttentionSource, itemKey: string): string {
+  return `${TYPE_PREFIX}:${source}:${itemKey}`;
+}
+
+/** Whether a `Notification.type` is an attention-spine notification. */
+export function isAttentionNotificationType(type: string): boolean {
+  return type.startsWith(`${TYPE_PREFIX}:`);
+}
+
+/**
+ * Notify a human that a NEW pending-human item appeared. Idempotent per
+ * (userId, source, itemKey): if an unread notification already exists it no-ops,
+ * so re-entry or a re-render never spams the bell. Returns whether it created one.
+ */
+export async function notifyAttention(
+  deps: NotifyAttentionDeps,
+  input: NotifyAttentionInput,
+): Promise<{ created: boolean }> {
+  const type = attentionNotificationType(input.source, input.itemKey);
+  if (await deps.hasUnread(input.userId, type)) return { created: false };
+
+  await deps.createNotification({
+    userId: input.userId,
+    type,
+    title: input.title,
+    body: input.body ?? null,
+    deepLink: input.deepLink,
+  });
+
+  deps.emit?.({
+    eventType: "attention.created",
+    source: input.source,
+    itemKey: input.itemKey,
+    userId: input.userId,
+    title: input.title,
+    deepLink: input.deepLink,
+    riskClass: input.riskClass,
+    occurredAtIso: deps.nowIso(),
+  });
+
+  return { created: true };
+}

--- a/apps/web/lib/build/escalate-build-to-human.ts
+++ b/apps/web/lib/build/escalate-build-to-human.ts
@@ -33,6 +33,7 @@
 
 import { prisma } from "@dpf/db";
 import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+import { notifyAttentionLive, resolveOperatorRecipient } from "@/lib/attention/notify-live";
 
 /** Self-fix-feasibility class — why an autonomous producer could not self-repair. */
 export const SELF_FIX_CLASS = {
@@ -180,6 +181,23 @@ export async function escalateBuildToHuman(args: EscalateBuildArgs): Promise<Esc
     reportId = r.reportId;
   } catch (err) {
     await safeLog(`Escalation report not filed (continuing to free WIP): ${String(err)}`.slice(0, 300));
+  }
+
+  // Attention spine (BI-094A124F): proactively tell the operator a new escalation
+  // needs them. The "Needs you" inbox already shows it (re-homed off /ops); this
+  // adds the bell + live refresh. Best-effort by contract — never blocks WIP free-up.
+  if (reportId) {
+    const recipient = await resolveOperatorRecipient();
+    if (recipient) {
+      await notifyAttentionLive({
+        source: "escalation",
+        itemKey: reportId,
+        userId: recipient,
+        title,
+        deepLink: `/build?buildId=${encodeURIComponent(buildId)}`,
+        riskClass: "high-risk",
+      });
+    }
   }
 
   // 2. FREE WIP — mark the build abandoned (mirrors the inert-build reaper). The

--- a/apps/web/lib/tak/agent-event-bus.ts
+++ b/apps/web/lib/tak/agent-event-bus.ts
@@ -5,6 +5,9 @@
 import type { TaskState } from "@/lib/tak/task-states";
 
 export type AgentEvent =
+  // Attention Surface (EP-ATTENTION-SURFACE, BI-094A124F): a new pending-human
+  // item appeared. Broadcast system-wide so the "Needs you" inbox refreshes live.
+  | { type: "attention:created"; source: string; itemKey: string; userId: string; title: string; deepLink: string; riskClass?: string }
   | { type: "task:status"; taskId: string; contextId: string | null; state: TaskState; sourceEvent?: string; message?: string; progress?: { stage?: string; percent?: number } }
   | { type: "task:artifact"; taskId: string; contextId: string | null; artifactId: string; name: string; artifactType: string; sourceEvent?: string; message?: string }
   | { type: "tool:start"; tool: string; iteration: number }

--- a/docs/superpowers/plans/2026-06-26-attention-notification-spine.md
+++ b/docs/superpowers/plans/2026-06-26-attention-notification-spine.md
@@ -1,0 +1,38 @@
+# Attention Surface — notification spine (BI-094A124F)
+
+| Field | Value |
+| ----- | ----- |
+| Status | **Slice 1 implemented in this branch** — canonical notifier + live binding + bus event + escalation producer. Verified: 67 vitest green. Remaining producers + badge are a clean fast-follow. |
+| Date | 2026-06-26 |
+| Spec | [2026-06-23 human attention surface design](../specs/2026-06-23-human-attention-surface-design.md) §4.2 |
+| Epic / BI | `EP-ATTENTION-SURFACE` / `BI-094A124F` |
+| Predecessor | Keystone + triage + business adapters (PR #2342, merged `d568aec91`). |
+
+## Problem
+The "Needs you" inbox is **passive** — you must open `/workspace` to see it. The `Notification` backbone, `/api/v1/notifications`, `agent-event-bus`, and the `/api/agent/stream` SSE route all exist, but **nothing rides them for attention items**: only `taskrun-recovery` and tax-remittance write `Notification` rows, each hand-rolling its own shape, and no producer emits a realtime event. So a new escalation/approval/paused-AI item arrives silently.
+
+## Design
+One canonical notifier — no per-producer Notification hand-rolling.
+
+- **`lib/attention/notify.ts`** (pure core, tested): `notifyAttention(deps, input)` writes **one deduped `Notification`** + emits a `HitlAttentionEvent`. Idempotent per `(userId, source, itemKey)`: the dedup key is carried in `Notification.type` as `attention:<source>:<itemKey>` (migration-free — no dedup column), and an existing **unread** notification of that type makes it a no-op (no bell spam on re-entry/re-render).
+- **`lib/attention/notify-live.ts`** (production binding): wires the core to `prisma` (the `Notification` row) and `agentEventBus.broadcastSystem` (the realtime event), and resolves the operator recipient via `resolveScheduledOwnerUserId` (the bootstrap owner). **Best-effort by contract** — `notifyAttentionLive` never throws, so a notify failure can't break the producer path it hooks into.
+- **`agent-event-bus.ts`**: a new `attention:created` member on the `AgentEvent` union → the existing SSE stream auto-delivers it for live inbox refresh.
+- **Consumer**: the notifications flow to the existing `/api/v1/notifications` feed (the bell) immediately; the dedicated nav **badge** is the next slice.
+
+## Wired this slice
+- **Escalation producer** — `escalateBuildToHuman` (`apps/web/lib/build/escalate-build-to-human.ts`): after the `PlatformIssueReport` is filed, notify the operator (best-effort). This is the dominant source (18 live items at verification time), and the function is already runtime-coupled (real `prisma`), so the hook adds no test-hermeticity risk — `escalate-build-to-human.test.ts` stays green.
+
+## Deferred (fast-follow, same pattern)
+- **paused-AI** (`mcp-task-submit.ts` → `input-required`) — recipient is the `TaskRun.userId` owner; resolve from the run.
+- **agent-proposal** (`agent-coworker.ts` → `AgentActionProposal` `proposed`) — recipient is the conversation's user.
+- **ai-decision** (`persistDecisionInteraction`) — this function takes an **injected `db`** (hermetic, unit-tested), so the notify must hook its **caller** (the build-studio gate flow), not the persist function, to avoid polluting its tests. Only fire on `outcomeType ∈ {escalate, defer}`.
+- **Nav badge** on the "Needs you" entry — a cheap unread-`attention:`-notification count (the "new since you looked" signal); SSE refresh via the `attention:created` event.
+
+## Verification
+- `pnpm --filter web exec vitest run lib/attention lib/build/escalate-build-to-human` — **67 tests pass** (6 files), incl. the new `notify.test.ts` (5: dedup, create+emit, body passthrough, bus-optional) and the unbroken escalation test.
+- `pnpm --filter web typecheck` — clean (gate).
+- Runtime: a `build-stall-escalation` writes one `attention:escalation:<reportId>` `Notification` to the operator + broadcasts `attention:created`; re-entry while unread is a no-op.
+
+## Files
+- New: `apps/web/lib/attention/notify.ts`, `notify.test.ts`, `notify-live.ts`.
+- Modified: `apps/web/lib/tak/agent-event-bus.ts` (event member), `apps/web/lib/build/escalate-build-to-human.ts` (escalation hook).


### PR DESCRIPTION
Makes the **"Needs you" inbox proactive**. Today it's passive — you must open `/workspace` to see it — and although the `Notification` backbone + `agent-event-bus` + `/api/agent/stream` SSE all exist, nothing rides them for attention items. This wires a single canonical notifier and the dominant producer.

Builds on the merged keystone (#2342). Plan: `docs/superpowers/plans/2026-06-26-attention-notification-spine.md` · Spec §4.2.

## What this delivers
- **`lib/attention/notify.ts`** (pure, tested) — `notifyAttention` writes **one deduped `Notification`** + emits a `HitlAttentionEvent`. Dedup key lives in `Notification.type` as `attention:<source>:<itemKey>` (migration-free); idempotent per `(userId, source, itemKey)` so re-entry never spams the bell.
- **`lib/attention/notify-live.ts`** — `prisma` + `agentEventBus` binding + operator-recipient resolution (`resolveScheduledOwnerUserId`). **Best-effort by contract**: `notifyAttentionLive` never throws, so it can't break the producer path it hooks.
- **`agent-event-bus.ts`** — new `attention:created` event → the existing SSE stream auto-delivers it for live inbox refresh.
- **Escalation producer wired** (`escalateBuildToHuman`) — the dominant source (18 live items); the notification flows to the existing `/api/v1/notifications` bell immediately.

## Deferred (same-pattern fast-follow, in the plan)
The other 3 producers (paused-AI, agent-proposal, ai-decision — the last needs a caller-level hook since `persistDecisionInteraction` is hermetic) + the nav **badge**.

## Verification
- `pnpm --filter web typecheck` — **0 errors** (after `prisma generate`; the worktree client was stale vs. rebased `main`).
- `pnpm --filter web exec vitest run lib/attention lib/build/escalate-build-to-human` — **67 tests pass** (incl. new `notify.test.ts`; the escalation test stays green — the best-effort hook is non-intrusive).

No new routes or UI controls (backend lib + a producer hook), so no route-manifest or UX-Fit impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)