### PR TITLE
docs(golden-triangle): per-vector parameter + feature reference (what each position configures)

### DIFF
--- a/apps/web/components/golden-triangle/README.md
+++ b/apps/web/components/golden-triangle/README.md
@@ -1,6 +1,6 @@
 # Golden Triangle — posture control (UI)
 
-`EP-GOLDEN-TRIANGLE` · Slice 2 (`BI-D48EB34C`). The canonical, reusable control for setting a Cost / Quality / Time posture. Design: [`docs/design/golden-triangle-design.md`](../../../../docs/design/golden-triangle-design.md) §6.
+`EP-GOLDEN-TRIANGLE` · Slice 2 (`BI-D48EB34C`). The canonical, reusable control for setting a Cost / Quality / Time posture. Design: [`docs/design/golden-triangle-design.md`](../../../../docs/design/golden-triangle-design.md) §6. **What each vector position actually configures** (exact parameters + features on/off, incl. the debate rung): [`docs/design/golden-triangle-vector-reference.md`](../../../../docs/design/golden-triangle-vector-reference.md).
 
 ## Components
 
@@ -8,13 +8,13 @@
   1. **Presets (primary, one click):** Fast / Balanced / Assured / Frugal, each with a plain-language effect line.
   2. **Triangle (opt-in fine-tune):** a draggable point inside a Cost / Quality / Time triangle (pointer + keyboard on the thumb).
   3. **Numeric inputs (canonical accessible control):** three labelled percent inputs — a 2D drag surface is *not* a 1-D ARIA slider, so the numeric/preset layer is the accessible source of truth.
-- **`GoldenTrianglePriorityPanel`** — a stateful host (view-local state) for a settings/preview surface.
-- **`CoworkerPriorityControl`** — a small, self-contained posture chip for the AI coworker dialog header: a balance-coloured dot + active preset that opens the compact control in a popover.
-- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, `describeConfigured()` / `plainSummary()` (derived from the **real Slice 1 compiler** so the UI never drifts), and `balanceState()` for the colour cue.
+- **`GoldenTrianglePriorityPanel`** — a stateful host (view-local state) for the platform-default settings surface.
+- **`CoworkerPriorityDock`** — the per-coworker control docked in-flow at the composer (collapsed by default to a colour-graded chip; expands to the full control). Replaced the old `CoworkerPriorityControl` header popover, which clipped off the panel edge.
+- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, `postureLabel()` (a meaningful label at every position — "Max Quality", "Quality-first", …), `describeConfigured()` / `plainSummary()` (derived from the **real Slice 1 compiler** so the UI never drifts), `TRIANGLE_AXIS_GUIDE` (the min/max explainer), and `balanceState()` for the colour cue.
 
 ## Balance colouring
 
-The triangle shades by balance: **green** when the three axes are centred, through **yellow** to **red** as one or two axes get starved (the posture pushes toward an edge or vertex). A starved axis's vertex label turns red, and a balance pill names the state ("Well balanced" / "Starving Time"). It is an at-a-glance cue that you are trading something away.
+The triangle shades by balance: **green** when the three axes are centred, through **yellow** to **red** as one or two axes get starved (the posture pushes toward an edge or vertex). There are no vertex labels — the gradient colour conveys the state (founder direction) — and a balance pill names it ("Well balanced" / "Starving Time"). It is an at-a-glance cue that you are trading something away.
 
 ## Surfaces
 

--- a/docs/design/golden-triangle-design.md
+++ b/docs/design/golden-triangle-design.md
@@ -442,14 +442,20 @@ Non-functional requirements for the compiler:
 
 ### Representative Compile Table
 
+> **Canonical, current mapping:** the exact per-vector parameters + features (incl.
+> the **debate** rung the table below pre-dates) live in
+> [golden-triangle-vector-reference.md](golden-triangle-vector-reference.md), mirrored
+> from `compile.ts`. The rows below are the original illustrative intent.
+
 | User posture | Decoded intent | Compiler behavior |
 | --- | --- | --- |
-| Assured | "Get this right." | `quality_first`, high `effort`/reasoning, stronger tier floor, more context, multi-branch deliberation, deep verification, generous retry, explicit receipt. Cost and time may rise. |
-| Fast | "I need this now." | Lower latency target, minimal/low `effort` when safe, single pass, shallow verification, tight retries, fastest eligible endpoint. May reduce assurance. |
-| Frugal | "Spend carefully." | `minimize_cost`, smallest capable model, low `effort`, tighter token/context and loop/duration budget, single deliberation branch, avoid frontier unless policy requires it. May increase time. |
-| Balanced | "Use the sensible default." | Pass-through: existing task-requirement and agent defaults, modest review/verification (no deltas — see Cold-start). |
-| Custom: cost 0.6 / quality 0.3 / time 0.1 | "Mostly cheap, some care." | `minimize_cost`, low `effort`, shallow verification, single deliberation branch, retry ≤ 1, mid tier-floor. |
-| Custom: cost 0.2 / quality 0.6 / time 0.2 | "Mostly right, watch spend." | `quality_first`, high `effort`, deep verification, 2-branch deliberation, retry ≤ 2, strong tier-floor — but capped token/context budget. |
+| Assured | "Get this right." | `quality_first`, high `effort`/reasoning, frontier tier floor, deep verification, a **review** deliberation, retry 3. Cost and time may rise. |
+| Max Quality (custom: quality ≥ 0.85) | "Get this as right as possible." | As Assured but **max effort** and a multi-perspective **debate** (the top of the rigor ladder) instead of a single review. |
+| Fast | "I need this now." | Lower latency target (30s), low `effort` when safe, single pass, no verification, tight retries (1), fastest eligible endpoint. May reduce assurance. |
+| Frugal | "Spend carefully." | `minimize_cost`, adequate (smallest capable) tier, low `effort`, shallow verification, no deliberation, retry 1, avoid frontier unless policy requires it. May increase time. |
+| Balanced | "Use the sensible default." | Pass-through: existing task-requirement and agent defaults, no deltas (see Cold-start). |
+| Custom: cost 0.6 / quality 0.3 / time 0.1 | "Mostly cheap, some care." | `minimize_cost`, low `effort`, shallow verification, no deliberation, retry 1, adequate tier-floor. |
+| Custom: cost 0.2 / quality 0.6 / time 0.2 | "Mostly right, watch spend." | `quality_first`, high `effort`, deep verification, a **review** deliberation, retry 3, frontier tier-floor. |
 
 ### Coupling Rules
 

--- a/docs/design/golden-triangle-vector-reference.md
+++ b/docs/design/golden-triangle-vector-reference.md
@@ -1,0 +1,102 @@
+# Golden Triangle — what each vector position configures
+
+*Reference — current as of 2026-06-26. Source of truth: `apps/web/lib/golden-triangle/compile.ts` (the compiler) — this doc mirrors it; if they ever disagree, the code wins and this doc is the bug.*
+
+This is the operator/engineer-facing answer to "what actually changes when I move the
+triangle?" — the exact parameters and the features turned on/off at each position.
+
+## How it works (the flow)
+
+```
+Cost / Quality / Time posture (the vector)
+        │
+        ▼  compileGoldenTrianglePolicy()   ← the only place the mapping lives
+        │
+        ├── PostureOverride      → model tier, effort, reasoning depth, budget class, max latency
+        └── OrchestrationBudget  → verification depth, retry budget, deliberation pattern (review/debate)
+        │
+        ▼  applied at three seams (never re-implemented — fed in)
+        ├── Routing            inferContract() — picks the model + effort for every coworker turn
+        ├── Deliberation       the inline review / debate pass on high-effort coworker turns
+        └── Build right-sizing resolveBuildSizing() — the build's tier + review, floored by sensitivity
+```
+
+The three axes are **not literal zero-sum math** — they're a posture the compiler reads.
+The **presets sit at the corners** (Assured = Quality, Frugal = Cost, Fast = Time,
+Balanced = centre); the space **between** them compiles continuously. **Maxing a
+dimension is that dimension at full strength** — for Quality, the top of the ladder is
+a multi-perspective *debate*, above the single *review* the Assured preset buys.
+
+## Presets — exact settings
+
+| Posture | Model tier | Effort | Reasoning | Budget class | Verification | Retries | Deliberation | Latency target |
+|---|---|---|---|---|---|---|---|---|
+| **Balanced** | — | — | — | — | none | — | none | — |
+| **Fast** | — | low | low | — | none | 1 | none | 30s |
+| **Frugal** | adequate | low | low | minimize-cost | shallow | 1 | none | — |
+| **Assured** | frontier | high | high | quality-first | deep | 3 | **review** | — |
+
+"—" = no override (the platform/agent default stands). **Balanced emits *no* deltas** —
+it is byte-identical to the system with the triangle switched off (the cold-start
+guarantee).
+
+## Custom positions — by dominant axis + how far you push
+
+A custom posture snaps to its **dominant axis** and reads its **intensity** (the
+normalized weight of that axis):
+
+| Where the dot is | Tier | Effort | Reasoning | Budget | Verification | Retries | Deliberation |
+|---|---|---|---|---|---|---|---|
+| No clear lean (every axis < 0.40) | — | — | — | — | none | — | none → **= Balanced** |
+| **Quality** 0.40–0.55 ("leaning") | strong | medium | medium | quality-first | shallow | 2 | review |
+| **Quality** 0.55–0.85 ("Quality-first") | frontier | high | high | quality-first | deep | 3 | review → **= Assured** |
+| **Quality** ≥ 0.85 ("**Max Quality**") | frontier | **max** | high | quality-first | deep | 3 | **debate** |
+| **Cost** 0.40–0.55 ("leaning") | adequate | low | low | minimize-cost | shallow | 1 | none |
+| **Cost** ≥ 0.55 ("Max Cost") | adequate | low | low | minimize-cost | shallow | 1 | none → **= Frugal** |
+| **Time** 0.40–0.55 ("leaning") | — | low | low | — | none | 1 | none (latency 60s) |
+| **Time** ≥ 0.55 ("Max Speed") | — | low | — | — | none | 1 | none → **= Fast** |
+
+The only thing the very top of Quality adds over Assured is **max effort + debate**
+(vs. high effort + review) — that's the "Max Quality" corner.
+
+## Features turned ON / OFF by the vector
+
+| Feature | Enabled when | What it does |
+|---|---|---|
+| **Self-review** | deliberation = `review` *or* `debate` (Quality ≥ ~0.40, incl. Assured) | A distinct reviewer pass critiques the draft and returns an improved reply (or approves it). On a coworker turn this is one extra, bounded, fail-open call. |
+| **Debate** | deliberation = `debate` (Quality ≥ 0.85 / "Max Quality") | Instead of a single review, an adversarial pass steelmans the case *for* and *against* the draft and synthesizes the stronger answer. |
+| **Verification** | `shallow` (Frugal / mild leans) or `deep` (Assured / Quality-first+) | How hard the run checks its own work; `none` skips it. |
+| **Stronger model** | tier raised to `strong` / `frontier` (Quality regions) | Routes to a more capable model; Cost pulls it down to `adequate`. |
+| **More thinking** | effort `high` / `max` (Quality); `low` (Cost / Time) | The per-call reasoning/thinking budget — the primary Quality↔Cost↔Time lever. |
+| **Retry budget** | 1 (Fast/Frugal) → 3 (Assured/Max Quality) | How many transient/fabrication retries a run may spend. |
+| **Latency cap** | set by Fast (30s) / Time-lean (60s) | A target the router honors when picking an endpoint. |
+
+## Hard limits that override the vector (precedence)
+
+The posture is a *request*; these clamp it (and the UI says so when they do):
+
+1. **Residency** — never relaxed. Restricted data stays local even at Fast/Frugal.
+2. **Minimum tier floor** — an agent/task (or, for builds, the **deliverable-sensitivity**
+   axis) can raise the tier; the posture can't drop below it. So a Cost dial cannot
+   discount a sensitive deliverable below its floor.
+3. **Max-latency ceiling** — clamps the latency target.
+4. **Model availability** — if the requested tier isn't reachable, the compiler clamps
+   to the best available, or **defers / blocks** (fail-closed) rather than silently
+   routing to an unsafe path.
+
+## Where the posture is read
+
+- **Per coworker** — the priority dock at the composer sets that coworker's posture; it
+  feeds routing (`routed-inference`) on every turn and selects the review/debate pass.
+- **Platform / org default** — the "Priority & Models" surface; coworkers inherit it
+  unless they set their own (agent → org → platform → Balanced).
+- **Builds** — the build posture (default **Quality**) compiles through the same
+  compiler into the build's model tier + review intensity, floored by the change's
+  derived sensitivity (EP-QUALITY-RIGHTSIZING).
+
+## Plain-language echo in the UI
+
+The control never drifts from this table: it renders the **compiled** result live —
+the label (`Max Quality`, `Quality-first`, `Frugal`, …), a one-line summary, and a chip
+row showing the actual `tier · effort · verification · deliberation`, plus the
+axis-guide line explaining that each corner is that dimension at full strength.


### PR DESCRIPTION
**Founder ask:** is the documentation updated to illustrate how it works + the features enabled/disabled + the parameter changes per vector change?

**Honest answer was "not adequately":** the design-doc compile table was conceptual and **stale** (it pre-dated the debate rung), and there was no precise per-vector reference. This adds one.

- **NEW [`golden-triangle-vector-reference.md`](docs/design/golden-triangle-vector-reference.md)** — the canonical, current mapping, mirrored from `compile.ts`:
  - the **flow** (vector → `PostureOverride` + `OrchestrationBudget` → routing / deliberation / build sizing)
  - **exact settings** for every preset *and* custom region (tier, effort, reasoning, budget class, verification, retries, deliberation, latency)
  - a **"features ON/OFF by the vector"** table (self-review, **debate**, verification, stronger model, retries, latency cap)
  - the **hard limits** that override the posture (residency, tier floor, latency ceiling, availability — fail-closed)
  - **where the posture is read** (per coworker / platform default / builds)
- Updated the design-doc **Representative Compile Table** → points at the reference + adds the missing **Max-Quality / debate** rung, and corrected each preset row to the real values.
- Refreshed the component README (link + stale-component/vertex-label fixes).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)