### PR TITLE
feat(observability): scheduled-job misfire/defer counter — code→AI ascent signal (BI-9BF17415)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/staleness-escalation.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/staleness-escalation.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateJobStaleness,
   readStalenessState,
   mergeStalenessState,
+  recordJobDefer,
   type JobStalenessState,
   type StalenessThresholds,
 } from "./staleness-escalation";
@@ -13,15 +14,15 @@ const NOW = new Date("2026-06-23T12:00:00.000Z");
 
 describe("evaluateJobStaleness", () => {
   it("a successful run resets counters and never escalates", () => {
-    const prev: JobStalenessState = { lastOkAt: "2026-06-20T00:00:00.000Z", consecutiveErrors: 9 };
+    const prev: JobStalenessState = { lastOkAt: "2026-06-20T00:00:00.000Z", consecutiveErrors: 9, deferCount: 5 };
     const d = evaluateJobStaleness(prev, "ok", NOW, THRESHOLDS);
     expect(d.escalate).toBe(false);
     expect(d.reason).toBeNull();
-    expect(d.nextState).toEqual({ lastOkAt: NOW.toISOString(), consecutiveErrors: 0 });
+    expect(d.nextState).toEqual({ lastOkAt: NOW.toISOString(), consecutiveErrors: 0, deferCount: 0 });
   });
 
   it("a single recent failure below thresholds does not escalate", () => {
-    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(), consecutiveErrors: 0 };
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(), consecutiveErrors: 0, deferCount: 0 };
     const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
     expect(d.escalate).toBe(false);
     expect(d.nextState.consecutiveErrors).toBe(1);
@@ -29,7 +30,7 @@ describe("evaluateJobStaleness", () => {
   });
 
   it("escalates once consecutive errors reach the threshold", () => {
-    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(), consecutiveErrors: 3 };
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(), consecutiveErrors: 3, deferCount: 0 };
     const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
     expect(d.nextState.consecutiveErrors).toBe(4);
     expect(d.escalate).toBe(true);
@@ -37,7 +38,7 @@ describe("evaluateJobStaleness", () => {
   });
 
   it("escalates by age when the last success is older than maxAgeMs (even below the error count)", () => {
-    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 3 * 3_600_000).toISOString(), consecutiveErrors: 0 };
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 3 * 3_600_000).toISOString(), consecutiveErrors: 0, deferCount: 0 };
     const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
     expect(d.nextState.consecutiveErrors).toBe(1);
     expect(d.escalate).toBe(true);
@@ -45,14 +46,14 @@ describe("evaluateJobStaleness", () => {
   });
 
   it("a never-succeeded job does NOT escalate on its first error (no infinite age)", () => {
-    const prev: JobStalenessState = { lastOkAt: null, consecutiveErrors: 0 };
+    const prev: JobStalenessState = { lastOkAt: null, consecutiveErrors: 0, deferCount: 0 };
     const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
     expect(d.escalate).toBe(false);
-    expect(d.nextState).toEqual({ lastOkAt: null, consecutiveErrors: 1 });
+    expect(d.nextState).toEqual({ lastOkAt: null, consecutiveErrors: 1, deferCount: 0 });
   });
 
   it("a never-succeeded job escalates on the consecutive-error threshold", () => {
-    const prev: JobStalenessState = { lastOkAt: null, consecutiveErrors: 3 };
+    const prev: JobStalenessState = { lastOkAt: null, consecutiveErrors: 3, deferCount: 0 };
     const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
     expect(d.escalate).toBe(true);
     expect(d.reason).toMatch(/4 consecutive failed run/);
@@ -60,43 +61,67 @@ describe("evaluateJobStaleness", () => {
   });
 
   it("reports both reasons when both thresholds trip", () => {
-    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 5 * 3_600_000).toISOString(), consecutiveErrors: 3 };
+    const prev: JobStalenessState = { lastOkAt: new Date(NOW.getTime() - 5 * 3_600_000).toISOString(), consecutiveErrors: 3, deferCount: 0 };
     const d = evaluateJobStaleness(prev, "error", NOW, THRESHOLDS);
     expect(d.escalate).toBe(true);
     expect(d.reason).toMatch(/consecutive failed run/);
     expect(d.reason).toMatch(/no successful run for/);
   });
+
+  it("an actual run (ok OR error) resets the defer counter — BI-9BF17415", () => {
+    const deferred: JobStalenessState = { lastOkAt: "2026-06-20T00:00:00.000Z", consecutiveErrors: 0, deferCount: 7 };
+    expect(evaluateJobStaleness(deferred, "ok", NOW, THRESHOLDS).nextState.deferCount).toBe(0);
+    expect(evaluateJobStaleness(deferred, "error", NOW, THRESHOLDS).nextState.deferCount).toBe(0);
+  });
 });
 
 describe("readStalenessState", () => {
   it("returns empty state for null / non-object / missing key", () => {
-    expect(readStalenessState(null)).toEqual({ lastOkAt: null, consecutiveErrors: 0 });
-    expect(readStalenessState("nope")).toEqual({ lastOkAt: null, consecutiveErrors: 0 });
-    expect(readStalenessState({ other: 1 })).toEqual({ lastOkAt: null, consecutiveErrors: 0 });
+    expect(readStalenessState(null)).toEqual({ lastOkAt: null, consecutiveErrors: 0, deferCount: 0 });
+    expect(readStalenessState("nope")).toEqual({ lastOkAt: null, consecutiveErrors: 0, deferCount: 0 });
+    expect(readStalenessState({ other: 1 })).toEqual({ lastOkAt: null, consecutiveErrors: 0, deferCount: 0 });
   });
 
-  it("parses a valid staleness sub-state", () => {
-    const md = { staleness: { lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2 }, other: "x" };
-    expect(readStalenessState(md)).toEqual({ lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2 });
+  it("parses a valid staleness sub-state including deferCount", () => {
+    const md = { staleness: { lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2, deferCount: 4 }, other: "x" };
+    expect(readStalenessState(md)).toEqual({ lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2, deferCount: 4 });
+  });
+
+  it("defaults deferCount to 0 when absent (back-compat with pre-BI-9BF17415 metadata)", () => {
+    const md = { staleness: { lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2 } };
+    expect(readStalenessState(md).deferCount).toBe(0);
   });
 
   it("defaults malformed fields", () => {
-    expect(readStalenessState({ staleness: { lastOkAt: 5, consecutiveErrors: -3 } })).toEqual({
+    expect(readStalenessState({ staleness: { lastOkAt: 5, consecutiveErrors: -3, deferCount: -1 } })).toEqual({
       lastOkAt: null,
       consecutiveErrors: 0,
+      deferCount: 0,
     });
+  });
+});
+
+describe("recordJobDefer", () => {
+  it("increments deferCount and preserves the staleness counters", () => {
+    const prev: JobStalenessState = { lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2, deferCount: 3 };
+    expect(recordJobDefer(prev)).toEqual({ lastOkAt: "2026-06-23T00:00:00.000Z", consecutiveErrors: 2, deferCount: 4 });
+  });
+
+  it("starts from 0 when deferCount is missing (defensive ?? 0)", () => {
+    const prev = { lastOkAt: null, consecutiveErrors: 0 } as unknown as JobStalenessState;
+    expect(recordJobDefer(prev).deferCount).toBe(1);
   });
 });
 
 describe("mergeStalenessState", () => {
   it("sets staleness while preserving other metadata keys", () => {
-    const merged = mergeStalenessState({ githubPrEtag: "abc" }, { lastOkAt: null, consecutiveErrors: 1 });
-    expect(merged).toEqual({ githubPrEtag: "abc", staleness: { lastOkAt: null, consecutiveErrors: 1 } });
+    const merged = mergeStalenessState({ githubPrEtag: "abc" }, { lastOkAt: null, consecutiveErrors: 1, deferCount: 0 });
+    expect(merged).toEqual({ githubPrEtag: "abc", staleness: { lastOkAt: null, consecutiveErrors: 1, deferCount: 0 } });
   });
 
   it("handles null/garbage base metadata", () => {
-    expect(mergeStalenessState(null, { lastOkAt: null, consecutiveErrors: 0 })).toEqual({
-      staleness: { lastOkAt: null, consecutiveErrors: 0 },
+    expect(mergeStalenessState(null, { lastOkAt: null, consecutiveErrors: 0, deferCount: 0 })).toEqual({
+      staleness: { lastOkAt: null, consecutiveErrors: 0, deferCount: 0 },
     });
   });
 });

--- a/apps/web/lib/operate/scheduled-jobs/staleness-escalation.ts
+++ b/apps/web/lib/operate/scheduled-jobs/staleness-escalation.ts
@@ -17,6 +17,15 @@ export type JobStalenessState = {
   lastOkAt: string | null;
   /** Consecutive error runs since the last success. */
   consecutiveErrors: number;
+  /**
+   * Consecutive DEFERRED runs since the last actual run (BI-9BF17415) — a
+   * scheduled tick that was skipped before executing (e.g. blocked by the
+   * quiescence drain gate) instead of running to ok/error. Reset to 0 on any
+   * actual run. A climbing value is a make-silent-failures-observable signal
+   * that the job is being starved of execution windows — a code→AI "ascent"
+   * candidate whose fixed gating may need judgment (consumed by BI-A028AA14).
+   */
+  deferCount: number;
 };
 
 export type StalenessThresholds = {
@@ -33,7 +42,7 @@ export type StalenessDecision = {
   reason: string | null;
 };
 
-const EMPTY_STATE: JobStalenessState = { lastOkAt: null, consecutiveErrors: 0 };
+const EMPTY_STATE: JobStalenessState = { lastOkAt: null, consecutiveErrors: 0, deferCount: 0 };
 
 /** Read the staleness sub-state out of a ScheduledJob.metadata JSON blob. */
 export function readStalenessState(metadata: unknown): JobStalenessState {
@@ -44,6 +53,7 @@ export function readStalenessState(metadata: unknown): JobStalenessState {
   return {
     lastOkAt: typeof r.lastOkAt === "string" ? r.lastOkAt : null,
     consecutiveErrors: typeof r.consecutiveErrors === "number" && r.consecutiveErrors >= 0 ? r.consecutiveErrors : 0,
+    deferCount: typeof r.deferCount === "number" && r.deferCount >= 0 ? r.deferCount : 0,
   };
 }
 
@@ -68,7 +78,7 @@ export function evaluateJobStaleness(
   thresholds: StalenessThresholds,
 ): StalenessDecision {
   if (status === "ok") {
-    return { nextState: { lastOkAt: now.toISOString(), consecutiveErrors: 0 }, escalate: false, reason: null };
+    return { nextState: { lastOkAt: now.toISOString(), consecutiveErrors: 0, deferCount: 0 }, escalate: false, reason: null };
   }
 
   const consecutiveErrors = (prev.consecutiveErrors ?? 0) + 1;
@@ -90,7 +100,19 @@ export function evaluateJobStaleness(
     reason = parts.join("; ");
   }
 
-  return { nextState: { lastOkAt, consecutiveErrors }, escalate, reason };
+  return { nextState: { lastOkAt, consecutiveErrors, deferCount: 0 }, escalate, reason };
+}
+
+/**
+ * Pure: record that a scheduled run was DEFERRED (skipped before executing —
+ * e.g. blocked by the quiescence drain gate) instead of running. Increments the
+ * consecutive-defer counter and preserves the staleness counters; an actual run
+ * (`evaluateJobStaleness` on ok|error) resets deferCount to 0. The rate/
+ * threshold read is the consumer's job (BI-A028AA14); this only emits the
+ * queryable counter, so a deferral is never mistaken for an error or a success.
+ */
+export function recordJobDefer(prev: JobStalenessState): JobStalenessState {
+  return { ...prev, deferCount: (prev.deferCount ?? 0) + 1 };
 }
 
 /**

--- a/apps/web/lib/queue/functions/code-graph-reconcile.ts
+++ b/apps/web/lib/queue/functions/code-graph-reconcile.ts
@@ -54,6 +54,32 @@ async function recordCodeGraphJob(status: "ok" | "error", error?: string): Promi
   }
 }
 
+// BI-9BF17415 (make-silent-failures-observable): a scheduled tick deferred by
+// the quiescence drain gate is a silent no-op today. Bump a queryable
+// consecutive-defer counter on the job's metadata so a job being starved of
+// execution windows becomes an observable signal (consumed by the code→AI
+// ascent scan, BI-A028AA14) instead of vanishing. Mirrors recordCodeGraphJob.
+async function recordCodeGraphDefer(): Promise<void> {
+  const { prisma } = await import("@dpf/db");
+  const { CODE_GRAPH_JOB_ID } = await import("@/lib/integrate/code-graph-refresh");
+  const { readStalenessState, recordJobDefer, mergeStalenessState } = await import(
+    "@/lib/operate/scheduled-jobs/staleness-escalation"
+  );
+
+  const job = await prisma.scheduledJob.findUnique({ where: { jobId: CODE_GRAPH_JOB_ID } });
+  if (!job) return;
+
+  await prisma.scheduledJob.update({
+    where: { jobId: CODE_GRAPH_JOB_ID },
+    data: {
+      metadata: mergeStalenessState(
+        job.metadata,
+        recordJobDefer(readStalenessState(job.metadata)),
+      ) as import("@dpf/db").Prisma.InputJsonValue,
+    },
+  });
+}
+
 export const codeGraphReconcileScheduled = inngest.createFunction(
   {
     id: "ops/code-graph-reconcile-scheduled",
@@ -63,7 +89,14 @@ export const codeGraphReconcileScheduled = inngest.createFunction(
   },
   async ({ step }) => {
     const gate = await gateAtEntry(step);
-    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    if (!gate.proceed) {
+      // BI-9BF17415: record the deferral as a counter before bailing, so a job
+      // repeatedly starved by the drain gate surfaces instead of silently skipping.
+      await step.run("record-defer", async () => {
+        await recordCodeGraphDefer();
+      });
+      return { skipped: true, reason: gate.reason };
+    }
 
     // Per-job kill switch (BI-5A42E572). Honour an operator's disable from the
     // Scheduled Jobs admin surface in addition to the global gate. Defaults to


### PR DESCRIPTION
Implements **BI-9BF17415** (cognitive-load analysis §10 / `make-silent-failures-observable`) as an **external Claude Code build** per AGENTS.md §17 — the first delivery under the corrected "external builds first-class" directive (#2411).

## What
Adds a `deferCount` misfire counter to the `staleness-escalation` foundation (BI-12E646D3): consecutive scheduled runs **deferred by the quiescence drain gate**, reset to 0 on any actual run. Wired into `code-graph-reconcile`'s gate-defer path so a job starved of execution windows emits a queryable signal instead of silently skipping — feeding the code→AI ascent scan (BI-A028AA14).

## Why this design (vs. the embedded BS codegen's attempt)
The embedded Build Studio build of this BI mis-wired it (wrong jobId `ops/taskrun-watchdog`, no ScheduledJob row → silent no-op, unused import). This external build targets `code-graph-reconcile` — which **has** a ScheduledJob row + a record function + a real defer path — so the counter actually persists. Pure logic unit-tested (reset-on-run, parse, back-compat, increment).

## Verification
Pure counter logic; CI Unit Tests + Typecheck validate (worktree is source-only — relying on CI per the established pattern).

Process-Spine-Decision: small additive counter extending the existing staleness-escalation module (no new module/route/migration, no large rewrite); design documented by BI-9BF17415 + cognitive-load analysis §10 + this PR — no new spec/plan warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)