### PR TITLE
feat(build-studio): plain-language resume-stop copy (Band 4 slice) (BI-FD796419)

### DIFF
--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -605,6 +605,12 @@ describe("deriveBuildStudioWorkflowAction", () => {
     expect(action.title).toBe("Review workspace noise before retrying this build");
     expect(action.failureAxis).toBe("out-of-scope-noise");
     expect(action.resumeMode?.mode).toBe("rerun-verification");
+    // BI-FD796419 / Band 4 — the operator-facing message leads with plain
+    // language (what it means + what to do), not the "Failure axis:" jargon;
+    // the technical axis is kept only as a trailing engineer detail.
+    expect(action.message).not.toMatch(/^Failure axis/);
+    expect(action.message).toContain("Resume");
+    expect(action.message).toContain("out-of-scope-noise");
   });
 
   it("surfaces implementation recovery in review when review only contains failed execution evidence", () => {

--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -409,7 +409,9 @@ describe("deriveBuildStudioWorkflowAction", () => {
 
     expect(action.kind).toBe("resume-implementation");
     expect(action.primaryLabel).toBe("Resume Implementation");
-    expect(action.message).toContain("healthy sandbox");
+    // BI-FD796419 / Band 4 — plain copy: "clean workspace" replaced the
+    // "healthy sandbox" jargon; the message still guides the operator to Resume.
+    expect(action.message).toContain("clean workspace");
   });
 
   it("does not force Resume Implementation on a review build whose scoped surface is clean despite out-of-scope test noise (BI-2F10D6D3 follow-up)", () => {

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -384,10 +384,13 @@ function buildResumeAction(args: {
         : state.resumeMode.mode === "replan-and-dispatch"
           ? "Click Resume to re-plan and dispatch tasks"
           : "Click Resume to rerun verification";
+  // BI-FD796419 / Band 4 — lead with plain "what it means + what to do"; keep
+  // the technical failure axis + reason as a trailing engineer detail rather
+  // than the headline, so an overseer is not asked to parse "Failure axis:".
   const message =
     axis === "out-of-scope-noise"
-      ? "Failure axis: out-of-scope-noise. Verification failures appear to come from outside this build's source surface; review the scoped evidence before retrying."
-      : `Failure axis: ${axis}. ${state.resumeMode.reason} Resume from a healthy sandbox before review continues.`;
+      ? "The checks that failed look like they came from other work, not this build, so it is probably fine. Take a look, then click Resume to re-run on a clean workspace. (Details: failure axis out-of-scope-noise.)"
+      : `Some of the work did not pass its checks yet. Click Resume to re-run it on a clean workspace before the review continues. (Details: failure axis ${axis}. ${state.resumeMode.reason})`;
 
   return {
     kind: "resume-implementation",


### PR DESCRIPTION
## What

The first slice of Band 4 ("Where we need you") — de-jargons the **exact stop the founder flagged**. The resume / verification-failure message led with `"Failure axis: rate-limit. …"`; it now leads with plain *what-it-means + what-to-do* and keeps the technical axis as a trailing engineer detail:

> before: `Failure axis: out-of-scope-noise. Verification failures appear to come from outside this build's source surface…`
> after: `The checks that failed look like they came from other work, not this build, so it is probably fine. Take a look, then click Resume to re-run on a clean workspace. (Details: failure axis out-of-scope-noise.)`

The `failureAxis` metadata is unchanged (engineer view), so nothing is lost. Unit test asserts the message no longer leads with the jargon.

## Scope

This is one stop. The broader Band 4 — replacing the review-failure **chat-punt** with a guided in-place recovery, and the same plain treatment for the other stops — remains.

## Verification

Source-only worktree → CI-gated. The existing unit test for this path checks `failureAxis` metadata + title (unchanged); I extended it to assert the new plain message lead. No new surface.

`Process-Spine-Decision` + `UX-Fit-Decision: fits-with-guardrails` in the commit trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
