### PR TITLE
fix(grants): grant list_patch_posture — clears INV-1 orphan jamming the merge queue

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -335,6 +335,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
 
   // Discovery / Monitoring
   summarize_estate_posture: ["registry_read"],
+  list_patch_posture: ["registry_read"], // read-only patch-posture summary (peer of summarize_estate_posture); was an INV-1 default-deny orphan from the patch-mgmt MCP tool (#2400)
   review_estate_identity: ["registry_read"],
   validate_version_confidence: ["registry_read"],
   explain_blast_radius: ["registry_read"],

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -335,7 +335,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
 
   // Discovery / Monitoring
   summarize_estate_posture: ["registry_read"],
-  list_patch_posture: ["registry_read"], // read-only patch-posture summary (peer of summarize_estate_posture); was an INV-1 default-deny orphan from the patch-mgmt MCP tool (#2400)
+  list_patch_posture: ["registry_read"], // read-only patch-posture summary (peer of summarize_estate_posture); was a default-deny orphan flagged by the routing audit
   review_estate_identity: ["registry_read"],
   validate_version_confidence: ["registry_read"],
   explain_blast_radius: ["registry_read"],


### PR DESCRIPTION
## Problem
The Routing Invariants Audit (**INV-1**) is failing on **every open PR**, jamming the merge queue. Root cause: the patch-management MCP tool `list_patch_posture` (added in #2400) is in `PLATFORM_TOOLS` but has **no `TOOL_TO_GRANTS` entry** — so it's default-denied (unreachable from any coworker) *and* trips the invariant.

## Fix
Add `list_patch_posture: ["registry_read"]` in `agent-grants.ts`. It's a **read-only** estate patch-posture summary (handler calls `getPatchPosture`, no mutation), so it gets the same grant as its direct peer `summarize_estate_posture` — minimal, consistent, no escalation.

This unblocks the merge queue for all open PRs (incl. #2411, #2415).

Process-Spine-Decision: one-line grant entry fixing an inherited CI-invariant orphan; no new module/route/migration — no spec/plan warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)