### PR TITLE
fix(triage): preserve author-provided effortSize in autonomous drain (BI-TRIAGE-SIZE-OVERWRITE)

### DIFF
--- a/apps/web/lib/operate/backlog-triage-drain.test.ts
+++ b/apps/web/lib/operate/backlog-triage-drain.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import {
   parseTriageDecision,
   autoApplyBuildSize,
+  authorEffortSize,
+  buildTriageDrainPrompt,
   runBacklogTriageDrain,
   AUTO_TRIAGE_CONFIDENCE_THRESHOLD,
   type TriageCandidate,
@@ -49,6 +51,83 @@ describe("autoApplyBuildSize (safety gate)", () => {
 
   it("rejects null decision", () => {
     expect(autoApplyBuildSize(null)).toBeNull();
+  });
+
+  // BI-TRIAGE-SIZE-OVERWRITE: a deliberate author size must survive the drain.
+  it("preserves a valid author-provided size instead of the LLM re-estimate", () => {
+    expect(
+      autoApplyBuildSize(
+        { outcome: "build", effortSize: "medium", confidence: 0.95 },
+        { itemId: "BI-1", title: "t", effortSize: "large" },
+      ),
+    ).toBe("large");
+  });
+
+  it("falls back to the LLM size when the item has no valid author size", () => {
+    expect(
+      autoApplyBuildSize(
+        { outcome: "build", effortSize: "small", confidence: 0.95 },
+        { itemId: "BI-2", title: "t", effortSize: null },
+      ),
+    ).toBe("small");
+    expect(
+      autoApplyBuildSize(
+        { outcome: "build", effortSize: "small", confidence: 0.95 },
+        { itemId: "BI-3", title: "t", effortSize: "huge" /* invalid */ },
+      ),
+    ).toBe("small");
+  });
+
+  it("does not let an author size bypass the build / confidence gate", () => {
+    // needs-human still defers even when the item carries a size.
+    expect(
+      autoApplyBuildSize(
+        { outcome: "needs-human", confidence: 0.99 },
+        { itemId: "BI-4", title: "t", effortSize: "large" },
+      ),
+    ).toBeNull();
+    // Low confidence still defers even when the item carries a size.
+    expect(
+      autoApplyBuildSize(
+        { outcome: "build", effortSize: "large", confidence: AUTO_TRIAGE_CONFIDENCE_THRESHOLD - 0.01 },
+        { itemId: "BI-5", title: "t", effortSize: "large" },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("authorEffortSize", () => {
+  it("returns a valid author size and null otherwise", () => {
+    expect(authorEffortSize({ itemId: "BI-1", title: "t", effortSize: "xlarge" })).toBe("xlarge");
+    expect(authorEffortSize({ itemId: "BI-2", title: "t", effortSize: null })).toBeNull();
+    expect(authorEffortSize({ itemId: "BI-3", title: "t", effortSize: "huge" })).toBeNull();
+    expect(authorEffortSize({ itemId: "BI-4", title: "t" })).toBeNull();
+    expect(authorEffortSize(null)).toBeNull();
+  });
+});
+
+describe("buildTriageDrainPrompt", () => {
+  it("includes the author effortSize + proposedOutcome as non-binding priors when present", () => {
+    const prompt = buildTriageDrainPrompt({
+      itemId: "BI-P",
+      title: "Sized item",
+      effortSize: "large",
+      proposedOutcome: "build",
+    });
+    // The distinctive prior LINES are emitted (note: the static instruction also
+    // mentions the token "AUTHOR_EFFORT_SIZE", so match on the line prefix).
+    expect(prompt).toContain("AUTHOR_EFFORT_SIZE (prior");
+    expect(prompt).toMatch(/AUTHOR_EFFORT_SIZE \(prior[^\n]*: large/);
+    expect(prompt).toContain("AUTHOR_PROPOSED_OUTCOME (prior");
+    // The guidance to not re-estimate is present.
+    expect(prompt).toContain("do not re-estimate the size");
+  });
+
+  it("omits the prior lines when the item has no author size or outcome", () => {
+    const prompt = buildTriageDrainPrompt({ itemId: "BI-Q", title: "Unsized item" });
+    // No prior LINES are emitted (the instruction text may still reference the token).
+    expect(prompt).not.toContain("AUTHOR_EFFORT_SIZE (prior");
+    expect(prompt).not.toContain("AUTHOR_PROPOSED_OUTCOME (prior");
   });
 });
 
@@ -98,5 +177,44 @@ describe("runBacklogTriageDrain", () => {
     });
     expect(result).toEqual({ considered: 0, autoBuilt: 0, leftForOperator: 0 });
     expect(decide).not.toHaveBeenCalled();
+  });
+
+  // BI-TRIAGE-SIZE-OVERWRITE regression (a): a deliberate author size survives a
+  // confident build decision instead of being overwritten by the LLM's guess.
+  it("preserves an author-provided effortSize on auto-build (no blind overwrite)", async () => {
+    const applyBuild = vi.fn(async () => {});
+    // LLM confidently says BUILD but re-estimates the size to "medium"; the author said "large".
+    const decide = vi.fn(
+      async () => '{"outcome":"build","effortSize":"medium","confidence":0.95,"rationale":"r"}',
+    );
+
+    const result = await runBacklogTriageDrain({
+      getTriagingItems: async () => [{ itemId: "BI-SIZED", title: "Author-sized", effortSize: "large" }],
+      decide,
+      applyBuild,
+    });
+
+    expect(result).toEqual({ considered: 1, autoBuilt: 1, leftForOperator: 0 });
+    // The author's "large" is preserved — NOT the LLM's "medium".
+    expect(applyBuild).toHaveBeenCalledWith("BI-SIZED", "large", expect.any(String));
+  });
+
+  // BI-TRIAGE-SIZE-OVERWRITE regression (b): the autonomous-capture path still
+  // works — an item filed with no size gets the LLM-decided size.
+  it("uses the LLM-decided size for an item captured with no size", async () => {
+    const applyBuild = vi.fn(async () => {});
+    const decide = vi.fn(
+      async () => '{"outcome":"build","effortSize":"small","confidence":0.95,"rationale":"r"}',
+    );
+
+    const result = await runBacklogTriageDrain({
+      getTriagingItems: async () => [{ itemId: "BI-UNSIZED", title: "No author size" }],
+      decide,
+      applyBuild,
+    });
+
+    expect(result).toEqual({ considered: 1, autoBuilt: 1, leftForOperator: 0 });
+    // No author size → fall back to the LLM's size.
+    expect(applyBuild).toHaveBeenCalledWith("BI-UNSIZED", "small", expect.any(String));
   });
 });

--- a/apps/web/lib/operate/backlog-triage-drain.ts
+++ b/apps/web/lib/operate/backlog-triage-drain.ts
@@ -18,6 +18,12 @@
 //     decisions, and parse failures are LEFT in the triaging queue for a human
 //     (or the Scrum Master on request) to decide. An autonomous job must never
 //     silently bury work.
+//   - Author intent is preserved (BI-TRIAGE-SIZE-OVERWRITE): when an item
+//     already carries a deliberate, valid effortSize, the drain keeps THAT size
+//     on auto-build and never overwrites it with the LLM's blind re-estimate
+//     (which regresses to "medium"). The LLM only sizes items captured with no
+//     size — the autonomous-capture path this drain was originally built for.
+//     The LLM still makes the build-vs-needs-human call in both cases.
 //
 // The Inngest wrapper (apps/web/lib/queue/functions/backlog-triage-drain.ts)
 // supplies prisma + the LLM caller; this module stays pure and unit-testable.
@@ -31,6 +37,14 @@ export type TriageCandidate = {
   body?: string | null;
   type?: string | null;
   workType?: string | null;
+  /**
+   * Author-provided effort size, if any. Preserved by the drain — a valid value
+   * here is used verbatim on auto-build and is never overwritten by the LLM's
+   * re-estimate (BI-TRIAGE-SIZE-OVERWRITE).
+   */
+  effortSize?: string | null;
+  /** Author's advisory proposed outcome; passed to the LLM as a non-binding prior. */
+  proposedOutcome?: string | null;
 };
 
 export type TriageDecision = {
@@ -56,12 +70,25 @@ export const TRIAGE_DRAIN_SYSTEM_PROMPT =
 /** Build the per-item decision prompt. */
 export function buildTriageDrainPrompt(item: TriageCandidate): string {
   const body = (item.body ?? "").toString().slice(0, 1200);
+
+  // Author-provided priors (non-binding). They inform the build-vs-needs-human
+  // judgment; the author's effortSize is preserved by the platform, so the model
+  // does not need to re-estimate size when one is shown.
+  const priors: string[] = [];
+  if (typeof item.effortSize === "string" && item.effortSize.trim()) {
+    priors.push(`AUTHOR_EFFORT_SIZE (prior, non-binding, preserved by the platform): ${item.effortSize.trim()}`);
+  }
+  if (typeof item.proposedOutcome === "string" && item.proposedOutcome.trim()) {
+    priors.push(`AUTHOR_PROPOSED_OUTCOME (prior, non-binding): ${item.proposedOutcome.trim()}`);
+  }
+  const priorBlock = priors.length ? `${priors.join("\n")}\n` : "";
+
   return `Decide how to triage this backlog item.
 
 ITEM: ${item.itemId}
 TITLE: ${item.title}
 TYPE: ${item.type ?? "unknown"} / ${item.workType ?? "unspecified"}
-${body ? `DETAIL:\n${body}\n` : ""}
+${priorBlock}${body ? `DETAIL:\n${body}\n` : ""}
 Return ONLY this JSON (no prose, no fences):
 {
   "outcome": "build" | "needs-human",
@@ -70,7 +97,7 @@ Return ONLY this JSON (no prose, no fences):
   "rationale": "<one concise sentence>"
 }
 
-Choose "build" ONLY when the item is clearly real, scoped engineering/product work and you can size it confidently. For ANY noise, duplicate, stale/optional item, vague request, or uncertainty, choose "needs-human" (a human will decide defer/discard/duplicate). effortSize is required when outcome is "build".`;
+Choose "build" ONLY when the item is clearly real, scoped engineering/product work and you can size it confidently. For ANY noise, duplicate, stale/optional item, vague request, or uncertainty, choose "needs-human" (a human will decide defer/discard/duplicate). effortSize is required when outcome is "build" — but when an AUTHOR_EFFORT_SIZE prior is shown, treat it as the author's deliberate estimate (the platform keeps it; do not re-estimate the size) and focus your judgment on build vs needs-human.`;
 }
 
 /** Parse the model's JSON decision; tolerant of markdown fences. Returns null on failure. */
@@ -96,16 +123,39 @@ export function parseTriageDecision(content: string): TriageDecision | null {
   };
 }
 
+/** The author's pre-existing effortSize when it is a valid size; otherwise null. */
+export function authorEffortSize(item?: TriageCandidate | null): string | null {
+  const size = item?.effortSize;
+  return typeof size === "string" && VALID_EFFORT_SIZES.has(size) ? size : null;
+}
+
 /**
  * The auto-apply gate. Returns the effortSize to apply when the decision is a
- * confident, well-formed BUILD; otherwise null (leave for a human).
+ * confident BUILD; otherwise null (leave for a human).
+ *
+ * Author intent is preserved (BI-TRIAGE-SIZE-OVERWRITE): when the item already
+ * carries a valid author-provided effortSize, THAT size is returned and the
+ * LLM's blind re-estimate is ignored — the drain must never overwrite a
+ * deliberate author size. The LLM-decided size is only a fallback for items
+ * captured with no size (the autonomous-capture path), which still require a
+ * size to enter the build pool. The author size never bypasses the build /
+ * confidence gate: a needs-human or low-confidence decision still defers.
  */
-export function autoApplyBuildSize(decision: TriageDecision | null): string | null {
+export function autoApplyBuildSize(
+  decision: TriageDecision | null,
+  item?: TriageCandidate | null,
+): string | null {
   if (!decision) return null;
   if (decision.outcome !== "build") return null;
-  if (typeof decision.effortSize !== "string" || !VALID_EFFORT_SIZES.has(decision.effortSize)) return null;
   if ((decision.confidence ?? 0) < AUTO_TRIAGE_CONFIDENCE_THRESHOLD) return null;
-  return decision.effortSize;
+  // Preserve a valid author-provided size; never clobber it with a re-estimate.
+  const authored = authorEffortSize(item);
+  if (authored) return authored;
+  // Autonomous-capture fallback: items filed with no size get the LLM's size.
+  if (typeof decision.effortSize === "string" && VALID_EFFORT_SIZES.has(decision.effortSize)) {
+    return decision.effortSize;
+  }
+  return null;
 }
 
 export type TriageDrainDeps = {
@@ -136,7 +186,7 @@ export async function runBacklogTriageDrain(deps: TriageDrainDeps): Promise<Tria
     } catch {
       decision = null;
     }
-    const size = autoApplyBuildSize(decision);
+    const size = autoApplyBuildSize(decision, item);
     if (size) {
       try {
         await deps.applyBuild(

--- a/apps/web/lib/queue/functions/backlog-triage-drain.ts
+++ b/apps/web/lib/queue/functions/backlog-triage-drain.ts
@@ -48,7 +48,18 @@ export const backlogTriageDrain = inngest.createFunction(
             where: { status: "triaging" },
             orderBy: { createdAt: "asc" },
             take: MAX_PER_RUN,
-            select: { itemId: true, title: true, body: true, type: true, workType: true },
+            select: {
+              itemId: true,
+              title: true,
+              body: true,
+              type: true,
+              workType: true,
+              // Author intent: load the existing size + proposed outcome so the
+              // drain preserves a deliberate effortSize instead of overwriting it
+              // with a blind re-estimate (BI-TRIAGE-SIZE-OVERWRITE).
+              effortSize: true,
+              proposedOutcome: true,
+            },
           }),
 
         decide: async (item) => {


### PR DESCRIPTION
## Summary

Fixes **BI-TRIAGE-SIZE-OVERWRITE** — the hourly autonomous triage drain (`ops/backlog-triage-drain`, cron `23 * * * *`) discarded an author-provided `effortSize` and replaced it with a blind LLM re-estimate that regresses to `"medium"`. Six freshly-filed BIs with deliberate, evidence-based sizes all flipped to `medium` on the next `:23` cron.

## Root cause

- `getTriagingItems` selected only `{ itemId, title, body, type, workType }` — the existing `effortSize`/`proposedOutcome` were never loaded.
- `buildTriageDrainPrompt` asked the LLM to size from scratch off `body.slice(0,1200)` with no anchor.
- `applyBuild` did an **unconditional** `prisma.backlogItem.update({ data: { effortSize, … } })`. Because triage→build requires a size, the blind guess always won.

## Fix (preserve author intent; LLM sizes only when none exists)

The autonomous-capture path the drain was built for keeps working — an item filed with **no** size still gets an LLM size. The LLM still makes the build‑vs‑needs‑human call in **both** cases.

1. `getTriagingItems` now selects `effortSize` + `proposedOutcome`.
2. `TriageCandidate` carries optional `effortSize?` / `proposedOutcome?`.
3. `autoApplyBuildSize(decision, item)` returns the author's **valid** size when present, and only falls back to the LLM-decided size for items with none. The author size **never bypasses** the build/confidence gate — `needs-human` and low-confidence decisions still defer to a human.
4. `buildTriageDrainPrompt` passes the existing size + proposed outcome as a **non-binding author prior** so the build‑vs‑needs‑human judgment is informed, and tells the model not to re-estimate a preserved size.
5. `applyBuild` writes the resolved (preserved-or-LLM) size — never clobbers a present author size.

## Verification

Substrate: source-only worktree (no local `node_modules`); cheap source-local gates run via the documented junction-borrow of a compile-ready toolchain.

- **Unit tests — PASS (19/19):** `vitest run lib/operate/backlog-triage-drain` — includes new regression tests: (a) an item with `effortSize="large"` + a confident build **stays `large`** after the drain (no overwrite); (b) an unsized item still gets the LLM size; plus gate-level coverage that an author size cannot turn a `needs-human`/low-confidence decision into a build. Existing tests stay green.
- **Typecheck — changed files clean:** full-project `tsc --noEmit` reports **zero** errors in the three changed files. (Project-wide drift errors from the sibling's older generated Prisma client are the documented source-only limitation and are re-run authoritatively by CI, which runs `prisma generate` + `next typegen`.)
- **Production build + full typecheck:** delegated to CI on this PR (runtime-bound gate; not hosted in a source-only worktree per AGENTS.md §5).

## Backlog

- BI: `BI-TRIAGE-SIZE-OVERWRITE` (workType `bug`, epic `EP-INTAKE-UNIFY`). Evidence recorded on the item.
- Blast radius: `backlog-triage-drain` only; reversible.

## Process-Spine-Decision

Small, well-scoped bug fix to an existing autonomous job — no new source module/route/migration and no large in-place rewrite; the behavior change is confined to `backlog-triage-drain`. Durable behavior is documented in-module (module header + `autoApplyBuildSize` docblock) and the fix rationale is recorded on `BI-TRIAGE-SIZE-OVERWRITE`, so no separate spec/plan is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
