### PR TITLE
refactor(perf): BacklogItem.status index + collapse EA-traversal & model-discovery N+1 (BI-OPT-DB-HOTPATH)

### DIFF
--- a/apps/web/lib/ea/traversal-executor.test.ts
+++ b/apps/web/lib/ea/traversal-executor.test.ts
@@ -56,6 +56,7 @@ describe("runTraversalPattern", () => {
       elementType: { slug: "artifact" },
     } as never);
     vi.mocked(prisma.eaRelationship.findMany).mockResolvedValue([{
+      fromElementId: "start-1", toElementId: "comp-1",
       fromElement: { id: "comp-1", name: "Portal", refinementLevel: "logical", elementType: { slug: "application_component" } },
       toElement:   { id: "comp-1", name: "Portal", refinementLevel: "logical", elementType: { slug: "application_component" } },
       relationshipType: { slug: "depends_on" },
@@ -82,10 +83,10 @@ describe("runTraversalPattern", () => {
       id: "model", name: "RuntimeTarget", refinementLevel: null, elementType: { slug: "data_object" },
     } as never);
     vi.mocked(prisma.eaRelationship.findMany).mockResolvedValue([
-      { fromElement: { id: "inst1", name: "portal · RT-ROOT-PORTAL", refinementLevel: null, elementType: { slug: "part_usage" } }, toElement: { id: "model", elementType: { slug: "data_object" } }, relationshipType: { slug: "traces" } },
-      { fromElement: { id: "inst2", name: "build-sandbox · RT-X", refinementLevel: null, elementType: { slug: "part_usage" } }, toElement: { id: "model", elementType: { slug: "data_object" } }, relationshipType: { slug: "traces" } },
+      { fromElementId: "inst1", toElementId: "model", fromElement: { id: "inst1", name: "portal · RT-ROOT-PORTAL", refinementLevel: null, elementType: { slug: "part_usage" } }, toElement: { id: "model", elementType: { slug: "data_object" } }, relationshipType: { slug: "traces" } },
+      { fromElementId: "inst2", toElementId: "model", fromElement: { id: "inst2", name: "build-sandbox · RT-X", refinementLevel: null, elementType: { slug: "part_usage" } }, toElement: { id: "model", elementType: { slug: "data_object" } }, relationshipType: { slug: "traces" } },
       // wrong element type AND wrong relationship type → must be filtered out
-      { fromElement: { id: "other", name: "Component", refinementLevel: null, elementType: { slug: "application_component" } }, toElement: { id: "model", elementType: { slug: "data_object" } }, relationshipType: { slug: "depends_on" } },
+      { fromElementId: "other", toElementId: "model", fromElement: { id: "other", name: "Component", refinementLevel: null, elementType: { slug: "application_component" } }, toElement: { id: "model", elementType: { slug: "data_object" } }, relationshipType: { slug: "depends_on" } },
     ] as never);
 
     const result = await runTraversalPattern({ patternSlug: "cross_layer_impact", startElementIds: ["model"] });
@@ -110,5 +111,109 @@ describe("runTraversalPattern", () => {
     const path = result.data!.paths[0];
     expect(path.terminationReason).toBe("no_matching_elements");
     expect(path.steps.map((s) => s.elementId)).toEqual(["model"]);
+  });
+
+  // BI-OPT-DB-HOTPATH: the depth loop was changed from one findMany PER NODE to
+  // ONE batched findMany({ where: { fromElementId: { in: currentIds } } }) per
+  // depth step, with the rows grouped back by their originating node in JS. These
+  // tests pin the byte-identical traversal semantics that change must preserve:
+  // exactly one query per depth step, and per-node grouping/ordering unchanged.
+
+  const OUTBOUND_TWO_STEPS = [
+    { elementTypeSlugs: [], refinementLevel: null, relationshipTypeSlugs: [], direction: "outbound" },
+    { elementTypeSlugs: [], refinementLevel: null, relationshipTypeSlugs: [], direction: "outbound" },
+  ];
+
+  it("issues ONE batched eaRelationship.findMany per depth step (not one per node)", async () => {
+    vi.mocked(prisma.eaNotation.findUnique).mockResolvedValue({ id: "n-1" } as never);
+    vi.mocked(prisma.eaTraversalPattern.findUnique).mockResolvedValue({ steps: OUTBOUND_TWO_STEPS, forbiddenShortcuts: [] } as never);
+    vi.mocked(prisma.eaElement.findUnique).mockResolvedValue({
+      id: "root", name: "Root", refinementLevel: null, elementType: { slug: "node" },
+    } as never);
+    // Step 0: root → a, b. Step 1: two current nodes (a, b) — the old code would
+    // have fired TWO queries here; the batched code fires ONE.
+    vi.mocked(prisma.eaRelationship.findMany)
+      .mockResolvedValueOnce([
+        { fromElementId: "root", toElementId: "a", fromElement: { id: "root", name: "Root", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "a", name: "A", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+        { fromElementId: "root", toElementId: "b", fromElement: { id: "root", name: "Root", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "b", name: "B", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+      ] as never)
+      .mockResolvedValueOnce([
+        { fromElementId: "a", toElementId: "a1", fromElement: { id: "a", name: "A", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "a1", name: "A1", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+        { fromElementId: "b", toElementId: "b1", fromElement: { id: "b", name: "B", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "b1", name: "B1", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+      ] as never);
+
+    const result = await runTraversalPattern({ patternSlug: "p", startElementIds: ["root"] });
+    expect(result.ok).toBe(true);
+    // One findMany per depth step (2 steps), NOT one per node (which would be 1 + 2 = 3).
+    expect(vi.mocked(prisma.eaRelationship.findMany)).toHaveBeenCalledTimes(2);
+    // Step 1 query is batched over both current nodes.
+    expect(vi.mocked(prisma.eaRelationship.findMany).mock.calls[1][0]).toMatchObject({
+      where: { fromElementId: { in: ["a", "b"] } },
+    });
+    // Full path preserved: root → a → b → a1 → b1 (per-node order: a's children
+    // before b's children at each step, exactly as the per-node loop produced).
+    expect(result.data!.paths[0].steps.map((s) => s.elementId)).toEqual(["root", "a", "b", "a1", "b1"]);
+  });
+
+  it("groups batched rows back to the correct originating node and preserves per-node order", async () => {
+    vi.mocked(prisma.eaNotation.findUnique).mockResolvedValue({ id: "n-1" } as never);
+    vi.mocked(prisma.eaTraversalPattern.findUnique).mockResolvedValue({
+      steps: [{ elementTypeSlugs: [], refinementLevel: null, relationshipTypeSlugs: [], direction: "outbound" }],
+      forbiddenShortcuts: [],
+    } as never);
+    // Two start nodes share the first depth step's currentIds = [s1, s2].
+    vi.mocked(prisma.eaElement.findUnique).mockImplementation((async (args: { where: { id: string } }) => {
+      const id = args.where.id;
+      return { id, name: id.toUpperCase(), refinementLevel: null, elementType: { slug: "node" } };
+    }) as never);
+    // Batched rows for { fromElementId: { in: [s1] } } and { in: [s2] } — each
+    // start element is its own path, so the loop runs once per start with a
+    // single-node currentIds. Rows are returned interleaved to prove grouping
+    // keys on fromElementId, not on row position.
+    vi.mocked(prisma.eaRelationship.findMany)
+      .mockResolvedValueOnce([
+        { fromElementId: "s1", toElementId: "x", fromElement: { id: "s1", name: "S1", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "x", name: "X", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+        { fromElementId: "s1", toElementId: "y", fromElement: { id: "s1", name: "S1", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "y", name: "Y", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+      ] as never)
+      .mockResolvedValueOnce([
+        { fromElementId: "s2", toElementId: "z", fromElement: { id: "s2", name: "S2", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "z", name: "Z", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+      ] as never);
+
+    const result = await runTraversalPattern({ patternSlug: "p", startElementIds: ["s1", "s2"] });
+    expect(result.ok).toBe(true);
+    expect(result.data!.paths[0].steps.map((s) => s.elementId)).toEqual(["s1", "x", "y"]);
+    expect(result.data!.paths[1].steps.map((s) => s.elementId)).toEqual(["s2", "z"]);
+  });
+
+  it("either-direction: a single row matching two current nodes is bucketed under both (OR-per-node parity)", async () => {
+    vi.mocked(prisma.eaNotation.findUnique).mockResolvedValue({ id: "n-1" } as never);
+    vi.mocked(prisma.eaTraversalPattern.findUnique).mockResolvedValue({
+      steps: [
+        { elementTypeSlugs: [], refinementLevel: null, relationshipTypeSlugs: [], direction: "outbound" },
+        { elementTypeSlugs: [], refinementLevel: null, relationshipTypeSlugs: [], direction: "either" },
+      ],
+      forbiddenShortcuts: [],
+    } as never);
+    vi.mocked(prisma.eaElement.findUnique).mockResolvedValue({
+      id: "root", name: "Root", refinementLevel: null, elementType: { slug: "node" },
+    } as never);
+    // Step 0 (outbound): root → p, q  ⇒ currentIds = [p, q].
+    // Step 1 (either): one row p→q. Under the OLD OR-per-node code this row is
+    // returned for BOTH p (via fromElementId=p) and q (via toElementId=q); for
+    // "either" nextEl is always toElement, so p yields q and q yields q.
+    vi.mocked(prisma.eaRelationship.findMany)
+      .mockResolvedValueOnce([
+        { fromElementId: "root", toElementId: "p", fromElement: { id: "root", name: "Root", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "p", name: "P", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+        { fromElementId: "root", toElementId: "q", fromElement: { id: "root", name: "Root", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "q", name: "Q", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+      ] as never)
+      .mockResolvedValueOnce([
+        { fromElementId: "p", toElementId: "q", fromElement: { id: "p", name: "P", refinementLevel: null, elementType: { slug: "node" } }, toElement: { id: "q", name: "Q", refinementLevel: null, elementType: { slug: "node" } }, relationshipType: { slug: "rel" } },
+      ] as never);
+
+    const result = await runTraversalPattern({ patternSlug: "p", startElementIds: ["root"] });
+    expect(result.ok).toBe(true);
+    // p contributes q (via from-match), q contributes q (via to-match): both
+    // surface, in currentIds order [p, q] → two q steps appended after root,p,q.
+    expect(result.data!.paths[0].steps.map((s) => s.elementId)).toEqual(["root", "p", "q", "q", "q"]);
   });
 });

--- a/apps/web/lib/ea/traversal-executor.ts
+++ b/apps/web/lib/ea/traversal-executor.ts
@@ -81,20 +81,52 @@ export async function runTraversalPattern(input: TraversalInput): Promise<Traver
       }
 
       const nextIds: string[] = [];
-      for (const currentId of currentIds) {
-        const relWhere =
-          step.direction === "outbound" ? { fromElementId: currentId } :
-          step.direction === "inbound"  ? { toElementId: currentId } :
-          { OR: [{ fromElementId: currentId }, { toElementId: currentId }] };
 
-        const rels = await prisma.eaRelationship.findMany({
-          where: relWhere,
-          include: {
-            fromElement: { include: { elementType: { select: { slug: true } } } },
-            toElement:   { include: { elementType: { select: { slug: true } } } },
-            relationshipType: { select: { slug: true } },
-          },
-        });
+      // One batched query per depth step (was one findMany PER NODE — N+1 over a
+      // 331+-edge graph). The rows are grouped back by their originating current
+      // node and replayed in the original currentIds order so the per-node
+      // traversal semantics (and therefore run_traversal_pattern output) are
+      // byte-identical to the per-node loop.
+      const relWhere =
+        step.direction === "outbound" ? { fromElementId: { in: currentIds } } :
+        step.direction === "inbound"  ? { toElementId: { in: currentIds } } :
+        { OR: [{ fromElementId: { in: currentIds } }, { toElementId: { in: currentIds } }] };
+
+      const allRels = await prisma.eaRelationship.findMany({
+        where: relWhere,
+        include: {
+          fromElement: { include: { elementType: { select: { slug: true } } } },
+          toElement:   { include: { elementType: { select: { slug: true } } } },
+          relationshipType: { select: { slug: true } },
+        },
+      });
+
+      // Group the batched rows by the current-node id the per-node query would
+      // have matched on. For "either", a single row can match two distinct
+      // current nodes (once via fromElementId, once via toElementId) — exactly
+      // as the old OR-per-node query would have surfaced it under both — so it is
+      // bucketed under each. Encounter order within a bucket follows the DB row
+      // order, matching the per-node query's order for the same table state.
+      const relsByCurrentId = new Map<string, typeof allRels>();
+      const bucket = (id: string, rel: (typeof allRels)[number]) => {
+        const list = relsByCurrentId.get(id);
+        if (list) list.push(rel);
+        else relsByCurrentId.set(id, [rel]);
+      };
+      const currentIdSet = new Set(currentIds);
+      for (const rel of allRels) {
+        if (step.direction === "outbound") {
+          bucket(rel.fromElementId, rel);
+        } else if (step.direction === "inbound") {
+          bucket(rel.toElementId, rel);
+        } else {
+          if (currentIdSet.has(rel.fromElementId)) bucket(rel.fromElementId, rel);
+          if (currentIdSet.has(rel.toElementId)) bucket(rel.toElementId, rel);
+        }
+      }
+
+      for (const currentId of currentIds) {
+        const rels = relsByCurrentId.get(currentId) ?? [];
 
         for (const rel of rels) {
           const nextEl = step.direction === "inbound" ? rel.fromElement : rel.toElement;

--- a/apps/web/lib/inference/ai-provider-internals.test.ts
+++ b/apps/web/lib/inference/ai-provider-internals.test.ts
@@ -6,11 +6,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const credState = vi.hoisted(() => ({
   row: null as Record<string, unknown> | null,
 }));
+const discoveredModelMock = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  update: vi.fn(),
+  createMany: vi.fn(),
+}));
 vi.mock("@dpf/db", () => ({
   prisma: {
     credentialEntry: {
       findUnique: vi.fn(async () => credState.row),
     },
+    discoveredModel: discoveredModelMock,
   },
 }));
 
@@ -19,6 +25,7 @@ import {
   extractTokenUsage,
   providerHasConfiguredCredential,
   resolveSyncedToolUse,
+  upsertDiscoveredModels,
 } from "./ai-provider-internals";
 
 describe("extractTokenUsage", () => {
@@ -189,5 +196,72 @@ describe("resolveSyncedToolUse (sticky-false trap — BI-B6DEBFFE)", () => {
         existing: null,
       }),
     ).toBe(true);
+  });
+});
+
+describe("upsertDiscoveredModels (model-discovery N+1 batching — BI-OPT-DB-HOTPATH)", () => {
+  beforeEach(() => {
+    discoveredModelMock.findMany.mockReset();
+    discoveredModelMock.update.mockReset();
+    discoveredModelMock.createMany.mockReset();
+    discoveredModelMock.findMany.mockResolvedValue([]);
+    discoveredModelMock.update.mockResolvedValue({});
+    discoveredModelMock.createMany.mockResolvedValue({ count: 0 });
+  });
+
+  it("reads existing models with ONE findMany keyed on providerId + modelId IN [...]", async () => {
+    await upsertDiscoveredModels("openrouter", [
+      { modelId: "a", rawMetadata: { id: "a" } },
+      { modelId: "b", rawMetadata: { id: "b" } },
+    ]);
+    expect(discoveredModelMock.findMany).toHaveBeenCalledTimes(1);
+    expect(discoveredModelMock.findMany.mock.calls[0][0]).toMatchObject({
+      where: { providerId: "openrouter", modelId: { in: ["a", "b"] } },
+    });
+  });
+
+  it("createMany's only the new models and returns their count; existing rows are updated, not created", async () => {
+    // "a" already stored, "b" and "c" are new.
+    discoveredModelMock.findMany.mockResolvedValue([{ modelId: "a" }]);
+    const newCount = await upsertDiscoveredModels("p", [
+      { modelId: "a", rawMetadata: { id: "a", v: 2 } },
+      { modelId: "b", rawMetadata: { id: "b" } },
+      { modelId: "c", rawMetadata: { id: "c" } },
+    ]);
+
+    expect(newCount).toBe(2);
+    // existing "a" refreshed via a single update
+    expect(discoveredModelMock.update).toHaveBeenCalledTimes(1);
+    expect(discoveredModelMock.update.mock.calls[0][0]).toMatchObject({
+      where: { providerId_modelId: { providerId: "p", modelId: "a" } },
+      data: { rawMetadata: { id: "a", v: 2 } },
+    });
+    // new "b","c" inserted with one createMany
+    expect(discoveredModelMock.createMany).toHaveBeenCalledTimes(1);
+    const createArg = discoveredModelMock.createMany.mock.calls[0][0];
+    expect(createArg.skipDuplicates).toBe(true);
+    expect(createArg.data.map((r: { modelId: string }) => r.modelId)).toEqual(["b", "c"]);
+  });
+
+  it("counts a model new exactly once and last-write-wins when the batch repeats a new modelId", async () => {
+    discoveredModelMock.findMany.mockResolvedValue([]); // none stored yet
+    const newCount = await upsertDiscoveredModels("p", [
+      { modelId: "dup", rawMetadata: { id: "dup", seq: 1 } },
+      { modelId: "dup", rawMetadata: { id: "dup", seq: 2 } },
+    ]);
+    expect(newCount).toBe(1);
+    expect(discoveredModelMock.createMany).toHaveBeenCalledTimes(1);
+    const createArg = discoveredModelMock.createMany.mock.calls[0][0];
+    expect(createArg.data).toHaveLength(1);
+    // last occurrence's metadata wins, matching the old create-then-update loop
+    expect(createArg.data[0].rawMetadata).toEqual({ id: "dup", seq: 2 });
+  });
+
+  it("no-ops on an empty model list (no DB calls)", async () => {
+    const newCount = await upsertDiscoveredModels("p", []);
+    expect(newCount).toBe(0);
+    expect(discoveredModelMock.findMany).not.toHaveBeenCalled();
+    expect(discoveredModelMock.createMany).not.toHaveBeenCalled();
+    expect(discoveredModelMock.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -388,7 +388,62 @@ export async function discoverChatGptBackendModels(
 
 // ─── Exported internal functions (no auth guard) ─────────────────────────────
 
+/**
+ * Persist a freshly-discovered set of models against DiscoveredModel, returning
+ * the count of genuinely-new rows.
+ *
+ * Replaces the per-model findUnique→update/create N+1 (100s of rows for a large
+ * catalog such as OpenRouter) with: ONE findMany to read the existing modelIds,
+ * a createMany for the new ones, and one update per changed existing row
+ * (Prisma has no single-statement bulk update with per-row values, so the
+ * existing-row metadata refresh stays one update each — the win is collapsing
+ * the read + the inserts). Behaviour is identical to the old loop:
+ *   • existing rows have their rawMetadata overwritten with the fresh value;
+ *   • new rows are inserted with { providerId, modelId, rawMetadata };
+ *   • the returned newCount equals the number of distinct modelIds not already
+ *     present (a modelId repeated within `models` counts once, exactly as the
+ *     old loop did once its first occurrence was created).
+ */
+export async function upsertDiscoveredModels(
+  providerId: string,
+  models: Array<{ modelId: string; rawMetadata: Record<string, unknown> }>,
+): Promise<number> {
+  if (models.length === 0) return 0;
 
+  const existingRows = await prisma.discoveredModel.findMany({
+    where: { providerId, modelId: { in: models.map((m) => m.modelId) } },
+    select: { modelId: true },
+  });
+  const existingIds = new Set(existingRows.map((r) => r.modelId));
+
+  const newRowByModelId = new Map<string, { providerId: string; modelId: string; rawMetadata: Prisma.InputJsonValue }>();
+  for (const m of models) {
+    if (existingIds.has(m.modelId)) {
+      // Refresh rawMetadata for the already-known model (was the update branch).
+      await prisma.discoveredModel.update({
+        where: { providerId_modelId: { providerId, modelId: m.modelId } },
+        data: { rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
+      });
+    } else {
+      // Not-yet-stored model. If the same new modelId appears more than once in
+      // this batch, last-write-wins on rawMetadata — exactly as the old loop did
+      // (its first occurrence created the row, later occurrences updated it) —
+      // and it is still created (and counted) once.
+      newRowByModelId.set(m.modelId, {
+        providerId,
+        modelId: m.modelId,
+        rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue,
+      });
+    }
+  }
+
+  const newRows = [...newRowByModelId.values()];
+  if (newRows.length > 0) {
+    await prisma.discoveredModel.createMany({ data: newRows, skipDuplicates: true });
+  }
+
+  return newRows.length;
+}
 
 export async function discoverModelsInternal(
   providerId: string,
@@ -416,23 +471,7 @@ export async function discoverModelsInternal(
       return { discovered: 0, newCount: 0, error: result.error };
     }
 
-    let newCount = 0;
-    for (const m of result.models) {
-      const existing = await prisma.discoveredModel.findUnique({
-        where: { providerId_modelId: { providerId, modelId: m.modelId } },
-      });
-      if (existing) {
-        await prisma.discoveredModel.update({
-          where: { id: existing.id },
-          data: { rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
-        });
-      } else {
-        await prisma.discoveredModel.create({
-          data: { providerId, modelId: m.modelId, rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
-        });
-        newCount++;
-      }
-    }
+    const newCount = await upsertDiscoveredModels(providerId, result.models);
 
     return { discovered: result.models.length, newCount };
   }
@@ -480,26 +519,10 @@ export async function discoverModelsInternal(
   }
 
   const models = parseModelsResponse(providerId, json);
-  let newCount = 0;
 
   const freshModelIds = new Set(models.map((m) => m.modelId));
 
-  for (const m of models) {
-    const existing = await prisma.discoveredModel.findUnique({
-      where: { providerId_modelId: { providerId, modelId: m.modelId } },
-    });
-    if (existing) {
-      await prisma.discoveredModel.update({
-        where: { id: existing.id },
-        data: { rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
-      });
-    } else {
-      await prisma.discoveredModel.create({
-        data: { providerId, modelId: m.modelId, rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
-      });
-      newCount++;
-    }
-  }
+  const newCount = await upsertDiscoveredModels(providerId, models);
 
   // ── EP-INF-002: Discovery reconciliation — detect gone models ──
   const isLocalProvider = providerId === "local" || providerId === "ollama";

--- a/packages/db/prisma/migrations/20260625140000_backlogitem_status_index/migration.sql
+++ b/packages/db/prisma/migrations/20260625140000_backlogitem_status_index/migration.sql
@@ -1,0 +1,11 @@
+-- DB hot-path (BI-OPT-DB-HOTPATH): BacklogItem.status had NO index, yet status is
+-- filtered at the hot feed/selector sites (backlog-selector, activity-feed-data,
+-- remediation-teeup). Add a single-column index for equality/IN filters and a
+-- composite [status, updatedAt] for the selector's status-filtered, updatedAt-ordered
+-- reads. Additive index-only migration — no data change.
+
+-- CreateIndex
+CREATE INDEX "BacklogItem_status_idx" ON "BacklogItem"("status");
+
+-- CreateIndex
+CREATE INDEX "BacklogItem_status_updatedAt_idx" ON "BacklogItem"("status", "updatedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1045,6 +1045,8 @@ model BacklogItem {
   businessCapabilityLinks BusinessCapabilityTraceLink[] @relation("BusinessCapabilityBacklogLinks")
 
   @@index([portfolioId])
+  @@index([status])
+  @@index([status, updatedAt])
 }
 
 // Per-item timeline. Cross-cutting tool audit lives in ToolExecution; this is


### PR DESCRIPTION
Implements **BI-OPT-DB-HOTPATH** (EP-PLATFORM-OPTIMIZATION sweep, spec §4.4 F–G). Three parity-preserving database hot-path fixes. Behaviour is held exactly; only the query shape changes.

## 1. `BacklogItem.status` index (+ migration)
The model carried only `@@index([portfolioId])`, yet `status` is filtered at the hot feed/selector sites (`backlog-selector`, `activity-feed-data`, `remediation-teeup`). Added `@@index([status])` and `@@index([status, updatedAt])` (the selector filters on status and orders by `updatedAt`).

**Migration (call-out):** hand-authored, not generated — `packages/db/prisma/migrations/20260625140000_backlogitem_status_index/migration.sql`. It matches exactly what Prisma would emit: `CREATE INDEX` with no `IF NOT EXISTS`, index names `BacklogItem_status_idx` / `BacklogItem_status_updatedAt_idx`. Verified against the existing `20260623040000_add_backlog_portfolio_id` (same table) and `DelegationGrant_status_expiresAt_idx` (composite `[status, x]`) precedents. `schema.prisma` and the SQL agree. The migration **apply** gate is runtime-bound — it must run in CI / the shared local-CI convergence sandbox, not in this source-only worktree.

## 2. EA traversal N+1 (`run_traversal_pattern` MCP tool)
`apps/web/lib/ea/traversal-executor.ts` ran one `eaRelationship.findMany` **per node** inside the depth loop, over a 331+-edge graph. Replaced with **one** batched `findMany({ where: { fromElementId: { in: currentIds } } })` per depth step; rows are then grouped back by their originating current node in JS and replayed in the original `currentIds` order.

Output is **byte-identical**: outbound/inbound key on the matching FK; `either` buckets a row under every current node it matches, preserving the old OR-per-node duplication (incl. the self-reference a `to`-match yields). New tests assert the query count drops to one-per-depth-step and that per-node grouping/ordering and the `either` parity are preserved.

## 3. Model-discovery N+1 (`apps/web/lib/inference/ai-provider-internals.ts`)
Both discovery loops (ChatGPT-backend ~L420 and standard ~L487) did `findUnique(providerId_modelId)` + `create`/`update` **per model** — hundreds of rows for OpenRouter. Extracted `upsertDiscoveredModels()`: **one** `findMany` to read existing modelIds → `createMany` for new rows → one `update` per changed existing row. `newCount` and `rawMetadata` semantics are identical (distinct-new count; last-write-wins on an in-batch duplicate, matching the old create-then-update loop). Return values unchanged.

**Anti-findings left untouched** (per the BI): the index-backed per-unique `findUnique` loops (`credentialEntry`, `modelProfile`) and the already-batched EP-INF-002 reconciliation block.

## Tests
- `traversal-executor.test.ts`: added batched-query-count, per-node regrouping, and `either`-direction OR-parity cases. Existing mocks gained the scalar FK fields (`fromElementId`/`toElementId`) that real Prisma `findMany` always returns.
- `ai-provider-internals.test.ts`: new `upsertDiscoveredModels` suite (single batched read, createMany-only-new + count, in-batch-duplicate last-write-wins, empty-list no-op).

## Verification & gates
- **Ran (worktree-local):** Gitleaks staged scan — no leaks. Schema regression guard vs `origin/main` — no regressions (purely additive). `git diff origin/main` on `schema.prisma` is exactly the two `@@index` lines.
- **Unrun, not red — runtime/toolchain-bound (CI / shared local-CI sandbox):** `pnpm --filter web typecheck`, `pnpm --filter web build`, `pnpm --filter web exec vitest run`, and the **migration apply**. This worktree is source-only (no installed deps; `pnpm install` is out of scope), so these could not execute here. The commit's pre-commit typecheck was skipped for the same reason (`DPF_SKIP_TYPECHECK=1`); CI is the backstop.

`Process-Spine-Decision` and the migration call-out are in the commit body. Not UI-impacting (internal MCP tool + discovery logic), so the UX-Fit gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)