### PR TITLE
refactor(perf): request-scoped routing-loader cache (BI-OPT-ROUTING-CACHE)

### DIFF
--- a/apps/web/lib/routing/fallback.test.ts
+++ b/apps/web/lib/routing/fallback.test.ts
@@ -50,6 +50,13 @@ vi.mock("./rate-recovery", () => ({
   scheduleRecovery: vi.fn(),
 }));
 
+// BI-OPT-ROUTING-CACHE: fallback.ts busts the request-scoped routing-loader
+// cache when it degrades a model / cools an endpoint. Mock the loader so we can
+// assert the bust is wired without exercising the real DB-backed loaders.
+vi.mock("./loader", () => ({
+  invalidateRoutingLoaderCache: vi.fn(),
+}));
+
 vi.mock("@/lib/ai-provider-internals", () => ({
   autoDiscoverAndProfile: vi.fn(),
 }));
@@ -71,6 +78,7 @@ import {
   clearEndpointUnavailable,
 } from "./rate-tracker";
 import { scheduleRecovery } from "./rate-recovery";
+import { invalidateRoutingLoaderCache } from "./loader";
 import { autoDiscoverAndProfile } from "@/lib/ai-provider-internals";
 import { recordRouteOutcome } from "./route-outcome";
 import type { RouteDecision } from "./types";
@@ -127,6 +135,7 @@ const mockAutoDiscoverAndProfile = autoDiscoverAndProfile as ReturnType<typeof v
 const mockRecordRouteOutcome = recordRouteOutcome as ReturnType<typeof vi.fn>;
 const mockMarkEndpointUnavailable = markEndpointUnavailable as ReturnType<typeof vi.fn>;
 const mockClearEndpointUnavailable = clearEndpointUnavailable as ReturnType<typeof vi.fn>;
+const mockInvalidateRoutingLoaderCache = invalidateRoutingLoaderCache as ReturnType<typeof vi.fn>;
 
 // ── Setup ────────────────────────────────────────────────────────────────────
 
@@ -196,6 +205,9 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
 
       expect(mockClearEndpointUnavailable).toHaveBeenCalledWith("prov1", "model1");
       expect(mockMarkEndpointUnavailable).not.toHaveBeenCalled();
+      // BI-OPT-ROUTING-CACHE: a clean success must NOT bust the loader cache —
+      // the per-turn memo has to survive an ordinary iteration.
+      expect(mockInvalidateRoutingLoaderCache).not.toHaveBeenCalled();
     });
 
     it("records route outcomes with coworker attribution from the MCP session", async () => {
@@ -317,6 +329,25 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
 
       // Provider NOT updated
       expect(mockPrisma.modelProvider.update).not.toHaveBeenCalled();
+    });
+
+    // BI-OPT-ROUTING-CACHE: degrading a model changes what loadEndpointManifests
+    // returns (manifest status derives from modelStatus), so the request-scoped
+    // loader cache MUST be busted — otherwise the next routing iteration in the
+    // turn would route against a stale "active" manifest.
+    it("invalidates the routing-loader cache when a model is degraded", async () => {
+      throwRateLimit();
+
+      const pending = callWithFallbackChain(
+        makeDecision("prov1", "model1"),
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+      const rejection = expect(pending).rejects.toThrow();
+      await vi.runAllTimersAsync();
+      await rejection;
+
+      expect(mockInvalidateRoutingLoaderCache).toHaveBeenCalled();
     });
 
     it("opens the runtime circuit (markEndpointUnavailable) with reason rate_limit", async () => {

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -17,6 +17,7 @@ import {
   type EndpointUnavailableReason,
 } from "./rate-tracker";
 import { scheduleRecovery } from "./rate-recovery";
+import { invalidateRoutingLoaderCache } from "./loader";
 import { recordRouteOutcome } from "./route-outcome";
 import { autoDiscoverAndProfile } from "@/lib/ai-provider-internals";
 import {
@@ -144,6 +145,11 @@ async function markModelDegraded(
         err,
       ),
     );
+  // The manifest loader derives EndpointManifest.status from modelStatus, so this
+  // degrade changes what loadEndpointManifests would return — drop the request-
+  // scoped loader cache so the next routing iteration sees the degraded status
+  // rather than a stale "active" manifest.
+  invalidateRoutingLoaderCache();
 }
 
 /**
@@ -455,6 +461,11 @@ export async function callWithFallbackChain(
           cooldown.ms,
           e.message,
         );
+        // Bust the request-scoped loader cache on this cooldown mutation too, so
+        // the candidate-pool health change is reflected immediately. (The skip
+        // itself is enforced by routeEndpointV2 reading the live circuit state per
+        // iteration, not by the manifests — this keeps the cached inputs honest.)
+        invalidateRoutingLoaderCache();
 
         // EP-INF-006: Record error outcome (fire-and-forget)
         recordRouteOutcome({

--- a/apps/web/lib/routing/index.ts
+++ b/apps/web/lib/routing/index.ts
@@ -18,6 +18,7 @@ export {
   loadTaskRequirement,
   loadPolicyRules,
   loadOverrides,
+  invalidateRoutingLoaderCache,
   persistRouteDecision,
 } from "./loader";
 export { callWithFallbackChain } from "./fallback";

--- a/apps/web/lib/routing/loader.test.ts
+++ b/apps/web/lib/routing/loader.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { loadEndpointManifests, persistRouteDecision } from "./loader";
+import {
+  loadEndpointManifests,
+  loadOverrides,
+  loadPolicyRules,
+  invalidateRoutingLoaderCache,
+  persistRouteDecision,
+} from "./loader";
 import type { RouteDecision } from "./types";
 import { MODEL_ROUTING_ENDPOINT_TYPES } from "./provider-eligibility";
 
@@ -9,6 +15,12 @@ const { mockPrisma } = vi.hoisted(() => ({
       create: vi.fn().mockResolvedValue({ id: "decision-log-1" }),
     },
     modelProfile: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    policyRule: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    endpointTaskPerformance: {
       findMany: vi.fn().mockResolvedValue([]),
     },
   },
@@ -58,6 +70,7 @@ describe("persistRouteDecision", () => {
 describe("loadEndpointManifests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    invalidateRoutingLoaderCache();
     mockPrisma.modelProfile.findMany.mockResolvedValue([]);
   });
 
@@ -72,6 +85,188 @@ describe("loadEndpointManifests", () => {
           }),
         }),
       }),
+    );
+  });
+});
+
+// ── BI-OPT-ROUTING-CACHE: request/turn-scoped loader cache ───────────────────
+//
+// On the agentic hot path the three loaders are re-run on every loop iteration
+// (up to 200) via prepareRoute, returning identical rows. These tests prove the
+// memo collapses the per-iteration reloads to ONE DB round-trip per turn, that a
+// degrade/cooldown mutation (or TTL expiry) invalidates it, and — critically —
+// that the cached values are byte-identical to a fresh load so routing decisions
+// cannot drift. The `now`/`nowMs` clock is injected so the assertions are
+// deterministic rather than wall-clock dependent.
+describe("routing-loader cache (BI-OPT-ROUTING-CACHE)", () => {
+  // Distinct, non-empty rows so we can assert identity + content parity.
+  const profileRow = {
+    id: "mp-1",
+    providerId: "anthropic",
+    modelId: "claude-sonnet",
+    friendlyName: "Claude Sonnet",
+    modelStatus: "active",
+    profileSource: "seed",
+    profileConfidence: "medium",
+    capabilityOverrides: null,
+    capabilities: null,
+    supportsToolUse: true,
+    maxContextTokens: 200000,
+    maxOutputTokens: 8192,
+    pricing: null,
+    customScores: null,
+    reasoning: 90,
+    codegen: 85,
+    toolFidelity: 80,
+    instructionFollowingScore: 80,
+    structuredOutputScore: 80,
+    conversational: 80,
+    contextRetention: 80,
+    outputPricePerMToken: 15,
+    retiredAt: null,
+    qualityTier: null,
+    modelClass: "chat",
+    modelFamily: "claude",
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    supportedParameters: [],
+    deprecationDate: null,
+    metadataSource: "inferred",
+    metadataConfidence: "low",
+    perRequestLimits: null,
+    provider: {
+      endpointType: "chat",
+      status: "active",
+      sensitivityClearance: ["public", "internal"],
+      supportsToolUse: true,
+      supportsStructuredOutput: true,
+      supportsStreaming: true,
+      maxContextTokens: 200000,
+      maxOutputTokens: 8192,
+      modelRestrictions: [],
+      avgLatencyMs: 1000,
+      recentFailureRate: 0,
+      outputPricePerMToken: 15,
+    },
+  };
+  const policyRow = {
+    id: "pr-1",
+    name: "no-public-to-cloud",
+    description: "demo",
+    condition: { kind: "noop" },
+  };
+  const overrideRow = {
+    endpointId: "anthropic:claude-sonnet",
+    taskType: "code-gen",
+    pinned: true,
+    blocked: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateRoutingLoaderCache();
+    mockPrisma.modelProfile.findMany.mockResolvedValue([profileRow]);
+    mockPrisma.policyRule.findMany.mockResolvedValue([policyRow]);
+    mockPrisma.endpointTaskPerformance.findMany.mockResolvedValue([overrideRow]);
+  });
+
+  it("loads each loader's DB rows exactly once across a 200-iteration turn", async () => {
+    const t0 = 1_000_000;
+    // Simulate the agentic loop calling prepareRoute's loaders every iteration.
+    for (let i = 0; i < 200; i++) {
+      await loadEndpointManifests(t0 + i); // +i ms — same TTL window
+      await loadPolicyRules(t0 + i);
+      await loadOverrides("code-gen", t0 + i);
+    }
+
+    expect(mockPrisma.modelProfile.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.policyRule.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.endpointTaskPerformance.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns values byte-identical to a fresh (uncached) load — decisions cannot drift", async () => {
+    const t0 = 2_000_000;
+    // Fresh load with the cache cold.
+    const freshManifests = await loadEndpointManifests(t0);
+    const freshPolicies = await loadPolicyRules(t0);
+    const freshOverrides = await loadOverrides("code-gen", t0);
+
+    // Cached load later in the same TTL window.
+    const cachedManifests = await loadEndpointManifests(t0 + 100);
+    const cachedPolicies = await loadPolicyRules(t0 + 100);
+    const cachedOverrides = await loadOverrides("code-gen", t0 + 100);
+
+    // Only one DB hit each — second call served from memo.
+    expect(mockPrisma.modelProfile.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.policyRule.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.endpointTaskPerformance.findMany).toHaveBeenCalledTimes(1);
+
+    // Same reference (the memo) AND deep-equal to what a cold load produced.
+    expect(cachedManifests).toBe(freshManifests);
+    expect(cachedPolicies).toBe(freshPolicies);
+    expect(cachedOverrides).toBe(freshOverrides);
+    expect(cachedManifests).toEqual(freshManifests);
+    // The mapped manifest carries the expected shape (sanity that we cached the
+    // transformed rows, not raw Prisma rows).
+    expect(cachedManifests[0]).toMatchObject({
+      id: "mp-1",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      status: "active",
+    });
+  });
+
+  it("reloads after the TTL window elapses", async () => {
+    const t0 = 3_000_000;
+    await loadEndpointManifests(t0);
+    expect(mockPrisma.modelProfile.findMany).toHaveBeenCalledTimes(1);
+
+    // Just inside the window — still served from memo.
+    await loadEndpointManifests(t0 + 29_999);
+    expect(mockPrisma.modelProfile.findMany).toHaveBeenCalledTimes(1);
+
+    // Past the 30s TTL — a fresh DB load.
+    await loadEndpointManifests(t0 + 30_001);
+    expect(mockPrisma.modelProfile.findMany).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidateRoutingLoaderCache forces a reload on the next call (degrade/cooldown hook)", async () => {
+    const t0 = 4_000_000;
+    await loadEndpointManifests(t0);
+    await loadPolicyRules(t0);
+    await loadOverrides("code-gen", t0);
+    expect(mockPrisma.modelProfile.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.policyRule.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.endpointTaskPerformance.findMany).toHaveBeenCalledTimes(1);
+
+    // A degrade/cooldown mutation busts the cache (what markModelDegraded /
+    // markEndpointUnavailable call in fallback.ts).
+    invalidateRoutingLoaderCache();
+
+    // Next call within the same TTL window must hit the DB again — proving a
+    // status change lands on the next routing iteration, not after the TTL.
+    await loadEndpointManifests(t0 + 1);
+    await loadPolicyRules(t0 + 1);
+    await loadOverrides("code-gen", t0 + 1);
+    expect(mockPrisma.modelProfile.findMany).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.policyRule.findMany).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.endpointTaskPerformance.findMany).toHaveBeenCalledTimes(2);
+  });
+
+  it("memoizes overrides per taskType (a process serves many; a turn routes one)", async () => {
+    const t0 = 5_000_000;
+    await loadOverrides("code-gen", t0);
+    await loadOverrides("code-gen", t0 + 1); // same key → memo
+    await loadOverrides("conversation", t0 + 2); // different key → fresh load
+
+    expect(mockPrisma.endpointTaskPerformance.findMany).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.endpointTaskPerformance.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ where: expect.objectContaining({ taskType: "code-gen" }) }),
+    );
+    expect(mockPrisma.endpointTaskPerformance.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ where: expect.objectContaining({ taskType: "conversation" }) }),
     );
   });
 });

--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -12,6 +12,55 @@ import type {
   SensitivityLevel,
 } from "./types";
 
+// ── Request/turn-scoped loader cache ────────────────────────────────────────
+//
+// The three loaders below (loadEndpointManifests, loadPolicyRules, loadOverrides)
+// are re-run on EVERY agentic-loop iteration via prepareRoute (up to 200 times a
+// turn), each time returning identical rows — ~40-60 redundant identical queries
+// on the most latency-sensitive code on the platform. These are loader INPUTS to
+// routing, not the routing DECISION: a short TTL memo collapses the per-iteration
+// reloads to one DB round-trip per turn while routeEndpointV2 still runs every
+// iteration against fresh, process-local circuit-breaker state (markEndpoint
+// Unavailable / getEndpointRuntimeState) — so a cooled-down endpoint is still
+// skipped and a recovered provider still re-selected. Caching the inputs never
+// changes the decision.
+//
+// Mirrors the proven TTL idiom on this same hot path (lib/inference/local-only.ts):
+// a small TTL plus an explicit invalidator that the rare degrade/cooldown
+// mutations call so a status change takes effect on the next iteration rather than
+// waiting out the window. The injectable `now` keeps the behaviour deterministic
+// for tests (no wall-clock flake).
+//
+// TTL sizing: longer than local-only's 5s because a multi-iteration build turn can
+// run for tens of seconds and the goal is one load PER TURN; still bounded so an
+// operator config edit (provider toggled, policy added, endpoint pinned) propagates
+// within the window even absent an explicit bust. Degrade/cooldown mutations bust
+// immediately, so the bound only governs the benign config-edit case.
+const ROUTING_LOADER_TTL_MS = 30_000;
+
+interface LoaderCacheEntry<T> {
+  value: T;
+  at: number;
+}
+
+let manifestsCache: LoaderCacheEntry<EndpointManifest[]> | null = null;
+let policyRulesCache: LoaderCacheEntry<PolicyRuleEval[]> | null = null;
+// Overrides are keyed by taskType — a turn routes one taskType, but a process
+// serves many, so memo per key rather than a single slot.
+const overridesCache = new Map<string, LoaderCacheEntry<EndpointOverride[]>>();
+
+/**
+ * Drop all cached routing-loader inputs. Called by the degrade/cooldown
+ * mutations (markModelDegraded, markEndpointUnavailable) so a candidate-pool
+ * health change is reflected on the very next routing iteration, and exported for
+ * tests. Cheap and idempotent — clearing an already-cold cache is a no-op.
+ */
+export function invalidateRoutingLoaderCache(): void {
+  manifestsCache = null;
+  policyRulesCache = null;
+  overridesCache.clear();
+}
+
 /**
  * Providers that ship with DPF and require no user action to be usable.
  * All other providers are classified as `user_configured` — the user
@@ -94,8 +143,25 @@ export function resolveToolUse(
  * Load all active/degraded endpoints as EndpointManifest objects.
  * Queries ModelProfile joined with ModelProvider — each manifest entry represents
  * a specific model, not just a provider.
+ *
+ * Request/turn-scoped TTL cached (see invalidateRoutingLoaderCache): on the
+ * agentic hot path this is hit once per loop iteration with identical results;
+ * the memo serves the same array for the rest of the turn. Degrade/cooldown
+ * mutations bust the cache so a status change lands on the next iteration. `now`
+ * is injectable for deterministic tests.
  */
-export async function loadEndpointManifests(): Promise<EndpointManifest[]> {
+export async function loadEndpointManifests(
+  now: number = Date.now(),
+): Promise<EndpointManifest[]> {
+  if (manifestsCache && now - manifestsCache.at < ROUTING_LOADER_TTL_MS) {
+    return manifestsCache.value;
+  }
+  const value = await queryEndpointManifests();
+  manifestsCache = { value, at: now };
+  return value;
+}
+
+async function queryEndpointManifests(): Promise<EndpointManifest[]> {
   const profiles = await prisma.modelProfile.findMany({
     where: {
       modelStatus: { in: ["active", "degraded"] },
@@ -195,8 +261,25 @@ export async function loadTaskRequirement(
 
 /**
  * Load active policy rules.
+ *
+ * Request/turn-scoped TTL cached (see invalidateRoutingLoaderCache) — same
+ * per-iteration hot-path memo as loadEndpointManifests. The effectiveFrom/Until
+ * window is evaluated at load time; a rule crossing its boundary mid-window is
+ * served for at most the TTL, acceptable for rarely-edited operator policy.
+ * `nowMs` is injectable for deterministic tests.
  */
-export async function loadPolicyRules(): Promise<PolicyRuleEval[]> {
+export async function loadPolicyRules(
+  nowMs: number = Date.now(),
+): Promise<PolicyRuleEval[]> {
+  if (policyRulesCache && nowMs - policyRulesCache.at < ROUTING_LOADER_TTL_MS) {
+    return policyRulesCache.value;
+  }
+  const value = await queryPolicyRules();
+  policyRulesCache = { value, at: nowMs };
+  return value;
+}
+
+async function queryPolicyRules(): Promise<PolicyRuleEval[]> {
   const now = new Date();
   const rules = await prisma.policyRule.findMany({
     where: {
@@ -218,8 +301,26 @@ export async function loadPolicyRules(): Promise<PolicyRuleEval[]> {
 
 /**
  * Load pinned/blocked overrides for a task type.
+ *
+ * Request/turn-scoped TTL cached per taskType (see invalidateRoutingLoaderCache)
+ * — the per-iteration hot-path memo, keyed because a process serves many task
+ * types while one turn routes a single one. `now` is injectable for deterministic
+ * tests.
  */
-export async function loadOverrides(taskType: string): Promise<EndpointOverride[]> {
+export async function loadOverrides(
+  taskType: string,
+  now: number = Date.now(),
+): Promise<EndpointOverride[]> {
+  const cached = overridesCache.get(taskType);
+  if (cached && now - cached.at < ROUTING_LOADER_TTL_MS) {
+    return cached.value;
+  }
+  const value = await queryOverrides(taskType);
+  overridesCache.set(taskType, { value, at: now });
+  return value;
+}
+
+async function queryOverrides(taskType: string): Promise<EndpointOverride[]> {
   const perf = await prisma.endpointTaskPerformance.findMany({
     where: {
       taskType,


### PR DESCRIPTION
## What

Adds a short request/turn-scoped TTL cache (30s) to the three routing loaders that `prepareRoute` re-runs on **every** agentic-loop iteration (up to 200/turn): `loadEndpointManifests`, `loadPolicyRules`, `loadOverrides`. Mirrors the proven `lib/inference/local-only.ts` idiom already used on this same hot path.

Implements **BI-OPT-ROUTING-CACHE** (EP-PLATFORM-OPTIMIZATION); design authored in `docs/superpowers/specs/2026-06-26-platform-optimization-sweep.md` §4.3 (F-F).

## Why

On the most latency-sensitive code on the platform, a 10-iteration build turn issued **~40–60 redundant identical DB queries** (a `modelProfile.findMany` + 35-field `.map` per model, a policy-rule query, and an overrides query — all returning the same rows every iteration), while sibling loaders (`local-only.ts`, `task-requirements.ts`) already cache. This collapses them to **one DB round-trip per turn**.

## Approach — TTL cache (not a threaded bundle)

Chosen over a threaded `RoutingDataBundle` because the TTL idiom is **already proven on this exact hot path** and requires **zero signature churn** — a bundle would have to be threaded through `prepareRoute` / `previewRoute` / `routeAndCall` / both agentic-loop call sites / `deliberation-run` / `diagnostics-preflight`, a much larger surface and higher parity risk. Caching inside the loaders benefits every caller for free. The BI lists TTL as an explicitly-equal alternative.

- 30s TTL (longer than local-only's 5s because a multi-iteration turn runs for tens of seconds; the goal is *one load per turn*). Bounded so a benign operator config edit still propagates; degrade/cooldown mutations bust immediately.
- Injectable `now`/`nowMs` keeps behaviour deterministic for tests (no wall-clock flake).
- Overrides memo keyed per `taskType` (a process serves many; a turn routes one).

## Parity — decisions are provably unchanged

**Caches the loaded INPUTS, never the DECISION.** `routeEndpointV2` still runs every iteration against fresh, process-local circuit-breaker state (`markEndpointUnavailable` / `getEndpointRuntimeState`) — read inside the pipeline, **not** from the cached manifests — so a cooled-down endpoint is still skipped and a recovered provider still re-selected. The `pipeline-v2` cooldown/recovery **decision** tests (47) remain green.

### Invalidation hooks
Wired into the two degrade/cooldown mutations in `fallback.ts` (the only production callers):
- **`markModelDegraded`** — flips `ModelProfile.modelStatus`, which changes the `EndpointManifest.status` the loader derives → bust so the next iteration sees the degrade.
- **`markEndpointUnavailable`** (cooldown site) — busts on the candidate-pool health change too.

`rate-tracker.ts` is left a pure leaf (no loader/DB coupling).

## Verification

Source-local via the junctioned root toolchain (sibling worktree `platform-consolidation-spec`; junctions removed the safe non-recursive way afterward — root/sibling untouched):

| Suite | Result |
|---|---|
| `loader.test.ts` (+5 new) — once-per-turn across 200 iters; cached == fresh (same ref + deep-equal); reload after TTL; invalidator forces reload; per-taskType memo | **13 pass** |
| `fallback.test.ts` (+2 assertions) — degrade busts cache; clean success does not | **25 pass** |
| `pipeline-v2.test.ts` — decision path incl. cooldown skip | **47 pass** |
| `deliberation-run.test.ts` — other loader consumer (mocked) | **6 pass** |
| `tsc --noEmit` | **0 errors in changed files** (2 unrelated pre-existing `@dpf/db` junction-staleness errors in `remote-action` files) |

**Parity statement:** routing decisions are unchanged. The cache stores only the loader inputs; `routeEndpointV2` runs per iteration on live circuit-breaker state; cached values are byte-identical (same reference *and* deep-equal) to a fresh load; degrade/cooldown events invalidate immediately. Proven by the tests above. **Not partial.**

## Rider — intentionally skipped (noted)

The `getAvailableTools` triple-read dedupe (`agent-coworker.ts:1134/1195/1221`) is **not obviously safe**: the two `getAvailableTools` calls pass **different** `externalAccessEnabled` values (granted-now vs would-be-if-enabled — not redundant), and `getAvailableTools` does not return the `getAgentToolGrantsAsync` result it resolves internally, so deduping would require changing its return contract across all callers. Out of this one concern; left for a separate BI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)