### PR TITLE
refactor(nav): migrate remaining TabNavs onto SectionNav + flat variant + clone ratchet (BI-ARCH-SECTIONNAV)

### DIFF
--- a/apps/web/components/compliance/ComplianceTabNav.tsx
+++ b/apps/web/components/compliance/ComplianceTabNav.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 import { COMPLIANCE_FAMILIES } from "./compliance-nav";
+
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// resolves active state from the pathname. Compliance uses the "tab" style (underline
+// families + a boxed sub-item panel shown only when the active family has sub-items).
 
 export function ComplianceTabNav() {
   const pathname = usePathname();
@@ -16,48 +20,24 @@ export function ComplianceTabNav() {
     href === "/compliance" ? pathname === "/compliance" : pathname.startsWith(href);
 
   return (
-    <div className="mb-6">
-      <div className="flex gap-1 overflow-x-auto border-b border-[var(--dpf-border)]">
-        {COMPLIANCE_FAMILIES.map((family) => {
-          const isActive = activeFamily.href === family.href;
-          return (
-            <Link
-              key={family.href}
-              href={family.href}
-              className={[
-                "whitespace-nowrap rounded-t px-3 py-1.5 text-xs font-medium transition-colors",
-                isActive
-                  ? "border-b-2 border-[var(--dpf-accent)] text-[var(--dpf-text)]"
-                  : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-              ].join(" ")}
-            >
-              {family.label}
-            </Link>
-          );
-        })}
-      </div>
-
-      {activeFamily.subItems.length > 0 && (
-        <div className="rounded-b-xl border border-t-0 border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3">
-          <p className="text-xs text-[var(--dpf-muted)]">{activeFamily.description}</p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {activeFamily.subItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={[
-                  "rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors",
-                  subItemActive(item.href)
-                    ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
-                    : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-                ].join(" ")}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+    <SectionNav
+      config={{
+        variant: "families",
+        style: "tab",
+        dataComponent: "compliance-tab-nav",
+        families: COMPLIANCE_FAMILIES.map((family) => ({
+          key: family.href,
+          label: family.label,
+          href: family.href,
+          active: activeFamily.href === family.href,
+        })),
+        description: activeFamily.description,
+        subItems: activeFamily.subItems.map((item) => ({
+          label: item.label,
+          href: item.href,
+          active: subItemActive(item.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/customer-marketing/MarketingTabNav.tsx
+++ b/apps/web/components/customer-marketing/MarketingTabNav.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 import { MARKETING_TABS } from "./marketing-nav";
+
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// resolves active state from the pathname. Marketing uses the flat "pill" tone in a
+// semantic <nav> element.
 
 export function MarketingTabNav() {
   const pathname = usePathname();
@@ -15,21 +19,19 @@ export function MarketingTabNav() {
   }
 
   return (
-    <nav className="mb-6 flex flex-wrap gap-2 border-b border-[var(--dpf-border)] pb-3">
-      {MARKETING_TABS.map((tab) => (
-        <Link
-          key={tab.href}
-          href={tab.href}
-          className={[
-            "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
-            isActive(tab.href)
-              ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
-              : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-          ].join(" ")}
-        >
-          {tab.label}
-        </Link>
-      ))}
-    </nav>
+    <SectionNav
+      config={{
+        variant: "flat",
+        tone: "pill",
+        as: "nav",
+        dataComponent: "marketing-tab-nav",
+        tabs: MARKETING_TABS.map((tab) => ({
+          key: tab.href,
+          label: tab.label,
+          href: tab.href,
+          active: isActive(tab.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/customer/CustomerTabNav.tsx
+++ b/apps/web/components/customer/CustomerTabNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 
 export type CustomerTabNavItem = {
   label: string;
@@ -11,6 +11,10 @@ export type CustomerTabNavItem = {
 type Props = {
   tabs: CustomerTabNavItem[];
 };
+
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// resolves active state from the pathname. Customer uses the flat single-row tab style
+// and wraps on narrow screens (it can carry many CRM + Marketing tabs).
 
 export function CustomerTabNav({ tabs }: Props) {
   const pathname = usePathname();
@@ -23,21 +27,18 @@ export function CustomerTabNav({ tabs }: Props) {
   if (tabs.length === 0) return null;
 
   return (
-    <div className="mb-6 flex flex-wrap gap-x-1 gap-y-2 border-b border-[var(--dpf-border)]">
-      {tabs.map((t) => (
-        <Link
-          key={t.href}
-          href={t.href}
-          className={[
-            "px-3 py-1.5 text-xs font-medium rounded-t transition-colors",
-            isActive(t.href)
-              ? "text-[var(--dpf-text)] border-b-2 border-[var(--dpf-accent)]"
-              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-          ].join(" ")}
-        >
-          {t.label}
-        </Link>
-      ))}
-    </div>
+    <SectionNav
+      config={{
+        variant: "flat",
+        wrap: true,
+        dataComponent: "customer-tab-nav",
+        tabs: tabs.map((t) => ({
+          key: t.href,
+          label: t.label,
+          href: t.href,
+          active: isActive(t.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/ea/EaTabNav.tsx
+++ b/apps/web/components/ea/EaTabNav.tsx
@@ -1,9 +1,12 @@
 // apps/web/components/ea/EaTabNav.tsx
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 import { EA_TABS } from "./ea-nav";
+
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// resolves active state from the pathname. EA uses the flat single-row tab style.
 
 export function EaTabNav() {
   const pathname = usePathname();
@@ -11,21 +14,17 @@ export function EaTabNav() {
     href === "/ea" ? pathname === "/ea" : pathname.startsWith(href);
 
   return (
-    <div className="flex gap-1 mb-6 border-b border-[var(--dpf-border)]">
-      {EA_TABS.map((t) => (
-        <Link
-          key={t.href}
-          href={t.href}
-          className={[
-            "px-3 py-1.5 text-xs font-medium rounded-t transition-colors",
-            active(t.href)
-              ? "text-[var(--dpf-text)] border-b-2 border-[var(--dpf-accent)]"
-              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-          ].join(" ")}
-        >
-          {t.label}
-        </Link>
-      ))}
-    </div>
+    <SectionNav
+      config={{
+        variant: "flat",
+        dataComponent: "ea-tab-nav",
+        tabs: EA_TABS.map((t) => ({
+          key: t.href,
+          label: t.label,
+          href: t.href,
+          active: active(t.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/employee/EmployeeTabNav.tsx
+++ b/apps/web/components/employee/EmployeeTabNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSearchParams, useRouter } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 
 const TABS = [
   { label: "Directory", value: "directory" },
@@ -12,6 +13,10 @@ const TABS = [
 ] as const;
 
 export type EmployeeTab = (typeof TABS)[number]["value"];
+
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// owns active state and the in-place `?view=` switch. Employee uses the flat tab style
+// in button mode (the tabs switch a query-param view rather than navigating to a route).
 
 export function EmployeeTabNav() {
   const searchParams = useSearchParams();
@@ -30,21 +35,17 @@ export function EmployeeTabNav() {
   }
 
   return (
-    <div className="flex gap-1 mb-6 border-b border-[var(--dpf-border)]">
-      {TABS.map((t) => (
-        <button
-          key={t.value}
-          onClick={() => handleClick(t.value)}
-          className={[
-            "px-3 py-1.5 text-xs font-medium rounded-t transition-colors",
-            currentTab === t.value
-              ? "text-[var(--dpf-text)] border-b-2 border-[var(--dpf-accent)]"
-              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-          ].join(" ")}
-        >
-          {t.label}
-        </button>
-      ))}
-    </div>
+    <SectionNav
+      config={{
+        variant: "flat",
+        dataComponent: "employee-tab-nav",
+        tabs: TABS.map((t) => ({
+          key: t.value,
+          label: t.label,
+          active: currentTab === t.value,
+          onSelect: () => handleClick(t.value),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/platform/AuditTabNav.tsx
+++ b/apps/web/components/platform/AuditTabNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 
 const TABS = [
   { label: "Action Ledger",           href: "/platform/audit/ledger" },
@@ -12,26 +12,25 @@ const TABS = [
   { label: "Operational Metrics",     href: "/platform/audit/metrics" },
 ];
 
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// resolves active state from the pathname. Audit uses the flat single-row tab style.
+
 export function AuditTabNav() {
   const pathname = usePathname();
   const active = (href: string) => pathname.startsWith(href);
 
   return (
-    <div className="flex gap-1 mb-6 border-b border-[var(--dpf-border)]">
-      {TABS.map((t) => (
-        <Link
-          key={t.href}
-          href={t.href}
-          className={[
-            "px-3 py-1.5 text-xs font-medium rounded-t transition-colors",
-            active(t.href)
-              ? "text-[var(--dpf-text)] border-b-2 border-[var(--dpf-accent)]"
-              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-          ].join(" ")}
-        >
-          {t.label}
-        </Link>
-      ))}
-    </div>
+    <SectionNav
+      config={{
+        variant: "flat",
+        dataComponent: "audit-tab-nav",
+        tabs: TABS.map((t) => ({
+          key: t.href,
+          label: t.label,
+          href: t.href,
+          active: active(t.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/platform/WorkforceTabNav.tsx
+++ b/apps/web/components/platform/WorkforceTabNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
 
 const TABS = [
@@ -12,6 +12,9 @@ const TABS = [
   { label: "Skills", href: "/platform/ai/skills" },
 ];
 
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// resolves active state from the pathname. Workforce uses the flat single-row tab style.
+
 export function WorkforceTabNav() {
   const pathname = usePathname();
   const active = (href: string) =>
@@ -20,21 +23,17 @@ export function WorkforceTabNav() {
       : pathname.startsWith(href);
 
   return (
-    <div className="flex gap-1 mb-6 border-b border-[var(--dpf-border)]">
-      {TABS.map((t) => (
-        <Link
-          key={t.href}
-          href={t.href}
-          className={[
-            "px-3 py-1.5 text-xs font-medium rounded-t transition-colors",
-            active(t.href)
-              ? "text-[var(--dpf-text)] border-b-2 border-[var(--dpf-accent)]"
-              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-          ].join(" ")}
-        >
-          {t.label}
-        </Link>
-      ))}
-    </div>
+    <SectionNav
+      config={{
+        variant: "flat",
+        dataComponent: "workforce-tab-nav",
+        tabs: TABS.map((t) => ({
+          key: t.href,
+          label: t.label,
+          href: t.href,
+          active: active(t.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/platform/identity/IdentityTabNav.tsx
+++ b/apps/web/components/platform/identity/IdentityTabNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 
 const TABS = [
   { label: "Overview", href: "/platform/identity" },
@@ -14,27 +14,26 @@ const TABS = [
   { label: "Agents", href: "/platform/identity/agents" },
 ];
 
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// resolves active state from the pathname. Identity uses the flat single-row tab style.
+
 export function IdentityTabNav() {
   const pathname = usePathname();
   const active = (href: string) =>
     href === "/platform/identity" ? pathname === href : pathname.startsWith(href);
 
   return (
-    <div className="mb-6 flex gap-1 border-b border-[var(--dpf-border)]">
-      {TABS.map((tab) => (
-        <Link
-          key={tab.href}
-          href={tab.href}
-          className={[
-            "rounded-t px-3 py-1.5 text-xs font-medium transition-colors",
-            active(tab.href)
-              ? "border-b-2 border-[var(--dpf-accent)] text-[var(--dpf-text)]"
-              : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-          ].join(" ")}
-        >
-          {tab.label}
-        </Link>
-      ))}
-    </div>
+    <SectionNav
+      config={{
+        variant: "flat",
+        dataComponent: "identity-tab-nav",
+        tabs: TABS.map((tab) => ({
+          key: tab.href,
+          label: tab.label,
+          href: tab.href,
+          active: active(tab.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/product/ProductTabNav.tsx
+++ b/apps/web/components/product/ProductTabNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 
 type ProductFamily = {
   label: string;
@@ -9,6 +9,10 @@ type ProductFamily = {
   description: string;
   subItems: Array<{ label: string; href: string }>;
 };
+
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper
+// owns the product-scoped nav data and resolves active state from the pathname. Product
+// uses the "tab" style (underline families + a boxed sub-item panel).
 
 export function ProductTabNav({ productId }: { productId: string }) {
   const pathname = usePathname();
@@ -79,48 +83,24 @@ export function ProductTabNav({ productId }: { productId: string }) {
       : pathname.startsWith(href);
 
   return (
-    <div className="mb-6">
-      <div className="flex gap-1 overflow-x-auto border-b border-[var(--dpf-border)]">
-        {families.map((family) => {
-          const isActive = activeFamily.href === family.href;
-          return (
-            <Link
-              key={family.href}
-              href={family.href}
-              className={[
-                "rounded-t px-3 py-1.5 text-xs font-medium transition-colors whitespace-nowrap",
-                isActive
-                  ? "text-[var(--dpf-text)] border-b-2 border-[var(--dpf-accent)]"
-                  : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-              ].join(" ")}
-            >
-              {family.label}
-            </Link>
-          );
-        })}
-      </div>
-
-      {activeFamily.subItems.length > 0 && (
-        <div className="rounded-b-xl border border-t-0 border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3">
-          <p className="text-xs text-[var(--dpf-muted)]">{activeFamily.description}</p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {activeFamily.subItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={[
-                  "rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors",
-                  isSubItemActive(item.href)
-                    ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
-                    : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-                ].join(" ")}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+    <SectionNav
+      config={{
+        variant: "families",
+        style: "tab",
+        dataComponent: "product-tab-nav",
+        families: families.map((family) => ({
+          key: family.href,
+          label: family.label,
+          href: family.href,
+          active: activeFamily.href === family.href,
+        })),
+        description: activeFamily.description,
+        subItems: activeFamily.subItems.map((item) => ({
+          label: item.label,
+          href: item.href,
+          active: isSubItemActive(item.href),
+        })),
+      }}
+    />
   );
 }

--- a/apps/web/components/shell/SectionNav.tsx
+++ b/apps/web/components/shell/SectionNav.tsx
@@ -1,15 +1,17 @@
 import Link from "next/link";
 import type {
   FamiliesSectionNavConfig,
+  FlatSectionNavConfig,
   GroupedSectionNavConfig,
   SectionNavConfig,
   SectionNavLink,
+  SectionNavTab,
 } from "@/lib/navigation/section-nav-model";
 
 // One renderer for every portal section nav (BI-ARCH-SECTIONNAV). It is pure and
 // presentational: callers resolve active state with their own `usePathname` rules
-// and pass a fully-resolved SectionNavConfig. The three styles below reproduce
-// the exact markup the per-surface *TabNav components used to each carry.
+// and pass a fully-resolved SectionNavConfig. The styles below reproduce the exact
+// markup the per-surface *TabNav components used to each carry.
 //
 // All colors are --dpf-* tokens (AGENTS.md §12). To add a section nav, build a
 // SectionNavConfig from your domain nav data and render <SectionNav> — do not
@@ -18,6 +20,9 @@ import type {
 export function SectionNav({ config }: { config: SectionNavConfig }) {
   if (config.variant === "grouped") {
     return <GroupedNav config={config} />;
+  }
+  if (config.variant === "flat") {
+    return <FlatNav config={config} />;
   }
   return <FamiliesNav config={config} />;
 }
@@ -103,6 +108,64 @@ function GroupedNav({ config }: { config: GroupedSectionNavConfig }) {
   );
 }
 
+function FlatNav({ config }: { config: FlatSectionNavConfig }) {
+  const { tone = "underline", as = "div", wrap = false, tabs, dataComponent } = config;
+  const Root = as === "nav" ? "nav" : "div";
+
+  // Underline default matches EA/Audit/Workforce/Identity (gap-1). `wrap` matches
+  // Customer (flex-wrap gap-x-1 gap-y-2). Pill matches Marketing (a bottom-padded
+  // bordered strip of rounded-full pills). Emphasis matches the Storefront admin
+  // strip (heavier tabs, gap-0).
+  const containerClass =
+    tone === "pill"
+      ? "mb-6 flex flex-wrap gap-2 border-b border-[var(--dpf-border)] pb-3"
+      : tone === "emphasis"
+        ? "mb-6 flex flex-wrap gap-0 border-b border-[var(--dpf-border)]"
+        : wrap
+          ? "mb-6 flex flex-wrap gap-x-1 gap-y-2 border-b border-[var(--dpf-border)]"
+          : "flex gap-1 mb-6 border-b border-[var(--dpf-border)]";
+
+  return (
+    <Root className={containerClass} data-component={dataComponent}>
+      {tabs.map((tab) => {
+        const className = flatTabClass(tone, tab.active);
+        if (tab.href !== undefined) {
+          return (
+            <Link key={tab.key} href={tab.href} className={className}>
+              {tab.label}
+            </Link>
+          );
+        }
+        return (
+          <button key={tab.key} type="button" onClick={tab.onSelect} className={className}>
+            {tab.label}
+          </button>
+        );
+      })}
+    </Root>
+  );
+}
+
+function flatTabClass(tone: "underline" | "pill" | "emphasis", active: boolean): string {
+  if (tone === "pill") {
+    return [
+      "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+      active
+        ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+        : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+    ].join(" ");
+  }
+  if (tone === "emphasis") {
+    return [
+      "whitespace-nowrap px-4 py-2.5 text-[13px] no-underline transition-colors",
+      active
+        ? "border-b-2 border-[var(--dpf-accent)] font-semibold text-[var(--dpf-accent)]"
+        : "border-b-2 border-transparent font-normal text-[var(--dpf-muted)]",
+    ].join(" ");
+  }
+  return tabLinkClass(active);
+}
+
 function familyClass(style: "pill" | "tab", active: boolean): string {
   if (style === "tab") return tabLinkClass(active, "whitespace-nowrap rounded-t px-3 py-1.5 text-xs font-medium");
   return [
@@ -139,4 +202,4 @@ function tabLinkClass(active: boolean, base = "rounded-t px-3 py-1.5 text-xs fon
   ].join(" ");
 }
 
-export type { SectionNavLink };
+export type { SectionNavLink, SectionNavTab };

--- a/apps/web/components/shell/section-nav-ratchet.test.ts
+++ b/apps/web/components/shell/section-nav-ratchet.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Clone ratchet for the canonical section nav (BI-ARCH-SECTIONNAV).
+//
+// Every portal section nav (`*TabNav.tsx`) renders through the one shared
+// `components/shell/SectionNav.tsx` renderer. Before the migration, each surface
+// carried its own copy of the underline-tab markup — a raw `<Link>` (or inline-
+// styled `<a>`) with the `border-b-2 border-[var(--dpf-accent)]` active underline.
+// That duplication is exactly what this BI removed, and a brand-new `*TabNav.tsx`
+// that re-inlines the markup would silently re-fork it.
+//
+// So this guard locks the convergence in: a `*TabNav.tsx` may NOT carry the raw
+// tab chrome itself (the `border-b-2` active underline, a raw `next/link`
+// import, or inline `style={{`). It must build a SectionNavConfig and hand it to
+// <SectionNav>. The shared renderer is the only place tab markup lives.
+
+const WEB_ROOT = join(__dirname, "..", "..");
+const COMPONENTS_ROOT = join(WEB_ROOT, "components");
+
+function tabNavFiles(): string[] {
+  return (readdirSync(COMPONENTS_ROOT, { recursive: true }) as string[])
+    .map((e) => join(COMPONENTS_ROOT, e))
+    .filter((p) => p.endsWith("TabNav.tsx"));
+}
+
+// The active-underline marker every flat/tab clone carried. All tab chrome now
+// lives in SectionNav.tsx, so no wrapper should reference it.
+const RAW_UNDERLINE = /border-b-2/;
+// A wrapper that imports next/link is rendering its own anchors instead of
+// delegating to the shared renderer.
+const RAW_LINK_IMPORT = /from\s+["']next\/link["']/;
+// Inline style objects are both a token-hygiene defect (AGENTS.md §12) and a
+// sign of hand-rolled tab markup (the old StorefrontAdminTabNav).
+const INLINE_STYLE = /style=\{\{/;
+
+describe("section nav clone ratchet (BI-ARCH-SECTIONNAV)", () => {
+  const files = tabNavFiles();
+
+  it("finds the section-nav wrappers (guards against an empty pass)", () => {
+    // 14 *TabNav wrappers exist today; never let this silently drop to zero.
+    expect(files.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("routes every *TabNav through the shared SectionNav (no raw underline-tab markup)", () => {
+    const offenders = files
+      .map((path) => ({ path, src: readFileSync(path, "utf-8") }))
+      .filter(({ src }) => RAW_UNDERLINE.test(src) || RAW_LINK_IMPORT.test(src) || INLINE_STYLE.test(src))
+      .map(({ path }) => path.slice(WEB_ROOT.length + 1).replace(/\\/g, "/"));
+
+    expect(
+      offenders,
+      `These *TabNav components re-inline tab markup instead of rendering through ` +
+        `components/shell/SectionNav.tsx. Build a SectionNavConfig and pass it to ` +
+        `<SectionNav> (add a flat/families/grouped variant if the shape is new):\n` +
+        offenders.map((p) => `  ${p}`).join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
+++ b/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
@@ -1,6 +1,6 @@
 "use client";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { SectionNav } from "@/components/shell/SectionNav";
 import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
 
 type Props = {
@@ -10,6 +10,10 @@ type Props = {
   /** Show the Units tab — only for rental archetypes with a stockable fleet. */
   showUnits?: boolean;
 };
+
+// Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper owns
+// the archetype-aware tab labels and resolves active state from the pathname. Storefront
+// admin uses the flat "emphasis" tone (the heavier storefront-management strip).
 
 export function StorefrontAdminTabNav({ vocabulary, showAnimals = false, showUnits = false }: Props) {
   const path = usePathname();
@@ -25,34 +29,25 @@ export function StorefrontAdminTabNav({ vocabulary, showAnimals = false, showUni
     { label: "Settings", href: "/storefront/settings" },
   ];
 
+  const isActive = (href: string) =>
+    href === "/storefront"
+      ? path === "/storefront"
+      : path === href || path.startsWith(`${href}/`);
+
   return (
-    <nav
-      style={{
-        display: "flex",
-        flexWrap: "wrap",
-        gap: 0,
-        borderBottom: "1px solid var(--dpf-border)",
-        marginBottom: 24,
+    <SectionNav
+      config={{
+        variant: "flat",
+        tone: "emphasis",
+        as: "nav",
+        dataComponent: "storefront-admin-tab-nav",
+        tabs: tabs.map((tab) => ({
+          key: tab.href,
+          label: tab.label,
+          href: tab.href,
+          active: isActive(tab.href),
+        })),
       }}
-    >
-      {tabs.map((tab) => {
-        const active = tab.href === "/storefront"
-          ? path === "/storefront"
-          : path === tab.href || path.startsWith(`${tab.href}/`);
-        return (
-          <Link key={tab.href} href={tab.href} style={{
-            padding: "10px 16px",
-            fontSize: 13,
-            fontWeight: active ? 600 : 400,
-            color: active ? "var(--dpf-accent)" : "var(--dpf-muted)",
-            borderBottom: active ? "2px solid var(--dpf-accent)" : "2px solid transparent",
-            textDecoration: "none",
-            whiteSpace: "nowrap",
-          }}>
-            {tab.label}
-          </Link>
-        );
-      })}
-    </nav>
+    />
   );
 }

--- a/apps/web/lib/navigation/section-nav-model.ts
+++ b/apps/web/lib/navigation/section-nav-model.ts
@@ -17,6 +17,22 @@ export type SectionNavLink = {
   active: boolean;
 };
 
+/**
+ * A single flat tab. Most flat navs link to a route (`href`); a few switch a
+ * query-param view in place (`onSelect`) instead of navigating. Exactly one of
+ * the two is supplied per tab — the renderer emits a `<Link>` for `href` and a
+ * `<button>` for `onSelect`. The caller still owns active-state resolution.
+ */
+export type SectionNavTab = {
+  key: string;
+  label: string;
+  active: boolean;
+  /** Route target — rendered as a `<Link>`. */
+  href?: string;
+  /** In-place selection (e.g. a `?view=` switch) — rendered as a `<button>`. */
+  onSelect?: () => void;
+};
+
 /** A top-level family plus the sub-items shown when it is active. */
 export type SectionNavFamily = {
   key: string;
@@ -60,4 +76,30 @@ export type GroupedSectionNavConfig = {
   groups: SectionNavGroup[];
 };
 
-export type SectionNavConfig = FamiliesSectionNavConfig | GroupedSectionNavConfig;
+/**
+ * Flat-style section nav: a single row of sibling tabs with no sub-item panel.
+ * This is the shape the single-row `*TabNav` clones each carried (EA / Audit /
+ * Workforce / Identity / Customer = underline links, Employee = underline buttons
+ * that switch a `?view=` param, Marketing = pills, Storefront admin = emphasis).
+ *   - tone "underline": `rounded-t` tabs, active = `border-b-2 border-accent`.
+ *   - tone "pill":      `rounded-full` bordered pills, active = surface-2 fill.
+ *   - tone "emphasis":  heavier storefront strip — larger 13px tabs, semibold +
+ *                       accent-coloured active label, transparent-border inactive
+ *                       (constant tab height), gap-0. Storefront admin only.
+ */
+export type FlatSectionNavConfig = {
+  variant: "flat";
+  /** Tab chrome. Defaults to "underline". */
+  tone?: "underline" | "pill" | "emphasis";
+  /** Render the root as a semantic `<nav>` instead of a `<div>` (Marketing/Storefront). */
+  as?: "div" | "nav";
+  /** Allow tabs to wrap onto multiple rows on narrow screens (Customer/Marketing). */
+  wrap?: boolean;
+  dataComponent?: string;
+  tabs: SectionNavTab[];
+};
+
+export type SectionNavConfig =
+  | FamiliesSectionNavConfig
+  | GroupedSectionNavConfig
+  | FlatSectionNavConfig;


### PR DESCRIPTION
## What

Migration tail for the canonical **SectionNav** renderer (BI-ARCH-SECTIONNAV, EP-PLATFORM-CONSOLIDATION). The shared renderer (`components/shell/SectionNav.tsx` + `lib/navigation/section-nav-model.ts`) already backed 4 of 14 `*TabNav` surfaces (Platform / Admin / Finance / Ops, PR #2368). This converges the remaining **10** onto it and locks the convergence with a **clone ratchet**.

## Changes

**1. `flat` variant added to SectionNav** for single-row tab navs, with three tones:
- `underline` — EA / Audit / Workforce / Identity / Customer (`border-b-2` active tab)
- `pill` — Marketing (rounded-full bordered pills in a semantic `<nav>`)
- `emphasis` — Storefront admin (the heavier 13px storefront strip)

Tabs render as `<Link>` for route targets or `<button>` for in-place `?view=` switches (Employee), so the renderer owns the chrome while each caller keeps its navigation mechanism. Labels/nav data stay domain-owned.

**2. All 10 remaining wrappers migrated** to build a `SectionNavConfig` and delegate rendering:

| Component | Variant |
|---|---|
| `EaTabNav` | flat / underline |
| `AuditTabNav` (platform/) | flat / underline |
| `WorkforceTabNav` (platform/) | flat / underline |
| `IdentityTabNav` (platform/identity/) | flat / underline |
| `CustomerTabNav` | flat / underline (wrap) |
| `MarketingTabNav` (customer-marketing/) | flat / pill |
| `EmployeeTabNav` | flat / underline (button mode) |
| `ComplianceTabNav` | families / tab |
| `ProductTabNav` | families / tab |
| `StorefrontAdminTabNav` | flat / emphasis |

**3. `StorefrontAdminTabNav` token hygiene** — dropped the inline `style={{}}` literals for `--dpf-*` className tokens (AGENTS.md §12), reproducing the exact strip pixels via the new `emphasis` tone.

**4. Clone ratchet** (`components/shell/section-nav-ratchet.test.ts`) — asserts no `*TabNav.tsx` under `apps/web/components` carries raw underline-tab markup (a `border-b-2` active underline, a raw `next/link` import, or inline `style={{`). Every section nav must route through SectionNav. This stops the 11th clone.

Net: **+358 / −238** (≈120 LOC removed from the duplicated wrappers; the rest is the new variant + ratchet).

## Parity

Each nav's links, order, active state, and labels render **identically** through the shared renderer. The 12 existing per-nav tests pass **unchanged** (content-assertion based: labels, hrefs, active-class substrings). Two navs were not byte-identical to a plain flat underline strip and were migrated faithfully rather than normalized — see "Parity notes" below.

### Parity notes (flagged, not guessed)
- **Marketing** is pill-shaped (`rounded-full` + `bg-[var(--dpf-surface-2)]` active / `bg-[var(--dpf-surface-1)]` inactive), not an underline strip — migrated onto a faithful `tone: "pill"` in a semantic `<nav>`, preserving exact markup.
- **Employee** uses `<button>` + `useSearchParams` (`?view=` switch), not `<Link>` route navigation — preserved by the flat variant's button mode (`onSelect`); URLs and routing behavior are unchanged. (`type="button"` is now explicit — a correctness nit, no UX change.)
- **Storefront admin** had a deliberately heavier look (13px / semibold / accent-coloured active label / transparent-border inactive / `gap-0`) expressed via inline styles — reproduced pixel-for-pixel by the `emphasis` tone while removing the inline `style={{}}` token-hygiene defect.

## Verification

- **Typecheck**: `tsc --noEmit` (apps/web) — **0 errors** (run against a native install; this worktree is source-only, so the gate ran via a same-commit sibling's toolchain).
- **Unit tests**: `vitest run` on all 13 nav test files (the new ratchet + SectionNav + 11 per-nav suites) — **42 passed**.
- **UX verification** is runtime-bound (live portal) — deferred to CI / screenshots. This is a pure renderer consolidation with no rendered-output change, so the existing per-nav tests are the parity evidence.

Closes the migration-tail continuation of BI-ARCH-SECTIONNAV.

UX-Fit-Decision: No user-facing change. Pure renderer consolidation — the 10 `*TabNav` wrappers now delegate to the shared SectionNav instead of each carrying duplicate tab markup. No new route, tab, form control, or numeric input is added; every nav's links, order, labels, and active state are byte-identical after migration. Progressive disclosure and cognitive load are unchanged (no new choices surfaced to any user). cognitive-load axis: neutral.

Process-Spine-Decision: No new spec/plan required. This is the implementation tail of an existing in-progress BI (BI-ARCH-SECTIONNAV) whose design shipped in PR #2368; this PR consolidates the remaining wrappers onto that already-specified renderer and adds a regression ratchet. The durable-knowledge artifact (the SectionNav contract + its doc comments) is extended in place (`lib/navigation/section-nav-model.ts`, `components/shell/SectionNav.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
