### PR TITLE
feat(scheduling): MCP tools to manage recurring agent tasks (BI-1C44A93A v1)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -2,9 +2,14 @@
 
 import { auth } from "@/lib/auth";
 import { prisma, DATA_MODEL_MIRROR_TASK_ID, SYSML_PROJECTION_TASK_ID } from "@dpf/db";
-import { SCHEDULING_MAP } from "@/lib/operate/scheduled-jobs/scheduling-map";
-import { occupiedTicks, deconflictCron } from "@/lib/operate/scheduled-jobs/scheduling-allocator";
-import { randomUUID } from "crypto";
+import {
+  scheduleAgentTaskFor,
+  getScheduledAgentTasksFor,
+  cancelAgentTaskFor,
+  type ScheduleAgentTaskInput,
+  type ScheduleAgentTaskResult,
+  type ScheduledAgentTaskView,
+} from "@/lib/operate/scheduled-jobs/agent-task-core";
 import { runDataModelMirror } from "@/lib/ea/run-data-model-mirror";
 import { runArchitectureParitySteward } from "@/lib/ea/architecture-parity-steward";
 import { computeNextCronRun, isOneShotCron } from "@/lib/operate/cron-next-run";
@@ -45,136 +50,26 @@ function getRequiredProceduralToolForScheduledTask(taskId: string): {
 
 // ─── Public actions ─────────────────────────────────────────────────────────
 
-export type ScheduleAgentTaskInput = {
-  agentId: string;
-  title: string;
-  prompt: string;
-  routeContext: string;
-  schedule: string; // cron expression
-  timezone?: string;
-};
+// ScheduleAgentTaskInput + result/view types live in agent-task-core.ts
+// (BI-1C44A93A) so the MCP tools share the same logic without the "use server"
+// boundary. These thin wrappers resolve identity from auth() and delegate.
 
-export async function scheduleAgentTask(
-  input: ScheduleAgentTaskInput,
-): Promise<{ success: true; taskId: string; note?: string } | { success: false; error: string }> {
+export async function scheduleAgentTask(input: ScheduleAgentTaskInput): Promise<ScheduleAgentTaskResult> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, error: "Unauthorized" };
-
-  if (input.timezone && input.timezone !== "UTC") {
-    return {
-      success: false,
-      error: "Non-UTC timezones are not yet supported. All schedules run in UTC.",
-    };
-  }
-
-  const taskId = `agent-task-${randomUUID().slice(0, 8)}`;
-  const now = new Date();
-
-  // BI-SCHED-ALLOCATE: de-conflict at creation so a new task does not pile onto
-  // a tick already in use. Occupied ticks = the canonical scheduling map (code
-  // crons + seeded tasks) plus other live agent tasks. Interval cadences pass
-  // through untouched (those are governed by the CI contention guard).
-  const liveTasks = await prisma.scheduledAgentTask.findMany({
-    where: { isActive: true },
-    select: { schedule: true },
-  });
-  const occupied = occupiedTicks([
-    ...SCHEDULING_MAP.map((e) => e.cron),
-    ...liveTasks.map((t) => t.schedule),
-  ]);
-  const { cron: schedule, note } = deconflictCron(input.schedule, occupied);
-
-  const nextRunAt = computeNextCronRun(schedule, now);
-
-  await prisma.scheduledAgentTask.create({
-    data: {
-      taskId,
-      agentId: input.agentId,
-      title: input.title,
-      prompt: input.prompt,
-      routeContext: input.routeContext,
-      schedule,
-      timezone: input.timezone ?? "UTC",
-      ownerUserId: session.user.id,
-      nextRunAt,
-    },
-  });
-
-  // Also register as ScheduledJob so it appears in calendar projections
-  await prisma.scheduledJob.upsert({
-    where: { jobId: taskId },
-    create: {
-      jobId: taskId,
-      name: `Agent: ${input.title}`,
-      schedule,
-      nextRunAt,
-    },
-    update: {
-      name: `Agent: ${input.title}`,
-      schedule,
-      nextRunAt,
-    },
-  });
-
-  return note ? { success: true, taskId, note } : { success: true, taskId };
+  return scheduleAgentTaskFor(session.user.id, input);
 }
 
-export async function cancelAgentTask(
-  taskId: string,
-): Promise<{ success: boolean; error?: string }> {
+export async function cancelAgentTask(taskId: string): Promise<{ success: boolean; error?: string }> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, error: "Unauthorized" };
-
-  await prisma.scheduledAgentTask.update({
-    where: { taskId },
-    data: { isActive: false },
-  });
-
-  await prisma.scheduledJob.update({
-    where: { jobId: taskId },
-    data: { schedule: "disabled" },
-  }).catch(() => {});
-
-  return { success: true };
+  return cancelAgentTaskFor(session.user.id, taskId);
 }
 
-export async function getScheduledAgentTasks(): Promise<
-  Array<{
-    taskId: string;
-    agentId: string;
-    title: string;
-    prompt: string;
-    schedule: string;
-    isActive: boolean;
-    nextRunAt: string | null;
-    lastRunAt: string | null;
-    lastStatus: string | null;
-  }>
-> {
+export async function getScheduledAgentTasks(): Promise<ScheduledAgentTaskView[]> {
   const session = await auth();
   if (!session?.user?.id) return [];
-
-  const tasks = await prisma.scheduledAgentTask.findMany({
-    where: { ownerUserId: session.user.id },
-    orderBy: { createdAt: "desc" },
-    select: {
-      taskId: true,
-      agentId: true,
-      title: true,
-      prompt: true,
-      schedule: true,
-      isActive: true,
-      nextRunAt: true,
-      lastRunAt: true,
-      lastStatus: true,
-    },
-  });
-
-  return tasks.map((t) => ({
-    ...t,
-    nextRunAt: t.nextRunAt?.toISOString() ?? null,
-    lastRunAt: t.lastRunAt?.toISOString() ?? null,
-  }));
+  return getScheduledAgentTasksFor(session.user.id);
 }
 
 // ─── Execution (called by Inngest dispatcher) ───────────────────────────────

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2552,6 +2552,46 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "create_scheduled_agent_task",
+    description: "Create a recurring agent task that runs in the coordination plane (TaskRun/thread/tools/evidence) on a 5-field UTC cron. Owned by the calling user; the supported way for an agent to schedule recurring work instead of a client-local cron.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agentId: { type: "string", description: "Coworker agent id that runs the task (e.g. AGT-... or a role id like platform-engineer)." },
+        title: { type: "string", description: "Short human title for the task." },
+        prompt: { type: "string", description: "The instruction the agent runs each tick." },
+        schedule: { type: "string", description: "5-field cron expression in UTC, e.g. '0 9 1 * *' = 1st of each month at 09:00 UTC." },
+        routeContext: { type: "string", description: "Route context the task runs under (optional, default /platform)." },
+      },
+      required: ["agentId", "title", "prompt", "schedule"],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "list_scheduled_agent_tasks",
+    description: "List the recurring agent tasks owned by the calling user (id, title, schedule, active state, next/last run, last status).",
+    inputSchema: { type: "object", properties: {}, required: [] },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "cancel_scheduled_agent_task",
+    description: "Deactivate a recurring agent task by id. Only the owning user may cancel it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        taskId: { type: "string", description: "The scheduled agent task id (agent-task-xxxxxxxx)." },
+      },
+      required: ["taskId"],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
     name: "get_release_status",
     description: "Get the current status of a release bundle or promotion, including deployment window availability and gate check results.",
     inputSchema: {
@@ -14189,6 +14229,40 @@ export async function executeTool(
           findings: findings.slice(0, 50),
         },
       };
+    }
+
+    case "create_scheduled_agent_task": {
+      const { scheduleAgentTaskFor } = await import("@/lib/operate/scheduled-jobs/agent-task-core");
+      const result = await scheduleAgentTaskFor(userId, {
+        agentId: String(params.agentId ?? ""),
+        title: String(params.title ?? ""),
+        prompt: String(params.prompt ?? ""),
+        routeContext: typeof params.routeContext === "string" ? params.routeContext : "/platform",
+        schedule: String(params.schedule ?? ""),
+        timezone: typeof params.timezone === "string" ? params.timezone : undefined,
+      });
+      return result.success
+        ? { success: true, entityId: result.taskId, message: `Scheduled agent task ${result.taskId} created${result.note ? ` (${result.note})` : ""}.` }
+        : { success: false, error: result.error, message: result.error };
+    }
+
+    case "list_scheduled_agent_tasks": {
+      const { getScheduledAgentTasksFor } = await import("@/lib/operate/scheduled-jobs/agent-task-core");
+      const tasks = await getScheduledAgentTasksFor(userId);
+      // Bound each prompt so a few long tasks can't blow the local context window
+      // (the MCP-route result cap is the backstop).
+      const compact = tasks.map((t) => ({ ...t, prompt: t.prompt.length > 200 ? `${t.prompt.slice(0, 200)}…` : t.prompt }));
+      return { success: true, message: `${tasks.length} scheduled agent task(s).`, data: { tasks: compact } };
+    }
+
+    case "cancel_scheduled_agent_task": {
+      const { cancelAgentTaskFor } = await import("@/lib/operate/scheduled-jobs/agent-task-core");
+      const taskId = String(params.taskId ?? "");
+      if (!taskId) return { success: false, error: "taskId is required.", message: "Provide a scheduled agent task id." };
+      const result = await cancelAgentTaskFor(userId, taskId);
+      return result.success
+        ? { success: true, entityId: taskId, message: `Scheduled agent task ${taskId} cancelled.` }
+        : { success: false, error: result.error, message: result.error ?? "Cancel failed." };
     }
 
     case "summarize_estate_posture": {

--- a/apps/web/lib/operate/scheduled-jobs/agent-task-core.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/agent-task-core.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    scheduledAgentTask: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+      create: vi.fn().mockResolvedValue({}),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    scheduledJob: {
+      upsert: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+// Imported after the mock so the module picks up the mocked prisma. The cron /
+// allocator helpers it imports are pure (no DB), so they run for real.
+import { scheduleAgentTaskFor, getScheduledAgentTasksFor, cancelAgentTaskFor } from "./agent-task-core";
+
+const baseInput = { agentId: "a", title: "t", prompt: "p", routeContext: "/x", schedule: "0 9 1 * *" };
+
+describe("scheduleAgentTaskFor", () => {
+  it("rejects a non-UTC timezone before writing anything", async () => {
+    const { prisma } = await import("@dpf/db");
+    const create = prisma.scheduledAgentTask.create as ReturnType<typeof vi.fn>;
+    create.mockClear();
+
+    const r = await scheduleAgentTaskFor("u1", { ...baseInput, timezone: "America/New_York" });
+
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/Non-UTC/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("creates a task owned by the calling user", async () => {
+    const { prisma } = await import("@dpf/db");
+    const create = prisma.scheduledAgentTask.create as ReturnType<typeof vi.fn>;
+    (prisma.scheduledAgentTask.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    create.mockClear();
+
+    const r = await scheduleAgentTaskFor("u1", baseInput);
+
+    expect(r.success).toBe(true);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ ownerUserId: "u1" }) }),
+    );
+  });
+});
+
+describe("cancelAgentTaskFor", () => {
+  it("refuses to cancel a task owned by another user", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({ ownerUserId: "owner" });
+    const update = prisma.scheduledAgentTask.update as ReturnType<typeof vi.fn>;
+    update.mockClear();
+
+    const r = await cancelAgentTaskFor("intruder", "agent-task-1");
+
+    expect(r.success).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("returns not-found for a missing task", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const r = await cancelAgentTaskFor("u1", "nope");
+
+    expect(r.success).toBe(false);
+  });
+
+  it("cancels a task the caller owns", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({ ownerUserId: "u1" });
+    const update = prisma.scheduledAgentTask.update as ReturnType<typeof vi.fn>;
+    update.mockClear();
+
+    const r = await cancelAgentTaskFor("u1", "agent-task-1");
+
+    expect(r.success).toBe(true);
+    expect(update).toHaveBeenCalledWith({ where: { taskId: "agent-task-1" }, data: { isActive: false } });
+  });
+});
+
+describe("getScheduledAgentTasksFor", () => {
+  it("filters by owner and ISO-formats the run timestamps", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.scheduledAgentTask.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        taskId: "agent-task-1",
+        agentId: "a",
+        title: "t",
+        prompt: "p",
+        schedule: "0 9 * * *",
+        isActive: true,
+        nextRunAt: new Date("2026-07-01T09:00:00.000Z"),
+        lastRunAt: null,
+        lastStatus: null,
+      },
+    ]);
+
+    const r = await getScheduledAgentTasksFor("u1");
+
+    expect(r).toHaveLength(1);
+    expect(r[0]!.nextRunAt).toBe("2026-07-01T09:00:00.000Z");
+    expect(prisma.scheduledAgentTask.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { ownerUserId: "u1" } }),
+    );
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/agent-task-core.ts
+++ b/apps/web/lib/operate/scheduled-jobs/agent-task-core.ts
@@ -1,0 +1,156 @@
+// Scheduled-agent-task management core (BI-1C44A93A).
+//
+// The create / list / cancel logic for recurring agent tasks lives here,
+// EXPLICITLY userId-parameterized and NOT marked "use server", so it can be
+// shared by two callers with different identity sources without either letting a
+// caller spoof a user:
+//   - the web server actions (apps/web/lib/actions/agent-task-scheduler.ts)
+//     resolve userId from auth() and delegate here;
+//   - the MCP tools (apps/web/lib/mcp-tools.ts) pass the MCP-authenticated
+//     userId (the tool layer already gated scope + grants).
+// A "use server" file exports only client-callable actions, so a userId
+// parameter there would be client-spoofable — hence this separate core.
+
+import { prisma } from "@dpf/db";
+import { randomUUID } from "crypto";
+import { SCHEDULING_MAP } from "@/lib/operate/scheduled-jobs/scheduling-map";
+import { occupiedTicks, deconflictCron } from "@/lib/operate/scheduled-jobs/scheduling-allocator";
+import { computeNextCronRun } from "@/lib/operate/cron-next-run";
+
+export type ScheduleAgentTaskInput = {
+  agentId: string;
+  title: string;
+  prompt: string;
+  routeContext: string;
+  /** Cron expression (5-field). */
+  schedule: string;
+  timezone?: string;
+};
+
+export type ScheduleAgentTaskResult =
+  | { success: true; taskId: string; note?: string }
+  | { success: false; error: string };
+
+export type ScheduledAgentTaskView = {
+  taskId: string;
+  agentId: string;
+  title: string;
+  prompt: string;
+  schedule: string;
+  isActive: boolean;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  lastStatus: string | null;
+};
+
+/**
+ * Create a recurring agent task owned by `userId`. De-conflicts the cron tick at
+ * creation (BI-SCHED-ALLOCATE) and registers a mirror ScheduledJob row so the
+ * task shows up in calendar projections. Caller is responsible for authorizing
+ * `userId` (auth() in the web action; scope+grant gate in the MCP tool).
+ */
+export async function scheduleAgentTaskFor(
+  userId: string,
+  input: ScheduleAgentTaskInput,
+): Promise<ScheduleAgentTaskResult> {
+  if (input.timezone && input.timezone !== "UTC") {
+    return {
+      success: false,
+      error: "Non-UTC timezones are not yet supported. All schedules run in UTC.",
+    };
+  }
+
+  const taskId = `agent-task-${randomUUID().slice(0, 8)}`;
+  const now = new Date();
+
+  // De-conflict at creation so a new task does not pile onto a tick already in
+  // use (canonical scheduling map + other live agent tasks). Interval cadences
+  // pass through untouched.
+  const liveTasks = await prisma.scheduledAgentTask.findMany({
+    where: { isActive: true },
+    select: { schedule: true },
+  });
+  const occupied = occupiedTicks([
+    ...SCHEDULING_MAP.map((e) => e.cron),
+    ...liveTasks.map((t) => t.schedule),
+  ]);
+  const { cron: schedule, note } = deconflictCron(input.schedule, occupied);
+
+  const nextRunAt = computeNextCronRun(schedule, now);
+
+  await prisma.scheduledAgentTask.create({
+    data: {
+      taskId,
+      agentId: input.agentId,
+      title: input.title,
+      prompt: input.prompt,
+      routeContext: input.routeContext,
+      schedule,
+      timezone: input.timezone ?? "UTC",
+      ownerUserId: userId,
+      nextRunAt,
+    },
+  });
+
+  // Mirror as a ScheduledJob so it appears in calendar projections.
+  await prisma.scheduledJob.upsert({
+    where: { jobId: taskId },
+    create: { jobId: taskId, name: `Agent: ${input.title}`, schedule, nextRunAt },
+    update: { name: `Agent: ${input.title}`, schedule, nextRunAt },
+  });
+
+  return note ? { success: true, taskId, note } : { success: true, taskId };
+}
+
+/** List the recurring agent tasks owned by `userId`, newest first. */
+export async function getScheduledAgentTasksFor(userId: string): Promise<ScheduledAgentTaskView[]> {
+  const tasks = await prisma.scheduledAgentTask.findMany({
+    where: { ownerUserId: userId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      taskId: true,
+      agentId: true,
+      title: true,
+      prompt: true,
+      schedule: true,
+      isActive: true,
+      nextRunAt: true,
+      lastRunAt: true,
+      lastStatus: true,
+    },
+  });
+
+  return tasks.map((t) => ({
+    ...t,
+    nextRunAt: t.nextRunAt?.toISOString() ?? null,
+    lastRunAt: t.lastRunAt?.toISOString() ?? null,
+  }));
+}
+
+/**
+ * Deactivate a recurring agent task. Ownership-checked: only the owning `userId`
+ * may cancel it (so an MCP caller cannot cancel another user's task by id).
+ */
+export async function cancelAgentTaskFor(
+  userId: string,
+  taskId: string,
+): Promise<{ success: boolean; error?: string }> {
+  const task = await prisma.scheduledAgentTask.findUnique({
+    where: { taskId },
+    select: { ownerUserId: true },
+  });
+  if (!task) return { success: false, error: "Scheduled agent task not found" };
+  if (task.ownerUserId !== userId) {
+    return { success: false, error: "Not authorized to cancel this scheduled agent task" };
+  }
+
+  await prisma.scheduledAgentTask.update({
+    where: { taskId },
+    data: { isActive: false },
+  });
+  await prisma.scheduledJob
+    .update({ where: { jobId: taskId }, data: { schedule: "disabled" } })
+    .catch(() => {});
+
+  return { success: true };
+}

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -185,6 +185,13 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   release_nonprod_environment_lease: ["work_capsule_write"],
   renew_nonprod_environment_lease: ["work_capsule_write"],
 
+  // Scheduled agent tasks — recurring coordination-plane work. Reuse the
+  // coordination read/write grants (scheduling is coordination work) so MCP and
+  // portal share one rule set; satisfies the routing-audit INV-1 mapping.
+  create_scheduled_agent_task: ["work_capsule_write"],
+  cancel_scheduled_agent_task: ["work_capsule_write"],
+  list_scheduled_agent_tasks: ["work_capsule_read"],
+
   // Backlog triage and Build Studio promotion (spec 2026-04-21)
   // These were defined in PLATFORM_TOOLS but missing here, so every call was
   // denied by the default-deny rule below. That broke the entire backlog →

--- a/docs/superpowers/plans/2026-06-26-mcp-schedule-agent-tasks-plan.md
+++ b/docs/superpowers/plans/2026-06-26-mcp-schedule-agent-tasks-plan.md
@@ -1,0 +1,46 @@
+# Plan — MCP interface for scheduled agent tasks (BI-1C44A93A, v1)
+
+**Status:** in progress (external Claude Code build, 2026-06-26)
+**Backlog:** BI-1C44A93A (EP-PROACTIVE-OPS) — "MCP interface to manage schedules; today portal-server-action only."
+
+## Problem
+
+DPF's recurring-agent-task substrate (`scheduledAgentTask` + `scheduleAgentTask()` / `getScheduledAgentTasks()` / `cancelAgentTask()` in `apps/web/lib/actions/agent-task-scheduler.ts`) is reachable **only** through portal server actions. An MCP-driven agent (Claude Code / Codex / Grok / in-portal coworker) cannot create / list / cancel recurring tasks through MCP — which forced a Claude-Code client-local cron workaround (a defect under `mcp-is-the-coordination-plane`).
+
+## Design
+
+### Auth safety (the load-bearing decision)
+The existing functions are `"use server"` actions that resolve identity via `auth()` (web session). Adding an optional `userId` override to a server action would let a client **spoof another user** across the action boundary. Instead, extract the logic into a **non-`"use server"` core** — `apps/web/lib/operate/scheduled-jobs/agent-task-core.ts` — with explicitly `userId`-parameterized functions:
+- `scheduleAgentTaskFor(userId, input)`
+- `getScheduledAgentTasksFor(userId)`
+- `cancelAgentTaskFor(userId, taskId)` — ownership-checked (only the owner may cancel).
+
+Both callers delegate to the core with a *trusted* userId:
+- web actions (`agent-task-scheduler.ts`) → `auth()` → core;
+- MCP tools (`mcp-tools.ts`) → MCP-authenticated userId (the tool layer already gated scope + grant).
+
+### v1 scope — the agent-task trio
+Closes the founder-flagged gap (create a recurring scan via MCP):
+- `create_scheduled_agent_task` (side-effecting → **write** scope)
+- `list_scheduled_agent_tasks` (read-only → **read** scope)
+- `cancel_scheduled_agent_task` (side-effecting → **write** scope)
+
+The ScheduledJob admin tools (`list/update/enable/run_scheduled_job`) — managing platform crons, which require `manage_platform` + core-locked rules — are a **follow-up slice** (separate PR), to keep this change bounded and the auth surface small.
+
+### Grants
+Reuse existing grants for v1 to avoid a new grant category + seed/role churn:
+- `create_scheduled_agent_task`, `cancel_scheduled_agent_task` → `["work_capsule_write"]`
+- `list_scheduled_agent_tasks` → `["work_capsule_read"]`
+
+Scheduling a recurring agent task is coordination-plane work, so the work-capsule grants are a semantically reasonable fit and satisfy the routing-audit INV-1 (every PLATFORM_TOOLS entry needs a TOOL_TO_GRANTS mapping). A dedicated `schedule_manage` category (per the BI) can follow if tighter separation is wanted.
+
+### Authority / scope
+All three are **userId-scoped**: tasks are owned by the caller; list returns the caller's tasks; cancel is ownership-checked. No platform-wide authority is taken in v1.
+
+### Out of scope (follow-ups)
+- ScheduledJob admin MCP tools (platform crons; `manage_platform`).
+- A dedicated `schedule_manage` grant category.
+- Non-UTC timezone support (the existing UTC-only limitation is retained; tracked separately).
+
+## Tests
+Unit-test the core's pure-ish guarantees (UTC rejection, ownership check on cancel) against a mocked prisma, mirroring the existing scheduled-jobs test style.


### PR DESCRIPTION
Implements **BI-1C44A93A** (v1) as an external Claude Code build per AGENTS.md §17 — closes the founder-flagged gap where MCP agents couldn't manage schedules (which forced a client-local cron workaround, a defect under `mcp-is-the-coordination-plane`).

## What
MCP tools to create / list / cancel **recurring agent tasks**: `create_scheduled_agent_task`, `list_scheduled_agent_tasks`, `cancel_scheduled_agent_task`.

## How (auth-safe)
The schedule functions were `"use server"` actions authenticating via `auth()` — no `userId` param. Wrapping them in MCP safely required extracting a **non-action core** (`agent-task-core.ts`) with explicit `userId` params, so neither caller can spoof identity:
- web actions → `auth()` → core;
- MCP tools → MCP-authenticated `userId` → core.

The server actions become thin wrappers; behavior is unchanged for the existing Calendar UI (only `scheduleAgentTask` is imported externally).

## Scope / safety
- `view_operations` capability; create/cancel are side-effecting → **write** scope; **userId-scoped**; cancel is **ownership-checked**.
- Grants reuse `work_capsule_write/read` (scheduling = coordination work) → satisfies routing-audit INV-1.
- List result bounds each task's prompt; tool descriptions are provenance-free (hygiene guard).
- Unit tests cover the UTC-rejection + cancel-ownership guards, create-ownership, and the list filter.

## Follow-ups (in the plan)
ScheduledJob admin MCP tools (platform crons), a dedicated `schedule_manage` grant, and non-UTC timezone support. Plan: `docs/superpowers/plans/2026-06-26-mcp-schedule-agent-tasks-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)