### PR TITLE
fix(marketing): route-aware fabrication guard so the coworker keeps advice instead of build copy

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -10,6 +10,8 @@ import {
   phaseRequiresToolCall,
   detectUnsavedEvidence,
   enrichToolDescriptions,
+  buildUnsavedAdviceNote,
+  HARD_COMPLETION_CLAIM_PATTERN,
 } from "./agentic-loop";
 
 vi.mock("@dpf/db", () => ({
@@ -1585,6 +1587,128 @@ describe("runAgenticLoop", () => {
     // The original guard is unchanged for healthy providers.
     expect(result.content).not.toContain("deployed the feature");
     expect(result.content.toLowerCase()).toContain("wasn't recorded");
+  });
+
+  // ─── Conversational-route fabrication: keep the advice, don't nuke it ──────
+  // The fabrication guard exists to stop a BUILD agent from falsely claiming it
+  // shipped code. On an advisory chat (the marketing strategist is the one
+  // advise-mode route that still carries authoritative artifact tools) the same
+  // signal fires on genuinely useful advice that merely forgot to persist.
+  // Replacing it with build copy ("open the build details") is the bug the user
+  // reported. These cases lock in: keep the advice, use domain-appropriate
+  // copy, and correct only a hard, unbacked completion claim.
+  const marketingTools = {
+    tools: [
+      { name: "save_marketing_review", description: "Save a marketing recommendation", inputSchema: {}, requiredCapability: null, executionMode: "immediate" as const, sideEffect: true, coworkerArtifact: true },
+    ],
+    toolsForProvider: [
+      { type: "function", function: { name: "save_marketing_review", description: "Save a marketing recommendation", parameters: {} } },
+    ],
+  };
+
+  it("keeps marketing advice (narration, no tool call) instead of showing build copy", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    // Every dispatch narrates intent without calling the persist tool.
+    mockRoute.mockResolvedValue(mockResult({
+      content: "Here's your owner-operator segment profile: trades owners on Facebook groups. Let me create the campaign brief for you now.",
+      downgraded: false,
+    }));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/customer/marketing",
+      agentId: "marketing-specialist",
+      ...marketingTools,
+    });
+
+    // Advice is preserved; build copy is gone.
+    expect(result.content).toContain("owner-operator segment profile");
+    expect(result.content.toLowerCase()).not.toContain("wasn't recorded");
+    expect(result.content.toLowerCase()).not.toContain("build details");
+    // Plain narration (no hard completion claim) gets no correction note.
+    expect(result.content).not.toContain("haven't saved this to your marketing workspace");
+  });
+
+  it("keeps marketing advice but appends an honest note on a hard, unbacked completion claim", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockResolvedValue(mockResult({
+      content: "Done — I've saved your campaign brief and it's now in your approval queue.",
+      downgraded: false,
+    }));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/customer/marketing",
+      agentId: "marketing-specialist",
+      ...marketingTools,
+    });
+
+    // The model's text is kept...
+    expect(result.content).toContain("campaign brief");
+    // ...with an honest correction so the user is not misled, and NO build copy.
+    expect(result.content).toContain("haven't saved this to your marketing workspace");
+    expect(result.content.toLowerCase()).not.toContain("build details");
+  });
+
+  it("nudges the marketing coworker to persist (domain copy, not build/code copy)", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockResolvedValue(mockResult({
+      content: "Let me create the campaign brief for you now.",
+      downgraded: false,
+    }));
+
+    await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/customer/marketing",
+      agentId: "marketing-specialist",
+      ...marketingTools,
+    });
+
+    // Second dispatch carries the recovery nudge as the last user message.
+    const secondCallMessages = mockRoute.mock.calls[1]?.[0] ?? [];
+    const lastUserMessage = [...secondCallMessages].reverse().find((m: any) => m.role === "user");
+    expect(lastUserMessage?.content).toContain("save_marketing_review");
+    expect(lastUserMessage?.content).not.toContain("Do NOT show code");
+  });
+});
+
+describe("buildUnsavedAdviceNote", () => {
+  it("uses marketing-specific copy on the marketing route", () => {
+    const note = buildUnsavedAdviceNote("/customer/marketing");
+    expect(note).toContain("marketing workspace");
+    expect(note.toLowerCase()).not.toContain("build details");
+  });
+
+  it("uses generic workspace copy off the marketing route and never mentions builds", () => {
+    const note = buildUnsavedAdviceNote("/platform/estate");
+    expect(note.toLowerCase()).not.toContain("build details");
+    expect(note.toLowerCase()).toContain("workspace");
+  });
+});
+
+describe("HARD_COMPLETION_CLAIM_PATTERN", () => {
+  it("matches first-person persistence/publish claims that would mislead", () => {
+    for (const claim of [
+      "I've saved your campaign brief.",
+      "Done — I saved that for you.",
+      "Your post is now live on LinkedIn.",
+      "I've added it to your approval queue.",
+      "The email has been sent.",
+      "It's now in your approval queue.",
+    ]) {
+      expect(HARD_COMPLETION_CLAIM_PATTERN.test(claim)).toBe(true);
+    }
+  });
+
+  it("does not match intent/narration or plain advice", () => {
+    for (const text of [
+      "Let me draft the campaign brief for you now.",
+      "Here's your owner-operator segment profile.",
+      "I'll create the campaign brief next.",
+      "I recommend a weekly LinkedIn cadence targeting trades owners.",
+    ]) {
+      expect(HARD_COMPLETION_CLAIM_PATTERN.test(text)).toBe(false);
+    }
   });
 });
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -69,6 +69,18 @@ const MAX_TEXT_MESSAGE_CHARS = 4_000;
 const COMPLETION_CLAIM_PATTERN =
   /\b(built|deployed|shipped|created|implemented|saved|configured|tested|fixed|completed|installed|launched|starting up|initializing|applying|generating)\b|tests?\s+pass|plan(?:ning)?\s+(?:is\s+done|ready)|building\s+now|start\s+implementation/i;
 
+// HARD completion claim: a first-person assertion that tool-backed work was
+// actually persisted, published, sent, or scheduled — the kind of claim that
+// MISLEADS a user if no tool ran ("I've saved your campaign brief", "it's now
+// live", "added it to your approval queue"). This is narrower than
+// COMPLETION_CLAIM_PATTERN (which also catches generic narration like
+// "generating" / "applying"). On a conversational coworker route we never
+// discard the model's advice over a fabrication signal, but when the reply
+// makes one of THESE claims without a backing tool call we append an honest
+// "not saved yet" note so the user is not misled. See buildUnsavedAdviceNote.
+export const HARD_COMPLETION_CLAIM_PATTERN =
+  /\bI(?:'ve| have| just)?\s*(?:have\s+)?(?:saved|created|published|posted|sent|scheduled|recorded|queued|logged|added|drafted and saved|placed)\b|\b(?:saved|published|posted|sent|scheduled|queued|added|recorded)\s+(?:it|that|your|the)\b|\b(?:is|are|has been|have been)\s+(?:now\s+)?(?:live|saved|published|sent|scheduled|posted|queued|recorded)\b|in\s+(?:your\s+)?approval\s+queue/i;
+
 /**
  * Build a plain-language, non-technical explanation when an agent turn fails
  * because routing could not complete a tool-using call (BI-23E0714C).
@@ -403,6 +415,7 @@ function buildFabricationRecoveryNudge(params: {
   response: string;
   tools: ToolDefinition[];
   executedTools: Array<{ name: string }>;
+  routeContext?: string | null;
 }): string {
   const availableToolNames = new Set(params.tools.map((tool) => tool.name));
   const looksLikePlanReady =
@@ -416,13 +429,57 @@ function buildFabricationRecoveryNudge(params: {
     return 'STOP. Do not say the plan is ready yet. First call saveBuildEvidence with field "buildPlan" and a valid value containing top-level "fileStructure" and "tasks" arrays. Then call reviewBuildPlan. Only after those tool calls succeed may you say Start Implementation is the next approval.';
   }
 
+  // Conversational coworker routes are advisory chats, not code-build sessions.
+  // The build copy ("Do NOT show code to the user") is meaningless there and the
+  // value is the advice itself. Nudge the model to PERSIST the concrete
+  // recommendation with its own artifact tool, while keeping the advice it
+  // already gave — do not tell it to suppress its answer.
+  if (!BUILD_ROUTE_PATTERN.test(params.routeContext ?? "")) {
+    const routeContext = params.routeContext ?? "";
+    if (routeContext.startsWith("/customer/marketing")) {
+      const persistTool = ["save_marketing_review", "create_marketing_campaign_brief", "create_marketing_asset_task"]
+        .find((toolName) => availableToolNames.has(toolName));
+      if (persistTool) {
+        return `You gave a concrete marketing recommendation but did not record it. Keep that recommendation, and now call ${persistTool} to persist it so it shows on the page. Do not restate the diagnosis — advance the work. Only after the tool result confirms the save may you tell the user it was saved.`;
+      }
+    }
+    const sideEffectTool = params.tools.find((tool) => tool.sideEffect)?.name;
+    if (sideEffectTool) {
+      return `You described an action or outcome but did not actually perform it. Keep your advice, but if you are recording or changing something, call ${sideEffectTool} now and only claim it is done after the tool result confirms it.`;
+    }
+    // No action tool to call — the reply is ordinary advice; ask the model to
+    // simply give its answer directly without claiming work it cannot perform.
+    return "Give your answer directly as advice. Do not claim you saved, created, sent, or scheduled anything — you have no tool to do so on this page.";
+  }
+
   return `STOP. You described code or claimed actions without using tools. Do NOT show code to the user. ${getPhaseSpecificNudge(params.executedTools)} Call a tool NOW.`;
+}
+
+/**
+ * Honest, conversational note appended to a coworker's advice when it made a
+ * hard completion claim ("I've saved that") that no tool actually backed. We
+ * keep the advice (it's the value) but correct the misleading claim WITHOUT the
+ * build-oriented copy ("open the build details") that is nonsensical on a chat
+ * route. Respects IDENTITY_BLOCK rule #5 — no tool names or internals exposed.
+ */
+export function buildUnsavedAdviceNote(routeContext?: string | null): string {
+  if ((routeContext ?? "").startsWith("/customer/marketing")) {
+    return (
+      "_Note: I haven't saved this to your marketing workspace yet — the recommendation "
+      + "above is ready to go. Reply “save it” and I'll record it so it shows on the page._"
+    );
+  }
+  return (
+    "_Note: I wasn't able to record that on your workspace just now — the details above are "
+    + "complete. Tell me to save it and I'll record it._"
+  );
 }
 
 function buildFabricationFailureMessage(params: {
   response: string;
   tools: ToolDefinition[];
   executedTools: Array<{ name: string }>;
+  routeContext?: string | null;
 }): string {
   // User-facing message: respects IDENTITY_BLOCK rule #5 — never expose tool
   // names, schema fields ("buildPlan"), or internal architecture terms like
@@ -440,6 +497,17 @@ function buildFabricationFailureMessage(params: {
       "I described the plan as ready before it was actually recorded, so the build "
       + "doesn't have a saved plan yet. Try the request again, or open the build "
       + "details to see what's saved so far."
+    );
+  }
+
+  // Conversational coworker routes have no "build details" panel — pointing a
+  // marketing user there is nonsensical. This path is only reached on a
+  // conversational route as a last resort (the main loop keeps the advice
+  // instead); keep the copy honest and route-appropriate.
+  if (!BUILD_ROUTE_PATTERN.test(params.routeContext ?? "")) {
+    return (
+      "I couldn't record that on your workspace just now. Nothing was left half-saved. "
+      + "Please try again in a moment, or tell me to save it and I'll record it."
     );
   }
 
@@ -1691,14 +1759,69 @@ export async function runAgenticLoop(params: {
           };
         }
 
+        // Conversational coworker routes (e.g. the marketing strategist): the
+        // fabrication guard exists to stop a BUILD agent from falsely claiming
+        // it shipped code. On an advisory chat the same signal mostly fires on a
+        // genuinely useful answer that ends with an intent to persist ("let me
+        // draft that") — and the marketing route is the one advise-mode route
+        // that still carries authoritative artifact tools, so it is exactly
+        // where this misfires. Discarding the advice and showing build copy
+        // ("open the build details") is the wrong cure: it is the failure the
+        // user reported. Retry ONCE with a domain nudge to coax the persist
+        // tool; if the model still won't call it, KEEP the advice rather than
+        // nuke it. Only when the reply makes a hard, unbacked completion claim
+        // ("I've saved that", "it's live") do we append an honest note so the
+        // user is not misled. detectFabrication stays pure; route handling lives
+        // here. BI-3E92B28B (EP-MARKETING-EXEC).
+        if (!isBuildRoute) {
+          if (fabricationRetries < 1) {
+            fabricationRetries++;
+            console.warn(
+              "[agentic-loop] fabrication signal on a conversational route — retrying once with a persist nudge before keeping the advice.",
+            );
+            messages = [
+              ...messages,
+              { role: "assistant" as const, content: result.content },
+              {
+                role: "user" as const,
+                content: buildFabricationRecoveryNudge({
+                  response: trimmed,
+                  tools,
+                  executedTools,
+                  routeContext,
+                }),
+              },
+            ];
+            continue;
+          }
+
+          const makesHardCompletionClaim = HARD_COMPLETION_CLAIM_PATTERN.test(trimmed);
+          console.warn(
+            `[agentic-loop] conversational fabrication retry exhausted — keeping the advice${makesHardCompletionClaim ? " with an unsaved-work note" : ""} rather than discarding it.`,
+          );
+          return {
+            content: makesHardCompletionClaim
+              ? `${trimmed}\n\n${buildUnsavedAdviceNote(routeContext)}`
+              : trimmed,
+            providerId: result.providerId,
+            modelId: result.modelId,
+            downgraded: result.downgraded,
+            downgradeMessage: result.downgradeMessage,
+            totalInputTokens,
+            totalOutputTokens,
+            executedTools,
+            proposal: null,
+          };
+        }
+
         // BI-PIR-cc091267 — a build-route fabrication signal (completion claim
         // with zero tool calls) is most often a TRANSIENT provider downgrade:
         // the preferred provider 529s, a weaker backup confabulates "done"
         // without emitting the required tool call. A single retry can't ride out
         // a blip that self-clears in ~30s, so give build routes a few attempts —
         // each re-dispatches and can re-route to the recovered preferred
-        // provider. Conversational routes keep a single retry (unchanged).
-        const maxFabricationRetries = isBuildRoute ? 3 : 1;
+        // provider.
+        const maxFabricationRetries = 3;
         if (fabricationRetries < maxFabricationRetries) {
           fabricationRetries++;
           console.warn(
@@ -1713,6 +1836,7 @@ export async function runAgenticLoop(params: {
                 response: trimmed,
                 tools,
                 executedTools,
+                routeContext,
               }),
             },
           ];
@@ -1729,6 +1853,7 @@ export async function runAgenticLoop(params: {
                 response: trimmed,
                 tools,
                 executedTools,
+                routeContext,
               }),
           providerId: result.providerId,
           modelId: result.modelId,
@@ -2211,10 +2336,19 @@ export async function runAgenticLoop(params: {
       : fallbackIsFabricated
       ? (downgraded
           ? exhaustedMessage
+          // Conversational routes: keep the advice rather than discard it for a
+          // build-recording failure that does not apply. Append an honest note
+          // only on a hard, unbacked completion claim. Build routes keep the
+          // existing fabrication copy.
+          : !BUILD_ROUTE_PATTERN.test(routeContext)
+          ? (HARD_COMPLETION_CLAIM_PATTERN.test(fallbackContent)
+              ? `${fallbackContent}\n\n${buildUnsavedAdviceNote(routeContext)}`
+              : fallbackContent)
           : buildFabricationFailureMessage({
               response: fallbackContent,
               tools,
               executedTools,
+              routeContext,
             }))
       : (lastResult?.content?.trim() ? lastResult.content : exhaustedMessage),
     providerId: lastResult?.providerId ?? "unknown",

--- a/docs/superpowers/specs/2026-06-25-marketing-coworker-fabrication-guard-fix.md
+++ b/docs/superpowers/specs/2026-06-25-marketing-coworker-fabrication-guard-fix.md
@@ -1,0 +1,79 @@
+# Marketing coworker — route-aware fabrication guard
+
+- **BI:** BI-3E92B28B
+- **Epic:** EP-MARKETING-EXEC
+- **Date:** 2026-06-25
+- **Surface:** `apps/web/lib/tak/agentic-loop.ts`
+
+## Symptom
+
+On `/customer/marketing` the Marketing Strategist would answer a "lets go" /
+"go" continuation with:
+
+> I couldn't complete that — the underlying work wasn't recorded. Try rephrasing
+> the request, or open the build details to see what's saved so far.
+
+A chat route has no "build details" panel, so the copy is nonsensical and the
+user is blocked from establishing or executing a campaign. The model's actual
+advice (a segment profile, a campaign brief, etc.) was discarded.
+
+## Root cause
+
+The agentic-loop **fabrication guard** is build-oriented. Its job is to stop a
+*build* agent from falsely claiming it shipped code without calling a tool
+(`detectFabrication` → retry → `buildFabricationFailureMessage`).
+
+`/customer/marketing` is the **one advise-mode conversational route that still
+carries authoritative artifact tools**: `save_marketing_review`,
+`create_marketing_campaign_brief`, `create_marketing_asset_task`, … are
+`sideEffect: true, coworkerArtifact: true`, so `coworker-tool-filter.ts` keeps
+them in advise mode (saving advice is part of the advisory workflow). That makes
+`hasAuthoritativeToolAvailable` true, which **arms the guard on a chat**.
+
+So when the model narrated a concrete recommendation ("…let me draft the campaign
+brief now") without emitting the persist tool call, the loop:
+
+1. retried once with a build/code nudge (`"Do NOT show code to the user"`), then
+2. **threw away the advice** and substituted `buildFabricationFailureMessage`
+   ("open the build details").
+
+The capability itself was fine — the marketing roster is real and DB-backed
+(`save_marketing_review` @ mcp-tools.ts, `create_marketing_campaign_brief`,
+`draft_marketing_asset`; external publish stubbed via `lib/marketing/publish`).
+The guard was hiding a working establish→execute flow.
+
+## Fix
+
+Route-aware handling at the fabrication call site and in the MAX_ITERATIONS
+fallback. `detectFabrication` stays pure; the route policy lives at the call
+site, mirroring the existing downgraded-turn precedent (Slice D).
+
+For **non-`/build` (conversational) routes**:
+
+- Retry once with a **domain** recovery nudge that tells the model to call its
+  persist tool (`save_marketing_review` / `create_marketing_campaign_brief`) and
+  to keep — not suppress — its advice. No "show code" language.
+- If the model still won't persist, **keep the advice** instead of nuking it.
+- Append an honest, conversational "not saved yet" note
+  (`buildUnsavedAdviceNote`) **only** when the reply makes a hard, unbacked
+  completion claim (`HARD_COMPLETION_CLAIM_PATTERN` — "I've saved that", "it's
+  now live", "in your approval queue"), so the user is never misled.
+- `buildFabricationFailureMessage` gets a conversational variant with no "build
+  details" reference (last-resort only).
+
+**`/build` routes are unchanged**: retry ×3, then the existing fabrication /
+downgraded copy.
+
+## Tests
+
+`apps/web/lib/tak/agentic-loop.test.ts`:
+
+- `HARD_COMPLETION_CLAIM_PATTERN` matches misleading persistence/publish claims,
+  not intent/narration or plain advice.
+- `buildUnsavedAdviceNote` is route-specific and never mentions builds.
+- Integration: a marketing route that narrates without a tool call **keeps the
+  advice** (no build copy, no spurious note); a hard completion claim **keeps the
+  advice + appends the note**; the recovery nudge carries `save_marketing_review`
+  and not "Do NOT show code".
+
+92 tests pass (85 prior + 7 new).


### PR DESCRIPTION
## Problem

On `/customer/marketing` the Marketing Strategist answered a "lets go" / "go" continuation with:

> I couldn't complete that — the underlying work wasn't recorded. Try rephrasing the request, or open the build details to see what's saved so far.

A chat route has no "build details" panel, so the copy is nonsensical and the user is blocked from establishing or executing a campaign — and the model's actual advice (segment profile, campaign brief, …) was thrown away.

## Root cause

The agentic-loop **fabrication guard** is build-oriented (it stops a *build* agent from claiming it shipped code without a tool call). `/customer/marketing` is the **one advise-mode conversational route that still carries authoritative artifact tools** — `save_marketing_review`, `create_marketing_campaign_brief`, … are `sideEffect:true, coworkerArtifact:true`, so `coworker-tool-filter.ts` keeps them in advise mode. That arms the guard on a chat. When the model narrated a recommendation without emitting the persist tool call, the loop retried with a build/code nudge (`"Do NOT show code to the user"`) and then **discarded the advice** in favour of `buildFabricationFailureMessage` ("open the build details").

The marketing capability itself is **real and DB-backed** (`save_marketing_review`, `create_marketing_campaign_brief`, `draft_marketing_asset`; external publish stubbed via `lib/marketing/publish`). The guard was hiding a working establish→execute flow.

## Fix

Route-aware handling at the fabrication call site **and** the MAX_ITERATIONS fallback. `detectFabrication` stays pure; the route policy lives at the call site, mirroring the existing downgraded-turn precedent (Slice D).

For **non-`/build` (conversational) routes**:
- Retry once with a **domain** recovery nudge to call the persist tool (`save_marketing_review` / `create_marketing_campaign_brief`) while keeping — not suppressing — the advice.
- If still unpersisted, **keep the advice** rather than nuke it.
- Append an honest "not saved yet" note (`buildUnsavedAdviceNote`) **only** on a hard, unbacked completion claim (`HARD_COMPLETION_CLAIM_PATTERN` — "I've saved that", "it's now live", "in your approval queue").
- `buildFabricationFailureMessage` gets a conversational variant with no "build details" reference (last-resort only).

**`/build` routes are unchanged** (retry ×3, then existing fabrication / downgraded copy).

## Tests

`apps/web/lib/tak/agentic-loop.test.ts` — **92 pass (85 prior + 7 new):**
- `HARD_COMPLETION_CLAIM_PATTERN` matches misleading persistence/publish claims, not intent/narration or plain advice.
- `buildUnsavedAdviceNote` is route-specific and never mentions builds.
- Integration: marketing narration without a tool call **keeps the advice** (no build copy, no spurious note); a hard completion claim **keeps the advice + note**; the recovery nudge carries `save_marketing_review`, not "Do NOT show code".

## Notes

- BI-3E92B28B (EP-MARKETING-EXEC).
- Design note: `docs/superpowers/specs/2026-06-25-marketing-coworker-fabrication-guard-fix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)