### PR TITLE
feat(providers): recommended action per blocked provider row (BI-0C30CF9B v1)

### DIFF
--- a/apps/web/components/platform/ServiceRow.tsx
+++ b/apps/web/components/platform/ServiceRow.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import type { ProviderWithCredential, ProviderModelSummary } from "@/lib/ai-provider-types";
-import type { RoutingEligibility } from "@/lib/routing/provider-routing-eligibility";
+import { recommendedActionFor, type RoutingEligibility } from "@/lib/routing/provider-routing-eligibility";
 import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
 import { DataSourceBadge } from "@/components/ui/DataSourceBadge";
 import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
@@ -140,6 +140,12 @@ export function ServiceRow({ pw, modelSummary, eligibility }: Props) {
   // The status dot mirrors the eligibility badge intent so a quick scan down the
   // left edge of the list reads the same yes/no as the badge text.
   const statusColor = intentStyle(resolveIntent("routingEligibility", eligibility.state)).fg;
+  // The concrete next step for a blocked provider, surfaced in the eligibility
+  // tooltip so the operator sees what to do, not just the status (null = no action).
+  const recommendedAction = recommendedActionFor(eligibility);
+  const eligibilityTitle = recommendedAction
+    ? `${eligibility.reason} — Recommended: ${recommendedAction}`
+    : eligibility.reason;
   const typeLabel   = provider.endpointType === "service" ? "MCP" : "LLM";
   const costView = buildProviderCostView({ provider, financeProfile: null, internalUsage: null });
 
@@ -169,7 +175,7 @@ export function ServiceRow({ pw, modelSummary, eligibility }: Props) {
       >
         {/* Status dot — colored by routing eligibility */}
         <span
-          title={eligibility.reason}
+          title={eligibilityTitle}
           style={{
             width: 7,
             height: 7,
@@ -196,7 +202,7 @@ export function ServiceRow({ pw, modelSummary, eligibility }: Props) {
         </span>
 
         {/* Routing eligibility — the single "can routing use this now?" answer */}
-        <span title={eligibility.reason} style={{ flexShrink: 0, display: "inline-flex" }}>
+        <span title={eligibilityTitle} style={{ flexShrink: 0, display: "inline-flex" }}>
           <StatusBadge
             domain="routingEligibility"
             status={eligibility.state}

--- a/apps/web/lib/routing/provider-routing-eligibility.test.ts
+++ b/apps/web/lib/routing/provider-routing-eligibility.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   cliAdapterTypeForProvider,
   deriveRoutingEligibility,
+  recommendedActionFor,
   type RoutingEligibilityInput,
 } from "./provider-routing-eligibility";
 
@@ -17,6 +18,18 @@ function base(overrides: Partial<RoutingEligibilityInput> = {}): RoutingEligibil
     ...overrides,
   };
 }
+
+describe("recommendedActionFor", () => {
+  it("returns a concrete action for each blocking state and null when none applies", () => {
+    expect(recommendedActionFor(deriveRoutingEligibility(base()))).toBeNull(); // routable
+    expect(recommendedActionFor(deriveRoutingEligibility(base({ status: "unconfigured" })))).toMatch(/Set this provider up/);
+    expect(recommendedActionFor(deriveRoutingEligibility(base({ status: "inactive" })))).toMatch(/Enable/);
+    expect(recommendedActionFor(deriveRoutingEligibility(base({ authMethod: "api_key", hasCredential: false })))).toMatch(/credentials/);
+    expect(recommendedActionFor(deriveRoutingEligibility(base({ discoveredModelCount: 0 })))).toMatch(/model sync/);
+    expect(recommendedActionFor(deriveRoutingEligibility(base({ cliPoolExhausted: true })))).toBeNull(); // rate_limited self-recovers
+    expect(recommendedActionFor(deriveRoutingEligibility(base({ endpointType: "service" })))).toBeNull(); // not_routable
+  });
+});
 
 describe("deriveRoutingEligibility", () => {
   it("local active provider with models is routable (no credentials needed)", () => {

--- a/apps/web/lib/routing/provider-routing-eligibility.ts
+++ b/apps/web/lib/routing/provider-routing-eligibility.ts
@@ -177,6 +177,30 @@ export function deriveRoutingEligibility(input: RoutingEligibilityInput): Routin
 }
 
 /**
+ * The concrete next step an operator should take to make a non-routable provider
+ * routable — the "do this" complement to RoutingEligibility.reason. Returns null
+ * when no operator action applies: already routable, self-recovering (rate
+ * limited), or not a routing target. Pure + total over the states so it is
+ * unit-testable and can render from data already on the admin page.
+ */
+export function recommendedActionFor(eligibility: RoutingEligibility): string | null {
+  switch (eligibility.state) {
+    case "unconfigured":
+      return "Set this provider up to make it available to routing.";
+    case "disabled":
+      return "Enable this provider to allow routing to use it.";
+    case "needs_credentials":
+      return "Connect (or reconnect) this provider's credentials.";
+    case "no_models":
+      return "Run a model sync to discover this provider's models.";
+    case "routable":
+    case "rate_limited":
+    case "not_routable":
+      return null;
+  }
+}
+
+/**
  * Which CLI subscription pool (if any) gates a provider's live availability,
  * grounded in the canonical adapter predicates in `provider-utils.ts`:
  *   - anthropic-sub → claude-cli  (Claude OAuth subscription, routes via `claude -p`)


### PR DESCRIPTION
Implements **BI-0C30CF9B** (v1) as an external Claude Code build — a deterministic recommended action per blocked AI-provider row, surfaced in the eligibility tooltip so the operator sees what to **do**, not just the status.

## Finding
Verifying the substrate showed BI-0C30CF9B is **largely already implemented**: `deriveRoutingEligibility` computes a single mutually-exclusive eligibility state per provider, and the providers page already auto-re-enables providers when quota timers elapse. The remaining cognitive-load gap was the BI's explicit "recommended action per blocked row" — this PR adds it.

## What
- `recommendedActionFor(eligibility)` — pure, total over the 7 eligibility states: the concrete next step for actionable states (set up / enable / connect credentials / run a model sync), `null` for routable / self-recovering (rate-limited) / not-a-routing-target. Unit-tested.
- `ServiceRow` surfaces it in the existing eligibility tooltip (no layout change).

## Scope
The "surface only blocking rows" progressive-disclosure filter is an information-architecture change best done with the portal running for visual review — a follow-up. This v1 is fully verifiable here (pure logic + tooltip; CI typecheck/tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)