### PR TITLE
feat(skills): deterministic curator quality-health signal + ascent design pass (BI-93FE150F)

### DIFF
--- a/apps/web/lib/skills/quality.test.ts
+++ b/apps/web/lib/skills/quality.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assessSkillQuality,
+  ELEVATED_FAILURE_RATE,
+  MIN_INVOCATIONS_FOR_QUALITY,
+  REGRESSING_FAILURE_RATE,
+} from "./quality";
+
+describe("assessSkillQuality", () => {
+  it("returns insufficient-data with a null rate when there are no invocations", () => {
+    const r = assessSkillQuality({ invoked: 0, failed: 0 });
+    expect(r.verdict).toBe("insufficient-data");
+    expect(r.failureRate).toBeNull();
+  });
+
+  it("withholds a verdict on small samples even when every invocation failed", () => {
+    // (MIN-1)/(MIN-1) = 100%, but the sample is below MIN — a noise guard, not
+    // a regression. This is the bug the lifecycle classifier cannot have today
+    // because it never looks at failures at all.
+    const n = MIN_INVOCATIONS_FOR_QUALITY - 1;
+    const r = assessSkillQuality({ invoked: n, failed: n });
+    expect(r.verdict).toBe("insufficient-data");
+    expect(r.failureRate).toBe(1);
+  });
+
+  it("flags regressing when at least half of a trustworthy sample failed", () => {
+    const r = assessSkillQuality({ invoked: 10, failed: 5 });
+    expect(r.verdict).toBe("regressing");
+    expect(r.failureRate).toBe(REGRESSING_FAILURE_RATE);
+    expect(r.reason).toMatch(/50%/);
+  });
+
+  it("flags elevated-failures between the elevated and regressing thresholds", () => {
+    const r = assessSkillQuality({ invoked: 10, failed: 3 }); // 30%
+    expect(r.verdict).toBe("elevated-failures");
+    expect(r.failureRate).toBeCloseTo(0.3, 5);
+  });
+
+  it("treats the elevated boundary as inclusive", () => {
+    const r = assessSkillQuality({ invoked: 100, failed: 20 }); // exactly 20%
+    expect(r.verdict).toBe("elevated-failures");
+  });
+
+  it("reads just below the elevated boundary as healthy", () => {
+    const r = assessSkillQuality({ invoked: 100, failed: 19 }); // 19%
+    expect(r.verdict).toBe("healthy");
+  });
+
+  it("is healthy with a clear reason when nothing failed", () => {
+    const r = assessSkillQuality({ invoked: 50, failed: 0 });
+    expect(r.verdict).toBe("healthy");
+    expect(r.failureRate).toBe(0);
+    expect(r.reason).toMatch(/no failures/);
+  });
+
+  it("clamps a dropped-terminal anomaly (failed > invoked) to a 100% rate", () => {
+    const r = assessSkillQuality({ invoked: 6, failed: 9 });
+    expect(r.failureRate).toBe(1);
+    expect(r.verdict).toBe("regressing");
+  });
+
+  it("normalizes negative/fractional inputs defensively", () => {
+    const r = assessSkillQuality({ invoked: -3, failed: -1 });
+    expect(r.verdict).toBe("insufficient-data");
+    expect(r.failureRate).toBeNull();
+  });
+
+  it("orders the thresholds so callers can render bands", () => {
+    expect(ELEVATED_FAILURE_RATE).toBeLessThan(REGRESSING_FAILURE_RATE);
+  });
+});

--- a/apps/web/lib/skills/quality.ts
+++ b/apps/web/lib/skills/quality.ts
@@ -1,0 +1,107 @@
+// Skill quality-health signal for the governed Hermes curator (BI-93FE150F,
+// EP-FULL-OBS).
+//
+// Companion to lifecycle.ts. classifySkillLifecycle answers "is this skill
+// being USED?" on crisp presence-of-use signals (invoked === 0 / hasContent /
+// assignmentCount === 0). It is deliberately blind to whether the invocations
+// it counts SUCCEED: the curator collects usage30d.failed and then never reads
+// it. This module fills exactly that gap — a deterministic read of the failure
+// rate already in hand, with a small-sample guard so low-volume noise is never
+// mislabelled as a regression.
+//
+// Why deterministic, not the learned classifier the BI literally asks for: the
+// lifecycle boundary is crisp, so per the platform bridge-pattern doctrine (AI
+// ascends only where the boundary is genuinely fuzzy, then re-descends to code
+// once thresholds stabilise) there is nothing to "learn" yet — explicit
+// thresholds are the correct floor. Ascent to a learned step is warranted only
+// if these thresholds prove fuzzy in practice. See the design pass:
+// docs/superpowers/plans/2026-06-26-curator-quality-health-ascent-design.md
+
+export type SkillQualityVerdict =
+  | "healthy" // failure rate within tolerance
+  | "elevated-failures" // failing noticeably more than tolerance — worth a look
+  | "regressing" // failing at or above half of invocations — acute
+  | "insufficient-data"; // too few invocations to judge quality (the noise guard)
+
+export interface SkillQualityInput {
+  /** Total invocations in the window (SkillUsageEvent phase="invoked"). */
+  invoked: number;
+  /** Failed invocations in the window (phase="failed") — a subset of `invoked`. */
+  failed: number;
+}
+
+export interface SkillQualityAssessment {
+  verdict: SkillQualityVerdict;
+  /** failed / invoked, clamped to [0,1]; null when there were no invocations. */
+  failureRate: number | null;
+  /** One-line, plain-language explanation — no internals. */
+  reason: string;
+}
+
+/**
+ * Minimum invocations before a failure rate is trustworthy. Below this a single
+ * failure swings the rate wildly (1 of 2 = 50%), so we withhold a verdict
+ * rather than cry "regression" on noise. This is the first threshold a future
+ * learned step would tune — and the first to re-descend to code once stable.
+ */
+export const MIN_INVOCATIONS_FOR_QUALITY = 5;
+
+/** failureRate at or above this → regressing (acute; ~majority failing). */
+export const REGRESSING_FAILURE_RATE = 0.5;
+/** failureRate at or above this (and below regressing) → elevated-failures. */
+export const ELEVATED_FAILURE_RATE = 0.2;
+
+/**
+ * Deterministic quality-health read for a skill, derived from failure telemetry
+ * the curator already holds. Pure — no DB, no clock — so it runs inside the
+ * curator's per-skill loop and is fully unit-testable.
+ *
+ * Precedence (most-specific first):
+ *   1. invoked === 0          → insufficient-data (nothing happened)
+ *   2. invoked < MIN          → insufficient-data (sample too small to trust)
+ *   3. rate >= REGRESSING     → regressing
+ *   4. rate >= ELEVATED       → elevated-failures
+ *   5. otherwise              → healthy
+ */
+export function assessSkillQuality(input: SkillQualityInput): SkillQualityAssessment {
+  const invoked = Math.max(0, Math.trunc(input.invoked));
+  const failed = Math.max(0, Math.trunc(input.failed));
+
+  if (invoked === 0) {
+    return { verdict: "insufficient-data", failureRate: null, reason: "no invocations to judge quality" };
+  }
+
+  // `failed` is a subset of `invoked`, but a terminal telemetry event can be
+  // dropped, so clamp defensively rather than ever emit a rate above 1.
+  const failureRate = Math.min(1, failed / invoked);
+
+  if (invoked < MIN_INVOCATIONS_FOR_QUALITY) {
+    return {
+      verdict: "insufficient-data",
+      failureRate,
+      reason: `only ${invoked} invocation${invoked === 1 ? "" : "s"} — too few to judge quality`,
+    };
+  }
+
+  if (failureRate >= REGRESSING_FAILURE_RATE) {
+    return { verdict: "regressing", failureRate, reason: `${pct(failureRate)} of invocations failed in the window` };
+  }
+
+  if (failureRate >= ELEVATED_FAILURE_RATE) {
+    return {
+      verdict: "elevated-failures",
+      failureRate,
+      reason: `${pct(failureRate)} of invocations failed — above the ${pct(ELEVATED_FAILURE_RATE)} tolerance`,
+    };
+  }
+
+  return {
+    verdict: "healthy",
+    failureRate,
+    reason: failed === 0 ? "no failures in the window" : `${pct(failureRate)} failure rate — within tolerance`,
+  };
+}
+
+function pct(rate: number): string {
+  return `${Math.round(rate * 100)}%`;
+}

--- a/docs/superpowers/plans/2026-06-26-curator-quality-health-ascent-design.md
+++ b/docs/superpowers/plans/2026-06-26-curator-quality-health-ascent-design.md
@@ -1,0 +1,115 @@
+# Curator quality-health ascent — design pass
+
+- **BI:** BI-93FE150F — "Ascent (code→AI): skill-curator learned signal classification instead of hand-coded sourceType rules"
+- **Epic:** EP-FULL-OBS
+- **Date:** 2026-06-26
+- **Status:** design pass complete; deterministic floor shipped with this doc; learned ascent deferred (conditional — see §5)
+
+## 0. TL;DR
+
+The BI asks to replace a "hand-coded per-sourceType switch over SkillMetric
+performance/regression/drift" with a learned classifier. **That switch does not
+exist.** The shipped curator classifier (`classifySkillLifecycle`) is a crisp
+5-rule function over presence-of-use signals. Per the platform's own
+bridge-pattern doctrine — AI ascends only where a boundary is genuinely *fuzzy*,
+then re-descends to deterministic code once thresholds stabilise — replacing a
+crisp classifier with a learned one would be over-engineering.
+
+There **is** a real gap, but it is the opposite of "too hand-coded": the curator
+collects `usage30d.failed` and then **ignores it entirely**. It is blind to
+whether the invocations it counts succeed. This pass closes that blind spot
+deterministically (`assessSkillQuality`, shipped here) and **re-scopes** the BI
+from "make it learned" to "make it see failures; ascend only if the
+regression-vs-noise boundary later proves fuzzy."
+
+## 1. What the BI assumed vs. what the code is
+
+| BI premise | Reality in `main` |
+|---|---|
+| Classifies `SkillMetric` performance/regression/drift | Classifies operational **lifecycle**: `active / stale / pinned / quarantined / archived` |
+| Via a "hand-coded per-sourceType switch" | Via `classifySkillLifecycle` — 5 ordered rules, no `sourceType` anywhere |
+| Naive about combinations → "mislabels regression vs noise" | Never evaluates regression **at all** — it reads `failed` and discards it |
+
+Evidence:
+- `apps/web/lib/skills/lifecycle.ts:70` — `classifySkillLifecycle(input)`; rules at `:78-90` key only on `hasContent`, `assignmentCount`, `usage30d.invoked === 0`.
+- `apps/web/lib/skills/curator.ts:88-94` — builds `usageMap` with both `invoked` and `failed`; `:119-126` passes only `{ invoked, failed }` into the classifier as `usage30d`, which then **uses `invoked` only**.
+- `apps/web/lib/skills/types.ts:7-14` — `SKILL_USAGE_PHASES = [eligible, loaded, invoked, completed, failed, rated]`.
+- `apps/web/lib/tak/agentic-loop.ts:2277` — terminal phase is `toolResult.success ? "completed" : "failed"`; `apps/web/lib/actions/agent-coworker.ts:903` records `invoked` at start. So `invoked` = total invocations and `failed` = the failure subset → `failed / invoked ∈ [0,1]`.
+
+The BI was filed 2026-06-20 from the migration analysis; the description tracked
+an *envisioned* richer curator, not the shipped one. We honour the intent
+(catch quality regressions the rules miss), not the stale letter.
+
+## 2. The bridge-pattern test (does this boundary warrant AI?)
+
+Doctrine (AGENTS.md / `project_cognitive_load_migration` — "tool-ification =
+AI→code"; ascent is *temporary scaffolding* that re-descends once the boundary
+is crisp):
+
+- **Lifecycle boundary — CRISP.** "Has it been invoked in 30 days? Does it have
+  a body? Is it assigned?" are binary facts. A learned model here adds a model
+  dependency, non-determinism, and re-descent machinery to reproduce a correct
+  5-line function. **Keep deterministic. Do not ascend.**
+- **Quality boundary — POTENTIALLY FUZZY.** "Is a 25% failure rate over 8
+  invocations a regression or noise?" depends on volume, trend, and baseline.
+  This is the only place a learned step could earn its keep — and only after a
+  deterministic floor proves insufficient.
+
+## 3. The real gap: failure-blindness
+
+A skill invoked 100× with 95 failures is `active` ("in use") under the current
+rules — a silent quality hole. The data to catch it is **already collected and
+already discarded**. Closing this needs no new telemetry, no new query, no
+model: just *read the number the curator already has*.
+
+## 4. Deterministic floor — shipped with this pass
+
+`apps/web/lib/skills/quality.ts` — `assessSkillQuality({ invoked, failed })`:
+
+- Verdict ∈ `healthy | elevated-failures | regressing | insufficient-data`.
+- Explicit, named, reviewable thresholds: `MIN_INVOCATIONS_FOR_QUALITY = 5`
+  (small-sample noise guard), `ELEVATED_FAILURE_RATE = 0.2`,
+  `REGRESSING_FAILURE_RATE = 0.5`.
+- Pure (no DB, no clock); clamps defensively; fully unit-tested
+  (`quality.test.ts`).
+
+These three constants are deliberately the **learnable surface**: if/when a
+learned step is justified, it tunes exactly these, and re-descends by writing
+the tuned values back here.
+
+This PR ships the function and its tests **only** — it does not yet wire into
+the curator. The wiring is a behaviour change (report shape / signals /
+transitions) and belongs to a reviewed follow-up (§5), not bundled with the
+design pass.
+
+## 5. Wiring roadmap (deferred — each step gated on the prior's evidence)
+
+1. **v1 — record-only.** Curator computes `assessSkillQuality` per skill and
+   records the verdict in the `curator-report` TaskArtifact (and per
+   `CuratorFinding`). No new signals, no transition changes — pure observability
+   so operators (and we) can see the distribution before acting. *Small, safe,
+   reversible.*
+2. **v2 — governed action (needs policy review).** Promote `regressing` to an
+   `ImprovementSignal` (deduped like the lifecycle findings) and/or let it
+   influence lifecycle (e.g. suggest — never auto — quarantine). Threshold and
+   noise budget are an operator decision; do not ship unattended.
+3. **v3 — learned ascent (conditional).** ONLY if v1/v2 evidence shows the
+   deterministic thresholds genuinely mislabel (regression vs noise) across
+   volume/trend. Feature-extract from `SkillMetric` history (trend, baseline
+   delta, agent volatility) into a lightweight classifier via
+   `resolve_model_selection`, with the deterministic floor as the always-on
+   fallback. **Re-descent criterion:** once the learned thresholds stabilise
+   (low variance over N curator runs), codify them back into the §4 constants
+   and retire the model — the bridge has served its purpose.
+
+## 6. Recommendation
+
+- **Re-scope BI-93FE150F** from "replace the classifier with AI" to "give the
+  curator a deterministic quality-health signal; ascend to learned only if the
+  regression-vs-noise boundary proves fuzzy (§5 v3)." Update the BI body so it
+  no longer references the non-existent `sourceType` switch.
+- **Apply the same bridge-pattern scrutiny to BI-A1FC3EBB** (watchdog
+  learned-anomaly) before building it — confirm its boundary is fuzzy rather
+  than assuming a learned step is needed. (Watchdog is safety-sensitive; that
+  review is its own pass.)
+- Proceed to §5 v1 (record-only wiring) as the next curator increment.


### PR DESCRIPTION
## What

The curator's classifier `classifySkillLifecycle` is a crisp 5-rule function over presence-of-use signals — **not** the "hand-coded sourceType switch over SkillMetric performance/regression/drift" that BI-93FE150F describes (that switch does not exist). Per the platform's bridge-pattern doctrine — AI ascends only where a boundary is genuinely *fuzzy*, then re-descends to code once thresholds stabilise — replacing a crisp classifier with a learned one would be over-engineering.

The real gap is the opposite of "too hand-coded": the curator collects `usage30d.failed` and **never reads it**. It is blind to whether the invocations it counts succeed — a skill invoked 100× with 95 failures reads as `active` today.

## This PR

- `apps/web/lib/skills/quality.ts` — `assessSkillQuality({ invoked, failed })`: pure, deterministic quality-health verdict (`healthy | elevated-failures | regressing | insufficient-data`) computed from the failure rate already in hand, with a small-sample noise guard and explicit, named, *learnable* thresholds.
- `apps/web/lib/skills/quality.test.ts` — full unit coverage (boundaries, noise guard, defensive clamping).
- `docs/superpowers/plans/2026-06-26-curator-quality-health-ascent-design.md` — the design pass: the BI-vs-code mismatch (with file:line evidence), the bridge-pattern test, the deterministic floor, and the **conditional** learned-ascent + re-descent roadmap.

Ships the function + tests **only**. Wiring into the curator (record-only in the report first) changes curator behaviour and is a reviewed follow-up per the design doc — not bundled with the design pass.

## Scope note

Recommends **re-scoping BI-93FE150F** from "make it learned" → "give the curator a deterministic quality signal; ascend to learned only if the regression-vs-noise boundary proves fuzzy," and applying the same bridge-pattern scrutiny to BI-A1FC3EBB (watchdog) before building it.

## Verification

Pure function + co-located vitest; relies on CI (source-only worktree, no local toolchain). No UI (UX-Fit N/A); the design doc satisfies the Spec/Plan/Doc gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
