### PR TITLE
feat(skills): wire curator quality-health signal into findings + report (BI-93FE150F v1)

### DIFF
--- a/apps/web/lib/skills/curator.test.ts
+++ b/apps/web/lib/skills/curator.test.ts
@@ -230,3 +230,52 @@ describe("runSkillCurator — empty population", () => {
     expect(state.artifactsCreated).toHaveLength(1);
   });
 });
+
+describe("runSkillCurator — quality-health signal (BI-93FE150F v1, record-only)", () => {
+  it("records a regressing verdict for an in-use skill whose invocations mostly fail", async () => {
+    addSkill({ skillId: "flaky-skill", skillMdContent: "body" });
+    // 10 invocations, 5 failures → 50% → regressing, while lifecycle still
+    // reads "active" (it is being used). This is exactly the blind spot the
+    // lifecycle classifier cannot see — it never looks at failures.
+    for (let i = 0; i < 10; i++) {
+      state.usageEvents.push({ skillId: "flaky-skill", phase: "invoked", createdAt: new Date("2026-05-01") });
+    }
+    for (let i = 0; i < 5; i++) {
+      state.usageEvents.push({ skillId: "flaky-skill", phase: "failed", createdAt: new Date("2026-05-02") });
+    }
+
+    const report = await runSkillCurator({ invokedByUserId: "usr_owner" });
+
+    const finding = report.findings.find((f) => f.skillId === "flaky-skill");
+    expect(finding?.toState).toBe("active"); // lifecycle: in use
+    expect(finding?.quality?.verdict).toBe("regressing"); // quality: failing
+    expect(finding?.quality?.failureRate).toBe(0.5);
+
+    // record-only: an active skill still emits no ImprovementSignal in v1.
+    expect(
+      state.signalsTouched.find((s) => (s.sourceId as string)?.startsWith("flaky-skill:")),
+    ).toBeUndefined();
+
+    // The verdict is persisted into the curator-report artifact, not just the
+    // returned object.
+    const parts = state.artifactsCreated[0]?.parts as Array<{
+      data: { findings: Array<{ skillId: string; quality?: { verdict?: string } }> };
+    }>;
+    const persisted = parts[0]?.data.findings.find((f) => f.skillId === "flaky-skill");
+    expect(persisted?.quality?.verdict).toBe("regressing");
+  });
+
+  it("records insufficient-data rather than a regression on a tiny sample", async () => {
+    addSkill({ skillId: "rare-skill", skillMdContent: "body" });
+    // 2 invocations, both failed: 100% but below the trust threshold — the
+    // curator must not cry regression on noise.
+    state.usageEvents.push({ skillId: "rare-skill", phase: "invoked", createdAt: new Date("2026-05-01") });
+    state.usageEvents.push({ skillId: "rare-skill", phase: "invoked", createdAt: new Date("2026-05-01") });
+    state.usageEvents.push({ skillId: "rare-skill", phase: "failed", createdAt: new Date("2026-05-02") });
+    state.usageEvents.push({ skillId: "rare-skill", phase: "failed", createdAt: new Date("2026-05-02") });
+
+    const report = await runSkillCurator({ invokedByUserId: "usr_owner" });
+    const finding = report.findings.find((f) => f.skillId === "rare-skill");
+    expect(finding?.quality?.verdict).toBe("insufficient-data");
+  });
+});

--- a/apps/web/lib/skills/curator.ts
+++ b/apps/web/lib/skills/curator.ts
@@ -24,6 +24,7 @@ import {
   isSkillLifecycleState,
   type SkillLifecycleState,
 } from "./lifecycle";
+import { assessSkillQuality, type SkillQualityAssessment } from "./quality";
 
 export const CURATOR_REPORT_KIND = "curator-report";
 
@@ -35,6 +36,13 @@ export type CuratorFinding = {
   toState: SkillLifecycleState;
   reason: string;
   changed: boolean;
+  /**
+   * Operational quality-health read for the skill's invocations in the window,
+   * recorded alongside the lifecycle verdict (BI-93FE150F v1, record-only). The
+   * lifecycle axis answers "is it used?"; this answers "do those uses succeed?".
+   * Optional because reports written before this signal existed omit it.
+   */
+  quality?: SkillQualityAssessment;
 };
 
 export type CuratorReport = {
@@ -128,12 +136,18 @@ export async function runSkillCurator(
     const next = isCuratorImmutable(current) ? current : result.next;
     totals[next] = (totals[next] ?? 0) + 1;
     const changed = next !== current;
+    // Record-only quality-health read from failure telemetry the curator
+    // already holds (usage30d.failed) — surfaced in the finding/report but
+    // never acted on in v1. See the design pass:
+    // docs/superpowers/plans/2026-06-26-curator-quality-health-ascent-design.md
+    const quality = assessSkillQuality(usage30d);
     findings.push({
       skillId: s.skillId,
       fromState: current,
       toState: next,
       reason: result.reason,
       changed,
+      quality,
     });
 
     if (changed) {

--- a/apps/web/lib/skills/curator.ts
+++ b/apps/web/lib/skills/curator.ts
@@ -221,7 +221,10 @@ export async function runSkillCurator(
             findings,
           },
         },
-      ] as Prisma.InputJsonValue,
+      // Widen through `unknown`: CuratorFinding.quality.failureRate is
+      // `number | null`, and Prisma's InputJsonValue type excludes null even
+      // though null is valid JSON at runtime. The graph is otherwise plain JSON.
+      ] as unknown as Prisma.InputJsonValue,
       metadata: { kind: CURATOR_REPORT_KIND } as Prisma.InputJsonValue,
     },
   });

--- a/docs/superpowers/plans/2026-06-26-curator-quality-health-ascent-design.md
+++ b/docs/superpowers/plans/2026-06-26-curator-quality-health-ascent-design.md
@@ -3,7 +3,7 @@
 - **BI:** BI-93FE150F — "Ascent (code→AI): skill-curator learned signal classification instead of hand-coded sourceType rules"
 - **Epic:** EP-FULL-OBS
 - **Date:** 2026-06-26
-- **Status:** design pass complete; deterministic floor shipped with this doc; learned ascent deferred (conditional — see §5)
+- **Status:** design pass complete; deterministic floor + record-only wiring (§5 v1) shipped; v2 governed action and v3 learned ascent deferred (conditional — see §5)
 
 ## 0. TL;DR
 


### PR DESCRIPTION
## What

v1 **record-only** wiring of the curator quality-health signal — the follow-up to the deterministic floor + design pass in the merged BI-93FE150F PR.

The curator already collects `usage30d.failed` per skill and never reads it. This wires `assessSkillQuality` into the per-skill loop so every `CuratorFinding` — and the persisted `curator-report` TaskArtifact — carries a quality verdict alongside the lifecycle verdict.

**Record-only by design:** no new `ImprovementSignal`s, no lifecycle transitions. Pure observability so the failure-rate distribution is visible before any v2 governed action (per the design doc §5 roadmap).

## Why it matters

A skill invoked 100× with 95 failures reads as `lifecycle=active` today — the classifier never looks at failures. It now *also* reads `quality=regressing` in the report. The blind spot is closed end-to-end, deterministically, with no model and no new telemetry.

## Tests

- **active-but-regressing** (the blind spot): `toState=active` + `quality.verdict=regressing`, persisted into the artifact.
- small-sample → `insufficient-data` (the noise guard fires instead of crying regression).
- record-only: an active skill emits no extra `ImprovementSignal`.

## Verification

Co-located vitest; relies on CI (source-only worktree, no local toolchain). No UI (UX-Fit N/A); the design-doc touch satisfies the Spec/Plan/Doc gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
