### PR TITLE
refactor(finance): extract pure tax-remittance helpers into domain core (BI-OPT-FAT-ACTIONS Slice A)

### DIFF
--- a/apps/web/lib/actions/tax-remittance.ts
+++ b/apps/web/lib/actions/tax-remittance.ts
@@ -1,12 +1,29 @@
 "use server";
 
-import { createHash } from "crypto";
 import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { encryptSecret } from "@/lib/govern/credential-crypto";
 import { can } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
-import { nanoid } from "nanoid";
+import {
+  MANAGED_TAX_ISSUE_TYPES,
+  addDays,
+  addMonths,
+  appendNote,
+  credentialPublicId,
+  decimalValue,
+  issueKey,
+  issuePublicId,
+  nullableString,
+  periodPublicId,
+  registrationPublicId,
+  remittanceRunPublicId,
+  roundCurrency,
+  stableTaxEntityId,
+  taxExecutionTaskId,
+  taxMonitorTaskId,
+  taxableBaseFromLine,
+} from "@/lib/finance/tax-remittance-core";
 import {
   addTaxFilingArtifactSchema,
   createTaxRegistrationSchema,
@@ -67,17 +84,6 @@ type ManagedTaxIssueDraft = {
   periodId?: string | null;
 };
 
-const MANAGED_TAX_ISSUE_TYPES = new Set([
-  "tax_setup_mode_unknown",
-  "tax_home_jurisdiction_missing",
-  "tax_footprint_missing",
-  "tax_registration_research_needed",
-  "tax_registration_number_missing",
-  "tax_registration_live_verification_needed",
-  "tax_external_handoff_missing",
-  "tax_dpf_filing_not_available",
-]);
-
 async function requireManageFinance() {
   const session = await auth();
   const user = session?.user;
@@ -120,68 +126,6 @@ async function getOrCreateTaxProfile(organizationId: string) {
   });
 }
 
-function nullableString(value?: string | null) {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : null;
-}
-
-function appendNote(existing: string | null, incoming?: string | null) {
-  const next = nullableString(incoming);
-  if (!next) return existing;
-  const current = nullableString(existing);
-  if (!current) return next;
-  if (current.includes(next)) return current;
-  return `${current}\n${next}`;
-}
-
-function registrationPublicId() {
-  return `TAX-REG-${nanoid(8).toUpperCase()}`;
-}
-
-function issuePublicId() {
-  return `TAX-ISS-${nanoid(8).toUpperCase()}`;
-}
-
-function periodPublicId() {
-  return `TAX-PER-${nanoid(8).toUpperCase()}`;
-}
-
-function taxMonitorTaskId() {
-  return `tax-monitor-${nanoid(8).toLowerCase()}`;
-}
-
-function credentialPublicId() {
-  return `TAX-CRED-${nanoid(8).toUpperCase()}`;
-}
-
-function remittanceRunPublicId() {
-  return `TAX-RUN-${nanoid(8).toUpperCase()}`;
-}
-
-function taxExecutionTaskId() {
-  return `tax-run-${nanoid(8).toLowerCase()}`;
-}
-
-function stableTaxEntityId(prefix: string, ...parts: Array<string | number | Date | null | undefined>) {
-  const digest = createHash("sha1")
-    .update(
-      parts
-        .map((part) => {
-          if (part instanceof Date) return part.toISOString();
-          return part == null ? "" : String(part);
-        })
-        .join("|"),
-    )
-    .digest("hex")
-    .slice(0, 12)
-    .toUpperCase();
-  return `${prefix}-${digest}`;
-}
-
-function issueKey(issueType: string, registrationId?: string | null, periodId?: string | null) {
-  return [issueType, registrationId ?? "profile", periodId ?? "none"].join(":");
-}
-
 function revalidateTaxRoutes() {
   revalidatePath("/finance");
   revalidatePath("/finance/settings");
@@ -202,34 +146,6 @@ async function createTaxNotification(userId: string, title: string, body: string
   });
 }
 
-function decimalValue(value: unknown) {
-  if (typeof value === "number") return value;
-  if (typeof value === "string") return Number(value) || 0;
-  if (value && typeof value === "object" && "toNumber" in value && typeof value.toNumber === "function") {
-    return value.toNumber();
-  }
-  if (value && typeof value === "object" && "toString" in value && typeof value.toString === "function") {
-    return Number(value.toString()) || 0;
-  }
-  return 0;
-}
-
-function roundCurrency(value: number) {
-  return Math.round(value * 100) / 100;
-}
-
-function addDays(date: Date, days: number) {
-  const next = new Date(date);
-  next.setUTCDate(next.getUTCDate() + days);
-  return next;
-}
-
-function addMonths(date: Date, months: number) {
-  const next = new Date(date);
-  next.setUTCMonth(next.getUTCMonth() + months);
-  return next;
-}
-
 type LiabilityDraft = {
   snapshotId?: string;
   entryId: string;
@@ -247,10 +163,6 @@ type LiabilityDraft = {
   evidence?: Record<string, unknown>;
   notes?: string | null;
 };
-
-function taxableBaseFromLine(lineTotal: unknown, taxAmount: number) {
-  return roundCurrency(Math.max(decimalValue(lineTotal) - taxAmount, 0));
-}
 
 function buildInvoiceLiabilityDrafts(
   registration: TaxRegistrationRecord,

--- a/apps/web/lib/finance/tax-remittance-core.ts
+++ b/apps/web/lib/finance/tax-remittance-core.ts
@@ -1,0 +1,115 @@
+// apps/web/lib/finance/tax-remittance-core.ts
+//
+// Pure (no prisma / auth / Next.js) domain helpers for tax remittance: id
+// generation, date/number/string utilities, and the managed-issue-type set.
+// Extracted verbatim from lib/actions/tax-remittance.ts (BI-OPT-FAT-ACTIONS,
+// Slice A) so the domain logic lives in the finance domain layer and is
+// unit-testable on its own. Behavior-preserving relocation — identical bodies.
+
+import { createHash } from "crypto";
+import { nanoid } from "nanoid";
+
+export const MANAGED_TAX_ISSUE_TYPES = new Set([
+  "tax_setup_mode_unknown",
+  "tax_home_jurisdiction_missing",
+  "tax_footprint_missing",
+  "tax_registration_research_needed",
+  "tax_registration_number_missing",
+  "tax_registration_live_verification_needed",
+  "tax_external_handoff_missing",
+  "tax_dpf_filing_not_available",
+]);
+
+export function nullableString(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function appendNote(existing: string | null, incoming?: string | null) {
+  const next = nullableString(incoming);
+  if (!next) return existing;
+  const current = nullableString(existing);
+  if (!current) return next;
+  if (current.includes(next)) return current;
+  return `${current}\n${next}`;
+}
+
+export function registrationPublicId() {
+  return `TAX-REG-${nanoid(8).toUpperCase()}`;
+}
+
+export function issuePublicId() {
+  return `TAX-ISS-${nanoid(8).toUpperCase()}`;
+}
+
+export function periodPublicId() {
+  return `TAX-PER-${nanoid(8).toUpperCase()}`;
+}
+
+export function taxMonitorTaskId() {
+  return `tax-monitor-${nanoid(8).toLowerCase()}`;
+}
+
+export function credentialPublicId() {
+  return `TAX-CRED-${nanoid(8).toUpperCase()}`;
+}
+
+export function remittanceRunPublicId() {
+  return `TAX-RUN-${nanoid(8).toUpperCase()}`;
+}
+
+export function taxExecutionTaskId() {
+  return `tax-run-${nanoid(8).toLowerCase()}`;
+}
+
+export function stableTaxEntityId(prefix: string, ...parts: Array<string | number | Date | null | undefined>) {
+  const digest = createHash("sha1")
+    .update(
+      parts
+        .map((part) => {
+          if (part instanceof Date) return part.toISOString();
+          return part == null ? "" : String(part);
+        })
+        .join("|"),
+    )
+    .digest("hex")
+    .slice(0, 12)
+    .toUpperCase();
+  return `${prefix}-${digest}`;
+}
+
+export function issueKey(issueType: string, registrationId?: string | null, periodId?: string | null) {
+  return [issueType, registrationId ?? "profile", periodId ?? "none"].join(":");
+}
+
+export function decimalValue(value: unknown) {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") return Number(value) || 0;
+  if (value && typeof value === "object" && "toNumber" in value && typeof value.toNumber === "function") {
+    return value.toNumber();
+  }
+  if (value && typeof value === "object" && "toString" in value && typeof value.toString === "function") {
+    return Number(value.toString()) || 0;
+  }
+  return 0;
+}
+
+export function roundCurrency(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
+export function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+export function addMonths(date: Date, months: number) {
+  const next = new Date(date);
+  next.setUTCMonth(next.getUTCMonth() + months);
+  return next;
+}
+
+export function taxableBaseFromLine(lineTotal: unknown, taxAmount: number) {
+  return roundCurrency(Math.max(decimalValue(lineTotal) - taxAmount, 0));
+}


### PR DESCRIPTION
First code slice of BI-OPT-FAT-ACTIONS (the 8th EP-PLATFORM-OPTIMIZATION BI). Lowest-risk, behavior-preserving step from the extraction plan.

## What
Moves the **17 pure helpers** (id generators, date/number/string utils, `MANAGED_TAX_ISSUE_TYPES`) out of the 1,875-LOC `lib/actions/tax-remittance.ts` into a new `lib/finance/tax-remittance-core.ts`. Identical bodies; the 42 call sites are unchanged; dead `createHash`/`nanoid` imports removed. Action file → 1,787 LOC; domain logic is now unit-testable in the finance layer.

## Why it's safe
Pure functions only — no `prisma`/`auth`/`revalidatePath` touched. Verified by the existing `apps/web/lib/actions/tax-remittance.test.ts` (the 12 actions delegate; the test exercises them unchanged). Slice B (prisma orchestration) and `build`/`crm`/`ea` follow as separate PRs.

## Verification
Gating on CI (Typecheck + Production Build + `tax-remittance.test.ts`) — not source-only-then-trust. **Held for review, no auto-merge** (financial domain).

Process-Spine-Decision: implementation of BI-OPT-FAT-ACTIONS Slice A; the design/plan lives in `docs/superpowers/plans/2026-06-26-fat-actions-tax-remittance-extraction.md` (PR #2435). This PR is a behavior-preserving relocation of pure helpers, no new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)