### PR TITLE
fix(golden-triangle): label corners, center the triangle, plain-language copy

### DIFF
--- a/apps/web/components/golden-triangle/GoldenTriangleControl.test.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.test.tsx
@@ -35,9 +35,16 @@ describe("GoldenTriangleControl", () => {
     expect(screen.getByText(/Frontier tier/)).toBeInTheDocument();
   });
 
-  it("shows a plain-language summary for the active posture", () => {
+  it("shows the configured-chip explanation for the active posture", () => {
     render(<Harness initial={preferenceFromPreset("frugal")} />);
-    expect(screen.getByText(/May take a little longer/)).toBeInTheDocument();
+    expect(screen.getByText(/Cost-first/)).toBeInTheDocument();
+  });
+
+  it("labels the three triangle corners with what each buys", () => {
+    render(<Harness initial={preferenceFromPreset("balanced")} />);
+    expect(screen.getByText("Higher Reasoning")).toBeInTheDocument();
+    expect(screen.getByText("Lower Cost")).toBeInTheDocument();
+    expect(screen.getByText("Lower Time")).toBeInTheDocument();
   });
 
   it("exposes three numeric weight inputs (canonical accessible control)", () => {

--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -87,7 +87,7 @@ export function GoldenTriangleControl({
   const labelId = useId();
 
   const w = normalize(value);
-  const { plain, chips } = decodePostureForDisplay(value, taskClass, authorityScopeKind);
+  const { chips } = decodePostureForDisplay(value, taskClass, authorityScopeKind);
   const balance = balanceState(w.qualityWeight, w.costWeight, w.timeWeight);
   const point = weightsToPoint(w.qualityWeight, w.costWeight, w.timeWeight);
   const thumb = unitToVb(point.x, point.y);
@@ -138,8 +138,8 @@ export function GoldenTriangleControl({
 
   const triangle = (
     <div
-      className={["relative h-auto w-full", compact ? "max-w-[150px]" : "max-w-[220px]"].join(" ")}
-      style={{ aspectRatio: "1 / 1" }}
+      className={["relative mx-auto h-auto w-full", compact ? "max-w-[180px]" : "max-w-[240px]"].join(" ")}
+      style={{ aspectRatio: "1 / 1", overflow: "visible" }}
     >
       <GoldenTriangleGradient
         qualityWeight={w.qualityWeight}
@@ -152,6 +152,7 @@ export function GoldenTriangleControl({
         viewBox="0 0 100 100"
         className="absolute inset-0 h-full w-full touch-none select-none"
         role="img"
+        style={{ overflow: "visible" }}
       aria-label={`Cost, quality and time priority triangle. Quality ${pct(w.qualityWeight)} percent, cost ${pct(
         w.costWeight,
       )} percent, time ${pct(w.timeWeight)} percent. Balance: ${balance.label}. Drag the point or use the inputs to fine-tune.`}
@@ -167,8 +168,18 @@ export function GoldenTriangleControl({
         draggingRef.current = false;
       }}
     >
-      {/* No vertex labels — the gradient colour conveys the state (founder direction).
-          Axis identity stays accessible via the SVG aria-label + the numeric inputs. */}
+      {/* Corner labels — what pulling the point toward each vertex buys (founder
+          direction, 2026-06-26). The gradient still colour-codes balance; SR gets
+          the axes from role="img" + aria-label, so these stay purely visual. */}
+      <text x={50} y={7} textAnchor="middle" fontSize={6} fontWeight={500} fill="var(--dpf-text-secondary)">
+        Higher Reasoning
+      </text>
+      <text x={1} y={97} textAnchor="start" fontSize={6} fontWeight={500} fill="var(--dpf-text-secondary)">
+        Lower Cost
+      </text>
+      <text x={99} y={97} textAnchor="end" fontSize={6} fontWeight={500} fill="var(--dpf-text-secondary)">
+        Lower Time
+      </text>
       <polygon
         points={`${vQuality.x},${vQuality.y} ${vCost.x},${vCost.y} ${vTime.x},${vTime.y}`}
         fill="transparent"
@@ -220,10 +231,7 @@ export function GoldenTriangleControl({
       )}
 
       <div className="mb-1.5">{balancePill}</div>
-      <p className="mb-2 text-[14px] font-medium leading-snug text-[var(--dpf-text)]" aria-live="polite">
-        {plain}
-      </p>
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-wrap gap-1.5" aria-live="polite">
         {chips.map((chip, i) => (
           <span
             key={`${chip.label}-${i}`}
@@ -294,8 +302,8 @@ export function GoldenTriangleControl({
         })}
       </div>
 
-      <div className={compact ? "grid gap-3" : "grid gap-4 sm:grid-cols-[200px_1fr]"}>
-        <div>{triangle}</div>
+      <div className={compact ? "grid gap-3" : "grid gap-4"}>
+        {triangle}
         {readout}
       </div>
     </div>

--- a/apps/web/components/golden-triangle/README.md
+++ b/apps/web/components/golden-triangle/README.md
@@ -10,11 +10,11 @@
   3. **Numeric inputs (canonical accessible control):** three labelled percent inputs — a 2D drag surface is *not* a 1-D ARIA slider, so the numeric/preset layer is the accessible source of truth.
 - **`GoldenTrianglePriorityPanel`** — a stateful host (view-local state) for the platform-default settings surface.
 - **`CoworkerPriorityDock`** — the per-coworker control docked in-flow at the composer (collapsed by default to a colour-graded chip; expands to the full control). Replaced the old `CoworkerPriorityControl` header popover, which clipped off the panel edge.
-- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, `postureLabel()` (a meaningful label at every position — "Max Quality", "Quality-first", …), `describeConfigured()` / `plainSummary()` (derived from the **real Slice 1 compiler** so the UI never drifts), `TRIANGLE_AXIS_GUIDE` (the min/max explainer), and `balanceState()` for the colour cue.
+- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, `postureLabel()` (a meaningful label at every position — "Max Quality", "Quality-first", …), `describeConfigured()` (the configured-chip explanation, derived from the **real Slice 1 compiler** so the UI never drifts), `TRIANGLE_AXIS_GUIDE` (the min/max explainer), and `balanceState()` for the colour cue.
 
 ## Balance colouring
 
-The triangle shades by balance: **green** when the three axes are centred, through **yellow** to **red** as one or two axes get starved (the posture pushes toward an edge or vertex). There are no vertex labels — the gradient colour conveys the state (founder direction) — and a balance pill names it ("Well balanced" / "Starving Time"). It is an at-a-glance cue that you are trading something away.
+The triangle shades by balance: **green** when the three axes are centred, through **yellow** to **red** as one or two axes get starved (the posture pushes toward an edge or vertex). Each vertex is labelled with what pulling toward it buys — **Higher Reasoning** (top), **Lower Cost** (bottom-left), **Lower Time** (bottom-right) — while the gradient colour conveys balance, named by a balance pill ("Well balanced" / "Starving Time"). It is an at-a-glance cue that you are trading something away.
 
 ## Surfaces
 

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -7,7 +7,6 @@ import {
   balanceState,
   decodePostureForDisplay,
   describeConfigured,
-  plainSummary,
   pointToWeights,
   postureLabel,
   preferenceFromPreset,
@@ -80,30 +79,10 @@ describe("describeConfigured (driven by the real compiler)", () => {
   });
 });
 
-describe("plainSummary", () => {
-  it("uses the preset line for named presets", () => {
-    expect(plainSummary(preferenceFromPreset("fast"))).toMatch(/Quickest/);
-    expect(plainSummary(preferenceFromPreset("frugal"))).toMatch(/least/i);
-  });
-
-  it("describes a moderate custom lean", () => {
-    expect(plainSummary({ preset: "custom", qualityWeight: 0.45, costWeight: 0.3, timeWeight: 0.25 })).toMatch(/right/i);
-  });
-
-  it("maxing Quality describes a debate (the top of the rigor ladder)", () => {
-    expect(plainSummary({ preset: "custom", qualityWeight: 0.9, costWeight: 0.05, timeWeight: 0.05 })).toMatch(/debate/i);
-  });
-
-  it("falls back to balanced for an unfocused custom posture", () => {
-    expect(plainSummary({ preset: "custom", qualityWeight: 0.34, costWeight: 0.33, timeWeight: 0.33 })).toMatch(/balance/i);
-  });
-});
-
 describe("decodePostureForDisplay", () => {
-  it("returns decoded policy + plain + chips together", () => {
+  it("returns decoded policy + chips together", () => {
     const view = decodePostureForDisplay(preferenceFromPreset("frugal"));
     expect(view.decoded.postureOverride.budgetClass).toBe("minimize_cost");
-    expect(view.plain).toMatch(/least/i);
     expect(view.chips.length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -87,14 +87,7 @@ export function preferenceFromPreset(preset: Exclude<GoldenTrianglePreset, "cust
   return { preset, qualityWeight, costWeight, timeWeight };
 }
 
-// ── Plain-language summary ──────────────────────────────────────────────────
-const PLAIN: Record<Exclude<GoldenTrianglePreset, "custom">, string> = {
-  fast: "Quickest result. Less checking.",
-  balanced: "A sensible balance — platform defaults.",
-  assured: "Strongest model, deeper review. Higher cost and time.",
-  frugal: "Spends the least. May take a little longer.",
-};
-
+// ── Posture label (dominant axis → a short, meaningful name) ─────────────────
 function dominantAxis(p: GoldenTrianglePreference): { axis: "quality" | "cost" | "time"; weight: number } {
   const s = Math.max(0, p.qualityWeight) + Math.max(0, p.costWeight) + Math.max(0, p.timeWeight) || 1;
   const q = Math.max(0, p.qualityWeight) / s;
@@ -118,20 +111,6 @@ function dominantAxis(p: GoldenTrianglePreference): { axis: "quality" | "cost" |
 // multi-perspective debate (the compiler emits it at qualityWeight >= 0.85, the
 // same QUALITY_DEBATE_FLOOR) — above the single review the Assured preset buys.
 const QUALITY_DEBATE_FLOOR = 0.85;
-
-export function plainSummary(pref: GoldenTrianglePreference): string {
-  if (pref.preset !== "custom") return PLAIN[pref.preset];
-  const { axis, weight } = dominantAxis(pref);
-  if (weight < 0.4) return PLAIN.balanced;
-  if (axis === "quality") {
-    if (weight >= QUALITY_DEBATE_FLOOR) {
-      return "Maxed for quality: strongest model, max effort, deep review, and a multi-perspective debate. Highest cost and time.";
-    }
-    return weight >= 0.55 ? PLAIN.assured : "Leaning toward getting it right.";
-  }
-  if (axis === "cost") return weight >= 0.55 ? PLAIN.frugal : "Leaning toward saving money.";
-  return weight >= 0.55 ? PLAIN.fast : "Leaning toward speed.";
-}
 
 /**
  * A short, meaningful label for ANY posture — the preset name for a preset, or a
@@ -188,14 +167,13 @@ export function describeConfigured(decoded: DecodedPolicy): ConfigChip[] {
   if (ob.retryBudget !== undefined) {
     chips.push({ icon: "refresh", label: `${ob.retryBudget} ${ob.retryBudget === 1 ? "retry" : "retries"}` });
   }
-  if (po.maxLatencyMs !== undefined) chips.push({ icon: "clock", label: `${Math.round(po.maxLatencyMs / 1000)}s target` });
+  if (po.maxLatencyMs !== undefined) chips.push({ icon: "clock", label: `Under ${Math.round(po.maxLatencyMs / 1000)}s` });
   if (chips.length === 0) chips.push({ icon: "adjustments-horizontal", label: "Platform defaults" });
   return chips;
 }
 
 export interface PostureView {
   decoded: DecodedPolicy;
-  plain: string;
   chips: ConfigChip[];
 }
 
@@ -210,7 +188,7 @@ export function decodePostureForDisplay(
     taskClass,
     authorityScope: { kind: authorityScopeKind },
   });
-  return { decoded, plain: plainSummary(pref), chips: describeConfigured(decoded) };
+  return { decoded, chips: describeConfigured(decoded) };
 }
 
 // ── Balance / starvation colouring ──────────────────────────────────────────


### PR DESCRIPTION
Founder UX pass on the Cost/Quality/Time posture control (the Golden Triangle), addressing four pieces of direct feedback.

## What changed
1. **Corner labels** — each vertex now says what pulling toward it buys: **Higher Reasoning** (top), **Lower Cost** (bottom-left), **Lower Time** (bottom-right). (Supersedes the earlier "no vertex labels" choice, per new founder direction.)
2. **Centered + de-cramped layout** — the triangle is centered (`mx-auto`) with the readout stacked beneath it, replacing the narrow ~200px left column that left dead space on the right. This also gives the corner labels room to render (`overflow: visible`).
3. **Removed the jumpy white prose** — the variable-length summary reflowed as you dragged the point (shoving the triangle up/down) and duplicated the configured-chip list below it. The chips remain as the explanation, now an `aria-live` region so screen readers still hear changes.
4. **Plainer time language** — latency chip `"30s target"` → `"Under 30s"`; the unconventional `"Higher/Highest cost and time"` phrasing is gone with the prose. Dead `plainSummary`/`PLAIN` helpers removed.

## Files
- `apps/web/components/golden-triangle/GoldenTriangleControl.tsx`
- `apps/web/components/golden-triangle/posture-display.ts`
- `apps/web/components/golden-triangle/{GoldenTriangleControl,posture-display}.test.ts(x)`
- `apps/web/components/golden-triangle/README.md`

## Verification
- **26/26** golden-triangle unit tests pass (incl. a new test asserting the three corner labels render).
- `tsc` clean for the touched files. (Local full-tree tsc showed only stale-Prisma false positives from a borrowed verification toolchain — unrelated to this change; CI runs the authoritative typecheck.)

Surfaces: `/platform/ai/assignments` (Everyday priority panel) and the per-coworker priority dock at the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)