### PR TITLE
refactor(storefront-admin): className palette literals → --dpf-* tokens (§12) (BI-CB6EF360)

### DIFF
--- a/apps/web/components/storefront-admin/ItemFormDialog.tsx
+++ b/apps/web/components/storefront-admin/ItemFormDialog.tsx
@@ -484,7 +484,7 @@ function Field({ label, required, children }: { label: string; required?: boolea
   return (
     <label className="block">
       <span className="text-xs text-[var(--dpf-muted)] mb-1 block">
-        {label}{required && <span className="text-red-400 ml-0.5">*</span>}
+        {label}{required && <span className="text-[var(--dpf-error)] ml-0.5">*</span>}
       </span>
       {children}
     </label>

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -290,7 +290,7 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
                 </button>
                 <button
                   onClick={() => handleDelete(item)}
-                  className="text-[10px] px-2 py-0.5 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-red-400 hover:border-red-400/30 transition-colors"
+                  className="text-[10px] px-2 py-0.5 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-error)] hover:border-[var(--dpf-error)]/30 transition-colors"
                   title="Delete"
                 >
                   Del


### PR DESCRIPTION
## What

Converts the **two residual Tailwind palette classNames** in `storefront-admin/` to AGENTS.md §12 `--dpf-*` tokens. These are the className-literal complement to the inline-`style={{}}` migration done in **#2434** (BI-75645278), which by design touched inline styles only and left these className literals behind.

| File | Before | After |
|---|---|---|
| `ItemFormDialog.tsx:487` (required-field `*`) | `text-red-400` | `text-[var(--dpf-error)]` |
| `ItemsManager.tsx:293` (Delete button) | `hover:text-red-400 hover:border-red-400/30` | `hover:text-[var(--dpf-error)] hover:border-[var(--dpf-error)]/30` |

2 files, 2 lines changed.

## Why it's an intentional hue shift (not 1:1)

§12 tokens are the canonical brand colors, so this is a **theme-aware** swap, not a literal color match. `--dpf-error` resolves to:
- **dark mode `#f87171`** — a pixel match for Tailwind `red-400`, and
- **light mode `#dc2626`** — the deeper canonical brand error red.

That divergence *is* the §12 intent: one token, correct in light, dark, and custom branding. Calling it out explicitly since the light-mode error red shifts slightly darker.

## Scope boundaries

- **Left as-is (allowed):** the two `text-white` labels on `bg-[var(--dpf-accent)]` buttons (`ItemsManager.tsx` 203/215) — §12's *sole* permitted hardcoded exception.
- **Out of scope (follow-up):** the broader apps/web palette-className footprint — **~273 occurrences across ~74 files** (incl. non-code `data/design-intelligence/*.csv`). Deliberately not folded in to keep this a small, reviewable refactor. Candidate for a separate sweep under EP-PLATFORM-CONSOLIDATION.

## Verification

- **Grep is the authoritative check here** — the Style Drift Guard (`scripts/check-style-drift.mjs`) only catches hardcoded **hex**, not Tailwind palette classNames. Post-change grep of `storefront-admin/` shows **no palette classNames remain** except the allowed `text-white`-on-accent exception.
- **Typecheck:** ran the full `tsc --noEmit` against a junctioned toolchain — **zero diagnostics for the two changed files** (this source-only worktree has no `node_modules`; the only seeded sibling is 3 days stale, so its 92 unrelated Prisma/subpath drift errors are noise, none touching this change). The required **CI Typecheck** gate is authoritative.

## Overlap

Sibling of the still-open **#2434**. Both touch these two files but at **disjoint, non-adjacent line ranges** (#2434: 173–191/468–475 and 186–193/275–282; this: 487 and 293) — they auto-merge in either order.

## Backlog

Filed **BI-CB6EF360** under **EP-PLATFORM-CONSOLIDATION** (portfolio / refactor / build / small), sibling to BI-75645278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
