### PR TITLE
feat(observability): deterministic watchdog phase-duration calibration + ascent design pass (BI-A1FC3EBB)

### DIFF
--- a/apps/web/lib/observability/phase-duration-baseline.test.ts
+++ b/apps/web/lib/observability/phase-duration-baseline.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assessThresholdCalibration,
+  MIN_SAMPLES_FOR_CALIBRATION,
+  summarizePhaseDurationBaseline,
+  TOO_LOOSE_RATIO,
+  type PhaseDurationStats,
+} from "./phase-duration-baseline";
+
+describe("summarizePhaseDurationBaseline", () => {
+  it("computes per-phase count/p50/p95/max with nearest-rank percentiles", () => {
+    const samples = [
+      ...Array.from({ length: 10 }, (_, i) => ({ phase: "build", durationMs: (i + 1) * 1000 })), // 1000..10000
+      { phase: "ideate", durationMs: 500 },
+    ];
+    const out = summarizePhaseDurationBaseline(samples);
+
+    expect(out.build!.count).toBe(10);
+    expect(out.build!.p50Ms).toBe(5000); // ceil(0.5*10)=5 → idx 4
+    expect(out.build!.p95Ms).toBe(10000); // ceil(0.95*10)=10 → idx 9
+    expect(out.build!.maxMs).toBe(10000);
+    expect(out.ideate!.count).toBe(1);
+    expect(out.ideate!.p95Ms).toBe(500);
+  });
+
+  it("drops non-finite/negative durations and omits phases left empty", () => {
+    const out = summarizePhaseDurationBaseline([
+      { phase: "build", durationMs: -5 },
+      { phase: "build", durationMs: Number.NaN },
+      { phase: "plan", durationMs: 2000 },
+    ]);
+    expect(out.build).toBeUndefined();
+    expect(out.plan!.count).toBe(1);
+  });
+
+  it("returns an empty object for no samples", () => {
+    expect(summarizePhaseDurationBaseline([])).toEqual({});
+  });
+});
+
+describe("assessThresholdCalibration", () => {
+  const stats = (over: Partial<PhaseDurationStats> = {}): PhaseDurationStats => ({
+    count: 50,
+    p50Ms: 1000,
+    p95Ms: 2000,
+    maxMs: 3000,
+    ...over,
+  });
+
+  it("withholds a verdict below the sample floor", () => {
+    const r = assessThresholdCalibration({
+      stats: stats({ count: MIN_SAMPLES_FOR_CALIBRATION - 1 }),
+      seededTotalTimeoutMs: 10_000,
+    });
+    expect(r.verdict).toBe("insufficient-data");
+    expect(r.ratio).toBeNull();
+  });
+
+  it("withholds a verdict when stats are missing", () => {
+    expect(
+      assessThresholdCalibration({ stats: undefined, seededTotalTimeoutMs: 10_000 }).verdict,
+    ).toBe("insufficient-data");
+  });
+
+  it("flags too-tight when p95 exceeds the seeded total-timeout", () => {
+    const r = assessThresholdCalibration({ stats: stats({ p95Ms: 12_000 }), seededTotalTimeoutMs: 10_000 });
+    expect(r.verdict).toBe("too-tight");
+    expect(r.ratio).toBeCloseTo(1.2, 5);
+  });
+
+  it("flags too-loose when p95 is far under the seeded total-timeout", () => {
+    const r = assessThresholdCalibration({ stats: stats({ p95Ms: 1000 }), seededTotalTimeoutMs: 10_000 }); // 0.1
+    expect(r.verdict).toBe("too-loose");
+    expect(r.ratio!).toBeLessThan(TOO_LOOSE_RATIO);
+  });
+
+  it("reads ok when p95 sits comfortably within the timeout", () => {
+    const r = assessThresholdCalibration({ stats: stats({ p95Ms: 5000 }), seededTotalTimeoutMs: 10_000 }); // 0.5
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("guards against a non-positive timeout", () => {
+    expect(
+      assessThresholdCalibration({ stats: stats(), seededTotalTimeoutMs: 0 }).verdict,
+    ).toBe("insufficient-data");
+  });
+});

--- a/apps/web/lib/observability/phase-duration-baseline.ts
+++ b/apps/web/lib/observability/phase-duration-baseline.ts
@@ -1,0 +1,136 @@
+// Phase-duration baseline + threshold-calibration check for the taskrun
+// watchdog (BI-A1FC3EBB, EP-FULL-OBS).
+//
+// The watchdog's PRIMARY stall signal is heartbeat silence (`decideStall` in
+// watchdog-detect.ts) — a crisp deadness signal that needs no learning: a dead
+// process stops heartbeating. Per the platform bridge-pattern doctrine (ascend
+// to AI only where a boundary is genuinely fuzzy, then re-descend to code) we
+// keep that deterministic. The one genuinely naive part is the per-phase TOTAL
+// timeout: a hand-seeded `BuildStudioStallThreshold` constant that nobody checks
+// against the actual phase-duration distribution. A phase whose real p95 exceeds
+// its seeded total-timeout false-stalls legitimate slow runs; one far under it
+// leaves the wall-clock backstop lax.
+//
+// This module makes that calibration observable from data already collected but
+// never read for this purpose — `BuildPhaseRun.durationMs`. Pure + deterministic
+// (no DB, no clock) so it is fully unit-testable; the watchdog/report wires the
+// query. A learned/statistical anomaly step is deferred and conditional (the
+// distribution must be visible first). See the design pass:
+// docs/superpowers/plans/2026-06-26-watchdog-phase-duration-baseline-design.md
+
+export interface PhaseDurationSample {
+  phase: string;
+  /** Completed-phase duration in ms (BuildPhaseRun.durationMs). */
+  durationMs: number;
+}
+
+export interface PhaseDurationStats {
+  count: number;
+  p50Ms: number;
+  p95Ms: number;
+  maxMs: number;
+}
+
+/**
+ * Per-phase duration baseline from completed `BuildPhaseRun` rows. Percentiles
+ * use nearest-rank on the sorted samples (deterministic, no interpolation).
+ * Non-finite/negative durations are dropped; phases with no valid samples are
+ * omitted entirely.
+ */
+export function summarizePhaseDurationBaseline(
+  samples: PhaseDurationSample[],
+): Record<string, PhaseDurationStats> {
+  const byPhase = new Map<string, number[]>();
+  for (const s of samples) {
+    if (!Number.isFinite(s.durationMs) || s.durationMs < 0) continue;
+    const arr = byPhase.get(s.phase) ?? [];
+    arr.push(s.durationMs);
+    byPhase.set(s.phase, arr);
+  }
+
+  const out: Record<string, PhaseDurationStats> = {};
+  for (const [phase, durations] of byPhase) {
+    durations.sort((a, b) => a - b);
+    out[phase] = {
+      count: durations.length,
+      p50Ms: percentileNearestRank(durations, 50),
+      p95Ms: percentileNearestRank(durations, 95),
+      maxMs: durations[durations.length - 1]!,
+    };
+  }
+  return out;
+}
+
+/** Nearest-rank percentile on an already-ascending, non-empty array. */
+function percentileNearestRank(sortedAsc: number[], p: number): number {
+  const rank = Math.ceil((p / 100) * sortedAsc.length); // 1-based
+  const idx = Math.min(sortedAsc.length, Math.max(1, rank)) - 1;
+  return sortedAsc[idx]!;
+}
+
+export type CalibrationVerdict = "ok" | "too-tight" | "too-loose" | "insufficient-data";
+
+export interface CalibrationAssessment {
+  verdict: CalibrationVerdict;
+  /** observed p95 / seeded total-timeout; null when insufficient data. */
+  ratio: number | null;
+  reason: string;
+}
+
+/** Minimum completed phase runs before a calibration verdict is trustworthy. */
+export const MIN_SAMPLES_FOR_CALIBRATION = 20;
+/** Below this p95/timeout ratio the wall-clock backstop is considered lax. */
+export const TOO_LOOSE_RATIO = 0.25;
+
+/**
+ * Compare a phase's seeded total-timeout against its observed p95 duration:
+ *   - p95 above the timeout  → too-tight (legitimate runs risk false stalls)
+ *   - p95 far below it        → too-loose (the wall-clock backstop is lax)
+ *
+ * Deterministic; the sample floor and ratio are explicit + the learnable
+ * surface. ADVISORY ONLY — this never changes reaping; it tells an operator
+ * whether the seeded constant still matches reality.
+ */
+export function assessThresholdCalibration(args: {
+  stats: PhaseDurationStats | undefined;
+  seededTotalTimeoutMs: number;
+}): CalibrationAssessment {
+  const { stats, seededTotalTimeoutMs } = args;
+
+  if (!stats || stats.count < MIN_SAMPLES_FOR_CALIBRATION) {
+    return {
+      verdict: "insufficient-data",
+      ratio: null,
+      reason: `need >= ${MIN_SAMPLES_FOR_CALIBRATION} completed runs to judge calibration`,
+    };
+  }
+  if (!(seededTotalTimeoutMs > 0)) {
+    return { verdict: "insufficient-data", ratio: null, reason: "no positive total-timeout to compare against" };
+  }
+
+  const ratio = stats.p95Ms / seededTotalTimeoutMs;
+
+  if (stats.p95Ms > seededTotalTimeoutMs) {
+    return {
+      verdict: "too-tight",
+      ratio,
+      reason: `p95 (${ms(stats.p95Ms)}) exceeds the ${ms(seededTotalTimeoutMs)} total-timeout — legitimate runs risk false stalls`,
+    };
+  }
+  if (ratio < TOO_LOOSE_RATIO) {
+    return {
+      verdict: "too-loose",
+      ratio,
+      reason: `p95 (${ms(stats.p95Ms)}) is well under the ${ms(seededTotalTimeoutMs)} total-timeout — the backstop is lax`,
+    };
+  }
+  return {
+    verdict: "ok",
+    ratio,
+    reason: `p95 (${ms(stats.p95Ms)}) sits within the ${ms(seededTotalTimeoutMs)} total-timeout`,
+  };
+}
+
+function ms(v: number): string {
+  return v >= 1000 ? `${Math.round(v / 1000)}s` : `${Math.round(v)}ms`;
+}

--- a/docs/superpowers/plans/2026-06-26-watchdog-phase-duration-baseline-design.md
+++ b/docs/superpowers/plans/2026-06-26-watchdog-phase-duration-baseline-design.md
@@ -1,0 +1,94 @@
+# Watchdog phase-duration calibration — design pass
+
+- **BI:** BI-A1FC3EBB — "taskrun-watchdog learned phase-duration anomaly detection vs fixed timeouts"
+- **Epic:** EP-FULL-OBS
+- **Date:** 2026-06-26
+- **Status:** design pass complete; deterministic primitives shipped with this doc; learned/statistical anomaly deferred (conditional — see §5)
+
+## 0. TL;DR
+
+The BI asks to replace fixed timeouts with a *learned* phase-duration anomaly
+detector. Applying the same bridge-pattern test the curator (BI-93FE150F) just
+got: **the watchdog's primary boundary is already crisp.** It stalls a TaskRun on
+*heartbeat silence* — a dead process stops heartbeating — and it *already*
+resolves per-phase thresholds. A learned model over phase durations would be
+over-engineering the one signal that is inherently sharp.
+
+The genuine, narrow gap is calibration: the per-phase **total-timeout** is a
+hand-seeded constant nobody checks against the actual duration distribution. This
+pass ships the deterministic primitives to make that calibration observable
+(`summarizePhaseDurationBaseline`, `assessThresholdCalibration`) and **re-scopes**
+the BI from "learn anomalies" to "calibrate deterministically; ascend only if the
+boundary proves fuzzy."
+
+## 1. What the BI assumed vs. what the code is
+
+| BI premise | Reality in `main` |
+|---|---|
+| "fixed timeouts" (implying one global timeout) | Per-phase thresholds already (`BuildStudioStallThreshold`: ideate 90/900, plan 120/1800, build 180/3600, …) |
+| Stall = phase-duration anomaly | Stall = **heartbeat silence** first; total-duration is only a wall-clock backstop |
+| Needs a learned classifier | The deadness signal is crisp; only the backstop constant is uncalibrated |
+
+Evidence:
+- `apps/web/lib/observability/watchdog-detect.ts:40` — `decideStall()`: priority is `total_timeout` (wall-clock) → `never_started` → `heartbeat_timeout` (silence). Heartbeat silence is the core signal.
+- `apps/web/lib/queue/functions/taskrun-watchdog.ts:~250,289` — resolves a **per-phase** threshold (`thresholdByScope`) then calls `decideStall`. On a positive it marks `status="stalled"` + writes a `StallEvent` + notifies; recovery is operator-driven (it does **not** auto-reap).
+- `packages/db/src/seed-stall-thresholds.ts` — the per-phase constants, seeded once, operator-editable.
+- `packages/db/prisma/schema.prisma` `BuildPhaseRun.durationMs` — completed-phase durations are collected but **never read** to check those constants.
+
+## 2. The bridge-pattern test
+
+- **Heartbeat-silence boundary — CRISP.** "Has the run emitted a heartbeat within
+  the window?" is a binary deadness fact. A learned model here adds a model
+  dependency + non-determinism to reproduce a correct, robust rule. **Keep
+  deterministic. Do not ascend.**
+- **Total-timeout calibration — NAIVE, not fuzzy.** The constant is just
+  *unchecked* against reality, not inherently ambiguous. The fix is to *measure*
+  the distribution (deterministic percentiles), not to *learn* it. A learned
+  step earns its keep only if deterministic p95 calibration later proves
+  insufficient — and even then statistical (z-score) before ML.
+
+## 3. The real gap: silent mis-calibration
+
+A phase whose real p95 exceeds its seeded total-timeout false-stalls legitimate
+slow runs; one whose p95 is a small fraction of the timeout leaves the wall-clock
+backstop lax. Today nobody can see which: `BuildPhaseRun.durationMs` is collected
+and discarded for this purpose. Closing this needs no model and no new
+telemetry — just read the durations already in hand.
+
+## 4. Deterministic primitives — shipped with this pass
+
+`apps/web/lib/observability/phase-duration-baseline.ts`:
+
+- `summarizePhaseDurationBaseline(samples)` → per-phase `{count, p50Ms, p95Ms, maxMs}` (nearest-rank percentiles; drops bad samples).
+- `assessThresholdCalibration({stats, seededTotalTimeoutMs})` → `ok | too-tight | too-loose | insufficient-data`, with explicit, named, *learnable* constants: `MIN_SAMPLES_FOR_CALIBRATION = 20`, `TOO_LOOSE_RATIO = 0.25`.
+
+Pure (no DB, no clock); fully unit-tested. **Advisory only** — nothing here
+changes `decideStall` or reaping. This PR ships the functions + tests; wiring is
+a separate reviewed step (§5).
+
+## 5. Roadmap (deferred — each step gated on the prior's evidence)
+
+1. **v1 — record-only.** A periodic step (reuse the watchdog cron or the metrics
+   aggregator) queries recent `BuildPhaseRun` rows, computes the baseline, and
+   records the calibration verdict per phase (a log line / small report row). No
+   `decideStall` change. *Small, safe, reversible.*
+2. **v2 — operator-facing (needs review).** Surface "phase X total-timeout looks
+   too-tight (p95 Ys > Zs)" in the Build Studio stall-threshold admin so an
+   operator can retune the seeded constant. Suggestion only — never auto-edit.
+3. **v3 — statistical/learned (conditional).** ONLY if v1/v2 evidence shows fixed
+   per-phase constants genuinely can't separate slow-but-progressing from dead.
+   Prefer a deterministic rolling p95 baseline before any ML. **Re-descent
+   criterion:** once the baseline stabilises, fold the tuned value back into the
+   seeded threshold and retire the adaptive step.
+
+## 6. Recommendation
+
+- **Re-scope BI-A1FC3EBB** from "learned phase-duration anomaly detection" to
+  "keep the crisp heartbeat boundary deterministic; calibrate the per-phase
+  total-timeout against the observed distribution; ascend to statistical/learned
+  only if that proves fuzzy." Update the BI body so it no longer implies a global
+  fixed timeout or a mandatory learned step.
+- Proceed to §5 v1 (record-only calibration) as the next watchdog increment.
+- This is the second ascent BI (after the curator) found to be over-scoped toward
+  "learned" when the boundary is crisp — worth promoting "test the boundary for
+  fuzziness before ascending" toward a kernel principle.


### PR DESCRIPTION
## What

Bridge-pattern scrutiny of BI-A1FC3EBB (the watchdog ascent), mirroring the curator (BI-93FE150F): the watchdog's primary stall signal is **heartbeat silence** — a crisp deadness signal (a dead process stops heartbeating) — and it **already resolves per-phase thresholds**. A learned phase-duration anomaly detector would over-engineer that crisp boundary.

The real, narrow gap: the per-phase **total-timeout** is a hand-seeded constant (`BuildStudioStallThreshold`) nobody checks against the actual `BuildPhaseRun.durationMs` distribution → silent mis-calibration (false stalls when too tight; a lax wall-clock backstop when too loose).

## This PR

`apps/web/lib/observability/phase-duration-baseline.ts` — two pure, deterministic functions:
- `summarizePhaseDurationBaseline(samples)` → per-phase `{count, p50Ms, p95Ms, maxMs}` (nearest-rank percentiles).
- `assessThresholdCalibration({stats, seededTotalTimeoutMs})` → `ok | too-tight | too-loose | insufficient-data`, with explicit, named, *learnable* constants (`MIN_SAMPLES_FOR_CALIBRATION`, `TOO_LOOSE_RATIO`).

Pure (no DB, no clock), fully unit-tested. **Advisory only** — nothing here touches `decideStall` or the reaping path.

## Scope

Re-scopes BI-A1FC3EBB from "learned anomaly detection" → "keep the crisp heartbeat boundary deterministic; calibrate the per-phase total-timeout against the observed distribution; ascend to statistical/learned only if that proves fuzzy." Wiring (record-only first) and any learned step are deferred, reviewed follow-ups per the design doc.

This is the **second** ascent BI found over-scoped toward "learned" when the boundary is crisp — the design doc recommends promoting *"test the boundary for fuzziness before ascending"* toward a kernel principle.

## Verification

Co-located vitest; relies on CI (source-only worktree, no local toolchain). No UI (UX-Fit N/A); the design-doc touch satisfies the Spec/Plan/Doc gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
