### PR TITLE
feat(observability): self-driving migration signal (1) - tool-reasoning stability detector + keystone design pass (BI-A028AA14)

### DIFF
--- a/apps/web/lib/observability/tool-reasoning-stability.test.ts
+++ b/apps/web/lib/observability/tool-reasoning-stability.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MIN_RECURRENCE_TO_JUDGE,
+  summarizeToolReasoningStability,
+  type ToolReasoningSample,
+} from "./tool-reasoning-stability";
+
+function samples(
+  over: { agentId?: string; toolName?: string; inputShape?: string },
+  outputs: { outputDigest: string; success?: boolean }[],
+): ToolReasoningSample[] {
+  return outputs.map((o) => ({
+    agentId: over.agentId ?? "agt",
+    toolName: over.toolName ?? "tool",
+    inputShape: over.inputShape ?? "shape",
+    outputDigest: o.outputDigest,
+    success: o.success ?? true,
+  }));
+}
+
+function repeat(n: number, outputDigest: string, success = true) {
+  return Array.from({ length: n }, () => ({ outputDigest, success }));
+}
+
+describe("summarizeToolReasoningStability", () => {
+  it("returns insufficient-data below the recurrence floor", () => {
+    const rows = summarizeToolReasoningStability(samples({}, repeat(MIN_RECURRENCE_TO_JUDGE - 1, "X")));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.verdict).toBe("insufficient-data");
+    expect(rows[0]!.recurrence).toBe(MIN_RECURRENCE_TO_JUDGE - 1);
+  });
+
+  it("flags a recurring, low-variance, high-success pattern as stabilized (codify candidate)", () => {
+    const rows = summarizeToolReasoningStability(samples({}, repeat(20, "SAME")));
+    expect(rows[0]!.verdict).toBe("stabilized");
+    expect(rows[0]!.recurrence).toBe(20);
+    expect(rows[0]!.distinctOutputs).toBe(1);
+    expect(rows[0]!.varianceRatio).toBe(0.05);
+    expect(rows[0]!.successRate).toBe(1);
+  });
+
+  it("keeps a high-variance pattern as variable (genuine AI judgment, don't codify)", () => {
+    const outs = Array.from({ length: 20 }, (_, i) => ({ outputDigest: `O${i}` })); // all distinct → ratio 1.0
+    const rows = summarizeToolReasoningStability(samples({}, outs));
+    expect(rows[0]!.verdict).toBe("variable");
+    expect(rows[0]!.varianceRatio).toBe(1);
+  });
+
+  it("keeps a consistent-but-failing pattern as variable (never codify broken reasoning)", () => {
+    const outs = [...repeat(10, "SAME", true), ...repeat(10, "SAME", false)]; // 50% success
+    const rows = summarizeToolReasoningStability(samples({}, outs));
+    expect(rows[0]!.distinctOutputs).toBe(1);
+    expect(rows[0]!.successRate).toBe(0.5);
+    expect(rows[0]!.verdict).toBe("variable");
+  });
+
+  it("groups distinct (agent × tool × input-shape) signatures separately", () => {
+    const rows = summarizeToolReasoningStability([
+      ...samples({ agentId: "a1", toolName: "t1", inputShape: "s1" }, repeat(20, "SAME")),
+      ...samples({ agentId: "a2", toolName: "t1", inputShape: "s1" }, repeat(5, "SAME")),
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.agentId === "a1")!.verdict).toBe("stabilized");
+    expect(rows.find((r) => r.agentId === "a2")!.verdict).toBe("insufficient-data");
+  });
+
+  it("orders codify candidates first", () => {
+    const rows = summarizeToolReasoningStability([
+      ...samples({ inputShape: "variable" }, Array.from({ length: 20 }, (_, i) => ({ outputDigest: `O${i}` }))),
+      ...samples({ inputShape: "stable" }, repeat(20, "SAME")),
+    ]);
+    expect(rows[0]!.inputShape).toBe("stable");
+    expect(rows[0]!.verdict).toBe("stabilized");
+  });
+
+  it("returns an empty array for no samples", () => {
+    expect(summarizeToolReasoningStability([])).toEqual([]);
+  });
+});

--- a/apps/web/lib/observability/tool-reasoning-stability.ts
+++ b/apps/web/lib/observability/tool-reasoning-stability.ts
@@ -1,0 +1,125 @@
+// Signal (1) of the self-driving cognitive-load migration loop (BI-A028AA14,
+// EP-COST-001): the AI-to-code "stabilized -> codify" trigger.
+//
+// Distills ToolExecution telemetry into a per-(agent x tool x input-shape)
+// stability summary so the migration curator can NOMINATE "codify X" candidates
+// with evidence -- instead of re-reading code every cycle. A reasoning pattern
+// that recurs often, returns the same outcome, and succeeds is a candidate to
+// replace with deterministic code (the descent the whole effort is about).
+//
+// SCOPE -- this is the pure, deterministic STATS CORE only:
+//   - It takes samples whose `inputShape` / `outputDigest` are ALREADY
+//     normalised by the caller. HOW to canonicalise ToolExecution.parameters /
+//     result is a deliberate, tunable decision documented in the design pass and
+//     kept OUT of this codifiable core (so the core never churns when the
+//     normalisation is retuned).
+//   - It NEVER files anything. Turning a "stabilized" verdict into a triaging
+//     "codify X" BI is the auto-nomination wiring -- a separate, FOUNDER-GATED
+//     step, because it mutates the backlog from telemetry. See:
+//     docs/superpowers/plans/2026-06-26-self-driving-migration-nomination-signals-design.md
+
+export interface ToolReasoningSample {
+  agentId: string;
+  toolName: string;
+  /** Caller-normalised signature of the input parameters (the "kind" of call). */
+  inputShape: string;
+  /** Caller-normalised signature of the result (equal digests mean equal outcome). */
+  outputDigest: string;
+  success: boolean;
+}
+
+export type StabilityVerdict =
+  | "stabilized" // recurs often, low output variance, high success -> codify candidate
+  | "variable" // recurs, but outputs vary or it fails too often -> keep as AI judgment
+  | "insufficient-data"; // too few occurrences to judge
+
+export interface ToolReasoningStability {
+  agentId: string;
+  toolName: string;
+  inputShape: string;
+  recurrence: number;
+  distinctOutputs: number;
+  /** distinctOutputs / recurrence, in (0,1]; lower means more deterministic. */
+  varianceRatio: number;
+  /** successes / recurrence, in [0,1]. */
+  successRate: number;
+  verdict: StabilityVerdict;
+}
+
+/** Minimum occurrences of a signature before a verdict is trustworthy. */
+export const MIN_RECURRENCE_TO_JUDGE = 10;
+/** At/below this distinct-output ratio the pattern is deterministic enough. */
+export const MAX_VARIANCE_RATIO_TO_CODIFY = 0.2;
+/** Only codify a pattern that succeeds at least this often. */
+export const MIN_SUCCESS_RATE_TO_CODIFY = 0.9;
+
+/**
+ * Group tool-execution samples by (agent x tool x input-shape) and classify each
+ * group's codifiability. Pure + deterministic (no DB, no clock) so it is fully
+ * unit-testable and capacity-cheap to run over a telemetry window. Results are
+ * ordered most-codifiable-first.
+ */
+export function summarizeToolReasoningStability(
+  samples: ToolReasoningSample[],
+): ToolReasoningStability[] {
+  const groups = new Map<
+    string,
+    { agentId: string; toolName: string; inputShape: string; outputs: Set<string>; total: number; successes: number }
+  >();
+
+  for (const s of samples) {
+    const key = `${s.agentId} ${s.toolName} ${s.inputShape}`;
+    let g = groups.get(key);
+    if (!g) {
+      g = { agentId: s.agentId, toolName: s.toolName, inputShape: s.inputShape, outputs: new Set(), total: 0, successes: 0 };
+      groups.set(key, g);
+    }
+    g.total += 1;
+    if (s.success) g.successes += 1;
+    g.outputs.add(s.outputDigest);
+  }
+
+  const out: ToolReasoningStability[] = [];
+  for (const g of groups.values()) {
+    const recurrence = g.total;
+    const distinctOutputs = g.outputs.size;
+    const varianceRatio = distinctOutputs / recurrence;
+    const successRate = g.successes / recurrence;
+    out.push({
+      agentId: g.agentId,
+      toolName: g.toolName,
+      inputShape: g.inputShape,
+      recurrence,
+      distinctOutputs,
+      varianceRatio,
+      successRate,
+      verdict: classifyStability(recurrence, varianceRatio, successRate),
+    });
+  }
+
+  // Deterministic ordering: codify candidates first, then by recurrence desc,
+  // then by a stable key so equal rows never reorder run-to-run.
+  out.sort(
+    (a, b) =>
+      codifyRank(b) - codifyRank(a) ||
+      b.recurrence - a.recurrence ||
+      stableKey(a).localeCompare(stableKey(b)),
+  );
+  return out;
+}
+
+function classifyStability(recurrence: number, varianceRatio: number, successRate: number): StabilityVerdict {
+  if (recurrence < MIN_RECURRENCE_TO_JUDGE) return "insufficient-data";
+  if (varianceRatio <= MAX_VARIANCE_RATIO_TO_CODIFY && successRate >= MIN_SUCCESS_RATE_TO_CODIFY) {
+    return "stabilized";
+  }
+  return "variable";
+}
+
+function codifyRank(s: ToolReasoningStability): number {
+  return s.verdict === "stabilized" ? 1 : 0;
+}
+
+function stableKey(s: ToolReasoningStability): string {
+  return `${s.agentId} ${s.toolName} ${s.inputShape}`;
+}

--- a/docs/superpowers/plans/2026-06-26-self-driving-migration-nomination-signals-design.md
+++ b/docs/superpowers/plans/2026-06-26-self-driving-migration-nomination-signals-design.md
@@ -1,0 +1,107 @@
+# Self-driving migration — nomination signals design pass
+
+- **BI:** BI-A028AA14 — "Self-driving cognitive-load migration scan — recurring curator that nominates AI→code & code→AI BIs from telemetry" (the keystone)
+- **Epic:** EP-COST-001
+- **Date:** 2026-06-26
+- **Status:** design pass started; signal (1) stats core shipped with this doc; the auto-nomination wiring is **FOUNDER-GATED** (see §4); signals (2)–(5) are roadmap
+
+## 0. TL;DR
+
+The keystone closes the migration loop: OBSERVE telemetry → NOMINATE a "codify X"
+(or "ascend Y") BI with evidence → human APPROVES → Build Studio CODIFIES → hive
+PROPAGATES. The BI says the recommended first step is building the nomination
+signals, and it "needs a design pass before build."
+
+This pass starts that design and ships the **stats core for signal (1)** — the
+AI→code "stabilized → codify" trigger — as a pure, deterministic function
+(`summarizeToolReasoningStability`). It deliberately **defers two things**: the
+input/output *normalisation* (a tunable decision, §2) and, critically, the
+**auto-nomination wiring that files BIs from telemetry** (§4) — that mutates the
+backlog and must not go live without founder sign-off.
+
+## 1. The loop and where signal (1) sits
+
+The migration curator (reusing existing scheduled infra — `governed-backlog-tee-up`
+/ `skill-curator`, NO new cron, per the BI) needs queryable signals, not a code
+re-read each cycle. Signal (1) is the core descent trigger: an agent's reasoning
+through a tool that **recurs with low output variance and high success** is a
+candidate to replace with deterministic code.
+
+Substrate (verified): `ToolExecution` (schema.prisma:4094) already records
+`agentId`, `toolName`, `parameters` (input), `result` (output), `success`,
+`durationMs`, `costUsd`, `inputTokens`/`outputTokens` per call. Everything signal
+(1) needs is already collected.
+
+## 2. Signal (1): shapes + stats core
+
+**Two layers, deliberately separated so the codifiable core never churns when the
+heuristic is retuned:**
+
+- **Normalisation (tunable — caller's job, NOT in the shipped core):**
+  - `inputShape` = a canonical signature of `ToolExecution.parameters` capturing
+    the *kind* of call, not exact values. Proposed v1: sorted top-level key set +
+    value *types* (e.g. `{path:string,limit:number}`). Too coarse → unrelated
+    calls merge; too fine (raw value hash) → nothing recurs. This dial is the
+    thing to validate against real data first.
+  - `outputDigest` = a canonical signature of `result` where equal digests mean
+    "same outcome". Proposed v1: stable-stringify of the result with volatile
+    fields (ids, timestamps) stripped.
+- **Stats core (shipped, pure, deterministic — `tool-reasoning-stability.ts`):**
+  `summarizeToolReasoningStability(samples)` groups by (agent × tool ×
+  inputShape) and returns `{recurrence, distinctOutputs, varianceRatio,
+  successRate, verdict}`. Thresholds are explicit + named (the learnable surface):
+  `MIN_RECURRENCE_TO_JUDGE=10`, `MAX_VARIANCE_RATIO_TO_CODIFY=0.2`,
+  `MIN_SUCCESS_RATE_TO_CODIFY=0.9`.
+
+## 3. Verdict logic (shipped)
+
+- `recurrence < MIN` → **insufficient-data** (don't judge noise).
+- `varianceRatio ≤ MAX` and `successRate ≥ MIN` → **stabilized** (codify candidate).
+- otherwise → **variable** (genuine AI judgment — leave it at the AI tier; a
+  consistent-but-failing pattern is explicitly NOT codifiable).
+
+Pure + fully unit-tested; capacity-cheap to run over a telemetry window. It never
+files anything.
+
+## 4. Auto-nomination wiring — FOUNDER-GATED (not built here)
+
+Turning a `stabilized` verdict into a `triaging` "codify X" BacklogItem is the
+step that makes the loop *self-driving*. It **mutates the backlog from telemetry**
+and is consequential enough to need explicit founder sign-off on:
+
+1. **Should it auto-file at all**, or only produce a ranked report a human files
+   from? (Default-safe = report-first; the irreducible human decision is preserved
+   either way since BIs land at `triaging`, never `build`.)
+2. **Thresholds + volume cap** — how many nominations per cycle; what recurrence/
+   variance bar; per-cycle budget so it can't flood the backlog.
+3. **Dedupe vs prior BIs** — a stabilized signature seen last cycle must touch the
+   existing nomination (recurrenceCount++), not file a duplicate — mirror the
+   curator's `(sourceType, sourceId)` dedupe.
+4. **Evidence payload** — the nomination must carry the signature + counts so the
+   human approves on evidence, not vibes.
+
+Until that review, signal (1) is **report-only**: compute + surface, never file.
+
+## 5. Roadmap (the other signals + the reverse trigger)
+
+- **(2) cost-per-reasoning-pattern** rollup on `AdapterRunTelemetry` → ROI ranking
+  of nominations (which codifications save the most capacity).
+- **(3) per-job misfire/defer counters** → DONE (BI-9BF17415, shipped) — the
+  code→AI ascent self-nomination input.
+- **(4) surface friction** (time-on-field, abandonment) via EP-HX-LOOP → human→AI
+  surface nominations.
+- **(5) work-tier tag + load-descent trend** → makes migration measurable over
+  time rather than snapshotted.
+- **Reverse (ascent) trigger** — a deterministic/scheduled job whose defer/misfire
+  rate exceeds a bar is nominated for code→AI judgment (the watchdog + curator
+  calibration signals from BI-A1FC3EBB / BI-93FE150F feed this).
+
+## 6. Recommendation
+
+- Validate the §2 `inputShape` dial against a real `ToolExecution` window before
+  wiring anything — a bad normalisation makes every downstream nomination noise.
+- Build the **report-only** path first (compute signal (1) + surface a ranked
+  "codify candidates" list); get founder sign-off on §4 before any auto-filing.
+- Signal (1)'s stats core is now in place; signals (2)/(4)/(5) are the next
+  foundation pieces. The loop stays human-approved at the `triaging` gate — the
+  irreducible decision the whole design protects.


### PR DESCRIPTION
## What

Builds **signal (1)** of the self-driving cognitive-load migration loop (BI-A028AA14, the keystone) + its design pass. Signal (1) is the AI-to-code "stabilized -> codify" trigger: distill `ToolExecution` telemetry into a per-(agent x tool x input-shape) stability summary so the migration curator can NOMINATE "codify X" candidates with evidence, instead of re-reading code each cycle.

## This PR

`apps/web/lib/observability/tool-reasoning-stability.ts` — `summarizeToolReasoningStability(samples)`: pure, deterministic; groups by (agent x tool x input-shape) and classifies codifiability — `stabilized | variable | insufficient-data` — with explicit, named, learnable thresholds (`MIN_RECURRENCE_TO_JUDGE`, `MAX_VARIANCE_RATIO_TO_CODIFY`, `MIN_SUCCESS_RATE_TO_CODIFY`). Fully unit-tested.

Design pass: `docs/superpowers/plans/2026-06-26-self-driving-migration-nomination-signals-design.md`.

## Two deliberate boundaries

1. **Tunable normalisation kept out of the codifiable core** — the caller supplies `inputShape`/`outputDigest`; HOW to canonicalise `ToolExecution.parameters`/`result` is a design decision (documented), so the stats core never churns when the heuristic is retuned.
2. **Auto-nomination wiring is FOUNDER-GATED** — turning a `stabilized` verdict into a `triaging` "codify X" BI mutates the backlog from telemetry. This slice is **report-only**; it never files anything. The design doc lists the decisions needing sign-off (auto-file vs report-first, thresholds/volume cap, dedupe-vs-prior-BIs, evidence payload).

## Verification

Co-located vitest; relies on CI (source-only worktree, no local toolchain). No UI (UX-Fit N/A); the design-doc touch satisfies the Spec/Plan/Doc gate. Pure functions only — no Prisma types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
