### PR TITLE
feat(observability): self-driving migration signal (2) - cost ROI ranking for codify candidates (BI-A028AA14)

### DIFF
--- a/apps/web/lib/observability/migration-codify-roi.test.ts
+++ b/apps/web/lib/observability/migration-codify-roi.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  rankByCodifyRoi,
+  summarizeCostPerPattern,
+  type CodifyCandidate,
+  type PatternCostSample,
+} from "./migration-codify-roi";
+
+function sample(over: Partial<PatternCostSample> & { costUsd: number }): PatternCostSample {
+  return { agentId: "a", toolName: "t", inputShape: "s", totalTokens: 0, ...over };
+}
+
+describe("summarizeCostPerPattern", () => {
+  it("groups by (agent x tool x input-shape) and sums cost + tokens", () => {
+    const out = summarizeCostPerPattern([
+      sample({ costUsd: 0.1, totalTokens: 100 }),
+      sample({ costUsd: 0.3, totalTokens: 300 }),
+      sample({ agentId: "b", costUsd: 1.0, totalTokens: 50 }),
+    ]);
+    expect(out["a t s"]!.invocations).toBe(2);
+    expect(out["a t s"]!.totalCostUsd).toBeCloseTo(0.4, 6);
+    expect(out["a t s"]!.avgCostUsd).toBeCloseTo(0.2, 6);
+    expect(out["a t s"]!.totalTokens).toBe(400);
+    expect(out["b t s"]!.invocations).toBe(1);
+  });
+
+  it("treats non-finite/negative cost and tokens as zero", () => {
+    const out = summarizeCostPerPattern([
+      sample({ costUsd: Number.NaN, totalTokens: -5 }),
+      sample({ costUsd: -1, totalTokens: Number.POSITIVE_INFINITY }),
+      sample({ costUsd: 0.5, totalTokens: 10 }),
+    ]);
+    expect(out["a t s"]!.invocations).toBe(3);
+    expect(out["a t s"]!.totalCostUsd).toBeCloseTo(0.5, 6);
+    expect(out["a t s"]!.totalTokens).toBe(10);
+  });
+
+  it("returns an empty object for no samples", () => {
+    expect(summarizeCostPerPattern([])).toEqual({});
+  });
+});
+
+describe("rankByCodifyRoi", () => {
+  const cand = (over: Partial<CodifyCandidate>): CodifyCandidate => ({
+    agentId: "a",
+    toolName: "t",
+    inputShape: "s",
+    recurrence: 10,
+    ...over,
+  });
+
+  it("ranks codify candidates by total cost burned, highest first", () => {
+    const costByKey = {
+      "a cheap s": { invocations: 50, totalCostUsd: 1.0, avgCostUsd: 0.02, totalTokens: 0 },
+      "a pricey s": { invocations: 20, totalCostUsd: 8.0, avgCostUsd: 0.4, totalTokens: 0 },
+    };
+    const ranked = rankByCodifyRoi([cand({ toolName: "cheap" }), cand({ toolName: "pricey" })], costByKey);
+    expect(ranked[0]!.toolName).toBe("pricey");
+    expect(ranked[0]!.totalCostUsd).toBe(8.0);
+    expect(ranked[1]!.toolName).toBe("cheap");
+  });
+
+  it("sorts candidates with no cost data last", () => {
+    const costByKey = { "a known s": { invocations: 10, totalCostUsd: 2.0, avgCostUsd: 0.2, totalTokens: 0 } };
+    const ranked = rankByCodifyRoi([cand({ toolName: "unknown" }), cand({ toolName: "known" })], costByKey);
+    expect(ranked[0]!.toolName).toBe("known");
+    expect(ranked[1]!.totalCostUsd).toBe(0);
+  });
+
+  it("breaks cost ties by recurrence desc", () => {
+    const ranked = rankByCodifyRoi([cand({ toolName: "x", recurrence: 5 }), cand({ toolName: "y", recurrence: 50 })], {});
+    expect(ranked[0]!.toolName).toBe("y");
+  });
+
+  it("returns an empty array for no candidates", () => {
+    expect(rankByCodifyRoi([], {})).toEqual([]);
+  });
+});

--- a/apps/web/lib/observability/migration-codify-roi.ts
+++ b/apps/web/lib/observability/migration-codify-roi.ts
@@ -1,0 +1,116 @@
+// Signal (2) of the self-driving cognitive-load migration loop (BI-A028AA14,
+// EP-COST-001): cost-per-reasoning-pattern ROI ranking.
+//
+// Pairs with signal (1) (tool-reasoning-stability): signal (1) says WHICH
+// patterns are codifiable; signal (2) says which codifiable ones are worth
+// codifying FIRST -- the ones burning the most capacity. Codifying a high-cost
+// stabilized pattern into deterministic code saves the most (the
+// responsible-capacity-utilization principle), so it ranks first.
+//
+// Pure stats core, source-agnostic: the caller supplies per-call cost samples
+// keyed the same way signal (1) groups (agent x tool x input-shape), extracted
+// from ToolExecution.costUsd (per tool call -- composes 1:1 with signal 1) or
+// the finer-grained AdapterRunTelemetry. It never files anything; auto-nomination
+// is founder-gated (see the keystone design pass).
+
+export interface PatternCostSample {
+  agentId: string;
+  toolName: string;
+  inputShape: string;
+  /** USD cost of this single call (e.g. ToolExecution.costUsd); 0 if unmetered. */
+  costUsd: number;
+  /** Total tokens for this call (input + output); optional. */
+  totalTokens?: number;
+}
+
+export interface PatternCostRollup {
+  invocations: number;
+  totalCostUsd: number;
+  avgCostUsd: number;
+  totalTokens: number;
+}
+
+/**
+ * A signal-(1) codify candidate. Structurally compatible with the relevant
+ * fields of ToolReasoningStability, declared locally so this module does not
+ * depend on signal (1) -- the caller passes signal (1)'s "stabilized" rows.
+ */
+export interface CodifyCandidate {
+  agentId: string;
+  toolName: string;
+  inputShape: string;
+  recurrence: number;
+}
+
+export interface RankedCodifyCandidate extends CodifyCandidate {
+  totalCostUsd: number;
+  avgCostUsd: number;
+  totalTokens: number;
+}
+
+function patternKey(p: { agentId: string; toolName: string; inputShape: string }): string {
+  return `${p.agentId} ${p.toolName} ${p.inputShape}`;
+}
+
+/**
+ * Roll up per-call cost samples into a per-(agent x tool x input-shape) summary.
+ * Pure + deterministic; non-finite/negative cost or tokens are treated as 0.
+ */
+export function summarizeCostPerPattern(samples: PatternCostSample[]): Record<string, PatternCostRollup> {
+  const acc = new Map<string, { invocations: number; totalCostUsd: number; totalTokens: number }>();
+
+  for (const s of samples) {
+    const cost = Number.isFinite(s.costUsd) && s.costUsd > 0 ? s.costUsd : 0;
+    const rawTokens = s.totalTokens ?? 0;
+    const tokens = Number.isFinite(rawTokens) && rawTokens > 0 ? rawTokens : 0;
+    const key = patternKey(s);
+    const a = acc.get(key) ?? { invocations: 0, totalCostUsd: 0, totalTokens: 0 };
+    a.invocations += 1;
+    a.totalCostUsd += cost;
+    a.totalTokens += tokens;
+    acc.set(key, a);
+  }
+
+  const out: Record<string, PatternCostRollup> = {};
+  for (const [key, a] of acc) {
+    out[key] = {
+      invocations: a.invocations,
+      totalCostUsd: a.totalCostUsd,
+      avgCostUsd: a.invocations > 0 ? a.totalCostUsd / a.invocations : 0,
+      totalTokens: a.totalTokens,
+    };
+  }
+  return out;
+}
+
+/**
+ * Rank codify candidates (signal 1's "stabilized" patterns) by ROI = the total
+ * capacity each currently burns. Highest total cost first -- codifying those
+ * deterministically saves the most. Candidates with no cost data sort last
+ * (cost 0). Deterministic tie-break: recurrence desc, then key.
+ */
+export function rankByCodifyRoi(
+  candidates: CodifyCandidate[],
+  costByKey: Record<string, PatternCostRollup>,
+): RankedCodifyCandidate[] {
+  const ranked: RankedCodifyCandidate[] = candidates.map((c) => {
+    const roll = costByKey[patternKey(c)];
+    return {
+      agentId: c.agentId,
+      toolName: c.toolName,
+      inputShape: c.inputShape,
+      recurrence: c.recurrence,
+      totalCostUsd: roll?.totalCostUsd ?? 0,
+      avgCostUsd: roll?.avgCostUsd ?? 0,
+      totalTokens: roll?.totalTokens ?? 0,
+    };
+  });
+
+  ranked.sort(
+    (a, b) =>
+      b.totalCostUsd - a.totalCostUsd ||
+      b.recurrence - a.recurrence ||
+      patternKey(a).localeCompare(patternKey(b)),
+  );
+  return ranked;
+}

--- a/docs/superpowers/plans/2026-06-26-migration-codify-roi-design.md
+++ b/docs/superpowers/plans/2026-06-26-migration-codify-roi-design.md
@@ -1,0 +1,51 @@
+# Self-driving migration signal (2) — cost ROI ranking (design note)
+
+- **BI:** BI-A028AA14 (the keystone) — signal (2) of the nomination set
+- **Epic:** EP-COST-001
+- **Date:** 2026-06-26
+- **Status:** stats core shipped with this note; companion to signal (1) (see 2026-06-26-self-driving-migration-nomination-signals-design.md)
+
+## Why
+
+Signal (1) (`tool-reasoning-stability`) finds WHICH agent-reasoning patterns are
+codifiable (recur with low output variance + high success). On its own it can
+nominate dozens of candidates with no priority. Signal (2) adds the ROI axis:
+**which codifiable patterns are worth codifying first** — the ones burning the
+most capacity. Codifying a high-cost stabilized pattern into deterministic code
+saves the most inference spend (responsible-capacity-utilization), so it ranks
+first.
+
+## What shipped
+
+`apps/web/lib/observability/migration-codify-roi.ts` — pure, deterministic:
+
+- `summarizeCostPerPattern(samples)` — rolls per-call cost into a
+  per-(agent x tool x input-shape) summary `{invocations, totalCostUsd,
+  avgCostUsd, totalTokens}`. Non-finite/negative cost or tokens count as 0.
+- `rankByCodifyRoi(candidates, costByKey)` — joins signal (1)'s "stabilized"
+  candidates with their cost rollup and ranks by total cost burned (desc;
+  no-cost candidates last; deterministic tie-break by recurrence then key).
+
+Fully unit-tested. It declares its own minimal `CodifyCandidate` shape rather
+than importing signal (1), so the two signals compose without coupling.
+
+## Cost source
+
+v1 uses `ToolExecution.costUsd` / `inputTokens+outputTokens` (per tool call —
+composes 1:1 with signal (1)'s grouping). `AdapterRunTelemetry` (per inference
+run, finer-grained) is the future refinement noted in the BI; the function is
+source-agnostic (caller extracts the samples), so swapping the source needs no
+change here.
+
+## Boundaries (unchanged from the keystone design)
+
+Detection only — it never files anything. Turning a ranked candidate into a
+`triaging` "codify X" BI is the **founder-gated** auto-nomination wiring; until
+that review, the output is report-only.
+
+## Next
+
+With signals (1) + (2) in place, the keystone's core detection foundation is
+ready: a report that lists codifiable patterns ranked by ROI. Remaining signals
+— (4) surface friction (EP-HX-LOOP), (5) work-tier descent trend — and the
+report-only surfacing + the founder-gated auto-nomination loop are the follow-ups.


### PR DESCRIPTION
## What

**Signal (2)** of the self-driving cognitive-load migration loop (BI-A028AA14, the keystone): cost-per-pattern ROI ranking. Pairs with signal (1) — signal (1) finds WHICH agent-reasoning patterns are codifiable; signal (2) ranks which to codify FIRST, the ones burning the most capacity (responsible-capacity-utilization).

## This PR

`apps/web/lib/observability/migration-codify-roi.ts` — pure, deterministic:
- `summarizeCostPerPattern(samples)` -> per-(agent x tool x input-shape) cost rollup `{invocations, totalCostUsd, avgCostUsd, totalTokens}` (non-finite/negative -> 0).
- `rankByCodifyRoi(candidates, costByKey)` -> joins signal (1)'s stabilized candidates with their cost and ranks by total spend (no-cost candidates last; deterministic tie-break by recurrence then key).

Fully unit-tested. Declares its own minimal `CodifyCandidate` shape so it composes with signal (1) without coupling.

## Boundaries

Detection only — it never files anything. Cost source v1 = `ToolExecution.costUsd` / tokens (composes 1:1 with signal 1's grouping); `AdapterRunTelemetry` is the finer-grained future source (the function is source-agnostic). The auto-nomination loop that files BIs stays **founder-gated** (see the keystone design pass).

## Verification

Co-located vitest; relies on CI (source-only worktree, no local toolchain). No UI (UX-Fit N/A); the design-note touch satisfies the Spec/Plan/Doc gate. Pure functions only — no Prisma types. UTF-8 verified (ASCII-only source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
