### PR TITLE
feat(autonomy): trust-graduation decision core - hold/promote/demote by agreement (EP-8AF1C996)

### DIFF
--- a/apps/web/lib/autonomy/trust-graduation.test.ts
+++ b/apps/web/lib/autonomy/trust-graduation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agreementRate,
+  DEFAULT_RISK_CEILINGS,
+  recommendTrustChange,
+} from "./trust-graduation";
+
+describe("agreementRate", () => {
+  it("returns null when there is nothing to judge", () => {
+    expect(agreementRate({ samples: 0, agreements: 0 })).toBeNull();
+  });
+  it("computes the ratio and clamps to [0,1]", () => {
+    expect(agreementRate({ samples: 10, agreements: 5 })).toBe(0.5);
+    expect(agreementRate({ samples: 10, agreements: 12 })).toBe(1); // clamp
+  });
+});
+
+describe("recommendTrustChange", () => {
+  it("holds at shadow until enough samples accrue", () => {
+    const r = recommendTrustChange({ level: "shadow", risk: "internal-reversible", window: { samples: 5, agreements: 5 } });
+    expect(r.action).toBe("hold");
+    expect(r.reason).toMatch(/samples/);
+  });
+
+  it("promotes shadow -> propose on a high agreement rate over enough samples", () => {
+    const r = recommendTrustChange({ level: "shadow", risk: "internal-reversible", window: { samples: 20, agreements: 19 } });
+    expect(r).toMatchObject({ action: "promote", from: "shadow", to: "propose" });
+  });
+
+  it("holds (does not promote) when the rate is below the gate", () => {
+    const r = recommendTrustChange({ level: "propose", risk: "internal-reversible", window: { samples: 40, agreements: 32 } }); // 80%
+    expect(r.action).toBe("hold");
+  });
+
+  it("demotes a level when the rate falls below the demotion floor", () => {
+    const r = recommendTrustChange({ level: "supervised", risk: "internal-reversible", window: { samples: 20, agreements: 10 } }); // 50%
+    expect(r).toMatchObject({ action: "demote", from: "supervised", to: "propose" });
+  });
+
+  it("cannot demote below shadow (holds instead)", () => {
+    const r = recommendTrustChange({ level: "shadow", risk: "internal-reversible", window: { samples: 15, agreements: 5 } }); // 33%
+    expect(r.action).toBe("hold");
+    expect(r.reason).toMatch(/already at shadow/);
+  });
+
+  it("caps kernel-floor (outbound) risk at propose even with perfect agreement", () => {
+    const r = recommendTrustChange({ level: "propose", risk: "outbound-or-floor", window: { samples: 100, agreements: 100 } });
+    expect(r.action).toBe("hold");
+    expect(r.reason).toMatch(/floor|propose/);
+  });
+
+  it("holds at the top once a class reaches its ceiling", () => {
+    const r = recommendTrustChange({ level: "autopilot", risk: "read-only", window: { samples: 100, agreements: 100 } });
+    expect(r.action).toBe("hold");
+  });
+
+  it("by default lets internal-irreversible climb to autopilot", () => {
+    const r = recommendTrustChange({ level: "supervised", risk: "internal-irreversible", window: { samples: 30, agreements: 29 } }); // ~96.7%
+    expect(r).toMatchObject({ action: "promote", from: "supervised", to: "autopilot" });
+  });
+
+  it("respects a ceiling override (the open founder question: cap internal-irreversible at supervised)", () => {
+    const r = recommendTrustChange({
+      level: "supervised",
+      risk: "internal-irreversible",
+      window: { samples: 30, agreements: 30 },
+      ceilings: { ...DEFAULT_RISK_CEILINGS, "internal-irreversible": "supervised" },
+    });
+    expect(r.action).toBe("hold");
+  });
+});

--- a/apps/web/lib/autonomy/trust-graduation.ts
+++ b/apps/web/lib/autonomy/trust-graduation.ts
@@ -1,0 +1,149 @@
+// Trust-graduation core for progressive autonomy (EP-8AF1C996, BI-DE4BF92F).
+//
+// The rules by which an AI activity's autonomy level rises or falls based on
+// MEASURED agreement -- "earn autonomy by proving you make the right call."
+// Pure + deterministic; it returns a RECOMMENDATION and never acts or mutates
+// anything (the operator confirms a promotion). The DB substrate
+// (DecisionShadowLedger, TrustState) + recording hooks are a separate BI.
+//
+// Founder directive 2026-06-26: ease in incrementally, validate over time, no
+// YOLO. Everything starts at L0 (shadow). Thresholds + risk ceilings are explicit
+// named config = the tunable dial; defaults come from the design pass:
+// docs/superpowers/plans/2026-06-26-progressive-autonomy-trust-graduation-design.md
+
+/** L0 -> L3, least to most autonomous. */
+export const AUTONOMY_LEVELS = ["shadow", "propose", "supervised", "autopilot"] as const;
+export type AutonomyLevel = (typeof AUTONOMY_LEVELS)[number];
+
+/** Buckets actions by reversibility / blast radius. */
+export type RiskClass =
+  | "read-only"
+  | "internal-reversible"
+  | "internal-irreversible"
+  | "outbound-or-floor"; // the kernel floor: irreversible/outbound/financial/access-control
+
+/**
+ * Highest autonomy a risk-class may ever reach. The kernel floor is capped at
+ * "propose" forever (a human always makes that call). The internal-irreversible
+ * cap is an OPEN founder question (autopilot vs supervised) -- defaulted here and
+ * overridable so answering it is a one-line config change, not a rebuild.
+ */
+export const DEFAULT_RISK_CEILINGS: Record<RiskClass, AutonomyLevel> = {
+  "read-only": "autopilot",
+  "internal-reversible": "autopilot",
+  "internal-irreversible": "autopilot",
+  "outbound-or-floor": "propose",
+};
+
+/** Agreement evidence over a rolling window. */
+export interface AgreementWindow {
+  /** Decisions observed in the window. */
+  samples: number;
+  /** How many matched the human's actual choice / the confirmed outcome. */
+  agreements: number;
+}
+
+/** agreements / samples in [0,1]; null when there is nothing to judge. */
+export function agreementRate(w: AgreementWindow): number | null {
+  if (w.samples <= 0) return null;
+  return Math.min(1, Math.max(0, w.agreements / w.samples));
+}
+
+/** Per-level gate to climb to the NEXT level. The tunable dial. */
+export interface GraduationThreshold {
+  minSamples: number;
+  minRate: number;
+}
+
+/** Defaults from the design pass; the founder tunes these per risk appetite. Keyed
+ * by the FROM level (autopilot has no next level, so it is intentionally absent). */
+export const DEFAULT_THRESHOLDS: Partial<Record<AutonomyLevel, GraduationThreshold>> = {
+  shadow: { minSamples: 20, minRate: 0.9 }, // L0 -> L1
+  propose: { minSamples: 20, minRate: 0.9 }, // L1 -> L2
+  supervised: { minSamples: 30, minRate: 0.95 }, // L2 -> L3
+};
+
+/** Below this rate (with enough samples) trust drops a level (symmetric demotion). */
+export const DEMOTION_RATE = 0.7;
+export const DEMOTION_MIN_SAMPLES = 10;
+
+export type TrustRecommendation =
+  | { action: "hold"; level: AutonomyLevel; reason: string }
+  | { action: "promote"; from: AutonomyLevel; to: AutonomyLevel; reason: string }
+  | { action: "demote"; from: AutonomyLevel; to: AutonomyLevel; reason: string };
+
+const NEXT_LEVEL: Record<AutonomyLevel, AutonomyLevel | null> = {
+  shadow: "propose",
+  propose: "supervised",
+  supervised: "autopilot",
+  autopilot: null,
+};
+const PREV_LEVEL: Record<AutonomyLevel, AutonomyLevel | null> = {
+  shadow: null,
+  propose: "shadow",
+  supervised: "propose",
+  autopilot: "supervised",
+};
+
+function levelIndex(l: AutonomyLevel): number {
+  return AUTONOMY_LEVELS.indexOf(l);
+}
+
+function pct(r: number): string {
+  return `${Math.round(r * 100)}%`;
+}
+
+/**
+ * Recommend a trust change for one (coworker x activity x risk) given its
+ * current level and agreement window. Pure -- NEVER auto-applies; a promotion is
+ * a recommendation the operator confirms. Precedence:
+ *   1. Demotion first (safety): a bad track record drops a level.
+ *   2. Risk ceiling: cannot promote past the class's cap (floor caps at propose).
+ *   3. Promotion: only when the per-level gate (samples + rate) is met.
+ *   4. Otherwise hold, with the reason it is not yet eligible.
+ */
+export function recommendTrustChange(args: {
+  level: AutonomyLevel;
+  risk: RiskClass;
+  window: AgreementWindow;
+  thresholds?: Partial<Record<AutonomyLevel, GraduationThreshold>>;
+  ceilings?: Record<RiskClass, AutonomyLevel>;
+}): TrustRecommendation {
+  const { level, risk, window } = args;
+  const rate = agreementRate(window);
+  const ceiling = (args.ceilings ?? DEFAULT_RISK_CEILINGS)[risk];
+
+  // 1. Demotion first.
+  if (rate !== null && window.samples >= DEMOTION_MIN_SAMPLES && rate < DEMOTION_RATE) {
+    const prev = PREV_LEVEL[level];
+    if (prev) {
+      return { action: "demote", from: level, to: prev, reason: `agreement ${pct(rate)} below the ${pct(DEMOTION_RATE)} floor` };
+    }
+    return { action: "hold", level, reason: `agreement ${pct(rate)} is low but already at shadow` };
+  }
+
+  // 2. Risk ceiling reached.
+  if (levelIndex(level) >= levelIndex(ceiling)) {
+    return {
+      action: "hold",
+      level,
+      reason:
+        ceiling === "propose"
+          ? `kernel-floor risk (${risk}) is capped at propose -- a human always confirms`
+          : `at the ${risk} ceiling (${ceiling})`,
+    };
+  }
+
+  // 3. Promotion gate.
+  const next = NEXT_LEVEL[level];
+  if (!next) return { action: "hold", level, reason: "already at the most autonomous level" };
+  const gate = (args.thresholds ?? DEFAULT_THRESHOLDS)[level];
+  if (!gate) return { action: "hold", level, reason: `no graduation gate defined for ${level}` };
+  if (rate === null || window.samples < gate.minSamples) {
+    return { action: "hold", level, reason: `need >= ${gate.minSamples} samples to judge (have ${window.samples})` };
+  }
+  if (rate >= gate.minRate) {
+    return { action: "promote", from: level, to: next, reason: `agreement ${pct(rate)} >= ${pct(gate.minRate)} over ${window.samples} samples` };
+  }
+  return { action: "hold", level, reason: `agreement ${pct(rate)} below the ${pct(gate.minRate)} bar to reach ${next}` };
+}

--- a/docs/superpowers/plans/2026-06-26-trust-graduation-core-impl-note.md
+++ b/docs/superpowers/plans/2026-06-26-trust-graduation-core-impl-note.md
@@ -1,0 +1,35 @@
+# Trust-graduation core — implementation note
+
+- **Epic:** EP-8AF1C996 (Progressive Autonomy & Trust Graduation)
+- **BI:** BI-DE4BF92F (the foundation)
+- **Full design:** `2026-06-26-progressive-autonomy-trust-graduation-design.md`
+- **Date:** 2026-06-26
+
+Implements the pure **decision core** of the trust dial:
+`apps/web/lib/autonomy/trust-graduation.ts` —
+`recommendTrustChange({ level, risk, window })` returns `hold | promote | demote`
+for one `(coworker x activity x risk)`, honoring:
+
+- **symmetric demotion first** (a bad track record drops a level — safety before promotion),
+- the **risk ceiling** (`outbound-or-floor` capped at `propose` forever; the kernel floor),
+- the **promotion gate** (agreement rate over a minimum sample count).
+
+It is pure + deterministic and **returns a recommendation only — it never acts or
+auto-applies**; a human confirms a promotion. Thresholds (`DEFAULT_THRESHOLDS`)
+and ceilings (`DEFAULT_RISK_CEILINGS`) are exported, named, and overridable = the
+tunable dial.
+
+## Open founder questions surfaced as config (not hard-coded guesses)
+
+- `DEFAULT_RISK_CEILINGS["internal-irreversible"]` defaults to `autopilot`; the
+  open question (cap state-mutating actions at `supervised`?) is a one-line config
+  change, covered by a unit test exercising the override.
+- `DEFAULT_THRESHOLDS` values are the design-pass defaults; tune per risk appetite.
+
+## Deferred (separate BIs)
+
+The DB substrate (`DecisionShadowLedger` + `TrustState` models, recording hooks,
+the reconciliation pass that fills actual-vs-proposed and computes agreement), the
+graduation evaluator UI, and wiring real activities into shadow mode (first tenant:
+the auto-nomination loop BI-A028AA14) — all per the full design pass. Nothing in
+this PR causes any activity to act.


### PR DESCRIPTION
## What
The pure decision core of progressive autonomy (EP-8AF1C996, foundation BI-DE4BF92F), per the 2026-06-26 directive to ease autonomy in and validate before release (no YOLO).

`apps/web/lib/autonomy/trust-graduation.ts` — `recommendTrustChange({level, risk, window})` returns `hold | promote | demote` for one (coworker x activity x risk):
- **symmetric demotion first** (a bad track record drops a level — safety before promotion),
- the **risk ceiling** (outbound/floor capped at `propose` forever — the kernel floor),
- the **promotion gate** (agreement rate over a minimum sample count).

Pure + deterministic + unit-tested. Returns a recommendation only — **it never acts or auto-applies**; a human confirms promotions.

## Tunable dial
`DEFAULT_THRESHOLDS` and `DEFAULT_RISK_CEILINGS` are exported, named, defaulted, and overridable. The open founder question (cap internal-irreversible at `supervised` vs `autopilot`) is a one-line config change, covered by a test.

## Deferred (separate BIs)
DB substrate (DecisionShadowLedger/TrustState + recording hooks), graduation UI, wiring real activities into shadow. Nothing here causes any activity to act.

## Verification
Co-located vitest; relies on CI (source-only worktree). No UI; impl-note doc satisfies the Spec/Plan/Doc gate. Pure functions, no Prisma types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)