### PR TITLE
feat(autonomy): regulatory ceiling in trust-graduation core - effective = min(trust, risk, regulatory) (BI-40CD8ACD)

### DIFF
--- a/apps/web/lib/autonomy/trust-graduation.test.ts
+++ b/apps/web/lib/autonomy/trust-graduation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   agreementRate,
   DEFAULT_RISK_CEILINGS,
+  minLevel,
   recommendTrustChange,
 } from "./trust-graduation";
 
@@ -68,5 +69,63 @@ describe("recommendTrustChange", () => {
       ceilings: { ...DEFAULT_RISK_CEILINGS, "internal-irreversible": "supervised" },
     });
     expect(r.action).toBe("hold");
+  });
+});
+
+describe("recommendTrustChange — regulatory ceiling (BI-40CD8ACD)", () => {
+  it("minLevel returns the more-restrictive level", () => {
+    expect(minLevel("shadow", "autopilot")).toBe("shadow");
+    expect(minLevel("supervised", "propose")).toBe("propose");
+    expect(minLevel("autopilot", "autopilot")).toBe("autopilot");
+  });
+
+  it("caps a low-risk activity at the regulatory ceiling regardless of agreement", () => {
+    const r = recommendTrustChange({
+      level: "propose",
+      risk: "read-only", // risk alone would allow autopilot
+      window: { samples: 50, agreements: 50 }, // perfect agreement
+      regulatoryCeiling: "propose",
+    });
+    expect(r.action).toBe("hold");
+    expect(r.reason).toMatch(/regulatory/);
+  });
+
+  it("still allows promotion up to (but not past) the regulatory ceiling", () => {
+    const up = recommendTrustChange({
+      level: "propose",
+      risk: "read-only",
+      window: { samples: 20, agreements: 20 },
+      regulatoryCeiling: "supervised",
+    });
+    expect(up).toMatchObject({ action: "promote", from: "propose", to: "supervised" });
+
+    const capped = recommendTrustChange({
+      level: "supervised",
+      risk: "read-only",
+      window: { samples: 30, agreements: 30 },
+      regulatoryCeiling: "supervised",
+    });
+    expect(capped.action).toBe("hold");
+    expect(capped.reason).toMatch(/regulatory/);
+  });
+
+  it("is unchanged when no regulatory ceiling applies (the dial governs)", () => {
+    const r = recommendTrustChange({
+      level: "propose",
+      risk: "read-only",
+      window: { samples: 20, agreements: 20 },
+    });
+    expect(r).toMatchObject({ action: "promote", from: "propose", to: "supervised" });
+  });
+
+  it("the more-restrictive of risk and regulatory wins (risk floor still binds under a lax reg)", () => {
+    const r = recommendTrustChange({
+      level: "propose",
+      risk: "outbound-or-floor", // hard-capped at propose
+      window: { samples: 50, agreements: 50 },
+      regulatoryCeiling: "autopilot", // laxer; must NOT lift the floor
+    });
+    expect(r.action).toBe("hold");
+    expect(r.reason).toMatch(/floor|propose/);
   });
 });

--- a/apps/web/lib/autonomy/trust-graduation.ts
+++ b/apps/web/lib/autonomy/trust-graduation.ts
@@ -49,6 +49,11 @@ export function agreementRate(w: AgreementWindow): number | null {
   return Math.min(1, Math.max(0, w.agreements / w.samples));
 }
 
+/** The more-restrictive (lower) of two autonomy levels. */
+export function minLevel(a: AutonomyLevel, b: AutonomyLevel): AutonomyLevel {
+  return levelIndex(a) <= levelIndex(b) ? a : b;
+}
+
 /** Per-level gate to climb to the NEXT level. The tunable dial. */
 export interface GraduationThreshold {
   minSamples: number;
@@ -108,10 +113,21 @@ export function recommendTrustChange(args: {
   window: AgreementWindow;
   thresholds?: Partial<Record<AutonomyLevel, GraduationThreshold>>;
   ceilings?: Record<RiskClass, AutonomyLevel>;
+  /**
+   * Regulatory/compliance cap for this (industry x jurisdiction x activity),
+   * independent of earned trust (BI-40CD8ACD). The EFFECTIVE ceiling is the more
+   * restrictive of the risk ceiling and this. Omit when the activity is not
+   * regulated (trust + risk govern alone). A regulated activity stays capped no
+   * matter how high the agreement -- only a compliance change lifts it.
+   */
+  regulatoryCeiling?: AutonomyLevel;
 }): TrustRecommendation {
   const { level, risk, window } = args;
   const rate = agreementRate(window);
-  const ceiling = (args.ceilings ?? DEFAULT_RISK_CEILINGS)[risk];
+  const riskCeiling = (args.ceilings ?? DEFAULT_RISK_CEILINGS)[risk];
+  const ceiling = args.regulatoryCeiling ? minLevel(riskCeiling, args.regulatoryCeiling) : riskCeiling;
+  const regulatoryBinds =
+    args.regulatoryCeiling != null && levelIndex(args.regulatoryCeiling) < levelIndex(riskCeiling);
 
   // 1. Demotion first.
   if (rate !== null && window.samples >= DEMOTION_MIN_SAMPLES && rate < DEMOTION_RATE) {
@@ -122,13 +138,14 @@ export function recommendTrustChange(args: {
     return { action: "hold", level, reason: `agreement ${pct(rate)} is low but already at shadow` };
   }
 
-  // 2. Risk ceiling reached.
+  // 2. Ceiling reached (risk and/or regulatory -- the more restrictive binds).
   if (levelIndex(level) >= levelIndex(ceiling)) {
     return {
       action: "hold",
       level,
-      reason:
-        ceiling === "propose"
+      reason: regulatoryBinds
+        ? `regulatory ceiling (${ceiling}) caps this activity regardless of agreement -- only a compliance change lifts it`
+        : ceiling === "propose"
           ? `kernel-floor risk (${risk}) is capped at propose -- a human always confirms`
           : `at the ${risk} ceiling (${ceiling})`,
     };

--- a/docs/superpowers/plans/2026-06-26-trust-graduation-core-impl-note.md
+++ b/docs/superpowers/plans/2026-06-26-trust-graduation-core-impl-note.md
@@ -26,6 +26,16 @@ tunable dial.
   change, covered by a unit test exercising the override.
 - `DEFAULT_THRESHOLDS` values are the design-pass defaults; tune per risk appetite.
 
+## Regulatory ceiling — now integrated (BI-40CD8ACD)
+
+`recommendTrustChange` now takes an optional `regulatoryCeiling`, and the EFFECTIVE
+cap = `minLevel(riskCeiling, regulatoryCeiling)`. So a regulated activity stays
+capped regardless of agreement ("only a compliance change lifts it"), while the
+risk floor still binds when it is the more restrictive of the two. Omit the param
+for non-regulated activities (trust + risk govern alone). The policy DATA layer —
+which (industry x jurisdiction x activity) maps to which ceiling, versioned and
+compliance-editable — remains a separate build needing the founder's domain input.
+
 ## Deferred (separate BIs)
 
 The DB substrate (`DecisionShadowLedger` + `TrustState` models, recording hooks,


### PR DESCRIPTION
## What
Folds the **regulatory ceiling** into the trust-graduation core (BI-40CD8ACD), per the 2026-06-26 directive: regulated markets require HITL regardless of how perfect the autonomy is, until the regulation allows otherwise.

`recommendTrustChange` now takes an optional `regulatoryCeiling`; the effective cap = `minLevel(riskCeiling, regulatoryCeiling)`. A regulated activity stays capped no matter the agreement rate (only a compliance change lifts it); the risk floor still binds when it is the more restrictive of the two; omit the param for non-regulated activities (trust + risk govern alone).

## Tests
caps below risk regardless of agreement; promote up-to-but-not-past the reg ceiling; more-restrictive-of-(risk,reg) wins (risk floor binds under a lax reg); unchanged when absent; `minLevel`.

## Deferred
The policy DATA layer ((industry x jurisdiction x activity) -> ceiling, versioned + compliance-editable) needs the founder's domain input — tracked under BI-40CD8ACD.

## Verification
Co-located vitest; relies on CI (source-only worktree). No UI; impl-note doc touch satisfies the Spec/Plan/Doc gate. Pure functions, no Prisma types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)