### PR TITLE
feat(inference): Anthropic prompt-cache breakpoint on the stable system prefix (BI-79A5C00F)

### DIFF
--- a/apps/web/lib/routing/anthropic-cache.test.ts
+++ b/apps/web/lib/routing/anthropic-cache.test.ts
@@ -1,0 +1,52 @@
+// apps/web/lib/routing/anthropic-cache.test.ts
+import { describe, it, expect } from "vitest";
+import { buildAnthropicSystem, type AnthropicTextBlock } from "./anthropic-cache";
+import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "../tak/prompt-boundary";
+
+const STABLE = "You are DPF. Identity, mode, and mission are fixed for this session.";
+const DYNAMIC = "Today is 2026-06-26.\n--- PAGE DATA ---\nvolatile per-turn content";
+
+describe("buildAnthropicSystem (BI-79A5C00F)", () => {
+  it("splits on the boundary and caches ONLY the stable prefix", () => {
+    const prompt = STABLE + SYSTEM_PROMPT_DYNAMIC_BOUNDARY + DYNAMIC;
+    const result = buildAnthropicSystem(prompt);
+
+    expect(Array.isArray(result)).toBe(true);
+    const blocks = result as AnthropicTextBlock[];
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({
+      type: "text",
+      text: STABLE,
+      cache_control: { type: "ephemeral" },
+    });
+    expect(blocks[1]).toEqual({ type: "text", text: DYNAMIC });
+    // The cached block must never contain dynamic content.
+    expect(blocks[0].text).not.toContain(DYNAMIC);
+    expect(blocks[1].cache_control).toBeUndefined();
+  });
+
+  it("returns the string UNCHANGED when no boundary is present (simplest-safe)", () => {
+    const prompt = "A flat prompt with no boundary marker at all.";
+    expect(buildAnthropicSystem(prompt)).toBe(prompt);
+  });
+
+  it("returns unchanged when the stable prefix is empty (boundary at start)", () => {
+    const prompt = SYSTEM_PROMPT_DYNAMIC_BOUNDARY + DYNAMIC;
+    expect(buildAnthropicSystem(prompt)).toBe(prompt);
+  });
+
+  it("handles empty / null / undefined system prompts without throwing", () => {
+    expect(buildAnthropicSystem("")).toBe("");
+    expect(buildAnthropicSystem(undefined)).toBe("");
+    expect(buildAnthropicSystem(null)).toBe("");
+  });
+
+  it("omits the dynamic block when nothing follows the boundary", () => {
+    const prompt = STABLE + SYSTEM_PROMPT_DYNAMIC_BOUNDARY;
+    const result = buildAnthropicSystem(prompt) as AnthropicTextBlock[];
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(result[0].text).toBe(STABLE);
+  });
+});

--- a/apps/web/lib/routing/anthropic-cache.ts
+++ b/apps/web/lib/routing/anthropic-cache.ts
@@ -1,0 +1,55 @@
+// apps/web/lib/routing/anthropic-cache.ts
+
+/**
+ * EP-COST-001 / BI-79A5C00F — Anthropic prompt-cache breakpoint emission.
+ *
+ * DPF assembles system prompts with a stable prefix (identity / mode / mission)
+ * before SYSTEM_PROMPT_DYNAMIC_BOUNDARY and per-turn dynamic content after it,
+ * but never told Anthropic to cache the prefix — so the large, invariant prefix
+ * was re-billed at full input rate on every turn. This emits a single ephemeral
+ * cache_control breakpoint on the stable prefix only.
+ *
+ * Simplest-safe contract: when the boundary is present we split and cache the
+ * prefix; when it is absent we return the original string UNCHANGED (no
+ * cache_control), because without the boundary we cannot prove which content is
+ * dynamic and must never risk caching volatile content.
+ *
+ * Note: cache_control:{type:"ephemeral"} is the 5-minute TTL (GA, no beta
+ * header). A 1-hour TTL (ttl:"1h") is a follow-up: it needs the extended-cache
+ * beta header to be confirmed against the live Anthropic API version.
+ */
+import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "../tak/prompt-boundary";
+
+export type AnthropicTextBlock = {
+  type: "text";
+  text: string;
+  cache_control?: { type: "ephemeral" };
+};
+
+/**
+ * Build the Anthropic `system` request field. Returns a content-block array with
+ * an ephemeral cache breakpoint on the stable prefix when the dynamic boundary
+ * is present; otherwise returns the input string unchanged.
+ */
+export function buildAnthropicSystem(
+  systemPrompt: string | undefined | null,
+): string | AnthropicTextBlock[] {
+  if (!systemPrompt) return systemPrompt ?? "";
+
+  const idx = systemPrompt.indexOf(SYSTEM_PROMPT_DYNAMIC_BOUNDARY);
+  if (idx === -1) return systemPrompt;
+
+  const stablePrefix = systemPrompt.slice(0, idx);
+  const dynamicTail = systemPrompt.slice(idx + SYSTEM_PROMPT_DYNAMIC_BOUNDARY.length);
+
+  // Boundary at the very start — nothing stable to cache. Leave unchanged.
+  if (stablePrefix.trim().length === 0) return systemPrompt;
+
+  const blocks: AnthropicTextBlock[] = [
+    { type: "text", text: stablePrefix, cache_control: { type: "ephemeral" } },
+  ];
+  if (dynamicTail.length > 0) {
+    blocks.push({ type: "text", text: dynamicTail });
+  }
+  return blocks;
+}

--- a/apps/web/lib/routing/anthropic-cache.ts
+++ b/apps/web/lib/routing/anthropic-cache.ts
@@ -34,7 +34,7 @@ export type AnthropicTextBlock = {
 export function buildAnthropicSystem(
   systemPrompt: string | undefined | null,
 ): string | AnthropicTextBlock[] {
-  if (!systemPrompt) return systemPrompt ?? "";
+  if (!systemPrompt) return "";
 
   const idx = systemPrompt.indexOf(SYSTEM_PROMPT_DYNAMIC_BOUNDARY);
   if (idx === -1) return systemPrompt;

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -26,6 +26,7 @@ import {
 import { isAnthropic } from "./provider-utils";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { extractToolCalls as extractTextualToolUse } from "./extract-tool-calls";
+import { buildAnthropicSystem } from "./anthropic-cache";
 
 // ─── Inference HTTP timeouts ──────────────────────────────────────────────────
 // A hung local Docker Model Runner endpoint must fail fast so callWithFallbackChain
@@ -171,7 +172,10 @@ export const chatAdapter: ExecutionAdapterHandler = {
       body = {
         model: modelId,
         max_tokens: plan.maxTokens,
-        system: systemPrompt,
+        // BI-79A5C00F: emit a cache_control breakpoint on the stable system
+        // prefix (split on SYSTEM_PROMPT_DYNAMIC_BOUNDARY); plain string when
+        // no boundary is present, so non-assembled prompts are unchanged.
+        system: buildAnthropicSystem(systemPrompt),
         messages: messages
           .filter((m) => m.role !== "system")
           .map((m) => formatMessageForAnthropic(m)),

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -11,6 +11,7 @@ import {
 import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
 import { DECISION_ROUTING_BLOCK } from "./decision-routing-block";
 import { readingLevelDirective, type ReadingLevel } from "@dpf/validators";
+import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./prompt-boundary";
 
 export type PromptInput = {
   hrRole: string;
@@ -105,10 +106,12 @@ const ACT_MODE_BLOCK = `Mode: ACT. You may execute any tool the employee's role 
 // SYSTEM_PROMPT_DYNAMIC_BOUNDARY pattern revealed in the source leak.
 //
 // The marker itself is invisible to the model — it's consumed by the caller
-// (routed-inference.ts) to split the prompt into cacheable and non-cacheable
+// (routing/anthropic-cache.ts, used by chat-adapter) to split the prompt into cacheable and non-cacheable
 // segments when the provider supports prompt caching.
 
-export const SYSTEM_PROMPT_DYNAMIC_BOUNDARY = "\n\n<!-- DYNAMIC_BOUNDARY -->\n\n";
+// Single source of truth lives in ./prompt-boundary (dependency-free so the
+// routing layer can split on it without importing this DB-coupled assembler).
+export { SYSTEM_PROMPT_DYNAMIC_BOUNDARY };
 
 // ─── Block 0: Company Mission (dynamic — admin-editable) ───────────────────
 

--- a/apps/web/lib/tak/prompt-boundary.ts
+++ b/apps/web/lib/tak/prompt-boundary.ts
@@ -1,0 +1,15 @@
+// apps/web/lib/tak/prompt-boundary.ts
+
+/**
+ * Marker placed between the STATIC (cacheable) and DYNAMIC (per-turn) halves of
+ * an assembled system prompt.
+ *
+ * Kept in its own dependency-free module so the routing layer
+ * (chat-adapter -> anthropic-cache) can split on it WITHOUT importing the full
+ * prompt assembler — assembleSystemPrompt pulls in DB/Prisma loaders, which must
+ * not leak into the inference request path or its unit tests (BI-79A5C00F).
+ *
+ * The marker is an HTML comment, invisible to the model. Providers that support
+ * prompt caching use it to attach a cache breakpoint to the stable prefix.
+ */
+export const SYSTEM_PROMPT_DYNAMIC_BOUNDARY = "\n\n<!-- DYNAMIC_BOUNDARY -->\n\n";

--- a/docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md
+++ b/docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md
@@ -92,6 +92,8 @@ Rollback:
 
 Backlog: `BI-79A5C00F`.
 
+**Status (2026-06-26): implemented** on `feat/anthropic-prompt-cache-breakpoint-bi-79a5c00f` (capsule WC-68ABAA4C). New `apps/web/lib/routing/anthropic-cache.ts` `buildAnthropicSystem()` splits the assembled system prompt on the boundary and attaches `cache_control:{type:"ephemeral"}` to the stable prefix in the Anthropic branch of `chat-adapter.ts`; the boundary constant was extracted to a dependency-free `apps/web/lib/tak/prompt-boundary.ts` (so the routing path/tests do not import the DB-coupled assembler). The 5-minute TTL (GA, no beta header) shipped; the 1-hour TTL is a tracked follow-up pending confirmation of the extended-cache beta header. Unit tests in `anthropic-cache.test.ts`; the live cache-read check (turn-2 `cache_read_input_tokens > 0`) remains as functional verification.
+
 Goal: make DPF exploit the stable/dynamic prompt split it already builds.
 
 Files to inspect or update:


### PR DESCRIPTION
## Summary

External build (§17, capsule `WC-68ABAA4C`) of **BI-79A5C00F** / EP-COST-001 — the highest-leverage token-cost fix from the delivery-surface study. DPF ordered system prompts for caching (`SYSTEM_PROMPT_DYNAMIC_BOUNDARY`) and metered Anthropic cache tokens, but never emitted `cache_control`, so the invariant prefix was re-billed at full input rate every turn.

## Change
- `buildAnthropicSystem()` (new `apps/web/lib/routing/anthropic-cache.ts`) splits on the boundary and attaches `cache_control:{type:"ephemeral"}` to the **stable prefix only**; plain-string passthrough when no boundary is present (non-Anthropic branches untouched).
- Wired into the Anthropic `/messages` branch of `chat-adapter.ts` (`system` field).
- Boundary constant extracted to dependency-free `apps/web/lib/tak/prompt-boundary.ts` so the routing path/tests stay free of the DB-coupled assembler; `prompt-assembler.ts` re-exports it (single source of truth).

## Verification
- Unit tests `anthropic-cache.test.ts` (5 cases) — **green locally** via the real `apps/web` vitest config (setup 0ms, no DB pulled).
- Local pre-commit `tsc` skipped (`DPF_SKIP_TYPECHECK=1`): the source-only worktree junctions a sibling's `node_modules`, whose `@dpf/db` predates `@dpf/db/remote-action-dispatch` and emits two unrelated false-negative `TS2307`s. This change imports no `@dpf/db`. **CI's Typecheck gate is authoritative.**
- Remaining: live cache-read functional check (turn-2 `cache_read_input_tokens > 0`).

## Scope notes
- 5-minute ephemeral TTL (GA) here; **1-hour TTL is a tracked follow-up** (needs the extended-cache beta header confirmed against the live API version).
- Benefit applies wherever the assembled boundary is present (the coworker prompt path); a safe no-op elsewhere.

Plan: Phase 1A of `docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md` (annotated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
