### PR TITLE
feat(autonomy): activate org/WWWD business-decision gate (BI-230C9EF7)

### DIFF
--- a/apps/web/lib/decision-perspective/org-business-gate.test.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
+import { evaluateOrgBusinessDecisionGate } from "./org-business-gate";
+import type {
+  DecisionDomainClass,
+  DecisionPerspectiveEvaluationResult,
+  DecisionPerspectiveProfile,
+} from "./types";
+
+const DOMAIN: DecisionDomainClass = "professional-practice";
+
+function makeProfile(profileId: string): DecisionPerspectiveProfile {
+  return { ...MARK_DPF_PLATFORM_PROFILE, profileId };
+}
+
+function makeEval(over: Partial<DecisionPerspectiveEvaluationResult> = {}): DecisionPerspectiveEvaluationResult {
+  return {
+    outcomeType: "recommend",
+    selectedProfileId: "org-1",
+    fallbackProfileId: null,
+    profileVersionId: "org-v1",
+    confidenceBefore: 0.8,
+    confidenceAfter: 0.8,
+    confidenceScore: 0.8,
+    coverageGap: false,
+    principleConflict: false,
+    domainClass: DOMAIN,
+    resolvedProfileChain: ["org-1"],
+    materialCount: 1,
+    freshnessDistribution: { current: 1, stale: 0, superseded: 0, contradicted: 0 },
+    riskTier: "medium",
+    question: "q",
+    options: ["a", "b"],
+    rationale: "the org stance supports it",
+    materialScores: [],
+    sources: [],
+    ...over,
+  };
+}
+
+function makeDb() {
+  return {
+    decisionInteraction: {
+      create: vi.fn().mockImplementation(async (args: { data: Record<string, unknown> }) => ({ id: "row-1", ...args.data })),
+    },
+  };
+}
+
+function fakeResolver(over: Record<string, unknown> = {}) {
+  return vi.fn().mockResolvedValue({
+    selectedProfileId: "org-1",
+    selectedProfile: makeProfile("org-1"),
+    resolvedProfileChain: ["org-1"],
+    coverageGap: false,
+    materials: [],
+    orgProfileSelected: true,
+    ...over,
+  });
+}
+
+const base = {
+  organizationId: "org-123",
+  question: "Should we send a replacement to this customer?",
+  options: ["Send replacement", "Decline", "Escalate"],
+  domainClass: DOMAIN,
+  riskTier: "medium" as const,
+  routeContext: "/coworker-business",
+};
+
+describe("evaluateOrgBusinessDecisionGate (BI-230C9EF7)", () => {
+  it("decides from the org's own profile and records orgProfileSelected=true (no build context)", async () => {
+    const db = makeDb();
+    const result = await evaluateOrgBusinessDecisionGate({
+      ...base,
+      db: db as never,
+      resolver: fakeResolver() as never,
+      evaluator: () => makeEval({ outcomeType: "recommend" }),
+    });
+
+    expect(result.orgProfileSelected).toBe(true);
+    expect(result.allowed).toBe(true); // recommend
+    expect(result.operatorMessage).toMatch(/your organization's recorded stance/);
+
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    expect(data.routeContext).toBe("/coworker-business");
+    expect(data.buildId).toBeNull();
+    expect(data.phaseFrom).toBeNull();
+    expect(data.phaseTo).toBeNull();
+    expect((data.outcomePayload as { orgProfileSelected?: boolean }).orgProfileSelected).toBe(true);
+  });
+
+  it("falls back to platform as ADVISORY when the org is silent (orgProfileSelected=false)", async () => {
+    const db = makeDb();
+    const result = await evaluateOrgBusinessDecisionGate({
+      ...base,
+      db: db as never,
+      resolver: fakeResolver({
+        selectedProfileId: MARK_DPF_PLATFORM_PROFILE.profileId,
+        selectedProfile: MARK_DPF_PLATFORM_PROFILE,
+        resolvedProfileChain: [MARK_DPF_PLATFORM_PROFILE.profileId],
+        orgProfileSelected: false,
+      }) as never,
+      evaluator: () => makeEval({ selectedProfileId: MARK_DPF_PLATFORM_PROFILE.profileId }),
+    });
+
+    expect(result.orgProfileSelected).toBe(false);
+    expect(result.operatorMessage).toMatch(/platform defaults/);
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    expect((data.outcomePayload as { orgProfileSelected?: boolean }).orgProfileSelected).toBe(false);
+  });
+
+  it("coverage gap forces defer and is not allowed", async () => {
+    const db = makeDb();
+    const result = await evaluateOrgBusinessDecisionGate({
+      ...base,
+      db: db as never,
+      resolver: fakeResolver({ coverageGap: true }) as never,
+      evaluator: () => makeEval({ outcomeType: "recommend" }), // overridden by the coverage gap
+    });
+    expect(result.evaluation.outcomeType).toBe("defer");
+    expect(result.allowed).toBe(false);
+    expect(db.decisionInteraction.create).toHaveBeenCalled();
+  });
+
+  it("fail-closed: a resolver error escalates to a human and is still recorded", async () => {
+    const db = makeDb();
+    const result = await evaluateOrgBusinessDecisionGate({
+      ...base,
+      db: db as never,
+      resolver: vi.fn().mockRejectedValue(new Error("db down")) as never,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.evaluation.outcomeType).toBe("escalate");
+    expect(result.evaluation.rationale).toMatch(/fail-closed/);
+    expect(db.decisionInteraction.create).toHaveBeenCalled();
+  });
+
+  it("a non-recommend org outcome (e.g. escalate) is not allowed", async () => {
+    const db = makeDb();
+    const result = await evaluateOrgBusinessDecisionGate({
+      ...base,
+      db: db as never,
+      resolver: fakeResolver() as never,
+      evaluator: () => makeEval({ outcomeType: "escalate" }),
+    });
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/apps/web/lib/decision-perspective/org-business-gate.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.ts
@@ -1,0 +1,282 @@
+// Org/WWWD business-decision gate (BI-230C9EF7, EP-8AF1C996).
+//
+// The org + profession DecisionPerspectiveProfiles are seeded on install (mission
+// / how-we-decide / profession corpus) but were DORMANT: resolveProfileMaterialForOrg
+// is built + tested yet called by zero decision surfaces. This gate activates them
+// so a coworker's business decision is actually governed by the organization's own
+// recorded stance (WWWD) -- falling back to platform doctrine only as ADVISORY when
+// the org is silent, never letting platform doctrine bind a business call.
+//
+// It mirrors evaluateBuildStudioPlanAdvancementGate (the WWMD/build gate) but keyed
+// on organizationId instead of a build, with no build-phase idempotency and no voice
+// dispatch. Pure composition of three already-tested primitives:
+// resolveProfileMaterialForOrg -> evaluateDecisionPerspective -> persistDecisionInteraction.
+//
+// It records every decision (proposed outcome + profile chain + orgProfileSelected) to
+// the DecisionInteraction ledger -- the substrate the trust-graduation dial reads to
+// measure agreement before any autonomy is released. Fail-closed: any resolver/evaluator
+// error escalates to a human and is still recorded.
+
+import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
+import { evaluateDecisionPerspective } from "./evaluator";
+import { resolveProfileMaterialForOrg } from "./material";
+import { createDecisionInteractionId, persistDecisionInteraction } from "./persistence";
+import type {
+  DecisionDomainClass,
+  DecisionPerspectiveEvaluationInput,
+  DecisionPerspectiveEvaluationResult,
+  DecisionPerspectiveProfile,
+  DecisionRiskTier,
+} from "./types";
+
+type OrgBusinessGateClient = Parameters<typeof resolveProfileMaterialForOrg>[0]["db"] &
+  Parameters<typeof persistDecisionInteraction>[0]["db"];
+
+type GateEvaluator = (input: DecisionPerspectiveEvaluationInput) => DecisionPerspectiveEvaluationResult;
+
+export type OrgBusinessDecisionGateResult = {
+  /** True only when the org's own stance recommends/arbitrates the call. */
+  allowed: boolean;
+  interactionId: string;
+  evaluation: DecisionPerspectiveEvaluationResult;
+  operatorMessage: string;
+  /** True when the organization's OWN profile (not a platform fallback) decided. */
+  orgProfileSelected: boolean;
+};
+
+function traceWwwd(event: string, payload: Record<string, unknown>): void {
+  console.info(`[tool-trace] ${event} ${JSON.stringify(payload)}`);
+}
+
+function errorClass(error: unknown): string {
+  return error instanceof Error && error.name ? error.name : "UnknownError";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function operatorMessageFor(evaluation: DecisionPerspectiveEvaluationResult, orgProfileSelected: boolean): string {
+  const scope = orgProfileSelected
+    ? "your organization's recorded stance"
+    : "platform defaults (your organization has not recorded a stance here yet)";
+  switch (evaluation.outcomeType) {
+    case "defer":
+      return `No applicable business stance found via ${scope}. ${evaluation.rationale}`;
+    case "escalate":
+      return `This business decision needs your call (${scope}). ${evaluation.rationale}`;
+    case "arbitrate":
+      return `Decided from ${scope} at ${evaluation.confidenceScore} confidence.`;
+    default:
+      return `Recommended from ${scope} at ${evaluation.confidenceScore} confidence.`;
+  }
+}
+
+function failClosedEvaluation(input: {
+  profile: DecisionPerspectiveProfile;
+  question: string;
+  options: string[];
+  domainClass: DecisionDomainClass;
+  riskTier: DecisionRiskTier;
+  error: unknown;
+  resolvedProfileChain: string[];
+}): DecisionPerspectiveEvaluationResult {
+  return {
+    outcomeType: "escalate",
+    selectedProfileId: input.profile.profileId,
+    fallbackProfileId: null,
+    profileVersionId: input.profile.currentVersion.versionId,
+    confidenceBefore: 0,
+    confidenceAfter: 0,
+    confidenceScore: 0,
+    coverageGap: false,
+    principleConflict: false,
+    domainClass: input.domainClass,
+    resolvedProfileChain: input.resolvedProfileChain,
+    materialCount: 0,
+    freshnessDistribution: { current: 0, stale: 0, superseded: 0, contradicted: 0 },
+    riskTier: input.riskTier,
+    question: input.question,
+    options: input.options,
+    rationale: `WWWD fail-closed escalation: ${errorClass(input.error)}. The decision could not be safely evaluated, so it routes to a human.`,
+    materialScores: [],
+    sources: [],
+    gapReason: "material-below-confidence",
+  };
+}
+
+/**
+ * Govern an organization business decision through its WWWD profile (with platform
+ * fallback as advisory). Returns the evaluation, an operator message, and whether the
+ * org's own profile decided. Always records a DecisionInteraction.
+ */
+export async function evaluateOrgBusinessDecisionGate(input: {
+  db: OrgBusinessGateClient;
+  organizationId: string | null | undefined;
+  question: string;
+  options: string[];
+  domainClass: DecisionDomainClass;
+  riskTier: DecisionRiskTier;
+  /** Where the decision originated, e.g. "/coworker-business". Recorded on the ledger. */
+  routeContext: string;
+  phaseFrom?: string | null;
+  phaseTo?: string | null;
+  evidence?: DecisionPerspectiveEvaluationInput["evidence"];
+  fallbackProfileId?: string;
+  triggeredByUserId?: string | null;
+  taskRunId?: string | null;
+  evaluator?: GateEvaluator;
+  /** Injectable for tests; defaults to the real (already-tested) org resolver. */
+  resolver?: typeof resolveProfileMaterialForOrg;
+  now?: Date;
+  recentOverrideCount?: number;
+}): Promise<OrgBusinessDecisionGateResult> {
+  const interactionId = createDecisionInteractionId();
+  const { question, options, domainClass, riskTier } = input;
+  const resolve = input.resolver ?? resolveProfileMaterialForOrg;
+
+  let resolved: Awaited<ReturnType<typeof resolveProfileMaterialForOrg>> | undefined;
+  let profile: DecisionPerspectiveProfile = MARK_DPF_PLATFORM_PROFILE;
+  let orgProfileSelected = false;
+
+  try {
+    resolved = await resolve({
+      db: input.db,
+      organizationId: input.organizationId,
+      domainClass,
+      fallbackProfileId: input.fallbackProfileId,
+    });
+    profile = resolved.selectedProfile ?? MARK_DPF_PLATFORM_PROFILE;
+    orgProfileSelected = resolved.orgProfileSelected;
+  } catch (error) {
+    const evaluation = failClosedEvaluation({
+      profile,
+      question,
+      options,
+      domainClass,
+      riskTier,
+      error,
+      resolvedProfileChain: [profile.profileId],
+    });
+    traceWwwd("wwwd.org-gate.invoked", {
+      interactionId,
+      organizationId: input.organizationId ?? null,
+      domainClass,
+      riskTier,
+      routeContext: input.routeContext,
+      triggeredByUserId: input.triggeredByUserId ?? null,
+    });
+    traceWwwd("wwwd.evaluator.failed", {
+      interactionId,
+      errorClass: errorClass(error),
+      errorMessage: errorMessage(error),
+    });
+    await persistDecisionInteraction({
+      db: input.db,
+      evaluation,
+      triggeredByUserId: input.triggeredByUserId,
+      taskRunId: input.taskRunId,
+      interactionId,
+      routeContext: input.routeContext,
+      phaseFrom: input.phaseFrom ?? null,
+      phaseTo: input.phaseTo ?? null,
+      outcomePayloadExtra: { orgProfileSelected },
+    });
+    traceWwwd("wwwd.ledger.written", { interactionId, outcomeType: evaluation.outcomeType });
+    return {
+      allowed: false,
+      interactionId,
+      evaluation,
+      operatorMessage: operatorMessageFor(evaluation, orgProfileSelected),
+      orgProfileSelected,
+    };
+  }
+
+  traceWwwd("wwwd.org-gate.invoked", {
+    interactionId,
+    organizationId: input.organizationId ?? null,
+    profileId: profile.profileId,
+    orgProfileSelected,
+    domainClass,
+    riskTier,
+    routeContext: input.routeContext,
+    triggeredByUserId: input.triggeredByUserId ?? null,
+  });
+  traceWwwd("wwwd.profile.resolved", {
+    interactionId,
+    resolvedProfileChain: resolved.resolvedProfileChain,
+    materialCount: resolved.materials.length,
+    coverageGap: resolved.coverageGap,
+    orgProfileSelected,
+  });
+
+  const evaluator = input.evaluator ?? evaluateDecisionPerspective;
+  let evaluation: DecisionPerspectiveEvaluationResult;
+  try {
+    evaluation = evaluator({
+      profile,
+      fallbackProfiles: [],
+      materials: resolved.materials,
+      question,
+      questionDomain: domainClass,
+      options,
+      riskTier,
+      recentOverrideCount: input.recentOverrideCount ?? 0,
+      evidence: input.evidence ?? [],
+    });
+  } catch (error) {
+    evaluation = failClosedEvaluation({
+      profile,
+      question,
+      options,
+      domainClass,
+      riskTier,
+      error,
+      resolvedProfileChain: resolved.resolvedProfileChain,
+    });
+    traceWwwd("wwwd.evaluator.failed", {
+      interactionId,
+      errorClass: errorClass(error),
+      errorMessage: errorMessage(error),
+    });
+  }
+
+  if (resolved.coverageGap) {
+    evaluation.outcomeType = "defer";
+    evaluation.coverageGap = true;
+    evaluation.rationale =
+      "No applicable business stance: neither the organization's profile nor any fallback has material for this decision class.";
+    evaluation.resolvedProfileChain = resolved.resolvedProfileChain;
+  }
+
+  traceWwwd("wwwd.evaluator.complete", {
+    interactionId,
+    confidenceScore: evaluation.confidenceScore,
+    outcomeType: evaluation.outcomeType,
+    principleConflict: evaluation.principleConflict,
+  });
+
+  const persisted = await persistDecisionInteraction({
+    db: input.db,
+    evaluation,
+    triggeredByUserId: input.triggeredByUserId,
+    taskRunId: input.taskRunId,
+    interactionId,
+    routeContext: input.routeContext,
+    phaseFrom: input.phaseFrom ?? null,
+    phaseTo: input.phaseTo ?? null,
+    outcomePayloadExtra: { orgProfileSelected },
+  });
+  traceWwwd("wwwd.ledger.written", {
+    interactionId: persisted.interactionId,
+    outcomeType: evaluation.outcomeType,
+  });
+
+  return {
+    allowed: evaluation.outcomeType === "recommend" || evaluation.outcomeType === "arbitrate",
+    interactionId: persisted.interactionId,
+    evaluation,
+    operatorMessage: operatorMessageFor(evaluation, orgProfileSelected),
+    orgProfileSelected,
+  };
+}

--- a/apps/web/lib/decision-perspective/persistence.ts
+++ b/apps/web/lib/decision-perspective/persistence.ts
@@ -184,12 +184,20 @@ export async function findExistingDecisionInteraction(input: {
 
 export async function persistDecisionInteraction(input: {
   db: DecisionInteractionClient;
-  build: { buildId: string };
+  /** Optional: the build a decision belongs to. Omit for non-build (e.g. org/WWWD) decisions. */
+  build?: { buildId: string } | null;
   evaluation: DecisionPerspectiveEvaluationResult;
   deliberationRunId?: string | null;
   taskRunId?: string | null;
   triggeredByUserId?: string | null;
   interactionId?: string;
+  /** Defaults to "/build" (the Build Studio gate) when omitted. */
+  routeContext?: string;
+  /** Build-phase transition fields; default to plan->build when omitted, pass null for non-build decisions. */
+  phaseFrom?: string | null;
+  phaseTo?: string | null;
+  /** Extra fields merged into outcomePayload (e.g. { orgProfileSelected }). */
+  outcomePayloadExtra?: Record<string, unknown>;
 }): Promise<{ interactionId: string; row: Record<string, unknown> }> {
   const interactionId = input.interactionId ?? createDecisionInteractionId();
   const row = await input.db.decisionInteraction.create({
@@ -198,13 +206,13 @@ export async function persistDecisionInteraction(input: {
       profileId: input.evaluation.selectedProfileId,
       profileVersionId: input.evaluation.profileVersionId,
       fallbackProfileId: input.evaluation.fallbackProfileId,
-      buildId: input.build.buildId,
+      buildId: input.build?.buildId ?? null,
       taskRunId: input.taskRunId ?? null,
       deliberationRunId: input.deliberationRunId ?? null,
       triggeredByUserId: input.triggeredByUserId ?? null,
-      routeContext: "/build",
-      phaseFrom: "plan",
-      phaseTo: "build",
+      routeContext: input.routeContext ?? "/build",
+      phaseFrom: input.phaseFrom === undefined ? "plan" : input.phaseFrom,
+      phaseTo: input.phaseTo === undefined ? "build" : input.phaseTo,
       domainClass: input.evaluation.domainClass,
       question: input.evaluation.question,
       options: input.evaluation.options,
@@ -229,6 +237,7 @@ export async function persistDecisionInteraction(input: {
         resolvedProfileChain: input.evaluation.resolvedProfileChain,
         materialCount: input.evaluation.materialCount,
         freshnessDistribution: input.evaluation.freshnessDistribution,
+        ...(input.outcomePayloadExtra ?? {}),
       },
     },
   }) as Record<string, unknown>;

--- a/docs/superpowers/plans/2026-06-19-org-wwwd-decision-resolution.md
+++ b/docs/superpowers/plans/2026-06-19-org-wwwd-decision-resolution.md
@@ -2,7 +2,7 @@
 
 **BI:** BI-230C9EF7 (open, `medium`, epic **EP-WWMD-MCP**) — "Org DecisionPerspectiveProfile resolution entry-point (select per-org profile by ownerOrganizationId)."
 **Governing doctrine:** [`decisions-belong-to-their-scope`](../../founder-kernel/wiki/principles/decisions-belong-to-their-scope.md) (PR #2094) — each decision resolves in its owning scope; cross-scope doctrine is advisory until the owning scope speaks. This plan is the work that turns that boundary from *documented* into *enforced*.
-**Status:** plan for review. No code yet.
+**Status:** Phase 1 **IMPLEMENTED** (2026-06-26, external build) — `evaluateOrgBusinessDecisionGate()` + co-located tests shipped in `apps/web/lib/decision-perspective/org-business-gate.ts`; `persistDecisionInteraction` parameterized (optional `build`, `routeContext`, `phaseFrom/phaseTo`, `outcomePayloadExtra`) so non-build (org/WWWD) decisions record to the same ledger. This activates the dormant org/profession resolution so a coworker business decision is governed by the org's own stance (WWWD) with platform fallback as advisory. It is the keystone the progressive-autonomy trust dial (EP-8AF1C996) reads to measure agreement. **Phase 2** (wire to a coworker business-decision surface) and **Phase 3** (consolidate `principle_decide` business questions) remain — no call site invokes the new gate yet, so this is additive with zero behavior change.
 
 ---
 


### PR DESCRIPTION
## What
Activates the keystone of the progressive-autonomy framework (BI-230C9EF7). The org/profession DecisionPerspectiveProfiles are seeded on install (mission / how-we-decide / profession corpus incl. the `legal-compliance` Compliance Coworker) but were **dormant** — `resolveProfileMaterialForOrg` was built + tested yet called by zero decision surfaces.

`evaluateOrgBusinessDecisionGate()` composes the existing, tested primitives (`resolveProfileMaterialForOrg` -> `evaluateDecisionPerspective` -> `persistDecisionInteraction`) so a coworker business decision is governed by the org's OWN recorded stance (WWWD), with platform doctrine as **advisory fallback only** (the non-inherit boundary) — never binding a business call. Mirrors the proven `evaluateBuildStudioPlanAdvancementGate`.

Records `orgProfileSelected` + the resolved profile chain to the `DecisionInteraction` ledger — the substrate the trust-graduation dial (EP-8AF1C996) reads to measure agreement before releasing autonomy. Fail-closed: any resolver/evaluator error escalates to a human and is still recorded.

## Changes
- NEW `org-business-gate.ts` — gate + fail-closed + operator messaging + tests (resolver/evaluator injected for determinism).
- `persistDecisionInteraction` parameterized (optional `build`, `routeContext`, `phaseFrom/phaseTo`, `outcomePayloadExtra`) so non-build decisions record to the same ledger. **Backward-compatible** — the Build Studio gate path keeps its exact defaults.

## Scope
Phase 1 of `2026-06-19-org-wwwd-decision-resolution.md`. **Additive — no call site invokes the gate yet** (zero behavior change). Phase 2 (wire to a coworker business surface) + Phase 3 (consolidate `principle_decide`) remain.

## Verification
Co-located vitest; relies on CI (source-only worktree). No UI (UX-Fit N/A); plan-doc touch satisfies Spec/Plan/Doc. No schema change (DecisionInteraction.buildId/routeContext/phase already nullable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)