### PR TITLE
feat(deliberation): golden-triangle activation policy for cross-surface review (BI-A245FE00)

### DIFF
--- a/apps/web/lib/deliberation/external-review-activation.test.ts
+++ b/apps/web/lib/deliberation/external-review-activation.test.ts
@@ -1,0 +1,75 @@
+// apps/web/lib/deliberation/external-review-activation.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  decideExternalReviewActivation,
+  pickIndependentSurface,
+} from "./external-review-activation";
+
+describe("decideExternalReviewActivation (BI-A245FE00)", () => {
+  it("always reviews doctrine-shaping artifacts (architecture-decision / policy)", () => {
+    const d = decideExternalReviewActivation({
+      artifactType: "architecture-decision",
+      authorSurface: "claude-desktop",
+      risk: "low",
+    });
+    expect(d.activate).toBe(true);
+    expect(d.pattern).toBe("review");
+  });
+
+  it("debates the highest-stakes doctrine work", () => {
+    const d = decideExternalReviewActivation({
+      artifactType: "policy",
+      authorSurface: "claude-desktop",
+      risk: "critical",
+    });
+    expect(d.activate).toBe(true);
+    expect(d.pattern).toBe("debate");
+    expect(d.strategyProfile).toBe("document-authority");
+  });
+
+  it("reviews specs only at medium+ risk", () => {
+    expect(
+      decideExternalReviewActivation({ artifactType: "spec", authorSurface: "codex-desktop", risk: "low" }).activate,
+    ).toBe(false);
+    expect(
+      decideExternalReviewActivation({ artifactType: "spec", authorSurface: "codex-desktop", risk: "medium" }).activate,
+    ).toBe(true);
+  });
+
+  it("reviews code-change only at high+ risk (CI + author review covers the rest)", () => {
+    expect(
+      decideExternalReviewActivation({ artifactType: "code-change", authorSurface: "claude-desktop", risk: "medium" })
+        .activate,
+    ).toBe(false);
+    expect(
+      decideExternalReviewActivation({ artifactType: "code-change", authorSurface: "claude-desktop", risk: "high" })
+        .activate,
+    ).toBe(true);
+  });
+
+  it("golden triangle: higher risk -> more assurance via the strategyProfile dial", () => {
+    expect(decideExternalReviewActivation({ artifactType: "spec", authorSurface: "x", risk: "medium" }).strategyProfile).toBe("balanced");
+    expect(decideExternalReviewActivation({ artifactType: "spec", authorSurface: "x", risk: "high" }).strategyProfile).toBe("high-assurance");
+    expect(decideExternalReviewActivation({ artifactType: "spec", authorSurface: "x", risk: "critical" }).strategyProfile).toBe("document-authority");
+  });
+
+  it("sensitivity floor raises the profile but never lowers it", () => {
+    expect(
+      decideExternalReviewActivation({ artifactType: "plan", authorSurface: "x", risk: "low", sensitivityFloor: "high-assurance" })
+        .strategyProfile,
+    ).toBe("high-assurance");
+    expect(
+      decideExternalReviewActivation({ artifactType: "architecture-decision", authorSurface: "x", risk: "critical", sensitivityFloor: "economy" })
+        .strategyProfile,
+    ).toBe("document-authority");
+  });
+});
+
+describe("pickIndependentSurface (BI-A245FE00)", () => {
+  it("picks a surface other than the author (evidence-not-provenance)", () => {
+    expect(pickIndependentSurface("claude-desktop", ["claude-desktop", "codex-desktop", "grok-desktop"])).toBe("codex-desktop");
+  });
+  it("returns null when no independent surface is available", () => {
+    expect(pickIndependentSurface("claude-desktop", ["claude-desktop"])).toBeNull();
+  });
+});

--- a/apps/web/lib/deliberation/external-review-activation.ts
+++ b/apps/web/lib/deliberation/external-review-activation.ts
@@ -1,0 +1,130 @@
+// apps/web/lib/deliberation/external-review-activation.ts
+//
+// BI-A245FE00 / EP-BUILD-65837F — autonomous cross-surface deliberation for
+// EXTERNAL-surface artifacts.
+//
+// Founder insight (Mark, 2026-06-26): independent cross-LLM review materially
+// improves quality (this study's own design was corrected by an independent
+// codex-desktop review that caught three errors a single model missed). That is
+// the diversity-of-thought / reviewer-not-author pattern, and the Golden Triangle
+// is the governance dial that decides WHEN the added Cost + Time of a second
+// independent reviewer is worth the Quality.
+//
+// The deliberation ENGINE already exists (start_deliberation: review/debate over
+// an artifact, a stage/risk activation resolver, a strategyProfile cost/quality
+// dial, budget + branch breadth, async dispatch). It is wired to Build Studio
+// artifacts but NOT to the external host-CLI surfaces — so today a human
+// controller routes a review by hand. This module is the missing activation
+// POLICY: given an artifact authored on an external surface, decide whether to
+// fire an independent-surface deliberation and with what golden-triangle profile.
+//
+// PURE (no DB): the caller supplies the artifact descriptor. Wiring this into the
+// capsule/evidence-recording path and the start_deliberation dispatch (selecting
+// an independent surface, enforcing the budget) is the follow-up slice.
+
+export type DeliberationArtifactType =
+  | "spec"
+  | "plan"
+  | "code-change"
+  | "architecture-decision"
+  | "policy"
+  | "research-question";
+export type DeliberationRisk = "low" | "medium" | "high" | "critical";
+export type DeliberationPattern = "review" | "debate";
+export type StrategyProfile = "economy" | "balanced" | "high-assurance" | "document-authority";
+
+export interface ExternalArtifact {
+  readonly artifactType: DeliberationArtifactType;
+  /** WorkCapsule executorKind of the authoring surface (e.g. claude-desktop). */
+  readonly authorSurface: string;
+  readonly risk?: DeliberationRisk;
+  /** Deliverable-sensitivity floor — can only RAISE the profile, never lower it. */
+  readonly sensitivityFloor?: StrategyProfile;
+}
+
+export interface ActivationDecision {
+  readonly activate: boolean;
+  readonly pattern: DeliberationPattern;
+  readonly strategyProfile: StrategyProfile;
+  readonly risk: DeliberationRisk;
+  readonly reason: string;
+}
+
+const RISK_ORDER: Record<DeliberationRisk, number> = { low: 0, medium: 1, high: 2, critical: 3 };
+const PROFILE_ORDER: Record<StrategyProfile, number> = {
+  economy: 0,
+  balanced: 1,
+  "high-assurance": 2,
+  "document-authority": 3,
+};
+
+function riskToProfile(risk: DeliberationRisk): StrategyProfile {
+  switch (risk) {
+    case "critical":
+      return "document-authority";
+    case "high":
+      return "high-assurance";
+    case "medium":
+      return "balanced";
+    case "low":
+      return "economy";
+  }
+}
+
+/** Apply the deliverable-sensitivity floor: the floor can only RAISE the profile. */
+function applyFloor(profile: StrategyProfile, floor?: StrategyProfile): StrategyProfile {
+  if (!floor) return profile;
+  return PROFILE_ORDER[floor] > PROFILE_ORDER[profile] ? floor : profile;
+}
+
+/**
+ * Minimum risk at which each artifact type warrants an independent deliberation.
+ * Doctrine-shaping artifacts always warrant one; code/plan only as risk rises
+ * (normal CI + author review covers the low-risk tail).
+ */
+const MIN_ACTIVATION_RISK: Record<DeliberationArtifactType, DeliberationRisk | null> = {
+  "architecture-decision": "low", // always
+  policy: "low", // always
+  spec: "medium",
+  plan: "medium",
+  "code-change": "high",
+  "research-question": "high",
+};
+
+/**
+ * Decide whether an external-surface artifact should fire an independent-surface
+ * deliberation, and with what golden-triangle profile. `strategyProfile` is the
+ * Golden Triangle dial (more assurance = more Cost+Time for Quality), selected
+ * from risk and raised — never lowered — by the deliverable-sensitivity floor.
+ */
+export function decideExternalReviewActivation(artifact: ExternalArtifact): ActivationDecision {
+  const risk = artifact.risk ?? "medium";
+  const threshold = MIN_ACTIVATION_RISK[artifact.artifactType];
+  const activate = threshold !== null && RISK_ORDER[risk] >= RISK_ORDER[threshold];
+  const strategyProfile = applyFloor(riskToProfile(risk), artifact.sensitivityFloor);
+  // Debate (adversarial, multi-position) for the highest-stakes doctrine work;
+  // peer review otherwise.
+  const pattern: DeliberationPattern =
+    risk === "critical" &&
+    (artifact.artifactType === "architecture-decision" || artifact.artifactType === "policy")
+      ? "debate"
+      : "review";
+  const reason = activate
+    ? `${artifact.artifactType} at risk=${risk} >= ${threshold} -> ${pattern} (${strategyProfile})`
+    : `${artifact.artifactType} at risk=${risk} below activation threshold ${threshold ?? "n/a"} -> no independent review`;
+  return { activate, pattern, strategyProfile, risk, reason };
+}
+
+/**
+ * Pick a reviewing surface INDEPENDENT of the author. Governance approves
+ * evidence, not provenance, so any surface other than the author can review.
+ * Returns null when no independent surface is available (caller falls back to
+ * the operator or a same-surface second pass).
+ */
+export function pickIndependentSurface(
+  authorSurface: string,
+  availableSurfaces: readonly string[],
+): string | null {
+  const independent = availableSurfaces.filter((s) => s !== authorSurface);
+  return independent[0] ?? null;
+}

--- a/docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md
+++ b/docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md
@@ -319,3 +319,4 @@ For docs-only changes:
 - WWMD/kernel decision consolidation should be handled under its own epic or BI after live backlog confirmation.
 - Outbound webhooks should wait for a concrete consuming workflow.
 - Gemini CLI, OpenCode, and Aider should remain benchmark comparators unless the tool evaluation pipeline approves broader DPF support.
+- Autonomous cross-surface deliberation (BI-A245FE00, EP-BUILD-65837F): the activation POLICY foundation shipped — `apps/web/lib/deliberation/external-review-activation.ts` decides, per external-surface artifact, whether to fire an independent-surface deliberation and with what golden-triangle `strategyProfile` (risk-driven, raised by the deliverable-sensitivity floor). Follow-up slice: wire it into the capsule/evidence-recording path + `start_deliberation` dispatch (select an independent surface via `pickIndependentSurface`, enforce the budget). Founder-raised 2026-06-26; demonstrated value in this study's own review cycle.


### PR DESCRIPTION
## Summary
BI-A245FE00 (EP-BUILD-65837F) — founder insight: independent cross-LLM review materially improves quality (this study's own design was corrected by an independent codex-desktop review). The Golden Triangle is the dial that decides when a second independent reviewer's Cost+Time buys Quality.

The deliberation **engine** already exists (`start_deliberation`: review/debate, stage/risk activation, `strategyProfile` cost/quality dial, budget + branch breadth) but is wired only to Build Studio artifacts — so a human routes external reviews by hand. This adds the missing **activation policy** for external-surface artifacts.

## This slice (pure, DB-free, testable)
- `apps/web/lib/deliberation/external-review-activation.ts`:
  - `decideExternalReviewActivation()` — per external-surface artifact, decides whether to fire an independent-surface deliberation and with what golden-triangle `strategyProfile` (risk-driven; raised — never lowered — by a deliverable-sensitivity floor; `debate` for critical doctrine work, `review` otherwise; doctrine-shaping artifacts always reviewed, code-change only at high+ risk).
  - `pickIndependentSurface()` — reviewer surface != author (governance-approves-evidence-not-provenance makes any other surface valid).
- 8 unit tests, green locally.

## Follow-up slice (same BI)
Wire into the capsule/evidence-recording path + `start_deliberation` dispatch (independent-surface selection, budget enforcement).

CI Typecheck authoritative (local tsc skipped — stale junctioned `@dpf/db`; imports none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
