### PR TITLE
feat(worktree): managed dependency bootstrap helper — kill the junction dance (BI-3047C122)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md
+++ b/docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md
@@ -236,6 +236,8 @@ Rollback:
 
 Backlog: `BI-3047C122`.
 
+**Status (2026-06-26): bootstrap helper shipped** — `scripts/lib/bootstrap-worktree-deps.mjs` provides the idempotent, fail-safe managed dependency bootstrap (shared pnpm store, `--frozen-lockfile`, never mutates the root clone, never junctions). `classifyReadiness()` marks `compile-ready` only after deps resolve AND a cheap gate passes; any failure -> `source-only`. Pure logic unit-tested (`node --test scripts/lib/bootstrap-worktree-deps.test.mjs`, 2/2). Follow-up slice: invoke it from `seed-worktree-mcp` / a `dpf worktree --bootstrap` CLI (NOT the blocking WorktreeCreate hook), wire the real cheap gate, and update `.dpf-worktree-readiness.json`.
+
 Goal: reduce manual setup friction without coupling worktrees unsafely to the root clone.
 
 Files to inspect or update:

--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// scripts/lib/bootstrap-worktree-deps.mjs
+//
+// BI-3047C122 / EP-WORKTREE-HYGIENE — managed dependency bootstrap for a worktree.
+//
+// A fresh worktree is born SOURCE-ONLY: nothing installs node_modules, so it
+// cannot run vitest/tsc and contributors fall back to the fragile "junction a
+// sibling's node_modules" dance — which follows a link into the root clone and
+// was the mechanism of the 2026-06-19 730-file wipe. principle_decide chose a
+// MANAGED dependency bootstrap (pinned pnpm via the shared content store) over a
+// root junction: lower blast radius, no root-clone coupling, lockfile-honest.
+//
+// This helper is IDEMPOTENT and FAIL-SAFE: it never mutates the root clone, never
+// junctions, and on any failure leaves the worktree SOURCE-ONLY rather than
+// breaking it. It is intentionally NOT auto-run inside the blocking WorktreeCreate
+// hook (a multi-minute install must never gate worktree creation) — it is invoked
+// explicitly (a `dpf worktree --bootstrap` CLI / the seed script / an opt-in env),
+// so worktree creation stays fast and convergence is a deliberate step.
+
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+/**
+ * Readiness classification given probe results. Pure — unit-tested.
+ * compile-ready ONLY when deps resolved AND a cheap gate passed: structural
+ * presence of node_modules is not enough (a partial/stale install is not ready).
+ */
+export function classifyReadiness({ hasNodeModules, depProbeOk, gateOk }) {
+  if (hasNodeModules && depProbeOk && gateOk) return "compile-ready";
+  return "source-only";
+}
+
+/** Operator-readable reason for the readiness outcome (written to the marker). */
+export function readinessReason({ hasNodeModules, depProbeOk, gateOk }) {
+  if (!hasNodeModules) return "node_modules_missing";
+  if (!depProbeOk) return "dependency_resolution_failed";
+  if (!gateOk) return "cheap_gate_failed";
+  return "managed_bootstrap_ok";
+}
+
+function run(cmd, args, cwd) {
+  try {
+    execFileSync(cmd, args, { cwd, stdio: "pipe", encoding: "utf8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run a managed dependency bootstrap in `worktreePath` and return its readiness.
+ * - Never mutates the root clone; never junctions; uses pnpm's shared content
+ *   store with --prefer-offline so installs are fast and disk-light.
+ * - Idempotent: if node_modules already resolves, skips the install.
+ * - Fail-safe: any failure -> source-only; never throws.
+ */
+export function bootstrapWorktreeDeps(worktreePath, opts = {}) {
+  const pkgMgr = opts.packageManager ?? "pnpm";
+  try {
+    if (!existsSync(`${worktreePath}/node_modules`)) {
+      // Managed install via the shared store; --frozen-lockfile keeps it honest
+      // to the worktree's lockfile (a worktree off main carries main's lockfile).
+      run(pkgMgr, ["install", "--prefer-offline", "--frozen-lockfile"], worktreePath);
+    }
+    const hasNodeModules = existsSync(`${worktreePath}/node_modules`);
+    const depProbeOk = hasNodeModules && run(pkgMgr, ["ls", "--depth", "-1"], worktreePath);
+    // The cheap gate (e.g. one vitest file) is wired in the follow-up slice; for
+    // now a resolvable dependency tree is the gate.
+    const gateOk = depProbeOk;
+    return {
+      status: classifyReadiness({ hasNodeModules, depProbeOk, gateOk }),
+      reason: readinessReason({ hasNodeModules, depProbeOk, gateOk }),
+    };
+  } catch {
+    return { status: "source-only", reason: "bootstrap_threw" };
+  }
+}

--- a/scripts/lib/bootstrap-worktree-deps.test.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.test.mjs
@@ -1,0 +1,19 @@
+// scripts/lib/bootstrap-worktree-deps.test.mjs
+// Node built-in test runner (no node_modules needed): node --test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyReadiness, readinessReason } from "./bootstrap-worktree-deps.mjs";
+
+test("compile-ready ONLY when deps resolved AND the cheap gate passes", () => {
+  assert.equal(classifyReadiness({ hasNodeModules: true, depProbeOk: true, gateOk: true }), "compile-ready");
+  assert.equal(classifyReadiness({ hasNodeModules: true, depProbeOk: true, gateOk: false }), "source-only");
+  assert.equal(classifyReadiness({ hasNodeModules: true, depProbeOk: false, gateOk: false }), "source-only");
+  assert.equal(classifyReadiness({ hasNodeModules: false, depProbeOk: false, gateOk: false }), "source-only");
+});
+
+test("readinessReason explains the source-only cause", () => {
+  assert.equal(readinessReason({ hasNodeModules: false, depProbeOk: false, gateOk: false }), "node_modules_missing");
+  assert.equal(readinessReason({ hasNodeModules: true, depProbeOk: false, gateOk: false }), "dependency_resolution_failed");
+  assert.equal(readinessReason({ hasNodeModules: true, depProbeOk: true, gateOk: false }), "cheap_gate_failed");
+  assert.equal(readinessReason({ hasNodeModules: true, depProbeOk: true, gateOk: true }), "managed_bootstrap_ok");
+});


### PR DESCRIPTION
## Summary
BI-3047C122 (EP-WORKTREE-HYGIENE). A fresh worktree is born source-only, so contributors junction a sibling's `node_modules` — the dance that follows a link into the root clone and caused the 2026-06-19 730-file wipe. `principle_decide` chose a **managed dependency bootstrap** over a root junction.

This study reproduced the friction in its own implementation (the source-only worktrees + stale-junction typecheck false-negatives) — concrete motivation for this BI.

## This slice (toolchain-free to verify)
- `scripts/lib/bootstrap-worktree-deps.mjs` — idempotent, fail-safe: shared pnpm store + `--frozen-lockfile`; **never mutates the root clone, never junctions**; `classifyReadiness()` marks `compile-ready` only after deps resolve AND a cheap gate passes; any failure → `source-only`.
- Pure logic unit-tested via `node --test` (2/2) — no node_modules needed.
- Deliberately **not** auto-run in the blocking `WorktreeCreate` hook (a multi-minute install must not gate creation).

## Follow-up slice (same BI)
Invoke from `seed-worktree-mcp` / a `dpf worktree --bootstrap` CLI, wire the real cheap gate, update `.dpf-worktree-readiness.json`, and collect the test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
