### PR TITLE
fix(mcp): align e2e + docs to DPF_MCP_BEARER_TOKEN (BI-14E9F7CE token-var slice)

### DIFF
--- a/docs/superpowers/plans/2026-05-13-code-intelligence-graph-adoption.md
+++ b/docs/superpowers/plans/2026-05-13-code-intelligence-graph-adoption.md
@@ -2297,7 +2297,7 @@ Call MCP:
 
 ```powershell
 $body = @{ jsonrpc = "2.0"; id = 1; method = "tools/list"; params = @{} } | ConvertTo-Json -Depth 6
-Invoke-RestMethod -Method Post -Uri "http://localhost:3000/api/mcp/v1" -Headers @{ Authorization = "Bearer $env:DPF_MCP_TOKEN" } -Body $body -ContentType "application/json"
+Invoke-RestMethod -Method Post -Uri "http://localhost:3000/api/mcp/v1" -Headers @{ Authorization = "Bearer $env:DPF_MCP_BEARER_TOKEN" } -Body $body -ContentType "application/json"
 ```
 
 Expected: tool list includes `get_code_graph_freshness`, `inspect_build_code_impact`, `search_code_graph`, `trace_code_surface`, and `find_related_tests`.

--- a/e2e/fixtures/evidence.ts
+++ b/e2e/fixtures/evidence.ts
@@ -65,7 +65,8 @@ async function publishFunctionalFailureEvidence(evidence: FunctionalFailureEvide
 
 async function readMcpConfig(): Promise<{ url: string; authorization: string } | null> {
   const explicitUrl = process.env.DPF_MCP_URL;
-  const explicitToken = process.env.DPF_MCP_TOKEN;
+  // Active standard is DPF_MCP_BEARER_TOKEN; keep DPF_MCP_TOKEN as back-compat (BI-14E9F7CE).
+  const explicitToken = process.env.DPF_MCP_BEARER_TOKEN ?? process.env.DPF_MCP_TOKEN;
   if (explicitUrl && explicitToken) {
     return {
       url: explicitUrl,


### PR DESCRIPTION
## Summary
BI-14E9F7CE (EP-CLIENT-HOOK-PLANE) — **token-var slice only.** The active MCP token standard is `DPF_MCP_BEARER_TOKEN`; this aligns the two stale repo references (`e2e/fixtures/evidence.ts` read the legacy `DPF_MCP_TOKEN`; an old plan snippet referenced it) — preferring the bearer var with a back-compat fallback.

## Honestly out of scope here
The **core** of BI-14E9F7CE — *functional* proof that the guard hooks fire on **Codex and Grok**, plus the Grok `GROK_PLUGIN_ROOT` vs `CLAUDE_PLUGIN_ROOT` portability fix — requires those client runtimes and **cannot be exercised from a Claude Code session**. Changing the shared `hooks.json` command blind would risk the working Claude/Codex path, so it's deliberately left as the cross-surface follow-up (tracked in `docs/architecture/agent-client-capability-parity.md` and AGENTS.md §17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
