### PR TITLE
feat(worktree): wire managed bootstrap into the seed path — born compile-ready (BI-3047C122 Wave 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Invoke-RestMethod -Method Post -Uri 'http://127.0.0.1:3000/api/mcp/token/refresh
 ```
 Then retry the MCP call in the running session. No file edits. No re-registration.
 
-**New worktree MCP sync:** `.mcp.json` and `.vscode/mcp.json` are gitignored, so each worktree needs local MCP config plus its own `COMPOSE_PROJECT_NAME` and readiness marker. For a single new worktree, run the seed script from inside that worktree. To repair or rotate every linked worktree, run:
+**New worktree MCP sync:** `.mcp.json` and `.vscode/mcp.json` are gitignored, so each worktree needs local MCP config plus its own `COMPOSE_PROJECT_NAME` and readiness marker. For a single new worktree, run the seed script from inside that worktree. To have it born **compile-ready** (a managed dependency bootstrap via the shared pnpm store, instead of source-only — no junction dance), set `DPF_WORKTREE_BOOTSTRAP=1` before seeding; the seed step then runs `scripts/lib/bootstrap-worktree-deps.mjs` fail-safe (BI-3047C122 — off by default so it never slows routine creation). To repair or rotate every linked worktree, run:
 ```powershell
 .\scripts\sync-mcp-worktrees.ps1
 ```

--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -75,3 +75,16 @@ export function bootstrapWorktreeDeps(worktreePath, opts = {}) {
     return { status: "source-only", reason: "bootstrap_threw" };
   }
 }
+
+// CLI entry: `node scripts/lib/bootstrap-worktree-deps.mjs <worktreePath>`.
+// Invoked by seed-worktree-mcp when DPF_WORKTREE_BOOTSTRAP=1 (opt-in). Prints the
+// readiness JSON and ALWAYS exits 0 — a bootstrap failure must never break the
+// seed script (the worktree just stays source-only). Skipped on import so unit
+// tests of the pure helpers never trigger an install (mirrors worktree-create.mjs).
+const invokedDirectly =
+  process.argv[1] && process.argv[1].replace(/\\/g, "/").endsWith("bootstrap-worktree-deps.mjs");
+if (invokedDirectly) {
+  const target = process.argv[2] ?? process.cwd();
+  process.stdout.write(JSON.stringify(bootstrapWorktreeDeps(target)) + "\n");
+  process.exit(0);
+}

--- a/scripts/seed-worktree-mcp.ps1
+++ b/scripts/seed-worktree-mcp.ps1
@@ -180,6 +180,23 @@ foreach ($pair in $pairs) {
     Write-Ok "Wrote $($pair.Dst)"
 }
 
+# BI-3047C122 (Wave 2): optional managed dependency bootstrap. Born compile-ready
+# instead of source-only when requested (no junction dance). OFF by default so it
+# never slows routine creation; enable with $env:DPF_WORKTREE_BOOTSTRAP = "1".
+# Fail-safe: a failed bootstrap leaves the worktree source-only, never breaks creation.
+if ($env:DPF_WORKTREE_BOOTSTRAP -eq "1") {
+    $bootstrapHelper = Join-Path $Target "scripts/lib/bootstrap-worktree-deps.mjs"
+    if ((Test-Path $bootstrapHelper) -and (Get-Command node -ErrorAction SilentlyContinue)) {
+        Write-Step "Bootstrapping worktree dependencies (managed; DPF_WORKTREE_BOOTSTRAP=1)"
+        try {
+            & node $bootstrapHelper $Target *> $null
+            Write-Ok "Dependency bootstrap attempted (fail-safe; readiness recorded below)"
+        } catch {
+            Write-Host "  [WARN] Dependency bootstrap failed; worktree stays source-only." -ForegroundColor Yellow
+        }
+    }
+}
+
 Write-Step "Classifying worktree verification readiness"
 $pnpmOnPath = $null -ne (Get-Command pnpm -ErrorAction SilentlyContinue)
 $corepackOnPath = $null -ne (Get-Command corepack -ErrorAction SilentlyContinue)

--- a/scripts/seed-worktree-mcp.sh
+++ b/scripts/seed-worktree-mcp.sh
@@ -159,6 +159,23 @@ EOF
 copy_one "$main_abs/.mcp.json"        "$target_abs/.mcp.json"
 copy_one "$main_abs/.vscode/mcp.json" "$target_abs/.vscode/mcp.json"
 
+# BI-3047C122 (Wave 2): optional managed dependency bootstrap. Born compile-ready
+# instead of source-only when requested — kills the "junction a sibling's
+# node_modules" dance. OFF by default (a multi-minute install must not slow every
+# creation); enable per session with DPF_WORKTREE_BOOTSTRAP=1. Fail-safe: a failed
+# bootstrap leaves the worktree source-only and NEVER breaks creation.
+if [ "${DPF_WORKTREE_BOOTSTRAP:-0}" = "1" ]; then
+    bootstrap_helper="$target_abs/scripts/lib/bootstrap-worktree-deps.mjs"
+    if [ -f "$bootstrap_helper" ] && command -v node >/dev/null 2>&1; then
+        step "Bootstrapping worktree dependencies (managed; DPF_WORKTREE_BOOTSTRAP=1)"
+        if node "$bootstrap_helper" "$target_abs" >/dev/null 2>&1; then
+            ok "Dependency bootstrap attempted (fail-safe; readiness recorded below)"
+        else
+            warn "Dependency bootstrap failed; worktree stays source-only."
+        fi
+    fi
+fi
+
 step "Classifying worktree verification readiness"
 pnpm_on_path=false
 corepack_on_path=false


### PR DESCRIPTION
## Summary
**Wave 2 of BI-3047C122** — makes the junction-dance fix *actually fire*. Wave 1 shipped the helper; nothing invoked it, so fresh worktrees were still source-only. This wires it into the governed seed path.

## Change
- **`scripts/lib/bootstrap-worktree-deps.mjs`** — CLI entry (`node … <path>`) that prints readiness JSON and always exits 0 (never breaks seeding); skipped on import so unit tests don't install.
- **`scripts/seed-worktree-mcp.{sh,ps1}`** — before readiness classification, run the bootstrap when `DPF_WORKTREE_BOOTSTRAP=1`, then the existing classifier records `compile-ready`. **OFF by default** (a multi-minute install must not slow routine creation); fail-safe to `source-only`.
- **AGENTS.md §8** — documents the opt-in.

## Your proof path
After this deploys: `setx DPF_WORKTREE_BOOTSTRAP 1` (or `$env:DPF_WORKTREE_BOOTSTRAP="1"`), then create a worktree here — it should be born **compile-ready** and an agent can run `vitest` immediately, **no junction dance**. That's the friction that started this whole effort, closed.

Pure helper logic unit-tested (`node --test`, 2/2). `.sh`+`.ps1` parity. CI Typecheck authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
