### PR TITLE
feat(build): guide to a first-class external build when the BS sandbox cap is hit (BI-937128F6 Wave 2)

### DIFF
--- a/apps/web/lib/build/wip-cap.test.ts
+++ b/apps/web/lib/build/wip-cap.test.ts
@@ -41,4 +41,15 @@ describe("assertWipCapacity", () => {
       expect(err.message).toContain("Finish or abandon one");
     }
   });
+
+  it("guides toward a first-class external build when the BS sandbox is full (BI-937128F6)", () => {
+    try {
+      assertWipCapacity(5, 3);
+      throw new Error("should have thrown");
+    } catch (e) {
+      const err = e as BuildWipCapError;
+      expect(err.message).toMatch(/external .*build/i);
+      expect(err.message).toContain("§17");
+    }
+  });
 });

--- a/apps/web/lib/build/wip-cap.ts
+++ b/apps/web/lib/build/wip-cap.ts
@@ -39,8 +39,10 @@ export class BuildWipCapError extends Error {
   constructor(active: number, cap: number) {
     super(
       `You already have ${active} build${active === 1 ? "" : "s"} in progress ` +
-        `(the limit is ${cap}). Finish or abandon one before starting a new build — ` +
-        `Build Studio keeps work-in-progress low so things actually get completed.`,
+        `(the limit is ${cap}). Build Studio shares one sandbox. Finish or abandon one ` +
+        `before starting another — or run it as an external Claude Code / Codex / Grok ` +
+        `build, which is first-class and NOT gated by the Build Studio sandbox (AGENTS.md §17). ` +
+        `External work still registers its capsule, so it stays visible in the unified WIP.`,
     );
     this.name = "BuildWipCapError";
     this.active = active;


### PR DESCRIPTION
## Summary
**Wave 2 of BI-937128F6** — the *felt* half. The BS WIP cap correctly gates the shared Build Studio sandbox, but hitting it (the `wip_cap_reached` that blocked promotion earlier this session) just said "no". Per §17, external Claude Code / Codex / Grok builds are first-class and **not** gated by the BS sandbox — so the cap error now **points you there**, and notes that external work still registers its capsule and stays visible in the unified WIP.

## Change
- `wip-cap.ts` — enrich `BuildWipCapError` with external-build guidance (pure; keeps the existing "Finish or abandon one" phrasing).
- `wip-cap.test.ts` — assert the external-build guidance + §17 reference. **6/6 green.**

## Follow-up slice (same BI)
The DB-backed unified-WIP **count** — query active `WorkCapsule`s by `executorKind` + lease, run `summarizeUnifiedWip` (#2450), surface it at the promote Definition-of-Ready + an operator view, with `principle_decide` on the cap model. That's a hot-path integration deserving a focused pass.

CI Typecheck authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
