### PR TITLE
fix(self-upgrade): link "Settings → Operating Hours" in timezone note

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -969,7 +969,11 @@ export default function SelfUpgradeClient({
           {windowTimezone && (
             <div className="mt-1 text-[var(--dpf-muted)]" data-window-timezone={windowTimezone}>
               Times shown in <span className="font-medium text-[var(--dpf-text)]">{windowTimezone}</span> — your
-              operating-hours timezone. Change it in Settings → Operating Hours.
+              operating-hours timezone. Change it in{" "}
+              <a className="underline" href="/storefront/settings/operations">
+                Settings → Operating Hours
+              </a>
+              .
             </div>
           )}
         </div>


### PR DESCRIPTION
## Problem

On the Self-Upgrade page, the **Schedule** banner shows a note like:

> Times shown in *America/New_York* — your operating-hours timezone. Change it in Settings → Operating Hours.

An operator reported they couldn't find where to change the timezone. Two issues:

1. **"Settings → Operating Hours" was plain text, not a link** — nothing to click.
2. The label doesn't obviously map to a nav location. The actual page lives under **Storefront → Settings → Operating Hours** (`/storefront/settings/operations`).

The sibling `needs-timezone` banner just above this one already links to that route — so the timezone note was the lone inconsistent case.

## Fix

Make "Settings → Operating Hours" a link to `/storefront/settings/operations`, reusing the exact `<a className="underline">` pattern from the adjacent banner ([SelfUpgradeClient.tsx](apps/web/components/ops/SelfUpgradeClient.tsx)).

No behavior or copy change beyond turning the existing phrase into a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)