### PR TITLE
fix(release): unbreak GHCR multi-arch image publish (edge-node tsc + sandbox arm64)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -51,9 +51,19 @@ RUN curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash \
 # perms trap that bit grok). curl/libstdc++/libgcc are already installed above.
 # Verified live on node:24-alpine: v1.17.4 baseline-musl runs as both users.
 ARG OPENCODE_VERSION=1.17.4
+# Select the arch-matched musl tarball. buildx sets TARGETARCH per matrix leg;
+# amd64 keeps the `baseline` (no-AVX2) variant for broad x86 hardware, arm64
+# uses the plain musl build — upstream ships no arm64 `baseline` (arm64 has no
+# equivalent microarch tier). Hardcoding x64 here broke the linux/arm64 image.
+ARG TARGETARCH
 RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) OPENCODE_ASSET="opencode-linux-x64-baseline-musl.tar.gz" ;; \
+      arm64) OPENCODE_ASSET="opencode-linux-arm64-musl.tar.gz" ;; \
+      *) echo "unsupported TARGETARCH for opencode: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
     curl -fsSL -o /tmp/opencode.tar.gz \
-      "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-baseline-musl.tar.gz"; \
+      "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${OPENCODE_ASSET}"; \
     tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin; \
     rm /tmp/opencode.tar.gz; \
     chmod 755 /usr/local/bin/opencode; \

--- a/services/edge-node/tsconfig.json
+++ b/services/edge-node/tsconfig.json
@@ -8,6 +8,12 @@
     // either module style, so this only changes what tsc emits to dist/.
     "module": "CommonJS",
     "moduleResolution": "Node",
+    // TS5107: 'Node' (node10) module resolution is deprecated and now errors
+    // under the current TypeScript. We keep CommonJS + Node resolution on
+    // purpose (see the module note above — it preserves the extensionless
+    // runtime imports), so silence the deprecation rather than migrate. Drop
+    // this when the service moves to node16/nodenext resolution before TS 7.0.
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Problem

The **Publish Docker Images** workflow has failed since at least **v6.4.0** (and again on v6.5.0). Because every `merge` job declares `needs: build` with no `if:`, a *single* failed build leg skips **all** merge jobs — so the named `vX.Y.Z` / `latest` multi-arch tags are never created and **no release publishes a complete image set**. The per-arch layers push by-digest, but nothing ties them to a consumable tag.

Two independent, deterministic breaks (surfaced when cutting v6.5.0):

### 1. edge-node — `tsc` TS5107
`services/edge-node/tsconfig.json` used `moduleResolution: "Node"` (the legacy `node10` alias). **TypeScript 6.0.3** (current pin) now rejects it with a hard `error TS5107`, failing `pnpm --filter dpf-edge-node build` in the image build:

```
tsconfig.json(10,25): error TS5107: Option 'moduleResolution=node10' is deprecated
and will stop functioning in TypeScript 7.0. Specify '"ignoreDeprecations": "6.0"' to silence.
```

edge-node is the **only** package with legacy resolution, so repo-wide `pnpm typecheck` stays green and the break only appears at image-build time (where `tsc` runs the config directly).

**Fix:** add `"ignoreDeprecations": "6.0"` (the value `tsc` itself prescribes), preserving the file's deliberate CommonJS + extensionless-import design. Documented to migrate to `node16`/`nodenext` before TS 7.0.

### 2. sandbox — arm64 pulled an x64 binary
`Dockerfile.sandbox` hardcoded `opencode-linux-x64-baseline-musl.tar.gz`, so the `linux/arm64` leg downloaded an x64 binary and the `opencode --version` gate failed with exit 2.

**Fix:** select the arch-matched musl tarball via `TARGETARCH` — amd64 keeps the no-AVX2 `baseline` variant (**unchanged**); arm64 uses `opencode-linux-arm64-musl.tar.gz` (the only arm64 musl build upstream ships; there is no arm64 `baseline`).

## Verification
- TS5107 **reproduced then cleared** under `tsc` 6.0.3 in isolation (with/without `ignoreDeprecations`).
- `case` selection maps amd64/arm64 correctly and rejects unknown arches.
- **Both** opencode asset URLs return **HTTP 200** — neither arch 404s.
- Full multi-arch build (all 6 images × 2 arches → merge → E2E install) is validated by this workflow when **v6.5.1** is tagged after merge.

## Follow-up
Per maintainer decision, **v6.5.0 is left as-is**; a fresh **v6.5.1** will be cut after this merges to produce the first complete multi-arch image set. (Does not affect local installs, which build images locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)