### PR TITLE
fix(golden-triangle): plain-language balance pill (drop "Starving")

### DIFF
--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -3,8 +3,8 @@
 // control. Presets are the primary, one-click path; the triangle is an opt-in
 // fine-tune; three numeric inputs are the canonical accessible control (a 2D
 // drag surface is not a 1-D ARIA slider). The triangle is colour-coded by
-// balance — green when centred, shading to yellow then red as one or two axes
-// get starved — and every posture shows, in plain language, what it configures
+// balance — green when centred, shading to yellow then red as the posture trades
+// one or two axes away — and every posture shows, in plain language, what it configures
 // (driven by the real Slice 1 compiler so the UI never drifts).
 import { useId, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
 

--- a/apps/web/components/golden-triangle/GoldenTriangleGradient.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleGradient.tsx
@@ -1,7 +1,7 @@
 "use client";
 // EP-GOLDEN-TRIANGLE — the colour-graded triangle fill. A canvas Gouraud-shades
 // the triangle from each vertex's health colour (red→yellow→green per axis
-// weight): a dominant corner reads green, the starved corners red, dead-centre
+// weight): a dominant corner reads green, the low-weight corners red, dead-centre
 // pure yellow, an edge yellow-near / red-far. Decorative (aria-hidden) — the SVG
 // thumb + the numeric inputs carry the accessible control. Geometry matches the
 // SVG triangle (INSET 12 / SPAN 76 of a 100-unit box): Quality top-centre, Cost

--- a/apps/web/components/golden-triangle/README.md
+++ b/apps/web/components/golden-triangle/README.md
@@ -14,7 +14,7 @@
 
 ## Balance colouring
 
-The triangle shades by balance: **green** when the three axes are centred, through **yellow** to **red** as one or two axes get starved (the posture pushes toward an edge or vertex). Each vertex is labelled with what pulling toward it buys — **Higher Reasoning** (top), **Lower Cost** (bottom-left), **Lower Time** (bottom-right) — while the gradient colour conveys balance, named by a balance pill ("Well balanced" / "Starving Time"). It is an at-a-glance cue that you are trading something away.
+The triangle shades by balance: **green** when the three axes are centred, through **yellow** to **red** as the posture trades one or two axes away (pushing toward an edge or vertex). Each vertex is labelled with what pulling toward it buys — **Higher Reasoning** (top), **Lower Cost** (bottom-left), **Lower Time** (bottom-right) — while the gradient colour conveys balance, named by a balance pill ("Well balanced" / "Higher Cost & More Time"). It is an at-a-glance cue that you are trading something away.
 
 ## Surfaces
 

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -100,7 +100,7 @@ describe("balanceState (triangle colouring)", () => {
     expect(b.level).toBe("starved");
     expect(b.token).toBe("--dpf-error");
     expect(b.starved).toEqual(["Cost", "Time"]);
-    expect(b.label).toMatch(/Starving Cost & Time/);
+    expect(b.label).toMatch(/Higher Cost & More Time/);
   });
 
   it("an edge posture starves one axis (red)", () => {

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -191,9 +191,9 @@ export function decodePostureForDisplay(
   return { decoded, chips: describeConfigured(decoded) };
 }
 
-// ── Balance / starvation colouring ──────────────────────────────────────────
+// ── Balance / trade-off colouring ────────────────────────────────────────────
 // Green when the three axes are in balance (centre), shading through yellow to
-// red as one or two axes get starved (the posture pushes toward an edge/vertex).
+// red as the posture trades one or two axes away (pushes toward an edge/vertex).
 export type BalanceLevel = "balanced" | "leaning" | "starved";
 
 export interface BalanceState {
@@ -206,6 +206,15 @@ export interface BalanceState {
 }
 
 const STARVE_FLOOR = 0.12;
+
+// What deprioritizing an axis actually costs you, in plain terms — the inverse of
+// the corner labels (Lower Cost / Lower Time / Higher Reasoning). Drives the balance
+// pill so it reads e.g. "Higher Cost & More Time" — the plain trade-off, not jargon.
+const AXIS_TRADE_OFF: Record<"Quality" | "Cost" | "Time", string> = {
+  Quality: "Lower Reasoning",
+  Cost: "Higher Cost",
+  Time: "More Time",
+};
 
 export function balanceState(qualityWeight: number, costWeight: number, timeWeight: number): BalanceState {
   const q = Math.max(0, qualityWeight);
@@ -221,7 +230,7 @@ export function balanceState(qualityWeight: number, costWeight: number, timeWeig
   if (nc < STARVE_FLOOR) starved.push("Cost");
   if (nt < STARVE_FLOOR) starved.push("Time");
 
-  // 1 = perfectly balanced (1/3 each); 0 = an axis fully starved (a vertex/edge).
+  // 1 = perfectly balanced (1/3 each); 0 = an axis fully deprioritized (a vertex/edge).
   const score = Math.min(nq, nc, nt) * 3;
   let level: BalanceLevel;
   let token: BalanceState["token"];
@@ -237,7 +246,11 @@ export function balanceState(qualityWeight: number, costWeight: number, timeWeig
   }
 
   const label =
-    level === "balanced" ? "Well balanced" : starved.length > 0 ? `Starving ${starved.join(" & ")}` : "Leaning";
+    level === "balanced"
+      ? "Well balanced"
+      : starved.length > 0
+        ? starved.map((a) => AXIS_TRADE_OFF[a]).join(" & ")
+        : "Leaning";
 
   return { level, token, label, starved };
 }


### PR DESCRIPTION
Follow-up to #2438. The balance pill under the Cost/Quality/Time triangle labelled a deprioritized axis **"Starving Cost & Time"** — founder feedback: that reads as nonsensical/alarming jargon.

## Change
Replace the "Starving X" label with the plain trade-off — the inverse of the corner labels:

| Deprioritized axis | Old | New |
|---|---|---|
| Cost | Starving Cost | **Higher Cost** |
| Time | Starving Time | **More Time** |
| Quality | Starving Quality | **Lower Reasoning** |

So a max-quality posture now reads **"Higher Cost & More Time"** instead of "Starving Cost & Time"; "Well balanced" and "Leaning" are unchanged.

The colour/level logic (green → yellow → red) is **untouched** — only the displayed `label` string changes. Also swept the `starv*` metaphor out of the surrounding prose/comments/README; internal identifiers (`STARVE_FLOOR`, the `starved` array, the `level` enum value) are kept so behaviour and tests stay stable.

## Files
- `apps/web/components/golden-triangle/posture-display.ts` (the label + map)
- `apps/web/components/golden-triangle/posture-display.test.ts`
- `apps/web/components/golden-triangle/{GoldenTriangleControl,GoldenTriangleGradient}.tsx` (comments)
- `apps/web/components/golden-triangle/README.md`

## Verification
- **26/26** golden-triangle unit tests pass (incl. the updated balance-label assertion).
- `tsc` clean for the touched files (remaining local tsc errors are stale-Prisma false positives from a borrowed verification toolchain; CI runs the authoritative typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)