### PR TITLE
fix(golden-triangle): stop the dock jumping when chips wrap to a 2nd row

### DIFF
--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -231,7 +231,13 @@ export function GoldenTriangleControl({
       )}
 
       <div className="mb-1.5">{balancePill}</div>
-      <div className="flex flex-wrap gap-1.5" aria-live="polite">
+      {/* Reserve ~2 rows of chip height in the compact dock so the control's total
+          height (and thus the triangle's position in the bottom-anchored composer
+          dock) stays put when the configured chips wrap from one row to two. */}
+      <div
+        className={["flex flex-wrap content-start gap-1.5", compact ? "min-h-[3.75rem]" : ""].join(" ")}
+        aria-live="polite"
+      >
         {chips.map((chip, i) => (
           <span
             key={`${chip.label}-${i}`}


### PR DESCRIPTION
Founder feedback (3rd round): in the per-coworker priority **dock** at the composer, dragging the point makes the triangle jump up and down — because the configured-chip list ("bubbles") below it wraps from **one row to two** (e.g. Balanced shows a single "Platform defaults" chip; Frugal / Max Cost show 5–6 chips over two rows). The dock is bottom-anchored, so the taller chip area shoves the whole control — and the triangle — upward.

## Fix
Reserve ~2 rows of height for the chip container in **compact** mode (`min-h-[3.75rem]` + `content-start`), so the control's total height stays constant whether the chips occupy one row or two. The triangle no longer moves as you drag.

- **Compact only:** the non-compact platform-page layout flows downward (not bottom-anchored), so the triangle never moved there — no reserved space added, no wasted gap.
- Colour/level/label logic untouched; this is layout-only.

## Files
- `apps/web/components/golden-triangle/GoldenTriangleControl.tsx`

## Verification
- 6/6 `GoldenTriangleControl` unit tests pass.

Note: stacks on top of the merged corner-labels/centering work (#2438) and the in-flight balance-pill copy fix (#2466); touches a different line, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)