### PR TITLE
chore(ratchets): re-tighten module-size baseline for tax-remittance.ts

### DIFF
--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -32,7 +32,7 @@
   "apps/web/lib/actions/promotions.self-upgrade.test.ts": 1021,
   "apps/web/lib/actions/promotions.ts": 948,
   "apps/web/lib/actions/tax-remittance.test.ts": 1080,
-  "apps/web/lib/actions/tax-remittance.ts": 1876,
+  "apps/web/lib/actions/tax-remittance.ts": 1788,
   "apps/web/lib/ai-operations-map/load-map-data.test.ts": 825,
   "apps/web/lib/explore/build-process-matrix.ts": 811,
   "apps/web/lib/explore/feature-build-types.ts": 1049,


### PR DESCRIPTION
## What

Re-tightens the module-size ratchet baseline (`scripts/module-size-baseline.json`, guarded by `scripts/check-module-size.mjs`, BI-OPT-RATCHETS) for `apps/web/lib/actions/tax-remittance.ts`: the baseline recorded **1876** LOC, but the file has since shrunk to **1788**.

## Why

The ratchet only fails when a baselined file *grows*, so a baseline left looser than the file's current size never causes CI red — it just lets the file silently grow back up to the stale number before the guard would object. Lowering the entry to the current count keeps the ratchet meaningful.

## How

- **Surgical one-line edit**, not a blind `node scripts/check-module-size.mjs --update`. A blind `--update` would also rewrite the unrelated `SelfUpgradeClient.tsx` entry (1217 → 1221), which is drift owned by #2469.
- `1788` is the exact LOC `scripts/check-module-size.mjs` computes for this file (`split(/\r?\n/).length`).

## Verification

- `git diff` is exactly the one tax-remittance line (1 insertion / 1 deletion); JSON still valid, 62 entries.
- With #2469's SelfUpgradeClient bump also applied locally, `node scripts/check-module-size.mjs` exits **0** ("Module-size OK"), confirming `1788` is exactly right. On this branch alone, the guard's only residual failure is the pre-existing SelfUpgradeClient drift that #2469 fixes — **not** tax-remittance (a shrink never trips the guard).

Advisory check only (BI-OPT-RATCHETS); no rush. Complementary to and non-conflicting with #2469, which edits a different, non-adjacent line in the same baseline file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)