### PR TITLE
feat(build-studio): auto plain-language change summary band (Band 2) (BI-D93CF6C0)

### DIFF
--- a/apps/web/components/build/BuildChangeSummaryBand.test.tsx
+++ b/apps/web/components/build/BuildChangeSummaryBand.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
+import type { BuildChangeNarrative } from "@/lib/feature-build-types";
+
+// BI-D93CF6C0 — render checks via renderToStaticMarkup (report-kit convention).
+
+function narrative(over: Partial<BuildChangeNarrative> = {}): BuildChangeNarrative {
+  return {
+    headline: "Repeat customers now get an automatic 10% discount.",
+    bullets: ["Applies the discount at checkout", "Shows the saving on the receipt"],
+    whyItMatters: "Rewards your regulars without you tracking who qualifies.",
+    openQuestions: ["Should it stack with coupon codes?"],
+    generatedAt: "2026-06-26T00:00:00.000Z",
+    model: "local",
+    ...over,
+  };
+}
+
+describe("BuildChangeSummaryBand", () => {
+  it("renders the headline, bullets, why-it-matters, and open questions", () => {
+    const html = renderToStaticMarkup(<BuildChangeSummaryBand narrative={narrative()} />);
+    expect(html).toContain("What");
+    expect(html).toContain("changing");
+    expect(html).toContain("automatic 10% discount");
+    expect(html).toContain("Applies the discount at checkout");
+    expect(html).toContain("Rewards your regulars");
+    expect(html).toContain("Should it stack with coupon codes?");
+  });
+
+  it("omits the why-it-matters and open-questions sections when they are absent", () => {
+    const html = renderToStaticMarkup(
+      <BuildChangeSummaryBand narrative={narrative({ whyItMatters: "", openQuestions: undefined })} />,
+    );
+    expect(html).toContain("automatic 10% discount");
+    expect(html).not.toContain("Why it matters");
+    expect(html).not.toContain("left open");
+  });
+});

--- a/apps/web/components/build/BuildChangeSummaryBand.tsx
+++ b/apps/web/components/build/BuildChangeSummaryBand.tsx
@@ -1,0 +1,69 @@
+// apps/web/components/build/BuildChangeSummaryBand.tsx
+//
+// Band 2 of the Build Studio overseer "Solution & Oversight" layer:
+// "What's changing" — the auto-generated plain-language change summary
+// (BuildChangeNarrative, BI-D93CF6C0). Presentational only; the raw diff stays
+// the dive-in. No hardcoded colors. Spec: docs/superpowers/specs/2026-06-22-build-studio-overseer-ux-design.md.
+
+import type { BuildChangeNarrative } from "@/lib/feature-build-types";
+
+export function BuildChangeSummaryBand({
+  narrative,
+}: {
+  narrative: BuildChangeNarrative;
+}) {
+  return (
+    <section
+      data-testid="build-change-summary-band"
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 shadow-dpf-xs"
+    >
+      <div className="flex items-center gap-2">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+          className="text-[var(--dpf-muted)]"
+        >
+          <circle cx="6" cy="6" r="3" />
+          <circle cx="6" cy="18" r="3" />
+          <path d="M6 9v6M13 6h3a2 2 0 0 1 2 2v7M15 4l-2 2 2 2" />
+        </svg>
+        <h3 className="m-0 text-sm font-semibold text-[var(--dpf-text)]">What&apos;s changing</h3>
+      </div>
+
+      <p className="mt-2 text-sm font-medium text-[var(--dpf-text)]">{narrative.headline}</p>
+
+      {narrative.bullets.length > 0 && (
+        <ul className="mt-2 list-disc pl-5 text-xs leading-relaxed text-[var(--dpf-text-secondary)]">
+          {narrative.bullets.map((bullet, index) => (
+            <li key={`change-bullet-${index}`}>{bullet}</li>
+          ))}
+        </ul>
+      )}
+
+      {narrative.whyItMatters && (
+        <p className="mt-2 text-xs leading-relaxed text-[var(--dpf-text-secondary)]">
+          <span className="font-medium text-[var(--dpf-text)]">Why it matters:</span>{" "}
+          {narrative.whyItMatters}
+        </p>
+      )}
+
+      {narrative.openQuestions && narrative.openQuestions.length > 0 && (
+        <div className="mt-2">
+          <div className="text-[10px] uppercase tracking-wider text-[var(--dpf-warning)]">
+            One thing we left open
+          </div>
+          <ul className="mt-0.5 list-disc pl-5 text-xs leading-relaxed text-[var(--dpf-text-secondary)]">
+            {narrative.openQuestions.map((question, index) => (
+              <li key={`change-open-${index}`}>{question}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -30,11 +30,13 @@ import { deriveFleetCounts, deriveNeedsAttention, deriveQueueState } from "./fle
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
 import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
+import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
 import { BuildSolutionSummaryBand } from "./BuildSolutionSummaryBand";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
 import { createFeatureBuild, deleteFeatureBuild } from "@/lib/actions/build";
 import { getFeatureBuild } from "@/lib/actions/build-read";
 import { getBuildDecisionLedgerAction } from "@/lib/actions/build-decision-ledger";
+import { getBuildChangeNarrativeAction } from "@/lib/actions/build-change-narrative";
 import { getBuildFlowStateAction } from "@/lib/actions/build-flow";
 import { getBuildProgressVisibilityAction } from "@/lib/actions/build-progress-visibility";
 import { getCodeGraphFreshnessAction } from "@/lib/actions/code-intelligence";
@@ -42,7 +44,7 @@ import { getBuildAssuranceFindings, getBuildBomSummary } from "@/lib/actions/ass
 import type { ActiveAssuranceFindingRow } from "@/lib/assurance/finding-read";
 import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 import type { BuildFlowState } from "@/lib/build-flow-state";
-import type { FeatureBuildRow } from "@/lib/feature-build-types";
+import type { FeatureBuildRow, BuildChangeNarrative } from "@/lib/feature-build-types";
 import type { EpicRollupView } from "@/lib/build/epic-rollup";
 import type { BomSummary } from "@/lib/assurance/bom-read";
 import type { CodeGraphFreshness } from "@/lib/integrate/code-graph-access";
@@ -186,6 +188,7 @@ export function BuildStudio({
   const [bomSummary, setBomSummary] = useState<BomSummary>(MISSING_BOM_SUMMARY);
   const [assuranceFindings, setAssuranceFindings] = useState<ActiveAssuranceFindingRow[]>([]);
   const [decisionLedger, setDecisionLedger] = useState<BuildDecisionLedgerEntry[]>([]);
+  const [changeNarrative, setChangeNarrative] = useState<BuildChangeNarrative | null>(null);
   const workflowAction = activeBuild
     ? deriveBuildStudioWorkflowAction({
       build: activeBuild,
@@ -312,6 +315,27 @@ export function BuildStudio({
       })
       .catch(() => {
         if (!cancelled) setDecisionLedger([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeBuild?.buildId]);
+
+  // Band 2 (overseer "Solution & Oversight") — load the plain-language change
+  // narrative for the active build. Standalone fetch off the hot SSE refresh
+  // path; null until the build completes and the narrative is generated. BI-D93CF6C0.
+  useEffect(() => {
+    if (!activeBuild) {
+      setChangeNarrative(null);
+      return;
+    }
+    let cancelled = false;
+    getBuildChangeNarrativeAction(activeBuild.buildId)
+      .then((narrative) => {
+        if (!cancelled) setChangeNarrative(narrative);
+      })
+      .catch(() => {
+        if (!cancelled) setChangeNarrative(null);
       });
     return () => {
       cancelled = true;
@@ -793,6 +817,11 @@ export function BuildStudio({
                       proposedApproach={activeBuild.designDoc?.proposedApproach ?? null}
                       fallbackIntent={activeBuild.description}
                     />
+                  </div>
+                )}
+                {changeNarrative && (
+                  <div className="border-b border-[var(--dpf-border)] px-4 py-3">
+                    <BuildChangeSummaryBand narrative={changeNarrative} />
                   </div>
                 )}
                 {decisionLedger.length > 0 && (

--- a/apps/web/lib/actions/build-change-narrative.ts
+++ b/apps/web/lib/actions/build-change-narrative.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import type { BuildChangeNarrative } from "@/lib/feature-build-types";
+
+/**
+ * Read-only server action backing Band 2 ("What's changing") of the Build Studio
+ * overseer layer. Returns the stored plain-language change narrative for a build,
+ * or null if none has been generated yet (the band then simply doesn't render).
+ * BI-D93CF6C0. Mirrors the auth gate of getFeatureBuild; adds no new exposure.
+ */
+export async function getBuildChangeNarrativeAction(
+  buildId: string,
+): Promise<BuildChangeNarrative | null> {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { changeNarrative: true },
+  });
+
+  const raw = build?.changeNarrative;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const o = raw as Record<string, unknown>;
+  if (typeof o.headline !== "string" || o.headline.trim().length === 0) return null;
+
+  return raw as unknown as BuildChangeNarrative;
+}

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -377,6 +377,22 @@ export type BuildDeliberationSummary = Partial<
   Record<BuildDeliberationPhase, BuildDeliberationSummaryEntry>
 >;
 
+/**
+ * BI-D93CF6C0 — plain-language change summary (Band 2 of the overseer layer).
+ * Generated once at build completion from the goal + plan + diff, stored on
+ * FeatureBuild.changeNarrative. Distinct from diffSummary (the raw diff prefix);
+ * this is the "we added X so your customers can Y" narrative for a non-technical
+ * overseer. Spec: docs/superpowers/specs/2026-06-22-build-studio-overseer-ux-design.md.
+ */
+export type BuildChangeNarrative = {
+  headline: string;
+  bullets: string[];
+  whyItMatters: string;
+  openQuestions?: string[];
+  generatedAt: string;
+  model: string;
+};
+
 export type HappyPathFailureStage = "connect" | "fetch" | "parse" | "persist";
 
 export type HappyPathIntakeState = {

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -681,12 +681,48 @@ async function stepComplete(
     listSandboxCommitsAheadOfBase(state.containerId, baseRef, buildWorkdir),
   ]);
 
+  // BI-D93CF6C0 — generate the plain-language change narrative (Band 2 of the
+  // overseer layer) from the goal + plan + diff. Best-effort: a null result just
+  // falls back to the raw diffSummary dive-in, so this never blocks completion.
+  let changeNarrative:
+    | import("@/lib/feature-build-types").BuildChangeNarrative
+    | null = null;
+  try {
+    const buildRow = await prisma.featureBuild.findUnique({
+      where: { buildId },
+      select: { title: true, designDoc: true, buildPlan: true },
+    });
+    if (buildRow) {
+      const designDoc = buildRow.designDoc as
+        | { problemStatement?: string; proposedApproach?: string }
+        | null;
+      const { generateChangeNarrative } = await import("./change-narrative");
+      changeNarrative = await generateChangeNarrative({
+        title: buildRow.title,
+        goal: designDoc?.problemStatement ?? designDoc?.proposedApproach ?? null,
+        planText: buildRow.buildPlan ? JSON.stringify(buildRow.buildPlan) : null,
+        diff: fullDiff,
+      });
+    }
+  } catch (err) {
+    console.warn(
+      "[build-pipeline] change-narrative generation skipped:",
+      (err as Error)?.message,
+    );
+  }
+
   await prisma.featureBuild.update({
     where: { buildId },
     data: {
       diffPatch: fullDiff,
       diffSummary: fullDiff.slice(0, 500),
       gitCommitHashes: commitHashes,
+      ...(changeNarrative
+        ? {
+            changeNarrative:
+              changeNarrative as unknown as import("@dpf/db").Prisma.InputJsonValue,
+          }
+        : {}),
     },
   });
 

--- a/apps/web/lib/integrate/change-narrative.test.ts
+++ b/apps/web/lib/integrate/change-narrative.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { parseChangeNarrative } from "./change-narrative";
+
+// BI-D93CF6C0 — the model call is mocked away; we unit-test the pure parser,
+// which is the part that must be defensive against real local-model output.
+
+describe("parseChangeNarrative", () => {
+  it("parses a well-formed narrative", () => {
+    const n = parseChangeNarrative(
+      JSON.stringify({
+        headline: "Repeat customers now get 10% off.",
+        bullets: ["Applies at checkout", "Shows on the receipt"],
+        whyItMatters: "Rewards your regulars automatically.",
+        openQuestions: ["Should it stack with coupons?"],
+      }),
+      "qwen3-coder",
+    );
+    expect(n).not.toBeNull();
+    expect(n!.headline).toBe("Repeat customers now get 10% off.");
+    expect(n!.bullets).toHaveLength(2);
+    expect(n!.whyItMatters).toContain("regulars");
+    expect(n!.openQuestions).toEqual(["Should it stack with coupons?"]);
+    expect(n!.model).toBe("qwen3-coder");
+    expect(typeof n!.generatedAt).toBe("string");
+  });
+
+  it("extracts JSON from code fences / surrounding prose", () => {
+    const n = parseChangeNarrative(
+      'Here you go:\n```json\n{"headline":"Did a thing","bullets":[],"whyItMatters":""}\n```\nHope that helps!',
+      "m",
+    );
+    expect(n).not.toBeNull();
+    expect(n!.headline).toBe("Did a thing");
+  });
+
+  it("returns null when there is no headline", () => {
+    expect(parseChangeNarrative(JSON.stringify({ bullets: ["x"] }), "m")).toBeNull();
+  });
+
+  it("returns null on non-JSON output", () => {
+    expect(parseChangeNarrative("the model refused to answer", "m")).toBeNull();
+  });
+
+  it("drops non-string entries and omits empty openQuestions", () => {
+    const n = parseChangeNarrative(
+      JSON.stringify({ headline: "h", bullets: ["ok", 5, ""], whyItMatters: "w", openQuestions: [] }),
+      "m",
+    );
+    expect(n!.bullets).toEqual(["ok"]);
+    expect(n!.openQuestions).toBeUndefined();
+  });
+});

--- a/apps/web/lib/integrate/change-narrative.ts
+++ b/apps/web/lib/integrate/change-narrative.ts
@@ -1,0 +1,123 @@
+// apps/web/lib/integrate/change-narrative.ts
+//
+// BI-D93CF6C0 — Band 2 of the Build Studio overseer layer: an auto-generated
+// PLAIN-LANGUAGE change summary. Called once at build completion from the goal +
+// plan + diff; the structured result is stored on FeatureBuild.changeNarrative
+// and rendered at top altitude by BuildChangeSummaryBand. This replaces the
+// engineer-grade raw-diff prefix (diffSummary) for the non-technical overseer.
+//
+// Mirrors the routeAndCall + try/catch fallback pattern in phase-compaction.ts;
+// the model call is intentionally taskType "analysis" so it routes through the
+// platform's standard provider selection (local or robust tier).
+
+import type { BuildChangeNarrative } from "@/lib/feature-build-types";
+
+const MAX_DIFF_CHARS = 8_000;
+const MAX_PLAN_CHARS = 3_000;
+const MAX_GOAL_CHARS = 800;
+
+/** Primitive inputs so the generator is decoupled from the build-doc types and
+ *  trivially unit-testable. The caller (stepComplete) extracts these. */
+export type ChangeNarrativeInputs = {
+  title: string;
+  /** The build's goal — designDoc.problemStatement || proposedApproach. */
+  goal?: string | null;
+  /** The implementation plan, pre-stringified by the caller. */
+  planText?: string | null;
+  /** The releasable git diff for the build. */
+  diff: string;
+};
+
+export async function generateChangeNarrative(
+  inputs: ChangeNarrativeInputs,
+): Promise<BuildChangeNarrative | null> {
+  const diff = (inputs.diff ?? "").trim();
+  if (!diff) return null;
+
+  try {
+    const { routeAndCall } = await import("@/lib/inference/routed-inference");
+    const goal = (inputs.goal ?? "").trim().slice(0, MAX_GOAL_CHARS);
+    const plan = (inputs.planText ?? "").trim().slice(0, MAX_PLAN_CHARS);
+
+    const result = await routeAndCall(
+      [
+        {
+          role: "user",
+          content:
+            `Summarize what a software change does, for a NON-TECHNICAL business owner reviewing it. ` +
+            `Use plain business language — no code, no file names, no jargon. ` +
+            `Answer with ONLY minified JSON of shape ` +
+            `{"headline":string,"bullets":string[],"whyItMatters":string,"openQuestions":string[]}.\n` +
+            `- headline: one plain sentence (e.g. "Repeat customers now get an automatic 10% discount.").\n` +
+            `- bullets: 2-5 plain statements of what changed, in business terms.\n` +
+            `- whyItMatters: one plain sentence on the benefit to the user or their customers.\n` +
+            `- openQuestions: 0-2 plain things left undecided, or [].\n\n` +
+            `Feature: ${inputs.title}\n` +
+            (goal ? `Goal: ${goal}\n` : "") +
+            (plan ? `Plan: ${plan}\n` : "") +
+            `\nCode changes (git diff):\n${diff.slice(0, MAX_DIFF_CHARS)}`,
+        },
+      ],
+      "You translate code changes into plain business language for a non-technical reviewer. Output only minified JSON — no prose, no code fences.",
+      "internal",
+      { taskType: "analysis" },
+    );
+
+    const out = result as { content?: string; model?: string };
+    return parseChangeNarrative(out.content ?? "", out.model ?? "local");
+  } catch (err) {
+    // Non-fatal: a missing narrative just falls back to the raw-diff dive-in.
+    console.warn("[change-narrative] generation failed:", (err as Error)?.message);
+    return null;
+  }
+}
+
+/**
+ * Parse a model response into a BuildChangeNarrative. Pure + defensive: tolerates
+ * code fences / surrounding prose, drops non-string entries, and returns null on
+ * anything missing a headline (so the band simply doesn't render).
+ */
+export function parseChangeNarrative(
+  raw: string,
+  model: string,
+): BuildChangeNarrative | null {
+  const json = extractJsonObject(raw);
+  if (!json) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const o = parsed as Record<string, unknown>;
+  const headline = typeof o.headline === "string" ? o.headline.trim() : "";
+  if (!headline) return null;
+
+  const toStringList = (v: unknown): string[] =>
+    Array.isArray(v)
+      ? v.filter((s): s is string => typeof s === "string" && s.trim().length > 0).map((s) => s.trim())
+      : [];
+
+  const openQuestions = toStringList(o.openQuestions);
+
+  return {
+    headline,
+    bullets: toStringList(o.bullets),
+    whyItMatters: typeof o.whyItMatters === "string" ? o.whyItMatters.trim() : "",
+    ...(openQuestions.length > 0 ? { openQuestions } : {}),
+    generatedAt: new Date().toISOString(),
+    model,
+  };
+}
+
+/** Pull the first {...} object out of a model response (handles fences/prose). */
+function extractJsonObject(raw: string): string | null {
+  if (!raw) return null;
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  return raw.slice(start, end + 1);
+}

--- a/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
+++ b/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
@@ -1,0 +1,27 @@
+# Build Studio Overseer Layer — Implementation Plan & Status
+
+Implements [`2026-06-22-build-studio-overseer-ux-design.md`](../specs/2026-06-22-build-studio-overseer-ux-design.md) (DESIGN-ONLY spec). This plan tracks the band-by-band build-out and the remaining IA reframe under EP-BUILD-STUDIO-UX.
+
+## Status (2026-06-26)
+
+| Band | Surface | BI | State |
+| --- | --- | --- | --- |
+| 3 — Decisions & why | `buildDecisionLedger` read-model + `BuildDecisionLedgerBand` | BI-EC934FC6 | **Done** (#2320 + #2325), merged + deployed |
+| 1 — What we're building | `BuildSolutionSummaryBand` (from `designDoc`) | BI-90670010 (band part) | **Done** (#2416), merged |
+| 4 — Where we need you | plain stop-copy in `deriveBuildStudioWorkflowAction` | BI-FD796419 | **Partial** (#2417); guided-recovery follow-up remains |
+| 2 — What's changing | `changeNarrative` field + generator + `BuildChangeSummaryBand` | BI-D93CF6C0 | **This PR** |
+
+## Band 2 — design realized (spec §4.1)
+
+- `FeatureBuild.changeNarrative Json?` (migration `20260626130000_add_change_narrative`) — additive, nullable; older builds fall back to the raw `diffSummary` dive-in.
+- `generateChangeNarrative` (`apps/web/lib/integrate/change-narrative.ts`) — `routeAndCall` (taskType `analysis`, so it routes through the platform's standard local/robust provider selection) over goal + plan + diff → a `BuildChangeNarrative`. Best-effort; a null result never blocks completion. The parser is pure + defensive (tolerates code fences / prose, drops non-strings) and is unit-tested.
+- Wired into `stepComplete` (`build-pipeline.ts`) — generated once at build completion, alongside `diffSummary`, in a try/catch that can never fail the pipeline step.
+- `getBuildChangeNarrativeAction` server action (mirrors `getBuildDecisionLedgerAction`); `BuildStudio` fetches it on a standalone effect (off the hot SSE path) and renders the band between Band 1 and Band 3, gated on a narrative existing.
+
+## Remaining — the IA reframe (keystone, BI-90670010)
+
+The bands currently render **additively above** the `ProcessGraph`. The spec's altitude flip (§3.1, Option B) is the last and most important piece: make the plain "Solution & Oversight" layer the **default first-viewport**, demote the `ProcessGraph` + engineer surfaces behind a single labeled **"Engineer view"** disclosure, and keep `PhaseMiniRail` always-visible for liveness. It restructures `BuildStudio.tsx`'s render and requires live UX verification before it lands (`structural-verification-is-not-functional`).
+
+## Verification
+
+Source-only worktree → typecheck / vitest / production build / migration-apply are CI-gated. Band 2's parser + the band component are unit/render tested. The narrative's *generation quality* depends on the model tier (local vs robust) and is validated by a real build run; the structure ships now so it is ready the moment a build completes.

--- a/packages/db/prisma/migrations/20260626130000_add_change_narrative/migration.sql
+++ b/packages/db/prisma/migrations/20260626130000_add_change_narrative/migration.sql
@@ -1,0 +1,4 @@
+-- BI-D93CF6C0: plain-language change narrative (Band 2 of the Build Studio
+-- overseer "Solution & Oversight" layer). Additive, nullable — older builds
+-- simply have no narrative and fall back to the raw diffSummary dive-in.
+ALTER TABLE "FeatureBuild" ADD COLUMN "changeNarrative" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4774,6 +4774,7 @@ model FeatureBuild {
   sandboxPort              Int?
   buildBranch              String? // git branch in sandbox: "build/<buildId>"
   diffSummary              String?
+  changeNarrative          Json?
   diffPatch                String?
   codingProvider           String?
   threadId                 String?


### PR DESCRIPTION
## What

**Band 2** of the Build Studio overseer "Solution & Oversight" layer — the **highest-value content gap** from the design. An auto-generated, plain-language *"what's changing"* summary that replaces the engineer-grade raw-diff prefix (`diffSummary`) for a non-technical overseer.

## How

- **`FeatureBuild.changeNarrative Json?`** — additive, nullable migration (`20260626130000`). Older builds fall back to the raw-diff dive-in.
- **`generateChangeNarrative`** (`lib/integrate/change-narrative.ts`) — `routeAndCall` (taskType `analysis`, so it routes through the platform's standard local/robust provider selection) over goal + plan + diff → a structured `BuildChangeNarrative` (headline / plain bullets / why-it-matters / open questions). The parser is **pure + defensive** (tolerates code fences and prose, drops non-strings) and is unit-tested. Best-effort: a null result never blocks build completion.
- Wired into **`stepComplete`** — generated once at build completion alongside `diffSummary`, in a try/catch that can't fail the pipeline.
- **`getBuildChangeNarrativeAction`** + **`BuildChangeSummaryBand`** (render-tested), rendered between Band 1 and Band 3, gated on a narrative existing.

## Verification

Source-only worktree → typecheck / vitest / production build / migration-apply are **CI-gated**. The pure parser + the band component are unit/render tested. The narrative's *generation quality* depends on the model tier and is validated by a real build run; the structure ships now so it's ready the moment a build completes.

Plan/status (incl. the remaining IA reframe): [`2026-06-26-build-studio-overseer-implementation.md`](docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md). `UX-Fit-Decision` in the commit trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
