### PR TITLE
fix(inference): host-aware + operator-overridable local served context (durable COO fix)

### DIFF
--- a/apps/web/lib/inference/bootstrap-first-run.ts
+++ b/apps/web/lib/inference/bootstrap-first-run.ts
@@ -6,8 +6,11 @@ import { activateProvider } from "@/lib/govern/activate-provider";
 import { syncAgentPrincipal } from "@/lib/identity/principal-linking";
 import {
   recommendGenerationModel,
+  recommendServedContextTokens,
+  estimateModelVramGb,
   detectLocalModelOverCommit,
   normaliseModelId,
+  type HostMemory,
 } from "./local-model-policy";
 
 /** Check if first-run bootstrap is needed. */
@@ -193,7 +196,37 @@ export async function executeFirstRunBootstrap(
         // every boot, so first-run and every restart converge on one target.
         // Best-effort — never blocks setup.
         {
-          const { reconcileLocalModelContext } = await import("./local-model-context-reconcile");
+          const { reconcileLocalModelContext, LOCAL_SERVED_CONTEXT_CONFIG_KEY } = await import(
+            "./local-model-context-reconcile"
+          );
+
+          // Seed a host-aware served-context default the FIRST time only, so a
+          // capable box (which can afford a large KV cache) gets the bigger
+          // window the heaviest coworkers need instead of the conservative build
+          // floor. Skip when an operator has already pinned a value. Best-effort.
+          try {
+            const existing = await prisma.platformConfig.findUnique({
+              where: { key: LOCAL_SERVED_CONTEXT_CONFIG_KEY },
+            });
+            if (!existing) {
+              const hw = await getOllamaHardwareInfo(baseUrl);
+              const genId = (tagsData.models ?? [])
+                .map((m) => normaliseModelId(m.name))
+                .find((id) => !id.includes("embed"));
+              const host: HostMemory = { architecture: "discrete", vramGb: hw?.vramGb ?? null };
+              const recommended = recommendServedContextTokens(
+                host,
+                genId ? estimateModelVramGb(genId) : null,
+              );
+              await prisma.platformConfig.create({
+                data: { key: LOCAL_SERVED_CONTEXT_CONFIG_KEY, value: recommended },
+              });
+              console.log(`[bootstrap] Seeded local served-context default → ${recommended} tokens.`);
+            }
+          } catch {
+            // best-effort — reconcile still applies the build floor below
+          }
+
           const ctx = await reconcileLocalModelContext();
           if (ctx.status === "raised") {
             console.log(`[bootstrap] Raised ${ctx.modelId} served context ${ctx.before ?? "unset"} → ${ctx.after} for Build Studio.`);

--- a/apps/web/lib/inference/local-model-context-reconcile.test.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.test.ts
@@ -1,13 +1,20 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockPrisma } = vi.hoisted(() => ({
-  mockPrisma: { modelProfile: { updateMany: vi.fn() } },
+  mockPrisma: {
+    modelProfile: { updateMany: vi.fn() },
+    platformConfig: { findUnique: vi.fn() },
+  },
 }));
 vi.mock("@dpf/db", () => ({ prisma: mockPrisma, DISCOVERY_TRIAGE_AGENT_ID: "discovery-triage" }));
 
 import { reconcileLocalModelContext, resolveLocalServedContextTokens } from "./local-model-context-reconcile";
-import { RECOMMENDED_BUILD_CONTEXT_TOKENS } from "./local-model-policy";
+import { RECOMMENDED_BUILD_CONTEXT_TOKENS, MAX_LOCAL_CONTEXT_TOKENS } from "./local-model-policy";
 
+// Default: no operator override set → target is the build floor. Individual tests
+// override per case. Set in beforeEach because clearAllMocks() clears calls but
+// not implementations, so a prior test's mockResolvedValue would otherwise leak.
+beforeEach(() => mockPrisma.platformConfig.findUnique.mockResolvedValue(null));
 afterEach(() => vi.clearAllMocks());
 
 const GEN = "docker.io/ai/qwen3-coder:latest";
@@ -76,13 +83,59 @@ describe("reconcileLocalModelContext", () => {
     expect(r.after).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
   });
 
-  it("is a no-op when already at/above target — no POST, no DB write", async () => {
+  it("is a no-op (no POST) when already at/above target — DB write is conditional repair only", async () => {
+    mockPrisma.modelProfile.updateMany.mockResolvedValue({ count: 0 });
     const f = makeFetch({ configured: RECOMMENDED_BUILD_CONTEXT_TOKENS });
     const r = await reconcileLocalModelContext(f.fetchImpl);
     expect(r.status).toBe("ok");
     expect(r.before).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
     expect(f.calls.post).toBe(0);
-    expect(mockPrisma.modelProfile.updateMany).not.toHaveBeenCalled();
+    // No DMR write, but a conditional column-repair update is issued (count 0 = nothing stale).
+    expect(mockPrisma.modelProfile.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ maxContextTokens: null }, { maxContextTokens: { lt: RECOMMENDED_BUILD_CONTEXT_TOKENS } }],
+        }),
+        data: { maxContextTokens: RECOMMENDED_BUILD_CONTEXT_TOKENS },
+      }),
+    );
+  });
+
+  it("targets the operator override from PlatformConfig and raises DMR to it (e.g. 128k)", async () => {
+    mockPrisma.platformConfig.findUnique.mockResolvedValue({ value: MAX_LOCAL_CONTEXT_TOKENS });
+    mockPrisma.modelProfile.updateMany.mockResolvedValue({ count: 1 });
+    const f = makeFetch({ configured: RECOMMENDED_BUILD_CONTEXT_TOKENS });
+    const r = await reconcileLocalModelContext(f.fetchImpl);
+    expect(r.status).toBe("raised");
+    expect(r.before).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+    expect(r.after).toBe(MAX_LOCAL_CONTEXT_TOKENS);
+    expect(f.calls.post).toBe(1);
+    expect(mockPrisma.modelProfile.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { maxContextTokens: MAX_LOCAL_CONTEXT_TOKENS } }),
+    );
+  });
+
+  it("clamps an over-ceiling operator override down to MAX_LOCAL_CONTEXT_TOKENS", async () => {
+    mockPrisma.platformConfig.findUnique.mockResolvedValue({ value: 999_999 });
+    mockPrisma.modelProfile.updateMany.mockResolvedValue({ count: 1 });
+    const f = makeFetch({ configured: null });
+    const r = await reconcileLocalModelContext(f.fetchImpl);
+    expect(r.status).toBe("raised");
+    expect(r.after).toBe(MAX_LOCAL_CONTEXT_TOKENS);
+  });
+
+  it("repairs a drifted routing column when DMR already serves at/above target", async () => {
+    // Override unset → target is the floor; DMR serves 49152 (re-profiling left the
+    // ModelProfile column below that). No DMR POST, but the column is synced up.
+    mockPrisma.modelProfile.updateMany.mockResolvedValue({ count: 1 });
+    const f = makeFetch({ configured: 49_152 });
+    const r = await reconcileLocalModelContext(f.fetchImpl);
+    expect(r.status).toBe("ok");
+    expect(r.before).toBe(49_152);
+    expect(f.calls.post).toBe(0);
+    expect(mockPrisma.modelProfile.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { maxContextTokens: 49_152 } }),
+    );
   });
 
   it("leaves the embedding model alone (no generation model installed)", async () => {

--- a/apps/web/lib/inference/local-model-context-reconcile.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.ts
@@ -21,8 +21,47 @@
 
 import { prisma } from "@dpf/db";
 import { getOllamaBaseUrl, getOllamaApiRoot } from "./ollama-url";
-import { isEmbeddingModelId, RECOMMENDED_BUILD_CONTEXT_TOKENS } from "./local-model-policy";
+import {
+  isEmbeddingModelId,
+  RECOMMENDED_BUILD_CONTEXT_TOKENS,
+  clampServedContextTokens,
+} from "./local-model-policy";
 import { getServedContextTokens, setServedContextTokens } from "./dmr-runtime-config";
+
+/**
+ * PlatformConfig key holding the operator-chosen served context (tokens) for the
+ * local generation model. The reconcile target is this value (clamped) when set,
+ * else RECOMMENDED_BUILD_CONTEXT_TOKENS. Stored here — NOT in ModelProfile — so it
+ * survives model re-profiling, which periodically rewrites ModelProfile columns
+ * from the model card's small default. First-run bootstrap seeds a host-aware
+ * default; an operator can pin a specific value (e.g. raise a capable box to 128k
+ * so the heaviest coworkers fit).
+ */
+export const LOCAL_SERVED_CONTEXT_CONFIG_KEY = "local.servedContextTokens";
+
+/**
+ * The reconcile target: the operator override from PlatformConfig (clamped to the
+ * supported band) when present, else the build floor. Best-effort — any read
+ * error falls back to the floor so a DB hiccup never lowers a healthy install
+ * below where it was.
+ */
+export async function resolveServedContextTarget(): Promise<number> {
+  try {
+    const row = await prisma.platformConfig.findUnique({
+      where: { key: LOCAL_SERVED_CONTEXT_CONFIG_KEY },
+    });
+    const raw =
+      typeof row?.value === "number"
+        ? row.value
+        : typeof row?.value === "string"
+          ? Number(row.value)
+          : null;
+    if (raw != null && Number.isFinite(raw)) return clampServedContextTokens(raw);
+  } catch {
+    // best-effort — fall through to the floor
+  }
+  return RECOMMENDED_BUILD_CONTEXT_TOKENS;
+}
 
 export type ContextReconcileStatus =
   | "raised" // was below target; override applied (and ModelProfile synced)
@@ -43,12 +82,20 @@ export type ContextReconcileResult = {
 };
 
 /**
- * Ensure the local generation model serves at least RECOMMENDED_BUILD_CONTEXT_TOKENS.
+ * Ensure the local generation model serves at least the reconcile target — the
+ * operator override (PlatformConfig) when set, else RECOMMENDED_BUILD_CONTEXT_TOKENS.
  * Best-effort and idempotent — safe to call on every boot and on an interval.
+ *
+ * Also REPAIRS the routing source of truth (ModelProfile.maxContextTokens) when
+ * the served context already meets target but the DB column has drifted below it
+ * (model re-profiling resets the column to the card's small default). Routing's
+ * context-window filter reads that column, so a stale value silently excludes the
+ * heaviest coworker even though DMR is serving plenty of context.
  */
 export async function reconcileLocalModelContext(
   fetchImpl: typeof fetch = fetch,
 ): Promise<ContextReconcileResult> {
+  const target = await resolveServedContextTarget();
   const none = (status: ContextReconcileStatus, reason: string | null): ContextReconcileResult => ({
     status,
     modelId: null,
@@ -81,11 +128,24 @@ export async function reconcileLocalModelContext(
       return { status: "unsupported", modelId, before: null, after: null, reason: served.reason };
     }
     const before = served.contextTokens; // null = no override set (DMR default ~4k)
-    if (before !== null && before >= RECOMMENDED_BUILD_CONTEXT_TOKENS) {
+    if (before !== null && before >= target) {
+      // DMR already serves enough. Repair the routing column if re-profiling has
+      // drifted it below what is actually served — best-effort, conditional so the
+      // steady state stays write-free.
+      await prisma.modelProfile
+        .updateMany({
+          where: {
+            providerId: { in: ["local", "ollama"] },
+            modelId,
+            OR: [{ maxContextTokens: null }, { maxContextTokens: { lt: before } }],
+          },
+          data: { maxContextTokens: before },
+        })
+        .catch(() => {});
       return { status: "ok", modelId, before, after: before, reason: null };
     }
 
-    const applied = await setServedContextTokens(apiRoot, modelId, RECOMMENDED_BUILD_CONTEXT_TOKENS, fetchImpl);
+    const applied = await setServedContextTokens(apiRoot, modelId, target, fetchImpl);
     if (!applied.ok) {
       // DMR refuses while a runner is active; the override applies on next load.
       return { status: "deferred", modelId, before, after: null, reason: applied.reason };
@@ -96,7 +156,7 @@ export async function reconcileLocalModelContext(
     await prisma.modelProfile
       .updateMany({
         where: { providerId: { in: ["local", "ollama"] }, modelId },
-        data: { maxContextTokens: applied.contextTokens ?? RECOMMENDED_BUILD_CONTEXT_TOKENS },
+        data: { maxContextTokens: applied.contextTokens ?? target },
       })
       .catch(() => {});
 
@@ -104,7 +164,7 @@ export async function reconcileLocalModelContext(
       status: "raised",
       modelId,
       before,
-      after: applied.contextTokens ?? RECOMMENDED_BUILD_CONTEXT_TOKENS,
+      after: applied.contextTokens ?? target,
       reason: null,
     };
   } catch (err) {

--- a/apps/web/lib/inference/local-model-policy.test.ts
+++ b/apps/web/lib/inference/local-model-policy.test.ts
@@ -11,6 +11,9 @@ import {
   normaliseModelId,
   MAX_CONCURRENT_GENERATION_MODELS,
   RECOMMENDED_BUILD_CONTEXT_TOKENS,
+  MAX_LOCAL_CONTEXT_TOKENS,
+  clampServedContextTokens,
+  recommendServedContextTokens,
 } from "./local-model-policy";
 
 describe("classifyLocalModelRole / isEmbeddingModelId", () => {
@@ -72,6 +75,51 @@ describe("recommendGenerationModelForHost (architecture-aware) + computeMemoryBu
 describe("RECOMMENDED_BUILD_CONTEXT_TOKENS", () => {
   it("clears the OpenCode build floor (22k) so the auto-set context never truncates builds", () => {
     expect(RECOMMENDED_BUILD_CONTEXT_TOKENS).toBeGreaterThanOrEqual(22_000);
+  });
+});
+
+describe("clampServedContextTokens", () => {
+  it("floors below-build values up to the build floor", () => {
+    expect(clampServedContextTokens(4_096)).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+    expect(clampServedContextTokens(0)).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+  });
+  it("caps above-ceiling values at MAX_LOCAL_CONTEXT_TOKENS", () => {
+    expect(clampServedContextTokens(999_999)).toBe(MAX_LOCAL_CONTEXT_TOKENS);
+  });
+  it("passes in-band values through", () => {
+    expect(clampServedContextTokens(49_152)).toBe(49_152);
+  });
+  it("falls back to the floor on non-finite input", () => {
+    expect(clampServedContextTokens(NaN)).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+  });
+});
+
+describe("recommendServedContextTokens (host-aware)", () => {
+  it("scales a big unified Mac up to the ceiling", () => {
+    // 128 GB unified → 96 GB budget; minus 22 GB weights + 5 GB headroom = 69 GB
+    // KV budget → ~690k tokens, clamped to the ceiling.
+    const host = { architecture: "unified" as const, totalRamGb: 128 };
+    expect(recommendServedContextTokens(host, 22)).toBe(MAX_LOCAL_CONTEXT_TOKENS);
+  });
+  it("keeps a 24 GB discrete card near the build floor", () => {
+    // 24 GB VRAM − 16 GB weights − 5 GB headroom = 3 GB KV → ~30k, rounded to 8k.
+    const host = { architecture: "discrete" as const, vramGb: 24 };
+    const ctx = recommendServedContextTokens(host, 16);
+    expect(ctx).toBeGreaterThanOrEqual(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+    expect(ctx).toBeLessThan(MAX_LOCAL_CONTEXT_TOKENS);
+  });
+  it("falls back to the build floor when the budget is undetectable (e.g. DMR reports no VRAM)", () => {
+    expect(recommendServedContextTokens({ architecture: "discrete", vramGb: null }, 16)).toBe(
+      RECOMMENDED_BUILD_CONTEXT_TOKENS,
+    );
+    expect(recommendServedContextTokens({ architecture: "unified", totalRamGb: 128 }, null)).toBe(
+      RECOMMENDED_BUILD_CONTEXT_TOKENS,
+    );
+  });
+  it("falls back to the floor when weights leave no room for KV cache", () => {
+    expect(recommendServedContextTokens({ architecture: "discrete", vramGb: 18 }, 16)).toBe(
+      RECOMMENDED_BUILD_CONTEXT_TOKENS,
+    );
   });
 });
 

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -86,6 +86,71 @@ export const CPU_USABLE_FRACTION = 0.5;
  */
 export const RECOMMENDED_BUILD_CONTEXT_TOKENS = 24_576;
 
+/**
+ * Practical ceiling for the local served context, and the cap on both the
+ * operator override and the host-aware recommendation below.
+ *
+ * WHY THIS MATTERS: the build floor (24k) clears OpenCode but is too small for
+ * the heaviest COWORKER. The COO's assembled prompt — full persona + skills
+ * catalog + tool schemas — is ~16k input tokens before the user types anything,
+ * and routing demands `estimatedInput × 1.5` of context (request-contract.ts).
+ * 16k × 1.5 = 24.6k > 24,576, so a 24k served window HARD-EXCLUDES the COO on a
+ * single-local-model install ("No eligible endpoints for task 'conversation'"),
+ * surfaced to the user as "The AI provider is temporarily unavailable". 128k
+ * clears every coworker with room for long threads (~13 GB KV cache at this
+ * size) and fits comfortably inside a capable box's memory budget.
+ */
+export const MAX_LOCAL_CONTEXT_TOKENS = 131_072;
+
+/**
+ * Approximate KV-cache cost per 1k tokens of served context, GB. Measured on-box
+ * (RTX 4090 / qwen3-coder 30B): ~2.3 GB at 24k ≈ 0.1 GB / 1k. Used to size the
+ * served context to the memory the host can actually spare after model weights.
+ */
+export const KV_CACHE_GB_PER_1K_TOKENS = 0.1;
+
+/** Round a token count DOWN to a clean 8k multiple (what runtimes prefer). */
+function roundDownTo8k(tokens: number): number {
+  return Math.floor(tokens / 8_192) * 8_192;
+}
+
+/**
+ * Clamp a served-context request to the supported band: never below the build
+ * floor (smaller silently truncates local builds / coworker turns), never above
+ * the practical ceiling. Non-finite / non-positive input falls back to the floor.
+ */
+export function clampServedContextTokens(tokens: number): number {
+  if (!Number.isFinite(tokens) || tokens <= 0) return RECOMMENDED_BUILD_CONTEXT_TOKENS;
+  return Math.min(MAX_LOCAL_CONTEXT_TOKENS, Math.max(RECOMMENDED_BUILD_CONTEXT_TOKENS, Math.floor(tokens)));
+}
+
+/**
+ * Recommend the served context window (tokens) for the local generation model,
+ * scaled to the memory the host can spare AFTER the model weights + embedder +
+ * runtime overhead (MODEL_HEADROOM_GB already covers the embedder/overhead, so we
+ * only subtract weights from the budget here). Architecture-aware via
+ * computeMemoryBudgetGb: a 24 GB discrete card lands near the build floor, a
+ * 128 GB unified Mac lands at the ceiling.
+ *
+ * Falls back to the build floor whenever the budget or weights are unknown
+ * (e.g. Docker Model Runner reports no VRAM on Apple Silicon) — in that case the
+ * operator override is the mechanism for going higher. Result is clamped to
+ * [RECOMMENDED_BUILD_CONTEXT_TOKENS, MAX_LOCAL_CONTEXT_TOKENS] and rounded to 8k.
+ */
+export function recommendServedContextTokens(
+  host: HostMemory,
+  modelWeightsGb: number | null,
+): number {
+  const budget = computeMemoryBudgetGb(host);
+  if (!budget || budget <= 0 || modelWeightsGb == null || modelWeightsGb < 0) {
+    return RECOMMENDED_BUILD_CONTEXT_TOKENS;
+  }
+  const kvBudgetGb = budget - modelWeightsGb - MODEL_HEADROOM_GB;
+  if (kvBudgetGb <= 0) return RECOMMENDED_BUILD_CONTEXT_TOKENS;
+  const tokens = roundDownTo8k((kvBudgetGb / KV_CACHE_GB_PER_1K_TOKENS) * 1_000);
+  return clampServedContextTokens(tokens);
+}
+
 export type HostArchitecture = "discrete" | "unified" | "cpu";
 
 export interface HostMemory {


### PR DESCRIPTION
## Problem

On a single-local-model install (only the bundled Docker Model Runner model active, all cloud providers off), the **COO coworker** — and any heavy coworker — fails with:

> The AI provider is temporarily unavailable. Please try again in about 30 seconds.

That string is the agentic-loop **catch-all**, not a real provider blip.

## Root cause

The local generation model's served context is pinned to the flat `RECOMMENDED_BUILD_CONTEXT_TOKENS` (**24,576**). But the COO's assembled prompt (persona + skills catalog + tool schemas) is **~16k input tokens** before the user types anything, and routing demands `estimatedInput × 1.5` of context headroom (`request-contract.ts:203`). `16k × 1.5 > 24,576`, so the context-window hard filter (`pipeline-v2.getExclusionReasonV2`) **excludes the only endpoint** → `No eligible endpoints for task 'conversation'` → the generic message. When a turn did dispatch, the model itself returned `500 "Context size has been exceeded"`.

The 24k floor is deliberately sized for a 24 GB discrete GPU; it is far too conservative for a capable box (e.g. a 128 GB Apple Silicon machine that can serve 128k for ~13 GB of KV cache). Observed live: thread history was only ~400 tokens, so this is **not** a long-conversation problem — the coworker's base prompt alone exceeds the window.

## Changes

- **`local-model-policy.ts`** — add `MAX_LOCAL_CONTEXT_TOKENS` (131,072), `KV_CACHE_GB_PER_1K_TOKENS`, `clampServedContextTokens()`, and `recommendServedContextTokens(host, weights)` that scales served context to the memory the host can spare after model weights (floored at the build minimum, capped at the ceiling, rounded to 8k).
- **`local-model-context-reconcile.ts`** — the reconcile target is now the operator override in `PlatformConfig` (`local.servedContextTokens`), clamped, else the build floor. Stored in `PlatformConfig` (not `ModelProfile`) so it **survives model re-profiling**. The reconcile also **repairs `ModelProfile.maxContextTokens`** (the routing column) when DMR already serves enough but re-profiling drifted the column below it — the silent routing-exclusion this file already documents.
- **`bootstrap-first-run.ts`** — seed a host-aware served-context default on first run (uses the existing hardware probe), so capable hardware gets the larger window out of the box.

## Tests

`local-model-policy.test.ts` (clamp + host-aware sizing) and `local-model-context-reconcile.test.ts` (override-as-target, ceiling clamp, drifted-column repair). **42 + 3 tests pass**; changed app files typecheck clean.

## Operator note

On Apple Silicon, Docker Model Runner reports no VRAM, so the first-run auto-default lands on the floor there — the `PlatformConfig` override is the lever (set `local.servedContextTokens`). A follow-up for real host-RAM detection on Mac is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)