### PR TITLE
fix(coworker): truthful coverage %, COO kind, neutral tier labels (review findings)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -192,7 +192,7 @@ export default async function AgentDetailPage({
 
   const coveragePct =
     profession.coverage && profession.coverage.checklist.length > 0
-      ? Math.round((profession.coverage.pageCount / profession.coverage.checklist.length) * 100)
+      ? Math.min(100, Math.round((profession.coverage.pageCount / profession.coverage.checklist.length) * 100))
       : null;
 
   // WS4: a one-word badge on the Priority tab so an override is visible without

--- a/apps/web/components/platform/coworker-record/RosterView.tsx
+++ b/apps/web/components/platform/coworker-record/RosterView.tsx
@@ -12,10 +12,15 @@ import { matchesFilters, kindOptions, EMPTY_FILTERS, type RosterFilters } from "
 import { computeWorkforceSummary } from "@/lib/coworker-record/workforce-summary";
 import { WorkforceSummaryPanel } from "./WorkforceSummaryPanel";
 
+// Tier is a span-of-control level, not a role — the role-type lives in each
+// coworker's `kind` chip (a tier-1 group can hold a specialist, e.g. an analyst
+// reporting at orchestration tier). Labels stay neutral so they never contradict
+// the kind chip (EP-COWORKER-RT follow-up: tier said "Orchestrators" over a COO
+// whose kind chip read "Specialist").
 const TIER_LABELS: Record<number, string> = {
-  1: "Tier 1 — Orchestrators",
-  2: "Tier 2 — Specialists",
-  3: "Tier 3 — Cross-cutting",
+  1: "Tier 1",
+  2: "Tier 2",
+  3: "Tier 3",
 };
 
 type Filters = RosterFilters;

--- a/apps/web/components/platform/coworker-record/panels.tsx
+++ b/apps/web/components/platform/coworker-record/panels.tsx
@@ -7,6 +7,7 @@
 import Link from "next/link";
 import type { CoworkerRecord } from "@/lib/coworker-record/load-record";
 import type { CorpusGapRow, CorpusUsageRollup } from "@/lib/coworker-record/corpus-signals";
+import { jurisdictionGaps } from "@/lib/coworker-record/coverage";
 import {
   PROFESSION_JURISDICTIONS,
   PROFESSION_COMPETENCY_LEVELS,
@@ -173,8 +174,11 @@ export function OverviewPanel({ record, summary }: { record: CoworkerRecord; sum
   const owningTeam = agent.ownerships[0]?.team.name ?? null;
   const coveragePct =
     profession.coverage && profession.coverage.checklist.length > 0
-      ? Math.round((profession.coverage.pageCount / profession.coverage.checklist.length) * 100)
+      ? Math.min(100, Math.round((profession.coverage.pageCount / profession.coverage.checklist.length) * 100))
       : null;
+  // Jurisdiction gaps surface a risk the volume % alone hides (e.g. 100% corpus
+  // depth while a whole jurisdiction has zero pages). EP-COWORKER-RT follow-up.
+  const jurGaps = profession.coverage ? jurisdictionGaps(profession.coverage) : [];
 
   return (
     <div>
@@ -191,9 +195,12 @@ export function OverviewPanel({ record, summary }: { record: CoworkerRecord; sum
             <Chip tone="error">unmapped role</Chip>
           )}
           {coveragePct !== null ? (
-            <Chip tone={coveragePct >= 80 ? "success" : coveragePct >= 40 ? "warning" : "error"}>
+            <Chip tone={jurGaps.length > 0 ? "warning" : coveragePct >= 80 ? "success" : coveragePct >= 40 ? "warning" : "error"}>
               corpus {coveragePct}% of checklist
             </Chip>
+          ) : null}
+          {jurGaps.length > 0 ? (
+            <Chip tone="error">jurisdiction gap: {jurGaps.map((j) => j.toUpperCase()).join(", ")}</Chip>
           ) : null}
           <Chip tone={decisions.deferRate > 0.25 ? "warning" : "muted"}>
             defer {Math.round(decisions.deferRate * 100)}% ({decisions.total} decisions/30d)
@@ -272,6 +279,13 @@ export function ProfessionPanel({
               <strong style={{ color: "var(--dpf-text)" }}>{installArchetype ?? "universal (none set)"}</strong>
             </div>
             <CoverageMatrix coverage={cov} />
+            {jurisdictionGaps(cov).length > 0 ? (
+              <div style={{ marginTop: 10 }}>
+                <Chip tone="error">
+                  jurisdiction gap: {jurisdictionGaps(cov).map((j) => j.toUpperCase()).join(", ")} uncovered while other jurisdictions have corpus
+                </Chip>
+              </div>
+            ) : null}
             <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 10 }}>
               Archetype variants:{" "}
               {Object.keys(cov.archetype).length > 0

--- a/apps/web/lib/coworker-record/coverage.test.ts
+++ b/apps/web/lib/coworker-record/coverage.test.ts
@@ -5,10 +5,22 @@
 
 import { describe, it, expect } from "vitest";
 import { normalizeVariantAxes } from "./variant-axes";
+import { jurisdictionGaps, type ProfessionCoverage } from "./coverage";
 import {
   PROFESSION_REGISTRY,
   findProfessionFamily,
 } from "@/lib/decision-perspective/resolve-profession-profile";
+
+const baseCoverage: ProfessionCoverage = {
+  professionKey: "x",
+  label: "X",
+  pageCount: 0,
+  jurisdiction: {},
+  competency: {},
+  archetype: {},
+  checklist: [],
+  emptyCorpus: false,
+};
 
 describe("normalizeVariantAxes", () => {
   it("defaults to global / practitioner / universal / global-basis when metadata is empty (seed parity)", () => {
@@ -48,5 +60,17 @@ describe("profession registry coverage contract (WSID §4.11)", () => {
     for (const family of PROFESSION_REGISTRY.families) {
       expect(Array.isArray(family.coverageChecklist), family.professionKey).toBe(true);
     }
+  });
+});
+
+describe("jurisdictionGaps (surfaces the risk a volume-only coverage % hides)", () => {
+  it("flags a non-global jurisdiction with 0 pages when others are covered", () => {
+    expect(jurisdictionGaps({ ...baseCoverage, jurisdiction: { global: 5, us: 2, eu: 3, uk: 0 } })).toEqual(["uk"]);
+  });
+  it("returns [] for global-only / universal families (no jurisdiction-specific gap implied)", () => {
+    expect(jurisdictionGaps({ ...baseCoverage, jurisdiction: { global: 5, us: 0, eu: 0, uk: 0 } })).toEqual([]);
+  });
+  it("returns [] when every non-global jurisdiction is covered", () => {
+    expect(jurisdictionGaps({ ...baseCoverage, jurisdiction: { global: 5, us: 1, eu: 1, uk: 1 } })).toEqual([]);
   });
 });

--- a/apps/web/lib/coworker-record/coverage.ts
+++ b/apps/web/lib/coworker-record/coverage.ts
@@ -88,3 +88,17 @@ export async function loadProfessionCoverage(
     emptyCorpus: pages.length === 0,
   };
 }
+
+/**
+ * Non-global jurisdictions with ZERO corpus pages while at least one OTHER
+ * non-global jurisdiction has coverage — a likely jurisdiction gap (partial
+ * coverage). Returns [] for universal / global-only families, where no
+ * jurisdiction-specific gap is implied. This surfaces the risk a volume-only
+ * coverage % hides (e.g. 100% corpus depth while the UK column is empty).
+ */
+export function jurisdictionGaps(coverage: ProfessionCoverage): string[] {
+  const nonGlobal = Object.entries(coverage.jurisdiction).filter(([j]) => j !== "global");
+  const anyCovered = nonGlobal.some(([, n]) => n > 0);
+  if (!anyCovered) return [];
+  return nonGlobal.filter(([, n]) => n === 0).map(([j]) => j);
+}

--- a/packages/db/src/agent-identity.ts
+++ b/packages/db/src/agent-identity.ts
@@ -31,8 +31,8 @@ const ACRONYMS = new Set([
 /** Per-agent overrides where deterministic derivation is wrong or too generic.
  *  Keyed by the stable agentId (AGT-*) and/or the slug handle so both seed paths hit it. */
 export const AGENT_IDENTITY_OVERRIDES: Record<string, { displayName?: string; kind?: AgentKind }> = {
-  "AGT-ORCH-000": { displayName: "COO" },
-  "coo": { displayName: "COO" },
+  "AGT-ORCH-000": { displayName: "COO", kind: "orchestrator" },
+  "coo": { displayName: "COO", kind: "orchestrator" },
   "AGT-WS-BUILD": { displayName: "Build Lead", kind: "orchestrator" },
   "build-specialist": { displayName: "Build Lead", kind: "orchestrator" },
   "AGT-901": { displayName: "Solution Architect" },


### PR DESCRIPTION
Fixes from founder review of the live install after #2461 merged + self-upgraded.

- **Misleading coverage %** — the headline was `pages ÷ checklist`, **uncapped** (160% for the Compliance Officer) and blind to the jurisdiction matrix, so an empty UK column hid behind a >100% number. Now capped at 100% in both render paths (tab badge + Overview chip), and `jurisdictionGaps()` surfaces non-global jurisdictions with zero corpus *while others are covered* as an explicit risk chip on the Overview fitness row **and** the Profession matrix.
- **COO kind** — showed a `Specialist` chip while sitting in the orchestration tier; the COO override now sets `kind=orchestrator`.
- **Tier vs kind contradiction** — the roster labelled tiers as roles (`Tier 1 — Orchestrators`) while `kind` is the real role facet, so a tier-1 specialist contradicted the header. Tier labels are now neutral; the kind chip carries the role.

Verified via the worktree toolchain: coverage **9/9** (3 new `jurisdictionGaps` cases), agent-identity **88/88**, record + roster render tests green. (Source-only worktree → typecheck/build gated by CI.)

## Deeper follow-ups (filed separately, out of this fix's scope)
- **Duplicate COO rows** — the registry `coo-orchestrator` (`AGT-ORCH-000`) and the workspace-seed `coo` are two Agent rows for the same role, which also inflates the "82 coworkers" count. Needs a careful identity dedup (ROUTE_AGENT_MAP `/workspace` → `coo` depends on the slug).
- **Self-upgrade skips the seed** — the live install shows migration-backfill Title-case ("Coo Orchestrator") instead of the canonical override names ("COO"), because the canonical `resolveAgentIdentity` values are applied by the **seed**, which self-upgrade did not re-run. The names land on the next seed.
- **Agent ↔ AI-coworker vocabulary** — same entities, two lenses (identity-principal vs workforce). A founder decision on the canonical user-facing term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
