### PR TITLE
fix(shell): full-width content surfaces; close the docked coworker-panel gutter

### DIFF
--- a/apps/web/app/(shell)/build/layout.tsx
+++ b/apps/web/app/(shell)/build/layout.tsx
@@ -23,7 +23,7 @@ export default async function BuildLayout({
   return (
     <>
       <ShellPresentationMode
-        frameMaxWidth="1600px"
+        frameMaxWidth="none"
         contentMaxWidth="none"
         pagePadding="0px"
         bottomGap="16px"

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -195,10 +195,22 @@ export default async function ShellLayout({ children }: { children: React.ReactN
             </aside>
           )}
           <main className="min-w-0 flex-1">
+            {/* Full-width by default (operator directive 2026-06-26): the page frame
+                fills the viewport so wide surfaces — boards, grids, tables, canvases —
+                use all the available room instead of a centered 1600px column. A
+                surface that wants a narrower, centered measure (e.g. a reading view)
+                opts in via <ShellPresentationMode frameMaxWidth=… contentMaxWidth=… />,
+                which mx-auto then re-centers. */}
             <div
-              className="mx-auto w-full max-w-[1600px] transition-[padding-right] duration-200"
+              className="mx-auto w-full"
               style={{
-                maxWidth: "var(--shell-page-frame-max-width, 1600px)",
+                // NOTE: no CSS transition on padding-right. The reserve comes from the
+                // unregistered custom property --agent-panel-reserved-width; transitioning
+                // a property whose value derives from an unregistered var leaves it stuck
+                // at the fallback (0px) after the var updates, which intermittently let
+                // content slide under the docked panel. Resolving the var directly (no
+                // transition) makes the reserve reliable.
+                maxWidth: "var(--shell-page-frame-max-width, none)",
                 paddingRight: "var(--agent-panel-reserved-width, 0px)",
               }}
             >
@@ -206,13 +218,23 @@ export default async function ShellLayout({ children }: { children: React.ReactN
                 data-shell-content="true"
                 style={{
                   padding: "var(--shell-page-padding, clamp(1rem, 1vw + 0.75rem, 1.5rem))",
+                  // When the coworker panel is docked, the frame already reserves space
+                  // for it on the right (--agent-panel-reserved-width). The page's own
+                  // right gutter would otherwise STACK on top of that reserve and leave a
+                  // dead black band between wide content (grids, boards) and the panel.
+                  // Collapse the right padding once the reserve exceeds it, so content
+                  // extends up to one clean gap from the panel. Undocked (reserve 0) it
+                  // stays the normal page gutter — and the reserve itself remains the
+                  // safety margin, so content never slides under the panel.
+                  paddingRight:
+                    "max(0px, calc(var(--shell-page-padding, clamp(1rem, 1vw + 0.75rem, 1.5rem)) - var(--agent-panel-reserved-width, 0px)))",
                   minHeight:
                     "calc(100dvh - var(--shell-content-top, 16px) - var(--shell-page-bottom-gap, 16px))",
                 }}
               >
                 <div
                   className="mx-auto w-full"
-                  style={{ maxWidth: "var(--shell-page-content-max-width, 80rem)" }}
+                  style={{ maxWidth: "var(--shell-page-content-max-width, none)" }}
                 >
                   {shellNavSections.length > 0 && <ShellBreadcrumb />}
                   {children}

--- a/apps/web/components/portal-context/PortalContextOverlayDrawer.tsx
+++ b/apps/web/components/portal-context/PortalContextOverlayDrawer.tsx
@@ -33,7 +33,12 @@ export function PortalContextOverlayDrawer({
       // is no gutter to offset around, while staying below the z-[80] banner
       // overlay tier.
       style={{ right: "var(--agent-panel-reserved-width, 0px)" }}
-      className="fixed inset-y-0 z-[60] flex w-full max-w-xl flex-col border-l border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] shadow-xl transition-[right] duration-200"
+      // No CSS transition on `right`: it derives from the unregistered custom property
+      // --agent-panel-reserved-width, and transitioning a value that comes from an
+      // unregistered var leaves it stuck at the 0px fallback after the var updates —
+      // which would dock this drawer to the viewport edge ON TOP of the coworker panel
+      // instead of beside it. Resolving the var directly keeps the side-by-side layout.
+      className="fixed inset-y-0 z-[60] flex w-full max-w-xl flex-col border-l border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] shadow-xl"
     >
       <div className="flex items-center justify-between gap-3 border-b border-[var(--dpf-border)] px-4 py-3">
         <div className="min-w-0">

--- a/apps/web/components/shell/Header.tsx
+++ b/apps/web/components/shell/Header.tsx
@@ -42,7 +42,7 @@ export function Header({ platformRole, brandName, brandLogoUrl, brandLogoUrlLigh
 
   return (
     <header className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-      <div className="mx-auto flex w-full max-w-[1600px] items-center justify-between gap-4 px-4 py-2.5 lg:px-6">
+      <div className="flex w-full items-center justify-between gap-4 px-4 py-2.5 lg:px-6">
         <Link href="/workspace" className="flex min-w-0 items-center gap-3">
           {hasLogo && !logoFailed ? (
             <div className="h-14 flex items-center">


### PR DESCRIPTION
## Problem

Two operator reports, same theme — surfaces not using the available browser width:

1. **Board/grid not using the window.** On wide monitors the main content sat in a centered **1280px (80rem)** column inside a 1600px frame; the rest of the window was empty and wide content (boards, grids, tables) overflowed into horizontal scroll.
2. **Black gutter between the grid and the docked AI coworker panel** — wasted real-estate the content should fill.

## Root cause

- The shell capped content at `80rem` and the frame/header at `1600px` (centered). Only `/build` had opted out.
- The gutter had **two** causes: (a) the page's right padding **stacked** on top of the panel's reserve, and (b) a **latent bug** — the frame transitioned `padding-right`, but the reserve comes from the **unregistered** custom property `--agent-panel-reserved-width`. Transitioning a value derived from an unregistered var leaves it stuck at the `0px` fallback after the var updates, so the reserve intermittently didn't apply and content slid **under** the panel. (Confirmed live: disabling the transition flipped the frame padding `0px → 412px` instantly.)

## Changes (4 files)

- **`(shell)/layout.tsx`** — full-width default (frame + content `max-width: none`); collapse the page's right padding while the panel is docked; drop the broken `padding-right` transition so the reserve resolves reliably.
- **`(shell)/build/layout.tsx`** — `/build` frame `none` for consistency (keeps its zero-padding full-bleed).
- **`shell/Header.tsx`** — header bar uncapped so its right-edge items align with full-width content.
- **`portal-context/PortalContextOverlayDrawer.tsx`** — same stuck-reserve transition removed (it docks beside the panel via the same var).

Surfaces that genuinely want a narrow reading measure can still opt in per-surface via `ShellPresentationMode`.

## Verification (live)

- Board: all four lanes visible (incl. Deferred), no horizontal scroll, panel still docked.
- Grid: content now ends at a **~31px gutter** balanced with the 24px left gutter; **no content under the panel**; reclaimed columns visible.
- List: reflows cleanly to full width; header spans edge-to-edge.
- No page-level horizontal overflow introduced.

## Notes

- Verified via faithful CSS-variable injection on the live portal (the exact mechanism this PR changes).
- No test changes needed: nothing asserts these defaults and the panel-reserve constant is untouched.
- Local scoped typecheck was deferred to CI (source-only worktree has no `node_modules`); change is className/style-string only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
