### PR TITLE
fix(coworker): bundle document parsers in standalone so live document uploads work

### DIFF
--- a/apps/web/lib/shared/file-upload.ts
+++ b/apps/web/lib/shared/file-upload.ts
@@ -1,5 +1,5 @@
 import { prisma, type Prisma } from "@dpf/db";
-import { parseFileContent, capParsedContentSize } from "./file-parsers";
+import { parseFileContent, capParsedContentSize, type ParsedFileContent } from "./file-parsers";
 import { lazyFsPromises, lazyPath, lazyCrypto } from "./lazy-node";
 
 const ALLOWED_EXTENSIONS = new Set(["csv", "xlsx", "pdf", "doc", "docx", "txt", "json", "md", "xml", "yaml", "yml", "tsv", "log", "ppt", "pptx", "rtf", "png", "jpg", "jpeg", "gif", "webp"]);
@@ -78,8 +78,18 @@ export async function handleFileUpload(file: File, threadId: string, userId: str
   await fs.mkdir(path.join(storagePath, threadId), { recursive: true });
   await fs.writeFile(path.join(storagePath, storageKey), buffer);
 
-  let parsedContent = await parseFileContent(buffer, file.type, file.name);
-  if (parsedContent) parsedContent = capParsedContentSize(parsedContent);
+  // A parser failure — a missing/failed optional dependency, a corrupt file, or
+  // a parser bug — must never fail the whole upload. Store the file and let the
+  // attachment exist without parsed content (the agent surfaces "uploaded but
+  // content not available"). Images legitimately have no parser and return null.
+  let parsedContent: ParsedFileContent | null = null;
+  try {
+    parsedContent = await parseFileContent(buffer, file.type, file.name);
+    if (parsedContent) parsedContent = capParsedContentSize(parsedContent);
+  } catch (err) {
+    console.warn(`[file-upload] parse failed for ${file.name}: ${err instanceof Error ? err.message : String(err)}`);
+    parsedContent = null;
+  }
 
   const attachment = await prisma.agentAttachment.create({
     data: {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -7,6 +7,14 @@ const config = {
   output: "standalone",
   reactStrictMode: true,
   transpilePackages: ["@dpf/db", "@dpf/validators"],
+  // Server-only document parsers loaded via dynamic `import()` in the upload
+  // route (lib/shared/file-parsers.ts). They MUST stay external (not bundled)
+  // so Next's standalone output traces them into the shipped node_modules —
+  // otherwise `import("pdf-parse")` / "mammoth" / "read-excel-file" throw
+  // "Cannot find package" at runtime in the production image and every document
+  // upload 500s. (These are app-level deps; their symlink lives in
+  // apps/web/node_modules, which the standalone trace omits without this.)
+  serverExternalPackages: ["pdf-parse", "mammoth", "read-excel-file"],
   turbopack: {
     root: turbopackRoot,
   },


### PR DESCRIPTION
## The bug (found on the live install)

Mark hit **"Upload failed"** using the AI Coworker "Attach file" feature. The portal log showed the real cause:

```
⨯ Error: Cannot find package 'pdf-parse' imported from /app/apps/web/.next/server/chunks/...
```

So **every document upload was 500-ing** on the production image — not a storage or config problem, a packaging one.

## Root cause

`handleFileUpload` → `parseFileContent` loads the document parsers via dynamic `import()` in `lib/shared/file-parsers.ts` (`pdf-parse`, `mammoth`, `read-excel-file`). These are **app-level** deps whose pnpm symlink lives in `apps/web/node_modules`. The production image ships Next's **standalone** output (`Dockerfile` copies `.next/standalone`), and the standalone trace **omits** them — the `/* turbopackIgnore: true */` dynamic imports aren't followed by the file tracer. The Dockerfile copies only the *root* `node_modules`, so the app-level symlink is absent at runtime → `Cannot find package`.

(The packages are present in the image's `.pnpm` store but with no resolvable top-level symlink.)

## Fix

1. **`next.config.mjs`** — `serverExternalPackages: ["pdf-parse", "mammoth", "read-excel-file"]`. This keeps them external (not bundled) **and** makes Next trace them into the standalone output's `node_modules`, so the runtime `import()` resolves.
2. **`handleFileUpload`** — wrap `parseFileContent` in try/catch so a parser failure (missing dep, corrupt file, parser bug) degrades to *"file attached, content not parsed"* instead of 500-ing the whole upload. Defense in depth so a parser issue can never again lose an upload.

## Relationship to #2474

Follow-up to [#2474](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2474) (paste/drag/image attachments, just merged). That added image attachments (which skip parsing, so they were unaffected); this restores **document** parsing on the production image. Branched off post-merge `main`.

## Verification

- Unit tests green via junctioned toolchain (barrel import path through `file-upload.ts` + touched suites: 83 passing); `tsc` clean on changed files.
- ⏳ The `serverExternalPackages` tracing fix can only be **fully** confirmed by rebuilding the portal image — I'll verify the live "Attach a document → coworker reads it" happy path once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)