### PR TITLE
fix(grants): map raw browser-use tool aliases

### DIFF
--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -716,21 +716,18 @@ describe("Existing coworkers — no behavior regression from the refactor", () =
 
 describe("TOOL_TO_GRANTS — Browser-driving entries (EP-BROWSER-DRIVE, Verdict 5)", () => {
   it("browse_act (side-effecting) requires browser_drive, not browser_read", () => {
-    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", ["browser_drive"])).toBe(true);
-    // browser_read alone is NOT enough to drive — the whole point of the split.
-    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", ["browser_read"])).toBe(false);
-    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", [])).toBe(false);
-    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", ["backlog_write"])).toBe(false);
+    for (const tool of ["mcp-browser-use__browse_act", "browse_act"]) {
+      expect(isToolAllowedByGrants(tool, ["browser_drive"])).toBe(true);
+      // browser_read alone is NOT enough to drive — the whole point of the split.
+      expect(isToolAllowedByGrants(tool, ["browser_read"])).toBe(false);
+      expect(isToolAllowedByGrants(tool, [])).toBe(false);
+      expect(isToolAllowedByGrants(tool, ["backlog_write"])).toBe(false);
+    }
   });
 
   it("read tools require browser_read, and browser_drive satisfies them via implication", () => {
-    for (const tool of [
-      "mcp-browser-use__browse_open",
-      "mcp-browser-use__browse_extract",
-      "mcp-browser-use__browse_screenshot",
-      "mcp-browser-use__browse_close",
-      "mcp-browser-use__browse_run_tests",
-    ]) {
+    const tools = ["mcp-browser-use__browse_open", "mcp-browser-use__browse_extract", "mcp-browser-use__browse_screenshot", "mcp-browser-use__browse_close", "mcp-browser-use__browse_run_tests", "browse_open", "browse_extract", "browse_screenshot", "browse_close", "browse_run_tests"];
+    for (const tool of tools) {
       expect(isToolAllowedByGrants(tool, ["browser_read"])).toBe(true);
       // browser_drive implies browser_read, so a driver can also read.
       expect(isToolAllowedByGrants(tool, ["browser_drive"])).toBe(true);
@@ -740,6 +737,7 @@ describe("TOOL_TO_GRANTS — Browser-driving entries (EP-BROWSER-DRIVE, Verdict 
 
   it("browse_run_tests stays QA-scoped on browser_read, never browser_drive", () => {
     expect(isToolAllowedByGrants("mcp-browser-use__browse_run_tests", ["browser_read"])).toBe(true);
+    expect(isToolAllowedByGrants("browse_run_tests", ["browser_read"])).toBe(true);
   });
 
   it("GRANT_IMPLICATIONS is one-way: browser_drive implies browser_read, not the reverse", () => {
@@ -751,7 +749,8 @@ describe("TOOL_TO_GRANTS — Browser-driving entries (EP-BROWSER-DRIVE, Verdict 
   it("the namespaced browser tools are present in the grant mapping (so they don't default-deny)", () => {
     const map = getToolGrantMapping();
     expect(map["mcp-browser-use__browse_act"]).toEqual(["browser_drive"]);
-    expect(map["mcp-browser-use__browse_open"]).toEqual(["browser_read"]);
+    expect(map["browse_act"]).toEqual(["browser_drive"]);
+    expect(map["browse_open"]).toEqual(["browser_read"]);
   });
 });
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -120,6 +120,16 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   "mcp-browser-use__browse_close": ["browser_read"],
   "mcp-browser-use__browse_run_tests": ["browser_read"],
   "mcp-browser-use__browse_act": ["browser_drive"],
+  // Raw browser-use RPC names are used by first-party helpers and by the local
+  // sidecar binding before namespace decoration. Keep them on the same scope as
+  // their namespaced forms so a broader PLATFORM_TOOLS/audit extraction cannot
+  // strand them in default-deny with a different authority story.
+  browse_open: ["browser_read"],
+  browse_extract: ["browser_read"],
+  browse_screenshot: ["browser_read"],
+  browse_close: ["browser_read"],
+  browse_run_tests: ["browser_read"],
+  browse_act: ["browser_drive"],
   // The coworker-facing orchestrator entry point (drives a full bounded task).
   drive_browser_task: ["browser_drive"],
 


### PR DESCRIPTION
## Summary
- Maps raw browser-use RPC aliases to the same grants as their namespaced MCP forms.
- Keeps read/test/screenshot/open/close on `browser_read` and the side-effecting action on `browser_drive`.
- Adds grant tests for the alias behavior.

## Verification
- `git diff --check` passed.
- Read-only extraction across MCP tool definitions and packs reports zero unmapped names after the change.
- Targeted Vitest and audit runner commands were attempted and blocked in this source-only worktree: `vitest` and `tsx` not found because `node_modules` is missing.
- Pre-commit gitleaks scan passed; `DPF_SKIP_TYPECHECK=1` was used because the source-only worktree cannot run `next typegen && tsc --noEmit` without dependencies.