### PR TITLE
fix(build): trigger pre-build repair loops in place

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1826,7 +1826,7 @@ export async function sendMessage(input: {
             const { executeTool } = await import("@/lib/mcp-tools");
             await executeTool(
               "saveBuildEvidence",
-              { field: "scoutFindings", value: scoutResult.result },
+              { buildId: resolvedBuildId, field: "scoutFindings", value: scoutResult.result },
               user.id!,
               { routeContext: input.routeContext }
             );
@@ -1873,18 +1873,14 @@ export async function sendMessage(input: {
           // Build context for the research
           const buildCtx = await getFeatureBuildForContext(resolvedBuildId, user.id!);
           // Use the active provider — Claude, Codex, or Grok depending on config
-          const ideateProviderId =
-            config.provider === "claude"
-              ? config.claudeProviderId
-              : config.provider === "grok"
-                ? config.grokProviderId
-                : config.codexProviderId;
-          const ideateModel =
-            config.provider === "claude"
-              ? config.claudeModel
-              : config.provider === "grok"
-                ? config.grokModel
-                : config.codexModel;
+          const ideateProviderId = config.provider === "claude" ? config.claudeProviderId
+            : config.provider === "grok" ? config.grokProviderId
+            : config.provider === "opencode" ? config.opencodeProviderId
+            : config.codexProviderId;
+          const ideateModel = config.provider === "claude" ? config.claudeModel
+            : config.provider === "grok" ? config.grokModel
+            : config.provider === "opencode" ? config.opencodeModel
+            : config.codexModel;
 
           const ideateResult = await dispatchIdeateResearch({
             featureTitle: buildForResearch?.title ?? "Untitled Feature",
@@ -1915,7 +1911,7 @@ export async function sendMessage(input: {
             const { executeTool } = await import("@/lib/mcp-tools");
             const saveResult = await executeTool(
               "saveBuildEvidence",
-              { field: "designDoc", value: ideateResult.designDoc },
+              { buildId: resolvedBuildId, field: "designDoc", value: ideateResult.designDoc },
               user.id!,
               { routeContext: input.routeContext },
             );
@@ -1933,7 +1929,7 @@ export async function sendMessage(input: {
                 // Run the design doc review
                 console.log(`[coworker] Running reviewDesignDoc...`);
                 agentEventBus.emit(input.threadId, { type: "tool:start", tool: "design_review", iteration: 0 });
-                const reviewResult = await executeTool("reviewDesignDoc", {}, user.id!, { routeContext: input.routeContext });
+                const reviewResult = await executeTool("reviewDesignDoc", { buildId: resolvedBuildId }, user.id!, { routeContext: input.routeContext });
                 console.log(`[coworker] reviewDesignDoc result: success=${reviewResult.success}, msg=${JSON.stringify(reviewResult.message?.slice(0, 100))}`);
                 agentEventBus.emit(input.threadId, { type: "tool:complete", tool: "design_review", success: reviewResult.success });
 
@@ -1959,7 +1955,7 @@ export async function sendMessage(input: {
                 const patchedDoc = { ...rawDoc, existingCodeAudit: fallbackAudit };
                 const retryResult = await executeTool(
                   "saveBuildEvidence",
-                  { field: "designDoc", value: patchedDoc },
+                  { buildId: resolvedBuildId, field: "designDoc", value: patchedDoc },
                   user.id!,
                   { routeContext: input.routeContext },
                 );
@@ -1971,7 +1967,7 @@ export async function sendMessage(input: {
                     responseContent = "The codebase research ran but didn't produce a complete design. The research engine may have had trouble accessing the codebase. Please try starting the feature again — if the problem persists, check that the sandbox is running.";
                   } else {
                     agentEventBus.emit(input.threadId, { type: "tool:start", tool: "design_review", iteration: 0 });
-                    const reviewResult = await executeTool("reviewDesignDoc", {}, user.id!, { routeContext: input.routeContext });
+                    const reviewResult = await executeTool("reviewDesignDoc", { buildId: resolvedBuildId }, user.id!, { routeContext: input.routeContext });
                     agentEventBus.emit(input.threadId, { type: "tool:complete", tool: "design_review", success: reviewResult.success });
                     const reviewDecision = (reviewResult.data as { review?: { decision?: string }; blocked?: boolean } | undefined);
                     const reviewPassed = reviewDecision?.review?.decision === "pass" && !reviewDecision?.blocked;

--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockPrisma } = vi.hoisted(() => ({
   mockPrisma: {
-    featureBuild: { findUnique: vi.fn(), findMany: vi.fn() },
+    featureBuild: { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
     backlogItem: { findUnique: vi.fn() },
     buildActivity: { create: vi.fn() },
   },
@@ -38,6 +38,7 @@ vi.mock("@/lib/build/escalate-build-to-human", () => ({
 import {
   dispatchIdeateForApprovedBuild,
   buildNeedsIdeateDispatch,
+  getIdeateResearchRequest,
   dispatchApprovedIdeateBuilds,
   dispatchDesignReviewFixLoop,
 } from "./ideate-on-approval";
@@ -326,6 +327,25 @@ describe("buildNeedsIdeateDispatch (BI-3E0EE3BA)", () => {
   });
 });
 
+describe("getIdeateResearchRequest", () => {
+  it("reads an explicit start_ideate_research request and its context", () => {
+    expect(getIdeateResearchRequest({
+      ideateResearchRequested: true,
+      userContext: "Focus on appointment capacity.",
+      reusabilityScope: "one-off",
+    })).toEqual({
+      requested: true,
+      userContext: "Focus on appointment capacity.",
+      reusabilityScope: "one-off",
+    });
+  });
+
+  it("ignores missing or false request flags", () => {
+    expect(getIdeateResearchRequest(null)).toEqual({ requested: false });
+    expect(getIdeateResearchRequest({ ideateResearchRequested: false })).toEqual({ requested: false });
+  });
+});
+
 describe("dispatchApprovedIdeateBuilds (BI-3E0EE3BA recovery)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -334,10 +354,10 @@ describe("dispatchApprovedIdeateBuilds (BI-3E0EE3BA recovery)", () => {
 
   it("fires dispatch only for approved drafts still missing a designDoc, bounded by limit", async () => {
     mockPrisma.featureBuild.findMany.mockResolvedValue([
-      { buildId: "FB-A", designDoc: null },                         // needs
-      { buildId: "FB-B", designDoc: { problemStatement: "done" } }, // already has → not counted
-      { buildId: "FB-C", designDoc: { problemStatement: "" } },     // needs
-      { buildId: "FB-D", designDoc: null },                         // needs
+      { buildId: "FB-A", designDoc: null, buildExecState: null },                         // needs
+      { buildId: "FB-B", designDoc: { problemStatement: "done" }, buildExecState: null }, // already has → not counted
+      { buildId: "FB-C", designDoc: { problemStatement: "" }, buildExecState: null },     // needs
+      { buildId: "FB-D", designDoc: null, buildExecState: null },                         // needs
     ]);
     // Inner dispatch returns fast (skipped-no-bi, no LLM) — we're asserting the
     // recovery's selection + iteration, not the dispatch internals.
@@ -359,6 +379,59 @@ describe("dispatchApprovedIdeateBuilds (BI-3E0EE3BA recovery)", () => {
           phase: "ideate",
           draftApprovedAt: { not: null },
           abandonedAt: null,
+        }),
+      }),
+    );
+  });
+
+  it("consumes an explicit ideate re-request even when a designDoc already exists", async () => {
+    mockPrisma.featureBuild.findMany.mockResolvedValue([
+      {
+        buildId: "FB-R",
+        designDoc: { problemStatement: "Existing design." },
+        buildExecState: {
+          ideateResearchRequested: true,
+          userContext: "Re-check capacity conflicts.",
+          reusabilityScope: "template",
+        },
+      },
+    ]);
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({
+        originatingBacklogItemId: "cmpcuid-r",
+        designDoc: { problemStatement: "Existing design." },
+        title: "Fallback Title",
+        description: "Fallback description.",
+      })
+      .mockResolvedValueOnce({ designDoc: { problemStatement: "Revised design." } });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({
+      title: "BI Title",
+      body: "Original BI body.",
+      effortSize: "medium",
+    });
+    mockDispatchIdeateResearch.mockResolvedValue({
+      success: true,
+      designDoc: { problemStatement: "Revised design.", proposedApproach: "x".repeat(60) },
+      rawOutput: "",
+      durationMs: 99,
+    });
+    mockExecuteTool.mockResolvedValue({ success: true });
+    mockPrisma.featureBuild.update.mockResolvedValue({});
+
+    const res = await dispatchApprovedIdeateBuilds({ userId: "u-1" });
+
+    expect(res).toEqual({ candidates: 1, dispatched: 1, skipped: 0 });
+    expect(mockDispatchIdeateResearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reusabilityScope: "template",
+        userContext: expect.stringContaining("Re-check capacity conflicts."),
+      }),
+    );
+    expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { buildId: "FB-R" },
+        data: expect.objectContaining({
+          buildExecState: expect.objectContaining({ ideateResearchRequested: false }),
         }),
       }),
     );

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -55,10 +55,20 @@ export async function dispatchIdeateForApprovedBuild(params: {
    *  context so the regenerated designDoc addresses them. Setting this also
    *  bypasses the idempotency guard (we WANT to overwrite the rejected doc). */
   priorReviewFeedback?: string;
+  /** Explicit operator/coworker re-request context from start_ideate_research. */
+  requestedUserContext?: string;
+  requestedReusabilityScope?: string;
   /** Bypass the designDoc idempotency guard (a fix-loop regeneration). */
   forceRegenerate?: boolean;
 }): Promise<DispatchOutcome> {
-  const { buildId, userId, priorReviewFeedback, forceRegenerate = false } = params;
+  const {
+    buildId,
+    userId,
+    priorReviewFeedback,
+    requestedUserContext,
+    requestedReusabilityScope,
+    forceRegenerate = false,
+  } = params;
 
   const logActivity = async (summary: string): Promise<void> => {
     await prisma.buildActivity.create({
@@ -100,7 +110,7 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // designDoc shape is BuildDesignDoc | null; we treat presence of a
     // non-empty problemStatement as "real evidence already saved".
     const existingDesignDoc = build.designDoc as { problemStatement?: string } | null;
-    const skipIdempotent = !forceRegenerate && !priorReviewFeedback;
+    const skipIdempotent = !forceRegenerate && !priorReviewFeedback && !requestedUserContext;
     if (skipIdempotent && existingDesignDoc && typeof existingDesignDoc.problemStatement === "string" && existingDesignDoc.problemStatement.trim().length > 0) {
       const outcome: DispatchOutcome = {
         kind: "skipped-already-has-design",
@@ -175,9 +185,11 @@ export async function dispatchIdeateForApprovedBuild(params: {
     const featureDescription = bi.body || build.description || "";
     // BI body is the operator-authored context; on a fix-loop regeneration we
     // append the reviewer's prior issues so the revised design addresses them.
-    const userContext = priorReviewFeedback
-      ? `${bi.body || ""}\n\n${priorReviewFeedback}`
-      : (bi.body || "");
+    const userContext = [
+      bi.body || "",
+      priorReviewFeedback ?? "",
+      requestedUserContext ? `Operator requested another ideate pass:\n${requestedUserContext}` : "",
+    ].filter((part) => part.trim().length > 0).join("\n\n");
 
     const startedAt = Date.now();
     await logActivity(`Dispatching ideate research via ${config.provider} (provider=${providerId}, model=${model || "default"})`);
@@ -197,7 +209,7 @@ export async function dispatchIdeateForApprovedBuild(params: {
     const ideateResult = await dispatchIdeateResearch({
       featureTitle,
       featureDescription,
-      reusabilityScope: "parameterizable",
+      reusabilityScope: requestedReusabilityScope || "parameterizable",
       userContext,
       // businessContext: see select comment above — field does not exist on
       // FeatureBuild. Passing undefined preserves the dispatch signature.
@@ -332,6 +344,37 @@ export function buildNeedsIdeateDispatch(designDoc: unknown): boolean {
   );
 }
 
+export function getIdeateResearchRequest(buildExecState: unknown): {
+  requested: boolean;
+  userContext?: string;
+  reusabilityScope?: string;
+} {
+  if (!buildExecState || typeof buildExecState !== "object" || Array.isArray(buildExecState)) {
+    return { requested: false };
+  }
+  const state = buildExecState as Record<string, unknown>;
+  if (state.ideateResearchRequested !== true) return { requested: false };
+  return {
+    requested: true,
+    userContext: typeof state.userContext === "string" ? state.userContext : undefined,
+    reusabilityScope: typeof state.reusabilityScope === "string" ? state.reusabilityScope : undefined,
+  };
+}
+
+async function clearIdeateResearchRequest(buildId: string, buildExecState: unknown): Promise<void> {
+  const state =
+    buildExecState && typeof buildExecState === "object" && !Array.isArray(buildExecState)
+      ? { ...(buildExecState as Record<string, unknown>) }
+      : {};
+  state.ideateResearchRequested = false;
+  await prisma.featureBuild.update({
+    where: { buildId },
+    data: { buildExecState: state as unknown as import("@dpf/db").Prisma.InputJsonValue },
+  }).catch((err) => {
+    console.warn("[ideate-on-approval] Failed to clear ideateResearchRequested:", { buildId }, err);
+  });
+}
+
 /**
  * BI-3E0EE3BA — recover/auto-drive Ideate for backlog-promoted drafts that were
  * auto-approved (draftApprovedAt set by the governed tee-up) but never had their
@@ -360,19 +403,29 @@ export async function dispatchApprovedIdeateBuilds(params: {
       parentEpicId: null,
       originatingBacklogItemId: { not: null },
     },
-    select: { buildId: true, designDoc: true },
+    select: { buildId: true, designDoc: true, buildExecState: true },
     orderBy: { draftApprovedAt: "asc" },
     take: 50,
   });
   const pending = approved
-    .filter((b) => buildNeedsIdeateDispatch(b.designDoc))
+    .filter((b) => buildNeedsIdeateDispatch(b.designDoc) || getIdeateResearchRequest(b.buildExecState).requested)
     .slice(0, limit);
 
   let dispatched = 0;
   let skipped = 0;
   for (const b of pending) {
+    const request = getIdeateResearchRequest(b.buildExecState);
     // dispatchIdeateForApprovedBuild never throws and is idempotent.
-    const outcome = await dispatchIdeateForApprovedBuild({ buildId: b.buildId, userId });
+    const outcome = await dispatchIdeateForApprovedBuild({
+      buildId: b.buildId,
+      userId,
+      forceRegenerate: request.requested,
+      requestedUserContext: request.userContext,
+      requestedReusabilityScope: request.reusabilityScope,
+    });
+    if (request.requested) {
+      await clearIdeateResearchRequest(b.buildId, b.buildExecState);
+    }
     if (outcome.kind === "dispatched-success") dispatched += 1;
     else skipped += 1;
   }
@@ -462,7 +515,12 @@ export async function dispatchDesignReviewFixLoop(params: {
         await log(`Design regeneration round ${round} produced no designDoc (${regen.kind}) — stopping.`);
         break;
       }
-      await executeTool("reviewDesignDoc", { buildId }, userId, { featureBuildId: buildId });
+      await executeTool(
+        "reviewDesignDoc",
+        { buildId },
+        userId,
+        { featureBuildId: buildId, suppressDesignReviewAutoRepair: true },
+      );
       const fresh = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designReview: true } });
       review = fresh?.designReview as DesignReviewVerdict;
     }

--- a/apps/web/lib/integrate/plan-on-approval.ts
+++ b/apps/web/lib/integrate/plan-on-approval.ts
@@ -242,7 +242,12 @@ async function readPlanReview(buildId: string): Promise<{ decision: string; issu
 async function runPlanReview(buildId: string, userId: string, log: (s: string) => Promise<void>): Promise<void> {
   try {
     const { executeTool } = await import("@/lib/mcp-tools");
-    const reviewResult = await executeTool("reviewBuildPlan", { buildId }, userId, { featureBuildId: buildId });
+    const reviewResult = await executeTool(
+      "reviewBuildPlan",
+      { buildId },
+      userId,
+      { featureBuildId: buildId, suppressPlanReviewAutoRepair: true },
+    );
     const reviewSummary = typeof reviewResult.message === "string" ? reviewResult.message.slice(0, 200) : "review complete";
     await log(`Auto-reviewBuildPlan: ${reviewSummary}`);
   } catch (reviewErr) {

--- a/apps/web/lib/integrate/pre-build-review-auto-repair.ts
+++ b/apps/web/lib/integrate/pre-build-review-auto-repair.ts
@@ -1,0 +1,48 @@
+import { prisma } from "@dpf/db";
+
+type AutoRepairContext = {
+  suppressDesignReviewAutoRepair?: boolean;
+  suppressPlanReviewAutoRepair?: boolean;
+};
+
+function logBuildActivity(buildId: string, tool: string, summary: string): void {
+  prisma.buildActivity.create({ data: { buildId, tool, summary } }).catch(() => {});
+}
+
+export function triggerDesignReviewAutoRepair(buildId: string, userId: string, context?: AutoRepairContext): void {
+  if (context?.suppressDesignReviewAutoRepair) return;
+  logBuildActivity(buildId, "design_fix_loop", "Design review failed - starting the in-place repair loop.");
+  void import("@/lib/integrate/ideate-on-approval")
+    .then((m) => m.dispatchDesignReviewFixLoop({ buildId, userId }))
+    .then((outcome) => {
+      logBuildActivity(
+        buildId,
+        "design_fix_loop",
+        `In-place design repair finished: ${outcome.kind} after ${outcome.rounds} round(s).`,
+      );
+    })
+    .catch((err) => {
+      logBuildActivity(
+        buildId,
+        "design_fix_loop",
+        `In-place design repair failed to start: ${String(err instanceof Error ? err.message : err).slice(0, 180)}`,
+      );
+    });
+}
+
+export function triggerPlanReviewAutoRepair(buildId: string, userId: string, context?: AutoRepairContext): void {
+  if (context?.suppressPlanReviewAutoRepair) return;
+  logBuildActivity(buildId, "plan_dispatch", "Plan review failed - starting the in-place repair loop.");
+  void import("@/lib/integrate/plan-on-approval")
+    .then((m) => m.dispatchPlanForApprovedBuild({ buildId, userId, forceRegenerate: true }))
+    .then((outcome) => {
+      logBuildActivity(buildId, "plan_dispatch", `In-place plan repair finished: ${outcome.kind}.`);
+    })
+    .catch((err) => {
+      logBuildActivity(
+        buildId,
+        "plan_dispatch",
+        `In-place plan repair failed to start: ${String(err instanceof Error ? err.message : err).slice(0, 180)}`,
+      );
+    });
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -51,6 +51,7 @@ import {
   saveLicensingInvestigationFinding,
 } from "@/lib/actions/licensing-compliance";
 import type { ReviewBranchInput } from "@/lib/integrate/build-reviewers";
+import { triggerDesignReviewAutoRepair, triggerPlanReviewAutoRepair } from "@/lib/integrate/pre-build-review-auto-repair";
 import {
   getIntegrationBenchmarkMetadata,
   matchesIntegrationBenchmarkFilters,
@@ -93,6 +94,7 @@ type ToolExecutionContext = {
   agentId?: string;
   threadId?: string;
   taskRunId?: string;
+  suppressDesignReviewAutoRepair?: boolean; suppressPlanReviewAutoRepair?: boolean;
   /**
    * Build the user is currently messaging from. Plumbed by agentic-loop.ts
    * from runAgenticLoop's `featureBuildId` param so phase-scoped tools can
@@ -8166,6 +8168,7 @@ export async function executeTool(
         if (context?.threadId) agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "designReview" });
         logBuildActivity(buildId, "reviewDesignDoc", `Fix review: ${review.decision}. ${review.summary}`);
         if (review.decision === "fail") {
+          triggerDesignReviewAutoRepair(buildId, userId, context);
           return { success: true, message: `Fix review FAILED. ${review.issues[0]?.description ?? review.summary}`, data: { review, blocked: true, action: "revise_and_resubmit" } };
         }
         let fixPhaseGateBlocker: string | null = null;
@@ -8343,6 +8346,7 @@ export async function executeTool(
 
       // Failed review → structured recovery instructions, no auto-advance
       if (review.decision === "fail") {
+        triggerDesignReviewAutoRepair(buildId, userId, context);
         const criticalIssues = review.issues.filter((i: { severity: string }) => i.severity === "critical");
         const issueList = criticalIssues.length > 0
           ? criticalIssues.map((i: { description: string }) => i.description).join("; ")
@@ -8653,6 +8657,7 @@ export async function executeTool(
           agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "planReview" });
         }
         logBuildActivity(buildId, "reviewBuildPlan", `Plan review: fail. ${review.summary}`);
+        triggerPlanReviewAutoRepair(buildId, userId, context);
         return {
           success: true,
           message: `Plan review FAILED. Blocking issues: ${normalizedPlan.unresolvedModifyPaths.join(", ")} no longer exist in the repo. Revise the implementation plan to target the current files, then re-run reviewBuildPlan.`,
@@ -8827,6 +8832,7 @@ export async function executeTool(
           planReviewIsGating = true; // fail safe: keep the stricter loop on any gate-read error
         }
         if (planReviewIsGating) {
+          triggerPlanReviewAutoRepair(buildId, userId, context);
           const criticalIssues = review.issues.filter((i: { severity: string }) => i.severity === "critical");
           const issueList = criticalIssues.length > 0
             ? criticalIssues.map((i: { description: string }) => i.description).join("; ")
@@ -8849,14 +8855,6 @@ export async function executeTool(
       }
 
       // Passed review → auto-advance if gate is satisfied.
-      // NOTE: Cannot call advanceBuildPhase (server action) here because auth()
-      // has no HTTP request context inside the agentic loop. Direct DB update instead.
-      //
-      // Same pattern as reviewDesignDoc's auto-advance: checkPhaseGate also
-      // evaluates evidence.happyPathState, which must be passed from
-      // build.plan or the intake check fails silently. Reading the plan and
-      // pulling happyPathState out so the gate sees the real anchors —
-      // see the fix in reviewDesignDoc for the backstory.
       try {
         const { checkPhaseGate, canTransitionPhase, normalizeHappyPathState } = await import("@/lib/feature-build-types");
         const { deriveFeatureBuildDependencyGate, FEATURE_BUILD_DEPENDENCY_GATE_SELECT } = await import("@/lib/build/feature-build-dependencies");


### PR DESCRIPTION
## Summary
- Starts the existing bounded design/plan repair loops immediately when review tools persist blocking failures.
- Adds recursion guards so auto-generated fix-loop reviews do not spawn duplicate repair loops.
- Consumes explicit ideate re-requests from the approved-build dispatcher and pins coworker research writes/reviews to the resolved build id.

## Evidence
- Live read-only DB checks showed no current failed review rows and no pending `ideateResearchRequested` flags; visible old ideate rows are parked `decompose-required` decisions with candidates, not review-fail stalls.
- The fix targets the code path where review failures previously returned a manual rerun instruction and relied on later resume/boot recovery.

## Verification
- `git diff --check` passed.
- Targeted Vitest command was attempted and blocked in this source-only worktree: `vitest` not found because `node_modules` is missing.
- Pre-commit gitleaks scan passed; `DPF_SKIP_TYPECHECK=1` was used because the source-only worktree cannot run `next typegen && tsc --noEmit` without dependencies.