### PR TITLE
feat(build): complete overseer action guidance

### DIFF
--- a/apps/web/components/build/ActionBanner.test.tsx
+++ b/apps/web/components/build/ActionBanner.test.tsx
@@ -40,6 +40,19 @@ describe("ActionBanner", () => {
     expect(matches).toHaveLength(1);
   });
 
+  it("renders the operator status through report-kit StatusBadge", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="ready"
+        operatorStatus={{ label: "Waiting on you", intent: "accent" }}
+        sentence="Next: start implementation from Build Studio."
+      />,
+    );
+    expect(html).toContain("Waiting on you");
+    expect(html).toContain('data-intent="accent"');
+    expect(html).toContain("Next: start implementation from Build Studio.");
+  });
+
   it("does NOT render a 'Build Status' or 'Operational status' label", () => {
     const html = renderToStaticMarkup(
       <ActionBanner state="ready" sentence="Plan review passed." />,

--- a/apps/web/components/build/ActionBanner.tsx
+++ b/apps/web/components/build/ActionBanner.tsx
@@ -19,6 +19,7 @@
 
 "use client";
 
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
 import { ACTION_BANNER_HEIGHT_CLASS, BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
 
 export type ActionBannerState = "ready" | "running" | "blocked" | "review_failed" | "complete";
@@ -31,6 +32,10 @@ export type ActionBannerPrimaryAction = {
 
 export type ActionBannerProps = {
   state: ActionBannerState;
+  operatorStatus?: {
+    label: string;
+    intent: Intent;
+  };
   /** One sentence describing the current state. This IS the heading — no separate title. */
   sentence: string;
   /** Optional primary action. Right-aligned, min-width 120px. */
@@ -76,7 +81,7 @@ function shouldShowDetail(state: ActionBannerState, detail: string | undefined):
   return state === "blocked" || state === "review_failed";
 }
 
-export function ActionBanner({ state, sentence, primaryAction, detail }: ActionBannerProps) {
+export function ActionBanner({ state, operatorStatus, sentence, primaryAction, detail }: ActionBannerProps) {
   const showDetail = shouldShowDetail(state, detail);
   return (
     <div
@@ -99,9 +104,20 @@ export function ActionBanner({ state, sentence, primaryAction, detail }: ActionB
       ].join(" ")}
     >
       <div className="flex min-w-0 flex-1 flex-col">
-        {/* The sentence IS the heading — render as a single line that describes the state. */}
-        <span className="min-w-0 truncate font-medium" data-testid="action-banner-sentence">
-          {sentence}
+        <span className="flex min-w-0 items-center gap-2">
+          {operatorStatus && (
+            <StatusBadge
+              intent={operatorStatus.intent}
+              label={operatorStatus.label}
+              variant="soft"
+              uppercase={false}
+              className="shrink-0"
+            />
+          )}
+          {/* The sentence IS the heading — render as a single line that describes the state. */}
+          <span className="min-w-0 truncate font-medium" data-testid="action-banner-sentence">
+            {sentence}
+          </span>
         </span>
         {showDetail && (
           <span

--- a/apps/web/components/build/BuildListItem.test.tsx
+++ b/apps/web/components/build/BuildListItem.test.tsx
@@ -292,7 +292,7 @@ describe("BuildListItem fleet density", () => {
     expect(html).not.toContain('aria-current="true"');
   });
 
-  it("shows the BI-* originator code as a hover tooltip on the FB code", () => {
+  it("hides FB-* and BI-* codes by default at fleet density", () => {
     const html = renderToStaticMarkup(
       <BuildListItem
         build={makeBuild()}
@@ -305,8 +305,9 @@ describe("BuildListItem fleet density", () => {
         onDelete={vi.fn()}
       />,
     );
-    // The originator itemId becomes the title attribute on the FB code span.
-    expect(html).toMatch(/title="BI-5B839D74"/);
+    expect(html).not.toContain("FB-9B19098C");
+    expect(html).not.toContain("BI-5B839D74");
+    expect(html).not.toMatch(/title="BI-/);
   });
 
   it("delete button is icon-only and hidden by default at fleet density", () => {

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -110,10 +110,9 @@ export function BuildListItem({
           {build.title}
         </div>
         <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-[var(--dpf-muted)]">
-          <span className="font-mono">{build.buildId}</span>
           {build.originator && (
             <span className="inline-flex max-w-full min-w-0 items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-1.5 py-0.5 font-medium text-[var(--dpf-text)]">
-              {build.originator.itemId}
+              Backlog-linked
             </span>
           )}
           <span className="capitalize">{build.phase}</span>
@@ -171,7 +170,6 @@ function FleetDensityRow({
   needsAttention,
 }: FleetRowProps) {
   const railPhase = toPhaseRailPhase(build.phase);
-  const biCostTooltip = build.originator?.itemId ?? "";
   return (
     <div
       data-testid={BUILD_STUDIO_TEST_IDS.buildListItem}
@@ -206,12 +204,6 @@ function FleetDensityRow({
         onClick={onSelect}
         className="flex min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
       >
-        <span
-          className="shrink-0 font-mono text-[11px] text-[var(--dpf-text)]"
-          title={biCostTooltip || undefined}
-        >
-          {build.buildId}
-        </span>
         <PhaseMiniRail currentPhase={railPhase} />
         {build.phase === "build" && (
           <FleetDensityBar taskResults={build.taskResults} buildPlan={build.buildPlan} />

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -26,7 +26,14 @@ import { CodeIntelligenceStatusCard } from "./CodeIntelligenceStatusCard";
 import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
 import { BuildListItem } from "./BuildListItem";
 import { EpicRollupListItem } from "./EpicRollupListItem";
-import { deriveFleetCounts, deriveNeedsAttention, deriveQueueState } from "./fleet-derivation";
+import {
+  DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP,
+  deriveFleetCounts,
+  deriveNeedsAttention,
+  deriveQueueState,
+  formatFleetHeader,
+} from "./fleet-derivation";
+import { QueueStateBadge } from "./QueueStateBadge";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
 import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
@@ -780,9 +787,8 @@ export function BuildStudio({
                         className="inline-flex items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
                         data-testid="build-studio-canonical-doc-trigger"
                       >
-                        {activeBuild.originator.itemId}
+                        {activeBuild.originator.title}
                       </button>
-                      <span>{activeBuild.originator.title}</span>
                     </div>
                     <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">
                       <span>Status: {activeBuild.originator.status}</span>
@@ -961,12 +967,6 @@ export function BuildStudio({
               <div className="text-center max-w-md px-8">
                 <div className="text-5xl mb-4 opacity-20">&#128736;</div>
                 <h2 className="text-lg font-bold text-[var(--dpf-text)] mb-3">Product Development Studio</h2>
-                {branchBadge && (
-                  <div className="inline-flex items-center gap-1.5 px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-xs font-mono text-[var(--dpf-muted)] mb-4" title={branchBadge.title}>
-                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.5 2.5 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" /></svg>
-                    {branchBadge.value}
-                  </div>
-                )}
                 <p className="text-sm text-[var(--dpf-muted)] leading-relaxed mb-6">
                   Build features without writing code. Describe what you want, and your AI Coworker will design, build, and deploy it.
                 </p>
@@ -1447,8 +1447,8 @@ function FleetRailZone({
 
   // Split entries into active (needs attention) vs completed (historical). The
   // fleet rail surfaces what needs attention; completed work is one click away
-  // via the "{N} completed" toggle below. Matches the "Builds: {N} running"
-  // header semantic — the list should only show inflight work by default.
+  // via the "{N} completed" toggle below. Matches the WIP-slots header
+  // semantic: the list should only show inflight work by default.
   const activeEntries = sorted.filter((e) => e.build.phase !== "complete");
   const completedEntries = sorted.filter((e) => e.build.phase === "complete");
   const activeEpicRollups = epicRollups.filter((rollup) => rollup.status !== "complete");
@@ -1457,6 +1457,7 @@ function FleetRailZone({
   const [showCompleted, setShowCompleted] = useState(false);
 
   const counts = deriveFleetCounts(entries.map((e) => e.queueState));
+  const wipSlotCap = Math.max(DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP, counts.runningCount);
 
   useEffect(() => {
     if (!activeBuildId) return;
@@ -1505,17 +1506,26 @@ function FleetRailZone({
         onClick={onOpenQueueDrawer}
         role="status"
         aria-live="polite"
-        aria-label="Open build details drawer — BS queue section"
+        aria-label={`Open build details drawer - queue section. ${formatFleetHeader(counts.runningCount, wipSlotCap, counts.queuedCount)}`}
         data-testid="build-studio-fleet-header"
         className="flex w-full shrink-0 cursor-pointer items-center justify-between border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-left text-[11px] font-semibold text-[var(--dpf-text)] transition-colors hover:bg-[var(--dpf-surface-3)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
       >
-        <span data-testid="fleet-header-label">
-          Builds: {counts.runningCount} running
+        <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-1">
+          <span className="truncate">
+            {formatFleetHeader(counts.runningCount, wipSlotCap, counts.queuedCount)}
+          </span>
+          {counts.queuedCount > 0 && (
+            <QueueStateBadge
+              state={{
+                kind: "queued",
+                position: counts.queuedCount,
+                reason: "capacity",
+                ahead: Math.max(0, counts.queuedCount - 1),
+              }}
+            />
+          )}
           {counts.blockedCount > 0 && (
             <> · <span className="text-[var(--dpf-warning)]">{counts.blockedCount} blocked</span></>
-          )}
-          {counts.queuedCount > 0 && (
-            <> · {counts.queuedCount} queued</>
           )}
         </span>
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">›</span>

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -464,6 +464,15 @@ describe("BuildStudio active-build header layout", () => {
             summary: "Ready to implement.",
             issues: [],
           },
+          happyPathState: normalizeHappyPathState({
+            intake: {
+              status: "ready",
+              taxonomyNodeId: "capability-build-studio",
+              backlogItemId: "BI-5B839D74",
+              epicId: "EP-BUILD-STUDIO-UX",
+              constrainedGoal: "Fix Build Studio header/content overlap in workflow view.",
+            },
+          }),
         })]}
         portfolios={[]}
         governedBacklogEnabled
@@ -478,9 +487,8 @@ describe("BuildStudio active-build header layout", () => {
     // banner's primary action label.
     expect(html).toContain('data-testid="build-studio-action-banner"');
     expect(html).toContain("Start Implementation");
-    // Detail line surfaces the intake-incomplete reason (banner shows detail
-    // only when state ∈ {blocked, review_failed}, which intake-missing maps to).
-    expect(html).toContain('data-testid="action-banner-detail"');
+    // Ready intake keeps the banner focused on one next action.
+    expect(html).not.toContain('data-testid="action-banner-detail"');
   });
 
   it("mounts the footer OpenSandboxButton — single shared sandbox link", () => {

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
@@ -14,9 +14,10 @@ import {
   type FeatureBuildRow,
 } from "@/lib/feature-build-types";
 
-const { mockAdvanceBuildPhase, mockCaptureDecisionInteraction, mockResumeBuildImplementation } = vi.hoisted(() => ({
+const { mockAdvanceBuildPhase, mockCaptureDecisionInteraction, mockRerunPlanReview, mockResumeBuildImplementation } = vi.hoisted(() => ({
   mockAdvanceBuildPhase: vi.fn(),
   mockCaptureDecisionInteraction: vi.fn(),
+  mockRerunPlanReview: vi.fn(),
   mockResumeBuildImplementation: vi.fn(),
 }));
 
@@ -30,6 +31,7 @@ vi.mock("@/lib/actions/build", () => ({
   advanceBuildPhase: mockAdvanceBuildPhase,
   approveBuildStart: vi.fn(),
   recordBuildAcceptance: vi.fn(),
+  rerunPlanReview: mockRerunPlanReview,
   resumeBuildImplementation: mockResumeBuildImplementation,
   resetBuildExecution: vi.fn(),
   retryBuildExecution: vi.fn(),
@@ -43,6 +45,7 @@ vi.mock("@/lib/actions/decision-perspective", () => ({
 beforeEach(() => {
   mockAdvanceBuildPhase.mockReset();
   mockCaptureDecisionInteraction.mockReset();
+  mockRerunPlanReview.mockReset();
   mockResumeBuildImplementation.mockReset();
   mockCaptureDecisionInteraction.mockResolvedValue({ status: "captured", captureType: "escalation" });
   mockResumeBuildImplementation.mockResolvedValue({
@@ -50,6 +53,10 @@ beforeEach(() => {
     resetTasks: 3,
     dispatchQueued: true,
     message: "Reset 3 tasks to BLOCKED; queued implementation resume.",
+  });
+  mockRerunPlanReview.mockResolvedValue({
+    success: true,
+    message: "Plan review passed; implementation is unlocked.",
   });
 });
 
@@ -220,9 +227,9 @@ describe("BuildStudioWorkflowActionCard resume visibility", () => {
     const onCompleted = vi.fn();
     const action: BuildStudioWorkflowAction = {
       kind: "resume-implementation",
-      title: "Click Resume to re-execute 3 blocked tasks",
-      message: "Failure axis: usage-limit. Resume will reset blocked tasks and queue the existing implementation path.",
-      primaryLabel: "Resume Implementation",
+      title: "3 tasks need another pass",
+      message: "Some work did not pass its checks yet. Next: click Try to fix to rerun the failed work from Build Studio.",
+      primaryLabel: "Try to fix",
       targetPhase: null,
       disabledReason: null,
       coworkerLabel: "Review failures with coworker",
@@ -252,15 +259,52 @@ describe("BuildStudioWorkflowActionCard resume visibility", () => {
     );
 
     expect(screen.getByText("Reset blocked tasks")).toBeInTheDocument();
+    expect(screen.getByText("Blocked (technical)")).toBeInTheDocument();
+    expect(screen.getByTestId("build-next-action")).toHaveTextContent("Next: try to fix the failed work from Build Studio.");
+    expect(screen.getByTestId("build-guided-recovery")).toHaveTextContent("Something looks off");
     expect(screen.getByText("DB")).toBeInTheDocument();
     expect(screen.getByText("3 blocked tasks will be reset before the existing resume path is queued.")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Resume Implementation" }));
+    fireEvent.click(screen.getByRole("button", { name: "Try to fix" }));
 
     await waitFor(() => {
       expect(screen.getByText("Reset 3 tasks to BLOCKED; queued implementation resume.")).toBeInTheDocument();
     });
     expect(mockResumeBuildImplementation).toHaveBeenCalledWith("FB-9B19098C");
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders plan-review failure as guided in-place recovery", async () => {
+    const onCompleted = vi.fn();
+    const action: BuildStudioWorkflowAction = {
+      kind: "rerun-plan-review",
+      title: "Plan review needs a fix",
+      message: "The plan review did not pass. Next: click Try to fix to rerun the guided recovery in Build Studio.",
+      primaryLabel: "Try to fix",
+      targetPhase: null,
+      disabledReason: null,
+      coworkerLabel: "Something looks off",
+      coworkerPrompt: "Explain the blocking issues in plain language.",
+    };
+
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "plan", decisionInteraction: null })}
+        action={action}
+        onCompleted={onCompleted}
+      />,
+    );
+
+    expect(screen.getByText("Waiting on you")).toBeInTheDocument();
+    expect(screen.getByTestId("build-next-action")).toHaveTextContent("Next: try to fix the plan review in place.");
+    expect(screen.getByTestId("build-guided-recovery")).toHaveTextContent("Try to fix");
+    expect(screen.getByRole("button", { name: "Something looks off" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try to fix" }));
+
+    await waitFor(() => {
+      expect(mockRerunPlanReview).toHaveBeenCalledWith("FB-9B19098C");
+    });
     expect(onCompleted).toHaveBeenCalledTimes(1);
   });
 });
@@ -404,9 +448,10 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
     // ActionBanner emits a region with the canonical aria-label.
     const banner = screen.getByRole("region", { name: "Current build action" });
     expect(banner).toBeInTheDocument();
-    // The sentence is from action.message — no separate "Build Status" or
-    // "Operational status" label duplicates the heading.
-    expect(banner).toHaveTextContent(action.message);
+    // The compact sentence is the derived one-line Next action, paired with a
+    // single operator status.
+    expect(banner).toHaveTextContent("Waiting on you");
+    expect(banner).toHaveTextContent("Next: start implementation from Build Studio.");
     expect(screen.queryByText("Build Status")).not.toBeInTheDocument();
     expect(screen.queryByText("Operational status")).not.toBeInTheDocument();
   });
@@ -444,6 +489,8 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
     );
     const banner = screen.getByRole("region", { name: "Current build action" });
     expect(banner).toHaveAttribute("data-state", "blocked");
+    expect(banner).toHaveTextContent("Waiting on you");
+    expect(banner).toHaveTextContent("Next: clear the missing evidence with the coworker");
     expect(banner).toHaveTextContent("Plan review failed. Refine the plan first.");
   });
 

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { StatusBadge } from "@/components/ui/report-kit";
 import {
   advanceBuildPhase,
   approveBuildStart,
@@ -19,7 +20,10 @@ import type { DecisionGateCaptureDraft } from "@/lib/decision-perspective/captur
 import { ActionBanner, type ActionBannerState } from "./ActionBanner";
 import { DecisionPerspectiveGatePanel } from "./DecisionPerspectiveGatePanel";
 import { TruthSourceBadge } from "./TruthSourceBadge";
-import type { BuildStudioWorkflowAction } from "./build-studio-workflow-actions";
+import {
+  deriveBuildStudioOperatorGuidance,
+  type BuildStudioWorkflowAction,
+} from "./build-studio-workflow-actions";
 
 type Props = {
   build: FeatureBuildRow;
@@ -66,6 +70,7 @@ export function BuildStudioWorkflowActionCard({
   const [lastOutcome, setLastOutcome] = useState<ResumeBuildImplementationOutcome | null>(null);
 
   const primaryEnabled = action.kind !== "review-only" && action.disabledReason == null;
+  const operatorGuidance = useMemo(() => deriveBuildStudioOperatorGuidance(action, build), [action, build]);
   const decisionInteraction =
     action.kind === "advance-phase" && action.targetPhase === "build"
       ? build.decisionInteraction ?? null
@@ -254,18 +259,19 @@ export function BuildStudioWorkflowActionCard({
   const compactBannerEligible = compact && !decisionInteraction;
   if (compactBannerEligible) {
     const bannerState = deriveActionBannerState(build, action);
-    const bannerPrimaryAction = primaryLabel
+    const bannerPrimaryAction = operatorGuidance.nextLabel
       ? {
-        label: primaryLabel,
-        onClick: handlePrimaryAction,
-        disabled: !primaryEnabled || pending,
+        label: operatorGuidance.useCoworkerForNext ? operatorGuidance.nextLabel : (primaryLabel ?? operatorGuidance.nextLabel),
+        onClick: operatorGuidance.useCoworkerForNext ? handleCoworkerAction : handlePrimaryAction,
+        disabled: operatorGuidance.useCoworkerForNext ? false : (!primaryEnabled || pending),
       }
       : undefined;
     return (
       <div data-testid="build-studio-workflow-action-card">
         <ActionBanner
           state={bannerState}
-          sentence={action.message}
+          operatorStatus={operatorGuidance.status}
+          sentence={operatorGuidance.nextSentence}
           primaryAction={bannerPrimaryAction}
           detail={action.disabledReason ?? undefined}
         />
@@ -295,11 +301,30 @@ export function BuildStudioWorkflowActionCard({
             <p className="text-[11px] font-semibold uppercase text-[var(--dpf-muted)]">
               Build Status
             </p>
-            <h4 className="mt-1 text-sm font-semibold text-[var(--dpf-text)]">
-              {action.title}
-            </h4>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <h4 className="m-0 text-sm font-semibold text-[var(--dpf-text)]">
+                {action.title}
+              </h4>
+              <span
+                data-testid="build-operator-status"
+                className="inline-flex"
+              >
+                <StatusBadge
+                  intent={operatorGuidance.status.intent}
+                  label={operatorGuidance.status.label}
+                  variant="soft"
+                  uppercase={false}
+                />
+              </span>
+            </div>
             <p className="mt-1 text-xs leading-relaxed text-[var(--dpf-muted)]">
               {action.message}
+            </p>
+            <p
+              className="mt-1 text-xs font-medium leading-relaxed text-[var(--dpf-text)]"
+              data-testid="build-next-action"
+            >
+              {operatorGuidance.nextSentence}
             </p>
           </div>
           <span className="inline-flex items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] font-semibold uppercase text-[var(--dpf-text)]">
@@ -350,6 +375,15 @@ export function BuildStudioWorkflowActionCard({
           voiceOutput={voiceOutput}
         />
 
+        {operatorGuidance.guidedRecovery && operatorGuidance.recoveryHint && (
+          <div
+            data-testid="build-guided-recovery"
+            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-xs leading-relaxed text-[var(--dpf-muted)]"
+          >
+            {operatorGuidance.recoveryHint}
+          </div>
+        )}
+
         <div className="flex flex-wrap items-center gap-2">
           {primaryLabel && (
             <span
@@ -383,7 +417,7 @@ export function BuildStudioWorkflowActionCard({
             onClick={handleCoworkerAction}
             className="inline-flex items-center rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-xs font-semibold text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)]"
           >
-            {action.coworkerLabel}
+            {operatorGuidance.guidedRecovery ? "Something looks off" : action.coworkerLabel}
           </button>
         </div>
       </div>

--- a/apps/web/components/build/FleetRail.test.tsx
+++ b/apps/web/components/build/FleetRail.test.tsx
@@ -82,8 +82,8 @@ function entry(
 
 describe("formatFleetHeader", () => {
   it("formats running/cap and queued count", () => {
-    expect(formatFleetHeader(2, 3, 4)).toBe("Builds: 2/3 · 4 queued");
-    expect(formatFleetHeader(0, 5, 0)).toBe("Builds: 0/5 · 0 queued");
+    expect(formatFleetHeader(2, 3, 4)).toBe("WIP slots: 2 of 3 in use · 4 queued");
+    expect(formatFleetHeader(0, 5, 0)).toBe("WIP slots: 0 of 5 in use · 0 queued");
   });
 });
 
@@ -147,7 +147,8 @@ describe("FleetRail rendering", () => {
         onDeleteBuild={vi.fn()}
       />,
     );
-    expect(screen.getByTestId("fleet-header-label")).toHaveTextContent("Builds: 1/3 · 2 queued");
+    expect(screen.getByTestId("fleet-header-label")).toHaveTextContent("WIP slots: 1 of 3 in use · 2 queued");
+    expect(screen.getByLabelText("Queued, position 2")).toBeInTheDocument();
   });
 
   it("header has role=status + aria-live=polite for queue-change announcement", () => {

--- a/apps/web/components/build/FleetRail.tsx
+++ b/apps/web/components/build/FleetRail.tsx
@@ -5,7 +5,7 @@
 // runtime state (concurrency cap + running + queued counts).
 //
 // Per the spec §1 (Fleet Rail) and the queue surface amendment (PR #898):
-//   - Header: "Builds: {running}/{cap} · {queuedCount} queued", role=status,
+//   - Header: "WIP slots: {running} of {cap} in use · {queuedCount} queued", role=status,
 //     aria-live="polite" so cap/queue-position changes are announced.
 //   - Default sort: running → blocked → queued (by position) → idle.
 //   - Each row uses BuildListItem density="fleet".
@@ -23,7 +23,8 @@ import {
   getFleetRailHeaderClassName,
 } from "./build-studio-layout";
 import { BuildListItem } from "./BuildListItem";
-import type { BuildQueueState } from "./QueueStateBadge";
+import { formatFleetHeader as formatFleetHeaderLabel } from "./fleet-derivation";
+import { QueueStateBadge, type BuildQueueState } from "./QueueStateBadge";
 
 /** Each visible entry: the FeatureBuildRow plus per-row queue/attention state. */
 export type FleetRailEntry = {
@@ -80,7 +81,7 @@ export function sortFleetEntries(entries: readonly FleetRailEntry[]): FleetRailE
 
 /** Formats the header label. Pinned as a helper so tests can assert it. */
 export function formatFleetHeader(runningCount: number, cap: number, queuedCount: number): string {
-  return `Builds: ${runningCount}/${cap} · ${queuedCount} queued`;
+  return formatFleetHeaderLabel(runningCount, cap, queuedCount);
 }
 
 export function FleetRail({
@@ -117,8 +118,18 @@ export function FleetRail({
           "focus-visible:outline-[var(--dpf-accent)]",
         ].join(" ")}
       >
-        <span data-testid="fleet-header-label">
+        <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-1">
           {formatFleetHeader(runningCount, cap, queuedCount)}
+          {queuedCount > 0 && (
+            <QueueStateBadge
+              state={{
+                kind: "queued",
+                position: queuedCount,
+                reason: "capacity",
+                ahead: Math.max(0, queuedCount - 1),
+              }}
+            />
+          )}
         </span>
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">
           ›

--- a/apps/web/components/build/build-studio-layout.ts
+++ b/apps/web/components/build/build-studio-layout.ts
@@ -261,7 +261,7 @@ export function getDetailsDrawerPillClassName(): string {
 }
 
 /**
- * Fleet rail header — shows `Builds: {running}/{cap} · {queuedCount} queued`.
+ * Fleet rail header — shows `WIP slots: {running} of {cap} in use · {queuedCount} queued`.
  * Uses `role="status"` + `aria-live="polite"` (set on the element itself, not here).
  */
 export function getFleetRailHeaderClassName(): string {

--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  deriveBuildStudioOperatorGuidance,
   deriveBuildStudioWorkflowAction,
   deriveWorkflowStageGuidance,
 } from "./build-studio-workflow-actions";
@@ -325,10 +326,63 @@ describe("deriveBuildStudioWorkflowAction", () => {
     });
 
     expect(action.kind).toBe("rerun-plan-review");
-    expect(action.primaryLabel).toBe("Re-run Plan Review");
+    expect(action.primaryLabel).toBe("Try to fix");
+    expect(action.coworkerLabel).toBe("Something looks off");
     expect(action.targetPhase).toBeNull();
     expect(action.disabledReason).toBeNull();
-    expect(action.message).toContain("did not pass review");
+    expect(action.message).toContain("Next: click Try to fix");
+    expect(action.coworkerPrompt).not.toContain("saveBuildEvidence");
+    expect(action.coworkerPrompt).not.toContain("reviewBuildPlan");
+  });
+
+  it("derives a single operator status and next action for plan-review recovery", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({
+        draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        buildPlan: {
+          fileStructure: [{ path: "apps/web/lib/integrate/ollama-url.ts", action: "modify", purpose: "Add a clarifying comment." }],
+          tasks: [{ title: "Add comment", testFirst: "n/a for a comment", implement: "Add the comment", verify: "Read the file" }],
+        },
+        planReview: {
+          decision: "fail",
+          summary: "Missing test-first steps.",
+          issues: [{ severity: "critical", description: "Task lacks a test-first step." }],
+          iteration: { round: 1 },
+        },
+      }),
+      governedBacklogEnabled: true,
+    });
+
+    const guidance = deriveBuildStudioOperatorGuidance(action);
+    expect(guidance.status.label).toBe("Waiting on you");
+    expect(guidance.nextLabel).toBe("Try to fix");
+    expect(guidance.nextSentence).toBe("Next: try to fix the plan review in place.");
+    expect(guidance.guidedRecovery).toBe(true);
+  });
+
+  it("labels an active build execution as Working even before the next gate unlocks", () => {
+    const build = makeBuild({
+      phase: "build",
+      draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+      buildPlan: {
+        fileStructure: [{ path: "apps/web/components/build/BuildStudio.tsx", action: "modify", purpose: "Surface workflow actions." }],
+        tasks: [{ title: "Add workflow actions", testFirst: "Add failing tests.", implement: "Render the actions.", verify: "Run the build checks." }],
+      },
+      planReview: { decision: "pass", summary: "Ready.", issues: [] },
+      buildExecState: {
+        step: "deps_installed",
+        retryCount: 0,
+        startedAt: "2026-04-25T13:10:00Z",
+      },
+    });
+    const action = deriveBuildStudioWorkflowAction({
+      build,
+      governedBacklogEnabled: true,
+    });
+
+    const guidance = deriveBuildStudioOperatorGuidance(action, build);
+    expect(guidance.status.label).toBe("Working");
+    expect(guidance.nextSentence).toContain("Next:");
   });
 
   it("does not offer re-run-plan-review when the plan review has not run yet", () => {
@@ -408,10 +462,11 @@ describe("deriveBuildStudioWorkflowAction", () => {
     });
 
     expect(action.kind).toBe("resume-implementation");
-    expect(action.primaryLabel).toBe("Resume Implementation");
-    // BI-FD796419 / Band 4 — plain copy: "clean workspace" replaced the
-    // "healthy sandbox" jargon; the message still guides the operator to Resume.
-    expect(action.message).toContain("clean workspace");
+    expect(action.primaryLabel).toBe("Try to fix");
+    // BI-FD796419 / Band 4 — plain copy guides the operator to the in-place
+    // recovery action without surfacing sandbox/runtime jargon.
+    expect(action.message).toContain("Next: click Try to fix");
+    expect(action.message).not.toContain("healthy sandbox");
   });
 
   it("does not force Resume Implementation on a review build whose scoped surface is clean despite out-of-scope test noise (BI-2F10D6D3 follow-up)", () => {
@@ -427,7 +482,7 @@ describe("deriveBuildStudioWorkflowAction", () => {
     });
 
     expect(action.kind).not.toBe("resume-implementation");
-    expect(action.primaryLabel).not.toBe("Resume Implementation");
+    expect(action.primaryLabel).not.toBe("Try to fix");
     expect(action.kind).toBe("advance-phase");
     expect(action.primaryLabel).toBe("Continue to Release");
     expect(action.targetPhase).toBe("ship");
@@ -445,7 +500,7 @@ describe("deriveBuildStudioWorkflowAction", () => {
     });
 
     expect(action.kind).toBe("resume-implementation");
-    expect(action.primaryLabel).toBe("Resume Implementation");
+    expect(action.primaryLabel).toBe("Try to fix");
   });
 
   it("names the resume action and failure axis for blocked usage-limit tasks", () => {
@@ -468,9 +523,10 @@ describe("deriveBuildStudioWorkflowAction", () => {
     });
 
     expect(action.kind).toBe("resume-implementation");
-    expect(action.title).toBe("Click Resume to re-execute 3 blocked tasks");
+    expect(action.title).toBe("3 tasks need another pass");
     expect(action.failureAxis).toBe("usage-limit");
-    expect(action.message).toContain("usage-limit");
+    expect(action.message).toContain("Next: click Try to fix");
+    expect(action.message).not.toContain("usage-limit");
     expect(action.resumeMode?.mode).toBe("reset-blocked");
   });
 
@@ -572,9 +628,10 @@ describe("deriveBuildStudioWorkflowAction", () => {
     });
 
     expect(action.kind).toBe("resume-implementation");
-    expect(action.title).toBe("Click Resume to re-execute 2 blocked tasks");
+    expect(action.title).toBe("2 tasks need another pass");
     expect(action.failureAxis).toBe("usage-limit");
-    expect(action.message).toContain("usage-limit");
+    expect(action.message).toContain("Next: click Try to fix");
+    expect(action.message).not.toContain("usage-limit");
   });
 
   it("separates out-of-scope verification noise from implementation recovery", () => {
@@ -609,10 +666,10 @@ describe("deriveBuildStudioWorkflowAction", () => {
     expect(action.resumeMode?.mode).toBe("rerun-verification");
     // BI-FD796419 / Band 4 — the operator-facing message leads with plain
     // language (what it means + what to do), not the "Failure axis:" jargon;
-    // the technical axis is kept only as a trailing engineer detail.
+    // the technical axis is kept only on structured fields for engineer view.
     expect(action.message).not.toMatch(/^Failure axis/);
-    expect(action.message).toContain("Resume");
-    expect(action.message).toContain("out-of-scope-noise");
+    expect(action.message).toContain("Next: click Try to fix");
+    expect(action.message).not.toContain("out-of-scope-noise");
   });
 
   it("surfaces implementation recovery in review when review only contains failed execution evidence", () => {
@@ -640,7 +697,7 @@ describe("deriveBuildStudioWorkflowAction", () => {
     });
 
     expect(action.kind).toBe("resume-implementation");
-    expect(action.primaryLabel).toBe("Resume Implementation");
+    expect(action.primaryLabel).toBe("Try to fix");
     expect(action.coworkerLabel).toBe("Recover with coworker");
   });
 
@@ -789,8 +846,8 @@ describe("deriveWorkflowStageGuidance", () => {
       governedBacklogEnabled: true,
     });
 
-    expect(guidance.title).toBe("Click Resume to re-execute 1 blocked task");
-    expect(guidance.nextApproval).toContain("Resume implementation");
+    expect(guidance.title).toBe("1 task needs another pass");
+    expect(guidance.nextApproval).toContain("Try to fix");
   });
 
   it("exposes specific recovery heading details in stage guidance", () => {
@@ -812,9 +869,10 @@ describe("deriveWorkflowStageGuidance", () => {
       governedBacklogEnabled: true,
     });
 
-    expect(guidance.title).toBe("Click Resume to re-execute 3 blocked tasks");
+    expect(guidance.title).toBe("3 tasks need another pass");
     expect(guidance.workflowAction.failureAxis).toBe("usage-limit");
-    expect(guidance.workflowAction.message).toContain("usage-limit");
+    expect(guidance.workflowAction.message).toContain("Next: click Try to fix");
+    expect(guidance.workflowAction.message).not.toContain("usage-limit");
   });
 
   it("shows release guidance on the review node when review evidence is complete", () => {
@@ -958,7 +1016,7 @@ describe("deriveWorkflowStageGuidance", () => {
     expect(guidance.workflowAction.failureAxis).toBe("usage-limit");
     expect(guidance.workflowAction.failureAxis).toBe(topCardAction.failureAxis);
     expect(guidance.title).toBe(topCardAction.title);
-    expect(guidance.title).toBe("Click Resume to re-execute 2 blocked tasks");
+    expect(guidance.title).toBe("2 tasks need another pass");
   });
 
   // FB-78E967D4 — Reset Build affordance for contradictory pipeline state.

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -28,6 +28,25 @@ type BuildStudioWorkflowActionMetadata = {
   resumeMode?: ResumeImplementationModeDetail;
 };
 
+export type BuildOperatorStatusKind = "waiting-on-you" | "working" | "blocked-technical";
+
+export type BuildOperatorStatus = {
+  kind: BuildOperatorStatusKind;
+  label: "Waiting on you" | "Working" | "Blocked (technical)";
+  intent: "accent" | "info" | "danger";
+};
+
+export type BuildStudioOperatorGuidance = {
+  status: BuildOperatorStatus;
+  nextLabel: string | null;
+  nextSentence: string;
+  useCoworkerForNext: boolean;
+  guidedRecovery: boolean;
+  recoveryHint: string | null;
+};
+
+type OperatorGuidanceBuildContext = Pick<FeatureBuildRow, "phase" | "buildExecState">;
+
 export type BuildStudioWorkflowAction =
   | ({
     kind: "approve-start";
@@ -328,6 +347,105 @@ function explicitFailureAxisOrNull(value: unknown): BuildFailureAxis | null {
   ) ? failureAxis : null;
 }
 
+function statusForAction(
+  action: BuildStudioWorkflowAction,
+  build?: OperatorGuidanceBuildContext,
+): BuildOperatorStatus {
+  if (
+    action.kind === "retry-build"
+    || action.kind === "reset-build"
+    || action.kind === "resume-implementation"
+  ) {
+    return {
+      kind: "blocked-technical",
+      label: "Blocked (technical)",
+      intent: "danger",
+    };
+  }
+
+  const exec = build?.buildExecState as { step?: string | null; error?: string | null } | null | undefined;
+  if (
+    build?.phase === "build"
+    && exec?.step
+    && exec.step !== "failed"
+    && exec.step !== "complete"
+    && !exec.error
+  ) {
+    return {
+      kind: "working",
+      label: "Working",
+      intent: "info",
+    };
+  }
+
+  if (action.kind === "review-only") {
+    return {
+      kind: "working",
+      label: "Working",
+      intent: "info",
+    };
+  }
+
+  return {
+    kind: "waiting-on-you",
+    label: "Waiting on you",
+    intent: "accent",
+  };
+}
+
+function nextSentenceForAction(action: BuildStudioWorkflowAction): string {
+  if (action.disabledReason) {
+    return "Next: clear the missing evidence with the coworker, then come back to this button.";
+  }
+
+  switch (action.kind) {
+    case "approve-start":
+      return "Next: record approval so Build Studio can keep going.";
+    case "advance-phase":
+      if (action.targetPhase === "plan") return "Next: move the reviewed design into planning.";
+      if (action.targetPhase === "build") return "Next: start implementation from Build Studio.";
+      if (action.targetPhase === "review") return "Next: run verification review from Build Studio.";
+      if (action.targetPhase === "ship") return "Next: continue to release decisions.";
+      return "Next: move this build to the next stage.";
+    case "run-review-verification":
+      return "Next: run UX verification from Build Studio.";
+    case "record-acceptance":
+      return "Next: record acceptance so release decisions can unlock.";
+    case "retry-build":
+      return "Next: retry the sandbox launch.";
+    case "reset-build":
+      return "Next: reset the build pipeline and start it again.";
+    case "resume-implementation":
+      return "Next: try to fix the failed work from Build Studio.";
+    case "decompose-now":
+      return "Next: split this build into smaller builds.";
+    case "amend-parent-design":
+      return "Next: amend the parent design before this child continues.";
+    case "rerun-plan-review":
+      return "Next: try to fix the plan review in place.";
+    case "review-only":
+      return "Next: watch this stage, or ask the coworker what needs attention.";
+  }
+}
+
+export function deriveBuildStudioOperatorGuidance(
+  action: BuildStudioWorkflowAction,
+  build?: OperatorGuidanceBuildContext,
+): BuildStudioOperatorGuidance {
+  const useCoworkerForNext = action.disabledReason != null || action.primaryLabel == null;
+  const guidedRecovery = action.kind === "rerun-plan-review" || action.kind === "resume-implementation";
+  return {
+    status: statusForAction(action, build),
+    nextLabel: useCoworkerForNext ? action.coworkerLabel : action.primaryLabel,
+    nextSentence: nextSentenceForAction(action),
+    useCoworkerForNext,
+    guidedRecovery,
+    recoveryHint: guidedRecovery
+      ? "Choose Try to fix when the failure looks stale or already addressed. Choose Something looks off when the plan or checks need a human-readable revision first."
+      : null,
+  };
+}
+
 function deriveResumeMode(args: {
   build: FeatureBuildRow;
   taskResults: NormalizedTaskResults;
@@ -375,28 +493,27 @@ function buildResumeAction(args: {
   const blockedCount = state.nonCleanTasks.length;
   const axis = state.failureAxis ?? "unknown";
   const title =
-    state.operatorAction
-      ? state.operatorAction
-      : axis === "out-of-scope-noise"
+    axis === "out-of-scope-noise"
       ? "Review workspace noise before retrying this build"
       : blockedCount > 0
-        ? `Click Resume to re-execute ${blockedCount} blocked task${blockedCount === 1 ? "" : "s"}`
+        ? blockedCount === 1
+          ? "1 task needs another pass"
+          : `${blockedCount} tasks need another pass`
         : state.resumeMode.mode === "replan-and-dispatch"
-          ? "Click Resume to re-plan and dispatch tasks"
-          : "Click Resume to rerun verification";
-  // BI-FD796419 / Band 4 — lead with plain "what it means + what to do"; keep
-  // the technical failure axis + reason as a trailing engineer detail rather
-  // than the headline, so an overseer is not asked to parse "Failure axis:".
+          ? "Implementation needs a fresh plan"
+          : "Verification needs another pass";
+  // BI-FD796419 / Band 4 — lead with plain "what it means + what to do";
+  // technical recovery metadata stays on structured fields for engineer view.
   const message =
     axis === "out-of-scope-noise"
-      ? "The checks that failed look like they came from other work, not this build, so it is probably fine. Take a look, then click Resume to re-run on a clean workspace. (Details: failure axis out-of-scope-noise.)"
-      : `Some of the work did not pass its checks yet. Click Resume to re-run it on a clean workspace before the review continues. (Details: failure axis ${axis}. ${state.resumeMode.reason})`;
+      ? "The failed checks look like they came from other work, not this build. Next: click Try to fix to rerun recovery from Build Studio."
+      : "Some work did not pass its checks yet. Next: click Try to fix to rerun the failed work from Build Studio.";
 
   return {
     kind: "resume-implementation",
     title,
     message,
-    primaryLabel: "Resume Implementation",
+    primaryLabel: "Try to fix",
     targetPhase: null,
     disabledReason: null,
     coworkerLabel: args.coworkerLabel,
@@ -547,15 +664,15 @@ export function deriveBuildStudioWorkflowAction({
     if (isPlanReviewFailed(build.planReview)) {
       return {
         kind: "rerun-plan-review",
-        title: "Plan Review Failed",
+        title: "Plan review needs a fix",
         message:
-          "The implementation plan did not pass review. Re-run the plan review to refresh the result with the current reviewer logic, or revise the plan with the coworker first. If the blocking issues are resolved (or no longer apply), the re-run passes and Start Implementation unlocks automatically.",
-        primaryLabel: "Re-run Plan Review",
+          "The plan review did not pass. Next: click Try to fix to rerun the guided recovery in Build Studio, or choose Something looks off if the plan needs edits first.",
+        primaryLabel: "Try to fix",
         targetPhase: null,
         disabledReason: null,
-        coworkerLabel: "Revise the plan",
+        coworkerLabel: "Something looks off",
         coworkerPrompt:
-          "The Build Studio plan review failed. Summarize the blocking issues, revise the implementation plan to address them, save the plan with saveBuildEvidence field buildPlan, then re-run reviewBuildPlan and tell me when Start Implementation is unlocked.",
+          "The Build Studio plan review failed. Explain the blocking issues in plain language, update the saved implementation plan to address them, run the plan review again, and report whether implementation is unlocked.",
       };
     }
 
@@ -628,7 +745,7 @@ export function deriveBuildStudioWorkflowAction({
         state: concernState,
         coworkerLabel: "Review failures with coworker",
         coworkerPrompt:
-          "The current build still has flagged execution or verification concerns. Explain what failed, then rerun the non-clean implementation work on a healthy sandbox and tell me when verification is genuinely ready.",
+          "The current build still has execution or verification concerns. Explain what failed in plain language, rerun the non-clean implementation work through the existing recovery path, and report when verification is genuinely ready.",
       });
     }
 
@@ -671,7 +788,7 @@ export function deriveBuildStudioWorkflowAction({
         state: concernState,
         coworkerLabel: "Recover with coworker",
         coworkerPrompt:
-          "The current review state reflects implementation failures, not a clean verification pass. Recover the build from the live product path: rerun the non-clean implementation work on a healthy sandbox, then tell me the next approval when verification is truly ready.",
+          "The current review state reflects implementation failures, not a clean verification pass. Recover the build through the existing Build Studio recovery path, then tell me the next approval when verification is truly ready.",
       });
     }
   }
@@ -815,7 +932,7 @@ export function deriveWorkflowStageGuidance({
     return {
       title: workflowAction.title,
       nextApproval:
-        "Resume implementation from Build Studio so the coworker can rerun the flagged work and return to review with clean evidence.",
+        "Try to fix from Build Studio so the coworker can rerun the flagged work and return to review with clean evidence.",
       workflowAction,
     };
   }

--- a/apps/web/components/build/fleet-derivation.ts
+++ b/apps/web/components/build/fleet-derivation.ts
@@ -10,6 +10,8 @@
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import type { BuildQueueState } from "./QueueStateBadge";
 
+export const DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP = 3;
+
 /**
  * Derive a BuildQueueState from the FeatureBuildRow's phase + execution state.
  *
@@ -125,4 +127,12 @@ export function deriveFleetCounts(states: readonly BuildQueueState[]): {
     else if (s.kind === "blocked") blocked++;
   }
   return { runningCount: running, queuedCount: queued, blockedCount: blocked };
+}
+
+export function formatFleetHeader(
+  runningCount: number,
+  cap: number = DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP,
+  queuedCount: number = 0,
+): string {
+  return `WIP slots: ${runningCount} of ${cap} in use · ${queuedCount} queued`;
 }


### PR DESCRIPTION
## Summary
- Adds one operator-facing status and one inline next action per Build Studio build.
- Adds guided recovery affordances for review failures, WIP slot messaging, queued-state badges, and hides internal build/backlog identifiers by default.
- Keeps the implementation on existing Build Studio band/report-kit patterns.

## Verification
- `git diff --check` passed.
- Targeted Vitest command was attempted and blocked in this source-only worktree: `vitest` not found because `node_modules` is missing.
- Pre-commit gitleaks scan passed; `DPF_SKIP_TYPECHECK=1` was used because the source-only worktree cannot run `next typegen && tsc --noEmit` without dependencies.