### PR TITLE
fix(build): hide default Build Studio internal IDs

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -706,7 +706,10 @@ export function BuildStudio({
 
         {/* Right: Preview or Brief */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-[var(--dpf-surface-1)]">
-          <PortalContextStrip envelope={portalContext ?? null} />
+          <PortalContextStrip
+            envelope={portalContext ?? null}
+            showInternalIds={engineerView || headerDetailsExpanded}
+          />
           {activeBuild ? (
             <>
               <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--dpf-border)] px-4 py-3">
@@ -994,7 +997,10 @@ export function BuildStudio({
       {/* Footer — single shared OpenSandboxButton (sandbox is shared across
           all in-flight builds; surfacing one link labeled with the current
           driver replaces the dishonest per-build Preview tab). */}
-      <BuildStudioFooter builds={supervisedBuildRows} />
+      <BuildStudioFooter
+        builds={supervisedBuildRows}
+        showDrivingBuildCode={engineerView || headerDetailsExpanded}
+      />
     </div>
   );
 }
@@ -1309,7 +1315,13 @@ function NodeInspectorBody({ info }: { info: ProcessGraphNodeClickInfo }) {
   return <p className="text-[var(--dpf-muted)]">Workflow node selected.</p>;
 }
 
-function BuildStudioFooter({ builds }: { builds: FeatureBuildRow[] }) {
+function BuildStudioFooter({
+  builds,
+  showDrivingBuildCode,
+}: {
+  builds: FeatureBuildRow[];
+  showDrivingBuildCode: boolean;
+}) {
   const candidates: SandboxDriverCandidate[] = builds.map((b) => ({
     buildCode: b.buildId,
     sandboxPort: b.sandboxPort,
@@ -1336,6 +1348,7 @@ function BuildStudioFooter({ builds }: { builds: FeatureBuildRow[] }) {
       <OpenSandboxButton
         drivingBuildCode={driving?.buildCode ?? null}
         sandboxUrl={sandboxUrl}
+        showDrivingBuildCode={showDrivingBuildCode}
       />
     </div>
   );

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -422,7 +422,8 @@ describe("BuildStudio active-build header layout", () => {
 
     expect(html).toContain("Portal context");
     expect(html).toContain("Build Studio");
-    expect(html).toContain("WC-123");
+    expect(html).toContain("Portal overlay");
+    expect(html).not.toContain("WC-123");
   });
 
   it("renders a studio approval control for backlog-linked builds that are missing start approval", () => {
@@ -511,6 +512,8 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).toContain('data-testid="build-studio-footer"');
     expect(html).toContain('data-testid="build-studio-open-sandbox"');
     expect(html).toContain('data-driving="FB-9B19098C"');
+    expect(html).toContain("Open live preview · current build");
+    expect(html).not.toContain("driving: FB-9B19098C");
     expect(html).toContain('href="http://localhost:5555"');
     expect(html).toMatch(/rel="noopener noreferrer"/);
   });

--- a/apps/web/components/build/BuildStudioNodeInspector.test.tsx
+++ b/apps/web/components/build/BuildStudioNodeInspector.test.tsx
@@ -314,7 +314,9 @@ describe("BuildStudio NodeInspector lifecycle", () => {
     graphState.onNodeClick!(mockClickInfo());
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
     fireEvent.keyDown(document, { key: "Escape" });
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
   });
 
   it("Ask-coworker button dispatches open-agent-panel with the right prefill", async () => {

--- a/apps/web/components/build/EpicRollupListItem.test.tsx
+++ b/apps/web/components/build/EpicRollupListItem.test.tsx
@@ -68,6 +68,7 @@ describe("EpicRollupListItem", () => {
     expect(html).toContain("1 of 3 done");
     expect(html).toContain("2 backlog items");
     expect(html).toContain("Updated May 25");
+    expect(html).not.toContain("EP-TRUCK-STOCK");
     expect(html).not.toContain("Low-stock surfacing");
   });
 

--- a/apps/web/components/build/EpicRollupListItem.tsx
+++ b/apps/web/components/build/EpicRollupListItem.tsx
@@ -66,9 +66,6 @@ export function EpicRollupListItem({
           className="flex min-w-0 flex-1 flex-col gap-0.5 text-left focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
         >
           <span className="flex min-w-0 items-center gap-2">
-            <span className="shrink-0 font-mono text-[11px] text-[var(--dpf-text)]">
-              {rollup.epicId}
-            </span>
             <span className="min-w-0 truncate text-[11px] font-semibold text-[var(--dpf-text)]">
               {rollup.title}
             </span>

--- a/apps/web/components/build/OpenSandboxButton.test.tsx
+++ b/apps/web/components/build/OpenSandboxButton.test.tsx
@@ -37,6 +37,20 @@ describe("OpenSandboxButton", () => {
     expect(html).toContain("driving: idle");
   });
 
+  it("can hide the raw driving build code from the visible operator label", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton
+        drivingBuildCode="FB-B33E84B5"
+        sandboxUrl="http://localhost:5555"
+        showDrivingBuildCode={false}
+      />,
+    );
+
+    expect(html).toContain("Open live preview · current build");
+    expect(html).toContain('data-driving="FB-B33E84B5"');
+    expect(html).not.toContain("driving: FB-B33E84B5");
+  });
+
   it("emits data-driving for snapshot diffing", () => {
     const html = renderToStaticMarkup(
       <OpenSandboxButton drivingBuildCode="FB-CCC" sandboxUrl="http://localhost:5555" />,

--- a/apps/web/components/build/OpenSandboxButton.tsx
+++ b/apps/web/components/build/OpenSandboxButton.tsx
@@ -9,10 +9,8 @@
 //
 // Per the design spec §1 (Footer) and §6 (component contract):
 //   - Renders <a target="_blank" rel="noopener noreferrer"> — rel is non-optional.
-//   - Label: "Open live preview · driving: {code | 'idle'}". The component
-//     name (OpenSandboxButton) and the underlying URL still point at the
-//     "sandbox" compose service — only the user-facing string flipped
-//     per the 2026-05-24 portal topology consolidation spec §8.1.
+//   - Default label: "Open live preview · current build" / "idle". Engineering
+//     surfaces may opt into the semantic FB-* code for diagnostics.
 //   - Disabled visual + aria-disabled when sandboxUrl is empty.
 //   - Deterministic driver via sandbox-driver helper (R1 from peer review).
 //
@@ -31,10 +29,19 @@ export type OpenSandboxButtonProps = {
   drivingBuildCode: string | null;
   /** Sandbox preview URL. Empty/null disables the button. */
   sandboxUrl: string;
+  /** Show the raw FB-* code in the label. Defaults to true for compatibility;
+   *  Build Studio's non-technical default passes false. */
+  showDrivingBuildCode?: boolean;
 };
 
-export function OpenSandboxButton({ drivingBuildCode, sandboxUrl }: OpenSandboxButtonProps) {
-  const label = formatSandboxLabel(drivingBuildCode);
+export function OpenSandboxButton({
+  drivingBuildCode,
+  sandboxUrl,
+  showDrivingBuildCode = true,
+}: OpenSandboxButtonProps) {
+  const label = showDrivingBuildCode
+    ? formatSandboxLabel(drivingBuildCode)
+    : formatOperatorSandboxLabel(drivingBuildCode);
   const isDisabled = !sandboxUrl || sandboxUrl.trim().length === 0;
 
   if (isDisabled) {
@@ -65,4 +72,8 @@ export function OpenSandboxButton({ drivingBuildCode, sandboxUrl }: OpenSandboxB
       {label}
     </a>
   );
+}
+
+function formatOperatorSandboxLabel(drivingBuildCode: string | null): string {
+  return drivingBuildCode ? "Open live preview · current build" : "Open live preview · idle";
 }

--- a/apps/web/components/portal-context/PortalContextStrip.test.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.test.tsx
@@ -87,6 +87,51 @@ describe("PortalContextStrip", () => {
     expect(html).not.toMatch(/bg-\[var\(--dpf-error\)\][^"]*text-\[var\(--dpf-error\)\]/);
     expect(html).toContain("Missing evidence");
   });
+
+  it("hides raw build and capsule IDs in operator-facing mode", () => {
+    const base = makeEnvelope();
+    const html = renderToStaticMarkup(
+      <PortalContextStrip
+        envelope={{
+          ...base,
+          work: {
+            ...base.work,
+            capsule: {
+              capsuleId: "WC-12345678",
+              title: "Operator handoff",
+              status: "working",
+              executorKind: "build-studio",
+              executorRef: null,
+              leaseHolderPrincipalId: null,
+              leaseExpiresAt: null,
+              isLeaseExpired: false,
+              isStale: false,
+              scopeClaims: [],
+              scopeClaimPrincipalIds: [],
+              branchName: "feat/internal-branch",
+              href: "/build/work/WC-12345678",
+            },
+            featureBuild: {
+              buildId: "FB-87654321",
+              title: "Backlog launched build",
+              phase: "review",
+              status: "active",
+              evidenceComplete: false,
+              href: "/build?buildId=FB-87654321",
+              updatedAt: "2026-06-27T02:00:00.000Z",
+            },
+          },
+        }}
+        showInternalIds={false}
+      />,
+    );
+
+    expect(html).toContain("Backlog launched build");
+    expect(html).toContain("Operator handoff");
+    expect(html).not.toContain("FB-87654321");
+    expect(html).not.toContain("WC-12345678");
+    expect(html).not.toContain("feat/internal-branch");
+  });
 });
 
 function makeEnvelope(overrides: Partial<PortalContextEnvelope> = {}): PortalContextEnvelope {

--- a/apps/web/components/portal-context/PortalContextStrip.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.tsx
@@ -4,16 +4,26 @@ import { useState } from "react";
 import Link from "next/link";
 import { AlertTriangle, Network, Users } from "lucide-react";
 
-import type { AttentionSignal, PortalContextEnvelope } from "@/lib/portal-context";
+import type {
+  AttentionSignal,
+  FeatureBuildAnchor,
+  PortalContextEnvelope,
+  WorkCapsuleAnchor,
+} from "@/lib/portal-context";
 import { PortalContextOverlayDrawer } from "./PortalContextOverlayDrawer";
 
-export function PortalContextStrip({ envelope }: { envelope: PortalContextEnvelope | null }) {
+type PortalContextStripProps = {
+  envelope: PortalContextEnvelope | null;
+  showInternalIds?: boolean;
+};
+
+export function PortalContextStrip({ envelope, showInternalIds = true }: PortalContextStripProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   if (!envelope) return null;
 
   const primarySignal = envelope.attention[0] ?? null;
-  const buildLabel = envelope.work.featureBuild?.buildId ?? "No active build";
-  const capsuleLabel = envelope.work.capsule?.capsuleId ?? "No capsule";
+  const buildLabel = formatBuildLabel(envelope.work.featureBuild ?? null, showInternalIds);
+  const capsuleLabel = formatCapsuleLabel(envelope.work.capsule ?? null, showInternalIds);
   // D11 (2026-05-23): suppress the AttentionChip rendering when it would
   // duplicate the "No active build" text already shown in the buildLabel
   // chip to its left. The chip's job is to carry build identity; when
@@ -37,10 +47,18 @@ export function PortalContextStrip({ envelope }: { envelope: PortalContextEnvelo
           <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs font-medium text-[var(--dpf-text)]">
             {envelope.route.domain}
           </span>
-          <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-muted)]">
+          <span
+            className="inline-block max-w-[18rem] truncate rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-muted)]"
+            title={formatBuildTitle(envelope.work.featureBuild ?? null, showInternalIds)}
+            data-testid="portal-context-build-label"
+          >
             {buildLabel}
           </span>
-          <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-muted)]">
+          <span
+            className="inline-block max-w-[18rem] truncate rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-muted)]"
+            title={formatCapsuleTitle(envelope.work.capsule ?? null, showInternalIds)}
+            data-testid="portal-context-capsule-label"
+          >
             {capsuleLabel}
           </span>
           {primarySignal && showAttentionChip && <AttentionChip signal={primarySignal} />}
@@ -73,6 +91,30 @@ export function PortalContextStrip({ envelope }: { envelope: PortalContextEnvelo
       />
     </div>
   );
+}
+
+function formatBuildLabel(build: FeatureBuildAnchor | null, showInternalIds: boolean): string {
+  if (!build) return "No active build";
+  if (showInternalIds) return build.buildId;
+  return build.title || "Active build";
+}
+
+function formatCapsuleLabel(capsule: WorkCapsuleAnchor | null, showInternalIds: boolean): string {
+  if (!capsule) return "No capsule";
+  if (showInternalIds) return capsule.capsuleId;
+  return capsule.title || "Work capsule";
+}
+
+function formatBuildTitle(build: FeatureBuildAnchor | null, showInternalIds: boolean): string | undefined {
+  if (!build) return undefined;
+  if (showInternalIds) return `${build.title || "Active build"} (${build.buildId})`;
+  return build.title || "Active build";
+}
+
+function formatCapsuleTitle(capsule: WorkCapsuleAnchor | null, showInternalIds: boolean): string | undefined {
+  if (!capsule) return undefined;
+  if (showInternalIds) return `${capsule.title || "Work capsule"} (${capsule.capsuleId})`;
+  return capsule.title || "Work capsule";
 }
 
 function AttentionChip({ signal }: { signal: AttentionSignal }) {


### PR DESCRIPTION
## Summary
- Hide raw `FB-*` / `WC-*` labels in the Build Studio portal-context strip unless Details or Engineer view is open.
- Hide the shared preview footer's raw driving build code in the default operator label while preserving `data-driving` for automation.
- Remove the `EP-*` label from collapsed fleet epic rollup rows.

## Verification
- `git diff --check`
- `node scripts/check-module-size.mjs`
- Source-only worktree: `node_modules` is absent, so targeted Vitest/typecheck/build are CI-gated per guardrail.

UX-Fit-Decision: hide-by-default; `principle_decide` recommended hide-by-default with high confidence after live `/build` verification exposed default `FB-*`/`WC-*`/`EP-*` identifiers. Exact `dpf-ux-fit-review` surface was not callable in this session.

Process-Spine-Decision: Covered by existing Build Studio overseer UX spec and implementation plan; this is a narrow acceptance follow-up to BI-63EAD801.