### PR TITLE
fix(agent-toolchain): keep preflight useful while MCP is unavailable

### DIFF
--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -10,7 +10,7 @@ That sentence is the whole contract for non-technical contributors. Everything b
 
 ## Agent toolchain readiness
 
-After the install completes, `install-dpf` prints a single readiness banner. There are six possible states. The wording shown to the contributor matches this table exactly — drift between the table and the installer copy is a CI lint enforced by `readiness-state.test.ts` in the `@dpf/bootstrap` package.
+After the install completes, `install-dpf` prints a single readiness banner. There are eight possible states. The wording shown to the contributor matches this table exactly — drift between the table and the installer copy is a CI lint enforced by `readiness-state.test.ts` in the `@dpf/bootstrap` package.
 
 | State | Banner message | Primary action |
 |---|---|---|
@@ -19,6 +19,8 @@ After the install completes, `install-dpf` prints a single readiness banner. The
 | `missing_cli` | Install the selected agent client to enable contributor sessions. | Open setup guide |
 | `missing_token` | DPF MCP needs a development token before agents can use governed tools. | Issue development token |
 | `needs_refresh` | A token exists, but the running client has not picked it up yet. | Refresh client binding |
+| `portal-unavailable` | The portal is rebooting; I can still repair local agent tooling and will sync evidence when it comes back. | Continue local repair |
+| `mcp-unavailable` | DPF coordination is unavailable; I can still repair local agent tooling and will sync evidence when it returns. | Continue local repair |
 | `failed_smoke` | The agent is installed but did not apply a DPF kernel principle. | View evidence |
 
 ### Why each state appears
@@ -28,6 +30,8 @@ After the install completes, `install-dpf` prints a single readiness banner. The
 - **`missing_cli`** — neither Claude Code nor Codex CLI was detected. The contributor needs to install one before any agent work is possible. The installer does NOT print a command for the contributor to type — install the CLI from its official documentation, then re-run the installer.
 - **`missing_token`** — the DPF MCP server requires a bearer token before governed tools (backlog, build studio, deliberations) become available. Issue one from **Admin > Platform Development > MCP** in the portal.
 - **`needs_refresh`** — a token exists in the contributor's environment, but the running client hasn't picked it up yet. Restart Claude Code / Codex in this worktree. If the issue persists after restart, the endpoint is unreachable or returning an unexpected shape — collect a `dpf-doctor` bundle.
+- **`portal-unavailable`** — a token exists, but the portal endpoint cannot be reached or is clearly rebooting/quiescing. The bootstrap still performs local-only repairs such as plugin convergence, MCP client config writes, and memory seeding, then records a local state that can be reconciled after the portal returns.
+- **`mcp-unavailable`** — the portal is reachable enough to answer, but the MCP route is missing, unavailable, or returning a server-side failure that is not a portal reboot signal. The bootstrap still performs the same local repairs and keeps the contributor unblocked for source-local work.
 - **`failed_smoke`** — the installed CLI responded to the kernel smoke prompt but did not include any of the expected refusal signatures. This is usually a CLI version that hasn't loaded the kernel memory yet. See the smoke-test transcript under `~/.dpf/install-state.json` → `agentToolchain.smokeTest.transcript`.
 
 ### Idempotence guarantee

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/codex-config.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/codex-config.test.ts
@@ -188,6 +188,17 @@ describe("planCodexConfig", () => {
     expect(plan.preservedUserIntent).toBe(false);
   });
 
+  it("accepts a UTF-8 BOM at the start of a Windows-written config", () => {
+    const plan = planCodexConfig(`\uFEFF${operatorRedacted}`, REPO, CONFIG_PATH);
+
+    expect(plan.writes).toHaveLength(1);
+    expect(plan.rationale).not.toMatch(/TOML parse error/);
+    const parsed = parse(plan.writes[0].content) as {
+      plugins: Record<string, { enabled?: boolean }>;
+    };
+    expect(parsed.plugins["dpf-platform"].enabled).toBe(true);
+  });
+
   it("handles empty existing config (fresh contributor)", () => {
     const plan = planCodexConfig("", REPO, CONFIG_PATH);
 

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/evidence-queue.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/evidence-queue.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createLocalEvidenceEnvelope,
+  parseEvidenceQueue,
+  planEvidenceQueueWrite,
+  reconcileEvidenceQueue,
+} from "../evidence-queue";
+
+describe("local evidence queue", () => {
+  it("creates a stable, bearer-free envelope for MCP evidence writes while offline", () => {
+    const envelope = createLocalEvidenceEnvelope({
+      createdAt: "2026-06-27T16:30:00.000Z",
+      idempotencyKey: "BI-E29B44F9:test-pass",
+      target: { itemId: "BI-E29B44F9" },
+      toolName: "record_execution_evidence",
+      payload: {
+        itemId: "BI-E29B44F9",
+        kind: "test_pass",
+        summary: "Targeted bootstrap preflight tests passed",
+        body: "Portal was unavailable; evidence queued locally.",
+      },
+    });
+
+    expect(envelope.envelopeId).toBe("evq_21727aa4e3384716");
+    expect(envelope.status).toBe("queued");
+    expect(JSON.stringify(envelope)).not.toMatch(/dpfmcp_|Bearer\s+\w/);
+  });
+
+  it("plans an idempotent queue write and replaces an existing envelope by id", () => {
+    const first = createLocalEvidenceEnvelope({
+      createdAt: "2026-06-27T16:30:00.000Z",
+      idempotencyKey: "same",
+      target: { itemId: "BI-E29B44F9" },
+      toolName: "record_execution_evidence",
+      payload: { itemId: "BI-E29B44F9", kind: "manual_check", summary: "first" },
+    });
+    const second = createLocalEvidenceEnvelope({
+      createdAt: "2026-06-27T16:31:00.000Z",
+      idempotencyKey: "same",
+      target: { itemId: "BI-E29B44F9" },
+      toolName: "record_execution_evidence",
+      payload: { itemId: "BI-E29B44F9", kind: "manual_check", summary: "second" },
+    });
+
+    const write = planEvidenceQueueWrite("queue.json", JSON.stringify([first]), second);
+
+    expect(write.path).toBe("queue.json");
+    const parsed = parseEvidenceQueue(write.content);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].payload.summary).toBe("second");
+  });
+
+  it("reconciles sent envelopes and preserves conflicts for operator review", async () => {
+    const sent = createLocalEvidenceEnvelope({
+      createdAt: "2026-06-27T16:30:00.000Z",
+      idempotencyKey: "sent",
+      target: { itemId: "BI-E29B44F9" },
+      toolName: "record_execution_evidence",
+      payload: { itemId: "BI-E29B44F9", kind: "test_pass", summary: "sent" },
+    });
+    const conflict = createLocalEvidenceEnvelope({
+      createdAt: "2026-06-27T16:30:00.000Z",
+      idempotencyKey: "conflict",
+      target: { itemId: "BI-E29B44F9" },
+      toolName: "record_execution_evidence",
+      payload: { itemId: "BI-E29B44F9", kind: "manual_check", summary: "conflict" },
+    });
+
+    const result = await reconcileEvidenceQueue({
+      envelopes: [sent, conflict],
+      attemptedAt: "2026-06-27T16:40:00.000Z",
+      send: async (envelope) =>
+        envelope.payload.summary === "conflict"
+          ? { ok: false, conflict: true, error: "remote item is done" }
+          : { ok: true, remoteId: "activity-1" },
+    });
+
+    expect(result.sent).toBe(1);
+    expect(result.conflicts).toBe(1);
+    expect(result.updatedEnvelopes[0]).toMatchObject({
+      status: "sent",
+      remoteId: "activity-1",
+      lastAttemptAt: "2026-06-27T16:40:00.000Z",
+    });
+    expect(result.updatedEnvelopes[1]).toMatchObject({
+      status: "conflict",
+      lastError: "remote item is done",
+    });
+  });
+});

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/grok-config.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/grok-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "smol-toml";
+
+import { planGrokConfig } from "../grok-config";
+
+const REPO = "D:\\DPF-worktrees\\agent-preflight-offline";
+const CONFIG_PATH = "C:\\Users\\Test\\.grok\\config.toml";
+const ENDPOINT = "http://127.0.0.1:3000/api/mcp/v1";
+
+describe("planGrokConfig", () => {
+  it("accepts a UTF-8 BOM at the start of a Windows-written config", () => {
+    const plan = planGrokConfig(
+      "\uFEFF[cli]\r\ninstaller = \"internal\"\r\n",
+      REPO,
+      CONFIG_PATH,
+      ENDPOINT,
+    );
+
+    expect(plan.writes).toHaveLength(1);
+    expect(plan.rationale).not.toMatch(/TOML parse error/);
+    const parsed = parse(plan.writes[0].content) as {
+      cli: { installer: string };
+      mcp_servers: Record<string, { url: string; bearer_token_env_var: string }>;
+    };
+    expect(parsed.cli.installer).toBe("internal");
+    expect(parsed.mcp_servers.dpf).toEqual({
+      url: ENDPOINT,
+      bearer_token_env_var: "DPF_MCP_BEARER_TOKEN",
+    });
+  });
+
+  it("returns zero writes with a parse-error rationale on unparseable TOML", () => {
+    const plan = planGrokConfig("[unterminated\nkey = ", REPO, CONFIG_PATH, ENDPOINT);
+
+    expect(plan.writes).toEqual([]);
+    expect(plan.rationale).toMatch(/TOML parse error/);
+  });
+});

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/install-state.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/install-state.test.ts
@@ -82,7 +82,16 @@ describe("install-state.schema.json agentToolchain block", () => {
 
   it("schema readinessState enum covers every value the materializer can emit", () => {
     const declared: string[] = schema.properties.agentToolchain.properties.readinessState.enum;
-    const expected = ["ready", "partial", "missing_cli", "missing_token", "needs_refresh", "failed_smoke"];
+    const expected = [
+      "ready",
+      "partial",
+      "missing_cli",
+      "missing_token",
+      "needs_refresh",
+      "failed_smoke",
+      "portal-unavailable",
+      "mcp-unavailable",
+    ];
     expect(declared.sort()).toEqual(expected.sort());
   });
 

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/mcp-readiness-probe.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/mcp-readiness-probe.test.ts
@@ -62,12 +62,34 @@ describe("interpretMcpReadinessResponse", () => {
 
   it("returns endpoint_unreachable for 5xx", () => {
     const result = interpretMcpReadinessResponse(503, {}, OBSERVED);
-    expect(result).toEqual({ ok: false, reason: "endpoint_unreachable", httpStatus: 503 });
+    expect(result).toEqual({ ok: false, reason: "mcp-unavailable", httpStatus: 503 });
   });
 
-  it("returns endpoint_unreachable for status=0 (no response)", () => {
+  it("returns portal-unavailable for status=0 (no response)", () => {
     const result = interpretMcpReadinessResponse(0, null, OBSERVED);
-    expect(result).toEqual({ ok: false, reason: "endpoint_unreachable", httpStatus: null });
+    expect(result).toEqual({ ok: false, reason: "portal-unavailable", httpStatus: null });
+  });
+
+  it("classifies a rebooting/quiescing portal response separately from MCP route failures", () => {
+    const result = interpretMcpReadinessResponse(
+      503,
+      {
+        error: {
+          message: "portal_quiescing: the portal is rebooting",
+        },
+      },
+      OBSERVED,
+    );
+    expect(result).toEqual({ ok: false, reason: "portal-unavailable", httpStatus: 503 });
+  });
+
+  it("classifies a reachable portal with an unavailable MCP route as mcp-unavailable", () => {
+    const result = interpretMcpReadinessResponse(
+      404,
+      { error: { message: "No route matches /api/mcp/v1" } },
+      OBSERVED,
+    );
+    expect(result).toEqual({ ok: false, reason: "mcp-unavailable", httpStatus: 404 });
   });
 
   it("returns unexpected_shape for 200 with no tools array", () => {

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/probes.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/probes.test.ts
@@ -91,7 +91,7 @@ describe("runMcpReadinessProbe", () => {
     expect(result).toEqual({ ok: false, reason: "no_token", httpStatus: 401 });
   });
 
-  it("interprets 5xx as endpoint_unreachable", async () => {
+  it("interprets 5xx as mcp-unavailable when the portal answered without a reboot marker", async () => {
     const result = await runMcpReadinessProbe({
       endpoint: ENDPOINT,
       token: "dpfmcp_synthetic",
@@ -100,12 +100,12 @@ describe("runMcpReadinessProbe", () => {
     });
     expect(result).toEqual({
       ok: false,
-      reason: "endpoint_unreachable",
+      reason: "mcp-unavailable",
       httpStatus: 503,
     });
   });
 
-  it("maps fetch errors to endpoint_unreachable", async () => {
+  it("maps fetch errors to portal-unavailable", async () => {
     const result = await runMcpReadinessProbe({
       endpoint: ENDPOINT,
       token: "dpfmcp_synthetic",
@@ -118,7 +118,7 @@ describe("runMcpReadinessProbe", () => {
     });
     expect(result).toEqual({
       ok: false,
-      reason: "endpoint_unreachable",
+      reason: "portal-unavailable",
       httpStatus: null,
     });
   });

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/readiness-state.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/readiness-state.test.ts
@@ -32,6 +32,14 @@ describe("readinessCopy", () => {
       message: "The agent is installed but did not apply a DPF kernel principle.",
       primaryAction: "View evidence",
     });
+    expect(readinessCopy("portal-unavailable")).toEqual({
+      message: "The portal is rebooting; I can still repair local agent tooling and will sync evidence when it comes back.",
+      primaryAction: "Continue local repair",
+    });
+    expect(readinessCopy("mcp-unavailable")).toEqual({
+      message: "DPF coordination is unavailable; I can still repair local agent tooling and will sync evidence when it returns.",
+      primaryAction: "Continue local repair",
+    });
   });
 
   it("contains no substrate names in any banner copy (UX contract)", () => {
@@ -52,6 +60,8 @@ describe("readinessCopy", () => {
       "missing_token",
       "needs_refresh",
       "failed_smoke",
+      "portal-unavailable",
+      "mcp-unavailable",
     ];
     for (const state of states) {
       const copy = readinessCopy(state);
@@ -93,14 +103,24 @@ describe("computeReadinessState", () => {
     ).toBe("missing_token");
   });
 
-  it("returns needs_refresh when MCP endpoint unreachable", () => {
+  it("returns portal-unavailable when the portal cannot be reached or is rebooting", () => {
     expect(
       computeReadinessState({
         claudeCodeWired: true,
         codexWired: true,
-        mcpReadiness: { ok: false, reason: "endpoint_unreachable", httpStatus: null },
+        mcpReadiness: { ok: false, reason: "portal-unavailable", httpStatus: null },
       }),
-    ).toBe("needs_refresh");
+    ).toBe("portal-unavailable");
+  });
+
+  it("returns mcp-unavailable when the portal is reachable but MCP is unavailable", () => {
+    expect(
+      computeReadinessState({
+        claudeCodeWired: true,
+        codexWired: true,
+        mcpReadiness: { ok: false, reason: "mcp-unavailable", httpStatus: 404 },
+      }),
+    ).toBe("mcp-unavailable");
   });
 
   it("returns failed_smoke when the smoke test failed but everything else is fine", () => {

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/upstream-versions.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/upstream-versions.test.ts
@@ -63,6 +63,14 @@ enabled = true
     expect(drift.status).toBe("match");
   });
 
+  it("accepts a UTF-8 BOM at the start of a Windows-written config", () => {
+    const drift = detectSuperpowersDrift(`\uFEFF
+[plugins."superpowers@openai-curated"]
+enabled = true
+`);
+    expect(drift.status).toBe("match");
+  });
+
   it("treats unparseable TOML as missing (defensive)", () => {
     const drift = detectSuperpowersDrift("[unterminated\nkey = ");
     expect(drift.status).toBe("missing");

--- a/packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts
@@ -135,9 +135,10 @@ export function planCodexConfig(
   configPath: string,
   mcpEndpoint?: string,
 ): CodexConfigPlan {
+  const normalizedTomlText = existingTomlText.replace(/^\uFEFF/, "");
   let parsed: Record<string, unknown>;
   try {
-    parsed = (existingTomlText.length > 0 ? parse(existingTomlText) : {}) as Record<string, unknown>;
+    parsed = (normalizedTomlText.length > 0 ? parse(normalizedTomlText) : {}) as Record<string, unknown>;
   } catch (err) {
     return {
       writes: [],

--- a/packages/dpf-bootstrap/src/agent-toolchain/evidence-queue.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/evidence-queue.ts
@@ -1,0 +1,200 @@
+/**
+ * Local evidence queue for agent preflight / bootstrap work.
+ *
+ * MCP is the coordination plane, but the preflight itself must keep working
+ * when the portal or MCP endpoint is down. This module defines the small local
+ * envelope we can persist while offline and reconcile once MCP returns.
+ *
+ * Pure planning + reconciliation only. Shell adapters own filesystem writes
+ * and the actual MCP client call.
+ */
+
+import { createHash } from "node:crypto";
+
+export type EvidenceToolName =
+  | "record_execution_evidence"
+  | "record_external_development_evidence"
+  | "record_capsule_evidence";
+
+export type EvidencePayload = Record<string, unknown> & {
+  itemId?: string;
+  kind?: string;
+  summary: string;
+  body?: string;
+  url?: string;
+};
+
+export type LocalEvidenceEnvelope = {
+  schemaVersion: 1;
+  envelopeId: string;
+  idempotencyKey: string;
+  createdAt: string;
+  target: {
+    itemId?: string;
+    capsuleId?: string;
+    buildId?: string;
+  };
+  toolName: EvidenceToolName;
+  payload: EvidencePayload;
+  status: "queued" | "sent" | "conflict";
+  lastAttemptAt?: string;
+  remoteId?: string;
+  lastError?: string;
+};
+
+export type EvidenceQueueWritePlan = {
+  path: string;
+  content: string;
+};
+
+export type EvidenceQueueSendResult =
+  | { ok: true; remoteId?: string }
+  | { ok: false; error: string; conflict?: boolean };
+
+export type EvidenceQueueReconcileResult = {
+  updatedEnvelopes: LocalEvidenceEnvelope[];
+  sent: number;
+  conflicts: number;
+  pending: number;
+};
+
+export function createLocalEvidenceEnvelope(args: {
+  idempotencyKey: string;
+  createdAt: string;
+  target: LocalEvidenceEnvelope["target"];
+  toolName: EvidenceToolName;
+  payload: EvidencePayload;
+}): LocalEvidenceEnvelope {
+  return {
+    schemaVersion: 1,
+    envelopeId: `evq_${stableHash(args.idempotencyKey)}`,
+    idempotencyKey: args.idempotencyKey,
+    createdAt: args.createdAt,
+    target: args.target,
+    toolName: args.toolName,
+    payload: args.payload,
+    status: "queued",
+  };
+}
+
+export function parseEvidenceQueue(text: string | null | undefined): LocalEvidenceEnvelope[] {
+  if (!text || text.trim() === "") return [];
+  const parsed = JSON.parse(text) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error("Evidence queue must be a JSON array.");
+  }
+  return parsed.map((entry) => normalizeEnvelope(entry));
+}
+
+export function planEvidenceQueueWrite(
+  path: string,
+  existingText: string | null | undefined,
+  envelope: LocalEvidenceEnvelope,
+): EvidenceQueueWritePlan {
+  const existing = parseEvidenceQueue(existingText);
+  const index = existing.findIndex((entry) => entry.envelopeId === envelope.envelopeId);
+  if (index >= 0) {
+    existing[index] = envelope;
+  } else {
+    existing.push(envelope);
+  }
+  return {
+    path,
+    content: `${JSON.stringify(existing, null, 2)}\n`,
+  };
+}
+
+export async function reconcileEvidenceQueue(args: {
+  envelopes: LocalEvidenceEnvelope[];
+  attemptedAt: string;
+  send: (envelope: LocalEvidenceEnvelope) => Promise<EvidenceQueueSendResult>;
+}): Promise<EvidenceQueueReconcileResult> {
+  const updated: LocalEvidenceEnvelope[] = [];
+  let sent = 0;
+  let conflicts = 0;
+  let pending = 0;
+
+  for (const envelope of args.envelopes) {
+    if (envelope.status === "sent") {
+      updated.push(envelope);
+      sent += 1;
+      continue;
+    }
+    if (envelope.status === "conflict") {
+      updated.push(envelope);
+      conflicts += 1;
+      continue;
+    }
+
+    const result = await args.send(envelope);
+    if (result.ok) {
+      sent += 1;
+      updated.push({
+        ...envelope,
+        status: "sent",
+        lastAttemptAt: args.attemptedAt,
+        remoteId: result.remoteId,
+        lastError: undefined,
+      });
+      continue;
+    }
+
+    if (result.conflict) {
+      conflicts += 1;
+      updated.push({
+        ...envelope,
+        status: "conflict",
+        lastAttemptAt: args.attemptedAt,
+        lastError: result.error,
+      });
+      continue;
+    }
+
+    pending += 1;
+    updated.push({
+      ...envelope,
+      status: "queued",
+      lastAttemptAt: args.attemptedAt,
+      lastError: result.error,
+    });
+  }
+
+  return { updatedEnvelopes: updated, sent, conflicts, pending };
+}
+
+function stableHash(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex").slice(0, 16);
+}
+
+function normalizeEnvelope(entry: unknown): LocalEvidenceEnvelope {
+  if (!entry || typeof entry !== "object") {
+    throw new Error("Evidence queue entry must be an object.");
+  }
+  const envelope = entry as Partial<LocalEvidenceEnvelope>;
+  if (envelope.schemaVersion !== 1) {
+    throw new Error("Unsupported evidence queue envelope version.");
+  }
+  if (!envelope.envelopeId || !envelope.idempotencyKey || !envelope.createdAt) {
+    throw new Error("Evidence queue envelope is missing identity fields.");
+  }
+  if (!envelope.toolName || !envelope.payload || !envelope.target) {
+    throw new Error("Evidence queue envelope is missing tool payload fields.");
+  }
+  const status = envelope.status ?? "queued";
+  if (status !== "queued" && status !== "sent" && status !== "conflict") {
+    throw new Error(`Unsupported evidence queue status: ${status}`);
+  }
+  return {
+    schemaVersion: 1,
+    envelopeId: envelope.envelopeId,
+    idempotencyKey: envelope.idempotencyKey,
+    createdAt: envelope.createdAt,
+    target: envelope.target,
+    toolName: envelope.toolName,
+    payload: envelope.payload,
+    status,
+    lastAttemptAt: envelope.lastAttemptAt,
+    remoteId: envelope.remoteId,
+    lastError: envelope.lastError,
+  };
+}

--- a/packages/dpf-bootstrap/src/agent-toolchain/grok-config.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/grok-config.ts
@@ -44,7 +44,17 @@ export function planGrokConfig(
   configPath: string,
   mcpEndpoint: string,
 ): GrokConfigPlan {
-  const existing = existingText ? (parse(existingText) as any) : {};
+  void repoRoot;
+  const normalizedText = existingText.replace(/^\uFEFF/, "");
+  let existing: any = {};
+  try {
+    existing = normalizedText ? (parse(normalizedText) as any) : {};
+  } catch (err) {
+    return {
+      writes: [],
+      rationale: `TOML parse error; refusing to write. (${(err as Error).message})`,
+    };
+  }
   const existingDpf = existing.mcp_servers?.[DPF_MCP_KEY];
   const desiredDpf = desiredMcpServerBlock(mcpEndpoint);
 

--- a/packages/dpf-bootstrap/src/agent-toolchain/index.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/index.ts
@@ -79,6 +79,16 @@ export {
 } from "./probes";
 
 export {
+  createLocalEvidenceEnvelope,
+  parseEvidenceQueue,
+  planEvidenceQueueWrite,
+  reconcileEvidenceQueue,
+  type EvidenceQueueReconcileResult,
+  type EvidenceQueueSendResult,
+  type LocalEvidenceEnvelope,
+} from "./evidence-queue";
+
+export {
   normalizeRepoPath,
   repoPathsMatch,
 } from "./path-normalize";

--- a/packages/dpf-bootstrap/src/agent-toolchain/install-state.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/install-state.ts
@@ -32,6 +32,7 @@ export function materializeAgentToolchainState(
   const readinessState = computeReadinessState({
     claudeCodeWired: inputs.claudeCodeWired,
     codexWired: inputs.codexWired,
+    grokWired: inputs.grokWired ?? false,
     mcpReadiness: inputs.mcpReadiness,
     smokeTest: inputs.smokeTest,
   });

--- a/packages/dpf-bootstrap/src/agent-toolchain/mcp-readiness-probe.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/mcp-readiness-probe.ts
@@ -40,7 +40,9 @@ export function planMcpReadinessProbe(
  * - HTTP 200 but shape unrecognized -> ok=false reason=unexpected_shape.
  * - HTTP 401/403 with `insufficient_token_scope` in body -> scope_insufficient.
  * - HTTP 401/403 otherwise -> no_token.
- * - HTTP 5xx or 0 (no response) -> endpoint_unreachable.
+ * - HTTP 0 (no response) -> portal-unavailable.
+ * - HTTP 5xx/404 from a reachable portal route -> mcp-unavailable, unless the
+ *   body clearly says the portal is quiescing/rebooting.
  */
 export function interpretMcpReadinessResponse(
   httpStatus: number,
@@ -48,11 +50,19 @@ export function interpretMcpReadinessResponse(
   observedAt: string,
 ): McpReadinessProbeResult {
   if (httpStatus === 0) {
-    return { ok: false, reason: "endpoint_unreachable", httpStatus: null };
+    return { ok: false, reason: "portal-unavailable", httpStatus: null };
   }
 
   if (httpStatus >= 500) {
-    return { ok: false, reason: "endpoint_unreachable", httpStatus };
+    return {
+      ok: false,
+      reason: looksLikePortalUnavailable(body) ? "portal-unavailable" : "mcp-unavailable",
+      httpStatus,
+    };
+  }
+
+  if (httpStatus === 404) {
+    return { ok: false, reason: "mcp-unavailable", httpStatus };
   }
 
   if (httpStatus === 401 || httpStatus === 403) {
@@ -168,6 +178,30 @@ function looksLikeInsufficientScope(body: unknown): boolean {
     return true;
   }
   return false;
+}
+
+function looksLikePortalUnavailable(body: unknown): boolean {
+  const text = stringifyBody(body).toLowerCase();
+  return [
+    "portal_quiescing",
+    "portal quiescing",
+    "portal-rebooting",
+    "portal rebooting",
+    "portal is rebooting",
+    "portal unavailable",
+    "quiescing",
+    "rebooting",
+  ].some((marker) => text.includes(marker));
+}
+
+function stringifyBody(body: unknown): string {
+  if (body == null) return "";
+  if (typeof body === "string") return body;
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return String(body);
+  }
 }
 
 function extractToolsArray(body: unknown): unknown[] | null {

--- a/packages/dpf-bootstrap/src/agent-toolchain/probes.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/probes.ts
@@ -84,9 +84,11 @@ export async function runMcpReadinessProbe(args: {
 
     return interpretMcpReadinessResponse(response.status, body, observedAt);
   } catch (err) {
-    // AbortError or network failure both map to endpoint_unreachable.
+    // AbortError or network failure means the portal endpoint itself is not
+    // currently reachable. A reachable portal with a broken MCP route is
+    // classified later from the HTTP response.
     void err;
-    return { ok: false, reason: "endpoint_unreachable", httpStatus: null };
+    return { ok: false, reason: "portal-unavailable", httpStatus: null };
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/dpf-bootstrap/src/agent-toolchain/readiness-state.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/readiness-state.ts
@@ -39,6 +39,14 @@ const COPY: Record<ReadinessState, ReadinessCopy> = {
     message: "The agent is installed but did not apply a DPF kernel principle.",
     primaryAction: "View evidence",
   },
+  "portal-unavailable": {
+    message: "The portal is rebooting; I can still repair local agent tooling and will sync evidence when it comes back.",
+    primaryAction: "Continue local repair",
+  },
+  "mcp-unavailable": {
+    message: "DPF coordination is unavailable; I can still repair local agent tooling and will sync evidence when it returns.",
+    primaryAction: "Continue local repair",
+  },
 };
 
 export function readinessCopy(state: ReadinessState): ReadinessCopy {
@@ -65,6 +73,12 @@ export function computeReadinessState(
   if (mcp && !mcp.ok) {
     if (mcp.reason === "no_token" || mcp.reason === "scope_insufficient") {
       return "missing_token";
+    }
+    if (mcp.reason === "portal-unavailable") {
+      return "portal-unavailable";
+    }
+    if (mcp.reason === "mcp-unavailable") {
+      return "mcp-unavailable";
     }
     if (mcp.reason === "endpoint_unreachable" || mcp.reason === "unexpected_shape") {
       return "needs_refresh";

--- a/packages/dpf-bootstrap/src/agent-toolchain/types.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/types.ts
@@ -27,6 +27,8 @@ export type McpReadinessProbeResult =
       ok: false;
       reason:
         | "no_token"
+        | "portal-unavailable"
+        | "mcp-unavailable"
         | "endpoint_unreachable"
         | "scope_insufficient"
         | "unexpected_shape";
@@ -43,7 +45,12 @@ export type SmokeTestResult =
   | { result: "failed"; transcript: string; reason: string }
   | {
       result: "skipped";
-      reason: "claude_not_on_path" | "codex_not_on_path" | "grok_not_on_path" | "no_token";
+      reason:
+        | "claude_not_on_path"
+        | "codex_not_on_path"
+        | "grok_not_on_path"
+        | "no_cli_on_path"
+        | "no_token";
     };
 
 /**
@@ -56,6 +63,8 @@ export type ReadinessState =
   | "missing_cli"
   | "missing_token"
   | "needs_refresh"
+  | "portal-unavailable"
+  | "mcp-unavailable"
   | "failed_smoke";
 
 /**

--- a/packages/dpf-bootstrap/src/agent-toolchain/upstream-versions.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/upstream-versions.ts
@@ -55,11 +55,12 @@ export type UpstreamVersionDrift = {
  */
 export function detectSuperpowersDrift(codexTomlText: string): UpstreamVersionDrift {
   const pinned = PINNED_UPSTREAM_VERSIONS.superpowers;
+  const normalizedTomlText = codexTomlText.replace(/^\uFEFF/, "");
   let observed: string | null = null;
   let present = false;
 
   try {
-    const parsed = (codexTomlText.length > 0 ? parse(codexTomlText) : {}) as Record<string, unknown>;
+    const parsed = (normalizedTomlText.length > 0 ? parse(normalizedTomlText) : {}) as Record<string, unknown>;
     const plugins = (parsed["plugins"] as Record<string, unknown> | undefined) ?? {};
     // Try the canonical OpenAI-curated id first, then fall back to other
     // marketplace suffixes (a user might be on a beta channel).

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -81,6 +81,33 @@ class UpdateAgentToolchainTest(unittest.TestCase):
             self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
             self.assertEqual(data["mcp_servers"]["dpf"]["url"], "https://mcp.example.test/api/mcp/v1")
 
+    def test_repairs_missing_managed_plugin_without_token_or_portal(self) -> None:
+        skill_pack = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                os.environ,
+                {"DPF_AGENT_TOOLCHAIN_HOME": tmp},
+                clear=True,
+            ):
+                code = updater.main([
+                    "--skill-pack-path",
+                    str(skill_pack),
+                    "--skip-claude-cli-install",
+                ])
+
+            self.assertEqual(code, 0)
+            home = Path(tmp)
+            managed = home / ".agents" / "plugins" / "plugins" / "dpf-platform"
+            self.assertTrue((managed / ".codex-plugin" / "plugin.json").exists())
+            self.assertTrue((managed / "skills" / "dpf-worktree-per-session" / "SKILL.md").exists())
+
+            codex_config = tomllib.loads((home / ".codex" / "config.toml").read_text())
+            self.assertTrue(codex_config["plugins"]["dpf-platform"]["enabled"])
+            self.assertEqual(
+                codex_config["mcp_servers"]["dpf"]["bearer_token_env_var"],
+                "DPF_MCP_BEARER_TOKEN",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/dpf-bootstrap-agent-toolchain.ps1
+++ b/scripts/dpf-bootstrap-agent-toolchain.ps1
@@ -175,8 +175,24 @@ if ($GrokPresent)          { $nodeArgs += "--grok-cli-present" }
 if ($HasToken)             { $nodeArgs += "--has-token" }
 if ($ReconcileStaleEntries.IsPresent) { $nodeArgs += "--reconcile-stale-entries" }
 
-$planJson = & pnpm @nodeArgs 2>$null
-if ($LASTEXITCODE -ne 0 -or -not $planJson) {
+$planJson = $null
+$computePlanFailed = $false
+$computePlanExitCode = 0
+$previousErrorActionPreference = $ErrorActionPreference
+try {
+    $ErrorActionPreference = "Continue"
+    $planJson = & pnpm @nodeArgs 2>$null
+    $computePlanExitCode = $LASTEXITCODE
+    if ($computePlanExitCode -ne 0 -or -not $planJson) {
+        $computePlanFailed = $true
+    }
+} catch {
+    $computePlanFailed = $true
+} finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+}
+
+if ($computePlanFailed) {
     Write-Warn2 "compute-plan failed; using standalone skill-pack updater fallback."
     $fallback = Join-Path $RepoRoot "packages\dpf-skill-pack\scripts\update-agent-toolchain.ps1"
     if (Test-Path -LiteralPath $fallback) {
@@ -187,7 +203,7 @@ if ($LASTEXITCODE -ne 0 -or -not $planJson) {
     exit 1
 }
 
-$plan = $planJson | ConvertFrom-Json
+$plan = ($planJson -join "`n") | ConvertFrom-Json
 Write-Info "Plan preview: $($plan.preview.readinessState)"
 
 # --- Apply plan ---------------------------------------------------------------
@@ -352,16 +368,25 @@ if (-not $DryRun.IsPresent) {
         if ($HasToken) {
             $probeArgs += @("--token", $env:DPF_MCP_BEARER_TOKEN)
         }
+        $probeJson = $null
+        $probeExitCode = 0
+        $previousErrorActionPreference = $ErrorActionPreference
         try {
+            $ErrorActionPreference = "Continue"
             $probeJson = & pnpm @probeArgs 2>$null
-            if ($LASTEXITCODE -eq 0 -and $probeJson) {
-                $probeResult = $probeJson | ConvertFrom-Json
-                # ConvertFrom-Json returns PSCustomObject - re-serialize as
-                # nested hashtables so Set-DpfStateValue round-trips cleanly.
-                $mcpReadiness = $probeResult.mcpReadiness | ConvertTo-Json -Depth 6 -Compress | ConvertFrom-Json -AsHashtable
-                $smokeResult  = $probeResult.smokeTest    | ConvertTo-Json -Depth 6 -Compress | ConvertFrom-Json -AsHashtable
+            $probeExitCode = $LASTEXITCODE
+        } catch {
+            $probeExitCode = 1
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        try {
+            if ($probeExitCode -eq 0 -and $probeJson) {
+                $probeResult = ($probeJson -join "`n") | ConvertFrom-Json
+                $mcpReadiness = $probeResult.mcpReadiness
+                $smokeResult  = $probeResult.smokeTest
             } else {
-                Write-Warn2 "run-probes exited $LASTEXITCODE; recording probes as skipped."
+                Write-Warn2 "run-probes exited $probeExitCode; recording probes as skipped."
             }
         } catch {
             Write-Warn2 "run-probes invocation failed: $_"
@@ -375,14 +400,14 @@ if (-not $DryRun.IsPresent) {
 # probe-runner failure). Skipping is honest and surfaces in the state.
 if ($null -eq $mcpReadiness) {
     $mcpReadiness = if ($HasToken) {
-        @{ ok = $false; reason = "endpoint_unreachable"; httpStatus = $null }
+        @{ ok = $false; reason = "mcp-unavailable"; httpStatus = $null }
     } else {
         @{ ok = $false; reason = "no_token"; httpStatus = $null }
     }
 }
 if ($null -eq $smokeResult) {
-    $smokeResult = if (-not ($ClaudePresent -or $CodexPresent)) {
-        @{ result = "skipped"; reason = "claude_not_on_path" }
+    $smokeResult = if (-not ($ClaudePresent -or $CodexPresent -or $GrokPresent)) {
+        @{ result = "skipped"; reason = "no_cli_on_path" }
     } else {
         @{ result = "skipped"; reason = "no_token" }
     }
@@ -410,6 +435,10 @@ if (-not $claudeWired -and -not $codexWired -and -not $grokWired) {
 } elseif (-not $mcpReadiness.ok) {
     if ($mcpReadiness.reason -in @("no_token", "scope_insufficient")) {
         $state.readinessState = "missing_token"
+    } elseif ($mcpReadiness.reason -eq "portal-unavailable") {
+        $state.readinessState = "portal-unavailable"
+    } elseif ($mcpReadiness.reason -eq "mcp-unavailable") {
+        $state.readinessState = "mcp-unavailable"
     } elseif ($mcpReadiness.reason -in @("endpoint_unreachable", "unexpected_shape")) {
         $state.readinessState = "needs_refresh"
     } else {
@@ -435,6 +464,8 @@ $copyTable = @{
     "missing_cli"    = @{ message = "Install the selected agent client to enable contributor sessions.";                 primaryAction = "Open setup guide" }
     "missing_token"  = @{ message = "DPF MCP needs a development token before agents can use governed tools.";           primaryAction = "Issue development token" }
     "needs_refresh"  = @{ message = "A token exists, but the running client has not picked it up yet.";                  primaryAction = "Refresh client binding" }
+    "portal-unavailable" = @{ message = "The portal is rebooting; I can still repair local agent tooling and will sync evidence when it comes back."; primaryAction = "Continue local repair" }
+    "mcp-unavailable"    = @{ message = "DPF coordination is unavailable; I can still repair local agent tooling and will sync evidence when it returns."; primaryAction = "Continue local repair" }
     "failed_smoke"   = @{ message = "The agent is installed but did not apply a DPF kernel principle.";                  primaryAction = "View evidence" }
 }
 $copy = $copyTable[$state.readinessState]

--- a/scripts/dpf-bootstrap-agent-toolchain.sh
+++ b/scripts/dpf-bootstrap-agent-toolchain.sh
@@ -614,7 +614,7 @@ fi
 
 if [ -z "$MCP_READINESS" ]; then
   if [ $HAS_TOKEN -eq 1 ]; then
-    MCP_READINESS='{"ok": false, "reason": "endpoint_unreachable", "httpStatus": null}'
+    MCP_READINESS='{"ok": false, "reason": "mcp-unavailable", "httpStatus": null}'
   else
     MCP_READINESS='{"ok": false, "reason": "no_token", "httpStatus": null}'
   fi
@@ -644,6 +644,8 @@ if [ "$CLAUDE_WIRED" -eq 0 ] && [ "$CODEX_WIRED" -eq 0 ] && [ "$GROK_WIRED" -eq 
 elif [ "$MCP_OK" != "True" ]; then
   case "$MCP_REASON" in
     no_token|scope_insufficient) FINAL_STATE="missing_token" ;;
+    portal-unavailable)          FINAL_STATE="portal-unavailable" ;;
+    mcp-unavailable)             FINAL_STATE="mcp-unavailable" ;;
     endpoint_unreachable|unexpected_shape) FINAL_STATE="needs_refresh" ;;
     *)                                     FINAL_STATE="needs_refresh" ;;
   esac
@@ -688,6 +690,8 @@ case "$FINAL_STATE" in
   missing_cli)   BANNER_MSG="Install the selected agent client to enable contributor sessions.";                 BANNER_ACTION="Open setup guide" ;;
   missing_token) BANNER_MSG="DPF MCP needs a development token before agents can use governed tools.";           BANNER_ACTION="Issue development token" ;;
   needs_refresh) BANNER_MSG="A token exists, but the running client has not picked it up yet.";                  BANNER_ACTION="Refresh client binding" ;;
+  portal-unavailable) BANNER_MSG="The portal is rebooting; I can still repair local agent tooling and will sync evidence when it comes back."; BANNER_ACTION="Continue local repair" ;;
+  mcp-unavailable) BANNER_MSG="DPF coordination is unavailable; I can still repair local agent tooling and will sync evidence when it returns."; BANNER_ACTION="Continue local repair" ;;
   failed_smoke)  BANNER_MSG="The agent is installed but did not apply a DPF kernel principle.";                  BANNER_ACTION="View evidence" ;;
 esac
 

--- a/scripts/installer/install-state.schema.json
+++ b/scripts/installer/install-state.schema.json
@@ -151,7 +151,14 @@
                 "ok": { "const": false },
                 "reason": {
                   "type": "string",
-                  "enum": ["no_token", "endpoint_unreachable", "scope_insufficient", "unexpected_shape"]
+                  "enum": [
+                    "no_token",
+                    "portal-unavailable",
+                    "mcp-unavailable",
+                    "endpoint_unreachable",
+                    "scope_insufficient",
+                    "unexpected_shape"
+                  ]
                 },
                 "httpStatus": { "type": ["integer", "null"] }
               },
@@ -188,7 +195,7 @@
                 "result": { "const": "skipped" },
                 "reason": {
                   "type": "string",
-                  "enum": ["claude_not_on_path", "codex_not_on_path", "no_token"]
+                  "enum": ["claude_not_on_path", "codex_not_on_path", "grok_not_on_path", "no_cli_on_path", "no_token"]
                 }
               },
               "additionalProperties": false
@@ -197,7 +204,16 @@
         },
         "readinessState": {
           "type": "string",
-          "enum": ["ready", "partial", "missing_cli", "missing_token", "needs_refresh", "failed_smoke"]
+          "enum": [
+            "ready",
+            "partial",
+            "missing_cli",
+            "missing_token",
+            "needs_refresh",
+            "portal-unavailable",
+            "mcp-unavailable",
+            "failed_smoke"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary
- Teach agent-toolchain preflight to distinguish portal reboot/unreachable from MCP-route unavailable, then continue local plugin/config/memory repair instead of treating coordination as a hard stop.
- Add a local evidence-envelope queue/reconcile contract for later MCP reconciliation when evidence cannot be written immediately.
- Harden Windows/POSIX bootstrap adapters, BOM-tolerant CLI config parsing, schema/docs, and regression coverage for portal-down, MCP-down, missing token, missing plugin, and reconcile paths.

## Test plan
- [x] `pnpm --filter @dpf/bootstrap exec vitest run src/agent-toolchain/__tests__` — 15 files / 147 tests passed
- [x] `pnpm --filter @dpf/bootstrap typecheck` — passed
- [x] `python -m unittest packages.dpf-skill-pack.scripts.update_agent_toolchain_test` — 3 tests passed
- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dpf-bootstrap-agent-toolchain.ps1 -DryRun -ShowSubstrate` — passed, emitted MCP-UNAVAILABLE local-repair banner
- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dpf-bootstrap-agent-toolchain.ps1 -ShowSubstrate` — completed local repair; MCP tools/list ok=true, toolCount=180; final smoke state failed because local Claude CLI returned 401 auth
- [x] `pnpm --filter web build` — passed under local-integration-ci lease NPEL-5D6C266513; existing Turbopack Edge/NFT warnings only
- [x] `git diff --check` / `git diff --cached --check` — passed; Git reported expected PS1 line-ending normalization warning only

Linked BI: BI-E29B44F9

Operational note: the live host's actual bootstrap now completes, but its final readiness is `failed_smoke` because Claude CLI authentication is invalid in this environment. MCP itself is reachable and returned 180 tools; the auth issue is captured as evidence on BI-E29B44F9 and is not a portal/MCP availability blocker.