### PR TITLE
Implement Work Case Wave 1 enforcement spine

### DIFF
--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -511,3 +511,113 @@ describe("governedExecuteTool — coworker read-baseline at execution time", () 
     expect(executeMock).not.toHaveBeenCalled();
   });
 });
+
+describe("governedExecuteTool — Work Case receipt context", () => {
+  const WORK_CASE_CONTEXT = {
+    caseRef: {
+      caseId: "backlog-item:BI-1",
+      sourceType: "backlog-item",
+      sourceId: "BI-1",
+    },
+    sourceKey: "backlog-item",
+    action: "complete",
+    currentState: {
+      state: "active",
+      terminal: false,
+    },
+    envelope: {
+      autonomyMode: "autonomous",
+      receiptPolicy: {
+        required: true,
+        kind: "governed-action",
+      },
+    },
+  } as const;
+
+  it("does not mint a Work Case receipt when context.workCase is absent", async () => {
+    await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      source: "rest",
+    });
+
+    expect(receiptRows).toHaveLength(0);
+  });
+
+  it("mints a governed Work Case receipt for successful consequential actions", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_write"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: async (data: AuditRow) => {
+        auditRows.push(data);
+        return { id: "tool-exec-work-case-1" };
+      },
+      toolExecutionReceiptCreate: captureAudit(receiptRows),
+    });
+
+    await governedExecuteTool({
+      toolName: "update_backlog_item_status",
+      rawParams: { itemId: "BI-1", status: "done" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: {
+        workCase: WORK_CASE_CONTEXT,
+      },
+      source: "external-jsonrpc",
+    });
+
+    expect(receiptRows).toHaveLength(1);
+    expect(receiptRows[0]).toEqual(
+      expect.objectContaining({
+        buildId: null,
+        executionStatus: "succeeded",
+        receiptKind: "work-case-governed-action",
+        receiptStatus: "valid",
+        toolExecutionId: "tool-exec-work-case-1",
+      }),
+    );
+  });
+
+  it("mints an invalid governed Work Case receipt for failed consequential actions", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_write"],
+      isAllowedByGrants: () => true,
+      executeTool: vi.fn(
+        async (): Promise<ToolResult> => ({
+          success: false,
+          error: "failed",
+          message: "could not update",
+        }),
+      ) as ReturnType<typeof vi.fn> & ExecuteFn,
+      toolExecutionCreate: async (data: AuditRow) => {
+        auditRows.push(data);
+        return { id: "tool-exec-work-case-2" };
+      },
+      toolExecutionReceiptCreate: captureAudit(receiptRows),
+    });
+
+    await governedExecuteTool({
+      toolName: "update_backlog_item_status",
+      rawParams: { itemId: "BI-1", status: "done" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: {
+        workCase: WORK_CASE_CONTEXT,
+      },
+      source: "external-jsonrpc",
+    });
+
+    expect(receiptRows).toHaveLength(1);
+    expect(receiptRows[0]).toEqual(
+      expect.objectContaining({
+        executionStatus: "failed",
+        receiptKind: "work-case-governed-action",
+        receiptStatus: "invalid",
+        toolExecutionId: "tool-exec-work-case-2",
+      }),
+    );
+  });
+});

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -18,6 +18,8 @@ import {
 } from "./mcp-tools";
 import { coerceMcpToolArgs } from "./mcp-arg-coercion";
 import { deriveAuditClassForTool, deriveCapabilityId } from "./tool-audit-helpers";
+import { getWorkCaseAction } from "./work-management/action-registry";
+import type { WorkCaseExecutionContext } from "./work-management/work-case-governance-hook";
 
 export type GovernedExecuteSource =
   | "rest"
@@ -61,6 +63,12 @@ export type GovernedExecuteContext = {
    * gate, so honouring it here never escalates beyond what the operator may see.
    */
   coworkerReadBaseline?: boolean;
+  /**
+   * Optional Work Case context for consequential actions flowing through the
+   * governed execution seam. Existing callers omit this and retain their
+   * current audit/receipt behavior.
+   */
+  workCase?: WorkCaseExecutionContext;
 };
 
 export type GovernedExecuteArgs = {
@@ -85,7 +93,7 @@ export type GovernedExecuteResult = ToolResult & {
   };
 };
 
-type ToolLifecycleEvent = {
+export type ToolLifecycleEvent = {
   toolName: string;
   rawParams: Record<string, unknown>;
   userId: string;
@@ -94,12 +102,12 @@ type ToolLifecycleEvent = {
   source: GovernedExecuteSource;
 };
 
-type ToolLifecyclePostEvent = ToolLifecycleEvent & {
+export type ToolLifecyclePostEvent = ToolLifecycleEvent & {
   result: ToolResult;
   durationMs: number;
 };
 
-type ToolLifecycleDecision =
+export type ToolLifecycleDecision =
   | { decision: "allow"; reason?: string }
   | { decision: "deny"; reason: string };
 
@@ -256,7 +264,17 @@ async function writeAudit(data: {
   }
 }
 
-function deriveReceiptKind(toolName: string): string | null {
+function deriveReceiptKind(
+  toolName: string,
+  context?: GovernedExecuteContext,
+): string | null {
+  if (context?.workCase) {
+    const action = getWorkCaseAction(context.workCase.action);
+    if (action?.consequential) {
+      return "work-case-governed-action";
+    }
+  }
+
   switch (toolName) {
     case "run_sandbox_tests":
       return "sandbox-test-run";
@@ -286,18 +304,19 @@ void createHash;
 
 async function writeReceipt(data: {
   auditRowId: string;
-  buildId: string;
+  buildId: string | null;
   rawParams: Record<string, unknown>;
   result: ToolResult;
   toolName: string;
+  context?: GovernedExecuteContext;
 }): Promise<void> {
-  const receiptKind = deriveReceiptKind(data.toolName);
+  const receiptKind = deriveReceiptKind(data.toolName, data.context);
   if (!receiptKind) {
     return;
   }
 
   const row = {
-    buildId: data.buildId,
+    buildId: data.buildId ?? null,
     executionStatus: data.result.success ? "succeeded" : "failed",
     expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
     inputFingerprint: digestPayload({
@@ -531,13 +550,15 @@ export async function governedExecuteTool(
     && typeof (result.data as Record<string, unknown>).buildId === "string"
       ? String((result.data as Record<string, unknown>).buildId)
       : null;
-  if (auditRow?.id && resultBuildId) {
+  const shouldWriteReceipt = Boolean(resultBuildId || args.context?.workCase);
+  if (auditRow?.id && shouldWriteReceipt) {
     await writeReceipt({
       auditRowId: auditRow.id,
       buildId: resultBuildId,
       rawParams: args.rawParams,
       result,
       toolName: args.toolName,
+      context: args.context,
     });
   }
 

--- a/apps/web/lib/work-management/action-registry.test.ts
+++ b/apps/web/lib/work-management/action-registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WORK_CASE_ACTION_REGISTRY,
+  getWorkCaseAction,
+} from "./action-registry";
+import { WORK_CASE_SOURCE_REGISTRY } from "./source-registry";
+
+describe("Work Case action registry", () => {
+  it("defines the full handoff grammar from the spec", () => {
+    expect(WORK_CASE_ACTION_REGISTRY.map((entry) => entry.action)).toEqual([
+      "claim",
+      "pause",
+      "needs-input",
+      "needs-auth",
+      "respond",
+      "resume",
+      "propose",
+      "delegate",
+      "handoff",
+      "escalate",
+      "verify",
+      "complete",
+      "cancel",
+    ]);
+  });
+
+  it("marks consequential actions as policy and receipt gated", () => {
+    for (const action of [
+      "claim",
+      "delegate",
+      "handoff",
+      "verify",
+      "complete",
+      "cancel",
+    ]) {
+      expect(getWorkCaseAction(action)).toMatchObject({
+        consequential: true,
+        requiresPolicyEvaluation: true,
+        requiresReceipt: true,
+      });
+    }
+  });
+
+  it("keeps every source-registry transition backed by a registered action", () => {
+    for (const source of WORK_CASE_SOURCE_REGISTRY) {
+      for (const transition of source.supportedTransitions) {
+        expect(
+          getWorkCaseAction(transition),
+          `${source.sourceKey}:${transition}`,
+        ).toBeTruthy();
+      }
+    }
+  });
+});

--- a/apps/web/lib/work-management/action-registry.ts
+++ b/apps/web/lib/work-management/action-registry.ts
@@ -1,0 +1,180 @@
+import {
+  WORK_CASE_ACTION_VERBS,
+  type WorkCaseA2aStatus,
+  type WorkCaseActionVerb,
+} from "./case-types";
+
+export type WorkCaseCoworkerEnvelopeRequirement =
+  | "never"
+  | "when-supervised"
+  | "always";
+
+export interface WorkCaseActionDescriptor {
+  action: WorkCaseActionVerb;
+  displayLabel: string;
+  a2aStatusHint?: WorkCaseA2aStatus;
+  consequential: boolean;
+  requiresPolicyEvaluation: boolean;
+  requiresDecisionInteraction: boolean;
+  requiresCoworkerEnvelope: WorkCaseCoworkerEnvelopeRequirement;
+  requiresReceipt: boolean;
+  sanctionedMutators: readonly string[];
+}
+
+export const WORK_CASE_ACTION_REGISTRY = [
+  {
+    action: "claim",
+    displayLabel: "Claim",
+    a2aStatusHint: "working",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "never",
+    requiresReceipt: true,
+    sanctionedMutators: ["claim_capsule_scope", "update_backlog_item_status"],
+  },
+  {
+    action: "pause",
+    displayLabel: "Pause",
+    a2aStatusHint: "working",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "never",
+    requiresReceipt: true,
+    sanctionedMutators: ["update_work_capsule_status", "update_backlog_item_status"],
+  },
+  {
+    action: "needs-input",
+    displayLabel: "Needs input",
+    a2aStatusHint: "input-required",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "when-supervised",
+    requiresReceipt: true,
+    sanctionedMutators: ["screen_propose_action", "WorkItemMessage"],
+  },
+  {
+    action: "needs-auth",
+    displayLabel: "Needs authorization",
+    a2aStatusHint: "auth-required",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: true,
+    requiresCoworkerEnvelope: "always",
+    requiresReceipt: true,
+    sanctionedMutators: ["screen_propose_action"],
+  },
+  {
+    action: "respond",
+    displayLabel: "Respond",
+    a2aStatusHint: "working",
+    consequential: false,
+    requiresPolicyEvaluation: false,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "never",
+    requiresReceipt: false,
+    sanctionedMutators: ["WorkItemMessage"],
+  },
+  {
+    action: "resume",
+    displayLabel: "Resume",
+    a2aStatusHint: "working",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "never",
+    requiresReceipt: true,
+    sanctionedMutators: ["update_work_capsule_status", "update_backlog_item_status"],
+  },
+  {
+    action: "propose",
+    displayLabel: "Propose action",
+    a2aStatusHint: "input-required",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "always",
+    requiresReceipt: true,
+    sanctionedMutators: ["screen_propose_action"],
+  },
+  {
+    action: "delegate",
+    displayLabel: "Delegate",
+    a2aStatusHint: "working",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "when-supervised",
+    requiresReceipt: true,
+    sanctionedMutators: ["screen_propose_action"],
+  },
+  {
+    action: "handoff",
+    displayLabel: "Handoff",
+    a2aStatusHint: "working",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "when-supervised",
+    requiresReceipt: true,
+    sanctionedMutators: ["screen_propose_action"],
+  },
+  {
+    action: "escalate",
+    displayLabel: "Escalate",
+    a2aStatusHint: "input-required",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: true,
+    requiresCoworkerEnvelope: "always",
+    requiresReceipt: true,
+    sanctionedMutators: ["record_execution_evidence", "DecisionInteraction"],
+  },
+  {
+    action: "verify",
+    displayLabel: "Verify",
+    a2aStatusHint: "working",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "never",
+    requiresReceipt: true,
+    sanctionedMutators: ["run_sandbox_tests", "run_ux_test", "record_capsule_evidence"],
+  },
+  {
+    action: "complete",
+    displayLabel: "Complete",
+    a2aStatusHint: "completed",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "never",
+    requiresReceipt: true,
+    sanctionedMutators: ["update_work_capsule_status", "update_backlog_item_status"],
+  },
+  {
+    action: "cancel",
+    displayLabel: "Cancel",
+    a2aStatusHint: "canceled",
+    consequential: true,
+    requiresPolicyEvaluation: true,
+    requiresDecisionInteraction: false,
+    requiresCoworkerEnvelope: "never",
+    requiresReceipt: true,
+    sanctionedMutators: ["update_work_capsule_status", "update_backlog_item_status"],
+  },
+] as const satisfies readonly WorkCaseActionDescriptor[];
+
+const WORK_CASE_ACTIONS_BY_VERB = new Map<WorkCaseActionVerb, WorkCaseActionDescriptor>(
+  WORK_CASE_ACTION_REGISTRY.map((entry) => [entry.action, entry]),
+);
+
+export function getWorkCaseAction(
+  action: string | null | undefined,
+): WorkCaseActionDescriptor | null {
+  const normalized = action?.trim() as WorkCaseActionVerb | undefined;
+  if (!normalized || !WORK_CASE_ACTION_VERBS.includes(normalized)) return null;
+  return WORK_CASE_ACTIONS_BY_VERB.get(normalized) ?? null;
+}

--- a/apps/web/lib/work-management/architecture-grounding.test.ts
+++ b/apps/web/lib/work-management/architecture-grounding.test.ts
@@ -4,10 +4,16 @@ import {
   WORK_CASE_ARCHITECTURE_ALLOCATIONS,
   WORK_CASE_ARCHITECTURE_ELEMENTS,
   getWorkCaseRequirementVerificationPairs,
+  type WorkCaseArchitectureElement,
 } from "./architecture-grounding";
+import { WORK_CASE_ACTION_VERBS } from "./case-types";
+
+const elementById = new Map<string, WorkCaseArchitectureElement>(
+  WORK_CASE_ARCHITECTURE_ELEMENTS.map((element) => [element.elementId, element]),
+);
 
 describe("Work Case architecture grounding manifest", () => {
-  it("allocates every Wave 0 work-management source file into the EA/SysML graph", () => {
+  it("allocates every Wave 0 and Wave 1 work-management source file into the EA/SysML graph", () => {
     const allocatedFiles = new Set(
       WORK_CASE_ARCHITECTURE_ALLOCATIONS.map((allocation) => allocation.targetRef),
     );
@@ -19,6 +25,12 @@ describe("Work Case architecture grounding manifest", () => {
         "apps/web/lib/work-management/status-projection.ts",
         "apps/web/lib/work-management/case-read-model.ts",
         "apps/web/lib/work-management/architecture-grounding.ts",
+        "apps/web/lib/work-management/action-registry.ts",
+        "apps/web/lib/work-management/policy-envelope.ts",
+        "apps/web/lib/work-management/receipt-envelope.ts",
+        "apps/web/lib/work-management/receipt-coverage.ts",
+        "apps/web/lib/work-management/case-telemetry.ts",
+        "apps/web/lib/work-management/work-case-governance-hook.ts",
       ]),
     );
   });
@@ -42,6 +54,31 @@ describe("Work Case architecture grounding manifest", () => {
 
     expect(pairs.map((pair) => pair.requirementId).sort()).toEqual(requirementIds);
     expect(pairs.every((pair) => pair.verificationCaseId.startsWith("VC-WC-"))).toBe(true);
+  });
+
+  it("grounds Wave 1 requirements in implemented or partially implemented verification cases", () => {
+    for (const requirementId of ["REQ-WC-1", "REQ-WC-2"]) {
+      const requirement = elementById.get(requirementId);
+      expect(requirement?.implementationStatus).toMatch(/^(implemented|partially-implemented)$/);
+
+      const verificationCase = elementById.get(requirement?.verificationCaseId ?? "");
+      expect(verificationCase?.elementType).toBe("verification_case");
+      expect(verificationCase?.implementationStatus).toMatch(
+        /^(implemented|partially-implemented)$/,
+      );
+    }
+  });
+
+  it("declares EA Action elements for the Work Case handoff grammar", () => {
+    const actionIds = WORK_CASE_ARCHITECTURE_ELEMENTS
+      .filter((element) => element.elementType === "action")
+      .map((element) => element.elementId);
+
+    expect(actionIds).toEqual(
+      expect.arrayContaining(
+        WORK_CASE_ACTION_VERBS.map((action) => `ACT-WC-${action}`),
+      ),
+    );
   });
 
   it("anchors the Wave 0 slice to IT4IT streams already supported by the EA substrate", () => {

--- a/apps/web/lib/work-management/architecture-grounding.ts
+++ b/apps/web/lib/work-management/architecture-grounding.ts
@@ -1,3 +1,5 @@
+import { WORK_CASE_ACTION_REGISTRY } from "./action-registry";
+
 export type WorkCaseArchitectureElementType =
   | "requirement"
   | "action"
@@ -30,13 +32,23 @@ export interface WorkCaseArchitectureAllocation {
   targetRef: string;
 }
 
+const WORK_CASE_ACTION_ARCHITECTURE_ELEMENTS =
+  WORK_CASE_ACTION_REGISTRY.map((action) => ({
+    elementId: `ACT-WC-${action.action}`,
+    elementType: "action",
+    name: action.displayLabel,
+    description: `Governed Work Case handoff action '${action.action}' backed by the action registry.`,
+    implementationStatus: "implemented",
+    itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
+  })) satisfies readonly WorkCaseArchitectureElement[];
+
 export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
   {
     elementId: "REQ-WC-1",
     elementType: "requirement",
     name: "Governed write path",
     description: "Consequential Work Case transitions mutate only through governed Actions.",
-    implementationStatus: "planned",
+    implementationStatus: "partially-implemented",
     itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
     verificationCaseId: "VC-WC-1",
   },
@@ -45,7 +57,7 @@ export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
     elementType: "requirement",
     name: "Receipt coverage and sealing",
     description: "Every consequential transition emits a receipt and terminal cases are sealed.",
-    implementationStatus: "planned",
+    implementationStatus: "partially-implemented",
     itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
     verificationCaseId: "VC-WC-2",
   },
@@ -108,6 +120,7 @@ export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
     implementationStatus: "implemented",
     itValueStreams: ["operate", "consume", "integrate"],
   },
+  ...WORK_CASE_ACTION_ARCHITECTURE_ELEMENTS,
   {
     elementId: "PART-WC-source-registry",
     elementType: "part_definition",
@@ -125,6 +138,38 @@ export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
     itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
   },
   {
+    elementId: "PART-WC-action-registry",
+    elementType: "part_definition",
+    name: "Work Case action registry",
+    description: "Canonical handoff grammar and consequential-action metadata for governed transitions.",
+    implementationStatus: "implemented",
+    itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
+  },
+  {
+    elementId: "PART-WC-policy-envelope",
+    elementType: "part_definition",
+    name: "Work Case policy envelope",
+    description: "Pure policy evaluator for source support, terminal sealing, decisions, staging, and receipts.",
+    implementationStatus: "implemented",
+    itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
+  },
+  {
+    elementId: "PART-WC-receipt-envelope",
+    elementType: "part_definition",
+    name: "Work Case receipt envelope",
+    description: "Projection envelope that normalizes governed receipts and observed substrate events.",
+    implementationStatus: "implemented",
+    itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
+  },
+  {
+    elementId: "PART-WC-case-telemetry",
+    elementType: "part_definition",
+    name: "Work Case telemetry projection",
+    description: "OTel-compatible event projection for receipt-backed Work Case actions.",
+    implementationStatus: "implemented",
+    itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
+  },
+  {
     elementId: "IF-WC-agentcard",
     elementType: "interface_definition",
     name: "AgentCard-compatible capability descriptor",
@@ -136,16 +181,16 @@ export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
     elementId: "VC-WC-1",
     elementType: "verification_case",
     name: "Governed write path receipt guard",
-    description: "Future guard proving consequential transitions cannot bypass governed Actions.",
-    implementationStatus: "planned",
+    description: "Tests proving optional Work Case context is policy-checked and can emit governed receipts.",
+    implementationStatus: "partially-implemented",
     itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
   },
   {
     elementId: "VC-WC-2",
     elementType: "verification_case",
     name: "Receipt coverage and sealing verification",
-    description: "Future guard proving receipts are emitted and terminal cases are sealed.",
-    implementationStatus: "planned",
+    description: "Pure guard tests proving consequential actions require governed receipts and terminal cases are sealed.",
+    implementationStatus: "implemented",
     itValueStreams: ["operate", "consume", "integrate", "deploy", "release"],
   },
   {
@@ -198,6 +243,42 @@ export const WORK_CASE_ARCHITECTURE_ALLOCATIONS = [
     relationshipType: "sysml_allocates",
     targetKind: "source_file",
     targetRef: "apps/web/lib/work-management/case-read-model.ts",
+  },
+  {
+    sourceElementId: "PART-WC-action-registry",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/lib/work-management/action-registry.ts",
+  },
+  {
+    sourceElementId: "PART-WC-policy-envelope",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/lib/work-management/policy-envelope.ts",
+  },
+  {
+    sourceElementId: "PART-WC-receipt-envelope",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/lib/work-management/receipt-envelope.ts",
+  },
+  {
+    sourceElementId: "VC-WC-2",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/lib/work-management/receipt-coverage.ts",
+  },
+  {
+    sourceElementId: "PART-WC-case-telemetry",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/lib/work-management/case-telemetry.ts",
+  },
+  {
+    sourceElementId: "VC-WC-1",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/lib/work-management/work-case-governance-hook.ts",
   },
   {
     sourceElementId: "REQ-WC-4",

--- a/apps/web/lib/work-management/case-telemetry.test.ts
+++ b/apps/web/lib/work-management/case-telemetry.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReceiptEnvelope } from "./receipt-envelope";
+import { projectReceiptEnvelopeEvent } from "./case-telemetry";
+
+const RECEIPT = {
+  receiptId: "ter-1",
+  caseRef: {
+    caseId: "backlog-item:BI-1",
+    sourceType: "backlog-item",
+    sourceId: "BI-1",
+  },
+  receiptKind: "work-case-governed-action",
+  enforcementMode: "governed-action",
+  sourceRef: {
+    kind: "source",
+    id: "te-1",
+    sourceType: "tool-execution",
+  },
+  actionType: "complete",
+  status: "valid",
+  summary: "work-case-governed-action valid for te-1",
+  occurredAt: "2026-06-27T21:00:00.000Z",
+  outputDigest: { ok: true },
+  policyRefs: ["golden-triangle:assured"],
+  trace: {
+    traceId: "trace-1",
+    spanId: "span-1",
+    parentSpanId: "parent-1",
+  },
+  rawRef: {
+    table: "ToolExecutionReceipt",
+    id: "ter-1",
+  },
+} as const satisfies ReceiptEnvelope;
+
+describe("projectReceiptEnvelopeEvent", () => {
+  it("projects a ReceiptEnvelope to a stable OTel-compatible event", () => {
+    expect(projectReceiptEnvelopeEvent(RECEIPT)).toEqual({
+      name: "work_case.action",
+      occurredAt: "2026-06-27T21:00:00.000Z",
+      traceId: "trace-1",
+      spanId: "span-1",
+      parentSpanId: "parent-1",
+      attributes: {
+        "work_case.id": "backlog-item:BI-1",
+        "work_case.source_type": "backlog-item",
+        "work_case.action": "complete",
+        "work_case.enforcement_mode": "governed-action",
+        "work_case.receipt.id": "ter-1",
+        "work_case.receipt.kind": "work-case-governed-action",
+        "work_case.receipt.status": "valid",
+        "work_case.source.kind": "source",
+        "work_case.source.id": "te-1",
+        "work_case.source.ref_type": "tool-execution",
+        "work_case.raw.table": "ToolExecutionReceipt",
+        "work_case.raw.id": "ter-1",
+      },
+    });
+  });
+});

--- a/apps/web/lib/work-management/case-telemetry.ts
+++ b/apps/web/lib/work-management/case-telemetry.ts
@@ -1,0 +1,49 @@
+import type { ReceiptEnvelope } from "./receipt-envelope";
+
+export type WorkCaseTelemetryAttributeValue = string | number | boolean;
+
+export interface WorkCaseTelemetryEvent {
+  name: "work_case.action";
+  occurredAt: string;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  attributes: Record<string, WorkCaseTelemetryAttributeValue>;
+}
+
+function setIfDefined(
+  attributes: Record<string, WorkCaseTelemetryAttributeValue>,
+  key: string,
+  value: string | undefined,
+) {
+  if (value) attributes[key] = value;
+}
+
+export function projectReceiptEnvelopeEvent(
+  receipt: ReceiptEnvelope,
+): WorkCaseTelemetryEvent {
+  const attributes: Record<string, WorkCaseTelemetryAttributeValue> = {
+    "work_case.id": receipt.caseRef?.caseId ?? receipt.sourceRef.id,
+    "work_case.action": receipt.actionType ?? "unknown",
+    "work_case.enforcement_mode": receipt.enforcementMode,
+    "work_case.receipt.id": receipt.receiptId,
+    "work_case.receipt.kind": receipt.receiptKind,
+    "work_case.receipt.status": receipt.status,
+    "work_case.source.kind": receipt.sourceRef.kind,
+    "work_case.source.id": receipt.sourceRef.id,
+    "work_case.raw.table": receipt.rawRef.table,
+    "work_case.raw.id": receipt.rawRef.id,
+  };
+
+  setIfDefined(attributes, "work_case.source_type", receipt.caseRef?.sourceType);
+  setIfDefined(attributes, "work_case.source.ref_type", receipt.sourceRef.sourceType);
+
+  return {
+    name: "work_case.action",
+    occurredAt: receipt.occurredAt,
+    traceId: receipt.trace?.traceId,
+    spanId: receipt.trace?.spanId,
+    parentSpanId: receipt.trace?.parentSpanId,
+    attributes,
+  };
+}

--- a/apps/web/lib/work-management/case-types.ts
+++ b/apps/web/lib/work-management/case-types.ts
@@ -23,6 +23,40 @@ export type WorkCaseA2aStatus =
   | "failed"
   | "rejected";
 
+export const WORK_CASE_ACTION_VERBS = [
+  "claim",
+  "pause",
+  "needs-input",
+  "needs-auth",
+  "respond",
+  "resume",
+  "propose",
+  "delegate",
+  "handoff",
+  "escalate",
+  "verify",
+  "complete",
+  "cancel",
+] as const;
+
+export type WorkCaseActionVerb = (typeof WORK_CASE_ACTION_VERBS)[number];
+
+export type WorkCaseEnforcementMode = "governed-action" | "observed-event";
+
+export interface WorkCaseRef {
+  caseId: string;
+  sourceType: string;
+  sourceId: string;
+}
+
+export type WorkCaseActorKind = "person" | "agent" | "system" | "external";
+
+export interface WorkCaseActorRef {
+  actorKind: WorkCaseActorKind;
+  actorId?: string;
+  displayName?: string;
+}
+
 export type WorkCaseBlockingActorKind =
   | "person"
   | "system"

--- a/apps/web/lib/work-management/index.ts
+++ b/apps/web/lib/work-management/index.ts
@@ -1,5 +1,6 @@
 export * from "./action-registry";
 export * from "./architecture-grounding";
+export * from "./case-telemetry";
 export * from "./case-read-model";
 export * from "./case-types";
 export * from "./policy-envelope";

--- a/apps/web/lib/work-management/index.ts
+++ b/apps/web/lib/work-management/index.ts
@@ -3,5 +3,6 @@ export * from "./architecture-grounding";
 export * from "./case-read-model";
 export * from "./case-types";
 export * from "./policy-envelope";
+export * from "./receipt-envelope";
 export * from "./source-registry";
 export * from "./status-projection";

--- a/apps/web/lib/work-management/index.ts
+++ b/apps/web/lib/work-management/index.ts
@@ -3,6 +3,7 @@ export * from "./architecture-grounding";
 export * from "./case-read-model";
 export * from "./case-types";
 export * from "./policy-envelope";
+export * from "./receipt-coverage";
 export * from "./receipt-envelope";
 export * from "./source-registry";
 export * from "./status-projection";

--- a/apps/web/lib/work-management/index.ts
+++ b/apps/web/lib/work-management/index.ts
@@ -2,5 +2,6 @@ export * from "./action-registry";
 export * from "./architecture-grounding";
 export * from "./case-read-model";
 export * from "./case-types";
+export * from "./policy-envelope";
 export * from "./source-registry";
 export * from "./status-projection";

--- a/apps/web/lib/work-management/index.ts
+++ b/apps/web/lib/work-management/index.ts
@@ -1,3 +1,4 @@
+export * from "./action-registry";
 export * from "./architecture-grounding";
 export * from "./case-read-model";
 export * from "./case-types";

--- a/apps/web/lib/work-management/index.ts
+++ b/apps/web/lib/work-management/index.ts
@@ -8,3 +8,4 @@ export * from "./receipt-coverage";
 export * from "./receipt-envelope";
 export * from "./source-registry";
 export * from "./status-projection";
+export * from "./work-case-governance-hook";

--- a/apps/web/lib/work-management/policy-envelope.test.ts
+++ b/apps/web/lib/work-management/policy-envelope.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateWorkCasePolicy } from "./policy-envelope";
+
+const CASE_REF = {
+  caseId: "backlog-item:BI-1",
+  sourceType: "backlog-item",
+  sourceId: "BI-1",
+} as const;
+
+const ACTIVE_STATE = {
+  state: "active",
+  terminal: false,
+} as const;
+
+const GOVERNED_ENVELOPE = {
+  autonomyMode: "autonomous",
+  receiptPolicy: {
+    required: true,
+    kind: "governed-action",
+  },
+} as const;
+
+describe("evaluateWorkCasePolicy", () => {
+  it("allows a supported non-terminal action with receipt policy present", () => {
+    expect(
+      evaluateWorkCasePolicy({
+        caseRef: CASE_REF,
+        sourceKey: "backlog-item",
+        action: "respond",
+        currentState: ACTIVE_STATE,
+        envelope: GOVERNED_ENVELOPE,
+      }),
+    ).toEqual({
+      ok: true,
+      enforcementMode: "governed-action",
+      requiredReceiptKind: "governed-action",
+    });
+  });
+
+  it("denies unsupported source and action combinations", () => {
+    expect(
+      evaluateWorkCasePolicy({
+        caseRef: { ...CASE_REF, sourceType: "scheduled" },
+        sourceKey: "scheduled",
+        action: "handoff",
+        currentState: ACTIVE_STATE,
+        envelope: GOVERNED_ENVELOPE,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "unsupported_transition",
+    });
+  });
+
+  it("denies consequential actions on terminal cases", () => {
+    expect(
+      evaluateWorkCasePolicy({
+        caseRef: CASE_REF,
+        sourceKey: "backlog-item",
+        action: "complete",
+        currentState: { state: "closed", terminal: true },
+        envelope: GOVERNED_ENVELOPE,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "terminal_case_sealed",
+    });
+  });
+
+  it("denies supervised consequential actions without an approved coworker envelope", () => {
+    expect(
+      evaluateWorkCasePolicy({
+        caseRef: CASE_REF,
+        sourceKey: "backlog-item",
+        action: "delegate",
+        currentState: ACTIVE_STATE,
+        envelope: {
+          ...GOVERNED_ENVELOPE,
+          autonomyMode: "supervised",
+        },
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "missing_coworker_envelope",
+    });
+  });
+
+  it("denies actions when a stop condition is tripped", () => {
+    expect(
+      evaluateWorkCasePolicy({
+        caseRef: CASE_REF,
+        sourceKey: "backlog-item",
+        action: "claim",
+        currentState: ACTIVE_STATE,
+        envelope: GOVERNED_ENVELOPE,
+        stopConditions: [
+          {
+            stopId: "STOP-auth-expired",
+            tripped: true,
+            reason: "Authorization expired.",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "stop_condition_tripped",
+    });
+  });
+
+  it("denies consequential decision actions when decisionInteractionId is missing", () => {
+    expect(
+      evaluateWorkCasePolicy({
+        caseRef: CASE_REF,
+        sourceKey: "backlog-item",
+        action: "escalate",
+        currentState: ACTIVE_STATE,
+        envelope: GOVERNED_ENVELOPE,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "missing_decision_interaction",
+    });
+  });
+
+  it("allows observed external events and marks the enforcement mode", () => {
+    expect(
+      evaluateWorkCasePolicy({
+        caseRef: {
+          caseId: "engagement:ENG-1",
+          sourceType: "engagement",
+          sourceId: "ENG-1",
+        },
+        sourceKey: "engagement",
+        action: "respond",
+        currentState: ACTIVE_STATE,
+        envelope: {
+          autonomyMode: "observed",
+          receiptPolicy: {
+            required: false,
+            kind: "observed-event",
+          },
+        },
+        observedEvent: true,
+      }),
+    ).toEqual({
+      ok: true,
+      enforcementMode: "observed-event",
+      requiredReceiptKind: "observed-event",
+    });
+  });
+});

--- a/apps/web/lib/work-management/policy-envelope.ts
+++ b/apps/web/lib/work-management/policy-envelope.ts
@@ -1,0 +1,162 @@
+import type { EnvelopeStatus } from "../coworker/envelope-state-machine";
+import { getWorkCaseAction } from "./action-registry";
+import type {
+  WorkCaseActionVerb,
+  WorkCaseEnforcementMode,
+  WorkCaseRef,
+  WorkCaseState,
+} from "./case-types";
+import {
+  getWorkCaseSourceEntry,
+  type WorkCaseReceiptKind,
+} from "./source-registry";
+
+export type WorkCaseAutonomyMode = "autonomous" | "supervised" | "observed";
+
+export interface WorkCasePolicyEnvelope {
+  autonomyMode: WorkCaseAutonomyMode;
+  receiptPolicy?: {
+    required: boolean;
+    kind: WorkCaseReceiptKind;
+  };
+  sensitivityCeiling?: "low" | "medium" | "high" | "critical";
+}
+
+export interface WorkCaseStopCondition {
+  stopId: string;
+  tripped: boolean;
+  reason?: string;
+}
+
+export interface WorkCasePolicyInput {
+  caseRef: WorkCaseRef;
+  sourceKey?: string | null;
+  action: WorkCaseActionVerb | string;
+  currentState: Pick<{ state: WorkCaseState; terminal: boolean }, "state" | "terminal">;
+  envelope: WorkCasePolicyEnvelope;
+  coworkerEnvelope?: {
+    envelopeId: string;
+    status: EnvelopeStatus;
+  } | null;
+  decisionInteractionId?: string | null;
+  stopConditions?: readonly WorkCaseStopCondition[];
+  observedEvent?: boolean;
+}
+
+export type WorkCasePolicyDenialReason =
+  | "unknown_source"
+  | "unknown_action"
+  | "unsupported_transition"
+  | "terminal_case_sealed"
+  | "missing_receipt_policy"
+  | "stop_condition_tripped"
+  | "missing_decision_interaction"
+  | "missing_coworker_envelope"
+  | "coworker_envelope_not_approved";
+
+export type WorkCasePolicyDecision =
+  | {
+      ok: true;
+      enforcementMode: WorkCaseEnforcementMode;
+      requiredReceiptKind: WorkCaseReceiptKind;
+    }
+  | {
+      ok: false;
+      reason: WorkCasePolicyDenialReason;
+      message: string;
+    };
+
+function deny(
+  reason: WorkCasePolicyDenialReason,
+  message: string,
+): WorkCasePolicyDecision {
+  return { ok: false, reason, message };
+}
+
+function requiresApprovedCoworkerEnvelope(input: WorkCasePolicyInput): boolean {
+  const action = getWorkCaseAction(input.action);
+  if (!action) return false;
+  if (action.requiresCoworkerEnvelope === "always") return true;
+  return (
+    action.requiresCoworkerEnvelope === "when-supervised" &&
+    input.envelope.autonomyMode === "supervised"
+  );
+}
+
+export function evaluateWorkCasePolicy(
+  input: WorkCasePolicyInput,
+): WorkCasePolicyDecision {
+  const sourceKey = input.sourceKey ?? input.caseRef.sourceType;
+  const source = getWorkCaseSourceEntry(sourceKey);
+  if (!source) {
+    return deny("unknown_source", `Work Case source '${sourceKey}' is not registered.`);
+  }
+
+  const action = getWorkCaseAction(input.action);
+  if (!action) {
+    return deny("unknown_action", `Work Case action '${input.action}' is not registered.`);
+  }
+
+  if (!source.supportedTransitions.includes(action.action)) {
+    return deny(
+      "unsupported_transition",
+      `${source.sourceKey} does not support Work Case action '${action.action}'.`,
+    );
+  }
+
+  if (action.consequential && input.currentState.terminal) {
+    return deny(
+      "terminal_case_sealed",
+      `Work Case ${input.caseRef.caseId} is terminal and cannot accept consequential action '${action.action}'.`,
+    );
+  }
+
+  const trippedStop = input.stopConditions?.find((condition) => condition.tripped);
+  if (trippedStop) {
+    return deny(
+      "stop_condition_tripped",
+      trippedStop.reason ?? `Stop condition '${trippedStop.stopId}' is tripped.`,
+    );
+  }
+
+  if (action.requiresDecisionInteraction && !input.decisionInteractionId?.trim()) {
+    return deny(
+      "missing_decision_interaction",
+      `Work Case action '${action.action}' requires a DecisionInteraction reference.`,
+    );
+  }
+
+  if (requiresApprovedCoworkerEnvelope(input)) {
+    if (!input.coworkerEnvelope) {
+      return deny(
+        "missing_coworker_envelope",
+        `Work Case action '${action.action}' requires an approved CoworkerActionEnvelope.`,
+      );
+    }
+    if (input.coworkerEnvelope.status !== "approved") {
+      return deny(
+        "coworker_envelope_not_approved",
+        `CoworkerActionEnvelope ${input.coworkerEnvelope.envelopeId} is '${input.coworkerEnvelope.status}', not approved.`,
+      );
+    }
+  }
+
+  if ((action.requiresReceipt || source.receiptPolicy.receiptRequiredForConsequentialTransition) && !input.envelope.receiptPolicy) {
+    return deny(
+      "missing_receipt_policy",
+      `Work Case action '${action.action}' requires a receipt policy.`,
+    );
+  }
+
+  const enforcementMode: WorkCaseEnforcementMode =
+    input.observedEvent || input.envelope.autonomyMode === "observed"
+      ? "observed-event"
+      : "governed-action";
+
+  return {
+    ok: true,
+    enforcementMode,
+    requiredReceiptKind:
+      input.envelope.receiptPolicy?.kind ?? source.receiptPolicy.defaultReceiptKind,
+  };
+}

--- a/apps/web/lib/work-management/receipt-coverage.test.ts
+++ b/apps/web/lib/work-management/receipt-coverage.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { getWorkCaseAction } from "./action-registry";
+import type { WorkCasePolicyDecision } from "./policy-envelope";
+import {
+  fromRuntimeVerification,
+  fromToolExecutionReceipt,
+} from "./receipt-envelope";
+import { assertWorkCaseReceiptCoverage } from "./receipt-coverage";
+
+const ACTIVE_STATE = {
+  state: "active",
+  terminal: false,
+} as const;
+
+const TERMINAL_STATE = {
+  state: "closed",
+  terminal: true,
+} as const;
+
+const ALLOWED_GOVERNED_POLICY = {
+  ok: true,
+  enforcementMode: "governed-action",
+  requiredReceiptKind: "governed-action",
+} as const satisfies WorkCasePolicyDecision;
+
+const ALLOWED_OBSERVED_POLICY = {
+  ok: true,
+  enforcementMode: "observed-event",
+  requiredReceiptKind: "observed-event",
+} as const satisfies WorkCasePolicyDecision;
+
+const DENIED_POLICY = {
+  ok: false,
+  reason: "unsupported_transition",
+  message: "Source does not support this action.",
+} as const satisfies WorkCasePolicyDecision;
+
+const GOVERNED_RECEIPT = fromToolExecutionReceipt({
+  id: "ter-1",
+  toolExecutionId: "te-1",
+  receiptKind: "work-case-governed-action",
+  receiptStatus: "valid",
+  executionStatus: "success",
+  inputFingerprint: "sha256:input",
+  outputDigest: { ok: true },
+  createdAt: "2026-06-27T21:00:00.000Z",
+});
+
+const OBSERVED_RECEIPT = fromRuntimeVerification({
+  id: "rv-row-1",
+  verificationId: "RV-1",
+  kind: "unit-test",
+  status: "passed",
+  result: { ok: true },
+  createdAt: "2026-06-27T21:00:00.000Z",
+});
+
+describe("assertWorkCaseReceiptCoverage", () => {
+  it("returns missing_receipt for consequential governed actions with no receipt", () => {
+    expect(
+      assertWorkCaseReceiptCoverage({
+        action: getWorkCaseAction("complete")!,
+        policyDecision: ALLOWED_GOVERNED_POLICY,
+        projectedState: ACTIVE_STATE,
+        receipt: null,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "missing_receipt",
+    });
+  });
+
+  it("returns receipt_not_governed when only an observed-event receipt exists", () => {
+    expect(
+      assertWorkCaseReceiptCoverage({
+        action: getWorkCaseAction("complete")!,
+        policyDecision: ALLOWED_GOVERNED_POLICY,
+        projectedState: ACTIVE_STATE,
+        receipt: OBSERVED_RECEIPT,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "receipt_not_governed",
+    });
+  });
+
+  it("returns policy_denied when the policy evaluator denied the action", () => {
+    expect(
+      assertWorkCaseReceiptCoverage({
+        action: getWorkCaseAction("complete")!,
+        policyDecision: DENIED_POLICY,
+        projectedState: ACTIVE_STATE,
+        receipt: GOVERNED_RECEIPT,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "policy_denied",
+    });
+  });
+
+  it("returns terminal_case_sealed for terminal projected state", () => {
+    expect(
+      assertWorkCaseReceiptCoverage({
+        action: getWorkCaseAction("complete")!,
+        policyDecision: ALLOWED_GOVERNED_POLICY,
+        projectedState: TERMINAL_STATE,
+        receipt: GOVERNED_RECEIPT,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "terminal_case_sealed",
+    });
+  });
+
+  it("allows non-consequential observed source events with observed receipts", () => {
+    expect(
+      assertWorkCaseReceiptCoverage({
+        action: getWorkCaseAction("respond")!,
+        policyDecision: ALLOWED_OBSERVED_POLICY,
+        projectedState: ACTIVE_STATE,
+        receipt: OBSERVED_RECEIPT,
+      }),
+    ).toEqual({
+      ok: true,
+      enforcementMode: "observed-event",
+      receiptId: OBSERVED_RECEIPT.receiptId,
+    });
+  });
+
+  it("allows consequential actions with a passing policy and governed receipt", () => {
+    expect(
+      assertWorkCaseReceiptCoverage({
+        action: getWorkCaseAction("complete")!,
+        policyDecision: ALLOWED_GOVERNED_POLICY,
+        projectedState: ACTIVE_STATE,
+        receipt: GOVERNED_RECEIPT,
+      }),
+    ).toEqual({
+      ok: true,
+      enforcementMode: "governed-action",
+      receiptId: GOVERNED_RECEIPT.receiptId,
+    });
+  });
+});

--- a/apps/web/lib/work-management/receipt-coverage.ts
+++ b/apps/web/lib/work-management/receipt-coverage.ts
@@ -1,0 +1,99 @@
+import type { WorkCaseActionDescriptor } from "./action-registry";
+import type { WorkCasePolicyDecision } from "./policy-envelope";
+import type { ReceiptEnvelope } from "./receipt-envelope";
+import type { WorkCaseStateProjection } from "./status-projection";
+
+export type WorkCaseReceiptCoverageDenialReason =
+  | "policy_denied"
+  | "terminal_case_sealed"
+  | "missing_receipt"
+  | "receipt_not_governed"
+  | "receipt_not_observed"
+  | "receipt_invalid";
+
+export type WorkCaseReceiptCoverageResult =
+  | {
+      ok: true;
+      enforcementMode: ReceiptEnvelope["enforcementMode"];
+      receiptId?: string;
+    }
+  | {
+      ok: false;
+      reason: WorkCaseReceiptCoverageDenialReason;
+      message: string;
+    };
+
+function deny(
+  reason: WorkCaseReceiptCoverageDenialReason,
+  message: string,
+): WorkCaseReceiptCoverageResult {
+  return { ok: false, reason, message };
+}
+
+export function assertWorkCaseReceiptCoverage(input: {
+  action: WorkCaseActionDescriptor;
+  policyDecision: WorkCasePolicyDecision;
+  projectedState: Pick<WorkCaseStateProjection, "state" | "terminal">;
+  receipt?: ReceiptEnvelope | null;
+}): WorkCaseReceiptCoverageResult {
+  if (!input.policyDecision.ok) {
+    return deny(
+      "policy_denied",
+      `Policy denied Work Case action '${input.action.action}': ${input.policyDecision.message}`,
+    );
+  }
+
+  if (input.action.consequential && input.projectedState.terminal) {
+    return deny(
+      "terminal_case_sealed",
+      `Terminal Work Case state '${input.projectedState.state}' cannot complete consequential action '${input.action.action}'.`,
+    );
+  }
+
+  if (input.action.requiresReceipt && !input.receipt) {
+    return deny(
+      "missing_receipt",
+      `Work Case action '${input.action.action}' requires a receipt.`,
+    );
+  }
+
+  if (!input.receipt) {
+    return {
+      ok: true,
+      enforcementMode: input.policyDecision.enforcementMode,
+    };
+  }
+
+  if (
+    input.policyDecision.enforcementMode === "governed-action" &&
+    input.receipt.enforcementMode !== "governed-action"
+  ) {
+    return deny(
+      "receipt_not_governed",
+      `Work Case action '${input.action.action}' requires a governed-action receipt.`,
+    );
+  }
+
+  if (
+    input.policyDecision.enforcementMode === "observed-event" &&
+    input.receipt.enforcementMode !== "observed-event"
+  ) {
+    return deny(
+      "receipt_not_observed",
+      `Observed Work Case event '${input.action.action}' requires an observed-event receipt.`,
+    );
+  }
+
+  if (input.receipt.status === "invalid" || input.receipt.status === "failed") {
+    return deny(
+      "receipt_invalid",
+      `Receipt ${input.receipt.receiptId} is '${input.receipt.status}'.`,
+    );
+  }
+
+  return {
+    ok: true,
+    enforcementMode: input.receipt.enforcementMode,
+    receiptId: input.receipt.receiptId,
+  };
+}

--- a/apps/web/lib/work-management/receipt-envelope.test.ts
+++ b/apps/web/lib/work-management/receipt-envelope.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTriangleReceipt } from "@/lib/golden-triangle/receipt";
+
+import {
+  fromBacklogItemActivity,
+  fromDecisionInteraction,
+  fromExternalEvidenceRecord,
+  fromGoldenTriangleReceipt,
+  fromRuntimeVerification,
+  fromToolExecutionReceipt,
+  fromWorkCapsuleActivity,
+  fromWorkItemMessage,
+} from "./receipt-envelope";
+
+const CASE_REF = {
+  caseId: "backlog-item:BI-1",
+  sourceType: "backlog-item",
+  sourceId: "BI-1",
+} as const;
+
+const NOW = "2026-06-27T21:00:00.000Z";
+
+function goldenTriangleReceipt(): GoldenTriangleReceipt {
+  return {
+    preset: "assured",
+    governedBy: "organization",
+    requested: {
+      minimumTier: "strong",
+      effort: "high",
+      budgetClass: "standard",
+      verificationDepth: "deep",
+    },
+    actual: {
+      modelId: "gpt-5.4",
+      tier: "frontier",
+      costUsd: 0.42,
+      latencyMs: 1234,
+      fallbackOccurred: false,
+      verificationPassed: true,
+      accepted: true,
+    },
+    deviations: [],
+    matchedRequest: true,
+    summary: "Assured policy matched the actual run.",
+  };
+}
+
+describe("ReceiptEnvelope normalizers", () => {
+  it("normalizes GoldenTriangleReceipt with requested and actual policy details", () => {
+    const envelope = fromGoldenTriangleReceipt(goldenTriangleReceipt(), {
+      interactionId: "DI-gt",
+      occurredAt: NOW,
+      caseRef: CASE_REF,
+    });
+
+    expect(envelope).toMatchObject({
+      receiptId: "golden-triangle:DI-gt",
+      receiptKind: "golden-triangle",
+      enforcementMode: "governed-action",
+      status: "valid",
+      summary: "Assured policy matched the actual run.",
+      occurredAt: NOW,
+      caseRef: CASE_REF,
+      sourceRef: {
+        kind: "decision-interaction",
+        id: "DI-gt",
+      },
+      rawRef: {
+        table: "DecisionInteraction",
+        id: "DI-gt",
+      },
+      policyRefs: ["golden-triangle:assured", "governed-by:organization"],
+    });
+    expect(envelope.outputDigest).toMatchObject({
+      requested: { minimumTier: "strong", effort: "high" },
+      actual: { modelId: "gpt-5.4", tier: "frontier" },
+      matchedRequest: true,
+    });
+  });
+
+  it("normalizes ToolExecutionReceipt without losing execution fields", () => {
+    const envelope = fromToolExecutionReceipt(
+      {
+        id: "ter-1",
+        toolExecutionId: "te-1",
+        receiptKind: "work-case-governed-action",
+        receiptStatus: "valid",
+        executionStatus: "success",
+        inputFingerprint: "sha256:input",
+        outputDigest: { ok: true, result: "done" },
+        createdAt: new Date(NOW),
+      },
+      { caseRef: CASE_REF, actionType: "complete" },
+    );
+
+    expect(envelope).toMatchObject({
+      receiptId: "ter-1",
+      receiptKind: "work-case-governed-action",
+      enforcementMode: "governed-action",
+      sourceRef: {
+        kind: "source",
+        id: "te-1",
+        sourceType: "tool-execution",
+      },
+      actionType: "complete",
+      status: "valid",
+      occurredAt: NOW,
+      inputDigest: "sha256:input",
+      outputDigest: { ok: true, result: "done" },
+      rawRef: {
+        table: "ToolExecutionReceipt",
+        id: "ter-1",
+      },
+    });
+  });
+
+  it("normalizes existing activity and evidence rows as observed-event receipts", () => {
+    const envelopes = [
+      fromWorkCapsuleActivity({
+        id: "wca-1",
+        workCapsuleId: "wc-row-1",
+        kind: "note",
+        summary: "Capsule note recorded.",
+        payload: { capsuleId: "WC-1" },
+        recordedAt: new Date(NOW),
+      }),
+      fromWorkItemMessage({
+        id: "msg-row-1",
+        messageId: "MSG-1",
+        workItemId: "wi-row-1",
+        senderType: "agent",
+        senderAgentId: "AGT-1",
+        messageType: "reply",
+        body: "A response was posted.",
+        structuredPayload: { caseId: CASE_REF.caseId },
+        createdAt: new Date(NOW),
+      }),
+      fromRuntimeVerification({
+        id: "rv-row-1",
+        verificationId: "RV-1",
+        kind: "unit-test",
+        status: "passed",
+        result: { tests: 42 },
+        createdAt: new Date(NOW),
+      }),
+      fromExternalEvidenceRecord({
+        id: "eer-1",
+        routeContext: "/ops",
+        operationType: "manual-review",
+        target: "BI-1",
+        provider: "codex",
+        resultSummary: "Reviewed by an external agent.",
+        details: { branch: "feat/work-case-wave1-enforcement" },
+        createdAt: new Date(NOW),
+      }),
+      fromDecisionInteraction({
+        id: "di-row-1",
+        interactionId: "DI-1",
+        domainClass: "plan-readiness",
+        question: "Proceed?",
+        outcomeType: "escalate",
+        outcomePayload: { reason: "human-needed" },
+        createdAt: new Date(NOW),
+      }),
+      fromBacklogItemActivity({
+        id: "bia-1",
+        backlogItemId: "backlog-row-1",
+        kind: "evidence",
+        summary: "Backlog evidence recorded.",
+        payload: { itemId: "BI-1" },
+        recordedAt: new Date(NOW),
+      }),
+    ];
+
+    for (const envelope of envelopes) {
+      expect(envelope.enforcementMode).toBe("observed-event");
+      expect(envelope.status).toBe("observed");
+      expect(envelope.receiptKind).toBe("observed-event");
+      expect(envelope.rawRef.id.length).toBeGreaterThan(0);
+      expect(envelope.summary.length).toBeGreaterThan(0);
+      expect(envelope.occurredAt).toBe(NOW);
+    }
+  });
+
+  it("keeps governed-action receipts distinguishable from observed events", () => {
+    const governed = fromToolExecutionReceipt({
+      id: "ter-2",
+      toolExecutionId: "te-2",
+      receiptKind: "work-case-governed-action",
+      receiptStatus: "valid",
+      executionStatus: "success",
+      inputFingerprint: "sha256:input",
+      outputDigest: { ok: true },
+      createdAt: new Date(NOW),
+    });
+    const observed = fromRuntimeVerification({
+      id: "rv-row-2",
+      verificationId: "RV-2",
+      kind: "unit-test",
+      status: "passed",
+      result: { ok: true },
+      createdAt: new Date(NOW),
+    });
+
+    expect(governed.enforcementMode).toBe("governed-action");
+    expect(observed.enforcementMode).toBe("observed-event");
+  });
+});

--- a/apps/web/lib/work-management/receipt-envelope.ts
+++ b/apps/web/lib/work-management/receipt-envelope.ts
@@ -1,0 +1,327 @@
+import type { GoldenTriangleReceipt } from "@/lib/golden-triangle/receipt";
+
+import type {
+  WorkCaseActionVerb,
+  WorkCaseActorRef,
+  WorkCaseEnforcementMode,
+  WorkCaseRef,
+  WorkCaseSourceRef,
+} from "./case-types";
+
+export type ReceiptEnvelopeStatus = "valid" | "invalid" | "observed" | "failed";
+
+export interface ReceiptEnvelope {
+  receiptId: string;
+  caseRef?: WorkCaseRef;
+  receiptKind: string;
+  enforcementMode: WorkCaseEnforcementMode;
+  sourceRef: WorkCaseSourceRef;
+  actionType?: WorkCaseActionVerb | string;
+  status: ReceiptEnvelopeStatus;
+  summary: string;
+  occurredAt: string;
+  actorRef?: WorkCaseActorRef;
+  inputDigest?: string;
+  outputDigest?: unknown;
+  policyRefs: readonly string[];
+  trace?: {
+    traceId?: string;
+    spanId?: string;
+    parentSpanId?: string;
+  };
+  rawRef: {
+    table: string;
+    id: string;
+  };
+}
+
+type DateLike = Date | string;
+
+export interface GoldenTriangleReceiptEnvelopeOptions {
+  interactionId: string;
+  occurredAt: DateLike;
+  caseRef?: WorkCaseRef;
+}
+
+export interface ToolExecutionReceiptRow {
+  id: string;
+  toolExecutionId: string;
+  receiptKind: string;
+  receiptStatus: string;
+  executionStatus: string;
+  inputFingerprint: string;
+  outputDigest: unknown;
+  createdAt: DateLike;
+}
+
+export interface ToolExecutionReceiptEnvelopeOptions {
+  caseRef?: WorkCaseRef;
+  actionType?: WorkCaseActionVerb | string;
+  policyRefs?: readonly string[];
+}
+
+export interface WorkCapsuleActivityRow {
+  id: string;
+  workCapsuleId: string;
+  kind: string;
+  summary: string;
+  payload?: unknown;
+  recordedAt: DateLike;
+}
+
+export interface WorkItemMessageRow {
+  id: string;
+  messageId: string;
+  workItemId: string;
+  senderType: string;
+  senderUserId?: string | null;
+  senderAgentId?: string | null;
+  messageType: string;
+  body: string;
+  structuredPayload?: unknown;
+  createdAt: DateLike;
+}
+
+export interface RuntimeVerificationRow {
+  id: string;
+  verificationId: string;
+  kind: string;
+  status: string;
+  result?: unknown;
+  createdAt: DateLike;
+}
+
+export interface ExternalEvidenceRecordRow {
+  id: string;
+  routeContext: string;
+  operationType: string;
+  target: string;
+  provider: string;
+  resultSummary: string;
+  details?: unknown;
+  createdAt: DateLike;
+}
+
+export interface DecisionInteractionRow {
+  id: string;
+  interactionId: string;
+  domainClass: string;
+  question: string;
+  outcomeType: string;
+  outcomePayload?: unknown;
+  createdAt: DateLike;
+}
+
+export interface BacklogItemActivityRow {
+  id: string;
+  backlogItemId: string;
+  kind: string;
+  summary: string;
+  payload?: unknown;
+  recordedAt: DateLike;
+}
+
+function iso(value: DateLike): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function receiptStatusFromTool(row: ToolExecutionReceiptRow): ReceiptEnvelopeStatus {
+  if (row.receiptStatus !== "valid") return "invalid";
+  if (/fail|error|denied|rejected/i.test(row.executionStatus)) return "failed";
+  return "valid";
+}
+
+function enforcementModeFromReceiptKind(receiptKind: string): WorkCaseEnforcementMode {
+  return /governed/i.test(receiptKind) ? "governed-action" : "observed-event";
+}
+
+function observedEnvelope(input: {
+  receiptId: string;
+  sourceRef: WorkCaseSourceRef;
+  rawRef: ReceiptEnvelope["rawRef"];
+  summary: string;
+  occurredAt: DateLike;
+  outputDigest?: unknown;
+  actorRef?: WorkCaseActorRef;
+}): ReceiptEnvelope {
+  return {
+    receiptId: input.receiptId,
+    receiptKind: "observed-event",
+    enforcementMode: "observed-event",
+    sourceRef: input.sourceRef,
+    status: "observed",
+    summary: input.summary,
+    occurredAt: iso(input.occurredAt),
+    actorRef: input.actorRef,
+    outputDigest: input.outputDigest,
+    policyRefs: [],
+    rawRef: input.rawRef,
+  };
+}
+
+export function fromGoldenTriangleReceipt(
+  receipt: GoldenTriangleReceipt,
+  options: GoldenTriangleReceiptEnvelopeOptions,
+): ReceiptEnvelope {
+  return {
+    receiptId: `golden-triangle:${options.interactionId}`,
+    caseRef: options.caseRef,
+    receiptKind: "golden-triangle",
+    enforcementMode: "governed-action",
+    sourceRef: {
+      kind: "decision-interaction",
+      id: options.interactionId,
+    },
+    status: receipt.matchedRequest ? "valid" : "invalid",
+    summary: receipt.summary,
+    occurredAt: iso(options.occurredAt),
+    inputDigest: JSON.stringify(receipt.requested),
+    outputDigest: {
+      requested: receipt.requested,
+      actual: receipt.actual,
+      deviations: receipt.deviations,
+      matchedRequest: receipt.matchedRequest,
+    },
+    policyRefs: [
+      `golden-triangle:${receipt.preset}`,
+      `governed-by:${receipt.governedBy}`,
+    ],
+    rawRef: {
+      table: "DecisionInteraction",
+      id: options.interactionId,
+    },
+  };
+}
+
+export function fromToolExecutionReceipt(
+  row: ToolExecutionReceiptRow,
+  options: ToolExecutionReceiptEnvelopeOptions = {},
+): ReceiptEnvelope {
+  return {
+    receiptId: row.id,
+    caseRef: options.caseRef,
+    receiptKind: row.receiptKind,
+    enforcementMode: enforcementModeFromReceiptKind(row.receiptKind),
+    sourceRef: {
+      kind: "source",
+      id: row.toolExecutionId,
+      sourceType: "tool-execution",
+    },
+    actionType: options.actionType,
+    status: receiptStatusFromTool(row),
+    summary: `${row.receiptKind} ${row.receiptStatus} for ${row.toolExecutionId}`,
+    occurredAt: iso(row.createdAt),
+    inputDigest: row.inputFingerprint,
+    outputDigest: row.outputDigest,
+    policyRefs: options.policyRefs ?? [],
+    rawRef: {
+      table: "ToolExecutionReceipt",
+      id: row.id,
+    },
+  };
+}
+
+export function fromWorkCapsuleActivity(row: WorkCapsuleActivityRow): ReceiptEnvelope {
+  return observedEnvelope({
+    receiptId: `work-capsule-activity:${row.id}`,
+    sourceRef: {
+      kind: "work-capsule",
+      id: row.workCapsuleId,
+      status: row.kind,
+    },
+    rawRef: { table: "WorkCapsuleActivity", id: row.id },
+    summary: row.summary,
+    occurredAt: row.recordedAt,
+    outputDigest: row.payload,
+  });
+}
+
+export function fromWorkItemMessage(row: WorkItemMessageRow): ReceiptEnvelope {
+  const actorRef: WorkCaseActorRef = {
+    actorKind: row.senderType === "agent" ? "agent" : row.senderType === "user" ? "person" : "system",
+    actorId: row.senderAgentId ?? row.senderUserId ?? undefined,
+  };
+  return observedEnvelope({
+    receiptId: `work-item-message:${row.messageId}`,
+    sourceRef: {
+      kind: "work-item",
+      id: row.workItemId,
+      status: row.messageType,
+    },
+    rawRef: { table: "WorkItemMessage", id: row.id },
+    summary: row.body,
+    occurredAt: row.createdAt,
+    actorRef,
+    outputDigest: row.structuredPayload,
+  });
+}
+
+export function fromRuntimeVerification(row: RuntimeVerificationRow): ReceiptEnvelope {
+  return observedEnvelope({
+    receiptId: `runtime-verification:${row.verificationId}`,
+    sourceRef: {
+      kind: "runtime-verification",
+      id: row.verificationId,
+      status: row.status,
+    },
+    rawRef: { table: "RuntimeVerification", id: row.id },
+    summary: `${row.kind} ${row.status}`,
+    occurredAt: row.createdAt,
+    outputDigest: row.result,
+  });
+}
+
+export function fromExternalEvidenceRecord(row: ExternalEvidenceRecordRow): ReceiptEnvelope {
+  return observedEnvelope({
+    receiptId: `external-evidence:${row.id}`,
+    sourceRef: {
+      kind: "evidence",
+      id: row.id,
+      status: row.operationType,
+      sourceType: "external-evidence",
+    },
+    rawRef: { table: "ExternalEvidenceRecord", id: row.id },
+    summary: row.resultSummary,
+    occurredAt: row.createdAt,
+    outputDigest: {
+      routeContext: row.routeContext,
+      target: row.target,
+      provider: row.provider,
+      details: row.details,
+    },
+  });
+}
+
+export function fromDecisionInteraction(row: DecisionInteractionRow): ReceiptEnvelope {
+  return observedEnvelope({
+    receiptId: `decision-interaction:${row.interactionId}`,
+    sourceRef: {
+      kind: "decision-interaction",
+      id: row.interactionId,
+      status: row.outcomeType,
+    },
+    rawRef: { table: "DecisionInteraction", id: row.id },
+    summary: row.question,
+    occurredAt: row.createdAt,
+    outputDigest: {
+      domainClass: row.domainClass,
+      outcomePayload: row.outcomePayload,
+    },
+  });
+}
+
+export function fromBacklogItemActivity(row: BacklogItemActivityRow): ReceiptEnvelope {
+  return observedEnvelope({
+    receiptId: `backlog-item-activity:${row.id}`,
+    sourceRef: {
+      kind: "source",
+      id: row.backlogItemId,
+      status: row.kind,
+      sourceType: "backlog-item",
+    },
+    rawRef: { table: "BacklogItemActivity", id: row.id },
+    summary: row.summary,
+    occurredAt: row.recordedAt,
+    outputDigest: row.payload,
+  });
+}

--- a/apps/web/lib/work-management/source-registry.ts
+++ b/apps/web/lib/work-management/source-registry.ts
@@ -1,3 +1,8 @@
+import {
+  WORK_CASE_ACTION_VERBS,
+  type WorkCaseActionVerb,
+} from "./case-types";
+
 export const WORK_CASE_WORK_ITEM_SOURCE_TYPES = [
   "task-node",
   "backlog-item",
@@ -22,16 +27,7 @@ export type WorkCaseAccountResolverKey =
   | "booking"
   | "activity";
 
-export type WorkCaseSupportedTransition =
-  | "claim"
-  | "delegate"
-  | "pause"
-  | "resume"
-  | "ask"
-  | "approve"
-  | "verify"
-  | "close"
-  | "cancel";
+export type WorkCaseSupportedTransition = WorkCaseActionVerb;
 
 export interface WorkCaseReceiptPolicy {
   defaultReceiptKind: WorkCaseReceiptKind;
@@ -51,14 +47,26 @@ export interface WorkCaseSourceRegistryEntry {
   receiptPolicy: WorkCaseReceiptPolicy;
 }
 
-const STANDARD_TRANSITIONS = [
+const STANDARD_TRANSITIONS =
+  WORK_CASE_ACTION_VERBS satisfies readonly WorkCaseSupportedTransition[];
+
+const APPROVAL_TRANSITIONS = [
+  "needs-input",
+  "respond",
+  "propose",
+  "escalate",
+  "complete",
+  "cancel",
+] as const satisfies readonly WorkCaseSupportedTransition[];
+
+const SCHEDULED_TRANSITIONS = [
   "claim",
-  "delegate",
   "pause",
+  "needs-input",
   "resume",
-  "ask",
   "verify",
-  "close",
+  "complete",
+  "cancel",
 ] as const satisfies readonly WorkCaseSupportedTransition[];
 
 const GOVERNED_RECEIPT_POLICY = {
@@ -105,7 +113,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
     accountResolverKey: null,
     titleProjection: "Use the approval question.",
     summaryProjection: "Use the requested action, options, and evidence bundle.",
-    supportedTransitions: ["ask", "approve", "close", "cancel"],
+    supportedTransitions: APPROVAL_TRANSITIONS,
     receiptPolicy: GOVERNED_RECEIPT_POLICY,
   },
   {
@@ -129,7 +137,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
     accountResolverKey: null,
     titleProjection: "Use the schedule title and next run window.",
     summaryProjection: "Use schedule cadence, owner, and due window.",
-    supportedTransitions: ["claim", "pause", "resume", "verify", "close", "cancel"],
+    supportedTransitions: SCHEDULED_TRANSITIONS,
     receiptPolicy: OBSERVED_RECEIPT_POLICY,
   },
   {

--- a/apps/web/lib/work-management/work-case-governance-hook.test.ts
+++ b/apps/web/lib/work-management/work-case-governance-hook.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { createWorkCaseGovernanceHook } from "./work-case-governance-hook";
+
+const NORMAL_USER = {
+  platformRole: "ceo",
+  isSuperuser: true,
+};
+
+const BASE_EVENT = {
+  toolName: "query_backlog",
+  rawParams: {},
+  userId: "user-1",
+  userContext: NORMAL_USER,
+  source: "rest",
+} as const;
+
+const BASE_WORK_CASE = {
+  caseRef: {
+    caseId: "backlog-item:BI-1",
+    sourceType: "backlog-item",
+    sourceId: "BI-1",
+  },
+  sourceKey: "backlog-item",
+  action: "respond",
+  currentState: {
+    state: "active",
+    terminal: false,
+  },
+  envelope: {
+    autonomyMode: "autonomous",
+    receiptPolicy: {
+      required: true,
+      kind: "governed-action",
+    },
+  },
+} as const;
+
+describe("createWorkCaseGovernanceHook", () => {
+  it("allows tool execution when no Work Case context is present", async () => {
+    const hook = createWorkCaseGovernanceHook();
+
+    await expect(hook.onPreToolUse?.(BASE_EVENT)).resolves.toEqual({
+      decision: "allow",
+      reason: "No Work Case context supplied.",
+    });
+  });
+
+  it("denies tool execution when Work Case policy denies the action", async () => {
+    const hook = createWorkCaseGovernanceHook();
+
+    await expect(
+      hook.onPreToolUse?.({
+        ...BASE_EVENT,
+        context: {
+          workCase: {
+            ...BASE_WORK_CASE,
+            action: "complete",
+            currentState: {
+              state: "closed",
+              terminal: true,
+            },
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      decision: "deny",
+      reason: expect.stringContaining("terminal_case_sealed"),
+    });
+  });
+
+  it("allows tool execution when Work Case policy allows the action", async () => {
+    const hook = createWorkCaseGovernanceHook();
+
+    await expect(
+      hook.onPreToolUse?.({
+        ...BASE_EVENT,
+        context: {
+          workCase: BASE_WORK_CASE,
+        },
+      }),
+    ).resolves.toEqual({
+      decision: "allow",
+      reason: "Work Case policy allowed respond.",
+    });
+  });
+});

--- a/apps/web/lib/work-management/work-case-governance-hook.ts
+++ b/apps/web/lib/work-management/work-case-governance-hook.ts
@@ -1,0 +1,35 @@
+import type { ToolLifecycleHook } from "../mcp-governed-execute";
+import {
+  evaluateWorkCasePolicy,
+  type WorkCasePolicyInput,
+} from "./policy-envelope";
+
+export type WorkCaseExecutionContext = WorkCasePolicyInput;
+
+export function createWorkCaseGovernanceHook(): ToolLifecycleHook {
+  return {
+    id: "work-case-governance",
+    onPreToolUse: async (event) => {
+      const workCase = event.context?.workCase;
+      if (!workCase) {
+        return {
+          decision: "allow",
+          reason: "No Work Case context supplied.",
+        };
+      }
+
+      const decision = evaluateWorkCasePolicy(workCase);
+      if (!decision.ok) {
+        return {
+          decision: "deny",
+          reason: `Work Case policy denied ${workCase.action}: ${decision.reason} - ${decision.message}`,
+        };
+      }
+
+      return {
+        decision: "allow",
+        reason: `Work Case policy allowed ${workCase.action}.`,
+      };
+    },
+  };
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,7 +101,10 @@ allowBuilds:
   esbuild: true
   msw: true
   prisma: true
+  protobufjs: false
+  puppeteer: false
   sharp: true
+  unrs-resolver: false
 # Restore peerDependencies that @testing-library/jest-dom dropped in 6.x but still
 # imports from at runtime (src/vitest.js imports `vitest`). Without this, vitest
 # 4.1.6+ loses the `toBeInTheDocument` type augmentation across every test site.


### PR DESCRIPTION
## Summary
- Adds the Work Case Wave 1 enforcement spine: action grammar, policy envelope evaluation, receipt envelope normalization, receipt coverage guard, and OTel-compatible event projection.
- Wires optional `context.workCase` into `governedExecuteTool` so consequential Work Case executions can emit governed `ToolExecutionReceipt` rows without changing existing callers.
- Updates executable EA/SysML architecture grounding for Wave 1 allocations, Actions, and verification status.

## Verification
- PASS: `pnpm --filter web exec vitest run lib/work-management/action-registry.test.ts lib/work-management/architecture-grounding.test.ts lib/work-management/case-read-model.test.ts lib/work-management/case-telemetry.test.ts lib/work-management/policy-envelope.test.ts lib/work-management/receipt-coverage.test.ts lib/work-management/receipt-envelope.test.ts lib/work-management/source-registry.test.ts lib/work-management/status-projection.test.ts lib/work-management/work-case-governance-hook.test.ts lib/mcp-governed-execute.test.ts lib/api/work-item-account-resolution.test.ts lib/api/work-items.test.ts lib/work-capsules.test.ts lib/work-capsules-enum-parity.test.ts` — 15 files, 110 tests.
- PASS: `pnpm --filter web typecheck` — `next typegen` plus `tsc --noEmit`.
- PASS: `git diff --check`.
- PASS: `pnpm --filter web build` under `local-integration-ci` lease `NPEL-C7EB5A0C06` — exit 0; compiled successfully; TypeScript completed; generated 131 static pages. Existing Turbopack Edge Runtime `process.cwd` / NFT trace warning class remains.

## Evidence
- Backlog evidence recorded on `BI-D633F7AF` for focused tests/typecheck and production build.
- Capsule evidence recorded on `WC-205B485D` with external Codex handoff evidence.

Process-Spine-Decision: Durable design and implementation plan already landed in #2484 and #2485; this PR updates executable architecture grounding for the implementation rather than duplicating the spec text.
