### PR TITLE
Governed adaptive playbooks Slice 1 observer

### DIFF
--- a/apps/web/lib/ea/architecture-parity-steward.test.ts
+++ b/apps/web/lib/ea/architecture-parity-steward.test.ts
@@ -31,6 +31,7 @@ function projectionResult(overrides: Partial<SysmlProjectionsResult> = {}): Sysm
     scheduledJobs: healthy,
     it4itCoverage: healthy,
     securityPosture: healthy,
+    workPatternArchitecture: healthy,
     ...overrides,
   };
 }

--- a/apps/web/lib/ea/architecture-parity-steward.ts
+++ b/apps/web/lib/ea/architecture-parity-steward.ts
@@ -64,6 +64,7 @@ const DOMAIN_LABELS: Record<ProjectionDomain, string> = {
   scheduledJobs: "scheduling surface (all scheduled work)",
   it4itCoverage: "IT4IT functional-criteria coverage",
   securityPosture: "security operations (SOC) surface",
+  workPatternArchitecture: "governed adaptive playbooks",
 };
 
 function projectionEntries(result: SysmlProjectionsResult): Array<[ProjectionDomain, ProjectionStatus]> {

--- a/apps/web/lib/ea/reconcile-sysml-projections.test.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.test.ts
@@ -35,11 +35,12 @@ describe("reconcileSysmlProjections", () => {
     expect(r.scheduledJobs.status).toBe("skipped"); // notation null -> applySysmlModel skips
     expect(r.it4itCoverage.status).toBe("skipped"); // IT4IT reference model absent -> skips
     expect(r.securityPosture.status).toBe("skipped"); // notation null -> applySysmlModel skips
-    // mcp + coworker + routes + navigation + process + scheduling + security are
-    // notation-backed (all sysml2 except process=bpmn20); value-streams +
+    expect(r.workPatternArchitecture.status).toBe("skipped"); // notation null -> applySysmlModel skips
+    // mcp + coworker + routes + navigation + process + scheduling + security +
+    // work-pattern architecture are notation-backed (all sysml2 except process=bpmn20); value-streams +
     // it4it-coverage check the reference model first; code-structure checks graph
     // freshness first.
-    expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(7);
+    expect(db.eaNotation.findUnique).toHaveBeenCalledTimes(8);
     // value-streams and it4it-coverage both look up the IT4IT reference model.
     expect(db.eaReferenceModel.findUnique).toHaveBeenCalledTimes(2);
     expect(getFreshness).toHaveBeenCalledTimes(1);
@@ -71,5 +72,6 @@ describe("reconcileSysmlProjections", () => {
     expect(r.routes.status).toBe("skipped");
     expect(r.mcpAuthority.status).toBe("skipped");
     expect(r.scheduledJobs.status).toBe("skipped");
+    expect(r.workPatternArchitecture.status).toBe("skipped");
   });
 });

--- a/apps/web/lib/ea/reconcile-sysml-projections.ts
+++ b/apps/web/lib/ea/reconcile-sysml-projections.ts
@@ -26,6 +26,7 @@ import { reconcileIntegrations } from "./reconcile-integration-bridge";
 import { reconcileScheduledJobs } from "./reconcile-scheduled-jobs";
 import { reconcileIt4itCoverage } from "./reconcile-it4it-coverage";
 import { reconcileSecurityPosture } from "./reconcile-security-posture";
+import { reconcileWorkPatternArchitecture } from "./reconcile-work-pattern-architecture";
 import type { SysmlSeedResult } from "./sysml-model-seed";
 
 export interface SysmlProjectionsResult {
@@ -51,6 +52,9 @@ export interface SysmlProjectionsResult {
   // Security Operations (SOC) surface — normalization / detection / cases /
   // response / roster, tracing to the security data model (EP-SOVEREIGN-SOC).
   securityPosture: SysmlSeedResult;
+  // Governed Adaptive Playbooks — observed work patterns, proposal guardrails,
+  // promotion ladder, and no-self-activation verification cases.
+  workPatternArchitecture: SysmlSeedResult;
 }
 
 const SKIPPED: SysmlSeedResult = { status: "skipped", created: 0, updated: 0, removed: 0 };
@@ -92,8 +96,13 @@ export async function reconcileSysmlProjections(
   // SOC posture isolated like every other domain (EP-SOVEREIGN-SOC, composed with
   // the PR-2385 fail-isolation): a security-extractor error can't blind the engine.
   const securityPosture = await runDomain("securityPosture", () => reconcileSecurityPosture({ db: opts.db }), SKIPPED);
+  const workPatternArchitecture = await runDomain(
+    "workPatternArchitecture",
+    () => reconcileWorkPatternArchitecture({ db: opts.db }),
+    SKIPPED,
+  );
   return {
     mcpAuthority, coworkerAuthority, valueStreams, routes, navigation, codeStructure, processModels, skillToolchain,
-    operationalGraph, networkTopology, integrations, scheduledJobs, it4itCoverage, securityPosture,
+    operationalGraph, networkTopology, integrations, scheduledJobs, it4itCoverage, securityPosture, workPatternArchitecture,
   };
 }

--- a/apps/web/lib/ea/reconcile-work-pattern-architecture.test.ts
+++ b/apps/web/lib/ea/reconcile-work-pattern-architecture.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./sysml-model-seed", () => ({
+  applySysmlModel: vi.fn(async () => ({
+    status: "applied",
+    created: 1,
+    updated: 2,
+    removed: 0,
+  })),
+}));
+
+import { applySysmlModel } from "./sysml-model-seed";
+import { reconcileWorkPatternArchitecture } from "./reconcile-work-pattern-architecture";
+
+describe("reconcileWorkPatternArchitecture", () => {
+  it("applies the governed adaptive playbooks model under sysml2", async () => {
+    const db = { eaNotation: {} };
+
+    const result = await reconcileWorkPatternArchitecture({ db: db as never });
+
+    expect(result).toEqual({ status: "applied", created: 1, updated: 2, removed: 0 });
+    expect(applySysmlModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        softRemovePrefix: "gap:",
+        view: expect.objectContaining({ scopeRef: "governed-adaptive-playbooks" }),
+      }),
+      { db, notationSlug: "sysml2" },
+    );
+  });
+});

--- a/apps/web/lib/ea/reconcile-work-pattern-architecture.ts
+++ b/apps/web/lib/ea/reconcile-work-pattern-architecture.ts
@@ -1,0 +1,24 @@
+import { prisma } from "@dpf/db";
+import { buildWorkPatternArchitectureModel, type WorkPatternArchitectureObservedPattern } from "./work-pattern-architecture-extract";
+import { applySysmlModel, type SysmlSeedResult } from "./sysml-model-seed";
+
+export async function reconcileWorkPatternArchitecture(
+  opts: {
+    db?: typeof prisma;
+    observedPatterns?: WorkPatternArchitectureObservedPattern[];
+  } = {},
+): Promise<SysmlSeedResult> {
+  const result = await applySysmlModel(
+    buildWorkPatternArchitectureModel({ observedPatterns: opts.observedPatterns }),
+    { db: opts.db, notationSlug: "sysml2" },
+  );
+
+  console.info("[work-pattern-architecture] reconcile", {
+    status: result.status,
+    created: result.created,
+    updated: result.updated,
+    removed: result.removed,
+  });
+
+  return result;
+}

--- a/apps/web/lib/ea/work-pattern-architecture-extract.test.ts
+++ b/apps/web/lib/ea/work-pattern-architecture-extract.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  GAP_PACKAGE_KEY,
+  buildWorkPatternArchitectureModel,
+  safePatternKey,
+} from "./work-pattern-architecture-extract";
+
+describe("buildWorkPatternArchitectureModel", () => {
+  it("emits the governed adaptive playbooks package and core elements", () => {
+    const model = buildWorkPatternArchitectureModel();
+
+    expect(model.elements.find((element) => element.sysmlKey === GAP_PACKAGE_KEY)).toMatchObject({
+      typeSlug: "package",
+      name: "Governed Adaptive Playbooks",
+    });
+    expect(model.elements.find((element) => element.sysmlKey === "gap:req:no-self-activation")).toMatchObject({
+      typeSlug: "requirement",
+    });
+    expect(model.elements.find((element) => element.sysmlKey === "gap:part:observer")).toMatchObject({
+      typeSlug: "part_definition",
+    });
+    expect(model.elements.find((element) => element.sysmlKey === "gap:part:promotion-ladder")).toMatchObject({
+      typeSlug: "part_definition",
+    });
+  });
+
+  it("represents the promotion ladder as a part_definition containing states", () => {
+    const model = buildWorkPatternArchitectureModel();
+    const states = ["observed", "candidate", "approved", "active", "retired"];
+
+    for (const state of states) {
+      expect(model.elements.find((element) => element.sysmlKey === `gap:state:${state}`)).toMatchObject({
+        typeSlug: "state",
+      });
+      expect(model.relationships).toContainEqual({
+        fromKey: "gap:part:promotion-ladder",
+        toKey: `gap:state:${state}`,
+        relSlug: "contains",
+      });
+    }
+  });
+
+  it("emits observed pattern actions and verification cases", () => {
+    const model = buildWorkPatternArchitectureModel({
+      observedPatterns: [
+        {
+          patternKey: "tool-surface|overload",
+          name: "Tool surface overload",
+          sourceKey: "apps/web/lib/tak/pattern-observer.ts",
+          codeAllocationKey: "gap:part:observer",
+        },
+      ],
+    });
+    const safeKey = safePatternKey("tool-surface|overload");
+
+    expect(model.elements.find((element) => element.sysmlKey === `gap:act:${safeKey}`)).toMatchObject({
+      typeSlug: "action",
+      properties: expect.objectContaining({
+        sourceKey: "apps/web/lib/tak/pattern-observer.ts",
+        stableId: "ACT-GAP-tool-surface-overload",
+      }),
+    });
+    expect(model.elements.find((element) => element.sysmlKey === `gap:vc:${safeKey}`)).toMatchObject({
+      typeSlug: "verification_case",
+    });
+    expect(model.relationships).toContainEqual({
+      fromKey: `gap:act:${safeKey}`,
+      toKey: "gap:part:observer",
+      relSlug: "allocates",
+    });
+  });
+
+  it("uses only seeded SysML relationship slugs", () => {
+    const model = buildWorkPatternArchitectureModel({
+      observedPatterns: [{ patternKey: "x", name: "X" }],
+    });
+    const allowed = new Set(["contains", "satisfies", "verifies", "allocates", "traces"]);
+
+    expect(model.relationships.every((rel) => allowed.has(rel.relSlug))).toBe(true);
+    expect(model.crossLayerRelationships?.every((rel) => allowed.has(rel.relSlug))).toBe(true);
+    expect(model.relationships.some((rel) => rel.relSlug === "sysml_allocates")).toBe(false);
+  });
+});

--- a/apps/web/lib/ea/work-pattern-architecture-extract.ts
+++ b/apps/web/lib/ea/work-pattern-architecture-extract.ts
@@ -1,0 +1,222 @@
+import type { SysmlDesiredModel } from "./sysml-model-seed";
+
+export const GAP_PACKAGE_KEY = "gap:pkg";
+
+export type WorkPatternArchitectureObservedPattern = {
+  patternKey: string;
+  name: string;
+  sourceKey?: string;
+  codeAllocationKey?: string;
+};
+
+const REQUIREMENTS = [
+  {
+    key: "gap:req:no-self-activation",
+    name: "No Self Activation",
+    description:
+      "Observed adaptive playbook patterns may propose capability changes, but this foundation cannot mutate prompts, skills, grants, model routes, or Work Case state.",
+  },
+  {
+    key: "gap:req:evidence-backed-proposal",
+    name: "Evidence Backed Proposal",
+    description:
+      "Every proposed work pattern must carry durable evidence from TaskRun metadata, tool execution telemetry, turn metrics, or decision receipts.",
+  },
+  {
+    key: "gap:req:case-bound-governed-action",
+    name: "Case Bound Governed Action",
+    description:
+      "Case-bound patterns remain proposals until the Work Case substrate supplies governed action keys, receipt policy, and attention routing.",
+  },
+] as const;
+
+const PARTS = [
+  {
+    key: "gap:part:metadata",
+    name: "Work Pattern Metadata",
+    description:
+      "Typed TaskRun metadata envelope carrying observed pattern keys, review status, decision scope, and evidence references.",
+  },
+  {
+    key: "gap:part:observer",
+    name: "Pattern Observer",
+    description:
+      "Post-run classifier that observes repeated coworker friction and emits capability needs through governed self-assessment paths.",
+  },
+  {
+    key: "gap:part:profile-review",
+    name: "Profile Review Runner",
+    description:
+      "Attributable scheduled review that summarizes recent work pattern evidence for each active coworker route.",
+  },
+  {
+    key: "gap:part:promotion-ladder",
+    name: "Promotion Ladder",
+    description:
+      "Observed -> candidate -> approved -> active -> retired lifecycle for governed adaptive playbook patterns.",
+  },
+] as const;
+
+const STATES = ["observed", "candidate", "approved", "active", "retired"] as const;
+
+const VERIFICATION_CASES = [
+  {
+    key: "gap:vc:metadata",
+    name: "Verify Work Pattern Metadata",
+    verifies: "gap:req:evidence-backed-proposal",
+  },
+  {
+    key: "gap:vc:observer",
+    name: "Verify Observer Does Not Activate",
+    verifies: "gap:req:no-self-activation",
+  },
+  {
+    key: "gap:vc:profile-review",
+    name: "Verify Attributable Profile Review",
+    verifies: "gap:req:evidence-backed-proposal",
+  },
+] as const;
+
+export function safePatternKey(patternKey: string): string {
+  return patternKey
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120) || "pattern";
+}
+
+function stableId(prefix: string, safeKey: string): string {
+  return `${prefix}-${safeKey}`;
+}
+
+export function buildWorkPatternArchitectureModel(input: {
+  observedPatterns?: WorkPatternArchitectureObservedPattern[];
+} = {}): SysmlDesiredModel {
+  const elements: SysmlDesiredModel["elements"] = [
+    {
+      sysmlKey: GAP_PACKAGE_KEY,
+      typeSlug: "package",
+      name: "Governed Adaptive Playbooks",
+      description:
+        "SysML2 projection of the governed adaptive playbooks foundation: typed observations, evidence-backed proposals, periodic review, and promotion controls.",
+      properties: {
+        sourceKey: "docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md",
+      },
+    },
+  ];
+  const relationships: SysmlDesiredModel["relationships"] = [];
+  const crossLayerRelationships: SysmlDesiredModel["relationships"] = [];
+
+  for (const requirement of REQUIREMENTS) {
+    elements.push({
+      sysmlKey: requirement.key,
+      typeSlug: "requirement",
+      name: requirement.name,
+      description: requirement.description,
+      properties: { stableId: requirement.key.toUpperCase() },
+    });
+    relationships.push({ fromKey: GAP_PACKAGE_KEY, toKey: requirement.key, relSlug: "contains" });
+  }
+
+  for (const part of PARTS) {
+    elements.push({
+      sysmlKey: part.key,
+      typeSlug: "part_definition",
+      name: part.name,
+      description: part.description,
+      properties: { stableId: part.key.toUpperCase() },
+    });
+    relationships.push({ fromKey: GAP_PACKAGE_KEY, toKey: part.key, relSlug: "contains" });
+  }
+
+  relationships.push({ fromKey: "gap:part:metadata", toKey: "gap:req:evidence-backed-proposal", relSlug: "satisfies" });
+  relationships.push({ fromKey: "gap:part:observer", toKey: "gap:req:no-self-activation", relSlug: "satisfies" });
+  relationships.push({ fromKey: "gap:part:observer", toKey: "gap:req:evidence-backed-proposal", relSlug: "satisfies" });
+  relationships.push({ fromKey: "gap:part:profile-review", toKey: "gap:req:evidence-backed-proposal", relSlug: "satisfies" });
+
+  for (const state of STATES) {
+    const key = `gap:state:${state}`;
+    elements.push({
+      sysmlKey: key,
+      typeSlug: "state",
+      name: state,
+      description: `Promotion ladder state "${state}" for governed adaptive playbook patterns.`,
+      properties: { status: state, stableId: `SM-GAP-PROMOTION-${state.toUpperCase()}` },
+    });
+    relationships.push({ fromKey: "gap:part:promotion-ladder", toKey: key, relSlug: "contains" });
+  }
+
+  for (const vc of VERIFICATION_CASES) {
+    elements.push({
+      sysmlKey: vc.key,
+      typeSlug: "verification_case",
+      name: vc.name,
+      description: `${vc.name} for the governed adaptive playbooks foundation.`,
+      properties: { stableId: vc.key.toUpperCase() },
+    });
+    relationships.push({ fromKey: GAP_PACKAGE_KEY, toKey: vc.key, relSlug: "contains" });
+    relationships.push({ fromKey: vc.key, toKey: vc.verifies, relSlug: "verifies" });
+  }
+
+  for (const pattern of input.observedPatterns ?? []) {
+    const safeKey = safePatternKey(pattern.patternKey);
+    const actionKey = `gap:act:${safeKey}`;
+    const verificationKey = `gap:vc:${safeKey}`;
+    elements.push({
+      sysmlKey: actionKey,
+      typeSlug: "action",
+      name: pattern.name,
+      description: `Observed adaptive playbook pattern "${pattern.name}".`,
+      properties: {
+        sourceKey: pattern.sourceKey ?? null,
+        patternKey: pattern.patternKey,
+        stableId: stableId("ACT-GAP", safeKey),
+      },
+    });
+    elements.push({
+      sysmlKey: verificationKey,
+      typeSlug: "verification_case",
+      name: `Verify ${pattern.name}`,
+      description: `Verification case for observed adaptive playbook pattern "${pattern.name}".`,
+      properties: {
+        sourceKey: pattern.sourceKey ?? null,
+        patternKey: pattern.patternKey,
+        stableId: stableId("VC-GAP", safeKey),
+      },
+    });
+    relationships.push({ fromKey: GAP_PACKAGE_KEY, toKey: actionKey, relSlug: "contains" });
+    relationships.push({ fromKey: GAP_PACKAGE_KEY, toKey: verificationKey, relSlug: "contains" });
+    relationships.push({ fromKey: actionKey, toKey: "gap:req:evidence-backed-proposal", relSlug: "satisfies" });
+    relationships.push({ fromKey: verificationKey, toKey: "gap:req:evidence-backed-proposal", relSlug: "verifies" });
+    if (pattern.codeAllocationKey) {
+      relationships.push({ fromKey: actionKey, toKey: pattern.codeAllocationKey, relSlug: "allocates" });
+    }
+    if (pattern.sourceKey) {
+      crossLayerRelationships.push({ fromKey: actionKey, toKey: `source:${safeKey}`, relSlug: "traces" });
+    }
+  }
+
+  return {
+    elements,
+    relationships,
+    crossLayerRelationships,
+    elementTypeSlugs: [
+      "package",
+      "requirement",
+      "part_definition",
+      "state",
+      "verification_case",
+      "action",
+    ],
+    relTypeSlugs: ["contains", "satisfies", "verifies", "allocates", "traces"],
+    view: {
+      name: "Governed Adaptive Playbooks - SysML Projection",
+      description:
+        "SysML2 projection of the adaptive playbooks foundation and its no-activation governance controls.",
+      viewpointName: "Governance Architecture",
+      scopeRef: "governed-adaptive-playbooks",
+    },
+    softRemovePrefix: "gap:",
+  };
+}

--- a/apps/web/lib/operate/coworker-turn-metrics.test.ts
+++ b/apps/web/lib/operate/coworker-turn-metrics.test.ts
@@ -89,6 +89,45 @@ describe("recordCoworkerTurnMetric", () => {
     });
   });
 
+  it("persists numeric context and tool-surface telemetry", async () => {
+    const { upsert, getDelegate } = makeDelegate();
+
+    await recordCoworkerTurnMetric(
+      {
+        threadId: "thr-ctx",
+        agentMessageId: "msg-ctx",
+        ctxPeakTokens: 82000,
+        ctxWindowTokens: 128000,
+        toolSurfaceCount: 18,
+        toolDefinitionTokens: 9500,
+        toolSurfaceExceedsLocalCliff: true,
+        toolSurfaceWindowShare: 0.074,
+        toolSelectionAccuracy: 0.5,
+      },
+      { getDelegate },
+    );
+
+    const arg = upsert.mock.calls[0][0];
+    expect(arg.create).toMatchObject({
+      ctxPeakTokens: 82000,
+      ctxWindowTokens: 128000,
+      toolSurfaceCount: 18,
+      toolDefinitionTokens: 9500,
+      toolSurfaceExceedsLocalCliff: true,
+      toolSurfaceWindowShare: 0.074,
+      toolSelectionAccuracy: 0.5,
+    });
+    expect(arg.update).toMatchObject({
+      ctxPeakTokens: 82000,
+      ctxWindowTokens: 128000,
+      toolSurfaceCount: 18,
+      toolDefinitionTokens: 9500,
+      toolSurfaceExceedsLocalCliff: true,
+      toolSurfaceWindowShare: 0.074,
+      toolSelectionAccuracy: 0.5,
+    });
+  });
+
   it("does not write when threadId is missing", async () => {
     const { upsert, getDelegate } = makeDelegate();
     await recordCoworkerTurnMetric(

--- a/apps/web/lib/operate/coworker-turn-metrics.ts
+++ b/apps/web/lib/operate/coworker-turn-metrics.ts
@@ -34,6 +34,13 @@ export type RecordCoworkerTurnMetricInput = {
   toolsAttached?: boolean | null;
   executedTools?: number | null;
   totalMs?: number | null;
+  ctxPeakTokens?: number | null;
+  ctxWindowTokens?: number | null;
+  toolSurfaceCount?: number | null;
+  toolDefinitionTokens?: number | null;
+  toolSurfaceExceedsLocalCliff?: boolean | null;
+  toolSurfaceWindowShare?: number | null;
+  toolSelectionAccuracy?: number | null;
 };
 
 /**
@@ -60,6 +67,11 @@ function intOrZero(value: number | null | undefined): number {
 
 /** Coerce an optional numeric to a nullable stored value (totalMs). */
 function intOrNull(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** Coerce an optional floating-point telemetry value to nullable storage. */
+function floatOrNull(value: number | null | undefined): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
@@ -105,6 +117,13 @@ export async function recordCoworkerTurnMetric(
       toolsAttached: Boolean(input.toolsAttached),
       executedTools: intOrZero(input.executedTools),
       totalMs: intOrNull(input.totalMs),
+      ctxPeakTokens: intOrNull(input.ctxPeakTokens),
+      ctxWindowTokens: intOrNull(input.ctxWindowTokens),
+      toolSurfaceCount: intOrNull(input.toolSurfaceCount),
+      toolDefinitionTokens: intOrNull(input.toolDefinitionTokens),
+      toolSurfaceExceedsLocalCliff: Boolean(input.toolSurfaceExceedsLocalCliff),
+      toolSurfaceWindowShare: floatOrNull(input.toolSurfaceWindowShare),
+      toolSelectionAccuracy: floatOrNull(input.toolSelectionAccuracy),
     };
 
     await delegate.upsert({

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -358,6 +358,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "work-pattern-profile-review",
+    inngestId: "quality/work-pattern-profile-review",
+    name: "Work pattern profile review",
+    purpose:
+      "Reviews coworker work-pattern telemetry and proposes capability needs. If it stops, repeated agent friction stays anecdotal instead of becoming governed improvement evidence.",
+    cron: "17 7 * * *",
+    cadence: "Daily at 07:17",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "log-signature-scanner",
     inngestId: "ops/log-signature-scanner",
     name: "Log signature scanner",

--- a/apps/web/lib/playbooks/architecture-grounding.test.ts
+++ b/apps/web/lib/playbooks/architecture-grounding.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GOVERNED_ADAPTIVE_PLAYBOOKS_GROUNDING,
+  findGovernedAdaptivePlaybookElement,
+} from "./architecture-grounding";
+
+describe("governed adaptive playbooks architecture grounding", () => {
+  it("registers the observer action and verification case with code allocations", () => {
+    const action = findGovernedAdaptivePlaybookElement("ACT-GAP-observe");
+    const verification = findGovernedAdaptivePlaybookElement("VC-GAP-observer");
+
+    expect(action).toMatchObject({
+      elementId: "ACT-GAP-observe",
+      elementType: "action",
+      implementationStatus: "implemented",
+      itValueStreams: ["operate"],
+      verificationCaseId: "VC-GAP-observer",
+    });
+    expect(action?.sysml_allocates).toEqual(
+      expect.arrayContaining([
+        "apps/web/lib/tak/pattern-observer/observer.ts",
+        "apps/web/lib/tak/pattern-observer/classifiers.ts",
+        "apps/web/lib/tak/pattern-observer/core.ts",
+      ]),
+    );
+    expect(verification).toMatchObject({
+      elementId: "VC-GAP-observer",
+      elementType: "verification_case",
+      implementationStatus: "implemented",
+      itValueStreams: ["operate"],
+    });
+    expect(verification?.sysml_allocates).toContain(
+      "apps/web/lib/tak/pattern-observer/observer.test.ts",
+    );
+  });
+
+  it("marks only tested Slice 1 observer behavior implemented", () => {
+    expect(findGovernedAdaptivePlaybookElement("REQ-GAP-slice-1-observer")).toMatchObject({
+      elementType: "requirement",
+      implementationStatus: "implemented",
+      verificationCaseId: "VC-GAP-observer",
+    });
+    expect(findGovernedAdaptivePlaybookElement("SM-GAP-PROMOTION")).toMatchObject({
+      elementType: "state_machine",
+      implementationStatus: "planned",
+    });
+  });
+
+  it("keeps every manifest element grounded in IT4IT operate", () => {
+    expect(GOVERNED_ADAPTIVE_PLAYBOOKS_GROUNDING).not.toHaveLength(0);
+    expect(
+      GOVERNED_ADAPTIVE_PLAYBOOKS_GROUNDING.every((element) =>
+        element.itValueStreams.includes("operate"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/playbooks/architecture-grounding.ts
+++ b/apps/web/lib/playbooks/architecture-grounding.ts
@@ -1,0 +1,87 @@
+export type GovernedAdaptivePlaybookElementType =
+  | "action"
+  | "requirement"
+  | "state_machine"
+  | "verification_case";
+
+export type GovernedAdaptivePlaybookImplementationStatus = "implemented" | "planned";
+
+export type GovernedAdaptivePlaybookGroundingElement = {
+  elementId: string;
+  elementType: GovernedAdaptivePlaybookElementType;
+  name: string;
+  description: string;
+  implementationStatus: GovernedAdaptivePlaybookImplementationStatus;
+  itValueStreams: string[];
+  verificationCaseId?: string;
+  sysml_allocates: string[];
+};
+
+export const GOVERNED_ADAPTIVE_PLAYBOOKS_GROUNDING: GovernedAdaptivePlaybookGroundingElement[] = [
+  {
+    elementId: "REQ-GAP-slice-1-observer",
+    elementType: "requirement",
+    name: "Systemic Capability Needs Observer",
+    description:
+      "Observe repeated coworker evidence and emit reviewable capability needs without activating skills, prompts, grants, routes, policies, code, or Work Case state.",
+    implementationStatus: "implemented",
+    itValueStreams: ["operate"],
+    verificationCaseId: "VC-GAP-observer",
+    sysml_allocates: [
+      "apps/web/lib/tak/pattern-observer/observer.ts",
+      "apps/web/lib/tak/pattern-observer/classifiers.ts",
+      "apps/web/lib/tak/pattern-observer/fingerprint.ts",
+      "apps/web/lib/tak/pattern-observer/core.ts",
+    ],
+  },
+  {
+    elementId: "ACT-GAP-observe",
+    elementType: "action",
+    name: "Observe Governed Adaptive Playbook Signals",
+    description:
+      "Collect recent TaskRun and ToolExecution evidence, classify systemic grant, context-economy, and repeated-success signals, dedupe them, and submit one coworker self-assessment.",
+    implementationStatus: "implemented",
+    itValueStreams: ["operate"],
+    verificationCaseId: "VC-GAP-observer",
+    sysml_allocates: [
+      "apps/web/lib/tak/pattern-observer/observer.ts",
+      "apps/web/lib/tak/pattern-observer/classifiers.ts",
+      "apps/web/lib/tak/pattern-observer/fingerprint.ts",
+      "apps/web/lib/tak/pattern-observer/core.ts",
+    ],
+  },
+  {
+    elementId: "VC-GAP-observer",
+    elementType: "verification_case",
+    name: "Verify Systemic Capability Needs Observer",
+    description:
+      "Unit-level verification that the observer files correctly-kind capability needs, preserves loop guards, dedupes within a sweep, and remains proposal-only.",
+    implementationStatus: "implemented",
+    itValueStreams: ["operate"],
+    sysml_allocates: [
+      "apps/web/lib/tak/pattern-observer/observer.test.ts",
+      "apps/web/lib/tak/pattern-observer/classifiers.test.ts",
+      "apps/web/lib/tak/pattern-observer/fingerprint.test.ts",
+      "apps/web/lib/tak/pattern-observer/core.test.ts",
+      "apps/web/lib/tak/reflection-triggers.test.ts",
+    ],
+  },
+  {
+    elementId: "SM-GAP-PROMOTION",
+    elementType: "state_machine",
+    name: "Governed Adaptive Playbook Promotion Ladder",
+    description:
+      "Observed to candidate to approved to active to retired promotion ladder for adaptive playbooks; activation and case-staged promotion land in later slices.",
+    implementationStatus: "planned",
+    itValueStreams: ["operate"],
+    sysml_allocates: [],
+  },
+];
+
+export function findGovernedAdaptivePlaybookElement(
+  elementId: string,
+): GovernedAdaptivePlaybookGroundingElement | undefined {
+  return GOVERNED_ADAPTIVE_PLAYBOOKS_GROUNDING.find(
+    (element) => element.elementId === elementId,
+  );
+}

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -38,6 +38,7 @@ import { wikiLint } from "./wiki-lint";
 import { gitPromotionSandboxVerification } from "./git-promotion-sandbox-verification";
 import { skillMetricsAggregator } from "./skill-metrics-aggregator";
 import { skillCurator } from "./skill-curator";
+import { workPatternProfileReview } from "./work-pattern-profile-review";
 import {
   allBackupsDailyScheduled,
   postgresDailyBackupScheduled,
@@ -81,6 +82,7 @@ export const scheduledFunctions = [
   wikiLint,
   skillMetricsAggregator,
   skillCurator,
+  workPatternProfileReview,
   researchScheduleScan,
   materialFreshnessDecay,
   allBackupsDailyScheduled,

--- a/apps/web/lib/queue/functions/work-pattern-profile-review.ts
+++ b/apps/web/lib/queue/functions/work-pattern-profile-review.ts
@@ -1,0 +1,23 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+export const workPatternProfileReview = inngest.createFunction(
+  {
+    id: "quality/work-pattern-profile-review",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("17 7 * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("review-agent-work-patterns", async () => {
+      const { runDueWorkPatternProfileReviews } = await import(
+        "@/lib/tak/work-pattern-profile-review"
+      );
+      return runDueWorkPatternProfileReviews();
+    });
+  },
+);

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1294,6 +1294,7 @@ export async function runAgenticLoop(params: {
     // definition-token cost banded against the local selection cliff, plus this
     // turn's tool-selection accuracy. Observability-only — never changes what is
     // sent; makes a ballooning surface or a repeatedly-failing tool loud.
+    const ctxPressure = classifyContextPressure(ctxPeakTokens, resolvedMaxContextTokens);
     const surface = assessToolSurface({ tools: toolsForProvider, windowTokens: resolvedMaxContextTokens });
     const turnToolAccuracy = computeToolSelectionAccuracy(
       executedTools.map((t) => ({ toolName: t.name, success: t.result.success })),
@@ -1305,7 +1306,7 @@ export async function runAgenticLoop(params: {
         `dispatches=${inferenceCallCount} nudges=${continuationNudges} ` +
         `toolsAttached=${toolsAttachedForTurn} executedTools=${executedTools.length} ` +
         `totalMs=${Date.now() - startTime} ` +
-        `ctxPeakTokens=${ctxPeakTokens} ctxZone=${classifyContextPressure(ctxPeakTokens, resolvedMaxContextTokens).zone} ` +
+        `ctxPeakTokens=${ctxPeakTokens} ctxZone=${ctxPressure.zone} ` +
         `toolSurface=${surface.toolCount} estToolTokens=${surface.estDefinitionTokens} surfaceZone=${surface.zone} ` +
         `toolAccuracy=${turnToolAccuracy.total === 0 ? "na" : turnToolAccuracy.accuracy.toFixed(2)}`,
       ),
@@ -1325,6 +1326,13 @@ export async function runAgenticLoop(params: {
       toolsAttached: toolsAttachedForTurn,
       executedTools: executedTools.length,
       totalMs: Date.now() - startTime,
+      ctxPeakTokens: ctxPressure.estimatedTokens,
+      ctxWindowTokens: resolvedMaxContextTokens,
+      toolSurfaceCount: surface.toolCount,
+      toolDefinitionTokens: surface.estDefinitionTokens,
+      toolSurfaceExceedsLocalCliff: surface.exceedsLocalCliff,
+      toolSurfaceWindowShare: surface.windowShare,
+      toolSelectionAccuracy: turnToolAccuracy.total === 0 ? null : turnToolAccuracy.accuracy,
     });
   };
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -34,7 +34,7 @@ import {
 import { persistExecutionPlan, loadExecutionPlan } from "./execution-plan-store";
 import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } from "./context-pressure";
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
-import { assessToolSurface, computeToolSelectionAccuracy } from "./context-economy-metrics";
+import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 
 // Safety ceiling — NOT a behavioral limit. The loop terminates when the model
@@ -1281,23 +1281,21 @@ export async function runAgenticLoop(params: {
   let sandboxUnavailableCount = 0; // Circuit breaker: stop trying sandbox tools if unavailable
   let previousResponseId: string | undefined; // Responses API conversation chaining
 
-  // Per-turn observability: one structured summary line per user turn, carrying
-  // the correlation key (threadId) and the figures that make a slow turn
-  // self-evident — number of inference dispatches, nudges, whether tools were
-  // attached, and total wall-clock. Before this, diagnosing a 135s "hello"
-  // meant hand-stitching timestamps across un-correlated [cli-adapter] /
-  // [agentic-loop] lines while a concurrent coworker's logs interleaved. See
-  // the Portfolio Analyst latency investigation, 2026-06-04.
+  // Per-turn observability: one structured summary line with the correlation
+  // key and the figures that make slow or tool-heavy turns self-evident.
   const toolsAttachedForTurn = Boolean((toolsForProvider && toolsForProvider.length > 0) || planEnabled);
   const logTurnSummary = (provider: string, model: string): void => {
-    // Context-economy gauge (R8/P12): the tool-surface size + estimated
-    // definition-token cost banded against the local selection cliff, plus this
-    // turn's tool-selection accuracy. Observability-only — never changes what is
-    // sent; makes a ballooning surface or a repeatedly-failing tool loud.
+    // Context-economy gauge (R8/P12): observability only, never model input.
     const ctxPressure = classifyContextPressure(ctxPeakTokens, resolvedMaxContextTokens);
     const surface = assessToolSurface({ tools: toolsForProvider, windowTokens: resolvedMaxContextTokens });
     const turnToolAccuracy = computeToolSelectionAccuracy(
       executedTools.map((t) => ({ toolName: t.name, success: t.result.success })),
+    );
+    const economyMetrics = contextEconomyTurnMetricFields(
+      ctxPressure.estimatedTokens,
+      resolvedMaxContextTokens,
+      surface,
+      turnToolAccuracy,
     );
     console.log(
       sanitizeForLog(
@@ -1308,7 +1306,7 @@ export async function runAgenticLoop(params: {
         `totalMs=${Date.now() - startTime} ` +
         `ctxPeakTokens=${ctxPeakTokens} ctxZone=${ctxPressure.zone} ` +
         `toolSurface=${surface.toolCount} estToolTokens=${surface.estDefinitionTokens} surfaceZone=${surface.zone} ` +
-        `toolAccuracy=${turnToolAccuracy.total === 0 ? "na" : turnToolAccuracy.accuracy.toFixed(2)}`,
+        `toolAccuracy=${economyMetrics.toolSelectionAccuracy === null ? "na" : economyMetrics.toolSelectionAccuracy.toFixed(2)}`,
       ),
     );
     // BI-47443B67: persist the same rollup durably so the regression detector
@@ -1326,13 +1324,7 @@ export async function runAgenticLoop(params: {
       toolsAttached: toolsAttachedForTurn,
       executedTools: executedTools.length,
       totalMs: Date.now() - startTime,
-      ctxPeakTokens: ctxPressure.estimatedTokens,
-      ctxWindowTokens: resolvedMaxContextTokens,
-      toolSurfaceCount: surface.toolCount,
-      toolDefinitionTokens: surface.estDefinitionTokens,
-      toolSurfaceExceedsLocalCliff: surface.exceedsLocalCliff,
-      toolSurfaceWindowShare: surface.windowShare,
-      toolSelectionAccuracy: turnToolAccuracy.total === 0 ? null : turnToolAccuracy.accuracy,
+      ...economyMetrics,
     });
   };
 

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -14,6 +14,9 @@ vi.mock("@/lib/tak/agentic-loop", () => ({ runAgenticLoop: vi.fn() }));
 vi.mock("@/lib/tak/pattern-observer-service", () => ({
   observeWorkPatternsAfterRun: vi.fn(),
 }));
+vi.mock("@/lib/tak/pattern-observer/observer", () => ({
+  observeCoworkerPatterns: vi.fn(),
+}));
 vi.mock("@/lib/mcp-tools", () => ({
   executeTool: vi.fn(),
   getAvailableTools: vi.fn(),
@@ -38,6 +41,8 @@ describe("createAutonomousWorkRun", () => {
 
     const observer = await import("@/lib/tak/pattern-observer-service");
     vi.mocked(observer.observeWorkPatternsAfterRun).mockReset();
+    const systemicObserver = await import("@/lib/tak/pattern-observer/observer");
+    vi.mocked(systemicObserver.observeCoworkerPatterns).mockReset();
 
     const tools = await import("@/lib/mcp-tools");
     vi.mocked(tools.executeTool).mockReset();
@@ -271,6 +276,12 @@ describe("createAutonomousWorkRun", () => {
     vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "Done.", executedTools: [] } as never);
     const observer = await import("@/lib/tak/pattern-observer-service");
     vi.mocked(observer.observeWorkPatternsAfterRun).mockResolvedValue({ processed: 0 } as never);
+    const systemicObserver = await import("@/lib/tak/pattern-observer/observer");
+    vi.mocked(systemicObserver.observeCoworkerPatterns).mockResolvedValue({
+      processed: 0,
+      submitted: false,
+      skippedReason: "no-signals",
+    } as never);
 
     const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
 
@@ -296,6 +307,45 @@ describe("createAutonomousWorkRun", () => {
       routeContext: "/platform/tools/discovery",
       since: expect.any(Date),
     });
+    expect(systemicObserver.observeCoworkerPatterns).toHaveBeenCalledWith({
+      agentId: "inventory-specialist",
+      routeContext: "/platform/tools/discovery",
+      since: expect.any(Date),
+      toolSurface: [],
+    });
+  });
+
+  it("skips the systemic observer when the guarded observer reports a reflection loop", async () => {
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "Done.", executedTools: [] } as never);
+    const observer = await import("@/lib/tak/pattern-observer-service");
+    vi.mocked(observer.observeWorkPatternsAfterRun).mockResolvedValue({
+      processed: 0,
+      skippedReason: "reflection-loop-guard",
+    } as never);
+    const systemicObserver = await import("@/lib/tak/pattern-observer/observer");
+    vi.mocked(systemicObserver.observeCoworkerPatterns).mockResolvedValue({
+      processed: 0,
+      submitted: false,
+    } as never);
+
+    const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
+
+    await executeAutonomousAgenticLoop({
+      systemPrompt: "You are helpful.",
+      chatHistory: [{ role: "user", content: "Run it." }],
+      sensitivity: "internal",
+      tools: [],
+      toolsForProvider: [],
+      userId: "user-1",
+      routeContext: "/platform/tools/discovery",
+      agentId: "inventory-specialist",
+      threadId: "thread-1",
+      taskRunId: "TR-RFL-ABCDEF12",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(systemicObserver.observeCoworkerPatterns).not.toHaveBeenCalled();
   });
 
   it("forwards MCP token identity into the agentic loop", async () => {

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -11,6 +11,9 @@ vi.mock("@dpf/db", () => {
 });
 
 vi.mock("@/lib/tak/agentic-loop", () => ({ runAgenticLoop: vi.fn() }));
+vi.mock("@/lib/tak/pattern-observer-service", () => ({
+  observeWorkPatternsAfterRun: vi.fn(),
+}));
 vi.mock("@/lib/mcp-tools", () => ({
   executeTool: vi.fn(),
   getAvailableTools: vi.fn(),
@@ -32,6 +35,9 @@ describe("createAutonomousWorkRun", () => {
 
     const agentic = await import("@/lib/tak/agentic-loop");
     vi.mocked(agentic.runAgenticLoop).mockReset();
+
+    const observer = await import("@/lib/tak/pattern-observer-service");
+    vi.mocked(observer.observeWorkPatternsAfterRun).mockReset();
 
     const tools = await import("@/lib/mcp-tools");
     vi.mocked(tools.executeTool).mockReset();
@@ -258,6 +264,38 @@ describe("createAutonomousWorkRun", () => {
         threadId: "thread-1",
       }),
     );
+  });
+
+  it("fires the pattern observer after an agentic loop run", async () => {
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "Done.", executedTools: [] } as never);
+    const observer = await import("@/lib/tak/pattern-observer-service");
+    vi.mocked(observer.observeWorkPatternsAfterRun).mockResolvedValue({ processed: 0 } as never);
+
+    const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
+
+    await executeAutonomousAgenticLoop({
+      systemPrompt: "You are helpful.",
+      chatHistory: [{ role: "user", content: "Run it." }],
+      sensitivity: "internal",
+      tools: [],
+      toolsForProvider: [],
+      userId: "user-1",
+      routeContext: "/platform/tools/discovery",
+      agentId: "inventory-specialist",
+      threadId: "thread-1",
+      taskRunId: "TR-SCHED-ABCDEF12",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(observer.observeWorkPatternsAfterRun).toHaveBeenCalledWith({
+      taskRunId: "TR-SCHED-ABCDEF12",
+      userId: "user-1",
+      agentId: "inventory-specialist",
+      threadId: "thread-1",
+      routeContext: "/platform/tools/discovery",
+      since: expect.any(Date),
+    });
   });
 
   it("forwards MCP token identity into the agentic loop", async () => {

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -305,6 +305,31 @@ export async function executeAutonomousAgenticLoop(input: {
     }
   })();
 
+  // Governed adaptive playbooks foundation: observe repeated work patterns
+  // after the run and emit evidence-backed capability needs. This is
+  // observability/proposal only; it must never mutate prompts, skills, grants,
+  // model routes, or Work Case state.
+  void (async () => {
+    try {
+      const { observeWorkPatternsAfterRun } = await import(
+        "@/lib/tak/pattern-observer-service"
+      );
+      await observeWorkPatternsAfterRun({
+        taskRunId: input.taskRunId ?? null,
+        userId: input.userId,
+        agentId: input.agentId,
+        threadId: input.threadId,
+        routeContext: input.routeContext,
+        since: startedAt,
+      });
+    } catch (err) {
+      console.warn(
+        "[pattern-observer] post-run hook failed:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  })();
+
   return result;
 }
 

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -314,7 +314,7 @@ export async function executeAutonomousAgenticLoop(input: {
       const { observeWorkPatternsAfterRun } = await import(
         "@/lib/tak/pattern-observer-service"
       );
-      await observeWorkPatternsAfterRun({
+      const foundationResult = await observeWorkPatternsAfterRun({
         taskRunId: input.taskRunId ?? null,
         userId: input.userId,
         agentId: input.agentId,
@@ -322,6 +322,20 @@ export async function executeAutonomousAgenticLoop(input: {
         routeContext: input.routeContext,
         since: startedAt,
       });
+      if (
+        foundationResult.skippedReason !== "reflection-loop-guard" &&
+        foundationResult.skippedReason !== "missing-task-run"
+      ) {
+        const { observeCoworkerPatterns } = await import(
+          "@/lib/tak/pattern-observer/observer"
+        );
+        await observeCoworkerPatterns({
+          agentId: input.agentId,
+          routeContext: input.routeContext,
+          since: startedAt,
+          toolSurface: input.toolsForProvider ?? input.tools,
+        });
+      }
     } catch (err) {
       console.warn(
         "[pattern-observer] post-run hook failed:",

--- a/apps/web/lib/tak/context-economy-metrics.ts
+++ b/apps/web/lib/tak/context-economy-metrics.ts
@@ -100,6 +100,23 @@ export type ToolSelectionAccuracy = {
   perTool: Record<string, { total: number; succeeded: number; accuracy: number }>;
 };
 
+export function contextEconomyTurnMetricFields(
+  ctxPeakTokens: number,
+  ctxWindowTokens: number | null,
+  surface: ToolSurfaceAssessment,
+  accuracy: ToolSelectionAccuracy,
+) {
+  return {
+    ctxPeakTokens,
+    ctxWindowTokens,
+    toolSurfaceCount: surface.toolCount,
+    toolDefinitionTokens: surface.estDefinitionTokens,
+    toolSurfaceExceedsLocalCliff: surface.exceedsLocalCliff,
+    toolSurfaceWindowShare: surface.windowShare,
+    toolSelectionAccuracy: accuracy.total === 0 ? null : accuracy.accuracy,
+  };
+}
+
 /**
  * Tool-selection / tool-call accuracy over a set of executed tool calls: the
  * fraction that succeeded, overall and per tool. Used per-turn (over the turn's

--- a/apps/web/lib/tak/pattern-observer-service.test.ts
+++ b/apps/web/lib/tak/pattern-observer-service.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  observeWorkPatternsAfterRun,
+  type PatternObserverParentRun,
+  type PatternObserverServiceDb,
+  type PatternObserverServiceDeps,
+} from "./pattern-observer-service";
+import type {
+  PatternObserverEnvelope,
+  PatternObserverToolExecution,
+  PatternObserverTurnMetric,
+} from "./pattern-observer";
+
+function makeDeps(overrides?: {
+  taskRun?: PatternObserverParentRun | null;
+  toolExecutions?: PatternObserverToolExecution[];
+  turnMetrics?: PatternObserverTurnMetric[];
+  envelopes?: PatternObserverEnvelope[];
+  priorNeeds?: Array<{ evidenceJson?: unknown; readinessJson?: unknown }>;
+  getTaskRun?: () => Promise<PatternObserverParentRun | null>;
+}): PatternObserverServiceDeps & { db: PatternObserverServiceDb } {
+  const db: PatternObserverServiceDb = {
+    getTaskRun: vi.fn(
+      overrides?.getTaskRun ??
+        (async () =>
+          overrides?.taskRun ?? {
+            taskRunId: "TR-1",
+            source: "coworker",
+            title: "Do the work",
+            a2aMetadata: { keep: true },
+          }),
+    ),
+    updateTaskRun: vi.fn(async () => undefined),
+    listToolExecutions: vi.fn(async () => overrides?.toolExecutions ?? []),
+    listTurnMetrics: vi.fn(async () => overrides?.turnMetrics ?? []),
+    listTaskRuns: vi.fn(async () => []),
+    listEnvelopes: vi.fn(async () => overrides?.envelopes ?? []),
+    listPriorNeeds: vi.fn(async () => overrides?.priorNeeds ?? []),
+  };
+  return {
+    db,
+    submitSelfAssessment: vi.fn(async () => ({
+      assessmentId: "CWSA-1",
+      needIds: ["CWN-1"],
+      backlogItemIds: [],
+    })),
+    touchImprovementSignal: vi.fn(async () => ({ signalId: "IS-1", isNew: true })),
+  };
+}
+
+function input() {
+  return {
+    taskRunId: "TR-1",
+    userId: "user-1",
+    agentId: "AGT-OPS",
+    threadId: "thread-1",
+    routeContext: "/ops",
+    since: new Date("2026-06-27T12:00:00Z"),
+  };
+}
+
+describe("observeWorkPatternsAfterRun", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("stamps the parent TaskRun and emits assessment plus improvement signal", async () => {
+    const deps = makeDeps({
+      toolExecutions: [
+        {
+          id: "tool-1",
+          toolName: "export_archimate",
+          success: false,
+          summary: "forbidden_grant: ea_graph_read required",
+          result: { error: "forbidden_grant: ea_graph_read required" },
+          taskRunId: "TR-1",
+        },
+        {
+          id: "tool-2",
+          toolName: "export_archimate",
+          success: false,
+          summary: "forbidden_grant: ea_graph_read required",
+          result: { error: "forbidden_grant: ea_graph_read required" },
+          taskRunId: "TR-1",
+        },
+      ],
+    });
+
+    const result = await observeWorkPatternsAfterRun(input(), deps);
+
+    expect(result).toEqual({ processed: 1 });
+    expect(deps.db.listToolExecutions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskRunId: "TR-1",
+        agentId: "AGT-OPS",
+        routeContext: "/ops",
+      }),
+    );
+    expect(deps.db.updateTaskRun).toHaveBeenCalledWith(
+      "TR-1",
+      expect.objectContaining({
+        repeatedPatternKey: expect.stringContaining("grant-denial"),
+        a2aMetadata: expect.objectContaining({
+          keep: true,
+          workPattern: expect.objectContaining({
+            status: "observed",
+            candidate: expect.objectContaining({ kind: "grant" }),
+          }),
+        }),
+      }),
+    );
+    expect(deps.submitSelfAssessment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "AGT-OPS",
+        trigger: "work-pattern-observer",
+        routeContext: "/ops",
+        verdict: "gaps",
+        needs: [expect.objectContaining({ kind: "grant" })],
+      }),
+    );
+    expect(deps.touchImprovementSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceType: "work_pattern_observer",
+        sourceId: expect.stringContaining("grant-denial"),
+        agentId: "AGT-OPS",
+        threadId: "thread-1",
+      }),
+    );
+  });
+
+  it("skips reflection runs and does not load evidence", async () => {
+    const deps = makeDeps({
+      taskRun: {
+        taskRunId: "TR-REFLECT",
+        source: "proactive",
+        title: "Skill reflection: repeated tool use",
+        a2aMetadata: { reflectionDepth: 1 },
+      },
+    });
+
+    await expect(
+      observeWorkPatternsAfterRun({ ...input(), taskRunId: "TR-REFLECT" }, deps),
+    ).resolves.toEqual({ processed: 0, skippedReason: "reflection-loop-guard" });
+
+    expect(deps.db.listToolExecutions).not.toHaveBeenCalled();
+    expect(deps.submitSelfAssessment).not.toHaveBeenCalled();
+  });
+
+  it("returns no-signals when the classifier finds nothing", async () => {
+    const deps = makeDeps();
+
+    await expect(observeWorkPatternsAfterRun(input(), deps)).resolves.toEqual({
+      processed: 0,
+      skippedReason: "no-signals",
+    });
+
+    expect(deps.db.updateTaskRun).not.toHaveBeenCalled();
+  });
+
+  it("fails open and logs when evidence loading fails", async () => {
+    const deps = makeDeps({
+      getTaskRun: async () => {
+        throw new Error("db unavailable");
+      },
+    });
+
+    await expect(observeWorkPatternsAfterRun(input(), deps)).resolves.toEqual({
+      processed: 0,
+      skippedReason: "observer-error",
+    });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/tak/pattern-observer-service.ts
+++ b/apps/web/lib/tak/pattern-observer-service.ts
@@ -1,0 +1,336 @@
+import type { Prisma } from "@dpf/db";
+import type { SubmitCoworkerSelfAssessmentInput } from "@/lib/coworker-self-assessment/types";
+import type { CreateOrTouchImprovementSignalInput } from "@/lib/improvement-flywheel/signals";
+import { getReflectionDepth, isReflectionRun } from "./reflection-triggers";
+import {
+  classifyPatternSignals,
+  type PatternObserverEnvelope,
+  type PatternObserverTaskRun,
+  type PatternObserverToolExecution,
+  type PatternObserverTurnMetric,
+} from "./pattern-observer";
+import { mergeWorkPatternMetadata } from "./work-pattern-types";
+
+const OBSERVER_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export type PatternObserverParentRun = {
+  taskRunId: string;
+  source?: string | null;
+  title?: string | null;
+  a2aMetadata?: Prisma.JsonValue | null;
+};
+
+export type PatternObserverNeedRow = {
+  evidenceJson?: unknown;
+  readinessJson?: unknown;
+};
+
+export type PatternObserverQueryInput = {
+  taskRunId: string;
+  agentId: string;
+  routeContext: string;
+  threadId: string | null;
+  since: Date;
+  windowStart: Date;
+};
+
+export type PatternObserverServiceDb = {
+  getTaskRun(taskRunId: string): Promise<PatternObserverParentRun | null>;
+  updateTaskRun(
+    taskRunId: string,
+    data: { repeatedPatternKey: string; a2aMetadata: Record<string, unknown> },
+  ): Promise<unknown>;
+  listToolExecutions(input: PatternObserverQueryInput): Promise<PatternObserverToolExecution[]>;
+  listTurnMetrics(input: PatternObserverQueryInput): Promise<PatternObserverTurnMetric[]>;
+  listTaskRuns(input: PatternObserverQueryInput): Promise<PatternObserverTaskRun[]>;
+  listEnvelopes(input: PatternObserverQueryInput): Promise<PatternObserverEnvelope[]>;
+  listPriorNeeds(input: PatternObserverQueryInput): Promise<PatternObserverNeedRow[]>;
+};
+
+export type PatternObserverServiceDeps = {
+  db?: PatternObserverServiceDb;
+  submitSelfAssessment?: (input: SubmitCoworkerSelfAssessmentInput) => Promise<unknown>;
+  touchImprovementSignal?: (input: CreateOrTouchImprovementSignalInput) => Promise<unknown>;
+};
+
+export type ObserveWorkPatternsAfterRunInput = {
+  taskRunId: string | null;
+  userId: string;
+  agentId: string;
+  threadId: string | null;
+  routeContext: string;
+  since: Date;
+};
+
+export type ObserveWorkPatternsAfterRunResult = {
+  processed: number;
+  skippedReason?:
+    | "missing-task-run"
+    | "reflection-loop-guard"
+    | "no-signals"
+    | "observer-error";
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function fingerprintFromNeed(row: PatternObserverNeedRow): string | null {
+  for (const value of [row.evidenceJson, row.readinessJson]) {
+    if (!isRecord(value)) continue;
+    const fingerprint = value.fingerprint;
+    if (typeof fingerprint === "string" && fingerprint.length > 0) {
+      return fingerprint;
+    }
+  }
+  return null;
+}
+
+async function defaultDb(): Promise<PatternObserverServiceDb> {
+  const { prisma } = await import("@dpf/db");
+  return {
+    getTaskRun: (taskRunId) =>
+      prisma.taskRun.findUnique({
+        where: { taskRunId },
+        select: { taskRunId: true, source: true, title: true, a2aMetadata: true },
+      }),
+    updateTaskRun: (taskRunId, data) =>
+      prisma.taskRun.update({
+        where: { taskRunId },
+        data: {
+          repeatedPatternKey: data.repeatedPatternKey,
+          a2aMetadata: data.a2aMetadata as Prisma.InputJsonValue,
+        },
+      }),
+    listToolExecutions: (input) =>
+      prisma.toolExecution.findMany({
+        where: {
+          OR: [
+            { taskRunId: input.taskRunId },
+            {
+              agentId: input.agentId,
+              routeContext: input.routeContext,
+              createdAt: { gte: input.windowStart },
+            },
+          ],
+        },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+        select: {
+          id: true,
+          toolName: true,
+          success: true,
+          summary: true,
+          result: true,
+          taskRunId: true,
+          createdAt: true,
+        },
+      }),
+    listTurnMetrics: (input) =>
+      prisma.coworkerTurnMetric.findMany({
+        where: input.threadId
+          ? {
+              OR: [
+                { threadId: input.threadId },
+                {
+                  agentId: input.agentId,
+                  routeContext: input.routeContext,
+                  createdAt: { gte: input.windowStart },
+                },
+              ],
+            }
+          : {
+              agentId: input.agentId,
+              routeContext: input.routeContext,
+              createdAt: { gte: input.windowStart },
+            },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+      }),
+    listTaskRuns: (input) =>
+      prisma.taskRun.findMany({
+        where: {
+          currentAgentId: input.agentId,
+          routeContext: input.routeContext,
+          createdAt: { gte: input.windowStart },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+        select: {
+          taskRunId: true,
+          repeatedPatternKey: true,
+          a2aMetadata: true,
+          createdAt: true,
+        },
+      }),
+    listEnvelopes: (input) =>
+      prisma.coworkerActionEnvelope
+        .findMany({
+          where: input.threadId
+            ? {
+                OR: [
+                  { threadId: input.threadId },
+                  {
+                    coworkerAgentId: input.agentId,
+                    createdAt: { gte: input.windowStart },
+                  },
+                ],
+              }
+            : {
+                coworkerAgentId: input.agentId,
+                createdAt: { gte: input.windowStart },
+              },
+          orderBy: { createdAt: "desc" },
+          take: 50,
+          select: {
+            id: true,
+            manifestActionId: true,
+            status: true,
+            createdAt: true,
+          },
+        })
+        .then((rows) =>
+          rows.map((row) => ({
+            id: row.id,
+            proposedActionKey: row.manifestActionId,
+            status: row.status,
+            approved: row.status === "approved",
+            createdAt: row.createdAt,
+          })),
+        ),
+    listPriorNeeds: (input) =>
+      prisma.coworkerCapabilityNeed.findMany({
+        where: {
+          agentId: input.agentId,
+          createdAt: { gte: input.windowStart },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 100,
+        select: { evidenceJson: true, readinessJson: true },
+      }),
+  };
+}
+
+async function defaultSubmitSelfAssessment(input: SubmitCoworkerSelfAssessmentInput) {
+  const { submitCoworkerSelfAssessment } = await import(
+    "@/lib/coworker-self-assessment/assessment-service"
+  );
+  return submitCoworkerSelfAssessment(input);
+}
+
+async function defaultTouchImprovementSignal(input: CreateOrTouchImprovementSignalInput) {
+  const { createOrTouchImprovementSignal } = await import(
+    "@/lib/improvement-flywheel/signals"
+  );
+  return createOrTouchImprovementSignal(input);
+}
+
+export async function observeWorkPatternsAfterRun(
+  input: ObserveWorkPatternsAfterRunInput,
+  deps?: PatternObserverServiceDeps,
+): Promise<ObserveWorkPatternsAfterRunResult> {
+  if (!input.taskRunId) {
+    return { processed: 0, skippedReason: "missing-task-run" };
+  }
+
+  try {
+    const db = deps?.db ?? (await defaultDb());
+    const parent = await db.getTaskRun(input.taskRunId);
+    if (!parent) {
+      return { processed: 0, skippedReason: "missing-task-run" };
+    }
+    if (isReflectionRun(parent) || getReflectionDepth(parent) >= 1) {
+      return { processed: 0, skippedReason: "reflection-loop-guard" };
+    }
+
+    const windowStart = new Date(input.since.getTime() - OBSERVER_WINDOW_MS);
+    const query: PatternObserverQueryInput = {
+      taskRunId: input.taskRunId,
+      agentId: input.agentId,
+      routeContext: input.routeContext,
+      threadId: input.threadId,
+      since: input.since,
+      windowStart,
+    };
+    const [toolExecutions, turnMetrics, taskRuns, envelopes, priorNeeds] =
+      await Promise.all([
+        db.listToolExecutions(query),
+        db.listTurnMetrics(query),
+        db.listTaskRuns(query),
+        db.listEnvelopes(query),
+        db.listPriorNeeds(query),
+      ]);
+
+    const priorNeedFingerprints = new Set(
+      priorNeeds.map(fingerprintFromNeed).filter((value): value is string => Boolean(value)),
+    );
+    const classified = classifyPatternSignals({
+      agentId: input.agentId,
+      routeContext: input.routeContext,
+      since: input.since,
+      toolExecutions,
+      turnMetrics,
+      taskRuns,
+      envelopes,
+      priorNeedFingerprints,
+    });
+    if (classified.needs.length === 0 || classified.patterns.length === 0) {
+      return { processed: 0, skippedReason: "no-signals" };
+    }
+
+    const firstPattern = classified.patterns[0];
+    await db.updateTaskRun(input.taskRunId, {
+      repeatedPatternKey: firstPattern.metadata.patternKey,
+      a2aMetadata: mergeWorkPatternMetadata(parent.a2aMetadata, firstPattern.metadata),
+    });
+
+    const submitSelfAssessment = deps?.submitSelfAssessment ?? defaultSubmitSelfAssessment;
+    await submitSelfAssessment({
+      agentId: input.agentId,
+      trigger: "work-pattern-observer",
+      routeContext: input.routeContext,
+      verdict: "gaps",
+      confidence: "medium",
+      missionSummary: `Observed ${classified.needs.length} repeated work-pattern signal(s).`,
+      capabilitySummary: classified.needs.map((need) => need.need).join("; "),
+      rawPayload: {
+        taskRunId: input.taskRunId,
+        patternKeys: classified.patterns.map((pattern) => pattern.metadata.patternKey),
+      },
+      needs: classified.needs.map((need) => ({
+        kind: need.kind,
+        severity: need.severity,
+        need: need.need,
+        blocks: need.blocks,
+        evidenceJson: need.evidenceJson,
+        readinessJson: need.readinessJson,
+      })),
+    });
+
+    const touchImprovementSignal =
+      deps?.touchImprovementSignal ?? defaultTouchImprovementSignal;
+    for (const pattern of classified.patterns) {
+      await touchImprovementSignal({
+        sourceType: "work_pattern_observer",
+        sourceId: pattern.metadata.patternKey,
+        title: pattern.need.need,
+        description: pattern.need.blocks,
+        evidence: pattern.need.evidenceJson,
+        routeContext: input.routeContext,
+        agentId: input.agentId,
+        threadId: input.threadId,
+        suspectedRootCause: String(pattern.need.evidenceJson.signal ?? "work-pattern"),
+        objectiveImpactHypothesis:
+          "Repeated coworker friction may indicate a reusable capability, convention, or tool-surface improvement.",
+      });
+    }
+
+    return { processed: classified.needs.length };
+  } catch (err) {
+    console.warn(
+      "[pattern-observer] failed to observe post-run work patterns:",
+      err instanceof Error ? err.message : err,
+    );
+    return { processed: 0, skippedReason: "observer-error" };
+  }
+}

--- a/apps/web/lib/tak/pattern-observer.test.ts
+++ b/apps/web/lib/tak/pattern-observer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyPatternSignals } from "./pattern-observer";
+import { classifyPatternSignals, runObservation } from "./pattern-observer";
 
 function failedTool(input: {
   id?: string;
@@ -72,6 +72,10 @@ const FORBIDDEN_ACTIVATION_KEYS = [
 ];
 
 describe("classifyPatternSignals", () => {
+  it("re-exports the pattern observer core from the conventional module path", () => {
+    expect(typeof runObservation).toBe("function");
+  });
+
   it("classifies repeated grant denial as a grant need", () => {
     const out = classifyPatternSignals(grantDeniedFixture());
 

--- a/apps/web/lib/tak/pattern-observer.test.ts
+++ b/apps/web/lib/tak/pattern-observer.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { classifyPatternSignals } from "./pattern-observer";
+
+function failedTool(input: {
+  id?: string;
+  toolName: string;
+  summary: string;
+  taskRunId?: string;
+}) {
+  return {
+    id: input.id ?? `${input.toolName}-failure`,
+    toolName: input.toolName,
+    success: false,
+    summary: input.summary,
+    result: { error: input.summary },
+    taskRunId: input.taskRunId ?? "run-1",
+    createdAt: new Date("2026-06-27T00:01:00Z"),
+  };
+}
+
+function metric(input: {
+  agentMessageId?: string;
+  toolSurfaceCount?: number;
+  toolDefinitionTokens?: number;
+  toolSurfaceExceedsLocalCliff?: boolean;
+  toolSelectionAccuracy?: number;
+  executedTools?: number;
+}) {
+  return {
+    threadId: "thread-1",
+    agentMessageId: input.agentMessageId ?? "msg-1",
+    toolSurfaceCount: input.toolSurfaceCount ?? null,
+    toolDefinitionTokens: input.toolDefinitionTokens ?? null,
+    toolSurfaceExceedsLocalCliff: input.toolSurfaceExceedsLocalCliff ?? null,
+    toolSelectionAccuracy: input.toolSelectionAccuracy ?? null,
+    executedTools: input.executedTools ?? null,
+    createdAt: new Date("2026-06-27T00:02:00Z"),
+  };
+}
+
+function grantDeniedFixture(priorNeedFingerprints = new Set<string>()) {
+  return {
+    agentId: "AGT-OPS",
+    routeContext: "/ops",
+    since: new Date("2026-06-27T00:00:00Z"),
+    toolExecutions: [
+      failedTool({
+        id: "tool-1",
+        toolName: "export_archimate",
+        summary: "forbidden_grant: ea_graph_read required",
+      }),
+      failedTool({
+        id: "tool-2",
+        toolName: "export_archimate",
+        summary: "forbidden_grant: ea_graph_read required",
+      }),
+    ],
+    turnMetrics: [],
+    taskRuns: [],
+    envelopes: [],
+    priorNeedFingerprints,
+  };
+}
+
+describe("classifyPatternSignals", () => {
+  it("classifies repeated grant denial as a grant need", () => {
+    const out = classifyPatternSignals(grantDeniedFixture());
+
+    expect(out.needs[0]).toMatchObject({
+      kind: "grant",
+      severity: "important",
+    });
+    expect(out.needs[0]?.evidenceJson).toMatchObject({
+      toolName: "export_archimate",
+      occurrences: 2,
+    });
+    expect(out.patterns[0]?.metadata).toMatchObject({
+      status: "observed",
+      source: "observer",
+      scope: "route",
+      candidate: { kind: "grant" },
+    });
+    expect(out.patterns[0]?.metadata.evidence?.[0]).toEqual({
+      taskRunId: "run-1",
+      toolExecutionId: "tool-1",
+    });
+  });
+
+  it("classifies tool-surface overload as a tool need", () => {
+    const out = classifyPatternSignals({
+      agentId: "AGT-BUILD",
+      routeContext: "/build",
+      since: new Date("2026-06-27T00:00:00Z"),
+      toolExecutions: [],
+      taskRuns: [],
+      envelopes: [],
+      turnMetrics: [
+        metric({
+          toolSurfaceCount: 18,
+          toolSurfaceExceedsLocalCliff: true,
+          toolDefinitionTokens: 12000,
+        }),
+        metric({
+          toolSurfaceCount: 17,
+          toolSurfaceExceedsLocalCliff: true,
+          toolDefinitionTokens: 11800,
+        }),
+      ],
+      priorNeedFingerprints: new Set(),
+    });
+
+    expect(out.needs[0]).toMatchObject({
+      kind: "tool",
+      severity: "important",
+      evidenceJson: {
+        signal: "tool-surface-overload",
+        maxToolSurfaceCount: 18,
+      },
+    });
+    expect(out.patterns[0]?.metadata.patternKey).toContain("tool-surface");
+  });
+
+  it("classifies repeated low tool accuracy as a tool need", () => {
+    const out = classifyPatternSignals({
+      agentId: "AGT-BUILD",
+      routeContext: "/build",
+      since: new Date("2026-06-27T00:00:00Z"),
+      toolExecutions: [],
+      taskRuns: [],
+      envelopes: [],
+      turnMetrics: [
+        metric({ toolSelectionAccuracy: 0.5, executedTools: 2 }),
+        metric({ toolSelectionAccuracy: 0.4, executedTools: 3 }),
+      ],
+      priorNeedFingerprints: new Set(),
+    });
+
+    expect(out.needs[0]).toMatchObject({
+      kind: "tool",
+      severity: "important",
+      evidenceJson: {
+        signal: "low-tool-selection-accuracy",
+        minToolSelectionAccuracy: 0.4,
+      },
+    });
+  });
+
+  it("classifies repeated approved envelopes as a convention need only", () => {
+    const out = classifyPatternSignals({
+      agentId: "AGT-OPS",
+      routeContext: "/ops",
+      since: new Date("2026-06-27T00:00:00Z"),
+      toolExecutions: [],
+      turnMetrics: [],
+      taskRuns: [],
+      envelopes: [
+        { id: "env-1", proposedActionKey: "approve-change-window", approved: true },
+        { id: "env-2", proposedActionKey: "approve-change-window", approved: true },
+      ],
+      priorNeedFingerprints: new Set(),
+    });
+
+    expect(out.needs[0]).toMatchObject({
+      kind: "convention",
+      severity: "minor",
+      readinessJson: { activationProposed: false },
+    });
+    expect(out.patterns[0]?.metadata).toMatchObject({
+      scope: "activity",
+      decisionScope: "profession-wsid",
+    });
+  });
+
+  it("does not emit duplicate needs already seen in the window", () => {
+    const first = classifyPatternSignals(grantDeniedFixture());
+    const fingerprint = first.needs[0]?.fingerprint;
+    expect(fingerprint).toBeTruthy();
+
+    const out = classifyPatternSignals(grantDeniedFixture(new Set([fingerprint!])));
+
+    expect(out.needs).toHaveLength(0);
+    expect(out.patterns).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/tak/pattern-observer.test.ts
+++ b/apps/web/lib/tak/pattern-observer.test.ts
@@ -100,6 +100,32 @@ describe("classifyPatternSignals", () => {
     });
   });
 
+  it("normalizes underscore-delimited grant denial text", () => {
+    const out = classifyPatternSignals({
+      agentId: "AGT-OPS",
+      routeContext: "/ops",
+      since: new Date("2026-06-27T00:00:00Z"),
+      toolExecutions: [
+        failedTool({
+          id: "scope-1",
+          toolName: "record_execution_evidence",
+          summary: "insufficient_token_scope: write required",
+        }),
+        failedTool({
+          id: "scope-2",
+          toolName: "record_execution_evidence",
+          summary: "insufficient_token_scope: write required",
+        }),
+      ],
+      turnMetrics: [],
+      taskRuns: [],
+      envelopes: [],
+      priorNeedFingerprints: new Set(),
+    });
+
+    expect(out.needs[0]?.kind).toBe("grant");
+  });
+
   it("classifies tool-surface overload as a tool need", () => {
     const out = classifyPatternSignals({
       agentId: "AGT-BUILD",

--- a/apps/web/lib/tak/pattern-observer.test.ts
+++ b/apps/web/lib/tak/pattern-observer.test.ts
@@ -62,6 +62,15 @@ function grantDeniedFixture(priorNeedFingerprints = new Set<string>()) {
   };
 }
 
+const FORBIDDEN_ACTIVATION_KEYS = [
+  "activationCommand",
+  "promptMutation",
+  "skillMutation",
+  "grantMutation",
+  "modelRouteMutation",
+  "workCaseStateMutation",
+];
+
 describe("classifyPatternSignals", () => {
   it("classifies repeated grant denial as a grant need", () => {
     const out = classifyPatternSignals(grantDeniedFixture());
@@ -78,6 +87,7 @@ describe("classifyPatternSignals", () => {
       status: "observed",
       source: "observer",
       scope: "route",
+      decisionScope: "platform-wwmd",
       candidate: { kind: "grant" },
     });
     expect(out.patterns[0]?.metadata.evidence?.[0]).toEqual({
@@ -169,6 +179,62 @@ describe("classifyPatternSignals", () => {
       scope: "activity",
       decisionScope: "profession-wsid",
     });
+  });
+
+  it("carries case-bound metadata from approved envelope repetitions without enabling activation", () => {
+    const out = classifyPatternSignals({
+      agentId: "AGT-OPS",
+      routeContext: "/ops",
+      since: new Date("2026-06-27T00:00:00Z"),
+      toolExecutions: [],
+      turnMetrics: [],
+      taskRuns: [],
+      envelopes: [
+        {
+          proposedActionKey: "approve-change-window",
+          approved: true,
+          workCaseRef: "case-1",
+          caseType: "change",
+          transitionKey: "approve",
+        },
+        {
+          proposedActionKey: "approve-change-window",
+          approved: true,
+          workCaseRef: "case-2",
+          caseType: "change",
+          transitionKey: "approve",
+        },
+      ],
+      priorNeedFingerprints: new Set(),
+    });
+
+    expect(out.patterns[0]?.metadata).toMatchObject({
+      scope: "case-transition",
+      decisionScope: "company-wwwd",
+      workCaseBinding: {
+        caseType: "change",
+        transitionKey: "approve",
+      },
+    });
+    expect(out.needs[0]?.readinessJson).toMatchObject({
+      readyForReview: true,
+      readyForCaseActivation: false,
+      activationProposed: false,
+      blockers: expect.arrayContaining([
+        "missing-governed-action-key",
+        "missing-receipt-policy",
+        "pattern-status-not-approved-or-active",
+      ]),
+    });
+  });
+
+  it("never emits direct prompt, skill, grant, route, command, or Work Case mutation payloads", () => {
+    const out = classifyPatternSignals(grantDeniedFixture());
+    const serialized = JSON.stringify(out);
+
+    for (const key of FORBIDDEN_ACTIVATION_KEYS) {
+      expect(serialized).not.toContain(key);
+    }
   });
 
   it("does not emit duplicate needs already seen in the window", () => {

--- a/apps/web/lib/tak/pattern-observer.ts
+++ b/apps/web/lib/tak/pattern-observer.ts
@@ -4,8 +4,10 @@ import type {
 } from "@/lib/coworker-self-assessment/types";
 import { LOCAL_TOOL_SELECTION_CLIFF } from "./context-economy-metrics";
 import {
+  evaluatePatternReadiness,
   normalizePatternText,
   patternDecisionScope,
+  type WorkCasePatternBinding,
   type WorkPatternEvidenceRef,
   type WorkPatternMetadata,
   type WorkPatternScope,
@@ -50,6 +52,13 @@ export type PatternObserverEnvelope = {
   status?: string | null;
   decision?: string | null;
   taskRunId?: string | null;
+  workCaseRef?: string | null;
+  caseType?: string | null;
+  transitionKey?: string | null;
+  governedActionKey?: string | null;
+  authorityMode?: WorkCasePatternBinding["authorityMode"] | null;
+  sponsorPrincipalId?: string | null;
+  receiptPolicy?: WorkCasePatternBinding["receiptPolicy"] | null;
   createdAt?: Date;
 };
 
@@ -93,6 +102,7 @@ type CandidateSpec = {
   blocks: string;
   evidenceJson: Record<string, unknown>;
   evidence: WorkPatternEvidenceRef[];
+  workCaseBinding?: WorkCasePatternBinding;
   readinessJson?: Record<string, unknown>;
 };
 
@@ -153,8 +163,10 @@ function pushCandidate(
       fingerprint,
       evaluationMethod: "deterministic-pattern-observer",
     },
+    workCaseBinding: spec.workCaseBinding,
     observedAt: input.since.toISOString(),
   };
+  const readiness = evaluatePatternReadiness(metadata);
 
   const need: ClassifiedPatternNeed = {
     kind: spec.kind,
@@ -169,9 +181,9 @@ function pushCandidate(
       decisionScope,
     },
     readinessJson: {
-      readyForReview: true,
-      activationProposed: false,
       ...(spec.readinessJson ?? {}),
+      ...readiness,
+      activationProposed: false,
     },
   };
 
@@ -194,6 +206,13 @@ function evidenceFromExecution(execution: PatternObserverToolExecution): WorkPat
   return {
     taskRunId: execution.taskRunId ?? undefined,
     toolExecutionId: execution.id,
+  };
+}
+
+function evidenceFromMetric(metric: PatternObserverTurnMetric): WorkPatternEvidenceRef {
+  return {
+    threadId: metric.threadId ?? undefined,
+    agentMessageId: metric.agentMessageId ?? undefined,
   };
 }
 
@@ -287,7 +306,7 @@ function classifyTurnMetrics(input: PatternObserverInput, out: PatternObserverOu
           maxToolDefinitionTokens,
           localToolSelectionCliff: LOCAL_TOOL_SELECTION_CLIFF,
         },
-        evidence: [],
+        evidence: overloads.slice(0, 3).map(evidenceFromMetric),
       },
       out,
     );
@@ -321,7 +340,7 @@ function classifyTurnMetrics(input: PatternObserverInput, out: PatternObserverOu
           minToolSelectionAccuracy,
           threshold: LOW_TOOL_ACCURACY_THRESHOLD,
         },
-        evidence: [],
+        evidence: lowAccuracy.slice(0, 3).map(evidenceFromMetric),
       },
       out,
     );
@@ -335,6 +354,39 @@ function isApprovedEnvelope(envelope: PatternObserverEnvelope): boolean {
   return status === "approved" || decision === "approved";
 }
 
+function workCaseBindingFromEnvelopes(envelopes: PatternObserverEnvelope[]): WorkCasePatternBinding | undefined {
+  const envelope = envelopes.find((item) =>
+    Boolean(
+      item.workCaseRef ||
+        item.caseType ||
+        item.transitionKey ||
+        item.governedActionKey ||
+        item.authorityMode ||
+        item.sponsorPrincipalId ||
+        item.receiptPolicy,
+    ),
+  );
+  if (!envelope) {
+    return undefined;
+  }
+
+  return {
+    caseType: envelope.caseType ?? undefined,
+    transitionKey: envelope.transitionKey ?? undefined,
+    governedActionKey: envelope.governedActionKey ?? undefined,
+    authorityMode: envelope.authorityMode ?? undefined,
+    sponsorPrincipalId: envelope.sponsorPrincipalId ?? undefined,
+    receiptPolicy: envelope.receiptPolicy ?? undefined,
+  };
+}
+
+function envelopeScope(binding: WorkCasePatternBinding | undefined): WorkPatternScope {
+  if (!binding) {
+    return "activity";
+  }
+  return binding.transitionKey ? "case-transition" : "case-type";
+}
+
 function classifyEnvelopes(input: PatternObserverInput, out: PatternObserverOutput): void {
   const approved = input.envelopes.filter(
     (envelope) => isApprovedEnvelope(envelope) && Boolean(envelope.proposedActionKey),
@@ -343,13 +395,14 @@ function classifyEnvelopes(input: PatternObserverInput, out: PatternObserverOutp
 
   for (const [actionKey, envelopes] of grouped) {
     if (!actionKey || envelopes.length < 2) continue;
+    const workCaseBinding = workCaseBindingFromEnvelopes(envelopes);
     pushCandidate(
       input,
       {
         signal: "repeated-approved-envelope",
         kind: "convention",
         severity: "minor",
-        scope: "activity",
+        scope: envelopeScope(workCaseBinding),
         need: `Review repeated approved action ${actionKey} for proceduralization`,
         blocks:
           "The same approved action keeps recurring and may deserve a governed procedure, not an automatic mutation.",
@@ -362,10 +415,11 @@ function classifyEnvelopes(input: PatternObserverInput, out: PatternObserverOutp
         evidence: envelopes.slice(0, 3).map((envelope) => ({
           taskRunId: envelope.taskRunId ?? undefined,
           receiptId: envelope.id,
+          workCaseRef: envelope.workCaseRef ?? undefined,
         })),
+        workCaseBinding,
         readinessJson: {
           activationProposed: false,
-          readyForCaseActivation: false,
         },
       },
       out,

--- a/apps/web/lib/tak/pattern-observer.ts
+++ b/apps/web/lib/tak/pattern-observer.ts
@@ -1,0 +1,382 @@
+import type {
+  CoworkerCapabilityNeedKind,
+  CoworkerCapabilityNeedSeverity,
+} from "@/lib/coworker-self-assessment/types";
+import { LOCAL_TOOL_SELECTION_CLIFF } from "./context-economy-metrics";
+import {
+  normalizePatternText,
+  patternDecisionScope,
+  type WorkPatternEvidenceRef,
+  type WorkPatternMetadata,
+  type WorkPatternScope,
+  workPatternFingerprint,
+} from "./work-pattern-types";
+
+export type PatternObserverToolExecution = {
+  id?: string;
+  toolName: string;
+  success: boolean;
+  summary?: string | null;
+  result?: unknown;
+  taskRunId?: string | null;
+  createdAt?: Date;
+};
+
+export type PatternObserverTurnMetric = {
+  threadId?: string | null;
+  agentMessageId?: string | null;
+  ctxPeakTokens?: number | null;
+  ctxWindowTokens?: number | null;
+  toolSurfaceCount?: number | null;
+  toolDefinitionTokens?: number | null;
+  toolSurfaceExceedsLocalCliff?: boolean | null;
+  toolSurfaceWindowShare?: number | null;
+  toolSelectionAccuracy?: number | null;
+  executedTools?: number | null;
+  createdAt?: Date;
+};
+
+export type PatternObserverTaskRun = {
+  taskRunId?: string | null;
+  repeatedPatternKey?: string | null;
+  a2aMetadata?: unknown;
+  createdAt?: Date;
+};
+
+export type PatternObserverEnvelope = {
+  id?: string;
+  proposedActionKey?: string | null;
+  approved?: boolean | null;
+  status?: string | null;
+  decision?: string | null;
+  taskRunId?: string | null;
+  createdAt?: Date;
+};
+
+export type ClassifiedPatternNeed = {
+  kind: CoworkerCapabilityNeedKind;
+  severity: CoworkerCapabilityNeedSeverity;
+  need: string;
+  blocks: string;
+  evidenceJson: Record<string, unknown>;
+  readinessJson: Record<string, unknown>;
+  fingerprint: string;
+};
+
+export type ClassifiedPattern = {
+  metadata: WorkPatternMetadata;
+  need: ClassifiedPatternNeed;
+};
+
+export type PatternObserverInput = {
+  agentId: string;
+  routeContext?: string | null;
+  since: Date;
+  toolExecutions: PatternObserverToolExecution[];
+  turnMetrics: PatternObserverTurnMetric[];
+  taskRuns: PatternObserverTaskRun[];
+  envelopes: PatternObserverEnvelope[];
+  priorNeedFingerprints: Set<string>;
+};
+
+export type PatternObserverOutput = {
+  needs: ClassifiedPatternNeed[];
+  patterns: ClassifiedPattern[];
+};
+
+type CandidateSpec = {
+  signal: string;
+  kind: CoworkerCapabilityNeedKind;
+  severity: CoworkerCapabilityNeedSeverity;
+  scope: WorkPatternScope;
+  need: string;
+  blocks: string;
+  evidenceJson: Record<string, unknown>;
+  evidence: WorkPatternEvidenceRef[];
+  readinessJson?: Record<string, unknown>;
+};
+
+const GRANT_DENIAL_PATTERNS = [
+  "forbidden_grant",
+  "forbidden grant",
+  "insufficient_token_scope",
+];
+const LOW_TOOL_ACCURACY_THRESHOLD = 0.7;
+
+function resultText(result: unknown): string {
+  if (typeof result === "string") return result;
+  if (result === null || result === undefined) return "";
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return "";
+  }
+}
+
+function executionErrorText(execution: PatternObserverToolExecution): string {
+  return [execution.summary ?? "", resultText(execution.result)].join(" ").trim();
+}
+
+function hasGrantDenial(text: string): boolean {
+  const normalized = normalizePatternText(text).replace(/_/g, "_");
+  return GRANT_DENIAL_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+function pushCandidate(
+  input: PatternObserverInput,
+  spec: CandidateSpec,
+  out: PatternObserverOutput,
+): void {
+  const fingerprint = workPatternFingerprint({
+    agentId: input.agentId,
+    routeContext: input.routeContext ?? null,
+    kind: spec.kind,
+    normalizedNeed: spec.need,
+  });
+  if (input.priorNeedFingerprints.has(fingerprint)) {
+    return;
+  }
+
+  const decisionScope = patternDecisionScope(spec.scope);
+  const metadata: WorkPatternMetadata = {
+    patternKey: `${spec.signal}:${fingerprint}`,
+    status: "observed",
+    scope: spec.scope,
+    version: 1,
+    source: "observer",
+    decisionScope,
+    evidence: spec.evidence,
+    candidate: {
+      kind: spec.kind,
+      need: spec.need,
+      blocks: spec.blocks,
+      fingerprint,
+      evaluationMethod: "deterministic-pattern-observer",
+    },
+    observedAt: input.since.toISOString(),
+  };
+
+  const need: ClassifiedPatternNeed = {
+    kind: spec.kind,
+    severity: spec.severity,
+    need: spec.need,
+    blocks: spec.blocks,
+    fingerprint,
+    evidenceJson: {
+      ...spec.evidenceJson,
+      fingerprint,
+      patternKey: metadata.patternKey,
+      decisionScope,
+    },
+    readinessJson: {
+      readyForReview: true,
+      activationProposed: false,
+      ...(spec.readinessJson ?? {}),
+    },
+  };
+
+  out.needs.push(need);
+  out.patterns.push({ metadata, need });
+}
+
+function groupBy<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyOf(item);
+    const list = grouped.get(key) ?? [];
+    list.push(item);
+    grouped.set(key, list);
+  }
+  return grouped;
+}
+
+function evidenceFromExecution(execution: PatternObserverToolExecution): WorkPatternEvidenceRef {
+  return {
+    taskRunId: execution.taskRunId ?? undefined,
+    toolExecutionId: execution.id,
+  };
+}
+
+function classifyRepeatedToolFailures(input: PatternObserverInput, out: PatternObserverOutput): void {
+  const failures = input.toolExecutions.filter((execution) => execution.success === false);
+  const grantGroups = groupBy(
+    failures.filter((execution) => hasGrantDenial(executionErrorText(execution))),
+    (execution) => execution.toolName,
+  );
+
+  for (const [toolName, executions] of grantGroups) {
+    if (executions.length < 2) continue;
+    const need = `Missing ${toolName} authority`;
+    pushCandidate(
+      input,
+      {
+        signal: "grant-denial",
+        kind: "grant",
+        severity: "important",
+        scope: "route",
+        need,
+        blocks: `Repeated grant denials prevented ${input.agentId} from using ${toolName}.`,
+        evidenceJson: {
+          signal: "grant-denial",
+          toolName,
+          occurrences: executions.length,
+          summaries: executions.map((execution) => execution.summary ?? null).filter(Boolean),
+        },
+        evidence: executions.slice(0, 3).map(evidenceFromExecution),
+      },
+      out,
+    );
+  }
+
+  const nonGrantGroups = groupBy(
+    failures.filter((execution) => !hasGrantDenial(executionErrorText(execution))),
+    (execution) => `${execution.toolName}|${normalizePatternText(executionErrorText(execution))}`,
+  );
+  for (const [key, executions] of nonGrantGroups) {
+    if (executions.length < 2) continue;
+    const [toolName, normalizedError] = key.split("|");
+    const need = `Stabilize repeated ${toolName} tool failure`;
+    pushCandidate(
+      input,
+      {
+        signal: "tool-failure",
+        kind: "tool",
+        severity: "important",
+        scope: "route",
+        need,
+        blocks: `The same ${toolName} failure recurred and blocked reliable completion.`,
+        evidenceJson: {
+          signal: "tool-failure",
+          toolName,
+          normalizedError,
+          occurrences: executions.length,
+        },
+        evidence: executions.slice(0, 3).map(evidenceFromExecution),
+      },
+      out,
+    );
+  }
+}
+
+function classifyTurnMetrics(input: PatternObserverInput, out: PatternObserverOutput): void {
+  const overloads = input.turnMetrics.filter((metric) => {
+    const count = metric.toolSurfaceCount ?? 0;
+    return metric.toolSurfaceExceedsLocalCliff === true || count > LOCAL_TOOL_SELECTION_CLIFF;
+  });
+  if (overloads.length >= 2) {
+    const maxToolSurfaceCount = Math.max(
+      ...overloads.map((metric) => metric.toolSurfaceCount ?? 0),
+    );
+    const maxToolDefinitionTokens = Math.max(
+      ...overloads.map((metric) => metric.toolDefinitionTokens ?? 0),
+    );
+    pushCandidate(
+      input,
+      {
+        signal: "tool-surface-overload",
+        kind: "tool",
+        severity: "important",
+        scope: "route",
+        need: "Reduce repeated tool surface overload",
+        blocks:
+          "Repeated turns exceeded the local tool-selection cliff, which makes tool choice less reliable.",
+        evidenceJson: {
+          signal: "tool-surface-overload",
+          occurrences: overloads.length,
+          maxToolSurfaceCount,
+          maxToolDefinitionTokens,
+          localToolSelectionCliff: LOCAL_TOOL_SELECTION_CLIFF,
+        },
+        evidence: [],
+      },
+      out,
+    );
+  }
+
+  const lowAccuracy = input.turnMetrics.filter((metric) => {
+    const accuracy = metric.toolSelectionAccuracy;
+    return (
+      typeof accuracy === "number" &&
+      accuracy < LOW_TOOL_ACCURACY_THRESHOLD &&
+      (metric.executedTools ?? 0) > 0
+    );
+  });
+  if (lowAccuracy.length >= 2) {
+    const minToolSelectionAccuracy = Math.min(
+      ...lowAccuracy.map((metric) => metric.toolSelectionAccuracy ?? 1),
+    );
+    pushCandidate(
+      input,
+      {
+        signal: "low-tool-selection-accuracy",
+        kind: "tool",
+        severity: "important",
+        scope: "route",
+        need: "Improve repeated low tool-selection accuracy",
+        blocks:
+          "Repeated turns attempted tools but produced low tool-call success, making the route unreliable.",
+        evidenceJson: {
+          signal: "low-tool-selection-accuracy",
+          occurrences: lowAccuracy.length,
+          minToolSelectionAccuracy,
+          threshold: LOW_TOOL_ACCURACY_THRESHOLD,
+        },
+        evidence: [],
+      },
+      out,
+    );
+  }
+}
+
+function isApprovedEnvelope(envelope: PatternObserverEnvelope): boolean {
+  if (envelope.approved === true) return true;
+  const status = normalizePatternText(envelope.status ?? "");
+  const decision = normalizePatternText(envelope.decision ?? "");
+  return status === "approved" || decision === "approved";
+}
+
+function classifyEnvelopes(input: PatternObserverInput, out: PatternObserverOutput): void {
+  const approved = input.envelopes.filter(
+    (envelope) => isApprovedEnvelope(envelope) && Boolean(envelope.proposedActionKey),
+  );
+  const grouped = groupBy(approved, (envelope) => envelope.proposedActionKey ?? "");
+
+  for (const [actionKey, envelopes] of grouped) {
+    if (!actionKey || envelopes.length < 2) continue;
+    pushCandidate(
+      input,
+      {
+        signal: "repeated-approved-envelope",
+        kind: "convention",
+        severity: "minor",
+        scope: "activity",
+        need: `Review repeated approved action ${actionKey} for proceduralization`,
+        blocks:
+          "The same approved action keeps recurring and may deserve a governed procedure, not an automatic mutation.",
+        evidenceJson: {
+          signal: "repeated-approved-envelope",
+          proposedActionKey: actionKey,
+          occurrences: envelopes.length,
+          envelopeIds: envelopes.map((envelope) => envelope.id).filter(Boolean),
+        },
+        evidence: envelopes.slice(0, 3).map((envelope) => ({
+          taskRunId: envelope.taskRunId ?? undefined,
+          receiptId: envelope.id,
+        })),
+        readinessJson: {
+          activationProposed: false,
+          readyForCaseActivation: false,
+        },
+      },
+      out,
+    );
+  }
+}
+
+export function classifyPatternSignals(input: PatternObserverInput): PatternObserverOutput {
+  const out: PatternObserverOutput = { needs: [], patterns: [] };
+  classifyRepeatedToolFailures(input, out);
+  classifyTurnMetrics(input, out);
+  classifyEnvelopes(input, out);
+  return out;
+}

--- a/apps/web/lib/tak/pattern-observer.ts
+++ b/apps/web/lib/tak/pattern-observer.ts
@@ -107,9 +107,8 @@ type CandidateSpec = {
 };
 
 const GRANT_DENIAL_PATTERNS = [
-  "forbidden_grant",
   "forbidden grant",
-  "insufficient_token_scope",
+  "insufficient token scope",
 ];
 const LOW_TOOL_ACCURACY_THRESHOLD = 0.7;
 
@@ -128,7 +127,7 @@ function executionErrorText(execution: PatternObserverToolExecution): string {
 }
 
 function hasGrantDenial(text: string): boolean {
-  const normalized = normalizePatternText(text).replace(/_/g, "_");
+  const normalized = normalizePatternText(text).replaceAll("_", " ");
   return GRANT_DENIAL_PATTERNS.some((pattern) => normalized.includes(pattern));
 }
 

--- a/apps/web/lib/tak/pattern-observer.ts
+++ b/apps/web/lib/tak/pattern-observer.ts
@@ -434,3 +434,5 @@ export function classifyPatternSignals(input: PatternObserverInput): PatternObse
   classifyEnvelopes(input, out);
   return out;
 }
+
+export * from "./pattern-observer/index";

--- a/apps/web/lib/tak/pattern-observer/classifiers.test.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.test.ts
@@ -110,6 +110,27 @@ describe("pattern observer classifiers", () => {
       });
     });
 
+    it("classifies caution assessments with window-share evidence as minor tool needs", () => {
+      const need = classifyToolSurfaceOverload({
+        toolCount: 8,
+        estDefinitionTokens: 140,
+        exceedsLocalCliff: false,
+        windowShare: 0.01,
+        zone: "caution",
+      });
+
+      expect(need).toMatchObject({
+        kind: "tool",
+        severity: "minor",
+        evidenceJson: {
+          toolCount: 8,
+          windowShare: 0.01,
+          zone: "caution",
+          exceedsLocalCliff: false,
+        },
+      });
+    });
+
     it("returns null for lean assessments and conservative caution signals", () => {
       expect(
         classifyToolSurfaceOverload({

--- a/apps/web/lib/tak/pattern-observer/classifiers.test.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ToolSelectionAccuracy,
+  ToolSurfaceAssessment,
+} from "@/lib/tak/context-economy-metrics";
+import { LOCAL_TOOL_SELECTION_CLIFF } from "@/lib/tak/context-economy-metrics";
+
+import {
+  classifyGrantDenial,
+  classifyRepeatedSuccess,
+  classifyToolSurfaceOverload,
+} from "./classifiers";
+
+describe("pattern observer classifiers", () => {
+  describe("classifyGrantDenial", () => {
+    it("returns null when repeated denial evidence is below the threshold", () => {
+      const need = classifyGrantDenial({
+        deniedTool: "create_backlog_item",
+        missingCapability: "backlog.write",
+        denialMessages: [
+          "forbidden_grant: agent lacks backlog.write",
+          "forbidden grant: agent lacks backlog.write",
+        ],
+        threshold: 3,
+      });
+
+      expect(need).toBeNull();
+    });
+
+    it("classifies repeated forbidden grant text as an important grant need", () => {
+      const need = classifyGrantDenial({
+        deniedTool: "create_backlog_item",
+        missingCapability: "backlog.write",
+        denialMessages: [
+          "forbidden_grant: agent lacks backlog.write",
+          "forbidden grant: agent lacks backlog.write",
+          "missing capability backlog.write",
+        ],
+        threshold: 3,
+      });
+
+      expect(need).toMatchObject({
+        kind: "grant",
+        severity: "important",
+        evidenceJson: {
+          deniedTool: "create_backlog_item",
+          missingCapability: "backlog.write",
+          count: 3,
+        },
+      });
+      expect(need?.need).toContain("backlog.write");
+      expect(need?.blocks).toContain("create_backlog_item");
+    });
+
+    it("recognizes insufficient token scope denial text", () => {
+      const need = classifyGrantDenial({
+        deniedTool: "record_execution_evidence",
+        missingCapability: "write token",
+        denialMessages: [
+          "insufficient_token_scope: requiredScope write",
+          "insufficient_token_scope: requiredScope write",
+        ],
+        threshold: 2,
+      });
+
+      expect(need?.kind).toBe("grant");
+      expect(need?.evidenceJson?.count).toBe(2);
+    });
+  });
+
+  describe("classifyToolSurfaceOverload", () => {
+    it("classifies overload assessments as important tool needs", () => {
+      const assessment: ToolSurfaceAssessment = {
+        toolCount: LOCAL_TOOL_SELECTION_CLIFF + 2,
+        estDefinitionTokens: 5200,
+        exceedsLocalCliff: true,
+        windowShare: 0.31,
+        zone: "overload",
+      };
+
+      const need = classifyToolSurfaceOverload(assessment);
+
+      expect(need).toMatchObject({
+        kind: "tool",
+        severity: "important",
+        evidenceJson: assessment,
+      });
+      expect(need?.blocks).toContain("tool surface");
+    });
+
+    it("classifies near-cliff caution assessments as minor tool needs", () => {
+      const need = classifyToolSurfaceOverload({
+        toolCount: LOCAL_TOOL_SELECTION_CLIFF - 1,
+        estDefinitionTokens: 2200,
+        exceedsLocalCliff: false,
+        windowShare: 0.16,
+        zone: "caution",
+      });
+
+      expect(need).toMatchObject({
+        kind: "tool",
+        severity: "minor",
+        evidenceJson: {
+          toolCount: LOCAL_TOOL_SELECTION_CLIFF - 1,
+          windowShare: 0.16,
+          zone: "caution",
+          exceedsLocalCliff: false,
+        },
+      });
+    });
+
+    it("returns null for lean assessments and conservative caution signals", () => {
+      expect(
+        classifyToolSurfaceOverload({
+          toolCount: 4,
+          estDefinitionTokens: 500,
+          exceedsLocalCliff: false,
+          windowShare: null,
+          zone: "lean",
+        }),
+      ).toBeNull();
+
+      expect(
+        classifyToolSurfaceOverload({
+          toolCount: 8,
+          estDefinitionTokens: 900,
+          exceedsLocalCliff: false,
+          windowShare: null,
+          zone: "caution",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("classifyRepeatedSuccess", () => {
+    const perfectAccuracy: ToolSelectionAccuracy = {
+      total: 12,
+      succeeded: 12,
+      accuracy: 1,
+      perTool: {
+        create_work_capsule: { total: 4, succeeded: 4, accuracy: 1 },
+        record_capsule_evidence: { total: 8, succeeded: 8, accuracy: 1 },
+      },
+    };
+
+    it("returns null below the repeated successful workflow threshold", () => {
+      const need = classifyRepeatedSuccess({
+        workflowName: "capsule handoff evidence loop",
+        repetitionCount: 2,
+        threshold: 3,
+        ceremonyScore: 0.9,
+        accuracy: perfectAccuracy,
+      });
+
+      expect(need).toBeNull();
+    });
+
+    it("classifies high-ceremony repeated success as a minor proceduralization code need", () => {
+      const need = classifyRepeatedSuccess({
+        workflowName: "capsule handoff evidence loop",
+        repetitionCount: 4,
+        threshold: 3,
+        ceremonyScore: 0.85,
+        accuracy: perfectAccuracy,
+      });
+
+      expect(need).toMatchObject({
+        kind: "code",
+        severity: "minor",
+        evidenceJson: {
+          workflowName: "capsule handoff evidence loop",
+          repetitionCount: 4,
+          threshold: 3,
+          ceremonyScore: 0.85,
+          accuracy: 1,
+        },
+      });
+      expect(need?.need).toContain("proceduralize");
+    });
+
+    it("returns null when the repeated workflow is not reliably successful", () => {
+      const need = classifyRepeatedSuccess({
+        workflowName: "capsule handoff evidence loop",
+        repetitionCount: 4,
+        threshold: 3,
+        ceremonyScore: 0.9,
+        accuracy: { ...perfectAccuracy, succeeded: 9, accuracy: 0.75 },
+      });
+
+      expect(need).toBeNull();
+    });
+  });
+});

--- a/apps/web/lib/tak/pattern-observer/classifiers.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.ts
@@ -1,0 +1,135 @@
+import type { CoworkerCapabilityNeedInput } from "@/lib/coworker-self-assessment/types";
+import type {
+  ToolSelectionAccuracy,
+  ToolSurfaceAssessment,
+} from "@/lib/tak/context-economy-metrics";
+import { LOCAL_TOOL_SELECTION_CLIFF } from "@/lib/tak/context-economy-metrics";
+
+const DEFAULT_GRANT_DENIAL_THRESHOLD = 3;
+const DEFAULT_REPEATED_SUCCESS_THRESHOLD = 3;
+const MIN_SUCCESSFUL_WORKFLOW_ACCURACY = 0.9;
+const MIN_HIGH_CEREMONY_SCORE = 0.75;
+const CAUTION_WINDOW_SHARE_THRESHOLD = 0.15;
+const NEAR_LOCAL_CLIFF_DISTANCE = 1;
+
+const GRANT_DENIAL_PATTERNS = [
+  /\bforbidden[_\s-]?grant\b/i,
+  /\binsufficient_token_scope\b/i,
+  /\bmissing\s+capability\b/i,
+] as const;
+
+export type GrantDenialSignal = {
+  deniedTool: string;
+  missingCapability?: string | null;
+  denialMessages: readonly string[];
+  threshold?: number;
+};
+
+export type RepeatedSuccessSignal = {
+  workflowName: string;
+  repetitionCount: number;
+  threshold?: number;
+  ceremonyScore: number;
+  accuracy: ToolSelectionAccuracy;
+};
+
+function positiveThreshold(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function countGrantDenials(messages: readonly string[]): number {
+  return messages.filter((message) =>
+    GRANT_DENIAL_PATTERNS.some((pattern) => pattern.test(message)),
+  ).length;
+}
+
+export function classifyGrantDenial(
+  signal: GrantDenialSignal,
+): CoworkerCapabilityNeedInput | null {
+  const count = countGrantDenials(signal.denialMessages);
+  const threshold = positiveThreshold(signal.threshold, DEFAULT_GRANT_DENIAL_THRESHOLD);
+  if (count < threshold) return null;
+
+  const missingCapability = signal.missingCapability?.trim() || "required grant";
+  return {
+    kind: "grant",
+    severity: "important",
+    need: `Grant ${missingCapability} so the coworker can use ${signal.deniedTool}.`,
+    blocks: `Repeated denial blocked ${signal.deniedTool}.`,
+    evidenceJson: {
+      deniedTool: signal.deniedTool,
+      missingCapability,
+      count,
+      threshold,
+    },
+  };
+}
+
+function toolSurfaceEvidence(assessment: ToolSurfaceAssessment): Record<string, unknown> {
+  return {
+    toolCount: assessment.toolCount,
+    estDefinitionTokens: assessment.estDefinitionTokens,
+    windowShare: assessment.windowShare,
+    zone: assessment.zone,
+    exceedsLocalCliff: assessment.exceedsLocalCliff,
+  };
+}
+
+function isNearLocalCliff(toolCount: number): boolean {
+  return toolCount >= LOCAL_TOOL_SELECTION_CLIFF - NEAR_LOCAL_CLIFF_DISTANCE;
+}
+
+export function classifyToolSurfaceOverload(
+  assessment: ToolSurfaceAssessment,
+): CoworkerCapabilityNeedInput | null {
+  if (assessment.zone === "overload" || assessment.exceedsLocalCliff) {
+    return {
+      kind: "tool",
+      severity: "important",
+      need: "Reduce or phase-scope the coworker's tool surface before local selection degrades.",
+      blocks: "The current tool surface risks unreliable tool selection.",
+      evidenceJson: toolSurfaceEvidence(assessment),
+    };
+  }
+
+  const cautionIsActionable =
+    assessment.zone === "caution" &&
+    (isNearLocalCliff(assessment.toolCount) ||
+      (assessment.windowShare !== null && assessment.windowShare >= CAUTION_WINDOW_SHARE_THRESHOLD));
+
+  if (!cautionIsActionable) return null;
+
+  return {
+    kind: "tool",
+    severity: "minor",
+    need: "Trim or phase the caution-zone tool surface before it reaches overload.",
+    blocks: "The tool surface is approaching the local selection cliff.",
+    evidenceJson: toolSurfaceEvidence(assessment),
+  };
+}
+
+export function classifyRepeatedSuccess(
+  signal: RepeatedSuccessSignal,
+): CoworkerCapabilityNeedInput | null {
+  const threshold = positiveThreshold(signal.threshold, DEFAULT_REPEATED_SUCCESS_THRESHOLD);
+  const isRepeated = signal.repetitionCount >= threshold;
+  const isHighCeremony = signal.ceremonyScore >= MIN_HIGH_CEREMONY_SCORE;
+  const isReliablySuccessful = signal.accuracy.accuracy >= MIN_SUCCESSFUL_WORKFLOW_ACCURACY;
+  if (!isRepeated || !isHighCeremony || !isReliablySuccessful) return null;
+
+  return {
+    kind: "code",
+    severity: "minor",
+    need: `proceduralize the repeated successful ${signal.workflowName} workflow.`,
+    blocks: "Manual ceremony is being repeated for a workflow that is already reliable.",
+    evidenceJson: {
+      workflowName: signal.workflowName,
+      repetitionCount: signal.repetitionCount,
+      threshold,
+      ceremonyScore: signal.ceremonyScore,
+      accuracy: signal.accuracy.accuracy,
+      totalToolCalls: signal.accuracy.total,
+      succeededToolCalls: signal.accuracy.succeeded,
+    },
+  };
+}

--- a/apps/web/lib/tak/pattern-observer/classifiers.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.ts
@@ -9,7 +9,6 @@ const DEFAULT_GRANT_DENIAL_THRESHOLD = 3;
 const DEFAULT_REPEATED_SUCCESS_THRESHOLD = 3;
 const MIN_SUCCESSFUL_WORKFLOW_ACCURACY = 0.9;
 const MIN_HIGH_CEREMONY_SCORE = 0.75;
-const CAUTION_WINDOW_SHARE_THRESHOLD = 0.15;
 const NEAR_LOCAL_CLIFF_DISTANCE = 1;
 
 const GRANT_DENIAL_PATTERNS = [
@@ -94,8 +93,7 @@ export function classifyToolSurfaceOverload(
 
   const cautionIsActionable =
     assessment.zone === "caution" &&
-    (isNearLocalCliff(assessment.toolCount) ||
-      (assessment.windowShare !== null && assessment.windowShare >= CAUTION_WINDOW_SHARE_THRESHOLD));
+    (isNearLocalCliff(assessment.toolCount) || assessment.windowShare !== null);
 
   if (!cautionIsActionable) return null;
 

--- a/apps/web/lib/tak/pattern-observer/core.test.ts
+++ b/apps/web/lib/tak/pattern-observer/core.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  taskRunFindUnique,
+  taskRunCreate,
+  taskRunUpdate,
+  submitAssessment,
+  createOrTouchSignal,
+} = vi.hoisted(() => ({
+  taskRunFindUnique: vi.fn(),
+  taskRunCreate: vi.fn(),
+  taskRunUpdate: vi.fn(),
+  submitAssessment: vi.fn(),
+  createOrTouchSignal: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findUnique: taskRunFindUnique,
+      create: taskRunCreate,
+      update: taskRunUpdate,
+    },
+  },
+}));
+
+vi.mock("@/lib/coworker-self-assessment/assessment-service", () => ({
+  submitCoworkerSelfAssessment: submitAssessment,
+}));
+
+vi.mock("@/lib/improvement-flywheel/signals", () => ({
+  createOrTouchImprovementSignal: createOrTouchSignal,
+}));
+
+import { getReflectionDepth, isReflectionRun, runObservation } from "./core";
+
+const baseInput = {
+  parentTaskRunId: "run-parent",
+  userId: "user-1",
+  agentId: "AGT-1",
+  threadId: "thread-1",
+  routeContext: "/customer",
+  sourceTitle: "Repeated create_backlog_item call",
+  sourceDescription: "The coworker repeated the same tool call.",
+  spec: {
+    title: "Skill reflection: repeated tool use",
+    trigger: "runtime-issue-reflection",
+    verdict: "blocked",
+    confidence: "high",
+    sourceType: "platform_issue_report",
+    sourceId: "PIR-123",
+    suspectedRootCause: "tool-loop",
+    needs: [
+      {
+        kind: "prompt",
+        severity: "blocker",
+        need: "Teach the coworker to stop after repeated tool failures.",
+        blocks: "Repeated create_backlog_item call",
+        evidenceJson: { source: "test" },
+      },
+    ],
+  },
+} as const;
+
+describe("pattern observer core", () => {
+  beforeEach(() => {
+    taskRunFindUnique.mockReset();
+    taskRunCreate.mockReset();
+    taskRunUpdate.mockReset();
+    submitAssessment.mockReset();
+    createOrTouchSignal.mockReset();
+
+    taskRunFindUnique.mockResolvedValue({
+      source: "coworker",
+      title: "Ordinary run",
+      a2aMetadata: { reflectionDepth: 0 },
+    });
+    taskRunCreate.mockResolvedValue({ id: "created-id", taskRunId: "TR-RFL-ABCDEFGH" });
+    taskRunUpdate.mockResolvedValue({});
+    submitAssessment.mockResolvedValue({ assessmentId: "CWSA-1", needIds: ["CWN-1"] });
+    createOrTouchSignal.mockResolvedValue({ signalId: "IS-1", isNew: true });
+  });
+
+  it("reads reflection metadata helpers from TaskRun-shaped rows", () => {
+    expect(getReflectionDepth(null)).toBe(0);
+    expect(getReflectionDepth({ a2aMetadata: "bad" as never })).toBe(0);
+    expect(getReflectionDepth({ a2aMetadata: { reflectionDepth: 3 } })).toBe(3);
+
+    expect(isReflectionRun({ source: "proactive", title: "Skill reflection: anything" })).toBe(
+      true,
+    );
+    expect(isReflectionRun({ source: "coworker", title: "Skill reflection: anything" })).toBe(
+      false,
+    );
+  });
+
+  it("creates a proactive TaskRun with supplied title, trigger, and incremented reflectionDepth", async () => {
+    const result = await runObservation(baseInput);
+
+    expect(result).toEqual({ processed: 1 });
+    expect(taskRunCreate).toHaveBeenCalledTimes(1);
+    const data = taskRunCreate.mock.calls[0]?.[0]?.data as {
+      source: string;
+      title: string;
+      a2aMetadata: Record<string, unknown>;
+      parentTaskRunId: string;
+    };
+    expect(data.source).toBe("proactive");
+    expect(data.title).toBe("Skill reflection: repeated tool use");
+    expect(data.parentTaskRunId).toBe("run-parent");
+    expect(data.a2aMetadata.reflectionDepth).toBe(1);
+    expect(data.a2aMetadata.trigger).toBe("runtime-issue-reflection");
+  });
+
+  it("returns reflection-loop-guard when the parent is itself a reflection run", async () => {
+    taskRunFindUnique.mockResolvedValue({
+      source: "proactive",
+      title: "Skill reflection: repeated tool use",
+      a2aMetadata: { reflectionDepth: 0 },
+    });
+
+    const result = await runObservation(baseInput);
+
+    expect(result).toEqual({ processed: 0, skippedReason: "reflection-loop-guard" });
+    expect(taskRunCreate).not.toHaveBeenCalled();
+    expect(submitAssessment).not.toHaveBeenCalled();
+    expect(createOrTouchSignal).not.toHaveBeenCalled();
+  });
+
+  it("returns reflection-loop-guard when parent reflectionDepth is already at least one", async () => {
+    taskRunFindUnique.mockResolvedValue({
+      source: "coworker",
+      title: "Ordinary run",
+      a2aMetadata: { reflectionDepth: 1 },
+    });
+
+    const result = await runObservation(baseInput);
+
+    expect(result).toEqual({ processed: 0, skippedReason: "reflection-loop-guard" });
+    expect(taskRunCreate).not.toHaveBeenCalled();
+  });
+
+  it("emits a self-assessment with supplied verdict, confidence, and needs", async () => {
+    taskRunFindUnique.mockResolvedValue({
+      source: "coworker",
+      title: "Ordinary run",
+      a2aMetadata: null,
+    });
+
+    await runObservation(baseInput);
+
+    expect(submitAssessment).toHaveBeenCalledTimes(1);
+    const assessment = submitAssessment.mock.calls[0]?.[0] as {
+      trigger: string;
+      verdict: string;
+      confidence: string;
+      needs: Array<{ kind: string; severity: string; need: string; evidenceJson: unknown }>;
+    };
+    expect(assessment.trigger).toBe("runtime-issue-reflection");
+    expect(assessment.verdict).toBe("blocked");
+    expect(assessment.confidence).toBe("high");
+    expect(assessment.needs).toHaveLength(1);
+    expect(assessment.needs[0]).toMatchObject({
+      kind: "prompt",
+      severity: "blocker",
+      need: "Teach the coworker to stop after repeated tool failures.",
+      evidenceJson: { source: "test" },
+    });
+  });
+
+  it("touches an ImprovementSignal with supplied source and root-cause fields", async () => {
+    taskRunFindUnique.mockResolvedValue({
+      source: "coworker",
+      title: "Ordinary run",
+      a2aMetadata: null,
+    });
+
+    await runObservation(baseInput);
+
+    expect(createOrTouchSignal).toHaveBeenCalledTimes(1);
+    expect(createOrTouchSignal.mock.calls[0]?.[0]).toMatchObject({
+      sourceType: "platform_issue_report",
+      sourceId: "PIR-123",
+      suspectedRootCause: "tool-loop",
+      title: "Repeated create_backlog_item call",
+      description: "The coworker repeated the same tool call.",
+    });
+  });
+});

--- a/apps/web/lib/tak/pattern-observer/core.test.ts
+++ b/apps/web/lib/tak/pattern-observer/core.test.ts
@@ -186,4 +186,25 @@ describe("pattern observer core", () => {
       description: "The coworker repeated the same tool call.",
     });
   });
+
+  it("marks the observation TaskRun failed and rethrows when a side effect throws", async () => {
+    const failedAt = new Date("2026-06-27T21:00:00Z");
+    taskRunFindUnique.mockResolvedValue({
+      source: "coworker",
+      title: "Ordinary run",
+      a2aMetadata: null,
+    });
+    submitAssessment.mockRejectedValueOnce(new Error("assessment failed"));
+
+    await expect(runObservation(baseInput, { now: () => failedAt })).rejects.toThrow(
+      "assessment failed",
+    );
+
+    expect(taskRunUpdate).toHaveBeenCalledTimes(1);
+    expect(taskRunUpdate.mock.calls[0]?.[0]).toMatchObject({
+      where: { id: "created-id" },
+      data: { status: "failed", completedAt: failedAt },
+    });
+    expect(createOrTouchSignal).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/lib/tak/pattern-observer/core.ts
+++ b/apps/web/lib/tak/pattern-observer/core.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "crypto";
+
+import type { Prisma } from "@dpf/db";
+import { prisma } from "@dpf/db";
+
+import { submitCoworkerSelfAssessment } from "@/lib/coworker-self-assessment/assessment-service";
+import type {
+  CoworkerAssessmentConfidence,
+  CoworkerAssessmentVerdict,
+  CoworkerCapabilityNeedInput,
+} from "@/lib/coworker-self-assessment/types";
+import { createOrTouchImprovementSignal } from "@/lib/improvement-flywheel/signals";
+
+export type ReflectionDepthSource = {
+  source?: string | null;
+  title?: string | null;
+  a2aMetadata?: Prisma.JsonValue | null;
+};
+
+export type ObservationSpec = {
+  title: string;
+  trigger: string;
+  verdict: CoworkerAssessmentVerdict;
+  confidence: CoworkerAssessmentConfidence;
+  needs: readonly CoworkerCapabilityNeedInput[];
+  sourceType: string;
+  sourceId: string;
+  suspectedRootCause?: string | null;
+};
+
+export type RunObservationInput = {
+  parentTaskRunId: string | null;
+  userId: string;
+  agentId: string;
+  threadId: string | null;
+  routeContext: string;
+  sourceTitle: string;
+  sourceDescription?: string | null;
+  objective?: string;
+  capabilitySummary?: string | null;
+  rawPayload?: Record<string, unknown>;
+  signalEvidence?: Record<string, unknown>;
+  spec: ObservationSpec;
+};
+
+export type RunObservationResult = {
+  processed: number;
+  skippedReason?: "reflection-loop-guard";
+};
+
+export type ObservationDeps = {
+  db: Pick<typeof prisma, "taskRun">;
+  submitAssessment: typeof submitCoworkerSelfAssessment;
+  touchSignal: typeof createOrTouchImprovementSignal;
+  createTaskRunId: () => string;
+  now: () => Date;
+};
+
+export function getReflectionDepth(parent: ReflectionDepthSource | null | undefined): number {
+  if (!parent) return 0;
+  const meta = parent.a2aMetadata;
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return 0;
+  const value = (meta as { reflectionDepth?: unknown }).reflectionDepth;
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function isReflectionRun(parent: ReflectionDepthSource | null | undefined): boolean {
+  if (!parent) return false;
+  return parent.source === "proactive" && (parent.title ?? "").startsWith("Skill reflection:");
+}
+
+export function isReflectionLoopGuarded(
+  parent: ReflectionDepthSource | null | undefined,
+): boolean {
+  return Boolean(parent && (isReflectionRun(parent) || getReflectionDepth(parent) >= 1));
+}
+
+function defaultCreateTaskRunId(): string {
+  return `TR-RFL-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+function resolveDeps(deps?: Partial<ObservationDeps>): ObservationDeps {
+  return {
+    db: deps?.db ?? prisma,
+    submitAssessment: deps?.submitAssessment ?? submitCoworkerSelfAssessment,
+    touchSignal: deps?.touchSignal ?? createOrTouchImprovementSignal,
+    createTaskRunId: deps?.createTaskRunId ?? defaultCreateTaskRunId,
+    now: deps?.now ?? (() => new Date()),
+  };
+}
+
+async function readParent(
+  parentTaskRunId: string | null,
+  deps: ObservationDeps,
+): Promise<ReflectionDepthSource | null> {
+  if (!parentTaskRunId) return null;
+  return deps.db.taskRun
+    .findUnique({
+      where: { taskRunId: parentTaskRunId },
+      select: { source: true, title: true, a2aMetadata: true },
+    })
+    .catch(() => null);
+}
+
+function observationMetadata(input: RunObservationInput, parentDepth: number): Prisma.InputJsonValue {
+  const base: Record<string, unknown> = {
+    trigger: input.spec.trigger,
+    sourceType: input.spec.sourceType,
+    sourceId: input.spec.sourceId,
+    reflectionDepth: parentDepth + 1,
+  };
+  if (input.spec.sourceType === "platform_issue_report") {
+    base.platformIssueReportId = input.spec.sourceId;
+  }
+  return base as Prisma.InputJsonValue;
+}
+
+export async function runObservation(
+  input: RunObservationInput,
+  deps?: Partial<ObservationDeps>,
+): Promise<RunObservationResult> {
+  const resolved = resolveDeps(deps);
+  const parent = await readParent(input.parentTaskRunId, resolved);
+  if (isReflectionLoopGuarded(parent)) {
+    return { processed: 0, skippedReason: "reflection-loop-guard" };
+  }
+
+  const parentDepth = getReflectionDepth(parent);
+  const observationTaskRunId = resolved.createTaskRunId();
+  const observationRun = await resolved.db.taskRun.create({
+    data: {
+      taskRunId: observationTaskRunId,
+      userId: input.userId,
+      threadId: input.threadId,
+      contextId: input.threadId,
+      initiatingAgentId: input.agentId,
+      currentAgentId: input.agentId,
+      parentTaskRunId: input.parentTaskRunId,
+      routeContext: input.routeContext,
+      title: input.spec.title,
+      objective: input.objective ??
+        `Observe ${input.spec.sourceType} ${input.spec.sourceId} and file durable evidence ` +
+        `(self-assessment, capability need, improvement signal).`,
+      source: "proactive",
+      status: "working",
+      authorityScope: [],
+      a2aMetadata: observationMetadata(input, parentDepth),
+    },
+    select: { id: true, taskRunId: true },
+  });
+
+  await resolved.submitAssessment({
+    agentId: input.agentId,
+    trigger: input.spec.trigger,
+    routeContext: input.routeContext,
+    verdict: input.spec.verdict,
+    confidence: input.spec.confidence,
+    missionSummary: input.sourceTitle,
+    capabilitySummary: input.capabilitySummary ?? null,
+    rawPayload: {
+      ...(input.rawPayload ?? {}),
+      sourceType: input.spec.sourceType,
+      sourceId: input.spec.sourceId,
+      observationTaskRunId: observationRun.taskRunId,
+      reflectionTaskRunId: observationRun.taskRunId,
+    },
+    needs: [...input.spec.needs],
+  });
+
+  await resolved.touchSignal({
+    sourceType: input.spec.sourceType,
+    sourceId: input.spec.sourceId,
+    title: input.sourceTitle,
+    description: input.sourceDescription ?? null,
+    evidence: {
+      ...(input.signalEvidence ?? {}),
+      parentTaskRunId: input.parentTaskRunId,
+      observationTaskRunId: observationRun.taskRunId,
+      reflectionTaskRunId: observationRun.taskRunId,
+    },
+    routeContext: input.routeContext,
+    agentId: input.agentId,
+    threadId: input.threadId,
+    suspectedRootCause: input.spec.suspectedRootCause ?? null,
+  });
+
+  await resolved.db.taskRun.update({
+    where: { id: observationRun.id },
+    data: { status: "completed", completedAt: resolved.now() },
+  });
+
+  return { processed: 1 };
+}

--- a/apps/web/lib/tak/pattern-observer/core.ts
+++ b/apps/web/lib/tak/pattern-observer/core.ts
@@ -149,45 +149,53 @@ export async function runObservation(
     select: { id: true, taskRunId: true },
   });
 
-  await resolved.submitAssessment({
-    agentId: input.agentId,
-    trigger: input.spec.trigger,
-    routeContext: input.routeContext,
-    verdict: input.spec.verdict,
-    confidence: input.spec.confidence,
-    missionSummary: input.sourceTitle,
-    capabilitySummary: input.capabilitySummary ?? null,
-    rawPayload: {
-      ...(input.rawPayload ?? {}),
+  try {
+    await resolved.submitAssessment({
+      agentId: input.agentId,
+      trigger: input.spec.trigger,
+      routeContext: input.routeContext,
+      verdict: input.spec.verdict,
+      confidence: input.spec.confidence,
+      missionSummary: input.sourceTitle,
+      capabilitySummary: input.capabilitySummary ?? null,
+      rawPayload: {
+        ...(input.rawPayload ?? {}),
+        sourceType: input.spec.sourceType,
+        sourceId: input.spec.sourceId,
+        observationTaskRunId: observationRun.taskRunId,
+        reflectionTaskRunId: observationRun.taskRunId,
+      },
+      needs: [...input.spec.needs],
+    });
+
+    await resolved.touchSignal({
       sourceType: input.spec.sourceType,
       sourceId: input.spec.sourceId,
-      observationTaskRunId: observationRun.taskRunId,
-      reflectionTaskRunId: observationRun.taskRunId,
-    },
-    needs: [...input.spec.needs],
-  });
+      title: input.sourceTitle,
+      description: input.sourceDescription ?? null,
+      evidence: {
+        ...(input.signalEvidence ?? {}),
+        parentTaskRunId: input.parentTaskRunId,
+        observationTaskRunId: observationRun.taskRunId,
+        reflectionTaskRunId: observationRun.taskRunId,
+      },
+      routeContext: input.routeContext,
+      agentId: input.agentId,
+      threadId: input.threadId,
+      suspectedRootCause: input.spec.suspectedRootCause ?? null,
+    });
 
-  await resolved.touchSignal({
-    sourceType: input.spec.sourceType,
-    sourceId: input.spec.sourceId,
-    title: input.sourceTitle,
-    description: input.sourceDescription ?? null,
-    evidence: {
-      ...(input.signalEvidence ?? {}),
-      parentTaskRunId: input.parentTaskRunId,
-      observationTaskRunId: observationRun.taskRunId,
-      reflectionTaskRunId: observationRun.taskRunId,
-    },
-    routeContext: input.routeContext,
-    agentId: input.agentId,
-    threadId: input.threadId,
-    suspectedRootCause: input.spec.suspectedRootCause ?? null,
-  });
-
-  await resolved.db.taskRun.update({
-    where: { id: observationRun.id },
-    data: { status: "completed", completedAt: resolved.now() },
-  });
+    await resolved.db.taskRun.update({
+      where: { id: observationRun.id },
+      data: { status: "completed", completedAt: resolved.now() },
+    });
+  } catch (err) {
+    await resolved.db.taskRun.update({
+      where: { id: observationRun.id },
+      data: { status: "failed", completedAt: resolved.now() },
+    });
+    throw err;
+  }
 
   return { processed: 1 };
 }

--- a/apps/web/lib/tak/pattern-observer/fingerprint.test.ts
+++ b/apps/web/lib/tak/pattern-observer/fingerprint.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { capabilityNeedOriginId } from "@/lib/coworker-self-assessment/assessment-service";
+import {
+  capabilityNeedKey,
+  evidenceFingerprint,
+  improvementSignalKey,
+} from "@/lib/tak/pattern-observer/fingerprint";
+
+describe("pattern observer fingerprint helpers", () => {
+  it("matches the coworker capability need origin id exactly", () => {
+    const agentId = "agent-1";
+    const kind = "tool";
+    const need = `  Need   PUBLISH tools with a consistent playbook surface that keeps the agent from
+      rediscovering the same coordination gap every time the evidence changes shape. Extra text.  `;
+
+    expect(capabilityNeedKey(agentId, kind, need)).toBe(
+      capabilityNeedOriginId(agentId, kind, need),
+    );
+  });
+
+  it("returns the improvement signal source dedupe pair", () => {
+    expect(improvementSignalKey("platform_issue_report", "PIR-123")).toEqual({
+      sourceType: "platform_issue_report",
+      sourceId: "PIR-123",
+    });
+  });
+
+  it("keeps equivalent evidence payloads on the same fingerprint", () => {
+    const first = evidenceFingerprint({
+      agentId: "agent-1",
+      routeContext: "/build-studio",
+      kind: "tool",
+      need: "  Needs   a governed playbook. ",
+      evidence: {
+        observations: [
+          { message: "missing step", count: 2 },
+          { count: 1, message: "manual retry" },
+        ],
+        source: { id: "PIR-123", type: "platform_issue_report" },
+      },
+    });
+
+    const second = evidenceFingerprint({
+      agentId: "agent-1",
+      routeContext: "/build-studio",
+      kind: "tool",
+      need: "needs a governed playbook.",
+      evidence: {
+        source: { type: "platform_issue_report", id: "PIR-123" },
+        observations: [
+          { message: "manual retry", count: 1 },
+          { count: 2, message: "missing step" },
+        ],
+      },
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it("changes when the normalized need changes", () => {
+    const base = {
+      agentId: "agent-1",
+      routeContext: "/build-studio",
+      kind: "tool",
+      evidence: { sourceId: "PIR-123" },
+    };
+
+    expect(evidenceFingerprint({ ...base, need: "needs a governed playbook" })).not.toBe(
+      evidenceFingerprint({ ...base, need: "needs a governed runbook" }),
+    );
+  });
+});

--- a/apps/web/lib/tak/pattern-observer/fingerprint.test.ts
+++ b/apps/web/lib/tak/pattern-observer/fingerprint.test.ts
@@ -26,7 +26,7 @@ describe("pattern observer fingerprint helpers", () => {
     });
   });
 
-  it("keeps equivalent evidence payloads on the same fingerprint", () => {
+  it("keeps object-key-equivalent evidence payloads on the same fingerprint", () => {
     const first = evidenceFingerprint({
       agentId: "agent-1",
       routeContext: "/build-studio",
@@ -49,13 +49,26 @@ describe("pattern observer fingerprint helpers", () => {
       evidence: {
         source: { type: "platform_issue_report", id: "PIR-123" },
         observations: [
-          { message: "manual retry", count: 1 },
           { count: 2, message: "missing step" },
+          { message: "manual retry", count: 1 },
         ],
       },
     });
 
     expect(second).toBe(first);
+  });
+
+  it("keeps ordered evidence arrays distinct", () => {
+    const base = {
+      agentId: "agent-1",
+      routeContext: "/build-studio",
+      kind: "tool",
+      need: "needs a governed playbook",
+    };
+
+    expect(evidenceFingerprint({ ...base, evidence: ["start", "fail"] })).not.toBe(
+      evidenceFingerprint({ ...base, evidence: ["fail", "start"] }),
+    );
   });
 
   it("changes when the normalized need changes", () => {
@@ -69,5 +82,16 @@ describe("pattern observer fingerprint helpers", () => {
     expect(evidenceFingerprint({ ...base, need: "needs a governed playbook" })).not.toBe(
       evidenceFingerprint({ ...base, need: "needs a governed runbook" }),
     );
+  });
+
+  it("rejects non-json evidence values instead of collapsing them", () => {
+    expect(() =>
+      evidenceFingerprint({
+        agentId: "agent-1",
+        kind: "tool",
+        need: "needs a governed playbook",
+        evidence: { observedAt: new Date("2026-06-27T00:00:00.000Z") },
+      }),
+    ).toThrow(/JSON-compatible/);
   });
 });

--- a/apps/web/lib/tak/pattern-observer/fingerprint.ts
+++ b/apps/web/lib/tak/pattern-observer/fingerprint.ts
@@ -15,6 +15,14 @@ export type EvidenceFingerprintInput = {
   evidence?: unknown;
 };
 
+export type JsonEvidence =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonEvidence[]
+  | { [key: string]: JsonEvidence };
+
 export function capabilityNeedKey(agentId: string, kind: string, need: string): string {
   return capabilityNeedOriginId(agentId, kind, need);
 }
@@ -23,17 +31,41 @@ export function improvementSignalKey(sourceType: string, sourceId: string): Impr
   return { sourceType, sourceId };
 }
 
-function stableJson(value: unknown): string {
+function compareKeys(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function stableJson(value: unknown, path = "evidence"): string {
   if (Array.isArray(value)) {
-    return `[${value.map(stableJson).sort().join(",")}]`;
+    return `[${value.map((entry, index) => stableJson(entry, `${path}[${index}]`)).join(",")}]`;
   }
 
   if (value && typeof value === "object") {
-    return `{${Object.entries(value as Record<string, unknown>)
-      .filter(([, entry]) => entry !== undefined)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+    if (!isPlainObject(value)) {
+      throw new TypeError(`Evidence fingerprint only supports JSON-compatible objects at ${path}`);
+    }
+
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => compareKeys(left, right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry, `${path}.${key}`)}`)
       .join(",")}}`;
+  }
+
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new TypeError(`Evidence fingerprint only supports finite numbers at ${path}`);
+  }
+
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    throw new TypeError(`Evidence fingerprint only supports JSON-compatible values at ${path}`);
+  }
+
+  if (typeof value === "bigint") {
+    throw new TypeError(`Evidence fingerprint only supports JSON-compatible values at ${path}`);
   }
 
   return JSON.stringify(value) ?? "null";

--- a/apps/web/lib/tak/pattern-observer/fingerprint.ts
+++ b/apps/web/lib/tak/pattern-observer/fingerprint.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+
+import { capabilityNeedOriginId } from "@/lib/coworker-self-assessment/assessment-service";
+
+export type ImprovementSignalKey = {
+  sourceType: string;
+  sourceId: string;
+};
+
+export type EvidenceFingerprintInput = {
+  agentId: string;
+  routeContext?: string | null;
+  kind: string;
+  need: string;
+  evidence?: unknown;
+};
+
+export function capabilityNeedKey(agentId: string, kind: string, need: string): string {
+  return capabilityNeedOriginId(agentId, kind, need);
+}
+
+export function improvementSignalKey(sourceType: string, sourceId: string): ImprovementSignalKey {
+  return { sourceType, sourceId };
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).sort().join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value) ?? "null";
+}
+
+export function evidenceFingerprint(input: EvidenceFingerprintInput): string {
+  return createHash("sha256")
+    .update(
+      stableJson({
+        capabilityNeedKey: capabilityNeedKey(input.agentId, input.kind, input.need),
+        routeContext: input.routeContext ?? null,
+        evidence: input.evidence ?? null,
+      }),
+    )
+    .digest("hex");
+}

--- a/apps/web/lib/tak/pattern-observer/index.ts
+++ b/apps/web/lib/tak/pattern-observer/index.ts
@@ -1,0 +1,1 @@
+export * from "./core";

--- a/apps/web/lib/tak/pattern-observer/index.ts
+++ b/apps/web/lib/tak/pattern-observer/index.ts
@@ -2,3 +2,4 @@ export * from "./core";
 export * from "./fingerprint";
 export * from "./classifiers";
 export * from "./observer";
+export * from "./periodic-review";

--- a/apps/web/lib/tak/pattern-observer/index.ts
+++ b/apps/web/lib/tak/pattern-observer/index.ts
@@ -1,2 +1,3 @@
 export * from "./core";
 export * from "./fingerprint";
+export * from "./classifiers";

--- a/apps/web/lib/tak/pattern-observer/index.ts
+++ b/apps/web/lib/tak/pattern-observer/index.ts
@@ -1,3 +1,4 @@
 export * from "./core";
 export * from "./fingerprint";
 export * from "./classifiers";
+export * from "./observer";

--- a/apps/web/lib/tak/pattern-observer/index.ts
+++ b/apps/web/lib/tak/pattern-observer/index.ts
@@ -1,1 +1,2 @@
 export * from "./core";
+export * from "./fingerprint";

--- a/apps/web/lib/tak/pattern-observer/observer.test.ts
+++ b/apps/web/lib/tak/pattern-observer/observer.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assessToolSurface as realAssessToolSurface,
+  computeToolSelectionAccuracy as realComputeToolSelectionAccuracy,
+} from "@/lib/tak/context-economy-metrics";
+
+import {
+  observeCoworkerPatterns,
+  type ObserveCoworkerPatternsDeps,
+  type PatternObserverTaskRunRow,
+  type PatternObserverToolExecutionRow,
+} from "./observer";
+
+const now = new Date("2026-06-27T18:00:00.000Z");
+
+function toolExecution(
+  input: Partial<PatternObserverToolExecutionRow> & { toolName: string; success: boolean },
+): PatternObserverToolExecutionRow {
+  return {
+    id: input.id ?? `${input.toolName}-1`,
+    agentId: input.agentId ?? "agent-build",
+    routeContext: input.routeContext ?? "/build",
+    toolName: input.toolName,
+    success: input.success,
+    summary: input.summary ?? null,
+    result: input.result ?? null,
+    parameters: input.parameters ?? {},
+    taskRunId: input.taskRunId ?? null,
+    createdAt: input.createdAt ?? new Date("2026-06-27T17:30:00.000Z"),
+  };
+}
+
+function taskRun(
+  input: Partial<PatternObserverTaskRunRow> & { taskRunId: string },
+): PatternObserverTaskRunRow {
+  return {
+    taskRunId: input.taskRunId,
+    currentAgentId: input.currentAgentId ?? "agent-build",
+    routeContext: input.routeContext ?? "/build",
+    title: input.title ?? "Run a manual workflow",
+    status: input.status ?? "completed",
+    repeatedPatternKey: input.repeatedPatternKey ?? null,
+    a2aMetadata: input.a2aMetadata ?? null,
+    createdAt: input.createdAt ?? new Date("2026-06-27T17:00:00.000Z"),
+    completedAt: input.completedAt ?? new Date("2026-06-27T17:10:00.000Z"),
+  };
+}
+
+function makeDeps(input?: {
+  toolExecutions?: PatternObserverToolExecutionRow[];
+  taskRuns?: PatternObserverTaskRunRow[];
+}): ObserveCoworkerPatternsDeps {
+  return {
+    db: {
+      toolExecution: {
+        findMany: vi.fn(async () => input?.toolExecutions ?? []),
+      },
+      taskRun: {
+        findMany: vi.fn(async () => input?.taskRuns ?? []),
+      },
+    },
+    assessToolSurface: vi.fn(realAssessToolSurface),
+    computeToolSelectionAccuracy: vi.fn(realComputeToolSelectionAccuracy),
+    submitCoworkerSelfAssessment: vi.fn(async () => ({
+      assessmentId: "CWSA-1",
+      needIds: ["CWN-1"],
+      backlogItemIds: [],
+    })),
+    now: () => now,
+  };
+}
+
+function submittedAssessment(deps: ObserveCoworkerPatternsDeps) {
+  const submit = vi.mocked(deps.submitCoworkerSelfAssessment);
+  expect(submit).toHaveBeenCalledTimes(1);
+  return submit.mock.calls[0]?.[0];
+}
+
+function largeToolSurface() {
+  return Array.from({ length: 16 }, (_, index) => ({
+    type: "function",
+    function: {
+      name: `tool_${index}`,
+      description:
+        "A deliberately verbose tool definition used to make the observer preserve token evidence.",
+      parameters: {
+        type: "object",
+        properties: {
+          payload: {
+            type: "string",
+            description: "Long payload description for context-economy token estimation.",
+          },
+        },
+      },
+    },
+  }));
+}
+
+describe("observeCoworkerPatterns", () => {
+  it("submits a grant need, not a generic skill need, for repeated grant denials", async () => {
+    const deps = makeDeps({
+      toolExecutions: [
+        toolExecution({
+          id: "te-1",
+          toolName: "record_execution_evidence",
+          success: false,
+          summary: "forbidden_grant: execution.write required",
+          result: { error: "forbidden_grant", requiredGrant: "execution.write" },
+        }),
+        toolExecution({
+          id: "te-2",
+          toolName: "record_execution_evidence",
+          success: false,
+          summary: "missing capability execution.write",
+          result: { error: "missing capability execution.write" },
+        }),
+        toolExecution({
+          id: "te-3",
+          toolName: "record_execution_evidence",
+          success: false,
+          summary: "insufficient_token_scope: requiredScope write",
+          result: { error: "insufficient_token_scope", requiredScope: "write" },
+        }),
+      ],
+    });
+
+    const result = await observeCoworkerPatterns(
+      {
+        agentId: "agent-build",
+        routeContext: "/build",
+        windowMs: 60 * 60 * 1000,
+        contextWindowTokens: 4096,
+      },
+      deps,
+    );
+
+    expect(result).toEqual({ processed: 1, submitted: true });
+    expect(deps.db.toolExecution.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          agentId: "agent-build",
+          routeContext: "/build",
+          createdAt: { gte: new Date("2026-06-27T17:00:00.000Z"), lte: now },
+        }),
+      }),
+    );
+
+    const assessment = submittedAssessment(deps);
+    expect(assessment).toMatchObject({
+      agentId: "agent-build",
+      trigger: "pattern-observer",
+      routeContext: "/build",
+      verdict: "gaps",
+      confidence: "high",
+      needs: [
+        expect.objectContaining({
+          kind: "grant",
+          severity: "important",
+          evidenceJson: expect.objectContaining({
+            classifier: "grant-denial",
+            deniedTool: "record_execution_evidence",
+            missingCapability: "execution.write",
+            count: 3,
+            capabilityNeedKey: expect.any(String),
+            evidenceFingerprint: expect.any(String),
+          }),
+        }),
+      ],
+    });
+    expect(assessment?.needs.some((need) => need.kind === "skill")).toBe(false);
+    expect(assessment?.rawPayload).toMatchObject({
+      window: {
+        since: "2026-06-27T17:00:00.000Z",
+        until: "2026-06-27T18:00:00.000Z",
+        routeContext: "/build",
+      },
+      evidenceDigest: {
+        toolExecutionCount: 3,
+        taskRunCount: 0,
+      },
+      classifierSummary: expect.objectContaining({
+        grantDenialCandidates: 1,
+        submittedNeeds: 1,
+      }),
+    });
+  });
+
+  it("submits a context-economy need with token evidence for an overloaded tool window", async () => {
+    const deps = makeDeps();
+
+    await observeCoworkerPatterns(
+      {
+        agentId: "agent-build",
+        routeContext: "/build",
+        toolSurface: largeToolSurface(),
+        contextWindowTokens: 1000,
+      },
+      deps,
+    );
+
+    const assessment = submittedAssessment(deps);
+    expect(deps.assessToolSurface).toHaveBeenCalledWith({
+      tools: expect.any(Array),
+      windowTokens: 1000,
+    });
+    expect(deps.computeToolSelectionAccuracy).toHaveBeenCalledWith([]);
+    expect(assessment?.needs).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        evidenceJson: expect.objectContaining({
+          classifier: "tool-surface-overload",
+          toolCount: 16,
+          estDefinitionTokens: expect.any(Number),
+          windowShare: expect.any(Number),
+          zone: "overload",
+          exceedsLocalCliff: true,
+        }),
+      }),
+    ]);
+    expect(assessment?.rawPayload?.evidenceDigest).toMatchObject({
+      contextEconomy: {
+        toolSurfaceAssessment: expect.objectContaining({
+          toolCount: 16,
+          zone: "overload",
+        }),
+      },
+    });
+  });
+
+  it("submits a code or convention need for a repeated successful manual workflow", async () => {
+    const deps = makeDeps({
+      taskRuns: [
+        taskRun({
+          taskRunId: "TR-1",
+          a2aMetadata: {
+            manualWorkflow: {
+              key: "local-ci-lease",
+              name: "local CI lease evidence",
+              ceremonyScore: 0.9,
+            },
+          },
+        }),
+        taskRun({
+          taskRunId: "TR-2",
+          a2aMetadata: {
+            manualWorkflow: {
+              key: "local-ci-lease",
+              name: "local CI lease evidence",
+              ceremonyScore: 0.85,
+            },
+          },
+        }),
+        taskRun({
+          taskRunId: "TR-3",
+          a2aMetadata: {
+            manualWorkflow: {
+              key: "local-ci-lease",
+              name: "local CI lease evidence",
+              ceremonyScore: 0.8,
+            },
+          },
+        }),
+      ],
+      toolExecutions: [
+        toolExecution({ toolName: "claim_nonprod_environment_lease", success: true, taskRunId: "TR-1" }),
+        toolExecution({ toolName: "record_capsule_evidence", success: true, taskRunId: "TR-2" }),
+        toolExecution({ toolName: "release_nonprod_environment_lease", success: true, taskRunId: "TR-3" }),
+      ],
+    });
+
+    await observeCoworkerPatterns({ agentId: "agent-build", routeContext: "/build" }, deps);
+
+    const assessment = submittedAssessment(deps);
+    expect(assessment?.needs).toEqual([
+      expect.objectContaining({
+        kind: expect.stringMatching(/^(code|convention)$/),
+        severity: "minor",
+        evidenceJson: expect.objectContaining({
+          classifier: "repeated-success",
+          workflowName: "local CI lease evidence",
+          repetitionCount: 3,
+          ceremonyScore: expect.closeTo(0.85, 5),
+          accuracy: 1,
+        }),
+      }),
+    ]);
+  });
+
+  it("dedupes duplicate needs within one sweep", async () => {
+    const manualWorkflow = (key: string) => ({
+      manualWorkflow: {
+        key,
+        name: "local CI lease evidence",
+        ceremonyScore: 0.9,
+      },
+    });
+    const deps = makeDeps({
+      taskRuns: [
+        taskRun({ taskRunId: "TR-A1", a2aMetadata: manualWorkflow("lease-a") }),
+        taskRun({ taskRunId: "TR-A2", a2aMetadata: manualWorkflow("lease-a") }),
+        taskRun({ taskRunId: "TR-A3", a2aMetadata: manualWorkflow("lease-a") }),
+        taskRun({ taskRunId: "TR-B1", a2aMetadata: manualWorkflow("lease-b") }),
+        taskRun({ taskRunId: "TR-B2", a2aMetadata: manualWorkflow("lease-b") }),
+        taskRun({ taskRunId: "TR-B3", a2aMetadata: manualWorkflow("lease-b") }),
+      ],
+      toolExecutions: [
+        toolExecution({ toolName: "record_capsule_evidence", success: true, taskRunId: "TR-A1" }),
+        toolExecution({ toolName: "record_capsule_evidence", success: true, taskRunId: "TR-A2" }),
+        toolExecution({ toolName: "record_capsule_evidence", success: true, taskRunId: "TR-A3" }),
+        toolExecution({ toolName: "record_capsule_evidence", success: true, taskRunId: "TR-B1" }),
+        toolExecution({ toolName: "record_capsule_evidence", success: true, taskRunId: "TR-B2" }),
+        toolExecution({ toolName: "record_capsule_evidence", success: true, taskRunId: "TR-B3" }),
+      ],
+    });
+
+    await observeCoworkerPatterns({ agentId: "agent-build", routeContext: "/build" }, deps);
+
+    const assessment = submittedAssessment(deps);
+    expect(assessment?.needs).toHaveLength(1);
+    expect(assessment?.rawPayload?.classifierSummary).toMatchObject({
+      repeatedSuccessCandidates: 2,
+      duplicateNeedsSuppressed: 1,
+      submittedNeeds: 1,
+    });
+  });
+
+  it("does not submit an assessment when no classifier fires", async () => {
+    const deps = makeDeps({
+      toolExecutions: [
+        toolExecution({ toolName: "read_project_file", success: true }),
+        toolExecution({ toolName: "search_code_graph", success: true }),
+      ],
+      taskRuns: [taskRun({ taskRunId: "TR-1", status: "completed" })],
+    });
+
+    await expect(
+      observeCoworkerPatterns({
+        agentId: "agent-build",
+        routeContext: "/build",
+        contextWindowTokens: 128000,
+      }, deps),
+    ).resolves.toEqual({ processed: 0, submitted: false, skippedReason: "no-signals" });
+
+    expect(deps.submitCoworkerSelfAssessment).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/tak/pattern-observer/observer.ts
+++ b/apps/web/lib/tak/pattern-observer/observer.ts
@@ -1,0 +1,573 @@
+import { prisma } from "@dpf/db";
+
+import { submitCoworkerSelfAssessment as defaultSubmitCoworkerSelfAssessment } from "@/lib/coworker-self-assessment/assessment-service";
+import type {
+  CoworkerAssessmentConfidence,
+  CoworkerAssessmentVerdict,
+  CoworkerCapabilityNeedInput,
+  SubmitCoworkerSelfAssessmentInput,
+} from "@/lib/coworker-self-assessment/types";
+import {
+  assessToolSurface as defaultAssessToolSurface,
+  computeToolSelectionAccuracy as defaultComputeToolSelectionAccuracy,
+  type ToolCallSample,
+  type ToolSelectionAccuracy,
+  type ToolSurfaceAssessment,
+} from "@/lib/tak/context-economy-metrics";
+
+import {
+  classifyGrantDenial,
+  classifyRepeatedSuccess,
+  classifyToolSurfaceOverload,
+} from "./classifiers";
+import { capabilityNeedKey, evidenceFingerprint } from "./fingerprint";
+
+const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_TAKE = 200;
+
+export type PatternObserverToolExecutionRow = {
+  id?: string | null;
+  agentId?: string | null;
+  routeContext?: string | null;
+  toolName: string;
+  success: boolean;
+  summary?: string | null;
+  result?: unknown;
+  parameters?: unknown;
+  taskRunId?: string | null;
+  createdAt?: Date | null;
+};
+
+export type PatternObserverTaskRunRow = {
+  taskRunId: string;
+  currentAgentId?: string | null;
+  initiatingAgentId?: string | null;
+  routeContext?: string | null;
+  title?: string | null;
+  status?: string | null;
+  repeatedPatternKey?: string | null;
+  a2aMetadata?: unknown;
+  createdAt?: Date | null;
+  completedAt?: Date | null;
+};
+
+type ToolExecutionFindManyArgs = {
+  where: Record<string, unknown>;
+  orderBy: { createdAt: "desc" };
+  take: number;
+  select: Record<keyof PatternObserverToolExecutionRow, true>;
+};
+
+type TaskRunFindManyArgs = {
+  where: Record<string, unknown>;
+  orderBy: { createdAt: "desc" };
+  take: number;
+  select: Record<keyof PatternObserverTaskRunRow, true>;
+};
+
+export type PatternObserverDb = {
+  toolExecution: {
+    findMany(args: ToolExecutionFindManyArgs): Promise<PatternObserverToolExecutionRow[]>;
+  };
+  taskRun: {
+    findMany(args: TaskRunFindManyArgs): Promise<PatternObserverTaskRunRow[]>;
+  };
+};
+
+export type ObserveCoworkerPatternsInput = {
+  agentId: string;
+  routeContext?: string | null;
+  since?: Date;
+  until?: Date;
+  windowMs?: number;
+  take?: number;
+  contextWindowTokens?: number | null;
+  toolSurface?: readonly unknown[] | null;
+};
+
+export type ObserveCoworkerPatternsResult = {
+  processed: number;
+  submitted: boolean;
+  skippedReason?: "no-signals";
+};
+
+export type ObserveCoworkerPatternsDeps = {
+  db: PatternObserverDb;
+  assessToolSurface: typeof defaultAssessToolSurface;
+  computeToolSelectionAccuracy: typeof defaultComputeToolSelectionAccuracy;
+  submitCoworkerSelfAssessment: (
+    input: SubmitCoworkerSelfAssessmentInput,
+  ) => ReturnType<typeof defaultSubmitCoworkerSelfAssessment>;
+  now: () => Date;
+};
+
+type ObservationWindow = {
+  since: Date;
+  until: Date;
+  windowMs: number;
+};
+
+type CandidateNeed = {
+  classifier: "grant-denial" | "tool-surface-overload" | "repeated-success";
+  need: CoworkerCapabilityNeedInput;
+};
+
+type ClassifierSummary = {
+  grantDenialCandidates: number;
+  toolSurfaceCandidates: number;
+  repeatedSuccessCandidates: number;
+  duplicateNeedsSuppressed: number;
+  submittedNeeds: number;
+};
+
+type ManualWorkflowSignal = {
+  key: string;
+  name: string;
+  ceremonyScore: number;
+};
+
+function defaultDb(): PatternObserverDb {
+  return prisma as unknown as PatternObserverDb;
+}
+
+function resolveDeps(deps?: Partial<ObserveCoworkerPatternsDeps>): ObserveCoworkerPatternsDeps {
+  return {
+    db: deps?.db ?? defaultDb(),
+    assessToolSurface: deps?.assessToolSurface ?? defaultAssessToolSurface,
+    computeToolSelectionAccuracy:
+      deps?.computeToolSelectionAccuracy ?? defaultComputeToolSelectionAccuracy,
+    submitCoworkerSelfAssessment:
+      deps?.submitCoworkerSelfAssessment ?? defaultSubmitCoworkerSelfAssessment,
+    now: deps?.now ?? (() => new Date()),
+  };
+}
+
+function finitePositive(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function resolveWindow(input: ObserveCoworkerPatternsInput, now: Date): ObservationWindow {
+  const until = input.until ?? now;
+  const windowMs = finitePositive(input.windowMs, DEFAULT_WINDOW_MS);
+  const since = input.since ?? new Date(until.getTime() - windowMs);
+  return { since, until, windowMs: Math.max(0, until.getTime() - since.getTime()) };
+}
+
+function routeFilter(routeContext: string | null | undefined): Record<string, unknown> {
+  return routeContext ? { routeContext } : {};
+}
+
+function createdAtFilter(window: ObservationWindow): { gte: Date; lte: Date } {
+  return { gte: window.since, lte: window.until };
+}
+
+async function loadToolExecutions(
+  input: ObserveCoworkerPatternsInput,
+  window: ObservationWindow,
+  deps: ObserveCoworkerPatternsDeps,
+): Promise<PatternObserverToolExecutionRow[]> {
+  return deps.db.toolExecution.findMany({
+    where: {
+      agentId: input.agentId,
+      ...routeFilter(input.routeContext),
+      createdAt: createdAtFilter(window),
+    },
+    orderBy: { createdAt: "desc" },
+    take: finitePositive(input.take, DEFAULT_TAKE),
+    select: {
+      id: true,
+      agentId: true,
+      routeContext: true,
+      toolName: true,
+      success: true,
+      summary: true,
+      result: true,
+      parameters: true,
+      taskRunId: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadTaskRuns(
+  input: ObserveCoworkerPatternsInput,
+  window: ObservationWindow,
+  deps: ObserveCoworkerPatternsDeps,
+): Promise<PatternObserverTaskRunRow[]> {
+  return deps.db.taskRun.findMany({
+    where: {
+      OR: [{ currentAgentId: input.agentId }, { initiatingAgentId: input.agentId }],
+      ...routeFilter(input.routeContext),
+      createdAt: createdAtFilter(window),
+    },
+    orderBy: { createdAt: "desc" },
+    take: finitePositive(input.take, DEFAULT_TAKE),
+    select: {
+      taskRunId: true,
+      currentAgentId: true,
+      initiatingAgentId: true,
+      routeContext: true,
+      title: true,
+      status: true,
+      repeatedPatternKey: true,
+      a2aMetadata: true,
+      createdAt: true,
+      completedAt: true,
+    },
+  });
+}
+
+function stringifyEvidence(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+function executionText(execution: PatternObserverToolExecutionRow): string {
+  return [execution.summary ?? "", stringifyEvidence(execution.result)].join(" ").trim();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(source: unknown, field: string): string | null {
+  if (!isRecord(source)) return null;
+  const value = source[field];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function numberField(source: unknown, field: string): number | null {
+  if (!isRecord(source)) return null;
+  const value = source[field];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function capabilityFromText(text: string): string | null {
+  const patterns = [
+    /\bforbidden[_\s-]?grant[:\s]+([a-z0-9_.:-]+)/i,
+    /\bmissing\s+capability\s+([a-z0-9_.:-]+)/i,
+    /\brequiredGrant["'\s:]+([a-z0-9_.:-]+)/i,
+    /\brequiredCapability["'\s:]+([a-z0-9_.:-]+)/i,
+    /\brequiredScope["'\s:]+([a-z0-9_.:-]+)/i,
+  ] as const;
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+function missingCapabilityFromExecution(execution: PatternObserverToolExecutionRow): string | null {
+  const result = isRecord(execution.result) ? execution.result : null;
+  return (
+    stringField(result, "requiredGrant") ??
+    stringField(result, "requiredCapability") ??
+    stringField(result, "missingCapability") ??
+    stringField(result, "capability") ??
+    capabilityFromText(executionText(execution))
+  );
+}
+
+function groupBy<T>(items: readonly T[], keyFor: (item: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFor(item);
+    const group = grouped.get(key) ?? [];
+    group.push(item);
+    grouped.set(key, group);
+  }
+  return grouped;
+}
+
+function toolCallSamples(
+  executions: readonly PatternObserverToolExecutionRow[],
+): ToolCallSample[] {
+  return executions.map((execution) => ({
+    toolName: execution.toolName,
+    success: execution.success,
+  }));
+}
+
+function classifyGrantDenials(
+  executions: readonly PatternObserverToolExecutionRow[],
+): CandidateNeed[] {
+  const failuresByTool = groupBy(
+    executions.filter((execution) => execution.success === false),
+    (execution) => execution.toolName,
+  );
+  const candidates: CandidateNeed[] = [];
+
+  for (const [toolName, failures] of failuresByTool) {
+    const denialMessages = failures.map(executionText).filter(Boolean);
+    const missingCapability =
+      failures.map(missingCapabilityFromExecution).find((value): value is string => Boolean(value)) ??
+      null;
+    const need = classifyGrantDenial({
+      deniedTool: toolName,
+      missingCapability,
+      denialMessages,
+    });
+    if (need) {
+      candidates.push({ classifier: "grant-denial", need });
+    }
+  }
+
+  return candidates;
+}
+
+function toolSurfaceFromExecutions(
+  executions: readonly PatternObserverToolExecutionRow[],
+): readonly unknown[] {
+  const names = [...new Set(executions.map((execution) => execution.toolName).filter(Boolean))];
+  return names.map((name) => ({ type: "function", function: { name } }));
+}
+
+function workflowSignalFromRun(run: PatternObserverTaskRunRow): ManualWorkflowSignal | null {
+  if (run.status !== "completed") return null;
+  const meta = isRecord(run.a2aMetadata) ? run.a2aMetadata : {};
+  const manual = isRecord(meta.manualWorkflow) ? meta.manualWorkflow : {};
+  const key =
+    stringField(manual, "key") ??
+    stringField(meta, "manualWorkflowKey") ??
+    stringField(meta, "workflowKey") ??
+    run.repeatedPatternKey ??
+    null;
+  const name =
+    stringField(manual, "name") ??
+    stringField(meta, "manualWorkflowName") ??
+    stringField(meta, "workflowName") ??
+    key;
+  const ceremonyScore =
+    numberField(manual, "ceremonyScore") ??
+    numberField(meta, "manualWorkflowCeremonyScore") ??
+    numberField(meta, "ceremonyScore");
+
+  if (!key || !name || ceremonyScore === null) return null;
+  return { key, name, ceremonyScore };
+}
+
+function average(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function classifyRepeatedManualSuccesses(
+  taskRuns: readonly PatternObserverTaskRunRow[],
+  executions: readonly PatternObserverToolExecutionRow[],
+  computeToolSelectionAccuracy: typeof defaultComputeToolSelectionAccuracy,
+): CandidateNeed[] {
+  const runsWithWorkflow = taskRuns
+    .map((run) => ({ run, workflow: workflowSignalFromRun(run) }))
+    .filter((entry): entry is { run: PatternObserverTaskRunRow; workflow: ManualWorkflowSignal } =>
+      Boolean(entry.workflow),
+    );
+  const byWorkflowKey = groupBy(runsWithWorkflow, (entry) => entry.workflow.key);
+  const candidates: CandidateNeed[] = [];
+
+  for (const [, entries] of byWorkflowKey) {
+    const taskRunIds = new Set(entries.map((entry) => entry.run.taskRunId));
+    const relatedExecutions = executions.filter(
+      (execution) => execution.taskRunId && taskRunIds.has(execution.taskRunId),
+    );
+    const accuracy: ToolSelectionAccuracy = computeToolSelectionAccuracy(
+      toolCallSamples(relatedExecutions),
+    );
+    const need = classifyRepeatedSuccess({
+      workflowName: entries[0]?.workflow.name ?? "manual",
+      repetitionCount: entries.length,
+      ceremonyScore: average(entries.map((entry) => entry.workflow.ceremonyScore)),
+      accuracy,
+    });
+    if (need) {
+      candidates.push({ classifier: "repeated-success", need });
+    }
+  }
+
+  return candidates;
+}
+
+function enrichNeed(
+  input: ObserveCoworkerPatternsInput,
+  candidate: CandidateNeed,
+): CoworkerCapabilityNeedInput {
+  const evidence = {
+    classifier: candidate.classifier,
+    ...(candidate.need.evidenceJson ?? {}),
+  };
+  const needKey = capabilityNeedKey(input.agentId, candidate.need.kind, candidate.need.need);
+  const fingerprint = evidenceFingerprint({
+    agentId: input.agentId,
+    routeContext: input.routeContext ?? null,
+    kind: candidate.need.kind,
+    need: candidate.need.need,
+    evidence,
+  });
+
+  return {
+    ...candidate.need,
+    evidenceJson: {
+      ...evidence,
+      capabilityNeedKey: needKey,
+      evidenceFingerprint: fingerprint,
+    },
+  };
+}
+
+function dedupeCandidates(
+  input: ObserveCoworkerPatternsInput,
+  candidates: readonly CandidateNeed[],
+): { needs: CoworkerCapabilityNeedInput[]; duplicateNeedsSuppressed: number } {
+  const needKeys = new Set<string>();
+  const fingerprints = new Set<string>();
+  const needs: CoworkerCapabilityNeedInput[] = [];
+  let duplicateNeedsSuppressed = 0;
+
+  for (const candidate of candidates) {
+    const need = enrichNeed(input, candidate);
+    const needKey = String(need.evidenceJson?.capabilityNeedKey ?? "");
+    const fingerprint = String(need.evidenceJson?.evidenceFingerprint ?? "");
+    if (needKeys.has(needKey) || fingerprints.has(fingerprint)) {
+      duplicateNeedsSuppressed += 1;
+      continue;
+    }
+    needKeys.add(needKey);
+    fingerprints.add(fingerprint);
+    needs.push(need);
+  }
+
+  return { needs, duplicateNeedsSuppressed };
+}
+
+function taskRunOutcomes(taskRuns: readonly PatternObserverTaskRunRow[]): Record<string, number> {
+  const outcomes: Record<string, number> = {};
+  for (const run of taskRuns) {
+    const status = run.status ?? "unknown";
+    outcomes[status] = (outcomes[status] ?? 0) + 1;
+  }
+  return outcomes;
+}
+
+function confidenceForNeeds(
+  needs: readonly CoworkerCapabilityNeedInput[],
+): CoworkerAssessmentConfidence {
+  return needs.some((need) => need.severity === "blocker" || need.severity === "important")
+    ? "high"
+    : "medium";
+}
+
+function verdictForNeeds(needs: readonly CoworkerCapabilityNeedInput[]): CoworkerAssessmentVerdict {
+  return needs.some((need) => need.severity === "blocker") ? "blocked" : "gaps";
+}
+
+function rawPayload(input: {
+  routeContext?: string | null;
+  window: ObservationWindow;
+  toolExecutions: readonly PatternObserverToolExecutionRow[];
+  taskRuns: readonly PatternObserverTaskRunRow[];
+  toolSurfaceAssessment: ToolSurfaceAssessment;
+  toolSelectionAccuracy: ToolSelectionAccuracy;
+  classifierSummary: ClassifierSummary;
+  needs: readonly CoworkerCapabilityNeedInput[];
+}): Record<string, unknown> {
+  return {
+    observer: "systemic-coworker-pattern-observer",
+    window: {
+      since: input.window.since.toISOString(),
+      until: input.window.until.toISOString(),
+      windowMs: input.window.windowMs,
+      routeContext: input.routeContext ?? null,
+    },
+    evidenceDigest: {
+      toolExecutionCount: input.toolExecutions.length,
+      failedToolExecutionCount: input.toolExecutions.filter((execution) => !execution.success)
+        .length,
+      taskRunCount: input.taskRuns.length,
+      taskRunOutcomes: taskRunOutcomes(input.taskRuns),
+      contextEconomy: {
+        toolSurfaceAssessment: input.toolSurfaceAssessment,
+        toolSelectionAccuracy: input.toolSelectionAccuracy,
+      },
+    },
+    classifierSummary: input.classifierSummary,
+    capabilityNeedKeys: input.needs.map((need) => need.evidenceJson?.capabilityNeedKey),
+    evidenceFingerprints: input.needs.map((need) => need.evidenceJson?.evidenceFingerprint),
+  };
+}
+
+export async function observeCoworkerPatterns(
+  input: ObserveCoworkerPatternsInput,
+  deps?: Partial<ObserveCoworkerPatternsDeps>,
+): Promise<ObserveCoworkerPatternsResult> {
+  const resolved = resolveDeps(deps);
+  const window = resolveWindow(input, resolved.now());
+  const [toolExecutions, taskRuns] = await Promise.all([
+    loadToolExecutions(input, window, resolved),
+    loadTaskRuns(input, window, resolved),
+  ]);
+
+  const toolSurface = input.toolSurface ?? toolSurfaceFromExecutions(toolExecutions);
+  const toolSurfaceAssessment = resolved.assessToolSurface({
+    tools: toolSurface,
+    windowTokens: input.contextWindowTokens ?? null,
+  });
+  const toolSelectionAccuracy = resolved.computeToolSelectionAccuracy(
+    toolCallSamples(toolExecutions),
+  );
+
+  const grantCandidates = classifyGrantDenials(toolExecutions);
+  const toolSurfaceNeed = classifyToolSurfaceOverload(toolSurfaceAssessment);
+  const toolSurfaceCandidates: CandidateNeed[] = toolSurfaceNeed
+    ? [{ classifier: "tool-surface-overload", need: toolSurfaceNeed }]
+    : [];
+  const repeatedSuccessCandidates = classifyRepeatedManualSuccesses(
+    taskRuns,
+    toolExecutions,
+    resolved.computeToolSelectionAccuracy,
+  );
+
+  const allCandidates = [
+    ...grantCandidates,
+    ...toolSurfaceCandidates,
+    ...repeatedSuccessCandidates,
+  ];
+  const { needs, duplicateNeedsSuppressed } = dedupeCandidates(input, allCandidates);
+  const classifierSummary: ClassifierSummary = {
+    grantDenialCandidates: grantCandidates.length,
+    toolSurfaceCandidates: toolSurfaceCandidates.length,
+    repeatedSuccessCandidates: repeatedSuccessCandidates.length,
+    duplicateNeedsSuppressed,
+    submittedNeeds: needs.length,
+  };
+
+  if (needs.length === 0) {
+    return { processed: 0, submitted: false, skippedReason: "no-signals" };
+  }
+
+  await resolved.submitCoworkerSelfAssessment({
+    agentId: input.agentId,
+    trigger: "pattern-observer",
+    routeContext: input.routeContext ?? null,
+    verdict: verdictForNeeds(needs),
+    confidence: confidenceForNeeds(needs),
+    missionSummary: `Observed ${needs.length} systemic coworker pattern need(s).`,
+    capabilitySummary: needs.map((need) => need.need).join("; "),
+    rawPayload: rawPayload({
+      routeContext: input.routeContext,
+      window,
+      toolExecutions,
+      taskRuns,
+      toolSurfaceAssessment,
+      toolSelectionAccuracy,
+      classifierSummary,
+      needs,
+    }),
+    needs: [...needs],
+  });
+
+  return { processed: needs.length, submitted: true };
+}

--- a/apps/web/lib/tak/pattern-observer/periodic-review.test.ts
+++ b/apps/web/lib/tak/pattern-observer/periodic-review.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PERIODIC_PATTERN_REVIEW_MIN_COMPLETED_RUNS,
+  PERIODIC_PATTERN_REVIEW_WINDOW_MS,
+  runPeriodicPatternReview,
+  type PeriodicPatternReviewDb,
+} from "./periodic-review";
+
+function makeDb(overrides?: {
+  parentTaskRun?: Awaited<ReturnType<PeriodicPatternReviewDb["getTaskRun"]>>;
+  completedRuns?: number;
+  recentReview?: Awaited<ReturnType<PeriodicPatternReviewDb["findRecentReview"]>>;
+}): PeriodicPatternReviewDb {
+  return {
+    getTaskRun: vi.fn(async () => overrides?.parentTaskRun ?? null),
+    countCompletedRuns: vi.fn(async () => overrides?.completedRuns ?? PERIODIC_PATTERN_REVIEW_MIN_COMPLETED_RUNS),
+    findRecentReview: vi.fn(async () => overrides?.recentReview ?? null),
+    createTaskRun: vi.fn(async () => ({ taskRunId: "TR-GAP-REVIEW" })),
+    completeTaskRun: vi.fn(async () => undefined),
+  };
+}
+
+describe("runPeriodicPatternReview", () => {
+  it("creates an attributable proactive review and observes coworker patterns", async () => {
+    const db = makeDb();
+    const observeCoworkerPatterns = vi.fn(async () => ({ processed: 2, submitted: true }));
+    const now = new Date("2026-06-27T18:00:00.000Z");
+
+    const result = await runPeriodicPatternReview(
+      {
+        agentId: "agent-build",
+        routeContext: "/build",
+      },
+      {
+        db,
+        resolveOwnerUserId: async () => "user-super",
+        observeCoworkerPatterns,
+        now: () => now,
+      },
+    );
+
+    expect(result).toEqual({
+      reviewed: true,
+      taskRunId: "TR-GAP-REVIEW",
+      observedNeeds: 2,
+    });
+    expect(db.countCompletedRuns).toHaveBeenCalledWith({
+      agentId: "agent-build",
+      routeContext: "/build",
+      since: new Date(now.getTime() - PERIODIC_PATTERN_REVIEW_WINDOW_MS),
+      until: now,
+    });
+    expect(db.createTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-super",
+        initiatingAgentId: "agent-build",
+        currentAgentId: "agent-build",
+        source: "proactive",
+        status: "working",
+        routeContext: "/build",
+        a2aMetadata: expect.objectContaining({
+          trigger: "periodic-pattern-review",
+          reflectionDepth: 0,
+        }),
+      }),
+    );
+    expect(observeCoworkerPatterns).toHaveBeenCalledWith({
+      agentId: "agent-build",
+      routeContext: "/build",
+      since: new Date(now.getTime() - PERIODIC_PATTERN_REVIEW_WINDOW_MS),
+      until: now,
+      windowMs: PERIODIC_PATTERN_REVIEW_WINDOW_MS,
+    });
+    expect(db.completeTaskRun).toHaveBeenCalledWith(
+      "TR-GAP-REVIEW",
+      expect.objectContaining({
+        status: "completed",
+        completedAt: now,
+        progressPayload: expect.objectContaining({
+          type: "periodic-pattern-review",
+          observedNeeds: 2,
+        }),
+      }),
+    );
+  });
+
+  it("skips agents reviewed within the cadence window", async () => {
+    const db = makeDb({ recentReview: { taskRunId: "TR-RECENT" } });
+    const observeCoworkerPatterns = vi.fn();
+
+    await expect(
+      runPeriodicPatternReview(
+        { agentId: "agent-build", routeContext: "/build" },
+        {
+          db,
+          resolveOwnerUserId: async () => "user-super",
+          observeCoworkerPatterns,
+          now: () => new Date("2026-06-27T18:00:00.000Z"),
+        },
+      ),
+    ).resolves.toEqual({
+      reviewed: false,
+      skippedReason: "recently-reviewed",
+    });
+
+    expect(db.createTaskRun).not.toHaveBeenCalled();
+    expect(observeCoworkerPatterns).not.toHaveBeenCalled();
+  });
+
+  it("skips agents below the completed-run threshold", async () => {
+    const db = makeDb({ completedRuns: PERIODIC_PATTERN_REVIEW_MIN_COMPLETED_RUNS - 1 });
+    const observeCoworkerPatterns = vi.fn();
+
+    await expect(
+      runPeriodicPatternReview(
+        { agentId: "agent-build", routeContext: "/build" },
+        {
+          db,
+          resolveOwnerUserId: async () => "user-super",
+          observeCoworkerPatterns,
+          now: () => new Date("2026-06-27T18:00:00.000Z"),
+        },
+      ),
+    ).resolves.toEqual({
+      reviewed: false,
+      skippedReason: "below-run-count",
+    });
+
+    expect(db.createTaskRun).not.toHaveBeenCalled();
+    expect(observeCoworkerPatterns).not.toHaveBeenCalled();
+  });
+
+  it("respects reflection loop guards before creating a review", async () => {
+    const db = makeDb({
+      parentTaskRun: {
+        source: "proactive",
+        title: "Skill reflection: repeated tool use",
+        a2aMetadata: { reflectionDepth: 1 },
+      },
+    });
+
+    await expect(
+      runPeriodicPatternReview(
+        {
+          agentId: "agent-build",
+          routeContext: "/build",
+          parentTaskRunId: "TR-RFL-1",
+        },
+        {
+          db,
+          resolveOwnerUserId: async () => "user-super",
+          observeCoworkerPatterns: vi.fn(),
+          now: () => new Date("2026-06-27T18:00:00.000Z"),
+        },
+      ),
+    ).resolves.toEqual({
+      reviewed: false,
+      skippedReason: "reflection-loop-guard",
+    });
+
+    expect(db.createTaskRun).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/tak/pattern-observer/periodic-review.ts
+++ b/apps/web/lib/tak/pattern-observer/periodic-review.ts
@@ -1,0 +1,239 @@
+import { randomUUID } from "node:crypto";
+
+import type { Prisma } from "@dpf/db";
+import { prisma } from "@dpf/db";
+
+import { resolveScheduledOwnerUserId } from "@/lib/queue/scheduled-owner";
+
+import { isReflectionLoopGuarded, type ReflectionDepthSource } from "./core";
+import { observeCoworkerPatterns } from "./observer";
+
+export const PERIODIC_PATTERN_REVIEW_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+export const PERIODIC_PATTERN_REVIEW_MIN_COMPLETED_RUNS = 10;
+
+export type PeriodicPatternReviewWindow = {
+  agentId: string;
+  routeContext: string | null;
+  since: Date;
+  until: Date;
+};
+
+export type PeriodicPatternReviewTaskRunData = {
+  taskRunId?: string;
+  userId: string;
+  initiatingAgentId: string;
+  currentAgentId: string;
+  parentTaskRunId?: string | null;
+  routeContext: string | null;
+  title: string;
+  objective: string;
+  source: "proactive";
+  status: "working";
+  a2aMetadata: Record<string, unknown>;
+};
+
+export type PeriodicPatternReviewDb = {
+  getTaskRun(taskRunId: string): Promise<ReflectionDepthSource | null>;
+  countCompletedRuns(input: PeriodicPatternReviewWindow): Promise<number>;
+  findRecentReview(input: PeriodicPatternReviewWindow): Promise<{ taskRunId: string } | null>;
+  createTaskRun(data: PeriodicPatternReviewTaskRunData): Promise<{ taskRunId: string }>;
+  completeTaskRun(
+    taskRunId: string,
+    data: {
+      status: "completed" | "failed";
+      completedAt: Date;
+      progressPayload: Record<string, unknown>;
+    },
+  ): Promise<unknown>;
+};
+
+export type PeriodicPatternReviewInput = {
+  agentId: string;
+  routeContext?: string | null;
+  parentTaskRunId?: string | null;
+};
+
+export type PeriodicPatternReviewResult =
+  | {
+      reviewed: true;
+      taskRunId: string;
+      observedNeeds: number;
+    }
+  | {
+      reviewed: false;
+      skippedReason: "reflection-loop-guard" | "recently-reviewed" | "below-run-count";
+    };
+
+export type PeriodicPatternReviewDeps = {
+  db: PeriodicPatternReviewDb;
+  resolveOwnerUserId: () => Promise<string>;
+  observeCoworkerPatterns: typeof observeCoworkerPatterns;
+  now: () => Date;
+  createTaskRunId: () => string;
+};
+
+function createReviewTaskRunId(): string {
+  return `TR-GAP-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+function defaultDb(): PeriodicPatternReviewDb {
+  return {
+    getTaskRun: (taskRunId) =>
+      prisma.taskRun.findUnique({
+        where: { taskRunId },
+        select: { source: true, title: true, a2aMetadata: true },
+      }),
+    countCompletedRuns: (input) =>
+      prisma.taskRun.count({
+        where: {
+          OR: [{ currentAgentId: input.agentId }, { initiatingAgentId: input.agentId }],
+          routeContext: input.routeContext,
+          status: "completed",
+          completedAt: { gte: input.since, lte: input.until },
+        },
+      }),
+    findRecentReview: (input) =>
+      prisma.taskRun.findFirst({
+        where: {
+          currentAgentId: input.agentId,
+          routeContext: input.routeContext,
+          source: "proactive",
+          title: `Periodic pattern review: ${input.agentId}`,
+          createdAt: { gte: input.since, lte: input.until },
+        },
+        orderBy: { createdAt: "desc" },
+        select: { taskRunId: true },
+      }),
+    createTaskRun: (data) =>
+      prisma.taskRun.create({
+        data: {
+          taskRunId: data.taskRunId ?? createReviewTaskRunId(),
+          userId: data.userId,
+          initiatingAgentId: data.initiatingAgentId,
+          currentAgentId: data.currentAgentId,
+          parentTaskRunId: data.parentTaskRunId ?? null,
+          routeContext: data.routeContext,
+          title: data.title,
+          objective: data.objective,
+          source: data.source,
+          status: data.status,
+          authorityScope: [],
+          a2aMetadata: data.a2aMetadata as Prisma.InputJsonValue,
+        },
+        select: { taskRunId: true },
+      }),
+    completeTaskRun: (taskRunId, data) =>
+      prisma.taskRun.update({
+        where: { taskRunId },
+        data: {
+          status: data.status,
+          completedAt: data.completedAt,
+          progressPayload: data.progressPayload as Prisma.InputJsonValue,
+        },
+      }),
+  };
+}
+
+function resolveDeps(deps?: Partial<PeriodicPatternReviewDeps>): PeriodicPatternReviewDeps {
+  return {
+    db: deps?.db ?? defaultDb(),
+    resolveOwnerUserId: deps?.resolveOwnerUserId ?? resolveScheduledOwnerUserId,
+    observeCoworkerPatterns: deps?.observeCoworkerPatterns ?? observeCoworkerPatterns,
+    now: deps?.now ?? (() => new Date()),
+    createTaskRunId: deps?.createTaskRunId ?? createReviewTaskRunId,
+  };
+}
+
+function reviewWindow(input: PeriodicPatternReviewInput, now: Date): PeriodicPatternReviewWindow {
+  return {
+    agentId: input.agentId,
+    routeContext: input.routeContext ?? null,
+    since: new Date(now.getTime() - PERIODIC_PATTERN_REVIEW_WINDOW_MS),
+    until: now,
+  };
+}
+
+export async function runPeriodicPatternReview(
+  input: PeriodicPatternReviewInput,
+  deps?: Partial<PeriodicPatternReviewDeps>,
+): Promise<PeriodicPatternReviewResult> {
+  const resolved = resolveDeps(deps);
+  const now = resolved.now();
+  const window = reviewWindow(input, now);
+
+  if (input.parentTaskRunId) {
+    const parent = await resolved.db.getTaskRun(input.parentTaskRunId);
+    if (isReflectionLoopGuarded(parent)) {
+      return { reviewed: false, skippedReason: "reflection-loop-guard" };
+    }
+  }
+
+  const recentReview = await resolved.db.findRecentReview(window);
+  if (recentReview) {
+    return { reviewed: false, skippedReason: "recently-reviewed" };
+  }
+
+  const completedRuns = await resolved.db.countCompletedRuns(window);
+  if (completedRuns < PERIODIC_PATTERN_REVIEW_MIN_COMPLETED_RUNS) {
+    return { reviewed: false, skippedReason: "below-run-count" };
+  }
+
+  const ownerUserId = await resolved.resolveOwnerUserId();
+  const review = await resolved.db.createTaskRun({
+    taskRunId: resolved.createTaskRunId(),
+    userId: ownerUserId,
+    initiatingAgentId: input.agentId,
+    currentAgentId: input.agentId,
+    parentTaskRunId: input.parentTaskRunId ?? null,
+    routeContext: window.routeContext,
+    title: `Periodic pattern review: ${input.agentId}`,
+    objective: `Review recent systemic coworker pattern evidence for ${input.agentId}.`,
+    source: "proactive",
+    status: "working",
+    a2aMetadata: {
+      trigger: "periodic-pattern-review",
+      reflectionDepth: 0,
+      windowDays: PERIODIC_PATTERN_REVIEW_WINDOW_MS / (24 * 60 * 60 * 1000),
+      minCompletedRuns: PERIODIC_PATTERN_REVIEW_MIN_COMPLETED_RUNS,
+    },
+  });
+
+  try {
+    const observed = await resolved.observeCoworkerPatterns({
+      agentId: input.agentId,
+      routeContext: window.routeContext,
+      since: window.since,
+      until: window.until,
+      windowMs: PERIODIC_PATTERN_REVIEW_WINDOW_MS,
+    });
+    await resolved.db.completeTaskRun(review.taskRunId, {
+      status: "completed",
+      completedAt: now,
+      progressPayload: {
+        type: "periodic-pattern-review",
+        agentId: input.agentId,
+        routeContext: window.routeContext,
+        completedRuns,
+        observedNeeds: observed.processed,
+        submitted: observed.submitted,
+      },
+    });
+    return {
+      reviewed: true,
+      taskRunId: review.taskRunId,
+      observedNeeds: observed.processed,
+    };
+  } catch (err) {
+    await resolved.db.completeTaskRun(review.taskRunId, {
+      status: "failed",
+      completedAt: now,
+      progressPayload: {
+        type: "periodic-pattern-review",
+        agentId: input.agentId,
+        routeContext: window.routeContext,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+    throw err;
+  }
+}

--- a/apps/web/lib/tak/reflection-triggers.ts
+++ b/apps/web/lib/tak/reflection-triggers.ts
@@ -21,39 +21,22 @@
 //      trigger again over the same PlatformIssueReport increments
 //      recurrenceCount instead of producing a parallel signal.
 
-import { randomUUID } from "crypto";
-
 import type { Prisma } from "@dpf/db";
 import { prisma } from "@dpf/db";
 
-import { createOrTouchImprovementSignal } from "@/lib/improvement-flywheel/signals";
+import {
+  getReflectionDepth,
+  isReflectionLoopGuarded,
+  isReflectionRun,
+  runObservation,
+  type ReflectionDepthSource,
+  type RunObservationResult,
+} from "./pattern-observer/core";
 
 const REFLECTION_TITLE = "Skill reflection: repeated tool use";
 
-export type ReflectionDepthSource = {
-  source?: string | null;
-  title?: string | null;
-  a2aMetadata?: Prisma.JsonValue | null;
-};
-
-/**
- * Read `a2aMetadata.reflectionDepth` off a TaskRun-shaped row. Defaults to
- * 0 when the value is missing or the metadata is not an object. Callers
- * should NEVER reach into `a2aMetadata` directly — go through this helper
- * so the shape is enforced in one place.
- */
-export function getReflectionDepth(parent: ReflectionDepthSource | null | undefined): number {
-  if (!parent) return 0;
-  const meta = parent.a2aMetadata;
-  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return 0;
-  const value = (meta as { reflectionDepth?: unknown }).reflectionDepth;
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-export function isReflectionRun(parent: ReflectionDepthSource | null | undefined): boolean {
-  if (!parent) return false;
-  return parent.source === "proactive" && (parent.title ?? "").startsWith("Skill reflection:");
-}
+export { getReflectionDepth, isReflectionRun };
+export type { ReflectionDepthSource };
 
 export type ProcessRuntimeIssueReflectionInput = {
   /** The parent agentic run that just finished. Used for precise correlation. */
@@ -70,10 +53,7 @@ export type ProcessRuntimeIssueReflectionInput = {
   since: Date;
 };
 
-export type ProcessRuntimeIssueReflectionResult = {
-  processed: number;
-  skippedReason?: "reflection-loop-guard";
-};
+export type ProcessRuntimeIssueReflectionResult = RunObservationResult;
 
 /**
  * Inspect PlatformIssueReport rows that this run produced (or, for legacy
@@ -92,7 +72,7 @@ export async function processRuntimeIssueReflection(
         select: { source: true, title: true, a2aMetadata: true },
       })
       .catch(() => null);
-    if (parent && (isReflectionRun(parent) || getReflectionDepth(parent) >= 1)) {
+    if (isReflectionLoopGuarded(parent)) {
       return { processed: 0, skippedReason: "reflection-loop-guard" };
     }
   }
@@ -157,7 +137,7 @@ export async function processRuntimeIssueReflection(
   let processed = 0;
   for (const row of rows) {
     try {
-      await reflectOnIssue({
+      const result = await reflectOnIssue({
         parentTaskRunId: input.taskRunId,
         userId: input.userId,
         agentId: input.agentId,
@@ -165,7 +145,7 @@ export async function processRuntimeIssueReflection(
         routeContext: input.routeContext,
         issue: row,
       });
-      processed++;
+      processed += result.processed;
     } catch (err) {
       // Reflection must never break the user response path. Log and keep
       // processing the next row.
@@ -191,107 +171,51 @@ async function reflectOnIssue(input: {
     description: string | null;
     taskRunId: string | null;
   };
-}): Promise<void> {
-  const parentDepth = await readParentReflectionDepth(input.parentTaskRunId);
-
-  // Spawn a proactive TaskRun for the reflection so the evidence is
-  // attributable. Stamp reflectionDepth onto a2aMetadata.
-  const reflectionTaskRunId = `TR-RFL-${randomUUID().slice(0, 8).toUpperCase()}`;
-  const reflectionRun = await prisma.taskRun.create({
-    data: {
-      taskRunId: reflectionTaskRunId,
-      userId: input.userId,
-      threadId: input.threadId,
-      contextId: input.threadId,
-      initiatingAgentId: input.agentId,
-      currentAgentId: input.agentId,
-      parentTaskRunId: input.parentTaskRunId,
-      routeContext: input.routeContext,
-      title: REFLECTION_TITLE,
-      objective:
-        `Reflect on PlatformIssueReport ${input.issue.reportId} and file durable evidence ` +
-        `(self-assessment, capability need, improvement signal).`,
-      source: "proactive",
-      status: "working",
-      authorityScope: [],
-      a2aMetadata: {
-        trigger: "runtime-issue-reflection",
-        platformIssueReportId: input.issue.reportId,
-        reflectionDepth: parentDepth + 1,
-      } as Prisma.InputJsonValue,
-    },
-    select: { id: true, taskRunId: true },
-  });
-
-  // Self-assessment + skill need. Reuses submitCoworkerSelfAssessment so the
-  // existing review surfaces show the row without changes.
-  const { submitCoworkerSelfAssessment } = await import(
-    "@/lib/coworker-self-assessment/assessment-service"
-  );
-  await submitCoworkerSelfAssessment({
+}): Promise<RunObservationResult> {
+  return runObservation({
+    parentTaskRunId: input.parentTaskRunId,
+    userId: input.userId,
     agentId: input.agentId,
-    trigger: "runtime-issue-reflection",
+    threadId: input.threadId,
     routeContext: input.routeContext,
-    verdict: "gaps",
-    confidence: "medium",
-    missionSummary: input.issue.title,
+    sourceTitle: input.issue.title,
+    sourceDescription: input.issue.description ?? null,
+    objective:
+      `Reflect on PlatformIssueReport ${input.issue.reportId} and file durable evidence ` +
+      `(self-assessment, capability need, improvement signal).`,
     capabilitySummary:
       "The coworker hit the repeated-tool guard. A skill or workflow change is likely required.",
     rawPayload: {
       platformIssueReportId: input.issue.reportId,
-      reflectionTaskRunId: reflectionRun.taskRunId,
     },
-    needs: [
-      {
-        kind: "skill",
-        severity: "important",
-        need:
-          "Add or update the coworker skill that handles this workflow so it does not retry " +
-          "with identical arguments after a failure.",
-        blocks: input.issue.title,
-        evidenceJson: {
-          platformIssueReportId: input.issue.reportId,
-          threadId: input.threadId,
-          taskRunId: input.parentTaskRunId,
-          routeContext: input.routeContext,
-        },
-      },
-    ],
-  });
-
-  // Emit a deduped ImprovementSignal so the portfolio flywheel can prioritize
-  // across signals. Sourcing on the public reportId is intentional: re-firing
-  // reflection over the same issue increments recurrenceCount.
-  await createOrTouchImprovementSignal({
-    sourceType: "platform_issue_report",
-    sourceId: input.issue.reportId,
-    title: input.issue.title,
-    description: input.issue.description ?? null,
-    evidence: {
+    signalEvidence: {
       threadId: input.threadId,
-      parentTaskRunId: input.parentTaskRunId,
-      reflectionTaskRunId: reflectionRun.taskRunId,
+      taskRunId: input.parentTaskRunId,
     },
-    routeContext: input.routeContext,
-    agentId: input.agentId,
-    threadId: input.threadId,
-    suspectedRootCause: "repeated-tool-call",
+    spec: {
+      title: REFLECTION_TITLE,
+      trigger: "runtime-issue-reflection",
+      verdict: "gaps",
+      confidence: "medium",
+      sourceType: "platform_issue_report",
+      sourceId: input.issue.reportId,
+      suspectedRootCause: "repeated-tool-call",
+      needs: [
+        {
+          kind: "skill",
+          severity: "important",
+          need:
+            "Add or update the coworker skill that handles this workflow so it does not retry " +
+            "with identical arguments after a failure.",
+          blocks: input.issue.title,
+          evidenceJson: {
+            platformIssueReportId: input.issue.reportId,
+            threadId: input.threadId,
+            taskRunId: input.parentTaskRunId,
+            routeContext: input.routeContext,
+          },
+        },
+      ],
+    },
   });
-
-  // Mark the reflection run completed. The user-facing run is unaffected.
-  await prisma.taskRun.update({
-    where: { id: reflectionRun.id },
-    data: { status: "completed", completedAt: new Date() },
-  });
-}
-
-async function readParentReflectionDepth(parentTaskRunId: string | null): Promise<number> {
-  if (!parentTaskRunId) return 0;
-  const parent = await prisma.taskRun
-    .findUnique({
-      where: { taskRunId: parentTaskRunId },
-      select: { source: true, title: true, a2aMetadata: true },
-    })
-    .catch(() => null);
-  return getReflectionDepth(parent);
 }

--- a/apps/web/lib/tak/work-pattern-profile-review.test.ts
+++ b/apps/web/lib/tak/work-pattern-profile-review.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  runDueWorkPatternProfileReviews,
+  runWorkPatternProfileReview,
+  type WorkPatternProfileReviewDb,
+} from "./work-pattern-profile-review";
+import type {
+  PatternObserverEnvelope,
+  PatternObserverToolExecution,
+  PatternObserverTurnMetric,
+} from "./pattern-observer";
+
+function makeDb(overrides?: {
+  toolExecutions?: PatternObserverToolExecution[];
+  turnMetrics?: PatternObserverTurnMetric[];
+  envelopes?: PatternObserverEnvelope[];
+  dueTargets?: Array<{ agentId: string; routeContext?: string | null }>;
+}): WorkPatternProfileReviewDb {
+  return {
+    createTaskRun: vi.fn(async () => ({ taskRunId: "TR-SCHED-REVIEW" })),
+    completeTaskRun: vi.fn(async () => undefined),
+    listToolExecutions: vi.fn(async () => overrides?.toolExecutions ?? []),
+    listTurnMetrics: vi.fn(async () => overrides?.turnMetrics ?? []),
+    listTaskRuns: vi.fn(async () => []),
+    listEnvelopes: vi.fn(async () => overrides?.envelopes ?? []),
+    listPriorNeeds: vi.fn(async () => []),
+    listDueReviewTargets: vi.fn(async () => overrides?.dueTargets ?? []),
+  };
+}
+
+describe("runWorkPatternProfileReview", () => {
+  it("creates an attributable review TaskRun and files observed needs", async () => {
+    const db = makeDb({
+      toolExecutions: [
+        {
+          id: "tool-1",
+          toolName: "export_archimate",
+          success: false,
+          summary: "forbidden_grant: ea_graph_read required",
+          result: { error: "forbidden_grant: ea_graph_read required" },
+          taskRunId: "TR-WORK-1",
+        },
+        {
+          id: "tool-2",
+          toolName: "export_archimate",
+          success: false,
+          summary: "forbidden_grant: ea_graph_read required",
+          result: { error: "forbidden_grant: ea_graph_read required" },
+          taskRunId: "TR-WORK-2",
+        },
+      ],
+    });
+    const submitSelfAssessment = vi.fn(async () => ({
+      assessmentId: "CWSA-1",
+      needIds: ["CWN-1"],
+      backlogItemIds: [],
+    }));
+
+    const result = await runWorkPatternProfileReview(
+      {
+        agentId: "AGT-OPS",
+        routeContext: "/ops",
+        now: new Date("2026-06-27T14:00:00Z"),
+      },
+      {
+        db,
+        resolveOwnerUserId: async () => "user-owner",
+        submitSelfAssessment,
+      },
+    );
+
+    expect(result).toEqual({
+      taskRunId: "TR-SCHED-REVIEW",
+      observedPatterns: 1,
+      needsFiled: 1,
+    });
+    expect(db.createTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-owner",
+        initiatingAgentId: "AGT-OPS",
+        currentAgentId: "AGT-OPS",
+        routeContext: "/ops",
+        source: "proactive",
+        status: "working",
+      }),
+    );
+    expect(submitSelfAssessment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "AGT-OPS",
+        trigger: "work-pattern-profile-review",
+        needs: [expect.objectContaining({ kind: "grant" })],
+      }),
+    );
+    expect(db.completeTaskRun).toHaveBeenCalledWith(
+      "TR-SCHED-REVIEW",
+      expect.objectContaining({
+        status: "completed",
+        progressPayload: expect.objectContaining({
+          type: "work-pattern-profile-review",
+          agentId: "AGT-OPS",
+          routeContext: "/ops",
+          windowDays: 7,
+          observedPatterns: 1,
+          needsFiled: 1,
+        }),
+      }),
+    );
+  });
+
+  it("marks the review completed even when no needs are found", async () => {
+    const db = makeDb();
+    const submitSelfAssessment = vi.fn();
+
+    const result = await runWorkPatternProfileReview(
+      { agentId: "AGT-BUILD", now: new Date("2026-06-27T14:00:00Z") },
+      {
+        db,
+        resolveOwnerUserId: async () => "user-owner",
+        submitSelfAssessment,
+      },
+    );
+
+    expect(result).toEqual({
+      taskRunId: "TR-SCHED-REVIEW",
+      observedPatterns: 0,
+      needsFiled: 0,
+    });
+    expect(submitSelfAssessment).not.toHaveBeenCalled();
+    expect(db.completeTaskRun).toHaveBeenCalledWith(
+      "TR-SCHED-REVIEW",
+      expect.objectContaining({ status: "completed" }),
+    );
+  });
+});
+
+describe("runDueWorkPatternProfileReviews", () => {
+  it("runs due targets through the same review path", async () => {
+    const db = makeDb({
+      dueTargets: [
+        { agentId: "AGT-OPS", routeContext: "/ops" },
+        { agentId: "AGT-BUILD", routeContext: "/build" },
+      ],
+    });
+
+    const result = await runDueWorkPatternProfileReviews({
+      db,
+      resolveOwnerUserId: async () => "user-owner",
+      now: () => new Date("2026-06-27T14:00:00Z"),
+    });
+
+    expect(result.reviewed).toBe(2);
+    expect(db.listDueReviewTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ windowDays: 7, minCompletedRuns: 10 }),
+    );
+    expect(db.createTaskRun).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/tak/work-pattern-profile-review.ts
+++ b/apps/web/lib/tak/work-pattern-profile-review.ts
@@ -1,0 +1,385 @@
+import { randomUUID } from "node:crypto";
+import type { Prisma } from "@dpf/db";
+import type { SubmitCoworkerSelfAssessmentInput } from "@/lib/coworker-self-assessment/types";
+import {
+  classifyPatternSignals,
+  type PatternObserverEnvelope,
+  type PatternObserverTaskRun,
+  type PatternObserverToolExecution,
+  type PatternObserverTurnMetric,
+} from "./pattern-observer";
+
+export const WORK_PATTERN_PROFILE_REVIEW_WINDOW_DAYS = 7;
+export const WORK_PATTERN_PROFILE_REVIEW_MIN_COMPLETED_RUNS = 10;
+
+export type WorkPatternReviewTarget = {
+  agentId: string;
+  routeContext?: string | null;
+};
+
+export type WorkPatternProfileReviewTaskRunData = {
+  taskRunId?: string;
+  userId: string;
+  initiatingAgentId: string;
+  currentAgentId: string;
+  routeContext: string | null;
+  title: string;
+  objective: string;
+  source: "proactive";
+  status: "working";
+  a2aMetadata: Record<string, unknown>;
+};
+
+export type WorkPatternProfileReviewQuery = {
+  agentId: string;
+  routeContext?: string | null;
+  now: Date;
+  windowStart: Date;
+  windowDays: number;
+  minCompletedRuns: number;
+};
+
+export type WorkPatternProfileReviewDb = {
+  createTaskRun(data: WorkPatternProfileReviewTaskRunData): Promise<{ taskRunId: string }>;
+  completeTaskRun(
+    taskRunId: string,
+    data: { status: "completed"; completedAt: Date; progressPayload: Record<string, unknown> },
+  ): Promise<unknown>;
+  listToolExecutions(query: WorkPatternProfileReviewQuery): Promise<PatternObserverToolExecution[]>;
+  listTurnMetrics(query: WorkPatternProfileReviewQuery): Promise<PatternObserverTurnMetric[]>;
+  listTaskRuns(query: WorkPatternProfileReviewQuery): Promise<PatternObserverTaskRun[]>;
+  listEnvelopes(query: WorkPatternProfileReviewQuery): Promise<PatternObserverEnvelope[]>;
+  listPriorNeeds(query: WorkPatternProfileReviewQuery): Promise<Array<{ evidenceJson?: unknown; readinessJson?: unknown }>>;
+  listDueReviewTargets(query: {
+    now: Date;
+    windowStart: Date;
+    windowDays: number;
+    minCompletedRuns: number;
+  }): Promise<WorkPatternReviewTarget[]>;
+};
+
+export type WorkPatternProfileReviewDeps = {
+  db?: WorkPatternProfileReviewDb;
+  resolveOwnerUserId?: () => Promise<string>;
+  submitSelfAssessment?: (input: SubmitCoworkerSelfAssessmentInput) => Promise<unknown>;
+  now?: () => Date;
+};
+
+export type WorkPatternProfileReviewResult = {
+  taskRunId: string;
+  observedPatterns: number;
+  needsFiled: number;
+};
+
+function createPublicTaskRunId(): string {
+  return `TR-SCHED-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+function windowStart(now: Date): Date {
+  return new Date(now.getTime() - WORK_PATTERN_PROFILE_REVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function fingerprintFromNeed(row: { evidenceJson?: unknown; readinessJson?: unknown }): string | null {
+  for (const value of [row.evidenceJson, row.readinessJson]) {
+    if (!isRecord(value)) continue;
+    const fingerprint = value.fingerprint;
+    if (typeof fingerprint === "string" && fingerprint.length > 0) return fingerprint;
+  }
+  return null;
+}
+
+function targetKey(target: WorkPatternReviewTarget): string {
+  return `${target.agentId}|${target.routeContext ?? ""}`;
+}
+
+async function defaultDb(): Promise<WorkPatternProfileReviewDb> {
+  const { prisma } = await import("@dpf/db");
+  return {
+    createTaskRun: async (data) => {
+      const row = await prisma.taskRun.create({
+        data: {
+          taskRunId: data.taskRunId ?? createPublicTaskRunId(),
+          userId: data.userId,
+          initiatingAgentId: data.initiatingAgentId,
+          currentAgentId: data.currentAgentId,
+          routeContext: data.routeContext,
+          title: data.title,
+          objective: data.objective,
+          source: data.source,
+          status: data.status,
+          a2aMetadata: data.a2aMetadata as Prisma.InputJsonValue,
+        },
+        select: { taskRunId: true },
+      });
+      return row;
+    },
+    completeTaskRun: (taskRunId, data) =>
+      prisma.taskRun.update({
+        where: { taskRunId },
+        data: {
+          status: data.status,
+          completedAt: data.completedAt,
+          progressPayload: data.progressPayload as Prisma.InputJsonValue,
+        },
+      }),
+    listToolExecutions: (query) =>
+      prisma.toolExecution.findMany({
+        where: {
+          agentId: query.agentId,
+          ...(query.routeContext ? { routeContext: query.routeContext } : {}),
+          createdAt: { gte: query.windowStart },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 100,
+        select: {
+          id: true,
+          toolName: true,
+          success: true,
+          summary: true,
+          result: true,
+          taskRunId: true,
+          createdAt: true,
+        },
+      }),
+    listTurnMetrics: (query) =>
+      prisma.coworkerTurnMetric.findMany({
+        where: {
+          agentId: query.agentId,
+          ...(query.routeContext ? { routeContext: query.routeContext } : {}),
+          createdAt: { gte: query.windowStart },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 100,
+      }),
+    listTaskRuns: (query) =>
+      prisma.taskRun.findMany({
+        where: {
+          currentAgentId: query.agentId,
+          ...(query.routeContext ? { routeContext: query.routeContext } : {}),
+          createdAt: { gte: query.windowStart },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 100,
+        select: {
+          taskRunId: true,
+          repeatedPatternKey: true,
+          a2aMetadata: true,
+          createdAt: true,
+        },
+      }),
+    listEnvelopes: (query) =>
+      prisma.coworkerActionEnvelope
+        .findMany({
+          where: {
+            coworkerAgentId: query.agentId,
+            createdAt: { gte: query.windowStart },
+          },
+          orderBy: { createdAt: "desc" },
+          take: 100,
+          select: {
+            id: true,
+            manifestActionId: true,
+            status: true,
+            createdAt: true,
+          },
+        })
+        .then((rows) =>
+          rows.map((row) => ({
+            id: row.id,
+            proposedActionKey: row.manifestActionId,
+            status: row.status,
+            approved: row.status === "approved",
+            createdAt: row.createdAt,
+          })),
+        ),
+    listPriorNeeds: (query) =>
+      prisma.coworkerCapabilityNeed.findMany({
+        where: {
+          agentId: query.agentId,
+          createdAt: { gte: query.windowStart },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 100,
+        select: { evidenceJson: true, readinessJson: true },
+      }),
+    listDueReviewTargets: async (query) => {
+      const [completed, recentReviews] = await Promise.all([
+        prisma.taskRun.findMany({
+          where: {
+            status: "completed",
+            currentAgentId: { not: null },
+            createdAt: { gte: query.windowStart },
+          },
+          select: { currentAgentId: true, routeContext: true },
+          take: 500,
+        }),
+        prisma.taskRun.findMany({
+          where: {
+            source: "proactive",
+            title: { startsWith: "Work pattern profile review:" },
+            createdAt: { gte: query.windowStart },
+          },
+          select: { currentAgentId: true, routeContext: true },
+          take: 500,
+        }),
+      ]);
+      const reviewed = new Set(
+        recentReviews
+          .filter((row) => row.currentAgentId)
+          .map((row) => targetKey({ agentId: row.currentAgentId!, routeContext: row.routeContext })),
+      );
+      const counts = new Map<string, { target: WorkPatternReviewTarget; count: number }>();
+      for (const row of completed) {
+        if (!row.currentAgentId) continue;
+        const target = { agentId: row.currentAgentId, routeContext: row.routeContext };
+        const key = targetKey(target);
+        const current = counts.get(key) ?? { target, count: 0 };
+        current.count += 1;
+        counts.set(key, current);
+      }
+      return Array.from(counts.values())
+        .filter((entry) => entry.count >= 1 && !reviewed.has(targetKey(entry.target)))
+        .filter((entry) => entry.count >= query.minCompletedRuns || entry.count > 0)
+        .map((entry) => entry.target)
+        .slice(0, 10);
+    },
+  };
+}
+
+async function defaultOwner(): Promise<string> {
+  const { resolveScheduledOwnerUserId } = await import("@/lib/queue/scheduled-owner");
+  return resolveScheduledOwnerUserId();
+}
+
+async function defaultSubmitSelfAssessment(input: SubmitCoworkerSelfAssessmentInput) {
+  const { submitCoworkerSelfAssessment } = await import(
+    "@/lib/coworker-self-assessment/assessment-service"
+  );
+  return submitCoworkerSelfAssessment(input);
+}
+
+export async function runWorkPatternProfileReview(
+  input: { agentId: string; routeContext?: string | null; now?: Date },
+  deps?: WorkPatternProfileReviewDeps,
+): Promise<WorkPatternProfileReviewResult> {
+  const db = deps?.db ?? (await defaultDb());
+  const now = input.now ?? deps?.now?.() ?? new Date();
+  const since = windowStart(now);
+  const routeContext = input.routeContext ?? null;
+  const ownerId = await (deps?.resolveOwnerUserId ?? defaultOwner)();
+  const review = await db.createTaskRun({
+    userId: ownerId,
+    initiatingAgentId: input.agentId,
+    currentAgentId: input.agentId,
+    routeContext,
+    title: `Work pattern profile review: ${input.agentId}`,
+    objective: `Review recent work-pattern evidence for ${input.agentId}.`,
+    source: "proactive",
+    status: "working",
+    a2aMetadata: {
+      trigger: "scheduled",
+      profileReview: {
+        type: "work-pattern-profile-review",
+        agentId: input.agentId,
+        routeContext,
+        windowDays: WORK_PATTERN_PROFILE_REVIEW_WINDOW_DAYS,
+      },
+    },
+  });
+
+  const query: WorkPatternProfileReviewQuery = {
+    agentId: input.agentId,
+    routeContext,
+    now,
+    windowStart: since,
+    windowDays: WORK_PATTERN_PROFILE_REVIEW_WINDOW_DAYS,
+    minCompletedRuns: WORK_PATTERN_PROFILE_REVIEW_MIN_COMPLETED_RUNS,
+  };
+  const [toolExecutions, turnMetrics, taskRuns, envelopes, priorNeeds] = await Promise.all([
+    db.listToolExecutions(query),
+    db.listTurnMetrics(query),
+    db.listTaskRuns(query),
+    db.listEnvelopes(query),
+    db.listPriorNeeds(query),
+  ]);
+  const priorNeedFingerprints = new Set(
+    priorNeeds.map(fingerprintFromNeed).filter((value): value is string => Boolean(value)),
+  );
+  const classified = classifyPatternSignals({
+    agentId: input.agentId,
+    routeContext,
+    since,
+    toolExecutions,
+    turnMetrics,
+    taskRuns,
+    envelopes,
+    priorNeedFingerprints,
+  });
+
+  if (classified.needs.length > 0) {
+    const submit = deps?.submitSelfAssessment ?? defaultSubmitSelfAssessment;
+    await submit({
+      agentId: input.agentId,
+      trigger: "work-pattern-profile-review",
+      routeContext,
+      verdict: "gaps",
+      confidence: "medium",
+      missionSummary: `Reviewed ${WORK_PATTERN_PROFILE_REVIEW_WINDOW_DAYS} days of work-pattern evidence.`,
+      capabilitySummary: classified.needs.map((need) => need.need).join("; "),
+      rawPayload: {
+        taskRunId: review.taskRunId,
+        patternKeys: classified.patterns.map((pattern) => pattern.metadata.patternKey),
+      },
+      needs: classified.needs.map((need) => ({
+        kind: need.kind,
+        severity: need.severity,
+        need: need.need,
+        blocks: need.blocks,
+        evidenceJson: need.evidenceJson,
+        readinessJson: need.readinessJson,
+      })),
+    });
+  }
+
+  const progressPayload = {
+    type: "work-pattern-profile-review",
+    agentId: input.agentId,
+    routeContext,
+    windowDays: WORK_PATTERN_PROFILE_REVIEW_WINDOW_DAYS,
+    observedPatterns: classified.patterns.length,
+    needsFiled: classified.needs.length,
+  };
+  await db.completeTaskRun(review.taskRunId, {
+    status: "completed",
+    completedAt: now,
+    progressPayload,
+  });
+
+  return {
+    taskRunId: review.taskRunId,
+    observedPatterns: classified.patterns.length,
+    needsFiled: classified.needs.length,
+  };
+}
+
+export async function runDueWorkPatternProfileReviews(
+  deps?: WorkPatternProfileReviewDeps,
+): Promise<{ reviewed: number; results: WorkPatternProfileReviewResult[] }> {
+  const db = deps?.db ?? (await defaultDb());
+  const now = deps?.now?.() ?? new Date();
+  const targets = await db.listDueReviewTargets({
+    now,
+    windowStart: windowStart(now),
+    windowDays: WORK_PATTERN_PROFILE_REVIEW_WINDOW_DAYS,
+    minCompletedRuns: WORK_PATTERN_PROFILE_REVIEW_MIN_COMPLETED_RUNS,
+  });
+  const results: WorkPatternProfileReviewResult[] = [];
+  for (const target of targets) {
+    results.push(await runWorkPatternProfileReview({ ...target, now }, { ...deps, db }));
+  }
+  return { reviewed: results.length, results };
+}

--- a/apps/web/lib/tak/work-pattern-types.test.ts
+++ b/apps/web/lib/tak/work-pattern-types.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeWorkPatternMetadata,
+  normalizePatternText,
+  parseWorkPatternMetadata,
+  patternDecisionScope,
+  workPatternFingerprint,
+} from "./work-pattern-types";
+
+describe("work pattern metadata helpers", () => {
+  it("parses governed metadata from TaskRun JSON envelopes", () => {
+    const metadata = parseWorkPatternMetadata({
+      patternKey: "need:agent-a:route:tool:better-search",
+      status: "candidate",
+      scope: "route",
+      version: 1,
+      source: "observer",
+      evidence: [{ taskRunId: "run-1", toolExecutionId: "tool-1" }],
+      candidate: {
+        kind: "tool",
+        need: "Needs a better search affordance",
+        blocks: "Cannot inspect prior specs reliably",
+        fingerprint: "agent-a|route|tool|needs a better search affordance",
+      },
+    });
+
+    expect(metadata).toMatchObject({
+      patternKey: "need:agent-a:route:tool:better-search",
+      status: "candidate",
+      scope: "route",
+      version: 1,
+      source: "observer",
+      decisionScope: "platform-wwmd",
+      evidence: [{ taskRunId: "run-1", toolExecutionId: "tool-1" }],
+      candidate: {
+        kind: "tool",
+        need: "Needs a better search affordance",
+      },
+    });
+  });
+
+  it("rejects invalid statuses, scopes, sources, and capability kinds", () => {
+    expect(
+      parseWorkPatternMetadata({
+        patternKey: "bad-status",
+        status: "shipping",
+        scope: "route",
+        version: 1,
+        source: "observer",
+      }),
+    ).toBeNull();
+
+    expect(
+      parseWorkPatternMetadata({
+        patternKey: "bad-kind",
+        status: "candidate",
+        scope: "route",
+        version: 1,
+        source: "observer",
+        candidate: {
+          kind: "vibe",
+          need: "Needs vibes",
+          blocks: "Hard to tell",
+          fingerprint: "vibe",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("merges metadata under the workPattern key without erasing sibling payload", () => {
+    const merged = mergeWorkPatternMetadata(
+      { unrelated: { keep: true } },
+      {
+        patternKey: "case:handoff:missing-receipt",
+        status: "observed",
+        scope: "case-transition",
+        version: 1,
+        source: "human-review",
+        decisionScope: "company-wwwd",
+      },
+    );
+
+    expect(merged).toEqual({
+      unrelated: { keep: true },
+      workPattern: {
+        patternKey: "case:handoff:missing-receipt",
+        status: "observed",
+        scope: "case-transition",
+        version: 1,
+        source: "human-review",
+        decisionScope: "company-wwwd",
+      },
+    });
+  });
+
+  it("maps pattern scope to the commons layer that should own review", () => {
+    expect(patternDecisionScope("case-type")).toBe("company-wwwd");
+    expect(patternDecisionScope("case-transition")).toBe("company-wwwd");
+    expect(patternDecisionScope("activity")).toBe("profession-wsid");
+    expect(patternDecisionScope("risk-class")).toBe("profession-wsid");
+    expect(patternDecisionScope("agent")).toBe("platform-wwmd");
+    expect(patternDecisionScope("route")).toBe("platform-wwmd");
+  });
+
+  it("normalizes repeated need text into stable fingerprints", () => {
+    expect(normalizePatternText("  Needs   better SEARCH. ")).toBe("needs better search");
+    expect(
+      workPatternFingerprint({
+        agentId: "Agent A",
+        routeContext: "/Storefront",
+        kind: "tool",
+        normalizedNeed: "Needs Better Search",
+      }),
+    ).toBe("agent a|/storefront|tool|needs better search");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-types.test.ts
+++ b/apps/web/lib/tak/work-pattern-types.test.ts
@@ -105,6 +105,7 @@ describe("work pattern metadata helpers", () => {
 
   it("normalizes repeated need text into stable fingerprints", () => {
     expect(normalizePatternText("  Needs   better SEARCH. ")).toBe("needs better search");
+    expect(normalizePatternText("Needs better SEARCH...")).toBe("needs better search");
     expect(
       workPatternFingerprint({
         agentId: "Agent A",

--- a/apps/web/lib/tak/work-pattern-types.test.ts
+++ b/apps/web/lib/tak/work-pattern-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  evaluatePatternReadiness,
   mergeWorkPatternMetadata,
   normalizePatternText,
   parseWorkPatternMetadata,
@@ -112,5 +113,87 @@ describe("work pattern metadata helpers", () => {
         normalizedNeed: "Needs Better Search",
       }),
     ).toBe("agent a|/storefront|tool|needs better search");
+  });
+
+  it("requires evidence and decision scope before a pattern is ready for review", () => {
+    expect(
+      evaluatePatternReadiness({
+        patternKey: "missing-evidence",
+        status: "observed",
+        scope: "route",
+        version: 1,
+        source: "observer",
+        decisionScope: "platform-wwmd",
+      }),
+    ).toEqual({
+      readyForReview: false,
+      readyForCaseActivation: false,
+      blockers: ["missing-evidence", "pattern-status-not-approved-or-active"],
+    });
+
+    expect(
+      evaluatePatternReadiness({
+        patternKey: "ready-for-review",
+        status: "observed",
+        scope: "route",
+        version: 1,
+        source: "observer",
+        decisionScope: "platform-wwmd",
+        evidence: [{ taskRunId: "run-1" }],
+      }),
+    ).toEqual({
+      readyForReview: true,
+      readyForCaseActivation: false,
+      blockers: ["pattern-status-not-approved-or-active"],
+    });
+  });
+
+  it("blocks case activation until governed action, receipt policy, source evidence, and approved status exist", () => {
+    expect(
+      evaluatePatternReadiness({
+        patternKey: "case-transition",
+        status: "observed",
+        scope: "case-transition",
+        version: 1,
+        source: "observer",
+        decisionScope: "company-wwwd",
+        workCaseBinding: {
+          caseType: "change",
+          transitionKey: "approve",
+        },
+      }),
+    ).toEqual({
+      readyForReview: false,
+      readyForCaseActivation: false,
+      blockers: [
+        "missing-evidence",
+        "missing-governed-action-key",
+        "missing-receipt-policy",
+        "missing-case-source-reference",
+        "pattern-status-not-approved-or-active",
+      ],
+    });
+
+    expect(
+      evaluatePatternReadiness({
+        patternKey: "case-transition",
+        status: "approved",
+        scope: "case-transition",
+        version: 1,
+        source: "human-review",
+        decisionScope: "company-wwwd",
+        evidence: [{ workCaseRef: "case-1", receiptId: "receipt-1" }],
+        workCaseBinding: {
+          caseType: "change",
+          transitionKey: "approve",
+          governedActionKey: "work-case.approve",
+          receiptPolicy: "governed-action",
+        },
+      }),
+    ).toEqual({
+      readyForReview: true,
+      readyForCaseActivation: true,
+      blockers: [],
+    });
   });
 });

--- a/apps/web/lib/tak/work-pattern-types.ts
+++ b/apps/web/lib/tak/work-pattern-types.ts
@@ -1,0 +1,272 @@
+import {
+  COWORKER_CAPABILITY_NEED_KINDS,
+  type CoworkerCapabilityNeedKind,
+} from "@/lib/coworker-self-assessment/types";
+
+export const WORK_PATTERN_STATUSES = [
+  "observed",
+  "candidate",
+  "approved",
+  "active",
+  "retired",
+] as const;
+export type WorkPatternStatus = (typeof WORK_PATTERN_STATUSES)[number];
+
+export const WORK_PATTERN_SCOPES = [
+  "agent",
+  "route",
+  "skill",
+  "build-phase",
+  "activity",
+  "risk-class",
+  "case-type",
+  "case-transition",
+] as const;
+export type WorkPatternScope = (typeof WORK_PATTERN_SCOPES)[number];
+
+export const WORK_PATTERN_SOURCES = [
+  "observer",
+  "periodic-review",
+  "human-review",
+  "shadow-trial",
+] as const;
+export type WorkPatternSource = (typeof WORK_PATTERN_SOURCES)[number];
+
+export const WORK_PATTERN_DECISION_SCOPES = [
+  "platform-wwmd",
+  "company-wwwd",
+  "profession-wsid",
+] as const;
+export type WorkPatternDecisionScope = (typeof WORK_PATTERN_DECISION_SCOPES)[number];
+
+export type WorkPatternEvidenceRef = {
+  taskRunId?: string;
+  toolExecutionId?: string;
+  improvementSignalId?: string;
+  capabilityNeedId?: string;
+  backlogItemId?: string;
+  workCaseRef?: string;
+  receiptId?: string;
+  decisionInteractionId?: string;
+};
+
+export type WorkCasePatternBinding = {
+  caseType?: string;
+  transitionKey?: string;
+  governedActionKey?: string;
+  authorityMode?: "autonomous" | "on-behalf-of" | "authenticated-inbound";
+  sponsorPrincipalId?: string;
+  receiptPolicy?: "governed-action" | "observed-event";
+};
+
+export type WorkPatternCandidate = {
+  kind: CoworkerCapabilityNeedKind;
+  need: string;
+  blocks: string;
+  fingerprint: string;
+  evaluationMethod?: string;
+};
+
+export type WorkPatternMetadata = {
+  patternKey: string;
+  status: WorkPatternStatus;
+  scope: WorkPatternScope;
+  version: number;
+  source: WorkPatternSource;
+  decisionScope: WorkPatternDecisionScope;
+  evidence?: WorkPatternEvidenceRef[];
+  candidate?: WorkPatternCandidate;
+  workCaseBinding?: WorkCasePatternBinding;
+  observedAt?: string;
+};
+
+const AUTHORITY_MODES = [
+  "autonomous",
+  "on-behalf-of",
+  "authenticated-inbound",
+] as const;
+const RECEIPT_POLICIES = ["governed-action", "observed-event"] as const;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isOneOf<const T extends readonly string[]>(
+  value: unknown,
+  options: T,
+): value is T[number] {
+  return typeof value === "string" && (options as readonly string[]).includes(value);
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  return isNonEmptyString(value) ? value : undefined;
+}
+
+function parseEvidenceRef(value: unknown): WorkPatternEvidenceRef | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const evidence: WorkPatternEvidenceRef = {
+    taskRunId: parseOptionalString(value.taskRunId),
+    toolExecutionId: parseOptionalString(value.toolExecutionId),
+    improvementSignalId: parseOptionalString(value.improvementSignalId),
+    capabilityNeedId: parseOptionalString(value.capabilityNeedId),
+    backlogItemId: parseOptionalString(value.backlogItemId),
+    workCaseRef: parseOptionalString(value.workCaseRef),
+    receiptId: parseOptionalString(value.receiptId),
+    decisionInteractionId: parseOptionalString(value.decisionInteractionId),
+  };
+  return Object.values(evidence).some(Boolean) ? evidence : null;
+}
+
+function parseCandidate(value: unknown): WorkPatternCandidate | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (!isOneOf(value.kind, COWORKER_CAPABILITY_NEED_KINDS)) {
+    return null;
+  }
+  if (
+    !isNonEmptyString(value.need) ||
+    !isNonEmptyString(value.blocks) ||
+    !isNonEmptyString(value.fingerprint)
+  ) {
+    return null;
+  }
+  return {
+    kind: value.kind,
+    need: value.need,
+    blocks: value.blocks,
+    fingerprint: value.fingerprint,
+    evaluationMethod: parseOptionalString(value.evaluationMethod),
+  };
+}
+
+function parseWorkCaseBinding(value: unknown): WorkCasePatternBinding | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    value.authorityMode !== undefined &&
+    !isOneOf(value.authorityMode, AUTHORITY_MODES)
+  ) {
+    return null;
+  }
+  if (
+    value.receiptPolicy !== undefined &&
+    !isOneOf(value.receiptPolicy, RECEIPT_POLICIES)
+  ) {
+    return null;
+  }
+
+  return {
+    caseType: parseOptionalString(value.caseType),
+    transitionKey: parseOptionalString(value.transitionKey),
+    governedActionKey: parseOptionalString(value.governedActionKey),
+    authorityMode: isOneOf(value.authorityMode, AUTHORITY_MODES)
+      ? value.authorityMode
+      : undefined,
+    sponsorPrincipalId: parseOptionalString(value.sponsorPrincipalId),
+    receiptPolicy: isOneOf(value.receiptPolicy, RECEIPT_POLICIES)
+      ? value.receiptPolicy
+      : undefined,
+  };
+}
+
+export function patternDecisionScope(scope: WorkPatternScope): WorkPatternDecisionScope {
+  if (scope === "case-type" || scope === "case-transition") {
+    return "company-wwwd";
+  }
+  if (scope === "activity" || scope === "risk-class") {
+    return "profession-wsid";
+  }
+  return "platform-wwmd";
+}
+
+export function parseWorkPatternMetadata(value: unknown): WorkPatternMetadata | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    !isNonEmptyString(value.patternKey) ||
+    !isOneOf(value.status, WORK_PATTERN_STATUSES) ||
+    !isOneOf(value.scope, WORK_PATTERN_SCOPES) ||
+    !isOneOf(value.source, WORK_PATTERN_SOURCES) ||
+    typeof value.version !== "number" ||
+    !Number.isFinite(value.version) ||
+    value.version <= 0
+  ) {
+    return null;
+  }
+
+  const decisionScope =
+    value.decisionScope === undefined
+      ? patternDecisionScope(value.scope)
+      : isOneOf(value.decisionScope, WORK_PATTERN_DECISION_SCOPES)
+        ? value.decisionScope
+        : null;
+  if (!decisionScope) {
+    return null;
+  }
+
+  const evidence = Array.isArray(value.evidence)
+    ? value.evidence.map(parseEvidenceRef).filter((ref): ref is WorkPatternEvidenceRef => Boolean(ref))
+    : undefined;
+  const candidate =
+    value.candidate === undefined ? undefined : parseCandidate(value.candidate);
+  const workCaseBinding =
+    value.workCaseBinding === undefined
+      ? undefined
+      : parseWorkCaseBinding(value.workCaseBinding);
+  if (candidate === null || workCaseBinding === null) {
+    return null;
+  }
+
+  return {
+    patternKey: value.patternKey,
+    status: value.status,
+    scope: value.scope,
+    version: value.version,
+    source: value.source,
+    decisionScope,
+    evidence,
+    candidate,
+    workCaseBinding,
+    observedAt: parseOptionalString(value.observedAt),
+  };
+}
+
+export function mergeWorkPatternMetadata(
+  existing: unknown,
+  metadata: WorkPatternMetadata,
+): Record<string, unknown> {
+  const base = isRecord(existing) ? existing : {};
+  return {
+    ...base,
+    workPattern: metadata,
+  };
+}
+
+export function normalizePatternText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ").replace(/[.]+$/g, "");
+}
+
+export function workPatternFingerprint(input: {
+  agentId: string;
+  routeContext?: string | null;
+  kind: string;
+  normalizedNeed: string;
+}): string {
+  return [
+    normalizePatternText(input.agentId),
+    normalizePatternText(input.routeContext ?? "global"),
+    normalizePatternText(input.kind),
+    normalizePatternText(input.normalizedNeed),
+  ].join("|");
+}

--- a/apps/web/lib/tak/work-pattern-types.ts
+++ b/apps/web/lib/tak/work-pattern-types.ts
@@ -325,7 +325,10 @@ export function mergeWorkPatternMetadata(
 }
 
 export function normalizePatternText(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, " ").replace(/[.]+$/g, "");
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, " ");
+  let end = normalized.length;
+  while (end > 0 && normalized.charCodeAt(end - 1) === 46) end -= 1;
+  return end === normalized.length ? normalized : normalized.slice(0, end);
 }
 
 export function workPatternFingerprint(input: {

--- a/apps/web/lib/tak/work-pattern-types.ts
+++ b/apps/web/lib/tak/work-pattern-types.ts
@@ -42,6 +42,8 @@ export type WorkPatternDecisionScope = (typeof WORK_PATTERN_DECISION_SCOPES)[num
 export type WorkPatternEvidenceRef = {
   taskRunId?: string;
   toolExecutionId?: string;
+  threadId?: string;
+  agentMessageId?: string;
   improvementSignalId?: string;
   capabilityNeedId?: string;
   backlogItemId?: string;
@@ -80,6 +82,12 @@ export type WorkPatternMetadata = {
   observedAt?: string;
 };
 
+export type WorkPatternReadiness = {
+  readyForReview: boolean;
+  readyForCaseActivation: boolean;
+  blockers: string[];
+};
+
 const AUTHORITY_MODES = [
   "autonomous",
   "on-behalf-of",
@@ -115,6 +123,8 @@ function parseEvidenceRef(value: unknown): WorkPatternEvidenceRef | null {
   const evidence: WorkPatternEvidenceRef = {
     taskRunId: parseOptionalString(value.taskRunId),
     toolExecutionId: parseOptionalString(value.toolExecutionId),
+    threadId: parseOptionalString(value.threadId),
+    agentMessageId: parseOptionalString(value.agentMessageId),
     improvementSignalId: parseOptionalString(value.improvementSignalId),
     capabilityNeedId: parseOptionalString(value.capabilityNeedId),
     backlogItemId: parseOptionalString(value.backlogItemId),
@@ -187,6 +197,67 @@ export function patternDecisionScope(scope: WorkPatternScope): WorkPatternDecisi
     return "profession-wsid";
   }
   return "platform-wwmd";
+}
+
+function hasEvidenceRef(metadata: WorkPatternMetadata): boolean {
+  return Boolean(metadata.evidence?.length);
+}
+
+function hasCaseSourceReference(metadata: WorkPatternMetadata): boolean {
+  return Boolean(
+    metadata.evidence?.some((ref) =>
+      Boolean(ref.workCaseRef || ref.receiptId || ref.decisionInteractionId),
+    ),
+  );
+}
+
+function isCaseBoundPattern(metadata: WorkPatternMetadata): boolean {
+  return (
+    metadata.scope === "case-type" ||
+    metadata.scope === "case-transition" ||
+    metadata.workCaseBinding !== undefined
+  );
+}
+
+export function evaluatePatternReadiness(metadata: WorkPatternMetadata): WorkPatternReadiness {
+  const blockers: string[] = [];
+  const hasDecisionScope = isOneOf(metadata.decisionScope, WORK_PATTERN_DECISION_SCOPES);
+  const hasEvidence = hasEvidenceRef(metadata);
+  const caseBound = isCaseBoundPattern(metadata);
+  const approvedForActivation = metadata.status === "approved" || metadata.status === "active";
+
+  if (!hasEvidence) {
+    blockers.push("missing-evidence");
+  }
+  if (!hasDecisionScope) {
+    blockers.push("missing-decision-scope");
+  }
+  if (caseBound && !metadata.workCaseBinding?.governedActionKey) {
+    blockers.push("missing-governed-action-key");
+  }
+  if (caseBound && !metadata.workCaseBinding?.receiptPolicy) {
+    blockers.push("missing-receipt-policy");
+  }
+  if (caseBound && !hasCaseSourceReference(metadata)) {
+    blockers.push("missing-case-source-reference");
+  }
+  if (!approvedForActivation) {
+    blockers.push("pattern-status-not-approved-or-active");
+  }
+
+  const readyForReview = hasEvidence && hasDecisionScope;
+  const caseActivationBlockers = new Set([
+    "missing-evidence",
+    "missing-decision-scope",
+    "missing-governed-action-key",
+    "missing-receipt-policy",
+    "missing-case-source-reference",
+    "pattern-status-not-approved-or-active",
+  ]);
+  const readyForCaseActivation =
+    caseBound && blockers.every((blocker) => !caseActivationBlockers.has(blocker));
+
+  return { readyForReview, readyForCaseActivation, blockers };
 }
 
 export function parseWorkPatternMetadata(value: unknown): WorkPatternMetadata | null {

--- a/docs/superpowers/plans/2026-06-27-governed-adaptive-playbooks-foundation.md
+++ b/docs/superpowers/plans/2026-06-27-governed-adaptive-playbooks-foundation.md
@@ -1,0 +1,1027 @@
+# Governed Adaptive Playbooks Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first testable foundation for Governed Adaptive Playbooks: durable work-pattern metadata, richer context/tool-surface telemetry, systemic capability-need observation, attributable periodic agent reviews, and EA/SysML grounding.
+
+**Architecture:** Start with existing DPF substrates instead of a new WorkPattern table: `TaskRun.a2aMetadata`, `TaskRun.repeatedPatternKey`, `CoworkerTurnMetric`, `ToolExecution`, `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, `ImprovementSignal`, and the EA/SysML parity engine. Pattern candidates are evidence-backed proposals only; they do not activate skills, prompts, grants, model routes, Work Case state, or code. Case-bound proposals carry Work Case references when available, but consequential case transitions remain blocked behind the Work Case governed Action and receipt-coverage work.
+
+**Tech Stack:** Next.js 16 monorepo, TypeScript, Prisma 7, Vitest, Inngest, DPF TAK runtime, coworker self-assessment substrate, EA/SysML projection helpers.
+
+---
+
+## Scope
+
+This plan implements the first foundation wave from `docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md`.
+
+It covers:
+
+- Typed Work Pattern metadata in `TaskRun.a2aMetadata.workPattern`.
+- Pattern query key stamping through existing `TaskRun.repeatedPatternKey`.
+- Durable context/tool-surface telemetry on existing `CoworkerTurnMetric`.
+- Pure pattern classification for systemic needs.
+- A side-effect service that emits `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, and `ImprovementSignal`.
+- A periodic profile-review runner owned by the install superuser and executed by the reviewing agent.
+- EA/SysML projection support for `ACT-GAP-*`, `SM-GAP-PROMOTION`, and `VC-GAP-*` using the existing parity engine.
+
+It does not cover:
+
+- A new `WorkPattern` Prisma model.
+- A new capability-need kind.
+- A new decision ledger, receipt ledger, architecture model, or work surface.
+- Operator UI.
+- Automatic activation of a candidate playbook.
+- Work Case consequential transitions.
+- Trust graduation, shadow-ledger comparison, or Ornith model routing.
+
+Live backlog grounding checked 2026-06-27:
+
+- `EP-2984B02B` / `BI-40EE7AFD`: Work Case Wave 0 is in progress and is the dependency for case-bound source/status references.
+- `EP-8AF1C996` / `BI-DE4BF92F` and `BI-40CD8ACD`: trust/shadow/autonomy-ceiling work is in progress and must gate later promotion behavior.
+- `EP-COWORKER-INTERACTIVITY` has active tool-surface, grant, envelope, and context-overflow items that this observer should learn from rather than bypass.
+- `EP-MODEL-TIER-ROUTING` remains the lane for Ornith/model adoption; this plan only records model-mismatch evidence.
+
+## Refactoring Budget
+
+Reserve roughly 20 percent of implementation effort for refactoring that reduces future complexity:
+
+- Extract typed metadata helpers instead of reaching into `a2aMetadata` ad hoc.
+- Extend the existing turn-metric writer instead of scraping `[turn]` logs.
+- Split pure classification from DB side effects.
+- Add one EA/SysML extractor/reconciler in the existing parity-engine style.
+- Keep observer wiring as a post-run hook; do not fork a second reflection subsystem.
+
+Do not spend this budget on navigation, AI Workforce UI, Operations Map layout, Work Case UI, or broad schema cleanup.
+
+## File Map
+
+Create:
+
+- `apps/web/lib/tak/work-pattern-types.ts` - pure types, metadata parsing, merge helpers, pattern key/fingerprint helpers, decision-scope mapping.
+- `apps/web/lib/tak/work-pattern-types.test.ts` - metadata and fingerprint unit tests.
+- `apps/web/lib/tak/pattern-observer.ts` - pure signal classifier that converts evidence windows into capability needs and candidate metadata.
+- `apps/web/lib/tak/pattern-observer.test.ts` - classifier tests for grant denial, tool-surface pressure, repeated tool failure, repeated approval, and dedupe.
+- `apps/web/lib/tak/pattern-observer-service.ts` - DB-backed observer that loads evidence, stamps `TaskRun`, and emits self-assessment + improvement signal.
+- `apps/web/lib/tak/pattern-observer-service.test.ts` - injected-DB tests for side effects and loop guard behavior.
+- `apps/web/lib/tak/work-pattern-profile-review.ts` - deterministic periodic agent review runner.
+- `apps/web/lib/tak/work-pattern-profile-review.test.ts` - superuser ownership and output tests.
+- `apps/web/lib/queue/functions/work-pattern-profile-review.ts` - Inngest cron entry.
+- `apps/web/lib/ea/work-pattern-architecture-extract.ts` - pure SysML desired model builder for playbook foundation concepts and observed pattern elements.
+- `apps/web/lib/ea/work-pattern-architecture-extract.test.ts` - EA element/relationship tests.
+- `apps/web/lib/ea/reconcile-work-pattern-architecture.ts` - idempotent parity-engine reconcile shell.
+- `apps/web/lib/ea/reconcile-work-pattern-architecture.test.ts` - apply/reconcile tests with injected DB.
+
+Modify:
+
+- `packages/db/prisma/schema.prisma` - add numeric/boolean context-economy fields to `CoworkerTurnMetric`; do not add string enum columns.
+- `packages/db/prisma/migrations/<timestamp>_add_coworker_turn_context_economy/migration.sql` - generated migration for the telemetry fields.
+- `apps/web/lib/operate/coworker-turn-metrics.ts` - accept/write the new telemetry fields.
+- `apps/web/lib/operate/coworker-turn-metrics.test.ts` - writer coverage for new fields.
+- `apps/web/lib/tak/agentic-loop.ts` - pass context/tool-surface metrics into `recordCoworkerTurnMetric`.
+- `apps/web/lib/tak/autonomous-work-run.ts` - fire-and-forget pattern observer after the agentic loop.
+- `apps/web/lib/tak/autonomous-work-run.test.ts` - verify the observer is called and fail-open.
+- `apps/web/lib/queue/functions/index.ts` - register the periodic review cron.
+- `apps/web/lib/ea/reconcile-sysml-projections.ts` - add the Work Pattern projection domain.
+- `apps/web/lib/ea/architecture-parity-steward.ts` - add a domain label for Work Pattern projection health.
+- `apps/web/lib/ea/reconcile-sysml-projections.test.ts` - verify domain isolation still applies.
+- `docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md` - link this plan if any implementation detail changes the design summary.
+
+## Chunk 1: Metadata Helpers
+
+### Task 1: Add typed Work Pattern metadata helpers
+
+**Files:**
+
+- Create: `apps/web/lib/tak/work-pattern-types.ts`
+- Create: `apps/web/lib/tak/work-pattern-types.test.ts`
+
+- [ ] **Step 1: Write metadata parsing tests**
+
+Add tests for all of these cases:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  mergeWorkPatternMetadata,
+  parseWorkPatternMetadata,
+  patternDecisionScope,
+  workPatternFingerprint,
+} from "./work-pattern-types";
+
+describe("work-pattern metadata", () => {
+  it("parses valid metadata and rejects malformed status", () => {
+    expect(parseWorkPatternMetadata({
+      patternKey: "gap:build:review-repeat",
+      status: "observed",
+      scope: "build-phase",
+      version: 1,
+      source: "observer",
+    })?.patternKey).toBe("gap:build:review-repeat");
+
+    expect(parseWorkPatternMetadata({
+      patternKey: "gap:bad",
+      status: "auto-activated",
+      scope: "agent",
+      version: 1,
+      source: "observer",
+    })).toBeNull();
+  });
+
+  it("merges metadata without dropping unrelated TaskRun metadata", () => {
+    const next = mergeWorkPatternMetadata(
+      { reflectionDepth: 1, sourceRef: { kind: "x", id: "y" } },
+      { patternKey: "gap:agent:grant-denial", status: "observed", scope: "agent", version: 1, source: "observer" },
+    );
+    expect(next.reflectionDepth).toBe(1);
+    expect(next.workPattern).toMatchObject({ patternKey: "gap:agent:grant-denial" });
+  });
+
+  it("maps decision scope by playbook scope", () => {
+    expect(patternDecisionScope("build-phase")).toBe("platform-wwmd");
+    expect(patternDecisionScope("case-type")).toBe("company-wwwd");
+    expect(patternDecisionScope("activity")).toBe("profession-wsid");
+  });
+
+  it("produces stable fingerprints from normalized evidence", () => {
+    expect(workPatternFingerprint({
+      agentId: "AGT-BUILD",
+      routeContext: "/build",
+      kind: "grant",
+      normalizedNeed: "missing deploy grant",
+    })).toBe(workPatternFingerprint({
+      agentId: "AGT-BUILD",
+      routeContext: "/build",
+      kind: "grant",
+      normalizedNeed: "  Missing   deploy grant. ",
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing metadata tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-types.test.ts
+```
+
+Expected: fails because `work-pattern-types.ts` does not exist.
+
+- [ ] **Step 3: Implement the pure metadata module**
+
+Include these exported shapes and helpers:
+
+```ts
+import type { CoworkerCapabilityNeedKind } from "@/lib/coworker-self-assessment/types";
+
+export const WORK_PATTERN_STATUSES = ["observed", "candidate", "approved", "active", "retired"] as const;
+export type WorkPatternStatus = (typeof WORK_PATTERN_STATUSES)[number];
+
+export const WORK_PATTERN_SCOPES = [
+  "agent",
+  "route",
+  "skill",
+  "build-phase",
+  "activity",
+  "risk-class",
+  "case-type",
+  "case-transition",
+] as const;
+export type WorkPatternScope = (typeof WORK_PATTERN_SCOPES)[number];
+
+export type WorkPatternDecisionScope = "platform-wwmd" | "company-wwwd" | "profession-wsid";
+export type WorkPatternSource = "observer" | "periodic-review" | "human-review" | "shadow-trial";
+
+export type WorkPatternEvidenceRef = {
+  taskRunId?: string;
+  toolExecutionId?: string;
+  improvementSignalId?: string;
+  capabilityNeedId?: string;
+  backlogItemId?: string;
+  workCaseRef?: string;
+  receiptId?: string;
+  decisionInteractionId?: string;
+};
+
+export type WorkCasePatternBinding = {
+  caseType?: string;
+  transitionKey?: string;
+  governedActionKey?: string;
+  authorityMode?: "autonomous" | "on-behalf-of" | "authenticated-inbound";
+  sponsorPrincipalId?: string;
+  receiptPolicy?: "governed-action" | "observed-event";
+};
+
+export type WorkPatternMetadata = {
+  patternKey: string;
+  status: WorkPatternStatus;
+  scope: WorkPatternScope;
+  version: number;
+  source: WorkPatternSource;
+  decisionScope?: WorkPatternDecisionScope;
+  evidence?: WorkPatternEvidenceRef[];
+  candidate?: {
+    kind: CoworkerCapabilityNeedKind;
+    need: string;
+    blocks: string;
+    evaluationMethod: string;
+    fingerprint: string;
+  };
+  workCaseBinding?: WorkCasePatternBinding;
+  observedAt?: string;
+};
+```
+
+Implementation notes:
+
+- Use local type guards, not a new runtime validation dependency.
+- `parseWorkPatternMetadata(value)` returns `WorkPatternMetadata | null`.
+- `mergeWorkPatternMetadata(existing, metadata)` returns a plain JSON-safe object with existing keys preserved and `workPattern` replaced.
+- `patternDecisionScope(scope)` returns `company-wwwd` for `case-type` and `case-transition`, `platform-wwmd` for `build-phase`, `skill`, `route`, and `agent`, and `profession-wsid` for `activity` and `risk-class`.
+- `normalizePatternText(value)` trims, lowercases, collapses whitespace, strips a trailing period, and is used by `workPatternFingerprint`.
+- Do not import Prisma.
+
+- [ ] **Step 4: Re-run the metadata tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-types.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit metadata helpers**
+
+Run:
+
+```powershell
+git add apps/web/lib/tak/work-pattern-types.ts apps/web/lib/tak/work-pattern-types.test.ts
+git commit -s -m "feat: add work pattern metadata helpers"
+```
+
+## Chunk 2: Context And Tool-Surface Telemetry
+
+### Task 2: Extend CoworkerTurnMetric without string enum columns
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_coworker_turn_context_economy/migration.sql`
+- Modify: `apps/web/lib/operate/coworker-turn-metrics.ts`
+- Modify: `apps/web/lib/operate/coworker-turn-metrics.test.ts`
+- Modify: `apps/web/lib/tak/agentic-loop.ts`
+
+- [ ] **Step 1: Write writer tests for new telemetry fields**
+
+Extend `apps/web/lib/operate/coworker-turn-metrics.test.ts`:
+
+```ts
+it("persists numeric context and tool-surface telemetry", async () => {
+  const { upsert, getDelegate } = makeDelegate();
+
+  await recordCoworkerTurnMetric(
+    {
+      threadId: "thr-ctx",
+      agentMessageId: "msg-ctx",
+      ctxPeakTokens: 82000,
+      ctxWindowTokens: 128000,
+      toolSurfaceCount: 18,
+      toolDefinitionTokens: 9500,
+      toolSurfaceExceedsLocalCliff: true,
+      toolSurfaceWindowShare: 0.074,
+      toolSelectionAccuracy: 0.5,
+    },
+    { getDelegate },
+  );
+
+  expect(upsert.mock.calls[0][0].create).toMatchObject({
+    ctxPeakTokens: 82000,
+    ctxWindowTokens: 128000,
+    toolSurfaceCount: 18,
+    toolDefinitionTokens: 9500,
+    toolSurfaceExceedsLocalCliff: true,
+    toolSurfaceWindowShare: 0.074,
+    toolSelectionAccuracy: 0.5,
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing writer test**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/operate/coworker-turn-metrics.test.ts
+```
+
+Expected: fails because the input type and writer do not include these fields.
+
+- [ ] **Step 3: Add Prisma fields**
+
+Add only numeric/boolean fields to avoid a new DB string enum surface:
+
+```prisma
+model CoworkerTurnMetric {
+  // existing fields...
+  ctxPeakTokens                Int?
+  ctxWindowTokens              Int?
+  toolSurfaceCount             Int?
+  toolDefinitionTokens         Int?
+  toolSurfaceExceedsLocalCliff Boolean @default(false)
+  toolSurfaceWindowShare       Float?
+  toolSelectionAccuracy        Float?
+  createdAt                    DateTime @default(now())
+
+  @@unique([threadId, agentMessageId])
+  @@index([createdAt])
+  @@index([agentId, routeContext, createdAt])
+  @@index([threadId, createdAt])
+}
+```
+
+- [ ] **Step 4: Generate the migration**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma migrate dev --name add_coworker_turn_context_economy
+```
+
+Expected: a migration directory is created under `packages/db/prisma/migrations/` and Prisma completes without drift errors.
+
+- [ ] **Step 5: Update the turn-metric writer**
+
+Add optional fields to `RecordCoworkerTurnMetricInput`, normalize numbers with `intOrNull` or a new `floatOrNull`, and include the fields in the `data` object. Keep the writer fail-open.
+
+- [ ] **Step 6: Pass context-economy metrics from `agentic-loop.ts`**
+
+At the existing `logTurnSummary()` point, compute once and pass to the writer:
+
+```ts
+const ctxPressure = classifyContextPressure(ctxPeakTokens, resolvedMaxContextTokens);
+const surface = assessToolSurface({ tools: toolsForProvider, windowTokens: resolvedMaxContextTokens });
+const turnToolAccuracy = computeToolSelectionAccuracy(
+  executedTools.map((t) => ({ toolName: t.name, success: t.result.success })),
+);
+
+void recordCoworkerTurnMetric({
+  threadId,
+  agentMessageId: agentMessageId ?? null,
+  agentId,
+  routeContext,
+  taskType: taskType ?? null,
+  providerId: provider,
+  modelId: model,
+  dispatches: inferenceCallCount,
+  nudges: continuationNudges,
+  toolsAttached: toolsAttachedForTurn,
+  executedTools: executedTools.length,
+  totalMs: Date.now() - startTime,
+  ctxPeakTokens: ctxPressure.estimatedTokens,
+  ctxWindowTokens: resolvedMaxContextTokens,
+  toolSurfaceCount: surface.toolCount,
+  toolDefinitionTokens: surface.estDefinitionTokens,
+  toolSurfaceExceedsLocalCliff: surface.exceedsLocalCliff,
+  toolSurfaceWindowShare: surface.windowShare,
+  toolSelectionAccuracy: turnToolAccuracy.total === 0 ? null : turnToolAccuracy.accuracy,
+});
+```
+
+Keep the existing console line, but do not make the observer parse it.
+
+- [ ] **Step 7: Re-run telemetry tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/operate/coworker-turn-metrics.test.ts apps/web/lib/tak/context-economy-metrics.test.ts apps/web/lib/tak/context-pressure.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit telemetry foundation**
+
+Run:
+
+```powershell
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations apps/web/lib/operate/coworker-turn-metrics.ts apps/web/lib/operate/coworker-turn-metrics.test.ts apps/web/lib/tak/agentic-loop.ts
+git commit -s -m "feat: persist coworker context economy telemetry"
+```
+
+## Chunk 3: Pattern Observer
+
+### Task 3: Add pure pattern classification
+
+**Files:**
+
+- Create: `apps/web/lib/tak/pattern-observer.ts`
+- Create: `apps/web/lib/tak/pattern-observer.test.ts`
+
+- [ ] **Step 1: Write classifier tests**
+
+Cover at least these cases:
+
+```ts
+describe("classifyPatternSignals", () => {
+  it("classifies repeated grant denial as a grant need", () => {
+    const out = classifyPatternSignals({
+      agentId: "AGT-OPS",
+      routeContext: "/ops",
+      since: new Date("2026-06-27T00:00:00Z"),
+      toolExecutions: [
+        failedTool({ toolName: "export_archimate", summary: "forbidden_grant: ea_graph_read required" }),
+        failedTool({ toolName: "export_archimate", summary: "forbidden_grant: ea_graph_read required" }),
+      ],
+      turnMetrics: [],
+      taskRuns: [],
+      envelopes: [],
+      priorNeedFingerprints: new Set(),
+    });
+
+    expect(out.needs[0]).toMatchObject({ kind: "grant", severity: "important" });
+    expect(out.needs[0].evidenceJson.toolName).toBe("export_archimate");
+  });
+
+  it("classifies tool-surface overload as a tool or prompt need", () => {
+    const out = classifyPatternSignals({
+      agentId: "AGT-BUILD",
+      routeContext: "/build",
+      since: new Date("2026-06-27T00:00:00Z"),
+      toolExecutions: [],
+      taskRuns: [],
+      envelopes: [],
+      turnMetrics: [
+        metric({ toolSurfaceCount: 18, toolSurfaceExceedsLocalCliff: true, toolDefinitionTokens: 12000 }),
+        metric({ toolSurfaceCount: 17, toolSurfaceExceedsLocalCliff: true, toolDefinitionTokens: 11800 }),
+      ],
+      priorNeedFingerprints: new Set(),
+    });
+
+    expect(out.needs[0]?.kind).toBe("tool");
+    expect(out.patterns[0]?.metadata.patternKey).toContain("tool-surface");
+  });
+
+  it("does not emit duplicate needs already seen in the window", () => {
+    const prior = new Set(["AGT-OPS|/ops|grant|missing export_archimate authority"]);
+    const out = classifyPatternSignals({ ...grantDeniedFixture(), priorNeedFingerprints: prior });
+    expect(out.needs).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing classifier tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/pattern-observer.test.ts
+```
+
+Expected: fails because the module does not exist.
+
+- [ ] **Step 3: Implement classifier input/output types**
+
+Use narrow row types so tests do not need Prisma:
+
+```ts
+export type PatternObserverToolExecution = {
+  id?: string;
+  toolName: string;
+  success: boolean;
+  summary?: string | null;
+  result?: unknown;
+  taskRunId?: string | null;
+  createdAt?: Date;
+};
+
+export type PatternObserverTurnMetric = {
+  threadId?: string | null;
+  agentMessageId?: string | null;
+  ctxPeakTokens?: number | null;
+  ctxWindowTokens?: number | null;
+  toolSurfaceCount?: number | null;
+  toolDefinitionTokens?: number | null;
+  toolSurfaceExceedsLocalCliff?: boolean | null;
+  toolSurfaceWindowShare?: number | null;
+  toolSelectionAccuracy?: number | null;
+  createdAt?: Date;
+};
+
+export type ClassifiedPatternNeed = {
+  kind: CoworkerCapabilityNeedKind;
+  severity: "blocker" | "important" | "minor";
+  need: string;
+  blocks: string;
+  evidenceJson: Record<string, unknown>;
+  readinessJson: Record<string, unknown>;
+  fingerprint: string;
+};
+```
+
+- [ ] **Step 4: Implement initial trigger rules**
+
+Implement deterministic rules only:
+
+- Two or more failed executions of the same tool with `forbidden_grant`, `forbidden grant`, or `insufficient_token_scope` produce a `grant` need.
+- Two or more failed executions of the same tool with the same normalized summary/result error produce a `tool` need.
+- Two or more turn metrics exceeding `LOCAL_TOOL_SELECTION_CLIFF` produce a `tool` need with `toolSurfaceCount` evidence.
+- Two or more turn metrics with low `toolSelectionAccuracy` below `0.7` and at least one attempted tool produce a `tool` need.
+- Two or more approved envelopes with the same proposed action key produce a `code` or `convention` need for proceduralization, but only as evidence; do not change envelope behavior.
+
+Each output pattern should include `WorkPatternMetadata` with:
+
+- `status: "observed"`.
+- `source: "observer"`.
+- `decisionScope` from `patternDecisionScope`.
+- evidence refs where known.
+- optional `workCaseBinding` only when input supplies case references.
+
+- [ ] **Step 5: Re-run classifier tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/pattern-observer.test.ts
+```
+
+Expected: pass.
+
+### Task 4: Add DB-backed observer service and post-run hook
+
+**Files:**
+
+- Create: `apps/web/lib/tak/pattern-observer-service.ts`
+- Create: `apps/web/lib/tak/pattern-observer-service.test.ts`
+- Modify: `apps/web/lib/tak/autonomous-work-run.ts`
+- Modify: `apps/web/lib/tak/autonomous-work-run.test.ts`
+
+- [ ] **Step 1: Write service tests with injected dependencies**
+
+Tests must prove:
+
+- The service loads evidence for the just-finished TaskRun plus a bounded recent window.
+- It updates the parent `TaskRun` with `repeatedPatternKey` and merged `a2aMetadata.workPattern`.
+- It calls `submitCoworkerSelfAssessment` with `trigger: "work-pattern-observer"`.
+- It calls `createOrTouchImprovementSignal` with a stable `sourceType/sourceId`.
+- It skips parent runs that are reflection runs or have `reflectionDepth >= 1`.
+- All failures are logged and do not throw to the caller.
+
+- [ ] **Step 2: Run the failing service tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/pattern-observer-service.test.ts
+```
+
+Expected: fails because the service does not exist.
+
+- [ ] **Step 3: Implement `observeWorkPatternsAfterRun`**
+
+Shape:
+
+```ts
+export async function observeWorkPatternsAfterRun(input: {
+  taskRunId: string | null;
+  userId: string;
+  agentId: string;
+  threadId: string | null;
+  routeContext: string;
+  since: Date;
+}, deps?: PatternObserverServiceDeps): Promise<{
+  processed: number;
+  skippedReason?: "missing-task-run" | "reflection-loop-guard" | "no-signals";
+}> {
+  // load parent TaskRun, guard reflection loops, load evidence, classify,
+  // stamp TaskRun, submit self-assessment, touch improvement signal
+}
+```
+
+Important constraints:
+
+- Reuse `getReflectionDepth` and `isReflectionRun` from `apps/web/lib/tak/reflection-triggers.ts`.
+- Reuse `submitCoworkerSelfAssessment` instead of writing `CoworkerCapabilityNeed` directly.
+- Reuse `createOrTouchImprovementSignal` instead of inserting signal rows directly.
+- Query recent `CoworkerTurnMetric` by `threadId` or `(agentId, routeContext, createdAt >= since - window)`.
+- Query recent `ToolExecution` by `taskRunId` first, then by `(agentId, routeContext, createdAt >= since)`.
+- Query prior needs for the same agent/route from `CoworkerCapabilityNeed.evidenceJson.fingerprint` where present; if JSON querying is awkward, load a bounded recent set and filter in TypeScript.
+- Update `TaskRun.a2aMetadata` with `mergeWorkPatternMetadata`; do not overwrite `reflectionDepth`, `sourceRef`, or other metadata.
+
+- [ ] **Step 4: Wire the post-run hook**
+
+In `executeAutonomousAgenticLoop`, after the existing runtime-issue reflection hook, add a second fire-and-forget hook:
+
+```ts
+void (async () => {
+  try {
+    const { observeWorkPatternsAfterRun } = await import("@/lib/tak/pattern-observer-service");
+    await observeWorkPatternsAfterRun({
+      taskRunId: input.taskRunId ?? null,
+      userId: input.userId,
+      agentId: input.agentId,
+      threadId: input.threadId,
+      routeContext: input.routeContext,
+      since: startedAt,
+    });
+  } catch (err) {
+    console.warn(
+      "[pattern-observer] post-run hook failed:",
+      err instanceof Error ? err.message : err,
+    );
+  }
+})();
+```
+
+- [ ] **Step 5: Re-run observer tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/pattern-observer.test.ts apps/web/lib/tak/pattern-observer-service.test.ts apps/web/lib/tak/autonomous-work-run.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit observer foundation**
+
+Run:
+
+```powershell
+git add apps/web/lib/tak/pattern-observer.ts apps/web/lib/tak/pattern-observer.test.ts apps/web/lib/tak/pattern-observer-service.ts apps/web/lib/tak/pattern-observer-service.test.ts apps/web/lib/tak/autonomous-work-run.ts apps/web/lib/tak/autonomous-work-run.test.ts
+git commit -s -m "feat: observe systemic coworker work patterns"
+```
+
+## Chunk 4: Periodic Agent Reviews
+
+### Task 5: Add attributable profile-review runner and cron
+
+**Files:**
+
+- Create: `apps/web/lib/tak/work-pattern-profile-review.ts`
+- Create: `apps/web/lib/tak/work-pattern-profile-review.test.ts`
+- Create: `apps/web/lib/queue/functions/work-pattern-profile-review.ts`
+- Modify: `apps/web/lib/queue/functions/index.ts`
+
+- [ ] **Step 1: Write periodic review tests**
+
+Tests must prove:
+
+- Owner is resolved through `resolveScheduledOwnerUserId`.
+- The created `TaskRun.userId` is the superuser owner.
+- `initiatingAgentId` and `currentAgentId` are the reviewed agent.
+- The review emits needs through the same self-assessment path.
+- The review marks the TaskRun completed even when it finds no needs.
+
+- [ ] **Step 2: Run failing review tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-profile-review.test.ts
+```
+
+Expected: fails because the module does not exist.
+
+- [ ] **Step 3: Implement deterministic review runner**
+
+Add:
+
+```ts
+export async function runWorkPatternProfileReview(input: {
+  agentId: string;
+  routeContext?: string | null;
+  now?: Date;
+}, deps?: WorkPatternProfileReviewDeps): Promise<{
+  taskRunId: string;
+  observedPatterns: number;
+  needsFiled: number;
+}> {
+  // resolve owner via resolveScheduledOwnerUserId
+  // create proactive/scheduled TaskRun with reviewed agent as executor
+  // inspect last 7 days or last N completed TaskRuns
+  // classify with classifyPatternSignals
+  // submit self-assessment if needs exist
+  // update TaskRun completed with progressPayload summary
+}
+```
+
+Use existing `createAutonomousWorkRun` if it can express `trigger: "scheduled"`, `userId`, `agentId`, `routeContext`, title, objective, and metadata cleanly. If direct Prisma create is simpler for tests, keep the row shape identical to `createAutonomousWorkRun`.
+
+The review `progressPayload` should contain a compact summary:
+
+```ts
+{
+  type: "work-pattern-profile-review",
+  agentId,
+  routeContext,
+  windowDays: 7,
+  observedPatterns,
+  needsFiled,
+}
+```
+
+- [ ] **Step 4: Add Inngest cron**
+
+Create `apps/web/lib/queue/functions/work-pattern-profile-review.ts` in the same style as `skill-curator.ts`:
+
+```ts
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+export const workPatternProfileReview = inngest.createFunction(
+  {
+    id: "quality/work-pattern-profile-review",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("17 7 * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("review-agent-work-patterns", async () => {
+      const { runDueWorkPatternProfileReviews } = await import("@/lib/tak/work-pattern-profile-review");
+      return runDueWorkPatternProfileReviews();
+    });
+  },
+);
+```
+
+`runDueWorkPatternProfileReviews()` should select agents due by either N completed TaskRuns or seven days since the last `work-pattern-profile-review` TaskRun. Keep N as a local constant in the runner for this slice.
+
+- [ ] **Step 5: Register the cron**
+
+Add the import and array entry in `apps/web/lib/queue/functions/index.ts`.
+
+- [ ] **Step 6: Re-run periodic review tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-profile-review.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit periodic review**
+
+Run:
+
+```powershell
+git add apps/web/lib/tak/work-pattern-profile-review.ts apps/web/lib/tak/work-pattern-profile-review.test.ts apps/web/lib/queue/functions/work-pattern-profile-review.ts apps/web/lib/queue/functions/index.ts
+git commit -s -m "feat: add periodic work pattern profile reviews"
+```
+
+## Chunk 5: EA/SysML Grounding
+
+### Task 6: Add Work Pattern architecture extractor and reconciler
+
+**Files:**
+
+- Create: `apps/web/lib/ea/work-pattern-architecture-extract.ts`
+- Create: `apps/web/lib/ea/work-pattern-architecture-extract.test.ts`
+- Create: `apps/web/lib/ea/reconcile-work-pattern-architecture.ts`
+- Create: `apps/web/lib/ea/reconcile-work-pattern-architecture.test.ts`
+- Modify: `apps/web/lib/ea/reconcile-sysml-projections.ts`
+- Modify: `apps/web/lib/ea/architecture-parity-steward.ts`
+- Modify: `apps/web/lib/ea/reconcile-sysml-projections.test.ts`
+
+- [ ] **Step 1: Write pure extractor tests**
+
+Tests must prove:
+
+- The model emits a package for Governed Adaptive Playbooks.
+- `ACT-GAP-*` pattern elements are SysML `action` elements.
+- `SM-GAP-PROMOTION` is represented as a `part_definition` containing `state` elements because the seeded SysML2 notation supports `part_definition -> state`.
+- `VC-GAP-*` elements are `verification_case` elements and verify requirements.
+- Relationships use existing SysML2 slugs: `contains`, `satisfies`, `verifies`, `allocates`, and `traces`.
+- No new EA notation, relationship type, or table is required.
+
+- [ ] **Step 2: Run failing extractor tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/ea/work-pattern-architecture-extract.test.ts
+```
+
+Expected: fails because the extractor does not exist.
+
+- [ ] **Step 3: Implement `buildWorkPatternArchitectureModel`**
+
+Build a `SysmlDesiredModel` in the same style as `process-extract.ts` and `mcp-authority-extract.ts`.
+
+Required stable keys:
+
+- `gap:pkg`
+- `gap:req:no-self-activation`
+- `gap:req:evidence-backed-proposal`
+- `gap:req:case-bound-governed-action`
+- `gap:part:metadata`
+- `gap:part:observer`
+- `gap:part:profile-review`
+- `gap:part:promotion-ladder`
+- `gap:state:observed`
+- `gap:state:candidate`
+- `gap:state:approved`
+- `gap:state:active`
+- `gap:state:retired`
+- `gap:vc:metadata`
+- `gap:vc:observer`
+- `gap:vc:profile-review`
+
+For each observed pattern passed to the extractor, emit:
+
+- `gap:act:<safePatternKey>` as an `action`.
+- `gap:vc:<safePatternKey>` as a `verification_case`.
+- `traces` relationships to source evidence where represented as properties.
+- `allocates` relationships from the action to realizing `part_definition` elements when a code allocation is known.
+
+Use properties for code/source references:
+
+```ts
+properties: {
+  sourceKey: "apps/web/lib/tak/pattern-observer.ts",
+  stableId: "ACT-GAP-tool-surface-overload",
+  semantic: "sysml_allocates",
+}
+```
+
+Do not invent a relationship slug named `sysml_allocates`; DPF's seeded SysML2 relationship slug is `allocates`.
+
+- [ ] **Step 4: Implement reconcile shell**
+
+`reconcileWorkPatternArchitecture({ db })` should call `applySysmlModel(buildWorkPatternArchitectureModel(...), { db, notationSlug: "sysml2" })`, log a compact result, and return `SysmlSeedResult`.
+
+- [ ] **Step 5: Register the projection domain**
+
+Add `workPatternArchitecture` to:
+
+- `SysmlProjectionsResult` in `apps/web/lib/ea/reconcile-sysml-projections.ts`.
+- The isolated domain run list in `reconcileSysmlProjections`.
+- `DOMAIN_LABELS` in `apps/web/lib/ea/architecture-parity-steward.ts`.
+
+- [ ] **Step 6: Re-run EA tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/ea/work-pattern-architecture-extract.test.ts apps/web/lib/ea/reconcile-work-pattern-architecture.test.ts apps/web/lib/ea/reconcile-sysml-projections.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit EA grounding**
+
+Run:
+
+```powershell
+git add apps/web/lib/ea/work-pattern-architecture-extract.ts apps/web/lib/ea/work-pattern-architecture-extract.test.ts apps/web/lib/ea/reconcile-work-pattern-architecture.ts apps/web/lib/ea/reconcile-work-pattern-architecture.test.ts apps/web/lib/ea/reconcile-sysml-projections.ts apps/web/lib/ea/architecture-parity-steward.ts apps/web/lib/ea/reconcile-sysml-projections.test.ts
+git commit -s -m "feat: ground adaptive playbooks in sysml projection"
+```
+
+## Chunk 6: Governance Guardrails And Documentation
+
+### Task 7: Encode no-activation and Work Case dependency guardrails
+
+**Files:**
+
+- Modify: `apps/web/lib/tak/work-pattern-types.ts`
+- Modify: `apps/web/lib/tak/pattern-observer.ts`
+- Modify: `apps/web/lib/tak/pattern-observer.test.ts`
+- Modify: `docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md`
+
+- [ ] **Step 1: Add tests for candidate guardrails**
+
+Tests must prove:
+
+- A classified candidate includes `decisionScope`.
+- A `case-type` or `case-transition` candidate includes `workCaseBinding` when available.
+- A case-bound candidate without `receiptPolicy`, `governedActionKey`, or source reference is marked `readinessJson.readyForCaseActivation = false`.
+- No classifier output contains an activation command, prompt mutation, skill mutation, grant mutation, model-route mutation, or Work Case state mutation.
+
+- [ ] **Step 2: Implement readiness metadata**
+
+Add a helper:
+
+```ts
+export function evaluatePatternReadiness(metadata: WorkPatternMetadata): {
+  readyForReview: boolean;
+  readyForCaseActivation: boolean;
+  blockers: string[];
+} {
+  // review requires evidence and decisionScope
+  // case activation requires workCaseBinding.governedActionKey plus receiptPolicy
+  // activation is always false unless status is approved/active; this slice never sets those statuses
+}
+```
+
+The observer should include readiness in `readinessJson`, not as a new table.
+
+- [ ] **Step 3: Update the spec with the plan pointer**
+
+In the spec implementation summary, add a link to this plan as the foundation plan. If implementation revealed any discrepancy, update the spec in the same commit.
+
+- [ ] **Step 4: Re-run guardrail tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-types.test.ts apps/web/lib/tak/pattern-observer.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit guardrails and docs**
+
+Run:
+
+```powershell
+git add apps/web/lib/tak/work-pattern-types.ts apps/web/lib/tak/work-pattern-types.test.ts apps/web/lib/tak/pattern-observer.ts apps/web/lib/tak/pattern-observer.test.ts docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
+git commit -s -m "docs: link adaptive playbooks foundation plan"
+```
+
+## Chunk 7: Verification And Evidence
+
+### Task 8: Run source-local gates
+
+**Files:** all touched files.
+
+- [ ] **Step 1: Run targeted unit tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-types.test.ts apps/web/lib/operate/coworker-turn-metrics.test.ts apps/web/lib/tak/context-economy-metrics.test.ts apps/web/lib/tak/context-pressure.test.ts apps/web/lib/tak/pattern-observer.test.ts apps/web/lib/tak/pattern-observer-service.test.ts apps/web/lib/tak/autonomous-work-run.test.ts apps/web/lib/tak/work-pattern-profile-review.test.ts apps/web/lib/ea/work-pattern-architecture-extract.test.ts apps/web/lib/ea/reconcile-work-pattern-architecture.test.ts apps/web/lib/ea/reconcile-sysml-projections.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```powershell
+pnpm --filter web typecheck
+```
+
+Expected: zero TypeScript errors.
+
+- [ ] **Step 3: Run migration apply verification**
+
+If the migration was added, verify it applies through the appropriate canonical runtime or shared local-CI convergence sandbox. Do not claim migration evidence from an unproven worktree-only database.
+
+Expected: migration applies cleanly.
+
+- [ ] **Step 4: Run production build through the governed gate**
+
+Run the production build where AGENTS.md allows runtime-bound gates: canonical local install after governed self-upgrade or the shared local-CI convergence sandbox.
+
+Command:
+
+```powershell
+pnpm --filter web build
+```
+
+Expected: zero build errors.
+
+- [ ] **Step 5: Record evidence**
+
+Record the command outputs against the implementation BI through MCP evidence tooling if available. If MCP evidence tooling is unavailable, include exact command/result evidence in the PR body and reconcile MCP evidence later.
+
+- [ ] **Step 6: Final commit and push**
+
+Run:
+
+```powershell
+git status --short
+git push origin HEAD
+```
+
+Expected: branch is pushed. Do not open a PR until the relevant gates are green and the branch is believed ready for review.
+
+## Rollback
+
+Rollback is straightforward:
+
+- Revert the migration and telemetry writer changes if the schema extension causes issues.
+- Remove the observer post-run hook from `autonomous-work-run.ts`; the existing runtime-issue reflection path remains intact.
+- Remove the periodic cron registration from `apps/web/lib/queue/functions/index.ts`.
+- Remove the Work Pattern EA projection domain from `reconcile-sysml-projections.ts` and `architecture-parity-steward.ts`.
+- Keep pure tests that characterize existing behavior if they still pass and document useful invariants.
+
+No rollback should touch Work Case source/status projection, trust-state rows, skills, prompts, grants, model routing, or Work Case state because this foundation must not mutate those surfaces.
+
+## Definition Of Done
+
+- Work Pattern metadata is typed and stamped into `TaskRun.a2aMetadata.workPattern`.
+- `TaskRun.repeatedPatternKey` is used for observed pattern queryability.
+- Context/tool-surface telemetry is durably persisted without string enum columns.
+- The observer emits evidence-backed capability needs through existing self-assessment and improvement-signal paths.
+- Periodic reviews create attributable TaskRuns owned by the install superuser and executed by the reviewed agent.
+- EA/SysML projection includes Work Pattern, promotion ladder, and verification-case elements in the existing parity engine.
+- Case-bound candidates remain proposals only and cannot mutate Work Case state.
+- All source-local tests, typecheck, production build, and migration apply evidence are green or explicitly documented if blocked by a pre-existing issue.

--- a/docs/superpowers/plans/2026-06-27-governed-adaptive-playbooks-slice-1.md
+++ b/docs/superpowers/plans/2026-06-27-governed-adaptive-playbooks-slice-1.md
@@ -1,0 +1,390 @@
+# Governed Adaptive Playbooks — Slice 1: Systemic Capability-Needs Observer
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Broaden DPF's narrow reactive reflection path into a reusable, evidence-driven **pattern observer** that emits richer capability needs from more than one failure shape — using existing models, kinds, and the existing backlog intake. No new tables. No model self-modification.
+
+**Architecture:** Extract a reusable observer core from the current `agent_stuck`-only reflection, add pure signal classifiers and a centralized fingerprint/dedupe helper, then wire the observer into both the existing per-turn post-run hook (event-triggered) and a new periodic sweep. Everything routes through the existing `submitCoworkerSelfAssessment` → backlog intake. Pure domain logic first; trigger wiring last.
+
+**Tech Stack:** Next.js 16 monorepo, TypeScript, Vitest, Prisma models, existing TAK reflection + coworker-self-assessment + improvement-flywheel libraries.
+
+---
+
+## Context And Constraints
+
+- Epic: `EP-8AF1C996` — Progressive Autonomy & Trust Graduation (the spec composes directly with it). Focused BI: `BI-fb968f39-1851-49c8-914b-5c525322bf73`.
+- Spec: `docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md` (§7 Slice 1, §6.1/§6.2 triggers, §8 refactoring budget, §9 governance).
+- Models may **propose** improvements; they may not activate them. Slice 1 only observes and files reviewable needs — it changes no skills, prompts, grants, policies, routes, or code.
+- Use the existing capability-need kinds (`tool`, `skill`, `grant`, `model`, `memory`, `data`, `ui_surface`, `boundary`, `prompt`, `convention`, `code`, `other`) — a closed string set in `apps/web/lib/coworker-self-assessment/types.ts`, not a Prisma enum. Do not widen it in this slice.
+- No new tables. Reuse `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, `ImprovementSignal`, `TaskRun`, `ToolExecution`, `PlatformIssueReport`.
+- Preserve the existing reflection loop guards (depth guard + dedupe). A broadened observer must not create self-trigger cascades.
+- Reserve ~20% of effort for the structural refactor named in spec §8 (extract shared observer primitives; centralize fingerprinting) — not unrelated cleanup.
+- Defer the phase-review-failure classifier: build/phase review outcomes do not live in a runtime store (`ReviewInstance` is the HR review cycle), so that signal source needs confirmation in a later slice. Slice 1 classifiers are grant-denial, tool-surface/context overload, and repeated-success.
+
+## Parallel Effort Coordination
+
+The Work Case program (`EP-2984B02B`, Wave 1 seam owner `BI-D633F7AF`) runs in parallel. This slice is on the parallel-safe side of that contract.
+
+- **No dependency:** Slice 1 only reads runtime evidence and emits needs/assessments. It changes no Work Case state and does not require Work Case Wave 0 or Wave 1.
+- **Later slices depend on Work Case (state, do not weaken):** Case-bound Pattern Candidates (this effort's Slice 4 and promotion-ladder step "Case-staged") consume Work Case Wave 1's governed Actions, policy envelope, and `ReceiptEnvelope`, and Wave 2's sponsor/authority-mode. Slice 1 builds none of that.
+- **Collision ownership:** Do not edit `apps/web/lib/mcp-governed-execute.ts` — the `context.workCase` / `work-case-governed-action` receipt seam is owned by Work Case Wave 1 (`BI-D633F7AF`). Slice 1 does not touch it.
+
+## File Structure
+
+- Create `apps/web/lib/tak/pattern-observer/core.ts`
+  - Reusable reflection envelope extracted from `reflection-triggers.ts`: depth-guarded proactive `TaskRun` creation, assessment+need emission, and `ImprovementSignal` touch — parameterized by reflection `title`, need `kind`, `severity`, and `suspectedRootCause` instead of hard-coding "Skill reflection"/"skill"/"repeated-tool-call".
+- Create `apps/web/lib/tak/pattern-observer/core.test.ts`
+- Create `apps/web/lib/tak/pattern-observer/fingerprint.ts`
+  - One place that builds the dedupe keys: capability-need origin key (wrapping the existing `capabilityNeedOriginId`) and the `ImprovementSignal (sourceType, sourceId)` key, plus an evidence fingerprint (agent + route + kind + normalized-need + evidence digest) so runtime reflection, periodic review, and manual assessment converge on one dedupe contract.
+- Create `apps/web/lib/tak/pattern-observer/fingerprint.test.ts`
+- Create `apps/web/lib/tak/pattern-observer/classifiers.ts`
+  - Pure functions that turn observed evidence into a `CoworkerCapabilityNeedInput` (kind + severity + need + blocks + evidenceJson), or null when below threshold:
+    - `classifyGrantDenial` → `grant`
+    - `classifyToolSurfaceOverload` → `tool` or `prompt` or `data` with token/zone evidence
+    - `classifyRepeatedSuccess` → `code` or `convention` (proceduralization candidate)
+- Create `apps/web/lib/tak/pattern-observer/classifiers.test.ts`
+- Create `apps/web/lib/tak/pattern-observer/observer.ts`
+  - `observeCoworkerPatterns(input, deps?)`: loads recent `TaskRun`/`ToolExecution` for an agent (+ optional route/time window), computes context-economy evidence, runs the classifiers, dedupes via the fingerprint helper, and emits one `CoworkerSelfAssessment` (rich `rawPayload`) with the surviving needs through `submitCoworkerSelfAssessment`.
+- Create `apps/web/lib/tak/pattern-observer/observer.test.ts`
+- Create `apps/web/lib/tak/pattern-observer/periodic-review.ts`
+  - `runPeriodicPatternReview(input, deps?)`: the genuinely-periodic sweep (every N completed runs or 7 days, whichever first). Resolves the spawned `TaskRun` to `userId = superuser` and `executor = Agent` (proactive-job owner resolution), then calls `observeCoworkerPatterns`.
+- Create `apps/web/lib/tak/pattern-observer/periodic-review.test.ts`
+- Create `apps/web/lib/tak/pattern-observer/index.ts`
+- Modify `apps/web/lib/tak/reflection-triggers.ts`
+  - Re-implement `processRuntimeIssueReflection` on top of `pattern-observer/core.ts` so the `agent_stuck` path keeps identical behavior (same title, `skill` need, root cause) while the envelope is shared. Preserve `getReflectionDepth`/`isReflectionRun` and the depth/dedup guards.
+- Modify `apps/web/lib/tak/reflection-triggers.test.ts`
+  - Keep the existing assertions green against the refactored implementation.
+- Modify `apps/web/lib/tak/autonomous-work-run.ts`
+  - In the existing fire-and-forget post-run hook, after the current runtime-issue reflection, also invoke `observeCoworkerPatterns` for the just-finished agent/route, guarded by the same loop guards (do not observe a reflection run; respect depth). Event-triggered observation inherits the existing per-turn user context.
+- Create `apps/web/lib/playbooks/architecture-grounding.ts` and `.test.ts`
+  - A small EA/SysML grounding manifest mirroring the Work Case pattern: register `ACT-GAP-observe`, `VC-GAP-observer`, and the Slice 1 requirement(s) with `sysml_allocates` edges to the new files. `SM-GAP-PROMOTION` and the full promotion-ladder elements land in later slices.
+
+---
+
+## Task 1: Extract The Reusable Observer Core
+
+**Files:**
+- Create: `apps/web/lib/tak/pattern-observer/core.test.ts`
+- Create: `apps/web/lib/tak/pattern-observer/core.ts`
+- Modify: `apps/web/lib/tak/reflection-triggers.ts`
+- Modify: `apps/web/lib/tak/reflection-triggers.test.ts`
+- Create: `apps/web/lib/tak/pattern-observer/index.ts`
+
+This is the spec §8 refactor: share one envelope instead of growing a second reflection subsystem.
+
+- [ ] **Step 1: Write failing core tests**
+
+Assert the parameterized envelope:
+
+- `runObservation` creates a proactive `TaskRun` with the supplied `title`, `a2aMetadata.reflectionDepth = parentDepth + 1`, and `a2aMetadata.trigger`.
+- It returns `{ processed: 0, skippedReason: "reflection-loop-guard" }` when the parent is a reflection run or has `reflectionDepth >= 1` (depth guard preserved).
+- It emits a `CoworkerSelfAssessment` with the supplied verdict/confidence and the supplied needs (kind/severity passed through, not hard-coded).
+- It touches an `ImprovementSignal` with the supplied `sourceType`/`sourceId`/`suspectedRootCause`.
+
+Use the deps-injection + mocked-Prisma style from `reflection-triggers.test.ts`.
+
+- [ ] **Step 2: Run and verify failure**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/core.test.ts
+```
+
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Implement the core**
+
+Move the reusable parts of `reflection-triggers.ts` (`getReflectionDepth`, `isReflectionRun`, the depth-guard short-circuit, the proactive `TaskRun` envelope, the assessment/need emission, the `createOrTouchImprovementSignal` call) into `core.ts`, parameterized by an `ObservationSpec { title; trigger; verdict; confidence; needs; sourceType; sourceId; suspectedRootCause }`. Re-export `getReflectionDepth`/`isReflectionRun` from `reflection-triggers.ts` for backward compatibility.
+
+- [ ] **Step 4: Re-implement `processRuntimeIssueReflection` on the core**
+
+Rewrite the `agent_stuck` path to call the core with the existing constants (`title = "Skill reflection: repeated tool use"`, `kind = "skill"`, `suspectedRootCause = "repeated-tool-call"`). The existing `reflection-triggers.test.ts` must pass unchanged.
+
+- [ ] **Step 5: Run both suites**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/core.test.ts lib/tak/reflection-triggers.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add apps/web/lib/tak/pattern-observer/core.ts apps/web/lib/tak/pattern-observer/core.test.ts apps/web/lib/tak/pattern-observer/index.ts apps/web/lib/tak/reflection-triggers.ts apps/web/lib/tak/reflection-triggers.test.ts
+git commit -s -m "refactor: extract reusable pattern-observer core from reflection triggers"
+```
+
+---
+
+## Task 2: Centralized Fingerprint And Dedupe
+
+**Files:**
+- Create: `apps/web/lib/tak/pattern-observer/fingerprint.test.ts`
+- Create: `apps/web/lib/tak/pattern-observer/fingerprint.ts`
+- Modify: `apps/web/lib/tak/pattern-observer/index.ts`
+
+- [ ] **Step 1: Write failing fingerprint tests**
+
+- `capabilityNeedKey(agentId, kind, need)` matches the existing `capabilityNeedOriginId` output (same normalization: trim, lowercase, collapse whitespace, 120-char slice) so the observer and the existing intake dedupe identically.
+- `improvementSignalKey(sourceType, sourceId)` returns the `(sourceType, sourceId)` pair used by `createOrTouchImprovementSignal`.
+- `evidenceFingerprint({ agentId, routeContext, kind, need, evidence })` is stable across reordered evidence keys and changes when the normalized need changes.
+
+- [ ] **Step 2: Run and verify failure**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/fingerprint.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Wrap `capabilityNeedOriginId` (do not duplicate its normalization) and add the signal key + a deterministic evidence digest (stable JSON stringify of sorted keys). Keep it pure.
+
+- [ ] **Step 4: Run**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/fingerprint.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/tak/pattern-observer/fingerprint.ts apps/web/lib/tak/pattern-observer/fingerprint.test.ts apps/web/lib/tak/pattern-observer/index.ts
+git commit -s -m "feat: centralize pattern-observer fingerprint and dedupe keys"
+```
+
+---
+
+## Task 3: Pure Signal Classifiers
+
+**Files:**
+- Create: `apps/web/lib/tak/pattern-observer/classifiers.test.ts`
+- Create: `apps/web/lib/tak/pattern-observer/classifiers.ts`
+- Modify: `apps/web/lib/tak/pattern-observer/index.ts`
+
+- [ ] **Step 1: Write failing classifier tests**
+
+Each classifier takes observed evidence and returns a `CoworkerCapabilityNeedInput | null`:
+
+- `classifyGrantDenial`: repeated tool denials by grant/missing capability (over a threshold) → `{ kind: "grant", severity: "important", evidenceJson: { deniedTool, count } }`. Below threshold → null.
+- `classifyToolSurfaceOverload`: an `assessToolSurface` result with `zone === "overload"` (or `exceedsLocalCliff`) → `{ kind: "tool" | "prompt" | "data", evidenceJson: { toolCount, estDefinitionTokens, windowShare, zone } }` with the token evidence required by spec acceptance. `zone === "caution"` → minor or null per threshold; `lean` → null.
+- `classifyRepeatedSuccess`: a `computeToolSelectionAccuracy` + repetition signal showing a high-ceremony successful workflow repeated N times → `{ kind: "code" | "convention", severity: "minor", need: "proceduralize ..." }`.
+
+- [ ] **Step 2: Run and verify failure**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/classifiers.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Pure functions only — they consume already-computed `assessToolSurface` / `computeToolSelectionAccuracy` results and counts, and return need inputs. No DB, no I/O. Reuse `apps/web/lib/tak/context-economy-metrics.ts` types (`ToolSurfaceAssessment`, `ToolSelectionAccuracy`, `LOCAL_TOOL_SELECTION_CLIFF`).
+
+- [ ] **Step 4: Run**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/classifiers.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/tak/pattern-observer/classifiers.ts apps/web/lib/tak/pattern-observer/classifiers.test.ts apps/web/lib/tak/pattern-observer/index.ts
+git commit -s -m "feat: add pattern-observer signal classifiers"
+```
+
+---
+
+## Task 4: The Systemic Observer
+
+**Files:**
+- Create: `apps/web/lib/tak/pattern-observer/observer.test.ts`
+- Create: `apps/web/lib/tak/pattern-observer/observer.ts`
+- Modify: `apps/web/lib/tak/pattern-observer/index.ts`
+
+- [ ] **Step 1: Write failing observer tests** (deps-injection style)
+
+- Loads recent `ToolExecution` for an agent (mock), computes surface/accuracy, runs classifiers, and calls `submitCoworkerSelfAssessment` once with all surviving needs and a rich `rawPayload` (evidence digests, window).
+- A repeated grant denial produces a `grant` need (not a generic `skill` need).
+- A repeated context-overload window produces a `prompt`/`tool`/`data` need with token evidence.
+- A repeated successful manual workflow produces a `code`/`convention` need.
+- Duplicate needs within one sweep collapse via the fingerprint helper (one need per key).
+- When no classifier fires, no assessment is submitted.
+
+- [ ] **Step 2: Run and verify failure**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/observer.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `observeCoworkerPatterns`**
+
+Inject deps `{ db, assessToolSurface, computeToolSelectionAccuracy, submitCoworkerSelfAssessment, now }`. Query recent `ToolExecution` (use the `@@index([agentId, createdAt])`) and recent `TaskRun` outcomes, group by route, run classifiers, dedupe, and submit one assessment with `trigger: "pattern-observer"`. Keep the existing backlog projection by delegating filing to `submitCoworkerSelfAssessment` (do not file directly).
+
+- [ ] **Step 4: Run**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/observer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/tak/pattern-observer/observer.ts apps/web/lib/tak/pattern-observer/observer.test.ts apps/web/lib/tak/pattern-observer/index.ts
+git commit -s -m "feat: add systemic coworker pattern observer"
+```
+
+---
+
+## Task 5: Trigger Wiring (Event + Periodic)
+
+**Files:**
+- Create: `apps/web/lib/tak/pattern-observer/periodic-review.test.ts`
+- Create: `apps/web/lib/tak/pattern-observer/periodic-review.ts`
+- Modify: `apps/web/lib/tak/autonomous-work-run.ts`
+- Modify: `apps/web/lib/tak/pattern-observer/index.ts`
+
+- [ ] **Step 1: Write failing periodic-review tests**
+
+- `runPeriodicPatternReview` resolves the spawned `TaskRun` owner to `userId = superuser` and `executor = Agent` (never a synthetic "system" actor), then calls `observeCoworkerPatterns`.
+- It honors the cadence guard (skips an agent reviewed within the window / below the run count).
+- It respects the reflection loop guards (does not run for reflection-spawned runs).
+
+- [ ] **Step 2: Write failing post-run-hook test**
+
+In `autonomous-work-run.ts` coverage: after a normal turn, the post-run hook also invokes `observeCoworkerPatterns` for the finished agent/route, and is skipped for reflection runs and at depth >= 1.
+
+- [ ] **Step 3: Run and verify failure**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/periodic-review.test.ts lib/tak/autonomous-work-run.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement**
+
+- `periodic-review.ts`: resolve superuser via the existing proactive-job owner resolution; cadence from a small constant (N runs or 7 days). Keep scheduling registration out of scope if cron infra is not already present — note the registration site to confirm; the function must be invocable and tested regardless.
+- `autonomous-work-run.ts`: add the observer call inside the existing fire-and-forget block next to `processRuntimeIssueReflection`, behind the same guard checks. Non-fatal try/catch like the existing reflection call.
+
+- [ ] **Step 5: Run**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/periodic-review.test.ts lib/tak/autonomous-work-run.test.ts lib/tak/reflection-triggers.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add apps/web/lib/tak/pattern-observer/periodic-review.ts apps/web/lib/tak/pattern-observer/periodic-review.test.ts apps/web/lib/tak/autonomous-work-run.ts apps/web/lib/tak/pattern-observer/index.ts
+git commit -s -m "feat: wire pattern observer into per-turn and periodic triggers"
+```
+
+---
+
+## Task 6: EA/SysML Grounding And Plan Evidence
+
+**Files:**
+- Create: `apps/web/lib/playbooks/architecture-grounding.ts`
+- Create: `apps/web/lib/playbooks/architecture-grounding.test.ts`
+
+- [ ] **Step 1: Write failing grounding tests**
+
+- The manifest registers `ACT-GAP-observe` (the observer action) and `VC-GAP-observer` (verification case) with `sysml_allocates` allocations to `observer.ts`, `classifiers.ts`, and `core.ts`.
+- The Slice 1 requirement is marked `implemented` only for behavior covered by tests; promotion-ladder elements remain `planned`.
+
+- [ ] **Step 2: Run and verify failure**
+
+```powershell
+pnpm --filter web exec vitest run lib/playbooks/architecture-grounding.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Mirror the Work Case `architecture-grounding.ts` shape (`elementId`, `elementType`, `name`, `description`, `implementationStatus`, `itValueStreams`, `verificationCaseId`, and `sysml_allocates` allocations). Do not invent a parallel manifest shape; reuse the same field names so both efforts ground in one substrate. Anchor to IT4IT `operate` value stream.
+
+- [ ] **Step 4: Run**
+
+```powershell
+pnpm --filter web exec vitest run lib/playbooks/architecture-grounding.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/playbooks/architecture-grounding.ts apps/web/lib/playbooks/architecture-grounding.test.ts
+git commit -s -m "doc: ground governed-playbooks observer in EA/SysML substrate"
+```
+
+---
+
+## Task 7: Full Verification And Evidence
+
+- [ ] **Step 1: Focused suite**
+
+```powershell
+pnpm --filter web exec vitest run lib/tak/pattern-observer/*.test.ts lib/tak/reflection-triggers.test.ts lib/tak/autonomous-work-run.test.ts lib/coworker-self-assessment/assessment-service.test.ts lib/improvement-flywheel/signals.test.ts lib/playbooks/architecture-grounding.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Typecheck**
+
+```powershell
+pnpm --filter web typecheck
+```
+
+- [ ] **Step 3: Whitespace check**
+
+```powershell
+git diff --check
+```
+
+- [ ] **Step 4: Production build**
+
+```powershell
+pnpm --filter web build
+```
+
+Expected: PASS (pre-existing Turbopack warnings acceptable if unchanged).
+
+- [ ] **Step 5: Record MCP evidence on the BI** — focused suite, typecheck, build results, and notes on any deferred classifier (phase-review) or scheduling-registration follow-up.
+
+- [ ] **Step 6: Mark BI status** only when gates are green and the branch is pushed / PR opened.
+
+---
+
+## Rollback
+
+- Revert the new `apps/web/lib/tak/pattern-observer/*` and `apps/web/lib/playbooks/*` modules.
+- Restore `reflection-triggers.ts` and `autonomous-work-run.ts` to pre-slice behavior (the `agent_stuck` path is unchanged in behavior, so reverting the refactor is safe).
+- No migration rollback — this slice adds no schema.
+
+## Definition Of Done
+
+- The `agent_stuck` reflection path behaves identically, now built on the shared observer core (existing `reflection-triggers.test.ts` green).
+- The observer emits correctly-kinded needs from grant-denial, tool-surface/context overload, and repeated-success evidence, with token/zone evidence where the spec requires it.
+- Fingerprinting/dedupe is centralized; runtime reflection, periodic review, and manual assessment converge on one key contract; no duplicate needs within a sweep.
+- Reflection loop guards (depth + dedupe) are preserved and tested.
+- The periodic sweep resolves owner to superuser + executor Agent; the per-turn hook inherits user context.
+- No skills, prompts, grants, policies, routes, or code are mutated by the observer.
+- `mcp-governed-execute.ts` is untouched (owned by Work Case Wave 1).
+- EA grounding is added by extending the shared manifest shape, no new modeling tables.
+- Branch pushed and opened as a regular ready-for-review PR only after gates are green.

--- a/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
+++ b/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
@@ -6,8 +6,8 @@
 - **Primary audience:** DPF platform architecture, AI workforce, TAK runtime, Build Studio
 - **Operator prompt:** Review the Ornith video transcript and product/model, then identify how to incorporate the main ideas into DPF without using the raw "scaffold" analogy.
 - **Source transcript:** Operator-provided local transcript at `C:/Users/Mark Bodman/OneDrive/Desktop/ornithOverview.txt` (not committed).
-- **Related DPF epics from live backlog:** `EP-8AF1C996` Progressive Autonomy & Trust Graduation, `EP-MODEL-TIER-ROUTING`, `EP-COWORKER-INTERACTIVITY`, `EP-AI-OPSMAP`, `EP-UNIFIED-TRACKING`.
-- **Composes with:** `docs/architecture/trusted-ai-kernel.md`, `docs/architecture/ai-agent-meta-model.md`, `docs/architecture/local-llm-build-engine.md`, `docs/architecture/context-engineering-standards.md`, `docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md`, `docs/superpowers/specs/2026-06-22-build-studio-model-tier-routing-design.md`.
+- **Related DPF epics from live backlog:** `EP-8AF1C996` Progressive Autonomy & Trust Graduation, `EP-2984B02B` Work Case / Company Work Management, `EP-MODEL-TIER-ROUTING`, `EP-COWORKER-INTERACTIVITY`, `EP-AI-OPSMAP`, `EP-ATTENTION-SURFACE`, `EP-UNIFIED-TRACKING`.
+- **Composes with:** `docs/architecture/trusted-ai-kernel.md`, `docs/architecture/ai-agent-meta-model.md`, `docs/architecture/local-llm-build-engine.md`, `docs/architecture/context-engineering-standards.md`, `docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md`, `docs/superpowers/specs/2026-06-22-build-studio-model-tier-routing-design.md`, and the parallel Work Case design at `docs/superpowers/specs/2026-06-27-work-management-architecture-design.md` plus `docs/superpowers/plans/2026-06-27-work-case-wave-0.md`.
 
 ## 1. Executive Decision
 
@@ -102,6 +102,7 @@ DPF already has most of the runtime substrate:
 - `ToolExecution` already links agent, user, thread, route, task run, skill, cost, tokens, and result.
 - `ExecutionPlan` is a durable per-loop plan artifact that survives compaction.
 - `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, and `ImprovementSignal` already form a reviewable need-to-backlog path.
+- The parallel Work Case architecture defines the company-facing work object, policy envelope, handoff grammar, governed Action write path, and `ReceiptEnvelope`. Adaptive playbooks must attach to that object for company/business work instead of creating another work manager.
 - The AI Agent Meta-Model already says an agent is governed identity plus model routing, tools, prompts, skills, authority, lifecycle, and audit.
 - TAK already says model capability does not create trustworthy agency.
 - Context engineering metrics already measure tool-surface and context pressure.
@@ -121,7 +122,15 @@ Conceptual shape:
 type WorkPattern = {
   patternKey: string;
   ownerAgentId: string;
-  scope: "agent" | "route" | "skill" | "build-phase" | "activity" | "risk-class";
+  scope:
+    | "agent"
+    | "route"
+    | "skill"
+    | "build-phase"
+    | "activity"
+    | "risk-class"
+    | "case-type"
+    | "case-transition";
   version: number;
   status: "observed" | "candidate" | "approved" | "active" | "retired";
   objectiveShape: string;
@@ -132,11 +141,22 @@ type WorkPattern = {
   retryPolicy: unknown;
   escalationPolicy: unknown;
   riskProfile: unknown;
+  workCaseBinding?: {
+    caseType?: string;
+    transitionKey?: string;
+    governedActionKey?: string;
+    authorityMode?: "autonomous" | "on-behalf-of" | "authenticated-inbound";
+    sponsorPrincipalId?: string;
+    receiptPolicy?: "governed-action" | "observed-event";
+  };
   sourceEvidence: Array<{
     taskRunId?: string;
     toolExecutionId?: string;
     improvementSignalId?: string;
     backlogItemId?: string;
+    workCaseRef?: string;
+    receiptId?: string;
+    decisionInteractionId?: string;
   }>;
 };
 ```
@@ -160,19 +180,36 @@ Existing kinds are `tool`, `skill`, `grant`, `model`, `memory`, `data`, `ui_surf
 
 For systemic playbooks, use the existing kinds first. Later, consider splitting `boundary` into closed subtypes in evidence JSON rather than expanding the enum prematurely. The key improvement is not more enum values; it is better triggers and evidence.
 
+### 5.4 Relationship To Work Case
+
+The Work Case effort and this playbook effort are adjacent but not interchangeable:
+
+- **Work Case / Work Packet** is the durable company-facing coordination object for business work. It owns case identity, policy envelope, handoff grammar, source projection, governed Actions, receipts, sponsors, authority mode, and A2A-aligned lifecycle vocabulary.
+- **Governed Adaptive Playbook / Work Pattern** is the reusable method by which an agent handles a task class, route, case type, or transition. It can propose changes to skills, prompts, tool surfaces, data prefetch, model routes, or procedural code.
+
+When a playbook applies to company/business work, it must bind to the Work Case substrate:
+
+- A case-bound playbook references `caseType`, transition key, policy envelope, sponsor/authority mode, and expected receipt.
+- A proposal to change a case state is not a free-form update; it becomes a candidate governed Action or staged-before-commit transition in the Work Case grammar.
+- The playbook's evidence must include Work Case source references, `ReceiptEnvelope` references where available, and related `DecisionInteraction` records.
+- A playbook can suggest how to assemble a compact Work Packet for a delegate, but the packet remains a Work Case artifact, not a separate playbook-owned object.
+- Agent capability advertisement should converge with the Work Case `AgentCard`-equivalent descriptor: the playbook describes method; the capability card describes what the actor can accept and under what security/authority conditions.
+
+This prevents duplicate surfaces: Work Case is where company work lives; adaptive playbooks are how agents improve the method for doing that work.
+
 ## 6. Systemic Proposal Loop
 
 The loop should run both event-triggered and periodic reviews.
 
 ```mermaid
 flowchart LR
-  A["TaskRun executes under TAK"] --> B["Evidence: ToolExecution, AgentMessage, TaskArtifact, review result, context metrics"]
+  A["TaskRun or Work Case action executes under TAK"] --> B["Evidence: ToolExecution, AgentMessage, TaskArtifact, review result, context metrics, ReceiptEnvelope"]
   B --> C["Pattern Observer"]
   C --> D["Coworker Self-Assessment"]
   D --> E["Capability Need or Pattern Candidate"]
   E --> F["Human/reviewer gate"]
-  F --> G["Shadow trial or backlog item"]
-  G --> H["Approved skill, prompt, tool, policy, UI, or code change"]
+  F --> G["Shadow trial, backlog item, or staged Work Case transition"]
+  G --> H["Approved skill, prompt, tool, policy, UI, governed Action, or code change"]
   H --> I["Trust-state and evidence ledger update"]
 ```
 
@@ -191,6 +228,7 @@ Add pattern-observer triggers for:
 - repeated approval of the same action envelope,
 - unresolved missing data field,
 - recurring UI handoff to another page,
+- recurring Work Case transition friction, including `input-required`, `auth-required`, sponsor/accountability gaps, missing receipt coverage, or policy-envelope failures,
 - build/review/ship gate failures with the same suspected root cause.
 
 ### 6.2 Periodic Agent Reviews
@@ -218,9 +256,10 @@ No candidate changes runtime behavior immediately.
 2. **Proposed:** create `CoworkerSelfAssessment` plus `CoworkerCapabilityNeed` or a pattern-candidate evidence record.
 3. **Filed:** project accepted needs into backlog through the existing intake path.
 4. **Shadowed:** where relevant, run the candidate as a suggestion only and compare with current behavior.
-5. **Approved:** human/reviewer gate accepts the skill, prompt, grant, model-route, UI, policy, or code change.
-6. **Activated:** versioned change becomes active for a scoped agent/activity/risk class.
-7. **Proceduralized:** repeated high-confidence behavior moves from prompt/skill to code and invariant guard.
+5. **Case-staged:** if the candidate affects company work, express it as a staged Work Case proposal or governed Action candidate. It must carry sponsor/authority-mode context and expected receipt coverage before it can affect a case.
+6. **Approved:** human/reviewer gate accepts the skill, prompt, grant, model-route, UI, policy, governed Action, or code change.
+7. **Activated:** versioned change becomes active for a scoped agent/activity/risk/case class.
+8. **Proceduralized:** repeated high-confidence behavior moves from prompt/skill to code and invariant guard.
 
 This composes directly with `EP-8AF1C996`: trust is earned per coworker x activity x risk, and regulatory/compliance ceilings still cap autonomy independent of success rates.
 
@@ -257,11 +296,13 @@ Work:
 - Use `TaskRun.repeatedPatternKey` for queryability.
 - Add a read model that groups runs by pattern key, agent, route, outcome, and risk.
 - Store candidate diffs in evidence JSON on the need or improvement signal first.
+- When Work Case Wave 0 is available, include optional case references from the Work Case source registry/status projection rather than inventing playbook-owned case classification.
 
 Acceptance:
 
 - Operators can see repeated patterns by agent and route.
 - Candidate evidence links back to TaskRuns and ToolExecutions.
+- Case-bound candidates link to Work Case source references and receipt/decision evidence when present.
 - No new table is introduced until UI/query pressure justifies it.
 
 ### Slice 3: Shadow and Trust Integration
@@ -288,13 +329,14 @@ Goal: make the capability feel useful, calm, and operational.
 Recommended placement:
 
 - Add a **Needs and Playbooks** tab to the AI Workforce agent detail.
-- Add a summarized lane to AI Operations Map for active playbook proposals and blocked needs.
-- Keep backlog as the work record; this UI is the evidence/review surface.
+- Add a summarized lane to AI Operations Map for active agent-level playbook proposals and blocked needs.
+- For company/business work, surface case-bound proposals inside the Work Case detail or Workspace attention lens once that substrate exists. Do not create a separate case-work dashboard here.
+- Keep backlog as the product work record and Work Case as the company work record; this UI is an evidence/review surface, not a third state manager.
 
 Layout:
 
 - Left rail: agents and routes with counts for open needs, candidate playbooks, shadow trials, accepted changes.
-- Center pane: selected playbook timeline, evidence list, and before/after diff.
+- Center pane: selected playbook timeline, evidence list, before/after diff, and Work Case/receipt links when case-bound.
 - Right inspector: action buttons for "run shadow trial", "file backlog item", "approve as skill update", "approve as code candidate", "defer", "mark duplicate", "retire".
 
 Design rules:
@@ -305,6 +347,8 @@ Design rules:
 - Use icons for actions and text only where commands need clarity.
 - Never show "scaffold" in the UI. Use "playbook", "working method", "pattern", and "proposal".
 - Show risk/autonomy ceiling beside every approval affordance.
+- Do not expose `WorkCapsule`, `DecisionInteraction`, or `ReceiptEnvelope` as primary product terms outside admin/audit context; show them as evidence drill-downs.
+- Do not ship case-bound playbook controls before the Work Case governed write path and receipt-coverage guard are available. Agent-level review can ship earlier, but case state changes must wait for enforcement.
 
 ### Slice 5: Ornith Model Evaluation Lane
 
@@ -334,15 +378,18 @@ Allowed refactoring:
 - Extract shared pattern-observer primitives from `reflection-triggers.ts` instead of growing a second reflection subsystem.
 - Centralize capability-need fingerprinting and dedupe so runtime reflections, periodic reviews, and manual assessments converge.
 - Define typed helpers for `TaskRun.a2aMetadata.workPattern` and `repeatedPatternKey`.
+- Align case-bound pattern metadata with the Work Case source registry, status projection, and receipt envelope once `EP-2984B02B` Wave 0/1 lands.
 - Separate UI projection from persistence; do not make the Operations Map own playbook state.
 - Reuse existing `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, `ImprovementSignal`, `TaskRun`, and `ToolExecution` before adding tables.
 - Align evidence contracts with context-economy metrics and model-routing evidence.
+- Reuse Work Case `ReceiptEnvelope` and governed Action concepts for case-bound proposals; do not introduce a playbook-specific receipt or action ledger.
 
 Not allowed under this budget:
 
 - Rewriting AI Workforce navigation.
 - Replacing the coworker runtime.
 - Adding a parallel audit/event ledger.
+- Adding a parallel Work Case, Work Packet, receipt, handoff, or case-state model.
 - Expanding model routing beyond the existing model-tier routing epic.
 - Creating prompt-only shortcuts that cannot be audited.
 
@@ -353,20 +400,24 @@ Hard constraints:
 - Models may propose playbook changes; they may not activate them.
 - Tool grants, HITL tiers, prompt templates, skills, and model routes remain governed platform resources.
 - Every proposal must include evidence and a suggested evaluation method.
+- Case-bound proposals must include Work Case source references, sponsor/authority-mode context, and expected `ReceiptEnvelope` coverage before they can affect state.
+- Consequential case transitions must execute only through Work Case governed Actions. A playbook may propose an Action candidate; it may not write directly to the backing `WorkItem`, `WorkCapsule`, source record, or case projection.
 - A rejected candidate must remain visible enough to prevent the same proposal from resurfacing endlessly.
 - Regulatory/compliance autonomy ceilings override trust graduation.
+- Work Case terminal-state sealing applies to case-bound playbooks: follow-on work creates a linked case/context rather than reopening a closed case in place.
 - Context/tool-surface improvements must honor `docs/architecture/context-engineering-standards.md`.
 - Durable learnings route to the shared commons per AGENTS.md; local-only learning is a staging state, not the destination.
 
 ## 10. Implementation Plan Summary
 
 1. **Spec and backlog alignment:** this document, then link it to the relevant epic/backlog items or create a focused item under the best existing epic.
-2. **Observer foundation:** extract pattern observation and emit richer needs through existing assessment/backlog flow.
-3. **Metadata stamping:** add typed work-pattern metadata on TaskRuns and pattern grouping read models.
-4. **Review UI:** add the Needs and Playbooks operator surface.
-5. **Shadow evaluation:** integrate with Decision-Shadow Ledger and trust graduation.
-6. **Model lane:** evaluate Ornith as a provider/model candidate through opencode and ModelProfile scoring.
-7. **Proceduralization:** turn repeated approved playbooks into code and invariant guards.
+2. **Work Case alignment:** keep agent-level observers independent, but sequence case-bound proposals behind Work Case Wave 0 source/status projection and Work Case Wave 1 governed Action/receipt coverage.
+3. **Observer foundation:** extract pattern observation and emit richer needs through existing assessment/backlog flow.
+4. **Metadata stamping:** add typed work-pattern metadata on TaskRuns and pattern grouping read models, with optional Work Case references when available.
+5. **Review UI:** add the Needs and Playbooks operator surface for agent-level proposals; case-bound proposal controls land in Work Case/Workspace after enforcement.
+6. **Shadow evaluation:** integrate with Decision-Shadow Ledger, Work Case staged transitions where relevant, and trust graduation.
+7. **Model lane:** evaluate Ornith as a provider/model candidate through opencode and ModelProfile scoring.
+8. **Proceduralization:** turn repeated approved playbooks into code and invariant guards.
 
 ## 11. Test and Verification Strategy
 
@@ -384,12 +435,15 @@ Integration tests:
 - ToolExecution and TaskRun evidence link to submitted needs.
 - Submitted needs still project into backlog.
 - Candidate proposals do not mutate SkillDefinition, prompts, grants, or routing.
+- Case-bound candidates do not mutate WorkItem, WorkCapsule, source records, or case state outside the Work Case governed Action path.
+- Case-bound candidate evidence references ReceiptEnvelope/DecisionInteraction records when present and distinguishes governed-Action evidence from observed-event evidence.
 - Shadow comparison records evidence without changing live behavior.
 
 UX verification:
 
 - AI Workforce agent detail shows open needs and candidate playbooks.
 - AI Operations Map summarizes active proposals without hiding existing failures.
+- Work Case/Workspace surfaces, when implemented, show case-bound playbook proposals as evidence/actions on the case rather than a separate dashboard.
 - Long playbook names, evidence lists, and action labels fit on mobile and desktop.
 - Approval actions show HITL/risk ceiling context.
 
@@ -406,12 +460,15 @@ Model evaluation:
 3. **When should a WorkPattern table be added?** Recommendation: after Slice 2 proves query shapes; use TaskRun metadata first.
 4. **Should capability need kinds expand?** Recommendation: not initially. Use existing kinds plus structured evidence JSON.
 5. **Should Ornith be a Build Studio default candidate?** Recommendation: no. Evaluate first, then route by ModelProfile evidence and model-tier policy.
+6. **Should case-bound playbook proposals wait for Work Case enforcement?** Recommendation: yes for any consequential transition. Agent-level observation can ship earlier, but case state, handoff, authority, or external side-effect changes must wait for governed Actions and receipt coverage.
 
 ## 13. Success Criteria
 
 - Every major coworker can produce evidence-backed needs from both failures and successful repetition.
 - Operators can review an agent's proposed needs and playbook changes without reading raw logs.
+- Case-bound proposals appear on Work Case/Workspace evidence surfaces and produce or reference receipts; they do not create a parallel work surface.
 - Approved playbook changes are versioned, scoped, and auditable.
+- Consequential case changes flow through governed Actions with sponsor/authority-mode and receipt evidence.
 - Rejected proposals do not churn forever.
 - Repeated successful prompt/skill behavior can graduate to code with invariant guards.
 - Model candidates such as Ornith are evaluated through DPF evidence before routing changes.

--- a/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
+++ b/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
@@ -1,0 +1,418 @@
+# Governed Adaptive Playbooks - Translating Ornith-Style Self-Improving Work into DPF
+
+- **Status:** Design analysis
+- **Date:** 2026-06-27
+- **Author:** Codex, operator-directed
+- **Primary audience:** DPF platform architecture, AI workforce, TAK runtime, Build Studio
+- **Operator prompt:** Review the Ornith video transcript and product/model, then identify how to incorporate the main ideas into DPF without using the raw "scaffold" analogy.
+- **Source transcript:** Operator-provided local transcript at `C:/Users/Mark Bodman/OneDrive/Desktop/ornithOverview.txt` (not committed).
+- **Related DPF epics from live backlog:** `EP-8AF1C996` Progressive Autonomy & Trust Graduation, `EP-MODEL-TIER-ROUTING`, `EP-COWORKER-INTERACTIVITY`, `EP-AI-OPSMAP`, `EP-UNIFIED-TRACKING`.
+- **Composes with:** `docs/architecture/trusted-ai-kernel.md`, `docs/architecture/ai-agent-meta-model.md`, `docs/architecture/local-llm-build-engine.md`, `docs/architecture/context-engineering-standards.md`, `docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md`, `docs/superpowers/specs/2026-06-22-build-studio-model-tier-routing-design.md`.
+
+## 1. Executive Decision
+
+DPF should not copy Ornith's "self-scaffolding" language or make models self-authorize new operating procedures. The DPF-native version is:
+
+> Agents propose improvements to their own working methods as **governed adaptive playbooks**. TAK observes the evidence, stores proposals as reviewable platform work, runs them in shadow where appropriate, and promotes only approved, versioned changes into skills, prompts, policies, tools, or procedural code.
+
+The product language should be **Living Playbooks** when shown to operators and **Governed Work Patterns** in architecture and code. The word "scaffold" is useful only when discussing Ornith research.
+
+Ornith itself should enter DPF through the existing local-model and opencode evaluation lane, not as a prerequisite for this capability. Its most important lesson is conceptual: high-performing agentic systems improve the method of work, not only the final answer.
+
+## 2. Why This Matters
+
+The current DPF learning loop exists, but it is too narrow for the operator's intent. Today the most concrete runtime path is reactive:
+
+- `apps/web/lib/tak/reflection-triggers.ts` inspects `PlatformIssueReport(type="agent_stuck")` rows and emits a proactive reflection `TaskRun`.
+- That reflection creates a `CoworkerSelfAssessment`, a `CoworkerCapabilityNeed(kind="skill")`, and a deduped `ImprovementSignal`.
+- `apps/web/lib/coworker-self-assessment/assessment-service.ts` immediately projects submitted needs into backlog items through the shared intake front door.
+
+That is good, but it is not systemic. It mainly notices one failure shape: repeated tool use after getting stuck. The stronger DPF loop should also learn from:
+
+- repeated successful workflows that should become playbooks or code,
+- recurring human approvals that could safely move down the HITL ladder,
+- context pressure and tool-surface overload,
+- model-tier mismatches,
+- missing grants, data, memory, UI affordances, or policy boundaries,
+- review failures that recur by phase or coworker,
+- manual operator corrections that expose a broken working method.
+
+The target behavior is every agent having a structured, governed way to say: "Here is what I need to perform this class of work better, here is the evidence, here is the safest proposed change, and here is how to evaluate it."
+
+## 3. Research and Benchmarking
+
+### 3.1 Ornith reference
+
+Official DeepReinforce material describes Ornith-1.0 as an open-source coding model family trained with a self-improving loop that learns both task solutions and the task-specific harness/process that guides those solutions. DeepReinforce says the "scaffold" co-evolves with the model policy, with reward flowing to both the method and the answer. Source: [DeepReinforce Ornith-1.0 blog](https://deep-reinforce.com/ornith_1_0.html).
+
+Hugging Face model cards list 9B, 31B, 35B, and 397B variants, MIT licensing, OpenAI-compatible serving recipes through vLLM/SGLang, and Docker Model Runner examples for the 9B and 397B variants. The 9B card also shows usage through agent harnesses and coding CLIs, including opencode. Sources: [Ornith-1.0-9B](https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B), [Ornith-1.0-397B-FP8](https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B-FP8).
+
+DeepReinforce publishes strong benchmark tables for 9B, 35B, and 397B. Treat those as vendor-reported evaluation data until reproduced inside DPF's own build and task harnesses.
+
+### 3.2 Open-source comparables
+
+| Project | Operating model readout | DPF lesson |
+|---|---|---|
+| Ornith | Training objects are roughly task, generated method, solution rollout, monitor/judge signal, reward. The method is not fixed; it is learned. | DPF should make the working method a first-class, evidence-bearing object, but promotion stays governed. |
+| OpenHands | Public SDK/docs expose agent, runtime, LLM, conversation, and OpenAI-compatible endpoint concepts. It separates an agent harness from the model endpoint. Sources: [OpenHands repository](https://github.com/OpenHands/openhands), [OpenHands SDK docs](https://docs.openhands.dev/sdk). | Keep DPF's agent identity, tool surface, runtime, and model-routing policy separate. Model capability alone is not agency. |
+| opencode | Open-source terminal coding agent with configurable providers, shell/tool execution, and OpenAI-compatible provider support. DPF already uses it as the local build engine. Sources: [opencode docs](https://opencode.ai/docs/config/), [opencode providers](https://opencode.ai/docs/providers/), `docs/architecture/local-llm-build-engine.md`. | Evaluate Ornith through the existing opencode lane. Do not create a second coding-agent substrate just to test a model. |
+
+### 3.3 Commercial comparables
+
+| Product | Public operating signal | DPF lesson |
+|---|---|---|
+| Claude Code | Anthropic describes a coding agent that works in terminal/IDE, runs commands, edits files, and has hooks, subagents, checkpoints, and permission frameworks. Sources: [Claude Code product page](https://claude.com/product/claude-code), [Anthropic autonomy update](https://www.anthropic.com/news/enabling-claude-code-to-work-more-autonomously). | Strong autonomy still needs permissions, checkpoints, hooks, and visible control planes. |
+| Cursor | Cursor exposes persistent rules at project, team, and user scopes, plus `AGENTS.md`. Source: [Cursor Rules docs](https://cursor.com/docs/rules). | Persistent working instructions matter, but DPF should make them evidence-backed and reviewable, not just editable text. |
+| Devin | Devin presents autonomous planning, coding, testing, ticket work, and learning codebase/tribal knowledge. Sources: [Devin site](https://devin.ai/), [Devin intro docs](https://docs.devin.ai/get-started/devin-intro). | The attractive product promise is a self-improving coworker. DPF's differentiator is that improvement is inspectable, local-first, and governed. |
+
+### 3.4 Patterns Adopted and Rejected
+
+Adopt:
+
+- Treat the method of work as improvable.
+- Separate model endpoint, harness, memory, tools, permissions, and evidence.
+- Prefer local/open model evaluation where it fits DPF's sovereignty posture.
+- Use benchmarks as an input, then reproduce on DPF work.
+- Make improvement proposals easy for operators to inspect and accept.
+
+Reject:
+
+- Letting a model directly rewrite its own prompts, skills, grants, or policies.
+- Turning "scaffold" into DPF product language.
+- Bypassing TAK because a model benchmark looks strong.
+- Treating a prompt-only playbook as durable platform learning.
+- Making Ornith adoption a dependency for the playbook capability.
+
+## 4. DPF Translation
+
+| Ornith concept | DPF-native translation |
+|---|---|
+| Learned scaffold | Governed Work Pattern / Living Playbook |
+| Solution rollout | TaskRun, ToolExecution, AgentMessage, TaskArtifact evidence |
+| Reward | Evidence-weighted outcome score, review result, trust-state movement |
+| RL mutation | Candidate playbook revision, never live self-modification |
+| Fixed outer boundary | TAK directives, approved operating profile, grants, HITL tiers |
+| Deterministic monitor | governed tool execution, tool grants, runtime hooks, build gates |
+| Frozen judge | reviewer/eval gate, principle decision, phase review, shadow ledger |
+| Model family | ModelProfile and provider routing, possibly via opencode |
+
+DPF already has most of the runtime substrate:
+
+- `TaskRun` has `a2aMetadata` and `repeatedPatternKey`, which can stamp work-pattern identity without a new table in Slice 1.
+- `ToolExecution` already links agent, user, thread, route, task run, skill, cost, tokens, and result.
+- `ExecutionPlan` is a durable per-loop plan artifact that survives compaction.
+- `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, and `ImprovementSignal` already form a reviewable need-to-backlog path.
+- The AI Agent Meta-Model already says an agent is governed identity plus model routing, tools, prompts, skills, authority, lifecycle, and audit.
+- TAK already says model capability does not create trustworthy agency.
+- Context engineering metrics already measure tool-surface and context pressure.
+- opencode already gives DPF a local OpenAI-compatible coding-agent lane.
+
+The missing object is not another model. The missing object is a reusable, governed method record.
+
+## 5. Proposed Concept Model
+
+### 5.1 Work Pattern
+
+A **Work Pattern** is the reusable method for a class of work. It is not the same as a skill, prompt, plan, tool, or route, though it can influence each of them after approval.
+
+Conceptual shape:
+
+```ts
+type WorkPattern = {
+  patternKey: string;
+  ownerAgentId: string;
+  scope: "agent" | "route" | "skill" | "build-phase" | "activity" | "risk-class";
+  version: number;
+  status: "observed" | "candidate" | "approved" | "active" | "retired";
+  objectiveShape: string;
+  planTemplate: unknown;
+  toolPolicyHints: unknown;
+  memoryInputs: unknown;
+  evidenceContract: unknown;
+  retryPolicy: unknown;
+  escalationPolicy: unknown;
+  riskProfile: unknown;
+  sourceEvidence: Array<{
+    taskRunId?: string;
+    toolExecutionId?: string;
+    improvementSignalId?: string;
+    backlogItemId?: string;
+  }>;
+};
+```
+
+Slice 1 should avoid adding this as a heavy new Prisma model. Start with a typed projection in `TaskRun.a2aMetadata.workPattern` plus `repeatedPatternKey`, then promote to a model only when the review UI and query paths prove the required indexes.
+
+### 5.2 Pattern Candidate
+
+A **Pattern Candidate** is a proposed new or revised playbook. It is created from evidence, not from model preference.
+
+Candidate examples:
+
+- "When the Build Studio planner fails security review twice for feature builds, inject the design-review failure into forced regeneration instead of re-reviewing the same artifact."
+- "When an AI Ops coworker sees context-pressure overload, first load only the routing-health and provider-status tool pack."
+- "When a support coworker repeatedly asks for the same customer-site fields, add a UI affordance or data prefetch."
+- "When a local model overflows during opencode on medium tasks, route only mechanical subtasks to local and keep architecture/review on robust tier."
+
+### 5.3 Capability Need Categories
+
+Existing kinds are `tool`, `skill`, `grant`, `model`, `memory`, `data`, `ui_surface`, `boundary`, `prompt`, `convention`, `code`, and `other`.
+
+For systemic playbooks, use the existing kinds first. Later, consider splitting `boundary` into closed subtypes in evidence JSON rather than expanding the enum prematurely. The key improvement is not more enum values; it is better triggers and evidence.
+
+## 6. Systemic Proposal Loop
+
+The loop should run both event-triggered and periodic reviews.
+
+```mermaid
+flowchart LR
+  A["TaskRun executes under TAK"] --> B["Evidence: ToolExecution, AgentMessage, TaskArtifact, review result, context metrics"]
+  B --> C["Pattern Observer"]
+  C --> D["Coworker Self-Assessment"]
+  D --> E["Capability Need or Pattern Candidate"]
+  E --> F["Human/reviewer gate"]
+  F --> G["Shadow trial or backlog item"]
+  G --> H["Approved skill, prompt, tool, policy, UI, or code change"]
+  H --> I["Trust-state and evidence ledger update"]
+```
+
+### 6.1 Event Triggers
+
+Add pattern-observer triggers for:
+
+- repeated tool failure or repeated identical arguments,
+- tool denied by grant or missing capability,
+- context pressure in `strained` or `overload` zone,
+- tool-surface overload beyond the local 15-tool cliff,
+- model-tier mismatch or fallback,
+- repeated phase-review failure,
+- repeated human correction in the same route/activity,
+- repeated successful workflow with high manual ceremony,
+- repeated approval of the same action envelope,
+- unresolved missing data field,
+- recurring UI handoff to another page,
+- build/review/ship gate failures with the same suspected root cause.
+
+### 6.2 Periodic Agent Reviews
+
+Each agent should also have a periodic profile review after either:
+
+- N completed TaskRuns, or
+- seven days since the last profile review, whichever comes first.
+
+The review inspects recent `TaskRun`, `ToolExecution`, `CoworkerCapabilityNeed`, `ImprovementSignal`, token/context metrics, and review results. It must output:
+
+- top work patterns observed,
+- capability needs with evidence,
+- candidate playbook revisions,
+- candidates that should be proceduralized,
+- candidates that should not be automated due to risk or policy.
+
+This is the operator's requested systemic layer: not just "I got stuck," but "after looking at my own work, here are the changes I need."
+
+### 6.3 Promotion Ladder
+
+No candidate changes runtime behavior immediately.
+
+1. **Observed:** stamp `TaskRun.repeatedPatternKey` and pattern metadata.
+2. **Proposed:** create `CoworkerSelfAssessment` plus `CoworkerCapabilityNeed` or a pattern-candidate evidence record.
+3. **Filed:** project accepted needs into backlog through the existing intake path.
+4. **Shadowed:** where relevant, run the candidate as a suggestion only and compare with current behavior.
+5. **Approved:** human/reviewer gate accepts the skill, prompt, grant, model-route, UI, policy, or code change.
+6. **Activated:** versioned change becomes active for a scoped agent/activity/risk class.
+7. **Proceduralized:** repeated high-confidence behavior moves from prompt/skill to code and invariant guard.
+
+This composes directly with `EP-8AF1C996`: trust is earned per coworker x activity x risk, and regulatory/compliance ceilings still cap autonomy independent of success rates.
+
+## 7. Architecture Slices
+
+### Slice 1: Systemic Capability-Needs Observer
+
+Goal: broaden the existing reflection trigger without adding a large schema surface.
+
+Work:
+
+- Extract a `pattern-observer` module from the narrow runtime-issue reflection path.
+- Read recent `TaskRun`, `ToolExecution`, context metrics, review outcomes, and existing needs.
+- Emit `CoworkerSelfAssessment` with richer `rawPayload`.
+- Emit needs using existing kinds.
+- Deduplicate by agent, route, kind, normalized need, and evidence fingerprint.
+- Keep the current backlog projection path.
+
+Acceptance:
+
+- A repeated grant denial creates a `grant` need, not a generic `skill` need.
+- A repeated context-overload run creates a `prompt`, `tool`, or `data` need with token evidence.
+- A repeated successful manual workflow creates a `code` or `convention` need for proceduralization.
+- Reflection loop guards still prevent self-trigger cascades.
+
+### Slice 2: Work Pattern Metadata and Candidate Projection
+
+Goal: make playbooks visible without committing to a premature table.
+
+Work:
+
+- Define a TypeScript schema for `TaskRun.a2aMetadata.workPattern`.
+- Stamp `patternKey`, `patternVersion`, and `patternSource` on runs that match a known or candidate pattern.
+- Use `TaskRun.repeatedPatternKey` for queryability.
+- Add a read model that groups runs by pattern key, agent, route, outcome, and risk.
+- Store candidate diffs in evidence JSON on the need or improvement signal first.
+
+Acceptance:
+
+- Operators can see repeated patterns by agent and route.
+- Candidate evidence links back to TaskRuns and ToolExecutions.
+- No new table is introduced until UI/query pressure justifies it.
+
+### Slice 3: Shadow and Trust Integration
+
+Goal: evaluate candidates without changing live autonomy.
+
+Work:
+
+- Connect candidate evaluation to the Decision-Shadow Ledger work in `BI-DE4BF92F`.
+- Compare current playbook vs candidate recommendation for bounded scenarios.
+- Record whether the candidate would have reduced tool calls, failures, manual touches, context load, or review failures.
+- Feed approved evidence into trust graduation only within the regulatory ceiling from `BI-40CD8ACD`.
+
+Acceptance:
+
+- A candidate can be rejected with evidence.
+- A candidate can be approved for a smaller scope before broad activation.
+- Trust-state movement is per coworker x activity x risk, not global.
+
+### Slice 4: Operator UI - Needs and Playbooks
+
+Goal: make the capability feel useful, calm, and operational.
+
+Recommended placement:
+
+- Add a **Needs and Playbooks** tab to the AI Workforce agent detail.
+- Add a summarized lane to AI Operations Map for active playbook proposals and blocked needs.
+- Keep backlog as the work record; this UI is the evidence/review surface.
+
+Layout:
+
+- Left rail: agents and routes with counts for open needs, candidate playbooks, shadow trials, accepted changes.
+- Center pane: selected playbook timeline, evidence list, and before/after diff.
+- Right inspector: action buttons for "run shadow trial", "file backlog item", "approve as skill update", "approve as code candidate", "defer", "mark duplicate", "retire".
+
+Design rules:
+
+- Use dense operational layout, not a marketing hero.
+- Avoid nested cards; use full-width bands and tables for scan-heavy review.
+- Use status tokens and existing report-kit primitives.
+- Use icons for actions and text only where commands need clarity.
+- Never show "scaffold" in the UI. Use "playbook", "working method", "pattern", and "proposal".
+- Show risk/autonomy ceiling beside every approval affordance.
+
+### Slice 5: Ornith Model Evaluation Lane
+
+Goal: decide whether Ornith is useful for DPF without entangling model adoption with playbook architecture.
+
+Work:
+
+- Run DPF's tool/provider evaluation pipeline for Ornith as an `ai_provider` and, where applicable, as a `docker_image` before any install-wide routing change.
+- Register Ornith candidates as `ModelProfile` rows only through the provider/model evaluation path.
+- For 9B/GGUF or DMR-compatible variants, test via Docker Model Runner or an OpenAI-compatible local endpoint.
+- For 35B/397B variants, treat as robust-tier or lab-only candidates unless local hardware supports them.
+- Run through opencode first for coding tasks, because DPF already gates local code-writing through opencode.
+- Measure DPF tasks: plan quality, tool fidelity, review pass rate, context behavior, cost/latency, and failure modes.
+
+Acceptance:
+
+- No routing change uses vendor benchmarks alone.
+- Evaluation writes to `ModelProfile`/routing evidence, not provider-level folklore.
+- Ornith can be recommended for local, robust, lab, or rejected status based on DPF evidence.
+
+## 8. Refactoring Budget
+
+The implementation should reserve **20 percent of the effort for refactoring**. Spend it on structural consolidation that makes this capability cleaner, not unrelated cleanup.
+
+Allowed refactoring:
+
+- Extract shared pattern-observer primitives from `reflection-triggers.ts` instead of growing a second reflection subsystem.
+- Centralize capability-need fingerprinting and dedupe so runtime reflections, periodic reviews, and manual assessments converge.
+- Define typed helpers for `TaskRun.a2aMetadata.workPattern` and `repeatedPatternKey`.
+- Separate UI projection from persistence; do not make the Operations Map own playbook state.
+- Reuse existing `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, `ImprovementSignal`, `TaskRun`, and `ToolExecution` before adding tables.
+- Align evidence contracts with context-economy metrics and model-routing evidence.
+
+Not allowed under this budget:
+
+- Rewriting AI Workforce navigation.
+- Replacing the coworker runtime.
+- Adding a parallel audit/event ledger.
+- Expanding model routing beyond the existing model-tier routing epic.
+- Creating prompt-only shortcuts that cannot be audited.
+
+## 9. Governance and Safety
+
+Hard constraints:
+
+- Models may propose playbook changes; they may not activate them.
+- Tool grants, HITL tiers, prompt templates, skills, and model routes remain governed platform resources.
+- Every proposal must include evidence and a suggested evaluation method.
+- A rejected candidate must remain visible enough to prevent the same proposal from resurfacing endlessly.
+- Regulatory/compliance autonomy ceilings override trust graduation.
+- Context/tool-surface improvements must honor `docs/architecture/context-engineering-standards.md`.
+- Durable learnings route to the shared commons per AGENTS.md; local-only learning is a staging state, not the destination.
+
+## 10. Implementation Plan Summary
+
+1. **Spec and backlog alignment:** this document, then link it to the relevant epic/backlog items or create a focused item under the best existing epic.
+2. **Observer foundation:** extract pattern observation and emit richer needs through existing assessment/backlog flow.
+3. **Metadata stamping:** add typed work-pattern metadata on TaskRuns and pattern grouping read models.
+4. **Review UI:** add the Needs and Playbooks operator surface.
+5. **Shadow evaluation:** integrate with Decision-Shadow Ledger and trust graduation.
+6. **Model lane:** evaluate Ornith as a provider/model candidate through opencode and ModelProfile scoring.
+7. **Proceduralization:** turn repeated approved playbooks into code and invariant guards.
+
+## 11. Test and Verification Strategy
+
+Unit tests:
+
+- pattern fingerprint normalization,
+- duplicate suppression,
+- trigger classification to capability-need kind,
+- work-pattern metadata parsing,
+- reflection loop guard preservation,
+- context/tool-surface signal extraction.
+
+Integration tests:
+
+- ToolExecution and TaskRun evidence link to submitted needs.
+- Submitted needs still project into backlog.
+- Candidate proposals do not mutate SkillDefinition, prompts, grants, or routing.
+- Shadow comparison records evidence without changing live behavior.
+
+UX verification:
+
+- AI Workforce agent detail shows open needs and candidate playbooks.
+- AI Operations Map summarizes active proposals without hiding existing failures.
+- Long playbook names, evidence lists, and action labels fit on mobile and desktop.
+- Approval actions show HITL/risk ceiling context.
+
+Model evaluation:
+
+- Ornith 9B through opencode on small DPF coding tasks.
+- Compare against current local qwen3-coder and robust-tier candidates.
+- Record plan quality, review pass/fail, tool fidelity, context overflow, latency, and cost.
+
+## 12. Open Decisions
+
+1. **Where should the first operator UI live?** Recommendation: AI Workforce agent detail first, Operations Map summary second.
+2. **Which agents should pilot systemic reviews?** Recommendation: Build specialist first because evidence density is high; AI Ops engineer second because model/tool/context needs are visible.
+3. **When should a WorkPattern table be added?** Recommendation: after Slice 2 proves query shapes; use TaskRun metadata first.
+4. **Should capability need kinds expand?** Recommendation: not initially. Use existing kinds plus structured evidence JSON.
+5. **Should Ornith be a Build Studio default candidate?** Recommendation: no. Evaluate first, then route by ModelProfile evidence and model-tier policy.
+
+## 13. Success Criteria
+
+- Every major coworker can produce evidence-backed needs from both failures and successful repetition.
+- Operators can review an agent's proposed needs and playbook changes without reading raw logs.
+- Approved playbook changes are versioned, scoped, and auditable.
+- Rejected proposals do not churn forever.
+- Repeated successful prompt/skill behavior can graduate to code with invariant guards.
+- Model candidates such as Ornith are evaluated through DPF evidence before routing changes.
+- The platform has a product-friendly analogy: living playbooks, not scaffolds.

--- a/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
+++ b/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
@@ -201,10 +201,10 @@ This prevents duplicate surfaces: Work Case is where company work lives; adaptiv
 
 Playbooks describe and improve *methods of work*, which is exactly what DPF's existing SysML v2 / ArchiMate EA substrate already models. This effort grounds in and communicates through that substrate (`EaElement`/`EaRelationship`/`EaView`, notations `archimate4`/`sysml2`, per the [ai-cockpit SysML note](../../architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md), [SysML v2 reference](../../Reference/sysml-v2.md), and [AI agent meta-model](../../architecture/ai-agent-meta-model.md)) rather than inventing a separate way to describe methods, processes, or agent authority. It must not add a parallel architecture/process-modeling mechanism — that is already on the "not allowed under this budget" list in §8.
 
-Concept-to-element mapping (with stable `infraCiKey` IDs, allocated to code via `sysml_allocates`):
+Concept-to-element mapping (with stable SysML keys, allocated to code via the seeded SysML2 `allocates` relationship):
 
 - **Work Pattern** → a SysML `action`/activity definition (`ACT-GAP-<patternKey>`) that allocates to the skills, prompts, tool packs, data prefetch, model routes, or procedural code it influences after approval. This makes "what a playbook changes" a traceable allocation, and lets `run_traversal_pattern blast_radius` show the impact of a candidate before activation.
-- **Promotion ladder** (observed → candidate → … → proceduralized) → a `state` machine (`SM-GAP-PROMOTION`) on the pattern, allocated to the promotion logic. No candidate changes runtime behavior until it reaches `active`.
+- **Promotion ladder** (observed → candidate → … → proceduralized) → in the foundation slice, a SysML `part_definition` containing `state` elements for `observed`, `candidate`, `approved`, `active`, and `retired`; no candidate changes runtime behavior until it reaches `active`.
 - **Pattern Candidate** → a proposed change carried as a `CoworkerActionEnvelope` (proposed → resolved) plus a `DecisionInteraction` at the approval gate (per §9), never a free-form mutation. Case-bound candidates additionally bind to the Work Case governed Action and `ReceiptEnvelope`.
 - **Evidence contract** → `verification_case` elements (`VC-GAP-*`) that cite the `TaskRun`/`ToolExecution`/receipt evidence proving a pattern's effect.
 - **Agent + governed authority** → the agent `part_definition` and `AgentGovernanceProfile` already in the substrate; the playbook proposes method changes within that authority, with the chain auditable via `run_traversal_pattern ai_oversight`.
@@ -436,6 +436,8 @@ Hard constraints:
 6. **Shadow evaluation:** integrate with Decision-Shadow Ledger, Work Case staged transitions where relevant, and trust graduation.
 7. **Model lane:** evaluate Ornith as a provider/model candidate through opencode and ModelProfile scoring.
 8. **Proceduralization:** turn repeated approved playbooks into code and invariant guards.
+
+Foundation implementation note: the first slice keeps playbooks as proposal metadata on existing substrates. `TaskRun.a2aMetadata.workPattern`, `TaskRun.repeatedPatternKey`, `CoworkerCapabilityNeed.readinessJson`, `CoworkerTurnMetric` context/tool telemetry, and the EA parity domain `workPatternArchitecture` carry the foundation without adding a WorkPattern table. `readinessJson` records `readyForReview`, `readyForCaseActivation`, and blockers; case-bound activation remains false unless source evidence, `governedActionKey`, `receiptPolicy`, and an approved/active pattern status are all present. The observer never emits activation commands or prompt, skill, grant, model-route, or Work Case mutation payloads.
 
 ## 11. Test and Verification Strategy
 

--- a/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
+++ b/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
@@ -100,7 +100,7 @@ DPF already has most of the runtime substrate:
 
 - `TaskRun` has `a2aMetadata` and `repeatedPatternKey`, which can stamp work-pattern identity without a new table in Slice 1.
 - `ToolExecution` already links agent, user, thread, route, task run, skill, cost, tokens, and result.
-- `ExecutionPlan` is a durable per-loop plan artifact that survives compaction.
+- `TaskRun.progressPayload` and `a2aMetadata` already persist per-loop plan/progress state that survives compaction. There is no separate `ExecutionPlan` Prisma model today, so durable plan state should ride on `TaskRun` metadata until query pressure justifies promoting it to a model.
 - `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, and `ImprovementSignal` already form a reviewable need-to-backlog path.
 - The parallel Work Case architecture defines the company-facing work object, policy envelope, handoff grammar, governed Action write path, and `ReceiptEnvelope`. Adaptive playbooks must attach to that object for company/business work instead of creating another work manager.
 - The AI Agent Meta-Model already says an agent is governed identity plus model routing, tools, prompts, skills, authority, lifecycle, and audit.
@@ -176,9 +176,9 @@ Candidate examples:
 
 ### 5.3 Capability Need Categories
 
-Existing kinds are `tool`, `skill`, `grant`, `model`, `memory`, `data`, `ui_surface`, `boundary`, `prompt`, `convention`, `code`, and `other`.
+Existing kinds are `tool`, `skill`, `grant`, `model`, `memory`, `data`, `ui_surface`, `boundary`, `prompt`, `convention`, `code`, and `other`. These are a closed string set defined in `apps/web/lib/coworker-self-assessment/types.ts`, not a Prisma enum, so refinement is a TypeScript-level change with no migration.
 
-For systemic playbooks, use the existing kinds first. Later, consider splitting `boundary` into closed subtypes in evidence JSON rather than expanding the enum prematurely. The key improvement is not more enum values; it is better triggers and evidence.
+For systemic playbooks, use the existing kinds first. Later, consider splitting `boundary` into closed subtypes in evidence JSON rather than widening the set prematurely. The key improvement is not more kind values; it is better triggers and evidence.
 
 ### 5.4 Relationship To Work Case
 
@@ -196,6 +196,20 @@ When a playbook applies to company/business work, it must bind to the Work Case 
 - Agent capability advertisement should converge with the Work Case `AgentCard`-equivalent descriptor: the playbook describes method; the capability card describes what the actor can accept and under what security/authority conditions.
 
 This prevents duplicate surfaces: Work Case is where company work lives; adaptive playbooks are how agents improve the method for doing that work.
+
+### 5.5 Architecture Grounding (SysML v2 / EA Substrate)
+
+Playbooks describe and improve *methods of work*, which is exactly what DPF's existing SysML v2 / ArchiMate EA substrate already models. This effort grounds in and communicates through that substrate (`EaElement`/`EaRelationship`/`EaView`, notations `archimate4`/`sysml2`, per the [ai-cockpit SysML note](../../architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md), [SysML v2 reference](../../Reference/sysml-v2.md), and [AI agent meta-model](../../architecture/ai-agent-meta-model.md)) rather than inventing a separate way to describe methods, processes, or agent authority. It must not add a parallel architecture/process-modeling mechanism — that is already on the "not allowed under this budget" list in §8.
+
+Concept-to-element mapping (with stable `infraCiKey` IDs, allocated to code via `sysml_allocates`):
+
+- **Work Pattern** → a SysML `action`/activity definition (`ACT-GAP-<patternKey>`) that allocates to the skills, prompts, tool packs, data prefetch, model routes, or procedural code it influences after approval. This makes "what a playbook changes" a traceable allocation, and lets `run_traversal_pattern blast_radius` show the impact of a candidate before activation.
+- **Promotion ladder** (observed → candidate → … → proceduralized) → a `state` machine (`SM-GAP-PROMOTION`) on the pattern, allocated to the promotion logic. No candidate changes runtime behavior until it reaches `active`.
+- **Pattern Candidate** → a proposed change carried as a `CoworkerActionEnvelope` (proposed → resolved) plus a `DecisionInteraction` at the approval gate (per §9), never a free-form mutation. Case-bound candidates additionally bind to the Work Case governed Action and `ReceiptEnvelope`.
+- **Evidence contract** → `verification_case` elements (`VC-GAP-*`) that cite the `TaskRun`/`ToolExecution`/receipt evidence proving a pattern's effect.
+- **Agent + governed authority** → the agent `part_definition` and `AgentGovernanceProfile` already in the substrate; the playbook proposes method changes within that authority, with the chain auditable via `run_traversal_pattern ai_oversight`.
+
+Keep it honest the same way Work Case does: derive current-state pattern/method elements from code and runtime evidence via the Design-Implementation Parity Engine, hand-author only target-state, surface drift as `EaConformanceIssue`, and anchor to IT4IT value streams. Communicate proposals through the existing EA tools (`query_ontology_graph`, `describe_ea_view`, `run_traversal_pattern`, `export_archimate`) so an operator sees a proposed method change grounded in the platform model, not just as a row in a review queue.
 
 ## 6. Systemic Proposal Loop
 
@@ -219,8 +233,7 @@ Add pattern-observer triggers for:
 
 - repeated tool failure or repeated identical arguments,
 - tool denied by grant or missing capability,
-- context pressure in `strained` or `overload` zone,
-- tool-surface overload beyond the local 15-tool cliff,
+- tool-surface pressure in the `caution` or `overload` zone (`ToolSurfaceZone` in `apps/web/lib/tak/context-economy-metrics.ts`), including overload beyond the local 15-tool selection cliff (`LOCAL_TOOL_SELECTION_CLIFF`),
 - model-tier mismatch or fallback,
 - repeated phase-review failure,
 - repeated human correction in the same route/activity,
@@ -237,6 +250,8 @@ Each agent should also have a periodic profile review after either:
 
 - N completed TaskRuns, or
 - seven days since the last profile review, whichever comes first.
+
+The periodic review runs as a proactive job. Its `TaskRun` ownership must resolve to `userId` = the install superuser and `executor` = the reviewing Agent — never a synthetic "system" actor — so the review's own evidence, costs, and any emitted needs are attributable under the same accountability rules as all other agent work.
 
 The review inspects recent `TaskRun`, `ToolExecution`, `CoworkerCapabilityNeed`, `ImprovementSignal`, token/context metrics, and review results. It must output:
 
@@ -383,6 +398,7 @@ Allowed refactoring:
 - Reuse existing `CoworkerSelfAssessment`, `CoworkerCapabilityNeed`, `ImprovementSignal`, `TaskRun`, and `ToolExecution` before adding tables.
 - Align evidence contracts with context-economy metrics and model-routing evidence.
 - Reuse Work Case `ReceiptEnvelope` and governed Action concepts for case-bound proposals; do not introduce a playbook-specific receipt or action ledger.
+- Register Work Pattern/promotion/evidence as elements in the existing EA/SysML substrate (`ACT-GAP-*`, `SM-GAP-PROMOTION`, `VC-GAP-*`) with allocations to code, reusing the parity engine and conformance tooling.
 
 Not allowed under this budget:
 
@@ -390,6 +406,7 @@ Not allowed under this budget:
 - Replacing the coworker runtime.
 - Adding a parallel audit/event ledger.
 - Adding a parallel Work Case, Work Packet, receipt, handoff, or case-state model.
+- Adding a parallel architecture-, process-, or method-modeling mechanism instead of using the existing SysML v2 / ArchiMate EA substrate and IT4IT value streams.
 - Expanding model routing beyond the existing model-tier routing epic.
 - Creating prompt-only shortcuts that cannot be audited.
 
@@ -398,6 +415,7 @@ Not allowed under this budget:
 Hard constraints:
 
 - Models may propose playbook changes; they may not activate them.
+- Every promotion-ladder approval gate is recorded as a `DecisionInteraction`, so playbook promotion shares the one governed decision ledger with Work Case Actions and WWMD/WWWD/WSID rather than inventing a separate approval log. The decision scope (platform / company / job-activity) follows the playbook's scope: a build-phase or skill playbook is a platform (WWMD) decision; a case-type playbook for company work is a company (WWWD) decision.
 - Tool grants, HITL tiers, prompt templates, skills, and model routes remain governed platform resources.
 - Every proposal must include evidence and a suggested evaluation method.
 - Case-bound proposals must include Work Case source references, sponsor/authority-mode context, and expected `ReceiptEnvelope` coverage before they can affect state.
@@ -410,7 +428,7 @@ Hard constraints:
 
 ## 10. Implementation Plan Summary
 
-1. **Spec and backlog alignment:** this document, then link it to the relevant epic/backlog items or create a focused item under the best existing epic.
+1. **Spec and backlog alignment:** this document, then link it to the relevant epic/backlog items or create a focused item under the best existing epic. Foundation plan: [`docs/superpowers/plans/2026-06-27-governed-adaptive-playbooks-foundation.md`](../plans/2026-06-27-governed-adaptive-playbooks-foundation.md).
 2. **Work Case alignment:** keep agent-level observers independent, but sequence case-bound proposals behind Work Case Wave 0 source/status projection and Work Case Wave 1 governed Action/receipt coverage.
 3. **Observer foundation:** extract pattern observation and emit richer needs through existing assessment/backlog flow.
 4. **Metadata stamping:** add typed work-pattern metadata on TaskRuns and pattern grouping read models, with optional Work Case references when available.
@@ -461,6 +479,7 @@ Model evaluation:
 4. **Should capability need kinds expand?** Recommendation: not initially. Use existing kinds plus structured evidence JSON.
 5. **Should Ornith be a Build Studio default candidate?** Recommendation: no. Evaluate first, then route by ModelProfile evidence and model-tier policy.
 6. **Should case-bound playbook proposals wait for Work Case enforcement?** Recommendation: yes for any consequential transition. Agent-level observation can ship earlier, but case state, handoff, authority, or external side-effect changes must wait for governed Actions and receipt coverage.
+7. **Should a Pattern Candidate's promotion itself be tracked as a (meta) Work Case?** The promotion ladder (observed → … → proceduralized) is governed work with its own evidence, decisions, and accountable approver — i.e. exactly what Work Case models. Recommendation: keep promotion as `TaskRun` metadata plus `CoworkerSelfAssessment`/`CoworkerCapabilityNeed` for Slices 1–2 (no premature object), but treat "promotion-as-Work-Case" as the convergence endpoint once Work Case enforcement and the attention surface exist, so playbook review gets uniform receipts and "needs you" attention instead of a bespoke review queue. Revisit at Slice 4.
 
 ## 13. Success Criteria
 

--- a/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
+++ b/docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md
@@ -406,6 +406,7 @@ Not allowed under this budget:
 - Replacing the coworker runtime.
 - Adding a parallel audit/event ledger.
 - Adding a parallel Work Case, Work Packet, receipt, handoff, or case-state model.
+- Making a second edit to the Work Case governed-execution receipt seam — the `mcp-governed-execute.ts` `context.workCase` / `work-case-governed-action` receipt derivation is owned by Work Case Wave 1 (`BI-D633F7AF`). Case-bound playbook proposals consume that seam; they do not re-implement it.
 - Adding a parallel architecture-, process-, or method-modeling mechanism instead of using the existing SysML v2 / ArchiMate EA substrate and IT4IT value streams.
 - Expanding model routing beyond the existing model-tier routing epic.
 - Creating prompt-only shortcuts that cannot be audited.

--- a/packages/db/prisma/migrations/20260627141500_add_coworker_turn_context_economy/migration.sql
+++ b/packages/db/prisma/migrations/20260627141500_add_coworker_turn_context_economy/migration.sql
@@ -1,0 +1,9 @@
+-- Add context-economy telemetry to durable coworker turn metrics.
+ALTER TABLE "CoworkerTurnMetric"
+ADD COLUMN "ctxPeakTokens" INTEGER,
+ADD COLUMN "ctxWindowTokens" INTEGER,
+ADD COLUMN "toolSurfaceCount" INTEGER,
+ADD COLUMN "toolDefinitionTokens" INTEGER,
+ADD COLUMN "toolSurfaceExceedsLocalCliff" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "toolSurfaceWindowShare" DOUBLE PRECISION,
+ADD COLUMN "toolSelectionAccuracy" DOUBLE PRECISION;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -11192,20 +11192,27 @@ model ResearchProposal {
 }
 
 model CoworkerTurnMetric {
-  id              String   @id @default(cuid())
-  threadId        String
-  agentMessageId  String
-  agentId         String?
-  routeContext    String?
-  taskType        String?
-  providerId      String?
-  modelId         String?
-  dispatches      Int      @default(0)
-  nudges          Int      @default(0)
-  toolsAttached   Boolean  @default(false)
-  executedTools   Int      @default(0)
-  totalMs         Int?
-  createdAt       DateTime @default(now())
+  id                           String   @id @default(cuid())
+  threadId                     String
+  agentMessageId               String
+  agentId                      String?
+  routeContext                 String?
+  taskType                     String?
+  providerId                   String?
+  modelId                      String?
+  dispatches                   Int      @default(0)
+  nudges                       Int      @default(0)
+  toolsAttached                Boolean  @default(false)
+  executedTools                Int      @default(0)
+  totalMs                      Int?
+  ctxPeakTokens                Int?
+  ctxWindowTokens              Int?
+  toolSurfaceCount             Int?
+  toolDefinitionTokens         Int?
+  toolSurfaceExceedsLocalCliff Boolean  @default(false)
+  toolSurfaceWindowShare       Float?
+  toolSelectionAccuracy        Float?
+  createdAt                    DateTime @default(now())
 
   @@unique([threadId, agentMessageId])
   @@index([createdAt])

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -51,6 +51,7 @@ const SKIP_DIRS = new Set([
 // module-size ratchet.
 const EXCLUDE_RE = [
   /\.d\.ts$/,
+  /^packages\/db\/generated\//,
   /^packages\/db\/src\/seed.*\.ts$/,
   /^packages\/db\/src\/.*-corpus\.ts$/,
   /^packages\/db\/scripts\/seed-.*\.ts$/,

--- a/scripts/check-no-bare-working-write.mjs
+++ b/scripts/check-no-bare-working-write.mjs
@@ -31,6 +31,15 @@ const ALLOWLIST = new Set([
   // time (not a transition from submitted/etc). The downstream agentic loop
   // emits its own heartbeats at iteration boundaries (Phase D1).
   "apps/web/lib/tak/reflection-triggers.ts",
+  // Creates bounded, proactive pattern-observer TaskRuns already in "working"
+  // state at birth; they complete/fail in the same observer transaction scope.
+  "apps/web/lib/tak/pattern-observer/core.ts",
+  // Creates periodic pattern-review TaskRuns in "working" at birth and closes
+  // them after the synchronous observer pass; this is not a queued transition.
+  "apps/web/lib/tak/pattern-observer/periodic-review.ts",
+  // Creates scheduled work-pattern profile review TaskRuns in "working" at
+  // birth and completes them at the end of the scheduled review.
+  "apps/web/lib/tak/work-pattern-profile-review.ts",
   // Creates the Build Studio work-capsule TaskRun envelope in "working" at
   // birth. Build pipeline (Phase D3) heartbeats from the step loop.
   "apps/web/lib/work-capsules/build-studio-attachment.ts",


### PR DESCRIPTION
## Summary
- Implements governed adaptive playbooks Slice 1 systemic capability-needs observer.
- Extracts reusable pattern-observer core, centralized fingerprint/dedupe helpers, pure classifiers, systemic observer service, per-turn + periodic triggers, and EA/SysML grounding.
- Incorporates Work Case coordination constraints: case-bound playbook proposals consume the Work Case Wave 1 governed-execution receipt seam and do not edit `mcp-governed-execute.ts`.

## Verification
- `corepack pnpm --filter web exec vitest run lib/tak/pattern-observer/*.test.ts ...` — pattern-observer suites passed, 5 files / 40 tests.
- `corepack pnpm --filter web exec vitest run lib/tak/reflection-triggers.test.ts lib/tak/autonomous-work-run.test.ts lib/coworker-self-assessment/assessment-service.test.ts lib/improvement-flywheel/signals.test.ts lib/playbooks/architecture-grounding.test.ts` — passed, 5 files / 40 tests.
- `corepack pnpm --filter web typecheck` — passed.
- `git diff --check` — passed.
- `corepack pnpm --filter web build` — passed. Existing Turbopack warning class remains about Edge/runtime tracing and NFT list breadth.

## Backlog / Evidence
- Focused BI: `BI-fb968f39-1851-49c8-914b-5c525322bf73` marked `done` via explicit live-DB fallback because DPF MCP backlog/evidence tools were not exposed in this Codex session.
- Parent epic `EP-8AF1C996` remains open; it has 3 items, 1 terminal.