### PR TITLE
Fix coworker personas audit drift

### DIFF
--- a/prompts/route-persona/ea-architect.prompt.md
+++ b/prompts/route-persona/ea-architect.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: ea-architect
 displayName: Enterprise Architect
-description: Structural analysis, dependency tracing, architecture governance across ArchiMate (structure), BPMN (process), and SysML v2 (systems requirements/verification). Implementable models.
+description: Structural analysis and architecture governance across ArchiMate, BPMN, and SysML v2 implementable models.
 category: route-persona
 version: 3
 

--- a/prompts/route-persona/external-catalog-scout.prompt.md
+++ b/prompts/route-persona/external-catalog-scout.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: external-catalog-scout
 displayName: External Catalog Scout
-description: Scouts external agent catalogs, files governed backlog suggestions, and summarizes new archetype opportunities without importing code.
+description: Scouts external agent catalogs and files governed backlog suggestions without importing code.
 category: route-persona
 version: 1
 

--- a/prompts/route-persona/soc-incident-commander.prompt.md
+++ b/prompts/route-persona/soc-incident-commander.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: soc-incident-commander
 displayName: SOC Incident Commander
-description: Coordinates containment and remediation. Drafts response proposals on the proposal-not-action rail, owns the case, never executes on a customer estate.
+description: Coordinates incident response proposals, owns the case, and never executes on a customer estate.
 category: route-persona
 version: 1
 

--- a/prompts/route-persona/soc-investigator.prompt.md
+++ b/prompts/route-persona/soc-investigator.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: soc-investigator
 displayName: SOC Tier-2 Investigator
-description: Deep investigation on escalated cases. Pivots across events, builds the incident timeline, scopes blast radius, maps ATT&CK, recommends a verdict.
+description: Investigates escalated cases, builds timelines, scopes blast radius, maps ATT&CK, and recommends verdicts.
 category: route-persona
 version: 1
 

--- a/prompts/route-persona/soc-threat-hunter.prompt.md
+++ b/prompts/route-persona/soc-threat-hunter.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: soc-threat-hunter
 displayName: SOC Threat Hunter
-description: Proactive, hypothesis-driven hunting across the estate. Closes detection gaps by proposing new content; propose-only, never acts.
+description: Proactive security hunting across the estate; proposes detection content and never acts directly.
 category: route-persona
 version: 1
 

--- a/prompts/route-persona/soc-triage-analyst.prompt.md
+++ b/prompts/route-persona/soc-triage-analyst.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: soc-triage-analyst
 displayName: SOC Tier-1 Triage Analyst
-description: First-line security alert triage. Enriches detections, assigns evidence-based verdicts, opens and manages low-risk cases, escalates the rest.
+description: Triage security alerts, enrich detections, assign verdicts, manage low-risk cases, and escalate the rest.
 category: route-persona
 version: 1
 

--- a/prompts/specialist/policy-specialist.prompt.md
+++ b/prompts/specialist/policy-specialist.prompt.md
@@ -8,7 +8,7 @@ version: 1
 agent_id: AGT-S2P-POL
 reports_to: HR-300
 delegates_to: []
-value_stream: Strategy to Portfolio
+value_stream: evaluate
 hitl_tier: 2
 status: active
 

--- a/prompts/specialist/portfolio-backlog-specialist.prompt.md
+++ b/prompts/specialist/portfolio-backlog-specialist.prompt.md
@@ -8,7 +8,7 @@ version: 1
 agent_id: AGT-S2P-PFB
 reports_to: HR-100
 delegates_to: []
-value_stream: Strategy to Portfolio
+value_stream: evaluate
 hitl_tier: 2
 status: active
 

--- a/prompts/specialist/product-backlog-specialist.prompt.md
+++ b/prompts/specialist/product-backlog-specialist.prompt.md
@@ -8,7 +8,7 @@ version: 1
 agent_id: AGT-R2D-PB
 reports_to: HR-200
 delegates_to: []
-value_stream: Request to Deploy
+value_stream: integrate
 hitl_tier: 3
 status: active
 


### PR DESCRIPTION
## Summary
- Aligns three specialist persona `value_stream` frontmatter values with the registry-canonical slugs.
- Shortens six route-persona descriptions that exceeded the coworker persona audit limit.
- Fixes the post-merge `main` Coworker Personas Audit failure triggered after PR #2486 merged.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `.\node_modules\.pnpm\node_modules\.bin\tsx.cmd apps\web\scripts\audit-coworker-personas.ts --baseline docs\superpowers\audits\2026-04-27-coworker-persona-audit.json --json-out audit-current.json` -> `errorCount: 0`, `warnCount: 0`, `new=0`

Failing run addressed: https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/28303035332