### PR TITLE
feat: add governed work pattern read model

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -58,6 +58,108 @@ vi.mock("@/components/golden-triangle/CoworkerPriorityControl", () => ({
   CoworkerPriorityControl: () => null,
 }));
 
+vi.mock("@/lib/tak/work-pattern-read-model", () => ({
+  getWorkPatternReadModel: vi.fn().mockResolvedValue({
+    generatedAt: new Date("2026-06-28T12:00:00.000Z"),
+    window: {
+      since: new Date("2026-05-29T12:00:00.000Z"),
+      until: new Date("2026-06-28T12:00:00.000Z"),
+    },
+    summary: {
+      totalPatterns: 1,
+      totalObservedRuns: 3,
+      openNeedCount: 1,
+      readyForReviewCount: 1,
+      candidateOnlyCount: 0,
+    },
+    patterns: [
+      {
+        patternKey: "grant-denial|hr-specialist|/build",
+        agentId: "hr-specialist",
+        routeContext: "/build",
+        riskClass: "medium-risk",
+        status: "observed",
+        scope: "route",
+        version: 1,
+        source: "observer",
+        decisionScope: "platform-wwmd",
+        observedRuns: 3,
+        completedRuns: 2,
+        failedRuns: 1,
+        outcomeCounts: { completed: 2, failed: 1 },
+        latestObservedAt: new Date("2026-06-28T10:24:00.000Z"),
+        latestTaskRunId: "TR-3",
+        evidenceRefs: [{ taskRunId: "TR-3", toolExecutionId: "TE-3" }],
+        candidate: {
+          kind: "grant",
+          need: "Missing sandbox lease grant",
+          blocks: "Repeated grant denials blocked local integration verification.",
+          fingerprint: "fp-grant",
+          evaluationMethod: "deterministic-pattern-observer",
+        },
+        candidateNeedKinds: ["grant"],
+        linkedNeedIds: ["NEED-1"],
+        openNeedCount: 1,
+        readiness: {
+          readyForReview: true,
+          readyForCaseActivation: false,
+          blockers: ["pattern-status-not-approved-or-active"],
+        },
+        activationProposed: false,
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/lib/coworker-self-assessment/review-service", () => ({
+  getCoworkerCapabilityNeedReview: vi.fn().mockResolvedValue({
+    summary: {
+      total: 1,
+      byStatus: { submitted: 1 },
+      bySeverity: { important: 1 },
+      byKind: { grant: 1 },
+    },
+    filterOptions: {
+      statuses: ["submitted"],
+      severities: ["important"],
+      kinds: ["grant"],
+    },
+    needs: [
+      {
+        needId: "NEED-1",
+        assessmentId: "CSA-1",
+        agentId: "hr-specialist",
+        coworkerName: "HR Specialist",
+        coworkerSlug: "hr-specialist",
+        coworkerTier: 2,
+        valueStream: "operate",
+        kind: "grant",
+        severity: "important",
+        status: "submitted",
+        need: "Missing sandbox lease grant",
+        blocks: "The coworker cannot claim local integration evidence without the grant.",
+        evidencePreview: "patternKey: grant-denial|hr-specialist|/build",
+        readinessPreview: "readyForReview: true",
+        linkedBacklogItemId: "BI-1",
+        linkedBacklogItemTitle: "Grant sandbox lease capability",
+        linkedBacklogItemStatus: "open",
+        duplicateOfId: null,
+        duplicateOfNeed: null,
+        duplicateCount: 0,
+        reviewerNote: null,
+        assessmentVerdict: "gaps",
+        assessmentConfidence: "medium",
+        missionSummary: "Observed repeated work-pattern friction.",
+        capabilitySummary: "Missing sandbox lease grant",
+        routeContext: "/build",
+        trigger: "work-pattern-observer",
+        createdAtLabel: "Jun 28, 2026",
+        updatedAtLabel: "Jun 28, 2026",
+      },
+    ],
+  }),
+}));
+
 import { prisma } from "@dpf/db";
 import { getAgentGaidMap } from "@/lib/identity/principal-linking";
 
@@ -103,5 +205,47 @@ describe("AgentDetailPage", () => {
 
     expect(html).toContain("GAID:");
     expect(html).toContain("gaid:priv:dpf.internal:hr-specialist");
+  });
+
+  it("shows the coworker's Needs & Playbooks record with living playbook candidates", async () => {
+    vi.mocked(prisma.agent.findFirst).mockResolvedValue({
+      id: "agent-db-1",
+      agentId: "hr-specialist",
+      slugId: "hr-specialist",
+      name: "HR Specialist",
+      displayName: "HR Specialist",
+      kind: "specialist",
+      tier: 2,
+      type: "specialist",
+      description: "HR help",
+      status: "active",
+      valueStream: "operate",
+      sensitivity: "restricted",
+      humanSupervisorId: "HR-100",
+      escalatesTo: null,
+      delegatesTo: [],
+      lifecycleStage: "production",
+      hitlTierDefault: 2,
+      portfolio: null,
+      executionConfig: null,
+      skills: [],
+      toolGrants: [],
+      performanceProfiles: [],
+      degradationMappings: [],
+      promptContext: null,
+      governanceProfile: null,
+      coworkerAssessments: [],
+      ownerships: [],
+    } as never);
+    vi.mocked(getAgentGaidMap).mockResolvedValue(new Map());
+
+    const { default: AgentDetailPage } = await import("./page");
+    const html = renderToStaticMarkup(
+      await AgentDetailPage({ params: Promise.resolve({ agentId: "hr-specialist" }) }),
+    );
+
+    expect(html).toContain("Needs &amp; Playbooks");
+    expect(html).toContain("Living Playbooks");
+    expect(html).toContain("Missing sandbox lease grant");
   });
 });

--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -17,8 +17,16 @@ import { CoworkerPriorityControl } from "@/components/golden-triangle/CoworkerPr
 import { getCoworkerPostureInheritance } from "@/lib/actions/golden-triangle";
 import { loadCoworkerRecord } from "@/lib/coworker-record/load-record";
 import { loadFamilyCorpusSignals } from "@/lib/coworker-record/corpus-signals";
+import {
+  getCoworkerCapabilityNeedReview,
+  type CoworkerCapabilityNeedReview,
+} from "@/lib/coworker-self-assessment/review-service";
 import { resolveInstallVariantContext } from "@/lib/decision-perspective/install-variant-context";
 import { knownGrantKeys } from "@/lib/tak/agent-grants";
+import {
+  getWorkPatternReadModel,
+  type WorkPatternReadModel,
+} from "@/lib/tak/work-pattern-read-model";
 import { assignTierFromModelId, TIER_LABELS as QUALITY_TIER_LABELS } from "@/lib/routing/quality-tiers";
 import { CoworkerRecordTabs, type CoworkerTab } from "@/components/platform/coworker-record/CoworkerRecordTabs";
 import {
@@ -28,6 +36,7 @@ import {
   PriorityPanel,
   GovernancePanel,
   PerformancePanel,
+  NeedsAndPlaybooksPanel,
   DecisionsPanel,
 } from "@/components/platform/coworker-record/panels";
 
@@ -42,6 +51,41 @@ const TIER_LABELS: Record<number, string> = {
   2: "Specialist",
   3: "Cross-cutting",
 };
+
+function emptyNeedReview(): CoworkerCapabilityNeedReview {
+  return {
+    summary: {
+      total: 0,
+      byStatus: {},
+      bySeverity: {},
+      byKind: {},
+    },
+    filterOptions: {
+      statuses: [],
+      severities: [],
+      kinds: [],
+    },
+    needs: [],
+  };
+}
+
+function emptyWorkPatternReadModel(now = new Date()): WorkPatternReadModel {
+  return {
+    generatedAt: now,
+    window: {
+      since: now,
+      until: now,
+    },
+    summary: {
+      totalPatterns: 0,
+      totalObservedRuns: 0,
+      openNeedCount: 0,
+      readyForReviewCount: 0,
+      candidateOnlyCount: 0,
+    },
+    patterns: [],
+  };
+}
 
 export default async function AgentDetailPage({
   params,
@@ -70,7 +114,17 @@ export default async function AgentDetailPage({
   // WS2 adds: catalog skills already assigned to this coworker (SkillAssignment,
   // keyed by the BUSINESS agentId) and the full active SkillDefinition catalog
   // for the add-select. Tool grants come from the loaded record (agent.toolGrants).
-  const [session, modelConfig, lastModelRows, activeProviders, assignedSkillRows, catalogSkillRows, allProviderStatuses] =
+  const [
+    session,
+    modelConfig,
+    lastModelRows,
+    activeProviders,
+    assignedSkillRows,
+    catalogSkillRows,
+    allProviderStatuses,
+    capabilityNeedReview,
+    workPatternReadModel,
+  ] =
     await Promise.all([
       auth(),
       prisma.agentModelConfig.findUnique({ where: { agentId: agent.agentId } }).catch(() => null),
@@ -110,6 +164,8 @@ export default async function AgentDetailPage({
         .catch(() => [] as Array<{ skillId: string; name: string; category: string; riskBand: string }>),
       // Provider statuses for the summary health chip (mirrors roster.ts logic).
       prisma.modelProvider.findMany({ select: { providerId: true, status: true } }).catch(() => []),
+      getCoworkerCapabilityNeedReview({ agentId: agent.agentId }).catch(() => emptyNeedReview()),
+      getWorkPatternReadModel({ agentId: agent.agentId }).catch(() => emptyWorkPatternReadModel()),
     ]);
 
   const canWrite = !!session?.user && can(
@@ -198,6 +254,8 @@ export default async function AgentDetailPage({
   // WS4: a one-word badge on the Priority tab so an override is visible without
   // opening it ("set" = this coworker has its own override; otherwise inherited).
   const priorityBadge = postureInheritance.hasOwnOverride ? "set" : null;
+  const needsAndPlaybooksCount =
+    capabilityNeedReview.summary.total + workPatternReadModel.summary.totalPatterns;
 
   const tabs: CoworkerTab[] = [
     { id: "overview", label: "Overview" },
@@ -206,6 +264,7 @@ export default async function AgentDetailPage({
     { id: "priority", label: "Priority", badge: priorityBadge },
     { id: "governance", label: "Governance" },
     { id: "performance", label: "Performance" },
+    { id: "needs-playbooks", label: "Needs & Playbooks", badge: needsAndPlaybooksCount > 0 ? String(needsAndPlaybooksCount) : null },
     { id: "decisions", label: "Decisions & Activity", badge: decisions.total > 0 ? String(decisions.total) : null },
   ];
 
@@ -260,6 +319,7 @@ export default async function AgentDetailPage({
         <PriorityPanel priorityControl={priorityControl} />
         <GovernancePanel record={record} />
         <PerformancePanel record={record} />
+        <NeedsAndPlaybooksPanel needs={capabilityNeedReview} workPatterns={workPatternReadModel} />
         <DecisionsPanel record={record} />
       </CoworkerRecordTabs>
     </div>

--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -36,9 +36,9 @@ import {
   PriorityPanel,
   GovernancePanel,
   PerformancePanel,
-  NeedsAndPlaybooksPanel,
   DecisionsPanel,
 } from "@/components/platform/coworker-record/panels";
+import { NeedsAndPlaybooksPanel } from "@/components/platform/coworker-record/NeedsAndPlaybooksPanel";
 
 const BUDGET_CLASS_LABELS: Record<string, string> = {
   quality_first: "Quality first",

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -1,0 +1,178 @@
+import type {
+  CoworkerCapabilityNeedReview,
+  CoworkerCapabilityNeedReviewItem,
+} from "@/lib/coworker-self-assessment/review-service";
+import type {
+  WorkPatternReadModel,
+  WorkPatternSummary,
+} from "@/lib/tak/work-pattern-read-model";
+import { LocalTime } from "@/components/ui/LocalTime";
+import { Chip, deepLink, EmptyState, Section } from "./panels";
+
+export function NeedsAndPlaybooksPanel({
+  needs,
+  workPatterns,
+}: {
+  needs: CoworkerCapabilityNeedReview;
+  workPatterns: WorkPatternReadModel;
+}) {
+  const visibleNeeds = needs.needs.slice(0, 5);
+  return (
+    <div>
+      <Section
+        title="Open needs"
+        count={needs.summary.total}
+        action={deepLink("/ops?origin=capability-need", "Review queue")}
+      >
+        {visibleNeeds.length > 0 ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            {visibleNeeds.map((need) => (
+              <NeedRow key={need.needId} need={need} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState text="No open needs recorded for this coworker." />
+        )}
+      </Section>
+
+      <Section title="Living Playbooks" count={workPatterns.summary.totalPatterns}>
+        {workPatterns.patterns.length > 0 ? (
+          <div style={{ display: "grid", gap: 10 }}>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              <Chip tone="accent">{workPatterns.summary.totalObservedRuns} observed runs</Chip>
+              <Chip tone={workPatterns.summary.openNeedCount > 0 ? "warning" : "muted"}>
+                {workPatterns.summary.openNeedCount} open needs
+              </Chip>
+              <Chip tone="muted">{workPatterns.summary.readyForReviewCount} review-ready</Chip>
+              <Chip tone="muted">{workPatterns.summary.candidateOnlyCount} candidate-only</Chip>
+            </div>
+            {workPatterns.patterns.slice(0, 8).map((pattern) => (
+              <PlaybookRow
+                key={`${pattern.patternKey}:${pattern.routeContext ?? ""}:${pattern.riskClass ?? ""}`}
+                pattern={pattern}
+              />
+            ))}
+          </div>
+        ) : (
+          <EmptyState text="No Living Playbook candidates recorded for this coworker." />
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function NeedRow({ need }: { need: CoworkerCapabilityNeedReviewItem }) {
+  const severityTone =
+    need.severity === "blocker" ? "error" : need.severity === "important" ? "warning" : "muted";
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) auto",
+        gap: 10,
+        padding: "8px 10px",
+        borderRadius: 6,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface)",
+        alignItems: "start",
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 5, marginBottom: 4 }}>
+          <Chip tone={severityTone}>{need.kind}</Chip>
+          <Chip tone="muted">{need.status}</Chip>
+          {need.routeContext ? <Chip tone="accent">{need.routeContext}</Chip> : null}
+        </div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
+          {need.need}
+        </div>
+        <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, overflowWrap: "anywhere" }}>
+          {need.blocks}
+        </div>
+      </div>
+      <div style={{ display: "grid", gap: 4, justifyItems: "end", minWidth: 92 }}>
+        <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{need.createdAtLabel}</span>
+        {need.linkedBacklogItemId ? <Chip tone="success">{need.linkedBacklogItemId}</Chip> : null}
+      </div>
+    </div>
+  );
+}
+
+function PlaybookRow({ pattern }: { pattern: WorkPatternSummary }) {
+  const statusTone =
+    pattern.status === "active" ? "success" : pattern.status === "candidate" ? "warning" : "accent";
+  const blockerLabel =
+    pattern.readiness.blockers.length > 0
+      ? pattern.readiness.blockers.slice(0, 2).join(", ")
+      : "ready for review";
+  return (
+    <div
+      style={{
+        padding: "9px 10px",
+        borderRadius: 6,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 8, flexWrap: "wrap" }}>
+        <div style={{ flex: "1 1 260px", minWidth: 0 }}>
+          <div style={{ display: "flex", gap: 5, flexWrap: "wrap", marginBottom: 5 }}>
+            <Chip tone={statusTone}>{pattern.status}</Chip>
+            <Chip tone="muted">{pattern.scope}</Chip>
+            {pattern.routeContext ? <Chip tone="accent">{pattern.routeContext}</Chip> : null}
+            {pattern.riskClass ? <Chip tone="warning">{pattern.riskClass}</Chip> : null}
+          </div>
+          <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
+            {pattern.candidate?.need ?? pattern.patternKey}
+          </div>
+          <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, overflowWrap: "anywhere" }}>
+            {pattern.candidate?.blocks ?? pattern.patternKey}
+          </div>
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(58px, 1fr))",
+            gap: 6,
+            flex: "0 1 240px",
+          }}
+        >
+          <PlaybookStat label="runs" value={String(pattern.observedRuns)} />
+          <PlaybookStat label="done" value={String(pattern.completedRuns)} />
+          <PlaybookStat label="failed" value={String(pattern.failedRuns)} />
+        </div>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 7 }}>
+        <Chip tone={pattern.openNeedCount > 0 ? "warning" : "muted"}>
+          {pattern.openNeedCount} open needs
+        </Chip>
+        <Chip tone="muted">{pattern.evidenceRefs.length} evidence refs</Chip>
+        <Chip tone={pattern.readiness.readyForReview ? "success" : "warning"}>{blockerLabel}</Chip>
+        {pattern.latestObservedAt ? (
+          <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: "auto" }}>
+            latest <LocalTime value={pattern.latestObservedAt} mode="date" />
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function PlaybookStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        minHeight: 40,
+        padding: "6px 8px",
+        borderRadius: 5,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+      }}
+    >
+      <div style={{ fontSize: 9, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 13, color: "var(--dpf-text)", fontWeight: 700 }}>{value}</div>
+    </div>
+  );
+}

--- a/apps/web/components/platform/coworker-record/panels.tsx
+++ b/apps/web/components/platform/coworker-record/panels.tsx
@@ -7,14 +7,6 @@
 import Link from "next/link";
 import type { CoworkerRecord } from "@/lib/coworker-record/load-record";
 import type { CorpusGapRow, CorpusUsageRollup } from "@/lib/coworker-record/corpus-signals";
-import type {
-  CoworkerCapabilityNeedReview,
-  CoworkerCapabilityNeedReviewItem,
-} from "@/lib/coworker-self-assessment/review-service";
-import type {
-  WorkPatternReadModel,
-  WorkPatternSummary,
-} from "@/lib/tak/work-pattern-read-model";
 import { jurisdictionGaps } from "@/lib/coworker-record/coverage";
 import {
   PROFESSION_JURISDICTIONS,
@@ -84,7 +76,7 @@ function InfoGrid({ children }: { children: React.ReactNode }) {
   );
 }
 
-function EmptyState({ text }: { text: string }) {
+export function EmptyState({ text }: { text: string }) {
   return (
     <div style={{ fontSize: 11, color: "var(--dpf-muted)", fontStyle: "italic", padding: "8px 0" }}>
       {text}
@@ -92,7 +84,7 @@ function EmptyState({ text }: { text: string }) {
   );
 }
 
-function Chip({ children, tone = "muted" }: { children: React.ReactNode; tone?: "muted" | "accent" | "success" | "warning" | "error" }) {
+export function Chip({ children, tone = "muted" }: { children: React.ReactNode; tone?: "muted" | "accent" | "success" | "warning" | "error" }) {
   const toneVar = {
     muted: "var(--dpf-muted)",
     accent: "var(--dpf-accent)",
@@ -117,7 +109,7 @@ function Chip({ children, tone = "muted" }: { children: React.ReactNode; tone?: 
   );
 }
 
-function deepLink(href: string, label: string) {
+export function deepLink(href: string, label: string) {
   return (
     <Link href={href} style={{ fontSize: 11, color: "var(--dpf-accent)", textDecoration: "none" }}>
       {label} →
@@ -641,173 +633,6 @@ export function PerformancePanel({ record }: { record: CoworkerRecord }) {
           <EmptyState text="No self-assessments recorded yet. The coworker has not run its improvement loop." />
         )}
       </Section>
-    </div>
-  );
-}
-
-// ─── Needs & Living Playbooks ────────────────────────────────────────────────
-
-export function NeedsAndPlaybooksPanel({
-  needs,
-  workPatterns,
-}: {
-  needs: CoworkerCapabilityNeedReview;
-  workPatterns: WorkPatternReadModel;
-}) {
-  const visibleNeeds = needs.needs.slice(0, 5);
-  return (
-    <div>
-      <Section
-        title="Open needs"
-        count={needs.summary.total}
-        action={deepLink("/ops?origin=capability-need", "Review queue")}
-      >
-        {visibleNeeds.length > 0 ? (
-          <div style={{ display: "grid", gap: 8 }}>
-            {visibleNeeds.map((need) => (
-              <NeedRow key={need.needId} need={need} />
-            ))}
-          </div>
-        ) : (
-          <EmptyState text="No open needs recorded for this coworker." />
-        )}
-      </Section>
-
-      <Section title="Living Playbooks" count={workPatterns.summary.totalPatterns}>
-        {workPatterns.patterns.length > 0 ? (
-          <div style={{ display: "grid", gap: 10 }}>
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-              <Chip tone="accent">{workPatterns.summary.totalObservedRuns} observed runs</Chip>
-              <Chip tone={workPatterns.summary.openNeedCount > 0 ? "warning" : "muted"}>
-                {workPatterns.summary.openNeedCount} open needs
-              </Chip>
-              <Chip tone="muted">{workPatterns.summary.readyForReviewCount} review-ready</Chip>
-              <Chip tone="muted">{workPatterns.summary.candidateOnlyCount} candidate-only</Chip>
-            </div>
-            {workPatterns.patterns.slice(0, 8).map((pattern) => (
-              <PlaybookRow key={`${pattern.patternKey}:${pattern.routeContext ?? ""}:${pattern.riskClass ?? ""}`} pattern={pattern} />
-            ))}
-          </div>
-        ) : (
-          <EmptyState text="No Living Playbook candidates recorded for this coworker." />
-        )}
-      </Section>
-    </div>
-  );
-}
-
-function NeedRow({ need }: { need: CoworkerCapabilityNeedReviewItem }) {
-  return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "minmax(0, 1fr) auto",
-        gap: 10,
-        padding: "8px 10px",
-        borderRadius: 6,
-        border: "1px solid var(--dpf-border)",
-        background: "var(--dpf-surface)",
-        alignItems: "start",
-      }}
-    >
-      <div style={{ minWidth: 0 }}>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 5, marginBottom: 4 }}>
-          <Chip tone={need.severity === "blocker" ? "error" : need.severity === "important" ? "warning" : "muted"}>
-            {need.kind}
-          </Chip>
-          <Chip tone="muted">{need.status}</Chip>
-          {need.routeContext ? <Chip tone="accent">{need.routeContext}</Chip> : null}
-        </div>
-        <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
-          {need.need}
-        </div>
-        <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, overflowWrap: "anywhere" }}>
-          {need.blocks}
-        </div>
-      </div>
-      <div style={{ display: "grid", gap: 4, justifyItems: "end", minWidth: 92 }}>
-        <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{need.createdAtLabel}</span>
-        {need.linkedBacklogItemId ? <Chip tone="success">{need.linkedBacklogItemId}</Chip> : null}
-      </div>
-    </div>
-  );
-}
-
-function PlaybookRow({ pattern }: { pattern: WorkPatternSummary }) {
-  const blockerLabel =
-    pattern.readiness.blockers.length > 0
-      ? pattern.readiness.blockers.slice(0, 2).join(", ")
-      : "ready for review";
-  return (
-    <div
-      style={{
-        padding: "9px 10px",
-        borderRadius: 6,
-        border: "1px solid var(--dpf-border)",
-        background: "var(--dpf-surface)",
-      }}
-    >
-      <div style={{ display: "flex", alignItems: "flex-start", gap: 8, flexWrap: "wrap" }}>
-        <div style={{ flex: "1 1 260px", minWidth: 0 }}>
-          <div style={{ display: "flex", gap: 5, flexWrap: "wrap", marginBottom: 5 }}>
-            <Chip tone={pattern.status === "active" ? "success" : pattern.status === "candidate" ? "warning" : "accent"}>
-              {pattern.status}
-            </Chip>
-            <Chip tone="muted">{pattern.scope}</Chip>
-            {pattern.routeContext ? <Chip tone="accent">{pattern.routeContext}</Chip> : null}
-            {pattern.riskClass ? <Chip tone="warning">{pattern.riskClass}</Chip> : null}
-          </div>
-          <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
-            {pattern.candidate?.need ?? pattern.patternKey}
-          </div>
-          <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, overflowWrap: "anywhere" }}>
-            {pattern.candidate?.blocks ?? pattern.patternKey}
-          </div>
-        </div>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(3, minmax(58px, 1fr))",
-            gap: 6,
-            flex: "0 1 240px",
-          }}
-        >
-          <PlaybookStat label="runs" value={String(pattern.observedRuns)} />
-          <PlaybookStat label="done" value={String(pattern.completedRuns)} />
-          <PlaybookStat label="failed" value={String(pattern.failedRuns)} />
-        </div>
-      </div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 7 }}>
-        <Chip tone={pattern.openNeedCount > 0 ? "warning" : "muted"}>
-          {pattern.openNeedCount} open needs
-        </Chip>
-        <Chip tone="muted">{pattern.evidenceRefs.length} evidence refs</Chip>
-        <Chip tone={pattern.readiness.readyForReview ? "success" : "warning"}>{blockerLabel}</Chip>
-        {pattern.latestObservedAt ? (
-          <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: "auto" }}>
-            latest <LocalTime value={pattern.latestObservedAt} mode="date" />
-          </span>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function PlaybookStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div
-      style={{
-        minHeight: 40,
-        padding: "6px 8px",
-        borderRadius: 5,
-        border: "1px solid var(--dpf-border)",
-        background: "var(--dpf-surface-1)",
-      }}
-    >
-      <div style={{ fontSize: 9, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
-        {label}
-      </div>
-      <div style={{ fontSize: 13, color: "var(--dpf-text)", fontWeight: 700 }}>{value}</div>
     </div>
   );
 }

--- a/apps/web/components/platform/coworker-record/panels.tsx
+++ b/apps/web/components/platform/coworker-record/panels.tsx
@@ -7,6 +7,14 @@
 import Link from "next/link";
 import type { CoworkerRecord } from "@/lib/coworker-record/load-record";
 import type { CorpusGapRow, CorpusUsageRollup } from "@/lib/coworker-record/corpus-signals";
+import type {
+  CoworkerCapabilityNeedReview,
+  CoworkerCapabilityNeedReviewItem,
+} from "@/lib/coworker-self-assessment/review-service";
+import type {
+  WorkPatternReadModel,
+  WorkPatternSummary,
+} from "@/lib/tak/work-pattern-read-model";
 import { jurisdictionGaps } from "@/lib/coworker-record/coverage";
 import {
   PROFESSION_JURISDICTIONS,
@@ -633,6 +641,173 @@ export function PerformancePanel({ record }: { record: CoworkerRecord }) {
           <EmptyState text="No self-assessments recorded yet. The coworker has not run its improvement loop." />
         )}
       </Section>
+    </div>
+  );
+}
+
+// ─── Needs & Living Playbooks ────────────────────────────────────────────────
+
+export function NeedsAndPlaybooksPanel({
+  needs,
+  workPatterns,
+}: {
+  needs: CoworkerCapabilityNeedReview;
+  workPatterns: WorkPatternReadModel;
+}) {
+  const visibleNeeds = needs.needs.slice(0, 5);
+  return (
+    <div>
+      <Section
+        title="Open needs"
+        count={needs.summary.total}
+        action={deepLink("/ops?origin=capability-need", "Review queue")}
+      >
+        {visibleNeeds.length > 0 ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            {visibleNeeds.map((need) => (
+              <NeedRow key={need.needId} need={need} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState text="No open needs recorded for this coworker." />
+        )}
+      </Section>
+
+      <Section title="Living Playbooks" count={workPatterns.summary.totalPatterns}>
+        {workPatterns.patterns.length > 0 ? (
+          <div style={{ display: "grid", gap: 10 }}>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              <Chip tone="accent">{workPatterns.summary.totalObservedRuns} observed runs</Chip>
+              <Chip tone={workPatterns.summary.openNeedCount > 0 ? "warning" : "muted"}>
+                {workPatterns.summary.openNeedCount} open needs
+              </Chip>
+              <Chip tone="muted">{workPatterns.summary.readyForReviewCount} review-ready</Chip>
+              <Chip tone="muted">{workPatterns.summary.candidateOnlyCount} candidate-only</Chip>
+            </div>
+            {workPatterns.patterns.slice(0, 8).map((pattern) => (
+              <PlaybookRow key={`${pattern.patternKey}:${pattern.routeContext ?? ""}:${pattern.riskClass ?? ""}`} pattern={pattern} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState text="No Living Playbook candidates recorded for this coworker." />
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function NeedRow({ need }: { need: CoworkerCapabilityNeedReviewItem }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) auto",
+        gap: 10,
+        padding: "8px 10px",
+        borderRadius: 6,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface)",
+        alignItems: "start",
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 5, marginBottom: 4 }}>
+          <Chip tone={need.severity === "blocker" ? "error" : need.severity === "important" ? "warning" : "muted"}>
+            {need.kind}
+          </Chip>
+          <Chip tone="muted">{need.status}</Chip>
+          {need.routeContext ? <Chip tone="accent">{need.routeContext}</Chip> : null}
+        </div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
+          {need.need}
+        </div>
+        <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, overflowWrap: "anywhere" }}>
+          {need.blocks}
+        </div>
+      </div>
+      <div style={{ display: "grid", gap: 4, justifyItems: "end", minWidth: 92 }}>
+        <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{need.createdAtLabel}</span>
+        {need.linkedBacklogItemId ? <Chip tone="success">{need.linkedBacklogItemId}</Chip> : null}
+      </div>
+    </div>
+  );
+}
+
+function PlaybookRow({ pattern }: { pattern: WorkPatternSummary }) {
+  const blockerLabel =
+    pattern.readiness.blockers.length > 0
+      ? pattern.readiness.blockers.slice(0, 2).join(", ")
+      : "ready for review";
+  return (
+    <div
+      style={{
+        padding: "9px 10px",
+        borderRadius: 6,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 8, flexWrap: "wrap" }}>
+        <div style={{ flex: "1 1 260px", minWidth: 0 }}>
+          <div style={{ display: "flex", gap: 5, flexWrap: "wrap", marginBottom: 5 }}>
+            <Chip tone={pattern.status === "active" ? "success" : pattern.status === "candidate" ? "warning" : "accent"}>
+              {pattern.status}
+            </Chip>
+            <Chip tone="muted">{pattern.scope}</Chip>
+            {pattern.routeContext ? <Chip tone="accent">{pattern.routeContext}</Chip> : null}
+            {pattern.riskClass ? <Chip tone="warning">{pattern.riskClass}</Chip> : null}
+          </div>
+          <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
+            {pattern.candidate?.need ?? pattern.patternKey}
+          </div>
+          <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2, overflowWrap: "anywhere" }}>
+            {pattern.candidate?.blocks ?? pattern.patternKey}
+          </div>
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(58px, 1fr))",
+            gap: 6,
+            flex: "0 1 240px",
+          }}
+        >
+          <PlaybookStat label="runs" value={String(pattern.observedRuns)} />
+          <PlaybookStat label="done" value={String(pattern.completedRuns)} />
+          <PlaybookStat label="failed" value={String(pattern.failedRuns)} />
+        </div>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 7 }}>
+        <Chip tone={pattern.openNeedCount > 0 ? "warning" : "muted"}>
+          {pattern.openNeedCount} open needs
+        </Chip>
+        <Chip tone="muted">{pattern.evidenceRefs.length} evidence refs</Chip>
+        <Chip tone={pattern.readiness.readyForReview ? "success" : "warning"}>{blockerLabel}</Chip>
+        {pattern.latestObservedAt ? (
+          <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: "auto" }}>
+            latest <LocalTime value={pattern.latestObservedAt} mode="date" />
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function PlaybookStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        minHeight: 40,
+        padding: "6px 8px",
+        borderRadius: 5,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+      }}
+    >
+      <div style={{ fontSize: 9, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 13, color: "var(--dpf-text)", fontWeight: 700 }}>{value}</div>
     </div>
   );
 }

--- a/apps/web/lib/tak/work-pattern-read-model.test.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkPatternMetadata } from "./work-pattern-types";
+import { getWorkPatternReadModel } from "./work-pattern-read-model";
+
+const now = new Date("2026-06-28T12:00:00.000Z");
+
+function pattern(overrides: Partial<WorkPatternMetadata> = {}): WorkPatternMetadata {
+  return {
+    patternKey: "grant-denial|build-specialist|/build",
+    status: "observed",
+    scope: "route",
+    version: 1,
+    source: "observer",
+    decisionScope: "platform-wwmd",
+    evidence: [{ taskRunId: "TR-1", toolExecutionId: "TE-1" }],
+    candidate: {
+      kind: "grant",
+      need: "Missing sandbox lease grant",
+      blocks: "Repeated grant denials blocked local integration verification.",
+      fingerprint: "fp-grant",
+      evaluationMethod: "deterministic-pattern-observer",
+    },
+    observedAt: "2026-06-28T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function taskRun(input: {
+  taskRunId: string;
+  status: string;
+  metadata?: WorkPatternMetadata;
+  repeatedPatternKey?: string | null;
+  createdAt?: Date;
+  completedAt?: Date | null;
+}) {
+  const repeatedPatternKey =
+    input.repeatedPatternKey ?? input.metadata?.patternKey ?? "grant-denial|build-specialist|/build";
+  return {
+    taskRunId: input.taskRunId,
+    currentAgentId: "build-specialist",
+    initiatingAgentId: "planner",
+    routeContext: "/build",
+    title: `Run ${input.taskRunId}`,
+    status: input.status,
+    repeatedPatternKey,
+    a2aMetadata: input.metadata
+      ? {
+          riskClass: "medium-risk",
+          workPattern: input.metadata,
+        }
+      : { riskClass: "medium-risk" },
+    createdAt: input.createdAt ?? new Date("2026-06-28T10:00:00.000Z"),
+    completedAt: input.completedAt ?? new Date("2026-06-28T10:05:00.000Z"),
+  };
+}
+
+function capabilityNeed(input: {
+  needId: string;
+  patternKey: string;
+  status?: string;
+  kind?: string;
+  routeContext?: string | null;
+}) {
+  return {
+    needId: input.needId,
+    agentId: "build-specialist",
+    kind: input.kind ?? "grant",
+    severity: "important",
+    status: input.status ?? "submitted",
+    need: "Missing sandbox lease grant",
+    blocks: "The coworker cannot claim local integration evidence without the grant.",
+    evidenceJson: {
+      patternKey: input.patternKey,
+      fingerprint: "fp-grant",
+      taskRunId: "TR-1",
+      toolExecutionId: "TE-1",
+    },
+    readinessJson: {
+      readyForReview: true,
+      readyForCaseActivation: false,
+      blockers: ["pattern-status-not-approved-or-active"],
+    },
+    linkedBacklogItemId: "BI-1",
+    duplicateOfId: null,
+    createdAt: new Date("2026-06-28T10:06:00.000Z"),
+    updatedAt: new Date("2026-06-28T10:06:00.000Z"),
+    assessment: {
+      routeContext: input.routeContext ?? "/build",
+      trigger: "work-pattern-observer",
+      createdAt: new Date("2026-06-28T10:06:00.000Z"),
+    },
+  };
+}
+
+describe("getWorkPatternReadModel", () => {
+  it("groups repeated TaskRuns by pattern, route, outcome, risk, and linked needs", async () => {
+    const db = {
+      listTaskRuns: vi.fn().mockResolvedValue([
+        taskRun({ taskRunId: "TR-1", status: "completed" }),
+        taskRun({
+          taskRunId: "TR-2",
+          status: "completed",
+          metadata: pattern({ evidence: [{ taskRunId: "TR-2", toolExecutionId: "TE-2" }] }),
+          createdAt: new Date("2026-06-28T10:10:00.000Z"),
+          completedAt: new Date("2026-06-28T10:14:00.000Z"),
+        }),
+        taskRun({
+          taskRunId: "TR-3",
+          status: "failed",
+          metadata: pattern({ evidence: [{ taskRunId: "TR-3", toolExecutionId: "TE-3" }] }),
+          createdAt: new Date("2026-06-28T10:20:00.000Z"),
+          completedAt: new Date("2026-06-28T10:24:00.000Z"),
+        }),
+      ]),
+      listCapabilityNeeds: vi.fn().mockResolvedValue([
+        capabilityNeed({
+          needId: "NEED-1",
+          patternKey: "grant-denial|build-specialist|/build",
+        }),
+        capabilityNeed({
+          needId: "NEED-2",
+          patternKey: "tool-surface|build-specialist|/build",
+          kind: "tool",
+        }),
+      ]),
+    };
+
+    const model = await getWorkPatternReadModel({ agentId: "build-specialist", now }, { db });
+
+    expect(model.summary.totalPatterns).toBe(2);
+    expect(model.summary.totalObservedRuns).toBe(3);
+    expect(model.summary.openNeedCount).toBe(2);
+
+    const observed = model.patterns.find(
+      (item) => item.patternKey === "grant-denial|build-specialist|/build",
+    );
+    expect(observed).toMatchObject({
+      agentId: "build-specialist",
+      routeContext: "/build",
+      riskClass: "medium-risk",
+      status: "observed",
+      scope: "route",
+      observedRuns: 3,
+      completedRuns: 2,
+      failedRuns: 1,
+      openNeedCount: 1,
+      candidateNeedKinds: ["grant"],
+      linkedNeedIds: ["NEED-1"],
+    });
+    expect(observed?.outcomeCounts).toEqual({ completed: 2, failed: 1 });
+    expect(observed?.latestObservedAt?.toISOString()).toBe("2026-06-28T10:24:00.000Z");
+    expect(observed?.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ taskRunId: "TR-1", toolExecutionId: "TE-1" }),
+        expect.objectContaining({ taskRunId: "TR-2", toolExecutionId: "TE-2" }),
+        expect.objectContaining({ taskRunId: "TR-3", toolExecutionId: "TE-3" }),
+      ]),
+    );
+    expect(observed?.readiness.blockers).toContain("pattern-status-not-approved-or-active");
+    expect(observed?.activationProposed).toBe(false);
+
+    const candidateOnly = model.patterns.find(
+      (item) => item.patternKey === "tool-surface|build-specialist|/build",
+    );
+    expect(candidateOnly).toMatchObject({
+      status: "candidate",
+      observedRuns: 0,
+      openNeedCount: 1,
+      candidateNeedKinds: ["tool"],
+      linkedNeedIds: ["NEED-2"],
+      routeContext: "/build",
+      activationProposed: false,
+    });
+  });
+});

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -1,0 +1,609 @@
+import { prisma } from "@dpf/db";
+
+import {
+  COWORKER_CAPABILITY_NEED_KINDS,
+  type CoworkerCapabilityNeedKind,
+} from "@/lib/coworker-self-assessment/types";
+import {
+  WORK_PATTERN_DECISION_SCOPES,
+  evaluatePatternReadiness,
+  parseWorkPatternMetadata,
+  patternDecisionScope,
+  type WorkPatternCandidate,
+  type WorkPatternDecisionScope,
+  type WorkPatternEvidenceRef,
+  type WorkPatternReadiness,
+  type WorkPatternScope,
+  type WorkPatternSource,
+  type WorkPatternStatus,
+} from "./work-pattern-types";
+
+const DEFAULT_WINDOW_DAYS = 30;
+const DEFAULT_TAKE = 200;
+
+const OPEN_NEED_STATUSES = new Set(["submitted", "reviewing", "accepted", "backlog-filed"]);
+const FAILED_RUN_STATUSES = new Set(["failed", "canceled", "rejected"]);
+
+export type WorkPatternReadModelTaskRunRow = {
+  taskRunId: string;
+  currentAgentId?: string | null;
+  initiatingAgentId?: string | null;
+  routeContext?: string | null;
+  title?: string | null;
+  status?: string | null;
+  repeatedPatternKey?: string | null;
+  a2aMetadata?: unknown;
+  createdAt?: Date | null;
+  completedAt?: Date | null;
+};
+
+export type WorkPatternReadModelNeedRow = {
+  needId: string;
+  agentId: string;
+  kind: string;
+  severity: string;
+  status: string;
+  need: string;
+  blocks: string;
+  evidenceJson?: unknown;
+  readinessJson?: unknown;
+  linkedBacklogItemId?: string | null;
+  duplicateOfId?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+  assessment?: {
+    routeContext?: string | null;
+    trigger?: string | null;
+    createdAt?: Date | null;
+  } | null;
+};
+
+export type WorkPatternReadModelQuery = {
+  agentId: string;
+  routeContext?: string | null;
+  since: Date;
+  until: Date;
+  take: number;
+};
+
+export type WorkPatternReadModelDb = {
+  listTaskRuns(query: WorkPatternReadModelQuery): Promise<WorkPatternReadModelTaskRunRow[]>;
+  listCapabilityNeeds(query: WorkPatternReadModelQuery): Promise<WorkPatternReadModelNeedRow[]>;
+};
+
+export type GetWorkPatternReadModelInput = {
+  agentId: string;
+  routeContext?: string | null;
+  since?: Date;
+  until?: Date;
+  now?: Date;
+  windowDays?: number;
+  take?: number;
+};
+
+export type WorkPatternSummary = {
+  patternKey: string;
+  agentId: string;
+  routeContext: string | null;
+  riskClass: string | null;
+  status: WorkPatternStatus;
+  scope: WorkPatternScope;
+  version: number;
+  source: WorkPatternSource;
+  decisionScope: WorkPatternDecisionScope;
+  observedRuns: number;
+  completedRuns: number;
+  failedRuns: number;
+  outcomeCounts: Record<string, number>;
+  latestObservedAt: Date | null;
+  latestTaskRunId: string | null;
+  evidenceRefs: WorkPatternEvidenceRef[];
+  candidate: WorkPatternCandidate | null;
+  candidateNeedKinds: CoworkerCapabilityNeedKind[];
+  linkedNeedIds: string[];
+  openNeedCount: number;
+  readiness: WorkPatternReadiness;
+  activationProposed: boolean;
+};
+
+export type WorkPatternReadModel = {
+  generatedAt: Date;
+  window: {
+    since: Date;
+    until: Date;
+  };
+  summary: {
+    totalPatterns: number;
+    totalObservedRuns: number;
+    openNeedCount: number;
+    readyForReviewCount: number;
+    candidateOnlyCount: number;
+  };
+  patterns: WorkPatternSummary[];
+};
+
+type SummaryAccumulator = Omit<WorkPatternSummary, "candidateNeedKinds" | "linkedNeedIds" | "evidenceRefs"> & {
+  candidateNeedKinds: Set<CoworkerCapabilityNeedKind>;
+  linkedNeedIds: Set<string>;
+  evidenceRefs: Map<string, WorkPatternEvidenceRef>;
+};
+
+type PatternSeed = {
+  patternKey: string;
+  agentId: string;
+  routeContext: string | null;
+  riskClass: string | null;
+  status: WorkPatternStatus;
+  scope: WorkPatternScope;
+  version: number;
+  source: WorkPatternSource;
+  decisionScope: WorkPatternDecisionScope;
+  candidate: WorkPatternCandidate | null;
+  readiness: WorkPatternReadiness;
+  activationProposed: boolean;
+};
+
+function defaultDb(): WorkPatternReadModelDb {
+  return {
+    listTaskRuns: (query) =>
+      prisma.taskRun.findMany({
+        where: {
+          OR: [{ currentAgentId: query.agentId }, { initiatingAgentId: query.agentId }],
+          ...(query.routeContext ? { routeContext: query.routeContext } : {}),
+          createdAt: { gte: query.since, lte: query.until },
+        },
+        orderBy: { createdAt: "desc" },
+        take: query.take,
+        select: {
+          taskRunId: true,
+          currentAgentId: true,
+          initiatingAgentId: true,
+          routeContext: true,
+          title: true,
+          status: true,
+          repeatedPatternKey: true,
+          a2aMetadata: true,
+          createdAt: true,
+          completedAt: true,
+        },
+      }) as Promise<WorkPatternReadModelTaskRunRow[]>,
+    listCapabilityNeeds: (query) =>
+      prisma.coworkerCapabilityNeed.findMany({
+        where: {
+          agentId: query.agentId,
+          ...(query.routeContext
+            ? { assessment: { routeContext: query.routeContext } }
+            : {}),
+          createdAt: { gte: query.since, lte: query.until },
+        },
+        orderBy: { createdAt: "desc" },
+        take: query.take,
+        select: {
+          needId: true,
+          agentId: true,
+          kind: true,
+          severity: true,
+          status: true,
+          need: true,
+          blocks: true,
+          evidenceJson: true,
+          readinessJson: true,
+          linkedBacklogItemId: true,
+          duplicateOfId: true,
+          createdAt: true,
+          updatedAt: true,
+          assessment: {
+            select: {
+              routeContext: true,
+              trigger: true,
+              createdAt: true,
+            },
+          },
+        },
+      }) as Promise<WorkPatternReadModelNeedRow[]>,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(source: unknown, field: string): string | null {
+  if (!isRecord(source)) return null;
+  const value = source[field];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function stringArrayField(source: unknown, field: string): string[] {
+  if (!isRecord(source)) return [];
+  const value = source[field];
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+}
+
+function booleanField(source: unknown, field: string): boolean | null {
+  if (!isRecord(source)) return null;
+  const value = source[field];
+  return typeof value === "boolean" ? value : null;
+}
+
+function dateFrom(value: unknown): Date | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value;
+  if (typeof value !== "string") return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+function positiveNumber(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function resolveQuery(input: GetWorkPatternReadModelInput): WorkPatternReadModelQuery {
+  const until = input.until ?? input.now ?? new Date();
+  const windowDays = positiveNumber(input.windowDays, DEFAULT_WINDOW_DAYS);
+  const since =
+    input.since ?? new Date(until.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  return {
+    agentId: input.agentId,
+    routeContext: input.routeContext ?? null,
+    since,
+    until,
+    take: positiveNumber(input.take, DEFAULT_TAKE),
+  };
+}
+
+function workPatternFromMetadata(value: unknown) {
+  if (!isRecord(value)) return null;
+  return parseWorkPatternMetadata(value.workPattern);
+}
+
+function riskClassFromMetadata(value: unknown): string | null {
+  return stringField(value, "riskClass");
+}
+
+function fallbackReadiness(): WorkPatternReadiness {
+  return {
+    readyForReview: true,
+    readyForCaseActivation: false,
+    blockers: ["pattern-status-not-approved-or-active"],
+  };
+}
+
+function fallbackSeed(input: {
+  patternKey: string;
+  agentId: string;
+  routeContext: string | null;
+  riskClass: string | null;
+}): PatternSeed {
+  return {
+    patternKey: input.patternKey,
+    agentId: input.agentId,
+    routeContext: input.routeContext,
+    riskClass: input.riskClass,
+    status: "observed",
+    scope: input.routeContext ? "route" : "agent",
+    version: 1,
+    source: "observer",
+    decisionScope: input.routeContext ? patternDecisionScope("route") : patternDecisionScope("agent"),
+    candidate: null,
+    readiness: fallbackReadiness(),
+    activationProposed: false,
+  };
+}
+
+function seedFromTaskRun(row: WorkPatternReadModelTaskRunRow, agentId: string): PatternSeed | null {
+  const metadata = workPatternFromMetadata(row.a2aMetadata);
+  const effectiveAgentId = row.currentAgentId ?? row.initiatingAgentId ?? agentId;
+  const routeContext = row.routeContext ?? null;
+  const riskClass = riskClassFromMetadata(row.a2aMetadata);
+  if (metadata) {
+    return {
+      patternKey: metadata.patternKey,
+      agentId: effectiveAgentId,
+      routeContext,
+      riskClass,
+      status: metadata.status,
+      scope: metadata.scope,
+      version: metadata.version,
+      source: metadata.source,
+      decisionScope: metadata.decisionScope,
+      candidate: metadata.candidate ?? null,
+      readiness: evaluatePatternReadiness(metadata),
+      activationProposed: false,
+    };
+  }
+
+  if (!row.repeatedPatternKey) return null;
+  return fallbackSeed({
+    patternKey: row.repeatedPatternKey,
+    agentId: effectiveAgentId,
+    routeContext,
+    riskClass,
+  });
+}
+
+function knownKind(value: string): CoworkerCapabilityNeedKind {
+  return COWORKER_CAPABILITY_NEED_KINDS.includes(value as CoworkerCapabilityNeedKind)
+    ? (value as CoworkerCapabilityNeedKind)
+    : "other";
+}
+
+function knownDecisionScope(value: string | null): WorkPatternDecisionScope | null {
+  return WORK_PATTERN_DECISION_SCOPES.includes(value as WorkPatternDecisionScope)
+    ? (value as WorkPatternDecisionScope)
+    : null;
+}
+
+function readinessFromNeed(row: WorkPatternReadModelNeedRow): WorkPatternReadiness {
+  const blockers = stringArrayField(row.readinessJson, "blockers");
+  return {
+    readyForReview: booleanField(row.readinessJson, "readyForReview") ?? Boolean(row.need),
+    readyForCaseActivation:
+      booleanField(row.readinessJson, "readyForCaseActivation") ?? false,
+    blockers:
+      blockers.length > 0 ? blockers : ["pattern-status-not-approved-or-active"],
+  };
+}
+
+function seedFromNeed(row: WorkPatternReadModelNeedRow): PatternSeed | null {
+  const patternKey =
+    stringField(row.evidenceJson, "patternKey") ?? stringField(row.readinessJson, "patternKey");
+  if (!patternKey) return null;
+  const routeContext = row.assessment?.routeContext ?? null;
+  const scope: WorkPatternScope = routeContext ? "route" : "agent";
+  const kind = knownKind(row.kind);
+  return {
+    patternKey,
+    agentId: row.agentId,
+    routeContext,
+    riskClass: stringField(row.evidenceJson, "riskClass"),
+    status: "candidate",
+    scope,
+    version: 1,
+    source: "observer",
+    decisionScope:
+      knownDecisionScope(stringField(row.evidenceJson, "decisionScope")) ??
+      patternDecisionScope(scope),
+    candidate: {
+      kind,
+      need: row.need,
+      blocks: row.blocks,
+      fingerprint:
+        stringField(row.evidenceJson, "fingerprint") ??
+        `${row.agentId}|${kind}|${row.need}`,
+      evaluationMethod:
+        stringField(row.evidenceJson, "evaluationMethod") ??
+        "capability-need-review",
+    },
+    readiness: readinessFromNeed(row),
+    activationProposed: booleanField(row.readinessJson, "activationProposed") ?? false,
+  };
+}
+
+function groupKey(seed: Pick<PatternSeed, "patternKey" | "agentId" | "routeContext" | "riskClass">): string {
+  return [seed.patternKey, seed.agentId, seed.routeContext ?? "", seed.riskClass ?? ""].join("\u001f");
+}
+
+function createAccumulator(seed: PatternSeed): SummaryAccumulator {
+  return {
+    patternKey: seed.patternKey,
+    agentId: seed.agentId,
+    routeContext: seed.routeContext,
+    riskClass: seed.riskClass,
+    status: seed.status,
+    scope: seed.scope,
+    version: seed.version,
+    source: seed.source,
+    decisionScope: seed.decisionScope,
+    observedRuns: 0,
+    completedRuns: 0,
+    failedRuns: 0,
+    outcomeCounts: {},
+    latestObservedAt: null,
+    latestTaskRunId: null,
+    evidenceRefs: new Map(),
+    candidate: seed.candidate,
+    candidateNeedKinds: seed.candidate ? new Set([seed.candidate.kind]) : new Set(),
+    linkedNeedIds: new Set(),
+    openNeedCount: 0,
+    readiness: seed.readiness,
+    activationProposed: seed.activationProposed,
+  };
+}
+
+function getOrCreate(
+  summaries: Map<string, SummaryAccumulator>,
+  seed: PatternSeed,
+): SummaryAccumulator {
+  const key = groupKey(seed);
+  const existing = summaries.get(key);
+  if (existing) {
+    if (!existing.candidate && seed.candidate) existing.candidate = seed.candidate;
+    existing.activationProposed = existing.activationProposed || seed.activationProposed;
+    if (seed.readiness.blockers.length < existing.readiness.blockers.length) {
+      existing.readiness = seed.readiness;
+    }
+    return existing;
+  }
+  const created = createAccumulator(seed);
+  summaries.set(key, created);
+  return created;
+}
+
+function findCompatibleSummaryForNeed(
+  summaries: Map<string, SummaryAccumulator>,
+  seed: PatternSeed,
+): SummaryAccumulator | null {
+  for (const summary of summaries.values()) {
+    if (
+      summary.patternKey !== seed.patternKey ||
+      summary.agentId !== seed.agentId ||
+      summary.routeContext !== seed.routeContext
+    ) {
+      continue;
+    }
+    if (seed.riskClass && summary.riskClass !== seed.riskClass) {
+      continue;
+    }
+    return summary;
+  }
+  return null;
+}
+
+function evidenceKey(ref: WorkPatternEvidenceRef): string {
+  return [
+    ref.taskRunId ?? "",
+    ref.toolExecutionId ?? "",
+    ref.threadId ?? "",
+    ref.agentMessageId ?? "",
+    ref.capabilityNeedId ?? "",
+    ref.backlogItemId ?? "",
+    ref.workCaseRef ?? "",
+    ref.receiptId ?? "",
+    ref.decisionInteractionId ?? "",
+  ].join("|");
+}
+
+function addEvidence(summary: SummaryAccumulator, refs: readonly WorkPatternEvidenceRef[]): void {
+  for (const ref of refs) {
+    const key = evidenceKey(ref);
+    if (key.replaceAll("|", "").length === 0) continue;
+    summary.evidenceRefs.set(key, ref);
+  }
+}
+
+function metadataEvidence(row: WorkPatternReadModelTaskRunRow): WorkPatternEvidenceRef[] {
+  const metadata = workPatternFromMetadata(row.a2aMetadata);
+  const refs = metadata?.evidence?.length ? [...metadata.evidence] : [];
+  if (refs.length === 0) {
+    refs.push({ taskRunId: row.taskRunId });
+  }
+  return refs;
+}
+
+function needEvidence(row: WorkPatternReadModelNeedRow): WorkPatternEvidenceRef[] {
+  const refs: WorkPatternEvidenceRef[] = [];
+  const direct: WorkPatternEvidenceRef = {
+    taskRunId: stringField(row.evidenceJson, "taskRunId") ?? undefined,
+    toolExecutionId: stringField(row.evidenceJson, "toolExecutionId") ?? undefined,
+    threadId: stringField(row.evidenceJson, "threadId") ?? undefined,
+    agentMessageId: stringField(row.evidenceJson, "agentMessageId") ?? undefined,
+    improvementSignalId: stringField(row.evidenceJson, "improvementSignalId") ?? undefined,
+    capabilityNeedId: row.needId,
+    backlogItemId: row.linkedBacklogItemId ?? undefined,
+    workCaseRef: stringField(row.evidenceJson, "workCaseRef") ?? undefined,
+    receiptId: stringField(row.evidenceJson, "receiptId") ?? undefined,
+    decisionInteractionId: stringField(row.evidenceJson, "decisionInteractionId") ?? undefined,
+  };
+  refs.push(direct);
+  for (const taskRunId of stringArrayField(row.evidenceJson, "taskRunIds")) {
+    refs.push({ taskRunId, capabilityNeedId: row.needId });
+  }
+  for (const toolExecutionId of stringArrayField(row.evidenceJson, "toolExecutionIds")) {
+    refs.push({ toolExecutionId, capabilityNeedId: row.needId });
+  }
+  return refs;
+}
+
+function maxDate(left: Date | null, right: Date | null): Date | null {
+  if (!left) return right;
+  if (!right) return left;
+  return right.getTime() > left.getTime() ? right : left;
+}
+
+function observeRun(summary: SummaryAccumulator, row: WorkPatternReadModelTaskRunRow): void {
+  const status = row.status ?? "unknown";
+  summary.observedRuns += 1;
+  summary.outcomeCounts[status] = (summary.outcomeCounts[status] ?? 0) + 1;
+  if (status === "completed") summary.completedRuns += 1;
+  if (FAILED_RUN_STATUSES.has(status)) summary.failedRuns += 1;
+
+  const metadataObservedAt = workPatternFromMetadata(row.a2aMetadata)?.observedAt;
+  const observedAt =
+    row.completedAt ??
+    row.createdAt ??
+    dateFrom(metadataObservedAt) ??
+    null;
+  const latest = maxDate(summary.latestObservedAt, observedAt);
+  if (latest !== summary.latestObservedAt) {
+    summary.latestObservedAt = latest;
+    summary.latestTaskRunId = row.taskRunId;
+  }
+  addEvidence(summary, metadataEvidence(row));
+}
+
+function attachNeed(summary: SummaryAccumulator, row: WorkPatternReadModelNeedRow): void {
+  const kind = knownKind(row.kind);
+  summary.candidateNeedKinds.add(kind);
+  summary.linkedNeedIds.add(row.needId);
+  if (OPEN_NEED_STATUSES.has(row.status)) {
+    summary.openNeedCount += 1;
+  }
+  if (!summary.candidate) {
+    summary.candidate = seedFromNeed(row)?.candidate ?? null;
+  }
+  summary.activationProposed =
+    summary.activationProposed ||
+    (booleanField(row.readinessJson, "activationProposed") ?? false);
+  addEvidence(summary, needEvidence(row));
+}
+
+function serializeSummary(summary: SummaryAccumulator): WorkPatternSummary {
+  return {
+    ...summary,
+    evidenceRefs: [...summary.evidenceRefs.values()],
+    candidateNeedKinds: [...summary.candidateNeedKinds].sort(),
+    linkedNeedIds: [...summary.linkedNeedIds].sort(),
+  };
+}
+
+function sortSummaries(left: WorkPatternSummary, right: WorkPatternSummary): number {
+  if (left.openNeedCount !== right.openNeedCount) {
+    return right.openNeedCount - left.openNeedCount;
+  }
+  const leftTime = left.latestObservedAt?.getTime() ?? 0;
+  const rightTime = right.latestObservedAt?.getTime() ?? 0;
+  if (leftTime !== rightTime) return rightTime - leftTime;
+  return left.patternKey.localeCompare(right.patternKey);
+}
+
+export async function getWorkPatternReadModel(
+  input: GetWorkPatternReadModelInput,
+  deps?: { db?: WorkPatternReadModelDb },
+): Promise<WorkPatternReadModel> {
+  const query = resolveQuery(input);
+  const db = deps?.db ?? defaultDb();
+  const [taskRuns, needs] = await Promise.all([
+    db.listTaskRuns(query),
+    db.listCapabilityNeeds(query),
+  ]);
+
+  const summaries = new Map<string, SummaryAccumulator>();
+  for (const row of taskRuns) {
+    const seed = seedFromTaskRun(row, query.agentId);
+    if (!seed) continue;
+    observeRun(getOrCreate(summaries, seed), row);
+  }
+  for (const row of needs) {
+    const seed = seedFromNeed(row);
+    if (!seed) continue;
+    attachNeed(findCompatibleSummaryForNeed(summaries, seed) ?? getOrCreate(summaries, seed), row);
+  }
+
+  const patterns = [...summaries.values()].map(serializeSummary).sort(sortSummaries);
+  return {
+    generatedAt: query.until,
+    window: {
+      since: query.since,
+      until: query.until,
+    },
+    summary: {
+      totalPatterns: patterns.length,
+      totalObservedRuns: patterns.reduce((sum, item) => sum + item.observedRuns, 0),
+      openNeedCount: patterns.reduce((sum, item) => sum + item.openNeedCount, 0),
+      readyForReviewCount: patterns.filter((item) => item.readiness.readyForReview).length,
+      candidateOnlyCount: patterns.filter((item) => item.observedRuns === 0).length,
+    },
+    patterns,
+  };
+}

--- a/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-read-model.md
+++ b/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-read-model.md
@@ -14,7 +14,7 @@
 
 - Create `apps/web/lib/tak/work-pattern-read-model.ts` for DB-backed and injectable read-model projection.
 - Create `apps/web/lib/tak/work-pattern-read-model.test.ts` for TDD coverage of grouping, evidence links, candidate-only projection, and no-activation guarantees.
-- Modify `apps/web/components/platform/coworker-record/panels.tsx` to add a `NeedsAndPlaybooksPanel` that accepts preloaded needs and playbook summaries.
+- Add `apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx` for the preloaded needs and playbook summaries panel, reusing coworker-record primitives without growing the shared panel module.
 - Modify `apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx` to load `getCoworkerCapabilityNeedReview({ agentId })` and `getWorkPatternReadModel({ agentId })`, then add the `Needs & Playbooks` tab.
 - Modify `apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx` to mock the new loaders and assert the tab/panel is rendered.
 

--- a/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-read-model.md
+++ b/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-read-model.md
@@ -1,0 +1,119 @@
+# Governed Adaptive Playbooks Read Model Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Slice 2 by projecting stamped Governed Work Pattern metadata and capability-need evidence into an operator-ready Living Playbooks view for each coworker.
+
+**Architecture:** Keep persistence on existing substrates: `TaskRun.a2aMetadata.workPattern`, `TaskRun.repeatedPatternKey`, and `CoworkerCapabilityNeed` evidence/readiness JSON. Add one typed read model that groups observed patterns by pattern key, agent, route, outcome, and risk, then render that projection in the existing AI Workforce coworker record. No new WorkPattern table, no activation path, no prompt/skill/grant/model-route mutation.
+
+**Tech Stack:** Next.js 16 server components, Prisma 7 client, Vitest, existing coworker-record tab/panel components.
+
+---
+
+## File Structure
+
+- Create `apps/web/lib/tak/work-pattern-read-model.ts` for DB-backed and injectable read-model projection.
+- Create `apps/web/lib/tak/work-pattern-read-model.test.ts` for TDD coverage of grouping, evidence links, candidate-only projection, and no-activation guarantees.
+- Modify `apps/web/components/platform/coworker-record/panels.tsx` to add a `NeedsAndPlaybooksPanel` that accepts preloaded needs and playbook summaries.
+- Modify `apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx` to load `getCoworkerCapabilityNeedReview({ agentId })` and `getWorkPatternReadModel({ agentId })`, then add the `Needs & Playbooks` tab.
+- Modify `apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx` to mock the new loaders and assert the tab/panel is rendered.
+
+## Task 1: Work Pattern Read Model
+
+- [x] **Step 1: Write the failing read-model test**
+
+Add tests that inject fake TaskRun and CoworkerCapabilityNeed rows:
+
+- Two completed runs and one failed run with the same `a2aMetadata.workPattern.patternKey` group into one summary.
+- Evidence refs include TaskRun and ToolExecution ids from metadata.
+- A capability need with `evidenceJson.patternKey` links to the summary and increments open need counts.
+- A need with `evidenceJson.patternKey` but no matching TaskRun creates a candidate-only summary.
+
+Run:
+
+```powershell
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-read-model.test.ts
+```
+
+Expected: FAIL because `work-pattern-read-model.ts` does not exist.
+
+- [x] **Step 2: Implement the minimal read model**
+
+Implement:
+
+- `getWorkPatternReadModel(input, deps?)`
+- `WorkPatternReadModelDb` with injected `listTaskRuns` and `listCapabilityNeeds`
+- grouping by `patternKey`, `agentId`, `routeContext`, and `riskClass`
+- parsing with `parseWorkPatternMetadata`
+- fallback summaries from `repeatedPatternKey`
+- candidate-only summaries from capability need `evidenceJson.patternKey`
+- readiness via `evaluatePatternReadiness`
+
+Do not add writes. Do not add a Prisma model.
+
+- [x] **Step 3: Verify the read-model test passes**
+
+Run the same Vitest command. Expected: PASS.
+
+## Task 2: Coworker Record Living Playbooks Tab
+
+- [x] **Step 1: Write the failing page/panel test**
+
+Update `page.test.tsx` to mock:
+
+- `getCoworkerCapabilityNeedReview`
+- `getWorkPatternReadModel`
+
+Assert rendered markup contains:
+
+- `Needs & Playbooks`
+- `Living Playbooks`
+- a candidate pattern title/need from the mocked read model
+
+Run:
+
+```powershell
+corepack pnpm --filter web exec vitest run -t "Needs & Playbooks"
+```
+
+Expected: FAIL before UI wiring.
+
+- [x] **Step 2: Implement the panel and page wiring**
+
+Add a compact server-rendered panel using existing `Section`, `Chip`, and table/card styling:
+
+- Open needs section links to `/ops?origin=capability-need`
+- Living Playbooks section groups summaries by route/status
+- Rows show pattern status, scope, run counts, latest observation, readiness blockers, and evidence counts
+- Copy uses product language: `Living Playbooks`; code/types keep `WorkPattern`
+
+Use only DPF theme tokens and existing layout primitives.
+
+- [x] **Step 3: Verify page/panel tests pass**
+
+Run the page test command. Expected: PASS.
+
+## Task 3: Gates and Evidence
+
+- [x] **Step 1: Run focused tests**
+
+```powershell
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-read-model.test.ts
+corepack pnpm --filter web exec vitest run -t "AgentDetailPage"
+```
+
+- [x] **Step 2: Run affected broader tests**
+
+```powershell
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-types.test.ts lib/tak/pattern-observer.test.ts lib/tak/pattern-observer-service.test.ts lib/tak/pattern-observer/observer.test.ts
+```
+
+- [x] **Step 3: Run build gate**
+
+```powershell
+corepack pnpm --filter web build
+```
+
+- [x] **Step 4: Record capsule evidence and commit**
+
+Record test/build results on Work Capsule `WC-75F39A23`, then commit with DCO sign-off.


### PR DESCRIPTION
## Summary
- Adds a typed, read-only governed work-pattern read model over TaskRun metadata and CoworkerCapabilityNeed evidence.
- Adds a Needs & Playbooks tab to the coworker record so operators can see open needs and Living Playbook candidates together.
- Adds the Slice 2 implementation plan and marks the executed steps complete.

## Verification
- `corepack pnpm --filter web exec vitest run lib/tak/work-pattern-read-model.test.ts`
- `corepack pnpm --filter web exec vitest run -t "AgentDetailPage"`
- `corepack pnpm --filter web exec vitest run lib/tak/work-pattern-types.test.ts lib/tak/pattern-observer.test.ts lib/tak/pattern-observer-service.test.ts lib/tak/pattern-observer/observer.test.ts`
- `corepack pnpm --filter web typecheck`
- `corepack pnpm --filter web build` (passes; emits existing Turbopack Edge-runtime/NFT tracing warnings)