### PR TITLE
Add playbook shadow trust projection

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -106,6 +106,29 @@ vi.mock("@/lib/tak/work-pattern-read-model", () => ({
           blockers: ["pattern-status-not-approved-or-active"],
         },
         activationProposed: false,
+        shadowEvaluation: {
+          samples: 20,
+          agreements: 19,
+          agreementRate: 0.95,
+          riskClass: "internal-reversible",
+          currentLevel: "shadow",
+          trustRecommendation: {
+            action: "promote",
+            from: "shadow",
+            to: "propose",
+            reason: "agreement 95% >= 90% over 20 samples",
+          },
+          decision: "approve-narrower-scope",
+          activationAllowed: false,
+          improvementTotals: {
+            toolCallDelta: -40,
+            failureDelta: -20,
+            manualTouchDelta: 0,
+            contextTokenDelta: -18000,
+            reviewFailureDelta: 0,
+          },
+          blockers: [],
+        },
       },
     ],
   }),
@@ -247,5 +270,8 @@ describe("AgentDetailPage", () => {
     expect(html).toContain("Needs &amp; Playbooks");
     expect(html).toContain("Living Playbooks");
     expect(html).toContain("Missing sandbox lease grant");
+    expect(html).toContain("Shadow evidence");
+    expect(html).toContain("95% agreement");
+    expect(html).toContain("approve narrower scope");
   });
 });

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -9,6 +9,25 @@ import type {
 import { LocalTime } from "@/components/ui/LocalTime";
 import { Chip, deepLink, EmptyState, Section } from "./panels";
 
+type ShadowEvaluation = NonNullable<WorkPatternSummary["shadowEvaluation"]>;
+type ImprovementTotals = ShadowEvaluation["improvementTotals"];
+type DeltaKey = keyof ImprovementTotals;
+
+const shadowDecisionLabels: Record<ShadowEvaluation["decision"], string> = {
+  "approve-narrower-scope": "approve narrower scope",
+  "continue-shadow": "continue shadow",
+  "insufficient-evidence": "insufficient evidence",
+  "reject-candidate": "reject candidate",
+};
+
+const deltaLabels: Record<DeltaKey, string> = {
+  contextTokenDelta: "context tokens",
+  failureDelta: "failures",
+  manualTouchDelta: "manual touches",
+  reviewFailureDelta: "review failures",
+  toolCallDelta: "tool calls",
+};
+
 export function NeedsAndPlaybooksPanel({
   needs,
   workPatterns,
@@ -154,8 +173,70 @@ function PlaybookRow({ pattern }: { pattern: WorkPatternSummary }) {
           </span>
         ) : null}
       </div>
+      {pattern.shadowEvaluation ? (
+        <ShadowEvidenceRow evaluation={pattern.shadowEvaluation} />
+      ) : null}
     </div>
   );
+}
+
+function ShadowEvidenceRow({ evaluation }: { evaluation: ShadowEvaluation }) {
+  const agreement =
+    evaluation.agreementRate == null
+      ? "agreement pending"
+      : `${Math.round(evaluation.agreementRate * 100)}% agreement`;
+  const decision = shadowDecisionLabels[evaluation.decision];
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 5,
+        marginTop: 8,
+        padding: "7px 8px",
+        borderRadius: 5,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+      }}
+    >
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
+        <Chip tone="accent">Shadow evidence</Chip>
+        <Chip tone="muted">{evaluation.samples} trials</Chip>
+        <Chip tone={evaluation.agreementRate != null && evaluation.agreementRate >= 0.9 ? "success" : "warning"}>
+          {agreement}
+        </Chip>
+        <Chip tone={shadowDecisionTone(evaluation.decision)}>{decision}</Chip>
+      </div>
+      <div style={{ fontSize: 10, color: "var(--dpf-muted)", overflowWrap: "anywhere" }}>
+        {trustRecommendationLabel(evaluation)}. {strongestReductionLabel(evaluation.improvementTotals)}
+      </div>
+    </div>
+  );
+}
+
+function shadowDecisionTone(decision: ShadowEvaluation["decision"]) {
+  if (decision === "approve-narrower-scope") return "success";
+  if (decision === "reject-candidate") return "error";
+  if (decision === "insufficient-evidence") return "warning";
+  return "accent";
+}
+
+function trustRecommendationLabel(evaluation: ShadowEvaluation): string {
+  const recommendation = evaluation.trustRecommendation;
+  if (!recommendation) return "trust projection pending";
+  if (recommendation.action === "hold") return `trust holds at ${recommendation.level}`;
+  if (recommendation.action === "promote") {
+    return `trust projection ${recommendation.from} to ${recommendation.to}`;
+  }
+  return `trust projection ${recommendation.from} down to ${recommendation.to}`;
+}
+
+function strongestReductionLabel(totals: ImprovementTotals): string {
+  const strongest = (Object.entries(totals) as Array<[DeltaKey, number]>)
+    .filter((entry) => entry[1] < 0)
+    .sort((left, right) => left[1] - right[1])[0];
+  if (!strongest) return "no measured reduction";
+  const [key, value] = strongest;
+  return `${deltaLabels[key]} ${Math.abs(value).toLocaleString()} lower`;
 }
 
 function PlaybookStat({ label, value }: { label: string; value: string }) {

--- a/apps/web/lib/tak/work-pattern-read-model.test.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.test.ts
@@ -61,6 +61,8 @@ function capabilityNeed(input: {
   status?: string;
   kind?: string;
   routeContext?: string | null;
+  evidenceJson?: Record<string, unknown>;
+  readinessJson?: Record<string, unknown>;
 }) {
   return {
     needId: input.needId,
@@ -75,11 +77,13 @@ function capabilityNeed(input: {
       fingerprint: "fp-grant",
       taskRunId: "TR-1",
       toolExecutionId: "TE-1",
+      ...input.evidenceJson,
     },
     readinessJson: {
       readyForReview: true,
       readyForCaseActivation: false,
       blockers: ["pattern-status-not-approved-or-active"],
+      ...input.readinessJson,
     },
     linkedBacklogItemId: "BI-1",
     duplicateOfId: null,
@@ -117,6 +121,23 @@ describe("getWorkPatternReadModel", () => {
         capabilityNeed({
           needId: "NEED-1",
           patternKey: "grant-denial|build-specialist|/build",
+          evidenceJson: {
+            currentAutonomyLevel: "shadow",
+            shadowTrials: Array.from({ length: 20 }, (_, index) => ({
+              trialId: `S-${index + 1}`,
+              riskClass: "internal-reversible",
+              candidateDecision: "file grant need",
+              actualDecision: index === 19 ? "defer" : "file grant need",
+              outcome: index === 19 ? "missed" : "accepted",
+              agreement: index !== 19,
+              toolCallDelta: -2,
+              failureDelta: -1,
+              manualTouchDelta: 0,
+              contextTokenDelta: -900,
+              reviewFailureDelta: 0,
+              observedAt: "2026-06-28T10:30:00.000Z",
+            })),
+          },
         }),
         capabilityNeed({
           needId: "NEED-2",
@@ -159,6 +180,26 @@ describe("getWorkPatternReadModel", () => {
     );
     expect(observed?.readiness.blockers).toContain("pattern-status-not-approved-or-active");
     expect(observed?.activationProposed).toBe(false);
+    expect(observed?.shadowEvaluation).toMatchObject({
+      samples: 20,
+      agreements: 19,
+      agreementRate: 0.95,
+      decision: "approve-narrower-scope",
+      activationAllowed: false,
+      riskClass: "internal-reversible",
+      improvementTotals: {
+        toolCallDelta: -40,
+        failureDelta: -20,
+        manualTouchDelta: 0,
+        contextTokenDelta: -18000,
+        reviewFailureDelta: 0,
+      },
+      trustRecommendation: {
+        action: "promote",
+        from: "shadow",
+        to: "propose",
+      },
+    });
 
     const candidateOnly = model.patterns.find(
       (item) => item.patternKey === "tool-surface|build-specialist|/build",
@@ -171,6 +212,7 @@ describe("getWorkPatternReadModel", () => {
       linkedNeedIds: ["NEED-2"],
       routeContext: "/build",
       activationProposed: false,
+      shadowEvaluation: null,
     });
   });
 });

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -4,6 +4,7 @@ import {
   COWORKER_CAPABILITY_NEED_KINDS,
   type CoworkerCapabilityNeedKind,
 } from "@/lib/coworker-self-assessment/types";
+import type { AutonomyLevel, RiskClass } from "@/lib/autonomy/trust-graduation";
 import {
   WORK_PATTERN_DECISION_SCOPES,
   evaluatePatternReadiness,
@@ -17,6 +18,14 @@ import {
   type WorkPatternSource,
   type WorkPatternStatus,
 } from "./work-pattern-types";
+import {
+  evaluateWorkPatternShadowEvidence,
+  parseAutonomyLevel,
+  parseRiskClass,
+  parseWorkPatternShadowTrials,
+  type WorkPatternShadowEvaluation,
+  type WorkPatternShadowTrial,
+} from "./work-pattern-shadow-evaluation";
 
 const DEFAULT_WINDOW_DAYS = 30;
 const DEFAULT_TAKE = 200;
@@ -104,6 +113,7 @@ export type WorkPatternSummary = {
   openNeedCount: number;
   readiness: WorkPatternReadiness;
   activationProposed: boolean;
+  shadowEvaluation: WorkPatternShadowEvaluation | null;
 };
 
 export type WorkPatternReadModel = {
@@ -122,10 +132,17 @@ export type WorkPatternReadModel = {
   patterns: WorkPatternSummary[];
 };
 
-type SummaryAccumulator = Omit<WorkPatternSummary, "candidateNeedKinds" | "linkedNeedIds" | "evidenceRefs"> & {
+type SummaryAccumulator = Omit<
+  WorkPatternSummary,
+  "candidateNeedKinds" | "linkedNeedIds" | "evidenceRefs" | "shadowEvaluation"
+> & {
   candidateNeedKinds: Set<CoworkerCapabilityNeedKind>;
   linkedNeedIds: Set<string>;
   evidenceRefs: Map<string, WorkPatternEvidenceRef>;
+  shadowTrials: WorkPatternShadowTrial[];
+  shadowCurrentLevel: AutonomyLevel | null;
+  shadowRegulatoryCeiling: AutonomyLevel | null;
+  shadowRiskClass: RiskClass | null;
 };
 
 type PatternSeed = {
@@ -225,6 +242,10 @@ function booleanField(source: unknown, field: string): boolean | null {
   if (!isRecord(source)) return null;
   const value = source[field];
   return typeof value === "boolean" ? value : null;
+}
+
+function unknownField(source: unknown, field: string): unknown {
+  return isRecord(source) ? source[field] : undefined;
 }
 
 function dateFrom(value: unknown): Date | null {
@@ -345,6 +366,32 @@ function readinessFromNeed(row: WorkPatternReadModelNeedRow): WorkPatternReadine
   };
 }
 
+function autonomyLevelFromNeed(
+  row: WorkPatternReadModelNeedRow,
+  field: string,
+): AutonomyLevel | null {
+  return (
+    parseAutonomyLevel(stringField(row.evidenceJson, field)) ??
+    parseAutonomyLevel(stringField(row.readinessJson, field))
+  );
+}
+
+function shadowRiskClassFromNeed(row: WorkPatternReadModelNeedRow): RiskClass | null {
+  return (
+    parseRiskClass(stringField(row.evidenceJson, "shadowRiskClass")) ??
+    parseRiskClass(stringField(row.readinessJson, "shadowRiskClass")) ??
+    parseRiskClass(stringField(row.evidenceJson, "riskClass")) ??
+    parseRiskClass(stringField(row.readinessJson, "riskClass"))
+  );
+}
+
+function shadowTrialsFromNeed(row: WorkPatternReadModelNeedRow): WorkPatternShadowTrial[] {
+  return [
+    ...parseWorkPatternShadowTrials(unknownField(row.evidenceJson, "shadowTrials")),
+    ...parseWorkPatternShadowTrials(unknownField(row.readinessJson, "shadowTrials")),
+  ];
+}
+
 function seedFromNeed(row: WorkPatternReadModelNeedRow): PatternSeed | null {
   const patternKey =
     stringField(row.evidenceJson, "patternKey") ?? stringField(row.readinessJson, "patternKey");
@@ -408,6 +455,10 @@ function createAccumulator(seed: PatternSeed): SummaryAccumulator {
     openNeedCount: 0,
     readiness: seed.readiness,
     activationProposed: seed.activationProposed,
+    shadowTrials: [],
+    shadowCurrentLevel: null,
+    shadowRegulatoryCeiling: null,
+    shadowRiskClass: null,
   };
 }
 
@@ -545,15 +596,43 @@ function attachNeed(summary: SummaryAccumulator, row: WorkPatternReadModelNeedRo
   summary.activationProposed =
     summary.activationProposed ||
     (booleanField(row.readinessJson, "activationProposed") ?? false);
+  summary.shadowTrials.push(...shadowTrialsFromNeed(row));
+  summary.shadowCurrentLevel =
+    summary.shadowCurrentLevel ?? autonomyLevelFromNeed(row, "currentAutonomyLevel");
+  summary.shadowRegulatoryCeiling =
+    summary.shadowRegulatoryCeiling ?? autonomyLevelFromNeed(row, "regulatoryCeiling");
+  summary.shadowRiskClass =
+    summary.shadowRiskClass ?? shadowRiskClassFromNeed(row);
   addEvidence(summary, needEvidence(row));
 }
 
 function serializeSummary(summary: SummaryAccumulator): WorkPatternSummary {
+  const {
+    candidateNeedKinds,
+    evidenceRefs,
+    linkedNeedIds,
+    shadowCurrentLevel,
+    shadowRegulatoryCeiling,
+    shadowRiskClass,
+    shadowTrials,
+    ...base
+  } = summary;
+  const shadowEvaluation =
+    shadowTrials.length > 0
+      ? evaluateWorkPatternShadowEvidence({
+          trials: shadowTrials,
+          currentLevel: shadowCurrentLevel,
+          regulatoryCeiling: shadowRegulatoryCeiling,
+          riskClass: shadowRiskClass,
+        })
+      : null;
+
   return {
-    ...summary,
-    evidenceRefs: [...summary.evidenceRefs.values()],
-    candidateNeedKinds: [...summary.candidateNeedKinds].sort(),
-    linkedNeedIds: [...summary.linkedNeedIds].sort(),
+    ...base,
+    evidenceRefs: [...evidenceRefs.values()],
+    candidateNeedKinds: [...candidateNeedKinds].sort(),
+    linkedNeedIds: [...linkedNeedIds].sort(),
+    shadowEvaluation,
   };
 }
 

--- a/apps/web/lib/tak/work-pattern-shadow-evaluation.test.ts
+++ b/apps/web/lib/tak/work-pattern-shadow-evaluation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateWorkPatternShadowEvidence,
+  parseWorkPatternShadowTrials,
+} from "./work-pattern-shadow-evaluation";
+
+function trial(overrides: Record<string, unknown> = {}) {
+  return {
+    trialId: "S-1",
+    riskClass: "internal-reversible",
+    candidateDecision: "file grant need",
+    actualDecision: "file grant need",
+    outcome: "accepted",
+    agreement: true,
+    toolCallDelta: -2,
+    failureDelta: -1,
+    manualTouchDelta: 0,
+    contextTokenDelta: -1200,
+    reviewFailureDelta: 0,
+    observedAt: "2026-06-28T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("parseWorkPatternShadowTrials", () => {
+  it("accepts bounded shadow rows and rejects malformed risk/agreement data", () => {
+    const parsed = parseWorkPatternShadowTrials([
+      trial(),
+      trial({ trialId: "S-2", riskClass: "not-a-risk" }),
+      trial({ trialId: "S-3", agreement: "yes" }),
+      null,
+    ]);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      trialId: "S-1",
+      riskClass: "internal-reversible",
+      agreement: true,
+      toolCallDelta: -2,
+    });
+    expect(parsed[0].observedAt?.toISOString()).toBe("2026-06-28T10:00:00.000Z");
+  });
+});
+
+describe("evaluateWorkPatternShadowEvidence", () => {
+  it("summarizes agreement, improvement deltas, and projected trust recommendation", () => {
+    const trials = Array.from({ length: 20 }, (_, index) =>
+      trial({
+        trialId: `S-${index + 1}`,
+        agreement: index !== 19,
+        actualDecision: index === 19 ? "defer" : "file grant need",
+      }),
+    );
+
+    const evaluation = evaluateWorkPatternShadowEvidence({
+      trials: parseWorkPatternShadowTrials(trials),
+      currentLevel: "shadow",
+    });
+
+    expect(evaluation).toMatchObject({
+      samples: 20,
+      agreements: 19,
+      agreementRate: 0.95,
+      decision: "approve-narrower-scope",
+      activationAllowed: false,
+      riskClass: "internal-reversible",
+    });
+    expect(evaluation.improvementTotals).toMatchObject({
+      toolCallDelta: -40,
+      failureDelta: -20,
+      contextTokenDelta: -24000,
+    });
+    expect(evaluation.trustRecommendation).toMatchObject({
+      action: "promote",
+      from: "shadow",
+      to: "propose",
+    });
+  });
+
+  it("rejects candidates with enough low-agreement shadow evidence", () => {
+    const trials = Array.from({ length: 10 }, (_, index) =>
+      trial({
+        trialId: `S-${index + 1}`,
+        agreement: index < 5,
+        actualDecision: index < 5 ? "file grant need" : "defer",
+      }),
+    );
+
+    const evaluation = evaluateWorkPatternShadowEvidence({
+      trials: parseWorkPatternShadowTrials(trials),
+      currentLevel: "propose",
+    });
+
+    expect(evaluation).toMatchObject({
+      samples: 10,
+      agreements: 5,
+      agreementRate: 0.5,
+      decision: "reject-candidate",
+      activationAllowed: false,
+    });
+    expect(evaluation.trustRecommendation).toMatchObject({
+      action: "demote",
+      from: "propose",
+      to: "shadow",
+    });
+  });
+
+  it("blocks trust projection when risk evidence is missing", () => {
+    const evaluation = evaluateWorkPatternShadowEvidence({
+      trials: parseWorkPatternShadowTrials([trial({ riskClass: null })]),
+      currentLevel: "shadow",
+    });
+
+    expect(evaluation).toMatchObject({
+      samples: 1,
+      agreements: 1,
+      riskClass: null,
+      trustRecommendation: null,
+      decision: "insufficient-evidence",
+      activationAllowed: false,
+    });
+    expect(evaluation.blockers).toContain("missing-risk-class");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-shadow-evaluation.ts
+++ b/apps/web/lib/tak/work-pattern-shadow-evaluation.ts
@@ -1,0 +1,202 @@
+import {
+  AUTONOMY_LEVELS,
+  recommendTrustChange,
+  type AutonomyLevel,
+  type RiskClass,
+  type TrustRecommendation,
+} from "@/lib/autonomy/trust-graduation";
+
+const RISK_CLASSES: readonly RiskClass[] = [
+  "read-only",
+  "internal-reversible",
+  "internal-irreversible",
+  "outbound-or-floor",
+];
+
+const DELTA_FIELDS = [
+  "toolCallDelta",
+  "failureDelta",
+  "manualTouchDelta",
+  "contextTokenDelta",
+  "reviewFailureDelta",
+] as const;
+
+type DeltaField = (typeof DELTA_FIELDS)[number];
+
+export type WorkPatternShadowTrial = {
+  trialId: string;
+  riskClass: RiskClass | null;
+  candidateDecision: string;
+  actualDecision: string;
+  outcome: string | null;
+  agreement: boolean;
+  toolCallDelta: number;
+  failureDelta: number;
+  manualTouchDelta: number;
+  contextTokenDelta: number;
+  reviewFailureDelta: number;
+  observedAt: Date | null;
+};
+
+export type WorkPatternShadowDecision =
+  | "insufficient-evidence"
+  | "continue-shadow"
+  | "approve-narrower-scope"
+  | "reject-candidate";
+
+export type WorkPatternShadowEvaluation = {
+  samples: number;
+  agreements: number;
+  agreementRate: number | null;
+  riskClass: RiskClass | null;
+  currentLevel: AutonomyLevel;
+  trustRecommendation: TrustRecommendation | null;
+  decision: WorkPatternShadowDecision;
+  activationAllowed: false;
+  improvementTotals: Record<DeltaField, number>;
+  blockers: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(source: Record<string, unknown>, field: string): string | null {
+  const value = source[field];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function numberField(source: Record<string, unknown>, field: DeltaField): number {
+  const value = source[field];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function dateFrom(value: unknown): Date | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value;
+  if (typeof value !== "string") return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+export function parseRiskClass(value: unknown): RiskClass | null {
+  return RISK_CLASSES.includes(value as RiskClass) ? (value as RiskClass) : null;
+}
+
+export function parseAutonomyLevel(value: unknown): AutonomyLevel | null {
+  return AUTONOMY_LEVELS.includes(value as AutonomyLevel) ? (value as AutonomyLevel) : null;
+}
+
+export function parseWorkPatternShadowTrials(value: unknown): WorkPatternShadowTrial[] {
+  if (!Array.isArray(value)) return [];
+  const trials: WorkPatternShadowTrial[] = [];
+  for (const row of value) {
+    if (!isRecord(row)) continue;
+    const trialId = stringField(row, "trialId");
+    const candidateDecision = stringField(row, "candidateDecision");
+    const actualDecision = stringField(row, "actualDecision");
+    const agreement = row.agreement;
+    const rawRiskClass = row.riskClass;
+    const riskClass = rawRiskClass == null ? null : parseRiskClass(rawRiskClass);
+    if (
+      !trialId ||
+      !candidateDecision ||
+      !actualDecision ||
+      typeof agreement !== "boolean" ||
+      (rawRiskClass != null && !riskClass)
+    ) {
+      continue;
+    }
+    trials.push({
+      trialId,
+      riskClass,
+      candidateDecision,
+      actualDecision,
+      outcome: stringField(row, "outcome"),
+      agreement,
+      toolCallDelta: numberField(row, "toolCallDelta"),
+      failureDelta: numberField(row, "failureDelta"),
+      manualTouchDelta: numberField(row, "manualTouchDelta"),
+      contextTokenDelta: numberField(row, "contextTokenDelta"),
+      reviewFailureDelta: numberField(row, "reviewFailureDelta"),
+      observedAt: dateFrom(row.observedAt),
+    });
+  }
+  return trials;
+}
+
+function emptyDeltas(): Record<DeltaField, number> {
+  return {
+    toolCallDelta: 0,
+    failureDelta: 0,
+    manualTouchDelta: 0,
+    contextTokenDelta: 0,
+    reviewFailureDelta: 0,
+  };
+}
+
+function resolveRiskClass(
+  trials: readonly WorkPatternShadowTrial[],
+  fallback?: RiskClass | null,
+): RiskClass | null {
+  if (fallback) return fallback;
+  return trials.find((trial) => trial.riskClass)?.riskClass ?? null;
+}
+
+function shadowDecision(args: {
+  samples: number;
+  riskClass: RiskClass | null;
+  trustRecommendation: TrustRecommendation | null;
+}): WorkPatternShadowDecision {
+  if (!args.riskClass || args.samples < 10) return "insufficient-evidence";
+  if (args.trustRecommendation?.action === "demote") return "reject-candidate";
+  if (args.trustRecommendation?.action === "promote") return "approve-narrower-scope";
+  return "continue-shadow";
+}
+
+export function evaluateWorkPatternShadowEvidence(input: {
+  trials: readonly WorkPatternShadowTrial[];
+  currentLevel?: AutonomyLevel | null;
+  riskClass?: RiskClass | null;
+  regulatoryCeiling?: AutonomyLevel | null;
+}): WorkPatternShadowEvaluation {
+  const samples = input.trials.length;
+  const agreements = input.trials.filter((trial) => trial.agreement).length;
+  const agreementRate = samples > 0 ? agreements / samples : null;
+  const riskClass = resolveRiskClass(input.trials, input.riskClass);
+  const currentLevel = input.currentLevel ?? "shadow";
+  const improvementTotals = emptyDeltas();
+  const blockers: string[] = [];
+
+  for (const trial of input.trials) {
+    for (const field of DELTA_FIELDS) {
+      improvementTotals[field] += trial[field];
+    }
+  }
+
+  if (samples === 0) blockers.push("no-shadow-trials");
+  if (!riskClass) blockers.push("missing-risk-class");
+  if (samples > 0 && samples < 10) blockers.push("insufficient-shadow-samples");
+
+  const trustRecommendation = riskClass
+    ? recommendTrustChange({
+        level: currentLevel,
+        risk: riskClass,
+        window: { samples, agreements },
+        regulatoryCeiling: input.regulatoryCeiling ?? undefined,
+      })
+    : null;
+  const decision = shadowDecision({ samples, riskClass, trustRecommendation });
+
+  return {
+    samples,
+    agreements,
+    agreementRate,
+    riskClass,
+    currentLevel,
+    trustRecommendation,
+    decision,
+    activationAllowed: false,
+    improvementTotals,
+    blockers,
+  };
+}

--- a/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-shadow-trust.md
+++ b/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-shadow-trust.md
@@ -1,0 +1,190 @@
+# Governed Adaptive Playbooks Shadow Trust Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Slice 3 by evaluating Living Playbook candidates in shadow against existing evidence and projecting trust recommendations without changing live autonomy.
+
+**Architecture:** Add a pure shadow-evidence evaluator that parses bounded trial evidence from existing `CoworkerCapabilityNeed.evidenceJson` / `readinessJson`, computes agreement and improvement deltas, and calls the existing `recommendTrustChange` core. Extend the read model and coworker-record panel to surface that projection. Do not add a `WorkPattern`, `DecisionShadowLedger`, or `TrustState` table, and do not mutate skills, prompts, grants, model routes, Work Case state, or autonomy levels.
+
+**Tech Stack:** Next.js 16 server components, TypeScript, Prisma 7, Vitest, existing TAK work-pattern read model, existing `apps/web/lib/autonomy/trust-graduation.ts`.
+
+---
+
+## Scope
+
+This plan implements the safe first half of Slice 3 from `docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md`.
+
+Included:
+
+- Pure parsing and evaluation of candidate shadow trials.
+- Agreement-window calculation over candidate-vs-actual decisions.
+- Improvement delta summaries for tool calls, failures, manual touches, context load, and review failures.
+- Trust recommendation projection using the existing regulatory-ceiling-aware trust core.
+- Read-model and AI Workforce UI projection.
+
+Excluded:
+
+- New persistence tables or migrations.
+- Decision-Shadow Ledger writes.
+- TrustState writes.
+- Automatic promotion, activation, or demotion.
+- Case-bound state changes or governed Action dispatch.
+- Any Ornith/model-routing evaluation.
+
+## Refactoring Budget
+
+Reserve roughly 20 percent of effort for structure:
+
+- Keep shadow evaluation in a small pure module instead of bloating `work-pattern-read-model.ts`.
+- Keep UI changes inside `NeedsAndPlaybooksPanel.tsx`; verify module-size guard locally.
+- Add parsing helpers with closed enum validation instead of ad hoc JSON casts.
+
+## File Structure
+
+Create:
+
+- `apps/web/lib/tak/work-pattern-shadow-evaluation.ts` - pure shadow-trial parser and evaluator.
+- `apps/web/lib/tak/work-pattern-shadow-evaluation.test.ts` - TDD coverage for parsing, agreement, deltas, trust recommendations, and no-activation guarantees.
+
+Modify:
+
+- `apps/web/lib/tak/work-pattern-read-model.ts` - collect shadow evidence from capability needs and attach `shadowEvaluation` to each `WorkPatternSummary`.
+- `apps/web/lib/tak/work-pattern-read-model.test.ts` - verify shadow evidence links into the grouped read model.
+- `apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx` - show a compact shadow/trust evidence row for patterns with shadow evidence.
+- `apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx` - include mocked shadow evidence and assert the operator-facing copy renders.
+- `docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-shadow-trust.md` - keep this checklist current.
+
+## Task 1: Pure Shadow Evidence Evaluator
+
+- [x] **Step 1: Write the failing evaluator test**
+
+Add tests for:
+
+- `parseWorkPatternShadowTrials` accepts only bounded trial rows with valid risk/current-level fields.
+- `evaluateWorkPatternShadowEvidence` computes samples, agreements, agreement rate, and improvement totals.
+- High agreement over enough samples returns a trust recommendation from `recommendTrustChange`, but labels it as an evidence projection, not activation.
+- Low agreement over enough samples returns a reject recommendation with evidence.
+- Missing risk class returns blockers and no trust recommendation.
+
+Run:
+
+```powershell
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-shadow-evaluation.test.ts
+```
+
+Expected: FAIL because the module does not exist.
+
+- [x] **Step 2: Implement the minimal pure evaluator**
+
+Implement:
+
+- `WorkPatternShadowTrial`
+- `WorkPatternShadowEvaluation`
+- `parseWorkPatternShadowTrials(value: unknown): WorkPatternShadowTrial[]`
+- `evaluateWorkPatternShadowEvidence(input): WorkPatternShadowEvaluation`
+
+Use `recommendTrustChange`, `AutonomyLevel`, and `RiskClass` from `apps/web/lib/autonomy/trust-graduation.ts`. Do not import Prisma or mutate anything.
+
+- [x] **Step 3: Verify evaluator test passes**
+
+Run the same Vitest command. Expected: PASS.
+
+## Task 2: Read Model Projection
+
+- [x] **Step 1: Extend the failing read-model test**
+
+Update `work-pattern-read-model.test.ts` so a linked capability need includes:
+
+```ts
+evidenceJson: {
+  patternKey: "...",
+  shadowTrials: [
+    { trialId: "S-1", riskClass: "internal-reversible", candidateDecision: "file grant need", actualDecision: "file grant need", agreement: true, toolCallDelta: -2 },
+  ],
+  currentAutonomyLevel: "shadow",
+}
+```
+
+Assert the grouped pattern has `shadowEvaluation.samples`, `agreementRate`, improvement deltas, and a non-activation recommendation.
+
+Run:
+
+```powershell
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-read-model.test.ts
+```
+
+Expected: FAIL until the read model attaches shadow evidence.
+
+- [x] **Step 2: Attach shadow evidence to summaries**
+
+Extend the accumulator with parsed trials and optional current/regulatory levels from need JSON. Serialize a `shadowEvaluation` using the pure evaluator. If there is no shadow evidence, return `null`.
+
+- [x] **Step 3: Verify read-model tests pass**
+
+Run the same command. Expected: PASS.
+
+## Task 3: Operator UI Projection
+
+- [x] **Step 1: Extend the failing page test**
+
+Update the mocked read model in `page.test.tsx` with a `shadowEvaluation` payload and assert the rendered markup includes:
+
+- `Shadow evidence`
+- an agreement percentage
+- a non-activation recommendation such as `continue shadow` or `approve narrower scope`
+
+Run:
+
+```powershell
+corepack pnpm --filter web exec vitest run -t "Needs & Playbooks"
+```
+
+Expected: FAIL until the panel renders the shadow row.
+
+- [x] **Step 2: Render compact shadow evidence**
+
+Update `NeedsAndPlaybooksPanel.tsx`:
+
+- Add a small shadow row under each pattern that has `shadowEvaluation`.
+- Show samples, agreement rate, trust action, and strongest delta.
+- Use product language: `Shadow evidence`, `continue shadow`, `approve narrower scope`, `reject candidate`.
+- Do not add activation buttons.
+
+- [x] **Step 3: Verify page tests and module-size guard**
+
+Run:
+
+```powershell
+corepack pnpm --filter web exec vitest run -t "Needs & Playbooks"
+node scripts/check-module-size.mjs
+```
+
+Expected: PASS.
+
+## Task 4: Gates, Evidence, And PR
+
+- [x] **Step 1: Run focused tests**
+
+```powershell
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-shadow-evaluation.test.ts
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-read-model.test.ts
+corepack pnpm --filter web exec vitest run -t "AgentDetailPage"
+```
+
+- [x] **Step 2: Run relevant existing suites**
+
+```powershell
+corepack pnpm --filter web exec vitest run lib/tak/work-pattern-types.test.ts lib/tak/pattern-observer.test.ts lib/tak/pattern-observer-service.test.ts lib/tak/pattern-observer/observer.test.ts lib/autonomy/trust-graduation.test.ts
+```
+
+- [x] **Step 3: Run source gates**
+
+```powershell
+node scripts/check-module-size.mjs
+corepack pnpm --filter web typecheck
+corepack pnpm --filter web build
+```
+
+- [ ] **Step 4: Record evidence and publish**
+
+Record results on Work Capsule `WC-7B6FF56A`, commit with DCO sign-off, push, open a ready PR, run `corepack pnpm pr:health <pr>`, and merge through the queue only after the PR is green.


### PR DESCRIPTION
## Summary
- Adds a pure TAK shadow-evidence evaluator for Living Playbook candidate trials, agreement rates, improvement deltas, and trust recommendation projection.
- Extends the work-pattern read model to attach `shadowEvaluation` from capability need evidence/readiness JSON without mutating live autonomy.
- Shows compact shadow evidence in the coworker Needs & Playbooks panel with samples, agreement, projected action, and strongest measured reduction.

## Verification
- `corepack pnpm --filter web exec vitest run lib/tak/work-pattern-shadow-evaluation.test.ts`
- `corepack pnpm --filter web exec vitest run lib/tak/work-pattern-read-model.test.ts`
- `corepack pnpm --filter web exec vitest run -t "AgentDetailPage"`
- `corepack pnpm --filter web exec vitest run lib/tak/work-pattern-types.test.ts lib/tak/pattern-observer.test.ts lib/tak/pattern-observer-service.test.ts lib/tak/pattern-observer/observer.test.ts lib/autonomy/trust-graduation.test.ts`
- `node scripts/check-module-size.mjs`
- `corepack pnpm --filter web typecheck`
- `corepack pnpm --filter web build` (exit 0; existing Turbopack Edge/NFT tracing warnings remain unrelated to this slice)

Work Capsule: `WC-7B6FF56A`
