### PR TITLE
fix(golden-triangle): name a dragged posture by its corner, not "Custom"

### DIFF
--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
@@ -16,7 +16,7 @@ import { getCoworkerGoldenTrianglePosture, saveCoworkerGoldenTrianglePosture } f
 
 import { GoldenTriangleControl } from "./GoldenTriangleControl";
 import { GoldenTriangleGradient } from "./GoldenTriangleGradient";
-import { PRESET_META, preferenceFromPreset } from "./posture-display";
+import { postureLabel, preferenceFromPreset } from "./posture-display";
 
 export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
   const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
@@ -43,7 +43,9 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
     };
   }, [agentId]);
 
-  const activeLabel = pref.preset === "custom" ? "Custom" : PRESET_META[pref.preset].label;
+  // Same meaningful label as the expanded control's badge — a dragged posture
+  // reads e.g. "Lower Cost" (the corner it sits on), never a bare "Custom".
+  const activeLabel = postureLabel(pref);
 
   function onChange(next: GoldenTrianglePreference) {
     setPref(next);

--- a/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
+++ b/apps/web/components/golden-triangle/GoldenTriangleControl.tsx
@@ -94,8 +94,8 @@ export function GoldenTriangleControl({
   const vQuality = unitToVb(0.5, 0);
   const vCost = unitToVb(0, 1);
   const vTime = unitToVb(1, 1);
-  // A meaningful label at every position — an extreme reads as e.g. "Max Quality"
-  // (the corner = that dimension's full setting), never a bare "Custom".
+  // A meaningful label at every position — a dragged posture reads as the corner it
+  // leans toward, e.g. "Lower Cost" (matching the vertex labels), never a bare "Custom".
   const activeLabel = postureLabel(value);
 
   const balanceColor = `var(${balance.token})`;

--- a/apps/web/components/golden-triangle/README.md
+++ b/apps/web/components/golden-triangle/README.md
@@ -10,7 +10,7 @@
   3. **Numeric inputs (canonical accessible control):** three labelled percent inputs — a 2D drag surface is *not* a 1-D ARIA slider, so the numeric/preset layer is the accessible source of truth.
 - **`GoldenTrianglePriorityPanel`** — a stateful host (view-local state) for the platform-default settings surface.
 - **`CoworkerPriorityDock`** — the per-coworker control docked in-flow at the composer (collapsed by default to a colour-graded chip; expands to the full control). Replaced the old `CoworkerPriorityControl` header popover, which clipped off the panel edge.
-- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, `postureLabel()` (a meaningful label at every position — "Max Quality", "Quality-first", …), `describeConfigured()` (the configured-chip explanation, derived from the **real Slice 1 compiler** so the UI never drifts), `TRIANGLE_AXIS_GUIDE` (the min/max explainer), and `balanceState()` for the colour cue.
+- **`posture-display.ts`** — pure helpers: triangle geometry (`weightsToPoint` / `pointToWeights`), preset metadata, `postureLabel()` (a meaningful label at every position — the preset name, or the corner a dragged posture leans toward like "Lower Cost", never a bare "Custom"), `describeConfigured()` (the configured-chip explanation, derived from the **real Slice 1 compiler** so the UI never drifts), `TRIANGLE_AXIS_GUIDE` (the min/max explainer), and `balanceState()` for the colour cue.
 
 ## Balance colouring
 

--- a/apps/web/components/golden-triangle/posture-display.test.ts
+++ b/apps/web/components/golden-triangle/posture-display.test.ts
@@ -18,13 +18,13 @@ describe("postureLabel — every position reads meaningfully (never bare 'Custom
     expect(postureLabel(preferenceFromPreset("assured"))).toBe("Assured");
     expect(postureLabel(preferenceFromPreset("frugal"))).toBe("Frugal");
   });
-  it("labels the maxed corner as 'Max <dimension>'", () => {
-    expect(postureLabel({ preset: "custom", qualityWeight: 1, costWeight: 0, timeWeight: 0 })).toBe("Max Quality");
-    expect(postureLabel({ preset: "custom", qualityWeight: 0, costWeight: 1, timeWeight: 0 })).toBe("Max Cost");
-    expect(postureLabel({ preset: "custom", qualityWeight: 0, costWeight: 0, timeWeight: 1 })).toBe("Max Speed");
+  it("labels a maxed corner with the vertex it sits on", () => {
+    expect(postureLabel({ preset: "custom", qualityWeight: 1, costWeight: 0, timeWeight: 0 })).toBe("Higher Reasoning");
+    expect(postureLabel({ preset: "custom", qualityWeight: 0, costWeight: 1, timeWeight: 0 })).toBe("Lower Cost");
+    expect(postureLabel({ preset: "custom", qualityWeight: 0, costWeight: 0, timeWeight: 1 })).toBe("Lower Time");
   });
-  it("labels a strong-but-not-max lean as '<dimension>-first'", () => {
-    expect(postureLabel({ preset: "custom", qualityWeight: 0.7, costWeight: 0.2, timeWeight: 0.1 })).toBe("Quality-first");
+  it("labels a strong lean by the corner it leans toward", () => {
+    expect(postureLabel({ preset: "custom", qualityWeight: 0.7, costWeight: 0.2, timeWeight: 0.1 })).toBe("Higher Reasoning");
   });
   it("labels a near-centroid custom posture 'Balanced'", () => {
     expect(postureLabel({ preset: "custom", qualityWeight: 0.34, costWeight: 0.33, timeWeight: 0.33 })).toBe("Balanced");

--- a/apps/web/components/golden-triangle/posture-display.ts
+++ b/apps/web/components/golden-triangle/posture-display.ts
@@ -106,26 +106,17 @@ function dominantAxis(p: GoldenTrianglePreference): { axis: "quality" | "cost" |
   return { axis, weight };
 }
 
-// The work scales continuously with the triangle: maxing an axis is that
-// dimension's FULL setting. For Quality, the top of the rigor ladder is a
-// multi-perspective debate (the compiler emits it at qualityWeight >= 0.85, the
-// same QUALITY_DEBATE_FLOOR) — above the single review the Assured preset buys.
-const QUALITY_DEBATE_FLOOR = 0.85;
-
 /**
- * A short, meaningful label for ANY posture — the preset name for a preset, or a
- * dimension + intensity descriptor for a custom one. So an extreme reads as e.g.
- * "Max Quality" (never a bare "Custom"), conveying that a corner is that
- * dimension's full setting.
+ * A short, meaningful label for ANY posture — the preset name for a preset, or the
+ * corner a custom posture leans toward, named exactly as the triangle's vertex
+ * labels (Higher Reasoning / Lower Cost / Lower Time). So a dragged posture reads
+ * e.g. "Lower Cost", never a bare "Custom" or the ambiguous "Max Cost".
  */
 export function postureLabel(pref: GoldenTrianglePreference): string {
   if (pref.preset !== "custom") return PRESET_META[pref.preset].label;
   const { axis, weight } = dominantAxis(pref);
   if (weight < 0.4) return "Balanced";
-  const dim = axis === "quality" ? "Quality" : axis === "cost" ? "Cost" : "Speed";
-  if (weight >= QUALITY_DEBATE_FLOOR) return `Max ${dim}`;
-  if (weight >= 0.55) return `${dim}-first`;
-  return `${dim}-leaning`;
+  return axis === "quality" ? "Higher Reasoning" : axis === "cost" ? "Lower Cost" : "Lower Time";
 }
 
 /**


### PR DESCRIPTION
Founder feedback: dragging the dot into a corner showed **"Custom"** in the collapsed coworker dock (and the one-liner) — which doesn't convey what the posture *is*. As the founder put it for the cost corner: *"it's lowest cost. Why is it custom?"*

## Root cause
Two different label paths:
- The **expanded** control badge used `postureLabel()` → showed "Max Cost" (itself ambiguous — reads like *expensive*).
- The **collapsed dock** header had its own logic: `pref.preset === "custom" ? "Custom" : …` → showed **"Custom"** for any dragged posture.

## Fix
Both now use the same `postureLabel()`, and `postureLabel()` names a custom posture by **the corner it leans toward — exactly matching the triangle's vertex labels**:

| Dot near… | Label |
|---|---|
| Cost corner | **Lower Cost** |
| Quality corner | **Higher Reasoning** |
| Time corner | **Lower Time** |
| Centre | **Balanced** |
| A preset | the preset name (Fast / Balanced / Assured / Frugal) |

So dragging into the cost corner now reads **"Lower Cost"** in both the collapsed one-liner and the expanded badge — consistent, and matching the corner the dot sits on. Removed the now-unused display-side `QUALITY_DEBATE_FLOOR` and the `Max`/`-first`/`-leaning` intensity tiers (the dot position and the chips already convey magnitude). The compiler's own debate floor (`lib/golden-triangle/compile.ts`) is untouched.

## Files
- `apps/web/components/golden-triangle/posture-display.ts` (postureLabel)
- `apps/web/components/golden-triangle/CoworkerPriorityDock.tsx` (use postureLabel, drop the "Custom" branch)
- `apps/web/components/golden-triangle/{posture-display.test.ts,GoldenTriangleControl.tsx,README.md}`

## Verification
- **30/30** golden-triangle unit tests pass (updated `postureLabel` assertions; dock test green).
- `tsc` clean for the touched files (remaining local tsc errors are stale-Prisma false positives from a borrowed verification toolchain; CI runs the authoritative typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)