### PR TITLE
Add governed playbook review activation

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -66,7 +66,7 @@ vi.mock("@/lib/tak/work-pattern-read-model", () => ({
       until: new Date("2026-06-28T12:00:00.000Z"),
     },
     summary: {
-      totalPatterns: 1,
+      totalPatterns: 2,
       totalObservedRuns: 3,
       openNeedCount: 1,
       readyForReviewCount: 1,
@@ -106,6 +106,8 @@ vi.mock("@/lib/tak/work-pattern-read-model", () => ({
           blockers: ["pattern-status-not-approved-or-active"],
         },
         activationProposed: false,
+        reviewState: null,
+        activationCandidate: null,
         shadowEvaluation: {
           samples: 20,
           agreements: 19,
@@ -129,6 +131,91 @@ vi.mock("@/lib/tak/work-pattern-read-model", () => ({
           },
           blockers: [],
         },
+      },
+      {
+        patternKey: "prompt-refinement|hr-specialist|/build",
+        agentId: "hr-specialist",
+        routeContext: "/build",
+        riskClass: "internal-reversible",
+        status: "candidate",
+        scope: "route",
+        version: 1,
+        source: "observer",
+        decisionScope: "platform-wwmd",
+        observedRuns: 1,
+        completedRuns: 1,
+        failedRuns: 0,
+        outcomeCounts: { completed: 1 },
+        latestObservedAt: new Date("2026-06-28T10:44:00.000Z"),
+        latestTaskRunId: "TR-4",
+        evidenceRefs: [{ decisionInteractionId: "DI-REVIEW001", capabilityNeedId: "NEED-2" }],
+        candidate: {
+          kind: "prompt",
+          need: "Prompt should ask for the sandbox lease evidence first",
+          blocks: "The coworker repeats extra context requests before filing the evidence.",
+          fingerprint: "fp-prompt",
+          evaluationMethod: "capability-need-review",
+        },
+        candidateNeedKinds: ["prompt"],
+        linkedNeedIds: ["NEED-2"],
+        openNeedCount: 0,
+        readiness: {
+          readyForReview: true,
+          readyForCaseActivation: false,
+          blockers: ["activation-candidate-awaits-governed-promotion"],
+        },
+        activationProposed: true,
+        reviewState: {
+          action: "approve",
+          status: "approved-candidate",
+          needId: "NEED-2",
+          agentId: "hr-specialist",
+          patternKey: "prompt-refinement|hr-specialist|/build",
+          routeContext: "/build",
+          riskClass: "internal-reversible",
+          decisionScope: "platform-wwmd",
+          decisionInteractionId: "DI-REVIEW001",
+          reviewerUserId: "user-1",
+          reviewedAt: "2026-06-28T11:00:00.000Z",
+          reviewerNote: "Approve only as a candidate.",
+          blockers: ["activation-candidate-awaits-governed-promotion"],
+          activationProposed: true,
+          activationCandidate: {
+            state: "candidate",
+            activationAllowed: false,
+            patternKey: "prompt-refinement|hr-specialist|/build",
+            agentId: "hr-specialist",
+            routeContext: "/build",
+            riskClass: "internal-reversible",
+            decisionScope: "platform-wwmd",
+            currentAutonomyLevel: "shadow",
+            proposedAutonomyLevel: "propose",
+            evidenceSummary: {
+              samples: 20,
+              agreements: 19,
+              agreementRate: 0.95,
+            },
+            blockers: ["activation-candidate-awaits-governed-promotion"],
+          },
+        },
+        activationCandidate: {
+          state: "candidate",
+          activationAllowed: false,
+          patternKey: "prompt-refinement|hr-specialist|/build",
+          agentId: "hr-specialist",
+          routeContext: "/build",
+          riskClass: "internal-reversible",
+          decisionScope: "platform-wwmd",
+          currentAutonomyLevel: "shadow",
+          proposedAutonomyLevel: "propose",
+          evidenceSummary: {
+            samples: 20,
+            agreements: 19,
+            agreementRate: 0.95,
+          },
+          blockers: ["activation-candidate-awaits-governed-promotion"],
+        },
+        shadowEvaluation: null,
       },
     ],
   }),
@@ -273,5 +360,11 @@ describe("AgentDetailPage", () => {
     expect(html).toContain("Shadow evidence");
     expect(html).toContain("95% agreement");
     expect(html).toContain("approve narrower scope");
+    expect(html).toContain("Approve candidate");
+    expect(html).toContain("Defer");
+    expect(html).toContain("Reject");
+    expect(html).toContain("Decision recorded");
+    expect(html).toContain("activation candidate");
+    expect(html).not.toContain("Activate playbook");
   });
 });

--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -319,7 +319,11 @@ export default async function AgentDetailPage({
         <PriorityPanel priorityControl={priorityControl} />
         <GovernancePanel record={record} />
         <PerformancePanel record={record} />
-        <NeedsAndPlaybooksPanel needs={capabilityNeedReview} workPatterns={workPatternReadModel} />
+        <NeedsAndPlaybooksPanel
+          needs={capabilityNeedReview}
+          workPatterns={workPatternReadModel}
+          canWrite={canWrite}
+        />
         <DecisionsPanel record={record} />
       </CoworkerRecordTabs>
     </div>

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -6,6 +6,7 @@ import type {
   WorkPatternReadModel,
   WorkPatternSummary,
 } from "@/lib/tak/work-pattern-read-model";
+import { reviewWorkPatternAction } from "@/lib/actions/work-pattern-review";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { Chip, deepLink, EmptyState, Section } from "./panels";
 
@@ -31,9 +32,11 @@ const deltaLabels: Record<DeltaKey, string> = {
 export function NeedsAndPlaybooksPanel({
   needs,
   workPatterns,
+  canWrite,
 }: {
   needs: CoworkerCapabilityNeedReview;
   workPatterns: WorkPatternReadModel;
+  canWrite: boolean;
 }) {
   const visibleNeeds = needs.needs.slice(0, 5);
   return (
@@ -69,6 +72,7 @@ export function NeedsAndPlaybooksPanel({
               <PlaybookRow
                 key={`${pattern.patternKey}:${pattern.routeContext ?? ""}:${pattern.riskClass ?? ""}`}
                 pattern={pattern}
+                canWrite={canWrite}
               />
             ))}
           </div>
@@ -117,7 +121,7 @@ function NeedRow({ need }: { need: CoworkerCapabilityNeedReviewItem }) {
   );
 }
 
-function PlaybookRow({ pattern }: { pattern: WorkPatternSummary }) {
+function PlaybookRow({ pattern, canWrite }: { pattern: WorkPatternSummary; canWrite: boolean }) {
   const statusTone =
     pattern.status === "active" ? "success" : pattern.status === "candidate" ? "warning" : "accent";
   const blockerLabel =
@@ -176,6 +180,7 @@ function PlaybookRow({ pattern }: { pattern: WorkPatternSummary }) {
       {pattern.shadowEvaluation ? (
         <ShadowEvidenceRow evaluation={pattern.shadowEvaluation} />
       ) : null}
+      <PlaybookReviewRow pattern={pattern} canWrite={canWrite} />
     </div>
   );
 }
@@ -237,6 +242,137 @@ function strongestReductionLabel(totals: ImprovementTotals): string {
   if (!strongest) return "no measured reduction";
   const [key, value] = strongest;
   return `${deltaLabels[key]} ${Math.abs(value).toLocaleString()} lower`;
+}
+
+function PlaybookReviewRow({ pattern, canWrite }: { pattern: WorkPatternSummary; canWrite: boolean }) {
+  if (pattern.reviewState) {
+    const tone = reviewActionTone(pattern.reviewState.action);
+    return (
+      <div
+        style={{
+          display: "grid",
+          gap: 5,
+          marginTop: 8,
+          padding: "7px 8px",
+          borderRadius: 5,
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-1)",
+        }}
+      >
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
+          <Chip tone="success">Decision recorded</Chip>
+          <Chip tone={tone}>{reviewActionLabel(pattern.reviewState.action)}</Chip>
+          <Chip tone="muted">{pattern.reviewState.decisionInteractionId}</Chip>
+          {pattern.activationCandidate ? <Chip tone="accent">activation candidate</Chip> : null}
+          <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: "auto" }}>
+            <LocalTime value={pattern.reviewState.reviewedAt} mode="date" />
+          </span>
+        </div>
+        <div style={{ fontSize: 10, color: "var(--dpf-muted)", overflowWrap: "anywhere" }}>
+          Candidate record only; live autonomy and Work Case state stay unchanged.
+        </div>
+      </div>
+    );
+  }
+
+  const needId = pattern.linkedNeedIds[0];
+  if (!canWrite || !needId || !pattern.shadowEvaluation) {
+    return null;
+  }
+
+  const approvalEligible = pattern.shadowEvaluation.decision === "approve-narrower-scope";
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 6,
+        alignItems: "center",
+        marginTop: 8,
+        padding: "7px 8px",
+        borderRadius: 5,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+      }}
+    >
+      <Chip tone="accent">Review</Chip>
+      {approvalEligible ? (
+        <ReviewActionForm
+          needId={needId}
+          agentId={pattern.agentId}
+          action="approve"
+          label="Approve candidate"
+          note="Approve as a scoped activation candidate; do not activate live autonomy."
+        />
+      ) : null}
+      <ReviewActionForm
+        needId={needId}
+        agentId={pattern.agentId}
+        action="defer"
+        label="Defer"
+        note="Defer this Living Playbook candidate for more shadow evidence."
+      />
+      <ReviewActionForm
+        needId={needId}
+        agentId={pattern.agentId}
+        action="reject"
+        label="Reject"
+        note="Reject this Living Playbook candidate and retain the decision evidence."
+      />
+    </div>
+  );
+}
+
+function ReviewActionForm({
+  needId,
+  agentId,
+  action,
+  label,
+  note,
+}: {
+  needId: string;
+  agentId: string;
+  action: "approve" | "defer" | "reject";
+  label: string;
+  note: string;
+}) {
+  return (
+    <form action={reviewWorkPatternAction} style={{ margin: 0 }}>
+      <input type="hidden" name="needId" value={needId} />
+      <input type="hidden" name="agentId" value={agentId} />
+      <input type="hidden" name="action" value={action} />
+      <input type="hidden" name="note" value={note} />
+      <button
+        type="submit"
+        style={{
+          appearance: "none",
+          border: "1px solid var(--dpf-border-strong)",
+          background: "var(--dpf-surface)",
+          color: "var(--dpf-text)",
+          borderRadius: 5,
+          padding: "4px 8px",
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: "pointer",
+          minHeight: 28,
+        }}
+      >
+        {label}
+      </button>
+    </form>
+  );
+}
+
+function reviewActionTone(action: "approve" | "defer" | "reject") {
+  if (action === "approve") return "success";
+  if (action === "reject") return "error";
+  return "warning";
+}
+
+function reviewActionLabel(action: "approve" | "defer" | "reject"): string {
+  if (action === "approve") return "approved";
+  if (action === "reject") return "rejected";
+  return "deferred";
 }
 
 function PlaybookStat({ label, value }: { label: string; value: string }) {

--- a/apps/web/lib/actions/work-pattern-review.test.ts
+++ b/apps/web/lib/actions/work-pattern-review.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockRequireCapability, mockRevalidatePath } = vi.hoisted(() => ({
+  mockPrisma: {
+    coworkerCapabilityNeed: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    decisionInteraction: {
+      create: vi.fn(),
+    },
+    trustState: {
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    workCase: {
+      update: vi.fn(),
+    },
+    skillDefinition: {
+      update: vi.fn(),
+    },
+    promptTemplate: {
+      update: vi.fn(),
+    },
+    backlogItem: {
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+  mockRequireCapability: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/actions/shared/guards", () => ({
+  requireCapability: mockRequireCapability,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mockRevalidatePath,
+}));
+
+import { recordWorkPatternReview } from "./work-pattern-review";
+
+function shadowTrials(count = 20) {
+  return Array.from({ length: count }, (_, index) => ({
+    trialId: `S-${index + 1}`,
+    riskClass: "internal-reversible",
+    candidateDecision: "file grant need",
+    actualDecision: index === count - 1 && count >= 20 ? "defer" : "file grant need",
+    outcome: index === count - 1 && count >= 20 ? "missed" : "accepted",
+    agreement: !(index === count - 1 && count >= 20),
+    toolCallDelta: -2,
+    failureDelta: -1,
+    manualTouchDelta: 0,
+    contextTokenDelta: -900,
+    reviewFailureDelta: 0,
+    observedAt: "2026-06-28T10:30:00.000Z",
+  }));
+}
+
+function needRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "need-row-1",
+    needId: "NEED-1",
+    agentId: "build-specialist",
+    kind: "grant",
+    severity: "important",
+    status: "submitted",
+    need: "Missing sandbox lease grant",
+    blocks: "Repeated grant denials block verification.",
+    evidenceJson: {
+      patternKey: "grant-denial|build-specialist|/build",
+      decisionScope: "platform-wwmd",
+      riskClass: "internal-reversible",
+      currentAutonomyLevel: "shadow",
+      shadowTrials: shadowTrials(),
+      taskRunId: "TR-1",
+      toolExecutionId: "TE-1",
+    },
+    readinessJson: {
+      readyForReview: true,
+      readyForCaseActivation: false,
+      blockers: ["pattern-status-not-approved-or-active"],
+    },
+    linkedBacklogItemId: "BI-1",
+    assessment: {
+      routeContext: "/build",
+    },
+    ...overrides,
+  };
+}
+
+function form(action: string) {
+  const data = new FormData();
+  data.set("needId", "NEED-1");
+  data.set("agentId", "build-specialist");
+  data.set("action", action);
+  data.set("note", "Approve only for sandbox lease filing.");
+  return data;
+}
+
+describe("reviewWorkPatternAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireCapability.mockResolvedValue({ userId: "user-1" });
+    mockPrisma.coworkerCapabilityNeed.findUnique.mockResolvedValue(needRow());
+    mockPrisma.coworkerCapabilityNeed.update.mockResolvedValue({});
+    mockPrisma.decisionInteraction.create.mockImplementation(async ({ data }) => ({
+      id: "decision-row-1",
+      ...data,
+    }));
+    mockPrisma.$transaction.mockImplementation(async (callback) => callback(mockPrisma));
+  });
+
+  it("records approval as a DecisionInteraction and scoped activation candidate", async () => {
+    await expect(recordWorkPatternReview(form("approve"))).resolves.toMatchObject({
+      status: "recorded",
+      action: "approve",
+      needId: "NEED-1",
+    });
+
+    expect(mockRequireCapability).toHaveBeenCalledWith("manage_platform");
+    expect(mockPrisma.decisionInteraction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        domainClass: "risk-assessment",
+        routeContext: "/platform/ai/agent/build-specialist",
+        outcomeType: "recommend",
+        riskTier: "medium",
+        humanOutcome: expect.objectContaining({
+          type: "work-pattern-review",
+          action: "approve",
+          clearsGate: false,
+          resolverUserId: "user-1",
+        }),
+      }),
+    });
+    expect(mockPrisma.coworkerCapabilityNeed.update).toHaveBeenCalledWith({
+      where: { needId: "NEED-1" },
+      data: expect.objectContaining({
+        status: "accepted",
+        reviewerNote: "Approve only for sandbox lease filing.",
+        readinessJson: expect.objectContaining({
+          activationProposed: true,
+          workPatternReview: expect.objectContaining({
+            action: "approve",
+            status: "approved-candidate",
+            activationCandidate: expect.objectContaining({
+              activationAllowed: false,
+              proposedAutonomyLevel: "propose",
+            }),
+          }),
+        }),
+        evidenceJson: expect.objectContaining({
+          decisionInteractionId: expect.stringMatching(/^DI-[A-F0-9]{12}$/),
+        }),
+      }),
+    });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/platform/ai/agent/build-specialist");
+  });
+
+  it("records rejection without creating an activation candidate", async () => {
+    await expect(recordWorkPatternReview(form("reject"))).resolves.toMatchObject({
+      status: "recorded",
+      action: "reject",
+    });
+
+    const update = mockPrisma.coworkerCapabilityNeed.update.mock.calls[0]![0];
+    expect(update.data.status).toBe("discarded");
+    expect(update.data.readinessJson.workPatternReview).toMatchObject({
+      action: "reject",
+      status: "rejected",
+      activationCandidate: null,
+    });
+    expect(update.data.readinessJson.activationProposed).toBe(false);
+  });
+
+  it("records deferral as a deferred decision", async () => {
+    await expect(recordWorkPatternReview(form("defer"))).resolves.toMatchObject({
+      status: "recorded",
+      action: "defer",
+    });
+
+    expect(mockPrisma.decisionInteraction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        outcomeType: "defer",
+        humanOutcome: expect.objectContaining({
+          action: "defer",
+          clearsGate: false,
+        }),
+      }),
+    });
+    expect(mockPrisma.coworkerCapabilityNeed.update.mock.calls[0]![0].data.status).toBe("deferred");
+  });
+
+  it("fails approval before writes when shadow evidence is not promotable", async () => {
+    mockPrisma.coworkerCapabilityNeed.findUnique.mockResolvedValue(
+      needRow({
+        evidenceJson: {
+          patternKey: "grant-denial|build-specialist|/build",
+          decisionScope: "platform-wwmd",
+          riskClass: "internal-reversible",
+          currentAutonomyLevel: "shadow",
+          shadowTrials: shadowTrials(5),
+        },
+      }),
+    );
+
+    await expect(recordWorkPatternReview(form("approve"))).rejects.toThrow(
+      "approval_requires_promotable_shadow_evidence",
+    );
+
+    expect(mockPrisma.decisionInteraction.create).not.toHaveBeenCalled();
+    expect(mockPrisma.coworkerCapabilityNeed.update).not.toHaveBeenCalled();
+  });
+
+  it("does not write when authorization fails", async () => {
+    mockRequireCapability.mockRejectedValue(new Error("Unauthorized"));
+
+    await expect(recordWorkPatternReview(form("approve"))).rejects.toThrow("Unauthorized");
+
+    expect(mockPrisma.coworkerCapabilityNeed.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.decisionInteraction.create).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate live autonomy, Work Cases, skills, prompts, or backlog", async () => {
+    await recordWorkPatternReview(form("approve"));
+
+    expect(mockPrisma.trustState.update).not.toHaveBeenCalled();
+    expect(mockPrisma.trustState.create).not.toHaveBeenCalled();
+    expect(mockPrisma.workCase.update).not.toHaveBeenCalled();
+    expect(mockPrisma.skillDefinition.update).not.toHaveBeenCalled();
+    expect(mockPrisma.promptTemplate.update).not.toHaveBeenCalled();
+    expect(mockPrisma.backlogItem.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/work-pattern-review.ts
+++ b/apps/web/lib/actions/work-pattern-review.ts
@@ -1,0 +1,320 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma, type Prisma } from "@dpf/db";
+import { requireCapability } from "@/lib/actions/shared/guards";
+import { MARK_DPF_PLATFORM_PROFILE } from "@/lib/decision-perspective/default-profile";
+import { createDecisionInteractionId } from "@/lib/decision-perspective/persistence";
+import type {
+  DecisionOutcomeType,
+  DecisionRiskTier,
+} from "@/lib/decision-perspective/types";
+import {
+  COWORKER_CAPABILITY_NEED_KINDS,
+  type CoworkerCapabilityNeedKind,
+} from "@/lib/coworker-self-assessment/types";
+import {
+  evaluateWorkPatternShadowEvidence,
+  parseAutonomyLevel,
+  parseRiskClass,
+  parseWorkPatternShadowTrials,
+} from "@/lib/tak/work-pattern-shadow-evaluation";
+import {
+  buildWorkPatternReview,
+  capabilityNeedStatusForReviewAction,
+  mergeWorkPatternReviewState,
+  WORK_PATTERN_REVIEW_ACTIONS,
+  type WorkPatternReviewAction,
+} from "@/lib/tak/work-pattern-review";
+import type {
+  WorkPatternCandidate,
+  WorkPatternDecisionScope,
+} from "@/lib/tak/work-pattern-types";
+
+type JsonRecord = Record<string, unknown>;
+
+type ReviewNeedRow = {
+  needId: string;
+  agentId: string;
+  kind: string;
+  need: string;
+  blocks: string;
+  evidenceJson?: unknown;
+  readinessJson?: unknown;
+  linkedBacklogItemId?: string | null;
+  assessment?: {
+    routeContext?: string | null;
+  } | null;
+};
+
+export type ReviewActionResult = {
+  status: "recorded";
+  action: WorkPatternReviewAction;
+  needId: string;
+  decisionInteractionId: string;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function recordFrom(value: unknown): JsonRecord {
+  return isRecord(value) ? value : {};
+}
+
+function stringField(source: unknown, field: string): string | null {
+  if (!isRecord(source)) return null;
+  const value = source[field];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function formString(formData: FormData, field: string): string | null {
+  const value = formData.get(field);
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseAction(value: string | null): WorkPatternReviewAction {
+  if (WORK_PATTERN_REVIEW_ACTIONS.includes(value as WorkPatternReviewAction)) {
+    return value as WorkPatternReviewAction;
+  }
+  throw new Error("invalid_work_pattern_review_action");
+}
+
+function knownKind(value: string): CoworkerCapabilityNeedKind {
+  return COWORKER_CAPABILITY_NEED_KINDS.includes(value as CoworkerCapabilityNeedKind)
+    ? value as CoworkerCapabilityNeedKind
+    : "other";
+}
+
+function parseDecisionScope(value: string | null): WorkPatternDecisionScope {
+  if (value === "company-wwwd" || value === "profession-wsid") return value;
+  return "platform-wwmd";
+}
+
+function riskTierFor(riskClass: ReturnType<typeof parseRiskClass>): DecisionRiskTier {
+  if (riskClass === "read-only") return "low";
+  if (riskClass === "internal-irreversible") return "high";
+  if (riskClass === "outbound-or-floor") return "critical";
+  return "medium";
+}
+
+function outcomeTypeFor(action: WorkPatternReviewAction): DecisionOutcomeType {
+  if (action === "approve") return "recommend";
+  if (action === "defer") return "defer";
+  return "escalate";
+}
+
+function appendString(values: unknown, next: string): string[] {
+  const existing = Array.isArray(values)
+    ? values.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : [];
+  return [...new Set([...existing, next])];
+}
+
+function evidenceSources(input: {
+  need: ReviewNeedRow;
+  evidenceJson: JsonRecord;
+}): Array<{ materialId: string; sourceType: string; summary: string; effectiveWeight: number }> {
+  const sources: Array<{ materialId: string; sourceType: string; summary: string; effectiveWeight: number }> = [
+    {
+      materialId: input.need.needId,
+      sourceType: "coworker-capability-need",
+      summary: input.need.need,
+      effectiveWeight: 1,
+    },
+  ];
+  const taskRunId = stringField(input.evidenceJson, "taskRunId");
+  if (taskRunId) {
+    sources.push({
+      materialId: taskRunId,
+      sourceType: "task-run",
+      summary: `TaskRun evidence for ${input.need.needId}.`,
+      effectiveWeight: 0.7,
+    });
+  }
+  const toolExecutionId = stringField(input.evidenceJson, "toolExecutionId");
+  if (toolExecutionId) {
+    sources.push({
+      materialId: toolExecutionId,
+      sourceType: "tool-execution",
+      summary: `Tool execution evidence for ${input.need.needId}.`,
+      effectiveWeight: 0.7,
+    });
+  }
+  return sources;
+}
+
+function candidateFromNeed(need: ReviewNeedRow, evidenceJson: JsonRecord): WorkPatternCandidate {
+  return {
+    kind: knownKind(need.kind),
+    need: need.need,
+    blocks: need.blocks,
+    fingerprint:
+      stringField(evidenceJson, "fingerprint") ??
+      `${need.agentId}|${need.kind}|${need.need.trim().toLowerCase().replace(/\s+/g, " ")}`,
+    evaluationMethod: stringField(evidenceJson, "evaluationMethod") ?? "capability-need-review",
+  };
+}
+
+function buildRoute(agentId: string): string {
+  return `/platform/ai/agent/${agentId}`;
+}
+
+export async function recordWorkPatternReview(formData: FormData): Promise<ReviewActionResult> {
+  const { userId } = await requireCapability("manage_platform");
+  const needId = formString(formData, "needId");
+  const formAgentId = formString(formData, "agentId");
+  const action = parseAction(formString(formData, "action"));
+  const note = formString(formData, "note");
+  if (!needId || !formAgentId) {
+    throw new Error("missing_work_pattern_review_input");
+  }
+
+  const need = await prisma.coworkerCapabilityNeed.findUnique({
+    where: { needId },
+    include: {
+      assessment: {
+        select: { routeContext: true },
+      },
+    },
+  }) as ReviewNeedRow | null;
+  if (!need) throw new Error("work_pattern_need_not_found");
+  if (need.agentId !== formAgentId) throw new Error("work_pattern_need_agent_mismatch");
+
+  const evidenceJson = recordFrom(need.evidenceJson);
+  const readinessJson = recordFrom(need.readinessJson);
+  const patternKey =
+    stringField(evidenceJson, "patternKey") ?? stringField(readinessJson, "patternKey");
+  if (!patternKey) throw new Error("work_pattern_missing_pattern_key");
+
+  const shadowTrials = [
+    ...parseWorkPatternShadowTrials(evidenceJson.shadowTrials),
+    ...parseWorkPatternShadowTrials(readinessJson.shadowTrials),
+  ];
+  const currentLevel =
+    parseAutonomyLevel(stringField(evidenceJson, "currentAutonomyLevel")) ??
+    parseAutonomyLevel(stringField(readinessJson, "currentAutonomyLevel"));
+  const regulatoryCeiling =
+    parseAutonomyLevel(stringField(evidenceJson, "regulatoryCeiling")) ??
+    parseAutonomyLevel(stringField(readinessJson, "regulatoryCeiling"));
+  const shadowRiskClass =
+    parseRiskClass(stringField(evidenceJson, "shadowRiskClass")) ??
+    parseRiskClass(stringField(readinessJson, "shadowRiskClass")) ??
+    parseRiskClass(stringField(evidenceJson, "riskClass")) ??
+    parseRiskClass(stringField(readinessJson, "riskClass"));
+  const shadowEvaluation = shadowTrials.length > 0
+    ? evaluateWorkPatternShadowEvidence({
+        trials: shadowTrials,
+        currentLevel,
+        regulatoryCeiling,
+        riskClass: shadowRiskClass,
+      })
+    : null;
+  const decisionInteractionId = createDecisionInteractionId();
+  const decisionScope = parseDecisionScope(
+    stringField(evidenceJson, "decisionScope") ?? stringField(readinessJson, "decisionScope"),
+  );
+  const review = buildWorkPatternReview({
+    action,
+    needId: need.needId,
+    agentId: need.agentId,
+    patternKey,
+    routeContext: need.assessment?.routeContext ?? null,
+    riskClass: shadowEvaluation?.riskClass ?? shadowRiskClass,
+    decisionScope,
+    candidate: candidateFromNeed(need, evidenceJson),
+    shadowEvaluation,
+    decisionInteractionId,
+    reviewerUserId: userId,
+    reviewedAt: new Date(),
+    reviewerNote: note,
+  });
+  const outcomeType = outcomeTypeFor(action);
+  const routeContext = buildRoute(need.agentId);
+  const confidence = shadowEvaluation?.agreementRate ?? 0;
+
+  await prisma.$transaction(async (tx) => {
+    await tx.decisionInteraction.create({
+      data: {
+        interactionId: decisionInteractionId,
+        profileId: MARK_DPF_PLATFORM_PROFILE.profileId,
+        profileVersionId: MARK_DPF_PLATFORM_PROFILE.currentVersion.versionId,
+        fallbackProfileId: MARK_DPF_PLATFORM_PROFILE.fallbackProfileId,
+        triggeredByUserId: userId,
+        routeContext,
+        phaseFrom: null,
+        phaseTo: null,
+        domainClass: "risk-assessment",
+        question: `Review Living Playbook candidate "${need.need}" for ${need.agentId}?`,
+        options: ["Approve scoped activation candidate", "Defer for more evidence", "Reject candidate"],
+        evidenceBundle: {
+          workPatternReview: review,
+          shadowEvaluation,
+          capabilityNeedId: need.needId,
+          linkedBacklogItemId: need.linkedBacklogItemId ?? null,
+          materialCount: 0,
+          freshnessDistribution: { current: 0, stale: 0, superseded: 0, contradicted: 0 },
+          resolvedProfileChain: [MARK_DPF_PLATFORM_PROFILE.profileId],
+        },
+        sources: evidenceSources({ need, evidenceJson }),
+        rationale: note ?? `Operator recorded ${action} for Living Playbook candidate ${patternKey}.`,
+        riskTier: riskTierFor(shadowEvaluation?.riskClass ?? shadowRiskClass),
+        confidenceBefore: confidence,
+        confidenceAfter: confidence,
+        outcomeType,
+        principleConflict: false,
+        outcomePayload: {
+          outcomeType,
+          domainClass: "risk-assessment",
+          confidenceScore: confidence,
+          coverageGap: false,
+          principleConflict: false,
+          resolvedProfileChain: [MARK_DPF_PLATFORM_PROFILE.profileId],
+          materialCount: 0,
+          freshnessDistribution: { current: 0, stale: 0, superseded: 0, contradicted: 0 },
+          workPatternReview: review,
+        },
+        humanOutcome: {
+          type: "work-pattern-review",
+          action,
+          chosenOption:
+            action === "approve"
+              ? "Approve scoped activation candidate"
+              : action === "defer"
+                ? "Defer for more evidence"
+                : "Reject candidate",
+          rationale: note,
+          resolverUserId: userId,
+          recordedAt: review.reviewedAt,
+          clearsGate: false,
+        },
+      },
+    });
+
+    await tx.coworkerCapabilityNeed.update({
+      where: { needId },
+      data: {
+        status: capabilityNeedStatusForReviewAction(action),
+        reviewerNote: note,
+        evidenceJson: {
+          ...evidenceJson,
+          decisionInteractionId,
+          decisionInteractionIds: appendString(evidenceJson.decisionInteractionIds, decisionInteractionId),
+        } as Prisma.InputJsonValue,
+        readinessJson: mergeWorkPatternReviewState(readinessJson, review) as Prisma.InputJsonValue,
+      },
+    });
+  });
+
+  revalidatePath(routeContext);
+  return {
+    status: "recorded",
+    action,
+    needId,
+    decisionInteractionId,
+  };
+}
+
+export async function reviewWorkPatternAction(formData: FormData): Promise<void> {
+  await recordWorkPatternReview(formData);
+}

--- a/apps/web/lib/tak/work-pattern-read-model.test.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.test.ts
@@ -138,6 +138,42 @@ describe("getWorkPatternReadModel", () => {
               observedAt: "2026-06-28T10:30:00.000Z",
             })),
           },
+          readinessJson: {
+            activationProposed: true,
+            workPatternReview: {
+              action: "approve",
+              status: "approved-candidate",
+              needId: "NEED-1",
+              agentId: "build-specialist",
+              patternKey: "grant-denial|build-specialist|/build",
+              routeContext: "/build",
+              riskClass: "internal-reversible",
+              decisionScope: "platform-wwmd",
+              decisionInteractionId: "DI-REVIEW001",
+              reviewerUserId: "user-1",
+              reviewedAt: "2026-06-28T11:00:00.000Z",
+              reviewerNote: "Approve only for sandbox lease filing.",
+              blockers: ["activation-candidate-awaits-governed-promotion"],
+              activationProposed: true,
+              activationCandidate: {
+                state: "candidate",
+                activationAllowed: false,
+                patternKey: "grant-denial|build-specialist|/build",
+                agentId: "build-specialist",
+                routeContext: "/build",
+                riskClass: "internal-reversible",
+                decisionScope: "platform-wwmd",
+                currentAutonomyLevel: "shadow",
+                proposedAutonomyLevel: "propose",
+                evidenceSummary: {
+                  samples: 20,
+                  agreements: 19,
+                  agreementRate: 0.95,
+                },
+                blockers: ["activation-candidate-awaits-governed-promotion"],
+              },
+            },
+          },
         }),
         capabilityNeed({
           needId: "NEED-2",
@@ -179,7 +215,22 @@ describe("getWorkPatternReadModel", () => {
       ]),
     );
     expect(observed?.readiness.blockers).toContain("pattern-status-not-approved-or-active");
-    expect(observed?.activationProposed).toBe(false);
+    expect(observed?.activationProposed).toBe(true);
+    expect(observed?.reviewState).toMatchObject({
+      action: "approve",
+      status: "approved-candidate",
+      decisionInteractionId: "DI-REVIEW001",
+    });
+    expect(observed?.activationCandidate).toMatchObject({
+      activationAllowed: false,
+      currentAutonomyLevel: "shadow",
+      proposedAutonomyLevel: "propose",
+    });
+    expect(observed?.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ decisionInteractionId: "DI-REVIEW001" }),
+      ]),
+    );
     expect(observed?.shadowEvaluation).toMatchObject({
       samples: 20,
       agreements: 19,
@@ -212,6 +263,8 @@ describe("getWorkPatternReadModel", () => {
       linkedNeedIds: ["NEED-2"],
       routeContext: "/build",
       activationProposed: false,
+      reviewState: null,
+      activationCandidate: null,
       shadowEvaluation: null,
     });
   });

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -26,6 +26,11 @@ import {
   type WorkPatternShadowEvaluation,
   type WorkPatternShadowTrial,
 } from "./work-pattern-shadow-evaluation";
+import {
+  parseWorkPatternReviewState,
+  type WorkPatternActivationCandidate,
+  type WorkPatternReviewState,
+} from "./work-pattern-review";
 
 const DEFAULT_WINDOW_DAYS = 30;
 const DEFAULT_TAKE = 200;
@@ -113,6 +118,8 @@ export type WorkPatternSummary = {
   openNeedCount: number;
   readiness: WorkPatternReadiness;
   activationProposed: boolean;
+  reviewState: WorkPatternReviewState | null;
+  activationCandidate: WorkPatternActivationCandidate | null;
   shadowEvaluation: WorkPatternShadowEvaluation | null;
 };
 
@@ -455,6 +462,8 @@ function createAccumulator(seed: PatternSeed): SummaryAccumulator {
     openNeedCount: 0,
     readiness: seed.readiness,
     activationProposed: seed.activationProposed,
+    reviewState: null,
+    activationCandidate: null,
     shadowTrials: [],
     shadowCurrentLevel: null,
     shadowRegulatoryCeiling: null,
@@ -562,6 +571,19 @@ function maxDate(left: Date | null, right: Date | null): Date | null {
   return right.getTime() > left.getTime() ? right : left;
 }
 
+function reviewTimestamp(review: WorkPatternReviewState): number {
+  const timestamp = Date.parse(review.reviewedAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function newerReview(
+  left: WorkPatternReviewState | null,
+  right: WorkPatternReviewState,
+): WorkPatternReviewState {
+  if (!left) return right;
+  return reviewTimestamp(right) >= reviewTimestamp(left) ? right : left;
+}
+
 function observeRun(summary: SummaryAccumulator, row: WorkPatternReadModelTaskRunRow): void {
   const status = row.status ?? "unknown";
   summary.observedRuns += 1;
@@ -585,6 +607,7 @@ function observeRun(summary: SummaryAccumulator, row: WorkPatternReadModelTaskRu
 
 function attachNeed(summary: SummaryAccumulator, row: WorkPatternReadModelNeedRow): void {
   const kind = knownKind(row.kind);
+  const reviewState = parseWorkPatternReviewState(row.readinessJson);
   summary.candidateNeedKinds.add(kind);
   summary.linkedNeedIds.add(row.needId);
   if (OPEN_NEED_STATUSES.has(row.status)) {
@@ -593,9 +616,19 @@ function attachNeed(summary: SummaryAccumulator, row: WorkPatternReadModelNeedRo
   if (!summary.candidate) {
     summary.candidate = seedFromNeed(row)?.candidate ?? null;
   }
-  summary.activationProposed =
-    summary.activationProposed ||
-    (booleanField(row.readinessJson, "activationProposed") ?? false);
+  if (reviewState) {
+    summary.reviewState = newerReview(summary.reviewState, reviewState);
+    summary.activationCandidate = summary.reviewState.activationCandidate;
+    summary.activationProposed = Boolean(summary.activationCandidate);
+    addEvidence(summary, [{
+      capabilityNeedId: row.needId,
+      decisionInteractionId: reviewState.decisionInteractionId,
+    }]);
+  } else {
+    summary.activationProposed =
+      summary.activationProposed ||
+      (booleanField(row.readinessJson, "activationProposed") ?? false);
+  }
   summary.shadowTrials.push(...shadowTrialsFromNeed(row));
   summary.shadowCurrentLevel =
     summary.shadowCurrentLevel ?? autonomyLevelFromNeed(row, "currentAutonomyLevel");

--- a/apps/web/lib/tak/work-pattern-review.test.ts
+++ b/apps/web/lib/tak/work-pattern-review.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkPatternShadowEvaluation } from "./work-pattern-shadow-evaluation";
+import {
+  buildWorkPatternReview,
+  capabilityNeedStatusForReviewAction,
+  mergeWorkPatternReviewState,
+  parseWorkPatternReviewState,
+  type BuildWorkPatternReviewInput,
+  workPatternReviewStatusForAction,
+} from "./work-pattern-review";
+
+function promotableShadowEvaluation(): WorkPatternShadowEvaluation {
+  return {
+    samples: 20,
+    agreements: 19,
+    agreementRate: 0.95,
+    riskClass: "internal-reversible",
+    currentLevel: "shadow",
+    trustRecommendation: {
+      action: "promote",
+      from: "shadow",
+      to: "propose",
+      reason: "agreement 95% >= 90% over 20 samples",
+    },
+    decision: "approve-narrower-scope",
+    activationAllowed: false,
+    improvementTotals: {
+      toolCallDelta: -3,
+      failureDelta: -1,
+      manualTouchDelta: 0,
+      contextTokenDelta: -100,
+      reviewFailureDelta: 0,
+    },
+    blockers: [],
+  };
+}
+
+function baseInput(overrides: Partial<BuildWorkPatternReviewInput> = {}): BuildWorkPatternReviewInput {
+  const input: BuildWorkPatternReviewInput = {
+    action: "approve" as const,
+    needId: "NEED-1",
+    agentId: "build-specialist",
+    patternKey: "grant-denial|build-specialist|/build",
+    routeContext: "/build",
+    riskClass: "internal-reversible",
+    decisionScope: "platform-wwmd" as const,
+    candidate: {
+      kind: "grant" as const,
+      need: "Missing sandbox lease grant",
+      blocks: "Repeated grant denials block verification.",
+      fingerprint: "fp-grant",
+    },
+    shadowEvaluation: promotableShadowEvaluation(),
+    decisionInteractionId: "DI-REVIEW001",
+    reviewerUserId: "user-1",
+    reviewedAt: new Date("2026-06-28T12:00:00.000Z"),
+  };
+  return { ...input, ...overrides };
+}
+
+describe("work-pattern-review", () => {
+  it("creates a scoped activation candidate for an approved promotable shadow pattern", () => {
+    const review = buildWorkPatternReview(baseInput());
+
+    expect(review).toMatchObject({
+      action: "approve",
+      status: "approved-candidate",
+      needId: "NEED-1",
+      decisionInteractionId: "DI-REVIEW001",
+      activationProposed: true,
+    });
+    expect(review.activationCandidate).toMatchObject({
+      state: "candidate",
+      activationAllowed: false,
+      patternKey: "grant-denial|build-specialist|/build",
+      agentId: "build-specialist",
+      routeContext: "/build",
+      riskClass: "internal-reversible",
+      currentAutonomyLevel: "shadow",
+      proposedAutonomyLevel: "propose",
+      decisionScope: "platform-wwmd",
+    });
+    expect(review.blockers).toContain("activation-candidate-awaits-governed-promotion");
+  });
+
+  it("blocks approval when the shadow decision is not promotable", () => {
+    expect(() =>
+      buildWorkPatternReview(
+        baseInput({
+          shadowEvaluation: {
+            ...promotableShadowEvaluation(),
+            trustRecommendation: { action: "hold", level: "shadow", reason: "not enough evidence" },
+            decision: "continue-shadow",
+          },
+        }),
+      ),
+    ).toThrow("approval_requires_promotable_shadow_evidence");
+  });
+
+  it("preserves rejected review state in readiness JSON without proposing activation", () => {
+    const review = buildWorkPatternReview(
+      baseInput({
+        action: "reject",
+        shadowEvaluation: null,
+        candidate: null,
+      }),
+    );
+    const merged = mergeWorkPatternReviewState(
+      {
+        readyForReview: true,
+        readyForCaseActivation: false,
+        blockers: ["pattern-status-not-approved-or-active"],
+      },
+      review,
+    );
+
+    expect(merged).toMatchObject({
+      readyForReview: true,
+      activationProposed: false,
+    });
+    expect(parseWorkPatternReviewState(merged)).toMatchObject({
+      action: "reject",
+      status: "rejected",
+      decisionInteractionId: "DI-REVIEW001",
+      activationCandidate: null,
+    });
+  });
+
+  it("maps review actions to need statuses and review statuses", () => {
+    expect(capabilityNeedStatusForReviewAction("approve")).toBe("accepted");
+    expect(capabilityNeedStatusForReviewAction("defer")).toBe("deferred");
+    expect(capabilityNeedStatusForReviewAction("reject")).toBe("discarded");
+    expect(workPatternReviewStatusForAction("approve")).toBe("approved-candidate");
+    expect(workPatternReviewStatusForAction("defer")).toBe("deferred");
+    expect(workPatternReviewStatusForAction("reject")).toBe("rejected");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-review.ts
+++ b/apps/web/lib/tak/work-pattern-review.ts
@@ -1,0 +1,293 @@
+import type { AutonomyLevel, RiskClass } from "@/lib/autonomy/trust-graduation";
+import type {
+  CoworkerCapabilityNeedStatus,
+} from "@/lib/coworker-self-assessment/types";
+import type { WorkPatternShadowEvaluation } from "./work-pattern-shadow-evaluation";
+import type {
+  WorkPatternCandidate,
+  WorkPatternDecisionScope,
+} from "./work-pattern-types";
+
+export const WORK_PATTERN_REVIEW_ACTIONS = ["approve", "reject", "defer"] as const;
+export type WorkPatternReviewAction = (typeof WORK_PATTERN_REVIEW_ACTIONS)[number];
+
+export const WORK_PATTERN_REVIEW_STATUSES = [
+  "approved-candidate",
+  "rejected",
+  "deferred",
+] as const;
+export type WorkPatternReviewStatus = (typeof WORK_PATTERN_REVIEW_STATUSES)[number];
+
+export type WorkPatternActivationCandidate = {
+  state: "candidate";
+  activationAllowed: false;
+  patternKey: string;
+  agentId: string;
+  routeContext: string | null;
+  riskClass: RiskClass | null;
+  decisionScope: WorkPatternDecisionScope;
+  currentAutonomyLevel: AutonomyLevel;
+  proposedAutonomyLevel: AutonomyLevel;
+  evidenceSummary: {
+    samples: number;
+    agreements: number;
+    agreementRate: number | null;
+  };
+  blockers: string[];
+};
+
+export type WorkPatternReviewState = {
+  action: WorkPatternReviewAction;
+  status: WorkPatternReviewStatus;
+  needId: string;
+  agentId: string;
+  patternKey: string;
+  routeContext: string | null;
+  riskClass: RiskClass | null;
+  decisionScope: WorkPatternDecisionScope;
+  decisionInteractionId: string;
+  reviewerUserId: string;
+  reviewedAt: string;
+  reviewerNote: string | null;
+  blockers: string[];
+  activationProposed: boolean;
+  activationCandidate: WorkPatternActivationCandidate | null;
+};
+
+export type BuildWorkPatternReviewInput = {
+  action: WorkPatternReviewAction;
+  needId: string;
+  agentId: string;
+  patternKey: string;
+  routeContext: string | null;
+  riskClass: RiskClass | null;
+  decisionScope: WorkPatternDecisionScope;
+  candidate: WorkPatternCandidate | null;
+  shadowEvaluation: WorkPatternShadowEvaluation | null;
+  decisionInteractionId: string;
+  reviewerUserId: string;
+  reviewedAt: Date;
+  reviewerNote?: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isAction(value: unknown): value is WorkPatternReviewAction {
+  return typeof value === "string" && WORK_PATTERN_REVIEW_ACTIONS.includes(value as WorkPatternReviewAction);
+}
+
+function isStatus(value: unknown): value is WorkPatternReviewStatus {
+  return typeof value === "string" && WORK_PATTERN_REVIEW_STATUSES.includes(value as WorkPatternReviewStatus);
+}
+
+function stringField(source: Record<string, unknown>, field: string): string | null {
+  const value = source[field];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function booleanField(source: Record<string, unknown>, field: string): boolean | null {
+  const value = source[field];
+  return typeof value === "boolean" ? value : null;
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
+}
+
+function parseRiskClass(value: unknown): RiskClass | null {
+  return (
+    value === "read-only" ||
+    value === "internal-reversible" ||
+    value === "internal-irreversible" ||
+    value === "outbound-or-floor"
+  )
+    ? value
+    : null;
+}
+
+function parseAutonomyLevel(value: unknown): AutonomyLevel | null {
+  return value === "shadow" || value === "propose" || value === "supervised" || value === "autopilot"
+    ? value
+    : null;
+}
+
+function parseDecisionScope(value: unknown): WorkPatternDecisionScope | null {
+  return value === "platform-wwmd" || value === "company-wwwd" || value === "profession-wsid"
+    ? value
+    : null;
+}
+
+function parseActivationCandidate(value: unknown): WorkPatternActivationCandidate | null {
+  if (!isRecord(value)) return null;
+  const patternKey = stringField(value, "patternKey");
+  const agentId = stringField(value, "agentId");
+  const decisionScope = parseDecisionScope(value.decisionScope);
+  const currentAutonomyLevel = parseAutonomyLevel(value.currentAutonomyLevel);
+  const proposedAutonomyLevel = parseAutonomyLevel(value.proposedAutonomyLevel);
+  const evidenceSummary = isRecord(value.evidenceSummary) ? value.evidenceSummary : {};
+  if (
+    value.state !== "candidate" ||
+    value.activationAllowed !== false ||
+    !patternKey ||
+    !agentId ||
+    !decisionScope ||
+    !currentAutonomyLevel ||
+    !proposedAutonomyLevel
+  ) {
+    return null;
+  }
+  return {
+    state: "candidate",
+    activationAllowed: false,
+    patternKey,
+    agentId,
+    routeContext: typeof value.routeContext === "string" ? value.routeContext : null,
+    riskClass: parseRiskClass(value.riskClass),
+    decisionScope,
+    currentAutonomyLevel,
+    proposedAutonomyLevel,
+    evidenceSummary: {
+      samples: typeof evidenceSummary.samples === "number" ? evidenceSummary.samples : 0,
+      agreements: typeof evidenceSummary.agreements === "number" ? evidenceSummary.agreements : 0,
+      agreementRate: typeof evidenceSummary.agreementRate === "number" ? evidenceSummary.agreementRate : null,
+    },
+    blockers: parseStringArray(value.blockers),
+  };
+}
+
+function activationCandidateFrom(input: BuildWorkPatternReviewInput): WorkPatternActivationCandidate {
+  const evaluation = input.shadowEvaluation;
+  const recommendation = evaluation?.trustRecommendation;
+  if (
+    !evaluation ||
+    evaluation.decision !== "approve-narrower-scope" ||
+    recommendation?.action !== "promote"
+  ) {
+    throw new Error("approval_requires_promotable_shadow_evidence");
+  }
+  return {
+    state: "candidate",
+    activationAllowed: false,
+    patternKey: input.patternKey,
+    agentId: input.agentId,
+    routeContext: input.routeContext,
+    riskClass: input.riskClass,
+    decisionScope: input.decisionScope,
+    currentAutonomyLevel: evaluation.currentLevel,
+    proposedAutonomyLevel: recommendation.to,
+    evidenceSummary: {
+      samples: evaluation.samples,
+      agreements: evaluation.agreements,
+      agreementRate: evaluation.agreementRate,
+    },
+    blockers: ["activation-candidate-awaits-governed-promotion"],
+  };
+}
+
+export function workPatternReviewStatusForAction(
+  action: WorkPatternReviewAction,
+): WorkPatternReviewStatus {
+  if (action === "approve") return "approved-candidate";
+  if (action === "reject") return "rejected";
+  return "deferred";
+}
+
+export function capabilityNeedStatusForReviewAction(
+  action: WorkPatternReviewAction,
+): CoworkerCapabilityNeedStatus {
+  if (action === "approve") return "accepted";
+  if (action === "reject") return "discarded";
+  return "deferred";
+}
+
+export function buildWorkPatternReview(input: BuildWorkPatternReviewInput): WorkPatternReviewState {
+  const activationCandidate =
+    input.action === "approve" ? activationCandidateFrom(input) : null;
+  const blockers = activationCandidate
+    ? [...activationCandidate.blockers]
+    : input.action === "reject"
+      ? ["operator-rejected-pattern-candidate"]
+      : ["operator-deferred-pattern-candidate"];
+
+  return {
+    action: input.action,
+    status: workPatternReviewStatusForAction(input.action),
+    needId: input.needId,
+    agentId: input.agentId,
+    patternKey: input.patternKey,
+    routeContext: input.routeContext,
+    riskClass: input.riskClass,
+    decisionScope: input.decisionScope,
+    decisionInteractionId: input.decisionInteractionId,
+    reviewerUserId: input.reviewerUserId,
+    reviewedAt: input.reviewedAt.toISOString(),
+    reviewerNote: input.reviewerNote?.trim() || null,
+    blockers,
+    activationProposed: Boolean(activationCandidate),
+    activationCandidate,
+  };
+}
+
+export function mergeWorkPatternReviewState(
+  readinessJson: unknown,
+  review: WorkPatternReviewState,
+): Record<string, unknown> {
+  const base = isRecord(readinessJson) ? readinessJson : {};
+  return {
+    ...base,
+    activationProposed: review.activationProposed,
+    workPatternReview: review,
+  };
+}
+
+export function parseWorkPatternReviewState(value: unknown): WorkPatternReviewState | null {
+  const review = isRecord(value) && isRecord(value.workPatternReview)
+    ? value.workPatternReview
+    : value;
+  if (!isRecord(review)) return null;
+
+  const action = isAction(review.action) ? review.action : null;
+  const status = isStatus(review.status) ? review.status : null;
+  const needId = stringField(review, "needId");
+  const agentId = stringField(review, "agentId");
+  const patternKey = stringField(review, "patternKey");
+  const decisionInteractionId = stringField(review, "decisionInteractionId");
+  const reviewerUserId = stringField(review, "reviewerUserId");
+  const reviewedAt = stringField(review, "reviewedAt");
+  const decisionScope = parseDecisionScope(review.decisionScope);
+  if (
+    !action ||
+    !status ||
+    !needId ||
+    !agentId ||
+    !patternKey ||
+    !decisionInteractionId ||
+    !reviewerUserId ||
+    !reviewedAt ||
+    !decisionScope
+  ) {
+    return null;
+  }
+
+  const activationCandidate = parseActivationCandidate(review.activationCandidate);
+  return {
+    action,
+    status,
+    needId,
+    agentId,
+    patternKey,
+    routeContext: typeof review.routeContext === "string" ? review.routeContext : null,
+    riskClass: parseRiskClass(review.riskClass),
+    decisionScope,
+    decisionInteractionId,
+    reviewerUserId,
+    reviewedAt,
+    reviewerNote: typeof review.reviewerNote === "string" ? review.reviewerNote : null,
+    blockers: parseStringArray(review.blockers),
+    activationProposed: booleanField(review, "activationProposed") ?? Boolean(activationCandidate),
+    activationCandidate,
+  };
+}

--- a/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-review-activation.md
+++ b/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-review-activation.md
@@ -1,0 +1,445 @@
+# Governed Adaptive Playbooks Review Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first integrated operator review loop for Living Playbook candidates: approve, reject, or defer shadow-backed proposals while recording governed evidence and never mutating live autonomy or Work Case state.
+
+**Architecture:** Keep the feature migration-free. A pure TAK review module owns action validation, activation-candidate shaping, risk ceiling checks, and readiness JSON merges; a thin server action writes `DecisionInteraction` plus `CoworkerCapabilityNeed` updates. The existing coworker record Needs & Playbooks panel becomes the compact operator surface, and the read model projects review state from existing JSON so rejected/deferred candidates remain visible without adding a `WorkPattern` table.
+
+**Tech Stack:** Next.js 16 server actions, Prisma 7 via `@dpf/db`, Vitest, React server rendering tests, existing `DecisionInteraction`, `CoworkerCapabilityNeed`, and TAK work-pattern read models.
+
+---
+
+## Chunk 1: Review Semantics
+
+### Task 1: Pure Work Pattern Review Model
+
+**Files:**
+- Create: `apps/web/lib/tak/work-pattern-review.ts`
+- Create: `apps/web/lib/tak/work-pattern-review.test.ts`
+- Reference: `apps/web/lib/tak/work-pattern-shadow-evaluation.ts`
+- Reference: `apps/web/lib/tak/work-pattern-types.ts`
+
+- [x] **Step 1: Write failing review model tests**
+
+Add tests for these behaviors:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkPatternReview,
+  mergeWorkPatternReviewState,
+  parseWorkPatternReviewState,
+} from "./work-pattern-review";
+
+describe("work-pattern-review", () => {
+  it("creates a scoped activation candidate for an approved promotable shadow pattern", () => {
+    const reviewedAt = new Date("2026-06-28T12:00:00.000Z");
+    const review = buildWorkPatternReview({
+      action: "approve",
+      needId: "NEED-1",
+      agentId: "build-specialist",
+      patternKey: "grant-denial|build-specialist|/build",
+      routeContext: "/build",
+      riskClass: "internal-reversible",
+      decisionScope: "platform-wwmd",
+      candidate: {
+        kind: "grant",
+        need: "Missing sandbox lease grant",
+        blocks: "Repeated grant denials block verification.",
+        fingerprint: "fp-grant",
+      },
+      shadowEvaluation: {
+        samples: 20,
+        agreements: 19,
+        agreementRate: 0.95,
+        riskClass: "internal-reversible",
+        currentLevel: "shadow",
+        trustRecommendation: { action: "promote", from: "shadow", to: "propose", reason: "enough agreement" },
+        decision: "approve-narrower-scope",
+        activationAllowed: false,
+        improvementTotals: { toolCallDelta: -3, failureDelta: -1, manualTouchDelta: 0, contextTokenDelta: -100, reviewFailureDelta: 0 },
+        blockers: [],
+      },
+      decisionInteractionId: "DI-1",
+      reviewerUserId: "user-1",
+      reviewedAt,
+    });
+
+    expect(review.activationCandidate).toMatchObject({
+      state: "candidate",
+      activationAllowed: false,
+      patternKey: "grant-denial|build-specialist|/build",
+      routeContext: "/build",
+      proposedAutonomyLevel: "propose",
+    });
+    expect(review.blockers).toContain("activation-candidate-awaits-governed-promotion");
+  });
+
+  it("blocks approval when the shadow decision is not promotable", () => {
+    expect(() => buildWorkPatternReview({
+      action: "approve",
+      needId: "NEED-1",
+      agentId: "build-specialist",
+      patternKey: "grant-denial|build-specialist|/build",
+      routeContext: "/build",
+      riskClass: "internal-reversible",
+      decisionScope: "platform-wwmd",
+      candidate: null,
+      shadowEvaluation: null,
+      decisionInteractionId: "DI-1",
+      reviewerUserId: "user-1",
+      reviewedAt: new Date("2026-06-28T12:00:00.000Z"),
+    })).toThrow("approval_requires_promotable_shadow_evidence");
+  });
+
+  it("preserves rejected and deferred review state in readiness JSON", () => {
+    const review = buildWorkPatternReview({
+      action: "reject",
+      needId: "NEED-1",
+      agentId: "build-specialist",
+      patternKey: "grant-denial|build-specialist|/build",
+      routeContext: "/build",
+      riskClass: "internal-reversible",
+      decisionScope: "platform-wwmd",
+      candidate: null,
+      shadowEvaluation: null,
+      decisionInteractionId: "DI-1",
+      reviewerUserId: "user-1",
+      reviewedAt: new Date("2026-06-28T12:00:00.000Z"),
+    });
+    const merged = mergeWorkPatternReviewState({ readyForReview: true }, review);
+
+    expect(parseWorkPatternReviewState(merged)).toMatchObject({
+      action: "reject",
+      decisionInteractionId: "DI-1",
+      status: "rejected",
+    });
+  });
+});
+```
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-review.test.ts`
+
+Expected: FAIL because `work-pattern-review.ts` does not exist.
+
+- [x] **Step 2: Implement the pure module**
+
+Create `apps/web/lib/tak/work-pattern-review.ts` with:
+
+- `WorkPatternReviewAction = "approve" | "reject" | "defer"`
+- `WorkPatternReviewStatus = "approved-candidate" | "rejected" | "deferred"`
+- `WorkPatternActivationCandidate` carrying `activationAllowed: false`, pattern key, agent, route, decision scope, risk class, current/proposed autonomy level, evidence summary, and blockers
+- `WorkPatternReviewState` carrying action, status, reviewer, timestamp, note, `decisionInteractionId`, blockers, and optional activation candidate
+- `buildWorkPatternReview(input)` that allows approval only when shadow evaluation says `approve-narrower-scope` and trust recommendation action is `promote`
+- `mergeWorkPatternReviewState(readinessJson, review)` that preserves existing readiness fields while adding `workPatternReview` and top-level `activationProposed`
+- `parseWorkPatternReviewState(value)` that tolerates missing/old JSON and returns `null` for malformed state
+- `workPatternReviewStatusForAction(action)` and `capabilityNeedStatusForReviewAction(action)` helpers, mapping approve to `accepted`, reject to `discarded`, and defer to `deferred`
+
+Keep the module pure: no Prisma, no server-action imports, no React.
+
+- [x] **Step 3: Run the review model test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-review.test.ts`
+
+Expected: PASS.
+
+---
+
+## Chunk 2: Governed Write Path
+
+### Task 2: Server Action Writes Decision Evidence and Need State
+
+**Files:**
+- Create: `apps/web/lib/actions/work-pattern-review.ts`
+- Create: `apps/web/lib/actions/work-pattern-review.test.ts`
+- Reference: `apps/web/lib/actions/shared/guards.ts`
+- Reference: `apps/web/lib/decision-perspective/default-profile.ts`
+- Reference: `apps/web/lib/decision-perspective/persistence.ts`
+
+- [x] **Step 1: Write failing action tests**
+
+Add tests that mock `@dpf/db`, `next/cache`, and the shared guard:
+
+```ts
+it("records approval as a DecisionInteraction and scoped activation candidate", async () => {
+  const form = new FormData();
+  form.set("needId", "NEED-1");
+  form.set("agentId", "build-specialist");
+  form.set("action", "approve");
+  form.set("note", "Approve only for sandbox lease filing.");
+
+  await expect(reviewWorkPatternAction(form)).resolves.toMatchObject({
+    status: "recorded",
+    action: "approve",
+  });
+
+  expect(mockPrisma.decisionInteraction.create).toHaveBeenCalledWith({
+    data: expect.objectContaining({
+      domainClass: "risk-assessment",
+      routeContext: "/platform/ai/agent/build-specialist",
+      outcomeType: "recommend",
+      humanOutcome: expect.objectContaining({
+        type: "work-pattern-review",
+        action: "approve",
+        clearsGate: false,
+      }),
+    }),
+  });
+  expect(mockPrisma.coworkerCapabilityNeed.update).toHaveBeenCalledWith({
+    where: { needId: "NEED-1" },
+    data: expect.objectContaining({
+      status: "accepted",
+      reviewerNote: "Approve only for sandbox lease filing.",
+    }),
+  });
+});
+```
+
+Also cover:
+- Reject records `status: "discarded"` and leaves no activation candidate.
+- Defer records `status: "deferred"` and `outcomeType: "defer"`.
+- Approval fails before writing when shadow evidence is not promotable.
+- Unauthorized users fail through `requireCapability("manage_platform")`.
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/actions/work-pattern-review.test.ts`
+
+Expected: FAIL because action does not exist.
+
+- [x] **Step 2: Implement the server action**
+
+Create `apps/web/lib/actions/work-pattern-review.ts` with `"use server"` and:
+
+- `reviewWorkPatternAction(formData: FormData)`
+- `recordWorkPatternReview(input, deps?)` for testable internals
+- `requireCapability("manage_platform")`
+- load `CoworkerCapabilityNeed` by `needId`, including `assessment.routeContext`
+- extract `patternKey`, `decisionScope`, `riskClass`, `shadowTrials`, `currentAutonomyLevel`, and `regulatoryCeiling` from existing evidence/readiness JSON
+- evaluate shadow evidence with `evaluateWorkPatternShadowEvidence`
+- build the review with `buildWorkPatternReview`
+- create a `DecisionInteraction` directly with `createDecisionInteractionId()` and `MARK_DPF_PLATFORM_PROFILE`
+- use `domainClass: "risk-assessment"`
+- map risk class to decision risk tier:
+  - `read-only` -> `low`
+  - `internal-reversible` -> `medium`
+  - `internal-irreversible` -> `high`
+  - `outbound-or-floor` -> `critical`
+  - missing -> `medium`
+- set `humanOutcome.type = "work-pattern-review"` for every action so reject/defer records never appear as unresolved AI decisions
+- update `CoworkerCapabilityNeed` readiness/evidence JSON with the review state and `decisionInteractionId`
+- call `revalidatePath("/platform/ai/agent/<agentId>")`
+
+Do not update TrustState, Work Case rows, SkillDefinition, PromptTemplate, or backlog rows.
+
+- [x] **Step 3: Run the action test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/actions/work-pattern-review.test.ts`
+
+Expected: PASS.
+
+---
+
+## Chunk 3: Read Model Projection
+
+### Task 3: Project Review State into Living Playbooks
+
+**Files:**
+- Modify: `apps/web/lib/tak/work-pattern-read-model.ts`
+- Modify: `apps/web/lib/tak/work-pattern-read-model.test.ts`
+- Reference: `apps/web/lib/tak/work-pattern-review.ts`
+
+- [x] **Step 1: Write failing read-model expectations**
+
+Extend the existing `getWorkPatternReadModel` test fixture so `NEED-1.readinessJson` contains:
+
+```ts
+workPatternReview: {
+  action: "approve",
+  status: "approved-candidate",
+  decisionInteractionId: "DI-REVIEW",
+  reviewedAt: "2026-06-28T11:00:00.000Z",
+  reviewerUserId: "user-1",
+  blockers: ["activation-candidate-awaits-governed-promotion"],
+  activationCandidate: {
+    state: "candidate",
+    activationAllowed: false,
+    patternKey: "grant-denial|build-specialist|/build",
+    proposedAutonomyLevel: "propose",
+  },
+}
+```
+
+Assert:
+
+```ts
+expect(observed?.reviewState).toMatchObject({
+  action: "approve",
+  decisionInteractionId: "DI-REVIEW",
+});
+expect(observed?.activationCandidate).toMatchObject({
+  activationAllowed: false,
+  proposedAutonomyLevel: "propose",
+});
+expect(observed?.activationProposed).toBe(true);
+expect(observed?.evidenceRefs).toEqual(
+  expect.arrayContaining([expect.objectContaining({ decisionInteractionId: "DI-REVIEW" })]),
+);
+```
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-read-model.test.ts`
+
+Expected: FAIL because `reviewState` and `activationCandidate` are not projected.
+
+- [x] **Step 2: Implement read-model projection**
+
+Modify `WorkPatternSummary` and `SummaryAccumulator` to include:
+
+- `reviewState: WorkPatternReviewState | null`
+- `activationCandidate: WorkPatternActivationCandidate | null`
+
+In `attachNeed()`:
+
+- parse `row.readinessJson.workPatternReview`
+- keep the newest `reviewedAt` review when multiple linked needs exist
+- set `activationProposed` true only when the parsed review carries an activation candidate
+- add `decisionInteractionId` from the review to evidence refs even if `evidenceJson` is old
+
+- [x] **Step 3: Run the read-model test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/tak/work-pattern-read-model.test.ts`
+
+Expected: PASS.
+
+---
+
+## Chunk 4: Operator UI
+
+### Task 4: Add Review Controls to Needs & Playbooks
+
+**Files:**
+- Modify: `apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx`
+- Modify: `apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx`
+- Modify: `apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx`
+- Reference: `apps/web/lib/actions/work-pattern-review.ts`
+
+- [x] **Step 1: Write failing page rendering test**
+
+Extend the mocked work pattern in `page.test.tsx` with `reviewState: null` and `activationCandidate: null`, then assert the rendered page includes:
+
+```ts
+expect(html).toContain("Approve candidate");
+expect(html).toContain("Defer");
+expect(html).toContain("Reject");
+expect(html).not.toContain("Activate playbook");
+```
+
+Add a second pattern fixture with `reviewState.action = "approve"` and assert:
+
+```ts
+expect(html).toContain("Decision recorded");
+expect(html).toContain("activation candidate");
+```
+
+Run: `pnpm --filter web exec vitest run 'apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'`
+
+Expected: FAIL because the UI does not render review controls/state yet.
+
+- [x] **Step 2: Implement UI changes**
+
+Update the panel:
+
+- `NeedsAndPlaybooksPanel` accepts `canWrite: boolean`
+- `PlaybookRow` passes `canWrite`
+- When a pattern has shadow evidence, a linked need, and no review state, render a compact form row:
+  - hidden `needId`
+  - hidden `agentId`
+  - hidden `action`
+  - hidden `note` with action-specific default text
+  - buttons: `Approve candidate`, `Defer`, `Reject`
+- Approval button appears only when `shadowEvaluation.decision === "approve-narrower-scope"`
+- Use existing `Chip`, `Section`, `LocalTime`, and CSS variables; no new color literals
+- Use small dense forms and buttons within the existing row, not a new route, modal, or nested card
+- If `canWrite` is false, render review state only
+- Render recorded state as `Decision recorded`, action label, `DI-*`, and `activation candidate` when present
+- Never render copy implying live activation happened
+
+Update `page.tsx` to pass `canWrite={canWrite}`.
+
+- [x] **Step 3: Run the page rendering test**
+
+Run: `pnpm --filter web exec vitest run 'apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'`
+
+Expected: PASS.
+
+---
+
+## Chunk 5: Verification, Refactor, and Handoff
+
+### Task 5: Focused Refactor and Verification
+
+**Files:**
+- Review all changed files
+- Update this plan checkboxes as work completes
+
+- [x] **Step 1: Refactor after green**
+
+Spend the explicit refactor budget on:
+
+- keeping review parsing/building pure and isolated in `work-pattern-review.ts`
+- removing duplicated JSON parsing helpers between the server action and read model where practical without widening scope
+- making UI action rendering small enough that `NeedsAndPlaybooksPanel.tsx` remains readable
+
+- [x] **Step 2: Run focused tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run `
+  apps/web/lib/tak/work-pattern-review.test.ts `
+  apps/web/lib/actions/work-pattern-review.test.ts `
+  apps/web/lib/tak/work-pattern-read-model.test.ts `
+  'apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run source-local typecheck/build gates available in this worktree**
+
+Run:
+
+```powershell
+pnpm --filter web typecheck
+pnpm --filter web build
+```
+
+Expected: PASS, unless the worktree remains `source-only`; if the bootstrap/runtime limitation blocks local execution, record the exact blocker and rely on GitHub CI after push.
+
+- [x] **Step 4: Record capsule evidence**
+
+Use `record_capsule_evidence` for:
+
+- plan written
+- focused tests
+- typecheck/build or blocked local gate explanation
+- PR URL and CI summary once available
+
+- [ ] **Step 5: Commit, push, create ready PR, and fix CI**
+
+Commands:
+
+```powershell
+git status --short --branch
+git add docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-review-activation.md apps/web/lib/tak/work-pattern-review.ts apps/web/lib/tak/work-pattern-review.test.ts apps/web/lib/actions/work-pattern-review.ts apps/web/lib/actions/work-pattern-review.test.ts apps/web/lib/tak/work-pattern-read-model.ts apps/web/lib/tak/work-pattern-read-model.test.ts apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx 'apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx' 'apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'
+git commit -s -m "feat: add governed playbook review activation"
+git push -u origin feat/governed-adaptive-playbooks-review-activation
+gh pr create --base main --head feat/governed-adaptive-playbooks-review-activation --title "Add governed playbook review activation" --body-file <prepared-body>
+corepack pnpm pr:health <pr-number>
+```
+
+Expected: PR opens ready for review, CI passes or failures are investigated and fixed in this branch.
+
+### Completion Notes
+
+- No migration is planned.
+- No live autonomy, TrustState, Work Case, SkillDefinition, PromptTemplate, or backlog mutation is allowed in this slice.
+- Operator/user testing is intentionally deferred until all integrated slices are complete, per Mark's direction. Internal source-local tests, build gates, and GitHub CI remain required.

--- a/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-review-activation.md
+++ b/docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-review-activation.md
@@ -423,7 +423,7 @@ Use `record_capsule_evidence` for:
 - typecheck/build or blocked local gate explanation
 - PR URL and CI summary once available
 
-- [ ] **Step 5: Commit, push, create ready PR, and fix CI**
+- [x] **Step 5: Commit, push, create ready PR, and fix CI**
 
 Commands:
 


### PR DESCRIPTION
## Summary
- Adds a governed Living Playbook review action that records approve, reject, and defer decisions to `DecisionInteraction` with `humanOutcome` evidence.
- Projects review state and scoped activation candidates through the TAK work-pattern read model without mutating TrustState, Work Cases, skills, prompts, or backlog rows.
- Adds compact operator controls/status to the coworker Needs & Playbooks panel and a durable implementation plan for the slice.

## Validation
- `pnpm --filter web exec vitest run lib/tak/work-pattern-review.test.ts lib/actions/work-pattern-review.test.ts lib/tak/work-pattern-read-model.test.ts 'app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'` - 4 files, 13 tests passed
- `pnpm --filter web typecheck` - passed
- `pnpm --filter web build` - passed; existing Turbopack trace warnings remain around process.cwd/NFT tracing

## Notes
- This slice intentionally creates activation candidates only. It does not activate live autonomy or mutate Work Case state.
- Operator/user testing is deferred until the integrated slices are complete, per Mark's direction.


UX-Fit-Decision: compact-progressive-disclosure (principle_decide; low cognitive load, controls gated by write permission + shadow evidence)
