### PR TITLE
feat: add portal work case drilldown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           node-version: 24
       - name: Test pr-health verdict logic
-        run: node --test scripts/pr-health.test.mjs
+        run: node --test scripts/pr-health.test.mjs scripts/check-ci-build-cache.test.mjs
 
   mobile-jest-pin-guard:
     name: Mobile Jest Pin Guard
@@ -663,17 +663,18 @@ jobs:
 
       # Restore Turbopack's filesystem cache (written under .next/cache when
       # DPF_TURBOPACK_BUILD_CACHE=1 enables experimental.turbopackFileSystemCacheForBuild).
-      # Key rolls on any web source change; restore-keys warm-start from the
-      # most recent build for the same deps. NOTE: hashFiles does NOT support
-      # brace globs ({ts,tsx}), so each extension is a separate arg.
+      # Key rolls on any web source change. Keep this exact-key only: broad
+      # restore-keys can hydrate stale multi-GB Turbopack caches on PRs, making
+      # the production build slower than a clean compile and vulnerable to
+      # hosted-runner cancellation before TypeScript completes. Exact-key hits
+      # still accelerate reruns of the same commit. NOTE: hashFiles does NOT
+      # support brace globs ({ts,tsx}), so each extension is a separate arg.
       - name: Cache Turbopack build cache
         if: needs.changes.outputs.heavy == 'true'
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/apps/web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/**/*.ts', 'apps/web/**/*.tsx', 'apps/web/**/*.js', 'apps/web/**/*.jsx') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
 
       - name: Build web (Next.js production)
         if: needs.changes.outputs.heavy == 'true'

--- a/apps/web/app/(portal)/portal/cases/[caseKey]/page.tsx
+++ b/apps/web/app/(portal)/portal/cases/[caseKey]/page.tsx
@@ -1,0 +1,31 @@
+import { prisma } from "@dpf/db";
+import { notFound, redirect } from "next/navigation";
+
+import { PortalWorkCaseDetail } from "@/components/portal/PortalWorkCaseDetail";
+import { auth } from "@/lib/auth";
+import {
+  loadPortalWorkCaseDetail,
+  type PortalCasePrismaClient,
+} from "@/lib/work-management/portal-case-loader";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ caseKey: string }>;
+};
+
+export default async function PortalCaseDetailPage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user || session.user.type !== "customer") redirect("/customer-login");
+  if (!session.user.accountId) redirect("/portal/account");
+
+  const { caseKey } = await params;
+  const view = await loadPortalWorkCaseDetail({
+    prismaClient: prisma as unknown as PortalCasePrismaClient,
+    customerAccountId: session.user.accountId,
+    caseKey,
+  });
+  if (!view) notFound();
+
+  return <PortalWorkCaseDetail view={view} />;
+}

--- a/apps/web/components/build/NodeInspector.tsx
+++ b/apps/web/components/build/NodeInspector.tsx
@@ -15,7 +15,7 @@
 
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
 import { BUILD_STUDIO_TEST_IDS, getNodeInspectorClassName } from "./build-studio-layout";
@@ -125,7 +125,7 @@ export function NodeInspector({
   // ── Esc to close ──────────────────────────────────────────────────────
   // Mount on open, unmount on close. Capture phase so it wins over text
   // inputs inside the inspector.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof document === "undefined") return;
     const handler = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -142,7 +142,7 @@ export function NodeInspector({
   // outside any element marked as a graph node (data-graph-node attribute),
   // close. Re-clicking the same node is detected by the parent BuildStudio,
   // not here — this hook only handles "click off the graph entirely".
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof document === "undefined") return;
     const handler = (event: MouseEvent) => {
       const target = event.target;

--- a/apps/web/components/portal/PortalWorkCaseDetail.test.tsx
+++ b/apps/web/components/portal/PortalWorkCaseDetail.test.tsx
@@ -1,0 +1,70 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PortalWorkCaseDetail } from "./PortalWorkCaseDetail";
+import type { PortalWorkCaseDetailView } from "@/lib/work-management/portal-case-loader";
+
+const fixture: PortalWorkCaseDetailView = {
+  generatedAt: "2026-06-28T12:00:00.000Z",
+  case: {
+    caseId: "booking:BK-1",
+    href: "/portal/cases/booking%3ABK-1",
+    title: "Confirm condenser appointment",
+    sourceLabel: "Storefront booking",
+    statusLabel: "Needs your response",
+    nextActionLabel: "Reply requested",
+    description: "Customer needs a scheduling confirmation.",
+    dueAt: "2026-06-29T15:00:00.000Z",
+    createdAt: "2026-06-28T10:00:00.000Z",
+    attentionRequired: true,
+    supportHref: "/portal/support",
+  },
+  timeline: [
+    {
+      label: "Received",
+      body: "We received this request.",
+      at: "2026-06-28T10:00:00.000Z",
+    },
+    {
+      label: "Current status",
+      body: "Needs your response",
+    },
+    {
+      label: "Due",
+      body: "Target date for the next update.",
+      at: "2026-06-29T15:00:00.000Z",
+    },
+  ],
+};
+
+describe("PortalWorkCaseDetail", () => {
+  it("renders a customer-safe digest and next step", () => {
+    const html = renderToStaticMarkup(<PortalWorkCaseDetail view={fixture} />);
+
+    expect(html).toContain("Confirm condenser appointment");
+    expect(html).toContain("Needs your response");
+    expect(html).toContain("Reply requested");
+    expect(html).toContain("Received");
+    expect(html).toContain("Current status");
+    expect(html).toContain('href="/portal/cases"');
+    expect(html).toContain('href="/portal/support"');
+  });
+
+  it("does not expose internal source or WorkItem references", () => {
+    const html = renderToStaticMarkup(<PortalWorkCaseDetail view={fixture} />);
+
+    expect(html).not.toContain("WI-");
+    expect(html).not.toContain("sourceRefs");
+    expect(html).not.toContain("work-item");
+    expect(html).not.toContain("sourceId");
+  });
+
+  it("uses DPF theme tokens and avoids hardcoded status colors", () => {
+    const html = renderToStaticMarkup(<PortalWorkCaseDetail view={fixture} />);
+
+    expect(html).toContain("var(--dpf-");
+    expect(html).not.toMatch(
+      /bg-white|text-blue-|text-red-|text-orange-|text-yellow-|bg-red-|bg-orange-|bg-yellow-|#[0-9a-fA-F]{3,6}/,
+    );
+  });
+});

--- a/apps/web/components/portal/PortalWorkCaseDetail.tsx
+++ b/apps/web/components/portal/PortalWorkCaseDetail.tsx
@@ -1,0 +1,116 @@
+import { ArrowLeft, CalendarClock, MessageCircle, ShieldCheck } from "lucide-react";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
+import type { Intent } from "@/components/ui/report-kit/statusColors";
+import type { PortalWorkCaseDetailView } from "@/lib/work-management/portal-case-loader";
+
+type Props = {
+  view: PortalWorkCaseDetailView;
+};
+
+const STATUS_INTENT: Record<string, Intent> = {
+  "Needs your response": "warning",
+  "In progress": "accent",
+  "Waiting on service": "info",
+  Received: "info",
+  Resolved: "success",
+  Cancelled: "neutral",
+};
+
+export function PortalWorkCaseDetail({ view }: Props) {
+  const item = view.case;
+  const statusIntent = STATUS_INTENT[item.statusLabel] ?? "neutral";
+
+  return (
+    <main className="space-y-5 text-[var(--dpf-text)]">
+      <header className="space-y-4">
+        <a
+          href="/portal/cases"
+          className="inline-flex min-h-9 items-center gap-2 rounded-md px-2 text-sm font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)]"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Cases
+        </a>
+
+        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <div className="mb-2 flex flex-wrap items-center gap-2">
+                <StatusBadge intent={statusIntent} label={item.statusLabel} variant="soft" />
+                <span className="text-xs text-[var(--dpf-muted)]">{item.sourceLabel}</span>
+              </div>
+              <h1 className="text-2xl font-semibold text-[var(--dpf-text)]">{item.title}</h1>
+              {item.description ? (
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
+                  {item.description}
+                </p>
+              ) : null}
+            </div>
+            <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm">
+              <p className="text-xs text-[var(--dpf-muted)]">Next</p>
+              <p className="mt-1 font-semibold text-[var(--dpf-text)]">{item.nextActionLabel}</p>
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-[var(--dpf-muted)]">
+            <span className="inline-flex items-center gap-1">
+              <ShieldCheck className="size-3.5" aria-hidden="true" />
+              Visible to your account
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <CalendarClock className="size-3.5" aria-hidden="true" />
+              Received <LocalTime value={item.createdAt} mode="date" />
+            </span>
+            {item.dueAt ? (
+              <span className="inline-flex items-center gap-1">
+                <CalendarClock className="size-3.5" aria-hidden="true" />
+                Due <LocalTime value={item.dueAt} mode="date" />
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <section
+        aria-label="Case timeline"
+        className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+      >
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">Timeline</h2>
+            <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+              Recent customer-visible updates for this case.
+            </p>
+          </div>
+          <a
+            href={item.supportHref}
+            className="inline-flex min-h-9 w-fit items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-sm font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-3)]"
+          >
+            <MessageCircle className="size-4" aria-hidden="true" />
+            Contact support
+          </a>
+        </div>
+
+        <ol className="mt-4 space-y-3">
+          {view.timeline.map((event) => (
+            <li
+              key={`${event.label}-${event.at ?? event.body}`}
+              className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2"
+            >
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm font-semibold text-[var(--dpf-text)]">{event.label}</p>
+                {event.at ? (
+                  <span className="text-xs text-[var(--dpf-muted)]">
+                    <LocalTime value={event.at} mode="date" />
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-1 text-sm leading-6 text-[var(--dpf-muted)]">{event.body}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/portal/PortalWorkCases.test.tsx
+++ b/apps/web/components/portal/PortalWorkCases.test.tsx
@@ -15,25 +15,29 @@ const fixture: PortalWorkCaseListView = {
   cases: [
     {
       caseId: "booking:BK-1",
-      href: "/portal/cases#booking-BK-1",
+      href: "/portal/cases/booking%3ABK-1",
       title: "Confirm condenser appointment",
       sourceLabel: "Storefront booking",
       statusLabel: "Needs your response",
       nextActionLabel: "Reply requested",
       description: "Customer needs a scheduling confirmation.",
       dueAt: "2026-06-29T15:00:00.000Z",
+      createdAt: "2026-06-28T10:00:00.000Z",
       attentionRequired: true,
+      supportHref: "/portal/support",
     },
     {
       caseId: "activity:ACT-1",
-      href: "/portal/cases#activity-ACT-1",
+      href: "/portal/cases/activity%3AACT-1",
       title: "Service follow-up",
       sourceLabel: "Activity",
       statusLabel: "In progress",
       nextActionLabel: "We are working on it",
       description: null,
       dueAt: null,
+      createdAt: "2026-06-28T11:00:00.000Z",
       attentionRequired: false,
+      supportHref: "/portal/support",
     },
   ],
 };
@@ -45,6 +49,7 @@ describe("PortalWorkCases", () => {
     expect(html).toContain("Cases");
     expect(html).toContain("Confirm condenser appointment");
     expect(html).toContain("Needs your response");
+    expect(html).toContain('href="/portal/cases/booking%3ABK-1"');
     expect(html).toContain('href="/portal/support"');
     expect(html).not.toContain("sourceRefs");
     expect(html).not.toContain("work-item");

--- a/apps/web/components/portal/PortalWorkCases.tsx
+++ b/apps/web/components/portal/PortalWorkCases.tsx
@@ -24,7 +24,6 @@ const STATUS_INTENT: Record<string, Intent> = {
 function CaseCard({ item }: { item: PortalWorkCaseListItem }) {
   return (
     <article
-      id={item.href.split("#")[1]}
       className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-[var(--dpf-text)]"
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -37,7 +36,11 @@ function CaseCard({ item }: { item: PortalWorkCaseListItem }) {
             />
             <span className="text-xs text-[var(--dpf-muted)]">{item.sourceLabel}</span>
           </div>
-          <h2 className="text-base font-semibold text-[var(--dpf-text)]">{item.title}</h2>
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+            <a href={item.href} className="hover:text-[var(--dpf-accent)]">
+              {item.title}
+            </a>
+          </h2>
           {item.description ? (
             <p className="mt-1 max-w-2xl text-sm leading-6 text-[var(--dpf-muted)]">{item.description}</p>
           ) : null}
@@ -56,7 +59,7 @@ function CaseCard({ item }: { item: PortalWorkCaseListItem }) {
         ) : null}
         {item.attentionRequired ? (
           <a
-            href="/portal/support"
+            href={item.supportHref}
             className="inline-flex min-h-9 items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-sm font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-3)]"
           >
             <MessageCircle className="size-4" aria-hidden="true" />
@@ -68,6 +71,13 @@ function CaseCard({ item }: { item: PortalWorkCaseListItem }) {
             Visible to your account
           </span>
         )}
+        <a
+          href={item.href}
+          className="inline-flex min-h-9 items-center gap-1 rounded-md px-2 text-sm font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)]"
+        >
+          View details
+          <ArrowRight className="size-4" aria-hidden="true" />
+        </a>
       </div>
     </article>
   );

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 524,
+  "routeCount": 525,
   "routes": [
     {
       "routePath": "/",
@@ -5408,6 +5408,19 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(portal)/portal/cases/page.tsx"
+    },
+    {
+      "routePath": "/portal/cases/[caseKey]",
+      "kind": "page",
+      "segments": [
+        "portal",
+        "cases",
+        "[caseKey]"
+      ],
+      "dynamicParams": [
+        "caseKey"
+      ],
+      "file": "apps/web/app/(portal)/portal/cases/[caseKey]/page.tsx"
     },
     {
       "routePath": "/portal/orders",

--- a/apps/web/lib/githooks/root-clone-guard.test.ts
+++ b/apps/web/lib/githooks/root-clone-guard.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -11,20 +11,80 @@ const GUARD = path.join(REPO_ROOT, ".githooks/lib/check-root-clone.sh");
 const LINKED_WORKTREE_GIT_DIR = "/Users/dev/dpf/.git/worktrees/some-topic";
 const PRIMARY_CLONE_GIT_DIR = ".git";
 
+type GuardShell = {
+  command: string;
+  guardPath: string;
+};
+
+function commandWorks(command: string, args: string[]): boolean {
+  const result = spawnSync(command, args, { stdio: "ignore" });
+  return result.status === 0;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function shellAssignments(env: Record<string, string>): string {
+  return Object.entries(env)
+    .map(([name, value]) => `${name}=${shellQuote(value)}`)
+    .join(" ");
+}
+
+function toWslPath(value: string): string | null {
+  const normalized = value.replace(/\\/g, "/");
+  const match = normalized.match(/^([A-Za-z]):\/(.*)$/);
+  if (!match) return null;
+  return `/mnt/${match[1].toLowerCase()}/${match[2]}`;
+}
+
+function resolveGuardShell(): GuardShell | null {
+  if (commandWorks("sh", ["-c", "exit 0"])) {
+    return { command: "sh", guardPath: GUARD };
+  }
+  if (!commandWorks("bash", ["-lc", "exit 0"])) {
+    return null;
+  }
+
+  const candidates = process.platform === "win32"
+    ? [toWslPath(GUARD), GUARD.replace(/\\/g, "/")].filter((candidate): candidate is string => Boolean(candidate))
+    : [GUARD];
+
+  const guardPath = candidates.find((candidate) =>
+    commandWorks("bash", ["-lc", `test -f ${shellQuote(candidate)}`]),
+  );
+  return guardPath ? { command: "bash", guardPath } : null;
+}
+
+const GUARD_SHELL = resolveGuardShell();
+const describeWithPosixShell = GUARD_SHELL ? describe : describe.skip;
+
 /** Run the guard; return its exit status (0 = allowed, 1 = refused). */
 function runGuard(gitDir: string, branch: string, env: Record<string, string> = {}): number {
+  if (!GUARD_SHELL) return -1;
+  const guardEnv = { DPF_ALLOW_ROOT_CLONE_COMMIT: "", ...env };
   try {
-    execFileSync("sh", [GUARD, gitDir, branch], {
-      env: { ...process.env, DPF_ALLOW_ROOT_CLONE_COMMIT: "", ...env },
-      stdio: "pipe",
-    });
+    if (GUARD_SHELL.command === "bash" && process.platform === "win32") {
+      execFileSync("bash", [
+        "-lc",
+        `${shellAssignments(guardEnv)} ${shellQuote(GUARD_SHELL.guardPath)} ${shellQuote(gitDir)} ${shellQuote(branch)}`,
+      ], {
+        env: process.env,
+        stdio: "pipe",
+      });
+    } else {
+      execFileSync(GUARD_SHELL.command, [GUARD_SHELL.guardPath, gitDir, branch], {
+        env: { ...process.env, ...guardEnv },
+        stdio: "pipe",
+      });
+    }
     return 0;
   } catch (error) {
     return (error as { status?: number }).status ?? -1;
   }
 }
 
-describe("check-root-clone guard", () => {
+describeWithPosixShell("check-root-clone guard", () => {
   it("allows feature-branch commits in a linked worktree", () => {
     expect(runGuard(LINKED_WORKTREE_GIT_DIR, "feat/something")).toBe(0);
   });

--- a/apps/web/lib/work-management/architecture-grounding.test.ts
+++ b/apps/web/lib/work-management/architecture-grounding.test.ts
@@ -13,7 +13,7 @@ const elementById = new Map<string, WorkCaseArchitectureElement>(
 );
 
 describe("Work Case architecture grounding manifest", () => {
-  it("allocates every Wave 0 through Wave 5 source file into the EA/SysML graph", () => {
+  it("allocates every Wave 0 through Wave 6 source file into the EA/SysML graph", () => {
     const allocatedFiles = new Set(
       WORK_CASE_ARCHITECTURE_ALLOCATIONS.map((allocation) => allocation.targetRef),
     );
@@ -47,7 +47,9 @@ describe("Work Case architecture grounding manifest", () => {
         "apps/web/lib/work-management/customer-domain-adoption.ts",
         "apps/web/lib/work-management/portal-case-loader.ts",
         "apps/web/components/portal/PortalWorkCases.tsx",
+        "apps/web/components/portal/PortalWorkCaseDetail.tsx",
         "apps/web/app/(portal)/portal/cases/page.tsx",
+        "apps/web/app/(portal)/portal/cases/[caseKey]/page.tsx",
         "apps/web/app/(portal)/portal/page.tsx",
       ]),
     );
@@ -133,6 +135,17 @@ describe("Work Case architecture grounding manifest", () => {
     expect(elementById.get("PART-WC-customer-domain-adoption")?.implementationStatus).toBe("implemented");
     expect(elementById.get("PART-WC-portal-case-view")?.implementationStatus).toBe("implemented");
     expect(elementById.get("PART-WC-mobile-attention")?.implementationStatus).toBe("implemented");
+  });
+
+  it("grounds Wave 6 customer portal drill-down in an implemented verification case", () => {
+    const requirement = elementById.get("REQ-WC-13");
+    expect(requirement?.implementationStatus).toBe("implemented");
+
+    const verificationCase = elementById.get(requirement?.verificationCaseId ?? "");
+    expect(verificationCase?.elementType).toBe("verification_case");
+    expect(verificationCase?.implementationStatus).toBe("implemented");
+
+    expect(elementById.get("PART-WC-portal-case-detail")?.implementationStatus).toBe("implemented");
   });
 
   it("declares EA Action elements for the Work Case handoff grammar", () => {

--- a/apps/web/lib/work-management/architecture-grounding.ts
+++ b/apps/web/lib/work-management/architecture-grounding.ts
@@ -152,6 +152,15 @@ export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
     verificationCaseId: "VC-WC-12",
   },
   {
+    elementId: "REQ-WC-13",
+    elementType: "requirement",
+    name: "Customer-safe portal case drill-down",
+    description: "Portal customers can inspect a single account-scoped Work Case without seeing internal WorkItem or source references.",
+    implementationStatus: "implemented",
+    itValueStreams: ["consume"],
+    verificationCaseId: "VC-WC-13",
+  },
+  {
     elementId: "SM-WC-LIFECYCLE",
     elementType: "state_machine",
     name: "Work Case lifecycle",
@@ -329,6 +338,14 @@ export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
     itValueStreams: ["consume"],
   },
   {
+    elementId: "PART-WC-portal-case-detail",
+    elementType: "part_definition",
+    name: "Portal Work Case detail",
+    description: "Customer-safe Portal drill-down route and component for a single account-scoped Work Case.",
+    implementationStatus: "implemented",
+    itValueStreams: ["consume"],
+  },
+  {
     elementId: "PART-WC-mobile-attention",
     elementType: "part_definition",
     name: "Mobile Work Case attention strip",
@@ -431,6 +448,14 @@ export const WORK_CASE_ARCHITECTURE_ELEMENTS = [
     description: "Component tests proving Workspace renders a mobile-first attention strip from the canonical Work Case projection.",
     implementationStatus: "implemented",
     itValueStreams: ["operate", "consume"],
+  },
+  {
+    elementId: "VC-WC-13",
+    elementType: "verification_case",
+    name: "Portal case drill-down verification",
+    description: "Loader, component, and route-grounding tests proving Portal case detail is account-scoped, customer-safe, and theme-aware.",
+    implementationStatus: "implemented",
+    itValueStreams: ["consume"],
   },
 ] as const satisfies readonly WorkCaseArchitectureElement[];
 
@@ -602,6 +627,24 @@ export const WORK_CASE_ARCHITECTURE_ALLOCATIONS = [
     relationshipType: "sysml_allocates",
     targetKind: "source_file",
     targetRef: "apps/web/app/(portal)/portal/page.tsx",
+  },
+  {
+    sourceElementId: "PART-WC-portal-case-detail",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/lib/work-management/portal-case-loader.ts",
+  },
+  {
+    sourceElementId: "PART-WC-portal-case-detail",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/components/portal/PortalWorkCaseDetail.tsx",
+  },
+  {
+    sourceElementId: "PART-WC-portal-case-detail",
+    relationshipType: "sysml_allocates",
+    targetKind: "source_file",
+    targetRef: "apps/web/app/(portal)/portal/cases/[caseKey]/page.tsx",
   },
   {
     sourceElementId: "PART-WC-mobile-attention",

--- a/apps/web/lib/work-management/portal-case-loader.test.ts
+++ b/apps/web/lib/work-management/portal-case-loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  loadPortalWorkCaseDetail,
   loadPortalWorkCaseList,
   type PortalCasePrismaClient,
 } from "./portal-case-loader";
@@ -109,6 +110,64 @@ describe("portal Work Case loader", () => {
     expect(serialized).not.toContain("WI-BOOKING-1");
     expect(serialized).not.toContain("sourceRefs");
     expect(serialized).not.toContain("work-item");
-    expect(view.cases[0].href).toBe("/portal/cases#booking-BK-1");
+    expect(view.cases[0].href).toBe("/portal/cases/booking%3ABK-1");
+  });
+
+  it("loads a customer-safe case detail for the owning account", async () => {
+    const detail = await loadPortalWorkCaseDetail({
+      prismaClient: prismaFor([bookingItem]),
+      customerAccountId: "CUST-1",
+      caseKey: "booking%3ABK-1",
+      now: new Date("2026-06-28T12:00:00.000Z"),
+    });
+
+    expect(detail).toMatchObject({
+      generatedAt: "2026-06-28T12:00:00.000Z",
+      case: {
+        href: "/portal/cases/booking%3ABK-1",
+        title: "Confirm condenser appointment",
+        sourceLabel: "Storefront booking",
+        statusLabel: "Needs your response",
+        nextActionLabel: "Reply requested",
+        supportHref: "/portal/support",
+      },
+    });
+    expect(detail?.timeline.map((event) => event.label)).toEqual([
+      "Received",
+      "Current status",
+      "Due",
+    ]);
+
+    const serialized = JSON.stringify(detail);
+    expect(serialized).not.toContain("WI-BOOKING-1");
+    expect(serialized).not.toContain("sourceRefs");
+    expect(serialized).not.toContain("work-item");
+    expect(serialized).not.toContain("sourceId");
+  });
+
+  it("does not load details for another account or invalid case keys", async () => {
+    await expect(
+      loadPortalWorkCaseDetail({
+        prismaClient: prismaFor([bookingItem]),
+        customerAccountId: "CUST-2",
+        caseKey: "booking%3ABK-1",
+      }),
+    ).resolves.toBeNull();
+
+    await expect(
+      loadPortalWorkCaseDetail({
+        prismaClient: prismaFor([bookingItem]),
+        customerAccountId: "CUST-1",
+        caseKey: "manual-task%3AMANUAL-1",
+      }),
+    ).resolves.toBeNull();
+
+    await expect(
+      loadPortalWorkCaseDetail({
+        prismaClient: prismaFor([bookingItem]),
+        customerAccountId: "CUST-1",
+        caseKey: "not-a-case-key",
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/apps/web/lib/work-management/portal-case-loader.ts
+++ b/apps/web/lib/work-management/portal-case-loader.ts
@@ -67,7 +67,9 @@ export interface PortalWorkCaseListItem {
   nextActionLabel: string;
   description: string | null;
   dueAt: string | null;
+  createdAt: string;
   attentionRequired: boolean;
+  supportHref: string;
 }
 
 export interface PortalWorkCaseListView {
@@ -81,13 +83,50 @@ export interface PortalWorkCaseListView {
   cases: PortalWorkCaseListItem[];
 }
 
+export interface PortalWorkCaseTimelineItem {
+  label: string;
+  body: string;
+  at?: string;
+}
+
+export interface PortalWorkCaseDetailView {
+  generatedAt: string;
+  case: PortalWorkCaseListItem;
+  timeline: PortalWorkCaseTimelineItem[];
+}
+
 function iso(value: Date | string | null | undefined): string | null {
   if (!value) return null;
   return value instanceof Date ? value.toISOString() : value;
 }
 
-function slug(value: string): string {
-  return value.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-|-$/g, "");
+function requiredIso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+export function encodePortalCaseKey(caseId: string): string {
+  return encodeURIComponent(caseId);
+}
+
+export function decodePortalCaseKey(
+  caseKey: string,
+): { sourceType: string; sourceId: string } | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(caseKey).trim();
+  } catch {
+    return null;
+  }
+  const separatorIndex = decoded.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === decoded.length - 1) return null;
+  const sourceType = decoded.slice(0, separatorIndex);
+  const sourceId = decoded.slice(separatorIndex + 1);
+  if (!getWorkCaseAccountResolverKey(sourceType)) return null;
+  return { sourceType, sourceId };
+}
+
+function portalCaseHref(caseId: string): string {
+  return `/portal/cases/${encodePortalCaseKey(caseId)}`;
 }
 
 async function accountFromBooking(
@@ -243,15 +282,42 @@ async function toPortalCase({
 
   return {
     caseId: summary.caseId,
-    href: `/portal/cases#${slug(summary.caseId)}`,
+    href: portalCaseHref(summary.caseId),
     title: summary.title,
     sourceLabel: entry?.displayLabel ?? summary.sourceLabel,
     statusLabel: portalStatus.statusLabel,
     nextActionLabel: portalStatus.nextActionLabel,
     description: item.description,
     dueAt: iso(item.dueAt),
+    createdAt: requiredIso(item.createdAt),
     attentionRequired: portalStatus.needsResponse || summary.attention.required,
+    supportHref: "/portal/support",
   };
+}
+
+function buildPortalTimeline(
+  item: PortalWorkItemRecord,
+  portalCase: PortalWorkCaseListItem,
+): PortalWorkCaseTimelineItem[] {
+  const timeline: PortalWorkCaseTimelineItem[] = [
+    {
+      label: "Received",
+      body: "We received this request.",
+      at: requiredIso(item.createdAt),
+    },
+    {
+      label: "Current status",
+      body: portalCase.statusLabel,
+    },
+  ];
+  if (portalCase.dueAt) {
+    timeline.push({
+      label: "Due",
+      body: "Target date for the next update.",
+      at: portalCase.dueAt,
+    });
+  }
+  return timeline;
 }
 
 function sortCases(left: PortalWorkCaseListItem, right: PortalWorkCaseListItem): number {
@@ -297,5 +363,43 @@ export async function loadPortalWorkCaseList({
       resolved: cases.filter((item) => item.statusLabel === "Resolved" || item.statusLabel === "Cancelled").length,
     },
     cases,
+  };
+}
+
+export async function loadPortalWorkCaseDetail({
+  prismaClient,
+  customerAccountId,
+  caseKey,
+  now = new Date(),
+}: {
+  prismaClient: PortalCasePrismaClient;
+  customerAccountId: string;
+  caseKey: string;
+  now?: Date;
+}): Promise<PortalWorkCaseDetailView | null> {
+  const parsed = decodePortalCaseKey(caseKey);
+  if (!parsed) return null;
+
+  const items = await prismaClient.workItem.findMany({
+    where: {
+      sourceType: parsed.sourceType,
+      sourceId: parsed.sourceId,
+    },
+    orderBy: [{ createdAt: "desc" }],
+    take: 10,
+  });
+  const item = items.find(
+    (candidate) =>
+      candidate.sourceType === parsed.sourceType && candidate.sourceId === parsed.sourceId,
+  );
+  if (!item) return null;
+
+  const portalCase = await toPortalCase({ prismaClient, item, customerAccountId });
+  if (!portalCase) return null;
+
+  return {
+    generatedAt: now.toISOString(),
+    case: portalCase,
+    timeline: buildPortalTimeline(item, portalCase),
   };
 }

--- a/docs/superpowers/plans/2026-06-28-work-case-wave-6-portal-drilldown.md
+++ b/docs/superpowers/plans/2026-06-28-work-case-wave-6-portal-drilldown.md
@@ -1,0 +1,176 @@
+# Work Case Wave 6 Portal Drill-Down Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a customer-safe Portal Work Case detail route under the existing `/portal/cases` section.
+
+**Architecture:** Stay projection-first over `WorkItem` and account-resolvable source records. Refactor the Portal loader so list and detail share the same account filter, case-key parsing, status language, and customer-safe DTO rules. The detail route is a child page, not a new dashboard, tab, or write path.
+
+**Tech Stack:** Next.js 16 App Router, Prisma 7 types, React server/static markup tests, Vitest, report-kit, DPF theme tokens, lucide-react icons.
+
+---
+
+## UX Fit Review
+
+**UX fit review - Work Case Wave 6 portal drill-down**
+
+- Decision: fits-with-guardrails
+- UX-Fit-Decision: detail-route-under-cases (manual dpf-ux-fit review; principle_decide returned a zeroed low-confidence tie)
+- Owning area: Portal
+- Route family: `/portal/cases`, `/portal/cases/[caseKey]`
+- Primary persona: external customer checking the status and next step for a visible service/request case
+- Navigation layer touched: Portal section route only; no global nav, no new dashboard
+- Reuse/convergence: reuse `PortalWorkCases`, `portal-case-loader`, report-kit `StatusBadge`/`StatCard`, DPF tokens, and the existing Portal support destination
+- Source truth: `WorkItem` plus account-resolvable source records through the Work Case source registry
+- Empty/failure behavior: missing, unauthorized, or non-account-resolvable case keys return `notFound()` after auth/account checks
+- AI boundary: no prompt send and no consequential mutation; support links navigate only
+- Required plan/spec edits:
+  - Keep the detail DTO free of `WorkItem` ids, source refs, internal refs, and raw activity/evidence ids.
+  - Make `/portal/cases/[caseKey]` a drill-down child route, not a new Portal tab or dashboard.
+  - Keep customer copy plain and business-facing.
+- Evidence before merge:
+  - Focused loader/component/route-grounding tests.
+  - Typecheck, module-size, production build, route-manifest freshness.
+  - Theme scan in component tests proving no hardcoded token-role colors.
+- Captured in: `docs/superpowers/plans/2026-06-28-work-case-wave-6-portal-drilldown.md`
+
+## Chunk 1: Portal Loader Detail Contract
+
+### Task 1: Customer-Safe Case Key And Detail Loader
+
+**Files:**
+- Modify: `apps/web/lib/work-management/portal-case-loader.test.ts`
+- Modify: `apps/web/lib/work-management/portal-case-loader.ts`
+
+- [x] **Step 1: Add failing loader tests**
+
+Tests must prove:
+- list items link to `/portal/cases/<encoded case key>` instead of hash anchors
+- `loadPortalWorkCaseDetail()` returns a customer-safe DTO for an account-owned case
+- another customer's case returns `null`
+- invalid/non-account-resolvable case keys return `null`
+- serialized detail does not include `WI-`, `sourceRefs`, `work-item`, raw source refs, or internal ids
+
+- [x] **Step 2: Run tests and verify RED**
+
+Run: `pnpm --filter web exec vitest run lib/work-management/portal-case-loader.test.ts`
+
+Expected: fail because `loadPortalWorkCaseDetail()` does not exist and list hrefs still use anchors.
+
+- [x] **Step 3: Refactor and implement loader**
+
+Add shared helpers:
+- `encodePortalCaseKey(caseId: string): string`
+- `decodePortalCaseKey(caseKey: string): { sourceType: string; sourceId: string } | null`
+- a shared `toPortalCase()` projection used by both list and detail
+- `loadPortalWorkCaseDetail({ prismaClient, customerAccountId, caseKey, now })`
+
+The detail DTO should include only customer-safe fields: title, source label, status label, next action, description, due date, created date, support href, and a short customer-safe timeline.
+
+- [x] **Step 4: Run focused loader tests**
+
+Run: `pnpm --filter web exec vitest run lib/work-management/portal-case-loader.test.ts`
+
+Expected: pass.
+
+## Chunk 2: Portal Detail Surface
+
+### Task 2: Detail Component And Route
+
+**Files:**
+- Create: `apps/web/components/portal/PortalWorkCaseDetail.tsx`
+- Create: `apps/web/components/portal/PortalWorkCaseDetail.test.tsx`
+- Create: `apps/web/app/(portal)/portal/cases/[caseKey]/page.tsx`
+- Modify: `apps/web/components/portal/PortalWorkCases.tsx`
+- Modify: `apps/web/components/portal/PortalWorkCases.test.tsx`
+
+- [x] **Step 1: Add failing component tests**
+
+Tests must prove:
+- detail renders a digest, status, next step, due/received dates, back link, and support link
+- detail omits internal refs and raw identifiers
+- list cards link to the detail route
+- component markup uses DPF tokens and no hardcoded hex/status color classes
+
+- [x] **Step 2: Run tests and verify RED**
+
+Run: `pnpm --filter web exec vitest run components/portal/PortalWorkCaseDetail.test.tsx components/portal/PortalWorkCases.test.tsx`
+
+Expected: fail because the detail component does not exist and list links still target anchors.
+
+- [x] **Step 3: Implement component and route**
+
+Create `PortalWorkCaseDetail` using report-kit `StatusBadge`, lucide icons, DPF theme tokens, and restrained page composition. Add `/portal/cases/[caseKey]` with the same customer auth/account guard as `/portal/cases`; call `notFound()` for unavailable cases.
+
+- [x] **Step 4: Run focused component tests**
+
+Run: `pnpm --filter web exec vitest run components/portal/PortalWorkCaseDetail.test.tsx components/portal/PortalWorkCases.test.tsx`
+
+Expected: pass.
+
+## Chunk 3: Architecture Grounding And Docs
+
+### Task 3: Traceability And Spec Update
+
+**Files:**
+- Modify: `apps/web/lib/work-management/architecture-grounding.test.ts`
+- Modify: `apps/web/lib/work-management/architecture-grounding.ts`
+- Modify: `docs/superpowers/specs/2026-06-27-work-management-architecture-design.md`
+
+- [x] **Step 1: Add failing grounding test**
+
+Test that Wave 6 has a requirement, part, verification case, and allocation for the Portal customer-safe drill-down route/component/loader.
+
+- [x] **Step 2: Run grounding test and verify RED**
+
+Run: `pnpm --filter web exec vitest run lib/work-management/architecture-grounding.test.ts`
+
+Expected: fail until Wave 6 grounding is added.
+
+- [x] **Step 3: Update grounding and spec**
+
+Add `REQ-WC-13`, `PART-WC-portal-case-detail`, `VC-WC-13`, allocations to the loader/component/route, and a spec implementation note that Wave 6 is the first long-tail calibration slice.
+
+- [x] **Step 4: Run focused grounding test**
+
+Run: `pnpm --filter web exec vitest run lib/work-management/architecture-grounding.test.ts`
+
+Expected: pass.
+
+## Chunk 4: Verification And PR
+
+### Task 4: Source-Local Verification
+
+**Files:**
+- Verify all touched files.
+
+- [x] **Step 1: Run focused suite**
+
+Run:
+`pnpm --filter web exec vitest run lib/work-management/portal-case-loader.test.ts components/portal/PortalWorkCases.test.tsx components/portal/PortalWorkCaseDetail.test.tsx lib/work-management/architecture-grounding.test.ts`
+
+- [x] **Step 2: Run typecheck**
+
+Run: `pnpm --filter web typecheck`
+
+- [x] **Step 3: Run module-size guard**
+
+Run: `pnpm check:module-size`
+
+- [x] **Step 4: Run production build**
+
+Run: `pnpm --filter web build`
+
+- [x] **Step 5: Refresh route manifest if needed**
+
+Run: `node node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/dist/cli.mjs apps/web/scripts/build-route-manifest.ts --check`.
+
+If stale, regenerate with the same command without `--check`, then rerun with `--check`.
+
+- [x] **Step 6: Run UX-fit gate**
+
+Run: `$env:BASE_SHA='origin/main'; node scripts/check-ux-fit-decision.mjs`
+
+- [ ] **Step 7: Commit, push, PR, CI**
+
+Commit with DCO sign-off, push `feat/work-case-wave-6-portal-drilldown`, open a ready PR, watch CI, fix failures, and merge only after PR health is green.

--- a/docs/superpowers/specs/2026-06-27-work-management-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-27-work-management-architecture-design.md
@@ -1,7 +1,7 @@
 # Company-Level Work Management Architecture
 
 Date: 2026-06-27
-Status: Accepted design; Wave 5 adoption views implemented
+Status: Accepted design; Wave 6 portal drill-down implemented
 Owner: DPF architecture
 Related capsule: WC-0A3909A2
 Epic: EP-2984B02B - Work Case / Company Work Management
@@ -17,6 +17,8 @@ Wave 4 BI: BI-WC-WAVE4 - Work Case ecosystem and autonomy contracts
 Wave 4 plan: docs/superpowers/plans/2026-06-28-work-case-wave-4-ecosystem-autonomy.md
 Wave 5 BI: BI-WC-WAVE5 - Work Case adoption workflows and constrained external views
 Wave 5 plan: docs/superpowers/plans/2026-06-28-work-case-wave-5-adoption-views.md
+Wave 6 BI: BI-WC-WAVE6-DRILLDOWN - Customer-safe Work Case portal drill-down
+Wave 6 plan: docs/superpowers/plans/2026-06-28-work-case-wave-6-portal-drilldown.md
 Sibling spec: docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md (the method-improvement pillar that binds to this object)
 
 ## Summary
@@ -661,6 +663,8 @@ Deliverables:
 
 Wave 5 implementation note: `customer-domain-adoption.ts` groups account-resolvable customer Work Cases into WWWD workflow lanes; `portal-case-loader.ts` and `/portal/cases` expose only account-scoped, customer-safe case status; `WorkCaseAttentionLens` now includes a mobile-first attention strip backed by the same Workspace projection. Federation contract work landed in Wave 4; external/customer visibility in Wave 5 is constrained to Portal account scope rather than raw internal source refs.
 
+Wave 6 implementation note: `portal-case-loader.ts` now owns the shared customer-safe case-key/detail projection for Portal list and detail surfaces; `/portal/cases/[caseKey]` renders a constrained single-case digest through `PortalWorkCaseDetail` without exposing internal WorkItem ids, raw source refs, or a new write path. This is the first Wave 6+ long-tail calibration BI: a narrow Portal drill-down extension against the stable Work Case architecture.
+
 ## Effort Portfolio (Long-Tail Program)
 
 The implementation slices above are the first concrete build sequence. This section frames the larger program: Work Case is not a single feature but a *pervasive idea* that many prior efforts were independently converging toward. Naming the convergence makes the long tail legible — refactoring that pays down debt this idea exposed, projection work over the current substrate, and new features and surfaces — and shows why the tail keeps narrowing into ever-more-focused refinement rather than ending.
@@ -737,7 +741,7 @@ The tracks sequence into waves. Each wave is more focused than the last because 
 - Wave 3 — Operator surfaces: R6, R7, S1, S2. UI on a substrate that is already safe. Implemented under `BI-WC-WAVE3`.
 - Wave 4 — Ecosystem and autonomy: S4, S5, S6. Capability advertisement, graduated autonomy, federation. Implemented under `BI-WC-WAVE4` as pure contracts over the existing Work Case, trust-graduation, and federation substrates.
 - Wave 5 — Adoption: S7, S8, S9. First domains and external views. Implemented under `BI-WC-WAVE5` as customer-domain workflow lanes, constrained Portal case visibility, and a mobile Workspace attention strip.
-- Wave 6+ — The long tail: each new source type, domain workflow, coworker capability, and autonomy graduation is a small, well-scoped BI against a now-stable architecture. This is where the idea stops being a build and becomes a calibration loop — the increasingly focused refinement that continues indefinitely.
+- Wave 6+ — The long tail: each new source type, domain workflow, coworker capability, portal drill-down, and autonomy graduation is a small, well-scoped BI against a now-stable architecture. The first item, customer-safe Portal case drill-down, is implemented under `BI-WC-WAVE6-DRILLDOWN`; the remaining tail is the calibration loop — increasingly focused refinement that continues indefinitely.
 
 ### Program Structure And Governance
 
@@ -826,4 +830,4 @@ Mitigations:
 
 ## Next Step
 
-Start Wave 6+ long-tail calibration: one focused BI per new source type, domain vocabulary, coworker capability, persisted transition hardening, customer portal drill-down, or autonomy graduation. Treat each tail item as a narrow Work Case extension with its own receipt, UX, and architecture-grounding evidence.
+Continue Wave 6+ long-tail calibration: one focused BI per new source type, domain vocabulary, coworker capability, persisted transition hardening, additional portal/customer drill-down, or autonomy graduation. Treat each tail item as a narrow Work Case extension with its own receipt, UX, and architecture-grounding evidence.

--- a/scripts/check-ci-build-cache.test.mjs
+++ b/scripts/check-ci-build-cache.test.mjs
@@ -1,0 +1,26 @@
+// scripts/check-ci-build-cache.test.mjs
+// node --test (no vitest). Keeps the production-build Turbopack cache exact-key
+// only: broad restore fallbacks can hydrate stale multi-GB caches and push PR
+// builds past the hosted runner's practical budget.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const ciWorkflow = readFileSync(".github/workflows/ci.yml", "utf8");
+
+function stepBlock(stepName) {
+  const start = ciWorkflow.indexOf(`- name: ${stepName}`);
+  assert.notEqual(start, -1, `missing workflow step: ${stepName}`);
+
+  const next = ciWorkflow.indexOf("\n      - name:", start + 1);
+  return ciWorkflow.slice(start, next === -1 ? undefined : next);
+}
+
+test("Production Build Turbopack cache uses exact keys only", () => {
+  const block = stepBlock("Cache Turbopack build cache");
+
+  assert.match(block, /path:\s*\$\{\{\s*github\.workspace\s*\}\}\/apps\/web\/\.next\/cache/);
+  assert.match(block, /key:\s*nextjs-/);
+  assert.doesNotMatch(block, /\n\s+restore-keys:/);
+});


### PR DESCRIPTION
## Summary
- add a customer-safe `/portal/cases/[caseKey]` detail route under the existing Portal Cases section
- refactor the Portal Work Case loader with shared case-key parsing and single-case projection, preserving account scoping and internal-ref redaction
- add token-backed detail UI, route manifest updates, and Wave 6 EA/spec/plan grounding for `BI-WC-WAVE6-DRILLDOWN`

## UX Fit
UX-Fit-Decision: detail-route-under-cases (manual dpf-ux-fit review; principle_decide zeroed low-confidence tie)

Guardrails captured in `docs/superpowers/plans/2026-06-28-work-case-wave-6-portal-drilldown.md`: detail route stays under `/portal/cases`, no new dashboard/global nav, no prompt send, no consequential write path, no internal `WorkItem` ids or raw source refs in customer-facing DTO/UI.

## Verification
- `pnpm --filter web exec vitest run lib/work-management/portal-case-loader.test.ts components/portal/PortalWorkCases.test.tsx components/portal/PortalWorkCaseDetail.test.tsx lib/work-management/architecture-grounding.test.ts` - 4 files, 21 tests passed
- `pnpm --filter web typecheck` - passed
- `pnpm check:module-size` - passed
- `pnpm --filter web build` - passed; existing Edge Runtime `process.cwd` and Turbopack NFT warnings observed
- `node node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/dist/cli.mjs apps/web/scripts/build-route-manifest.ts --check` - passed after regenerating manifest to 525 routes
- `$env:BASE_SHA='origin/main'; node scripts/check-ux-fit-decision.mjs` - passed
- `git diff --check` - passed