### PR TITLE
feat: stage governed playbooks into Work Cases

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -197,6 +197,48 @@ vi.mock("@/lib/tak/work-pattern-read-model", () => ({
             },
             blockers: ["activation-candidate-awaits-governed-promotion"],
           },
+          caseStaging: {
+            status: "stageable",
+            activationAllowed: false,
+            liveMutationAllowed: false,
+            caseRef: {
+              caseId: "backlog-item:BI-123",
+              sourceType: "backlog-item",
+              sourceId: "BI-123",
+            },
+            action: "propose",
+            transitionId: "work-pattern:backlog-item:BI-123:propose:DI-REVIEW001",
+            stagedTransition: {
+              transitionId: "work-pattern:backlog-item:BI-123:propose:DI-REVIEW001",
+              action: "propose",
+              status: "proposed",
+              caseState: "awaiting-decision",
+              a2aStatus: "input-required",
+              terminal: false,
+              committable: false,
+              sourceRef: {
+                kind: "decision-interaction",
+                id: "DI-REVIEW001",
+                status: "proposed",
+              },
+              reason: "Transition propose is proposed and waiting for approve/edit/reject/respond.",
+              nextAction: "Resolve staged transition",
+            },
+            enforcementMode: "governed-action",
+            requiredReceiptKind: "governed-action",
+            receiptCoverage: "required-before-commit",
+            blockers: ["receipt-required-before-commit"],
+            proposalRail: {
+              kind: "coworker-action-envelope-preview",
+              envelopeStatus: "proposed",
+              manifestActionId: "work-case.propose",
+              argsJson: {
+                caseRef: "backlog-item:BI-123",
+                action: "propose",
+              },
+              rationale: "Stage Work Case proposal from approved Living Playbook candidate.",
+            },
+          },
         },
         activationCandidate: {
           state: "candidate",
@@ -214,6 +256,48 @@ vi.mock("@/lib/tak/work-pattern-read-model", () => ({
             agreementRate: 0.95,
           },
           blockers: ["activation-candidate-awaits-governed-promotion"],
+        },
+        caseStaging: {
+          status: "stageable",
+          activationAllowed: false,
+          liveMutationAllowed: false,
+          caseRef: {
+            caseId: "backlog-item:BI-123",
+            sourceType: "backlog-item",
+            sourceId: "BI-123",
+          },
+          action: "propose",
+          transitionId: "work-pattern:backlog-item:BI-123:propose:DI-REVIEW001",
+          stagedTransition: {
+            transitionId: "work-pattern:backlog-item:BI-123:propose:DI-REVIEW001",
+            action: "propose",
+            status: "proposed",
+            caseState: "awaiting-decision",
+            a2aStatus: "input-required",
+            terminal: false,
+            committable: false,
+            sourceRef: {
+              kind: "decision-interaction",
+              id: "DI-REVIEW001",
+              status: "proposed",
+            },
+            reason: "Transition propose is proposed and waiting for approve/edit/reject/respond.",
+            nextAction: "Resolve staged transition",
+          },
+          enforcementMode: "governed-action",
+          requiredReceiptKind: "governed-action",
+          receiptCoverage: "required-before-commit",
+          blockers: ["receipt-required-before-commit"],
+          proposalRail: {
+            kind: "coworker-action-envelope-preview",
+            envelopeStatus: "proposed",
+            manifestActionId: "work-case.propose",
+            argsJson: {
+              caseRef: "backlog-item:BI-123",
+              action: "propose",
+            },
+            rationale: "Stage Work Case proposal from approved Living Playbook candidate.",
+          },
         },
         shadowEvaluation: null,
       },
@@ -365,6 +449,11 @@ describe("AgentDetailPage", () => {
     expect(html).toContain("Reject");
     expect(html).toContain("Decision recorded");
     expect(html).toContain("activation candidate");
+    expect(html).toContain("Work Case proposal staged");
+    expect(html).toContain("receipt required before commit");
     expect(html).not.toContain("Activate playbook");
+    expect(html).not.toContain("scaffold");
+    expect(html).not.toContain("ReceiptEnvelope");
+    expect(html).not.toContain("DecisionInteraction");
   });
 });

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -11,6 +11,7 @@ import { LocalTime } from "@/components/ui/LocalTime";
 import { Chip, deepLink, EmptyState, Section } from "./panels";
 
 type ShadowEvaluation = NonNullable<WorkPatternSummary["shadowEvaluation"]>;
+type CaseStaging = NonNullable<WorkPatternSummary["caseStaging"]>;
 type ImprovementTotals = ShadowEvaluation["improvementTotals"];
 type DeltaKey = keyof ImprovementTotals;
 
@@ -247,6 +248,7 @@ function strongestReductionLabel(totals: ImprovementTotals): string {
 function PlaybookReviewRow({ pattern, canWrite }: { pattern: WorkPatternSummary; canWrite: boolean }) {
   if (pattern.reviewState) {
     const tone = reviewActionTone(pattern.reviewState.action);
+    const caseStaging = pattern.caseStaging ?? pattern.reviewState.caseStaging ?? null;
     return (
       <div
         style={{
@@ -271,6 +273,7 @@ function PlaybookReviewRow({ pattern, canWrite }: { pattern: WorkPatternSummary;
         <div style={{ fontSize: 10, color: "var(--dpf-muted)", overflowWrap: "anywhere" }}>
           Candidate record only; live autonomy and Work Case state stay unchanged.
         </div>
+        <CaseStagingRow state={caseStaging} />
       </div>
     );
   }
@@ -321,6 +324,79 @@ function PlaybookReviewRow({ pattern, canWrite }: { pattern: WorkPatternSummary;
       />
     </div>
   );
+}
+
+function CaseStagingRow({ state }: { state: CaseStaging | null }) {
+  if (!state || state.status === "not-case-bound") return null;
+  const staged = state.status === "stageable";
+  const guardrail = caseStagingGuardrailLabel(state);
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 4,
+        paddingTop: 6,
+        borderTop: "1px solid var(--dpf-border)",
+      }}
+    >
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
+        <Chip tone={staged ? "accent" : "warning"}>
+          {staged ? "Work Case proposal staged" : "Case proposal blocked"}
+        </Chip>
+        {guardrail ? <Chip tone={staged ? "warning" : "error"}>{guardrail}</Chip> : null}
+        {state.action ? <Chip tone="muted">{workCaseActionLabel(state.action)}</Chip> : null}
+      </div>
+      <div style={{ fontSize: 10, color: "var(--dpf-muted)", overflowWrap: "anywhere" }}>
+        Proposal record only; the case waits for governed approval and receipt evidence before any commit.
+      </div>
+    </div>
+  );
+}
+
+function caseStagingGuardrailLabel(state: CaseStaging): string | null {
+  if (state.receiptCoverage === "required-before-commit") {
+    return "receipt required before commit";
+  }
+  if (state.status === "blocked") {
+    return caseStagingBlockerLabel(state.blockers[0]);
+  }
+  return null;
+}
+
+function caseStagingBlockerLabel(blocker: string | undefined): string {
+  if (!blocker) return "proposal needs more context";
+  const labels: Record<string, string> = {
+    "missing-case-source-reference": "Work Case reference required",
+    "missing-governed-action-key": "Work Case action required",
+    "unknown-governed-action-key": "Work Case action not recognized",
+    "missing-receipt-policy": "receipt policy required",
+    "missing-authority-mode": "authority mode required",
+    "missing-sponsor-principal": "sponsor required",
+    "missing-authenticated-inbound-principal": "authenticated principal required",
+    "policy-missing_agent_sponsor": "sponsor required",
+    "policy-missing_delegating_principal": "delegating principal required",
+    "policy-missing_authenticated_inbound_principal": "authenticated principal required",
+  };
+  return labels[blocker] ?? blocker.replaceAll("-", " ");
+}
+
+function workCaseActionLabel(action: string): string {
+  const labels: Record<string, string> = {
+    "needs-input": "needs input",
+    "needs-auth": "needs authorization",
+    propose: "propose next move",
+    delegate: "delegate",
+    handoff: "handoff",
+    escalate: "escalate",
+    verify: "verify",
+    complete: "complete",
+    cancel: "cancel",
+    claim: "claim",
+    pause: "pause",
+    respond: "respond",
+    resume: "resume",
+  };
+  return labels[action] ?? action.replaceAll("-", " ");
 }
 
 function ReviewActionForm({

--- a/apps/web/lib/actions/work-pattern-review.test.ts
+++ b/apps/web/lib/actions/work-pattern-review.test.ts
@@ -9,11 +9,19 @@ const { mockPrisma, mockRequireCapability, mockRevalidatePath } = vi.hoisted(() 
     decisionInteraction: {
       create: vi.fn(),
     },
+    coworkerActionEnvelope: {
+      create: vi.fn(),
+      update: vi.fn(),
+    },
     trustState: {
       update: vi.fn(),
       create: vi.fn(),
     },
     workCase: {
+      update: vi.fn(),
+    },
+    workItem: {
+      create: vi.fn(),
       update: vi.fn(),
     },
     skillDefinition: {
@@ -94,6 +102,51 @@ function needRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function caseBoundNeedRow(overrides: Record<string, unknown> = {}) {
+  return needRow({
+    evidenceJson: {
+      patternKey: "case-proposal|build-specialist|backlog-item",
+      decisionScope: "company-wwwd",
+      riskClass: "internal-reversible",
+      currentAutonomyLevel: "shadow",
+      shadowTrials: shadowTrials(),
+      taskRunId: "TR-1",
+      toolExecutionId: "TE-1",
+      workCaseRef: "backlog-item:BI-123",
+      workPattern: {
+        patternKey: "case-proposal|build-specialist|backlog-item",
+        status: "approved",
+        scope: "case-transition",
+        version: 1,
+        source: "human-review",
+        decisionScope: "company-wwwd",
+        evidence: [{ workCaseRef: "backlog-item:BI-123", taskRunId: "TR-1" }],
+        candidate: {
+          kind: "other",
+          need: "Suggest the next Work Case move",
+          blocks: "The coworker repeatedly asks what to do next.",
+          fingerprint: "fp-case-proposal",
+        },
+        workCaseBinding: {
+          caseType: "backlog-item",
+          transitionKey: "request-input",
+          governedActionKey: "propose",
+          authorityMode: "autonomous",
+          sponsorPrincipalId: "prn_user_1",
+          receiptPolicy: "governed-action",
+        },
+        observedAt: "2026-06-28T11:00:00.000Z",
+      },
+    },
+    readinessJson: {
+      readyForReview: true,
+      readyForCaseActivation: true,
+      blockers: [],
+    },
+    ...overrides,
+  });
+}
+
 function form(action: string) {
   const data = new FormData();
   data.set("needId", "NEED-1");
@@ -160,6 +213,91 @@ describe("reviewWorkPatternAction", () => {
       }),
     });
     expect(mockRevalidatePath).toHaveBeenCalledWith("/platform/ai/agent/build-specialist");
+  });
+
+  it("records approved case-bound candidates as staged Work Case proposals", async () => {
+    mockPrisma.coworkerCapabilityNeed.findUnique.mockResolvedValue(caseBoundNeedRow());
+
+    await expect(recordWorkPatternReview(form("approve"))).resolves.toMatchObject({
+      status: "recorded",
+      action: "approve",
+      needId: "NEED-1",
+    });
+
+    expect(mockPrisma.decisionInteraction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        evidenceBundle: expect.objectContaining({
+          workPatternReview: expect.objectContaining({
+            caseStaging: expect.objectContaining({
+              status: "stageable",
+              action: "propose",
+              receiptCoverage: "required-before-commit",
+              stagedTransition: expect.objectContaining({
+                caseState: "awaiting-decision",
+                a2aStatus: "input-required",
+                committable: false,
+              }),
+            }),
+          }),
+        }),
+        outcomePayload: expect.objectContaining({
+          workPatternReview: expect.objectContaining({
+            caseStaging: expect.objectContaining({
+              status: "stageable",
+              requiredReceiptKind: "governed-action",
+            }),
+          }),
+        }),
+      }),
+    });
+    expect(mockPrisma.coworkerCapabilityNeed.update).toHaveBeenCalledWith({
+      where: { needId: "NEED-1" },
+      data: expect.objectContaining({
+        readinessJson: expect.objectContaining({
+          activationProposed: true,
+          workPatternReview: expect.objectContaining({
+            caseStaging: expect.objectContaining({
+              status: "stageable",
+              activationAllowed: false,
+              liveMutationAllowed: false,
+              receiptCoverage: "required-before-commit",
+            }),
+          }),
+        }),
+      }),
+    });
+    expect(mockPrisma.coworkerActionEnvelope.create).not.toHaveBeenCalled();
+    expect(mockPrisma.workCase.update).not.toHaveBeenCalled();
+    expect(mockPrisma.workItem.create).not.toHaveBeenCalled();
+    expect(mockPrisma.workItem.update).not.toHaveBeenCalled();
+  });
+
+  it("records blocked case proposal guardrails when Work Case metadata is incomplete", async () => {
+    mockPrisma.coworkerCapabilityNeed.findUnique.mockResolvedValue(
+      caseBoundNeedRow({
+        evidenceJson: {
+          ...caseBoundNeedRow().evidenceJson,
+          workPattern: {
+            ...(caseBoundNeedRow().evidenceJson as Record<string, unknown>).workPattern as Record<string, unknown>,
+            workCaseBinding: {
+              caseType: "backlog-item",
+              governedActionKey: "propose",
+              authorityMode: "autonomous",
+              receiptPolicy: "governed-action",
+            },
+          },
+        },
+      }),
+    );
+
+    await recordWorkPatternReview(form("approve"));
+
+    const update = mockPrisma.coworkerCapabilityNeed.update.mock.calls[0]![0];
+    expect(update.data.readinessJson.workPatternReview.caseStaging).toMatchObject({
+      status: "blocked",
+      receiptCoverage: "blocked",
+      blockers: expect.arrayContaining(["missing-sponsor-principal"]),
+    });
   });
 
   it("records rejection without creating an activation candidate", async () => {
@@ -231,7 +369,11 @@ describe("reviewWorkPatternAction", () => {
 
     expect(mockPrisma.trustState.update).not.toHaveBeenCalled();
     expect(mockPrisma.trustState.create).not.toHaveBeenCalled();
+    expect(mockPrisma.coworkerActionEnvelope.create).not.toHaveBeenCalled();
+    expect(mockPrisma.coworkerActionEnvelope.update).not.toHaveBeenCalled();
     expect(mockPrisma.workCase.update).not.toHaveBeenCalled();
+    expect(mockPrisma.workItem.create).not.toHaveBeenCalled();
+    expect(mockPrisma.workItem.update).not.toHaveBeenCalled();
     expect(mockPrisma.skillDefinition.update).not.toHaveBeenCalled();
     expect(mockPrisma.promptTemplate.update).not.toHaveBeenCalled();
     expect(mockPrisma.backlogItem.update).not.toHaveBeenCalled();

--- a/apps/web/lib/actions/work-pattern-review.ts
+++ b/apps/web/lib/actions/work-pattern-review.ts
@@ -26,10 +26,12 @@ import {
   WORK_PATTERN_REVIEW_ACTIONS,
   type WorkPatternReviewAction,
 } from "@/lib/tak/work-pattern-review";
+import { buildWorkPatternCaseStaging } from "@/lib/tak/work-pattern-case-staging";
 import type {
   WorkPatternCandidate,
   WorkPatternDecisionScope,
 } from "@/lib/tak/work-pattern-types";
+import { parseWorkPatternMetadata } from "@/lib/tak/work-pattern-types";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -60,6 +62,10 @@ function isRecord(value: unknown): value is JsonRecord {
 
 function recordFrom(value: unknown): JsonRecord {
   return isRecord(value) ? value : {};
+}
+
+function inputJson(value: unknown): Prisma.InputJsonValue {
+  return value as Prisma.InputJsonValue;
 }
 
 function stringField(source: unknown, field: string): string | null {
@@ -160,6 +166,16 @@ function buildRoute(agentId: string): string {
   return `/platform/ai/agent/${agentId}`;
 }
 
+function workPatternMetadataFrom(
+  evidenceJson: JsonRecord,
+  readinessJson: JsonRecord,
+) {
+  return (
+    parseWorkPatternMetadata(evidenceJson.workPattern) ??
+    parseWorkPatternMetadata(readinessJson.workPattern)
+  );
+}
+
 export async function recordWorkPatternReview(formData: FormData): Promise<ReviewActionResult> {
   const { userId } = await requireCapability("manage_platform");
   const needId = formString(formData, "needId");
@@ -229,6 +245,14 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
     reviewedAt: new Date(),
     reviewerNote: note,
   });
+  const caseStaging = buildWorkPatternCaseStaging({
+    review,
+    metadata: workPatternMetadataFrom(evidenceJson, readinessJson),
+  });
+  const reviewWithStaging =
+    caseStaging.status === "not-case-bound"
+      ? review
+      : { ...review, caseStaging };
   const outcomeType = outcomeTypeFor(action);
   const routeContext = buildRoute(need.agentId);
   const confidence = shadowEvaluation?.agreementRate ?? 0;
@@ -247,15 +271,15 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
         domainClass: "risk-assessment",
         question: `Review Living Playbook candidate "${need.need}" for ${need.agentId}?`,
         options: ["Approve scoped activation candidate", "Defer for more evidence", "Reject candidate"],
-        evidenceBundle: {
-          workPatternReview: review,
+        evidenceBundle: inputJson({
+          workPatternReview: reviewWithStaging,
           shadowEvaluation,
           capabilityNeedId: need.needId,
           linkedBacklogItemId: need.linkedBacklogItemId ?? null,
           materialCount: 0,
           freshnessDistribution: { current: 0, stale: 0, superseded: 0, contradicted: 0 },
           resolvedProfileChain: [MARK_DPF_PLATFORM_PROFILE.profileId],
-        },
+        }),
         sources: evidenceSources({ need, evidenceJson }),
         rationale: note ?? `Operator recorded ${action} for Living Playbook candidate ${patternKey}.`,
         riskTier: riskTierFor(shadowEvaluation?.riskClass ?? shadowRiskClass),
@@ -263,7 +287,7 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
         confidenceAfter: confidence,
         outcomeType,
         principleConflict: false,
-        outcomePayload: {
+        outcomePayload: inputJson({
           outcomeType,
           domainClass: "risk-assessment",
           confidenceScore: confidence,
@@ -272,8 +296,8 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
           resolvedProfileChain: [MARK_DPF_PLATFORM_PROFILE.profileId],
           materialCount: 0,
           freshnessDistribution: { current: 0, stale: 0, superseded: 0, contradicted: 0 },
-          workPatternReview: review,
-        },
+          workPatternReview: reviewWithStaging,
+        }),
         humanOutcome: {
           type: "work-pattern-review",
           action,
@@ -285,7 +309,7 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
                 : "Reject candidate",
           rationale: note,
           resolverUserId: userId,
-          recordedAt: review.reviewedAt,
+          recordedAt: reviewWithStaging.reviewedAt,
           clearsGate: false,
         },
       },
@@ -301,7 +325,7 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
           decisionInteractionId,
           decisionInteractionIds: appendString(evidenceJson.decisionInteractionIds, decisionInteractionId),
         } as Prisma.InputJsonValue,
-        readinessJson: mergeWorkPatternReviewState(readinessJson, review) as Prisma.InputJsonValue,
+        readinessJson: mergeWorkPatternReviewState(readinessJson, reviewWithStaging) as Prisma.InputJsonValue,
       },
     });
   });

--- a/apps/web/lib/tak/work-pattern-case-staging.test.ts
+++ b/apps/web/lib/tak/work-pattern-case-staging.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkPatternReviewState } from "./work-pattern-review";
+import type { WorkPatternMetadata } from "./work-pattern-types";
+import {
+  buildWorkPatternCaseStaging,
+  parseWorkPatternCaseStagingState,
+} from "./work-pattern-case-staging";
+
+function approvedReview(overrides: Partial<WorkPatternReviewState> = {}): WorkPatternReviewState {
+  return {
+    action: "approve",
+    status: "approved-candidate",
+    needId: "NEED-1",
+    agentId: "build-specialist",
+    patternKey: "case-proposal|build-specialist|backlog-item",
+    routeContext: "/build",
+    riskClass: "internal-reversible",
+    decisionScope: "company-wwwd",
+    decisionInteractionId: "DI-REVIEW001",
+    reviewerUserId: "user-1",
+    reviewedAt: "2026-06-28T12:00:00.000Z",
+    reviewerNote: "Approve as a Work Case proposal only.",
+    blockers: ["activation-candidate-awaits-governed-promotion"],
+    activationProposed: true,
+    activationCandidate: {
+      state: "candidate",
+      activationAllowed: false,
+      patternKey: "case-proposal|build-specialist|backlog-item",
+      agentId: "build-specialist",
+      routeContext: "/build",
+      riskClass: "internal-reversible",
+      decisionScope: "company-wwwd",
+      currentAutonomyLevel: "shadow",
+      proposedAutonomyLevel: "propose",
+      evidenceSummary: {
+        samples: 20,
+        agreements: 19,
+        agreementRate: 0.95,
+      },
+      blockers: ["activation-candidate-awaits-governed-promotion"],
+    },
+    ...overrides,
+  };
+}
+
+function caseBoundMetadata(overrides: Partial<WorkPatternMetadata> = {}): WorkPatternMetadata {
+  return {
+    patternKey: "case-proposal|build-specialist|backlog-item",
+    status: "approved",
+    scope: "case-transition",
+    version: 1,
+    source: "human-review",
+    decisionScope: "company-wwwd",
+    evidence: [{ workCaseRef: "backlog-item:BI-123", taskRunId: "TR-1" }],
+    candidate: {
+      kind: "other",
+      need: "Suggest the next Work Case move",
+      blocks: "The coworker repeatedly asks what to do next.",
+      fingerprint: "fp-case-proposal",
+    },
+    workCaseBinding: {
+      caseType: "backlog-item",
+      transitionKey: "request-input",
+      governedActionKey: "propose",
+      authorityMode: "autonomous",
+      sponsorPrincipalId: "prn_user_1",
+      receiptPolicy: "governed-action",
+    },
+    observedAt: "2026-06-28T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("work-pattern-case-staging", () => {
+  it("projects approved case-bound candidates as non-committable Work Case proposals", () => {
+    const state = buildWorkPatternCaseStaging({
+      review: approvedReview(),
+      metadata: caseBoundMetadata(),
+    });
+
+    expect(state).toMatchObject({
+      status: "stageable",
+      activationAllowed: false,
+      liveMutationAllowed: false,
+      action: "propose",
+      caseRef: {
+        caseId: "backlog-item:BI-123",
+        sourceType: "backlog-item",
+        sourceId: "BI-123",
+      },
+      enforcementMode: "governed-action",
+      requiredReceiptKind: "governed-action",
+      receiptCoverage: "required-before-commit",
+      stagedTransition: {
+        status: "proposed",
+        caseState: "awaiting-decision",
+        a2aStatus: "input-required",
+        committable: false,
+        sourceRef: {
+          kind: "decision-interaction",
+          id: "DI-REVIEW001",
+        },
+      },
+      proposalRail: {
+        kind: "coworker-action-envelope-preview",
+        envelopeStatus: "proposed",
+        manifestActionId: "work-case.propose",
+      },
+    });
+    expect(state.blockers).toContain("receipt-required-before-commit");
+  });
+
+  it("blocks case-bound candidates that omit receipt policy", () => {
+    const state = buildWorkPatternCaseStaging({
+      review: approvedReview(),
+      metadata: caseBoundMetadata({
+        workCaseBinding: {
+          caseType: "backlog-item",
+          governedActionKey: "propose",
+          authorityMode: "autonomous",
+          sponsorPrincipalId: "prn_user_1",
+        },
+      }),
+    });
+
+    expect(state).toMatchObject({
+      status: "blocked",
+      receiptCoverage: "blocked",
+    });
+    expect(state.blockers).toContain("missing-receipt-policy");
+  });
+
+  it("blocks agent proposals without a sponsor principal", () => {
+    const state = buildWorkPatternCaseStaging({
+      review: approvedReview(),
+      metadata: caseBoundMetadata({
+        workCaseBinding: {
+          caseType: "backlog-item",
+          governedActionKey: "propose",
+          authorityMode: "autonomous",
+          receiptPolicy: "governed-action",
+        },
+      }),
+    });
+
+    expect(state).toMatchObject({
+      status: "blocked",
+      receiptCoverage: "blocked",
+    });
+    expect(state.blockers).toContain("missing-sponsor-principal");
+  });
+
+  it("does not stage non-case-bound or non-approved reviews", () => {
+    expect(
+      buildWorkPatternCaseStaging({
+        review: approvedReview(),
+        metadata: {
+          ...caseBoundMetadata(),
+          scope: "route",
+          workCaseBinding: undefined,
+        },
+      }),
+    ).toMatchObject({ status: "not-case-bound", receiptCoverage: "not-required" });
+
+    expect(
+      buildWorkPatternCaseStaging({
+        review: approvedReview({
+          action: "reject",
+          status: "rejected",
+          activationProposed: false,
+          activationCandidate: null,
+        }),
+        metadata: caseBoundMetadata(),
+      }),
+    ).toMatchObject({ status: "not-case-bound", receiptCoverage: "not-required" });
+  });
+
+  it("parses persisted case staging state and rejects malformed records", () => {
+    const state = buildWorkPatternCaseStaging({
+      review: approvedReview(),
+      metadata: caseBoundMetadata(),
+    });
+
+    expect(parseWorkPatternCaseStagingState(state)).toMatchObject({
+      status: "stageable",
+      action: "propose",
+      receiptCoverage: "required-before-commit",
+    });
+    expect(parseWorkPatternCaseStagingState({ status: "stageable" })).toBeNull();
+    expect(parseWorkPatternCaseStagingState(null)).toBeNull();
+  });
+});

--- a/apps/web/lib/tak/work-pattern-case-staging.ts
+++ b/apps/web/lib/tak/work-pattern-case-staging.ts
@@ -1,0 +1,517 @@
+import { getWorkCaseAction } from "@/lib/work-management/action-registry";
+import type {
+  WorkCaseActionVerb,
+  WorkCaseEnforcementMode,
+  WorkCaseRef,
+} from "@/lib/work-management/case-types";
+import { evaluateWorkCasePolicy } from "@/lib/work-management/policy-envelope";
+import { assertWorkCaseReceiptCoverage } from "@/lib/work-management/receipt-coverage";
+import type { WorkCaseReceiptKind } from "@/lib/work-management/source-registry";
+import {
+  projectWorkCaseStagedTransition,
+  type WorkCaseStagedTransitionProjection,
+} from "@/lib/work-management/staged-transition";
+import type { WorkPatternReviewState } from "./work-pattern-review";
+import type { WorkPatternMetadata } from "./work-pattern-types";
+
+export const WORK_PATTERN_CASE_STAGING_STATUSES = [
+  "not-case-bound",
+  "blocked",
+  "stageable",
+] as const;
+export type WorkPatternCaseStagingStatus =
+  (typeof WORK_PATTERN_CASE_STAGING_STATUSES)[number];
+
+export const WORK_PATTERN_CASE_RECEIPT_COVERAGE = [
+  "not-required",
+  "required-before-commit",
+  "covered",
+  "blocked",
+] as const;
+export type WorkPatternCaseReceiptCoverage =
+  (typeof WORK_PATTERN_CASE_RECEIPT_COVERAGE)[number];
+
+export type WorkPatternCaseProposalRail = {
+  kind: "coworker-action-envelope-preview";
+  envelopeStatus: "proposed";
+  manifestActionId: string;
+  argsJson: Record<string, unknown>;
+  rationale: string;
+};
+
+export type WorkPatternCaseStagingState = {
+  status: WorkPatternCaseStagingStatus;
+  activationAllowed: false;
+  liveMutationAllowed: false;
+  caseRef?: WorkCaseRef;
+  action?: WorkCaseActionVerb;
+  transitionId?: string;
+  stagedTransition?: WorkCaseStagedTransitionProjection;
+  enforcementMode?: WorkCaseEnforcementMode;
+  requiredReceiptKind?: WorkCaseReceiptKind;
+  receiptCoverage: WorkPatternCaseReceiptCoverage;
+  blockers: string[];
+  proposalRail?: WorkPatternCaseProposalRail;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(source: Record<string, unknown>, field: string): string | null {
+  const value = source[field];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
+}
+
+function notCaseBound(): WorkPatternCaseStagingState {
+  return {
+    status: "not-case-bound",
+    activationAllowed: false,
+    liveMutationAllowed: false,
+    receiptCoverage: "not-required",
+    blockers: [],
+  };
+}
+
+function blocked(
+  blockers: string[],
+  partial: Partial<WorkPatternCaseStagingState> = {},
+): WorkPatternCaseStagingState {
+  return {
+    status: "blocked",
+    activationAllowed: false,
+    liveMutationAllowed: false,
+    receiptCoverage: "blocked",
+    blockers: [...new Set(blockers)],
+    ...partial,
+  };
+}
+
+function isCaseBound(metadata: WorkPatternMetadata): boolean {
+  return (
+    metadata.scope === "case-type" ||
+    metadata.scope === "case-transition" ||
+    Boolean(metadata.workCaseBinding)
+  );
+}
+
+function firstWorkCaseRef(metadata: WorkPatternMetadata): string | null {
+  return metadata.evidence?.find((ref) => ref.workCaseRef?.trim())?.workCaseRef?.trim() ?? null;
+}
+
+function parseCaseRef(metadata: WorkPatternMetadata): WorkCaseRef | null {
+  const raw = firstWorkCaseRef(metadata);
+  if (!raw) return null;
+  const separator = raw.indexOf(":");
+  if (separator > 0 && separator < raw.length - 1) {
+    const sourceType = raw.slice(0, separator).trim();
+    const sourceId = raw.slice(separator + 1).trim();
+    if (sourceType && sourceId) {
+      return { caseId: raw, sourceType, sourceId };
+    }
+  }
+
+  const sourceType = metadata.workCaseBinding?.caseType?.trim();
+  if (!sourceType) return null;
+  return {
+    caseId: `${sourceType}:${raw}`,
+    sourceType,
+    sourceId: raw,
+  };
+}
+
+function present(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function transitionIdFor(input: {
+  review: WorkPatternReviewState;
+  caseRef: WorkCaseRef;
+  action: WorkCaseActionVerb;
+}): string {
+  return `work-pattern:${input.caseRef.caseId}:${input.action}:${input.review.decisionInteractionId}`;
+}
+
+function needsCoworkerEnvelope(action: ReturnType<typeof getWorkCaseAction>): boolean {
+  if (!action) return false;
+  return action.requiresCoworkerEnvelope !== "never";
+}
+
+export function buildWorkPatternCaseStaging(input: {
+  review: WorkPatternReviewState;
+  metadata?: WorkPatternMetadata | null;
+}): WorkPatternCaseStagingState {
+  const { review, metadata } = input;
+  if (
+    !metadata ||
+    !isCaseBound(metadata) ||
+    review.action !== "approve" ||
+    review.status !== "approved-candidate" ||
+    !review.activationCandidate
+  ) {
+    return notCaseBound();
+  }
+
+  const binding = metadata.workCaseBinding;
+  const caseRef = parseCaseRef(metadata);
+  const blockers: string[] = [];
+  if (!binding) blockers.push("missing-work-case-binding");
+  if (!caseRef) blockers.push("missing-case-source-reference");
+  if (!binding?.governedActionKey) blockers.push("missing-governed-action-key");
+  if (!binding?.receiptPolicy) blockers.push("missing-receipt-policy");
+  if (!binding?.authorityMode) blockers.push("missing-authority-mode");
+  if (
+    (binding?.authorityMode === "autonomous" || binding?.authorityMode === "on-behalf-of") &&
+    !present(binding.sponsorPrincipalId)
+  ) {
+    blockers.push("missing-sponsor-principal");
+  }
+  if (
+    binding?.authorityMode === "authenticated-inbound" &&
+    !present(binding.sponsorPrincipalId)
+  ) {
+    blockers.push("missing-authenticated-inbound-principal");
+  }
+
+  const action = getWorkCaseAction(binding?.governedActionKey);
+  if (binding?.governedActionKey && !action) blockers.push("unknown-governed-action-key");
+  if (blockers.length > 0 || !binding || !caseRef || !action || !binding.receiptPolicy || !binding.authorityMode) {
+    return blocked(blockers, {
+      caseRef: caseRef ?? undefined,
+      action: action?.action,
+    });
+  }
+
+  const transitionId = transitionIdFor({ review, caseRef, action: action.action });
+  const stagedTransition = projectWorkCaseStagedTransition({
+    transitionId,
+    action: action.action,
+    status: "proposed",
+    decisionInteractionId: review.decisionInteractionId,
+  });
+  const sponsorPrincipalId = binding.sponsorPrincipalId?.trim() ?? null;
+  const policyDecision = evaluateWorkCasePolicy({
+    caseRef,
+    sourceKey: caseRef.sourceType,
+    action: action.action,
+    currentState: { state: "active", terminal: false },
+    envelope: {
+      autonomyMode: "supervised",
+      accountability: {
+        actor: { actorKind: "agent", actorId: review.agentId },
+        authorityMode: binding.authorityMode,
+        sponsorPrincipalId,
+        delegatingPrincipalId:
+          binding.authorityMode === "on-behalf-of" ? sponsorPrincipalId : null,
+        authenticatedInboundPrincipalId:
+          binding.authorityMode === "authenticated-inbound" ? sponsorPrincipalId : null,
+        accountablePrincipalId: sponsorPrincipalId,
+      },
+      receiptPolicy: {
+        required: true,
+        kind: binding.receiptPolicy,
+      },
+    },
+    // This is a static policy preview for the future commit path. The visible
+    // proposal rail below remains proposed; no envelope row is written here.
+    coworkerEnvelope: needsCoworkerEnvelope(action)
+      ? { envelopeId: `preview:${transitionId}`, status: "approved" }
+      : null,
+    decisionInteractionId: review.decisionInteractionId,
+  });
+
+  if (!policyDecision.ok) {
+    return blocked([`policy-${policyDecision.reason}`], {
+      caseRef,
+      action: action.action,
+      transitionId,
+      stagedTransition,
+    });
+  }
+
+  const receiptCoverage = assertWorkCaseReceiptCoverage({
+    action,
+    policyDecision,
+    projectedState: {
+      state: stagedTransition.caseState,
+      terminal: stagedTransition.terminal,
+    },
+    receipt: null,
+  });
+  if (!receiptCoverage.ok && receiptCoverage.reason !== "missing_receipt") {
+    return blocked([`receipt-${receiptCoverage.reason}`], {
+      caseRef,
+      action: action.action,
+      transitionId,
+      stagedTransition,
+      enforcementMode: policyDecision.enforcementMode,
+      requiredReceiptKind: policyDecision.requiredReceiptKind,
+    });
+  }
+
+  const receiptStatus: WorkPatternCaseReceiptCoverage = receiptCoverage.ok
+    ? action.requiresReceipt
+      ? "covered"
+      : "not-required"
+    : "required-before-commit";
+  const receiptBlockers =
+    receiptStatus === "required-before-commit"
+      ? ["receipt-required-before-commit"]
+      : [];
+
+  return {
+    status: "stageable",
+    activationAllowed: false,
+    liveMutationAllowed: false,
+    caseRef,
+    action: action.action,
+    transitionId,
+    stagedTransition,
+    enforcementMode: policyDecision.enforcementMode,
+    requiredReceiptKind: policyDecision.requiredReceiptKind,
+    receiptCoverage: receiptStatus,
+    blockers: receiptBlockers,
+    proposalRail: {
+      kind: "coworker-action-envelope-preview",
+      envelopeStatus: "proposed",
+      manifestActionId: `work-case.${action.action}`,
+      argsJson: {
+        caseRef: caseRef.caseId,
+        sourceType: caseRef.sourceType,
+        sourceId: caseRef.sourceId,
+        action: action.action,
+        transitionId,
+        patternKey: review.patternKey,
+        decisionInteractionId: review.decisionInteractionId,
+        receiptPolicy: binding.receiptPolicy,
+      },
+      rationale: "Stage Work Case proposal from approved Living Playbook candidate.",
+    },
+  };
+}
+
+function parseCaseRefState(value: unknown): WorkCaseRef | null {
+  if (!isRecord(value)) return null;
+  const caseId = stringField(value, "caseId");
+  const sourceType = stringField(value, "sourceType");
+  const sourceId = stringField(value, "sourceId");
+  return caseId && sourceType && sourceId ? { caseId, sourceType, sourceId } : null;
+}
+
+function parseSourceRef(value: unknown): WorkCaseStagedTransitionProjection["sourceRef"] | null {
+  if (!isRecord(value)) return null;
+  const kind = stringField(value, "kind");
+  const id = stringField(value, "id");
+  if (
+    kind !== "source" &&
+    kind !== "work-item" &&
+    kind !== "work-capsule" &&
+    kind !== "decision-interaction" &&
+    kind !== "runtime-verification" &&
+    kind !== "evidence"
+  ) {
+    return null;
+  }
+  if (!id) return null;
+  return {
+    kind,
+    id,
+    status: stringField(value, "status") ?? undefined,
+    sourceType: stringField(value, "sourceType") ?? undefined,
+  };
+}
+
+function parseStagedTransition(value: unknown): WorkCaseStagedTransitionProjection | null {
+  if (!isRecord(value)) return null;
+  const transitionId = stringField(value, "transitionId");
+  const action = getWorkCaseAction(stringField(value, "action"))?.action;
+  const sourceRef = parseSourceRef(value.sourceRef);
+  const status = stringField(value, "status");
+  const caseState = stringField(value, "caseState");
+  const a2aStatus = stringField(value, "a2aStatus");
+  const reason = stringField(value, "reason");
+  const nextAction = stringField(value, "nextAction");
+  if (
+    !transitionId ||
+    !action ||
+    !sourceRef ||
+    !status ||
+    !caseState ||
+    !a2aStatus ||
+    typeof value.terminal !== "boolean" ||
+    typeof value.committable !== "boolean" ||
+    !reason ||
+    !nextAction
+  ) {
+    return null;
+  }
+  if (
+    status !== "proposed" &&
+    status !== "awaiting-approval" &&
+    status !== "edited" &&
+    status !== "approved" &&
+    status !== "rejected" &&
+    status !== "responded" &&
+    status !== "cancelled"
+  ) {
+    return null;
+  }
+  if (
+    caseState !== "intake" &&
+    caseState !== "triage" &&
+    caseState !== "active" &&
+    caseState !== "waiting-on-person" &&
+    caseState !== "waiting-on-system" &&
+    caseState !== "awaiting-decision" &&
+    caseState !== "verifying" &&
+    caseState !== "resolved" &&
+    caseState !== "closed" &&
+    caseState !== "cancelled"
+  ) {
+    return null;
+  }
+  if (
+    a2aStatus !== "submitted" &&
+    a2aStatus !== "working" &&
+    a2aStatus !== "input-required" &&
+    a2aStatus !== "auth-required" &&
+    a2aStatus !== "completed" &&
+    a2aStatus !== "canceled" &&
+    a2aStatus !== "failed" &&
+    a2aStatus !== "rejected"
+  ) {
+    return null;
+  }
+  return {
+    transitionId,
+    action,
+    status,
+    caseState,
+    a2aStatus,
+    terminal: value.terminal,
+    committable: value.committable,
+    sourceRef,
+    reason,
+    nextAction,
+  };
+}
+
+function parseProposalRail(value: unknown): WorkPatternCaseProposalRail | undefined {
+  if (!isRecord(value)) return undefined;
+  if (
+    value.kind !== "coworker-action-envelope-preview" ||
+    value.envelopeStatus !== "proposed"
+  ) {
+    return undefined;
+  }
+  const manifestActionId = stringField(value, "manifestActionId");
+  const rationale = stringField(value, "rationale");
+  if (!manifestActionId || !rationale) return undefined;
+  return {
+    kind: "coworker-action-envelope-preview",
+    envelopeStatus: "proposed",
+    manifestActionId,
+    argsJson: isRecord(value.argsJson) ? value.argsJson : {},
+    rationale,
+  };
+}
+
+export function parseWorkPatternCaseStagingState(
+  value: unknown,
+): WorkPatternCaseStagingState | null {
+  if (!isRecord(value)) return null;
+  const status = stringField(value, "status");
+  const blockers = stringArray(value.blockers);
+  if (
+    status !== "not-case-bound" &&
+    status !== "blocked" &&
+    status !== "stageable"
+  ) {
+    return null;
+  }
+  if (value.activationAllowed !== false || value.liveMutationAllowed !== false) {
+    return null;
+  }
+  const receiptCoverage = stringField(value, "receiptCoverage");
+  if (
+    receiptCoverage !== "not-required" &&
+    receiptCoverage !== "required-before-commit" &&
+    receiptCoverage !== "covered" &&
+    receiptCoverage !== "blocked"
+  ) {
+    return null;
+  }
+
+  if (status === "not-case-bound") {
+    return {
+      status,
+      activationAllowed: false,
+      liveMutationAllowed: false,
+      receiptCoverage,
+      blockers,
+    };
+  }
+
+  const caseRef = parseCaseRefState(value.caseRef);
+  const action = getWorkCaseAction(stringField(value, "action"))?.action;
+  if (status === "stageable") {
+    const transitionId = stringField(value, "transitionId");
+    const stagedTransition = parseStagedTransition(value.stagedTransition);
+    const enforcementMode = stringField(value, "enforcementMode");
+    const requiredReceiptKind = stringField(value, "requiredReceiptKind");
+    if (
+      !caseRef ||
+      !action ||
+      !transitionId ||
+      !stagedTransition ||
+      (enforcementMode !== "governed-action" && enforcementMode !== "observed-event") ||
+      (requiredReceiptKind !== "governed-action" &&
+        requiredReceiptKind !== "observed-event" &&
+        requiredReceiptKind !== "operator-note")
+    ) {
+      return null;
+    }
+    return {
+      status,
+      activationAllowed: false,
+      liveMutationAllowed: false,
+      caseRef,
+      action,
+      transitionId,
+      stagedTransition,
+      enforcementMode,
+      requiredReceiptKind,
+      receiptCoverage,
+      blockers,
+      proposalRail: parseProposalRail(value.proposalRail),
+    };
+  }
+
+  return {
+    status,
+    activationAllowed: false,
+    liveMutationAllowed: false,
+    caseRef: caseRef ?? undefined,
+    action,
+    transitionId: stringField(value, "transitionId") ?? undefined,
+    stagedTransition: parseStagedTransition(value.stagedTransition) ?? undefined,
+    enforcementMode:
+      value.enforcementMode === "governed-action" || value.enforcementMode === "observed-event"
+        ? value.enforcementMode
+        : undefined,
+    requiredReceiptKind:
+      value.requiredReceiptKind === "governed-action" ||
+      value.requiredReceiptKind === "observed-event" ||
+      value.requiredReceiptKind === "operator-note"
+        ? value.requiredReceiptKind
+        : undefined,
+    receiptCoverage,
+    blockers,
+    proposalRail: parseProposalRail(value.proposalRail),
+  };
+}

--- a/apps/web/lib/tak/work-pattern-read-model.test.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.test.ts
@@ -172,6 +172,48 @@ describe("getWorkPatternReadModel", () => {
                 },
                 blockers: ["activation-candidate-awaits-governed-promotion"],
               },
+              caseStaging: {
+                status: "stageable",
+                activationAllowed: false,
+                liveMutationAllowed: false,
+                caseRef: {
+                  caseId: "backlog-item:BI-123",
+                  sourceType: "backlog-item",
+                  sourceId: "BI-123",
+                },
+                action: "propose",
+                transitionId: "work-pattern:backlog-item:BI-123:propose:DI-REVIEW001",
+                stagedTransition: {
+                  transitionId: "work-pattern:backlog-item:BI-123:propose:DI-REVIEW001",
+                  action: "propose",
+                  status: "proposed",
+                  caseState: "awaiting-decision",
+                  a2aStatus: "input-required",
+                  terminal: false,
+                  committable: false,
+                  sourceRef: {
+                    kind: "decision-interaction",
+                    id: "DI-REVIEW001",
+                    status: "proposed",
+                  },
+                  reason: "Transition propose is proposed and waiting for approve/edit/reject/respond.",
+                  nextAction: "Resolve staged transition",
+                },
+                enforcementMode: "governed-action",
+                requiredReceiptKind: "governed-action",
+                receiptCoverage: "required-before-commit",
+                blockers: ["receipt-required-before-commit"],
+                proposalRail: {
+                  kind: "coworker-action-envelope-preview",
+                  envelopeStatus: "proposed",
+                  manifestActionId: "work-case.propose",
+                  argsJson: {
+                    caseRef: "backlog-item:BI-123",
+                    action: "propose",
+                  },
+                  rationale: "Stage Work Case proposal from approved Living Playbook candidate.",
+                },
+              },
             },
           },
         }),
@@ -225,6 +267,18 @@ describe("getWorkPatternReadModel", () => {
       activationAllowed: false,
       currentAutonomyLevel: "shadow",
       proposedAutonomyLevel: "propose",
+    });
+    expect(observed?.caseStaging).toMatchObject({
+      status: "stageable",
+      action: "propose",
+      receiptCoverage: "required-before-commit",
+    });
+    expect(observed?.reviewState?.caseStaging).toMatchObject({
+      status: "stageable",
+      stagedTransition: expect.objectContaining({
+        caseState: "awaiting-decision",
+        committable: false,
+      }),
     });
     expect(observed?.evidenceRefs).toEqual(
       expect.arrayContaining([

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -31,6 +31,7 @@ import {
   type WorkPatternActivationCandidate,
   type WorkPatternReviewState,
 } from "./work-pattern-review";
+import type { WorkPatternCaseStagingState } from "./work-pattern-case-staging";
 
 const DEFAULT_WINDOW_DAYS = 30;
 const DEFAULT_TAKE = 200;
@@ -120,6 +121,7 @@ export type WorkPatternSummary = {
   activationProposed: boolean;
   reviewState: WorkPatternReviewState | null;
   activationCandidate: WorkPatternActivationCandidate | null;
+  caseStaging: WorkPatternCaseStagingState | null;
   shadowEvaluation: WorkPatternShadowEvaluation | null;
 };
 
@@ -464,6 +466,7 @@ function createAccumulator(seed: PatternSeed): SummaryAccumulator {
     activationProposed: seed.activationProposed,
     reviewState: null,
     activationCandidate: null,
+    caseStaging: null,
     shadowTrials: [],
     shadowCurrentLevel: null,
     shadowRegulatoryCeiling: null,
@@ -619,6 +622,7 @@ function attachNeed(summary: SummaryAccumulator, row: WorkPatternReadModelNeedRo
   if (reviewState) {
     summary.reviewState = newerReview(summary.reviewState, reviewState);
     summary.activationCandidate = summary.reviewState.activationCandidate;
+    summary.caseStaging = summary.reviewState.caseStaging ?? null;
     summary.activationProposed = Boolean(summary.activationCandidate);
     addEvidence(summary, [{
       capabilityNeedId: row.needId,

--- a/apps/web/lib/tak/work-pattern-review.test.ts
+++ b/apps/web/lib/tak/work-pattern-review.test.ts
@@ -127,6 +127,67 @@ describe("work-pattern-review", () => {
     });
   });
 
+  it("preserves case staging state when parsing persisted review JSON", () => {
+    const review = buildWorkPatternReview(baseInput());
+    const merged = mergeWorkPatternReviewState(
+      { readyForReview: true },
+      {
+        ...review,
+        caseStaging: {
+          status: "stageable",
+          activationAllowed: false,
+          liveMutationAllowed: false,
+          caseRef: {
+            caseId: "backlog-item:BI-123",
+            sourceType: "backlog-item",
+            sourceId: "BI-123",
+          },
+          action: "propose",
+          transitionId: "work-pattern:DI-REVIEW001:propose",
+          stagedTransition: {
+            transitionId: "work-pattern:DI-REVIEW001:propose",
+            action: "propose",
+            status: "proposed",
+            caseState: "awaiting-decision",
+            a2aStatus: "input-required",
+            terminal: false,
+            committable: false,
+            sourceRef: {
+              kind: "decision-interaction",
+              id: "DI-REVIEW001",
+              status: "proposed",
+            },
+            reason: "Transition propose is proposed and waiting for approve/edit/reject/respond.",
+            nextAction: "Resolve staged transition",
+          },
+          enforcementMode: "governed-action",
+          requiredReceiptKind: "governed-action",
+          receiptCoverage: "required-before-commit",
+          blockers: ["receipt-required-before-commit"],
+          proposalRail: {
+            kind: "coworker-action-envelope-preview",
+            envelopeStatus: "proposed",
+            manifestActionId: "work-case.propose",
+            argsJson: {
+              caseRef: "backlog-item:BI-123",
+              action: "propose",
+            },
+            rationale: "Stage Work Case proposal from approved Living Playbook candidate.",
+          },
+        },
+      },
+    );
+
+    expect(parseWorkPatternReviewState(merged)).toMatchObject({
+      action: "approve",
+      caseStaging: {
+        status: "stageable",
+        action: "propose",
+        receiptCoverage: "required-before-commit",
+      },
+    });
+  });
+
   it("maps review actions to need statuses and review statuses", () => {
     expect(capabilityNeedStatusForReviewAction("approve")).toBe("accepted");
     expect(capabilityNeedStatusForReviewAction("defer")).toBe("deferred");

--- a/apps/web/lib/tak/work-pattern-review.ts
+++ b/apps/web/lib/tak/work-pattern-review.ts
@@ -7,6 +7,10 @@ import type {
   WorkPatternCandidate,
   WorkPatternDecisionScope,
 } from "./work-pattern-types";
+import {
+  parseWorkPatternCaseStagingState,
+  type WorkPatternCaseStagingState,
+} from "./work-pattern-case-staging";
 
 export const WORK_PATTERN_REVIEW_ACTIONS = ["approve", "reject", "defer"] as const;
 export type WorkPatternReviewAction = (typeof WORK_PATTERN_REVIEW_ACTIONS)[number];
@@ -52,6 +56,7 @@ export type WorkPatternReviewState = {
   blockers: string[];
   activationProposed: boolean;
   activationCandidate: WorkPatternActivationCandidate | null;
+  caseStaging?: WorkPatternCaseStagingState | null;
 };
 
 export type BuildWorkPatternReviewInput = {
@@ -273,6 +278,7 @@ export function parseWorkPatternReviewState(value: unknown): WorkPatternReviewSt
   }
 
   const activationCandidate = parseActivationCandidate(review.activationCandidate);
+  const caseStaging = parseWorkPatternCaseStagingState(review.caseStaging);
   return {
     action,
     status,
@@ -289,5 +295,6 @@ export function parseWorkPatternReviewState(value: unknown): WorkPatternReviewSt
     blockers: parseStringArray(review.blockers),
     activationProposed: booleanField(review, "activationProposed") ?? Boolean(activationCandidate),
     activationCandidate,
+    caseStaging,
   };
 }

--- a/docs/superpowers/plans/2026-06-28-governed-playbook-work-case-staging.md
+++ b/docs/superpowers/plans/2026-06-28-governed-playbook-work-case-staging.md
@@ -1,0 +1,227 @@
+# Governed Playbook Work Case Staging Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use the DPF worktree, planning, TDD, UX-fit, verification, and PR-with-DCO skills for this plan. Steps use checkbox (`- [ ]`) syntax for execution tracking.
+
+**Backlog item:** `BI-6F6C0675` - Governed adaptive playbooks Slice 5: Work Case staged proposal path
+
+**Work capsule:** `WC-9D3CA4E6` - Governed Playbook Work Case Staging
+
+**Goal:** Approved case-bound Living Playbook candidates should project into the existing Work Case staged-proposal rail with sponsor, authority, policy, and receipt guardrails. This slice must remain proposal-only: it records the staging state in review/readiness JSON and UI, but it must not mutate live Work Case state, TrustState, skills, prompts, grants, model routes, WorkItems, source records, or autonomy levels.
+
+**Architecture:** Extend the current governed work-pattern review model with a pure Work Case staging projection. Reuse existing Work Case substrate (`action-registry`, `policy-envelope`, `receipt-coverage`, `staged-transition`, source refs, and accountability context) instead of adding a new table, enum, dashboard, or runtime rail. The server action continues to write only `DecisionInteraction` and `CoworkerCapabilityNeed` readiness/review JSON.
+
+**Tech stack:** Next.js 16 server actions, Prisma 7 via `@dpf/db`, Vitest, React server rendering tests, existing TAK work-pattern modules, existing Work Case management helpers, existing `NeedsAndPlaybooksPanel` UI.
+
+---
+
+## Grounding
+
+- Design source: `docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md`.
+- Work Case source: `docs/superpowers/specs/2026-06-27-work-management-architecture-design.md`.
+- Previous slice: `docs/superpowers/plans/2026-06-28-governed-adaptive-playbooks-review-activation.md`.
+- Existing code substrate:
+  - `apps/web/lib/tak/work-pattern-review.ts`
+  - `apps/web/lib/tak/work-pattern-types.ts`
+  - `apps/web/lib/tak/work-pattern-read-model.ts`
+  - `apps/web/lib/actions/work-pattern-review.ts`
+  - `apps/web/lib/work-management/action-registry.ts`
+  - `apps/web/lib/work-management/accountability.ts`
+  - `apps/web/lib/work-management/policy-envelope.ts`
+  - `apps/web/lib/work-management/receipt-coverage.ts`
+  - `apps/web/lib/work-management/staged-transition.ts`
+  - `apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx`
+
+## UX Fit Review
+
+- Decision: `fits-with-guardrails`
+- Owning area: Platform
+- Route family: `/platform/ai/agent/[agentId]`
+- Primary persona: platform operator reviewing coworker behavior before granting any live agency
+- Navigation layer touched: local row-level disclosure inside the existing AI Workforce Needs & Playbooks tab
+- Reuse/convergence: reuse `NeedsAndPlaybooksPanel`, existing chips, `LocalTime`, and DPF theme variables; no new dashboard, tab row, card family, or Work Case route dependency
+- Source truth: work-pattern readiness/review JSON projected by TAK read models; Work Case policy/receipt/staged-transition helpers own proposal semantics
+- Empty/failure behavior: non-case-bound candidates remain unchanged; blocked case-bound candidates show a compact blocked reason; no empty Work Case dashboard
+- AI boundary: no prompt send and no live activation; this is a recorded proposal preview awaiting governed Work Case action and receipt evidence
+- Required plan/spec edits: this plan records the fit result and keeps UI copy on "Living Playbook" / "Work Case proposal," never "scaffold" or raw ledger terms
+- Evidence before merge: source-local Vitest, typecheck, production build, and UI rendering coverage for the compact row
+- Captured in: this plan and the PR body
+
+`UX-Fit-Decision: compact-existing-needs-playbooks-row (principle_decide; reuses AI Workforce Needs & Playbooks row, avoids duplicate Work Case dashboard, shows staged proposal guardrails without live activation)`
+
+## Refactoring Allocation
+
+Reserve roughly 20 percent of the slice for refactoring under green tests:
+
+- Extract Work Case staging into a pure TAK module rather than folding more branching into the server action.
+- Keep parsing and summary helpers typed and reusable so the read model and UI do not parse ad hoc JSON.
+- Remove any duplicated status-label logic introduced by the slice before PR.
+
+No broad unrelated cleanup belongs in this PR.
+
+---
+
+## Chunk 1: Pure Case Staging Projection
+
+### Task 1: Add test-first Work Case staging semantics
+
+**Files:**
+- Create: `apps/web/lib/tak/work-pattern-case-staging.ts`
+- Create: `apps/web/lib/tak/work-pattern-case-staging.test.ts`
+- Update: `apps/web/lib/tak/work-pattern-review.ts`
+- Update: `apps/web/lib/tak/work-pattern-review.test.ts`
+
+- [x] **Step 1: Write failing pure-module tests**
+
+Cover:
+
+- Approved case-bound review plus metadata with `workCaseBinding`, `governedActionKey`, `authorityMode`, `sponsorPrincipalId`, receipt policy, and `workCaseRef` returns a `stageable` proposal.
+- The stageable proposal projects through `projectWorkCaseStagedTransition` as `awaiting-decision`, `input-required`, and `committable: false`.
+- Missing receipt policy, unknown action key, unsupported source/action, missing authority, or missing sponsor returns `blocked` with operator-readable blocker keys.
+- Non-case-bound approval returns `not-case-bound`.
+- Rejected/deferred review returns `not-case-bound` and never stages.
+
+Run: `pnpm --filter web exec vitest run lib/tak/work-pattern-case-staging.test.ts lib/tak/work-pattern-review.test.ts`
+
+Expected first run: fail because the case-staging module and parser extension do not exist yet.
+
+- [x] **Step 2: Implement the pure module**
+
+Create a pure module that:
+
+- Exports `WorkPatternCaseStagingState`.
+- Reads case binding from `WorkPatternMetadata`.
+- Parses the first available `workCaseRef` evidence into a `WorkCaseRef`.
+- Resolves the governed action with `getWorkCaseAction`.
+- Builds a supervised `WorkCasePolicyEnvelope` with accountability context from the binding.
+- Uses `evaluateWorkCasePolicy` for static guardrails.
+- Uses `projectWorkCaseStagedTransition({ status: "proposed" })` for the proposal projection.
+- Uses `assertWorkCaseReceiptCoverage` only to identify receipt guardrails; a missing receipt is "required before commit," not permission to execute.
+- Returns a proposal rail descriptor for a future governed `CoworkerActionEnvelope` without writing an envelope row.
+
+- [x] **Step 3: Extend review state parsing**
+
+Update `WorkPatternReviewState`, `parseWorkPatternReviewState`, and related tests so case staging is preserved in readiness JSON while old review JSON still parses.
+
+---
+
+## Chunk 2: Server Action and Read Model
+
+### Task 2: Persist staging projection with review evidence
+
+**Files:**
+- Update: `apps/web/lib/actions/work-pattern-review.ts`
+- Update: `apps/web/lib/actions/work-pattern-review.test.ts`
+- Update: `apps/web/lib/tak/work-pattern-read-model.ts`
+- Update: `apps/web/lib/tak/work-pattern-read-model.test.ts`
+
+- [x] **Step 1: Write failing action/read-model tests**
+
+Cover:
+
+- Approving a case-bound candidate stores `workPatternReview.caseStaging.status: "stageable"` in readiness JSON.
+- The related `DecisionInteraction` outcome/evidence includes the same staging state.
+- Missing policy/receipt/sponsor metadata stores `blocked` with blocker keys.
+- Non-case-bound candidates keep the prior activation-candidate behavior.
+- No `CoworkerActionEnvelope`, Work Case, WorkItem, TrustState, SkillDefinition, PromptTemplate, grant, model-route, source-record, or backlog mutation is attempted.
+
+Run: `pnpm --filter web exec vitest run lib/actions/work-pattern-review.test.ts lib/tak/work-pattern-read-model.test.ts`
+
+Expected first run: fail until the action and read model call the pure projection.
+
+- [x] **Step 2: Wire the action**
+
+After `buildWorkPatternReview`, parse metadata from existing readiness/evidence JSON and attach case staging before creating `DecisionInteraction` and updating `CoworkerCapabilityNeed`.
+
+The action may only persist:
+
+- `DecisionInteraction`
+- `CoworkerCapabilityNeed.status`
+- `CoworkerCapabilityNeed.reviewerNote`
+- `CoworkerCapabilityNeed.readinessJson`
+- existing review timestamp/user fields already owned by the previous slice
+
+- [x] **Step 3: Wire the read model**
+
+Expose `caseStaging` through `WorkPatternSummary` via parsed review state so UI code does not inspect raw JSON.
+
+---
+
+## Chunk 3: Compact Operator UI
+
+### Task 3: Show proposal status in the existing Needs & Playbooks row
+
+**Files:**
+- Update: `apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx`
+- Update or add the nearest component/page rendering test for this panel.
+
+- [x] **Step 1: Write failing UI test**
+
+Assert that a reviewed case-bound Living Playbook row shows:
+
+- `Work Case proposal staged` for stageable proposals.
+- `receipt required before commit` as the guardrail copy.
+- `Case proposal blocked` for blocked staging.
+- No live activation language beyond the existing "candidate record only" warning.
+- No user-facing "scaffold", `ReceiptEnvelope`, `DecisionInteraction`, or raw implementation labels.
+
+- [x] **Step 2: Implement compact disclosure**
+
+Use existing chip/row styles and theme variables. Keep the new copy in the existing review row, below the decision chips. Do not add a dashboard, route, tab, or modal.
+
+---
+
+## Chunk 4: Verification, PR, and Landing
+
+### Task 4: Run source-local gates and PR workflow
+
+**Files:**
+- All files touched above.
+
+- [x] **Step 1: Focused tests**
+
+Run:
+
+`pnpm --filter web exec vitest run lib/tak/work-pattern-case-staging.test.ts lib/tak/work-pattern-review.test.ts lib/actions/work-pattern-review.test.ts lib/tak/work-pattern-read-model.test.ts 'app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'`
+
+- [x] **Step 2: Typecheck**
+
+Run:
+
+`pnpm --filter web typecheck`
+
+- [x] **Step 3: Production build**
+
+Run:
+
+`pnpm --filter web build`
+
+- [ ] **Step 4: PR mechanics**
+
+Before push:
+
+- Sweep open PRs and recent `origin/main` for overlap.
+- Stage explicit paths only; exclude `.mcp.json`.
+- Commit with `git commit -s`.
+- Push the branch.
+- Open a regular non-draft PR only after the gates pass.
+- Include `BI-6F6C0675`, `WC-9D3CA4E6`, build-gate evidence, and `UX-Fit-Decision` in the PR body.
+
+---
+
+## Risks and Rollback
+
+- **Risk:** Treating a missing receipt as approval to commit. Mitigation: encode it as `required-before-commit`, keep `committable: false`, and assert this in tests.
+- **Risk:** UI copy implies live activation. Mitigation: tests and copy keep "proposal" and "candidate record only"; no "activate" command is added.
+- **Risk:** Parallel substrate gets introduced accidentally. Mitigation: no migration, no new model, no envelope writes; Work Case helpers own semantics.
+- **Risk:** Case metadata is incomplete on existing records. Mitigation: return blocked state with plain blocker copy instead of throwing from the read model.
+
+Rollback is a revert of this PR. Because the slice is migration-free and writes only readiness/review JSON already owned by the previous slice, rollback does not require schema repair or runtime data migration.
+
+## Definition of Done
+
+- [x] Case-bound approved Living Playbook candidates project to governed Work Case staged proposals with policy and receipt guardrails.
+- [x] Non-case-bound candidates retain existing review activation behavior.
+- [x] No live Work Case/autonomy/source mutation is introduced.
+- [x] Existing Work Case helpers are reused; no parallel table or dashboard is added.
+- [x] Focused tests, typecheck, and production build pass.
+- [ ] PR is DCO-signed, pushed, opened non-draft, CI-green, and merged.


### PR DESCRIPTION
## Summary
- Wires approved case-bound Living Playbook candidates into a migration-free Work Case staged-proposal projection.
- Reuses existing Work Case action, policy, receipt, accountability, and staged-transition helpers; no live Work Case/autonomy/source mutation is introduced.
- Adds compact Needs & Playbooks row copy for staged/blocked Work Case proposals without exposing scaffold or raw ledger terminology.

## Linked Work
- BI-6F6C0675
- WC-9D3CA4E6
- Plan: docs/superpowers/plans/2026-06-28-governed-playbook-work-case-staging.md

## Verification
- [x] pnpm --filter web exec vitest run lib/tak/work-pattern-case-staging.test.ts lib/tak/work-pattern-review.test.ts lib/actions/work-pattern-review.test.ts lib/tak/work-pattern-read-model.test.ts 'app/(shell)/platform/ai/agent/[agentId]/page.test.tsx' -- 5 files, 21 tests passed
- [x] pnpm --filter web typecheck -- next typegen and tsc --noEmit passed
- [x] pnpm --filter web build -- compiled, TypeScript, and generated 131/131 static pages; existing Turbopack Edge/NFT warnings emitted but build completed successfully
- [x] UX render coverage: agent record shows "Work Case proposal staged" and "receipt required before commit" while omitting scaffold / ReceiptEnvelope / DecisionInteraction copy

## Overlap Sweep
- Open PR sweep found #2497 (Work Case portal drill-down); no overlapping files with this TAK/action/coworker-record slice.
- Recent main sweep found #2496 Work Case adoption views, which this branch builds on.

UX-Fit-Decision: compact-existing-needs-playbooks-row (principle_decide; reuses AI Workforce Needs & Playbooks row, avoids duplicate Work Case dashboard, shows staged proposal guardrails without live activation)