### PR TITLE
Simplify provider readiness controls

### DIFF
--- a/apps/web/components/platform/EndpointPerformancePanel.test.tsx
+++ b/apps/web/components/platform/EndpointPerformancePanel.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import EndpointPerformancePanel from "./EndpointPerformancePanel";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/endpoint-performance", () => ({
+  triggerEndpointTests: vi.fn(),
+}));
+
+describe("EndpointPerformancePanel", () => {
+  it("does not ask operators to manually run probes or full tests by default", () => {
+    const html = renderToStaticMarkup(
+      <EndpointPerformancePanel
+        endpointId="zai"
+        performances={[]}
+        recentEvals={[]}
+        testRuns={[]}
+        profile={null}
+      />,
+    );
+
+    expect(html).toContain("Endpoint Performance");
+    expect(html).not.toContain("Run Probes");
+    expect(html).not.toContain("Run Full Tests");
+    expect(html).not.toContain("Required for routing");
+  });
+
+  it("keeps manual probe controls available in diagnostics mode", () => {
+    const html = renderToStaticMarkup(
+      <EndpointPerformancePanel
+        endpointId="zai"
+        performances={[]}
+        recentEvals={[]}
+        testRuns={[]}
+        profile={null}
+        showDiagnostics={true}
+      />,
+    );
+
+    expect(html).toContain("Run Probes");
+    expect(html).toContain("Run Full Tests");
+  });
+});

--- a/apps/web/components/platform/EndpointPerformancePanel.tsx
+++ b/apps/web/components/platform/EndpointPerformancePanel.tsx
@@ -87,18 +87,22 @@ export default function EndpointPerformancePanel({
   recentEvals,
   testRuns,
   profile,
+  showDiagnostics = false,
 }: {
   endpointId: string;
   performances: TaskPerformance[];
   recentEvals: Evaluation[];
   testRuns: TestRun[];
   profile: Profile;
+  showDiagnostics?: boolean;
 }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [activeTab, setActiveTab] = useState<"performance" | "evaluations" | "tests">("performance");
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
 
   const [testMessage, setTestMessage] = useState<string | null>(null);
+  const diagnosticsVisible = showDiagnostics || diagnosticsOpen;
 
   function handleRunTests(probesOnly: boolean) {
     setTestMessage(null);
@@ -131,26 +135,37 @@ export default function EndpointPerformancePanel({
             </div>
           )}
         </div>
-        <div className="flex gap-2">
-          <button
-            onClick={() => handleRunTests(true)}
-            disabled={isPending}
-            className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/30 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
-          >
-            {isPending ? "Running..." : "Run Probes"}
-          </button>
-          <button
-            onClick={() => handleRunTests(false)}
-            disabled={isPending}
-            className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/30 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
-          >
-            {isPending ? "Running..." : "Run Full Tests"}
-          </button>
-        </div>
-        <div className="text-[10px] text-[var(--dpf-muted)] mt-1">
-          {testMessage && <span style={{ color: "var(--dpf-accent)" }}>{testMessage} </span>}
-          Re-run model evaluations. Required for routing — run once after pulling new models so the router can pick them. Each run also produces evidence visible in the Recent Evaluations tab below.
-        </div>
+        <button
+          type="button"
+          onClick={() => setDiagnosticsOpen((value) => !value)}
+          className="px-3 py-1.5 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {diagnosticsVisible ? "Hide diagnostics" : "Advanced diagnostics"}
+        </button>
+        {diagnosticsVisible && (
+          <div>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => handleRunTests(true)}
+                disabled={isPending}
+                className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/30 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
+              >
+                {isPending ? "Running..." : "Run Probes"}
+              </button>
+              <button
+                onClick={() => handleRunTests(false)}
+                disabled={isPending}
+                className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/30 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
+              >
+                {isPending ? "Running..." : "Run Full Tests"}
+              </button>
+            </div>
+            <div className="text-[10px] text-[var(--dpf-muted)] mt-1 text-right max-w-md">
+              {testMessage && <span style={{ color: "var(--dpf-accent)" }}>{testMessage} </span>}
+              Manual diagnostic runs for routing evidence and regression checks.
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Tabs */}
@@ -251,7 +266,7 @@ export default function EndpointPerformancePanel({
         <div className="space-y-2">
           {testRuns.length === 0 ? (
             <div className="text-center py-8 text-[var(--dpf-muted)] text-xs">
-              No test runs yet. Click &quot;Run Probes&quot; or &quot;Run Full Tests&quot; above.
+              No test runs yet. Automated and diagnostic runs will appear here.
             </div>
           ) : (
             testRuns.map((tr) => {

--- a/apps/web/components/platform/ModelCard.test.tsx
+++ b/apps/web/components/platform/ModelCard.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { DiscoveredModelRow, ModelProfileRow } from "@/lib/ai-provider-types";
+import { ModelCard } from "./ModelCard";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/endpoint-performance", () => ({
+  triggerDimensionEval: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/agent-model-config", () => ({
+  overrideModelTier: vi.fn(),
+}));
+
+const model: DiscoveredModelRow = {
+  id: "disc-1",
+  providerId: "zai",
+  modelId: "glm-5.1",
+  rawMetadata: {},
+  discoveredAt: new Date("2026-06-28T10:00:00Z"),
+  lastSeenAt: new Date("2026-06-28T10:00:00Z"),
+};
+
+const profile: ModelProfileRow = {
+  id: "profile-1",
+  providerId: "zai",
+  modelId: "glm-5.1",
+  friendlyName: "GLM-5.1",
+  summary: "",
+  capabilityCategory: "adequate",
+  costTier: "unknown",
+  bestFor: [],
+  avoidFor: [],
+  contextWindow: null,
+  speedRating: null,
+  generatedBy: "test",
+  generatedAt: new Date("2026-06-28T10:00:00Z"),
+  modelClass: "chat",
+  capabilities: { toolUse: true },
+  pricing: {},
+  metadataConfidence: "medium",
+  qualityTier: "adequate",
+  qualityTierSource: "family",
+};
+
+const routingProfile = {
+  reasoning: 55,
+  codegen: 55,
+  toolFidelity: 55,
+  instructionFollowingScore: 55,
+  structuredOutputScore: 52,
+  conversational: 55,
+  contextRetention: 52,
+  profileSource: "seed",
+  profileConfidence: "medium",
+  evalCount: 1,
+  lastEvalAt: "2026-06-28T10:00:00Z",
+  modelStatus: "active",
+};
+
+describe("ModelCard", () => {
+  it("hides routing scores, eval, and tier override in the default operator view", () => {
+    const html = renderToStaticMarkup(
+      <ModelCard
+        model={model}
+        profile={profile}
+        isStale={false}
+        profilingFailed={false}
+        canWrite={true}
+        hasActiveProvider={true}
+        onProfile={vi.fn()}
+        routingProfile={routingProfile}
+        endpointId="zai"
+      />,
+    );
+
+    expect(html).toContain("GLM-5.1");
+    expect(html).toContain("Adequate");
+    expect(html).not.toContain("Routing Scores");
+    expect(html).not.toContain("Run Eval");
+    expect(html).not.toContain("Override Tier");
+  });
+
+  it("shows calibration controls only in diagnostics mode", () => {
+    const html = renderToStaticMarkup(
+      <ModelCard
+        model={model}
+        profile={profile}
+        isStale={false}
+        profilingFailed={false}
+        canWrite={true}
+        hasActiveProvider={true}
+        onProfile={vi.fn()}
+        routingProfile={routingProfile}
+        endpointId="zai"
+        showDiagnostics={true}
+      />,
+    );
+
+    expect(html).toContain("Routing Scores");
+    expect(html).toContain("Override Tier");
+  });
+});

--- a/apps/web/components/platform/ModelCard.tsx
+++ b/apps/web/components/platform/ModelCard.tsx
@@ -35,6 +35,7 @@ type Props = {
   routingProfile?: RoutingProfileData | null;
   endpointId?: string;
   onRunEval?: (modelId: string) => void;
+  showDiagnostics?: boolean;
 };
 
 // ── Metadata confidence colours ──────────────────────────────────────────────
@@ -229,9 +230,9 @@ function ActionButton({
   );
 }
 
-export function ModelCard({ model, profile, isStale, profilingFailed, canWrite, hasActiveProvider, onProfile, routingProfile, endpointId, onRunEval }: Props) {
+export function ModelCard({ model, profile, isStale, profilingFailed, canWrite, hasActiveProvider, onProfile, routingProfile, endpointId, onRunEval, showDiagnostics = false }: Props) {
   const router = useRouter();
-  const [showScores, setShowScores] = useState(false);
+  const [showScores, setShowScores] = useState(showDiagnostics);
   const [isPending, startTransition] = useTransition();
   const [evalMessage, setEvalMessage] = useState<string | null>(null);
   const [tierOverride, setTierOverride] = useState(profile?.qualityTier ?? "");
@@ -361,7 +362,7 @@ export function ModelCard({ model, profile, isStale, profilingFailed, canWrite, 
         )}
 
         {/* EP-INF-006: Collapsible routing scores section */}
-        {hasRouting && (
+        {showDiagnostics && hasRouting && (
           <div style={{ marginTop: 4 }}>
             <button
               onClick={() => setShowScores(!showScores)}

--- a/apps/web/components/platform/ModelSection.test.tsx
+++ b/apps/web/components/platform/ModelSection.test.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { DiscoveredModelRow, ModelProfileRow } from "@/lib/ai-provider-types";
+import { ModelSection } from "./ModelSection";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/ai-providers", () => ({
+  profileModels: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/endpoint-performance", () => ({
+  triggerDimensionEval: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/agent-model-config", () => ({
+  overrideModelTier: vi.fn(),
+}));
+
+const discovered: DiscoveredModelRow[] = [
+  {
+    id: "disc-1",
+    providerId: "zai",
+    modelId: "glm-5.1",
+    rawMetadata: {},
+    discoveredAt: new Date("2026-06-28T10:00:00Z"),
+    lastSeenAt: new Date("2026-06-28T10:00:00Z"),
+  },
+  {
+    id: "disc-2",
+    providerId: "zai",
+    modelId: "glm-5.2",
+    rawMetadata: {},
+    discoveredAt: new Date("2026-06-28T10:00:00Z"),
+    lastSeenAt: new Date("2026-06-28T10:00:00Z"),
+  },
+];
+
+const profiles: ModelProfileRow[] = discovered.map((model) => ({
+  id: `profile-${model.id}`,
+  providerId: model.providerId,
+  modelId: model.modelId,
+  friendlyName: model.modelId.toUpperCase(),
+  summary: "",
+  capabilityCategory: "adequate",
+  costTier: "unknown",
+  bestFor: [],
+  avoidFor: [],
+  contextWindow: null,
+  speedRating: null,
+  generatedBy: "test",
+  generatedAt: new Date("2026-06-28T10:00:00Z"),
+  modelClass: "chat",
+  capabilities: { toolUse: true },
+  pricing: {},
+  metadataConfidence: "medium",
+  qualityTier: "adequate",
+  qualityTierSource: "family",
+}));
+
+const routingProfiles = discovered.map((model) => ({
+  modelId: model.modelId,
+  friendlyName: model.modelId.toUpperCase(),
+  reasoning: 55,
+  codegen: 55,
+  toolFidelity: 55,
+  instructionFollowingScore: 55,
+  structuredOutputScore: 52,
+  conversational: 55,
+  contextRetention: 52,
+  profileSource: "seed",
+  profileConfidence: "medium",
+  evalCount: 1,
+  lastEvalAt: "2026-06-28T10:00:00Z",
+  maxContextTokens: 128000,
+  supportsToolUse: true,
+  modelStatus: "active",
+  retiredAt: null,
+}));
+
+describe("ModelSection", () => {
+  it("summarizes model readiness without exposing search or per-model controls by default", () => {
+    const html = renderToStaticMarkup(
+      <ModelSection
+        providerId="zai"
+        models={discovered}
+        profiles={profiles}
+        canWrite={true}
+        hasActiveProvider={true}
+        latestDiscovery={new Date("2026-06-28T10:00:00Z")}
+        endpointId="zai"
+      />,
+    );
+
+    expect(html).toContain("2 models ready");
+    expect(html).not.toContain("Search models");
+    expect(html).not.toContain("Run Eval");
+    expect(html).not.toContain("Override Tier");
+    expect(html).not.toContain("Routing Scores");
+  });
+
+  it("keeps model search and calibration controls available in diagnostics mode", () => {
+    const html = renderToStaticMarkup(
+      <ModelSection
+        providerId="zai"
+        models={discovered}
+        profiles={profiles}
+        canWrite={true}
+        hasActiveProvider={true}
+        latestDiscovery={new Date("2026-06-28T10:00:00Z")}
+        endpointId="zai"
+        showDiagnostics={true}
+        routingProfiles={routingProfiles}
+      />,
+    );
+
+    expect(html).toContain("Search models");
+    expect(html).toContain("Override Tier");
+  });
+});

--- a/apps/web/components/platform/ModelSection.tsx
+++ b/apps/web/components/platform/ModelSection.tsx
@@ -39,6 +39,7 @@ type Props = {
   // EP-INF-006: Routing profiles merged into model cards
   routingProfiles?: RoutingProfile[];
   endpointId?: string;
+  showDiagnostics?: boolean;
 };
 
 export function ModelSection({
@@ -50,6 +51,7 @@ export function ModelSection({
   latestDiscovery,
   routingProfiles,
   endpointId,
+  showDiagnostics = false,
 }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -148,28 +150,29 @@ export function ModelSection({
           flexWrap: "wrap",
         }}
       >
-        {/* Search box */}
-        <input
-          type="search"
-          value={search}
-          onChange={handleSearchChange}
-          placeholder="Search models…"
-          style={{
-            background: "var(--dpf-surface-1)",
-            border: "1px solid var(--dpf-border)",
-            color: "var(--dpf-text)",
-            fontSize: 11,
-            padding: "5px 10px",
-            borderRadius: 4,
-            width: 200,
-            outline: "none",
-          }}
-        />
+        {showDiagnostics && (
+          <input
+            type="search"
+            value={search}
+            onChange={handleSearchChange}
+            placeholder="Search models..."
+            style={{
+              background: "var(--dpf-surface-1)",
+              border: "1px solid var(--dpf-border)",
+              color: "var(--dpf-text)",
+              fontSize: 11,
+              padding: "5px 10px",
+              borderRadius: 4,
+              width: 200,
+              outline: "none",
+            }}
+          />
+        )}
 
-        {/* Count label */}
         <span style={{ color: "var(--dpf-muted)", fontSize: 10, flexGrow: 1 }}>
-          {filtered.length} model{filtered.length !== 1 ? "s" : ""}
-          {searchLower ? " matching" : ""}
+          {profiles.length} model{profiles.length !== 1 ? "s" : ""} ready
+          {showDiagnostics && searchLower ? ` - ${filtered.length} matching` : ""}
+          {showDiagnostics && !searchLower && filtered.length !== profiles.length ? ` - ${filtered.length} shown` : ""}
           {unprofiledCount > 0 ? ` — ${unprofiledCount} unprofiled` : ""}
         </span>
       </div>
@@ -215,6 +218,7 @@ export function ModelSection({
               onProfile={handleProfileSingle}
               routingProfile={routingMap.get(model.modelId) ?? null}
               endpointId={endpointId}
+              showDiagnostics={showDiagnostics}
             />
           ))}
         </div>
@@ -225,7 +229,7 @@ export function ModelSection({
       )}
 
       {/* Pagination */}
-      {totalPages > 1 && (
+      {showDiagnostics && totalPages > 1 && (
         <div
           style={{
             display: "flex",

--- a/apps/web/components/platform/ProviderDetailForm.test.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { ProviderWithCredential } from "@/lib/ai-provider-types";
+import { ProviderDetailForm } from "./ProviderDetailForm";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/actions/ai-providers", () => ({
+  configureProvider: vi.fn(),
+  testProviderAuth: vi.fn(),
+  discoverModels: vi.fn(),
+  profileModels: vi.fn(),
+  toggleProviderStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/provider-oauth", () => ({
+  startProviderOAuth: vi.fn(),
+  disconnectProviderOAuth: vi.fn(),
+}));
+
+const providerFixture: ProviderWithCredential = {
+  provider: {
+    id: "provider-1",
+    providerId: "zai",
+    name: "Z.ai",
+    families: ["glm"],
+    enabledFamilies: ["glm"],
+    status: "active",
+    costModel: "token",
+    category: "direct",
+    baseUrl: "https://api.z.ai/v1",
+    authMethod: "api_key",
+    supportedAuthMethods: ["api_key"],
+    authHeader: "Authorization",
+    endpoint: null,
+    inputPricePerMToken: null,
+    outputPricePerMToken: null,
+    computeWatts: null,
+    electricityRateKwh: null,
+    docsUrl: null,
+    consoleUrl: null,
+    billingLabel: null,
+    costPerformanceNotes: null,
+    endpointType: "model",
+    serviceKind: null,
+    sensitivityClearance: ["internal"],
+    capabilityTier: "adequate",
+    costBand: "standard",
+    taskTags: [],
+    mcpTransport: null,
+    maxConcurrency: null,
+    authorizeUrl: null,
+    tokenUrl: null,
+    oauthClientId: null,
+    oauthRedirectUri: null,
+  },
+  credential: {
+    providerId: "zai",
+    secretHint: "sk-...",
+    clientId: null,
+    clientSecretHint: null,
+    tokenEndpoint: null,
+    scope: null,
+    status: "ok",
+    tokenExpiresAt: null,
+    hasRefreshToken: false,
+  },
+};
+
+describe("ProviderDetailForm", () => {
+  it("presents one managed readiness action instead of separate setup chores", () => {
+    const html = renderToStaticMarkup(
+      <ProviderDetailForm
+        pw={providerFixture}
+        canWrite={true}
+        models={[]}
+        profiles={[]}
+        hasActiveProvider={true}
+      />,
+    );
+
+    expect(html).toContain("Provider readiness");
+    expect(html).toContain("Save &amp; ready provider");
+    expect(html).not.toContain(">Save<");
+    expect(html).not.toContain("Test &amp; Discover");
+    expect(html).not.toContain("Discover &amp; Profile Models");
+    expect(html).not.toContain("Advanced: model families");
+  });
+});

--- a/apps/web/components/platform/ProviderDetailForm.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.tsx
@@ -59,6 +59,7 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
   const [profilingResult, setProfilingResult]       = useState<{ profiled: number; failed: number; error?: string } | null>(null);
   const [disconnectConfirm, setDisconnectConfirm]   = useState(false);
   const [pipelineStatus, setPipelineStatus]         = useState<string | null>(null);
+  const [showDiagnostics, setShowDiagnostics]       = useState(false);
 
   const [clientId, setClientId]                     = useState(credential?.clientId ?? "");
   const [clientSecret, setClientSecret]             = useState("");  // write-only
@@ -93,57 +94,51 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
     );
   }
 
-  function handleSave() {
-    startTransition(async () => {
-      const shouldPersistAuthMethod = hasDualAuth || selectedAuthMethod !== provider.authMethod;
-      const saveInput = {
-        providerId: provider.providerId,
-        enabledFamilies,
-        ...(shouldPersistAuthMethod && { authMethod: selectedAuthMethod }),
-        ...(selectedAuthMethod === "api_key" && secretRef ? { secretRef } : {}),
-        ...(selectedAuthMethod === "oauth2_client_credentials" && clientId       ? { clientId }       : {}),
-        ...(selectedAuthMethod === "oauth2_client_credentials" && clientSecret   ? { clientSecret }   : {}),
-        ...(selectedAuthMethod === "oauth2_client_credentials" && tokenEndpoint  ? { tokenEndpoint }  : {}),
-        ...(selectedAuthMethod === "oauth2_client_credentials" && scope          ? { scope }          : {}),
-        ...(needsEndpoint && endpoint ? { endpoint } : {}),
-        ...(isCompute ? { computeWatts: Number(computeWatts), electricityRateKwh: Number(electricityRate) } : {}),
-      };
-      const result = await configureProvider(saveInput);
-      setSaveMessage(result.error ? `Error: ${result.error}` : "Saved");
-      router.refresh();
-    });
+  function buildSaveInput() {
+    const shouldPersistAuthMethod = hasDualAuth || selectedAuthMethod !== provider.authMethod;
+    return {
+      providerId: provider.providerId,
+      enabledFamilies,
+      ...(shouldPersistAuthMethod && { authMethod: selectedAuthMethod }),
+      ...(selectedAuthMethod === "api_key" && secretRef ? { secretRef } : {}),
+      ...(selectedAuthMethod === "oauth2_client_credentials" && clientId       ? { clientId }       : {}),
+      ...(selectedAuthMethod === "oauth2_client_credentials" && clientSecret   ? { clientSecret }   : {}),
+      ...(selectedAuthMethod === "oauth2_client_credentials" && tokenEndpoint  ? { tokenEndpoint }  : {}),
+      ...(selectedAuthMethod === "oauth2_client_credentials" && scope          ? { scope }          : {}),
+      ...(needsEndpoint && endpoint ? { endpoint } : {}),
+      ...(isCompute ? { computeWatts: Number(computeWatts), electricityRateKwh: Number(electricityRate) } : {}),
+    };
   }
 
-  function handleTest() {
+  function handleReadyProvider() {
     startTransition(async () => {
-      // Step 1: Test connection
-      setPipelineStatus("Testing connection...");
+      setPipelineStatus("Saving provider settings...");
       setTestResult(null);
       setDiscoveryResult(null);
       setProfilingResult(null);
-      const result = await testProviderAuth(provider.providerId);
-      setTestResult(result);
 
-      if (!result.ok) {
+      const result = await configureProvider(buildSaveInput());
+      if (result.error) {
+        setSaveMessage(`Error: ${result.error}`);
         setPipelineStatus(null);
         return;
       }
+      setSaveMessage("Settings saved");
 
-      // Step 2: Discover models
-      setPipelineStatus("Discovering available models...");
-      const discovery = await discoverModels(provider.providerId);
-      setDiscoveryResult(discovery);
-
-      if (discovery.discovered === 0) {
+      setPipelineStatus("Checking connection...");
+      const test = await testProviderAuth(provider.providerId);
+      setTestResult(test);
+      if (!test.ok) {
         setPipelineStatus(null);
         router.refresh();
         return;
       }
 
-      // Step 3: Sync routing profiles for all discovered models.
-      // Uses metadata extraction + family baseline registry — no LLM calls, instant.
+      setPipelineStatus("Refreshing model catalog...");
+      const discovery = await discoverModels(provider.providerId);
+      setDiscoveryResult(discovery);
       if (discovery.discovered > 0) {
-        setPipelineStatus(`Syncing routing profiles for ${discovery.discovered} model${discovery.discovered !== 1 ? "s" : ""}...`);
+        setPipelineStatus("Preparing routing metadata...");
         const profResult = await profileModels(provider.providerId);
         setProfilingResult(profResult);
       }
@@ -170,28 +165,16 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
     });
   }
 
-  // Guided setup: determine which step the user is on.
-  // A provider is only truly "credentialed" if auth is "none" OR a credential exists.
   const hasProfiles = profiles.length > 0 || (profilingResult != null && profilingResult.profiled > 0);
   const hasCredential = selectedAuthMethod === "none"
     || credential?.secretHint
     || (selectedAuthMethod === "oauth2_authorization_code" && credential?.status === "ok")
     || secretRef;
-  const step = provider.status === "active" && hasProfiles && hasCredential ? 5
-    : provider.status === "active" && hasCredential ? 4
-    : testResult?.ok ? 3
-    : hasCredential ? 2
-    : 1;
-
-  const STEPS = [
-    { n: 1, label: "Credentials" },
-    { n: 2, label: "Connect" },
-    { n: 3, label: "Discover" },
-    { n: 4, label: "Profile" },
-    { n: 5, label: "Ready" },
-  ];
-
-  const statusColour = provider.status === "active" ? "var(--dpf-success)" : provider.status === "inactive" ? "var(--dpf-muted)" : "var(--dpf-warning)";
+  const readinessState = provider.status === "active" && hasProfiles && hasCredential
+    ? { label: "Ready", tone: "var(--dpf-success)", detail: "Connection, catalog, and routing metadata are prepared." }
+    : hasCredential
+      ? { label: "Needs readiness check", tone: "var(--dpf-warning)", detail: "Save once and DPF will test, discover, and prepare models automatically." }
+      : { label: "Needs credentials", tone: "var(--dpf-muted)", detail: "Add credentials, then DPF will handle the readiness checks." };
 
   const inputStyle: React.CSSProperties = {
     width: "100%",
@@ -213,33 +196,27 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
   return (
     <div>
       <div style={{ maxWidth: 560 }}>
-      {/* Setup progress */}
-      <div style={{ display: "flex", alignItems: "center", gap: 0, marginBottom: 24 }}>
-        {STEPS.map((s, i) => {
-          const isLastStep = s.n === STEPS.length;
-          const done = step > s.n || (isLastStep && step === s.n);
-          const current = step === s.n && !isLastStep;
-          const colour = done ? "var(--dpf-success)" : current ? "var(--dpf-accent)" : "var(--dpf-border)";
-          return (
-            <div key={s.n} style={{ display: "flex", alignItems: "center" }}>
-              <div style={{ display: "flex", flexDirection: "column", alignItems: "center", minWidth: 60 }}>
-                <div style={{
-                  width: 24, height: 24, borderRadius: "50%",
-                  background: done ? "color-mix(in srgb, var(--dpf-success) 19%, transparent)" : current ? "color-mix(in srgb, var(--dpf-accent) 20%, transparent)" : "var(--dpf-surface-1)",
-                  border: `2px solid ${colour}`,
-                  display: "grid", placeItems: "center",
-                  fontSize: 11, fontWeight: 600, color: colour,
-                }}>
-                  {done ? "\u2713" : s.n}
-                </div>
-                <span style={{ fontSize: 10, color: current ? "var(--dpf-text)" : "var(--dpf-muted)", marginTop: 4 }}>{s.label}</span>
-              </div>
-              {i < STEPS.length - 1 && (
-                <div style={{ width: 32, height: 2, background: done ? "color-mix(in srgb, var(--dpf-success) 38%, transparent)" : "var(--dpf-border)", marginBottom: 16 }} />
-              )}
-            </div>
-          );
-        })}
+      <div style={{ marginBottom: 20 }}>
+        <div style={{ color: "var(--dpf-muted)", fontSize: 10, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
+          Provider readiness
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <span style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            color: readinessState.tone,
+            background: `color-mix(in srgb, ${readinessState.tone} 14%, transparent)`,
+            border: `1px solid color-mix(in srgb, ${readinessState.tone} 28%, transparent)`,
+            borderRadius: 4,
+            padding: "4px 8px",
+            fontSize: 12,
+            fontWeight: 600,
+          }}>
+            {readinessState.label}
+          </span>
+          <span style={{ color: "var(--dpf-muted)", fontSize: 12 }}>{readinessState.detail}</span>
+        </div>
       </div>
 
       {/* Status + toggle */}
@@ -249,10 +226,10 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
       </div>
 
       {/* Model families — hidden during initial setup, shown as advanced after profiling */}
-      {hasProfiles && (
+      {showDiagnostics && hasProfiles && (
         <details style={{ marginBottom: 16 }}>
           <summary style={{ color: "var(--dpf-muted)", fontSize: 12, cursor: "pointer", marginBottom: 6 }}>
-            Advanced: model families ({enabledFamilies.length}/{provider.families.length} enabled)
+            Model families ({enabledFamilies.length}/{provider.families.length} enabled)
           </summary>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 6 }}>
             {provider.families.map((f) => (
@@ -585,19 +562,11 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
       {canWrite && (
         <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
           <button
-            onClick={handleSave}
+            onClick={handleReadyProvider}
             disabled={isPending}
             style={{ padding: "8px 16px", background: "var(--dpf-surface-2)", border: "1px solid var(--dpf-accent)", color: "var(--dpf-accent)", borderRadius: 4, fontSize: 13, cursor: "pointer" }}
           >
-            Save
-          </button>
-          <button
-            onClick={handleTest}
-            disabled={isPending}
-            title="Verifies the connection, then discovers and profiles the provider's models."
-            style={{ padding: "8px 16px", background: "transparent", border: "1px solid var(--dpf-border)", color: "var(--dpf-text)", borderRadius: 4, fontSize: 13, cursor: "pointer" }}
-          >
-            Test &amp; Discover
+            {isPending ? "Preparing..." : "Save & ready provider"}
           </button>
           {saveMessage && <span style={{ fontSize: 12, color: saveMessage.startsWith("Error") ? "var(--dpf-error)" : "var(--dpf-success)" }}>{saveMessage}</span>}
           {testResult && (
@@ -613,14 +582,24 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
         </div>
       )}
 
-      {canWrite && provider.status === "active" && (
+      <div style={{ marginTop: 12 }}>
+        <button
+          type="button"
+          onClick={() => setShowDiagnostics((value) => !value)}
+          style={{ background: "transparent", border: "1px solid var(--dpf-border)", color: "var(--dpf-muted)", fontSize: 12, padding: "6px 10px", borderRadius: 4, cursor: "pointer" }}
+        >
+          {showDiagnostics ? "Hide diagnostics" : "Advanced diagnostics"}
+        </button>
+      </div>
+
+      {showDiagnostics && canWrite && provider.status === "active" && (
         <div style={{ marginTop: 12 }}>
           <button
             onClick={handleRefreshModels}
             disabled={isPending}
             style={{ background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)", color: "var(--dpf-text)", fontSize: 13, padding: "8px 14px", borderRadius: 4, cursor: isPending ? "not-allowed" : "pointer", opacity: isPending ? 0.6 : 1 }}
           >
-            {isPending ? "Syncing..." : "Discover & Profile Models"}
+            {isPending ? "Syncing..." : "Refresh model diagnostics"}
           </button>
           {isPending && (
             <span style={{ marginLeft: 8, fontSize: 12, color: "var(--dpf-muted)" }} className="animate-pulse">
@@ -671,6 +650,7 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
             latestDiscovery={models.length > 0 ? new Date(Math.max(...models.map(m => new Date(m.lastSeenAt).getTime()))) : null}
             routingProfiles={routingProfiles}
             endpointId={provider.providerId}
+            showDiagnostics={showDiagnostics}
           />
         </div>
       )}

--- a/docs/superpowers/plans/2026-06-28-provider-readiness-automation.md
+++ b/docs/superpowers/plans/2026-06-28-provider-readiness-automation.md
@@ -1,0 +1,93 @@
+# Provider Readiness Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce cognitive load on AI provider detail pages by replacing manual model/test/eval decisions with a single managed readiness flow and advanced-only diagnostics.
+
+**Architecture:** Keep the existing provider actions as the automation substrate: `configureProvider` already activates providers and runs discovery/profile work, while `testProviderAuth`, `discoverModels`, `profileModels`, and endpoint test jobs remain callable for diagnostic use. Change the UI contract so the normal operator sees connection readiness and automation status; raw model family toggles, search, per-model eval, tier override, and probe/full-test controls move behind advanced diagnostics.
+
+**Tech Stack:** Next.js 16, React Server/Client Components, Vitest, Testing Library server rendering via `renderToStaticMarkup`.
+
+---
+
+## Chunk 1: Provider Detail Simplification
+
+### Task 1: Provider action contract and primary UI
+
+**Files:**
+- Modify: `apps/web/components/platform/ProviderDetailForm.tsx`
+- Test: `apps/web/components/platform/ProviderDetailForm.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests proving the default provider setup UI exposes one primary managed action and does not expose separate `Save`, `Test & Discover`, `Discover & Profile Models`, or model-family choices outside advanced diagnostics.
+
+- [ ] **Step 2: Run the provider form test and verify it fails**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/platform/ProviderDetailForm.test.tsx`
+
+- [ ] **Step 3: Implement minimal UI changes**
+
+Replace the separate `Save` and `Test & Discover` buttons with one `Save & ready provider` action that persists settings, tests the connection, discovers models, and profiles them. Replace the visible setup stepper with a compact readiness summary. Move model-family controls into an advanced diagnostics disclosure.
+
+- [ ] **Step 4: Run the provider form test and verify it passes**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/platform/ProviderDetailForm.test.tsx`
+
+### Task 2: Model list as evidence
+
+**Files:**
+- Modify: `apps/web/components/platform/ModelSection.tsx`
+- Modify: `apps/web/components/platform/ModelCard.tsx`
+- Test: `apps/web/components/platform/ModelSection.test.tsx`
+- Test: `apps/web/components/platform/ModelCard.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests proving the default model section shows readiness counts without search, per-model eval, or tier override controls. Add tests proving routing scores and manual model controls appear only when `showDiagnostics` is true.
+
+- [ ] **Step 2: Run model tests and verify they fail**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/platform/ModelSection.test.tsx apps/web/components/platform/ModelCard.test.tsx`
+
+- [ ] **Step 3: Implement minimal UI changes**
+
+Add a `showDiagnostics` prop to `ModelSection` and `ModelCard`. Default normal mode renders compact model cards with tier, class, pricing, and capabilities. Diagnostics mode keeps search, pagination, routing scores, per-model eval, and tier override.
+
+- [ ] **Step 4: Run model tests and verify they pass**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/platform/ModelSection.test.tsx apps/web/components/platform/ModelCard.test.tsx`
+
+### Task 3: Endpoint performance diagnostics
+
+**Files:**
+- Modify: `apps/web/components/platform/EndpointPerformancePanel.tsx`
+- Test: `apps/web/components/platform/EndpointPerformancePanel.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests proving `Run Probes` and `Run Full Tests` are hidden by default and visible only inside advanced diagnostics.
+
+- [ ] **Step 2: Run endpoint panel tests and verify they fail**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/platform/EndpointPerformancePanel.test.tsx`
+
+- [ ] **Step 3: Implement minimal UI changes**
+
+Move probe/full-test buttons and explanatory test-running copy into a diagnostics disclosure. Keep read-only performance/evaluation/test-run history visible.
+
+- [ ] **Step 4: Run endpoint panel tests and verify they pass**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/platform/EndpointPerformancePanel.test.tsx`
+
+## Chunk 2: Verification
+
+- [ ] Run focused component/action tests:
+
+`pnpm --filter web exec vitest run apps/web/components/platform/ProviderDetailForm.test.tsx apps/web/components/platform/ModelSection.test.tsx apps/web/components/platform/ModelCard.test.tsx apps/web/components/platform/EndpointPerformancePanel.test.tsx apps/web/lib/actions/ai-providers.test.ts`
+
+- [ ] Run production build:
+
+`pnpm --filter web build`
+
+- [ ] If runtime UX verification is available through a governed preview or local-CI lease, verify `/platform/ai/providers/[providerId]` default mode no longer asks the operator to choose save/test/discover/profile/eval/probe actions.


### PR DESCRIPTION
## Summary
- Replace separate provider setup chores with a single managed readiness action that saves, tests, refreshes the model catalog, and prepares routing metadata.
- Move model search, routing scores, per-model eval, tier override, and probe/full-test controls behind advanced diagnostics.
- Add focused component tests and a DPF implementation plan artifact for the provider readiness UX change.

## Verification
- `pnpm --filter web exec vitest run components/platform/ProviderDetailForm.test.tsx components/platform/ModelSection.test.tsx components/platform/ModelCard.test.tsx components/platform/EndpointPerformancePanel.test.tsx lib/actions/ai-providers.test.ts` - 18 passed.
- `pnpm --filter web typecheck` - passed.
- `pnpm --filter web build` - passed; existing Turbopack/NFT warnings were emitted outside this change.
- Preview server started on governed `local-integration-ci` lease at `http://127.0.0.1:3001`; Playwright navigation to `/platform/ai/providers` redirected to `/welcome` because the worktree preview lacked an authenticated DB-backed session, so full route UX verification was limited to component render tests plus build output.

Process-Spine-Decision: Durable plan artifact included at `docs/superpowers/plans/2026-06-28-provider-readiness-automation.md`.