### PR TITLE
Add Decision Shadow Ledger trust substrate

### DIFF
--- a/apps/web/lib/autonomy/trust-state.test.ts
+++ b/apps/web/lib/autonomy/trust-state.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { computeTrustStateFromLedger } from "./trust-state";
+
+describe("computeTrustStateFromLedger", () => {
+  it("aggregates reconciled ledger entries for one trust triple", () => {
+    const state = computeTrustStateFromLedger({
+      agentId: "build-specialist",
+      activityType: "work-pattern.review",
+      riskClass: "internal-reversible",
+      currentLevel: "propose",
+      rows: [
+        ...Array.from({ length: 5 }, (_, index) => ({
+          agreement: true,
+          observedAt: new Date(`2026-06-28T10:0${index}:00.000Z`),
+        })),
+        ...Array.from({ length: 5 }, (_, index) => ({
+          agreement: false,
+          observedAt: new Date(`2026-06-28T11:0${index}:00.000Z`),
+        })),
+        { agreement: null, observedAt: new Date("2026-06-28T12:00:00.000Z") },
+      ],
+    });
+
+    expect(state.window).toEqual({ samples: 10, agreements: 5 });
+    expect(state.agreementRate).toBe(0.5);
+    expect(state.latestObservedAt?.toISOString()).toBe("2026-06-28T12:00:00.000Z");
+    expect(state.recommendation).toMatchObject({
+      action: "demote",
+      from: "propose",
+      to: "shadow",
+    });
+  });
+
+  it("threads regulatory ceilings into the trust recommendation", () => {
+    const state = computeTrustStateFromLedger({
+      agentId: "finance-agent",
+      activityType: "invoice.send",
+      riskClass: "read-only",
+      currentLevel: "propose",
+      regulatoryCeiling: "propose",
+      rows: Array.from({ length: 20 }, (_, index) => ({
+        agreement: true,
+        observedAt: new Date(`2026-06-28T12:${String(index).padStart(2, "0")}:00.000Z`),
+      })),
+    });
+
+    expect(state.window).toEqual({ samples: 20, agreements: 20 });
+    expect(state.regulatoryCeiling).toBe("propose");
+    expect(state.recommendation).toMatchObject({
+      action: "hold",
+      level: "propose",
+    });
+    expect(state.recommendation.reason).toMatch(/regulatory ceiling/);
+  });
+
+  it("holds when the ledger has no resolved agreement evidence yet", () => {
+    const state = computeTrustStateFromLedger({
+      agentId: "review-agent",
+      activityType: "work-pattern.draft",
+      riskClass: "internal-reversible",
+      rows: [
+        { agreement: null, observedAt: "2026-06-28T09:00:00.000Z" },
+        { agreement: null, observedAt: "2026-06-28T10:00:00.000Z" },
+      ],
+    });
+
+    expect(state.currentLevel).toBe("shadow");
+    expect(state.window).toEqual({ samples: 0, agreements: 0 });
+    expect(state.agreementRate).toBeNull();
+    expect(state.latestObservedAt?.toISOString()).toBe("2026-06-28T10:00:00.000Z");
+    expect(state.recommendation).toMatchObject({
+      action: "hold",
+      level: "shadow",
+    });
+    expect(state.recommendation.reason).toMatch(/samples/);
+  });
+});

--- a/apps/web/lib/autonomy/trust-state.ts
+++ b/apps/web/lib/autonomy/trust-state.ts
@@ -1,0 +1,79 @@
+import {
+  agreementRate,
+  type AgreementWindow,
+  type AutonomyLevel,
+  recommendTrustChange,
+  type RiskClass,
+  type TrustRecommendation,
+} from "./trust-graduation";
+
+export type DecisionShadowLedgerAgreement = {
+  agreement: boolean | null;
+  observedAt?: Date | string | null;
+};
+
+export type ComputeTrustStateInput = {
+  agentId: string;
+  activityType: string;
+  riskClass: RiskClass;
+  currentLevel?: AutonomyLevel | null;
+  regulatoryCeiling?: AutonomyLevel | null;
+  rows: readonly DecisionShadowLedgerAgreement[];
+};
+
+export type ComputedTrustState = {
+  agentId: string;
+  activityType: string;
+  riskClass: RiskClass;
+  currentLevel: AutonomyLevel;
+  regulatoryCeiling: AutonomyLevel | null;
+  window: AgreementWindow;
+  agreementRate: number | null;
+  latestObservedAt: Date | null;
+  recommendation: TrustRecommendation;
+};
+
+export function trustStateKey(input: Pick<ComputeTrustStateInput, "agentId" | "activityType" | "riskClass">): string {
+  return `${input.agentId}:${input.activityType}:${input.riskClass}`;
+}
+
+export function computeTrustStateFromLedger(input: ComputeTrustStateInput): ComputedTrustState {
+  const window = input.rows.reduce<AgreementWindow>(
+    (acc, row) => {
+      if (row.agreement === null) return acc;
+      return {
+        samples: acc.samples + 1,
+        agreements: acc.agreements + (row.agreement ? 1 : 0),
+      };
+    },
+    { samples: 0, agreements: 0 },
+  );
+  const currentLevel = input.currentLevel ?? "shadow";
+  return {
+    agentId: input.agentId,
+    activityType: input.activityType,
+    riskClass: input.riskClass,
+    currentLevel,
+    regulatoryCeiling: input.regulatoryCeiling ?? null,
+    window,
+    agreementRate: agreementRate(window),
+    latestObservedAt: latestObservedAt(input.rows),
+    recommendation: recommendTrustChange({
+      level: currentLevel,
+      risk: input.riskClass,
+      window,
+      regulatoryCeiling: input.regulatoryCeiling ?? undefined,
+    }),
+  };
+}
+
+function latestObservedAt(rows: readonly DecisionShadowLedgerAgreement[]): Date | null {
+  let latest: Date | null = null;
+  for (const row of rows) {
+    if (!row.observedAt) continue;
+    const value = row.observedAt instanceof Date ? row.observedAt : new Date(row.observedAt);
+    if (Number.isNaN(value.getTime())) continue;
+    if (!latest || value > latest) latest = value;
+  }
+  return latest;
+}

--- a/docs/superpowers/plans/2026-06-28-decision-shadow-ledger-trust-state.md
+++ b/docs/superpowers/plans/2026-06-28-decision-shadow-ledger-trust-state.md
@@ -1,0 +1,131 @@
+# Decision Shadow Ledger TrustState Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the measured-trust substrate for `BI-DE4BF92F`: persistent `DecisionShadowLedger` rows and per-`coworker x activity x risk` `TrustState`, plus pure agreement/recommendation helpers.
+
+**Architecture:** Keep the first substrate narrow and non-acting. The Prisma models store evidence and aggregate trust state, while `apps/web/lib/autonomy/trust-state.ts` computes agreement windows and calls the existing `recommendTrustChange` core. No UI, prompt, skill, grant, model-route, Work Case, or autonomy-level mutation is introduced in this slice.
+
+**Tech Stack:** Prisma 7 schema/migration, TypeScript, Vitest, existing `apps/web/lib/autonomy/trust-graduation.ts`.
+
+---
+
+## Context
+
+- Epic: `EP-8AF1C996`
+- Backlog item: `BI-DE4BF92F`
+- Work Capsule: `WC-92CE0102`
+- Design source: `docs/superpowers/plans/2026-06-26-progressive-autonomy-trust-graduation-design.md`
+- Related spec: `docs/superpowers/specs/2026-06-27-governed-adaptive-playbooks-design.md`
+- Already landed: pure trust recommendation core, regulatory ceiling core, shadow projection/read model, playbook review, Work Case staging, and proposal resolution.
+
+## File Structure
+
+- Modify `packages/db/prisma/schema.prisma`
+  - Add `DecisionShadowLedger` and `TrustState` models near the task governance runtime area.
+  - Use semantic string IDs for agent/activity/risk references and optional source IDs, matching `ToolExecution.agentId` and `TaskRun.taskRunId` conventions.
+- Add `packages/db/prisma/migrations/20260628230000_decision_shadow_ledger_trust_state/migration.sql`
+  - Create both tables, unique keys, and query indexes.
+- Add `apps/web/lib/autonomy/trust-state.ts`
+  - Pure types and helpers for ledger rows, trust triples, aggregate agreement windows, and recommendations.
+- Add `apps/web/lib/autonomy/trust-state.test.ts`
+  - TDD coverage for aggregate state, ignored unresolved rows, regulatory ceiling propagation, and no-action recommendations.
+- Modify this plan as tasks complete.
+
+## Refactoring Allocation
+
+Reserve roughly 20 percent of effort for boundary cleanup: keep the agreement-window logic in a reusable pure helper instead of duplicating it inside future TAK or Work Case writers. Do not refactor unrelated autonomy, Work Case, or AI Workforce UI files.
+
+## Task 1: Pure TrustState Helper
+
+**Files:**
+- Create: `apps/web/lib/autonomy/trust-state.test.ts`
+- Create: `apps/web/lib/autonomy/trust-state.ts`
+
+- [x] **Step 1: Write failing aggregate test**
+
+Test that two reconciled ledger rows for one triple produce `samples=2`, `agreements=1`, `agreementRate=0.5`, and a demotion/hold recommendation from `recommendTrustChange`.
+
+Run:
+`pnpm --filter web exec vitest run lib/autonomy/trust-state.test.ts`
+
+Expected: fails because `trust-state.ts` does not exist.
+
+- [x] **Step 2: Implement minimal aggregate helper**
+
+Add `computeTrustStateFromLedger(input)` using resolved rows where `agreement !== null`, defaulting current level to `shadow`.
+
+- [x] **Step 3: Verify green**
+
+Run the same Vitest command.
+
+- [x] **Step 4: Add regulatory ceiling test**
+
+Assert a `regulatoryCeiling: "propose"` on a read-only activity is passed into the recommendation and caps promotion.
+
+- [x] **Step 5: Implement minimal ceiling support**
+
+Thread `regulatoryCeiling` through to `recommendTrustChange`.
+
+## Task 2: Prisma Models and Migration
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/20260628230000_decision_shadow_ledger_trust_state/migration.sql`
+
+- [x] **Step 1: Add schema/migration structural test by inspection**
+
+Before editing production schema, decide exact fields and indexes from the plan:
+`DecisionShadowLedger`: `ledgerId`, `agentId`, `activityType`, `riskClass`, `autonomyLevel`, proposed/actual/outcome JSON, `agreement`, optional source IDs, metadata, observed/reconciled timestamps.
+`TrustState`: unique `(agentId, activityType, riskClass)`, current level, regulatory ceiling, sample/agreement counts, rate, last ledger ID, recommendation JSON, evaluation timestamp.
+
+- [x] **Step 2: Add Prisma models and SQL migration**
+
+Use text columns plus application-level string unions from `trust-graduation.ts`; do not add DB enums in this slice.
+
+- [x] **Step 3: Generate Prisma client**
+
+Run:
+`pnpm --filter @dpf/db exec prisma generate`
+
+Expected: succeeds with generated client update.
+
+## Task 3: Verification
+
+**Files:**
+- All changed files from Tasks 1-2.
+
+- [x] **Step 1: Focused tests**
+
+Run:
+`pnpm --filter web exec vitest run lib/autonomy/trust-state.test.ts lib/autonomy/trust-graduation.test.ts lib/tak/work-pattern-shadow-evaluation.test.ts`
+
+- [x] **Step 2: DB typecheck**
+
+Run:
+`pnpm --filter @dpf/db typecheck`
+
+- [x] **Step 3: Web typecheck**
+
+Run:
+`pnpm --filter web typecheck`
+
+- [x] **Step 4: Production build**
+
+Run:
+`pnpm --filter web build`
+
+- [x] **Step 5: Migration apply check**
+
+Run `prisma migrate deploy` against throwaway database `dpf_codex_decision_shadow_20260628` inside the lease-scoped local Postgres container using this branch's copied schema/migration chain. Confirm `DecisionShadowLedger` and `TrustState` exist, then drop the throwaway database.
+
+- [x] **Step 6: Record evidence**
+
+Attach focused test/typecheck/build evidence to `BI-DE4BF92F` and `WC-92CE0102` before PR.
+
+## Non-Goals
+
+- Do not wire automatic writes from TAK, Work Case, WWMD, skills, prompts, or model routing yet.
+- Do not add a UI surface.
+- Do not auto-promote or demote live autonomy.
+- Do not implement the regulatory policy library; this slice only stores an optional regulatory ceiling on the trust triple.

--- a/packages/db/prisma/migrations/20260628230000_decision_shadow_ledger_trust_state/migration.sql
+++ b/packages/db/prisma/migrations/20260628230000_decision_shadow_ledger_trust_state/migration.sql
@@ -1,0 +1,94 @@
+-- CreateTable
+CREATE TABLE "DecisionShadowLedger" (
+    "id" TEXT NOT NULL,
+    "ledgerId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "activityType" TEXT NOT NULL,
+    "riskClass" TEXT NOT NULL,
+    "autonomyLevel" TEXT NOT NULL DEFAULT 'shadow',
+    "proposedDecision" JSONB NOT NULL,
+    "rationale" TEXT,
+    "actualDecision" JSONB,
+    "outcome" JSONB,
+    "agreement" BOOLEAN,
+    "sourceKind" TEXT,
+    "taskRunId" TEXT,
+    "toolExecutionId" TEXT,
+    "decisionInteractionId" TEXT,
+    "envelopeId" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "observedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reconciledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DecisionShadowLedger_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TrustState" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "activityType" TEXT NOT NULL,
+    "riskClass" TEXT NOT NULL,
+    "currentLevel" TEXT NOT NULL DEFAULT 'shadow',
+    "regulatoryCeiling" TEXT,
+    "sampleCount" INTEGER NOT NULL DEFAULT 0,
+    "agreementCount" INTEGER NOT NULL DEFAULT 0,
+    "agreementRate" DOUBLE PRECISION,
+    "lastLedgerId" TEXT,
+    "recommendation" JSONB NOT NULL DEFAULT '{}',
+    "lastEvaluatedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TrustState_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DecisionShadowLedger_ledgerId_key" ON "DecisionShadowLedger"("ledgerId");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_agentId_activityType_riskClass_observedAt_idx" ON "DecisionShadowLedger"("agentId", "activityType", "riskClass", "observedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_agentId_observedAt_idx" ON "DecisionShadowLedger"("agentId", "observedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_activityType_riskClass_idx" ON "DecisionShadowLedger"("activityType", "riskClass");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_agreement_idx" ON "DecisionShadowLedger"("agreement");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_taskRunId_idx" ON "DecisionShadowLedger"("taskRunId");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_toolExecutionId_idx" ON "DecisionShadowLedger"("toolExecutionId");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_decisionInteractionId_idx" ON "DecisionShadowLedger"("decisionInteractionId");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_envelopeId_idx" ON "DecisionShadowLedger"("envelopeId");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_observedAt_idx" ON "DecisionShadowLedger"("observedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TrustState_agentId_activityType_riskClass_key" ON "TrustState"("agentId", "activityType", "riskClass");
+
+-- CreateIndex
+CREATE INDEX "TrustState_agentId_currentLevel_idx" ON "TrustState"("agentId", "currentLevel");
+
+-- CreateIndex
+CREATE INDEX "TrustState_activityType_riskClass_idx" ON "TrustState"("activityType", "riskClass");
+
+-- CreateIndex
+CREATE INDEX "TrustState_currentLevel_idx" ON "TrustState"("currentLevel");
+
+-- CreateIndex
+CREATE INDEX "TrustState_regulatoryCeiling_idx" ON "TrustState"("regulatoryCeiling");
+
+-- CreateIndex
+CREATE INDEX "TrustState_lastEvaluatedAt_idx" ON "TrustState"("lastEvaluatedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -5316,6 +5316,69 @@ model PromotionBackup {
 
 // ─── Task Governance Runtime ──────────────────────────────────────
 
+// Progressive autonomy substrate (EP-8AF1C996 / BI-DE4BF92F).
+// DecisionShadowLedger records what a coworker would/did decide for a governed
+// activity; TrustState stores the measured aggregate for one
+// coworker x activity x risk triple. These tables measure trust only; they do
+// not authorize runtime autonomy changes.
+model DecisionShadowLedger {
+  id                    String    @id @default(cuid())
+  ledgerId              String    @unique
+  agentId               String
+  activityType          String
+  riskClass             String
+  autonomyLevel         String    @default("shadow")
+  proposedDecision      Json
+  rationale             String?   @db.Text
+  actualDecision        Json?
+  outcome               Json?
+  agreement             Boolean?
+  sourceKind            String?
+  taskRunId             String?
+  toolExecutionId       String?
+  decisionInteractionId String?
+  envelopeId            String?
+  metadata              Json      @default("{}")
+  observedAt            DateTime  @default(now())
+  reconciledAt          DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  @@index([agentId, activityType, riskClass, observedAt(sort: Desc)])
+  @@index([agentId, observedAt(sort: Desc)])
+  @@index([activityType, riskClass])
+  @@index([agreement])
+  @@index([taskRunId])
+  @@index([toolExecutionId])
+  @@index([decisionInteractionId])
+  @@index([envelopeId])
+  @@index([observedAt])
+}
+
+model TrustState {
+  id                String    @id @default(cuid())
+  agentId           String
+  activityType      String
+  riskClass         String
+  currentLevel      String    @default("shadow")
+  regulatoryCeiling String?
+  sampleCount       Int       @default(0)
+  agreementCount    Int       @default(0)
+  agreementRate     Float?
+  lastLedgerId      String?
+  recommendation    Json      @default("{}")
+  lastEvaluatedAt   DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  @@unique([agentId, activityType, riskClass])
+  @@index([agentId, currentLevel])
+  @@index([activityType, riskClass])
+  @@index([currentLevel])
+  @@index([regulatoryCeiling])
+  @@index([lastEvaluatedAt])
+}
+
 model TaskRun {
   id                   String                @id @default(cuid())
   taskRunId            String                @unique


### PR DESCRIPTION
## Summary
- Add the DecisionShadowLedger and TrustState Prisma substrate for progressive autonomy trust measurement.
- Add a pure trust-state aggregation helper that computes agreement windows, latest observation, and recommendation via the existing trust-graduation core.
- Add a durable implementation plan for BI-DE4BF92F with completed verification evidence.

## Verification
- `pnpm --filter web exec vitest run lib/autonomy/trust-state.test.ts lib/autonomy/trust-graduation.test.ts lib/tak/work-pattern-shadow-evaluation.test.ts` — 3 files, 23 tests passed.
- `pnpm --filter @dpf/db exec prisma validate` — schema valid.
- `pnpm --filter @dpf/db exec prisma generate` — Prisma Client 7.8.0 generated.
- `pnpm --filter @dpf/db typecheck` — passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web build` — passed, 131/131 static pages generated; existing Turbopack Edge/NFT warnings only.
- Migration apply check under local-integration lease `NPEL-158B4E6C82`: copied this branch's schema and migrations into the portal container, created throwaway DB `dpf_codex_decision_shadow_20260628`, ran `prisma migrate deploy`, confirmed `DecisionShadowLedger` and `TrustState`, then removed the throwaway DB and scratch directory.

## Scope Notes
- No UI surface in this slice.
- No automatic trust promotion/demotion or runtime autonomy mutation.
- No TAK/Work Case/WWMD write hooks yet; this PR lands the measured-trust substrate they will use.