### PR TITLE
Add regulatory autonomy ceiling policy

### DIFF
--- a/apps/web/lib/autonomy/regulatory-ceiling.test.ts
+++ b/apps/web/lib/autonomy/regulatory-ceiling.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRegulatoryAutonomyCeiling, type RegulatoryAutonomyPolicyRecord } from "./regulatory-ceiling";
+
+const emptyProfile = {
+  operatesIn: [],
+  sellsTo: [],
+  employsIn: [],
+  dataResidency: [],
+};
+
+function policy(overrides: Partial<RegulatoryAutonomyPolicyRecord>): RegulatoryAutonomyPolicyRecord {
+  return {
+    policyId: "RAP-1",
+    policyKey: "healthcare-eu-patient-message",
+    version: 1,
+    status: "active",
+    industry: "healthcare-provider",
+    jurisdiction: "eu",
+    jurisdictionBasis: "operating",
+    activityClass: "patient-message.send",
+    maxAutonomyLevel: "propose",
+    humanControlRequired: true,
+    requiredEvidence: ["human-approval"],
+    effectiveFrom: "2026-01-01T00:00:00.000Z",
+    effectiveUntil: null,
+    ...overrides,
+  };
+}
+
+describe("resolveRegulatoryAutonomyCeiling", () => {
+  it("defaults unknown policy state to human-controlled propose", () => {
+    const result = resolveRegulatoryAutonomyCeiling({
+      policies: [],
+      profile: { ...emptyProfile, operatesIn: ["eu"] },
+      industry: "healthcare-provider",
+      activityClass: "patient-message.send",
+      asOf: "2026-06-28T12:00:00.000Z",
+    });
+
+    expect(result.ceiling).toBe("propose");
+    expect(result.defaulted).toBe(true);
+    expect(result.humanControlRequired).toBe(true);
+    expect(result.requiredEvidence).toContain("operator-policy-review");
+    expect(result.reason).toMatch(/No active regulatory autonomy policy/);
+  });
+
+  it("matches industry, activity, and jurisdiction basis", () => {
+    const result = resolveRegulatoryAutonomyCeiling({
+      policies: [policy({})],
+      profile: { ...emptyProfile, operatesIn: ["eu"] },
+      industry: "healthcare-provider",
+      activityClass: "patient-message.send",
+      asOf: "2026-06-28T12:00:00.000Z",
+    });
+
+    expect(result.ceiling).toBe("propose");
+    expect(result.defaulted).toBe(false);
+    expect(result.humanControlRequired).toBe(true);
+    expect(result.requiredEvidence).toEqual(["human-approval"]);
+    expect(result.matchedPolicies.map((p) => p.policyId)).toEqual(["RAP-1"]);
+    expect(result.matchedBasis).toEqual(["operating"]);
+  });
+
+  it("chooses the most restrictive ceiling and deduplicates evidence across matching policies", () => {
+    const result = resolveRegulatoryAutonomyCeiling({
+      policies: [
+        policy({
+          policyId: "RAP-GLOBAL",
+          policyKey: "global-patient-message",
+          industry: null,
+          jurisdiction: "global",
+          jurisdictionBasis: "global",
+          activityClass: "*",
+          maxAutonomyLevel: "autopilot",
+          humanControlRequired: false,
+          requiredEvidence: ["decision-log"],
+        }),
+        policy({
+          policyId: "RAP-EU",
+          maxAutonomyLevel: "propose",
+          requiredEvidence: ["decision-log", "human-approval"],
+        }),
+      ],
+      profile: { ...emptyProfile, operatesIn: ["eu"] },
+      industry: "healthcare-provider",
+      activityClass: "patient-message.send",
+      asOf: "2026-06-28T12:00:00.000Z",
+    });
+
+    expect(result.ceiling).toBe("propose");
+    expect(result.humanControlRequired).toBe(true);
+    expect(result.requiredEvidence).toEqual(["decision-log", "human-approval"]);
+    expect(result.matchedPolicies.map((p) => p.policyId)).toEqual(["RAP-GLOBAL", "RAP-EU"]);
+  });
+
+  it("does not match an out-of-scope jurisdiction", () => {
+    const result = resolveRegulatoryAutonomyCeiling({
+      policies: [policy({})],
+      profile: { ...emptyProfile, operatesIn: ["us"] },
+      industry: "healthcare-provider",
+      activityClass: "patient-message.send",
+      asOf: "2026-06-28T12:00:00.000Z",
+    });
+
+    expect(result.defaulted).toBe(true);
+    expect(result.matchedPolicies).toEqual([]);
+  });
+
+  it("treats invalid policy autonomy levels as a human-controlled propose ceiling", () => {
+    const result = resolveRegulatoryAutonomyCeiling({
+      policies: [
+        policy({
+          maxAutonomyLevel: "unbounded" as never,
+          humanControlRequired: false,
+          requiredEvidence: [],
+        }),
+      ],
+      profile: { ...emptyProfile, operatesIn: ["eu"] },
+      industry: "healthcare-provider",
+      activityClass: "patient-message.send",
+      asOf: "2026-06-28T12:00:00.000Z",
+    });
+
+    expect(result.ceiling).toBe("propose");
+    expect(result.humanControlRequired).toBe(true);
+    expect(result.requiredEvidence).toContain("operator-policy-review");
+  });
+});

--- a/apps/web/lib/autonomy/regulatory-ceiling.ts
+++ b/apps/web/lib/autonomy/regulatory-ceiling.ts
@@ -1,0 +1,171 @@
+import {
+  regulationApplies,
+  type RegionProfile,
+} from "@dpf/db/regulation-applicability";
+import type { ProfessionJurisdictionBasis } from "@dpf/db/wiki-taxonomy";
+
+import {
+  AUTONOMY_LEVELS,
+  minLevel,
+  type AutonomyLevel,
+} from "./trust-graduation";
+
+const DEFAULT_REQUIRED_EVIDENCE = "operator-policy-review";
+
+export type RegulatoryAutonomyPolicyStatus = "draft" | "active" | "retired";
+
+export type RegulatoryAutonomyPolicyRecord = {
+  policyId: string;
+  policyKey?: string | null;
+  version?: number | null;
+  status: RegulatoryAutonomyPolicyStatus | string;
+  industry?: string | null;
+  jurisdiction: string;
+  jurisdictionBasis: ProfessionJurisdictionBasis;
+  activityClass: string;
+  maxAutonomyLevel: AutonomyLevel | string;
+  humanControlRequired?: boolean | null;
+  requiredEvidence?: unknown;
+  effectiveFrom?: Date | string | null;
+  effectiveUntil?: Date | string | null;
+};
+
+export type RegulatoryAutonomyCeilingResolution = {
+  ceiling: AutonomyLevel;
+  defaulted: boolean;
+  humanControlRequired: boolean;
+  requiredEvidence: string[];
+  matchedPolicies: RegulatoryAutonomyPolicyRecord[];
+  matchedBasis: ProfessionJurisdictionBasis[];
+  reason: string;
+};
+
+export type ResolveRegulatoryAutonomyCeilingInput = {
+  policies: readonly RegulatoryAutonomyPolicyRecord[];
+  profile: RegionProfile;
+  industry?: string | null;
+  activityClass: string;
+  asOf?: Date | string | null;
+};
+
+export function resolveRegulatoryAutonomyCeiling(
+  input: ResolveRegulatoryAutonomyCeilingInput,
+): RegulatoryAutonomyCeilingResolution {
+  const asOf = toDate(input.asOf) ?? new Date();
+  const matches: Array<{
+    policy: RegulatoryAutonomyPolicyRecord;
+    ceiling: AutonomyLevel;
+    invalidCeiling: boolean;
+    matchedBasis: ProfessionJurisdictionBasis[];
+  }> = [];
+
+  for (const policy of input.policies) {
+    if (!isActiveAt(policy, asOf)) continue;
+    if (!matchesActivity(policy.activityClass, input.activityClass)) continue;
+    if (!matchesIndustry(policy.industry, input.industry)) continue;
+
+    const applicability = regulationApplies(
+      {
+        basis: [policy.jurisdictionBasis],
+        jurisdictions: policy.jurisdictionBasis === "global" ? [] : [policy.jurisdiction],
+      },
+      input.profile,
+    );
+    if (!applicability.applies) continue;
+    const ceiling = coerceAutonomyLevel(policy.maxAutonomyLevel);
+    matches.push({
+      policy,
+      ceiling: ceiling.value,
+      invalidCeiling: ceiling.invalid,
+      matchedBasis: applicability.matchedBasis,
+    });
+  }
+
+  if (matches.length === 0) {
+    return {
+      ceiling: "propose",
+      defaulted: true,
+      humanControlRequired: true,
+      requiredEvidence: [DEFAULT_REQUIRED_EVIDENCE],
+      matchedPolicies: [],
+      matchedBasis: [],
+      reason:
+        "No active regulatory autonomy policy matched this industry, jurisdiction, and activity class; defaulting to propose until an operator/compliance policy review sets the ceiling.",
+    };
+  }
+
+  const ceiling = matches.reduce<AutonomyLevel>(
+    (acc, match) => minLevel(acc, match.ceiling),
+    "autopilot",
+  );
+  const humanControlRequired = matches.some(
+    (match) => match.invalidCeiling || match.policy.humanControlRequired === true,
+  );
+  const requiredEvidence = dedupe(
+    matches.flatMap((match) => [
+      ...evidenceKeys(match.policy.requiredEvidence),
+      ...(match.invalidCeiling ? [DEFAULT_REQUIRED_EVIDENCE] : []),
+    ]),
+  );
+  const matchedBasis = dedupe(matches.flatMap((match) => match.matchedBasis));
+
+  return {
+    ceiling,
+    defaulted: false,
+    humanControlRequired,
+    requiredEvidence,
+    matchedPolicies: matches.map((match) => match.policy),
+    matchedBasis,
+    reason: `Regulatory autonomy ceiling ${ceiling} from ${matches.length} active matching policy row${matches.length === 1 ? "" : "s"}.`,
+  };
+}
+
+function isActiveAt(policy: RegulatoryAutonomyPolicyRecord, asOf: Date): boolean {
+  if (policy.status !== "active") return false;
+  const effectiveFrom = toDate(policy.effectiveFrom);
+  const effectiveUntil = toDate(policy.effectiveUntil);
+  if (effectiveFrom && effectiveFrom > asOf) return false;
+  return !(effectiveUntil && effectiveUntil <= asOf);
+}
+
+function matchesActivity(policyActivityClass: string, activityClass: string): boolean {
+  const policyValue = normalize(policyActivityClass);
+  return policyValue === "*" || policyValue === "global" || policyValue === normalize(activityClass);
+}
+
+function matchesIndustry(policyIndustry: string | null | undefined, industry: string | null | undefined): boolean {
+  const policyValue = normalize(policyIndustry);
+  if (!policyValue || policyValue === "*" || policyValue === "global") return true;
+  return policyValue === normalize(industry);
+}
+
+function evidenceKeys(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function coerceAutonomyLevel(value: string): { value: AutonomyLevel; invalid: boolean } {
+  if (isAutonomyLevel(value)) return { value, invalid: false };
+  return { value: "propose", invalid: true };
+}
+
+function dedupe<T extends string>(values: readonly T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+export function isAutonomyLevel(value: string): value is AutonomyLevel {
+  return AUTONOMY_LEVELS.includes(value as AutonomyLevel);
+}

--- a/apps/web/lib/work-management/autonomy-envelope.test.ts
+++ b/apps/web/lib/work-management/autonomy-envelope.test.ts
@@ -44,6 +44,19 @@ describe("resolveWorkCaseAutonomyEnvelope", () => {
     });
   });
 
+  it("explains when a regulatory ceiling caps otherwise autonomous work", () => {
+    expect(
+      resolveWorkCaseAutonomyEnvelope({
+        action: "respond",
+        sourceKey: "engagement",
+        trustLevel: "autopilot",
+        risk: "read-only",
+        regulatoryCeiling: "supervised",
+        agreementWindow: { samples: 120, agreements: 120 },
+      }).reason,
+    ).toMatch(/regulatory policy/);
+  });
+
   it("uses the existing trust graduation core to explain holds and promotions", () => {
     expect(
       resolveWorkCaseAutonomyEnvelope({

--- a/apps/web/lib/work-management/autonomy-envelope.ts
+++ b/apps/web/lib/work-management/autonomy-envelope.ts
@@ -75,6 +75,13 @@ function receiptKindFor(sourceKey: string): WorkCaseReceiptKind {
   return getWorkCaseSourceEntry(sourceKey)?.receiptPolicy.defaultReceiptKind ?? "governed-action";
 }
 
+function capSourceLabel(input: WorkCaseAutonomyEnvelopeInput, riskCeiling: AutonomyLevel, ceiling: AutonomyLevel): string {
+  if (input.regulatoryCeiling && ceiling === input.regulatoryCeiling && input.regulatoryCeiling !== riskCeiling) {
+    return "regulatory policy";
+  }
+  return `${input.risk} risk`;
+}
+
 export function resolveWorkCaseAutonomyEnvelope(
   input: WorkCaseAutonomyEnvelopeInput,
 ): WorkCaseAutonomyEnvelopeResolution {
@@ -111,6 +118,6 @@ export function resolveWorkCaseAutonomyEnvelope(
     reason:
       effectiveTrustLevel === input.trustLevel
         ? trustRecommendation.reason
-        : `trust ${input.trustLevel} capped to ${effectiveTrustLevel} by ${input.risk} risk`,
+        : `trust ${input.trustLevel} capped to ${effectiveTrustLevel} by ${capSourceLabel(input, riskCeiling, ceiling)}`,
   };
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/next-build.mjs",
     "start": "next start",
     "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run",

--- a/apps/web/scripts/next-build.mjs
+++ b/apps/web/scripts/next-build.mjs
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const nextBin = require.resolve("next/dist/bin/next");
+const result = spawnSync(
+  process.execPath,
+  ["--max-old-space-size=8192", nextBin, "build", ...process.argv.slice(2)],
+  {
+    env: process.env,
+    stdio: "inherit",
+  },
+);
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+process.exit(result.status ?? (result.signal ? 1 : 0));

--- a/docs/superpowers/plans/2026-06-28-regulatory-autonomy-ceiling-policy.md
+++ b/docs/superpowers/plans/2026-06-28-regulatory-autonomy-ceiling-policy.md
@@ -1,0 +1,173 @@
+# Regulatory Autonomy Ceiling Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a versioned regulatory autonomy policy substrate and pure ceiling resolver for `BI-40CD8ACD`.
+
+**Architecture:** Keep policy evaluation pure and data-driven. Prisma stores versioned policy rows and ledger evidence references; `apps/web/lib/autonomy/regulatory-ceiling.ts` resolves an effective ceiling from supplied policy rows plus install context, and callers pass that ceiling into the existing trust-graduation core.
+
+**Tech Stack:** Prisma 7, TypeScript, Vitest, existing `@dpf/db/regulation-applicability` jurisdiction-basis model, existing autonomy trust core.
+
+---
+
+## Context
+
+- Epic: `EP-8AF1C996`
+- Backlog item: `BI-40CD8ACD`
+- Work Capsule: `WC-454EDEC3`
+- Design: `docs/superpowers/specs/2026-06-28-regulatory-autonomy-ceiling-policy-design.md`
+- Existing core: `apps/web/lib/autonomy/trust-graduation.ts` already accepts a `regulatoryCeiling`.
+- Previous slice: `BI-DE4BF92F` landed `DecisionShadowLedger`, `TrustState`, and pure trust-state aggregation in PR #2505.
+
+## Refactoring Allocation
+
+Reserve roughly 20 percent of effort for boundary cleanup: keep policy matching in one pure resolver, reuse `@dpf/db/regulation-applicability`, and avoid duplicating ceiling-source wording across Work Case callers.
+
+## File Structure
+
+- Create `apps/web/lib/autonomy/regulatory-ceiling.test.ts`
+  - TDD coverage for default-safe behavior, jurisdiction/industry/activity matching, multiple policies, and evidence union.
+- Create `apps/web/lib/autonomy/regulatory-ceiling.ts`
+  - Pure resolver, types, evidence normalization, and restrictive ceiling reduction.
+- Modify `apps/web/lib/work-management/autonomy-envelope.ts`
+  - Distinguish regulatory caps from risk caps in the returned reason when `regulatoryCeiling` binds.
+- Add/modify `apps/web/lib/work-management/autonomy-envelope.test.ts`
+  - One focused regression for regulatory reason wording.
+- Modify `packages/db/prisma/schema.prisma`
+  - Add `RegulatoryAutonomyPolicy`.
+  - Add optional `regulatoryPolicyId` and `regulatoryEvidence` to `DecisionShadowLedger`.
+- Add migration `packages/db/prisma/migrations/20260628233000_regulatory_autonomy_policy/migration.sql`
+  - Create table, indexes, unique `(policyKey, version)`, and ledger columns.
+- Modify `apps/web/package.json` and add `apps/web/scripts/next-build.mjs`
+  - Keep the canonical `pnpm --filter web build` gate stable by running the pinned Next build under an explicit Node heap ceiling.
+
+## Task 1: Pure Regulatory Ceiling Resolver
+
+**Files:**
+- Create: `apps/web/lib/autonomy/regulatory-ceiling.test.ts`
+- Create: `apps/web/lib/autonomy/regulatory-ceiling.ts`
+
+- [x] **Step 1: Write failing default-safe test**
+
+Test unknown policy state:
+
+```ts
+const result = resolveRegulatoryAutonomyCeiling({
+  policies: [],
+  profile: { operatesIn: ["eu"], sellsTo: [], employsIn: [], dataResidency: [] },
+  industry: "healthcare-provider",
+  activityClass: "patient-message.send",
+});
+
+expect(result.ceiling).toBe("propose");
+expect(result.defaulted).toBe(true);
+expect(result.humanControlRequired).toBe(true);
+expect(result.requiredEvidence).toContain("operator-policy-review");
+```
+
+Run:
+`pnpm --filter web exec vitest run lib/autonomy/regulatory-ceiling.test.ts`
+
+Expected: fail because the module does not exist.
+
+- [x] **Step 2: Implement minimal default resolver**
+
+Add types and return the default-safe `propose` result when no policies match.
+
+- [x] **Step 3: Verify green**
+
+Run the same Vitest command.
+
+- [x] **Step 4: Add matching and most-restrictive tests**
+
+Add tests for:
+- EU operating policy caps `patient-message.send` to `propose`.
+- A global `autopilot` policy plus EU `propose` policy resolves to `propose`.
+- Required evidence keys are deduplicated.
+- EU policy does not match a US-only profile.
+- A malformed `maxAutonomyLevel` string resolves safely to `propose` with operator-review evidence.
+
+- [x] **Step 5: Implement full resolver**
+
+Filter active/effective policies, match industry/activity, call `regulationApplies`, sort/reduce to the most restrictive ceiling, and return matched policy metadata.
+
+## Task 2: Work Case Cap Reason
+
+**Files:**
+- Modify: `apps/web/lib/work-management/autonomy-envelope.test.ts`
+- Modify: `apps/web/lib/work-management/autonomy-envelope.ts`
+
+- [x] **Step 1: Write failing reason test**
+
+Add a test where trust is `autopilot`, risk is `read-only`, and `regulatoryCeiling` is `supervised`; expect the reason to mention regulatory policy.
+
+- [x] **Step 2: Implement cap-source wording**
+
+Keep existing behavior, but when the regulatory ceiling is more restrictive than the risk ceiling, return `trust autopilot capped to supervised by regulatory policy`.
+
+- [x] **Step 3: Verify focused tests**
+
+Run:
+`pnpm --filter web exec vitest run lib/work-management/autonomy-envelope.test.ts lib/autonomy/regulatory-ceiling.test.ts`
+
+## Task 3: Prisma Policy Substrate
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/20260628233000_regulatory_autonomy_policy/migration.sql`
+
+- [x] **Step 1: Add schema models**
+
+Add `RegulatoryAutonomyPolicy` near compliance/runtime governance and add regulatory evidence fields to `DecisionShadowLedger`.
+
+- [x] **Step 2: Add migration**
+
+Create table/indexes and alter `DecisionShadowLedger`.
+
+- [x] **Step 3: Generate and validate Prisma**
+
+Run:
+`pnpm --filter @dpf/db exec prisma validate`
+`pnpm --filter @dpf/db exec prisma generate`
+
+## Task 4: Verification
+
+**Files:**
+- All changed files.
+
+- [x] **Step 1: Focused tests**
+
+Run:
+`pnpm --filter web exec vitest run lib/autonomy/regulatory-ceiling.test.ts lib/autonomy/trust-graduation.test.ts lib/autonomy/trust-state.test.ts lib/work-management/autonomy-envelope.test.ts`
+
+- [x] **Step 2: DB typecheck**
+
+Run:
+`pnpm --filter @dpf/db typecheck`
+
+- [x] **Step 3: Web typecheck**
+
+Run:
+`pnpm --filter web typecheck`
+
+- [x] **Step 4: Production build**
+
+Run:
+`pnpm --filter web build`
+
+The first canonical build attempt failed with V8 heap exhaustion during Next build-time TypeScript. The package build runner now invokes the pinned Next binary with `--max-old-space-size=8192`, and the same canonical command exits 0.
+
+- [x] **Step 5: Migration apply check**
+
+Under a `local-integration-ci` lease, apply the full migration chain to a throwaway database and confirm `RegulatoryAutonomyPolicy`, `DecisionShadowLedger.regulatoryPolicyId`, and `DecisionShadowLedger.regulatoryEvidence` exist.
+
+- [x] **Step 6: Record evidence**
+
+Record evidence on `BI-40CD8ACD` and `WC-454EDEC3`.
+
+## Non-Goals
+
+- No policy-management UI.
+- No seed data for real regulations.
+- No runtime policy fetching inside TAK, WWMD, or Work Case routes.
+- No automatic autonomy level mutation.

--- a/docs/superpowers/specs/2026-06-28-regulatory-autonomy-ceiling-policy-design.md
+++ b/docs/superpowers/specs/2026-06-28-regulatory-autonomy-ceiling-policy-design.md
@@ -1,0 +1,88 @@
+# Regulatory Autonomy Ceiling Policy Design
+
+## Purpose
+
+`BI-40CD8ACD` adds the policy layer that caps progressive autonomy independently of measured trust. A coworker may earn trust through agreement evidence, but regulated work still needs a separate ceiling that comes from industry, jurisdiction, activity class, and human-control requirements.
+
+This slice makes the ceiling data-driven and auditable without introducing a full policy engine. It adds a versioned policy table, a pure resolver, and ledger evidence fields so later TAK, Work Case, WWMD, and operator UI slices can use the same substrate.
+
+## Research and Benchmarking
+
+- Open Policy Agent uses policy-as-code with decision logs for auditability, including queried policy, input, bundle metadata, and other debugging context. DPF adopts the audit lesson, not the runtime dependency: ceiling decisions must be explainable and recordable. Source: https://openpolicyagent.org/docs and https://openpolicyagent.org/docs/management-decision-logs
+- Amazon Verified Permissions separates authorization policy from application logic through Cedar and supports RBAC plus ABAC conditions. DPF adopts the separation: trust graduation logic does not hard-code regulation facts; the resolver receives policy rows as data. Source: https://docs.aws.amazon.com/verifiedpermissions/latest/userguide/what-is-avp.html and https://docs.aws.amazon.com/verifiedpermissions/latest/userguide/terminology.html
+- OpenFGA models authorization from stored relationship tuples plus contextual tuples for request-time facts. DPF adopts the same split between durable policy rows and request/install context, but avoids a ReBAC engine because this is an autonomy ceiling, not relationship authorization. Source: https://openfga.dev/docs/concepts and https://openfga.dev/docs/interacting/contextual-tuples
+- ServiceNow GRC positions policy lifecycle, continuous monitoring, and compliance/risk visibility as one program. DPF adopts the lifecycle stance: policy rows are versioned, statused, effective-dated, and suitable for future compliance UI review. Source: https://downloads.docs.servicenow.com/pdf/enus/servicenow-xanadu-governance-risk-compliance-enus.pdf
+
+## Design
+
+### Data Model
+
+Add `RegulatoryAutonomyPolicy` near the existing compliance/runtime governance tables.
+
+Each row represents one versioned rule for an activity class in an industry and jurisdiction context:
+
+- `policyId`: unique row id.
+- `policyKey`: stable lineage key shared by versions.
+- `version`: integer version under the policy key.
+- `industry`: optional business-context industry or archetype category. Null means cross-industry.
+- `jurisdiction`: jurisdiction slug such as `eu`, `us`, or `global`.
+- `jurisdictionBasis`: one of the existing profession jurisdiction bases, such as `operating`, `selling`, `employing`, `data-residency`, or `global`.
+- `activityClass`: exact activity class or `*` for a fallback policy.
+- `maxAutonomyLevel`: `shadow`, `propose`, `supervised`, or `autopilot`.
+- `humanControlRequired`: whether the policy mandates human control even if the ceiling is above `propose`.
+- `requiredEvidence`: JSON array of evidence keys that must be captured.
+- `regulationId`: optional semantic link to a `Regulation`.
+- lifecycle fields: `status`, `sourceKind`, `effectiveFrom`, `effectiveUntil`, `rationale`, timestamps.
+
+Add optional regulatory evidence columns to `DecisionShadowLedger`:
+
+- `regulatoryPolicyId`
+- `regulatoryEvidence`
+
+The ledger keeps evidence; it does not decide. The resolver decides what evidence is required.
+
+### Resolver
+
+Add `apps/web/lib/autonomy/regulatory-ceiling.ts` with a pure function:
+
+`resolveRegulatoryAutonomyCeiling({ policies, profile, industry, activityClass, asOf })`
+
+Rules:
+
+1. Filter to active policies whose effective window contains `asOf`.
+2. Match activity by exact class or `*`.
+3. Match industry by exact industry, null, or `*`.
+4. Use the existing `regulationApplies` basis/jurisdiction logic for regional scope.
+5. If multiple policies apply, the effective ceiling is the most restrictive `maxAutonomyLevel`.
+6. If no policy applies, default to `propose`, require human control, and return a reason that operator policy review is required.
+7. If a matching policy row contains an invalid autonomy-level string, treat that row as `propose`, require human control, and require operator policy review evidence.
+
+The resolver returns the ceiling, matched policies, required evidence keys, human-control requirement, and a human-readable reason.
+
+### Integration
+
+The trust core already accepts `regulatoryCeiling`. This slice keeps that boundary and improves one caller:
+
+- `resolveWorkCaseAutonomyEnvelope` should distinguish regulatory caps from risk caps in its reason when `regulatoryCeiling` is more restrictive.
+
+Runtime policy fetching, operator policy UI, and automatic Decision Shadow Ledger writes are intentionally not wired here. Later slices can read `RegulatoryAutonomyPolicy`, call the resolver, pass its `ceiling` into trust-state/work-case evaluation, and store the policy/evidence result in `DecisionShadowLedger`.
+
+## Non-Goals
+
+- No external policy engine adoption.
+- No UI for managing policies.
+- No legal advice, regulatory content generation, or seeded regulation facts.
+- No automatic autonomy promotion or demotion.
+- No runtime Work Case/TAK/WWMD policy fetch yet.
+
+## Verification
+
+- TDD tests for the resolver:
+  - unknown policy defaults to `propose` and human control.
+  - matching policy caps a low-risk activity despite high trust.
+  - multiple matching policies choose the most restrictive ceiling and union evidence keys.
+  - out-of-scope jurisdiction does not match.
+  - malformed autonomy-level strings default safely to `propose` and operator review.
+- Existing trust and Work Case autonomy tests stay green.
+- Prisma schema validates, client generates, db/web typecheck pass.
+- Migration applies cleanly to a throwaway database under the local-integration lease.

--- a/packages/db/prisma/migrations/20260628233000_regulatory_autonomy_policy/migration.sql
+++ b/packages/db/prisma/migrations/20260628233000_regulatory_autonomy_policy/migration.sql
@@ -1,0 +1,56 @@
+-- AlterTable
+ALTER TABLE "DecisionShadowLedger"
+ADD COLUMN "regulatoryPolicyId" TEXT,
+ADD COLUMN "regulatoryEvidence" JSONB NOT NULL DEFAULT '{}';
+
+-- CreateTable
+CREATE TABLE "RegulatoryAutonomyPolicy" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "policyKey" TEXT NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "industry" TEXT,
+    "jurisdiction" TEXT NOT NULL DEFAULT 'global',
+    "jurisdictionBasis" TEXT NOT NULL DEFAULT 'global',
+    "activityClass" TEXT NOT NULL,
+    "maxAutonomyLevel" TEXT NOT NULL DEFAULT 'propose',
+    "humanControlRequired" BOOLEAN NOT NULL DEFAULT true,
+    "requiredEvidence" JSONB NOT NULL DEFAULT '[]',
+    "regulationId" TEXT,
+    "rationale" TEXT,
+    "sourceKind" TEXT NOT NULL DEFAULT 'operator',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "effectiveFrom" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "effectiveUntil" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RegulatoryAutonomyPolicy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RegulatoryAutonomyPolicy_policyId_key" ON "RegulatoryAutonomyPolicy"("policyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RegulatoryAutonomyPolicy_policyKey_version_key" ON "RegulatoryAutonomyPolicy"("policyKey", "version");
+
+-- CreateIndex
+CREATE INDEX "RegulatoryAutonomyPolicy_status_effectiveFrom_effectiveUntil_idx" ON "RegulatoryAutonomyPolicy"("status", "effectiveFrom", "effectiveUntil");
+
+-- CreateIndex
+CREATE INDEX "RegulatoryAutonomyPolicy_industry_jurisdiction_activityClass_idx" ON "RegulatoryAutonomyPolicy"("industry", "jurisdiction", "activityClass");
+
+-- CreateIndex
+CREATE INDEX "RegulatoryAutonomyPolicy_jurisdiction_jurisdictionBasis_idx" ON "RegulatoryAutonomyPolicy"("jurisdiction", "jurisdictionBasis");
+
+-- CreateIndex
+CREATE INDEX "RegulatoryAutonomyPolicy_activityClass_idx" ON "RegulatoryAutonomyPolicy"("activityClass");
+
+-- CreateIndex
+CREATE INDEX "RegulatoryAutonomyPolicy_maxAutonomyLevel_idx" ON "RegulatoryAutonomyPolicy"("maxAutonomyLevel");
+
+-- CreateIndex
+CREATE INDEX "RegulatoryAutonomyPolicy_regulationId_idx" ON "RegulatoryAutonomyPolicy"("regulationId");
+
+-- CreateIndex
+CREATE INDEX "DecisionShadowLedger_regulatoryPolicyId_idx" ON "DecisionShadowLedger"("regulatoryPolicyId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -5338,6 +5338,8 @@ model DecisionShadowLedger {
   toolExecutionId       String?
   decisionInteractionId String?
   envelopeId            String?
+  regulatoryPolicyId    String?
+  regulatoryEvidence    Json      @default("{}")
   metadata              Json      @default("{}")
   observedAt            DateTime  @default(now())
   reconciledAt          DateTime?
@@ -5352,6 +5354,7 @@ model DecisionShadowLedger {
   @@index([toolExecutionId])
   @@index([decisionInteractionId])
   @@index([envelopeId])
+  @@index([regulatoryPolicyId])
   @@index([observedAt])
 }
 
@@ -5377,6 +5380,36 @@ model TrustState {
   @@index([currentLevel])
   @@index([regulatoryCeiling])
   @@index([lastEvaluatedAt])
+}
+
+model RegulatoryAutonomyPolicy {
+  id                   String    @id @default(cuid())
+  policyId             String    @unique
+  policyKey            String
+  version              Int       @default(1)
+  industry             String?
+  jurisdiction         String    @default("global")
+  jurisdictionBasis    String    @default("global")
+  activityClass        String
+  maxAutonomyLevel     String    @default("propose")
+  humanControlRequired Boolean   @default(true)
+  requiredEvidence     Json      @default("[]")
+  regulationId         String?
+  rationale            String?   @db.Text
+  sourceKind           String    @default("operator")
+  status               String    @default("active")
+  effectiveFrom        DateTime  @default(now())
+  effectiveUntil       DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@unique([policyKey, version])
+  @@index([status, effectiveFrom, effectiveUntil])
+  @@index([industry, jurisdiction, activityClass])
+  @@index([jurisdiction, jurisdictionBasis])
+  @@index([activityClass])
+  @@index([maxAutonomyLevel])
+  @@index([regulationId])
 }
 
 model TaskRun {


### PR DESCRIPTION
## Summary

Adds the regulatory/compliance autonomy ceiling substrate for `BI-40CD8ACD`:

- versioned `RegulatoryAutonomyPolicy` Prisma model plus Decision Shadow Ledger regulatory evidence columns
- pure `resolveRegulatoryAutonomyCeiling(...)` resolver using existing jurisdiction-basis applicability logic
- default-safe behavior for unknown policy state and malformed policy autonomy strings
- Work Case autonomy-envelope wording that distinguishes regulatory caps from risk caps
- research-backed design spec and implementation plan
- heap-stable web build runner so the canonical `pnpm --filter web build` gate completes reliably

## Verification

- `pnpm --filter web exec vitest run lib/autonomy/regulatory-ceiling.test.ts lib/autonomy/trust-graduation.test.ts lib/autonomy/trust-state.test.ts lib/work-management/autonomy-envelope.test.ts` — 4 files, 30 tests passed
- `pnpm --filter @dpf/db typecheck` — passed
- `pnpm --filter web typecheck` — passed
- `pnpm --filter web build` — passed; compiled successfully and generated 131/131 static pages
- Migration apply check under `local-integration-ci` lease `NPEL-F0E1093A1F`: full migration chain applied to throwaway DB `dpf_codex_regulatory_autonomy_202606282344`; confirmed `RegulatoryAutonomyPolicy`, `DecisionShadowLedger.regulatoryPolicyId`, and `DecisionShadowLedger.regulatoryEvidence`; scratch/DB cleaned up

## Notes

The first canonical build run exposed a V8 heap exhaustion during Next build-time TypeScript. This PR keeps the public command unchanged and runs the pinned Next binary through a small cross-platform Node wrapper with `--max-old-space-size=8192`.
