### PR TITLE
feat: wire regulatory autonomy runtime evidence

### DIFF
--- a/apps/web/lib/actions/work-pattern-review.test.ts
+++ b/apps/web/lib/actions/work-pattern-review.test.ts
@@ -9,11 +9,26 @@ const { mockPrisma, mockRequireCapability, mockRevalidatePath } = vi.hoisted(() 
     decisionInteraction: {
       create: vi.fn(),
     },
+    businessContext: {
+      findFirst: vi.fn(),
+    },
+    storefrontConfig: {
+      findFirst: vi.fn(),
+    },
+    regulatoryAutonomyPolicy: {
+      findMany: vi.fn(),
+    },
+    decisionShadowLedger: {
+      upsert: vi.fn(),
+      findMany: vi.fn(),
+    },
     coworkerActionEnvelope: {
       create: vi.fn(),
       update: vi.fn(),
     },
     trustState: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
       update: vi.fn(),
       create: vi.fn(),
     },
@@ -85,6 +100,7 @@ function needRow(overrides: Record<string, unknown> = {}) {
     blocks: "Repeated grant denials block verification.",
     evidenceJson: {
       patternKey: "grant-denial|build-specialist|/build",
+      activityClass: "work-pattern.grant-denial",
       decisionScope: "platform-wwmd",
       riskClass: "internal-reversible",
       currentAutonomyLevel: "shadow",
@@ -265,6 +281,43 @@ describe("reviewWorkPatternAction", () => {
       id: "decision-row-1",
       ...data,
     }));
+    mockPrisma.businessContext.findFirst.mockResolvedValue({
+      operatesIn: ["eu"],
+      sellsTo: [],
+      employsIn: [],
+      dataResidency: [],
+      industry: "legacy-industry",
+    });
+    mockPrisma.storefrontConfig.findFirst.mockResolvedValue({
+      archetype: { category: "professional-services" },
+    });
+    mockPrisma.regulatoryAutonomyPolicy.findMany.mockResolvedValue([
+      {
+        policyId: "RAP-GLOBAL-WORK-PATTERN",
+        policyKey: "global-work-pattern",
+        version: 1,
+        status: "active",
+        industry: null,
+        jurisdiction: "global",
+        jurisdictionBasis: "global",
+        activityClass: "work-pattern.grant-denial",
+        maxAutonomyLevel: "propose",
+        humanControlRequired: true,
+        requiredEvidence: ["decision-shadow-ledger", "operator-review"],
+        effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+        effectiveUntil: null,
+      },
+    ]);
+    mockPrisma.decisionShadowLedger.upsert.mockResolvedValue({});
+    mockPrisma.decisionShadowLedger.findMany.mockResolvedValue(
+      shadowTrials().map((trial) => ({
+        ledgerId: `DI-LEDGER:${trial.trialId}`,
+        agreement: trial.agreement,
+        observedAt: new Date(trial.observedAt),
+      })),
+    );
+    mockPrisma.trustState.findUnique.mockResolvedValue(null);
+    mockPrisma.trustState.upsert.mockResolvedValue({});
     mockPrisma.$transaction.mockImplementation(async (callback) => callback(mockPrisma));
   });
 
@@ -311,7 +364,64 @@ describe("reviewWorkPatternAction", () => {
         }),
       }),
     });
+    expect(mockPrisma.regulatoryAutonomyPolicy.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "active" }),
+      }),
+    );
+    expect(mockPrisma.decisionShadowLedger.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { ledgerId: expect.stringMatching(/^DI-[A-F0-9]{12}:S-1$/) },
+        create: expect.objectContaining({
+          agentId: "build-specialist",
+          activityType: "work-pattern.grant-denial",
+          riskClass: "internal-reversible",
+          autonomyLevel: "shadow",
+          taskRunId: "TR-1",
+          toolExecutionId: "TE-1",
+          regulatoryPolicyId: "RAP-GLOBAL-WORK-PATTERN",
+          regulatoryEvidence: expect.objectContaining({
+            ceiling: "propose",
+            matchedPolicyIds: ["RAP-GLOBAL-WORK-PATTERN"],
+            requiredEvidence: ["decision-shadow-ledger", "operator-review"],
+          }),
+        }),
+      }),
+    );
+    expect(mockPrisma.trustState.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          agentId: "build-specialist",
+          activityType: "work-pattern.grant-denial",
+          riskClass: "internal-reversible",
+          regulatoryCeiling: "propose",
+          sampleCount: 20,
+          agreementCount: 19,
+        }),
+      }),
+    );
     expect(mockRevalidatePath).toHaveBeenCalledWith("/platform/ai/agent/build-specialist");
+  });
+
+  it("uses DB-resolved regulatory ceilings instead of stale evidence JSON during approval", async () => {
+    mockPrisma.coworkerCapabilityNeed.findUnique.mockResolvedValue(
+      needRow({
+        evidenceJson: {
+          ...needRow().evidenceJson,
+          currentAutonomyLevel: "propose",
+          regulatoryCeiling: "autopilot",
+        },
+      }),
+    );
+
+    await expect(recordWorkPatternReview(form("approve"))).rejects.toThrow(
+      "approval_requires_promotable_shadow_evidence",
+    );
+
+    expect(mockPrisma.regulatoryAutonomyPolicy.findMany).toHaveBeenCalled();
+    expect(mockPrisma.decisionInteraction.create).not.toHaveBeenCalled();
+    expect(mockPrisma.decisionShadowLedger.upsert).not.toHaveBeenCalled();
+    expect(mockPrisma.trustState.upsert).not.toHaveBeenCalled();
   });
 
   it("records approved case-bound candidates as staged Work Case proposals", async () => {
@@ -463,11 +573,10 @@ describe("reviewWorkPatternAction", () => {
     expect(mockPrisma.decisionInteraction.create).not.toHaveBeenCalled();
   });
 
-  it("does not mutate live autonomy, Work Cases, skills, prompts, or backlog", async () => {
+  it("does not mutate live Work Cases, skills, prompts, grants, or backlog", async () => {
     await recordWorkPatternReview(form("approve"));
 
-    expect(mockPrisma.trustState.update).not.toHaveBeenCalled();
-    expect(mockPrisma.trustState.create).not.toHaveBeenCalled();
+    expect(mockPrisma.trustState.upsert).toHaveBeenCalled();
     expect(mockPrisma.coworkerActionEnvelope.create).not.toHaveBeenCalled();
     expect(mockPrisma.coworkerActionEnvelope.update).not.toHaveBeenCalled();
     expect(mockPrisma.workCase.update).not.toHaveBeenCalled();

--- a/apps/web/lib/actions/work-pattern-review.ts
+++ b/apps/web/lib/actions/work-pattern-review.ts
@@ -10,6 +10,12 @@ import type {
   DecisionRiskTier,
 } from "@/lib/decision-perspective/types";
 import {
+  recordRegulatoryDecisionShadowEvidence,
+  resolveRuntimeRegulatoryAutonomyCeiling,
+  type RegulatoryAutonomyRuntimeDb,
+  type RuntimeRegulatoryAutonomyCeiling,
+} from "@/lib/autonomy/regulatory-autonomy-runtime";
+import {
   COWORKER_CAPABILITY_NEED_KINDS,
   type CoworkerCapabilityNeedKind,
 } from "@/lib/coworker-self-assessment/types";
@@ -190,6 +196,40 @@ function workPatternMetadataFrom(
   );
 }
 
+function activityClassForReview(input: {
+  evidenceJson: JsonRecord;
+  readinessJson: JsonRecord;
+  metadata: ReturnType<typeof workPatternMetadataFrom>;
+  patternKey: string;
+}): string {
+  const explicit =
+    stringField(input.evidenceJson, "activityClass") ??
+    stringField(input.readinessJson, "activityClass");
+  if (explicit) return explicit;
+
+  const binding = input.metadata?.workCaseBinding;
+  if (binding?.governedActionKey) {
+    return `work-case.${binding.caseType ?? "case"}.${binding.governedActionKey}`;
+  }
+
+  return input.patternKey;
+}
+
+function regulatorySummary(runtime: RuntimeRegulatoryAutonomyCeiling | null): JsonRecord | null {
+  if (!runtime) return null;
+  return {
+    activityClass: runtime.activityClass,
+    industry: runtime.industry,
+    ceiling: runtime.resolution.ceiling,
+    defaulted: runtime.resolution.defaulted,
+    humanControlRequired: runtime.resolution.humanControlRequired,
+    requiredEvidence: runtime.resolution.requiredEvidence,
+    matchedPolicyIds: runtime.resolution.matchedPolicies.map((policy) => policy.policyId),
+    matchedBasis: runtime.resolution.matchedBasis,
+    reason: runtime.resolution.reason,
+  };
+}
+
 function receiptEnvelopeFromForm(input: {
   formData: FormData;
   staging: NonNullable<ReturnType<typeof parseWorkPatternReviewState>>["caseStaging"];
@@ -259,6 +299,7 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
 
   const evidenceJson = recordFrom(need.evidenceJson);
   const readinessJson = recordFrom(need.readinessJson);
+  const metadata = workPatternMetadataFrom(evidenceJson, readinessJson);
   const patternKey =
     stringField(evidenceJson, "patternKey") ?? stringField(readinessJson, "patternKey");
   if (!patternKey) throw new Error("work_pattern_missing_pattern_key");
@@ -278,11 +319,26 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
     parseRiskClass(stringField(readinessJson, "shadowRiskClass")) ??
     parseRiskClass(stringField(evidenceJson, "riskClass")) ??
     parseRiskClass(stringField(readinessJson, "riskClass"));
+  const activityClass = activityClassForReview({
+    evidenceJson,
+    readinessJson,
+    metadata,
+    patternKey,
+  });
+  const reviewedAt = new Date();
+  const runtimeRegulatory = shadowTrials.length > 0
+    ? await resolveRuntimeRegulatoryAutonomyCeiling(prisma as unknown as RegulatoryAutonomyRuntimeDb, {
+        activityClass,
+        asOf: reviewedAt,
+      })
+    : null;
+  const effectiveRegulatoryCeiling =
+    runtimeRegulatory?.resolution.ceiling ?? regulatoryCeiling;
   const shadowEvaluation = shadowTrials.length > 0
     ? evaluateWorkPatternShadowEvidence({
         trials: shadowTrials,
         currentLevel,
-        regulatoryCeiling,
+        regulatoryCeiling: effectiveRegulatoryCeiling,
         riskClass: shadowRiskClass,
       })
     : null;
@@ -302,12 +358,12 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
     shadowEvaluation,
     decisionInteractionId,
     reviewerUserId: userId,
-    reviewedAt: new Date(),
+    reviewedAt,
     reviewerNote: note,
   });
   const caseStaging = buildWorkPatternCaseStaging({
     review,
-    metadata: workPatternMetadataFrom(evidenceJson, readinessJson),
+    metadata,
   });
   const reviewWithStaging =
     caseStaging.status === "not-case-bound"
@@ -334,6 +390,7 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
         evidenceBundle: inputJson({
           workPatternReview: reviewWithStaging,
           shadowEvaluation,
+          runtimeRegulatoryAutonomy: regulatorySummary(runtimeRegulatory),
           capabilityNeedId: need.needId,
           linkedBacklogItemId: need.linkedBacklogItemId ?? null,
           materialCount: 0,
@@ -357,6 +414,7 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
           materialCount: 0,
           freshnessDistribution: { current: 0, stale: 0, superseded: 0, contradicted: 0 },
           workPatternReview: reviewWithStaging,
+          runtimeRegulatoryAutonomy: regulatorySummary(runtimeRegulatory),
         }),
         humanOutcome: {
           type: "work-pattern-review",
@@ -374,6 +432,20 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
         },
       },
     });
+
+    if (runtimeRegulatory && shadowEvaluation?.riskClass && shadowTrials.length > 0) {
+      await recordRegulatoryDecisionShadowEvidence(tx as unknown as RegulatoryAutonomyRuntimeDb, {
+        agentId: need.agentId,
+        activityType: activityClass,
+        riskClass: shadowEvaluation.riskClass,
+        currentLevel: shadowEvaluation.currentLevel,
+        decisionInteractionId,
+        taskRunId: stringField(evidenceJson, "taskRunId"),
+        toolExecutionId: stringField(evidenceJson, "toolExecutionId"),
+        regulatory: runtimeRegulatory,
+        trials: shadowTrials,
+      });
+    }
 
     await tx.coworkerCapabilityNeed.update({
       where: { needId },

--- a/apps/web/lib/autonomy/regulatory-autonomy-runtime.test.ts
+++ b/apps/web/lib/autonomy/regulatory-autonomy-runtime.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  recordRegulatoryDecisionShadowEvidence,
+  resolveRuntimeRegulatoryAutonomyCeiling,
+  type RegulatoryAutonomyRuntimeDb,
+} from "./regulatory-autonomy-runtime";
+import type { RegulatoryAutonomyPolicyRecord } from "./regulatory-ceiling";
+
+const emptyRegional = {
+  operatesIn: [],
+  sellsTo: [],
+  employsIn: [],
+  dataResidency: [],
+};
+
+function policy(overrides: Partial<RegulatoryAutonomyPolicyRecord> = {}): RegulatoryAutonomyPolicyRecord {
+  return {
+    policyId: "RAP-EU-PATIENT-MESSAGE",
+    policyKey: "eu-patient-message",
+    version: 1,
+    status: "active",
+    industry: "healthcare-wellness",
+    jurisdiction: "eu",
+    jurisdictionBasis: "operating",
+    activityClass: "patient-message.send",
+    maxAutonomyLevel: "propose",
+    humanControlRequired: true,
+    requiredEvidence: ["decision-shadow-ledger", "human-approval"],
+    effectiveFrom: "2026-01-01T00:00:00.000Z",
+    effectiveUntil: null,
+    ...overrides,
+  };
+}
+
+function db(overrides: Partial<RegulatoryAutonomyRuntimeDb> = {}): RegulatoryAutonomyRuntimeDb {
+  return {
+    businessContext: {
+      findFirst: vi.fn().mockResolvedValue({
+        ...emptyRegional,
+        operatesIn: ["eu"],
+        industry: "legacy-business-context-industry",
+      }),
+    },
+    storefrontConfig: {
+      findFirst: vi.fn().mockResolvedValue({
+        archetype: { category: "healthcare-wellness" },
+      }),
+    },
+    regulatoryAutonomyPolicy: {
+      findMany: vi.fn().mockResolvedValue([policy()]),
+    },
+    decisionShadowLedger: {
+      findMany: vi.fn().mockResolvedValue([]),
+      upsert: vi.fn().mockResolvedValue({}),
+    },
+    trustState: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      upsert: vi.fn().mockResolvedValue({}),
+    },
+    ...overrides,
+  };
+}
+
+describe("resolveRuntimeRegulatoryAutonomyCeiling", () => {
+  it("loads install context and active policies before delegating to the pure resolver", async () => {
+    const fakeDb = db();
+
+    const result = await resolveRuntimeRegulatoryAutonomyCeiling(fakeDb, {
+      activityClass: "patient-message.send",
+      asOf: "2026-06-29T03:00:00.000Z",
+    });
+
+    expect(result.profile).toEqual({
+      operatesIn: ["eu"],
+      sellsTo: [],
+      employsIn: [],
+      dataResidency: [],
+      archetype: "healthcare-wellness",
+    });
+    expect(result.industry).toBe("healthcare-wellness");
+    expect(result.resolution).toMatchObject({
+      ceiling: "propose",
+      defaulted: false,
+      requiredEvidence: ["decision-shadow-ledger", "human-approval"],
+    });
+    expect(fakeDb.regulatoryAutonomyPolicy.findMany).toHaveBeenCalledWith({
+      where: {
+        status: "active",
+        effectiveFrom: { lte: new Date("2026-06-29T03:00:00.000Z") },
+        OR: [
+          { effectiveUntil: null },
+          { effectiveUntil: { gt: new Date("2026-06-29T03:00:00.000Z") } },
+        ],
+      },
+    });
+  });
+});
+
+describe("recordRegulatoryDecisionShadowEvidence", () => {
+  it("writes ledger evidence and refreshes the measured TrustState read model", async () => {
+    const fakeDb = db({
+      decisionShadowLedger: {
+        upsert: vi.fn().mockResolvedValue({}),
+        findMany: vi.fn().mockResolvedValue([
+          {
+            ledgerId: "DI-1:S-2",
+            agreement: false,
+            observedAt: new Date("2026-06-29T03:01:00.000Z"),
+          },
+          {
+            ledgerId: "DI-1:S-1",
+            agreement: true,
+            observedAt: new Date("2026-06-29T03:00:00.000Z"),
+          },
+        ]),
+      },
+      trustState: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        upsert: vi.fn().mockResolvedValue({}),
+      },
+    });
+    const runtime = await resolveRuntimeRegulatoryAutonomyCeiling(fakeDb, {
+      activityClass: "patient-message.send",
+      asOf: "2026-06-29T03:00:00.000Z",
+    });
+
+    const result = await recordRegulatoryDecisionShadowEvidence(fakeDb, {
+      agentId: "healthcare-agent",
+      activityType: "patient-message.send",
+      riskClass: "read-only",
+      currentLevel: "shadow",
+      decisionInteractionId: "DI-1",
+      taskRunId: "TR-1",
+      toolExecutionId: "TE-1",
+      regulatory: runtime,
+      trials: [
+        {
+          trialId: "S-1",
+          candidateDecision: "send suggested response",
+          actualDecision: "send suggested response",
+          outcome: "accepted",
+          agreement: true,
+          observedAt: "2026-06-29T03:00:00.000Z",
+        },
+        {
+          trialId: "S-2",
+          candidateDecision: "send suggested response",
+          actualDecision: "ask human",
+          outcome: "corrected",
+          agreement: false,
+          observedAt: "2026-06-29T03:01:00.000Z",
+        },
+      ],
+    });
+
+    expect(fakeDb.decisionShadowLedger.upsert).toHaveBeenCalledTimes(2);
+    expect(fakeDb.decisionShadowLedger.upsert).toHaveBeenCalledWith({
+      where: { ledgerId: "DI-1:S-1" },
+      update: expect.objectContaining({
+        regulatoryPolicyId: "RAP-EU-PATIENT-MESSAGE",
+      }),
+      create: expect.objectContaining({
+        ledgerId: "DI-1:S-1",
+        agentId: "healthcare-agent",
+        activityType: "patient-message.send",
+        riskClass: "read-only",
+        autonomyLevel: "shadow",
+        agreement: true,
+        taskRunId: "TR-1",
+        toolExecutionId: "TE-1",
+        decisionInteractionId: "DI-1",
+        regulatoryPolicyId: "RAP-EU-PATIENT-MESSAGE",
+        regulatoryEvidence: expect.objectContaining({
+          ceiling: "propose",
+          matchedPolicyIds: ["RAP-EU-PATIENT-MESSAGE"],
+          requiredEvidence: ["decision-shadow-ledger", "human-approval"],
+        }),
+      }),
+    });
+    expect(fakeDb.trustState.upsert).toHaveBeenCalledWith({
+      where: {
+        agentId_activityType_riskClass: {
+          agentId: "healthcare-agent",
+          activityType: "patient-message.send",
+          riskClass: "read-only",
+        },
+      },
+      create: expect.objectContaining({
+        currentLevel: "shadow",
+        regulatoryCeiling: "propose",
+        sampleCount: 2,
+        agreementCount: 1,
+        agreementRate: 0.5,
+        lastLedgerId: "DI-1:S-2",
+      }),
+      update: expect.objectContaining({
+        currentLevel: "shadow",
+        regulatoryCeiling: "propose",
+        sampleCount: 2,
+        agreementCount: 1,
+        agreementRate: 0.5,
+        lastLedgerId: "DI-1:S-2",
+      }),
+    });
+    expect(result.trustState?.window).toEqual({ samples: 2, agreements: 1 });
+  });
+});

--- a/apps/web/lib/autonomy/regulatory-autonomy-runtime.ts
+++ b/apps/web/lib/autonomy/regulatory-autonomy-runtime.ts
@@ -1,0 +1,398 @@
+import {
+  isProfessionJurisdictionBasis,
+  type ProfessionJurisdictionBasis,
+} from "@dpf/db/wiki-taxonomy";
+import type { RegionProfile } from "@dpf/db/regulation-applicability";
+
+import type { AutonomyLevel, RiskClass } from "./trust-graduation";
+import {
+  computeTrustStateFromLedger,
+  type ComputedTrustState,
+} from "./trust-state";
+import {
+  resolveRegulatoryAutonomyCeiling,
+  type RegulatoryAutonomyCeilingResolution,
+  type RegulatoryAutonomyPolicyRecord,
+} from "./regulatory-ceiling";
+
+type BusinessContextRegionRow = {
+  operatesIn?: string[] | null;
+  sellsTo?: string[] | null;
+  employsIn?: string[] | null;
+  dataResidency?: string[] | null;
+  industry?: string | null;
+};
+
+type StorefrontArchetypeRow = {
+  archetype?: {
+    category?: string | null;
+  } | null;
+} | null;
+
+type RegulatoryAutonomyPolicyDbRow = {
+  policyId: string;
+  policyKey?: string | null;
+  version?: number | null;
+  status: string;
+  industry?: string | null;
+  jurisdiction: string;
+  jurisdictionBasis: string;
+  activityClass: string;
+  maxAutonomyLevel: string;
+  humanControlRequired?: boolean | null;
+  requiredEvidence?: unknown;
+  effectiveFrom?: Date | string | null;
+  effectiveUntil?: Date | string | null;
+};
+
+type LedgerAgreementRow = {
+  ledgerId: string;
+  agreement: boolean | null;
+  observedAt?: Date | string | null;
+};
+
+type TrustStateRow = {
+  currentLevel?: string | null;
+};
+
+export type RegulatoryAutonomyRuntimeDb = {
+  businessContext: {
+    findFirst(args: unknown): Promise<BusinessContextRegionRow | null>;
+  };
+  storefrontConfig: {
+    findFirst(args: unknown): Promise<StorefrontArchetypeRow>;
+  };
+  regulatoryAutonomyPolicy: {
+    findMany(args: unknown): Promise<RegulatoryAutonomyPolicyDbRow[]>;
+  };
+  decisionShadowLedger: {
+    upsert(args: unknown): Promise<unknown>;
+    findMany(args: unknown): Promise<LedgerAgreementRow[]>;
+  };
+  trustState: {
+    findUnique(args: unknown): Promise<TrustStateRow | null>;
+    upsert(args: unknown): Promise<unknown>;
+  };
+};
+
+export type RuntimeRegulatoryAutonomyCeiling = {
+  activityClass: string;
+  asOf: Date;
+  profile: RegionProfile;
+  industry: string | null;
+  policies: RegulatoryAutonomyPolicyRecord[];
+  resolution: RegulatoryAutonomyCeilingResolution;
+};
+
+export type RegulatoryDecisionShadowTrial = {
+  trialId?: string | null;
+  candidateDecision: unknown;
+  actualDecision: unknown;
+  outcome?: unknown;
+  agreement: boolean;
+  observedAt?: Date | string | null;
+  rationale?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type RecordRegulatoryDecisionShadowEvidenceResult = {
+  ledgerIds: string[];
+  regulatoryEvidence: Record<string, unknown>;
+  trustState: ComputedTrustState | null;
+};
+
+const DEFAULT_WINDOW_SIZE = 100;
+
+function stringArray(value: string[] | null | undefined): string[] {
+  return Array.isArray(value) ? value.filter((entry) => entry.trim().length > 0) : [];
+}
+
+function asOfDate(value?: Date | string | null): Date {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value;
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (Number.isFinite(parsed.getTime())) return parsed;
+  }
+  return new Date();
+}
+
+function dateOr(value: Date | string | null | undefined, fallback: Date): Date {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value;
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (Number.isFinite(parsed.getTime())) return parsed;
+  }
+  return fallback;
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function normalizePolicy(row: RegulatoryAutonomyPolicyDbRow): RegulatoryAutonomyPolicyRecord {
+  const jurisdictionBasis: ProfessionJurisdictionBasis = isProfessionJurisdictionBasis(row.jurisdictionBasis)
+    ? row.jurisdictionBasis
+    : "global";
+  return {
+    policyId: row.policyId,
+    policyKey: row.policyKey,
+    version: row.version,
+    status: row.status,
+    industry: row.industry,
+    jurisdiction: row.jurisdiction,
+    jurisdictionBasis,
+    activityClass: row.activityClass,
+    maxAutonomyLevel: row.maxAutonomyLevel,
+    humanControlRequired: row.humanControlRequired,
+    requiredEvidence: row.requiredEvidence,
+    effectiveFrom: row.effectiveFrom,
+    effectiveUntil: row.effectiveUntil,
+  };
+}
+
+function jsonObject(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return { value };
+}
+
+function trialKey(trial: RegulatoryDecisionShadowTrial, index: number): string {
+  const raw = trial.trialId?.trim() || String(index + 1);
+  return raw.replace(/\s+/g, "-");
+}
+
+function primaryPolicyId(resolution: RegulatoryAutonomyCeilingResolution): string | null {
+  const ids = resolution.matchedPolicies
+    .map((policy) => policy.policyId)
+    .filter((policyId) => policyId.trim().length > 0)
+    .sort();
+  return ids[0] ?? null;
+}
+
+function regulatoryEvidenceFor(runtime: RuntimeRegulatoryAutonomyCeiling): Record<string, unknown> {
+  return {
+    activityClass: runtime.activityClass,
+    asOf: runtime.asOf.toISOString(),
+    ceiling: runtime.resolution.ceiling,
+    defaulted: runtime.resolution.defaulted,
+    humanControlRequired: runtime.resolution.humanControlRequired,
+    requiredEvidence: runtime.resolution.requiredEvidence,
+    matchedPolicyIds: runtime.resolution.matchedPolicies.map((policy) => policy.policyId),
+    matchedBasis: runtime.resolution.matchedBasis,
+    reason: runtime.resolution.reason,
+    industry: runtime.industry,
+    profile: runtime.profile,
+  };
+}
+
+export async function resolveRuntimeRegulatoryAutonomyCeiling(
+  db: RegulatoryAutonomyRuntimeDb,
+  input: {
+    activityClass: string;
+    asOf?: Date | string | null;
+    industry?: string | null;
+    profile?: RegionProfile | null;
+  },
+): Promise<RuntimeRegulatoryAutonomyCeiling> {
+  const asOf = asOfDate(input.asOf);
+  const [businessContext, storefront, policies] = await Promise.all([
+    input.profile
+      ? Promise.resolve(null)
+      : db.businessContext.findFirst({
+          select: {
+            operatesIn: true,
+            sellsTo: true,
+            employsIn: true,
+            dataResidency: true,
+            industry: true,
+          },
+        }),
+    db.storefrontConfig.findFirst({
+      select: {
+        archetype: {
+          select: { category: true },
+        },
+      },
+    }),
+    db.regulatoryAutonomyPolicy.findMany({
+      where: {
+        status: "active",
+        effectiveFrom: { lte: asOf },
+        OR: [
+          { effectiveUntil: null },
+          { effectiveUntil: { gt: asOf } },
+        ],
+      },
+    }),
+  ]);
+  const archetype = storefront?.archetype?.category ?? undefined;
+  const profile: RegionProfile = input.profile ?? {
+    operatesIn: stringArray(businessContext?.operatesIn),
+    sellsTo: stringArray(businessContext?.sellsTo),
+    employsIn: stringArray(businessContext?.employsIn),
+    dataResidency: stringArray(businessContext?.dataResidency),
+    archetype,
+  };
+  const industry = firstNonEmpty(input.industry, archetype, businessContext?.industry);
+  const normalizedPolicies = policies.map(normalizePolicy);
+  return {
+    activityClass: input.activityClass,
+    asOf,
+    profile,
+    industry,
+    policies: normalizedPolicies,
+    resolution: resolveRegulatoryAutonomyCeiling({
+      policies: normalizedPolicies,
+      profile,
+      industry,
+      activityClass: input.activityClass,
+      asOf,
+    }),
+  };
+}
+
+export async function recordRegulatoryDecisionShadowEvidence(
+  db: RegulatoryAutonomyRuntimeDb,
+  input: {
+    agentId: string;
+    activityType: string;
+    riskClass: RiskClass;
+    currentLevel: AutonomyLevel;
+    decisionInteractionId: string;
+    regulatory: RuntimeRegulatoryAutonomyCeiling;
+    trials: readonly RegulatoryDecisionShadowTrial[];
+    taskRunId?: string | null;
+    toolExecutionId?: string | null;
+    windowSize?: number | null;
+  },
+): Promise<RecordRegulatoryDecisionShadowEvidenceResult> {
+  if (input.trials.length === 0) {
+    return {
+      ledgerIds: [],
+      regulatoryEvidence: regulatoryEvidenceFor(input.regulatory),
+      trustState: null,
+    };
+  }
+
+  const regulatoryEvidence = regulatoryEvidenceFor(input.regulatory);
+  const regulatoryPolicyId = primaryPolicyId(input.regulatory.resolution);
+  const ledgerIds: string[] = [];
+
+  for (const [index, trial] of input.trials.entries()) {
+    const ledgerId = `${input.decisionInteractionId}:${trialKey(trial, index)}`;
+    ledgerIds.push(ledgerId);
+    const observedAt = dateOr(trial.observedAt, input.regulatory.asOf);
+    const data = {
+      agentId: input.agentId,
+      activityType: input.activityType,
+      riskClass: input.riskClass,
+      autonomyLevel: input.currentLevel,
+      proposedDecision: jsonObject(trial.candidateDecision),
+      rationale: trial.rationale ?? null,
+      actualDecision: jsonObject(trial.actualDecision),
+      outcome: trial.outcome == null ? null : jsonObject(trial.outcome),
+      agreement: trial.agreement,
+      sourceKind: "work-pattern-shadow-trial",
+      taskRunId: input.taskRunId ?? null,
+      toolExecutionId: input.toolExecutionId ?? null,
+      decisionInteractionId: input.decisionInteractionId,
+      regulatoryPolicyId,
+      regulatoryEvidence,
+      metadata: {
+        ...(trial.metadata ?? {}),
+        trialId: trial.trialId ?? null,
+        runtimeConsumer: "regulatory-autonomy",
+      },
+      observedAt,
+      reconciledAt: observedAt,
+    };
+
+    await db.decisionShadowLedger.upsert({
+      where: { ledgerId },
+      update: data,
+      create: {
+        ledgerId,
+        ...data,
+      },
+    });
+  }
+
+  const rows = await db.decisionShadowLedger.findMany({
+    where: {
+      agentId: input.agentId,
+      activityType: input.activityType,
+      riskClass: input.riskClass,
+    },
+    orderBy: { observedAt: "desc" },
+    take: input.windowSize ?? DEFAULT_WINDOW_SIZE,
+    select: {
+      ledgerId: true,
+      agreement: true,
+      observedAt: true,
+    },
+  });
+  const existing = await db.trustState.findUnique({
+    where: {
+      agentId_activityType_riskClass: {
+        agentId: input.agentId,
+        activityType: input.activityType,
+        riskClass: input.riskClass,
+      },
+    },
+    select: { currentLevel: true },
+  });
+  const currentLevel =
+    existing?.currentLevel === "shadow" ||
+    existing?.currentLevel === "propose" ||
+    existing?.currentLevel === "supervised" ||
+    existing?.currentLevel === "autopilot"
+      ? existing.currentLevel
+      : input.currentLevel;
+  const trustState = computeTrustStateFromLedger({
+    agentId: input.agentId,
+    activityType: input.activityType,
+    riskClass: input.riskClass,
+    currentLevel,
+    regulatoryCeiling: input.regulatory.resolution.ceiling,
+    rows,
+  });
+  const lastLedgerId = rows[0]?.ledgerId ?? null;
+  const trustStateData = {
+    currentLevel: trustState.currentLevel,
+    regulatoryCeiling: trustState.regulatoryCeiling,
+    sampleCount: trustState.window.samples,
+    agreementCount: trustState.window.agreements,
+    agreementRate: trustState.agreementRate,
+    lastLedgerId,
+    recommendation: trustState.recommendation,
+    lastEvaluatedAt: new Date(),
+  };
+
+  await db.trustState.upsert({
+    where: {
+      agentId_activityType_riskClass: {
+        agentId: input.agentId,
+        activityType: input.activityType,
+        riskClass: input.riskClass,
+      },
+    },
+    create: {
+      agentId: input.agentId,
+      activityType: input.activityType,
+      riskClass: input.riskClass,
+      ...trustStateData,
+    },
+    update: trustStateData,
+  });
+
+  return {
+    ledgerIds,
+    regulatoryEvidence,
+    trustState,
+  };
+}

--- a/docs/superpowers/plans/2026-06-29-regulatory-autonomy-runtime-consumer.md
+++ b/docs/superpowers/plans/2026-06-29-regulatory-autonomy-runtime-consumer.md
@@ -1,0 +1,111 @@
+# Regulatory Autonomy Runtime Consumer Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `RegulatoryAutonomyPolicy` into runtime autonomy evaluation so Work Case / TAK shadow evidence uses the policy ceiling and persists resolver evidence to `DecisionShadowLedger` and `TrustState`.
+
+**Architecture:** Keep policy matching pure and reuse `resolveRegulatoryAutonomyCeiling`, `computeTrustStateFromLedger`, and `resolveWorkCaseAutonomyEnvelope`. Add one injectable runtime adapter that loads install context and policy rows, records bounded shadow ledger evidence, and refreshes the measured trust read model without promoting live autonomy. Wire the adapter into Living Playbook review because that is the first TAK/Work Case runtime consumer already carrying shadow trials and decision interactions.
+
+**Tech Stack:** Next.js server actions, Prisma 7, TypeScript, Vitest, existing autonomy and Work Case modules.
+
+---
+
+## File Structure
+
+- Create `apps/web/lib/autonomy/regulatory-autonomy-runtime.ts`
+  - Loads install region/archetype context.
+  - Loads active `RegulatoryAutonomyPolicy` rows.
+  - Resolves the effective ceiling for an activity class.
+  - Records shadow trial rows in `DecisionShadowLedger`.
+  - Recomputes and upserts `TrustState` for the `(agentId, activityType, riskClass)` triple.
+- Create `apps/web/lib/autonomy/regulatory-autonomy-runtime.test.ts`
+  - Tests default-safe policy resolution from DB context.
+  - Tests ledger rows carry `regulatoryPolicyId` and `regulatoryEvidence`.
+  - Tests `TrustState` is refreshed from ledger evidence while `currentLevel` remains caller-provided.
+- Modify `apps/web/lib/actions/work-pattern-review.ts`
+  - Call the runtime adapter during Living Playbook review after the `DecisionInteraction` exists.
+  - Prefer DB-resolved regulatory ceiling over stale evidence JSON when evaluating shadow evidence.
+  - Keep no live Work Case, skill, prompt, grant, or backlog mutation.
+- Modify `apps/web/lib/actions/work-pattern-review.test.ts`
+  - Assert policy rows are loaded, shadow ledger rows are created, and trust state is upserted.
+  - Keep assertions that live Work Case and prompt/skill/grant surfaces are not mutated.
+
+## Task 1: Runtime Adapter
+
+**Files:**
+- Create: `apps/web/lib/autonomy/regulatory-autonomy-runtime.test.ts`
+- Create: `apps/web/lib/autonomy/regulatory-autonomy-runtime.ts`
+
+- [x] **Step 1: Write failing DB-context policy test**
+
+Assert `resolveRuntimeRegulatoryAutonomyCeiling` reads `BusinessContext` regional fields, `StorefrontConfig.archetype.category`, and active policy rows, then returns a restrictive policy match.
+
+Run: `pnpm --filter web exec vitest run lib/autonomy/regulatory-autonomy-runtime.test.ts`
+
+Expected: fail because the module does not exist.
+
+- [x] **Step 2: Implement minimal context and policy loader**
+
+Create typed DB interfaces and the runtime resolver that delegates final matching to `resolveRegulatoryAutonomyCeiling`.
+
+- [x] **Step 3: Write failing ledger/trust refresh test**
+
+Assert `recordRegulatoryDecisionShadowEvidence` creates one ledger row per shadow trial with regulatory evidence and upserts `TrustState` from computed agreement state.
+
+- [x] **Step 4: Implement minimal ledger writer and trust updater**
+
+Use deterministic `ledgerId` values based on decision interaction, trial id, and index so retries skip duplicates. Do not mutate live autonomy; `TrustState.currentLevel` remains the evaluated level supplied by the caller.
+
+## Task 2: Work Pattern Review Wiring
+
+**Files:**
+- Modify: `apps/web/lib/actions/work-pattern-review.test.ts`
+- Modify: `apps/web/lib/actions/work-pattern-review.ts`
+
+- [x] **Step 1: Write failing server-action test**
+
+Mock `businessContext`, `storefrontConfig`, `regulatoryAutonomyPolicy`, `decisionShadowLedger`, and `trustState`. Approving a candidate with shadow trials should create ledger rows and upsert measured trust using the DB-resolved ceiling.
+
+Run: `pnpm --filter web exec vitest run lib/actions/work-pattern-review.test.ts`
+
+Expected: fail because no runtime adapter is invoked.
+
+- [x] **Step 2: Wire the runtime adapter into `recordWorkPatternReview`**
+
+Resolve policy before `buildWorkPatternReview`, pass the resolved ceiling into `evaluateWorkPatternShadowEvidence`, then record ledger/trust evidence inside the existing transaction after `DecisionInteraction` creation.
+
+- [x] **Step 3: Refactor local helper boundaries**
+
+Keep action code readable by extracting small helpers for activity class selection, ceiling selection, and runtime-evidence input construction. Do not refactor unrelated Work Case review behavior.
+
+## Task 3: Verification
+
+**Files:**
+- All changed files.
+
+- [x] **Step 1: Focused autonomy tests**
+
+Run: `pnpm --filter web exec vitest run lib/autonomy/regulatory-autonomy-runtime.test.ts lib/autonomy/regulatory-ceiling.test.ts lib/autonomy/trust-state.test.ts lib/autonomy/trust-graduation.test.ts`
+
+- [x] **Step 2: Focused action tests**
+
+Run: `pnpm --filter web exec vitest run lib/actions/work-pattern-review.test.ts lib/tak/work-pattern-shadow-evaluation.test.ts lib/work-management/autonomy-envelope.test.ts`
+
+- [x] **Step 3: Source-local typecheck**
+
+Run: `pnpm --filter web typecheck`
+
+- [x] **Step 4: Build gate**
+
+Run: `pnpm --filter web build`
+
+- [x] **Step 5: Record capsule evidence**
+
+Record test/build evidence on `WC-E6869BA0`. Runtime-bound live install verification remains a later self-upgrade/browser step after the branch lands.
+
+## Non-Goals
+
+- No regulatory policy management UI.
+- No seeded real regulatory content.
+- No external policy engine.
+- No live autonomy promotion, skill/prompt/grant mutation, Work Case mutation, or backlog mutation.


### PR DESCRIPTION
## Summary
- add an injectable regulatory autonomy runtime adapter that loads install context + active RegulatoryAutonomyPolicy rows, resolves the effective ceiling, writes DecisionShadowLedger evidence, and refreshes measured TrustState
- wire Living Playbook review to use the DB-resolved ceiling during shadow evaluation and persist ledger/trust evidence after DecisionInteraction creation
- add a durable implementation plan and focused tests for stale-policy protection, ledger evidence, and non-mutation of live Work Case/source surfaces

## Test Plan
- [x] pnpm --filter web exec vitest run lib/autonomy/regulatory-autonomy-runtime.test.ts lib/autonomy/regulatory-ceiling.test.ts lib/autonomy/trust-state.test.ts lib/autonomy/trust-graduation.test.ts
- [x] pnpm --filter web exec vitest run lib/actions/work-pattern-review.test.ts lib/tak/work-pattern-shadow-evaluation.test.ts lib/work-management/autonomy-envelope.test.ts
- [x] pnpm --filter web typecheck
- [x] pnpm --filter web build

## Notes
- Build exited 0. Existing Turbopack Edge/NFT warnings were emitted outside this slice.
- No migration or UI route is added in this slice.