### PR TITLE
refactor: split module-size ratchet blockers

### DIFF
--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -7,23 +7,14 @@ import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-con
 import type { LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
-import { engineReadinessBadgeContent, ENGINE_READINESS_TONE_COLOR } from "./engine-readiness-badge";
-import { ProvisionEngineButton } from "./ProvisionEngineButton";
 import { ContributorMcpReadinessCard } from "./ContributorMcpReadinessCard";
-
-type ProviderOption = {
-  providerId: string;
-  name: string;
-  status: string;
-  billingLabel: string | null;
-  costNotes: string | null;
-};
-
-type EngineReadinessBadge = {
-  present: boolean | null;
-  version: string | null;
-  lastProbedAt: string | null;
-};
+import {
+  CredentialCard,
+  isConfigured,
+  ProviderRadio,
+  type EngineReadinessBadge,
+  type ProviderOption,
+} from "./BuildStudioProviderControls";
 
 type Props = {
   config: BuildStudioDispatchConfig;
@@ -38,39 +29,11 @@ type Props = {
   canWrite: boolean;
 };
 
-// Credential status lifecycle: unconfigured -> pending (on save) -> ok (after OAuth/exchange) -> expired (on failure)
-const STATUS_COLORS: Record<string, string> = {
-  ok:           "var(--dpf-success)",
-  configured:   "var(--dpf-success)",
-  pending:      "var(--dpf-warning)",
-  unconfigured: "var(--dpf-muted)",
-  auth_failed:  "var(--dpf-error)",
-  expired:      "var(--dpf-error)",
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  ok:           "Connected",
-  configured:   "Configured",
-  pending:      "Credentials saved, not yet verified",
-  unconfigured: "Not configured",
-  auth_failed:  "Auth failed",
-  expired:      "Token expired",
-};
-
 const CLAUDE_MODELS = [
   { value: "haiku", label: "Haiku", desc: "fastest, cheapest" },
   { value: "sonnet", label: "Sonnet", desc: "best balance", recommended: true },
   { value: "opus", label: "Opus", desc: "most capable, slower" },
 ];
-
-// Subscription providers are identified by $0 input pricing (billing via subscription)
-function isSubscriptionProvider(p: ProviderOption): boolean {
-  return p.billingLabel !== null && p.billingLabel.toLowerCase().includes("subscription");
-}
-
-function isConfigured(status: string): boolean {
-  return status === "ok" || status === "configured" || status === "pending";
-}
 
 function describeOpenCodeProvider(providerId: string, providers: ProviderOption[]): {
   label: string;
@@ -703,178 +666,6 @@ export function BuildStudioConfigForm({
           {error && <span style={{ fontSize: 11, color: "var(--dpf-error)" }}>{error}</span>}
         </div>
       )}
-    </div>
-  );
-}
-
-// ─── Sub-components ──────────────────────────────────────────────────────────
-
-function EngineReadinessBadgeView({ readiness }: { readiness: EngineReadinessBadge }) {
-  const { icon, text, tone } = engineReadinessBadgeContent(readiness.present, readiness.version);
-  return (
-    <div
-      role="status"
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 4,
-        marginTop: 3,
-        fontSize: 10,
-        fontWeight: 600,
-        color: ENGINE_READINESS_TONE_COLOR[tone],
-      }}
-    >
-      <span aria-hidden="true">{icon}</span>
-      <span>{text}</span>
-    </div>
-  );
-}
-
-function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, unconfiguredMsg, readiness, canProvision }: {
-  name: string;
-  value: string;
-  checked: boolean;
-  onChange: () => void;
-  disabled: boolean;
-  label: string;
-  desc: string;
-  unconfiguredMsg?: string;
-  readiness?: EngineReadinessBadge;
-  canProvision?: boolean;
-}) {
-  return (
-    <label style={{
-      display: "flex",
-      alignItems: "flex-start",
-      gap: 8,
-      padding: "8px 10px",
-      borderRadius: 6,
-      border: checked ? "1px solid var(--dpf-accent)" : "1px solid var(--dpf-border)",
-      background: checked ? "color-mix(in srgb, var(--dpf-accent) 5%, transparent)" : "transparent",
-      cursor: disabled ? "not-allowed" : "pointer",
-      opacity: disabled ? 0.5 : 1,
-    }}>
-      <input type="radio" name={name} value={value} checked={checked} onChange={onChange} disabled={disabled} style={{ marginTop: 2 }} />
-      <div>
-        <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)" }}>{label}</div>
-        <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{desc}</div>
-        {readiness && <EngineReadinessBadgeView readiness={readiness} />}
-        {canProvision && readiness?.present === false && (
-          <ProvisionEngineButton engineId={value} label={value.charAt(0).toUpperCase() + value.slice(1)} />
-        )}
-        {unconfiguredMsg && (
-          <div style={{ fontSize: 10, color: "var(--dpf-warning)", marginTop: 2 }}>
-            {unconfiguredMsg}{" "}
-            <Link href="/platform/ai/providers" style={{ color: "var(--dpf-accent)", textDecoration: "underline" }}>
-              Set up in External Services
-            </Link>
-          </div>
-        )}
-      </div>
-    </label>
-  );
-}
-
-function CredentialCard({ title, providers, selectedId, onSelect, active, canWrite }: {
-  title: string;
-  providers: ProviderOption[];
-  selectedId: string;
-  onSelect: (id: string) => void;
-  active: boolean;
-  canWrite: boolean;
-}) {
-  return (
-    <div style={{
-      flex: "1 1 280px",
-      minWidth: 280,
-      padding: 12,
-      borderRadius: 6,
-      border: "1px solid var(--dpf-border)",
-      opacity: active ? 1 : 0.5,
-    }}>
-      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", marginBottom: 8 }}>{title}</div>
-
-      {providers.length === 0 ? (
-        <p style={{ fontSize: 11, color: "var(--dpf-muted)" }}>
-          No credentials configured.{" "}
-          <Link href="/platform/ai/providers" style={{ color: "var(--dpf-accent)", textDecoration: "underline" }}>
-            Set up in External Services
-          </Link>
-        </p>
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          {providers.map(p => {
-            const isSubscription = isSubscriptionProvider(p);
-            const credConfigured = isConfigured(p.status);
-            return (
-              <label
-                key={p.providerId}
-                style={{
-                  display: "flex",
-                  alignItems: "flex-start",
-                  gap: 8,
-                  padding: "6px 8px",
-                  borderRadius: 4,
-                  border: selectedId === p.providerId ? "1px solid var(--dpf-accent)" : "1px solid transparent",
-                  cursor: canWrite && credConfigured ? "pointer" : "not-allowed",
-                  opacity: credConfigured ? 1 : 0.5,
-                }}
-              >
-                <input
-                  type="radio"
-                  name={`${title}-cred`}
-                  value={p.providerId}
-                  checked={selectedId === p.providerId}
-                  onChange={() => onSelect(p.providerId)}
-                  disabled={!canWrite || !credConfigured}
-                  style={{ marginTop: 2 }}
-                />
-                <div style={{ flex: 1 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                    <span style={{ fontSize: 11, fontWeight: 500, color: "var(--dpf-text)" }}>{p.name}</span>
-                    {isSubscription && (
-                      <span style={{
-                        fontSize: 9,
-                        fontWeight: 600,
-                        padding: "1px 5px",
-                        borderRadius: 3,
-                        background: "color-mix(in srgb, var(--dpf-success) 15%, transparent)",
-                        color: "var(--dpf-success)",
-                      }}>
-                        Recommended
-                      </span>
-                    )}
-                  </div>
-                  <div style={{ display: "flex", alignItems: "center", gap: 4, marginTop: 2 }}>
-                    <span style={{
-                      width: 6,
-                      height: 6,
-                      borderRadius: "50%",
-                      background: STATUS_COLORS[p.status] ?? "var(--dpf-muted)",
-                      flexShrink: 0,
-                    }} />
-                    <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>
-                      {p.providerId} · {STATUS_LABELS[p.status] ?? p.status}
-                    </span>
-                  </div>
-                  {p.billingLabel && (
-                    <div style={{ fontSize: 10, color: "var(--dpf-muted)", marginTop: 2 }}>{p.billingLabel}</div>
-                  )}
-                  {isSubscription && p.costNotes && (
-                    <div style={{ fontSize: 10, color: "var(--dpf-success)", marginTop: 2 }}>{p.costNotes}</div>
-                  )}
-                </div>
-              </label>
-            );
-          })}
-        </div>
-      )}
-
-      <div style={{ marginTop: 8 }}>
-        <Link href="/platform/ai/providers" style={{ fontSize: 10, color: "var(--dpf-accent)", textDecoration: "underline" }}>
-          Manage credentials in External Services
-        </Link>
-      </div>
     </div>
   );
 }

--- a/apps/web/components/platform/BuildStudioProviderControls.tsx
+++ b/apps/web/components/platform/BuildStudioProviderControls.tsx
@@ -1,0 +1,214 @@
+import Link from "next/link";
+
+import { engineReadinessBadgeContent, ENGINE_READINESS_TONE_COLOR } from "./engine-readiness-badge";
+import { ProvisionEngineButton } from "./ProvisionEngineButton";
+
+export type ProviderOption = {
+  providerId: string;
+  name: string;
+  status: string;
+  billingLabel: string | null;
+  costNotes: string | null;
+};
+
+export type EngineReadinessBadge = {
+  present: boolean | null;
+  version: string | null;
+  lastProbedAt: string | null;
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  ok: "var(--dpf-success)",
+  configured: "var(--dpf-success)",
+  pending: "var(--dpf-warning)",
+  unconfigured: "var(--dpf-muted)",
+  auth_failed: "var(--dpf-error)",
+  expired: "var(--dpf-error)",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  ok: "Connected",
+  configured: "Configured",
+  pending: "Credentials saved, not yet verified",
+  unconfigured: "Not configured",
+  auth_failed: "Auth failed",
+  expired: "Token expired",
+};
+
+function isSubscriptionProvider(p: ProviderOption): boolean {
+  return p.billingLabel !== null && p.billingLabel.toLowerCase().includes("subscription");
+}
+
+export function isConfigured(status: string): boolean {
+  return status === "ok" || status === "configured" || status === "pending";
+}
+
+function EngineReadinessBadgeView({ readiness }: { readiness: EngineReadinessBadge }) {
+  const { icon, text, tone } = engineReadinessBadgeContent(readiness.present, readiness.version);
+  return (
+    <div
+      role="status"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        marginTop: 3,
+        fontSize: 10,
+        fontWeight: 600,
+        color: ENGINE_READINESS_TONE_COLOR[tone],
+      }}
+    >
+      <span aria-hidden="true">{icon}</span>
+      <span>{text}</span>
+    </div>
+  );
+}
+
+export function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, unconfiguredMsg, readiness, canProvision }: {
+  name: string;
+  value: string;
+  checked: boolean;
+  onChange: () => void;
+  disabled: boolean;
+  label: string;
+  desc: string;
+  unconfiguredMsg?: string;
+  readiness?: EngineReadinessBadge;
+  canProvision?: boolean;
+}) {
+  return (
+    <label style={{
+      display: "flex",
+      alignItems: "flex-start",
+      gap: 8,
+      padding: "8px 10px",
+      borderRadius: 6,
+      border: checked ? "1px solid var(--dpf-accent)" : "1px solid var(--dpf-border)",
+      background: checked ? "color-mix(in srgb, var(--dpf-accent) 5%, transparent)" : "transparent",
+      cursor: disabled ? "not-allowed" : "pointer",
+      opacity: disabled ? 0.5 : 1,
+    }}>
+      <input type="radio" name={name} value={value} checked={checked} onChange={onChange} disabled={disabled} style={{ marginTop: 2 }} />
+      <div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)" }}>{label}</div>
+        <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{desc}</div>
+        {readiness && <EngineReadinessBadgeView readiness={readiness} />}
+        {canProvision && readiness?.present === false && (
+          <ProvisionEngineButton engineId={value} label={value.charAt(0).toUpperCase() + value.slice(1)} />
+        )}
+        {unconfiguredMsg && (
+          <div style={{ fontSize: 10, color: "var(--dpf-warning)", marginTop: 2 }}>
+            {unconfiguredMsg}{" "}
+            <Link href="/platform/ai/providers" style={{ color: "var(--dpf-accent)", textDecoration: "underline" }}>
+              Set up in External Services
+            </Link>
+          </div>
+        )}
+      </div>
+    </label>
+  );
+}
+
+export function CredentialCard({ title, providers, selectedId, onSelect, active, canWrite }: {
+  title: string;
+  providers: ProviderOption[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+  active: boolean;
+  canWrite: boolean;
+}) {
+  return (
+    <div style={{
+      flex: "1 1 280px",
+      minWidth: 280,
+      padding: 12,
+      borderRadius: 6,
+      border: "1px solid var(--dpf-border)",
+      opacity: active ? 1 : 0.5,
+    }}>
+      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)", marginBottom: 8 }}>{title}</div>
+
+      {providers.length === 0 ? (
+        <p style={{ fontSize: 11, color: "var(--dpf-muted)" }}>
+          No credentials configured.{" "}
+          <Link href="/platform/ai/providers" style={{ color: "var(--dpf-accent)", textDecoration: "underline" }}>
+            Set up in External Services
+          </Link>
+        </p>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {providers.map(p => {
+            const isSubscription = isSubscriptionProvider(p);
+            const credConfigured = isConfigured(p.status);
+            return (
+              <label
+                key={p.providerId}
+                style={{
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: 8,
+                  padding: "6px 8px",
+                  borderRadius: 4,
+                  border: selectedId === p.providerId ? "1px solid var(--dpf-accent)" : "1px solid transparent",
+                  cursor: canWrite && credConfigured ? "pointer" : "not-allowed",
+                  opacity: credConfigured ? 1 : 0.5,
+                }}
+              >
+                <input
+                  type="radio"
+                  name={`${title}-cred`}
+                  value={p.providerId}
+                  checked={selectedId === p.providerId}
+                  onChange={() => onSelect(p.providerId)}
+                  disabled={!canWrite || !credConfigured}
+                  style={{ marginTop: 2 }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span style={{ fontSize: 11, fontWeight: 500, color: "var(--dpf-text)" }}>{p.name}</span>
+                    {isSubscription && (
+                      <span style={{
+                        fontSize: 9,
+                        fontWeight: 600,
+                        padding: "1px 5px",
+                        borderRadius: 3,
+                        background: "color-mix(in srgb, var(--dpf-success) 15%, transparent)",
+                        color: "var(--dpf-success)",
+                      }}>
+                        Recommended
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 4, marginTop: 2 }}>
+                    <span style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: STATUS_COLORS[p.status] ?? "var(--dpf-muted)",
+                      flexShrink: 0,
+                    }} />
+                    <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>
+                      {p.providerId} · {STATUS_LABELS[p.status] ?? p.status}
+                    </span>
+                  </div>
+                  {p.billingLabel && (
+                    <div style={{ fontSize: 10, color: "var(--dpf-muted)", marginTop: 2 }}>{p.billingLabel}</div>
+                  )}
+                  {isSubscription && p.costNotes && (
+                    <div style={{ fontSize: 10, color: "var(--dpf-success)", marginTop: 2 }}>{p.costNotes}</div>
+                  )}
+                </div>
+              </label>
+            );
+          })}
+        </div>
+      )}
+
+      <div style={{ marginTop: 8 }}>
+        <Link href="/platform/ai/providers" style={{ fontSize: 10, color: "var(--dpf-accent)", textDecoration: "underline" }}>
+          Manage credentials in External Services
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { lazyFs, lazyPath, lazyFsPromises } from "@/lib/shared/lazy-node";
-import { prisma, type Prisma } from "@dpf/db";
+import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import {
@@ -29,6 +29,7 @@ import {
 } from "@/lib/provider-catalog-reconciliation";
 import { activateProvider } from "@/lib/govern/activate-provider";
 import { seedAiProviderFinanceBridge } from "@/lib/finance/ai-provider-finance";
+import { autoConfigureBuildStudio } from "@/lib/ai-provider-build-studio-config";
 
 const OPENAI_OAUTH_LINKED_PROVIDERS = new Set(["codex", "chatgpt"]);
 const SHARED_ACCOUNT_LINKED_PROVIDERS = new Set(["zai"]);
@@ -321,94 +322,6 @@ export async function configureProvider(input: {
   await autoConfigureBuildStudio(input.providerId);
 
   return {};
-}
-
-/**
- * If no Build Studio config exists, automatically set it based on the
- * newly configured provider. If config exists but the relevant engine's
- * providerId is empty, fill it in.
- */
-async function autoConfigureBuildStudio(providerId: string): Promise<void> {
-  const buildProviderId = providerId === "zai" ? "zai-coding" : providerId;
-  const provider = await prisma.modelProvider.findUnique({
-    where: { providerId: buildProviderId },
-    select: { cliEngine: true },
-  });
-  if (!provider?.cliEngine) return; // Not a CLI-dispatchable provider
-
-  const cliEngine = provider.cliEngine as "claude" | "codex" | "grok" | "opencode";
-  const existing = await prisma.platformConfig.findUnique({
-    where: { key: "build-studio-dispatch" },
-  });
-
-  if (!existing) {
-    // No config at all — create one auto-selecting this engine
-    const config = {
-      provider: cliEngine,
-      claudeProviderId: cliEngine === "claude" ? buildProviderId : "",
-      codexProviderId: cliEngine === "codex" ? buildProviderId : "",
-      grokProviderId: cliEngine === "grok" ? buildProviderId : "",
-      opencodeProviderId: cliEngine === "opencode" ? buildProviderId : "",
-      claudeModel: "sonnet",
-      codexModel: "",
-      grokModel: "",
-      opencodeModel: "",
-    };
-    await prisma.platformConfig.create({
-      data: {
-        key: "build-studio-dispatch",
-        value: config as unknown as Prisma.InputJsonValue,
-      },
-    });
-    return;
-  }
-
-  // Config exists — fill in the provider ID if it's empty for this engine
-  if (existing.value && typeof existing.value === "object") {
-    const config = existing.value as Record<string, unknown>;
-    const claudeKey = "claudeProviderId";
-    const codexKey = "codexProviderId";
-    const grokKey = "grokProviderId";
-    const opencodeKey = "opencodeProviderId";
-
-    if (cliEngine === "claude" && !config[claudeKey]) {
-      config[claudeKey] = buildProviderId;
-      if (config.provider === "agentic" || (config.provider === "codex" && !config[codexKey])) {
-        config.provider = "claude";
-      }
-      await prisma.platformConfig.update({
-        where: { key: "build-studio-dispatch" },
-        data: { value: config as unknown as Prisma.InputJsonValue },
-      });
-    } else if (cliEngine === "codex" && !config[codexKey]) {
-      config[codexKey] = buildProviderId;
-      if (config.provider === "agentic") {
-        config.provider = "codex";
-      }
-      await prisma.platformConfig.update({
-        where: { key: "build-studio-dispatch" },
-        data: { value: config as unknown as Prisma.InputJsonValue },
-      });
-    } else if (cliEngine === "grok" && !config[grokKey]) {
-      config[grokKey] = buildProviderId;
-      if (config.provider === "agentic") {
-        config.provider = "grok";
-      }
-      await prisma.platformConfig.update({
-        where: { key: "build-studio-dispatch" },
-        data: { value: config as unknown as Prisma.InputJsonValue },
-      });
-    } else if (cliEngine === "opencode" && !config[opencodeKey]) {
-      config[opencodeKey] = buildProviderId;
-      if (config.provider === "agentic") {
-        config.provider = "opencode";
-      }
-      await prisma.platformConfig.update({
-        where: { key: "build-studio-dispatch" },
-        data: { value: config as unknown as Prisma.InputJsonValue },
-      });
-    }
-  }
 }
 
 // ─── Test provider auth ───────────────────────────────────────────────────────

--- a/apps/web/lib/ai-provider-build-studio-config.ts
+++ b/apps/web/lib/ai-provider-build-studio-config.ts
@@ -1,0 +1,87 @@
+import { prisma, type Prisma } from "@dpf/db";
+
+/**
+ * If no Build Studio config exists, automatically set it based on the newly
+ * configured provider. If config exists but the relevant engine's providerId is
+ * empty, fill it in.
+ */
+export async function autoConfigureBuildStudio(providerId: string): Promise<void> {
+  const buildProviderId = providerId === "zai" ? "zai-coding" : providerId;
+  const provider = await prisma.modelProvider.findUnique({
+    where: { providerId: buildProviderId },
+    select: { cliEngine: true },
+  });
+  if (!provider?.cliEngine) return;
+
+  const cliEngine = provider.cliEngine as "claude" | "codex" | "grok" | "opencode";
+  const existing = await prisma.platformConfig.findUnique({
+    where: { key: "build-studio-dispatch" },
+  });
+
+  if (!existing) {
+    const config = {
+      provider: cliEngine,
+      claudeProviderId: cliEngine === "claude" ? buildProviderId : "",
+      codexProviderId: cliEngine === "codex" ? buildProviderId : "",
+      grokProviderId: cliEngine === "grok" ? buildProviderId : "",
+      opencodeProviderId: cliEngine === "opencode" ? buildProviderId : "",
+      claudeModel: "sonnet",
+      codexModel: "",
+      grokModel: "",
+      opencodeModel: "",
+    };
+    await prisma.platformConfig.create({
+      data: {
+        key: "build-studio-dispatch",
+        value: config as unknown as Prisma.InputJsonValue,
+      },
+    });
+    return;
+  }
+
+  if (existing.value && typeof existing.value === "object") {
+    const config = existing.value as Record<string, unknown>;
+    const claudeKey = "claudeProviderId";
+    const codexKey = "codexProviderId";
+    const grokKey = "grokProviderId";
+    const opencodeKey = "opencodeProviderId";
+
+    if (cliEngine === "claude" && !config[claudeKey]) {
+      config[claudeKey] = buildProviderId;
+      if (config.provider === "agentic" || (config.provider === "codex" && !config[codexKey])) {
+        config.provider = "claude";
+      }
+      await prisma.platformConfig.update({
+        where: { key: "build-studio-dispatch" },
+        data: { value: config as unknown as Prisma.InputJsonValue },
+      });
+    } else if (cliEngine === "codex" && !config[codexKey]) {
+      config[codexKey] = buildProviderId;
+      if (config.provider === "agentic") {
+        config.provider = "codex";
+      }
+      await prisma.platformConfig.update({
+        where: { key: "build-studio-dispatch" },
+        data: { value: config as unknown as Prisma.InputJsonValue },
+      });
+    } else if (cliEngine === "grok" && !config[grokKey]) {
+      config[grokKey] = buildProviderId;
+      if (config.provider === "agentic") {
+        config.provider = "grok";
+      }
+      await prisma.platformConfig.update({
+        where: { key: "build-studio-dispatch" },
+        data: { value: config as unknown as Prisma.InputJsonValue },
+      });
+    } else if (cliEngine === "opencode" && !config[opencodeKey]) {
+      config[opencodeKey] = buildProviderId;
+      if (config.provider === "agentic") {
+        config.provider = "opencode";
+      }
+      await prisma.platformConfig.update({
+        where: { key: "build-studio-dispatch" },
+        data: { value: config as unknown as Prisma.InputJsonValue },
+      });
+    }
+  }
+}

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -14,11 +14,12 @@ import {
 } from "@/lib/ai-provider-types";
 import { extractModelCardWithFallback } from "@/lib/routing/adapter-registry";
 import { assignTierFromModelId, TIER_DIMENSION_BASELINES } from "@/lib/routing/quality-tiers";
-import { KNOWN_PROVIDER_MODELS, type KnownModel } from "@/lib/routing/known-provider-models";
+import { KNOWN_PROVIDER_MODELS } from "@/lib/routing/known-provider-models";
 import {
   backgroundModelEvalSkipReason,
   canQueueBackgroundModelEvals,
 } from "@/lib/routing/provider-eligibility";
+import { seedKnownModels } from "@/lib/inference/known-model-seeding";
 
 /**
  * Resolve the `supportsToolUse` value a metadata-sync should persist for a model,
@@ -1223,123 +1224,4 @@ export async function queueUncalibratedModelEvals(providerId: string): Promise<n
       err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
   }
   return models.length;
-}
-
-/**
- * Seed DiscoveredModel + ModelProfile from the known-model catalog.
- * Used for providers that can't call /v1/models (subscription OAuth, agent providers).
- */
-async function seedKnownModels(
-  providerId: string,
-  models: KnownModel[],
-): Promise<{ discovered: number; profiled: number }> {
-  let discovered = 0;
-  let profiled = 0;
-
-  for (const m of models) {
-    await prisma.discoveredModel.upsert({
-      where: { providerId_modelId: { providerId, modelId: m.modelId } },
-      create: {
-        providerId,
-        modelId: m.modelId,
-        rawMetadata: { id: m.modelId, source: "known_catalog" } as any,
-        lastSeenAt: new Date(),
-      },
-      update: {
-        rawMetadata: { id: m.modelId, source: "known_catalog" } as any,
-        lastSeenAt: new Date(),
-      },
-    });
-    discovered++;
-
-    const existing = await prisma.modelProfile.findUnique({
-      where: { providerId_modelId: { providerId, modelId: m.modelId } },
-      select: { qualityTierSource: true, profileSource: true, supportsToolUse: true },
-    });
-
-    const shouldWriteScores = !existing?.profileSource || existing.profileSource === "seed";
-    const isManuallySetCatalog = existing?.profileSource === "evaluated" || existing?.profileSource === "admin";
-    const shouldWriteTier = !existing?.qualityTierSource || existing.qualityTierSource !== "admin";
-
-    // Use per-model scores if provided, otherwise fall back to tier baselines
-    const scores = m.scores ?? {
-      reasoning: TIER_DIMENSION_BASELINES[m.qualityTier].reasoning,
-      codegen: TIER_DIMENSION_BASELINES[m.qualityTier].codegen,
-      toolFidelity: TIER_DIMENSION_BASELINES[m.qualityTier].toolFidelity,
-      instructionFollowingScore: TIER_DIMENSION_BASELINES[m.qualityTier].instructionFollowing,
-      structuredOutputScore: TIER_DIMENSION_BASELINES[m.qualityTier].structuredOutput,
-      conversational: TIER_DIMENSION_BASELINES[m.qualityTier].conversational,
-      contextRetention: TIER_DIMENSION_BASELINES[m.qualityTier].contextRetention,
-    };
-
-    const scoreFields = shouldWriteScores ? {
-      ...scores,
-      profileSource: "seed" as const,
-      profileConfidence: "medium" as const,
-    } : {};
-
-    const tierFields = shouldWriteTier ? {
-      qualityTier: m.qualityTier,
-      qualityTierSource: "auto" as const,
-    } : {};
-
-    await prisma.modelProfile.upsert({
-      where: { providerId_modelId: { providerId, modelId: m.modelId } },
-      create: {
-        providerId,
-        modelId: m.modelId,
-        friendlyName: m.friendlyName,
-        summary: m.summary,
-        capabilityCategory: m.capabilityCategory,
-        costTier: m.costTier,
-        bestFor: m.bestFor,
-        avoidFor: m.avoidFor,
-        modelClass: m.modelClass,
-        modelFamily: m.modelFamily,
-        modelStatus: m.defaultStatus,
-        retiredAt: m.defaultStatus === "retired" ? new Date() : null,
-        retiredReason: m.defaultStatus === "retired" || m.defaultStatus === "disabled"
-          ? (m.retiredReason ?? null)
-          : null,
-        maxContextTokens: m.maxContextTokens,
-        maxOutputTokens: m.maxOutputTokens,
-        inputModalities: m.inputModalities,
-        outputModalities: m.outputModalities,
-        capabilities: m.capabilities as any,
-        supportsToolUse: m.capabilities.toolUse ?? false,
-        qualityTier: m.qualityTier,
-        qualityTierSource: "auto",
-        ...scores,
-        profileSource: "seed",
-        profileConfidence: "medium",
-        generatedBy: "system:auto-discover",
-      },
-      update: {
-        friendlyName: m.friendlyName,
-        summary: m.summary,
-        modelClass: m.modelClass,
-        modelFamily: m.modelFamily,
-        modelStatus: m.defaultStatus,
-        retiredAt: m.defaultStatus === "retired" ? new Date() : null,
-        retiredReason: m.defaultStatus === "retired" || m.defaultStatus === "disabled"
-          ? (m.retiredReason ?? null)
-          : null,
-        maxContextTokens: m.maxContextTokens,
-        maxOutputTokens: m.maxOutputTokens,
-        inputModalities: m.inputModalities,
-        outputModalities: m.outputModalities,
-        capabilities: m.capabilities as any,
-        supportsToolUse: isManuallySetCatalog
-          ? (existing.supportsToolUse ?? m.capabilities.toolUse ?? false)
-          : (m.capabilities.toolUse ?? false),
-        ...scoreFields,
-        ...tierFields,
-        generatedBy: "system:auto-discover",
-      },
-    });
-    profiled++;
-  }
-
-  console.log(`[auto-discover] Seeded ${discovered} known models for ${JSON.stringify(providerId)}`);
-  return { discovered, profiled };
 }

--- a/apps/web/lib/inference/known-model-seeding.ts
+++ b/apps/web/lib/inference/known-model-seeding.ts
@@ -1,0 +1,122 @@
+import { prisma } from "@dpf/db";
+
+import type { KnownModel } from "@/lib/routing/known-provider-models";
+import { TIER_DIMENSION_BASELINES } from "@/lib/routing/quality-tiers";
+
+/**
+ * Seed DiscoveredModel + ModelProfile from the known-model catalog.
+ * Used for providers that can't call /v1/models (subscription OAuth, agent providers).
+ */
+export async function seedKnownModels(
+  providerId: string,
+  models: KnownModel[],
+): Promise<{ discovered: number; profiled: number }> {
+  let discovered = 0;
+  let profiled = 0;
+
+  for (const m of models) {
+    await prisma.discoveredModel.upsert({
+      where: { providerId_modelId: { providerId, modelId: m.modelId } },
+      create: {
+        providerId,
+        modelId: m.modelId,
+        rawMetadata: { id: m.modelId, source: "known_catalog" } as any,
+        lastSeenAt: new Date(),
+      },
+      update: {
+        rawMetadata: { id: m.modelId, source: "known_catalog" } as any,
+        lastSeenAt: new Date(),
+      },
+    });
+    discovered++;
+
+    const existing = await prisma.modelProfile.findUnique({
+      where: { providerId_modelId: { providerId, modelId: m.modelId } },
+      select: { qualityTierSource: true, profileSource: true, supportsToolUse: true },
+    });
+
+    const shouldWriteScores = !existing?.profileSource || existing.profileSource === "seed";
+    const isManuallySetCatalog = existing?.profileSource === "evaluated" || existing?.profileSource === "admin";
+    const shouldWriteTier = !existing?.qualityTierSource || existing.qualityTierSource !== "admin";
+
+    const scores = m.scores ?? {
+      reasoning: TIER_DIMENSION_BASELINES[m.qualityTier].reasoning,
+      codegen: TIER_DIMENSION_BASELINES[m.qualityTier].codegen,
+      toolFidelity: TIER_DIMENSION_BASELINES[m.qualityTier].toolFidelity,
+      instructionFollowingScore: TIER_DIMENSION_BASELINES[m.qualityTier].instructionFollowing,
+      structuredOutputScore: TIER_DIMENSION_BASELINES[m.qualityTier].structuredOutput,
+      conversational: TIER_DIMENSION_BASELINES[m.qualityTier].conversational,
+      contextRetention: TIER_DIMENSION_BASELINES[m.qualityTier].contextRetention,
+    };
+
+    const scoreFields = shouldWriteScores ? {
+      ...scores,
+      profileSource: "seed" as const,
+      profileConfidence: "medium" as const,
+    } : {};
+
+    const tierFields = shouldWriteTier ? {
+      qualityTier: m.qualityTier,
+      qualityTierSource: "auto" as const,
+    } : {};
+
+    await prisma.modelProfile.upsert({
+      where: { providerId_modelId: { providerId, modelId: m.modelId } },
+      create: {
+        providerId,
+        modelId: m.modelId,
+        friendlyName: m.friendlyName,
+        summary: m.summary,
+        capabilityCategory: m.capabilityCategory,
+        costTier: m.costTier,
+        bestFor: m.bestFor,
+        avoidFor: m.avoidFor,
+        modelClass: m.modelClass,
+        modelFamily: m.modelFamily,
+        modelStatus: m.defaultStatus,
+        retiredAt: m.defaultStatus === "retired" ? new Date() : null,
+        retiredReason: m.defaultStatus === "retired" || m.defaultStatus === "disabled"
+          ? (m.retiredReason ?? null)
+          : null,
+        maxContextTokens: m.maxContextTokens,
+        maxOutputTokens: m.maxOutputTokens,
+        inputModalities: m.inputModalities,
+        outputModalities: m.outputModalities,
+        capabilities: m.capabilities as any,
+        supportsToolUse: m.capabilities.toolUse ?? false,
+        qualityTier: m.qualityTier,
+        qualityTierSource: "auto",
+        ...scores,
+        profileSource: "seed",
+        profileConfidence: "medium",
+        generatedBy: "system:auto-discover",
+      },
+      update: {
+        friendlyName: m.friendlyName,
+        summary: m.summary,
+        modelClass: m.modelClass,
+        modelFamily: m.modelFamily,
+        modelStatus: m.defaultStatus,
+        retiredAt: m.defaultStatus === "retired" ? new Date() : null,
+        retiredReason: m.defaultStatus === "retired" || m.defaultStatus === "disabled"
+          ? (m.retiredReason ?? null)
+          : null,
+        maxContextTokens: m.maxContextTokens,
+        maxOutputTokens: m.maxOutputTokens,
+        inputModalities: m.inputModalities,
+        outputModalities: m.outputModalities,
+        capabilities: m.capabilities as any,
+        supportsToolUse: isManuallySetCatalog
+          ? (existing.supportsToolUse ?? m.capabilities.toolUse ?? false)
+          : (m.capabilities.toolUse ?? false),
+        ...scoreFields,
+        ...tierFields,
+        generatedBy: "system:auto-discover",
+      },
+    });
+    profiled++;
+  }
+
+  console.log(`[auto-discover] Seeded ${discovered} known models for ${JSON.stringify(providerId)}`);
+  return { discovered, profiled };
+}


### PR DESCRIPTION
## Summary
- split Build Studio provider radio/card controls out of the oversized config form
- move provider setup's Build Studio auto-config side effect into a focused helper
- move known-model catalog seeding into a focused inference helper

## Test Plan
- [x] node scripts/check-module-size.mjs
- [x] pnpm --filter web exec vitest run components/platform/BuildStudioConfigForm.test.ts lib/actions/ai-providers.test.ts lib/inference/ai-provider-internals.test.ts lib/inference/ai-providers.test.ts
- [x] pnpm --filter web typecheck
- [x] pnpm --filter web build

## Notes
- This fixes the current main Module Size Guard blocker that was failing PR #2509 before that PR's own diff was evaluated.
- Build exited 0. Existing Turbopack Edge/NFT warnings were emitted outside this slice.

Process-Spine-Decision: No durable design doc needed; this is a mechanical CI ratchet refactor that preserves behavior and restores the enforced module-size invariant.

UX-Fit-Decision: no-new-cognitive-load (manual UX-fit review; extraction-only refactor preserves the existing Build Studio controls, progressive disclosure, labels, and theme-token styling without adding a new operator choice).