### PR TITLE
fix(build): simplify Build Studio operator view

### DIFF
--- a/apps/web/components/build/ActionBanner.test.tsx
+++ b/apps/web/components/build/ActionBanner.test.tsx
@@ -45,12 +45,13 @@ describe("ActionBanner", () => {
       <ActionBanner
         state="ready"
         operatorStatus={{ label: "Waiting on you", intent: "accent" }}
-        sentence="Next: start implementation from Build Studio."
+        sentence="Next: start implementation. I will track the checks."
       />,
     );
+    expect(html).toContain("AI Coworker");
     expect(html).toContain("Waiting on you");
     expect(html).toContain('data-intent="accent"');
-    expect(html).toContain("Next: start implementation from Build Studio.");
+    expect(html).toContain("Next: start implementation. I will track the checks.");
   });
 
   it("does NOT render a 'Build Status' or 'Operational status' label", () => {

--- a/apps/web/components/build/ActionBanner.tsx
+++ b/apps/web/components/build/ActionBanner.tsx
@@ -105,6 +105,9 @@ export function ActionBanner({ state, operatorStatus, sentence, primaryAction, d
     >
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0 font-semibold text-[var(--dpf-muted)]">
+            AI Coworker
+          </span>
           {operatorStatus && (
             <StatusBadge
               intent={operatorStatus.intent}

--- a/apps/web/components/build/BuildDecisionLedgerBand.test.tsx
+++ b/apps/web/components/build/BuildDecisionLedgerBand.test.tsx
@@ -24,14 +24,31 @@ function entry(over: Partial<BuildDecisionLedgerEntry> = {}): BuildDecisionLedge
 describe("BuildDecisionLedgerBand", () => {
   it("renders the heading and an honest empty state when there are no entries", () => {
     const html = renderToStaticMarkup(<BuildDecisionLedgerBand entries={[]} />);
-    expect(html).toContain("The decisions we made");
-    expect(html).toContain("No decisions have been recorded");
+    expect(html).toContain("AI Coworker decision");
+    expect(html).toContain("No build decision is waiting on you");
   });
 
-  it("renders an entry's call, weighed options, why, governance tag, and open risks", () => {
+  it("summarizes the latest decision for the operator without dumping review prose", () => {
     const html = renderToStaticMarkup(
       <BuildDecisionLedgerBand entries={[entry({ unresolvedRisks: ["Coupon stacking unresolved"] })]} />,
     );
+    expect(html).toContain("AI Coworker decision");
+    expect(html).toContain("Current call: Keep this as one build");
+    expect(html).toContain("Why: Small enough to ship safely in one go.");
+    expect(html).toContain("Governed");
+    expect(html).toContain("AI Coworker is carrying 1 technical concern");
+    expect(html).not.toContain("Weighed:");
+    expect(html).not.toContain("Coupon stacking unresolved");
+  });
+
+  it("renders an entry's call, weighed options, why, governance tag, and open risks in engineer view", () => {
+    const html = renderToStaticMarkup(
+      <BuildDecisionLedgerBand
+        entries={[entry({ unresolvedRisks: ["Coupon stacking unresolved"] })]}
+        engineerView
+      />,
+    );
+    expect(html).toContain("The decisions we made");
     expect(html).toContain("Keep this as one build");
     expect(html).toContain("Keep as one vs Split into three");
     expect(html).toContain("Small enough to ship safely in one go.");
@@ -51,6 +68,7 @@ describe("BuildDecisionLedgerBand", () => {
             governance: false,
           }),
         ]}
+        engineerView
       />,
     );
     expect(html).toContain("Accepted the plan after peer review");

--- a/apps/web/components/build/BuildDecisionLedgerBand.tsx
+++ b/apps/web/components/build/BuildDecisionLedgerBand.tsx
@@ -20,9 +20,15 @@ const PHASE_LABEL: Record<BuildDecisionLedgerEntry["phase"], string> = {
 
 export function BuildDecisionLedgerBand({
   entries,
+  engineerView = false,
 }: {
   entries: readonly BuildDecisionLedgerEntry[];
+  engineerView?: boolean;
 }) {
+  if (!engineerView) {
+    return <OperatorDecisionSummary entries={entries} />;
+  }
+
   return (
     <section
       data-testid="build-decision-ledger-band"
@@ -99,4 +105,79 @@ export function BuildDecisionLedgerBand({
       )}
     </section>
   );
+}
+
+function OperatorDecisionSummary({
+  entries,
+}: {
+  entries: readonly BuildDecisionLedgerEntry[];
+}) {
+  const latest = entries[0] ?? null;
+  const openConcernCount = entries.reduce((sum, entry) => sum + entry.unresolvedRisks.length, 0);
+
+  return (
+    <section
+      data-testid="build-decision-ledger-band"
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 shadow-dpf-xs"
+    >
+      <div className="flex items-center gap-2">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+          className="text-[var(--dpf-muted)]"
+        >
+          <path d="M12 3v18M3 7l9-4 9 4M5 10v6m14-6v6M3 16l2 4h-4zM21 16l2 4h-4zM10 7h4" />
+        </svg>
+        <h3 className="m-0 text-sm font-semibold text-[var(--dpf-text)]">
+          AI Coworker decision
+        </h3>
+      </div>
+
+      {latest ? (
+        <div className="mt-2 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-[var(--dpf-text)]">
+              Current call: {latest.theCall}
+            </span>
+            <StatusBadge
+              intent={latest.source === "kernel" ? "accent" : "neutral"}
+              label={PHASE_LABEL[latest.phase]}
+              variant="soft"
+            />
+            {latest.governance && <StatusBadge intent="success" label="Governed" variant="soft" />}
+          </div>
+
+          {latest.theWhy && (
+            <p className="m-0 max-w-3xl text-xs leading-relaxed text-[var(--dpf-text-secondary)]">
+              Why: {compactOperatorDecisionLine(latest.theWhy)}
+            </p>
+          )}
+
+          <p className="m-0 text-xs text-[var(--dpf-muted)]">
+            {openConcernCount > 0
+              ? `AI Coworker is carrying ${openConcernCount} technical ${openConcernCount === 1 ? "concern" : "concerns"} in Engineer view.`
+              : "No extra decision is waiting on you."}
+            {entries.length > 1 ? ` ${entries.length - 1} more ${entries.length === 2 ? "decision is" : "decisions are"} tracked in Engineer view.` : ""}
+          </p>
+        </div>
+      ) : (
+        <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+          No build decision is waiting on you. AI Coworker will surface one here when your direction is needed.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function compactOperatorDecisionLine(value: string, maxLength = 180): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  const sentenceBreak = normalized.lastIndexOf(".", maxLength);
+  const cutAt = sentenceBreak >= 80 ? sentenceBreak + 1 : maxLength;
+  return `${normalized.slice(0, cutAt).trim()}...`;
 }

--- a/apps/web/components/build/BuildListItem.test.tsx
+++ b/apps/web/components/build/BuildListItem.test.tsx
@@ -167,7 +167,7 @@ describe("BuildListItem fleet density", () => {
     expect(html).not.toContain("Updated Apr");
   });
 
-  it("renders the phase mini-rail wrapper", () => {
+  it("renders a plain work status label instead of an unlabeled phase dot rail", () => {
     const html = renderToStaticMarkup(
       <BuildListItem
         build={makeBuild()}
@@ -180,12 +180,13 @@ describe("BuildListItem fleet density", () => {
         onDelete={vi.fn()}
       />,
     );
-    // PhaseMiniRail emits role=img + Active: <phase> in its aria-label.
-    expect(html).toMatch(/role="img"/);
-    expect(html).toContain("Active: build");
+    expect(html).toContain('data-testid="fleet-row-status"');
+    expect(html).toContain("Building");
+    expect(html).not.toContain(BUILD_STUDIO_TEST_IDS.phaseMiniRail);
+    expect(html).not.toContain("Active: build");
   });
 
-  it("renders QueueStateBadge when queueState !== 'idle'", () => {
+  it("renders queued state as plain text when queueState is not idle", () => {
     const html = renderToStaticMarkup(
       <BuildListItem
         build={makeBuild()}
@@ -199,8 +200,10 @@ describe("BuildListItem fleet density", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(html).toContain('aria-label="Queued, position 3"');
-    expect(html).toContain('data-kind="queued"');
+    expect(html).toContain('data-testid="fleet-row-status"');
+    expect(html).toContain("Waiting");
+    expect(html).not.toContain('aria-label="Queued, position 3"');
+    expect(html).not.toContain('data-kind="queued"');
   });
 
   it("omits the QueueStateBadge when queueState is 'idle' (or missing)", () => {
@@ -222,7 +225,7 @@ describe("BuildListItem fleet density", () => {
     expect(html).not.toContain('data-kind="blocked"');
   });
 
-  it("renders the attention dot when needsAttention is true", () => {
+  it("renders needs-attention as a plain operator status, not a standalone dot", () => {
     const html = renderToStaticMarkup(
       <BuildListItem
         build={makeBuild()}
@@ -236,11 +239,13 @@ describe("BuildListItem fleet density", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(html).toContain('data-testid="fleet-row-attention"');
-    expect(html).toContain('aria-label="Needs attention"');
+    expect(html).toContain('data-testid="fleet-row-status"');
+    expect(html).toContain("Needs you");
+    expect(html).not.toContain('data-testid="fleet-row-attention"');
+    expect(html).not.toContain('aria-label="Needs attention"');
   });
 
-  it("omits the attention dot when needsAttention is false (default)", () => {
+  it("omits the needs-you status when needsAttention is false (default)", () => {
     const html = renderToStaticMarkup(
       <BuildListItem
         build={makeBuild()}
@@ -253,7 +258,7 @@ describe("BuildListItem fleet density", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(html).not.toContain('data-testid="fleet-row-attention"');
+    expect(html).not.toContain("Needs you");
   });
 
   it("uses 4px left-border accent + aria-current for the active row (not just color)", () => {

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -31,6 +31,7 @@ function formatUpdatedAt(value: Date | string) {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
   }).format(new Date(value));
 }
 

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -6,8 +6,7 @@ import {
   FLEET_ROW_HEIGHT_CLASS,
 } from "./build-studio-layout";
 import { FleetDensityBar } from "./FleetDensityBar";
-import { PhaseMiniRail, type PhaseRailPhase } from "./PhaseMiniRail";
-import { QueueStateBadge, type BuildQueueState } from "./QueueStateBadge";
+import type { BuildQueueState } from "./QueueStateBadge";
 
 export type BuildListItemDensity = "comfortable" | "fleet";
 
@@ -22,10 +21,9 @@ type BuildListItemProps = {
   /** Optional density variant. Defaults to "comfortable" so existing callers
    *  render the legacy card. The fleet rail uses "fleet" for ≤32px rows. */
   density?: BuildListItemDensity;
-  /** Runtime queue state surfaced as a badge between the claim and the
-   *  attention dot. Used only by the fleet density variant. */
+  /** Runtime queue state surfaced as a plain status label. Fleet density only. */
   queueState?: BuildQueueState;
-  /** Render the attention dot when true. Fleet density only. */
+  /** Render "Needs you" as the row status when true. Fleet density only. */
   needsAttention?: boolean;
 };
 
@@ -34,27 +32,6 @@ function formatUpdatedAt(value: Date | string) {
     month: "short",
     day: "numeric",
   }).format(new Date(value));
-}
-
-/** Resolve which canonical PhaseMiniRail phase to render for an FB phase.
- *  The mini-rail only knows about the 5 canonical phases — failed/complete
- *  fall back to the closest sensible representation. */
-function toPhaseRailPhase(phase: FeatureBuildRow["phase"]): PhaseRailPhase {
-  switch (phase) {
-    case "ideate":
-    case "plan":
-    case "build":
-    case "review":
-    case "ship":
-      return phase;
-    case "complete":
-      return "ship";
-    case "failed":
-      // Treat terminal-failure as still-in-review for the mini-rail.
-      return "review";
-    default:
-      return "ideate";
-  }
 }
 
 export function BuildListItem({
@@ -145,7 +122,7 @@ export function BuildListItem({
 }
 
 /* ────────────────────────────────────────────────────────────────────────── */
-/* Fleet density — compact 32px row with phase mini-rail + queue badge.       */
+/* Fleet density — compact 32px row with a plain operator status.             */
 /* ────────────────────────────────────────────────────────────────────────── */
 
 type FleetRowProps = {
@@ -159,6 +136,67 @@ type FleetRowProps = {
   needsAttention: boolean;
 };
 
+type FleetRowStatus = {
+  label: string;
+  className: string;
+};
+
+function statusClassName(intent: "info" | "warning" | "danger" | "success" | "neutral"): string {
+  const base = "inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-none";
+  if (intent === "danger") {
+    return `${base} border-[var(--dpf-error)] bg-[var(--dpf-state-error)] text-[var(--dpf-error)]`;
+  }
+  if (intent === "warning") {
+    return `${base} border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] text-[var(--dpf-warning)]`;
+  }
+  if (intent === "success") {
+    return `${base} border-[var(--dpf-success)] bg-[var(--dpf-state-success)] text-[var(--dpf-success)]`;
+  }
+  if (intent === "info") {
+    return `${base} border-[var(--dpf-info)] bg-[var(--dpf-state-info)] text-[var(--dpf-info)]`;
+  }
+  return `${base} border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]`;
+}
+
+function deriveFleetRowStatus(
+  build: FeatureBuildRow,
+  queueState: BuildQueueState,
+  needsAttention: boolean,
+): FleetRowStatus {
+  if (needsAttention) {
+    return { label: "Needs you", className: statusClassName("danger") };
+  }
+
+  if (queueState.kind === "blocked") {
+    return { label: "Blocked", className: statusClassName("warning") };
+  }
+  if (queueState.kind === "queued") {
+    return { label: "Waiting", className: statusClassName("neutral") };
+  }
+  if (queueState.kind === "running") {
+    return { label: "Working", className: statusClassName("info") };
+  }
+
+  switch (build.phase) {
+    case "ideate":
+      return { label: "Designing", className: statusClassName("neutral") };
+    case "plan":
+      return { label: "Planning", className: statusClassName("neutral") };
+    case "build":
+      return { label: "Building", className: statusClassName("info") };
+    case "review":
+      return { label: "Reviewing", className: statusClassName("info") };
+    case "ship":
+      return { label: "Ready", className: statusClassName("warning") };
+    case "complete":
+      return { label: "Done", className: statusClassName("success") };
+    case "failed":
+      return { label: "Blocked", className: statusClassName("warning") };
+    default:
+      return { label: "Queued", className: statusClassName("neutral") };
+  }
+}
+
 function FleetDensityRow({
   build,
   active,
@@ -169,7 +207,7 @@ function FleetDensityRow({
   queueState,
   needsAttention,
 }: FleetRowProps) {
-  const railPhase = toPhaseRailPhase(build.phase);
+  const status = deriveFleetRowStatus(build, queueState, needsAttention);
   return (
     <div
       data-testid={BUILD_STUDIO_TEST_IDS.buildListItem}
@@ -204,7 +242,13 @@ function FleetDensityRow({
         onClick={onSelect}
         className="flex min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
       >
-        <PhaseMiniRail currentPhase={railPhase} />
+        <span
+          data-testid="fleet-row-status"
+          aria-label={`Status: ${status.label}`}
+          className={status.className}
+        >
+          {status.label}
+        </span>
         {build.phase === "build" && (
           <FleetDensityBar taskResults={build.taskResults} buildPlan={build.buildPlan} />
         )}
@@ -216,16 +260,6 @@ function FleetDensityRow({
           >
             ●
           </span>
-        )}
-        <QueueStateBadge state={queueState} />
-        {needsAttention && (
-          <span
-            role="img"
-            aria-label="Needs attention"
-            title="Needs your attention"
-            data-testid="fleet-row-attention"
-            className="inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full bg-[var(--dpf-error)] ring-1 ring-[var(--dpf-error)] ring-offset-1 ring-offset-[var(--dpf-surface-1)]"
-          />
         )}
         <span className="ml-auto min-w-0 truncate text-[11px] text-[var(--dpf-muted)]">
           {build.title}

--- a/apps/web/components/build/BuildOperatorContext.tsx
+++ b/apps/web/components/build/BuildOperatorContext.tsx
@@ -28,6 +28,7 @@ function formatOperatorDate(value: Date | string): string {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
   }).format(new Date(value));
 }
 

--- a/apps/web/components/build/BuildOperatorContext.tsx
+++ b/apps/web/components/build/BuildOperatorContext.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import type { FeatureBuildRow, BuildPhase } from "@/lib/feature-build-types";
+import type { BuildStudioBranchBadge } from "./build-studio-branch-badge";
+
+export function formatOperatorPhaseLabel(phase: BuildPhase): string {
+  switch (phase) {
+    case "ideate":
+      return "Designing";
+    case "plan":
+      return "Planning";
+    case "build":
+      return "Building";
+    case "review":
+      return "Reviewing";
+    case "ship":
+      return "Release decision";
+    case "complete":
+      return "Complete";
+    case "failed":
+      return "Blocked";
+    default:
+      return "Working";
+  }
+}
+
+function formatOperatorDate(value: Date | string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
+}
+
+function compactOperatorLine(value: string, maxLength = 190): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  const sentenceBreak = normalized.lastIndexOf(".", maxLength);
+  const cutAt = sentenceBreak >= 80 ? sentenceBreak + 1 : maxLength;
+  return `${normalized.slice(0, cutAt).trim()}...`;
+}
+
+export function BuildOperatorHeaderDetails({
+  build,
+  branchBadge,
+  engineerView,
+}: {
+  build: FeatureBuildRow;
+  branchBadge: BuildStudioBranchBadge | null;
+  engineerView: boolean;
+}) {
+  if (!engineerView) {
+    return (
+      <>
+        <span className="font-medium text-[var(--dpf-text)]">AI Coworker is handling this build.</span>
+        <span>&middot;</span>
+        <span>{formatOperatorPhaseLabel(build.phase)}</span>
+        <span>&middot;</span>
+        <span>Updated {formatOperatorDate(build.updatedAt)}</span>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <span data-testid="build-studio-build-id">{build.buildId}</span>
+      {build.originator && (
+        <>
+          <span>&middot;</span>
+          <span className="inline-flex items-center gap-1 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 font-medium text-[var(--dpf-text)]">
+            {build.originator.itemId}
+          </span>
+        </>
+      )}
+      {branchBadge && (
+        <>
+          <span>&middot;</span>
+          <span
+            className="inline-flex max-w-full min-w-0 items-center gap-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-1.5 py-0.5 font-mono"
+            title={branchBadge.title}
+          >
+            <svg className="shrink-0" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.5 2.5 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" />
+            </svg>
+            <span className="truncate">{branchBadge.value}</span>
+          </span>
+        </>
+      )}
+    </>
+  );
+}
+
+export function BuildWorkRequestStrip({
+  build,
+  onOpenWorkRequest,
+}: {
+  build: FeatureBuildRow;
+  onOpenWorkRequest: () => void;
+}) {
+  if (!build.originator) return null;
+
+  return (
+    <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">
+        <span className="font-semibold text-[var(--dpf-text)]">Work request</span>
+        <button
+          type="button"
+          onClick={onOpenWorkRequest}
+          title="Open the full work request"
+          className="inline-flex items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+          data-testid="build-studio-canonical-doc-trigger"
+        >
+          {build.originator.title}
+        </button>
+        <span className="inline-flex items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 font-medium text-[var(--dpf-muted)]">
+          {formatOperatorPhaseLabel(build.phase)}
+        </span>
+      </div>
+      {build.originator.resolution && (
+        <p className="mt-2 max-w-4xl text-xs leading-relaxed text-[var(--dpf-muted)]">
+          <span className="font-semibold text-[var(--dpf-text)]">Why it matters:</span>{" "}
+          {compactOperatorLine(build.originator.resolution)}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/build/BuildSolutionSummaryBand.test.tsx
+++ b/apps/web/components/build/BuildSolutionSummaryBand.test.tsx
@@ -19,6 +19,26 @@ describe("BuildSolutionSummaryBand", () => {
     expect(html).toContain("Apply 10% at checkout for customers with 5+ orders.");
   });
 
+  it("keeps technical implementation detail out of the operator summary", () => {
+    const html = renderToStaticMarkup(
+      <BuildSolutionSummaryBand
+        problemStatement="Build Studio currently lets operators start a build that cannot run, which wastes time and creates confusion."
+        proposedApproach={[
+          "Data Model: Use existing configuration and runtime evidence.",
+          "ModelProvider supplies whether a provider is active, inactive, local, remote, API-backed, or CLI-backed.",
+          "BuildEngine supplies local opencode execution if the project chooses it.",
+        ].join(" ")}
+        fallbackIntent={null}
+      />,
+    );
+
+    expect(html).toContain("Build Studio currently lets operators start a build");
+    expect(html).toContain("AI Coworker has the technical plan");
+    expect(html).not.toContain("Data Model");
+    expect(html).not.toContain("ModelProvider");
+    expect(html).not.toContain("BuildEngine");
+  });
+
   it("falls back to the captured intent when no design doc exists yet", () => {
     const html = renderToStaticMarkup(
       <BuildSolutionSummaryBand

--- a/apps/web/components/build/BuildSolutionSummaryBand.tsx
+++ b/apps/web/components/build/BuildSolutionSummaryBand.tsx
@@ -23,6 +23,27 @@ type Props = {
   fallbackIntent?: string | null;
 };
 
+const OPERATOR_SUMMARY_LIMIT = 260;
+const OPERATOR_APPROACH_LIMIT = 170;
+
+function normalizeCopy(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function compactCopy(value: string, maxLength: number): string {
+  const normalized = normalizeCopy(value);
+  if (normalized.length <= maxLength) return normalized;
+  const sentenceBreak = normalized.lastIndexOf(".", maxLength);
+  const cutAt = sentenceBreak >= 80 ? sentenceBreak + 1 : maxLength;
+  return `${normalized.slice(0, cutAt).trim()}...`;
+}
+
+function isTechnicalPlanCopy(value: string): boolean {
+  const normalized = normalizeCopy(value);
+  if (normalized.length > OPERATOR_APPROACH_LIMIT) return true;
+  return /\b(Data Model|ModelProvider|BuildEngine|API Route|server-side|tool-use|CLI-backed|opencode|schema|migration)\b/i.test(normalized);
+}
+
 export function BuildSolutionSummaryBand({
   problemStatement,
   proposedApproach,
@@ -31,6 +52,10 @@ export function BuildSolutionSummaryBand({
   const problem = problemStatement?.trim() || null;
   const approach = proposedApproach?.trim() || null;
   const fallback = fallbackIntent?.trim() || null;
+  const primaryCopy = problem ?? fallback;
+  const operatorProblem = primaryCopy ? compactCopy(primaryCopy, OPERATOR_SUMMARY_LIMIT) : null;
+  const showApproach = approach != null && !isTechnicalPlanCopy(approach);
+  const operatorApproach = showApproach ? compactCopy(approach, OPERATOR_APPROACH_LIMIT) : null;
 
   // Nothing to say yet → render nothing (the caller also gates, but stay safe).
   if (!problem && !approach && !fallback) return null;
@@ -59,21 +84,19 @@ export function BuildSolutionSummaryBand({
         </h3>
       </div>
 
-      {problem ? (
-        <p className="mt-2 text-sm leading-relaxed text-[var(--dpf-text)]">{problem}</p>
-      ) : fallback ? (
-        <p className="mt-2 text-sm leading-relaxed text-[var(--dpf-text)]">{fallback}</p>
+      {operatorProblem ? (
+        <p className="mt-2 text-sm leading-relaxed text-[var(--dpf-text)]">{operatorProblem}</p>
       ) : null}
 
-      {approach ? (
+      {operatorApproach ? (
         <p className="mt-1 text-xs leading-relaxed text-[var(--dpf-text-secondary)]">
-          {approach}
+          {operatorApproach}
+        </p>
+      ) : approach ? (
+        <p className="mt-2 text-[11px] font-medium text-[var(--dpf-muted)]">
+          AI Coworker has the technical plan.
         </p>
       ) : null}
-
-      <p className="mt-2 text-[11px] text-[var(--dpf-muted)]">
-        Use &ldquo;Open live preview&rdquo; at the bottom to see it running.
-      </p>
     </section>
   );
 }

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -27,11 +27,11 @@ import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
 import { BuildListItem } from "./BuildListItem";
 import { EpicRollupListItem } from "./EpicRollupListItem";
 import {
-  DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP,
   deriveFleetCounts,
   deriveNeedsAttention,
   deriveQueueState,
-  formatFleetHeader,
+  formatOperatorFocusHeader,
+  isOperatorFocusEntry,
 } from "./fleet-derivation";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
@@ -1140,6 +1140,7 @@ function BsQueueSection({ builds }: { builds: readonly FeatureBuildRow[] }) {
   }));
   const kindRank = { running: 0, blocked: 1, queued: 2, idle: 3 } as const;
   const sorted = [...entries].sort((a, b) => {
+    if (a.needsAttention !== b.needsAttention) return a.needsAttention ? -1 : 1;
     const ra = kindRank[a.queueState.kind];
     const rb = kindRank[b.queueState.kind];
     if (ra !== rb) return ra - rb;
@@ -1425,51 +1426,82 @@ function FleetRailZone({
     return a.build.buildId.localeCompare(b.build.buildId);
   });
 
-  // Split entries into active (needs attention) vs completed (historical). The
-  // fleet rail surfaces what needs attention; completed work is one click away
-  // via the "{N} completed" toggle below. Current-work overflow is folded by
-  // default so the operator sees a bounded list, not the entire backlog.
-  const activeEntries = sorted.filter((e) => e.build.phase !== "complete");
+  // Split entries into focus work, parked coworker-custody work, and completed
+  // history. Quiet ideation/planning probes stay out of the operator's default
+  // list until they run, block, ask for a decision, or are selected.
+  const nonCompletedEntries = sorted.filter((e) => e.build.phase !== "complete");
+  const focusEntries = nonCompletedEntries.filter((entry) =>
+    isOperatorFocusEntry(entry, activeBuildId),
+  );
+  const parkedEntries = nonCompletedEntries.filter((entry) =>
+    !isOperatorFocusEntry(entry, activeBuildId),
+  );
   const completedEntries = sorted.filter((e) => e.build.phase === "complete");
-  const activeEpicRollups = epicRollups.filter((rollup) => rollup.status !== "complete");
+  const isFocusRollup = (rollup: EpicRollupView) => {
+    if (rollup.status === "complete") return false;
+    if (rollup.status === "needs-attention" || rollup.status === "blocked") return true;
+    if (rollup.children.some((child) => child.buildId === activeBuildId)) return true;
+    return rollup.children.some((child) => child.phase === "build" || child.phase === "review");
+  };
+  const focusEpicRollups = epicRollups.filter(isFocusRollup);
+  const parkedEpicRollups = epicRollups.filter((rollup) =>
+    rollup.status !== "complete" && !isFocusRollup(rollup),
+  );
   const completedEpicRollups = epicRollups.filter((rollup) => rollup.status === "complete");
   const completedItemCount = completedEntries.length + completedEpicRollups.length;
   const [showCompleted, setShowCompleted] = useState(false);
-  const [showAllActive, setShowAllActive] = useState(false);
+  const [showAllFocus, setShowAllFocus] = useState(false);
 
-  const counts = deriveFleetCounts(entries.map((e) => e.queueState));
-  const wipSlotCap = Math.max(DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP, counts.runningCount);
-  const totalActiveItemCount = activeEpicRollups.length + activeEntries.length;
-  const shouldCollapseActive = totalActiveItemCount > MAX_OPERATOR_FLEET_ITEMS && !showAllActive;
+  const counts = deriveFleetCounts(focusEntries.map((e) => e.queueState));
+  const parkedItemCount = parkedEntries.length + parkedEpicRollups.length;
+  const needsYouCount =
+    focusEntries.filter((entry) => entry.needsAttention).length
+    + focusEpicRollups.filter((rollup) => rollup.status === "needs-attention").length;
+  const blockedCount =
+    focusEntries.filter((entry) => !entry.needsAttention && entry.queueState.kind === "blocked").length
+    + focusEpicRollups.filter((rollup) => rollup.status === "blocked").length;
+  const workingEpicCount = focusEpicRollups.filter((rollup) =>
+    rollup.status === "in-progress"
+    && rollup.children.some((child) => child.phase === "build" || child.phase === "review"),
+  ).length;
+  const focusHeaderLabel = formatOperatorFocusHeader({
+    needsYouCount,
+    workingCount: counts.runningCount + workingEpicCount,
+    blockedCount,
+    queuedCount: counts.queuedCount,
+    parkedCount: parkedItemCount,
+  });
+  const totalFocusItemCount = focusEpicRollups.length + focusEntries.length;
+  const shouldCollapseFocus = totalFocusItemCount > MAX_OPERATOR_FLEET_ITEMS && !showAllFocus;
 
-  let visibleActiveEpicRollups = activeEpicRollups;
-  let visibleActiveEntries = activeEntries;
-  if (shouldCollapseActive) {
-    const activeEpicIndex = activeEpicRollups.findIndex((rollup) =>
+  let visibleFocusEpicRollups = focusEpicRollups;
+  let visibleFocusEntries = focusEntries;
+  if (shouldCollapseFocus) {
+    const activeEpicIndex = focusEpicRollups.findIndex((rollup) =>
       rollup.children.some((child) => child.buildId === activeBuildId),
     );
-    const activeEntryIndex = activeEntries.findIndex((entry) => entry.build.buildId === activeBuildId);
-    visibleActiveEpicRollups = activeEpicRollups.slice(0, Math.min(MAX_OPERATOR_FLEET_ITEMS, activeEpicRollups.length));
-    let remainingSlots = Math.max(0, MAX_OPERATOR_FLEET_ITEMS - visibleActiveEpicRollups.length);
+    const activeEntryIndex = focusEntries.findIndex((entry) => entry.build.buildId === activeBuildId);
+    visibleFocusEpicRollups = focusEpicRollups.slice(0, Math.min(MAX_OPERATOR_FLEET_ITEMS, focusEpicRollups.length));
+    let remainingSlots = Math.max(0, MAX_OPERATOR_FLEET_ITEMS - visibleFocusEpicRollups.length);
 
-    if (activeEpicIndex >= MAX_OPERATOR_FLEET_ITEMS && visibleActiveEpicRollups.length > 0) {
-      visibleActiveEpicRollups = [
-        ...visibleActiveEpicRollups.slice(0, MAX_OPERATOR_FLEET_ITEMS - 1),
-        activeEpicRollups[activeEpicIndex],
+    if (activeEpicIndex >= MAX_OPERATOR_FLEET_ITEMS && visibleFocusEpicRollups.length > 0) {
+      visibleFocusEpicRollups = [
+        ...visibleFocusEpicRollups.slice(0, MAX_OPERATOR_FLEET_ITEMS - 1),
+        focusEpicRollups[activeEpicIndex],
       ];
       remainingSlots = 0;
     }
 
-    visibleActiveEntries = activeEntries.slice(0, remainingSlots);
+    visibleFocusEntries = focusEntries.slice(0, remainingSlots);
     if (activeEntryIndex >= remainingSlots && remainingSlots > 0) {
-      visibleActiveEntries = [
-        ...visibleActiveEntries.slice(0, remainingSlots - 1),
-        activeEntries[activeEntryIndex],
+      visibleFocusEntries = [
+        ...visibleFocusEntries.slice(0, remainingSlots - 1),
+        focusEntries[activeEntryIndex],
       ];
     }
   }
-  const hiddenActiveItemCount =
-    totalActiveItemCount - visibleActiveEpicRollups.length - visibleActiveEntries.length;
+  const hiddenFocusItemCount =
+    totalFocusItemCount - visibleFocusEpicRollups.length - visibleFocusEntries.length;
 
   useEffect(() => {
     if (!activeBuildId) return;
@@ -1510,30 +1542,27 @@ function FleetRailZone({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* Compact fleet header — surfaces in-flight aggregate so the
-          operator can see queue pressure without opening every build.
-          Click opens the DetailsDrawer's BS-Queue section. */}
+      {/* Compact fleet header — summarizes the focus queue while quiet work
+          stays under AI Coworker custody. Click opens the DetailsDrawer's
+          BS-Queue section for the full diagnostic view. */}
       <button
         type="button"
         onClick={onOpenQueueDrawer}
         role="status"
         aria-live="polite"
-        aria-label={`Open build details drawer - queue section. ${formatFleetHeader(counts.runningCount, wipSlotCap, counts.queuedCount)}`}
+        aria-label={`Open build details drawer - queue section. ${focusHeaderLabel}`}
         data-testid="build-studio-fleet-header"
         className="flex w-full shrink-0 cursor-pointer items-center justify-between border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-left text-[11px] font-semibold text-[var(--dpf-text)] transition-colors hover:bg-[var(--dpf-surface-3)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
       >
         <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-1">
           <span className="truncate">
-            {formatFleetHeader(counts.runningCount, wipSlotCap, counts.queuedCount)}
+            {focusHeaderLabel}
           </span>
-          {counts.blockedCount > 0 && (
-            <> · <span className="text-[var(--dpf-warning)]">{counts.blockedCount} blocked</span></>
-          )}
         </span>
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">›</span>
       </button>
       <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1" data-testid="fleet-rail-body">
-        {visibleActiveEpicRollups.map((rollup, idx) => (
+        {visibleFocusEpicRollups.map((rollup, idx) => (
           <li key={rollup.epicId}>
             <EpicRollupListItem
               rollup={rollup}
@@ -1545,12 +1574,12 @@ function FleetRailZone({
             />
           </li>
         ))}
-        {visibleActiveEntries.map((entry, idx) => (
+        {visibleFocusEntries.map((entry, idx) => (
           <li key={entry.build.buildId}>
             <BuildListItem
               build={entry.build}
               active={activeBuildId === entry.build.buildId}
-              index={visibleActiveEpicRollups.length + idx}
+              index={visibleFocusEpicRollups.length + idx}
               lifecycleLabel={entry.lifecycleLabel}
               isDevEnvironment={isDevEnvironment}
               density="fleet"
@@ -1561,29 +1590,40 @@ function FleetRailZone({
             />
           </li>
         ))}
-        {visibleActiveEpicRollups.length === 0 && visibleActiveEntries.length === 0 && (
+        {visibleFocusEpicRollups.length === 0 && visibleFocusEntries.length === 0 && (
           <li className="px-3 py-6 text-center text-[11px] text-[var(--dpf-muted)]">
-            No active builds. Type a feature name above and click "Start a new build" to start.
+            Nothing needs you right now. AI Coworker is watching the build queue.
           </li>
         )}
-        {totalActiveItemCount > MAX_OPERATOR_FLEET_ITEMS && (
+        {parkedItemCount > 0 && (
+          <li>
+            <button
+              type="button"
+              onClick={onOpenQueueDrawer}
+              className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-left text-[11px] leading-snug text-[var(--dpf-muted)] transition-colors hover:bg-[var(--dpf-surface-3)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+            >
+              AI Coworker is watching {parkedItemCount} parked build{parkedItemCount === 1 ? "" : "s"}. Open details for the full queue.
+            </button>
+          </li>
+        )}
+        {totalFocusItemCount > MAX_OPERATOR_FLEET_ITEMS && (
           <li>
             <div className="mt-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[11px] leading-snug text-[var(--dpf-muted)]">
               <p>
-                {showAllActive
-                  ? "AI Coworker is tracking all current builds."
-                  : `AI Coworker is tracking ${hiddenActiveItemCount} more build${hiddenActiveItemCount === 1 ? "" : "s"}.`}
+                {showAllFocus
+                  ? "AI Coworker is showing all focus work."
+                  : `AI Coworker is keeping ${hiddenFocusItemCount} more focus build${hiddenFocusItemCount === 1 ? "" : "s"} ready.`}
               </p>
               <button
                 type="button"
-                onClick={() => setShowAllActive((v) => !v)}
-                aria-expanded={showAllActive}
+                onClick={() => setShowAllFocus((v) => !v)}
+                aria-expanded={showAllFocus}
                 data-testid="fleet-rail-active-toggle"
                 className="mt-1 inline-flex rounded px-0 text-[11px] font-semibold text-[var(--dpf-accent)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
               >
-                {showAllActive
-                  ? "Show fewer builds"
-                  : `Show ${hiddenActiveItemCount} more build${hiddenActiveItemCount === 1 ? "" : "s"}`}
+                {showAllFocus
+                  ? "Show fewer focus builds"
+                  : `Show ${hiddenFocusItemCount} more focus build${hiddenFocusItemCount === 1 ? "" : "s"}`}
               </button>
             </div>
           </li>
@@ -1616,7 +1656,7 @@ function FleetRailZone({
                         rollup={rollup}
                         activeBuildId={activeBuildId}
                         expanded={expandedEpicIds.has(rollup.epicId)}
-                        index={visibleActiveEpicRollups.length + visibleActiveEntries.length + idx}
+                        index={visibleFocusEpicRollups.length + visibleFocusEntries.length + idx}
                         onToggle={() => toggleEpic(rollup.epicId)}
                         onSelectBuild={onSelectBuildById}
                       />
@@ -1627,7 +1667,7 @@ function FleetRailZone({
                       <BuildListItem
                         build={entry.build}
                         active={activeBuildId === entry.build.buildId}
-                        index={visibleActiveEpicRollups.length + visibleActiveEntries.length + completedEpicRollups.length + idx}
+                        index={visibleFocusEpicRollups.length + visibleFocusEntries.length + completedEpicRollups.length + idx}
                         lifecycleLabel={entry.lifecycleLabel}
                         isDevEnvironment={isDevEnvironment}
                         density="fleet"

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -708,6 +708,7 @@ export function BuildStudio({
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-[var(--dpf-surface-1)]">
           <PortalContextStrip
             envelope={portalContext ?? null}
+            contextLabel="Build context"
             showInternalIds={engineerView}
           />
           {activeBuild ? (
@@ -828,7 +829,7 @@ export function BuildStudio({
                 )}
                 {decisionLedger.length > 0 && (
                   <div className="border-b border-[var(--dpf-border)] px-4 py-3">
-                    <BuildDecisionLedgerBand entries={decisionLedger} />
+                    <BuildDecisionLedgerBand entries={decisionLedger} engineerView={engineerView} />
                   </div>
                 )}
                 {/* Workflow graph — always-visible primary surface of the

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -33,12 +33,12 @@ import {
   deriveQueueState,
   formatFleetHeader,
 } from "./fleet-derivation";
-import { QueueStateBadge } from "./QueueStateBadge";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
 import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
 import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
 import { BuildSolutionSummaryBand } from "./BuildSolutionSummaryBand";
+import { BuildOperatorHeaderDetails, BuildWorkRequestStrip, formatOperatorPhaseLabel } from "./BuildOperatorContext";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
 import { createFeatureBuild, deleteFeatureBuild } from "@/lib/actions/build";
 import { getFeatureBuild } from "@/lib/actions/build-read";
@@ -102,6 +102,8 @@ const MISSING_BOM_SUMMARY: BomSummary = {
   },
 };
 
+const MAX_OPERATOR_FLEET_ITEMS = 4;
+
 /** Map the build's lifecycle phase onto the 5-dot overseer phase rail. */
 function toRailPhase(phase: BuildPhase): PhaseRailPhase {
   switch (phase) {
@@ -146,9 +148,8 @@ export function BuildStudio({
   // DetailsDrawer accordion (PR #912's DetailsDrawer + this slice).
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerInitialSectionId, setDrawerInitialSectionId] = useState<string | null>(null);
-  // BI-63EAD801: collapse internal IDs / git branch chip by default so
+  // BI-63EAD801: keep internal IDs / git branch chip behind Engineer view so
   // end-users (Dale) don't see FB-*, WC-*, and raw branch names in the header.
-  // Engineering users can expand with one click; state persists to localStorage.
   const BUILD_DETAILS_KEY = "dpf:build-studio-header-details-expanded";
   const [headerDetailsExpanded, setHeaderDetailsExpanded] = useState(() => {
     if (typeof window === "undefined") return false;
@@ -666,10 +667,9 @@ export function BuildStudio({
           )}
 
           {/* Fleet rail (compact density) — replaces the legacy comfortable
-              build cards. Per spec §1: one row per in-flight build, ≤32px
-              tall, phase mini-rail + queue badge + needs-attention dot.
-              Order: running → blocked → queued → idle. Falls back to FB
-              ascending for same-kind tie-break. */}
+              build cards. Rows use plain operator status labels; overflow is
+              folded under AI Coworker custody. Order: running → blocked →
+              queued → idle. Falls back to FB ascending for same-kind tie-break. */}
           <FleetRailZone
             buildRows={buildRows}
             epicRollups={rollupRows}
@@ -708,7 +708,7 @@ export function BuildStudio({
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-[var(--dpf-surface-1)]">
           <PortalContextStrip
             envelope={portalContext ?? null}
-            showInternalIds={engineerView || headerDetailsExpanded}
+            showInternalIds={engineerView}
           />
           {activeBuild ? (
             <>
@@ -724,11 +724,9 @@ export function BuildStudio({
                     <ClaimBadge agentId={activeBuild.claimedByAgentId ?? null} claimStatus={activeBuild.claimStatus ?? null} claimedAt={activeBuild.claimedAt ?? null} />
                   </div>
                   {/* BI-63EAD801 (D13): Internal IDs and git branch chip are
-                      hidden from default view — end-users (Dale) have no use
-                      for FB-*, WC-*, or raw branch names. A "Details" toggle
-                      reveals them for engineering workflows. State persists to
-                      localStorage so engineers don't have to re-expand every
-                      session. */}
+                      hidden from the operator view — end-users (Dale) have no
+                      use for FB-*, WC-*, or raw branch names. Engineer view is
+                      the explicit opt-in for those details. */}
                   <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">
                     <button
                       type="button"
@@ -746,24 +744,11 @@ export function BuildStudio({
                         className="flex flex-wrap items-center gap-2"
                         data-testid="build-studio-header-details"
                       >
-                        <span data-testid="build-studio-build-id">{activeBuild.buildId}</span>
-                        {activeBuild.originator && (
-                          <>
-                            <span>&middot;</span>
-                            <span className="inline-flex items-center gap-1 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 font-medium text-[var(--dpf-text)]">
-                              {activeBuild.originator.itemId}
-                            </span>
-                          </>
-                        )}
-                        {branchBadge && (
-                          <>
-                            <span>&middot;</span>
-                            <span className="inline-flex max-w-full min-w-0 items-center gap-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-1.5 py-0.5 font-mono" title={branchBadge.title}>
-                              <svg className="shrink-0" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.5 2.5 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" /></svg>
-                              <span className="truncate">{branchBadge.value}</span>
-                            </span>
-                          </>
-                        )}
+                        <BuildOperatorHeaderDetails
+                          build={activeBuild}
+                          branchBadge={branchBadge}
+                          engineerView={engineerView}
+                        />
                       </span>
                     )}
                   </div>
@@ -776,37 +761,13 @@ export function BuildStudio({
               )}
 
               <div className="flex min-h-0 flex-1 flex-col">
-                {activeBuild.originator && (
-                  <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">
-                      <span className="font-semibold text-[var(--dpf-text)]">Canonical backlog item</span>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setDrawerInitialSectionId("canonical-doc");
-                          setDrawerOpen(true);
-                        }}
-                        title="Open the full description and Scout findings"
-                        className="inline-flex items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
-                        data-testid="build-studio-canonical-doc-trigger"
-                      >
-                        {activeBuild.originator.title}
-                      </button>
-                    </div>
-                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">
-                      <span>Status: {activeBuild.originator.status}</span>
-                      {activeBuild.originator.triageOutcome && (
-                        <span>Triage: {activeBuild.originator.triageOutcome}</span>
-                      )}
-                      {activeBuild.originator.effortSize && (
-                        <span>Size: {activeBuild.originator.effortSize}</span>
-                      )}
-                      {activeBuild.originator.resolution && (
-                        <span>Decision: {activeBuild.originator.resolution}</span>
-                      )}
-                    </div>
-                  </div>
-                )}
+                <BuildWorkRequestStrip
+                  build={activeBuild}
+                  onOpenWorkRequest={() => {
+                    setDrawerInitialSectionId("canonical-doc");
+                    setDrawerOpen(true);
+                  }}
+                />
                 {activeBuild && activeBuild.phase === "ship" && (
                   <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
                     <ReleaseDecisionPanel
@@ -999,7 +960,7 @@ export function BuildStudio({
           driver replaces the dishonest per-build Preview tab). */}
       <BuildStudioFooter
         builds={supervisedBuildRows}
-        showDrivingBuildCode={engineerView || headerDetailsExpanded}
+        showDrivingBuildCode={engineerView}
       />
     </div>
   );
@@ -1187,17 +1148,24 @@ function BsQueueSection({ builds }: { builds: readonly FeatureBuildRow[] }) {
     return a.build.buildId.localeCompare(b.build.buildId);
   });
   const counts = deriveFleetCounts(entries.map((e) => e.queueState));
+  const labelForQueueState = (entry: (typeof entries)[number]) => {
+    if (entry.needsAttention) return "Needs you";
+    if (entry.queueState.kind === "running") return "Working";
+    if (entry.queueState.kind === "blocked") return "Blocked";
+    if (entry.queueState.kind === "queued") return `Waiting ${entry.queueState.position}`;
+    return formatOperatorPhaseLabel(entry.build.phase);
+  };
 
   return (
     <div className="flex flex-col gap-2">
       <p className="text-[var(--dpf-muted)]">
-        Shared sandbox runtime — read-only view. Per spec §10, queue mutation
-        (start/cancel/reorder) belongs to the concurrency thread, not this layout.
+        AI Coworker workload, read-only here. Use the build's main action when
+        one of these needs you.
       </p>
       <div className="flex flex-wrap gap-3 text-[11px] text-[var(--dpf-text)]">
-        <span>Running: <span className="font-semibold">{counts.runningCount}</span></span>
+        <span>Working: <span className="font-semibold">{counts.runningCount}</span></span>
         <span>Blocked: <span className="font-semibold text-[var(--dpf-warning)]">{counts.blockedCount}</span></span>
-        <span>Queued: <span className="font-semibold">{counts.queuedCount}</span></span>
+        <span>Waiting: <span className="font-semibold">{counts.queuedCount}</span></span>
       </div>
       <ul className="flex flex-col gap-1">
         {sorted.map((entry) => (
@@ -1207,11 +1175,9 @@ function BsQueueSection({ builds }: { builds: readonly FeatureBuildRow[] }) {
             data-build-id={entry.build.buildId}
             data-queue-kind={entry.queueState.kind}
           >
-            <span className="font-mono text-[var(--dpf-text)]">{entry.build.buildId}</span>
-            <span className="truncate text-[var(--dpf-muted)]">{entry.build.title}</span>
-            <span className="ml-auto text-[10px] uppercase tracking-wider text-[var(--dpf-muted)]">
-              {entry.queueState.kind}
-              {entry.queueState.kind === "queued" && ` @${entry.queueState.position}`}
+            <span className="min-w-0 flex-1 truncate text-[var(--dpf-text)]">{entry.build.title}</span>
+            <span className="ml-auto shrink-0 text-[10px] font-semibold text-[var(--dpf-muted)]">
+              {labelForQueueState(entry)}
             </span>
           </li>
         ))}
@@ -1460,17 +1426,49 @@ function FleetRailZone({
 
   // Split entries into active (needs attention) vs completed (historical). The
   // fleet rail surfaces what needs attention; completed work is one click away
-  // via the "{N} completed" toggle below. Matches the WIP-slots header
-  // semantic: the list should only show inflight work by default.
+  // via the "{N} completed" toggle below. Current-work overflow is folded by
+  // default so the operator sees a bounded list, not the entire backlog.
   const activeEntries = sorted.filter((e) => e.build.phase !== "complete");
   const completedEntries = sorted.filter((e) => e.build.phase === "complete");
   const activeEpicRollups = epicRollups.filter((rollup) => rollup.status !== "complete");
   const completedEpicRollups = epicRollups.filter((rollup) => rollup.status === "complete");
   const completedItemCount = completedEntries.length + completedEpicRollups.length;
   const [showCompleted, setShowCompleted] = useState(false);
+  const [showAllActive, setShowAllActive] = useState(false);
 
   const counts = deriveFleetCounts(entries.map((e) => e.queueState));
   const wipSlotCap = Math.max(DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP, counts.runningCount);
+  const totalActiveItemCount = activeEpicRollups.length + activeEntries.length;
+  const shouldCollapseActive = totalActiveItemCount > MAX_OPERATOR_FLEET_ITEMS && !showAllActive;
+
+  let visibleActiveEpicRollups = activeEpicRollups;
+  let visibleActiveEntries = activeEntries;
+  if (shouldCollapseActive) {
+    const activeEpicIndex = activeEpicRollups.findIndex((rollup) =>
+      rollup.children.some((child) => child.buildId === activeBuildId),
+    );
+    const activeEntryIndex = activeEntries.findIndex((entry) => entry.build.buildId === activeBuildId);
+    visibleActiveEpicRollups = activeEpicRollups.slice(0, Math.min(MAX_OPERATOR_FLEET_ITEMS, activeEpicRollups.length));
+    let remainingSlots = Math.max(0, MAX_OPERATOR_FLEET_ITEMS - visibleActiveEpicRollups.length);
+
+    if (activeEpicIndex >= MAX_OPERATOR_FLEET_ITEMS && visibleActiveEpicRollups.length > 0) {
+      visibleActiveEpicRollups = [
+        ...visibleActiveEpicRollups.slice(0, MAX_OPERATOR_FLEET_ITEMS - 1),
+        activeEpicRollups[activeEpicIndex],
+      ];
+      remainingSlots = 0;
+    }
+
+    visibleActiveEntries = activeEntries.slice(0, remainingSlots);
+    if (activeEntryIndex >= remainingSlots && remainingSlots > 0) {
+      visibleActiveEntries = [
+        ...visibleActiveEntries.slice(0, remainingSlots - 1),
+        activeEntries[activeEntryIndex],
+      ];
+    }
+  }
+  const hiddenActiveItemCount =
+    totalActiveItemCount - visibleActiveEpicRollups.length - visibleActiveEntries.length;
 
   useEffect(() => {
     if (!activeBuildId) return;
@@ -1527,16 +1525,6 @@ function FleetRailZone({
           <span className="truncate">
             {formatFleetHeader(counts.runningCount, wipSlotCap, counts.queuedCount)}
           </span>
-          {counts.queuedCount > 0 && (
-            <QueueStateBadge
-              state={{
-                kind: "queued",
-                position: counts.queuedCount,
-                reason: "capacity",
-                ahead: Math.max(0, counts.queuedCount - 1),
-              }}
-            />
-          )}
           {counts.blockedCount > 0 && (
             <> · <span className="text-[var(--dpf-warning)]">{counts.blockedCount} blocked</span></>
           )}
@@ -1544,7 +1532,7 @@ function FleetRailZone({
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">›</span>
       </button>
       <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1" data-testid="fleet-rail-body">
-        {activeEpicRollups.map((rollup, idx) => (
+        {visibleActiveEpicRollups.map((rollup, idx) => (
           <li key={rollup.epicId}>
             <EpicRollupListItem
               rollup={rollup}
@@ -1556,12 +1544,12 @@ function FleetRailZone({
             />
           </li>
         ))}
-        {activeEntries.map((entry, idx) => (
+        {visibleActiveEntries.map((entry, idx) => (
           <li key={entry.build.buildId}>
             <BuildListItem
               build={entry.build}
               active={activeBuildId === entry.build.buildId}
-              index={activeEpicRollups.length + idx}
+              index={visibleActiveEpicRollups.length + idx}
               lifecycleLabel={entry.lifecycleLabel}
               isDevEnvironment={isDevEnvironment}
               density="fleet"
@@ -1572,9 +1560,31 @@ function FleetRailZone({
             />
           </li>
         ))}
-        {activeEpicRollups.length === 0 && activeEntries.length === 0 && (
+        {visibleActiveEpicRollups.length === 0 && visibleActiveEntries.length === 0 && (
           <li className="px-3 py-6 text-center text-[11px] text-[var(--dpf-muted)]">
             No active builds. Type a feature name above and click "Start a new build" to start.
+          </li>
+        )}
+        {totalActiveItemCount > MAX_OPERATOR_FLEET_ITEMS && (
+          <li>
+            <div className="mt-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[11px] leading-snug text-[var(--dpf-muted)]">
+              <p>
+                {showAllActive
+                  ? "AI Coworker is tracking all current builds."
+                  : `AI Coworker is tracking ${hiddenActiveItemCount} more build${hiddenActiveItemCount === 1 ? "" : "s"}.`}
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowAllActive((v) => !v)}
+                aria-expanded={showAllActive}
+                data-testid="fleet-rail-active-toggle"
+                className="mt-1 inline-flex rounded px-0 text-[11px] font-semibold text-[var(--dpf-accent)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+              >
+                {showAllActive
+                  ? "Show fewer builds"
+                  : `Show ${hiddenActiveItemCount} more build${hiddenActiveItemCount === 1 ? "" : "s"}`}
+              </button>
+            </div>
           </li>
         )}
         {completedItemCount > 0 && (
@@ -1605,7 +1615,7 @@ function FleetRailZone({
                         rollup={rollup}
                         activeBuildId={activeBuildId}
                         expanded={expandedEpicIds.has(rollup.epicId)}
-                        index={activeEpicRollups.length + activeEntries.length + idx}
+                        index={visibleActiveEpicRollups.length + visibleActiveEntries.length + idx}
                         onToggle={() => toggleEpic(rollup.epicId)}
                         onSelectBuild={onSelectBuildById}
                       />
@@ -1616,7 +1626,7 @@ function FleetRailZone({
                       <BuildListItem
                         build={entry.build}
                         active={activeBuildId === entry.build.buildId}
-                        index={activeEpicRollups.length + activeEntries.length + completedEpicRollups.length + idx}
+                        index={visibleActiveEpicRollups.length + visibleActiveEntries.length + completedEpicRollups.length + idx}
                         lifecycleLabel={entry.lifecycleLabel}
                         isDevEnvironment={isDevEnvironment}
                         density="fleet"

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -420,7 +420,7 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Portal context");
+    expect(html).toContain("Build context");
     expect(html).toContain("Build Studio");
     expect(html).toContain("Portal overlay");
     expect(html).not.toContain("WC-123");

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -468,16 +468,42 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain("Decision:");
   });
 
-  it("limits the default fleet to the highest-signal work and folds the rest under AI Coworker custody", () => {
-    const builds = Array.from({ length: 8 }, (_, index) =>
+  it("shows only focus work in the operator fleet and parks quiet research/design builds under coworker custody", () => {
+    const parkedBuilds = Array.from({ length: 5 }, (_, index) =>
       makeBuild({
-        id: `build-row-${index + 1}`,
-        buildId: `FB-OVERFLOW-${index + 1}`,
-        title: `Operator build ${index + 1}`,
-        phase: "plan",
+        id: `parked-row-${index + 1}`,
+        buildId: `FB-PARKED-${index + 1}`,
+        title: `Parked research build ${index + 1}`,
+        phase: "ideate",
         originator: null,
       }),
     );
+    const builds = [
+      makeBuild({
+        id: "focus-row",
+        buildId: "FB-FOCUS",
+        title: "Review customer entry gate",
+        phase: "review",
+        originator: null,
+      }),
+      makeBuild({
+        id: "working-row",
+        buildId: "FB-WORKING",
+        title: "Ship provider readiness check",
+        phase: "build",
+        buildExecState: { step: "code_generated" } as unknown as FeatureBuildRow["buildExecState"],
+        originator: null,
+      }),
+      makeBuild({
+        id: "needs-row",
+        buildId: "FB-NEEDS-YOU",
+        title: "Choose recovery path for failed review",
+        phase: "plan",
+        planReview: { decision: "fail" } as unknown as FeatureBuildRow["planReview"],
+        originator: null,
+      }),
+      ...parkedBuilds,
+    ];
 
     const html = renderToStaticMarkup(
       <BuildStudio
@@ -489,13 +515,15 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Work in progress:");
+    expect(html).toContain("Needs you: 1 · Working: 2 · Parked: 5");
     expect(html).not.toContain("WIP slots");
-    expect(html).toContain("Operator build 1");
-    expect(html).toContain("Operator build 4");
-    expect(html).not.toContain("Operator build 5");
-    expect(html).toContain("AI Coworker is tracking 4 more builds");
-    expect(html).toContain("Show 4 more builds");
+    expect(html).toContain("Review customer entry gate");
+    expect(html).toContain("Ship provider readiness check");
+    expect(html).toContain("Choose recovery path for failed review");
+    expect(html).not.toContain("Parked research build 1");
+    expect(html).not.toContain("Parked research build 5");
+    expect(html).toContain("AI Coworker is watching 5 parked builds");
+    expect(html).not.toContain("Show 5 more builds");
   });
 
   it("renders an implementation control once the plan is approved and start approval is recorded", () => {

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -450,6 +450,54 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain(">Review with coworker<");
   });
 
+  it("presents backlog context as a short work request, not an internal canonical record", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild()]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    expect(html).toContain("Work request");
+    expect(html).toContain("Why it matters:");
+    expect(html).not.toContain("Canonical backlog item");
+    expect(html).not.toContain("Triage:");
+    expect(html).not.toContain("Decision:");
+  });
+
+  it("limits the default fleet to the highest-signal work and folds the rest under AI Coworker custody", () => {
+    const builds = Array.from({ length: 8 }, (_, index) =>
+      makeBuild({
+        id: `build-row-${index + 1}`,
+        buildId: `FB-OVERFLOW-${index + 1}`,
+        title: `Operator build ${index + 1}`,
+        phase: "plan",
+        originator: null,
+      }),
+    );
+
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={builds}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    expect(html).toContain("Work in progress:");
+    expect(html).not.toContain("WIP slots");
+    expect(html).toContain("Operator build 1");
+    expect(html).toContain("Operator build 4");
+    expect(html).not.toContain("Operator build 5");
+    expect(html).toContain("AI Coworker is tracking 4 more builds");
+    expect(html).toContain("Show 4 more builds");
+  });
+
   it("renders an implementation control once the plan is approved and start approval is recorded", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
@@ -612,8 +660,8 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
     expect(queryByTestId("build-studio-header-details")).toBeNull();
   });
 
-  it("clicking Details reveals the build ID chip", async () => {
-    const { getByRole, findByTestId } = render(
+  it("clicking Details keeps internal IDs hidden in operator mode", async () => {
+    const { getByRole, findByTestId, queryByTestId } = render(
       <BuildStudio
         builds={[makeBuild({ buildId: "FB-DALE02" })]}
         epicRollups={[]}
@@ -631,7 +679,11 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
 
     const details = await findByTestId("build-studio-header-details");
     expect(details).toBeDefined();
-    expect(details.textContent).toContain("FB-DALE02");
+    expect(details.textContent).toContain("AI Coworker is handling");
+    expect(details.textContent).not.toContain("FB-DALE02");
+    expect(details.textContent).not.toContain("BI-5B839D74");
+    expect(details.textContent).not.toContain("dpf/");
+    expect(queryByTestId("build-studio-build-id")).toBeNull();
   });
 
   it("clicking Details again collapses the panel", async () => {
@@ -685,7 +737,29 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
       />,
     );
     const details = await findByTestId("build-studio-header-details");
-    expect(details.textContent).toContain("FB-RESTORED");
+    expect(details.textContent).toContain("AI Coworker is handling");
+    expect(details.textContent).not.toContain("FB-RESTORED");
+  });
+
+  it("reveals IDs and branch only when Engineer view is enabled", async () => {
+    localStorage.setItem("dpf:build-studio-engineer-view", "true");
+    const { getByRole, findByTestId } = render(
+      <BuildStudio
+        builds={[makeBuild({ buildId: "FB-ENGINEER" })]}
+        epicRollups={[]}
+        portfolios={[]}
+        governedBacklogEnabled
+        portalContext={makePortalContextEnvelope()}
+        projectBranch="main"
+        submissionBranchShortId="aabbccdd"
+      />,
+    );
+
+    getByRole("button", { name: /Details/ }).click();
+    const details = await findByTestId("build-studio-header-details");
+    expect(details.textContent).toContain("FB-ENGINEER");
+    expect(details.textContent).toContain("BI-5B839D74");
+    expect(details.textContent).toContain("dpf/aabbccdd/");
   });
 });
 

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
@@ -260,7 +260,7 @@ describe("BuildStudioWorkflowActionCard resume visibility", () => {
 
     expect(screen.getByText("Reset blocked tasks")).toBeInTheDocument();
     expect(screen.getByText("Blocked (technical)")).toBeInTheDocument();
-    expect(screen.getByTestId("build-next-action")).toHaveTextContent("Next: try to fix the failed work from Build Studio.");
+    expect(screen.getByTestId("build-next-action")).toHaveTextContent("Next: try to fix the failed work. I will rerun the recovery path.");
     expect(screen.getByTestId("build-guided-recovery")).toHaveTextContent("Something looks off");
     expect(screen.getByText("DB")).toBeInTheDocument();
     expect(screen.getByText("3 blocked tasks will be reset before the existing resume path is queued.")).toBeInTheDocument();
@@ -296,7 +296,7 @@ describe("BuildStudioWorkflowActionCard resume visibility", () => {
     );
 
     expect(screen.getByText("Waiting on you")).toBeInTheDocument();
-    expect(screen.getByTestId("build-next-action")).toHaveTextContent("Next: try to fix the plan review in place.");
+    expect(screen.getByTestId("build-next-action")).toHaveTextContent("Next: try to fix the plan review here.");
     expect(screen.getByTestId("build-guided-recovery")).toHaveTextContent("Try to fix");
     expect(screen.getByRole("button", { name: "Something looks off" })).toBeInTheDocument();
 
@@ -451,7 +451,7 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
     // The compact sentence is the derived one-line Next action, paired with a
     // single operator status.
     expect(banner).toHaveTextContent("Waiting on you");
-    expect(banner).toHaveTextContent("Next: start implementation from Build Studio.");
+    expect(banner).toHaveTextContent("Next: start implementation. I will track the checks.");
     expect(screen.queryByText("Build Status")).not.toBeInTheDocument();
     expect(screen.queryByText("Operational status")).not.toBeInTheDocument();
   });
@@ -490,7 +490,7 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
     const banner = screen.getByRole("region", { name: "Current build action" });
     expect(banner).toHaveAttribute("data-state", "blocked");
     expect(banner).toHaveTextContent("Waiting on you");
-    expect(banner).toHaveTextContent("Next: clear the missing evidence with the coworker");
+    expect(banner).toHaveTextContent("Next: ask the AI Coworker to collect the missing evidence.");
     expect(banner).toHaveTextContent("Plan review failed. Refine the plan first.");
   });
 

--- a/apps/web/components/build/EpicRollupListItem.tsx
+++ b/apps/web/components/build/EpicRollupListItem.tsx
@@ -148,5 +148,6 @@ function formatUpdatedAt(value: Date | string) {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
   }).format(new Date(value));
 }

--- a/apps/web/components/build/FleetRail.test.tsx
+++ b/apps/web/components/build/FleetRail.test.tsx
@@ -14,6 +14,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { FleetRail, formatFleetHeader, sortFleetEntries, type FleetRailEntry } from "./FleetRail";
+import { formatOperatorFocusHeader } from "./fleet-derivation";
 import {
   normalizeHappyPathState,
   type FeatureBuildRow,
@@ -81,9 +82,22 @@ function entry(
 }
 
 describe("formatFleetHeader", () => {
-  it("formats running/cap and queued count", () => {
-    expect(formatFleetHeader(2, 3, 4)).toBe("Work in progress: 2 of 3 active · 4 waiting");
-    expect(formatFleetHeader(0, 5, 0)).toBe("Work in progress: 0 of 5 active · 0 waiting");
+  it("uses the current operator-focus wording for legacy callers", () => {
+    expect(formatFleetHeader(2, 3, 4)).toBe("Needs you: 0 · Working: 2 · Waiting: 4 · Parked: 0");
+    expect(formatFleetHeader(0, 5, 0)).toBe("Needs you: 0 · Working: 0 · Parked: 0");
+  });
+});
+
+describe("formatOperatorFocusHeader", () => {
+  it("formats the human-facing FleetRail summary", () => {
+    expect(
+      formatOperatorFocusHeader({
+        needsYouCount: 1,
+        workingCount: 2,
+        queuedCount: 3,
+        parkedCount: 4,
+      }),
+    ).toBe("Needs you: 1 · Working: 2 · Waiting: 3 · Parked: 4");
   });
 });
 
@@ -141,13 +155,14 @@ describe("FleetRail rendering", () => {
         cap={3}
         runningCount={1}
         queuedCount={2}
+        parkedCount={4}
         isDevEnvironment={false}
         onOpenQueueDrawer={vi.fn()}
         onSelectBuild={vi.fn()}
         onDeleteBuild={vi.fn()}
       />,
     );
-    expect(screen.getByTestId("fleet-header-label")).toHaveTextContent("Work in progress: 1 of 3 active · 2 waiting");
+    expect(screen.getByTestId("fleet-header-label")).toHaveTextContent("Needs you: 0 · Working: 1 · Waiting: 2 · Parked: 4");
     expect(screen.queryByLabelText("Queued, position 2")).not.toBeInTheDocument();
   });
 

--- a/apps/web/components/build/FleetRail.test.tsx
+++ b/apps/web/components/build/FleetRail.test.tsx
@@ -82,8 +82,8 @@ function entry(
 
 describe("formatFleetHeader", () => {
   it("formats running/cap and queued count", () => {
-    expect(formatFleetHeader(2, 3, 4)).toBe("WIP slots: 2 of 3 in use · 4 queued");
-    expect(formatFleetHeader(0, 5, 0)).toBe("WIP slots: 0 of 5 in use · 0 queued");
+    expect(formatFleetHeader(2, 3, 4)).toBe("Work in progress: 2 of 3 active · 4 waiting");
+    expect(formatFleetHeader(0, 5, 0)).toBe("Work in progress: 0 of 5 active · 0 waiting");
   });
 });
 
@@ -147,8 +147,8 @@ describe("FleetRail rendering", () => {
         onDeleteBuild={vi.fn()}
       />,
     );
-    expect(screen.getByTestId("fleet-header-label")).toHaveTextContent("WIP slots: 1 of 3 in use · 2 queued");
-    expect(screen.getByLabelText("Queued, position 2")).toBeInTheDocument();
+    expect(screen.getByTestId("fleet-header-label")).toHaveTextContent("Work in progress: 1 of 3 active · 2 waiting");
+    expect(screen.queryByLabelText("Queued, position 2")).not.toBeInTheDocument();
   });
 
   it("header has role=status + aria-live=polite for queue-change announcement", () => {

--- a/apps/web/components/build/FleetRail.tsx
+++ b/apps/web/components/build/FleetRail.tsx
@@ -1,13 +1,13 @@
 // apps/web/components/build/FleetRail.tsx
 //
-// The compact left rail of the redesigned Build Studio shell. Shows every
-// in-flight build as a ≤32px row plus a header that surfaces the BS queue
-// runtime state (concurrency cap + running + queued counts).
+// The compact left rail of the redesigned Build Studio shell. Shows the
+// operator focus queue as <=32px rows plus a header that separates work needing
+// the human, work the AI Coworker is doing, queued work, and parked work.
 //
 // Per the spec §1 (Fleet Rail) and the queue surface amendment (PR #898):
-//   - Header: "Work in progress: {running} of {cap} active · {queuedCount} waiting", role=status,
-//     aria-live="polite" so cap/queue-position changes are announced.
-//   - Default sort: running → blocked → queued (by position) → idle.
+//   - Header: "Needs you: N · Working: N · Waiting: N · Parked: N",
+//     role=status, aria-live="polite" so queue changes are announced.
+//   - Default sort: needs-attention -> running -> blocked -> queued -> idle.
 //   - Each row uses BuildListItem density="fleet".
 //   - Clicking the header invokes onOpenQueueDrawer (the BuildStudio shell
 //     opens the DetailsDrawer scrolled to the BS-Queue subsection).
@@ -23,7 +23,10 @@ import {
   getFleetRailHeaderClassName,
 } from "./build-studio-layout";
 import { BuildListItem } from "./BuildListItem";
-import { formatFleetHeader as formatFleetHeaderLabel } from "./fleet-derivation";
+import {
+  formatFleetHeader as formatFleetHeaderLabel,
+  formatOperatorFocusHeader,
+} from "./fleet-derivation";
 import type { BuildQueueState } from "./QueueStateBadge";
 
 /** Each visible entry: the FeatureBuildRow plus per-row queue/attention state. */
@@ -47,6 +50,8 @@ export type FleetRailProps = {
   runningCount: number;
   /** Count of queued builds (same provenance as runningCount). */
   queuedCount: number;
+  /** Count of quiet builds held by AI Coworker outside the operator focus list. */
+  parkedCount?: number;
   /** Build Studio is hidden/disabled in dev environments — passed through to
    *  BuildListItem so the delete button respects that state. */
   isDevEnvironment: boolean;
@@ -58,7 +63,7 @@ export type FleetRailProps = {
   onDeleteBuild: (build: FeatureBuildRow) => void;
 };
 
-/** Sort priority — running first, then blocked, then queued (by position ascending), then idle.
+/** Sort priority — needs-attention first, then running, blocked, queued, idle.
  *  Pure: callers can rely on the same input producing the same render order. */
 export function sortFleetEntries(entries: readonly FleetRailEntry[]): FleetRailEntry[] {
   const kindRank: Record<BuildQueueState["kind"], number> = {
@@ -68,6 +73,7 @@ export function sortFleetEntries(entries: readonly FleetRailEntry[]): FleetRailE
     idle: 3,
   };
   return [...entries].sort((a, b) => {
+    if (a.needsAttention !== b.needsAttention) return a.needsAttention ? -1 : 1;
     const ra = kindRank[a.queueState.kind];
     const rb = kindRank[b.queueState.kind];
     if (ra !== rb) return ra - rb;
@@ -87,15 +93,26 @@ export function formatFleetHeader(runningCount: number, cap: number, queuedCount
 export function FleetRail({
   entries,
   activeBuildId,
-  cap,
   runningCount,
   queuedCount,
+  parkedCount = 0,
   isDevEnvironment,
   onOpenQueueDrawer,
   onSelectBuild,
   onDeleteBuild,
 }: FleetRailProps) {
   const sorted = sortFleetEntries(entries);
+  const needsYouCount = entries.filter((entry) => entry.needsAttention).length;
+  const blockedCount = entries.filter((entry) =>
+    !entry.needsAttention && entry.queueState.kind === "blocked",
+  ).length;
+  const headerLabel = formatOperatorFocusHeader({
+    needsYouCount,
+    workingCount: runningCount,
+    blockedCount,
+    queuedCount,
+    parkedCount,
+  });
   return (
     <aside
       data-testid={BUILD_STUDIO_TEST_IDS.fleet}
@@ -108,7 +125,7 @@ export function FleetRail({
         data-testid={BUILD_STUDIO_TEST_IDS.fleetHeader}
         role="status"
         aria-live="polite"
-        aria-label={`Open queue details — ${formatFleetHeader(runningCount, cap, queuedCount)}`}
+        aria-label={`Open queue details — ${headerLabel}`}
         className={[
           getFleetRailHeaderClassName(),
           "cursor-pointer",
@@ -119,7 +136,7 @@ export function FleetRail({
         ].join(" ")}
       >
         <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-1">
-          {formatFleetHeader(runningCount, cap, queuedCount)}
+          {headerLabel}
         </span>
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">
           ›

--- a/apps/web/components/build/FleetRail.tsx
+++ b/apps/web/components/build/FleetRail.tsx
@@ -5,7 +5,7 @@
 // runtime state (concurrency cap + running + queued counts).
 //
 // Per the spec §1 (Fleet Rail) and the queue surface amendment (PR #898):
-//   - Header: "WIP slots: {running} of {cap} in use · {queuedCount} queued", role=status,
+//   - Header: "Work in progress: {running} of {cap} active · {queuedCount} waiting", role=status,
 //     aria-live="polite" so cap/queue-position changes are announced.
 //   - Default sort: running → blocked → queued (by position) → idle.
 //   - Each row uses BuildListItem density="fleet".
@@ -24,7 +24,7 @@ import {
 } from "./build-studio-layout";
 import { BuildListItem } from "./BuildListItem";
 import { formatFleetHeader as formatFleetHeaderLabel } from "./fleet-derivation";
-import { QueueStateBadge, type BuildQueueState } from "./QueueStateBadge";
+import type { BuildQueueState } from "./QueueStateBadge";
 
 /** Each visible entry: the FeatureBuildRow plus per-row queue/attention state. */
 export type FleetRailEntry = {
@@ -120,16 +120,6 @@ export function FleetRail({
       >
         <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-1">
           {formatFleetHeader(runningCount, cap, queuedCount)}
-          {queuedCount > 0 && (
-            <QueueStateBadge
-              state={{
-                kind: "queued",
-                position: queuedCount,
-                reason: "capacity",
-                ahead: Math.max(0, queuedCount - 1),
-              }}
-            />
-          )}
         </span>
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">
           ›

--- a/apps/web/components/build/build-studio-layout.ts
+++ b/apps/web/components/build/build-studio-layout.ts
@@ -261,7 +261,8 @@ export function getDetailsDrawerPillClassName(): string {
 }
 
 /**
- * Fleet rail header — shows `Work in progress: {running} of {cap} active · {queuedCount} waiting`.
+ * Fleet rail header — shows the operator focus summary
+ * (`Needs you: N · Working: N · Waiting: N · Parked: N`).
  * Uses `role="status"` + `aria-live="polite"` (set on the element itself, not here).
  */
 export function getFleetRailHeaderClassName(): string {

--- a/apps/web/components/build/build-studio-layout.ts
+++ b/apps/web/components/build/build-studio-layout.ts
@@ -261,7 +261,7 @@ export function getDetailsDrawerPillClassName(): string {
 }
 
 /**
- * Fleet rail header — shows `WIP slots: {running} of {cap} in use · {queuedCount} queued`.
+ * Fleet rail header — shows `Work in progress: {running} of {cap} active · {queuedCount} waiting`.
  * Uses `role="status"` + `aria-live="polite"` (set on the element itself, not here).
  */
 export function getFleetRailHeaderClassName(): string {

--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -356,7 +356,7 @@ describe("deriveBuildStudioWorkflowAction", () => {
     const guidance = deriveBuildStudioOperatorGuidance(action);
     expect(guidance.status.label).toBe("Waiting on you");
     expect(guidance.nextLabel).toBe("Try to fix");
-    expect(guidance.nextSentence).toBe("Next: try to fix the plan review in place.");
+    expect(guidance.nextSentence).toBe("Next: try to fix the plan review here.");
     expect(guidance.guidedRecovery).toBe(true);
   });
 

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -395,20 +395,20 @@ function statusForAction(
 
 function nextSentenceForAction(action: BuildStudioWorkflowAction): string {
   if (action.disabledReason) {
-    return "Next: clear the missing evidence with the coworker, then come back to this button.";
+    return "Next: ask the AI Coworker to collect the missing evidence.";
   }
 
   switch (action.kind) {
     case "approve-start":
-      return "Next: record approval so Build Studio can keep going.";
+      return "Next: approve the start. I will keep planning from there.";
     case "advance-phase":
-      if (action.targetPhase === "plan") return "Next: move the reviewed design into planning.";
-      if (action.targetPhase === "build") return "Next: start implementation from Build Studio.";
-      if (action.targetPhase === "review") return "Next: run verification review from Build Studio.";
+      if (action.targetPhase === "plan") return "Next: move this design into planning.";
+      if (action.targetPhase === "build") return "Next: start implementation. I will track the checks.";
+      if (action.targetPhase === "review") return "Next: run verification review. I will collect the evidence.";
       if (action.targetPhase === "ship") return "Next: continue to release decisions.";
       return "Next: move this build to the next stage.";
     case "run-review-verification":
-      return "Next: run UX verification from Build Studio.";
+      return "Next: run UX verification. I will use the result to keep this build moving.";
     case "record-acceptance":
       return "Next: record acceptance so release decisions can unlock.";
     case "retry-build":
@@ -416,15 +416,15 @@ function nextSentenceForAction(action: BuildStudioWorkflowAction): string {
     case "reset-build":
       return "Next: reset the build pipeline and start it again.";
     case "resume-implementation":
-      return "Next: try to fix the failed work from Build Studio.";
+      return "Next: try to fix the failed work. I will rerun the recovery path.";
     case "decompose-now":
       return "Next: split this build into smaller builds.";
     case "amend-parent-design":
       return "Next: amend the parent design before this child continues.";
     case "rerun-plan-review":
-      return "Next: try to fix the plan review in place.";
+      return "Next: try to fix the plan review here.";
     case "review-only":
-      return "Next: watch this stage, or ask the coworker what needs attention.";
+      return "Next: I am watching this stage. Ask if anything looks stuck.";
   }
 }
 

--- a/apps/web/components/build/fleet-derivation.test.ts
+++ b/apps/web/components/build/fleet-derivation.test.ts
@@ -11,7 +11,9 @@ import {
   deriveFleetCounts,
   deriveNeedsAttention,
   deriveQueueState,
+  formatOperatorFocusHeader,
   formatFleetHeader,
+  isOperatorFocusEntry,
 } from "./fleet-derivation";
 import {
   normalizeHappyPathState,
@@ -219,9 +221,98 @@ describe("deriveFleetCounts", () => {
   });
 });
 
+describe("isOperatorFocusEntry", () => {
+  it("keeps idle ideation work out of the operator focus queue", () => {
+    const build = makeBuild({ buildId: "FB-IDLE", phase: "ideate" });
+
+    expect(
+      isOperatorFocusEntry(
+        {
+          build,
+          queueState: { kind: "idle" },
+          needsAttention: false,
+        },
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the selected build visible even when it is otherwise parked", () => {
+    const build = makeBuild({ buildId: "FB-SELECTED", phase: "plan" });
+
+    expect(
+      isOperatorFocusEntry(
+        {
+          build,
+          queueState: { kind: "idle" },
+          needsAttention: false,
+        },
+        "FB-SELECTED",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps running, queued, blocked, and attention-needing builds visible", () => {
+    const base = makeBuild({ buildId: "FB-FOCUS", phase: "build" });
+
+    expect(
+      isOperatorFocusEntry(
+        {
+          build: base,
+          queueState: { kind: "running", stepLabel: "Generating code" },
+          needsAttention: false,
+        },
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      isOperatorFocusEntry(
+        {
+          build: base,
+          queueState: { kind: "queued", position: 1, reason: "capacity", ahead: 0 },
+          needsAttention: false,
+        },
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      isOperatorFocusEntry(
+        {
+          build: base,
+          queueState: { kind: "blocked", reason: "Plan review failed" },
+          needsAttention: false,
+        },
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      isOperatorFocusEntry(
+        {
+          build: base,
+          queueState: { kind: "idle" },
+          needsAttention: true,
+        },
+        null,
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("formatFleetHeader", () => {
-  it("uses operator language instead of WIP jargon", () => {
-    expect(formatFleetHeader(2, 3, 4)).toBe("Work in progress: 2 of 3 active · 4 waiting");
-    expect(formatFleetHeader(0, 5, 0)).toBe("Work in progress: 0 of 5 active · 0 waiting");
+  it("keeps the legacy formatter on the operator-focus language", () => {
+    expect(formatFleetHeader(2, 3, 4)).toBe("Needs you: 0 · Working: 2 · Waiting: 4 · Parked: 0");
+    expect(formatFleetHeader(0, 5, 0)).toBe("Needs you: 0 · Working: 0 · Parked: 0");
+  });
+});
+
+describe("formatOperatorFocusHeader", () => {
+  it("summarizes the human-facing queue without in-flight jargon", () => {
+    expect(
+      formatOperatorFocusHeader({
+        needsYouCount: 1,
+        workingCount: 2,
+        parkedCount: 8,
+      }),
+    ).toBe("Needs you: 1 · Working: 2 · Parked: 8");
   });
 });

--- a/apps/web/components/build/fleet-derivation.test.ts
+++ b/apps/web/components/build/fleet-derivation.test.ts
@@ -11,6 +11,7 @@ import {
   deriveFleetCounts,
   deriveNeedsAttention,
   deriveQueueState,
+  formatFleetHeader,
 } from "./fleet-derivation";
 import {
   normalizeHappyPathState,
@@ -215,5 +216,12 @@ describe("deriveFleetCounts", () => {
       queuedCount: 0,
       blockedCount: 0,
     });
+  });
+});
+
+describe("formatFleetHeader", () => {
+  it("uses operator language instead of WIP jargon", () => {
+    expect(formatFleetHeader(2, 3, 4)).toBe("Work in progress: 2 of 3 active · 4 waiting");
+    expect(formatFleetHeader(0, 5, 0)).toBe("Work in progress: 0 of 5 active · 0 waiting");
   });
 });

--- a/apps/web/components/build/fleet-derivation.ts
+++ b/apps/web/components/build/fleet-derivation.ts
@@ -86,7 +86,8 @@ function humanizeStep(step: string): string {
  *   - phase=ship with no acceptanceMet → yes (operator decision needed)
  *   - claim status indicates a stalled / abandoned claim → yes
  *
- * The dot is shape+color (red dot + ring) so color-blind users still see it.
+ * The fleet row renders this as the plain "Needs you" status so the cue is
+ * readable without decoding symbols.
  */
 export function deriveNeedsAttention(build: FeatureBuildRow): boolean {
   if (build.phase === "failed") return true;
@@ -134,5 +135,5 @@ export function formatFleetHeader(
   cap: number = DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP,
   queuedCount: number = 0,
 ): string {
-  return `WIP slots: ${runningCount} of ${cap} in use · ${queuedCount} queued`;
+  return `Work in progress: ${runningCount} of ${cap} active · ${queuedCount} waiting`;
 }

--- a/apps/web/components/build/fleet-derivation.ts
+++ b/apps/web/components/build/fleet-derivation.ts
@@ -10,8 +10,6 @@
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import type { BuildQueueState } from "./QueueStateBadge";
 
-export const DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP = 3;
-
 /**
  * Derive a BuildQueueState from the FeatureBuildRow's phase + execution state.
  *
@@ -130,10 +128,63 @@ export function deriveFleetCounts(states: readonly BuildQueueState[]): {
   return { runningCount: running, queuedCount: queued, blockedCount: blocked };
 }
 
+export type OperatorFocusEntry = {
+  build: Pick<FeatureBuildRow, "buildId" | "phase">;
+  queueState: BuildQueueState;
+  needsAttention: boolean;
+};
+
+/**
+ * The operator fleet is a focus queue, not a dump of every not-complete row.
+ * Quiet ideation / planning probes remain under the AI Coworker's custody;
+ * builds stay visible when they are selected, running, queued, blocked, or
+ * waiting on the human.
+ */
+export function isOperatorFocusEntry(
+  entry: OperatorFocusEntry,
+  activeBuildId: string | null,
+): boolean {
+  if (activeBuildId && entry.build.buildId === activeBuildId) return true;
+  if (entry.needsAttention) return true;
+  return entry.queueState.kind !== "idle";
+}
+
+export function formatOperatorFocusHeader({
+  needsYouCount,
+  workingCount,
+  parkedCount,
+  blockedCount = 0,
+  queuedCount = 0,
+}: {
+  needsYouCount: number;
+  workingCount: number;
+  parkedCount: number;
+  blockedCount?: number;
+  queuedCount?: number;
+}): string {
+  const parts = [
+    `Needs you: ${needsYouCount}`,
+    `Working: ${workingCount}`,
+  ];
+  if (blockedCount > 0) {
+    parts.push(`Blocked: ${blockedCount}`);
+  }
+  if (queuedCount > 0) {
+    parts.push(`Waiting: ${queuedCount}`);
+  }
+  parts.push(`Parked: ${parkedCount}`);
+  return parts.join(" · ");
+}
+
 export function formatFleetHeader(
   runningCount: number,
-  cap: number = DEFAULT_BUILD_STUDIO_WIP_SLOT_CAP,
+  _cap: number = 0,
   queuedCount: number = 0,
 ): string {
-  return `Work in progress: ${runningCount} of ${cap} active · ${queuedCount} waiting`;
+  return formatOperatorFocusHeader({
+    needsYouCount: 0,
+    workingCount: runningCount,
+    queuedCount,
+    parkedCount: 0,
+  });
 }

--- a/apps/web/components/portal-context/PortalContextStrip.test.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.test.tsx
@@ -88,6 +88,26 @@ describe("PortalContextStrip", () => {
     expect(html).toContain("Missing evidence");
   });
 
+  it("can use operator-facing labels while preserving the shared strip", () => {
+    const html = renderToStaticMarkup(
+      <PortalContextStrip
+        envelope={makeEnvelope({
+          attention: [{
+            kind: "missing_evidence",
+            severity: "warning",
+            message: "Required design doc is missing.",
+          }],
+        })}
+        contextLabel="Build context"
+        showInternalIds={false}
+      />,
+    );
+
+    expect(html).toContain("Build context");
+    expect(html).toContain("Waiting on you");
+    expect(html).not.toContain("Missing evidence");
+  });
+
   it("hides raw build and capsule IDs in operator-facing mode", () => {
     const base = makeEnvelope();
     const html = renderToStaticMarkup(

--- a/apps/web/components/portal-context/PortalContextStrip.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.tsx
@@ -14,10 +14,15 @@ import { PortalContextOverlayDrawer } from "./PortalContextOverlayDrawer";
 
 type PortalContextStripProps = {
   envelope: PortalContextEnvelope | null;
+  contextLabel?: string;
   showInternalIds?: boolean;
 };
 
-export function PortalContextStrip({ envelope, showInternalIds = true }: PortalContextStripProps) {
+export function PortalContextStrip({
+  envelope,
+  contextLabel = "Portal context",
+  showInternalIds = true,
+}: PortalContextStripProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   if (!envelope) return null;
 
@@ -42,7 +47,7 @@ export function PortalContextStrip({ envelope, showInternalIds = true }: PortalC
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-normal text-[var(--dpf-muted)]">
             <Network className="h-4 w-4" aria-hidden="true" />
-            Portal context
+            {contextLabel}
           </span>
           <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs font-medium text-[var(--dpf-text)]">
             {envelope.route.domain}
@@ -61,7 +66,9 @@ export function PortalContextStrip({ envelope, showInternalIds = true }: PortalC
           >
             {capsuleLabel}
           </span>
-          {primarySignal && showAttentionChip && <AttentionChip signal={primarySignal} />}
+          {primarySignal && showAttentionChip && (
+            <AttentionChip signal={primarySignal} showInternalIds={showInternalIds} />
+          )}
         </div>
 
         <div className="flex items-center gap-2">
@@ -117,14 +124,20 @@ function formatCapsuleTitle(capsule: WorkCapsuleAnchor | null, showInternalIds: 
   return capsule.title || "Work capsule";
 }
 
-function AttentionChip({ signal }: { signal: AttentionSignal }) {
+function AttentionChip({
+  signal,
+  showInternalIds,
+}: {
+  signal: AttentionSignal;
+  showInternalIds: boolean;
+}) {
   return (
     <span className={[
       "inline-flex items-center gap-1 rounded border px-2 py-1 text-xs font-medium",
       severityClassName(signal.severity),
     ].join(" ")}>
       <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
-      {signalLabel(signal)}
+      {signalLabel(signal, showInternalIds)}
     </span>
   );
 }
@@ -135,10 +148,10 @@ function severityClassName(severity: AttentionSignal["severity"]): string {
   return "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-info)]";
 }
 
-function signalLabel(signal: AttentionSignal): string {
+function signalLabel(signal: AttentionSignal, showInternalIds: boolean): string {
   if (signal.kind === "no_active_build") return "No active build";
   if (signal.kind === "capsule_not_linked") return "Capsule not linked";
-  if (signal.kind === "missing_evidence") return "Missing evidence";
+  if (signal.kind === "missing_evidence") return showInternalIds ? "Missing evidence" : "Waiting on you";
   if (signal.kind === "lease_expired") return "Lease expired";
   return signal.kind.replace(/_/g, " ");
 }

--- a/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
+++ b/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
@@ -42,9 +42,9 @@ Implemented defaults:
 - `BuildSolutionSummaryBand` caps the operator brief and suppresses technical plan text such as data model/provider/API detail.
 - `BuildDecisionLedgerBand` is compact by default (`AI Coworker decision` + current call + short why); full options and unresolved technical evidence only render in Engineer view.
 - Fleet rows replace phase-dot rails, queue glyphs, and attention dots with plain statuses (`Working`, `Waiting`, `Needs you`, etc.).
-- The fleet defaults to the highest-signal four current items and folds the rest under "AI Coworker is tracking N more builds" with a single show-more control.
+- The fleet is now an operator focus queue: selected, running, queued, blocked, and needs-you builds stay visible; quiet ideation/planning probes are parked under `AI Coworker is watching N parked builds` and remain available from Details.
 
-UX-Fit-Decision: choose the plain custodian view over the technical dashboard or chat-punt recovery. `principle_decide` returned low confidence and a tool-biased edge for the technical dashboard, so the decision was made on merits per the UX-fit rule: reduce human cognitive load, keep governance evidence in drill-down, and make the default action surface clear for non-technical operators.
+UX-Fit-Decision: choose the plain custodian view and focus queue over the technical dashboard, chat-punt recovery, or "show all current builds" rail. `principle_decide` retrieved mostly process-commandment dimensions for the focus-queue decision and recommended "show all current" without scoring operator cognitive load; the decision was made on merits per the UX-fit rule: reduce human cognitive load, keep governance evidence in drill-down, and make the default action surface clear for non-technical operators.
 
 ## Verification
 

--- a/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
+++ b/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
@@ -24,7 +24,7 @@ The altitude flip (spec §3.1, Option B) landed: the plain "Solution & Oversight
 
 ## Operator clarity correction (2026-06-29)
 
-Live `/build` review showed the reframe was still too technical for a non-technical overseer: the default view exposed FB/BI/WC IDs, branch chips, phase-dot rails, queue glyphs, a "Canonical backlog item" strip, and long design-plan copy. The correction treats the AI Coworker as custodian of the build process and keeps the operator surface to one status, one next action, and a bounded current-work list.
+Live `/build` review showed the reframe was still too technical for a non-technical overseer: the default view exposed FB/BI/WC IDs, branch chips, phase-dot rails, queue glyphs, a "Canonical backlog item" strip, and long design-plan / review-decision copy. The correction treats the AI Coworker as custodian of the build process and keeps the operator surface to one status, one next action, and a bounded current-work list.
 
 Research anchors:
 
@@ -37,8 +37,10 @@ Implemented defaults:
 
 - `ActionBanner` now names the `AI Coworker`, shows the single operator status, and uses first-person custody copy ("I will track the checks", "I will collect the evidence").
 - Header `Details` stays human-readable unless `Engineer view` is on; FB/BI IDs, WC IDs, and raw branches remain behind Engineer view.
+- The shared context strip says `Build context` in Build Studio and maps missing-evidence attention to `Waiting on you` when internal IDs are hidden.
 - The backlog strip is now `Work request` with a short "Why it matters" line; status/triage/size/decision metadata moves to the details drawer.
 - `BuildSolutionSummaryBand` caps the operator brief and suppresses technical plan text such as data model/provider/API detail.
+- `BuildDecisionLedgerBand` is compact by default (`AI Coworker decision` + current call + short why); full options and unresolved technical evidence only render in Engineer view.
 - Fleet rows replace phase-dot rails, queue glyphs, and attention dots with plain statuses (`Working`, `Waiting`, `Needs you`, etc.).
 - The fleet defaults to the highest-signal four current items and folds the rest under "AI Coworker is tracking N more builds" with a single show-more control.
 

--- a/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
+++ b/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
@@ -8,7 +8,7 @@ Implements [`2026-06-22-build-studio-overseer-ux-design.md`](../specs/2026-06-22
 | --- | --- | --- | --- |
 | 3 — Decisions & why | `buildDecisionLedger` read-model + `BuildDecisionLedgerBand` | BI-EC934FC6 | **Done** (#2320 + #2325), merged + deployed |
 | 1 — What we're building | `BuildSolutionSummaryBand` (from `designDoc`) | BI-90670010 (band part) | **Done** (#2416), merged |
-| 4 — Where we need you | plain stop-copy in `deriveBuildStudioWorkflowAction` | BI-FD796419 | **Partial** (#2417); guided-recovery follow-up remains |
+| 4 — Where we need you | plain stop-copy in `deriveBuildStudioWorkflowAction` | BI-FD796419 | **Continuing in this PR**; operator clarity + in-place guided action layer |
 | 2 — What's changing | `changeNarrative` field + generator + `BuildChangeSummaryBand` | BI-D93CF6C0 | **This PR** |
 
 ## Band 2 — design realized (spec §4.1)
@@ -21,6 +21,28 @@ Implements [`2026-06-22-build-studio-overseer-ux-design.md`](../specs/2026-06-22
 ## IA reframe (keystone, BI-90670010) — implemented
 
 The altitude flip (spec §3.1, Option B) landed: the plain "Solution & Oversight" bands are now the **default first-viewport** of the active-build pane, and the engineer-grade `ProcessGraph` + `AssuranceRow` + `AgentActivityStrip` + `NodeInspector` demote behind a single persisted **"Engineer view"** toggle (`engineerView`, localStorage-backed). A `PhaseMiniRail` stays always-visible for liveness even when the graph is hidden, and the `DetailsDrawer` remains the bands' dive-in either way (`toRailPhase` maps the build's lifecycle phase onto the 5-dot rail). This realizes "plain by default; dive into the engineer surfaces only when something looks off." Live UX verification is performed on the install after deploy (`structural-verification-is-not-functional`).
+
+## Operator clarity correction (2026-06-29)
+
+Live `/build` review showed the reframe was still too technical for a non-technical overseer: the default view exposed FB/BI/WC IDs, branch chips, phase-dot rails, queue glyphs, a "Canonical backlog item" strip, and long design-plan copy. The correction treats the AI Coworker as custodian of the build process and keeps the operator surface to one status, one next action, and a bounded current-work list.
+
+Research anchors:
+
+- NN/g's [visibility of system status](https://www.nngroup.com/articles/visibility-system-status/) guidance says users need the system state in order to know what to do next and trust the system.
+- NN/g's [progressive disclosure](https://www.nngroup.com/articles/progressive-disclosure/) guidance says advanced or rarely-used detail belongs behind a secondary request so the primary task stays learnable and less error-prone.
+- Atlassian's [WIP limits](https://www.atlassian.com/agile/kanban/wip-limits) guidance frames work-in-progress as a focus and bottleneck signal; the operator UI should show capacity and blocked work without making the human scan every stale item.
+- GitHub Actions' [visualization graph](https://docs.github.com/en/actions/how-tos/monitor-workflows/use-the-visualization-graph) keeps detailed job status available for debugging, but not as the only status surface.
+
+Implemented defaults:
+
+- `ActionBanner` now names the `AI Coworker`, shows the single operator status, and uses first-person custody copy ("I will track the checks", "I will collect the evidence").
+- Header `Details` stays human-readable unless `Engineer view` is on; FB/BI IDs, WC IDs, and raw branches remain behind Engineer view.
+- The backlog strip is now `Work request` with a short "Why it matters" line; status/triage/size/decision metadata moves to the details drawer.
+- `BuildSolutionSummaryBand` caps the operator brief and suppresses technical plan text such as data model/provider/API detail.
+- Fleet rows replace phase-dot rails, queue glyphs, and attention dots with plain statuses (`Working`, `Waiting`, `Needs you`, etc.).
+- The fleet defaults to the highest-signal four current items and folds the rest under "AI Coworker is tracking N more builds" with a single show-more control.
+
+UX-Fit-Decision: choose the plain custodian view over the technical dashboard or chat-punt recovery. `principle_decide` returned low confidence and a tool-biased edge for the technical dashboard, so the decision was made on merits per the UX-fit rule: reduce human cognitive load, keep governance evidence in drill-down, and make the default action surface clear for non-technical operators.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

This PR fixes the Build Studio operator default after live review showed the page still read like a technical cockpit: raw build/backlog/work-capsule IDs, branch chips, phase dots, queue glyphs, a canonical backlog strip, and long review copy were still first-viewport material.

It changes the default `/build` experience to a custodian view:

- AI Coworker owns the action banner with one status and one next action.
- Internal IDs, branches, detailed decision evidence, and full graph evidence stay behind Engineer view.
- The top strip says Build context and maps missing evidence to Waiting on you for operators.
- The work request and solution bands are short, human-readable summaries.
- Fleet rows use plain statuses, bounded active work, and a show-more fold.
- Decision evidence is compact by default and full only in Engineer view.
- Visible operator date labels use a stable timezone to avoid hydration text drift.

## Verification

- `pnpm --filter web exec vitest run components/build components/portal-context/PortalContextStrip.test.tsx` — 65 files, 518 tests passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web build` — passed. Existing Turbopack warnings remain around Edge `process.cwd()` and NFT tracing, but exit code was 0.
- Governed self-upgrade event deployed the final branch to the live install: `SUR-F35B026C`, target `f851440ea9188ce772d3fc61f68c4f6448c4ff81`, served image `83ade33d88efeba87def2c27ee4a9e9f1863e89f`.
- `pnpm verify:preflight` equivalent via `scripts/dpf-verify-preflight.ts --feature-sha f851440ea9188ce772d3fc61f68c4f6448c4ff81 --json` returned `CAN-TEST`.
- Live Playwright `/build` verification passed: default operator view shows AI Coworker, Build context, Work in progress, Work request, compact AI Coworker decision; it hides FB/BI/WC IDs, branch chips, Missing evidence jargon, WIP slots, Canonical backlog item, and full decision transcript. Operator Details still hides IDs. Engineer view exposes internal evidence and the full decision transcript. No page errors.

UX-Fit-Decision: choose the plain AI Coworker custodian view over the technical dashboard or chat-punt recovery. `principle_decide` returned low confidence and a tool-biased edge for the technical dashboard, so the final decision was made on merits: reduce human cognitive load, keep governance evidence in drill-down, and make the default action surface clear for non-technical operators.
