### PR TITLE
fix(build-studio): recover sandbox branch mismatch in place

### DIFF
--- a/apps/web/lib/integrate/sandbox/sandbox-recovery.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-recovery.test.ts
@@ -36,6 +36,7 @@ function makeDb(overrides: Partial<SandboxRecoveryDb> = {}): SandboxRecoveryDb {
       updateMany: vi.fn(),
     },
     featureBuild: {
+      findUnique: vi.fn(),
       update: vi.fn(),
     },
     ...overrides,
@@ -130,5 +131,56 @@ describe("recoverSandbox", () => {
       where: { buildId: "FB-TEST" },
       data: expect.objectContaining({ status: "available", buildId: null }),
     }));
+  });
+
+  it("checks out the registered build branch after preserving stale in-flight work", async () => {
+    const runCommand = vi.fn().mockResolvedValue("");
+    const recordActivity = vi.fn();
+    const db = makeDb({
+      featureBuild: {
+        findUnique: vi.fn().mockResolvedValue({ buildBranch: "build/FB-TEST" }),
+        update: vi.fn(),
+      },
+    });
+
+    const result = await recoverSandbox({
+      buildId: "FB-TEST",
+      action: "checkout_registered_branch",
+      confirmation: null,
+      diagnose: vi.fn()
+        .mockResolvedValueOnce(snapshot({
+          state: "branch_mismatch",
+          containerId: "dpf-sandbox-1",
+          branchName: "build/FB-STALE",
+        }))
+        .mockResolvedValueOnce(snapshot({
+          state: "healthy",
+          canDeploy: true,
+          canContribute: true,
+          summary: "healthy",
+          branchName: "build/FB-TEST",
+        })),
+      runCommand,
+      recordActivity,
+      db,
+    });
+
+    expect(result.success).toBe(true);
+    expect(runCommand).toHaveBeenCalledWith("docker", [
+      "exec",
+      "dpf-sandbox-1",
+      "sh",
+      "-lc",
+      expect.stringContaining("git -C /workspace checkout 'build/FB-TEST'"),
+    ]);
+    const command = (runCommand.mock.calls[0]?.[1] as string[])[4] ?? "";
+    expect(command).toContain("preserve in-flight build work before branch switch");
+    expect(command).toContain("git reset --hard HEAD");
+    expect(command).toContain("git -C /workspace update-index --skip-worktree apps/web/next-env.d.ts");
+    expect(recordActivity).toHaveBeenCalledWith(
+      "FB-TEST",
+      "sandbox_recovery: checkout_registered_branch build/FB-TEST",
+    );
+    expect(result.snapshot?.state).toBe("healthy");
   });
 });

--- a/apps/web/lib/integrate/sandbox/sandbox-recovery.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-recovery.ts
@@ -3,6 +3,12 @@ import { prisma } from "@dpf/db";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 
 import { diagnoseSandboxReadiness } from "./sandbox-admin";
+import {
+  buildSandboxBranchSwitchPrepCommand,
+  buildSandboxCommitInFlightWorkCommand,
+  buildSandboxGitCleanCommand,
+  wrapSandboxGitCommand,
+} from "./build-branch";
 import type {
   SandboxReadinessSnapshot,
   SandboxRecoveryAction,
@@ -29,6 +35,7 @@ export type SandboxRecoveryDb = {
     updateMany(args: unknown): Promise<unknown>;
   };
   featureBuild?: {
+    findUnique?(args: unknown): Promise<{ buildBranch?: string | null } | null>;
     update(args: unknown): Promise<unknown>;
   };
 };
@@ -123,8 +130,16 @@ export async function recoverSandbox(args: RecoverSandboxArgs): Promise<SandboxR
         snapshot: before,
       };
 
-    case "rebind_runtime_target":
     case "checkout_registered_branch":
+      return checkoutRegisteredBranch({
+        ...args,
+        db,
+        diagnose,
+        runCommand,
+        before,
+      });
+
+    case "rebind_runtime_target":
       return {
         success: false,
         error: "recovery action not implemented",
@@ -132,6 +147,51 @@ export async function recoverSandbox(args: RecoverSandboxArgs): Promise<SandboxR
         snapshot: before,
       };
   }
+}
+
+async function checkoutRegisteredBranch(args: RecoverSandboxArgs & {
+  db: SandboxRecoveryDb;
+  diagnose: (buildId: string) => Promise<SandboxReadinessSnapshot>;
+  runCommand: (command: string, args: string[]) => Promise<string>;
+  before: SandboxReadinessSnapshot;
+}): Promise<SandboxRecoveryResult> {
+  const containerId = requireContainerId(args.before);
+  if (!containerId) {
+    return {
+      success: false,
+      error: "container id missing",
+      message: "Sandbox recovery cannot run because the diagnosis did not return a container id.",
+      snapshot: args.before,
+    };
+  }
+
+  const branchName = await resolveRegisteredBuildBranch(args.db, args.buildId);
+  if (!branchName) {
+    return {
+      success: false,
+      error: "build branch missing",
+      message: "Sandbox recovery cannot checkout the registered branch because this build has no buildBranch on record.",
+      snapshot: args.before,
+    };
+  }
+
+  const command = wrapSandboxGitCommand([
+    buildSandboxCommitInFlightWorkCommand(),
+    buildSandboxBranchSwitchPrepCommand(),
+    buildSandboxGitCleanCommand(),
+    `git -C /workspace checkout ${shellQuote(branchName)}`,
+    // Next dev rewrites this tracked generated shim on boot; hide it from
+    // readiness checks without changing source.
+    `git -C /workspace update-index --skip-worktree apps/web/next-env.d.ts 2>/dev/null || true`,
+  ].join(" && "));
+
+  await args.runCommand("docker", ["exec", containerId, "sh", "-lc", command]);
+  await recordRecoveryActivity(
+    args,
+    args.db,
+    `sandbox_recovery: checkout_registered_branch ${branchName}`,
+  );
+  return successWithSnapshot(args.buildId, "Registered build branch checked out.", args.diagnose);
 }
 
 async function runContainerAction(args: {
@@ -290,8 +350,21 @@ function requireContainerId(snapshot: SandboxReadinessSnapshot): string {
   return snapshot.containerId ?? "";
 }
 
+async function resolveRegisteredBuildBranch(db: SandboxRecoveryDb, buildId: string): Promise<string | null> {
+  const build = await db.featureBuild?.findUnique?.({
+    where: { buildId },
+    select: { buildBranch: true },
+  });
+  const branchName = build?.buildBranch?.trim();
+  return branchName || null;
+}
+
 function hasReason(confirmation: NonNullable<SandboxRecoveryConfirmation>): boolean {
   return typeof confirmation.reason === "string" && confirmation.reason.trim().length > 0;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
 }
 
 async function runCommandDefault(command: string, args: string[]): Promise<string> {

--- a/apps/web/lib/integrate/sandbox/sandbox-source-currency.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-source-currency.test.ts
@@ -159,6 +159,7 @@ describe("buildSandboxSourceCurrencyProbeCommand", () => {
     expect(command).toContain("status --porcelain --untracked-files=all -- .");
     expect(command).toContain("localSourceChangeCount");
     expect(command).toContain(":!**/.next/**");
+    expect(command).toContain(":!apps/web/next-env.d.ts");
     expect(command).toContain(":!.pnpm-store");
   });
 });

--- a/apps/web/lib/integrate/sandbox/sandbox-source-currency.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-source-currency.ts
@@ -57,6 +57,9 @@ const SOURCE_DIFF_EXCLUDES = [
   ":!**/.pnpm-store/**",
   ":!*.tsbuildinfo",
   ":!**/*.tsbuildinfo",
+  // Next dev rewrites this tracked generated shim between .next/types and
+  // .next/dev/types. It is not build source and must not stall recovery.
+  ":!apps/web/next-env.d.ts",
   ":!pnpm-lock*",
   ":!**/generated/client/**",
   ":!packages/db/generated/**",

--- a/apps/web/lib/integrate/sandbox/sandbox.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.test.ts
@@ -140,6 +140,7 @@ describe("buildSandboxStageCommand", () => {
     expect(command).toContain("cd /workspace");
     expect(command).toContain(":!**/node_modules/**");
     expect(command).toContain(":!**/.next/**");
+    expect(command).toContain(":!apps/web/next-env.d.ts");
     expect(command).toContain(":!**/*.tsbuildinfo");
     expect(command).toContain(":!pnpm-lock*");
     expect(command).toContain(":!packages/db/generated/**");
@@ -178,6 +179,7 @@ describe("buildSandboxListReleasableFilesCommand", () => {
 
     expect(command).toContain("git diff --cached --name-only -- .");
     expect(command).toContain(":(exclude)**/.next/**");
+    expect(command).toContain(":(exclude)apps/web/next-env.d.ts");
     expect(command).toContain(":(exclude)**/node_modules/**");
     expect(command).not.toContain("grep -v");
   });
@@ -193,6 +195,7 @@ describe("buildSandboxListReleasableFilesCommand", () => {
 
     expect(command).toContain("git diff --cached 'client/abc-123' --name-only -- .");
     expect(command).toContain(":(exclude)**/.next/**");
+    expect(command).toContain(":(exclude)apps/web/next-env.d.ts");
   });
 });
 

--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -25,6 +25,9 @@ const SANDBOX_STAGE_EXCLUDES = [
   ":!.next/**",
   ":!.pnpm-store/**",
   ":!**/*.tsbuildinfo",
+  // Next dev rewrites this tracked generated shim; do not let preview churn
+  // enter Build Studio diffs or block deploy readiness.
+  ":!apps/web/next-env.d.ts",
   ":!pnpm-lock*",
   // Never include the generated Prisma client — it is regenerated from schema.prisma
   // on every `prisma generate` and would bloat the diff with hundreds of KB of
@@ -39,6 +42,7 @@ const SANDBOX_DIFF_EXCLUDES = [
   ":(exclude).next/**",
   ":(exclude).pnpm-store/**",
   ":(exclude)**/*.tsbuildinfo",
+  ":(exclude)apps/web/next-env.d.ts",
   ":(exclude)pnpm-lock*",
   // Generated Prisma client — see SANDBOX_STAGE_EXCLUDES comment above.
   ":(exclude)**/generated/client/**",


### PR DESCRIPTION
## Summary

Fixes the Build Studio sandbox recovery path hit live on `FB-2D587B42`: the UI/diagnostic layer recommended `checkout_registered_branch`, but the V1 recovery service returned `recovery action not implemented`, leaving the operator at a dead retry path.

This PR:

- implements governed `checkout_registered_branch` recovery by preserving stale in-flight build work, cleaning the shared sandbox tree, checking out the registered build branch, and recording recovery activity
- excludes the tracked generated Next dev shim `apps/web/next-env.d.ts` from sandbox readiness and deploy diff extraction so preview-server churn does not block release recovery
- adds regression coverage for the recovery action and generated-file exclusions

## Root Cause

The sandbox diagnostic correctly classified `branch_mismatch`, but one of its recommended actions was not implemented in `sandbox-recovery.ts`. Restarting the container did not fix branch state, and Next dev rewrote `next-env.d.ts`, keeping the sandbox dirty even after the correct branch was restored.

## Verification

- `pnpm --filter web exec vitest run lib/integrate/sandbox/sandbox-recovery.test.ts lib/integrate/sandbox/sandbox-source-currency.test.ts lib/integrate/sandbox/sandbox.test.ts`
- `pnpm --filter web exec tsc --noEmit`
- `pnpm --filter web build`

The production build completed successfully; it emitted the repo's existing Turbopack warning noise about Edge/runtime imports and NFT tracing.

Process-Spine-Decision: focused reliability bugfix for an existing Build Studio recovery path; no new spec/doc surface needed because no new model, route, or user-facing contract is introduced.

UX-Fit-Decision: reliability-only recovery fix; no new UI surface, control, route, or cognitive-load choice added. Improves the existing Build Studio operator path by making the recommended in-place recovery action real.