### PR TITLE
fix(build): queue pre-build review repair loop

### DIFF
--- a/apps/web/lib/integrate/pre-build-review-auto-repair.test.ts
+++ b/apps/web/lib/integrate/pre-build-review-auto-repair.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const buildActivityCreateMock = vi.fn();
+const inngestSendMock = vi.fn();
+const dispatchDesignReviewFixLoopMock = vi.fn();
+const dispatchPlanForApprovedBuildMock = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    buildActivity: {
+      create: (...args: unknown[]) => buildActivityCreateMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/queue/inngest-client", () => ({
+  inngest: {
+    send: (...args: unknown[]) => inngestSendMock(...args),
+  },
+}));
+
+vi.mock("@/lib/integrate/ideate-on-approval", () => ({
+  dispatchDesignReviewFixLoop: (...args: unknown[]) => dispatchDesignReviewFixLoopMock(...args),
+}));
+
+vi.mock("@/lib/integrate/plan-on-approval", () => ({
+  dispatchPlanForApprovedBuild: (...args: unknown[]) => dispatchPlanForApprovedBuildMock(...args),
+}));
+
+import {
+  triggerDesignReviewAutoRepair,
+  triggerPlanReviewAutoRepair,
+} from "./pre-build-review-auto-repair";
+
+describe("pre-build review auto-repair trigger", () => {
+  beforeEach(() => {
+    buildActivityCreateMock.mockReset().mockResolvedValue({});
+    inngestSendMock.mockReset().mockResolvedValue({ ids: ["evt-1"] });
+    dispatchDesignReviewFixLoopMock.mockReset().mockResolvedValue({ kind: "repaired", rounds: 1 });
+    dispatchPlanForApprovedBuildMock.mockReset().mockResolvedValue({ kind: "dispatched-success" });
+  });
+
+  it("queues design review repair durably instead of running the fix loop inside the request", async () => {
+    await triggerDesignReviewAutoRepair("FB-DESIGN", "usr-1");
+
+    expect(inngestSendMock).toHaveBeenCalledWith({
+      name: "build/pre-build-review.repair",
+      data: { buildId: "FB-DESIGN", userId: "usr-1", kind: "design" },
+    });
+    expect(dispatchDesignReviewFixLoopMock).not.toHaveBeenCalled();
+    expect(buildActivityCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        buildId: "FB-DESIGN",
+        tool: "design_fix_loop",
+        summary: expect.stringContaining("queued"),
+      }),
+    });
+  });
+
+  it("queues plan review repair durably with force-regenerate handled by the worker", async () => {
+    await triggerPlanReviewAutoRepair("FB-PLAN", "usr-2");
+
+    expect(inngestSendMock).toHaveBeenCalledWith({
+      name: "build/pre-build-review.repair",
+      data: { buildId: "FB-PLAN", userId: "usr-2", kind: "plan" },
+    });
+    expect(dispatchPlanForApprovedBuildMock).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue when the caller suppresses auto-repair", async () => {
+    await triggerDesignReviewAutoRepair("FB-SUPPRESS", "usr-3", {
+      suppressDesignReviewAutoRepair: true,
+    });
+
+    expect(inngestSendMock).not.toHaveBeenCalled();
+    expect(buildActivityCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("logs enqueue failure without throwing into the review tool", async () => {
+    inngestSendMock.mockRejectedValue(new Error("queue unavailable"));
+
+    await expect(triggerPlanReviewAutoRepair("FB-FAIL", "usr-4")).resolves.toBeUndefined();
+
+    expect(buildActivityCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        buildId: "FB-FAIL",
+        tool: "plan_dispatch",
+        summary: expect.stringContaining("failed to queue"),
+      }),
+    });
+  });
+});

--- a/apps/web/lib/integrate/pre-build-review-auto-repair.ts
+++ b/apps/web/lib/integrate/pre-build-review-auto-repair.ts
@@ -1,48 +1,44 @@
 import { prisma } from "@dpf/db";
+import { inngest, type BuildPreBuildReviewRepairEvent } from "@/lib/queue/inngest-client";
 
 type AutoRepairContext = {
   suppressDesignReviewAutoRepair?: boolean;
   suppressPlanReviewAutoRepair?: boolean;
 };
 
+type RepairKind = BuildPreBuildReviewRepairEvent["data"]["kind"];
+
 function logBuildActivity(buildId: string, tool: string, summary: string): void {
   prisma.buildActivity.create({ data: { buildId, tool, summary } }).catch(() => {});
 }
 
-export function triggerDesignReviewAutoRepair(buildId: string, userId: string, context?: AutoRepairContext): void {
-  if (context?.suppressDesignReviewAutoRepair) return;
-  logBuildActivity(buildId, "design_fix_loop", "Design review failed - starting the in-place repair loop.");
-  void import("@/lib/integrate/ideate-on-approval")
-    .then((m) => m.dispatchDesignReviewFixLoop({ buildId, userId }))
-    .then((outcome) => {
-      logBuildActivity(
-        buildId,
-        "design_fix_loop",
-        `In-place design repair finished: ${outcome.kind} after ${outcome.rounds} round(s).`,
-      );
-    })
-    .catch((err) => {
-      logBuildActivity(
-        buildId,
-        "design_fix_loop",
-        `In-place design repair failed to start: ${String(err instanceof Error ? err.message : err).slice(0, 180)}`,
-      );
+async function queuePreBuildReviewRepair(buildId: string, userId: string, kind: RepairKind): Promise<void> {
+  const tool = kind === "design" ? "design_fix_loop" : "plan_dispatch";
+  try {
+    await inngest.send({
+      name: "build/pre-build-review.repair",
+      data: { buildId, userId, kind },
     });
+    logBuildActivity(
+      buildId,
+      tool,
+      `${kind === "design" ? "Design" : "Plan"} review failed - queued the in-place repair loop.`,
+    );
+  } catch (err) {
+    logBuildActivity(
+      buildId,
+      tool,
+      `${kind === "design" ? "Design" : "Plan"} review failed - failed to queue the in-place repair loop: ${String(err instanceof Error ? err.message : err).slice(0, 180)}`,
+    );
+  }
 }
 
-export function triggerPlanReviewAutoRepair(buildId: string, userId: string, context?: AutoRepairContext): void {
+export async function triggerDesignReviewAutoRepair(buildId: string, userId: string, context?: AutoRepairContext): Promise<void> {
+  if (context?.suppressDesignReviewAutoRepair) return;
+  await queuePreBuildReviewRepair(buildId, userId, "design");
+}
+
+export async function triggerPlanReviewAutoRepair(buildId: string, userId: string, context?: AutoRepairContext): Promise<void> {
   if (context?.suppressPlanReviewAutoRepair) return;
-  logBuildActivity(buildId, "plan_dispatch", "Plan review failed - starting the in-place repair loop.");
-  void import("@/lib/integrate/plan-on-approval")
-    .then((m) => m.dispatchPlanForApprovedBuild({ buildId, userId, forceRegenerate: true }))
-    .then((outcome) => {
-      logBuildActivity(buildId, "plan_dispatch", `In-place plan repair finished: ${outcome.kind}.`);
-    })
-    .catch((err) => {
-      logBuildActivity(
-        buildId,
-        "plan_dispatch",
-        `In-place plan repair failed to start: ${String(err instanceof Error ? err.message : err).slice(0, 180)}`,
-      );
-    });
+  await queuePreBuildReviewRepair(buildId, userId, "plan");
 }

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -8169,7 +8169,7 @@ export async function executeTool(
         if (context?.threadId) agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "designReview" });
         logBuildActivity(buildId, "reviewDesignDoc", `Fix review: ${review.decision}. ${review.summary}`);
         if (review.decision === "fail") {
-          triggerDesignReviewAutoRepair(buildId, userId, context);
+          await triggerDesignReviewAutoRepair(buildId, userId, context);
           return { success: true, message: `Fix review FAILED. ${review.issues[0]?.description ?? review.summary}`, data: { review, blocked: true, action: "revise_and_resubmit" } };
         }
         let fixPhaseGateBlocker: string | null = null;
@@ -8347,7 +8347,7 @@ export async function executeTool(
 
       // Failed review → structured recovery instructions, no auto-advance
       if (review.decision === "fail") {
-        triggerDesignReviewAutoRepair(buildId, userId, context);
+        await triggerDesignReviewAutoRepair(buildId, userId, context);
         const criticalIssues = review.issues.filter((i: { severity: string }) => i.severity === "critical");
         const issueList = criticalIssues.length > 0
           ? criticalIssues.map((i: { description: string }) => i.description).join("; ")
@@ -8658,7 +8658,7 @@ export async function executeTool(
           agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "planReview" });
         }
         logBuildActivity(buildId, "reviewBuildPlan", `Plan review: fail. ${review.summary}`);
-        triggerPlanReviewAutoRepair(buildId, userId, context);
+        await triggerPlanReviewAutoRepair(buildId, userId, context);
         return {
           success: true,
           message: `Plan review FAILED. Blocking issues: ${normalizedPlan.unresolvedModifyPaths.join(", ")} no longer exist in the repo. Revise the implementation plan to target the current files, then re-run reviewBuildPlan.`,
@@ -8833,7 +8833,7 @@ export async function executeTool(
           planReviewIsGating = true; // fail safe: keep the stricter loop on any gate-read error
         }
         if (planReviewIsGating) {
-          triggerPlanReviewAutoRepair(buildId, userId, context);
+          await triggerPlanReviewAutoRepair(buildId, userId, context);
           const criticalIssues = review.issues.filter((i: { severity: string }) => i.severity === "critical");
           const issueList = criticalIssues.length > 0
             ? criticalIssues.map((i: { description: string }) => i.description).join("; ")

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -18,6 +18,7 @@ import { researchExecute } from "./research-execute";
 import { researchScheduleScan } from "./research-schedule";
 import { buildReviewVerification } from "./build-review-verification";
 import { buildExecute } from "./build-execute";
+import { preBuildReviewRepair } from "./pre-build-review-repair";
 import { assuranceBomGenerate } from "./assurance-bom";
 import { assuranceScanRun } from "./assurance-scan";
 import { deliberationRun } from "./deliberation-run";
@@ -112,6 +113,7 @@ export const eventFunctions = [
   researchExecute,
   buildReviewVerification,
   buildExecute,
+  preBuildReviewRepair,
   assuranceBomGenerate,
   assuranceScanRun,
   deliberationRun,

--- a/apps/web/lib/queue/functions/pre-build-review-repair.test.ts
+++ b/apps/web/lib/queue/functions/pre-build-review-repair.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dispatchDesignReviewFixLoopMock = vi.fn();
+const dispatchPlanForApprovedBuildMock = vi.fn();
+const buildActivityCreateMock = vi.fn();
+
+vi.mock("../inngest-client", () => ({
+  inngest: {
+    createFunction: (config: unknown, fn: unknown) => ({ config, fn }),
+  },
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    buildActivity: {
+      create: (...args: unknown[]) => buildActivityCreateMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/integrate/ideate-on-approval", () => ({
+  dispatchDesignReviewFixLoop: (...args: unknown[]) => dispatchDesignReviewFixLoopMock(...args),
+}));
+
+vi.mock("@/lib/integrate/plan-on-approval", () => ({
+  dispatchPlanForApprovedBuild: (...args: unknown[]) => dispatchPlanForApprovedBuildMock(...args),
+}));
+
+import { preBuildReviewRepair } from "./pre-build-review-repair";
+
+const repairFunction = preBuildReviewRepair as unknown as {
+  config: unknown;
+  fn: (input: { event: { data: unknown }; step: ReturnType<typeof stepRunner> }) => Promise<unknown>;
+};
+
+function stepRunner() {
+  return {
+    run: vi.fn(async (_name: string, fn: () => Promise<unknown>) => fn()),
+  };
+}
+
+describe("preBuildReviewRepair", () => {
+  beforeEach(() => {
+    dispatchDesignReviewFixLoopMock.mockReset().mockResolvedValue({ kind: "repaired", rounds: 1 });
+    dispatchPlanForApprovedBuildMock.mockReset().mockResolvedValue({ kind: "dispatched-success" });
+    buildActivityCreateMock.mockReset().mockResolvedValue({});
+  });
+
+  it("is registered on the durable pre-build review repair event", () => {
+    expect(repairFunction.config).toMatchObject({
+      id: "build/pre-build-review-repair",
+      triggers: [{ event: "build/pre-build-review.repair" }],
+    });
+  });
+
+  it("runs the design review fix loop for design repair events", async () => {
+    const step = stepRunner();
+
+    await repairFunction.fn({
+      event: { data: { buildId: "FB-DESIGN", userId: "usr-1", kind: "design" } },
+      step,
+    });
+
+    expect(dispatchDesignReviewFixLoopMock).toHaveBeenCalledWith({
+      buildId: "FB-DESIGN",
+      userId: "usr-1",
+    });
+    expect(dispatchPlanForApprovedBuildMock).not.toHaveBeenCalled();
+  });
+
+  it("runs the plan repair path with forceRegenerate for plan repair events", async () => {
+    const step = stepRunner();
+
+    await repairFunction.fn({
+      event: { data: { buildId: "FB-PLAN", userId: "usr-2", kind: "plan" } },
+      step,
+    });
+
+    expect(dispatchPlanForApprovedBuildMock).toHaveBeenCalledWith({
+      buildId: "FB-PLAN",
+      userId: "usr-2",
+      forceRegenerate: true,
+    });
+    expect(dispatchDesignReviewFixLoopMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/queue/functions/pre-build-review-repair.ts
+++ b/apps/web/lib/queue/functions/pre-build-review-repair.ts
@@ -1,0 +1,40 @@
+import { prisma } from "@dpf/db";
+import { inngest, type BuildPreBuildReviewRepairEvent } from "../inngest-client";
+
+type PreBuildReviewRepairEventData = BuildPreBuildReviewRepairEvent["data"];
+
+function logBuildActivity(buildId: string, tool: string, summary: string): void {
+  prisma.buildActivity.create({ data: { buildId, tool, summary: summary.slice(0, 240) } }).catch(() => {});
+}
+
+export const preBuildReviewRepair = inngest.createFunction(
+  {
+    id: "build/pre-build-review-repair",
+    retries: 2,
+    concurrency: [{ key: "event.data.buildId", limit: 1 }],
+    triggers: [{ event: "build/pre-build-review.repair" }],
+  },
+  async ({ event, step }) => {
+    const { buildId, userId, kind } = event.data as PreBuildReviewRepairEventData;
+
+    if (kind === "design") {
+      const outcome = await step.run("repair-design-review", async () => {
+        const { dispatchDesignReviewFixLoop } = await import("@/lib/integrate/ideate-on-approval");
+        return dispatchDesignReviewFixLoop({ buildId, userId });
+      });
+      logBuildActivity(
+        buildId,
+        "design_fix_loop",
+        `In-place design repair finished: ${outcome.kind} after ${outcome.rounds} round(s).`,
+      );
+      return { buildId, kind, outcome };
+    }
+
+    const outcome = await step.run("repair-plan-review", async () => {
+      const { dispatchPlanForApprovedBuild } = await import("@/lib/integrate/plan-on-approval");
+      return dispatchPlanForApprovedBuild({ buildId, userId, forceRegenerate: true });
+    });
+    logBuildActivity(buildId, "plan_dispatch", `In-place plan repair finished: ${outcome.kind}.`);
+    return { buildId, kind, outcome };
+  },
+);

--- a/apps/web/lib/queue/inngest-client.ts
+++ b/apps/web/lib/queue/inngest-client.ts
@@ -142,6 +142,15 @@ export interface BuildExecuteRunEvent {
   };
 }
 
+export interface BuildPreBuildReviewRepairEvent {
+  name: "build/pre-build-review.repair";
+  data: {
+    buildId: string;
+    userId: string;
+    kind: "design" | "plan";
+  };
+}
+
 export interface AssuranceBomGenerateEvent {
   name: "assurance/bom.generate";
   data: {


### PR DESCRIPTION
## Summary
- Queue failed design/plan pre-build review repairs as durable Inngest work instead of request-local fire-and-forget dynamic imports.
- Await repair enqueue from `reviewDesignDoc` / `reviewBuildPlan` failure paths so operator actions have a real in-place handoff before the request ends.
- Reuse existing `dispatchDesignReviewFixLoop` and `dispatchPlanForApprovedBuild(..., forceRegenerate: true)` plumbing in the worker.

## Why
BI-DCC660A8 live symptom: failed design/plan reviews did not reliably fire the fix loop in-place and only recovered after boot-time `resumeStrandedBuildsOnBoot`. The boot path already awaited the canonical repair functions; the request path only started background imports, which could be dropped when the request lifecycle ended.

## Verification
- `pnpm --filter web exec vitest run lib/integrate/pre-build-review-auto-repair.test.ts lib/queue/functions/pre-build-review-repair.test.ts lib/integrate/resume-pre-build-phase.test.ts lib/integrate/ideate-on-approval.test.ts lib/integrate/plan-on-approval.test.ts lib/queue/functions/index.test.ts` -> 6 files, 50 tests passed.
- `pnpm --filter web exec tsc --noEmit` -> passed.
- `pnpm --filter web build` -> passed; existing Turbopack/NFT tracing warnings still emitted.
- `git diff --cached --check` -> passed before commit.
- Pre-commit hook -> gitleaks passed, scoped typecheck passed.

## Notes
- `scripts/dpf-bootstrap-agent-toolchain.ps1` still fails in fresh worktrees at `ConvertFrom-Json: Invalid JSON primitive: Scope`; this appears unrelated to this branch and was not changed here.

Process-Spine-Decision: no new spec/plan/doc; this is a narrow reliability wiring fix for BI-DCC660A8 using the existing Build Studio overseer plan and existing repair-loop substrate.
UX-Fit-Decision: not applicable; no UI surface changed.
