### PR TITLE
feat(build-studio): add proactive custodian prompt

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -35,6 +35,7 @@ import {
 } from "./fleet-derivation";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
+import { deriveBuildStudioCustodianPrompt, type BuildStudioCustodianPrompt } from "./build-studio-custodian";
 import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
 import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
 import { BuildSolutionSummaryBand } from "./BuildSolutionSummaryBand";
@@ -103,6 +104,7 @@ const MISSING_BOM_SUMMARY: BomSummary = {
 };
 
 const MAX_OPERATOR_FLEET_ITEMS = 4;
+const BUILD_CUSTODIAN_SNOOZE_KEY = "dpf:build-studio-custodian-snoozed";
 
 /** Map the build's lifecycle phase onto the 5-dot overseer phase rail. */
 function toRailPhase(phase: BuildPhase): PhaseRailPhase {
@@ -117,6 +119,28 @@ function toRailPhase(phase: BuildPhase): PhaseRailPhase {
       return "ship";
     default:
       return "build";
+  }
+}
+
+function readCustodianSnoozes(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.sessionStorage.getItem(BUILD_CUSTODIAN_SNOOZE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((value): value is string => typeof value === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeCustodianSnoozes(values: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(BUILD_CUSTODIAN_SNOOZE_KEY, JSON.stringify([...values]));
+  } catch {
+    // Best-effort session snooze only; a storage failure should never block Build Studio.
   }
 }
 
@@ -173,6 +197,7 @@ export function BuildStudio({
     if (typeof window === "undefined") return false;
     return window.localStorage.getItem(BUILD_ENGINEER_VIEW_KEY) === "true";
   });
+  const [snoozedCustodianKeys, setSnoozedCustodianKeys] = useState(readCustodianSnoozes);
   const toggleEngineerView = useCallback(() => {
     setEngineerView((prev) => {
       const next = !prev;
@@ -236,6 +261,25 @@ export function BuildStudio({
       progressVisibility,
     })
     : null;
+  const custodianPromptRaw = activeBuild && workflowAction
+    ? deriveBuildStudioCustodianPrompt({
+      build: activeBuild,
+      action: workflowAction,
+      progressVisibility,
+    })
+    : null;
+  const custodianPrompt =
+    custodianPromptRaw && !snoozedCustodianKeys.has(custodianPromptRaw.dismissKey)
+      ? custodianPromptRaw
+      : null;
+  const snoozeCustodianPrompt = useCallback((prompt: BuildStudioCustodianPrompt) => {
+    setSnoozedCustodianKeys((previous) => {
+      const next = new Set(previous);
+      next.add(prompt.dismissKey);
+      writeCustodianSnoozes(next);
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     if (!activeBuild?.buildId) return;
@@ -789,6 +833,8 @@ export function BuildStudio({
                       build={activeBuild}
                       action={workflowAction}
                       compact
+                      custodianPrompt={custodianPrompt}
+                      onCustodianSnooze={snoozeCustodianPrompt}
                       onCompleted={() => refreshActiveBuildState(activeBuild.buildId)}
                     />
                     {workflowAction.kind === "decompose-now" && activeBuild.designDoc && (

--- a/apps/web/components/build/BuildStudioCustodianCallout.test.tsx
+++ b/apps/web/components/build/BuildStudioCustodianCallout.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { BuildStudioCustodianCallout } from "./BuildStudioCustodianCallout";
+import type { BuildStudioCustodianPrompt } from "./build-studio-custodian";
+
+function prompt(overrides: Partial<BuildStudioCustodianPrompt> = {}): BuildStudioCustodianPrompt {
+  return {
+    dismissKey: "one",
+    title: "I can keep this review moving.",
+    whyNow: "UX verification still needs clean evidence, so another quiet click can look like nothing happened.",
+    recommendedAction: "I can collect the acceptance evidence and report the one next decision.",
+    primaryLabel: "Let AI Coworker handle it",
+    primaryAction: "coworker",
+    coworkerPrompt: "Act as custodian.",
+    statusLabel: "Needs evidence",
+    intent: "warning",
+    details: ["UX evidence is missing.", "Acceptance evidence is missing."],
+    ...overrides,
+  };
+}
+
+describe("BuildStudioCustodianCallout", () => {
+  it("renders one proactive recommendation with one primary action", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudioCustodianCallout prompt={prompt()} onPrimaryAction={vi.fn()} onSnooze={vi.fn()} />,
+    );
+
+    expect(html).toContain("AI Coworker proactive help");
+    expect(html).toContain("I can keep this review moving.");
+    expect(html).toContain("UX verification still needs clean evidence");
+    expect(html).toContain("Let AI Coworker handle it");
+    expect(html.match(/Let AI Coworker handle it/g)).toHaveLength(1);
+    expect(html).toContain("Show why");
+    expect(html).toContain("Snooze");
+  });
+
+  it("keeps explanation details collapsed by default", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudioCustodianCallout prompt={prompt()} onPrimaryAction={vi.fn()} onSnooze={vi.fn()} />,
+    );
+
+    expect(html).not.toContain("UX evidence is missing.");
+    expect(html).not.toContain("Acceptance evidence is missing.");
+  });
+});

--- a/apps/web/components/build/BuildStudioCustodianCallout.tsx
+++ b/apps/web/components/build/BuildStudioCustodianCallout.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Clock3, Eye, Sparkles } from "lucide-react";
+import { StatusBadge } from "@/components/ui/report-kit";
+import type { BuildStudioCustodianPrompt } from "./build-studio-custodian";
+
+type Props = {
+  prompt: BuildStudioCustodianPrompt;
+  onPrimaryAction: () => void;
+  onSnooze: () => void;
+};
+
+export function BuildStudioCustodianCallout({ prompt, onPrimaryAction, onSnooze }: Props) {
+  const [showWhy, setShowWhy] = useState(false);
+
+  return (
+    <section
+      aria-label="AI Coworker proactive help"
+      data-testid="build-studio-custodian-callout"
+      className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <StatusBadge intent={prompt.intent} label={prompt.statusLabel} variant="soft" uppercase={false} />
+            <p className="text-sm font-semibold text-[var(--dpf-text)]">{prompt.title}</p>
+          </div>
+          <p className="text-sm leading-5 text-[var(--dpf-text)]">{prompt.whyNow}</p>
+          <p className="text-xs leading-5 text-[var(--dpf-muted)]">{prompt.recommendedAction}</p>
+          {showWhy && (
+            <ul className="mt-2 space-y-1 text-xs leading-5 text-[var(--dpf-muted)]" data-testid="build-studio-custodian-detail">
+              {prompt.details.map((detail) => (
+                <li key={detail} className="break-words">- {detail}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onPrimaryAction}
+            className="inline-flex min-h-9 items-center gap-1.5 rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+            {prompt.primaryLabel}
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowWhy((value) => !value)}
+            aria-expanded={showWhy}
+            className="inline-flex min-h-9 items-center gap-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs font-semibold text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            <Eye className="h-3.5 w-3.5" aria-hidden="true" />
+            {showWhy ? "Hide why" : "Show why"}
+          </button>
+          <button
+            type="button"
+            onClick={onSnooze}
+            className="inline-flex min-h-9 items-center gap-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs font-semibold text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+            Snooze
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -568,6 +568,37 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain('data-testid="action-banner-detail"');
   });
 
+  it("replaces the compact banner with custodian help when review recovery would otherwise look inert", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild({
+          phase: "review",
+          draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+          buildPlan: {
+            fileStructure: [{ path: "apps/web/components/build/BuildStudio.tsx", action: "modify", purpose: "Surface proactive help." }],
+            tasks: [{ title: "Add proactive help", testFirst: "Add tests.", implement: "Render the prompt.", verify: "Run checks." }],
+          },
+          planReview: {
+            decision: "pass",
+            summary: "Ready to review.",
+            issues: [],
+          },
+          uxVerificationStatus: "failed",
+          uxTestResults: [{ step: "Open the build", passed: false, screenshotUrl: null, error: "No evidence captured." }],
+        })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    expect(html).toContain('data-testid="build-studio-custodian-callout"');
+    expect(html).toContain("I can collect what is missing.");
+    expect(html.match(/Finish review with coworker/g)).toHaveLength(1);
+    expect(html).not.toContain('data-testid="build-studio-action-banner"');
+  });
+
   it("mounts the footer OpenSandboxButton — single shared sandbox link", () => {
     // Footer surfaces the shared sandbox without resorting to a per-build
     // Preview tab. When a build has a live sandboxPort, the footer button

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
@@ -494,6 +494,92 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
     expect(banner).toHaveTextContent("Plan review failed. Refine the plan first.");
   });
 
+  it("compact=true replaces the banner with custodian prompt when proactive help is active", () => {
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "review", decisionInteraction: null })}
+        action={implementationAction({ primaryLabel: "Run UX Verification" })}
+        compact
+        custodianPrompt={{
+          dismissKey: "custodian-one",
+          title: "I can keep this review moving.",
+          whyNow: "UX verification still needs clean evidence.",
+          recommendedAction: "I can collect the acceptance evidence.",
+          primaryLabel: "Let AI Coworker handle it",
+          primaryAction: "coworker",
+          coworkerPrompt: "Act as the Build Studio custodian.",
+          statusLabel: "Needs evidence",
+          intent: "warning",
+          details: ["Review evidence is missing."],
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("region", { name: "Current build action" })).not.toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "AI Coworker proactive help" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Let AI Coworker handle it/ })).toBeInTheDocument();
+  });
+
+  it("custodian coworker action opens the agent panel with the custodian prompt", () => {
+    const listener = vi.fn();
+    document.addEventListener("open-agent-panel", listener);
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "review", decisionInteraction: null })}
+        action={implementationAction({ primaryLabel: "Run UX Verification" })}
+        compact
+        custodianPrompt={{
+          dismissKey: "custodian-two",
+          title: "I can keep this review moving.",
+          whyNow: "UX verification still needs clean evidence.",
+          recommendedAction: "I can collect the acceptance evidence.",
+          primaryLabel: "Let AI Coworker handle it",
+          primaryAction: "coworker",
+          coworkerPrompt: "Act as the Build Studio custodian.",
+          statusLabel: "Needs evidence",
+          intent: "warning",
+          details: ["Review evidence is missing."],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Let AI Coworker handle it/ }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail.autoMessage).toBe("Act as the Build Studio custodian.");
+    expect(event.detail.targetBuildId).toBe("FB-9B19098C");
+    document.removeEventListener("open-agent-panel", listener);
+  });
+
+  it("custodian workflow action reuses the existing primary dispatch", async () => {
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "plan", decisionInteraction: null })}
+        action={implementationAction()}
+        compact
+        custodianPrompt={{
+          dismissKey: "custodian-three",
+          title: "I found the recovery path.",
+          whyNow: "This stop has a guided repair.",
+          recommendedAction: "Try the guided fix now.",
+          primaryLabel: "Start Implementation",
+          primaryAction: "workflow",
+          coworkerPrompt: "Act as the Build Studio custodian.",
+          statusLabel: "Blocked",
+          intent: "danger",
+          details: ["Use the existing dispatch."],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Start Implementation/ }));
+
+    await waitFor(() => {
+      expect(mockAdvanceBuildPhase).toHaveBeenCalledWith("FB-9B19098C", "build");
+    });
+  });
+
   it("compact=true falls back to the full card when a decision interaction needs capture", () => {
     // makeBuild() default already includes a decisionInteraction that
     // requires capture — perfect setup for the fallback path.

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -18,6 +18,8 @@ import type { ResumeBuildImplementationOutcome } from "@/lib/build/progress-visi
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import type { DecisionGateCaptureDraft } from "@/lib/decision-perspective/capture-types";
 import { ActionBanner, type ActionBannerState } from "./ActionBanner";
+import { BuildStudioCustodianCallout } from "./BuildStudioCustodianCallout";
+import type { BuildStudioCustodianPrompt } from "./build-studio-custodian";
 import { DecisionPerspectiveGatePanel } from "./DecisionPerspectiveGatePanel";
 import { TruthSourceBadge } from "./TruthSourceBadge";
 import {
@@ -29,6 +31,8 @@ type Props = {
   build: FeatureBuildRow;
   action: BuildStudioWorkflowAction;
   compact?: boolean;
+  custodianPrompt?: BuildStudioCustodianPrompt | null;
+  onCustodianSnooze?: (prompt: BuildStudioCustodianPrompt) => void;
   onCompleted?: () => Promise<void> | void;
 };
 
@@ -62,6 +66,8 @@ export function BuildStudioWorkflowActionCard({
   build,
   action,
   compact = false,
+  custodianPrompt = null,
+  onCustodianSnooze,
   onCompleted,
 }: Props) {
   const router = useRouter();
@@ -220,14 +226,26 @@ export function BuildStudioWorkflowActionCard({
   }
 
   function handleCoworkerAction() {
+    openCoworkerPanel(action.coworkerPrompt);
+  }
+
+  function openCoworkerPanel(prompt: string) {
     document.dispatchEvent(
       new CustomEvent("open-agent-panel", {
         detail: {
-          autoMessage: action.coworkerPrompt,
+          autoMessage: prompt,
           targetBuildId: build.buildId,
         },
       }),
     );
+  }
+
+  async function handleCustodianPrimaryAction(prompt: BuildStudioCustodianPrompt) {
+    if (prompt.primaryAction === "workflow") {
+      await handlePrimaryAction();
+      return;
+    }
+    openCoworkerPanel(prompt.coworkerPrompt);
   }
 
   async function handleDecisionCapture(capture: DecisionGateCaptureDraft) {
@@ -258,6 +276,26 @@ export function BuildStudioWorkflowActionCard({
   // 40px banner has no room for the capture UI.
   const compactBannerEligible = compact && !decisionInteraction;
   if (compactBannerEligible) {
+    if (custodianPrompt) {
+      return (
+        <div data-testid="build-studio-workflow-action-card">
+          <BuildStudioCustodianCallout
+            prompt={custodianPrompt}
+            onPrimaryAction={() => void handleCustodianPrimaryAction(custodianPrompt)}
+            onSnooze={() => onCustodianSnooze?.(custodianPrompt)}
+          />
+          {error && (
+            <div
+              role="alert"
+              className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-2 text-xs text-[var(--dpf-danger)]"
+            >
+              {error}
+            </div>
+          )}
+        </div>
+      );
+    }
+
     const bannerState = deriveActionBannerState(build, action);
     const bannerPrimaryAction = operatorGuidance.nextLabel
       ? {

--- a/apps/web/components/build/build-studio-custodian.test.ts
+++ b/apps/web/components/build/build-studio-custodian.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
+import {
+  normalizeHappyPathState,
+  type FeatureBuildRow,
+} from "@/lib/feature-build-types";
+import {
+  deriveBuildStudioWorkflowAction,
+  type BuildStudioWorkflowAction,
+} from "./build-studio-workflow-actions";
+import { deriveBuildStudioCustodianPrompt } from "./build-studio-custodian";
+
+function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    id: "build-row-1",
+    buildId: "FB-9B19098C",
+    title: "Build Studio operator review",
+    description: "Make the Build Studio review path clear.",
+    portfolioId: null,
+    originatingBacklogItemId: "backlog-row-1",
+    brief: {
+      title: "Build Studio operator review",
+      description: "Make the Build Studio review path clear.",
+      portfolioContext: "Platform",
+      targetRoles: ["operator"],
+      inputs: ["feature build state"],
+      dataNeeds: "FeatureBuild",
+      acceptanceCriteria: ["The operator can finish review from Build Studio."],
+    },
+    plan: { happyPathState: normalizeHappyPathState(null) },
+    phase: "review",
+    sandboxId: null,
+    sandboxPort: null,
+    diffSummary: null,
+    diffPatch: null,
+    codingProvider: null,
+    threadId: "thread-1",
+    digitalProductId: null,
+    product: null,
+    createdById: "user-1",
+    createdAt: new Date("2026-06-29T12:00:00Z"),
+    updatedAt: new Date("2026-06-29T12:10:00Z"),
+    draftApprovedAt: new Date("2026-06-29T12:01:00Z"),
+    designDoc: {
+      problemStatement: "The review path is unclear.",
+      proposedApproach: "Show one next action.",
+      reusePlan: "Reuse Build Studio actions.",
+      acceptanceCriteria: ["The operator can finish review from Build Studio."],
+    },
+    designReview: { decision: "pass", summary: "Ready.", issues: [] },
+    buildPlan: {
+      fileStructure: [{ path: "apps/web/components/build/BuildStudio.tsx", action: "modify", purpose: "Show custodian prompt." }],
+      tasks: [{ title: "Add custodian prompt", testFirst: "Add tests", implement: "Render prompt", verify: "Run tests" }],
+    },
+    planReview: { decision: "pass", summary: "Ready.", issues: [] },
+    taskResults: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    scoutFindings: null,
+    uxTestResults: null,
+    uxVerificationStatus: "failed",
+    accountableEmployeeId: null,
+    claimedByAgentId: null,
+    claimedAt: null,
+    claimStatus: null,
+    buildExecState: null,
+    deliberationSummary: null,
+    originator: null,
+    phaseHandoffs: [],
+    happyPathState: normalizeHappyPathState(null),
+    ...overrides,
+  };
+}
+
+function progress(overrides: Partial<BuildProgressVisibility> = {}): BuildProgressVisibility {
+  return {
+    buildId: "FB-9B19098C",
+    generatedAt: "2026-06-29T12:20:00.000Z",
+    statusHeading: { operatorAction: "Run UX verification", failureAxis: null },
+    progress: {
+      primary: { source: "db-task-results", completed: 0, total: 0, observedAt: null },
+      conflicts: [],
+    },
+    tasks: {
+      completedTasks: 0,
+      totalTasks: 0,
+      source: { source: "db-task-results", completed: 0, total: 0, observedAt: null },
+      tasks: [],
+    },
+    staleChatSnapshots: [],
+    sandbox: null,
+    dispatchHistory: [],
+    verification: null,
+    quietAgent: {
+      quiet: true,
+      minutesQuiet: 8,
+      lastObservableSignalAt: "2026-06-29T12:12:00.000Z",
+    },
+    phaseRuns: [],
+    ...overrides,
+  };
+}
+
+describe("deriveBuildStudioCustodianPrompt", () => {
+  it("surfaces proactive help when UX verification failed and the next click would feel inert", () => {
+    const build = makeBuild({ uxVerificationStatus: "failed" });
+    const action = deriveBuildStudioWorkflowAction({ build, governedBacklogEnabled: true });
+    const prompt = deriveBuildStudioCustodianPrompt({ build, action, progressVisibility: progress() });
+
+    expect(prompt).not.toBeNull();
+    expect(prompt?.title).toBe("I can keep this review moving.");
+    expect(prompt?.primaryAction).toBe("coworker");
+    expect(prompt?.primaryLabel).toBe("Let AI Coworker handle it");
+    expect(prompt?.whyNow).toContain("UX verification still needs clean evidence");
+    expect(prompt?.coworkerPrompt).toContain("Act as the Build Studio custodian");
+});
+
+  it("stays quiet while an execution step is actively working", () => {
+    const build = makeBuild({
+      phase: "build",
+      uxVerificationStatus: null,
+      buildExecState: {
+        step: "deps_installed",
+        retryCount: 0,
+        startedAt: "2026-06-29T12:12:00.000Z",
+      },
+    });
+    const action = deriveBuildStudioWorkflowAction({ build, governedBacklogEnabled: true });
+    const prompt = deriveBuildStudioCustodianPrompt({
+      build,
+      action,
+      progressVisibility: progress({ quietAgent: { quiet: false, minutesQuiet: 1, lastObservableSignalAt: "2026-06-29T12:19:00.000Z" } }),
+    });
+
+    expect(prompt).toBeNull();
+  });
+
+  it("uses the in-place guided recovery as the primary action for failed plan review", () => {
+    const build = makeBuild({
+      phase: "plan",
+      uxVerificationStatus: null,
+      planReview: {
+        decision: "fail",
+        summary: "Needs a clearer verification plan.",
+        issues: [{ severity: "critical", description: "Verification path is missing." }],
+      },
+    });
+    const action = deriveBuildStudioWorkflowAction({ build, governedBacklogEnabled: true });
+    const prompt = deriveBuildStudioCustodianPrompt({ build, action, progressVisibility: progress() });
+
+    expect(action.kind).toBe("rerun-plan-review");
+    expect(prompt?.primaryAction).toBe("workflow");
+    expect(prompt?.primaryLabel).toBe("Try to fix");
+    expect(prompt?.recommendedAction).toContain("guided fix");
+  });
+
+  it("offers evidence collection when the current gate is blocked by missing evidence", () => {
+    const build = makeBuild();
+    const action: BuildStudioWorkflowAction = {
+      kind: "advance-phase",
+      title: "Complete Review Evidence",
+      message: "Review is still missing evidence or approvals.",
+      primaryLabel: "Continue to Release",
+      targetPhase: "ship",
+      disabledReason: "Acceptance criteria not evaluated.",
+      coworkerLabel: "Finish review with coworker",
+      coworkerPrompt: "Evaluate each acceptance criterion.",
+    };
+    const prompt = deriveBuildStudioCustodianPrompt({ build, action, progressVisibility: progress() });
+
+    expect(action.disabledReason).toBe("Acceptance criteria not evaluated.");
+    expect(prompt?.statusLabel).toBe("Waiting on evidence");
+    expect(prompt?.primaryAction).toBe("coworker");
+    expect(prompt?.recommendedAction).toContain("collect the missing evidence");
+  });
+});

--- a/apps/web/components/build/build-studio-custodian.ts
+++ b/apps/web/components/build/build-studio-custodian.ts
@@ -1,0 +1,203 @@
+import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
+import type { FeatureBuildRow } from "@/lib/feature-build-types";
+import type { Intent } from "@/components/ui/report-kit";
+import {
+  deriveBuildStudioOperatorGuidance,
+  type BuildStudioWorkflowAction,
+} from "./build-studio-workflow-actions";
+
+export type BuildStudioCustodianPrimaryAction = "workflow" | "coworker";
+
+export type BuildStudioCustodianPrompt = {
+  dismissKey: string;
+  title: string;
+  whyNow: string;
+  recommendedAction: string;
+  primaryLabel: string;
+  primaryAction: BuildStudioCustodianPrimaryAction;
+  coworkerPrompt: string;
+  statusLabel: string;
+  intent: Intent;
+  details: string[];
+};
+
+type CustodianPromptInput = {
+  build: FeatureBuildRow;
+  action: BuildStudioWorkflowAction;
+  progressVisibility?: BuildProgressVisibility | null;
+};
+
+const QUIET_REVIEW_THRESHOLD_MINUTES = 5;
+const QUIET_BUILD_THRESHOLD_MINUTES = 10;
+
+function formatMinutes(minutes: number): string {
+  if (minutes < 1) return "less than a minute";
+  if (minutes === 1) return "1 minute";
+  return `${minutes} minutes`;
+}
+
+function appendCustodianInstruction(action: BuildStudioWorkflowAction, instruction: string): string {
+  return `${action.coworkerPrompt}\n\n${instruction}`;
+}
+
+function buildDismissKey(
+  build: FeatureBuildRow,
+  action: BuildStudioWorkflowAction,
+  progressVisibility?: BuildProgressVisibility | null,
+): string {
+  const signal =
+    progressVisibility?.quietAgent.lastObservableSignalAt
+    ?? build.updatedAt.toISOString();
+  return [
+    build.buildId,
+    build.phase,
+    action.kind,
+    build.uxVerificationStatus ?? "ux-unknown",
+    signal,
+  ].join(":");
+}
+
+function isUxReviewGap(
+  build: FeatureBuildRow,
+  action: BuildStudioWorkflowAction,
+  progressVisibility?: BuildProgressVisibility | null,
+): boolean {
+  if (build.phase !== "review" || action.kind !== "run-review-verification") {
+    return false;
+  }
+
+  return (
+    build.uxVerificationStatus === "failed"
+    || (
+      build.uxVerificationStatus == null
+      && progressVisibility?.quietAgent.quiet === true
+      && progressVisibility.quietAgent.minutesQuiet >= QUIET_REVIEW_THRESHOLD_MINUTES
+    )
+  );
+}
+
+export function deriveBuildStudioCustodianPrompt({
+  build,
+  action,
+  progressVisibility,
+}: CustodianPromptInput): BuildStudioCustodianPrompt | null {
+  if (build.phase === "complete" || build.phase === "ship") {
+    return null;
+  }
+
+  const guidance = deriveBuildStudioOperatorGuidance(action, build);
+  if (guidance.status.kind === "working" && progressVisibility?.quietAgent.quiet !== true) {
+    return null;
+  }
+
+  const quietMinutes = progressVisibility?.quietAgent.minutesQuiet ?? 0;
+  const isQuietReview =
+    build.phase === "review"
+    && progressVisibility?.quietAgent.quiet === true
+    && quietMinutes >= QUIET_REVIEW_THRESHOLD_MINUTES;
+  const isQuietBuild =
+    build.phase === "build"
+    && progressVisibility?.quietAgent.quiet === true
+    && quietMinutes >= QUIET_BUILD_THRESHOLD_MINUTES;
+  const blockedByEvidence = action.disabledReason != null;
+  const technicalRecovery =
+    action.kind === "resume-implementation"
+    || action.kind === "rerun-plan-review"
+    || action.kind === "retry-build"
+    || action.kind === "reset-build";
+  const uxReviewGap = isUxReviewGap(build, action, progressVisibility);
+
+  if (!uxReviewGap && !blockedByEvidence && !technicalRecovery && !isQuietReview && !isQuietBuild) {
+    return null;
+  }
+
+  const dismissKey = buildDismissKey(build, action, progressVisibility);
+
+  if (uxReviewGap) {
+    return {
+      dismissKey,
+      title: "I can keep this review moving.",
+      whyNow: build.uxVerificationStatus === "failed"
+        ? "UX verification still needs clean evidence, so another quiet click can look like nothing happened."
+        : `This review has been quiet for ${formatMinutes(quietMinutes)} while UX evidence is still missing.`,
+      recommendedAction: "I can collect the acceptance evidence, rerun the review path if needed, and report the one next decision.",
+      primaryLabel: "Let AI Coworker handle it",
+      primaryAction: "coworker",
+      coworkerPrompt: appendCustodianInstruction(
+        action,
+        "Act as the Build Studio custodian. Check the UX verification and acceptance evidence, take the safest in-place recovery available, and come back with exactly one next action for the human.",
+      ),
+      statusLabel: "Needs evidence",
+      intent: "warning",
+      details: [
+        "The review is not ready to release until UX evidence and acceptance evidence agree.",
+        "If the retry already started work, wait for that evidence first. If it did not, use the existing Build Studio recovery path instead of asking the human to diagnose logs.",
+      ],
+    };
+  }
+
+  if (technicalRecovery) {
+    return {
+      dismissKey,
+      title: "I found the recovery path.",
+      whyNow: guidance.guidedRecovery
+        ? "This stop has a guided repair, so you should not have to investigate technical details first."
+        : "The build is technically blocked, and the safest next step is already available here.",
+      recommendedAction: guidance.guidedRecovery
+        ? "Try the guided fix now. I will keep watching the result."
+        : "Restart the stuck step from Build Studio. I will keep watching the result.",
+      primaryLabel: action.primaryLabel ?? "Try to fix",
+      primaryAction: "workflow",
+      coworkerPrompt: appendCustodianInstruction(
+        action,
+        "Act as the Build Studio custodian. Explain the recovery in plain English and keep the human to one next action.",
+      ),
+      statusLabel: "Blocked",
+      intent: "danger",
+      details: [
+        action.message,
+        guidance.recoveryHint ?? "Use the in-place recovery first; escalate only if it cannot make progress.",
+      ].filter(Boolean),
+    };
+  }
+
+  if (blockedByEvidence) {
+    return {
+      dismissKey,
+      title: "I can collect what is missing.",
+      whyNow: "This build is waiting because required evidence is missing, not because you need to read the technical detail.",
+      recommendedAction: "Let the AI Coworker collect the missing evidence and return with the next release decision.",
+      primaryLabel: action.coworkerLabel,
+      primaryAction: "coworker",
+      coworkerPrompt: appendCustodianInstruction(
+        action,
+        "Act as the Build Studio custodian. Collect the missing evidence from the existing Build Studio surfaces and return with one next action.",
+      ),
+      statusLabel: "Waiting on evidence",
+      intent: "accent",
+      details: [
+        action.disabledReason ?? "Required evidence is missing.",
+        "The human should see the conclusion and one next action, not raw workflow internals.",
+      ],
+    };
+  }
+
+  return {
+    dismissKey,
+    title: "This build has gone quiet.",
+    whyNow: `I have not seen a fresh progress signal for ${formatMinutes(quietMinutes)}.`,
+    recommendedAction: "I can check whether work is still moving and come back with the next action only if one is needed.",
+    primaryLabel: "Ask AI Coworker to check",
+    primaryAction: "coworker",
+    coworkerPrompt: appendCustodianInstruction(
+      action,
+      "Act as the Build Studio custodian. Check whether this build is still making progress. If it is healthy, say so briefly. If not, take the safest available recovery or return one next action.",
+    ),
+    statusLabel: "Quiet",
+    intent: "info",
+    details: [
+      "The surface should stay quiet while work progresses.",
+      "A quiet build only interrupts when the next step is useful for keeping delivery moving.",
+    ],
+  };
+}

--- a/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
+++ b/docs/superpowers/plans/2026-06-26-build-studio-overseer-implementation.md
@@ -59,6 +59,14 @@ Design anchor: [Attention Surface §3.4](../specs/2026-06-23-human-attention-sur
 
 WWMD/UX-Fit-Decision: choose the Attention Surface amendment plus Build Studio pilot over a Build-Studio-only addendum or a standalone new spec. `principle_decide` recommended this direction with high confidence (composite 9.479, margin 2.200, commandmentConflict:false). The merits are the deciding rationale: no duplicate queue, no second backlog, no fabricated priority score, and a clear path from a painful Build Studio incident to a reusable coworker primitive.
 
+Implementation slice:
+
+- Add a pure `deriveBuildStudioCustodianPrompt` projection next to the existing workflow-action derivation. It watches the same source-owned build state plus `BuildProgressVisibility` quiet-agent signals; it does not introduce a new table or queue.
+- Render `BuildStudioCustodianCallout` only when the prompt is active. In compact mode it replaces the normal `ActionBanner`, so the operator still sees one visible status surface and one primary action rather than a stacked alert plus banner.
+- Covered prompt classes: UX-review evidence gaps (including the "retry felt inert" case), quiet review/build states, missing-evidence gates, and existing guided repair paths (`rerun-plan-review`, `resume-implementation`, retry/reset).
+- Add session snooze and collapsed "Show why" context. Snooze is intentionally local/session-scoped for the pilot; the platform primitive (`BI-5B6F666F`) owns durable cross-coworker quiet thresholds.
+- Primary actions reuse existing plumbing: workflow recovery uses the existing Build Studio primary action handler; coworker custody opens the existing agent panel with a narrowed custodian prompt.
+
 ## Verification
 
 Source-only worktree → typecheck / vitest / production build / migration-apply are CI-gated. Band 2's parser + the band component are unit/render tested. The narrative's *generation quality* depends on the model tier (local vs robust) and is validated by a real build run; the structure ships now so it is ready the moment a build completes.


### PR DESCRIPTION
## Summary
- add a Build Studio custodian prompt derivation for UX-review evidence gaps, quiet/stuck work, missing-evidence gates, and guided repair paths
- render the proactive prompt as the single compact action surface when active, replacing the normal ActionBanner instead of stacking another alert
- reuse existing workflow recovery and coworker-panel plumbing; add session snooze and collapsed Show why context
- update the Build Studio overseer implementation plan with the custodian-mode slice

## Verification
- `pnpm --filter web exec vitest run components/build/build-studio-custodian.test.ts components/build/BuildStudioCustodianCallout.test.tsx components/build/BuildStudioWorkflowActionCard.test.tsx components/build/BuildStudioHeaderLayout.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` passed; emitted existing Turbopack/NFT warnings around `next.config.mjs` and Edge-runtime imports, but completed successfully
- `git diff --check`

UX-Fit-Decision: fits-with-guardrails. The Build Studio custodian pilot reduces operator cognitive load by replacing the compact action banner only when a source-state prompt is active, preserving one status plus one primary action. It composes report-kit StatusBadge, token-backed styling, existing workflow recovery/coworker plumbing, and no new route, table, queue, or native dialog. WWMD was consulted; the raw principle_decide result was process-heavy and advisory, while the governing commandment "Do the work; don't task the operator" plus live backlog BI-ACB04A21 drove implementation.