### PR TITLE
feat: classify provider capacity failures

### DIFF
--- a/apps/web/lib/inference/ai-inference.test.ts
+++ b/apps/web/lib/inference/ai-inference.test.ts
@@ -13,6 +13,17 @@ describe("InferenceError", () => {
     const err = new InferenceError("rate limited", "rate_limit", "openai", 429);
     expect(err.statusCode).toBe(429);
   });
+
+  it("carries provider capacity classification when provided", () => {
+    const err = new InferenceError("needs credits", "billing", "zai-coding", 429, undefined, undefined, {
+      state: "billing_action_required",
+      action: "add_credits_or_plan",
+      safeSummary: "Z.ai needs coding credits.",
+      confidence: "exact",
+      isHumanActionRequired: true,
+    });
+    expect(err.capacity?.action).toBe("add_credits_or_plan");
+  });
 });
 
 describe("classifyHttpError", () => {
@@ -37,6 +48,27 @@ describe("classifyHttpError", () => {
 
     expect(err.code).toBe("overloaded");
     expect(err.statusCode).toBe(503);
+  });
+
+  it("attaches Z.ai capacity classification for insufficient coding credits", () => {
+    const err = classifyHttpError(
+      429,
+      "zai-coding",
+      JSON.stringify({
+        error: {
+          code: "1113",
+          message: "Insufficient balance or no resource package. Please recharge.",
+        },
+      }),
+    );
+
+    expect(err.code).toBe("billing");
+    expect(err.capacity).toMatchObject({
+      state: "billing_action_required",
+      action: "add_credits_or_plan",
+      providerCode: "1113",
+      isHumanActionRequired: true,
+    });
   });
 });
 

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -614,12 +614,16 @@ export async function callProvider(
         classification: err.capacity,
         source: "api",
         rawSnippet: err.rawBody ?? err.message,
+      }).catch((capacityErr) => {
+        console.warn("[ai-inference] Failed to record provider capacity:", capacityErr);
       });
     }
     throw err;
   }
 
-  void clearProviderCapacityStatus({ providerId, source: "api" });
+  void clearProviderCapacityStatus({ providerId, source: "api" }).catch((capacityErr) => {
+    console.warn("[ai-inference] Failed to clear provider capacity:", capacityErr);
+  });
 
   // 4. Record token and cost metrics
   aiInferenceTokens.inc({ provider: providerId, model: modelId, direction: "input" }, result.usage.inputTokens);

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -29,6 +29,14 @@ import {
 } from "../routing/execution-adapter-types";
 import { writeAdapterTelemetry } from "../routing/adapter-telemetry-writer";
 import { getCliPoolStatus } from "../routing/cli-pool-status";
+import {
+  classifyProviderCapacity,
+  type ProviderCapacityClassification,
+} from "../routing/provider-capacity";
+import {
+  clearProviderCapacityStatus,
+  recordProviderCapacityStatus,
+} from "../routing/provider-capacity/store";
 import "../routing/chat-adapter"; // side-effect: registers "chat" adapter
 import "../routing/responses-adapter"; // side-effect: registers "responses" adapter
 import "../routing/image-gen-adapter"; // EP-INF-009c: registers "image_gen" adapter
@@ -127,6 +135,7 @@ export class InferenceError extends Error {
     public readonly statusCode?: number,
     public readonly headers?: Record<string, string>,
     public readonly rawBody?: string,
+    public readonly capacity?: ProviderCapacityClassification,
   ) {
     super(message);
     this.name = "InferenceError";
@@ -154,29 +163,36 @@ export function classifyHttpError(
   const headers = rateLimitHeaders && Object.keys(rateLimitHeaders).length > 0
     ? rateLimitHeaders
     : undefined;
+  const capacity = classifyProviderCapacity({
+    providerId,
+    statusCode: status,
+    headers: responseHeaders ?? headers,
+    bodyText: body,
+    now: new Date(),
+  });
 
   if (status === 401 || status === 403) {
-    return new InferenceError(`Auth failed for ${providerId}: ${body.slice(0, 200)}`, "auth", providerId, status, headers, body);
+    return new InferenceError(`Auth failed for ${providerId}: ${body.slice(0, 200)}`, "auth", providerId, status, headers, body, capacity);
   }
-  if (status === 402) {
-    return new InferenceError(`Billing error on ${providerId}: ${body.slice(0, 200)}`, "billing", providerId, status, headers, body);
+  if (status === 402 || capacity.state === "billing_action_required" || capacity.state === "unsupported_plan") {
+    return new InferenceError(`Billing error on ${providerId}: ${body.slice(0, 200)}`, "billing", providerId, status, headers, body, capacity);
   }
   if (status === 413) {
-    return new InferenceError(`Request too large for ${providerId}: ${body.slice(0, 200)}`, "request_too_large", providerId, status, headers, body);
+    return new InferenceError(`Request too large for ${providerId}: ${body.slice(0, 200)}`, "request_too_large", providerId, status, headers, body, capacity);
   }
   if (status === 429) {
-    return new InferenceError(`Rate limited by ${providerId}`, "rate_limit", providerId, status, headers, body);
+    return new InferenceError(`Rate limited by ${providerId}`, "rate_limit", providerId, status, headers, body, capacity);
   }
   if (status === 529 || /\b529\b|overloaded/i.test(body)) {
-    return new InferenceError(`Provider overloaded on ${providerId}: ${body.slice(0, 300)}`, "overloaded", providerId, status, headers, body);
+    return new InferenceError(`Provider overloaded on ${providerId}: ${body.slice(0, 300)}`, "overloaded", providerId, status, headers, body, capacity);
   }
   if (status === 404) {
-    return new InferenceError(`Model not found on ${providerId}: ${body.slice(0, 200)}`, "model_not_found", providerId, status, headers, body);
+    return new InferenceError(`Model not found on ${providerId}: ${body.slice(0, 200)}`, "model_not_found", providerId, status, headers, body, capacity);
   }
   if (status === 408 || status === 500 || status === 502 || status === 503 || status === 504) {
-    return new InferenceError(`Transient error (${status}) from ${providerId}: ${body.slice(0, 200)}`, "transient", providerId, status, headers, body);
+    return new InferenceError(`Transient error (${status}) from ${providerId}: ${body.slice(0, 200)}`, "transient", providerId, status, headers, body, capacity);
   }
-  return new InferenceError(`HTTP ${status} from ${providerId}: ${body.slice(0, 300)}`, "provider_error", providerId, status, headers, body);
+  return new InferenceError(`HTTP ${status} from ${providerId}: ${body.slice(0, 300)}`, "provider_error", providerId, status, headers, body, capacity);
 }
 
 // ─── Build Auth Headers ──────────────────────────────────────────────────────
@@ -592,8 +608,18 @@ export async function callProvider(
       skillId: attribution?.skillId ?? undefined,
       agentMessageId: attribution?.agentMessageId ?? undefined,
     });
+    if (err instanceof InferenceError && err.capacity) {
+      void recordProviderCapacityStatus({
+        providerId,
+        classification: err.capacity,
+        source: "api",
+        rawSnippet: err.rawBody ?? err.message,
+      });
+    }
     throw err;
   }
+
+  void clearProviderCapacityStatus({ providerId, source: "api" });
 
   // 4. Record token and cost metrics
   aiInferenceTokens.inc({ provider: providerId, model: modelId, direction: "input" }, result.usage.inputTokens);

--- a/apps/web/lib/integrate/opencode-dispatch.test.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+const recordProviderCapacityStatusMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/routing/provider-capacity/store", () => ({
+  recordProviderCapacityStatus: recordProviderCapacityStatusMock,
+}));
+
 import {
   sandboxReachableUrl,
   preflightLocalEndpoint,
@@ -10,6 +17,7 @@ import {
   buildOpencodeInstructions,
   detectOpencodeFatalError,
   buildOpencodeRunnerScript,
+  recordOpencodeCapacityFailure,
 } from "./opencode-dispatch";
 
 describe("detectOpencodeFatalError", () => {
@@ -36,6 +44,33 @@ describe("detectOpencodeFatalError", () => {
 
   it("tolerates non-JSON / empty lines", () => {
     expect(detectOpencodeFatalError("plain log line\n\nnot json")).toBeNull();
+  });
+});
+
+describe("recordOpencodeCapacityFailure", () => {
+  it("records Z.ai insufficient credits as provider capacity state", async () => {
+    recordProviderCapacityStatusMock.mockResolvedValue(undefined);
+
+    await recordOpencodeCapacityFailure({
+      providerId: "zai-coding",
+      output: JSON.stringify({
+        error: {
+          code: "1113",
+          message: "Insufficient balance or no resource package. Please recharge.",
+        },
+      }),
+    });
+
+    expect(recordProviderCapacityStatusMock).toHaveBeenCalledWith({
+      providerId: "zai-coding",
+      source: "opencode",
+      rawSnippet: expect.stringContaining("1113"),
+      classification: expect.objectContaining({
+        state: "billing_action_required",
+        action: "add_credits_or_plan",
+        providerCode: "1113",
+      }),
+    });
   });
 });
 

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -39,6 +39,8 @@ import { KNOWN_PROVIDER_MODELS } from "@/lib/routing/known-provider-models";
 import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
 import { sanitizeForLog } from "@/lib/security/safe-log";
 import { resolveBuildWorkdir } from "./sandbox/build-branch";
+import { classifyProviderCapacity } from "@/lib/routing/provider-capacity";
+import { recordProviderCapacityStatus } from "@/lib/routing/provider-capacity/store";
 
 const DEFAULT_SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 
@@ -335,6 +337,29 @@ export function buildOpencodeRunnerScript(args: {
   ].join("\n");
 }
 
+export async function recordOpencodeCapacityFailure(args: {
+  providerId: string;
+  output: string;
+  statusCode?: number;
+}): Promise<void> {
+  const classification = classifyProviderCapacity({
+    providerId: args.providerId,
+    statusCode: args.statusCode ?? 429,
+    bodyText: args.output,
+    errorMessage: args.output,
+    now: new Date(),
+  });
+
+  if (classification.state === "unknown") return;
+
+  await recordProviderCapacityStatus({
+    providerId: args.providerId,
+    source: "opencode",
+    classification,
+    rawSnippet: args.output,
+  });
+}
+
 function defaultKnownOpencodeModel(providerId: string): string | null {
   const models = KNOWN_PROVIDER_MODELS[providerId] ?? [];
   return models.find((model) => model.defaultStatus === "active")?.modelId ?? models[0]?.modelId ?? null;
@@ -585,6 +610,12 @@ export async function dispatchOpencodeTask(params: {
         stdout: content,
         stderr: fatalError,
       });
+      await recordOpencodeCapacityFailure({
+        providerId,
+        output: fatalError,
+      }).catch((recordErr) => {
+        console.warn("[opencode-dispatch] Failed to record provider capacity:", recordErr);
+      });
       return {
         content: `OpenCode task failed: ${fatalError}`,
         success: false,
@@ -638,6 +669,12 @@ export async function dispatchOpencodeTask(params: {
       success: false,
       stdout: execErr.stdout ?? "",
       stderr: output || execErr.message || "",
+    });
+    await recordOpencodeCapacityFailure({
+      providerId,
+      output: output || execErr.message || "",
+    }).catch((recordErr) => {
+      console.warn("[opencode-dispatch] Failed to record provider capacity:", recordErr);
     });
 
     return {

--- a/apps/web/lib/routing/provider-capacity/headers.ts
+++ b/apps/web/lib/routing/provider-capacity/headers.ts
@@ -1,0 +1,28 @@
+type HeaderBag = Headers | Record<string, string | string[] | undefined> | undefined;
+
+function readHeader(headers: HeaderBag, name: string): string | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  const found = Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  const value = found?.[1];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+export function parseRetryAfterSeconds(headers: HeaderBag, now: Date = new Date()): number | null {
+  const retryAfter = readHeader(headers, "retry-after");
+  if (retryAfter) {
+    const seconds = Number.parseInt(retryAfter, 10);
+    if (Number.isFinite(seconds)) return Math.max(0, seconds);
+    const dateMs = Date.parse(retryAfter);
+    if (Number.isFinite(dateMs)) return Math.max(0, Math.ceil((dateMs - now.getTime()) / 1000));
+  }
+
+  const reset = readHeader(headers, "x-ratelimit-reset") ?? readHeader(headers, "x-rate-limit-reset");
+  if (reset) {
+    const epoch = Number.parseInt(reset, 10);
+    if (Number.isFinite(epoch)) return Math.max(0, epoch - Math.floor(now.getTime() / 1000));
+  }
+
+  return null;
+}

--- a/apps/web/lib/routing/provider-capacity/index.ts
+++ b/apps/web/lib/routing/provider-capacity/index.ts
@@ -1,0 +1,92 @@
+import { parseRetryAfterSeconds } from "./headers";
+import { classifyZaiCapacity } from "./zai";
+import type {
+  ProviderCapacityClassification,
+  ProviderCapacityClassifierInput,
+} from "./types";
+
+export { parseRetryAfterSeconds } from "./headers";
+export type {
+  ProviderCapacityAction,
+  ProviderCapacityClassification,
+  ProviderCapacityClassifierInput,
+  ProviderCapacityState,
+} from "./types";
+
+function retryAtFromSeconds(now: Date, seconds: number): Date {
+  return new Date(now.getTime() + seconds * 1000);
+}
+
+function isZaiProvider(providerId: string): boolean {
+  return providerId === "zai" || providerId === "zai-coding";
+}
+
+export function classifyProviderCapacity(
+  input: ProviderCapacityClassifierInput,
+): ProviderCapacityClassification {
+  if (isZaiProvider(input.providerId)) {
+    const zai = classifyZaiCapacity(input);
+    if (zai) return zai;
+  }
+
+  const retryAfterSeconds = parseRetryAfterSeconds(input.headers, input.now);
+  if (input.statusCode === 429 && retryAfterSeconds !== null) {
+    return {
+      state: "rate_limited",
+      action: "retry_at",
+      retryAt: retryAtFromSeconds(input.now, retryAfterSeconds),
+      retryAfterSeconds,
+      safeSummary: "The provider is temporarily rate limited. DPF will retry after the provider's reset time.",
+      confidence: "header",
+      isHumanActionRequired: false,
+    };
+  }
+
+  if (input.statusCode === 429) {
+    return {
+      state: "rate_limited",
+      action: "retry_with_backoff",
+      safeSummary: "The provider is temporarily rate limited. DPF will retry with backoff.",
+      confidence: "heuristic",
+      isHumanActionRequired: false,
+    };
+  }
+
+  if (input.statusCode === 401 || input.statusCode === 403) {
+    return {
+      state: "reauth_required",
+      action: "reconnect",
+      safeSummary: "The provider rejected the saved credential. Reconnect this provider to restore access.",
+      confidence: "heuristic",
+      isHumanActionRequired: true,
+    };
+  }
+
+  if (input.statusCode === 402) {
+    return {
+      state: "billing_action_required",
+      action: "add_credits_or_plan",
+      safeSummary: "The provider account needs billing attention before this request can run.",
+      confidence: "heuristic",
+      isHumanActionRequired: true,
+    };
+  }
+
+  if (input.statusCode === 413) {
+    return {
+      state: "request_too_large",
+      action: "reduce_request",
+      safeSummary: "The request is too large for this provider. Reduce or split the request.",
+      confidence: "heuristic",
+      isHumanActionRequired: false,
+    };
+  }
+
+  return {
+    state: "unknown",
+    action: "none",
+    safeSummary: "Provider capacity state is unknown.",
+    confidence: "unknown",
+    isHumanActionRequired: false,
+  };
+}

--- a/apps/web/lib/routing/provider-capacity/provider-capacity-store.test.ts
+++ b/apps/web/lib/routing/provider-capacity/provider-capacity-store.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    providerCapacityStatus: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import {
+  clearProviderCapacityStatus,
+  recordProviderCapacityStatus,
+} from "./store";
+
+const mockUpsert = prisma.providerCapacityStatus.upsert as ReturnType<typeof vi.fn>;
+const NOW = new Date("2026-06-29T20:00:00.000Z");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("provider capacity store", () => {
+  it("upserts the current provider capacity classification", async () => {
+    await recordProviderCapacityStatus({
+      providerId: "zai-coding",
+      source: "opencode",
+      observedAt: NOW,
+      classification: {
+        state: "billing_action_required",
+        action: "add_credits_or_plan",
+        providerCode: "1113",
+        safeSummary: "Z.ai needs coding credits.",
+        confidence: "exact",
+        isHumanActionRequired: true,
+      },
+      rawSnippet: "Insufficient balance",
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: { providerId: "zai-coding" },
+      create: expect.objectContaining({
+        providerId: "zai-coding",
+        state: "billing_action_required",
+        action: "add_credits_or_plan",
+        providerCode: "1113",
+        source: "opencode",
+        rawSnippet: "Insufficient balance",
+        isHumanActionRequired: true,
+      }),
+      update: expect.objectContaining({
+        state: "billing_action_required",
+        action: "add_credits_or_plan",
+        providerCode: "1113",
+        source: "opencode",
+        rawSnippet: "Insufficient balance",
+        isHumanActionRequired: true,
+      }),
+    });
+  });
+
+  it("marks a provider available after a successful call", async () => {
+    await clearProviderCapacityStatus({
+      providerId: "zai-coding",
+      source: "api",
+      observedAt: NOW,
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: { providerId: "zai-coding" },
+      create: expect.objectContaining({
+        providerId: "zai-coding",
+        state: "available",
+        action: "none",
+        lastSuccessAt: NOW,
+        isHumanActionRequired: false,
+      }),
+      update: expect.objectContaining({
+        state: "available",
+        action: "none",
+        retryAt: null,
+        providerCode: null,
+        lastSuccessAt: NOW,
+        isHumanActionRequired: false,
+      }),
+    });
+  });
+});

--- a/apps/web/lib/routing/provider-capacity/provider-capacity.test.ts
+++ b/apps/web/lib/routing/provider-capacity/provider-capacity.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyProviderCapacity,
+  parseRetryAfterSeconds,
+} from "./index";
+
+const NOW = new Date("2026-06-29T20:00:00.000Z");
+
+describe("provider capacity classification", () => {
+  it("maps Z.ai 1113 to a human billing action instead of a retry", () => {
+    const result = classifyProviderCapacity({
+      providerId: "zai-coding",
+      statusCode: 429,
+      bodyText: JSON.stringify({
+        error: {
+          code: "1113",
+          message: "Insufficient balance or no resource package. Please recharge.",
+        },
+      }),
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      state: "billing_action_required",
+      action: "add_credits_or_plan",
+      providerCode: "1113",
+      confidence: "exact",
+      isHumanActionRequired: true,
+    });
+    expect(result.retryAt).toBeUndefined();
+    expect(result.safeSummary).toContain("credits");
+  });
+
+  it("maps Z.ai timed quota responses to an exact retry time", () => {
+    const result = classifyProviderCapacity({
+      providerId: "zai",
+      statusCode: 429,
+      bodyText: JSON.stringify({
+        error: {
+          code: "1316",
+          message: "Quota will refresh later.",
+          next_flush_time: "2026-06-29T21:15:00Z",
+        },
+      }),
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      state: "quota_resets_at",
+      action: "retry_at",
+      providerCode: "1316",
+      confidence: "exact",
+      isHumanActionRequired: false,
+    });
+    expect(result.retryAt?.toISOString()).toBe("2026-06-29T21:15:00.000Z");
+  });
+
+  it("parses Retry-After seconds from headers", () => {
+    const result = classifyProviderCapacity({
+      providerId: "openai",
+      statusCode: 429,
+      headers: { "retry-after": "120" },
+      bodyText: "{}",
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      state: "rate_limited",
+      action: "retry_at",
+      retryAfterSeconds: 120,
+      confidence: "header",
+      isHumanActionRequired: false,
+    });
+    expect(result.retryAt?.toISOString()).toBe("2026-06-29T20:02:00.000Z");
+  });
+
+  it("parses epoch reset headers into retry seconds", () => {
+    expect(parseRetryAfterSeconds({ "x-ratelimit-reset": "1782763260" }, NOW)).toBe(60);
+  });
+
+  it("uses bounded backoff for unknown 429 responses", () => {
+    const result = classifyProviderCapacity({
+      providerId: "unknown-ai",
+      statusCode: 429,
+      bodyText: "rate limit",
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      state: "rate_limited",
+      action: "retry_with_backoff",
+      confidence: "heuristic",
+      isHumanActionRequired: false,
+    });
+    expect(result.retryAt).toBeUndefined();
+  });
+});

--- a/apps/web/lib/routing/provider-capacity/store.ts
+++ b/apps/web/lib/routing/provider-capacity/store.ts
@@ -1,0 +1,68 @@
+import { prisma } from "@dpf/db";
+
+import type { ProviderCapacityClassification } from "./types";
+
+export type ProviderCapacitySource = "api" | "cli" | "opencode" | "oauth" | "manual";
+
+export async function recordProviderCapacityStatus(input: {
+  providerId: string;
+  classification: ProviderCapacityClassification;
+  source: ProviderCapacitySource;
+  observedAt?: Date;
+  rawSnippet?: string;
+}): Promise<void> {
+  const observedAt = input.observedAt ?? new Date();
+  const data = {
+    state: input.classification.state,
+    action: input.classification.action,
+    retryAt: input.classification.retryAt ?? null,
+    retryAfterSeconds: input.classification.retryAfterSeconds ?? null,
+    providerCode: input.classification.providerCode ?? null,
+    safeSummary: input.classification.safeSummary,
+    confidence: input.classification.confidence,
+    isHumanActionRequired: input.classification.isHumanActionRequired,
+    lastObservedAt: observedAt,
+    source: input.source,
+    rawSnippet: input.rawSnippet?.slice(0, 500) ?? null,
+  };
+
+  await prisma.providerCapacityStatus.upsert({
+    where: { providerId: input.providerId },
+    create: {
+      providerId: input.providerId,
+      ...data,
+    },
+    update: data,
+  });
+}
+
+export async function clearProviderCapacityStatus(input: {
+  providerId: string;
+  source: ProviderCapacitySource;
+  observedAt?: Date;
+}): Promise<void> {
+  const observedAt = input.observedAt ?? new Date();
+  const data = {
+    state: "available",
+    action: "none",
+    retryAt: null,
+    retryAfterSeconds: null,
+    providerCode: null,
+    safeSummary: "Provider is available.",
+    confidence: "exact",
+    isHumanActionRequired: false,
+    lastObservedAt: observedAt,
+    lastSuccessAt: observedAt,
+    source: input.source,
+    rawSnippet: null,
+  };
+
+  await prisma.providerCapacityStatus.upsert({
+    where: { providerId: input.providerId },
+    create: {
+      providerId: input.providerId,
+      ...data,
+    },
+    update: data,
+  });
+}

--- a/apps/web/lib/routing/provider-capacity/types.ts
+++ b/apps/web/lib/routing/provider-capacity/types.ts
@@ -1,0 +1,44 @@
+export type ProviderCapacityState =
+  | "available"
+  | "cooling_down"
+  | "quota_resets_at"
+  | "rate_limited"
+  | "billing_action_required"
+  | "reauth_required"
+  | "unsupported_plan"
+  | "request_too_large"
+  | "provider_degraded"
+  | "unknown";
+
+export type ProviderCapacityAction =
+  | "retry_at"
+  | "retry_with_backoff"
+  | "switch_provider"
+  | "reduce_request"
+  | "reconnect"
+  | "add_credits_or_plan"
+  | "change_plan_or_model"
+  | "contact_provider"
+  | "none";
+
+export type ProviderCapacityConfidence = "exact" | "header" | "heuristic" | "unknown";
+
+export type ProviderCapacityClassifierInput = {
+  providerId: string;
+  statusCode?: number;
+  headers?: Headers | Record<string, string | string[] | undefined>;
+  bodyText?: string;
+  errorMessage?: string;
+  now: Date;
+};
+
+export type ProviderCapacityClassification = {
+  state: ProviderCapacityState;
+  action: ProviderCapacityAction;
+  retryAt?: Date;
+  retryAfterSeconds?: number;
+  providerCode?: string;
+  safeSummary: string;
+  confidence: ProviderCapacityConfidence;
+  isHumanActionRequired: boolean;
+};

--- a/apps/web/lib/routing/provider-capacity/zai.ts
+++ b/apps/web/lib/routing/provider-capacity/zai.ts
@@ -1,0 +1,67 @@
+import type {
+  ProviderCapacityClassification,
+  ProviderCapacityClassifierInput,
+} from "./types";
+
+type ZaiErrorBody = {
+  error?: {
+    code?: string | number;
+    message?: string;
+    next_flush_time?: string | number;
+  };
+};
+
+function parseBody(bodyText: string | undefined): ZaiErrorBody | null {
+  if (!bodyText) return null;
+  try {
+    return JSON.parse(bodyText) as ZaiErrorBody;
+  } catch {
+    return null;
+  }
+}
+
+function parseRetryAt(value: string | number | undefined): Date | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "number") {
+    const ms = value > 10_000_000_000 ? value : value * 1000;
+    const date = new Date(ms);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+export function classifyZaiCapacity(
+  input: ProviderCapacityClassifierInput,
+): ProviderCapacityClassification | null {
+  const parsed = parseBody(input.bodyText);
+  const code = parsed?.error?.code !== undefined ? String(parsed.error.code) : undefined;
+  if (!code) return null;
+
+  if (code === "1113") {
+    return {
+      state: "billing_action_required",
+      action: "add_credits_or_plan",
+      providerCode: code,
+      safeSummary: "Z.ai needs coding credits or a resource package before this request can run.",
+      confidence: "exact",
+      isHumanActionRequired: true,
+    };
+  }
+
+  const retryAt = parseRetryAt(parsed?.error?.next_flush_time);
+  if (retryAt) {
+    return {
+      state: "quota_resets_at",
+      action: "retry_at",
+      retryAt,
+      retryAfterSeconds: Math.max(0, Math.ceil((retryAt.getTime() - input.now.getTime()) / 1000)),
+      providerCode: code,
+      safeSummary: "Z.ai quota is temporarily exhausted. DPF will retry when the quota refreshes.",
+      confidence: "exact",
+      isHumanActionRequired: false,
+    };
+  }
+
+  return null;
+}

--- a/apps/web/lib/routing/provider-health-loader.test.ts
+++ b/apps/web/lib/routing/provider-health-loader.test.ts
@@ -4,6 +4,7 @@ vi.mock("@dpf/db", () => ({
   prisma: {
     modelProvider: { findUnique: vi.fn() },
     routeOutcome: { findMany: vi.fn() },
+    providerCapacityStatus: { findUnique: vi.fn() },
   },
 }));
 
@@ -12,11 +13,13 @@ import { prisma } from "@dpf/db";
 
 const mockProvider = prisma.modelProvider.findUnique as ReturnType<typeof vi.fn>;
 const mockOutcomes = prisma.routeOutcome.findMany as ReturnType<typeof vi.fn>;
+const mockCapacity = prisma.providerCapacityStatus.findUnique as ReturnType<typeof vi.fn>;
 
 const NOW = 1_700_000_000_000;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockCapacity.mockResolvedValue(null);
 });
 
 describe("loadProviderHealth", () => {
@@ -83,5 +86,34 @@ describe("loadProviderHealth", () => {
     expect(mockOutcomes).toHaveBeenCalledWith(
       expect.objectContaining({ take: 5, orderBy: { createdAt: "desc" } }),
     );
+  });
+
+  it("loads persisted provider capacity status", async () => {
+    mockProvider.mockResolvedValue({ status: "active", authMethod: "api_key" });
+    mockOutcomes.mockResolvedValue([
+      { providerErrorCode: null, fallbackOccurred: false, createdAt: new Date(NOW - 1_000), latencyMs: 1000, modelId: "glm-5.2" },
+    ]);
+    mockCapacity.mockResolvedValue({
+      state: "billing_action_required",
+      action: "add_credits_or_plan",
+      retryAt: null,
+      safeSummary: "Z.ai needs coding credits.",
+      isHumanActionRequired: true,
+    });
+
+    const health = await loadProviderHealth("zai-coding", { now: NOW });
+
+    expect(mockCapacity).toHaveBeenCalledWith({
+      where: { providerId: "zai-coding" },
+      select: {
+        state: true,
+        action: true,
+        retryAt: true,
+        safeSummary: true,
+        isHumanActionRequired: true,
+      },
+    });
+    expect(health.status).toBe("billing");
+    expect(health.safeSummary).toBe("Z.ai needs coding credits.");
   });
 });

--- a/apps/web/lib/routing/provider-health-loader.ts
+++ b/apps/web/lib/routing/provider-health-loader.ts
@@ -40,7 +40,7 @@ export async function loadProviderHealth(
 ): Promise<ProviderHealth> {
   const now = opts.now ?? Date.now();
 
-  const [provider, outcomes] = await Promise.all([
+  const [provider, outcomes, capacityStatus] = await Promise.all([
     prisma.modelProvider.findUnique({
       where: { providerId },
       select: { status: true, authMethod: true },
@@ -55,6 +55,16 @@ export async function loadProviderHealth(
         createdAt: true,
         latencyMs: true,
         modelId: true,
+      },
+    }),
+    prisma.providerCapacityStatus.findUnique({
+      where: { providerId },
+      select: {
+        state: true,
+        action: true,
+        retryAt: true,
+        safeSummary: true,
+        isHumanActionRequired: true,
       },
     }),
   ]);
@@ -89,6 +99,7 @@ export async function loadProviderHealth(
     lifecycleStatus: provider.status,
     authMethod: provider.authMethod,
     recentOutcomes,
+    capacityStatus,
     ...(runtimeCooldown ? { runtimeCooldown } : {}),
     now,
   });

--- a/apps/web/lib/routing/provider-health.test.ts
+++ b/apps/web/lib/routing/provider-health.test.ts
@@ -104,6 +104,40 @@ describe("deriveProviderHealth", () => {
     expect(h.status).toBe("billing");
   });
 
+  it("persisted billing capacity state takes precedence over recent telemetry", () => {
+    const h = base({
+      capacityStatus: {
+        state: "billing_action_required",
+        action: "add_credits_or_plan",
+        retryAt: null,
+        safeSummary: "Z.ai needs coding credits.",
+        isHumanActionRequired: true,
+      },
+      recentOutcomes: [outcome({ ageMs: 1_000, latencyMs: 1200 })],
+    });
+
+    expect(h.status).toBe("billing");
+    expect(h.remediationKind).toBe("provider_settings");
+    expect(h.safeSummary).toBe("Z.ai needs coding credits.");
+  });
+
+  it("persisted quota reset state maps to rate_limited with cooldownUntil", () => {
+    const retryAt = new Date(NOW + 90_000);
+    const h = base({
+      capacityStatus: {
+        state: "quota_resets_at",
+        action: "retry_at",
+        retryAt,
+        safeSummary: "Quota refreshes soon.",
+        isHumanActionRequired: false,
+      },
+    });
+
+    expect(h.status).toBe("rate_limited");
+    expect(h.remediationKind).toBe("wait");
+    expect(h.cooldownUntil).toBe(retryAt.getTime());
+  });
+
   // ── Disabled lifecycle (fallback.ts disables on auth/billing) ──
   it("disabled + recent billing error → billing", () => {
     const h = base({

--- a/apps/web/lib/routing/provider-health.ts
+++ b/apps/web/lib/routing/provider-health.ts
@@ -63,6 +63,14 @@ export interface RecentOutcome {
   latencyMs: number;
 }
 
+export interface ProviderCapacityHealthInput {
+  state: string;
+  action: string;
+  retryAt: Date | null;
+  safeSummary: string;
+  isHumanActionRequired: boolean;
+}
+
 export interface ProviderHealthInput {
   providerId: string;
   /** ModelProvider.status — admin lifecycle state. */
@@ -71,6 +79,8 @@ export interface ProviderHealthInput {
   authMethod?: string | null;
   /** Recent RouteOutcome rows for this provider. */
   recentOutcomes: RecentOutcome[];
+  /** Current provider-capacity state from ProviderCapacityStatus. */
+  capacityStatus?: ProviderCapacityHealthInput | null;
   /** Runtime circuit state from rate-tracker.getEndpointRuntimeState (optional). */
   runtimeCooldown?: { unavailable: boolean; reason?: string; until?: number };
   /** Epoch ms — injected for deterministic tests (no Date.now in a pure fn). */
@@ -150,6 +160,11 @@ export function deriveProviderHealth(input: ProviderHealthInput): ProviderHealth
     };
   }
 
+  if (input.capacityStatus && input.capacityStatus.state !== "available") {
+    const capacityHealth = mapCapacityStatusToHealth(input.capacityStatus, input.providerId);
+    if (capacityHealth) return capacityHealth;
+  }
+
   // 3. Lifecycle disabled — fallback.ts disables on auth/billing. Use the most
   // recent hard-failure class to choose the remediation wording.
   if (input.lifecycleStatus === "disabled") {
@@ -185,6 +200,52 @@ export function deriveProviderHealth(input: ProviderHealthInput): ProviderHealth
     remediationKind: "none",
     safeSummary: "No recent activity. Health will update after the next request.",
   };
+}
+
+function mapCapacityStatusToHealth(
+  capacity: ProviderCapacityHealthInput,
+  providerId: string,
+): ProviderHealth | null {
+  switch (capacity.state) {
+    case "billing_action_required":
+    case "unsupported_plan":
+      return {
+        status: "billing",
+        remediationKind: "provider_settings",
+        adminActionHref: providerDetailHref(providerId),
+        safeSummary: capacity.safeSummary,
+        lastFailureClass: "billing",
+      };
+    case "quota_resets_at":
+    case "rate_limited":
+      return {
+        status: "rate_limited",
+        remediationKind: "wait",
+        safeSummary: capacity.safeSummary,
+        lastFailureClass: "rate_limit",
+        ...(capacity.retryAt ? { cooldownUntil: capacity.retryAt.getTime() } : {}),
+      };
+    case "reauth_required":
+      return reauthHealth(providerId, null, "auth");
+    case "request_too_large":
+      return {
+        status: "degraded",
+        remediationKind: "choose_smaller_request",
+        safeSummary: capacity.safeSummary,
+        lastFailureClass: "request_too_large",
+      };
+    case "cooling_down":
+    case "provider_degraded":
+      return {
+        status: "cooling_down",
+        remediationKind: "wait",
+        safeSummary: capacity.safeSummary,
+        lastFailureClass: "provider_error",
+        ...(capacity.retryAt ? { cooldownUntil: capacity.retryAt.getTime() } : {}),
+      };
+    default:
+      return null;
+  }
 }
 
 function mapReasonToHealth(

--- a/docs/superpowers/plans/2026-06-29-provider-capacity-recovery.md
+++ b/docs/superpowers/plans/2026-06-29-provider-capacity-recovery.md
@@ -1,0 +1,73 @@
+# Provider Capacity Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first provider-capacity recovery slice so DPF can classify provider-specific quota, throttle, billing, and plan errors into canonical actions.
+
+**Architecture:** Add a provider-capacity classifier layer under routing, persist current live capacity in a dedicated Prisma model, and feed classifications into inference errors and provider health. Z.ai is the first exact provider classifier; generic OpenAI-compatible headers remain the fallback.
+
+**Tech Stack:** Next.js app code, TypeScript, Vitest, Prisma migration.
+
+---
+
+## Chunk 1: Classifier And Persistence
+
+### Task 1: Provider Capacity Classifier
+
+**Files:**
+- Create: `apps/web/lib/routing/provider-capacity/types.ts`
+- Create: `apps/web/lib/routing/provider-capacity/headers.ts`
+- Create: `apps/web/lib/routing/provider-capacity/zai.ts`
+- Create: `apps/web/lib/routing/provider-capacity/index.ts`
+- Test: `apps/web/lib/routing/provider-capacity/provider-capacity.test.ts`
+
+- [ ] Write failing tests for Z.ai `1113`, Z.ai `next_flush_time`, `Retry-After`, reset epoch headers, and unknown `429`.
+- [ ] Run targeted Vitest and verify tests fail because modules do not exist.
+- [ ] Implement minimal classifier code.
+- [ ] Run targeted Vitest and verify tests pass.
+
+### Task 2: Persistence
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_provider_capacity_status/migration.sql`
+- Create: `apps/web/lib/routing/provider-capacity/store.ts`
+- Test: `apps/web/lib/routing/provider-capacity/provider-capacity-store.test.ts`
+
+- [ ] Write failing store tests using mocked Prisma for upsert on error and clear on success.
+- [ ] Add Prisma model and migration SQL.
+- [ ] Implement store helpers.
+- [ ] Run targeted tests.
+
+### Task 3: Inference And Health Integration
+
+**Files:**
+- Modify: `apps/web/lib/inference/ai-inference.ts`
+- Modify: `apps/web/lib/routing/provider-health.ts`
+- Modify: `apps/web/lib/routing/provider-health-loader.ts`
+- Test: `apps/web/lib/inference/ai-inference.test.ts`
+- Test: `apps/web/lib/routing/provider-health.test.ts`
+
+- [ ] Write failing tests proving `classifyHttpError` carries a capacity classification for Z.ai `1113`.
+- [ ] Write failing provider-health tests proving capacity state overrides recent generic telemetry.
+- [ ] Implement minimal integration.
+- [ ] Run targeted tests.
+
+## Chunk 2: First Build Studio/OpenCode Hook
+
+### Task 4: OpenCode Capacity Recording
+
+**Files:**
+- Modify: `apps/web/lib/integrate/opencode-dispatch.ts`
+- Test: existing or new OpenCode dispatch tests.
+
+- [ ] Write failing tests for Z.ai/OpenCode error text classification.
+- [ ] Record capacity status from OpenCode failures without exposing credentials.
+- [ ] Run targeted tests.
+
+## Verification
+
+- [ ] `pnpm --filter web exec vitest run apps/web/lib/routing/provider-capacity/provider-capacity.test.ts apps/web/lib/routing/provider-health.test.ts apps/web/lib/inference/ai-inference.test.ts`
+- [ ] `pnpm --filter web typecheck`
+- [ ] Production build if runtime/UI integration lands in this PR.
+

--- a/packages/db/prisma/migrations/20260629212000_provider_capacity_status/migration.sql
+++ b/packages/db/prisma/migrations/20260629212000_provider_capacity_status/migration.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "ProviderCapacityStatus" (
+    "id" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "retryAt" TIMESTAMP(3),
+    "retryAfterSeconds" INTEGER,
+    "providerCode" TEXT,
+    "safeSummary" TEXT NOT NULL,
+    "confidence" TEXT NOT NULL,
+    "isHumanActionRequired" BOOLEAN NOT NULL DEFAULT false,
+    "lastObservedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSuccessAt" TIMESTAMP(3),
+    "source" TEXT NOT NULL,
+    "rawSnippet" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProviderCapacityStatus_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProviderCapacityStatus_providerId_key" ON "ProviderCapacityStatus"("providerId");
+CREATE INDEX "ProviderCapacityStatus_state_retryAt_idx" ON "ProviderCapacityStatus"("state", "retryAt");
+CREATE INDEX "ProviderCapacityStatus_isHumanActionRequired_updatedAt_idx" ON "ProviderCapacityStatus"("isHumanActionRequired", "updatedAt");
+
+ALTER TABLE "ProviderCapacityStatus" ADD CONSTRAINT "ProviderCapacityStatus_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "ModelProvider"("providerId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1591,6 +1591,7 @@ model ModelProvider {
   credentialOwnerMode      String?
   modelProfiles            ModelProfile[]
   financeProfile           AiProviderFinanceProfile?
+  capacityStatus           ProviderCapacityStatus?
 }
 
 model DiscoveredModel {
@@ -11147,6 +11148,32 @@ model CliPoolStatus {
   updatedAt         DateTime  @updatedAt
 
   @@index([adapterType, resetAt])
+}
+
+// Current live capacity state for a provider. This separates runtime capacity
+// (quota, throttles, credits, plan limits) from ModelProvider.status, which is
+// the configured/admin lifecycle state.
+model ProviderCapacityStatus {
+  id                    String        @id @default(cuid())
+  providerId            String        @unique
+  state                 String
+  action                String
+  retryAt               DateTime?
+  retryAfterSeconds     Int?
+  providerCode          String?
+  safeSummary           String
+  confidence            String
+  isHumanActionRequired Boolean       @default(false)
+  lastObservedAt        DateTime      @default(now())
+  lastSuccessAt         DateTime?
+  source                String
+  rawSnippet            String?
+  createdAt             DateTime      @default(now())
+  updatedAt             DateTime      @updatedAt
+  provider              ModelProvider @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
+
+  @@index([state, retryAt])
+  @@index([isHumanActionRequired, updatedAt])
 }
 
 // ─── Reduction Gear Phase 0 — GearInterface canonical observation envelope ────


### PR DESCRIPTION
## Summary
- adds ProviderCapacityStatus persistence separate from ModelProvider lifecycle state
- adds canonical provider-capacity classifiers with Z.ai-specific 1113 and timed-quota mappings
- carries capacity classifications through InferenceError and records/clears capacity state on API calls
- surfaces persisted capacity status through provider health
- records OpenCode/Z.ai capacity failures so Build Studio sees credits/package exhaustion as provider capacity, not a generic dispatch failure

## Verification
- pnpm --filter web exec vitest run lib/routing/provider-capacity/provider-capacity.test.ts lib/routing/provider-capacity/provider-capacity-store.test.ts lib/inference/ai-inference.test.ts lib/routing/provider-health.test.ts lib/routing/provider-health-loader.test.ts lib/integrate/opencode-dispatch.test.ts
- pnpm --filter @dpf/db exec prisma generate
- pnpm --filter web typecheck
- pnpm --filter web build
- migration SQL applied cleanly against a temporary schema-only clone of the live Postgres schema