### PR TITLE
AI coworker proactivity policy primitive

### DIFF
--- a/apps/web/components/agent/CoworkerProfilePanel.test.tsx
+++ b/apps/web/components/agent/CoworkerProfilePanel.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentInfo } from "@/lib/agent-coworker-types";
+
+import { CoworkerProfilePanel } from "./CoworkerProfilePanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    agentId: "dispatch-coworker",
+    agentName: "Dispatch coworker",
+    agentDescription: "Coordinates schedule-sensitive service work.",
+    canAssist: true,
+    sensitivity: "internal",
+    systemPrompt: "You coordinate dispatch work.",
+    skills: [],
+    ...overrides,
+  };
+}
+
+describe("CoworkerProfilePanel", () => {
+  it("shows the effective proactivity plan and boundaries", () => {
+    render(<CoworkerProfilePanel agent={makeAgent()} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Proactivity")).toBeTruthy();
+    expect(screen.getByText("Balanced")).toBeTruthy();
+    expect(screen.getByText(/Balanced is the default proactivity level/i)).toBeTruthy();
+    expect(screen.getByText(/Spend: standard/i)).toBeTruthy();
+    expect(screen.getByText(/Boundary: propose/i)).toBeTruthy();
+  });
+});

--- a/apps/web/components/agent/CoworkerProfilePanel.tsx
+++ b/apps/web/components/agent/CoworkerProfilePanel.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import type { AgentInfo, AgentSkill } from "@/lib/agent-coworker-types";
+import { getProactivityLevelCopy } from "@/lib/proactivity/proactivity-copy";
+import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
 
 type Props = {
   agent: AgentInfo;
@@ -62,6 +64,11 @@ const categoryLabels: Record<string, string> = {
 export function CoworkerProfilePanel({ agent, onClose }: Props) {
   const [expandedSkill, setExpandedSkill] = useState<string | null>(null);
   const grouped = groupSkillsByCategory(agent.skills);
+  const proactivityPlan = resolveProactivityPlan({
+    activityFamily: "scheduled-task",
+    agentId: agent.agentId,
+  });
+  const proactivityCopy = getProactivityLevelCopy(proactivityPlan.resolvedLevel);
 
   // Separate skills from tools based on enriched data
   const skills = agent.skills.filter((s) => !s.allowedTools || s.allowedTools.length === 0 || s.taskType !== "tool");
@@ -130,6 +137,48 @@ export function CoworkerProfilePanel({ agent, onClose }: Props) {
 
       {/* Scrollable content */}
       <div style={{ flex: 1, overflow: "auto", padding: "14px" }}>
+        {/* Proactivity Section */}
+        <div style={sectionStyle}>
+          <div style={{ ...sectionHeaderStyle, display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ fontSize: 12 }}>Proactivity</span>
+            <span style={{ fontSize: 9, color: "var(--dpf-muted)", fontWeight: 400 }}>
+              How persistently I follow up
+            </span>
+          </div>
+          <div
+            style={{
+              border: "1px solid var(--dpf-border)",
+              borderRadius: 6,
+              padding: "8px 9px",
+              background: "color-mix(in srgb, var(--dpf-surface-2) 70%, transparent)",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+              <span style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)" }}>
+                {proactivityCopy.label}
+              </span>
+              <span
+                style={{
+                  ...tagStyle,
+                  fontSize: 10,
+                  color: "var(--dpf-accent)",
+                  borderColor: "color-mix(in srgb, var(--dpf-accent) 40%, transparent)",
+                }}
+              >
+                {proactivityPlan.policyId}
+              </span>
+            </div>
+            <div style={{ fontSize: 10, color: "var(--dpf-muted)", marginTop: 6, lineHeight: 1.45 }}>
+              {proactivityPlan.explanation}
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 8 }}>
+              <span style={{ ...tagStyle, fontSize: 10 }}>Spend: {proactivityPlan.spendClass}</span>
+              <span style={{ ...tagStyle, fontSize: 10 }}>Boundary: {proactivityPlan.actionBoundary}</span>
+              <span style={{ ...tagStyle, fontSize: 10 }}>Escalates: {proactivityPlan.escalationTarget}</span>
+            </div>
+          </div>
+        </div>
+
         {/* Skills Section */}
         <div style={sectionStyle}>
           <div style={{ ...sectionHeaderStyle, display: "flex", alignItems: "center", gap: 6 }}>

--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx
@@ -28,6 +28,7 @@ describe("CoworkerPriorityDock", () => {
     const header = screen.getByRole("button", { name: /Priority/ });
     expect(header).toBeTruthy();
     expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByRole("button", { name: /Proactivity balanced/i })).toBeTruthy();
     expect(screen.queryByRole("radio", { name: /Assured/ })).toBeNull();
   });
 

--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
@@ -14,12 +14,16 @@ import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
 import { getCoworkerGoldenTrianglePosture, saveCoworkerGoldenTrianglePosture } from "@/lib/actions/golden-triangle";
 
+import { ProactivityLevelControl } from "@/components/proactivity/ProactivityLevelControl";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+
 import { GoldenTriangleControl } from "./GoldenTriangleControl";
 import { GoldenTriangleGradient } from "./GoldenTriangleGradient";
 import { postureLabel, preferenceFromPreset } from "./posture-display";
 
 export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
   const [pref, setPref] = useState<GoldenTrianglePreference>(preferenceFromPreset("balanced"));
+  const [proactivityLevel, setProactivityLevel] = useState<ProactivityLevel>("balanced");
   // Collapsed by default: the resting state is the compact colour-graded chip in
   // the header, not the open triangle. Re-initializes collapsed on every load so a
   // refresh never leaves the control hanging open (founder report 2026-06-26).
@@ -62,32 +66,38 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
 
   return (
     <div style={{ borderTop: "1px solid var(--dpf-border)", background: "color-mix(in srgb, var(--dpf-surface-2) 70%, transparent)" }}>
-      <button
-        type="button"
-        onClick={() => setCollapsed((c) => !c)}
-        aria-expanded={!collapsed}
-        title="Priority for this coworker — cost, quality and time. Tunes how this coworker works."
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          width: "100%",
-          background: "none",
-          border: "none",
-          padding: "7px 12px",
-          cursor: "pointer",
-          textAlign: "left",
-        }}
-      >
-        <span style={{ width: 16, height: 14, flex: "0 0 auto", display: "inline-block" }} aria-hidden="true">
-          <GoldenTriangleGradient qualityWeight={pref.qualityWeight} costWeight={pref.costWeight} timeWeight={pref.timeWeight} />
-        </span>
-        <span style={{ fontSize: 11, fontWeight: 500, color: "var(--dpf-text)" }}>Priority</span>
-        <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>{activeLabel}</span>
-        <span style={{ marginLeft: "auto", fontSize: 10, color: "var(--dpf-muted)" }} aria-hidden="true">
-          {collapsed ? "▸" : "▾"}
-        </span>
-      </button>
+      <div style={{ display: "flex", alignItems: "stretch", width: "100%", minWidth: 0 }}>
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
+          title="Priority for this coworker — cost, quality and time. Tunes how this coworker works."
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            minWidth: 0,
+            flex: "1 1 auto",
+            background: "none",
+            border: "none",
+            padding: "7px 12px",
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          <span style={{ width: 16, height: 14, flex: "0 0 auto", display: "inline-block" }} aria-hidden="true">
+            <GoldenTriangleGradient qualityWeight={pref.qualityWeight} costWeight={pref.costWeight} timeWeight={pref.timeWeight} />
+          </span>
+          <span style={{ fontSize: 11, fontWeight: 500, color: "var(--dpf-text)" }}>Priority</span>
+          <span style={{ fontSize: 11, color: "var(--dpf-muted)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {activeLabel}
+          </span>
+          <span style={{ marginLeft: "auto", fontSize: 10, color: "var(--dpf-muted)" }} aria-hidden="true">
+            {collapsed ? "▸" : "▾"}
+          </span>
+        </button>
+        <ProactivityLevelControl value={proactivityLevel} onChange={setProactivityLevel} />
+      </div>
       {!collapsed && (
         <div style={{ padding: "0 12px 10px" }}>
           <GoldenTriangleControl

--- a/apps/web/components/golden-triangle/test-setup.ts
+++ b/apps/web/components/golden-triangle/test-setup.ts
@@ -3,10 +3,33 @@
 // Activated per-file via `import "./test-setup"`.
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterAll, afterEach, vi } from "vitest";
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+  clearRect: vi.fn(),
+  createImageData: vi.fn((width: number, height: number) => ({
+    data: new Uint8ClampedArray(width * height * 4),
+    width,
+    height,
+  })),
+  createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+  fill: vi.fn(),
+  fillRect: vi.fn(),
+  putImageData: vi.fn(),
+  beginPath: vi.fn(),
+  closePath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+})) as unknown as HTMLCanvasElement["getContext"];
 
 // Vitest runs with `globals: false`, so testing-library's auto-cleanup does not
 // fire on its own — wire it up explicitly.
 afterEach(() => {
   cleanup();
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
 });

--- a/apps/web/components/proactivity/ProactivityGaugeIcon.tsx
+++ b/apps/web/components/proactivity/ProactivityGaugeIcon.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+
+const NEEDLE_ROTATION: Record<ProactivityLevel, number> = {
+  quiet: -42,
+  balanced: 0,
+  assertive: 42,
+};
+
+const ACCENT_TOKEN: Record<ProactivityLevel, string> = {
+  quiet: "var(--dpf-success)",
+  balanced: "var(--dpf-warning)",
+  assertive: "var(--dpf-error)",
+};
+
+export function ProactivityGaugeIcon({ level, size = 16 }: { level: ProactivityLevel; size?: number }) {
+  const rotation = NEEDLE_ROTATION[level];
+  const accent = ACCENT_TOKEN[level];
+
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ color: accent, display: "block", flex: "0 0 auto" }}
+    >
+      <path d="M4 14a8 8 0 0 1 16 0" stroke="currentColor" strokeWidth="2" opacity="0.45" />
+      <path
+        d="M7 14a5 5 0 0 1 10 0"
+        stroke="currentColor"
+        strokeWidth="2"
+        opacity={level === "balanced" ? "0.9" : "0.65"}
+      />
+      <g transform={`rotate(${rotation} 12 14)`}>
+        <path d="M12 14 12 8" stroke="currentColor" strokeWidth="2.25" />
+      </g>
+      <circle cx="12" cy="14" r="1.6" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/apps/web/components/proactivity/ProactivityLevelControl.test.tsx
+++ b/apps/web/components/proactivity/ProactivityLevelControl.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ProactivityLevelControl } from "./ProactivityLevelControl";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ProactivityLevelControl", () => {
+  it("renders compact gauge, label, and current level", () => {
+    render(<ProactivityLevelControl value="balanced" onChange={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /Proactivity balanced/i })).toBeTruthy();
+    expect(screen.getByText("Proactivity")).toBeTruthy();
+    expect(screen.getByText("Balanced")).toBeTruthy();
+  });
+
+  it("lets the operator choose Assertive without relying on color alone", () => {
+    const onChange = vi.fn();
+    render(<ProactivityLevelControl value="balanced" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Proactivity balanced/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Assertive/i }));
+
+    expect(onChange).toHaveBeenCalledWith("assertive");
+  });
+});

--- a/apps/web/components/proactivity/ProactivityLevelControl.tsx
+++ b/apps/web/components/proactivity/ProactivityLevelControl.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+
+import { getProactivityLevelCopy, PROACTIVITY_LEVEL_COPY } from "@/lib/proactivity/proactivity-copy";
+import { PROACTIVITY_LEVELS, type ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+
+import { ProactivityGaugeIcon } from "./ProactivityGaugeIcon";
+
+export function ProactivityLevelControl({
+  value,
+  onChange,
+}: {
+  value: ProactivityLevel;
+  onChange: (level: ProactivityLevel) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const copy = getProactivityLevelCopy(value);
+
+  return (
+    <div style={{ position: "relative", flex: "0 0 auto" }}>
+      <button
+        type="button"
+        onClick={() => setExpanded((next) => !next)}
+        aria-expanded={expanded}
+        aria-label={`Proactivity ${copy.label}`}
+        title={`${copy.label}: ${copy.description}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 7,
+          minHeight: 30,
+          background: "none",
+          border: "none",
+          borderLeft: "1px solid var(--dpf-border)",
+          padding: "7px 12px",
+          cursor: "pointer",
+          textAlign: "left",
+          whiteSpace: "nowrap",
+        }}
+      >
+        <ProactivityGaugeIcon level={value} />
+        <span style={{ fontSize: 11, fontWeight: 500, color: "var(--dpf-text)" }}>Proactivity</span>
+        <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>{copy.label}</span>
+      </button>
+      {expanded && (
+        <div
+          role="group"
+          aria-label="Choose proactivity level"
+          style={{
+            position: "absolute",
+            right: 0,
+            bottom: "calc(100% + 6px)",
+            zIndex: 10,
+            minWidth: 260,
+            border: "1px solid var(--dpf-border)",
+            borderRadius: 8,
+            background: "var(--dpf-surface-1)",
+            boxShadow: "0 12px 30px rgba(0,0,0,0.22)",
+            padding: 6,
+          }}
+        >
+          {PROACTIVITY_LEVELS.map((level) => {
+            const option = PROACTIVITY_LEVEL_COPY[level];
+            const selected = level === value;
+            return (
+              <button
+                key={level}
+                type="button"
+                onClick={() => {
+                  onChange(level);
+                  setExpanded(false);
+                }}
+                aria-pressed={selected}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  width: "100%",
+                  border: selected ? "1px solid var(--dpf-accent)" : "1px solid transparent",
+                  borderRadius: 6,
+                  background: selected ? "var(--dpf-accent-soft)" : "transparent",
+                  color: "var(--dpf-text)",
+                  padding: "7px 8px",
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                <ProactivityGaugeIcon level={level} size={15} />
+                <span style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  <span style={{ fontSize: 12, fontWeight: 600 }}>{option.label}</span>
+                  <span style={{ fontSize: 10, color: "var(--dpf-muted)", lineHeight: 1.25 }}>{option.description}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -358,22 +358,12 @@ function arrangeHiveScoutTask() {
 describe("executeScheduledAgentTask TaskRun lifecycle", () => {
   it("creates a TaskRun before the first runAgenticLoop call and links it back to ScheduledAgentTask", async () => {
     arrangeScheduledTask();
-    mocks.runAgenticLoop.mockResolvedValue({
-      content: "Done.",
-      executedTools: [{ name: "run_discovery_triage", args: {}, result: { success: true } }],
-    });
+    mocks.runAgenticLoop.mockResolvedValue({ content: "Done.", executedTools: [{ name: "run_discovery_triage", args: {}, result: { success: true } }] });
 
     await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
 
     expect(mocks.prisma.taskRun.create).toHaveBeenCalledOnce();
-    const taskRunCreateArg = mocks.prisma.taskRun.create.mock.calls[0]?.[0];
-    expect(taskRunCreateArg?.data?.a2aMetadata).toMatchObject({
-      proactivity: {
-        resolvedLevel: "balanced",
-        policyId: "proactivity:scheduled-task:balanced",
-        actionBoundary: "propose",
-      },
-    });
+    expect(mocks.prisma.taskRun.create.mock.calls[0]?.[0]?.data?.a2aMetadata?.proactivity).toMatchObject({ resolvedLevel: "balanced", policyId: "proactivity:scheduled-task:balanced", actionBoundary: "propose" });
     expect(mocks.runAgenticLoop).toHaveBeenCalledWith(
       expect.objectContaining({
         taskRunId: "TR-SCHED-ABCDE",

--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -366,6 +366,14 @@ describe("executeScheduledAgentTask TaskRun lifecycle", () => {
     await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
 
     expect(mocks.prisma.taskRun.create).toHaveBeenCalledOnce();
+    const taskRunCreateArg = mocks.prisma.taskRun.create.mock.calls[0]?.[0];
+    expect(taskRunCreateArg?.data?.a2aMetadata).toMatchObject({
+      proactivity: {
+        resolvedLevel: "balanced",
+        policyId: "proactivity:scheduled-task:balanced",
+        actionBoundary: "propose",
+      },
+    });
     expect(mocks.runAgenticLoop).toHaveBeenCalledWith(
       expect.objectContaining({
         taskRunId: "TR-SCHED-ABCDE",

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -25,6 +25,7 @@ import {
   resolveAutonomousWorkAgent,
   resolveAutonomousWorkTools,
 } from "@/lib/tak/autonomous-work-run";
+import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
 
 // ─── Cron helpers ───────────────────────────────────────────────────────────
 
@@ -175,6 +176,12 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       },
     });
 
+    const proactivity = resolveProactivityPlan({
+      activityFamily: "scheduled-task",
+      agentId: task.agentId,
+      routeContext: task.routeContext,
+    });
+
     taskRunRef = await createTaskRunForScheduledTask({
       taskId: task.taskId,
       ownerUserId: task.ownerUserId,
@@ -183,6 +190,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       routeContext: task.routeContext,
       title: task.title,
       prompt: task.prompt,
+      proactivity,
     });
 
     await createTaskMessage({

--- a/apps/web/lib/attention/sources/agent-proposal.ts
+++ b/apps/web/lib/attention/sources/agent-proposal.ts
@@ -4,6 +4,11 @@
 
 import type { prisma } from "@dpf/db";
 import { projectActionProposalPresentation } from "@/lib/governance/action-proposal-presentation";
+import {
+  PROACTIVITY_CHANGE_ACTION,
+  parseProactivityChangeProposalParameters,
+} from "@/lib/proactivity/proactivity-change-proposal";
+import { getProactivityLevelCopy } from "@/lib/proactivity/proactivity-copy";
 import type { AttentionItem } from "../types";
 
 type Db = typeof prisma;
@@ -19,6 +24,46 @@ export type AgentActionProposalRow = {
 export function agentProposalToAttentionItem(row: AgentActionProposalRow): AttentionItem {
   const presentation = projectActionProposalPresentation(row);
   const isActivityRoutingAction = row.actionType === "activity_harness_confidence_override";
+  const proactivityChange = row.actionType === PROACTIVITY_CHANGE_ACTION
+    ? parseProactivityChangeProposalParameters(row.parameters)
+    : null;
+
+  if (proactivityChange) {
+    const current = getProactivityLevelCopy(proactivityChange.currentLevel).label;
+    const proposed = getProactivityLevelCopy(proactivityChange.proposedLevel).label;
+    const scopeRef =
+      proactivityChange.activityFamily ??
+      proactivityChange.routeContext ??
+      proactivityChange.agentId ??
+      proactivityChange.scope;
+
+    return {
+      id: `agent-proposal:${row.proposalId}`,
+      source: "agent-proposal",
+      title: `Review proactivity: ${current} -> ${proposed}`,
+      context: presentation.summary,
+      decisionClass: { scorability: "unscorable" },
+      riskClass: "bounded-write",
+      triage: {
+        timeToAct: "none",
+        residueReason: "policy-approval",
+        blastRadius: scopeRef,
+        decideEffort: "review",
+        irreversible: false,
+      },
+      createdAtIso: row.proposedAt.toISOString(),
+      actions: [{
+        kind: "open-in-context",
+        label: "Review proactivity change",
+        href: "/platform/ai",
+      }, {
+        kind: "snooze",
+        label: "Snooze",
+      }],
+      deepLink: "/platform/ai",
+      audience: { operator: true },
+    };
+  }
 
   return {
     id: `agent-proposal:${row.proposalId}`,

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -143,4 +143,31 @@ describe("agentProposalToAttentionItem", () => {
     );
     expect(item.deepLink).toBe("/platform/ai/operations-map");
   });
+
+  it("projects a proactivity change proposal with why-now context and a bounded review action", () => {
+    const item = agentProposalToAttentionItem({
+      proposalId: "AP-PROACTIVE",
+      actionType: "propose_proactivity_change",
+      parameters: {
+        kind: "proactivity-change",
+        agentId: "dispatcher",
+        activityFamily: "field-dispatch-appointment",
+        currentLevel: "balanced",
+        proposedLevel: "assertive",
+        scope: "activity-family",
+        rationale: "Late customer appointments should be warned earlier.",
+        evidenceRefs: [{ kind: "dispatch-event", id: "running-late" }],
+        spendImpact: "may increase monitoring and notification spend within existing authority",
+        authorityImpact: "does not grant new tools, permissions, or approval bypasses",
+      },
+      proposedAt: new Date("2026-06-23T07:00:00.000Z"),
+    });
+
+    expect(item.title).toBe("Review proactivity: Balanced -> Assertive");
+    expect(item.context).toBe("Why now: Late customer appointments should be warned earlier.");
+    expect(item.triage.blastRadius).toBe("field-dispatch-appointment");
+    expect(item.actions).toContainEqual({ kind: "open-in-context", label: "Review proactivity change", href: "/platform/ai" });
+    expect(item.actions).toContainEqual({ kind: "snooze", label: "Snooze" });
+    expect(item.context).not.toMatch(/AP-|queue|diagnostic/i);
+  });
 });

--- a/apps/web/lib/governance/action-proposal-presentation.test.ts
+++ b/apps/web/lib/governance/action-proposal-presentation.test.ts
@@ -3,43 +3,27 @@ import { describe, expect, it } from "vitest";
 import { projectActionProposalPresentation } from "./action-proposal-presentation";
 
 describe("projectActionProposalPresentation", () => {
-  it("renders activity-harness confidence overrides as routing-tuning actions", () => {
+  it("renders proactivity change proposals without implying broader authority", () => {
     const presentation = projectActionProposalPresentation({
-      proposalId: "harness-action:plan:edge.plan.balanced:anthropic:claude-sonnet:promote",
-      actionType: "activity_harness_confidence_override",
+      proposalId: "AP-PROACTIVE",
+      actionType: "propose_proactivity_change",
       parameters: {
-        kind: "activity-harness-confidence-override",
-        activityClass: "plan",
-        harnessRecipeKey: "edge.plan.balanced",
-        providerId: "anthropic",
-        modelId: "claude-sonnet",
-        confidence: "trusted",
+        kind: "proactivity-change",
+        currentLevel: "balanced",
+        proposedLevel: "assertive",
+        scope: "activity-family",
+        activityFamily: "field-dispatch-appointment",
+        rationale: "Late customer appointments should be warned earlier.",
+        evidenceRefs: [],
+        spendImpact: "may increase monitoring and notification spend within existing authority",
+        authorityImpact: "does not grant new tools, permissions, or approval bypasses",
       },
     });
 
-    expect(presentation).toEqual({
-      title: "Tune activity routing confidence",
-      shortLabel: "Activity routing tuning",
-      summary: "Set plan / edge.plan.balanced on anthropic/claude-sonnet to trusted.",
-      details: [
-        { label: "Activity", value: "plan" },
-        { label: "Harness", value: "edge.plan.balanced" },
-        { label: "Provider", value: "anthropic" },
-        { label: "Model", value: "claude-sonnet" },
-        { label: "Confidence", value: "trusted" },
-      ],
-    });
-  });
-
-  it("falls back to a humanized action label for unknown proposal types", () => {
-    expect(projectActionProposalPresentation({
-      proposalId: "AP-1",
-      actionType: "create_invoice",
-      parameters: {},
-    })).toMatchObject({
-      title: "Create invoice",
-      shortLabel: "Create invoice",
-      summary: "Proposed action create_invoice.",
-    });
+    expect(presentation.title).toBe("Change proactivity to Assertive");
+    expect(presentation.shortLabel).toBe("Proactivity change");
+    expect(presentation.summary).toBe("Why now: Late customer appointments should be warned earlier.");
+    expect(presentation.details).toContainEqual({ label: "Authority", value: "does not grant new tools, permissions, or approval bypasses" });
+    expect(presentation.summary).not.toMatch(/AP-|queue|diagnostic/i);
   });
 });

--- a/apps/web/lib/governance/action-proposal-presentation.ts
+++ b/apps/web/lib/governance/action-proposal-presentation.ts
@@ -1,3 +1,9 @@
+import {
+  PROACTIVITY_CHANGE_ACTION,
+  parseProactivityChangeProposalParameters,
+} from "@/lib/proactivity/proactivity-change-proposal";
+import { getProactivityLevelCopy } from "@/lib/proactivity/proactivity-copy";
+
 export type ActionProposalPresentationInput = {
   proposalId: string;
   actionType: string;
@@ -22,6 +28,27 @@ const ACTIVITY_HARNESS_CONFIDENCE_OVERRIDE_ACTION =
 export function projectActionProposalPresentation(
   input: ActionProposalPresentationInput,
 ): ActionProposalPresentation {
+  if (input.actionType === PROACTIVITY_CHANGE_ACTION) {
+    const parameters = parseProactivityChangeProposalParameters(input.parameters);
+    if (parameters) {
+      const current = getProactivityLevelCopy(parameters.currentLevel).label;
+      const proposed = getProactivityLevelCopy(parameters.proposedLevel).label;
+
+      return {
+        title: `Change proactivity to ${proposed}`,
+        shortLabel: "Proactivity change",
+        summary: `Why now: ${parameters.rationale}`,
+        details: [
+          { label: "Current", value: current },
+          { label: "Recommended", value: proposed },
+          { label: "Scope", value: readableScope(parameters.scope, parameters.activityFamily ?? parameters.routeContext) },
+          { label: "Spend", value: parameters.spendImpact },
+          { label: "Authority", value: parameters.authorityImpact },
+        ],
+      };
+    }
+  }
+
   if (input.actionType === ACTIVITY_HARNESS_CONFIDENCE_OVERRIDE_ACTION) {
     const parameters = asRecord(input.parameters);
     const activityClass = readString(parameters?.activityClass) ?? "unknown activity";
@@ -51,6 +78,11 @@ export function projectActionProposalPresentation(
     summary: `Proposed action ${input.actionType}.`,
     details: [],
   };
+}
+
+function readableScope(scope: string, scopeRef?: string | null): string {
+  const label = scope.replace(/-/g, " ");
+  return scopeRef ? `${label}: ${scopeRef}` : label;
 }
 
 function humanizeActionType(actionType: string): string {

--- a/apps/web/lib/observability/stall-surface.test.ts
+++ b/apps/web/lib/observability/stall-surface.test.ts
@@ -30,9 +30,15 @@ describe("buildStallSurface", () => {
     expect(surface.execState.stalledByWatchdog).toBe(true);
     expect(surface.execState.containerId).toBe("dpf-sandbox-1"); // prior fields preserved
     expect(surface.error).toMatch(/stalled \(heartbeat_timeout\)/);
+    expect(surface.proactivityPlan).toMatchObject({
+      resolvedLevel: "assertive",
+      escalationTarget: "platform-operator",
+      actionBoundary: "propose",
+    });
     expect(surface.verificationPatch).toEqual({
       failureAxis: "timeout",
       stalledByWatchdog: true,
+      proactivity: surface.proactivityPlan,
       observedAt: "2026-06-16T01:00:00.000Z",
     });
   });
@@ -63,14 +69,32 @@ describe("buildStallSurface", () => {
 });
 
 describe("mergeVerificationPatch", () => {
+  const proactivity = buildStallSurface({
+    reason: "heartbeat_timeout",
+    phase: "build",
+    heartbeatTimeoutSeconds: 180,
+    totalPhaseTimeoutSeconds: 3600,
+    priorExecState: null,
+    now: "2026-06-16T01:00:00.000Z",
+  }).proactivityPlan;
+
   it("merges over an existing verificationOut, preserving prior fields", () => {
     const merged = mergeVerificationPatch(
       { testsPassed: 3, fullOutput: "ok" },
-      { failureAxis: "timeout", stalledByWatchdog: true, observedAt: "2026-06-16T01:00:00.000Z" },
+      {
+        failureAxis: "timeout",
+        stalledByWatchdog: true,
+        observedAt: "2026-06-16T01:00:00.000Z",
+        proactivity,
+      },
     );
     expect(merged.testsPassed).toBe(3);
     expect(merged.failureAxis).toBe("timeout");
     expect(merged.stalledByWatchdog).toBe(true);
+    expect(merged.proactivity).toMatchObject({
+      resolvedLevel: "assertive",
+      policyId: "proactivity:build-studio-custodian:assertive",
+    });
   });
 
   it("tolerates a null/non-object existing value", () => {
@@ -78,6 +102,7 @@ describe("mergeVerificationPatch", () => {
       failureAxis: "timeout",
       stalledByWatchdog: true,
       observedAt: "2026-06-16T01:00:00.000Z",
+      proactivity,
     });
     expect(merged.failureAxis).toBe("timeout");
   });

--- a/apps/web/lib/observability/stall-surface.ts
+++ b/apps/web/lib/observability/stall-surface.ts
@@ -14,6 +14,8 @@
 // Pure + unit-tested; the watchdog applies the result in its stall transaction.
 
 import type { BuildFailureAxis } from "@/lib/build/progress-visibility-types";
+import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
+import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 
 export type StallReason =
   | "heartbeat_timeout"
@@ -34,10 +36,16 @@ export function stallReasonToFailureAxis(_reason: StallReason): BuildFailureAxis
 export type StallSurface = {
   failureAxis: BuildFailureAxis;
   error: string;
+  proactivityPlan: ProactivityPlan;
   /** New buildExecState JSON to persist (failed checkpoint). */
   execState: Record<string, unknown>;
   /** Patch to merge into verificationOut so deriveFailureAxis surfaces it. */
-  verificationPatch: { failureAxis: BuildFailureAxis; stalledByWatchdog: true; observedAt: string };
+  verificationPatch: {
+    failureAxis: BuildFailureAxis;
+    stalledByWatchdog: true;
+    observedAt: string;
+    proactivity: ProactivityPlan;
+  };
 };
 
 /**
@@ -69,12 +77,18 @@ export function buildStallSurface(args: {
     priorStep && priorStep !== "failed" && priorStep !== "complete"
       ? priorStep
       : priorFailedAt ?? "code_generated";
+  const proactivityPlan = resolveProactivityPlan({
+    activityFamily: "build-studio-custodian",
+    statusSignal: "stalled",
+    routeContext: "build-studio",
+  });
 
   return {
     failureAxis,
     error,
+    proactivityPlan,
     execState: { ...prior, step: "failed", failedAt, error, stalledByWatchdog: true },
-    verificationPatch: { failureAxis, stalledByWatchdog: true, observedAt: args.now },
+    verificationPatch: { failureAxis, stalledByWatchdog: true, observedAt: args.now, proactivity: proactivityPlan },
   };
 }
 

--- a/apps/web/lib/proactivity/field-dispatch-proactivity.test.ts
+++ b/apps/web/lib/proactivity/field-dispatch-proactivity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildNotificationIntent } from "@dpf/validators";
+
+import { resolveFieldDispatchNotificationProactivity } from "./field-dispatch-proactivity";
+
+describe("resolveFieldDispatchNotificationProactivity", () => {
+  it("treats running-late slot-hour dispatch notices as assertive proposals", () => {
+    const intent = buildNotificationIntent("running-late", "JOB-1", {
+      company: "Acme HVAC",
+      etaText: "2:40 PM",
+    });
+
+    const plan = resolveFieldDispatchNotificationProactivity({
+      intent,
+      archetype: {
+        archetypeId: "hvac-services",
+        demandSignature: "emergency-reactive",
+        capacityUnit: "slot-hours",
+      },
+    });
+
+    expect(plan).toMatchObject({
+      resolvedLevel: "assertive",
+      channelPolicy: "urgent-channel",
+      escalationTarget: "dispatcher",
+      actionBoundary: "propose",
+    });
+    expect(plan.evidenceRefs).toContainEqual({ kind: "dispatch-event", id: "running-late" });
+  });
+
+  it("keeps ordinary dispatch confirmations balanced", () => {
+    const intent = buildNotificationIntent("confirm", "JOB-2", {
+      company: "Acme HVAC",
+      dateText: "tomorrow",
+      timeText: "9:00 AM",
+    });
+
+    expect(resolveFieldDispatchNotificationProactivity({ intent })).toMatchObject({
+      resolvedLevel: "balanced",
+      actionBoundary: "propose",
+    });
+  });
+});

--- a/apps/web/lib/proactivity/field-dispatch-proactivity.ts
+++ b/apps/web/lib/proactivity/field-dispatch-proactivity.ts
@@ -1,0 +1,35 @@
+import type { DispatchNotificationIntent } from "@dpf/validators";
+
+import { resolveProactivityPlan } from "./proactivity-resolver";
+import type { ProactivityPlan, ProactivityResolverInput } from "./proactivity-types";
+
+export type FieldDispatchNotificationProactivityInput = {
+  intent: DispatchNotificationIntent;
+  archetype?: ProactivityResolverInput["archetype"];
+  agentId?: string | null;
+  routeContext?: string | null;
+};
+
+export function resolveFieldDispatchNotificationProactivity(
+  input: FieldDispatchNotificationProactivityInput,
+): ProactivityPlan {
+  const isLate = input.intent.event === "running-late";
+  const plan = resolveProactivityPlan({
+    activityFamily: "field-dispatch-appointment",
+    agentId: input.agentId,
+    routeContext: input.routeContext,
+    archetype: {
+      ...input.archetype,
+      fieldDispatchRunningLate: input.archetype?.fieldDispatchRunningLate ?? isLate,
+    },
+  });
+
+  return {
+    ...plan,
+    evidenceRefs: [
+      ...plan.evidenceRefs,
+      { kind: "dispatch-event", id: input.intent.event },
+      { kind: "dispatch-urgency", id: input.intent.urgency },
+    ],
+  };
+}

--- a/apps/web/lib/proactivity/proactivity-change-proposal.test.ts
+++ b/apps/web/lib/proactivity/proactivity-change-proposal.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROACTIVITY_CHANGE_ACTION,
+  buildProactivityChangeProposalParameters,
+  parseProactivityChangeProposalParameters,
+} from "./proactivity-change-proposal";
+
+describe("proactivity change proposal parameters", () => {
+  it("builds a bounded proposal payload with rationale and operator impacts", () => {
+    const payload = buildProactivityChangeProposalParameters({
+      agentId: "dispatcher",
+      activityFamily: "field-dispatch-appointment",
+      currentLevel: "balanced",
+      proposedLevel: "assertive",
+      scope: "activity-family",
+      rationale: "Late customer appointments should be warned earlier.",
+      evidenceRefs: [{ kind: "dispatch-event", id: "running-late" }],
+    });
+
+    expect(payload.actionType).toBe(PROACTIVITY_CHANGE_ACTION);
+    expect(payload.parameters).toMatchObject({
+      kind: "proactivity-change",
+      currentLevel: "balanced",
+      proposedLevel: "assertive",
+      scope: "activity-family",
+      spendImpact: "may increase monitoring and notification spend within existing authority",
+      authorityImpact: "does not grant new tools, permissions, or approval bypasses",
+    });
+  });
+
+  it("parses only valid closed-level proposals", () => {
+    const valid = parseProactivityChangeProposalParameters({
+      kind: "proactivity-change",
+      agentId: "dispatcher",
+      activityFamily: "field-dispatch-appointment",
+      currentLevel: "balanced",
+      proposedLevel: "assertive",
+      scope: "activity-family",
+      rationale: "Late customer appointments should be warned earlier.",
+      evidenceRefs: [],
+      spendImpact: "may increase monitoring and notification spend within existing authority",
+      authorityImpact: "does not grant new tools, permissions, or approval bypasses",
+    });
+
+    expect(valid?.proposedLevel).toBe("assertive");
+    expect(parseProactivityChangeProposalParameters({ kind: "proactivity-change", proposedLevel: "aggressive" })).toBeNull();
+  });
+});

--- a/apps/web/lib/proactivity/proactivity-change-proposal.ts
+++ b/apps/web/lib/proactivity/proactivity-change-proposal.ts
@@ -1,0 +1,99 @@
+import {
+  PROACTIVITY_ACTIVITY_FAMILIES,
+  type ProactivityActivityFamily,
+  type ProactivityLevel,
+  isProactivityLevel,
+} from "./proactivity-types";
+
+export const PROACTIVITY_CHANGE_ACTION = "propose_proactivity_change" as const;
+
+export type ProactivityChangeScope = "agent" | "activity-family" | "route-context" | "organization";
+
+export type ProactivityChangeProposalParameters = {
+  kind: "proactivity-change";
+  agentId?: string | null;
+  activityFamily?: ProactivityActivityFamily | null;
+  routeContext?: string | null;
+  currentLevel: ProactivityLevel;
+  proposedLevel: ProactivityLevel;
+  scope: ProactivityChangeScope;
+  rationale: string;
+  evidenceRefs: Array<{ kind: string; id: string }>;
+  spendImpact: string;
+  authorityImpact: string;
+};
+
+export type BuildProactivityChangeProposalInput = Omit<
+  ProactivityChangeProposalParameters,
+  "kind" | "spendImpact" | "authorityImpact"
+>;
+
+export function buildProactivityChangeProposalParameters(
+  input: BuildProactivityChangeProposalInput,
+): { actionType: typeof PROACTIVITY_CHANGE_ACTION; parameters: ProactivityChangeProposalParameters } {
+  return {
+    actionType: PROACTIVITY_CHANGE_ACTION,
+    parameters: {
+      kind: "proactivity-change",
+      ...input,
+      spendImpact: "may increase monitoring and notification spend within existing authority",
+      authorityImpact: "does not grant new tools, permissions, or approval bypasses",
+    },
+  };
+}
+
+export function parseProactivityChangeProposalParameters(
+  value: unknown,
+): ProactivityChangeProposalParameters | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "proactivity-change") return null;
+  if (!isProactivityLevel(record.currentLevel) || !isProactivityLevel(record.proposedLevel)) return null;
+  if (!isScope(record.scope)) return null;
+  const activityFamily = readOptionalActivityFamily(record.activityFamily);
+  if (record.activityFamily != null && activityFamily == null) return null;
+
+  return {
+    kind: "proactivity-change",
+    agentId: readOptionalString(record.agentId),
+    activityFamily,
+    routeContext: readOptionalString(record.routeContext),
+    currentLevel: record.currentLevel,
+    proposedLevel: record.proposedLevel,
+    scope: record.scope,
+    rationale: readString(record.rationale) ?? "A coworker recommends adjusting how persistently this work is watched.",
+    evidenceRefs: readEvidenceRefs(record.evidenceRefs),
+    spendImpact: readString(record.spendImpact) ?? "may change monitoring or notification spend within existing authority",
+    authorityImpact: readString(record.authorityImpact) ?? "does not grant new tools, permissions, or approval bypasses",
+  };
+}
+
+function isScope(value: unknown): value is ProactivityChangeScope {
+  return value === "agent" || value === "activity-family" || value === "route-context" || value === "organization";
+}
+
+function readOptionalActivityFamily(value: unknown): ProactivityActivityFamily | null {
+  return typeof value === "string" && (PROACTIVITY_ACTIVITY_FAMILIES as readonly string[]).includes(value)
+    ? (value as ProactivityActivityFamily)
+    : null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readOptionalString(value: unknown): string | null {
+  if (value == null) return null;
+  return readString(value);
+}
+
+function readEvidenceRefs(value: unknown): Array<{ kind: string; id: string }> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    const kind = readString(record.kind);
+    const id = readString(record.id);
+    return kind && id ? [{ kind, id }] : [];
+  });
+}

--- a/apps/web/lib/proactivity/proactivity-copy.ts
+++ b/apps/web/lib/proactivity/proactivity-copy.ts
@@ -1,0 +1,38 @@
+import type { ProactivityLevel } from "./proactivity-types";
+
+export const PROACTIVITY_LEVEL_COPY: Record<
+  ProactivityLevel,
+  {
+    label: string;
+    description: string;
+    accent: "green" | "yellow" | "red";
+    gaugeNeedle: "low" | "center" | "high";
+    ariaLabel: string;
+  }
+> = {
+  quiet: {
+    label: "Quiet",
+    description: "Wait for me unless something is urgent or already approved.",
+    accent: "green",
+    gaugeNeedle: "low",
+    ariaLabel: "Proactivity quiet, minimum follow-up",
+  },
+  balanced: {
+    label: "Balanced",
+    description: "Follow up when timing, commitments, or risk make it useful.",
+    accent: "yellow",
+    gaugeNeedle: "center",
+    ariaLabel: "Proactivity balanced, normal follow-up",
+  },
+  assertive: {
+    label: "Assertive",
+    description: "Stay on this, warn earlier, and escalate sooner when allowed.",
+    accent: "red",
+    gaugeNeedle: "high",
+    ariaLabel: "Proactivity assertive, aggressive follow-up",
+  },
+};
+
+export function getProactivityLevelCopy(level: ProactivityLevel) {
+  return PROACTIVITY_LEVEL_COPY[level];
+}

--- a/apps/web/lib/proactivity/proactivity-resolver.test.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { getProactivityLevelCopy } from "./proactivity-copy";
+import { resolveProactivityPlan } from "./proactivity-resolver";
+import { PROACTIVITY_ACTIVITY_FAMILIES, PROACTIVITY_LEVELS, isProactivityLevel } from "./proactivity-types";
+
+describe("proactivity types", () => {
+  it("keeps the persisted level enum closed and stable", () => {
+    expect(PROACTIVITY_LEVELS).toEqual(["quiet", "balanced", "assertive"]);
+    expect(isProactivityLevel("balanced")).toBe(true);
+    expect(isProactivityLevel("aggressive")).toBe(false);
+    expect(isProactivityLevel("not-proactive")).toBe(false);
+  });
+
+  it("includes the first implementation activity families", () => {
+    expect(PROACTIVITY_ACTIVITY_FAMILIES).toContain("field-dispatch-appointment");
+    expect(PROACTIVITY_ACTIVITY_FAMILIES).toContain("build-studio-custodian");
+    expect(PROACTIVITY_ACTIVITY_FAMILIES).toContain("tax-compliance");
+  });
+});
+
+describe("proactivity copy", () => {
+  it("uses labels and descriptions that do not imply broader authority", () => {
+    expect(getProactivityLevelCopy("assertive").label).toBe("Assertive");
+    expect(getProactivityLevelCopy("assertive").description).toContain("warn earlier");
+    expect(getProactivityLevelCopy("assertive").description).not.toMatch(/auto-approve|permission|authority/i);
+  });
+
+  it("pairs color with gauge treatment for every level", () => {
+    expect(getProactivityLevelCopy("quiet").accent).toBe("green");
+    expect(getProactivityLevelCopy("balanced").gaugeNeedle).toBe("center");
+    expect(getProactivityLevelCopy("assertive").accent).toBe("red");
+  });
+});
+
+describe("resolveProactivityPlan", () => {
+  it("makes field-dispatch appointment delays assertive for slot-hours emergency work", () => {
+    expect(
+      resolveProactivityPlan({
+        activityFamily: "field-dispatch-appointment",
+        archetype: {
+          demandSignature: "emergency-reactive",
+          capacityUnit: "slot-hours",
+          fieldDispatchRunningLate: true,
+        },
+        riskBand: "medium",
+      }),
+    ).toMatchObject({
+      resolvedLevel: "assertive",
+      channelPolicy: "urgent-channel",
+      escalationTarget: "dispatcher",
+      actionBoundary: "propose",
+    });
+  });
+
+  it("keeps todo follow-up balanced and bounded", () => {
+    const plan = resolveProactivityPlan({ activityFamily: "todo-follow-up" });
+
+    expect(plan.resolvedLevel).toBe("balanced");
+    expect(plan.maxAttempts).toBeLessThanOrEqual(2);
+  });
+
+  it("escalates Build Studio blocked work without increasing authority", () => {
+    expect(
+      resolveProactivityPlan({
+        activityFamily: "build-studio-custodian",
+        statusSignal: "stalled",
+      }),
+    ).toMatchObject({
+      resolvedLevel: "assertive",
+      actionBoundary: "propose",
+    });
+  });
+
+  it("uses assertive reminders for tax deadlines but keeps action advisory or proposal-gated", () => {
+    const plan = resolveProactivityPlan({
+      activityFamily: "tax-compliance",
+      deadlineWindowDays: 7,
+      regulated: true,
+    });
+
+    expect(plan.resolvedLevel).toBe("assertive");
+    expect(["advise", "propose"]).toContain(plan.actionBoundary);
+  });
+});

--- a/apps/web/lib/proactivity/proactivity-resolver.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.ts
@@ -1,0 +1,150 @@
+import type {
+  ProactivityActionBoundary,
+  ProactivityChannelPolicy,
+  ProactivityEscalationTarget,
+  ProactivityLevel,
+  ProactivityPlan,
+  ProactivityResolverInput,
+  ProactivitySpendClass,
+} from "./proactivity-types";
+
+type PlanDefaults = {
+  attentionWindowMinutes: number;
+  followUpCadenceMinutes: number[];
+  maxAttempts: number;
+  spendClass: ProactivitySpendClass;
+  channelPolicy: ProactivityChannelPolicy;
+  escalationTarget: ProactivityEscalationTarget;
+  actionBoundary: ProactivityActionBoundary;
+};
+
+const DEFAULTS_BY_LEVEL: Record<ProactivityLevel, PlanDefaults> = {
+  quiet: {
+    attentionWindowMinutes: 120,
+    followUpCadenceMinutes: [],
+    maxAttempts: 0,
+    spendClass: "minimal",
+    channelPolicy: "in-app-only",
+    escalationTarget: "attention-surface",
+    actionBoundary: "advise",
+  },
+  balanced: {
+    attentionWindowMinutes: 60,
+    followUpCadenceMinutes: [120],
+    maxAttempts: 2,
+    spendClass: "standard",
+    channelPolicy: "preferred-channel",
+    escalationTarget: "attention-surface",
+    actionBoundary: "propose",
+  },
+  assertive: {
+    attentionWindowMinutes: 30,
+    followUpCadenceMinutes: [30, 60, 120],
+    maxAttempts: 3,
+    spendClass: "elevated",
+    channelPolicy: "urgent-channel",
+    escalationTarget: "owner",
+    actionBoundary: "propose",
+  },
+};
+
+export function resolveProactivityPlan(input: ProactivityResolverInput): ProactivityPlan {
+  const level = resolveLevel(input);
+  const defaults = { ...DEFAULTS_BY_LEVEL[level] };
+  const evidenceRefs = evidenceFor(input);
+
+  if (input.activityFamily === "field-dispatch-appointment") {
+    defaults.escalationTarget = "dispatcher";
+    if (level === "assertive") {
+      defaults.channelPolicy = "urgent-channel";
+      defaults.attentionWindowMinutes = 20;
+    }
+  }
+
+  if (input.activityFamily === "build-studio-custodian") {
+    defaults.escalationTarget = "platform-operator";
+  }
+
+  if (input.regulated || input.activityFamily === "tax-compliance") {
+    defaults.actionBoundary = input.regulated ? "advise" : "propose";
+    defaults.spendClass = level === "assertive" ? "standard" : defaults.spendClass;
+  }
+
+  return {
+    resolvedLevel: level,
+    policyId: policyIdFor(input, level),
+    ...defaults,
+    explanation: explanationFor(input, level),
+    evidenceRefs,
+  };
+}
+
+function resolveLevel(input: ProactivityResolverInput): ProactivityLevel {
+  if (input.activityFamily === "interactive-chat") return "balanced";
+
+  if (input.activityFamily === "todo-follow-up") return "balanced";
+
+  if (input.activityFamily === "field-dispatch-appointment") {
+    if (
+      input.archetype?.fieldDispatchRunningLate ||
+      input.archetype?.demandSignature === "emergency-reactive" ||
+      input.archetype?.capacityUnit === "slot-hours"
+    ) {
+      return "assertive";
+    }
+    return "balanced";
+  }
+
+  if (input.activityFamily === "build-studio-custodian") {
+    return input.statusSignal === "blocked" || input.statusSignal === "stalled" || input.statusSignal === "degraded"
+      ? "assertive"
+      : "balanced";
+  }
+
+  if (input.activityFamily === "platform-health") {
+    return input.statusSignal === "degraded" || input.statusSignal === "offline" ? "assertive" : "balanced";
+  }
+
+  if (input.activityFamily === "tax-compliance") {
+    return typeof input.deadlineWindowDays === "number" && input.deadlineWindowDays <= 7 ? "assertive" : "balanced";
+  }
+
+  if (input.activityFamily === "security-incident") return "assertive";
+
+  return "balanced";
+}
+
+function policyIdFor(input: ProactivityResolverInput, level: ProactivityLevel): string {
+  return `proactivity:${input.activityFamily}:${level}`;
+}
+
+function evidenceFor(input: ProactivityResolverInput): ProactivityPlan["evidenceRefs"] {
+  const refs: ProactivityPlan["evidenceRefs"] = [{ kind: "activity-family", id: input.activityFamily }];
+
+  if (input.agentId) refs.push({ kind: "agent", id: input.agentId });
+  if (input.routeContext) refs.push({ kind: "route-context", id: input.routeContext });
+  if (input.statusSignal) refs.push({ kind: "status-signal", id: input.statusSignal });
+  if (input.archetype?.archetypeId) refs.push({ kind: "archetype", id: input.archetype.archetypeId });
+  if (input.archetype?.demandSignature) refs.push({ kind: "demand-signature", id: input.archetype.demandSignature });
+  if (input.archetype?.capacityUnit) refs.push({ kind: "capacity-unit", id: input.archetype.capacityUnit });
+
+  return refs;
+}
+
+function explanationFor(input: ProactivityResolverInput, level: ProactivityLevel): string {
+  if (input.activityFamily === "field-dispatch-appointment" && level === "assertive") {
+    return "Customer appointment timing is operationally load-bearing, so the coworker should warn earlier and escalate sooner while preserving approval boundaries.";
+  }
+
+  if (input.activityFamily === "build-studio-custodian" && level === "assertive") {
+    return "Build Studio work is blocked or stalled, so the coworker should surface guided next action sooner without increasing authority.";
+  }
+
+  if (input.activityFamily === "tax-compliance" && level === "assertive") {
+    return "A compliance deadline is close enough to justify assertive reminders while keeping advice and filing approval-gated.";
+  }
+
+  return level === "balanced"
+    ? "Balanced is the default proactivity level for useful follow-up without noisy repeated interruption."
+    : "Quiet minimizes unsolicited follow-up unless urgency or prior approval justifies attention.";
+}

--- a/apps/web/lib/proactivity/proactivity-types.ts
+++ b/apps/web/lib/proactivity/proactivity-types.ts
@@ -1,0 +1,66 @@
+export const PROACTIVITY_LEVELS = ["quiet", "balanced", "assertive"] as const;
+export type ProactivityLevel = (typeof PROACTIVITY_LEVELS)[number];
+
+export const PROACTIVITY_ACTIVITY_FAMILIES = [
+  "interactive-chat",
+  "todo-follow-up",
+  "scheduled-task",
+  "field-dispatch-appointment",
+  "build-studio-custodian",
+  "technology-debt",
+  "platform-health",
+  "tax-compliance",
+  "customer-communication",
+  "finance-close",
+  "security-incident",
+] as const;
+export type ProactivityActivityFamily = (typeof PROACTIVITY_ACTIVITY_FAMILIES)[number];
+
+export type ProactivitySpendClass = "minimal" | "standard" | "elevated";
+export type ProactivityChannelPolicy = "in-app-only" | "preferred-channel" | "urgent-channel" | "multi-channel";
+export type ProactivityActionBoundary = "advise" | "propose" | "preauthorized";
+export type ProactivityRiskBand = "low" | "medium" | "high" | "critical";
+
+export type ProactivityEscalationTarget =
+  | "attention-surface"
+  | "owner"
+  | "role"
+  | "dispatcher"
+  | "platform-operator";
+
+export type ProactivityPlan = {
+  resolvedLevel: ProactivityLevel;
+  policyId: string;
+  attentionWindowMinutes: number;
+  followUpCadenceMinutes: number[];
+  maxAttempts: number;
+  spendClass: ProactivitySpendClass;
+  channelPolicy: ProactivityChannelPolicy;
+  escalationTarget: ProactivityEscalationTarget;
+  actionBoundary: ProactivityActionBoundary;
+  explanation: string;
+  evidenceRefs: Array<{ kind: string; id: string }>;
+};
+
+export type ProactivityResolverInput = {
+  activityFamily: ProactivityActivityFamily;
+  agentId?: string | null;
+  routeContext?: string | null;
+  riskBand?: ProactivityRiskBand;
+  statusSignal?: "normal" | "blocked" | "stalled" | "degraded" | "offline" | null;
+  deadlineWindowDays?: number | null;
+  regulated?: boolean;
+  archetype?: {
+    archetypeId?: string | null;
+    archetypeCategory?: string | null;
+    demandSignature?: string | null;
+    capacityUnit?: string | null;
+    fieldDispatchRunningLate?: boolean;
+    loadBearingStageKeys?: string[];
+    trustGates?: string[];
+  } | null;
+};
+
+export function isProactivityLevel(value: unknown): value is ProactivityLevel {
+  return typeof value === "string" && (PROACTIVITY_LEVELS as readonly string[]).includes(value);
+}

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -174,6 +174,54 @@ describe("createAutonomousWorkRun", () => {
     expect(String(arg?.data?.taskRunId)).toMatch(/^TR-CAP-/);
   });
 
+  it("writes explicit proactivity metadata without letting generic metadata clobber it", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "tr_internal_proactivity",
+      taskRunId: "TR-SCHED-PROACT",
+      contextId: "thread-proactivity",
+    } as never);
+
+    const proactivity = {
+      resolvedLevel: "assertive" as const,
+      policyId: "proactivity:field-dispatch-appointment:assertive",
+      attentionWindowMinutes: 20,
+      followUpCadenceMinutes: [30, 60],
+      maxAttempts: 3,
+      spendClass: "elevated" as const,
+      channelPolicy: "urgent-channel" as const,
+      escalationTarget: "dispatcher" as const,
+      actionBoundary: "propose" as const,
+      explanation: "Customer appointment timing is at risk.",
+      evidenceRefs: [{ kind: "activity-family", id: "field-dispatch-appointment" }],
+    };
+
+    const { createAutonomousWorkRun } = await import("./autonomous-work-run");
+
+    await createAutonomousWorkRun({
+      trigger: "scheduled",
+      userId: "dispatcher-1",
+      agentId: "dispatch-coworker",
+      routeContext: "/storefront/schedule",
+      title: "Appointment delay watch",
+      objective: "Watch appointment delay risk.",
+      prompt: "Watch appointment delay risk.",
+      threadId: "thread-proactivity",
+      metadata: {
+        proactivity: { resolvedLevel: "quiet" },
+        context: "field-dispatch",
+      },
+      proactivity,
+    });
+
+    const arg = vi.mocked(prisma.taskRun.create).mock.calls[0]?.[0];
+    expect(arg?.data?.a2aMetadata).toMatchObject({
+      trigger: "scheduled",
+      context: "field-dispatch",
+      proactivity,
+    });
+  });
+
   it("finds the newest unarchived TaskRun for an interactive thread", async () => {
     const { prisma } = await import("@dpf/db");
     vi.mocked(prisma.taskRun.findFirst).mockResolvedValue({ taskRunId: "TR-CHAT-123" } as never);

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -5,6 +5,7 @@ import { resolveCoworkerReviewPattern } from "@/lib/golden-triangle/coworker-rev
 import { reviewCoworkerDraft } from "@/lib/tak/coworker-inline-review";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { AgentEvent } from "@/lib/tak/agent-event-bus";
+import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 
 /** Best-effort latest user-turn text, for the reviewer's context. */
 function lastUserRequest(history: ChatMessage[]): string {
@@ -62,6 +63,7 @@ export type AutonomousWorkRunInput = {
     id: string;
   };
   metadata?: Record<string, unknown>;
+  proactivity?: ProactivityPlan;
 };
 
 const TRIGGER_PREFIX: Record<AutonomousWorkTrigger, string> = {
@@ -114,6 +116,7 @@ export async function createAutonomousWorkRun(
         trigger: input.trigger,
         ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
         ...(input.metadata ?? {}),
+        ...(input.proactivity ? { proactivity: input.proactivity } : {}),
       },
     },
     select: { id: true, taskRunId: true, contextId: true },

--- a/apps/web/lib/tak/scheduled-task-runs.test.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.test.ts
@@ -65,4 +65,46 @@ describe("createTaskRunForScheduledTask", () => {
     });
     expect(String(arg?.data?.taskRunId)).toMatch(/^TR-SCHED-/);
   });
+
+  it("passes scheduled proactivity plans into TaskRun metadata", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "tr_internal_2",
+      taskRunId: "TR-SCHED-PROACT",
+      contextId: "thread-2",
+    } as never);
+
+    const proactivity = {
+      resolvedLevel: "balanced" as const,
+      policyId: "proactivity:scheduled-task:balanced",
+      attentionWindowMinutes: 60,
+      followUpCadenceMinutes: [120],
+      maxAttempts: 2,
+      spendClass: "standard" as const,
+      channelPolicy: "preferred-channel" as const,
+      escalationTarget: "attention-surface" as const,
+      actionBoundary: "propose" as const,
+      explanation: "Balanced scheduled follow-up.",
+      evidenceRefs: [{ kind: "activity-family", id: "scheduled-task" }],
+    };
+
+    const { createTaskRunForScheduledTask } = await import("./scheduled-task-runs");
+
+    await createTaskRunForScheduledTask({
+      taskId: "daily-summary",
+      ownerUserId: "user-1",
+      agentId: "workspace-coworker",
+      threadId: "thread-2",
+      routeContext: "/workspace",
+      title: "Daily Summary",
+      prompt: "Summarize today.",
+      proactivity,
+    });
+
+    const arg = vi.mocked(prisma.taskRun.create).mock.calls[0]?.[0];
+    expect(arg?.data?.a2aMetadata).toMatchObject({
+      trigger: "scheduled",
+      proactivity,
+    });
+  });
 });

--- a/apps/web/lib/tak/scheduled-task-runs.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.ts
@@ -2,6 +2,7 @@ import {
   createAutonomousWorkRun,
   type AutonomousWorkRunRef,
 } from "@/lib/tak/autonomous-work-run";
+import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 
 export type ScheduledTaskRunRef = AutonomousWorkRunRef;
 
@@ -13,6 +14,7 @@ export async function createTaskRunForScheduledTask(input: {
   routeContext: string;
   title: string;
   prompt: string;
+  proactivity?: ProactivityPlan;
 }): Promise<ScheduledTaskRunRef> {
   return createAutonomousWorkRun({
     trigger: "scheduled",
@@ -27,5 +29,6 @@ export async function createTaskRunForScheduledTask(input: {
       kind: "scheduled-task",
       id: input.taskId,
     },
+    proactivity: input.proactivity,
   });
 }

--- a/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
+++ b/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
@@ -1,0 +1,794 @@
+# AI Coworker Proactivity Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available and explicitly authorized) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a governed Quiet / Balanced / Assertive proactivity setting for AI coworkers, visible beside the golden-triangle priority dock and resolved consistently for interactive, scheduled, Build Studio, field-dispatch, and monitoring work.
+
+**Architecture:** Build a shared `apps/web/lib/proactivity` module first, then consume it from UI and runtime callers. V1 keeps system/archetype defaults in typed code and writes runtime evidence into existing metadata; persistent overrides are added only after an implementation sweep proves no suitable existing preference substrate exists. Proactivity changes timing, persistence, escalation, spend class, and explanation only; existing autonomy, HITL, grants, routing, and outbound governance remain authoritative.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Prisma 7, Vitest, lucide-react, DPF theme tokens, existing golden-triangle coworker dock, existing TAK `TaskRun.a2aMetadata`.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md`
+
+---
+
+## File Structure
+
+- Create `apps/web/lib/proactivity/proactivity-types.ts`: closed enums, plan/policy/input types, type guards.
+- Create `apps/web/lib/proactivity/proactivity-copy.ts`: shared labels, descriptions, icon/color tokens, and accessible copy.
+- Create `apps/web/lib/proactivity/proactivity-resolver.ts`: pure resolver that maps activity, archetype, role, risk, and governance hints to a `ProactivityPlan`.
+- Create `apps/web/lib/proactivity/proactivity-resolver.test.ts`: resolver matrix tests.
+- Create `apps/web/lib/proactivity/proactivity-copy.test.ts`: copy/icon/color guard tests.
+- Create `apps/web/components/proactivity/ProactivityGaugeIcon.tsx`: compact gauge icon if stock Lucide cannot represent needle positions well enough.
+- Create `apps/web/components/proactivity/ProactivityLevelControl.tsx`: compact dock control and expanded segmented picker.
+- Create `apps/web/components/proactivity/ProactivityLevelControl.test.tsx`: interaction and accessible-label tests.
+- Modify `apps/web/components/golden-triangle/CoworkerPriorityDock.tsx`: render the proactivity chip beside the golden triangle and keep the dock collapsed by default.
+- Modify `apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx`: assert dock layout, collapsed state, and mobile-safe labels.
+- Modify `apps/web/components/agent/CoworkerProfilePanel.tsx`: show effective proactivity explanation and advanced policy details.
+- Modify `apps/web/components/agent/CoworkerProfilePanel.test.tsx` or add one if no local test exists.
+- Modify `apps/web/lib/tak/autonomous-work-run.ts`: accept optional proactivity metadata and write it into `TaskRun.a2aMetadata.proactivity`.
+- Modify `apps/web/lib/tak/scheduled-task-runs.ts`: accept proactivity metadata for scheduled runs if this helper owns the actual `TaskRun` create path.
+- Modify `apps/web/lib/actions/agent-task-scheduler.ts`: resolve and pass scheduled-task proactivity plan without bypassing owner/tool/HITL checks.
+- Modify relevant Build Studio custodian/stall caller once identified in implementation: consume shared resolver, do not fork a Build Studio-only policy.
+- Modify field-dispatch runtime caller once identified in implementation: consume shared resolver around runtime behavior, not pure validator functions.
+- Optional migration: `packages/db/prisma/migrations/<timestamp>_proactivity_override/migration.sql` only if no existing preference/action-envelope substrate can store accepted overrides cleanly.
+
+## Chunk 1: Shared Proactivity Resolver
+
+### Task 1: Add Closed Types
+
+**Files:**
+- Create: `apps/web/lib/proactivity/proactivity-types.ts`
+- Test: `apps/web/lib/proactivity/proactivity-resolver.test.ts`
+
+- [ ] **Step 1: Write failing enum/type tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { PROACTIVITY_ACTIVITY_FAMILIES, PROACTIVITY_LEVELS, isProactivityLevel } from "./proactivity-types";
+
+describe("proactivity types", () => {
+  it("keeps the persisted level enum closed and stable", () => {
+    expect(PROACTIVITY_LEVELS).toEqual(["quiet", "balanced", "assertive"]);
+    expect(isProactivityLevel("balanced")).toBe(true);
+    expect(isProactivityLevel("aggressive")).toBe(false);
+    expect(isProactivityLevel("not-proactive")).toBe(false);
+  });
+
+  it("includes the first implementation activity families", () => {
+    expect(PROACTIVITY_ACTIVITY_FAMILIES).toContain("field-dispatch-appointment");
+    expect(PROACTIVITY_ACTIVITY_FAMILIES).toContain("build-studio-custodian");
+    expect(PROACTIVITY_ACTIVITY_FAMILIES).toContain("tax-compliance");
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-resolver.test.ts`
+
+Expected: FAIL because `apps/web/lib/proactivity/proactivity-types.ts` does not exist.
+
+- [ ] **Step 3: Implement closed types**
+
+```ts
+export const PROACTIVITY_LEVELS = ["quiet", "balanced", "assertive"] as const;
+export type ProactivityLevel = (typeof PROACTIVITY_LEVELS)[number];
+
+export const PROACTIVITY_ACTIVITY_FAMILIES = [
+  "interactive-chat",
+  "todo-follow-up",
+  "scheduled-task",
+  "field-dispatch-appointment",
+  "build-studio-custodian",
+  "technology-debt",
+  "platform-health",
+  "tax-compliance",
+  "customer-communication",
+  "finance-close",
+  "security-incident",
+] as const;
+export type ProactivityActivityFamily = (typeof PROACTIVITY_ACTIVITY_FAMILIES)[number];
+
+export type ProactivitySpendClass = "minimal" | "standard" | "elevated";
+export type ProactivityChannelPolicy = "in-app-only" | "preferred-channel" | "urgent-channel" | "multi-channel";
+export type ProactivityActionBoundary = "advise" | "propose" | "preauthorized";
+
+export type ProactivityPlan = {
+  resolvedLevel: ProactivityLevel;
+  policyId: string;
+  attentionWindowMinutes: number;
+  followUpCadenceMinutes: number[];
+  maxAttempts: number;
+  spendClass: ProactivitySpendClass;
+  channelPolicy: ProactivityChannelPolicy;
+  escalationTarget: "attention-surface" | "owner" | "role" | "dispatcher" | "platform-operator";
+  actionBoundary: ProactivityActionBoundary;
+  explanation: string;
+  evidenceRefs: Array<{ kind: string; id: string }>;
+};
+
+export function isProactivityLevel(value: unknown): value is ProactivityLevel {
+  return typeof value === "string" && (PROACTIVITY_LEVELS as readonly string[]).includes(value);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-resolver.test.ts`
+
+Expected: PASS for type tests.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/proactivity/proactivity-types.ts apps/web/lib/proactivity/proactivity-resolver.test.ts
+git commit -s -m "feat: add proactivity policy types"
+```
+
+### Task 2: Add Shared Copy And Symbol Metadata
+
+**Files:**
+- Create: `apps/web/lib/proactivity/proactivity-copy.ts`
+- Test: `apps/web/lib/proactivity/proactivity-copy.test.ts`
+
+- [ ] **Step 1: Write failing copy tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { PROACTIVITY_LEVEL_COPY, getProactivityLevelCopy } from "./proactivity-copy";
+
+describe("proactivity copy", () => {
+  it("uses labels and descriptions that do not imply broader authority", () => {
+    expect(PROACTIVITY_LEVEL_COPY.assertive.label).toBe("Assertive");
+    expect(PROACTIVITY_LEVEL_COPY.assertive.description).toContain("warn earlier");
+    expect(PROACTIVITY_LEVEL_COPY.assertive.description).not.toMatch(/auto-approve|permission|authority/i);
+  });
+
+  it("pairs color with gauge treatment for every level", () => {
+    expect(getProactivityLevelCopy("quiet").accent).toBe("green");
+    expect(getProactivityLevelCopy("balanced").gaugeNeedle).toBe("center");
+    expect(getProactivityLevelCopy("assertive").accent).toBe("red");
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-copy.test.ts`
+
+Expected: FAIL because copy module does not exist.
+
+- [ ] **Step 3: Implement copy module**
+
+```ts
+import type { ProactivityLevel } from "./proactivity-types";
+
+export const PROACTIVITY_LEVEL_COPY: Record<ProactivityLevel, {
+  label: string;
+  description: string;
+  accent: "green" | "yellow" | "red";
+  gaugeNeedle: "low" | "center" | "high";
+  ariaLabel: string;
+}> = {
+  quiet: {
+    label: "Quiet",
+    description: "Wait for me unless something is urgent or already approved.",
+    accent: "green",
+    gaugeNeedle: "low",
+    ariaLabel: "Proactivity quiet, minimum follow-up",
+  },
+  balanced: {
+    label: "Balanced",
+    description: "Follow up when timing, commitments, or risk make it useful.",
+    accent: "yellow",
+    gaugeNeedle: "center",
+    ariaLabel: "Proactivity balanced, normal follow-up",
+  },
+  assertive: {
+    label: "Assertive",
+    description: "Stay on this, warn earlier, and escalate sooner when allowed.",
+    accent: "red",
+    gaugeNeedle: "high",
+    ariaLabel: "Proactivity assertive, aggressive follow-up",
+  },
+};
+
+export function getProactivityLevelCopy(level: ProactivityLevel) {
+  return PROACTIVITY_LEVEL_COPY[level];
+}
+```
+
+- [ ] **Step 4: Run copy and type tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-copy.test.ts apps/web/lib/proactivity/proactivity-resolver.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/proactivity/proactivity-copy.ts apps/web/lib/proactivity/proactivity-copy.test.ts
+git commit -s -m "feat: add proactivity copy metadata"
+```
+
+### Task 3: Implement Pure Resolver
+
+**Files:**
+- Create: `apps/web/lib/proactivity/proactivity-resolver.ts`
+- Test: `apps/web/lib/proactivity/proactivity-resolver.test.ts`
+
+- [ ] **Step 1: Add failing resolver matrix tests**
+
+```ts
+import { resolveProactivityPlan } from "./proactivity-resolver";
+
+describe("resolveProactivityPlan", () => {
+  it("makes field-dispatch appointment delays assertive for slot-hours emergency work", () => {
+    expect(resolveProactivityPlan({
+      activityFamily: "field-dispatch-appointment",
+      archetype: { demandSignature: "emergency-reactive", capacityUnit: "slot-hours", fieldDispatchRunningLate: true },
+      riskBand: "medium",
+    })).toMatchObject({
+      resolvedLevel: "assertive",
+      channelPolicy: "urgent-channel",
+      escalationTarget: "dispatcher",
+      actionBoundary: "propose",
+    });
+  });
+
+  it("keeps todo follow-up balanced and bounded", () => {
+    const plan = resolveProactivityPlan({ activityFamily: "todo-follow-up" });
+    expect(plan.resolvedLevel).toBe("balanced");
+    expect(plan.maxAttempts).toBeLessThanOrEqual(2);
+  });
+
+  it("escalates Build Studio blocked work without increasing authority", () => {
+    expect(resolveProactivityPlan({
+      activityFamily: "build-studio-custodian",
+      statusSignal: "stalled",
+    })).toMatchObject({ resolvedLevel: "assertive", actionBoundary: "propose" });
+  });
+
+  it("uses assertive reminders for tax deadlines but keeps action advisory or proposal-gated", () => {
+    const plan = resolveProactivityPlan({
+      activityFamily: "tax-compliance",
+      deadlineWindowDays: 7,
+      regulated: true,
+    });
+    expect(plan.resolvedLevel).toBe("assertive");
+    expect(["advise", "propose"]).toContain(plan.actionBoundary);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing resolver tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-resolver.test.ts`
+
+Expected: FAIL because `resolveProactivityPlan` does not exist.
+
+- [ ] **Step 3: Implement minimal resolver**
+
+Implementation notes:
+- Keep resolver pure and deterministic.
+- Accept only plain data; do not import Prisma, React, action modules, or field-dispatch validator internals.
+- Include `policyId`, `explanation`, and `evidenceRefs` in every plan.
+- Intersect regulated work and high risk with `actionBoundary: "advise"` or `"propose"`.
+
+- [ ] **Step 4: Run resolver tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-resolver.test.ts apps/web/lib/proactivity/proactivity-copy.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/proactivity/proactivity-resolver.ts apps/web/lib/proactivity/proactivity-resolver.test.ts
+git commit -s -m "feat: resolve coworker proactivity plans"
+```
+
+## Chunk 2: Composer Dock UX
+
+### Task 4: Build Proactivity Level Control
+
+**Files:**
+- Create: `apps/web/components/proactivity/ProactivityLevelControl.tsx`
+- Create: `apps/web/components/proactivity/ProactivityGaugeIcon.tsx`
+- Test: `apps/web/components/proactivity/ProactivityLevelControl.test.tsx`
+
+- [ ] **Step 1: Write failing render and interaction tests**
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProactivityLevelControl } from "./ProactivityLevelControl";
+
+describe("ProactivityLevelControl", () => {
+  it("renders compact gauge, label, and current level", () => {
+    render(<ProactivityLevelControl value="balanced" onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /Proactivity balanced/i })).toBeInTheDocument();
+    expect(screen.getByText("Proactivity")).toBeInTheDocument();
+    expect(screen.getByText("Balanced")).toBeInTheDocument();
+  });
+
+  it("lets the operator choose Assertive without relying on color alone", () => {
+    const onChange = vi.fn();
+    render(<ProactivityLevelControl value="balanced" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /Proactivity balanced/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Assertive/i }));
+    expect(onChange).toHaveBeenCalledWith("assertive");
+  });
+});
+```
+
+- [ ] **Step 2: Run failing component test**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/proactivity/ProactivityLevelControl.test.tsx`
+
+Expected: FAIL because component files do not exist.
+
+- [ ] **Step 3: Implement component**
+
+Implementation notes:
+- Use `button`, `aria-expanded`, and accessible names.
+- Use `PROACTIVITY_LEVEL_COPY` for labels/descriptions.
+- Use `lucide-react` `Gauge` or `CircleGauge` first.
+- If custom needle positions are needed, implement `ProactivityGaugeIcon` with 14-16px dimensions, Lucide-like stroke, and `aria-hidden`.
+- Use theme tokens and existing inline-style conventions in `CoworkerPriorityDock`; no hardcoded theme-breaking fills.
+- Use green/yellow/red accents only as small arcs/dots/borders plus text.
+
+- [ ] **Step 4: Run component test**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/proactivity/ProactivityLevelControl.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/components/proactivity apps/web/lib/proactivity
+git commit -s -m "feat: add proactivity level control"
+```
+
+### Task 5: Place Control Beside Golden Triangle
+
+**Files:**
+- Modify: `apps/web/components/golden-triangle/CoworkerPriorityDock.tsx`
+- Test: `apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx`
+
+- [ ] **Step 1: Update failing dock tests**
+
+Add assertions that the collapsed dock shows both critical settings:
+
+```tsx
+expect(screen.getByRole("button", { name: /Priority/i })).toBeInTheDocument();
+expect(screen.getByRole("button", { name: /Proactivity balanced/i })).toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run failing dock tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx`
+
+Expected: FAIL because proactivity is not rendered in the dock.
+
+- [ ] **Step 3: Modify dock layout**
+
+Implementation notes:
+- Keep priority collapsed by default.
+- Render a critical-settings strip with two siblings:
+  - left: existing golden-triangle priority button
+  - right: `ProactivityLevelControl`
+- Do not move `GoldenTriangleControl` into the proactivity expansion.
+- If one control is expanded, keep layout stable and avoid overlapping composer input.
+- Initial V1 value can be `balanced` until persistence lands.
+
+- [ ] **Step 4: Run dock and proactivity tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx apps/web/components/proactivity/ProactivityLevelControl.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/components/golden-triangle/CoworkerPriorityDock.tsx apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx apps/web/components/proactivity
+git commit -s -m "feat: show proactivity beside coworker priority"
+```
+
+### Task 6: Add Profile Details
+
+**Files:**
+- Modify: `apps/web/components/agent/CoworkerProfilePanel.tsx`
+- Test: `apps/web/components/agent/CoworkerProfilePanel.test.tsx` or nearest existing agent panel test.
+
+- [ ] **Step 1: Write failing profile test**
+
+Assert that the profile shows:
+- current level,
+- why selected,
+- source,
+- action boundary,
+- spend class.
+
+- [ ] **Step 2: Run failing profile test**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/agent/CoworkerProfilePanel.test.tsx`
+
+Expected: FAIL until profile section exists. If no test harness exists, create a focused test with minimal mocked agent props.
+
+- [ ] **Step 3: Implement profile section**
+
+Implementation notes:
+- Use shared copy from `proactivity-copy.ts`.
+- Default to a balanced plan from resolver when no explicit plan prop is provided.
+- Keep advanced policy details behind a compact disclosure if the existing profile pattern supports it.
+- Do not add a new global dashboard.
+
+- [ ] **Step 4: Run profile test**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/agent/CoworkerProfilePanel.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/components/agent/CoworkerProfilePanel.tsx apps/web/components/agent/CoworkerProfilePanel.test.tsx
+git commit -s -m "feat: show coworker proactivity details"
+```
+
+## Chunk 3: Runtime Metadata And Scheduled Work
+
+### Task 7: Thread Proactivity Into TaskRun Metadata
+
+**Files:**
+- Modify: `apps/web/lib/tak/autonomous-work-run.ts`
+- Test: add or update nearest TAK test for `createAutonomousWorkRun`.
+
+- [ ] **Step 1: Write failing metadata test**
+
+Assert that calling `createAutonomousWorkRun({ metadata: { proactivity: plan } })` persists `a2aMetadata.proactivity` without overwriting trigger/sourceRef metadata.
+
+- [ ] **Step 2: Run failing TAK test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/tak/autonomous-work-run.test.ts`
+
+Expected: FAIL if no test exists or if assertions are not met. Create the test file if needed using the repo's existing Prisma mocking pattern.
+
+- [ ] **Step 3: Implement typed proactivity metadata input**
+
+Implementation notes:
+- Prefer adding a typed optional `proactivity?: ProactivityPlan` to `AutonomousWorkRunInput`.
+- Merge into `a2aMetadata` as `{ proactivity: input.proactivity }`.
+- Preserve generic `metadata` for other callers, but prevent generic metadata from accidentally clobbering the resolved plan by applying explicit proactivity last.
+
+- [ ] **Step 4: Run TAK test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/tak/autonomous-work-run.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/tak/autonomous-work-run.ts apps/web/lib/tak/autonomous-work-run.test.ts
+git commit -s -m "feat: persist proactivity on task runs"
+```
+
+### Task 8: Resolve Scheduled Task Proactivity
+
+**Files:**
+- Modify: `apps/web/lib/actions/agent-task-scheduler.ts`
+- Modify: `apps/web/lib/tak/scheduled-task-runs.ts`
+- Test: `apps/web/lib/actions/agent-task-scheduler.test.ts`
+
+- [ ] **Step 1: Write failing scheduled-task test**
+
+Assert that `executeScheduledAgentTask()` resolves a `scheduled-task` proactivity plan and writes it to the created run metadata.
+
+- [ ] **Step 2: Run failing scheduler test**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/actions/agent-task-scheduler.test.ts`
+
+Expected: FAIL until scheduler calls the resolver and passes the plan.
+
+- [ ] **Step 3: Implement scheduled resolver call**
+
+Implementation notes:
+- Call `resolveProactivityPlan({ activityFamily: "scheduled-task", routeContext: task.routeContext, agentId: task.agentId })`.
+- If the scheduled task title/prompt clearly maps to tax/compliance or technology-debt later, add a separate classifier only after tests. Do not do prompt parsing in this task.
+- Pass the plan through `createTaskRunForScheduledTask` or the actual helper that creates the `TaskRun`.
+- Do not bypass existing owner resolution, tool grants, HITL, or scheduled job status handling.
+
+- [ ] **Step 4: Run scheduler tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/actions/agent-task-scheduler.test.ts apps/web/lib/tak/autonomous-work-run.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/actions/agent-task-scheduler.ts apps/web/lib/actions/agent-task-scheduler.test.ts apps/web/lib/tak/scheduled-task-runs.ts
+git commit -s -m "feat: resolve proactivity for scheduled tasks"
+```
+
+## Chunk 4: Field Dispatch And Build Studio Consumption
+
+### Task 9: Add Field Dispatch Runtime Fixture
+
+**Files:**
+- Modify: field-dispatch runtime caller identified during implementation.
+- Do not modify: `packages/validators/src/field-dispatch-policy.ts` except for tests proving it remains pure.
+- Test: nearest field-dispatch runtime test.
+
+- [ ] **Step 1: Locate runtime caller**
+
+Run: `rg -n "running-late|field-dispatch|FieldDispatchProfile|deriveFieldDispatchProfile|flag-attention|notify" apps packages -g "*.ts" -g "*.tsx"`
+
+Expected: identify the runtime layer that consumes pure field-dispatch intents and schedules/proposes outbound actions.
+
+- [ ] **Step 2: Write failing fixture**
+
+Assert that a running-late appointment in a slot-hours/emergency-reactive field-dispatch archetype resolves `assertive`, uses `urgent-channel`, and keeps `actionBoundary` at `propose` unless a separate automation policy exists.
+
+- [ ] **Step 3: Run failing field-dispatch test**
+
+Run the nearest focused test found in Step 1 with `pnpm --filter web exec vitest run <path>`.
+
+Expected: FAIL until runtime consumes `resolveProactivityPlan`.
+
+- [ ] **Step 4: Implement runtime resolver call**
+
+Implementation notes:
+- Wrap runtime behavior only.
+- Keep pure validator output unchanged.
+- Add proactivity plan to outbound/action metadata or related runtime evidence.
+
+- [ ] **Step 5: Run field-dispatch tests**
+
+Run the focused test and `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-resolver.test.ts`.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add <field-dispatch-runtime-files> apps/web/lib/proactivity/proactivity-resolver.test.ts
+git commit -s -m "feat: apply proactivity to field dispatch delays"
+```
+
+### Task 10: Add Build Studio Custodian Fixture
+
+**Files:**
+- Modify: Build Studio stuck/custodian caller identified during implementation.
+- Test: nearest Build Studio stall/custodian test.
+
+- [ ] **Step 1: Locate Build Studio caller**
+
+Run: `rg -n "custodian|stalled|blocked|missing progress|Build Studio|build-studio" apps/web/lib apps/web/components -g "*.ts" -g "*.tsx"`
+
+Expected: identify the caller that should resolve `build-studio-custodian`.
+
+- [ ] **Step 2: Write failing Build Studio fixture**
+
+Assert:
+- normal progress resolves `balanced`,
+- blocked/stalled progress resolves `assertive`,
+- spend remains bounded by right-sizing/cost governance,
+- action boundary remains `propose`.
+
+- [ ] **Step 3: Run failing Build Studio test**
+
+Run the nearest focused test with `pnpm --filter web exec vitest run <path>`.
+
+Expected: FAIL until shared resolver is consumed.
+
+- [ ] **Step 4: Implement Build Studio resolver call**
+
+Implementation notes:
+- Consume shared `resolveProactivityPlan`; do not create a Build Studio-specific proactivity enum or duplicate thresholds.
+- Record the plan where Build Studio task/progress evidence is already surfaced.
+- Keep recovery actions under existing Build Studio phase rules.
+
+- [ ] **Step 5: Run Build Studio and resolver tests**
+
+Run focused Build Studio test plus `pnpm --filter web exec vitest run apps/web/lib/proactivity/proactivity-resolver.test.ts`.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add <build-studio-files> apps/web/lib/proactivity/proactivity-resolver.test.ts
+git commit -s -m "feat: apply proactivity to build custodian state"
+```
+
+## Chunk 5: Overrides And Acknowledgement
+
+### Task 11: Decide Override Persistence
+
+**Files:**
+- Inspect: `packages/db/prisma/schema.prisma`
+- Inspect: `apps/web/lib/actions/*`
+- Optional create migration only if required.
+
+- [ ] **Step 1: Search for suitable existing preference/proposal stores**
+
+Run: `rg -n "Preference|Override|CoworkerActionEnvelope|ScheduledOutboundAction|autopilotPolicy|settings|acknowledgedBy|proposedBy" packages/db/prisma/schema.prisma apps/web/lib apps/web/components -g "*.ts" -g "*.tsx"`
+
+Expected: clear decision whether existing substrate can store accepted proactivity overrides.
+
+- [ ] **Step 2: Document decision in implementation notes**
+
+If existing substrate is suitable, add a short code comment near the chosen adapter and no migration. If not suitable, create `ProactivityOverride` using the spec's narrow table.
+
+- [ ] **Step 3: If migration is needed, create it with Prisma**
+
+Run: `pnpm --filter @dpf/db exec prisma migrate dev --name proactivity_override`
+
+Expected: migration file created under `packages/db/prisma/migrations/`.
+
+- [ ] **Step 4: Commit persistence decision**
+
+```powershell
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations apps/web/lib
+git commit -s -m "feat: persist proactivity overrides"
+```
+
+### Task 12: Add Coworker Proposal Envelope
+
+**Files:**
+- Modify: proposal/action-envelope code path found in Task 11.
+- Test: nearest action-envelope test.
+
+- [ ] **Step 1: Write failing proposal test**
+
+Assert that a coworker can propose:
+- current level,
+- proposed level,
+- scope,
+- evidence,
+- spend/notification impact,
+- acknowledgement actions.
+
+- [ ] **Step 2: Run failing proposal test**
+
+Run focused test with `pnpm --filter web exec vitest run <path>`.
+
+Expected: FAIL until proposal type and handlers exist.
+
+- [ ] **Step 3: Implement proposal type and acknowledgement handling**
+
+Implementation notes:
+- Name action type `propose_proactivity_change` if a new type is required.
+- Accepted proposals create the chosen override.
+- Dismissed proposals cool down to avoid nagging.
+- Every change records who proposed, who acknowledged, previous level, new level, scope, and rationale.
+
+- [ ] **Step 4: Run proposal tests**
+
+Run focused proposal tests plus resolver tests.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add <proposal-files> apps/web/lib/proactivity
+git commit -s -m "feat: acknowledge proactivity changes"
+```
+
+## Chunk 6: Verification And Ship Readiness
+
+### Task 13: Source-Local Verification
+
+- [ ] **Step 1: Run resolver and copy tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/lib/proactivity`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run component tests**
+
+Run: `pnpm --filter web exec vitest run apps/web/components/proactivity apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx apps/web/components/agent/CoworkerProfilePanel.test.tsx`
+
+Expected: PASS. If a listed test file does not exist because the implementation used another nearby test, run that exact file and record the substitution.
+
+- [ ] **Step 3: Run affected runtime tests**
+
+Run focused scheduler, field-dispatch, Build Studio, and TAK tests added above.
+
+Expected: PASS.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm --filter web typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit verification-only fixes if needed**
+
+Only commit if verification required code/test fixes:
+
+```powershell
+git add <fixed-files>
+git commit -s -m "fix: stabilize proactivity verification"
+```
+
+### Task 14: Runtime-Bound Verification
+
+- [ ] **Step 1: Acquire the canonical verification substrate**
+
+Use the shared local-CI convergence sandbox or canonical local install per `AGENTS.md`. Do not mutate the main `dpf` portal directly with ad hoc compose rebuilds.
+
+- [ ] **Step 2: Run production build**
+
+Run: `pnpm --filter web build`
+
+Expected: PASS with zero TypeScript/build errors.
+
+- [ ] **Step 3: UX verification**
+
+Use browser verification against the served app:
+- Open a coworker panel.
+- Confirm the golden-triangle dock still starts collapsed.
+- Confirm Proactivity appears to the right of Priority.
+- Switch Quiet, Balanced, Assertive.
+- Confirm green/yellow/red accents render with labels.
+- Confirm no overlap at desktop and mobile widths.
+- Confirm profile details explain why the level was chosen.
+
+- [ ] **Step 4: Runtime fixtures**
+
+Exercise or simulate:
+- running-late field appointment resolves assertive and proposes customer update,
+- normal Build Studio work resolves balanced,
+- blocked/stalled Build Studio work resolves assertive,
+- scheduled task run writes `a2aMetadata.proactivity`.
+
+- [ ] **Step 5: Migration apply if migration exists**
+
+Run: `pnpm --filter @dpf/db exec prisma migrate dev`
+
+Expected: applies cleanly. Skip and record "no migration added" if override persistence reused existing substrate.
+
+### Task 15: Final Review And Push
+
+- [ ] **Step 1: Run final status**
+
+Run: `git status --short --branch`
+
+Expected: clean working tree on topic branch.
+
+- [ ] **Step 2: Review commit history**
+
+Run: `git log --oneline --decorate -n 12`
+
+Expected: small, scoped, signed commits.
+
+- [ ] **Step 3: Push branch**
+
+Run: `git push`
+
+Expected: branch pushed to origin.
+
+- [ ] **Step 4: Open PR only after gates are green**
+
+Open a regular ready-for-review PR only after unit tests, typecheck, production build, UX verification, runtime fixtures, and migration gate are complete. Do not open a draft PR.
+
+## Review Checkpoints
+
+- Spec review: this Codex session did not spawn a reviewer because subagent spawning is gated unless the user explicitly asks for delegated agents. If delegated agents are authorized later, dispatch a spec-document-reviewer against `docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md`.
+- Plan review: after this plan is written, dispatch a plan-document-reviewer if subagents are explicitly authorized. Otherwise, run a self-review against the spec before implementation.
+- Code review: after each chunk, request code review if subagents are authorized; otherwise use the current-session review checklist and focused tests before continuing.
+
+## Implementation Notes
+
+- Preserve the 20 percent refactoring budget from the spec: shared resolver, shared copy, no one-off threshold fields in Build Studio, scheduled tasks, or field dispatch.
+- Keep `field-dispatch-policy.ts` pure. Proactivity belongs in runtime behavior around the intents.
+- Keep `assertive` bounded: more persistence, earlier warnings, faster escalation, higher spend class when allowed; never broader authority.
+- Use `lucide-react` before adding custom icon code. Add `ProactivityGaugeIcon` only if the stock icon cannot express the three needle positions clearly.
+- Use theme tokens and accessible labels; green/yellow/red must not be the only signal.

--- a/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
+++ b/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
@@ -10,6 +10,8 @@
 
 **Spec:** `docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md`
 
+**Deferred backlog:** `BI-424CFE7A` covers delegated coworker posture propagation: carry advisory proactivity and golden-triangle context from an initiating task into child coworker subtasks, with the receiving coworker's local policy/risk/quality requirements able to override. This is not part of V1.
+
 ---
 
 ## File Structure
@@ -790,5 +792,6 @@ Open a regular ready-for-review PR only after unit tests, typecheck, production 
 - Preserve the 20 percent refactoring budget from the spec: shared resolver, shared copy, no one-off threshold fields in Build Studio, scheduled tasks, or field dispatch.
 - Keep `field-dispatch-policy.ts` pure. Proactivity belongs in runtime behavior around the intents.
 - Keep `assertive` bounded: more persistence, earlier warnings, faster escalation, higher spend class when allowed; never broader authority.
+- Do not implement delegated coworker posture propagation in this V1 plan. Subtasks should execute once legitimately delegated; future work (`BI-424CFE7A`) can pass advisory caller proactivity and golden-triangle posture into child tasks, with receiving coworker local policy taking precedence where risk or quality demands it.
 - Use `lucide-react` before adding custom icon code. Add `ProactivityGaugeIcon` only if the stock icon cannot express the three needle positions clearly.
 - Use theme tokens and accessible labels; green/yellow/red must not be the only signal.

--- a/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
+++ b/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
@@ -6,6 +6,10 @@
 
 **Architecture:** Build a shared `apps/web/lib/proactivity` module first, then consume it from UI and runtime callers. V1 keeps system/archetype defaults in typed code and writes runtime evidence into existing metadata; persistent overrides are added only after an implementation sweep proves no suitable existing preference substrate exists. Proactivity changes timing, persistence, escalation, spend class, and explanation only; existing autonomy, HITL, grants, routing, and outbound governance remain authoritative.
 
+**Backlog ownership:** This branch owns the first shared implementation slice of `BI-5B6F666F` (`Attention Surface — proactive AI Coworker custodian mode`) under `EP-ATTENTION-SURFACE`. `BI-ACB04A21` is already shipped as the Build Studio pilot/proof point under the closed `EP-BUILD-STUDIO-UX`; this plan must compose with that pilot and must not rebuild Build Studio-specific custodian UX. Build Studio work in this plan is limited to consuming or exposing the shared proactivity plan where an existing runtime/progress seam needs it.
+
+**User outcome guardrail:** Every proactive intervention should be quiet until useful, explain "why now" in one plain-language line, show one recommended action, offer bounded alternatives such as snooze/show why, and hide internal IDs, queues, branches, and diagnostic jargon by default.
+
 **Tech Stack:** Next.js 16, React 19, TypeScript, Prisma 7, Vitest, lucide-react, DPF theme tokens, existing golden-triangle coworker dock, existing TAK `TaskRun.a2aMetadata`.
 
 **Spec:** `docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md`
@@ -567,6 +571,8 @@ git commit -s -m "feat: apply proactivity to field dispatch delays"
 **Files:**
 - Modify: Build Studio stuck/custodian caller identified during implementation.
 - Test: nearest Build Studio stall/custodian test.
+
+**Boundary:** Do not duplicate the shipped Build Studio custodian mode from `BI-ACB04A21`. Treat it as pilot evidence. This task should only add shared `ProactivityPlan` composition where Build Studio already has a progress/stall/escalation seam, preserving its existing one-status/one-next-action UX.
 
 - [ ] **Step 1: Locate Build Studio caller**
 

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -27,6 +27,8 @@ The answer must vary by mission. A casual chat coworker should not nag. A todo r
 
 This spec defines a cross-surface `ProactivityPolicy` contract and a simple UX dial that resolves into detailed runtime policy.
 
+Backlog ownership: this design is the active shared-primitive implementation slice for `BI-5B6F666F` under `EP-ATTENTION-SURFACE`. The shipped Build Studio pilot `BI-ACB04A21` under the closed `EP-BUILD-STUDIO-UX` is proof and input, not duplicated scope. Build Studio consumption in this design must compose with its existing proactive custodian UX: one plain-language status, one recommended action, bounded alternatives, and details behind disclosure.
+
 ## 2. Design Thesis
 
 Show humans a simple behavior dial. Let the platform resolve the actual policy.
@@ -440,6 +442,9 @@ Accepted changes write an auditable policy override. Dismissed proposals should 
 3. Coworker surfaces guided next action and can propose retry/abandon/escalate.
 4. Recovery still follows Build Studio phase rules and governance.
 5. Spend class remains bounded by Build Studio right-sizing and cost governance.
+6. Do not fork the shipped Build Studio custodian implementation from `BI-ACB04A21`; consume or expose the shared `ProactivityPlan` at existing Build Studio progress/stall/escalation seams.
+
+User-facing rule: Build Studio and every other consuming surface should remain quiet while work is progressing, then surface one recommended action with bounded alternatives such as snooze/show why. Internal IDs, queues, branches, and diagnostic jargon remain hidden by default and appear only in engineer-oriented disclosures.
 
 ## 11. Data Model Strategy
 

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -242,6 +242,8 @@ The resolver must also intersect with governance:
 - Cost/budget policy constrains `spendClass`.
 - Decision-routing governance constrains legal, tax, compliance, and business judgment responses.
 
+Delegated coworker work is a future resolution layer, not a V1 blocker. If a coworker delegates subtasks to other coworkers, the subtasks should still execute once legitimately delegated; proactivity does not decide whether the work exists. The initiating task may eventually pass advisory context posture, including its proactivity level and golden-triangle cost/quality/time intent. The receiving coworker must then resolve that advisory context against its own local policy, mission, risk, authority, and quality floor. A time-priority caller can bias subtasks toward time, but a receiving coworker responsible for regulated, high-risk, or quality-critical work can override toward higher quality. Track this as `BI-424CFE7A`; do not implement propagation in V1.
+
 ## 7. Defaults
 
 ### 7.1 Activity defaults
@@ -498,6 +500,10 @@ Notification preference controls channels a person accepts. Proactivity selects 
 
 Right-sizing controls process intensity for development work. Proactivity controls monitoring/escalation behavior around the process.
 
+### Proactivity vs delegated coworker execution
+
+Delegation decides which coworker owns a subtask. Proactivity decides how persistently that coworker should monitor, follow up, and escalate within its authority. In V1, subtasks execute according to the receiving coworker's local policy. Future work may pass an initiating context override for proactivity and golden-triangle posture, but the receiving coworker's local risk and quality requirements must remain able to override it.
+
 ### Proactivity vs Attention Surface
 
 The Attention Surface is where unresolved human-needed items land. Proactivity determines when and why an item gets moved there.
@@ -641,6 +647,7 @@ Runtime-bound gates must run on canonical local install or shared local-CI conve
 2. Whether the header control should be visible for every user or only when the user has authority to change the effective level. Recommendation: visible as status for all, editable only when permitted.
 3. Whether `assertive` can ever imply preauthorized customer notifications. Recommendation: only when a separate automation policy exists and the communication event is low-risk and reversible enough.
 4. Whether Build Studio custodian mode owns a specialized policy overlay. Recommendation: consume the shared resolver; do not fork.
+5. Whether delegated coworkers should inherit initiating task posture. Recommendation: create a future context override model where caller posture is advisory and receiving coworker local policy can override. Backlog: `BI-424CFE7A`.
 
 ## 19. Recommendation
 

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -121,6 +121,21 @@ Adopted pattern: silence is a signal. DPF already has Build Studio stall detecti
 
 Rejected pattern: background polling with no explicit policy or heartbeat/attempt accounting.
 
+### 4.5 Iconography and color accessibility
+
+NN/g's icon-usability guidance says icons are often ambiguous without visible labels, even when they save space. W3C WCAG 2.2 guidance for use of color says color should not be the only way information is conveyed. Sources: [NN/g Icon Usability](https://www.nngroup.com/articles/icon-usability/), [WCAG Understanding SC 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html).
+
+Lucide's `Gauge` and `CircleGauge` icons fit the dimension because they represent a dial, meter, speed, measure, and level. That maps to proactivity better than symbols that imply danger, alerts, or automatic permission. Sources: [Lucide Gauge](https://lucide.dev/icons/gauge), [Lucide CircleGauge](https://lucide.dev/icons/circle-gauge).
+
+Adopted pattern: use a gauge/speedometer-style symbol plus the text label. The symbol communicates adjustable intensity; the label disambiguates that the dimension is proactivity, not safety, priority, or authority.
+
+Rejected patterns:
+
+- Alert/warning symbol: reads as an incident or danger state, not a user-controlled behavior posture.
+- Flame/lightning symbol: reads as urgency, but can imply unsafe action or escalation.
+- Pure traffic-light dots: compact, but color-only without a semantic shape.
+- Three unrelated symbols for the three levels: creates recognition cost and makes the setting feel like three different modes instead of one adjustable dimension.
+
 ## 5. Core Concepts
 
 ### 5.1 Closed enum
@@ -293,13 +308,17 @@ The proactivity chip should be compact enough to fit in the available horizontal
 
 Recommended visual language:
 
-| Level | Accent | Meaning |
-| --- | --- | --- |
-| Quiet | Green | Minimum unsolicited follow-up. |
-| Balanced | Yellow | Normal default persistence. |
-| Assertive | Red | Aggressive monitoring, earlier warning, faster escalation. |
+| Level | Symbol treatment | Accent | Meaning |
+| --- | --- | --- | --- |
+| Quiet | Gauge needle low-left, calm fill/arc | Green | Minimum unsolicited follow-up. |
+| Balanced | Gauge needle centered | Yellow | Normal default persistence. |
+| Assertive | Gauge needle high-right, stronger fill/arc | Red | Aggressive monitoring, earlier warning, faster escalation. |
 
 Use these colors as accents only, paired with the text label and accessible name. Color must not be the only signal. The red state should communicate stronger persistence, not danger or unauthorized action.
+
+Preferred symbol: a compact gauge/speedometer icon, implemented with `Gauge` or `CircleGauge` from `lucide-react` where possible. If a level-specific needle position is required and the stock icon cannot express it, create a tiny local `ProactivityGaugeIcon` using the same stroke width and sizing conventions as Lucide. Keep it visually parallel to the golden triangle: compact, geometric, and meaningful at 14-16px.
+
+Do not use warning triangles, alert circles, flame/lightning marks, or color-only dots for the main resting-state symbol.
 
 Click opens a small segmented control:
 

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -281,11 +281,25 @@ Examples:
 
 ## 8. UX Design
 
-### 8.1 Coworker panel header
+### 8.1 Coworker composer critical-settings dock
 
-Add one compact header affordance near existing mode/profile controls:
+The primary coworker-chat placement is the existing golden-triangle priority dock just above the composer input (`CoworkerPriorityDock`). Proactivity is another critical behavior setting, so it should sit immediately to the right of the collapsed golden-triangle chip in the same strip.
 
-`Proactivity: Balanced`
+Collapsed resting state:
+
+`Priority  Higher Reasoning    Proactivity  Balanced`
+
+The proactivity chip should be compact enough to fit in the available horizontal space to the right of the triangle. It is a sibling control, not a replacement for the triangle. Priority answers cost/quality/time posture; proactivity answers how persistently the coworker should pursue allowed work.
+
+Recommended visual language:
+
+| Level | Accent | Meaning |
+| --- | --- | --- |
+| Quiet | Green | Minimum unsolicited follow-up. |
+| Balanced | Yellow | Normal default persistence. |
+| Assertive | Red | Aggressive monitoring, earlier warning, faster escalation. |
+
+Use these colors as accents only, paired with the text label and accessible name. Color must not be the only signal. The red state should communicate stronger persistence, not danger or unauthorized action.
 
 Click opens a small segmented control:
 
@@ -297,9 +311,13 @@ Plain-language helper copy:
 - Balanced: "Follow up when timing, commitments, or risk make it useful."
 - Assertive: "Stay on this, warn earlier, and escalate sooner when allowed."
 
-The control should use familiar segmented-button styling, theme tokens, and no hardcoded color. It must not crowd mobile. On narrow widths, fold it into the profile/settings disclosure rather than expanding the header row.
+The control should use familiar segmented-button styling, theme tokens, and no hardcoded color. It must not crowd mobile. On narrow widths, fold it into the existing profile/settings disclosure or a second line inside the dock rather than forcing the composer/header to overflow.
 
-### 8.2 Coworker profile
+### 8.2 Coworker panel header
+
+The broader panel header may also show a read-only proactivity status when space allows, but editing should happen in the composer critical-settings dock and profile/settings surfaces. This keeps the behavior control close to where the operator is actively talking to the coworker.
+
+### 8.3 Coworker profile
 
 `CoworkerProfilePanel` gains a "Proactivity" section:
 
@@ -311,7 +329,7 @@ The control should use familiar segmented-button styling, theme tokens, and no h
 
 Advanced details include cadence, max attempts, spend class, channels, escalation target, and action boundary.
 
-### 8.3 Scheduled Work / AI Operations
+### 8.4 Scheduled Work / AI Operations
 
 Scheduled work and AI Operations surfaces show the effective proactivity plan for recurring activity. Operators can filter for:
 
@@ -321,7 +339,7 @@ Scheduled work and AI Operations surfaces show the effective proactivity plan fo
 - policies with repeated ignored attempts,
 - coworker-proposed policy changes pending acknowledgement.
 
-### 8.4 Attention Surface
+### 8.5 Attention Surface
 
 The Attention Surface should render proactivity as one reason an item appears:
 
@@ -529,13 +547,15 @@ Acceptance:
 Files:
 
 - Modify `apps/web/components/agent/AgentPanelHeader.tsx`
+- Modify `apps/web/components/golden-triangle/CoworkerPriorityDock.tsx`
 - Modify `apps/web/components/agent/CoworkerProfilePanel.tsx`
 - Add small presentational component if needed: `ProactivityLevelControl.tsx`
 
 Acceptance:
 
-- compact level control renders without crowding desktop header.
+- compact level control renders beside the golden-triangle priority chip without crowding the composer dock.
 - mobile folds control into profile/details.
+- green/yellow/red accents map Quiet/Balanced/Assertive while preserving text labels and accessible names.
 - copy uses shared proactivity copy.
 - admin profile shows advanced details.
 - no hardcoded colors.

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -1,0 +1,616 @@
+# AI Coworker Proactivity Policy Design
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-29 |
+| Status | Draft for review |
+| Owner | Codex |
+| Scope | Cross-surface AI coworker proactivity setting for interactive coworkers, scheduled activity, attention surfaces, field dispatch, Build Studio custodian behavior, and recurring operational monitoring |
+| Related epics/items | `EP-ATTENTION-SURFACE`, `EP-PROACTIVE-OPS`, `EP-SCHEDULING-SURFACE`, `EP-COWORKER-INTERACTIVITY`, `EP-COST-001`, `BI-5B6F666F`, `BI-ACB04A21` |
+| Related specs | `2026-05-11-autonomous-coworker-runtime-design.md`, `2026-05-19-build-studio-stall-detection.md`, `2026-06-13-field-dispatch-capability-design.md`, `2026-05-31-archetype-aware-workspace-design.md`, `2026-06-18-coworker-decision-routing-governance-design.md`, `2026-05-30-build-studio-right-sizing-design.md` |
+| Primary repo substrate | `apps/web/lib/tak/autonomous-work-run.ts`, `packages/db/prisma/schema.prisma`, `packages/validators/src/field-dispatch-policy.ts`, `packages/storefront-templates/src/operational-value-stream.ts`, `packages/storefront-templates/src/field-dispatch.ts`, `apps/web/components/agent/AgentPanelHeader.tsx`, `apps/web/components/agent/CoworkerProfilePanel.tsx` |
+
+## 1. Purpose
+
+DPF needs one governed way to answer: "How hard should this AI coworker stay on this?"
+
+Today, proactivity is implicit. Build Studio has custodian-mode backlog items for stuck detection, scheduled coworker work runs through `ScheduledAgentTask`, field dispatch proposes confirmations and running-late notices, and workspace/attention surfaces collect things that need human input. Those are all variations of the same behavior question:
+
+1. When should the coworker notice?
+2. How early should it act before a deadline or customer promise is at risk?
+3. How many times should it follow up?
+4. How much AI/tool spend is justified?
+5. When should it escalate to a human, another coworker, or the Attention Surface?
+6. What authority boundary still applies?
+
+The answer must vary by mission. A casual chat coworker should not nag. A todo reminder should be persistent but not exhausting. A compliance deadline should be watched closely, but advice must stay cited and approval-gated. A dispatcher coworker for AC, plumbing, roadside, or security response should be assertive because late communication costs revenue, reputation, and customer trust.
+
+This spec defines a cross-surface `ProactivityPolicy` contract and a simple UX dial that resolves into detailed runtime policy.
+
+## 2. Design Thesis
+
+Show humans a simple behavior dial. Let the platform resolve the actual policy.
+
+User-facing levels:
+
+| Level | User meaning | Runtime intent |
+| --- | --- | --- |
+| `quiet` | Wait for me unless something is urgent or already approved. | Minimal unsolicited follow-up; only safety, compliance, or explicitly scheduled activity can interrupt. |
+| `balanced` | Follow up when timing, commitments, or risk make it useful. | Default. Reasonable nudges, modest spend, bounded retries, and Attention Surface escalation when ignored. |
+| `assertive` | Stay on this, warn earlier, and escalate sooner when allowed. | Earlier detection, higher persistence, more frequent checks, stronger escalation, and higher budget class within existing authority. |
+
+The key rule: **proactivity changes persistence, timing, escalation, channel choice, and spend. It never grants new authority.**
+
+Customer-visible sends, assignments, invoices, destructive changes, legal/tax advice, regulated actions, and risky operational changes still use DPF's existing action envelopes, HITL policy, tool grants, and decision-routing governance.
+
+## 3. Current Substrate Inventory
+
+### 3.1 Coworker and governance records
+
+`Agent` already stores role identity, sensitivity, HITL default, escalation target, delegation targets, lifecycle stage, tool grants, skills, governance profile, execution config, and authority bindings. `AgentGovernanceProfile` already carries `autonomyLevel`, `hitlPolicy`, delegation permission, and max delegation risk band.
+
+Design implication: proactivity belongs beside governance, not inside prompts only. The resolver should read coworker identity and governance posture, then return a runtime plan. It should not mutate `autonomyLevel`; autonomy answers "what can the coworker do?" while proactivity answers "how persistently should it pursue allowed work?"
+
+### 3.2 Task-run substrate
+
+`createAutonomousWorkRun()` maps triggers to `TaskRun.source`. Interactive work is `coworker`, Build Studio is `build`, deliberation is `skill`, and scheduled/external/radar/system-recovery/capacity-continuity become `proactive`. Non-interactive triggers start as `working`.
+
+Design implication: proactivity should attach to `TaskRun.a2aMetadata` and eventually to visible task/run projections. A proactive run needs evidence of which policy produced it, not just the fact that it happened.
+
+### 3.3 Scheduled activity
+
+`ScheduledAgentTask` stores a cron schedule, owner, agent, route context, prompt, `lastRunAt`, `nextRunAt`, `lastStatus`, and latest `taskRunId`. `agentTaskDispatch` polls due tasks every five minutes. `executeScheduledAgentTask()` creates an agent thread, creates a `TaskRun`, executes the autonomous agentic loop, persists messages, and updates task/job rows.
+
+Design implication: scheduled tasks are the first natural consumer of `ProactivityPlan`. The scheduler should not grow one-off cadence/escalation fields. It should ask the policy resolver what to do for this activity.
+
+### 3.4 Outbound and attention records
+
+`ScheduledOutboundAction` already has `autopilotPolicyId`, `scheduledByUserId`, `kind`, `targetId`, `scheduledFor`, and status fields. `BI-5B6F666F` and `EP-ATTENTION-SURFACE` establish a proactive "Needs you" lane separate from backlog.
+
+Design implication: proactivity policy can govern outbound reminders and escalation into the Attention Surface without making every reminder a backlog item.
+
+### 3.5 Field dispatch policy
+
+`packages/validators/src/field-dispatch-policy.ts` is the strongest existing pattern. The pure policy proposes actions (`notify`, `assign`, `flag-unassignable`, `flag-attention`, `invoice`) and never mutates or sends. Runtime commits through governance. `field-dispatch-notifications.ts` maps event urgency: `confirm` and `complete` are routine, `on-my-way` is priority, `running-late` is urgent.
+
+Design implication: proactivity should follow this split. Pure policy plans persistence and escalation. Runtime commits or proposes actions through existing governance.
+
+### 3.6 Archetype value stream
+
+`deriveOperationalValueStream()` already derives `loadBearingStageKeys`, `capacityUnit`, `demandSignature`, and trust gates from archetype/category/activation profile. `deriveFieldDispatchProfile()` derives dispatch applicability and per-vertical profile.
+
+Design implication: proactivity defaults should be derived from archetype facts, not hand-authored per leaf. Emergency-reactive, slot-hours, field-dispatch, and load-bearing scheduling stages should bias toward `assertive`.
+
+### 3.7 Coworker UI
+
+The panel header already shows compact controls for sensitivity, Hands On/Hands Off, Advise/Act, External Access, Diagnostics, profile, skills, and provider info. `CoworkerProfilePanel` already shows skills, tools, sensitivity, id, and model requirements.
+
+Design implication: the main proactivity control must stay compact. Advanced policy details belong in the profile/AI Operations/Scheduled Work surfaces, not as another row of header clutter.
+
+## 4. Research and Benchmarking
+
+### 4.1 NIST AI RMF
+
+The NIST AI RMF frames AI risk management around Govern, Map, Measure, and Manage functions. The AI RMF Core is designed to support dialogue, understanding, and activities for trustworthy AI risk management, with Govern as a cross-cutting function. Sources: [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework), [NIST AI RMF Core](https://airc.nist.gov/airmf-resources/airmf/5-sec-core/), [AI RMF 1.0 PDF](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf).
+
+Adopted pattern: proactivity policy must be governed and measurable. It should produce audit metadata, bounded risk behavior, and evidence for why the level was resolved.
+
+Rejected pattern: prompt-level "be more proactive" instructions with no policy record.
+
+### 4.2 OWASP AI Agent Security
+
+OWASP's AI Agent Security Cheat Sheet emphasizes securing autonomous agents that reason, use tools, remember context, and take actions. It highlights least privilege, monitoring, human oversight for risky actions, and minimizing agent attack surface. Source: [OWASP AI Agent Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html). OWASP's MCP guidance similarly points toward authenticated, least-privilege tool access and auditability for agent-tool integration. Source: [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html).
+
+Adopted pattern: increasing proactivity must never imply broader tools or bypass HITL. It changes scheduling and escalation around already-authorized work.
+
+Rejected pattern: "assertive" as auto-accept or hidden action mode.
+
+### 4.3 Microsoft agent orchestration patterns
+
+Microsoft's agent orchestration guidance describes patterns where agents and humans can participate in a shared flow, supporting transparency and auditability. Microsoft's Semantic Kernel agent architecture also calls out human-in-the-loop participation where judgment or expertise is required. Sources: [AI Agent Orchestration Patterns](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns), [Semantic Kernel Agent Architecture](https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/agent-architecture).
+
+Adopted pattern: proactivity should express when to involve humans, when to escalate, and when to keep working through a specialist/coworker path.
+
+Rejected pattern: one monolithic agent loop trying to handle every proactivity case. Policy should be a shared resolver consumed by specialized workflows.
+
+### 4.4 Temporal heartbeats and timeouts
+
+Temporal treats heartbeats and timeouts as first-class execution controls. Heartbeat timeouts detect missing progress, and retries are policy-driven. Sources: [Detecting Activity Failures](https://docs.temporal.io/encyclopedia/detecting-activity-failures), [Activity Definition](https://docs.temporal.io/activity-definition), [Activity Timeouts for TypeScript SDK](https://docs.temporal.io/develop/typescript/activities/timeouts).
+
+Adopted pattern: silence is a signal. DPF already has Build Studio stall detection; proactivity extends the idea from "is it alive?" to "how aggressively should this situation be watched and escalated?"
+
+Rejected pattern: background polling with no explicit policy or heartbeat/attempt accounting.
+
+## 5. Core Concepts
+
+### 5.1 Closed enum
+
+```ts
+export const PROACTIVITY_LEVELS = ["quiet", "balanced", "assertive"] as const;
+export type ProactivityLevel = (typeof PROACTIVITY_LEVELS)[number];
+```
+
+User copy may say Quiet / Balanced / Assertive. The code uses lowercase hyphen-free values. Do not use synonyms such as `low`, `medium`, `aggressive`, or `not-proactive` in persisted policy.
+
+### 5.2 Activity family
+
+```ts
+export const PROACTIVITY_ACTIVITY_FAMILIES = [
+  "interactive-chat",
+  "todo-follow-up",
+  "scheduled-task",
+  "field-dispatch-appointment",
+  "build-studio-custodian",
+  "technology-debt",
+  "platform-health",
+  "tax-compliance",
+  "customer-communication",
+  "finance-close",
+  "security-incident",
+] as const;
+```
+
+The list should start small in implementation. It is a policy axis, not a new workflow taxonomy. Adding a value requires updating the resolver and test matrix.
+
+### 5.3 `ProactivityPolicy`
+
+`ProactivityPolicy` is the durable configuration or catalog row. V1 can be code-owned plus operator overrides; V2 can persist first-class rows after evidence proves the shape.
+
+```ts
+type ProactivityPolicy = {
+  policyId: string;
+  level: ProactivityLevel;
+  appliesTo: {
+    agentId?: string;
+    activityFamily?: ProactivityActivityFamily;
+    archetypeCategory?: string;
+    archetypeId?: string;
+    routeContext?: string;
+    riskBand?: "low" | "medium" | "high" | "critical";
+  };
+  planDefaults: {
+    attentionWindowMinutes: number;
+    followUpCadenceMinutes: number[];
+    maxAttempts: number;
+    spendClass: "minimal" | "standard" | "elevated";
+    escalationTarget: "attention-surface" | "owner" | "role" | "dispatcher" | "platform-operator";
+    channelPolicy: "in-app-only" | "preferred-channel" | "urgent-channel" | "multi-channel";
+    actionBoundary: "advise" | "propose" | "preauthorized";
+  };
+  rationale: string;
+  source: "system-default" | "archetype-default" | "org-override" | "user-override" | "coworker-proposal";
+};
+```
+
+### 5.4 `ProactivityPlan`
+
+`ProactivityPlan` is the runtime result for one task, event, conversation, or scheduled activity.
+
+```ts
+type ProactivityPlan = {
+  resolvedLevel: ProactivityLevel;
+  policyId: string;
+  attentionWindowMinutes: number;
+  followUpCadenceMinutes: number[];
+  maxAttempts: number;
+  spendClass: "minimal" | "standard" | "elevated";
+  channelPolicy: "in-app-only" | "preferred-channel" | "urgent-channel" | "multi-channel";
+  escalationTarget: string;
+  actionBoundary: "advise" | "propose" | "preauthorized";
+  explanation: string;
+  evidenceRefs: Array<{ kind: string; id: string }>;
+};
+```
+
+The plan is written into `TaskRun.a2aMetadata.proactivity` for work that creates a `TaskRun`, and into the relevant outbound/action metadata when no task run exists yet.
+
+## 6. Resolution Order
+
+The resolver answers: "Given this activity, what level and behavior should apply?"
+
+Resolution order:
+
+1. Explicit per-activity override accepted by a human.
+2. User or org override for the coworker/activity.
+3. Archetype-derived default.
+4. Coworker role default.
+5. Activity family default.
+6. Platform fallback (`balanced`).
+
+If two defaults conflict, choose the more assertive one only when the activity is time-sensitive, customer-visible, deadline-bound, or operationally load-bearing. Otherwise choose the less disruptive one.
+
+The resolver must also intersect with governance:
+
+- `hitlPolicy` and `maxDelegationRiskBand` constrain `actionBoundary`.
+- Tool grants constrain available actions.
+- Communication channel bindings constrain `channelPolicy`.
+- Cost/budget policy constrains `spendClass`.
+- Decision-routing governance constrains legal, tax, compliance, and business judgment responses.
+
+## 7. Defaults
+
+### 7.1 Activity defaults
+
+| Activity family | Default level | Notes |
+| --- | --- | --- |
+| `interactive-chat` | `quiet` or `balanced` | Page/coworker specific. Chat should not create hidden background loops by default. |
+| `todo-follow-up` | `balanced` | One or two follow-ups, then Attention Surface. |
+| `scheduled-task` | `balanced` | Run on schedule, summarize, surface failures. |
+| `field-dispatch-appointment` | `assertive` | Customer promise and revenue/reputation risk. |
+| `build-studio-custodian` | `balanced`; `assertive` for blocked/stalled | Normal progress stays bounded; stuck work gets early attention. |
+| `technology-debt` | `balanced` | Persistent review and backlog surfacing; no noisy nagging. |
+| `platform-health` | `balanced`; `assertive` for degraded/offline | Service-impacting health can escalate. |
+| `tax-compliance` | `balanced`; deadline reminders can be `assertive` | Advice remains cited and approval-gated. |
+| `customer-communication` | `balanced`; urgent events `assertive` | Running late, failed send, high-value account, or emergency increases level. |
+| `finance-close` | `balanced` | Recurring nudges; assertive only near cutoff. |
+| `security-incident` | `assertive` | Detection/escalation high; containment actions still governed. |
+
+### 7.2 Archetype defaults
+
+Use existing archetype projections:
+
+- `demandSignature = "emergency-reactive"` biases live service events to `assertive`.
+- `capacityUnit = "slot-hours"` plus field dispatch biases appointment risk to `assertive`.
+- `loadBearingStageKeys` containing `qualify` for appointment checkout or `deliver` for recurring service increases proactivity for schedule and service commitments.
+- `trustGates` for regulated sectors increase detection proactivity but reduce automatic action.
+- `FieldDispatchProfile.notificationEvents` containing `running-late` activates assertive late-arrival handling.
+
+Examples:
+
+| Archetype / category | Default policy |
+| --- | --- |
+| Trades and maintenance with field dispatch | `assertive` for appointment delay, assignment gap, failed customer update; `balanced` for back-office suggestions. |
+| Automotive services / roadside / mobile repair | `assertive` for live service events; `balanced` for inventory and follow-up. |
+| Security services | `assertive` for live incidents and shift coverage gaps; cautious action boundary for public-safety-sensitive data. |
+| Healthcare/wellness | `balanced` for appointment readiness; assertive deadline/reminder detection; regulated evidence/action remains cautious. |
+| Professional services | `balanced` for client deadlines and missing inputs; quiet for casual advice. |
+| Software platform | `balanced` for tech debt and service health; assertive for outage/degraded customer-facing systems. |
+| Retail/food/hospitality | `balanced` for stock/order/task follow-up; assertive for customer-impacting fulfillment exceptions. |
+| Banking/financial/public sector | assertive detection for deadlines/incidents, cautious/cited/approved action boundary. |
+
+### 7.3 Coworker role defaults
+
+| Coworker role | Default |
+| --- | --- |
+| Dispatcher / scheduler | `assertive` for live appointments and assignment exceptions. |
+| Compliance / finance / tax | `balanced`, with deadline-driven assertive reminders. |
+| Build Studio / platform operator | `balanced`; stuck/stalled/degraded becomes `assertive`. |
+| Marketing / storefront / customer success | `balanced` for campaigns and follow-ups; quiet for ideation chat. |
+| General workspace coworker | `balanced` for commitments; quiet for advice. |
+| Onboarding coworker | `balanced` during setup; quiet after setup is complete unless gaps block operation. |
+
+## 8. UX Design
+
+### 8.1 Coworker panel header
+
+Add one compact header affordance near existing mode/profile controls:
+
+`Proactivity: Balanced`
+
+Click opens a small segmented control:
+
+`Quiet | Balanced | Assertive`
+
+Plain-language helper copy:
+
+- Quiet: "Wait for me unless something is urgent or already approved."
+- Balanced: "Follow up when timing, commitments, or risk make it useful."
+- Assertive: "Stay on this, warn earlier, and escalate sooner when allowed."
+
+The control should use familiar segmented-button styling, theme tokens, and no hardcoded color. It must not crowd mobile. On narrow widths, fold it into the profile/settings disclosure rather than expanding the header row.
+
+### 8.2 Coworker profile
+
+`CoworkerProfilePanel` gains a "Proactivity" section:
+
+- current effective level,
+- why it was chosen,
+- default source (`system`, `archetype`, `org override`, `user override`, `coworker proposal`),
+- activity-specific exceptions,
+- advanced policy details for admins.
+
+Advanced details include cadence, max attempts, spend class, channels, escalation target, and action boundary.
+
+### 8.3 Scheduled Work / AI Operations
+
+Scheduled work and AI Operations surfaces show the effective proactivity plan for recurring activity. Operators can filter for:
+
+- assertive policies,
+- policies with elevated spend,
+- policies with multi-channel escalation,
+- policies with repeated ignored attempts,
+- coworker-proposed policy changes pending acknowledgement.
+
+### 8.4 Attention Surface
+
+The Attention Surface should render proactivity as one reason an item appears:
+
+"Escalated because the customer appointment window is at risk and the dispatcher policy is Assertive."
+
+Avoid raw policy ids in worker-facing copy.
+
+## 9. AI-Suggested Policy Changes
+
+Coworkers may recommend a proactivity adjustment when evidence shows the current level is wrong.
+
+Allowed proposal examples:
+
+- "Appointments are slipping and this archetype depends on same-day dispatch. I recommend switching appointment-delay monitoring to Assertive."
+- "This todo has been ignored three times and is no longer urgent. I recommend moving it to Quiet and keeping it in Needs You."
+- "This tax deadline is within seven days. I recommend Assertive reminders until filed."
+
+The coworker must include:
+
+1. current level,
+2. proposed level,
+3. activity scope (`this appointment`, `all field-dispatch appointment delays`, `this coworker`, etc.),
+4. evidence,
+5. expected behavior change,
+6. spend/notification impact,
+7. acknowledgement options.
+
+The user may:
+
+- apply once,
+- apply for this activity type,
+- apply for this coworker,
+- dismiss,
+- ask for details.
+
+Accepted changes write an auditable policy override. Dismissed proposals should cool down to prevent repeated nagging about the same setting.
+
+## 10. Runtime Flows
+
+### 10.1 Field dispatch running-late
+
+1. Job ETA slips or current appointment runs long.
+2. Field dispatch policy emits a `notify` intent for `running-late`.
+3. Proactivity resolver sees `field-dispatch-appointment`, field-dispatch profile, customer-visible urgency, and emergency/reactive or slot-hours context.
+4. Resolver returns `assertive`.
+5. Runtime starts earlier than the promised window threshold, proposes customer update, and escalates to dispatcher if approval/contact is blocked.
+6. Action still goes through communication channel selection and proposal/approval unless an explicit automation policy exists.
+
+### 10.2 Todo follow-up
+
+1. A user or coworker creates a task with due date or promised follow-up.
+2. Resolver returns `balanced`.
+3. One or two follow-ups occur at policy cadence.
+4. If ignored, item moves to Attention Surface; no endless notifications.
+5. Coworker may suggest `quiet` if the task repeatedly loses relevance.
+
+### 10.3 Tax/compliance deadline
+
+1. Compliance monitor detects upcoming deadline or law-change review requirement.
+2. Resolver returns `balanced`; deadline window may elevate reminders to `assertive`.
+3. Coworker retrieves cited sources and creates an evidence-backed summary.
+4. Filing, advice, or external submission remains HITL/approval-gated.
+5. Missed or blocked actions escalate to owner/role and Attention Surface.
+
+### 10.4 Technology debt / platform health
+
+1. Health or debt signal is detected.
+2. Resolver returns `balanced`.
+3. Coworker creates review, backlog suggestion, or scheduled check.
+4. Service-affecting degradation can elevate to `assertive`.
+5. Repeated debt patterns route to proceduralization/backlog, not endless chat.
+
+### 10.5 Build Studio custodian mode
+
+1. Build is running normally: `balanced`.
+2. Build is blocked, stalled, or missing progress evidence: `assertive`.
+3. Coworker surfaces guided next action and can propose retry/abandon/escalate.
+4. Recovery still follows Build Studio phase rules and governance.
+5. Spend class remains bounded by Build Studio right-sizing and cost governance.
+
+## 11. Data Model Strategy
+
+### V1: code-owned defaults plus lightweight overrides
+
+V1 should avoid a broad schema migration until the policy matrix has evidence. Implement:
+
+- `apps/web/lib/proactivity/proactivity-types.ts`
+- `apps/web/lib/proactivity/proactivity-policy.ts`
+- `apps/web/lib/proactivity/proactivity-resolver.ts`
+- `apps/web/lib/proactivity/proactivity-copy.ts`
+- tests for archetype/coworker/activity fixtures
+
+Persist accepted overrides in the narrowest existing suitable substrate if one exists after implementation sweep. If no suitable existing store exists, add a small dedicated table:
+
+```prisma
+model ProactivityOverride {
+  id             String   @id @default(cuid())
+  scopeKind      String   // user | organization | agent | activity | scheduled-task
+  scopeId        String
+  activityFamily String?
+  level          String
+  rationale      String?
+  proposedByAgentId String?
+  acknowledgedByUserId String?
+  source         String   // user | org-admin | coworker-proposal
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  expiresAt      DateTime?
+
+  @@index([scopeKind, scopeId])
+  @@index([activityFamily])
+  @@index([level])
+}
+```
+
+Do not add a large generic rules engine in V1.
+
+### V2: first-class policy rows
+
+If operators start tuning many policies, promote system/archetype defaults to first-class catalog rows and add admin UI. Until then, typed code-owned policy is simpler, safer, and easier to test.
+
+## 12. Architecture Boundaries
+
+### Proactivity vs autonomy
+
+Autonomy controls what the coworker may do. Proactivity controls how persistently it pursues allowed work.
+
+### Proactivity vs priority
+
+Priority answers "how important is this item?" Proactivity answers "how aggressively should the system follow up or escalate?" A low-priority recurring hygiene task may be balanced; a high-priority legal action may be assertive for reminders but still require approval.
+
+### Proactivity vs notification preference
+
+Notification preference controls channels a person accepts. Proactivity selects urgency/channel policy within those preferences and verified bindings.
+
+### Proactivity vs Build Studio right-sizing
+
+Right-sizing controls process intensity for development work. Proactivity controls monitoring/escalation behavior around the process.
+
+### Proactivity vs Attention Surface
+
+The Attention Surface is where unresolved human-needed items land. Proactivity determines when and why an item gets moved there.
+
+## 13. UX Fit Review
+
+- Decision: `fits-with-guardrails`.
+- Owning area: AI Workforce / Workspace / Platform AI, with contextual presence in coworker panel and Scheduled Work.
+- Route family: existing coworker panel, coworker profile, AI Operations, Scheduled Work, Attention Surface. No new global dashboard.
+- Primary persona: founder/operator, dispatcher/scheduler, platform operator.
+- Navigation layer touched: contextual action and existing profile/settings details only.
+- Reuse/convergence: reuse existing coworker header/profile patterns and scheduled/operations surfaces. Do not add another dashboard.
+- Source truth: `ProactivityPlan` from resolver, recorded on `TaskRun.a2aMetadata.proactivity` and/or policy override rows.
+- Empty/failure behavior: missing policy resolves to `balanced`; missing channel falls back to Attention Surface; denied grants reduce action boundary.
+- AI boundary: coworker may propose a policy change, never silently broaden its behavior.
+- Evidence before merge: resolver unit tests, UI route/component tests, no hardcoded colors, browser verification for coworker panel/profile, scheduled field-dispatch fixture, Build Studio stuck fixture.
+
+## 14. Refactoring Budget
+
+Reserve roughly 20 percent of implementation effort for refactoring.
+
+Required refactoring targets:
+
+1. Extract a shared `proactivity` module instead of adding one-off thresholds to Build Studio, scheduled tasks, or field dispatch.
+2. Keep field-dispatch pure policy pure; proactivity wraps runtime behavior, not domain decision logic.
+3. Avoid adding proactivity fields directly to multiple unrelated models until the resolver shape is proven.
+4. Consolidate copy strings for Quiet/Balanced/Assertive so panel/profile/admin surfaces do not drift.
+5. Add typed enums and tests before wiring UI.
+
+## 15. Implementation Slices
+
+### Slice 1: Policy resolver and tests
+
+Files:
+
+- Create `apps/web/lib/proactivity/proactivity-types.ts`
+- Create `apps/web/lib/proactivity/proactivity-policy.ts`
+- Create `apps/web/lib/proactivity/proactivity-resolver.ts`
+- Create `apps/web/lib/proactivity/proactivity-copy.ts`
+- Test `apps/web/lib/proactivity/proactivity-resolver.test.ts`
+
+Acceptance:
+
+- `trades-maintenance` + field-dispatch appointment delay resolves `assertive`.
+- general todo follow-up resolves `balanced`.
+- Build Studio blocked/stalled resolves `assertive`.
+- interactive chat resolves `quiet` or `balanced` depending on route/coworker.
+- regulated/tax/compliance deadline resolves assertive reminders but `actionBoundary = "propose"` or `advise`, not preauthorized.
+
+### Slice 2: TaskRun and scheduled activity integration
+
+Files:
+
+- Modify `apps/web/lib/tak/autonomous-work-run.ts`
+- Modify `apps/web/lib/actions/agent-task-scheduler.ts`
+- Modify scheduled summary/projection helpers as needed
+
+Acceptance:
+
+- scheduled task runs write `a2aMetadata.proactivity`.
+- failures and ignored attempts can escalate to Attention Surface according to plan.
+- no scheduled task bypasses existing owner/tool/HITL checks.
+
+### Slice 3: Coworker panel/profile UX
+
+Files:
+
+- Modify `apps/web/components/agent/AgentPanelHeader.tsx`
+- Modify `apps/web/components/agent/CoworkerProfilePanel.tsx`
+- Add small presentational component if needed: `ProactivityLevelControl.tsx`
+
+Acceptance:
+
+- compact level control renders without crowding desktop header.
+- mobile folds control into profile/details.
+- copy uses shared proactivity copy.
+- admin profile shows advanced details.
+- no hardcoded colors.
+
+### Slice 4: AI proposal/acknowledgement path
+
+Files:
+
+- Reuse `CoworkerActionEnvelope` or existing proposal substrate.
+- Add action type such as `propose_proactivity_change` if needed.
+
+Acceptance:
+
+- coworker can propose a level change with evidence.
+- accepted proposal creates override or activity-scoped setting.
+- dismissed proposal cools down.
+- all changes audit who proposed, who acknowledged, scope, prior level, new level, and rationale.
+
+### Slice 5: Field dispatch and Build Studio fixtures
+
+Files:
+
+- Field dispatch runtime caller, not pure validator functions.
+- Build Studio custodian/stuck detection caller.
+- Attention Surface projection.
+
+Acceptance:
+
+- running-late appointment produces assertive plan and early customer-update proposal.
+- blocked Build Studio work produces assertive custodian guidance.
+- normal Build Studio progress remains balanced.
+
+## 16. Verification
+
+Required gates:
+
+1. Unit tests for resolver matrix and copy.
+2. Affected component tests for coworker panel/profile.
+3. Typecheck for web package.
+4. Production build.
+5. UX verification on coworker panel/profile and at least one scheduled/proactive surface.
+6. Field-dispatch fixture proof.
+7. Build Studio blocked/stalled fixture proof.
+8. Migration apply if a `ProactivityOverride` table is added.
+
+Runtime-bound gates must run on canonical local install or shared local-CI convergence sandbox per AGENTS.md.
+
+## 17. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Coworker becomes annoying | Default most work to `balanced`; cap attempts; route ignored work to Attention Surface instead of endless messages. |
+| Assertive is mistaken for more authority | UI and resolver make `actionBoundary` explicit; governance still gates tools/actions. |
+| Policy matrix becomes opaque | Show "why this level" in profile and scheduled work details. |
+| Admin UI becomes too complex | Simple dial first; advanced details behind disclosure and admin-only where appropriate. |
+| Cost blowout | `spendClass` intersects with AI cost governance; elevated spend only for assertive/time-critical cases. |
+| Legal/tax/compliance overreach | Assertive detection/reminders, cautious action; cited sources and approval required. |
+| Duplicated nag loops | Shared proactivity module and 20 percent refactoring budget. |
+| Archetype defaults wrong | Start with fixtures for field dispatch, todos, Build Studio; add telemetry and coworker-proposed changes to refine. |
+
+## 18. Open Decisions
+
+1. Whether V1 override persistence can reuse an existing preference/config table or needs `ProactivityOverride`.
+2. Whether the header control should be visible for every user or only when the user has authority to change the effective level. Recommendation: visible as status for all, editable only when permitted.
+3. Whether `assertive` can ever imply preauthorized customer notifications. Recommendation: only when a separate automation policy exists and the communication event is low-risk and reversible enough.
+4. Whether Build Studio custodian mode owns a specialized policy overlay. Recommendation: consume the shared resolver; do not fork.
+
+## 19. Recommendation
+
+Implement the policy-matrix approach:
+
+1. Simple visible dial: Quiet / Balanced / Assertive.
+2. Shared `ProactivityPolicy` resolver by coworker, activity, archetype, risk, and authority.
+3. Runtime `ProactivityPlan` written to task/outbound metadata.
+4. AI-suggested changes through acknowledged, auditable proposals.
+5. First fixtures: field-dispatch appointment delay, general todo follow-up, Build Studio stuck detection.
+
+This gives DPF a consistent way for coworkers to be helpful without becoming noisy, and assertive where business outcomes genuinely depend on it.


### PR DESCRIPTION
## Summary
- adds the shared Quiet / Balanced / Assertive proactivity primitive across resolver policy, scheduled work metadata, and field-dispatch/Build Studio signal composition
- places the Proactivity control beside the golden-triangle Priority control in the AI coworker drawer and adds profile explanations for the effective policy
- projects proactivity change recommendations into governance proposals and Attention Surface items with "why now", one recommended action, and snooze/review alternatives

## Backlog / coordination
- owns the first shared slice of `BI-5B6F666F` under `EP-ATTENTION-SURFACE`
- treats shipped Build Studio pilot `BI-ACB04A21` as proof/pilot evidence rather than duplicating its implementation
- follow-on inheritance/override design for delegated coworker subtasks is tracked separately as `BI-424CFE7A`

## Validation
- `pnpm --filter web exec vitest run lib/proactivity/proactivity-resolver.test.ts lib/proactivity/field-dispatch-proactivity.test.ts lib/proactivity/proactivity-change-proposal.test.ts lib/governance/action-proposal-presentation.test.ts lib/attention/sources/sources.test.ts lib/observability/stall-surface.test.ts components/proactivity/ProactivityLevelControl.test.tsx components/golden-triangle/CoworkerPriorityDock.test.tsx components/agent/CoworkerProfilePanel.test.tsx lib/tak/autonomous-work-run.test.ts lib/tak/scheduled-task-runs.test.ts lib/actions/agent-task-scheduler.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passed with existing Turbopack/NFT warning noise)
- authenticated Playwright UX check on branch server: `/platform/ai/agent/build-specialist` -> AI coworker drawer -> Proactivity menu shows Quiet, Balanced, and Assertive beside Priority on desktop and mobile
