### PR TITLE
Add receipt evidence step for playbook Work Case proposals

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -585,6 +585,8 @@ describe("AgentDetailPage", () => {
     expect(html).toContain("receipt required before commit");
     expect(html).toContain("Approve proposal");
     expect(html).toContain("Approved - receipt evidence needed");
+    expect(html).toContain("Attach receipt evidence");
+    expect(html).toContain("TER-LP-NEED-3-DI-RESOLVE001");
     expect(html).not.toContain("Activate playbook");
     expect(html).not.toContain("scaffold");
     expect(html).not.toContain("ReceiptEnvelope");

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -350,6 +350,8 @@ function CaseStagingRow({
   const resolution = state.resolution ?? null;
   const guardrail = caseStagingGuardrailLabel(state);
   const canResolve = canWrite && staged && !resolution && Boolean(needId);
+  const canAttachReceipt =
+    canWrite && staged && resolution?.status === "approved-awaiting-receipt" && Boolean(needId);
   return (
     <div
       style={{
@@ -405,6 +407,23 @@ function CaseStagingRow({
           />
         </div>
       ) : null}
+      {canAttachReceipt && needId && resolution ? (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          <CaseResolutionForm
+            needId={needId}
+            agentId={agentId}
+            action="approve"
+            label="Attach receipt evidence"
+            note="Attach receipt evidence for the approved Living Playbook Work Case proposal; do not commit the case."
+            receipt={{
+              receiptId: receiptIdForCaseResolution(needId, resolution.decisionInteractionId),
+              receiptStatus: "valid",
+              receiptEnforcementMode: state.enforcementMode ?? "governed-action",
+              receiptKind: state.requiredReceiptKind ?? state.enforcementMode ?? "governed-action",
+            }}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -444,6 +463,9 @@ function caseResolutionDetail(status: NonNullable<CaseStaging["resolution"]>["st
 }
 
 function caseStagingGuardrailLabel(state: CaseStaging): string | null {
+  if (state.resolution?.receiptCoverage === "covered") {
+    return null;
+  }
   if (state.receiptCoverage === "required-before-commit") {
     return "receipt required before commit";
   }
@@ -487,6 +509,10 @@ function workCaseActionLabel(action: string): string {
     resume: "resume",
   };
   return labels[action] ?? action.replaceAll("-", " ");
+}
+
+function receiptIdForCaseResolution(needId: string, decisionInteractionId: string): string {
+  return `TER-LP-${needId}-${decisionInteractionId}`;
 }
 
 function ReviewActionForm({
@@ -535,12 +561,19 @@ function CaseResolutionForm({
   action,
   label,
   note,
+  receipt,
 }: {
   needId: string;
   agentId: string;
   action: "approve" | "defer" | "reject";
   label: string;
   note: string;
+  receipt?: {
+    receiptId: string;
+    receiptStatus: "valid" | "invalid" | "observed" | "failed";
+    receiptEnforcementMode: "governed-action" | "observed-event";
+    receiptKind: string;
+  };
 }) {
   return (
     <form action={resolveWorkPatternCaseProposalAction} style={{ margin: 0 }}>
@@ -548,6 +581,14 @@ function CaseResolutionForm({
       <input type="hidden" name="agentId" value={agentId} />
       <input type="hidden" name="action" value={action} />
       <input type="hidden" name="note" value={note} />
+      {receipt ? (
+        <>
+          <input type="hidden" name="receiptId" value={receipt.receiptId} />
+          <input type="hidden" name="receiptStatus" value={receipt.receiptStatus} />
+          <input type="hidden" name="receiptEnforcementMode" value={receipt.receiptEnforcementMode} />
+          <input type="hidden" name="receiptKind" value={receipt.receiptKind} />
+        </>
+      ) : null}
       <button
         type="submit"
         style={{

--- a/apps/web/lib/actions/work-pattern-review.test.ts
+++ b/apps/web/lib/actions/work-pattern-review.test.ts
@@ -184,6 +184,18 @@ function resolutionForm(action: string) {
   return data;
 }
 
+function receiptResolutionForm() {
+  const data = resolutionForm("approve");
+  for (const [key, value] of Object.entries({
+    note: "Attach receipt evidence for the governed Work Case proposal.",
+    receiptId: "TER-LP-RECEIPT-1",
+    receiptStatus: "valid",
+    receiptEnforcementMode: "governed-action",
+    receiptKind: "governed-action",
+  })) data.set(key, value);
+  return data;
+}
+
 function stagedCaseNeedRow(overrides: Record<string, unknown> = {}) {
   return caseBoundNeedRow({
     readinessJson: {
@@ -269,6 +281,37 @@ function stagedCaseNeedRow(overrides: Record<string, unknown> = {}) {
     },
     ...overrides,
   });
+}
+
+function awaitingReceiptCaseNeedRow() {
+  const row = stagedCaseNeedRow() as ReturnType<typeof stagedCaseNeedRow>;
+  return {
+    ...row,
+    readinessJson: {
+      ...(row.readinessJson as Record<string, unknown>),
+      workPatternReview: {
+        ...((row.readinessJson as Record<string, unknown>).workPatternReview as Record<string, unknown>),
+        caseStaging: {
+          ...(((row.readinessJson as Record<string, unknown>).workPatternReview as Record<string, unknown>)
+            .caseStaging as Record<string, unknown>),
+          resolution: {
+            status: "approved-awaiting-receipt",
+            action: "approve",
+            activationAllowed: false,
+            liveMutationAllowed: false,
+            commitAllowed: false,
+            decisionInteractionId: "DI-FIRSTRES01",
+            resolverUserId: "user-1",
+            resolvedAt: "2026-06-28T12:05:00.000Z",
+            note: "Approve the proposal; receipt evidence still required.",
+            receiptCoverage: "required-before-commit",
+            receiptId: null,
+            blockers: ["receipt-required-before-commit"],
+          },
+        },
+      },
+    },
+  };
 }
 
 describe("reviewWorkPatternAction", () => {
@@ -651,6 +694,54 @@ describe("reviewWorkPatternAction", () => {
     expect(mockPrisma.coworkerActionEnvelope.create).not.toHaveBeenCalled();
     expect(mockPrisma.workCase.update).not.toHaveBeenCalled();
     expect(mockPrisma.workItem.update).not.toHaveBeenCalled();
+  });
+
+  it("records receipt evidence for an approved Work Case proposal without committing the case", async () => {
+    mockPrisma.coworkerCapabilityNeed.findUnique.mockResolvedValue(awaitingReceiptCaseNeedRow());
+
+    await expect(resolveWorkPatternCaseProposal(receiptResolutionForm())).resolves.toMatchObject({ action: "approve" });
+
+    expect(mockPrisma.decisionInteraction.create.mock.calls[0]![0].data).toMatchObject({
+      outcomeType: "recommend",
+      evidenceBundle: {
+        workPatternCaseProposalResolution: {
+          status: "approved-ready-for-governed-commit",
+          commitAllowed: true,
+          receiptCoverage: "covered",
+          receiptId: "TER-LP-RECEIPT-1",
+        },
+      },
+      outcomePayload: { coverageGap: false },
+      humanOutcome: { type: "work-pattern-case-proposal-resolution", action: "approve" },
+    });
+    const update = mockPrisma.coworkerCapabilityNeed.update.mock.calls[0]![0];
+    expect(update).toMatchObject({
+      where: { needId: "NEED-1" },
+      data: {
+        readinessJson: expect.objectContaining({
+          workPatternReview: expect.objectContaining({
+            caseStaging: expect.objectContaining({
+              status: "stageable",
+              resolution: expect.objectContaining({
+                status: "approved-ready-for-governed-commit",
+                commitAllowed: true,
+                receiptCoverage: "covered",
+                receiptId: "TER-LP-RECEIPT-1",
+              }),
+            }),
+          }),
+        }),
+        evidenceJson: expect.objectContaining({
+          caseProposalResolutionDecisionInteractionId: expect.stringMatching(/^DI-[A-F0-9]{12}$/),
+          caseProposalResolutionDecisionInteractionIds: expect.arrayContaining([
+            "DI-FIRSTRES01",
+            expect.stringMatching(/^DI-[A-F0-9]{12}$/),
+          ]),
+        }),
+      },
+    });
+    expect(mockPrisma.coworkerActionEnvelope.create).not.toHaveBeenCalled();
+    expect(mockPrisma.workCase.update).not.toHaveBeenCalled();
   });
 
   it("records rejected and deferred Work Case proposal resolutions", async () => {

--- a/apps/web/lib/actions/work-pattern-review.ts
+++ b/apps/web/lib/actions/work-pattern-review.ts
@@ -134,7 +134,8 @@ function appendString(values: unknown, next: string): string[] {
   const existing = Array.isArray(values)
     ? values.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
     : [];
-  return [...new Set([...existing, next])];
+  const additions = next.trim().length > 0 ? [next] : [];
+  return [...new Set([...existing, ...additions])];
 }
 
 function evidenceSources(input: {
@@ -503,7 +504,12 @@ export async function resolveWorkPatternCaseProposal(formData: FormData): Promis
   if (!reviewState || !staging || staging.status !== "stageable") {
     throw new Error("work_pattern_case_proposal_not_stageable");
   }
-  if (staging.resolution) {
+  const existingResolution = staging.resolution ?? null;
+  const receiptCompletion =
+    existingResolution?.status === "approved-awaiting-receipt" &&
+    action === "approve" &&
+    Boolean(formString(formData, "receiptId"));
+  if (existingResolution && !receiptCompletion) {
     throw new Error("work_pattern_case_proposal_already_resolved");
   }
 
@@ -603,7 +609,10 @@ export async function resolveWorkPatternCaseProposal(formData: FormData): Promis
           ...evidenceJson,
           caseProposalResolutionDecisionInteractionId: decisionInteractionId,
           caseProposalResolutionDecisionInteractionIds: appendString(
-            evidenceJson.caseProposalResolutionDecisionInteractionIds,
+            appendString(
+              evidenceJson.caseProposalResolutionDecisionInteractionIds,
+              existingResolution?.decisionInteractionId ?? "",
+            ),
             decisionInteractionId,
           ),
           decisionInteractionIds: appendString(evidenceJson.decisionInteractionIds, decisionInteractionId),

--- a/docs/superpowers/plans/2026-06-28-governed-playbook-work-case-resolution.md
+++ b/docs/superpowers/plans/2026-06-28-governed-playbook-work-case-resolution.md
@@ -156,6 +156,12 @@ Assert that a stageable case-bound Living Playbook row shows:
 
 Use existing chip/row styles and theme variables. Keep the new controls inside the existing review row. Do not add a dashboard, route, tab, modal, or chat prompt.
 
+- [x] **Step 3: Attach receipt evidence after approval**
+
+Follow-up slice `feat/living-playbook-receipt-evidence` closes the receipt-backed transition that browser shepherding exposed: a proposal approved without receipt evidence stops at `approved-awaiting-receipt` with `commitAllowed: false`. The existing row now exposes one contextual `Attach receipt evidence` action only in that state. The action reuses `resolveWorkPatternCaseProposal`, supplies a `ReceiptEnvelope` through the existing form fields, and records a second `DecisionInteraction` that moves the persisted resolution to `approved-ready-for-governed-commit` with `receiptCoverage: "covered"` and `commitAllowed: true`.
+
+This is still not a Work Case commit. The slice preserves the Work Case governed Action boundary and continues to assert that no `CoworkerActionEnvelope`, Work Case, WorkItem, source-record, skill, prompt, grant, model-route, backlog, or live autonomy mutation occurs.
+
 ---
 
 ## Chunk 4: Verification, PR, and Landing
@@ -207,10 +213,10 @@ Rollback is a revert of this PR. The slice is migration-free and writes only rea
 
 ## Definition of Done
 
-- [ ] Stageable case-bound Living Playbook proposals can be approved, deferred, or rejected.
-- [ ] Approval records receipt requirements and does not commit Work Case state.
-- [ ] Valid receipt evidence can mark the proposal ready for the governed commit path.
-- [ ] No live Work Case/autonomy/source mutation is introduced.
-- [ ] Existing Work Case helpers are reused; no parallel table, receipt, action rail, or dashboard is added.
-- [ ] Focused tests, typecheck, and production build pass.
+- [x] Stageable case-bound Living Playbook proposals can be approved, deferred, or rejected.
+- [x] Approval records receipt requirements and does not commit Work Case state.
+- [x] Valid receipt evidence can mark the proposal ready for the governed commit path.
+- [x] No live Work Case/autonomy/source mutation is introduced.
+- [x] Existing Work Case helpers are reused; no parallel table, receipt, action rail, or dashboard is added.
+- [x] Focused tests, typecheck, and production build pass.
 - [ ] PR is DCO-signed, pushed, opened non-draft, CI-green, and merged.


### PR DESCRIPTION
## Summary

- Adds the receipt-backed follow-up step for case-bound Living Playbook Work Case proposals that are already `approved-awaiting-receipt`.
- Reuses the existing `ReceiptEnvelope` form fields and `resolveWorkPatternCaseProposal` path to move the persisted resolution to `approved-ready-for-governed-commit` with `commitAllowed: true`.
- Adds the compact `Attach receipt evidence` action in the existing Needs & Playbooks row without adding a new route, dashboard, receipt model, or Work Case write path.
- Updates the governed playbook Work Case resolution plan for this follow-up slice.

BI-8B322CAB
WC-F2348719
UX-Fit-Decision: compact-existing-needs-playbooks-resolution-row

## Verification

- RED: `pnpm --filter web exec vitest run lib/actions/work-pattern-review.test.ts` failed on the new receipt-evidence test with `work_pattern_case_proposal_already_resolved`.
- GREEN: `pnpm --filter web exec vitest run lib/actions/work-pattern-review.test.ts` passed: 14 tests.
- `pnpm --filter web exec vitest run lib/actions/work-pattern-review.test.ts 'app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'` passed: 16 tests.
- `pnpm --filter web exec vitest run lib/tak/work-pattern-case-resolution.test.ts lib/tak/work-pattern-case-staging.test.ts lib/tak/work-pattern-review.test.ts lib/actions/work-pattern-review.test.ts lib/tak/work-pattern-read-model.test.ts 'app/(shell)/platform/ai/agent/[agentId]/page.test.tsx'` passed: 32 tests.
- `pnpm --filter web typecheck` passed.
- `pnpm --filter web build` passed. Build emitted existing Turbopack/NFT warnings around Edge `process.cwd` usage and broad tracing, but exited 0.
- Pre-commit staged gitleaks scan passed; pre-commit scoped typecheck passed.

## Browser verification

Attempted to run the built branch app on `PORT=3026` and visit `/platform/ai/agent/hr-specialist`. The worktree host process could not reach the local Docker-only Postgres endpoint because `.env` points to `postgres:5432` inside the Compose network and `dpf-postgres-1` does not publish host port 5432. The route returned 500 during Prisma instrumentation with `ECONNREFUSED` before the page could render. This PR should receive browser/runtime verification through the governed preview/canonical runtime after merge or via the shared local-CI runtime lease.

## Safety

The new receipt step still does not commit a Work Case. Tests assert no `CoworkerActionEnvelope`, Work Case, WorkItem, source-record, skill, prompt, grant, model-route, backlog, or live autonomy mutation is introduced.