### PR TITLE
Expose governed self-upgrade trigger to agents

### DIFF
--- a/apps/web/lib/actions/self-upgrade.test.ts
+++ b/apps/web/lib/actions/self-upgrade.test.ts
@@ -20,16 +20,6 @@ vi.mock("@/lib/permissions", () => ({
   can: vi.fn(),
 }));
 
-vi.mock("@/lib/queue/inngest-client", () => ({
-  inngest: {
-    send: vi.fn(),
-  },
-}));
-
-vi.mock("@/lib/queue/functions/self-upgrade", () => ({
-  SELF_UPGRADE_EVENT: "ops/self-upgrade.run",
-}));
-
 vi.mock("@/lib/self-upgrade/config", () => ({
   getSelfUpgradeConfig: vi.fn(),
 }));
@@ -38,17 +28,14 @@ vi.mock("@/lib/self-upgrade/version", () => ({
   getUpgradeVersionState: vi.fn(),
 }));
 
-vi.mock("@/lib/self-upgrade/run-store", () => ({
-  createRun: vi.fn(),
-  failRun: vi.fn(),
-  getLatestRun: vi.fn(),
+vi.mock("@/lib/self-upgrade/request", () => ({
+  requestSelfUpgrade: vi.fn(),
 }));
 
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { inngest } from "@/lib/queue/inngest-client";
-import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
+import { requestSelfUpgrade } from "@/lib/self-upgrade/request";
 import { requestPortalSelfUpgradeAction } from "./self-upgrade";
 
 describe("requestPortalSelfUpgradeAction", () => {
@@ -62,52 +49,58 @@ describe("requestPortalSelfUpgradeAction", () => {
       },
     } as never);
     vi.mocked(can).mockReturnValue(true);
-    vi.mocked(getLatestRun).mockResolvedValue(null);
-    vi.mocked(createRun).mockResolvedValue({
-      runId: "SUR-QUEUED1",
+    vi.mocked(requestSelfUpgrade).mockResolvedValue({
+      success: true,
       status: "queued",
+      runId: "SUR-QUEUED1",
+      triggeredBy: "manual:user-ops-1",
+      eventIds: ["evt-1"],
     } as never);
   });
 
-  it("creates a durable queued run before sending the worker event", async () => {
+  it("delegates to the shared request service as a human manual trigger", async () => {
     await requestPortalSelfUpgradeAction();
 
-    expect(createRun).toHaveBeenCalledWith({ triggeredBy: "manual:user-ops-1" });
-    expect(inngest.send).toHaveBeenCalledWith({
-      name: "ops/self-upgrade.run",
-      data: {
-        runId: "SUR-QUEUED1",
-        triggeredBy: "manual:user-ops-1",
-      },
+    expect(requestSelfUpgrade).toHaveBeenCalledWith({
+      requestedBy: "manual:user-ops-1",
+      actorKind: "human",
     });
     expect(revalidatePath).toHaveBeenCalledWith("/ops/self-upgrade");
   });
 
   it.each(["running", "queued", "pending"])(
-    "does not dispatch a duplicate event while the latest run is %s",
+    "delegates duplicate suppression to the shared service when latest run is %s",
     async (status) => {
-      vi.mocked(getLatestRun).mockResolvedValue({
+      vi.mocked(requestSelfUpgrade).mockResolvedValueOnce({
+        success: true,
+        status: "already_active",
         runId: "SUR-ACTIVE1",
-        status,
       } as never);
 
       await requestPortalSelfUpgradeAction();
 
-      expect(createRun).not.toHaveBeenCalled();
-      expect(inngest.send).not.toHaveBeenCalled();
+      expect(requestSelfUpgrade).toHaveBeenCalledWith({
+        requestedBy: "manual:user-ops-1",
+        actorKind: "human",
+      });
       expect(revalidatePath).toHaveBeenCalledWith("/ops/self-upgrade");
     },
   );
 
-  it("marks the queued run failed when event dispatch fails", async () => {
-    vi.mocked(inngest.send).mockRejectedValueOnce(new Error("inngest offline"));
+  it("still revalidates when the shared request service reports dispatch failure", async () => {
+    vi.mocked(requestSelfUpgrade).mockResolvedValueOnce({
+      success: false,
+      status: "dispatch_failed",
+      runId: "SUR-QUEUED1",
+      message: "queue-dispatch-failed: inngest offline",
+    } as never);
 
     await requestPortalSelfUpgradeAction();
 
-    expect(failRun).toHaveBeenCalledWith(
-      "SUR-QUEUED1",
-      "queue-dispatch-failed: inngest offline",
-    );
+    expect(requestSelfUpgrade).toHaveBeenCalledWith({
+      requestedBy: "manual:user-ops-1",
+      actorKind: "human",
+    });
     expect(revalidatePath).toHaveBeenCalledWith("/ops/self-upgrade");
   });
 });

--- a/apps/web/lib/actions/self-upgrade.ts
+++ b/apps/web/lib/actions/self-upgrade.ts
@@ -6,10 +6,8 @@ import { prisma } from "@dpf/db";
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { inngest } from "@/lib/queue/inngest-client";
-import { SELF_UPGRADE_EVENT } from "@/lib/queue/functions/self-upgrade";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
-import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
+import { requestSelfUpgrade } from "@/lib/self-upgrade/request";
 import { getUpgradeVersionState, type UpgradeVersionState } from "@/lib/self-upgrade/version";
 
 async function requireSelfUpgradeOperator(
@@ -136,33 +134,6 @@ export async function getSelfUpgradeDashboardAction(): Promise<SelfUpgradeDashbo
 export async function requestPortalSelfUpgradeAction(): Promise<void> {
   const { userId } = await requireSelfUpgradeOperator("manage_provider_connections");
   const triggeredBy = userId ? `manual:${userId}` : "manual";
-  const latestRun = await getLatestRun();
-
-  if (
-    latestRun?.status === "running" ||
-    latestRun?.status === "queued" ||
-    latestRun?.status === "pending"
-  ) {
-    revalidatePath("/ops/self-upgrade");
-    return;
-  }
-
-  const run = await createRun({
-    triggeredBy,
-  });
-
-  try {
-    await inngest.send({
-      name: SELF_UPGRADE_EVENT,
-      data: {
-        runId: run.runId,
-        triggeredBy,
-      },
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    await failRun(run.runId, `queue-dispatch-failed: ${message}`);
-  }
-
+  await requestSelfUpgrade({ requestedBy: triggeredBy, actorKind: "human" });
   revalidatePath("/ops/self-upgrade");
 }

--- a/apps/web/lib/mcp-tools-self-upgrade.test.ts
+++ b/apps/web/lib/mcp-tools-self-upgrade.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRequestSelfUpgrade = vi.fn();
+
+vi.mock("@/lib/self-upgrade/request", () => ({
+  requestSelfUpgrade: mockRequestSelfUpgrade,
+}));
+
+describe("self-upgrade MCP tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes request_self_upgrade as an operator side-effecting tool", async () => {
+    const { PLATFORM_TOOLS } = await import("./mcp-tools");
+    const tool = PLATFORM_TOOLS.find((candidate) => candidate.name === "request_self_upgrade");
+    const properties = tool?.inputSchema.properties as Record<string, unknown> | undefined;
+
+    expect(tool).toBeDefined();
+    expect(tool?.requiredCapability).toBe("manage_provider_connections");
+    expect(tool?.executionMode).toBe("immediate");
+    expect(tool?.sideEffect).toBe(true);
+    expect(tool?.inputSchema.required).toEqual([]);
+    expect(properties?.force).toBeUndefined();
+  });
+
+  it("queues the governed self-upgrade request as an agent trigger", async () => {
+    mockRequestSelfUpgrade.mockResolvedValueOnce({
+      success: true,
+      status: "queued",
+      runId: "SUR-QUEUED1",
+      triggeredBy: "mcp:codex",
+      eventIds: ["evt-1"],
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "request_self_upgrade",
+      { reason: "codex" },
+      "user-1",
+      { agentId: "codex" },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "Queued governed self-upgrade SUR-QUEUED1.",
+      data: { status: "queued", runId: "SUR-QUEUED1" },
+    });
+    expect(mockRequestSelfUpgrade).toHaveBeenCalledWith({
+      requestedBy: "mcp:codex",
+      actorKind: "agent",
+    });
+  });
+
+  it("surfaces the human override requirement without queueing a run", async () => {
+    mockRequestSelfUpgrade.mockResolvedValueOnce({
+      success: true,
+      status: "human_override_required",
+      reason: "outside-window",
+      message: "Self-upgrade is outside the allowed maintenance window. Use /ops/self-upgrade for a human override.",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("request_self_upgrade", {}, "user-1", { agentId: "codex" });
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "Self-upgrade is outside the allowed maintenance window. Use /ops/self-upgrade for a human override.",
+      data: {
+        status: "human_override_required",
+        reason: "outside-window",
+      },
+    });
+    expect(mockRequestSelfUpgrade).toHaveBeenCalledWith({
+      requestedBy: "mcp:codex",
+      actorKind: "agent",
+    });
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -46,6 +46,7 @@ import { feedbackPack } from "@/lib/mcp/packs/feedback-pack";
 import { marketingPack } from "@/lib/mcp/packs/marketing-pack";
 import { orgDecisionPack } from "@/lib/mcp/packs/org-decision-pack";
 import { activityRoutingPack } from "@/lib/mcp/packs/activity-routing-pack";
+import { selfUpgradePack } from "@/lib/mcp/packs/self-upgrade-pack";
 import { composeToolPacks } from "@/lib/mcp/tool-registry";
 import {
   createLicenseReadinessIssue,
@@ -437,7 +438,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, activityRoutingPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, activityRoutingPack, selfUpgradePack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,

--- a/apps/web/lib/mcp/packs/self-upgrade-pack.ts
+++ b/apps/web/lib/mcp/packs/self-upgrade-pack.ts
@@ -1,0 +1,83 @@
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "request_self_upgrade",
+    description:
+      "Request the governed portal self-upgrade pipeline. Queues the same run path as the operator control when the install is inside its allowed off-hours window; outside that window it returns a human-override-required result and does not queue a run.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        reason: {
+          type: "string",
+          description: "Optional short audit tag for the request origin.",
+        },
+      },
+      required: [],
+    },
+    requiredCapability: "manage_provider_connections",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+];
+
+function auditTag(params: Record<string, unknown>, context?: { agentId?: string }): string {
+  const reason = typeof params["reason"] === "string" ? params["reason"].trim() : "";
+  if (reason) return reason.slice(0, 80);
+  return context?.agentId?.trim() || "agent";
+}
+
+async function requestSelfUpgradeTool(
+  params: Record<string, unknown>,
+  _userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const { requestSelfUpgrade } = await import("@/lib/self-upgrade/request");
+  const result = await requestSelfUpgrade({
+    requestedBy: `mcp:${auditTag(params, context)}`,
+    actorKind: "agent",
+  });
+
+  if (result.status === "queued") {
+    return {
+      success: true,
+      message: `Queued governed self-upgrade ${result.runId}.`,
+      data: result as unknown as Record<string, unknown>,
+    };
+  }
+
+  if (result.status === "already_active") {
+    return {
+      success: true,
+      message: `Self-upgrade ${result.runId} is already active.`,
+      data: result as unknown as Record<string, unknown>,
+    };
+  }
+
+  if (result.status === "human_override_required") {
+    return {
+      success: true,
+      message: result.message,
+      data: result as unknown as Record<string, unknown>,
+    };
+  }
+
+  return {
+    success: false,
+    error: result.message,
+    message: result.message,
+    data: result as unknown as Record<string, unknown>,
+  };
+}
+
+export const selfUpgradePack: ToolPack = {
+  packId: "self-upgrade",
+  definitions,
+  handlers: {
+    request_self_upgrade: requestSelfUpgradeTool,
+  },
+  grants: {
+    request_self_upgrade: ["admin_write"],
+  },
+};

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -15,6 +15,7 @@ import { workCapsulesPack } from "./packs/work-capsules-pack";
 import { workbooksPack } from "./packs/workbooks-pack";
 import { feedbackPack } from "./packs/feedback-pack";
 import { activityRoutingPack } from "./packs/activity-routing-pack";
+import { selfUpgradePack } from "./packs/self-upgrade-pack";
 import { composeToolPacks } from "./tool-registry";
 // The inline-case ratchet's extractor lives in the CI guard (scripts/), kept as
 // the single source of truth so this test and the guard can never disagree.
@@ -169,6 +170,30 @@ describe("activity-routing tool pack", () => {
   });
 });
 
+describe("self-upgrade tool pack", () => {
+  it("bundles the governed self-upgrade request tool", () => {
+    expect(selfUpgradePack.definitions.map((t) => t.name)).toEqual([
+      "request_self_upgrade",
+    ]);
+    for (const def of selfUpgradePack.definitions) {
+      expect(selfUpgradePack.handlers[def.name], def.name).toBeTypeOf("function");
+    }
+  });
+
+  it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
+    for (const [name, grants] of Object.entries(selfUpgradePack.grants)) {
+      expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
+    }
+  });
+
+  it("keeps every pack tool present in the live PLATFORM_TOOLS registry", () => {
+    const platformNames = new Set(PLATFORM_TOOLS.map((t) => t.name));
+    for (const def of selfUpgradePack.definitions) {
+      expect(platformNames.has(def.name), def.name).toBe(true);
+    }
+  });
+});
+
 describe("composeToolPacks", () => {
   it("composes definitions + handler/grant lookup from packs", () => {
     const registry = composeToolPacks([deliberationSiemPack]);
@@ -185,18 +210,21 @@ describe("composeToolPacks", () => {
       workCapsulesPack,
       workbooksPack,
       feedbackPack,
+      selfUpgradePack,
     ]);
     expect(registry.definitions).toHaveLength(
       deliberationSiemPack.definitions.length +
         runtimeCoordinationPack.definitions.length +
         workCapsulesPack.definitions.length +
         workbooksPack.definitions.length +
-        feedbackPack.definitions.length,
+        feedbackPack.definitions.length +
+        selfUpgradePack.definitions.length,
     );
     expect(registry.getHandler("register_runtime_target")).toBeTypeOf("function");
     expect(registry.getHandler("create_work_capsule")).toBeTypeOf("function");
     expect(registry.getHandler("workbook_list_tables")).toBeTypeOf("function");
     expect(registry.getHandler("report_quality_issue")).toBeTypeOf("function");
+    expect(registry.getHandler("request_self_upgrade")).toBeTypeOf("function");
   });
 
   it("rejects the same tool name claimed by two packs", () => {

--- a/apps/web/lib/self-upgrade/request.test.ts
+++ b/apps/web/lib/self-upgrade/request.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  inngestSend: vi.fn(),
+  getSelfUpgradeConfig: vi.fn(),
+  resolveOperatingScheduleForSystem: vi.fn(),
+  resolveAutoUpgradeWindow: vi.fn(),
+  isUpgradeWindowOpen: vi.fn(),
+  getLatestRun: vi.fn(),
+  createRun: vi.fn(),
+  failRun: vi.fn(),
+}));
+
+vi.mock("@/lib/queue/inngest-client", () => ({
+  inngest: {
+    send: mocks.inngestSend,
+  },
+}));
+
+vi.mock("@/lib/queue/functions/self-upgrade", () => ({
+  SELF_UPGRADE_EVENT: "ops/self-upgrade.run",
+}));
+
+vi.mock("@/lib/self-upgrade/config", () => ({
+  getSelfUpgradeConfig: mocks.getSelfUpgradeConfig,
+}));
+
+vi.mock("@/lib/operating-hours-read", () => ({
+  resolveOperatingScheduleForSystem: mocks.resolveOperatingScheduleForSystem,
+}));
+
+vi.mock("@/lib/self-upgrade/auto-window", () => ({
+  resolveAutoUpgradeWindow: mocks.resolveAutoUpgradeWindow,
+}));
+
+vi.mock("@/lib/self-upgrade/window", () => ({
+  isUpgradeWindowOpen: mocks.isUpgradeWindowOpen,
+}));
+
+vi.mock("@/lib/self-upgrade/run-store", () => ({
+  getLatestRun: mocks.getLatestRun,
+  createRun: mocks.createRun,
+  failRun: mocks.failRun,
+}));
+
+import { requestSelfUpgrade } from "./request";
+
+const CONFIG = {
+  enabled: true,
+  channel: "stable",
+  checkIntervalHours: 24,
+  cooldownMinutes: 30,
+  healthTarget: 100,
+  maintenanceWindows: [],
+  sourceMode: "upstream" as const,
+  installBranch: "dpf/install",
+  useIsolatedWorkspace: true,
+};
+
+const SCHEDULE = {
+  sunday: { enabled: false, open: "09:00", close: "17:00" },
+  monday: { enabled: true, open: "09:00", close: "17:00" },
+  tuesday: { enabled: true, open: "09:00", close: "17:00" },
+  wednesday: { enabled: true, open: "09:00", close: "17:00" },
+  thursday: { enabled: true, open: "09:00", close: "17:00" },
+  friday: { enabled: true, open: "09:00", close: "17:00" },
+  saturday: { enabled: false, open: "09:00", close: "17:00" },
+};
+
+describe("requestSelfUpgrade", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSelfUpgradeConfig.mockResolvedValue(CONFIG);
+    mocks.resolveOperatingScheduleForSystem.mockResolvedValue({
+      schedule: SCHEDULE,
+      timezone: "America/Chicago",
+      timezoneKnown: true,
+      lowTrafficWindows: [],
+    });
+    mocks.resolveAutoUpgradeWindow.mockReturnValue({ kind: "operating-hours" });
+    mocks.isUpgradeWindowOpen.mockReturnValue(true);
+    mocks.getLatestRun.mockResolvedValue(null);
+    mocks.createRun.mockResolvedValue({ runId: "SUR-QUEUED1", status: "queued" });
+    mocks.inngestSend.mockResolvedValue({ ids: ["evt-1"] });
+    mocks.failRun.mockResolvedValue({});
+  });
+
+  it("queues the same event as the human action in manual mode", async () => {
+    const result = await requestSelfUpgrade({
+      requestedBy: "manual:user-ops-1",
+      actorKind: "human",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      status: "queued",
+      runId: "SUR-QUEUED1",
+      triggeredBy: "manual:user-ops-1",
+      eventIds: ["evt-1"],
+    });
+    expect(mocks.createRun).toHaveBeenCalledWith({ triggeredBy: "manual:user-ops-1" });
+    expect(mocks.inngestSend).toHaveBeenCalledWith({
+      name: "ops/self-upgrade.run",
+      data: {
+        runId: "SUR-QUEUED1",
+        triggeredBy: "manual:user-ops-1",
+      },
+    });
+    expect(mocks.isUpgradeWindowOpen).not.toHaveBeenCalled();
+  });
+
+  it.each(["running", "queued", "pending"])(
+    "does not dispatch a duplicate event when latest run is %s",
+    async (status) => {
+      mocks.getLatestRun.mockResolvedValue({ runId: "SUR-ACTIVE1", status });
+
+      const result = await requestSelfUpgrade({
+        requestedBy: "mcp:codex",
+        actorKind: "agent",
+      });
+
+      expect(result).toMatchObject({
+        success: true,
+        status: "already_active",
+        runId: "SUR-ACTIVE1",
+      });
+      expect(mocks.createRun).not.toHaveBeenCalled();
+      expect(mocks.inngestSend).not.toHaveBeenCalled();
+    },
+  );
+
+  it("marks the queued run failed when event dispatch fails", async () => {
+    mocks.inngestSend.mockRejectedValueOnce(new Error("inngest offline"));
+
+    const result = await requestSelfUpgrade({
+      requestedBy: "manual:user-ops-1",
+      actorKind: "human",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      status: "dispatch_failed",
+      runId: "SUR-QUEUED1",
+      message: "queue-dispatch-failed: inngest offline",
+    });
+    expect(mocks.failRun).toHaveBeenCalledWith(
+      "SUR-QUEUED1",
+      "queue-dispatch-failed: inngest offline",
+    );
+  });
+
+  it("requires human override when an agent requests outside the effective window", async () => {
+    mocks.isUpgradeWindowOpen.mockReturnValue(false);
+
+    const result = await requestSelfUpgrade({
+      requestedBy: "mcp:codex",
+      actorKind: "agent",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      status: "human_override_required",
+      reason: "outside-window",
+    });
+    expect(mocks.createRun).not.toHaveBeenCalled();
+    expect(mocks.inngestSend).not.toHaveBeenCalled();
+  });
+
+  it("allows an agent request inside the effective window without force", async () => {
+    const result = await requestSelfUpgrade({
+      requestedBy: "mcp:codex",
+      actorKind: "agent",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      status: "queued",
+      runId: "SUR-QUEUED1",
+      triggeredBy: "mcp:codex",
+    });
+    expect(mocks.inngestSend).toHaveBeenCalledWith({
+      name: "ops/self-upgrade.run",
+      data: {
+        runId: "SUR-QUEUED1",
+        triggeredBy: "mcp:codex",
+      },
+    });
+    expect(mocks.inngestSend.mock.calls[0]?.[0].data.force).toBeUndefined();
+  });
+
+  it("requires human override when a 24/7 install has no known timezone", async () => {
+    mocks.resolveAutoUpgradeWindow.mockReturnValue({ kind: "needs-timezone" });
+
+    const result = await requestSelfUpgrade({
+      requestedBy: "mcp:codex",
+      actorKind: "agent",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      status: "human_override_required",
+      reason: "no-window-needs-timezone",
+    });
+    expect(mocks.isUpgradeWindowOpen).not.toHaveBeenCalled();
+    expect(mocks.createRun).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/self-upgrade/request.ts
+++ b/apps/web/lib/self-upgrade/request.ts
@@ -1,0 +1,143 @@
+import { inngest } from "@/lib/queue/inngest-client";
+import { SELF_UPGRADE_EVENT } from "@/lib/queue/functions/self-upgrade";
+import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
+import { resolveAutoUpgradeWindow } from "@/lib/self-upgrade/auto-window";
+import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
+import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
+import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
+
+type RequestActorKind = "human" | "agent";
+
+type RequestSelfUpgradeInput = {
+  requestedBy: string;
+  actorKind: RequestActorKind;
+  now?: Date;
+};
+
+export type RequestSelfUpgradeResult =
+  | {
+      success: true;
+      status: "queued";
+      runId: string;
+      triggeredBy: string;
+      eventIds: string[];
+    }
+  | {
+      success: true;
+      status: "already_active";
+      runId: string;
+    }
+  | {
+      success: true;
+      status: "human_override_required";
+      reason: "outside-window" | "no-window-needs-timezone";
+      message: string;
+    }
+  | {
+      success: false;
+      status: "dispatch_failed";
+      runId: string;
+      message: string;
+    };
+
+const ACTIVE_RUN_STATUSES = new Set(["running", "queued", "pending"]);
+
+async function agentWindowGate(
+  now: Date,
+): Promise<
+  | { allowed: true }
+  | { allowed: false; reason: "outside-window" | "no-window-needs-timezone" }
+> {
+  const config = await getSelfUpgradeConfig();
+  const { schedule, timezone, timezoneKnown, lowTrafficWindows } =
+    await resolveOperatingScheduleForSystem();
+  const auto =
+    config.maintenanceWindows.length > 0
+      ? { kind: "operating-hours" as const }
+      : resolveAutoUpgradeWindow({
+          schedule,
+          timeZone: timezone,
+          timezoneKnown,
+          lowTrafficWindows,
+          now,
+        });
+
+  if (auto.kind === "needs-timezone") {
+    return { allowed: false, reason: "no-window-needs-timezone" };
+  }
+
+  const explicitWindows =
+    config.maintenanceWindows.length > 0
+      ? config.maintenanceWindows
+      : auto.kind === "auto-overnight"
+        ? auto.windows
+        : undefined;
+  const allowed = isUpgradeWindowOpen({
+    explicitWindows,
+    schedule,
+    timeZone: timezone,
+    now,
+  });
+  return allowed ? { allowed: true } : { allowed: false, reason: "outside-window" };
+}
+
+function humanOverrideMessage(reason: "outside-window" | "no-window-needs-timezone"): string {
+  if (reason === "no-window-needs-timezone") {
+    return "Self-upgrade cannot determine a safe off-hours window because the install needs a timezone. Use /ops/self-upgrade for a human override.";
+  }
+  return "Self-upgrade is outside the allowed maintenance window. Use /ops/self-upgrade for a human override.";
+}
+
+export async function requestSelfUpgrade(
+  input: RequestSelfUpgradeInput,
+): Promise<RequestSelfUpgradeResult> {
+  const triggeredBy = input.requestedBy.trim() || input.actorKind;
+  const latestRun = await getLatestRun();
+  if (latestRun && ACTIVE_RUN_STATUSES.has(String(latestRun.status))) {
+    return {
+      success: true,
+      status: "already_active",
+      runId: latestRun.runId,
+    };
+  }
+
+  if (input.actorKind === "agent") {
+    const gate = await agentWindowGate(input.now ?? new Date());
+    if (!gate.allowed) {
+      return {
+        success: true,
+        status: "human_override_required",
+        reason: gate.reason,
+        message: humanOverrideMessage(gate.reason),
+      };
+    }
+  }
+
+  const run = await createRun({ triggeredBy });
+  try {
+    const result = await inngest.send({
+      name: SELF_UPGRADE_EVENT,
+      data: {
+        runId: run.runId,
+        triggeredBy,
+      },
+    });
+    return {
+      success: true,
+      status: "queued",
+      runId: run.runId,
+      triggeredBy,
+      eventIds: result.ids,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const failure = `queue-dispatch-failed: ${message}`;
+    await failRun(run.runId, failure);
+    return {
+      success: false,
+      status: "dispatch_failed",
+      runId: run.runId,
+      message: failure,
+    };
+  }
+}

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -231,6 +231,11 @@ describe("TOOL_TO_GRANTS — Admin entries", () => {
     expect(isToolAllowedByGrants("admin_run_command", ["admin_write"])).toBe(true);
     expect(isToolAllowedByGrants("admin_run_command", [])).toBe(false);
   });
+
+  it("request_self_upgrade requires admin_write", () => {
+    expect(isToolAllowedByGrants("request_self_upgrade", ["admin_write"])).toBe(true);
+    expect(isToolAllowedByGrants("request_self_upgrade", ["admin_read"])).toBe(false);
+  });
 });
 
 describe("TOOL_TO_GRANTS — Licensing compliance entries", () => {

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -541,6 +541,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // that just pushed a branch / opened a PR can force the cron to run
   // out-of-band rather than waiting up to 10 minutes (BI-063BDF1B Phase 5).
   trigger_contributor_inventory_sync: ["admin_write"],
+  request_self_upgrade: ["admin_write"],
 
   // Design intelligence (read-only references)
   search_design_intelligence: ["file_read"],

--- a/docs/operations/dpf-production-runtime.md
+++ b/docs/operations/dpf-production-runtime.md
@@ -19,6 +19,7 @@ This install runs three local runtime roles:
 - The **Contributor preview** is opt-in via the `dev` compose profile. A plain `docker compose up -d` does not start it, and customer installs do not ship it by default.
 - Promote changes through branch → PR → merge → `/ops/self-upgrade` / governed promoter → Live portal verification rather than treating the Live portal as a scratch environment.
 - **Step zero for Live portal verification:** run `pnpm verify:preflight` (or the `verify_live_install_readiness` MCP tool / the `dpf-verify-on-live-install` skill) for a deterministic `CAN-TEST` / `MUST-ADVANCE` / `BLOCKED` verdict before driving a feature's happy path — instead of hand-comparing the served SHA. A `BLOCKED` verdict caused by an unrelated defect is a stop-and-file-a-BI condition, not a cue to refresh the portal by hand. Canonical procedure: [`2026-06-06-procedural-functional-verification-design.md`](../superpowers/specs/2026-06-06-procedural-functional-verification-design.md).
+- **Agent-led advancement:** when `verify_live_install_readiness` returns `MUST-ADVANCE`, agents may call the side-effecting `request_self_upgrade` MCP tool. The tool queues the same governed self-upgrade path as `/ops/self-upgrade` only when the install is inside the allowed off-hours window. Outside that window, or when the safe window cannot be determined, it returns `human_override_required` and the human operator must trigger `/ops/self-upgrade` intentionally.
 
 ## Why this matters
 

--- a/docs/superpowers/plans/2026-06-30-agent-safe-self-upgrade-trigger.md
+++ b/docs/superpowers/plans/2026-06-30-agent-safe-self-upgrade-trigger.md
@@ -1,0 +1,76 @@
+# Agent-Safe Self-Upgrade Trigger Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an MCP-accessible self-upgrade trigger that uses the existing governed self-upgrade pipeline and requires human override outside allowed maintenance windows.
+
+**Architecture:** Extract the current UI action's run creation and Inngest dispatch into a shared request service. Add an agent request mode that evaluates the same effective maintenance window as scheduled self-upgrade before any run is created. Wire MCP to the shared service and keep `force` unavailable to agents.
+
+**Tech Stack:** Next.js server actions, Vitest, DPF MCP tool registry in `apps/web/lib/mcp-tools.ts`, existing self-upgrade config/window helpers.
+
+---
+
+## File Map
+
+- Modify: `apps/web/lib/actions/self-upgrade.ts`
+  - Keep auth/revalidate behavior.
+  - Delegate request mechanics to a shared service.
+- Create: `apps/web/lib/self-upgrade/request.ts`
+  - Implement UI and agent request orchestration.
+  - Implement effective-window check for agent requests.
+- Create: `apps/web/lib/self-upgrade/request.test.ts`
+  - TDD coverage for queueing, duplicate suppression, dispatch failure, and human-override-required window outcomes.
+- Modify: `apps/web/lib/actions/self-upgrade.test.ts`
+  - Confirm UI action delegates and preserves current behavior.
+- Modify: `apps/web/lib/mcp-tools.ts`
+  - Add `request_self_upgrade` tool definition and handler.
+- Modify: `apps/web/lib/mcp-tools-work-capsules.test.ts` or create a focused MCP test if a better local MCP test exists.
+  - Confirm tool metadata and handler behavior.
+- Modify: `docs/operations/dpf-production-runtime.md`
+  - Add the post-merge agent verification loop using `request_self_upgrade`.
+
+## Task 1: Shared Request Service
+
+- [ ] Write failing tests in `apps/web/lib/self-upgrade/request.test.ts`:
+  - UI/manual mode creates a run and sends `ops/self-upgrade.run`.
+  - Active latest run returns `already_active` and does not dispatch.
+  - Dispatch failure marks the queued run failed and returns `dispatch_failed`.
+  - Agent mode outside effective window returns `human_override_required` and does not create a run.
+  - Agent mode inside effective window creates and dispatches a run with `triggeredBy` prefixed by `mcp:`.
+  - Agent mode with `needs-timezone` returns `human_override_required`.
+- [ ] Run: `pnpm --filter web exec vitest run lib/self-upgrade/request.test.ts`
+  - Expected: fail because the module does not exist.
+- [ ] Implement `apps/web/lib/self-upgrade/request.ts`.
+- [ ] Re-run the test until green.
+- [ ] Commit: `feat: add governed self-upgrade request service`.
+
+## Task 2: UI Action Delegation
+
+- [ ] Update `apps/web/lib/actions/self-upgrade.test.ts` to assert the action calls the shared service and preserves `revalidatePath`.
+- [ ] Run: `pnpm --filter web exec vitest run lib/actions/self-upgrade.test.ts`
+  - Expected: fail until action delegates.
+- [ ] Update `apps/web/lib/actions/self-upgrade.ts`.
+- [ ] Re-run action tests plus request tests.
+- [ ] Commit: `refactor: share self-upgrade request path`.
+
+## Task 3: MCP Tool
+
+- [ ] Add failing MCP tests for `request_self_upgrade`:
+  - Definition is side-effecting and requires `manage_provider_connections`.
+  - Schema has no `force` property.
+  - Handler returns `queued` when the service queues.
+  - Handler returns `human_override_required` without treating it as a transport failure.
+- [ ] Run the focused MCP test.
+- [ ] Add the tool definition and handler in `apps/web/lib/mcp-tools.ts`.
+- [ ] Re-run MCP tests.
+- [ ] Commit: `feat: expose governed self-upgrade trigger to agents`.
+
+## Task 4: Docs And Verification
+
+- [ ] Update `docs/operations/dpf-production-runtime.md` with the new post-merge loop.
+- [ ] Run focused tests:
+  - `pnpm --filter web exec vitest run lib/self-upgrade/request.test.ts lib/actions/self-upgrade.test.ts <mcp-test-path>`
+- [ ] Run `pnpm --filter web typecheck`.
+- [ ] Run `pnpm --filter web build` if source-local time allows; otherwise record why it was not run.
+- [ ] Commit docs and final fixes.
+- [ ] Push branch.

--- a/docs/superpowers/plans/2026-06-30-agent-safe-self-upgrade-trigger.md
+++ b/docs/superpowers/plans/2026-06-30-agent-safe-self-upgrade-trigger.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Extract the current UI action's run creation and Inngest dispatch into a shared request service. Add an agent request mode that evaluates the same effective maintenance window as scheduled self-upgrade before any run is created. Wire MCP to the shared service and keep `force` unavailable to agents.
 
-**Tech Stack:** Next.js server actions, Vitest, DPF MCP tool registry in `apps/web/lib/mcp-tools.ts`, existing self-upgrade config/window helpers.
+**Tech Stack:** Next.js server actions, Vitest, DPF MCP tool packs composed by `apps/web/lib/mcp-tools.ts`, existing self-upgrade config/window helpers.
 
 ---
 
@@ -22,53 +22,58 @@
   - TDD coverage for queueing, duplicate suppression, dispatch failure, and human-override-required window outcomes.
 - Modify: `apps/web/lib/actions/self-upgrade.test.ts`
   - Confirm UI action delegates and preserves current behavior.
-- Modify: `apps/web/lib/mcp-tools.ts`
+- Create: `apps/web/lib/mcp/packs/self-upgrade-pack.ts`
   - Add `request_self_upgrade` tool definition and handler.
-- Modify: `apps/web/lib/mcp-tools-work-capsules.test.ts` or create a focused MCP test if a better local MCP test exists.
+- Modify: `apps/web/lib/mcp-tools.ts`
+  - Compose the self-upgrade tool pack into the platform registry.
+- Create: `apps/web/lib/mcp-tools-self-upgrade.test.ts`
   - Confirm tool metadata and handler behavior.
+- Modify: `apps/web/lib/tak/agent-grants.ts` and `apps/web/lib/mcp/tool-registry.test.ts`
+  - Keep agent-grant and tool-pack parity explicit.
 - Modify: `docs/operations/dpf-production-runtime.md`
   - Add the post-merge agent verification loop using `request_self_upgrade`.
 
 ## Task 1: Shared Request Service
 
-- [ ] Write failing tests in `apps/web/lib/self-upgrade/request.test.ts`:
+- [x] Write failing tests in `apps/web/lib/self-upgrade/request.test.ts`:
   - UI/manual mode creates a run and sends `ops/self-upgrade.run`.
   - Active latest run returns `already_active` and does not dispatch.
   - Dispatch failure marks the queued run failed and returns `dispatch_failed`.
   - Agent mode outside effective window returns `human_override_required` and does not create a run.
   - Agent mode inside effective window creates and dispatches a run with `triggeredBy` prefixed by `mcp:`.
   - Agent mode with `needs-timezone` returns `human_override_required`.
-- [ ] Run: `pnpm --filter web exec vitest run lib/self-upgrade/request.test.ts`
+- [x] Run: `pnpm --filter web exec vitest run lib/self-upgrade/request.test.ts`
   - Expected: fail because the module does not exist.
-- [ ] Implement `apps/web/lib/self-upgrade/request.ts`.
-- [ ] Re-run the test until green.
-- [ ] Commit: `feat: add governed self-upgrade request service`.
+- [x] Implement `apps/web/lib/self-upgrade/request.ts`.
+- [x] Re-run the test until green.
+- [x] Commit: `feat: add governed self-upgrade request service`.
 
 ## Task 2: UI Action Delegation
 
-- [ ] Update `apps/web/lib/actions/self-upgrade.test.ts` to assert the action calls the shared service and preserves `revalidatePath`.
-- [ ] Run: `pnpm --filter web exec vitest run lib/actions/self-upgrade.test.ts`
+- [x] Update `apps/web/lib/actions/self-upgrade.test.ts` to assert the action calls the shared service and preserves `revalidatePath`.
+- [x] Run: `pnpm --filter web exec vitest run lib/actions/self-upgrade.test.ts`
   - Expected: fail until action delegates.
-- [ ] Update `apps/web/lib/actions/self-upgrade.ts`.
-- [ ] Re-run action tests plus request tests.
-- [ ] Commit: `refactor: share self-upgrade request path`.
+- [x] Update `apps/web/lib/actions/self-upgrade.ts`.
+- [x] Re-run action tests plus request tests.
+- [x] Commit: `refactor: share self-upgrade request path`.
 
 ## Task 3: MCP Tool
 
-- [ ] Add failing MCP tests for `request_self_upgrade`:
+- [x] Add failing MCP tests for `request_self_upgrade`:
   - Definition is side-effecting and requires `manage_provider_connections`.
   - Schema has no `force` property.
   - Handler returns `queued` when the service queues.
   - Handler returns `human_override_required` without treating it as a transport failure.
-- [ ] Run the focused MCP test.
-- [ ] Add the tool definition and handler in `apps/web/lib/mcp-tools.ts`.
-- [ ] Re-run MCP tests.
+- [x] Run the focused MCP test.
+- [x] Add the tool definition and handler in `apps/web/lib/mcp/packs/self-upgrade-pack.ts`.
+- [x] Compose the pack in `apps/web/lib/mcp-tools.ts` and map `request_self_upgrade` to `admin_write`.
+- [x] Re-run MCP tests.
 - [ ] Commit: `feat: expose governed self-upgrade trigger to agents`.
 
 ## Task 4: Docs And Verification
 
-- [ ] Update `docs/operations/dpf-production-runtime.md` with the new post-merge loop.
-- [ ] Run focused tests:
+- [x] Update `docs/operations/dpf-production-runtime.md` with the new post-merge loop.
+- [x] Run focused tests:
   - `pnpm --filter web exec vitest run lib/self-upgrade/request.test.ts lib/actions/self-upgrade.test.ts <mcp-test-path>`
 - [ ] Run `pnpm --filter web typecheck`.
 - [ ] Run `pnpm --filter web build` if source-local time allows; otherwise record why it was not run.

--- a/docs/superpowers/specs/2026-06-30-agent-safe-self-upgrade-trigger-design.md
+++ b/docs/superpowers/specs/2026-06-30-agent-safe-self-upgrade-trigger-design.md
@@ -1,0 +1,117 @@
+# Agent-Safe Self-Upgrade Trigger Design
+
+Date: 2026-06-30
+Status: Approved for implementation
+Backlog: BI-F5F0AC1D
+Work Capsule: WC-793D9EDA
+
+## Problem
+
+Post-merge verification depends on the live portal at `localhost:3000` serving the merged code. The governed path for advancing that portal already exists: `/ops/self-upgrade` creates a `SelfUpgradeRun`, dispatches `ops/self-upgrade.run`, and the runner performs activity precheck, quiescence, recovery point creation, source preparation, promoter swap, health verification, and cooldown handling.
+
+External agents currently cannot reliably initiate that governed path. Browser automation depends on Chrome/session state, direct compose rebuilds bypass governance, and the read-only preflight tool can only say that the live install must advance.
+
+## Goal
+
+Expose an agent-callable self-upgrade trigger that is equivalent to a human initiating the normal governed upgrade during an allowed off-hours window, while preserving human override as the only path outside that window.
+
+## Non-Goals
+
+- No direct Docker, Compose, promoter, or `promote.sh` execution from MCP.
+- No agent-controlled `force` or emergency override.
+- No new deployment pipeline.
+- No replacement for the existing `/ops/self-upgrade` UI.
+
+## Design
+
+Add a small request service shared by the UI server action and the MCP tool. The service owns durable run creation, duplicate-run suppression, event dispatch, and dispatch-failure handling.
+
+Human UI path:
+- Keeps current behavior.
+- Auth remains `manage_provider_connections`.
+- It may continue to act as a manual operator trigger.
+
+Agent MCP path:
+- New side-effecting MCP tool: `request_self_upgrade`.
+- Required capability: `manage_provider_connections`.
+- Checks the effective self-upgrade window before creating a run.
+- If the install is outside the allowed window, returns `success: true` with `status: "human_override_required"` and no run/event.
+- If the effective window cannot be determined safely, returns `status: "human_override_required"` with the specific reason.
+- If the window is allowed, creates a run and dispatches the same `ops/self-upgrade.run` event the UI uses.
+- Never accepts or forwards `force`.
+
+The request-layer window check should mirror the scheduled runner's effective-window calculation:
+- explicit `SelfUpgradeConfig.maintenanceWindows` wins;
+- otherwise a 24/7 install with a known timezone may use the auto-selected overnight window;
+- otherwise derive from operating hours;
+- if a timezone is needed but unavailable, require human override.
+
+The runner keeps its existing deeper safeguards. The new gate is not a substitute for quiescence; it prevents agents from starting a human-override-class action outside the normal unattended window.
+
+## Result Shape
+
+Allowed:
+
+```json
+{
+  "success": true,
+  "status": "queued",
+  "runId": "SUR-...",
+  "eventIds": ["..."],
+  "triggeredBy": "mcp:<principal-or-user>"
+}
+```
+
+Already active:
+
+```json
+{
+  "success": true,
+  "status": "already_active",
+  "runId": "SUR-..."
+}
+```
+
+Outside window:
+
+```json
+{
+  "success": true,
+  "status": "human_override_required",
+  "reason": "outside-window",
+  "message": "Self-upgrade is outside the allowed maintenance window. Use /ops/self-upgrade for a human override."
+}
+```
+
+Dispatch failure:
+
+```json
+{
+  "success": false,
+  "status": "dispatch_failed",
+  "runId": "SUR-...",
+  "message": "queue-dispatch-failed: ..."
+}
+```
+
+## Tests
+
+- UI action still creates a queued run and dispatches the existing event.
+- Shared request service suppresses duplicate active runs.
+- MCP/agent request queues only when the effective window is open.
+- MCP/agent request returns `human_override_required` outside the window and does not create a run.
+- MCP/agent request returns `human_override_required` when a safe window cannot be determined.
+- MCP definition is side-effecting, grant/capability gated, and has no `force` input.
+- MCP handler returns structured `queued`, `already_active`, `human_override_required`, and `dispatch_failed` results.
+
+## Operational Notes
+
+After this lands and the portal advances, the post-merge verification loop becomes:
+
+1. `verify_live_install_readiness(featureSha)`.
+2. If `MUST-ADVANCE`, call `request_self_upgrade`.
+3. If queued, wait for the live portal SHA to advance.
+4. Re-run preflight.
+5. Exercise the feature on `localhost:3000`.
+
+If `request_self_upgrade` returns `human_override_required`, an agent stops and asks for a human action rather than bypassing the window.


### PR DESCRIPTION
## Summary

Adds an agent-callable governed self-upgrade request path so external agents can advance the live portal through the same quiesced `/ops/self-upgrade` pipeline a human operator uses.

## What changed

- Added `requestSelfUpgrade`, a shared request service for durable run creation, duplicate suppression, Inngest dispatch, dispatch failure handling, and agent maintenance-window gating.
- Refactored the `/ops/self-upgrade` server action to use the shared service as a human/manual trigger.
- Added the `request_self_upgrade` MCP tool in a self-upgrade tool pack, with `manage_provider_connections` capability and `admin_write` coworker grant mapping.
- Documented the post-merge agent verification loop and human override stop condition.

## Safety behavior

Agents can queue the governed upgrade only inside the effective off-hours/maintenance window. Outside that window, or when the safe window cannot be determined, the tool returns `human_override_required` without creating a run or dispatching an event. The tool has no `force` input.

## Validation

- `pnpm --filter web exec vitest run lib/mcp-tools-self-upgrade.test.ts lib/mcp/tool-registry.test.ts lib/tak/agent-grants.test.ts lib/self-upgrade/request.test.ts lib/actions/self-upgrade.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`

The production build completed successfully. It emitted existing Turbopack Edge/NFT tracing warnings, but exited zero.
