### PR TITLE
Add delegated coworker posture context

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1,8 +1,7 @@
 import type { CapabilityKey } from "@/lib/permissions";
 import { can, type UserContext } from "@/lib/permissions";
 import { DISCOVERY_TRIAGE_AGENT_ID, prisma } from "@dpf/db";
-// Runtime kernel-commandment gate (BI-43F95F77). Static imports — executeTool
-// is a hot path; dynamic import per call would tank dispatcher throughput.
+// Static import: executeTool is a hot path; dynamic import per call would hurt throughput.
 import { evaluateExecution } from "@/lib/kernel/runtime-gate";
 import { loadEnforceablePrinciples } from "@/lib/kernel/load-enforceable-principles";
 import { detectSessionClass } from "@/lib/kernel/session-class";

--- a/apps/web/lib/proactivity/delegated-posture.test.ts
+++ b/apps/web/lib/proactivity/delegated-posture.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+import type { ProactivityPlan } from "./proactivity-types";
+import { resolveDelegatedPosture } from "./delegated-posture";
+
+function plan(resolvedLevel: ProactivityPlan["resolvedLevel"]): ProactivityPlan {
+  return {
+    resolvedLevel,
+    policyId: `proactivity:test:${resolvedLevel}`,
+    attentionWindowMinutes: 60,
+    followUpCadenceMinutes: [],
+    maxAttempts: 1,
+    spendClass: resolvedLevel === "assertive" ? "elevated" : "standard",
+    channelPolicy: "preferred-channel",
+    escalationTarget: "attention-surface",
+    actionBoundary: resolvedLevel === "quiet" ? "advise" : "propose",
+    explanation: `${resolvedLevel} test plan`,
+    evidenceRefs: [{ kind: "test", id: resolvedLevel }],
+  };
+}
+
+const balancedPriority: GoldenTrianglePreference = {
+  preset: "balanced",
+  qualityWeight: 1 / 3,
+  costWeight: 1 / 3,
+  timeWeight: 1 / 3,
+};
+
+const fastPriority: GoldenTrianglePreference = {
+  preset: "fast",
+  qualityWeight: 0.1,
+  costWeight: 0.1,
+  timeWeight: 0.8,
+};
+
+const assuredPriority: GoldenTrianglePreference = {
+  preset: "assured",
+  qualityWeight: 0.8,
+  costWeight: 0.1,
+  timeWeight: 0.1,
+};
+
+describe("resolveDelegatedPosture", () => {
+  it("inherits caller assertiveness and time priority as advisory context", () => {
+    const resolved = resolveDelegatedPosture({
+      caller: {
+        agentId: "dispatch-coordinator",
+        parentTaskRunId: "TR-PARENT",
+        proactivityPlan: plan("assertive"),
+        priority: fastPriority,
+      },
+      receiver: {
+        agentId: "parts-specialist",
+        localProactivityPlan: plan("balanced"),
+        localPriority: balancedPriority,
+      },
+    });
+
+    expect(resolved.executionAllowed).toBe(true);
+    expect(resolved.proactivity).toMatchObject({
+      inheritedLevel: "assertive",
+      localLevel: "balanced",
+      effectiveLevel: "assertive",
+      source: "inherited-bias",
+      actionBoundary: "propose",
+    });
+    expect(resolved.priority).toMatchObject({
+      source: "inherited-bias",
+      dominantAxis: "time",
+      effective: fastPriority,
+    });
+    expect(resolved.metadata).toMatchObject({
+      source: "delegated-coworker",
+      fromAgentId: "dispatch-coordinator",
+      toAgentId: "parts-specialist",
+      parentTaskRunId: "TR-PARENT",
+    });
+  });
+
+  it("keeps receiver quality floor ahead of caller time bias", () => {
+    const resolved = resolveDelegatedPosture({
+      caller: {
+        agentId: "build-coordinator",
+        proactivityPlan: plan("assertive"),
+        priority: fastPriority,
+      },
+      receiver: {
+        agentId: "security-reviewer",
+        localProactivityPlan: plan("balanced"),
+        localPriority: assuredPriority,
+        constraints: {
+          qualityCritical: true,
+          regulated: true,
+          reason: "Security review cannot trade away quality for speed.",
+        },
+      },
+    });
+
+    expect(resolved.executionAllowed).toBe(true);
+    expect(resolved.priority).toMatchObject({
+      source: "receiver-override",
+      dominantAxis: "quality",
+      effective: assuredPriority,
+    });
+    expect(resolved.proactivity.actionBoundary).toBe("propose");
+    expect(resolved.proactivity.explanation).toContain("Security review cannot trade away quality");
+  });
+
+  it("uses receiver local posture when no caller posture is present", () => {
+    const resolved = resolveDelegatedPosture({
+      caller: {
+        agentId: "researcher",
+      },
+      receiver: {
+        agentId: "tax-specialist",
+        localProactivityPlan: plan("balanced"),
+        localPriority: assuredPriority,
+      },
+    });
+
+    expect(resolved.executionAllowed).toBe(true);
+    expect(resolved.proactivity.source).toBe("receiver-local");
+    expect(resolved.proactivity.effectiveLevel).toBe("balanced");
+    expect(resolved.priority.source).toBe("receiver-local");
+    expect(resolved.priority.effective).toBe(assuredPriority);
+  });
+});

--- a/apps/web/lib/proactivity/delegated-posture.ts
+++ b/apps/web/lib/proactivity/delegated-posture.ts
@@ -1,0 +1,185 @@
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+import type { ProactivityLevel, ProactivityPlan } from "./proactivity-types";
+
+type PriorityAxis = "quality" | "cost" | "time" | "balanced";
+type PostureSource = "receiver-local" | "inherited-bias" | "receiver-override";
+
+export type DelegatedPostureInput = {
+  caller: {
+    agentId: string;
+    parentTaskRunId?: string | null;
+    proactivityPlan?: ProactivityPlan | null;
+    priority?: GoldenTrianglePreference | null;
+  };
+  receiver: {
+    agentId: string;
+    localProactivityPlan: ProactivityPlan;
+    localPriority?: GoldenTrianglePreference | null;
+    constraints?: {
+      regulated?: boolean;
+      qualityCritical?: boolean;
+      reason?: string | null;
+    };
+  };
+};
+
+export type ResolvedDelegatedPosture = {
+  executionAllowed: true;
+  proactivity: {
+    inheritedLevel: ProactivityLevel | null;
+    localLevel: ProactivityLevel;
+    effectiveLevel: ProactivityLevel;
+    source: PostureSource;
+    actionBoundary: ProactivityPlan["actionBoundary"];
+    explanation: string;
+  };
+  priority: {
+    inherited: GoldenTrianglePreference | null;
+    local: GoldenTrianglePreference | null;
+    effective: GoldenTrianglePreference | null;
+    source: PostureSource;
+    dominantAxis: PriorityAxis;
+    explanation: string;
+  };
+  metadata: {
+    source: "delegated-coworker";
+    fromAgentId: string;
+    toAgentId: string;
+    parentTaskRunId: string | null;
+  };
+};
+
+const LEVEL_RANK: Record<ProactivityLevel, number> = {
+  quiet: 0,
+  balanced: 1,
+  assertive: 2,
+};
+
+export function resolveDelegatedPosture(input: DelegatedPostureInput): ResolvedDelegatedPosture {
+  const localPlan = input.receiver.localProactivityPlan;
+  const inheritedPlan = input.caller.proactivityPlan ?? null;
+  const receiverOverride = Boolean(input.receiver.constraints?.regulated || input.receiver.constraints?.qualityCritical);
+  const proactivity = resolveProactivity({
+    inherited: inheritedPlan?.resolvedLevel ?? null,
+    local: localPlan.resolvedLevel,
+    actionBoundary: localPlan.actionBoundary,
+    receiverOverride,
+    overrideReason: input.receiver.constraints?.reason ?? null,
+  });
+  const priority = resolvePriority({
+    inherited: input.caller.priority ?? null,
+    local: input.receiver.localPriority ?? null,
+    receiverOverride,
+    overrideReason: input.receiver.constraints?.reason ?? null,
+  });
+
+  return {
+    executionAllowed: true,
+    proactivity,
+    priority,
+    metadata: {
+      source: "delegated-coworker",
+      fromAgentId: input.caller.agentId,
+      toAgentId: input.receiver.agentId,
+      parentTaskRunId: input.caller.parentTaskRunId ?? null,
+    },
+  };
+}
+
+function resolveProactivity(input: {
+  inherited: ProactivityLevel | null;
+  local: ProactivityLevel;
+  actionBoundary: ProactivityPlan["actionBoundary"];
+  receiverOverride: boolean;
+  overrideReason: string | null;
+}): ResolvedDelegatedPosture["proactivity"] {
+  if (!input.inherited) {
+    return {
+      inheritedLevel: null,
+      localLevel: input.local,
+      effectiveLevel: input.local,
+      source: "receiver-local",
+      actionBoundary: input.actionBoundary,
+      explanation: "No caller proactivity was provided, so the receiving coworker's local policy applies.",
+    };
+  }
+
+  if (input.receiverOverride && LEVEL_RANK[input.local] >= LEVEL_RANK[input.inherited]) {
+    return {
+      inheritedLevel: input.inherited,
+      localLevel: input.local,
+      effectiveLevel: input.local,
+      source: "receiver-override",
+      actionBoundary: input.actionBoundary,
+      explanation: input.overrideReason ?? "The receiving coworker's local risk or quality policy takes precedence.",
+    };
+  }
+
+  const effective = LEVEL_RANK[input.inherited] > LEVEL_RANK[input.local] ? input.inherited : input.local;
+  return {
+    inheritedLevel: input.inherited,
+    localLevel: input.local,
+    effectiveLevel: effective,
+    source: effective === input.local ? "receiver-local" : "inherited-bias",
+    actionBoundary: input.actionBoundary,
+    explanation:
+      input.receiverOverride && input.overrideReason
+        ? `${input.overrideReason} Caller proactivity remains advisory and cannot expand authority.`
+        : effective === input.local
+          ? "The receiving coworker's local proactivity is already at least as strong as the caller context."
+          : "The caller context increases persistence for this delegated subtask without changing authority.",
+  };
+}
+
+function resolvePriority(input: {
+  inherited: GoldenTrianglePreference | null;
+  local: GoldenTrianglePreference | null;
+  receiverOverride: boolean;
+  overrideReason: string | null;
+}): ResolvedDelegatedPosture["priority"] {
+  if (!input.inherited) {
+    return {
+      inherited: null,
+      local: input.local,
+      effective: input.local,
+      source: "receiver-local",
+      dominantAxis: dominantAxis(input.local),
+      explanation: "No caller priority posture was provided, so the receiving coworker's local priority applies.",
+    };
+  }
+
+  if (input.receiverOverride && dominantAxis(input.local) === "quality") {
+    return {
+      inherited: input.inherited,
+      local: input.local,
+      effective: input.local,
+      source: "receiver-override",
+      dominantAxis: "quality",
+      explanation: input.overrideReason ?? "The receiving coworker's quality floor takes precedence over caller priority.",
+    };
+  }
+
+  return {
+    inherited: input.inherited,
+    local: input.local,
+    effective: input.inherited,
+    source: "inherited-bias",
+    dominantAxis: dominantAxis(input.inherited),
+    explanation: "The caller priority posture is advisory context for the delegated subtask.",
+  };
+}
+
+function dominantAxis(priority: GoldenTrianglePreference | null): PriorityAxis {
+  if (!priority) return "balanced";
+  const weights = {
+    quality: priority.qualityWeight,
+    cost: priority.costWeight,
+    time: priority.timeWeight,
+  };
+  if (Math.abs(weights.quality - weights.cost) < 0.04 && Math.abs(weights.quality - weights.time) < 0.04) {
+    return "balanced";
+  }
+  if (weights.quality >= weights.cost && weights.quality >= weights.time) return "quality";
+  if (weights.cost >= weights.time) return "cost";
+  return "time";
+}

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -772,21 +772,16 @@ describe("COWORKER_READ_BASELINE_GRANTS — page visibility + docs/source/code-g
 
   it("unlocks the page coordination, docs, source, and code-graph read tools", () => {
     const baseline = [...COWORKER_READ_BASELINE_GRANTS];
-    // The exact tools the operator's Dev Loop question needed:
     expect(isToolAllowedByGrants("get_runtime_coordination_map", baseline)).toBe(true);
     expect(isToolAllowedByGrants("list_nonprod_environment_leases", baseline)).toBe(true);
-    // Documentation:
     expect(isToolAllowedByGrants("doc_search", baseline)).toBe(true);
     expect(isToolAllowedByGrants("doc_load", baseline)).toBe(true);
-    // Source code:
     expect(isToolAllowedByGrants("read_project_file", baseline)).toBe(true);
     expect(isToolAllowedByGrants("search_project_files", baseline)).toBe(true);
     expect(isToolAllowedByGrants("read_source_at_version", baseline)).toBe(true);
-    // Code graph ("the code graph especially"):
     expect(isToolAllowedByGrants("search_code_graph", baseline)).toBe(true);
     expect(isToolAllowedByGrants("trace_code_surface", baseline)).toBe(true);
     expect(isToolAllowedByGrants("find_related_tests", baseline)).toBe(true);
-    // Knowledge / wiki:
     expect(isToolAllowedByGrants("search_knowledge", baseline)).toBe(true);
     expect(isToolAllowedByGrants("wiki_query", baseline)).toBe(true);
   });

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -222,6 +222,67 @@ describe("createAutonomousWorkRun", () => {
     });
   });
 
+  it("writes delegated posture metadata without letting generic metadata clobber it", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "tr_internal_delegate",
+      taskRunId: "TR-CHAT-DELEG",
+      contextId: "thread-child",
+    } as never);
+
+    const delegatedPosture = {
+      executionAllowed: true as const,
+      proactivity: {
+        inheritedLevel: "assertive" as const,
+        localLevel: "balanced" as const,
+        effectiveLevel: "assertive" as const,
+        source: "inherited-bias" as const,
+        actionBoundary: "propose" as const,
+        explanation: "Caller context increases persistence without changing authority.",
+      },
+      priority: {
+        inherited: { preset: "fast" as const, qualityWeight: 0.1, costWeight: 0.1, timeWeight: 0.8 },
+        local: { preset: "balanced" as const, qualityWeight: 1 / 3, costWeight: 1 / 3, timeWeight: 1 / 3 },
+        effective: { preset: "fast" as const, qualityWeight: 0.1, costWeight: 0.1, timeWeight: 0.8 },
+        source: "inherited-bias" as const,
+        dominantAxis: "time" as const,
+        explanation: "Caller priority is advisory context.",
+      },
+      metadata: {
+        source: "delegated-coworker" as const,
+        fromAgentId: "dispatch-coordinator",
+        toAgentId: "parts-specialist",
+        parentTaskRunId: "TR-PARENT",
+      },
+    };
+
+    const { createAutonomousWorkRun } = await import("./autonomous-work-run");
+
+    await createAutonomousWorkRun({
+      trigger: "interactive",
+      userId: "user-1",
+      agentId: "parts-specialist",
+      routeContext: "/storefront/schedule",
+      title: "Find replacement part",
+      objective: "Find the replacement part for a delayed appointment.",
+      prompt: "Find the replacement part for a delayed appointment.",
+      threadId: "thread-child",
+      parentTaskRunId: "TR-PARENT",
+      metadata: {
+        delegatedPosture: { executionAllowed: false },
+        context: "field-dispatch",
+      },
+      delegatedPosture,
+    });
+
+    const arg = vi.mocked(prisma.taskRun.create).mock.calls[0]?.[0];
+    expect(arg?.data?.a2aMetadata).toMatchObject({
+      trigger: "interactive",
+      context: "field-dispatch",
+      delegatedPosture,
+    });
+  });
+
   it("finds the newest unarchived TaskRun for an interactive thread", async () => {
     const { prisma } = await import("@dpf/db");
     vi.mocked(prisma.taskRun.findFirst).mockResolvedValue({ taskRunId: "TR-CHAT-123" } as never);

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "crypto";
 import { prisma } from "@dpf/db";
+import type { Prisma } from "@dpf/db";
 import type { ChatMessage } from "@/lib/ai-inference";
 import { resolveCoworkerReviewPattern } from "@/lib/golden-triangle/coworker-review";
 import { reviewCoworkerDraft } from "@/lib/tak/coworker-inline-review";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { AgentEvent } from "@/lib/tak/agent-event-bus";
+import type { ResolvedDelegatedPosture } from "@/lib/proactivity/delegated-posture";
 import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 
 /** Best-effort latest user-turn text, for the reviewer's context. */
@@ -64,6 +66,7 @@ export type AutonomousWorkRunInput = {
   };
   metadata?: Record<string, unknown>;
   proactivity?: ProactivityPlan;
+  delegatedPosture?: ResolvedDelegatedPosture;
 };
 
 const TRIGGER_PREFIX: Record<AutonomousWorkTrigger, string> = {
@@ -96,6 +99,13 @@ export async function createAutonomousWorkRun(
   input: AutonomousWorkRunInput,
 ): Promise<AutonomousWorkRunRef> {
   const threadId = input.threadId ?? null;
+  const a2aMetadata = {
+    trigger: input.trigger,
+    ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
+    ...(input.metadata ?? {}),
+    ...(input.proactivity ? { proactivity: input.proactivity } : {}),
+    ...(input.delegatedPosture ? { delegatedPosture: input.delegatedPosture } : {}),
+  } as Prisma.InputJsonValue;
 
   return prisma.taskRun.create({
     data: {
@@ -112,12 +122,7 @@ export async function createAutonomousWorkRun(
       source: taskRunSourceForTrigger(input.trigger),
       status: initialStatusForTrigger(input.trigger),
       authorityScope: input.authorityScope ?? [],
-      a2aMetadata: {
-        trigger: input.trigger,
-        ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
-        ...(input.metadata ?? {}),
-        ...(input.proactivity ? { proactivity: input.proactivity } : {}),
-      },
+      a2aMetadata,
     },
     select: { id: true, taskRunId: true, contextId: true },
   });

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -244,7 +244,9 @@ The resolver must also intersect with governance:
 - Cost/budget policy constrains `spendClass`.
 - Decision-routing governance constrains legal, tax, compliance, and business judgment responses.
 
-Delegated coworker work is a future resolution layer, not a V1 blocker. If a coworker delegates subtasks to other coworkers, the subtasks should still execute once legitimately delegated; proactivity does not decide whether the work exists. The initiating task may eventually pass advisory context posture, including its proactivity level and golden-triangle cost/quality/time intent. The receiving coworker must then resolve that advisory context against its own local policy, mission, risk, authority, and quality floor. A time-priority caller can bias subtasks toward time, but a receiving coworker responsible for regulated, high-risk, or quality-critical work can override toward higher quality. Track this as `BI-424CFE7A`; do not implement propagation in V1.
+Delegated coworker work is a separate resolution layer, not a V1 blocker. If a coworker delegates subtasks to other coworkers, the subtasks should still execute once legitimately delegated; proactivity does not decide whether the work exists. The initiating task may pass advisory context posture, including its proactivity level and golden-triangle cost/quality/time intent. The receiving coworker must then resolve that advisory context against its own local policy, mission, risk, authority, and quality floor. A time-priority caller can bias subtasks toward time, but a receiving coworker responsible for regulated, high-risk, or quality-critical work can override toward higher quality. `BI-424CFE7A` owns this propagation work.
+
+Implementation status: PR #2524 adds the first shared substrate for `BI-424CFE7A`: `apps/web/lib/proactivity/delegated-posture.ts` resolves advisory caller proactivity and golden-triangle posture against receiver local policy, and `createAutonomousWorkRun` can persist the resolved result to `TaskRun.a2aMetadata.delegatedPosture`. This does not yet wire automatic propagation into every coworker handoff path.
 
 ## 7. Defaults
 
@@ -507,7 +509,7 @@ Right-sizing controls process intensity for development work. Proactivity contro
 
 ### Proactivity vs delegated coworker execution
 
-Delegation decides which coworker owns a subtask. Proactivity decides how persistently that coworker should monitor, follow up, and escalate within its authority. In V1, subtasks execute according to the receiving coworker's local policy. Future work may pass an initiating context override for proactivity and golden-triangle posture, but the receiving coworker's local risk and quality requirements must remain able to override it.
+Delegation decides which coworker owns a subtask. Proactivity decides how persistently that coworker should monitor, follow up, and escalate within its authority. Subtasks execute according to the receiving coworker's local policy unless an initiating context supplies advisory posture that the receiver can safely honor. The receiving coworker's local risk and quality requirements must remain able to override caller proactivity and golden-triangle intent.
 
 ### Proactivity vs Attention Surface
 
@@ -571,6 +573,21 @@ Acceptance:
 - scheduled task runs write `a2aMetadata.proactivity`.
 - failures and ignored attempts can escalate to Attention Surface according to plan.
 - no scheduled task bypasses existing owner/tool/HITL checks.
+
+### Slice 2A: Delegated coworker posture substrate
+
+Files:
+
+- Create `apps/web/lib/proactivity/delegated-posture.ts`
+- Test `apps/web/lib/proactivity/delegated-posture.test.ts`
+- Modify `apps/web/lib/tak/autonomous-work-run.ts`
+
+Acceptance:
+
+- delegated coworker subtasks are never blocked solely because of the caller's proactivity setting.
+- caller proactivity and golden-triangle priority are inherited as advisory context.
+- receiver local policy can override caller posture for regulated, risk-sensitive, or quality-critical work.
+- `TaskRun.a2aMetadata.delegatedPosture` records the resolved posture after generic metadata is merged, so callers cannot accidentally clobber the governed result.
 
 ### Slice 3: Coworker panel/profile UX
 


### PR DESCRIPTION
## Summary
- add a delegated posture resolver for coworker-to-coworker task handoffs
- preserve receiver local authority boundaries while inheriting caller proactivity and golden-triangle intent as advisory context
- persist resolved delegated posture metadata on autonomous TaskRuns without allowing generic metadata to clobber it

## Verification
- pnpm --filter web exec vitest run lib/proactivity/delegated-posture.test.ts lib/tak/autonomous-work-run.test.ts lib/proactivity/proactivity-resolver.test.ts lib/proactivity/proactivity-change-proposal.test.ts
- pnpm --filter web typecheck
- pnpm --filter web build

## Backlog
- BI-424CFE7A