### PR TITLE
Compose Build Studio custodian with proactivity policy

### DIFF
--- a/apps/web/components/build/BuildStudioCustodianCallout.test.tsx
+++ b/apps/web/components/build/BuildStudioCustodianCallout.test.tsx
@@ -15,6 +15,19 @@ function prompt(overrides: Partial<BuildStudioCustodianPrompt> = {}): BuildStudi
     statusLabel: "Needs evidence",
     intent: "warning",
     details: ["UX evidence is missing.", "Acceptance evidence is missing."],
+    proactivityPlan: {
+      resolvedLevel: "assertive",
+      policyId: "proactivity:build-studio-custodian:assertive",
+      attentionWindowMinutes: 30,
+      followUpCadenceMinutes: [30, 60, 120],
+      maxAttempts: 3,
+      spendClass: "elevated",
+      channelPolicy: "urgent-channel",
+      escalationTarget: "platform-operator",
+      actionBoundary: "propose",
+      explanation: "Build Studio work is blocked or stalled.",
+      evidenceRefs: [{ kind: "activity-family", id: "build-studio-custodian" }],
+    },
     ...overrides,
   };
 }

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
@@ -13,6 +13,7 @@ import {
   normalizeHappyPathState,
   type FeatureBuildRow,
 } from "@/lib/feature-build-types";
+import type { BuildStudioCustodianPrompt } from "./build-studio-custodian";
 
 const { mockAdvanceBuildPhase, mockCaptureDecisionInteraction, mockRerunPlanReview, mockResumeBuildImplementation } = vi.hoisted(() => ({
   mockAdvanceBuildPhase: vi.fn(),
@@ -59,6 +60,37 @@ beforeEach(() => {
     message: "Plan review passed; implementation is unlocked.",
   });
 });
+
+function custodianPrompt(
+  overrides: Partial<BuildStudioCustodianPrompt> = {},
+): BuildStudioCustodianPrompt {
+  return {
+    dismissKey: "custodian",
+    title: "I can keep this review moving.",
+    whyNow: "UX verification still needs clean evidence.",
+    recommendedAction: "I can collect the acceptance evidence.",
+    primaryLabel: "Let AI Coworker handle it",
+    primaryAction: "coworker",
+    coworkerPrompt: "Act as the Build Studio custodian.",
+    statusLabel: "Needs evidence",
+    intent: "warning",
+    details: ["Review evidence is missing."],
+    proactivityPlan: {
+      resolvedLevel: "assertive",
+      policyId: "proactivity:build-studio-custodian:assertive",
+      attentionWindowMinutes: 30,
+      followUpCadenceMinutes: [30, 60, 120],
+      maxAttempts: 3,
+      spendClass: "elevated",
+      channelPolicy: "urgent-channel",
+      escalationTarget: "platform-operator",
+      actionBoundary: "propose",
+      explanation: "Build Studio work is blocked or stalled.",
+      evidenceRefs: [{ kind: "activity-family", id: "build-studio-custodian" }],
+    },
+    ...overrides,
+  };
+}
 
 function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
   return {
@@ -500,18 +532,9 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
         build={makeBuild({ phase: "review", decisionInteraction: null })}
         action={implementationAction({ primaryLabel: "Run UX Verification" })}
         compact
-        custodianPrompt={{
+        custodianPrompt={custodianPrompt({
           dismissKey: "custodian-one",
-          title: "I can keep this review moving.",
-          whyNow: "UX verification still needs clean evidence.",
-          recommendedAction: "I can collect the acceptance evidence.",
-          primaryLabel: "Let AI Coworker handle it",
-          primaryAction: "coworker",
-          coworkerPrompt: "Act as the Build Studio custodian.",
-          statusLabel: "Needs evidence",
-          intent: "warning",
-          details: ["Review evidence is missing."],
-        }}
+        })}
       />,
     );
 
@@ -528,18 +551,9 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
         build={makeBuild({ phase: "review", decisionInteraction: null })}
         action={implementationAction({ primaryLabel: "Run UX Verification" })}
         compact
-        custodianPrompt={{
+        custodianPrompt={custodianPrompt({
           dismissKey: "custodian-two",
-          title: "I can keep this review moving.",
-          whyNow: "UX verification still needs clean evidence.",
-          recommendedAction: "I can collect the acceptance evidence.",
-          primaryLabel: "Let AI Coworker handle it",
-          primaryAction: "coworker",
-          coworkerPrompt: "Act as the Build Studio custodian.",
-          statusLabel: "Needs evidence",
-          intent: "warning",
-          details: ["Review evidence is missing."],
-        }}
+        })}
       />,
     );
 
@@ -558,18 +572,17 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
         build={makeBuild({ phase: "plan", decisionInteraction: null })}
         action={implementationAction()}
         compact
-        custodianPrompt={{
+        custodianPrompt={custodianPrompt({
           dismissKey: "custodian-three",
           title: "I found the recovery path.",
           whyNow: "This stop has a guided repair.",
           recommendedAction: "Try the guided fix now.",
           primaryLabel: "Start Implementation",
           primaryAction: "workflow",
-          coworkerPrompt: "Act as the Build Studio custodian.",
           statusLabel: "Blocked",
           intent: "danger",
           details: ["Use the existing dispatch."],
-        }}
+        })}
       />,
     );
 

--- a/apps/web/components/build/build-studio-custodian.test.ts
+++ b/apps/web/components/build/build-studio-custodian.test.ts
@@ -115,6 +115,26 @@ describe("deriveBuildStudioCustodianPrompt", () => {
     expect(prompt?.coworkerPrompt).toContain("Act as the Build Studio custodian");
 });
 
+  it("resolves shared assertive proactivity for blocked or stalled custodian prompts", () => {
+    const build = makeBuild({ uxVerificationStatus: "failed" });
+    const action = deriveBuildStudioWorkflowAction({ build, governedBacklogEnabled: true });
+    const prompt = deriveBuildStudioCustodianPrompt({ build, action, progressVisibility: progress() });
+
+    expect(prompt?.proactivityPlan).toMatchObject({
+      resolvedLevel: "assertive",
+      policyId: "proactivity:build-studio-custodian:assertive",
+      escalationTarget: "platform-operator",
+      actionBoundary: "propose",
+    });
+    expect(prompt?.proactivityPlan.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        { kind: "activity-family", id: "build-studio-custodian" },
+        { kind: "status-signal", id: "blocked" },
+        { kind: "route-context", id: "/build" },
+      ]),
+    );
+  });
+
   it("stays quiet while an execution step is actively working", () => {
     const build = makeBuild({
       phase: "build",

--- a/apps/web/components/build/build-studio-custodian.ts
+++ b/apps/web/components/build/build-studio-custodian.ts
@@ -1,6 +1,8 @@
 import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import type { Intent } from "@/components/ui/report-kit";
+import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
+import type { ProactivityPlan, ProactivityResolverInput } from "@/lib/proactivity/proactivity-types";
 import {
   deriveBuildStudioOperatorGuidance,
   type BuildStudioWorkflowAction,
@@ -19,6 +21,7 @@ export type BuildStudioCustodianPrompt = {
   statusLabel: string;
   intent: Intent;
   details: string[];
+  proactivityPlan: ProactivityPlan;
 };
 
 type CustodianPromptInput = {
@@ -76,6 +79,22 @@ function isUxReviewGap(
   );
 }
 
+function resolveCustodianStatusSignal(input: {
+  uxReviewGap: boolean;
+  blockedByEvidence: boolean;
+  technicalRecovery: boolean;
+  isQuietReview: boolean;
+  isQuietBuild: boolean;
+}): NonNullable<ProactivityResolverInput["statusSignal"]> {
+  if (input.uxReviewGap || input.blockedByEvidence || input.technicalRecovery) {
+    return "blocked";
+  }
+  if (input.isQuietReview || input.isQuietBuild) {
+    return "stalled";
+  }
+  return "normal";
+}
+
 export function deriveBuildStudioCustodianPrompt({
   build,
   action,
@@ -112,6 +131,18 @@ export function deriveBuildStudioCustodianPrompt({
   }
 
   const dismissKey = buildDismissKey(build, action, progressVisibility);
+  const proactivityPlan = resolveProactivityPlan({
+    activityFamily: "build-studio-custodian",
+    agentId: build.claimedByAgentId,
+    routeContext: "/build",
+    statusSignal: resolveCustodianStatusSignal({
+      uxReviewGap,
+      blockedByEvidence,
+      technicalRecovery,
+      isQuietReview,
+      isQuietBuild,
+    }),
+  });
 
   if (uxReviewGap) {
     return {
@@ -133,6 +164,7 @@ export function deriveBuildStudioCustodianPrompt({
         "The review is not ready to release until UX evidence and acceptance evidence agree.",
         "If the retry already started work, wait for that evidence first. If it did not, use the existing Build Studio recovery path instead of asking the human to diagnose logs.",
       ],
+      proactivityPlan,
     };
   }
 
@@ -158,6 +190,7 @@ export function deriveBuildStudioCustodianPrompt({
         action.message,
         guidance.recoveryHint ?? "Use the in-place recovery first; escalate only if it cannot make progress.",
       ].filter(Boolean),
+      proactivityPlan,
     };
   }
 
@@ -179,6 +212,7 @@ export function deriveBuildStudioCustodianPrompt({
         action.disabledReason ?? "Required evidence is missing.",
         "The human should see the conclusion and one next action, not raw workflow internals.",
       ],
+      proactivityPlan,
     };
   }
 
@@ -199,5 +233,6 @@ export function deriveBuildStudioCustodianPrompt({
       "The surface should stay quiet while work progresses.",
       "A quiet build only interrupts when the next step is useful for keeping delivery moving.",
     ],
+    proactivityPlan,
   };
 }

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -446,6 +446,8 @@ Accepted changes write an auditable policy override. Dismissed proposals should 
 5. Spend class remains bounded by Build Studio right-sizing and cost governance.
 6. Do not fork the shipped Build Studio custodian implementation from `BI-ACB04A21`; consume or expose the shared `ProactivityPlan` at existing Build Studio progress/stall/escalation seams.
 
+Implementation note: the Build Studio custodian prompt derivation consumes the shared `build-studio-custodian` proactivity resolver and attaches the resulting `ProactivityPlan` to the prompt object. The visible callout remains outcome-focused: one "why now" line, one recommended action, snooze/show-why alternatives, and no default exposure of internal build IDs or diagnostic queues.
+
 User-facing rule: Build Studio and every other consuming surface should remain quiet while work is progressing, then surface one recommended action with bounded alternatives such as snooze/show why. Internal IDs, queues, branches, and diagnostic jargon remain hidden by default and appear only in engineer-oriented disclosures.
 
 ## 11. Data Model Strategy


### PR DESCRIPTION
## Summary
- attach the shared build-studio-custodian ProactivityPlan to Build Studio custodian prompts
- keep the visible callout focused on why now, one recommended action, show-why, and snooze
- update tests and the proactivity policy spec for this consumption slice

## Verification
- pnpm --filter web exec vitest run components/build/build-studio-custodian.test.ts components/build/BuildStudioCustodianCallout.test.tsx components/build/BuildStudioWorkflowActionCard.test.tsx lib/proactivity/proactivity-resolver.test.ts
- pnpm --filter web typecheck
- node scripts/check-module-size.mjs
- pnpm --filter web build

## Backlog
- BI-5B6F666F