### PR TITLE
Stage field dispatch notifications with proactivity plans

### DIFF
--- a/apps/web/lib/governance/action-proposal-presentation.test.ts
+++ b/apps/web/lib/governance/action-proposal-presentation.test.ts
@@ -3,6 +3,37 @@ import { describe, expect, it } from "vitest";
 import { projectActionProposalPresentation } from "./action-proposal-presentation";
 
 describe("projectActionProposalPresentation", () => {
+  it("renders field-dispatch notification proposals with why-now context", () => {
+    const presentation = projectActionProposalPresentation({
+      proposalId: "AP-DISPATCH",
+      actionType: "field_dispatch_customer_notification",
+      parameters: {
+        kind: "field-dispatch-customer-notification",
+        jobId: "JOB-1",
+        recommendedAction: "Send running-late customer update",
+        whyNow: "Customer appointment timing is operationally load-bearing.",
+        intent: {
+          event: "running-late",
+          jobId: "JOB-1",
+          urgency: "urgent",
+          title: "Running a little behind",
+          body: "We're running a bit behind.",
+        },
+        proactivity: {
+          resolvedLevel: "assertive",
+          actionBoundary: "propose",
+        },
+      },
+    });
+
+    expect(presentation.title).toBe("Send running-late customer update");
+    expect(presentation.shortLabel).toBe("Customer update");
+    expect(presentation.summary).toBe("Why now: Customer appointment timing is operationally load-bearing.");
+    expect(presentation.details).toContainEqual({ label: "Proactivity", value: "Assertive" });
+    expect(presentation.details).toContainEqual({ label: "Approval", value: "Asks first" });
+    expect(presentation.summary).not.toMatch(/AP-|queue|diagnostic/i);
+  });
+
   it("renders proactivity change proposals without implying broader authority", () => {
     const presentation = projectActionProposalPresentation({
       proposalId: "AP-PROACTIVE",

--- a/apps/web/lib/governance/action-proposal-presentation.ts
+++ b/apps/web/lib/governance/action-proposal-presentation.ts
@@ -3,6 +3,7 @@ import {
   parseProactivityChangeProposalParameters,
 } from "@/lib/proactivity/proactivity-change-proposal";
 import { getProactivityLevelCopy } from "@/lib/proactivity/proactivity-copy";
+import { FIELD_DISPATCH_CUSTOMER_NOTIFICATION_ACTION } from "@/lib/proactivity/field-dispatch-runtime";
 
 export type ActionProposalPresentationInput = {
   proposalId: string;
@@ -28,6 +29,25 @@ const ACTIVITY_HARNESS_CONFIDENCE_OVERRIDE_ACTION =
 export function projectActionProposalPresentation(
   input: ActionProposalPresentationInput,
 ): ActionProposalPresentation {
+  if (input.actionType === FIELD_DISPATCH_CUSTOMER_NOTIFICATION_ACTION) {
+    const parameters = asRecord(input.parameters);
+    const recommendedAction = readString(parameters?.recommendedAction);
+    const whyNow = readString(parameters?.whyNow);
+    const proactivity = asRecord(parameters?.proactivity);
+    const level = readString(proactivity?.resolvedLevel);
+    const boundary = readString(proactivity?.actionBoundary);
+
+    return {
+      title: recommendedAction ?? "Send customer update",
+      shortLabel: "Customer update",
+      summary: `Why now: ${whyNow ?? "A customer-visible dispatch commitment needs attention."}`,
+      details: [
+        { label: "Proactivity", value: level ? readableProactivityLevel(level) : "Balanced" },
+        { label: "Approval", value: readableActionBoundary(boundary) },
+      ],
+    };
+  }
+
   if (input.actionType === PROACTIVITY_CHANGE_ACTION) {
     const parameters = parseProactivityChangeProposalParameters(input.parameters);
     if (parameters) {
@@ -78,6 +98,19 @@ export function projectActionProposalPresentation(
     summary: `Proposed action ${input.actionType}.`,
     details: [],
   };
+}
+
+function readableProactivityLevel(level: string): string {
+  if (level === "quiet" || level === "balanced" || level === "assertive") {
+    return getProactivityLevelCopy(level).label;
+  }
+  return humanizeActionType(level);
+}
+
+function readableActionBoundary(boundary: string | null): string {
+  if (boundary === "advise") return "Advises only";
+  if (boundary === "preauthorized") return "Pre-approved actions";
+  return "Asks first";
 }
 
 function readableScope(scope: string, scopeRef?: string | null): string {

--- a/apps/web/lib/proactivity/field-dispatch-runtime.test.ts
+++ b/apps/web/lib/proactivity/field-dispatch-runtime.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { planDepartureActions } from "@dpf/validators";
+
+import { buildFieldDispatchNotificationProposals } from "./field-dispatch-runtime";
+
+describe("buildFieldDispatchNotificationProposals", () => {
+  it("attaches assertive proactivity to running-late customer notification proposals", () => {
+    const actions = planDepartureActions({
+      jobId: "JOB-1",
+      arrivalEtaIso: "2026-06-30T19:15:00.000Z",
+      windowEndIso: "2026-06-30T19:00:00.000Z",
+      notificationVars: { company: "Acme HVAC", etaText: "2:15 PM" },
+    });
+
+    const proposals = buildFieldDispatchNotificationProposals({
+      actions,
+      agentId: "dispatcher",
+      routeContext: "/storefront",
+      archetype: {
+        archetypeId: "hvac-services",
+        demandSignature: "emergency-reactive",
+        capacityUnit: "slot-hours",
+      },
+    });
+
+    const late = proposals.find((proposal) => proposal.parameters.intent.event === "running-late");
+    expect(late).toMatchObject({
+      actionType: "field_dispatch_customer_notification",
+      parameters: {
+        kind: "field-dispatch-customer-notification",
+        jobId: "JOB-1",
+        recommendedAction: "Send running-late customer update",
+        proactivity: {
+          resolvedLevel: "assertive",
+          channelPolicy: "urgent-channel",
+          escalationTarget: "dispatcher",
+          actionBoundary: "propose",
+        },
+      },
+    });
+    expect(late?.parameters.proactivity.evidenceRefs).toContainEqual({
+      kind: "dispatch-event",
+      id: "running-late",
+    });
+    expect(late?.parameters.whyNow).toMatch(/customer appointment timing/i);
+  });
+
+  it("keeps on-my-way customer notification proposals balanced unless appointment risk is elevated", () => {
+    const actions = planDepartureActions({
+      jobId: "JOB-2",
+      arrivalEtaIso: "2026-06-30T18:30:00.000Z",
+      windowEndIso: "2026-06-30T19:00:00.000Z",
+      notificationVars: { company: "Acme HVAC", etaText: "1:30 PM" },
+    });
+
+    const proposals = buildFieldDispatchNotificationProposals({ actions });
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      parameters: {
+        intent: { event: "on-my-way" },
+        proactivity: { resolvedLevel: "balanced", actionBoundary: "propose" },
+      },
+    });
+  });
+
+  it("ignores non-notification field-dispatch actions", () => {
+    const proposals = buildFieldDispatchNotificationProposals({
+      actions: [{ kind: "flag-attention", jobId: "JOB-3", reason: "quote awaiting scheduling" }],
+    });
+
+    expect(proposals).toEqual([]);
+  });
+});

--- a/apps/web/lib/proactivity/field-dispatch-runtime.ts
+++ b/apps/web/lib/proactivity/field-dispatch-runtime.ts
@@ -1,0 +1,62 @@
+import type { DispatcherAction, DispatchNotificationIntent } from "@dpf/validators";
+
+import { resolveFieldDispatchNotificationProactivity } from "./field-dispatch-proactivity";
+import type { ProactivityPlan, ProactivityResolverInput } from "./proactivity-types";
+
+export const FIELD_DISPATCH_CUSTOMER_NOTIFICATION_ACTION = "field_dispatch_customer_notification" as const;
+
+export type FieldDispatchNotificationProposalParameters = {
+  kind: "field-dispatch-customer-notification";
+  jobId: string;
+  intent: DispatchNotificationIntent;
+  recommendedAction: string;
+  whyNow: string;
+  proactivity: ProactivityPlan;
+};
+
+export type FieldDispatchNotificationProposalDraft = {
+  actionType: typeof FIELD_DISPATCH_CUSTOMER_NOTIFICATION_ACTION;
+  parameters: FieldDispatchNotificationProposalParameters;
+};
+
+export type BuildFieldDispatchNotificationProposalsInput = {
+  actions: DispatcherAction[];
+  archetype?: ProactivityResolverInput["archetype"];
+  agentId?: string | null;
+  routeContext?: string | null;
+};
+
+export function buildFieldDispatchNotificationProposals(
+  input: BuildFieldDispatchNotificationProposalsInput,
+): FieldDispatchNotificationProposalDraft[] {
+  return input.actions.flatMap((action) => {
+    if (action.kind !== "notify") return [];
+    const proactivity = resolveFieldDispatchNotificationProactivity({
+      intent: action.intent,
+      archetype: input.archetype,
+      agentId: input.agentId,
+      routeContext: input.routeContext,
+    });
+
+    return [
+      {
+        actionType: FIELD_DISPATCH_CUSTOMER_NOTIFICATION_ACTION,
+        parameters: {
+          kind: "field-dispatch-customer-notification",
+          jobId: action.jobId,
+          intent: action.intent,
+          recommendedAction: recommendedNotificationAction(action.intent),
+          whyNow: proactivity.explanation,
+          proactivity,
+        },
+      },
+    ];
+  });
+}
+
+function recommendedNotificationAction(intent: DispatchNotificationIntent): string {
+  if (intent.event === "running-late") return "Send running-late customer update";
+  if (intent.event === "on-my-way") return "Send on-my-way customer update";
+  if (intent.event === "confirm") return "Send appointment confirmation";
+  return "Send completion update";
+}


### PR DESCRIPTION
## Summary
- Adds a pure field-dispatch runtime adapter that converts notification actions into governed customer-notification proposal drafts.
- Attaches the shared `ProactivityPlan` to each notification proposal, making running-late appointment updates assertive while preserving proposal/approval boundaries.
- Adds proposal presentation copy so the attention/proposal surface leads with one recommended action and a plain-language `why now` line.

## Verification
- `pnpm --filter web exec vitest run lib/proactivity/field-dispatch-runtime.test.ts lib/proactivity/field-dispatch-proactivity.test.ts lib/proactivity/proactivity-resolver.test.ts`
- `pnpm --filter web exec vitest run lib/governance/action-proposal-presentation.test.ts lib/proactivity/field-dispatch-runtime.test.ts lib/proactivity/field-dispatch-proactivity.test.ts lib/proactivity/proactivity-resolver.test.ts`
- `pnpm --filter web typecheck`
- `node scripts/check-module-size.mjs`
- `pnpm --filter web build` (passed; existing Turbopack/Edge tracing warnings remain)

Backlog: BI-5B6F666F