### PR TITLE
Persist proactivity override acknowledgements

### DIFF
--- a/apps/web/app/api/v1/governance/approvals/[id]/route.ts
+++ b/apps/web/app/api/v1/governance/approvals/[id]/route.ts
@@ -5,6 +5,15 @@ import { prisma } from "@dpf/db";
 import { authenticateRequest } from "@/lib/api/auth-middleware";
 import { ApiError, apiError } from "@/lib/api/error";
 import { apiSuccess } from "@/lib/api/response";
+import {
+  PROACTIVITY_CHANGE_ACTION,
+  parseProactivityChangeProposalParameters,
+} from "@/lib/proactivity/proactivity-change-proposal";
+import {
+  buildProactivityDismissalFact,
+  buildProactivityOverrideFact,
+  persistProactivityFact,
+} from "@/lib/proactivity/proactivity-override-preferences";
 
 export async function POST(
   request: Request,
@@ -40,6 +49,33 @@ export async function POST(
       throw apiError("NOT_FOUND", "Proposal not found", 404);
     }
 
+    if (proposal.actionType === PROACTIVITY_CHANGE_ACTION) {
+      const parsed = parseProactivityChangeProposalParameters(proposal.parameters);
+      if (!parsed) {
+        return NextResponse.json(
+          { code: "VALIDATION_ERROR", message: "Invalid proactivity proposal parameters" },
+          { status: 422 },
+        );
+      }
+      const decidedAt = new Date();
+      const fact = decision === "approve"
+        ? buildProactivityOverrideFact({
+            proposalId: proposal.proposalId,
+            acknowledgedByUserId: user.id,
+            acknowledgedAt: decidedAt.toISOString(),
+            proposal: parsed,
+          })
+        : buildProactivityDismissalFact({
+            proposalId: proposal.proposalId,
+            dismissedByUserId: user.id,
+            dismissedAt: decidedAt.toISOString(),
+            cooldownUntil: cooldownUntil(decidedAt).toISOString(),
+            proposal: parsed,
+          });
+
+      await persistProactivityFact(user.id, fact);
+    }
+
     const updated = await prisma.agentActionProposal.update({
       where: { id },
       data: {
@@ -66,4 +102,10 @@ export async function POST(
       { status: 500 },
     );
   }
+}
+
+function cooldownUntil(dismissedAt: Date): Date {
+  const until = new Date(dismissedAt);
+  until.setUTCDate(until.getUTCDate() + 7);
+  return until;
 }

--- a/apps/web/lib/actions/proposals.test.ts
+++ b/apps/web/lib/actions/proposals.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  executeTool: vi.fn(),
+  can: vi.fn(),
+  prisma: {
+    agentActionProposal: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    authorizationDecisionLog: {
+      create: vi.fn(),
+    },
+    agentMessage: {
+      create: vi.fn(),
+    },
+    userFact: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("@/lib/permissions", () => ({ can: mocks.can }));
+vi.mock("@/lib/mcp-tools", () => ({
+  PLATFORM_TOOLS: [{ name: "create_backlog_item", requiredCapability: "manage_backlog" }],
+  executeTool: mocks.executeTool,
+}));
+
+import { approveProposal, rejectProposal } from "./proposals";
+
+const proactivityParameters = {
+  kind: "proactivity-change",
+  agentId: "dispatcher",
+  activityFamily: "field-dispatch-appointment",
+  routeContext: "/storefront",
+  currentLevel: "balanced",
+  proposedLevel: "assertive",
+  scope: "activity-family",
+  rationale: "Late customer appointments should be warned earlier.",
+  evidenceRefs: [{ kind: "dispatch-event", id: "running-late" }],
+  spendImpact: "may increase monitoring and notification spend within existing authority",
+  authorityImpact: "does not grant new tools, permissions, or approval bypasses",
+};
+
+describe("proposal actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.setSystemTime(new Date("2026-06-30T18:30:00.000Z"));
+    mocks.auth.mockResolvedValue({
+      user: { id: "user-1", platformRole: "HR-000", isSuperuser: true },
+    });
+    mocks.can.mockReturnValue(true);
+    mocks.prisma.agentActionProposal.update.mockResolvedValue({});
+    mocks.prisma.authorizationDecisionLog.create.mockResolvedValue({});
+    mocks.prisma.agentMessage.create.mockResolvedValue({});
+    mocks.prisma.userFact.findFirst.mockResolvedValue(null);
+    mocks.prisma.userFact.update.mockResolvedValue({});
+    mocks.prisma.userFact.create.mockResolvedValue({});
+    mocks.executeTool.mockResolvedValue({ success: true, entityId: "BI-1", message: "Created" });
+  });
+
+  it("approves proactivity changes by persisting a scoped preference override without executing a tool", async () => {
+    mocks.prisma.agentActionProposal.findUnique.mockResolvedValue({
+      proposalId: "AP-PROACTIVE",
+      status: "proposed",
+      actionType: "propose_proactivity_change",
+      parameters: proactivityParameters,
+      agentId: "dispatcher",
+      threadId: "thread-1",
+    });
+
+    const result = await approveProposal("AP-PROACTIVE");
+
+    expect(result).toEqual({
+      success: true,
+      resultEntityId: "proactivity-override:activity-family:field-dispatch-appointment",
+    });
+    expect(mocks.executeTool).not.toHaveBeenCalled();
+    expect(mocks.prisma.userFact.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        category: "preference",
+        key: "aiCoworkerProactivity:activity-family:field-dispatch-appointment",
+        sourceRoute: "/storefront",
+        sourceAgentId: "dispatcher",
+        value: expect.any(String),
+        confidence: 1,
+        lastValidatedAt: new Date("2026-06-30T18:30:00.000Z"),
+      },
+    });
+    const savedValue = JSON.parse(mocks.prisma.userFact.create.mock.calls[0][0].data.value);
+    expect(savedValue).toMatchObject({
+      scopeKey: "activity-family:field-dispatch-appointment",
+      level: "assertive",
+      previousLevel: "balanced",
+      proposalId: "AP-PROACTIVE",
+      acknowledgedByUserId: "user-1",
+    });
+    expect(mocks.prisma.agentActionProposal.update).toHaveBeenCalledWith({
+      where: { proposalId: "AP-PROACTIVE" },
+      data: expect.objectContaining({
+        status: "executed",
+        resultEntityId: "proactivity-override:activity-family:field-dispatch-appointment",
+      }),
+    });
+  });
+
+  it("rejects proactivity changes by recording a cooldown marker", async () => {
+    mocks.prisma.agentActionProposal.findUnique.mockResolvedValue({
+      proposalId: "AP-PROACTIVE",
+      status: "proposed",
+      actionType: "propose_proactivity_change",
+      parameters: proactivityParameters,
+      agentId: "dispatcher",
+      threadId: "thread-1",
+    });
+
+    const result = await rejectProposal("AP-PROACTIVE", "Not now");
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.prisma.userFact.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        category: "preference",
+        key: "aiCoworkerProactivityCooldown:activity-family:field-dispatch-appointment",
+        sourceRoute: "/storefront",
+        sourceAgentId: "dispatcher",
+        value: expect.any(String),
+        confidence: 1,
+      },
+    });
+    const savedValue = JSON.parse(mocks.prisma.userFact.create.mock.calls[0][0].data.value);
+    expect(savedValue).toMatchObject({
+      scopeKey: "activity-family:field-dispatch-appointment",
+      proposedLevel: "assertive",
+      dismissedByUserId: "user-1",
+      dismissedAt: "2026-06-30T18:30:00.000Z",
+      cooldownUntil: "2026-07-07T18:30:00.000Z",
+    });
+    expect(mocks.prisma.agentActionProposal.update).toHaveBeenCalledWith({
+      where: { proposalId: "AP-PROACTIVE" },
+      data: expect.objectContaining({ status: "rejected", decidedById: "user-1" }),
+    });
+  });
+});

--- a/apps/web/lib/actions/proposals.ts
+++ b/apps/web/lib/actions/proposals.ts
@@ -5,6 +5,16 @@ import { prisma } from "@dpf/db";
 import { can } from "@/lib/permissions";
 import { PLATFORM_TOOLS, executeTool } from "@/lib/mcp-tools";
 import * as crypto from "crypto";
+import {
+  PROACTIVITY_CHANGE_ACTION,
+  parseProactivityChangeProposalParameters,
+} from "@/lib/proactivity/proactivity-change-proposal";
+import {
+  buildProactivityDismissalFact,
+  buildProactivityOverrideFact,
+  persistProactivityFact,
+  scopeKeyFor,
+} from "@/lib/proactivity/proactivity-override-preferences";
 
 async function requireAuthUser() {
   const session = await auth();
@@ -23,6 +33,10 @@ export async function approveProposal(
   });
   if (!proposal) return { success: false, error: "Proposal not found" };
   if (proposal.status !== "proposed") return { success: false, error: "Proposal already decided" };
+
+  if (proposal.actionType === PROACTIVITY_CHANGE_ACTION) {
+    return approveProactivityChangeProposal(proposal, user.id);
+  }
 
   // Check capability
   const tool = PLATFORM_TOOLS.find((t) => t.name === proposal.actionType);
@@ -117,6 +131,10 @@ export async function rejectProposal(
   if (!proposal) return { success: false, error: "Proposal not found" };
   if (proposal.status !== "proposed") return { success: false, error: "Proposal already decided" };
 
+  if (proposal.actionType === PROACTIVITY_CHANGE_ACTION) {
+    return rejectProactivityChangeProposal(proposal, user.id, reason);
+  }
+
   await prisma.agentActionProposal.update({
     where: { proposalId },
     data: { status: "rejected", decidedAt: new Date(), decidedById: user.id },
@@ -131,6 +149,106 @@ export async function rejectProposal(
       actorRef: user.id,
       decision: "deny",
       rationale: { proposalId, reason: reason ?? "User rejected" },
+    },
+  });
+
+  return { success: true };
+}
+
+async function approveProactivityChangeProposal(
+  proposal: { proposalId: string; actionType: string; parameters: unknown; agentId: string; threadId: string },
+  userId: string,
+): Promise<{ success: boolean; resultEntityId?: string; error?: string }> {
+  const parsed = parseProactivityChangeProposalParameters(proposal.parameters);
+  if (!parsed) return { success: false, error: "Invalid proactivity proposal" };
+
+  const acknowledgedAt = new Date().toISOString();
+  const fact = buildProactivityOverrideFact({
+    proposalId: proposal.proposalId,
+    acknowledgedByUserId: userId,
+    acknowledgedAt,
+    proposal: parsed,
+  });
+  const resultEntityId = `proactivity-override:${scopeKeyFor(parsed)}`;
+
+  await persistProactivityFact(userId, fact);
+  await prisma.agentActionProposal.update({
+    where: { proposalId: proposal.proposalId },
+    data: {
+      status: "executed",
+      decidedAt: new Date(acknowledgedAt),
+      decidedById: userId,
+      executedAt: new Date(acknowledgedAt),
+      resultEntityId,
+    },
+  });
+  await prisma.authorizationDecisionLog.create({
+    data: {
+      decisionId: `DEC-${crypto.randomUUID()}`,
+      actionKey: proposal.actionType,
+      objectRef: proposal.proposalId,
+      actorType: "user",
+      actorRef: userId,
+      decision: "allow",
+      rationale: {
+        proposalId: proposal.proposalId,
+        scopeKey: scopeKeyFor(parsed),
+        proposedLevel: parsed.proposedLevel,
+        authorityImpact: parsed.authorityImpact,
+      },
+    },
+  });
+
+  await prisma.agentMessage.create({
+    data: {
+      threadId: proposal.threadId,
+      role: "system",
+      content: `Proactivity changed to ${parsed.proposedLevel} for ${scopeKeyFor(parsed)}. Authority boundaries were not expanded.`,
+      agentId: proposal.agentId,
+    },
+  }).catch(() => {});
+
+  return { success: true, resultEntityId };
+}
+
+async function rejectProactivityChangeProposal(
+  proposal: { proposalId: string; actionType: string; parameters: unknown },
+  userId: string,
+  reason?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const parsed = parseProactivityChangeProposalParameters(proposal.parameters);
+  if (!parsed) return { success: false, error: "Invalid proactivity proposal" };
+
+  const dismissedAt = new Date();
+  const cooldownUntil = new Date(dismissedAt);
+  cooldownUntil.setUTCDate(cooldownUntil.getUTCDate() + 7);
+  const fact = buildProactivityDismissalFact({
+    proposalId: proposal.proposalId,
+    dismissedByUserId: userId,
+    dismissedAt: dismissedAt.toISOString(),
+    cooldownUntil: cooldownUntil.toISOString(),
+    proposal: parsed,
+  });
+
+  await persistProactivityFact(userId, fact);
+  await prisma.agentActionProposal.update({
+    where: { proposalId: proposal.proposalId },
+    data: { status: "rejected", decidedAt: dismissedAt, decidedById: userId },
+  });
+  await prisma.authorizationDecisionLog.create({
+    data: {
+      decisionId: `DEC-${crypto.randomUUID()}`,
+      actionKey: proposal.actionType,
+      objectRef: proposal.proposalId,
+      actorType: "user",
+      actorRef: userId,
+      decision: "deny",
+      rationale: {
+        proposalId: proposal.proposalId,
+        reason: reason ?? "User rejected",
+        scopeKey: scopeKeyFor(parsed),
+        cooldownUntil: cooldownUntil.toISOString(),
+      },
     },
   });
 

--- a/apps/web/lib/api/__tests__/governance-endpoints.test.ts
+++ b/apps/web/lib/api/__tests__/governance-endpoints.test.ts
@@ -9,6 +9,7 @@ vi.mock("@dpf/db", () => ({
     agentThread: { findMany: vi.fn(), findUnique: vi.fn() },
     agentActionProposal: { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
     authorizationDecisionLog: { findMany: vi.fn() },
+    userFact: { findFirst: vi.fn(), update: vi.fn(), create: vi.fn() },
   },
 }));
 
@@ -189,6 +190,60 @@ describe("POST /api/v1/governance/approvals/:id", () => {
 
     expect(res.status).toBe(200);
     expect(body.status).toBe("approve");
+  });
+
+  it("persists proactivity overrides when approving a proactivity change proposal", async () => {
+    (authenticateRequest as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_AUTH);
+    (prisma.userFact.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (prisma.userFact.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.userFact.create as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.agentActionProposal.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "prop-1",
+      proposalId: "AP-PROACTIVE",
+      actionType: "propose_proactivity_change",
+      status: "proposed",
+      parameters: {
+        kind: "proactivity-change",
+        agentId: "dispatcher",
+        activityFamily: "field-dispatch-appointment",
+        currentLevel: "balanced",
+        proposedLevel: "assertive",
+        scope: "activity-family",
+        rationale: "Late customer appointments should be warned earlier.",
+        evidenceRefs: [{ kind: "dispatch-event", id: "running-late" }],
+        spendImpact: "may increase monitoring and notification spend within existing authority",
+        authorityImpact: "does not grant new tools, permissions, or approval bypasses",
+      },
+      thread: { userId: "user-1" },
+    });
+    (prisma.agentActionProposal.update as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "prop-1",
+      status: "approve",
+    });
+
+    const res = await approvalDecideHandler(
+      postRequest("/api/v1/governance/approvals/prop-1", { decision: "approve", rationale: "Looks good" }),
+      { params: Promise.resolve({ id: "prop-1" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(prisma.userFact.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        category: "preference",
+        key: "aiCoworkerProactivity:activity-family:field-dispatch-appointment",
+        sourceRoute: "/platform/ai",
+        sourceAgentId: "dispatcher",
+        value: expect.any(String),
+        confidence: 1,
+        lastValidatedAt: expect.any(Date),
+      },
+    });
+    expect(JSON.parse((prisma.userFact.create as ReturnType<typeof vi.fn>).mock.calls[0][0].data.value)).toMatchObject({
+      scopeKey: "activity-family:field-dispatch-appointment",
+      level: "assertive",
+      acknowledgedByUserId: "user-1",
+    });
   });
 
   it("rejects a proposal", async () => {

--- a/apps/web/lib/proactivity/proactivity-override-preferences.test.ts
+++ b/apps/web/lib/proactivity/proactivity-override-preferences.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildProactivityDismissalFact,
+  buildProactivityOverrideFact,
+  cooldownFactKeyFor,
+  overrideFactKeyFor,
+} from "./proactivity-override-preferences";
+
+const proposal = {
+  kind: "proactivity-change" as const,
+  agentId: "dispatcher",
+  activityFamily: "field-dispatch-appointment" as const,
+  routeContext: "/storefront",
+  currentLevel: "balanced" as const,
+  proposedLevel: "assertive" as const,
+  scope: "activity-family" as const,
+  rationale: "Late customer appointments should be warned earlier.",
+  evidenceRefs: [{ kind: "dispatch-event", id: "running-late" }],
+  spendImpact: "may increase monitoring and notification spend within existing authority",
+  authorityImpact: "does not grant new tools, permissions, or approval bypasses",
+};
+
+describe("proactivity override facts", () => {
+  it("builds accepted proactivity changes as scoped auditable user facts", () => {
+    const fact = buildProactivityOverrideFact({
+      proposalId: "AP-PROACTIVE",
+      acknowledgedByUserId: "user-1",
+      acknowledgedAt: "2026-06-30T18:30:00.000Z",
+      proposal,
+    });
+
+    expect(fact).toMatchObject({
+      category: "preference",
+      key: "aiCoworkerProactivity:activity-family:field-dispatch-appointment",
+      sourceRoute: "/storefront",
+      sourceAgentId: "dispatcher",
+      lastValidatedAt: new Date("2026-06-30T18:30:00.000Z"),
+    });
+    expect(JSON.parse(fact.value)).toMatchObject({
+      scope: "activity-family",
+      scopeKey: "activity-family:field-dispatch-appointment",
+      level: "assertive",
+      previousLevel: "balanced",
+      source: "coworker-proposal",
+      proposedByAgentId: "dispatcher",
+      acknowledgedByUserId: "user-1",
+      proposalId: "AP-PROACTIVE",
+      rationale: "Late customer appointments should be warned earlier.",
+    });
+    expect(JSON.parse(fact.value).evidenceRefs).toContainEqual({
+      kind: "dispatch-event",
+      id: "running-late",
+    });
+  });
+
+  it("uses stable scope keys so new acknowledgements replace the same fact", () => {
+    expect(overrideFactKeyFor(proposal)).toBe(
+      "aiCoworkerProactivity:activity-family:field-dispatch-appointment",
+    );
+    expect(overrideFactKeyFor({ ...proposal, proposedLevel: "quiet" })).toBe(
+      "aiCoworkerProactivity:activity-family:field-dispatch-appointment",
+    );
+  });
+
+  it("builds dismissed proposal cooldowns without changing overrides", () => {
+    const fact = buildProactivityDismissalFact({
+      proposalId: "AP-PROACTIVE",
+      dismissedByUserId: "user-1",
+      dismissedAt: "2026-06-30T18:30:00.000Z",
+      cooldownUntil: "2026-07-07T18:30:00.000Z",
+      proposal,
+    });
+
+    expect(fact).toMatchObject({
+      category: "preference",
+      key: "aiCoworkerProactivityCooldown:activity-family:field-dispatch-appointment",
+      sourceRoute: "/storefront",
+      sourceAgentId: "dispatcher",
+    });
+    expect(cooldownFactKeyFor(proposal)).toBe(fact.key);
+    expect(JSON.parse(fact.value)).toEqual({
+      proposalId: "AP-PROACTIVE",
+      scopeKey: "activity-family:field-dispatch-appointment",
+      proposedLevel: "assertive",
+      dismissedByUserId: "user-1",
+      dismissedAt: "2026-06-30T18:30:00.000Z",
+      cooldownUntil: "2026-07-07T18:30:00.000Z",
+      rationale: "Late customer appointments should be warned earlier.",
+    });
+  });
+});

--- a/apps/web/lib/proactivity/proactivity-override-preferences.ts
+++ b/apps/web/lib/proactivity/proactivity-override-preferences.ts
@@ -1,0 +1,160 @@
+import { prisma } from "@dpf/db";
+import type { ProactivityChangeProposalParameters } from "./proactivity-change-proposal";
+import type { ProactivityLevel } from "./proactivity-types";
+
+export const PROACTIVITY_FACT_CATEGORY = "preference";
+export const PROACTIVITY_OVERRIDE_FACT_PREFIX = "aiCoworkerProactivity";
+export const PROACTIVITY_COOLDOWN_FACT_PREFIX = "aiCoworkerProactivityCooldown";
+
+export type ProactivityOverrideFactValue = {
+  scope: ProactivityChangeProposalParameters["scope"];
+  scopeKey: string;
+  level: ProactivityLevel;
+  previousLevel: ProactivityLevel;
+  source: "coworker-proposal";
+  proposedByAgentId: string | null;
+  acknowledgedByUserId: string;
+  acknowledgedAt: string;
+  proposalId: string;
+  rationale: string;
+  evidenceRefs: ProactivityChangeProposalParameters["evidenceRefs"];
+};
+
+export type DismissedProactivityProposalFactValue = {
+  proposalId: string;
+  scopeKey: string;
+  proposedLevel: ProactivityLevel;
+  dismissedByUserId: string;
+  dismissedAt: string;
+  cooldownUntil: string;
+  rationale: string;
+};
+
+export type ProactivityFactWrite = {
+  category: typeof PROACTIVITY_FACT_CATEGORY;
+  key: string;
+  value: string;
+  sourceRoute: string;
+  sourceAgentId: string | null;
+  lastValidatedAt?: Date;
+};
+
+export type ApplyProactivityOverrideInput = {
+  proposalId: string;
+  acknowledgedByUserId: string;
+  acknowledgedAt: string;
+  proposal: ProactivityChangeProposalParameters;
+};
+
+export type DismissProactivityProposalInput = {
+  proposalId: string;
+  dismissedByUserId: string;
+  dismissedAt: string;
+  cooldownUntil: string;
+  proposal: ProactivityChangeProposalParameters;
+};
+
+export async function persistProactivityFact(userId: string, fact: ProactivityFactWrite): Promise<void> {
+  const existing = await prisma.userFact.findFirst({
+    where: {
+      userId,
+      category: fact.category,
+      key: fact.key,
+      supersededAt: null,
+    },
+    select: { id: true },
+  });
+
+  const data = {
+    value: fact.value,
+    confidence: 1,
+    sourceRoute: fact.sourceRoute,
+    sourceAgentId: fact.sourceAgentId,
+    ...(fact.lastValidatedAt ? { lastValidatedAt: fact.lastValidatedAt } : {}),
+  };
+
+  if (existing) {
+    await prisma.userFact.update({
+      where: { id: existing.id },
+      data,
+    });
+    return;
+  }
+
+  await prisma.userFact.create({
+    data: {
+      userId,
+      category: fact.category,
+      key: fact.key,
+      ...data,
+    },
+  });
+}
+
+export function buildProactivityOverrideFact(input: ApplyProactivityOverrideInput): ProactivityFactWrite {
+  const scopeKey = scopeKeyFor(input.proposal);
+  const value: ProactivityOverrideFactValue = {
+    scope: input.proposal.scope,
+    scopeKey,
+    level: input.proposal.proposedLevel,
+    previousLevel: input.proposal.currentLevel,
+    source: "coworker-proposal",
+    proposedByAgentId: input.proposal.agentId ?? null,
+    acknowledgedByUserId: input.acknowledgedByUserId,
+    acknowledgedAt: input.acknowledgedAt,
+    proposalId: input.proposalId,
+    rationale: input.proposal.rationale,
+    evidenceRefs: input.proposal.evidenceRefs,
+  };
+
+  return {
+    category: PROACTIVITY_FACT_CATEGORY,
+    key: overrideFactKeyFor(input.proposal),
+    value: JSON.stringify(value),
+    sourceRoute: input.proposal.routeContext ?? "/platform/ai",
+    sourceAgentId: input.proposal.agentId ?? null,
+    lastValidatedAt: new Date(input.acknowledgedAt),
+  };
+}
+
+export function buildProactivityDismissalFact(input: DismissProactivityProposalInput): ProactivityFactWrite {
+  const scopeKey = scopeKeyFor(input.proposal);
+  const value: DismissedProactivityProposalFactValue = {
+    proposalId: input.proposalId,
+    scopeKey,
+    proposedLevel: input.proposal.proposedLevel,
+    dismissedByUserId: input.dismissedByUserId,
+    dismissedAt: input.dismissedAt,
+    cooldownUntil: input.cooldownUntil,
+    rationale: input.proposal.rationale,
+  };
+
+  return {
+    category: PROACTIVITY_FACT_CATEGORY,
+    key: cooldownFactKeyFor(input.proposal),
+    value: JSON.stringify(value),
+    sourceRoute: input.proposal.routeContext ?? "/platform/ai",
+    sourceAgentId: input.proposal.agentId ?? null,
+  };
+}
+
+export function overrideFactKeyFor(proposal: ProactivityChangeProposalParameters): string {
+  return `${PROACTIVITY_OVERRIDE_FACT_PREFIX}:${scopeKeyFor(proposal)}`;
+}
+
+export function cooldownFactKeyFor(proposal: ProactivityChangeProposalParameters): string {
+  return `${PROACTIVITY_COOLDOWN_FACT_PREFIX}:${scopeKeyFor(proposal)}`;
+}
+
+export function scopeKeyFor(proposal: ProactivityChangeProposalParameters): string {
+  if (proposal.scope === "activity-family" && proposal.activityFamily) {
+    return `activity-family:${proposal.activityFamily}`;
+  }
+  if (proposal.scope === "route-context" && proposal.routeContext) {
+    return `route-context:${proposal.routeContext}`;
+  }
+  if (proposal.scope === "agent" && proposal.agentId) {
+    return `agent:${proposal.agentId}`;
+  }
+  return proposal.scope;
+}


### PR DESCRIPTION
## Summary
- persists accepted proactivity-change proposals as scoped `UserFact` preference records
- persists rejected proactivity-change proposals as 7-day cooldown facts
- handles both server action approvals and `/api/v1/governance/approvals/:id` decisions without executing a platform tool

## Verification
- `pnpm --filter web exec vitest run lib/actions/proposals.test.ts lib/api/__tests__/governance-endpoints.test.ts lib/proactivity/proactivity-override-preferences.test.ts lib/proactivity/proactivity-change-proposal.test.ts`
- `pnpm --filter web typecheck`
- `node scripts/check-module-size.mjs`
- `pnpm --filter web build` (passes; existing Turbopack Edge/NFT warnings remain)