### PR TITLE
Apply proactivity facts during runtime resolution

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     user: {
       findUnique: vi.fn(),
     },
+    userFact: { findMany: vi.fn() },
     taskRun: {
       create: vi.fn(),
       update: vi.fn(),
@@ -74,10 +75,7 @@ vi.mock("@/lib/ea/architecture-parity-steward", () => ({
   runArchitectureParitySteward: mocks.runArchitectureParitySteward,
 }));
 
-import {
-  executeScheduledAgentTask,
-  scheduleAgentTask,
-} from "./agent-task-scheduler";
+import { executeScheduledAgentTask, scheduleAgentTask } from "./agent-task-scheduler";
 import {
   extractDiscoveryTriageSummary,
   extractHiveScoutSummary,
@@ -262,6 +260,7 @@ function arrangeScheduledTask() {
   mocks.prisma.agentThread.upsert.mockResolvedValue({ id: "thread-1" });
   mocks.prisma.agentMessage.create.mockResolvedValue({});
   mocks.prisma.user.findUnique.mockResolvedValue({ id: "user-1", isSuperuser: true });
+  mocks.prisma.userFact.findMany.mockResolvedValue([]);
   mocks.resolveAgentForRouteWithPrompts.mockResolvedValue({
     systemPrompt: "You are Inventory Specialist.",
     sensitivity: "internal",
@@ -317,6 +316,7 @@ function arrangeHiveScoutTask() {
   mocks.prisma.agentThread.upsert.mockResolvedValue({ id: "thread-1" });
   mocks.prisma.agentMessage.create.mockResolvedValue({});
   mocks.prisma.user.findUnique.mockResolvedValue({ id: "user-1", isSuperuser: true });
+  mocks.prisma.userFact.findMany.mockResolvedValue([]);
   mocks.resolveAgentForRouteWithPrompts.mockResolvedValue({
     agentId: "platform-engineer",
     systemPrompt: "You are Platform Engineer.",

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -25,7 +25,7 @@ import {
   resolveAutonomousWorkAgent,
   resolveAutonomousWorkTools,
 } from "@/lib/tak/autonomous-work-run";
-import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
+import { resolveUserAwareProactivityPlan } from "@/lib/proactivity/proactivity-resolver.server";
 
 // ─── Cron helpers ───────────────────────────────────────────────────────────
 
@@ -176,10 +176,13 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       },
     });
 
-    const proactivity = resolveProactivityPlan({
-      activityFamily: "scheduled-task",
-      agentId: task.agentId,
-      routeContext: task.routeContext,
+    const proactivity = await resolveUserAwareProactivityPlan({
+      userId: task.ownerUserId,
+      input: {
+        activityFamily: "scheduled-task",
+        agentId: task.agentId,
+        routeContext: task.routeContext,
+      },
     });
 
     taskRunRef = await createTaskRunForScheduledTask({

--- a/apps/web/lib/proactivity/proactivity-resolver.server.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.server.ts
@@ -1,0 +1,128 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+import {
+  PROACTIVITY_COOLDOWN_FACT_PREFIX,
+  PROACTIVITY_FACT_CATEGORY,
+  PROACTIVITY_OVERRIDE_FACT_PREFIX,
+} from "./proactivity-override-preferences";
+import { resolveProactivityPlan, resolveProactivityPlanForLevel } from "./proactivity-resolver";
+import type { ProactivityLevel, ProactivityPlan, ProactivityResolverInput } from "./proactivity-types";
+import { isProactivityLevel } from "./proactivity-types";
+
+export async function resolveUserAwareProactivityPlan(input: {
+  userId: string;
+  input: ProactivityResolverInput;
+  now?: Date;
+}): Promise<ProactivityPlan> {
+  const scopeKeys = scopeKeysForInput(input.input);
+  const factKeys = scopeKeys.flatMap((scopeKey) => [
+    `${PROACTIVITY_OVERRIDE_FACT_PREFIX}:${scopeKey}`,
+    `${PROACTIVITY_COOLDOWN_FACT_PREFIX}:${scopeKey}`,
+  ]);
+
+  const facts = await prisma.userFact.findMany({
+    where: {
+      userId: input.userId,
+      category: PROACTIVITY_FACT_CATEGORY,
+      supersededAt: null,
+      key: { in: factKeys },
+    },
+    select: {
+      id: true,
+      key: true,
+      value: true,
+      createdAt: true,
+    },
+  });
+
+  const override = pickScopedFact(facts, scopeKeys, PROACTIVITY_OVERRIDE_FACT_PREFIX, parseOverrideFact);
+  const cooldown = pickScopedFact(facts, scopeKeys, PROACTIVITY_COOLDOWN_FACT_PREFIX, (value) =>
+    parseCooldownFact(value, input.now ?? new Date()),
+  );
+  const rulePlan = resolveProactivityPlanForLevel(input.input, inferRuleLevel(input.input));
+  const plan = override
+    ? resolveProactivityPlanForLevel(input.input, override.value.level, "user-override")
+    : rulePlan;
+
+  if (override) {
+    plan.userOverrideScopeKey = override.value.scopeKey;
+    plan.evidenceRefs = [...plan.evidenceRefs, { kind: "user-fact", id: override.id }];
+    plan.explanation = `${plan.explanation} A user-acknowledged proactivity preference applies for ${override.value.scopeKey}.`;
+  }
+
+  if (cooldown) {
+    plan.suggestionSuppressed = true;
+    plan.suggestionCooldownUntil = cooldown.value.cooldownUntil;
+    plan.suggestionCooldownScopeKey = cooldown.value.scopeKey;
+    plan.evidenceRefs = [...plan.evidenceRefs, { kind: "user-fact", id: cooldown.id }];
+  }
+
+  return plan;
+}
+
+function inferRuleLevel(input: ProactivityResolverInput): ProactivityLevel {
+  return resolveProactivityPlan(input).resolvedLevel;
+}
+
+function scopeKeysForInput(input: ProactivityResolverInput): string[] {
+  const keys: string[] = [];
+  if (input.agentId) keys.push(`agent:${input.agentId}`);
+  if (input.routeContext) keys.push(`route-context:${input.routeContext}`);
+  keys.push(`activity-family:${input.activityFamily}`);
+  return keys;
+}
+
+type ProactivityFactRow = {
+  id: string;
+  key: string;
+  value: string;
+  createdAt: Date;
+};
+
+function pickScopedFact<T>(
+  facts: ProactivityFactRow[],
+  scopeKeys: string[],
+  prefix: string,
+  parse: (value: string) => T | null,
+): { id: string; value: T } | null {
+  for (const scopeKey of scopeKeys) {
+    const key = `${prefix}:${scopeKey}`;
+    const candidates = facts
+      .filter((fact) => fact.key === key)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    for (const fact of candidates) {
+      const value = parse(fact.value);
+      if (value) return { id: fact.id, value };
+    }
+  }
+  return null;
+}
+
+function parseOverrideFact(value: string): { scopeKey: string; level: ProactivityLevel } | null {
+  const parsed = parseRecord(value);
+  const scopeKey = typeof parsed?.scopeKey === "string" ? parsed.scopeKey : null;
+  const level = parsed?.level;
+  if (!scopeKey || !isProactivityLevel(level)) return null;
+  return { scopeKey, level };
+}
+
+function parseCooldownFact(value: string, now: Date): { scopeKey: string; cooldownUntil: string } | null {
+  const parsed = parseRecord(value);
+  const scopeKey = typeof parsed?.scopeKey === "string" ? parsed.scopeKey : null;
+  const cooldownUntil = typeof parsed?.cooldownUntil === "string" ? parsed.cooldownUntil : null;
+  if (!scopeKey || !cooldownUntil) return null;
+
+  const cooldownDate = new Date(cooldownUntil);
+  if (Number.isNaN(cooldownDate.getTime()) || cooldownDate <= now) return null;
+  return { scopeKey, cooldownUntil };
+}
+
+function parseRecord(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/proactivity/proactivity-resolver.test.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    userFact: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
 
 import { getProactivityLevelCopy } from "./proactivity-copy";
 import { resolveProactivityPlan } from "./proactivity-resolver";
+import { resolveUserAwareProactivityPlan } from "./proactivity-resolver.server";
 import { PROACTIVITY_ACTIVITY_FAMILIES, PROACTIVITY_LEVELS, isProactivityLevel } from "./proactivity-types";
 
 describe("proactivity types", () => {
@@ -81,5 +92,86 @@ describe("resolveProactivityPlan", () => {
 
     expect(plan.resolvedLevel).toBe("assertive");
     expect(["advise", "propose"]).toContain(plan.actionBoundary);
+  });
+});
+
+describe("resolveUserAwareProactivityPlan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies the most specific acknowledged user override over rule defaults", async () => {
+    mocks.prisma.userFact.findMany.mockResolvedValue([
+      {
+        id: "fact-agent",
+        key: "aiCoworkerProactivity:agent:dispatcher",
+        value: JSON.stringify({
+          scopeKey: "agent:dispatcher",
+          level: "quiet",
+          acknowledgedAt: "2026-06-30T18:30:00.000Z",
+        }),
+        createdAt: new Date("2026-06-30T18:30:00.000Z"),
+      },
+      {
+        id: "fact-family",
+        key: "aiCoworkerProactivity:activity-family:field-dispatch-appointment",
+        value: JSON.stringify({
+          scopeKey: "activity-family:field-dispatch-appointment",
+          level: "assertive",
+          acknowledgedAt: "2026-06-30T18:00:00.000Z",
+        }),
+        createdAt: new Date("2026-06-30T18:00:00.000Z"),
+      },
+    ]);
+
+    const plan = await resolveUserAwareProactivityPlan({
+      userId: "user-1",
+      input: {
+        activityFamily: "field-dispatch-appointment",
+        agentId: "dispatcher",
+        archetype: {
+          demandSignature: "emergency-reactive",
+          capacityUnit: "slot-hours",
+        },
+      },
+    });
+
+    expect(plan).toMatchObject({
+      resolvedLevel: "quiet",
+      preferenceSource: "user-override",
+      userOverrideScopeKey: "agent:dispatcher",
+      policyId: "proactivity:field-dispatch-appointment:quiet",
+      actionBoundary: "advise",
+    });
+    expect(plan.evidenceRefs).toContainEqual({ kind: "user-fact", id: "fact-agent" });
+  });
+
+  it("surfaces active cooldown facts so repeat proactivity suggestions can be suppressed", async () => {
+    mocks.prisma.userFact.findMany.mockResolvedValue([
+      {
+        id: "cooldown-family",
+        key: "aiCoworkerProactivityCooldown:activity-family:todo-follow-up",
+        value: JSON.stringify({
+          scopeKey: "activity-family:todo-follow-up",
+          proposedLevel: "assertive",
+          cooldownUntil: "2026-07-07T18:30:00.000Z",
+        }),
+        createdAt: new Date("2026-06-30T18:30:00.000Z"),
+      },
+    ]);
+
+    const plan = await resolveUserAwareProactivityPlan({
+      userId: "user-1",
+      now: new Date("2026-07-01T12:00:00.000Z"),
+      input: { activityFamily: "todo-follow-up" },
+    });
+
+    expect(plan).toMatchObject({
+      resolvedLevel: "balanced",
+      suggestionSuppressed: true,
+      suggestionCooldownUntil: "2026-07-07T18:30:00.000Z",
+      suggestionCooldownScopeKey: "activity-family:todo-follow-up",
+    });
+    expect(plan.evidenceRefs).toContainEqual({ kind: "user-fact", id: "cooldown-family" });
   });
 });

--- a/apps/web/lib/proactivity/proactivity-resolver.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.ts
@@ -50,6 +50,14 @@ const DEFAULTS_BY_LEVEL: Record<ProactivityLevel, PlanDefaults> = {
 
 export function resolveProactivityPlan(input: ProactivityResolverInput): ProactivityPlan {
   const level = resolveLevel(input);
+  return resolveProactivityPlanForLevel(input, level);
+}
+
+export function resolveProactivityPlanForLevel(
+  input: ProactivityResolverInput,
+  level: ProactivityLevel,
+  preferenceSource: ProactivityPlan["preferenceSource"] = "rule",
+): ProactivityPlan {
   const defaults = { ...DEFAULTS_BY_LEVEL[level] };
   const evidenceRefs = evidenceFor(input);
 
@@ -76,6 +84,7 @@ export function resolveProactivityPlan(input: ProactivityResolverInput): Proacti
     ...defaults,
     explanation: explanationFor(input, level),
     evidenceRefs,
+    preferenceSource,
   };
 }
 

--- a/apps/web/lib/proactivity/proactivity-types.ts
+++ b/apps/web/lib/proactivity/proactivity-types.ts
@@ -40,6 +40,11 @@ export type ProactivityPlan = {
   actionBoundary: ProactivityActionBoundary;
   explanation: string;
   evidenceRefs: Array<{ kind: string; id: string }>;
+  preferenceSource?: "rule" | "user-override";
+  userOverrideScopeKey?: string;
+  suggestionSuppressed?: boolean;
+  suggestionCooldownUntil?: string;
+  suggestionCooldownScopeKey?: string;
 };
 
 export type ProactivityResolverInput = {

--- a/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
+++ b/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
@@ -16,6 +16,8 @@
 
 **Deferred backlog:** `BI-424CFE7A` covers delegated coworker posture propagation: carry advisory proactivity and golden-triangle context from an initiating task into child coworker subtasks, with the receiving coworker's local policy/risk/quality requirements able to override. This is not part of V1.
 
+**Current delivery state, 2026-06-30:** PR #2530 implements the user-aware runtime resolution slice for `BI-5B6F666F`. Approved proactivity changes are read from scoped `UserFact` preference records, dismissed changes are read from scoped cooldown facts, and scheduled task execution now records the effective user-aware `ProactivityPlan`. This composes with the shipped Build Studio pilot (`BI-ACB04A21`) by keeping the shared resolver as the primitive and avoiding a Build Studio-specific policy fork.
+
 ---
 
 ## File Structure
@@ -35,6 +37,7 @@
 - Modify `apps/web/lib/tak/autonomous-work-run.ts`: accept optional proactivity metadata and write it into `TaskRun.a2aMetadata.proactivity`.
 - Modify `apps/web/lib/tak/scheduled-task-runs.ts`: accept proactivity metadata for scheduled runs if this helper owns the actual `TaskRun` create path.
 - Modify `apps/web/lib/actions/agent-task-scheduler.ts`: resolve and pass scheduled-task proactivity plan without bypassing owner/tool/HITL checks.
+- Modify `apps/web/lib/proactivity/proactivity-resolver.server.ts`: read acknowledged `UserFact` override and cooldown facts without importing Prisma into client-safe resolver code.
 - Modify relevant Build Studio custodian/stall caller once identified in implementation: consume shared resolver, do not fork a Build Studio-only policy.
 - Modify field-dispatch runtime caller once identified in implementation: consume shared resolver around runtime behavior, not pure validator functions.
 - Optional migration: `packages/db/prisma/migrations/<timestamp>_proactivity_override/migration.sql` only if no existing preference/action-envelope substrate can store accepted overrides cleanly.

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -459,6 +459,7 @@ V1 should avoid a broad schema migration until the policy matrix has evidence. I
 - `apps/web/lib/proactivity/proactivity-types.ts`
 - `apps/web/lib/proactivity/proactivity-policy.ts`
 - `apps/web/lib/proactivity/proactivity-resolver.ts`
+- `apps/web/lib/proactivity/proactivity-resolver.server.ts`
 - `apps/web/lib/proactivity/proactivity-copy.ts`
 - tests for archetype/coworker/activity fixtures
 
@@ -486,6 +487,8 @@ model ProactivityOverride {
 ```
 
 Do not add a large generic rules engine in V1.
+
+Implementation status, 2026-06-30: the implementation sweep found `UserFact` suitable for narrow user-scoped proactivity acknowledgements, so V1 does not add `ProactivityOverride`. Accepted coworker proposals persist `preference` facts keyed as `aiCoworkerProactivity:<scopeKey>`; dismissed proposals persist cooldown facts keyed as `aiCoworkerProactivityCooldown:<scopeKey>`. The pure resolver remains client-safe in `proactivity-resolver.ts`; the server-only resolver in `proactivity-resolver.server.ts` reads `UserFact`, applies the most-specific active acknowledgement by agent, route context, then activity family, and returns evidence refs plus cooldown suppression metadata. Scheduled task execution consumes the server resolver with `ownerUserId` so `TaskRun.a2aMetadata.proactivity` reflects the effective user-aware plan without bundling Prisma into client surfaces.
 
 ### V2: first-class policy rows
 
@@ -576,6 +579,8 @@ Acceptance:
 - failures and ignored attempts can escalate to Attention Surface according to plan.
 - no scheduled task bypasses existing owner/tool/HITL checks.
 
+Status, 2026-06-30: implemented for scheduled task execution with user-aware resolution. The shared pure resolver remains available for client and fixture callers; the server resolver applies acknowledged override/cooldown facts before scheduled work writes proactivity metadata. Remaining work in this slice is Attention Surface escalation projection for ignored/failing scheduled work.
+
 ### Slice 2A: Delegated coworker posture substrate
 
 Files:
@@ -622,6 +627,8 @@ Acceptance:
 - accepted proposal creates override or activity-scoped setting.
 - dismissed proposal cools down.
 - all changes audit who proposed, who acknowledged, scope, prior level, new level, and rationale.
+
+Status, 2026-06-30: implemented without a new table. Approved proactivity change proposals create scoped `UserFact` preference records; rejected proposals create scoped cooldown facts so the coworker does not immediately repeat the same suggestion. The runtime resolver now consumes those facts for scheduled work. Remaining work is to extend the same user-aware consumption into field-dispatch and Attention Surface projections.
 
 ### Slice 5: Field dispatch and Build Studio fixtures
 


### PR DESCRIPTION
## Summary
- adds a server-only user-aware proactivity resolver that overlays acknowledged `UserFact` overrides and active cooldown facts on top of rule defaults
- keeps the existing sync resolver client-safe for Build Studio and other UI imports
- switches scheduled task execution to persist effective proactivity metadata from the user-aware resolver

## Verification
- `pnpm --filter web exec vitest run lib/proactivity/proactivity-resolver.test.ts lib/actions/agent-task-scheduler.test.ts lib/proactivity/field-dispatch-runtime.test.ts lib/proactivity/field-dispatch-proactivity.test.ts`
- `node scripts/check-module-size.mjs`
- `pnpm --filter web typecheck`
- `pnpm --filter @dpf/db exec prisma generate` after rebasing over main schema changes
- `pnpm --filter web build` (passes; existing Turbopack Edge/NFT warnings remain)