### PR TITLE
fix: raise portal Docker build heap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pnpm --filter @dpf/db exec prisma generate
 # not a constructor" when --webpack is forced. Use the default builder (Turbopack
 # in Next 16, gated in next.config.mjs) which does not trigger the broken plugin.
 # Re-evaluate --webpack on next version bump.
-RUN NODE_OPTIONS="--max-old-space-size=4096" NEXT_TELEMETRY_DISABLED=1 pnpm --filter web exec next build
+RUN NODE_OPTIONS="--max-old-space-size=8192" NEXT_TELEMETRY_DISABLED=1 pnpm --filter web exec next build
 
 # ─── Stage 4: init (build source for migrations, seed, Prisma client) ─────────
 FROM deps AS init

--- a/scripts/lib/dockerfile-portal-build.test.mjs
+++ b/scripts/lib/dockerfile-portal-build.test.mjs
@@ -11,6 +11,10 @@ test("portal image build uses the default Next builder under Docker", () => {
   assert.doesNotMatch(dockerfile, /NEXT_TURBOPACK_USE_WORKER=0/);
 });
 
+test("portal image build reserves enough heap for Next production tracing", () => {
+  assert.match(dockerfile, /NODE_OPTIONS="--max-old-space-size=8192"/);
+});
+
 test("runner image carries profession corpus seed assets", () => {
   assert.match(
     dockerfile,


### PR DESCRIPTION
## Summary
- raise the portal Docker build heap from 4096 MB to 8192 MB
- add a Dockerfile guard so the self-upgrade image build does not regress to the failing heap cap

## Verification
- node --test scripts/lib/dockerfile-portal-build.test.mjs
- docker build --progress=plain --target build -t dpf-self-upgrade-diagnostic:heap8192 D:\\DPF-worktrees\\coworker-service-catalog

Context: self-upgrade run SUR-A7A6CF96 failed at the Dockerfile Next build step with V8 heap OOM at the 4096 MB cap. The same build target passes after this change.