### PR TITLE
fix: seed baseline coworker catalog offers

### DIFF
--- a/docs/professions/registry.json
+++ b/docs/professions/registry.json
@@ -336,7 +336,13 @@
     {
       "professionKey": "legal-compliance",
       "label": "Legal & Compliance",
-      "roles": ["compliance-officer", "licensing-specialist", "policy-specialist", "policy-enforcement-agent"],
+      "roles": [
+        "compliance-officer",
+        "legal-operations-counsel",
+        "licensing-specialist",
+        "policy-specialist",
+        "policy-enforcement-agent"
+      ],
       "contextSlugs": ["compliance"],
       "sources": [
         {

--- a/docs/superpowers/specs/2026-06-30-coworker-service-offer-catalog-design.md
+++ b/docs/superpowers/specs/2026-06-30-coworker-service-offer-catalog-design.md
@@ -141,6 +141,18 @@ Closed application-level string sets:
 
 The first slice uses a catalog projection service that reads persisted catalog rows and enriches them with existing `Agent`, `SkillAssignment`, `AgentToolGrant`, `DigitalProduct`, and `ServiceOffering` data. It also includes a guarded Legal Operations Counsel example projection only when the legal coworker identity exists, so this branch does not need to duplicate the in-flight legal coworker branch.
 
+The durable seed must keep the first catalog useful without turning it into a full enterprise service universe. The baseline seed therefore includes a compact set of high-leverage offers that cover the common cross-surface handoffs identified during implementation:
+
+- Build Studio sensitive-domain requirements packet for coding and review agents;
+- PCI and regulated-control requirements review;
+- Legal contract and counsel packet preparation, with Legal Operations Counsel as an internal coworker;
+- Paid provider, token, renewal, D&B-style authority data, ADP/payroll, and procurement/cost intake;
+- external customer sales/service intake;
+- external marketing/partner collaboration intake;
+- external provider and MCP catalog scouting.
+
+External offers must carry public GAID metadata, AIDoc references, verified GAID authority, explicit legal terms, and data-boundary metadata before they can project into cross-organization A2A Agent Cards. Internal legal/compliance/finance offers remain authenticated and approval-aware by default. The seed is intentionally small: other specialist services should be added as repeated engagements prove they are repeatable or codified, not because an agent might theoretically need them.
+
 Legal offers:
 
 - Legal intake;

--- a/packages/db/src/coworker-service-catalog-seed.test.ts
+++ b/packages/db/src/coworker-service-catalog-seed.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COWORKER_SERVICE_CATALOG_OFFER_SEEDS,
+  COWORKER_SERVICE_CATALOG_SERVICE_SEEDS,
+} from "./coworker-service-catalog-seed";
+import { COWORKER_AGENT_SEEDS } from "./workforce-seed";
+
+function unique(values: readonly string[]) {
+  return new Set(values).size === values.length;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+describe("coworker service catalog seed data", () => {
+  it("seeds a compact baseline across internal, build, procurement, legal, and external surfaces", () => {
+    expect(COWORKER_SERVICE_CATALOG_SERVICE_SEEDS.length).toBeGreaterThanOrEqual(7);
+    expect(COWORKER_SERVICE_CATALOG_OFFER_SEEDS.length).toBeGreaterThanOrEqual(7);
+
+    expect(COWORKER_SERVICE_CATALOG_OFFER_SEEDS.map((offer) => offer.offerId)).toEqual(
+      expect.arrayContaining([
+        "offer-build-sensitive-domain-requirements",
+        "offer-pci-control-requirements",
+        "offer-legal-contract-packet",
+        "offer-provider-cost-intake",
+        "offer-customer-sales-intake",
+        "offer-marketing-partner-intake",
+      ]),
+    );
+  });
+
+  it("references seeded coworker providers and services", () => {
+    const seededAgents = new Set(COWORKER_AGENT_SEEDS.map((agent) => agent.agentId));
+    const serviceIds = COWORKER_SERVICE_CATALOG_SERVICE_SEEDS.map((service) => service.serviceId);
+
+    expect(unique(serviceIds)).toBe(true);
+    expect(unique(COWORKER_SERVICE_CATALOG_OFFER_SEEDS.map((offer) => offer.offerId))).toBe(true);
+
+    for (const service of COWORKER_SERVICE_CATALOG_SERVICE_SEEDS) {
+      expect(seededAgents.has(service.providerAgentId), service.serviceId).toBe(true);
+    }
+    for (const offer of COWORKER_SERVICE_CATALOG_OFFER_SEEDS) {
+      expect(serviceIds.includes(offer.serviceId), offer.offerId).toBe(true);
+    }
+  });
+
+  it("includes verified GAID authority metadata for public A2A offers", () => {
+    const externalOffers = COWORKER_SERVICE_CATALOG_OFFER_SEEDS.filter(
+      (offer) => offer.availabilityScope === "external",
+    );
+
+    expect(externalOffers.length).toBeGreaterThanOrEqual(2);
+    for (const offer of externalOffers) {
+      const service = COWORKER_SERVICE_CATALOG_SERVICE_SEEDS.find((candidate) => candidate.serviceId === offer.serviceId);
+      const metadata = record(offer.metadata);
+      const gaidAuthority = record(metadata.gaidAuthority);
+
+      expect(metadata.gaid, offer.offerId).toMatch(/^gaid:public:dpf:/);
+      expect(metadata.aidocRef, offer.offerId).toMatch(/^aidoc:\/\/dpf\/public\//);
+      expect(gaidAuthority, offer.offerId).toMatchObject({
+        state: "verified",
+        exposure: "public",
+        subjectAgentId: service?.providerAgentId,
+      });
+      expect(Object.keys(record(offer.legalTerms)).length, offer.offerId).toBeGreaterThan(0);
+      expect(Object.keys(record(offer.dataBoundary)).length, offer.offerId).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/db/src/coworker-service-catalog-seed.ts
+++ b/packages/db/src/coworker-service-catalog-seed.ts
@@ -1,0 +1,368 @@
+import type { Prisma, PrismaClient } from "../generated/client/client";
+
+type CoworkerServiceSeed = {
+  serviceId: string;
+  providerAgentId: string;
+  name: string;
+  summary: string;
+  description: string;
+  status: string;
+  riskTier: string;
+  hitlTier: number;
+  authorityBoundary: string;
+  availabilityScope: string;
+  personas: Prisma.InputJsonValue;
+  portfolioRoles: Prisma.InputJsonValue;
+  valueStreams: Prisma.InputJsonValue;
+  archetypes: Prisma.InputJsonValue;
+  jurisdictions: Prisma.InputJsonValue;
+  requiredInputs: Prisma.InputJsonValue;
+  producedOutputs: Prisma.InputJsonValue;
+  backingSkillIds: Prisma.InputJsonValue;
+  backingToolNames: Prisma.InputJsonValue;
+  backingGrantKeys: Prisma.InputJsonValue;
+  costModel: Prisma.InputJsonValue;
+  contractTerms: Prisma.InputJsonValue;
+  dataBoundary: Prisma.InputJsonValue;
+  metadata: Prisma.InputJsonValue;
+};
+
+type CoworkerOfferSeed = {
+  offerId: string;
+  serviceId: string;
+  name: string;
+  summary: string;
+  description: string;
+  status: string;
+  version: string;
+  providerOrganization: string;
+  availabilityScope: string;
+  riskTier: string;
+  authorityBoundary: string;
+  eligibleConsumers: Prisma.InputJsonValue;
+  budgetEnvelope: Prisma.InputJsonValue;
+  sla: Prisma.InputJsonValue;
+  requiredApprovals: Prisma.InputJsonValue;
+  legalTerms: Prisma.InputJsonValue;
+  dataBoundary: Prisma.InputJsonValue;
+  deliverables: Prisma.InputJsonValue;
+  filters: Prisma.InputJsonValue;
+  metadata: Prisma.InputJsonValue;
+};
+
+const dpfProductId = "dpf-portal";
+
+export const COWORKER_SERVICE_CATALOG_SERVICE_SEEDS: readonly CoworkerServiceSeed[] = [
+  serviceSeed("svc-build-sensitive-requirements", "build-specialist", {
+    name: "Build Studio sensitive-domain requirements broker",
+    summary: "Routes regulated, paid-provider, and sensitive feature builds to the right specialist packet.",
+    description:
+      "Detects PCI, payroll, identity, provider-token, contract, and regulated-domain signals before implementation and emits bounded requirements for coding agents.",
+    riskTier: "high",
+    authorityBoundary: "requirements-gate",
+    personas: ["builder", "product-owner", "coding-agent"],
+    valueStreams: ["integrate"],
+    requiredInputs: [{ key: "build-brief" }, { key: "design-doc" }, { key: "build-plan" }],
+    producedOutputs: [{ key: "bounded-requirements-packet" }, { key: "specialist-routing" }],
+    backingSkillIds: ["build-sensitive-domain-requirements"],
+    backingToolNames: ["analyze_coworker_engagement_refinement"],
+    backingGrantKeys: ["backlog_read", "architecture_read", "coworker_screen_read"],
+    costModel: { pricing: "internal", metering: "per-build-trigger" },
+    contractTerms: { posture: "internal-platform-control" },
+    dataBoundary: { sensitivity: "confidential", retention: "build-evidence" },
+    metadata: { aggregate: true, processMaturity: "codified" },
+  }),
+  serviceSeed("svc-compliance-pci-requirements", "compliance-officer", {
+    name: "PCI and regulated-control requirements",
+    summary: "Translates compliance obligations into build acceptance criteria and evidence.",
+    description:
+      "Specialist packet for cardholder data, regulated operations, audit evidence, approval gates, and control ownership.",
+    riskTier: "high",
+    authorityBoundary: "proposal-only",
+    personas: ["builder", "operator", "compliance-reviewer"],
+    valueStreams: ["integrate", "operate"],
+    requiredInputs: [{ key: "regulated-feature-scope" }, { key: "data-flow" }],
+    producedOutputs: [{ key: "control-requirements" }, { key: "audit-evidence-plan" }],
+    backingSkillIds: ["compliance-requirements-review"],
+    backingToolNames: ["wiki_query", "create_backlog_item"],
+    backingGrantKeys: ["policy_write", "data_governance_validate", "backlog_write"],
+    costModel: { pricing: "internal", externalCost: "possible-assessor-or-provider-review" },
+    contractTerms: { posture: "policy-and-audit-review-required" },
+    dataBoundary: { sensitivity: "regulated", pii: "minimize", cardholderData: "no-storage-without-approved-pattern" },
+    metadata: { triggerFamilies: ["pci-cardholder-data", "regulated-sensitive-domain"] },
+  }),
+  serviceSeed("svc-legal-counsel-packet", "legal-operations-counsel", {
+    name: "Legal and contract review packet",
+    summary: "Prepares counsel-ready facts, questions, clauses, and risk notes.",
+    description:
+      "Internal legal operations coworker for contracts, terms, privacy clauses, supplier terms, and counsel handoff. It does not provide legal advice.",
+    riskTier: "high",
+    authorityBoundary: "proposal-only",
+    personas: ["founder", "operator", "procurement"],
+    valueStreams: ["cross-cutting"],
+    requiredInputs: [{ key: "contract-or-terms" }, { key: "business-context" }],
+    producedOutputs: [{ key: "counsel-packet" }, { key: "issue-list" }],
+    backingSkillIds: ["prepare-counsel-packet"],
+    backingToolNames: ["doc_search", "doc_save"],
+    backingGrantKeys: ["document_read", "document_write", "registry_read"],
+    costModel: { pricing: "internal", externalCost: "attorney-review-if-escalated" },
+    contractTerms: { posture: "attorney-review-required-for-advice" },
+    dataBoundary: { sensitivity: "confidential", privilegedMaterial: "segregate" },
+    metadata: { legalRisk: "attorney-review-required" },
+  }),
+  serviceSeed("svc-finance-provider-cost-intake", "finance-controller", {
+    name: "Provider cost and purchasing intake",
+    summary: "Captures paid provider, token, renewal, D&B, ADP, and subscription cost impacts.",
+    description:
+      "Budget and procurement coworker service for non-free dependencies introduced during feature definition or operations.",
+    riskTier: "medium",
+    authorityBoundary: "approval-required",
+    personas: ["builder", "operator", "procurement"],
+    valueStreams: ["integrate", "operate"],
+    requiredInputs: [{ key: "provider-name" }, { key: "expected-usage" }, { key: "renewal-terms" }],
+    producedOutputs: [{ key: "cost-record" }, { key: "approval-recommendation" }],
+    backingSkillIds: ["provider-cost-intake"],
+    backingToolNames: ["create_backlog_item"],
+    backingGrantKeys: ["registry_read", "portfolio_read", "backlog_read"],
+    costModel: { pricing: "internal", tracksExternalSpend: true },
+    contractTerms: { posture: "finance-approval-before-production-use" },
+    dataBoundary: { sensitivity: "confidential", financialData: true },
+    metadata: { triggerFamilies: ["paid-provider-or-token", "contract-renewal-obligation"] },
+  }),
+  serviceSeed("svc-customer-sales-intake", "customer-advisor", {
+    name: "Customer sales and service intake",
+    summary: "External-facing customer inquiry, quote, support, and service-request triage.",
+    description:
+      "Customer-accessible AI coworker surface for authenticated external customers, with internal escalation to legal, finance, or fulfillment when needed.",
+    riskTier: "medium",
+    authorityBoundary: "proposal-only",
+    availabilityScope: "external",
+    personas: ["customer", "sales", "support"],
+    valueStreams: ["consume"],
+    requiredInputs: [{ key: "customer-intent" }, { key: "account-context" }],
+    producedOutputs: [{ key: "qualified-request" }, { key: "escalation" }],
+    backingSkillIds: ["customer-intake-triage"],
+    backingToolNames: ["create_customer_case"],
+    backingGrantKeys: ["consumer_read", "backlog_write"],
+    costModel: { pricing: "included", metering: "per-customer-interaction" },
+    contractTerms: { posture: "published-customer-terms" },
+    dataBoundary: { sensitivity: "customer-confidential", externalSubject: "customer" },
+    metadata: { externalInterface: true },
+  }),
+  serviceSeed("svc-marketing-partner-intake", "marketing-specialist", {
+    name: "Marketing and campaign collaboration intake",
+    summary: "External/partner-facing campaign, lead-source, and channel collaboration intake.",
+    description:
+      "Surface for customers or partners to request campaign collaboration while preserving approval, brand, consent, and data-use boundaries.",
+    riskTier: "medium",
+    authorityBoundary: "proposal-only",
+    availabilityScope: "external",
+    personas: ["customer", "partner", "marketing"],
+    valueStreams: ["consume"],
+    requiredInputs: [{ key: "campaign-goal" }, { key: "audience" }, { key: "consent-context" }],
+    producedOutputs: [{ key: "campaign-brief" }, { key: "approval-checklist" }],
+    backingSkillIds: ["marketing-collaboration-intake"],
+    backingToolNames: ["create_backlog_item"],
+    backingGrantKeys: ["marketing_read", "marketing_write", "consumer_read"],
+    costModel: { pricing: "included", externalCost: "ad-spend-if-approved" },
+    contractTerms: { posture: "brand-and-consent-review-required" },
+    dataBoundary: { sensitivity: "customer-confidential", consentRequired: true },
+    metadata: { externalInterface: true },
+  }),
+  serviceSeed("svc-external-provider-scout", "external-catalog-scout", {
+    name: "External provider and MCP catalog scout",
+    summary: "Researches external AI coworkers, MCP servers, providers, and authority data sources for governed adoption.",
+    description:
+      "Specialist scout for D&B-style authority feeds, payroll providers, MCP tools, and other paid or external capabilities before onboarding.",
+    riskTier: "medium",
+    authorityBoundary: "proposal-only",
+    personas: ["operator", "builder", "procurement"],
+    valueStreams: ["explore", "integrate"],
+    requiredInputs: [{ key: "capability-gap" }, { key: "provider-candidates" }],
+    producedOutputs: [{ key: "tool-evaluation-candidate" }, { key: "adoption-risks" }],
+    backingSkillIds: ["external-catalog-scout"],
+    backingToolNames: ["create_backlog_item", "wiki_query"],
+    backingGrantKeys: ["backlog_read", "backlog_write", "registry_read"],
+    costModel: { pricing: "internal", externalCost: "provider-dependent" },
+    contractTerms: { posture: "tool-evaluation-required-before-adoption" },
+    dataBoundary: { sensitivity: "public-to-confidential", supplierData: true },
+    metadata: { triggerFamilies: ["external-authority-data", "mcp-provider-adoption"] },
+  }),
+];
+
+export const COWORKER_SERVICE_CATALOG_OFFER_SEEDS: readonly CoworkerOfferSeed[] = [
+  offerSeed("offer-build-sensitive-domain-requirements", "svc-build-sensitive-requirements", {
+    name: "Sensitive-domain build requirements packet",
+    summary: "Bounded requirements packet for coding agents when a feature touches PCI, payroll, paid providers, or regulated domains.",
+    riskTier: "high",
+    authorityBoundary: "requirements-gate",
+    eligibleConsumers: ["build-studio", "coding-agent", "review-agent"],
+    deliverables: ["Requirements packet", "Specialist routing list", "Acceptance criteria"],
+    filters: { triggerFamilies: ["pci-cardholder-data", "payroll-provider", "paid-provider-or-token"] },
+  }),
+  offerSeed("offer-pci-control-requirements", "svc-compliance-pci-requirements", {
+    name: "PCI control requirements review",
+    summary: "Compliance requirements for features that touch payment cards, tokens, checkout, or cardholder data.",
+    riskTier: "high",
+    eligibleConsumers: ["builder", "operator", "compliance-reviewer"],
+    requiredApprovals: [{ type: "compliance-review", required: true }],
+    deliverables: ["Control checklist", "Evidence plan", "Forbidden implementation patterns"],
+    filters: { jurisdiction: ["us", "global"], domain: "pci" },
+  }),
+  offerSeed("offer-legal-contract-packet", "svc-legal-counsel-packet", {
+    name: "Legal contract and counsel packet",
+    summary: "Internal packet for terms, supplier contracts, privacy clauses, or policy-sensitive activity before counsel review.",
+    riskTier: "high",
+    eligibleConsumers: ["operator", "procurement", "finance", "builder"],
+    requiredApprovals: [{ type: "attorney-review", required: true }],
+    deliverables: ["Counsel packet", "Issue list", "Clause and source inventory"],
+    filters: { artifact: "contract-or-terms", jurisdiction: ["us", "global"] },
+  }),
+  offerSeed("offer-provider-cost-intake", "svc-finance-provider-cost-intake", {
+    name: "Paid provider and token cost intake",
+    summary: "Finance/procurement intake when a feature needs D&B, ADP, provider tokens, subscriptions, or non-free services.",
+    riskTier: "medium",
+    authorityBoundary: "approval-required",
+    eligibleConsumers: ["builder", "operator", "procurement", "finance"],
+    requiredApprovals: [{ type: "finance-approval", required: true }],
+    deliverables: ["Cost record", "Approval path", "Renewal tracking notes"],
+    filters: { triggerFamilies: ["paid-provider-or-token", "contract-renewal-obligation"] },
+  }),
+  externalOfferSeed("offer-customer-sales-intake", "svc-customer-sales-intake", "customer-advisor", {
+    name: "Customer sales and service intake",
+    summary: "Authenticated customer-facing intake for inquiries, quotes, cases, and service requests.",
+    eligibleConsumers: ["authenticated-customer", "sales", "support"],
+    deliverables: ["Qualified request", "Suggested next action", "Escalation path"],
+    filters: { exposure: "external", channel: "customer" },
+  }),
+  externalOfferSeed("offer-marketing-partner-intake", "svc-marketing-partner-intake", "marketing-specialist", {
+    name: "Marketing partner collaboration intake",
+    summary: "Authenticated external/partner intake for campaign collaboration, lead-source requests, and channel coordination.",
+    eligibleConsumers: ["authenticated-customer", "partner", "marketing"],
+    deliverables: ["Campaign brief", "Consent checklist", "Approval path"],
+    filters: { exposure: "external", channel: "marketing" },
+  }),
+  offerSeed("offer-external-provider-scout", "svc-external-provider-scout", {
+    name: "External provider and MCP scout pass",
+    summary: "Research and governed intake for external providers, authority data sources, MCP tools, and paid AI capabilities.",
+    riskTier: "medium",
+    eligibleConsumers: ["operator", "builder", "procurement"],
+    deliverables: ["Provider comparison", "Tool evaluation candidate", "Cost and contract risks"],
+    filters: { domain: "external-provider-adoption" },
+  }),
+];
+
+export async function seedCoworkerServiceCatalog(prisma: PrismaClient): Promise<void> {
+  for (const service of COWORKER_SERVICE_CATALOG_SERVICE_SEEDS) {
+    await prisma.coworkerService.upsert({
+      where: { serviceId: service.serviceId },
+      create: { ...service, digitalProductId: dpfProductId },
+      update: { ...service, digitalProductId: dpfProductId },
+    });
+  }
+
+  for (const offer of COWORKER_SERVICE_CATALOG_OFFER_SEEDS) {
+    await prisma.coworkerOffer.upsert({
+      where: { offerId: offer.offerId },
+      create: { ...offer, digitalProductId: dpfProductId },
+      update: { ...offer, digitalProductId: dpfProductId },
+    });
+  }
+}
+
+function serviceSeed(
+  serviceId: string,
+  providerAgentId: string,
+  overrides: Partial<CoworkerServiceSeed>,
+): CoworkerServiceSeed {
+  return {
+    serviceId,
+    providerAgentId,
+    name: overrides.name ?? serviceId,
+    summary: overrides.summary ?? "",
+    description: overrides.description ?? "",
+    status: overrides.status ?? "active",
+    riskTier: overrides.riskTier ?? "low",
+    hitlTier: overrides.hitlTier ?? 2,
+    authorityBoundary: overrides.authorityBoundary ?? "proposal-only",
+    availabilityScope: overrides.availabilityScope ?? "internal",
+    personas: overrides.personas ?? [],
+    portfolioRoles: overrides.portfolioRoles ?? ["platform"],
+    valueStreams: overrides.valueStreams ?? ["cross-cutting"],
+    archetypes: overrides.archetypes ?? ["software-and-platforms"],
+    jurisdictions: overrides.jurisdictions ?? ["us", "global"],
+    requiredInputs: overrides.requiredInputs ?? [],
+    producedOutputs: overrides.producedOutputs ?? [],
+    backingSkillIds: overrides.backingSkillIds ?? [],
+    backingToolNames: overrides.backingToolNames ?? [],
+    backingGrantKeys: overrides.backingGrantKeys ?? [],
+    costModel: overrides.costModel ?? { pricing: "internal" },
+    contractTerms: overrides.contractTerms ?? { posture: "internal" },
+    dataBoundary: overrides.dataBoundary ?? { sensitivity: "internal" },
+    metadata: overrides.metadata ?? {},
+  };
+}
+
+function offerSeed(
+  offerId: string,
+  serviceId: string,
+  overrides: Partial<CoworkerOfferSeed>,
+): CoworkerOfferSeed {
+  return {
+    offerId,
+    serviceId,
+    name: overrides.name ?? offerId,
+    summary: overrides.summary ?? "",
+    description: overrides.description ?? overrides.summary ?? "",
+    status: overrides.status ?? "active",
+    version: overrides.version ?? "1.0.0",
+    providerOrganization: overrides.providerOrganization ?? "Digital Product Factory",
+    availabilityScope: overrides.availabilityScope ?? "internal",
+    riskTier: overrides.riskTier ?? "low",
+    authorityBoundary: overrides.authorityBoundary ?? "proposal-only",
+    eligibleConsumers: overrides.eligibleConsumers ?? [],
+    budgetEnvelope: overrides.budgetEnvelope ?? { estimate: "internal-budget", approval: "owner" },
+    sla: overrides.sla ?? { response: "1 business day" },
+    requiredApprovals: overrides.requiredApprovals ?? [],
+    legalTerms: overrides.legalTerms ?? { posture: "internal-use" },
+    dataBoundary: overrides.dataBoundary ?? { sensitivity: "internal" },
+    deliverables: overrides.deliverables ?? [],
+    filters: overrides.filters ?? {},
+    metadata: overrides.metadata ?? {},
+  };
+}
+
+function externalOfferSeed(
+  offerId: string,
+  serviceId: string,
+  providerAgentId: string,
+  overrides: Partial<CoworkerOfferSeed>,
+): CoworkerOfferSeed {
+  return offerSeed(offerId, serviceId, {
+    ...overrides,
+    availabilityScope: "external",
+    riskTier: overrides.riskTier ?? "medium",
+    authorityBoundary: overrides.authorityBoundary ?? "proposal-only",
+    legalTerms: {
+      posture: "published-external-terms",
+      consentRequired: true,
+    },
+    dataBoundary: {
+      sensitivity: "customer-confidential",
+      externalSubject: true,
+      retention: "published-policy",
+    },
+    metadata: {
+      ...(typeof overrides.metadata === "object" && !Array.isArray(overrides.metadata) ? overrides.metadata : {}),
+      gaid: `gaid:public:dpf:${providerAgentId}`,
+      aidocRef: `aidoc://dpf/public/${providerAgentId}/${offerId}`,
+      gaidAuthority: {
+        state: "verified",
+        exposure: "public",
+        subjectAgentId: providerAgentId,
+        verifiedAt: "2026-06-30T00:00:00.000Z",
+        expiresAt: "2027-06-30T00:00:00.000Z",
+      },
+    },
+  });
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -66,6 +66,7 @@ import { ensureAllBackupScheduledJobs } from "./seed-platform-backup.js";
 import { ensureDataRetentionScheduledJob } from "./seed-platform-retention.js";
 import { ensureContributorInventoryScheduledJob } from "./seed-contributor-inventory.js";
 import { seedAgentControlPlaneMaturity } from "./seed-agent-control-plane-maturity.js";
+import { seedCoworkerServiceCatalog } from "./coworker-service-catalog-seed.js";
 import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
@@ -2368,6 +2369,7 @@ async function main(): Promise<void> {
   await step("eaSysmlAgentAuthority", () => seedEaSysmlAgentAuthority());
   await step("eaSysmlDataAuthority", () => seedEaSysmlDataAuthority());
   await step("dpfSelfRegistration", () => seedDpfSelfRegistration());
+  await step("coworkerServiceCatalog", () => seedCoworkerServiceCatalog(prisma));
   await step("platformCapabilityPortfolio", () => projectPlatformCapabilities());
   await step("defaultAdminUser", () => seedDefaultAdminUser());
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -186,6 +186,16 @@ export const COWORKER_AGENT_SEEDS: readonly CoworkerAgentSeed[] = [
     sensitivity: "confidential",
   },
   {
+    agentId: "legal-operations-counsel",
+    slugId: "legal-operations-counsel",
+    name: "Legal Operations Counsel",
+    tier: 2,
+    type: "coworker",
+    description: "Legal review packet preparation, contract issue spotting, and counsel handoff coordination",
+    valueStream: "cross-cutting",
+    sensitivity: "confidential",
+  },
+  {
     agentId: "finance-controller",
     slugId: "finance-controller",
     name: "Finance Controller",
@@ -266,6 +276,7 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
     "backlog_write",
     "tool_evaluation_create",
   ],
+  "legal-operations-counsel": ["file_read", "document_read", "document_write", "registry_read"],
   "finance-controller": ["registry_read", "backlog_read", "portfolio_read"],
   // Reads field-service jobs and customer contact data, updates job status, and
   // proposes customer notifications for approval.


### PR DESCRIPTION
## Summary
- seed baseline coworker services and offers for Build Studio, compliance/PCI, legal, finance/procurement, customer, marketing, and external-provider scout surfaces
- add Legal Operations Counsel as a seeded coworker and bind it to the legal-compliance profession family
- add seed-data invariants for provider references, offer references, and GAID/AIDoc metadata on public A2A offers

## Verification
- pnpm --filter @dpf/db exec vitest run src/coworker-service-catalog-seed.test.ts src/seed.test.ts src/agent-identity.test.ts
- pnpm --filter @dpf/db typecheck

Context: after #2523 deployed, the live catalog schema existed but CoworkerService/CoworkerOffer were empty. This fixes the source seed so self-upgrade/fresh installs converge to a usable baseline catalog instead of an empty page/API.