### PR TITLE
Persist coworker proactivity dock setting

### DIFF
--- a/apps/web/components/agent/CoworkerProfilePanel.test.tsx
+++ b/apps/web/components/agent/CoworkerProfilePanel.test.tsx
@@ -4,10 +4,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentInfo } from "@/lib/agent-coworker-types";
 
+const getProactivityPreference = vi.fn();
+
+vi.mock("@/lib/actions/proactivity", () => ({
+  getCoworkerProactivityPreference: (agentId: string) => getProactivityPreference(agentId),
+}));
+
 import { CoworkerProfilePanel } from "./CoworkerProfilePanel";
 
 afterEach(() => {
   cleanup();
+  getProactivityPreference.mockReset();
 });
 
 function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
@@ -25,6 +32,7 @@ function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
 
 describe("CoworkerProfilePanel", () => {
   it("shows the effective proactivity plan and boundaries", () => {
+    getProactivityPreference.mockResolvedValue(null);
     render(<CoworkerProfilePanel agent={makeAgent()} onClose={vi.fn()} />);
 
     expect(screen.getByText("Proactivity")).toBeTruthy();
@@ -35,5 +43,15 @@ describe("CoworkerProfilePanel", () => {
     expect(screen.queryByText(/Spend: standard/i)).toBeNull();
     expect(screen.queryByText(/Boundary: propose/i)).toBeNull();
     expect(screen.queryByText(/proactivity:scheduled-task:balanced/i)).toBeNull();
+  });
+
+  it("loads the saved coworker proactivity preference for the profile summary", async () => {
+    getProactivityPreference.mockResolvedValue("assertive");
+
+    render(<CoworkerProfilePanel agent={makeAgent()} onClose={vi.fn()} />);
+
+    expect(await screen.findByText("Assertive")).toBeTruthy();
+    expect(screen.getByText(/Stay on this/i)).toBeTruthy();
+    expect(screen.queryByText(/proactivity:scheduled-task:assertive/i)).toBeNull();
   });
 });

--- a/apps/web/components/agent/CoworkerProfilePanel.tsx
+++ b/apps/web/components/agent/CoworkerProfilePanel.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { AgentInfo, AgentSkill } from "@/lib/agent-coworker-types";
+import { getCoworkerProactivityPreference } from "@/lib/actions/proactivity";
 import { getProactivityLevelCopy } from "@/lib/proactivity/proactivity-copy";
-import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
+import { resolveProactivityPlan, resolveProactivityPlanForLevel } from "@/lib/proactivity/proactivity-resolver";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 
 type Props = {
   agent: AgentInfo;
@@ -84,12 +86,28 @@ function formatProactivityEscalation(escalationTarget: string): string {
 
 export function CoworkerProfilePanel({ agent, onClose }: Props) {
   const [expandedSkill, setExpandedSkill] = useState<string | null>(null);
+  const [savedProactivityLevel, setSavedProactivityLevel] = useState<ProactivityLevel | null>(null);
   const grouped = groupSkillsByCategory(agent.skills);
-  const proactivityPlan = resolveProactivityPlan({
+  const proactivityInput = {
     activityFamily: "scheduled-task",
     agentId: agent.agentId,
-  });
+  } as const;
+  const proactivityPlan = savedProactivityLevel
+    ? resolveProactivityPlanForLevel(proactivityInput, savedProactivityLevel, "user-override")
+    : resolveProactivityPlan(proactivityInput);
   const proactivityCopy = getProactivityLevelCopy(proactivityPlan.resolvedLevel);
+
+  useEffect(() => {
+    let alive = true;
+    getCoworkerProactivityPreference(agent.agentId)
+      .then((level) => {
+        if (alive) setSavedProactivityLevel(level);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [agent.agentId]);
 
   // Separate skills from tools based on enriched data
   const skills = agent.skills.filter((s) => !s.allowedTools || s.allowedTools.length === 0 || s.taskType !== "tool");

--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx
@@ -5,10 +5,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getPosture = vi.fn();
 const savePosture = vi.fn();
+const getProactivityPreference = vi.fn();
+const saveProactivityPreference = vi.fn();
 
 vi.mock("@/lib/actions/golden-triangle", () => ({
   getCoworkerGoldenTrianglePosture: (agentId: string) => getPosture(agentId),
   saveCoworkerGoldenTrianglePosture: (agentId: string, pref: unknown) => savePosture(agentId, pref),
+}));
+
+vi.mock("@/lib/actions/proactivity", () => ({
+  getCoworkerProactivityPreference: (agentId: string) => getProactivityPreference(agentId),
+  saveCoworkerProactivityPreference: (agentId: string, level: unknown) => saveProactivityPreference(agentId, level),
 }));
 
 import { CoworkerPriorityDock } from "./CoworkerPriorityDock";
@@ -17,7 +24,11 @@ describe("CoworkerPriorityDock", () => {
   beforeEach(() => {
     getPosture.mockReset();
     savePosture.mockReset();
+    getProactivityPreference.mockReset();
+    saveProactivityPreference.mockReset();
     savePosture.mockResolvedValue({ ok: true });
+    getProactivityPreference.mockResolvedValue(null);
+    saveProactivityPreference.mockResolvedValue({ ok: true });
   });
 
   it("is collapsed by default — the resting state is the chip, triangle hidden until opened", async () => {
@@ -58,5 +69,19 @@ describe("CoworkerPriorityDock", () => {
     await waitFor(() => expect(savePosture).toHaveBeenCalledTimes(1), { timeout: 2000 });
     expect(savePosture.mock.calls[0][0]).toBe("agent-1");
     expect((savePosture.mock.calls[0][1] as { preset: string }).preset).toBe("assured");
+  });
+
+  it("loads and saves this coworker's proactivity level next to priority", async () => {
+    getPosture.mockResolvedValueOnce(null);
+    getProactivityPreference.mockResolvedValueOnce("assertive");
+
+    render(<CoworkerPriorityDock agentId="agent-1" />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Proactivity assertive/i })).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /Proactivity assertive/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Quiet/i }));
+
+    await waitFor(() => expect(saveProactivityPreference).toHaveBeenCalledWith("agent-1", "quiet"));
+    expect(screen.getByRole("button", { name: /Proactivity quiet/i })).toBeTruthy();
   });
 });

--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState } from "react";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
 
 import { getCoworkerGoldenTrianglePosture, saveCoworkerGoldenTrianglePosture } from "@/lib/actions/golden-triangle";
+import { getCoworkerProactivityPreference, saveCoworkerProactivityPreference } from "@/lib/actions/proactivity";
 
 import { ProactivityLevelControl } from "@/components/proactivity/ProactivityLevelControl";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
@@ -47,6 +48,18 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
     };
   }, [agentId]);
 
+  useEffect(() => {
+    let alive = true;
+    getCoworkerProactivityPreference(agentId)
+      .then((level) => {
+        if (alive && level) setProactivityLevel(level);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [agentId]);
+
   // Same meaningful label as the expanded control's badge — a dragged posture
   // reads e.g. "Lower Cost" (the corner it sits on), never a bare "Custom".
   const activeLabel = postureLabel(pref);
@@ -62,6 +75,11 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
         saveCoworkerGoldenTrianglePosture(agentId, next).catch(() => {});
       }
     }, 800);
+  }
+
+  function onProactivityChange(next: ProactivityLevel) {
+    setProactivityLevel(next);
+    saveCoworkerProactivityPreference(agentId, next).catch(() => {});
   }
 
   return (
@@ -96,7 +114,7 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
             {collapsed ? "▸" : "▾"}
           </span>
         </button>
-        <ProactivityLevelControl value={proactivityLevel} onChange={setProactivityLevel} />
+        <ProactivityLevelControl value={proactivityLevel} onChange={onProactivityChange} />
       </div>
       {!collapsed && (
         <div style={{ padding: "0 12px 10px" }}>

--- a/apps/web/lib/actions/proactivity.test.ts
+++ b/apps/web/lib/actions/proactivity.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  revalidatePath: vi.fn(),
+  prisma: {
+    userFact: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+
+import { getCoworkerProactivityPreference, saveCoworkerProactivityPreference } from "./proactivity";
+
+describe("proactivity actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.setSystemTime(new Date("2026-06-30T20:00:00.000Z"));
+    mocks.auth.mockResolvedValue({
+      user: { id: "user-1", platformRole: "HR-000", isSuperuser: true },
+    });
+    mocks.prisma.userFact.findFirst.mockResolvedValue(null);
+    mocks.prisma.userFact.update.mockResolvedValue({});
+    mocks.prisma.userFact.create.mockResolvedValue({});
+  });
+
+  it("reads the current user's agent-scoped proactivity preference", async () => {
+    mocks.prisma.userFact.findFirst.mockResolvedValueOnce({
+      value: JSON.stringify({
+        scope: "agent",
+        scopeKey: "agent:dispatcher",
+        level: "assertive",
+        source: "manual-setting",
+      }),
+    });
+
+    await expect(getCoworkerProactivityPreference("dispatcher")).resolves.toBe("assertive");
+    expect(mocks.prisma.userFact.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        category: "preference",
+        key: "aiCoworkerProactivity:agent:dispatcher",
+        supersededAt: null,
+      },
+      select: { value: true },
+      orderBy: { updatedAt: "desc" },
+    });
+  });
+
+  it("saves a manual agent-scoped proactivity preference for the current user", async () => {
+    const result = await saveCoworkerProactivityPreference("dispatcher", "quiet");
+
+    expect(result).toEqual({ ok: true });
+    expect(mocks.prisma.userFact.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        category: "preference",
+        key: "aiCoworkerProactivity:agent:dispatcher",
+        sourceRoute: "/platform/ai",
+        sourceAgentId: "dispatcher",
+        value: expect.any(String),
+        confidence: 1,
+        lastValidatedAt: new Date("2026-06-30T20:00:00.000Z"),
+      },
+    });
+    const savedValue = JSON.parse(mocks.prisma.userFact.create.mock.calls[0][0].data.value);
+    expect(savedValue).toMatchObject({
+      scope: "agent",
+      scopeKey: "agent:dispatcher",
+      level: "quiet",
+      source: "manual-setting",
+      acknowledgedByUserId: "user-1",
+    });
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/platform/ai");
+  });
+
+  it("updates the existing active preference fact instead of creating duplicates", async () => {
+    mocks.prisma.userFact.findFirst.mockResolvedValueOnce({ id: "fact-1" });
+
+    await saveCoworkerProactivityPreference("dispatcher", "assertive");
+
+    expect(mocks.prisma.userFact.update).toHaveBeenCalledWith({
+      where: { id: "fact-1" },
+      data: expect.objectContaining({
+        value: expect.any(String),
+        confidence: 1,
+        sourceRoute: "/platform/ai",
+        sourceAgentId: "dispatcher",
+      }),
+    });
+    expect(mocks.prisma.userFact.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/proactivity.ts
+++ b/apps/web/lib/actions/proactivity.ts
@@ -1,0 +1,95 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import {
+  persistProactivityFact,
+  PROACTIVITY_FACT_CATEGORY,
+  PROACTIVITY_OVERRIDE_FACT_PREFIX,
+} from "@/lib/proactivity/proactivity-override-preferences";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import { isProactivityLevel } from "@/lib/proactivity/proactivity-types";
+
+type ManualProactivityPreferenceValue = {
+  scope: "agent";
+  scopeKey: string;
+  level: ProactivityLevel;
+  source: "manual-setting";
+  acknowledgedByUserId: string;
+  acknowledgedAt: string;
+};
+
+export async function getCoworkerProactivityPreference(agentId: string): Promise<ProactivityLevel | null> {
+  const user = await currentUser();
+  if (!user || !agentId) return null;
+
+  const fact = await prisma.userFact.findFirst({
+    where: {
+      userId: user.id,
+      category: PROACTIVITY_FACT_CATEGORY,
+      key: proactivityAgentFactKey(agentId),
+      supersededAt: null,
+    },
+    select: { value: true },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return readProactivityLevel(fact?.value);
+}
+
+export async function saveCoworkerProactivityPreference(
+  agentId: string,
+  level: ProactivityLevel,
+): Promise<{ ok: boolean }> {
+  const user = await currentUser();
+  if (!user || !agentId || !isProactivityLevel(level)) return { ok: false };
+
+  const now = new Date();
+  const value: ManualProactivityPreferenceValue = {
+    scope: "agent",
+    scopeKey: proactivityAgentScopeKey(agentId),
+    level,
+    source: "manual-setting",
+    acknowledgedByUserId: user.id,
+    acknowledgedAt: now.toISOString(),
+  };
+
+  await persistProactivityFact(user.id, {
+    category: PROACTIVITY_FACT_CATEGORY,
+    key: proactivityAgentFactKey(agentId),
+    value: JSON.stringify(value),
+    sourceRoute: "/platform/ai",
+    sourceAgentId: agentId,
+    lastValidatedAt: now,
+  });
+
+  revalidatePath("/platform/ai");
+  revalidatePath(`/platform/ai/agent/${agentId}`);
+  return { ok: true };
+}
+
+function proactivityAgentScopeKey(agentId: string): string {
+  return `agent:${agentId}`;
+}
+
+function proactivityAgentFactKey(agentId: string): string {
+  return `${PROACTIVITY_OVERRIDE_FACT_PREFIX}:${proactivityAgentScopeKey(agentId)}`;
+}
+
+async function currentUser(): Promise<{ id: string } | null> {
+  const session = await auth();
+  return session?.user?.id ? { id: session.user.id } : null;
+}
+
+function readProactivityLevel(value: string | null | undefined): ProactivityLevel | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as { level?: unknown };
+    return isProactivityLevel(parsed.level) ? parsed.level : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/proactivity/proactivity-resolver.test.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
 
 import { getProactivityLevelCopy } from "./proactivity-copy";
-import { resolveProactivityPlan } from "./proactivity-resolver";
+import { resolveProactivityPlan, resolveProactivityPlanForLevel } from "./proactivity-resolver";
 import { resolveUserAwareProactivityPlan } from "./proactivity-resolver.server";
 import { PROACTIVITY_ACTIVITY_FAMILIES, PROACTIVITY_LEVELS, isProactivityLevel } from "./proactivity-types";
 
@@ -92,6 +92,14 @@ describe("resolveProactivityPlan", () => {
 
     expect(plan.resolvedLevel).toBe("assertive");
     expect(["advise", "propose"]).toContain(plan.actionBoundary);
+  });
+
+  it("keeps forced assertive fallback explanation aligned with the resolved level", () => {
+    const plan = resolveProactivityPlanForLevel({ activityFamily: "scheduled-task" }, "assertive", "user-override");
+
+    expect(plan.resolvedLevel).toBe("assertive");
+    expect(plan.explanation).toMatch(/stay on this|warn earlier|escalate sooner/i);
+    expect(plan.explanation).not.toMatch(/quiet minimizes/i);
   });
 });
 

--- a/apps/web/lib/proactivity/proactivity-resolver.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.ts
@@ -153,7 +153,11 @@ function explanationFor(input: ProactivityResolverInput, level: ProactivityLevel
     return "A compliance deadline is close enough to justify assertive reminders while keeping advice and filing approval-gated.";
   }
 
-  return level === "balanced"
-    ? "Balanced is the default proactivity level for useful follow-up without noisy repeated interruption."
-    : "Quiet minimizes unsolicited follow-up unless urgency or prior approval justifies attention.";
+  if (level === "balanced") {
+    return "Balanced is the default proactivity level for useful follow-up without noisy repeated interruption.";
+  }
+  if (level === "assertive") {
+    return "Stay on this, warn earlier, and escalate sooner while preserving approval boundaries.";
+  }
+  return "Quiet minimizes unsolicited follow-up unless urgency or prior approval justifies attention.";
 }

--- a/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
+++ b/docs/superpowers/plans/2026-06-29-ai-coworker-proactivity-policy.md
@@ -30,10 +30,12 @@
 - Create `apps/web/components/proactivity/ProactivityGaugeIcon.tsx`: compact gauge icon if stock Lucide cannot represent needle positions well enough.
 - Create `apps/web/components/proactivity/ProactivityLevelControl.tsx`: compact dock control and expanded segmented picker.
 - Create `apps/web/components/proactivity/ProactivityLevelControl.test.tsx`: interaction and accessible-label tests.
+- Create `apps/web/lib/actions/proactivity.ts`: server actions for reading and writing the current user's agent-scoped proactivity preference via `UserFact`.
+- Create `apps/web/lib/actions/proactivity.test.ts`: preference read/write tests for the manual dock setting.
 - Modify `apps/web/components/golden-triangle/CoworkerPriorityDock.tsx`: render the proactivity chip beside the golden triangle and keep the dock collapsed by default.
-- Modify `apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx`: assert dock layout, collapsed state, and mobile-safe labels.
-- Modify `apps/web/components/agent/CoworkerProfilePanel.tsx`: show effective proactivity explanation and advanced policy details.
-- Modify `apps/web/components/agent/CoworkerProfilePanel.test.tsx` or add one if no local test exists.
+- Modify `apps/web/components/golden-triangle/CoworkerPriorityDock.test.tsx`: assert dock layout, collapsed state, persisted proactivity loading/saving, and mobile-safe labels.
+- Modify `apps/web/components/agent/CoworkerProfilePanel.tsx`: show effective proactivity explanation and advanced policy details using the same saved preference as the dock.
+- Modify `apps/web/components/agent/CoworkerProfilePanel.test.tsx` or add one if no local test exists; assert saved preference consistency and no raw policy IDs.
 - Modify `apps/web/lib/tak/autonomous-work-run.ts`: accept optional proactivity metadata and write it into `TaskRun.a2aMetadata.proactivity`.
 - Modify `apps/web/lib/tak/scheduled-task-runs.ts`: accept proactivity metadata for scheduled runs if this helper owns the actual `TaskRun` create path.
 - Modify `apps/web/lib/actions/agent-task-scheduler.ts`: resolve and pass scheduled-task proactivity plan without bypassing owner/tool/HITL checks.

--- a/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md
@@ -221,6 +221,8 @@ type ProactivityPlan = {
 
 The plan is written into `TaskRun.a2aMetadata.proactivity` for work that creates a `TaskRun`, and into the relevant outbound/action metadata when no task run exists yet.
 
+Manual UI changes use the same `UserFact` preference substrate as acknowledged coworker proposals. A user changing the dock control writes an agent-scoped fact keyed `aiCoworkerProactivity:agent:<agentId>` with `source = "manual-setting"`. The server resolver already treats that fact as a user override, so scheduled work, field-dispatch proposal builders, and future Attention Surface projections consume the same value without a second settings table.
+
 ## 6. Resolution Order
 
 The resolver answers: "Given this activity, what level and behavior should apply?"
@@ -604,10 +606,13 @@ Files:
 - Modify `apps/web/components/golden-triangle/CoworkerPriorityDock.tsx`
 - Modify `apps/web/components/agent/CoworkerProfilePanel.tsx`
 - Add small presentational component if needed: `ProactivityLevelControl.tsx`
+- Add `apps/web/lib/actions/proactivity.ts` for user-scoped manual dock reads/writes through `UserFact`.
 
 Acceptance:
 
 - compact level control renders beside the golden-triangle priority chip without crowding the composer dock.
+- dock changes persist as agent-scoped `UserFact` preferences and reload for the same user/coworker.
+- profile/details summary reads the same saved preference and does not show a contradictory default level.
 - mobile folds control into profile/details.
 - green/yellow/red accents map Quiet/Balanced/Assertive while preserving text labels and accessible names.
 - copy uses shared proactivity copy.


### PR DESCRIPTION
## Summary
- Persist the composer proactivity control as the current user's agent-scoped `UserFact` preference.
- Load and save the same Quiet/Balanced/Assertive level beside the golden-triangle priority dock.
- Make the coworker profile summary read the same saved preference so it does not show a contradictory default.
- Fix forced Assertive fallback copy so resolver explanations match the resolved level.
- Update the proactivity spec/plan to document manual dock writes and cross-surface preference consistency.

## Verification
- `pnpm --filter web exec vitest run lib/actions/proactivity.test.ts components/golden-triangle/CoworkerPriorityDock.test.tsx components/agent/CoworkerProfilePanel.test.tsx lib/proactivity/proactivity-resolver.test.ts lib/proactivity/proactivity-override-preferences.test.ts` - 5 files, 24 tests passed.
- `node scripts/check-module-size.mjs` - passed.
- `node scripts/check-spec-plan-doc.mjs` - passed/no gated source delta reported; this PR includes spec and plan updates.
- `pnpm --filter web typecheck` - passed.
- `pnpm --filter web build` - passed with existing Turbopack Edge/NFT warnings.

## Notes
- No migration: V1 continues to use `UserFact` preference records keyed `aiCoworkerProactivity:agent:<agentId>`.
- Bootstrap in this new worktree hit the known `scripts/dpf-bootstrap-agent-toolchain.ps1:206` `ConvertFrom-Json` issue; source-local gates above were run successfully.