### PR TITLE
fix: return delegated ids from a2a task creation

### DIFF
--- a/apps/web/lib/coworker-service-catalog/a2a-tasks.test.ts
+++ b/apps/web/lib/coworker-service-catalog/a2a-tasks.test.ts
@@ -65,6 +65,8 @@ describe("Coworker A2A task lifecycle", () => {
     const createEngagement = vi.fn(async (_input: CreateCoworkerEngagementInput): Promise<CoworkerEngagementResult> => ({
       engagementId: "CE-A2A",
       status: "requested",
+      serviceId: "svc-sales",
+      providerAgentId: "sales-coworker",
       workCapsuleId: null,
       approvalContext: { required: false, reasons: [] },
     }));
@@ -108,6 +110,9 @@ describe("Coworker A2A task lifecycle", () => {
     expect(task).toMatchObject({
       id: "CE-A2A",
       contextId: "ctx-1",
+      serviceId: "svc-sales",
+      providerAgentId: "sales-coworker",
+      metadata: { delegatedAgentId: "sales-coworker" },
       status: { state: "submitted" },
     });
   });

--- a/apps/web/lib/coworker-service-catalog/a2a-tasks.ts
+++ b/apps/web/lib/coworker-service-catalog/a2a-tasks.ts
@@ -116,8 +116,8 @@ export async function createCoworkerA2aTask(
   return mapCoworkerEngagementToA2aTask({
     engagementId: result.engagementId,
     offerId: input.offerId,
-    serviceId: "",
-    providerAgentId: "",
+    serviceId: result.serviceId,
+    providerAgentId: result.providerAgentId,
     requestedOutcome: input.requestedOutcome,
     status: result.status,
     inputPayload: input.inputPayload ?? {},

--- a/apps/web/lib/coworker-service-catalog/engagements.ts
+++ b/apps/web/lib/coworker-service-catalog/engagements.ts
@@ -24,6 +24,8 @@ type DbClient = {
   coworkerEngagement: {
     create(args: unknown): Promise<{
       engagementId: string;
+      serviceId: string;
+      providerAgentId: string;
       status: string;
       workCapsuleId: string | null;
       approvalContext: unknown;
@@ -50,6 +52,8 @@ export type CreateCoworkerEngagementInput = {
 
 export type CoworkerEngagementResult = {
   engagementId: string;
+  serviceId: string;
+  providerAgentId: string;
   status: CoworkerEngagementStatus;
   workCapsuleId: string | null;
   approvalContext: {
@@ -99,6 +103,8 @@ export async function createCoworkerEngagement(
 
   return {
     engagementId: created.engagementId,
+    serviceId: created.serviceId,
+    providerAgentId: created.providerAgentId,
     status,
     workCapsuleId: created.workCapsuleId,
     approvalContext,


### PR DESCRIPTION
## Summary
- return `serviceId` and `providerAgentId` from coworker engagement creation
- use those IDs in the immediate A2A task creation response
- add a regression test for delegated IDs in the submitted A2A task

## Verification
- `corepack pnpm@10.33.2 --filter web exec vitest run lib/coworker-service-catalog/a2a-tasks.test.ts lib/coworker-service-catalog/engagements.test.ts app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts app/api/a2a/tasks/[taskId]/route.test.ts`
- `corepack pnpm@10.33.2 --filter web typecheck`
- `corepack pnpm@10.33.2 --filter web build`

Process-Spine-Decision: No new durable artifact required; this is a focused API response bugfix covered by an existing coworker A2A lifecycle test.