### PR TITLE
fix: include coworker catalog grants in mcp templates

### DIFF
--- a/apps/web/lib/mcp-token-scopes.test.ts
+++ b/apps/web/lib/mcp-token-scopes.test.ts
@@ -124,6 +124,16 @@ describe("MCP_TOKEN_TEMPLATES", () => {
       expect(development!.grants).toContain(grant);
     }
   });
+
+  it("includes coworker service catalog grants in development and admin templates", () => {
+    const development = getMcpTokenTemplate("development");
+    const admin = getMcpTokenTemplate("admin");
+
+    for (const template of [development, admin]) {
+      expect(template?.grants).toContain("coworker_catalog_read");
+      expect(template?.grants).toContain("coworker_engagement_write");
+    }
+  });
 });
 
 describe("resolveTemplateGrants", () => {
@@ -161,6 +171,8 @@ describe("templateScopesForTier", () => {
       "build_plan_write",
       "registry_read",
       "decision_record_create",
+      "coworker_catalog_read",
+      "coworker_engagement_write",
     ]) {
       expect(scopes).toContain(g);
     }

--- a/apps/web/lib/mcp-token-scopes.ts
+++ b/apps/web/lib/mcp-token-scopes.ts
@@ -189,6 +189,7 @@ const DEVELOPMENT_TEMPLATE_GRANTS = [
   "telemetry_read",
   "portfolio_read",
   "document_read",
+  "coworker_catalog_read",
   // Writes / actions for the build-studio + ship loop
   "backlog_write",
   "backlog_triage",
@@ -206,6 +207,7 @@ const DEVELOPMENT_TEMPLATE_GRANTS = [
   "decision_record_create",
   "tool_evaluation_create",
   "document_write",
+  "coworker_engagement_write",
 ] as const;
 
 const EMPLOYEE_FINANCE_TEMPLATE_GRANTS = [


### PR DESCRIPTION
## Summary
- add `coworker_catalog_read` and `coworker_engagement_write` to development/admin MCP token templates
- add regression coverage so default write/admin templates expose the coworker catalog MCP surface

## Verification
- `corepack pnpm@10.33.2 --filter web exec vitest run lib/mcp-token-scopes.test.ts lib/mcp-tools-coworker-service-catalog.test.ts lib/mcp/tool-registry.test.ts lib/coworker-service-catalog/a2a-tasks.test.ts lib/coworker-service-catalog/engagements.test.ts app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts app/api/a2a/tasks/[taskId]/route.test.ts`
- `corepack pnpm@10.33.2 --filter web typecheck`
- `corepack pnpm@10.33.2 --filter web build`

Process-Spine-Decision: No new durable artifact required; this is a token-template wiring fix for the coworker catalog MCP surface with focused tests.