### PR TITLE
fix(db): reconcile emits capabilityCategory, not renamed capabilityTier

### DIFF
--- a/packages/db/scripts/reconcile-catalog-capabilities.test.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.test.ts
@@ -15,7 +15,7 @@ const sampleModel: KnownModel = {
   outputModalities: ["text"],
   modelClass: "chat",
   modelFamily: "gpt-5",
-  capabilityTier: "tier-1",
+  capabilityCategory: "advanced",
   costTier: "premium",
   bestFor: ["tool-use"],
   avoidFor: [],
@@ -67,6 +67,16 @@ describe("catalogEntryToProfileFields", () => {
     expect(fields.toolFidelity).toBe(80);
     expect((fields.capabilities as any).toolUse).toBe(true);
     expect(fields.modelStatus).toBe("active");
+  });
+
+  // Regression: the create path requires the non-nullable ModelProfile.capabilityCategory
+  // column. A pre-#318 mapping emitted `capabilityTier` (renamed away) and omitted
+  // capabilityCategory, which Prisma rejects on create — crashing catalog reconciliation
+  // the first time a brand-new catalog model is seen (e.g. zai/glm-5.2).
+  it("emits capabilityCategory (not the renamed capabilityTier) so create() satisfies the schema", () => {
+    const fields = catalogEntryToProfileFields(sampleModel) as Record<string, unknown>;
+    expect(fields.capabilityCategory).toBe("advanced");
+    expect(fields).not.toHaveProperty("capabilityTier");
   });
 });
 

--- a/packages/db/scripts/reconcile-catalog-capabilities.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.ts
@@ -44,7 +44,7 @@ export type ProfileUpdateShape = {
   modelFamily: string | null;
   friendlyName: string;
   summary: string;
-  capabilityTier: string;
+  capabilityCategory: string;
   costTier: string;
   qualityTier: string;
   modelStatus: string;
@@ -158,7 +158,7 @@ export function catalogEntryToProfileFields(entry: KnownModel): ProfileUpdateSha
     modelFamily: entry.modelFamily ?? null,
     friendlyName: entry.friendlyName,
     summary: entry.summary,
-    capabilityTier: entry.capabilityTier,
+    capabilityCategory: entry.capabilityCategory,
     costTier: entry.costTier,
     qualityTier: entry.qualityTier,
     modelStatus: entry.defaultStatus === "active"


### PR DESCRIPTION
## Problem

The main portal crash-loops on boot (`:3000` never comes up). Boot log:

```
Argument `capabilityCategory` is missing.
  at reconcile (/app/packages/db/scripts/reconcile-catalog-capabilities.ts:240)
[portal-boot] FATAL: catalog capability reconciliation failed
```

## Root cause

The catalog-reconcile script never got the Phase B rename from #318
(`ModelProfile.capabilityTier` → `capabilityCategory`). `catalogEntryToProfileFields`
still read `entry.capabilityTier` — now `undefined`, since the catalog `KnownModel`
type carries `capabilityCategory` — and wrote it to a `capabilityTier` field that no
longer exists on `ModelProfile`, while omitting the required, non-nullable
`capabilityCategory` column.

- **Update path masked it:** the phantom field diffs to equal, and existing rows already have the column populated.
- **Create path did not:** the first time a brand-new catalog model is reconciled (here `zai/glm-5.2`, added since the last profile snapshot), `modelProfile.create` throws `PrismaClientValidationError: Argument 'capabilityCategory' is missing`. Boot-time reconcile treats that as fatal → portal restart loop.

This is a latent regression that only surfaces when a genuinely new model enters `KNOWN_PROVIDER_MODELS` (cf. the earlier `docs/superpowers/audits/2026-04-28-rename-318-drift-surfaces.md`).

## Fix

- Rename `capabilityTier` → `capabilityCategory` in `ProfileUpdateShape` and in the `catalogEntryToProfileFields` mapping, so the create payload includes the required column.
- Add a regression test asserting the emitted shape carries `capabilityCategory` and **not** the renamed `capabilityTier`.

## Verification

- `pnpm --filter @dpf/db exec vitest run scripts/reconcile-catalog-capabilities.test.ts` → 10/10 pass.
- `pnpm --filter @dpf/db run typecheck` (`tsc --noEmit`) → clean.
- Live install unblocked out-of-band by running the fixed reconcile once against the running DB (created `zai/glm-5.2` + `zai-coding/glm-5.2`); portal now boots healthy with `0` restarts. This PR makes that fix durable so a rebuilt image boots cleanly on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)