### PR TITLE
fix(db): bulletproof the provider/model catalog boot path (typecheck + non-fatal reconcile)

### DIFF
--- a/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
+++ b/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
@@ -111,6 +111,28 @@ describe.skipIf(!BASH_OK)("portal-migrate-boot.sh (BI-5322D025)", () => {
     }
   }, TIMEOUT_MS);
 
+  it("DEGRADES OPEN — still starts the server when model-capability reconciliation fails", () => {
+    // Regression guard for the portal boot-loop: a stale/partial model catalog is a
+    // degraded state, not a correctness hazard, so reconcile-catalog-capabilities.ts
+    // failing (e.g. a new/renamed model the reconciler can't write) must NOT block boot.
+    const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
+    try {
+      const appDir = join(root, "app");
+      mkdirSync(appDir, { recursive: true });
+      const r = run({
+        appDir,
+        fakeBin: makeFakeBin(root),
+        pnpmExit: 0,
+        pnpmFailMatch: "scripts/reconcile-catalog-capabilities.ts",
+      });
+      expect(r.status).toBe(0); // boot still succeeds
+      expect(r.stderr).toContain("catalog capability reconciliation failed");
+      expect(r.stdout).toContain("BOOT_MARKER"); // server WAS started despite the failure
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, TIMEOUT_MS);
+
   it("FAILS CLOSED — does not start the server when migrations cannot apply", () => {
     const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
     try {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -50,7 +50,7 @@
     "skills:audit": "tsx src/skill-quality-audit.ts",
     "studio": "prisma studio",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.scripts.json --noEmit",
     "neo4j:rebuild-ea": "tsx src/neo4j-rebuild-ea.ts",
     "neo4j:rebuild-documents": "tsx src/neo4j-rebuild-documents.ts"
   },

--- a/packages/db/scripts/reconcile-catalog-capabilities.test.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildCatalogHash, diffExcludingOverrides, catalogEntryToProfileFields, resolveKnownProviderModelsPath } from "./reconcile-catalog-capabilities";
 import type { KnownModel } from "../../../apps/web/lib/routing/known-provider-models";
+import { KNOWN_PROVIDER_MODELS } from "../../../apps/web/lib/routing/known-provider-models";
 import { EMPTY_CAPABILITIES } from "../../../apps/web/lib/routing/model-card-types";
 
 const sampleModel: KnownModel = {
@@ -124,5 +125,40 @@ describe("admin row-level protection", () => {
     const diff = diffExcludingOverrides(profile as any, entry as any, null);
     expect(diff).toEqual({ supportsToolUse: true, toolFidelity: 80 });
     // The reconcile loop (not this helper) is responsible for skipping admin+null rows.
+  });
+});
+
+// Catalog-integrity guard — the whole point of "bulletproof": every model that ships
+// in KNOWN_PROVIDER_MODELS must map to a create-ready ModelProfile shape. Adding a new
+// model (e.g. Sonnet 5), or editing one during a retire/deprecate, that omits a
+// required column or uses a bad status now fails CI with a per-model message, instead
+// of surfacing as a boot-time PrismaClientValidationError on the create path.
+describe("catalog integrity — every KNOWN_PROVIDER_MODELS entry is create-ready", () => {
+  const allEntries: Array<{ providerId: string; modelId: string; model: KnownModel }> =
+    Object.entries(KNOWN_PROVIDER_MODELS).flatMap(([providerId, models]) =>
+      (models as KnownModel[]).map((model) => ({ providerId, modelId: model.modelId, model })),
+    );
+
+  it("has at least one catalog model", () => {
+    expect(allEntries.length).toBeGreaterThan(0);
+  });
+
+  // Required, non-nullable ModelProfile columns that catalogEntryToProfileFields supplies.
+  const REQUIRED_STRING_COLUMNS = ["capabilityCategory", "costTier", "friendlyName", "summary", "modelClass"] as const;
+  const VALID_MODEL_STATUSES = ["active", "retired", "disabled"];
+
+  it.each(allEntries)("$providerId/$modelId maps to a valid profile shape", ({ providerId, modelId, model }) => {
+    const label = `${providerId}/${modelId}`;
+    const fields = catalogEntryToProfileFields(model) as Record<string, unknown>;
+
+    for (const col of REQUIRED_STRING_COLUMNS) {
+      const value = fields[col];
+      expect(typeof value, `${label} — column '${col}' must be a string`).toBe("string");
+      expect((value as string).length, `${label} — column '${col}' must be non-empty`).toBeGreaterThan(0);
+    }
+    // Retire/deprecate path: defaultStatus drives modelStatus; must land on a known value.
+    expect(VALID_MODEL_STATUSES, `${label} — modelStatus`).toContain(fields.modelStatus);
+    // Hashing must be deterministic and never throw (used for idempotent reconcile).
+    expect(() => buildCatalogHash(model)).not.toThrow();
   });
 });

--- a/packages/db/scripts/reconcile-catalog-capabilities.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.ts
@@ -16,6 +16,7 @@ import { existsSync } from "fs";
 import { dirname, posix, resolve as nativeResolve, win32 } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { prisma } from "../src/client";
+import type { Prisma } from "../generated/client/client";
 import type { KnownModel } from "../../../apps/web/lib/routing/known-provider-models";
 
 type KnownProviderModelsByProvider = Record<string, KnownModel[]>;
@@ -51,6 +52,20 @@ export type ProfileUpdateShape = {
   metadataSource: string;
   metadataConfidence: string;
 };
+
+// Compile-time drift guard — this would have caught #318 (ModelProfile.capabilityTier
+// → capabilityCategory). Every key this mapping writes MUST be a real column on the
+// generated ModelProfile create input. A schema rename that leaves a stale key here (or
+// a typo'd column) makes this line fail `tsc`, so CI's typecheck gate blocks the merge —
+// instead of the reconciler throwing PrismaClientValidationError and crash-looping the
+// portal at boot the first time a brand-new catalog model reaches the create path.
+// NOTE: object-literal spreads (`...fields`) suppress TS's missing-required-property
+// check at the create call site, so relying on the create payload's type is NOT enough —
+// this explicit key assertion is the safeguard that actually bites.
+type _ProfileShapeKeysAreRealColumns =
+  keyof ProfileUpdateShape extends keyof Prisma.ModelProfileUncheckedCreateInput ? true : never;
+const _assertProfileShapeKeysAreRealColumns: _ProfileShapeKeysAreRealColumns = true;
+void _assertProfileShapeKeysAreRealColumns;
 
 function isWindowsAbsolutePath(value: string): boolean {
   return /^[a-zA-Z]:[\\/]/.test(value) || /^\\\\/.test(value);
@@ -149,7 +164,7 @@ export function catalogEntryToProfileFields(entry: KnownModel): ProfileUpdateSha
     structuredOutputScore: scores.structuredOutputScore,
     conversational: scores.conversational,
     contextRetention: scores.contextRetention,
-    capabilities: entry.capabilities as Record<string, unknown>,
+    capabilities: entry.capabilities as unknown as Record<string, unknown>,
     maxContextTokens: entry.maxContextTokens,
     maxOutputTokens: entry.maxOutputTokens,
     inputModalities: entry.inputModalities,
@@ -188,7 +203,9 @@ async function logChanges(
     source,
   }));
   if (entries.length > 0) {
-    await prisma.modelCapabilityChangeLog.createMany({ data: entries });
+    await prisma.modelCapabilityChangeLog.createMany({
+      data: entries as Prisma.ModelCapabilityChangeLogCreateManyInput[],
+    });
   }
 }
 
@@ -198,6 +215,7 @@ async function reconcile(): Promise<void> {
   let updated = 0;
   let skipped = 0;
   let noChange = 0;
+  let failed = 0;
 
   // Prune change log entries older than 90 days
   const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
@@ -209,6 +227,12 @@ async function reconcile(): Promise<void> {
   for (const [providerId, models] of Object.entries(KNOWN_PROVIDER_MODELS)) {
     for (const entry of models) {
       const { modelId } = entry;
+      // Per-model isolation: one bad model (e.g. a catalog/schema mismatch that
+      // makes the create payload invalid) must not abort the whole reconcile or
+      // crash the portal at boot. Log it loudly, count it, and move on — every
+      // other model still reconciles. The shell invocation is already non-fatal;
+      // this keeps a single failure from starving all models that follow it.
+      try {
       const hash = buildCatalogHash(entry);
 
       const profile = await prisma.modelProfile.findFirst({
@@ -247,7 +271,7 @@ async function reconcile(): Promise<void> {
             bestFor: entry.bestFor,
             avoidFor: entry.avoidFor,
             ...fields,
-          } as Parameters<typeof prisma.modelProfile.create>[0]["data"],
+          } as Prisma.ModelProfileUncheckedCreateInput,
         });
         console.log(`  CREATED  ${providerId}/${modelId}`);
         const newFieldsForLog = fields as unknown as Record<string, unknown>;
@@ -308,10 +332,18 @@ async function reconcile(): Promise<void> {
         "catalog",
       );
       updated++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`  FAILED   ${providerId}/${modelId}: ${message}`);
+        failed++;
+      }
     }
   }
 
-  console.log(`\nCatalog reconciliation: ${created} created, ${updated} updated, ${skipped} skipped (discovery/admin-owned), ${noChange} unchanged.`);
+  console.log(`\nCatalog reconciliation: ${created} created, ${updated} updated, ${skipped} skipped (discovery/admin-owned), ${noChange} unchanged, ${failed} failed.`);
+  if (failed > 0) {
+    console.error(`  WARNING: ${failed} model(s) failed to reconcile (see FAILED lines above). Portal boot continues; affected models keep their prior profile, or none if brand-new.`);
+  }
 }
 
 // Only run reconcile() when invoked directly (e.g. `tsx scripts/reconcile-catalog-capabilities.ts`).

--- a/packages/db/tsconfig.scripts.json
+++ b/packages/db/tsconfig.scripts.json
@@ -1,0 +1,25 @@
+// Typecheck scope for boot-critical DB scripts that the main tsconfig
+// (include: ["src", "generated"]) does NOT cover.
+//
+// Why this exists: reconcile-catalog-capabilities.ts runs on every portal boot
+// (docker-entrypoint.sh step 3b) and writes ModelProfile rows. It was outside the
+// typecheck boundary, so the #318 capabilityTier -> capabilityCategory rename left a
+// stale field here that no `tsc` ever saw — surfacing only as a fatal
+// PrismaClientValidationError the first time a brand-new catalog model hit the create
+// path, crash-looping the portal. Bringing this file under `pnpm typecheck` (wired via
+// the package's typecheck script, so both the pre-commit hook and CI enforce it) makes
+// that class of schema/code drift a build failure instead of a boot failure.
+//
+// Scope is intentionally narrow (the boot-critical reconciler) so the gate stays green;
+// widen `include` as other scripts are made type-clean.
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "scripts/reconcile-catalog-capabilities.ts",
+    "scripts/reconcile-catalog-capabilities.test.ts",
+    "generated"
+  ]
+}

--- a/scripts/portal-migrate-boot.sh
+++ b/scripts/portal-migrate-boot.sh
@@ -42,10 +42,20 @@ if ! pnpm --filter @dpf/db exec tsx scripts/sync-provider-registry.ts; then
   exit 1
 fi
 
+# Model-capability reconciliation is NON-FATAL — unlike migrations (a drifted *schema*
+# is unsafe to serve) and the provider registry above (providers gate backend auth),
+# this step only refreshes advisory model-capability metadata (which model is good at
+# what). A stale, partial, or slightly-wrong model catalog is a DEGRADED state, not a
+# correctness hazard: the portal serves fine on the model catalog already in the DB.
+# Blocking boot on it is what crash-looped the portal when a single new or renamed
+# model made the reconciler throw (the #318 capabilityTier -> capabilityCategory drift;
+# a brand-new model hitting the create path). Models get added, retired, and deprecated
+# routinely, so this step degrades loudly and never fails the whole boot. Failures are
+# logged; the catalog keeps its prior state until the next successful reconcile, and
+# CI's typecheck + catalog-integrity tests catch bad catalog changes before they ship.
 if ! pnpm --filter @dpf/db exec tsx scripts/reconcile-catalog-capabilities.ts; then
-  echo "[portal-boot] FATAL: catalog capability reconciliation failed" >&2
-  exit 1
+  echo "[portal-boot] WARN: catalog capability reconciliation failed — starting with the existing model catalog (see error above)" >&2
 fi
 
-echo "[portal-boot] provider catalog reconciled; starting server"
+echo "[portal-boot] provider catalog reconciled (or degraded); starting server"
 exec "$@"


### PR DESCRIPTION
## Why

Follow-up to #2538 (the `capabilityTier → capabilityCategory` rename that crash-looped the portal). That PR fixed the specific drift; this one makes the whole provider/model catalog path — **add, retire, deprecate** — incapable of taking the portal down, and catches this class of bug at CI instead of at boot.

**Root safeguard gap:** `packages/db/tsconfig.json` includes only `["src", "generated"]`, so `packages/db/scripts/` — including `reconcile-catalog-capabilities.ts`, which runs on **every portal boot** — was never typechecked. A blatant type error there produced zero build errors. That is exactly why #318's stale `capabilityTier` reference survived to crash the portal the first time a brand-new model hit the create path.

## Defense in depth (5 layers)

1. **Typecheck coverage** — new `packages/db/tsconfig.scripts.json` brings the boot reconciler under `tsc`, wired into the package `typecheck` script so **both the pre-commit hook and CI** enforce it. Scope is intentionally narrow (the boot-critical script) so the gate stays green; widen as other scripts are made type-clean.
2. **Compile-time column-drift guard** — `keyof ProfileUpdateShape extends keyof Prisma.ModelProfileUncheckedCreateInput`. Any key the catalog mapping writes that is not a real `ModelProfile` column (a rename leaving a stale field, a typo) now fails `tsc`. Verified: re-injecting the #318 bug trips `error TS2322: Type 'true' is not assignable to type 'never'`.
3. **Per-model runtime isolation** — the per-model reconcile body is wrapped in try/catch, so one bad or brand-new model logs a `FAILED` line and is counted instead of aborting the whole run. Summary reports a `failed` count.
4. **Non-fatal boot** — `scripts/portal-migrate-boot.sh` ran the reconciler as a fatal gate (`exit 1`); one new/renamed model the reconciler couldn't write crash-looped the whole portal. Migrations stay fail-closed (a drifted **schema** is unsafe to serve) and provider-registry sync stays fail-closed (providers gate backend auth), but model-capability metadata is advisory — a stale/partial model catalog is a degraded state, not a correctness hazard. It now degrades loudly (`WARN`) and the server still starts on the catalog already in the DB. **This is the guarantee the portal always boots.**
5. **Catalog-integrity test** — over the real `KNOWN_PROVIDER_MODELS`, every shipped model is asserted to map to a create-ready `ModelProfile` shape (required non-null columns present + non-empty; `modelStatus ∈ {active,retired,disabled}`; hash deterministic). Adding a model (e.g. Sonnet 5) or editing one during retire/deprecate that omits a required column now fails CI with a per-model message.

## Verification

- `pnpm --filter @dpf/db run typecheck` (both configs) → exits 0
- reconcile + catalog-integrity suite → 23/23
- `portal-migrate-boot` suite → 6/6 (incl. new "DEGRADES OPEN" case)

## Note for reviewers / ops

The currently-running self-upgrade image predates #2538 and still has the fatal reconcile gate — a rebuild from `main` after this merges is needed for the fixes to actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)