### PR TITLE
fix(marketing): harden dueWindow parsing + metric coercion (pre-live-run hardening)

### DIFF
--- a/apps/web/lib/marketing/campaign-performance.test.ts
+++ b/apps/web/lib/marketing/campaign-performance.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { summarizeCampaignPerformance, type PublicationMetricRow } from "./campaign-performance";
+import {
+  metricRowFromSnapshot,
+  summarizeCampaignPerformance,
+  type PublicationMetricRow,
+} from "./campaign-performance";
 
 const rows: PublicationMetricRow[] = [
   { channel: "linkedin-personal-social", impressions: 10_000, clicks: 300, costInUsdCents: 0, conversions: 12 },
@@ -91,5 +95,28 @@ describe("summarizeCampaignPerformance", () => {
     const r = summarizeCampaignPerformance({ rows, budgetTotalCents: 100_000 });
     expect(r.headline).toMatch(/CTR/);
     expect(r.headline).toMatch(/40% of budget/);
+  });
+});
+
+describe("metricRowFromSnapshot", () => {
+  it("reads numeric fields from a well-formed snapshot", () => {
+    const row = metricRowFromSnapshot("linkedin", {
+      impressions: 100,
+      clicks: 10,
+      costInUsdCents: 500,
+      conversions: 2,
+    });
+    expect(row).toEqual({ channel: "linkedin", impressions: 100, clicks: 10, costInUsdCents: 500, conversions: 2 });
+  });
+
+  it("defaults missing / non-numeric / non-object snapshots to zero", () => {
+    expect(metricRowFromSnapshot("x", null)).toEqual({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
+    expect(metricRowFromSnapshot("x", "not-an-object")).toEqual({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
+    expect(metricRowFromSnapshot("x", { impressions: "50", clicks: NaN })).toEqual({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
+  });
+
+  it("clamps negative counts to zero so the rollup can't show a negative CTR", () => {
+    const row = metricRowFromSnapshot("x", { impressions: 100, clicks: -100, conversions: -5, costInUsdCents: -1 });
+    expect(row).toEqual({ channel: "x", impressions: 100, clicks: 0, costInUsdCents: 0, conversions: 0 });
   });
 });

--- a/apps/web/lib/marketing/campaign-performance.ts
+++ b/apps/web/lib/marketing/campaign-performance.ts
@@ -195,9 +195,12 @@ export function summarizeCampaignPerformance(input: {
 /** Coerce a lastMetricsSnapshot JSON blob into a numeric metric row. Defensive:
  *  missing/non-numeric fields become 0 so a partially-populated snapshot still
  *  contributes what it has. */
-function metricRowFromSnapshot(channel: string, snapshot: unknown): PublicationMetricRow {
+export function metricRowFromSnapshot(channel: string, snapshot: unknown): PublicationMetricRow {
   const m = snapshot && typeof snapshot === "object" ? (snapshot as Record<string, unknown>) : {};
-  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+  // Clamp to >= 0: a corrupt/adversarial snapshot with a negative count would
+  // otherwise flow into totals and produce a negative CTR/conversion rate in
+  // the rollup and headline. Mirrors recordVariantResult's clamping.
+  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? Math.max(0, v) : 0);
   return {
     channel,
     impressions: num(m.impressions),

--- a/apps/web/lib/marketing/content-calendar.test.ts
+++ b/apps/web/lib/marketing/content-calendar.test.ts
@@ -104,6 +104,24 @@ describe("buildContentCalendar", () => {
     expect(channelTotal).toBe(cal.totalTasks);
   });
 
+  it("routes an overflowing 'week N' due window to unscheduled without throwing", () => {
+    // Regression: parseDueWindowToDate used to return an Invalid Date here, which
+    // is truthy and crashed the whole calendar via isoDate/toISOString.
+    expect(() =>
+      buildContentCalendar([
+        task({ taskId: "ok", dueWindow: "2026-07-15" }),
+        task({ taskId: "overflow", dueWindow: "week 999999999999" }),
+      ]),
+    ).not.toThrow();
+    const cal = buildContentCalendar([
+      task({ taskId: "ok", dueWindow: "2026-07-15" }),
+      task({ taskId: "overflow", dueWindow: "week 999999999999" }),
+    ]);
+    expect(cal.weeks).toHaveLength(1);
+    expect(cal.unscheduled.map((e) => e.taskId)).toEqual(["overflow"]);
+    expect(cal.totalTasks).toBe(2);
+  });
+
   it("returns an empty calendar for no tasks", () => {
     const cal = buildContentCalendar([]);
     expect(cal).toEqual({

--- a/apps/web/lib/marketing/content-calendar.ts
+++ b/apps/web/lib/marketing/content-calendar.ts
@@ -77,7 +77,10 @@ export function buildContentCalendar(tasks: CalendarTaskInput[]): ContentCalenda
     byChannel[channelKey] = (byChannel[channelKey] ?? 0) + 1;
     byStatus[t.status] = (byStatus[t.status] ?? 0) + 1;
 
-    const due = t.dueWindow ? parseDueWindowToDate(t.dueWindow, t.createdAt) : null;
+    const parsed = t.dueWindow ? parseDueWindowToDate(t.dueWindow, t.createdAt) : null;
+    // Defend against an Invalid Date even if a future parser regressed — an
+    // Invalid Date is truthy and would throw in isoDate/weekStartUtc below.
+    const due = parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
     const entry: CalendarEntry = {
       taskId: t.taskId,
       title: t.title,

--- a/apps/web/lib/marketing/scheduler.test.ts
+++ b/apps/web/lib/marketing/scheduler.test.ts
@@ -22,6 +22,7 @@ vi.mock("./kpi-pullback", () => ({ pullChannelKpis: vi.fn() }));
 
 import { prisma } from "@dpf/db";
 import {
+  parseDueWindowToDate,
   planUpcomingForAssetTasks,
   scheduleAction,
   tickScheduler,
@@ -168,5 +169,38 @@ describe("planUpcomingForAssetTasks", () => {
     const result = await planUpcomingForAssetTasks({ organizationId: "org-1" });
     expect(result.scheduled).toBe(0);
     expect(result.skipped).toBe(1);
+  });
+});
+
+describe("parseDueWindowToDate", () => {
+  const createdAt = new Date("2026-01-01T00:00:00.000Z");
+
+  it("resolves 1-based 'week N' relative to createdAt", () => {
+    expect(parseDueWindowToDate("week 1", createdAt)!.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    expect(parseDueWindowToDate("week 5", createdAt)!.toISOString()).toBe("2026-01-29T00:00:00.000Z");
+  });
+
+  it("clamps 'week 0' to week 1 instead of going a week into the past", () => {
+    expect(parseDueWindowToDate("week 0", createdAt)!.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("returns null (never an Invalid Date) on an overflowing week/day count", () => {
+    // Regression: an Invalid Date is truthy and would crash get_content_calendar
+    // via toISOString(). Must be null so the task lands in `unscheduled`.
+    expect(parseDueWindowToDate("week 999999999999", createdAt)).toBeNull();
+    expect(parseDueWindowToDate("next 999999999999 days", createdAt)).toBeNull();
+  });
+
+  it("parses a leading YYYY-MM-DD as UTC midnight", () => {
+    expect(parseDueWindowToDate("2026-07-15", createdAt)!.toISOString()).toBe("2026-07-15T00:00:00.000Z");
+    expect(parseDueWindowToDate("2026-07-15T09:30:00Z", createdAt)!.toISOString()).toBe("2026-07-15T00:00:00.000Z");
+  });
+
+  it("rejects bare numbers and locale date strings (→ unscheduled) rather than misbucketing", () => {
+    // "2" → new Date("2") is Feb 2001; "July 15 2026" parses in server-local TZ.
+    // Both silently land tasks in the wrong week, so we return null instead.
+    expect(parseDueWindowToDate("2", createdAt)).toBeNull();
+    expect(parseDueWindowToDate("July 15 2026", createdAt)).toBeNull();
+    expect(parseDueWindowToDate("sometime soon", createdAt)).toBeNull();
   });
 });

--- a/apps/web/lib/marketing/scheduler.ts
+++ b/apps/web/lib/marketing/scheduler.ts
@@ -215,20 +215,33 @@ export async function planUpcomingForAssetTasks(input: {
  * Returns null when the format isn't recognizable.
  */
 export function parseDueWindowToDate(dueWindow: string, createdAt: Date): Date | null {
+  // Never hand back an Invalid Date: a huge "week N"/"next N days" overflows the
+  // valid Date range, and an Invalid Date is truthy — it would slip past a
+  // `!due` guard in callers and later throw RangeError on toISOString() (which
+  // would crash get_content_calendar for the whole workspace). Return null so
+  // callers route the task to `unscheduled` instead.
+  const finiteOrNull = (d: Date): Date | null => (Number.isNaN(d.getTime()) ? null : d);
+
   const trimmed = dueWindow.trim().toLowerCase();
   const weekMatch = /^week\s+(\d+)/.exec(trimmed);
   if (weekMatch) {
-    const weeks = parseInt(weekMatch[1]!, 10);
-    return new Date(createdAt.getTime() + (weeks - 1) * 7 * 24 * 60 * 60 * 1000);
+    // Week numbering is 1-based ("week 1" → createdAt); clamp 0/overflow-parsed.
+    const weeks = Math.max(1, parseInt(weekMatch[1]!, 10));
+    return finiteOrNull(new Date(createdAt.getTime() + (weeks - 1) * 7 * 24 * 60 * 60 * 1000));
   }
   const daysMatch = /^next\s+(\d+)\s+days?/.exec(trimmed);
   if (daysMatch) {
     const days = parseInt(daysMatch[1]!, 10);
-    return new Date(createdAt.getTime() + days * 24 * 60 * 60 * 1000);
+    return finiteOrNull(new Date(createdAt.getTime() + days * 24 * 60 * 60 * 1000));
   }
-  const isoCandidate = new Date(dueWindow);
-  if (!Number.isNaN(isoCandidate.getTime())) {
-    return isoCandidate;
+  // Explicit calendar date: accept ONLY a leading YYYY-MM-DD and parse it as
+  // UTC. `new Date("2")` → year 2001 and `new Date("July 15 2026")` → server
+  // LOCAL time both silently misbucket a task; requiring an ISO date parsed as
+  // UTC keeps the calendar's all-UTC contract and sends anything ambiguous to
+  // `unscheduled` (the honest, visible outcome) rather than a wrong week.
+  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(dueWindow.trim());
+  if (isoMatch) {
+    return finiteOrNull(new Date(`${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}T00:00:00.000Z`));
   }
   return null;
 }

--- a/docs/superpowers/plans/2026-06-24-marketing-coworker-parity-completion.md
+++ b/docs/superpowers/plans/2026-06-24-marketing-coworker-parity-completion.md
@@ -73,6 +73,30 @@ Each slice: vitest for the pure logic; CI Typecheck (vitest's esbuild path skips
 types — always confirm `tsc` on touched files, INCLUDING test files); Production
 Build; tool-registry no-drift. Merge queue lands each on `main`.
 
+## Post-merge hardening (follow-up branch feat/marketing-calendar-date-hardening)
+
+An adversarial correctness pass over the merged modules found robustness gaps
+before the first live run, fixed in a follow-up:
+
+- **HIGH — calendar crash.** `parseDueWindowToDate` (scheduler.ts) returned an
+  *Invalid Date* (not null) on an overflowing `"week N"` / `"next N days"`
+  string. An Invalid Date is truthy, so it slipped past the `!due` guard and
+  threw `RangeError` in `toISOString()` — crashing `get_content_calendar` for
+  the whole workspace on one bad task string. Fixed at source: every branch now
+  returns null on a non-finite date; `buildContentCalendar` also guards
+  defensively.
+- **MEDIUM — silent misbucketing.** The ISO fallback accepted bare numbers
+  (`"2"` → Feb 2001) and locale strings parsed in server-local time (wrong
+  Mon–Sun week). Now only a leading `YYYY-MM-DD` parsed as UTC is accepted;
+  anything ambiguous → `unscheduled` (honest, visible).
+- **LOW.** `"week 0"` clamped to week 1 (was 7 days early); negative snapshot
+  counts clamped to 0 in `metricRowFromSnapshot` so the rollup can't show a
+  negative CTR.
+
+New tests: parseDueWindowToDate (6 cases), calendar overflow→unscheduled,
+metricRowFromSnapshot coercion/clamp. Pure code hardening — no schema, no
+production changes.
+
 ## Out of scope
 
 Live external endpoint calls remain stubbed by design (per the operator directive).


### PR DESCRIPTION
## Why

An adversarial correctness pass over the just-merged marketing parity modules (#2540) — before the coworker's first live-model run — found a user-facing crash and two correctness bugs in date/metric handling. Pure code hardening: no schema, no production/DB changes.

## Findings fixed

- **HIGH — `get_content_calendar` crash.** `parseDueWindowToDate` (`scheduler.ts`) returned an **Invalid Date** (not `null`) on an overflowing `"week 999999999999"` / `"next N days"` string. An Invalid Date is truthy → slipped past the `!due` guard in `buildContentCalendar` → `toISOString()` threw an uncaught `RangeError`, crashing the calendar tool for the **entire workspace** on one bad task string (trivially model-triggerable). Fixed at source (every branch returns `null` on a non-finite date) + a defensive guard in `buildContentCalendar`.
- **MEDIUM — silent misbucketing.** The ISO fallback accepted bare numbers (`"2"` → Feb 2001) and locale strings parsed in **server-local** time (wrong Mon–Sun week). Now only a leading `YYYY-MM-DD` parsed as **UTC** is accepted; anything ambiguous → `unscheduled` (honest and visible), preserving the calendar's all-UTC contract.
- **LOW.** `"week 0"` clamped to week 1 (was 7 days early); negative snapshot counts clamped to 0 in `metricRowFromSnapshot` so the performance rollup can't report a negative CTR.

Modules `variants.ts`, `battlecards.ts`, and the handler coercion in `marketing-pack.ts` came back clean.

## Tests

- `parseDueWindowToDate`: 6 cases (1-based weeks, week-0 clamp, overflow→null, UTC ISO, bare-number/locale→null).
- `buildContentCalendar`: overflow window routes to `unscheduled` without throwing.
- `metricRowFromSnapshot`: well-formed read, missing/non-numeric/non-object→0, negative→clamped.
- Full marketing suite green (181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)