### PR TITLE
feat(marketing): register marketing capabilities in coworker service catalog (A2A discovery)

### DIFF
--- a/apps/web/lib/mcp/packs/marketing-catalog-coverage.test.ts
+++ b/apps/web/lib/mcp/packs/marketing-catalog-coverage.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { COWORKER_SERVICE_CATALOG_SERVICE_SEEDS } from "@dpf/db";
+// Import via the subpath (not bare "@dpf/db", which the apps/web vitest alias
+// maps to client.ts, exposing only the prisma client — not the seed barrel).
+import { COWORKER_SERVICE_CATALOG_SERVICE_SEEDS } from "@dpf/db/coworker-service-catalog-seed";
 import { marketingPack } from "./marketing-pack";
 
 // Drift guard (BI-4C5F7A2D): neither A2A nor the coworker service catalog

--- a/apps/web/lib/mcp/packs/marketing-catalog-coverage.test.ts
+++ b/apps/web/lib/mcp/packs/marketing-catalog-coverage.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { COWORKER_SERVICE_CATALOG_SERVICE_SEEDS } from "@dpf/db";
+import { marketingPack } from "./marketing-pack";
+
+// Drift guard (BI-4C5F7A2D): neither A2A nor the coworker service catalog
+// auto-derives from the tool registry — a coworker's services are explicit seed
+// records. Without this test a newly-added marketing-pack tool would be
+// invocable but invisible to A2A discovery and list_coworker_services, silently.
+// Assert every marketing-pack tool is backed by a marketing-specialist service.
+describe("marketing tools are covered by the coworker service catalog", () => {
+  const backedToolNames = new Set(
+    COWORKER_SERVICE_CATALOG_SERVICE_SEEDS.filter(
+      (service) => service.providerAgentId === "marketing-specialist",
+    ).flatMap((service) => service.backingToolNames),
+  );
+
+  it("has at least one marketing-specialist service", () => {
+    expect(backedToolNames.size).toBeGreaterThan(0);
+  });
+
+  for (const tool of marketingPack.definitions) {
+    it(`backs "${tool.name}" with a catalog service`, () => {
+      expect(backedToolNames.has(tool.name), tool.name).toBe(true);
+    });
+  }
+});

--- a/docs/superpowers/plans/2026-06-24-marketing-coworker-parity-completion.md
+++ b/docs/superpowers/plans/2026-06-24-marketing-coworker-parity-completion.md
@@ -77,3 +77,24 @@ Build; tool-registry no-drift. Merge queue lands each on `main`.
 
 Live external endpoint calls remain stubbed by design (per the operator directive).
 The value is the internal establish→execute→measure workflow reaching market parity.
+
+## Coworker-substrate integration (BI-4C5F7A2D, branch feat/marketing-coworker-catalog)
+
+A review (prompted by the operator) found the marketing coworker's tools were
+registered in the tool registry + grants but NOT integrated with three
+cross-cutting substrates — none of which auto-derive from the tool registry:
+
+- **A2A + service catalog (fixed here).** Coworker services are explicit seed
+  records in `packages/db/src/coworker-service-catalog-seed.ts`. There were zero
+  marketing-execution services, so the whole marketing coworker was invisible to
+  A2A discovery and `list_coworker_services`. Added 3 internal services
+  (campaign-execution, ab-testing, competitive-intelligence) + offers covering
+  all 12 marketing-pack tools, plus a drift-guard test
+  (`marketing-catalog-coverage.test.ts`) asserting every marketing tool has a
+  backing service so this can't silently recur. Internal scope → no GAID/AIDoc.
+- **Work-capture (deferred — design decision).** Marketing tools write only
+  their domain rows; they emit no `Activity` (CRM-centric) or `CoworkerEngagement`
+  record, while CRM and platform-dev work do. Which capture layer marketing
+  should use is a genuine design call (Activity vs. CoworkerEngagement vs.
+  MarketingReview-is-enough) — tracked in BI-4C5F7A2D for a kernel decision, not
+  guessed here.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./sysml-model-seed": "./src/sysml-model-seed.ts",
+    "./coworker-service-catalog-seed": "./src/coworker-service-catalog-seed.ts",
     "./ea-validation": "./src/ea-validation.ts",
     "./neo4j-sync": "./src/neo4j-sync.ts",
     "./reference-model-projection": "./src/reference-model-projection.ts",

--- a/packages/db/src/coworker-service-catalog-seed.ts
+++ b/packages/db/src/coworker-service-catalog-seed.ts
@@ -188,6 +188,74 @@ export const COWORKER_SERVICE_CATALOG_SERVICE_SEEDS: readonly CoworkerServiceSee
     dataBoundary: { sensitivity: "public-to-confidential", supplierData: true },
     metadata: { triggerFamilies: ["external-authority-data", "mcp-provider-adoption"] },
   }),
+  // Internal marketing-execution services (EP-MARKETING-EXEC, BI-4C5F7A2D):
+  // make the Marketing Strategist's execution capabilities discoverable in the
+  // coworker catalog and projectable to internal A2A agent cards, the same way
+  // build/compliance/legal specialists are registered. Internal scope → no
+  // GAID/AIDoc required. backingToolNames cover every marketing-pack tool (a
+  // drift-guard test asserts the union stays complete).
+  serviceSeed("svc-marketing-campaign-execution", "marketing-specialist", {
+    name: "Marketing campaign execution",
+    summary: "Establishes and runs a campaign end to end: plan, brief, tracked links, content calendar, and cross-channel performance.",
+    description:
+      "The Marketing Strategist's execution surface — create/update a campaign aggregate, attach briefs and asset tasks, mint UTM tracked links, read the editorial content calendar, and roll up measured cross-channel performance against budget and KPI targets.",
+    riskTier: "low",
+    authorityBoundary: "autonomous-allowed",
+    personas: ["marketing", "strategist", "operator"],
+    valueStreams: ["consume"],
+    requiredInputs: [{ key: "business-context" }, { key: "campaign-goal" }],
+    producedOutputs: [{ key: "campaign-plan" }, { key: "content-calendar" }, { key: "performance-rollup" }],
+    backingToolNames: [
+      "create_marketing_campaign",
+      "update_marketing_campaign",
+      "attach_to_campaign",
+      "get_campaign_plan",
+      "get_campaign_performance",
+      "get_content_calendar",
+      "build_tracked_links",
+    ],
+    backingGrantKeys: ["marketing_read", "marketing_write"],
+    costModel: { pricing: "internal", metering: "per-campaign" },
+    contractTerms: { posture: "internal", approvalGate: "human-approval-before-external-publish" },
+    dataBoundary: { sensitivity: "internal" },
+    metadata: { aggregate: true, family: "marketing-execution" },
+  }),
+  serviceSeed("svc-marketing-ab-testing", "marketing-specialist", {
+    name: "Marketing A/B variant testing",
+    summary: "Creates competing copy variants for an asset, records measured results, and recommends a statistically-guarded winner.",
+    description:
+      "Produce and compare multiple copy treatments per asset task; record impressions/clicks/conversions per variant; get a ranked winner recommendation by conversions-per-impression with a minimum-sample guard so noise is never crowned.",
+    riskTier: "low",
+    authorityBoundary: "autonomous-allowed",
+    personas: ["marketing", "strategist"],
+    valueStreams: ["consume"],
+    requiredInputs: [{ key: "asset-task" }],
+    producedOutputs: [{ key: "variant-set" }, { key: "winner-recommendation" }],
+    backingToolNames: ["create_asset_variant", "record_variant_result", "get_asset_variants"],
+    backingGrantKeys: ["marketing_read", "marketing_write"],
+    costModel: { pricing: "internal", metering: "per-variant" },
+    contractTerms: { posture: "internal" },
+    dataBoundary: { sensitivity: "internal" },
+    metadata: { family: "marketing-execution" },
+  }),
+  serviceSeed("svc-marketing-competitive-intelligence", "marketing-specialist", {
+    name: "Marketing competitive battlecards",
+    summary: "Maintains durable per-competitor battlecards and projects a competitive matrix across them.",
+    description:
+      "Turn competitive-analysis findings into durable, reusable battlecards (positioning, their strengths/weaknesses, our differentiators, win themes, objection handling) and read them back as a competitive matrix.",
+    riskTier: "low",
+    authorityBoundary: "autonomous-allowed",
+    personas: ["marketing", "strategist", "product-owner"],
+    valueStreams: ["consume"],
+    requiredInputs: [{ key: "competitor" }],
+    producedOutputs: [{ key: "battlecard" }, { key: "competitive-matrix" }],
+    backingToolNames: ["create_battlecard", "get_battlecards"],
+    backingGrantKeys: ["marketing_read", "marketing_write"],
+    costModel: { pricing: "internal", metering: "per-battlecard" },
+    contractTerms: { posture: "internal" },
+    dataBoundary: { sensitivity: "internal" },
+    metadata: { family: "marketing-execution" },
+  }),
 ];
 
 export const COWORKER_SERVICE_CATALOG_OFFER_SEEDS: readonly CoworkerOfferSeed[] = [
@@ -249,6 +317,28 @@ export const COWORKER_SERVICE_CATALOG_OFFER_SEEDS: readonly CoworkerOfferSeed[] 
     eligibleConsumers: ["operator", "builder", "procurement"],
     deliverables: ["Provider comparison", "Tool evaluation candidate", "Cost and contract risks"],
     filters: { domain: "external-provider-adoption" },
+  }),
+  // Internal marketing-execution offers (EP-MARKETING-EXEC, BI-4C5F7A2D).
+  offerSeed("offer-marketing-campaign-execution", "svc-marketing-campaign-execution", {
+    name: "Campaign execution and measurement",
+    summary: "Plan, produce, and measure a marketing campaign end to end — brief, tracked links, content calendar, and cross-channel performance.",
+    eligibleConsumers: ["marketing", "operator", "product"],
+    deliverables: ["Campaign plan", "Content calendar", "Cross-channel performance rollup"],
+    filters: { domain: "marketing-execution", family: "campaign" },
+  }),
+  offerSeed("offer-marketing-ab-testing", "svc-marketing-ab-testing", {
+    name: "A/B variant testing",
+    summary: "Create competing copy variants, record results, and get a guarded winner recommendation.",
+    eligibleConsumers: ["marketing", "product"],
+    deliverables: ["Variant set", "Per-variant performance", "Winner recommendation"],
+    filters: { domain: "marketing-execution", family: "experimentation" },
+  }),
+  offerSeed("offer-marketing-competitive-intelligence", "svc-marketing-competitive-intelligence", {
+    name: "Competitive battlecards",
+    summary: "Durable per-competitor battlecards and a competitive matrix for positioning.",
+    eligibleConsumers: ["marketing", "product", "operator"],
+    deliverables: ["Battlecard", "Competitive matrix"],
+    filters: { domain: "marketing-execution", family: "competitive" },
   }),
 ];
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -398,10 +398,3 @@ export {
   CONTRIBUTOR_INVENTORY_JOB_NAME,
   CONTRIBUTOR_INVENTORY_SCHEDULE,
 } from "./seed-contributor-inventory";
-
-// Coworker service catalog seed data (exported so app-layer drift tests can
-// assert tool→service coverage). BI-4C5F7A2D.
-export {
-  COWORKER_SERVICE_CATALOG_SERVICE_SEEDS,
-  COWORKER_SERVICE_CATALOG_OFFER_SEEDS,
-} from "./coworker-service-catalog-seed";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -398,3 +398,10 @@ export {
   CONTRIBUTOR_INVENTORY_JOB_NAME,
   CONTRIBUTOR_INVENTORY_SCHEDULE,
 } from "./seed-contributor-inventory";
+
+// Coworker service catalog seed data (exported so app-layer drift tests can
+// assert tool→service coverage). BI-4C5F7A2D.
+export {
+  COWORKER_SERVICE_CATALOG_SERVICE_SEEDS,
+  COWORKER_SERVICE_CATALOG_OFFER_SEEDS,
+} from "./coworker-service-catalog-seed";


### PR DESCRIPTION
## Why

Prompted by an operator review: the marketing parity work (#2540) made the coworker's tools **invocable** but left them **invisible** to A2A discovery and the coworker service catalog. Neither substrate auto-derives from the tool registry — coworker services are explicit seed records — and there were **zero** marketing-execution services, so the entire Marketing Strategist was absent from `list_coworker_services` and A2A agent-card projection. (Filed as **BI-4C5F7A2D**.)

## What

Seed 3 internal marketing-execution services + offers in `packages/db/src/coworker-service-catalog-seed.ts`, registered to `marketing-specialist`, the same way build/compliance/legal specialists are:

- **svc-marketing-campaign-execution** — create/update/attach campaign, plan, performance, content calendar, tracked links
- **svc-marketing-ab-testing** — variant create/record/read
- **svc-marketing-competitive-intelligence** — battlecard create/read

`backingToolNames` cover **all 12** marketing-pack tools (proven 12/12). Internal scope → no GAID/AIDoc required (external-only per the seed-validation test).

Plus `marketing-catalog-coverage.test.ts` — a **drift guard** asserting every marketing-pack tool has a backing service, so a future tool can't silently skip the catalog again. (`COWORKER_SERVICE_CATALOG_*_SEEDS` are now exported from `@dpf/db` for the app-layer test.)

## Verification

- Seed-validation test assertions satisfied (≥7 services/offers, unique IDs, `marketing-specialist` is a seeded agent, offers reference real services, internal offers skip external-GAID checks).
- Tool→service coverage proven 12/12 locally (the drift test itself resolves `@dpf/db` to the main checkout in this worktree, so it runs authoritatively in CI).
- Additive, idempotent (`upsert`) seed — applies on next boot; no migration.

## Not in this PR (deliberate)

**Work-capture** (marketing tools emit no `Activity`/`CoworkerEngagement` records while CRM/platform work does) is a genuine design decision — which capture layer marketing should use — tracked in **BI-4C5F7A2D** for a kernel call, not guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)