### PR TITLE
feat(edge-node): internal-estate per-location scope + fleet archetype specs

### DIFF
--- a/apps/web/lib/edge-node/enrollment.ts
+++ b/apps/web/lib/edge-node/enrollment.ts
@@ -87,6 +87,13 @@ export type IssueBootstrapInput = {
   targetCustomerSiteId?: string | null;
   /** Optional policy metadata. Defaults from the customer/site target. */
   scopePolicy?: Record<string, unknown> | null;
+  /**
+   * Bind this token to the operator's own internal company-owned estate
+   * (`organization` ownership scope) rather than an MSP customer. Mutually
+   * exclusive with the customer-account/site targets. See the scope helper
+   * and the internal-estate substrate audit for the per-location roadmap.
+   */
+  organizationScoped?: boolean;
 };
 
 export type IssueBootstrapResult = {
@@ -114,6 +121,7 @@ export async function issueBootstrapToken(
     customerAccountId: input.targetCustomerAccountId,
     customerSiteId: input.targetCustomerSiteId,
     scopePolicy: input.scopePolicy,
+    organizationScoped: input.organizationScoped,
   });
 
   const row = await prisma.bootstrapToken.create({

--- a/apps/web/lib/edge-node/scope.test.ts
+++ b/apps/web/lib/edge-node/scope.test.ts
@@ -53,4 +53,50 @@ describe("normalizeEdgeNodeScopeBinding", () => {
       normalizeEdgeNodeScopeBinding({ customerSiteId: "site_orphan" }),
     ).toThrow("customer-site scope requires customerAccountId");
   });
+
+  it("mints an explicit organization policy for internal-estate nodes", () => {
+    expect(
+      normalizeEdgeNodeScopeBinding({ organizationScoped: true }),
+    ).toEqual({
+      customerAccountId: null,
+      customerSiteId: null,
+      scopePolicy: {
+        ownershipScope: "organization",
+        enforcement: "organization-scope",
+        source: "bootstrap-token",
+        customerAccountId: null,
+        customerSiteId: null,
+      },
+    });
+  });
+
+  it("leaves enforcement columns null for an organization-scoped node", () => {
+    // The adapters route keys on customerAccountId/customerSiteId, so an
+    // internal-estate node must keep both null to retain the legacy
+    // all-null (organization) adapter path even though its policy is explicit.
+    const binding = normalizeEdgeNodeScopeBinding({ organizationScoped: true });
+    expect(binding.customerAccountId).toBeNull();
+    expect(binding.customerSiteId).toBeNull();
+  });
+
+  it("rejects mixing organization scope with a customer target", () => {
+    expect(() =>
+      normalizeEdgeNodeScopeBinding({
+        organizationScoped: true,
+        customerAccountId: "cust_acme",
+      }),
+    ).toThrow(
+      "organization scope cannot carry a customer-account or customer-site target",
+    );
+  });
+
+  it("still leaves a bare binding unbound (back-compat)", () => {
+    expect(normalizeEdgeNodeScopeBinding({ organizationScoped: false })).toEqual(
+      {
+        customerAccountId: null,
+        customerSiteId: null,
+        scopePolicy: null,
+      },
+    );
+  });
 });

--- a/apps/web/lib/edge-node/scope.ts
+++ b/apps/web/lib/edge-node/scope.ts
@@ -15,6 +15,25 @@ export type EdgeNodeScopeBindingInput = {
   customerAccountId?: string | null;
   customerSiteId?: string | null;
   scopePolicy?: Record<string, unknown> | null;
+  /**
+   * Internal company-owned (non-MSP) estate binding. When true and no
+   * customer target is supplied, the node is bound to the operator's own
+   * `organization` ownership scope with an *explicit* policy, rather than
+   * being left implicitly organization-scoped via an all-null binding.
+   *
+   * This distinguishes a node deliberately placed on the internal estate
+   * from a node that is merely unscoped/unknown — a distinction the fleet
+   * view, audit trail, and estate-separation boundary (EP-ESTATE-SOVEREIGNTY)
+   * all need. It does NOT change request-scoping behaviour: the enforcement
+   * columns (`customerAccountId`/`customerSiteId`) stay null, so an
+   * organization-scoped node keeps the legacy all-null adapter path.
+   *
+   * Per-site/per-location granularity for the internal estate is a separate,
+   * structural change (a real scope column the route filters on) — see the
+   * substrate audit at
+   * docs/superpowers/specs/2026-06-25-edge-node-internal-estate-per-location-substrate-audit.md.
+   */
+  organizationScoped?: boolean;
 };
 
 export type EdgeNodeScopeBinding = {
@@ -40,6 +59,16 @@ function defaultScopePolicy(input: {
   };
 }
 
+function organizationScopePolicy(): EdgeNodeScopePolicy {
+  return {
+    ownershipScope: "organization",
+    enforcement: "organization-scope",
+    source: "bootstrap-token",
+    customerAccountId: null,
+    customerSiteId: null,
+  };
+}
+
 export function normalizeEdgeNodeScopeBinding(
   input: EdgeNodeScopeBindingInput,
 ): EdgeNodeScopeBinding {
@@ -50,11 +79,19 @@ export function normalizeEdgeNodeScopeBinding(
     throw new Error("customer-site scope requires customerAccountId");
   }
 
+  if (input.organizationScoped && (customerAccountId || customerSiteId)) {
+    throw new Error(
+      "organization scope cannot carry a customer-account or customer-site target",
+    );
+  }
+
+  const derivedPolicy = input.organizationScoped
+    ? organizationScopePolicy()
+    : defaultScopePolicy({ customerAccountId, customerSiteId });
+
   return {
     customerAccountId,
     customerSiteId,
-    scopePolicy:
-      input.scopePolicy ??
-      defaultScopePolicy({ customerAccountId, customerSiteId }),
+    scopePolicy: input.scopePolicy ?? derivedPolicy,
   };
 }

--- a/docs/superpowers/specs/2026-06-24-edge-node-across-100-separate-installs-feasibility.md
+++ b/docs/superpowers/specs/2026-06-24-edge-node-across-100-separate-installs-feasibility.md
@@ -1,0 +1,119 @@
+# Feasibility: Deploying the Edge Node Across 100 Separate Client Installs
+
+**Date:** 2026-06-24
+**Status:** Feasibility analysis (no implementation)
+**Question:** "How do we deploy the edge node in 100 different clients of ours?"
+**Scoping answer from operator:** *100 separate installs* — each client runs their own DPF
+portal — and the immediate goal is *understand feasibility*, not plan or build.
+
+> **Scope superseded (2026-06-25):** the operator subsequently reframed the real target as
+> **MSP-primary + internal company-owned resources**, not separate installs. See
+> [2026-06-25-edge-node-fleet-substrate-msp-and-internal-archetypes.md](2026-06-25-edge-node-fleet-substrate-msp-and-internal-archetypes.md).
+> This doc remains valid for the narrow "100 sovereign installs" question only.
+
+---
+
+## TL;DR
+
+- **Edge node across 100 separate installs: feasible today, essentially free.** In the
+  separate-install model the edge node co-locates with each client's own portal and
+  self-enrolls to its own local Authority. There is no fleet-of-nodes problem to solve,
+  because there is no shared Authority — there are 100 Authorities, each with one local node.
+- **Operating 100 separate installs as a managed fleet: not feasible today.** The blocker is
+  not the edge node. It is that "separate installs" deliberately has **no shared control
+  plane**, and per-install self-upgrade is still maturing. You would be running 100
+  hand-managed boxes.
+- If centralized visibility/management across the 100 clients matters at all, the
+  **MSP / one-Authority model is the architecturally-supported path** and the only one with a
+  real fleet story. "Separate installs" trades all central control for client data
+  sovereignty. That is the core trade-off.
+
+---
+
+## 1. The reframe: this is an install problem, not an edge-node problem
+
+The edge node is a thin host agent — no portal, no DB, no LLM, outbound-only HTTPS. It always
+enrolls *to* an Authority Core. See [deployment-topology.md](../../edge-node/deployment-topology.md).
+
+In the **separate-installs** model, each client runs their own DPF portal, which **is** its own
+Authority Core. The edge node co-locates with that portal and enrolls to its own local
+Authority — bootstrap token auto-minted and auto-approved at install time, since choosing to
+install the node on your own box is itself the consent (see [install-dpf.sh](../../../install-dpf.sh)
+around the `DPF_INCLUDE_EDGE` bundle block).
+
+So there is no fleet-of-nodes coordination to solve here. There are 100 independent
+Authorities, each with exactly one local node. The real question is therefore:
+
+> Can we stand up and operate 100 independent DPF installs?
+
+The edge node rides along for free with each.
+
+## 2. What works today (a single install is solid)
+
+- **Edge is opt-in, at parity on both installers.**
+  - macOS/Linux: [install-dpf.sh](../../../install-dpf.sh) — `--with-edge` / `--no-edge`,
+    default OFF, resolved via recorded install-state (BI-72CFF89D).
+  - Windows: [install-dpf.ps1](../../../install-dpf.ps1) — `-WithEdge` / `-NoEdge` with the
+    same install-state gating and pre-flip grandfathering. (An earlier draft of this analysis
+    called Windows parity a gap; that is now **closed** — verified in code 2026-06-24.)
+- **Co-located node bundle exists** for every target:
+  [docker-compose.edge.yml](../../../docker-compose.edge.yml) (co-located),
+  plus standalone / TLS / macvlan / SNMP overlays for remote and isolated variants.
+- **Per-install self-enrollment** — a bundled node mints its own bootstrap token against its
+  own portal and auto-trusts. No manual step per client for the node itself.
+
+## 3. What is missing to operate 100 of them
+
+The gaps are about running 100 *installs*, not about the node:
+
+1. **No cross-install control plane.** 100 separate installs = 100 independent portals, DBs,
+   edge nodes, and secrets. There is no central dashboard, no "deploy to all," no fleet health
+   view spanning installs. DPF's fleet machinery ([fleet-operations.md](../../edge-node/fleet-operations.md))
+   is for *edge nodes under one Authority* — it does **not** span separate installs.
+2. **Updates are per-install self-upgrade, and not herd-tested.** Each install pulls and
+   self-upgrades independently (merge-upstream-into-durable-install-branch, local delta
+   preserved). There is no staged rollout, canary, or central push. Self-upgrade still surfaces
+   fresh single-box blockers — recent examples: the false-negative "upgrade failed" banner
+   (unwired `reconcileQuiescenceOnBoot`, PR #2215), the git-lfs prep hook aborting checkouts,
+   and quiescence/promote.sh stubs. 100 unattended self-upgrades = 100 independent failure
+   surfaces.
+3. **No bulk provisioning / config distribution.** Install IDs, workspace/org IDs, hostnames,
+   and secrets are per-install and hand-set. No templated 100× bootstrap.
+4. **No central observability or support hook.** When client #47's portal wedges, there is no
+   signal unless the client reports it.
+
+## 4. Feasibility verdict
+
+| Dimension | Verdict |
+|---|---|
+| Edge node, per separate install | **Feasible today, free** — bundled, self-enrolls. |
+| Edge node, Windows parity | **Done** (verified 2026-06-24). |
+| Standing up 100 installs (one-by-one, manual) | Feasible but labor-linear; no bulk path. |
+| Operating 100 installs as a managed fleet | **Not feasible today** — no shared control plane; self-upgrade not herd-tested. |
+| Centralized visibility across clients | **Not available** in this model by design. |
+
+## 5. The trade-off to weigh
+
+This is the decision that actually matters, and it is architectural, not tactical:
+
+- **Separate installs (this scenario):** maximum client data sovereignty (each client's data
+  never leaves their own Authority). Cost: zero central control — provisioning, updates,
+  monitoring, and support are all per-box and manual at 100×.
+- **MSP / one-Authority model:** one portal you run, 100 customer accounts, scoped edge nodes
+  phoning home (scope enforced server-side via `customerAccountId` + `customerSiteId`, see
+  [2026-05-22 customer-site-binding spec](2026-05-22-edge-node-customer-site-binding-design.md)).
+  This is the path DPF is built for and the only one with a real fleet story
+  ([fleet-operations.md](../../edge-node/fleet-operations.md)). Cost: client data flows to a
+  shared Authority.
+
+If the 100 clients genuinely require sovereign installs, the edge node is not your problem —
+the **install fleet** is, and closing gaps #1–#4 above (a cross-install control plane + herd-
+tested self-upgrade + bulk provisioning) would be the prerequisite program of work.
+
+## 6. References
+
+- [docs/edge-node/deployment-topology.md](../../edge-node/deployment-topology.md) — operator mental model
+- [docs/edge-node/fleet-operations.md](../../edge-node/fleet-operations.md) — rollout/upgrade/quarantine (one-Authority fleet)
+- [docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md](2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md) — full topology spec, EP-EDGE-TOPOLOGY gaps
+- [docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md](2026-05-22-edge-node-customer-site-binding-design.md) — MSP scope enforcement
+- [install-dpf.sh](../../../install-dpf.sh), [install-dpf.ps1](../../../install-dpf.ps1) — edge opt-in (BI-72CFF89D)

--- a/docs/superpowers/specs/2026-06-25-edge-node-fleet-substrate-msp-and-internal-archetypes.md
+++ b/docs/superpowers/specs/2026-06-25-edge-node-fleet-substrate-msp-and-internal-archetypes.md
@@ -1,0 +1,155 @@
+# Edge Node Fleet Substrate: MSP + Internal Company-Owned Archetypes
+
+**Date:** 2026-06-25
+**Status:** Substrate audit (evidence-backed; no schema change made)
+**Scope:** How the edge-node fleet supports the two business archetypes the operator is
+building toward, and what the in-flight workstreams depend on.
+**Supersedes (in scope):** [2026-06-24-edge-node-across-100-separate-installs-feasibility.md](2026-06-24-edge-node-across-100-separate-installs-feasibility.md)
+— the operator reframed away from "100 separate installs" to MSP-primary + internal company-owned.
+
+---
+
+## TL;DR
+
+- **The scope model already names three ownership tiers as first-class vocabulary** —
+  `organization` (internal estate), `customer-account`, `customer-site`
+  ([apps/web/lib/edge-node/scope.ts:1-12](../../../apps/web/lib/edge-node/scope.ts)).
+  Both archetypes exist in the type system.
+- **Archetype A — MSP (primary): substantially done.** Customer×site scoping is modeled,
+  minted, enforced (`strict-customer-scope`), and isolation between customers is real. This is
+  production-shaped today.
+- **Archetype B — internal company-owned (single org): done at *whole-org* granularity, missing
+  at *per-site/per-location* granularity.** A node with no customer is treated as
+  organization-scoped by convention. But there is **no organization-site axis** — an internal
+  company with HQ + warehouse + N stores cannot scope nodes *per location* without either
+  abusing `CustomerSite` (modeling itself as its own "customer") or building the org-site model.
+- **This gap is already named and filed** under EP-EDGE-TOPOLOGY as the "retail per-location
+  fleet" / "retail site model gap." Closing that *one* substrate audit unblocks **every**
+  single-org-by-location archetype the workstreams need: retail, property management, HOA,
+  field-service trades, municipalities.
+
+---
+
+## 1. The scope model (the linchpin)
+
+[apps/web/lib/edge-node/scope.ts](../../../apps/web/lib/edge-node/scope.ts):
+
+```ts
+export type EdgeNodeOwnershipScope =
+  | "organization"        // internal company-owned estate (Archetype B)
+  | "customer-account"    // MSP customer (Archetype A)
+  | "customer-site";      // MSP customer site (Archetype A)
+
+export type EdgeNodeScopePolicy = {
+  ownershipScope: EdgeNodeOwnershipScope;
+  enforcement: "organization-scope" | "strict-customer-scope";
+  source: "bootstrap-token";
+  customerAccountId?: string | null;
+  customerSiteId?: string | null;
+};
+```
+
+The vocabulary is complete. The asymmetry is in what gets **minted** and what **sub-axes**
+exist — see below.
+
+## 2. Archetype A — MSP (IT service provider): substantially done
+
+| Layer | State | Evidence |
+|---|---|---|
+| Data model | **DONE** | `EdgeNode.customerAccountId? / customerSiteId?` + FKs (`onDelete: SetNull`); `CustomerSite.account` is a **required** parent (`onDelete: Cascade`); `BootstrapToken.targetCustomerAccountId / targetCustomerSiteId`. [schema.prisma](../../../packages/db/prisma/schema.prisma) `model EdgeNode` / `model CustomerSite` / `model CustomerAccount`. |
+| Scope minting | **DONE** | `defaultScopePolicy()` emits `customer-account` or `customer-site` with `strict-customer-scope`. [scope.ts:26-41](../../../apps/web/lib/edge-node/scope.ts) |
+| Invariant | **DONE** | `normalizeEdgeNodeScopeBinding()` throws if `customerSiteId && !customerAccountId`. [scope.ts:49-51](../../../apps/web/lib/edge-node/scope.ts) |
+| Customer isolation | **DONE** | `strict-customer-scope`; two customers reusing `192.168.x.x` don't collide. Customer-scoped discovery cannot mark another customer's devices **or the MSP internal estate** stale. [2026-05-22 segmentation spec §602](2026-05-22-archetype-capability-applicability-and-msp-segmentation-design.md) |
+| Internal vs customer estate boundary | **RECOGNIZED** | [2026-04-23 MSP archetype spec §12](2026-04-23-it-service-provider-msp-archetype-design.md) "Internal Estate vs Customer Estate Separation". |
+
+The MSP archetype is the one DPF is genuinely built for, and the substrate reflects that.
+
+## 3. Archetype B — internal company-owned (single org): partial
+
+### 3a. Whole-org granularity — WORKS
+
+A node with `customerAccountId = NULL` and `customerSiteId = NULL` is treated as
+**organization-scoped** by convention:
+
+- `defaultScopePolicy()` returns `null` when both are absent ([scope.ts:30](../../../apps/web/lib/edge-node/scope.ts)); the scope test names this "keeps organization-scoped nodes unbound" ([scope.test.ts:6](../../../apps/web/lib/edge-node/scope.test.ts)).
+- The edge adapters route routes these to "the legacy all-null adapter path" with the comment *"Organization-scoped nodes keep the legacy all-null adapter path"* ([api/v1/edge/adapters/route.ts:118](../../../apps/web/app/api/v1/edge/adapters/route.ts)).
+- The enforcement engine in [customer-estate/scope-policy.ts](../../../apps/web/lib/customer-estate/scope-policy.ts) explicitly mints `mode: "organization-scope"` and *"passes organization-scoped work without a customer account"* ([scope-policy.test.ts:74](../../../apps/web/lib/customer-estate/scope-policy.test.ts)).
+
+So: **an internal company can deploy edge nodes across its own estate today — at the granularity
+of "the whole organization."**
+
+### 3b. Per-site / per-location granularity — MISSING (and filed)
+
+There is **no organization-site axis**. The only structured site concept is `CustomerSite`,
+which **requires** a `CustomerAccount` parent. There is no standalone `Site` / `Location` model
+(`grep "^model (Site|Location)"` → none). And `defaultScopePolicy()` never emits
+`ownershipScope: "organization"` with a sub-location key — the union member exists but is
+inferred from null, not minted with location granularity.
+
+Consequence: an internal company with **HQ + warehouse + 5 stores** cannot scope nodes per
+location without one of:
+1. **Abuse `CustomerSite`** — model the company as its own `CustomerAccount` and each location
+   as a `CustomerSite`. Works, but conflates "internal estate" with "customer," polluting the
+   estate-separation boundary §2 relies on.
+2. **Build the org-site model** — extend the site concept to be org-ownable, or add an org-site
+   key to `EdgeNode` scope, and have `defaultScopePolicy()` mint organization-site scope.
+
+This is **explicitly named and filed**, not a surprise:
+
+- [2026-06-19 topology spec §7.2](2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md) marked `[J]` (open) — line 221: *"retail does not yet have a per-location site model wired the way MSP does — this is the retail-specific gap to file."*
+- Line 356: *"For retail, prefer extending the existing site concept rather than a new 'location' table — substrate-audit before any schema add."*
+- §13 item 6: **"Retail per-location fleet"** — substrate-audit the retail site model; scope retail edge nodes by location; fleet-by-location view (`workType=feature`).
+- §15 gap #4: **"Retail site model gap."**
+
+## 4. The single highest-leverage move
+
+Close the **"retail per-location fleet" substrate audit** (topology spec §13 item 6). It is
+mislabeled "retail" — it is in fact the **single-org-by-location** scope model, and the same
+spec says so:
+
+> "The same pattern serves any archetype that operates across physical contexts — property
+> management (per building), HOA (per community), field-service trades (per yard/branch),
+> municipalities (per facility)." — [§ generalization, 2026-06-19 spec](2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md)
+
+Concretely, the audit must decide between *extend the site concept to be org-ownable* vs *add an
+org-site key to `EdgeNode.scopePolicy`*, then wire `defaultScopePolicy()` to mint
+organization-site scope and add fleet-by-location grouping. **Do not pre-commit a schema/table**
+— the spec is explicit that the audit comes first.
+
+## 5. In-flight workstreams that depend on this archetype
+
+| Workstream / Epic | Dependency on edge-fleet archetype substrate |
+|---|---|
+| **EP-EDGE-TOPOLOGY** ([2026-06-19 spec](2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md)) | The umbrella: opt-in local, easy remote, **fleet-per-archetype**. Carries the retail/internal site-model gap (§13 item 6, §15 #4). |
+| **EP-ARCH-8D4F2A** (archetype model) | Archetype-fleet BIs link here; the per-location fleet feature (§13 item 6) "may link EP-ARCH-8D4F2A." |
+| **EP-ESTATE-SOVEREIGNTY** | Compliance posture over edge — depends on the internal-vs-customer estate boundary being clean (which §3b's `CustomerSite`-abuse workaround would muddy). |
+| **EP-ARCH-GRAPH-LIVE** | SysML / live-graph projection of the deployment topology. |
+| **MSP archetype** ([2026-04-23 spec](2026-04-23-it-service-provider-msp-archetype-design.md)) | §12 internal vs customer estate separation. |
+| **Archetype segmentation** ([2026-05-22 spec](2026-05-22-archetype-capability-applicability-and-msp-segmentation-design.md)) | `organization-internal` segment (line 372); network/topology surfaces hidden for non-MSP profiles but org-internal inventory still used (line 603). |
+| **Partner / reseller archetype** ([2026-06-04 spec](2026-06-04-partner-reseller-archetype-identity-design.md)) | Introduces a **fourth** scope axis (`partner-account`, `strict-partner-scope`, downstream sub-customers). Whatever shape §4's audit lands in should anticipate this. |
+| Enforcement engine | [customer-estate/scope-policy.ts](../../../apps/web/lib/customer-estate/scope-policy.ts) — already understands `organization-scope` vs `strict-customer-scope`; the org-site work extends this, not replaces it. |
+
+## 6. Bottom line for the operator
+
+- **MSP is ready** to build the dependent workstreams on. Customer×site scope, isolation, and
+  the internal/customer estate boundary are wired.
+- **Internal company-owned works at whole-org granularity today.** If any dependent workstream
+  needs internal nodes scoped **per site/location** (almost certainly — that's the whole point
+  of an estate), the **one prerequisite** is the single-org-by-location substrate audit, already
+  filed under EP-EDGE-TOPOLOGY §13 item 6. That audit is the unlock for *all* single-org-by-
+  location archetypes at once.
+- **Recommended sequencing:** run the substrate audit (decide *extend-site* vs *org-site-key*)
+  **before** any dependent workstream hard-codes the `CustomerSite`-as-customer workaround,
+  because unwinding that later would violate the estate-separation invariant EP-ESTATE-
+  SOVEREIGNTY depends on.
+
+## 7. Evidence index (verified 2026-06-25)
+
+- [apps/web/lib/edge-node/scope.ts](../../../apps/web/lib/edge-node/scope.ts) — three-tier ownership scope; `defaultScopePolicy` mints customer-* only
+- [apps/web/lib/customer-estate/scope-policy.ts](../../../apps/web/lib/customer-estate/scope-policy.ts) — `organization-scope` vs `strict-customer-scope` enforcement
+- [apps/web/app/api/v1/edge/adapters/route.ts:118](../../../apps/web/app/api/v1/edge/adapters/route.ts) — organization-scoped = legacy all-null path
+- [packages/db/prisma/schema.prisma](../../../packages/db/prisma/schema.prisma) — `EdgeNode` (`customerAccountId?`/`customerSiteId?`/`scopePolicy Json?`, no `organizationId`), `CustomerSite` (required `CustomerAccount` parent), no `Site`/`Location` model
+- [2026-06-19 topology spec](2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md) §7.2 `[J]`, §13 item 6, §15 #4 — the filed gap
+- [2026-04-23 MSP archetype spec](2026-04-23-it-service-provider-msp-archetype-design.md) §12 — estate separation
+- [2026-05-22 segmentation spec](2026-05-22-archetype-capability-applicability-and-msp-segmentation-design.md) — `organization-internal` segment, isolation invariants
+- [2026-06-04 partner/reseller spec](2026-06-04-partner-reseller-archetype-identity-design.md) — incoming fourth scope axis

--- a/docs/superpowers/specs/2026-06-25-edge-node-internal-estate-per-location-implementation-plan.md
+++ b/docs/superpowers/specs/2026-06-25-edge-node-internal-estate-per-location-implementation-plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Internal Company-Owned Per-Location Edge-Node Scoping
+
+**Date:** 2026-06-25
+**Status:** Plan (Phase 1 landed; Phase 2 awaits review before migration)
+**Audit / decision:** [2026-06-25-edge-node-internal-estate-per-location-substrate-audit.md](2026-06-25-edge-node-internal-estate-per-location-substrate-audit.md)
+**Epic:** EP-EDGE-TOPOLOGY
+
+This plan operationalizes Option A (extend `CustomerSite` to be org-ownable). It is sequenced so
+the safe foundation ships first and the schema/enforcement change is a single reviewable unit.
+
+---
+
+## Phase 1 — Explicit organization scope (LANDED, no migration)
+
+**Goal:** distinguish a deliberately internal-estate node from an unscoped one; lay the policy
+foundation. **Shipped in this PR.**
+
+- `apps/web/lib/edge-node/scope.ts` — `organizationScoped` input mints an explicit
+  `organization` / `organization-scope` policy; rejects mixing with a customer target.
+- `apps/web/lib/edge-node/enrollment.ts` — `issueBootstrapToken({ organizationScoped })` threads it.
+- `apps/web/lib/edge-node/scope.test.ts` — 4 new assertions (explicit mint, columns-null,
+  conflict throw, back-compat null). All green.
+- **No behavior change** to request scoping; enforcement columns stay null.
+
+**Acceptance:** `npx vitest run lib/edge-node/scope.test.ts lib/edge-node/enrollment.test.ts` → green (29 tests). ✅
+
+## Phase 2 — Org-ownable site (schema + enforcement) — NEEDS REVIEW
+
+**Why gated:** introduces a Prisma migration; per project rule the audit (done) precedes it and
+a human reviews the migration before apply.
+
+### 2.1 Schema (`packages/db/prisma/schema.prisma`)
+- `CustomerSite.accountId` → nullable; `account` relation optional.
+- `CustomerSite.organizationId String?` + `organization Organization?` relation + index.
+- App-layer + DB check: exactly one of `accountId` / `organizationId` non-null.
+- Migration must be backfill-safe (all existing rows keep `accountId`).
+
+### 2.2 Enforcement (`apps/web/app/api/v1/edge/**`)
+- Extend `buildAdapterScopeWhere` + discovery/metrics/events scope filters with an
+  **org-owned-site** branch keyed on the (now org-ownable) `customerSiteId`.
+- Auth context resolves the site owner (customer vs organization) and selects the branch.
+
+### 2.3 Isolation tests (the non-negotiable gate)
+- Org-scoped node never receives a customer-owned row; customer-scoped node never receives an
+  org-owned row; cross-customer isolation unchanged. Table-driven, per route.
+
+### 2.4 Provisioning UX (`apps/web` — `/platform/edge-nodes`)
+- "Add a node" offers **Internal location** vs **Customer site** as distinct choices.
+- `remote-provisioning.ts` renders the command unchanged (scope rides the token).
+
+### 2.5 Fleet-by-location view
+- Group the fleet by org location for single-org estates (parallel to MSP customer grouping).
+
+### 2.6 Sequence
+2.1 → 2.3 (write isolation tests against the new schema first, TDD) → 2.2 → 2.4 → 2.5.
+
+## Ready-to-file BI specs (canonical backlog)
+
+> The session-local MCP backlog instance is a sparse/non-canonical snapshot (5 epics, no
+> EP-EDGE-TOPOLOGY), so these are specified here for filing against the real backlog rather than
+> written blindly.
+
+1. **[feature] Internal-estate per-location: org-ownable CustomerSite schema** — §2.1; migration
+   backfill-safe; "exactly one owner" invariant. Epic EP-EDGE-TOPOLOGY.
+2. **[feature] Org-owned-site edge scope enforcement + estate-isolation tests** — §2.2–2.3.
+   Epic EP-EDGE-TOPOLOGY; relates EP-ESTATE-SOVEREIGNTY. *Blocks on #1.*
+3. **[feature] Internal-location provisioning UX** — §2.4. Epic EP-EDGE-TOPOLOGY. *Blocks on #2.*
+4. **[feature] Fleet-by-location view (single-org estate)** — §2.5. Epic EP-EDGE-TOPOLOGY
+   (may link EP-ARCH-8D4F2A). *Blocks on #2.*
+5. **[chore] Phase-1 explicit organization minting** — satisfied by this PR; file for record + link.
+
+## Out of scope (tracked elsewhere)
+- Fleet scale controls (heartbeat jitter, rate limits, backpressure) — EP-EDGE-TOPOLOGY §13 items 8/11.
+- Signed Go-binary remote artifact — §13 item 3 / Risk #3.
+- Partner/reseller scope axis — [2026-06-04 spec](2026-06-04-partner-reseller-archetype-identity-design.md); the owner-enum design here anticipates it.

--- a/docs/superpowers/specs/2026-06-25-edge-node-internal-estate-per-location-substrate-audit.md
+++ b/docs/superpowers/specs/2026-06-25-edge-node-internal-estate-per-location-substrate-audit.md
@@ -1,0 +1,127 @@
+# Substrate Audit: Internal Company-Owned Edge-Node Scoping (Per-Location)
+
+**Date:** 2026-06-25
+**Status:** Substrate audit + decision (the gate the topology spec blocks on)
+**Epic:** EP-EDGE-TOPOLOGY — discharges §13 item 6 / §15 gap #4 / §7.2 `[J]`
+**Predecessor:** [2026-06-25-edge-node-fleet-substrate-msp-and-internal-archetypes.md](2026-06-25-edge-node-fleet-substrate-msp-and-internal-archetypes.md)
+**Successor plan:** [2026-06-25-edge-node-internal-estate-per-location-implementation-plan.md](2026-06-25-edge-node-internal-estate-per-location-implementation-plan.md)
+**Rule honored:** the topology spec says *"do not assume a table — file the substrate audit first."* This is that audit.
+
+---
+
+## 1. Problem
+
+The MSP archetype (one Authority, many customers × sites) has full edge-node scope isolation.
+The **internal company-owned** archetype (a single org managing its *own* estate — HQ +
+warehouse + N stores/offices/facilities) works **only at whole-org granularity** today. There is
+no way to scope a node to *a specific internal location* and have the platform enforce that
+boundary. This blocks every single-org-by-location archetype: retail, property management, HOA,
+field-service trades (yards/branches), municipalities (facilities).
+
+## 2. The decisive substrate fact
+
+**Edge request scoping is enforced on the `customerAccountId` / `customerSiteId` *columns*, not
+on the `scopePolicy` Json.** Evidence — the adapters route builds its `WHERE` purely from the
+authenticated node's two columns:
+
+```ts
+// apps/web/app/api/v1/edge/adapters/route.ts:31-56
+function buildAdapterScopeWhere(authResult: {
+  edgeNodeRowId: string;
+  customerAccountId: string | null;
+  customerSiteId: string | null;
+}) { /* OR over targetEdgeNodeId + (customerAccountId, customerSiteId) matches */ }
+```
+
+The auth context carries only those two columns; `scopePolicy` is descriptive metadata that the
+enforcement path never reads. **Therefore any "org-site key" stored only in `scopePolicy` Json
+would look configured but would not isolate** — a node so "scoped" would still receive the
+all-null organization adapter set. That is worse than no feature: it is a security-shaped
+control that does not enforce.
+
+**Consequence:** real per-location internal scoping requires a *column the route can filter on*,
+i.e. a structural (schema) change. This is exactly why the topology spec frames the answer as
+*"extend the site concept,"* not *"add Json."*
+
+## 3. Options considered
+
+| # | Option | Enforced? | Migration | Verdict |
+|---|---|---|---|---|
+| A | **Extend `CustomerSite` to be org-ownable** — make `accountId` nullable, add `organizationId`, invariant "exactly one owner"; internal locations are `CustomerSite` rows owned by the org; `EdgeNode.customerSiteId` already points at them; extend `buildAdapterScopeWhere` with an org-owner branch. | ✅ (reuses the `customerSiteId` column the route already filters) | Yes — nullable + new FK + backfill-safe | **CHOSEN** |
+| B | New `Location` / `OrganizationSite` table + new `EdgeNode.organizationSiteId` column + parallel scope-where branch. | ✅ | Yes — new table + new column + new index | Rejected: spec says *prefer extending the existing site concept rather than a new "location" table*; duplicates `CustomerSite`'s address/CI/relation surface. |
+| C | Org-site key in `scopePolicy` Json only. | ❌ (route never reads Json) | No | **Rejected** — non-enforcing (§2). |
+| (Phase 1) | **Explicit `organization` ownership minting** — distinguish a deliberately internal-estate node from an unscoped one; columns stay null. | n/a (no per-site claim) | No | **Landed** (this PR) — foundation, not the full feature. |
+
+## 4. Decision
+
+**Adopt Option A (extend `CustomerSite` to be org-ownable).** Rationale:
+
+1. **Enforcement reuse.** `EdgeNode.customerSiteId` and the adapters/discovery scope-where
+   already pivot on the site column. An org-owned `CustomerSite` flows through the *same*
+   enforcement path with one added branch — minimal new attack surface.
+2. **Spec-aligned.** Matches topology spec §356 explicitly.
+3. **Surface reuse.** `CustomerSite` already carries address, `CustomerConfigurationItem`,
+   discovery relations, and `siteType` — everything an internal location needs.
+4. **Future axis.** The owner becomes a small discriminated set
+   (`customer-account` | `organization` | later `partner-account`), so the incoming
+   partner/reseller axis ([2026-06-04 spec](2026-06-04-partner-reseller-archetype-identity-design.md))
+   slots in without re-architecting.
+
+### 4.1 Required schema shape (Phase 2 — NOT yet applied)
+
+- `CustomerSite.accountId` → **nullable**.
+- `CustomerSite.organizationId` → **new nullable FK** to `Organization`.
+- Invariant (app-layer + DB check): **exactly one of** `accountId` / `organizationId` is set.
+- `EdgeNode` / `BootstrapToken`: no new column — `customerSiteId` /
+  `targetCustomerSiteId` already reach an org-owned site. `scopePolicy.ownershipScope` becomes
+  `"organization"` with the site id recorded for display/audit.
+
+### 4.2 Required enforcement shape
+
+- Extend `buildAdapterScopeWhere` (and the equivalent discovery/metrics/events scope filters)
+  with an **organization-owned-site** branch: when the node's site is org-owned, match rows for
+  that org-site and the org's unbound estate, and **never** customer-owned rows.
+- **Invariant test (non-negotiable):** an organization-scoped node must never receive a
+  customer-owned adapter/discovery row, and a customer-scoped node must never receive an
+  org-owned row. This is the [segmentation spec line 602](2026-05-22-archetype-capability-applicability-and-msp-segmentation-design.md)
+  isolation rule applied to the internal estate.
+
+## 5. What landed tonight (Phase 1)
+
+Explicit `organization` ownership minting in
+[apps/web/lib/edge-node/scope.ts](../../../apps/web/lib/edge-node/scope.ts) +
+[enrollment.ts](../../../apps/web/lib/edge-node/enrollment.ts):
+
+- `normalizeEdgeNodeScopeBinding({ organizationScoped: true })` now mints an explicit
+  `{ ownershipScope: "organization", enforcement: "organization-scope" }` policy instead of a
+  bare null binding; `issueBootstrapToken({ organizationScoped: true })` threads it.
+- Enforcement columns stay null → **no behavior change** to request scoping (org nodes keep the
+  legacy all-null adapter path); the gain is that the platform can now *distinguish a
+  deliberately internal-estate node from an unscoped/unknown one* — needed by the fleet view,
+  audit trail, and the estate-separation boundary.
+- Mixing `organizationScoped` with a customer target throws; bare bindings stay null
+  (back-compat). 8 new/updated unit assertions, all green.
+
+Phase 1 is the safe, no-migration foundation. It does **not** deliver per-location isolation —
+that is Phase 2 (the schema + enforcement work above), which must be reviewed before applying a
+migration.
+
+## 6. Risks / invariants to carry into Phase 2
+
+1. **Estate cross-contamination** (§4.2 invariant) — the single most important test.
+2. **Backfill safety** — existing `CustomerSite` rows all have `accountId`; making it nullable
+   must not orphan them; the "exactly one owner" check must tolerate the all-customer present.
+3. **UI ambiguity** — the `/platform/edge-nodes` "add a node" flow must offer *internal
+   location* vs *customer site* as distinct, non-confusable choices.
+4. **Partner axis** — design the owner discriminator as an enum from day one.
+
+## 7. Ready-to-file backlog (file against the canonical backlog; see plan doc for full specs)
+
+- **BI — internal-estate per-location schema** (`workType=feature`): the §4.1 migration.
+- **BI — org-owned-site scope enforcement + isolation tests** (`workType=feature`): §4.2.
+- **BI — provisioning UX for internal location** (`workType=feature`): §6.3.
+- **BI — fleet-by-location view for single-org estate** (`workType=feature`).
+- (Phase 1 BI — explicit organization minting — satisfied by this PR; file for record + link.)
+
+All link **EP-EDGE-TOPOLOGY** (may cross-link EP-ARCH-8D4F2A); the isolation-test BI also
+relates to **EP-ESTATE-SOVEREIGNTY**.


### PR DESCRIPTION
## Summary
Internal-estate **per-location** ownership scoping for the edge-node fleet — the filed gap in the internal company-owned archetype (whole-org granularity already worked; per-location did not). Adds scope/enrollment handling + tests, plus the fleet-substrate, feasibility, implementation-plan, and substrate-audit specs.

## Provenance
Rescued from the root clone working tree (uncommitted + unpushed since 2026-06-25, was 141 commits behind); re-based clean onto current `origin/main`. Ref: EP-EDGE-TOPOLOGY (internal company-owned per-location archetype).

## Status
Operator assessment: "almost done" — opening for CI + review. Local typecheck was skipped at commit time (source-only worktree, no node_modules); CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)