### PR TITLE
fix(self-upgrade): sweep dangling images + build cache after each swap

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -146,6 +146,7 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
       "step=health",
       "step=sha-verify",
       "step=content-verify",
+      "step=cleanup",
     ] as const;
 
     let dryRunResult: ReturnType<typeof runScript>;
@@ -191,7 +192,13 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
       expect(dryRunResult.stdout).toContain("step=content-verify");
     });
 
-    it("steps appear in order: prepare → backup → docker-build → migrate → docker-up → health → sha-verify → content-verify", () => {
+    // Post-success disk hygiene: dangling portal images + build cache are swept
+    // after all verifies pass, so upgrades stop piling up tens of GB of dead disk.
+    it("emits cleanup step", () => {
+      expect(dryRunResult.stdout).toContain("step=cleanup");
+    });
+
+    it("steps appear in order: prepare → backup → docker-build → migrate → docker-up → health → sha-verify → content-verify → cleanup", () => {
       const positions = STEPS.map((s) => dryRunResult.stdout.indexOf(s));
       for (let i = 1; i < positions.length; i++) {
         expect(positions[i]).toBeGreaterThan(positions[i - 1]);

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -145,9 +145,11 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       expect(r.status).toBe(0);
       expect(r.stdout).toContain("step=cleanup");
       const dockerCalls = readFileSync(dockerLog, "utf8");
-      // Best-effort disk reclaim on the success path — dangling images + build cache.
+      // Best-effort disk reclaim on the success path.
+      // Dangling images: removed outright (superseded previous portal version).
       expect(dockerCalls).toContain("image prune -f");
-      expect(dockerCalls).toContain("builder prune -f");
+      // Build cache: BOUNDED, not wiped — kept as a rebuild-speed asset under a cap.
+      expect(dockerCalls).toContain("builder prune -f --keep-storage");
       // Conservative scope: never the destructive `-a` (would delete in-use tagged images).
       expect(dockerCalls).not.toContain("image prune -a");
       // Volumes are operator state — cleanup must never touch them.

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -137,6 +137,26 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     }
   }, PROMOTE_TEST_TIMEOUT_MS);
 
+  it("sweeps dangling images and build cache after a successful promote", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    try {
+      const r = runPromote({ source, backup, targetSha: head, fakeBin, dockerLog });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("step=cleanup");
+      const dockerCalls = readFileSync(dockerLog, "utf8");
+      // Best-effort disk reclaim on the success path — dangling images + build cache.
+      expect(dockerCalls).toContain("image prune -f");
+      expect(dockerCalls).toContain("builder prune -f");
+      // Conservative scope: never the destructive `-a` (would delete in-use tagged images).
+      expect(dockerCalls).not.toContain("image prune -a");
+      // Volumes are operator state — cleanup must never touch them.
+      expect(dockerCalls).not.toContain("volume");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
   it("derives a -dirty stamp when the build source has uncommitted changes", () => {
     const { root, source, backup, fakeBin, head } = makeScratch();
     try {

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -298,19 +298,26 @@ if [[ $_dry_run -eq 0 ]]; then
 fi
 
 # --- Step 8: cleanup ---
-# A successful swap leaves the PREVIOUS portal image untagged (dangling) plus the
-# BuildKit cache layers from step 3's rebuild. Nothing else sweeps them, so across
-# upgrades they pile into tens of GB of dead disk (an operator hit ~57 GB of dangling
-# images + build cache before this step existed). Reclaim them now — but ONLY after
-# every verify above has passed (so a still-needed rollback image is never pruned) and
-# BEST-EFFORT (a cleanup hiccup must never fail an upgrade that already succeeded).
-# Scope is deliberately conservative: dangling images only (never `docker image prune -a`,
-# which would delete tagged images the compose stack still needs) and build cache.
+# A successful swap leaves the PREVIOUS portal image untagged (dangling) plus BuildKit
+# cache layers from step 3's rebuild. Nothing else sweeps them, so across upgrades they
+# pile into tens of GB of dead disk on Docker's fixed VM disk — and once it fills, the
+# NEXT `docker compose build` (step 3) fails with "no space left on device", i.e. the
+# accumulation eventually breaks the very upgrade that produced it. Reclaim it now, but
+# ONLY after every verify above has passed (so a still-needed rollback image is never
+# pruned) and BEST-EFFORT (a cleanup hiccup must never fail an upgrade that succeeded).
+#
+# The two piles are treated differently on purpose:
+#   * Dangling images — the superseded previous portal version, zero value once the tag
+#     moved to the new build. Removed outright (never `docker image prune -a`, which
+#     would delete tagged images the compose stack still needs).
+#   * Build cache — a PERFORMANCE asset: those layers make the next rebuild fast, so we
+#     BOUND it (keep ~10GB; Docker evicts the oldest beyond that) rather than wiping it.
+#     Capping reclaims runaway disk without making every future upgrade rebuild cold.
 # Volumes are NEVER touched here — operator DB/state lives in volumes.
 emit_step cleanup
 if [[ $_dry_run -eq 0 ]]; then
   docker image prune -f >/dev/null 2>&1 || true
-  docker builder prune -f >/dev/null 2>&1 || true
+  docker builder prune -f --keep-storage "${PROMOTE_BUILD_CACHE_KEEP:-10GB}" >/dev/null 2>&1 || true
 fi
 
 # Terminal success marker — emitted only after every verify AND the cleanup sweep, so

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -295,5 +295,26 @@ if [[ $_dry_run -eq 0 ]]; then
       "${_running_hash:-unknown}" "$_built_hash" >&2
     exit 1
   }
+fi
+
+# --- Step 8: cleanup ---
+# A successful swap leaves the PREVIOUS portal image untagged (dangling) plus the
+# BuildKit cache layers from step 3's rebuild. Nothing else sweeps them, so across
+# upgrades they pile into tens of GB of dead disk (an operator hit ~57 GB of dangling
+# images + build cache before this step existed). Reclaim them now — but ONLY after
+# every verify above has passed (so a still-needed rollback image is never pruned) and
+# BEST-EFFORT (a cleanup hiccup must never fail an upgrade that already succeeded).
+# Scope is deliberately conservative: dangling images only (never `docker image prune -a`,
+# which would delete tagged images the compose stack still needs) and build cache.
+# Volumes are NEVER touched here — operator DB/state lives in volumes.
+emit_step cleanup
+if [[ $_dry_run -eq 0 ]]; then
+  docker image prune -f >/dev/null 2>&1 || true
+  docker builder prune -f >/dev/null 2>&1 || true
+fi
+
+# Terminal success marker — emitted only after every verify AND the cleanup sweep, so
+# `step=done` continues to mean "fully promoted" for the orchestrator.
+if [[ $_dry_run -eq 0 ]]; then
   printf 'step=done target=%s\n' "$_built_sha"
 fi


### PR DESCRIPTION
## Why

You asked how the Docker cruft accumulates and how to prevent it. Answer: **the self-upgrade never cleans up after itself.** `promote.sh` step 3 rebuilds the ~3 GB portal image on every upgrade (`docker compose build portal`), which leaves the previous image untagged (dangling) and adds BuildKit cache layers. There was no cleanup step, so across upgrades it piled into tens of GB of dead disk — an operator hit **~57 GB** of dangling images + build cache (30 dangling images).

## Fix

A final **`cleanup`** step in `promote.sh` running `docker image prune -f` + `docker builder prune -f`, deliberately:

- **Success-path only** — after `health`, `sha-verify`, and `content-verify` all pass, so a still-needed rollback image is never pruned.
- **Best-effort** (`|| true`) — a cleanup hiccup can't fail an upgrade that already succeeded; `step=done` is still the terminal marker right after.
- **Conservatively scoped** — dangling images only (never `docker image prune -a`, which would delete tagged images the stack needs) + build cache. **Volumes are never touched** — operator DB/state lives in volumes (and `docker volume rm` is correctly gated behind a `never-wipe-db` operator commandment).

## Tests

- Contract: `step=cleanup` added to the expected dry-run step sequence + ordering assertion.
- Functional: a successful promote invokes `image prune -f` and `builder prune -f`, and never `image prune -a` or any `volume` operation.
- Both suites green: **27/27**.

## Scope note

This handles the **big, recurring** source (self-upgrade image churn). Two smaller, separate sources are *not* in this PR: leftover one-off `docker run` containers, and the dev-portal's `dpf_dev_nm_*` node_modules volumes — both minor and not on the upgrade path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)