### PR TITLE
fix(build-studio): OpenCode preflight probes the selected provider's endpoint (Ollama bug)

### DIFF
--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -93,7 +93,10 @@ export function BuildStudioConfigForm({
   // BI-E06BB38A: technical knobs (raw context window, manual model, Apply/Test)
   // live behind this disclosure so the default view never asks for a token count.
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const autoCheckedRef = useRef(false);
+  // Tracks the last opencode providerId we preflighted, so switching the
+  // selected local provider (e.g. local → Ollama) re-probes the new endpoint
+  // instead of showing the previous provider's stale readiness.
+  const autoCheckedRef = useRef<string | null>(null);
 
   const hasClaudeCreds = claudeProviders.some(p => isConfigured(p.status));
   const hasCodexCreds = codexProviders.some(p => isConfigured(p.status));
@@ -112,7 +115,7 @@ export function BuildStudioConfigForm({
     setContextResult(null);
     startTransition(async () => {
       try {
-        const result = await checkLocalEndpoint(opencodeModel);
+        const result = await checkLocalEndpoint(opencodeModel, opencodeProviderId);
         setEndpointCheck(result);
         // Prefill the context input with the real served size (or the floor) so
         // the operator edits from the truth, not a blank box.
@@ -171,16 +174,24 @@ export function BuildStudioConfigForm({
     });
   }
 
-  // BI-E06BB38A: auto-preflight the local endpoint once when OpenCode is the
+  // BI-E06BB38A: auto-preflight the local endpoint when OpenCode is the
   // selected engine, so the default view shows the auto-sized context + model
   // read-only — the operator never has to click "Test" or type a token count.
+  // Re-runs when the selected local provider changes so switching e.g. from the
+  // Docker Model Runner provider to a distinct "Ollama" provider probes the new
+  // endpoint rather than leaving the previous provider's readiness on screen.
   useEffect(() => {
-    if (provider === "opencode" && hasOpencodeProvider && openCodeDescription.isLocal && !autoCheckedRef.current) {
-      autoCheckedRef.current = true;
+    if (
+      provider === "opencode" &&
+      hasOpencodeProvider &&
+      openCodeDescription.isLocal &&
+      autoCheckedRef.current !== opencodeProviderId
+    ) {
+      autoCheckedRef.current = opencodeProviderId;
       runEndpointCheck();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider, openCodeDescription.isLocal]);
+  }, [provider, opencodeProviderId, openCodeDescription.isLocal]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>

--- a/apps/web/lib/actions/build-studio.ts
+++ b/apps/web/lib/actions/build-studio.ts
@@ -3,7 +3,7 @@
 import { prisma, type Prisma } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
-import { getOllamaBaseUrl, getOllamaApiRoot } from "@/lib/inference/ollama-url";
+import { getOllamaBaseUrl, getOllamaApiRoot, resolveOpencodeProviderBaseUrl } from "@/lib/inference/ollama-url";
 import { preflightLocalEndpoint, OPENCODE_MIN_CONTEXT_TOKENS, type LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 import { setServedContextTokens } from "@/lib/inference/dmr-runtime-config";
 import { getLocalOnlyInference, setLocalOnlyInference } from "@/lib/inference/local-only";
@@ -80,9 +80,20 @@ export async function saveBuildStudioConfig(
  */
 export async function checkLocalEndpoint(
   model: string,
+  opencodeProviderId?: string,
 ): Promise<LocalEndpointPreflight> {
   await requireManageProviders();
-  const portalBaseUrl = getOllamaBaseUrl().replace(/\/$/, "");
+  // Probe the endpoint of the SELECTED opencode provider — so picking a seeded
+  // "Ollama" provider hits its own baseUrl (localhost:11434) and honestly
+  // reports reachable/not, instead of silently borrowing the Docker Model
+  // Runner default and showing a green "Ready" that was really DMR's status.
+  const provider = opencodeProviderId
+    ? await prisma.modelProvider.findFirst({
+        where: { providerId: opencodeProviderId, cliEngine: "opencode" },
+        select: { providerId: true, endpoint: true, baseUrl: true },
+      })
+    : null;
+  const portalBaseUrl = resolveOpencodeProviderBaseUrl(provider).replace(/\/$/, "");
   // checkServedContext: read the authoritative runtime context window so the
   // UX shows the real served size (e.g. a 32768 override) and warns/blocks
   // below the agent floor — not the misleading /v1/models artifact default.

--- a/apps/web/lib/inference/ollama-url.test.ts
+++ b/apps/web/lib/inference/ollama-url.test.ts
@@ -69,6 +69,58 @@ describe("getOllamaBaseUrl", () => {
   });
 });
 
+describe("resolveOpencodeProviderBaseUrl", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.OLLAMA_INTERNAL_URL;
+    delete process.env.LLM_BASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("probes a selected non-default provider's own baseUrl (Ollama → localhost:11434), not the DMR default", async () => {
+    // The bug: selecting the seeded "Ollama" provider probed Docker Model
+    // Runner and showed a green "Ready" that was really Docker's status.
+    const { resolveOpencodeProviderBaseUrl } = await import("./ollama-url");
+    expect(
+      resolveOpencodeProviderBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434", endpoint: null }),
+    ).toBe("http://localhost:11434");
+  });
+
+  it("a selected non-default provider's baseUrl wins even when OLLAMA_INTERNAL_URL is set (env governs the default only)", async () => {
+    process.env.OLLAMA_INTERNAL_URL = "http://model-runner.docker.internal/v1";
+    const { resolveOpencodeProviderBaseUrl } = await import("./ollama-url");
+    expect(
+      resolveOpencodeProviderBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434", endpoint: null }),
+    ).toBe("http://localhost:11434");
+  });
+
+  it("prefers a non-default provider's endpoint over its baseUrl", async () => {
+    const { resolveOpencodeProviderBaseUrl } = await import("./ollama-url");
+    expect(
+      resolveOpencodeProviderBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434", endpoint: "http://host.docker.internal:11434" }),
+    ).toBe("http://host.docker.internal:11434");
+  });
+
+  it("keeps env-first resolution for the default 'local' provider (no regression)", async () => {
+    process.env.OLLAMA_INTERNAL_URL = "http://custom-dmr:9000/v1";
+    const { resolveOpencodeProviderBaseUrl } = await import("./ollama-url");
+    expect(
+      resolveOpencodeProviderBaseUrl({ providerId: "local", baseUrl: "http://model-runner.docker.internal/v1", endpoint: null }),
+    ).toBe("http://custom-dmr:9000/v1");
+  });
+
+  it("falls back to the Docker Model Runner default when no provider is given", async () => {
+    const { resolveOpencodeProviderBaseUrl } = await import("./ollama-url");
+    expect(resolveOpencodeProviderBaseUrl(null)).toBe("http://model-runner.docker.internal/v1");
+  });
+});
+
 describe("getOllamaApiRoot", () => {
   const originalEnv = process.env;
 

--- a/apps/web/lib/inference/ollama-url.ts
+++ b/apps/web/lib/inference/ollama-url.ts
@@ -23,6 +23,25 @@ export function getOllamaBaseUrl(provider?: ProviderUrlFields | null): string {
 }
 
 /**
+ * Resolve the endpoint to preflight for an explicitly-selected OpenCode
+ * provider. The default local provider (`local`, or none) keeps the env-first
+ * resolution of getOllamaBaseUrl — LLM_BASE_URL / OLLAMA_INTERNAL_URL govern
+ * the *default* local endpoint and must not regress. A distinct selected
+ * provider — e.g. `ollama` at http://localhost:11434 — uses its OWN
+ * endpoint/baseUrl, so a config-time preflight probes the box the operator
+ * actually picked instead of silently borrowing the Docker Model Runner
+ * default. Fixes the case where selecting a seeded "Ollama" provider reported a
+ * green "Ready" that was really Docker Model Runner's status.
+ */
+export function resolveOpencodeProviderBaseUrl(provider?: ProviderUrlFields | null): string {
+  const explicit = provider?.endpoint ?? provider?.baseUrl ?? null;
+  if (provider && provider.providerId !== "local" && explicit) {
+    return explicit;
+  }
+  return getOllamaBaseUrl(provider);
+}
+
+/**
  * Returns the root URL for the local provider's Ollama-native management API
  * (`/api/tags`, `/api/pull`, `/api/version`).
  *


### PR DESCRIPTION
## The bug
Selecting the seeded **"Ollama"** OpenCode provider showed a green **"✓ Ready — docker.io/ai/qwen3.6:latest"** — but that was really reporting **Docker Model Runner**'s status, not Ollama. `checkLocalEndpoint` ignored the selected provider and always resolved the URL via `getOllamaBaseUrl()` (the DMR default), so "Ollama" was a selectable option that never actually probed Ollama (`localhost:11434`). Operator's report: *"it let me select ollama but it says docker."*

## Fix
- **`resolveOpencodeProviderBaseUrl()`** (new, unit-tested): an explicitly-selected *distinct* provider uses its own `endpoint`/`baseUrl`; the default `local` provider keeps env-first resolution (`LLM_BASE_URL` / `OLLAMA_INTERNAL_URL`) — **no regression** for DMR installs.
- **`checkLocalEndpoint(model, opencodeProviderId)`** looks up the selected provider and probes **its** endpoint. Selecting Ollama now honestly reports reachable / not-reachable (so an un-running Ollama shows a real error instead of borrowing Docker's green check).
- The config form passes `opencodeProviderId` and **re-preflights when the selected local provider changes**, so switching local ↔ Ollama doesn't leave stale readiness on screen.
- 5 unit tests in `ollama-url.test.ts`.

## Out of scope (follow-up)
The seed ships an "Ollama" provider most installs don't run, shown indistinguishably next to the working DMR one. Consider not offering it until an Ollama endpoint is actually detected. Filing separately if desired.

## Test note
Local typecheck was skipped at commit (source-only worktree, no node_modules); CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Process-Spine-Decision: Localized bug fix — corrects endpoint resolution in an existing server action (checkLocalEndpoint) so the OpenCode preflight probes the operator-selected provider. No new capability, route, migration, or contract; behavior covered by 5 unit tests in ollama-url.test.ts. No spec/plan/doc surface applies.
