### PR TITLE
fix(test): align plugin-hooks-wired test with Claude hooks auto-load (unblocks main)

### DIFF
--- a/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
+++ b/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
@@ -132,15 +132,18 @@ test("plugin hook commands reference the script via ${CLAUDE_PLUGIN_ROOT}, not a
   }
 });
 
-test("all three surface manifests declare the hooks file (all-3-surfaces wiring stays put)", () => {
-  // Each client resolves plugin-relative paths differently: Claude/Codex from the
-  // plugin root (./), Grok from the .grok-plugin dir (../). BI-CA0ED781.
-  const manifests = [
-    [".claude-plugin", "./hooks/hooks.json"],
+test("surface manifests wire the hooks file so guards ship on every surface", () => {
+  // Codex and Grok resolve the hooks manifest from an explicit plugin.json key
+  // (Grok from the .grok-plugin dir, hence ../). Claude Code 2.1.197+ AUTO-LOADS
+  // hooks/hooks.json by convention, and an explicit "hooks" key now raises
+  // "Duplicate hooks file detected" — failing the WHOLE plugin load — so the
+  // .claude-plugin manifest must NOT declare it (#2544). The guards still ship on
+  // Claude via the auto-loaded file, asserted present below. BI-CA0ED781.
+  const declaring = [
     [".codex-plugin", "./hooks/hooks.json"],
     [".grok-plugin", "../hooks/hooks.json"],
   ];
-  for (const [dir, expected] of manifests) {
+  for (const [dir, expected] of declaring) {
     const manifest = JSON.parse(readFileSync(join(here, "..", dir, "plugin.json"), "utf8"));
     assert.equal(
       manifest.hooks,
@@ -148,6 +151,21 @@ test("all three surface manifests declare the hooks file (all-3-surfaces wiring 
       `${dir}/plugin.json must declare "hooks": "${expected}" so the guards ship on this surface`,
     );
   }
+
+  // Claude: no explicit key (avoids the duplicate-hooks load failure), but the
+  // auto-loaded manifest must exist next to the plugin so the guards still ship.
+  const claudeManifest = JSON.parse(
+    readFileSync(join(here, "..", ".claude-plugin", "plugin.json"), "utf8"),
+  );
+  assert.equal(
+    claudeManifest.hooks,
+    undefined,
+    '.claude-plugin/plugin.json must NOT declare "hooks" — Claude Code auto-loads hooks/hooks.json and an explicit key triggers a duplicate-hooks load failure (#2544)',
+  );
+  assert.ok(
+    existsSync(join(here, "hooks.json")),
+    "hooks/hooks.json must exist so Claude auto-loads the guards",
+  );
 });
 
 test("repo .claude/settings.json does NOT also wire the plugin-owned guards (anti double-fire)", () => {


### PR DESCRIPTION
## main is currently red — this unblocks it

[#2544](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2544) correctly dropped the `"hooks"` key from `.claude-plugin/plugin.json` — Claude Code 2.1.197 **auto-loads** `hooks/hooks.json` by convention, and the explicit key now raises *"Duplicate hooks file detected"*, failing the **entire** plugin load (the "plugin has no skills/agents" symptom). But #2544 left `packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs` asserting **all three** surface manifests declare the key, so the test now fails on `origin/main` and on every open PR (it runs in the `Spec/Plan/Doc Gate` job via `node --test`).

## Fix

Align the test with #2544's intent:
- **Codex** and **Grok** still declare `hooks` (their clients require the explicit key; Grok resolves from `.grok-plugin`, hence `../`).
- **`.claude-plugin` must NOT declare `hooks`** — asserted explicitly to lock the fix against regression — and `hooks/hooks.json` must **exist** so the guards still ship on Claude via auto-load.

Test-only; no product behavior change. Verified: `node --test packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs` → **13/13 pass** on latest `origin/main` with this change (fails 1 without it).

Found while getting the general-ledger PRs (#2546 / #2548) green — their own failures are fixed; this pre-existing main breakage was the remaining red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)