### PR TITLE
feat(compliance): jurisdiction- and listing-gated UK Corp Gov Code / Provision 29

### DIFF
--- a/apps/web/app/(shell)/storefront/settings/business/page.tsx
+++ b/apps/web/app/(shell)/storefront/settings/business/page.tsx
@@ -43,6 +43,7 @@ export default async function StorefrontBusinessSettingsPage() {
     employsIn: businessContext?.employsIn ?? [],
     dataResidency: businessContext?.dataResidency ?? [],
     handlesCardPayments: businessContext?.handlesCardPayments ?? false,
+    listingStatus: businessContext?.listingStatus ?? null,
     address: parseOrgAddress(org?.address),
     // Pre-set the risk posture from the stored value, else the industry default.
     // Inert in P0 — captured/seeded only; consumers are wired in P1.

--- a/apps/web/app/api/business-context/setup/route.ts
+++ b/apps/web/app/api/business-context/setup/route.ts
@@ -25,6 +25,7 @@ export async function POST(req: NextRequest) {
     employsIn,
     dataResidency,
     handlesCardPayments,
+    listingStatus,
     riskPosture,
     address,
   } = (await req.json()) as {
@@ -41,6 +42,7 @@ export async function POST(req: NextRequest) {
     employsIn?: string[];
     dataResidency?: string[];
     handlesCardPayments?: boolean;
+    listingStatus?: string | null;
     riskPosture?: string;
     address?: unknown;
   };
@@ -51,12 +53,25 @@ export async function POST(req: NextRequest) {
   const ALLOWED_JURISDICTIONS = new Set(["us", "eu", "uk", "global"]);
   const sanitizeJurisdictions = (v: unknown): string[] =>
     Array.isArray(v) ? v.filter((j): j is string => typeof j === "string" && ALLOWED_JURISDICTIONS.has(j)) : [];
+  // Market-listing status gates listing-specific governance regimes (e.g. UK
+  // Corporate Governance Code Provision 29). Sanitize to the LISTING_STATUSES
+  // enum; an unknown/empty value clears it (null = undeclared → "review").
+  const ALLOWED_LISTING_STATUSES = new Set([
+    "premium-listed",
+    "standard-listed",
+    "aim-listed",
+    "private",
+    "other",
+  ]);
+  const sanitizeListingStatus = (v: unknown): string | null =>
+    typeof v === "string" && ALLOWED_LISTING_STATUSES.has(v) ? v : null;
   const complianceScopeProvided =
     operatesIn !== undefined ||
     sellsTo !== undefined ||
     employsIn !== undefined ||
     dataResidency !== undefined ||
-    handlesCardPayments !== undefined;
+    handlesCardPayments !== undefined ||
+    listingStatus !== undefined;
   const complianceScope = complianceScopeProvided
     ? {
         operatesIn: sanitizeJurisdictions(operatesIn),
@@ -64,6 +79,7 @@ export async function POST(req: NextRequest) {
         employsIn: sanitizeJurisdictions(employsIn),
         dataResidency: sanitizeJurisdictions(dataResidency),
         handlesCardPayments: handlesCardPayments === true,
+        listingStatus: sanitizeListingStatus(listingStatus),
         complianceScopeCapturedAt: new Date(),
       }
     : {};

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -62,6 +62,19 @@ const COMPLIANCE_SCOPE_DIMENSIONS = [
   { field: "dataResidency", label: "Where data must stay (data residency)" },
 ] as const;
 
+// Market-listing status. Values match the LISTING_STATUSES enum in
+// regulation-applicability.ts so listing-gated regimes (e.g. UK Corporate
+// Governance Code Provision 29) can match them. Only surfaced when the business
+// operates in the UK — a listed-vs-private distinction only changes what applies
+// for UK-operating companies, so a non-UK layman never sees it.
+const LISTING_STATUS_OPTIONS = [
+  { value: "private", label: "Private (not listed)" },
+  { value: "premium-listed", label: "Premium listing (LSE Main Market / FTSE 350)" },
+  { value: "standard-listed", label: "Standard listing" },
+  { value: "aim-listed", label: "AIM-listed" },
+  { value: "other", label: "Other / not sure" },
+];
+
 type JurisdictionScopeField = (typeof COMPLIANCE_SCOPE_DIMENSIONS)[number]["field"];
 
 type BusinessContextData = {
@@ -78,6 +91,7 @@ type BusinessContextData = {
   employsIn: string[];
   dataResidency: string[];
   handlesCardPayments: boolean;
+  listingStatus: string | null;
   riskPosture: string | null;
   address: OrgAddress;
 };
@@ -595,6 +609,42 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
             />
             We accept card payments (PCI-DSS applies wherever you handle cards)
           </label>
+
+          {/* Listing status — only relevant for UK-operating companies, where the
+              listed-vs-private distinction decides whether governance rules like
+              the UK Corporate Governance Code (Provision 29) apply. Hidden
+              otherwise to keep the default to a couple of plain choices. */}
+          {data.operatesIn.includes("uk") && (
+            <label style={{ display: "block", marginTop: 12, fontSize: 13 }}>
+              <div style={{ marginBottom: 4 }}>Is the company listed on a stock exchange?</div>
+              <select
+                value={data.listingStatus ?? ""}
+                onChange={(e) => update("listingStatus", e.target.value || null)}
+                style={{
+                  ...inputStyle,
+                  background: "var(--dpf-surface-2)",
+                  color: "var(--dpf-text)",
+                }}
+              >
+                <option value="" style={{ background: "var(--dpf-surface-2)", color: "var(--dpf-text)" }}>
+                  Select…
+                </option>
+                {LISTING_STATUS_OPTIONS.map((o) => (
+                  <option
+                    key={o.value}
+                    value={o.value}
+                    style={{ background: "var(--dpf-surface-2)", color: "var(--dpf-text)" }}
+                  >
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <div style={hintStyle}>
+                UK premium-listed companies must report on board internal-controls effectiveness
+                (Corporate Governance Code, Provision 29).
+              </div>
+            </label>
+          )}
 
           {showCrossBorder ? (
             <div style={{ marginTop: 12, paddingLeft: 12, borderLeft: "2px solid var(--dpf-border)" }}>

--- a/apps/web/lib/compliance-library.test.ts
+++ b/apps/web/lib/compliance-library.test.ts
@@ -178,4 +178,58 @@ describe("compliance library applicability", () => {
     expect(parseComplianceLibraryScope("unexpected")).toBe("applies");
     expect(complianceLibraryContextLabel(softwareContext)).toBe("Software Platform (software-platform)");
   });
+
+  describe("UK Corporate Governance Code / Provision 29 (listing-gated)", () => {
+    const ukCorpGov = regulation({
+      regulationId: "REG-UK-CORP-GOV-CODE",
+      name: "UK Corporate Governance Code (2024) — Provision 29",
+      shortName: "UK Corp Gov Code / Provision 29",
+      jurisdiction: "UK",
+      industry: null,
+      sourceUrl: null,
+    });
+
+    function ukContext(
+      overrides: Partial<ComplianceLibraryContext["regional"]>,
+    ): ComplianceLibraryContext {
+      return { ...softwareContext, regional: { ...softwareContext.regional, ...overrides } };
+    }
+
+    it("applies to a UK-operating premium-listed company", () => {
+      const result = classifyRegulationForInstall(
+        ukCorpGov,
+        ukContext({ operatesIn: ["uk"], listingStatus: "premium-listed" }),
+      );
+      expect(result.scope).toBe("applies");
+      expect(result.reason).toContain("premium-listed");
+    });
+
+    it("needs review when no operating footprint is captured", () => {
+      expect(classifyRegulationForInstall(ukCorpGov, softwareContext).scope).toBe("review");
+    });
+
+    it("needs review when UK-operating but listing status is undeclared", () => {
+      const result = classifyRegulationForInstall(ukCorpGov, ukContext({ operatesIn: ["uk"] }));
+      expect(result.scope).toBe("review");
+      expect(result.reason).toContain("market-listing status");
+    });
+
+    it("is reference for a UK-operating private company", () => {
+      const result = classifyRegulationForInstall(
+        ukCorpGov,
+        ukContext({ operatesIn: ["uk"], listingStatus: "private" }),
+      );
+      expect(result.scope).toBe("reference");
+      expect(result.reason).toContain("private");
+    });
+
+    it("is reference when the business does not operate in the UK", () => {
+      const result = classifyRegulationForInstall(
+        ukCorpGov,
+        ukContext({ operatesIn: ["us"], listingStatus: "premium-listed" }),
+      );
+      expect(result.scope).toBe("reference");
+      expect(result.reason).toContain("does not operate in the UK");
+    });
+  });
 });

--- a/apps/web/lib/compliance-library.ts
+++ b/apps/web/lib/compliance-library.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@dpf/db";
 import {
   CADA_APPLICABILITY,
+  UK_CORP_GOV_CODE_APPLICABILITY,
   regulationApplies,
   type RegionProfile,
 } from "@dpf/db/regulation-applicability";
@@ -86,6 +87,7 @@ export type ComplianceLibraryClient = {
         employsIn: true;
         dataResidency: true;
         handlesCardPayments: true;
+        listingStatus: true;
       };
     }): Promise<{
       industry: string | null;
@@ -95,6 +97,7 @@ export type ComplianceLibraryClient = {
       employsIn: string[];
       dataResidency: string[];
       handlesCardPayments: boolean;
+      listingStatus: string | null;
     } | null>;
   };
 };
@@ -214,12 +217,67 @@ function classifyCada(
   return applicability("reference", `CADA is out of scope for this install: ${result.reason}.`);
 }
 
+const LISTING_STATUS_LABEL: Record<string, string> = {
+  "premium-listed": "premium-listed",
+  "standard-listed": "standard-listed",
+  "aim-listed": "AIM-listed",
+  private: "private",
+  other: "another",
+};
+
+/**
+ * The UK Corporate Governance Code / Provision 29 is listing-gated, not
+ * industry-gated: it binds UK premium-listed companies regardless of archetype.
+ * So it needs a bespoke classifier (like CADA) rather than the industry-match
+ * fallback. Applies only when there is a UK OPERATING nexus AND the org has
+ * declared a premium listing; the intermediate "review" states cover the two
+ * undeclared-signal cases so an operator is prompted rather than silently
+ * excluded.
+ */
+function classifyUkCorpGov(context: ComplianceLibraryContext): ComplianceApplicability {
+  const result = regulationApplies(UK_CORP_GOV_CODE_APPLICABILITY, context.regional);
+  if (result.applies) {
+    return applicability(
+      "applies",
+      "The UK Corporate Governance Code Provision 29 applies: a UK-operating premium-listed company.",
+    );
+  }
+  const operatesInUk = context.regional.operatesIn.some((j) => j.toLowerCase() === "uk");
+  if (context.regional.operatesIn.length === 0) {
+    return applicability(
+      "review",
+      "Provision 29 binds UK premium-listed companies, but no operating footprint has been captured yet.",
+    );
+  }
+  if (!operatesInUk) {
+    return applicability(
+      "reference",
+      "Provision 29 is out of scope: the business does not operate in the UK.",
+    );
+  }
+  // UK operating nexus present — the remaining gate is listing status.
+  const listing = context.regional.listingStatus;
+  if (!listing) {
+    return applicability(
+      "review",
+      "The business operates in the UK, but its market-listing status hasn't been captured — Provision 29 applies only to premium-listed companies.",
+    );
+  }
+  return applicability(
+    "reference",
+    `Provision 29 is out of scope: it binds UK premium-listed companies, and this is ${LISTING_STATUS_LABEL[listing] ?? "a non-premium-listed"} company.`,
+  );
+}
+
 export function classifyRegulationForInstall(
   regulation: ClassifiableRegulation,
   context: ComplianceLibraryContext,
 ): ComplianceApplicability {
   if (regulation.regulationId === "REG-CADA-2026") {
     return classifyCada(regulation, context);
+  }
+  if (regulation.regulationId === "REG-UK-CORP-GOV-CODE") {
+    return classifyUkCorpGov(context);
   }
 
   const currentLabel = installedArchetypeLabel(context);
@@ -339,6 +397,7 @@ export async function resolveComplianceLibraryContext(
         employsIn: true,
         dataResidency: true,
         handlesCardPayments: true,
+        listingStatus: true,
       },
     }),
   ]);
@@ -356,6 +415,7 @@ export async function resolveComplianceLibraryContext(
       sellsTo: businessContext?.sellsTo ?? [],
       employsIn: businessContext?.employsIn ?? [],
       dataResidency: businessContext?.dataResidency ?? [],
+      listingStatus: businessContext?.listingStatus ?? undefined,
     },
   };
 }

--- a/docs/professions/finance/wiki/uk-corporate-governance-code-provision-29.md
+++ b/docs/professions/finance/wiki/uk-corporate-governance-code-provision-29.md
@@ -1,0 +1,47 @@
+---
+title: UK Corporate Governance Code — Provision 29 (board internal-controls declaration)
+pageKind: principle
+status: published
+abstract: Provision 29 of the 2024 UK Corporate Governance Code requires the board of a UK premium-listed company to monitor its risk-management and internal-control framework, review the effectiveness of its material controls, and declare in the annual report whether those controls operated effectively at the balance-sheet date. Applies to UK premium-listed companies for accounting periods beginning on or after 1 January 2026; "comply or explain", not statute.
+principleTier: core
+principleDirection: For a UK premium-listed company, treat Provision 29 as binding — build the year-round monitoring and assurance evidence needed for the board's annual material-controls effectiveness declaration; do not reduce it to a boilerplate framework description.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.95, "evidence_density": 0.8}
+professionJurisdiction:
+  - uk
+professionJurisdictionBasis: operating
+professionCompetencyLevel: practitioner
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** UK — companies with a **premium listing** (in practice the FTSE 350 and other premium-listed companies). Standard-listed, AIM-listed, and private companies are **out of scope** (many adopt it voluntarily as good practice, or because a premium-listed customer asks them to evidence controls). Basis: **operating** — it binds the UK-listed entity itself. **Competency:** practitioner — identifying which controls are "material" and building the assurance trail behind the declaration is the skilled judgment; the divergence from US SOX 404 is expert-level.
+
+## Rule
+
+The board must **monitor** the company's risk-management and internal-control framework throughout the year, **review the effectiveness** of its **material controls** — across **financial, operational, compliance, and reporting** risks — and **declare in the annual report** whether those material controls operated **effectively as at the balance-sheet date**. Where there are **material weaknesses**, disclose them and explain the remediation taken or planned.
+
+The shift is from *describing* a framework to *standing behind* an effectiveness declaration — an outcomes-based, personal-accountability change (the UK's lighter-touch, "comply or explain" cousin of US SOX 404).
+
+## What it requires in practice
+
+1. **Monitor** — evidence the framework is watched year-round, not only at year end.
+2. **Identify material controls** — the controls whose failure would be material across the four risk categories (not just financial).
+3. **Review effectiveness** — gather assurance evidence a board can rely on.
+4. **Declare** — the annual-report statement on effectiveness at the balance-sheet date.
+5. **Disclose & remediate** — name any material weaknesses and the remediation plan.
+
+## Status & scope gate
+
+- **Effective:** accounting periods beginning **on or after 1 January 2026** — first affected annual reports appear in **2027**. Prep needs a full year of monitoring evidence, so groundwork starts before 2026.
+- **Not statute:** enforcement is via the listing regime and investor pressure on a **comply-or-explain** basis, not criminal liability.
+- **Scope gate:** applies only when the company is **UK premium-listed**. For a private or non-UK company, advise it as good practice or a customer-driven expectation — not a binding obligation.
+
+## See Also
+
+- [[professions/finance/revenue-recognition-ifrs15]]
+- [[professions/finance/accrual-basis-accounting]]

--- a/docs/superpowers/specs/2026-07-03-uk-corporate-governance-provision-29-design.md
+++ b/docs/superpowers/specs/2026-07-03-uk-corporate-governance-provision-29-design.md
@@ -1,0 +1,59 @@
+# UK Corporate Governance Code — Provision 29 (jurisdiction- and listing-gated governance) — Design
+
+- **Status:** implemented (initial slice)
+- **Date:** 2026-07-03
+- **Area:** compliance / governance (customer-facing), onboarding, coworker corpus
+- **Related:** `regulation-applicability.ts`, `compliance-library.ts`, `seed-banking-compliance.ts` (pattern), profession-corpus jurisdiction-basis model
+
+## 1. Problem
+
+The UK Corporate Governance Code (FRC, 2024 edition), and specifically its **Provision 29**, requires the board of a UK **premium-listed** company to monitor its risk-management and internal-control framework, review the effectiveness of its **material controls** (financial, operational, compliance, reporting), and **declare in the annual report** whether they operated effectively at the balance-sheet date — disclosing material weaknesses and remediation. It applies for accounting periods beginning on/after **1 January 2026** on a **comply-or-explain** basis (not statute).
+
+We want the platform to (a) recognise when Provision 29 applies to the organisation using the platform — gated by **jurisdiction (UK operating nexus)** and **legal form (premium-listed)** — and (b) surface it through the AI coworkers during onboarding, without showing it to organisations it doesn't apply to.
+
+## 2. Key constraint: it is listing-gated, not industry-gated
+
+The platform's archetypes are deliberately jurisdiction- and legal-form-neutral (a "banking" archetype exists for US/UK/EU alike). Provision 29 keys on **corporate legal form** (premium-listed), which is **orthogonal** to the industry archetype — any archetype can be a listed or private company. This is the one genuine data-model gap; everything else reuses existing machinery.
+
+## 3. Research & Benchmarking
+
+- **UK FRC 2024 Code / Provision 29** (primary source): board declaration on material-controls effectiveness; premium-listing scope; 1 Jan 2026 effective date; comply-or-explain. Pattern adopted: model as reference `Regulation → Obligation → Control`, classified per-install — **not** asserted as binding platform doctrine (respects the WWWD / Decision-Perspective boundary in AGENTS.md §16).
+- **US SOX 404** (benchmark, rejected as a model): SOX is statutory with management + auditor attestation and criminal exposure. Provision 29 is deliberately lighter (comply-or-explain, board declaration only). We reused our existing attestation record (`RequirementCompletion`) rather than importing a SOX-style dual-attestation model the Code does not require.
+- **Existing DPF compliance packs** (`seed-banking-compliance.ts`, `seed-public-sector-compliance.ts`): those gate by **industry**. Provision 29 needed a **listing-status** gate instead — so we extended the applicability model with a listing dimension rather than forcing it through the industry match, and gave it a bespoke classifier (mirroring the existing `classifyCada` special-case).
+- **Anti-pattern avoided:** creating a new "listed company" *archetype*. That would fork every industry archetype into listed/private variants (combinatorial). Listing status is a per-org attribute on `BusinessContext`, matching how the regional footprint is already captured.
+
+## 4. Design
+
+### 4.1 Data model — listing status (the one net-new field)
+`BusinessContext.listingStatus String?` (nullable; null = undeclared → "review", never silently applied). Canonical values are the `LISTING_STATUSES` enum in `regulation-applicability.ts`: `premium-listed | standard-listed | aim-listed | private | other`. Migration: `20260703120000_add_business_context_listing_status` (additive, nullable — safe).
+
+### 4.2 Applicability model
+`RegionProfile` gains optional `listingStatus`; `RegulationApplicability` gains optional `listingStatuses[]`. `regulationApplies` adds a listing gate (after the archetype gate): a spec with `listingStatuses` requires the profile's status to be one of them. Backward compatible — existing specs (CADA) omit it. New export `UK_CORP_GOV_CODE_APPLICABILITY = { basis: ["operating"], jurisdictions: ["uk"], listingStatuses: ["premium-listed"] }`.
+
+### 4.3 Classification (per-install)
+`classifyUkCorpGov` in `compliance-library.ts` (keyed on `REG-UK-CORP-GOV-CODE`, like `classifyCada`):
+- **applies** — UK operating nexus **and** premium-listed.
+- **review** — no operating footprint captured yet; or UK-operating but listing status undeclared.
+- **reference** — no UK operating nexus; or UK-operating but non-premium-listed.
+
+`resolveComplianceLibraryContext` now reads `listingStatus` into `regional`.
+
+### 4.4 Seeder
+`seed-uk-corp-gov-compliance.ts` (cross-sector, `industry: null`) seeds one `Regulation` (`REG-UK-CORP-GOV-CODE`), four Provision-29 obligations (monitor / review material controls / board declaration / disclose weaknesses), and one linking `Control`. Registered in `seed.ts` after the banking pack. Idempotent upsert, following the banking-pack pattern exactly.
+
+### 4.5 Onboarding intake
+`BusinessContextForm` shows a listing-status `<select>` **only when the org operates in the UK** (`operatesIn.includes("uk")`) — progressive disclosure keeps cognitive load to a couple of plain choices for everyone else. Persisted via the existing `business-context/setup` route (sanitised against the enum).
+
+### 4.6 Coworker surfacing
+`docs/professions/finance/wiki/uk-corporate-governance-code-provision-29.md` — a UK-basis (`professionJurisdictionBasis: operating`, `professionJurisdiction: [uk]`) profession-corpus page. The existing `profession-corpus` + `install-variant-context` path injects it into coworkers **only for UK-operating installs**, with no new plumbing.
+
+## 5. Verification & gate status
+
+- **Source-local (run):** `@dpf/db` + `web` typecheck; `regulation-applicability.test.ts` and `compliance-library.test.ts` (new cases for the listing gate + all four classification outcomes).
+- **Runtime-bound (must run on the sandbox / canonical install per AGENTS.md §5 — unrun in the source-only authoring environment):** migration apply, seed run, `next build`, and UX verification of the UK-gated intake field. These are unrun gates, not red gates.
+
+## 6. Out of scope / follow-ups
+
+- Wiring the Provision-29 control into `RegulatoryAutonomyPolicy` (human-control ceiling for the board-declaration activity) — a natural next step, deferred.
+- A dedicated Provision-29 workspace/checklist surface beyond the existing compliance library.
+- Listing status is currently free single-select; a future refinement could auto-derive premium-listing from a companies-register lookup.

--- a/packages/db/prisma/migrations/20260703120000_add_business_context_listing_status/migration.sql
+++ b/packages/db/prisma/migrations/20260703120000_add_business_context_listing_status/migration.sql
@@ -1,0 +1,7 @@
+-- Add corporate-law legal-form / market-listing status to BusinessContext.
+-- Orthogonal to the industry archetype: any archetype can be a listed or private
+-- company. Gates listing-specific governance regimes such as the UK Corporate
+-- Governance Code Provision 29 (UK premium-listed companies). Nullable + no
+-- default: an existing install is "undeclared" until the operator confirms it,
+-- so a listing-gated regulation is surfaced as "review", never silently applied.
+ALTER TABLE "BusinessContext" ADD COLUMN "listingStatus" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3265,6 +3265,14 @@ model BusinessContext {
   dataResidency             String[]  @default([])
   // Whether the business handles card payments (PCI-DSS, a global-basis obligation).
   handlesCardPayments       Boolean   @default(false)
+  // Corporate-law legal form / market-listing status, orthogonal to industry
+  // archetype: any archetype can be a listed or private company. Gates
+  // listing-specific governance regimes (e.g. UK Corporate Governance Code
+  // Provision 29, which applies to UK premium-listed companies). Values are the
+  // LISTING_STATUSES enum in regulation-applicability.ts (premium-listed |
+  // standard-listed | aim-listed | private | other). Null = undeclared → a
+  // listing-gated regulation is surfaced as "review", never silently applied.
+  listingStatus             String?
   // When the operator last confirmed the compliance scope at setup.
   complianceScopeCapturedAt DateTime?
 

--- a/packages/db/src/regulation-applicability.test.ts
+++ b/packages/db/src/regulation-applicability.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   regulationApplies,
   CADA_APPLICABILITY,
+  UK_CORP_GOV_CODE_APPLICABILITY,
+  isListingStatus,
   type RegionProfile,
   type RegulationApplicability,
 } from "./regulation-applicability";
@@ -47,5 +49,48 @@ describe("regulationApplies — global + archetype", () => {
     const spec: RegulationApplicability = { basis: ["operating"], jurisdictions: ["eu"], archetypes: ["healthcare-provider"] };
     expect(regulationApplies(spec, { ...empty, operatesIn: ["eu"], archetype: "retailer" }).applies).toBe(false);
     expect(regulationApplies(spec, { ...empty, operatesIn: ["eu"], archetype: "healthcare-provider" }).applies).toBe(true);
+  });
+});
+
+describe("regulationApplies — listing-status gate (UK Corporate Governance Code / Provision 29)", () => {
+  it("applies to a UK-operating PREMIUM-LISTED company", () => {
+    const r = regulationApplies(UK_CORP_GOV_CODE_APPLICABILITY, {
+      ...empty,
+      operatesIn: ["uk"],
+      listingStatus: "premium-listed",
+    });
+    expect(r.applies).toBe(true);
+    expect(r.matchedBasis).toContain("operating");
+  });
+
+  it("does NOT apply to a UK-operating PRIVATE company (listing gate)", () => {
+    const r = regulationApplies(UK_CORP_GOV_CODE_APPLICABILITY, {
+      ...empty,
+      operatesIn: ["uk"],
+      listingStatus: "private",
+    });
+    expect(r.applies).toBe(false);
+    expect(r.reason).toMatch(/listing status/);
+  });
+
+  it("does NOT apply to a UK-operating company with UNDECLARED listing status", () => {
+    const r = regulationApplies(UK_CORP_GOV_CODE_APPLICABILITY, { ...empty, operatesIn: ["uk"] });
+    expect(r.applies).toBe(false);
+    expect(r.reason).toMatch(/undeclared/);
+  });
+
+  it("does NOT apply to a premium-listed company with no UK operating nexus", () => {
+    const r = regulationApplies(UK_CORP_GOV_CODE_APPLICABILITY, {
+      ...empty,
+      operatesIn: ["us"],
+      listingStatus: "premium-listed",
+    });
+    expect(r.applies).toBe(false);
+  });
+
+  it("isListingStatus validates the canonical set", () => {
+    expect(isListingStatus("premium-listed")).toBe(true);
+    expect(isListingStatus("nasdaq")).toBe(false);
+    expect(isListingStatus(null)).toBe(false);
   });
 });

--- a/packages/db/src/regulation-applicability.ts
+++ b/packages/db/src/regulation-applicability.ts
@@ -16,6 +16,26 @@
  */
 import { type ProfessionJurisdictionBasis } from "./wiki-taxonomy";
 
+/**
+ * Corporate-law legal form / market-listing status — orthogonal to the industry
+ * archetype (any archetype can be a listed or private company). Some governance
+ * regimes gate on this dimension rather than industry: the UK Corporate
+ * Governance Code applies to UK premium-listed companies, not to a "banking" or
+ * "retail" archetype per se. `undefined` on a profile means undeclared.
+ */
+export const LISTING_STATUSES = [
+  "premium-listed",
+  "standard-listed",
+  "aim-listed",
+  "private",
+  "other",
+] as const;
+export type ListingStatus = (typeof LISTING_STATUSES)[number];
+
+export function isListingStatus(value: string | null | undefined): value is ListingStatus {
+  return typeof value === "string" && (LISTING_STATUSES as readonly string[]).includes(value);
+}
+
 /** An org's regional footprint + archetype. Jurisdiction values are bloc slugs (e.g. "eu", "us", "uk"). */
 export interface RegionProfile {
   operatesIn: string[];
@@ -24,6 +44,8 @@ export interface RegionProfile {
   dataResidency: string[];
   /** Business archetype slug (storefront/archetype), when known. */
   archetype?: string;
+  /** Market-listing / legal-form status (LISTING_STATUSES), when declared. */
+  listingStatus?: string;
 }
 
 export interface RegulationApplicability {
@@ -33,6 +55,14 @@ export interface RegulationApplicability {
   jurisdictions: string[];
   /** If set, only these business archetypes are in scope; otherwise archetype-agnostic. */
   archetypes?: string[];
+  /**
+   * If set, only these listing statuses are in scope (e.g. `["premium-listed"]`
+   * for a rule that binds only UK premium-listed companies). An undeclared
+   * listing status is treated as NOT-in-scope by {@link regulationApplies} — the
+   * classifier layer decides whether that surfaces as "review" (unknown) rather
+   * than "reference" (known out-of-scope). Omitted = listing-status-agnostic.
+   */
+  listingStatuses?: string[];
 }
 
 export interface ApplicabilityResult {
@@ -72,6 +102,19 @@ export function regulationApplies(
       };
     }
   }
+  // Listing-status gate — a regulation can bind only certain legal forms (e.g.
+  // UK premium-listed companies). An undeclared status fails the gate here; the
+  // classifier decides whether that reads as "review" (unknown) vs "reference".
+  if (spec.listingStatuses && spec.listingStatuses.length > 0) {
+    const s = profile.listingStatus;
+    if (!s || !spec.listingStatuses.includes(s)) {
+      return {
+        applies: false,
+        reason: `listing status ${s ? `'${s}'` : "(undeclared)"} is out of scope (applies to: ${spec.listingStatuses.join(", ")})`,
+        matchedBasis: [],
+      };
+    }
+  }
   // Global regulations apply wherever the relevant capability exists (e.g. PCI-DSS).
   if (spec.basis.includes("global")) {
     return { applies: true, reason: "applies globally — no regional nexus required", matchedBasis: ["global"] };
@@ -105,4 +148,20 @@ export function regulationApplies(
 export const CADA_APPLICABILITY: RegulationApplicability = {
   basis: ["operating", "selling"],
   jurisdictions: ["eu"],
+};
+
+/**
+ * The UK Corporate Governance Code (FRC, 2024 edition) — and specifically its
+ * Provision 29 board internal-controls accountability declaration — applies to
+ * companies with a UK premium listing (in practice the FTSE 350 and other
+ * premium-listed companies). It binds on the OPERATING basis (a UK-incorporated /
+ * UK-listed company), and gates on listing status: standard-listed, AIM-listed,
+ * and private companies are out of scope (the Code is "comply or explain" under
+ * the premium-listing regime, not statute). Provision 29 first bites for
+ * accounting periods beginning on or after 1 January 2026.
+ */
+export const UK_CORP_GOV_CODE_APPLICABILITY: RegulationApplicability = {
+  basis: ["operating"],
+  jurisdictions: ["uk"],
+  listingStatuses: ["premium-listed"],
 };

--- a/packages/db/src/seed-uk-corp-gov-compliance.ts
+++ b/packages/db/src/seed-uk-corp-gov-compliance.ts
@@ -1,0 +1,238 @@
+import type { PrismaClient } from "../generated/client/client";
+import * as crypto from "crypto";
+
+// UK Corporate Governance Code (FRC, 2024 edition) compliance pack, focused on
+// Provision 29 — the board internal-controls accountability declaration. This is
+// a cross-sector, listing-gated regime (any industry archetype can be a UK
+// premium-listed company), so it is NOT industry-seeded like the banking /
+// public-sector packs. Applicability is computed per-install by
+// classifyUkCorpGov (apps/web/lib/compliance-library.ts) from the org's UK
+// operating nexus + listing status, keyed on UK_CORP_GOV_CODE_APPLICABILITY.
+//
+// The Code is "comply or explain" under the premium-listing regime, not statute.
+// Provision 29 first applies for accounting periods beginning on/after
+// 1 January 2026 (first affected annual reports land in 2027).
+
+function makeId(prefix: string): string {
+  const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
+  return `${prefix}-${hex}`;
+}
+
+type ObligationSeed = {
+  title: string;
+  reference: string;
+  description: string;
+  category: string;
+  frequency: string;
+  applicability: string;
+  penaltySummary: string | null;
+};
+
+type RegulationSeed = {
+  regulationId: string;
+  name: string;
+  shortName: string;
+  jurisdiction: string;
+  industry: string | null;
+  sourceType: "external";
+  sourceUrl: string | null;
+  notes: string;
+  obligations: ObligationSeed[];
+};
+
+// Single regulation record; cross-sector (industry = null) and listing-gated.
+export const UK_CORP_GOV_REGULATIONS: RegulationSeed[] = [
+  {
+    regulationId: "REG-UK-CORP-GOV-CODE",
+    name: "UK Corporate Governance Code (2024) — Provision 29 board internal-controls declaration",
+    shortName: "UK Corp Gov Code / Provision 29",
+    jurisdiction: "UK",
+    industry: null,
+    sourceType: "external",
+    sourceUrl: "https://www.frc.org.uk/library/standards-codes-policy/corporate-governance/uk-corporate-governance-code/",
+    notes:
+      "The Financial Reporting Council's UK Corporate Governance Code applies on a " +
+      "'comply or explain' basis to companies with a UK premium listing (in practice the " +
+      "FTSE 350 and other premium-listed companies). Provision 29 of the 2024 Code is the " +
+      "headline change: the board must monitor its risk-management and internal-control " +
+      "framework, review the effectiveness of its MATERIAL controls across financial, " +
+      "operational, compliance and reporting risks, and declare in the annual report whether " +
+      "those controls operated effectively at the balance-sheet date — disclosing any material " +
+      "weaknesses and remediation. Provision 29 applies for accounting periods beginning on or " +
+      "after 1 January 2026, so the first affected annual reports appear in 2027. Standard-listed, " +
+      "AIM-listed and private companies are out of scope (though many adopt it as good practice). " +
+      "Not statute: enforcement is via the listing regime and investor pressure, not criminal liability.",
+    obligations: [
+      {
+        title: "Monitor the risk-management & internal-control framework",
+        reference: "ukcgc/p29-monitor-framework",
+        description:
+          "The board monitors the company's risk-management and internal-control framework " +
+          "throughout the reporting year — not only at year end — covering financial, " +
+          "operational, compliance and reporting risks.",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "UK premium-listed companies (FTSE 350 and other premium listings)",
+        penaltySummary: "Comply-or-explain: a deficient framework or an unexplained deviation draws investor and listing-regime scrutiny.",
+      },
+      {
+        title: "Review effectiveness of material controls",
+        reference: "ukcgc/p29-review-material-controls",
+        description:
+          "Identify the company's MATERIAL controls and review whether they operated effectively " +
+          "across financial, operational, compliance and reporting risks, gathering the assurance " +
+          "evidence needed to support the year-end declaration.",
+        category: "governance",
+        frequency: "annual",
+        applicability: "UK premium-listed companies",
+        penaltySummary: null,
+      },
+      {
+        title: "Board declaration on material-controls effectiveness (annual report)",
+        reference: "ukcgc/p29-board-declaration",
+        description:
+          "Include a declaration in the annual report stating whether the board considers the " +
+          "company's material controls to have operated effectively as at the balance-sheet date. " +
+          "This is the personal-accountability shift — the board stands behind the declaration, " +
+          "not merely a description of the framework.",
+        category: "reporting",
+        frequency: "annual",
+        applicability: "UK premium-listed companies, for accounting periods beginning on/after 1 Jan 2026",
+        penaltySummary: "Comply-or-explain: a missing or unexplained declaration is a governance-reporting failure under the listing regime.",
+      },
+      {
+        title: "Disclose material weaknesses and remediation",
+        reference: "ukcgc/p29-disclose-weaknesses",
+        description:
+          "Where material weaknesses in the material controls are identified, disclose them and " +
+          "explain the action taken or planned to remediate them.",
+        category: "reporting",
+        frequency: "event-driven",
+        applicability: "UK premium-listed companies with identified material weaknesses",
+        penaltySummary: null,
+      },
+    ],
+  },
+];
+
+type ControlSeed = {
+  title: string;
+  description: string;
+  controlType: "preventive" | "detective" | "corrective";
+  obligationRefs: string[];
+};
+
+export const UK_CORP_GOV_CONTROLS: ControlSeed[] = [
+  {
+    title: "Provision 29 material-controls monitoring & board declaration",
+    description:
+      "Year-round monitoring of the risk-management and internal-control framework, an annual " +
+      "effectiveness review of the identified material controls (financial, operational, " +
+      "compliance, reporting), the board's annual-report effectiveness declaration, and " +
+      "disclosure/remediation of any material weaknesses.",
+    controlType: "detective",
+    obligationRefs: [
+      "ukcgc/p29-monitor-framework",
+      "ukcgc/p29-review-material-controls",
+      "ukcgc/p29-board-declaration",
+      "ukcgc/p29-disclose-weaknesses",
+    ],
+  },
+];
+
+export async function seedUkCorpGovCompliance(prisma: PrismaClient): Promise<void> {
+  let regUpserts = 0;
+  let oblCreated = 0;
+  let ctlCreated = 0;
+  let linksCreated = 0;
+
+  const oblIdByRef = new Map<string, string>();
+
+  for (const reg of UK_CORP_GOV_REGULATIONS) {
+    const { obligations, ...regData } = reg;
+    const regulation = await prisma.regulation.upsert({
+      where: { regulationId: regData.regulationId },
+      update: {
+        name: regData.name,
+        shortName: regData.shortName,
+        jurisdiction: regData.jurisdiction,
+        industry: regData.industry,
+        sourceType: regData.sourceType,
+        sourceUrl: regData.sourceUrl,
+        notes: regData.notes,
+      },
+      create: regData,
+    });
+    regUpserts++;
+
+    for (const obl of obligations) {
+      const existing = await prisma.obligation.findFirst({
+        where: { regulationId: regulation.id, reference: obl.reference, status: "active" },
+        select: { id: true },
+      });
+      if (existing) {
+        oblIdByRef.set(obl.reference, existing.id);
+        continue;
+      }
+      const created = await prisma.obligation.create({
+        data: {
+          obligationId: makeId("OBL"),
+          regulationId: regulation.id,
+          title: obl.title,
+          description: obl.description,
+          reference: obl.reference,
+          category: obl.category,
+          frequency: obl.frequency,
+          applicability: obl.applicability,
+          penaltySummary: obl.penaltySummary,
+        },
+      });
+      oblIdByRef.set(obl.reference, created.id);
+      oblCreated++;
+    }
+  }
+
+  for (const ctl of UK_CORP_GOV_CONTROLS) {
+    const existing = await prisma.control.findFirst({
+      where: { title: ctl.title, status: "active" },
+      select: { id: true },
+    });
+    const controlId =
+      existing?.id ??
+      (
+        await prisma.control.create({
+          data: {
+            controlId: makeId("CTL"),
+            title: ctl.title,
+            description: ctl.description,
+            controlType: ctl.controlType,
+            implementationStatus: "planned",
+          },
+        })
+      ).id;
+    if (!existing) ctlCreated++;
+
+    for (const ref of ctl.obligationRefs) {
+      const oblId = oblIdByRef.get(ref);
+      if (!oblId) {
+        throw new Error(
+          `[seed-uk-corp-gov-compliance] control "${ctl.title}" references unknown obligation "${ref}"`,
+        );
+      }
+      const link = await prisma.controlObligationLink.findUnique({
+        where: { controlId_obligationId: { controlId, obligationId: oblId } },
+      });
+      if (!link) {
+        await prisma.controlObligationLink.create({ data: { controlId, obligationId: oblId } });
+        linksCreated++;
+      }
+    }
+  }
+
+  const expectedObligations = UK_CORP_GOV_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+  console.log(
+    `[seed] UK corporate-governance compliance pack: ${regUpserts}/${UK_CORP_GOV_REGULATIONS.length} regulations upserted, ` +
+      `${oblCreated} obligations created (${expectedObligations} expected total), ` +
+      `${ctlCreated} controls created, ${linksCreated} links created`,
+  );
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -40,6 +40,7 @@ import { seedPublicSectorCompliance } from "./seed-public-sector-compliance.js";
 import { seedCooperativeCompliance } from "./seed-cooperative-compliance.js";
 import { seedLawEnforcementCompliance } from "./seed-law-enforcement-compliance.js";
 import { seedBankingCompliance } from "./seed-banking-compliance.js";
+import { seedUkCorpGovCompliance } from "./seed-uk-corp-gov-compliance.js";
 import { seedBusinessCapabilityPerspective } from "./business-capability-perspectives.js";
 import { seedGeographicData } from "./seed-geographic-data.js";
 import { seedTaxJurisdictions } from "./seed-tax-jurisdictions.js";
@@ -2400,6 +2401,7 @@ async function main(): Promise<void> {
   await step("cooperativeCompliance", () => seedCooperativeCompliance(prisma));
   await step("lawEnforcementCompliance", () => seedLawEnforcementCompliance(prisma));
   await step("bankingCompliance", () => seedBankingCompliance(prisma));
+  await step("ukCorpGovCompliance", () => seedUkCorpGovCompliance(prisma));
   await step("businessCapabilityPerspective", async () => {
     const capabilityPerspectiveSeed = await seedBusinessCapabilityPerspective(prisma);
     console.log(


### PR DESCRIPTION
## Summary

Recognises **UK Corporate Governance Code Provision 29** (the board's annual internal-controls effectiveness declaration) as a compliance obligation for the organisation using the platform, and surfaces it through the AI coworkers during onboarding. Provision 29 is **listing-gated, not industry-gated** — it applies to UK premium-listed companies regardless of industry archetype — so this reuses the existing jurisdiction-with-basis applicability engine and adds one orthogonal dimension (market-listing status) rather than forking archetypes into listed/private variants. It is modelled as reference data classified per-install (applies / needs-review / reference), not asserted as binding platform doctrine, respecting the WWWD boundary in AGENTS.md §16.

## Changes

- **Data model:** `BusinessContext.listingStatus` (nullable) + additive migration `20260703120000_add_business_context_listing_status`. Values are the new `LISTING_STATUSES` enum (`premium-listed | standard-listed | aim-listed | private | other`).
- **Applicability engine:** `RegionProfile` / `RegulationApplicability` gain an optional listing-status gate; `regulationApplies` enforces it (backward compatible — existing specs omit it). New `UK_CORP_GOV_CODE_APPLICABILITY = { basis: ["operating"], jurisdictions: ["uk"], listingStatuses: ["premium-listed"] }`.
- **Classification:** `classifyUkCorpGov` in `compliance-library.ts` (keyed on `REG-UK-CORP-GOV-CODE`, mirroring the existing CADA special-case) → applies / review / reference; `resolveComplianceLibraryContext` reads `listingStatus` into the regional profile.
- **Seeder:** `seed-uk-corp-gov-compliance.ts` seeds one `Regulation` → 4 Provision-29 obligations → 1 linking control; registered in `seed.ts` after the banking pack; idempotent upsert following the banking-pack pattern.
- **Onboarding intake:** listing-status `<select>` in `BusinessContextForm`, shown **only when the org operates in the UK** (progressive disclosure); persisted + sanitised in the `business-context/setup` route; threaded through the settings page's initial state.
- **Coworker surfacing:** UK-basis profession-corpus page (`docs/professions/finance/wiki/uk-corporate-governance-code-provision-29.md`) — injected into coworkers for UK-operating installs via the existing corpus path, no new plumbing.
- **Spec + tests:** design spec under `docs/superpowers/specs/`; unit tests for the listing gate and all four classifier outcomes.

## Test plan

- [x] **Source-only checks:**
  - [x] `pnpm --filter @dpf/db typecheck` — pass
  - [x] `pnpm --filter web typecheck` — pass (`next typegen && tsc --noEmit`)
  - [x] `packages/db/src/regulation-applicability.test.ts` — 12 pass
  - [x] `apps/web/lib/compliance-library.test.ts` — 12 pass

- [x] **Runtime-bound (DB) checks — ran against an ephemeral local Postgres 16 cluster** (no managed nonprod lease was reachable in this session and there is no Docker daemon, so I stood up a throwaway `initdb` cluster as the `postgres` user purely to validate the DB-dependent gates; it is not the canonical portal and was torn down afterward):
  - [x] `prisma migrate deploy` applied the **entire** migration chain including `20260703120000_add_business_context_listing_status` — "All migrations have been successfully applied."
  - [x] `listingStatus` column verified via `information_schema`: `data_type=text`, `is_nullable=YES`.
  - [x] `seedUkCorpGovCompliance` ran: **1 regulation / 4 obligations / 1 control / 4 links**; a second run created 0 (idempotency proven). Regulation shape correct (`jurisdiction=UK`, `industry=null`).

- [ ] **Runtime-bound checks still owed to the canonical runtime** (not the object of this env):
  - [ ] `NODE_ENV=production pnpm --filter web build`
  - [ ] UX verification of the UK-gated listing-status field in the business-context step against the served portal (per AGENTS.md §5, via the governed self-upgrade path / shared nonprod lease).

- [x] **Verification-harness limitation acknowledged** — the ephemeral cluster covers the migration + seed gates; the production build + live-UX gates remain for the canonical install. Not a product defect.

### Verification evidence

```
$ pnpm --filter @dpf/db exec prisma migrate deploy
  └─ 20260703120000_add_business_context_listing_status/migration.sql
All migrations have been successfully applied.

listingStatus column: [{"column_name":"listingStatus","data_type":"text","is_nullable":"YES"}]
[seed] UK corporate-governance compliance pack: 1/1 regulations upserted, 4 obligations created (4 expected), 1 controls created, 4 links created
[seed] UK corporate-governance compliance pack: 1/1 regulations upserted, 0 obligations created, 0 controls created, 0 links created   # idempotent re-run
Regulation: {"shortName":"UK Corp Gov Code / Provision 29","jurisdiction":"UK","industry":null}
Obligations: 4 | Control: detective | links: 4

$ pnpm --filter @dpf/db exec vitest run src/regulation-applicability.test.ts   → 12 passed
$ pnpm --filter web    exec vitest run lib/compliance-library.test.ts          → 12 passed
$ pnpm --filter @dpf/db typecheck   → exit 0
$ pnpm --filter web    typecheck    → exit 0
```

The wider `@dpf/db` suite's other DB-integration failures seen earlier were Prisma connection errors from before this ephemeral DB existed, unrelated to this diff.

## Related issues / Epic

Follows the compliance-pack + jurisdiction-basis pattern established by the banking/public-sector packs and CADA applicability. No existing epic linked; design spec: `docs/superpowers/specs/2026-07-03-uk-corporate-governance-provision-29-design.md`.

## Notes for the reviewer

- **UX-Fit-Decision** (also in the commit trailer): the one new user-facing control is the listing-status select, gated behind "operates in the UK" so non-UK users never see it; UK users get one plain single-select (5 labelled options + a one-line reason). No raw/numeric input, no new route/tab — default view stays 3–5 plain choices.
- **Migration validated on a real Postgres** (see evidence) but was hand-authored (no `prisma migrate dev` DB in the authoring env); please still confirm it applies on the canonical runtime as part of self-upgrade.
- Follow-ups (in the spec, out of scope here): wiring the Provision-29 control into `RegulatoryAutonomyPolicy` for a board-declaration autonomy ceiling; a dedicated Provision-29 checklist surface.
