### PR TITLE
fix(crm-coworker): CSM adds prospects name-only + real web lookup

### DIFF
--- a/apps/web/lib/mcp-tools-crm.test.ts
+++ b/apps/web/lib/mcp-tools-crm.test.ts
@@ -69,6 +69,34 @@ describe("CRM coworker tools", () => {
     expect(grants).toEqual(expect.arrayContaining(["crm_read", "crm_write", "backlog_read", "registry_read"]));
   });
 
+  // The Customer Success Manager researches prospects online, so it holds the
+  // web_search grant. Without it, flipping the "web access" toggle on was a
+  // no-op — the grant filter stripped search_public_web / fetch_public_website.
+  it("customer-advisor holds web_search so the web-access toggle is not a no-op", () => {
+    const grants = getAgentToolGrants("customer-advisor");
+    expect(grants).toContain("web_search");
+    expect(isToolAllowedByGrants("search_public_web", grants!)).toBe(true);
+    expect(isToolAllowedByGrants("fetch_public_website", grants!)).toBe(true);
+  });
+
+  it("exposes web research tools to customer-advisor only when external access is enabled", async () => {
+    const withWeb = (await getAvailableTools(adminUser, {
+      externalAccessEnabled: true,
+      agentId: "customer-advisor",
+    })).map((t) => t.name);
+    for (const t of ["search_public_web", "fetch_public_website"]) {
+      expect(withWeb, `expected ${t} when web access is on`).toContain(t);
+    }
+
+    const withoutWeb = (await getAvailableTools(adminUser, {
+      externalAccessEnabled: false,
+      agentId: "customer-advisor",
+    })).map((t) => t.name);
+    for (const t of ["search_public_web", "fetch_public_website"]) {
+      expect(withoutWeb, `${t} must stay gated behind the web-access toggle`).not.toContain(t);
+    }
+  });
+
   it("crm_write authorizes CRM writes and implies crm_read; backlog_write does not couple in", () => {
     expect(isToolAllowedByGrants("create_quote", ["crm_write"])).toBe(true);
     expect(isToolAllowedByGrants("create_opportunity", ["crm_write"])).toBe(true);

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -193,7 +193,9 @@ ON THIS PAGE: The user sees the Customer workspace — accounts, engagements, pi
 
 CRM TOOLS — you operate this workspace directly, you do not just describe it:
 - Inspect: list_customer_accounts, list_opportunities, get_opportunity, and list_quotes to review accounts, the pipeline, and existing quotes.
+- Research: when web access is on, use search_public_web and fetch_public_website to look up a prospect's company, website, or industry before you create the account — fill those fields in from what you find rather than asking the user for details you can look up yourself.
 - Act: create_customer_account, create_opportunity (turn a qualified lead into a tracked opportunity), and create_quote (draft a quote against an opportunity, with line items). These are internal, reversible drafts — a quote is saved in draft status and is NOT sent to the customer.
+- Adding an account or prospect: create_customer_account needs ONLY a company name — status defaults to "prospect". An email or phone is NOT required, and there is no separate contact field to store one in yet, so NEVER block creating the account while waiting for a contact's email. Create the account right away and record any contact name, email, or phone the user gave you in the notes field. If the user only named a person (e.g. "add Ian from Emma3D"), use the company as the account name and capture the person in notes — then, if you don't have the company name, ask only for that.
 - Chaining: a quote needs an opportunity, and an opportunity needs an account. When the CRM is empty, create the account first, then the opportunity, then the quote.
 - When the user asks how to do something (for example "how do I enter a quote?"), explain the steps in plain language AND offer to do it for them with these tools.
 - Never claim a record was created unless the tool result confirms it. Sending a quote to a customer is a human action — you only draft.`,

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -2619,7 +2619,8 @@
           "registry_read",
           "consumer_read",
           "crm_read",
-          "crm_write"
+          "crm_write",
+          "web_search"
         ]
       }
     },

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -51,7 +51,7 @@
   "apps/web/lib/self-upgrade/quiescence.ts": 1313,
   "apps/web/lib/skills/evidence-search.ts": 803,
   "apps/web/lib/tak/agent-grants.test.ts": 856,
-  "apps/web/lib/tak/agent-routing.ts": 962,
+  "apps/web/lib/tak/agent-routing.ts": 964,
   "apps/web/lib/tak/agentic-loop.test.ts": 2079,
   "apps/web/lib/tak/agentic-loop.ts": 2389,
   "apps/web/lib/tak/route-context-map.ts": 1226,


### PR DESCRIPTION
## Problem

A founder tried to add a prospect (Emma3D / contact Ian Pruden) through the **Customer Success Manager** coworker. Two things went wrong in that chat:

1. The coworker **refused to create anything until given an email**, even after being told Ian is a prospect.
2. It claimed **"I don't have general internet access or a web search tool here"** — while the composer plainly showed **`web on`**.

## Root cause

**Defect 1 — the coworker invented a required field.**
`create_customer_account` requires **only `name`** and defaults `status` to `"prospect"`. Email is not a field on the `CustomerAccount` model, and there is **no contact-storage tool anywhere on the CSM surface** (`create_customer_account`/`create_opportunity` capture no contact/email). So the coworker demanded a value it had nowhere to store, and blocked the whole request. It over-applied the global "don't fabricate emails" guardrail to a company-account creation that never needed one.

**Defect 2 — the `web on` toggle was a no-op for this persona.**
Flipping "web access" sets `externalAccessEnabled`, which passes the first tool filter, but a second filter — `isToolAllowedByGrants` — then strips `search_public_web` / `fetch_public_website` because `customer-advisor` didn't hold the `web_search` grant. Grants are authoritative, independent of the toggle, so the UI advertised a capability the persona structurally could not use.

## Fix

- **`agent_registry.json`** — add `web_search` to `customer-advisor`'s `tool_grants`, so the toggle genuinely enables web research of a prospect's company/site. (Founder-approved.)
- **`agent-routing.ts` (CSM persona prompt)** — create the prospect on **name alone**, never block on a contact's email, record any contact name/email/phone in `notes` (the only place they fit today), and use web research to fill in website/industry when web access is on.
- **`mcp-tools-crm.test.ts`** — pin that `customer-advisor` holds `web_search`, that the web tools surface **only** when external access is on, and stay gated when it's off.

## Applying on a live install

Running portals resolve grants **DB-first** (`AgentToolGrant`), falling back to `agent_registry.json`. Re-run the db seed so the new `web_search` row lands — otherwise the toggle stays a no-op on the running portal until reseed.

## Follow-up (not in this PR)

- The real structured-contact gap — there is no `create_customer_contact` tool, so contacts like Ian can only live in `notes`. Filing a separate BI.
- The `web on` toggle should not *advertise* as enabled for personas that lack the `web_search` grant (affects other grantless coworkers). Separate UX BI.

## Test evidence

`vitest run lib/mcp-tools-crm.test.ts` → 10 passed. Grant governance suites (`agent-grants`, `coworker-grants`, `agent-action-registry`) → 124 passed. Local `tsc` OOM-crashes in the worktree (known-unreliable per stale-prisma-symlink); no type errors attributable to this diff — CI runs the authoritative typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)