### PR TITLE
feat(coworker): limitation-response contract — propose the enabler, never dead-end

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -940,10 +940,18 @@ export async function sendMessage(input: {
     // proposing or asking, and never sees its decision skills at all.
     const { loadDecisionRoutingBlock } = await import("@/lib/tak/decision-routing-block");
     const legacyDecisionRoutingBlock = await loadDecisionRoutingBlock();
+    // Limitation-response contract — must be surface-uniform with the unified
+    // prompt-assembler path. Without this, a legacy-path coworker never sees the
+    // instruction to propose the one enabler + ask a single yes/no when blocked,
+    // and instead dead-ends or deflects to "ask an admin".
+    const { loadLimitationResponseBlock } = await import("@/lib/tak/limitation-response-block");
+    const legacyLimitationResponseBlock = await loadLimitationResponseBlock();
     const promptSections = [
       agent.systemPrompt,
       "",
       legacyDecisionRoutingBlock,
+      "",
+      legacyLimitationResponseBlock,
       "",
       "Current context:",
       `- Route: ${input.routeContext}`,

--- a/apps/web/lib/tak/limitation-response-block.ts
+++ b/apps/web/lib/tak/limitation-response-block.ts
@@ -1,0 +1,33 @@
+// apps/web/lib/tak/limitation-response-block.ts
+//
+// The limitation-response contract injected into EVERY in-portal coworker's
+// system prompt, on BOTH the unified prompt-assembler path and the legacy
+// persona path. It is the fix for the failure mode where a coworker, when it
+// cannot complete a request, dead-ends on an open-ended explanation or deflects
+// to "ask an administrator" — instead of proposing the one enabler that would
+// unblock it and asking for a single yes/no go-ahead. Proactivity here means
+// exactly that: suggest the next step and get permission, reducing the human's
+// effort to one "yes" while keeping human authority over anything that changes
+// authority, spends money, or is hard to undo.
+//
+// DB-overridable like the other identity blocks: seeded as PromptTemplate
+// `platform-identity/limitation-response` from prompts/platform-identity/
+// limitation-response.prompt.md; the constant below is the offline fallback.
+
+import { loadPrompt } from "./prompt-loader";
+
+export const LIMITATION_RESPONSE_BLOCK = `WHEN YOU HIT A LIMITATION — PROPOSE THE ENABLER, NEVER DEAD-END.
+If you cannot finish what the employee asked because of a limitation — a tool you can't call, a permission or mode you lack, a capability that is not yet provisioned, a connection or setting that is off — do NOT stop at an explanation, and do NOT deflect with "ask an administrator" or "that is outside what I can do here." Turn the blocker into one proposal the employee can approve in a single step:
+1. Name the ONE specific thing that would unblock it, in plain language (for example: "switch me to Act mode", "let me give the Catalog Scout permission to run its scan", "turn on the <X> connection").
+2. State the smallest next step that both enables it AND completes the task — one recommended action, not a menu of choices.
+3. Ask for a single yes/no go-ahead. If the only way to enable it is a control that just the employee can flip, tell them the exact one-click control by name and offer to carry on the moment it is on.
+Reduce their effort to the bare minimum — one "yes" should unblock you — and never leave the request as an open-ended "here is what is wrong" with no proposed way forward. Keep human authority intact: get that yes before any step that changes someone's authority, spends money, or is hard to undo, and never take such a step on your own. Do not surface tool names, permission keys, or internal mechanics as jargon — describe the action the way a colleague would.`;
+
+/**
+ * Load the limitation-response contract, DB-override first (PromptTemplate
+ * `platform-identity/limitation-response`), falling back to the constant above
+ * when the DB row is absent/disabled or the DB is unreachable.
+ */
+export async function loadLimitationResponseBlock(): Promise<string> {
+  return loadPrompt("platform-identity", "limitation-response", LIMITATION_RESPONSE_BLOCK);
+}

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -104,6 +104,26 @@ describe("assembleSystemPrompt", () => {
     expect(routingIdx).toBeLessThan(modeIdx);
   });
 
+  // Test 2b: The limitation-response contract sits between decision-routing and
+  // mode, and instructs the coworker to propose the enabler + ask one yes/no
+  // rather than dead-ending or deflecting. Regression guard for the "AI Ops
+  // Engineer could only summarize / punted to System Admin" failure mode.
+  it("injects the limitation-response contract between decision-routing and mode", async () => {
+    const prompt = await assembleSystemPrompt(fullInput);
+
+    expect(prompt).toContain("WHEN YOU HIT A LIMITATION — PROPOSE THE ENABLER, NEVER DEAD-END.");
+    // The anti-dead-end + anti-deflect stance must be explicit.
+    expect(prompt).toContain("ask an administrator");
+    expect(prompt).toContain("single yes/no go-ahead");
+
+    const routingIdx = indexOf(prompt, "DECISION ROUTING —");
+    const limitationIdx = indexOf(prompt, "WHEN YOU HIT A LIMITATION —");
+    const modeIdx = indexOf(prompt, "Mode: ACT");
+    expect(routingIdx).toBeGreaterThanOrEqual(0);
+    expect(routingIdx).toBeLessThan(limitationIdx);
+    expect(limitationIdx).toBeLessThan(modeIdx);
+  });
+
   // Test 3: Act mode text is injected correctly
   it("injects act mode text when mode is 'act'", async () => {
     const prompt = await assembleSystemPrompt(fullInput);

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -10,6 +10,7 @@ import {
 } from "./question-packet";
 import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
 import { DECISION_ROUTING_BLOCK } from "./decision-routing-block";
+import { LIMITATION_RESPONSE_BLOCK } from "./limitation-response-block";
 import { readingLevelDirective, type ReadingLevel } from "@dpf/validators";
 import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./prompt-boundary";
 
@@ -127,6 +128,7 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
   const loaded = await loadPrompts([
     { category: "platform-identity", slug: "identity-block", fallback: IDENTITY_BLOCK },
     { category: "platform-identity", slug: "decision-routing", fallback: DECISION_ROUTING_BLOCK },
+    { category: "platform-identity", slug: "limitation-response", fallback: LIMITATION_RESPONSE_BLOCK },
     { category: "platform-identity", slug: modeSlug, fallback: input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK },
     { category: "platform-mission", slug: "company-mission", fallback: COMPANY_MISSION_FALLBACK },
   ]);
@@ -141,6 +143,11 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
   // WWMD/WWWD/WSID before proposing or asking. Surface-uniform with the legacy
   // path (apps/web/lib/actions/agent-coworker.ts).
   staticBlocks.push(loaded.get("platform-identity/decision-routing") ?? DECISION_ROUTING_BLOCK);
+
+  // Block 1c: Limitation response (static) — when blocked, propose the one
+  // enabler and ask a single yes/no; never dead-end or deflect to an admin.
+  // Surface-uniform with the legacy path (apps/web/lib/actions/agent-coworker.ts).
+  staticBlocks.push(loaded.get("platform-identity/limitation-response") ?? LIMITATION_RESPONSE_BLOCK);
 
   // Block 3: Mode (static per session — advise or act doesn't change mid-conversation)
   staticBlocks.push(loaded.get(`platform-identity/${modeSlug}`) ?? (input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK));

--- a/docs/superpowers/specs/2026-07-03-coworker-limitation-response-contract-design.md
+++ b/docs/superpowers/specs/2026-07-03-coworker-limitation-response-contract-design.md
@@ -1,0 +1,50 @@
+# Coworker Limitation-Response Contract — Design
+
+- **Date:** 2026-07-03
+- **Epic:** EP-F7E35344 (AI Coworker Capability Inputs)
+- **Backlog:** BI-FE37B0A1 (advise-mode strip is invisible → self-misdiagnosis) — this generalizes it into a behavioral contract for *every* limitation
+- **Goal it serves:** "When faced with a limitation, an AI coworker should propose to the human how to enable and complete the task — no open-ended interaction; proactivity means suggest/ask permission for the next step, reducing cognitive load to a bare minimum while maintaining human-in-the-loop."
+
+## Problem
+
+When a coworker cannot complete a request, its default behavior is to **dead-end**: it explains what's wrong at length and/or deflects to "ask an administrator / that's outside what I can do here." The AI Ops Engineer did exactly this on the AI Readiness console — it summarized three blockers and routed the operator to "Jiminy or System Admin," when the real next step was a one-click Act-mode toggle plus, now, a tool it can call. That is high cognitive load and no path forward.
+
+This is a *behavioral* gap, not a capability gap. The platform already has:
+- the `manage_coworker_tool_grant` MCP door (PR #2556) for the self-serve case,
+- the Advise→Act toggle for the mode case,
+- the proactivity resolver whose action boundary already tops out at **propose** (approval card), never autonomous act.
+
+What was missing is the instruction that turns a limitation into a **single-approve proposal** instead of a dead-end.
+
+## Design
+
+Add a DB-overridable **limitation-response** prompt block, injected into every coworker's system prompt on **both** the unified assembler path and the legacy persona path — surface-uniform, exactly like the existing `decision-routing` block it sits beside.
+
+The contract instructs the coworker, whenever blocked by a limitation:
+1. **Name the one enabler** in plain language ("switch me to Act mode", "let me give the Catalog Scout permission to run its scan", "turn on the <X> connection").
+2. **State the smallest next step** that both enables it and completes the task — one recommended action, not a menu.
+3. **Ask a single yes/no.** If only the human can flip a control, name the exact one-click control and offer to continue the moment it's on.
+
+Explicit prohibitions: no open-ended "here's what's wrong" with no way forward; no deflection to "an administrator"; no jargon (tool names / grant keys). Explicit HITL rail: get the yes before anything that changes authority, spends money, or is hard to undo — never take such a step unprompted. This aligns with the proactivity resolver's `propose` ceiling.
+
+### Composition with existing blocks
+`decision-routing` governs *how a coworker decides what to recommend* (consult WWMD/WWWD/WSID before proposing). `limitation-response` governs *what a coworker does when it is blocked from acting on that recommendation*. They are complementary and both static/cacheable; ordering is identity → decision-routing → **limitation-response** → mode.
+
+### Files
+- `apps/web/lib/tak/limitation-response-block.ts` — constant + `loadLimitationResponseBlock()` (DB-override via PromptTemplate, offline fallback).
+- `prompts/platform-identity/limitation-response.prompt.md` — seeded, editable in Admin > Prompts.
+- `prompt-assembler.ts` + `agent-coworker.ts` — inject on both paths.
+
+## Research & Benchmarking
+
+- **Nielsen's error-message heuristic** ("clearly indicate the problem AND constructively suggest a solution"): the contract's step 2 (propose the fix) is the "constructive solution" half most agent failures omit.
+- **Progressive disclosure / one-decision-at-a-time** (the `human_cognitive_load` axis in DPF's own UX-fit gate): a single yes/no beats a menu; we forbid option-menus for the unblock step.
+- **Anti-pattern rejected:** autonomous self-enablement (a coworker granting itself authority to proceed). The HITL rail + the `manage_coworker_tool_grant` self-target guard both forbid it — the coworker proposes; the human authorizes.
+
+## Verification
+- Unit: `prompt-assembler.test.ts` asserts the block is present, ordered between decision-routing and mode, and carries the anti-dead-end / single-yes language.
+- Both paths carry it (legacy injection mirrors the proven `decision-routing` injection).
+- Build gate via CI (worktree is source-only). No schema/migration.
+
+## UX-Fit
+This is a prompt-behavior change, not a new UI control — it *reduces* cognitive load (one yes/no vs an open-ended analysis). No new form, route, or operator-configurable field is introduced; the block is editable in the existing Admin > Prompts surface.

--- a/prompts/platform-identity/limitation-response.prompt.md
+++ b/prompts/platform-identity/limitation-response.prompt.md
@@ -1,0 +1,22 @@
+---
+name: limitation-response
+displayName: Limitation Response Contract
+description: When blocked, coworkers propose the one enabler and ask a single yes/no — never dead-end or deflect to an admin
+category: platform-identity
+version: 1
+
+composesFrom: []
+contentFormat: markdown
+variables: []
+
+valueStream: ""
+stage: ""
+sensitivity: internal
+---
+
+WHEN YOU HIT A LIMITATION — PROPOSE THE ENABLER, NEVER DEAD-END.
+If you cannot finish what the employee asked because of a limitation — a tool you can't call, a permission or mode you lack, a capability that is not yet provisioned, a connection or setting that is off — do NOT stop at an explanation, and do NOT deflect with "ask an administrator" or "that is outside what I can do here." Turn the blocker into one proposal the employee can approve in a single step:
+1. Name the ONE specific thing that would unblock it, in plain language (for example: "switch me to Act mode", "let me give the Catalog Scout permission to run its scan", "turn on the <X> connection").
+2. State the smallest next step that both enables it AND completes the task — one recommended action, not a menu of choices.
+3. Ask for a single yes/no go-ahead. If the only way to enable it is a control that just the employee can flip, tell them the exact one-click control by name and offer to carry on the moment it is on.
+Reduce their effort to the bare minimum — one "yes" should unblock you — and never leave the request as an open-ended "here is what is wrong" with no proposed way forward. Keep human authority intact: get that yes before any step that changes someone's authority, spends money, or is hard to undo, and never take such a step on your own. Do not surface tool names, permission keys, or internal mechanics as jargon — describe the action the way a colleague would.

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -17,7 +17,7 @@
   "apps/web/instrumentation.test.ts": 826,
   "apps/web/instrumentation.ts": 1311,
   "apps/web/lib/actions/agent-coworker-external.test.ts": 866,
-  "apps/web/lib/actions/agent-coworker.ts": 2531,
+  "apps/web/lib/actions/agent-coworker.ts": 2539,
   "apps/web/lib/actions/agent-task-scheduler.test.ts": 890,
   "apps/web/lib/actions/ai-providers.ts": 920,
   "apps/web/lib/actions/build-governed.test.ts": 1114,


### PR DESCRIPTION
## Goal

> When faced with a limitation, an AI coworker should **propose to the human how to enable and complete the task** — no open-ended interaction; proactivity means *suggest / ask permission for the next step*, reducing cognitive load to a bare minimum while maintaining human-in-the-loop.

## Why

When a coworker can't finish a request, its default is to **dead-end** — explain what's wrong and/or deflect to "ask an administrator." The AI Ops Engineer did exactly this on the AI Readiness console: it summarized three blockers and sent the operator to "System Admin," when the real next step was a one-click Act-mode toggle (and, now, a tool it can call). High cognitive load, no path forward.

This is a **behavioral** gap, not a capability gap — the enablers already exist (the `manage_coworker_tool_grant` door from #2556, the Advise→Act toggle, the proactivity resolver's `propose` ceiling). What was missing is the instruction that turns a limitation into a **single-approve proposal**.

## What

A DB-overridable **`limitation-response`** prompt block, injected into every coworker's system prompt on **both** the unified assembler path and the legacy persona path (surface-uniform, beside the existing `decision-routing` block). It instructs the coworker, when blocked:

1. **Name the one enabler** in plain language ("switch me to Act mode", "let me give the Catalog Scout permission to run its scan").
2. **State the smallest next step** that enables *and* completes the task — one recommended action, not a menu.
3. **Ask a single yes/no.** If only the human can flip a control, name the exact one-click control and offer to continue the moment it's on.

Explicit prohibitions: no open-ended "here's what's wrong" with no way forward; no deflection to "an administrator"; no jargon. Explicit HITL rail: get the yes before anything that changes authority, spends money, or is hard to undo — never take such a step unprompted.

## Composition
`decision-routing` = *how a coworker decides what to recommend*. `limitation-response` = *what it does when blocked from acting on it*. Order: identity → decision-routing → **limitation-response** → mode.

## Tests
- `prompt-assembler.test.ts`: asserts the block is present, ordered between decision-routing and mode, and carries the anti-dead-end / single-yes language.
- Legacy-path injection mirrors the proven `decision-routing` injection.

## Notes
- Delivers the behavioral half of **BI-FE37B0A1**; the runtime "which tool was stripped by mode" signal remains a follow-up.
- Worktree is source-only → local typecheck/build unrun (AGENTS.md §5); CI authoritative.
- Module-size baseline: surgical +8 for `agent-coworker.ts` (legacy-path injection).

Epic: EP-F7E35344

🤖 Generated with [Claude Code](https://claude.com/claude-code)