### PR TITLE
feat(coworker-grants): give outward-facing roles web_search by default

### DIFF
--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -848,3 +848,55 @@ describe("knownGrantKeys — closed grant vocabulary for the per-coworker editor
     for (const k of keys) expect(authorizing.has(k)).toBe(true);
   });
 });
+
+describe("web_search roster — outward-facing roles hold it, internal/governance roles do not", () => {
+  // Roles whose expected outcome depends on public-internet information the
+  // platform does not already hold (market/competitor/vendor/standards/docs
+  // research). If any of these regresses, the coworker's web-access toggle
+  // silently becomes a no-op again.
+  const WEB_RESEARCH_ROLES = [
+    "marketing-specialist",
+    "external-catalog-scout",
+    "inventory-specialist",
+    "portfolio-advisor",
+    "gap-analysis-agent",
+    "security-auditor-agent",
+    "sbom-management-agent",
+    "build-software-engineer",
+    "build-frontend-engineer",
+    "build-data-architect",
+    "ea-architect",
+    "ux-accessibility-agent",
+    "investment-analysis-agent",
+    "hr-specialist",
+  ];
+
+  // Internal-only, governance, or egress-sensitive roles that must NOT reach the
+  // public web (privacy, security-estate, or pure internal coordination).
+  const NO_WEB_ROLES = [
+    "data-governance-agent",
+    "soc-triage-analyst",
+    "soc-investigator",
+    "soc-threat-hunter",
+    "soc-incident-commander",
+    "coo-orchestrator",
+    "governance-orchestrator",
+    "evidence-chain-agent",
+    "constraint-validation-agent",
+  ];
+
+  it.each(WEB_RESEARCH_ROLES)("%s holds web_search and can use public web tools", (role) => {
+    const grants = getAgentToolGrants(role);
+    expect(grants, `${role} not found in registry`).toBeTruthy();
+    expect(grants).toContain("web_search");
+    expect(isToolAllowedByGrants("search_public_web", grants ?? [])).toBe(true);
+    expect(isToolAllowedByGrants("fetch_public_website", grants ?? [])).toBe(true);
+  });
+
+  it.each(NO_WEB_ROLES)("%s does NOT hold web_search", (role) => {
+    const grants = getAgentToolGrants(role);
+    expect(grants, `${role} not found in registry`).toBeTruthy();
+    expect(grants).not.toContain("web_search");
+    expect(isToolAllowedByGrants("search_public_web", grants ?? [])).toBe(false);
+  });
+});

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -755,7 +755,8 @@
           "tool_evaluation_read",
           "tool_verdict_create",
           "risk_score_create",
-          "spec_plan_read"
+          "spec_plan_read",
+          "web_search"
         ],
         "memory": {
           "type": "session",
@@ -803,7 +804,8 @@
           "gap_analysis_create",
           "external_registry_search",
           "tool_evaluation_create",
-          "spec_plan_read"
+          "spec_plan_read",
+          "web_search"
         ],
         "memory": {
           "type": "session",
@@ -899,7 +901,8 @@
           "dependency_audit",
           "supply_chain_verify",
           "finding_create",
-          "spec_plan_read"
+          "spec_plan_read",
+          "web_search"
         ],
         "memory": {
           "type": "persistent",
@@ -1141,7 +1144,8 @@
           "work_capsule_adopt",
           "tool_evaluation_read",
           "integration_test_create",
-          "spec_plan_read"
+          "spec_plan_read",
+          "web_search"
         ],
         "memory": {
           "type": "session",
@@ -2179,7 +2183,8 @@
           "work_capsule_adopt",
           "registry_read",
           "backlog_write",
-          "decision_record_create"
+          "decision_record_create",
+          "web_search"
         ],
         "memory": {
           "type": "none",
@@ -2364,7 +2369,8 @@
           "sandbox_execute",
           "work_capsule_read",
           "work_capsule_write",
-          "work_capsule_adopt"
+          "work_capsule_adopt",
+          "web_search"
         ]
       }
     },
@@ -2401,7 +2407,8 @@
           "sandbox_execute",
           "work_capsule_read",
           "work_capsule_write",
-          "work_capsule_adopt"
+          "work_capsule_adopt",
+          "web_search"
         ]
       }
     },
@@ -2438,7 +2445,8 @@
           "sandbox_execute",
           "work_capsule_read",
           "work_capsule_write",
-          "work_capsule_adopt"
+          "work_capsule_adopt",
+          "web_search"
         ]
       }
     },
@@ -2664,7 +2672,8 @@
           "architecture_read",
           "backlog_read",
           "decision_record_create",
-          "registry_read"
+          "registry_read",
+          "web_search"
         ]
       }
     },
@@ -2705,7 +2714,8 @@
           "backlog_read",
           "backlog_write",
           "consumer_read",
-          "registry_read"
+          "registry_read",
+          "web_search"
         ]
       }
     },
@@ -3045,7 +3055,8 @@
           "backlog_read",
           "backlog_write",
           "portfolio_read",
-          "registry_read"
+          "registry_read",
+          "web_search"
         ]
       }
     },
@@ -3091,7 +3102,8 @@
         "tool_grants": [
           "backlog_read",
           "backlog_write",
-          "registry_read"
+          "registry_read",
+          "web_search"
         ]
       }
     },
@@ -3141,7 +3153,8 @@
           "file_read",
           "portfolio_read",
           "registry_read",
-          "registry_write"
+          "registry_write",
+          "web_search"
         ]
       }
     },
@@ -3186,7 +3199,8 @@
           "work_engagement_read",
           "work_engagement_write",
           "work_engagement_transition",
-          "registry_read"
+          "registry_read",
+          "web_search"
         ]
       }
     }

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -50,7 +50,7 @@
   "apps/web/lib/routing/fallback.test.ts": 953,
   "apps/web/lib/self-upgrade/quiescence.ts": 1313,
   "apps/web/lib/skills/evidence-search.ts": 803,
-  "apps/web/lib/tak/agent-grants.test.ts": 851,
+  "apps/web/lib/tak/agent-grants.test.ts": 903,
   "apps/web/lib/tak/agent-routing.ts": 964,
   "apps/web/lib/tak/agentic-loop.test.ts": 2079,
   "apps/web/lib/tak/agentic-loop.ts": 2389,


### PR DESCRIPTION
## Why

Follow-up to the CSM web-access fix in #2557. Investigation there found the per-coworker **web access** toggle is AND-gated by a role's `web_search` grant — and only **7 of 67** coworkers held it. For the other 60 the toggle was a **silent no-op** (it flips to "web on" but no web tool is added), including roles whose entire job is to look outward (Marketing Strategist, External Catalog Scout, etc.).

Per the founder's direction ("keep grants as the authority, broaden to the roles that need it, and make the toggle honest"), this PR does the **broaden** half: it grants `web_search` by default to the roles whose expected outcomes genuinely require public-internet information.

## Method

Every one of the 67 roles was judged against a single test: **does delivering this role's outcome require public-internet information the platform doesn't already hold?** (market/competitor/vendor/standards/docs research).

## Granted (14)

| Role | Rationale |
|---|---|
| `marketing-specialist` | competitor / channel / market research |
| `external-catalog-scout` | external catalog reconnaissance **is** the job |
| `inventory-specialist` | product / market-fit research |
| `portfolio-advisor` | external market & benchmark data |
| `gap-analysis-agent` | domain literally *"searches external registries"* |
| `security-auditor-agent` | vets external tools/pkgs/images → CVE/vendor/reputation |
| `sbom-management-agent` | dependency + vulnerability/advisory lookups |
| `build-software-engineer` | public API / library docs |
| `build-frontend-engineer` | MDN / CSS / ARIA / design-system docs |
| `build-data-architect` | DB / schema-standard docs |
| `ea-architect` | researches external architecture standards |
| `ux-accessibility-agent` | WCAG technique / ARIA authoring references |
| `investment-analysis-agent` | external cost / market benchmarks |
| `hr-specialist` | employment-law / compliance references |

## Deliberately NOT granted

- **All 9 orchestrators** — internal coordination; they delegate research to specialists.
- **`data-governance-agent`** — privacy role; must not egress.
- **SOC roles** (`soc-triage-analyst`, `soc-investigator`, `soc-threat-hunter`, `soc-incident-commander`) — genuine threat-intel need, but egress from a security context should go through a **governed intel connector**, not general `web_search`. Tracked separately.
- Internal enforcement / backlog / deploy / monitoring / coordination agents.

Existing 7 grantees (`policy-specialist`, `finance-agent`, `licensing-specialist`, `documentation-specialist`, `admin-assistant`, `onboarding-coo`, `platform-engineer`) are unchanged.

## Tests

`agent-grants.test.ts` now pins the 14-role research roster (each holds `web_search` and can use `search_public_web` / `fetch_public_website`) **and** pins that governance/privacy/SOC/orchestrator roles do **not** hold it — so a future edit can't silently re-break the toggle or over-grant a sensitive role. Local run: 144 passed.

## Applying on a live install

Running portals resolve grants **DB-first** (`AgentToolGrant`); re-run the db seed so the new rows land, else the toggle stays a no-op on the running portal until reseed.

## Companion follow-up

**BI-CD9DC3BC** — make the toggle **grant-aware** so the un-granted roles show an honest *disabled* state instead of a dead switch. That closes the "honest" half; this PR is the "broaden" half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)