### PR TITLE
fix(deps): patch js-yaml DoS (GHSA-h67p-54hq-rp68, Dependabot #97)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6667,8 +6667,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -11212,7 +11212,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -15800,7 +15800,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -16555,7 +16555,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -16656,7 +16656,7 @@ snapshots:
   json-schema-ref-parser@6.1.0:
     dependencies:
       call-me-maybe: 1.0.2
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       ono: 4.0.11
 
   json-schema-traverse@1.0.0: {}


### PR DESCRIPTION
## What

Bumps the transitive **js-yaml** 3.x resolution from `3.14.2` → `3.15.0` to close **Dependabot alert #97** (GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in merge-key handling via repeated aliases, CWE-1333, moderate).

## Why this shape

- `3.15.0` is the 3.x **backport fix**; its deps (`argparse ^1.0.7`, `esprima ^4.0.0`) and `bin` are byte-identical to 3.14.2, so it's a drop-in patch.
- js-yaml 3.x is transitive via `gray-matter`, `json-schema-ref-parser@6.1.0`, and `@istanbuljs/load-nyc-config`. The 4.x line (`4.2.0`) is **not** in range (`< 3.15.0`) and is left untouched.
- Applied as a **surgical lockfile edit**, not a `pnpm.overrides` entry. Adding an overrides block forces pnpm to re-resolve the whole graph, which diverges ~950 lines from the committed tree (unrelated transitive `jsdom` 26→20 / `jest-environment-jsdom` internal regressions). Editing only the js-yaml resolution keeps the diff to the 6 lines that matter and leaves the rest of the dependency graph identical.

## Verification

- `pnpm install --frozen-lockfile` succeeds — 3.15.0 is fetched and its integrity hash validates (a mismatch or inconsistent lockfile would fail this).
- No `3.14.2` references remain; `4.2.0` consumers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)