### PR TITLE
fix(compliance): backfill regulation applicability on existing installs (data-only migration)

### DIFF
--- a/packages/db/prisma/migrations/20260703170000_backfill_regulation_applicability/migration.sql
+++ b/packages/db/prisma/migrations/20260703170000_backfill_regulation_applicability/migration.sql
@@ -1,0 +1,20 @@
+-- Data-only backfill for the data-driven applicability rollout.
+--
+-- The prior migration added Regulation.applicability (nullable). Phase 1 removes
+-- the bespoke classifiers (classifyCada, classifyUkCorpGov), so on an EXISTING
+-- install the already-seeded REG-CADA-2026 / REG-UK-CORP-GOV-CODE rows would sit
+-- with applicability = NULL between deploy and the next seed run and fall back to
+-- the industry matcher (mis-classifying). Backfill both rows here so the correct
+-- classification is in effect the instant this migration applies — independent of
+-- seed timing.
+--
+-- Guarded on IS NULL: a later seed upsert or an operator edit stays authoritative,
+-- and this is a no-op on a fresh install (the rows are seeded after migrations, so
+-- 0 rows match here and the seed populates the spec).
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating","selling"],"jurisdictions":["eu"]}'::jsonb
+ WHERE "regulationId" = 'REG-CADA-2026' AND "applicability" IS NULL;
+
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["uk"],"listingStatuses":["premium-listed"]}'::jsonb
+ WHERE "regulationId" = 'REG-UK-CORP-GOV-CODE' AND "applicability" IS NULL;


### PR DESCRIPTION
## Summary

Follow-up to #2562 (data-driven regulation applicability). That PR removed the bespoke `classifyCada`/`classifyUkCorpGov` classifiers and added the nullable `Regulation.applicability` column. On an **existing** install, the already-seeded `REG-CADA-2026` and `REG-UK-CORP-GOV-CODE` rows carry `applicability = NULL`, so between deploy and the next seed run they would fall back to the legacy industry matcher and mis-classify. This adds a **data-only migration** that backfills both rows so the correct classification is in effect the instant it applies — independent of seed timing.

Split into its own PR because #2562 was already in the merge queue (branch locked) and Prisma migrations are immutable once committed — the backfill therefore lands as a new migration, not an edit to the prior one.

## Changes

- **New data-only migration** `20260703170000_backfill_regulation_applicability`:
  - `UPDATE "Regulation" SET applicability = … WHERE regulationId = 'REG-CADA-2026' AND applicability IS NULL`
  - `UPDATE "Regulation" SET applicability = … WHERE regulationId = 'REG-UK-CORP-GOV-CODE' AND applicability IS NULL`
- Guarded on `IS NULL` so a later seed upsert or an operator edit stays authoritative, and it is a **no-op on fresh installs** (regulation rows are seeded *after* migrations run, so 0 rows match here and the seeds populate the spec).

## Why this is safe (de-confliction)

- **Additive/nullable schema change** landed in #2562 (can't fail on existing data; transactional DDL — atomic apply or rollback, never a partial state).
- **This backfill is idempotent + guarded**: `IS NULL` predicate, so re-runs and later authoritative writes don't clobber. No lock contention (indexed `regulationId` equality, ≤2 rows).
- No live regression window: the install advances only via governed self-upgrade, so #2562 + this follow-up are both in `main` before any deploy.

## Test plan

- [x] **Runtime-bound (DB) — ran on ephemeral local Postgres 16** (throwaway `initdb` cluster; no managed lease reachable; torn down after):
  - [x] **Upgrade-path simulation:** applied all migrations *except* this one, inserted `REG-CADA-2026` + `REG-UK-CORP-GOV-CODE` with `applicability = NULL`, then applied this migration → both rows backfilled with the correct specs:
    - `REG-CADA-2026 → {"basis":["operating","selling"],"jurisdictions":["eu"]}`
    - `REG-UK-CORP-GOV-CODE → {"basis":["operating"],"jurisdictions":["uk"],"listingStatuses":["premium-listed"]}`
  - [x] **Full chain** (`main` + this migration) `prisma migrate deploy` → "All migrations have been successfully applied."; `prisma migrate status` → "Database schema is up to date!" (no drift).
- [x] **Verification-harness limitation acknowledged** — ephemeral cluster covers the migration gate; canonical-runtime apply happens via governed self-upgrade. Not a product defect.

### Verification evidence

```
applicability BEFORE backfill:
REG-CADA-2026|
REG-UK-CORP-GOV-CODE|
applicability AFTER backfill:
REG-CADA-2026|{"basis": ["operating", "selling"], "jurisdictions": ["eu"]}
REG-UK-CORP-GOV-CODE|{"basis": ["operating"], "jurisdictions": ["uk"], "listingStatuses": ["premium-listed"]}
Database schema is up to date!
```

## Notes for the reviewer

Data-only migration (no `schema.prisma` change). Pairs with #2562; no code changes. `Process-Spine-Decision:` trivial data-only backfill migration correcting an existing-install edge case introduced by #2562 — covered by that PR's design spec (`docs/superpowers/specs/2026-07-03-generalized-governance-controls-framework-design.md`), no new durable-knowledge artifact needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01S1c8wXXcFJxvn4Gnyp98De)_