### PR TITLE
feat(coworker): Proactivity level drives in-task initiative

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -34,6 +34,8 @@ import { observeConversation } from "@/lib/process-observer-hook";
 import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { resolveRouteContext } from "@/lib/route-context-map";
 import { assembleSystemPrompt } from "@/lib/prompt-assembler";
+import { buildInitiativeBlock } from "@/lib/tak/initiative-block";
+import { getCoworkerProactivityPreference } from "@/lib/actions/proactivity";
 import { resolveReadingLevelForRoute } from "@/lib/readability/policy";
 import type { QuestionPacket } from "@/lib/tak/question-packet";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
@@ -700,6 +702,14 @@ export async function sendMessage(input: {
   // attributes each tool call to the active skill.
   let activeSkillId: string | null = null;
 
+  // BI-E35A8AA4: the employee's Proactivity choice for this coworker drives an
+  // Initiative block that scales in-task effort. Resolved once and injected into
+  // BOTH prompt paths so behavior is surface-uniform. Fail-open to null
+  // (→ balanced) so a preference-lookup hiccup never breaks the response.
+  const proactivityLevel = await getCoworkerProactivityPreference(agent.agentId).catch(
+    () => null,
+  );
+
   if (useUnified) {
     // ── Unified prompt path: composable blocks from route-context-map + prompt-assembler ──
     // EP-CTX-001: Context sources are submitted to the arbitrator, which enforces
@@ -898,6 +908,8 @@ export async function sendMessage(input: {
       // BI-8F8C5F28: on customer-copy surfaces, hold the coworker to the org's
       // reading level (high-school by default). Null on internal surfaces.
       readingLevel: await resolveReadingLevelForRoute(input.routeContext),
+      // BI-E35A8AA4: Proactivity → in-task initiative.
+      proactivityLevel,
     });
 
     if (eligibleSkillIds.length > 0) {
@@ -952,6 +964,10 @@ export async function sendMessage(input: {
       legacyDecisionRoutingBlock,
       "",
       legacyLimitationResponseBlock,
+      "",
+      // BI-E35A8AA4: Proactivity → in-task initiative — surface-uniform with the
+      // unified path, which injects the same block via assembleSystemPrompt.
+      buildInitiativeBlock(proactivityLevel),
       "",
       "Current context:",
       `- Route: ${input.routeContext}`,

--- a/apps/web/lib/tak/initiative-block.test.ts
+++ b/apps/web/lib/tak/initiative-block.test.ts
@@ -1,0 +1,43 @@
+// apps/web/lib/tak/initiative-block.test.ts
+// BI-E35A8AA4: the Proactivity level must produce a materially different
+// initiative directive, and the assertive level must NOT read as license to
+// fabricate or overreach.
+
+import { describe, expect, it } from "vitest";
+import { buildInitiativeBlock } from "./initiative-block";
+
+describe("buildInitiativeBlock", () => {
+  it("returns a distinct, non-empty directive per level", () => {
+    const quiet = buildInitiativeBlock("quiet");
+    const balanced = buildInitiativeBlock("balanced");
+    const assertive = buildInitiativeBlock("assertive");
+    for (const b of [quiet, balanced, assertive]) {
+      expect(b.length).toBeGreaterThan(0);
+      expect(b).toMatch(/INITIATIVE/);
+    }
+    expect(new Set([quiet, balanced, assertive]).size).toBe(3);
+  });
+
+  it("null / undefined resolves to the balanced default (the dock's effective level)", () => {
+    expect(buildInitiativeBlock(null)).toBe(buildInitiativeBlock("balanced"));
+    expect(buildInitiativeBlock(undefined)).toBe(buildInitiativeBlock("balanced"));
+  });
+
+  it("quiet tells the coworker to do-and-stop, not chase", () => {
+    const quiet = buildInitiativeBlock("quiet").toLowerCase();
+    expect(quiet).toMatch(/stop|do not chase|let the employee/);
+  });
+
+  it("assertive tells it to close the gap with its own tools before asking", () => {
+    const a = buildInitiativeBlock("assertive").toLowerCase();
+    expect(a).toMatch(/exhaust|close the gap|research/);
+    expect(a).toMatch(/only for what you genuinely could not/);
+  });
+
+  it("assertive re-states the bounds so higher effort is not read as license to overreach", () => {
+    const a = buildInitiativeBlock("assertive").toLowerCase();
+    // must NOT invite fabrication or authority-widening
+    expect(a).toMatch(/never invent|never fabricate|not your authority|effort, not/);
+    expect(a).toMatch(/exceed|authority|external|customer/);
+  });
+});

--- a/apps/web/lib/tak/initiative-block.ts
+++ b/apps/web/lib/tak/initiative-block.ts
@@ -1,0 +1,45 @@
+// apps/web/lib/tak/initiative-block.ts
+//
+// BI-E35A8AA4. The per-turn INITIATIVE contract injected into every in-portal
+// coworker's system prompt, on BOTH the unified prompt-assembler path and the
+// legacy persona path (surface-uniform with the decision-routing block).
+//
+// The coworker's Proactivity setting (quiet | balanced | assertive) used to
+// affect ONLY notification cadence — the resolved proactivity plan never
+// reached prompt assembly, so the coworker worked exactly as hard at "assertive"
+// as at "quiet". This block makes the level modulate in-task initiative: how
+// hard the coworker tries to close a gap with its own tools before handing back,
+// and how readily it takes the next well-supported action.
+//
+// It shapes EFFORT only. It never widens authority, never overrides the
+// advise/act mode gate, never licenses fabricating a missing value, and never
+// sends anything externally — the assertive text re-states those bounds so a
+// higher initiative level cannot be misread as permission to overreach.
+//
+// See docs/superpowers/specs/2026-07-03-proactivity-drives-in-task-initiative.md
+
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+
+const QUIET_BLOCK = `INITIATIVE — LOW (Quiet posture).
+Do what the employee asked, then stop. Do not chase missing details or take extra steps beyond the request — surface what you found and let the employee drive the next move. Ask at most one short question, and only when the task genuinely cannot proceed without it.`;
+
+const BALANCED_BLOCK = `INITIATIVE — MEDIUM (Balanced posture).
+Take the next well-supported action rather than narrating it. If a needed detail is missing, make a reasonable effort to recover it yourself first (a quick lookup with your tools) before asking. Batch anything you still need into one short question, and offer the following step so the work keeps moving.`;
+
+const ASSERTIVE_BLOCK = `INITIATIVE — HIGH (Assertive posture).
+Drive the task to completion. When something is missing, exhaust the means you have to close the gap yourself first — research it, derive it, or look it up with your tools — and ask the employee ONLY for what you genuinely could not obtain, stating plainly what you already recovered. Once the request is done, take the next well-supported action that advances the goal without waiting to be told. This raises your EFFORT, not your authority: never invent a value to avoid asking, never exceed the employee's granted permissions or your current mode, and never send anything to a customer or external party on your own — those bounds hold at every posture.`;
+
+const BLOCKS: Record<ProactivityLevel, string> = {
+  quiet: QUIET_BLOCK,
+  balanced: BALANCED_BLOCK,
+  assertive: ASSERTIVE_BLOCK,
+};
+
+/**
+ * The initiative directive for a coworker's Proactivity level. `null` (no saved
+ * preference) resolves to `balanced` — the dock's effective default — so the
+ * block always matches the level the employee sees.
+ */
+export function buildInitiativeBlock(level: ProactivityLevel | null | undefined): string {
+  return BLOCKS[level ?? "balanced"];
+}

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -489,4 +489,21 @@ describe("assembleSystemPrompt", () => {
     const uncapped = await assembleSystemPrompt({ ...minimalInput, readingLevel: "uncapped" });
     expect(uncapped).not.toContain("READING LEVEL");
   });
+
+  // BI-E35A8AA4: Proactivity → in-task initiative is threaded through PromptInput.
+  it("injects the initiative block matching the proactivity level, defaulting to balanced", async () => {
+    const assertive = await assembleSystemPrompt({ ...minimalInput, proactivityLevel: "assertive" });
+    expect(assertive).toContain("INITIATIVE — HIGH");
+
+    const quiet = await assembleSystemPrompt({ ...minimalInput, proactivityLevel: "quiet" });
+    expect(quiet).toContain("INITIATIVE — LOW");
+
+    // omitted → balanced (the dock's effective default)
+    const omitted = await assembleSystemPrompt(minimalInput);
+    expect(omitted).toContain("INITIATIVE — MEDIUM");
+
+    // initiative sits after authority and before the sensitivity block
+    expect(assertive.indexOf("INITIATIVE — HIGH")).toBeGreaterThan(assertive.indexOf("authorized to"));
+    expect(assertive.indexOf("INITIATIVE — HIGH")).toBeLessThan(assertive.indexOf("classified"));
+  });
 });

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -11,6 +11,8 @@ import {
 import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
 import { DECISION_ROUTING_BLOCK } from "./decision-routing-block";
 import { LIMITATION_RESPONSE_BLOCK } from "./limitation-response-block";
+import { buildInitiativeBlock } from "./initiative-block";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 import { readingLevelDirective, type ReadingLevel } from "@dpf/validators";
 import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./prompt-boundary";
 
@@ -61,6 +63,15 @@ export type PromptInput = {
    * surfaces where the constraint does not apply.
    */
   readingLevel?: ReadingLevel | null;
+  /**
+   * BI-E35A8AA4: the coworker's Proactivity level (quiet | balanced | assertive),
+   * resolved by the caller from getCoworkerProactivityPreference(agentId). Drives
+   * an Initiative block that scales in-task effort — how hard the coworker works
+   * to close a gap with its own tools before handing back. Null/undefined maps to
+   * `balanced` (the dock's effective default). Effort only: it never widens
+   * authority, mode, or the no-fabrication rule.
+   */
+  proactivityLevel?: ProactivityLevel | null;
 };
 
 // ─── Block 1: Identity (static) ─────────────────────────────────────────────
@@ -173,6 +184,11 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
   dynamicBlocks.push(
     `The employee you're working with holds role ${input.hrRole}. They are authorized to: ${granted}. They are NOT authorized to: ${denied}. All actions you take execute under their authority. Never exceed it.`
   );
+
+  // Block 2b: Initiative (dynamic — the employee's Proactivity choice for this
+  // coworker). Scales in-task effort by level; sits after the cache boundary
+  // because it varies per user/session. BI-E35A8AA4.
+  dynamicBlocks.push(buildInitiativeBlock(input.proactivityLevel));
 
   // Block 4: Sensitivity
   const level = input.sensitivity.toUpperCase();

--- a/docs/superpowers/plans/2026-07-03-proactivity-drives-in-task-initiative-plan.md
+++ b/docs/superpowers/plans/2026-07-03-proactivity-drives-in-task-initiative-plan.md
@@ -1,0 +1,24 @@
+# Plan — Proactivity drives in-task initiative (BI-E35A8AA4)
+
+Spec: [2026-07-03-proactivity-drives-in-task-initiative.md](../specs/2026-07-03-proactivity-drives-in-task-initiative.md)
+
+## Phase 1 — Initiative block (pure)
+- [x] `apps/web/lib/tak/initiative-block.ts` — `buildInitiativeBlock(level)` returning per-level directive; `null → balanced`.
+- [ ] `apps/web/lib/tak/initiative-block.test.ts` — per-level distinctness, assertive bounds language, null===balanced.
+
+## Phase 2 — Thread into prompt assembly
+- [ ] `prompt-assembler.ts` — add `proactivityLevel?: ProactivityLevel | null` to `PromptInput`; push `buildInitiativeBlock(...)` into dynamic blocks after Authority (dynamic — after cache boundary).
+- [ ] `prompt-assembler` test — assertive directive present when set; balanced fallback when omitted.
+
+## Phase 3 — Wire both send paths (surface-uniform)
+- [ ] `agent-coworker.ts sendMessage` — resolve `getCoworkerProactivityPreference(agent.agentId)` once.
+- [ ] Unified path — pass `proactivityLevel` into `assembleSystemPrompt`.
+- [ ] Legacy path — push `buildInitiativeBlock(level)` into `promptSections` beside the decision-routing block.
+
+## Phase 4 — Verify
+- [ ] Targeted vitest green (initiative-block, prompt-assembler, agent-coworker if touched).
+- [ ] module-size guard.
+- [ ] DCO PR; babysit CI.
+
+## Ordering / risk
+Pure block first (no deps), then assembler (type + injection), then call sites. Behavior bounded by existing authority/mode/no-fabrication rules; null→balanced means every coworker gets balanced guidance (intended, matches dock default). No schema/migration.

--- a/docs/superpowers/specs/2026-07-03-proactivity-drives-in-task-initiative.md
+++ b/docs/superpowers/specs/2026-07-03-proactivity-drives-in-task-initiative.md
@@ -1,0 +1,88 @@
+# Proactivity level drives in-task initiative
+
+- **BI:** BI-E35A8AA4
+- **Epic:** EP-F7E35344 (coworker autonomy / decision-routing)
+- **Date:** 2026-07-03
+- **Companion:** PR #2557 (CSM close-the-loop persona fix)
+
+## Problem
+
+The per-coworker **Proactivity** control (`quiet` | `balanced` | `assertive`,
+[ProactivityLevelControl.tsx](apps/web/components/proactivity/ProactivityLevelControl.tsx))
+implies how hard the coworker will work. In reality it resolves only to a
+*notification* plan — attention window, follow-up cadence, escalation target,
+`spendClass`, `actionBoundary` — in
+[proactivity-resolver.ts](apps/web/lib/proactivity/proactivity-resolver.ts).
+That plan is stored in `TaskRun.a2aMetadata` and **never reaches prompt
+assembly or the agentic loop**. `PromptInput`
+([prompt-assembler.ts](apps/web/lib/tak/prompt-assembler.ts)) has no proactivity
+field, so the system prompt and tool-use behavior are byte-identical at
+`assertive` and `quiet`. Assertive only *pings the user more often*; it does not
+make the coworker close open loops.
+
+Concretely (the Emma3D prospect-add case): asked to add a prospect and a
+contact, the coworker stalled on a missing email instead of — under an
+assertive posture — researching the contact itself and asking only for the
+residual.
+
+## Goal
+
+Make the Proactivity level modulate **in-task initiative**: how hard the
+coworker works to close a gap with its own tools before handing back, and how
+readily it takes the next well-supported action — bounded by the existing
+authority, mode, and no-fabrication guardrails. Notification behavior is
+unchanged.
+
+## Design
+
+### Initiative block (new)
+
+`apps/web/lib/tak/initiative-block.ts` — mirrors
+[decision-routing-block.ts](apps/web/lib/tak/decision-routing-block.ts):
+a pure function `buildInitiativeBlock(level: ProactivityLevel | null): string`
+returning a directive keyed by level. `null` maps to `balanced` (the UI's
+effective default), so the block always reflects the level shown in the dock.
+
+| Level | Directive gist |
+|---|---|
+| `quiet` | Do what's asked and stop. Don't chase missing details or take extra steps; surface what you have and let the employee drive. Ask at most one question, only if the task cannot proceed at all. |
+| `balanced` | Take the next well-supported action; make a reasonable effort (a quick lookup) to recover a missing detail before asking; batch what you still need into one short question; propose the following step. |
+| `assertive` | Drive to completion. When something is missing, exhaust your own tools to close the gap first — research/derive/look it up — and ask only for what you genuinely could not obtain, stating what you recovered. After the request, take the next well-supported action that advances the goal. Never fabricate a value to avoid asking; never exceed authority or send anything externally — initiative is effort, not overreach. |
+
+The `assertive` text explicitly re-states the no-fabrication and
+no-overreach bounds so a higher initiative level cannot be read as license to
+guess or to exceed the granted authority / mode.
+
+### Threading
+
+1. `PromptInput` gains `proactivityLevel?: ProactivityLevel | null`. The
+   assembler pushes `buildInitiativeBlock(input.proactivityLevel)` into the
+   **dynamic** blocks (it varies per user/session, so it must sit after the
+   cache boundary), right after the Authority block.
+2. `agent-coworker.ts sendMessage` resolves the level once via
+   `getCoworkerProactivityPreference(agent.agentId)` and:
+   - **unified path** — passes `proactivityLevel` into `assembleSystemPrompt`;
+   - **legacy path** — pushes `buildInitiativeBlock(level)` into
+     `promptSections`, adjacent to the decision-routing block, so both paths
+     are surface-uniform (the `USE_UNIFIED_COWORKER`-off install default gets
+     the same behavior).
+
+### Non-goals
+
+- No change to notification cadence, escalation, or the resolver plan shape.
+- No autonomous background loop — initiative only shapes the in-turn response;
+  the approval-card contract and mode gating are untouched.
+- SOC/governance web egress is out of scope (separate governed-intel item).
+
+## Tests
+
+- `initiative-block.test.ts`: each level yields a distinct, non-empty directive;
+  `assertive` contains the close-the-gap + no-fabrication language and `quiet`
+  the do-and-stop language; `null` === `balanced`.
+- `prompt-assembler` test: assembling with `proactivityLevel: "assertive"`
+  includes the assertive directive; omitting the field falls back to balanced.
+
+## Rollout
+
+Prompt/code change only — takes effect on portal rebuild. No migration. Level
+already persisted as a `UserFact`; no schema change.

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -17,7 +17,7 @@
   "apps/web/instrumentation.test.ts": 826,
   "apps/web/instrumentation.ts": 1311,
   "apps/web/lib/actions/agent-coworker-external.test.ts": 866,
-  "apps/web/lib/actions/agent-coworker.ts": 2539,
+  "apps/web/lib/actions/agent-coworker.ts": 2555,
   "apps/web/lib/actions/agent-task-scheduler.test.ts": 890,
   "apps/web/lib/actions/ai-providers.ts": 920,
   "apps/web/lib/actions/build-governed.test.ts": 1114,


### PR DESCRIPTION
## Why

Follow-up to the CSM prospect-add fix (#2557). Tracing why an "assertive" coworker still stalled on a missing contact detail surfaced the real gap: the **Proactivity** setting (`quiet` | `balanced` | `assertive`) only controls **notification cadence**. The resolved proactivity plan lives in `TaskRun.a2aMetadata` and is **never passed to prompt assembly or the agentic loop** — so the system prompt and tool-use behavior are byte-identical at every level. Assertive just *pings you more*; it never makes the coworker work harder to finish.

Founder direction: under aggressive proactivity a coworker should **exhaust its own tools to close a gap before handing back**, and take the next well-supported action — while `quiet` just advises.

## What

Make the level modulate **in-task initiative**, bounded by the existing authority / mode / no-fabrication guardrails.

- **`initiative-block.ts` (new)** — `buildInitiativeBlock(level)` returns a per-level directive:
  - `quiet` → do what's asked and stop; don't chase; ask at most one question only if blocked.
  - `balanced` → take the next action; a quick lookup to recover a missing detail before asking; batch the residual into one question.
  - `assertive` → drive to completion; exhaust your own tools to close the gap, ask **only** for what you couldn't obtain (stating what you recovered), then take the next well-supported action.
  - `null` → `balanced` (the dock's effective default).
- **`prompt-assembler.ts`** — `PromptInput` gains `proactivityLevel`; the block is a **dynamic** block injected after Authority (varies per user/session, so it sits after the cache boundary).
- **`agent-coworker.ts`** — resolves the level once via `getCoworkerProactivityPreference(agentId)` and injects the block into **both** the unified (`assembleSystemPrompt`) and legacy (`promptSections`) paths — surface-uniform with the decision-routing block, so the `USE_UNIFIED_COWORKER`-off install default gets the same behavior. Fail-open to balanced.

### Effort, not authority

The `assertive` directive explicitly re-states the bounds — never invent a value to avoid asking, never exceed the employee's permissions or the current mode, never send anything external — so a higher initiative level can't be misread as license to overreach. A test pins this.

## Non-goals

No change to notification cadence / escalation / the resolver plan shape. No autonomous background loop — initiative only shapes the in-turn response; the approval-card contract and mode gate are untouched. No schema/migration (level is already a `UserFact`).

## Tests

- `initiative-block.test.ts` — per-level distinctness, `null === balanced`, assertive close-the-gap language **and** the no-fabrication/no-overreach bounds.
- `prompt-assembler.test.ts` — block threaded and matches the level, balanced fallback when omitted, correct ordering (after authority, before sensitivity).
- Local: initiative + assembler suites 42 passed; agent-coworker suites 9 passed; module-size guard green.

## Docs

Spec + plan in `docs/superpowers/{specs,plans}/2026-07-03-proactivity-drives-in-task-initiative*`. **BI-E35A8AA4** (EP-F7E35344). Companion to #2557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)