### PR TITLE
feat(decision-gov): reframe /wiki landing into a three-discipline hub (EP-0AF96937 Phase 1)

### DIFF
--- a/apps/web/app/(shell)/wiki/page.tsx
+++ b/apps/web/app/(shell)/wiki/page.tsx
@@ -1,22 +1,35 @@
-// EP-WIKI-001 Phase 6a: global wiki browse page.
-// Shows kernel pages + the platform organization's overlay rows.
+// EP-0AF96937 Phase 1: decision-governance landing.
+// Reframes the former document-taxonomy "Wiki" landing around the three
+// decision disciplines a business reasons about — WWMD (platform), WWWD
+// (business), WSID (craft) — with derived health and See/Adjust/Review actions.
+// The raw kernel material (principles/stances/heuristics/…) is retained below
+// as a drill-in, not the front door.
 // Server component; queries Prisma directly.
 
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 
 import { WikiPageList, type WikiPageListItem } from "@/components/wiki/WikiPageList";
+import { DecisionDisciplineHub } from "@/components/wiki/DecisionDisciplineHub";
+import { buildDisciplineCards } from "@/lib/wiki/decision-governance-hub";
+import {
+  WWMD_PLATFORM_PROFILE_ID,
+  WWWD_ORGANIZATION_PROFILE_ID,
+} from "@/lib/decision/caller-context";
+import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "Wiki",
+  title: "Decision governance",
 };
 
 type SearchParams = Promise<{
   kind?: string;
   status?: string;
 }>;
+
+const UNRESOLVED = ["defer", "escalate"];
 
 export default async function WikiBrowsePage({
   searchParams,
@@ -46,57 +59,121 @@ export default async function WikiBrowsePage({
     where.pageKind = sp.kind;
   }
 
-  const pages = (await prisma.wikiPage.findMany({
-    where,
-    select: {
-      id: true,
-      slug: true,
-      title: true,
-      pageKind: true,
-      status: true,
-      isKernel: true,
-      abstract: true,
-      principleTier: true,
-      principleConsumerArchetype: true,
-      principleConsumerContexts: true,
-    },
-    orderBy: [
-      { pageKind: "asc" },
-      { principleConsumerArchetype: "asc" },
-      { principleTier: "asc" },
-      { title: "asc" },
-    ],
-  })) as WikiPageListItem[];
+  // Derive discipline health + fetch the retained material list in parallel.
+  const [
+    pages,
+    kernelPrincipleCount,
+    kernelHeuristicCount,
+    orgStanceMaterialCount,
+    wwmdOpenReviews,
+    wwwdOpenReviews,
+    wsidActiveProfiles,
+    wsidOpenReviews,
+  ] = await Promise.all([
+    prisma.wikiPage.findMany({
+      where,
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        pageKind: true,
+        status: true,
+        isKernel: true,
+        abstract: true,
+        principleTier: true,
+        principleConsumerArchetype: true,
+        principleConsumerContexts: true,
+      },
+      orderBy: [
+        { pageKind: "asc" },
+        { principleConsumerArchetype: "asc" },
+        { principleTier: "asc" },
+        { title: "asc" },
+      ],
+    }) as Promise<WikiPageListItem[]>,
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "principle", status: "published" },
+    }),
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "heuristic", status: "published" },
+    }),
+    // The org has "its own stance" when the WWWD organization profile carries
+    // its own material rows. In a single-tenant install where WWWD has not yet
+    // been seeded with distinct material this is 0 → "no stance of your own yet".
+    prisma.perspectiveMaterial.count({
+      where: { profileId: WWWD_ORGANIZATION_PROFILE_ID },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: UNRESOLVED }, profileId: WWMD_PLATFORM_PROFILE_ID },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: UNRESOLVED }, profileId: WWWD_ORGANIZATION_PROFILE_ID },
+    }),
+    prisma.decisionPerspectiveProfile.count({
+      where: { kind: "profession", status: "active" },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: UNRESOLVED }, profileId: { startsWith: "wsid-" } },
+    }),
+  ]);
+
+  const disciplineCards = buildDisciplineCards({
+    kernelPrincipleCount,
+    kernelHeuristicCount,
+    orgHasOwnWwwdStance: orgStanceMaterialCount > 0,
+    wwmdOpenReviews,
+    wwwdOpenReviews,
+    wsidFamilyCount: PROFESSION_REGISTRY.families.length,
+    wsidActiveProfiles,
+    wsidOpenReviews,
+  });
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <header className="mb-6">
         <h1 className="text-2xl font-semibold text-[var(--dpf-text)] mb-1">
-          Wiki
+          Decision governance
         </h1>
         <p className="text-sm text-[var(--dpf-muted)]">
-          Founder kernel and per-org overlay. Kernel pages ship with the platform;
-          overlay pages live alongside.
+          How your AI workforce decides on your behalf — and where you shape it.
+          Three disciplines govern every call: platform doctrine (WWMD), your
+          business (WWWD), and each role&rsquo;s craft (WSID).
         </p>
       </header>
 
-      <WikiPageList pages={pages} />
+      <DecisionDisciplineHub cards={disciplineCards} />
 
-      {/* Decision Perspectives — voice admin entry point */}
-      <div className="mt-8 rounded-lg border border-border p-4 flex items-center justify-between">
+      {/* Decision Perspectives — profile + voice admin entry point */}
+      <div className="mt-6 rounded-lg border border-[var(--dpf-border)] p-4 flex items-center justify-between">
         <div>
-          <p className="font-medium text-sm">Decision Perspectives</p>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Configure voice narration for WWMD / WWTD persona profiles
+          <p className="font-medium text-sm text-[var(--dpf-text)]">
+            Decision perspectives
+          </p>
+          <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
+            Manage the profiles behind each discipline, and give any perspective
+            a voice.
           </p>
         </div>
         <Link
           href="/wiki/perspectives"
-          className="text-sm text-primary hover:underline shrink-0 ml-4"
+          className="text-sm text-[var(--dpf-accent)] hover:underline shrink-0 ml-4"
         >
           Manage →
         </Link>
       </div>
+
+      {/* Retained kernel material — the drill-in, one level below the hub. */}
+      <section id="governing-material" className="mt-10 scroll-mt-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-3">
+          Governing material
+        </h2>
+        <p className="text-xs text-[var(--dpf-muted)] mb-4">
+          The founder kernel and per-org overlay pages that the disciplines above
+          are built from. Kernel pages ship with the platform; overlay pages live
+          alongside.
+        </p>
+        <WikiPageList pages={pages} />
+      </section>
     </div>
   );
 }

--- a/apps/web/app/(shell)/wiki/perspectives/page.tsx
+++ b/apps/web/app/(shell)/wiki/perspectives/page.tsx
@@ -61,7 +61,7 @@ export default async function PerspectivesIndexPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
-        <Link href="/wiki" className="hover:text-foreground">Wiki</Link>
+        <Link href="/wiki" className="hover:text-foreground">Decision governance</Link>
         <span>/</span>
         <span className="text-foreground font-medium">Decision Perspectives</span>
       </nav>
@@ -71,8 +71,9 @@ export default async function PerspectivesIndexPage() {
           Decision Perspectives
         </h1>
         <p className="text-sm text-[var(--dpf-muted)]">
-          Active perspective profiles for WWMD/WWTD decision narration. Configure
-          a cloned voice for any profile to enable spoken decision rationale.
+          The profiles behind each decision discipline — platform (WWMD), your
+          business (WWWD), and each role&rsquo;s craft (WSID). Manage a profile,
+          or give it a cloned voice to narrate its decision rationale aloud.
         </p>
       </header>
 

--- a/apps/web/components/wiki/DecisionDisciplineHub.tsx
+++ b/apps/web/components/wiki/DecisionDisciplineHub.tsx
@@ -1,0 +1,131 @@
+// EP-0AF96937 Phase 1: the decision-governance landing hub.
+//
+// Reframes the top of the former "Wiki" page from a document-taxonomy list
+// (Principles/Stances/Heuristics/…) into the three decision disciplines a
+// business actually reasons about — WWMD (platform doctrine), WWWD (the
+// organization's own business doctrine), and WSID (each role's craft). The raw
+// kernel material is retained below this hub as a drill-in, not the front door.
+//
+// Presentational + server-friendly: all health is derived by the page and
+// passed in as plain data, so this component does no I/O. Theme-aware per
+// AGENTS.md §12 (no hardcoded colors).
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export type DisciplineKey = "wwmd" | "wwwd" | "wsid";
+
+export type DisciplineChipTone = "neutral" | "warning" | "success";
+
+export type DisciplineChip = {
+  label: string;
+  tone?: DisciplineChipTone;
+};
+
+export type DisciplineAction = {
+  label: string;
+  href: string;
+  /** Accent the action (used for the discipline's primary "Adjust"/owner action). */
+  emphasis?: boolean;
+};
+
+export type DisciplineCardModel = {
+  key: DisciplineKey;
+  /** Short code shown as the card title, e.g. "WWMD". */
+  code: string;
+  /** What the acronym expands to, e.g. "What would Mark do". */
+  expansion: string;
+  /** One-line, plain-language subtitle of what this discipline governs. */
+  blurb: string;
+  /** Derived health chips (counts, coverage, open gaps). */
+  chips: DisciplineChip[];
+  /** See / Adjust / Review action links. */
+  actions: DisciplineAction[];
+  /** Accent this card (WWWD — the discipline the business most owns). */
+  featured?: boolean;
+};
+
+function chipClasses(tone: DisciplineChipTone | undefined): string {
+  switch (tone) {
+    case "warning":
+      return "text-[var(--dpf-warning)] border-[var(--dpf-warning)]";
+    case "success":
+      return "text-[var(--dpf-success)] border-[var(--dpf-success)]";
+    default:
+      return "text-[var(--dpf-muted)] border-[var(--dpf-border)]";
+  }
+}
+
+function DisciplineCard({ card }: { card: DisciplineCardModel }): ReactNode {
+  return (
+    <div
+      className={[
+        "flex flex-col rounded-xl border bg-[var(--dpf-surface-1)] p-4",
+        card.featured
+          ? "border-[var(--dpf-accent)]"
+          : "border-[var(--dpf-border)]",
+      ].join(" ")}
+    >
+      <div className="mb-2 flex items-baseline gap-2">
+        <h3 className="text-base font-semibold text-[var(--dpf-text)]">
+          {card.code}
+        </h3>
+        {card.featured && (
+          <span className="rounded bg-[var(--dpf-accent-soft)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-accent)]">
+            yours to shape
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-[var(--dpf-muted)]">{card.expansion}</p>
+      <p className="mt-2 text-sm text-[var(--dpf-text-secondary)]">
+        {card.blurb}
+      </p>
+
+      {card.chips.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {card.chips.map((chip) => (
+            <span
+              key={chip.label}
+              className={`rounded border px-2 py-0.5 text-xs ${chipClasses(chip.tone)}`}
+            >
+              {chip.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2 pt-1">
+        {card.actions.map((action) => (
+          <Link
+            key={action.label}
+            href={action.href}
+            className={[
+              "rounded-md border px-2.5 py-1 text-xs transition-colors",
+              action.emphasis
+                ? "border-[var(--dpf-accent)] text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent-soft)]"
+                : "border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]",
+            ].join(" ")}
+          >
+            {action.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DecisionDisciplineHub({
+  cards,
+}: {
+  cards: DisciplineCardModel[];
+}): ReactNode {
+  return (
+    <section aria-label="Decision disciplines">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((card) => (
+          <DisciplineCard key={card.key} card={card} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -833,7 +833,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   },
   {
     key: "wiki",
-    label: "Wiki",
+    label: "Decision governance",
     path: "/wiki",
     parentPath: "/wiki",
     domain: "knowledge",
@@ -842,7 +842,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     capabilityKey: null,
     shellNav: {
       sectionKey: "knowledge",
-      description: "Founder kernel and per-org overlay - stances, heuristics, decisions.",
+      description: "How your AI decides on your behalf - WWMD, WWWD, WSID - and where you shape it.",
     },
   },
   {

--- a/apps/web/lib/wiki/decision-governance-hub.test.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+
+import { buildDisciplineCards } from "./decision-governance-hub";
+
+const base = {
+  kernelPrincipleCount: 157,
+  kernelHeuristicCount: 33,
+  orgHasOwnWwwdStance: false,
+  wwmdOpenReviews: 0,
+  wwwdOpenReviews: 0,
+  wsidFamilyCount: 23,
+  wsidActiveProfiles: 1,
+  wsidOpenReviews: 0,
+};
+
+describe("buildDisciplineCards", () => {
+  it("returns the three disciplines in WWMD → WWWD → WSID order", () => {
+    const cards = buildDisciplineCards(base);
+    expect(cards.map((c) => c.key)).toEqual(["wwmd", "wwwd", "wsid"]);
+  });
+
+  it("accents WWWD as the discipline the business owns", () => {
+    const cards = buildDisciplineCards(base);
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    expect(wwwd?.featured).toBe(true);
+    // WWMD and WSID are not accented.
+    expect(cards.find((c) => c.key === "wwmd")?.featured).toBeFalsy();
+    expect(cards.find((c) => c.key === "wsid")?.featured).toBeFalsy();
+  });
+
+  it("surfaces the kernel material counts on the WWMD card", () => {
+    const cards = buildDisciplineCards(base);
+    const wwmd = cards.find((c) => c.key === "wwmd");
+    const labels = wwmd?.chips.map((c) => c.label) ?? [];
+    expect(labels).toContain("157 principles");
+    expect(labels).toContain("33 heuristics");
+  });
+
+  it("warns when the org has no WWWD stance of its own", () => {
+    const cards = buildDisciplineCards({ ...base, orgHasOwnWwwdStance: false });
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    const stanceChip = wwwd?.chips.find((c) => c.label.includes("stance"));
+    expect(stanceChip?.label).toBe("no stance of your own yet");
+    expect(stanceChip?.tone).toBe("warning");
+  });
+
+  it("marks the WWWD stance healthy when the org has authored one", () => {
+    const cards = buildDisciplineCards({ ...base, orgHasOwnWwwdStance: true });
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    const stanceChip = wwwd?.chips.find((c) => c.label.includes("stance"));
+    expect(stanceChip?.label).toBe("your own stance");
+    expect(stanceChip?.tone).toBe("success");
+  });
+
+  it("adds a warning review chip only when there are open reviews, pluralized", () => {
+    const none = buildDisciplineCards(base);
+    expect(
+      none.find((c) => c.key === "wwmd")?.chips.some((c) => c.label.includes("review")),
+    ).toBe(false);
+
+    const some = buildDisciplineCards({
+      ...base,
+      wwmdOpenReviews: 1,
+      wwwdOpenReviews: 4,
+    });
+    const wwmd = some.find((c) => c.key === "wwmd");
+    const wwwd = some.find((c) => c.key === "wwwd");
+    expect(wwmd?.chips.find((c) => c.label.includes("review"))?.label).toBe("1 open review");
+    expect(wwwd?.chips.find((c) => c.label.includes("review"))?.label).toBe("4 open reviews");
+    expect(wwmd?.chips.find((c) => c.label.includes("review"))?.tone).toBe("warning");
+  });
+
+  it("pluralizes the WSID corpus chip and links every card to its review queue", () => {
+    const cards = buildDisciplineCards({ ...base, wsidActiveProfiles: 3 });
+    const wsid = cards.find((c) => c.key === "wsid");
+    expect(wsid?.chips.map((c) => c.label)).toContain("3 corpora active");
+    for (const card of cards) {
+      expect(
+        card.actions.some((a) => a.href.startsWith("/platform/ai/founder-review")),
+      ).toBe(true);
+    }
+  });
+
+  it("gives WWWD a primary emphasized manage-stance action", () => {
+    const cards = buildDisciplineCards(base);
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    const manage = wwwd?.actions.find((a) => a.emphasis);
+    expect(manage?.label).toBe("Manage stance");
+  });
+});

--- a/apps/web/lib/wiki/decision-governance-hub.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.ts
@@ -1,0 +1,111 @@
+// EP-0AF96937 Phase 1: derive the three decision-discipline cards for the
+// decision-governance landing hub from live counts.
+//
+// Pure — takes already-queried numbers and returns presentational card models.
+// The page does the Prisma I/O and passes the counts in, so this is unit
+// testable and does no DB work itself.
+
+import type {
+  DisciplineCardModel,
+} from "@/components/wiki/DecisionDisciplineHub";
+
+/** Live signals the page derives and feeds to the card builder. */
+export type DisciplineHealthInput = {
+  /** Kernel (platform) principle pages — the WWMD material weight. */
+  kernelPrincipleCount: number;
+  /** Kernel heuristic pages. */
+  kernelHeuristicCount: number;
+  /**
+   * True when the organization has authored its own WWWD stance material
+   * (an organization-kind profile with at least one org-scoped material row),
+   * rather than inheriting platform doctrine as advisory-only.
+   */
+  orgHasOwnWwwdStance: boolean;
+  /** Unresolved (defer/escalate) decisions on the platform (WWMD) profile. */
+  wwmdOpenReviews: number;
+  /** Unresolved (defer/escalate) decisions on the organization (WWWD) profile. */
+  wwwdOpenReviews: number;
+  /** Number of WSID profession families the platform covers. */
+  wsidFamilyCount: number;
+  /** Active profession (WSID) profiles seeded. */
+  wsidActiveProfiles: number;
+  /** Unresolved decisions across profession (WSID) profiles. */
+  wsidOpenReviews: number;
+};
+
+function reviewChipLabel(count: number): string {
+  return count === 1 ? "1 open review" : `${count} open reviews`;
+}
+
+/**
+ * Build the WWMD / WWWD / WSID discipline cards. Order is deliberate: platform
+ * doctrine first (the baseline everything inherits from), then the business's
+ * own doctrine (the one it most owns and is accented), then per-role craft.
+ */
+export function buildDisciplineCards(
+  input: DisciplineHealthInput,
+): DisciplineCardModel[] {
+  const wwmd: DisciplineCardModel = {
+    key: "wwmd",
+    code: "WWMD",
+    expansion: "What would Mark do",
+    blurb: "How the platform itself decides how to build.",
+    chips: [
+      { label: `${input.kernelPrincipleCount} principles`, tone: "neutral" },
+      { label: `${input.kernelHeuristicCount} heuristics`, tone: "neutral" },
+      ...(input.wwmdOpenReviews > 0
+        ? [{ label: reviewChipLabel(input.wwmdOpenReviews), tone: "warning" as const }]
+        : []),
+    ],
+    actions: [
+      { label: "Governing material", href: "#governing-material" },
+      { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwmd" },
+    ],
+  };
+
+  const wwwd: DisciplineCardModel = {
+    key: "wwwd",
+    code: "WWWD",
+    expansion: "What would we do",
+    blurb: "How your business decides — priorities, funding, customer calls.",
+    featured: true,
+    chips: [
+      input.orgHasOwnWwwdStance
+        ? { label: "your own stance", tone: "success" }
+        : { label: "no stance of your own yet", tone: "warning" },
+      ...(input.wwwdOpenReviews > 0
+        ? [{ label: reviewChipLabel(input.wwwdOpenReviews), tone: "warning" as const }]
+        : []),
+    ],
+    actions: [
+      { label: "Manage stance", href: "/wiki/perspectives", emphasis: true },
+      { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwwd" },
+    ],
+  };
+
+  const wsid: DisciplineCardModel = {
+    key: "wsid",
+    code: "WSID",
+    expansion: "What should I do",
+    blurb: "What a competent professional in each role should do.",
+    chips: [
+      { label: `${input.wsidFamilyCount} role families`, tone: "neutral" },
+      {
+        label:
+          input.wsidActiveProfiles === 1
+            ? "1 corpus active"
+            : `${input.wsidActiveProfiles} corpora active`,
+        tone: "neutral",
+      },
+      ...(input.wsidOpenReviews > 0
+        ? [{ label: reviewChipLabel(input.wsidOpenReviews), tone: "warning" as const }]
+        : []),
+    ],
+    actions: [
+      { label: "Role corpora", href: "/wiki/perspectives" },
+      { label: "Review decisions", href: "/platform/ai/founder-review" },
+    ],
+  };
+
+  return [wwmd, wwwd, wsid];
+}

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -206,9 +206,12 @@ Tracked under EP-WWMD, EP-VOICE-LAYER, and EP-WSID:
 
 ## Related Routes
 
+- `/wiki` — **Decision governance** landing. Reframed (EP-0AF96937 Phase 1) around the three decision disciplines — WWMD (platform), WWWD (your business), WSID (each role's craft) — each card showing derived health (material counts, whether the org has its own stance, open review counts) and See / Manage / Review actions. The raw kernel material (principles, stances, heuristics) is retained below the hub as a "Governing material" drill-in rather than the front door. See `docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md`.
+- `/wiki/perspectives` — manage the profiles behind each discipline; give any perspective a voice
 - Build Studio → **Decision Perspective Gate Panel** — primary surface for the gate
 - `/wiki/personas/[id]` — profile detail
 - `/wiki/personas/[id]/voice` — voice training and consent
+- `/platform/ai/founder-review` — the owner/founder review queue for `defer`/`escalate` outcomes (`?mode=wwmd` / `?mode=wwwd`)
 - `/platform/ai/operations` — Operations Map with decision-pressure overlays
 - MCP — the `decisionPerspective.invoke` tool exposes the gate to external clients under the same grant model
 


### PR DESCRIPTION
## What

**Phase 1** of EP-0AF96937 — turns the top-level `/wiki` surface from a document repository into a business-legible **Decision governance** landing organized around the three decision disciplines: **WWMD** (platform), **WWWD** (your business), **WSID** (each role's craft).

- New `DecisionDisciplineHub` renders three cards; a pure `buildDisciplineCards` builder maps live counts → card health (unit-tested).
- The landing derives real health: kernel principle/heuristic counts (WWMD), whether the org has its own WWWD stance material, open `defer`/`escalate` review counts per discipline, WSID family + active-corpus counts.
- Actions link the **existing** surfaces (perspectives index, `/platform/ai/founder-review?mode=…`) — no dead ends.
- The raw kernel material (principles/stances/heuristics browser) is **retained** below the hub as a `#governing-material` drill-in, not deleted.
- Nav entry renamed **"Wiki" → "Decision governance"**; perspectives index intro reframed away from voice-only.

Screenshot equivalent: the operator mockup shared in the design session.

## Why

The platform's most important capability was surfaced as a "Wiki" organized by librarian taxonomy, with the decision disciplines invisible. This is the highest-signal, lowest-risk slice of the [design spec](docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md) (merged in #2573): reframe the front door, keep everything working.

## Gates (root clone / source-local)

- `tsc --noEmit` clean
- `vitest` — 17 passing (8 new hub-builder tests + nav model)
- `pnpm --filter web build` — exit 0

Live UX walk-through is deferred to the operator's review — the live portal only reflects this after a self-upgrade deploy.

## Governance

- **UX-Fit-Decision**: `principle_decide` recommends the three-discipline hub over the flat list on `human_cognitive_load` — composite 5.80, margin 3.60, high confidence, no commandment conflict. Progressive disclosure (3 cards up front, 157-principle matrix one level down).
- **Process-Spine**: implements the filed EP-0AF96937 spec; user guide updated in this PR.

Scoped, additive, reversible. Phases 2–5 (review workspace, WWWD/WSID editors, `/wiki` alias) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)