### PR TITLE
feat(decision-gov): decision governance hub + review/adjust workspace (EP-0AF96937 Phases 1-2)

### DIFF
--- a/apps/web/app/(shell)/wiki/page.tsx
+++ b/apps/web/app/(shell)/wiki/page.tsx
@@ -1,22 +1,35 @@
-// EP-WIKI-001 Phase 6a: global wiki browse page.
-// Shows kernel pages + the platform organization's overlay rows.
+// EP-0AF96937 Phase 1: decision-governance landing.
+// Reframes the former document-taxonomy "Wiki" landing around the three
+// decision disciplines a business reasons about — WWMD (platform), WWWD
+// (business), WSID (craft) — with derived health and See/Adjust/Review actions.
+// The raw kernel material (principles/stances/heuristics/…) is retained below
+// as a drill-in, not the front door.
 // Server component; queries Prisma directly.
 
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 
 import { WikiPageList, type WikiPageListItem } from "@/components/wiki/WikiPageList";
+import { DecisionDisciplineHub } from "@/components/wiki/DecisionDisciplineHub";
+import { buildDisciplineCards } from "@/lib/wiki/decision-governance-hub";
+import {
+  WWMD_PLATFORM_PROFILE_ID,
+  WWWD_ORGANIZATION_PROFILE_ID,
+} from "@/lib/decision/caller-context";
+import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "Wiki",
+  title: "Decision governance",
 };
 
 type SearchParams = Promise<{
   kind?: string;
   status?: string;
 }>;
+
+const UNRESOLVED = ["defer", "escalate"];
 
 export default async function WikiBrowsePage({
   searchParams,
@@ -46,57 +59,121 @@ export default async function WikiBrowsePage({
     where.pageKind = sp.kind;
   }
 
-  const pages = (await prisma.wikiPage.findMany({
-    where,
-    select: {
-      id: true,
-      slug: true,
-      title: true,
-      pageKind: true,
-      status: true,
-      isKernel: true,
-      abstract: true,
-      principleTier: true,
-      principleConsumerArchetype: true,
-      principleConsumerContexts: true,
-    },
-    orderBy: [
-      { pageKind: "asc" },
-      { principleConsumerArchetype: "asc" },
-      { principleTier: "asc" },
-      { title: "asc" },
-    ],
-  })) as WikiPageListItem[];
+  // Derive discipline health + fetch the retained material list in parallel.
+  const [
+    pages,
+    kernelPrincipleCount,
+    kernelHeuristicCount,
+    orgStanceMaterialCount,
+    wwmdOpenReviews,
+    wwwdOpenReviews,
+    wsidActiveProfiles,
+    wsidOpenReviews,
+  ] = await Promise.all([
+    prisma.wikiPage.findMany({
+      where,
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        pageKind: true,
+        status: true,
+        isKernel: true,
+        abstract: true,
+        principleTier: true,
+        principleConsumerArchetype: true,
+        principleConsumerContexts: true,
+      },
+      orderBy: [
+        { pageKind: "asc" },
+        { principleConsumerArchetype: "asc" },
+        { principleTier: "asc" },
+        { title: "asc" },
+      ],
+    }) as Promise<WikiPageListItem[]>,
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "principle", status: "published" },
+    }),
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "heuristic", status: "published" },
+    }),
+    // The org has "its own stance" when the WWWD organization profile carries
+    // its own material rows. In a single-tenant install where WWWD has not yet
+    // been seeded with distinct material this is 0 → "no stance of your own yet".
+    prisma.perspectiveMaterial.count({
+      where: { profileId: WWWD_ORGANIZATION_PROFILE_ID },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: UNRESOLVED }, profileId: WWMD_PLATFORM_PROFILE_ID },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: UNRESOLVED }, profileId: WWWD_ORGANIZATION_PROFILE_ID },
+    }),
+    prisma.decisionPerspectiveProfile.count({
+      where: { kind: "profession", status: "active" },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: UNRESOLVED }, profileId: { startsWith: "wsid-" } },
+    }),
+  ]);
+
+  const disciplineCards = buildDisciplineCards({
+    kernelPrincipleCount,
+    kernelHeuristicCount,
+    orgHasOwnWwwdStance: orgStanceMaterialCount > 0,
+    wwmdOpenReviews,
+    wwwdOpenReviews,
+    wsidFamilyCount: PROFESSION_REGISTRY.families.length,
+    wsidActiveProfiles,
+    wsidOpenReviews,
+  });
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <header className="mb-6">
         <h1 className="text-2xl font-semibold text-[var(--dpf-text)] mb-1">
-          Wiki
+          Decision governance
         </h1>
         <p className="text-sm text-[var(--dpf-muted)]">
-          Founder kernel and per-org overlay. Kernel pages ship with the platform;
-          overlay pages live alongside.
+          How your AI workforce decides on your behalf — and where you shape it.
+          Three disciplines govern every call: platform doctrine (WWMD), your
+          business (WWWD), and each role&rsquo;s craft (WSID).
         </p>
       </header>
 
-      <WikiPageList pages={pages} />
+      <DecisionDisciplineHub cards={disciplineCards} />
 
-      {/* Decision Perspectives — voice admin entry point */}
-      <div className="mt-8 rounded-lg border border-border p-4 flex items-center justify-between">
+      {/* Decision Perspectives — profile + voice admin entry point */}
+      <div className="mt-6 rounded-lg border border-[var(--dpf-border)] p-4 flex items-center justify-between">
         <div>
-          <p className="font-medium text-sm">Decision Perspectives</p>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Configure voice narration for WWMD / WWTD persona profiles
+          <p className="font-medium text-sm text-[var(--dpf-text)]">
+            Decision perspectives
+          </p>
+          <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
+            Manage the profiles behind each discipline, and give any perspective
+            a voice.
           </p>
         </div>
         <Link
           href="/wiki/perspectives"
-          className="text-sm text-primary hover:underline shrink-0 ml-4"
+          className="text-sm text-[var(--dpf-accent)] hover:underline shrink-0 ml-4"
         >
           Manage →
         </Link>
       </div>
+
+      {/* Retained kernel material — the drill-in, one level below the hub. */}
+      <section id="governing-material" className="mt-10 scroll-mt-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-3">
+          Governing material
+        </h2>
+        <p className="text-xs text-[var(--dpf-muted)] mb-4">
+          The founder kernel and per-org overlay pages that the disciplines above
+          are built from. Kernel pages ship with the platform; overlay pages live
+          alongside.
+        </p>
+        <WikiPageList pages={pages} />
+      </section>
     </div>
   );
 }

--- a/apps/web/app/(shell)/wiki/page.tsx
+++ b/apps/web/app/(shell)/wiki/page.tsx
@@ -143,8 +143,27 @@ export default async function WikiBrowsePage({
 
       <DecisionDisciplineHub cards={disciplineCards} />
 
+      {/* Review & adjust — the findings workspace over the decision ledger */}
+      <Link
+        href="/wiki/review"
+        className="mt-6 block rounded-lg border border-[var(--dpf-border)] p-4 hover:bg-[var(--dpf-surface-2)] transition-colors"
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="font-medium text-sm text-[var(--dpf-text)]">
+              Review &amp; adjust
+            </p>
+            <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
+              As decisions accumulate, resolve clashing principles and cover the
+              gaps where your AI has no settled answer yet.
+            </p>
+          </div>
+          <span className="text-sm text-[var(--dpf-accent)] shrink-0 ml-4">Open →</span>
+        </div>
+      </Link>
+
       {/* Decision Perspectives — profile + voice admin entry point */}
-      <div className="mt-6 rounded-lg border border-[var(--dpf-border)] p-4 flex items-center justify-between">
+      <div className="mt-3 rounded-lg border border-[var(--dpf-border)] p-4 flex items-center justify-between">
         <div>
           <p className="font-medium text-sm text-[var(--dpf-text)]">
             Decision perspectives

--- a/apps/web/app/(shell)/wiki/perspectives/page.tsx
+++ b/apps/web/app/(shell)/wiki/perspectives/page.tsx
@@ -61,7 +61,7 @@ export default async function PerspectivesIndexPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
-        <Link href="/wiki" className="hover:text-foreground">Wiki</Link>
+        <Link href="/wiki" className="hover:text-foreground">Decision governance</Link>
         <span>/</span>
         <span className="text-foreground font-medium">Decision Perspectives</span>
       </nav>
@@ -71,8 +71,9 @@ export default async function PerspectivesIndexPage() {
           Decision Perspectives
         </h1>
         <p className="text-sm text-[var(--dpf-muted)]">
-          Active perspective profiles for WWMD/WWTD decision narration. Configure
-          a cloned voice for any profile to enable spoken decision rationale.
+          The profiles behind each decision discipline — platform (WWMD), your
+          business (WWWD), and each role&rsquo;s craft (WSID). Manage a profile,
+          or give it a cloned voice to narrate its decision rationale aloud.
         </p>
       </header>
 

--- a/apps/web/app/(shell)/wiki/review/page.tsx
+++ b/apps/web/app/(shell)/wiki/review/page.tsx
@@ -1,0 +1,155 @@
+// EP-0AF96937 Phase 2: Decision Review & Adjust workspace.
+// A findings surface over the accumulating decision ledger (not a log
+// firehose): conflicts the gate flagged, and clusters of unresolved decisions
+// where the doctrine has no settled answer yet. Each finding carries a
+// plain-language action. Server component; queries Prisma directly.
+
+import Link from "next/link";
+import { prisma } from "@dpf/db";
+
+import {
+  buildReviewFindings,
+  type ConflictRow,
+  type GapCluster,
+  type ReviewFinding,
+} from "@/lib/wiki/decision-review-findings";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Decision review",
+};
+
+const UNRESOLVED = ["defer", "escalate"];
+
+const CLASS_LABEL: Record<ReviewFinding["findingClass"], string> = {
+  conflict: "conflict",
+  gap: "gap",
+};
+
+// Semantic accent per finding class, via theme tokens (no hardcoded colors).
+const CLASS_ACCENT: Record<ReviewFinding["findingClass"], string> = {
+  conflict: "var(--dpf-error)",
+  gap: "var(--dpf-accent)",
+};
+
+function toGapClusters(
+  rows: { domainClass: string; question: string }[],
+): GapCluster[] {
+  const byDomain = new Map<string, { count: number; sampleQuestion: string }>();
+  for (const row of rows) {
+    const existing = byDomain.get(row.domainClass);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      byDomain.set(row.domainClass, { count: 1, sampleQuestion: row.question });
+    }
+  }
+  return [...byDomain.entries()].map(([domainClass, v]) => ({
+    domainClass,
+    count: v.count,
+    sampleQuestion: v.sampleQuestion,
+  }));
+}
+
+export default async function DecisionReviewPage() {
+  const [conflictRows, unresolvedRows] = await Promise.all([
+    prisma.decisionInteraction.findMany({
+      where: { principleConflict: true },
+      orderBy: { createdAt: "desc" },
+      take: 25,
+      select: {
+        interactionId: true,
+        question: true,
+        riskTier: true,
+        createdAt: true,
+      },
+    }),
+    prisma.decisionInteraction.findMany({
+      where: { outcomeType: { in: UNRESOLVED } },
+      orderBy: { createdAt: "desc" },
+      take: 200,
+      select: { domainClass: true, question: true },
+    }),
+  ]);
+
+  const findings = buildReviewFindings({
+    conflicts: conflictRows as ConflictRow[],
+    gapClusters: toGapClusters(unresolvedRows),
+  });
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4">
+      <nav className="mb-6 flex items-center gap-2 text-sm text-[var(--dpf-muted)]">
+        <Link href="/wiki" className="hover:text-[var(--dpf-text)]">
+          Decision governance
+        </Link>
+        <span>/</span>
+        <span className="text-[var(--dpf-text)] font-medium">Review &amp; adjust</span>
+      </nav>
+
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-[var(--dpf-text)] mb-1">
+          Review &amp; adjust
+        </h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          As your AI makes decisions, this is where you keep the governance sharp
+          — resolve clashing principles and cover the gaps where it has no
+          settled answer yet.
+        </p>
+      </header>
+
+      {findings.length === 0 ? (
+        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-8 text-center">
+          <p className="text-sm text-[var(--dpf-text)]">Nothing to review right now.</p>
+          <p className="text-xs text-[var(--dpf-muted)] mt-1">
+            No conflicting principles and no clusters of unresolved decisions.
+            Findings appear here as decisions accumulate.
+          </p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {findings.map((f) => (
+            <li
+              key={f.id}
+              className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+              style={{ borderLeftWidth: "3px", borderLeftColor: CLASS_ACCENT[f.findingClass] }}
+            >
+              <div className="flex items-center gap-3 flex-wrap">
+                <span
+                  className="rounded px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+                  style={{ color: CLASS_ACCENT[f.findingClass], border: `1px solid ${CLASS_ACCENT[f.findingClass]}` }}
+                >
+                  {CLASS_LABEL[f.findingClass]}
+                </span>
+                <span className="text-sm font-medium text-[var(--dpf-text)] min-w-0 flex-1">
+                  {f.title}
+                </span>
+                {f.postureLabel && (
+                  <span className="text-xs text-[var(--dpf-muted)] shrink-0">
+                    {f.postureLabel}
+                  </span>
+                )}
+                <Link
+                  href={f.actionHref}
+                  className="rounded-md border border-[var(--dpf-border)] px-2.5 py-1 text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] shrink-0"
+                >
+                  {f.actionLabel} →
+                </Link>
+              </div>
+              {f.detail && (
+                <p className="text-xs text-[var(--dpf-muted)] mt-1.5 ml-1">{f.detail}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="text-xs text-[var(--dpf-muted)] mt-8">
+        Coming next: golden-decision drift alerts, stale-material review, and the
+        principle-dimension matrix — see the{" "}
+        <span className="font-mono">decision-governance</span> design.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/wiki/DecisionDisciplineHub.tsx
+++ b/apps/web/components/wiki/DecisionDisciplineHub.tsx
@@ -1,0 +1,131 @@
+// EP-0AF96937 Phase 1: the decision-governance landing hub.
+//
+// Reframes the top of the former "Wiki" page from a document-taxonomy list
+// (Principles/Stances/Heuristics/…) into the three decision disciplines a
+// business actually reasons about — WWMD (platform doctrine), WWWD (the
+// organization's own business doctrine), and WSID (each role's craft). The raw
+// kernel material is retained below this hub as a drill-in, not the front door.
+//
+// Presentational + server-friendly: all health is derived by the page and
+// passed in as plain data, so this component does no I/O. Theme-aware per
+// AGENTS.md §12 (no hardcoded colors).
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export type DisciplineKey = "wwmd" | "wwwd" | "wsid";
+
+export type DisciplineChipTone = "neutral" | "warning" | "success";
+
+export type DisciplineChip = {
+  label: string;
+  tone?: DisciplineChipTone;
+};
+
+export type DisciplineAction = {
+  label: string;
+  href: string;
+  /** Accent the action (used for the discipline's primary "Adjust"/owner action). */
+  emphasis?: boolean;
+};
+
+export type DisciplineCardModel = {
+  key: DisciplineKey;
+  /** Short code shown as the card title, e.g. "WWMD". */
+  code: string;
+  /** What the acronym expands to, e.g. "What would Mark do". */
+  expansion: string;
+  /** One-line, plain-language subtitle of what this discipline governs. */
+  blurb: string;
+  /** Derived health chips (counts, coverage, open gaps). */
+  chips: DisciplineChip[];
+  /** See / Adjust / Review action links. */
+  actions: DisciplineAction[];
+  /** Accent this card (WWWD — the discipline the business most owns). */
+  featured?: boolean;
+};
+
+function chipClasses(tone: DisciplineChipTone | undefined): string {
+  switch (tone) {
+    case "warning":
+      return "text-[var(--dpf-warning)] border-[var(--dpf-warning)]";
+    case "success":
+      return "text-[var(--dpf-success)] border-[var(--dpf-success)]";
+    default:
+      return "text-[var(--dpf-muted)] border-[var(--dpf-border)]";
+  }
+}
+
+function DisciplineCard({ card }: { card: DisciplineCardModel }): ReactNode {
+  return (
+    <div
+      className={[
+        "flex flex-col rounded-xl border bg-[var(--dpf-surface-1)] p-4",
+        card.featured
+          ? "border-[var(--dpf-accent)]"
+          : "border-[var(--dpf-border)]",
+      ].join(" ")}
+    >
+      <div className="mb-2 flex items-baseline gap-2">
+        <h3 className="text-base font-semibold text-[var(--dpf-text)]">
+          {card.code}
+        </h3>
+        {card.featured && (
+          <span className="rounded bg-[var(--dpf-accent-soft)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-accent)]">
+            yours to shape
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-[var(--dpf-muted)]">{card.expansion}</p>
+      <p className="mt-2 text-sm text-[var(--dpf-text-secondary)]">
+        {card.blurb}
+      </p>
+
+      {card.chips.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {card.chips.map((chip) => (
+            <span
+              key={chip.label}
+              className={`rounded border px-2 py-0.5 text-xs ${chipClasses(chip.tone)}`}
+            >
+              {chip.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2 pt-1">
+        {card.actions.map((action) => (
+          <Link
+            key={action.label}
+            href={action.href}
+            className={[
+              "rounded-md border px-2.5 py-1 text-xs transition-colors",
+              action.emphasis
+                ? "border-[var(--dpf-accent)] text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent-soft)]"
+                : "border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]",
+            ].join(" ")}
+          >
+            {action.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DecisionDisciplineHub({
+  cards,
+}: {
+  cards: DisciplineCardModel[];
+}): ReactNode {
+  return (
+    <section aria-label="Decision disciplines">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((card) => (
+          <DisciplineCard key={card.key} card={card} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 530,
+  "routeCount": 531,
   "routes": [
     {
       "routePath": "/",
@@ -6125,6 +6125,16 @@
         "profileId"
       ],
       "file": "apps/web/app/(shell)/wiki/perspectives/[profileId]/voice/page.tsx"
+    },
+    {
+      "routePath": "/wiki/review",
+      "kind": "page",
+      "segments": [
+        "wiki",
+        "review"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/wiki/review/page.tsx"
     },
     {
       "routePath": "/workbooks",

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -833,7 +833,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   },
   {
     key: "wiki",
-    label: "Wiki",
+    label: "Decision governance",
     path: "/wiki",
     parentPath: "/wiki",
     domain: "knowledge",
@@ -842,7 +842,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     capabilityKey: null,
     shellNav: {
       sectionKey: "knowledge",
-      description: "Founder kernel and per-org overlay - stances, heuristics, decisions.",
+      description: "How your AI decides on your behalf - WWMD, WWWD, WSID - and where you shape it.",
     },
   },
   {

--- a/apps/web/lib/wiki/decision-governance-hub.test.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+
+import { buildDisciplineCards } from "./decision-governance-hub";
+
+const base = {
+  kernelPrincipleCount: 157,
+  kernelHeuristicCount: 33,
+  orgHasOwnWwwdStance: false,
+  wwmdOpenReviews: 0,
+  wwwdOpenReviews: 0,
+  wsidFamilyCount: 23,
+  wsidActiveProfiles: 1,
+  wsidOpenReviews: 0,
+};
+
+describe("buildDisciplineCards", () => {
+  it("returns the three disciplines in WWMD → WWWD → WSID order", () => {
+    const cards = buildDisciplineCards(base);
+    expect(cards.map((c) => c.key)).toEqual(["wwmd", "wwwd", "wsid"]);
+  });
+
+  it("accents WWWD as the discipline the business owns", () => {
+    const cards = buildDisciplineCards(base);
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    expect(wwwd?.featured).toBe(true);
+    // WWMD and WSID are not accented.
+    expect(cards.find((c) => c.key === "wwmd")?.featured).toBeFalsy();
+    expect(cards.find((c) => c.key === "wsid")?.featured).toBeFalsy();
+  });
+
+  it("surfaces the kernel material counts on the WWMD card", () => {
+    const cards = buildDisciplineCards(base);
+    const wwmd = cards.find((c) => c.key === "wwmd");
+    const labels = wwmd?.chips.map((c) => c.label) ?? [];
+    expect(labels).toContain("157 principles");
+    expect(labels).toContain("33 heuristics");
+  });
+
+  it("warns when the org has no WWWD stance of its own", () => {
+    const cards = buildDisciplineCards({ ...base, orgHasOwnWwwdStance: false });
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    const stanceChip = wwwd?.chips.find((c) => c.label.includes("stance"));
+    expect(stanceChip?.label).toBe("no stance of your own yet");
+    expect(stanceChip?.tone).toBe("warning");
+  });
+
+  it("marks the WWWD stance healthy when the org has authored one", () => {
+    const cards = buildDisciplineCards({ ...base, orgHasOwnWwwdStance: true });
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    const stanceChip = wwwd?.chips.find((c) => c.label.includes("stance"));
+    expect(stanceChip?.label).toBe("your own stance");
+    expect(stanceChip?.tone).toBe("success");
+  });
+
+  it("adds a warning review chip only when there are open reviews, pluralized", () => {
+    const none = buildDisciplineCards(base);
+    expect(
+      none.find((c) => c.key === "wwmd")?.chips.some((c) => c.label.includes("review")),
+    ).toBe(false);
+
+    const some = buildDisciplineCards({
+      ...base,
+      wwmdOpenReviews: 1,
+      wwwdOpenReviews: 4,
+    });
+    const wwmd = some.find((c) => c.key === "wwmd");
+    const wwwd = some.find((c) => c.key === "wwwd");
+    expect(wwmd?.chips.find((c) => c.label.includes("review"))?.label).toBe("1 open review");
+    expect(wwwd?.chips.find((c) => c.label.includes("review"))?.label).toBe("4 open reviews");
+    expect(wwmd?.chips.find((c) => c.label.includes("review"))?.tone).toBe("warning");
+  });
+
+  it("pluralizes the WSID corpus chip and links every card to its review queue", () => {
+    const cards = buildDisciplineCards({ ...base, wsidActiveProfiles: 3 });
+    const wsid = cards.find((c) => c.key === "wsid");
+    expect(wsid?.chips.map((c) => c.label)).toContain("3 corpora active");
+    for (const card of cards) {
+      expect(
+        card.actions.some((a) => a.href.startsWith("/platform/ai/founder-review")),
+      ).toBe(true);
+    }
+  });
+
+  it("gives WWWD a primary emphasized manage-stance action", () => {
+    const cards = buildDisciplineCards(base);
+    const wwwd = cards.find((c) => c.key === "wwwd");
+    const manage = wwwd?.actions.find((a) => a.emphasis);
+    expect(manage?.label).toBe("Manage stance");
+  });
+});

--- a/apps/web/lib/wiki/decision-governance-hub.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.ts
@@ -1,0 +1,111 @@
+// EP-0AF96937 Phase 1: derive the three decision-discipline cards for the
+// decision-governance landing hub from live counts.
+//
+// Pure — takes already-queried numbers and returns presentational card models.
+// The page does the Prisma I/O and passes the counts in, so this is unit
+// testable and does no DB work itself.
+
+import type {
+  DisciplineCardModel,
+} from "@/components/wiki/DecisionDisciplineHub";
+
+/** Live signals the page derives and feeds to the card builder. */
+export type DisciplineHealthInput = {
+  /** Kernel (platform) principle pages — the WWMD material weight. */
+  kernelPrincipleCount: number;
+  /** Kernel heuristic pages. */
+  kernelHeuristicCount: number;
+  /**
+   * True when the organization has authored its own WWWD stance material
+   * (an organization-kind profile with at least one org-scoped material row),
+   * rather than inheriting platform doctrine as advisory-only.
+   */
+  orgHasOwnWwwdStance: boolean;
+  /** Unresolved (defer/escalate) decisions on the platform (WWMD) profile. */
+  wwmdOpenReviews: number;
+  /** Unresolved (defer/escalate) decisions on the organization (WWWD) profile. */
+  wwwdOpenReviews: number;
+  /** Number of WSID profession families the platform covers. */
+  wsidFamilyCount: number;
+  /** Active profession (WSID) profiles seeded. */
+  wsidActiveProfiles: number;
+  /** Unresolved decisions across profession (WSID) profiles. */
+  wsidOpenReviews: number;
+};
+
+function reviewChipLabel(count: number): string {
+  return count === 1 ? "1 open review" : `${count} open reviews`;
+}
+
+/**
+ * Build the WWMD / WWWD / WSID discipline cards. Order is deliberate: platform
+ * doctrine first (the baseline everything inherits from), then the business's
+ * own doctrine (the one it most owns and is accented), then per-role craft.
+ */
+export function buildDisciplineCards(
+  input: DisciplineHealthInput,
+): DisciplineCardModel[] {
+  const wwmd: DisciplineCardModel = {
+    key: "wwmd",
+    code: "WWMD",
+    expansion: "What would Mark do",
+    blurb: "How the platform itself decides how to build.",
+    chips: [
+      { label: `${input.kernelPrincipleCount} principles`, tone: "neutral" },
+      { label: `${input.kernelHeuristicCount} heuristics`, tone: "neutral" },
+      ...(input.wwmdOpenReviews > 0
+        ? [{ label: reviewChipLabel(input.wwmdOpenReviews), tone: "warning" as const }]
+        : []),
+    ],
+    actions: [
+      { label: "Governing material", href: "#governing-material" },
+      { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwmd" },
+    ],
+  };
+
+  const wwwd: DisciplineCardModel = {
+    key: "wwwd",
+    code: "WWWD",
+    expansion: "What would we do",
+    blurb: "How your business decides — priorities, funding, customer calls.",
+    featured: true,
+    chips: [
+      input.orgHasOwnWwwdStance
+        ? { label: "your own stance", tone: "success" }
+        : { label: "no stance of your own yet", tone: "warning" },
+      ...(input.wwwdOpenReviews > 0
+        ? [{ label: reviewChipLabel(input.wwwdOpenReviews), tone: "warning" as const }]
+        : []),
+    ],
+    actions: [
+      { label: "Manage stance", href: "/wiki/perspectives", emphasis: true },
+      { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwwd" },
+    ],
+  };
+
+  const wsid: DisciplineCardModel = {
+    key: "wsid",
+    code: "WSID",
+    expansion: "What should I do",
+    blurb: "What a competent professional in each role should do.",
+    chips: [
+      { label: `${input.wsidFamilyCount} role families`, tone: "neutral" },
+      {
+        label:
+          input.wsidActiveProfiles === 1
+            ? "1 corpus active"
+            : `${input.wsidActiveProfiles} corpora active`,
+        tone: "neutral",
+      },
+      ...(input.wsidOpenReviews > 0
+        ? [{ label: reviewChipLabel(input.wsidOpenReviews), tone: "warning" as const }]
+        : []),
+    ],
+    actions: [
+      { label: "Role corpora", href: "/wiki/perspectives" },
+      { label: "Review decisions", href: "/platform/ai/founder-review" },
+    ],
+  };
+
+  return [wwmd, wwwd, wsid];
+}

--- a/apps/web/lib/wiki/decision-review-findings.test.ts
+++ b/apps/web/lib/wiki/decision-review-findings.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildReviewFindings,
+  buildConflictFindings,
+  buildGapFindings,
+  type ConflictRow,
+  type GapCluster,
+} from "./decision-review-findings";
+
+const conflict: ConflictRow = {
+  interactionId: "DI-ABC123",
+  question: "Should refunds over $500 need a manager sign-off?",
+  riskTier: "high",
+  createdAt: new Date("2026-07-01T00:00:00Z"),
+};
+
+const gap: GapCluster = {
+  domainClass: "vendor-selection",
+  count: 9,
+  sampleQuestion: "Which observability vendor should we standardize on?",
+};
+
+describe("buildConflictFindings", () => {
+  it("maps each conflicted decision to a canvas-linked finding with risk posture", () => {
+    const [f] = buildConflictFindings([conflict]);
+    expect(f.findingClass).toBe("conflict");
+    expect(f.postureLabel).toBe("risk: high");
+    expect(f.href).toBe("/platform/ai/decisions/DI-ABC123");
+    expect(f.actionLabel).toBe("De-conflict");
+    expect(f.count).toBe(1);
+  });
+
+  it("omits posture when the risk tier is unknown", () => {
+    const [f] = buildConflictFindings([{ ...conflict, riskTier: null }]);
+    expect(f.postureLabel).toBeNull();
+  });
+});
+
+describe("buildGapFindings", () => {
+  it("humanizes the domain and pluralizes the unresolved count", () => {
+    const [f] = buildGapFindings([gap]);
+    expect(f.title).toBe("No settled answer for vendor selection");
+    expect(f.postureLabel).toBe("9 unresolved");
+    expect(f.actionLabel).toBe("Add a stance");
+    expect(f.actionHref).toBe("/wiki/perspectives");
+  });
+
+  it("drops empty clusters and singularizes a lone unresolved", () => {
+    const findings = buildGapFindings([
+      { ...gap, count: 0 },
+      { domainClass: "pricing", count: 1, sampleQuestion: "q" },
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].postureLabel).toBe("1 unresolved");
+  });
+});
+
+describe("buildReviewFindings", () => {
+  it("orders conflicts first, then gaps by descending cluster size", () => {
+    const findings = buildReviewFindings({
+      conflicts: [conflict],
+      gapClusters: [
+        { domainClass: "small", count: 2, sampleQuestion: "q" },
+        gap, // count 9
+      ],
+    });
+    expect(findings.map((f) => f.findingClass)).toEqual(["conflict", "gap", "gap"]);
+    // biggest gap cluster (9) before the smaller (2)
+    expect(findings[1].id).toBe("gap:vendor-selection");
+    expect(findings[2].id).toBe("gap:small");
+  });
+
+  it("truncates a very long question into the detail line", () => {
+    const long = "x".repeat(200);
+    const [f] = buildReviewFindings({
+      conflicts: [{ ...conflict, question: long }],
+      gapClusters: [],
+    });
+    expect(f.detail.length).toBeLessThanOrEqual(120);
+    expect(f.detail.endsWith("…")).toBe(true);
+  });
+});

--- a/apps/web/lib/wiki/decision-review-findings.ts
+++ b/apps/web/lib/wiki/decision-review-findings.ts
@@ -1,0 +1,113 @@
+// EP-0AF96937 Phase 2: derive Decision Review findings from the accumulating
+// decision ledger.
+//
+// A findings surface, not a log firehose (spec §4.3). This module is pure —
+// the page queries the `DecisionInteraction` ledger and passes already-shaped
+// rows/clusters in, so the builders are unit testable and do no DB work.
+//
+// v1 surfaces the two finding classes that are directly computable from
+// recorded fields today:
+//   - conflict — a decision the gate flagged as `principleConflict` (two
+//     principles/materials pulling opposite ways)
+//   - gap — a cluster of `defer`/`escalate` outcomes in one decision domain,
+//     i.e. the doctrine has no settled answer there yet
+// Drift (golden-decision flips) and staleness (stale-but-cited material) are
+// tracked as later sub-slices; see the spec.
+
+export type FindingClass = "conflict" | "gap";
+
+export type ReviewFinding = {
+  id: string;
+  findingClass: FindingClass;
+  title: string;
+  detail: string;
+  /** Plain-language posture/risk context for the decision(s), when known. */
+  postureLabel: string | null;
+  /** How many decisions this finding rolls up (gap clusters); 1 for a single conflict. */
+  count: number;
+  /** Deep-link to the Decision Canvas for a single decision, when applicable. */
+  href: string | null;
+  /** The plain-language action this finding invites. */
+  actionLabel: string;
+  /** Where the action goes (e.g. the review queue, the stance editor). */
+  actionHref: string;
+};
+
+/** A single gate decision the ledger flagged as a principle conflict. */
+export type ConflictRow = {
+  interactionId: string;
+  question: string;
+  riskTier: string | null;
+  createdAt: Date;
+};
+
+/** A rolled-up cluster of unresolved (defer/escalate) decisions in one domain. */
+export type GapCluster = {
+  domainClass: string;
+  count: number;
+  /** A representative question from the cluster, for human context. */
+  sampleQuestion: string;
+};
+
+function riskPosture(riskTier: string | null): string | null {
+  if (!riskTier) return null;
+  return `risk: ${riskTier}`;
+}
+
+function truncate(text: string, max = 120): string {
+  const t = text.trim();
+  return t.length > max ? `${t.slice(0, max - 1).trimEnd()}…` : t;
+}
+
+function humanDomain(domainClass: string): string {
+  return domainClass
+    .split("-")
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function buildConflictFindings(rows: ConflictRow[]): ReviewFinding[] {
+  return rows.map((row) => ({
+    id: `conflict:${row.interactionId}`,
+    findingClass: "conflict",
+    title: "Two principles pull opposite ways",
+    detail: truncate(row.question),
+    postureLabel: riskPosture(row.riskTier),
+    count: 1,
+    href: `/platform/ai/decisions/${encodeURIComponent(row.interactionId)}`,
+    actionLabel: "De-conflict",
+    actionHref: `/platform/ai/decisions/${encodeURIComponent(row.interactionId)}`,
+  }));
+}
+
+export function buildGapFindings(clusters: GapCluster[]): ReviewFinding[] {
+  return clusters
+    .filter((c) => c.count > 0)
+    .map((cluster) => ({
+      id: `gap:${cluster.domainClass}`,
+      findingClass: "gap",
+      title: `No settled answer for ${humanDomain(cluster.domainClass)}`,
+      detail: truncate(cluster.sampleQuestion),
+      postureLabel:
+        cluster.count === 1 ? "1 unresolved" : `${cluster.count} unresolved`,
+      count: cluster.count,
+      href: null,
+      actionLabel: "Add a stance",
+      actionHref: "/wiki/perspectives",
+    }));
+}
+
+/**
+ * Assemble the ordered findings list. Conflicts first (they actively misfire),
+ * then gaps by descending cluster size (the biggest coverage holes first).
+ */
+export function buildReviewFindings(input: {
+  conflicts: ConflictRow[];
+  gapClusters: GapCluster[];
+}): ReviewFinding[] {
+  const conflicts = buildConflictFindings(input.conflicts);
+  const gaps = buildGapFindings(input.gapClusters).sort(
+    (a, b) => b.count - a.count,
+  );
+  return [...conflicts, ...gaps];
+}

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -207,6 +207,7 @@ Tracked under EP-WWMD, EP-VOICE-LAYER, and EP-WSID:
 ## Related Routes
 
 - `/wiki` — **Decision governance** landing. Reframed (EP-0AF96937 Phase 1) around the three decision disciplines — WWMD (platform), WWWD (your business), WSID (each role's craft) — each card showing derived health (material counts, whether the org has its own stance, open review counts) and See / Manage / Review actions. The raw kernel material (principles, stances, heuristics) is retained below the hub as a "Governing material" drill-in rather than the front door. See `docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md`.
+- `/wiki/review` — **Review & adjust** workspace (EP-0AF96937 Phase 2). A findings surface over the accumulating decision ledger: `conflict` findings (decisions the gate flagged as `principleConflict`) and `gap` findings (clusters of `defer`/`escalate` outcomes in one decision domain where the doctrine has no settled answer yet), each with a plain-language action. Drift (golden-decision flips), stale-material review, and the principle-dimension matrix follow as later sub-slices.
 - `/wiki/perspectives` — manage the profiles behind each discipline; give any perspective a voice
 - Build Studio → **Decision Perspective Gate Panel** — primary surface for the gate
 - `/wiki/personas/[id]` — profile detail

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -206,9 +206,12 @@ Tracked under EP-WWMD, EP-VOICE-LAYER, and EP-WSID:
 
 ## Related Routes
 
+- `/wiki` — **Decision governance** landing. Reframed (EP-0AF96937 Phase 1) around the three decision disciplines — WWMD (platform), WWWD (your business), WSID (each role's craft) — each card showing derived health (material counts, whether the org has its own stance, open review counts) and See / Manage / Review actions. The raw kernel material (principles, stances, heuristics) is retained below the hub as a "Governing material" drill-in rather than the front door. See `docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md`.
+- `/wiki/perspectives` — manage the profiles behind each discipline; give any perspective a voice
 - Build Studio → **Decision Perspective Gate Panel** — primary surface for the gate
 - `/wiki/personas/[id]` — profile detail
 - `/wiki/personas/[id]/voice` — voice training and consent
+- `/platform/ai/founder-review` — the owner/founder review queue for `defer`/`escalate` outcomes (`?mode=wwmd` / `?mode=wwwd`)
 - `/platform/ai/operations` — Operations Map with decision-pressure overlays
 - MCP — the `decisionPerspective.invoke` tool exposes the gate to external clients under the same grant model
 


### PR DESCRIPTION
## What

EP-0AF96937 **Phases 1 + 2** in one PR (the two were stacked; folded together to remove merge-ordering friction). Reframes the `/wiki` surface from a document repository into a business-legible **Decision governance** center.

### Phase 1 — reframe the landing
- `/wiki` is now a three-discipline hub (**WWMD** platform · **WWWD** your business · **WSID** each role's craft) with health derived from live data (kernel material counts, whether the org has its own WWWD stance, open-review counts, WSID family/corpus counts) and See/Manage/Review actions into existing surfaces.
- Raw kernel material retained below as a "Governing material" drill-in.
- Nav entry renamed **"Wiki" → "Decision governance"**; perspectives index reframed away from voice-only.

### Phase 2 — review & adjust loop
- New `/wiki/review` findings surface over the decision ledger: **conflict** findings (`principleConflict` decisions → de-conflict) and **gap** findings (clusters of unresolved `defer`/`escalate` decisions → add a stance), each with posture/risk context and an action.
- The `/wiki` landing gains a "Review & adjust" entry point.
- Drift (golden-decision flips), stale-material review, and the principle matrix are noted in-page and follow as later sub-slices.

## Gates (root clone / source-local)

- `tsc --noEmit` clean · `vitest` passing (14 new builder tests: hub + findings) · `pnpm --filter web build` exit 0.
- Live UX walk-through deferred to operator review (the live portal reflects this only after a self-upgrade deploy). CI runs the authoritative gates.

## Governance

- **UX-Fit-Decision**: `principle_decide` recommends the three-discipline hub over the flat material list on `human_cognitive_load` — composite 5.80, margin 3.60, high confidence, no commandment conflict. Progressive disclosure: 3 cards up front, 157-principle matrix one level down.
- **Process-Spine**: implements the filed EP-0AF96937 spec (#2573); user guide (decision-perspective.md Related Routes) updated in this PR.

Phases 3–5 (WWWD/WSID authoring editors, full route rename) follow as separate PRs — the authoring write-paths carry an open gate-consumption dependency (BI-E1FB2307) and benefit from operator-in-loop review; the rename waits on the operator's name choice (spec §8 Q1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)