### PR TITLE
feat(coworker): advise-mode awareness signal — name the held-back authority, not a missing permission

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -84,7 +84,7 @@ import {
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
-import { filterToolsForCoworkerRuntime } from "./coworker-tool-filter";
+import { filterToolsForCoworkerRuntime, adviseHeldBackTools } from "./coworker-tool-filter";
 export { filterToolsForCoworkerRuntime };
 
 async function requireAuthUser() {
@@ -1456,6 +1456,30 @@ export async function sendMessage(input: {
       } catch (err) {
         console.warn("[ship] Failed to inject contribution mode context:", err);
       }
+    }
+  }
+
+  // Advise mode holds back the coworker's side-effecting tools. Tell it exactly
+  // which authority is being held back — this is NOT a missing permission — so it
+  // proposes switching to Act mode and names the specific capability per the
+  // limitation-response contract, instead of misdiagnosing a mode muzzle as a
+  // missing grant or deflecting the employee to an administrator. Mirrors the
+  // external-access block below. Covers both prompt paths (they converge here).
+  if (input.coworkerMode === "advise") {
+    const heldBack = adviseHeldBackTools(mergedTools);
+    if (heldBack.length > 0) {
+      const ADVISE_HELD_BACK_CAP = 10;
+      const shown = heldBack.slice(0, ADVISE_HELD_BACK_CAP);
+      const toolList = shown.map((t) => `- ${t.name}: ${t.description}`).join("\n");
+      const moreLine = heldBack.length > shown.length ? `- (+${heldBack.length - shown.length} more)` : "";
+      populatedPrompt += [
+        "",
+        "",
+        "ADVISE MODE — AUTHORITY HELD BACK (NOT A MISSING PERMISSION).",
+        "You already hold permission for the actions below; they are disabled ONLY because you are in Advise mode. Do not tell the employee you lack access to these, and do not send them to an administrator. When the request needs one, follow the limitation-response contract: say you can do it and ask to switch to Act mode.",
+        toolList,
+        moreLine,
+      ].filter(Boolean).join("\n");
     }
   }
 

--- a/apps/web/lib/actions/coworker-tool-filter.test.ts
+++ b/apps/web/lib/actions/coworker-tool-filter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import type { ToolDefinition } from "@/lib/mcp-tools";
+
+import { adviseHeldBackTools, filterToolsForCoworkerRuntime } from "./coworker-tool-filter";
+
+const tool = (over: Partial<ToolDefinition> & { name: string }): ToolDefinition =>
+  ({
+    description: `${over.name} description`,
+    inputSchema: { type: "object", properties: {}, required: [] },
+    ...over,
+  }) as ToolDefinition;
+
+const READ = tool({ name: "list_backlog_items" });
+const WRITE = tool({ name: "create_backlog_item", sideEffect: true });
+const PROVISION = tool({ name: "manage_coworker_tool_grant", sideEffect: true });
+const ARTIFACT = tool({ name: "save_marketing_review", sideEffect: true, coworkerArtifact: true });
+
+const MERGED = [READ, WRITE, PROVISION, ARTIFACT];
+
+describe("filterToolsForCoworkerRuntime — advise rule", () => {
+  it("strips side-effect tools but keeps reads and coworker artifacts in advise mode", () => {
+    const kept = filterToolsForCoworkerRuntime(MERGED, { coworkerMode: "advise", activeBuildPhase: null }).map((t) => t.name);
+    expect(kept).toEqual(["list_backlog_items", "save_marketing_review"]);
+  });
+
+  it("keeps everything in act mode", () => {
+    const kept = filterToolsForCoworkerRuntime(MERGED, { coworkerMode: "act", activeBuildPhase: null }).map((t) => t.name);
+    expect(kept).toEqual(["list_backlog_items", "create_backlog_item", "manage_coworker_tool_grant", "save_marketing_review"]);
+  });
+});
+
+describe("adviseHeldBackTools", () => {
+  it("returns exactly the side-effect, non-artifact tools the advise rule removes", () => {
+    const held = adviseHeldBackTools(MERGED).map((t) => t.name);
+    expect(held).toEqual(["create_backlog_item", "manage_coworker_tool_grant"]);
+  });
+
+  it("is the complement of the advise-filtered set (held-back = merged − kept, minus artifacts)", () => {
+    const kept = new Set(
+      filterToolsForCoworkerRuntime(MERGED, { coworkerMode: "advise", activeBuildPhase: null }).map((t) => t.name),
+    );
+    const held = adviseHeldBackTools(MERGED);
+    // Nothing held back is also kept, and every held-back tool is a stripped side-effect tool.
+    for (const t of held) {
+      expect(kept.has(t.name)).toBe(false);
+      expect(t.sideEffect).toBe(true);
+      expect(t.coworkerArtifact).toBeFalsy();
+    }
+  });
+
+  it("returns empty when the coworker holds no side-effecting authority", () => {
+    expect(adviseHeldBackTools([READ, ARTIFACT])).toEqual([]);
+  });
+});

--- a/apps/web/lib/actions/coworker-tool-filter.ts
+++ b/apps/web/lib/actions/coworker-tool-filter.ts
@@ -52,3 +52,19 @@ export function filterToolsForCoworkerRuntime(
     return true;
   });
 }
+
+/**
+ * The tools that Advise mode holds back — the exact set `filterToolsForCoworkerRuntime`
+ * removes for its `coworkerMode === "advise"` rule (side-effecting, non-artifact).
+ * The coworker HOLDS authority for these (they passed grant + capability gating to
+ * reach the merged set); advise mode is disabling them, not a missing permission.
+ *
+ * Surfaced into the coworker's prompt so it can name the specific enabler ("switch
+ * me to Act mode and I can …") per the limitation-response contract, instead of
+ * misdiagnosing a mode muzzle as a missing permission or deflecting to an admin.
+ *
+ * Pass the FULL merged (authorized) tool set — not the already-filtered set.
+ */
+export function adviseHeldBackTools(mergedTools: ToolDefinition[]): ToolDefinition[] {
+  return mergedTools.filter((tool) => tool.sideEffect && !tool.coworkerArtifact);
+}

--- a/docs/superpowers/specs/2026-07-03-coworker-limitation-response-contract-design.md
+++ b/docs/superpowers/specs/2026-07-03-coworker-limitation-response-contract-design.md
@@ -48,3 +48,11 @@ Explicit prohibitions: no open-ended "here's what's wrong" with no way forward; 
 
 ## UX-Fit
 This is a prompt-behavior change, not a new UI control — it *reduces* cognitive load (one yes/no vs an open-ended analysis). No new form, route, or operator-configurable field is introduced; the block is editable in the existing Admin > Prompts surface.
+
+## Follow-up shipped: runtime mode-awareness signal (BI-FE37B0A1 pinpoint half)
+
+The prompt contract above tells a coworker *how* to respond to a limitation, but for the advise-mode case it still had to guess *which* enabler applies — a stripped tool is invisible, so the coworker could not tell "held back by Advise mode" from "not granted." That is the misdiagnosis the AI Ops Engineer made ("backlog access rejected → go to System Admin") when it actually held the grant.
+
+Fix: surface the held-back set into the prompt. `adviseHeldBackTools(mergedTools)` (in `coworker-tool-filter.ts`) returns exactly the set the advise rule removes — side-effecting, non-`coworkerArtifact` tools the coworker already passed grant + capability gating to reach. When `coworkerMode === "advise"` and that set is non-empty, `agent-coworker.ts` appends a bounded block (mirroring the existing external-access block) to the system prompt: **"ADVISE MODE — AUTHORITY HELD BACK (NOT A MISSING PERMISSION)"** listing up to 10 of those actions, with the instruction not to claim missing access or deflect to an admin, and to propose switching to Act mode instead. The injection sits in the section both prompt paths converge on, so it covers unified and legacy in one place. Bounded at 10 (+N-more) to respect the local served-context budget.
+
+Net effect: the coworker now knows precisely which requested actions are mode-gated vs ungranted, so the limitation-response proposal names the right enabler with certainty.

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -17,7 +17,7 @@
   "apps/web/instrumentation.test.ts": 826,
   "apps/web/instrumentation.ts": 1311,
   "apps/web/lib/actions/agent-coworker-external.test.ts": 866,
-  "apps/web/lib/actions/agent-coworker.ts": 2555,
+  "apps/web/lib/actions/agent-coworker.ts": 2579,
   "apps/web/lib/actions/agent-task-scheduler.test.ts": 890,
   "apps/web/lib/actions/ai-providers.ts": 920,
   "apps/web/lib/actions/build-governed.test.ts": 1114,


### PR DESCRIPTION
## Why

Completes the **pinpoint half of BI-FE37B0A1**, closing the loop on the operator's goal.

The limitation-response contract ([#2563](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2563)) tells a coworker to *propose the enabler* when blocked. But for the advise-mode case it still had to **guess which enabler applies** — a tool stripped by advise mode is simply absent from the coworker's tool list, so it can't tell "held back by Advise mode" from "not granted." That is the exact misdiagnosis the AI Ops Engineer made: it claimed "backlog access rejected on this route" and sent the operator to System Admin, when it actually **held** the grant.

## What

- `adviseHeldBackTools(mergedTools)` (in `coworker-tool-filter.ts`) returns exactly the set the advise rule removes — side-effecting, non-`coworkerArtifact` tools the coworker already passed grant + capability gating to reach.
- When `coworkerMode === "advise"` and that set is non-empty, `agent-coworker.ts` appends a bounded prompt block:

  > **ADVISE MODE — AUTHORITY HELD BACK (NOT A MISSING PERMISSION).** You already hold permission for the actions below; they are disabled ONLY because you are in Advise mode. Do not tell the employee you lack access… propose switching to Act mode.

  …listing up to 10 held-back actions (+N-more). Injected in the section **both prompt paths converge on** (covers unified + legacy in one place); mirrors the existing external-access block; bounded to respect the local served-context budget.

Net effect: the coworker now knows precisely which requested actions are mode-gated vs ungranted, so the limitation-response proposal names the right enabler **with certainty** instead of guessing or deflecting.

## Tests
- `coworker-tool-filter.test.ts` (new): the advise rule strips side-effect/keeps reads+artifacts; `adviseHeldBackTools` returns exactly the stripped side-effect set and is the complement of the advise-filtered set. **5/5 verified green** in the root toolchain.

## Notes
- Worktree is source-only → local typecheck/build unrun (AGENTS.md §5); CI authoritative.
- Module-size: surgical +24 for `agent-coworker.ts`.

Epic: EP-F7E35344 · Backlog: BI-FE37B0A1

🤖 Generated with [Claude Code](https://claude.com/claude-code)