### PR TITLE
fix(inference): back off CLI pool when rate-limit has no parseable Retry-After

### DIFF
--- a/apps/web/lib/routing/cli-pool-status.test.ts
+++ b/apps/web/lib/routing/cli-pool-status.test.ts
@@ -60,6 +60,13 @@ describe("parseRetryAfterSeconds", () => {
     expect(parseRetryAfterSeconds("try again in 10 seconds")).toBe(10);
   });
 
+  it("parses hour/minute reset windows (ChatGPT/Codex subscription limits)", () => {
+    expect(parseRetryAfterSeconds("try again in 5 minutes")).toBe(300);
+    expect(parseRetryAfterSeconds("rate limit reached. try again in 2 hours")).toBe(7200);
+    expect(parseRetryAfterSeconds("reset in 2h 30m")).toBe(9000);
+    expect(parseRetryAfterSeconds("you've hit your limit — retry in 1h")).toBe(3600);
+  });
+
   it("returns null for unparseable input", () => {
     expect(parseRetryAfterSeconds("rate limited")).toBeNull();
     expect(parseRetryAfterSeconds("429 Too Many Requests")).toBeNull();
@@ -100,11 +107,29 @@ describe("recordCliRateLimit", () => {
     expect(status!.errorSnippet).toHaveLength(300);
   });
 
-  it("handles missing Retry-After gracefully (resetAt is null)", async () => {
-    await recordCliRateLimit("claude-cli", "anthropic-sub", "rate limit hit");
-    const status = await getCliPoolStatus("claude-cli");
-    expect(status!.resetAt).toBeNull();
-    expect(status!.isExhausted).toBe(false); // no reset time means we don't know — not blocking
+  it("backs off with a default cooldown when Retry-After is unparseable", async () => {
+    // Regression: codex CLI rate-limit output carries no parseable Retry-After
+    // ("Reading prompt from stdin... OpenAI Codex v0.137.0 ..."). Previously
+    // resetAt stayed null, isExhausted was never true, and the dispatch gate
+    // never tripped — so agents kept firing doomed children (the portal-
+    // starving retry-storm). We must still back off for a bounded window.
+    await recordCliRateLimit("codex-cli", "codex", "Reading prompt from stdin...\nOpenAI Codex v0.137.0");
+    const status = await getCliPoolStatus("codex-cli");
+    expect(status!.resetAt).not.toBeNull();
+    expect(status!.isExhausted).toBe(true);
+    // Default is 60s; allow a little slack for execution time.
+    expect(status!.secondsUntilReset).toBeGreaterThan(50);
+    expect(status!.secondsUntilReset).toBeLessThanOrEqual(60);
+    // retryAfterSeconds records only what was actually parsed (nothing here).
+    expect(status!.retryAfterSeconds).toBeNull();
+  });
+
+  it("caps the cooldown so a long/misparsed window can't wedge the provider", async () => {
+    await recordCliRateLimit("codex-cli", "codex", "rate limit reached. try again in 5 hours");
+    const status = await getCliPoolStatus("codex-cli");
+    // 5h would be 18000s; capped to MAX_CLI_COOLDOWN_SECONDS (3600).
+    expect(status!.secondsUntilReset).toBeGreaterThan(3500);
+    expect(status!.secondsUntilReset).toBeLessThanOrEqual(3600);
   });
 
   it("swallows db errors without throwing", async () => {
@@ -133,11 +158,11 @@ describe("getCliPoolStatus", () => {
     expect(status!.secondsUntilReset).toBeGreaterThan(290);
   });
 
-  it("computes isExhausted=false when resetAt is null", async () => {
+  it("computes isExhausted=true via the default cooldown even without Retry-After", async () => {
     await recordCliRateLimit("claude-cli", "anthropic-sub", "rate limited");
     const status = await getCliPoolStatus("claude-cli");
-    expect(status!.isExhausted).toBe(false);
-    expect(status!.secondsUntilReset).toBeNull();
+    expect(status!.isExhausted).toBe(true);
+    expect(status!.secondsUntilReset).toBeGreaterThan(0);
   });
 
   it("swallows db errors and returns null", async () => {

--- a/apps/web/lib/routing/cli-pool-status.ts
+++ b/apps/web/lib/routing/cli-pool-status.ts
@@ -14,6 +14,28 @@ import { prisma } from "@dpf/db";
 
 export type CliAdapterType = "claude-cli" | "codex-cli";
 
+/**
+ * Fallback backoff window (seconds) applied when a CLI reports a rate limit but
+ * gives no parseable Retry-After. Without this the pool's `resetAt` stayed null,
+ * `isExhausted` was never true, and the dispatch gate in ai-inference.ts never
+ * tripped — so every Build Studio agent kept firing doomed CLI children into an
+ * already rate-limited pool (the codex `docker exec` retry-storm that starved
+ * the portal event loop / Docker daemon). A bounded default converts that storm
+ * into an orderly "back off, fall back, re-probe after the window" cycle. A
+ * successful call clears the row immediately via clearCliRateLimit, so the
+ * window is only ever an upper bound. Env-overridable for operators.
+ */
+const DEFAULT_CLI_COOLDOWN_SECONDS =
+  Number(process.env.DPF_CLI_RATELIMIT_DEFAULT_COOLDOWN_SECONDS) || 60;
+
+/**
+ * Upper bound (seconds) on any parsed/derived cooldown, so a misparsed provider
+ * message (or a genuinely multi-hour subscription reset) can never wedge a CLI
+ * provider off the fallback chain for longer than this. We re-probe at the cap
+ * and re-record if still limited. 1 hour.
+ */
+const MAX_CLI_COOLDOWN_SECONDS = 3_600;
+
 export interface CliPoolState {
   adapterType: CliAdapterType;
   providerId: string;
@@ -56,6 +78,18 @@ export function parseRetryAfterSeconds(stderr: string): number | null {
     return isNaN(s) ? null : s;
   }
 
+  // "try again in 2h 30m" / "2 hours 30 minutes" / "5 minutes" — ChatGPT/Codex
+  // subscription limits report reset windows in hours/minutes, not seconds, so
+  // the seconds-only patterns above miss them. Sum any hour + minute components.
+  const hourMatch = /(\d+)\s*h(?:ours?|r)?\b/i.exec(stderr);
+  const minMatch = /(\d+)\s*m(?:in(?:ute)?s?)?\b/i.exec(stderr);
+  if (hourMatch || minMatch) {
+    const hours = hourMatch ? parseInt(hourMatch[1]!, 10) : 0;
+    const mins = minMatch ? parseInt(minMatch[1]!, 10) : 0;
+    const total = hours * 3_600 + mins * 60;
+    if (total > 0) return total;
+  }
+
   return null;
 }
 
@@ -73,10 +107,17 @@ export async function recordCliRateLimit(
   try {
     const retryAfterSeconds = parseRetryAfterSeconds(errorText);
     const now = new Date();
-    const resetAt =
-      retryAfterSeconds != null
-        ? new Date(now.getTime() + retryAfterSeconds * 1_000)
-        : null;
+    // Always back off on a recorded rate limit: use the provider's Retry-After
+    // when it gave one, otherwise a bounded default window. Capping guards
+    // against a misparse (or a genuinely long subscription reset) pinning the
+    // provider off the fallback chain indefinitely. `retryAfterSeconds` still
+    // records only what was actually parsed (may be null) for observability;
+    // `resetAt` is what the dispatch gate reads.
+    const cooldownSeconds = Math.min(
+      retryAfterSeconds ?? DEFAULT_CLI_COOLDOWN_SECONDS,
+      MAX_CLI_COOLDOWN_SECONDS,
+    );
+    const resetAt = new Date(now.getTime() + cooldownSeconds * 1_000);
 
     await prisma.cliPoolStatus.upsert({
       where: { adapterType },


### PR DESCRIPTION
## Symptom
The portal on :3000 intermittently stops responding — "happening a lot." No crash, no OOM (`oom_kill 0`), `RestartCount=0`, healthy between incidents. The unresponsiveness is **transient event-loop / Docker-daemon starvation** during a **Codex CLI retry-storm** driven by Build Studio.

Observed on the live install (2026-07-04): codex rate-limit + child-timeout events peaked at **87/hr** (08:00 UTC), portal sluggish during the window, self-recovered when the storm cleared.

## Root cause (confirmed against live DB + logs)
Build Studio fans out agents (e.g. `reviewDesignDoc` = 3 parallel reviewers). Each shells out a `docker exec dpf-sandbox-1 codex` child held open up to 10 min (`CLI_TIMEOUT_MS`) through the single shared sandbox. OpenAI rate-limits the codex subscription.

There **is** a backoff gate: `ai-inference.ts` consults `getCliPoolStatus` before dispatching a CLI-backed call and fast-fails to fallback when the pool `isExhausted`. **But the gate was a permanent no-op for codex:**
- `isExhausted` requires `resetAt` in the future.
- `recordCliRateLimit` only set `resetAt` when `parseRetryAfterSeconds` returned a value.
- Codex's rate-limit output (`"Reading prompt from stdin... OpenAI Codex v0.137.0 ..."`) carries **no parseable Retry-After** → `resetAt` stayed `null` → `isExhausted` always `false` → gate never tripped.

Live `CliPoolStatus` row confirmed: `resetAt = null`, `retryAfterSeconds = null`. So every agent kept spawning doomed 30s-retry children into an already-rate-limited pool — the thundering herd that hung the portal.

## Fix
- **Always back off on a recorded CLI rate limit**: use the provider's Retry-After when present, otherwise a bounded default window (`DEFAULT_CLI_COOLDOWN_SECONDS`, 60s, env-overridable via `DPF_CLI_RATELIMIT_DEFAULT_COOLDOWN_SECONDS`), capped at `MAX_CLI_COOLDOWN_SECONDS` (1h) so a misparse or long subscription reset can't wedge a provider off the fallback chain. A successful call still calls `clearCliRateLimit`, so the window is only ever an upper bound.
- **Teach `parseRetryAfterSeconds` the hour/minute reset formats** ChatGPT/Codex subscription limits actually emit ("try again in 2h 30m").
- `retryAfterSeconds` still records only what was parsed (may be null) for observability; `resetAt` is what the gate reads.

Net effect: a rate-limited codex now backs off ~60s and dispatches fall back to the next provider, instead of storming the shared sandbox and the portal.

## Tests
`apps/web/lib/routing/cli-pool-status.test.ts` — 19/19 pass. Updated the two tests that encoded the old "null resetAt = not blocking" behavior; added coverage for the default-cooldown backoff, the cap, and hour/minute parsing.

## Follow-up (not in this PR)
The codex-cli adapter still has **no concurrency cap** (the local adapter has `withLocalInferenceLock`; codex-cli has nothing), so the shared sandbox can still be hit by unbounded parallel children. Filing a separate BI to serialize/limit codex-cli dispatch through the shared sandbox. This PR resolves the observed storm by making the existing backoff gate actually function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)