### PR TITLE
feat(inference): global bounded concurrency gate for CLI-backed inference (Build Studio + coworkers)

### DIFF
--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -25,6 +25,7 @@ import { extractToolCalls as extractToolCallsFromText } from "./extract-tool-cal
 import { createMcpSessionToken } from "@/lib/mcp/session-token";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 import { recordCliRateLimit, clearCliRateLimit } from "./cli-pool-status";
+import { withCliSlot } from "./cli-concurrency";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 600_000; // 10 minutes — accumulated Build Studio context (>100K chars) takes longer than 3 min to process
@@ -546,7 +547,12 @@ export const cliAdapter: ExecutionAdapterHandler = {
         (mcpJwt ? `, scopes=${scopesForJwt.length}, capability=${capabilityForJwt}` : ""),
       );
 
-      const { stdout } = await new Promise<{ stdout: string }>((resolve, reject) => {
+      // Acquire a global CLI slot around the heavy spawn-and-wait: bounds how
+      // many `docker exec <sandbox> claude` children run at once across ALL
+      // callers (Build Studio + coworkers), so a fan-out can't starve the
+      // shared sandbox / portal. Prep (auth, file writes) stays outside the
+      // slot so slots turn over on real inference, not setup.
+      const { stdout } = await withCliSlot(() => new Promise<{ stdout: string }>((resolve, reject) => {
         const proc = spawnCb("docker", [
           "exec", "--user", "node", SANDBOX_CONTAINER, runnerScript,
         ]);
@@ -625,7 +631,7 @@ export const cliAdapter: ExecutionAdapterHandler = {
             providerId,
           ));
         });
-      });
+      }));
 
       // 7. Parse the output
       const parsed = parseCliJsonOutput(stdout);

--- a/apps/web/lib/routing/cli-concurrency.test.ts
+++ b/apps/web/lib/routing/cli-concurrency.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  withCliSlot,
+  cliConcurrencyStats,
+  __resetCliConcurrencyForTest,
+} from "./cli-concurrency";
+
+// A controllable deferred task: resolves only when we call .finish().
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, finish: resolve };
+}
+
+describe("cli-concurrency gate", () => {
+  const origEnv = process.env.DPF_CLI_MAX_CONCURRENCY;
+
+  beforeEach(() => {
+    __resetCliConcurrencyForTest();
+    process.env.DPF_CLI_MAX_CONCURRENCY = "2";
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.DPF_CLI_MAX_CONCURRENCY;
+    else process.env.DPF_CLI_MAX_CONCURRENCY = origEnv;
+    __resetCliConcurrencyForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("runs up to the cap concurrently and queues the rest", async () => {
+    const a = deferred();
+    const b = deferred();
+    const c = deferred();
+
+    const ranA = withCliSlot(() => a.promise);
+    const ranB = withCliSlot(() => b.promise);
+    const ranC = withCliSlot(() => c.promise);
+
+    // Let microtasks flush so acquires settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Cap is 2 → A and B in flight, C queued.
+    expect(cliConcurrencyStats()).toEqual({ inFlight: 2, queued: 1, max: 2 });
+
+    // Finish A → its slot hands off to C.
+    a.finish();
+    await ranA;
+    await Promise.resolve();
+    expect(cliConcurrencyStats()).toMatchObject({ inFlight: 2, queued: 0 });
+
+    b.finish();
+    c.finish();
+    await Promise.all([ranB, ranC]);
+    expect(cliConcurrencyStats()).toMatchObject({ inFlight: 0, queued: 0 });
+  });
+
+  it("releases the slot even when the task rejects (no permanent leak)", async () => {
+    process.env.DPF_CLI_MAX_CONCURRENCY = "1";
+    __resetCliConcurrencyForTest();
+
+    const boom = withCliSlot(() => Promise.reject(new Error("cli blew up")));
+    await expect(boom).rejects.toThrow("cli blew up");
+
+    // Slot must be free again for the next caller.
+    expect(cliConcurrencyStats()).toMatchObject({ inFlight: 0, queued: 0 });
+
+    const ok = await withCliSlot(() => Promise.resolve("recovered"));
+    expect(ok).toBe("recovered");
+  });
+
+  it("preserves FIFO order for queued callers", async () => {
+    process.env.DPF_CLI_MAX_CONCURRENCY = "1";
+    __resetCliConcurrencyForTest();
+
+    const order: string[] = [];
+    const first = deferred();
+
+    const p1 = withCliSlot(async () => {
+      order.push("start-1");
+      await first.promise;
+      order.push("end-1");
+    });
+    const p2 = withCliSlot(async () => {
+      order.push("run-2");
+    });
+    const p3 = withCliSlot(async () => {
+      order.push("run-3");
+    });
+
+    await Promise.resolve();
+    // Only the first holds the single slot; 2 and 3 are queued in order.
+    expect(cliConcurrencyStats()).toMatchObject({ inFlight: 1, queued: 2 });
+
+    first.finish();
+    await Promise.all([p1, p2, p3]);
+    expect(order).toEqual(["start-1", "end-1", "run-2", "run-3"]);
+  });
+
+  it("defaults to a cap of 4 when the env var is unset or invalid", async () => {
+    delete process.env.DPF_CLI_MAX_CONCURRENCY;
+    __resetCliConcurrencyForTest();
+    expect(cliConcurrencyStats().max).toBe(4);
+
+    process.env.DPF_CLI_MAX_CONCURRENCY = "not-a-number";
+    expect(cliConcurrencyStats().max).toBe(4);
+
+    process.env.DPF_CLI_MAX_CONCURRENCY = "0";
+    expect(cliConcurrencyStats().max).toBe(4);
+  });
+});

--- a/apps/web/lib/routing/cli-concurrency.ts
+++ b/apps/web/lib/routing/cli-concurrency.ts
@@ -1,0 +1,106 @@
+// apps/web/lib/routing/cli-concurrency.ts
+//
+// Global bounded-concurrency gate for CLI-backed inference (codex-cli +
+// claude-cli). Both adapters spawn a `docker exec <sandbox> <runner>` child
+// held open up to CLI_TIMEOUT_MS (10 min) through the SAME shared sandbox
+// container. Nothing bounded how many ran at once, so a fan-out — Build Studio
+// (e.g. reviewDesignDoc = 3 parallel reviewers) OR many concurrent AI coworkers
+// — could pile dozens of held-open `docker exec` children onto the one sandbox
+// and the Docker daemon, starving the portal event loop (the observed
+// "portal :3000 not responding" incidents).
+//
+// The scarce resource is the shared sandbox, not any one caller, so the gate
+// lives here at the adapter seam and is GLOBAL: every CLI inference call from
+// every caller (Build Studio, coworkers, evals) acquires a slot first. This is
+// the CLI analog of chat-adapter.ts's `withLocalInferenceLock` (which serializes
+// the single-GPU local endpoint) — a bounded semaphore rather than a strict
+// serial chain, because the sandbox can handle a handful of concurrent CLIs.
+//
+// Default cap is deliberately small (4). Env-overridable via
+// DPF_CLI_MAX_CONCURRENCY for operators on bigger/smaller hardware. Excess
+// calls queue and run as slots free; none are dropped.
+
+/** Resolve the concurrency cap each acquire so an operator env change (or a
+ *  test override) takes effect without a process restart. Floors at 1. */
+function maxConcurrency(): number {
+  const raw = Number(process.env.DPF_CLI_MAX_CONCURRENCY);
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : 4;
+}
+
+let inFlight = 0;
+const waiters: Array<() => void> = [];
+
+/**
+ * Acquire a slot. Resolves immediately when under the cap; otherwise queues
+ * (FIFO) until a slot is released. The slot is accounted the moment this
+ * resolves, so `release()` must be called exactly once per acquire.
+ */
+function acquire(): Promise<void> {
+  if (inFlight < maxConcurrency()) {
+    inFlight++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waiters.push(() => {
+      // Slot handed over directly by release(); inFlight already reflects the
+      // hold (release did NOT decrement when handing off), so just proceed.
+      resolve();
+    });
+  });
+}
+
+/**
+ * Release a slot. If anyone is queued, hand the slot directly to the next
+ * waiter (inFlight stays the same — no window where a freed slot could be
+ * grabbed by a later caller ahead of the queue). Otherwise decrement.
+ */
+function release(): void {
+  const next = waiters.shift();
+  if (next) {
+    next();
+  } else {
+    inFlight = Math.max(0, inFlight - 1);
+  }
+}
+
+/**
+ * Run `fn` while holding one CLI concurrency slot. The slot is released when
+ * `fn`'s promise settles (resolve OR reject — including timeouts), so one hung
+ * or failing CLI never permanently consumes a slot. Callers wrap ONLY the
+ * heavy spawn-and-wait section, not cheap prep, to keep slots turning over.
+ */
+export async function withCliSlot<T>(fn: () => Promise<T>): Promise<T> {
+  const queuedAtEntry = waiters.length;
+  const hadToWait = inFlight >= maxConcurrency();
+  await acquire();
+  if (hadToWait) {
+    // Surfaced so operators can see sandbox contention in the portal logs —
+    // sustained queueing means the cap (or the sandbox) is the bottleneck.
+    console.log(
+      `[cli-concurrency] queued for a CLI slot (inFlight=${inFlight}/${maxConcurrency()}, queuedAhead=${queuedAtEntry})`,
+    );
+  }
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Current gate state — for tests and operator observability. Not part of the
+ * hot path.
+ */
+export function cliConcurrencyStats(): {
+  inFlight: number;
+  queued: number;
+  max: number;
+} {
+  return { inFlight, queued: waiters.length, max: maxConcurrency() };
+}
+
+/** Test-only: reset gate state between cases. */
+export function __resetCliConcurrencyForTest(): void {
+  inFlight = 0;
+  waiters.length = 0;
+}

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -22,6 +22,7 @@ import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { extractToolCalls as sharedExtractToolCalls } from "./extract-tool-calls";
 import { recordCliRateLimit, clearCliRateLimit } from "./cli-pool-status";
+import { withCliSlot } from "./cli-concurrency";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 600_000; // 10 minutes — accumulated Build Studio context (>100K chars) takes longer than 3 min to process
@@ -302,7 +303,12 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
         { timeout: 5_000 },
       ).catch(() => {});
 
-      const { stdout } = await new Promise<{ stdout: string }>((resolve, reject) => {
+      // Acquire a global CLI slot around the heavy spawn-and-wait: this bounds
+      // how many `docker exec <sandbox> codex` children run at once across ALL
+      // callers (Build Studio + coworkers), so a fan-out can't starve the
+      // shared sandbox / portal. Auth + file writes above are cheap and stay
+      // outside the slot so slots turn over on real inference, not prep.
+      const { stdout } = await withCliSlot(() => new Promise<{ stdout: string }>((resolve, reject) => {
         const proc = spawnCb("docker", [
           "exec", SANDBOX_CONTAINER, runnerScript,
         ]);
@@ -379,7 +385,7 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
             providerId,
           ));
         });
-      });
+      }));
 
       // 6. Parse output — codex exec returns plain text (no structured JSON)
       const text = stdout.trim();

--- a/docs/superpowers/plans/2026-07-04-cli-inference-concurrency-and-provider-spreading.md
+++ b/docs/superpowers/plans/2026-07-04-cli-inference-concurrency-and-provider-spreading.md
@@ -1,0 +1,36 @@
+# Plan — Bound CLI inference concurrency + spread load across providers
+
+- **Date:** 2026-07-04
+- **Backlog items:** BI-CE7DE053 (concurrency cap), BI-15068745 (proactive multi-provider spreading)
+- **Related PR:** #2578 (reactive CLI rate-limit backoff — the safety net once a provider 429s)
+- **Kernel decision:** `principle_decide` (in_platform_coworker, high confidence, composite 8.17 / margin 2.51, no commandment conflict) — reuse the existing capacity-weighted scorer rather than build a new load-balancer subsystem.
+
+## Problem
+
+The portal on :3000 intermittently stops responding. Root cause (confirmed on the live install 2026-07-04): a **Codex CLI retry-storm**. Both CLI execution adapters (`codex-cli-adapter.ts`, `cli-adapter.ts`) spawn a `docker exec <sandbox> <runner>` child held open up to `CLI_TIMEOUT_MS` (10 min) through the **single shared sandbox** container, with **no concurrency bound**. A fan-out — Build Studio (`reviewDesignDoc` = 3 parallel reviewers) **or many concurrent AI coworkers** — piles dozens of held-open `docker exec` children onto the one sandbox and the Docker daemon, starving the portal event loop.
+
+The scarce resource is the shared sandbox, shared by every CLI caller — so the protection must live at the shared adapter seam and be **global**, not scoped to Build Studio.
+
+## Phase 1 — Global CLI concurrency gate (this PR) — BI-CE7DE053
+
+New module `apps/web/lib/routing/cli-concurrency.ts`: a process-global bounded semaphore (`withCliSlot`). Both CLI adapters wrap ONLY their heavy spawn-and-wait block with `withCliSlot(...)`; cheap prep (auth, temp-file writes) stays outside so slots turn over on real inference.
+
+- Cap defaults to **4**, env-overridable via `DPF_CLI_MAX_CONCURRENCY`. Excess calls FIFO-queue; none are dropped.
+- Slot released on settle (resolve OR reject, including the 10-min timeout path), so a hung CLI never permanently leaks a slot.
+- Contention is logged (`[cli-concurrency] queued for a CLI slot ...`) for operator observability.
+- This is the CLI analog of `chat-adapter.ts`'s `withLocalInferenceLock` (which serializes the single-GPU local endpoint).
+
+Covers **both** Build Studio and coworker inference automatically, since all CLI inference routes through these two adapters.
+
+Tests: `cli-concurrency.test.ts` — cap enforcement, FIFO ordering, slot release on rejection, env default/override.
+
+## Phase 2 — Proactive multi-provider spreading (follow-up) — BI-15068745
+
+The router already discounts an endpoint's fitness above 80% utilization (`pipeline.ts:379`, fed by `rate-tracker.ts`), so it spreads concurrent requests toward less-loaded providers — but this is inert for CLI/subscription providers:
+
+1. **Invisible caps.** `checkModelCapacity` returns 0% utilization when an endpoint has no known rpm/tpm/rpd limits. CLI subscriptions publish no rate headers, so they read 0% forever and the penalty never fires. *Recommended safe fix:* feed the Phase-1 concurrency-slot saturation (`cliConcurrencyStats`) into `checkModelCapacity` for CLI-backed providers as the utilization signal — no rate-number guessing required.
+2. **Hard pins bypass the scorer** (`pipeline-v2.ts` pinnedOverride, `routed-inference.ts` preferredProviderId). *Fix:* tier-route high-fan-out phases to a pool instead of a single pin. **Needs operator steer** on which phases must stay pinned to a specific model (output-quality trade-off), so it is deliberately deferred to a separate PR.
+
+## Layering
+
+The three protections compose: **proactive spreading** (Phase 2) → **reactive fallback** (PR #2578) → **hard concurrency bound** (Phase 1).


### PR DESCRIPTION
## Why
Portal :3000 intermittently stops responding. Root cause (live install, 2026-07-04): a Codex CLI retry-storm. Both CLI adapters (codex-cli-adapter.ts, cli-adapter.ts) spawn a `docker exec <sandbox> <runner>` child held open up to CLI_TIMEOUT_MS (10 min) through the ONE shared sandbox, with no concurrency bound. A fan-out — Build Studio (reviewDesignDoc = 3 parallel reviewers) OR many concurrent AI coworkers — piles dozens of held-open docker-exec children onto the shared sandbox + Docker daemon, starving the portal event loop. The scarce resource is the shared sandbox, used by every CLI caller, so the fix is at the shared adapter seam and GLOBAL — covering coworkers, not just builds.

## What
New apps/web/lib/routing/cli-concurrency.ts — a process-global bounded semaphore (withCliSlot), the CLI analog of chat-adapter.ts's withLocalInferenceLock. Cap defaults to 4, env-overridable via DPF_CLI_MAX_CONCURRENCY; excess calls FIFO-queue; slot released on settle (resolve OR reject, incl. the 10-min timeout) so a hung CLI never leaks a slot; contention logged. Both adapters wrap only the heavy spawn-and-wait block; cheap prep stays outside so slots turn over on real inference.

## Tests
cli-concurrency.test.ts 4/4. Existing codex-cli-adapter.test.ts (25) + cli-adapter.test.ts (25) still pass.

## Layering
Phase 1 of BI-CE7DE053. Composes with PR #2578 (reactive backoff) + deferred BI-15068745 (proactive spreading): proactive spreading -> reactive fallback (#2578) -> hard concurrency bound (this PR). Plan: docs/superpowers/plans/2026-07-04-cli-inference-concurrency-and-provider-spreading.md

Generated with Claude Code