### PR TITLE
fix(build-studio): 'Pending dispatch' not 'Not selected' for pre-dispatch builds (BI-197165D3)

### DIFF
--- a/apps/web/components/build/FeatureBriefPanel.test.tsx
+++ b/apps/web/components/build/FeatureBriefPanel.test.tsx
@@ -16,9 +16,12 @@ const brief: FeatureBrief = {
   acceptanceCriteria: ["Shows spend by feature build"],
 };
 
-function makeBuild(): FeatureBuildRow {
+function makeBuild(
+  overrides: { phase?: FeatureBuildRow["phase"]; engine?: string | null } = {},
+): FeatureBuildRow {
   return {
     buildId: "FB-1",
+    phase: overrides.phase ?? "ideate",
     happyPathState: {
       intake: {
         status: "pending",
@@ -28,7 +31,12 @@ function makeBuild(): FeatureBuildRow {
         constrainedGoal: null,
         failureReason: null,
       },
-      execution: { engine: null, source: null, status: "pending", failureStage: null },
+      execution: {
+        engine: overrides.engine ?? null,
+        source: null,
+        status: "pending",
+        failureStage: null,
+      },
       verification: { status: "pending", checks: [] },
     },
     deliberationSummary: null,
@@ -67,5 +75,36 @@ describe("FeatureBriefPanel taxonomy placement", () => {
     expect(screen.getByText("39%")).toBeInTheDocument();
     expect(screen.getAllByText("Test & Validate").length).toBeGreaterThan(0);
     expect(screen.getByText("matched: test, validate")).toBeInTheDocument();
+  });
+});
+
+describe("HappyPathStatusCard engine label", () => {
+  it("shows 'Pending dispatch' (not 'Not selected') pre-dispatch in ideate", () => {
+    render(
+      <FeatureBriefPanel brief={brief} phase="ideate" diffSummary={null} build={makeBuild({ phase: "ideate", engine: null })} />,
+    );
+    expect(screen.getAllByText(/Engine: Pending dispatch/).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/Engine: Not selected/)).toHaveLength(0);
+  });
+
+  it("shows 'Pending dispatch' pre-dispatch in plan", () => {
+    render(
+      <FeatureBriefPanel brief={brief} phase="plan" diffSummary={null} build={makeBuild({ phase: "plan", engine: null })} />,
+    );
+    expect(screen.getAllByText(/Engine: Pending dispatch/).length).toBeGreaterThan(0);
+  });
+
+  it("shows the dispatched engine once one is assigned", () => {
+    render(
+      <FeatureBriefPanel brief={brief} phase="build" diffSummary={null} build={makeBuild({ phase: "build", engine: "claude" })} />,
+    );
+    expect(screen.getAllByText(/Engine: claude/).length).toBeGreaterThan(0);
+  });
+
+  it("keeps 'Not selected' at build phase when no engine is set (genuine gap)", () => {
+    render(
+      <FeatureBriefPanel brief={brief} phase="build" diffSummary={null} build={makeBuild({ phase: "build", engine: null })} />,
+    );
+    expect(screen.getAllByText(/Engine: Not selected/).length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/components/build/FeatureBriefPanel.tsx
+++ b/apps/web/components/build/FeatureBriefPanel.tsx
@@ -251,13 +251,21 @@ function HappyPathStatusCard({ build }: { build: FeatureBuildRow }) {
     { label: "Epic", value: intake.epicId ?? "Missing", ok: Boolean(intake.epicId) },
     { label: "Goal", value: intake.constrainedGoal ?? "Missing", ok: Boolean(intake.constrainedGoal) },
   ];
+  // A dispatch engine is only assigned when the build reaches the build phase.
+  // Before then (ideate/plan) `execution.engine` is null simply because nothing
+  // has been dispatched yet — NOT because the runtime is misconfigured. Showing
+  // "Not selected" there reads as a config error on a perfectly healthy build,
+  // so surface the honest "Pending dispatch" for the pre-build phases instead.
+  const engineLabel =
+    execution.engine ??
+    (build.phase === "ideate" || build.phase === "plan" ? "Pending dispatch" : "Not selected");
 
   return (
     <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 flex flex-col gap-2">
       <div className="flex items-center justify-between gap-3">
         <span className="text-xs font-semibold text-[var(--dpf-text)]">Happy Path Status</span>
         <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-wider">
-          Engine: {execution.engine ?? "Not selected"}
+          Engine: {engineLabel}
         </span>
       </div>
       <div className="grid grid-cols-1 gap-1.5">


### PR DESCRIPTION
## What
The Build Studio **Happy Path Status** panel rendered `Engine: Not selected` on every build still in `ideate`/`plan`. `execution.engine` is only assigned when a build reaches the `build` phase, so it is null for all pre-dispatch builds — even though config auto-resolves a dispatch engine (`build-studio-config` DEFAULTS + autoDetect). The result: **every healthy fresh build looked misconfigured.**

## Change
`FeatureBriefPanel.tsx` — make the engine label phase-aware:
- `ideate`/`plan` (pre-dispatch) → honest **"Pending dispatch"**
- `build`+ with no engine → keeps **"Not selected"** (a genuine gap worth flagging)
- dispatched → shows the actual engine

## Why
Part of **EP-BS-UX-HARDENING** — an exercise-driven pass over the Build Studio UX found the status surfaces read as errors on healthy builds. Smallest self-contained honesty fix (BI-197165D3).

## Tests
Adds 4 tests to `FeatureBriefPanel.test.tsx` (ideate/plan → Pending dispatch; dispatched engine shown; build-phase-null → Not selected retained). **vitest: 5/5 pass.**

## Verification notes
Local full-package `tsc` OOMs/times out in the worktree (known heap-heavy op); CI typecheck is authoritative. Type-safe by inspection; no data-model or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)