### PR TITLE
feat(finance): supplier-bill → GL auto-posting (AP recognition) — EP-SAP-PARITY Phase 4

### DIFF
--- a/apps/web/lib/actions/ap.ts
+++ b/apps/web/lib/actions/ap.ts
@@ -8,6 +8,7 @@ import { sendEmail, composeApprovalEmail } from "@/lib/email";
 import { getOrgIdentity } from "@/lib/org-identity";
 import { resolveAppBaseUrl } from "@/lib/app-url";
 import { recordPayment } from "@/lib/actions/finance";
+import { postBillFinalized } from "@/lib/finance/ledger-service";
 import { PAYMENT_METHODS } from "@/lib/finance/finance-validation";
 import type { CreateSupplierInput, CreateBillInput, CreatePOInput, CreatePaymentRunInput } from "@/lib/ap-validation";
 
@@ -300,6 +301,15 @@ export async function submitBillForApproval(billId: string): Promise<void> {
       data: { status: "approved" },
     });
 
+    // Approved with no approval rule required — recognise AP in the ledger now.
+    // Best-effort: a ledger hiccup must not fail approving the bill (idempotent).
+    // billId is a route param (tainted), so it is not logged — the error is the signal.
+    try {
+      await postBillFinalized(billId);
+    } catch (err) {
+      console.error("[ledger] failed to post an approved bill to the general ledger:", err);
+    }
+
     revalidatePath("/finance/ap");
     revalidatePath("/finance/ap/bills");
     revalidatePath("/finance/bills");
@@ -392,6 +402,14 @@ export async function respondToBillApproval(
       where: { id: approval.billId },
       data: { status: "approved" },
     });
+
+    // All approvals collected — recognise AP in the ledger now. Best-effort +
+    // idempotent; the id is not logged (tainted), the error is the signal.
+    try {
+      await postBillFinalized(approval.billId);
+    } catch (err) {
+      console.error("[ledger] failed to post an approved bill to the general ledger:", err);
+    }
   }
 }
 

--- a/apps/web/lib/finance/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/finance/__snapshots__/index.test.ts.snap
@@ -38,6 +38,7 @@ exports[`finance barrel export > exports all public symbols 1`] = `
   "SUPPLIER_STATUSES",
   "activateAiProviderContract",
   "activateAiProviderContractSchema",
+  "buildBillPostingLines",
   "buildInvoicePostingLines",
   "buildOrgChartOfAccounts",
   "buildPaymentPostingLines",

--- a/apps/web/lib/finance/chart-of-accounts.test.ts
+++ b/apps/web/lib/finance/chart-of-accounts.test.ts
@@ -6,7 +6,12 @@ import {
   resolvePostingAccounts,
   type DeterminableAccount,
 } from "./chart-of-accounts";
-import { buildInvoicePostingLines, validateJournalEntry, normalBalanceForType } from "./ledger";
+import {
+  buildInvoicePostingLines,
+  buildBillPostingLines,
+  validateJournalEntry,
+  normalBalanceForType,
+} from "./ledger";
 
 // A commercial/trades-style archetype seed: revenue + expense only, no
 // balance-sheet control accounts — the common SMB case.
@@ -99,6 +104,27 @@ describe("resolvePostingAccounts", () => {
         receivablesAccountId: resolved.receivables!.id!,
         revenueAccountId: resolved.salesRevenue!.id!,
         taxPayableAccountId: resolved.taxPayable!.id!,
+      },
+    );
+    expect(validateJournalEntry(lines).ok).toBe(true);
+  });
+
+  it("resolves bill-posting roles and feeds buildBillPostingLines end-to-end", () => {
+    const coa = buildOrgChartOfAccounts(tradesProfile).map((a, i) => ({ ...a, id: `acc-${i}` }));
+    const { resolved, unresolved } = resolvePostingAccounts(coa);
+
+    // operatingExpense resolves to the archetype's first expense (5000), inputTax to 1200
+    expect(resolved.operatingExpense?.code).toBe("5000");
+    expect(resolved.inputTaxRecoverable?.code).toBe("1200");
+    expect(resolved.payables?.code).toBe("2000");
+    expect(unresolved).not.toContain("operatingExpense");
+
+    const lines = buildBillPostingLines(
+      { subtotal: 800, taxAmount: 160 },
+      {
+        payablesAccountId: resolved.payables!.id!,
+        expenseAccountId: resolved.operatingExpense!.id!,
+        inputTaxAccountId: resolved.inputTaxRecoverable!.id!,
       },
     );
     expect(validateJournalEntry(lines).ok).toBe(true);

--- a/apps/web/lib/finance/chart-of-accounts.ts
+++ b/apps/web/lib/finance/chart-of-accounts.ts
@@ -26,6 +26,8 @@ export const POSTING_ACCOUNT_ROLES = [
   "payables", // trade creditors (AP control)
   "taxPayable", // output sales tax / VAT owed
   "salesRevenue", // default sales/income account
+  "operatingExpense", // default expense account (supplier bills post here)
+  "inputTaxRecoverable", // recoverable input VAT/GST on purchases (an asset)
   "retainedEarnings", // accumulated result
   "openingBalanceEquity", // opening-balance counterweight
 ] as const;
@@ -58,6 +60,7 @@ export type ResolvedChartAccount = ChartAccountSeed & { normalBalance: NormalBal
 export const BASE_CONTROL_ACCOUNTS: readonly ChartAccountSeed[] = [
   { code: "1000", name: "Cash at Bank", type: "asset", role: "bank", isControl: true },
   { code: "1100", name: "Accounts Receivable", type: "asset", role: "receivables", isControl: true },
+  { code: "1200", name: "Input Tax Recoverable", type: "asset", role: "inputTaxRecoverable", isControl: true },
   { code: "2000", name: "Accounts Payable", type: "liability", role: "payables", isControl: true },
   { code: "2200", name: "Sales Tax Payable", type: "liability", role: "taxPayable", isControl: true },
   { code: "3000", name: "Retained Earnings", type: "equity", role: "retainedEarnings" },
@@ -66,6 +69,10 @@ export const BASE_CONTROL_ACCOUNTS: readonly ChartAccountSeed[] = [
   // almost always override 4000 with a domain-specific revenue line, inheriting
   // this role.
   { code: "4000", name: "Sales", type: "revenue", role: "salesRevenue" },
+  // A generic expense account so operatingExpense always resolves; archetype seeds
+  // almost always override 5000 with a domain-specific expense line, inheriting
+  // this role.
+  { code: "5000", name: "Operating Expenses", type: "expense", role: "operatingExpense" },
 ] as const;
 
 // ─── Build the full org chart of accounts ────────────────────────────────────
@@ -131,6 +138,9 @@ const HEURISTICS: Record<PostingAccountRole, (a: DeterminableAccount) => boolean
     a.type === "liability" && (a.code === "2000" || /payable|creditor/i.test(a.name)),
   taxPayable: (a) => a.type === "liability" && /\b(tax|vat|gst)\b/i.test(a.name),
   salesRevenue: (a) => a.type === "revenue",
+  operatingExpense: (a) => a.type === "expense",
+  inputTaxRecoverable: (a) =>
+    a.type === "asset" && (a.code === "1200" || /input\s*(tax|vat)|recoverable|reclaim/i.test(a.name)),
   retainedEarnings: (a) => a.type === "equity" && /retained|undivided|fund balance/i.test(a.name),
   openingBalanceEquity: (a) => a.type === "equity" && /opening/i.test(a.name),
 };

--- a/apps/web/lib/finance/ledger-service.ts
+++ b/apps/web/lib/finance/ledger-service.ts
@@ -19,6 +19,7 @@ import {
 import {
   buildInvoicePostingLines,
   buildPaymentPostingLines,
+  buildBillPostingLines,
   validateJournalEntry,
   periodKeyOf,
   type LedgerAccountType,
@@ -283,6 +284,101 @@ export async function postPaymentRecorded(paymentId: string): Promise<PostPaymen
           debit: l.debit ?? 0,
           credit: l.credit ?? 0,
           currency: payment.currency,
+          description: l.description,
+          customerAccountId: l.customerAccountId ?? null,
+          contactId: l.contactId ?? null,
+          sortOrder: i,
+        })),
+      },
+    },
+    select: { id: true, entryRef: true },
+  });
+
+  return { posted: true, journalEntryId: entry.id, entryRef: entry.entryRef };
+}
+
+// ─── Bill → GL auto-posting (AP recognition) ─────────────────────────────────
+
+export type PostBillResult =
+  | { posted: true; journalEntryId: string; entryRef: string }
+  | { posted: false; reason: "already-posted" | "no-organization" | "unresolved-accounts"; detail?: string };
+
+/**
+ * Post a finalised (approved) supplier bill to the ledger:
+ *   Dr Expense (net) [+ Dr Input Tax (tax)] / Cr Accounts Payable (gross).
+ *
+ * Idempotent (one journal per bill). Automatic account determination via
+ * resolvePostingAccounts; if the expense or payables account can't be resolved the
+ * bill is not posted and the missing roles are reported rather than guessed.
+ */
+export async function postBillFinalized(billId: string): Promise<PostBillResult> {
+  const existing = await prisma.journalEntry.findFirst({
+    where: { sourceType: "Bill", sourceId: billId },
+    select: { id: true, entryRef: true },
+  });
+  if (existing) return { posted: false, reason: "already-posted", detail: existing.entryRef };
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) return { posted: false, reason: "no-organization" };
+
+  const bill = await prisma.bill.findUniqueOrThrow({
+    where: { id: billId },
+    select: { billRef: true, currency: true, issueDate: true, subtotal: true, taxAmount: true },
+  });
+
+  const accounts = await prisma.ledgerAccount.findMany({
+    where: { organizationId: org.id, isActive: true },
+    orderBy: { code: "asc" },
+    select: { id: true, code: true, name: true, type: true },
+  });
+  const determinable: DeterminableAccount[] = accounts.map((a) => ({
+    id: a.id,
+    code: a.code,
+    name: a.name,
+    type: a.type as LedgerAccountType,
+  }));
+  const { resolved } = resolvePostingAccounts(determinable);
+
+  const missing: string[] = [];
+  if (!resolved.payables) missing.push("payables");
+  if (!resolved.operatingExpense) missing.push("operatingExpense");
+  if (missing.length > 0) {
+    return { posted: false, reason: "unresolved-accounts", detail: missing.join(", ") };
+  }
+
+  const lines = buildBillPostingLines(
+    { subtotal: Number(bill.subtotal), taxAmount: Number(bill.taxAmount) },
+    {
+      payablesAccountId: resolved.payables!.id!,
+      expenseAccountId: resolved.operatingExpense!.id!,
+      inputTaxAccountId: resolved.inputTaxRecoverable?.id,
+    },
+  );
+
+  const check = validateJournalEntry(lines);
+  if (!check.ok) {
+    throw new Error(`Bill ${bill.billRef} posting is unbalanced: ${check.errors.join("; ")}`);
+  }
+
+  const entry = await prisma.journalEntry.create({
+    data: {
+      organizationId: org.id,
+      entryRef: `JE-${bill.billRef}`,
+      entryDate: bill.issueDate,
+      periodKey: periodKeyOf(bill.issueDate),
+      status: "posted",
+      source: "bill",
+      sourceType: "Bill",
+      sourceId: billId,
+      currency: bill.currency,
+      postedAt: new Date(),
+      memo: `Supplier bill ${bill.billRef}`,
+      lines: {
+        create: lines.map((l, i) => ({
+          accountId: l.accountId,
+          debit: l.debit ?? 0,
+          credit: l.credit ?? 0,
+          currency: bill.currency,
           description: l.description,
           customerAccountId: l.customerAccountId ?? null,
           contactId: l.contactId ?? null,

--- a/apps/web/lib/finance/ledger.test.ts
+++ b/apps/web/lib/finance/ledger.test.ts
@@ -6,6 +6,7 @@ import {
   computeTrialBalance,
   buildInvoicePostingLines,
   buildPaymentPostingLines,
+  buildBillPostingLines,
   periodKeyOf,
   toMinorUnits,
   LEDGER_ACCOUNT_TYPES,
@@ -242,5 +243,40 @@ describe("buildPaymentPostingLines", () => {
   it("never emits a negative amount", () => {
     const lines = buildPaymentPostingLines({ direction: "inbound", amount: -5 }, resolver);
     expect(lines.every((l) => (l.debit ?? 0) >= 0 && (l.credit ?? 0) >= 0)).toBe(true);
+  });
+});
+
+describe("buildBillPostingLines", () => {
+  const resolver = {
+    payablesAccountId: "acc-ap",
+    expenseAccountId: "acc-exp",
+    inputTaxAccountId: "acc-input-tax",
+  };
+
+  it("splits Dr Expense (net) + Dr Input Tax / Cr AP (gross) when tax + input-tax account", () => {
+    const lines = buildBillPostingLines({ subtotal: 1000, taxAmount: 200 }, resolver);
+    expect(validateJournalEntry(lines).ok).toBe(true);
+    expect(lines.find((l) => l.accountId === "acc-exp")!.debit).toBe(1000);
+    expect(lines.find((l) => l.accountId === "acc-input-tax")!.debit).toBe(200);
+    expect(lines.find((l) => l.accountId === "acc-ap")!.credit).toBe(1200);
+  });
+
+  it("folds tax into the expense (tax-inclusive) when no input-tax account, still balancing", () => {
+    const lines = buildBillPostingLines(
+      { subtotal: 1000, taxAmount: 200 },
+      { payablesAccountId: "acc-ap", expenseAccountId: "acc-exp" },
+    );
+    expect(validateJournalEntry(lines).ok).toBe(true);
+    expect(lines.find((l) => l.accountId === "acc-exp")!.debit).toBe(1200);
+    expect(lines.find((l) => l.accountId === "acc-input-tax")).toBeUndefined();
+    expect(lines.find((l) => l.accountId === "acc-ap")!.credit).toBe(1200);
+  });
+
+  it("handles a zero-tax bill (Dr Expense / Cr AP only)", () => {
+    const lines = buildBillPostingLines({ subtotal: 500, taxAmount: 0 }, resolver);
+    expect(validateJournalEntry(lines).ok).toBe(true);
+    expect(lines).toHaveLength(2);
+    expect(lines.find((l) => l.accountId === "acc-exp")!.debit).toBe(500);
+    expect(lines.find((l) => l.accountId === "acc-ap")!.credit).toBe(500);
   });
 });

--- a/apps/web/lib/finance/ledger.ts
+++ b/apps/web/lib/finance/ledger.ts
@@ -390,3 +390,65 @@ export function buildPaymentPostingLines(
     },
   ];
 }
+
+// ─── Supplier-bill posting (AP recognition) ──────────────────────────────────
+
+export type BillPostingResolver = {
+  /** Trade payables control — what we now owe the supplier. */
+  payablesAccountId: string;
+  /** The expense account the bill's cost lands in. */
+  expenseAccountId: string;
+  /** Recoverable input VAT/GST (an asset), if tax applies and an account exists. */
+  inputTaxAccountId?: string;
+};
+
+export type BillPostingSource = {
+  subtotal: number; // net of tax
+  taxAmount: number;
+  contactId?: string | null;
+};
+
+/**
+ * Build the journal for finalising a supplier bill (SAP MM → FI vendor invoice):
+ *   Dr  Expense              net
+ *   Dr  Input Tax Recoverable tax   (only when tax applies AND an input-tax account exists)
+ *     Cr  Accounts Payable        net + tax   (the gross we now owe)
+ *
+ * Balances by construction. When no input-tax account is resolved the tax is folded
+ * into the expense (tax-inclusive cost) so the entry still balances — the common
+ * case for a non-VAT-registered SMB.
+ */
+export function buildBillPostingLines(
+  bill: BillPostingSource,
+  accounts: BillPostingResolver,
+): JournalLineInput[] {
+  const net = Math.max(bill.subtotal, 0);
+  const tax = Math.max(bill.taxAmount, 0);
+  const gross = net + tax;
+  const splitTax = tax > 0 && !!accounts.inputTaxAccountId;
+
+  const lines: JournalLineInput[] = [
+    {
+      accountId: accounts.expenseAccountId,
+      debit: splitTax ? net : gross,
+      description: "Operating expense",
+      contactId: bill.contactId ?? null,
+    },
+  ];
+
+  if (splitTax) {
+    lines.push({
+      accountId: accounts.inputTaxAccountId!,
+      debit: tax,
+      description: "Input tax recoverable",
+    });
+  }
+
+  lines.push({
+    accountId: accounts.payablesAccountId,
+    credit: gross,
+    description: "Accounts payable",
+  });
+
+  return lines;
+}

--- a/docs/superpowers/specs/2026-07-01-sap-parity-gap-analysis-and-general-ledger-design.md
+++ b/docs/superpowers/specs/2026-07-01-sap-parity-gap-analysis-and-general-ledger-design.md
@@ -274,10 +274,36 @@ cases: inbound, outbound, unresolved-control guard, non-negative). Standalone st
 `tsc` on `ledger.ts` clean. Prisma service/wiring is field-exact; typecheck + runtime
 gated by CI / the shared local-CI sandbox per §5.
 
-## 10. Roadmap
+## 10. Phase 4 — supplier-bill posting (AP recognition, off main)
 
-Phases 1–2 land the ledger foundation and make it automatic. Remaining ranked gaps
-(§4) — GL portal UI + trial-balance/balance-sheet reports, bill/payment/depreciation
-posting builders, procurement 3-way match (MM), inventory movements (WM) — are filed
-under **EP-SAP-PARITY** and delivered by deepening this one spine, not by bolting on
-separate tools.
+Phase 2 recognised revenue+AR (invoice), Phase 3 settled it (payment). Phase 4 closes
+the **payable** side so procurement rides the same ledger:
+
+- **`buildBillPostingLines` (`ledger.ts`, pure, tested)** — Dr Expense (net) [+ Dr Input
+  Tax (tax)] / Cr Accounts Payable (gross). Balances by construction; when no input-tax
+  account is resolved the tax folds into the expense (tax-inclusive cost) — the common
+  non-VAT SMB case.
+- **Chart-of-accounts extension (`chart-of-accounts.ts`)** — two new roles/base accounts:
+  `operatingExpense` (5000, the default expense supplier bills post to; archetype seeds
+  override 5000 and inherit the role) and `inputTaxRecoverable` (1200, an asset —
+  recoverable input VAT/GST, distinct from 2200 output tax payable). Determination stays
+  automatic; unresolved roles are reported, never guessed.
+- **`postBillFinalized` (`ledger-service.ts`)** — idempotent `source: bill` journal,
+  **wired into `ap.ts`** at both `"approved"` transitions (`submitBillForApproval` when no
+  approval rule matches, and `respondToBillApproval` when all approvals are collected),
+  best-effort so a ledger hiccup never fails approving the bill.
+
+Result: **all three core sub-ledgers now post to one ledger** — invoice→AR, payment→
+settlement, bill→AP — so the trial balance (next) reflects a complete book.
+
+Verification: `vitest run lib/finance/ledger.test.ts lib/finance/chart-of-accounts.test.ts`
+— **38/38 pass** (3 new bill cases + 1 determination case). Standalone strict `tsc` on the
+pure modules clean. Prisma service/wiring field-exact; CI/sandbox-gated per §5.
+
+## 11. Roadmap
+
+Phases 1–4 land the ledger, make it automatic, and post all three core sub-ledgers to it.
+Remaining ranked gaps (§4) — **GL portal UI + trial-balance/balance-sheet report** (the
+next slice, so the owner can *see* the books), fixed-asset depreciation posting (FI-AA),
+procurement 3-way match (MM), inventory movements (WM), HCM payroll — are filed under
+**EP-SAP-PARITY** and delivered by deepening this one spine, not by bolting on separate tools.


### PR DESCRIPTION
## Why

Phases 1–3 (all merged) recognise revenue+AR on invoice and settle it on payment. This closes the **payable** side: an approved supplier bill posts to the **same ledger** — so all three core sub-ledgers (invoice→AR, payment→settlement, bill→AP) now ride one spine. Branches off `main` (Phases 1–3 landed), no stacking.

## What it adds

- **`buildBillPostingLines` (`ledger.ts`, pure, fully tested)** — Dr Expense (net) [+ Dr Input Tax (tax)] / Cr Accounts Payable (gross). Balances by construction; when no input-tax account is resolved the tax folds into the expense (tax-inclusive cost — the common non-VAT SMB case).
- **Chart-of-accounts extension (`chart-of-accounts.ts`)** — two new roles + base accounts: `operatingExpense` (5000; archetype seeds override it and inherit the role) and `inputTaxRecoverable` (1200 — an **asset**, recoverable input VAT/GST, distinct from 2200 output tax payable). Determination stays automatic; unresolved roles reported, never guessed.
- **`postBillFinalized` (`ledger-service.ts`)** — idempotent `source: bill` journal, **wired into `ap.ts`** at both `"approved"` transitions (`submitBillForApproval` no-rule path + `respondToBillApproval` all-approved path), best-effort so a ledger hiccup never fails approving the bill. Tainted ids kept out of logs (the CodeQL lesson from Phase 2).

**Result:** all three core sub-ledgers post to one ledger — the trial-balance/balance-sheet report (next slice) will reflect a complete book.

## Verification

- `vitest run lib/finance/ledger.test.ts lib/finance/chart-of-accounts.test.ts` — **38/38 pass** (3 new bill cases: split-tax, tax-inclusive fold, zero-tax; + 1 determination case).
- Standalone strict `tsc` on the pure modules — clean.
- Prisma service + wiring are field-exact to the schema; typecheck + runtime gated by CI / the shared local-CI sandbox per AGENTS.md §5 (source-only worktree).

Advances EP-SAP-PARITY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)