### PR TITLE
feat(finance): General Ledger report — trial balance + balance sheet + P&L (EP-SAP-PARITY Phase 5)

### DIFF
--- a/apps/web/app/(shell)/finance/reports/general-ledger/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/general-ledger/page.tsx
@@ -1,0 +1,155 @@
+// apps/web/app/(shell)/finance/reports/general-ledger/page.tsx
+//
+// The General Ledger report: a trial balance and the balance sheet + income
+// statement derived from it. This is the payoff of every sub-ledger posting to one
+// journal (EP-SAP-PARITY) — the owner sees a real book, derived from the ledger
+// rather than recomputed ad hoc from documents. Read-only; the numbers are computed
+// by getGeneralLedgerReport (which reuses the pure computeTrialBalance /
+// deriveFinancialStatements invariants).
+
+import Link from "next/link";
+
+import { getGeneralLedgerReport } from "@/lib/finance/ledger-service";
+import { getCurrencySymbol } from "@/lib/currency-symbol";
+import { StatCard } from "@/components/ui/report-kit";
+
+interface SearchParams {
+  period?: string;
+}
+
+export default async function GeneralLedgerReportPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const periodKey = params.period && /^\d{4}-\d{2}$/.test(params.period) ? params.period : undefined;
+
+  const report = await getGeneralLedgerReport(periodKey);
+  const sym = getCurrencySymbol(report.currency);
+  const money = (n: number) =>
+    `${n < 0 ? "-" : ""}${sym}${Math.abs(n).toLocaleString("en-GB", { minimumFractionDigits: 2 })}`;
+
+  const {
+    trialBalance: tb,
+    statements: { incomeStatement: is, balanceSheet: bs },
+  } = report;
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <div className="mb-2">
+        <Link href="/finance" className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+          Finance
+        </Link>
+        <span className="text-xs text-[var(--dpf-muted)]"> / </span>
+        <Link
+          href="/finance/reports"
+          className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+        >
+          Reports
+        </Link>
+        <span className="text-xs text-[var(--dpf-muted)]"> / </span>
+        <span className="text-xs text-[var(--dpf-text)]">General Ledger</span>
+      </div>
+
+      <div className="mb-6 flex items-baseline justify-between gap-3">
+        <h1 className="text-xl font-semibold text-[var(--dpf-text)]">General Ledger</h1>
+        <span className="text-xs text-[var(--dpf-muted)]">
+          {report.periodKey ? `Period ${report.periodKey}` : "All time"}
+          {" · "}
+          {tb.balanced ? "Books balance ✓" : "Out of balance — review"}
+        </span>
+      </div>
+
+      {report.isEmpty ? (
+        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-8 text-center">
+          <p className="text-[var(--dpf-text)]">No posted entries yet.</p>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            Send an invoice, record a payment, or approve a supplier bill and your books appear here
+            automatically — no journal entries required.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Income statement */}
+          <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">This period</h2>
+          <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <StatCard label="Revenue" value={money(is.revenue)} intent="info" />
+            <StatCard label="Expenses" value={money(is.expenses)} intent="warning" />
+            <StatCard
+              label="Net income"
+              value={money(is.netIncome)}
+              intent={is.netIncome >= 0 ? "success" : "danger"}
+              hint={is.netIncome >= 0 ? "Profit" : "Loss"}
+            />
+          </div>
+
+          {/* Balance sheet */}
+          <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">Financial position</h2>
+          <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <StatCard label="Assets" value={money(bs.assets)} intent="info" />
+            <StatCard label="Liabilities" value={money(bs.liabilities)} intent="warning" />
+            <StatCard
+              label="Equity + retained"
+              value={money(bs.equity + bs.netIncome)}
+              intent="neutral"
+              hint={bs.balanced ? "Assets = Liabilities + Equity ✓" : "Does not balance"}
+            />
+          </div>
+
+          {/* Trial balance */}
+          <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">Trial balance</h2>
+          <div className="overflow-x-auto rounded-lg border border-[var(--dpf-border)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]">
+                  <th className="px-4 py-2 text-left text-[10px] font-normal uppercase tracking-widest text-[var(--dpf-muted)]">
+                    Code
+                  </th>
+                  <th className="px-4 py-2 text-left text-[10px] font-normal uppercase tracking-widest text-[var(--dpf-muted)]">
+                    Account
+                  </th>
+                  <th className="px-4 py-2 text-right text-[10px] font-normal uppercase tracking-widest text-[var(--dpf-muted)]">
+                    Debit
+                  </th>
+                  <th className="px-4 py-2 text-right text-[10px] font-normal uppercase tracking-widest text-[var(--dpf-muted)]">
+                    Credit
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {tb.rows.map((row) => (
+                  <tr key={row.accountId} className="border-b border-[var(--dpf-border)] last:border-0">
+                    <td className="px-4 py-2 text-[var(--dpf-muted)]">{row.code}</td>
+                    <td className="px-4 py-2 text-[var(--dpf-text)]">
+                      {row.name}
+                      <span className="ml-2 text-[10px] uppercase text-[var(--dpf-muted)]">{row.type}</span>
+                    </td>
+                    <td className="px-4 py-2 text-right text-[var(--dpf-text)]">
+                      {row.debitTotal ? money(row.debitTotal) : ""}
+                    </td>
+                    <td className="px-4 py-2 text-right text-[var(--dpf-text)]">
+                      {row.creditTotal ? money(row.creditTotal) : ""}
+                    </td>
+                  </tr>
+                ))}
+                <tr className="bg-[var(--dpf-surface-2)] font-semibold">
+                  <td className="px-4 py-2 text-[var(--dpf-text)]" colSpan={2}>
+                    Total
+                  </td>
+                  <td className="px-4 py-2 text-right text-[var(--dpf-text)]">{money(tb.totalDebit)}</td>
+                  <td className="px-4 py-2 text-right text-[var(--dpf-text)]">{money(tb.totalCredit)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+            Derived from posted journal entries — every invoice, payment and bill posts here
+            automatically.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/reports/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/page.tsx
@@ -7,7 +7,7 @@ const REPORTS = [
     title: "General Ledger",
     description: "Trial balance, balance sheet & income statement",
     href: "/finance/reports/general-ledger",
-    accent: "#22d3ee",
+    accent: "var(--dpf-accent)",
   },
   {
     title: "Profit & Loss",

--- a/apps/web/app/(shell)/finance/reports/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/page.tsx
@@ -4,6 +4,12 @@ import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 
 const REPORTS = [
   {
+    title: "General Ledger",
+    description: "Trial balance, balance sheet & income statement",
+    href: "/finance/reports/general-ledger",
+    accent: "#22d3ee",
+  },
+  {
     title: "Profit & Loss",
     description: "See your revenue, costs, and profit",
     href: "/finance/reports/profit-loss",

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 535,
+  "routeCount": 536,
   "routes": [
     {
       "routePath": "/",
@@ -4150,6 +4150,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/finance/reports/cash-flow/page.tsx"
+    },
+    {
+      "routePath": "/finance/reports/general-ledger",
+      "kind": "page",
+      "segments": [
+        "finance",
+        "reports",
+        "general-ledger"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/finance/reports/general-ledger/page.tsx"
     },
     {
       "routePath": "/finance/reports/outstanding",

--- a/apps/web/lib/finance/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/finance/__snapshots__/index.test.ts.snap
@@ -57,6 +57,7 @@ exports[`finance barrel export > exports all public symbols 1`] = `
   "createPaymentRunSchema",
   "createRecurringScheduleSchema",
   "createSupplierSchema",
+  "deriveFinancialStatements",
   "disposeAssetSchema",
   "ensureFinanceCommitment",
   "evaluateAiProviderUtilization",

--- a/apps/web/lib/finance/ledger-service.ts
+++ b/apps/web/lib/finance/ledger-service.ts
@@ -21,8 +21,13 @@ import {
   buildPaymentPostingLines,
   buildBillPostingLines,
   validateJournalEntry,
+  computeTrialBalance,
+  deriveFinancialStatements,
   periodKeyOf,
   type LedgerAccountType,
+  type TrialBalanceAccount,
+  type TrialBalance,
+  type FinancialStatements,
 } from "./ledger";
 
 // ─── Chart-of-accounts seeding ───────────────────────────────────────────────
@@ -390,4 +395,81 @@ export async function postBillFinalized(billId: string): Promise<PostBillResult>
   });
 
   return { posted: true, journalEntryId: entry.id, entryRef: entry.entryRef };
+}
+
+// ─── General-ledger report (read model) ──────────────────────────────────────
+
+export type GeneralLedgerReport = {
+  /** The period this report covers ("YYYY-MM"), or null for all-time. */
+  periodKey: string | null;
+  currency: string;
+  trialBalance: TrialBalance;
+  statements: FinancialStatements;
+  /** True when the org has no posted journal entries yet (empty-state signal). */
+  isEmpty: boolean;
+};
+
+/**
+ * Build the general-ledger report — a trial balance and the balance sheet + income
+ * statement derived from it — from posted journal lines. This is the *read* side of
+ * the ledger: the books are derived from the one journal, never recomputed ad hoc
+ * from sub-ledger documents. Pass a `periodKey` ("YYYY-MM") to scope to a fiscal
+ * period, or omit for all-time.
+ */
+export async function getGeneralLedgerReport(periodKey?: string): Promise<GeneralLedgerReport> {
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  const settings = await prisma.orgSettings.findFirst({ select: { baseCurrency: true } });
+  const currency = settings?.baseCurrency ?? "GBP";
+
+  const emptyReport: GeneralLedgerReport = {
+    periodKey: periodKey ?? null,
+    currency,
+    trialBalance: { rows: [], totalDebit: 0, totalCredit: 0, balanced: true },
+    statements: {
+      incomeStatement: { revenue: 0, expenses: 0, netIncome: 0 },
+      balanceSheet: { assets: 0, liabilities: 0, equity: 0, netIncome: 0, balanced: true },
+    },
+    isEmpty: true,
+  };
+  if (!org) return emptyReport;
+
+  const accountRows = await prisma.ledgerAccount.findMany({
+    where: { organizationId: org.id },
+    orderBy: { code: "asc" },
+    select: { id: true, code: true, name: true, type: true },
+  });
+
+  const lineRows = await prisma.journalLine.findMany({
+    where: {
+      journalEntry: {
+        organizationId: org.id,
+        status: "posted",
+        ...(periodKey ? { periodKey } : {}),
+      },
+    },
+    select: { accountId: true, debit: true, credit: true },
+  });
+
+  const accounts: TrialBalanceAccount[] = accountRows.map((a) => ({
+    accountId: a.id,
+    code: a.code,
+    name: a.name,
+    type: a.type as LedgerAccountType,
+  }));
+  const lines = lineRows.map((l) => ({
+    accountId: l.accountId,
+    debit: Number(l.debit),
+    credit: Number(l.credit),
+  }));
+
+  const trialBalance = computeTrialBalance(accounts, lines);
+  const statements = deriveFinancialStatements(trialBalance);
+
+  return {
+    periodKey: periodKey ?? null,
+    currency,
+    trialBalance,
+    statements,
+    isEmpty: lineRows.length === 0,
+  };
 }

--- a/apps/web/lib/finance/ledger.test.ts
+++ b/apps/web/lib/finance/ledger.test.ts
@@ -4,6 +4,7 @@ import {
   isLedgerAccountType,
   validateJournalEntry,
   computeTrialBalance,
+  deriveFinancialStatements,
   buildInvoicePostingLines,
   buildPaymentPostingLines,
   buildBillPostingLines,
@@ -278,5 +279,60 @@ describe("buildBillPostingLines", () => {
     expect(lines).toHaveLength(2);
     expect(lines.find((l) => l.accountId === "acc-exp")!.debit).toBe(500);
     expect(lines.find((l) => l.accountId === "acc-ap")!.credit).toBe(500);
+  });
+});
+
+describe("deriveFinancialStatements", () => {
+  const accounts: TrialBalanceAccount[] = [
+    { accountId: "1000", code: "1000", name: "Bank", type: "asset" },
+    { accountId: "1100", code: "1100", name: "Accounts Receivable", type: "asset" },
+    { accountId: "2000", code: "2000", name: "Accounts Payable", type: "liability" },
+    { accountId: "3000", code: "3000", name: "Retained Earnings", type: "equity" },
+    { accountId: "4000", code: "4000", name: "Sales", type: "revenue" },
+    { accountId: "5000", code: "5000", name: "Expenses", type: "expense" },
+  ];
+
+  it("derives a balanced income statement + balance sheet from a balanced ledger", () => {
+    // Sell 1000 on credit, pay 400 of expenses from the bank, open with 500 equity.
+    const tb = computeTrialBalance(accounts, [
+      { accountId: "1000", debit: 500 }, // opening equity injection
+      { accountId: "3000", credit: 500 },
+      { accountId: "1100", debit: 1000 }, // AR from a sale
+      { accountId: "4000", credit: 1000 }, // revenue
+      { accountId: "5000", debit: 400 }, // expense
+      { accountId: "1000", credit: 400 }, // paid from bank
+    ]);
+    expect(tb.balanced).toBe(true);
+
+    const { incomeStatement: is, balanceSheet: bs } = deriveFinancialStatements(tb);
+    expect(is.revenue).toBe(1000);
+    expect(is.expenses).toBe(400);
+    expect(is.netIncome).toBe(600);
+
+    expect(bs.assets).toBe(1100); // bank 100 + AR 1000
+    expect(bs.liabilities).toBe(0);
+    expect(bs.equity).toBe(500);
+    expect(bs.netIncome).toBe(600);
+    // Assets 1100 = Liabilities 0 + Equity 500 + NetIncome 600
+    expect(bs.balanced).toBe(true);
+  });
+
+  it("reports a net loss when expenses exceed revenue", () => {
+    const tb = computeTrialBalance(accounts, [
+      { accountId: "4000", credit: 100 },
+      { accountId: "1100", debit: 100 },
+      { accountId: "5000", debit: 300 },
+      { accountId: "2000", credit: 300 },
+    ]);
+    const { incomeStatement: is } = deriveFinancialStatements(tb);
+    expect(is.netIncome).toBe(-200);
+  });
+
+  it("an empty ledger yields all-zero, balanced statements", () => {
+    const { incomeStatement: is, balanceSheet: bs } = deriveFinancialStatements(
+      computeTrialBalance(accounts, []),
+    );
+    expect(is.netIncome).toBe(0);
+    expect(bs.balanced).toBe(true);
   });
 });

--- a/apps/web/lib/finance/ledger.ts
+++ b/apps/web/lib/finance/ledger.ts
@@ -452,3 +452,71 @@ export function buildBillPostingLines(
 
   return lines;
 }
+
+// ─── Financial statements (derived from the trial balance) ───────────────────
+
+export type IncomeStatement = {
+  revenue: number;
+  expenses: number;
+  netIncome: number; // revenue − expenses
+};
+
+export type BalanceSheet = {
+  assets: number;
+  liabilities: number;
+  equity: number;
+  /** Current-period result, not yet closed to retained earnings. */
+  netIncome: number;
+  /** Assets = Liabilities + Equity + net income (the accounting equation holds). */
+  balanced: boolean;
+};
+
+export type FinancialStatements = {
+  incomeStatement: IncomeStatement;
+  balanceSheet: BalanceSheet;
+};
+
+/**
+ * Roll a trial balance up into an income statement and a balance sheet by account
+ * class. Each row's `balance` is already oriented to its normal side, so summing by
+ * type gives the natural positive totals. A ledger whose trial balance balances
+ * satisfies the accounting equation Assets = Liabilities + Equity + (Revenue −
+ * Expenses); `balanced` re-checks that in integer minor units so display rounding
+ * can never make a consistent book look inconsistent.
+ */
+export function deriveFinancialStatements(tb: TrialBalance): FinancialStatements {
+  let assets = 0;
+  let liabilities = 0;
+  let equity = 0;
+  let revenue = 0;
+  let expenses = 0;
+
+  for (const row of tb.rows) {
+    switch (row.type) {
+      case "asset":
+        assets += row.balance;
+        break;
+      case "liability":
+        liabilities += row.balance;
+        break;
+      case "equity":
+        equity += row.balance;
+        break;
+      case "revenue":
+        revenue += row.balance;
+        break;
+      case "expense":
+        expenses += row.balance;
+        break;
+    }
+  }
+
+  const netIncome = (toMinorUnits(revenue) - toMinorUnits(expenses)) / 100;
+  const balanced =
+    toMinorUnits(assets) === toMinorUnits(liabilities) + toMinorUnits(equity) + toMinorUnits(netIncome);
+
+  return {
+    incomeStatement: { revenue, expenses, netIncome },
+    balanceSheet: { assets, liabilities, equity, netIncome, balanced },
+  };
+}

--- a/docs/superpowers/specs/2026-07-01-sap-parity-gap-analysis-and-general-ledger-design.md
+++ b/docs/superpowers/specs/2026-07-01-sap-parity-gap-analysis-and-general-ledger-design.md
@@ -300,10 +300,44 @@ Verification: `vitest run lib/finance/ledger.test.ts lib/finance/chart-of-accoun
 — **38/38 pass** (3 new bill cases + 1 determination case). Standalone strict `tsc` on the
 pure modules clean. Prisma service/wiring field-exact; CI/sandbox-gated per §5.
 
-## 11. Roadmap
+## 11. Phase 5 — the General Ledger report (see the books, off main)
 
-Phases 1–4 land the ledger, make it automatic, and post all three core sub-ledgers to it.
-Remaining ranked gaps (§4) — **GL portal UI + trial-balance/balance-sheet report** (the
-next slice, so the owner can *see* the books), fixed-asset depreciation posting (FI-AA),
-procurement 3-way match (MM), inventory movements (WM), HCM payroll — are filed under
-**EP-SAP-PARITY** and delivered by deepening this one spine, not by bolting on separate tools.
+Phases 1–4 write to the ledger; Phase 5 lets the owner **read** it. The books are
+*derived* from the one journal, never recomputed ad hoc from documents:
+
+- **`deriveFinancialStatements(trialBalance)` (`ledger.ts`, pure, tested)** — rolls the
+  trial balance up by account class into an **income statement** (revenue − expenses =
+  net income) and a **balance sheet** (assets / liabilities / equity). Because the trial
+  balance balances, the accounting equation Assets = Liabilities + Equity + net income
+  holds; `balanced` re-checks it in integer minor units.
+- **`getGeneralLedgerReport(periodKey?)` (`ledger-service.ts`)** — the read model:
+  aggregates posted `JournalLine`s (optionally scoped to a `YYYY-MM` period) through the
+  pure `computeTrialBalance` + `deriveFinancialStatements`, returning the trial balance,
+  both statements, currency, and an `isEmpty` empty-state signal.
+- **`/finance/reports/general-ledger` page** — a themed, read-only report: six KPI tiles
+  (revenue/expenses/net income; assets/liabilities/equity) via report-kit `StatCard`, a
+  trial-balance table matching the existing finance-report pages, a "books balance ✓"
+  indicator, and an empty state that points the owner at the actions that populate it.
+  Added to the reports index for discovery.
+
+**UX-Fit decision (progressive disclosure):** the default view is six plain-language
+headline numbers a layman reads at a glance; the trial-balance detail sits below for
+those who want it. Everything is *derived* — the only optional input is a period. No
+token-count-style control a non-technical user can't answer. Scored on
+`human_cognitive_load`; attested with a `UX-Fit-Decision` trailer.
+
+Verification: `vitest run lib/finance/ledger.test.ts` — **29/29 pass** (3 new statement
+cases: balanced book, net loss, empty ledger). Standalone strict `tsc` on `ledger.ts`
+clean. The Prisma read service + the server-component page are field-exact and
+CI/sandbox-gated per §5 (a worktree cannot host the Next runtime); the pure derivation
+they call is fully proven. Report-kit `DataTable` was intentionally not used for the trial
+balance — it is a client component and all seven sibling finance reports hand-roll a
+themed table; converging finance reports onto report-kit is a separate follow-up.
+
+## 12. Roadmap
+
+Phases 1–5 land the ledger, make it automatic, post all three core sub-ledgers to it, and
+surface the derived books. Remaining ranked gaps (§4) — fixed-asset depreciation posting
+(FI-AA), procurement 3-way match (MM), inventory movements (WM), HCM payroll — are filed
+under **EP-SAP-PARITY** and delivered by deepening this one spine, not by bolting on
+separate tools.


### PR DESCRIPTION
## Why

Phases 1–4 (all merged) write to one ledger — invoice→AR, payment→settlement, bill→AP. This is the payoff: the owner can now **see a real book**, *derived* from the journal rather than recomputed ad hoc from documents.

## What it adds

- **`deriveFinancialStatements` (`ledger.ts`, pure, fully tested)** — rolls a trial balance up by account class into an **income statement** (revenue − expenses = net income) and a **balance sheet** (assets / liabilities / equity). Re-checks Assets = Liabilities + Equity + net income in integer minor units, so display rounding can't make a consistent book look broken.
- **`getGeneralLedgerReport(periodKey?)` (`ledger-service.ts`)** — the read model: aggregates posted `JournalLine`s (optional `YYYY-MM` period) through the pure `computeTrialBalance` + `deriveFinancialStatements`; returns the trial balance, both statements, currency, and an `isEmpty` empty-state signal.
- **`/finance/reports/general-ledger` page** — themed, read-only: six KPI tiles via report-kit `StatCard`, a trial-balance table matching the existing finance reports, a "books balance ✓" indicator, and an empty state that points the owner at the actions that populate it. Added to the reports index for discovery.

## Verification

- `vitest run lib/finance/ledger.test.ts` — **29/29 pass** (3 new statement cases: balanced book, net loss, empty ledger).
- Standalone strict `tsc` on `ledger.ts` — clean.
- The Prisma read service + the server-component page are field-exact and CI/sandbox-gated per AGENTS.md §5 (a worktree can't host the Next runtime); the pure derivation they call is fully proven.

**UX-Fit-Decision** (spec §11): progressive disclosure — default is six plain-language headline numbers, trial-balance detail below, everything derived, the only optional input is a period. Scored on `human_cognitive_load`.

**Note:** report-kit `DataTable` was intentionally not used for the trial balance — it's a client component and all seven sibling finance reports hand-roll a themed table; converging finance reports onto report-kit is a separate follow-up.

Completes the read side of EP-SAP-PARITY's general ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)