### PR TITLE
fix(docker): pin baked pnpm to 10.33.2 to match packageManager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ─── Stage 1: base ────────────────────────────────────────────────────────────
 # Cache bust: 2026-04-09-ideate-dispatch
 FROM node:24-alpine AS base
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
 WORKDIR /app
 
 # ─── Dev stage (parallel branch — not part of production chain) ──────────────


### PR DESCRIPTION
## What

Bumps the base-stage corepack pin in the root `Dockerfile` from `pnpm@10.33.0` to `pnpm@10.33.2`, matching the `packageManager` field in `package.json`.

## Why

The base image baked `pnpm@10.33.0` while `package.json` pins `packageManager: pnpm@10.33.2` (set in #184 on 2026-04-23; the Dockerfile was only ever bumped to `.0`). Because the baked version differs from the pinned one, **corepack re-downloads pnpm@10.33.2 from `registry.npmjs.org` on every container start** — making container boot depend on live npm-registry egress.

### Real-world failure this caused

Self-upgrade run `SUR-A6EAF63D` (2026-07-04) **failed** as a direct result:
- the new portal image **built successfully**
- the verification container started, ran a `pnpm` command, and corepack tried to fetch `pnpm-10.33.2.tgz`
- egress was momentarily refused → `ECONNREFUSED` to `registry.npmjs.org` (Cloudflare `104.16.x.34:443`)
- corepack crashed → the verify step failed → the whole upgrade was marked `failed` and the portal correctly stayed on the prior good SHA

The install only survives normal boots because egress usually works when a container starts; the upgrade verifier got unlucky. This is latent fragility, not a one-off.

## Scope

The root `Dockerfile` was the **last** stale pin — `services/adp/Dockerfile`, `services/integration-test-harness/Dockerfile`, and `.github/actions/setup-pnpm` already track `10.33.2` (the CI action reads the `packageManager` field directly). Baking the pinned version removes the container-start network dependency entirely.

## Test

One-line version bump; no behavior change beyond removing the runtime download. Sibling images already run `10.33.2` in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)