### PR TITLE
fix(build-studio): 'gone quiet' nudge for stalled ideate/plan builds (BI-97738ED0)

### DIFF
--- a/apps/web/components/build/build-studio-custodian.test.ts
+++ b/apps/web/components/build/build-studio-custodian.test.ts
@@ -193,4 +193,44 @@ describe("deriveBuildStudioCustodianPrompt", () => {
     expect(prompt?.primaryAction).toBe("coworker");
     expect(prompt?.recommendedAction).toContain("collect the missing evidence");
   });
+
+  it("surfaces a 'gone quiet' nudge for a stalled ideate build (previously invisible)", () => {
+    const build = makeBuild({
+      phase: "ideate",
+      uxVerificationStatus: null,
+      designDoc: null,
+      designReview: null,
+      buildPlan: null,
+      planReview: null,
+      draftApprovedAt: null,
+    });
+    // A plain forward action with a null disabledReason — nothing else would
+    // trip the custodian, so the only reason to surface is the early-phase quiet
+    // bar. (blockedByEvidence keys off disabledReason != null, so it stays false.)
+    const action: BuildStudioWorkflowAction = {
+      kind: "advance-phase",
+      title: "Continue",
+      message: "Keep defining the feature.",
+      primaryLabel: "Continue",
+      targetPhase: "plan",
+      disabledReason: null,
+      coworkerLabel: "Continue with coworker",
+      coworkerPrompt: "Keep defining the feature.",
+    };
+
+    // Quiet 8 minutes in ideate → now surfaces the honest "gone quiet" prompt.
+    const quiet = deriveBuildStudioCustodianPrompt({ build, action, progressVisibility: progress() });
+    expect(quiet).not.toBeNull();
+    expect(quiet?.title).toBe("This build has gone quiet.");
+
+    // Actively working (not quiet) in ideate → stays silent, no false nudge.
+    const active = deriveBuildStudioCustodianPrompt({
+      build,
+      action,
+      progressVisibility: progress({
+        quietAgent: { quiet: false, minutesQuiet: 1, lastObservableSignalAt: "2026-06-29T12:19:00.000Z" },
+      }),
+    });
+    expect(active).toBeNull();
+  });
 });

--- a/apps/web/components/build/build-studio-custodian.ts
+++ b/apps/web/components/build/build-studio-custodian.ts
@@ -32,6 +32,11 @@ type CustodianPromptInput = {
 
 const QUIET_REVIEW_THRESHOLD_MINUTES = 5;
 const QUIET_BUILD_THRESHOLD_MINUTES = 10;
+// Early phases (ideate / plan) had no quiet threshold at all, so a build that
+// died before producing a brief — the most common failure window — surfaced no
+// custodian nudge and read as "Needs you: 0". Give it the same 5-minute quiet
+// bar as review so a stalled ideate/plan build is not invisible.
+const QUIET_EARLY_PHASE_THRESHOLD_MINUTES = 5;
 
 function formatMinutes(minutes: number): string {
   if (minutes < 1) return "less than a minute";
@@ -85,11 +90,12 @@ function resolveCustodianStatusSignal(input: {
   technicalRecovery: boolean;
   isQuietReview: boolean;
   isQuietBuild: boolean;
+  isQuietEarlyPhase: boolean;
 }): NonNullable<ProactivityResolverInput["statusSignal"]> {
   if (input.uxReviewGap || input.blockedByEvidence || input.technicalRecovery) {
     return "blocked";
   }
-  if (input.isQuietReview || input.isQuietBuild) {
+  if (input.isQuietReview || input.isQuietBuild || input.isQuietEarlyPhase) {
     return "stalled";
   }
   return "normal";
@@ -118,6 +124,10 @@ export function deriveBuildStudioCustodianPrompt({
     build.phase === "build"
     && progressVisibility?.quietAgent.quiet === true
     && quietMinutes >= QUIET_BUILD_THRESHOLD_MINUTES;
+  const isQuietEarlyPhase =
+    (build.phase === "ideate" || build.phase === "plan")
+    && progressVisibility?.quietAgent.quiet === true
+    && quietMinutes >= QUIET_EARLY_PHASE_THRESHOLD_MINUTES;
   const blockedByEvidence = action.disabledReason != null;
   const technicalRecovery =
     action.kind === "resume-implementation"
@@ -126,7 +136,7 @@ export function deriveBuildStudioCustodianPrompt({
     || action.kind === "reset-build";
   const uxReviewGap = isUxReviewGap(build, action, progressVisibility);
 
-  if (!uxReviewGap && !blockedByEvidence && !technicalRecovery && !isQuietReview && !isQuietBuild) {
+  if (!uxReviewGap && !blockedByEvidence && !technicalRecovery && !isQuietReview && !isQuietBuild && !isQuietEarlyPhase) {
     return null;
   }
 
@@ -141,6 +151,7 @@ export function deriveBuildStudioCustodianPrompt({
       technicalRecovery,
       isQuietReview,
       isQuietBuild,
+      isQuietEarlyPhase,
     }),
   });
 


### PR DESCRIPTION
## What
Build Studio's custodian only had quiet/stall thresholds for the **review** and **build** phases. A build that went quiet in **ideate** or **plan** — the earliest and most common failure window, before a brief even exists — tripped none of the custodian flags, produced **no prompt at all**, and read as `Needs you: 0` while actually stalled. (Observed live: a build sat 30+ min in ideate with no nudge.)

## Change
`build-studio-custodian.ts`:
- Add `QUIET_EARLY_PHASE_THRESHOLD_MINUTES` (5m — same bar as review).
- Add `isQuietEarlyPhase` for `ideate`/`plan` and thread it through the emit gate + `resolveCustodianStatusSignal` (reads as `stalled`).
- A genuinely quiet early-phase build now surfaces the honest **"This build has gone quiet"** prompt; an actively-working one stays silent (no false nudge).

## Why
Part of **EP-BS-UX-HARDENING** (exercise-driven pass). This closes the biggest stall-blindness gap: the phase where builds most often die had the weakest safety net.

## Tests
Adds a test covering both the quiet-surfaces and actively-working-stays-silent paths. **vitest: 6/6 pass.**

## Verification notes
Local full-package `tsc` OOMs in-worktree (heap limit); CI typecheck authoritative. Type-safe by inspection; no data-model/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)