### PR TITLE
fix(build-studio): Work Control flags a stalled 'working' capsule as degraded, not 'ok' (BI-29D26B23)

### DIFF
--- a/apps/web/lib/work-capsules/work-capsule-presenter.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.test.ts
@@ -41,6 +41,60 @@ describe("presentCapsuleRow", () => {
     expect(row.branch).toBe("no branch");
   });
 
+  it("marks a working capsule that has not advanced as stalled, not ok", () => {
+    const row = presentCapsuleRow({
+      capsuleId: "WC-STALL",
+      title: "Add timestamps",
+      status: "working",
+      source: "manual",
+      executorKind: "build-studio",
+      headBranch: null,
+      worktreePath: null,
+      pullRequestUrl: null,
+      leaseExpiresAt: new Date("2026-05-14T05:00:00.000Z"), // lease still valid
+      lastSyncedAt: new Date("2026-05-14T01:00:00.000Z"), // freshly synced (not stale-cache)
+      updatedAt: new Date("2026-05-14T00:30:00.000Z"), // no progress for 30 min
+    }, new Date("2026-05-14T01:00:00.000Z"));
+
+    expect(row.health).toBe("stalled");
+  });
+
+  it("keeps a freshly-advanced working capsule healthy", () => {
+    const row = presentCapsuleRow({
+      capsuleId: "WC-OK",
+      title: "Add timestamps",
+      status: "working",
+      source: "manual",
+      executorKind: "build-studio",
+      headBranch: null,
+      worktreePath: null,
+      pullRequestUrl: null,
+      leaseExpiresAt: new Date("2026-05-14T05:00:00.000Z"),
+      lastSyncedAt: new Date("2026-05-14T01:00:00.000Z"),
+      updatedAt: new Date("2026-05-14T00:58:00.000Z"), // advanced 2 min ago
+    }, new Date("2026-05-14T01:00:00.000Z"));
+
+    expect(row.health).toBe("ok");
+  });
+
+  it("does not flag a non-working capsule as stalled", () => {
+    const row = presentCapsuleRow({
+      capsuleId: "WC-READY",
+      title: "Queued work",
+      status: "ready",
+      source: "manual",
+      executorKind: null,
+      headBranch: null,
+      worktreePath: null,
+      pullRequestUrl: null,
+      leaseExpiresAt: new Date("2026-05-14T05:00:00.000Z"),
+      lastSyncedAt: new Date("2026-05-14T01:00:00.000Z"),
+      updatedAt: new Date("2026-05-14T00:00:00.000Z"), // old, but not "working"
+    }, new Date("2026-05-14T01:00:00.000Z"));
+
+    expect(row.health).toBe("ok");
+  });
+
   it("presents readable scope labels for Work Control", () => {
     const row = presentCapsuleRow({
       capsuleId: "WC-SCOPE",

--- a/apps/web/lib/work-capsules/work-capsule-presenter.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.ts
@@ -1,5 +1,11 @@
 import { STALE_CACHE_MS } from "@/lib/work-capsules";
 
+// A capsule that claims to be "working" but has not changed in this long is
+// almost certainly stalled (e.g. its build died in ideate). Surface that as a
+// degraded health signal instead of a misleading "ok" — Work Control must not
+// report a dead capsule as healthy.
+const WORKING_STALL_MS = 15 * 60 * 1000;
+
 type CapsuleRowInput = {
   capsuleId: string;
   title: string;
@@ -68,6 +74,8 @@ function outcomeAnchorLabel(value: unknown): string | null {
 export function presentCapsuleRow(row: CapsuleRowInput, now = new Date()) {
   const leaseExpired = row.leaseExpiresAt != null && row.leaseExpiresAt.getTime() < now.getTime();
   const staleCache = row.lastSyncedAt != null && now.getTime() - row.lastSyncedAt.getTime() > STALE_CACHE_MS;
+  const stalledWorking =
+    row.status === "working" && now.getTime() - row.updatedAt.getTime() > WORKING_STALL_MS;
 
   return {
     capsuleId: row.capsuleId,
@@ -90,7 +98,13 @@ export function presentCapsuleRow(row: CapsuleRowInput, now = new Date()) {
     },
     worktreePath: row.worktreePath,
     pullRequestUrl: row.pullRequestUrl,
-    health: leaseExpired ? "lease-expired" : staleCache ? "stale-cache" : "ok",
+    health: leaseExpired
+      ? "lease-expired"
+      : stalledWorking
+        ? "stalled"
+        : staleCache
+          ? "stale-cache"
+          : "ok",
     updatedAt: row.updatedAt.toISOString(),
   };
 }


### PR DESCRIPTION
## What
Work Control capsule **health** was derived only from lease expiry and scanner-cache staleness — never from whether the work actually advanced. A capsule whose build died in ideate keeps a valid lease and fresh sync, so Work Control reported `Health: ok` for a **dead** capsule. (Observed live: WC-A8B57C4D shown `working · ok` with 30+ min of zero progress.)

## Change
`work-capsule-presenter.ts`: add `WORKING_STALL_MS` (15m). A capsule in status `working` that hasn't been updated within that window now reports health **`stalled`**, slotted between `lease-expired` and `stale-cache`. Non-working capsules are unaffected.

## Why
Part of **EP-BS-UX-HARDENING**. Same stall-blindness class as the custodian quiet-detection fix, on the Work Control surface.

## Tests
3 new cases (stalled / fresh-ok / non-working). **vitest: 6/6 pass.**

## Verification notes
Local full-package `tsc` OOMs in-worktree; CI typecheck authoritative. Pure presenter logic; no data-model/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)