### PR TITLE
fix(build-studio): 'getting started' state for pre-brief ideate builds, not 'Waiting on evidence' (BI-86D6AD78)

### DIFF
--- a/apps/web/components/build/build-studio-custodian.test.ts
+++ b/apps/web/components/build/build-studio-custodian.test.ts
@@ -233,4 +233,35 @@ describe("deriveBuildStudioCustodianPrompt", () => {
     });
     expect(active).toBeNull();
   });
+
+  it("shows a 'getting started' state (not 'Waiting on evidence') for a pre-brief ideate build", () => {
+    const build = makeBuild({
+      phase: "ideate",
+      brief: null,
+      uxVerificationStatus: null,
+      designDoc: null,
+      designReview: null,
+      buildPlan: null,
+      planReview: null,
+      draftApprovedAt: null,
+    });
+    // disabledReason is set → this would normally hit the "Waiting on evidence"
+    // branch; the pre-brief guard must intercept it.
+    const action: BuildStudioWorkflowAction = {
+      kind: "advance-phase",
+      title: "Define the feature",
+      message: "The feature brief is not ready yet.",
+      primaryLabel: "Continue",
+      targetPhase: "plan",
+      disabledReason: "Feature brief not created yet.",
+      coworkerLabel: "Continue with coworker",
+      coworkerPrompt: "Draft the feature brief.",
+    };
+    const prompt = deriveBuildStudioCustodianPrompt({ build, action, progressVisibility: progress() });
+
+    expect(prompt?.statusLabel).toBe("Getting started");
+    expect(prompt?.title).toBe("Let's get this build started.");
+    expect(prompt?.intent).toBe("info");
+    expect(prompt?.whyNow).not.toContain("required evidence is missing");
+  });
 });

--- a/apps/web/components/build/build-studio-custodian.ts
+++ b/apps/web/components/build/build-studio-custodian.ts
@@ -206,6 +206,32 @@ export function deriveBuildStudioCustodianPrompt({
   }
 
   if (blockedByEvidence) {
+    // A brand-new build in ideate that has not produced its Feature Brief yet is
+    // not "missing evidence" — it is simply still being defined. Reusing the
+    // alarming "required evidence is missing" copy here reads as an error on the
+    // normal first step (and contradicts the panel telling the user to describe
+    // the feature). Surface an honest "getting started" state instead.
+    if (build.phase === "ideate" && build.brief == null) {
+      return {
+        dismissKey,
+        title: "Let's get this build started.",
+        whyNow: "This build is still being defined — the coworker is drafting your Feature Brief from your description. Nothing is wrong.",
+        recommendedAction: "Add any detail in the conversation panel, or let the coworker keep drafting the brief.",
+        primaryLabel: action.coworkerLabel,
+        primaryAction: "coworker",
+        coworkerPrompt: appendCustodianInstruction(
+          action,
+          "Act as the Build Studio custodian. Draft the Feature Brief from the user's description and return one next action.",
+        ),
+        statusLabel: "Getting started",
+        intent: "info",
+        details: [
+          "The build is being defined from your description; no evidence is missing yet.",
+          "The human should see the conclusion and one next action, not raw workflow internals.",
+        ],
+        proactivityPlan,
+      };
+    }
     return {
       dismissKey,
       title: "I can collect what is missing.",


### PR DESCRIPTION
## What
A brand-new build in `ideate` that hasn't produced its Feature Brief yet fell into the custodian's `blockedByEvidence` branch and rendered **"Waiting on evidence / required evidence is missing"** — an error framing for the normal first step, which also contradicts the panel telling the user to *describe the feature* in the conversation.

## Change
`build-studio-custodian.ts`: guard the `blockedByEvidence` branch — when `phase === "ideate" && brief == null`, return an `info`-intent **"Getting started"** prompt ("Let's get this build started" / "the coworker is drafting your Feature Brief… nothing is wrong") instead. Genuine missing-evidence states are unchanged.

## Why
Part of **EP-BS-UX-HARDENING**, status-honesty cluster. Removes the last alarming-on-a-healthy-build message in the early phase.

## Tests
Adds a test asserting a pre-brief ideate build gets `statusLabel: "Getting started"`, `intent: "info"`, and no "required evidence is missing" copy. **vitest: 7/7 pass.**

## Verification notes
Local full-package `tsc` OOMs in-worktree; CI typecheck authoritative. Return shape mirrors the adjacent `blockedByEvidence` return; `intent: "info"` already used by the quiet fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)