### PR TITLE
docs(founder-kernel): recontextualize WWMD corpus from ServiceNow/EA to DPF (Phase 1)

### DIFF
--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,5 +1,5 @@
 {
-  "kernelVersion": "0.4.0",
+  "kernelVersion": "0.4.1",
   "schemaVersion": "0.3.0",
   "pageCount": 94,
   "sourceCount": 15,

--- a/docs/founder-kernel/wiki/heuristics/be-a-meteorologist.md
+++ b/docs/founder-kernel/wiki/heuristics/be-a-meteorologist.md
@@ -1,32 +1,30 @@
 ---
-title: Be a meteorologist — produce forecasts, not raw models
+title: Be a meteorologist — produce the forecast, not the radar image
 pageKind: heuristic
 status: published
-abstract: Architects deliver forecasts and recommended actions to leadership, not exposed models. The deliverable is the guidance, not the diagram.
+abstract: When reporting a judgment to a decision-maker, produce the forecast — recommendation, confidence, trade-offs — not the raw model. Applies to an architect briefing leadership and to a DPF coworker surfacing a decision to an operator alike.
 sources:
   - articles/possible-futures-enterprise-architecture
 ---
 
 ## The heuristic
 
-> When presenting architecture work to leadership, **produce the forecast** (recommendation, confidence, trade-offs) — not the raw architecture model. Architects are meteorologists, not radar operators.
+> When you report a judgment to someone who has to act on it, **produce the forecast** — the recommendation, its confidence level, and the trade-offs it accepts — not the raw model behind it. Be the meteorologist, not the radar operator.
 
 ## When it applies
 
-Executive briefings. Investment-committee architecture reviews. Portfolio rationalisation recommendations. Any time a non-architect is asking "what should we do?" rather than "what does the model say?"
+Any coworker surfacing a decision to an operator: a WWMD/WWWD/WSID recommendation, a proposed action, a build-gate verdict. Executive briefings and investment-committee reviews — the original enterprise-architecture setting. Any time a non-modeller asks "what should we do?" rather than "what does the model say?"
 
 ## Why it works
 
-Leadership decisions need three things: a recommendation, a confidence level, and the trade-offs they&#39;re accepting. The architecture model is the *input* to those — not the output. Showing leadership the radar imagery instead of the weather forecast misallocates everyone&#39;s time and produces decisions made on the wrong abstraction.
+A decision needs three things: a recommendation, a confidence level, and the trade-offs being accepted. The model is the *input* to those, not the output. Handing the consumer the radar imagery instead of the forecast misallocates everyone&#39;s time and pushes the decision onto the wrong abstraction.
 
-The meteorology framing also disciplines the architect&#39;s own work. A meteorologist who can&#39;t state confidence levels isn&#39;t doing forecasting. An architect who can&#39;t say "I&#39;m 70% confident option B is the right call because of X, Y, Z" isn&#39;t doing EA — they&#39;re doing modeling exhibition.
-
-This is also the philosophical core of the platform&#39;s wiki kernel: the "what would Mark do?" question is a forecast question. The kernel produces guidance, not raw model output.
+The framing also disciplines the producer. A meteorologist who can&#39;t state a confidence level isn&#39;t forecasting. An architect who can&#39;t say "70% confident in option B because X, Y, Z" is exhibiting a model, not advising. And a DPF coworker that returns the whole principle corpus instead of a scored recommendation-with-confidence has skipped its actual job — the "what would Mark do?" question is a forecast question, and the kernel is built to answer it as one.
 
 ## Counterexamples
 
-- Peer-to-peer architecture review where the model *is* the medium.
-- Engineering hand-offs where the next team needs the model to build against.
+- Peer-to-peer review where the model *is* the medium — architect-to-architect, or an agent-to-agent structured handoff.
+- Engineering hand-offs where the next actor needs the model to build against.
 - Compliance / audit contexts where the model is required as record.
 
 ## See also

--- a/docs/founder-kernel/wiki/heuristics/contextualize-before-transforming.md
+++ b/docs/founder-kernel/wiki/heuristics/contextualize-before-transforming.md
@@ -2,29 +2,31 @@
 title: Contextualize before transforming
 pageKind: heuristic
 status: published
-abstract: When adopting a standard, first map the existing operating model onto the standard's structure. Adoption follows mapping; transformation follows adoption.
+abstract: When adopting a standard — or bringing an organisation onto a new platform — first map the existing operating model onto the target's structure. Adoption follows mapping; transformation follows adoption.
 sources:
   - articles/open-group-2017-managing-business-of-it
 ---
 
 ## The heuristic
 
-> When introducing a new standard or framework, first **map** the existing operating model onto its structure. Don&#39;t try to transform until the map is shared.
+> When introducing a new standard, framework, or platform, first **map** the existing operating model onto its structure. Don&#39;t try to transform until the map is shared.
 
 ## When it applies
 
-Any standard adoption against an organisation that already runs — `[[entities/it4it]]`, TOGAF, ArchiMate, `[[entities/csdm]]`, BIAN, COBIT, ITIL refactor. Especially when the executive audience is fluent in their current operating model and skeptical of "yet another framework."
+Any adoption against an organisation that already runs — `[[entities/it4it]]`, TOGAF, ArchiMate, `[[entities/csdm]]`, BIAN, COBIT, an ITIL refactor — or onboarding a new company onto DPF. Especially when the audience is fluent in their current operating model and sceptical of "yet another framework" or "yet another platform."
 
 ## Why it works
 
-Mapping is a low-stakes activity. It doesn&#39;t commit anyone to change. It surfaces where the current model is strong (those parts stay) and where the standard adds value (those parts get adopted deliberately). The conversation moves from "are we wrong?" to "where is the standard most useful for us?" — which is a question executives engage with.
+Mapping is a low-stakes activity. It commits no one to change. It surfaces where the current model is strong (those parts stay) and where the target adds value (those parts get adopted deliberately). The conversation moves from "are we wrong?" to "where is the target most useful for us?" — a question people engage with.
 
-The phrase to use: *"How is our current operating model the same or different from this standard?"*
+The phrase to use: *"How is our current operating model the same or different from this?"*
+
+In DPF onboarding, the map is not throwaway — it becomes the organisation&#39;s own "what would we do?" (WWWD) overlay. Mapping a company&#39;s products onto `[[entities/digital-product]]`s and their existing tools against the one platform model is the artefact every later adoption conversation attaches to; transformation (replacing fragmented tools with the cohesive whole) scopes to the gaps the map revealed.
 
 ## Counterexamples
 
-- Greenfield builds where there&#39;s no current operating model to contextualize against — go straight to the standard.
-- Compliance-driven mandates where the standard is non-negotiable. You still contextualize internally for adoption planning, but the framing externally is "adopt this."
+- Greenfield builds with no current operating model to contextualize against — go straight to the target.
+- Compliance-driven mandates where the target is non-negotiable. You still contextualize internally for adoption planning, but the external framing is "adopt this."
 - Operating models that are visibly broken and the org agrees they&#39;re broken. Contextualization is too patient for a fire-drill; transformation is the right frame.
 
 ## See also

--- a/docs/founder-kernel/wiki/index.md
+++ b/docs/founder-kernel/wiki/index.md
@@ -46,10 +46,10 @@ The judgment kernel. Cite these when grounding an answer in his thinking.
 - `[[stances/digital-product-is-the-unit-of-organization]]` — Digital Product is the right primitive for portfolio, team, funding, lifecycle, governance.
 - `[[stances/persistent-product-teams-over-projects]]` — Replace project teams with persistent teams; annual budgets with rolling investment.
 - `[[stances/it4it-is-substrate]]` — IT4IT integrates ITIL, COBIT, TOGAF, DevOps, SAFe at the operating-model layer. It does not compete.
-- `[[stances/dont-integrate-ea-platform]]` — Consolidate on one data model (CSDM); don&#39;t integrate a third-party EA tool with ServiceNow. The integration goes through Independent → Honeymoon → Ugly Reckoning.
+- `[[stances/dont-integrate-ea-platform]]` — Consolidate on one canonical data model; don&#39;t integrate two systems of record for the same entities. The integration goes through Independent → Honeymoon → Ugly Reckoning. This is why DPF is one platform, not a hub.
 - `[[stances/trust-the-cmdb-or-rebuild-it]]` — Most organisations have a CMDB; very few trust it. Trust requires three pillars: Ingestion, Insight, Governance.
-- `[[stances/ea-is-meteorology]]` — Architects produce forecasts and guidance, not raw model exhibits.
-- `[[stances/contextualize-dont-transform]]` — When introducing a standard, map first. Adoption follows mapping; transformation follows adoption.
+- `[[stances/ea-is-meteorology]]` — Deliver forecasts, not raw models. A coworker reports a recommendation with confidence and trade-offs; WWMD/WWWD/WSID are forecast questions.
+- `[[stances/contextualize-dont-transform]]` — When introducing a standard or onboarding a company onto DPF, map the current operating model first. Adoption follows mapping; the map becomes the org&#39;s WWWD overlay.
 
 ## Heuristics — operational rules
 

--- a/docs/founder-kernel/wiki/stances/contextualize-dont-transform.md
+++ b/docs/founder-kernel/wiki/stances/contextualize-dont-transform.md
@@ -2,37 +2,39 @@
 title: Contextualize, don't transform — map first, evolve second
 pageKind: stance
 status: published
-abstract: Standards adoption that frames itself as transformation gets rejected. Frame it as contextualization — "how is our operating model the same or different from the standard?" — and adoption follows.
+abstract: Change that frames itself as transformation gets rejected. Frame it as contextualization — "how is our operating model the same or different from the target?" — and adoption follows. This is the standards-adoption lesson; in DPF it is also how a new company should be brought onto the platform.
 sources:
   - articles/open-group-2017-managing-business-of-it
 ---
 
 ## The position
 
-When introducing `[[entities/it4it]]`, TOGAF, ArchiMate, `[[entities/csdm]]`, or any other standard to an organisation that already runs, **frame the work as contextualization, not transformation**. The question is: *"How is our current operating model the same or different from the standard?"*
+When introducing anything that reorganises how an organisation already works — a standard like `[[entities/it4it]]`, TOGAF, or `[[entities/csdm]]`, or a *new platform such as DPF itself* — **frame the work as contextualization, not transformation**. The question is: *"How is our current operating model the same or different from this?"*
 
 Adoption follows mapping. Transformation follows adoption. Skip the first step and the second never lands.
 
 ## Why
 
-Executives reach their position by experience with what works. Introducing a "new framework" feels like a threat to that experience — it implies the current operating model is wrong, which implicates the people who built it. Resistance is rational.
+Executives reach their position through experience with what works. A "new framework" — or a new platform — feels like a threat to that experience: it implies the current operating model is wrong, which implicates the people who built it. Resistance is rational.
 
-Contextualization side-steps the threat. It says: your operating model exists; it works; let&#39;s name it in the standard&#39;s vocabulary so we can compare. Where the standard adds value, you adopt it deliberately. Where your current model is already strong, you keep it. The standard becomes a tool, not a verdict.
+Contextualization side-steps the threat. It says: your operating model exists; it works; let&#39;s name it in the target&#39;s vocabulary so we can compare. Where the target adds value, you adopt it deliberately. Where your current model is already strong, you keep it. The target becomes a tool, not a verdict.
 
-This was the lesson that landed in the 2017 IT4IT executive-adoption work. The phrase: *"I like to use the word &#39;contextualize,&#39; and the way I view the challenge is that if I contextualize our current operating model against IT4IT, how are we the same or different?"*
+This was the lesson that landed in the 2017 IT4IT executive-adoption work. The phrase: *"I like to use the word &#39;contextualize,&#39; and the way I view the challenge is that if I contextualize our current operating model against IT4IT, how are we the same or different?"* The same framing has held for every cross-framework adoption I&#39;ve led since.
 
-The same framing applies to every cross-framework adoption I&#39;ve led since.
+## How this applies to DPF onboarding
+
+Bringing a new company onto DPF is exactly this move. Don&#39;t open with "the platform will transform how you run." Open by **mapping their current operating model into DPF&#39;s structure** — their products onto `[[entities/digital-product]]`s, their portfolios onto `[[entities/portfolio]]`s, their existing tools and data against the one platform model — and naming where DPF is the same, where it adds, and where they keep what already works. That mapping becomes the organisation&#39;s own **"what would *we* do?" (WWWD) overlay**: the recorded business stances the platform&#39;s coworkers ground their calls in. Adoption compounds from the map; the transformation — replacing fragmented tools with the cohesive whole — follows once the map is shared, not before.
 
 ## When this applies
 
-- Introducing any standard (IT4IT, TOGAF, CSDM, ArchiMate, BIAN) to an operating organisation.
-- Cross-framework reconciliation work (e.g., mapping existing ITIL processes onto IT4IT value streams).
-- Strategic planning where you want executives to engage with a model they didn&#39;t design.
+- Introducing any standard (IT4IT, TOGAF, CSDM, ArchiMate, BIAN) to an organisation that already runs.
+- Onboarding a new company onto DPF — seed the WWWD overlay from a contextualization pass, don&#39;t mandate a transformation.
+- Strategic planning where you want people to engage with a model they didn&#39;t design.
 
 ## When it doesn&#39;t
 
-- Greenfield. There&#39;s nothing to contextualize *against*; pick a standard and build to it.
-- Compliance-driven adoption where the standard is mandatory. Contextualization is still useful internally, but the framing externally is different.
+- Greenfield. There&#39;s nothing to contextualize *against*; pick the target and build to it.
+- Compliance-driven adoption where the target is mandatory. Contextualization is still useful internally, but the external framing is different.
 
 ## Heuristics derived from this stance
 
@@ -42,6 +44,6 @@ The same framing applies to every cross-framework adoption I&#39;ve led since.
 
 ## See also
 
-- Stance: `[[stances/it4it-is-substrate]]` — the standard most often being contextualized.
+- Stance: `[[stances/it4it-is-substrate]]` — a standard often being contextualized.
 - Entity: `[[entities/it4it]]`
 - Raw source: `[raw-sources/articles/open-group-2017-managing-business-of-it](../../raw-sources/articles/open-group-2017-managing-business-of-it.md)`

--- a/docs/founder-kernel/wiki/stances/dont-integrate-ea-platform.md
+++ b/docs/founder-kernel/wiki/stances/dont-integrate-ea-platform.md
@@ -1,8 +1,8 @@
 ---
-title: Don't integrate a third-party EA platform with ServiceNow — consolidate on one data model
+title: Consolidate on one canonical data model — don't integrate two systems of record
 pageKind: stance
 status: published
-abstract: EA-platform-to-CMDB integrations go through Independent → Honeymoon → Ugly Reckoning. Pick one platform and one canonical data model (CSDM). The cost of consolidation is far less than the cost of the integration failing slowly.
+abstract: When two platforms each claim authority over the same entities, the integration between them goes through Independent → Honeymoon → Ugly Reckoning and fails slowly. Pick one platform and one canonical data model. This is the war-story behind why DPF is one cohesive platform, not an integration hub.
 sources:
   - articles/think-twice-ea-platform-servicenow
   - articles/sibling-portfolios
@@ -10,32 +10,41 @@ sources:
 
 ## The position
 
-Don&#39;t integrate a third-party EA platform with ServiceNow (or with any operational system of record). **Consolidate on one platform with one canonical data model — `[[entities/csdm]]`**. Best-of-breed EA loses on practicality even when it wins on feature depth.
+When two platforms each hold a **system of record for the same entities**, don&#39;t integrate them — **consolidate on one platform with one canonical data model**. Best-of-breed loses on practicality even when it wins on feature depth. The cost of consolidating is almost always far less than the cost of an integration that fails slowly.
 
-> Disclosure: I&#39;m a ServiceNow Senior PM, and this stance aligns with ServiceNow&#39;s commercial interest. It also aligns with 18 years of watching the integration pattern fail at Dell, Troux, HPE, and ServiceNow. The pattern is real; my employer happens to be the consolidation target most often.
+This is the conviction DPF is built on. DPF is deliberately *one cohesive platform over one data model* rather than a hub that wires together best-of-breed point tools — because I have watched the wire-it-together pattern fail the same way for 18 years. The stance below is why the platform has the shape it does.
 
 ## Why
 
-The integration progresses through three predictable phases:
+Any integration between two systems of record for the same entities progresses through three predictable phases:
 
-1. **Independent** — both platforms work fine. EA team owns the EA model; Ops team owns the CMDB. Each is correct on its own terms.
+1. **Independent** — both platforms work fine. Each team owns its own model; each is correct on its own terms.
 2. **Honeymoon** — the integration ships. Everyone reports success. The first ~6 months look great.
 3. **Ugly Reckoning** — scope creep, semantic mismatches, chicken-vs-egg ownership questions, and reconciliation drift compound. The integration becomes "unachievable as originally intended." Data quality collapses. People stop trusting the model.
 
-The failure mode is structural. You have two systems of record claiming authority over the same entities. Reconciliation requires either a third authoritative source (which nobody can afford) or a one-way master-slave relationship (which one team has to accept losing). Both options usually fail to ship; the integration limps along producing increasingly stale views.
+The failure mode is structural, not a matter of effort or tooling. Two systems of record claiming authority over the same entities can only be reconciled by a third authoritative source (which nobody can afford) or a one-way master-slave relationship (which one team has to accept losing). Both usually fail to ship; the integration limps along producing increasingly stale views.
 
-The alternative is consolidation. Pick one platform and accept that you&#39;ll lose 10–20% of the specialist EA feature depth in exchange for never running the integration. The maths almost always favours the consolidation — see `[[heuristics/reuse-the-camera-in-your-pocket]]`.
+The alternative is consolidation: pick one platform, accept losing 10–20% of specialist feature depth, and never run the integration. The maths almost always favours consolidation — see `[[heuristics/reuse-the-camera-in-your-pocket]]`.
+
+### The war-story: EA platforms and ServiceNow
+
+The pattern that named this stance was third-party enterprise-architecture tools integrated with ServiceNow&#39;s CMDB, consolidating instead on one canonical model (`[[entities/csdm]]`).
+
+> Disclosure: I wrote the original argument as a ServiceNow Senior PM, and it aligns with ServiceNow&#39;s commercial interest. It also aligns with 18 years of watching the same integration pattern fail at Dell, Troux, HPE, and ServiceNow. The pattern is real independent of the vendor; ServiceNow simply happened to be the consolidation target most often.
+
+The generalisation is the point: the entities were "applications" and the two records were "the EA tool" and "the CMDB," but the structural trap — two authorities, slow reconciliation failure — is the same wherever it appears, which is why DPF refuses to be the second record.
 
 ## When this applies
 
-- Choosing between a dedicated EA tool and an integrated platform that includes EA capability.
-- Inheriting an existing dedicated-EA-tool deployment with a CMDB integration in trouble.
-- Designing a CSDM rollout where someone proposes "let&#39;s keep the existing EA tool as the source for application data."
+- Choosing between a dedicated best-of-breed tool and an integrated platform that already covers the capability.
+- Inheriting a two-system-of-record integration that&#39;s in trouble.
+- Any DPF adoption where someone proposes keeping an existing external tool as the authoritative source for entities the platform already models.
+- Designing a canonical-data-model rollout (CSDM or DPF&#39;s own model) where a parallel authority is being proposed.
 
-## When it doesn&#39;t
+## When it doesn't
 
-- Pure modeling work that doesn&#39;t need to flow into operations — academic EA exercises, future-state target architectures with no current-state tie-in.
-- Specialist domains the consolidation target genuinely doesn&#39;t cover (some industry-specific EA tools have capability ServiceNow lacks; those *might* justify the integration cost, but the bar is high).
+- Pure modeling work that never flows into operations — academic exercises, future-state target architectures with no current-state tie-in.
+- Specialist domains the consolidation target genuinely doesn&#39;t cover. Those *might* justify the integration cost, but the bar is high — one authority per entity, not two.
 
 ## Heuristics derived from this stance
 
@@ -43,7 +52,7 @@ The alternative is consolidation. Pick one platform and accept that you&#39;ll l
 
 ## See also
 
-- Stance: `[[stances/trust-the-cmdb-or-rebuild-it]]` — why consolidation only works if the CMDB is trustworthy.
+- Stance: `[[stances/trust-the-cmdb-or-rebuild-it]]` — consolidation only works if the surviving record is trustworthy.
 - Entity: `[[entities/csdm]]`
 - Entity: `[[entities/portfolio]]`
 - Related: `[raw-sources/articles/sibling-portfolios](../../raw-sources/articles/sibling-portfolios.md)` — the APM/SPM unification case study.

--- a/docs/founder-kernel/wiki/stances/ea-is-meteorology.md
+++ b/docs/founder-kernel/wiki/stances/ea-is-meteorology.md
@@ -1,50 +1,46 @@
 ---
-title: EA is meteorology — provide forecasts, not raw models
+title: Deliver forecasts, not raw models
 pageKind: stance
 status: published
-abstract: Architects should be like meteorologists — produce forecasts and recommended actions, not exposed models. The deliverable to leadership is the guidance, not the diagram.
+abstract: The deliverable to a decision-maker is a forecast — a recommendation, a confidence level, and the trade-offs being accepted — not the raw model behind it. This began as a stance about enterprise architects reporting to leadership; in DPF it is how every coworker reports to an operator, and it is the founding shape of the decision-governance surface itself.
 sources:
   - articles/possible-futures-enterprise-architecture
 ---
 
 ## The position
 
-Enterprise Architecture&#39;s job is to be a **judgment surface on top of the models**, not the model exhibit. Architects should function like meteorologists: collect the inputs, run the models internally, and produce a forecast that drives the decision. The deliverable to leadership is the recommendation, not the diagram.
+Anyone who holds a model on someone else&#39;s behalf — an enterprise architect, a data team, or a DPF coworker — should be a **judgment surface on top of the model, not the model exhibit**. Function like a meteorologist: collect the inputs, run the model internally, and produce a **forecast** that drives the decision. The deliverable is the recommendation, the confidence, and the trade-offs — not the diagram.
 
-Most IT organisations have little to no business architecture in play, effectively making most current and future technology investment impossible to trace to business outcomes. The fix for that isn&#39;t more diagrams — it&#39;s a *guidance layer* on top of whatever model you have.
+I first made this argument about enterprise architecture: most IT organisations have little to no business architecture in play, which makes technology investment impossible to trace to business outcomes. The fix was never more diagrams — it was a *guidance layer* on top of whatever model you already have. That conviction is why DPF exists in the shape it does.
 
 ## Why
 
-Showing leadership the raw architecture model is showing them the radar imagery instead of the weather forecast. They are not radar specialists. They are decision-makers. They need to know whether to invest, retire, consolidate, hire, or wait — not which functional component sits behind which API in the application portfolio.
+Showing a decision-maker the raw model is showing them the radar imagery instead of the weather forecast. They aren&#39;t radar specialists — they are deciding whether to invest, retire, consolidate, hire, or wait. A weather forecast has four properties, and a good decision output should have all four:
 
-The meteorology analogy carries further. Weather forecasts:
+- It uses a model the consumer doesn&#39;t have to see.
+- It states its confidence explicitly.
+- It updates as conditions change.
+- It is useful even when it turns out wrong, because it made the unknowns legible.
 
-- Use a model the consumer doesn&#39;t see.
-- State confidence levels explicitly.
-- Update as conditions change.
-- Are useful even when they&#39;re wrong, because they made the unknowns legible.
-
-EA should produce outputs with the same properties.
-
-This is also the philosophical frame behind DPF&#39;s wiki kernel. The platform exists to be the guidance layer, not the model exhibit — "what would Mark do?" is a forecast question, not a diagram question.
+This is the founding shape of DPF&#39;s decision governance, not a metaphor bolted on afterward. "What would Mark do?" (WWMD), "what would *we* do?" (WWWD), and "what would someone in this role do?" (WSID) are all **forecast questions**. When a coworker faces a call, the platform surfaces a recommendation with its confidence and the principles that pulled for and against it — the kernel as a forecast engine — rather than handing the operator the raw principle corpus to reason out. An architect who can&#39;t say "I&#39;m 70% confident option B is right, because of X, Y, Z" isn&#39;t forecasting; a coworker that dumps the model instead of the call has made the same mistake.
 
 ## When this applies
 
-- Executive-level architecture reviews.
-- Investment decisions on portfolios or platforms.
-- Any time an architect is asked to "show the model" by someone who isn&#39;t an architect.
+- Any point where a coworker reports a judgment to an operator — the WWMD/WWWD/WSID decision surfaces, a recommended action, a build gate.
+- Executive-level reviews and investment decisions — the original enterprise-architecture setting.
+- Any time someone who isn&#39;t a modeller asks "what should we do?" rather than "what does the model say?"
 
 ## When it doesn&#39;t
 
-- Peer-to-peer architecture discussions where the model *is* the medium.
+- Peer-to-peer review where the model *is* the medium — two architects, or two agents exchanging a structured handoff, need the model itself.
 - Compliance / audit contexts that require the model on record.
-- Engineering hand-off where the next team needs the model to build against.
+- Engineering hand-off where the next team (or the next agent) needs the model to build against.
 
 ## Heuristics derived from this stance
 
-- `[[heuristics/be-a-meteorologist]]`
+- `[[heuristics/be-a-meteorologist]]` — the operational rule.
 
 ## See also
 
-- Parent context: `[[entities/it4it]]` provides the substrate; this stance is about how to deploy the substrate to leadership.
+- Substrate: `[[entities/it4it]]` provides the model; this stance is about how to deliver from it.
 - Raw source: `[raw-sources/articles/possible-futures-enterprise-architecture](../../raw-sources/articles/possible-futures-enterprise-architecture.md)`

--- a/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
+++ b/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
@@ -27,6 +27,8 @@ The technical-debt use case was where this lesson originally landed. The early S
 
 The ROI conversation that lands with executives is tool consolidation: organisations routinely have 300+ tools doing the same IT function (monitoring is the canonical example). You can&#39;t rationalise that without a trusted CMDB to tell you which tool does what. Build the three pillars; the rationalisation funds itself.
 
+The lesson generalises past the CMDB. "CMDB" is the ITSM name for *the record of what you run*; DPF has the same record in its own canonical data model, and its coworkers reason off it. The three pillars are the acceptance test for any such record: if DPF&#39;s model isn&#39;t auto-populated (Ingestion), actually used by the coworkers making calls (Insight), and owned and pruned (Governance), then every WWMD/WWWD/WSID recommendation grounded in it inherits the same lie. A decision surface is only as trustworthy as the record beneath it.
+
 ## When this applies
 
 - Standing up a new CMDB.

--- a/docs/superpowers/plans/2026-07-04-wwmd-corpus-recontextualization-plan.md
+++ b/docs/superpowers/plans/2026-07-04-wwmd-corpus-recontextualization-plan.md
@@ -1,0 +1,83 @@
+# WWMD Corpus Recontextualization — Review, Plan & Phase-1 Execution
+
+**Date:** 2026-07-04
+**Scope:** The founder-kernel "what would Mark do?" (WWMD) corpus under `docs/founder-kernel/wiki/` — genericize the universally-true content, contextualize the rest to DPF, and back-propagate the distilled "vector" the newer principle work already introduced. WWWD (per-org business overlay, seeded at install/onboarding) is out of scope for this pass but shares the method — see §7.
+**Status:** Phase 1 + high-value slices of Phases 2–3 **executed in this PR** (§0). Remaining phases planned, not yet built.
+
+---
+
+## 0. Execution status (this PR)
+
+Lands the highest-value, lowest-risk recontextualizations and records the review that scopes the rest. **No `principle` page was edited, so the golden-decisions gate does not apply** (it triggers only on `principleDimensionVector` changes).
+
+**Landed:**
+
+| Page | Kind | Disposition applied |
+|---|---|---|
+| `stances/ea-is-meteorology` | stance | **Genericized** → "Deliver forecasts, not raw models." Reframed as the founding shape of DPF decision governance: WWMD/WWWD/WSID are forecast questions; a coworker that dumps the model instead of a scored recommendation-with-confidence made the architect's mistake. |
+| `heuristics/be-a-meteorologist` | heuristic | Generalized to any coworker reporting a judgment to an operator. |
+| `stances/contextualize-dont-transform` | stance | **Genericized** + "How this applies to DPF onboarding": onboarding = map the new company's operating model into DPF → that map becomes the org's WWWD overlay. |
+| `heuristics/contextualize-before-transforming` | heuristic | Extended to platform onboarding / WWWD-overlay seeding. |
+| `stances/dont-integrate-ea-platform` | stance | **Generalized** off ServiceNow: retitled "Consolidate on one canonical data model — don't integrate two systems of record." ServiceNow/CMDB kept as the *war-story* (disclosure preserved); DPF one-platform-model framing added. |
+| `stances/trust-the-cmdb-or-rebuild-it` | stance | Surgical DPF tie: "CMDB" = the record of what you run; DPF's canonical data model is the same record, and every WWMD/WWWD/WSID recommendation is only as trustworthy as it. |
+| `wiki/index.md` | index | Updated one-line descriptions for the three changed stances. |
+| `manifest.json` | — | `kernelVersion` 0.4.0 → 0.4.1 (content batch; `pageCount` unchanged). |
+
+**Reviewed and deliberately left unchanged** (already principle-level and DPF-aligned — war-stories, not ServiceNow-framed):
+
+- `stances/digital-product-is-the-unit-of-organization` — already the DPF primitive; names "agents and AI co-workers." The model the rest should look like.
+- `stances/persistent-product-teams-over-projects` — universal org/funding lesson; DPROM-grounded.
+- `stances/it4it-is-substrate` — framework-integration principle; no ServiceNow.
+
+**Conventions honoured:** slugs unchanged (inbound `[[wikilinks]]` intact); backtick-wrapped `` `[[slug]]` `` form kept; apostrophes HTML-encoded (`&#39;`) to match the corpus; `raw-sources/` untouched; every referenced wikilink and source target verified to exist.
+
+---
+
+## 1. What the corpus is
+
+The founder kernel (`docs/founder-kernel/`) is the wisdom layer that ships with DPF. It seeds into `WikiPage` rows and renders as the "Governing material" drill-in on the reframed `/wiki` Decision Governance page. Authoring contract: [SCHEMA.md](../../founder-kernel/SCHEMA.md) + [AUTHORING.md](../../founder-kernel/AUTHORING.md).
+
+Two populations mixed together: ~85 DPF-native engineering principles (**leave alone**) and Mark's EA/ServiceNow thought-leadership — 7 stances + 7 heuristics + 5 entities + 2 derived principles (**in scope**).
+
+## 2. The core problem (confirmed)
+
+A subset teaches genuine wisdom in ServiceNow/EA-consultant terms (employer disclosure, CMDB/CSDM/IT4IT as the frame not the example, audience = "executives in an EA engagement"). **Review finding:** less pervasive than the screenshot suggested — most stances already demote ServiceNow to war-story. The genuinely SN/EA-narrow pages were exactly two (`ea-is-meteorology`, `dont-integrate-ea-platform`), both fixed here, plus CMDB-flavoured `trust-the-cmdb` (surgically tied).
+
+## 3. The distilled "vector" — method already proven
+
+> **Product-centric, one cohesive data model, and — in the age of agentic AI — the deliverable is guidance and action on the *whole*, not reports, diagrams, or integrations between silos.**
+
+Two principle pages already carry this and are the templates: [optimize-for-the-whole.md](../../founder-kernel/wiki/principles/optimize-for-the-whole.md) (genericized form) and [native-cohesion-over-interfacing.md](../../founder-kernel/wiki/principles/native-cohesion-over-interfacing.md) (contextualized form). The rest of the EA content had not been brought to that bar; this pass starts closing it.
+
+## 4. Method: genericize vs contextualize (one call per page)
+
+- **GENERICIZE** — lesson is universally true; lift it out of the ServiceNow story, demote SN to one example.
+- **CONTEXTUALIZE** — lesson lands hardest as a concrete DPF instantiation; rewrite the example in DPF terms, keep the SN origin as cited provenance.
+
+**Hard constraints:** don't touch `raw-sources/` (immutable receipts; SN origin stays cited); kernel pages are PR-only; preserve every `[[wikilink]]` (dangling = publish-blocking lint); only **principle** edits trip the golden-decisions gate (none here).
+
+## 5. Per-page disposition — see §0 for what landed; follow-ups below
+
+**Stances:** `trust-the-cmdb` deeper pass optional; `it4it-is-substrate` optional trim; the other four done or already-aligned.
+**Heuristics (follow-up):** `reuse-the-camera-in-your-pocket`, `find-at-least-one-champion` (re-scope to human/onboarding), `pitch-simple-adjust-per-audience`, `auto-populate-or-its-wrong`, `model-what-naturally-happens`.
+**Entities (follow-up):** `csdm` → reframe as "DPF's canonical data model (CSDM-lineage)"; reconcile with `entities/ea-reference-model`.
+**Principles (follow-up, 2 in scope):** `one-data-model` (contextualize SN *examples*; vector unchanged but golden-decisions gate still runs since it loads the live corpus) and any principle the Phase-4 sweep surfaces.
+
+## 6. Execution (phased)
+
+- **Phase 1 — exemplar rewrites. DONE** (`ea-is-meteorology`+`be-a-meteorologist`, `contextualize-dont-transform`+`contextualize-before-transforming`).
+- **Phase 2 — data-spine cluster.** Partially done (`trust-the-cmdb` tie + `dont-integrate-ea-platform` generalize). Remaining: `csdm`, `one-data-model` (run golden-decisions gate), `model-what-naturally-happens`, `auto-populate-or-its-wrong`, `reuse-the-camera-in-your-pocket`.
+- **Phase 3 — operating-model + adoption heuristics.** `it4it-is-substrate` trim (optional); adoption heuristics re-scoped.
+- **Phase 4 — principles ServiceNow sweep.** `grep -il servicenow wiki/principles/*.md`; recontextualize SN-specific examples (prose-only, but gate runs per AUTHORING §8B).
+- **Phase 5 — rebuild & verify per batch.** seed → build-kernel-embeddings (deploy-time) → manifest bump → `wiki_lint` (clear dangling/orphan/stale) → golden-decisions gate **only if a principle changed** → coworker-retrieval spot-check.
+- **Phase 6 — PR per phase**, DCO-signed, babysat to green. (This PR = Phase 1 + high-value Phase 2/3 slices.)
+
+## 7. WWWD parallel (noted, not this pass)
+
+Same treatment for the org-overlay layer (`WikiPage` rows with `organizationId != null`, authored via the "How your business decides" surface — empty on a fresh install). The `contextualize-dont-transform` rewrite here is the bridge: onboarding *is* "map the new company's operating model into DPF before transforming it," and that map *becomes* the org's WWWD overlay. Follow-on: seed-at-onboarding starter business stances + an elicitation flow (`dpf-elicit-tacit-knowledge`).
+
+## 8. Open items
+
+- **Voice:** stances stay first-person "Mark" (WWMD voice); principles/heuristics neutral. Applied. SCHEMA §8 agrees.
+- **`csdm`/`ea-reference-model` reconciliation** (Phase 2).
+- **Principle count:** confirm portal-shown extras are DPF-engineering (out of scope) — Phase-4 sweep.


### PR DESCRIPTION
## What & why

The founder-kernel **WWMD** ("what would Mark do?") corpus — the stances/heuristics/principles that render as *Governing material* on `/wiki` and ground every coworker's decisions — taught genuine wisdom in **ServiceNow/EA-consultant terms**. This PR recontextualizes the genuinely ServiceNow/EA-narrow pages to DPF's decision-governance frame, while keeping each page's provenance honest (raw-sources untouched, ServiceNow retained as a *cited war-story*, first-person "Mark" voice preserved).

**Review finding:** the problem was less pervasive than it looked. Most stances already demote ServiceNow to a war-story and are principle-level. The genuinely SN/EA-narrow pages were **two** — both fixed here — plus one CMDB-flavoured page tied surgically. Three stances were reviewed and **deliberately left unchanged** because they're already DPF-aligned.

## Landed

*(No `principle` page edited, so the golden-decisions gate does not apply.)*

- `stances/ea-is-meteorology` — **genericized** to "Deliver forecasts, not raw models"; WWMD/WWWD/WSID reframed as forecast questions a coworker answers for an operator.
- `stances/dont-integrate-ea-platform` — **generalized off ServiceNow** to "Consolidate on one canonical data model"; SN/CMDB demoted to the war-story; DPF one-platform-model framing added.
- `stances/contextualize-dont-transform` — added **"How this applies to DPF onboarding"**: mapping a new company's operating model into DPF *becomes the org's WWWD overlay*.
- `stances/trust-the-cmdb-or-rebuild-it` — surgical DPF tie (CMDB = the record of what you run).
- `heuristics/be-a-meteorologist`, `heuristics/contextualize-before-transforming` — generalized to the coworker-to-operator / onboarding case.
- `wiki/index.md`, `manifest.json` (kernelVersion 0.4.0 to 0.4.1).

**Left unchanged (already principle-level, zero ServiceNow):** digital-product-is-the-unit-of-organization, persistent-product-teams-over-projects, it4it-is-substrate.

## Safety / conventions

Slugs unchanged (inbound `[[wikilinks]]` intact, no dangling xrefs — self-checked); backtick-wrapped `[[slug]]` + `&#39;` encoding matched; `raw-sources/` untouched; every referenced target verified. Embeddings regen is a deploy-time step, not a CI gate.

## Scope of the rest

The [plan doc](docs/superpowers/plans/2026-07-04-wwmd-corpus-recontextualization-plan.md) phases the remainder: the CSDM/one-data-model data-spine cluster (golden-decisions gate applies there), the adoption heuristics, a principles ServiceNow sweep, and the **WWWD parallel** (same treatment for a company's own overlay, seeded at onboarding) that the operator flagged for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)