### PR TITLE
feat(finance): procurement two-way match — PO ↔ bill (EP-SAP-PARITY, MM invoice verification)

### DIFF
--- a/apps/web/lib/actions/ap.ts
+++ b/apps/web/lib/actions/ap.ts
@@ -9,6 +9,7 @@ import { getOrgIdentity } from "@/lib/org-identity";
 import { resolveAppBaseUrl } from "@/lib/app-url";
 import { recordPayment } from "@/lib/actions/finance";
 import { postBillFinalized } from "@/lib/finance/ledger-service";
+import { getBillPoMatch } from "@/lib/finance/po-match-service";
 import { PAYMENT_METHODS } from "@/lib/finance/finance-validation";
 import type { CreateSupplierInput, CreateBillInput, CreatePOInput, CreatePaymentRunInput } from "@/lib/ap-validation";
 
@@ -174,7 +175,7 @@ export async function createBill(input: CreateBillInput) {
 export async function getBill(id: string) {
   await requireManageFinance();
 
-  return prisma.bill.findUnique({
+  const bill = await prisma.bill.findUnique({
     where: { id },
     include: {
       lineItems: { orderBy: { sortOrder: "asc" } },
@@ -191,6 +192,10 @@ export async function getBill(id: string) {
       },
     },
   });
+  if (!bill) return null;
+  // Two-way match against the linked purchase order (SAP MM invoice verification).
+  const poMatch = await getBillPoMatch(id);
+  return { ...bill, poMatch };
 }
 
 // ─── recordBillPayment ──────────────────────────────────────────────────────────
@@ -296,6 +301,14 @@ export async function submitBillForApproval(billId: string): Promise<void> {
   });
 
   if (rules.length === 0) {
+    // AP integrity (MM two-way match): a bill that exceeds its purchase order beyond
+    // tolerance is flagged. Non-blocking for now — with no approval rule the bill
+    // still auto-approves — but the variance is surfaced on the bill (getBill.poMatch)
+    // and logged, so an over-order bill can't pass silently.
+    const poMatch = await getBillPoMatch(billId);
+    if (poMatch.hasPurchaseOrder && poMatch.match.status === "over") {
+      console.warn(`[ap] bill exceeds its purchase order beyond tolerance: ${poMatch.match.message}`);
+    }
     await prisma.bill.update({
       where: { id: billId },
       data: { status: "approved" },

--- a/apps/web/lib/finance/po-match-service.ts
+++ b/apps/web/lib/finance/po-match-service.ts
@@ -1,0 +1,53 @@
+// lib/finance/po-match-service.ts — DB read for PO ↔ bill matching (SAP MM verification)
+//
+// Loads a bill and the purchase order it was raised from and runs the pure two-way
+// match (./po-match). Read-only; the accounting decision (flag / require approval)
+// stays with the caller.
+
+import { prisma } from "@dpf/db";
+import {
+  matchBillToPurchaseOrder,
+  type BillPoMatch,
+  type MatchTolerance,
+} from "./po-match";
+
+export type BillMatchResult =
+  | { hasPurchaseOrder: false }
+  | { hasPurchaseOrder: true; poNumber: string; match: BillPoMatch };
+
+/**
+ * Match a bill against its linked purchase order. Returns `hasPurchaseOrder: false`
+ * when the bill was not raised from a PO (nothing to verify against).
+ */
+export async function getBillPoMatch(
+  billId: string,
+  tolerance?: MatchTolerance,
+): Promise<BillMatchResult> {
+  const bill = await prisma.bill.findUnique({
+    where: { id: billId },
+    select: {
+      subtotal: true,
+      taxAmount: true,
+      totalAmount: true,
+      purchaseOrder: {
+        select: { poNumber: true, subtotal: true, taxAmount: true, totalAmount: true },
+      },
+    },
+  });
+  if (!bill || !bill.purchaseOrder) return { hasPurchaseOrder: false };
+
+  const match = matchBillToPurchaseOrder(
+    {
+      subtotal: Number(bill.subtotal),
+      taxAmount: Number(bill.taxAmount),
+      totalAmount: Number(bill.totalAmount),
+    },
+    {
+      subtotal: Number(bill.purchaseOrder.subtotal),
+      taxAmount: Number(bill.purchaseOrder.taxAmount),
+      totalAmount: Number(bill.purchaseOrder.totalAmount),
+    },
+    tolerance,
+  );
+  return { hasPurchaseOrder: true, poNumber: bill.purchaseOrder.poNumber, match };
+}

--- a/apps/web/lib/finance/po-match.test.ts
+++ b/apps/web/lib/finance/po-match.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchBillToPurchaseOrder,
+  DEFAULT_MATCH_TOLERANCE,
+  type MatchDocument,
+} from "./po-match";
+
+const po: MatchDocument = { subtotal: 1000, taxAmount: 200, totalAmount: 1200 };
+
+describe("matchBillToPurchaseOrder", () => {
+  it("matches an identical bill", () => {
+    const m = matchBillToPurchaseOrder({ subtotal: 1000, taxAmount: 200, totalAmount: 1200 }, po);
+    expect(m.matched).toBe(true);
+    expect(m.status).toBe("matched");
+    expect(m.variance).toBe(0);
+  });
+
+  it("matches within the percentage tolerance (2% of 1200 = 24)", () => {
+    const m = matchBillToPurchaseOrder({ subtotal: 1020, taxAmount: 200, totalAmount: 1220 }, po);
+    expect(m.matched).toBe(true); // +20 ≤ 24
+  });
+
+  it("flags an over-billing beyond tolerance as 'over'", () => {
+    const m = matchBillToPurchaseOrder({ subtotal: 1100, taxAmount: 220, totalAmount: 1320 }, po);
+    expect(m.matched).toBe(false);
+    expect(m.status).toBe("over"); // +120, the cash-protecting case
+    expect(m.variance).toBe(120);
+    expect(m.message).toMatch(/exceeds the purchase order/i);
+  });
+
+  it("flags an under-billing beyond tolerance as 'under'", () => {
+    const m = matchBillToPurchaseOrder({ subtotal: 800, taxAmount: 160, totalAmount: 960 }, po);
+    expect(m.matched).toBe(false);
+    expect(m.status).toBe("under");
+    expect(m.variance).toBe(-240);
+  });
+
+  it("applies the absolute tolerance when it is larger than the percentage", () => {
+    const smallPo: MatchDocument = { subtotal: 10, taxAmount: 0, totalAmount: 10 };
+    // 2% of 10 = 0.20, but absolute floor is 1 → a 1.00 variance still matches.
+    const m = matchBillToPurchaseOrder({ subtotal: 11, taxAmount: 0, totalAmount: 11 }, smallPo);
+    expect(m.toleranceAmount).toBe(1);
+    expect(m.matched).toBe(true);
+  });
+
+  it("respects a custom tolerance", () => {
+    const strict = matchBillToPurchaseOrder(
+      { subtotal: 1010, taxAmount: 200, totalAmount: 1210 },
+      po,
+      { absolute: 0, percent: 0 },
+    );
+    expect(strict.matched).toBe(false); // zero tolerance, +10 fails
+    expect(strict.status).toBe("over");
+  });
+
+  it("computes a variance percentage against the PO total", () => {
+    const m = matchBillToPurchaseOrder({ subtotal: 1200, taxAmount: 240, totalAmount: 1440 }, po);
+    expect(m.variancePct).toBe(20); // 240 / 1200
+  });
+
+  it("exposes a default tolerance of 1 / 2%", () => {
+    expect(DEFAULT_MATCH_TOLERANCE).toEqual({ absolute: 1, percent: 2 });
+  });
+});

--- a/apps/web/lib/finance/po-match.ts
+++ b/apps/web/lib/finance/po-match.ts
@@ -1,0 +1,82 @@
+// lib/finance/po-match.ts — purchase-order ↔ bill matching (SAP MM invoice verification)
+//
+// The AP-integrity control SAP calls invoice verification: before a supplier bill is
+// paid, check it against the purchase order it was raised from, so you never pay more
+// than you agreed to buy. DPF has PurchaseOrder + Bill (Bill.purchaseOrderId links
+// them) but no goods-receipt record, so this is a **two-way match** (PO ↔ Bill) with a
+// tolerance; a full three-way match (adding goods receipt) is a follow-up once a
+// GoodsReceipt model exists.
+//
+// Pure and DB-free so the whole comparison is unit-testable; the DB read that loads a
+// bill and its PO lives in apps/web/lib/finance/po-match-service.ts.
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** How far a bill may diverge from its PO before it needs review. */
+export type MatchTolerance = {
+  /** Absolute currency amount always allowed (covers rounding, small fees). */
+  absolute: number;
+  /** Percentage of the PO total also allowed; the larger of the two applies. */
+  percent: number;
+};
+
+/** Default: the greater of 1 currency unit or 2% of the PO total. */
+export const DEFAULT_MATCH_TOLERANCE: MatchTolerance = { absolute: 1, percent: 2 };
+
+/** The minimal document shape the match needs (a bill or a purchase order). */
+export type MatchDocument = {
+  subtotal: number;
+  taxAmount: number;
+  totalAmount: number;
+};
+
+export type MatchStatus = "matched" | "over" | "under";
+
+export type BillPoMatch = {
+  /** True when the bill is within tolerance of the PO. */
+  matched: boolean;
+  status: MatchStatus;
+  poTotal: number;
+  billTotal: number;
+  /** bill − PO. Positive means the supplier billed MORE than was ordered. */
+  variance: number;
+  variancePct: number;
+  /** The absolute tolerance actually applied (the larger of absolute / percent). */
+  toleranceAmount: number;
+  /** Plain-language verdict for the approver / finance coworker. */
+  message: string;
+};
+
+/**
+ * Two-way match a supplier bill against its purchase order on the header total.
+ * `matched` is true when |bill − PO| is within tolerance (the greater of the
+ * absolute allowance and `percent`% of the PO). An over-tolerance bill is flagged
+ * `over` (billed more than ordered — the case that protects cash) or `under`.
+ */
+export function matchBillToPurchaseOrder(
+  bill: MatchDocument,
+  po: MatchDocument,
+  tolerance: MatchTolerance = DEFAULT_MATCH_TOLERANCE,
+): BillPoMatch {
+  const billTotal = round2(bill.totalAmount);
+  const poTotal = round2(po.totalAmount);
+  const variance = round2(billTotal - poTotal);
+  const variancePct =
+    poTotal !== 0 ? round2((variance / Math.abs(poTotal)) * 100) : billTotal === 0 ? 0 : 100;
+
+  const toleranceAmount = round2(
+    Math.max(Math.max(tolerance.absolute, 0), (Math.abs(poTotal) * Math.max(tolerance.percent, 0)) / 100),
+  );
+  const matched = Math.abs(variance) <= toleranceAmount + 1e-9;
+  const status: MatchStatus = matched ? "matched" : variance > 0 ? "over" : "under";
+
+  const message = matched
+    ? `Bill matches the purchase order within tolerance (variance ${variance}).`
+    : status === "over"
+      ? `Bill exceeds the purchase order by ${round2(Math.abs(variance))} (${round2(Math.abs(variancePct))}%) — review before paying.`
+      : `Bill is ${round2(Math.abs(variance))} (${round2(Math.abs(variancePct))}%) under the purchase order.`;
+
+  return { matched, status, poTotal, billTotal, variance, variancePct, toleranceAmount, message };
+}


### PR DESCRIPTION
Closes the **MM invoice-verification** gap: a supplier bill is checked against the purchase order it was raised from, so you never pay more than you ordered. Two-way match (PO ↔ Bill); no schema change.

## What it adds
- **`po-match.ts` (pure, tested):** `matchBillToPurchaseOrder` compares header totals → `matched` / `over` / `under` with variance, %, and the tolerance applied (greater of an absolute allowance or % of the PO; default 1 / 2%). The `over` case (billed more than ordered) protects cash.
- **`po-match-service.ts`:** `getBillPoMatch(billId)` loads the bill + its PO and runs the pure match; `hasPurchaseOrder: false` when the bill wasn't raised from a PO.
- **`ap.ts` wiring:** `getBill` returns the match (bill detail surfaces the variance); `submitBillForApproval` flags an over-tolerance bill on the auto-approve path.

**Non-blocking** for now — hard-block + a flagged status + a manual-approve path is a documented follow-up (needs a new status value). **Three-way match** (goods receipt) is a follow-up once a `GoodsReceipt` model exists.

## Verification
- `vitest run lib/finance/po-match.test.ts` — **8/8 pass**.
- Standalone strict `tsc` on `po-match.ts` — clean.
- The Prisma read + `ap.ts` wiring are field-exact and CI-gated per AGENTS.md §5.

Advances **EP-SAP-PARITY** (MM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Process-Spine-Decision: MM two-way match is documented in this PR body and in po-match.ts/po-match-service.ts headers; the shared spec section was dropped to avoid a serial merge-conflict cascade across the parallel EP-SAP-PARITY gap PRs.
