### PR TITLE
feat(hr): payroll gross-to-net engine (EP-SAP-PARITY, HCM payroll)

### DIFF
--- a/apps/web/lib/hr/payroll.test.ts
+++ b/apps/web/lib/hr/payroll.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { computePayslip, flatRateStatutory } from "./payroll";
+
+// 20% income tax above a 1000 allowance; 10% employee / 13.8% employer NI above 800.
+const statutory = flatRateStatutory({
+  taxFreeAllowance: 1000,
+  incomeTaxRate: 0.2,
+  employeeNIRate: 0.1,
+  employerNIRate: 0.138,
+  niThreshold: 800,
+});
+
+describe("computePayslip", () => {
+  it("computes gross → net for a salaried employee", () => {
+    const slip = computePayslip({ baseSalary: 3000, statutory });
+    expect(slip.grossPay).toBe(3000);
+    expect(slip.taxablePay).toBe(3000);
+    // income tax = (3000 − 1000) × 20% = 400; employee NI = (3000 − 800) × 10% = 220
+    const tax = slip.employeeDeductions.find((d) => d.code === "TAX")!;
+    const ni = slip.employeeDeductions.find((d) => d.code === "NI")!;
+    expect(tax.amount).toBe(400);
+    expect(ni.amount).toBe(220);
+    expect(slip.netPay).toBe(3000 - 400 - 220); // 2380
+  });
+
+  it("computes hourly + overtime earnings", () => {
+    const slip = computePayslip({
+      hoursWorked: 100,
+      hourlyRate: 20,
+      overtimeHours: 10,
+      overtimeRate: 30,
+      statutory,
+    });
+    // 100×20 + 10×30 = 2300
+    expect(slip.grossPay).toBe(2300);
+    expect(slip.earnings.find((e) => e.code === "HOURS")!.amount).toBe(2000);
+    expect(slip.earnings.find((e) => e.code === "OT")!.amount).toBe(300);
+  });
+
+  it("applies pre-tax deductions to taxable pay but not to gross", () => {
+    const slip = computePayslip({
+      baseSalary: 3000,
+      preTaxDeductions: [{ code: "PEN", label: "Pension", amount: 200 }],
+      statutory,
+    });
+    expect(slip.grossPay).toBe(3000);
+    expect(slip.taxablePay).toBe(2800); // 3000 − 200
+    // income tax = (2800 − 1000) × 20% = 360
+    expect(slip.employeeDeductions.find((d) => d.code === "TAX")!.amount).toBe(360);
+    // net = 3000 − 200(pension) − 360(tax) − 220(NI) = 2220
+    expect(slip.netPay).toBe(2220);
+  });
+
+  it("subtracts post-tax deductions from net", () => {
+    const slip = computePayslip({
+      baseSalary: 3000,
+      postTaxDeductions: [{ code: "LOAN", label: "Loan repayment", amount: 100 }],
+      statutory,
+    });
+    expect(slip.netPay).toBe(3000 - 400 - 220 - 100); // 2280
+  });
+
+  it("computes employer cost = gross + employer NI", () => {
+    const slip = computePayslip({ baseSalary: 3000, statutory });
+    const erni = slip.employerCosts.find((c) => c.code === "ERNI")!;
+    expect(erni.amount).toBe(round2((3000 - 800) * 0.138)); // 303.6
+    expect(slip.totalEmployerCost).toBe(round2(3000 + erni.amount));
+  });
+
+  it("never pays negative net when deductions exceed gross", () => {
+    const slip = computePayslip({
+      baseSalary: 500,
+      postTaxDeductions: [{ code: "LOAN", label: "Big loan", amount: 1000 }],
+      statutory,
+    });
+    expect(slip.netPay).toBe(0);
+  });
+
+  it("zero earnings yield an all-zero slip", () => {
+    const slip = computePayslip({ statutory });
+    expect(slip.grossPay).toBe(0);
+    expect(slip.netPay).toBe(0);
+    expect(slip.totalEmployerCost).toBe(0);
+  });
+});
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/apps/web/lib/hr/payroll.ts
+++ b/apps/web/lib/hr/payroll.ts
@@ -1,0 +1,160 @@
+// lib/hr/payroll.ts — gross-to-net payroll engine (SAP HCM / SuccessFactors payroll)
+//
+// The substantive, hard part of payroll: turning what someone earned into what lands
+// in their account, and what it costs the employer. Pure and DB-free so every rule is
+// unit-testable; the PayRun / Payslip persistence and the GL posting
+// (Dr Wages Expense / Cr Net Pay Payable / Cr Tax Payable …) are separate follow-ups.
+//
+// STATUTORY TAX IS PLUGGABLE, NOT HARDCODED. Real income-tax / national-insurance /
+// social-security rules are jurisdiction-specific and change yearly, so this engine
+// takes a `StatutoryDeductionFn` rather than baking in one country's bands — the same
+// stance as the ERP-sync seam elsewhere in finance. `flatRateStatutory` is a simple
+// default for demos/tests; a production jurisdiction plugs in its own function.
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** A named money line on a payslip (an earning, a deduction, or an employer cost). */
+export type PayComponent = { code: string; label: string; amount: number };
+
+export type StatutoryContext = {
+  /** Total gross earnings for the period. */
+  gross: number;
+  /** Gross less pre-tax deductions — the base statutory tax is charged on. */
+  taxable: number;
+};
+
+export type StatutoryResult = {
+  /** Employee income tax / PAYE. */
+  incomeTax: number;
+  /** Employee national insurance / social-security contribution. */
+  employeeNI: number;
+  /** Employer national insurance / social-security contribution (an employer cost). */
+  employerNI: number;
+};
+
+/** Pluggable statutory-deduction calculation — supply your jurisdiction's rules. */
+export type StatutoryDeductionFn = (ctx: StatutoryContext) => StatutoryResult;
+
+export type PayrollInput = {
+  /** Fixed salary for the period (for salaried staff). */
+  baseSalary?: number;
+  /** Hours × rate (for hourly staff) — e.g. from approved timesheets. */
+  hoursWorked?: number;
+  hourlyRate?: number;
+  /** Overtime hours × the overtime hourly rate. */
+  overtimeHours?: number;
+  overtimeRate?: number;
+  /** Bonuses, allowances, etc. */
+  additions?: PayComponent[];
+  /** Pre-tax deductions (reduce taxable pay) — e.g. salary-sacrifice pension. */
+  preTaxDeductions?: PayComponent[];
+  /** Post-tax deductions — e.g. a loan repayment. */
+  postTaxDeductions?: PayComponent[];
+  statutory: StatutoryDeductionFn;
+};
+
+export type Payslip = {
+  grossPay: number;
+  taxablePay: number;
+  earnings: PayComponent[];
+  /** Everything taken off the employee: statutory + post-tax + pre-tax. */
+  employeeDeductions: PayComponent[];
+  netPay: number;
+  /** Costs the employer bears on top of gross (employer NI, …). */
+  employerCosts: PayComponent[];
+  /** Gross + employer costs — the true cost of the employee for the period. */
+  totalEmployerCost: number;
+};
+
+function sum(components: PayComponent[]): number {
+  return round2(components.reduce((t, c) => t + c.amount, 0));
+}
+
+/**
+ * Compute a payslip from earnings and a pluggable statutory calculation:
+ *   gross      = base + hours×rate + overtime + additions
+ *   taxable    = gross − pre-tax deductions
+ *   net        = gross − pre-tax − income tax − employee NI − post-tax
+ *   total cost = gross + employer NI (and any other employer costs)
+ *
+ * Net pay can never be negative — if deductions exceed gross it is floored at 0 (the
+ * shortfall is a payroll error the caller should surface, not a negative payment).
+ */
+export function computePayslip(input: PayrollInput): Payslip {
+  const earnings: PayComponent[] = [];
+  if (input.baseSalary) earnings.push({ code: "BASE", label: "Base salary", amount: round2(input.baseSalary) });
+  if (input.hoursWorked && input.hourlyRate) {
+    earnings.push({ code: "HOURS", label: "Hours worked", amount: round2(input.hoursWorked * input.hourlyRate) });
+  }
+  if (input.overtimeHours && input.overtimeRate) {
+    earnings.push({ code: "OT", label: "Overtime", amount: round2(input.overtimeHours * input.overtimeRate) });
+  }
+  for (const a of input.additions ?? []) earnings.push({ ...a, amount: round2(a.amount) });
+
+  const grossPay = sum(earnings);
+  const preTax = input.preTaxDeductions ?? [];
+  const preTaxTotal = sum(preTax);
+  const taxablePay = round2(Math.max(grossPay - preTaxTotal, 0));
+
+  const stat = input.statutory({ gross: grossPay, taxable: taxablePay });
+  const incomeTax = round2(Math.max(stat.incomeTax, 0));
+  const employeeNI = round2(Math.max(stat.employeeNI, 0));
+  const employerNI = round2(Math.max(stat.employerNI, 0));
+  const postTax = input.postTaxDeductions ?? [];
+
+  const employeeDeductions: PayComponent[] = [
+    ...preTax.map((d) => ({ ...d, amount: round2(d.amount) })),
+    { code: "TAX", label: "Income tax", amount: incomeTax },
+    { code: "NI", label: "National insurance", amount: employeeNI },
+    ...postTax.map((d) => ({ ...d, amount: round2(d.amount) })),
+  ];
+
+  const netPay = round2(Math.max(grossPay - sum(employeeDeductions), 0));
+  const employerCosts: PayComponent[] = [{ code: "ERNI", label: "Employer NI", amount: employerNI }];
+  const totalEmployerCost = round2(grossPay + sum(employerCosts));
+
+  return {
+    grossPay,
+    taxablePay,
+    earnings,
+    employeeDeductions,
+    netPay,
+    employerCosts,
+    totalEmployerCost,
+  };
+}
+
+/** Parameters for the simple default statutory calculation (demo / SMB / tests). */
+export type FlatRateStatutoryParams = {
+  /** Tax-free allowance per period before income tax applies. */
+  taxFreeAllowance?: number;
+  /** Income-tax rate on taxable pay above the allowance (e.g. 0.2 = 20%). */
+  incomeTaxRate: number;
+  /** Employee NI rate on gross above the NI threshold. */
+  employeeNIRate: number;
+  /** Employer NI rate on gross above the NI threshold. */
+  employerNIRate: number;
+  /** Gross per period below which no NI is due. */
+  niThreshold?: number;
+};
+
+/**
+ * A simple threshold-and-flat-rate statutory calculation for demos, tests and SMB
+ * defaults. NOT a substitute for a real jurisdiction engine — production installs
+ * plug in their country's bands via a `StatutoryDeductionFn`.
+ */
+export function flatRateStatutory(params: FlatRateStatutoryParams): StatutoryDeductionFn {
+  const allowance = params.taxFreeAllowance ?? 0;
+  const niThreshold = params.niThreshold ?? 0;
+  return ({ gross, taxable }) => {
+    const taxBase = Math.max(taxable - allowance, 0);
+    const niBase = Math.max(gross - niThreshold, 0);
+    return {
+      incomeTax: round2(taxBase * params.incomeTaxRate),
+      employeeNI: round2(niBase * params.employeeNIRate),
+      employerNI: round2(niBase * params.employerNIRate),
+    };
+  };
+}


### PR DESCRIPTION
The substantive, hard part of payroll — turning earnings into net pay and employer cost — shipped as a pure, fully-tested engine. The `PayRun`/`Payslip` persistence, timesheet feed, payroll→GL posting and run UI are filed follow-ups under EP-SAP-PARITY.

## What it adds
- **`computePayslip(input)` (`hr/payroll.ts`, pure, tested):** `gross = base + hours×rate + overtime + additions`; `taxable = gross − pre-tax`; `net = gross − pre-tax − income tax − employee NI − post-tax`; employer cost = `gross + employer NI`. Net floored at 0 (a shortfall is a payroll error, never a negative payment).
- **Statutory tax is pluggable, not hardcoded.** The engine takes a `StatutoryDeductionFn` — real income-tax/NI/social-security rules are jurisdiction-specific and change yearly. `flatRateStatutory` is a simple threshold-and-rate default for demos/SMB/tests; a production install plugs in its jurisdiction (same stance as the ERP-sync seam).

## Verification
- `vitest run lib/hr/payroll.test.ts` — **7/7 pass** (salaried; hourly + overtime; pre-tax; post-tax; employer cost; non-negative net; zero).
- Standalone strict `tsc` on `payroll.ts` — clean.

Advances **EP-SAP-PARITY** (HCM payroll — the calculation core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Process-Spine-Decision: the payroll gross-to-net engine is documented in this PR body and in hr/payroll.ts headers; the shared spec section was dropped to avoid a serial merge-conflict cascade across the parallel EP-SAP-PARITY gap PRs.
