### PR TITLE
feat(inventory): weighted-average stock valuation (EP-SAP-PARITY, WM/MM-IM)

### DIFF
--- a/apps/web/lib/inventory/stock.test.ts
+++ b/apps/web/lib/inventory/stock.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { applyStockMovement, type StockState } from "./stock";
+
+const empty: StockState = { quantity: 0, unitCost: 0 };
+
+describe("applyStockMovement — weighted average", () => {
+  it("a receipt into empty stock sets qty and unit cost", () => {
+    const r = applyStockMovement(empty, { type: "receipt", quantity: 10, unitCost: 5 });
+    expect(r.state).toEqual({ quantity: 10, unitCost: 5 });
+    expect(r.valueDelta).toBe(50);
+    expect(r.cogs).toBe(0);
+  });
+
+  it("a second receipt at a different cost re-averages the unit cost", () => {
+    const after1 = applyStockMovement(empty, { type: "receipt", quantity: 10, unitCost: 5 }).state;
+    const r = applyStockMovement(after1, { type: "receipt", quantity: 10, unitCost: 7 });
+    // (10×5 + 10×7) / 20 = 6
+    expect(r.state).toEqual({ quantity: 20, unitCost: 6 });
+    expect(r.valueDelta).toBe(70);
+  });
+
+  it("an issue leaves at the current average and books COGS", () => {
+    const start: StockState = { quantity: 20, unitCost: 6 };
+    const r = applyStockMovement(start, { type: "issue", quantity: 5 });
+    expect(r.state).toEqual({ quantity: 15, unitCost: 6 });
+    expect(r.cogs).toBe(30); // 5 × 6
+    expect(r.valueDelta).toBe(-30);
+    expect(r.quantityDelta).toBe(-5);
+  });
+
+  it("an over-issue is capped at what is on hand (no negative stock)", () => {
+    const start: StockState = { quantity: 3, unitCost: 10 };
+    const r = applyStockMovement(start, { type: "issue", quantity: 10 });
+    expect(r.state.quantity).toBe(0);
+    expect(r.cogs).toBe(30); // only the 3 held × 10
+    expect(r.quantityDelta).toBe(-3);
+  });
+
+  it("a positive adjustment adds stock at the current average", () => {
+    const start: StockState = { quantity: 10, unitCost: 4 };
+    const r = applyStockMovement(start, { type: "adjustment", quantity: 5 });
+    expect(r.state).toEqual({ quantity: 15, unitCost: 4 });
+    expect(r.valueDelta).toBe(20); // 5 × 4
+  });
+
+  it("a negative adjustment is clamped so stock never goes below zero", () => {
+    const start: StockState = { quantity: 2, unitCost: 4 };
+    const r = applyStockMovement(start, { type: "adjustment", quantity: -5 });
+    expect(r.state.quantity).toBe(0);
+    expect(r.quantityDelta).toBe(-2);
+    expect(r.valueDelta).toBe(-8); // only the 2 removed × 4
+  });
+
+  it("re-averaging avoids float drift", () => {
+    const after1 = applyStockMovement(empty, { type: "receipt", quantity: 3, unitCost: 0.1 }).state;
+    const r = applyStockMovement(after1, { type: "receipt", quantity: 3, unitCost: 0.2 });
+    expect(r.state.unitCost).toBe(0.15);
+  });
+});

--- a/apps/web/lib/inventory/stock.ts
+++ b/apps/web/lib/inventory/stock.ts
@@ -1,0 +1,93 @@
+// lib/inventory/stock.ts — weighted-average inventory valuation (SAP MM-IM / WM stock)
+//
+// The substantive, hard part of inventory accounting: what a unit is worth as stock
+// moves, and the cost of goods when it leaves. Pure and DB-free so the costing rules
+// are unit-testable; the StockItem / StockMovement persistence and the movement → GL
+// posting (Dr Inventory / Cr GRNI on receipt, Dr COGS / Cr Inventory on issue) are
+// separate follow-ups.
+//
+// Costing method: perpetual **weighted average** — the SMB-friendly default (no lot
+// tracking, no FIFO layer maths). Each receipt re-averages the unit cost; each issue
+// leaves at the current average, so cost of goods sold is deterministic.
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** An item's current stock position: how many units and their weighted-average cost. */
+export type StockState = {
+  quantity: number;
+  /** Weighted-average cost per unit. */
+  unitCost: number;
+};
+
+export type StockMovement =
+  /** Goods in at a purchase cost (re-averages the unit cost). */
+  | { type: "receipt"; quantity: number; unitCost: number }
+  /** Goods out (sale / consumption) — leaves at the current average cost. */
+  | { type: "issue"; quantity: number }
+  /** Stock-take correction: a signed quantity delta valued at the current average. */
+  | { type: "adjustment"; quantity: number };
+
+export type StockMovementResult = {
+  /** The item's new position after the movement. */
+  state: StockState;
+  /** Units in (+) or out (−). */
+  quantityDelta: number;
+  /** Change in total inventory value (drives the Dr/Cr Inventory posting). */
+  valueDelta: number;
+  /** Cost of goods issued (an `issue`), else 0 — drives the Dr COGS posting. */
+  cogs: number;
+};
+
+/**
+ * Apply one stock movement to an item's position under perpetual weighted-average
+ * costing:
+ *   receipt:    qty += in; unitCost = (oldValue + inQty×inCost) / newQty
+ *   issue:      cogs = min(qty, out) × unitCost; qty −= issued (never below 0)
+ *   adjustment: qty += delta (valued at the current average), never below 0
+ *
+ * Quantities never go negative — an over-issue is capped at what is on hand (the
+ * shortfall is surfaced by the caller, not booked as negative stock).
+ */
+export function applyStockMovement(prev: StockState, m: StockMovement): StockMovementResult {
+  const prevQty = Math.max(prev.quantity, 0);
+  const prevCost = Math.max(prev.unitCost, 0);
+  const prevValue = round2(prevQty * prevCost);
+
+  if (m.type === "receipt") {
+    const inQty = Math.max(m.quantity, 0);
+    const inCost = Math.max(m.unitCost, 0);
+    const inValue = round2(inQty * inCost);
+    const newQty = prevQty + inQty;
+    const newUnitCost = newQty > 0 ? round2((prevValue + inValue) / newQty) : prevCost;
+    return {
+      state: { quantity: newQty, unitCost: newUnitCost },
+      quantityDelta: inQty,
+      valueDelta: inValue,
+      cogs: 0,
+    };
+  }
+
+  if (m.type === "issue") {
+    const issued = Math.min(Math.max(m.quantity, 0), prevQty);
+    const cogs = round2(issued * prevCost);
+    return {
+      state: { quantity: prevQty - issued, unitCost: prevCost },
+      quantityDelta: -issued,
+      valueDelta: -cogs,
+      cogs,
+    };
+  }
+
+  // adjustment: signed quantity delta valued at the current average.
+  const delta = m.quantity;
+  const newQty = Math.max(prevQty + delta, 0);
+  const appliedDelta = newQty - prevQty; // clamped if it would go negative
+  return {
+    state: { quantity: newQty, unitCost: prevCost },
+    quantityDelta: appliedDelta,
+    valueDelta: round2(appliedDelta * prevCost),
+    cogs: 0,
+  };
+}


### PR DESCRIPTION
The substantive core of inventory accounting — what a unit is worth as stock moves, and the cost of goods when it leaves — shipped as a pure, fully-tested engine. The `StockItem`/`StockMovement` persistence, the movement→GL posting, and the stock UI are filed follow-ups (WM is a net-new subsystem; `InventoryEntity`/`InventoryRelationship` are edge-fleet placeholders, not warehouse stock).

## What it adds
- **`applyStockMovement` (`inventory/stock.ts`, pure, tested):** perpetual **weighted-average** costing — receipt re-averages the unit cost; issue leaves at the current average and returns **COGS**; adjustment applies a signed quantity delta at the current average. Quantities never go negative (over-issue capped at what's on hand). Returns new state + `valueDelta` + `cogs`, ready for a **Dr Inventory / Cr GRNI** (receipt) or **Dr COGS / Cr Inventory** (issue) posting.

## Verification
- `vitest run lib/inventory/stock.test.ts` — **7/7 pass** (receipt, re-average, issue+COGS, over-issue cap, adjustments, float-drift).
- Standalone strict `tsc` — clean.

Advances **EP-SAP-PARITY** (WM/MM-IM — the valuation core). Doc gate satisfied via `Process-Spine-Decision` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)