### PR TITLE
fix(crm-coworker): CSM CRM grants + engagement lifecycle

### DIFF
--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -63,8 +63,16 @@ describe("coworker seed invariants", () => {
     );
   });
 
-  it("extends customer-advisor with marketing_read", () => {
-    expect(HARDCODED_COWORKER_GRANTS["customer-advisor"]).toContain("marketing_read");
+  it("grants customer-advisor the CRM grants it operates with — not backlog_write", () => {
+    // The Customer Success Manager resolves its runtime grants from THIS map (the
+    // slug agent row), so the CRM grants must be here. Regression guard for the
+    // bug where it held backlog_write + marketing_read and NO crm_* grants, which
+    // stripped every CRM tool from its surface (it filed backlog items instead of
+    // creating accounts).
+    const grants = HARDCODED_COWORKER_GRANTS["customer-advisor"];
+    expect(grants).toEqual(expect.arrayContaining(["crm_read", "crm_write"]));
+    expect(grants).not.toContain("backlog_write");
+    expect(grants).not.toContain("marketing_read");
   });
 
   it("binds every hardcoded coworker seed to one profession family", () => {

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -234,7 +234,13 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
   ],
   "ea-architect": ["ea_graph_read", "ea_graph_write", "architecture_read", "file_read", "registry_read"],
   "hr-specialist": ["registry_read", "consumer_read", "consumer_write"],
-  "customer-advisor": ["consumer_read", "registry_read", "backlog_read", "backlog_write", "marketing_read"],
+  // The Customer Success Manager operates the CRM (accounts, pipeline, quotes),
+  // so it needs crm_read/crm_write — NOT backlog_write (which let it retire live
+  // backlog items while flailing) or marketing_read (wrong domain). Its runtime
+  // grants resolve from THIS map (the slug agent row the coworker queries by
+  // agentId "customer-advisor"), not from agent_registry.json — so the CRM
+  // grants must live here to actually reach the coworker's tool surface.
+  "customer-advisor": ["crm_read", "crm_write", "consumer_read", "registry_read", "backlog_read", "web_search"],
   "marketing-specialist": ["marketing_read", "marketing_write", "consumer_read", "registry_read"],
   "storefront-advisor": [
     "consumer_read",


### PR DESCRIPTION
## Problem (found by driving the live coworker)

Exercising the Customer Success Manager on `/customer` to add a prospect, it **filed a backlog item instead of creating the account**. The live `[tools]` log + DB proved why: the coworker's attached tool surface was backlog/build/marketing tools with **no CRM tools even authorized**.

## Root cause

The interactive coworker resolves its grants to the **slug agent row** seeded by `HARDCODED_COWORKER_GRANTS` (`packages/db/src/workforce-seed.ts`) — **not** `agent_registry.json`. That entry held `["consumer_read","registry_read","backlog_read","backlog_write","marketing_read"]`: the dangerous `backlog_write` (the grant that let it retire live backlog items) + `marketing_read`, and **zero CRM grants**. So `getAvailableTools` stripped every CRM tool. Earlier grant edits to `agent_registry.json` (#2557/#2564) targeted the separate `AGT-WS-CUSTOMER` row and never reached the running coworker.

## Fix (this commit)

`customer-advisor` now holds `["crm_read","crm_write","consumer_read","registry_read","backlog_read","web_search"]` — CRM operate + web research, without `backlog_write`/`marketing_read`. Regression test asserts the CRM grants and forbids `backlog_write`. Takes effect after the db reseed (self-upgrade re-runs `seedCoworkerAgents`).

## Following commits (in progress on this branch)

Building out the rest of the engagement lifecycle so a prospect can be worked through to an active customer with a support contract for their DPF instance:
- `Subscription`/support-contract model tied to the customer's `EdgeNode` (the one real model gap) + create action.
- Coworker tools / UI controls for the transitions that have server actions but no surface today: accept quote → order, generate invoice, record payment, convert prospect → active customer, create support contract.

Verified on the contributor preview before the prod self-upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)