### PR TITLE
feat(hr): labor-economics engine — cost/bill/margin of employee time (EP-LABOR-ECONOMICS Phase 1)

### DIFF
--- a/apps/web/lib/hr/labor.test.ts
+++ b/apps/web/lib/hr/labor.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  hourlyCostRate,
+  computeLaborCost,
+  computeWagePay,
+  computeBillableRevenue,
+  summarizeLaborEconomics,
+  DEFAULT_STANDARD_ANNUAL_HOURS,
+  type Compensation,
+} from "./labor";
+
+const hourly: Compensation = { payType: "hourly", hourlyRate: 25 };
+const salary: Compensation = { payType: "salary", annualSalary: 52000, standardAnnualHours: 2080 };
+
+describe("hourlyCostRate", () => {
+  it("is the wage rate for hourly staff", () => {
+    expect(hourlyCostRate(hourly)).toBe(25);
+  });
+  it("spreads annual salary over standard annual hours", () => {
+    expect(hourlyCostRate(salary)).toBe(25); // 52000 / 2080
+  });
+  it("defaults standard annual hours when unset", () => {
+    expect(hourlyCostRate({ payType: "salary", annualSalary: DEFAULT_STANDARD_ANNUAL_HOURS * 30 })).toBe(30);
+  });
+});
+
+describe("computeWagePay — pay type matters", () => {
+  it("hourly is paid rate × hours (variable)", () => {
+    expect(computeWagePay(hourly, 160)).toBe(4000); // 25 × 160
+    expect(computeWagePay(hourly, 120)).toBe(3000); // fewer hours → less pay
+  });
+  it("salary is paid a fixed amount per period, regardless of hours", () => {
+    expect(computeWagePay(salary, 160, 12)).toBe(round2(52000 / 12)); // 4333.33
+    expect(computeWagePay(salary, 999, 12)).toBe(round2(52000 / 12)); // hours don't change salaried pay
+  });
+});
+
+describe("computeLaborCost", () => {
+  it("costs hours at the cost rate for both pay types", () => {
+    expect(computeLaborCost(hourly, 10)).toBe(250);
+    expect(computeLaborCost(salary, 10)).toBe(250); // salaried time is still costed
+  });
+});
+
+describe("computeBillableRevenue", () => {
+  it("is bill rate × billable hours", () => {
+    expect(computeBillableRevenue(80, 6)).toBe(480);
+  });
+});
+
+describe("summarizeLaborEconomics — cost, revenue, margin", () => {
+  it("bill rate above cost rate yields positive margin", () => {
+    // cost rate 25/h; bill rate 80/h; 40 hours, 30 billable.
+    const e = summarizeLaborEconomics({ comp: hourly, hours: 40, billableHours: 30, billRate: 80 });
+    expect(e.cost).toBe(1000); // 25 × 40 (all hours)
+    expect(e.revenue).toBe(2400); // 80 × 30
+    expect(e.margin).toBe(2400 - 25 * 30); // revenue − cost of billable hours = 1650
+    expect(e.marginPct).toBe(round2((1650 / 2400) * 100)); // 68.75
+  });
+
+  it("salaried employee: margin uses the derived cost rate, not the fixed pay", () => {
+    const e = summarizeLaborEconomics({ comp: salary, hours: 10, billableHours: 10, billRate: 100 });
+    expect(e.revenue).toBe(1000);
+    expect(e.margin).toBe(1000 - 25 * 10); // 750 (cost rate 25/h)
+  });
+
+  it("caps billable hours at hours actually worked", () => {
+    const e = summarizeLaborEconomics({ comp: hourly, hours: 5, billableHours: 100, billRate: 80 });
+    expect(e.billableHours).toBe(5);
+    expect(e.revenue).toBe(400); // 80 × 5, not 80 × 100
+  });
+
+  it("no billable hours → zero revenue and margin", () => {
+    const e = summarizeLaborEconomics({ comp: hourly, hours: 8, billableHours: 0, billRate: 80 });
+    expect(e.revenue).toBe(0);
+    expect(e.margin).toBe(0);
+    expect(e.marginPct).toBe(0);
+    expect(e.cost).toBe(200); // the 8 hours still cost money (overhead)
+  });
+
+  it("bill rate below cost rate yields negative margin (a loss flag)", () => {
+    const e = summarizeLaborEconomics({ comp: hourly, hours: 10, billableHours: 10, billRate: 20 });
+    expect(e.margin).toBeLessThan(0); // 200 − 250
+  });
+});
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/apps/web/lib/hr/labor.ts
+++ b/apps/web/lib/hr/labor.ts
@@ -1,0 +1,108 @@
+// lib/hr/labor.ts — labor economics: the cost, revenue and margin of employee time.
+//
+// An hour of an employee's time has two prices that must never be conflated:
+//   • COST  — what the company pays for it (the wage, hourly or salaried).
+//   • BILL  — what the company charges a client for it (a rate-card rate).
+// The difference is margin. This module makes both explicit and pure, so the rules
+// are unit-testable; the compensation/rate-card persistence, the timesheet → payroll
+// feed and the billable-hours → invoice generation are separate (schema-bearing) phases.
+//
+// The two axes the design turns on:
+//   1. Pay type — hourly is paid rate × hours (variable); salary is paid a fixed amount
+//      per period (independent of hours). But a salaried hour is still COSTED at a
+//      derived hourly rate, so job margin is real: pay ≠ cost-of-time for salary.
+//   2. Selling labor — billable hours are charged at a bill rate drawn from the services
+//      / resources the company sells (a rate card), distinct from the wage.
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Standard paid hours in a year (40h × 52w) — the default salary→hourly cost divisor. */
+export const DEFAULT_STANDARD_ANNUAL_HOURS = 2080;
+
+export type Compensation =
+  | { payType: "hourly"; hourlyRate: number }
+  | { payType: "salary"; annualSalary: number; standardAnnualHours?: number };
+
+/**
+ * The effective per-hour COST of an employee's time — the basis for job costing and
+ * margin. Hourly: the wage rate. Salary: annual salary spread over standard annual hours.
+ */
+export function hourlyCostRate(comp: Compensation): number {
+  if (comp.payType === "hourly") return round2(Math.max(comp.hourlyRate, 0));
+  const hours =
+    comp.standardAnnualHours && comp.standardAnnualHours > 0
+      ? comp.standardAnnualHours
+      : DEFAULT_STANDARD_ANNUAL_HOURS;
+  return round2(Math.max(comp.annualSalary, 0) / hours);
+}
+
+/** The cost of a number of hours of this employee's time (cost rate × hours). */
+export function computeLaborCost(comp: Compensation, hours: number): number {
+  return round2(hourlyCostRate(comp) * Math.max(hours, 0));
+}
+
+/**
+ * What the employee is PAID for a period:
+ *   hourly → wage rate × hours worked (variable);
+ *   salary → annual salary / periods per year (fixed — hours logged do not change it).
+ * Feeds the payroll gross-to-net engine (lib/hr/payroll.ts) as gross for the period.
+ */
+export function computeWagePay(
+  comp: Compensation,
+  hoursInPeriod: number,
+  periodsPerYear = 12,
+): number {
+  if (comp.payType === "hourly") {
+    return round2(Math.max(comp.hourlyRate, 0) * Math.max(hoursInPeriod, 0));
+  }
+  const periods = periodsPerYear > 0 ? periodsPerYear : 12;
+  return round2(Math.max(comp.annualSalary, 0) / periods);
+}
+
+/** Revenue from billing labor: bill rate × billable hours. */
+export function computeBillableRevenue(billRate: number, billableHours: number): number {
+  return round2(Math.max(billRate, 0) * Math.max(billableHours, 0));
+}
+
+export type LaborEconomics = {
+  /** Total hours worked. */
+  hours: number;
+  /** Of which billable to a customer (capped at total hours). */
+  billableHours: number;
+  /** Cost of ALL hours worked (cost rate × hours). */
+  cost: number;
+  /** Revenue from the billable hours (bill rate × billable hours). */
+  revenue: number;
+  /** Margin on the billed work = revenue − cost of the billable hours. */
+  margin: number;
+  /** Margin as a % of revenue (0 when no revenue). */
+  marginPct: number;
+};
+
+/**
+ * Summarise the economics of an employee's hours: what they cost, what the billable
+ * portion earns, and the margin on that billed work. Margin compares revenue against
+ * the cost of the *billable* hours (like for like); the cost of any non-billable hours
+ * is overhead, visible as `cost − (cost rate × billableHours)`. Billable hours are
+ * capped at total hours so you can never bill more time than was worked.
+ */
+export function summarizeLaborEconomics(input: {
+  comp: Compensation;
+  hours: number;
+  billableHours: number;
+  billRate: number;
+}): LaborEconomics {
+  const costRate = hourlyCostRate(input.comp);
+  const hours = Math.max(input.hours, 0);
+  const billableHours = Math.min(Math.max(input.billableHours, 0), hours);
+
+  const cost = round2(costRate * hours);
+  const billableCost = round2(costRate * billableHours);
+  const revenue = computeBillableRevenue(input.billRate, billableHours);
+  const margin = round2(revenue - billableCost);
+  const marginPct = revenue > 0 ? round2((margin / revenue) * 100) : 0;
+
+  return { hours, billableHours, cost, revenue, margin, marginPct };
+}

--- a/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
+++ b/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
@@ -1,0 +1,88 @@
+# Labor Economics — wage time + billable labor
+
+- **Date:** 2026-07-04
+- **Status:** Design; Phase 1 (pure engine) landing
+- **Author:** Claude (Enterprise Architect lens)
+- **Epic:** EP-LABOR-ECONOMICS (new) — companion to EP-SAP-PARITY
+- **Operator directive:** "the association to employee wage time (hourly or salary) and how the
+  company may sell services or resources to bill for that labor needs to be factored in."
+
+## 1. Purpose
+
+DPF has timecards (`TimesheetPeriod`/`TimesheetEntry`, with an approval workflow) and — from the
+SAP-parity work — a payroll gross-to-net engine, an invoicing sub-ledger, and a general ledger.
+But the timecard is **wired to nothing**, employee **compensation is unmodeled**, and there is
+**no billable dimension** on time. This capability connects them: an hour of an employee's time
+has a **cost** (what the company pays for it) and, for labor-selling businesses, a **revenue**
+(what the company bills a client for it); the difference is **margin**.
+
+Two axes the directive names explicitly:
+
+1. **Wage time — hourly *or* salary.** How the employee is paid differs by pay type; how their
+   time is *costed* for margin is a separate, always-hourly figure.
+2. **Selling labor — services / resources.** The company bills labor at a **bill rate** drawn
+   from a rate card of the services/resources it sells — distinct from the wage.
+
+## 2. Current-state audit (grounded — verified 2026-07-04)
+
+| Concern | State | Location |
+| --- | --- | --- |
+| Timecards | ✅ `TimesheetPeriod` (employee, `weekStarting`, `status` draft→submitted→approved/rejected, `totalHours`, `overtimeHours`) + `TimesheetEntry` (`hours`, `breakMinutes`, per day). Approval workflow. | `schema.prisma` ~6785 |
+| Timecard wiring | ❌ Standalone — consumed by neither payroll nor billing | — |
+| Employee compensation | ❌ **Absent** — no pay fields on `EmployeeProfile`, `Position`, or `EmploymentType` | `schema.prisma` 284/393/407 |
+| Billable dimension | ❌ Absent — no customer/job/billable/rate on `TimesheetEntry`; no `Job`/`WorkOrder` model (`ServiceTicket` has `customerAccountId`/`customerSiteId` but no hours) | — |
+| Payroll engine | ✅ `computePayslip` (pure) — takes `baseSalary`/`hoursWorked`+`hourlyRate` as *inputs* | `lib/hr/payroll.ts` |
+| Invoicing + GL | ✅ `createInvoice`, `postInvoiceIssued`, ledger | `lib/actions/finance.ts`, `lib/finance/*` |
+| Archetype feature gating | ✅ Proven pattern: `FinancialProfile` flags (`purchaseOrdersEnabled`, `dunningEnabled`, `recurringBillingEnabled`) + `OrgSettings.appliedProfileSlug` + `OrganizationCapabilityActivation` overlay (has a `project-work` capability) | `finance-templates`, `capability-registry.ts` |
+
+## 3. Research & Benchmarking (per AGENTS.md §10)
+
+The pattern is **PSA / job costing** (professional-services automation — Harvest, Toggl,
+BigTime, SAP CATS + SD service billing). Adopted ideas: **cost rate vs bill rate** as distinct
+figures (the margin is the whole point); a **rate card** of billable services rather than a rate
+buried per employee; **billable vs non-billable** hours as a first-class flag; time approved
+before it can be billed or paid. Rejected for SMB scale: multi-tier rate hierarchies, utilization
+forecasting, revenue recognition schedules, WIP accounting — deferred until asked. Anti-pattern
+avoided: billing at the wage rate (erases margin) or paying salaried staff by the hour.
+
+## 4. The model — cost, revenue, margin
+
+**Cost side (per employee).** Compensation has a `payType`:
+- `hourly`: `hourlyRate`. Pay = `hourlyRate × hoursWorked` (variable). Cost rate = `hourlyRate`.
+- `salary`: `annualSalary` + `standardAnnualHours` (e.g. 2080). Pay = `annualSalary / periodsPerYear`
+  (fixed, independent of hours). **Cost rate** (for costing an hour of their time) =
+  `annualSalary / standardAnnualHours`.
+
+The key nuance: for a salaried employee, **pay ≠ cost-of-time**. Pay is fixed; each logged hour is
+still *costed* at the derived hourly cost rate so job margin is real.
+
+**Revenue side (billable hours).** The company sells labor as **services/resources** on a **rate
+card** (`BillableRate`: a named service/resource with a `billRate` per unit). A billable time
+entry references a rate (or carries an override) and a customer; revenue = `billRate × billableHours`.
+
+**Margin.** For a set of hours: `margin = billableRevenue − laborCost`; `marginPct = margin / revenue`.
+
+## 5. Phasing
+
+- **Phase 1 (this PR) — pure engine (`lib/hr/labor.ts`).** `hourlyCostRate(comp)`,
+  `computeLaborCost(comp, hours)`, `computeWagePay(comp, hoursInPeriod, periodsPerYear)` (hourly
+  variable / salary fixed), `computeBillableRevenue(billRate, billableHours)`, and
+  `summarizeLaborEconomics(...)` → `{ cost, revenue, margin, marginPct }`. Pure, fully unit-tested.
+- **Phase 2 — schema + migration.** Compensation fields on `EmployeeProfile`
+  (`payType`, `hourlyRate?`, `annualSalary?`, `standardAnnualHours?`); a `BillableRate` rate-card
+  model (org-scoped: `name`, `unit`, `billRate`, `active`); a billable dimension on `TimesheetEntry`
+  (`customerAccountId?`, `billableRateId?`, `billable`, `billableHours`, optional `serviceTicketId?`);
+  a `billableTimeEnabled` flag on `FinancialProfile` (on for `trades_construction`,
+  `professional_services`, `fitness_recreation`, `beauty_personal`, `pet_services`,
+  `healthcare_wellness`; off for retail/food/nonprofit/banking/software).
+- **Phase 3 — wiring, archetype-gated.** Approved `TimesheetPeriod` hours → `computePayslip`
+  (hourly staff paid rate×hours; salary staff paid fixed); **billable** hours → **draft invoice
+  lines** (via `createInvoice`, posting to the ledger through the existing invoice→GL path);
+  the billable UI/route appears only when `billableTimeEnabled`.
+- **Phase 4 — UX.** Compensation on the employee record; a rate-card admin; billable columns on
+  the timesheet (customer + service + billable hours), shown only when enabled; a "generate
+  invoice from billable time" action; a labor-margin view for the owner.
+
+**Non-negotiables:** cost rate vs bill rate stay distinct; salaried pay never varies with hours;
+billable is off entirely for non-labor archetypes; every downstream money movement rides the
+ledger/invoicing/payroll engines already merged — no parallel record.


### PR DESCRIPTION
New platform capability (operator-directed): connect timecards, payroll, and billing so an hour of employee time carries a **cost** (the wage) and, for labor-selling businesses, a **revenue** (a bill rate) — with the margin between. This PR lands the **design spec** + the **pure engine**.

## The two axes the directive names
- **Pay type — hourly or salary.** Hourly is paid `rate × hours` (variable); salary is paid a **fixed** amount per period (hours never change it). But a salaried hour is still **costed** at a derived hourly rate (`annualSalary / standardAnnualHours`) so job margin is real — *pay ≠ cost-of-time for salary*.
- **Selling labor — services/resources.** Billable hours are charged at a **bill rate** (from a rate card), distinct from the wage. Margin = revenue − cost of the billable hours.

## What it adds
`lib/hr/labor.ts` (pure, fully tested): `hourlyCostRate`, `computeLaborCost`, `computeWagePay`, `computeBillableRevenue`, `summarizeLaborEconomics` → `{ cost, revenue, margin, marginPct }` (billable capped at hours worked).

## Design spec
`docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md` — grounded current-state audit (timecards exist but wired to nothing; **employee compensation is unmodeled**; no billable dimension; the archetype feature-flag gating pattern is proven), the cost-vs-bill model, and Phases 2–4 (compensation + rate-card + billable-timesheet schema; timesheet→payroll + billable→invoice wiring gated by a `billableTimeEnabled` archetype flag; UI).

## Verification
`vitest run lib/hr/labor.test.ts` — **12/12 pass**; standalone strict `tsc` clean.

Opens **EP-LABOR-ECONOMICS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)