### PR TITLE
fix(build-studio): context strip null-state reads 'No build selected' (BI-AC156613)

### DIFF
--- a/apps/web/components/build/work-control/WorkControlPanel.test.tsx
+++ b/apps/web/components/build/work-control/WorkControlPanel.test.tsx
@@ -64,7 +64,11 @@ describe("WorkControlPanel", () => {
     );
 
     expect(html).toContain("Portal context");
-    expect(html).toContain("No active build");
+    // BI-AC156613: on /build/work nothing is anchored, so the strip shows a
+    // selection null-state ("No build selected"), never a false activity claim
+    // that would clash with the "Active capsules: N" card on the same page.
+    expect(html).toContain("No build selected");
+    expect(html).not.toContain("No active build");
   });
 
   it("renders adoptable worktree rows surfaced by the scanner", () => {

--- a/apps/web/components/portal-context/PortalContextStrip.test.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.test.tsx
@@ -10,25 +10,28 @@ describe("PortalContextStrip", () => {
 
     expect(html).toContain("Portal context");
     expect(html).toContain("Build Studio");
-    expect(html).toContain("No active build");
+    // BI-AC156613: the null-state label states SELECTION, not activity, so the
+    // strip cannot falsely contradict a page that lists active work below it.
+    expect(html).toContain("No build selected");
+    expect(html).not.toContain("No active build");
     expect(html).toContain("Select build");
     expect(html).toContain("text-[var(--dpf-text)]");
     expect(html).toContain("border-[var(--dpf-border)]");
     expect(html).not.toMatch(/text-gray|bg-white|#[0-9a-fA-F]{3,6}/);
   });
 
-  it("D11 (2026-05-23): does NOT render the no_active_build AttentionChip when the buildLabel chip already says 'No active build' (dedupe)", () => {
-    // Repro: PortalContextStrip used to render "No active build" twice when
-    // the user was on /build with no featureBuild anchor — once as the
+  it("D11 (2026-05-23): does NOT render the no_active_build AttentionChip when the buildLabel chip already says 'No build selected' (dedupe)", () => {
+    // Repro: PortalContextStrip used to render the no-build null-state twice
+    // when the user was on /build with no featureBuild anchor — once as the
     // buildLabel chip (left of strip) and again as a yellow warning
     // AttentionChip (right of it). Looked like the strip was broken /
     // double-announcing the same state. The fix suppresses only the
     // AttentionChip rendering (the right-side action button stays — it
     // is genuinely useful).
     const html = renderToStaticMarkup(<PortalContextStrip envelope={makeEnvelope()} />);
-    // The buildLabel chip says "No active build" exactly once.
-    const noActiveMatches = html.match(/No active build/g) ?? [];
-    expect(noActiveMatches.length).toBe(1);
+    // The buildLabel chip says "No build selected" exactly once (BI-AC156613).
+    const noBuildMatches = html.match(/No build selected/g) ?? [];
+    expect(noBuildMatches.length).toBe(1);
     // The "Select build" action button is preserved — it is the actionable
     // affordance the user needs to recover from the no-build state.
     expect(html).toContain("Select build");

--- a/apps/web/components/portal-context/PortalContextStrip.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.tsx
@@ -30,7 +30,7 @@ export function PortalContextStrip({
   const buildLabel = formatBuildLabel(envelope.work.featureBuild ?? null, showInternalIds);
   const capsuleLabel = formatCapsuleLabel(envelope.work.capsule ?? null, showInternalIds);
   // D11 (2026-05-23): suppress the AttentionChip rendering when it would
-  // duplicate the "No active build" text already shown in the buildLabel
+  // duplicate the "No build selected" text already shown in the buildLabel
   // chip to its left. The chip's job is to carry build identity; when
   // there is no build, the chip says so — adding a yellow warning chip
   // with the same text was straight duplication that made the strip
@@ -101,13 +101,18 @@ export function PortalContextStrip({
 }
 
 function formatBuildLabel(build: FeatureBuildAnchor | null, showInternalIds: boolean): string {
-  if (!build) return "No active build";
+  // BI-AC156613: the strip reflects the work object ANCHORED in the URL, not
+  // system-wide activity. On list/control routes (e.g. /build/work) nothing is
+  // anchored, so this renders. "No active build" read as an activity claim and
+  // contradicted the page's own "Active capsules: N" count directly below it —
+  // "No build selected" states the true (selection) meaning without the clash.
+  if (!build) return "No build selected";
   if (showInternalIds) return build.buildId;
   return build.title || "Active build";
 }
 
 function formatCapsuleLabel(capsule: WorkCapsuleAnchor | null, showInternalIds: boolean): string {
-  if (!capsule) return "No capsule";
+  if (!capsule) return "No capsule selected";
   if (showInternalIds) return capsule.capsuleId;
   return capsule.title || "Work capsule";
 }
@@ -149,7 +154,7 @@ function severityClassName(severity: AttentionSignal["severity"]): string {
 }
 
 function signalLabel(signal: AttentionSignal, showInternalIds: boolean): string {
-  if (signal.kind === "no_active_build") return "No active build";
+  if (signal.kind === "no_active_build") return "No build selected";
   if (signal.kind === "capsule_not_linked") return "Capsule not linked";
   if (signal.kind === "missing_evidence") return showInternalIds ? "Missing evidence" : "Waiting on you";
   if (signal.kind === "lease_expired") return "Lease expired";


### PR DESCRIPTION
## Summary

On `/build/work` the shared top **PortalContextStrip** rendered *"Build Studio · No active build · No capsule · Select build"* even though the same page shows **Active capsules: 2** and a just-created build — reading as broken/empty (user-filed **BI-AC156613**, epic **EP-BS-UX-HARDENING**).

### Root cause (investigation)
The strip is a *selection/anchor* indicator: it reflects the work object anchored in the URL (`buildId`/`capsuleId`/`threadId`). `/build/work` is a list/control page where nothing is anchored, so it correctly renders a null state — but it phrased that null state as *"No **active** build"* / *"No capsule"*, which reads as a claim about **activity**. That claim sits directly above the page's own *"Active capsules: 2"* card ([WorkControlPanel.tsx](apps/web/components/build/work-control/WorkControlPanel.tsx)), producing a visible on-screen contradiction.

This is **not** working-as-intended (the wording makes a false activity assertion), and **not** fixable by "reflecting the active capsule/build" (there are 2 capsules and none is selected — a single-object strip has nothing to reflect). The honest, minimal fix is to correct the misleading word.

### Change
Reword the strip's null-state labels to *selection* language — no false activity claim, no contradiction with the count card:
- `No active build` → **`No build selected`**
- `No capsule` → **`No capsule selected`**
- the deduped `no_active_build` `signalLabel` updated to match

The `Select build` action affordance and the D11 (2026-05-23) AttentionChip dedupe behaviour are unchanged. Purely a copy/clarity fix — no logic or data changes.

## Tests
- `apps/web/components/portal-context/PortalContextStrip.test.tsx` and `apps/web/components/build/work-control/WorkControlPanel.test.tsx` updated to the new wording, plus regression guards asserting the false-activity phrasing (`"No active build"`) never renders.
- `pnpm exec vitest run` on both files: **11 passed**.

Local typecheck skipped in worktree (OOMs; CI authoritative).

Refs: EP-BS-UX-HARDENING, BI-AC156613

🤖 Generated with [Claude Code](https://claude.com/claude-code)