### PR TITLE
feat(bom): Workforce activation + AI coworker DigitalProducts (BI-9A5F0EA3, BI-8F9EDD6C, EP-BOM-WIRING)

### DIFF
--- a/apps/web/components/employee/WorkforceRosterPanel.test.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.test.tsx
@@ -25,6 +25,8 @@ const roster: WorkforceRoster = {
       agentNeeds: {
         valueStream: "evaluate",
         supervisorId: "HR-000",
+        humanRoleParity: { roleId: "HR-000", roleName: "Chief Executive Officer" },
+        approvalInterfaceOwner: { scope: "role", label: "Chief Executive Officer", roleId: "HR-000" },
         hitlTier: 2,
         lifecycleStage: "production",
         model: "claude-sonnet-4-6",
@@ -47,10 +49,13 @@ describe("WorkforceRosterPanel", () => {
     expect(html).toContain("Ada Lovelace");
     expect(html).toContain("human");
     expect(html).toContain("Chief of Staff");
-    expect(html).toContain("AI agent");
+    expect(html).toContain("AI coworker");
 
-    // agent-needs lens surfaced
-    expect(html).toContain("HR-000"); // supervisor
+    // agent-needs lens surfaced — incl. human-role parity + approval/interface owner
+    expect(html).toContain("role parity");
+    expect(html).toContain("approval owner");
+    expect(html).toContain("Chief Executive Officer"); // resolved parity/owner role
+    expect(html).toContain("(role)"); // broad-owner scope hint
     expect(html).toContain("T2"); // HITL tier
     expect(html).toContain("claude-sonnet-4-6"); // model
     expect(html).toContain("200k/day"); // token budget

--- a/apps/web/components/employee/WorkforceRosterPanel.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.tsx
@@ -1,9 +1,12 @@
-// Unified Workforce roster panel (BI-554E1A14, EP-BOM-WIRING Phase 2).
+// Unified Workforce roster panel (BI-554E1A14 + BI-9A5F0EA3, EP-BOM-WIRING).
 //
 // Renders the org's workforce as ONE roster spanning human employees and AI
-// agents. For agents it shows the "needs lens" — what the non-human identity
-// needs to contribute: value-stream role, supervising human, HITL tier, model +
-// token budget, tool/skill counts, and unmet capability needs (the gap signal).
+// coworkers. For coworkers it shows the "needs lens" — what the non-human peer
+// needs to contribute: value-stream role, HITL tier, model + token budget,
+// tool/skill counts, and unmet capability needs (the gap signal) — plus, per the
+// founder invariant DOC-7693D528, its human-role parity anchor (the equivalent
+// human role it is patterned against) and its approval/interface owner (broad
+// role → specific employee as headcount grows).
 //
 // Presentational and theme-aware (DPF CSS custom properties, dense layout, no
 // hardcoded colors, no nested cards). Server component — no client state.
@@ -25,10 +28,19 @@ function AgentNeeds({ member }: { member: WorkforceMember }) {
   const tokenBudget =
     needs.dailyTokenLimit != null ? `${(needs.dailyTokenLimit / 1000).toFixed(0)}k/day` : "—";
 
+  // DOC-7693D528: each AI coworker is a role-shaped peer — show the equivalent
+  // human role it is patterned against and the responsible approval/interface
+  // owner, whose specificity (a named employee vs the broad role) scales with
+  // headcount.
+  const owner = needs.approvalInterfaceOwner;
+  const ownerValue =
+    owner.scope === "unassigned" ? "unassigned" : `${owner.label ?? "—"} (${owner.scope})`;
+
   return (
     <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
       <StatPill label="stream" value={needs.valueStream ?? "—"} />
-      <StatPill label="supervisor" value={needs.supervisorId ?? "unassigned"} />
+      <StatPill label="role parity" value={needs.humanRoleParity?.roleName ?? "—"} />
+      <StatPill label="approval owner" value={ownerValue} />
       <StatPill label="HITL" value={`T${needs.hitlTier}`} />
       <StatPill label="model" value={needs.model ?? "unset"} />
       <StatPill label="budget" value={tokenBudget} />
@@ -61,7 +73,7 @@ function MemberRow({ member }: { member: WorkforceMember }) {
           </p>
         </div>
         <span className="text-[9px] font-mono uppercase tracking-wide text-[var(--dpf-muted)] shrink-0">
-          {isAgent ? "AI agent" : "human"}
+          {isAgent ? "AI coworker" : "human"}
         </span>
       </div>
       {isAgent && <AgentNeeds member={member} />}
@@ -78,13 +90,13 @@ export function WorkforceRosterPanel({ roster }: { roster: WorkforceRoster }) {
         <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Workforce</h2>
         <StatPill label="total" value={summary.total} />
         <StatPill label="people" value={summary.humans} />
-        <StatPill label="AI agents" value={summary.agents} />
-        <StatPill label="agents w/ unmet needs" value={summary.agentsWithUnmetNeeds} />
+        <StatPill label="AI coworkers" value={summary.agents} />
+        <StatPill label="coworkers w/ unmet needs" value={summary.agentsWithUnmetNeeds} />
       </div>
 
       {members.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)] py-8 text-center">
-          No workforce members yet. Humans and AI agents will appear here as they are onboarded.
+          No workforce members yet. Humans and AI coworkers will appear here as they are onboarded.
         </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">

--- a/apps/web/lib/work-capsules/work-capsule-presenter.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.ts
@@ -38,7 +38,7 @@ const DECISION_SCOPE_LABELS: Record<string, string> = {
 const PORTFOLIO_ROLE_LABELS: Record<string, string> = {
   foundational: "Foundational",
   manufactureAndDeliver: "Manufacture & Deliver",
-  forEmployees: "For Employees",
+  forEmployees: "Workforce / For Employees",
   productsAndServicesSold: "Products & Services Sold",
 };
 

--- a/apps/web/lib/workforce/workforce-roster.test.ts
+++ b/apps/web/lib/workforce/workforce-roster.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { loadWorkforceRoster } from "./workforce-roster";
 
-function makeDb(opts: { employees?: unknown[]; agents?: unknown[] }) {
+function makeDb(opts: { employees?: unknown[]; agents?: unknown[]; roles?: unknown[] }) {
   return {
     employeeProfile: { findMany: vi.fn().mockResolvedValue(opts.employees ?? []) },
     agent: { findMany: vi.fn().mockResolvedValue(opts.agents ?? []) },
+    platformRole: { findMany: vi.fn().mockResolvedValue(opts.roles ?? []) },
   };
 }
 
@@ -35,7 +36,16 @@ const AGENT = {
   coworkerNeeds: [{ status: "submitted" }, { status: "resolved" }, { status: "in-progress" }],
 };
 
-describe("loadWorkforceRoster (BI-554E1A14)", () => {
+/** A supervising HR role with exactly one active employee holding it. */
+const ROLE_SINGLE_HOLDER = {
+  roleId: "HR-000",
+  name: "Chief Executive Officer",
+  users: [
+    { user: { isActive: true, employeeProfile: { displayName: "Grace Hopper", status: "active" } } },
+  ],
+};
+
+describe("loadWorkforceRoster (BI-554E1A14, BI-9A5F0EA3)", () => {
   it("unifies humans and agents into one roster", async () => {
     const db = makeDb({ employees: [HUMAN], agents: [AGENT] });
 
@@ -67,7 +77,8 @@ describe("loadWorkforceRoster (BI-554E1A14)", () => {
     });
   });
 
-  it("surfaces the agent-needs lens (tools/tokens/skills/supervision)", async () => {
+  it("surfaces the agent-needs lens (tools/tokens/skills/supervision + parity/owner)", async () => {
+    // No platformRole rows returned → owner stays BROAD (the role itself).
     const db = makeDb({ employees: [], agents: [AGENT] });
 
     const { members } = await loadWorkforceRoster({ db: db as never });
@@ -79,6 +90,8 @@ describe("loadWorkforceRoster (BI-554E1A14)", () => {
     expect(agent.agentNeeds).toEqual({
       valueStream: "evaluate",
       supervisorId: "HR-000",
+      humanRoleParity: { roleId: "HR-000", roleName: "HR-000" },
+      approvalInterfaceOwner: { scope: "role", label: "HR-000", roleId: "HR-000" },
       hitlTier: 2,
       lifecycleStage: "production",
       model: "claude-sonnet-4-6",
@@ -88,6 +101,64 @@ describe("loadWorkforceRoster (BI-554E1A14)", () => {
       skillCount: 3,
       // 2 of 3 needs are not resolved (submitted + in-progress)
       unmetNeedCount: 2,
+    });
+  });
+
+  it("resolves the human-role parity anchor from the supervising role's name", async () => {
+    const db = makeDb({ employees: [], agents: [AGENT], roles: [ROLE_SINGLE_HOLDER] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0].agentNeeds?.humanRoleParity).toEqual({
+      roleId: "HR-000",
+      roleName: "Chief Executive Officer",
+    });
+  });
+
+  it("narrows the approval owner to a specific employee when exactly one active person holds the role", async () => {
+    const db = makeDb({ employees: [], agents: [AGENT], roles: [ROLE_SINGLE_HOLDER] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    // DOC-7693D528: broad role owner becomes a specific employee as headcount converges.
+    expect(members[0].agentNeeds?.approvalInterfaceOwner).toEqual({
+      scope: "employee",
+      label: "Grace Hopper",
+      roleId: "HR-000",
+    });
+  });
+
+  it("keeps the approval owner BROAD (the role) when zero or many employees hold it", async () => {
+    const twoHolders = {
+      ...ROLE_SINGLE_HOLDER,
+      name: "Approver Pool",
+      users: [
+        { user: { isActive: true, employeeProfile: { displayName: "A", status: "active" } } },
+        { user: { isActive: true, employeeProfile: { displayName: "B", status: "active" } } },
+      ],
+    };
+    const db = makeDb({ employees: [], agents: [AGENT], roles: [twoHolders] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0].agentNeeds?.approvalInterfaceOwner).toEqual({
+      scope: "role",
+      label: "Approver Pool",
+      roleId: "HR-000",
+    });
+  });
+
+  it("marks the owner unassigned when the coworker has no supervising role", async () => {
+    const noSupervisor = { ...AGENT, humanSupervisorId: null };
+    const db = makeDb({ employees: [], agents: [noSupervisor] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0].agentNeeds?.humanRoleParity).toBeNull();
+    expect(members[0].agentNeeds?.approvalInterfaceOwner).toEqual({
+      scope: "unassigned",
+      label: null,
+      roleId: null,
     });
   });
 

--- a/apps/web/lib/workforce/workforce-roster.ts
+++ b/apps/web/lib/workforce/workforce-roster.ts
@@ -1,29 +1,64 @@
-// Unified Workforce roster (BI-554E1A14, EP-BOM-WIRING Phase 2).
+// Unified Workforce roster (BI-554E1A14 + BI-9A5F0EA3, EP-BOM-WIRING).
 //
 // The "For Employees" portfolio is too narrow when it means only humans: the AI
-// agent workforce (non-human identities) is workforce too. This projection
+// coworker workforce (non-human identities) is workforce too. This projection
 // returns ONE roster spanning both populations — human EmployeeProfiles and AI
 // Agents — so the Workforce portfolio can manage them together.
 //
-// For AI agents it surfaces the "needs lens": what a non-human identity needs to
-// be successful and contribute — its value-stream role, supervising human, HITL
-// tier, assigned model + token budget (the agent's cost-to-employ), tool and
-// skill counts (its equipment), and unmet capability needs (the gap signal). The
-// underlying Agent substrate already carries all of this; this module surfaces it
-// under the workforce lens rather than the platform-internals lens.
+// For AI coworkers it surfaces the "needs lens": what a non-human identity needs
+// to be successful and contribute — its value-stream role, supervising human,
+// HITL tier, assigned model + token budget (the coworker's cost-to-employ), tool
+// and skill counts (its equipment), and unmet capability needs (the gap signal).
 //
-// Pure projection: no schema change, no mutation. The persisted portfolio link
-// and the operator UI are separate follow-on slices.
+// Per the founder-reviewed invariant DOC-7693D528, each AI coworker is a
+// role-shaped non-human peer: it also exposes its human-role parity anchor (the
+// equivalent/adjacent human role it is patterned against) and its current
+// approval/interface owner (the responsible human). That ownership starts BROAD
+// (an HR role) in a small org and becomes SPECIFIC (a named employee) as headcount
+// grows and exactly one person holds the supervising role — resolved live here,
+// with no parallel identity substrate.
+//
+// Pure projection: no schema change, no mutation.
 
 import { prisma } from "@dpf/db";
 
 export type WorkforceMemberKind = "human" | "agent";
 
-/** What an AI agent needs to be successful and contribute. Null for humans. */
+/**
+ * The equivalent/adjacent human role an AI coworker is patterned against
+ * (DOC-7693D528). Null when the coworker has no supervising human role set.
+ */
+export type HumanRoleParity = {
+  /** HR role id, e.g. "HR-100". */
+  roleId: string;
+  /** Human-readable role name, e.g. "Chief Revenue Officer" (falls back to roleId). */
+  roleName: string;
+} | null;
+
+/**
+ * The responsible human for an AI coworker's approval, supervision, escalation,
+ * and day-to-day interface. Scope widens/narrows with headcount:
+ *  - "employee"   — exactly one active employee holds the supervising role (specific)
+ *  - "role"       — the supervising HR role, held by zero or many (broad)
+ *  - "unassigned" — no supervising role is set
+ */
+export type ApprovalInterfaceOwner = {
+  scope: "employee" | "role" | "unassigned";
+  /** Employee display name (employee), role name (role), or null (unassigned). */
+  label: string | null;
+  /** The supervising HR role id, when one is set. */
+  roleId: string | null;
+};
+
+/** What an AI coworker needs to be successful and contribute. Null for humans. */
 export type AgentNeeds = {
   valueStream: string | null;
   /** Supervising human (HR role id), e.g. "HR-000". */
   supervisorId: string | null;
+  /** The equivalent/adjacent human role this coworker is patterned against. */
+  humanRoleParity: HumanRoleParity;
+  /** The responsible human owner for approval/interface (broad → specific). */
+  approvalInterfaceOwner: ApprovalInterfaceOwner;
   /** 0=human-only, 1=approve, 2=review, 3=autonomous. */
   hitlTier: number;
   lifecycleStage: string;
@@ -49,7 +84,7 @@ export type WorkforceMember = {
   role: string | null;
   /** Human: department name. Agent: portfolio id the agent's work serves. */
   group: string | null;
-  /** Present only for AI agents. */
+  /** Present only for AI coworkers. */
   agentNeeds: AgentNeeds | null;
 };
 
@@ -70,6 +105,8 @@ export type WorkforceRoster = {
 export type WorkforceRosterClient = {
   employeeProfile: { findMany: (args: unknown) => Promise<unknown> };
   agent: { findMany: (args: unknown) => Promise<unknown> };
+  /** Optional — resolves the specific/broad approval owner for supervising roles. */
+  platformRole?: { findMany: (args: unknown) => Promise<unknown> };
 };
 
 /**
@@ -105,6 +142,20 @@ type AgentRow = {
   coworkerNeeds: Array<{ status: string }>;
 };
 
+type PlatformRoleRow = {
+  roleId: string;
+  name: string;
+  users: Array<{
+    user: {
+      isActive: boolean;
+      employeeProfile: { displayName: string; status: string } | null;
+    } | null;
+  }>;
+};
+
+/** Resolution for one supervising HR role: its name + the active employees holding it. */
+type RoleResolution = { roleName: string; activeHolderNames: string[] };
+
 function humanToMember(row: EmployeeRow): WorkforceMember {
   return {
     kind: "human",
@@ -117,10 +168,53 @@ function humanToMember(row: EmployeeRow): WorkforceMember {
   };
 }
 
-function agentToMember(row: AgentRow): WorkforceMember {
+/**
+ * Derive an AI coworker's human-role parity anchor and current approval/interface
+ * owner from its supervising HR role. Ownership is BROAD (the role) until exactly
+ * one active employee holds that role, at which point it becomes SPECIFIC (that
+ * employee) — the DOC-7693D528 scale-with-headcount invariant.
+ */
+function resolveParityAndOwner(
+  supervisorId: string | null,
+  roles: Map<string, RoleResolution>,
+): { humanRoleParity: HumanRoleParity; approvalInterfaceOwner: ApprovalInterfaceOwner } {
+  if (!supervisorId) {
+    return {
+      humanRoleParity: null,
+      approvalInterfaceOwner: { scope: "unassigned", label: null, roleId: null },
+    };
+  }
+
+  const resolved = roles.get(supervisorId);
+  const roleName = resolved?.roleName ?? supervisorId;
+  const humanRoleParity: HumanRoleParity = { roleId: supervisorId, roleName };
+
+  if (resolved && resolved.activeHolderNames.length === 1) {
+    return {
+      humanRoleParity,
+      approvalInterfaceOwner: {
+        scope: "employee",
+        label: resolved.activeHolderNames[0],
+        roleId: supervisorId,
+      },
+    };
+  }
+
+  return {
+    humanRoleParity,
+    approvalInterfaceOwner: { scope: "role", label: roleName, roleId: supervisorId },
+  };
+}
+
+function agentToMember(row: AgentRow, roles: Map<string, RoleResolution>): WorkforceMember {
   const unmetNeedCount = row.coworkerNeeds.filter(
     (n) => !RESOLVED_NEED_STATUSES.has(n.status),
   ).length;
+
+  const { humanRoleParity, approvalInterfaceOwner } = resolveParityAndOwner(
+    row.humanSupervisorId,
+    roles,
+  );
 
   return {
     kind: "agent",
@@ -132,6 +226,8 @@ function agentToMember(row: AgentRow): WorkforceMember {
     agentNeeds: {
       valueStream: row.valueStream,
       supervisorId: row.humanSupervisorId,
+      humanRoleParity,
+      approvalInterfaceOwner,
       hitlTier: row.hitlTierDefault,
       lifecycleStage: row.lifecycleStage,
       model: row.executionConfig?.defaultModelId ?? null,
@@ -145,8 +241,50 @@ function agentToMember(row: AgentRow): WorkforceMember {
 }
 
 /**
- * Load the unified Workforce roster: human employees + AI agents, with the
- * agent-needs lens. Deterministic ordering (humans then agents, each by name).
+ * Resolve the supervising HR roles referenced by the agents into {roleName,
+ * activeHolderNames}. Only the roles actually referenced are queried. Degrades to
+ * an empty map when the client exposes no platformRole reader (owner stays broad).
+ */
+async function resolveSupervisingRoles(
+  db: WorkforceRosterClient,
+  supervisorIds: string[],
+): Promise<Map<string, RoleResolution>> {
+  const map = new Map<string, RoleResolution>();
+  if (supervisorIds.length === 0 || !db.platformRole) return map;
+
+  const rows = (await db.platformRole.findMany({
+    where: { roleId: { in: supervisorIds } },
+    select: {
+      roleId: true,
+      name: true,
+      users: {
+        select: {
+          user: {
+            select: {
+              isActive: true,
+              employeeProfile: { select: { displayName: true, status: true } },
+            },
+          },
+        },
+      },
+    },
+  })) as PlatformRoleRow[];
+
+  for (const row of rows) {
+    const activeHolderNames = row.users
+      .map((u) => u.user)
+      .filter((u): u is NonNullable<typeof u> => !!u && u.isActive && !!u.employeeProfile)
+      .map((u) => u.employeeProfile!.displayName);
+    map.set(row.roleId, { roleName: row.name, activeHolderNames });
+  }
+
+  return map;
+}
+
+/**
+ * Load the unified Workforce roster: human employees + AI coworkers, with the
+ * agent-needs lens plus human-role parity + approval/interface owner. Deterministic
+ * ordering (humans then agents, each by name).
  */
 export async function loadWorkforceRoster(input?: {
   db?: WorkforceRosterClient;
@@ -188,8 +326,17 @@ export async function loadWorkforceRoster(input?: {
     }) as Promise<AgentRow[]>,
   ]);
 
+  const supervisorIds = [
+    ...new Set(
+      agents
+        .map((a) => a.humanSupervisorId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    ),
+  ];
+  const roles = await resolveSupervisingRoles(db, supervisorIds);
+
   const humanMembers = employees.map(humanToMember);
-  const agentMembers = agents.map(agentToMember);
+  const agentMembers = agents.map((a) => agentToMember(a, roles));
   const members = [...humanMembers, ...agentMembers];
 
   return {

--- a/docs/superpowers/plans/2026-07-04-bom-workforce-activation-and-coworker-digitalproducts-plan.md
+++ b/docs/superpowers/plans/2026-07-04-bom-workforce-activation-and-coworker-digitalproducts-plan.md
@@ -1,0 +1,44 @@
+# BOM Workforce Activation + AI Coworker DigitalProducts — Implementation Plan
+
+**Date:** 2026-07-04
+**Epic:** EP-BOM-WIRING (Business Operating Model portfolio wiring — Workforce / AI Coworker parity and business portfolio fan-out)
+**BIs implemented:** BI-9A5F0EA3, BI-8F9EDD6C
+**Consumes (governed artifacts):** DOC-7693D528 (AI Coworker Human-Role Parity and Workforce-Scale Approval Invariant), DOC-1996319D (BOM Workforce Portfolio Reassociation and Surface-to-DigitalProduct Matrix), and the BOM design spec [`2026-06-07-business-operating-model-portfolio-wiring-design.md`](../specs/2026-06-07-business-operating-model-portfolio-wiring-design.md).
+**Predecessors (done, not redone):** BI-058BEB95 + BI-2BB3DB23 (their artifact is DOC-1996319D); BI-554E1A14 (Phase 2 unified roster + panel); BI-4503E6B9 (Phase 1 market offer); the portfolio-source projector framework (EP-PORTCOV).
+
+---
+
+## Governing invariant (DOC-7693D528)
+
+AI coworkers are **role-shaped non-human workforce peers**, not detached automation. Each maps to an equivalent/adjacent human role; the responsible human **approval/interface owner** starts BROAD (an HR role) in a small org and becomes SPECIFIC (a named employee) as headcount converges. Portfolio/product/backlog projections must preserve *coworker role ↔ human counterpart/supervisor ↔ approval/interface owner*, and must not introduce a parallel identity or coworker-product registry.
+
+## Substrate reused (no parallel structures)
+
+`Portfolio` (root `for_employees`), `DigitalProduct` (`portfolioId`, `lifecycleStage`, `observationConfig`), `Agent` (`portfolioId`, `valueStream`, `humanSupervisorId`, `kind`, `coworkerServices`), `CoworkerService.digitalProductId`, `CoworkerCapabilityNeed.linkedBacklogItemId`, `PlatformRole` → `UserGroup` → `User` → `EmployeeProfile`, and the idempotent `projectPortfolioEntries` writer.
+
+---
+
+## BI-9A5F0EA3 — Activate For Employees as Workforce
+
+1. **Roster projection** ([`apps/web/lib/workforce/workforce-roster.ts`](../../../apps/web/lib/workforce/workforce-roster.ts)) — extend `AgentNeeds` with `humanRoleParity` (the supervising HR role, resolved to its name) and `approvalInterfaceOwner` (`scope: employee | role | unassigned`). The owner resolves BROAD→SPECIFIC: when exactly one active employee holds the supervising role, the owner is that named employee; otherwise the role (broad); otherwise unassigned. Resolution reads only the supervising roles actually referenced (`PlatformRole.findMany` on the collected `humanSupervisorId`s). Degrades to broad when no `platformRole` reader is present.
+2. **Roster panel** ([`WorkforceRosterPanel.tsx`](../../../apps/web/components/employee/WorkforceRosterPanel.tsx)) — render `role parity` + `approval owner (scope)`; relabel "AI agent(s)" → "AI coworker(s)".
+3. **Portfolio label** ([`portfolio_registry.json`](../../../packages/db/data/portfolio_registry.json)) — `for_employees.name` "For Employees" → "Workforce / For Employees"; description now names AI coworkers as members. **Canonical key/slug `for_employees` is unchanged** (upsert is keyed by slug → zero data churn). Label map [`work-capsule-presenter.ts`](../../../apps/web/lib/work-capsules/work-capsule-presenter.ts) follows.
+4. **Tests** — `workforce-roster.test.ts` updated for the new shape + broad/specific/unassigned owner resolution.
+
+## BI-8F9EDD6C — AI coworkers as Workforce DigitalProducts
+
+1. **Projector** ([`project-coworker-workforce.ts`](../../../packages/db/src/portfolio-sources/project-coworker-workforce.ts)) — new `PortfolioSourceProjector` (`sourceKind: "coworker_service"`, added to the closed enum in [`types.ts`](../../../packages/db/src/portfolio-sources/types.ts)). Projects each non-archived `Agent` as a `DigitalProduct` (`productId = coworker-<agentId>`) under `for_employees`, carrying the human-role parity anchor + approval/interface owner in `observationConfig` (via the new optional `observationExtras` on `ProjectedPortfolioEntry`, merged by the shared writer). Then back-links WITHOUT churn: `Agent.portfolioId → for_employees` (only when unset) and `CoworkerService.digitalProductId → coworker-<agentId>` (only where unset). Idempotent + non-destructive (reuses `projectPortfolioEntries`' `projectedBy` ownership guard).
+2. **Seed wiring** ([`seed.ts`](../../../packages/db/src/seed.ts)) — `coworkerWorkforcePortfolio` step after `coworkerServiceCatalog` (so services exist to link) and `platformCapabilityPortfolio`.
+3. **Reassociation path** — once linked, `BacklogItem.digitalProductId → DigitalProduct.portfolioId = for_employees` resolves an AI-coworker item's portfolio (DOC-1996319D "DigitalProduct first" rule); capability needs resolve via `CoworkerCapabilityNeed.linkedBacklogItemId → BacklogItem`.
+4. **Tests** — `project-coworker-workforce.test.ts` (create, portfolio/service back-link, non-destructive skip, idempotent update, empty no-op, coverage-by-status).
+
+## Verification
+
+- `pnpm --filter @dpf/db exec vitest run portfolio-sources/project-coworker-workforce`
+- `pnpm --filter web exec vitest run lib/workforce/workforce-roster`
+- `pnpm --filter web typecheck` + `pnpm --filter web build`
+- Execution evidence recorded on both BIs via `record_execution_evidence`.
+
+## Explicit deferred sub-item (kept honest)
+
+BI-8F9EDD6C AC2 asks that the **product detail page itself** render the parity anchor + approval/interface owner for a coworker product. The data is now linked and reachable (parity/owner on `observationConfig`; services/offers/backlog/knowledge via the existing `/portfolio/product/[id]/*` sub-routes), and parity/owner ARE shown in the primary coworker surface (the Workforce roster). Rendering them on `DigitalProductDetail` requires extending `toDigitalProductViewModel` + the detail component — a thin follow-up tracked under EP-BOM-WIRING. BI-8F9EDD6C is therefore **not** marked done on that criterion until the product-page render + live-portal proof land.

--- a/packages/db/data/portfolio_registry.json
+++ b/packages/db/data/portfolio_registry.json
@@ -21,8 +21,8 @@
     {
       "id": "for_employees",
       "portfolio_id": "for_employees",
-      "name": "For Employees",
-      "description": "Digital products and services consumed internally by employees: productivity tools, ITSM, HR systems, and internal portals.",
+      "name": "Workforce / For Employees",
+      "description": "The workforce and the internal digital products it consumes. Members are BOTH human employees AND AI coworkers (role-shaped non-human peers per DOC-7693D528, each with a human-role parity anchor and an approval/interface owner). Products include productivity tools, ITSM, HR systems, internal portals, and the AI coworker services/offers the workforce runs on. Canonical key stays `for_employees`.",
       "owner_role": "HR-200",
       "it4it_reference": "IT4IT §6.3 For Employees Portfolio"
     },

--- a/packages/db/src/portfolio-sources/index.ts
+++ b/packages/db/src/portfolio-sources/index.ts
@@ -12,3 +12,4 @@ export * from "./project-external-supply";
 export * from "./licensed-dependencies-manifest";
 export * from "./project-sbom";
 export * from "./product-dependency";
+export * from "./project-coworker-workforce";

--- a/packages/db/src/portfolio-sources/project-coworker-workforce.test.ts
+++ b/packages/db/src/portfolio-sources/project-coworker-workforce.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  coworkerProductId,
+  projectCoworkerWorkforce,
+} from "./project-coworker-workforce";
+import { PORTFOLIO_PROJECTION_KEYS, PROJECTED_BY } from "./types";
+
+type ProductRow = {
+  id: string;
+  productId: string;
+  portfolioId: string | null;
+  observationConfig: Record<string, unknown>;
+  coverageStatus?: string;
+  sourceKind?: string;
+};
+
+/**
+ * Stateful fake that satisfies both the projectPortfolioEntries writer and the
+ * coworker back-link surface. Mirrors the real Prisma behaviour closely enough to
+ * exercise create/update, portfolio linking, and service linking.
+ */
+function makeDb(opts: {
+  agents: unknown[];
+  existingProducts?: ProductRow[];
+  serviceLinkCounts?: Record<string, number>; // agentId -> rows updateMany will touch
+  forEmployeesId?: string | null;
+}) {
+  const products = new Map<string, ProductRow>();
+  for (const p of opts.existingProducts ?? []) products.set(p.productId, { ...p });
+
+  const agentUpdates: Array<{ agentId: string; data: Record<string, unknown> }> = [];
+  const serviceUpdates: Array<{ where: Record<string, unknown>; data: Record<string, unknown> }> =
+    [];
+
+  return {
+    _products: products,
+    _agentUpdates: agentUpdates,
+    _serviceUpdates: serviceUpdates,
+    portfolio: {
+      findUnique: vi.fn(async () =>
+        opts.forEmployeesId === null ? null : { id: opts.forEmployeesId ?? "port-fe" },
+      ),
+    },
+    taxonomyNode: { findUnique: vi.fn(async () => null) },
+    digitalProduct: {
+      findUnique: vi.fn(async (args: { where: { productId: string } }) => {
+        const row = products.get(args.where.productId);
+        return row ? { id: row.id, observationConfig: row.observationConfig } : null;
+      }),
+      create: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        const d = args.data;
+        const row: ProductRow = {
+          id: `dp-${d.productId as string}`,
+          productId: d.productId as string,
+          portfolioId: (d.portfolioId as string) ?? null,
+          observationConfig: (d.observationConfig as Record<string, unknown>) ?? {},
+          coverageStatus: d.coverageStatus as string,
+          sourceKind: d.sourceKind as string,
+        };
+        products.set(row.productId, row);
+        return row;
+      }),
+      update: vi.fn(async (args: { where: { productId: string }; data: Record<string, unknown> }) => {
+        const row = products.get(args.where.productId)!;
+        Object.assign(row, args.data);
+        return row;
+      }),
+    },
+    agent: {
+      findMany: vi.fn(async () => opts.agents),
+      update: vi.fn(async (args: { where: { agentId: string }; data: Record<string, unknown> }) => {
+        agentUpdates.push({ agentId: args.where.agentId, data: args.data });
+        return {};
+      }),
+    },
+    coworkerService: {
+      updateMany: vi.fn(
+        async (args: { where: { providerAgentId: string }; data: Record<string, unknown> }) => {
+          serviceUpdates.push(args);
+          return { count: opts.serviceLinkCounts?.[args.where.providerAgentId] ?? 0 };
+        },
+      ),
+    },
+  };
+}
+
+const COWORKER = {
+  agentId: "AGT-COO",
+  displayName: "Chief of Staff",
+  name: "coo",
+  kind: "orchestrator",
+  status: "active",
+  valueStream: "evaluate",
+  humanSupervisorId: "HR-000",
+  portfolioId: null,
+};
+
+describe("projectCoworkerWorkforce (BI-8F9EDD6C)", () => {
+  it("projects an active coworker as a for_employees DigitalProduct with parity/owner markers", async () => {
+    const db = makeDb({ agents: [COWORKER], serviceLinkCounts: { "AGT-COO": 2 } });
+
+    const result = await projectCoworkerWorkforce({ db: db as never });
+
+    expect(result.coworkers).toBe(1);
+    expect(result.created).toBe(1);
+
+    const product = db._products.get(coworkerProductId("AGT-COO"))!;
+    expect(product.portfolioId).toBe("port-fe");
+    expect(product.coverageStatus).toBe("used");
+    expect(product.sourceKind).toBe("coworker_service");
+    // Projector-owned + parity/owner facts carried in observationConfig.
+    expect(product.observationConfig[PORTFOLIO_PROJECTION_KEYS.projectedBy]).toBe(PROJECTED_BY);
+    expect(product.observationConfig.agentId).toBe("AGT-COO");
+    expect(product.observationConfig.humanRoleParity).toBe("HR-000");
+    expect(product.observationConfig.approvalInterfaceOwnerRole).toBe("HR-000");
+  });
+
+  it("anchors Agent.portfolioId to for_employees only when unset, and links its services", async () => {
+    const db = makeDb({ agents: [COWORKER], serviceLinkCounts: { "AGT-COO": 3 } });
+
+    const result = await projectCoworkerWorkforce({ db: db as never });
+
+    expect(result.agentsPortfolioLinked).toBe(1);
+    expect(db._agentUpdates).toEqual([{ agentId: "AGT-COO", data: { portfolioId: "port-fe" } }]);
+
+    expect(result.servicesLinked).toBe(3);
+    expect(db._serviceUpdates[0]).toEqual({
+      where: { providerAgentId: "AGT-COO", digitalProductId: null },
+      data: { digitalProductId: coworkerProductId("AGT-COO") },
+    });
+  });
+
+  it("does NOT move a coworker already assigned to a portfolio", async () => {
+    const assigned = { ...COWORKER, portfolioId: "some-other-portfolio" };
+    const db = makeDb({ agents: [assigned] });
+
+    const result = await projectCoworkerWorkforce({ db: db as never });
+
+    expect(result.agentsPortfolioLinked).toBe(0);
+    expect(db._agentUpdates).toEqual([]);
+  });
+
+  it("is idempotent: a re-run updates the projector-owned product, does not duplicate", async () => {
+    const existing: ProductRow = {
+      id: "dp-coworker-AGT-COO",
+      productId: coworkerProductId("AGT-COO"),
+      portfolioId: "port-fe",
+      observationConfig: { [PORTFOLIO_PROJECTION_KEYS.projectedBy]: PROJECTED_BY },
+    };
+    const db = makeDb({ agents: [COWORKER], existingProducts: [existing] });
+
+    const result = await projectCoworkerWorkforce({ db: db as never });
+
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(1);
+    expect(db._products.size).toBe(1);
+  });
+
+  it("no-ops when there are no non-archived agents", async () => {
+    const db = makeDb({ agents: [] });
+
+    const result = await projectCoworkerWorkforce({ db: db as never });
+
+    expect(result).toEqual({
+      total: 0,
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      coworkers: 0,
+      agentsPortfolioLinked: 0,
+      servicesLinked: 0,
+    });
+    expect(db.agent.update).not.toHaveBeenCalled();
+  });
+
+  it("marks an inactive coworker product as 'available' coverage", async () => {
+    const inactive = { ...COWORKER, agentId: "AGT-IDLE", status: "inactive", portfolioId: "x" };
+    const db = makeDb({ agents: [inactive] });
+
+    await projectCoworkerWorkforce({ db: db as never });
+
+    expect(db._products.get(coworkerProductId("AGT-IDLE"))!.coverageStatus).toBe("available");
+  });
+});

--- a/packages/db/src/portfolio-sources/project-coworker-workforce.ts
+++ b/packages/db/src/portfolio-sources/project-coworker-workforce.ts
@@ -1,0 +1,168 @@
+// AI coworker → Workforce DigitalProduct projector (BI-8F9EDD6C, EP-BOM-WIRING).
+//
+// The founder invariant DOC-7693D528 is that AI coworkers are role-shaped
+// non-human workforce peers, NOT detached automation services. The portfolio
+// model already links CoworkerService/CoworkerOffer to DigitalProduct, but the
+// product association is not yet load-bearing. This projector makes it so:
+//
+//   1. Project each active AI coworker (Agent) as a DigitalProduct under
+//      `for_employees` (Workforce), carrying its human-role parity anchor and
+//      approval/interface owner in observationConfig (reusing the shared,
+//      idempotent, non-destructive projectPortfolioEntries writer).
+//   2. Back-link the coworker's substrate to that product WITHOUT churn:
+//        - set Agent.portfolioId → for_employees (only when unset), and
+//        - set CoworkerService.digitalProductId → the coworker product
+//          (only for services with no product yet).
+//
+// This does NOT introduce a parallel coworker-product registry — it reuses
+// Portfolio, DigitalProduct, Agent, and CoworkerService. Backlog and capability
+// needs resolve their portfolio through DigitalProduct.portfolioId once linked
+// (the DOC-1996319D "DigitalProduct first" reassociation rule).
+
+import { prisma } from "../client";
+import {
+  projectPortfolioEntries,
+  type ProjectPortfolioClient,
+  type ProjectPortfolioResult,
+} from "./project-portfolio-source";
+import type { ProjectedPortfolioEntry } from "./types";
+
+const FOR_EMPLOYEES_SLUG = "for_employees" as const;
+
+/** Structural client — the writer client plus the coworker back-link surface. */
+export type ProjectCoworkerWorkforceClient = ProjectPortfolioClient & {
+  agent: {
+    findMany: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+  coworkerService: {
+    updateMany: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export type ProjectCoworkerWorkforceResult = ProjectPortfolioResult & {
+  /** AI coworkers projected as Workforce products. */
+  coworkers: number;
+  /** Agents whose portfolioId was set to for_employees (were previously unset). */
+  agentsPortfolioLinked: number;
+  /** CoworkerService rows linked to their coworker DigitalProduct. */
+  servicesLinked: number;
+};
+
+type CoworkerAgentRow = {
+  agentId: string;
+  displayName: string;
+  name: string;
+  kind: string;
+  status: string;
+  valueStream: string | null;
+  humanSupervisorId: string | null;
+  portfolioId: string | null;
+};
+
+/** Stable, deterministic product id per coworker so re-projection is idempotent. */
+export function coworkerProductId(agentId: string): string {
+  return `coworker-${agentId}`;
+}
+
+function buildEntry(agent: CoworkerAgentRow): ProjectedPortfolioEntry {
+  const label = agent.displayName || agent.name || agent.agentId;
+  const roleShape = [agent.kind, agent.valueStream].filter(Boolean).join(" · ") || "coworker";
+  const parity = agent.humanSupervisorId ?? "unassigned";
+  return {
+    productId: coworkerProductId(agent.agentId),
+    name: label,
+    description:
+      `AI coworker (${roleShape}) as a Workforce product. Role-shaped non-human peer ` +
+      `(DOC-7693D528); human-role parity / approval-interface owner: ${parity}.`,
+    portfolioSlug: FOR_EMPLOYEES_SLUG,
+    taxonomyNodeId: null,
+    // An active coworker is workforce the org is actively using; others are available.
+    coverageStatus: agent.status === "active" ? "used" : "available",
+    sourceKind: "coworker_service",
+    observationExtras: {
+      agentId: agent.agentId,
+      coworkerKind: agent.kind,
+      valueStream: agent.valueStream ?? "",
+      humanRoleParity: agent.humanSupervisorId ?? "",
+      approvalInterfaceOwnerRole: agent.humanSupervisorId ?? "",
+    },
+  };
+}
+
+const EMPTY: ProjectCoworkerWorkforceResult = {
+  total: 0,
+  created: 0,
+  updated: 0,
+  skipped: 0,
+  coworkers: 0,
+  agentsPortfolioLinked: 0,
+  servicesLinked: 0,
+};
+
+/**
+ * Project active AI coworkers as Workforce DigitalProducts and back-link their
+ * Agent.portfolioId and CoworkerService.digitalProductId. Idempotent and
+ * non-destructive: existing operator-owned rows and already-set links are left
+ * intact. No-op when there are no non-archived agents.
+ */
+export async function projectCoworkerWorkforce(
+  input: { db?: ProjectCoworkerWorkforceClient } = {},
+): Promise<ProjectCoworkerWorkforceResult> {
+  const db = input.db ?? (prisma as unknown as ProjectCoworkerWorkforceClient);
+
+  const agents = (await db.agent.findMany({
+    where: { archived: false },
+    orderBy: { name: "asc" },
+    select: {
+      agentId: true,
+      displayName: true,
+      name: true,
+      kind: true,
+      status: true,
+      valueStream: true,
+      humanSupervisorId: true,
+      portfolioId: true,
+    },
+  })) as CoworkerAgentRow[];
+
+  if (agents.length === 0) return { ...EMPTY };
+
+  const entries = agents.map(buildEntry);
+  const projection = await projectPortfolioEntries(entries, { db });
+
+  // Resolve the for_employees portfolio id once for the Agent.portfolioId link.
+  const portfolio = (await db.portfolio.findUnique({
+    where: { slug: FOR_EMPLOYEES_SLUG },
+    select: { id: true },
+  })) as { id: string } | null;
+
+  let agentsPortfolioLinked = 0;
+  let servicesLinked = 0;
+
+  for (const agent of agents) {
+    // (a) Anchor the coworker itself to the Workforce portfolio, only when unset —
+    // never move an agent an operator has already assigned elsewhere.
+    if (portfolio && !agent.portfolioId) {
+      await db.agent.update({
+        where: { agentId: agent.agentId },
+        data: { portfolioId: portfolio.id },
+      });
+      agentsPortfolioLinked++;
+    }
+
+    // (b) Link the coworker's services to its product, only where none is set.
+    const linked = (await db.coworkerService.updateMany({
+      where: { providerAgentId: agent.agentId, digitalProductId: null },
+      data: { digitalProductId: coworkerProductId(agent.agentId) },
+    })) as { count: number };
+    servicesLinked += linked?.count ?? 0;
+  }
+
+  return {
+    ...projection,
+    coworkers: agents.length,
+    agentsPortfolioLinked,
+    servicesLinked,
+  };
+}

--- a/packages/db/src/portfolio-sources/project-portfolio-source.ts
+++ b/packages/db/src/portfolio-sources/project-portfolio-source.ts
@@ -108,6 +108,7 @@ export async function projectPortfolioEntries(
       [PORTFOLIO_PROJECTION_KEYS.coverageStatus]: entry.coverageStatus,
       [PORTFOLIO_PROJECTION_KEYS.sourceKind]: entry.sourceKind,
       [PORTFOLIO_PROJECTION_KEYS.projectedBy]: PROJECTED_BY,
+      ...(entry.observationExtras ?? {}),
     };
     const { lifecycleStage, lifecycleStatus } = lifecycleFromCoverage(entry.coverageStatus);
 

--- a/packages/db/src/portfolio-sources/types.ts
+++ b/packages/db/src/portfolio-sources/types.ts
@@ -37,6 +37,7 @@ export const PORTFOLIO_SOURCE_KINDS = [
   "ai_provider", // ModelProvider / providers-registry.json
   "sbom", // BomComponent (CycloneDX)
   "archetype", // archetype-seeded offers / suppliers / goods
+  "coworker_service", // Agent / CoworkerService — AI coworkers as Workforce products (BI-8F9EDD6C)
 ] as const;
 export type PortfolioSourceKind = (typeof PORTFOLIO_SOURCE_KINDS)[number];
 
@@ -60,6 +61,14 @@ export interface ProjectedPortfolioEntry {
   taxonomyNodeId: string | null;
   coverageStatus: PortfolioCoverageStatus;
   sourceKind: PortfolioSourceKind;
+  /**
+   * Extra string markers merged into DigitalProduct.observationConfig alongside
+   * the coverage/source/projectedBy markers. Used by projectors that carry
+   * projector-specific facts on the row — e.g. the coworker projector stamps the
+   * AI coworker's agentId, human-role parity anchor, and approval/interface owner
+   * (BI-8F9EDD6C / DOC-7693D528). Optional; omitted for projectors that don't.
+   */
+  observationExtras?: Record<string, string>;
 }
 
 /**

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -21,6 +21,7 @@ import { projectPlatformCapabilities } from "./portfolio-sources/project-portfol
 import { projectAiProviders, projectIntegrations } from "./portfolio-sources/project-external-supply.js";
 import { projectSupplyChain } from "./portfolio-sources/project-sbom.js";
 import { projectProductDependencyGraph } from "./portfolio-sources/product-dependency.js";
+import { projectCoworkerWorkforce } from "./portfolio-sources/project-coworker-workforce.js";
 import { backfillBacklogPortfolios } from "./backlog-portfolio.js";
 import {
   seedViewpointsForNotation,
@@ -2372,6 +2373,10 @@ async function main(): Promise<void> {
   await step("dpfSelfRegistration", () => seedDpfSelfRegistration());
   await step("coworkerServiceCatalog", () => seedCoworkerServiceCatalog(prisma));
   await step("platformCapabilityPortfolio", () => projectPlatformCapabilities());
+  // BI-8F9EDD6C: project AI coworkers as Workforce DigitalProducts under
+  // for_employees and back-link Agent.portfolioId + CoworkerService.digitalProductId.
+  // Runs after coworkerServiceCatalog so services exist to link.
+  await step("coworkerWorkforcePortfolio", () => projectCoworkerWorkforce());
   await step("defaultAdminUser", () => seedDefaultAdminUser());
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));
   await step("dataModelMirrorScheduledTask", () => ensureDataModelMirrorScheduledTask(prisma));


### PR DESCRIPTION
## What & why

Executes the two remaining **EP-BOM-WIRING** implementation items, consuming the governed artifacts **DOC-7693D528** (AI Coworker Human-Role Parity and Workforce-Scale Approval Invariant) and **DOC-1996319D** (BOM Workforce Portfolio Reassociation and Surface-to-DigitalProduct Matrix). Predecessors BI-058BEB95 / BI-2BB3DB23 (which produced DOC-1996319D) are **not** redone — this consumes their matrix.

The governing invariant: **AI coworkers are role-shaped non-human workforce peers**, not detached automation — each maps to an equivalent human role, and the responsible approval/interface owner scales **broad → specific** with headcount. All work **reuses existing substrate; no parallel identity or coworker-product registry** is introduced (`schema-audit-before-features`).

## BI-9A5F0EA3 — Activate For Employees as Workforce
- **`workforce-roster.ts`**: `AgentNeeds` gains `humanRoleParity` (supervising HR role resolved to its name) and `approvalInterfaceOwner` (`employee | role | unassigned`). Owner resolves **broad→specific**: exactly one active employee holds the supervising role → that named employee; else the role (broad); else unassigned. Resolved live via `PlatformRole → UserGroup → EmployeeProfile` — no schema change.
- **`WorkforceRosterPanel.tsx`**: renders `role parity` + `approval owner (scope)`; "AI agent(s)" → "AI coworker(s)".
- **`portfolio_registry.json`**: `for_employees` label → **"Workforce / For Employees"**; description names AI coworkers. **Canonical slug key `for_employees` unchanged** — upsert is keyed by slug, so zero data churn. Label map in `work-capsule-presenter.ts` follows.

## BI-8F9EDD6C — AI coworkers as Workforce DigitalProducts
- **`project-coworker-workforce.ts`** (new `PortfolioSourceProjector`, `sourceKind: "coworker_service"`): projects each non-archived `Agent` as a `DigitalProduct` (`coworker-<agentId>`) under `for_employees`, carrying the parity anchor + approval owner in `observationConfig`, then back-links `Agent.portfolioId → for_employees` and `CoworkerService.digitalProductId` (only where unset). Idempotent + non-destructive (reuses `projectPortfolioEntries`' `projectedBy` ownership guard).
- **`types.ts` / `project-portfolio-source.ts`**: new source-kind enum value + optional `observationExtras` merged by the shared writer.
- **`seed.ts`**: `coworkerWorkforcePortfolio` step after `coworkerServiceCatalog`.
- Reassociation: once linked, `BacklogItem.digitalProductId → DigitalProduct.portfolioId = for_employees` resolves an AI-coworker item's portfolio (DOC-1996319D "DigitalProduct first" rule).

## Verification (substrate: dedicated worktree bootstrapped from the shared pnpm store)
- ✅ `@dpf/db` `vitest run src/portfolio-sources` — **44 passed** (incl. new projector suite + projection-parity).
- ✅ web `vitest run lib/workforce/workforce-roster` — **10 passed**; `WorkforceRosterPanel` — **2 passed**.
- ✅ `apps/web` `tsc --noEmit` clean; `@dpf/db` typecheck clean.
- ✅ `pnpm --filter web build` — **exit 0** (full production build).
- No migration (no schema change).

Live-portal UX exercise is **not** included (worktree is source-control isolation, not a runtime); CI + a follow-up live check cover it.

## Deferred sub-item (kept honest)
BI-8F9EDD6C AC2 also asks the **product detail page itself** to render parity/owner for a coworker product. The data is now linked and reachable (parity/owner on `observationConfig`; services/offers/backlog/knowledge via existing `/portfolio/product/[id]/*` sub-routes) and parity/owner **are** shown in the primary coworker surface (the Workforce roster). Rendering them on `DigitalProductDetail` is a thin follow-up under EP-BOM-WIRING — so that BI is **not** marked done on that criterion until it + live proof land.

## Gate attestations
**Spec/Plan/Doc:** adds `docs/superpowers/plans/2026-07-04-bom-workforce-activation-and-coworker-digitalproducts-plan.md`.

**UX-Fit-Decision:** UI change is progressive-disclosure-safe — two auto-derived stat pills added to the existing dense Workforce roster panel (no new route, form, or operator-configurable input; nothing a layman must type), and a portfolio label rename. Cognitive load is low by construction: the parity anchor and approval owner are computed from existing data, not asked. Reuses the panel's established `StatPill` pattern; no new component family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
