### PR TITLE
feat(build-studio): differentiate the two work-intake doors (EP-BS-UX-HARDENING, BI-E167A8A6)

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -247,6 +247,17 @@ export default async function BuildPage({ searchParams }: PageProps) {
     ? devConfig.clientId.replace(/-/g, "").slice(0, 8)
     : null;
 
+  // BI-E167A8A6: Build Studio has two work-intake doors. Door 2 — "Work Control /
+  // Plan governed work" — creates a git-governed work capsule and needs
+  // manage_backlog (createGovernedWorkAction enforces it server-side). Only
+  // surface that door to operators who can actually use it; everyone else sees
+  // the single plain-English "Start a new build" door, removing the "which one
+  // is correct?" confusion.
+  const canManageGovernedWork = can(
+    { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+    "manage_backlog",
+  );
+
   return (
     <section className="min-h-full">
       <BuildStudio
@@ -254,6 +265,7 @@ export default async function BuildPage({ searchParams }: PageProps) {
         epicRollups={epicRollups}
         portfolios={portfolios}
         governedBacklogEnabled={devConfig.governedBacklogEnabled}
+        canManageGovernedWork={canManageGovernedWork}
         dpfEnvironment={process.env.DPF_ENVIRONMENT ?? "production"}
         projectBranch={projectBranch}
         submissionBranchShortId={submissionBranchShortId}

--- a/apps/web/app/(shell)/build/work/page.tsx
+++ b/apps/web/app/(shell)/build/work/page.tsx
@@ -1,11 +1,24 @@
 import { WorkControlPanel } from "@/components/build/work-control/WorkControlPanel";
 import { createGovernedWorkAction, getWorkControlData } from "@/lib/actions/work-capsules";
 import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 
 export default async function WorkControlPage() {
   const session = await auth();
   const data = await getWorkControlData();
+  // BI-E167A8A6: the "Plan governed work" form is door 2 of Build Studio's two
+  // work-intake paths. Creating a governed work capsule requires manage_backlog
+  // (createGovernedWorkAction enforces it server-side). Gate the create door in
+  // the UI to the same capability so a non-technical operator — who can view
+  // Build Studio (view_platform) but not create governed work — never faces a
+  // second "start work" door that would 403 on submit.
+  const canCreateGovernedWork = session?.user
+    ? can(
+        { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+        "manage_backlog",
+      )
+    : false;
   const portalContext = session?.user?.id
     ? await resolvePortalContextEnvelope(
         {
@@ -21,6 +34,7 @@ export default async function WorkControlPage() {
       capsules={data.capsules}
       adoptable={data.adoptable}
       createAction={createGovernedWorkAction}
+      canCreateGovernedWork={canCreateGovernedWork}
       portalContext={portalContext}
     />
   );

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -77,6 +77,12 @@ type Props = {
   epicRollups?: EpicRollupView[];
   portfolios: PortfolioForSelect[];
   governedBacklogEnabled: boolean;
+  /**
+   * BI-E167A8A6: whether the operator holds manage_backlog. Gates door 2 —
+   * the "Work Control / Plan governed work" intake — so a non-technical
+   * operator only ever sees the plain-English "Start a new build" door.
+   */
+  canManageGovernedWork?: boolean;
   dpfEnvironment?: string;
   projectBranch?: string | null;
   submissionBranchShortId?: string | null;
@@ -149,6 +155,7 @@ export function BuildStudio({
   epicRollups = [],
   portfolios,
   governedBacklogEnabled,
+  canManageGovernedWork = false,
   dpfEnvironment,
   projectBranch,
   submissionBranchShortId,
@@ -645,15 +652,28 @@ export function BuildStudio({
 
         {/* Left: Build List */}
         <div className={getBuildStudioSidebarClassName(sidebarOpen)}>
-          <div className="border-b border-[var(--dpf-border)] p-3">
-            <Link
-              href="/build/work"
-              className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
-            >
-              <GitBranch className="h-4 w-4" aria-hidden="true" />
-              <span>Work Control</span>
-            </Link>
-          </div>
+          {/* BI-E167A8A6: door 2 (Work Control / governed engineering work) is
+              only surfaced to operators who can actually create it
+              (manage_backlog). Non-technical operators see just the
+              plain-English "Start a new build" door below — no second intake to
+              guess between. Where both are shown, the subtitle states the
+              relationship so it is clear which door does what. */}
+          {canManageGovernedWork && (
+            <div className="border-b border-[var(--dpf-border)] p-3">
+              <Link
+                href="/build/work"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+              >
+                <GitBranch className="h-4 w-4" aria-hidden="true" />
+                <span>Work Control</span>
+              </Link>
+              <p className="mt-1.5 text-[10px] leading-snug text-[var(--dpf-muted)]">
+                Governed engineering work — git branches &amp; worktrees. To
+                describe a feature in plain English instead, use{" "}
+                <span className="font-medium text-[var(--dpf-text)]">Start a new build</span> below.
+              </p>
+            </div>
+          )}
           {isDevEnvironment ? (
             <div className="p-3 border-b border-[var(--dpf-border)]">
               <div className="px-3 py-2 text-sm bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded-md text-[var(--dpf-muted)]">
@@ -669,6 +689,15 @@ export function BuildStudio({
             // a newline (multiline field), Cmd/Ctrl+Enter submits to preserve
             // keyboard flow without losing the multiline capability.
             <div className="p-3 border-b border-[var(--dpf-border)]">
+              {/* BI-E167A8A6: name door 1 and state its purpose so it reads as
+                  the primary, plain-English intake — distinct from governed
+                  Work Control above. */}
+              <div className="mb-2">
+                <p className="text-xs font-semibold text-[var(--dpf-text)]">Start a new build</p>
+                <p className="mt-0.5 text-[10px] leading-snug text-[var(--dpf-muted)]">
+                  Describe a feature in plain English — your AI Coworker designs, builds, and ships it for you.
+                </p>
+              </div>
               <textarea
                 placeholder="Describe a new feature in plain English — say what you want to do, who it's for, and any details that matter."
                 value={newTitle}

--- a/apps/web/components/build/work-control/WorkControlPanel.test.tsx
+++ b/apps/web/components/build/work-control/WorkControlPanel.test.tsx
@@ -47,10 +47,45 @@ describe("WorkControlPanel", () => {
   });
 
   it("renders empty state", () => {
-    const html = renderToStaticMarkup(<WorkControlPanel capsules={[]} adoptable={[]} createAction={vi.fn()} />);
+    const html = renderToStaticMarkup(
+      <WorkControlPanel capsules={[]} adoptable={[]} createAction={vi.fn()} canCreateGovernedWork />,
+    );
 
     expect(html).toContain("No active capsules yet.");
     expect(html).toContain("Plan governed work");
+  });
+
+  it("shows the governed-work create form to manage_backlog holders", () => {
+    const html = renderToStaticMarkup(
+      <WorkControlPanel capsules={[]} adoptable={[]} createAction={vi.fn()} canCreateGovernedWork />,
+    );
+
+    // Door 2's create form is present, and the "reserved role" fallback is not.
+    expect(html).toContain("Plan governed work");
+    expect(html).not.toContain("reserved for the manage-backlog role");
+  });
+
+  it("hides the create door and explains the alternative when manage_backlog is absent", () => {
+    // BI-E167A8A6: default (no capability) hides door 2's create form so a
+    // non-technical operator is not offered a second intake they cannot use.
+    const html = renderToStaticMarkup(
+      <WorkControlPanel capsules={[]} adoptable={[]} createAction={vi.fn()} />,
+    );
+
+    // No governed-work form heading/button ("Plan governed work"). The intro's
+    // "Planning governed work" prose does not contain that exact substring.
+    expect(html).not.toContain("Plan governed work");
+    expect(html).toContain("reserved for the manage-backlog role");
+    expect(html).toContain('href="/build"');
+  });
+
+  it("states the relationship to the plain-English Start a new build door", () => {
+    const html = renderToStaticMarkup(
+      <WorkControlPanel capsules={[]} adoptable={[]} createAction={vi.fn()} canCreateGovernedWork />,
+    );
+
+    expect(html).toContain("Start a new build");
+    expect(html).toContain('href="/build"');
   });
 
   it("renders the portal context strip when a server envelope is provided", () => {

--- a/apps/web/components/build/work-control/WorkControlPanel.tsx
+++ b/apps/web/components/build/work-control/WorkControlPanel.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { GitBranch, RefreshCcw } from "lucide-react";
 
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
@@ -10,11 +11,16 @@ export function WorkControlPanel({
   capsules,
   adoptable,
   createAction,
+  canCreateGovernedWork = false,
   portalContext,
 }: {
   capsules: WorkCapsuleRow[];
   adoptable: AdoptableWorktreeRow[];
   createAction: CreateGovernedWorkAction;
+  // BI-E167A8A6: gates door 2's create form to manage_backlog holders so a
+  // non-technical operator never faces a second "start work" intake they
+  // cannot use. Defaults false — the create door is hidden unless granted.
+  canCreateGovernedWork?: boolean;
   portalContext?: PortalContextEnvelope | null;
 }) {
   return (
@@ -24,6 +30,26 @@ export function WorkControlPanel({
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">Work Control</h1>
         </div>
       </div>
+
+      {/* BI-E167A8A6: state what this surface is and how it relates to the other
+          Build Studio intake ("Start a new build"). Work Control is the governed
+          engineering substrate; describing a feature in plain English lives in
+          Build Studio. Making the relationship explicit is the fix for the
+          dual-intake IA confusion. */}
+      <p className="max-w-2xl text-sm leading-relaxed text-[var(--dpf-muted)]">
+        The governed engineering substrate for Build Studio — git branches,
+        worktrees, and work capsules for hands-on development and AI coding
+        agents. Every build you start already manages its own capsule here. To
+        describe a feature in plain English and have your AI Coworker design,
+        build, and ship it, use{" "}
+        <Link
+          href="/build"
+          className="font-medium text-[var(--dpf-accent)] hover:underline"
+        >
+          Start a new build
+        </Link>{" "}
+        in Build Studio.
+      </p>
 
       <PortalContextStrip envelope={portalContext ?? null} />
 
@@ -44,7 +70,22 @@ export function WorkControlPanel({
         </div>
       </div>
 
-      <CreateGovernedWorkForm action={createAction} />
+      {canCreateGovernedWork ? (
+        <CreateGovernedWorkForm action={createAction} />
+      ) : (
+        <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm text-[var(--dpf-muted)]">
+          Planning governed work directly is reserved for the manage-backlog role.
+          To start new work, use{" "}
+          <Link
+            href="/build"
+            className="font-medium text-[var(--dpf-accent)] hover:underline"
+          >
+            Start a new build
+          </Link>{" "}
+          in Build Studio — your AI Coworker sets up the capsule and branch for
+          you.
+        </div>
+      )}
 
       <WorkCapsuleTable capsules={capsules} />
       <AdoptableWorktreeTable rows={adoptable} />

--- a/docs/superpowers/specs/2026-07-05-build-studio-dual-work-intake-differentiation-design.md
+++ b/docs/superpowers/specs/2026-07-05-build-studio-dual-work-intake-differentiation-design.md
@@ -1,0 +1,92 @@
+# Build Studio — dual work-intake differentiation (BI-E167A8A6)
+
+- **Epic:** EP-BS-UX-HARDENING
+- **Backlog item:** BI-E167A8A6
+- **Extends:** BI-86D6AD78 (dual-entry clarity, done)
+- **Date:** 2026-07-05
+- **Status:** design + implementation
+
+## Problem
+
+Build Studio exposes two doors to start work, with no stated relationship:
+
+1. **`/build` → "Start a new build"** — a plain-English free-text textarea in the
+   `BuildStudio` sidebar. Submitting calls `createFeatureBuild` → creates a
+   `FeatureBuild` (phase `ideate`) and opens the AI Coworker to interview the
+   operator. This is the outcome-first, non-technical intake.
+2. **`/build/work` → "Plan governed work"** — a structured Title / Taxonomy
+   (`feat|fix|chore|doc|clean`) / Objective form in `WorkControlPanel`.
+   Submitting calls `createGovernedWorkAction` → creates a `WorkCapsule` with a
+   git worktree + branch. This is the governed engineering / git substrate.
+
+Different shapes, both reachable from the Build Studio experience, with no
+explanation of when to use which. A non-technical operator cannot tell which is
+correct.
+
+### Key substrate fact — the capability mismatch
+
+- `/build` (Build Studio) renders for **`view_platform`** → roles HR-000,
+  HR-200, HR-300.
+- `createGovernedWorkAction` requires **`manage_backlog`** → roles HR-000,
+  HR-500 (enforced server-side).
+
+So HR-200 / HR-300 — precisely the non-technical operators who *can* see Build
+Studio — could open the "Plan governed work" form but **could not submit it**
+(it throws `Unauthorized`). Door 2 is a dead door for the population the BI is
+about.
+
+`FeatureBuild` and `WorkCapsule` are related but distinct: a `FeatureBuild`
+already manages its own capsule under the hood; `WorkCapsule` is the lower-level
+governed git container used for hands-on development and coding agents. Unifying
+them behind one router would blur two deliberately-separate layers.
+
+## Decision
+
+Kernel routing (`principle_decide`, population `human`, surface
+`build-studio-work-intake`) found **no commandment conflict** across the three
+candidate options. Scored on the `human_cognitive_load` axis it recommends
+**Option C** with high confidence (composite 1.372, margin 0.459 > tie margin).
+
+**Chosen: Option C + B (hybrid) — audience-gate door 2 to `manage_backlog`
+holders, plus differentiation/relationship copy on both surfaces.**
+
+- **A — unify into one routing entry.** Rejected: adds an intent-classification
+  layer over two distinct substrates, highest blast radius, over-scoped for a
+  medium BI. The real distinction is *audience / capability*, not *phrasing*.
+- **B — differentiation copy only.** Necessary but insufficient alone: leaves
+  both doors visible to operators who cannot use door 2.
+- **C — audience-gate door 2 + copy.** Aligns the UI with the authorization the
+  server already enforces; a non-technical operator sees exactly one door.
+
+## Implementation
+
+1. `apps/web/app/(shell)/build/page.tsx` — compute `canManageGovernedWork` and
+   pass to `BuildStudio`.
+2. `apps/web/components/build/BuildStudio.tsx` — new `canManageGovernedWork?`
+   prop (default `false`). The "Work Control" sidebar link renders only for
+   `manage_backlog` holders and carries a one-line subtitle stating its
+   relationship to "Start a new build"; the primary textarea gains a purpose
+   caption naming door 1.
+3. `apps/web/app/(shell)/build/work/page.tsx` — compute `canCreateGovernedWork`
+   and pass to `WorkControlPanel`.
+4. `apps/web/components/build/work-control/WorkControlPanel.tsx` — new
+   `canCreateGovernedWork?` prop (default `false`). Adds an intro paragraph
+   naming the surface and linking back to "Start a new build"; the create form
+   renders only for `manage_backlog` holders, otherwise an honest fallback note
+   with a recovery link.
+
+No substrate, schema, or route changes. Copy uses theme tokens only.
+
+## Verification
+
+- `WorkControlPanel.test.tsx` — gated create form (present with capability,
+  hidden + fallback without), relationship copy, `href="/build"` link.
+- `CreateGovernedWorkForm.test.tsx` — unchanged, still green.
+- Live Contributor-preview viewport check of `/build` and `/build/work`.
+
+## UX-Fit-Decision
+
+`fits`. Owning area Products › Delivery (Build Studio). Net reduction in surface
+area — removes a dead door and adds only static, theme-tokened copy. Reuses the
+existing `manage_backlog` capability (single source of truth with the server
+action); no new primitives; no prompt-sending controls.


### PR DESCRIPTION
## What & why

Build Studio had **two doors to start work with no stated relationship**, and a non-technical operator couldn't tell which was correct (BI-E167A8A6, epic EP-BS-UX-HARDENING):

- **Door 1** — `/build` → *"Start a new build"* (plain-English textarea → `FeatureBuild`, AI-Coworker-guided).
- **Door 2** — `/build/work` → *"Plan governed work"* (Title/Taxonomy/Objective form → `WorkCapsule` + git worktree/branch).

**Key finding:** door 2's `createGovernedWorkAction` requires `manage_backlog` (HR-000/HR-500), but `/build` renders for `view_platform` (HR-000/HR-200/HR-300). So HR-200/HR-300 — the exact non-technical operators who see Build Studio — could open the "Plan governed work" form but got `Unauthorized` on submit. Door 2 was a **dead door** for them.

## Decision (kernel-routed)

`principle_decide` (population `human`, surface `build-studio-work-intake`) found **no commandment conflict** across three options; scored on `human_cognitive_load` it recommends **Option C** with high confidence (composite 1.372, margin 0.459). Chosen: **C + B hybrid** — audience-gate door 2 to `manage_backlog` holders (matching the server-side auth) so non-technical operators see one clear door, **plus** purpose/relationship copy on both surfaces for operators who see both. Option A (a router over the two distinct `FeatureBuild`/`WorkCapsule` substrates) was rejected as over-scoped and higher blast-radius.

## Changes

- `apps/web/app/(shell)/build/page.tsx` — thread `canManageGovernedWork` into `BuildStudio`.
- `apps/web/components/build/BuildStudio.tsx` — gate the "Work Control" sidebar link to `manage_backlog`; add its relationship subtitle; add a purpose caption naming door 1.
- `apps/web/app/(shell)/build/work/page.tsx` — thread `canCreateGovernedWork`.
- `apps/web/components/build/work-control/WorkControlPanel.tsx` — intro paragraph (governed engineering substrate) + link back to "Start a new build"; gate the create form, with an honest fallback note + recovery link otherwise.
- Design doc under `docs/superpowers/specs/`.

No substrate/schema/route changes. Theme tokens only.

## Tests

`WorkControlPanel.test.tsx` — create form present with capability, hidden + fallback without, relationship copy, `/build` link. `CreateGovernedWorkForm.test.tsx` unchanged. All 9 green locally.

UX-Fit-Decision: fits. Products › Delivery (Build Studio). Net reduction in surface area — removes a dead door, adds only static theme-tokened copy; reuses the existing `manage_backlog` capability (single source of truth with the server action); no new primitives; no prompt-sending controls.

Closes BI-E167A8A6. Extends BI-86D6AD78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)