### PR TITLE
feat(bom): coworker parity/owner on product detail + finish Workforce copy (BI-8F9EDD6C AC2, BI-9A5F0EA3 AC5)

### DIFF
--- a/apps/web/app/(shell)/knowledge/page.tsx
+++ b/apps/web/app/(shell)/knowledge/page.tsx
@@ -17,8 +17,8 @@ const PORTFOLIO_PERSONAS: Record<string, { label: string; description: string }>
     description: "Operational knowledge for delivery and production teams",
   },
   for_employees: {
-    label: "For Employees",
-    description: "People and policy knowledge for HR and managers",
+    label: "Workforce / For Employees",
+    description: "Knowledge for the workforce — human employees and AI coworkers — plus HR, managers, and policy",
   },
   products_and_services_sold: {
     label: "Products & Services Sold",

--- a/apps/web/components/portfolio/DigitalProductDetail.test.tsx
+++ b/apps/web/components/portfolio/DigitalProductDetail.test.tsx
@@ -12,6 +12,7 @@ const emptyVm: DigitalProductView = {
   lifecycleStage: "plan",
   lifecycleStatus: "draft",
   observationConfig: null,
+  coworker: null,
   taxonomyLineage: [],
   portfolio: null,
   primaryEntity: null,
@@ -32,6 +33,7 @@ const fullVm: DigitalProductView = {
   lifecycleStage: "production",
   lifecycleStatus: "active",
   observationConfig: { classifyAs: "infrastructure_endpoint" },
+  coworker: null,
   taxonomyLineage: [
     { nodeId: "foundational", name: "Foundational" },
     { nodeId: "foundational/data_and_storage_management", name: "Data and Storage Management" },
@@ -219,6 +221,43 @@ describe("DigitalProductDetail", () => {
       // No bare JSON-looking blobs (e.g. the entire stringified entity).
       expect(html).not.toContain("entityKey:");
       expect(html).not.toContain('"manufacturer"');
+    });
+  });
+
+  describe("AI coworker product (BI-8F9EDD6C)", () => {
+    const coworkerVm: DigitalProductView = {
+      ...emptyVm,
+      id: "dp_coworker",
+      productId: "coworker-AGT-COO",
+      name: "Chief of Staff",
+      coworker: {
+        agentId: "AGT-COO",
+        humanRoleParity: "HR-000",
+        approvalInterfaceOwner: "HR-000",
+      },
+    };
+
+    it("renders the AI Coworker section with parity anchor + approval owner", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={coworkerVm} />);
+      expect(html).toContain(">AI Coworker<");
+      expect(html).toContain("Human-role parity");
+      expect(html).toContain("Approval / interface owner");
+      expect(html).toContain("AGT-COO");
+      expect(html).toContain("HR-000");
+    });
+
+    it("shows a broad-unassigned owner when no owner role is set", () => {
+      const vm: DigitalProductView = {
+        ...coworkerVm,
+        coworker: { agentId: "AGT-X", humanRoleParity: null, approvalInterfaceOwner: null },
+      };
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={vm} />);
+      expect(html).toContain("broad (unassigned)");
+    });
+
+    it("does not render the AI Coworker section for a non-coworker product", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).not.toMatch(/>AI Coworker</);
     });
   });
 

--- a/apps/web/components/portfolio/DigitalProductDetail.tsx
+++ b/apps/web/components/portfolio/DigitalProductDetail.tsx
@@ -21,6 +21,7 @@ export function DigitalProductDetail({ vm }: Props): ReactElement {
     <div>
       <Header vm={vm} />
       <DescriptionSection description={vm.description} />
+      <CoworkerSection vm={vm} />
       <IdentitySection vm={vm} />
       <TaxonomySection lineage={vm.taxonomyLineage} />
       <LinkedEntitiesSection vm={vm} />
@@ -65,6 +66,35 @@ function DescriptionSection({ description }: { description: string | null }): Re
     <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
       <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">Description</h2>
       <p className="text-sm text-[var(--dpf-text)]">{description}</p>
+    </section>
+  );
+}
+
+// --- AI coworker (role-shaped Workforce product; BI-8F9EDD6C) ----------
+
+function CoworkerSection({ vm }: { vm: DigitalProductView }): ReactElement | null {
+  const coworker = vm.coworker;
+  if (coworker === null) return null;
+  // DOC-7693D528: a coworker product preserves the coworker's identity, its
+  // human-role parity anchor, and its approval/interface owner.
+  const fields = [
+    { label: "Coworker", value: coworker.agentId },
+    { label: "Human-role parity", value: coworker.humanRoleParity },
+    { label: "Approval / interface owner", value: coworker.approvalInterfaceOwner ?? "broad (unassigned)" },
+  ];
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">AI Coworker</h2>
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+        {fields.map((f) => (
+          <div key={f.label} className="flex flex-col">
+            <dt className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">
+              {f.label}
+            </dt>
+            <dd className="text-[var(--dpf-text)]">{f.value ?? "—"}</dd>
+          </div>
+        ))}
+      </dl>
     </section>
   );
 }

--- a/apps/web/lib/portfolio/digital-product-view-model.test.ts
+++ b/apps/web/lib/portfolio/digital-product-view-model.test.ts
@@ -69,6 +69,62 @@ describe("toDigitalProductViewModel", () => {
     expect(vm.observationConfig).toEqual({ classifyAs: "infrastructure_endpoint" });
   });
 
+  it("projects the coworker summary from coworker_service observationConfig markers", () => {
+    const vm = toDigitalProductViewModel({
+      product: {
+        ...baseProduct,
+        productId: "coworker-AGT-COO",
+        observationConfig: {
+          sourceKind: "coworker_service",
+          projectedBy: "portfolio-source-projector",
+          agentId: "AGT-COO",
+          humanRoleParity: "HR-000",
+          approvalInterfaceOwnerRole: "HR-000",
+        },
+      },
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.coworker).toEqual({
+      agentId: "AGT-COO",
+      humanRoleParity: "HR-000",
+      approvalInterfaceOwner: "HR-000",
+    });
+  });
+
+  it("coworker is null for non-coworker products, and empty markers become null", () => {
+    // Non-coworker product.
+    expect(
+      toDigitalProductViewModel({
+        product: baseProduct,
+        taxonomyAncestors: [],
+        inventoryEntities: [],
+        qualityIssues: [],
+      }).coworker,
+    ).toBeNull();
+    // Coworker product with an unassigned owner (empty-string markers).
+    const vm = toDigitalProductViewModel({
+      product: {
+        ...baseProduct,
+        observationConfig: {
+          sourceKind: "coworker_service",
+          agentId: "AGT-X",
+          humanRoleParity: "",
+          approvalInterfaceOwnerRole: "",
+        },
+      },
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.coworker).toEqual({
+      agentId: "AGT-X",
+      humanRoleParity: null,
+      approvalInterfaceOwner: null,
+    });
+  });
+
   it("returns null observationConfig when absent or malformed", () => {
     const vm1 = toDigitalProductViewModel({
       product: { ...baseProduct, observationConfig: null },

--- a/apps/web/lib/portfolio/digital-product-view-model.ts
+++ b/apps/web/lib/portfolio/digital-product-view-model.ts
@@ -20,6 +20,20 @@
 export type FreshnessValue = "fresh" | "stale" | "retired";
 export type EnrichmentStatusValue = "pending" | "enriched" | "partial" | "failed";
 
+/**
+ * Present only for products projected from an AI coworker (sourceKind
+ * "coworker_service", BI-8F9EDD6C). Carries the DOC-7693D528 relationship the
+ * product must preserve: the coworker's identity, its human-role parity anchor,
+ * and its approval/interface owner. Sourced from DigitalProduct.observationConfig.
+ */
+export interface CoworkerProductSummary {
+  agentId: string | null;
+  /** The equivalent/adjacent human role (HR role id) the coworker is patterned against. */
+  humanRoleParity: string | null;
+  /** The responsible human approval/interface owner (HR role id). */
+  approvalInterfaceOwner: string | null;
+}
+
 export interface DigitalProductView {
   id: string;
   productId: string;
@@ -29,6 +43,9 @@ export interface DigitalProductView {
   lifecycleStage: string;
   lifecycleStatus: string;
   observationConfig: { classifyAs?: string } | null;
+
+  /** Present only for AI-coworker-sourced products (BI-8F9EDD6C); null otherwise. */
+  coworker: CoworkerProductSummary | null;
 
   taxonomyLineage: Array<{ nodeId: string; name: string }>; // breadcrumb root -> leaf
   portfolio: { id: string; slug: string; name: string } | null;
@@ -142,6 +159,27 @@ function projectObservationConfig(value: unknown): { classifyAs?: string } | nul
   return out;
 }
 
+/** Non-empty string, else null — coworker markers are stored as "" when absent. */
+function nonEmpty(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Project the AI-coworker markers the coworker projector stamps into
+ * observationConfig (sourceKind "coworker_service", agentId, humanRoleParity,
+ * approvalInterfaceOwnerRole). Returns null for any non-coworker product, so the
+ * detail page renders the coworker section only when it applies (BI-8F9EDD6C).
+ */
+function projectCoworker(value: unknown): CoworkerProductSummary | null {
+  if (!isPlainObject(value)) return null;
+  if (value.sourceKind !== "coworker_service") return null;
+  return {
+    agentId: nonEmpty(value.agentId),
+    humanRoleParity: nonEmpty(value.humanRoleParity),
+    approvalInterfaceOwner: nonEmpty(value.approvalInterfaceOwnerRole),
+  };
+}
+
 function projectTaxonomyLineage(
   ancestors: Array<{ nodeId: string; name: string }>,
   leaf: { nodeId: string; name: string } | null,
@@ -206,6 +244,7 @@ export function toDigitalProductViewModel(
     lifecycleStage: product.lifecycleStage,
     lifecycleStatus: product.lifecycleStatus,
     observationConfig: projectObservationConfig(product.observationConfig),
+    coworker: projectCoworker(product.observationConfig),
     taxonomyLineage: projectTaxonomyLineage(taxonomyAncestors, product.taxonomyNode),
     portfolio: product.portfolio,
     primaryEntity: projectLinkedEntities(inventoryEntities)[0] ?? null,
@@ -217,4 +256,3 @@ export function toDigitalProductViewModel(
     openQualityIssues: projectOpenQualityIssues(qualityIssues),
   };
 }
-

--- a/prompts/route-persona/portfolio-advisor.prompt.md
+++ b/prompts/route-persona/portfolio-advisor.prompt.md
@@ -26,7 +26,7 @@ interpretiveModel: "Risk-adjusted return on investment — healthy when no singl
 
 # Role
 
-You are the Portfolio Analyst for the `/portfolio` route. You see every initiative through the lens of investment, return, and risk. You encode the world as budget allocations, health scores (active / total product ratios), and portfolio balance across 4 root portfolios — Foundational, Manufacturing & Delivery, For Employees, Products & Services Sold — each with a 481-node DPPM taxonomy tree.
+You are the Portfolio Analyst for the `/portfolio` route. You see every initiative through the lens of investment, return, and risk. You encode the world as budget allocations, health scores (active / total product ratios), and portfolio balance across 4 root portfolios — Foundational, Manufacturing & Delivery, Workforce / For Employees (humans **and** AI coworkers), Products & Services Sold — each with a 481-node DPPM taxonomy tree.
 
 You optimise for risk-adjusted return. A portfolio is healthy when no single failure can cascade, budgets are aligned with strategic priorities, and health scores trend upward.
 


### PR DESCRIPTION
## What & why

Closes the two acceptance-criteria tails left open by **[#2600](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2600)** (the EP-BOM-WIRING Workforce activation + coworker-DigitalProducts PR), per its documented follow-up. Consumes DOC-7693D528 + DOC-1996319D.

## BI-8F9EDD6C AC2 — coworker parity/owner on the product detail page
- **`digital-product-view-model.ts`**: projects the coworker markers the projector stamps into `observationConfig` (`sourceKind: "coworker_service"`, `agentId`, `humanRoleParity`, `approvalInterfaceOwnerRole`) into a typed `vm.coworker` — `null` for non-coworker products; empty markers → `null`.
- **`DigitalProductDetail.tsx`**: new **"AI Coworker"** section rendering the human-role parity anchor + approval/interface owner (falls back to "broad (unassigned)"). Theme-aware; renders only when the product is coworker-sourced. Together with the existing `/portfolio/product/[id]/*` sub-routes (backlog, knowledge, offerings) this completes AC2's "product detail can show … parity anchor and approval/interface ownership."

## BI-9A5F0EA3 AC5 — finish the Workforce copy
- **`portfolio-advisor.prompt.md`** and **`/knowledge`** nav label + description: "For Employees" → **"Workforce / For Employees (humans and AI coworkers)"** — the remaining route/prompt copy that still implied human-only. (Canonical portfolio label/description were already done in #2600. The binary 4-portfolio `.xlsx` reference artifacts are left as-is — they're non-load-bearing reference exports, not a generated source.)

## Verification (worktree, shared pnpm store)
- ✅ web `vitest` `digital-product-view-model` + `DigitalProductDetail` — **33 passed** (coworker projection: present/null/empty-markers; section render/omit/unassigned-owner).
- ✅ `apps/web` `tsc --noEmit` clean.
- ✅ `pnpm --filter web build` (see CI Production Build). No migration.

## Gate attestations
**UX-Fit-Decision:** additive read-only detail section — no new route, form, or operator-configurable input; parity anchor + approval owner are derived from existing data, not asked. Reuses the detail page's existing `<dl>` section pattern; progressive disclosure preserved.

**Process-Spine-Decision:** no new plan needed — this closes the named deferred sub-items of the existing EP-BOM-WIRING plan (`docs/superpowers/plans/2026-07-04-bom-workforce-activation-and-coworker-digitalproducts-plan.md`, merged in #2600); the `portfolio-advisor.prompt.md` durable resource is also updated here.

With this merged, both **BI-9A5F0EA3** and **BI-8F9EDD6C** have all acceptance criteria met and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
