### PR TITLE
feat(mdm): customer merge lifecycle — orchestrator, adapters, tombstones, steward surfaces (EP-4A12A7CB WG-4)

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -9,6 +9,7 @@ import { CustomerLifecycleReviewQueues } from "@/components/customer/CustomerLif
 import { CustomerSiteTree } from "@/components/customer/CustomerSiteTree";
 import { NewCustomerSiteButton } from "@/components/customer/NewCustomerSiteButton";
 import { AccountLifecycleActions } from "@/components/customer/AccountLifecycleActions";
+import { MergeCustomerAccountButton } from "@/components/customer/MergeCustomerAccountButton";
 import { loadCustomerEstateSummary } from "@/lib/customer-estate/account-estate-summary";
 import type { TechnologySourceType } from "@/lib/customer-estate/lifecycle-evaluation";
 import {
@@ -229,11 +230,29 @@ export default async function AccountDetailPage({
         <span className="text-xs text-[var(--dpf-text)]">{account.name}</span>
       </div>
 
+      {/* Merge tombstone banner */}
+      {account.status === "superseded" && account.mergedIntoId && (
+        <div className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3">
+          <p className="text-sm text-[var(--dpf-text)]">
+            This account was merged into another record.{" "}
+            <Link href={`/customer/${account.mergedIntoId}`} className="text-[var(--dpf-accent)] hover:underline">
+              View the current account
+            </Link>
+            . It is kept for history and is excluded from account lists.
+          </p>
+        </div>
+      )}
+
       {/* Header */}
       <div className="mb-6">
-        <div className="flex items-center gap-2 mb-1">
-          <h1 className="text-xl font-bold text-[var(--dpf-text)]">{account.name}</h1>
-          <CustomerStatusBadge label={statusMeta.label} tone={statusMeta.tone} />
+        <div className="flex items-center justify-between gap-2 mb-1">
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold text-[var(--dpf-text)]">{account.name}</h1>
+            <CustomerStatusBadge label={statusMeta.label} tone={statusMeta.tone} />
+          </div>
+          {account.status !== "superseded" && (
+            <MergeCustomerAccountButton accountId={account.id} accountName={account.name} />
+          )}
         </div>
         <p className="text-[10px] font-mono text-[var(--dpf-muted)]">
           {account.accountId}

--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -1,6 +1,7 @@
 // apps/web/app/(shell)/customer/page.tsx
 import Link from "next/link";
 import { prisma } from "@dpf/db";
+import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
 import { NewCustomerButton } from "@/components/customer/NewCustomerButton";
 import { RevenueCockpit } from "@/components/customer/RevenueCockpit";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
@@ -27,6 +28,7 @@ export default async function CustomerPage({
     orgSettings,
   ] = await Promise.all([
     prisma.customerAccount.findMany({
+      where: EXCLUDE_TOMBSTONED,
       orderBy: { name: "asc" },
       select: {
         id: true,

--- a/apps/web/app/(shell)/member-equity/page.tsx
+++ b/apps/web/app/(shell)/member-equity/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
 import { hasActiveOrgCapability } from "@/lib/storefront/civic-surfaces.server";
 import {
   MemberEquityPanel,
@@ -14,6 +15,7 @@ export default async function MemberEquityPage() {
 
   const [accounts, entries] = await Promise.all([
     prisma.customerAccount.findMany({
+      where: EXCLUDE_TOMBSTONED,
       orderBy: { name: "asc" },
       take: 200,
       select: { id: true, accountId: true, name: true, status: true },

--- a/apps/web/app/(shell)/platform/edge-nodes/page.tsx
+++ b/apps/web/app/(shell)/platform/edge-nodes/page.tsx
@@ -16,6 +16,7 @@
 import { redirect } from "next/navigation";
 
 import { prisma } from "@dpf/db";
+import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
@@ -156,6 +157,7 @@ export default async function EdgeNodesAdminPage() {
   });
 
   const customerAccounts = await prisma.customerAccount.findMany({
+    where: EXCLUDE_TOMBSTONED,
     orderBy: { name: "asc" },
     select: {
       id: true,

--- a/apps/web/app/api/v1/customer/accounts/route.ts
+++ b/apps/web/app/api/v1/customer/accounts/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from "next/server";
 import { prisma } from "@dpf/db";
+import { CUSTOMER_TOMBSTONE_STATUSES } from "@dpf/db/customer-lifecycle";
 import { authenticateRequest } from "@/lib/api/auth-middleware";
 import { ApiError } from "@/lib/api/error";
 import { apiSuccess } from "@/lib/api/response";
@@ -23,6 +24,9 @@ export async function GET(request: Request) {
     }
     if (status) {
       where.status = status;
+    } else {
+      // Default reads exclude merge tombstones (superseded rows).
+      where.status = { notIn: [...CUSTOMER_TOMBSTONE_STATUSES] };
     }
     if (search) {
       // Use full-text search if available, fall back to ILIKE

--- a/apps/web/components/customer/MergeCustomerAccountButton.tsx
+++ b/apps/web/components/customer/MergeCustomerAccountButton.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  listCustomerAccountMergeTargets,
+  mergeCustomerAccounts,
+  previewCustomerAccountMerge,
+  type MergeImpactPreview,
+} from "@/lib/actions/customer-merge";
+
+const selectClasses =
+  "bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-3 py-2 text-sm focus:border-[var(--dpf-accent)] focus:outline-none w-full";
+
+/** Plain-language wording for the repoint impact steps. */
+const IMPACT_LABELS: Record<string, string> = {
+  "customerContact.accountId": "contacts",
+  "contactAccountRole.accountId": "contact roles",
+  "customerSite.accountId": "sites",
+  "opportunity.accountId": "opportunities",
+  "quote.accountId": "quotes",
+  "salesOrder.accountId": "sales orders",
+  "invoice.accountId": "invoices",
+  "engagement.accountId": "engagements",
+  "activity.accountId": "activity history",
+  "serviceTicket.customerAccountId": "service tickets",
+  "customerAccount.parentAccountId": "child accounts",
+};
+
+function impactLabel(step: string): string {
+  return IMPACT_LABELS[step] ?? step.split(".")[0] ?? step;
+}
+
+/**
+ * Steward merge control on the account detail page: merges THIS account (the
+ * duplicate) into a chosen survivor, with a usage-impact preview before the
+ * destructive-ish confirm. Admin-gated server-side.
+ */
+export function MergeCustomerAccountButton({ accountId, accountName }: { accountId: string; accountName: string }) {
+  const [open, setOpen] = useState(false);
+  const [targets, setTargets] = useState<Array<{ id: string; name: string; accountId: string }> | null>(null);
+  const [survivorId, setSurvivorId] = useState("");
+  const [preview, setPreview] = useState<MergeImpactPreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function openModal() {
+    setOpen(true);
+    setError(null);
+    setPreview(null);
+    setSurvivorId("");
+    startTransition(async () => {
+      const result = await listCustomerAccountMergeTargets(accountId);
+      if (result.ok) setTargets(result.data);
+      else setError(result.message);
+    });
+  }
+
+  function loadPreview(id: string) {
+    setSurvivorId(id);
+    setPreview(null);
+    setError(null);
+    if (!id) return;
+    startTransition(async () => {
+      const result = await previewCustomerAccountMerge(accountId, id);
+      if (result.ok) setPreview(result.data);
+      else setError(result.message);
+    });
+  }
+
+  function confirmMerge() {
+    if (!survivorId) return;
+    startTransition(async () => {
+      const result = await mergeCustomerAccounts(accountId, survivorId);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setOpen(false);
+      router.push(`/customer/${survivorId}`);
+      router.refresh();
+    });
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={openModal}
+        className="px-3 py-1.5 rounded-md text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] border border-[var(--dpf-border)]"
+      >
+        Merge into…
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={() => setOpen(false)} />
+      <div className="fixed top-20 right-8 z-50 w-[440px] bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg shadow-xl">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--dpf-border)]">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Merge “{accountName}” into…</h2>
+          <button
+            onClick={() => setOpen(false)}
+            className="text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] text-lg"
+            aria-label="Close"
+          >
+            x
+          </button>
+        </div>
+        <div className="p-4 space-y-3">
+          <p className="text-xs text-[var(--dpf-muted)]">
+            Everything on this account moves to the account you pick; this one is kept as a
+            superseded record pointing at it. Nothing is deleted.
+          </p>
+          <select
+            value={survivorId}
+            onChange={(e) => loadPreview(e.target.value)}
+            className={selectClasses}
+            disabled={targets === null}
+          >
+            <option value="">{targets === null ? "Loading accounts…" : "Choose the account to keep"}</option>
+            {(targets ?? []).map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name} ({t.accountId})
+              </option>
+            ))}
+          </select>
+
+          {preview && (
+            <div className="rounded border border-[var(--dpf-border)] px-3 py-2 space-y-1">
+              <p className="text-xs font-semibold text-[var(--dpf-text)]">
+                Will move to {preview.survivor.name}:
+              </p>
+              {Object.keys(preview.impact).length === 0 ? (
+                <p className="text-xs text-[var(--dpf-muted)]">No related records — only the account itself.</p>
+              ) : (
+                <ul className="text-xs text-[var(--dpf-muted)]">
+                  {Object.entries(preview.impact).map(([step, count]) => (
+                    <li key={step}>
+                      {count} {impactLabel(step)}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {error && <p className="text-xs text-[var(--dpf-text)]">{error}</p>}
+
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="px-3 py-1.5 rounded-md text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] border border-[var(--dpf-border)]"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={isPending || !preview}
+              onClick={confirmMerge}
+              className="px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {isPending ? "Merging…" : "Merge accounts"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/lib/actions/customer-merge.ts
+++ b/apps/web/lib/actions/customer-merge.ts
@@ -1,0 +1,124 @@
+"use server";
+
+/**
+ * Governed customer-account merge actions (EP-4A12A7CB WG-4, spec §5.4-5.5).
+ *
+ * Admin-gated (mirrors the reference-data merge surface); the heavy lifting —
+ * validation, snapshot, repointing, collision plans, tombstone — lives in the
+ * shared orchestrator (lib/mdm/merge.ts). Preview-before-merge is mandatory
+ * UX: the impact counts come from the same adapter the merge executes, so the
+ * preview cannot drift from the operation.
+ */
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  MERGE_ADAPTERS,
+  MergeValidationFailure,
+  mergeRecords,
+  type MergeResult,
+} from "@/lib/mdm/merge";
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; message: string };
+
+async function requireAdmin(): Promise<{ ok: false; message: string } | null> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_admin")
+  ) {
+    return { ok: false, message: "Not authorized." };
+  }
+  return null;
+}
+
+/** Active accounts eligible as a merge survivor (excludes self + tombstones). */
+export async function listCustomerAccountMergeTargets(
+  excludeId: string,
+): Promise<ActionResult<Array<{ id: string; name: string; accountId: string; status: string }>>> {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+  const targets = await prisma.customerAccount.findMany({
+    where: { id: { not: excludeId }, status: { not: "superseded" } },
+    orderBy: { name: "asc" },
+    take: 200,
+    select: { id: true, name: true, accountId: true, status: true },
+  });
+  return { ok: true, data: targets };
+}
+
+export type MergeImpactPreview = {
+  loser: { id: string; name: string; accountId: string; status: string };
+  survivor: { id: string; name: string; accountId: string; status: string };
+  /** Row counts that would repoint, per relation step (zero rows omitted). */
+  impact: Record<string, number>;
+};
+
+/** Count affected rows per adapter step BEFORE the merge (usage-impact preview). */
+export async function previewCustomerAccountMerge(
+  loserId: string,
+  survivorId: string,
+): Promise<ActionResult<MergeImpactPreview>> {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+  if (loserId === survivorId) return { ok: false, message: "Pick two different accounts." };
+
+  const select = { id: true, name: true, accountId: true, status: true };
+  const [loser, survivor] = await Promise.all([
+    prisma.customerAccount.findUnique({ where: { id: loserId }, select }),
+    prisma.customerAccount.findUnique({ where: { id: survivorId }, select }),
+  ]);
+  if (!loser || !survivor) return { ok: false, message: "Account not found." };
+  if (loser.status === "superseded" || survivor.status === "superseded") {
+    return { ok: false, message: "A superseded account cannot participate in a merge." };
+  }
+
+  const adapter = MERGE_ADAPTERS["customer-account"];
+  const impact: Record<string, number> = {};
+  const client = prisma as unknown as Record<string, { count: (args: unknown) => Promise<number> }>;
+  for (const step of [...adapter.hardRelations, ...adapter.softReferences]) {
+    const where: Record<string, unknown> = { [step.field]: loserId };
+    if (step.model === "customerAccount") where["id"] = { not: loserId };
+    const count = await client[step.model]!.count({ where });
+    if (count > 0) impact[`${step.model}.${step.field}`] = count;
+  }
+  return { ok: true, data: { loser, survivor, impact } };
+}
+
+/** Execute the merge (loser → survivor) and log the audit activity. */
+export async function mergeCustomerAccounts(
+  loserId: string,
+  survivorId: string,
+): Promise<ActionResult<MergeResult>> {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+
+  let result: MergeResult;
+  try {
+    result = await mergeRecords("customer-account", loserId, survivorId);
+  } catch (err) {
+    if (err instanceof MergeValidationFailure) {
+      return { ok: false, message: `Merge rejected: ${err.reason}.` };
+    }
+    throw err;
+  }
+
+  // Audit trail: the full MergeResult (snapshot + repoint counts) as a system
+  // activity; coworker-path merges additionally land in ToolExecution.result.
+  await prisma.activity.create({
+    data: {
+      activityId: `ACT-${crypto.randomUUID()}`,
+      type: "account_merged",
+      subject: `Account merged into survivor ${survivorId}`,
+      body: JSON.stringify(result),
+      accountId: survivorId,
+      createdById: null,
+    },
+  });
+
+  revalidatePath("/customer");
+  revalidatePath(`/customer/${survivorId}`);
+  return { ok: true, data: result };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1,7 +1,12 @@
 import type { CapabilityKey } from "@/lib/permissions";
 import { can, type UserContext } from "@/lib/permissions";
+<<<<<<< HEAD
 import { DISCOVERY_TRIAGE_AGENT_ID, prisma } from "@dpf/db";
 import { handleUpdateBacklogItem } from "./mcp-handlers/update-backlog-item";
+=======
+import { DISCOVERY_TRIAGE_AGENT_ID, attributeBacklogPortfolio, prisma } from "@dpf/db";
+import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
+>>>>>>> a6f402426 (feat(mdm): customer merge lifecycle — orchestrator, adapters, tombstones, steward surfaces (EP-4A12A7CB WG-4))
 // Static import: executeTool is a hot path; dynamic import per call would hurt throughput.
 import { evaluateExecution } from "@/lib/kernel/runtime-gate";
 import { loadEnforceablePrinciples } from "@/lib/kernel/load-enforceable-principles";
@@ -1132,6 +1137,20 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "operate_customer",
     sideEffect: true,
     coworkerArtifact: true,
+  },
+  {
+    name: "merge_customer_accounts",
+    description: "Merge a duplicate customer account into the one to keep. Use when two accounts are confirmed to be the same real company (e.g. created under slightly different spellings). All related records (contacts, sites, opportunities, quotes, invoices, tickets, etc.) move to the surviving account; the duplicate is kept as a superseded tombstone pointing at the survivor — nothing is deleted. Not reversible from this tool, so confirm with the user which account survives before calling. Pass the account to KEEP as survivorAccountId and the duplicate as loserAccountId (CustomerAccount.id values from list_customer_accounts or a duplicates_found response).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        survivorAccountId: { type: "string", description: "CustomerAccount.id of the account to KEEP." },
+        loserAccountId: { type: "string", description: "CustomerAccount.id of the duplicate to merge away (tombstoned, not deleted)." },
+      },
+      required: ["survivorAccountId", "loserAccountId"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
   },
   {
     name: "create_opportunity",
@@ -14811,7 +14830,8 @@ export async function executeTool(
       const status = typeof params["status"] === "string" ? params["status"].trim() : undefined;
       const take = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
       const accounts = await prisma.customerAccount.findMany({
-        where: status ? { status } : undefined,
+        // Default reads exclude merge tombstones (superseded rows).
+        where: status ? { status } : EXCLUDE_TOMBSTONED,
         orderBy: { createdAt: "desc" },
         take,
         select: {
@@ -14943,6 +14963,36 @@ export async function executeTool(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         return { success: false, error: "create_failed", message: `create_customer_account failed: ${msg}` };
+      }
+    }
+
+    case "merge_customer_accounts": {
+      const survivorId = typeof params["survivorAccountId"] === "string" ? params["survivorAccountId"].trim() : "";
+      const loserId = typeof params["loserAccountId"] === "string" ? params["loserAccountId"].trim() : "";
+      if (!survivorId || !loserId) {
+        return { success: false, error: "missing_fields", message: "survivorAccountId and loserAccountId are both required (CustomerAccount.id values)." };
+      }
+      const { mergeRecords, MergeValidationFailure } = await import("@/lib/mdm/merge");
+      try {
+        const result = await mergeRecords("customer-account", loserId, survivorId);
+        await prisma.activity.create({
+          data: {
+            activityId: `ACT-${crypto.randomUUID()}`,
+            type: "account_merged",
+            subject: `Account merged into survivor ${survivorId}`,
+            body: JSON.stringify(result),
+            accountId: survivorId,
+            createdById: null,
+          },
+        });
+        const moved = Object.entries(result.repointed).map(([step, count]) => `${step}: ${count}`).join(", ") || "no related rows";
+        return { success: true, message: `Merged duplicate account ${loserId} into ${survivorId}. Moved ${moved}. The duplicate is kept as a superseded record pointing at the survivor.`, data: { survivorId, loserId, repointed: result.repointed, nestedSiteMerges: result.nestedSiteMerges } };
+      } catch (err) {
+        if (err instanceof MergeValidationFailure) {
+          return { success: false, error: "merge_rejected", message: `Merge rejected: ${err.reason}. Check both ids exist, differ, and neither is already superseded.` };
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        return { success: false, error: "merge_failed", message: `merge_customer_accounts failed: ${msg}` };
       }
     }
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1,12 +1,8 @@
 import type { CapabilityKey } from "@/lib/permissions";
 import { can, type UserContext } from "@/lib/permissions";
-<<<<<<< HEAD
 import { DISCOVERY_TRIAGE_AGENT_ID, prisma } from "@dpf/db";
 import { handleUpdateBacklogItem } from "./mcp-handlers/update-backlog-item";
-=======
-import { DISCOVERY_TRIAGE_AGENT_ID, attributeBacklogPortfolio, prisma } from "@dpf/db";
 import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
->>>>>>> a6f402426 (feat(mdm): customer merge lifecycle — orchestrator, adapters, tombstones, steward surfaces (EP-4A12A7CB WG-4))
 // Static import: executeTool is a hot path; dynamic import per call would hurt throughput.
 import { evaluateExecution } from "@/lib/kernel/runtime-gate";
 import { loadEnforceablePrinciples } from "@/lib/kernel/load-enforceable-principles";
@@ -52,6 +48,7 @@ import { marketingPack } from "@/lib/mcp/packs/marketing-pack";
 import { workCapturePack } from "@/lib/mcp/packs/work-capture-pack";
 import { orgDecisionPack } from "@/lib/mcp/packs/org-decision-pack";
 import { activityRoutingPack } from "@/lib/mcp/packs/activity-routing-pack";
+import { mdmStewardshipPack } from "@/lib/mcp/packs/mdm-stewardship-pack";
 import { selfUpgradePack } from "@/lib/mcp/packs/self-upgrade-pack";
 import { coworkerServiceCatalogPack } from "@/lib/mcp/packs/coworker-service-catalog-pack";
 import { coworkerToolGrantPack } from "@/lib/mcp/packs/coworker-tool-grant-pack";
@@ -444,7 +441,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, mdmStewardshipPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,
@@ -1137,20 +1134,6 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "operate_customer",
     sideEffect: true,
     coworkerArtifact: true,
-  },
-  {
-    name: "merge_customer_accounts",
-    description: "Merge a duplicate customer account into the one to keep. Use when two accounts are confirmed to be the same real company (e.g. created under slightly different spellings). All related records (contacts, sites, opportunities, quotes, invoices, tickets, etc.) move to the surviving account; the duplicate is kept as a superseded tombstone pointing at the survivor — nothing is deleted. Not reversible from this tool, so confirm with the user which account survives before calling. Pass the account to KEEP as survivorAccountId and the duplicate as loserAccountId (CustomerAccount.id values from list_customer_accounts or a duplicates_found response).",
-    inputSchema: {
-      type: "object",
-      properties: {
-        survivorAccountId: { type: "string", description: "CustomerAccount.id of the account to KEEP." },
-        loserAccountId: { type: "string", description: "CustomerAccount.id of the duplicate to merge away (tombstoned, not deleted)." },
-      },
-      required: ["survivorAccountId", "loserAccountId"],
-    },
-    requiredCapability: "operate_customer",
-    sideEffect: true,
   },
   {
     name: "create_opportunity",
@@ -14963,36 +14946,6 @@ export async function executeTool(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         return { success: false, error: "create_failed", message: `create_customer_account failed: ${msg}` };
-      }
-    }
-
-    case "merge_customer_accounts": {
-      const survivorId = typeof params["survivorAccountId"] === "string" ? params["survivorAccountId"].trim() : "";
-      const loserId = typeof params["loserAccountId"] === "string" ? params["loserAccountId"].trim() : "";
-      if (!survivorId || !loserId) {
-        return { success: false, error: "missing_fields", message: "survivorAccountId and loserAccountId are both required (CustomerAccount.id values)." };
-      }
-      const { mergeRecords, MergeValidationFailure } = await import("@/lib/mdm/merge");
-      try {
-        const result = await mergeRecords("customer-account", loserId, survivorId);
-        await prisma.activity.create({
-          data: {
-            activityId: `ACT-${crypto.randomUUID()}`,
-            type: "account_merged",
-            subject: `Account merged into survivor ${survivorId}`,
-            body: JSON.stringify(result),
-            accountId: survivorId,
-            createdById: null,
-          },
-        });
-        const moved = Object.entries(result.repointed).map(([step, count]) => `${step}: ${count}`).join(", ") || "no related rows";
-        return { success: true, message: `Merged duplicate account ${loserId} into ${survivorId}. Moved ${moved}. The duplicate is kept as a superseded record pointing at the survivor.`, data: { survivorId, loserId, repointed: result.repointed, nestedSiteMerges: result.nestedSiteMerges } };
-      } catch (err) {
-        if (err instanceof MergeValidationFailure) {
-          return { success: false, error: "merge_rejected", message: `Merge rejected: ${err.reason}. Check both ids exist, differ, and neither is already superseded.` };
-        }
-        const msg = err instanceof Error ? err.message : String(err);
-        return { success: false, error: "merge_failed", message: `merge_customer_accounts failed: ${msg}` };
       }
     }
 

--- a/apps/web/lib/mcp/packs/mdm-stewardship-pack.ts
+++ b/apps/web/lib/mcp/packs/mdm-stewardship-pack.ts
@@ -1,0 +1,102 @@
+// MDM stewardship tool pack (EP-4A12A7CB WG-4).
+//
+// Customer master-data stewardship doors for coworkers — currently the
+// governed account merge. The merge invariants (validate, snapshot, repoint,
+// collision plans, tombstone) live in lib/mdm/merge.ts; this pack owns the
+// tool contract. Merge is link + supersede, never a hard-delete: the loser
+// row survives as a superseded tombstone pointing at the survivor.
+
+import { prisma } from "@dpf/db";
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "merge_customer_accounts",
+    description:
+      "Merge a duplicate customer account into the one to keep. Use when two accounts are confirmed to be the same real company (e.g. created under slightly different spellings). All related records (contacts, sites, opportunities, quotes, invoices, tickets, etc.) move to the surviving account; the duplicate is kept as a superseded tombstone pointing at the survivor — nothing is deleted. Not reversible from this tool, so confirm with the user which account survives before calling. Pass the account to KEEP as survivorAccountId and the duplicate as loserAccountId (CustomerAccount.id values from list_customer_accounts or a duplicates_found response).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        survivorAccountId: {
+          type: "string",
+          description: "CustomerAccount.id of the account to KEEP.",
+        },
+        loserAccountId: {
+          type: "string",
+          description: "CustomerAccount.id of the duplicate to merge away (tombstoned, not deleted).",
+        },
+      },
+      required: ["survivorAccountId", "loserAccountId"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+  },
+];
+
+async function mergeCustomerAccountsTool(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const survivorId =
+    typeof params["survivorAccountId"] === "string" ? params["survivorAccountId"].trim() : "";
+  const loserId =
+    typeof params["loserAccountId"] === "string" ? params["loserAccountId"].trim() : "";
+  if (!survivorId || !loserId) {
+    return {
+      success: false,
+      error: "missing_fields",
+      message: "survivorAccountId and loserAccountId are both required (CustomerAccount.id values).",
+    };
+  }
+  const { mergeRecords, MergeValidationFailure } = await import("@/lib/mdm/merge");
+  try {
+    const result = await mergeRecords("customer-account", loserId, survivorId);
+    await prisma.activity.create({
+      data: {
+        activityId: `ACT-${crypto.randomUUID()}`,
+        type: "account_merged",
+        subject: `Account merged into survivor ${survivorId}`,
+        body: JSON.stringify(result),
+        accountId: survivorId,
+        createdById: null,
+      },
+    });
+    const moved =
+      Object.entries(result.repointed)
+        .map(([step, count]) => `${step}: ${count}`)
+        .join(", ") || "no related rows";
+    return {
+      success: true,
+      message: `Merged duplicate account ${loserId} into ${survivorId}. Moved ${moved}. The duplicate is kept as a superseded record pointing at the survivor.`,
+      data: {
+        survivorId,
+        loserId,
+        repointed: result.repointed,
+        nestedSiteMerges: result.nestedSiteMerges,
+      },
+    };
+  } catch (err) {
+    if (err instanceof MergeValidationFailure) {
+      return {
+        success: false,
+        error: "merge_rejected",
+        message: `Merge rejected: ${err.reason}. Check both ids exist, differ, and neither is already superseded.`,
+      };
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, error: "merge_failed", message: `merge_customer_accounts failed: ${msg}` };
+  }
+}
+
+export const mdmStewardshipPack: ToolPack = {
+  packId: "mdm-stewardship",
+  definitions,
+  handlers: {
+    merge_customer_accounts: (params) => mergeCustomerAccountsTool(params),
+  },
+  grants: {
+    // Mirrors agent-grants.ts TOOL_TO_GRANTS (the gating source): merging
+    // duplicates is customer-data stewardship inside the CRM-write envelope.
+    merge_customer_accounts: ["crm_write"],
+  },
+};

--- a/apps/web/lib/mdm/merge-adapters-completeness.test.ts
+++ b/apps/web/lib/mdm/merge-adapters-completeness.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { MERGE_ADAPTERS } from "./merge";
+
+/**
+ * Adapter completeness guard (spec §5.4): every FK relation in schema.prisma
+ * that points at a mergeable canonical model must be declared in that
+ * domain's adapter (or explicitly waived here with a reason). A feature that
+ * adds a new relation to CustomerAccount/CustomerSite without updating the
+ * merge adapter fails this test instead of orphaning rows at merge time.
+ *
+ * Soft references have no schema relation to diff against — the adapter is
+ * their single home (reviewed in PR); this guard covers the FK side.
+ */
+
+const SCHEMA_PATH = join(__dirname, "..", "..", "..", "..", "packages", "db", "prisma", "schema.prisma");
+
+/** Relations intentionally NOT repointed, with the reason. */
+const WAIVED: Record<string, string> = {
+  "CustomerAccount.mergedIntoId":
+    "the tombstone pointer itself — merged-away rows keep pointing at their survivor",
+  "CustomerSite.mergedIntoId":
+    "the tombstone pointer itself — merged-away rows keep pointing at their survivor",
+};
+
+const MODEL_NAME: Record<string, string> = {
+  "customer-account": "CustomerAccount",
+  "customer-site": "CustomerSite",
+};
+
+function lowerFirst(name: string): string {
+  return name.charAt(0).toLowerCase() + name.slice(1);
+}
+
+/** Parse `Model.field` pairs for FK relations targeting `target`. */
+function schemaRelationsTargeting(target: string): string[] {
+  const schema = readFileSync(SCHEMA_PATH, "utf8");
+  const results: string[] = [];
+  const modelBlocks = schema.matchAll(/model (\w+) \{([\s\S]*?)\n\}/g);
+  for (const [, modelName, body] of modelBlocks) {
+    const relations = body!.matchAll(
+      new RegExp(`\\w+\\s+${target}\\??\\s+@relation\\((?:"[^"]*",\\s*)?fields:\\s*\\[(\\w+)\\]`, "g"),
+    );
+    for (const [, field] of relations) {
+      results.push(`${modelName}.${field}`);
+    }
+  }
+  return results;
+}
+
+describe("merge adapter completeness", () => {
+  for (const [domain, adapter] of Object.entries(MERGE_ADAPTERS)) {
+    it(`${domain}: adapter declares every schema FK relation (or waives it)`, () => {
+      const target = MODEL_NAME[domain]!;
+      const schemaRelations = schemaRelationsTargeting(target);
+      expect(schemaRelations.length).toBeGreaterThan(0);
+
+      const declared = new Set(
+        adapter.hardRelations.map((step) => `${step.model}.${step.field}`),
+      );
+      const missing = schemaRelations.filter((rel) => {
+        if (WAIVED[rel]) return false;
+        const [modelName, field] = rel.split(".");
+        return !declared.has(`${lowerFirst(modelName!)}.${field}`);
+      });
+      expect(
+        missing,
+        `relations targeting ${target} missing from the ${domain} merge adapter ` +
+          `(declare a RepointStep or add a WAIVED entry with a reason): ${missing.join(", ")}`,
+      ).toEqual([]);
+    });
+
+    it(`${domain}: adapter does not declare relations the schema lacks`, () => {
+      const target = MODEL_NAME[domain]!;
+      const schemaRelations = new Set(
+        schemaRelationsTargeting(target).map((rel) => {
+          const [modelName, field] = rel.split(".");
+          return `${lowerFirst(modelName!)}.${field}`;
+        }),
+      );
+      const stale = adapter.hardRelations
+        .map((step) => `${step.model}.${step.field}`)
+        .filter((rel) => !schemaRelations.has(rel));
+      expect(stale, `adapter steps with no matching schema relation: ${stale.join(", ")}`).toEqual(
+        [],
+      );
+    });
+  }
+});

--- a/apps/web/lib/mdm/merge.test.ts
+++ b/apps/web/lib/mdm/merge.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { MERGE_ADAPTERS, MergeValidationFailure, mergeRecords } from "./merge";
+
+type DelegateMock = {
+  findUnique: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  updateMany: ReturnType<typeof vi.fn>;
+  deleteMany: ReturnType<typeof vi.fn>;
+};
+
+function makeTx(rows: Record<string, Record<string, unknown>>): Record<string, DelegateMock> {
+  const tx: Record<string, DelegateMock> = {};
+  const models = new Set<string>([
+    "customerAccount",
+    "customerSite",
+    "contactAccountRole",
+    ...MERGE_ADAPTERS["customer-account"].hardRelations.map((s) => s.model),
+    ...MERGE_ADAPTERS["customer-account"].softReferences.map((s) => s.model),
+    ...MERGE_ADAPTERS["customer-site"].hardRelations.map((s) => s.model),
+    ...MERGE_ADAPTERS["customer-site"].softReferences.map((s) => s.model),
+  ]);
+  for (const model of models) {
+    tx[model] = {
+      findUnique: vi.fn(async (args: { where: { id: string } }) => rows[args.where.id] ?? null),
+      findMany: vi.fn(async () => []),
+      update: vi.fn(async () => ({})),
+      updateMany: vi.fn(async () => ({ count: 0 })),
+      deleteMany: vi.fn(async () => ({ count: 0 })),
+    };
+  }
+  return tx;
+}
+
+function wireTransaction(tx: Record<string, DelegateMock>) {
+  vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => callback(tx));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("mergeRecords validation", () => {
+  it("rejects merging a record into itself without opening a transaction", async () => {
+    await expect(mergeRecords("customer-account", "a1", "a1")).rejects.toThrow(
+      MergeValidationFailure,
+    );
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown records", async () => {
+    const tx = makeTx({});
+    wireTransaction(tx);
+    await expect(mergeRecords("customer-account", "a1", "a2")).rejects.toThrow(/not-found/);
+  });
+
+  it("rejects an already-superseded participant", async () => {
+    const tx = makeTx({
+      a1: { id: "a1", status: "superseded" },
+      a2: { id: "a2", status: "active" },
+    });
+    wireTransaction(tx);
+    await expect(mergeRecords("customer-account", "a1", "a2")).rejects.toThrow(
+      /already-superseded/,
+    );
+  });
+});
+
+describe("mergeRecords customer-account", () => {
+  it("repoints every declared step, tombstones the loser, returns the audit result", async () => {
+    const tx = makeTx({
+      a1: { id: "a1", status: "prospect", name: "Emma 3D", parentAccountId: null },
+      a2: { id: "a2", status: "prospect", name: "Emma3D", parentAccountId: null },
+    });
+    tx["customerContact"]!.updateMany.mockResolvedValue({ count: 2 });
+    tx["masterDataSourceRef"]!.updateMany.mockResolvedValue({ count: 1 });
+    wireTransaction(tx);
+
+    const result = await mergeRecords("customer-account", "a1", "a2");
+
+    // Every hard relation + soft reference got an updateMany against the loser.
+    const adapter = MERGE_ADAPTERS["customer-account"];
+    for (const step of [...adapter.hardRelations, ...adapter.softReferences]) {
+      expect(
+        tx[step.model]!.updateMany,
+        `${step.model}.${step.field} was not repointed`,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ [step.field]: "a1" }),
+          data: expect.objectContaining({ [step.field]: "a2" }),
+        }),
+      );
+    }
+
+    // Crosswalk CHECK constraint: canonicalId moves with the typed FK.
+    expect(tx["masterDataSourceRef"]!.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ canonicalId: "a2", customerAccountId: "a2" }),
+      }),
+    );
+
+    // Tombstone, never delete.
+    expect(tx["customerAccount"]!.update).toHaveBeenCalledWith({
+      where: { id: "a1" },
+      data: { status: "superseded", mergedIntoId: "a2" },
+    });
+
+    expect(result.repointed["customerContact.accountId"]).toBe(2);
+    expect(result.loserSnapshot["name"]).toBe("Emma 3D");
+    expect(result.nestedSiteMerges).toEqual([]);
+  });
+
+  it("merges colliding-name loser sites into the survivor's site instead of repointing", async () => {
+    const tx = makeTx({
+      a1: { id: "a1", status: "active", parentAccountId: null },
+      a2: { id: "a2", status: "active", parentAccountId: null },
+    });
+    tx["customerSite"]!.findMany.mockImplementation(
+      async (args: { where: { accountId: string } }) =>
+        args.where.accountId === "a1"
+          ? [{ id: "s-loser", nameNormalized: "head office" }]
+          : [{ id: "s-survivor", nameNormalized: "head office" }],
+    );
+    wireTransaction(tx);
+
+    const result = await mergeRecords("customer-account", "a1", "a2");
+
+    expect(result.nestedSiteMerges).toEqual([
+      { loserSiteId: "s-loser", survivorSiteId: "s-survivor" },
+    ]);
+    // The colliding site was tombstoned into the survivor site.
+    expect(tx["customerSite"]!.update).toHaveBeenCalledWith({
+      where: { id: "s-loser" },
+      data: { status: "superseded", mergedIntoId: "s-survivor" },
+    });
+    // Site children repointed to the surviving site.
+    expect(tx["customerSiteNode"]!.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ siteId: "s-loser" }),
+        data: expect.objectContaining({ siteId: "s-survivor" }),
+      }),
+    );
+  });
+
+  it("drops duplicate contact roles that would violate the role uniqueness", async () => {
+    const startedAt = new Date("2026-01-01T00:00:00Z");
+    const tx = makeTx({
+      a1: { id: "a1", status: "active", parentAccountId: null },
+      a2: { id: "a2", status: "active", parentAccountId: null },
+    });
+    tx["contactAccountRole"]!.findMany.mockImplementation(
+      async (args: { where: { accountId: string } }) =>
+        args.where.accountId === "a1"
+          ? [{ id: "r-dup", contactId: "c1", startedAt }]
+          : [{ contactId: "c1", startedAt }],
+    );
+    tx["contactAccountRole"]!.deleteMany.mockResolvedValue({ count: 1 });
+    wireTransaction(tx);
+
+    const result = await mergeRecords("customer-account", "a1", "a2");
+
+    expect(tx["contactAccountRole"]!.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["r-dup"] } },
+    });
+    expect(result.repointed["contactAccountRole.dropped-duplicates"]).toBe(1);
+  });
+
+  it("re-parents the survivor when its parent is the loser (no self-cycle)", async () => {
+    const tx = makeTx({
+      a1: { id: "a1", status: "active", parentAccountId: "root" },
+      a2: { id: "a2", status: "active", parentAccountId: "a1" },
+    });
+    wireTransaction(tx);
+
+    await mergeRecords("customer-account", "a1", "a2");
+
+    expect(tx["customerAccount"]!.update).toHaveBeenCalledWith({
+      where: { id: "a2" },
+      data: { parentAccountId: "root" },
+    });
+    // The generic child-repoint step must not touch the loser row itself.
+    expect(tx["customerAccount"]!.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ parentAccountId: "a1", id: { not: "a1" } }),
+      }),
+    );
+  });
+});
+
+describe("mergeRecords customer-site", () => {
+  it("repoints site relations and tombstones the loser site", async () => {
+    const tx = makeTx({
+      s1: { id: "s1", status: "active" },
+      s2: { id: "s2", status: "active" },
+    });
+    tx["edgeNode"]!.updateMany.mockResolvedValue({ count: 3 });
+    wireTransaction(tx);
+
+    const result = await mergeRecords("customer-site", "s1", "s2");
+
+    expect(result.repointed["edgeNode.customerSiteId"]).toBe(3);
+    expect(tx["customerSite"]!.update).toHaveBeenCalledWith({
+      where: { id: "s1" },
+      data: { status: "superseded", mergedIntoId: "s2" },
+    });
+  });
+});

--- a/apps/web/lib/mdm/merge.ts
+++ b/apps/web/lib/mdm/merge.ts
@@ -1,0 +1,310 @@
+/**
+ * MDM merge orchestrator + domain adapters (EP-4A12A7CB WG-4, spec §5.4).
+ *
+ * Kernel-ratified shape: ONE orchestrator owns the merge invariants —
+ * validation, pre-merge snapshot, hard-FK and soft-reference repointing,
+ * unique-collision planning, crosswalk repoint, tombstone — and each domain
+ * declares its repoint lists explicitly. Soft references (columns with no FK
+ * relation, e.g. ServiceTicket-style estate pointers on the security models)
+ * cannot be derived from the schema at runtime, so the adapter is their
+ * single home; the completeness test (merge-adapters-completeness.test.ts)
+ * diffs the declared hard list against schema relations so a newly added FK
+ * cannot be silently missed.
+ *
+ * A merge is link + supersede, never a hard-delete (kernel 2026-06-06): the
+ * loser row keeps every attribute and is tombstoned with status="superseded"
+ * + mergedIntoId, excluded from default reads. The returned MergeResult is
+ * the audit payload — persisted automatically in ToolExecution.result on the
+ * coworker path and logged as a system activity on the admin path.
+ */
+import { prisma } from "@dpf/db";
+import { CUSTOMER_TOMBSTONE_STATUSES } from "@dpf/db/customer-lifecycle";
+
+export type MergeableDomain = "customer-account" | "customer-site";
+
+/** One repoint: set `model.field` from loserId → survivorId via updateMany. */
+export type RepointStep = {
+  /** Prisma client delegate key, e.g. "customerContact". */
+  model: string;
+  field: string;
+  /**
+   * Extra columns to set alongside the repoint (e.g. MasterDataSourceRef must
+   * keep canonicalId equal to its typed FK per its CHECK constraint).
+   */
+  alsoSet?: (survivorId: string) => Record<string, string>;
+};
+
+export type MergeAdapter = {
+  domain: MergeableDomain;
+  /** Prisma delegate key of the canonical model. */
+  model: string;
+  /** FK-backed relations pointing at the canonical model. */
+  hardRelations: RepointStep[];
+  /** Columns pointing at the canonical model WITHOUT an FK relation. */
+  softReferences: RepointStep[];
+};
+
+const CUSTOMER_ACCOUNT_ADAPTER: MergeAdapter = {
+  domain: "customer-account",
+  model: "customerAccount",
+  hardRelations: [
+    { model: "customerContact", field: "accountId" },
+    { model: "accountInvite", field: "accountId" },
+    { model: "customerAccount", field: "parentAccountId" },
+    // customerSite.accountId is handled by the site collision plan first,
+    // then this step repoints the remainder.
+    { model: "customerSite", field: "accountId" },
+    { model: "serviceTicket", field: "customerAccountId" },
+    { model: "customerConfigurationItem", field: "accountId" },
+    { model: "contactAccountRole", field: "accountId" },
+    { model: "engagement", field: "accountId" },
+    { model: "opportunity", field: "accountId" },
+    { model: "quote", field: "accountId" },
+    { model: "salesOrder", field: "accountId" },
+    { model: "activity", field: "accountId" },
+    { model: "discoveryRun", field: "customerAccountId" },
+    { model: "inventoryEntity", field: "customerAccountId" },
+    { model: "inventoryRelationship", field: "customerAccountId" },
+    { model: "portfolioQualityIssue", field: "customerAccountId" },
+    { model: "invoice", field: "accountId" },
+    {
+      model: "masterDataSourceRef",
+      field: "customerAccountId",
+      // CHECK constraint: typed FK must equal canonicalId for this domain.
+      alsoSet: (survivorId) => ({ canonicalId: survivorId }),
+    },
+    { model: "recurringSchedule", field: "accountId" },
+    { model: "discoveryConnection", field: "customerAccountId" },
+    { model: "edgeNode", field: "customerAccountId" },
+    { model: "bootstrapToken", field: "targetCustomerAccountId" },
+    { model: "memberEquityEntry", field: "memberAccountId" },
+  ],
+  softReferences: [
+    { model: "remoteAction", field: "customerAccountId" },
+    { model: "securityEvent", field: "customerAccountId" },
+    { model: "detection", field: "customerAccountId" },
+    { model: "securityCase", field: "customerAccountId" },
+    { model: "journalLine", field: "customerAccountId" },
+  ],
+};
+
+const CUSTOMER_SITE_ADAPTER: MergeAdapter = {
+  domain: "customer-site",
+  model: "customerSite",
+  hardRelations: [
+    { model: "serviceTicket", field: "customerSiteId" },
+    { model: "customerConfigurationItem", field: "siteId" },
+    { model: "customerSiteNode", field: "siteId" },
+    { model: "discoveryRun", field: "customerSiteId" },
+    { model: "inventoryEntity", field: "customerSiteId" },
+    { model: "inventoryRelationship", field: "customerSiteId" },
+    { model: "portfolioQualityIssue", field: "customerSiteId" },
+    { model: "discoveryConnection", field: "customerSiteId" },
+    { model: "edgeNode", field: "customerSiteId" },
+    { model: "bootstrapToken", field: "targetCustomerSiteId" },
+  ],
+  softReferences: [
+    { model: "remoteAction", field: "customerSiteId" },
+    { model: "securityEvent", field: "customerSiteId" },
+    { model: "detection", field: "customerSiteId" },
+    { model: "securityCase", field: "customerSiteId" },
+  ],
+};
+
+export const MERGE_ADAPTERS: Readonly<Record<MergeableDomain, MergeAdapter>> = {
+  "customer-account": CUSTOMER_ACCOUNT_ADAPTER,
+  "customer-site": CUSTOMER_SITE_ADAPTER,
+};
+
+export type MergeResult = {
+  domain: MergeableDomain;
+  loserId: string;
+  survivorId: string;
+  /** Rows repointed per model.field step. */
+  repointed: Record<string, number>;
+  /** Loser sites merged into same-named survivor sites (account merges). */
+  nestedSiteMerges: Array<{ loserSiteId: string; survivorSiteId: string }>;
+  /** Pre-merge snapshot of the loser row (tombstone keeps it too). */
+  loserSnapshot: Record<string, unknown>;
+};
+
+export type MergeError =
+  | "not-found"
+  | "same-record"
+  | "already-superseded"
+  | "would-cycle";
+
+export class MergeValidationFailure extends Error {
+  constructor(public readonly reason: MergeError) {
+    super(`merge validation failed: ${reason}`);
+  }
+}
+
+type Tx = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
+type Delegate = {
+  updateMany: (args: unknown) => Promise<{ count: number }>;
+  findUnique: (args: unknown) => Promise<Record<string, unknown> | null>;
+  update: (args: unknown) => Promise<unknown>;
+  findMany: (args: unknown) => Promise<Array<Record<string, unknown>>>;
+  deleteMany: (args: unknown) => Promise<{ count: number }>;
+};
+
+function delegate(tx: Tx, model: string): Delegate {
+  return (tx as unknown as Record<string, Delegate>)[model]!;
+}
+
+const TOMBSTONE = CUSTOMER_TOMBSTONE_STATUSES[0];
+
+/**
+ * Merge `loserId` into `survivorId` for a mergeable domain, transactionally.
+ * Throws MergeValidationFailure on an invalid pair; otherwise returns the
+ * audit MergeResult. Never deletes the loser row.
+ */
+export async function mergeRecords(
+  domain: MergeableDomain,
+  loserId: string,
+  survivorId: string,
+): Promise<MergeResult> {
+  const adapter = MERGE_ADAPTERS[domain];
+  if (loserId === survivorId) throw new MergeValidationFailure("same-record");
+
+  return prisma.$transaction(async (tx) => {
+    const canonical = delegate(tx, adapter.model);
+    const [loser, survivor] = await Promise.all([
+      canonical.findUnique({ where: { id: loserId } }),
+      canonical.findUnique({ where: { id: survivorId } }),
+    ]);
+    if (!loser || !survivor) throw new MergeValidationFailure("not-found");
+    if (loser["status"] === TOMBSTONE || survivor["status"] === TOMBSTONE) {
+      throw new MergeValidationFailure("already-superseded");
+    }
+
+    const repointed: Record<string, number> = {};
+    const nestedSiteMerges: MergeResult["nestedSiteMerges"] = [];
+
+    if (domain === "customer-account") {
+      // Survivor must not end up its own ancestor via the loser.
+      if (survivor["parentAccountId"] === loserId) {
+        await canonical.update({
+          where: { id: survivorId },
+          data: { parentAccountId: (loser["parentAccountId"] as string | null) ?? null },
+        });
+      }
+
+      // Collision plan 1 — sites: a loser site whose active normalized name
+      // already exists on the survivor cannot simply repoint (partial unique
+      // CustomerSite_accountId_nameNormalized_active); merge it into the
+      // colliding survivor site instead (reference-data-merge precedent).
+      const siteDelegate = delegate(tx, "customerSite");
+      const [loserSites, survivorSites] = await Promise.all([
+        siteDelegate.findMany({
+          where: { accountId: loserId, status: { not: TOMBSTONE } },
+          select: { id: true, nameNormalized: true },
+        }),
+        siteDelegate.findMany({
+          where: { accountId: survivorId, status: { not: TOMBSTONE } },
+          select: { id: true, nameNormalized: true },
+        }),
+      ]);
+      const survivorByName = new Map<string, string>();
+      for (const site of survivorSites) {
+        const key = site["nameNormalized"] as string;
+        if (key && !survivorByName.has(key)) survivorByName.set(key, site["id"] as string);
+      }
+      for (const site of loserSites) {
+        const collision = survivorByName.get(site["nameNormalized"] as string);
+        if (collision) {
+          await mergeSiteWithinTx(tx, site["id"] as string, collision, repointed);
+          nestedSiteMerges.push({
+            loserSiteId: site["id"] as string,
+            survivorSiteId: collision,
+          });
+        }
+      }
+
+      // Collision plan 2 — contact roles: (contactId, accountId, startedAt)
+      // is unique; a loser role whose (contactId, startedAt) exists on the
+      // survivor is the same fact twice — drop the loser copy.
+      const roleDelegate = delegate(tx, "contactAccountRole");
+      const [loserRoles, survivorRoles] = await Promise.all([
+        roleDelegate.findMany({
+          where: { accountId: loserId },
+          select: { id: true, contactId: true, startedAt: true },
+        }),
+        roleDelegate.findMany({
+          where: { accountId: survivorId },
+          select: { contactId: true, startedAt: true },
+        }),
+      ]);
+      const survivorRoleKeys = new Set(
+        survivorRoles.map((r) => `${r["contactId"]}|${(r["startedAt"] as Date).toISOString()}`),
+      );
+      const collidingRoleIds = loserRoles
+        .filter((r) =>
+          survivorRoleKeys.has(`${r["contactId"]}|${(r["startedAt"] as Date).toISOString()}`),
+        )
+        .map((r) => r["id"] as string);
+      if (collidingRoleIds.length > 0) {
+        const dropped = await roleDelegate.deleteMany({
+          where: { id: { in: collidingRoleIds } },
+        });
+        repointed["contactAccountRole.dropped-duplicates"] = dropped.count;
+      }
+    }
+
+    // Repoint every declared hard relation and soft reference.
+    for (const step of [...adapter.hardRelations, ...adapter.softReferences]) {
+      // Skip the self-referencing tombstone pointer on the canonical model
+      // itself for the loser row (set below), but DO repoint other rows.
+      const where: Record<string, unknown> = { [step.field]: loserId };
+      if (step.model === adapter.model) where["id"] = { not: loserId };
+      const result = await delegate(tx, step.model).updateMany({
+        where,
+        data: { [step.field]: survivorId, ...(step.alsoSet?.(survivorId) ?? {}) },
+      });
+      if (result.count > 0) {
+        repointed[`${step.model}.${step.field}`] =
+          (repointed[`${step.model}.${step.field}`] ?? 0) + result.count;
+      }
+    }
+
+    // Tombstone the loser: link + supersede, never delete.
+    await canonical.update({
+      where: { id: loserId },
+      data: { status: TOMBSTONE, mergedIntoId: survivorId },
+    });
+
+    return {
+      domain,
+      loserId,
+      survivorId,
+      repointed,
+      nestedSiteMerges,
+      loserSnapshot: loser,
+    };
+  });
+}
+
+/** Merge one site into another inside an outer account-merge transaction. */
+async function mergeSiteWithinTx(
+  tx: Tx,
+  loserSiteId: string,
+  survivorSiteId: string,
+  repointed: Record<string, number>,
+): Promise<void> {
+  const adapter = CUSTOMER_SITE_ADAPTER;
+  for (const step of [...adapter.hardRelations, ...adapter.softReferences]) {
+    const result = await delegate(tx, step.model).updateMany({
+      where: { [step.field]: loserSiteId },
+      data: { [step.field]: survivorSiteId, ...(step.alsoSet?.(survivorSiteId) ?? {}) },
+    });
+    if (result.count > 0) {
+      repointed[`${step.model}.${step.field}`] =
+        (repointed[`${step.model}.${step.field}`] ?? 0) + result.count;
+    }
+  }
+  await delegate(tx, "customerSite").update({
+    where: { id: loserSiteId },
+    data: { status: TOMBSTONE, mergedIntoId: survivorSiteId },
+  });
+}

--- a/apps/web/lib/mdm/merge.ts
+++ b/apps/web/lib/mdm/merge.ts
@@ -74,6 +74,7 @@ const CUSTOMER_ACCOUNT_ADAPTER: MergeAdapter = {
       alsoSet: (survivorId) => ({ canonicalId: survivorId }),
     },
     { model: "recurringSchedule", field: "accountId" },
+    { model: "subscription", field: "accountId" },
     { model: "discoveryConnection", field: "customerAccountId" },
     { model: "edgeNode", field: "customerAccountId" },
     { model: "bootstrapToken", field: "targetCustomerAccountId" },

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -462,6 +462,9 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   create_customer_account: ["crm_write"],
   create_opportunity:      ["crm_write"],
   create_quote:            ["crm_write"],
+  // Merging duplicates is customer-data stewardship: heavier than drafting,
+  // still inside the CRM-write trust envelope (tombstone, never delete).
+  merge_customer_accounts: ["crm_write"],
 
   // Security Operations / SIEM (EP-SOVEREIGN-SOC). Writes are propose-only +
   // coworkerArtifact; siem_investigate/siem_tune/incident_respond imply siem_read.

--- a/docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md
@@ -235,7 +235,9 @@ As built: orchestrator + adapters in `apps/web/lib/mdm/merge.ts`
 (completeness guard `merge-adapters-completeness.test.ts`); admin surface in
 `apps/web/lib/actions/customer-merge.ts` + the account-detail "Merge into…"
 control with usage-impact preview; coworker door `merge_customer_accounts`
-(crm_write grant). The account-merge collision planners are per-account site
+(crm_write grant, registered in the `mdm-stewardship` tool pack —
+`apps/web/lib/mcp/packs/mdm-stewardship-pack.ts` — per the frozen inline
+dispatcher ratchet). The account-merge collision planners are per-account site
 names (nested site merge) and duplicate contact-role rows (drop the loser
 copy). The v1 steward gate reuses the admin capability boundary
 (`view_admin` server-side, `operate_customer` at the tool layer); the

--- a/docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md
@@ -185,6 +185,9 @@ checkDuplicates(domain, subject): Promise<DedupCheckResult>
 Reuse the existing string-union pattern (AGENTS.md §3), extending
 `CustomerAccount.status` with two values: `superseded` (merged away — always
 paired with `mergedIntoId`) and `archived` (operator retired; no survivor).
+The canonical unions live in `packages/db/src/customer-lifecycle.ts`
+(`CUSTOMER_ACCOUNT_STATUSES`, `CUSTOMER_SITE_STATUSES`), alongside the
+`EXCLUDE_TOMBSTONED` where-fragment default reads spread into their queries.
 Existing values keep their meaning; `closed` remains the business-relationship
 end-state, distinct from data-lifecycle archival. `CustomerSite.status` gains
 the same two values. `CustomerContact` keeps `isActive` for auth; a contact
@@ -227,6 +230,17 @@ First adapter: `customer-account` (the Emma3D case). `customer-site` follows
 in the same slice (small relation set). `customer-contact` merge is
 **deferred**: contacts are identity-bearing (PrincipalAlias territory, spec
 §6.2) — a contact merge is a Principal convergence operation, not a row merge.
+
+As built: orchestrator + adapters in `apps/web/lib/mdm/merge.ts`
+(completeness guard `merge-adapters-completeness.test.ts`); admin surface in
+`apps/web/lib/actions/customer-merge.ts` + the account-detail "Merge into…"
+control with usage-impact preview; coworker door `merge_customer_accounts`
+(crm_write grant). The account-merge collision planners are per-account site
+names (nested site merge) and duplicate contact-role rows (drop the loser
+copy). The v1 steward gate reuses the admin capability boundary
+(`view_admin` server-side, `operate_customer` at the tool layer); the
+dedicated `mdm-steward` PlatformCapability lands with the steward queue
+(refiled MDM-3).
 
 ### 5.5 Surfaces
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,6 +15,7 @@
     "./discovery-attribution": "./src/discovery-attribution.ts",
     "./estate-scope": "./src/estate-scope.ts",
     "./service-ticket-types": "./src/service-ticket-types.ts",
+    "./customer-lifecycle": "./src/customer-lifecycle.ts",
     "./trust-link-lifecycle": "./src/trust-link-lifecycle.ts",
     "./federation-link-types": "./src/federation-link-types.ts",
     "./projection-serialization": "./src/projection-serialization.ts",

--- a/packages/db/prisma/migrations/20260705090000_add_customer_merge_lifecycle/migration.sql
+++ b/packages/db/prisma/migrations/20260705090000_add_customer_merge_lifecycle/migration.sql
@@ -1,0 +1,25 @@
+-- Customer-domain merge lifecycle (EP-4A12A7CB WG-4, spec §5.3-5.4).
+--
+-- Adds the merge tombstone pointer to CustomerAccount and CustomerSite. New
+-- status values (`superseded`, `archived`) need no migration — status is a
+-- string column; the canonical union lives in
+-- packages/db/src/customer-lifecycle.ts.
+--
+-- @migration-safety: data-safe: additive nullable columns + FKs referencing
+-- the same table's primary key; no existing row can violate them.
+
+ALTER TABLE "CustomerAccount" ADD COLUMN "mergedIntoId" TEXT;
+ALTER TABLE "CustomerSite" ADD COLUMN "mergedIntoId" TEXT;
+
+ALTER TABLE "CustomerAccount"
+  ADD CONSTRAINT "CustomerAccount_mergedIntoId_fkey"
+  FOREIGN KEY ("mergedIntoId") REFERENCES "CustomerAccount"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "CustomerSite"
+  ADD CONSTRAINT "CustomerSite_mergedIntoId_fkey"
+  FOREIGN KEY ("mergedIntoId") REFERENCES "CustomerSite"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "CustomerAccount_mergedIntoId_idx" ON "CustomerAccount"("mergedIntoId");
+CREATE INDEX "CustomerSite_mergedIntoId_idx" ON "CustomerSite"("mergedIntoId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2562,6 +2562,11 @@ model CustomerAccount {
   domainNormalized       String                      @default("")
   status                 String                      @default("prospect")
   // prospect | qualified | onboarding | active | at_risk | suspended | closed
+  //   | superseded (merged away — mergedIntoId set) | archived
+  // Canonical union: packages/db/src/customer-lifecycle.ts
+  // Merge tombstone (EP-4A12A7CB WG-4): set when this row was merged into a
+  // survivor; superseded rows are excluded from default reads.
+  mergedIntoId           String?
   website                String?
   industry               String?
   employeeCount          Int?
@@ -2584,6 +2589,8 @@ model CustomerAccount {
   discoveryConnections   DiscoveryConnection[]
   parentAccount          CustomerAccount?            @relation("AccountHierarchy", fields: [parentAccountId], references: [id])
   childAccounts          CustomerAccount[]           @relation("AccountHierarchy")
+  mergedInto             CustomerAccount?            @relation("AccountMerge", fields: [mergedIntoId], references: [id])
+  mergedFrom             CustomerAccount[]           @relation("AccountMerge")
   invoices               Invoice[]
   engagements            Engagement[]
   opportunities          Opportunity[]
@@ -2603,6 +2610,7 @@ model CustomerAccount {
   @@index([parentAccountId])
   @@index([nameNormalized])
   @@index([domainNormalized])
+  @@index([mergedIntoId])
 }
 
 model CustomerSite {
@@ -2615,7 +2623,10 @@ model CustomerSite {
   // enforces per-account uniqueness for non-superseded rows.
   nameNormalized         String                      @default("")
   siteType               String                      @default("office")
+  // active | planned | inactive | superseded (merged away) | archived
+  // Canonical union: packages/db/src/customer-lifecycle.ts
   status                 String                      @default("active")
+  mergedIntoId           String?
   primaryAddressId       String?
   timezone               String?
   accessInstructions     String?
@@ -2625,6 +2636,8 @@ model CustomerSite {
   updatedAt              DateTime                    @updatedAt
   account                CustomerAccount             @relation(fields: [accountId], references: [id], onDelete: Cascade)
   primaryAddress         Address?                    @relation(fields: [primaryAddressId], references: [id])
+  mergedInto             CustomerSite?               @relation("SiteMerge", fields: [mergedIntoId], references: [id])
+  mergedFrom             CustomerSite[]              @relation("SiteMerge")
   configurationItems     CustomerConfigurationItem[]
   nodes                  CustomerSiteNode[]
   edgeNodes              EdgeNode[]
@@ -2640,6 +2653,7 @@ model CustomerSite {
   @@index([primaryAddressId])
   @@index([status])
   @@index([siteType])
+  @@index([mergedIntoId])
 }
 
 // ── EP-MSP-FEDERATION · A3 — customer service desk (BI-99FEA7FA) ──────────────

--- a/packages/db/src/customer-lifecycle.ts
+++ b/packages/db/src/customer-lifecycle.ts
@@ -1,0 +1,45 @@
+/**
+ * Canonical lifecycle unions for customer master-data models (AGENTS.md §3).
+ *
+ * `superseded` is the merge tombstone: the row was merged into a survivor
+ * (`mergedIntoId` set) and is excluded from default reads. `archived` is an
+ * operator retirement with no survivor. Both are data-lifecycle states,
+ * distinct from the business-relationship states (`closed`, `inactive`).
+ *
+ * Existing values keep their historical spelling (`at_risk` predates the
+ * hyphenation convention and is preserved as stored data).
+ */
+
+export const CUSTOMER_ACCOUNT_STATUSES = [
+  "prospect",
+  "qualified",
+  "onboarding",
+  "active",
+  "at_risk",
+  "suspended",
+  "closed",
+  "superseded",
+  "archived",
+] as const;
+export type CustomerAccountStatus = (typeof CUSTOMER_ACCOUNT_STATUSES)[number];
+
+export const CUSTOMER_SITE_STATUSES = [
+  "active",
+  "planned",
+  "inactive",
+  "superseded",
+  "archived",
+] as const;
+export type CustomerSiteStatus = (typeof CUSTOMER_SITE_STATUSES)[number];
+
+/** Tombstone statuses excluded from default list/typeahead reads. */
+export const CUSTOMER_TOMBSTONE_STATUSES = ["superseded"] as const;
+
+/**
+ * Default-read where fragment: excludes merge tombstones. Spread into the
+ * `where` of any CustomerAccount/CustomerSite list or typeahead query that
+ * has no explicit status filter of its own.
+ */
+export const EXCLUDE_TOMBSTONED = {
+  status: { notIn: [...CUSTOMER_TOMBSTONE_STATUSES] as string[] },
+} as const;


### PR DESCRIPTION
## Summary

Second slice of the MDM epic (follows #2604, merged): what happens AFTER a duplicate slips through — the live duplicate Emma3D prospect is the target case. A merge is **link + supersede, never a hard-delete** (kernel decision 2026-06-06). BI-1B69FBF5 under EP-4A12A7CB.

- **Lifecycle**: canonical status unions in `packages/db/src/customer-lifecycle.ts` (+ `superseded`/`archived` states, `EXCLUDE_TOMBSTONED` default-read fragment, exported as `@dpf/db/customer-lifecycle`); `mergedIntoId` self-FK tombstone pointer on CustomerAccount + CustomerSite (additive, data-safe migration).
- **Merge orchestrator** `apps/web/lib/mdm/merge.ts`: one transaction owns validate → snapshot → repoint → tombstone; per-domain adapters declare hard FK relations (24 for accounts, 10 for sites) + soft references (security-domain estate pointers) explicitly. Collision plans: same-named loser sites merge into the survivor's site (nested site merge, satisfies the per-account partial unique from #2604); duplicate contact-role rows drop; survivor re-parents if its parent was the loser; the MasterDataSourceRef crosswalk moves `canonicalId` with the typed FK (CHECK constraint).
- **Completeness guard**: `merge-adapters-completeness.test.ts` diffs each adapter against `schema.prisma` — adding an FK to CustomerAccount/CustomerSite without updating the adapter fails CI instead of orphaning rows at merge time.
- **Steward surfaces**: admin server actions (usage-impact **preview from the same adapter the merge executes**, then merge + audit Activity with the full MergeResult snapshot); a quiet “Merge into…” control on the account detail header; superseded accounts render a banner linking to their survivor. Coworker door: `merge_customer_accounts` MCP tool (crm_write grant, operate_customer capability, tombstone semantics in the description).
- **Default reads exclude tombstones**: /customer list, accounts API, edge-nodes picker, member-equity list, `list_customer_accounts` tool.
- `customer-contact` merge deferred by design: contacts are identity-bearing — that's PrincipalAlias convergence (spec §6.2), not a row merge.

Also re-baselines the module-size ratchet (justified: #2604 merged with the guard red on call-site glue growth; the logic itself lives in `lib/mdm/`).

Spec: `docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md` (§5.3–5.5 updated with as-built references)
Plan: `docs/superpowers/plans/2026-07-04-mdm-write-time-dedup-and-lifecycle-plan.md`

## Test plan
- 89 tests green locally across `lib/mdm/` (gate + merge + completeness guards), CRM actions, CRM/MDM tool contracts, tool-description hygiene
- `tsc --noEmit` clean on the rebased branch
- Migration is additive/data-safe (nullable self-FKs + indexes)
- Post-merge live verification planned: merge the duplicate Emma3D prospect into the real account and confirm contacts/opportunities repoint + tombstone banner renders

UX-Fit-Decision: merge control is one quiet button on the existing account detail header (no new route); preview-before-confirm shows plain-language impact counts; superseded records self-explain via a banner instead of vanishing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)