### PR TITLE
feat(crm): engagement lifecycle to support contract — model, actions, UI

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -8,6 +8,7 @@ import { NewCustomerConfigurationItemButton } from "@/components/customer/NewCus
 import { CustomerLifecycleReviewQueues } from "@/components/customer/CustomerLifecycleReviewQueues";
 import { CustomerSiteTree } from "@/components/customer/CustomerSiteTree";
 import { NewCustomerSiteButton } from "@/components/customer/NewCustomerSiteButton";
+import { AccountLifecycleActions } from "@/components/customer/AccountLifecycleActions";
 import { loadCustomerEstateSummary } from "@/lib/customer-estate/account-estate-summary";
 import type { TechnologySourceType } from "@/lib/customer-estate/lifecycle-evaluation";
 import {
@@ -166,6 +167,38 @@ export default async function AccountDetailPage({
 
   if (!account) notFound();
 
+  // Engagement-lifecycle context (BI: prospect → active customer → support
+  // contract). The active support contract (if any) and the most recent accepted
+  // order not yet under a contract, so the account surface can drive the two
+  // post-order transitions the CRM had no UI for.
+  const [contractRow, contractableOrderRow] = await Promise.all([
+    prisma.subscription.findFirst({
+      where: { accountId: id, status: { not: "cancelled" } },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.salesOrder.findFirst({
+      where: { accountId: id, subscription: null },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, orderRef: true },
+    }),
+  ]);
+  const lifecycleContext = {
+    accountId: account.id,
+    status: account.status,
+    contractableOrder: contractableOrderRow,
+    contract: contractRow
+      ? {
+          subscriptionRef: contractRow.subscriptionRef,
+          planName: contractRow.planName,
+          status: contractRow.status,
+          currency: contractRow.currency,
+          totalValue: String(contractRow.totalValue),
+          billingCadence: contractRow.billingCadence,
+          renewalDate: contractRow.renewalDate ? contractRow.renewalDate.toISOString() : null,
+        }
+      : null,
+  };
+
   const statusMeta = getAccountStatusMeta(account.status);
   const managedItemDefaults = deriveCustomerConfigurationItemDefaults(
     readActivationProfile(storefrontConfig?.archetype?.activationProfile),
@@ -206,6 +239,8 @@ export default async function AccountDetailPage({
           {account.accountId}
         </p>
       </div>
+
+      <AccountLifecycleActions {...lifecycleContext} />
 
       {/* Metadata grid */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">

--- a/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.test.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.test.tsx
@@ -18,6 +18,8 @@ vi.mock("@dpf/db", () => ({
 
 vi.mock("next/navigation", () => ({
   notFound,
+  // QuoteLifecycleActions (client component on this page) calls useRouter().
+  useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 import QuoteDetailPage from "./page";

--- a/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { QuoteLifecycleActions } from "@/components/customer/QuoteLifecycleActions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import {
   CRM_TONE_CLASSES,
@@ -84,6 +85,9 @@ export default async function QuoteDetailPage({ params }: QuoteDetailPageProps) 
           <p className="mt-1 text-sm text-[var(--dpf-muted)]">
             {quote.account.name} / {quote.opportunity.title}
           </p>
+          <div className="mt-3">
+            <QuoteLifecycleActions quoteId={quote.id} status={quote.status} />
+          </div>
         </div>
         <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3 md:text-right">
           <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">

--- a/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { InvoiceSendButton } from "@/components/finance/InvoiceSendButton";
 import { InvoiceDownloadButton } from "@/components/finance/InvoiceDownloadButton";
+import { RecordInvoicePaymentButton } from "@/components/finance/RecordInvoicePaymentButton";
 import { InvoiceSignatureToggle } from "@/components/finance/InvoiceSignatureToggle";
 import { LocalTime } from "@/components/ui/LocalTime";
 
@@ -91,6 +92,12 @@ export default async function InvoiceDetailPage({ params }: Props) {
           <div className="flex gap-2 mt-3">
             <InvoiceDownloadButton invoiceId={invoice.id} />
             <InvoiceSendButton invoiceId={invoice.id} status={invoice.status} customerAccountId={invoice.account.id} />
+            <RecordInvoicePaymentButton
+              invoiceId={invoice.id}
+              outstanding={amountDue}
+              currency={invoice.currency}
+              status={invoice.status}
+            />
           </div>
         </div>
         <div className="text-right">

--- a/apps/web/components/customer/AccountLifecycleActions.tsx
+++ b/apps/web/components/customer/AccountLifecycleActions.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { convertAccountToActiveCustomer, convertOrderToSubscription } from "@/lib/actions/subscriptions";
+
+export type LifecycleContext = {
+  accountId: string;
+  status: string;
+  // The most recent accepted sales order without a support contract yet, if any.
+  contractableOrder: { id: string; orderRef: string } | null;
+  // The active support contract, if one already exists.
+  contract: {
+    subscriptionRef: string;
+    planName: string;
+    status: string;
+    currency: string;
+    totalValue: string;
+    billingCadence: string;
+    renewalDate: string | null;
+  } | null;
+};
+
+const btn =
+  "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50";
+const btnPrimary =
+  "rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50";
+
+export function AccountLifecycleActions(ctx: LifecycleContext) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  function run(fn: () => Promise<unknown>) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await fn();
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  const isProspect = ctx.status !== "active" && ctx.status !== "closed";
+
+  return (
+    <div className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--dpf-muted)]">
+          Engagement lifecycle
+        </h2>
+        <div className="flex flex-wrap items-center gap-2">
+          {isProspect && (
+            <button
+              className={btnPrimary}
+              disabled={isPending}
+              onClick={() => run(() => convertAccountToActiveCustomer(ctx.accountId))}
+            >
+              Convert to active customer
+            </button>
+          )}
+          {ctx.contractableOrder && !ctx.contract && (
+            <button
+              className={btn}
+              disabled={isPending}
+              onClick={() => run(() => convertOrderToSubscription(ctx.contractableOrder!.id))}
+              title={`Create a support contract from order ${ctx.contractableOrder.orderRef}`}
+            >
+              Create support contract
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+
+      {ctx.contract && (
+        <div className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-[var(--dpf-text)]">
+              Support contract — {ctx.contract.planName}
+            </p>
+            <span className="text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-accent)]">
+              {ctx.contract.status}
+            </span>
+          </div>
+          <p className="mt-1 text-[11px] font-mono text-[var(--dpf-muted)]">
+            {ctx.contract.subscriptionRef}
+          </p>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            {ctx.contract.currency} {Number(ctx.contract.totalValue).toLocaleString()} ·{" "}
+            {ctx.contract.billingCadence}
+            {ctx.contract.renewalDate
+              ? ` · renews ${new Date(ctx.contract.renewalDate).toLocaleDateString()}`
+              : ""}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/customer/QuoteLifecycleActions.tsx
+++ b/apps/web/components/customer/QuoteLifecycleActions.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { acceptQuote, sendQuote } from "@/lib/actions/crm";
+
+// Quote lifecycle controls. The server actions (sendQuote / acceptQuote) existed
+// but had NO UI surface — a quote could only leave draft via a coworker tool call,
+// which the local model performs unreliably. acceptQuote also creates the sales
+// order and auto-generates the invoice, so this single button advances
+// quote → order → invoice deterministically.
+
+const btn =
+  "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50";
+const btnPrimary =
+  "rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50";
+
+export function QuoteLifecycleActions({ quoteId, status }: { quoteId: string; status: string }) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  function run(fn: () => Promise<unknown>) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await fn();
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  if (status === "accepted" || status === "rejected" || status === "superseded") return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      {status === "draft" && (
+        <button className={btn} disabled={isPending} onClick={() => run(() => sendQuote(quoteId))}>
+          Mark as sent
+        </button>
+      )}
+      <button
+        className={btnPrimary}
+        disabled={isPending}
+        title="Accept the quote — creates the sales order and generates the invoice"
+        onClick={() => run(() => acceptQuote(quoteId))}
+      >
+        {isPending ? "Working…" : "Accept quote → create order"}
+      </button>
+      {error && <span className="text-xs text-red-400">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/components/finance/RecordInvoicePaymentButton.tsx
+++ b/apps/web/components/finance/RecordInvoicePaymentButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { recordPayment } from "@/lib/actions/finance";
+
+// Record an incoming payment against a customer invoice for its outstanding
+// amount. The recordPayment action (and its GL posting) existed but AR had no
+// UI control — only AP bills had a record-payment button — so an invoice could
+// never be settled through the portal.
+
+export function RecordInvoicePaymentButton({
+  invoiceId,
+  outstanding,
+  currency,
+  status,
+}: {
+  invoiceId: string;
+  outstanding: number;
+  currency: string;
+  status: string;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  if (status === "paid" || status === "void" || outstanding <= 0) return null;
+
+  function handleClick() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await recordPayment({
+          direction: "inbound",
+          method: "bank_transfer",
+          amount: outstanding,
+          currency,
+          invoiceId,
+          notes: "Recorded from invoice page",
+        });
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+        disabled={isPending}
+        title={`Record an incoming ${currency} ${outstanding.toLocaleString()} payment against this invoice`}
+        onClick={handleClick}
+      >
+        {isPending ? "Recording…" : "Record payment"}
+      </button>
+      {error && <span className="text-xs text-red-400">{error}</span>}
+    </span>
+  );
+}

--- a/apps/web/lib/actions/subscriptions.test.ts
+++ b/apps/web/lib/actions/subscriptions.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    customerAccount: { findUnique: vi.fn(), update: vi.fn() },
+    salesOrder: { findUnique: vi.fn() },
+    subscription: { create: vi.fn() },
+    edgeNode: { update: vi.fn() },
+    activity: { create: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { convertAccountToActiveCustomer, convertOrderToSubscription } from "./subscriptions";
+
+const p = prisma as unknown as {
+  customerAccount: { findUnique: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  salesOrder: { findUnique: ReturnType<typeof vi.fn> };
+  subscription: { create: ReturnType<typeof vi.fn> };
+  edgeNode: { update: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("convertAccountToActiveCustomer", () => {
+  it("flips a prospect to active", async () => {
+    p.customerAccount.findUnique.mockResolvedValue({ id: "a1", name: "Emma3D", status: "prospect" });
+    p.customerAccount.update.mockResolvedValue({ id: "a1", status: "active" });
+    const out = await convertAccountToActiveCustomer("a1");
+    expect(p.customerAccount.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "a1" }, data: { status: "active" } }),
+    );
+    expect(out.status).toBe("active");
+  });
+
+  it("is idempotent on an already-active account (no update)", async () => {
+    p.customerAccount.findUnique.mockResolvedValue({ id: "a1", name: "Emma3D", status: "active" });
+    await convertAccountToActiveCustomer("a1");
+    expect(p.customerAccount.update).not.toHaveBeenCalled();
+  });
+
+  it("throws on a missing account", async () => {
+    p.customerAccount.findUnique.mockResolvedValue(null);
+    await expect(convertAccountToActiveCustomer("nope")).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("convertOrderToSubscription", () => {
+  const order = {
+    id: "so1",
+    accountId: "a1",
+    totalAmount: 12000,
+    currency: "GBP",
+    account: { id: "a1", name: "Emma3D" },
+    subscription: null,
+  };
+
+  it("creates an active annual contract carrying the order's value and account", async () => {
+    p.salesOrder.findUnique.mockResolvedValue(order);
+    p.subscription.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "sub1", ...data }));
+    const sub = await convertOrderToSubscription("so1");
+    const created = p.subscription.create.mock.calls[0][0].data;
+    expect(created.status).toBe("active");
+    expect(created.accountId).toBe("a1");
+    expect(created.salesOrderId).toBe("so1");
+    expect(created.totalValue).toBe(12000);
+    expect(created.currency).toBe("GBP");
+    expect(created.billingCadence).toBe("annual");
+    expect(created.subscriptionRef).toMatch(/^SUB-\d{4}-[0-9A-F]{6}$/);
+    expect(sub.id).toBe("sub1");
+  });
+
+  it("links an edge node (DPF instance) to the contract when provided", async () => {
+    p.salesOrder.findUnique.mockResolvedValue(order);
+    p.subscription.create.mockResolvedValue({ id: "sub1" });
+    p.edgeNode.update.mockResolvedValue({ id: "en1", subscriptionId: "sub1" });
+    await convertOrderToSubscription("so1", { edgeNodeId: "en1" });
+    expect(p.edgeNode.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "en1" }, data: { subscriptionId: "sub1" } }),
+    );
+  });
+
+  it("is idempotent per order — returns the existing contract, creates nothing", async () => {
+    p.salesOrder.findUnique.mockResolvedValue({ ...order, subscription: { id: "existing" } });
+    const sub = await convertOrderToSubscription("so1");
+    expect(sub).toEqual({ id: "existing" });
+    expect(p.subscription.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/subscriptions.ts
+++ b/apps/web/lib/actions/subscriptions.ts
@@ -1,0 +1,123 @@
+"use server";
+
+import crypto from "crypto";
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+
+// Post-order lifecycle: turning a won deal into an ACTIVE CUSTOMER under a
+// SUPPORT CONTRACT for their own instance of DPF. These wrap the two transitions
+// the CRM had server-side gaps for — no model + no action for the subscription,
+// and no explicit prospect→active conversion.
+
+const CADENCE_MONTHS: Record<string, number> = { monthly: 1, quarterly: 3, annual: 12 };
+
+function nextSubscriptionRef(): string {
+  const year = new Date().getFullYear();
+  // Short random suffix keeps refs unique without a dedicated DB sequence; the
+  // subscriptionRef unique index is the backstop.
+  const suffix = crypto.randomBytes(3).toString("hex").toUpperCase();
+  return `SUB-${year}-${suffix}`;
+}
+
+/**
+ * Flip a prospect account to an active customer. Idempotent: calling it on an
+ * already-active account is a no-op that still returns the account. Emits an
+ * activity for the timeline.
+ */
+export async function convertAccountToActiveCustomer(accountId: string) {
+  const account = await prisma.customerAccount.findUnique({ where: { id: accountId } });
+  if (!account) throw new Error("Account not found");
+  if (account.status === "active") return account;
+
+  const updated = await prisma.customerAccount.update({
+    where: { id: accountId },
+    data: { status: "active" },
+  });
+
+  await prisma.activity
+    .create({
+      data: {
+        activityId: `ACT-${crypto.randomUUID()}`,
+        type: "status_change",
+        subject: `Account ${account.name} converted to active customer`,
+        accountId,
+        completedAt: new Date(),
+      },
+    })
+    .catch(() => {});
+
+  revalidatePath("/customer");
+  revalidatePath(`/customer/${accountId}`);
+  return updated;
+}
+
+/**
+ * Create the support contract (Subscription) for a customer's DPF instance from
+ * an accepted sales order. The order supplies the account, value and currency;
+ * the plan name and billing cadence default sensibly and can be overridden.
+ * Optionally links one EdgeNode (their provisioned instance) to the contract.
+ * Idempotent per order: an order already tied to a subscription returns it.
+ */
+export async function convertOrderToSubscription(
+  salesOrderId: string,
+  opts: {
+    planName?: string;
+    billingCadence?: "monthly" | "quarterly" | "annual";
+    autoRenew?: boolean;
+    edgeNodeId?: string;
+    notes?: string;
+  } = {},
+) {
+  const order = await prisma.salesOrder.findUnique({
+    where: { id: salesOrderId },
+    include: { account: { select: { id: true, name: true } }, subscription: true },
+  });
+  if (!order) throw new Error("Sales order not found");
+  if (order.subscription) return order.subscription;
+
+  const cadence = opts.billingCadence ?? "annual";
+  const months = CADENCE_MONTHS[cadence] ?? 12;
+  const start = new Date();
+  const renewal = new Date(start);
+  renewal.setMonth(renewal.getMonth() + months);
+
+  const subscription = await prisma.subscription.create({
+    data: {
+      subscriptionRef: nextSubscriptionRef(),
+      status: "active",
+      accountId: order.accountId,
+      salesOrderId: order.id,
+      planName: opts.planName ?? `DPF Managed Instance — Support & Hosting (${order.account.name})`,
+      billingCadence: cadence,
+      totalValue: order.totalAmount,
+      currency: order.currency,
+      startDate: start,
+      renewalDate: renewal,
+      autoRenew: opts.autoRenew ?? true,
+      notes: opts.notes ?? null,
+    },
+  });
+
+  // Link the customer's provisioned DPF instance (edge node) to the contract.
+  if (opts.edgeNodeId) {
+    await prisma.edgeNode
+      .update({ where: { id: opts.edgeNodeId }, data: { subscriptionId: subscription.id } })
+      .catch(() => {});
+  }
+
+  await prisma.activity
+    .create({
+      data: {
+        activityId: `ACT-${crypto.randomUUID()}`,
+        type: "status_change",
+        subject: `Support contract ${subscription.subscriptionRef} created for ${order.account.name}`,
+        accountId: order.accountId,
+        completedAt: new Date(),
+      },
+    })
+    .catch(() => {});
+
+  revalidatePath("/customer");
+  revalidatePath(`/customer/${order.accountId}`);
+  return subscription;
+}

--- a/docs/superpowers/plans/2026-07-04-crm-engagement-lifecycle-to-support-contract-plan.md
+++ b/docs/superpowers/plans/2026-07-04-crm-engagement-lifecycle-to-support-contract-plan.md
@@ -1,0 +1,27 @@
+# Plan — CRM engagement lifecycle: prospect → active customer → DPF support contract
+
+Date: 2026-07-04. Companion to the root-cause coworker-grant fix (#2596).
+
+## Why
+
+Driving the Customer Success Manager through a real engagement surfaced two classes of gap:
+
+1. **Post-order model gap** — the CRM chain (account → opportunity → quote → sales order → invoice → payment) is fully modelled, but there was **no model for the support contract** covering a customer's own DPF instance, and **no prospect→active conversion action**. An order says "they bought once"; nothing said "they are under an active support contract with a renewal date, covering these instances."
+2. **Seed grant drift** — `seedCoworkerAgents` only *upserted* grants, so a corrected grant set left stale rows behind. `customer-advisor` kept `backlog_write`/`marketing_read`, whose tier-1 tools crowded the per-turn tool budget and pushed `create_quote` past the cap.
+
+## Scope
+
+- **`Subscription` model** (support contract) tied to `CustomerAccount`, created from a `SalesOrder`, optionally covering `EdgeNode`s (the provisioned DPF instances). Migration `20260704120000_add_subscription_support_contract`.
+- **Actions** (`apps/web/lib/actions/subscriptions.ts`): `convertAccountToActiveCustomer`, `convertOrderToSubscription` — both idempotent.
+- **Seed reconcile**: `seedCoworkerAgents` now deletes grant rows not in the declared set.
+- **UI** (follow-on in this PR): account-detail lifecycle controls (accept quote → order + invoice, record payment, convert to customer, create support contract) and a support-contract display, so the whole chain is drivable deterministically through the UX rather than via flaky local-model tool-calling.
+
+## Non-goals
+
+- Recurring-billing materialization (a scheduler that mints monthly invoices from a subscription) — the contract + renewal date land now; recurring invoicing is a later slice.
+- Reworking the two-grant-source split (registry vs workforce-seed) — tracked separately; this PR only corrects the reconcile behavior.
+
+## Verification
+
+- Unit tests for the actions (idempotency, contract fields from order) and the seed reconcile (stale grants removed).
+- Deploy via self-upgrade (runs `prisma migrate deploy` + reseed), then drive the full lifecycle by clicks for Ian, then Dan.

--- a/packages/db/prisma/migrations/20260704120000_add_subscription_support_contract/migration.sql
+++ b/packages/db/prisma/migrations/20260704120000_add_subscription_support_contract/migration.sql
@@ -1,0 +1,52 @@
+-- Subscription = the support contract for a customer's own instance of DPF.
+-- Created from an accepted SalesOrder; scoped to a CustomerAccount; optionally
+-- covers one or more EdgeNodes (the provisioned DPF instances).
+
+-- AlterTable
+ALTER TABLE "EdgeNode" ADD COLUMN     "subscriptionId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Subscription" (
+    "id" TEXT NOT NULL,
+    "subscriptionRef" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "accountId" TEXT NOT NULL,
+    "salesOrderId" TEXT,
+    "planName" TEXT NOT NULL,
+    "billingCadence" TEXT NOT NULL DEFAULT 'annual',
+    "totalValue" DECIMAL(65,30) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'GBP',
+    "startDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "renewalDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3),
+    "autoRenew" BOOLEAN NOT NULL DEFAULT true,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subscription_subscriptionRef_key" ON "Subscription"("subscriptionRef");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subscription_salesOrderId_key" ON "Subscription"("salesOrderId");
+
+-- CreateIndex
+CREATE INDEX "Subscription_accountId_idx" ON "Subscription"("accountId");
+
+-- CreateIndex
+CREATE INDEX "Subscription_status_idx" ON "Subscription"("status");
+
+-- CreateIndex
+CREATE INDEX "Subscription_renewalDate_idx" ON "Subscription"("renewalDate");
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "CustomerAccount"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_salesOrderId_fkey" FOREIGN KEY ("salesOrderId") REFERENCES "SalesOrder"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+-- @migration-safety: data-safe: subscriptionId was just added as a nullable column in this same migration, so every pre-existing EdgeNode row holds NULL, and a NULL foreign key never violates the constraint. No backfill or NOT VALID needed.
+ALTER TABLE "EdgeNode" ADD CONSTRAINT "EdgeNode_subscriptionId_fkey" FOREIGN KEY ("subscriptionId") REFERENCES "Subscription"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2590,6 +2590,7 @@ model CustomerAccount {
   activities             Activity[]
   quotes                 Quote[]
   salesOrders            SalesOrder[]
+  subscriptions          Subscription[]
   recurringSchedules     RecurringSchedule[]
   inventoryEntities      InventoryEntity[]           @relation("InventoryEntityCustomerAccount")
   inventoryRelationships InventoryRelationship[]     @relation("InventoryRelationshipCustomerAccount")
@@ -3124,9 +3125,44 @@ model SalesOrder {
 
   quote   Quote           @relation(fields: [quoteId], references: [id])
   account CustomerAccount @relation(fields: [accountId], references: [id])
+  subscription Subscription?
 
   @@index([accountId])
   @@index([status])
+}
+
+// A support/service subscription — the "contract for supporting a customer's own
+// instance of DPF". Created from an accepted SalesOrder (convertOrderToSubscription),
+// scoped to a CustomerAccount, and optionally covering one or more EdgeNodes (the
+// customer's provisioned DPF instances). Closes the post-order gap: an order alone
+// says "they bought once"; a Subscription says "they are under an active support
+// contract with a renewal date". Recurring-billing materialization is a later slice.
+model Subscription {
+  id              String    @id @default(cuid())
+  subscriptionRef String    @unique // SUB-2026-0001 (sequential)
+  status          String    @default("active")
+  // active | suspended | expired | cancelled
+  accountId       String
+  salesOrderId    String?   @unique // the accepted order that created this contract
+  planName        String // e.g. "DPF Managed Instance — Support & Hosting"
+  billingCadence  String    @default("annual") // monthly | quarterly | annual
+  totalValue      Decimal
+  currency        String    @default("GBP")
+  startDate       DateTime  @default(now())
+  renewalDate     DateTime
+  endDate         DateTime?
+  autoRenew       Boolean   @default(true)
+  notes           String?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  account    CustomerAccount @relation(fields: [accountId], references: [id])
+  salesOrder SalesOrder?     @relation(fields: [salesOrderId], references: [id])
+  edgeNodes  EdgeNode[]
+
+  @@index([accountId])
+  @@index([status])
+  @@index([renewalDate])
 }
 
 model Activity {
@@ -10786,6 +10822,8 @@ model EdgeNode {
   metadata          Json?
   customerAccountId String?
   customerSiteId    String?
+  // The support contract (Subscription) this instance is covered by, if any.
+  subscriptionId    String?
   scopePolicy       Json?
 
   // ── Auth (per spec § Token namespaces and lifecycle) ─────────────
@@ -10822,6 +10860,7 @@ model EdgeNode {
   approvedBy                   Principal?            @relation("EdgeNodeApprover", fields: [approvedByPrincipalId], references: [id])
   customerAccount              CustomerAccount?      @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
   customerSite                 CustomerSite?         @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
+  subscription                 Subscription?         @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
   capabilityRows               EdgeNodeCapability[]
   discoveryRuns                DiscoveryRun[]        @relation("EdgeNodeDiscoveryRuns")
   targetedDiscoveryConnections DiscoveryConnection[] @relation("EdgeNodeTargetedDiscoveryConnections")

--- a/packages/db/src/edge-node-types.test.ts
+++ b/packages/db/src/edge-node-types.test.ts
@@ -44,6 +44,7 @@ function makeNode(overrides: Partial<EdgeNode> = {}): EdgeNode {
     metadata: null,
     customerAccountId: null,
     customerSiteId: null,
+    subscriptionId: null,
     scopePolicy: null,
     tokenHash: null,
     tokenPrefix: null,

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1104,6 +1104,15 @@ async function seedCoworkerAgents(): Promise<void> {
         });
         grantCount++;
       }
+      // Reconcile, don't just add: remove grant rows no longer in the desired
+      // set. The pure-upsert loop above left stale grants behind forever — e.g.
+      // customer-advisor kept backlog_write/marketing_read after its grants were
+      // corrected, and those stale tier-1 tools crowded the per-turn tool budget
+      // and pushed the CRM tools (create_quote) past the cap. A coworker's live
+      // grants must equal its declared set.
+      await prisma.agentToolGrant.deleteMany({
+        where: { agentId: agent.id, grantKey: { notIn: [...grants] } },
+      });
     }
   }
 

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -42,7 +42,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16503,
+  "apps/web/lib/mcp-tools.ts": 16556,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1183,


### PR DESCRIPTION
## Why

Driving a real engagement (adding prospect Emma3D / Ian Pruden via the Customer Success Manager, after the grant root-cause fix in #2596) surfaced the remaining gaps that make a full prospect→customer engagement impossible to complete:

1. **No support-contract model.** The chain account → opportunity → quote → sales order → invoice → payment is fully modelled, but nothing represented *"this customer is under an active support contract for their own DPF instance, renewing on date X."*
2. **No UI for the post-quote transitions.** `sendQuote`/`acceptQuote`/`recordPayment` existed as server actions with zero UI surface — the only path was coworker tool-calling, which the local model performs unreliably (it filed a quality issue instead of calling `create_quote`, even when the tool was attached).
3. **Seed grant drift.** `seedCoworkerAgents` only upserted grants, so corrected grant sets left stale rows (`backlog_write`, `marketing_read` on customer-advisor) that crowded the per-turn tool budget and pushed CRM tools past the attachment cap.

## What

**Model + actions**
- `Subscription` (support contract): tied to `CustomerAccount`, created from a `SalesOrder`, optionally covering `EdgeNode`s (the customer's provisioned DPF instances). Migration `20260704120000_add_subscription_support_contract`; the EdgeNode FK carries a data-safe attestation (column added nullable in the same migration).
- `convertAccountToActiveCustomer` + `convertOrderToSubscription` (`apps/web/lib/actions/subscriptions.ts`) — both idempotent, both emit timeline activities.
- Seed reconcile: `seedCoworkerAgents` now **deletes** grant rows not in the declared set, so a coworker's live grants equal its declared set.

**UI — the deterministic click path**
- **Quote page**: `Mark as sent` + `Accept quote → create order` (acceptQuote also closes the opportunity won and auto-generates the invoice).
- **Invoice page**: `Record payment` for the outstanding amount (GL posting rides `recordPayment`).
- **Account page**: `Convert to active customer` + `Create support contract` from the latest uncontracted order, and a contract card (ref, plan, value, cadence, renewal date).

With this, the full engagement — prospect → opportunity → quote → order + invoice → payment → active customer → support contract — is drivable end-to-end through the UX.

## Tests

`subscriptions.test.ts` (idempotency, contract fields from order, edge-node link) — 6/6; `seed.test.ts` (incl. reconcile expectations) — 12/12. Pre-commit schema-regression + migration-safety guards green.

## Deploy note

Live installs pick this up via self-upgrade (runs `prisma migrate deploy` + reseed). Follow-on verification: drive Ian (Emma3D) through the full lifecycle by clicks, then repeat for customer #2 (Dan Warfield / Managing Digital).

🤖 Generated with [Claude Code](https://claude.com/claude-code)