### PR TITLE
feat(bom): make DOC-1996319D structural — Workforce surface products + governed backlog write path (BI-D5C9C3F7, BI-87A8BF2A)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1,6 +1,6 @@
 import type { CapabilityKey } from "@/lib/permissions";
 import { can, type UserContext } from "@/lib/permissions";
-import { DISCOVERY_TRIAGE_AGENT_ID, prisma } from "@dpf/db";
+import { DISCOVERY_TRIAGE_AGENT_ID, attributeBacklogPortfolio, prisma } from "@dpf/db";
 // Static import: executeTool is a hot path; dynamic import per call would hurt throughput.
 import { evaluateExecution } from "@/lib/kernel/runtime-gate";
 import { loadEnforceablePrinciples } from "@/lib/kernel/load-enforceable-principles";
@@ -627,6 +627,9 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
         workType: { type: "string", enum: [...BACKLOG_WORK_TYPE_VALUES], description: "Reclassify what kind of work this is (closed enum)." },
         source: { type: "string", enum: [...BACKLOG_SOURCE_VALUES], description: "Reclassify the intake origin." },
         proposedOutcome: { type: "string", enum: ["build", "runbook", "coworker-task", "defer", "duplicate", "discard"], description: "Advisory recommendation; non-binding on triage" },
+        digitalProductId: { type: "string", description: "Associate this item with a DigitalProduct by its productId (e.g. 'coworker-AGT-X'). The item's portfolio is then re-derived from the product (product first, then taxonomy node, then epic)." },
+        taxonomyNodeId: { type: "string", description: "Associate this item with a portfolio taxonomy node by its nodeId (e.g. 'for_employees/financial_management'). Used to derive the portfolio when no product link exists." },
+        portfolioSlug: { type: "string", description: "Directly pin the item's portfolio by root slug (e.g. 'for_employees'). Prefer digitalProductId/taxonomyNodeId so the link is structural; use this only for a deliberate override." },
       },
       required: ["itemId"],
     },
@@ -5796,8 +5799,58 @@ export async function executeTool(
       if (typeof params["workType"] === "string") data["workType"] = params["workType"];
       if (typeof params["source"] === "string") data["source"] = params["source"];
       if (typeof params["proposedOutcome"] === "string") data["proposedOutcome"] = params["proposedOutcome"];
+
+      // Structural portfolio association (closes the DOC-1996319D "Open Gap":
+      // governed write paths for BacklogItem.digitalProductId / taxonomyNodeId /
+      // portfolioId). Accept the stable human ids and resolve to the FK ids.
+      let explicitPortfolio = false;
+      let touchedLinks = false;
+      if (typeof params["digitalProductId"] === "string") {
+        const prod = await prisma.digitalProduct.findUnique({
+          where: { productId: params["digitalProductId"] },
+          select: { id: true },
+        });
+        if (!prod) return { success: false, error: "digital_product_not_found", message: `DigitalProduct ${params["digitalProductId"]} not found` };
+        data["digitalProductId"] = prod.id;
+        touchedLinks = true;
+      }
+      if (typeof params["taxonomyNodeId"] === "string") {
+        const node = await prisma.taxonomyNode.findUnique({
+          where: { nodeId: params["taxonomyNodeId"] },
+          select: { id: true },
+        });
+        if (!node) return { success: false, error: "taxonomy_node_not_found", message: `TaxonomyNode ${params["taxonomyNodeId"]} not found` };
+        data["taxonomyNodeId"] = node.id;
+        touchedLinks = true;
+      }
+      if (typeof params["portfolioSlug"] === "string") {
+        const portfolio = await prisma.portfolio.findUnique({
+          where: { slug: params["portfolioSlug"] },
+          select: { id: true },
+        });
+        if (!portfolio) return { success: false, error: "portfolio_not_found", message: `Portfolio ${params["portfolioSlug"]} not found` };
+        data["portfolioId"] = portfolio.id;
+        explicitPortfolio = true;
+      }
+
       await prisma.backlogItem.update({ where: { itemId: String(params["itemId"]) }, data });
-      return { success: true, entityId: String(params["itemId"]), message: `Updated ${String(params["itemId"])}` };
+
+      // When links changed and the portfolio wasn't explicitly pinned, re-derive
+      // the denormalized portfolioId cache from the links (product → taxonomy →
+      // epic), reusing the canonical resolver.
+      let resolvedPortfolioId: string | null = null;
+      if (touchedLinks && !explicitPortfolio) {
+        resolvedPortfolioId = await attributeBacklogPortfolio(existing.id);
+      } else if (explicitPortfolio) {
+        resolvedPortfolioId = String(data["portfolioId"]);
+      }
+
+      return {
+        success: true,
+        entityId: String(params["itemId"]),
+        message: `Updated ${String(params["itemId"])}`,
+        ...(resolvedPortfolioId !== null ? { portfolioId: resolvedPortfolioId } : {}),
+      };
     }
 
     case "create_digital_product": {

--- a/docs/superpowers/plans/2026-07-05-bom-structural-reassociation-and-surface-products-plan.md
+++ b/docs/superpowers/plans/2026-07-05-bom-structural-reassociation-and-surface-products-plan.md
@@ -1,0 +1,28 @@
+# BOM Structural Reassociation + Surface DigitalProducts — Implementation Plan
+
+**Date:** 2026-07-05
+**Epic:** EP-BOM-WIRING
+**BIs:** BI-87A8BF2A (structural Workforce reassociation for AI-coworker backlog), BI-D5C9C3F7 (structural surface→DigitalProduct mappings)
+**Consumes:** DOC-1996319D (surface→DigitalProduct matrix + reassociation rule), DOC-7693D528 (coworker parity/approval invariant). Predecessors BI-058BEB95 / BI-2BB3DB23 produced DOC-1996319D as evidence; these two BIs make it structural.
+
+## Substrate reused (verify-substrate-first wins)
+- `resolveBacklogPortfolio` / `attributeBacklogPortfolio` / `backfillBacklogPortfolios` **already exist** (`packages/db/src/backlog-portfolio.ts`) — the DigitalProduct→taxonomy→epic precedence resolver + the denormalized `BacklogItem.portfolioId` cache writer. No new resolver.
+- The idempotent, non-destructive `projectPortfolioEntries` portfolio-source writer.
+- `BacklogItem.digitalProductId → DigitalProduct.id`, `taxonomyNodeId → TaxonomyNode.id`, `portfolioId` (denormalized cache).
+
+## BI-D5C9C3F7 — surface→DigitalProduct mappings
+- **`bom-workforce-surface-manifest.ts`**: the `for_employees` rows of the DOC-1996319D matrix (AI Workforce Operations, Workforce Roster, AI Coworker Services Catalog, Portfolio Management Cockpit, Finance Operations Work Lane) **plus the tax-remittance exemplar** (`Tax Remittance / Paying Taxes`, taxonomy `for_employees/financial_management`).
+- **`project-bom-workforce-surfaces.ts`**: projector reusing `projectPortfolioEntries` (`sourceKind: "bom_surface"`, added to the closed enum). Materializes each surface as a `for_employees` DigitalProduct. Wired into `seed.ts` (`bomWorkforceSurfaces` step) + `index.ts`. Idempotent + non-destructive; no parallel surface-map table.
+
+## BI-87A8BF2A — governed structural write path
+Closes the DOC-1996319D "Open Implementation Gap" (external MCP couldn't write `BacklogItem.digitalProductId` / `taxonomyNodeId` / `portfolioId`).
+- **`update_backlog_item`** MCP tool (`apps/web/lib/mcp-tools.ts`): accepts `digitalProductId` (productId → resolves to `DigitalProduct.id`), `taxonomyNodeId` (nodeId → `TaxonomyNode.id`), and `portfolioSlug` (slug → `Portfolio.id`, explicit override). After setting links, calls the existing `attributeBacklogPortfolio` to re-derive the `portfolioId` cache via the DigitalProduct→taxonomy→epic rule; returns the resolved `portfolioId`.
+- **Effect:** an AI-coworker / Workforce backlog item linked to a coworker or surface DigitalProduct (both `portfolioId = for_employees`) now resolves structurally to `for_employees` — the AC. Hive Scout coworker-archetype + capability items gain the same path (link a product → attribution follows).
+
+## Verification
+- `@dpf/db` `vitest run src/portfolio-sources` (new surface projector suite) + `src/backlog-portfolio` (resolver unchanged, still green).
+- `@dpf/db` + `apps/web` `tsc --noEmit`; `pnpm --filter web build`.
+- Execution evidence on both BIs; close when merged to `main`.
+
+## Notes
+- `mcp-tools.ts` is a large module (Module Size Guard is advisory, non-blocking) — this extends an existing tool rather than adding a new one, per the context-engineering "few, consolidated tools" rule; tool descriptions kept provenance-free (hygiene guard).

--- a/packages/db/src/portfolio-sources/bom-workforce-surface-manifest.ts
+++ b/packages/db/src/portfolio-sources/bom-workforce-surface-manifest.ts
@@ -1,0 +1,68 @@
+// BOM Workforce surface manifest (BI-D5C9C3F7, EP-BOM-WIRING).
+//
+// Structural realization of the DOC-1996319D "Surface-to-DigitalProduct Matrix":
+// the platform surfaces/functions the workforce operates ARE digital products the
+// org uses internally, and belong under the `for_employees` (Workforce) portfolio.
+// This manifest names the for_employees rows of that matrix (plus the tax-
+// remittance exemplar the doc calls out) so a projector can materialize them as
+// DigitalProducts idempotently — no parallel surface-map table.
+//
+// Note: per-AI-coworker products are produced separately by the coworker projector
+// (BI-8F9EDD6C). These are the SURFACE-level Workforce products (the operator/
+// coworker tools + the finance/tax business function), not the coworkers.
+
+/** One BOM Workforce surface to materialize as a for_employees DigitalProduct. */
+export interface BomWorkforceSurface {
+  /** Stable, deterministic product id (idempotent re-projection). */
+  productId: string;
+  name: string;
+  description: string;
+  /** Existing taxonomy nodeId string, or null to sit at the portfolio root. */
+  taxonomyNodeId: string | null;
+}
+
+export const BOM_WORKFORCE_SURFACE_MANIFEST: BomWorkforceSurface[] = [
+  {
+    productId: "bom-surface-ai-workforce-ops",
+    name: "AI Workforce Operations",
+    description:
+      "The AI Workforce admin & operations surface (/platform/ai): coworker records, capability needs, tool grants, model/token budgets. The workforce-management product the org runs its AI coworkers on.",
+    taxonomyNodeId: null,
+  },
+  {
+    productId: "bom-surface-workforce-roster",
+    name: "Workforce Roster",
+    description:
+      "The unified workforce roster spanning human employees and AI coworkers, with the coworker needs lens plus human-role parity anchor and approval/interface owner (DOC-7693D528).",
+    taxonomyNodeId: null,
+  },
+  {
+    productId: "bom-surface-ai-coworker-services-catalog",
+    name: "AI Coworker Services Catalog",
+    description:
+      "The catalog of AI coworker services and offers consumed internally — the CoworkerService / CoworkerOffer surface, linked to per-coworker Workforce products.",
+    taxonomyNodeId: null,
+  },
+  {
+    productId: "bom-surface-portfolio-management-cockpit",
+    name: "Portfolio Management Cockpit",
+    description:
+      "The employee/coworker-facing tool for managing all four portfolios (/portfolio). A Workforce-facing management surface; the products it manages retain their own portfolios.",
+    taxonomyNodeId: null,
+  },
+  {
+    productId: "bom-surface-finance-operations-work-lane",
+    name: "Finance Operations Work Lane",
+    description:
+      "The employee/accountant-coworker finance operations surface (financial management). Depends on Foundational accounting ledger, bank feeds, and identity.",
+    taxonomyNodeId: "for_employees/financial_management",
+  },
+  {
+    // DOC-1996319D Tax Remittance exemplar: a Workforce financial-management product.
+    productId: "bom-surface-tax-remittance",
+    name: "Tax Remittance / Paying Taxes",
+    description:
+      "Paying taxes / tax remittance as a Workforce financial-management product (consumers: finance employee, accountant coworker, operator). Depends on Foundational accounting/banking/identity and, where tax derives from sales, Products & Services Sold revenue records.",
+    taxonomyNodeId: "for_employees/financial_management",
+  },
+];

--- a/packages/db/src/portfolio-sources/index.ts
+++ b/packages/db/src/portfolio-sources/index.ts
@@ -13,3 +13,5 @@ export * from "./licensed-dependencies-manifest";
 export * from "./project-sbom";
 export * from "./product-dependency";
 export * from "./project-coworker-workforce";
+export * from "./bom-workforce-surface-manifest";
+export * from "./project-bom-workforce-surfaces";

--- a/packages/db/src/portfolio-sources/project-bom-workforce-surfaces.test.ts
+++ b/packages/db/src/portfolio-sources/project-bom-workforce-surfaces.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BOM_WORKFORCE_SURFACE_MANIFEST } from "./bom-workforce-surface-manifest";
+import { projectBomWorkforceSurfaces } from "./project-bom-workforce-surfaces";
+import { PORTFOLIO_PROJECTION_KEYS, PROJECTED_BY } from "./types";
+
+type ProductRow = { id: string; productId: string; observationConfig: Record<string, unknown> };
+
+function makeDb() {
+  const products = new Map<string, ProductRow & Record<string, unknown>>();
+  return {
+    _products: products,
+    portfolio: { findUnique: vi.fn(async () => ({ id: "port-fe" })) },
+    taxonomyNode: {
+      // Resolve the financial_management node; everything else sits at root.
+      findUnique: vi.fn(async (args: { where: { nodeId: string } }) =>
+        args.where.nodeId === "for_employees/financial_management" ? { id: "tax-node" } : null,
+      ),
+    },
+    digitalProduct: {
+      findUnique: vi.fn(async (args: { where: { productId: string } }) => {
+        const r = products.get(args.where.productId);
+        return r ? { id: r.id, observationConfig: r.observationConfig } : null;
+      }),
+      create: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        const d = args.data;
+        products.set(d.productId as string, {
+          id: `dp-${d.productId as string}`,
+          productId: d.productId as string,
+          observationConfig: (d.observationConfig as Record<string, unknown>) ?? {},
+          ...d,
+        });
+        return {};
+      }),
+      update: vi.fn(async () => ({})),
+    },
+  };
+}
+
+describe("projectBomWorkforceSurfaces (BI-D5C9C3F7)", () => {
+  it("projects every manifest surface as a for_employees DigitalProduct", async () => {
+    const db = makeDb();
+    const result = await projectBomWorkforceSurfaces({ db: db as never });
+
+    expect(result.total).toBe(BOM_WORKFORCE_SURFACE_MANIFEST.length);
+    expect(result.created).toBe(BOM_WORKFORCE_SURFACE_MANIFEST.length);
+    for (const s of BOM_WORKFORCE_SURFACE_MANIFEST) {
+      const row = db._products.get(s.productId)!;
+      expect(row).toBeDefined();
+      expect(row.portfolioId).toBe("port-fe");
+      expect(row.sourceKind).toBe("bom_surface");
+      expect(row.coverageStatus).toBe("used");
+      expect(row.observationConfig[PORTFOLIO_PROJECTION_KEYS.projectedBy]).toBe(PROJECTED_BY);
+    }
+  });
+
+  it("places the tax-remittance exemplar under the financial_management taxonomy node", async () => {
+    const db = makeDb();
+    await projectBomWorkforceSurfaces({ db: db as never });
+
+    const tax = db._products.get("bom-surface-tax-remittance")!;
+    expect(tax.taxonomyNodeId).toBe("tax-node");
+  });
+
+  it("is idempotent — a re-run updates projector-owned rows, no duplicates", async () => {
+    const db = makeDb();
+    await projectBomWorkforceSurfaces({ db: db as never });
+    const sizeAfterFirst = db._products.size;
+
+    const result2 = await projectBomWorkforceSurfaces({ db: db as never });
+    expect(db._products.size).toBe(sizeAfterFirst);
+    expect(result2.created).toBe(0);
+    expect(result2.updated).toBe(BOM_WORKFORCE_SURFACE_MANIFEST.length);
+  });
+});

--- a/packages/db/src/portfolio-sources/project-bom-workforce-surfaces.ts
+++ b/packages/db/src/portfolio-sources/project-bom-workforce-surfaces.ts
@@ -1,0 +1,46 @@
+// BOM Workforce surface projector (BI-D5C9C3F7, EP-BOM-WIRING).
+//
+// Materializes the DOC-1996319D Workforce (for_employees) surfaces + the tax-
+// remittance exemplar as DigitalProducts, reusing the idempotent, non-destructive
+// projectPortfolioEntries writer. This makes the surface-to-DigitalProduct matrix
+// STRUCTURAL (backlog can attribute a Workforce-surface item to for_employees via
+// DigitalProduct.portfolioId) rather than a written rule — no parallel surface map.
+
+import {
+  BOM_WORKFORCE_SURFACE_MANIFEST,
+  type BomWorkforceSurface,
+} from "./bom-workforce-surface-manifest";
+import {
+  projectPortfolioEntries,
+  type ProjectPortfolioClient,
+  type ProjectPortfolioResult,
+} from "./project-portfolio-source";
+import type { ProjectedPortfolioEntry } from "./types";
+
+const FOR_EMPLOYEES_SLUG = "for_employees" as const;
+
+function toEntry(surface: BomWorkforceSurface): ProjectedPortfolioEntry {
+  return {
+    productId: surface.productId,
+    name: surface.name,
+    description: surface.description,
+    portfolioSlug: FOR_EMPLOYEES_SLUG,
+    taxonomyNodeId: surface.taxonomyNodeId,
+    // A surface the workforce actively operates is a "used" internal product.
+    coverageStatus: "used",
+    sourceKind: "bom_surface",
+  };
+}
+
+/**
+ * Project the BOM Workforce surfaces (DOC-1996319D) as for_employees
+ * DigitalProducts. Idempotent + non-destructive (reuses projectPortfolioEntries'
+ * projectedBy ownership guard). Called from the seed alongside the other
+ * portfolio-source projectors.
+ */
+export async function projectBomWorkforceSurfaces(
+  options: { db?: ProjectPortfolioClient } = {},
+): Promise<ProjectPortfolioResult> {
+  const entries = BOM_WORKFORCE_SURFACE_MANIFEST.map(toEntry);
+  return projectPortfolioEntries(entries, options);
+}

--- a/packages/db/src/portfolio-sources/types.ts
+++ b/packages/db/src/portfolio-sources/types.ts
@@ -38,6 +38,7 @@ export const PORTFOLIO_SOURCE_KINDS = [
   "sbom", // BomComponent (CycloneDX)
   "archetype", // archetype-seeded offers / suppliers / goods
   "coworker_service", // Agent / CoworkerService — AI coworkers as Workforce products (BI-8F9EDD6C)
+  "bom_surface", // DOC-1996319D Workforce surfaces (AI Workforce Ops, roster, finance/tax) (BI-D5C9C3F7)
 ] as const;
 export type PortfolioSourceKind = (typeof PORTFOLIO_SOURCE_KINDS)[number];
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -22,6 +22,7 @@ import { projectAiProviders, projectIntegrations } from "./portfolio-sources/pro
 import { projectSupplyChain } from "./portfolio-sources/project-sbom.js";
 import { projectProductDependencyGraph } from "./portfolio-sources/product-dependency.js";
 import { projectCoworkerWorkforce } from "./portfolio-sources/project-coworker-workforce.js";
+import { projectBomWorkforceSurfaces } from "./portfolio-sources/project-bom-workforce-surfaces.js";
 import { backfillBacklogPortfolios } from "./backlog-portfolio.js";
 import {
   seedViewpointsForNotation,
@@ -2377,6 +2378,10 @@ async function main(): Promise<void> {
   // for_employees and back-link Agent.portfolioId + CoworkerService.digitalProductId.
   // Runs after coworkerServiceCatalog so services exist to link.
   await step("coworkerWorkforcePortfolio", () => projectCoworkerWorkforce());
+  // BI-D5C9C3F7: project the DOC-1996319D Workforce surfaces (AI Workforce Ops,
+  // roster, finance/tax) as for_employees DigitalProducts so surface-to-product
+  // mappings are structural, not just documented.
+  await step("bomWorkforceSurfaces", () => projectBomWorkforceSurfaces());
   await step("defaultAdminUser", () => seedDefaultAdminUser());
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));
   await step("dataModelMirrorScheduledTask", () => ensureDataModelMirrorScheduledTask(prisma));


### PR DESCRIPTION
## What & why

Turns the **DOC-1996319D** surface-to-DigitalProduct matrix + reassociation rule from *documented evidence* into *structural behavior*, per EP-BOM-WIRING. Predecessors BI-058BEB95 / BI-2BB3DB23 produced the doc; these two BIs implement it. Reuses existing substrate — **no parallel surface-map or resolver**.

## BI-D5C9C3F7 — Workforce surfaces as DigitalProducts
- **`bom-workforce-surface-manifest.ts`** + **`project-bom-workforce-surfaces.ts`**: project the `for_employees` rows of the matrix (AI Workforce Operations, Workforce Roster, AI Coworker Services Catalog, Portfolio Management Cockpit, Finance Operations Work Lane) **plus the tax-remittance exemplar** (taxonomy `for_employees/financial_management`) as `for_employees` DigitalProducts — reusing the idempotent `projectPortfolioEntries` writer (`sourceKind: "bom_surface"`). Wired into the seed.

## BI-87A8BF2A — governed structural write path
- **`update_backlog_item`** now accepts `digitalProductId` / `taxonomyNodeId` / `portfolioSlug` (stable human ids → resolved to FK ids), then calls the **existing** `attributeBacklogPortfolio` to re-derive `BacklogItem.portfolioId` via the canonical **DigitalProduct → taxonomy → epic** precedence, and returns the resolved portfolio. This closes DOC-1996319D's "Open Implementation Gap" (external MCP could link epics but not products/taxonomy/portfolio).
- **Effect:** an AI-coworker / Workforce backlog item linked to a coworker product (BI-8F9EDD6C) or a BOM-surface product (this PR) — both `portfolioId = for_employees` — now resolves structurally to `for_employees`. Hive Scout coworker-archetype + capability items gain the same path.

## Verification (worktree, shared pnpm store)
- ✅ `@dpf/db` `vitest src/portfolio-sources src/backlog-portfolio` — **52 passed** (new surface projector suite + the reused resolver).
- ✅ `apps/web` `tsc --noEmit` clean; `@dpf/db` typecheck clean; **tool-description hygiene guard green** (new fields provenance-free).
- ✅ `pnpm --filter web build` (see CI Production Build). No migration.

**Process-Spine-Decision:** plan at `docs/superpowers/plans/2026-07-05-bom-structural-reassociation-and-surface-products-plan.md`. `mcp-tools.ts` is a large module (Module Size Guard is advisory) — this extends an existing tool rather than adding one, per the context-engineering "few consolidated tools" rule.

Closes **BI-D5C9C3F7** and **BI-87A8BF2A** once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)