### PR TITLE
fix(mcp): start_scout_research resolves cuid context id via buildId hint (BI-7FEAFD9A)

### DIFF
--- a/apps/web/lib/mcp-tools-resolve-build-id.test.ts
+++ b/apps/web/lib/mcp-tools-resolve-build-id.test.ts
@@ -228,3 +228,59 @@ describe("resolveActiveBuildId (via saveBuildEvidence)", () => {
   // without thinking about callers.
   void buildSelectShape;
 });
+
+describe("start_scout_research build resolution (BI-7FEAFD9A regression)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.featureBuild.update.mockResolvedValue({});
+    mockPrisma.buildActivity.create.mockResolvedValue({});
+  });
+
+  it("resolves a cuid-shaped context.featureBuildId via the preamble-mapped params.buildId hint", async () => {
+    // Observed live 2026-07-05 on FB-F4BE093E: the agentic loop plumbs
+    // context.featureBuildId as a FeatureBuild.id cuid. The executeTool
+    // preamble maps it to params.buildId (the FB- form), but the scout
+    // handler passed the raw cuid to resolveIdeateBuildForTool, whose
+    // findUniqueBuild queries where:{buildId} — a guaranteed miss, so the
+    // tool always refused with "Couldn't find that build".
+    const contextCuid = "cmcpqr7xk0001v8m3h2j9d4ta";
+    const fbId = "FB-F4BE093E";
+
+    mockPrisma.featureBuild.findUnique.mockImplementation(
+      ({ where, select }: { where: { id?: string; buildId?: string }; select: Record<string, boolean> }) => {
+        // executeTool preamble: cuid → FB- buildId mapping.
+        if (where.id === contextCuid) return Promise.resolve({ buildId: fbId });
+        // Ideate resolver lookup (select: { buildId, phase }).
+        if (where.buildId === fbId && select.phase) {
+          return Promise.resolve({ buildId: fbId, phase: "ideate" });
+        }
+        // Scout handler re-read (select: { buildId, buildExecState, scoutFindings }).
+        if (where.buildId === fbId) {
+          return Promise.resolve({ buildId: fbId, buildExecState: null, scoutFindings: null });
+        }
+        // Anything else — including the pre-fix where:{buildId:<cuid>} — misses.
+        return Promise.resolve(null);
+      },
+    );
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "start_scout_research",
+      {},
+      "user-1",
+      { threadId: "thread-1", routeContext: "/build", featureBuildId: contextCuid },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Scout started");
+    expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { buildId: fbId } }),
+    );
+    // The resolver must never be asked to look up the raw cuid as a buildId —
+    // that query is the bug (it can never match an FB- keyed row).
+    const cuidAsBuildIdLookups = mockPrisma.featureBuild.findUnique.mock.calls.filter(
+      (call) => (call[0] as { where?: { buildId?: string } }).where?.buildId === contextCuid,
+    );
+    expect(cuidAsBuildIdLookups).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -11852,8 +11852,12 @@ export async function executeTool(
 
       // BI-F4A30FCB (Dale dogfood 2026-05-24): resolve the target build
       // from agent context first; see start_ideate_research comment above.
+      // BI-7FEAFD9A (2026-07-05): prefer the FB- hint from params.buildId
+      // (set by the executeTool preamble from the context cuid) — passing the
+      // raw context.featureBuildId cuid here made the resolver's
+      // where:{buildId} lookup a guaranteed miss, so scout always refused.
       const resolved = await resolveIdeateBuildForTool({
-        contextBuildId: context?.featureBuildId,
+        contextBuildId: extractBuildIdHint(params) ?? context?.featureBuildId,
         toolName: "start_scout_research",
       });
       if (!resolved.build) {

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -42,7 +42,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16556,
+  "apps/web/lib/mcp-tools.ts": 16472,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1183,


### PR DESCRIPTION
## Summary
- Fixes BI-7FEAFD9A (EP-BS-UX-HARDENING): `start_scout_research` passed the raw `context.featureBuildId` (a FeatureBuild.id cuid) as `contextBuildId` to `resolveIdeateBuildForTool`, whose `findUniqueBuild` queries `where:{buildId}` (the FB-XXXX key) — a guaranteed miss, so the tool refused every call with "Couldn't find that build to start research on". Observed live 2026-07-05 on FB-F4BE093E during BI-4E84841D verification.
- The `executeTool` preamble already maps the context cuid to `params.buildId` in FB- form, and `start_ideate_research` resolves via `extractBuildIdHint(params) ?? context?.featureBuildId` and works. This makes `start_scout_research` resolve identically (one-line fix + comment).
- Adds a handler-level regression test in `mcp-tools-resolve-build-id.test.ts` driving the real `start_scout_research` handler with a cuid-shaped context id: red pre-fix (refusal), green post-fix, and asserts the raw cuid is never queried as a `buildId`.

## Test plan
- [x] vitest `lib/mcp-tools-resolve-build-id.test.ts` + `lib/build/ideate-build-resolution.test.ts`: 14 passing (new regression test verified red before the fix, green after)
- [x] typecheck: clean (`tsc --noEmit` exit 0; needs `NODE_OPTIONS=--max-old-space-size=8192` locally on macOS — default heap aborts, known worktree harness issue; CI Typecheck authoritative)
- [x] next build: n/a (server-side tool handler, no UI surface; CI runs the production build)
- [x] UX verification: n/a locally — live re-verification of scout on a real build to follow post-merge (same path as the BI-4E84841D live check that surfaced this bug)

Overlap sweep: no sibling PR on this surface. #2611 refactors mcp-tools.ts (extracts update_backlog_item handler) — different concern; textual merge-conflict risk only, no duplicate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)