### PR TITLE
fix(release): re-pin hwdsl2/whisper-server to current registry digest (BI-4439CDF1)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -864,7 +864,7 @@ services:
   # No profile gate — voice ships working on `docker compose up`.
   dpf-stt:
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-06-25 (the prior 008ef78e… digest was deleted from the
+    # resolved on 2026-07-05 (the prior 10af319a… digest was deleted from the
     # registry — Release Image Manifest Guard caught it again). The registry
     # owner re-pushes :latest periodically and prunes the previous index, so
     # this digest must be re-resolved every time the guard fails. Bump
@@ -874,7 +874,7 @@ services:
     # the sidecar won't start, set DPF_STT_IMAGE in .env to a reachable ref
     # (e.g. hwdsl2/whisper-server:latest) then `docker compose up -d dpf-stt`,
     # and open a PR re-resolving the digest here (this is that PR's pattern).
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:10af319a81e81d03535e94b364b0103e8132d205b46438b4f469da9746fa8462}
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:44d7690a05787f76d001a097513e578c51624def64e9dbc4a61132d739851e6b}
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:3f109fa1cfd99d701b9e60a8ef52457630b0711ef2c1ad44d57cd95e25b91b39";
+  "hwdsl2/whisper-server@sha256:10af319a81e81d03535e94b364b0103e8132d205b46438b4f469da9746fa8462";
 const CURRENT_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:008ef78e8164be1a52d3c16a0a4702af4190bc355c057e481ceb35af739ab184";
+  "hwdsl2/whisper-server@sha256:44d7690a05787f76d001a097513e578c51624def64e9dbc4a61132d739851e6b";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
Release Contract Guards + Release Image Manifest Guard have been red on `main` since 2026-06-22 (last green run 2026-06-20). Root cause: the registry owner re-pushed `hwdsl2/whisper-server:latest` on 2026-07-03 and pruned the previously pinned index digest (`10af319a…`), and `tests/release/installer-release-contract.test.mjs` still expected the rotation before that (`008ef78e…`) — so compose and the contract test disagreed AND both pointed at unreachable/stale digests.

Fix (the pattern documented in the compose comment for exactly this recurrence):
- `docker-compose.yml`: pin `dpf-stt` to the live multi-arch index digest `sha256:44d7690a…` (resolved 2026-07-05, verified reachable via `node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned` → `[ok]`).
- Contract test: `CURRENT_STT_DIGEST` → `44d7690a…`, `RETIRED_STT_DIGEST` → `10af319a…`.

`node --test tests/release/installer-release-contract.test.mjs`: 14/14 pass.

This un-reds the two release gates for every open PR. Digest-rot recurrence is tracked as BI-4439CDF1 (consider automating re-resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)