### PR TITLE
feat(release): STT Digest Watch — automated whisper-server re-pin (BI-A9EAEE2C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ on:
   # statuses that never post. The `changes` gate below fails safe to heavy=true
   # on any non-PR event, so the heavy required jobs do run on merge_group.
   merge_group:
+  # Manual/bot dispatch (BI-A9EAEE2C): PRs created with GITHUB_TOKEN (e.g. the
+  # STT Digest Watch re-pin PR) never trigger pull_request workflows, so the
+  # bot dispatches this workflow onto its branch to post the required checks.
+  # The `changes` fail-safe above applies here too: heavy jobs run.
+  workflow_dispatch: {}
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -498,6 +503,7 @@ jobs:
             scripts/lib/compose-safety.test.mjs \
             scripts/lib/sandbox-freshness.test.mjs \
             scripts/sandbox-freshness-preflight.test.mjs \
+            scripts/release/re-resolve-stt-digest.test.mjs \
             tests/release/local-ci-gate-contract.test.mjs
       - name: Smoke --help (must exit 0, no docker required)
         run: node scripts/runtime-artifact-janitor.mjs --help > /dev/null

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -30,6 +30,9 @@ permissions:
 #                      so this is path-filtered.
 
 on:
+  # Manual/bot dispatch (BI-A9EAEE2C): lets the STT Digest Watch post these
+  # gates onto its GITHUB_TOKEN-created re-pin PR branch.
+  workflow_dispatch: {}
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/stt-digest-watch.yml
+++ b/.github/workflows/stt-digest-watch.yml
@@ -1,0 +1,89 @@
+name: STT Digest Watch
+
+# The hwdsl2/whisper-server registry owner re-pushes :latest roughly weekly and
+# prunes the previously pinned index manifest. When that happens, the digest
+# pinned in docker-compose.yml rots and Release Contract Guards + Release Image
+# Manifest Guard go red on main for every open PR until someone manually
+# re-pins (BI-4439CDF1 sat red for two weeks; fixed by hand in PR #2615).
+# This watch closes the loop: on drift it applies the mechanical re-pin
+# (scripts/release/re-resolve-stt-digest.mjs --apply), opens a signed PR,
+# dispatches the required CI workflows onto the branch (PRs created with
+# GITHUB_TOKEN do not trigger checks on their own), and arms auto-merge.
+# BI-A9EAEE2C.
+
+on:
+  schedule:
+    - cron: "17 6 * * *" # daily 06:17 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # push the re-pin branch
+  pull-requests: write # open the re-pin PR + arm auto-merge
+  actions: write # dispatch ci.yml / release-gates.yml onto the branch
+
+concurrency:
+  group: stt-digest-watch
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: Watch STT image digest
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      BRANCH: bot/stt-digest-repin
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Check pinned digest against the live registry
+        id: check
+        run: |
+          set +e
+          node scripts/release/re-resolve-stt-digest.mjs --check
+          code=$?
+          set -e
+          if [ "$code" = "0" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          elif [ "$code" = "3" ]; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docker Hub API unavailable; skipping this run (transient)" >&2
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Skip if a re-pin PR is already open
+        id: existing
+        if: steps.check.outputs.drift == 'true'
+        run: |
+          open_pr=$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number // empty' --repo "$GITHUB_REPOSITORY")
+          echo "pr=$open_pr" >> "$GITHUB_OUTPUT"
+      - name: Apply re-pin and open PR
+        if: steps.check.outputs.drift == 'true' && steps.existing.outputs.pr == ''
+        run: |
+          node scripts/release/re-resolve-stt-digest.mjs --apply
+          node --test scripts/release/re-resolve-stt-digest.test.mjs tests/release/installer-release-contract.test.mjs
+          node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add docker-compose.yml tests/release/installer-release-contract.test.mjs
+          git commit -s \
+            -m "fix(release): re-pin hwdsl2/whisper-server to current registry digest" \
+            -m "Automated re-pin by STT Digest Watch (BI-A9EAEE2C): the registry owner re-pushed :latest and the previously pinned index digest is being (or has been) pruned. Re-resolved via the Docker Hub API; contract tests and the digest-pinned manifest guard were run in this workflow before the commit." \
+            -m "Process-Spine-Decision: mechanical dependency re-pin, no doc surface changed."
+          git push -f origin "$BRANCH"
+
+          gh pr create \
+            --title "fix(release): re-pin hwdsl2/whisper-server to current registry digest (auto)" \
+            --body "Automated re-pin by the **STT Digest Watch** (BI-A9EAEE2C). The registry owner re-pushed \`:latest\`, rotating the index digest; without this re-pin the Release Contract Guards + Release Image Manifest Guard go red on every PR (see BI-4439CDF1 / PR #2615 for the manual precedent). Verified inside the workflow before commit: contract tests + \`verify-compose-image-manifests.mjs --only digest-pinned\` against the live registry. Required CI is dispatched onto this branch by the watch (GITHUB_TOKEN-created PRs do not trigger checks); auto-merge is armed. If checks have not appeared, dispatch \`ci.yml\` on this branch or push an empty commit." \
+            --head "$BRANCH" --base main
+
+          # PRs created with GITHUB_TOKEN never trigger pull_request workflows;
+          # dispatch the required check workflows onto the branch explicitly.
+          gh workflow run ci.yml --ref "$BRANCH" || echo "ci.yml dispatch failed; dispatch manually"
+          gh workflow run release-gates.yml --ref "$BRANCH" || echo "release-gates dispatch failed; dispatch manually"
+
+          gh pr merge "$BRANCH" --auto || echo "auto-merge not armed; arm manually after checks pass"

--- a/scripts/release/re-resolve-stt-digest.mjs
+++ b/scripts/release/re-resolve-stt-digest.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// Re-resolve the pinned STT sidecar image digest (BI-A9EAEE2C).
+//
+// hwdsl2/whisper-server re-pushes :latest periodically and prunes the previous
+// index manifest, so the digest pinned in docker-compose.yml rots on the
+// registry owner's schedule. When that happens, Release Contract Guards +
+// Release Image Manifest Guard go red on main for EVERY open PR until someone
+// manually re-pins (BI-4439CDF1 sat red for two weeks). This script closes the
+// loop mechanically:
+//
+//   --check   resolve the live index digest for the tracked tag via the Docker
+//             Hub API and compare with the compose pin. Exit 0 in-sync, exit 3
+//             on drift (prints the new digest), exit 2 on usage/API failure.
+//   --apply   on drift, rewrite docker-compose.yml (image pin + "resolved on"
+//             comment date) and tests/release/installer-release-contract.test.mjs
+//             (CURRENT_STT_DIGEST -> new, RETIRED_STT_DIGEST -> the digest being
+//             replaced), then exit 3 so callers know a change was made.
+//
+// Driven by .github/workflows/stt-digest-watch.yml (daily cron), which opens a
+// signed re-pin PR when this script reports drift. Also runnable by hand.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+export const STT_IMAGE_REPO = "hwdsl2/whisper-server";
+// The upstream tag whose index digest we track. Never shipped as `:latest` in
+// compose (non-reproducible installs); we pin the digest that tag resolves to.
+export const STT_TRACKED_TAG = "latest";
+export const COMPOSE_PATH = "docker-compose.yml";
+export const CONTRACT_TEST_PATH = "tests/release/installer-release-contract.test.mjs";
+
+export const EXIT_IN_SYNC = 0;
+export const EXIT_USAGE_OR_API = 2;
+export const EXIT_DRIFT = 3;
+
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+
+/** Extract the pinned digest from the compose text. Returns "" when absent. */
+export function parsePinnedDigest(composeText, repo = STT_IMAGE_REPO) {
+  const match = String(composeText ?? "").match(
+    new RegExp(`${repo.replace(/[/]/g, "\\/")}@(sha256:[0-9a-f]{64})`),
+  );
+  return match ? match[1] : "";
+}
+
+/** Extract CURRENT_STT_DIGEST from the contract test text. Returns "" when absent. */
+export function parseContractCurrentDigest(testText, repo = STT_IMAGE_REPO) {
+  const match = String(testText ?? "").match(
+    new RegExp(
+      `CURRENT_STT_DIGEST\\s*=\\s*\\n?\\s*"${repo.replace(/[/]/g, "\\/")}@(sha256:[0-9a-f]{64})"`,
+    ),
+  );
+  return match ? match[1] : "";
+}
+
+/**
+ * Resolve the live index digest for repo:tag from the Docker Hub API.
+ * `fetchImpl` is injectable for tests. Throws on HTTP/shape failures.
+ */
+export async function resolveLiveDigest({ repo = STT_IMAGE_REPO, tag = STT_TRACKED_TAG, fetchImpl = fetch } = {}) {
+  const url = `https://hub.docker.com/v2/repositories/${repo}/tags/${tag}`;
+  const response = await fetchImpl(url, { headers: { accept: "application/json" } });
+  if (!response.ok) {
+    throw new Error(`Docker Hub API ${response.status} for ${url}`);
+  }
+  const payload = await response.json();
+  const digest = payload?.digest;
+  if (typeof digest !== "string" || !DIGEST_RE.test(digest)) {
+    throw new Error(`Docker Hub API returned no valid index digest for ${repo}:${tag} (got: ${JSON.stringify(digest)})`);
+  }
+  return digest;
+}
+
+/**
+ * Rewrite compose + contract test for a new digest. Pure text-in/text-out.
+ * Returns { composeText, testText, oldDigest }. Throws if the expected
+ * structures are not found — a silent partial rewrite would recreate the
+ * compose/test disagreement this automation exists to prevent.
+ */
+export function applyRepin({ composeText, testText, newDigest, repo = STT_IMAGE_REPO, today }) {
+  if (!DIGEST_RE.test(newDigest ?? "")) throw new Error(`invalid digest: ${newDigest}`);
+  const oldDigest = parsePinnedDigest(composeText, repo);
+  if (!oldDigest) throw new Error(`no ${repo}@sha256:… pin found in compose text`);
+  if (oldDigest === newDigest) throw new Error("compose already pins the requested digest");
+
+  let nextCompose = composeText.replaceAll(`${repo}@${oldDigest}`, `${repo}@${newDigest}`);
+  // Keep the human trail in the compose comment current: the "resolved on
+  // <date> (the prior <shortdigest>… digest ...)" line documents each rotation.
+  const shortOld = oldDigest.replace("sha256:", "").slice(0, 8);
+  nextCompose = nextCompose.replace(
+    /resolved on \d{4}-\d{2}-\d{2} \(the prior [0-9a-f]{8}… digest/,
+    `resolved on ${today} (the prior ${shortOld}… digest`,
+  );
+
+  const testCurrent = parseContractCurrentDigest(testText, repo);
+  if (!testCurrent) throw new Error(`no CURRENT_STT_DIGEST found in contract test text`);
+  let nextTest = testText.replace(
+    new RegExp(`(RETIRED_STT_DIGEST\\s*=\\s*\\n?\\s*")${repo.replace(/[/]/g, "\\/")}@sha256:[0-9a-f]{64}(")`),
+    `$1${repo}@${oldDigest}$2`,
+  );
+  nextTest = nextTest.replace(
+    new RegExp(`(CURRENT_STT_DIGEST\\s*=\\s*\\n?\\s*")${repo.replace(/[/]/g, "\\/")}@sha256:[0-9a-f]{64}(")`),
+    `$1${repo}@${newDigest}$2`,
+  );
+  if (!nextTest.includes(`${repo}@${newDigest}`) || !nextTest.includes(`${repo}@${oldDigest}`)) {
+    throw new Error("contract test rewrite did not land both digests");
+  }
+  return { composeText: nextCompose, testText: nextTest, oldDigest };
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const check = process.argv.includes("--check") || !apply;
+  const rootIndex = process.argv.indexOf("--root");
+  const root = rootIndex >= 0 ? path.resolve(process.argv[rootIndex + 1]) : process.cwd();
+
+  const composePath = path.join(root, COMPOSE_PATH);
+  const testPath = path.join(root, CONTRACT_TEST_PATH);
+  const composeText = readFileSync(composePath, "utf8");
+  const pinned = parsePinnedDigest(composeText);
+  if (!pinned) {
+    console.error(`[stt-digest] no ${STT_IMAGE_REPO} digest pin found in ${composePath}`);
+    process.exit(EXIT_USAGE_OR_API);
+  }
+
+  let live;
+  try {
+    live = await resolveLiveDigest({});
+  } catch (error) {
+    console.error(`[stt-digest] could not resolve live digest: ${error.message}`);
+    process.exit(EXIT_USAGE_OR_API);
+  }
+
+  if (live === pinned) {
+    console.log(`[stt-digest] in sync: ${STT_IMAGE_REPO}:${STT_TRACKED_TAG} -> ${pinned}`);
+    process.exit(EXIT_IN_SYNC);
+  }
+
+  console.log(`[stt-digest] DRIFT: compose pins ${pinned} but ${STT_IMAGE_REPO}:${STT_TRACKED_TAG} now resolves to ${live}`);
+  if (check && !apply) process.exit(EXIT_DRIFT);
+
+  const testText = readFileSync(testPath, "utf8");
+  const today = new Date().toISOString().slice(0, 10);
+  const result = applyRepin({ composeText, testText, newDigest: live, today });
+  writeFileSync(composePath, result.composeText);
+  writeFileSync(testPath, result.testText);
+  console.log(`[stt-digest] re-pinned ${result.oldDigest} -> ${live} in ${COMPOSE_PATH} and ${CONTRACT_TEST_PATH}`);
+  process.exit(EXIT_DRIFT);
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(`[stt-digest] ${error.message}`);
+    process.exit(EXIT_USAGE_OR_API);
+  });
+}

--- a/scripts/release/re-resolve-stt-digest.test.mjs
+++ b/scripts/release/re-resolve-stt-digest.test.mjs
@@ -1,0 +1,88 @@
+// Tests for the STT digest re-resolver (BI-A9EAEE2C). Pure fixtures, no
+// network, no docker — runs under the bare-runner CI test job.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import {
+  applyRepin,
+  parseContractCurrentDigest,
+  parsePinnedDigest,
+  resolveLiveDigest,
+} from "./re-resolve-stt-digest.mjs";
+
+const OLD = `sha256:${"1".repeat(64)}`;
+const OLDER = `sha256:${"0".repeat(64)}`;
+const NEW = `sha256:${"2".repeat(64)}`;
+
+const COMPOSE = `services:
+  dpf-stt:
+    # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
+    # resolved on 2026-07-05 (the prior ${"0".repeat(8)}… digest was deleted from the
+    # registry — Release Image Manifest Guard caught it again).
+    image: \${DPF_STT_IMAGE:-hwdsl2/whisper-server@${OLD}}
+`;
+
+const CONTRACT_TEST = `const RETIRED_STT_DIGEST =
+  "hwdsl2/whisper-server@${OLDER}";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@${OLD}";
+`;
+
+test("parsePinnedDigest reads the compose pin", () => {
+  assert.equal(parsePinnedDigest(COMPOSE), OLD);
+  assert.equal(parsePinnedDigest("no pin here"), "");
+});
+
+test("parseContractCurrentDigest reads the test constant across the line break", () => {
+  assert.equal(parseContractCurrentDigest(CONTRACT_TEST), OLD);
+  assert.equal(parseContractCurrentDigest("nothing"), "");
+});
+
+test("applyRepin rotates compose pin, comment date, and both test constants", () => {
+  const { composeText, testText, oldDigest } = applyRepin({
+    composeText: COMPOSE,
+    testText: CONTRACT_TEST,
+    newDigest: NEW,
+    today: "2027-01-02",
+  });
+  assert.equal(oldDigest, OLD);
+  assert.equal(parsePinnedDigest(composeText), NEW);
+  assert.match(composeText, /resolved on 2027-01-02 \(the prior 11111111… digest/);
+  assert.doesNotMatch(composeText, new RegExp(OLD));
+  assert.match(testText, new RegExp(`RETIRED_STT_DIGEST =\\n  "hwdsl2/whisper-server@${OLD}"`));
+  assert.match(testText, new RegExp(`CURRENT_STT_DIGEST =\\n  "hwdsl2/whisper-server@${NEW}"`));
+  assert.doesNotMatch(testText, new RegExp(OLDER));
+});
+
+test("applyRepin refuses no-op and malformed inputs", () => {
+  assert.throws(() => applyRepin({ composeText: COMPOSE, testText: CONTRACT_TEST, newDigest: OLD, today: "2027-01-02" }), /already pins/);
+  assert.throws(() => applyRepin({ composeText: COMPOSE, testText: CONTRACT_TEST, newDigest: "sha256:zz", today: "2027-01-02" }), /invalid digest/);
+  assert.throws(() => applyRepin({ composeText: "no pin", testText: CONTRACT_TEST, newDigest: NEW, today: "2027-01-02" }), /no hwdsl2/);
+  assert.throws(() => applyRepin({ composeText: COMPOSE, testText: "no constant", newDigest: NEW, today: "2027-01-02" }), /CURRENT_STT_DIGEST/);
+});
+
+test("applyRepin round-trips against the REAL repo files", () => {
+  // Guards against the fixture and the actual docker-compose.yml / contract
+  // test drifting apart structurally (comment shape, constant layout).
+  const compose = readFileSync(new URL("../../docker-compose.yml", import.meta.url), "utf8");
+  const contractTest = readFileSync(new URL("../../tests/release/installer-release-contract.test.mjs", import.meta.url), "utf8");
+  const { composeText, testText } = applyRepin({ composeText: compose, testText: contractTest, newDigest: NEW, today: "2027-01-02" });
+  assert.equal(parsePinnedDigest(composeText), NEW);
+  assert.equal(parseContractCurrentDigest(testText), NEW);
+  assert.match(composeText, /resolved on 2027-01-02/);
+});
+
+test("resolveLiveDigest validates the API response shape", async () => {
+  const ok = await resolveLiveDigest({
+    fetchImpl: async () => ({ ok: true, json: async () => ({ digest: NEW }) }),
+  });
+  assert.equal(ok, NEW);
+  await assert.rejects(
+    resolveLiveDigest({ fetchImpl: async () => ({ ok: false, status: 503 }) }),
+    /503/,
+  );
+  await assert.rejects(
+    resolveLiveDigest({ fetchImpl: async () => ({ ok: true, json: async () => ({ digest: "not-a-digest" }) }) }),
+    /no valid index digest/,
+  );
+});


### PR DESCRIPTION
## Problem

`hwdsl2/whisper-server` re-pushes `:latest` roughly weekly (June 22 → July 3 in the last cycle) and prunes the previously pinned index manifest. Every rotation turns **Release Contract Guards** + **Release Image Manifest Guard** red on `main` for every open PR until someone manually re-pins — last cycle that took two weeks (BI-4439CDF1; manual fix precedent [PR #2615](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2615)). Two weeks of permanently-red checks trains everyone to ignore CI — the same false-red pathology as the sandbox-staleness incident ([PR #2613](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2613)), one layer up.

## Fix — close the loop mechanically

- **`scripts/release/re-resolve-stt-digest.mjs`** — resolves the live index digest for the tracked tag via the Docker Hub API. `--check` exits 3 on drift (0 in-sync, 2 API/usage); `--apply` rewrites the compose pin + "resolved on" comment date and rotates `CURRENT_STT_DIGEST`/`RETIRED_STT_DIGEST` in the release contract test, refusing partial/malformed rewrites (a partial rewrite would recreate the compose/test disagreement this exists to prevent).
- **`.github/workflows/stt-digest-watch.yml`** — daily cron (06:17 UTC) + manual dispatch. On drift: applies the re-pin, re-runs the contract tests **and** the digest-pinned manifest guard against the live registry *inside the workflow*, pushes a DCO-signed `bot/stt-digest-repin` branch, opens the PR, dispatches `ci.yml` + `release-gates.yml` onto the branch (PRs created with `GITHUB_TOKEN` never trigger checks on their own), and arms auto-merge. Idempotent (skips when a re-pin PR is already open); Docker Hub outages are treated as transient skips.
- **`ci.yml` / `release-gates.yml`** gain `workflow_dispatch` so required checks can be posted onto bot branches (ci.yml's `changes` gate already fails safe to heavy on non-PR events, so the required jobs run).

## Verification

- `node --test scripts/release/re-resolve-stt-digest.test.mjs tests/release/installer-release-contract.test.mjs tests/release/local-ci-gate-contract.test.mjs` — 25/25 pass. Includes a round-trip of `applyRepin` against the **real** compose + contract-test files, so structural drift in either surfaces immediately.
- Live `--check` against Docker Hub confirms the current pin (`44d7690a…`) is in sync.
- All three workflow YAMLs validated.
- New tests wired into the CI bare-runner test job.

Backlog: BI-A9EAEE2C
Process-Spine-Decision: automation for a recurring release-gate defect; behavior documented in workflow + script headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)