### PR TITLE
fix(self-upgrade): survive transient registry fetch — deps-layer manifest coverage + pnpm-install failure class (BI-C0B9B7AA)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,20 @@ COPY packages/db/package.json ./packages/db/
 COPY packages/db/prisma/schema.prisma ./packages/db/prisma/
 COPY packages/db/prisma.config.ts ./packages/db/
 COPY packages/db/src/load-env.ts ./packages/db/src/
+# EVERY workspace importer that later stages COPY into the image must have its
+# manifest here, so this cached layer fetches its deps into the pnpm store.
+# Otherwise the stage-3/4 `pnpm install` (re-run on every source change) fetches
+# the missing packages from the registry on EVERY build, and a single transient
+# registry failure fails the whole self-upgrade (SUR-73668D5C: 6-minute retry
+# on smol-toml, the one dep unique to packages/dpf-bootstrap).
+COPY packages/api-client/package.json ./packages/api-client/
+COPY packages/coworker-sim-harness/package.json ./packages/coworker-sim-harness/
+COPY packages/dpf-bootstrap/package.json ./packages/dpf-bootstrap/
+COPY packages/finance-templates/package.json ./packages/finance-templates/
+COPY packages/integration-shared/package.json ./packages/integration-shared/
+COPY packages/storefront-templates/package.json ./packages/storefront-templates/
+COPY packages/types/package.json ./packages/types/
+COPY packages/validators/package.json ./packages/validators/
 RUN pnpm install --frozen-lockfile
 
 # ─── Stage 3: build ───────────────────────────────────────────────────────────

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -565,7 +565,18 @@ export async function runSelfUpgrade(
     return { ok: true, status: "succeeded", runId: run.runId, quiescenceRunId, deployed };
   }
 
-  const rawExcerpt = result.stderr || result.stdout || "unknown error";
+  // Persist a tail of BOTH streams: with the classic builder the failing RUN
+  // step's output (e.g. pnpm's actual fetch error) is on stdout while compose
+  // writes only progress lines to stderr — `stderr || stdout` threw the real
+  // error away (SUR-73668D5C persisted no pnpm output at all).
+  const streamTail = (s: string) => (s.length > 4000 ? `…${s.slice(-4000)}` : s);
+  const rawExcerpt =
+    [
+      result.stderr && `--- stderr (tail) ---\n${streamTail(result.stderr)}`,
+      result.stdout && `--- stdout (tail) ---\n${streamTail(result.stdout)}`,
+    ]
+      .filter(Boolean)
+      .join("\n") || "unknown error";
   // Classify the build-gate failure into a known recurring class so the
   // persisted failure — and the BLOCKED reason an agent reads downstream —
   // leads with an actionable diagnosis instead of a raw log to reproduce from

--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -27,6 +27,23 @@ Error: duplicate emitted asset static/chunks/self-upgrade.js (conflict)`;
 const UNKNOWN_LOG = `error: connect ECONNREFUSED 127.0.0.1:5432
 prisma migrate failed`;
 
+// Verbatim from SUR-73668D5C (2026-07-05): the classic builder's step output
+// (pnpm's own error) was lost — only compose stderr survived, ending in the
+// bare non-zero RUN line. Must still classify as a retryable install failure.
+const PNPM_INSTALL_RUNLINE_LOG = `time="2026-07-05T11:34:45Z" level=warning msg="Docker Compose requires buildx plugin to be installed"
+ Image dpf-portal Building
+ Image dpf-portal Building
+The command '/bin/sh -c pnpm install --frozen-lockfile' returned a non-zero code: 1`;
+
+const PNPM_FETCH_LOG = `#12 [build 4/8] RUN pnpm install --frozen-lockfile
+#12 371.2 WARN GET https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz: ETIMEDOUT (retrying, attempt 2)
+#12 402.9  ERR_PNPM_FETCH_404 or network failure
+The command '/bin/sh -c pnpm install --frozen-lockfile' returned a non-zero code: 1`;
+
+const PNPM_LOCKFILE_DRIFT_LOG = `#12 [deps 9/9] RUN pnpm install --frozen-lockfile
+#12 2.1 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with apps/web/package.json
+The command '/bin/sh -c pnpm install --frozen-lockfile' returned a non-zero code: 1`;
+
 describe("classifyBuildFailure", () => {
   it("classifies the real @opentelemetry host-vs-Docker hoist divergence", () => {
     const c = classifyBuildFailure({ log: HOIST_LOG, hostBuildPassed: true });
@@ -49,6 +66,33 @@ describe("classifyBuildFailure", () => {
     expect(c.class).toBe("bundle-boundary-static-import");
     expect(c.summary).toContain("#1555");
     expect(c.isMainDefectVsEnvironment).toBe("main-defect");
+  });
+
+  it("classifies the SUR-73668D5C bare RUN-line install failure as retryable environment", () => {
+    const c = classifyBuildFailure({ log: PNPM_INSTALL_RUNLINE_LOG });
+    expect(c.class).toBe("pnpm-install-failure");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    expect(c.summary).toContain("Retry the upgrade first");
+    expect(c.failingTrace).toContain("returned a non-zero code");
+  });
+
+  it("classifies a registry fetch error as retryable environment", () => {
+    const c = classifyBuildFailure({ log: PNPM_FETCH_LOG });
+    expect(c.class).toBe("pnpm-install-failure");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    expect(c.failingTrace).toContain("registry.npmjs.org");
+  });
+
+  it("classifies a frozen-lockfile drift as a main defect, not environment", () => {
+    const c = classifyBuildFailure({ log: PNPM_LOCKFILE_DRIFT_LOG });
+    expect(c.class).toBe("pnpm-install-failure");
+    expect(c.isMainDefectVsEnvironment).toBe("main-defect");
+    expect(c.summary).toContain("lockfile");
+  });
+
+  it("keeps a non-pnpm ECONNREFUSED (e.g. prisma → postgres) unclassified", () => {
+    const c = classifyBuildFailure({ log: UNKNOWN_LOG });
+    expect(c.class).toBe("unknown");
   });
 
   it("falls back to unknown with a null defect/environment verdict", () => {

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -27,6 +27,14 @@ export type BuildFailureClass =
   // server bundle and colliding chunks. The specific cause behind many of the
   // duplicate-asset symptoms; fixed by a lazy import boundary (see PR #1555).
   | "bundle-boundary-static-import"
+  // `pnpm install --frozen-lockfile` failed inside the Docker build. Two
+  // sub-causes with opposite ownership: a lockfile/manifest mismatch
+  // (ERR_PNPM_OUTDATED_LOCKFILE) is a main defect; a registry fetch error
+  // (ECONNREFUSED/ETIMEDOUT/ERR_PNPM_FETCH, or the bare non-zero RUN line when
+  // pnpm's output was lost) is a transient environment failure — retry the
+  // upgrade before diagnosing anything (SUR-73668D5C, 2026-07-05: one flaky
+  // smol-toml fetch failed the upgrade; the identical tree built clean on retry).
+  | "pnpm-install-failure"
   | "unknown";
 
 export type BuildFailureClassification = {
@@ -62,6 +70,17 @@ const HOIST_PLAYBOOK = "docs/triage/2026-05-24-portal-prisma-generate-rebuild-fa
 const HOST_ONLY_MODULE = /(promoter|self-upgrade|child_process|node:child_process|dockerode|\/queue\/functions\/|api\/inngest)/i;
 const DUPLICATE_ASSET = /(duplicate\s+emitted\s+asset|multiple\s+assets\s+emit|conflict:.*emit|emit[^\n]*to the same (file|filename))/i;
 const MODULE_NOT_FOUND = /(cannot find module ['"]([^'"]+)['"]|module not found:\s*can't resolve ['"]([^'"]+)['"])/i;
+
+// The Dockerfile RUN line for a dependency install that exited non-zero —
+// present even when the builder's step output (pnpm's own error text) was lost.
+const PNPM_INSTALL_FAILED = /command ['"][^'"]*pnpm (install|fetch)[^'"]*['"] (returned a non-zero code|did not complete successfully)/i;
+// Lockfile/manifest mismatch — deterministic, a defect on main.
+const PNPM_OUTDATED_LOCKFILE = /ERR_PNPM_(OUTDATED_)?LOCKFILE|specifiers in the lockfile don't match|cannot install with "frozen-lockfile"/i;
+// Registry fetch errors — transient environment. Deliberately ONLY pnpm's own
+// error codes: bare network errnos (ECONNREFUSED etc.) appear in unrelated
+// failures (e.g. prisma migrate unable to reach postgres) and must stay
+// unclassified rather than misdiagnosed as a dependency fetch.
+const PNPM_FETCH_ERROR = /ERR_PNPM_FETCH|ERR_PNPM_META_FETCH_FAIL|GET https:\/\/registry\.npmjs\.org\/[^\s]+: (?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|socket hang up)/i;
 
 /** Up to ~6 lines around the first matching line, capped, for the agent. */
 function traceAround(log: string, re: RegExp): string {
@@ -101,6 +120,18 @@ export function classifyBuildFailure(
     };
   }
 
+  // Dependency-install failures before build-output analysis: a failed
+  // `pnpm install` step produces no build output, so nothing below can match.
+  if (PNPM_OUTDATED_LOCKFILE.test(log)) {
+    return {
+      class: "pnpm-install-failure",
+      summary:
+        "pnpm refused --frozen-lockfile: pnpm-lock.yaml does not match the package manifests at the target SHA. A manifest changed without regenerating the lockfile — fix on main (pnpm install, commit the lockfile).",
+      playbookLink: SPEC,
+      failingTrace: traceAround(log, PNPM_OUTDATED_LOCKFILE),
+      isMainDefectVsEnvironment: "main-defect",
+    };
+  }
   const moduleMiss = log.match(MODULE_NOT_FOUND);
   if (moduleMiss) {
     const missing = moduleMiss[2] || moduleMiss[3] || "an undeclared module";
@@ -114,6 +145,20 @@ export function classifyBuildFailure(
       playbookLink: HOIST_PLAYBOOK,
       failingTrace: traceAround(log, MODULE_NOT_FOUND),
       isMainDefectVsEnvironment: "main-defect",
+    };
+  }
+
+  // After the more specific build-output classes: a failed install RUN line, or
+  // registry/network errnos in a log that ran a pnpm install step.
+  if (PNPM_INSTALL_FAILED.test(log) || PNPM_FETCH_ERROR.test(log)) {
+    const matched = PNPM_FETCH_ERROR.test(log) ? PNPM_FETCH_ERROR : PNPM_INSTALL_FAILED;
+    return {
+      class: "pnpm-install-failure",
+      summary:
+        "pnpm install failed inside the Docker build — most likely a transient registry fetch failure (SUR-73668D5C: one flaky package fetch, identical tree built clean on retry). Retry the upgrade first; only diagnose further if it fails the same way twice.",
+      playbookLink: SPEC,
+      failingTrace: traceAround(log, matched),
+      isMainDefectVsEnvironment: "environment",
     };
   }
 


### PR DESCRIPTION
## Why

Self-upgrade run SUR-73668D5C (2026-07-05) failed at the Docker build's `pnpm install --frozen-lockfile` after ~6 minutes retrying **one** registry fetch: `smol-toml`, the only dependency unique to `packages/dpf-bootstrap`. The identical tree built clean on retry — a transient egress blip failed the whole upgrade, and it surfaced as `[build-failure-class] unknown (unclassified)` with the actual pnpm error missing from the run record.

Evidence: `docker diff` of the failed intermediate container showed exactly one directory created in 6 minutes (`node_modules/.pnpm/smol-toml@1.7.0`) — every other dep was satisfied by the cached deps layer; the single un-cached fetch was the failure point.

## Three defects, three fixes

1. **Dockerfile deps stage** copied only the root, `apps/web`, and `packages/db` manifests. The other 8 `packages/*` importers' unique deps were fetched from the registry during the stage-3/4 installs — which re-run on any `apps/web` change, with no persistent pnpm store under the classic builder. Now every workspace manifest that later stages COPY is in the cached deps layer, so all deps land in the store once and stage-3/4 installs are offline-satisfiable.

2. **build-failure-classifier**: new `pnpm-install-failure` class. `ERR_PNPM_OUTDATED_LOCKFILE` → main-defect (fix the lockfile on main); registry fetch errors or the bare non-zero `pnpm install` RUN line → environment with "retry the upgrade first" guidance. Bare network errnos (e.g. prisma `ECONNREFUSED` to postgres) deliberately stay `unknown` — regression-tested.

3. **self-upgrade failure excerpt** persisted `stderr || stdout`; the classic builder emits the failing step's output (pnpm's real error) on stdout while compose writes only progress lines to stderr, so the run record lost the diagnosis. Now persists tails of both streams.

## Tests

- Classifier regression suite extended with the verbatim SUR-73668D5C log, a registry-fetch log, a lockfile-drift log, and the non-pnpm ECONNREFUSED counter-case.
- Backlog: BI-C0B9B7AA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)