### PR TITLE
fix(release): fully escape regex metacharacters in STT digest re-resolver (CodeQL)

### DIFF
--- a/scripts/release/re-resolve-stt-digest.mjs
+++ b/scripts/release/re-resolve-stt-digest.mjs
@@ -37,10 +37,15 @@ export const EXIT_DRIFT = 3;
 
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
 
+/** Escape ALL regex metacharacters, not just "/" (CodeQL js/incomplete-sanitization). */
+function escapeRegExp(text) {
+  return String(text).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Extract the pinned digest from the compose text. Returns "" when absent. */
 export function parsePinnedDigest(composeText, repo = STT_IMAGE_REPO) {
   const match = String(composeText ?? "").match(
-    new RegExp(`${repo.replace(/[/]/g, "\\/")}@(sha256:[0-9a-f]{64})`),
+    new RegExp(`${escapeRegExp(repo)}@(sha256:[0-9a-f]{64})`),
   );
   return match ? match[1] : "";
 }
@@ -49,7 +54,7 @@ export function parsePinnedDigest(composeText, repo = STT_IMAGE_REPO) {
 export function parseContractCurrentDigest(testText, repo = STT_IMAGE_REPO) {
   const match = String(testText ?? "").match(
     new RegExp(
-      `CURRENT_STT_DIGEST\\s*=\\s*\\n?\\s*"${repo.replace(/[/]/g, "\\/")}@(sha256:[0-9a-f]{64})"`,
+      `CURRENT_STT_DIGEST\\s*=\\s*\\n?\\s*"${escapeRegExp(repo)}@(sha256:[0-9a-f]{64})"`,
     ),
   );
   return match ? match[1] : "";
@@ -97,11 +102,11 @@ export function applyRepin({ composeText, testText, newDigest, repo = STT_IMAGE_
   const testCurrent = parseContractCurrentDigest(testText, repo);
   if (!testCurrent) throw new Error(`no CURRENT_STT_DIGEST found in contract test text`);
   let nextTest = testText.replace(
-    new RegExp(`(RETIRED_STT_DIGEST\\s*=\\s*\\n?\\s*")${repo.replace(/[/]/g, "\\/")}@sha256:[0-9a-f]{64}(")`),
+    new RegExp(`(RETIRED_STT_DIGEST\\s*=\\s*\\n?\\s*")${escapeRegExp(repo)}@sha256:[0-9a-f]{64}(")`),
     `$1${repo}@${oldDigest}$2`,
   );
   nextTest = nextTest.replace(
-    new RegExp(`(CURRENT_STT_DIGEST\\s*=\\s*\\n?\\s*")${repo.replace(/[/]/g, "\\/")}@sha256:[0-9a-f]{64}(")`),
+    new RegExp(`(CURRENT_STT_DIGEST\\s*=\\s*\\n?\\s*")${escapeRegExp(repo)}@sha256:[0-9a-f]{64}(")`),
     `$1${repo}@${newDigest}$2`,
   );
   if (!nextTest.includes(`${repo}@${newDigest}`) || !nextTest.includes(`${repo}@${oldDigest}`)) {


### PR DESCRIPTION
Resolves the 4 `js/incomplete-sanitization` CodeQL alerts introduced by [PR #2617](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2617): RegExp patterns built from the image-repo string escaped only `/`, leaving `.` and other metacharacters live. Replaced with a full `escapeRegExp` helper at all four sites. `node --test scripts/release/re-resolve-stt-digest.test.mjs` 6/6 pass; live `--check` against Docker Hub still in sync.

Follow-up to BI-A9EAEE2C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)