### PR TITLE
fix(build-studio): recover from failed ideate/scout inference instead of stalling as "Waiting on evidence" (BI-F0005EB0)

### DIFF
--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -150,6 +150,8 @@ export function BuildStudioWorkflowActionCard({
         return "Opening release decisions...";
       case "retry-build":
         return "Retrying build...";
+      case "retry-inference":
+        return "Retrying the AI call...";
       case "reset-build":
         return "Resetting build...";
       case "resume-implementation":
@@ -181,6 +183,12 @@ export function BuildStudioWorkflowActionCard({
         await runBuildReviewVerification(build.buildId);
       } else if (action.kind === "advance-phase" && action.targetPhase) {
         await advanceBuildPhase(build.buildId, action.targetPhase);
+      } else if (action.kind === "retry-inference") {
+        // BI-F0005EB0 — the AI call errored. Re-drive the failed coworker turn
+        // (the same recovery the user does by re-prompting today) by opening the
+        // coworker panel with a retry message. The server-side bounded auto-retry
+        // handles transient failures before we ever get here.
+        openCoworkerPanel(action.coworkerPrompt);
       } else if (action.kind === "retry-build") {
         await retryBuildExecution(build.buildId);
       } else if (action.kind === "reset-build") {

--- a/apps/web/components/build/build-studio-custodian.test.ts
+++ b/apps/web/components/build/build-studio-custodian.test.ts
@@ -264,6 +264,33 @@ describe("deriveBuildStudioCustodianPrompt", () => {
     expect(prompt?.intent).toBe("info");
     expect(prompt?.whyNow).not.toContain("required evidence is missing");
   });
+
+  it("surfaces a danger 'AI call failed' prompt (not 'Waiting on evidence') for a failed ideate inference (BI-F0005EB0)", () => {
+    const build = makeBuild({
+      phase: "ideate",
+      uxVerificationStatus: null,
+      // designDoc null => the advance gate would otherwise fire a disabledReason
+      // and the custodian would say "Waiting on evidence".
+      designDoc: null,
+      designReview: null,
+    });
+    const progressVisibility = progress({
+      quietAgent: { quiet: false, minutesQuiet: 0, lastObservableSignalAt: "2026-06-29T12:19:00.000Z" },
+      inferenceFailure: { failed: true, kind: "connection", observedAt: "2026-06-29T12:19:00.000Z" },
+    });
+    const action = deriveBuildStudioWorkflowAction({ build, governedBacklogEnabled: true, progressVisibility });
+    const prompt = deriveBuildStudioCustodianPrompt({ build, action, progressVisibility });
+
+    expect(action.kind).toBe("retry-inference");
+    expect(prompt).not.toBeNull();
+    expect(prompt?.title).toBe("The AI call failed.");
+    expect(prompt?.statusLabel).toBe("AI call failed");
+    expect(prompt?.intent).toBe("danger");
+    expect(prompt?.primaryAction).toBe("workflow");
+    expect(prompt?.primaryLabel).toBe("Retry the AI call");
+    // The raw provider error must never reach the user via the custodian.
+    expect(JSON.stringify(prompt)).not.toMatch(/ECONNREFUSED|ConnectionRefused|API Error:/);
+  });
 });
 
 // BI-A2F3FA9D — "abandoned" is a terminal escalate-to-human handoff. The

--- a/apps/web/components/build/build-studio-custodian.ts
+++ b/apps/web/components/build/build-studio-custodian.ts
@@ -88,11 +88,12 @@ function resolveCustodianStatusSignal(input: {
   uxReviewGap: boolean;
   blockedByEvidence: boolean;
   technicalRecovery: boolean;
+  failedInference: boolean;
   isQuietReview: boolean;
   isQuietBuild: boolean;
   isQuietEarlyPhase: boolean;
 }): NonNullable<ProactivityResolverInput["statusSignal"]> {
-  if (input.uxReviewGap || input.blockedByEvidence || input.technicalRecovery) {
+  if (input.uxReviewGap || input.blockedByEvidence || input.technicalRecovery || input.failedInference) {
     return "blocked";
   }
   if (input.isQuietReview || input.isQuietBuild || input.isQuietEarlyPhase) {
@@ -139,9 +140,20 @@ export function deriveBuildStudioCustodianPrompt({
     || action.kind === "rerun-plan-review"
     || action.kind === "retry-build"
     || action.kind === "reset-build";
+  // BI-F0005EB0 — the AI call itself errored (failed ideate/scout inference).
+  // This is a distinct danger state, NOT the benign "Waiting on evidence".
+  const failedInference = action.kind === "retry-inference";
   const uxReviewGap = isUxReviewGap(build, action, progressVisibility);
 
-  if (!uxReviewGap && !blockedByEvidence && !technicalRecovery && !isQuietReview && !isQuietBuild && !isQuietEarlyPhase) {
+  if (
+    !uxReviewGap
+    && !blockedByEvidence
+    && !technicalRecovery
+    && !failedInference
+    && !isQuietReview
+    && !isQuietBuild
+    && !isQuietEarlyPhase
+  ) {
     return null;
   }
 
@@ -154,6 +166,7 @@ export function deriveBuildStudioCustodianPrompt({
       uxReviewGap,
       blockedByEvidence,
       technicalRecovery,
+      failedInference,
       isQuietReview,
       isQuietBuild,
       isQuietEarlyPhase,
@@ -180,6 +193,34 @@ export function deriveBuildStudioCustodianPrompt({
         "The review is not ready to release until UX evidence and acceptance evidence agree.",
         "If the retry already started work, wait for that evidence first. If it did not, use the existing Build Studio recovery path instead of asking the human to diagnose logs.",
       ],
+      proactivityPlan,
+    };
+  }
+
+  if (failedInference) {
+    // BI-F0005EB0 — the AI call errored (e.g. ideate/scout inference failed to
+    // connect). Present it honestly as a failed call the AI must retry, NOT as
+    // the human owing evidence. Details use provider-detail-free copy carried on
+    // the action; the raw provider error never reaches the user here.
+    return {
+      dismissKey,
+      title: "The AI call failed.",
+      whyNow:
+        "The last AI response could not complete — the request errored, so this build is waiting on a retry, not on you.",
+      recommendedAction:
+        "Retry the AI call. I will keep watching and pick it up automatically if it fails again.",
+      primaryLabel: action.primaryLabel ?? "Retry the AI call",
+      primaryAction: "workflow",
+      coworkerPrompt: appendCustodianInstruction(
+        action,
+        "Act as the Build Studio custodian. The AI call failed to complete. Retry it, and if it keeps failing explain the likely cause in plain English and give the human exactly one next action.",
+      ),
+      statusLabel: "AI call failed",
+      intent: "danger",
+      details: [
+        action.message,
+        "This is a failed AI call, not a missing input from you. Retrying re-runs the same request.",
+      ].filter(Boolean),
       proactivityPlan,
     };
   }

--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -1260,3 +1260,76 @@ describe("deriveBuildStudioWorkflowAction — escalate-to-human (BI-A2F3FA9D)", 
     expect(action.message).toContain("waiting for you in Delivery");
   });
 });
+
+describe("deriveBuildStudioWorkflowAction — failed inference (BI-F0005EB0)", () => {
+  function progressWithInferenceFailure(
+    failure: BuildProgressVisibility["inferenceFailure"],
+  ): BuildProgressVisibility {
+    return {
+      buildId: "FB-INF",
+      generatedAt: "2026-07-05T12:00:00.000Z",
+      statusHeading: { operatorAction: "Monitor build progress", failureAxis: null },
+      progress: { primary: { source: "db-task-results", completed: 0, total: 0, observedAt: null }, conflicts: [] },
+      tasks: {
+        completedTasks: 0,
+        totalTasks: 0,
+        source: { source: "db-task-results", completed: 0, total: 0, observedAt: null },
+        tasks: [],
+      },
+      staleChatSnapshots: [],
+      sandbox: null,
+      dispatchHistory: [],
+      verification: null,
+      quietAgent: { quiet: false, minutesQuiet: 0, lastObservableSignalAt: null },
+      inferenceFailure: failure,
+      phaseRuns: [],
+    } satisfies BuildProgressVisibility;
+  }
+
+  it("surfaces retry-inference (danger) for a failed ideate inference instead of Waiting on evidence", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      // designDoc null => the advance gate would otherwise fire with a disabledReason.
+      build: makeBuild({ phase: "ideate", draftApprovedAt: new Date("2026-04-25T13:00:00Z"), designDoc: null, designReview: null }),
+      governedBacklogEnabled: true,
+      progressVisibility: progressWithInferenceFailure({ failed: true, kind: "connection", observedAt: "2026-07-05T11:59:00.000Z" }),
+    });
+
+    expect(action.kind).toBe("retry-inference");
+    expect(action.primaryLabel).toBe("Retry the AI call");
+    expect(action.disabledReason).toBeNull();
+    expect(action.title).toMatch(/AI call failed/i);
+    // Never leak the raw provider string into user-facing copy.
+    expect(action.message).not.toMatch(/ECONNREFUSED|ConnectionRefused|API Error:/);
+    expect(deriveBuildStudioOperatorGuidance(action).status.intent).toBe("danger");
+  });
+
+  it("surfaces retry-inference for a failed plan inference", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({ phase: "plan", draftApprovedAt: new Date("2026-04-25T13:00:00Z") }),
+      governedBacklogEnabled: true,
+      progressVisibility: progressWithInferenceFailure({ failed: true, kind: "rate-limit", observedAt: "2026-07-05T11:59:00.000Z" }),
+    });
+
+    expect(action.kind).toBe("retry-inference");
+  });
+
+  it("does NOT surface retry-inference when the failure is stale (failed:false)", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({ phase: "ideate", draftApprovedAt: new Date("2026-04-25T13:00:00Z") }),
+      governedBacklogEnabled: true,
+      progressVisibility: progressWithInferenceFailure({ failed: false, kind: "connection", observedAt: "2026-07-05T11:59:00.000Z" }),
+    });
+
+    expect(action.kind).not.toBe("retry-inference");
+  });
+
+  it("does NOT surface retry-inference in build phase (scoped to ideate/plan)", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({ phase: "build", draftApprovedAt: new Date("2026-04-25T13:00:00Z") }),
+      governedBacklogEnabled: true,
+      progressVisibility: progressWithInferenceFailure({ failed: true, kind: "connection", observedAt: "2026-07-05T11:59:00.000Z" }),
+    });
+
+    expect(action.kind).not.toBe("retry-inference");
+  });
+});

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -21,11 +21,18 @@ import type {
   ResumeImplementationModeDetail,
   TruthNumericSnapshot,
 } from "@/lib/build/progress-visibility-types";
+import {
+  friendlyInferenceFailureMessage,
+  type InferenceFailureKind,
+} from "@/lib/build/inference-failure";
 
 type BuildStudioWorkflowActionMetadata = {
   failureAxis?: BuildFailureAxis | null;
   truthSources?: TruthNumericSnapshot[];
   resumeMode?: ResumeImplementationModeDetail;
+  /** BI-F0005EB0 — set on the retry-inference action so the custodian can render
+   *  provider-detail-free copy for the specific failure. */
+  inferenceFailureKind?: InferenceFailureKind | null;
 };
 
 export type BuildOperatorStatusKind = "waiting-on-you" | "working" | "blocked-technical" | "escalated";
@@ -90,6 +97,22 @@ export type BuildStudioWorkflowAction =
   } & BuildStudioWorkflowActionMetadata)
   | ({
     kind: "retry-build";
+    title: string;
+    message: string;
+    primaryLabel: string;
+    targetPhase: null;
+    disabledReason: string | null;
+    coworkerLabel: string;
+    coworkerPrompt: string;
+  } & BuildStudioWorkflowActionMetadata)
+  | ({
+    // BI-F0005EB0 (EP-BS-UX-HARDENING) — the AI call itself failed (e.g. the
+    // ideate/scout inference errored with a connection/provider failure). Scoped
+    // to the coworker-chat deliberation phases (ideate/plan); surfaces a danger
+    // "Retry the AI call" affordance instead of the benign "Waiting on evidence"
+    // state, and re-drives the failed turn rather than asking the human to
+    // diagnose logs.
+    kind: "retry-inference";
     title: string;
     message: string;
     primaryLabel: string;
@@ -388,6 +411,7 @@ function statusForAction(
     action.kind === "retry-build"
     || action.kind === "reset-build"
     || action.kind === "resume-implementation"
+    || action.kind === "retry-inference"
   ) {
     return {
       kind: "blocked-technical",
@@ -446,6 +470,8 @@ function nextSentenceForAction(action: BuildStudioWorkflowAction): string {
       return "Next: record acceptance so release decisions can unlock.";
     case "retry-build":
       return "Next: retry the sandbox launch.";
+    case "retry-inference":
+      return "Next: retry the AI call. I will keep watching and pick it up if it fails again.";
     case "reset-build":
       return "Next: reset the build pipeline and start it again.";
     case "resume-implementation":
@@ -562,6 +588,33 @@ function buildResumeAction(args: {
 }
 
 /**
+ * BI-F0005EB0 — build the "Retry the AI call" action for a failed ideate/plan
+ * inference. Copy is provider-detail-free (via friendlyInferenceFailureMessage);
+ * the raw error stays in server logs. `phase` labels the coworker recovery
+ * prompt so the re-drive re-asks the right deliberation question.
+ */
+function buildRetryInferenceAction(
+  phase: "ideate" | "plan",
+  kind: InferenceFailureKind | null,
+): BuildStudioWorkflowAction {
+  const friendly = kind
+    ? friendlyInferenceFailureMessage(kind)
+    : "The AI call did not complete. Retry to try the request again.";
+  const phaseNoun = phase === "ideate" ? "define this feature" : "plan this build";
+  return {
+    kind: "retry-inference",
+    title: "The AI call failed.",
+    message: `${friendly} Next: click Retry the AI call to run it again.`,
+    primaryLabel: "Retry the AI call",
+    targetPhase: null,
+    disabledReason: null,
+    coworkerLabel: "Ask the AI Coworker to retry",
+    coworkerPrompt: `The last AI response failed to complete (the request errored, not a missing input from me). Please retry the request now and continue helping me ${phaseNoun}.`,
+    inferenceFailureKind: kind,
+  };
+}
+
+/**
  * FB-78E967D4 — detect a buildExecState shape that no existing recovery path
  * accepts:
  *   - `retryBuildExecution` rejects unless `state.step === "failed"`.
@@ -658,6 +711,19 @@ export function deriveBuildStudioWorkflowAction({
       coworkerPrompt:
         "Review the draft assumptions with me and confirm what I should approve before this build moves forward.",
     };
+  }
+
+  // BI-F0005EB0 — a failed AI call (inference errored) in a coworker-chat
+  // deliberation phase must surface as a distinct danger "Retry the AI call"
+  // affordance, NOT fall through to the phase's advance gate (which reads as the
+  // benign "Waiting on evidence"). Scoped to ideate/plan so it never shadows the
+  // richer exec-state recovery paths in build/review. Checked before the phase
+  // branches so it takes priority over "advance gate not met".
+  if (
+    (build.phase === "ideate" || build.phase === "plan")
+    && progressVisibility?.inferenceFailure?.failed === true
+  ) {
+    return buildRetryInferenceAction(build.phase, progressVisibility.inferenceFailure.kind ?? null);
   }
 
   if (build.phase === "ideate") {

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1766,31 +1766,46 @@ export async function sendMessage(input: {
       select: { id: true, phase: true },
     }).catch(() => null);
 
-    const agenticResult = await executeAutonomousAgenticLoop({
-      chatHistory,
-      systemPrompt: populatedPrompt,
-      sensitivity: agent.sensitivity,
-      tools: attachedTools,
-      toolsForProvider,
-      deferredTools,
-      userId: user.id!,
-      routeContext: input.routeContext,
-      agentId: agent.agentId,
-      threadId: input.threadId,
-      taskType: taskTypeId,
-      agentDisplayName: agent.agentName,
-      buildPhase: activeBuild?.phase ?? null,
-      featureBuildId: activeBuild?.id ?? null,
-      activeSkillId,
-      agentMessageId: pendingAgentMessageId,
-      // sendMessage is the user-typed-a-question path. Chat mode disables the
-      // Operator Contract zero-tool-call / unsaved-evidence guards so a
-      // conversational reply ("yes do the truck list first") does not
-      // false-positive into a PlatformIssueReport.
-      interactionMode: "chat",
-      ...(Object.keys(modelReqs).length > 0 ? { modelRequirements: modelReqs } : {}),
-      onProgress: (event) => agentEventBus.emit(input.threadId, event),
-    });
+    // BI-F0005EB0 — auto-retry a TRANSIENT ideate inference failure (connection
+    // hiccup / short rate-limit) with backoff before it reaches the user. The
+    // ideate first turn is the reported dead-end: without this, a single
+    // ConnectionRefused stalls the whole build. Non-ideate turns run once
+    // (enabled:false), so behavior elsewhere is unchanged. A failure that
+    // survives all retries falls through to the persist-time sanitizer below and
+    // the "Retry the AI call" affordance.
+    const { runWithTransientInferenceRetry } = await import("@/lib/build/inference-retry");
+    const agenticResult = await runWithTransientInferenceRetry(
+      () => executeAutonomousAgenticLoop({
+        chatHistory,
+        systemPrompt: populatedPrompt,
+        sensitivity: agent.sensitivity,
+        tools: attachedTools,
+        toolsForProvider,
+        deferredTools,
+        userId: user.id!,
+        routeContext: input.routeContext,
+        agentId: agent.agentId,
+        threadId: input.threadId,
+        taskType: taskTypeId,
+        agentDisplayName: agent.agentName,
+        buildPhase: activeBuild?.phase ?? null,
+        featureBuildId: activeBuild?.id ?? null,
+        activeSkillId,
+        agentMessageId: pendingAgentMessageId,
+        // sendMessage is the user-typed-a-question path. Chat mode disables the
+        // Operator Contract zero-tool-call / unsaved-evidence guards so a
+        // conversational reply ("yes do the truck list first") does not
+        // false-positive into a PlatformIssueReport.
+        interactionMode: "chat",
+        ...(Object.keys(modelReqs).length > 0 ? { modelRequirements: modelReqs } : {}),
+        onProgress: (event) => agentEventBus.emit(input.threadId, event),
+      }),
+      {
+        enabled: activeBuildPhase === "ideate",
+        onRetry: (attempt, kind) =>
+          console.warn(`[coworker] ideate inference ${kind} failure — auto-retry attempt ${attempt}`),
+      },
+    );
 
     // EP-ASYNC-COWORKER-001: done event moved to caller (API route) so it fires
     // AFTER message persistence, enabling SSE-driven async completion.
@@ -2180,6 +2195,24 @@ export async function sendMessage(input: {
       ? `Provider ${responseProviderId}/${responseModelId} returned an empty response.`
       : "No AI provider was matched by the routing pipeline.";
     responseContent = `**Unable to process this request.** ${providerHint} Check AI Workforce settings (Platform > AI) to verify provider configuration.`;
+  }
+
+  // BI-F0005EB0 — never persist a raw provider/CLI error string as a
+  // user-visible assistant message. When the loop smuggled a raw error into
+  // `content` (e.g. `API Error: Unable to connect to API (ConnectionRefused)`),
+  // replace it with provider-detail-free copy; the raw string stays in server
+  // logs for engineers. The sanitized copy is still classifiable, so the
+  // progress-visibility signal + "Retry the AI call" affordance still fire.
+  {
+    const { isRawProviderError, classifyInferenceFailure, friendlyInferenceFailureMessage } =
+      await import("@/lib/build/inference-failure");
+    if (isRawProviderError(responseContent)) {
+      const kind = classifyInferenceFailure(responseContent) ?? "provider-unavailable";
+      console.warn(
+        `[coworker] raw inference error hidden from user (kind=${kind}, route=${JSON.stringify(input.routeContext)}): ${JSON.stringify(responseContent.slice(0, 300))}`,
+      );
+      responseContent = friendlyInferenceFailureMessage(kind);
+    }
   }
 
   // Persist agent response

--- a/apps/web/lib/build/inference-failure.test.ts
+++ b/apps/web/lib/build/inference-failure.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyInferenceFailure,
+  friendlyInferenceFailureMessage,
+  isRawProviderError,
+  isTransientInferenceFailure,
+  type InferenceFailureKind,
+} from "./inference-failure";
+
+describe("classifyInferenceFailure", () => {
+  it("classifies the live-repro raw connection error as connection", () => {
+    // BI-F0005EB0 exact persisted content on FB-54088DED.
+    expect(
+      classifyInferenceFailure("API Error: Unable to connect to API (ConnectionRefused)"),
+    ).toBe("connection");
+  });
+
+  it("classifies raw node connection signatures", () => {
+    expect(classifyInferenceFailure("Error: connect ECONNREFUSED 127.0.0.1:12434")).toBe("connection");
+    expect(classifyInferenceFailure("read ECONNRESET")).toBe("connection");
+    expect(classifyInferenceFailure("Connection refused")).toBe("connection");
+    expect(classifyInferenceFailure("API Error: fetch failed")).toBe("connection");
+  });
+
+  it("classifies describeToolRouteFailure friendly outputs", () => {
+    // These strings must stay recognisable so the signal survives after the
+    // persist-time guard rewrites a raw error into friendly copy.
+    expect(
+      classifyInferenceFailure(
+        "Your paid AI providers (such as Claude or GPT) are briefly unavailable right now — usually a short rate-limit that clears within a minute — and this coworker uses too many tools (58 of them) for the bundled local model to run on its own. Nothing is misconfigured. Please wait a moment and try again.",
+      ),
+    ).toBe("rate-limit");
+    expect(
+      classifyInferenceFailure(
+        "The AI providers are momentarily busy (usually rate-limited or overloaded). Please try again in about 30 seconds — no setup change is needed.",
+      ),
+    ).toBe("rate-limit");
+    expect(
+      classifyInferenceFailure(
+        "The AI provider is temporarily unavailable. Please try again in about 30 seconds.",
+      ),
+    ).toBe("provider-unavailable");
+    expect(
+      classifyInferenceFailure(
+        "No AI model that supports tools is active right now. Open Platform > AI > Providers & Routing to activate a tool-capable provider, then try again.",
+      ),
+    ).toBe("config");
+    expect(
+      classifyInferenceFailure(
+        "No AI provider credentials are configured for this feature. Open Platform › AI Operations › Providers & Routing, connect a cloud provider (Claude, OpenAI, Google, or similar), then try again.",
+      ),
+    ).toBe("config");
+  });
+
+  it("classifies empty-response fallbacks", () => {
+    expect(
+      classifyInferenceFailure(
+        "**Unable to process this request.** Provider local/qwen returned an empty response. Check AI Workforce settings (Platform > AI) to verify provider configuration.",
+      ),
+    ).toBe("empty-response");
+    expect(
+      classifyInferenceFailure(
+        "The model (claude-3-haiku) returned an empty response and did not use any tools. This typically means it does not support the tool format required for this task. Try a different model or provider.",
+      ),
+    ).toBe("empty-response");
+  });
+
+  it("returns null for normal assistant content (no false positives)", () => {
+    expect(classifyInferenceFailure(null)).toBeNull();
+    expect(classifyInferenceFailure(undefined)).toBeNull();
+    expect(classifyInferenceFailure("")).toBeNull();
+    expect(classifyInferenceFailure("   ")).toBeNull();
+    // Legitimate replies that merely mention errors must NOT trip the classifier.
+    expect(
+      classifyInferenceFailure(
+        "I found the error in your validation logic — the form was rejecting valid emails. I've fixed it and added a test.",
+      ),
+    ).toBeNull();
+    expect(
+      classifyInferenceFailure(
+        "Let's define it together — I'll ask a few questions about how your shop works. First, what job types do you handle most?",
+      ),
+    ).toBeNull();
+    expect(
+      classifyInferenceFailure(
+        "The build hit a network of dependencies we should map before starting.",
+      ),
+    ).toBeNull();
+  });
+
+  it("does NOT classify deterministic context-overflow copy (retry cannot fix it)", () => {
+    expect(
+      classifyInferenceFailure(
+        "Your conversation is too long for this AI provider. Please start a new thread to continue.",
+      ),
+    ).toBeNull();
+    expect(
+      classifyInferenceFailure(
+        "That request was too large for the active AI model's context window — usually too many tools active at once, or a long conversation.",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("isTransientInferenceFailure", () => {
+  it("marks connection / rate-limit / provider-unavailable as transient", () => {
+    for (const kind of ["connection", "rate-limit", "provider-unavailable"] as InferenceFailureKind[]) {
+      expect(isTransientInferenceFailure(kind)).toBe(true);
+    }
+  });
+
+  it("marks config / empty-response as non-transient, and null as non-transient", () => {
+    expect(isTransientInferenceFailure("config")).toBe(false);
+    expect(isTransientInferenceFailure("empty-response")).toBe(false);
+    expect(isTransientInferenceFailure(null)).toBe(false);
+  });
+});
+
+describe("isRawProviderError", () => {
+  it("flags raw provider/CLI machine errors that must be hidden from users", () => {
+    expect(isRawProviderError("API Error: Unable to connect to API (ConnectionRefused)")).toBe(true);
+    expect(isRawProviderError("Error: connect ECONNREFUSED 127.0.0.1:12434")).toBe(true);
+    expect(isRawProviderError("read ECONNRESET")).toBe(true);
+    expect(isRawProviderError("API Error: fetch failed")).toBe(true);
+    expect(isRawProviderError("429 Too Many Requests")).toBe(true);
+    expect(isRawProviderError("HTTP 503 Service Unavailable error")).toBe(true);
+  });
+
+  it("does NOT flag curated friendly copy (that copy is intentional UX)", () => {
+    // describeToolRouteFailure outputs are already user-safe — leave them alone.
+    expect(
+      isRawProviderError(
+        "The AI providers are momentarily busy (usually rate-limited or overloaded). Please try again in about 30 seconds — no setup change is needed.",
+      ),
+    ).toBe(false);
+    expect(
+      isRawProviderError("The AI provider is temporarily unavailable. Please try again in about 30 seconds."),
+    ).toBe(false);
+    expect(isRawProviderError("**Unable to process this request.** Provider returned an empty response.")).toBe(false);
+  });
+
+  it("does NOT flag normal content or empties", () => {
+    expect(isRawProviderError(null)).toBe(false);
+    expect(isRawProviderError("")).toBe(false);
+    expect(isRawProviderError("I found the error in your validation logic and fixed it.")).toBe(false);
+  });
+});
+
+describe("friendlyInferenceFailureMessage", () => {
+  it("returns non-empty, provider-detail-free copy for every kind", () => {
+    for (const kind of [
+      "connection",
+      "rate-limit",
+      "provider-unavailable",
+      "config",
+      "empty-response",
+    ] as InferenceFailureKind[]) {
+      const msg = friendlyInferenceFailureMessage(kind);
+      expect(msg.length).toBeGreaterThan(20);
+      // Never leak raw provider signatures to the user.
+      expect(msg).not.toMatch(/ECONNREFUSED|ConnectionRefused|API Error:/);
+    }
+  });
+});

--- a/apps/web/lib/build/inference-failure.ts
+++ b/apps/web/lib/build/inference-failure.ts
@@ -1,0 +1,164 @@
+/**
+ * BI-F0005EB0 (EP-BS-UX-HARDENING) — shared classifier for "the AI call itself
+ * failed" turns.
+ *
+ * When a Build Studio ideate/scout inference fails, the failure currently lands
+ * in the conversation as an ordinary `assistant` AgentMessage — either the raw
+ * provider/CLI error verbatim (the live repro:
+ * `API Error: Unable to connect to API (ConnectionRefused)`) or one of the
+ * friendly strings `describeToolRouteFailure` emits. Both leave the build
+ * stalled in `ideate`, mis-classified by the custodian as the benign
+ * "Waiting on evidence" state.
+ *
+ * This module is the single source of truth for "is this message content an
+ * inference failure, and of what kind". It is consumed at three layers:
+ *   1. progress-visibility — expose an `inferenceFailure` signal off the newest
+ *      assistant turn.
+ *   2. build-studio-workflow-actions / custodian — surface a danger
+ *      "Retry the AI call" affordance instead of "Waiting on evidence".
+ *   3. agent-coworker persist-time — sanitize the raw provider string and drive
+ *      bounded auto-retry for transient kinds.
+ *
+ * Matching is deliberately CONSERVATIVE — anchored / whole-phrase patterns, not
+ * loose substring hunts — so a legitimate assistant reply that merely mentions
+ * the word "error" is never misread as a failed inference. Every pattern here is
+ * grounded in a real emitter: the raw provider/CLI forms, and the exact copy in
+ * describeToolRouteFailure (agentic-loop.ts) + the empty-response fallbacks in
+ * agent-coworker.ts / agentic-loop.ts.
+ */
+
+export type InferenceFailureKind =
+  | "connection"           // ConnectionRefused / ECONNREFUSED / "Unable to connect to API"
+  | "rate-limit"           // paid providers briefly unavailable / momentarily busy
+  | "provider-unavailable" // generic "temporarily unavailable"
+  | "config"               // no credential / no eligible tool-capable endpoint configured
+  | "empty-response";      // model returned nothing usable
+
+/** Kinds where an immediate bounded retry is worth attempting (transient). */
+export const TRANSIENT_INFERENCE_FAILURE_KINDS: readonly InferenceFailureKind[] = [
+  "connection",
+  "rate-limit",
+  "provider-unavailable",
+];
+
+export function isTransientInferenceFailure(kind: InferenceFailureKind | null): boolean {
+  return kind != null && TRANSIENT_INFERENCE_FAILURE_KINDS.includes(kind);
+}
+
+type Matcher = { kind: InferenceFailureKind; test: RegExp };
+
+// Ordered most-specific → least-specific. First match wins, so the raw
+// connection signatures and the exact friendly strings are checked before the
+// broad "temporarily unavailable" catch-all.
+const MATCHERS: Matcher[] = [
+  // ── Raw provider / CLI connection errors ─────────────────────────────────
+  // Live repro: "API Error: Unable to connect to API (ConnectionRefused)".
+  { kind: "connection", test: /unable to connect to (?:the )?api/i },
+  { kind: "connection", test: /connection\s*refused/i },
+  { kind: "connection", test: /\bECONNREFUSED\b/ },
+  { kind: "connection", test: /\bECONNRESET\b/ },
+  { kind: "connection", test: /^\s*(?:API Error:\s*)?fetch failed\b/i },
+  { kind: "connection", test: /network (?:error|timeout|unreachable)/i },
+
+  // ── describeToolRouteFailure friendly outputs (agentic-loop.ts) ───────────
+  // "Your paid AI providers (such as Claude or GPT) are briefly unavailable…"
+  { kind: "rate-limit", test: /paid AI providers.*(?:briefly|momentarily) unavailable/i },
+  // "The AI providers are momentarily busy (usually rate-limited or overloaded)…"
+  { kind: "rate-limit", test: /AI providers are momentarily busy/i },
+  { kind: "rate-limit", test: /\brate[- ]limit(?:ed|s)?\b/i },
+  // "No AI provider credentials are configured for this feature…"
+  { kind: "config", test: /No AI provider credentials are configured/i },
+  // "No AI model that supports tools is active right now…"
+  { kind: "config", test: /No AI model that supports tools is active/i },
+  // agent-coworker NoProvidersAvailableError system copy / generic config gap.
+  { kind: "config", test: /No AI providers are configured/i },
+  { kind: "config", test: /No eligible AI endpoints/i },
+  // "The AI provider is temporarily unavailable. Please try again…" (fallback)
+  { kind: "provider-unavailable", test: /AI provider is temporarily unavailable/i },
+  { kind: "provider-unavailable", test: /AI (?:co-?workers?|providers?) are temporarily offline/i },
+
+  // ── Empty / unusable model responses ─────────────────────────────────────
+  // agent-coworker.ts quality gate: "**Unable to process this request.** …"
+  { kind: "empty-response", test: /^\s*\*?\*?Unable to process this request/i },
+  // agentic-loop.ts: "The model (X) returned an empty response and did not use any tools…"
+  { kind: "empty-response", test: /returned an empty response and did not use any tools/i },
+];
+
+/**
+ * Classify a persisted assistant-turn `content` string. Returns the failure
+ * kind, or `null` when the content is a normal (non-failure) response.
+ *
+ * NOTE: deterministic context-overflow copy ("conversation is too long",
+ * "too large for the active AI model's context window") is intentionally NOT
+ * matched — a plain retry cannot fix it, so offering "Retry the AI call" there
+ * would mislead. Those turns keep their own guidance path.
+ */
+export function classifyInferenceFailure(content: string | null | undefined): InferenceFailureKind | null {
+  if (typeof content !== "string") {
+    return null;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return null;
+  }
+  for (const matcher of MATCHERS) {
+    if (matcher.test.test(trimmed)) {
+      return matcher.kind;
+    }
+  }
+  return null;
+}
+
+// Raw machine-error signatures that must NEVER be shown to a user verbatim.
+// These are the shapes a provider SDK / local CLI emits directly — distinct from
+// the intentional, already-friendly copy describeToolRouteFailure produces. The
+// persist-time guard rewrites only these; it leaves curated copy untouched.
+const RAW_PROVIDER_ERROR_PATTERNS: RegExp[] = [
+  /^\s*API Error:/i,
+  /unable to connect to (?:the )?api/i,
+  /connection\s*refused/i,
+  /\bECONNREFUSED\b/,
+  /\bECONNRESET\b/,
+  /\bETIMEDOUT\b/,
+  /\bENOTFOUND\b/,
+  /^\s*(?:API Error:\s*)?fetch failed\b/i,
+  /\b(?:HTTP\s*)?(?:4\d\d|5\d\d)\b.*\b(?:error|too many requests|internal server|bad gateway|service unavailable|gateway timeout)\b/i,
+  /\bToo Many Requests\b/i,
+];
+
+/**
+ * True when `content` looks like a raw provider/CLI machine error that should be
+ * hidden from the user (and replaced with friendly copy) rather than persisted
+ * as a visible assistant message. Curated friendly strings return false.
+ */
+export function isRawProviderError(content: string | null | undefined): boolean {
+  if (typeof content !== "string") {
+    return false;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return RAW_PROVIDER_ERROR_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+/**
+ * User-facing, provider-detail-free copy for a failed inference turn. Used both
+ * to replace the raw persisted string (so a non-technical user never sees
+ * `API Error: …`) and to render the custodian/action details. Never leaks the
+ * raw provider error — that stays in server logs for engineers.
+ */
+export function friendlyInferenceFailureMessage(kind: InferenceFailureKind): string {
+  switch (kind) {
+    case "connection":
+      return "The AI service could not be reached, so this response did not complete. This is usually a brief connection hiccup — retry to try the request again.";
+    case "rate-limit":
+      return "The AI providers are briefly busy (usually a short rate-limit that clears within a minute). Retry in a moment to try again.";
+    case "provider-unavailable":
+      return "The AI provider is temporarily unavailable. Retry to try the request again — no setup change is needed.";
+    case "config":
+      return "No AI provider is available to handle this request. An administrator can connect one in Platform › AI › Providers & Routing, then you can retry.";
+    case "empty-response":
+      return "The AI model returned an empty response. Retry to try the request again; if it keeps happening, a different model or provider may be needed.";
+  }
+}

--- a/apps/web/lib/build/inference-retry.test.ts
+++ b/apps/web/lib/build/inference-retry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { runWithTransientInferenceRetry } from "./inference-retry";
+
+const CONNECTION_ERROR = "API Error: Unable to connect to API (ConnectionRefused)";
+const CONFIG_ERROR = "No AI provider credentials are configured for this feature.";
+const OK = "Let's define it together — what job types do you handle most?";
+
+function sequenceRunner(contents: string[]) {
+  let i = 0;
+  const run = vi.fn(async () => ({ content: contents[Math.min(i++, contents.length - 1)]! }));
+  return { run };
+}
+
+describe("runWithTransientInferenceRetry", () => {
+  it("returns the first result without retrying when disabled", async () => {
+    const { run } = sequenceRunner([CONNECTION_ERROR, OK]);
+    const result = await runWithTransientInferenceRetry(run, { enabled: false, sleep: async () => {} });
+    expect(result.content).toBe(CONNECTION_ERROR);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a successful first turn", async () => {
+    const { run } = sequenceRunner([OK, CONNECTION_ERROR]);
+    const result = await runWithTransientInferenceRetry(run, { enabled: true, sleep: async () => {} });
+    expect(result.content).toBe(OK);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient failure and returns the eventual success", async () => {
+    const { run } = sequenceRunner([CONNECTION_ERROR, CONNECTION_ERROR, OK]);
+    const onRetry = vi.fn();
+    const result = await runWithTransientInferenceRetry(run, {
+      enabled: true,
+      sleep: async () => {},
+      onRetry,
+    });
+    expect(result.content).toBe(OK);
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the backoff cap and returns the final failure", async () => {
+    const { run } = sequenceRunner([CONNECTION_ERROR, CONNECTION_ERROR, CONNECTION_ERROR, CONNECTION_ERROR]);
+    const result = await runWithTransientInferenceRetry(run, {
+      enabled: true,
+      backoffMs: [10, 20],
+      sleep: async () => {},
+    });
+    expect(result.content).toBe(CONNECTION_ERROR);
+    // first attempt + 2 retries = 3 total
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT retry a non-transient (config) failure", async () => {
+    const { run } = sequenceRunner([CONFIG_ERROR, OK]);
+    const result = await runWithTransientInferenceRetry(run, { enabled: true, sleep: async () => {} });
+    expect(result.content).toBe(CONFIG_ERROR);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors the backoff schedule via the injected sleep", async () => {
+    const { run } = sequenceRunner([CONNECTION_ERROR, CONNECTION_ERROR, OK]);
+    const sleeps: number[] = [];
+    await runWithTransientInferenceRetry(run, {
+      enabled: true,
+      backoffMs: [500, 1500],
+      sleep: async (ms) => { sleeps.push(ms); },
+    });
+    expect(sleeps).toEqual([500, 1500]);
+  });
+});

--- a/apps/web/lib/build/inference-retry.ts
+++ b/apps/web/lib/build/inference-retry.ts
@@ -1,0 +1,76 @@
+/**
+ * BI-F0005EB0 (EP-BS-UX-HARDENING) — bounded, transient-only retry wrapper for a
+ * coworker inference turn.
+ *
+ * The reported dead-end is a Build Studio ideate/scout turn whose FIRST inference
+ * fails (e.g. `API Error: Unable to connect to API (ConnectionRefused)`) and is
+ * then dropped, stalling the build. Before we surface the "Retry the AI call"
+ * affordance to the human, give the request a couple of automatic retries with
+ * backoff — a brief connection hiccup or a short rate-limit often clears on its
+ * own, so the non-technical user never sees a failure at all.
+ *
+ * Deliberately conservative:
+ *   - only TRANSIENT failure kinds are retried (connection / rate-limit /
+ *     provider-unavailable) — a config gap or empty-response won't fix itself, so
+ *     retrying just burns compute;
+ *   - bounded attempt count + explicit backoff schedule;
+ *   - caller opts in per-phase (`enabled`), so non-ideate/scout turns are
+ *     unchanged.
+ *
+ * Pure and injectable (`sleep`) so the retry decision is unit-testable without
+ * real timers or a real inference call.
+ */
+
+import { classifyInferenceFailure, isTransientInferenceFailure } from "./inference-failure";
+
+const DEFAULT_BACKOFF_MS = [500, 1500];
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type TransientInferenceRetryOptions = {
+  /** When false, run once and return — no classification, no retry. */
+  enabled: boolean;
+  /**
+   * Backoff schedule in ms; length caps the number of RETRIES (attempts beyond
+   * the first). Defaults to [500, 1500] (up to 2 retries → 3 attempts total).
+   */
+  backoffMs?: number[];
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Observability hook fired before each retry. */
+  onRetry?: (attempt: number, kind: string) => void;
+};
+
+/**
+ * Run `run()` and, when it returns a transient inference-failure `content`,
+ * retry it with backoff up to the configured cap. Returns the LAST result
+ * (whether success or a final failure) — the caller's downstream persist-time
+ * guard sanitizes a lingering failure and the custodian surfaces the retry
+ * affordance.
+ */
+export async function runWithTransientInferenceRetry<T extends { content: string }>(
+  run: () => Promise<T>,
+  opts: TransientInferenceRetryOptions,
+): Promise<T> {
+  const sleep = opts.sleep ?? defaultSleep;
+  const backoff = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+
+  let result = await run();
+  if (!opts.enabled) {
+    return result;
+  }
+
+  for (let attempt = 0; attempt < backoff.length; attempt++) {
+    const kind = classifyInferenceFailure(result.content);
+    if (!isTransientInferenceFailure(kind)) {
+      return result;
+    }
+    opts.onRetry?.(attempt + 1, kind as string);
+    await sleep(backoff[attempt] ?? 0);
+    result = await run();
+  }
+
+  return result;
+}

--- a/apps/web/lib/build/progress-visibility.test.ts
+++ b/apps/web/lib/build/progress-visibility.test.ts
@@ -167,6 +167,83 @@ describe("buildProgressProjectionFromParts", () => {
   });
 });
 
+describe("buildProgressProjectionFromParts — inferenceFailure (BI-F0005EB0)", () => {
+  function partsWithLastAssistant(
+    lastAssistant: { content: string | null; createdAt: Date | string | null } | null,
+    lastActivityAt: string | null,
+  ) {
+    return {
+      buildId: "FB-INF",
+      now: new Date("2026-07-05T12:00:00.000Z"),
+      dbTasks: normalizeTaskResults(null),
+      chatSnapshots: [],
+      sandbox: null,
+      dispatchHistory: [],
+      verification: buildScopedVerificationFromParts({
+        verification: normalizeVerificationOutput(null),
+        changedFiles: [],
+        dispatchHistory: [],
+      }),
+      lastActivityAt,
+      lastAssistant,
+    };
+  }
+
+  it("flags a failed ideate inference turn as inferenceFailure.failed", () => {
+    const projection = buildProgressProjectionFromParts(
+      partsWithLastAssistant(
+        {
+          content: "API Error: Unable to connect to API (ConnectionRefused)",
+          createdAt: "2026-07-05T11:59:00.000Z",
+        },
+        // No fresher observable signal than the failed turn.
+        "2026-07-05T11:59:00.000Z",
+      ),
+    );
+
+    expect(projection.inferenceFailure).toEqual({
+      failed: true,
+      kind: "connection",
+      observedAt: "2026-07-05T11:59:00.000Z",
+    });
+  });
+
+  it("does not flag when a fresher observable signal superseded the failed turn", () => {
+    const projection = buildProgressProjectionFromParts(
+      partsWithLastAssistant(
+        {
+          content: "API Error: Unable to connect to API (ConnectionRefused)",
+          createdAt: "2026-07-05T11:59:00.000Z",
+        },
+        // Activity landed AFTER the failed turn — pipeline moved on.
+        "2026-07-05T11:59:30.000Z",
+      ),
+    );
+
+    expect(projection.inferenceFailure?.failed).toBe(false);
+    expect(projection.inferenceFailure?.kind).toBe("connection");
+  });
+
+  it("does not flag a normal assistant turn", () => {
+    const projection = buildProgressProjectionFromParts(
+      partsWithLastAssistant(
+        {
+          content: "Let's define it together — what job types do you handle most?",
+          createdAt: "2026-07-05T11:59:00.000Z",
+        },
+        "2026-07-05T11:59:00.000Z",
+      ),
+    );
+
+    expect(projection.inferenceFailure).toEqual({ failed: false, kind: null, observedAt: null });
+  });
+
+  it("does not flag when there is no assistant turn", () => {
+    const projection = buildProgressProjectionFromParts(partsWithLastAssistant(null, null));
+    expect(projection.inferenceFailure).toEqual({ failed: false, kind: null, observedAt: null });
+  });
+});
+
 describe("extractChatProgressSnapshots", () => {
   it("extracts only valid assistant self-report task counts", () => {
     const snapshots = extractChatProgressSnapshots([

--- a/apps/web/lib/build/progress-visibility.ts
+++ b/apps/web/lib/build/progress-visibility.ts
@@ -11,6 +11,7 @@ import { getScopedVerificationForBuild, type ScopedVerificationView } from "./sc
 import { normalizeTaskResults, type NormalizedTaskResults } from "./task-results";
 import { loadBuildEvidenceTimelineEvents } from "./evidence-timeline";
 import type { UnifiedEvidenceTimelineEvent } from "./evidence-timeline-types";
+import { classifyInferenceFailure, type InferenceFailureKind } from "./inference-failure";
 
 export type ChatProgressSnapshot = {
   completed: number | null;
@@ -58,6 +59,24 @@ export type BuildProgressVisibility = {
     minutesQuiet: number;
     lastObservableSignalAt: string | null;
   };
+  /**
+   * BI-F0005EB0 (EP-BS-UX-HARDENING) — whether the most recent assistant turn in
+   * the build's coworker thread is an inference failure (the AI call errored)
+   * rather than a real answer. Drives the danger "Retry the AI call" affordance
+   * so a failed ideate/scout inference is not mis-surfaced as "Waiting on
+   * evidence". `failed` is true only when the newest assistant message
+   * classifies AND no fresher observable signal (task/dispatch/activity) has
+   * landed since — so a successful turn after a retry self-clears it.
+   *
+   * Optional so projection literals (tests) need not supply it;
+   * getBuildProgressVisibility always populates it. Consumers read it with
+   * optional chaining (`progressVisibility?.inferenceFailure?.failed`).
+   */
+  inferenceFailure?: {
+    failed: boolean;
+    kind: InferenceFailureKind | null;
+    observedAt: string | null;
+  };
   /** Phase-level cost rollup; empty array when BuildPhaseRun rows don't exist yet */
   phaseRuns: PhaseRunSummary[];
   /**
@@ -77,6 +96,12 @@ export function buildProgressProjectionFromParts(args: {
   dispatchHistory: BuildDispatchAttemptView[];
   verification: ScopedVerificationView | null;
   lastActivityAt: string | null;
+  /**
+   * Newest assistant turn in the build's coworker thread, used to detect a
+   * failed inference. Optional so projection literals (tests) need not supply it
+   * — absent means "no inference failure".
+   */
+  lastAssistant?: { content: string | null; createdAt: Date | string | null } | null;
   phaseRuns?: PhaseRunSummary[];
   evidenceTimeline?: UnifiedEvidenceTimelineEvent[];
 }): BuildProgressVisibility {
@@ -93,6 +118,7 @@ export function buildProgressProjectionFromParts(args: {
     lastActivityAt: args.lastActivityAt,
   });
   const minutesQuiet = getMinutesQuiet(lastObservableSignalAt, now);
+  const inferenceFailure = deriveInferenceFailure(args.lastAssistant, lastObservableSignalAt);
 
   return {
     buildId: args.buildId,
@@ -127,9 +153,41 @@ export function buildProgressProjectionFromParts(args: {
       minutesQuiet,
       lastObservableSignalAt,
     },
+    inferenceFailure,
     phaseRuns: args.phaseRuns ?? [],
     evidenceTimeline: args.evidenceTimeline ?? [],
   };
+}
+
+/**
+ * BI-F0005EB0 — classify the newest assistant turn. Only reports `failed` when
+ * the failing turn is at least as recent as the last observable non-chat signal:
+ * a task result, dispatch, or activity landing AFTER the failed turn means the
+ * pipeline moved on (e.g. the user retried and work resumed), so the stale error
+ * must not keep the build parked in a danger state.
+ */
+function deriveInferenceFailure(
+  lastAssistant: { content: string | null; createdAt: Date | string | null } | null | undefined,
+  lastObservableSignalAt: string | null,
+): BuildProgressVisibility["inferenceFailure"] {
+  const none: BuildProgressVisibility["inferenceFailure"] = { failed: false, kind: null, observedAt: null };
+  if (!lastAssistant) {
+    return none;
+  }
+  const kind = classifyInferenceFailure(lastAssistant.content);
+  if (!kind) {
+    return none;
+  }
+  const observedAt = normalizeObservedAt(lastAssistant.createdAt);
+  if (
+    observedAt != null
+    && lastObservableSignalAt != null
+    && new Date(lastObservableSignalAt).getTime() > new Date(observedAt).getTime()
+  ) {
+    // A fresher observable signal superseded the failed turn — not stalled here.
+    return { failed: false, kind, observedAt };
+  }
+  return { failed: true, kind, observedAt };
 }
 
 export async function getBuildProgressVisibility(buildId: string): Promise<BuildProgressVisibility | null> {
@@ -199,6 +257,9 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     build: { id: build.id, buildId: build.buildId },
   });
 
+  // chatMessages is ordered createdAt desc, so [0] is the newest assistant turn.
+  const newestAssistant = chatMessages[0] ?? null;
+
   return buildProgressProjectionFromParts({
     buildId,
     dbTasks: normalizeTaskResults(build.taskResults),
@@ -207,6 +268,9 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     dispatchHistory: await getDispatchHistoryForBuild(buildId),
     verification: await getScopedVerificationForBuild(buildId),
     lastActivityAt: build.activities[0]?.createdAt.toISOString() ?? build.updatedAt.toISOString(),
+    lastAssistant: newestAssistant
+      ? { content: newestAssistant.content, createdAt: newestAssistant.createdAt }
+      : null,
     phaseRuns,
     evidenceTimeline,
   });

--- a/docs/superpowers/plans/2026-07-05-build-studio-failed-inference-recovery.md
+++ b/docs/superpowers/plans/2026-07-05-build-studio-failed-inference-recovery.md
@@ -1,0 +1,179 @@
+# Build Studio — failed ideate/scout inference recovery
+
+- **BI:** BI-F0005EB0 (large, bug, triage=build)
+- **Epic:** EP-BS-UX-HARDENING — "happy path survives inference failures, status surfaces stay honest"
+- **Date:** 2026-07-05
+- **Author:** Claude (Opus 4.8)
+
+## Problem (verified live 2026-07-04, FB-54088DED)
+
+When a Build Studio build's **first ideate inference fails**, the raw provider error
+(e.g. `API Error: Unable to connect to API (ConnectionRefused)`) is stored as an
+ordinary **assistant** `AgentMessage` and the build silently stalls in `ideate`. The
+custodian classifies this as the benign **"Waiting on evidence"** (accent) state — there
+is no error state, no retry affordance, and no auto-recovery. A non-technical user is
+dead-ended: the UI implies *they* must act, when in fact the AI call errored and was
+dropped. Recovery today requires the user to manually re-prompt.
+
+## Root cause (grounded)
+
+1. **Persist path** — the auto-seeded ideate turn (`BuildStudio.tsx:615`, "Let's define it
+   together") runs the coworker loop: `agent-coworker.ts sendMessage` →
+   `executeAutonomousAgenticLoop` (`lib/tak/autonomous-work-run.ts:190`) → `runAgenticLoop`
+   (`lib/tak/agentic-loop.ts`). A thrown route error becomes friendly `content` via
+   `describeToolRouteFailure` (`agentic-loop.ts:1531-1546`); but a provider/CLI error that
+   comes back **as a successful `result.content`** (e.g. the observed
+   `API Error: Unable to connect…`) is never recognised as a failure. Either way, the
+   loop returns a string and `agent-coworker.ts` persists it verbatim as an `assistant`
+   message (`agent-coworker.ts:2138`). The existing `catch` only handles typed
+   `NoProvidersAvailableError` / `NoEligibleEndpointsError` — a raw connection error is
+   not one of them.
+2. **Classification path** — the custodian
+   (`build-studio-custodian.ts:121-217`) classifies stalls into `technicalRecovery`
+   (`resume-implementation`/`rerun-plan-review`/`retry-build`/`reset-build`) vs
+   `blockedByEvidence` (`action.disabledReason != null`). In `ideate`,
+   `deriveBuildStudioWorkflowAction` returns `advance-phase` with a `disabledReason` (gate
+   not met) → `blockedByEvidence` → "Waiting on evidence". **No branch inspects whether
+   the last agent turn was an error.**
+
+## Substrate we build on (verified)
+
+- `getBuildProgressVisibility` (`lib/build/progress-visibility.ts:135`) **already** loads
+  the last 50 assistant `AgentMessage` rows for the build's `threadId`
+  (`progress-visibility.ts:155-169`). This is the natural seam to detect a failed-inference
+  turn and expose a signal — no new query needed.
+- Both `deriveBuildStudioWorkflowAction` and `deriveBuildStudioCustodianPrompt` already
+  receive `progressVisibility` (`BuildStudio.tsx:257-270`), so a new signal flows to both
+  with no plumbing changes at the call site.
+- Action → execution wiring is a `switch (action.kind)` in
+  `BuildStudioWorkflowActionCard.tsx:173-207`; adding a kind means adding one branch there.
+- `FeatureBuildRow.threadId` (`lib/explore/feature-build-types.ts:504`) links the build to
+  its coworker thread.
+
+## Design
+
+A **shared inference-error classifier** recognised at three layers. The classifier is the
+heart; everything else consumes it.
+
+### New module — `apps/web/lib/build/inference-failure.ts` (pure, unit-tested)
+
+```ts
+export type InferenceFailureKind =
+  | "connection"            // ConnectionRefused / ECONNREFUSED / "Unable to connect"
+  | "provider-unavailable"  // "temporarily unavailable", "providers are momentarily busy"
+  | "rate-limit"
+  | "config"                // "No AI provider…configured", "No eligible endpoints"
+  | "empty-response";
+
+export function classifyInferenceFailure(content: string | null | undefined): InferenceFailureKind | null;
+export function friendlyInferenceFailureMessage(kind: InferenceFailureKind): string;
+```
+
+- Recognises **both** the raw provider forms (`/^API Error:/i`, `/unable to connect to
+  api/i`, `/connection\s*refused/i`, `/ECONNREFUSED/`, `/fetch failed/i`) **and** the
+  friendly strings `describeToolRouteFailure` already emits (so a sanitised turn is still
+  classifiable — this is what keeps the custodian signal alive after we stop persisting raw
+  text).
+- **Conservative** matching — anchored patterns (`^`/whole-message), not substring hunts,
+  so a legitimate assistant reply that merely *mentions* "error" is not misread as a
+  failure. This is the primary false-positive risk and gets dedicated tests.
+
+### Phase 1 — Classifier module + tests (ships independently)
+
+- Create `inference-failure.ts` + `inference-failure.test.ts`.
+- **Verify:** `pnpm --filter web exec vitest run apps/web/lib/build/inference-failure.test.ts`
+  — asserts the observed live string classifies as `connection`; asserts friendly
+  `describeToolRouteFailure` outputs classify; asserts normal chat ("I hit an error in your
+  config, let me fix it") returns `null`.
+
+### Phase 2 — Expose signal on progress-visibility
+
+- Extend `BuildProgressVisibility` with:
+  ```ts
+  inferenceFailure: { failed: boolean; kind: InferenceFailureKind | null; observedAt: string | null };
+  ```
+- In `buildProgressProjectionFromParts`, accept an optional `lastAssistant?: { content; createdAt }`
+  arg (keeps existing test literals valid — defaults to no-failure). Classify the **newest**
+  assistant message; set `failed` only when it classifies **and** it is at least as recent
+  as `lastObservableSignalAt` (so a fresh successful task/dispatch after the error clears it).
+- In `getBuildProgressVisibility`, pass the newest element of the already-fetched
+  `chatMessages` (desc-ordered) as `lastAssistant`.
+- **Verify:** unit tests on `buildProgressProjectionFromParts` — failure turn → `failed:true`;
+  newer task activity → `failed:false`; no assistant messages → `failed:false`.
+
+### Phase 3 — New `retry-inference` action + honest custodian branch (closes the reported dead-end)
+
+- `build-studio-workflow-actions.ts`:
+  - Add action kind `retry-inference` (danger, `primaryLabel: "Retry the AI call"`,
+    `disabledReason: null`).
+  - In `deriveBuildStudioWorkflowAction`, **scoped to `ideate`/`plan`** (the coworker-chat
+    deliberation phases the bug covers; build/review keep their richer exec-state recovery),
+    return `retry-inference` when `progressVisibility?.inferenceFailure?.failed` — checked
+    before the phase's advance-gate branch so it takes priority over "gate not met".
+  - Add `retry-inference` to `statusForAction` (→ `blocked-technical`/danger) and
+    `nextSentenceForAction`.
+- `build-studio-custodian.ts`:
+  - `const failedInference = action.kind === "retry-inference";`
+  - Add to the early null-guard and to `resolveCustodianStatusSignal` (→ `"blocked"`).
+  - New branch **before** `technicalRecovery`/`blockedByEvidence`: title "The AI call
+    failed.", danger intent, `statusLabel: "AI call failed"`, primary
+    `"Retry the AI call"` (`primaryAction: "workflow"`), details drawn from
+    `friendlyInferenceFailureMessage(kind)` — **never** the raw provider string.
+- `BuildStudioWorkflowActionCard.tsx`: add `retry-inference` to the `primaryLabel` pending
+  map ("Retrying the AI call…") and a `handlePrimaryAction` branch that re-drives the
+  failed turn (see retry wiring below).
+- **Verify:** extend `build-studio-workflow-actions.test.ts` and
+  `build-studio-custodian.test.ts` — an ideate build with `inferenceFailure.failed` yields
+  `retry-inference`/danger "AI call failed", **not** "Waiting on evidence".
+
+### Phase 4 — Stop persisting raw provider errors + bounded auto-retry (fix (c),(d))
+
+- **Persist-time guard (d)** in `agent-coworker.ts` before `agentMessage.create`
+  (~line 2138): if `classifyInferenceFailure(responseContent)` is non-null, replace the
+  user-visible content with `friendlyInferenceFailureMessage(kind)` (raw error still logged
+  server-side for engineers). The sanitised text remains classifiable, so Phase 2/3 still
+  fire.
+- **Bounded auto-retry (c)** — for `ideate`/scout turns, when the first loop result
+  classifies as a *transient* failure (`connection`/`rate-limit`), retry the loop up to 2×
+  with backoff (500ms, 1500ms) inside the same request before falling through to the
+  sanitised-failure persist. Deterministic `connection` to a downed local engine may still
+  fail all attempts → custodian surfaces Retry (Phase 3). Backoff/attempt count are
+  constants so the retry decision is unit-testable via an injected `sleep`/attempt hook.
+- **Verify:** unit test the retry helper (2 failures then success → success; 3 failures →
+  sanitised failure). Manual: confirm no raw `API Error:` string is persisted.
+
+### Retry wiring
+
+The `retry-inference` primary button re-drives the failed turn — the same recovery the
+user does manually today. Least-invasive, consistent with `decompose-now`: dispatch the
+`open-agent-panel` CustomEvent with a phase-appropriate retry `autoMessage` (re-ask the
+ideate/scout question). No new server action required for the button; the durable
+auto-retry lives server-side in Phase 4.
+
+## Risks & rollback
+
+- **False positives** (normal chat misread as failure) — mitigated by conservative anchored
+  patterns + dedicated negative tests. Blast radius if wrong: a build shows a spurious
+  "Retry the AI call" that, when clicked, simply re-drives the turn (harmless).
+- **Over-eager auto-retry** burning local GPU — bounded to 2 retries, transient kinds only,
+  ideate/scout only.
+- **Scope creep into build/review recovery** — explicitly avoided; `retry-inference` is
+  gated to `ideate`/`plan` so it never shadows `resume-implementation`/`reset-build`.
+- **Rollback:** the classifier is additive; reverting Phases 2-4 restores prior behaviour.
+  Phases are independently revertable (Phase 1 has no consumers on its own).
+
+## Definition of done (BI acceptance)
+
+- A failed ideate/scout inference surfaces as danger **"The AI call failed — Retry"**, not
+  "Waiting on evidence".
+- The raw provider error string is never persisted as a user-visible assistant message.
+- Transient ideate/scout inference failures auto-retry with backoff before parking.
+- All new/changed vitest suites green; CI typecheck authoritative.
+
+## Sequencing
+
+Phases 1→2→3 land the honest surface (the reported dead-end) and are the priority. Phase 4
+(persist guard + auto-retry) completes the BI. All four ship in **one PR** (one concern:
+inference-failure handling) referencing EP-BS-UX-HARDENING + BI-F0005EB0; if Phase 4's
+auto-retry balloons, it splits to an immediate follow-up PR with Phases 1-3 already
+delivering the user-visible fix.


### PR DESCRIPTION
## Problem (verified live 2026-07-04, FB-54088DED)

When a Build Studio build's **first ideate inference failed**, the raw provider error (e.g. `API Error: Unable to connect to API (ConnectionRefused)`) was stored as an ordinary **assistant** chat message and the build silently stalled in `ideate`, mis-surfaced by the custodian as the benign **"Waiting on evidence"** state — no error, no retry, no auto-recovery. The whole promise ("describe a feature, the coworker builds it") broke on the first inference hiccup, and the non-technical target user was dead-ended: the UI implied *they* had to act when in fact the AI call errored and was dropped.

**Root cause:** `build-studio-custodian.ts` classified stalls into `technicalRecovery` vs `blockedByEvidence` (`action.disabledReason != null`) with **no branch inspecting whether the last agent turn was an error** → an inference failure fell into `blockedByEvidence` → "Waiting on evidence" (accent), never "Blocked" (danger).

## Fix (EP-BS-UX-HARDENING · BI-F0005EB0)

Shared inference-failure classifier consumed at three layers:

- **`lib/build/inference-failure.ts`** — conservative, anchored classifier (`classifyInferenceFailure`) recognising both raw provider forms **and** the friendly `describeToolRouteFailure` outputs; `isRawProviderError` for the persist guard; `friendlyInferenceFailureMessage` for provider-detail-free copy.
- **`progress-visibility.ts`** — new `inferenceFailure` signal derived from the newest assistant turn (self-clears when a fresher observable signal lands).
- **`build-studio-workflow-actions.ts` + `build-studio-custodian.ts`** — new `retry-inference` action (scoped to ideate/plan, **danger**) and an honest **"The AI call failed — Retry the AI call"** custodian branch instead of "Waiting on evidence".
- **`lib/build/inference-retry.ts`** — bounded, transient-only auto-retry with backoff, wired into the ideate coworker turn.
- **`agent-coworker.ts` persist guard** — a raw provider error is **never** persisted as a user-visible assistant message (raw stays in server logs).

Delivers all four BI fix directions: (a) detect failed inference → distinct state; (b) danger "Retry" affordance; (c) auto-retry with backoff before parking; (d) never persist a raw provider error string.

## Plan

`docs/superpowers/plans/2026-07-05-build-studio-failed-inference-recovery.md`

## Tests / verification

- New suites: `inference-failure`, `inference-retry`; extended `progress-visibility`, `build-studio-workflow-actions`, `build-studio-custodian`.
- All affected suites green (129 tests across the touched files; 1044 across `lib/build` + `components/build`).
- Full `apps/web` typecheck clean locally.

Epic: **EP-BS-UX-HARDENING** · Backlog item: **BI-F0005EB0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)