### PR TITLE
feat(hr): labor substrate — compensation, billable timesheet, rate card, archetype flag (EP-LABOR-ECONOMICS Phase 2)

### DIFF
--- a/packages/db/prisma/migrations/20260704230000_labor_economics/migration.sql
+++ b/packages/db/prisma/migrations/20260704230000_labor_economics/migration.sql
@@ -1,0 +1,31 @@
+-- AlterTable
+ALTER TABLE "EmployeeProfile" ADD COLUMN     "payType" TEXT,
+ADD COLUMN     "hourlyRate" DECIMAL(65,30),
+ADD COLUMN     "annualSalary" DECIMAL(65,30),
+ADD COLUMN     "standardAnnualHours" INTEGER;
+
+-- AlterTable
+ALTER TABLE "TimesheetEntry" ADD COLUMN     "customerAccountId" TEXT,
+ADD COLUMN     "billableRateId" TEXT,
+ADD COLUMN     "billable" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "billableHours" DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "BillableRate" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "unit" TEXT NOT NULL DEFAULT 'hour',
+    "billRate" DECIMAL(65,30) NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BillableRate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TimesheetEntry_customerAccountId_idx" ON "TimesheetEntry"("customerAccountId");
+
+-- CreateIndex
+CREATE INDEX "BillableRate_organizationId_isActive_idx" ON "BillableRate"("organizationId", "isActive");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -312,6 +312,10 @@ model EmployeeProfile {
   updatedAt                    DateTime                      @updatedAt
   phoneMobile                  String?
   phoneEmergency               String?
+  payType                      String?
+  hourlyRate                   Decimal?
+  annualSalary                 Decimal?
+  standardAnnualHours          Int?
   accountableItems             BacklogItem[]                 @relation("ItemAccountable")
   calendarEvents               CalendarEvent[]
   calendarSyncs                CalendarSync[]
@@ -6886,10 +6890,28 @@ model TimesheetEntry {
   notes             String?
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
+  customerAccountId String?
+  billableRateId    String?
+  billable          Boolean         @default(false)
+  billableHours     Float           @default(0)
   timesheetPeriod   TimesheetPeriod @relation(fields: [timesheetPeriodId], references: [id], onDelete: Cascade)
 
   @@unique([timesheetPeriodId, dayOfWeek])
   @@index([timesheetPeriodId])
+  @@index([customerAccountId])
+}
+
+model BillableRate {
+  id             String   @id @default(cuid())
+  organizationId String
+  name           String
+  unit           String   @default("hour")
+  billRate       Decimal
+  isActive       Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@index([organizationId, isActive])
 }
 
 model CalendarEvent {

--- a/packages/finance-templates/src/profiles.ts
+++ b/packages/finance-templates/src/profiles.ts
@@ -113,6 +113,7 @@ const LEDGER_FRAGMENTS_INTERNAL: Record<Exclude<LedgerModel, "commercial">, Char
 
 const PROFILES: Record<string, FinancialProfileSeed> = {
   healthcare_wellness: {
+    billableTimeEnabled: true,
     archetypeCategory: "healthcare-wellness",
     displayName: "Healthcare & Wellness",
     defaultPaymentTerms: "Due on receipt",
@@ -144,6 +145,7 @@ const PROFILES: Record<string, FinancialProfileSeed> = {
   },
 
   trades_construction: {
+    billableTimeEnabled: true,
     archetypeCategory: "trades-maintenance",
     displayName: "Trades & Construction",
     defaultPaymentTerms: "Net 14",
@@ -176,6 +178,7 @@ const PROFILES: Record<string, FinancialProfileSeed> = {
   },
 
   professional_services: {
+    billableTimeEnabled: true,
     archetypeCategory: "professional-services",
     displayName: "Professional Services",
     defaultPaymentTerms: "Net 30",
@@ -329,6 +332,7 @@ const PROFILES: Record<string, FinancialProfileSeed> = {
   },
 
   fitness_recreation: {
+    billableTimeEnabled: true,
     archetypeCategory: "fitness-recreation",
     displayName: "Fitness & Recreation",
     defaultPaymentTerms: "Monthly direct debit",
@@ -359,6 +363,7 @@ const PROFILES: Record<string, FinancialProfileSeed> = {
   },
 
   beauty_personal: {
+    billableTimeEnabled: true,
     archetypeCategory: "beauty-personal-care",
     displayName: "Beauty & Personal Care",
     defaultPaymentTerms: "Due on receipt",
@@ -427,6 +432,7 @@ const PROFILES: Record<string, FinancialProfileSeed> = {
   },
 
   pet_services: {
+    billableTimeEnabled: true,
     archetypeCategory: "pet-services",
     displayName: "Pet Services",
     defaultPaymentTerms: "Due on receipt",

--- a/packages/finance-templates/src/types.ts
+++ b/packages/finance-templates/src/types.ts
@@ -51,6 +51,8 @@ export type FinancialProfile = {
   invoiceTemplateStyle: "professional" | "trade" | "creative" | "nonprofit" | "minimal";
   expenseCategories: string[];
   purchaseOrdersEnabled: boolean;
+  /** Sell employee labour as billable services (PSA). Archetype-gated. */
+  billableTimeEnabled?: boolean;
   chartOfAccountsSeed: Array<{
     code: string;
     name: string;


### PR DESCRIPTION
Implements Phase 2 of the labor-economics design (spec merged in #2598): the schema for the two axes the operator named — **employee wage time (hourly or salary)** and **selling services/resources to bill for that labor**.

## What it adds
- **`EmployeeProfile` compensation** — `payType` (`hourly`|`salary`), `hourlyRate`, `annualSalary`, `standardAnnualHours`: the wage/cost basis, previously unmodeled anywhere.
- **`TimesheetEntry` billable dimension** — `customerAccountId`, `billableRateId`, `billable`, `billableHours` (+ index): one hour can now be both a payroll cost and customer-billable work.
- **`BillableRate`** — an org-scoped rate card: the services/resources the company sells labour as (`name`, `unit`, `billRate`, `isActive`).
- **`FinancialProfile.billableTimeEnabled`** — archetype gating per the proven flag pattern (`purchaseOrdersEnabled` et al.): **on** for the 6 labour archetypes (trades, professional services, fitness, beauty, pet services, healthcare), **off** for retail/food/nonprofit/banking/software.

## Migration
`20260704230000_labor_economics` — purely additive (nullable/defaulted columns + one new table + indexes; no backfill). `prisma validate` passes; the schema regression guard is green against current main (an earlier stale-base attempt was correctly rejected by the guard and rebuilt on fresh main).

Phase 3 (next PR): approved timesheet hours → payroll gross; billable hours → draft invoice lines; gated by the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)