### PR TITLE
fix(local-ci): pin V8 heap headroom on the host-next gate build (BI-B5011ACE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,7 @@ jobs:
             scripts/runtime-artifact-janitor.cli.test.mjs \
             scripts/lib/junction-safe-worktree-remove.test.mjs \
             scripts/lib/compose-safety.test.mjs \
+            scripts/lib/local-integration-ci.test.mjs \
             scripts/lib/sandbox-freshness.test.mjs \
             scripts/sandbox-freshness-preflight.test.mjs \
             scripts/release/re-resolve-stt-digest.test.mjs \

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -15,12 +15,22 @@ export function dockerBuildTag(candidateBranch) {
   return `dpf-${integrationBranchName(candidateBranch).replace(/\//g, "-")}-build`;
 }
 
+// V8 heap headroom for the host-next production build (BI-B5011ACE). With the
+// node 24 default heap, the Next build worker intermittently dies with SIGABRT
+// during the TypeScript phase — an exit that is indistinguishable from a red
+// product build, so it poisons gate evidence exactly like sandbox staleness
+// did (and the freshness gate correctly stays green, so nothing else catches
+// it). Verified 2026-07-05: default heap SIGABRT; 8 GiB completes cleanly.
+export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=8192";
+
 export function createLocalIntegrationPlan(input) {
   const branch = integrationBranchName(input.candidateBranch);
   const buildStrategy = input.buildStrategy ?? defaultBuildStrategy(input.hostPlatform);
   const productionBuildCommand = buildStrategy === "docker-build"
     ? ["docker", "build", "--target", "build", "-t", dockerBuildTag(input.candidateBranch), "."]
-    : ["pnpm", "--filter", "web", "exec", "next", "build"];
+    // `env VAR=… cmd` keeps the plan a plain argv (no shell) — host-next is
+    // POSIX-only by construction (Windows defaults to docker-build above).
+    : ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "exec", "next", "build"];
   const commands = [
     ["git", "fetch", "origin", "main"],
     ["git", "checkout", "-B", branch, "origin/main"],

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+// node --test (was vitest, which no CI job executed for scripts/ — converted
+// alongside BI-B5011ACE so the plan contract actually gates in the bare-runner
+// CI test job).
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import { createLocalIntegrationPlan } from "./local-integration-ci.mjs";
 
 describe("createLocalIntegrationPlan", () => {
@@ -10,14 +14,14 @@ describe("createLocalIntegrationPlan", () => {
       hostPlatform: "linux",
     });
 
-    expect(plan.commands.map((command) => command.join(" "))).toEqual([
+    assert.deepEqual(plan.commands.map((command) => command.join(" ")), [
       "git fetch origin main",
       "git checkout -B local-integration/doc-build-studio-decision-skill-packs origin/main",
       "git merge --no-ff --no-edit doc/build-studio-decision-skill-packs",
       "node scripts/sandbox-freshness-preflight.mjs --converge --branch local-integration/doc-build-studio-decision-skill-packs",
       "pnpm --filter web exec vitest run",
       "pnpm --filter web typecheck",
-      "pnpm --filter web exec next build",
+      "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build",
     ]);
   });
 
@@ -32,8 +36,8 @@ describe("createLocalIntegrationPlan", () => {
     const preflightIndex = commands.findIndex((c) => c.includes("sandbox-freshness-preflight.mjs"));
     const lastMergeIndex = commands.map((c, i) => (c.startsWith("git merge") ? i : -1)).reduce((a, b) => Math.max(a, b), -1);
     const firstGateIndex = commands.findIndex((c) => c.includes("vitest run"));
-    expect(preflightIndex).toBeGreaterThan(lastMergeIndex);
-    expect(preflightIndex).toBeLessThan(firstGateIndex);
+    assert.ok(preflightIndex > lastMergeIndex);
+    assert.ok(preflightIndex < firstGateIndex);
   });
 
   it("adds sibling branches in order for concurrent development", () => {
@@ -43,13 +47,13 @@ describe("createLocalIntegrationPlan", () => {
       siblingBranches: ["feat/environment-broker", "fix/build-studio-copy"],
     });
 
-    expect(plan.integrationBranch).toBe("local-integration/feat-build-studio-decision-skills-slice-1");
-    expect(plan.commands.map((command) => command.join(" "))).toContain(
+    assert.equal(plan.integrationBranch, "local-integration/feat-build-studio-decision-skills-slice-1");
+    assert.ok(plan.commands.map((command) => command.join(" ")).includes(
       "git merge --no-ff --no-edit feat/environment-broker",
-    );
-    expect(plan.commands.map((command) => command.join(" "))).toContain(
+    ));
+    assert.ok(plan.commands.map((command) => command.join(" ")).includes(
       "git merge --no-ff --no-edit fix/build-studio-copy",
-    );
+    ));
   });
 
   it("uses a Docker production build on Windows hosts", () => {
@@ -60,11 +64,11 @@ describe("createLocalIntegrationPlan", () => {
       hostPlatform: "win32",
     });
 
-    expect(plan.commands.map((command) => command.join(" "))).toContain(
+    assert.ok(plan.commands.map((command) => command.join(" ")).includes(
       "docker build --target build -t dpf-local-integration-feat-build-studio-decision-skills-slice-1-build .",
-    );
-    expect(plan.commands.map((command) => command.join(" "))).not.toContain(
-      "pnpm --filter web exec next build",
-    );
+    ));
+    assert.ok(!plan.commands.map((command) => command.join(" ")).join("\n").includes(
+      "exec next build",
+    ));
   });
 });


### PR DESCRIPTION
## Problem

During the BI-ECDF9520 verification, the host-next production build in the freshness-green sandbox crashed with **SIGABRT in the Next build worker during the TypeScript phase** (node 24, default heap). A heap-exhaustion SIGABRT exits 1 — indistinguishable from a red product build — so it poisons gate evidence the same way sandbox staleness did, and the freshness gate correctly stays green, so nothing else catches it. Verified live: default heap → SIGABRT; `NODE_OPTIONS=--max-old-space-size=8192` → clean build (131/131 pages).

## Fix

- The plan's host-next production build command is now `env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build` — still a plain argv (no shell); host-next is POSIX-only by construction (Windows defaults to docker-build, unchanged).
- `scripts/lib/local-integration-ci.test.mjs` ported from vitest to `node:test` — no CI job ever executed the vitest version for `scripts/` — and added to the bare-runner CI test job, so the plan contract (including the freshness-preflight ordering from #2613 and this heap pin) actually gates.

## Verification

`node --test` across the plan, freshness, digest, and gate-contract suites: **38/38 pass**. `env NODE_OPTIONS=...` wrapper confirmed to raise the child heap limit (~8.4 GB). ci.yml YAML validated.

Backlog: BI-B5011ACE
Process-Spine-Decision: gate-tooling fix; rationale in code comment + BI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)