### PR TITLE
feat(hr): wire timecards to payroll and billable time to invoicing (EP-LABOR-ECONOMICS Phase 3)

### DIFF
--- a/apps/web/lib/hr/labor-billing.test.ts
+++ b/apps/web/lib/hr/labor-billing.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { payrollEarningsFromTimesheet, buildBillableInvoiceLines } from "./labor-billing";
+import type { Compensation } from "./labor";
+
+const hourly: Compensation = { payType: "hourly", hourlyRate: 20 };
+const salary: Compensation = { payType: "salary", annualSalary: 60000, standardAnnualHours: 2000 };
+
+describe("payrollEarningsFromTimesheet", () => {
+  it("hourly: regular hours at rate, overtime at 1.5× — overtime never double-paid", () => {
+    // 45 approved hours of which 5 overtime → 40 regular + 5 OT.
+    const e = payrollEarningsFromTimesheet(hourly, { totalHours: 45, overtimeHours: 5 });
+    expect(e).toEqual({ hoursWorked: 40, hourlyRate: 20, overtimeHours: 5, overtimeRate: 30 });
+  });
+
+  it("salary: fixed period pay, hours ignored", () => {
+    const e = payrollEarningsFromTimesheet(salary, { totalHours: 200, overtimeHours: 60 }, { periodsPerYear: 12 });
+    expect(e).toEqual({ baseSalary: 5000 });
+  });
+
+  it("caps overtime at total hours and respects a custom multiplier", () => {
+    const e = payrollEarningsFromTimesheet(hourly, { totalHours: 10, overtimeHours: 99 }, { overtimeMultiplier: 2 });
+    expect(e.hoursWorked).toBe(0);
+    expect(e.overtimeHours).toBe(10);
+    expect(e.overtimeRate).toBe(40);
+  });
+});
+
+describe("buildBillableInvoiceLines", () => {
+  const rateCard = [
+    { id: "r-consult", name: "Consulting", unit: "hour", billRate: 120 },
+    { id: "r-site", name: "Site Labour", unit: "hour", billRate: 65 },
+  ];
+
+  it("aggregates hours per rate into one line with a date range", () => {
+    const r = buildBillableInvoiceLines(
+      [
+        { id: "e1", date: new Date("2026-07-01"), billableHours: 3, billableRateId: "r-consult" },
+        { id: "e2", date: new Date("2026-07-03"), billableHours: 2.5, billableRateId: "r-consult" },
+        { id: "e3", date: new Date("2026-07-02"), billableHours: 8, billableRateId: "r-site" },
+      ],
+      rateCard,
+    );
+    expect(r.lines).toHaveLength(2);
+    const consult = r.lines.find((l) => l.description.startsWith("Consulting"))!;
+    expect(consult.quantity).toBe(5.5);
+    expect(consult.unitPrice).toBe(120);
+    expect(consult.description).toContain("2026-07-01 – 2026-07-03");
+    expect(r.billedEntryIds.sort()).toEqual(["e1", "e2", "e3"]);
+    expect(r.totalHours).toBe(13.5);
+    expect(r.skipped).toHaveLength(0);
+  });
+
+  it("skips entries with no resolvable rate — never bills at zero", () => {
+    const r = buildBillableInvoiceLines(
+      [
+        { id: "e1", date: new Date("2026-07-01"), billableHours: 4, billableRateId: null },
+        { id: "e2", date: new Date("2026-07-01"), billableHours: 4, billableRateId: "r-unknown" },
+        { id: "e3", date: new Date("2026-07-01"), billableHours: 0, billableRateId: "r-consult" },
+      ],
+      rateCard,
+    );
+    expect(r.lines).toHaveLength(0);
+    expect(r.billedEntryIds).toHaveLength(0);
+    expect(r.skipped).toEqual(
+      expect.arrayContaining([
+        { entryId: "e1", reason: "no-rate" },
+        { entryId: "e2", reason: "no-rate" },
+        { entryId: "e3", reason: "zero-hours" },
+      ]),
+    );
+  });
+
+  it("single-day work shows one date, singular unit", () => {
+    const r = buildBillableInvoiceLines(
+      [{ id: "e1", date: new Date("2026-07-04"), billableHours: 1, billableRateId: "r-site" }],
+      rateCard,
+    );
+    expect(r.lines[0].description).toBe("Site Labour (1 hour, 2026-07-04)");
+  });
+});

--- a/apps/web/lib/hr/labor-billing.ts
+++ b/apps/web/lib/hr/labor-billing.ts
@@ -1,0 +1,153 @@
+// lib/hr/labor-billing.ts — the pure bridges that wire the timecard to money.
+//
+// Two one-way flows, both starting from APPROVED timesheet time:
+//   1. timesheet → payroll: approved hours + the employee's compensation become the
+//      earnings side of a PayrollInput (lib/hr/payroll.ts computes gross-to-net).
+//   2. billable time → invoice: approved billable hours priced from the BillableRate
+//      rate card become draft invoice line inputs (lib/actions/finance.ts createInvoice
+//      turns them into a real Invoice, which auto-posts to the GL on send).
+//
+// Pure and DB-free; the Prisma reads/writes live in lib/hr/labor-service.ts.
+
+import type { Compensation } from "./labor";
+import type { PayrollInput } from "./payroll";
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ─── Timesheet → payroll earnings ────────────────────────────────────────────
+
+export type ApprovedTimesheetTotals = {
+  /** Total approved hours in the pay period (INCLUDING overtime hours). */
+  totalHours: number;
+  /** Of which overtime (TimesheetPeriod.overtimeHours). */
+  overtimeHours: number;
+};
+
+export type PayrollEarnings = Pick<
+  PayrollInput,
+  "baseSalary" | "hoursWorked" | "hourlyRate" | "overtimeHours" | "overtimeRate"
+>;
+
+/**
+ * Build the earnings side of a PayrollInput from an employee's compensation and
+ * their approved timesheet totals for the pay period:
+ *   salary → a fixed baseSalary (annualSalary / periodsPerYear); logged hours never
+ *            change salaried pay.
+ *   hourly → regular hours (total − overtime) at hourlyRate, plus overtime hours at
+ *            hourlyRate × overtimeMultiplier (default 1.5).
+ * TimesheetPeriod.totalHours includes its overtimeHours, so regular hours are the
+ * difference — overtime is never double-paid.
+ */
+export function payrollEarningsFromTimesheet(
+  comp: Compensation,
+  approved: ApprovedTimesheetTotals,
+  opts?: { periodsPerYear?: number; overtimeMultiplier?: number },
+): PayrollEarnings {
+  const periods = opts?.periodsPerYear && opts.periodsPerYear > 0 ? opts.periodsPerYear : 12;
+
+  if (comp.payType === "salary") {
+    return { baseSalary: round2(Math.max(comp.annualSalary, 0) / periods) };
+  }
+
+  const multiplier = opts?.overtimeMultiplier && opts.overtimeMultiplier > 0 ? opts.overtimeMultiplier : 1.5;
+  const total = Math.max(approved.totalHours, 0);
+  const overtime = Math.min(Math.max(approved.overtimeHours, 0), total);
+  const regular = round2(total - overtime);
+  const rate = Math.max(comp.hourlyRate, 0);
+
+  return {
+    hoursWorked: regular,
+    hourlyRate: rate,
+    overtimeHours: overtime,
+    overtimeRate: round2(rate * multiplier),
+  };
+}
+
+// ─── Billable time → invoice lines ───────────────────────────────────────────
+
+export type BillableTimeEntry = {
+  id: string;
+  /** ISO date of the work, used only for the line description range. */
+  date: Date;
+  billableHours: number;
+  billableRateId: string | null;
+};
+
+export type RateCardEntry = {
+  id: string;
+  name: string;
+  unit: string;
+  billRate: number;
+};
+
+export type BillableInvoiceLine = {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+};
+
+export type BillableLinesResult = {
+  lines: BillableInvoiceLine[];
+  /** Entry ids priced into `lines` — the set the caller should stamp as invoiced. */
+  billedEntryIds: string[];
+  /** Entries skipped because they carry no resolvable rate — surfaced, never billed at 0. */
+  skipped: Array<{ entryId: string; reason: "no-rate" | "zero-hours" }>;
+  totalHours: number;
+};
+
+/**
+ * Price approved billable time entries into draft invoice line inputs, one line per
+ * rate-card service (hours aggregated, date range in the description). An entry with
+ * no resolvable rate or zero hours is SKIPPED and reported — a missing rate must
+ * surface as a decision, not silently bill at £0.
+ */
+export function buildBillableInvoiceLines(
+  entries: BillableTimeEntry[],
+  rateCard: RateCardEntry[],
+): BillableLinesResult {
+  const rates = new Map(rateCard.map((r) => [r.id, r]));
+  const byRate = new Map<string, { rate: RateCardEntry; hours: number; from: Date; to: Date; ids: string[] }>();
+  const skipped: BillableLinesResult["skipped"] = [];
+
+  for (const e of entries) {
+    const hours = Math.max(e.billableHours, 0);
+    if (hours === 0) {
+      skipped.push({ entryId: e.id, reason: "zero-hours" });
+      continue;
+    }
+    const rate = e.billableRateId ? rates.get(e.billableRateId) : undefined;
+    if (!rate) {
+      skipped.push({ entryId: e.id, reason: "no-rate" });
+      continue;
+    }
+    const bucket = byRate.get(rate.id);
+    if (!bucket) {
+      byRate.set(rate.id, { rate, hours, from: e.date, to: e.date, ids: [e.id] });
+    } else {
+      bucket.hours = round2(bucket.hours + hours);
+      if (e.date < bucket.from) bucket.from = e.date;
+      if (e.date > bucket.to) bucket.to = e.date;
+      bucket.ids.push(e.id);
+    }
+  }
+
+  const fmt = (d: Date) => d.toISOString().slice(0, 10);
+  const lines: BillableInvoiceLine[] = [];
+  const billedEntryIds: string[] = [];
+  let totalHours = 0;
+
+  for (const { rate, hours, from, to, ids } of byRate.values()) {
+    const range = fmt(from) === fmt(to) ? fmt(from) : `${fmt(from)} – ${fmt(to)}`;
+    lines.push({
+      description: `${rate.name} (${hours} ${rate.unit}${hours === 1 ? "" : "s"}, ${range})`,
+      quantity: hours,
+      unitPrice: rate.billRate,
+    });
+    billedEntryIds.push(...ids);
+    totalHours = round2(totalHours + hours);
+  }
+
+  return { lines, billedEntryIds, skipped, totalHours };
+}

--- a/apps/web/lib/hr/labor-service.ts
+++ b/apps/web/lib/hr/labor-service.ts
@@ -1,0 +1,205 @@
+// lib/hr/labor-service.ts — persistence + wiring for labor economics (EP-LABOR-ECONOMICS Phase 3).
+//
+// Connects the (already-shipped) pieces end to end:
+//   • approved timesheets + EmployeeProfile compensation → payroll earnings
+//     (lib/hr/labor-billing.ts payrollEarningsFromTimesheet → lib/hr/payroll.ts);
+//   • approved billable hours + the BillableRate rate card → a draft customer
+//     invoice (lib/actions/finance.ts createInvoice → GL auto-post on send).
+//
+// The billable flow is ARCHETYPE-GATED: it only runs when the org's applied
+// financial profile carries billableTimeEnabled (labour archetypes) — the same
+// per-business-model flag pattern as purchaseOrdersEnabled. All pure rules live
+// in labor.ts / labor-billing.ts; this file only reads/writes Prisma around them.
+
+import { prisma } from "@dpf/db";
+import { getFinancialProfile } from "@dpf/finance-templates";
+import { createInvoice } from "@/lib/actions/finance";
+import type { Compensation } from "./labor";
+import {
+  payrollEarningsFromTimesheet,
+  buildBillableInvoiceLines,
+  type PayrollEarnings,
+  type ApprovedTimesheetTotals,
+} from "./labor-billing";
+
+// ─── Compensation resolution ─────────────────────────────────────────────────
+
+type EmployeeCompRow = {
+  payType: string | null;
+  hourlyRate: unknown;
+  annualSalary: unknown;
+  standardAnnualHours: number | null;
+};
+
+/** Map EmployeeProfile compensation columns to the pure Compensation type; null when unset/incomplete. */
+export function compensationFromEmployee(row: EmployeeCompRow): Compensation | null {
+  if (row.payType === "hourly" && row.hourlyRate != null) {
+    return { payType: "hourly", hourlyRate: Number(row.hourlyRate) };
+  }
+  if (row.payType === "salary" && row.annualSalary != null) {
+    return {
+      payType: "salary",
+      annualSalary: Number(row.annualSalary),
+      standardAnnualHours: row.standardAnnualHours ?? undefined,
+    };
+  }
+  return null;
+}
+
+// ─── Timesheet → payroll earnings ────────────────────────────────────────────
+
+export type EmployeePayrollEarningsResult =
+  | { ok: true; earnings: PayrollEarnings; approved: ApprovedTimesheetTotals; periodsCounted: number }
+  | { ok: false; reason: "no-employee" | "no-compensation" };
+
+/**
+ * The earnings side of an employee's payslip for a pay period, from APPROVED
+ * timesheets only: salaried staff get their fixed period pay; hourly staff get
+ * approved regular + overtime hours at their rates. Feed the result into
+ * computePayslip (lib/hr/payroll.ts) together with the statutory function.
+ */
+export async function getEmployeePayrollEarnings(
+  employeeProfileId: string,
+  periodStart: Date,
+  periodEnd: Date,
+  opts?: { periodsPerYear?: number; overtimeMultiplier?: number },
+): Promise<EmployeePayrollEarningsResult> {
+  const employee = await prisma.employeeProfile.findUnique({
+    where: { id: employeeProfileId },
+    select: { payType: true, hourlyRate: true, annualSalary: true, standardAnnualHours: true },
+  });
+  if (!employee) return { ok: false, reason: "no-employee" };
+
+  const comp = compensationFromEmployee(employee);
+  if (!comp) return { ok: false, reason: "no-compensation" };
+
+  const periods = await prisma.timesheetPeriod.findMany({
+    where: {
+      employeeProfileId,
+      status: "approved",
+      weekStarting: { gte: periodStart, lt: periodEnd },
+    },
+    select: { totalHours: true, overtimeHours: true },
+  });
+
+  const approved: ApprovedTimesheetTotals = {
+    totalHours: periods.reduce((t, p) => t + p.totalHours, 0),
+    overtimeHours: periods.reduce((t, p) => t + p.overtimeHours, 0),
+  };
+
+  return {
+    ok: true,
+    earnings: payrollEarningsFromTimesheet(comp, approved, opts),
+    approved,
+    periodsCounted: periods.length,
+  };
+}
+
+// ─── Billable time → draft invoice ───────────────────────────────────────────
+
+export type BillableInvoiceResult =
+  | {
+      generated: true;
+      invoiceId: string;
+      invoiceRef: string;
+      hoursBilled: number;
+      entriesBilled: number;
+      skipped: Array<{ entryId: string; reason: string }>;
+    }
+  | {
+      generated: false;
+      reason: "billable-time-disabled" | "nothing-to-bill";
+      skipped: Array<{ entryId: string; reason: string }>;
+    };
+
+/**
+ * Turn a customer's APPROVED, un-invoiced billable hours into a draft invoice.
+ *
+ * Gated by the org's financial profile: only labour archetypes carry
+ * billableTimeEnabled, so a retail/food/nonprofit install can never reach the
+ * billing path. Only entries whose timesheet period is approved qualify (unapproved
+ * time is neither payable nor billable). Entries priced into the invoice are
+ * stamped invoiceId/invoicedAt (guarded on invoiceId IS NULL) so hours can never be
+ * billed twice; entries with no resolvable rate are reported, never billed at zero.
+ */
+export async function generateInvoiceFromBillableTime(
+  customerAccountId: string,
+  opts?: { dueInDays?: number },
+): Promise<BillableInvoiceResult> {
+  const settings = await prisma.orgSettings.findFirst({
+    select: { appliedProfileSlug: true, baseCurrency: true },
+  });
+  const profile = settings?.appliedProfileSlug ? getFinancialProfile(settings.appliedProfileSlug) : null;
+  if (!profile?.billableTimeEnabled) {
+    return { generated: false, reason: "billable-time-disabled", skipped: [] };
+  }
+
+  const entries = await prisma.timesheetEntry.findMany({
+    where: {
+      customerAccountId,
+      billable: true,
+      billableHours: { gt: 0 },
+      invoiceId: null,
+      timesheetPeriod: { status: "approved" },
+    },
+    select: { id: true, date: true, billableHours: true, billableRateId: true },
+    orderBy: { date: "asc" },
+  });
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  const rateCard = org
+    ? await prisma.billableRate.findMany({
+        where: { organizationId: org.id, isActive: true },
+        select: { id: true, name: true, unit: true, billRate: true },
+      })
+    : [];
+
+  const priced = buildBillableInvoiceLines(
+    entries.map((e) => ({
+      id: e.id,
+      date: e.date,
+      billableHours: e.billableHours,
+      billableRateId: e.billableRateId,
+    })),
+    rateCard.map((r) => ({ id: r.id, name: r.name, unit: r.unit, billRate: Number(r.billRate) })),
+  );
+
+  if (priced.lines.length === 0) {
+    return { generated: false, reason: "nothing-to-bill", skipped: priced.skipped };
+  }
+
+  const dueInDays = opts?.dueInDays && opts.dueInDays > 0 ? opts.dueInDays : 14;
+  const dueDate = new Date(Date.now() + dueInDays * 24 * 60 * 60 * 1000);
+
+  const invoice = await createInvoice({
+    accountId: customerAccountId,
+    type: "standard",
+    dueDate: dueDate.toISOString(),
+    currency: settings?.baseCurrency ?? "GBP",
+    sourceType: "billable-time",
+    notes: `Billable time through ${new Date().toISOString().slice(0, 10)} (${priced.totalHours} hours).`,
+    lineItems: priced.lines.map((l) => ({
+      description: l.description,
+      quantity: l.quantity,
+      unitPrice: l.unitPrice,
+      taxRate: 0,
+      discountPercent: 0,
+    })),
+  });
+
+  // Stamp immediately after creation, guarded on invoiceId IS NULL, so the same
+  // hours can never be priced into a second invoice even under a concurrent run.
+  await prisma.timesheetEntry.updateMany({
+    where: { id: { in: priced.billedEntryIds }, invoiceId: null },
+    data: { invoiceId: invoice.id, invoicedAt: new Date() },
+  });
+
+  return {
+    generated: true,
+    invoiceId: invoice.id,
+    invoiceRef: invoice.invoiceRef,
+    hoursBilled: priced.totalHours,
+    entriesBilled: priced.billedEntryIds.length,
+    skipped: priced.skipped,
+  };
+}

--- a/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
+++ b/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
@@ -86,3 +86,35 @@ entry references a rate (or carries an override) and a customer; revenue = `bill
 **Non-negotiables:** cost rate vs bill rate stay distinct; salaried pay never varies with hours;
 billable is off entirely for non-labor archetypes; every downstream money movement rides the
 ledger/invoicing/payroll engines already merged — no parallel record.
+
+## 6. Phase 3 — the wiring, as built (delivered 2026-07-05)
+
+Phases 1 (#2598) and 2 (#2621) are merged. Phase 3 connects them:
+
+- **`lib/hr/labor-billing.ts` (pure, tested).**
+  - `payrollEarningsFromTimesheet(comp, approvedTotals, opts)` → the earnings side of a
+    `PayrollInput`: salary → fixed `baseSalary` (hours ignored); hourly → regular hours
+    (`totalHours − overtimeHours`, so overtime is never double-paid) at `hourlyRate` plus
+    overtime at `hourlyRate × multiplier` (default 1.5).
+  - `buildBillableInvoiceLines(entries, rateCard)` → one draft invoice line per rate-card
+    service (hours aggregated, date range in the description). Entries with no resolvable
+    rate or zero hours are **skipped and reported — never billed at £0**. Returns the
+    priced entry ids so the caller stamps exactly what was billed.
+- **`lib/hr/labor-service.ts` (Prisma).**
+  - `getEmployeePayrollEarnings(employeeId, from, to)` — compensation from
+    `EmployeeProfile` + **approved-only** `TimesheetPeriod` totals → payroll earnings;
+    feeds `computePayslip` with the org's statutory function.
+  - `generateInvoiceFromBillableTime(customerAccountId)` — **archetype-gated**
+    (`billableTimeEnabled` on the applied financial profile; disabled installs get a
+    typed refusal, not a hidden failure). Collects **approved, un-invoiced** billable
+    entries for the customer, prices them from the active `BillableRate` card, creates a
+    **draft invoice** via `createInvoice` (`sourceType: "billable-time"`; posts to the GL
+    through the existing invoice→GL path when sent), then stamps entries
+    `invoiceId`/`invoicedAt` guarded on `invoiceId IS NULL` — hours can never be billed
+    twice, even concurrently.
+- **Migration `20260705100000_billable_time_invoice_link`** — `TimesheetEntry.invoiceId`
+  / `invoicedAt` + index: the idempotency link between billed hours and their invoice.
+
+**Approval is the money gate on both flows:** unapproved time is neither payable nor
+billable. Phase 4 (UX: compensation on the employee record, rate-card admin, billable
+timesheet columns, generate-invoice action, margin view) remains.

--- a/packages/db/prisma/migrations/20260705100000_billable_time_invoice_link/migration.sql
+++ b/packages/db/prisma/migrations/20260705100000_billable_time_invoice_link/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "TimesheetEntry" ADD COLUMN     "invoiceId" TEXT,
+ADD COLUMN     "invoicedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "TimesheetEntry_invoiceId_idx" ON "TimesheetEntry"("invoiceId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -6894,11 +6894,14 @@ model TimesheetEntry {
   billableRateId    String?
   billable          Boolean         @default(false)
   billableHours     Float           @default(0)
+  invoiceId         String?
+  invoicedAt        DateTime?
   timesheetPeriod   TimesheetPeriod @relation(fields: [timesheetPeriodId], references: [id], onDelete: Cascade)
 
   @@unique([timesheetPeriodId, dayOfWeek])
   @@index([timesheetPeriodId])
   @@index([customerAccountId])
+  @@index([invoiceId])
 }
 
 model BillableRate {


### PR DESCRIPTION
Completes the wiring phase of labor economics (spec §6; Phases 1 #2598 and 2 #2621 merged): **approved timecard hours now feed the paycheck, and approved billable hours become a draft customer invoice** — archetype-gated, riding the payroll + invoicing + GL engines already on main.

## The two flows (approval is the money gate on both)

**Timesheet → payroll**
- `payrollEarningsFromTimesheet` (pure): salary → fixed period pay, hours ignored; hourly → regular hours (total − overtime, never double-paid) at rate + overtime at rate×1.5 (configurable).
- `getEmployeePayrollEarnings` (service): `EmployeeProfile` compensation + **approved-only** `TimesheetPeriod` totals → the earnings side of `PayrollInput`, ready for `computePayslip`.

**Billable time → invoice**
- `buildBillableInvoiceLines` (pure): one line per rate-card service, hours aggregated with a date range; entries with no resolvable rate or zero hours are **skipped and reported — never billed at £0**.
- `generateInvoiceFromBillableTime` (service): **gated on `billableTimeEnabled`** (labour archetypes only — a retail/nonprofit install gets a typed refusal); collects **approved, un-invoiced** billable entries for the customer, prices them from the active `BillableRate` card, creates a **draft invoice** (`sourceType: billable-time` → posts to the GL when sent), and stamps entries `invoiceId`/`invoicedAt` guarded on `invoiceId IS NULL` so **hours can never be billed twice**, even concurrently.

## Migration
`20260705100000_billable_time_invoice_link` — additive: `TimesheetEntry.invoiceId`/`invoicedAt` + index (the billed-hours↔invoice idempotency link).

## Verification
- `vitest run lib/hr` — **18/18 pass** (12 labor + 6 labor-billing).
- Standalone strict `tsc` on the pure trio (`labor.ts`, `payroll.ts`, `labor-billing.ts`) — clean.
- Prisma service is field-exact (incl. `CreateInvoiceInput` z.infer defaults); CI Typecheck is authoritative per AGENTS.md §5.

Remaining (Phase 4, filed in spec): UX — compensation on the employee record, rate-card admin, billable timesheet columns, generate-invoice action, margin view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)