### PR TITLE
feat(crm): parity quick wins — draft-quote UI, new-opportunity UI, structured contacts

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -9,6 +9,7 @@ import { CustomerLifecycleReviewQueues } from "@/components/customer/CustomerLif
 import { CustomerSiteTree } from "@/components/customer/CustomerSiteTree";
 import { NewCustomerSiteButton } from "@/components/customer/NewCustomerSiteButton";
 import { AccountLifecycleActions } from "@/components/customer/AccountLifecycleActions";
+import { AddContactButton } from "@/components/customer/AddContactButton";
 import { MergeCustomerAccountButton } from "@/components/customer/MergeCustomerAccountButton";
 import { UnmergeCustomerAccountButton } from "@/components/customer/UnmergeCustomerAccountButton";
 import { loadCustomerEstateSummary } from "@/lib/customer-estate/account-estate-summary";
@@ -357,10 +358,13 @@ export default async function AccountDetailPage({
         <div className="space-y-6">
           {/* Contacts */}
           <div>
-            <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest mb-3">
-              Contacts
-              <span className="ml-2 normal-case font-normal">{account.contacts.length}</span>
-            </h2>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest">
+                Contacts
+                <span className="ml-2 normal-case font-normal">{account.contacts.length}</span>
+              </h2>
+              <AddContactButton accountId={account.id} />
+            </div>
             <div className="space-y-2">
               {account.contacts.map((c) => (
                 <div

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { DraftQuoteButton } from "@/components/customer/DraftQuoteButton";
 import { PipelineStageInspector } from "@/components/customer/PipelineStageInspector";
 import { updateOpportunityStageFromForm } from "@/lib/actions/crm";
 import { getPipelineInspectorView } from "@/lib/crm/pipeline-inspector-data";
@@ -73,6 +74,16 @@ export default async function OpportunityDetailPage({
         <p className="text-[10px] font-mono text-[var(--dpf-muted)]">
           {opportunity.opportunityId}
         </p>
+        {!isClosed && (
+          <div className="mt-3">
+            <DraftQuoteButton
+              opportunityId={opportunity.id}
+              defaultDescription={opportunity.title}
+              defaultAmount={opportunity.expectedValue ? Number(opportunity.expectedValue) : null}
+              currency={opportunity.currency}
+            />
+          </div>
+        )}
       </div>
 
       <PipelineStageInspector

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/page.test.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/page.test.tsx
@@ -1,8 +1,9 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { findMany, getPipelineInspectorView } = vi.hoisted(() => ({
+const { findMany, accountFindMany, getPipelineInspectorView } = vi.hoisted(() => ({
   findMany: vi.fn(),
+  accountFindMany: vi.fn(),
   getPipelineInspectorView: vi.fn(),
 }));
 
@@ -11,7 +12,15 @@ vi.mock("@dpf/db", () => ({
     opportunity: {
       findMany,
     },
+    customerAccount: {
+      findMany: accountFindMany,
+    },
   },
+}));
+
+// NewOpportunityButton (client component in the page header) calls useRouter().
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 vi.mock("@/lib/actions/crm", () => ({
@@ -33,6 +42,7 @@ import OpportunitiesPage from "./page";
 describe("OpportunitiesPage", () => {
   beforeEach(() => {
     findMany.mockResolvedValue([]);
+    accountFindMany.mockResolvedValue([]);
     getPipelineInspectorView.mockResolvedValue(null);
   });
 

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import { EmptyPipelineGuidance } from "@/components/customer/EmptyPipelineGuidance";
+import { NewOpportunityButton } from "@/components/customer/NewOpportunityButton";
 import { PipelineStageInspector } from "@/components/customer/PipelineStageInspector";
 import { updateOpportunityStageFromForm } from "@/lib/actions/crm";
 import {
@@ -24,7 +25,7 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
   const sp = await searchParams;
   const requestedOpportunityId = sp?.opportunity;
   const view = parseSurfaceView(sp?.view);
-  const [opportunities, orgSettings] = await Promise.all([
+  const [opportunities, orgSettings, accounts] = await Promise.all([
     prisma.opportunity.findMany({
     orderBy: { createdAt: "desc" },
     include: {
@@ -34,6 +35,10 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
       },
     }),
     getOrgSettings(),
+    prisma.customerAccount.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    }),
   ]);
   const baseCurrency = orgSettings?.baseCurrency ?? "USD";
 
@@ -66,7 +71,8 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
 
   return (
     <div>
-      <div className="mb-6">
+      <div className="mb-6 flex items-start justify-between gap-3">
+        <div>
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Pipeline</h1>
         <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[10px]">
           <span className="text-[var(--dpf-muted)]">
@@ -84,6 +90,8 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
             </span>
           )}
         </div>
+        </div>
+        <NewOpportunityButton accounts={accounts} />
       </div>
 
       <PlatformGridSection entityType="opportunity" view={view} />

--- a/apps/web/components/customer/AddContactButton.tsx
+++ b/apps/web/components/customer/AddContactButton.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createCustomerContact } from "@/lib/actions/customer-contacts";
+import type { DedupCandidate } from "@/lib/mdm/dedup-gate";
+
+const inputClasses =
+  "bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-3 py-2 text-sm focus:border-[var(--dpf-accent)] focus:outline-none placeholder:text-[var(--dpf-muted)] w-full";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+// Structured contact capture on the account page. CustomerContact previously
+// had no create door anywhere in the UI, so contacts were parked in account
+// notes as free text.
+export function AddContactButton({ accountId }: { accountId: string }) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [jobTitle, setJobTitle] = useState("");
+  const [candidates, setCandidates] = useState<DedupCandidate[] | null>(null);
+
+  function reset() {
+    setFirstName(""); setLastName(""); setEmail(""); setPhone(""); setJobTitle("");
+    setCandidates(null); setError(null);
+  }
+
+  function submit(confirmNew: boolean) {
+    if (!firstName.trim() || !email.trim()) {
+      setError("First name and email are required.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      try {
+        const result = await createCustomerContact(
+          {
+            accountId,
+            firstName: firstName.trim(),
+            lastName: lastName.trim() || undefined,
+            email: email.trim(),
+            phone: phone.trim() || undefined,
+            jobTitle: jobTitle.trim() || undefined,
+          },
+          confirmNew ? { kind: "confirm-new", reason: "confirmed different person in Add contact" } : undefined,
+        );
+        if (result.outcome === "duplicates-found") {
+          setCandidates(result.check.candidates);
+          return;
+        }
+        reset();
+        setOpen(false);
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  if (!open) {
+    return (
+      <button
+        className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+        onClick={() => setOpen(true)}
+      >
+        + Add contact
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-label="Add contact">
+      <div className="w-full max-w-md rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+        <h2 className="mb-4 text-sm font-semibold text-[var(--dpf-text)]">Add contact</h2>
+
+        {candidates ? (
+          <div>
+            <p className="mb-2 text-sm text-[var(--dpf-text)]">
+              This looks similar to {candidates.length === 1 ? "an existing contact" : "existing contacts"}:
+            </p>
+            <ul className="mb-3 space-y-1">
+              {candidates.map((c) => (
+                <li key={c.id} className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]">
+                  {c.label}
+                  {c.detail && <span className="ml-2 text-xs text-[var(--dpf-muted)]">{c.detail}</span>}
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end gap-2">
+              <button className="px-3 py-1.5 text-sm text-[var(--dpf-muted)]" onClick={() => setCandidates(null)}>
+                Back
+              </button>
+              <button
+                className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                disabled={isPending}
+                onClick={() => submit(true)}
+              >
+                It&apos;s a different person — create
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelClasses}>First name *</label>
+                <input className={inputClasses} value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+              </div>
+              <div>
+                <label className={labelClasses}>Last name</label>
+                <input className={inputClasses} value={lastName} onChange={(e) => setLastName(e.target.value)} />
+              </div>
+            </div>
+            <div>
+              <label className={labelClasses}>Email *</label>
+              <input className={inputClasses} type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelClasses}>Phone</label>
+                <input className={inputClasses} value={phone} onChange={(e) => setPhone(e.target.value)} />
+              </div>
+              <div>
+                <label className={labelClasses}>Job title</label>
+                <input className={inputClasses} value={jobTitle} onChange={(e) => setJobTitle(e.target.value)} />
+              </div>
+            </div>
+            {error && <p className="text-xs text-red-400">{error}</p>}
+            <div className="flex justify-end gap-2">
+              <button className="px-3 py-1.5 text-sm text-[var(--dpf-muted)]" onClick={() => { reset(); setOpen(false); }}>
+                Cancel
+              </button>
+              <button
+                className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                disabled={isPending}
+                onClick={() => submit(false)}
+              >
+                {isPending ? "Adding…" : "Add contact"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/customer/DraftQuoteButton.tsx
+++ b/apps/web/components/customer/DraftQuoteButton.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createQuote } from "@/lib/actions/crm";
+
+const inputClasses =
+  "bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-3 py-2 text-sm focus:border-[var(--dpf-accent)] focus:outline-none placeholder:text-[var(--dpf-muted)] w-full";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+// Draft-quote control on the opportunity page — quote creation previously had
+// no UI door (coworker tool only). One line item covers the common case; more
+// lines can be added on the quote after drafting (reviseQuote).
+export function DraftQuoteButton({
+  opportunityId,
+  defaultDescription,
+  defaultAmount,
+  currency,
+}: {
+  opportunityId: string;
+  defaultDescription: string;
+  defaultAmount: number | null;
+  currency: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  const [description, setDescription] = useState(defaultDescription);
+  const [quantity, setQuantity] = useState("1");
+  const [unitPrice, setUnitPrice] = useState(defaultAmount ? String(defaultAmount) : "");
+
+  function submit() {
+    const qty = Number(quantity);
+    const price = Number(unitPrice);
+    if (!description.trim() || !Number.isFinite(qty) || qty <= 0 || !Number.isFinite(price) || price <= 0) {
+      setError("A description, quantity, and unit price are required.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      try {
+        const validUntil = new Date();
+        validUntil.setDate(validUntil.getDate() + 30);
+        const quote = await createQuote({
+          opportunityId,
+          validUntil: validUntil.toISOString(),
+          currency,
+          lineItems: [{ description: description.trim(), quantity: qty, unitPrice: price }],
+        });
+        setOpen(false);
+        router.push(`/customer/quotes/${quote.id}`);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  if (!open) {
+    return (
+      <button
+        className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+        onClick={() => setOpen(true)}
+      >
+        Draft quote
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-label="Draft quote">
+      <div className="w-full max-w-md rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+        <h2 className="mb-1 text-sm font-semibold text-[var(--dpf-text)]">Draft quote</h2>
+        <p className="mb-4 text-xs text-[var(--dpf-muted)]">
+          Valid for 30 days. You can revise line items on the quote afterwards.
+        </p>
+        <div className="space-y-3">
+          <div>
+            <label className={labelClasses}>Line item description *</label>
+            <input className={inputClasses} value={description} onChange={(e) => setDescription(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>Quantity *</label>
+              <input className={inputClasses} type="number" min="1" value={quantity} onChange={(e) => setQuantity(e.target.value)} />
+            </div>
+            <div>
+              <label className={labelClasses}>Unit price ({currency}) *</label>
+              <input className={inputClasses} type="number" min="0" value={unitPrice} onChange={(e) => setUnitPrice(e.target.value)} />
+            </div>
+          </div>
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <button className="px-3 py-1.5 text-sm text-[var(--dpf-muted)]" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+            <button
+              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              disabled={isPending}
+              onClick={submit}
+            >
+              {isPending ? "Drafting…" : "Create draft quote"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/customer/NewOpportunityButton.tsx
+++ b/apps/web/components/customer/NewOpportunityButton.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createOpportunity } from "@/lib/actions/crm";
+
+const inputClasses =
+  "bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-3 py-2 text-sm focus:border-[var(--dpf-accent)] focus:outline-none placeholder:text-[var(--dpf-muted)] w-full";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+// + New Opportunity on the Pipeline tab — opportunity creation previously had
+// no UI door (coworker tool only). Defaults: qualification stage, GBP.
+export function NewOpportunityButton({
+  accounts,
+}: {
+  accounts: Array<{ id: string; name: string }>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  const [accountId, setAccountId] = useState(accounts[0]?.id ?? "");
+  const [title, setTitle] = useState("");
+  const [expectedValue, setExpectedValue] = useState("");
+
+  function submit() {
+    if (!accountId || !title.trim()) {
+      setError("An account and a title are required.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      try {
+        const value = Number(expectedValue);
+        await createOpportunity({
+          title: title.trim(),
+          accountId,
+          expectedValue: Number.isFinite(value) && value > 0 ? value : undefined,
+          currency: "GBP",
+        });
+        setTitle("");
+        setExpectedValue("");
+        setOpen(false);
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  if (!open) {
+    return (
+      <button
+        className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+        onClick={() => setOpen(true)}
+      >
+        + New Opportunity
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-label="New opportunity">
+      <div className="w-full max-w-md rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+        <h2 className="mb-4 text-sm font-semibold text-[var(--dpf-text)]">New opportunity</h2>
+        <div className="space-y-3">
+          <div>
+            <label className={labelClasses}>Account *</label>
+            <select className={inputClasses} value={accountId} onChange={(e) => setAccountId(e.target.value)}>
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClasses}>Title *</label>
+            <input
+              className={inputClasses}
+              placeholder="e.g. Acme — DPF managed instance & support"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className={labelClasses}>Expected value (GBP)</label>
+            <input className={inputClasses} type="number" min="0" value={expectedValue} onChange={(e) => setExpectedValue(e.target.value)} />
+          </div>
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <button className="px-3 py-1.5 text-sm text-[var(--dpf-muted)]" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+            <button
+              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              disabled={isPending}
+              onClick={submit}
+            >
+              {isPending ? "Creating…" : "Create opportunity"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/customer-contacts.test.ts
+++ b/apps/web/lib/actions/customer-contacts.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const { checkMock } = vi.hoisted(() => ({ checkMock: vi.fn() }));
+vi.mock("@/lib/mdm/dedup-gate", () => ({
+  checkCustomerContactDuplicates: checkMock,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    customerAccount: { findUnique: vi.fn() },
+    customerContact: { findUnique: vi.fn(), create: vi.fn() },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { createCustomerContact } from "./customer-contacts";
+
+const p = prisma as unknown as {
+  customerAccount: { findUnique: ReturnType<typeof vi.fn> };
+  customerContact: { findUnique: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  p.customerAccount.findUnique.mockResolvedValue({ id: "a1", name: "Emma3D" });
+  p.customerContact.findUnique.mockResolvedValue(null);
+  checkMock.mockResolvedValue({ verdict: "clear", candidates: [] });
+});
+
+describe("createCustomerContact", () => {
+  it("creates a contact with normalized identity fields", async () => {
+    p.customerContact.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "c1", ...data }));
+    const result = await createCustomerContact({
+      accountId: "a1",
+      firstName: "Ian",
+      lastName: "Pruden",
+      email: "Ian@Emma3D.com",
+      phone: "0123",
+      jobTitle: "Founder",
+    });
+    expect(result.outcome).toBe("created");
+    const data = p.customerContact.create.mock.calls[0][0].data;
+    expect(data.email).toBe("ian@emma3d.com"); // lowercased identity key
+    expect(data.name).toBe("Ian Pruden");
+    expect(data.nameNormalized.length).toBeGreaterThan(0);
+    expect(data.source).toBe("manual");
+  });
+
+  it("returns the existing contact on exact email match (never duplicates)", async () => {
+    p.customerContact.findUnique.mockResolvedValue({ id: "existing", email: "ian@emma3d.com" });
+    const result = await createCustomerContact({ accountId: "a1", firstName: "Ian", email: "ian@emma3d.com" });
+    expect(result.outcome).toBe("existing");
+    expect(p.customerContact.create).not.toHaveBeenCalled();
+  });
+
+  it("surfaces near-duplicates for a decision instead of silently creating", async () => {
+    checkMock.mockResolvedValue({
+      verdict: "possible-duplicate",
+      candidates: [{ id: "c9", label: "Ian Prudden", detail: "ianp@emma3d.com" }],
+    });
+    const result = await createCustomerContact({ accountId: "a1", firstName: "Ian", email: "new@emma3d.com" });
+    expect(result.outcome).toBe("duplicates-found");
+    expect(p.customerContact.create).not.toHaveBeenCalled();
+  });
+
+  it("confirm-new bypasses the near-duplicate check and creates", async () => {
+    p.customerContact.create.mockResolvedValue({ id: "c1" });
+    const result = await createCustomerContact(
+      { accountId: "a1", firstName: "Ian", email: "new@emma3d.com" },
+      { kind: "confirm-new", reason: "different person" },
+    );
+    expect(result.outcome).toBe("created");
+    expect(checkMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on a missing account", async () => {
+    p.customerAccount.findUnique.mockResolvedValue(null);
+    await expect(
+      createCustomerContact({ accountId: "nope", firstName: "Ian", email: "x@y.com" }),
+    ).rejects.toThrow(/not found/i);
+  });
+});

--- a/apps/web/lib/actions/customer-contacts.ts
+++ b/apps/web/lib/actions/customer-contacts.ts
@@ -1,0 +1,90 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import {
+  checkCustomerContactDuplicates,
+  type DedupCheckResult,
+  type DedupResolution,
+} from "@/lib/mdm/dedup-gate";
+import { standardizeName } from "@/lib/mdm/standardize";
+
+// Structured contact capture (BI-D873CD28). CustomerContact existed as a model
+// but was unreachable from the CRM surface — no create action, no coworker
+// tool, no UI button — so real contacts (Ian Pruden, Dan Warfield) ended up as
+// free-text in account notes. This is the missing create door, gated by the
+// MDM write-time dedup check like createCustomerAccount (EP-4A12A7CB).
+
+export type CreateCustomerContactResult =
+  | { outcome: "created"; contact: Awaited<ReturnType<typeof prisma.customerContact.create>> }
+  | { outcome: "existing"; contact: Awaited<ReturnType<typeof prisma.customerContact.create>> }
+  | { outcome: "duplicates-found"; check: DedupCheckResult };
+
+export async function createCustomerContact(
+  input: {
+    accountId: string;
+    firstName: string;
+    lastName?: string;
+    email: string;
+    phone?: string;
+    jobTitle?: string;
+    notes?: string;
+  },
+  dedup?: DedupResolution,
+): Promise<CreateCustomerContactResult> {
+  const account = await prisma.customerAccount.findUnique({
+    where: { id: input.accountId },
+    select: { id: true, name: true },
+  });
+  if (!account) throw new Error("Account not found");
+
+  const email = input.email.trim().toLowerCase();
+  if (!email) throw new Error("Email is required for a contact");
+  const firstName = input.firstName.trim();
+  if (!firstName) throw new Error("First name is required");
+  const lastName = input.lastName?.trim() || undefined;
+
+  // Email is the identity key — an exact match is always "use existing".
+  const existing = await prisma.customerContact.findUnique({ where: { email } });
+  if (existing) {
+    return { outcome: "existing", contact: existing };
+  }
+
+  if (dedup?.kind === "use-existing") {
+    const chosen = await prisma.customerContact.findUnique({ where: { id: dedup.existingId } });
+    if (!chosen) throw new Error("Selected existing contact not found");
+    return { outcome: "existing", contact: chosen };
+  }
+
+  if (dedup?.kind !== "confirm-new") {
+    const check = await checkCustomerContactDuplicates({
+      firstName,
+      lastName: lastName ?? null,
+      email,
+      phone: input.phone ?? null,
+      accountId: input.accountId,
+    });
+    if (check.verdict !== "clear") {
+      return { outcome: "duplicates-found", check };
+    }
+  }
+
+  const displayName = [firstName, lastName].filter(Boolean).join(" ");
+  const contact = await prisma.customerContact.create({
+    data: {
+      accountId: input.accountId,
+      email,
+      firstName,
+      lastName: lastName ?? null,
+      name: displayName,
+      nameNormalized: standardizeName(displayName),
+      phone: input.phone?.trim() || null,
+      jobTitle: input.jobTitle?.trim() || null,
+      source: "manual",
+    },
+  });
+
+  revalidatePath(`/customer/${input.accountId}`);
+  revalidatePath("/customer");
+  return { outcome: "created", contact };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -49,6 +49,7 @@ import { workCapturePack } from "@/lib/mcp/packs/work-capture-pack";
 import { orgDecisionPack } from "@/lib/mcp/packs/org-decision-pack";
 import { activityRoutingPack } from "@/lib/mcp/packs/activity-routing-pack";
 import { mdmStewardshipPack } from "@/lib/mcp/packs/mdm-stewardship-pack";
+import { crmContactsPack } from "@/lib/mcp/packs/crm-contacts-pack";
 import { selfUpgradePack } from "@/lib/mcp/packs/self-upgrade-pack";
 import { coworkerServiceCatalogPack } from "@/lib/mcp/packs/coworker-service-catalog-pack";
 import { coworkerToolGrantPack } from "@/lib/mcp/packs/coworker-tool-grant-pack";
@@ -438,7 +439,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, mdmStewardshipPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, mdmStewardshipPack, crmContactsPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,

--- a/apps/web/lib/mcp/packs/crm-contacts-pack.test.ts
+++ b/apps/web/lib/mcp/packs/crm-contacts-pack.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { crmContactsPack } from "./crm-contacts-pack";
+import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
+
+describe("crm-contacts pack", () => {
+  it("registers create_customer_contact with an operate_customer capability and side-effect flag", () => {
+    const def = crmContactsPack.definitions.find((d) => d.name === "create_customer_contact");
+    expect(def).toBeDefined();
+    expect(def!.requiredCapability).toBe("operate_customer");
+    expect(def!.sideEffect).toBe(true);
+    expect(def!.coworkerArtifact).toBe(true);
+    expect(crmContactsPack.handlers.create_customer_contact).toBeTypeOf("function");
+  });
+
+  it("gates the tool behind crm_write so the CSM's grant set covers it", () => {
+    expect(crmContactsPack.grants.create_customer_contact).toEqual(["crm_write"]);
+    expect(isToolAllowedByGrants("create_customer_contact", ["crm_write"])).toBe(true);
+    expect(isToolAllowedByGrants("create_customer_contact", ["crm_read"])).toBe(false);
+    expect(isToolAllowedByGrants("create_customer_contact", ["backlog_write"])).toBe(false);
+  });
+
+  it("keeps the tool description provenance-free (no BI/phase/source-path leakage)", () => {
+    const def = crmContactsPack.definitions[0]!;
+    expect(def.description).not.toMatch(/BI-|Phase \d|apps\/web|EP-/);
+  });
+});

--- a/apps/web/lib/mcp/packs/crm-contacts-pack.ts
+++ b/apps/web/lib/mcp/packs/crm-contacts-pack.ts
@@ -1,0 +1,97 @@
+// CRM contacts pack (BI-D873CD28, EP-B51FA3BC). Gives the Customer Success
+// Manager a structured-contact door: before this, CustomerContact was a full
+// model but unreachable — no tool existed, so the coworker parked real people
+// ("Ian Pruden — email to be added") in free-text account notes.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "create_customer_contact",
+    description:
+      "Add a person as a structured contact on an existing customer account (from list_customer_accounts). " +
+      "Email is required and is the contact's unique identity — if a contact with that email already exists, " +
+      "it is returned instead of duplicated. Near-duplicates (same name/phone) are surfaced for a decision. " +
+      "Use this instead of stashing contact details in account notes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        accountId: { type: "string", description: "CustomerAccount.id the contact belongs to." },
+        firstName: { type: "string", description: "First name." },
+        lastName: { type: "string", description: "Last name (optional)." },
+        email: { type: "string", description: "Email — the contact's unique identity key." },
+        phone: { type: "string", description: "Optional phone number." },
+        jobTitle: { type: "string", description: "Optional job title." },
+        confirmNew: {
+          type: "boolean",
+          description:
+            "Set true ONLY after the employee confirms a flagged near-duplicate really is a different person.",
+        },
+      },
+      required: ["accountId", "firstName", "email"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+    coworkerArtifact: true,
+  },
+];
+
+async function createCustomerContactTool(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const { createCustomerContact } = await import("@/lib/actions/customer-contacts");
+  const str = (k: string) => (typeof params[k] === "string" ? (params[k] as string) : undefined);
+  const accountId = str("accountId");
+  const firstName = str("firstName");
+  const email = str("email");
+  if (!accountId || !firstName || !email) {
+    return { success: false, error: "accountId, firstName, and email are required.", message: "accountId, firstName, and email are required." };
+  }
+
+  const result = await createCustomerContact(
+    {
+      accountId,
+      firstName,
+      lastName: str("lastName"),
+      email,
+      phone: str("phone"),
+      jobTitle: str("jobTitle"),
+    },
+    params["confirmNew"] === true
+      ? { kind: "confirm-new", reason: "employee confirmed different person via coworker" }
+      : undefined,
+  );
+
+  if (result.outcome === "duplicates-found") {
+    return {
+      success: false,
+      message:
+        "Possible duplicate contact(s) found — ask the employee whether one of these is the same person: " +
+        result.check.candidates.map((c) => `${c.label}${c.detail ? ` (${c.detail})` : ""}`).join("; ") +
+        ". If they confirm it's a different person, call again with confirmNew=true.",
+      data: { candidates: result.check.candidates } as unknown as Record<string, unknown>,
+    };
+  }
+
+  const c = result.contact;
+  return {
+    success: true,
+    message:
+      result.outcome === "existing"
+        ? `Contact already exists: ${c.name ?? c.email} (${c.email}).`
+        : `Created contact ${c.name ?? c.email} (${c.email}).`,
+    data: { id: c.id, email: c.email, name: c.name, outcome: result.outcome },
+  };
+}
+
+export const crmContactsPack: ToolPack = {
+  packId: "crm-contacts",
+  definitions,
+  handlers: {
+    create_customer_contact: createCustomerContactTool,
+  },
+  grants: {
+    create_customer_contact: ["crm_write"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -460,6 +460,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   get_opportunity:        ["crm_read"],
   list_quotes:            ["crm_read"],
   create_customer_account: ["crm_write"],
+  create_customer_contact: ["crm_write"],
   create_opportunity:      ["crm_write"],
   create_quote:            ["crm_write"],
   // Merging duplicates is customer-data stewardship: heavier than drafting,

--- a/docs/superpowers/plans/2026-07-05-crm-parity-quickwins-plan.md
+++ b/docs/superpowers/plans/2026-07-05-crm-parity-quickwins-plan.md
@@ -1,0 +1,39 @@
+# Plan — CRM parity quick wins: draft-quote UI, new-opportunity UI, structured contacts
+
+Date: 2026-07-05. Epic: EP-B51FA3BC (Sales/CRM market parity). BIs: BI-7FF2064C, BI-024FF1C2, BI-D873CD28.
+
+## Why
+
+The E2E engagement demo (Emma3D/Ian, Managing Digital/Dan — PRs #2596/#2609) left three
+concrete gaps, all confirmed by market research (Salesforce fidelity reference + loved-CRM
+sweep): quote creation and opportunity creation are coworker-only doors (no deterministic UI),
+and contacts have NO create door at all — real people end up as free-text in account notes,
+even though CustomerContact is a full model with the MDM dedup gate already supporting a
+`customer-contact` domain.
+
+## Scope (one PR, three slices)
+
+1. **BI-D873CD28 — structured contacts**
+   - `apps/web/lib/actions/customer-contacts.ts`: `createCustomerContact` — email-unique
+     identity, MDM dedup-gated (checkCustomerContactDuplicates), `use-existing`/`confirm-new`
+     resolutions, source="manual".
+   - `apps/web/lib/mcp/packs/crm-contacts-pack.ts`: `create_customer_contact` coworker tool
+     (grant `crm_write`) so the CSM can capture a contact conversationally.
+   - `AddContactButton` on the account detail page (dialog + duplicate picker, mirroring
+     NewCustomerButton).
+2. **BI-7FF2064C — Draft quote button** on the opportunity detail page: dialog (line-item
+   description/qty/unit price defaulted from the opportunity, valid-until default +30d)
+   calling the existing `createQuote`.
+3. **BI-024FF1C2 — + New Opportunity button** on the Pipeline tab: dialog (account select,
+   title, expected value/currency) calling the existing `createOpportunity`.
+
+## Non-goals
+
+Leads (BI-7906DAC0), recurring billing (BI-8681E93C), quote external delivery (BI-8E45CCA3),
+and the research-driven delight slices (activity auto-capture, deal rotting, next-step loop)
+— all tracked separately under EP-B51FA3BC pending the research synthesis BI-00FBDC20.
+
+## Verification
+
+Unit tests per action/pack; existing page tests extended where rendering changes; deploy via
+self-upgrade; then drive by clicks on the live portal against the two real customers.

--- a/docs/superpowers/specs/2026-07-06-sales-crm-parity-delight-gap-matrix.md
+++ b/docs/superpowers/specs/2026-07-06-sales-crm-parity-delight-gap-matrix.md
@@ -1,0 +1,80 @@
+# Sales/CRM parity + delight gap matrix — research synthesis and build order
+
+Date: 2026-07-06. Epic: EP-B51FA3BC. BI: BI-00FBDC20.
+Inputs: five research tracks — Salesforce Sales Cloud functional reference (fidelity bar);
+loved-mechanics sweeps of Pipedrive/Close, HubSpot (+Salesforce anti-patterns),
+Salesloft/Outreach/Clay, Attio/Folk/Copper, and a dark-horse community sweep
+(Less Annoying CRM, Streak, Bigin, Nutshell, Kommo, Day.ai).
+
+## The one-sentence thesis
+
+Every loved sales tool wins the same inversion: **the CRM records itself as a byproduct of
+the rep's real work and gives something back immediately** (open-notification, next-step
+prompt, prioritized queue), while Salesforce is hated where it makes the rep pay a data-entry
+and click tax to feed management dashboards. DPF's AI-coworker motion is natively positioned
+for this inversion — the coworker IS the auto-capture and next-step engine — so parity means
+matching Salesforce's *functional* essence (objects + lifecycle mechanics) while shipping the
+delight mechanics the incumbents bolt on.
+
+## Fidelity bar — table stakes vs DPF today
+
+| Capability (Salesforce essence) | DPF state | Evidence / gap |
+|---|---|---|
+| Account + status lifecycle | **EXISTS** | CustomerAccount prospect→active…closed; convert button (PR #2609) |
+| Contacts (email identity, account FK) | **EXISTS** (as of #2629) | createCustomerContact + tool + UI; MDM dedup-gated |
+| Opportunity w/ stage machine {open/won/lost, probability} | **EXISTS (PARTIAL)** | stages+probability+kanban exist; no forecast-category axis, no contact roles |
+| Line items / product catalog / price books | **PARTIAL** | QuoteLineItem.productId → DigitalProduct exists; no price books, list-vs-sale price, or product picker in the quote UI |
+| Quote lifecycle (draft→sent→accepted, versioning) | **EXISTS** | createQuote/reviseQuote/sendQuote/acceptQuote + UI buttons |
+| Order mirroring accepted quote | **EXISTS** | SalesOrder auto-created on accept |
+| Invoice + payment + GL | **EXISTS** | exceeds bar (double-entry GL posting) |
+| Contract w/ term + renewal notice | **EXISTS (PARTIAL)** | Subscription (renewalDate, autoRenew); no renewal invoice materialization (BI-8681E93C), no amendments |
+| **Lead + convert flow** | **MISSING** | BI-7906DAC0; check Engagement/acquisition-signal substrate first — it is the lead-shaped thing DPF already has |
+| Activity mgmt (tasks/events, who/what, open vs history, follow-ups) | **PARTIAL** | Activity model + timeline exist; no open-task queue, no follow-up prompt, no auto-capture |
+| Campaign → attribution | **PARTIAL** | marketing workspace + funnel exist; no campaign-member/response semantics, single-touch attribution absent |
+| Lead/opportunity assignment (rules, queues, round robin) | **MISSING** | single-operator installs today; needed for multi-rep orgs |
+| Weighted pipeline (amount × probability) | **EXISTS** | Pipeline tab shows total + weighted |
+| Forecast categories + quota rollups | **MISSING** | funnel ≠ forecast; defer past delight slices (SF-mid tier) |
+| Discount-threshold approval on quotes | **MISSING** | approval-process substrate exists elsewhere in DPF (governance); defer |
+| Cases/service tickets vs account | **PARTIAL** | ServiceTicket exists; serviceAgreementId soft-FK unbacked → tie to Subscription |
+
+Explicitly NOT gaps (Salesforce-enterprise complexity to skip): opportunity splits, territory
+management, multi-touch campaign influence models, person accounts, product schedules,
+reduction orders, CPQ machinery.
+
+## Delight bar — the mechanics people love, ranked for DPF
+
+1. **Auto-capture / "the CRM records itself"** (Close, Copper, Attio, HubSpot, Day.ai — and
+   the #1 Salesforce hate inverted). DPF angle: every coworker conversation already touches
+   the record — auto-log coworker interactions as Activities; later email/calendar sync.
+2. **Always-a-next-step loop** (Pipedrive's done-activity→schedule-next prompt + no-next-step
+   warning on deal cards). Cheap: Opportunity.nextActivityAt + pipeline-card warning + the
+   coworker prompting for the next step whenever it completes one.
+3. **Deal rotting / staleness as ambient visual state** (Pipedrive's red tiles; zero reports
+   needed). Cheap: per-stage inactivity threshold → tile tint on the kanban; pairs with the
+   existing isDormant flag.
+4. **Prioritized daily queue with a "why"** (Close Inbox, Salesloft Rhythm's explained
+   next-best-action). DPF angle: the coworker composes this from rotting deals, due
+   follow-ups, renewal dates — an "engagement inbox" card on /customer.
+5. **Email tracking + one-click scheduler** (HubSpot's hook features). Bigger lift (needs
+   email infra); defer behind quote-delivery BI-8E45CCA3 which builds the send rail.
+6. **Enrichment on capture** (Attio/Clay/Folk). The CSM already holds web_search — prompt it
+   to enrich accounts (website/industry) on create; structured waterfall enrichment later.
+7. **Anti-patterns to hold as constraints**: no required-field ambushes, minimal clicks
+   (inline edits), no admin-priesthood config, price/complexity honesty, fast pages.
+
+## Build order (value ÷ effort, after #2629)
+
+1. **BI-8681E93C** recurring billing + renewal lifecycle (completes the contract story; reuse
+   RecurringSchedule/work-capture expander).
+2. **NEW: next-step loop + deal rotting** (delight mechanics #2+#3 — small schema touch:
+   nextActivityAt; kanban tint; coworker prompt).
+3. **BI-7906DAC0** lead/triage flow grounded in the Engagement substrate (fidelity gap that
+   also unlocks funnel top).
+4. **NEW: engagement inbox** — prioritized "work these now" queue w/ reasons (delight #4).
+5. **BI-8E45CCA3** quote delivery + e-sign accept (reuses invoice rails; unlocks email
+   mechanics later).
+6. **NEW: coworker auto-activity capture** — log coworker-performed actions as Activities on
+   the records they touch (delight #1, DPF-native form).
+7. Products/price-book picker on quotes; contact roles; assignment rules — as follow-ups.
+
+Items marked NEW to be filed as BIs under EP-B51FA3BC when their slice starts.

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -42,7 +42,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16472,
+  "apps/web/lib/mcp-tools.ts": 16473,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1183,

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -25,7 +25,7 @@
   "apps/web/lib/actions/compliance.ts": 1064,
   "apps/web/lib/actions/crm.ts": 1408,
   "apps/web/lib/actions/ea.ts": 1055,
-  "apps/web/lib/actions/hive-scout/ingest-500-agents.ts": 971,
+  "apps/web/lib/actions/hive-scout/ingest-500-agents.ts": 1005,
   "apps/web/lib/actions/mcp-tokens.test.ts": 1254,
   "apps/web/lib/actions/platform-dev-config.ts": 1330,
   "apps/web/lib/actions/promotions.self-upgrade.test.ts": 1021,


### PR DESCRIPTION
## Why

First build slice of **EP-B51FA3BC** (Sales/CRM market parity). The E2E engagement demo (Emma3D/Ian, Managing Digital/Dan) left three concrete gaps, and the market research confirmed all three are table stakes (Salesforce fidelity reference) while the loved-CRM sweep showed deterministic low-click controls are what make sales tools enjoyable vs model-dependent paths:

- **BI-D873CD28** — contacts had NO create door anywhere: `CustomerContact` is a full model (email-unique, MDM dedup domain already defined) but real people ended up as free-text in account notes.
- **BI-7FF2064C** — quote creation was a coworker-only door (no UI button).
- **BI-024FF1C2** — opportunity creation was a coworker-only door (no UI button on the Pipeline tab).

## What

**Structured contacts**
- `createCustomerContact` action: email is the unique identity (exact match → returns existing, never duplicates); near-duplicates surface via the MDM write-time dedup gate with `use-existing`/`confirm-new` resolutions; name normalized for pg_trgm matching.
- New `crm-contacts` tool pack: `create_customer_contact` (grant `crm_write`, capability `operate_customer`, provenance-free description) — the CSM can now capture contacts conversationally instead of stashing them in notes.
- `+ Add contact` button on the account page with a one-decision duplicate picker.

**Draft quote** on the opportunity detail page — one line item defaulted from the opportunity title/value, 30-day validity, navigates to the quote page where the existing send/accept controls take over. Hidden on closed opportunities.

**+ New Opportunity** on the Pipeline tab — account select, title, optional expected value, qualification default.

With these, every stage of the engagement chain has a deterministic UI door: account → contact → opportunity → quote → accept (order+invoice) → payment → convert → support contract.

## Tests

Action tests (identity normalization, exact-email short-circuit, near-duplicate surfacing, confirm-new bypass, missing account), pack tests (capability + grant gating, description hygiene), existing quote-page/CRM-grant suites green. Ratchet guards green (module-size baseline folds main drift per convention).

UX-Fit-Decision: each control is a single button opening one small dialog with 2-5 plain fields, defaults derived from the record in view; duplicate resolution is a one-decision picker consistent with the existing + New Account pattern.

## Deploy

Rides the next self-upgrade (no migration; new tool reaches coworkers via the pack registry — grants already held). Verified next by driving Ian/Dan's records live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)