### PR TITLE
fix(dpf-skill-pack): standalone updater crashes on macOS system Python 3.9 (BI-D3C3E59D)

### DIFF
--- a/.github/workflows/agent-toolchain-bootstrap-smoke.yml
+++ b/.github/workflows/agent-toolchain-bootstrap-smoke.yml
@@ -22,6 +22,7 @@ on:
     branches: [main]
     paths:
       - "packages/dpf-bootstrap/**"
+      - "packages/dpf-skill-pack/scripts/**"
       - "scripts/dpf-bootstrap-agent-toolchain.sh"
       - "scripts/ensure-dpf-skill-pack.sh"
       - "scripts/installer/lib/state.sh"
@@ -31,6 +32,7 @@ on:
     branches: [main]
     paths:
       - "packages/dpf-bootstrap/**"
+      - "packages/dpf-skill-pack/scripts/**"
       - "scripts/dpf-bootstrap-agent-toolchain.sh"
       - "scripts/ensure-dpf-skill-pack.sh"
       - "scripts/installer/lib/state.sh"
@@ -68,6 +70,11 @@ jobs:
 
       - name: Vitest (planning library + bridge + probes)
         run: pnpm --filter @dpf/bootstrap test
+
+      - name: Standalone skill-pack updater tests (fallback path)
+        # The runner's python3 is 3.12+, so the tomllib-gated suites run here;
+        # the Python-3.9 compatibility locks are version-independent.
+        run: python3 -m unittest discover -s packages/dpf-skill-pack/scripts -p "*_test.py" -v
 
       - name: Typecheck planning library
         run: pnpm --filter @dpf/bootstrap typecheck

--- a/docs/install/platform-support-watchlist.md
+++ b/docs/install/platform-support-watchlist.md
@@ -57,13 +57,16 @@ roadmap before touching any host exporter.
 ## 2. Shell scripts (BSD vs GNU coreutils)
 
 macOS ships BSD userland; Linux ships GNU. The installer targets **bash 3.2**
-(stock macOS) — no associative arrays, `mapfile`, or `${var^^}`.
+and **python3 3.9** (stock macOS) — no associative arrays, `mapfile`, or
+`${var^^}` in bash; no Python-3.10+-only stdlib kwargs or syntax in scripts the
+bootstrap runs with the system interpreter.
 
 | # | Trap | Platforms | Status | Watch for |
 |---|---|---|---|---|
 | S1 | `sed -i` differs (BSD requires a backup-suffix arg) | macOS | ✅ Use `dpf_sed_inplace()` in [`scripts/installer/lib/platform.sh`](../../scripts/installer/lib/platform.sh) — never raw `sed -i`. | New scripts calling `sed -i` directly. |
 | S2 | `netstat -anP tcp` (`-P` is GNU-only) | macOS | 📌 Works today only because `preflight.sh` tries `lsof` → `ss` → `netstat` and macOS always has `lsof`. | Don't reorder the fallback chain or hardcode `netstat -anP`. |
 | S3 | `readlink -f`, `stat -c`, `date -d`, `find -printf`, `grep -P` | macOS | ⚠️ watch | These GNU-isms have no BSD equivalent. Prefer POSIX forms; `shellcheck --shell=bash` runs in CI. |
+| S4 | `Path.write_text(newline="\n")` raises `TypeError: unexpected keyword argument` — the kwarg was added in Python 3.10 | macOS (system python3 can be 3.9) | ✅ `packages/dpf-skill-pack/scripts/update_agent_toolchain.py` writes bytes (`write_bytes(content.encode("utf-8"))`) to keep LF endings; crashed `dpf-bootstrap-agent-toolchain.sh` during `ensure_codex_marketplace`. Locked by `update_agent_toolchain_test.py`. | Any Python invoked via bare `python3` from installer/bootstrap scripts must run on 3.9: no `match`, no `tomllib` (3.11+, test-only), no 3.10+ stdlib kwargs. CI runs 3.11+, so a 3.9 break won't show there — check `docs.python.org` "Changed in version" notes when touching these scripts. |
 
 ## 3. Docker / Compose
 

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -54,7 +54,10 @@ def write_text_if_changed(path: Path, content: str) -> bool:
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists() and path.read_text(encoding="utf-8") == content:
         return False
-    path.write_text(content, encoding="utf-8", newline="\n")
+    # Path.write_text() only grew its newline= kwarg in Python 3.10; the
+    # bootstrap runs this script with the system python3, which is 3.9 on
+    # stock macOS. Write bytes so LF endings survive on every platform.
+    path.write_bytes(content.encode("utf-8"))
     return True
 
 

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -1,17 +1,61 @@
 import json
 import os
 import tempfile
-import tomllib
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 import sys
 
+# tomllib is 3.11+; the updater itself must run on the system python3, which
+# is 3.9 on stock macOS. Keep the suite importable there so the regression
+# tests below run on the interpreter that actually ships with the platform.
+try:
+    import tomllib
+except ImportError:  # Python < 3.11
+    tomllib = None
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import update_agent_toolchain as updater
 
 
+class WriteTextIfChangedTest(unittest.TestCase):
+    def test_writes_lf_bytes_and_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "nested" / "settings.json"
+            self.assertTrue(updater.write_text_if_changed(target, '{"a": 1}\n'))
+            self.assertEqual(target.read_bytes(), b'{"a": 1}\n')
+            self.assertFalse(updater.write_text_if_changed(target, '{"a": 1}\n'))
+            self.assertTrue(updater.write_text_if_changed(target, '{"a": 2}\n'))
+            self.assertEqual(target.read_bytes(), b'{"a": 2}\n')
+
+    def test_no_python310_only_write_text_newline_kwarg(self) -> None:
+        # Regression: Path.write_text(newline=...) requires Python 3.10, but
+        # scripts/dpf-bootstrap-agent-toolchain.sh runs this script with the
+        # system python3 — 3.9 on stock macOS — where it raises TypeError.
+        source = Path(updater.__file__).read_text(encoding="utf-8")
+        self.assertNotRegex(source, r"write_text\([^)]*newline\s*=")
+
+    def test_main_converges_on_system_python(self) -> None:
+        # End-to-end repro of the macOS 3.9 crash: ensure_codex_marketplace
+        # -> write_json -> write_text_if_changed raised TypeError. No tomllib
+        # here so this test runs on 3.9 where the other suites must skip.
+        skill_pack = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"DPF_AGENT_TOOLCHAIN_HOME": tmp}, clear=False):
+                code = updater.main([
+                    "--skill-pack-path",
+                    str(skill_pack),
+                    "--skip-claude-cli-install",
+                ])
+            self.assertEqual(code, 0)
+            marketplace = json.loads(
+                (Path(tmp) / ".agents" / "plugins" / "marketplace.json").read_text(),
+            )
+            self.assertEqual(marketplace["plugins"][0]["name"], "dpf-platform")
+
+
 class UpdateAgentToolchainTest(unittest.TestCase):
+    @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
     def test_converges_codex_and_claude_marketplaces_in_temp_home(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmp:
@@ -52,6 +96,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
             self.assertEqual(claude_marketplace["name"], "dpf-platform-local")
             self.assertEqual(claude_marketplace["plugins"][0]["source"], "./plugins/dpf-platform")
 
+    @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
     def test_replaces_existing_codex_blocks_without_clobbering_other_settings(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmp:
@@ -81,6 +126,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
             self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
             self.assertEqual(data["mcp_servers"]["dpf"]["url"], "https://mcp.example.test/api/mcp/v1")
 
+    @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
     def test_repairs_missing_managed_plugin_without_token_or_portal(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- `scripts/dpf-bootstrap-agent-toolchain.sh`'s standalone-updater fallback crashed on stock macOS with `TypeError: write_text() got an unexpected keyword argument 'newline'` during `ensure_codex_marketplace`: `Path.write_text(newline=...)` only exists on Python 3.10+, and the bootstrap runs the updater with the system `python3` (3.9.6 on macOS).
- Fix: `write_text_if_changed` now writes bytes (`write_bytes(content.encode("utf-8"))`), which keeps LF endings on every platform without the 3.10-only kwarg.

## Regression locks
- `update_agent_toolchain_test.py`: LF-byte write + idempotence test, a source-level guard rejecting any `write_text(... newline=)` reintroduction, and an end-to-end converge test that runs on 3.9 (the `tomllib`-dependent suites now `skipIf` below 3.11 instead of failing at import — the suite was previously un-runnable on the very interpreter the bug ships on).
- The suite now runs in the `agent-toolchain-bootstrap-smoke` workflow, and the workflow triggers on `packages/dpf-skill-pack/scripts/**`.

## Docs
- Watch-list row **S4** added to `docs/install/platform-support-watchlist.md` (§2 now covers stock-macOS Python 3.9 alongside bash 3.2) per AGENTS.md §2.

## Verification
- Reproduced the `TypeError` on macOS system Python 3.9.6 with the old call.
- `python3 -m unittest discover -s packages/dpf-skill-pack/scripts -p "*_test.py" -v` on 3.9.6: 6 tests, OK (3 tomllib suites skipped), including the end-to-end converge test that previously crashed.

Backlog: BI-D3C3E59D

🤖 Generated with [Claude Code](https://claude.com/claude-code)