### PR TITLE
feat(hr): labor economics UX — pay, rate card, billable timesheet, invoice + margin (EP-LABOR-ECONOMICS Phase 4)

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -21,6 +21,9 @@ import {
 import { getAccountStatusMeta } from "@/lib/crm/presentation";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { getFinancialProfile } from "@dpf/finance-templates";
+import { getAccountLaborEconomics } from "@/lib/hr/labor-report";
+import { BillableTimeSection } from "@/components/customer/BillableTimeSection";
 
 const ACTIVITY_ICONS: Record<string, string> = {
   note: "📝",
@@ -202,6 +205,17 @@ export default async function AccountDetailPage({
       : null,
   };
 
+  // Billable time (EP-LABOR-ECONOMICS) — labour archetypes only, and only
+  // once this account actually has approved billable hours.
+  const laborOrgSettings = await prisma.orgSettings.findFirst({
+    select: { appliedProfileSlug: true, baseCurrency: true },
+  });
+  const billableTimeEnabled =
+    (laborOrgSettings?.appliedProfileSlug
+      ? getFinancialProfile(laborOrgSettings.appliedProfileSlug)?.billableTimeEnabled
+      : false) ?? false;
+  const laborEconomics = billableTimeEnabled ? await getAccountLaborEconomics(id) : null;
+
   const statusMeta = getAccountStatusMeta(account.status);
   const managedItemDefaults = deriveCustomerConfigurationItemDefaults(
     readActivationProfile(storefrontConfig?.archetype?.activationProfile),
@@ -263,6 +277,15 @@ export default async function AccountDetailPage({
       </div>
 
       <AccountLifecycleActions {...lifecycleContext} />
+
+      {laborEconomics && laborEconomics.billableHours > 0 && (
+        <BillableTimeSection
+          accountId={account.id}
+          accountName={account.name}
+          economics={laborEconomics}
+          currency={laborOrgSettings?.baseCurrency ?? "GBP"}
+        />
+      )}
 
       {/* Metadata grid */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">

--- a/apps/web/app/(shell)/employee/page.test.tsx
+++ b/apps/web/app/(shell)/employee/page.test.tsx
@@ -36,7 +36,17 @@ vi.mock("@dpf/db", () => ({
     user: {
       findMany: vi.fn(),
     },
+    orgSettings: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
   },
+}));
+
+vi.mock("@/lib/hr/compensation-data", () => ({
+  getEmployeeCompensationRows: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/components/employee/CompensationPanel", () => ({
+  CompensationPanel: () => <section>Pay</section>,
 }));
 
 vi.mock("@/lib/workforce-data", () => ({

--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -23,6 +23,10 @@ import {
 import { getEmployeeAddresses } from "@/lib/address-data";
 import { getTimesheetForWeek, getPendingTimesheetsForManager, getCurrentWeekStart } from "@/lib/timesheet-data";
 import { auth } from "@/lib/auth";
+import { getFinancialProfile } from "@dpf/finance-templates";
+import { CompensationPanel } from "@/components/employee/CompensationPanel";
+import { getEmployeeCompensationRows } from "@/lib/hr/compensation-data";
+import type { TimesheetBillingContext } from "@/components/employee/TimesheetGrid";
 
 type Props = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -94,6 +98,39 @@ export default async function EmployeePage({ searchParams }: Props) {
     ? await getPendingTimesheetsForManager(currentUserProfile.id)
     : [];
   const workforceRoster = view === "workforce" ? await loadWorkforceRoster() : null;
+
+  // Billable time is archetype-gated (labour financial profiles only); when
+  // off, the timesheet shows no billing controls at all.
+  const orgSettings = await prisma.orgSettings.findFirst({
+    select: { appliedProfileSlug: true, baseCurrency: true },
+  });
+  const billableTimeEnabled =
+    (orgSettings?.appliedProfileSlug
+      ? getFinancialProfile(orgSettings.appliedProfileSlug)?.billableTimeEnabled
+      : false) ?? false;
+  let timesheetBilling: TimesheetBillingContext | null = null;
+  if (view === "timesheets" && billableTimeEnabled) {
+    const [customers, org] = await Promise.all([
+      prisma.customerAccount.findMany({
+        where: { status: { not: "superseded" } },
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
+      }),
+      prisma.organization.findFirst({ select: { id: true } }),
+    ]);
+    const services = org
+      ? await prisma.billableRate.findMany({
+          where: { organizationId: org.id, isActive: true },
+          select: { id: true, name: true },
+          orderBy: { name: "asc" },
+        })
+      : [];
+    timesheetBilling = {
+      customers,
+      services: services.map((s) => ({ id: s.id, name: s.name })),
+    };
+  }
+  const compensationRows = view === "directory" ? await getEmployeeCompensationRows() : [];
 
   return (
     <div>
@@ -187,6 +224,7 @@ export default async function EmployeePage({ searchParams }: Props) {
               <TimesheetGrid
                 existingPeriod={currentTimesheet}
                 weekStarting={weekStart.toISOString()}
+                billing={timesheetBilling}
               />
             ) : (
               <p className="text-sm text-[var(--dpf-muted)] py-8 text-center">
@@ -213,6 +251,13 @@ export default async function EmployeePage({ searchParams }: Props) {
                 workLocations={workforceReferenceData.workLocations}
               />
               <LifecycleEventPanel events={lifecycleEvents} />
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 xl:grid-cols-2 gap-4">
+              <CompensationPanel
+                employees={compensationRows}
+                currency={orgSettings?.baseCurrency ?? "GBP"}
+              />
             </div>
           </>
         )}

--- a/apps/web/app/(shell)/finance/settings/page.tsx
+++ b/apps/web/app/(shell)/finance/settings/page.tsx
@@ -28,6 +28,10 @@ export default async function FinancialSettingsPage() {
   const recurringEnabled = profile?.recurringBillingEnabled ?? false;
   const purchaseOrdersEnabled = profile?.purchaseOrdersEnabled ?? false;
   const invoiceTemplateStyle = profile?.invoiceTemplateStyle ?? "professional";
+  // Labour archetypes only — the card (and the rate-card surface behind it)
+  // is hidden entirely for business types that don't bill time.
+  const billableTimeEnabled = profile?.billableTimeEnabled ?? false;
+  const activeRateCount = billableTimeEnabled ? await prisma.billableRate.count({ where: { isActive: true } }) : 0;
 
   const dunningStepCount = dunningSequence?.steps.length ?? 0;
   const dunningEnabled = setupStatus.dunningActive && dunningStepCount > 0;
@@ -271,6 +275,31 @@ export default async function FinancialSettingsPage() {
             Formal PO workflow for procurement approvals.
           </p>
         </div>
+
+        {/* Billable time / labour rates — labour archetypes only */}
+        {billableTimeEnabled && (
+          <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+            <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
+              Labour Rates
+            </p>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-bold text-[var(--dpf-text)]">
+                {activeRateCount > 0
+                  ? `${activeRateCount} active rate${activeRateCount !== 1 ? "s" : ""}`
+                  : "No rates yet"}
+              </span>
+              <Link
+                href="/finance/settings/rate-card"
+                className="text-[10px] text-[var(--dpf-accent)] hover:underline"
+              >
+                Manage rates →
+              </Link>
+            </div>
+            <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
+              The services you bill your team&apos;s time as when invoicing billable hours.
+            </p>
+          </div>
+        )}
 
         {/* 8. Invoice Template */}
         <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">

--- a/apps/web/app/(shell)/finance/settings/rate-card/page.tsx
+++ b/apps/web/app/(shell)/finance/settings/rate-card/page.tsx
@@ -1,0 +1,81 @@
+// apps/web/app/(shell)/finance/settings/rate-card/page.tsx
+// Rate-card admin (EP-LABOR-ECONOMICS Phase 4). Archetype-gated: only labour
+// financial profiles (billableTimeEnabled) bill time, so other business types
+// see an honest explanation instead of an empty admin surface.
+import Link from "next/link";
+import { prisma } from "@dpf/db";
+import { getFinancialProfile } from "@dpf/finance-templates";
+import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { RateCardManager } from "@/components/finance/RateCardManager";
+
+export default async function RateCardPage() {
+  const [orgSettings, org] = await Promise.all([
+    prisma.orgSettings.findFirst({ select: { appliedProfileSlug: true, baseCurrency: true } }),
+    prisma.organization.findFirst({ select: { id: true } }),
+  ]);
+  const billableTimeEnabled =
+    (orgSettings?.appliedProfileSlug
+      ? getFinancialProfile(orgSettings.appliedProfileSlug)?.billableTimeEnabled
+      : false) ?? false;
+
+  const rates =
+    billableTimeEnabled && org
+      ? await prisma.billableRate.findMany({
+          where: { organizationId: org.id },
+          orderBy: [{ isActive: "desc" }, { name: "asc" }],
+          select: { id: true, name: true, billRate: true, isActive: true },
+        })
+      : [];
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <div className="mb-2">
+        <Link href="/finance" className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+          Finance
+        </Link>
+        <span className="text-xs text-[var(--dpf-muted)]"> / </span>
+        <Link href="/finance/settings" className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+          Settings
+        </Link>
+        <span className="text-xs text-[var(--dpf-muted)]"> / </span>
+        <span className="text-xs text-[var(--dpf-text)]">Labour rates</span>
+      </div>
+
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Labour Rates</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          The services you bill your team&apos;s time as.
+        </p>
+      </div>
+
+      <FinanceTabNav />
+
+      {billableTimeEnabled ? (
+        <RateCardManager
+          rates={rates.map((r) => ({
+            id: r.id,
+            name: r.name,
+            billRate: Number(r.billRate),
+            isActive: r.isActive,
+          }))}
+          currency={orgSettings?.baseCurrency ?? "GBP"}
+        />
+      ) : (
+        <div className="rounded-lg border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+          <p className="text-sm text-[var(--dpf-text)]">
+            Billable time isn&apos;t used for your business type.
+          </p>
+          <p className="text-xs text-[var(--dpf-muted)] mt-1">
+            Labour rates apply to businesses that bill customers for their team&apos;s hours (trades,
+            professional services, and similar). Your invoicing works from products and orders instead.{" "}
+            <Link href="/finance/settings" className="text-[var(--dpf-accent)] hover:underline">
+              Back to settings
+            </Link>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/customer/BillableTimeSection.tsx
+++ b/apps/web/components/customer/BillableTimeSection.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+// Billable time on the customer account (EP-LABOR-ECONOMICS Phase 4).
+// Shows what the account's approved billable hours cost/earn (report-kit
+// StatCards) and turns the un-invoiced ones into a draft invoice. Skipped
+// entries are surfaced with a fix-it path — never silently dropped.
+
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { confirmDialog } from "@/components/ui/Dialog";
+import { StatCard } from "@/components/ui/report-kit/StatCard";
+import { generateBillableInvoice } from "@/lib/actions/labor";
+import type { BillableInvoiceResult } from "@/lib/hr/labor-service";
+import type { AccountLaborEconomics } from "@/lib/hr/labor-report";
+
+type Props = {
+  accountId: string;
+  accountName: string;
+  economics: AccountLaborEconomics;
+  /** Org base currency code — display only. */
+  currency: string;
+};
+
+function money(currency: string, amount: number): string {
+  return `${currency} ${amount.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+export function BillableTimeSection({ accountId, accountName, economics, currency }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<BillableInvoiceResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleGenerate() {
+    startTransition(async () => {
+      setError(null);
+      const ok = await confirmDialog({
+        title: "Create a draft invoice?",
+        message: `Turn ${economics.unbilledHours} approved billable hour${economics.unbilledHours === 1 ? "" : "s"} for ${accountName} into a draft invoice. You can review it before sending.`,
+      });
+      if (!ok) return;
+      try {
+        const r = await generateBillableInvoice(accountId);
+        setResult(r);
+        if (r.generated) router.refresh();
+      } catch {
+        setError("Couldn't create the invoice. Try again, or check the finance settings.");
+      }
+    });
+  }
+
+  const skippedNoRate = result?.skipped.filter((s) => s.reason === "no-rate").length ?? 0;
+
+  return (
+    <div className="mb-6">
+      <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--dpf-muted)] mb-3">
+        Billable Time
+      </h2>
+
+      {/* Margin band — cost vs billed revenue vs margin for the account's billable hours */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-3">
+        <StatCard
+          label="Labour cost"
+          value={money(currency, economics.cost)}
+          hint={`${economics.billableHours}h billable worked`}
+        />
+        <StatCard
+          label="Billed value"
+          value={money(currency, economics.revenue)}
+          hint={economics.unbilledHours > 0 ? `${economics.unbilledHours}h not invoiced yet` : "All hours invoiced"}
+        />
+        <StatCard
+          label="Margin"
+          value={money(currency, economics.margin)}
+          hint={economics.revenue > 0 ? `${economics.marginPct}% of billed value` : "No billed value yet"}
+          intent={economics.margin >= 0 ? "success" : "danger"}
+        />
+      </div>
+
+      {economics.hoursMissingCompensation > 0 && (
+        <p className="mb-3 text-[11px] text-[var(--dpf-warning)]">
+          {economics.hoursMissingCompensation}h of this time is from team members with no pay set, so
+          the true cost is higher than shown.{" "}
+          <Link href="/employee" className="text-[var(--dpf-accent)] hover:underline">
+            Set their pay →
+          </Link>
+        </p>
+      )}
+
+      <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm text-[var(--dpf-text)]">
+              {economics.unbilledHours > 0
+                ? `${economics.unbilledHours} approved hour${economics.unbilledHours === 1 ? "" : "s"} ready to invoice`
+                : "No approved hours waiting to be invoiced"}
+            </p>
+            {economics.unbilledEntriesMissingRate > 0 && (
+              <p className="text-[11px] text-[var(--dpf-warning)] mt-1">
+                {economics.unbilledEntriesMissingRate} entr{economics.unbilledEntriesMissingRate === 1 ? "y has" : "ies have"} no
+                service rate and would be left out.{" "}
+                <Link href="/finance/settings/rate-card" className="text-[var(--dpf-accent)] hover:underline">
+                  Fix the rates →
+                </Link>
+              </p>
+            )}
+          </div>
+          {economics.unbilledHours > 0 && (
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={handleGenerate}
+              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+            >
+              Create draft invoice
+            </button>
+          )}
+        </div>
+
+        {error && <p className="mt-2 text-xs text-[var(--dpf-error)]">{error}</p>}
+
+        {result && (
+          <div className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs space-y-1">
+            {result.generated ? (
+              <>
+                <p className="text-[var(--dpf-text)]">
+                  Draft invoice{" "}
+                  <Link
+                    href={`/finance/invoices/${result.invoiceId}`}
+                    className="text-[var(--dpf-accent)] hover:underline"
+                  >
+                    {result.invoiceRef}
+                  </Link>{" "}
+                  created for {result.hoursBilled}h ({result.entriesBilled} timesheet{" "}
+                  {result.entriesBilled === 1 ? "entry" : "entries"}). Review and send it from Finance.
+                </p>
+                {skippedNoRate > 0 && (
+                  <p className="text-[var(--dpf-warning)]">
+                    {skippedNoRate} entr{skippedNoRate === 1 ? "y was" : "ies were"} left out because no
+                    service rate is set.{" "}
+                    <Link href="/finance/settings/rate-card" className="text-[var(--dpf-accent)] hover:underline">
+                      Add the rate
+                    </Link>{" "}
+                    and create another invoice to bill them.
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="text-[var(--dpf-muted)]">
+                {result.reason === "billable-time-disabled"
+                  ? "Billable time isn't enabled for your business type."
+                  : skippedNoRate > 0
+                    ? "Nothing could be billed — the hours are missing service rates."
+                    : "Nothing to bill yet — hours must be on an approved timesheet first."}
+                {result.reason === "nothing-to-bill" && skippedNoRate > 0 && (
+                  <>
+                    {" "}
+                    <Link href="/finance/settings/rate-card" className="text-[var(--dpf-accent)] hover:underline">
+                      Fix the rates →
+                    </Link>
+                  </>
+                )}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/employee/CompensationPanel.tsx
+++ b/apps/web/components/employee/CompensationPanel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+// Compensation on the employee record (EP-LABOR-ECONOMICS Phase 4).
+// Plain-language pay setup: pick a person, say whether they're paid hourly or
+// salaried, enter one number. Standard annual hours (the salary→hourly cost
+// divisor) stays behind an advanced disclosure with a sensible default.
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { setEmployeeCompensation } from "@/lib/actions/workforce";
+import type { EmployeeCompensationRow } from "@/lib/hr/compensation-data";
+
+type Props = {
+  employees: EmployeeCompensationRow[];
+  /** Org base currency code, e.g. "GBP" — display only. */
+  currency: string;
+};
+
+const inputCls =
+  "w-32 px-2 py-1 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] text-[var(--dpf-text)]";
+
+function describePay(e: EmployeeCompensationRow, currency: string): string {
+  if (e.payType === "hourly" && e.hourlyRate != null) {
+    return `Paid hourly — ${currency} ${e.hourlyRate.toLocaleString()} per hour`;
+  }
+  if (e.payType === "salary" && e.annualSalary != null) {
+    return `Salaried — ${currency} ${e.annualSalary.toLocaleString()} per year`;
+  }
+  return "Pay not set yet";
+}
+
+export function CompensationPanel({ employees, currency }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [selectedId, setSelectedId] = useState(employees[0]?.employeeProfileId ?? "");
+  const selected = useMemo(
+    () => employees.find((e) => e.employeeProfileId === selectedId) ?? null,
+    [employees, selectedId],
+  );
+
+  const [payType, setPayType] = useState<"hourly" | "salary">(selected?.payType ?? "hourly");
+  const [hourlyRate, setHourlyRate] = useState<string>(selected?.hourlyRate?.toString() ?? "");
+  const [annualSalary, setAnnualSalary] = useState<string>(selected?.annualSalary?.toString() ?? "");
+  const [standardHours, setStandardHours] = useState<string>(
+    selected?.standardAnnualHours?.toString() ?? "",
+  );
+  const [message, setMessage] = useState<string | null>(null);
+
+  function selectEmployee(id: string) {
+    setSelectedId(id);
+    const e = employees.find((emp) => emp.employeeProfileId === id) ?? null;
+    setPayType(e?.payType ?? "hourly");
+    setHourlyRate(e?.hourlyRate?.toString() ?? "");
+    setAnnualSalary(e?.annualSalary?.toString() ?? "");
+    setStandardHours(e?.standardAnnualHours?.toString() ?? "");
+    setMessage(null);
+  }
+
+  function handleSave() {
+    if (!selected) return;
+    startTransition(async () => {
+      const result = await setEmployeeCompensation({
+        employeeProfileId: selected.employeeProfileId,
+        payType,
+        ...(payType === "hourly"
+          ? { hourlyRate: parseFloat(hourlyRate) || 0 }
+          : {
+              annualSalary: parseFloat(annualSalary) || 0,
+              standardAnnualHours: standardHours ? parseInt(standardHours, 10) || null : null,
+            }),
+      });
+      setMessage(result.message);
+      if (result.ok) router.refresh();
+    });
+  }
+
+  return (
+    <section className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-3">
+      <div>
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Pay</h2>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">
+          How each person is paid. This feeds payroll and what your labour costs on jobs.
+        </p>
+      </div>
+
+      {employees.length === 0 ? (
+        <p className="text-xs text-[var(--dpf-muted)]">Add an employee first, then set their pay here.</p>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={selectedId}
+              onChange={(e) => selectEmployee(e.target.value)}
+              className="px-2 py-1 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] max-w-56"
+              aria-label="Employee"
+            >
+              {employees.map((e) => (
+                <option key={e.employeeProfileId} value={e.employeeProfileId} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                  {e.displayName}
+                </option>
+              ))}
+            </select>
+            {selected && (
+              <span className="text-[10px] text-[var(--dpf-muted)]">{describePay(selected, currency)}</span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3 text-xs text-[var(--dpf-text)]">
+            <label className="flex items-center gap-1.5 cursor-pointer">
+              <input
+                type="radio"
+                name="payType"
+                checked={payType === "hourly"}
+                onChange={() => setPayType("hourly")}
+              />
+              Paid hourly
+            </label>
+            <label className="flex items-center gap-1.5 cursor-pointer">
+              <input
+                type="radio"
+                name="payType"
+                checked={payType === "salary"}
+                onChange={() => setPayType("salary")}
+              />
+              Salaried
+            </label>
+          </div>
+
+          {payType === "hourly" ? (
+            <label className="flex items-center gap-2 text-xs text-[var(--dpf-text)]">
+              Hourly pay rate ({currency})
+              <input
+                type="number"
+                min={0}
+                step={0.5}
+                value={hourlyRate}
+                onChange={(e) => setHourlyRate(e.target.value)}
+                className={inputCls}
+              />
+            </label>
+          ) : (
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-xs text-[var(--dpf-text)]">
+                Annual salary ({currency})
+                <input
+                  type="number"
+                  min={0}
+                  step={500}
+                  value={annualSalary}
+                  onChange={(e) => setAnnualSalary(e.target.value)}
+                  className={inputCls}
+                />
+              </label>
+              <details className="text-xs">
+                <summary className="cursor-pointer text-[var(--dpf-muted)]">Advanced</summary>
+                <label className="mt-2 flex items-center gap-2 text-xs text-[var(--dpf-text)]">
+                  Standard hours per year
+                  <input
+                    type="number"
+                    min={1}
+                    max={8760}
+                    step={1}
+                    placeholder="2080"
+                    value={standardHours}
+                    onChange={(e) => setStandardHours(e.target.value)}
+                    className={inputCls}
+                  />
+                </label>
+                <p className="mt-1 text-[10px] text-[var(--dpf-muted)]">
+                  Used to work out an hourly cost for job pricing. Leave blank for 2,080 (40 hours × 52 weeks).
+                </p>
+              </details>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={isPending || !selected}
+              onClick={handleSave}
+              className="text-[11px] px-3 py-1.5 rounded border border-[var(--dpf-accent)]/40 text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent)]/10 disabled:opacity-50"
+            >
+              Save pay
+            </button>
+            {message && <span className="text-[11px] text-[var(--dpf-muted)]">{message}</span>}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/employee/TimesheetGrid.tsx
+++ b/apps/web/components/employee/TimesheetGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { Fragment, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { saveTimesheetEntries, submitTimesheet } from "@/lib/actions/timesheet";
 import type { TimesheetPeriodRow } from "@/lib/timesheet-data";
@@ -20,11 +20,23 @@ type EntryState = {
   hours: number;
   breakMinutes: number;
   notes: string;
+  billable: boolean;
+  customerAccountId: string | null;
+  billableRateId: string | null;
+  billableHours: number;
+  invoiceId: string | null;
+};
+
+/** Present only when the org's financial profile enables billable time. */
+export type TimesheetBillingContext = {
+  customers: Array<{ id: string; name: string }>;
+  services: Array<{ id: string; name: string }>;
 };
 
 type Props = {
   existingPeriod: TimesheetPeriodRow | null;
   weekStarting: string;
+  billing?: TimesheetBillingContext | null;
 };
 
 function buildEmptyEntries(weekStarting: string): EntryState[] {
@@ -38,6 +50,11 @@ function buildEmptyEntries(weekStarting: string): EntryState[] {
       hours: 0,
       breakMinutes: 0,
       notes: "",
+      billable: false,
+      customerAccountId: null,
+      billableRateId: null,
+      billableHours: 0,
+      invoiceId: null,
     };
   });
 }
@@ -53,13 +70,18 @@ function buildEntriesFromPeriod(period: TimesheetPeriodRow, weekStarting: string
         hours: entry.hours,
         breakMinutes: entry.breakMinutes,
         notes: entry.notes ?? "",
+        billable: entry.billable,
+        customerAccountId: entry.customerAccountId,
+        billableRateId: entry.billableRateId,
+        billableHours: entry.billableHours,
+        invoiceId: entry.invoiceId,
       };
     }
   }
   return empty;
 }
 
-export function TimesheetGrid({ existingPeriod, weekStarting }: Props) {
+export function TimesheetGrid({ existingPeriod, weekStarting, billing }: Props) {
   const router = useRouter();
 
   function navigateWeek(direction: -1 | 1) {
@@ -78,12 +100,39 @@ export function TimesheetGrid({ existingPeriod, weekStarting }: Props) {
   const isEditable = !existingPeriod || existingPeriod.status === "draft" || existingPeriod.status === "rejected";
   const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
   const totalBreaks = entries.reduce((sum, e) => sum + e.breakMinutes, 0);
+  const totalBillable = entries.reduce((sum, e) => sum + (e.billable ? e.billableHours : 0), 0);
   const overtimeThreshold = existingPeriod?.overtimeThreshold ?? 40;
   const overtimeHours = Math.max(0, totalHours - overtimeThreshold);
+  const showBilling = Boolean(billing);
 
   function updateEntry(dayOfWeek: number, field: "hours" | "breakMinutes", value: number) {
     setEntries((prev) =>
-      prev.map((e) => (e.dayOfWeek === dayOfWeek ? { ...e, [field]: value } : e)),
+      prev.map((e) => {
+        if (e.dayOfWeek !== dayOfWeek) return e;
+        const next = { ...e, [field]: value };
+        // Billable hours track worked hours: never above them, and follow them
+        // while the two are still equal (the common "all of it" case).
+        if (field === "hours" && next.billable) {
+          next.billableHours = e.billableHours === e.hours ? value : Math.min(next.billableHours, value);
+        }
+        return next;
+      }),
+    );
+  }
+
+  function updateBilling(dayOfWeek: number, patch: Partial<EntryState>) {
+    setEntries((prev) =>
+      prev.map((e) => (e.dayOfWeek === dayOfWeek ? { ...e, ...patch } : e)),
+    );
+  }
+
+  function toggleBillable(dayOfWeek: number, on: boolean) {
+    setEntries((prev) =>
+      prev.map((e) =>
+        e.dayOfWeek === dayOfWeek
+          ? { ...e, billable: on, billableHours: on ? e.hours : 0 }
+          : e,
+      ),
     );
   }
 
@@ -177,14 +226,19 @@ export function TimesheetGrid({ existingPeriod, weekStarting }: Props) {
               <th className="text-left text-[10px] text-[var(--dpf-muted)] uppercase pb-2 w-20">Date</th>
               <th className="text-center text-[10px] text-[var(--dpf-muted)] uppercase pb-2 w-20">Hours</th>
               <th className="text-center text-[10px] text-[var(--dpf-muted)] uppercase pb-2 w-24">Break (min)</th>
+              {showBilling && (
+                <th className="text-center text-[10px] text-[var(--dpf-muted)] uppercase pb-2 w-24">Bill to customer</th>
+              )}
             </tr>
           </thead>
           <tbody>
             {entries.map((entry) => {
               const isWeekend = entry.dayOfWeek >= 5;
+              const isInvoiced = entry.invoiceId != null;
+              const billingEditable = isEditable && !isInvoiced;
               return (
+                <Fragment key={entry.dayOfWeek}>
                 <tr
-                  key={entry.dayOfWeek}
                   style={{ background: isWeekend ? "rgba(255,255,255,0.02)" : "transparent" }}
                 >
                   <td className="py-1.5 text-[var(--dpf-text)] font-medium">{DAY_NAMES[entry.dayOfWeek]}</td>
@@ -219,7 +273,86 @@ export function TimesheetGrid({ existingPeriod, weekStarting }: Props) {
                       <span className="text-[var(--dpf-muted)]">{entry.breakMinutes}</span>
                     )}
                   </td>
+                  {showBilling && (
+                    <td className="py-1.5 text-center">
+                      {isInvoiced ? (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--dpf-success)]/10 text-[var(--dpf-success)]">
+                          Invoiced
+                        </span>
+                      ) : billingEditable ? (
+                        <input
+                          type="checkbox"
+                          checked={entry.billable}
+                          disabled={entry.hours <= 0 && !entry.billable}
+                          onChange={(e) => toggleBillable(entry.dayOfWeek, e.target.checked)}
+                          aria-label={`Bill ${DAY_NAMES[entry.dayOfWeek]} to a customer`}
+                        />
+                      ) : (
+                        <span className="text-[var(--dpf-muted)]">{entry.billable ? `${entry.billableHours}h` : "—"}</span>
+                      )}
+                    </td>
+                  )}
                 </tr>
+                {showBilling && entry.billable && (
+                  <tr>
+                    <td />
+                    <td colSpan={showBilling ? 4 : 3} className="pb-2">
+                      <div className="flex flex-wrap items-center gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1.5">
+                        <select
+                          value={entry.customerAccountId ?? ""}
+                          disabled={!billingEditable}
+                          onChange={(e) => updateBilling(entry.dayOfWeek, { customerAccountId: e.target.value || null })}
+                          className="px-2 py-1 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] max-w-40"
+                          aria-label="Customer"
+                        >
+                          <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Customer…</option>
+                          {billing!.customers.map((c) => (
+                            <option key={c.id} value={c.id} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                              {c.name}
+                            </option>
+                          ))}
+                        </select>
+                        <select
+                          value={entry.billableRateId ?? ""}
+                          disabled={!billingEditable}
+                          onChange={(e) => updateBilling(entry.dayOfWeek, { billableRateId: e.target.value || null })}
+                          className="px-2 py-1 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] max-w-40"
+                          aria-label="Service billed as"
+                        >
+                          <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Service…</option>
+                          {billing!.services.map((s) => (
+                            <option key={s.id} value={s.id} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                              {s.name}
+                            </option>
+                          ))}
+                        </select>
+                        <label className="flex items-center gap-1 text-[10px] text-[var(--dpf-muted)]">
+                          Billable hours
+                          <input
+                            type="number"
+                            min={0}
+                            max={entry.hours}
+                            step={0.25}
+                            value={entry.billableHours || ""}
+                            disabled={!billingEditable}
+                            onChange={(e) =>
+                              updateBilling(entry.dayOfWeek, {
+                                billableHours: Math.min(Math.max(parseFloat(e.target.value) || 0, 0), entry.hours),
+                              })
+                            }
+                            className="w-16 px-2 py-1 text-center text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] text-[var(--dpf-text)]"
+                          />
+                        </label>
+                        {billingEditable && (!entry.customerAccountId || !entry.billableRateId) && (
+                          <span className="text-[10px] text-[var(--dpf-warning)]">
+                            Choose a customer and service so these hours can be invoiced.
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                )}
+                </Fragment>
               );
             })}
           </tbody>
@@ -228,6 +361,11 @@ export function TimesheetGrid({ existingPeriod, weekStarting }: Props) {
               <td colSpan={2} className="py-2 text-[var(--dpf-text)] font-semibold">Total</td>
               <td className="py-2 text-center font-semibold text-[var(--dpf-text)]">{totalHours}h</td>
               <td className="py-2 text-center text-[var(--dpf-muted)]">{totalBreaks}m</td>
+              {showBilling && (
+                <td className="py-2 text-center text-[var(--dpf-text)] font-semibold">
+                  {totalBillable > 0 ? `${totalBillable}h billable` : "—"}
+                </td>
+              )}
             </tr>
           </tfoot>
         </table>

--- a/apps/web/components/finance/RateCardManager.tsx
+++ b/apps/web/components/finance/RateCardManager.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+// Rate-card admin (EP-LABOR-ECONOMICS Phase 4): "What services do you bill
+// labour as?" — a short list of named hourly rates with an active toggle.
+// Rows price billable timesheet hours when an invoice is generated.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { upsertBillableRate } from "@/lib/actions/labor";
+
+export type RateCardRow = {
+  id: string;
+  name: string;
+  billRate: number;
+  isActive: boolean;
+};
+
+type Props = {
+  rates: RateCardRow[];
+  /** Org base currency code — display only. */
+  currency: string;
+};
+
+const inputCls =
+  "px-2 py-1 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] text-[var(--dpf-text)]";
+
+export function RateCardManager({ rates, currency }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  // Add-a-service row
+  const [newName, setNewName] = useState("");
+  const [newRate, setNewRate] = useState("");
+
+  // Inline edit state (one row at a time keeps the list calm)
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editRate, setEditRate] = useState("");
+
+  function run(input: Parameters<typeof upsertBillableRate>[0], after?: () => void) {
+    startTransition(async () => {
+      const result = await upsertBillableRate(input);
+      setMessage(result.message);
+      if (result.ok) {
+        after?.();
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 space-y-3">
+      <div>
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">What do you bill labour as?</h2>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">
+          Each service has an hourly rate. Your team picks one when they mark timesheet hours as
+          billable, and invoices price the hours from this list.
+        </p>
+      </div>
+
+      {rates.length === 0 ? (
+        <p className="text-xs text-[var(--dpf-muted)]">
+          No services yet — add your first one below, e.g. “Standard labour”.
+        </p>
+      ) : (
+        <ul className="space-y-1.5">
+          {rates.map((rate) => (
+            <li
+              key={rate.id}
+              className="flex flex-wrap items-center gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2"
+            >
+              {editingId === rate.id ? (
+                <>
+                  <input
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    className={`${inputCls} w-44`}
+                    aria-label="Service name"
+                  />
+                  <input
+                    type="number"
+                    min={0}
+                    step={0.5}
+                    value={editRate}
+                    onChange={(e) => setEditRate(e.target.value)}
+                    className={`${inputCls} w-24`}
+                    aria-label={`Rate per hour (${currency})`}
+                  />
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() =>
+                      run(
+                        {
+                          id: rate.id,
+                          name: editName,
+                          billRate: parseFloat(editRate) || 0,
+                          isActive: rate.isActive,
+                        },
+                        () => setEditingId(null),
+                      )
+                    }
+                    className="text-[11px] px-2 py-1 rounded border border-[var(--dpf-accent)]/40 text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent)]/10 disabled:opacity-50"
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditingId(null)}
+                    className="text-[11px] px-2 py-1 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <>
+                  <span className="text-xs font-medium text-[var(--dpf-text)]">{rate.name}</span>
+                  <span className="text-xs text-[var(--dpf-muted)]">
+                    {currency} {rate.billRate.toLocaleString()} / hour
+                  </span>
+                  {!rate.isActive && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)]">
+                      Off
+                    </span>
+                  )}
+                  <span className="flex-1" />
+                  <label className="flex items-center gap-1.5 text-[10px] text-[var(--dpf-muted)] cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={rate.isActive}
+                      disabled={isPending}
+                      onChange={(e) =>
+                        run({
+                          id: rate.id,
+                          name: rate.name,
+                          billRate: rate.billRate,
+                          isActive: e.target.checked,
+                        })
+                      }
+                    />
+                    Active
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingId(rate.id);
+                      setEditName(rate.name);
+                      setEditRate(String(rate.billRate));
+                    }}
+                    className="text-[11px] px-2 py-1 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                  >
+                    Edit
+                  </button>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 pt-2 border-t border-[var(--dpf-border)]">
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="Service name, e.g. Standard labour"
+          className={`${inputCls} w-56 placeholder:text-[var(--dpf-muted)]`}
+          aria-label="New service name"
+        />
+        <input
+          type="number"
+          min={0}
+          step={0.5}
+          value={newRate}
+          onChange={(e) => setNewRate(e.target.value)}
+          placeholder={`Rate (${currency}/hour)`}
+          className={`${inputCls} w-32 placeholder:text-[var(--dpf-muted)]`}
+          aria-label={`New service rate per hour (${currency})`}
+        />
+        <button
+          type="button"
+          disabled={isPending || !newName.trim() || !(parseFloat(newRate) > 0)}
+          onClick={() =>
+            run(
+              { name: newName, billRate: parseFloat(newRate) || 0, isActive: true },
+              () => {
+                setNewName("");
+                setNewRate("");
+              },
+            )
+          }
+          className="text-[11px] px-3 py-1.5 rounded border border-[var(--dpf-accent)]/40 text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent)]/10 disabled:opacity-50"
+        >
+          Add service
+        </button>
+        {message && <span className="text-[11px] text-[var(--dpf-muted)]">{message}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/labor.ts
+++ b/apps/web/lib/actions/labor.ts
@@ -1,0 +1,89 @@
+// apps/web/lib/actions/labor.ts — server actions for the billable-time surfaces
+// (EP-LABOR-ECONOMICS Phase 4): the BillableRate rate card and turning a
+// customer's approved billable hours into a draft invoice. The billing rules
+// live in lib/hr/labor-billing.ts / lib/hr/labor-service.ts; these actions only
+// add auth, validation and cache revalidation around them.
+
+"use server";
+
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { requireCapability } from "@/lib/actions/shared/guards";
+import {
+  generateInvoiceFromBillableTime,
+  type BillableInvoiceResult,
+} from "@/lib/hr/labor-service";
+
+export type LaborActionResult = { ok: boolean; message: string };
+
+// ─── Rate card ────────────────────────────────────────────────────────────────
+
+export type UpsertBillableRateInput = {
+  /** Present when editing an existing rate; omitted when adding one. */
+  id?: string;
+  name: string;
+  billRate: number;
+  isActive: boolean;
+};
+
+/** Add or edit a rate-card service ("what do you bill labour as?"). */
+export async function upsertBillableRate(
+  input: UpsertBillableRateInput,
+): Promise<LaborActionResult> {
+  await requireCapability("manage_finance");
+
+  const name = input.name.trim();
+  if (!name) return { ok: false, message: "Give the service a name." };
+  if (!Number.isFinite(input.billRate) || input.billRate <= 0) {
+    return { ok: false, message: "Enter an hourly rate greater than zero." };
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) return { ok: false, message: "No organization configured yet." };
+
+  if (input.id) {
+    const existing = await prisma.billableRate.findFirst({
+      where: { id: input.id, organizationId: org.id },
+      select: { id: true },
+    });
+    if (!existing) return { ok: false, message: "Rate not found." };
+    await prisma.billableRate.update({
+      where: { id: input.id },
+      data: { name, billRate: input.billRate, isActive: input.isActive },
+    });
+  } else {
+    await prisma.billableRate.create({
+      data: {
+        organizationId: org.id,
+        name,
+        billRate: input.billRate,
+        isActive: input.isActive,
+      },
+    });
+  }
+
+  revalidatePath("/finance/settings/rate-card");
+  revalidatePath("/finance/settings");
+  return { ok: true, message: `Saved ${name}.` };
+}
+
+// ─── Billable time → draft invoice ───────────────────────────────────────────
+
+/**
+ * Turn a customer's approved, un-invoiced billable hours into a draft invoice.
+ * Returns the typed result (draft invoice ref/link, hours billed, skipped
+ * entries with reasons) so the UI can surface skips as a fix-it nudge.
+ */
+export async function generateBillableInvoice(
+  customerAccountId: string,
+): Promise<BillableInvoiceResult> {
+  await requireCapability("manage_finance");
+
+  const result = await generateInvoiceFromBillableTime(customerAccountId);
+
+  if (result.generated) {
+    revalidatePath(`/customer/${customerAccountId}`);
+    revalidatePath("/finance/invoices");
+  }
+  return result;
+}

--- a/apps/web/lib/actions/timesheet.ts
+++ b/apps/web/lib/actions/timesheet.ts
@@ -16,6 +16,13 @@ export async function saveTimesheetEntries(input: {
     hours: number;
     breakMinutes: number;
     notes?: string;
+    // Billable time (EP-LABOR-ECONOMICS). Only persisted when the org's
+    // financial profile enables billable time (the UI hides them otherwise);
+    // harmless defaults when omitted.
+    billable?: boolean;
+    customerAccountId?: string | null;
+    billableRateId?: string | null;
+    billableHours?: number;
   }>;
   notes?: string;
 }): Promise<{ success: boolean; periodId?: string; error?: string }> {
@@ -76,8 +83,34 @@ export async function saveTimesheetEntries(input: {
     });
   }
 
+  // Billing lock: an entry whose hours are already on an invoice keeps its
+  // billing fields frozen (belt-and-braces — an invoiced entry's period is
+  // approved and not editable anyway, but never trust one guard alone).
+  const invoicedDays = new Set(
+    (
+      await prisma.timesheetEntry.findMany({
+        where: { timesheetPeriodId: period.id, invoiceId: { not: null } },
+        select: { dayOfWeek: true },
+      })
+    ).map((e) => e.dayOfWeek),
+  );
+
   // Upsert each day's entry
   for (const entry of input.entries) {
+    const billable = entry.billable ?? false;
+    // Billable hours default to the day's worked hours and can never exceed them.
+    const billableHours = billable
+      ? Math.min(Math.max(entry.billableHours ?? entry.hours, 0), entry.hours)
+      : 0;
+    const billingFields = invoicedDays.has(entry.dayOfWeek)
+      ? {}
+      : {
+          billable,
+          billableHours,
+          customerAccountId: billable ? (entry.customerAccountId ?? null) : null,
+          billableRateId: billable ? (entry.billableRateId ?? null) : null,
+        };
+
     await prisma.timesheetEntry.upsert({
       where: {
         timesheetPeriodId_dayOfWeek: {
@@ -92,11 +125,13 @@ export async function saveTimesheetEntries(input: {
         hours: entry.hours,
         breakMinutes: entry.breakMinutes,
         notes: entry.notes ?? null,
+        ...billingFields,
       },
       update: {
         hours: entry.hours,
         breakMinutes: entry.breakMinutes,
         notes: entry.notes ?? null,
+        ...billingFields,
       },
     });
   }

--- a/apps/web/lib/actions/workforce.ts
+++ b/apps/web/lib/actions/workforce.ts
@@ -458,3 +458,77 @@ export async function recordEmploymentLifecycleEvent(
     },
   });
 }
+
+// ─── Compensation (EP-LABOR-ECONOMICS) ───────────────────────────────────────
+
+export type SetEmployeeCompensationInput = {
+  employeeProfileId: string;
+  payType: "hourly" | "salary";
+  /** Required when payType is "hourly". */
+  hourlyRate?: number | null;
+  /** Required when payType is "salary". */
+  annualSalary?: number | null;
+  /** Salary only; defaults to 2080 (40h × 52w) when left unset. */
+  standardAnnualHours?: number | null;
+};
+
+/**
+ * Set how an employee is paid. Stores the compensation columns that feed both
+ * payroll earnings (lib/hr/labor-service.ts) and job costing (lib/hr/labor.ts).
+ * Switching pay type keeps the other type's stored value — payType decides
+ * which one is live, so a switch back never loses data.
+ */
+export async function setEmployeeCompensation(
+  input: SetEmployeeCompensationInput,
+): Promise<WorkforceActionResult> {
+  const employeeProfileId = trimRequired(input.employeeProfileId);
+  if (!employeeProfileId) return workforceDenied("Employee profile is required.");
+
+  if (input.payType === "hourly") {
+    if (input.hourlyRate == null || !Number.isFinite(input.hourlyRate) || input.hourlyRate <= 0) {
+      return workforceDenied("Enter an hourly pay rate greater than zero.");
+    }
+  } else if (input.payType === "salary") {
+    if (input.annualSalary == null || !Number.isFinite(input.annualSalary) || input.annualSalary <= 0) {
+      return workforceDenied("Enter an annual salary greater than zero.");
+    }
+    if (
+      input.standardAnnualHours != null &&
+      (!Number.isInteger(input.standardAnnualHours) ||
+        input.standardAnnualHours < 1 ||
+        input.standardAnnualHours > 8760)
+    ) {
+      return workforceDenied("Standard hours per year must be a whole number between 1 and 8760.");
+    }
+  } else {
+    return workforceDenied("Choose how this employee is paid.");
+  }
+
+  return withGovernedWorkforceAction({
+    actionKey: "employee_profile.set_compensation",
+    riskBand: "medium",
+    objectRef: employeeProfileId,
+    run: async () => {
+      const employee = await prisma.employeeProfile.findUnique({
+        where: { id: employeeProfileId },
+        select: { id: true, displayName: true },
+      });
+      if (!employee) return workforceDenied("Employee profile not found.");
+
+      await prisma.employeeProfile.update({
+        where: { id: employeeProfileId },
+        data:
+          input.payType === "hourly"
+            ? { payType: "hourly", hourlyRate: input.hourlyRate }
+            : {
+                payType: "salary",
+                annualSalary: input.annualSalary,
+                standardAnnualHours: input.standardAnnualHours ?? null,
+              },
+      });
+
+      revalidatePath("/employee");
+      return { ok: true, message: `Pay updated for ${employee.displayName}.` };
+    },
+  });
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 536,
+  "routeCount": 537,
   "routes": [
     {
       "routePath": "/",
@@ -4247,6 +4247,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/finance/settings/dunning/page.tsx"
+    },
+    {
+      "routePath": "/finance/settings/rate-card",
+      "kind": "page",
+      "segments": [
+        "finance",
+        "settings",
+        "rate-card"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/finance/settings/rate-card/page.tsx"
     },
     {
       "routePath": "/finance/settings/setup",

--- a/apps/web/lib/hr/compensation-data.ts
+++ b/apps/web/lib/hr/compensation-data.ts
@@ -1,0 +1,43 @@
+// lib/hr/compensation-data.ts — read model for the employee compensation panel.
+//
+// Serializes EmployeeProfile compensation columns (Decimal → number) so a
+// client component can render/edit them. Writes go through the governed
+// setEmployeeCompensation action in lib/actions/workforce.ts.
+
+import { prisma } from "@dpf/db";
+
+export type EmployeeCompensationRow = {
+  employeeProfileId: string;
+  displayName: string;
+  employeeId: string;
+  payType: "hourly" | "salary" | null;
+  hourlyRate: number | null;
+  annualSalary: number | null;
+  standardAnnualHours: number | null;
+};
+
+export async function getEmployeeCompensationRows(): Promise<EmployeeCompensationRow[]> {
+  const employees = await prisma.employeeProfile.findMany({
+    where: { status: { notIn: ["inactive"] } },
+    orderBy: { displayName: "asc" },
+    select: {
+      id: true,
+      displayName: true,
+      employeeId: true,
+      payType: true,
+      hourlyRate: true,
+      annualSalary: true,
+      standardAnnualHours: true,
+    },
+  });
+
+  return employees.map((e) => ({
+    employeeProfileId: e.id,
+    displayName: e.displayName,
+    employeeId: e.employeeId,
+    payType: e.payType === "hourly" || e.payType === "salary" ? e.payType : null,
+    hourlyRate: e.hourlyRate != null ? Number(e.hourlyRate) : null,
+    annualSalary: e.annualSalary != null ? Number(e.annualSalary) : null,
+    standardAnnualHours: e.standardAnnualHours,
+  }));
+}

--- a/apps/web/lib/hr/labor-report.test.ts
+++ b/apps/web/lib/hr/labor-report.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { aggregateAccountLaborEconomics, type BillableEconRow } from "./labor-report";
+
+const hourly = (rate: number) => ({ payType: "hourly" as const, hourlyRate: rate });
+const salary = (annual: number, hours?: number) => ({
+  payType: "salary" as const,
+  annualSalary: annual,
+  ...(hours ? { standardAnnualHours: hours } : {}),
+});
+
+describe("aggregateAccountLaborEconomics", () => {
+  it("returns zeros for no rows", () => {
+    const r = aggregateAccountLaborEconomics([]);
+    expect(r.billableHours).toBe(0);
+    expect(r.unbilledHours).toBe(0);
+    expect(r.cost).toBe(0);
+    expect(r.revenue).toBe(0);
+    expect(r.margin).toBe(0);
+    expect(r.marginPct).toBe(0);
+  });
+
+  it("computes cost, revenue and margin across hourly and salaried employees", () => {
+    const rows: BillableEconRow[] = [
+      // 10h by an hourly £20 employee at £85 bill rate, already invoiced
+      { billableHours: 10, invoiced: true, comp: hourly(20), billRate: 85, hasActiveRate: true },
+      // 4h by a salaried £41,600/2080 (=£20/h) employee at £85, unbilled
+      { billableHours: 4, invoiced: false, comp: salary(41600, 2080), billRate: 85, hasActiveRate: true },
+    ];
+    const r = aggregateAccountLaborEconomics(rows);
+    expect(r.billableHours).toBe(14);
+    expect(r.unbilledHours).toBe(4);
+    expect(r.unbilledEntryCount).toBe(1);
+    expect(r.cost).toBe(280); // 14h × £20
+    expect(r.revenue).toBe(1190); // 14h × £85
+    expect(r.margin).toBe(910);
+    expect(r.marginPct).toBe(76.47);
+  });
+
+  it("counts unbilled entries with no active rate as missing-rate, excluded from revenue", () => {
+    const rows: BillableEconRow[] = [
+      { billableHours: 3, invoiced: false, comp: hourly(20), billRate: null, hasActiveRate: false },
+      { billableHours: 2, invoiced: false, comp: hourly(20), billRate: 90, hasActiveRate: true },
+    ];
+    const r = aggregateAccountLaborEconomics(rows);
+    expect(r.unbilledEntriesMissingRate).toBe(1);
+    expect(r.revenue).toBe(180); // only the priced 2h
+    expect(r.cost).toBe(100); // all 5h still cost money
+  });
+
+  it("tracks hours whose employee has no pay set instead of costing them at zero silently", () => {
+    const rows: BillableEconRow[] = [
+      { billableHours: 6, invoiced: false, comp: null, billRate: 70, hasActiveRate: true },
+    ];
+    const r = aggregateAccountLaborEconomics(rows);
+    expect(r.hoursMissingCompensation).toBe(6);
+    expect(r.cost).toBe(0);
+    expect(r.revenue).toBe(420);
+  });
+
+  it("ignores zero-hour rows and never counts invoiced entries as unbilled", () => {
+    const rows: BillableEconRow[] = [
+      { billableHours: 0, invoiced: false, comp: hourly(20), billRate: 85, hasActiveRate: true },
+      { billableHours: 5, invoiced: true, comp: hourly(20), billRate: 85, hasActiveRate: true },
+    ];
+    const r = aggregateAccountLaborEconomics(rows);
+    expect(r.billableHours).toBe(5);
+    expect(r.unbilledHours).toBe(0);
+    expect(r.unbilledEntryCount).toBe(0);
+  });
+
+  it("prices already-invoiced hours with an inactive rate for reporting", () => {
+    const rows: BillableEconRow[] = [
+      { billableHours: 8, invoiced: true, comp: hourly(25), billRate: 60, hasActiveRate: false },
+    ];
+    const r = aggregateAccountLaborEconomics(rows);
+    expect(r.revenue).toBe(480);
+    expect(r.unbilledEntriesMissingRate).toBe(0);
+  });
+});

--- a/apps/web/lib/hr/labor-report.ts
+++ b/apps/web/lib/hr/labor-report.ts
@@ -1,0 +1,161 @@
+// lib/hr/labor-report.ts — read-side aggregation for the labour margin view.
+//
+// Answers one question for a customer account: what did the billable hours we
+// worked for them COST us, what do they EARN, and what margin is left — split
+// into what is already on an invoice and what is still waiting to be billed.
+// The pure aggregation is separated from the Prisma read so the maths is
+// unit-testable; per-row economics reuse lib/hr/labor.ts so cost/revenue rules
+// live in exactly one place.
+
+import { prisma } from "@dpf/db";
+import { hourlyCostRate, computeBillableRevenue, type Compensation } from "./labor";
+import { compensationFromEmployee } from "./labor-service";
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ─── Pure aggregation ────────────────────────────────────────────────────────
+
+export type BillableEconRow = {
+  /** Approved billable hours on the entry. */
+  billableHours: number;
+  /** Already stamped onto an invoice? */
+  invoiced: boolean;
+  /** The employee's compensation, when set — null means cost is unknown. */
+  comp: Compensation | null;
+  /** The resolved rate-card bill rate — null means the entry cannot be priced. */
+  billRate: number | null;
+  /** Whether the entry would be invoiceable today (active rate resolved). */
+  hasActiveRate: boolean;
+};
+
+export type AccountLaborEconomics = {
+  /** All approved billable hours for the account (invoiced + unbilled). */
+  billableHours: number;
+  /** Approved billable hours not yet on an invoice. */
+  unbilledHours: number;
+  /** Approved, un-invoiced entries ready to price. */
+  unbilledEntryCount: number;
+  /** Un-invoiced entries that would be SKIPPED for lack of an active rate. */
+  unbilledEntriesMissingRate: number;
+  /** Billable hours whose employee has no pay set — excluded from cost. */
+  hoursMissingCompensation: number;
+  /** Cost of the billable hours where the employee's pay is known. */
+  cost: number;
+  /** Revenue of the billable hours at their rate-card rates (where priced). */
+  revenue: number;
+  /** revenue − cost (like-for-like on the billable hours). */
+  margin: number;
+  /** Margin as a % of revenue (0 when no revenue). */
+  marginPct: number;
+};
+
+/** Fold per-entry billable rows into the account-level economics summary. */
+export function aggregateAccountLaborEconomics(rows: BillableEconRow[]): AccountLaborEconomics {
+  let billableHours = 0;
+  let unbilledHours = 0;
+  let unbilledEntryCount = 0;
+  let unbilledEntriesMissingRate = 0;
+  let hoursMissingCompensation = 0;
+  let cost = 0;
+  let revenue = 0;
+
+  for (const row of rows) {
+    const hours = Math.max(row.billableHours, 0);
+    if (hours === 0) continue;
+
+    billableHours = round2(billableHours + hours);
+    if (!row.invoiced) {
+      unbilledHours = round2(unbilledHours + hours);
+      unbilledEntryCount += 1;
+      if (!row.hasActiveRate) unbilledEntriesMissingRate += 1;
+    }
+
+    if (row.comp) {
+      cost = round2(cost + round2(hourlyCostRate(row.comp) * hours));
+    } else {
+      hoursMissingCompensation = round2(hoursMissingCompensation + hours);
+    }
+    if (row.billRate != null) {
+      revenue = round2(revenue + computeBillableRevenue(row.billRate, hours));
+    }
+  }
+
+  const margin = round2(revenue - cost);
+  const marginPct = revenue > 0 ? round2((margin / revenue) * 100) : 0;
+
+  return {
+    billableHours,
+    unbilledHours,
+    unbilledEntryCount,
+    unbilledEntriesMissingRate,
+    hoursMissingCompensation,
+    cost,
+    revenue,
+    margin,
+    marginPct,
+  };
+}
+
+// ─── Prisma read ─────────────────────────────────────────────────────────────
+
+/**
+ * The labour economics of one customer account, from APPROVED billable
+ * timesheet entries. Rates resolve by id against the org rate card (inactive
+ * rates still price already-worked time for reporting; only ACTIVE rates make
+ * an entry invoiceable, mirroring generateInvoiceFromBillableTime).
+ */
+export async function getAccountLaborEconomics(
+  customerAccountId: string,
+): Promise<AccountLaborEconomics> {
+  const [entries, org] = await Promise.all([
+    prisma.timesheetEntry.findMany({
+      where: {
+        customerAccountId,
+        billable: true,
+        billableHours: { gt: 0 },
+        timesheetPeriod: { status: "approved" },
+      },
+      select: {
+        billableHours: true,
+        billableRateId: true,
+        invoiceId: true,
+        timesheetPeriod: {
+          select: {
+            employeeProfile: {
+              select: {
+                payType: true,
+                hourlyRate: true,
+                annualSalary: true,
+                standardAnnualHours: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.organization.findFirst({ select: { id: true } }),
+  ]);
+
+  const rates = org
+    ? await prisma.billableRate.findMany({
+        where: { organizationId: org.id },
+        select: { id: true, billRate: true, isActive: true },
+      })
+    : [];
+  const rateById = new Map(rates.map((r) => [r.id, { billRate: Number(r.billRate), isActive: r.isActive }]));
+
+  return aggregateAccountLaborEconomics(
+    entries.map((e) => {
+      const rate = e.billableRateId ? rateById.get(e.billableRateId) : undefined;
+      return {
+        billableHours: e.billableHours,
+        invoiced: e.invoiceId != null,
+        comp: compensationFromEmployee(e.timesheetPeriod.employeeProfile),
+        billRate: rate ? rate.billRate : null,
+        hasActiveRate: Boolean(rate?.isActive),
+      };
+    }),
+  );
+}

--- a/apps/web/lib/workforce/timesheet-data.ts
+++ b/apps/web/lib/workforce/timesheet-data.ts
@@ -13,6 +13,14 @@ export type TimesheetEntryRow = {
   hours: number;
   breakMinutes: number;
   notes: string | null;
+  // Billable time (EP-LABOR-ECONOMICS) — rendered only when the org's
+  // financial profile carries billableTimeEnabled.
+  billable: boolean;
+  customerAccountId: string | null;
+  billableRateId: string | null;
+  billableHours: number;
+  /** Set once the hours are on an invoice — the entry's billing is then locked. */
+  invoiceId: string | null;
 };
 
 export type TimesheetPeriodRow = {
@@ -81,6 +89,11 @@ export const getTimesheetForWeek = cache(async (
       hours: e.hours,
       breakMinutes: e.breakMinutes,
       notes: e.notes,
+      billable: e.billable,
+      customerAccountId: e.customerAccountId,
+      billableRateId: e.billableRateId,
+      billableHours: e.billableHours,
+      invoiceId: e.invoiceId,
     })),
   };
 });
@@ -133,6 +146,11 @@ export const getPendingTimesheetsForManager = cache(async (
       hours: e.hours,
       breakMinutes: e.breakMinutes,
       notes: e.notes,
+      billable: e.billable,
+      customerAccountId: e.customerAccountId,
+      billableRateId: e.billableRateId,
+      billableHours: e.billableHours,
+      invoiceId: e.invoiceId,
     })),
   }));
 });

--- a/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
+++ b/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
@@ -118,3 +118,51 @@ Phases 1 (#2598) and 2 (#2621) are merged. Phase 3 connects them:
 **Approval is the money gate on both flows:** unapproved time is neither payable nor
 billable. Phase 4 (UX: compensation on the employee record, rate-card admin, billable
 timesheet columns, generate-invoice action, margin view) remains.
+
+## 7. Phase 4 — the UX, as built (delivered 2026-07-06)
+
+Four surfaces, each embedded in its existing home (kernel-scored placement: no new hub,
+no new global nav; every billable surface disappears entirely when the applied financial
+profile lacks `billableTimeEnabled`, so non-labour archetypes never see any of it).
+
+- **Pay on the employee record** (`components/employee/CompensationPanel.tsx`, mounted on
+  `/employee` directory view). Plain words: pick a person → "Paid hourly" or "Salaried" →
+  one number (hourly rate or annual salary). Standard annual hours (the salary→hourly
+  cost divisor) sits behind an **Advanced** disclosure, blank = 2,080. Saves through the
+  governed `setEmployeeCompensation` action (`lib/actions/workforce.ts`,
+  `employee_profile.set_compensation`, risk band medium); switching pay type never
+  destroys the other type's stored value. Read model:
+  `lib/hr/compensation-data.ts`. Pay is universal (payroll), so this panel is NOT
+  archetype-gated.
+- **Labour rate card** (`/finance/settings/rate-card` +
+  `components/finance/RateCardManager.tsx`). "What do you bill labour as?" — name +
+  rate/hour + active toggle, inline add/edit via `upsertBillableRate`
+  (`lib/actions/labor.ts`, `manage_finance`-gated, org-scoped). The Finance settings page
+  shows a **Labour Rates** card (active-rate count + Manage link) only when
+  `billableTimeEnabled`; the route itself explains "billable time isn't used for your
+  business type" for everyone else.
+- **Billable columns on the timesheet** (`components/employee/TimesheetGrid.tsx`,
+  `billing` prop wired from `/employee?view=timesheets`). One extra column — a
+  "Bill to customer" checkbox per day; ticking it discloses a sub-row: customer picker,
+  service picker (active rates), billable hours (defaults to the day's hours, capped at
+  them). A missing customer/service shows an inline warning so hours can't silently
+  never-bill. Entries whose hours are on an invoice render an **Invoiced** chip and their
+  billing is frozen — enforced again server-side in `saveTimesheetEntries`
+  (`lib/actions/timesheet.ts`), which refuses billing-field changes for invoiced entries
+  and re-caps billable hours.
+- **Billable time on the customer account** (`components/customer/BillableTimeSection.tsx`
+  on `/customer/[id]`, shown only when the account has approved billable hours). A
+  report-kit StatCard band — **Labour cost / Billed value / Margin** (with %) — computed
+  by `lib/hr/labor-report.ts` (`aggregateAccountLaborEconomics`, pure + unit-tested;
+  hours from employees with no pay set are counted and surfaced as "true cost is higher",
+  with a Set-their-pay link, never silently costed at £0). "Create draft invoice" runs
+  through `confirmDialog` → `generateBillableInvoice` (`lib/actions/labor.ts`) and shows
+  the typed result: draft invoice link (`/finance/invoices/[id]`), hours/entries billed,
+  and skipped entries with a **Fix the rates →** nudge to the rate card — skips are a
+  decision surface, never silent.
+
+Verification: `lib/hr/labor-report.test.ts` (aggregation), employee page tests extended
+for the new reads, full `components/*` + `lib/actions` vitest sweep and `web` typecheck
+green in the worktree; live happy-path verification (set pay → approve billable hours →
+generate invoice → margin band; non-labour archetype sees none of it) follows the next
+self-upgrade per `dpf-verify-on-live-install`.


### PR DESCRIPTION
## What

Phase 4 (the last slice) of EP-LABOR-ECONOMICS: makes the merged timecard→payroll and billable-time→invoice engine (Phases 1–3, #2598/#2621/#2625) visible and usable by a non-technical operator. Four surfaces, each embedded in its existing home, all hidden entirely for business types that don't bill time (`billableTimeEnabled` on the applied financial profile):

1. **Pay on the employee record** (`/employee`): pick a person → "Paid hourly" or "Salaried" → one number. Standard annual hours behind an *Advanced* disclosure (blank = 2,080). Governed action `employee_profile.set_compensation`.
2. **Labour rate card** (`/finance/settings/rate-card` + settings card): "What do you bill labour as?" — name, rate/hour, active toggle. `manage_finance`-gated; non-labour archetypes get an honest explanation instead of an empty admin screen.
3. **Billable columns on the timesheet** (`/employee?view=timesheets`): per-day *Bill to customer* checkbox disclosing customer / service / billable hours (defaults to the day's hours, capped at them). *Invoiced* lock chip; `saveTimesheetEntries` also freezes billing fields server-side once hours are on an invoice.
4. **Billable Time on the customer account** (`/customer/[id]`): report-kit StatCard band — labour cost / billed value / margin (%) — from the new pure `aggregateAccountLaborEconomics` (unit-tested), plus **Create draft invoice** (`confirmDialog` → `generateInvoiceFromBillableTime`) showing the typed result: draft invoice link, hours billed, and skipped entries with a *Fix the rates →* nudge — skips are surfaced, never silent. Hours from people with no pay set are flagged ("true cost is higher") with a *Set their pay* link.

## Verification (worktree — source-local gates)

- `lib/hr/labor-report.test.ts` — 6 new aggregation tests
- `vitest run` over employee/customer/finance components + lib/actions + lib/hr + lib/workforce: **1,239 passed**
- `pnpm --filter web typecheck` green (also enforced by pre-commit)
- Route manifest regenerated (537 routes)
- Spec updated in-PR: §7 Phase 4 as-built (`docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md`)
- Live happy-path verification follows the next self-upgrade per `dpf-verify-on-live-install`

UX-Fit-Decision: principle_decide (external_coding_agent, dpf-ux-fit-review) scored embed-existing-homes 8.655 vs new-labor-hub / coworker-only alternatives, margin 2.711, confidence HIGH — embed each surface in its existing home, no new hub/nav, progressive disclosure, report-kit reuse, archetype gating hides all billable surfaces for non-labour profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)