### PR TITLE
feat(crm): subscription recurring billing rides the existing invoice cron

### DIFF
--- a/apps/web/lib/actions/recurring.test.ts
+++ b/apps/web/lib/actions/recurring.test.ts
@@ -13,6 +13,7 @@ vi.mock("@dpf/db", () => ({
       update: vi.fn(),
     },
     recurringLineItem: {},
+    subscription: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
     invoice: { findFirst: vi.fn(), findMany: vi.fn() },
   },
 }));
@@ -333,5 +334,43 @@ describe("generateDueInvoices", () => {
     const createCall = mockCreateInvoice.mock.calls[0][0];
     expect(createCall.sourceType).toBe("recurring");
     expect(createCall.sourceId).toBe("sch-1");
+  });
+});
+
+describe("generateDueInvoices — subscription renewal sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prisma as any).subscription.update.mockResolvedValue({});
+    (prisma as any).subscription.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it("advances the linked contract's renewalDate when a renewal invoice is minted", async () => {
+    const due = new Date(Date.now() - 3600_000);
+    mockPrisma.recurringSchedule.findMany.mockResolvedValue([
+      {
+        id: "sch1", accountId: "a1", subscriptionId: "sub1", frequency: "annually",
+        nextInvoiceDate: due, endDate: null, autoSend: false, currency: "GBP",
+        lineItems: [{ description: "plan", quantity: 1, unitPrice: 12000, taxRate: 0, sortOrder: 0 }],
+      },
+    ]);
+    mockPrisma.invoice.findFirst.mockResolvedValue(null);
+    vi.mocked(createInvoice).mockResolvedValue({ id: "inv1", invoiceRef: "INV-X" });
+    mockPrisma.recurringSchedule.update.mockResolvedValue({});
+
+    const res = await generateDueInvoices();
+    expect(res.generated).toBe(1);
+    const call = (prisma as any).subscription.update.mock.calls[0][0];
+    expect(call.where).toEqual({ id: "sub1" });
+    expect(call.data.renewalDate).toBeInstanceOf(Date);
+  });
+
+  it("expires past-due non-auto-renew contracts in the same sweep", async () => {
+    mockPrisma.recurringSchedule.findMany.mockResolvedValue([]);
+    (prisma as any).subscription.updateMany.mockResolvedValue({ count: 2 });
+    const res = await generateDueInvoices();
+    expect(res.expired).toBe(2);
+    const call = (prisma as any).subscription.updateMany.mock.calls[0][0];
+    expect(call.where.autoRenew).toBe(false);
+    expect(call.data.status).toBe("expired");
   });
 });

--- a/apps/web/lib/actions/recurring.ts
+++ b/apps/web/lib/actions/recurring.ts
@@ -142,7 +142,7 @@ export async function updateScheduleStatus(
 
 // ─── generateDueInvoices ──────────────────────────────────────────────────────
 
-export async function generateDueInvoices(): Promise<{ generated: number; sent: number }> {
+export async function generateDueInvoices(): Promise<{ generated: number; sent: number; expired: number }> {
   const now = new Date();
   let generated = 0;
   let sent = 0;
@@ -220,7 +220,27 @@ export async function generateDueInvoices(): Promise<{ generated: number; sent: 
         status: isCompleted ? "completed" : "active",
       },
     });
+
+    // Renewal-linked schedule: the invoice we just minted IS the contract
+    // renewal, so advance the support contract's renewalDate in lockstep
+    // (or expire it when the schedule's term completed).
+    if (schedule.subscriptionId) {
+      await prisma.subscription
+        .update({
+          where: { id: schedule.subscriptionId },
+          data: isCompleted ? { status: "expired" } : { renewalDate: nextDate },
+        })
+        .catch(() => {});
+    }
   }
 
-  return { generated, sent };
+  // Contracts that do NOT auto-renew have no schedule; their term simply ends.
+  // Expire any active non-auto-renew subscription whose renewalDate has passed,
+  // so the account surface stops showing a live contract that lapsed.
+  const expired = await prisma.subscription.updateMany({
+    where: { status: "active", autoRenew: false, renewalDate: { lt: now } },
+    data: { status: "expired" },
+  });
+
+  return { generated, sent, expired: expired.count };
 }

--- a/apps/web/lib/actions/subscriptions.test.ts
+++ b/apps/web/lib/actions/subscriptions.test.ts
@@ -7,6 +7,7 @@ vi.mock("@dpf/db", () => ({
     customerAccount: { findUnique: vi.fn(), update: vi.fn() },
     salesOrder: { findUnique: vi.fn() },
     subscription: { create: vi.fn() },
+    recurringSchedule: { create: vi.fn().mockResolvedValue({}) },
     edgeNode: { update: vi.fn() },
     activity: { create: vi.fn().mockResolvedValue({}) },
   },
@@ -19,6 +20,7 @@ const p = prisma as unknown as {
   customerAccount: { findUnique: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
   salesOrder: { findUnique: ReturnType<typeof vi.fn> };
   subscription: { create: ReturnType<typeof vi.fn> };
+  recurringSchedule: { create: ReturnType<typeof vi.fn> };
   edgeNode: { update: ReturnType<typeof vi.fn> };
 };
 
@@ -87,5 +89,45 @@ describe("convertOrderToSubscription", () => {
     const sub = await convertOrderToSubscription("so1");
     expect(sub).toEqual({ id: "existing" });
     expect(p.subscription.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("renewal schedule pairing", () => {
+  const order = {
+    id: "so1",
+    accountId: "a1",
+    totalAmount: 12000,
+    currency: "GBP",
+    account: { id: "a1", name: "Emma3D" },
+    subscription: null,
+  };
+
+  it("creates a renewal RecurringSchedule for auto-renew contracts, starting at the renewal date", async () => {
+    p.salesOrder.findUnique.mockResolvedValue(order);
+    p.subscription.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "sub1", ...data }));
+    await convertOrderToSubscription("so1", { billingCadence: "annual" });
+    expect(p.recurringSchedule.create).toHaveBeenCalledTimes(1);
+    const data = p.recurringSchedule.create.mock.calls[0][0].data;
+    expect(data.subscriptionId).toBe("sub1");
+    expect(data.frequency).toBe("annually"); // cadence vocab mapped to schedule vocab
+    expect(data.amount).toBe(12000);
+    expect(data.autoSend).toBe(true);
+    // first period was billed by the order — the schedule begins AT renewal
+    expect(new Date(data.nextInvoiceDate).getTime()).toBeGreaterThan(Date.now());
+    expect(data.lineItems.create).toHaveLength(1);
+  });
+
+  it("maps monthly cadence straight through", async () => {
+    p.salesOrder.findUnique.mockResolvedValue(order);
+    p.subscription.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "sub1", ...data }));
+    await convertOrderToSubscription("so1", { billingCadence: "monthly" });
+    expect(p.recurringSchedule.create.mock.calls[0][0].data.frequency).toBe("monthly");
+  });
+
+  it("creates NO schedule for non-auto-renew contracts (term simply ends)", async () => {
+    p.salesOrder.findUnique.mockResolvedValue(order);
+    p.subscription.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "sub1", ...data }));
+    await convertOrderToSubscription("so1", { autoRenew: false });
+    expect(p.recurringSchedule.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/actions/subscriptions.ts
+++ b/apps/web/lib/actions/subscriptions.ts
@@ -105,6 +105,42 @@ export async function convertOrderToSubscription(
       .catch(() => {});
   }
 
+  // Auto-renewing contracts get a paired RecurringSchedule so the existing
+  // daily recurring-invoice cron (generateDueInvoices) mints each renewal
+  // invoice when renewalDate arrives and keeps the contract's renewalDate
+  // advancing. The order already billed the first period, so the schedule
+  // starts AT the renewal date, not today. Non-auto-renew contracts get no
+  // schedule — the renewal sweep expires them when their term ends.
+  if (subscription.autoRenew) {
+    const frequency = cadence === "annual" ? "annually" : cadence; // schedule vocab
+    await prisma.recurringSchedule.create({
+      data: {
+        scheduleId: `REC-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
+        accountId: order.accountId,
+        subscriptionId: subscription.id,
+        name: `${subscription.planName} — renewal`,
+        frequency,
+        amount: order.totalAmount,
+        currency: order.currency,
+        startDate: renewal,
+        nextInvoiceDate: renewal,
+        status: "active",
+        autoSend: true,
+        lineItems: {
+          create: [
+            {
+              description: subscription.planName,
+              quantity: 1,
+              unitPrice: order.totalAmount,
+              taxRate: 0,
+              sortOrder: 0,
+            },
+          ],
+        },
+      },
+    });
+  }
+
   await prisma.activity
     .create({
       data: {

--- a/docs/superpowers/plans/2026-07-06-subscription-recurring-billing-plan.md
+++ b/docs/superpowers/plans/2026-07-06-subscription-recurring-billing-plan.md
@@ -1,0 +1,32 @@
+# Plan — Subscription recurring billing + renewal lifecycle (BI-8681E93C)
+
+Date: 2026-07-06. Epic: EP-B51FA3BC. Build-order slice 1 of the parity gap matrix
+(docs/superpowers/specs/2026-07-06-sales-crm-parity-delight-gap-matrix.md).
+
+## Substrate finding (dpf-verify-substrate-first)
+
+A complete recurring-invoice engine already exists: `RecurringSchedule` (+ line items),
+`generateDueInvoices()` (idempotent per-period, auto-send, GL rides `sendInvoice`), and a
+daily 06:30 cron (`recurring-invoice-dispatch`). Support contracts (Subscription, PR #2609)
+carry `billingCadence`/`renewalDate` but nothing minted renewals. The slice is therefore
+WIRING, not a new engine.
+
+## Design
+
+- Migration `20260706060000`: `RecurringSchedule.subscriptionId` (nullable, unique, SetNull
+  FK) — a schedule can be the renewal engine of exactly one contract. Data-safe attested.
+- `convertOrderToSubscription`: auto-renew contracts also create their paired schedule —
+  name "<plan> — renewal", frequency mapped from cadence (annual→annually), amount/currency
+  from the order, `startDate`/`nextInvoiceDate` = renewalDate (the order billed the first
+  period), one line item, autoSend. Non-auto-renew contracts get NO schedule.
+- `generateDueInvoices()`: after minting for a linked schedule, advance the contract's
+  `renewalDate` to the schedule's next date (or `expired` when the schedule term completes);
+  plus a sweep expiring active non-auto-renew contracts whose renewalDate passed. Returns
+  `{generated, sent, expired}`.
+
+## Verification
+
+subscriptions.test.ts (schedule pairing, cadence vocab mapping, none-when-no-autorenew) +
+recurring.test.ts (renewalDate advance, expiry sweep) — green. Deploy via self-upgrade;
+live check: Emma3D's contract gains a paired REC- schedule on the next contract created,
+and the daily cron drives renewals.

--- a/packages/db/prisma/migrations/20260706060000_link_recurring_schedule_to_subscription/migration.sql
+++ b/packages/db/prisma/migrations/20260706060000_link_recurring_schedule_to_subscription/migration.sql
@@ -1,0 +1,12 @@
+-- Link a RecurringSchedule to the Subscription (support contract) it renews,
+-- so the existing daily recurring-invoice cron can drive contract renewals.
+
+-- AlterTable
+ALTER TABLE "RecurringSchedule" ADD COLUMN     "subscriptionId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RecurringSchedule_subscriptionId_key" ON "RecurringSchedule"("subscriptionId");
+
+-- AddForeignKey
+-- @migration-safety: data-safe: subscriptionId is added as a nullable column in this same migration, so every pre-existing RecurringSchedule row holds NULL and a NULL FK never violates the constraint; the unique index over all-NULL values is also trivially satisfied.
+ALTER TABLE "RecurringSchedule" ADD CONSTRAINT "RecurringSchedule_subscriptionId_fkey" FOREIGN KEY ("subscriptionId") REFERENCES "Subscription"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3177,6 +3177,7 @@ model Subscription {
   account    CustomerAccount @relation(fields: [accountId], references: [id])
   salesOrder SalesOrder?     @relation(fields: [salesOrderId], references: [id])
   edgeNodes  EdgeNode[]
+  renewalSchedule RecurringSchedule?
 
   @@index([accountId])
   @@index([status])
@@ -9301,8 +9302,11 @@ model RecurringSchedule {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
+  // The support contract this schedule renews, if it was minted from one.
+  subscriptionId String? @unique
   account   CustomerAccount     @relation(fields: [accountId], references: [id])
   createdBy User?               @relation("RecurringScheduleCreations", fields: [createdById], references: [id])
+  subscription Subscription?    @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
   lineItems RecurringLineItem[]
 
   @@index([accountId])


### PR DESCRIPTION
## Why

**BI-8681E93C** (EP-B51FA3BC slice 1). Support contracts (Subscription, #2609) carry `billingCadence` + `renewalDate` but nothing minted renewal invoices — a contract billed once via its originating order, then went silent forever, and non-renewing contracts never expired.

## Substrate finding

A complete recurring-invoice engine already exists and runs daily: `RecurringSchedule` + idempotent `generateDueInvoices()` (auto-send, GL posting rides `sendInvoice`) + the 06:30 `recurring-invoice-dispatch` cron. So this slice is **wiring, not a new engine**.

## What

- **Migration**: `RecurringSchedule.subscriptionId` — nullable unique FK (SetNull), data-safe attested (column added nullable in-migration).
- **`convertOrderToSubscription`**: auto-renew contracts also create their paired renewal schedule — frequency mapped from cadence (`annual→annually`), amount/currency from the order, `nextInvoiceDate = renewalDate` (the order already billed the first period), one line item, auto-send. Non-auto-renew contracts get no schedule.
- **`generateDueInvoices`**: when a linked schedule mints a renewal invoice, the contract's `renewalDate` advances in lockstep (or flips to `expired` when the schedule's term completes); a sweep in the same run expires active non-auto-renew contracts whose renewalDate passed. Returns `{generated, sent, expired}`.

## Tests

Schedule pairing + cadence vocab + no-schedule-without-autorenew (subscriptions suite); renewalDate advance + expiry sweep (recurring suite) — 34/34 green. Schema-regression + migration-safety pre-commit guards green.

Deploys via self-upgrade (migration rides `migrate deploy`); the daily cron then drives contract renewals with no further action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)