### PR TITLE
feat(crm): next-step loop + deal rotting on the pipeline

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
@@ -11,7 +11,7 @@ import {
   getOpportunityStageMeta,
   OPEN_OPPORTUNITY_STAGES,
 } from "@/lib/crm/presentation";
-import { getStageAgeDays } from "@/lib/crm/pipeline-inspector";
+import { getStageAgeDays, isStageStale } from "@/lib/crm/pipeline-inspector";
 import { getPipelineInspectorView } from "@/lib/crm/pipeline-inspector-data";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 import { getOrgSettings } from "@/lib/actions/currency";
@@ -129,6 +129,11 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
                     {opps.map((opp) => {
                       const selected = opp.id === selectedOpportunityId;
                       const stageAgeDays = getStageAgeDays(opp.stageChangedAt);
+                      // Deal rotting — ambient visual state, no report needed:
+                      // a deal past its stage's inactivity threshold tints red.
+                      const rotting = isStageStale({ stage: opp.stage, stageAgeDays, isDormant: opp.isDormant });
+                      const nextAt = opp.nextActivityAt ? new Date(opp.nextActivityAt) : null;
+                      const nextOverdue = nextAt !== null && nextAt.getTime() < Date.now();
                       return (
                         <Link
                           key={opp.id}
@@ -136,16 +141,22 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
                           aria-current={selected ? "true" : undefined}
                           className={[
                             "block rounded-lg border bg-[var(--dpf-surface-1)] p-3 transition-colors hover:bg-[var(--dpf-surface-2)]",
-                            selected ? "border-[var(--dpf-accent)]" : "border-[var(--dpf-border)]",
+                            selected
+                              ? "border-[var(--dpf-accent)]"
+                              : rotting
+                                ? "border-red-500/60"
+                                : "border-[var(--dpf-border)]",
                           ].join(" ")}
                         >
                           <div className="mb-1 flex items-start justify-between gap-2">
                             <p className="min-w-0 truncate text-xs font-semibold leading-tight text-[var(--dpf-text)]">
                               {opp.title}
                             </p>
-                            {opp.isDormant && (
+                            {rotting ? (
+                              <CustomerStatusBadge label={`Rotting ${stageAgeDays}d`} tone="danger" />
+                            ) : opp.isDormant ? (
                               <CustomerStatusBadge label="Dormant" tone="warning" />
-                            )}
+                            ) : null}
                           </div>
                           <p className="truncate text-[9px] text-[var(--dpf-muted)]">
                             {opp.account.name}
@@ -157,6 +168,11 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
                               </span>
                             )}
                             <span className="shrink-0 text-[9px] text-[var(--dpf-muted)]">
+                              {nextAt === null ? (
+                                <span className="mr-1 text-amber-400" title="No next step planned">⚠ no next step</span>
+                              ) : nextOverdue ? (
+                                <span className="mr-1 text-red-400" title="Planned next step is overdue">⚠ step overdue</span>
+                              ) : null}
                               {opp.probability}% / {stageAgeDays}d
                             </span>
                           </div>

--- a/apps/web/components/customer/NextStepControl.tsx
+++ b/apps/web/components/customer/NextStepControl.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { setOpportunityNextStep } from "@/lib/actions/opportunity-next-step";
+
+// The activity-based-selling loop: one small control to plan the deal's next
+// step. Renders the current plan (or an "overdue"/"none" nudge) + a date and
+// optional note; saving logs a task on the timeline and clears dormancy.
+export function NextStepControl({
+  opportunityId,
+  nextActivityAt,
+}: {
+  opportunityId: string;
+  nextActivityAt: string | null;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [date, setDate] = useState("");
+  const [note, setNote] = useState("");
+  const router = useRouter();
+
+  const planned = nextActivityAt ? new Date(nextActivityAt) : null;
+  const overdue = planned !== null && planned.getTime() < Date.now();
+
+  function save() {
+    if (!date) {
+      setError("Pick a date.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      try {
+        await setOpportunityNextStep({ opportunityId, scheduledAt: date, note: note.trim() || undefined });
+        setOpen(false);
+        setDate("");
+        setNote("");
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  return (
+    <div className="mt-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        {planned ? (
+          <span className={overdue ? "text-red-400" : "text-[var(--dpf-muted)]"}>
+            Next step {overdue ? "was due" : "planned"} {planned.toLocaleDateString()}
+          </span>
+        ) : (
+          <span className="text-amber-400">No next step planned</span>
+        )}
+        <button
+          className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 text-[11px] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+          onClick={() => setOpen((v) => !v)}
+        >
+          {planned ? "Reschedule" : "Set next step"}
+        </button>
+      </div>
+      {open && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <input
+            type="date"
+            className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs text-[var(--dpf-text)]"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="What's the step? (optional)"
+            className="min-w-40 flex-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)]"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+          <button
+            className="rounded bg-[var(--dpf-accent)] px-2.5 py-1 text-xs font-medium text-white disabled:opacity-50"
+            disabled={isPending}
+            onClick={save}
+          >
+            {isPending ? "Saving…" : "Save"}
+          </button>
+          {error && <span className="text-[11px] text-red-400">{error}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/customer/PipelineStageInspector.test.tsx
+++ b/apps/web/components/customer/PipelineStageInspector.test.tsx
@@ -1,5 +1,8 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// NextStepControl (client child) calls useRouter().
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 import { PipelineStageInspector } from "./PipelineStageInspector";
 import type { PipelineInspectorView } from "@/lib/crm/pipeline-inspector";
 
@@ -16,6 +19,7 @@ const inspector: PipelineInspectorView = {
   stageAgeLabel: "20 days in stage",
   isStale: true,
   staleLabel: "Stale stage",
+  nextActivityAt: null,
   probabilityLabel: "70%",
   expectedValueLabel: "£15,000",
   expectedCloseLabel: "10 Jun 2026",

--- a/apps/web/components/customer/PipelineStageInspector.tsx
+++ b/apps/web/components/customer/PipelineStageInspector.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { AgentWorkLauncher } from "@/components/agent/AgentWorkLauncher";
+import { NextStepControl } from "@/components/customer/NextStepControl";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import {
   PIPELINE_STAGE_UPDATE_OPTIONS,
@@ -115,6 +116,7 @@ export function PipelineStageInspector({
           Suggested next action
         </p>
         <p className="mt-1 text-sm text-[var(--dpf-text)]">{inspector.suggestedNextAction}</p>
+        <NextStepControl opportunityId={inspector.id} nextActivityAt={inspector.nextActivityAt} />
       </div>
 
       <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-1">

--- a/apps/web/lib/actions/opportunity-next-step.test.ts
+++ b/apps/web/lib/actions/opportunity-next-step.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    opportunity: { update: vi.fn() },
+    activity: { create: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { setOpportunityNextStep } from "./opportunity-next-step";
+
+const p = prisma as unknown as {
+  opportunity: { update: ReturnType<typeof vi.fn> };
+  activity: { create: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  p.opportunity.update.mockResolvedValue({ id: "o1", accountId: "a1", title: "Deal" });
+  p.activity.create.mockResolvedValue({});
+});
+
+describe("setOpportunityNextStep", () => {
+  it("sets nextActivityAt, clears dormancy, and logs a scheduled task on the timeline", async () => {
+    const res = await setOpportunityNextStep({ opportunityId: "o1", scheduledAt: "2026-08-01", note: "Call Ian" });
+    const upd = p.opportunity.update.mock.calls[0][0];
+    expect(upd.where).toEqual({ id: "o1" });
+    expect(upd.data.nextActivityAt).toBeInstanceOf(Date);
+    expect(upd.data.isDormant).toBe(false);
+    const act = p.activity.create.mock.calls[0][0].data;
+    expect(act.type).toBe("task");
+    expect(act.subject).toBe("Call Ian");
+    expect(act.opportunityId).toBe("o1");
+    expect(act.scheduledAt).toBeInstanceOf(Date);
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects an unparseable date", async () => {
+    await expect(setOpportunityNextStep({ opportunityId: "o1", scheduledAt: "not-a-date" })).rejects.toThrow(/valid date/i);
+    expect(p.opportunity.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/opportunity-next-step.ts
+++ b/apps/web/lib/actions/opportunity-next-step.ts
@@ -1,0 +1,43 @@
+"use server";
+
+import crypto from "crypto";
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+
+// The activity-based-selling loop: every open opportunity carries a planned
+// next step. Setting one updates the deal's nextActivityAt AND logs a task
+// activity on the timeline, so the plan is visible in both places.
+
+export async function setOpportunityNextStep(input: {
+  opportunityId: string;
+  /** ISO date (yyyy-mm-dd) or datetime for the planned step. */
+  scheduledAt: string;
+  /** Short description, e.g. "Follow-up call on proposal". */
+  note?: string;
+}) {
+  const when = new Date(input.scheduledAt);
+  if (Number.isNaN(when.getTime())) throw new Error("A valid date is required");
+
+  const opportunity = await prisma.opportunity.update({
+    where: { id: input.opportunityId },
+    data: { nextActivityAt: when, isDormant: false },
+    select: { id: true, accountId: true, title: true },
+  });
+
+  await prisma.activity
+    .create({
+      data: {
+        activityId: `ACT-${crypto.randomUUID()}`,
+        type: "task",
+        subject: input.note?.trim() || `Next step planned for ${opportunity.title}`,
+        scheduledAt: when,
+        accountId: opportunity.accountId,
+        opportunityId: opportunity.id,
+      },
+    })
+    .catch(() => {});
+
+  revalidatePath("/customer/opportunities");
+  revalidatePath(`/customer/opportunities/${opportunity.id}`);
+  return { ok: true as const, nextActivityAt: when.toISOString() };
+}

--- a/apps/web/lib/crm/pipeline-inspector-data.ts
+++ b/apps/web/lib/crm/pipeline-inspector-data.ts
@@ -62,6 +62,7 @@ export async function getPipelineInspectorView(
       currency: opportunity.currency,
       expectedClose: opportunity.expectedClose,
       stageChangedAt: opportunity.stageChangedAt,
+      nextActivityAt: opportunity.nextActivityAt,
       notes: opportunity.notes,
       account: opportunity.account,
       contact: opportunity.contact,

--- a/apps/web/lib/crm/pipeline-inspector.ts
+++ b/apps/web/lib/crm/pipeline-inspector.ts
@@ -93,6 +93,7 @@ export type PipelineInspectorOpportunityInput = {
   currency?: string | null;
   expectedClose?: Date | null;
   stageChangedAt: Date;
+  nextActivityAt?: Date | null;
   notes?: string | null;
   account: {
     id: string;
@@ -133,6 +134,7 @@ export type PipelineInspectorView = {
   stageAgeLabel: string;
   isStale: boolean;
   staleLabel: string | null;
+  nextActivityAt: string | null;
   probabilityLabel: string;
   expectedValueLabel: string | null;
   expectedCloseLabel: string | null;
@@ -352,6 +354,7 @@ export function buildPipelineInspectorView(input: {
     stageTone: stageMeta.tone,
     stageAgeDays,
     stageAgeLabel: formatStageAgeLabel(stageAgeDays),
+    nextActivityAt: opportunity.nextActivityAt ? opportunity.nextActivityAt.toISOString() : null,
     isStale: stale,
     staleLabel: stale ? "Stale stage" : null,
     probabilityLabel: `${opportunity.probability}%`,

--- a/docs/superpowers/plans/2026-07-06-nextstep-loop-deal-rotting-plan.md
+++ b/docs/superpowers/plans/2026-07-06-nextstep-loop-deal-rotting-plan.md
@@ -1,0 +1,28 @@
+# Plan — Pipeline next-step loop + deal rotting (BI-0A6DF80F)
+
+Date: 2026-07-06. Epic: EP-B51FA3BC. Build-order slice 2 of the parity gap matrix —
+the two cheapest Pipedrive-proven delight mechanics (activity-based selling + ambient
+staleness), per docs/superpowers/specs/2026-07-06-sales-crm-parity-delight-gap-matrix.md.
+
+## Substrate finding (dpf-verify-substrate-first)
+
+`isStageStale` with per-stage `STAGE_STALE_THRESHOLDS_DAYS` and a `suggestedNextAction`
+generator ALREADY exist in `apps/web/lib/crm/pipeline-inspector.ts` — they render in the
+stage inspector but never on the kanban tiles, and there is no structured next-step field.
+
+## Design
+
+- Migration `20260706070000`: `Opportunity.nextActivityAt DateTime?` (nullable add).
+- `setOpportunityNextStep` action: sets the date, clears dormancy, logs a `task` Activity
+  (scheduledAt) so the plan shows on the timeline too.
+- `NextStepControl` (client, on the stage inspector): shows planned/overdue/none state +
+  date-and-note setter — the Pipedrive done→plan-next loop surface.
+- Kanban tiles: `isStageStale` now tints the card border red + "Rotting Nd" badge (ambient,
+  no report); amber "no next step" / red "step overdue" markers from `nextActivityAt`.
+- `PipelineInspectorView` gains `nextActivityAt` (ISO string) threaded from the data loader.
+
+## Verification
+
+opportunity-next-step tests (set+log+dormancy-clear, invalid date) and existing inspector /
+page suites green. Live check post-deploy: Emma3D's open £2,500 opportunity shows the
+no-next-step marker; setting a step logs the task and clears it.

--- a/packages/db/prisma/migrations/20260706070000_add_opportunity_next_activity/migration.sql
+++ b/packages/db/prisma/migrations/20260706070000_add_opportunity_next_activity/migration.sql
@@ -1,0 +1,5 @@
+-- Activity-based selling: every open opportunity should carry a planned next
+-- step. Nullable add — purely additive, no backfill needed.
+
+-- AlterTable
+ALTER TABLE "Opportunity" ADD COLUMN     "nextActivityAt" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3049,6 +3049,10 @@ model Opportunity {
   assignedToId   String?
   engagementId   String? // FK to Engagement (if converted from engagement)
   notes          String?
+  // The planned next step (call/meeting/follow-up) — the activity-based-selling
+  // loop: every open deal should have one; pipeline cards warn when it's missing
+  // and flag when it's overdue.
+  nextActivityAt DateTime?
   stageChangedAt DateTime  @default(now())
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt


### PR DESCRIPTION
## Why

**BI-0A6DF80F** (EP-B51FA3BC slice 2). The parity research's two cheapest, most-loved mechanics (Pipedrive-proven): every open deal should carry a planned next step, and stale deals should be *ambiently visible* — no reports.

## Substrate finding

`isStageStale` + per-stage thresholds + a suggested-next-action generator already existed in the stage inspector — they just never rendered on the kanban tiles, and there was no structured next-step field.

## What

- `Opportunity.nextActivityAt` (nullable migration — purely additive).
- `setOpportunityNextStep`: sets the date, clears dormancy, logs a scheduled task Activity on the timeline.
- `NextStepControl` on the stage inspector — planned/overdue/none state + one-click date/note setter.
- Kanban tiles: rotting deals tint red with a **Rotting Nd** badge; **no next step** (amber) / **step overdue** (red) markers.
- `PipelineInspectorView` carries `nextActivityAt`.

## Tests

8/8 green (action + inspector + page). Guards green.

UX-Fit-Decision: ambient tile tint and two plain-language markers replace any report/query; the setter is one button revealing a date + optional note; no jargon; state derived from data already on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)