### PR TITLE
feat(crm): lead capture + triage on the Engagement substrate

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
@@ -6,6 +6,8 @@ import { createEngagementFromSignalForm } from "@/lib/actions/crm";
 import { getAcquisitionSignalWorkspace } from "@/lib/crm/acquisition-signal-data";
 import { formatAcquisitionSourceLabel } from "@/lib/crm/acquisition-signals";
 import { getEngagementStatusMeta } from "@/lib/crm/presentation";
+import { NewLeadButton } from "@/components/customer/NewLeadButton";
+import { EngagementTriageActions } from "@/components/customer/EngagementTriageActions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 
@@ -37,7 +39,10 @@ export default async function EngagementsPage({ searchParams }: { searchParams?:
   return (
     <div className="space-y-6">
       <div className="mb-6">
-        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Engagements</h1>
+        <div className="flex items-start justify-between gap-3">
+          <h1 className="text-xl font-bold text-[var(--dpf-text)]">Engagements</h1>
+          <NewLeadButton />
+        </div>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
           {engagements.length} engagement{engagements.length !== 1 ? "s" : ""}
         </p>
@@ -105,6 +110,11 @@ export default async function EngagementsPage({ searchParams }: { searchParams?:
                     {e.notes}
                   </p>
                 ) : null}
+                <EngagementTriageActions
+                  engagementId={e.id}
+                  status={e.status}
+                  hasAccount={Boolean(e.account)}
+                />
               </div>
               <LocalTime
                 value={e.createdAt}

--- a/apps/web/components/customer/EngagementTriageActions.tsx
+++ b/apps/web/components/customer/EngagementTriageActions.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateEngagementStatus } from "@/lib/actions/leads";
+import { qualifyEngagement } from "@/lib/actions/crm";
+
+// Lead-triage loop on each engagement row: contacted → qualify (converts to an
+// opportunity via the existing qualifyEngagement flow) or disqualify. Only the
+// transitions valid for the current status render.
+export function EngagementTriageActions({
+  engagementId,
+  status,
+  hasAccount,
+}: {
+  engagementId: string;
+  status: string;
+  hasAccount: boolean;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  function run(fn: () => Promise<unknown>) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await fn();
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  if (status === "converted" || status === "unqualified") return null;
+
+  const btn =
+    "rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-[11px] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50";
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2">
+      {status === "new" && (
+        <button className={btn} disabled={isPending} onClick={() => run(() => updateEngagementStatus(engagementId, "contacted"))}>
+          Mark contacted
+        </button>
+      )}
+      <button
+        className="rounded bg-[var(--dpf-accent)] px-2 py-1 text-[11px] font-medium text-white disabled:opacity-50"
+        disabled={isPending || !hasAccount}
+        title={hasAccount ? "Create the opportunity from this lead" : "Link an account first"}
+        onClick={() => run(() => qualifyEngagement(engagementId))}
+      >
+        Qualify → opportunity
+      </button>
+      <button className={btn} disabled={isPending} onClick={() => run(() => updateEngagementStatus(engagementId, "unqualified"))}>
+        Disqualify
+      </button>
+      {error && <span className="text-[11px] text-red-400">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/components/customer/NewLeadButton.tsx
+++ b/apps/web/components/customer/NewLeadButton.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createLead } from "@/lib/actions/leads";
+
+const inputClasses =
+  "bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-3 py-2 text-sm focus:border-[var(--dpf-accent)] focus:outline-none placeholder:text-[var(--dpf-muted)] w-full";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+// Manual lead capture: one small dialog lands the whole trio — contact (email
+// identity), account (dedup-aware reuse-or-create), engagement (status new).
+export function NewLeadButton() {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [company, setCompany] = useState("");
+  const [note, setNote] = useState("");
+
+  function submit() {
+    if (!firstName.trim() || !email.trim() || !company.trim()) {
+      setError("First name, email, and company are required.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      try {
+        await createLead({
+          firstName: firstName.trim(),
+          lastName: lastName.trim() || undefined,
+          email: email.trim(),
+          company: company.trim(),
+          note: note.trim() || undefined,
+        });
+        setFirstName(""); setLastName(""); setEmail(""); setCompany(""); setNote("");
+        setOpen(false);
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Something went wrong.");
+      }
+    });
+  }
+
+  if (!open) {
+    return (
+      <button
+        className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+        onClick={() => setOpen(true)}
+      >
+        + New lead
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-label="New lead">
+      <div className="w-full max-w-md rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+        <h2 className="mb-1 text-sm font-semibold text-[var(--dpf-text)]">New lead</h2>
+        <p className="mb-4 text-xs text-[var(--dpf-muted)]">
+          Creates the contact, links (or creates) the company, and starts the engagement.
+        </p>
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>First name *</label>
+              <input className={inputClasses} value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+            </div>
+            <div>
+              <label className={labelClasses}>Last name</label>
+              <input className={inputClasses} value={lastName} onChange={(e) => setLastName(e.target.value)} />
+            </div>
+          </div>
+          <div>
+            <label className={labelClasses}>Email *</label>
+            <input className={inputClasses} type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClasses}>Company *</label>
+            <input className={inputClasses} value={company} onChange={(e) => setCompany(e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClasses}>Note</label>
+            <input className={inputClasses} placeholder="Where did this lead come from?" value={note} onChange={(e) => setNote(e.target.value)} />
+          </div>
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <button className="px-3 py-1.5 text-sm text-[var(--dpf-muted)]" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+            <button
+              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              disabled={isPending}
+              onClick={submit}
+            >
+              {isPending ? "Creating…" : "Create lead"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/leads.test.ts
+++ b/apps/web/lib/actions/leads.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const { checkMock } = vi.hoisted(() => ({ checkMock: vi.fn() }));
+vi.mock("@/lib/mdm/dedup-gate", () => ({ checkCustomerAccountDuplicates: checkMock }));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    customerAccount: { findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn() },
+    customerContact: { findUnique: vi.fn(), create: vi.fn() },
+    engagement: { create: vi.fn(), update: vi.fn() },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { createLead, updateEngagementStatus } from "./leads";
+
+const p = prisma as unknown as {
+  customerAccount: { findFirst: ReturnType<typeof vi.fn>; findUnique: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  customerContact: { findUnique: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  engagement: { create: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  checkMock.mockResolvedValue({ verdict: "clear", candidates: [] });
+  p.customerAccount.findFirst.mockResolvedValue(null);
+  p.customerContact.findUnique.mockResolvedValue(null);
+  p.customerContact.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "c1", ...data }));
+  p.customerAccount.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "a1", name: data.name }));
+  p.engagement.create.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({ id: "e1", ...data }));
+});
+
+describe("createLead", () => {
+  it("lands the trio: prospect account, email-identity contact, new engagement", async () => {
+    const res = await createLead({ firstName: "Dan", lastName: "Warfield", email: "Dan@ManagingDigital.com", company: "Managing Digital" });
+    expect(p.customerAccount.create.mock.calls[0][0].data.status).toBe("prospect");
+    const contact = p.customerContact.create.mock.calls[0][0].data;
+    expect(contact.email).toBe("dan@managingdigital.com");
+    expect(contact.accountId).toBe("a1");
+    const eng = p.engagement.create.mock.calls[0][0].data;
+    expect(eng.status).toBe("new");
+    expect(eng.source).toBe("manual");
+    expect(eng.title).toContain("Dan Warfield");
+    expect(res.engagementId).toBe("e1");
+  });
+
+  it("reuses an exact-name account instead of creating a duplicate", async () => {
+    p.customerAccount.findFirst.mockResolvedValue({ id: "a-existing", name: "Managing Digital" });
+    await createLead({ firstName: "Dan", email: "dan@md.com", company: "managing digital" });
+    expect(p.customerAccount.create).not.toHaveBeenCalled();
+    expect(p.engagement.create.mock.calls[0][0].data.accountId).toBe("a-existing");
+  });
+
+  it("reuses a likely-duplicate account flagged by the dedup gate", async () => {
+    checkMock.mockResolvedValue({ verdict: "likely-duplicate", candidates: [{ id: "a-dup" }] });
+    p.customerAccount.findUnique.mockResolvedValue({ id: "a-dup", name: "Managing Digital Ltd" });
+    await createLead({ firstName: "Dan", email: "dan@md.com", company: "Managing Digital" });
+    expect(p.customerAccount.create).not.toHaveBeenCalled();
+    expect(p.engagement.create.mock.calls[0][0].data.accountId).toBe("a-dup");
+  });
+
+  it("reuses an existing contact by email identity", async () => {
+    p.customerContact.findUnique.mockResolvedValue({ id: "c-existing", email: "dan@md.com" });
+    await createLead({ firstName: "Dan", email: "dan@md.com", company: "MD" });
+    expect(p.customerContact.create).not.toHaveBeenCalled();
+    expect(p.engagement.create.mock.calls[0][0].data.contactId).toBe("c-existing");
+  });
+
+  it("requires first name, email, and company", async () => {
+    await expect(createLead({ firstName: "", email: "x@y.com", company: "C" })).rejects.toThrow(/required/i);
+  });
+});
+
+describe("updateEngagementStatus", () => {
+  it("applies the triage transition", async () => {
+    p.engagement.update.mockResolvedValue({ id: "e1", accountId: "a1" });
+    await updateEngagementStatus("e1", "contacted");
+    expect(p.engagement.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "e1" }, data: { status: "contacted" } }),
+    );
+  });
+});

--- a/apps/web/lib/actions/leads.ts
+++ b/apps/web/lib/actions/leads.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import crypto from "crypto";
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { checkCustomerAccountDuplicates } from "@/lib/mdm/dedup-gate";
+import { standardizeName } from "@/lib/mdm/standardize";
+
+// Manual lead capture — the missing top of the funnel. An Engagement (status
+// lifecycle new→contacted→qualified/unqualified→converted) IS this platform's
+// lead record; qualifyEngagement IS lead-convert (it creates the opportunity
+// and links contact+account). What was missing is a door that takes the way
+// leads actually arrive — "Dan Warfield at Managing Digital, dan@..." — and
+// lands the whole trio: contact (email identity), account, engagement.
+
+export async function createLead(input: {
+  firstName: string;
+  lastName?: string;
+  email: string;
+  company: string;
+  phone?: string;
+  note?: string;
+}) {
+  const email = input.email.trim().toLowerCase();
+  const firstName = input.firstName.trim();
+  const company = input.company.trim();
+  if (!firstName || !email || !company) {
+    throw new Error("First name, email, and company are required");
+  }
+  const lastName = input.lastName?.trim() || undefined;
+  const personName = [firstName, lastName].filter(Boolean).join(" ");
+
+  // Account: reuse an exact-name match, then a likely-duplicate (same company
+  // spelled slightly differently — the dedup gate's high-confidence verdict),
+  // else create a fresh prospect. Lead capture must never mint dup accounts.
+  let account = await prisma.customerAccount.findFirst({
+    where: { name: { equals: company, mode: "insensitive" } },
+    select: { id: true, name: true },
+  });
+  if (!account) {
+    const check = await checkCustomerAccountDuplicates({ name: company });
+    const top = check.candidates[0];
+    if (check.verdict === "likely-duplicate" && top) {
+      const existing = await prisma.customerAccount.findUnique({
+        where: { id: top.id },
+        select: { id: true, name: true },
+      });
+      account = existing ?? null;
+    }
+  }
+  if (!account) {
+    account = await prisma.customerAccount.create({
+      data: {
+        accountId: `ACCT-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
+        name: company,
+        nameNormalized: standardizeName(company),
+        status: "prospect",
+        notes: input.note?.trim() || null,
+      },
+      select: { id: true, name: true },
+    });
+  }
+
+  // Contact: email is the identity key — reuse or create under the account.
+  let contact = await prisma.customerContact.findUnique({ where: { email } });
+  if (!contact) {
+    contact = await prisma.customerContact.create({
+      data: {
+        accountId: account.id,
+        email,
+        firstName,
+        lastName: lastName ?? null,
+        name: personName,
+        nameNormalized: standardizeName(personName),
+        phone: input.phone?.trim() || null,
+        source: "manual",
+      },
+    });
+  }
+
+  const engagement = await prisma.engagement.create({
+    data: {
+      engagementId: `ENG-${crypto.randomUUID()}`,
+      title: `${personName} — ${account.name}`,
+      status: "new",
+      source: "manual",
+      accountId: account.id,
+      contactId: contact.id,
+      notes: input.note?.trim() || null,
+    },
+  });
+
+  revalidatePath("/customer/engagements");
+  revalidatePath("/customer");
+  return { engagementId: engagement.id, accountId: account.id, contactId: contact.id };
+}
+
+/** Triage transitions for the lead lifecycle (qualify has its own convert action). */
+export async function updateEngagementStatus(
+  engagementId: string,
+  status: "contacted" | "unqualified",
+) {
+  const engagement = await prisma.engagement.update({
+    where: { id: engagementId },
+    data: { status },
+    select: { id: true, accountId: true },
+  });
+  revalidatePath("/customer/engagements");
+  return engagement;
+}

--- a/docs/superpowers/plans/2026-07-06-lead-capture-triage-plan.md
+++ b/docs/superpowers/plans/2026-07-06-lead-capture-triage-plan.md
@@ -1,0 +1,33 @@
+# Plan — Lead capture + triage on the Engagement substrate (BI-7906DAC0)
+
+Date: 2026-07-06. Epic: EP-B51FA3BC. Build-order slice 3 of the parity gap matrix.
+
+## Substrate finding (dpf-verify-substrate-first)
+
+The platform already HAS a lead model: `Engagement` carries the full lead lifecycle
+(`new → contacted → qualified/unqualified → converted`, `convertedToId`), and
+`qualifyEngagement` IS Salesforce lead-convert (creates the opportunity, links
+contact+account, stamps converted). No new model. What was missing:
+
+1. A **manual capture door** — engagements only arrived from storefront signals; leads that
+   arrive as "Dan Warfield at Managing Digital, dan@…" had nowhere to land.
+2. **Triage controls** — the Engagements tab listed rows read-only; no contacted /
+   disqualify / qualify actions.
+
+## Design
+
+- `createLead` action (`apps/web/lib/actions/leads.ts`): one call lands the trio —
+  account (exact-name reuse → dedup-gate likely-duplicate reuse → create prospect),
+  contact (email identity: reuse or create), engagement (status new, source manual).
+  Lead capture must never mint duplicate accounts, hence the reuse ladder.
+- `updateEngagementStatus`: the two triage transitions (contacted / unqualified).
+- `NewLeadButton` (Engagements header): first/last/email/company/note dialog.
+- `EngagementTriageActions` (each row): Mark contacted · Qualify → opportunity (existing
+  `qualifyEngagement`) · Disqualify; only valid transitions render; qualify disabled until
+  an account is linked.
+
+## Verification
+
+leads.test.ts: trio creation, exact-name reuse, likely-duplicate reuse, contact-identity
+reuse, validation, triage transition. Live check post-deploy: capture a test lead, walk
+new → contacted → qualified and see the opportunity appear on the pipeline.


### PR DESCRIPTION
**BI-7906DAC0** (EP-B51FA3BC slice 3). Engagement already IS the lead model — `qualifyEngagement` IS lead-convert. Missing: a manual capture door and triage controls.

- `createLead`: lands the trio — account (exact-name → dedup-gate likely-dup reuse → create prospect), contact (email identity), engagement (new/manual).
- `updateEngagementStatus`: contacted / unqualified.
- `NewLeadButton` + per-row `EngagementTriageActions` (Mark contacted · Qualify → opportunity · Disqualify) on the Engagements tab.

Tests 6/6 green; guards green. No migration.

UX-Fit-Decision: one 4-field capture dialog matching how leads arrive; per-row triage shows only valid transitions; qualify explains itself when disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)