### PR TITLE
feat(crm): close the auto-activity-capture hole — contact creation on the timeline

### DIFF
--- a/apps/web/lib/actions/customer-contacts.test.ts
+++ b/apps/web/lib/actions/customer-contacts.test.ts
@@ -11,6 +11,7 @@ vi.mock("@dpf/db", () => ({
   prisma: {
     customerAccount: { findUnique: vi.fn() },
     customerContact: { findUnique: vi.fn(), create: vi.fn() },
+    activity: { create: vi.fn().mockResolvedValue({}) },
   },
 }));
 
@@ -20,6 +21,7 @@ import { createCustomerContact } from "./customer-contacts";
 const p = prisma as unknown as {
   customerAccount: { findUnique: ReturnType<typeof vi.fn> };
   customerContact: { findUnique: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  activity: { create: ReturnType<typeof vi.fn> };
 };
 
 beforeEach(() => {
@@ -46,6 +48,11 @@ describe("createCustomerContact", () => {
     expect(data.name).toBe("Ian Pruden");
     expect(data.nameNormalized.length).toBeGreaterThan(0);
     expect(data.source).toBe("manual");
+    // auto-capture: creation lands on the account timeline
+    const act = p.activity.create.mock.calls[0][0].data;
+    expect(act.subject).toContain("Ian Pruden");
+    expect(act.accountId).toBe("a1");
+    expect(act.contactId).toBe("c1");
   });
 
   it("returns the existing contact on exact email match (never duplicates)", async () => {

--- a/apps/web/lib/actions/customer-contacts.ts
+++ b/apps/web/lib/actions/customer-contacts.ts
@@ -8,6 +8,7 @@ import {
   type DedupResolution,
 } from "@/lib/mdm/dedup-gate";
 import { standardizeName } from "@/lib/mdm/standardize";
+import crypto from "crypto";
 
 // Structured contact capture (BI-D873CD28). CustomerContact existed as a model
 // but was unreachable from the CRM surface — no create action, no coworker
@@ -83,6 +84,21 @@ export async function createCustomerContact(
       source: "manual",
     },
   });
+
+  // Auto-capture: contact creation lands on the account timeline like every
+  // other CRM mutation, whether a human or a coworker performed it.
+  await prisma.activity
+    .create({
+      data: {
+        activityId: `ACT-${crypto.randomUUID()}`,
+        type: "note",
+        subject: `Contact added: ${displayName} (${email})`,
+        accountId: input.accountId,
+        contactId: contact.id,
+        completedAt: new Date(),
+      },
+    })
+    .catch(() => {});
 
   revalidatePath(`/customer/${input.accountId}`);
   revalidatePath("/customer");

--- a/docs/superpowers/plans/2026-07-06-coworker-auto-activity-capture-plan.md
+++ b/docs/superpowers/plans/2026-07-06-coworker-auto-activity-capture-plan.md
@@ -1,0 +1,27 @@
+# Plan — Coworker auto-activity capture (BI-5618BADF)
+
+Date: 2026-07-06. Epic: EP-B51FA3BC. Build-order slice 6 — "the CRM records itself",
+the #1 loved-CRM mechanic from the parity research.
+
+## Substrate audit (dpf-verify-substrate-first)
+
+Auto-capture is ALREADY nearly complete by construction: coworker tools call the same
+server actions as the UI, and `crm.ts` logs system activities on every mutation —
+account create, site/CI create+update, engagement create/qualify, opportunity
+create/stage-change, quote create/revise/send/accept (+ order + closed-won), and
+`subscriptions.ts` logs conversion + contract creation. So coworker-driven work already
+lands on account timelines.
+
+The audit found ONE hole: **contact creation** (`createCustomerContact`, added in #2629)
+wrote no timeline activity — a coworker could add a contact invisibly.
+
+## Design
+
+- `createCustomerContact` now writes a `note` Activity ("Contact added: <name> (<email>)")
+  linked to both the account and the contact — same fail-open pattern as the other writes.
+- Lead capture (`createLead`, in-flight #2640) creates the Engagement itself, which is the
+  visible record on the Engagements tab; a timeline echo can join later if wanted.
+
+## Verification
+
+customer-contacts test asserts the captured activity (subject/account/contact linkage).


### PR DESCRIPTION
**BI-5618BADF** (EP-B51FA3BC slice 6). Audit showed auto-capture already works by construction (coworker tools share the UI's server actions; crm.ts logs every mutation). One hole: `createCustomerContact` wrote no timeline activity. Now it does — note-type Activity linked to account + contact, fail-open. Test 5/5; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)