### PR TITLE
fix(decision-gov): materialize the WWWD fallback profile row — the FK that kept every install's org corpus dormant (BI-44526F3E)

### DIFF
--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
@@ -127,10 +127,16 @@ describe("seedOrgWwwdCorpus", () => {
 
     const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
 
-    // Profile container
+    // Profile containers: the platform fallback row (FK target, seeded first
+    // so the org profile's fallbackProfileId FK cannot violate) + the org row.
     expect(result.profileId).toBe(`org-perspective-${ORG}`);
-    expect(fake.profiles).toHaveLength(1);
+    expect(fake.profiles).toHaveLength(2);
     expect(fake.profiles[0]).toMatchObject({
+      profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      kind: "organization",
+      fallbackProfileId: null,
+    });
+    expect(fake.profiles[1]).toMatchObject({
       kind: "organization",
       ownerOrganizationId: ORG,
       fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
@@ -193,7 +199,8 @@ describe("seedOrgWwwdCorpus", () => {
     await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
     await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
 
-    expect(fake.profiles).toHaveLength(1);
+    // Fallback + org profile, each upserted once (no duplicates on re-run).
+    expect(fake.profiles).toHaveLength(2);
     expect(fake.versions).toHaveLength(1);
     expect(fake.materials).toHaveLength(4);
     expect(fake.wikiPages).toHaveLength(4);

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -221,6 +221,28 @@ export async function seedOrgWwwdCorpus(
   const industry = sf?.archetype?.category ?? bc?.industry ?? null;
   const orgName = org?.name ?? null;
 
+  // 0. Ensure the platform fallback profile ROW exists. The org profile's
+  // fallbackProfileId carries an FK to it, but the fallback shipped only as an
+  // in-code constant (default-profile.ts) — no seed ever materialized it, so
+  // this upsert threw P2003 on every install and the fail-open completion
+  // chain swallowed it: THE reason the WWWD substrate stayed dormant
+  // (observed live 2026-07-06, BI-44526F3E). Minimal row, no version — the
+  // resolution chain only needs the profile to exist.
+  await db.decisionPerspectiveProfile.upsert({
+    where: { profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID },
+    update: {},
+    create: {
+      profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      name: "DPF Organizational Principles",
+      kind: "organization",
+      scope: { domains: ["platform-governance", PLAN_READINESS_DOMAIN_CLASS] },
+      fallbackProfileId: null,
+      defaultResolver: { type: "build-studio-owner" },
+      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
+      status: "active",
+    },
+  });
+
   // 1. Profile (container).
   await db.decisionPerspectiveProfile.upsert({
     where: { profileId },

--- a/docs/superpowers/plans/2026-07-06-wwwd-corpus-onboarding-contextualization-plan.md
+++ b/docs/superpowers/plans/2026-07-06-wwwd-corpus-onboarding-contextualization-plan.md
@@ -5,6 +5,8 @@
 **Scope:** The org-level "what would WE do?" (WWWD) decision corpus — how a new company's onboarding produces it, how existing installs get it retroactively, and how coworkers' business decisions actually consult it. Companion to the WWMD recontextualization (PRs #2591/#2623).
 **Status:** Executing — operator authorized full overnight execution 2026-07-06 ("execute all"). Phases A+B land together in one PR (the boot backfill runs the Phase-B generator through the shared seed chain); Phase C is its own PR. Open-question calls taken with the recommendations: backfill via boot reconcile (no extra hub button), C1 as coworker conversation, honest starter framing kept.
 
+**Live-verification finding (post Phase A deploy):** the first backfill run on the reference install failed with a P2003 FK violation — `seedOrgWwwdCorpus` points `fallbackProfileId` at `dpf-organizational-principles`, which only ever existed as an in-code constant ([default-profile.ts](apps/web/lib/decision-perspective/default-profile.ts)); no seed materializes the row (`seed-decision-perspective.ts` creates `mark-dpf-platform` + `wsid-*` only). **This FK throw, swallowed by the fail-open completion chain, is the root cause of the WWWD substrate being dormant on every install — fresh ones included.** Fix: the seeder now upserts the fallback profile row before the org profile (same-BI follow-up PR).
+
 ---
 
 ## 1. What WWWD actually is (verified against code + live install, 2026-07-06)


### PR DESCRIPTION
## Summary

Live verification of the Phase A boot backfill (#2632) caught the actual root cause of the dormant WWWD substrate: `seedOrgWwwdCorpus` sets `fallbackProfileId: "dpf-organizational-principles"`, but no seed ever materialized that profile as a DB row (`seed-decision-perspective.ts` creates `mark-dpf-platform` + `wsid-*` only; the fallback lived purely as an in-code constant). The org-profile upsert threw **P2003 on every install — fresh onboarding included** — and the fail-open completion chain swallowed it. Observed live on the reference install:

```
[wwwd-backfill] org cmq5kq9ob…: seed failed (non-fatal): PrismaClientKnownRequestError
Foreign key constraint violated: DecisionPerspectiveProfile_fallbackProfileId_fkey
```

## Fix

The seeder upserts the fallback profile row (minimal — the resolution chain only needs the row to exist) before the org profile. Heals the boot backfill AND fresh onboarding.

## Testing

- Seeder suite updated for the FK-target row (order + idempotency asserted), 13 tests green; apps/web tsc clean.
- Post-merge: the next self-upgrade's boot backfill on the reference install is the live proof (org profile + 4 overlay pages + operating-model pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)