### PR TITLE
feat(decision-gov): decision audit log — persist principle_decide consults + per-tier /wiki/decisions surface (BI-E286E148)

### DIFF
--- a/apps/web/app/(shell)/wiki/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/wiki/decisions/[interactionId]/page.tsx
@@ -1,0 +1,218 @@
+// Decision drill-in — the full audit record for one DecisionInteraction:
+// what was asked, the options weighed, what was recommended and why (top
+// principle contributors), flags, and any human resolution.
+// Server component; queries Prisma directly.
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+
+import { StatusBadge } from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import { TIER_LABELS, tierForProfileKind } from "@/lib/wiki/decision-audit";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Decision record",
+};
+
+type Params = Promise<{ interactionId: string }>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+type Contributor = {
+  principleId: string;
+  principleName: string;
+  tier: string;
+  contribution: number;
+};
+
+function readContributors(payload: Record<string, unknown>): Contributor[] {
+  if (!Array.isArray(payload.topContributors)) return [];
+  return payload.topContributors
+    .map((entry) => {
+      const c = asRecord(entry);
+      return typeof c.principleId === "string" && typeof c.contribution === "number"
+        ? {
+          principleId: c.principleId,
+          principleName: typeof c.principleName === "string" ? c.principleName : c.principleId,
+          tier: typeof c.tier === "string" ? c.tier : "—",
+          contribution: c.contribution,
+        }
+        : null;
+    })
+    .filter((c): c is Contributor => Boolean(c));
+}
+
+export default async function DecisionRecordPage({ params }: { params: Params }) {
+  const { interactionId } = await params;
+
+  const row = await prisma.decisionInteraction.findUnique({
+    where: { interactionId },
+    include: {
+      profile: { select: { kind: true, name: true, profileId: true } },
+      escalationCapture: true,
+      deferralCapture: true,
+    },
+  });
+  if (!row) notFound();
+
+  const tier = tierForProfileKind(row.profile?.kind);
+  const tierLabel = TIER_LABELS[tier];
+  const payload = asRecord(row.outcomePayload);
+  const optionDescriptions = asRecord(payload.optionDescriptions);
+  const contributors = readContributors(payload);
+  const options = Array.isArray(row.options)
+    ? row.options.filter((o): o is string => typeof o === "string")
+    : [];
+  const recommendedOptionId =
+    typeof payload.recommendedOptionId === "string" ? payload.recommendedOptionId : null;
+
+  return (
+    <div className="max-w-3xl mx-auto py-6 px-4">
+      <header className="mb-6">
+        <Link href="/wiki/decisions" className="text-sm text-[var(--dpf-accent)] hover:underline">
+          ← Decision log
+        </Link>
+        <div className="mt-2 flex items-center gap-2 flex-wrap">
+          <StatusBadge
+            intent={tier === "wwmd" ? "info" : tier === "wwwd" ? "accent" : "neutral"}
+            label={`${tierLabel.code} — ${tierLabel.expansion}`}
+            variant="soft"
+          />
+          <StatusBadge domain="decisionOutcome" status={row.outcomeType} />
+          <StatusBadge domain="decisionRisk" status={row.riskTier} variant="soft" />
+          {row.principleConflict ? (
+            <StatusBadge intent="danger" label="principle conflict" variant="soft" />
+          ) : null}
+        </div>
+        <h1 className="mt-3 text-xl font-semibold text-[var(--dpf-text)]">
+          {row.question || "(no question text)"}
+        </h1>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          <LocalTime value={row.createdAt} /> · {row.profile?.name ?? row.profileId} ·{" "}
+          {row.routeContext ?? "—"} · {row.domainClass} · {row.interactionId}
+        </p>
+      </header>
+
+      {/* Options weighed */}
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
+          Options weighed
+        </h2>
+        {options.length === 0 ? (
+          <p className="text-sm text-[var(--dpf-muted)]">No options recorded.</p>
+        ) : (
+          <ul className="space-y-2">
+            {options.map((optionId) => {
+              const description = optionDescriptions[optionId];
+              const isRecommended = optionId === recommendedOptionId;
+              return (
+                <li
+                  key={optionId}
+                  className={`rounded-lg border p-3 ${
+                    isRecommended
+                      ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)]"
+                      : "border-[var(--dpf-border)]"
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm text-[var(--dpf-text)]">{optionId}</span>
+                    {isRecommended ? (
+                      <StatusBadge intent="success" label="recommended" variant="soft" />
+                    ) : null}
+                  </div>
+                  {typeof description === "string" && description ? (
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">{description}</p>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* Why */}
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
+          Why
+        </h2>
+        <p className="text-sm text-[var(--dpf-text)] whitespace-pre-wrap">
+          {row.rationale || "No rationale recorded."}
+        </p>
+        {contributors.length > 0 ? (
+          <div className="mt-3 rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-left text-[var(--dpf-muted)] border-b border-[var(--dpf-border)]">
+                  <th className="px-3 py-2 font-medium">Principle</th>
+                  <th className="px-3 py-2 font-medium">Tier</th>
+                  <th className="px-3 py-2 font-medium text-right">Contribution</th>
+                </tr>
+              </thead>
+              <tbody>
+                {contributors.map((c) => (
+                  <tr key={c.principleId} className="border-b border-[var(--dpf-border)] last:border-0">
+                    <td className="px-3 py-2 text-[var(--dpf-text)]">{c.principleName}</td>
+                    <td className="px-3 py-2 text-[var(--dpf-muted)]">{c.tier}</td>
+                    <td
+                      className={`px-3 py-2 text-right font-mono ${
+                        c.contribution < 0 ? "text-[var(--dpf-error)]" : "text-[var(--dpf-text)]"
+                      }`}
+                    >
+                      {c.contribution.toFixed(3)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+
+      {/* Human resolution */}
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
+          Human review
+        </h2>
+        {row.escalationCapture ? (
+          <div className="rounded-lg border border-[var(--dpf-border)] p-3 text-sm">
+            <p className="text-[var(--dpf-text)]">
+              {row.escalationCapture.answer ?? "(resolved without an answer text)"}
+            </p>
+            {row.escalationCapture.rationale ? (
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                {row.escalationCapture.rationale}
+              </p>
+            ) : null}
+            <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+              Resolved <LocalTime value={row.escalationCapture.createdAt} />
+            </p>
+          </div>
+        ) : row.deferralCapture ? (
+          <p className="text-sm text-[var(--dpf-muted)]">
+            Deferred — {row.deferralCapture.gapReason}. The perspective lacks material to answer;
+            adding stance/principle coverage closes this gap.
+          </p>
+        ) : row.outcomeType === "escalate" || row.outcomeType === "defer" ? (
+          <p className="text-sm text-[var(--dpf-muted)]">
+            Awaiting human review — see{" "}
+            <Link href="/wiki/review" className="text-[var(--dpf-accent)] hover:underline">
+              Review &amp; adjust
+            </Link>
+            .
+          </p>
+        ) : (
+          <p className="text-sm text-[var(--dpf-muted)]">
+            None needed — the recommendation stood on its own.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/wiki/decisions/page.tsx
+++ b/apps/web/app/(shell)/wiki/decisions/page.tsx
@@ -1,0 +1,202 @@
+// Decision log — the audit surface over the DecisionInteraction ledger,
+// split by governance tier (WWMD / WWWD / WSID). Answers "is the decision
+// gate actually being used, and what did it decide?" — per-tier usage stats
+// up top, the decision timeline below, drill-in per row.
+// Server component; queries Prisma directly (same pattern as /wiki).
+
+import Link from "next/link";
+import { prisma } from "@dpf/db";
+
+import { StatCard } from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import { DecisionAuditTable } from "@/components/wiki/DecisionAuditTable";
+import {
+  DECISION_AUDIT_TIERS,
+  buildTierStats,
+  profileKindsForTier,
+  toAuditRow,
+  type DecisionAuditRowInput,
+  type DecisionAuditTier,
+} from "@/lib/wiki/decision-audit";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Decision log",
+};
+
+type SearchParams = Promise<{ tier?: string }>;
+
+const UNRESOLVED = ["defer", "escalate"];
+const ROW_LIMIT = 200;
+
+function isTier(value: string | undefined): value is DecisionAuditTier {
+  return (DECISION_AUDIT_TIERS as readonly string[]).includes(value ?? "");
+}
+
+export default async function DecisionLogPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const sp = await searchParams;
+  const activeTier = isTier(sp.tier) ? sp.tier : null;
+
+  const now = Date.now();
+  const d7 = new Date(now - 7 * 24 * 60 * 60 * 1000);
+  const d30 = new Date(now - 30 * 24 * 60 * 60 * 1000);
+
+  // Per-tier usage stats (always all three, independent of the filter) +
+  // the filtered timeline rows, in parallel.
+  const [tierStatRaw, rows] = await Promise.all([
+    Promise.all(
+      DECISION_AUDIT_TIERS.map(async (tier) => {
+        const where = { profile: { kind: { in: profileKindsForTier(tier) } } };
+        const [total, last7d, last30d, unresolved, latest] = await Promise.all([
+          prisma.decisionInteraction.count({ where }),
+          prisma.decisionInteraction.count({
+            where: { ...where, createdAt: { gte: d7 } },
+          }),
+          prisma.decisionInteraction.count({
+            where: { ...where, createdAt: { gte: d30 } },
+          }),
+          prisma.decisionInteraction.count({
+            where: { ...where, outcomeType: { in: UNRESOLVED }, escalationCapture: null },
+          }),
+          prisma.decisionInteraction.findFirst({
+            where,
+            orderBy: { createdAt: "desc" },
+            select: { createdAt: true },
+          }),
+        ]);
+        return buildTierStats({
+          tier,
+          total,
+          last7d,
+          last30d,
+          unresolved,
+          lastDecisionAt: latest?.createdAt ?? null,
+        });
+      }),
+    ),
+    prisma.decisionInteraction.findMany({
+      where: activeTier
+        ? { profile: { kind: { in: profileKindsForTier(activeTier) } } }
+        : undefined,
+      orderBy: { createdAt: "desc" },
+      take: ROW_LIMIT,
+      select: {
+        interactionId: true,
+        createdAt: true,
+        question: true,
+        options: true,
+        outcomeType: true,
+        riskTier: true,
+        principleConflict: true,
+        domainClass: true,
+        routeContext: true,
+        rationale: true,
+        confidenceAfter: true,
+        outcomePayload: true,
+        humanOutcome: true,
+        profile: { select: { kind: true, name: true } },
+        escalationCapture: { select: { createdAt: true } },
+        deferralCapture: { select: { gapReason: true } },
+      },
+    }) as Promise<DecisionAuditRowInput[]>,
+  ]);
+
+  const auditRows = rows.map(toAuditRow);
+
+  const tierFilters: Array<{ label: string; tier: DecisionAuditTier | null }> = [
+    { label: "All tiers", tier: null },
+    { label: "WWMD", tier: "wwmd" },
+    { label: "WWWD", tier: "wwwd" },
+    { label: "WSID", tier: "wsid" },
+  ];
+
+  return (
+    <div className="max-w-5xl mx-auto py-6 px-4">
+      <header className="mb-6">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-[var(--dpf-text)] mb-1">
+              Decision log
+            </h1>
+            <p className="text-sm text-[var(--dpf-muted)]">
+              Every governed decision your AI workforce consulted the kernel on —
+              what was asked, what was recommended, and which calls still need a
+              human. A silent tier means that gate isn&rsquo;t being exercised.
+            </p>
+          </div>
+          <Link
+            href="/wiki"
+            className="text-sm text-[var(--dpf-accent)] hover:underline shrink-0"
+          >
+            ← Decision governance
+          </Link>
+        </div>
+      </header>
+
+      {/* Per-tier usage — the "is the gate in play?" answer at a glance. */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+        {tierStatRaw.map((s) => (
+          <StatCard
+            key={s.tier}
+            label={`${s.code} — ${s.expansion}`}
+            value={s.total === 0 ? "never used" : String(s.last30d)}
+            intent={s.total === 0 ? "warning" : s.unresolved > 0 ? "info" : "success"}
+            hint={
+              s.total === 0
+                ? "No decisions recorded on this tier yet."
+                : `${s.last30d} in 30d · ${s.unresolved} awaiting review · ${s.total} all-time`
+            }
+            href={`/wiki/decisions?tier=${s.tier}`}
+          />
+        ))}
+      </div>
+
+      {/* Tier filter */}
+      <div className="flex items-center gap-2 mb-4">
+        {tierFilters.map((f) => {
+          const active = f.tier === activeTier;
+          return (
+            <Link
+              key={f.label}
+              href={f.tier ? `/wiki/decisions?tier=${f.tier}` : "/wiki/decisions"}
+              className={
+                active
+                  ? "rounded-full border border-[var(--dpf-accent)] bg-[var(--dpf-accent)] px-3 py-1 text-xs font-medium text-white"
+                  : "rounded-full border border-[var(--dpf-border)] px-3 py-1 text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+              }
+            >
+              {f.label}
+            </Link>
+          );
+        })}
+        <span className="ml-auto text-xs text-[var(--dpf-muted)]">
+          {auditRows.length === ROW_LIMIT
+            ? `Showing the most recent ${ROW_LIMIT}`
+            : `${auditRows.length} decision${auditRows.length === 1 ? "" : "s"}`}
+        </span>
+      </div>
+
+      <DecisionAuditTable rows={auditRows} />
+
+      {tierStatRaw.some((s) => s.lastDecisionAt) ? (
+        <p className="mt-4 text-xs text-[var(--dpf-muted)]">
+          Most recent decision:{" "}
+          <LocalTime
+            value={
+              tierStatRaw
+                .map((s) => s.lastDecisionAt)
+                .filter((v): v is string => Boolean(v))
+                .sort()
+                .at(-1)
+            }
+          />
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/wiki/page.tsx
+++ b/apps/web/app/(shell)/wiki/page.tsx
@@ -72,6 +72,8 @@ export default async function WikiBrowsePage({
     : [WWWD_ORGANIZATION_PROFILE_ID];
 
   // Derive discipline health + fetch the retained material list in parallel.
+  const decisionWindow = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
   const [
     pages,
     kernelPrincipleCount,
@@ -81,6 +83,9 @@ export default async function WikiBrowsePage({
     wwwdOpenReviews,
     wsidActiveProfiles,
     wsidOpenReviews,
+    wwmdDecisions30d,
+    wwwdDecisions30d,
+    wsidDecisions30d,
   ] = await Promise.all([
     prisma.wikiPage.findMany({
       where,
@@ -127,6 +132,18 @@ export default async function WikiBrowsePage({
     prisma.decisionInteraction.count({
       where: { outcomeType: { in: UNRESOLVED }, profileId: { startsWith: "wsid-" } },
     }),
+    // Ledger usage per tier (30d) — the audit signal behind each card's
+    // usage chip; a zero surfaces "no decisions recorded" so a dormant gate
+    // is visible, not silently assumed active.
+    prisma.decisionInteraction.count({
+      where: { profileId: WWMD_PLATFORM_PROFILE_ID, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { profileId: { in: wwwdProfileIds }, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { profile: { kind: "profession" }, createdAt: { gte: decisionWindow } },
+    }),
   ]);
 
   const disciplineCards = buildDisciplineCards({
@@ -138,6 +155,9 @@ export default async function WikiBrowsePage({
     wsidFamilyCount: PROFESSION_REGISTRY.families.length,
     wsidActiveProfiles,
     wsidOpenReviews,
+    wwmdDecisions30d,
+    wwwdDecisions30d,
+    wsidDecisions30d,
   });
 
   return (

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -56,6 +56,19 @@ export function intentStyle(intent: Intent): IntentStyle {
  * (e.g. complaints) so each gets its own namespace.
  */
 export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
+  // Decision governance ledger (DecisionInteraction.outcomeType / riskTier).
+  decisionOutcome: {
+    recommend: "success",
+    arbitrate: "info",
+    escalate: "danger",
+    defer: "warning",
+  },
+  decisionRisk: {
+    low: "success",
+    medium: "warning",
+    high: "danger",
+    critical: "danger",
+  },
   // Portfolio coverage axis (BI-PORTCOV-P6): what relationship the org has to a
   // portfolio entry — used/sold = in use, available = configurable now,
   // potential = one governed click to enable, planned/retired.

--- a/apps/web/components/wiki/DecisionAuditTable.tsx
+++ b/apps/web/components/wiki/DecisionAuditTable.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+// Decision-ledger table for /wiki/decisions. Server page fetches the rows;
+// this client child composes the report-kit DataTable per its server-page →
+// client-table contract.
+
+import { DataTable, StatusBadge, type Column } from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import type { DecisionAuditRow } from "@/lib/wiki/decision-audit";
+
+const columns: Column<DecisionAuditRow>[] = [
+  {
+    key: "createdAt",
+    header: "When",
+    cell: (r) => <LocalTime value={r.createdAt} />,
+    sortAccessor: (r) => r.createdAt,
+  },
+  {
+    key: "tier",
+    header: "Tier",
+    cell: (r) => (
+      <StatusBadge
+        intent={r.tier === "wwmd" ? "info" : r.tier === "wwwd" ? "accent" : "neutral"}
+        label={r.tierCode}
+        variant="soft"
+      />
+    ),
+    sortAccessor: (r) => r.tierCode,
+  },
+  {
+    key: "question",
+    header: "Decision",
+    cell: (r) => (
+      <span className="block max-w-md truncate" title={r.question}>
+        {r.question || "—"}
+      </span>
+    ),
+  },
+  {
+    key: "outcome",
+    header: "Outcome",
+    cell: (r) => (
+      <span className="inline-flex items-center gap-1.5">
+        <StatusBadge domain="decisionOutcome" status={r.outcomeType} />
+        {r.awaitingHuman ? (
+          <StatusBadge intent="warning" label="awaiting review" variant="soft" />
+        ) : null}
+      </span>
+    ),
+    sortAccessor: (r) => r.outcomeType,
+  },
+  {
+    key: "recommended",
+    header: "Recommended",
+    cell: (r) => (
+      <span className="block max-w-[10rem] truncate" title={r.recommendedOptionId ?? undefined}>
+        {r.recommendedOptionId ?? "—"}
+      </span>
+    ),
+  },
+  {
+    key: "risk",
+    header: "Risk",
+    cell: (r) => <StatusBadge domain="decisionRisk" status={r.riskTier} variant="soft" />,
+    sortAccessor: (r) => r.riskTier,
+  },
+  {
+    key: "conflict",
+    header: "Conflict",
+    cell: (r) =>
+      r.principleConflict ? (
+        <StatusBadge intent="danger" label="principle conflict" variant="soft" />
+      ) : (
+        <span className="text-[var(--dpf-muted)]">—</span>
+      ),
+    sortAccessor: (r) => (r.principleConflict ? 1 : 0),
+  },
+  {
+    key: "where",
+    header: "Where",
+    cell: (r) => (
+      <span className="block max-w-[10rem] truncate text-[var(--dpf-muted)]" title={r.routeContext}>
+        {r.routeContext}
+      </span>
+    ),
+  },
+];
+
+export function DecisionAuditTable({ rows }: { rows: DecisionAuditRow[] }) {
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      getRowKey={(r) => r.interactionId}
+      rowHref={(r) => `/wiki/decisions/${r.interactionId}`}
+      initialSort={{ key: "createdAt", dir: "desc" }}
+      pageSize={25}
+      empty="No decisions recorded yet for this view."
+    />
+  );
+}

--- a/apps/web/lib/decision-perspective/types.ts
+++ b/apps/web/lib/decision-perspective/types.ts
@@ -16,7 +16,7 @@ export type DecisionRiskTier = typeof DECISION_RISK_TIERS[number];
 export const DECISION_OUTCOME_TYPES = ["recommend", "arbitrate", "escalate", "defer"] as const;
 export type DecisionOutcomeType = typeof DECISION_OUTCOME_TYPES[number];
 
-export const DECISION_DOMAIN_CLASSES = ["plan-readiness", "architecture-tradeoff", "risk-assessment", "professional-practice"] as const;
+export const DECISION_DOMAIN_CLASSES = ["plan-readiness", "architecture-tradeoff", "risk-assessment", "professional-practice", "kernel-consult"] as const;
 export type DecisionDomainClass = typeof DECISION_DOMAIN_CLASSES[number];
 export const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness" satisfies DecisionDomainClass;
 

--- a/apps/web/lib/decision/kernel-consult-ledger.test.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  mapConsultOutcome,
+  recordKernelConsultInteraction,
+} from "./kernel-consult-ledger";
+import type { DecisionResult } from "./option-scoring";
+import type { DecisionCallerContext } from "./caller-context";
+
+function makeResult(overrides: Partial<DecisionResult> = {}): DecisionResult {
+  return {
+    recommendation: {
+      optionId: "option-a",
+      composite: 4.2,
+      margin: 1.5,
+      confidence: "high",
+    },
+    scores: [
+      {
+        optionId: "option-a",
+        composite: 4.2,
+        contributions: [
+          {
+            principleId: "architecture-over-shortcuts",
+            principleName: "Architecture over shortcuts",
+            tier: "commandment",
+            weight: 1,
+            mode: "structured",
+            alignment: 1,
+            contribution: 1,
+          },
+        ],
+      },
+    ],
+    flags: {
+      tieMargin: 0.2,
+      semanticFallbackRatio: 0,
+      structuredCoverage: "strong",
+      commandmentConflict: false,
+      commandmentConflictPrinciples: [],
+    },
+    reasoning: "Recommends option-a.",
+    ...overrides,
+  };
+}
+
+const wwmdContext: DecisionCallerContext = {
+  principalId: null,
+  governingProfileId: "mark-dpf-platform",
+  governingProfileKind: "platform",
+  callingPopulation: "external_coding_agent",
+  resolvedVia: "calling-population",
+};
+
+function makeDb(overrides: {
+  profile?: { profileId: string; kind: string } | null;
+  version?: { versionId: string } | null;
+  createImpl?: (args: { data: Record<string, unknown> }) => Promise<unknown>;
+} = {}) {
+  const created: Array<Record<string, unknown>> = [];
+  return {
+    created,
+    decisionPerspectiveProfile: {
+      findUnique: vi.fn(async () =>
+        overrides.profile === undefined
+          ? { profileId: "mark-dpf-platform", kind: "platform" }
+          : overrides.profile,
+      ),
+    },
+    decisionPerspectiveProfileVersion: {
+      findFirst: vi.fn(async () =>
+        overrides.version === undefined
+          ? { versionId: "mark-dpf-platform-v1" }
+          : overrides.version,
+      ),
+    },
+    decisionInteraction: {
+      create:
+        overrides.createImpl ??
+        (async (args: { data: Record<string, unknown> }) => {
+          created.push(args.data);
+          return args.data;
+        }),
+    },
+  };
+}
+
+describe("mapConsultOutcome", () => {
+  it("maps a confident, conflict-free recommendation to recommend/low-risk", () => {
+    expect(mapConsultOutcome(makeResult())).toEqual({
+      outcomeType: "recommend",
+      riskTier: "low",
+      confidenceScore: 0.9,
+    });
+  });
+
+  it("maps a commandment conflict to escalate/high-risk", () => {
+    const result = makeResult();
+    result.flags.commandmentConflict = true;
+    result.flags.commandmentConflictPrinciples = ["never-fabricate"];
+    expect(mapConsultOutcome(result).outcomeType).toBe("escalate");
+    expect(mapConsultOutcome(result).riskTier).toBe("high");
+  });
+
+  it("maps a low-margin call to escalate (needs human review)", () => {
+    const result = makeResult();
+    result.recommendation = { ...result.recommendation!, confidence: "low" };
+    expect(mapConsultOutcome(result).outcomeType).toBe("escalate");
+  });
+
+  it("maps a no-signal result to defer (coverage gap)", () => {
+    const result = makeResult({ recommendation: null });
+    expect(mapConsultOutcome(result).outcomeType).toBe("defer");
+    expect(mapConsultOutcome(result).confidenceScore).toBe(0);
+  });
+});
+
+describe("recordKernelConsultInteraction", () => {
+  it("persists a ledger row attributed to the governing profile", async () => {
+    const db = makeDb();
+    const outcome = await recordKernelConsultInteraction({
+      db: db as never,
+      result: makeResult(),
+      callerContext: wwmdContext,
+      question: "Which storage approach should we take?",
+      optionIds: ["option-a", "option-b"],
+      optionDescriptions: { "option-a": "Reuse table", "option-b": "New table" },
+      appliedPrincipleCount: 21,
+      callingSurface: "claude-code",
+    });
+
+    expect(outcome.recorded).toBe(true);
+    expect(outcome.interactionId).toMatch(/^DI-/);
+    expect(db.created).toHaveLength(1);
+    const row = db.created[0];
+    expect(row.profileId).toBe("mark-dpf-platform");
+    expect(row.profileVersionId).toBe("mark-dpf-platform-v1");
+    expect(row.domainClass).toBe("kernel-consult");
+    expect(row.outcomeType).toBe("recommend");
+    expect(row.question).toBe("Which storage approach should we take?");
+    expect(row.options).toEqual(["option-a", "option-b"]);
+    expect(row.phaseFrom).toBeNull();
+    expect(row.phaseTo).toBeNull();
+    const payload = row.outcomePayload as Record<string, unknown>;
+    expect(payload.tool).toBe("principle_decide");
+    expect(payload.recommendedOptionId).toBe("option-a");
+    expect(payload.callingPopulation).toBe("external_coding_agent");
+    expect(Array.isArray(payload.topContributors)).toBe(true);
+  });
+
+  it("skips observably when the governing profile is not provisioned", async () => {
+    const db = makeDb({ profile: null });
+    const outcome = await recordKernelConsultInteraction({
+      db: db as never,
+      result: makeResult(),
+      callerContext: {
+        ...wwmdContext,
+        governingProfileId: "dpf-organizational-principles",
+        governingProfileKind: "organization",
+        callingPopulation: "in_platform_coworker",
+      },
+      question: "q",
+      optionIds: ["a"],
+      optionDescriptions: {},
+      appliedPrincipleCount: 0,
+    });
+    expect(outcome).toEqual({
+      recorded: false,
+      profileId: "dpf-organizational-principles",
+      reason: "profile-not-provisioned",
+    });
+    expect(db.created).toHaveLength(0);
+  });
+
+  it("fails open when the ledger write throws", async () => {
+    const db = makeDb({
+      createImpl: async () => {
+        throw new Error("db down");
+      },
+    });
+    const outcome = await recordKernelConsultInteraction({
+      db: db as never,
+      result: makeResult(),
+      callerContext: wwmdContext,
+      question: "q",
+      optionIds: ["a"],
+      optionDescriptions: {},
+      appliedPrincipleCount: 1,
+    });
+    expect(outcome.recorded).toBe(false);
+    expect(outcome.reason).toBe("write-failed");
+  });
+});

--- a/apps/web/lib/decision/kernel-consult-ledger.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.ts
@@ -1,0 +1,180 @@
+// Kernel-consult decision ledger — persists every `principle_decide` call to
+// the DecisionInteraction audit table so WWMD/WWWD/WSID governance is
+// observable, not just advisory.
+//
+// Before this module, `principle_decide` computed a recommendation and
+// returned it with no durable record: the decision ledger stayed empty on
+// installs where the kernel was consulted constantly, so an operator could
+// not validate the HITL-equivalent gate was in play at all. The write is
+// fail-open (a ledger outage must never block the decision itself), but the
+// outcome is always observable in the tool response (`ledger.recorded`),
+// per make-silent-failures-observable.
+
+import type { DecisionResult } from "@/lib/decision/option-scoring";
+import type { DecisionCallerContext } from "@/lib/decision/caller-context";
+import {
+  persistDecisionInteraction,
+} from "@/lib/decision-perspective/persistence";
+import type {
+  DecisionOutcomeType,
+  DecisionPerspectiveEvaluationResult,
+  DecisionRiskTier,
+} from "@/lib/decision-perspective/types";
+
+type ProfileResolverDb = {
+  decisionPerspectiveProfile: {
+    findUnique(args: {
+      where: { profileId: string };
+      select: { profileId: true; kind: true };
+    }): Promise<{ profileId: string; kind: string } | null>;
+  };
+  decisionPerspectiveProfileVersion: {
+    findFirst(args: {
+      where: { profileId: string };
+      orderBy: { versionNumber: "desc" };
+      select: { versionId: true };
+    }): Promise<{ versionId: string } | null>;
+  };
+} & Parameters<typeof persistDecisionInteraction>[0]["db"];
+
+export type KernelConsultLedgerOutcome = {
+  recorded: boolean;
+  interactionId?: string;
+  profileId?: string;
+  /** Why the write was skipped, when it was. */
+  reason?: string;
+};
+
+/**
+ * Map the pure decide() result onto the ledger's unresolved/resolved
+ * semantics: a confident, conflict-free recommendation is `recommend`; a
+ * commandment conflict or low-margin call is `escalate` (needs human review —
+ * these feed the hub's open-review counts); no applicable principles is
+ * `defer` (a coverage gap).
+ */
+export function mapConsultOutcome(result: DecisionResult): {
+  outcomeType: DecisionOutcomeType;
+  riskTier: DecisionRiskTier;
+  confidenceScore: number;
+} {
+  if (!result.recommendation) {
+    return { outcomeType: "defer", riskTier: "medium", confidenceScore: 0 };
+  }
+  if (result.flags.commandmentConflict) {
+    return { outcomeType: "escalate", riskTier: "high", confidenceScore: 0.3 };
+  }
+  if (result.recommendation.confidence === "low") {
+    return { outcomeType: "escalate", riskTier: "medium", confidenceScore: 0.5 };
+  }
+  return { outcomeType: "recommend", riskTier: "low", confidenceScore: 0.9 };
+}
+
+export async function recordKernelConsultInteraction(input: {
+  db: ProfileResolverDb;
+  result: DecisionResult;
+  callerContext: DecisionCallerContext;
+  /** The decision context/question text supplied by the caller. */
+  question: string;
+  /** Option ids as supplied to decide(). */
+  optionIds: string[];
+  /** Full option descriptions, kept in the payload for the audit drill-in. */
+  optionDescriptions: Record<string, string>;
+  appliedPrincipleCount: number;
+  callingSurface?: string | null;
+  routeContext?: string | null;
+  taskRunId?: string | null;
+  triggeredByUserId?: string | null;
+}): Promise<KernelConsultLedgerOutcome> {
+  try {
+    const profileId = input.callerContext.governingProfileId;
+    const [profile, version] = await Promise.all([
+      input.db.decisionPerspectiveProfile.findUnique({
+        where: { profileId },
+        select: { profileId: true, kind: true },
+      }),
+      input.db.decisionPerspectiveProfileVersion.findFirst({
+        where: { profileId },
+        orderBy: { versionNumber: "desc" },
+        select: { versionId: true },
+      }),
+    ]);
+    if (!profile || !version) {
+      // Observable skip — e.g. the WWWD fallback constant has no DB row on
+      // installs that predate the org-profile seed (BI-44526F3E).
+      console.warn(
+        `[kernel-consult-ledger] skipped: governing profile "${profileId}" is not provisioned (profile=${Boolean(profile)}, version=${Boolean(version)})`,
+      );
+      return { recorded: false, profileId, reason: "profile-not-provisioned" };
+    }
+
+    const { outcomeType, riskTier, confidenceScore } = mapConsultOutcome(input.result);
+
+    // Top contributions for the recommended option — the "why" the audit
+    // drill-in shows without replaying the scoring math.
+    const winner = input.result.recommendation
+      ? input.result.scores.find((s) => s.optionId === input.result.recommendation?.optionId)
+      : null;
+    const topContributors = winner
+      ? [...winner.contributions]
+        .sort((a, b) => Math.abs(b.contribution) - Math.abs(a.contribution))
+        .slice(0, 5)
+        .map((c) => ({
+          principleId: c.principleId,
+          principleName: c.principleName,
+          tier: c.tier,
+          contribution: Number(c.contribution.toFixed(4)),
+        }))
+      : [];
+
+    const evaluation: DecisionPerspectiveEvaluationResult = {
+      outcomeType,
+      selectedProfileId: profile.profileId,
+      fallbackProfileId: null,
+      profileVersionId: version.versionId,
+      confidenceBefore: confidenceScore,
+      confidenceAfter: confidenceScore,
+      confidenceScore,
+      coverageGap: !input.result.recommendation,
+      principleConflict: input.result.flags.commandmentConflict,
+      domainClass: "kernel-consult",
+      resolvedProfileChain: [profile.profileId],
+      materialCount: input.appliedPrincipleCount,
+      freshnessDistribution: { current: 0, stale: 0, superseded: 0, contradicted: 0 },
+      riskTier,
+      question: input.question,
+      options: input.optionIds,
+      rationale: input.result.reasoning,
+      materialScores: [],
+      sources: [],
+    };
+
+    const { interactionId } = await persistDecisionInteraction({
+      db: input.db,
+      build: null,
+      evaluation,
+      taskRunId: input.taskRunId ?? null,
+      triggeredByUserId: input.triggeredByUserId ?? null,
+      routeContext: input.routeContext ?? input.callingSurface ?? "mcp:principle_decide",
+      phaseFrom: null,
+      phaseTo: null,
+      outcomePayloadExtra: {
+        tool: "principle_decide",
+        callingPopulation: input.callerContext.callingPopulation,
+        callingSurface: input.callingSurface ?? null,
+        recommendedOptionId: input.result.recommendation?.optionId ?? null,
+        composite: input.result.recommendation?.composite ?? null,
+        margin: input.result.recommendation?.margin ?? null,
+        recommendationConfidence: input.result.recommendation?.confidence ?? null,
+        commandmentConflictPrinciples: input.result.flags.commandmentConflictPrinciples,
+        structuredCoverage: input.result.flags.structuredCoverage,
+        optionDescriptions: input.optionDescriptions,
+        topContributors,
+      },
+    });
+
+    return { recorded: true, interactionId, profileId: profile.profileId };
+  } catch (err) {
+    console.warn("[kernel-consult-ledger] write failed (fail-open):", err);
+    return { recorded: false, reason: "write-failed" };
+  }
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -13295,6 +13295,31 @@ export async function executeTool(
         ? `Recommends ${result.recommendation.optionId} (confidence: ${result.recommendation.confidence}, composite ${result.recommendation.composite.toFixed(3)}; governing profile: ${governingProfile.governingProfileKind})`
         : "No applicable principles to evaluate.";
 
+      // Persist the consult to the DecisionInteraction ledger so the decision
+      // governance hub can audit that the gate is in use (per-tier log at
+      // /wiki/decisions). Fail-open: a ledger outage never blocks the
+      // decision, but the outcome is named in the response either way.
+      // This is audit observability, not a business mutation — the tool's
+      // read-only annotation stays as-is (ToolExecution already logs calls;
+      // this adds the decision-shaped record the governance surfaces read).
+      const { recordKernelConsultInteraction } = await import(
+        "@/lib/decision/kernel-consult-ledger"
+      );
+      const ledger = await recordKernelConsultInteraction({
+        db: prisma,
+        result,
+        callerContext: governingProfile,
+        question: contextQuery,
+        optionIds: decisionOptions.map((o) => o.id),
+        optionDescriptions: Object.fromEntries(
+          decisionOptions.map((o) => [o.id, o.description]),
+        ),
+        appliedPrincipleCount: cappedPrinciples.length,
+        callingSurface,
+        routeContext: context?.routeContext ?? null,
+        taskRunId: context?.taskRunId ?? null,
+      });
+
       return {
         success: true,
         message: summary,
@@ -13309,6 +13334,7 @@ export async function executeTool(
             kind: governingProfile.governingProfileKind,
             resolvedVia: governingProfile.resolvedVia,
           },
+          ledger,
         },
       };
     }

--- a/apps/web/lib/wiki/decision-audit.test.ts
+++ b/apps/web/lib/wiki/decision-audit.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildTierStats,
+  profileKindsForTier,
+  tierForProfileKind,
+  toAuditRow,
+  type DecisionAuditRowInput,
+} from "./decision-audit";
+
+function makeRow(overrides: Partial<DecisionAuditRowInput> = {}): DecisionAuditRowInput {
+  return {
+    interactionId: "DI-ABC123",
+    createdAt: new Date("2026-07-06T10:00:00Z"),
+    question: "Which approach?",
+    options: ["a", "b"],
+    outcomeType: "recommend",
+    riskTier: "low",
+    principleConflict: false,
+    domainClass: "kernel-consult",
+    routeContext: "mcp:principle_decide",
+    rationale: "Recommends a.",
+    confidenceAfter: 0.9,
+    outcomePayload: { recommendedOptionId: "a" },
+    humanOutcome: null,
+    profile: { kind: "platform", name: "Mark / DPF platform" },
+    escalationCapture: null,
+    deferralCapture: null,
+    ...overrides,
+  };
+}
+
+describe("tierForProfileKind", () => {
+  it("maps profile kinds onto the three governance tiers", () => {
+    expect(tierForProfileKind("platform")).toBe("wwmd");
+    expect(tierForProfileKind("organization")).toBe("wwwd");
+    expect(tierForProfileKind("profession")).toBe("wsid");
+    expect(tierForProfileKind("persona-real")).toBe("other");
+    expect(tierForProfileKind(null)).toBe("other");
+  });
+
+  it("round-trips with profileKindsForTier", () => {
+    for (const tier of ["wwmd", "wwwd", "wsid"] as const) {
+      for (const kind of profileKindsForTier(tier)) {
+        expect(tierForProfileKind(kind)).toBe(tier);
+      }
+    }
+  });
+});
+
+describe("toAuditRow", () => {
+  it("shapes a ledger row for the audit table", () => {
+    const row = toAuditRow(makeRow());
+    expect(row.tier).toBe("wwmd");
+    expect(row.tierCode).toBe("WWMD");
+    expect(row.optionCount).toBe(2);
+    expect(row.recommendedOptionId).toBe("a");
+    expect(row.awaitingHuman).toBe(false);
+    expect(row.createdAt).toBe("2026-07-06T10:00:00.000Z");
+  });
+
+  it("marks unresolved escalations as awaiting a human", () => {
+    const row = toAuditRow(makeRow({ outcomeType: "escalate" }));
+    expect(row.awaitingHuman).toBe(true);
+  });
+
+  it("treats an escalation capture or human outcome as resolved", () => {
+    expect(
+      toAuditRow(
+        makeRow({
+          outcomeType: "escalate",
+          escalationCapture: { createdAt: new Date() },
+        }),
+      ).awaitingHuman,
+    ).toBe(false);
+    expect(
+      toAuditRow(
+        makeRow({ outcomeType: "defer", humanOutcome: { clearsGate: true } }),
+      ).awaitingHuman,
+    ).toBe(false);
+  });
+
+  it("degrades gracefully on missing profile and payload", () => {
+    const row = toAuditRow(
+      makeRow({ profile: null, outcomePayload: null, options: null, routeContext: null }),
+    );
+    expect(row.tier).toBe("other");
+    expect(row.profileName).toBe("—");
+    expect(row.optionCount).toBe(0);
+    expect(row.recommendedOptionId).toBeNull();
+    expect(row.routeContext).toBe("—");
+  });
+});
+
+describe("buildTierStats", () => {
+  it("shapes per-tier usage including the never-used signal", () => {
+    const stats = buildTierStats({
+      tier: "wwmd",
+      total: 0,
+      last7d: 0,
+      last30d: 0,
+      unresolved: 0,
+      lastDecisionAt: null,
+    });
+    expect(stats.code).toBe("WWMD");
+    expect(stats.total).toBe(0);
+    expect(stats.lastDecisionAt).toBeNull();
+  });
+
+  it("serializes the last-decision timestamp", () => {
+    const stats = buildTierStats({
+      tier: "wsid",
+      total: 3,
+      last7d: 1,
+      last30d: 2,
+      unresolved: 1,
+      lastDecisionAt: new Date("2026-07-01T00:00:00Z"),
+    });
+    expect(stats.lastDecisionAt).toBe("2026-07-01T00:00:00.000Z");
+  });
+});

--- a/apps/web/lib/wiki/decision-audit.ts
+++ b/apps/web/lib/wiki/decision-audit.ts
@@ -1,0 +1,150 @@
+// Decision audit — per-tier (WWMD/WWWD/WSID) read model over the
+// DecisionInteraction ledger for the decision-governance hub.
+//
+// Pure mapping/summarization lives here (unit-testable); the pages do the
+// Prisma I/O and pass rows in, mirroring decision-governance-hub.ts.
+
+export const DECISION_AUDIT_TIERS = ["wwmd", "wwwd", "wsid"] as const;
+export type DecisionAuditTier = (typeof DECISION_AUDIT_TIERS)[number];
+
+export type DecisionAuditTierOrOther = DecisionAuditTier | "other";
+
+/** Map a decision-perspective profile kind onto its governance tier. */
+export function tierForProfileKind(kind: string | null | undefined): DecisionAuditTierOrOther {
+  switch (kind) {
+    case "platform":
+      return "wwmd";
+    case "organization":
+      return "wwwd";
+    case "profession":
+      return "wsid";
+    default:
+      return "other";
+  }
+}
+
+export const TIER_LABELS: Record<DecisionAuditTierOrOther, { code: string; expansion: string }> = {
+  wwmd: { code: "WWMD", expansion: "Platform doctrine" },
+  wwwd: { code: "WWWD", expansion: "Your business" },
+  wsid: { code: "WSID", expansion: "Role craft" },
+  other: { code: "Other", expansion: "Other perspectives" },
+};
+
+/** Profile-kind filter for a tier, for Prisma `profile: { kind: ... }` clauses. */
+export function profileKindsForTier(tier: DecisionAuditTier): string[] {
+  switch (tier) {
+    case "wwmd":
+      return ["platform"];
+    case "wwwd":
+      return ["organization"];
+    case "wsid":
+      return ["profession"];
+  }
+}
+
+export type DecisionAuditRowInput = {
+  interactionId: string;
+  createdAt: Date;
+  question: string;
+  options: unknown;
+  outcomeType: string;
+  riskTier: string;
+  principleConflict: boolean;
+  domainClass: string;
+  routeContext: string | null;
+  rationale: string | null;
+  confidenceAfter: number | null;
+  outcomePayload: unknown;
+  humanOutcome: unknown;
+  profile: { kind: string; name: string } | null;
+  escalationCapture: { createdAt: Date } | null;
+  deferralCapture: { gapReason: string } | null;
+};
+
+export type DecisionAuditRow = {
+  interactionId: string;
+  createdAt: string;
+  tier: DecisionAuditTierOrOther;
+  tierCode: string;
+  profileName: string;
+  question: string;
+  optionCount: number;
+  recommendedOptionId: string | null;
+  outcomeType: string;
+  /** True for defer/escalate rows with no human resolution yet. */
+  awaitingHuman: boolean;
+  riskTier: string;
+  principleConflict: boolean;
+  domainClass: string;
+  routeContext: string;
+  confidence: number | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+const UNRESOLVED_OUTCOMES = new Set(["defer", "escalate"]);
+
+export function toAuditRow(row: DecisionAuditRowInput): DecisionAuditRow {
+  const tier = tierForProfileKind(row.profile?.kind);
+  const payload = asRecord(row.outcomePayload);
+  const human = asRecord(row.humanOutcome);
+  const resolvedByHuman = Boolean(row.escalationCapture) || Object.keys(human).length > 0;
+  return {
+    interactionId: row.interactionId,
+    createdAt: row.createdAt.toISOString(),
+    tier,
+    tierCode: TIER_LABELS[tier].code,
+    profileName: row.profile?.name ?? "—",
+    question: row.question,
+    optionCount: Array.isArray(row.options) ? row.options.length : 0,
+    recommendedOptionId:
+      typeof payload.recommendedOptionId === "string" ? payload.recommendedOptionId : null,
+    outcomeType: row.outcomeType,
+    awaitingHuman: UNRESOLVED_OUTCOMES.has(row.outcomeType) && !resolvedByHuman,
+    riskTier: row.riskTier,
+    principleConflict: row.principleConflict,
+    domainClass: row.domainClass,
+    routeContext: row.routeContext ?? "—",
+    confidence: row.confidenceAfter,
+  };
+}
+
+export type DecisionTierStats = {
+  tier: DecisionAuditTier;
+  code: string;
+  expansion: string;
+  total: number;
+  last7d: number;
+  last30d: number;
+  unresolved: number;
+  lastDecisionAt: string | null;
+};
+
+/**
+ * Summarize per-tier usage from raw per-tier counts. The page supplies the
+ * counts (Prisma count queries); this shapes them for the stat cards,
+ * including the "never used" signal the hub uses to flag a dormant tier.
+ */
+export function buildTierStats(input: {
+  tier: DecisionAuditTier;
+  total: number;
+  last7d: number;
+  last30d: number;
+  unresolved: number;
+  lastDecisionAt: Date | null;
+}): DecisionTierStats {
+  return {
+    tier: input.tier,
+    code: TIER_LABELS[input.tier].code,
+    expansion: TIER_LABELS[input.tier].expansion,
+    total: input.total,
+    last7d: input.last7d,
+    last30d: input.last30d,
+    unresolved: input.unresolved,
+    lastDecisionAt: input.lastDecisionAt ? input.lastDecisionAt.toISOString() : null,
+  };
+}

--- a/apps/web/lib/wiki/decision-governance-hub.test.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.test.ts
@@ -11,6 +11,9 @@ const base = {
   wsidFamilyCount: 23,
   wsidActiveProfiles: 1,
   wsidOpenReviews: 0,
+  wwmdDecisions30d: 0,
+  wwwdDecisions30d: 0,
+  wsidDecisions30d: 0,
 };
 
 describe("buildDisciplineCards", () => {
@@ -86,5 +89,44 @@ describe("buildDisciplineCards", () => {
     const wwwd = cards.find((c) => c.key === "wwwd");
     const manage = wwwd?.actions.find((a) => a.emphasis);
     expect(manage?.label).toBe("Manage stance");
+  });
+
+  it("flags a silent decision ledger with a warning usage chip on every tier", () => {
+    const cards = buildDisciplineCards(base);
+    for (const card of cards) {
+      const chip = card.chips.find((c) => c.label === "no decisions recorded");
+      expect(chip?.tone).toBe("warning");
+    }
+  });
+
+  it("shows 30d decision counts (pluralized) when the ledger is in use", () => {
+    const cards = buildDisciplineCards({
+      ...base,
+      wwmdDecisions30d: 12,
+      wwwdDecisions30d: 1,
+      wsidDecisions30d: 0,
+    });
+    const wwmdChip = cards
+      .find((c) => c.key === "wwmd")
+      ?.chips.find((c) => c.label.includes("decision"));
+    expect(wwmdChip?.label).toBe("12 decisions · 30d");
+    expect(wwmdChip?.tone).toBe("success");
+    const wwwdChip = cards
+      .find((c) => c.key === "wwwd")
+      ?.chips.find((c) => c.label.includes("decision"));
+    expect(wwwdChip?.label).toBe("1 decision · 30d");
+    const wsidChip = cards
+      .find((c) => c.key === "wsid")
+      ?.chips.find((c) => c.label.includes("decision"));
+    expect(wsidChip?.label).toBe("no decisions recorded");
+  });
+
+  it("links every tier card to its decision log", () => {
+    const cards = buildDisciplineCards(base);
+    for (const card of cards) {
+      expect(
+        card.actions.some((a) => a.href === `/wiki/decisions?tier=${card.key}`),
+      ).toBe(true);
+    }
   });
 });

--- a/apps/web/lib/wiki/decision-governance-hub.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.ts
@@ -31,10 +31,28 @@ export type DisciplineHealthInput = {
   wsidActiveProfiles: number;
   /** Unresolved decisions across profession (WSID) profiles. */
   wsidOpenReviews: number;
+  /** Ledger decisions recorded in the last 30 days, per tier (audit signal). */
+  wwmdDecisions30d: number;
+  wwwdDecisions30d: number;
+  wsidDecisions30d: number;
 };
 
 function reviewChipLabel(count: number): string {
   return count === 1 ? "1 open review" : `${count} open reviews`;
+}
+
+/**
+ * Usage chip for a tier's decision ledger: green when decisions are flowing,
+ * warning when the tier is silent — a silent tier means the gate exists but
+ * is not being exercised, which is itself the finding the hub must surface.
+ */
+function usageChip(decisions30d: number): { label: string; tone: "success" | "warning" } {
+  return decisions30d > 0
+    ? {
+      label: decisions30d === 1 ? "1 decision · 30d" : `${decisions30d} decisions · 30d`,
+      tone: "success",
+    }
+    : { label: "no decisions recorded", tone: "warning" };
 }
 
 /**
@@ -53,12 +71,14 @@ export function buildDisciplineCards(
     chips: [
       { label: `${input.kernelPrincipleCount} principles`, tone: "neutral" },
       { label: `${input.kernelHeuristicCount} heuristics`, tone: "neutral" },
+      usageChip(input.wwmdDecisions30d),
       ...(input.wwmdOpenReviews > 0
         ? [{ label: reviewChipLabel(input.wwmdOpenReviews), tone: "warning" as const }]
         : []),
     ],
     actions: [
       { label: "Governing material", href: "#governing-material" },
+      { label: "Decision log", href: "/wiki/decisions?tier=wwmd" },
       { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwmd" },
     ],
   };
@@ -73,12 +93,14 @@ export function buildDisciplineCards(
       input.orgHasOwnWwwdStance
         ? { label: "your own stance", tone: "success" }
         : { label: "no stance of your own yet", tone: "warning" },
+      usageChip(input.wwwdDecisions30d),
       ...(input.wwwdOpenReviews > 0
         ? [{ label: reviewChipLabel(input.wwwdOpenReviews), tone: "warning" as const }]
         : []),
     ],
     actions: [
       { label: "Manage stance", href: "/wiki/stance", emphasis: true },
+      { label: "Decision log", href: "/wiki/decisions?tier=wwwd" },
       { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwwd" },
     ],
   };
@@ -97,12 +119,14 @@ export function buildDisciplineCards(
             : `${input.wsidActiveProfiles} corpora active`,
         tone: "neutral",
       },
+      usageChip(input.wsidDecisions30d),
       ...(input.wsidOpenReviews > 0
         ? [{ label: reviewChipLabel(input.wsidOpenReviews), tone: "warning" as const }]
         : []),
     ],
     actions: [
       { label: "Role craft", href: "/wiki/craft", emphasis: true },
+      { label: "Decision log", href: "/wiki/decisions?tier=wsid" },
       { label: "Review decisions", href: "/platform/ai/founder-review" },
     ],
   };

--- a/docs/superpowers/plans/2026-07-06-decision-governance-audit-log.md
+++ b/docs/superpowers/plans/2026-07-06-decision-governance-audit-log.md
@@ -1,0 +1,40 @@
+# Decision Governance Audit Log — surface the ledger, instrument the gate
+
+**Date:** 2026-07-06
+**Epic:** EP-0AF96937 (Decision Governance surface redesign) — follow-on to Phases 1–4 (#2573/#2575, commits 298658db6/bebeb339c)
+**Companion:** BI-44526F3E (WWWD corpus activation — owns routing business calls through `evaluate_org_business_decision`; out of scope here)
+
+## 1. Problem
+
+The Decision Governance hub (`/wiki`) presents three decision tiers — WWMD (platform doctrine), WWWD (the business), WSID (role craft) — as a HITL-equivalent gate, but the operator cannot see the decisions the gate actually made, so there is no way to validate the feature is in play or effective. Verified on the live install (2026-07-06): the `DecisionInteraction` ledger, its `EscalationCapture`/`DeferralCapture` companions, and `DecisionShadowLedger` all hold **zero rows ever**, because:
+
+1. **WWMD** — `principle_decide` (the tool consulted constantly by external agents and skills) computes a recommendation and returns it with **no persistence at all** (`apps/web/lib/mcp-tools.ts`, `case "principle_decide"`). Only a `console.info` trace line exists.
+2. **WWWD** — `evaluate_org_business_decision` does write the ledger, but is never invoked: the coworker decision-routing prompt predates it (BI-44526F3E G3) and this install has no org profile (G1).
+3. **WSID** — profession profiles exist (24 seeded) but no decision path attributes rows to them yet.
+
+The hub's "open reviews" chips already read the ledger — they are honest but vacuous while nothing writes.
+
+## 2. Approach
+
+Two legs, one PR:
+
+**Leg A — make the biggest writer write.** Persist every `principle_decide` call to `DecisionInteraction` via a new fail-open recorder (`apps/web/lib/decision/kernel-consult-ledger.ts`), attributed to the governing profile the handler already resolves (`resolveDecisionCallerContext` — WWMD platform vs WWWD organization). Outcome mapping encodes the HITL semantics: confident conflict-free recommendation → `recommend`; commandment conflict or low-margin call → `escalate` (feeds the open-review queues); no applicable principles → `defer` (coverage gap). A new `kernel-consult` domain class keeps these rows a distinct cluster in `/wiki/review` findings. The write is fail-open (a ledger outage never blocks the decision) but always observable: the tool response carries `ledger: { recorded, interactionId | reason }`, and a skip (e.g. unprovisioned WWWD profile) is named, not silent.
+
+**Leg B — surface the log.** New `/wiki/decisions` audit surface (report-kit composition):
+- Per-tier StatCards: 30d count, unresolved count, all-time, with an explicit **"never used"** warning state — a silent tier is itself the finding.
+- Filterable decision timeline (tier pills → `?tier=wwmd|wwwd|wsid`), showing when/tier/question/outcome/recommendation/risk/conflict/where.
+- Drill-in `/wiki/decisions/[interactionId]`: options weighed (recommended highlighted), rationale, top principle contributors, flags, human-resolution state (escalation capture / deferral gap / awaiting review).
+- Hub cards each gain a usage chip (`N decisions · 30d` / warning `no decisions recorded`) and a **Decision log** action.
+
+Tier attribution is by profile kind (`platform`→WWMD, `organization`→WWWD, `profession`→WSID), so rows written by the Build Studio gate, the org business gate, work-pattern review, and the new kernel-consult recorder all land in the same audit view without special-casing their writers.
+
+## 3. Explicitly out of scope
+
+- Routing coworker business decisions through `evaluate_org_business_decision` (BI-44526F3E Phase A3) — once that lands, its rows appear here automatically.
+- WSID-attributed writes from profession surfaces (no current writer; the tier shows honestly silent until one exists).
+- Escalation-resolution workflows (exist at `/platform/ai/founder-review` and `/wiki/review`; the log links to them).
+
+## 4. Verification
+
+- Unit: `kernel-consult-ledger.test.ts` (outcome mapping, profile attribution, observable skip, fail-open), `decision-audit.test.ts` (tier mapping, awaiting-human semantics), extended `decision-governance-hub.test.ts` (usage chips, log links).
+- Runtime (canonical install, post self-upgrade): call `principle_decide` via MCP → row visible at `/wiki/decisions` with WWMD attribution; hub chip flips from "no decisions recorded" to a live count.


### PR DESCRIPTION
## Problem

The Decision Governance hub (`/wiki`) presents WWMD / WWWD / WSID as a HITL-equivalent decision gate, but the operator cannot see the decisions it makes — so there is no way to validate the gate is in play or effective. Verified on the live install (2026-07-06): `DecisionInteraction`, `EscalationCapture`, `DeferralCapture`, and `DecisionShadowLedger` hold **zero rows ever**, because `principle_decide` — the tool consulted constantly — computes a recommendation and returns it with **no persistence at all**. (The WWWD door `evaluate_org_business_decision` does write the ledger but is never invoked — that routing is BI-44526F3E and stays out of scope here.)

## Change

**Leg A — instrument the gate.** New fail-open recorder `apps/web/lib/decision/kernel-consult-ledger.ts` persists every `principle_decide` call to `DecisionInteraction`, attributed to the governing profile the handler already resolves (WWMD platform vs WWWD organization). Outcome mapping encodes the HITL semantics: confident conflict-free recommendation → `recommend`; commandment conflict or low-margin call → `escalate` (feeds the existing open-review queues); no applicable principles → `defer` (coverage gap). Rows land under a new `kernel-consult` domain class so they cluster distinctly in `/wiki/review`. The write never blocks the decision, and its outcome is named in the tool response (`ledger.recorded` / skip reason), per make-silent-failures-observable.

**Leg B — surface the log.** New `/wiki/decisions` audit page (report-kit `StatCard` + `DataTable` + `StatusBadge`, `LocalTime` timestamps):
- Per-tier usage stats — 30d count, awaiting-review count, all-time — with an explicit **"never used"** warning state: a silent tier is itself the finding.
- Tier-filterable decision timeline (`?tier=wwmd|wwwd|wsid`): when, tier, question, outcome, recommendation, risk, conflict, origin.
- Drill-in `/wiki/decisions/[interactionId]`: options weighed (recommended highlighted), rationale, top principle contributors, human-resolution state (escalation capture / deferral gap / awaiting review).
- Hub tier cards each gain a usage chip (`N decisions · 30d` or warning `no decisions recorded`) and a **Decision log** action.

Tier attribution is by profile kind (`platform`→WWMD, `organization`→WWWD, `profession`→WSID), so rows from any writer — Build Studio gate, org business gate, work-pattern review, kernel consults — land in the same audit view with no writer special-casing.

## Evidence

- Targeted vitest: 47/47 across `kernel-consult-ledger`, `decision-audit`, `decision-governance-hub`, `mcp-tools-principle-decide`, `decision-routing-governance-hook` (worktree, compile-ready).
- `pnpm typecheck` (next typegen + tsc) clean (worktree).
- Kernel consults (recorded via governed MCP, high confidence, no commandment conflict):
  - UX-fit: `dedicated-decisions-page` composite 8.517, margin 2.074 — over inline-hub-feed and /platform/audit placement.
  - Scope: `instrument-and-surface` composite 8.473, margin 2.856 — over surface-only / instrument-only.
  - Those two consults themselves left no ledger row on the deployed portal — the exact gap this PR closes.
- Complements #2639 (plane-2 decision-routing gate), whose in-memory consult map explicitly lacks a durable ledger; these rows are that ledger.

BI-E286E148 · EP-0AF96937 · Work Capsule WC-263903EE

UX-Fit-Decision: principle_decide recommends dedicated /wiki/decisions page with progressive disclosure (one usage chip + one action per hub card, detail one click away); composite 8.517, margin 2.074, high confidence, human_cognitive_load cost-axis scored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
