### PR TITLE
chore(ea): regenerate route manifest for the public quote-accept route

### DIFF
--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 537,
+  "routeCount": 538,
   "routes": [
     {
       "routePath": "/",
@@ -5931,6 +5931,19 @@
         "token"
       ],
       "file": "apps/web/app/(storefront)/s/pay/[token]/page.tsx"
+    },
+    {
+      "routePath": "/s/quote/[token]",
+      "kind": "page",
+      "segments": [
+        "s",
+        "quote",
+        "[token]"
+      ],
+      "dynamicParams": [
+        "token"
+      ],
+      "file": "apps/web/app/(storefront)/s/quote/[token]/page.tsx"
     },
     {
       "routePath": "/sandbox-restricted",


### PR DESCRIPTION
Mechanical regen: `/s/quote/[token]` (#2644) merged via the advisory-red queue before the manifest was rebuilt. `check:route-manifest` now passes (538 routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)