### PR TITLE
fix(hr): billable-invoice confirm dialog wedged inside transition (EP-LABOR-ECONOMICS)

### DIFF
--- a/apps/web/components/customer/BillableTimeSection.tsx
+++ b/apps/web/components/customer/BillableTimeSection.tsx
@@ -32,14 +32,18 @@ export function BillableTimeSection({ accountId, accountName, economics, currenc
   const [result, setResult] = useState<BillableInvoiceResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  function handleGenerate() {
+  async function handleGenerate() {
+    // Await the confirm dialog OUTSIDE the transition — confirmDialog raises a
+    // DialogHost state update, and one deferred inside startTransition never
+    // renders interactively, wedging the button in its pending state. Every
+    // other confirmDialog caller awaits first, then runs the work.
+    const ok = await confirmDialog({
+      title: "Create a draft invoice?",
+      message: `Turn ${economics.unbilledHours} approved billable hour${economics.unbilledHours === 1 ? "" : "s"} for ${accountName} into a draft invoice. You can review it before sending.`,
+    });
+    if (!ok) return;
     startTransition(async () => {
       setError(null);
-      const ok = await confirmDialog({
-        title: "Create a draft invoice?",
-        message: `Turn ${economics.unbilledHours} approved billable hour${economics.unbilledHours === 1 ? "" : "s"} for ${accountName} into a draft invoice. You can review it before sending.`,
-      });
-      if (!ok) return;
       try {
         const r = await generateBillableInvoice(accountId);
         setResult(r);


### PR DESCRIPTION
## What

The **Create draft invoice** button on the customer account (`/customer/[id]` Billable Time section, EP-LABOR-ECONOMICS Phase 4) raised `confirmDialog` **inside** `startTransition`. `confirmDialog` dispatches a `DialogHost` state update, and a state update deferred inside a transition never renders interactively — so the confirm dialog never appeared and the button stayed wedged in its `isPending`/disabled state with no way to generate the invoice.

Found during Phase 4 live verification on the deployed install: pay → rate card → billable timesheet → margin band all verified exact, but the final invoice-generation click could not complete because of this.

## Fix

Await the dialog **first** (the pattern every other `confirmDialog` caller uses — e.g. `ItemsManager`), then run the generation inside the transition. One-file, behaviour-preserving beyond the dialog now showing and the action running on confirm.

## Verification

- `apps/web` typecheck green (fresh `origin/main` + Prisma regen).
- Follow-up to #2634; the underlying `generateInvoiceFromBillableTime` (Phase 3) and the margin aggregation (`labor-report.test.ts`) are unchanged and already covered.

UX-Fit-Decision: no new surface — restores the intended confirm-then-generate flow on the existing Billable Time section; progressive disclosure and report-kit usage unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)