### PR TITLE
feat(portfolio): recognize Workforce portfolio terminology

### DIFF
--- a/apps/web/app/(shell)/knowledge/page.tsx
+++ b/apps/web/app/(shell)/knowledge/page.tsx
@@ -17,8 +17,8 @@ const PORTFOLIO_PERSONAS: Record<string, { label: string; description: string }>
     description: "Operational knowledge for delivery and production teams",
   },
   for_employees: {
-    label: "Workforce / For Employees",
-    description: "Knowledge for the workforce — human employees and AI coworkers — plus HR, managers, and policy",
+    label: "Workforce",
+    description: "Knowledge for employees, contractors, AI coworkers, robots, non-human identities, HR, managers, and policy",
   },
   products_and_services_sold: {
     label: "Products & Services Sold",

--- a/apps/web/lib/onboarding/seed-org-operating-model-pages.ts
+++ b/apps/web/lib/onboarding/seed-org-operating-model-pages.ts
@@ -108,7 +108,7 @@ function listNames(names: string[]): string {
 const ROLE_LABELS: Record<string, string> = {
   productsAndServicesSold: "Products & Services Sold — what we offer the market",
   manufactureAndDeliver: "Manufacturing & Delivery — how the work gets made and delivered",
-  forEmployees: "Workforce / For Employees — what our people work with",
+  forEmployees: "Workforce — who and what performs work",
   foundational: "Foundational — the base the rest stands on",
 };
 
@@ -208,7 +208,7 @@ function buildToolsAndDataPage(input: {
   }
   if (input.forEmployeeNames.length > 0) {
     sections.push(
-      "What our people work with day to day (recorded in `Workforce / For Employees`):",
+      "What our workforce works with day to day (recorded in `Workforce`):",
       "",
       listNames(input.forEmployeeNames),
       "",

--- a/apps/web/lib/work-capsules/work-capsule-presenter.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.ts
@@ -38,7 +38,7 @@ const DECISION_SCOPE_LABELS: Record<string, string> = {
 const PORTFOLIO_ROLE_LABELS: Record<string, string> = {
   foundational: "Foundational",
   manufactureAndDeliver: "Manufacture & Deliver",
-  forEmployees: "Workforce / For Employees",
+  forEmployees: "Workforce",
   productsAndServicesSold: "Products & Services Sold",
 };
 

--- a/docs/architecture/2026-07-06-it4it-dppm-workforce-portfolio-white-paper.md
+++ b/docs/architecture/2026-07-06-it4it-dppm-workforce-portfolio-white-paper.md
@@ -1,0 +1,201 @@
+# Workforce Portfolio: A Proposed Evolution of the IT4IT/DPPM Internal Portfolio
+
+## Status
+
+Working draft for discussion with The Open Group IT4IT Forum and Digital Portfolio Work Group.
+
+## Executive Summary
+
+The current Digital Product Portfolio Management (DPPM) model is built around four portfolio types: Provided Externally, Provided Internally, Foundational, and Manufacture and Delivery. In DPF, the Provided Internally concept has historically appeared as `For Employees`, with the stable platform slug `for_employees`.
+
+This paper proposes that standards-facing language evolve from `For Employees` to **Workforce**. The change is intentionally small in structure and significant in meaning: it preserves the four-portfolio model while recognizing that modern work is performed by a mixed set of accountable actors, including employees, contractors, AI coworkers, robots, non-human identities, managed-service roles, and future actor classes not yet common.
+
+The proposed label is:
+
+> **Workforce Portfolio (Provided Internally)**
+
+The objective is not to replace the DPPM portfolio shape. It is to make the internal portfolio fit the operating reality that IT4IT and DPPM increasingly need to govern: digital products are consumed by people, AI coworkers, autonomous systems, service accounts, robotic systems, and blended human/non-human teams. Portfolio management should be able to account for all of them without treating non-employee actors as exceptions.
+
+## Why This Matters Now
+
+The term `employee` is an employment classification. It is useful for HR, benefits, and legal treatment, but it is too narrow as a portfolio-management boundary.
+
+Enterprises already depend on work actors that are not employees:
+
+- contractors and consultants who use internal digital products
+- outsourced and managed-service roles accountable for business outcomes
+- AI coworkers and specialist agents with role-like responsibilities
+- robotic process automation and physical robots that perform operational work
+- non-human identities, service accounts, and automation principals that initiate or approve system actions
+- partner or ecosystem actors who operate inside a governed internal workflow
+
+In a product-managed digital enterprise, these actors create the same portfolio questions employees create:
+
+- What internal digital products do they need?
+- Which roles and responsibilities do they fulfill?
+- What tools, credentials, skills, permissions, and budgets do they require?
+- Which human approval, supervision, or escalation path governs their work?
+- What gaps prevent them from contributing safely and effectively?
+- What internal-product investment is justified by their work?
+
+`Workforce` is a better portfolio word because it describes accountable work capacity rather than one legal employment status.
+
+## The Four-Portfolio Model With Workforce
+
+The proposal keeps the DPPM four-portfolio model intact.
+
+| Current DPPM portfolio role | Proposed standards-facing label | Purpose |
+| --- | --- | --- |
+| Provided Externally | Products and Services Sold | Digital products and services provided to customers, citizens, partners, or other external consumers. |
+| Provided Internally / For Employees | Workforce | Internal digital products and workforce actor support capabilities used by employees, contractors, AI coworkers, robots, non-human identities, and other accountable work actors. |
+| Foundational | Foundational | Reusable technology building blocks, platforms, data, infrastructure, security, and shared services that enable the other portfolios. |
+| Manufacture and Delivery | Manufacture and Delivery | The digital factory products and capabilities used to build, deploy, release, operate, and support digital products. |
+
+The Workforce change is not a fifth portfolio. It is a terminology correction and scope clarification for the internal portfolio.
+
+## What Changes Conceptually
+
+### From internal user to accountable actor
+
+The older mental model asks: "Which employee-facing digital products do we provide?"
+
+The Workforce model asks: "Which accountable actors perform work for the enterprise, and what internal digital products do they need to do that work safely and effectively?"
+
+That shift matters because AI coworkers and robotic systems are not merely tools used by employees. They are increasingly role-shaped operating participants with assigned responsibilities, tool grants, capacity constraints, decision limits, supervisors, and audit evidence.
+
+### From consumer-only to consumer and contributor
+
+The Provided Internally portfolio has traditionally focused on internal consumption: the tools and services internal users consume.
+
+The Workforce portfolio adds a second lens:
+
+- **Consumption lens:** internal products the workforce uses, such as HR, ITSM, finance, collaboration, knowledge, identity, access, and productivity products.
+- **Contribution lens:** the workforce actors themselves, including their role, authority, capacity, tools, approvals, and unmet needs.
+
+Both lenses are necessary. A missing internal tool and an unfilled workforce capability are both internal operating-model gaps.
+
+### From employee count to workforce capacity
+
+As employee count rises or falls, the AI coworker parity model becomes more specific. A business may add a human employee, assign an AI coworker to a parallel or supporting role, appoint a human approver, or replace manual work with a governed automation. Those changes are workforce-capacity decisions, not merely HR headcount decisions.
+
+The portfolio should therefore track the relationship between:
+
+- human roles
+- AI coworker roles
+- assigned human approval or interface owners
+- skills and tool grants
+- budget and capacity limits
+- work outcomes and lifecycle stage
+
+## Proposed Terminology
+
+### Recommended standard wording
+
+Use **Workforce Portfolio (Provided Internally)** as the standards-facing label.
+
+Use **For Employees** only as a legacy alias during transition.
+
+### Proposed glossary entry
+
+**Workforce Portfolio:** The DPPM portfolio containing internally provided digital products, workforce actor support capabilities, and governance surfaces that enable accountable work actors to perform enterprise work. Workforce actors may include employees, contractors, AI coworkers, robotic systems, non-human identities, partner roles, and other approved human or non-human actors operating under enterprise authority.
+
+### Proposed note for standards text
+
+The Workforce Portfolio extends the traditional employee-facing interpretation of Provided Internally. It includes internal digital products consumed by workforce actors and the support capabilities required to govern, equip, supervise, and improve those actors.
+
+## Implications for IT4IT and DPPM
+
+### Portfolio taxonomy
+
+The portfolio taxonomy should continue to classify internal digital products, but examples should be updated so the internal portfolio does not imply employee-only scope.
+
+Examples that belong under Workforce include:
+
+- HR and people operations
+- contractor onboarding and offboarding
+- AI coworker registry and lifecycle management
+- tool grants, skills, and authority for AI coworkers
+- robotics operations and supervision
+- internal finance, time, payroll, and tax-remittance work surfaces
+- collaboration, knowledge, ticketing, ITSM, and employee-service products
+- non-human identity governance and service-account lifecycle
+
+### Value-stream line of sight
+
+Workforce actors participate across IT4IT value streams. They help evaluate demand, explore options, integrate solutions, deploy changes, release value, operate products, and support consumption. Treating AI coworkers and non-human actors as workforce members lets the model express who or what is doing the work at each stage.
+
+### Governance and accountability
+
+The change improves governance clarity. A robot, automation, service account, or AI coworker can be represented as a workforce actor only when the organization can identify:
+
+- accountable owner or supervisor
+- permitted work and tool scope
+- approval and escalation pattern
+- audit evidence
+- lifecycle status
+- capability needs and constraints
+
+That is stronger than treating non-human participants as invisible implementation detail.
+
+### Financial management
+
+Employee-only language hides important cost drivers. Workforce management needs to account for:
+
+- salary and contractor cost
+- AI provider and token cost
+- model hosting cost
+- robot/automation asset cost
+- license and seat cost
+- approval and supervision effort
+- opportunity cost of constrained workforce capacity
+
+The Workforce portfolio gives financial managers a more complete view of internal operating spend and capacity.
+
+## DPF Platform Recognition
+
+DPF now treats this as a platform terminology and architecture direction:
+
+- The canonical portfolio slug remains `for_employees` for compatibility.
+- The operator-facing portfolio label is **Workforce**.
+- `For Employees` is retained as a legacy alias and standards cross-reference.
+- AI coworkers are associated structurally to the Workforce portfolio through Digital Product, taxonomy, coworker capability need, and epic fallback paths.
+- The AI Workforce surface is treated as an internal Workforce digital product, not a detached platform administration page.
+- Tax remittance and other internal operating surfaces remain under Workforce when they are internal capabilities used by the business to perform work.
+
+This avoids breaking existing data while moving the human-facing model forward.
+
+## Adoption Path
+
+1. Use **Workforce Portfolio (Provided Internally)** in new standards text and discussion material.
+2. Add `For Employees` as a transition alias in glossaries and diagrams.
+3. Update examples to include employees, contractors, AI coworkers, robots, and non-human identities.
+4. Keep the four-portfolio structure unchanged.
+5. Encourage tools and platforms to keep stable machine identifiers where needed, while updating display labels and descriptions.
+6. Add conformance guidance that workforce actors require accountable ownership, authorization, and auditability.
+
+## Open Questions for the Forum
+
+1. Should the standard prefer **Workforce Portfolio** or **Workforce and Internal Enablement** as the human-facing label?
+2. Should `Provided Internally` remain the formal architecture term, with `Workforce` as the business-facing portfolio name?
+3. Should AI coworkers and robots be modeled as workforce actors directly, or as a subcategory of non-human identity?
+4. What minimum attributes should a non-human workforce actor carry for portfolio governance: owner, purpose, scope, grants, budget, lifecycle, evidence, or all of these?
+5. How should workforce-capacity accounting align to financial views across salary, contract, license, token, model-hosting, and automation costs?
+
+## Recommendation
+
+Adopt **Workforce Portfolio (Provided Internally)** as the next standards-facing label for the internal DPPM portfolio. Preserve the existing four-portfolio model and use the change to clarify that the internal portfolio now covers both:
+
+- the internal digital products consumed by the workforce
+- the accountable human and non-human actors that perform enterprise work
+
+This is a small terminology change with a large architectural benefit. It lets IT4IT and DPPM recognize the parity between employees and AI coworkers without creating a new portfolio type or destabilizing existing implementations.
+
+## References
+
+- The Open Group, [IT4IT](https://www.opengroup.org/it4it)
+- The Open Group, [IT4IT Standard Version 3.0 licensed downloads](https://www.opengroup.org/IT4IT/downloads)
+- The Open Group, [Digital Portfolio Work Group](https://www.opengroup.org/forum/digital-practitioners-work-group)
+- The Open Group, [Digital Portfolio of Open Standards](https://www.opengroup.org/digitalportfolio)
+- The Open Group Guide, `Digital Product Portfolio Management in the Digital Enterprise`, Document Number `G252`, March 2025, local reference: [`docs/Reference/digital_product_portfolio_mgmt.txt`](../Reference/digital_product_portfolio_mgmt.txt)
+- DPF, [`Business Operating Model - Portfolio Wiring Design`](../superpowers/specs/2026-06-07-business-operating-model-portfolio-wiring-design.md)
+- DPF, [`IT4IT` entity reference](../founder-kernel/wiki/entities/it4it.md)

--- a/docs/founder-kernel/wiki/entities/portfolio.md
+++ b/docs/founder-kernel/wiki/entities/portfolio.md
@@ -20,6 +20,8 @@ DPF&#39;s `Portfolio` Prisma model groups Digital Products with explicit lifecyc
 
 Portfolios are also the unit of agent context — a coworker on a portfolio page sees the portfolio&#39;s Digital Products, their value-stream coverage, their lifecycle states, and the portfolio-scoped wiki overlay.
 
+DPF keeps the four DPPM root slugs stable for compatibility. The internal root slug remains `for_employees`, but the operator-facing portfolio label is **Workforce** so the same management surface covers employees, contractors, AI coworkers, robots, non-human identities, and other accountable work actors.
+
 ## Relationships
 
 - Contains: `[[entities/digital-product]]`s.

--- a/docs/superpowers/specs/2026-06-07-business-operating-model-portfolio-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-07-business-operating-model-portfolio-wiring-design.md
@@ -53,7 +53,7 @@ Introduce a per-company **Business Operating Model (BOM)** — not a new substra
 Archetype business context (top-down, leadership-defined)
   → seeds the two business-critical portfolios
       • Products & Services Sold  (DPPM "Provided Externally" — the market offer, line of sight to customers)
-      • Workforce / For Employees (DPPM "Provided Internally" + the workforce itself: humans + AI agents)
+      • Workforce (DPPM "Provided Internally" + the workforce itself: humans + AI agents)
   → those portfolios decompose down the DPPM dependency chain
       • Foundational  ◀── depended on by
       • Manufacturing & Delivery  ◀── delivers
@@ -130,6 +130,8 @@ Mark's reframe: "Employees" is too narrow because it excludes the AI agent workf
 > **Naming:** the canonical registry key stays `for_employees` (no churn to `portfolio_registry.json`), but the operator-facing label becomes **"Workforce"** (or "Workforce & Internal Enablement"), with a `displayShort` per the maturity spec's §12.4 label-fit invariant. The DPPM "Provided Internally" digital products (the tools the workforce *consumes*) and the workforce *identities themselves* both live here — consumer and contributor in one portfolio.
 
 **2026-07-04 implementation amendment.** The `for_employees` root now explicitly includes AI coworkers as workforce peers, not only human employees. Structural backlog attribution follows this order for AI coworker work: `DigitalProduct` first, `TaxonomyNode` second, linked `CoworkerCapabilityNeed.agent.portfolioId` third, then `EpicPortfolio` as the broad fallback. New AI coworker capability-need backlog filings and Hive Scout coworker-archetype suggestions resolve to the `dpf-ai-workforce` DigitalProduct under `for_employees/workforce_services`; tax-remittance / paying-taxes work resolves to `dpf-tax-remittance` under `for_employees/financial_management/manage_taxes`. Text-only classification is not a valid association path.
+
+**2026-07-06 terminology amendment.** The `for_employees` root now renders as **Workforce** in the portfolio registry. "For Employees" remains a legacy alias and standards cross-reference only; the canonical slug stays `for_employees` to avoid data churn. This aligns the platform with the standards-facing proposal in [`docs/architecture/2026-07-06-it4it-dppm-workforce-portfolio-white-paper.md`](../../architecture/2026-07-06-it4it-dppm-workforce-portfolio-white-paper.md): the internal portfolio should account for employees, contractors, AI coworkers, robots, non-human identities, and any other accountable actor that performs or approves work.
 
 ### 4.3 Facets C & D — Foundational and Manufacturing & Delivery (the dependency floor)
 

--- a/docs/user-guide/portfolios/index.md
+++ b/docs/user-guide/portfolios/index.md
@@ -11,6 +11,7 @@ The Portfolios area organizes your digital products into four root portfolios, e
 ## Key Concepts
 
 - **Root Portfolios** — The four top-level groupings that all products belong to. Your organization defines what these represent (e.g., by business unit, delivery model, or strategic theme).
+- **Workforce Portfolio** — The internal portfolio formerly labeled For Employees. It covers the digital products used by employees, contractors, AI coworkers, robots, non-human identities, and other accountable work actors.
 - **DPPM Taxonomy** — A 481-node product classification tree used to categorize products by type, capability, and market segment. Products are tagged with taxonomy nodes to enable filtering and benchmarking.
 - **Health Metrics** — Calculated scores for each portfolio based on product lifecycle distribution, investment balance, active issues, and operational performance.
 - **Risk Concentration** — A measure of how unevenly investment or strategic risk is distributed across a portfolio. Useful for identifying over-dependence on a single product or technology.

--- a/packages/db/data/portfolio_registry.json
+++ b/packages/db/data/portfolio_registry.json
@@ -21,10 +21,10 @@
     {
       "id": "for_employees",
       "portfolio_id": "for_employees",
-      "name": "Workforce / For Employees",
-      "description": "The workforce and the internal digital products it consumes. Members are BOTH human employees AND AI coworkers (role-shaped non-human peers per DOC-7693D528, each with a human-role parity anchor and an approval/interface owner). Products include productivity tools, ITSM, HR systems, internal portals, and the AI coworker services/offers the workforce runs on. Canonical key stays `for_employees`.",
+      "name": "Workforce",
+      "description": "The workforce and the internal digital products it consumes. This evolves the legacy For Employees label to include employees, contractors, AI coworkers, robots, non-human identities, and any other accountable actor that performs or approves work. Products include productivity tools, ITSM, HR systems, internal portals, and the AI coworker services/offers the workforce runs on. Canonical key stays `for_employees`.",
       "owner_role": "HR-200",
-      "it4it_reference": "IT4IT §6.3 For Employees Portfolio"
+      "it4it_reference": "DPPM Provided Internally / legacy IT4IT §6.3 For Employees Portfolio"
     },
     {
       "id": "products_and_services_sold",

--- a/packages/db/src/digital-product-registry.test.ts
+++ b/packages/db/src/digital-product-registry.test.ts
@@ -23,7 +23,7 @@ function product(productId: string): RegistryProduct {
 }
 
 describe("digital product registry BOM workforce mappings", () => {
-  it("maps the AI Workforce surface to the For Employees workforce taxonomy", () => {
+  it("maps the AI Workforce surface to the Workforce portfolio taxonomy", () => {
     const aiWorkforce = product("dpf-ai-workforce");
 
     expect(aiWorkforce.name).toBe("AI Workforce");
@@ -32,7 +32,7 @@ describe("digital product registry BOM workforce mappings", () => {
     expect(aiWorkforce.description).toContain("human employees and AI coworkers");
   });
 
-  it("maps paying taxes / tax remittance to For Employees financial management", () => {
+  it("maps paying taxes / tax remittance to Workforce financial management", () => {
     const taxRemittance = product("dpf-tax-remittance");
 
     expect(taxRemittance.portfolio_id).toBe("for_employees");


### PR DESCRIPTION
## Summary
- Renames the visible internal portfolio label from `Workforce / For Employees` to `Workforce` while keeping the stable `for_employees` slug and legacy standards cross-reference.
- Adds a working-draft IT4IT/DPPM white paper proposing `Workforce Portfolio (Provided Internally)` as the standards-facing evolution of the internal portfolio.
- Updates platform-facing labels in knowledge persona copy, org operating-model seed pages, Work Capsule presentation, the portfolio user guide, the founder-kernel portfolio entity, and the BOM portfolio wiring spec amendment.

Linked BI: BI-70DD2466
Linked epic: EP-BOM-WIRING

## Test Plan
- [x] `node -e "JSON.parse(require('fs').readFileSync('packages/db/data/portfolio_registry.json','utf8'))"`
- [x] `git diff --check HEAD~1 HEAD`
- [x] Shared local-CI merged candidate: branch merged cleanly into `origin/main`; sandbox freshness reported green; `prisma migrate deploy` reported no pending migrations.
- [x] `/Users/markbodman/dpf-worktrees/.local-ci-runner`: `pnpm --filter @dpf/db exec vitest run src/digital-product-registry.test.ts` - 1 file / 3 tests passed.
- [x] `/Users/markbodman/dpf-worktrees/.local-ci-runner`: `pnpm --filter web exec vitest run lib/onboarding/seed-org-operating-model-pages.test.ts lib/work-capsules/work-capsule-presenter.test.ts` - 2 files / 12 tests passed.
- [x] `/Users/markbodman/dpf-worktrees/.local-ci-runner`: `pnpm --filter @dpf/db typecheck` passed.
- [x] `/Users/markbodman/dpf-worktrees/.local-ci-runner`: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` passed.
- [x] `/Users/markbodman/dpf-worktrees/.local-ci-runner`: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build` passed. Existing Edge-runtime/NFT warnings were emitted, but the build completed successfully.
- [ ] Full shared local-CI broad web Vitest sweep: attempted twice. The second run completed merge, freshness, dependency convergence, and migrations, then failed in broad `pnpm --filter web exec vitest run` with unrelated worker startup/timeouts (`ToolExecutionLogClient.test.tsx` timeout plus eight Vitest worker startup errors and repeated `/bin/sh: ip: command not found`). Targeted affected tests passed as listed above.

Local-CI-Override: Broad local-CI web Vitest sweep failed in the shared sandbox on unrelated worker startup/timeouts after merge/freshness/migrations. Targeted affected tests, DB and web typechecks, and production build passed on the merged candidate; GitHub CI is the merge-authoritative full-suite lane for this PR.