### PR TITLE
fix(decision-gov): widen domainClass CHECK constraints to match the registry (BI-E286E148)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-decision-governance-audit-log.md
+++ b/docs/superpowers/plans/2026-07-06-decision-governance-audit-log.md
@@ -38,3 +38,12 @@ Tier attribution is by profile kind (`platform`→WWMD, `organization`→WWWD, `
 
 - Unit: `kernel-consult-ledger.test.ts` (outcome mapping, profile attribution, observable skip, fail-open), `decision-audit.test.ts` (tier mapping, awaiting-human semantics), extended `decision-governance-hub.test.ts` (usage chips, log links).
 - Runtime (canonical install, post self-upgrade): call `principle_decide` via MCP → row visible at `/wiki/decisions` with WWMD attribution; hub chip flips from "no decisions recorded" to a live count.
+
+## 5. Migration addendum (post-#2647 live verification)
+
+Live verification caught a DB/TS enum drift: the `DecisionInteraction_domainClass_check` /
+`PerspectiveMaterial_domainClass_check` constraints (migration 20260517233000) froze the
+domain-class set at the original three values, so every `kernel-consult` ledger write failed
+its CHECK — observably (`ledger.recorded=false`, fail-open) but the audit trail stayed empty.
+Migration `20260706110000_align_decision_domainclass_check` widens both constraints to the
+full registry (`professional-practice`, `kernel-consult` added). Widening is data-safe.

--- a/packages/db/prisma/migrations/20260706110000_align_decision_domainclass_check/migration.sql
+++ b/packages/db/prisma/migrations/20260706110000_align_decision_domainclass_check/migration.sql
@@ -1,0 +1,19 @@
+-- Align the domainClass CHECK constraints with the DECISION_DOMAIN_CLASSES
+-- registry (apps/web/lib/decision-perspective/types.ts). The 20260517233000
+-- constraints froze the set at the original three values; the registry has
+-- since added 'professional-practice' (WSID) and 'kernel-consult' (the
+-- principle_decide audit ledger, #2647). The drift made every kernel-consult
+-- ledger write fail its CHECK on live installs — observably (fail-open
+-- ledger.recorded=false), but the audit trail stayed empty.
+--
+-- @migration-safety: data-safe: strictly widens the allowed value set of two
+-- CHECK constraints; every row valid under the old three-value set is valid
+-- under the five-value set, so no existing row can violate it.
+
+ALTER TABLE "DecisionInteraction" DROP CONSTRAINT IF EXISTS "DecisionInteraction_domainClass_check";
+ALTER TABLE "DecisionInteraction" ADD CONSTRAINT "DecisionInteraction_domainClass_check"
+  CHECK ("domainClass" IN ('plan-readiness', 'architecture-tradeoff', 'risk-assessment', 'professional-practice', 'kernel-consult'));
+
+ALTER TABLE "PerspectiveMaterial" DROP CONSTRAINT IF EXISTS "PerspectiveMaterial_domainClass_check";
+ALTER TABLE "PerspectiveMaterial" ADD CONSTRAINT "PerspectiveMaterial_domainClass_check"
+  CHECK ("domainClass" IN ('plan-readiness', 'architecture-tradeoff', 'risk-assessment', 'professional-practice', 'kernel-consult'));


### PR DESCRIPTION
## Problem

Live verification of #2647 caught a DB/TS enum drift: the `DecisionInteraction_domainClass_check` and `PerspectiveMaterial_domainClass_check` constraints (migration 20260517233000) froze `domainClass` at the original three values. Every `kernel-consult` ledger write from the new principle_decide recorder failed its CHECK on live — fail-open and observable (`ledger.recorded=false`, `[kernel-consult-ledger] write failed` in portal logs, two independent sessions hit it), but the audit trail stayed empty. `professional-practice` (in the TS registry since the WSID work) had also never been added to the DB constraint.

## Change

Migration `20260706110000_align_decision_domainclass_check` widens both CHECK constraints to the five-value `DECISION_DOMAIN_CLASSES` registry. Widening is data-safe (in-file `@migration-safety` attestation): every row valid under the old set is valid under the new one.

## Evidence

- Migration + a `kernel-consult` insert verified against the live schema in a rolled-back transaction (canonical install postgres).
- Local-CI sandbox gate passed (lease `decision-ledger-constraint`, production build + suite).
- Plan doc addendum: `docs/superpowers/plans/2026-07-06-decision-governance-audit-log.md` §5.

BI-E286E148 · EP-0AF96937 · follow-up to #2647

🤖 Generated with [Claude Code](https://claude.com/claude-code)