### PR TITLE
docs(hr): Phase 4 live-verified + dialog fix in labor-economics spec

### DIFF
--- a/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
+++ b/docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md
@@ -163,6 +163,21 @@ profile lacks `billableTimeEnabled`, so non-labour archetypes never see any of i
 
 Verification: `lib/hr/labor-report.test.ts` (aggregation), employee page tests extended
 for the new reads, full `components/*` + `lib/actions` vitest sweep and `web` typecheck
-green in the worktree; live happy-path verification (set pay → approve billable hours →
-generate invoice → margin band; non-labour archetype sees none of it) follows the next
-self-upgrade per `dpf-verify-on-live-install`.
+green in the worktree.
+
+**Live-verified on the deployed install (2026-07-06, sha `e0a7e35`).** Full happy path
+driven end-to-end: set an hourly employee's pay ($50/h, governed action logged `allow`)
+→ add a rate-card service (Consulting $150/h) → mark 8 billable timesheet hours to a
+customer + service → approve → **Create draft invoice** on the customer account produced
+draft `INV-2026-0003` (`sourceType='billable-time'`, one line `Consulting (8 hours …)` at
+8 × $150 = **$1,200**), stamped `TimesheetEntry.invoiceId`/`invoicedAt` so the hours drop
+out of the unbilled set (double-bill guard confirmed live). Margin band computed exact
+throughout: $400 cost / $1,200 billed / $800 margin (66.67%). The archetype gate is
+structural — only the 6 labour profiles set `billableTimeEnabled: true`; every other
+profile falls through `?? false`, so non-labour installs render none of the billable
+surfaces.
+
+A confirm-dialog defect was caught during this verification and fixed in a follow-up
+(#2649): the "Create draft invoice" button raised `confirmDialog` inside `startTransition`,
+which deferred the dialog's render so it never became interactive. Fixed to await the
+dialog before the transition (the pattern every other `confirmDialog` caller uses).


### PR DESCRIPTION
Doc-only status update to `docs/superpowers/specs/2026-07-04-labor-economics-timecard-billing-design.md` §7: records that EP-LABOR-ECONOMICS Phase 4 (#2634) + the confirm-dialog fix (#2649) are **live-verified on the deployed install** (sha `e0a7e35`).

Happy path driven end-to-end: set hourly pay → rate card → 8 billable timesheet hours → approve → **Create draft invoice** → draft `INV-2026-0003` (`billable-time`, 8 × $150 = $1,200) with the `invoiceId`/`invoicedAt` double-bill stamp. Margin band exact ($400 / $1,200 / $800, 66.67%). Archetype gate structural (6 labour profiles enable it; rest fall through `?? false`).

Process-Spine-Decision: doc-only status note on an existing spec section; no implementation surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)