### PR TITLE
fix(db,test): migration timestamp-collision guard + hermetic external-evidence test (BI-BFDCE0A9)

### DIFF
--- a/.github/workflows/migration-safety-guard.yml
+++ b/.github/workflows/migration-safety-guard.yml
@@ -24,6 +24,7 @@ on:
       # Also trigger when the guard machinery itself changes so a guard
       # regression can't slip through without exercising the CI path.
       - "packages/db/scripts/migration-safety-guard.mjs"
+      - "packages/db/scripts/migration-timestamp-collision-guard.mjs"
       - ".github/workflows/migration-safety-guard.yml"
 
 jobs:
@@ -44,3 +45,14 @@ jobs:
         run: |
           git fetch origin main --depth=50
           node packages/db/scripts/migration-safety-guard.mjs origin/main
+
+      - name: Detect new migration timestamp collisions
+        # Fails a PR whose NEW migration reuses another migration's 14-digit
+        # timestamp prefix. Ordering stays deterministic (Prisma sorts by full
+        # dir name) so this is hygiene, not a mechanical break — but it stops the
+        # collision set from growing and heads off the destructive "de-collide by
+        # renaming an applied migration" reflex (P3018 on every install).
+        # Logic in packages/db/scripts/migration-timestamp-collision-guard.mjs;
+        # covered by packages/db/scripts/migration-timestamp-collision-guard.test.ts.
+        # BI-BFDCE0A9.
+        run: node packages/db/scripts/migration-timestamp-collision-guard.mjs origin/main

--- a/apps/web/lib/mcp-tools-external-development-evidence.test.ts
+++ b/apps/web/lib/mcp-tools-external-development-evidence.test.ts
@@ -12,6 +12,30 @@ vi.mock("@/lib/actions/external-evidence", () => ({
   recordExternalEvidence: mockRecordExternalEvidence,
 }));
 
+// Hermeticity (BI-BFDCE0A9): the handler runs an owner check
+// (`prisma.featureBuild.findUnique`) and a best-effort capsule capture before
+// returning. Neither is the unit under test, but against an unmocked prisma with
+// no ambient Postgres the owner check throws, executeTool catches it, and the
+// tool returns success:false — so this test used to pass ONLY where a DB was
+// wired (CI shards) and fail in every DB-less run (fresh worktree, pre-push
+// gate). Stub the DB-touching seams so the test asserts the handler's own
+// contract, not the presence of a database. mcp-tools.ts imports only `prisma`
+// and `DISCOVERY_TRIAGE_AGENT_ID` from @dpf/db, so preserving the rest of the
+// module and replacing just `prisma` is sufficient.
+vi.mock("@dpf/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dpf/db")>();
+  return {
+    ...actual,
+    prisma: {
+      featureBuild: { findUnique: vi.fn().mockResolvedValue(null) },
+    },
+  };
+});
+
+vi.mock("@/lib/work-capsules/external-session-capture", () => ({
+  captureExternalSessionEvidence: vi.fn().mockResolvedValue("WC-test-1"),
+}));
+
 import { executeTool } from "./mcp-tools";
 
 describe("record_external_development_evidence", () => {

--- a/packages/db/scripts/migration-timestamp-collision-guard.mjs
+++ b/packages/db/scripts/migration-timestamp-collision-guard.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+//
+// migration-timestamp-collision-guard.mjs — block a NEW Prisma migration whose
+// 14-digit timestamp prefix collides with another migration in the tree.
+//
+// Why this exists (BI-BFDCE0A9, 2026-07-06): Prisma orders migrations by full
+// directory name, so a timestamp-prefix collision (two dirs sharing the same
+// 20260706080000 prefix) does NOT break `migrate deploy` — ordering falls back
+// to the suffix and stays deterministic. The repo already carries 19 such pairs
+// and they apply fine. The hazard is human, not mechanical: a shared timestamp
+// makes migration ordering non-obvious to a reader, invites "just bump the
+// timestamp" fixes, and — critically — renaming an ALREADY-APPLIED migration to
+// de-collide is destructive (it re-runs on every existing install: P3018
+// `column already exists`, wedging the forward-only chain). The safe posture is
+// therefore: never retro-rename applied migrations, but stop NEW collisions at
+// the door so the set never grows.
+//
+// What it flags: any NEW migration (absent at <base-ref>) whose 14-digit
+// timestamp prefix is shared by any other migration in the working tree —
+// whether that other migration is pre-existing or also new. Existing pairs are
+// never "new", so the 19 legacy collisions self-baseline and are never flagged.
+//
+// The fix for a flagged collision is always to pick a fresh, later timestamp for
+// the NEW migration BEFORE it merges (it has never been applied anywhere, so
+// renaming it is free) — never to rename the migration it collides with.
+//
+// Usage:   node packages/db/scripts/migration-timestamp-collision-guard.mjs <base-ref>
+// Exit:    0 no new collisions · 1 at least one · 2 invocation error
+//
+// Wired into:
+//   - .github/workflows/migration-safety-guard.yml (CI)
+//   - packages/db/scripts/migration-timestamp-collision-guard.test.ts (vitest)
+
+import { execFileSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIGRATIONS_DIR = "packages/db/prisma/migrations";
+const TS_PREFIX = /^(\d{14})_/;
+
+/**
+ * Given the full set of migration directory names and the subset that is NEW
+ * (absent at the base ref), return one finding per new migration that collides.
+ * Pure — no I/O — so the test can drive it directly.
+ *
+ * @param {string[]} allDirs   every migration dir name in the working tree
+ * @param {Set<string>} newDirs the subset that is new since the base ref
+ * @returns {{ dir: string, timestamp: string, collidesWith: string[] }[]}
+ */
+export function findCollisions(allDirs, newDirs) {
+  const byTimestamp = new Map();
+  for (const dir of allDirs) {
+    const m = TS_PREFIX.exec(dir);
+    if (!m) continue;
+    const ts = m[1];
+    if (!byTimestamp.has(ts)) byTimestamp.set(ts, []);
+    byTimestamp.get(ts).push(dir);
+  }
+
+  const findings = [];
+  for (const dir of allDirs) {
+    if (!newDirs.has(dir)) continue;
+    const m = TS_PREFIX.exec(dir);
+    if (!m) continue;
+    const siblings = byTimestamp.get(m[1]).filter((d) => d !== dir);
+    if (siblings.length > 0) {
+      findings.push({ dir, timestamp: m[1], collidesWith: siblings.sort() });
+    }
+  }
+  return findings;
+}
+
+// ─── driver ──────────────────────────────────────────────────────────────────
+function main() {
+  const baseRef = process.argv[2];
+  if (!baseRef) {
+    console.error("Usage: node packages/db/scripts/migration-timestamp-collision-guard.mjs <base-ref>");
+    process.exit(2);
+  }
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+  let tracked;
+  try {
+    tracked = execFileSync("git", ["ls-files", `${MIGRATIONS_DIR}/**/migration.sql`], {
+      cwd: repoRoot, encoding: "utf8",
+    }).split("\n").filter(Boolean);
+  } catch (err) {
+    console.error(`❌ git ls-files failed: ${err.message.split("\n")[0]}`);
+    process.exit(2);
+  }
+
+  // Map each migration.sql path → its migration directory name.
+  const dirOf = (f) => f.slice(`${MIGRATIONS_DIR}/`.length).split("/")[0];
+  const allDirs = tracked.map(dirOf);
+
+  const newDirs = new Set(
+    tracked
+      .filter((f) => {
+        try {
+          execFileSync("git", ["cat-file", "-e", `${baseRef}:${f}`], { cwd: repoRoot, stdio: "ignore" });
+          return false; // exists at base → not new
+        } catch {
+          return true; // absent at base → new migration
+        }
+      })
+      .map(dirOf),
+  );
+
+  const findings = findCollisions(allDirs, newDirs);
+
+  if (findings.length === 0) {
+    console.log("✅ No new migration timestamp collisions.");
+    process.exit(0);
+  }
+
+  console.error("❌ Migration timestamp collision: a new migration shares its timestamp with another.");
+  console.error("");
+  console.error("Prisma still applies these deterministically (ordered by full dir name), but a");
+  console.error("shared timestamp obscures ordering and invites a de-collide rename. Renaming an");
+  console.error("ALREADY-APPLIED migration re-runs it on every install (P3018 column-already-exists),");
+  console.error("so the only safe fix is to rebump THIS new, unapplied migration to a later timestamp.");
+  console.error("");
+  for (const f of findings) {
+    console.error(`  ${f.dir}`);
+    console.error(`    • timestamp ${f.timestamp} also used by: ${f.collidesWith.join(", ")}`);
+  }
+  console.error("");
+  console.error("Fix: rename the NEW migration directory above to a fresh, later 14-digit timestamp");
+  console.error("(YYYYMMDDHHMMSS) that no other migration uses. Do NOT rename the migration it");
+  console.error("collides with — if that one has already been applied anywhere, renaming it wedges");
+  console.error("the forward-only chain.");
+  console.error("");
+  process.exit(1);
+}
+
+// Only run when invoked directly (not when imported by the test).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/packages/db/scripts/migration-timestamp-collision-guard.test.ts
+++ b/packages/db/scripts/migration-timestamp-collision-guard.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — .mjs guard, no types
+import { findCollisions } from "./migration-timestamp-collision-guard.mjs";
+
+const newSet = (...dirs: string[]) => new Set(dirs);
+
+describe("migration-timestamp-collision-guard", () => {
+  it("FLAGS a new migration colliding with an EXISTING one (the BI-BFDCE0A9 case)", () => {
+    const all = [
+      "20260706070000_add_opportunity_next_activity",
+      "20260706080000_add_mdm_steward_substrate", // pre-existing
+      "20260706080000_add_quote_accept_token", // new, same timestamp
+    ];
+    const f = findCollisions(all, newSet("20260706080000_add_quote_accept_token"));
+    expect(f).toHaveLength(1);
+    expect(f[0].dir).toBe("20260706080000_add_quote_accept_token");
+    expect(f[0].timestamp).toBe("20260706080000");
+    expect(f[0].collidesWith).toEqual(["20260706080000_add_mdm_steward_substrate"]);
+  });
+
+  it("FLAGS both when two NEW migrations collide with each other", () => {
+    const all = [
+      "20260707120000_add_alpha",
+      "20260707120000_add_beta",
+    ];
+    const f = findCollisions(all, newSet("20260707120000_add_alpha", "20260707120000_add_beta"));
+    expect(f).toHaveLength(2);
+    expect(f.map((x) => x.dir).sort()).toEqual([
+      "20260707120000_add_alpha",
+      "20260707120000_add_beta",
+    ]);
+  });
+
+  it("does NOT flag the 19 legacy collisions — pre-existing pairs are never 'new'", () => {
+    // Both share a timestamp but neither is new → self-baselined.
+    const all = [
+      "20260704120000_add_mdm_normalized_columns_and_trgm",
+      "20260704120000_add_subscription_support_contract",
+    ];
+    expect(findCollisions(all, newSet())).toHaveLength(0);
+  });
+
+  it("PASSES a new migration with a unique timestamp", () => {
+    const all = [
+      "20260706080000_add_mdm_steward_substrate",
+      "20260706080000_add_quote_accept_token",
+      "20260707120000_add_fresh_thing", // new, unique
+    ];
+    expect(findCollisions(all, newSet("20260707120000_add_fresh_thing"))).toHaveLength(0);
+  });
+
+  it("reports every colliding sibling, sorted, for a triple collision", () => {
+    const all = [
+      "20260708090000_add_one", // existing
+      "20260708090000_add_two", // existing
+      "20260708090000_add_three", // new
+    ];
+    const f = findCollisions(all, newSet("20260708090000_add_three"));
+    expect(f).toHaveLength(1);
+    expect(f[0].collidesWith).toEqual([
+      "20260708090000_add_one",
+      "20260708090000_add_two",
+    ]);
+  });
+
+  it("ignores dirs without a 14-digit timestamp prefix", () => {
+    const all = ["migration_lock.toml_notadir", "20260707120000_add_alpha"];
+    expect(findCollisions(all, newSet("20260707120000_add_alpha"))).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Resolves **BI-BFDCE0A9**. Two independent fixes under one BI, both CI/test-only (no product code):

## 1. Hermetic test — the real defect behind the "main-red" report

`apps/web/lib/mcp-tools-external-development-evidence.test.ts` mocked `recordExternalEvidence` + `loadEnforceablePrinciples`, but left the handler's owner check (`prisma.featureBuild.findUnique`) and best-effort capsule capture hitting a **live** prisma. With no ambient Postgres the owner check throws → `executeTool` catches it → the tool returns `success:false`. So the test passed **only where a DB was wired** (GitHub CI shards) and failed in every DB-less run (fresh worktree, local pre-push gate) — which is what produced the spurious "main-red" report.

Fix: stub the two DB-touching seams (`featureBuild.findUnique` → null; the dynamically-imported `captureExternalSessionEvidence`). `pnpm --filter web exec vitest run lib/mcp-tools-external-development-evidence.test.ts` now passes with `DATABASE_URL` **unset**.

> The test was **already green on GitHub CI** (all four `Unit Tests (web shard N/4)` on `48c9abe`) — this change makes it green *everywhere*, not just where a DB happens to be present.

## 2. Guard against new migration timestamp collisions

The original BI also asked to "fix the `20260706080000` collision by renaming one" migration. That is **destructive**: renaming the already-applied `20260706080000_add_quote_accept_token` makes `migrate deploy` fail with **`P3018 / column "acceptToken" already exists`** on every install that applied it, wedging the forward-only self-upgrade chain (empirically confirmed). Timestamp-prefix collisions are also **benign and pervasive** — Prisma orders by full dir name, and main already carries **19** such pairs that apply cleanly.

**WWMD kernel decision** (`principle_decide` / `dpf-decision-via-kernel`): recommend a **future-collision guard** — composite 1.014, margin 0.397, high confidence, no commandment conflict; top driver *Architecture Over Shortcuts*. The `rename-migration` option scored last, penalized by *Never wipe the DB to fix code* + *Destructive actions require explicit go*.

Fix: `packages/db/scripts/migration-timestamp-collision-guard.mjs` fails any PR whose **new** migration reuses another's 14-digit timestamp prefix (existing pairs are never "new", so the 19 legacy collisions self-baseline). Wired as a step in `.github/workflows/migration-safety-guard.yml`, covered by a 6-case unit test. The guard tells authors to rebump the **new, unapplied** migration — never to rename the one it collides with.

## Verification
- `pnpm --filter web exec vitest run lib/mcp-tools-external-development-evidence.test.ts` → 1 passed (DATABASE_URL unset)
- `pnpm --filter @dpf/db exec vitest run scripts/migration-timestamp-collision-guard.test.ts scripts/migration-safety-guard.test.ts` → 17 passed
- Guard vs `origin/main`: `✅ No new migration timestamp collisions` (exit 0); simulated new collision → exit 1 with report

🤖 Generated with [Claude Code](https://claude.com/claude-code)