### PR TITLE
fix(dpf-skill-pack): avoid duplicate Codex TOML plugin tables

### DIFF
--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -161,21 +161,71 @@ def ensure_claude_marketplace(home: Path, version: str, dry_run: bool) -> bool:
     return write_json(path, data)
 
 
+def split_toml_dotted_key(key: str) -> list[str] | None:
+    parts: list[str] = []
+    current: list[str] = []
+    quoted = False
+    escape = False
+
+    for char in key.strip():
+        if quoted:
+            if escape:
+                current.append(char)
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                quoted = False
+            else:
+                current.append(char)
+        elif char == '"':
+            quoted = True
+        elif char == ".":
+            part = "".join(current).strip()
+            if not part:
+                return None
+            parts.append(part)
+            current = []
+        else:
+            current.append(char)
+
+    if quoted or escape:
+        return None
+    part = "".join(current).strip()
+    if not part:
+        return None
+    parts.append(part)
+    return parts
+
+
+def canonical_toml_table_header(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped.startswith("[") or not stripped.endswith("]") or stripped.startswith("[["):
+        return None
+    parts = split_toml_dotted_key(stripped[1:-1])
+    if parts is None:
+        return None
+    return ".".join(parts)
+
+
 def upsert_toml_table(text: str, header: str, body_lines: list[str]) -> str:
     lines = text.splitlines()
     start = None
+    target_header = canonical_toml_table_header(header)
     for index, line in enumerate(lines):
-        if line.strip() == header:
+        if target_header is not None and canonical_toml_table_header(line) == target_header:
             start = index
             break
-    block = [header, *body_lines]
+    block = [lines[start].strip() if start is not None else header, *body_lines]
     if start is None:
         prefix = "\n" if text.strip() else ""
         return text.rstrip() + prefix + "\n".join(block) + "\n"
     end = start + 1
     while end < len(lines):
         stripped = lines[end].strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
+        if canonical_toml_table_header(stripped) is not None or (
+            stripped.startswith("[[") and stripped.endswith("]]")
+        ):
             break
         end += 1
     next_lines = lines[:start] + block + lines[end:]

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -126,6 +126,32 @@ class UpdateAgentToolchainTest(unittest.TestCase):
             self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
             self.assertEqual(data["mcp_servers"]["dpf"]["url"], "https://mcp.example.test/api/mcp/v1")
 
+    def test_reuses_bare_codex_plugin_table_instead_of_appending_duplicate(self) -> None:
+        skill_pack = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            config = home / ".codex" / "config.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                'model = "gpt-5.5"\n'
+                "[plugins.dpf-platform]\n"
+                "enabled = true\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {"DPF_AGENT_TOOLCHAIN_HOME": tmp}, clear=False):
+                updater.main([
+                    "--skill-pack-path",
+                    str(skill_pack),
+                    "--skip-claude-cli-install",
+                ])
+
+            raw = config.read_text()
+            if tomllib is not None:
+                data = tomllib.loads(raw)
+                self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
+            self.assertEqual(raw.count("dpf-platform"), 1)
+
     @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
     def test_repairs_missing_managed_plugin_without_token_or_portal(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- Fixes `BI-FDD30E7D`: the standalone DPF agent-toolchain fallback now treats `[plugins.dpf-platform]` and `[plugins.\"dpf-platform\"]` as the same TOML table instead of appending a duplicate.
- Adds a regression test for the exact Codex config corruption shape that blocked thread resume/plugin/MCP loading.
- Files follow-up `BI-C82D58A3` for the separate local-CI runner bug discovered while gating.

## Test plan
- [x] Red regression first: existing `[plugins.dpf-platform]` made the old fallback append a second `dpf-platform` table.
- [x] `python3 -m unittest packages.dpf-skill-pack.scripts.update_agent_toolchain_test` — 7 tests OK, 3 skipped on system Python without `tomllib`.
- [x] Bundled Python: same unittest module — 7 tests OK.
- [x] `pnpm --filter @dpf/bootstrap exec vitest run src/agent-toolchain/__tests__/codex-config.test.ts` — 15 tests passed.
- [x] `bash scripts/dpf-bootstrap-agent-toolchain.sh` after the patch — completed without re-corrupting `~/.codex/config.toml`; active config parses and has a single DPF plugin table header.
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — passed.
- [x] `pnpm --filter web build` — passed.
- [x] `pnpm run pregate` default runner: branch pushed and lease `NPEL-67F84A49AF` claimed; merged cleanly, sandbox freshness green, migrations clean, web Vitest passed 1666 files / 14286 tests; then runner failed web typecheck because the scratch checkout lacked ignored Prisma generated client delegates. Tracked as `BI-C82D58A3`.

Local-CI-Override: Default local-CI runner failed on BI-C82D58A3, where the scratch checkout deletes ignored packages/db/generated then typechecks without prisma generate. This branch is verified clean by focused Python/TS tests, heap-raised web typecheck, production build, and the default local-CI web Vitest pass before the runner bug.