### PR TITLE
feat(queue): queue-awareness visibility — coworker MCP pack + attention resolver + health tiles (EP-3516E23D Phase 3)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
@@ -16,6 +16,7 @@ import {
 import { LocalTime } from "@/components/ui/LocalTime";
 import { AiReadinessHeaderLink } from "@/components/platform/AiReadinessHeaderLink";
 import { QueueHealthSection } from "@/components/queue/QueueHealthSection";
+import { readQueueSnapshots } from "@/lib/queue/queue-snapshot-service";
 import Link from "next/link";
 
 export const dynamic = "force-dynamic";
@@ -99,6 +100,10 @@ export default async function RuntimeHealthPage() {
 
   const errorCount = overview?.flags.filter((f) => f.severity === "error").length ?? 0;
 
+  // Fetch here (in the async page body) and pass to the synchronous section so
+  // the page renders in a single synchronous pass — no suspending child.
+  const queueSnapshots = await readQueueSnapshots({ limit: 24 });
+
   return (
     <div>
       <div style={{ marginBottom: 20, display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
@@ -117,7 +122,7 @@ export default async function RuntimeHealthPage() {
       </div>
 
       <div style={{ marginBottom: 20 }}>
-        <QueueHealthSection />
+        <QueueHealthSection snapshots={queueSnapshots} />
       </div>
 
       {loadError && (

--- a/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/inference/phase-model-resolution";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { AiReadinessHeaderLink } from "@/components/platform/AiReadinessHeaderLink";
+import { QueueHealthSection } from "@/components/queue/QueueHealthSection";
 import Link from "next/link";
 
 export const dynamic = "force-dynamic";
@@ -113,6 +114,10 @@ export default async function RuntimeHealthPage() {
           </p>
         </div>
         <AiReadinessHeaderLink />
+      </div>
+
+      <div style={{ marginBottom: 20 }}>
+        <QueueHealthSection />
       </div>
 
       {loadError && (

--- a/apps/web/components/queue/QueueHealthSection.tsx
+++ b/apps/web/components/queue/QueueHealthSection.tsx
@@ -1,0 +1,57 @@
+// apps/web/components/queue/QueueHealthSection.tsx
+//
+// EP-3516E23D Phase 3 — the human half of queue visibility. A server component
+// that renders one report-kit StatCard per queue with a snapshot today, so an
+// operator sees at a glance where scarce-resource work is piling up (depth, p95
+// wait, cycle time, first-pass yield, SLA) — the same numbers the AI coworker
+// reads through get_queue_status. Spec §4.5.
+
+import { StatCard } from "@/components/ui/report-kit";
+import { readQueueSnapshots } from "@/lib/queue/queue-snapshot-service";
+import { queueTileModel } from "@/lib/queue/queue-tile-model";
+
+export async function QueueHealthSection() {
+  const snapshots = await readQueueSnapshots({ limit: 24 });
+
+  return (
+    <section aria-labelledby="queue-health-heading" style={{ display: "grid", gap: "0.75rem" }}>
+      <div>
+        <h2 id="queue-health-heading" style={{ fontSize: "1rem", fontWeight: 600, margin: 0 }}>
+          Queue health
+        </h2>
+        <p style={{ margin: "0.25rem 0 0", fontSize: "0.8125rem", color: "var(--dpf-muted)" }}>
+          Flow metrics for scarce-resource queues today — wait, cycle time, throughput, and
+          first-pass yield. Rolled up hourly from queue telemetry.
+        </p>
+      </div>
+
+      {snapshots.length === 0 ? (
+        <p style={{ margin: 0, fontSize: "0.875rem", color: "var(--dpf-muted)" }}>
+          No queue activity recorded yet today.
+        </p>
+      ) : (
+        <div
+          style={{
+            display: "grid",
+            gap: "0.75rem",
+            gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          }}
+        >
+          {snapshots.map((s) => {
+            const m = queueTileModel(s);
+            return (
+              <StatCard
+                key={s.queueKey}
+                label={m.label}
+                value={m.value}
+                hint={m.hint}
+                intent={m.intent}
+                delta={m.delta ?? undefined}
+              />
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/queue/QueueHealthSection.tsx
+++ b/apps/web/components/queue/QueueHealthSection.tsx
@@ -1,18 +1,19 @@
 // apps/web/components/queue/QueueHealthSection.tsx
 //
-// EP-3516E23D Phase 3 — the human half of queue visibility. A server component
-// that renders one report-kit StatCard per queue with a snapshot today, so an
-// operator sees at a glance where scarce-resource work is piling up (depth, p95
-// wait, cycle time, first-pass yield, SLA) — the same numbers the AI coworker
-// reads through get_queue_status. Spec §4.5.
+// EP-3516E23D Phase 3 — the human half of queue visibility. A SYNCHRONOUS
+// presentational component: it renders one report-kit StatCard per queue with a
+// snapshot today, so an operator sees at a glance where scarce-resource work is
+// piling up (depth, p95 wait, cycle time, first-pass yield, SLA) — the same
+// numbers the AI coworker reads through get_queue_status. Spec §4.5.
+//
+// Data-in-props (not a self-fetching async component) so a page can render it in
+// a synchronous pass — the caller (a server component) does the awaiting.
 
 import { StatCard } from "@/components/ui/report-kit";
-import { readQueueSnapshots } from "@/lib/queue/queue-snapshot-service";
+import type { QueueSnapshotView } from "@/lib/queue/queue-snapshot-service";
 import { queueTileModel } from "@/lib/queue/queue-tile-model";
 
-export async function QueueHealthSection() {
-  const snapshots = await readQueueSnapshots({ limit: 24 });
-
+export function QueueHealthSection({ snapshots }: { snapshots: QueueSnapshotView[] }) {
   return (
     <section aria-labelledby="queue-health-heading" style={{ display: "grid", gap: "0.75rem" }}>
       <div>

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -53,6 +53,7 @@ import { crmContactsPack } from "@/lib/mcp/packs/crm-contacts-pack";
 import { selfUpgradePack } from "@/lib/mcp/packs/self-upgrade-pack";
 import { coworkerServiceCatalogPack } from "@/lib/mcp/packs/coworker-service-catalog-pack";
 import { coworkerToolGrantPack } from "@/lib/mcp/packs/coworker-tool-grant-pack";
+import { queueAwarenessPack } from "@/lib/mcp/packs/queue-awareness-pack";
 import { composeToolPacks } from "@/lib/mcp/tool-registry";
 import {
   createLicenseReadinessIssue,
@@ -449,7 +450,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, mdmStewardshipPack, crmContactsPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,

--- a/apps/web/lib/mcp/packs/queue-awareness-pack.test.ts
+++ b/apps/web/lib/mcp/packs/queue-awareness-pack.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const readQueueSnapshots = vi.fn();
+const readAtRiskQueues = vi.fn();
+const { assessQueueHealth } = await vi.importActual<
+  typeof import("@/lib/queue/queue-snapshot-service")
+>("@/lib/queue/queue-snapshot-service");
+
+vi.mock("@/lib/queue/queue-snapshot-service", () => ({
+  readQueueSnapshots: (...a: unknown[]) => readQueueSnapshots(...a),
+  readAtRiskQueues: (...a: unknown[]) => readAtRiskQueues(...a),
+  assessQueueHealth: (s: unknown) => assessQueueHealth(s as never),
+}));
+
+import { queueAwarenessPack } from "./queue-awareness-pack";
+
+function snap(over: Record<string, unknown> = {}) {
+  return {
+    queueKey: "cwq:q1",
+    period: "2026-07-06",
+    depth: 0,
+    wip: 0,
+    arrivals: 0,
+    throughput: 0,
+    waitP50Ms: null,
+    waitP95Ms: null,
+    processP50Ms: null,
+    processP95Ms: null,
+    cycleP50Ms: null,
+    cycleP95Ms: null,
+    firstPassYield: null,
+    slaAttainment: null,
+    abandonmentRate: null,
+    computedAt: "2026-07-06T12:00:00.000Z",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  readQueueSnapshots.mockReset();
+  readAtRiskQueues.mockReset();
+});
+
+describe("queueAwarenessPack", () => {
+  it("declares two read-only tools with matching grants", () => {
+    expect(queueAwarenessPack.packId).toBe("queue-awareness");
+    expect(queueAwarenessPack.definitions.map((d) => d.name).sort()).toEqual([
+      "get_queue_status",
+      "list_at_risk_queues",
+    ]);
+    for (const def of queueAwarenessPack.definitions) {
+      expect(def.sideEffect).toBe(false);
+      expect(queueAwarenessPack.grants[def.name]).toEqual(["work_capsule_read"]);
+    }
+  });
+
+  it("get_queue_status formats durations/percentages and a health verdict", async () => {
+    readQueueSnapshots.mockResolvedValue([
+      snap({ queueKey: "cwq:hot", depth: 12, throughput: 3, waitP95Ms: 45000, cycleP50Ms: 500, firstPassYield: 0.9 }),
+    ]);
+    const res = await queueAwarenessPack.handlers.get_queue_status!({}, "u1");
+    expect(res.success).toBe(true);
+    const queues = res.data!.queues as Array<Record<string, unknown>>;
+    expect(queues[0]!.queueKey).toBe("cwq:hot");
+    expect(queues[0]!.health).toBe("at-risk"); // depth ≥ 10
+    expect(queues[0]!.waitP95).toBe("45s");
+    expect(queues[0]!.cycleP50).toBe("500ms");
+    expect(queues[0]!.firstPassYield).toBe("90%");
+  });
+
+  it("get_queue_status returns an honest empty message when no snapshot exists", async () => {
+    readQueueSnapshots.mockResolvedValue([]);
+    const res = await queueAwarenessPack.handlers.get_queue_status!({ queueKey: "cwq:none" }, "u1");
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("No flow-metric snapshot");
+    expect((res.data!.queues as unknown[]).length).toBe(0);
+  });
+
+  it("list_at_risk_queues surfaces reasons", async () => {
+    readAtRiskQueues.mockResolvedValue([
+      { snapshot: snap({ queueKey: "cwq:hot", depth: 20 }), assessment: { health: "at-risk", reasons: ["20 items waiting"] } },
+    ]);
+    const res = await queueAwarenessPack.handlers.list_at_risk_queues!({}, "u1");
+    expect(res.success).toBe(true);
+    const queues = res.data!.queues as Array<Record<string, unknown>>;
+    expect(queues[0]!.reasons).toEqual(["20 items waiting"]);
+  });
+});

--- a/apps/web/lib/mcp/packs/queue-awareness-pack.ts
+++ b/apps/web/lib/mcp/packs/queue-awareness-pack.ts
@@ -1,0 +1,145 @@
+// Queue-awareness tool pack — EP-3516E23D Phase 3 (BI-FD56CC6A).
+//
+// Read-only coworker surface over the shared queue flow-telemetry. Lets an AI
+// coworker answer "how is queue X doing?" — depth, wait/cycle time, throughput,
+// first-pass yield (% correct), SLA attainment — from the SAME QueueMetricSnapshot
+// rows the human tiles render, so human and coworker never argue from different
+// numbers (spec §4.5). Handlers lazy-import the snapshot service so this pack
+// pulls no heavy modules at registration. Grants mirror agent-grants.ts
+// TOOL_TO_GRANTS.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "get_queue_status",
+    description:
+      "Read the current flow metrics for one queue (or all queues) — depth, wait/process/cycle time percentiles, throughput, first-pass yield, SLA attainment, and a health verdict. Use before prioritizing work or when asked how a queue or the platform's scarce resources are doing. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        queueKey: {
+          type: "string",
+          description:
+            "Optional stable queue key (e.g. 'cwq:triage-default', 'compute:sandbox-pool'). Omit to list every queue with a snapshot today, most-backed-up first.",
+        },
+        limit: { type: "number", description: "Max queues to return (default 50, max 200)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "list_at_risk_queues",
+    description:
+      "List only the queues currently assessed at-risk — a deep backlog, low first-pass yield, missed SLA, or high abandonment — with the reasons. Use to decide where attention or capacity should go. Read-only.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+];
+
+function ms(v: number | null): string {
+  if (v == null) return "—";
+  if (v < 1000) return `${v}ms`;
+  const s = v / 1000;
+  if (s < 90) return `${s.toFixed(s < 10 ? 1 : 0)}s`;
+  const m = s / 60;
+  if (m < 90) return `${m.toFixed(0)}m`;
+  return `${(m / 60).toFixed(1)}h`;
+}
+
+function pct(v: number | null): string {
+  return v == null ? "—" : `${Math.round(v * 100)}%`;
+}
+
+async function getQueueStatusHandler(params: Record<string, unknown>): Promise<ToolResult> {
+  const { readQueueSnapshots, assessQueueHealth } = await import(
+    "@/lib/queue/queue-snapshot-service"
+  );
+  const queueKey = typeof params["queueKey"] === "string" ? params["queueKey"].trim() : undefined;
+  const limit = typeof params["limit"] === "number" ? params["limit"] : undefined;
+  const snapshots = await readQueueSnapshots({ queueKey: queueKey || undefined, limit });
+
+  if (snapshots.length === 0) {
+    return {
+      success: true,
+      message: queueKey
+        ? `No flow-metric snapshot yet for queue ${queueKey} today. Either nothing has flowed through it, or the hourly rollup has not run since its first event.`
+        : "No queue flow-metric snapshots for today yet.",
+      data: { queues: [] },
+    };
+  }
+
+  const queues = snapshots.map((s) => {
+    const { health, reasons } = assessQueueHealth(s);
+    return {
+      queueKey: s.queueKey,
+      health,
+      reasons,
+      depth: s.depth,
+      wip: s.wip,
+      arrivals: s.arrivals,
+      throughput: s.throughput,
+      waitP50: ms(s.waitP50Ms),
+      waitP95: ms(s.waitP95Ms),
+      cycleP50: ms(s.cycleP50Ms),
+      cycleP95: ms(s.cycleP95Ms),
+      firstPassYield: pct(s.firstPassYield),
+      slaAttainment: pct(s.slaAttainment),
+      abandonment: pct(s.abandonmentRate),
+      computedAt: s.computedAt,
+    };
+  });
+
+  const summary = queueKey
+    ? `Queue ${queueKey}: ${queues[0]!.health}, depth ${queues[0]!.depth}, p95 wait ${queues[0]!.waitP95}, throughput ${queues[0]!.throughput}, first-pass yield ${queues[0]!.firstPassYield}.`
+    : `${queues.length} queue(s) with activity today. ${
+        queues.filter((q) => q.health === "at-risk").length
+      } at-risk.`;
+
+  return { success: true, message: summary, data: { queues } };
+}
+
+async function listAtRiskQueuesHandler(): Promise<ToolResult> {
+  const { readAtRiskQueues } = await import("@/lib/queue/queue-snapshot-service");
+  const atRisk = await readAtRiskQueues();
+  if (atRisk.length === 0) {
+    return { success: true, message: "No queues are at-risk right now.", data: { queues: [] } };
+  }
+  const queues = atRisk.map(({ snapshot, assessment }) => ({
+    queueKey: snapshot.queueKey,
+    reasons: assessment.reasons,
+    depth: snapshot.depth,
+    waitP95: ms(snapshot.waitP95Ms),
+    firstPassYield: pct(snapshot.firstPassYield),
+    slaAttainment: pct(snapshot.slaAttainment),
+  }));
+  return {
+    success: true,
+    message: `${queues.length} at-risk queue(s): ${queues.map((q) => q.queueKey).join(", ")}.`,
+    data: { queues },
+  };
+}
+
+export const queueAwarenessPack: ToolPack = {
+  packId: "queue-awareness",
+  definitions,
+  handlers: {
+    get_queue_status: (params) => getQueueStatusHandler(params),
+    list_at_risk_queues: () => listAtRiskQueuesHandler(),
+  },
+  // Grants mirror agent-grants.ts TOOL_TO_GRANTS. Queue status is platform-
+  // coordination visibility, so it rides the same read grant as the sibling
+  // ops-read tool get_runtime_coordination_map (work_capsule_read) — any
+  // coworker that can read platform coordination state can read queue health,
+  // with no new grant to seed.
+  grants: {
+    get_queue_status: ["work_capsule_read"],
+    list_at_risk_queues: ["work_capsule_read"],
+  },
+};

--- a/apps/web/lib/portal-context/index.ts
+++ b/apps/web/lib/portal-context/index.ts
@@ -15,12 +15,15 @@ import { resolveHiveMindCandidates } from "./hive-mind-resolver";
 import { createPortalContextPromptDigest } from "./prompt-digest";
 import { resolvePortalRoute } from "./route-resolver";
 import { resolvePortalWork, type WorkResolution } from "./work-resolver";
+import { resolveQueueAttention } from "./queue-awareness-resolver";
 import type { AttentionSignal, PortalContextEnvelope, PortalContextInput } from "./types";
 
 type ResolverDeps = {
   db?: PortalContextDb;
   now?: () => Date;
   getRouteDataContext?: (routeContext: string, userId: string) => Promise<string | null>;
+  /** Injectable for tests; defaults to the live at-risk-queue resolver. */
+  getQueueAttention?: () => Promise<AttentionSignal[]>;
   resolverTimeoutMs?: number;
 };
 
@@ -89,6 +92,18 @@ export async function resolvePortalContextEnvelopeUncached(
   const workProjection = workProjectionResult.value;
   attention.push(...workProjectionResult.attention);
   attention.push(...workProjection.attention);
+
+  // Queue backpressure (EP-3516E23D): surface at-risk queues as attention so a
+  // coworker proactively knows where scarce-resource work is piling up. Value is
+  // the signal list itself; best-effort, capped inside the resolver.
+  const queueAttentionResult = await resolveSource(
+    "queue-awareness",
+    (deps.getQueueAttention ?? resolveQueueAttention)(),
+    [] as AttentionSignal[],
+    resolverTimeoutMs,
+  );
+  attention.push(...queueAttentionResult.value);
+  attention.push(...queueAttentionResult.attention);
 
   const evidenceResult = await resolveSource(
     "evidence",

--- a/apps/web/lib/portal-context/portal-context.test.ts
+++ b/apps/web/lib/portal-context/portal-context.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
+// Keep the envelope hermetic: the queue-attention resolver reads QueueMetricSnapshot
+// via the live client; stub it so this suite never touches an ambient DB.
+vi.mock("./queue-awareness-resolver", () => ({
+  resolveQueueAttention: vi.fn().mockResolvedValue([]),
+}));
+
 import {
   bucketPortalContextTimestamp,
   createPortalContextEnvelopeId,

--- a/apps/web/lib/portal-context/queue-awareness-resolver.test.ts
+++ b/apps/web/lib/portal-context/queue-awareness-resolver.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  atRiskQueueToSignal,
+  resolveQueueAttention,
+} from "./queue-awareness-resolver";
+import type { QueueSnapshotView } from "@/lib/queue/queue-snapshot-service";
+
+function snap(over: Partial<QueueSnapshotView> = {}): QueueSnapshotView {
+  return {
+    queueKey: "cwq:field-service",
+    period: "2026-07-06",
+    depth: 14,
+    wip: 16,
+    arrivals: 20,
+    throughput: 4,
+    waitP50Ms: null,
+    waitP95Ms: null,
+    processP50Ms: null,
+    processP95Ms: null,
+    cycleP50Ms: null,
+    cycleP95Ms: null,
+    firstPassYield: null,
+    slaAttainment: null,
+    abandonmentRate: null,
+    computedAt: "2026-07-06T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("atRiskQueueToSignal", () => {
+  it("produces a warning-severity queue_backpressure signal with reasons", () => {
+    const sig = atRiskQueueToSignal(snap(), { health: "at-risk", reasons: ["14 items waiting", "SLA attainment 60%"] });
+    expect(sig.kind).toBe("queue_backpressure");
+    expect(sig.severity).toBe("warning");
+    expect(sig.message).toContain("cwq:field-service");
+    expect(sig.message).toContain("14 items waiting");
+    expect(sig.actionHref).toBe("/platform/ai/runtime-health");
+  });
+});
+
+describe("resolveQueueAttention", () => {
+  it("maps at-risk queues to signals, capped", async () => {
+    const readAtRiskQueues = vi.fn(async () =>
+      Array.from({ length: 8 }, (_, i) => ({
+        snapshot: snap({ queueKey: `cwq:q${i}` }),
+        assessment: { health: "at-risk" as const, reasons: [`${10 + i} items waiting`] },
+      })),
+    );
+    const signals = await resolveQueueAttention({ readAtRiskQueues, limit: 3 });
+    expect(signals).toHaveLength(3);
+    expect(signals.every((s) => s.kind === "queue_backpressure")).toBe(true);
+  });
+
+  it("returns [] when nothing is at risk", async () => {
+    const signals = await resolveQueueAttention({ readAtRiskQueues: async () => [] });
+    expect(signals).toEqual([]);
+  });
+
+  it("never throws — returns [] on reader failure", async () => {
+    const signals = await resolveQueueAttention({
+      readAtRiskQueues: async () => {
+        throw new Error("db down");
+      },
+    });
+    expect(signals).toEqual([]);
+  });
+});

--- a/apps/web/lib/portal-context/queue-awareness-resolver.ts
+++ b/apps/web/lib/portal-context/queue-awareness-resolver.ts
@@ -1,0 +1,67 @@
+// apps/web/lib/portal-context/queue-awareness-resolver.ts
+//
+// EP-3516E23D Phase 3 — the PUSH half of queue visibility for coworkers. Turns
+// at-risk queue snapshots into AttentionSignals injected into the coworker's
+// portal context, so a coworker proactively knows "the field-service queue is
+// backing up (14 waiting, oldest breaching SLA)" without being asked — the
+// complement to the on-demand get_queue_status MCP tool. Spec §4.5.
+//
+// Best-effort: any failure yields no signals and never disturbs envelope
+// assembly. The snapshot reader is injected so this is unit-testable without a DB.
+
+import type { AttentionSignal } from "./types";
+import type {
+  QueueSnapshotView,
+  QueueHealthAssessment,
+  QueueSnapshotReadDeps,
+} from "@/lib/queue/queue-snapshot-service";
+
+/** Map a single at-risk queue to one attention signal. Pure. */
+export function atRiskQueueToSignal(
+  snapshot: QueueSnapshotView,
+  assessment: QueueHealthAssessment,
+): AttentionSignal {
+  const reasons = assessment.reasons.length > 0 ? assessment.reasons.join(", ") : "backing up";
+  return {
+    kind: "queue_backpressure",
+    severity: "warning",
+    message: `Queue ${snapshot.queueKey} is at-risk: ${reasons}.`,
+    actionLabel: "View queue metrics",
+    actionHref: "/platform/ai/runtime-health",
+  };
+}
+
+export interface ResolveQueueAttentionDeps extends QueueSnapshotReadDeps {
+  readAtRiskQueues?: (
+    deps?: QueueSnapshotReadDeps,
+  ) => Promise<Array<{ snapshot: QueueSnapshotView; assessment: QueueHealthAssessment }>>;
+  /** Cap the number of queue signals so a broad outage can't flood attention. */
+  limit?: number;
+}
+
+/**
+ * Resolve at-risk-queue attention signals for the coworker context. Returns []
+ * on any failure. Caps output (default 5) so a platform-wide stall surfaces the
+ * worst queues, not fifty rows.
+ */
+export async function resolveQueueAttention(
+  deps: ResolveQueueAttentionDeps = {},
+): Promise<AttentionSignal[]> {
+  try {
+    const read =
+      deps.readAtRiskQueues ??
+      (await import("@/lib/queue/queue-snapshot-service")).readAtRiskQueues;
+    const atRisk = await read({ getFinder: deps.getFinder, now: deps.now });
+    const limit = Math.min(Math.max(deps.limit ?? 5, 1), 20);
+    return atRisk
+      .slice(0, limit)
+      .map(({ snapshot, assessment }) => atRiskQueueToSignal(snapshot, assessment));
+  } catch (err) {
+    console.warn(
+      `[queue-awareness-resolver] failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return [];
+  }
+}

--- a/apps/web/lib/portal-context/types.ts
+++ b/apps/web/lib/portal-context/types.ts
@@ -117,7 +117,8 @@ export type AttentionSignal = {
     | "source_unavailable"
     | "envelope_timeout"
     | "unknown_route"
-    | "no_active_build";
+    | "no_active_build"
+    | "queue_backpressure";
   severity: "info" | "warning" | "error";
   message: string;
   actionLabel?: string | null;

--- a/apps/web/lib/proactivity/proactivity-resolver.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.ts
@@ -114,6 +114,12 @@ function resolveLevel(input: ProactivityResolverInput): ProactivityLevel {
     return input.statusSignal === "degraded" || input.statusSignal === "offline" ? "assertive" : "balanced";
   }
 
+  if (input.activityFamily === "queue-health") {
+    // A queue past its backpressure thresholds surfaces as blocked/degraded —
+    // nudge assertively so a backing-up scarce resource does not sit unnoticed.
+    return input.statusSignal === "blocked" || input.statusSignal === "degraded" ? "assertive" : "balanced";
+  }
+
   if (input.activityFamily === "tax-compliance") {
     return typeof input.deadlineWindowDays === "number" && input.deadlineWindowDays <= 7 ? "assertive" : "balanced";
   }

--- a/apps/web/lib/proactivity/proactivity-types.ts
+++ b/apps/web/lib/proactivity/proactivity-types.ts
@@ -13,6 +13,9 @@ export const PROACTIVITY_ACTIVITY_FAMILIES = [
   "customer-communication",
   "finance-close",
   "security-incident",
+  // EP-3516E23D: queue backpressure — a scarce-resource queue backing up past
+  // its thresholds warrants a more assertive nudge to whoever manages it.
+  "queue-health",
 ] as const;
 export type ProactivityActivityFamily = (typeof PROACTIVITY_ACTIVITY_FAMILIES)[number];
 

--- a/apps/web/lib/queue/queue-snapshot-service.test.ts
+++ b/apps/web/lib/queue/queue-snapshot-service.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  assessQueueHealth,
+  readQueueSnapshots,
+  readAtRiskQueues,
+  type QueueSnapshotView,
+} from "./queue-snapshot-service";
+
+function view(over: Partial<QueueSnapshotView> = {}): QueueSnapshotView {
+  return {
+    queueKey: "cwq:q1",
+    period: "2026-07-06",
+    depth: 0,
+    wip: 0,
+    arrivals: 0,
+    throughput: 0,
+    waitP50Ms: null,
+    waitP95Ms: null,
+    processP50Ms: null,
+    processP95Ms: null,
+    cycleP50Ms: null,
+    cycleP95Ms: null,
+    firstPassYield: null,
+    slaAttainment: null,
+    abandonmentRate: null,
+    computedAt: "2026-07-06T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("assessQueueHealth", () => {
+  it("is idle when nothing waiting or flowing", () => {
+    expect(assessQueueHealth(view()).health).toBe("idle");
+  });
+  it("is healthy when flowing with good metrics", () => {
+    const a = assessQueueHealth(view({ throughput: 5, firstPassYield: 0.95, depth: 2 }));
+    expect(a.health).toBe("healthy");
+  });
+  it("is at-risk on a deep backlog", () => {
+    const a = assessQueueHealth(view({ depth: 12, throughput: 1 }));
+    expect(a.health).toBe("at-risk");
+    expect(a.reasons.join(" ")).toContain("12 items waiting");
+  });
+  it("is watch on a single soft signal", () => {
+    const a = assessQueueHealth(view({ throughput: 4, firstPassYield: 0.6, depth: 3 }));
+    expect(a.health).toBe("watch");
+    expect(a.reasons.join(" ")).toContain("first-pass yield 60%");
+  });
+  it("is at-risk when two soft signals combine", () => {
+    const a = assessQueueHealth(
+      view({ throughput: 4, firstPassYield: 0.6, slaAttainment: 0.5, depth: 3 }),
+    );
+    expect(a.health).toBe("at-risk");
+    expect(a.reasons.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("readQueueSnapshots", () => {
+  it("queries the current-day period and maps rows to views", async () => {
+    const findMany = vi.fn(async (_args: { where?: Record<string, unknown> }) => [
+      { queueKey: "cwq:q1", period: "2026-07-06", depth: 3, wip: 5, arrivals: 8, throughput: 6, firstPassYield: 0.9, computedAt: new Date("2026-07-06T12:00:00Z") },
+    ]);
+    const result = await readQueueSnapshots(
+      {},
+      { getFinder: async () => ({ findMany }), now: new Date("2026-07-06T15:00:00Z") },
+    );
+    expect(findMany).toHaveBeenCalledOnce();
+    expect(findMany.mock.calls[0]![0].where).toEqual({ period: "2026-07-06" });
+    expect(result[0]!.depth).toBe(3);
+    expect(result[0]!.firstPassYield).toBe(0.9);
+    expect(result[0]!.computedAt).toBe("2026-07-06T12:00:00.000Z");
+  });
+
+  it("returns [] on read failure (never throws)", async () => {
+    const result = await readQueueSnapshots(
+      {},
+      { getFinder: async () => ({ findMany: async () => { throw new Error("db down"); } }) },
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("filters by queueKey when supplied", async () => {
+    const findMany = vi.fn(async (_args: { where?: Record<string, unknown> }) => []);
+    await readQueueSnapshots(
+      { queueKey: "compute:sandbox-pool" },
+      { getFinder: async () => ({ findMany }), now: new Date("2026-07-06T00:00:00Z") },
+    );
+    expect(findMany.mock.calls[0]![0].where).toEqual({
+      period: "2026-07-06",
+      queueKey: "compute:sandbox-pool",
+    });
+  });
+});
+
+describe("readAtRiskQueues", () => {
+  it("returns only at-risk queues with their assessments", async () => {
+    const findMany = vi.fn(async () => [
+      { queueKey: "cwq:hot", period: "2026-07-06", depth: 15, throughput: 2, computedAt: new Date() },
+      { queueKey: "cwq:calm", period: "2026-07-06", depth: 1, throughput: 9, firstPassYield: 0.98, computedAt: new Date() },
+    ]);
+    const atRisk = await readAtRiskQueues({ getFinder: async () => ({ findMany }) });
+    expect(atRisk).toHaveLength(1);
+    expect(atRisk[0]!.snapshot.queueKey).toBe("cwq:hot");
+    expect(atRisk[0]!.assessment.health).toBe("at-risk");
+  });
+});

--- a/apps/web/lib/queue/queue-snapshot-service.ts
+++ b/apps/web/lib/queue/queue-snapshot-service.ts
@@ -1,0 +1,163 @@
+// apps/web/lib/queue/queue-snapshot-service.ts
+//
+// EP-3516E23D Phase 3 — the single read model over QueueMetricSnapshot that ALL
+// visibility surfaces share (the coworker MCP pack, the portal-context
+// awareness resolver, and the human report-kit tiles). One reader ⇒ the human
+// tile and the coworker tool can never quote different numbers for the same
+// queue. Spec §4.5.
+
+import { queueMetricPeriod } from "./flow-metrics";
+
+/** One queue's most-recent rolled-up flow metrics (a QueueMetricSnapshot row). */
+export interface QueueSnapshotView {
+  queueKey: string;
+  period: string;
+  depth: number;
+  wip: number;
+  arrivals: number;
+  throughput: number;
+  waitP50Ms: number | null;
+  waitP95Ms: number | null;
+  processP50Ms: number | null;
+  processP95Ms: number | null;
+  cycleP50Ms: number | null;
+  cycleP95Ms: number | null;
+  firstPassYield: number | null;
+  slaAttainment: number | null;
+  abandonmentRate: number | null;
+  computedAt: string;
+}
+
+/**
+ * Health classification for a queue, derived purely from its snapshot. Pure so
+ * tiles (intent color), the resolver (attention severity), and the coworker
+ * tool all agree on when a queue is "at risk". Thresholds are deliberately
+ * conservative defaults; a queue with no throughput yet is "idle", not "at risk".
+ */
+export type QueueHealth = "healthy" | "watch" | "at-risk" | "idle";
+
+export interface QueueHealthAssessment {
+  health: QueueHealth;
+  reasons: string[];
+}
+
+const DEEP_BACKLOG_DEPTH = 10; // items waiting
+const LOW_FIRST_PASS_YIELD = 0.7; // 70% — below this, rework is eating capacity
+const LOW_SLA_ATTAINMENT = 0.8; // 80% on-time
+const HIGH_ABANDONMENT = 0.2; // 20% balk/renege
+
+/** Assess a snapshot's health. Pure — no I/O. */
+export function assessQueueHealth(s: QueueSnapshotView): QueueHealthAssessment {
+  const reasons: string[] = [];
+  if (s.depth >= DEEP_BACKLOG_DEPTH) reasons.push(`${s.depth} items waiting`);
+  if (s.firstPassYield != null && s.firstPassYield < LOW_FIRST_PASS_YIELD) {
+    reasons.push(`first-pass yield ${Math.round(s.firstPassYield * 100)}%`);
+  }
+  if (s.slaAttainment != null && s.slaAttainment < LOW_SLA_ATTAINMENT) {
+    reasons.push(`SLA attainment ${Math.round(s.slaAttainment * 100)}%`);
+  }
+  if (s.abandonmentRate != null && s.abandonmentRate > HIGH_ABANDONMENT) {
+    reasons.push(`abandonment ${Math.round(s.abandonmentRate * 100)}%`);
+  }
+
+  // Idle: nothing waiting and nothing flowing — not a problem, just quiet.
+  if (reasons.length === 0 && s.depth === 0 && s.throughput === 0 && s.arrivals === 0) {
+    return { health: "idle", reasons };
+  }
+  if (reasons.length === 0) return { health: "healthy", reasons };
+  // A deep backlog OR two-plus concurrent problems ⇒ at-risk; a single softer
+  // signal ⇒ watch.
+  const atRisk = s.depth >= DEEP_BACKLOG_DEPTH || reasons.length >= 2;
+  return { health: atRisk ? "at-risk" : "watch", reasons };
+}
+
+/** Structural contract for the Prisma delegate the reader touches. */
+export interface QueueSnapshotFinder {
+  findMany: (args: {
+    where?: Record<string, unknown>;
+    orderBy?: unknown;
+    take?: number;
+  }) => Promise<Array<Record<string, unknown>>>;
+}
+
+export interface QueueSnapshotReadDeps {
+  getFinder?: () => Promise<QueueSnapshotFinder>;
+  now?: Date;
+}
+
+function toView(row: Record<string, unknown>): QueueSnapshotView {
+  const n = (k: string): number | null => {
+    const v = row[k];
+    return typeof v === "number" && Number.isFinite(v) ? v : null;
+  };
+  const i = (k: string): number => n(k) ?? 0;
+  const computedAt = row["computedAt"];
+  return {
+    queueKey: String(row["queueKey"] ?? ""),
+    period: String(row["period"] ?? ""),
+    depth: i("depth"),
+    wip: i("wip"),
+    arrivals: i("arrivals"),
+    throughput: i("throughput"),
+    waitP50Ms: n("waitP50Ms"),
+    waitP95Ms: n("waitP95Ms"),
+    processP50Ms: n("processP50Ms"),
+    processP95Ms: n("processP95Ms"),
+    cycleP50Ms: n("cycleP50Ms"),
+    cycleP95Ms: n("cycleP95Ms"),
+    firstPassYield: n("firstPassYield"),
+    slaAttainment: n("slaAttainment"),
+    abandonmentRate: n("abandonmentRate"),
+    computedAt:
+      computedAt instanceof Date
+        ? computedAt.toISOString()
+        : String(computedAt ?? ""),
+  };
+}
+
+async function defaultGetFinder(): Promise<QueueSnapshotFinder> {
+  const { prisma } = await import("@dpf/db");
+  return prisma.queueMetricSnapshot as unknown as QueueSnapshotFinder;
+}
+
+/**
+ * Read the current-day snapshots for all queues (or a single queueKey), newest
+ * period first. Returns [] on any read failure — visibility is best-effort and
+ * must never throw into a coworker turn or a page render.
+ */
+export async function readQueueSnapshots(
+  opts: { queueKey?: string; limit?: number } = {},
+  deps?: QueueSnapshotReadDeps,
+): Promise<QueueSnapshotView[]> {
+  try {
+    const now = deps?.now ?? new Date();
+    const period = queueMetricPeriod(now);
+    const getFinder = deps?.getFinder ?? defaultGetFinder;
+    const finder = await getFinder();
+    const where: Record<string, unknown> = { period };
+    if (opts.queueKey) where["queueKey"] = opts.queueKey;
+    const rows = await finder.findMany({
+      where,
+      orderBy: [{ depth: "desc" }],
+      take: Math.min(Math.max(opts.limit ?? 50, 1), 200),
+    });
+    return rows.map(toView);
+  } catch (err) {
+    console.warn(
+      `[queue-snapshot-service] read failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return [];
+  }
+}
+
+/** Snapshots whose health is at-risk (for attention signals / alerts). */
+export async function readAtRiskQueues(
+  deps?: QueueSnapshotReadDeps,
+): Promise<Array<{ snapshot: QueueSnapshotView; assessment: QueueHealthAssessment }>> {
+  const snapshots = await readQueueSnapshots({}, deps);
+  return snapshots
+    .map((snapshot) => ({ snapshot, assessment: assessQueueHealth(snapshot) }))
+    .filter((x) => x.assessment.health === "at-risk");
+}

--- a/apps/web/lib/queue/queue-tile-model.test.ts
+++ b/apps/web/lib/queue/queue-tile-model.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { queueTileModel, humanizeQueueKey } from "./queue-tile-model";
+import type { QueueSnapshotView } from "./queue-snapshot-service";
+
+function snap(over: Partial<QueueSnapshotView> = {}): QueueSnapshotView {
+  return {
+    queueKey: "cwq:triage-default",
+    period: "2026-07-06",
+    depth: 0,
+    wip: 0,
+    arrivals: 0,
+    throughput: 0,
+    waitP50Ms: null,
+    waitP95Ms: null,
+    processP50Ms: null,
+    processP95Ms: null,
+    cycleP50Ms: null,
+    cycleP95Ms: null,
+    firstPassYield: null,
+    slaAttainment: null,
+    abandonmentRate: null,
+    computedAt: "2026-07-06T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("humanizeQueueKey", () => {
+  it("strips the cwq prefix", () => {
+    expect(humanizeQueueKey("cwq:triage-default")).toBe("triage-default");
+  });
+  it("annotates compute lanes", () => {
+    expect(humanizeQueueKey("compute:sandbox-pool")).toBe("sandbox-pool (compute)");
+  });
+});
+
+describe("queueTileModel", () => {
+  it("maps a healthy flowing queue to a success tile with an up delta", () => {
+    const m = queueTileModel(snap({ depth: 2, throughput: 8, arrivals: 6, firstPassYield: 0.95, cycleP50Ms: 120000, waitP95Ms: 30000 }));
+    expect(m.intent).toBe("success");
+    expect(m.value).toBe("2 waiting");
+    expect(m.hint).toContain("p95 wait 30s");
+    expect(m.hint).toContain("FPY 95%");
+    expect(m.delta).toEqual({ label: "8/6 done/in", direction: "up" });
+  });
+
+  it("maps a deep backlog to a danger tile", () => {
+    const m = queueTileModel(snap({ depth: 25, throughput: 2, arrivals: 20 }));
+    expect(m.intent).toBe("danger");
+    expect(m.health).toBe("at-risk");
+    expect(m.delta!.direction).toBe("down");
+  });
+
+  it("maps an idle queue to a neutral tile with no delta", () => {
+    const m = queueTileModel(snap());
+    expect(m.intent).toBe("neutral");
+    expect(m.health).toBe("idle");
+    expect(m.delta).toBeNull();
+  });
+});

--- a/apps/web/lib/queue/queue-tile-model.ts
+++ b/apps/web/lib/queue/queue-tile-model.ts
@@ -1,0 +1,70 @@
+// apps/web/lib/queue/queue-tile-model.ts
+//
+// EP-3516E23D Phase 3 — pure mapping from a queue snapshot to the props a
+// report-kit StatCard needs. Kept separate from the React component so the
+// human-tile logic (label, headline value, hint line, intent color, throughput
+// delta) is unit-tested without rendering. Same numbers the coworker MCP tool
+// quotes — both read QueueSnapshotView. Spec §4.5.
+
+import type { QueueSnapshotView } from "./queue-snapshot-service";
+import { assessQueueHealth, type QueueHealth } from "./queue-snapshot-service";
+
+export type QueueTileIntent = "success" | "warning" | "danger" | "info" | "neutral";
+
+export interface QueueTileModel {
+  label: string;
+  value: string;
+  hint: string;
+  intent: QueueTileIntent;
+  delta: { label: string; direction: "up" | "down" | "flat" } | null;
+  health: QueueHealth;
+}
+
+const HEALTH_INTENT: Record<QueueHealth, QueueTileIntent> = {
+  healthy: "success",
+  watch: "warning",
+  "at-risk": "danger",
+  idle: "neutral",
+};
+
+/** Human-readable queue label from a queueKey ("cwq:triage-default" → "triage-default"). */
+export function humanizeQueueKey(queueKey: string): string {
+  const [prefix, ...rest] = queueKey.split(":");
+  const name = rest.join(":") || prefix || queueKey;
+  if (prefix === "compute") return `${name} (compute)`;
+  return name;
+}
+
+function ms(v: number | null): string {
+  if (v == null) return "—";
+  if (v < 1000) return `${v}ms`;
+  const s = v / 1000;
+  if (s < 90) return `${s.toFixed(s < 10 ? 1 : 0)}s`;
+  const m = s / 60;
+  if (m < 90) return `${m.toFixed(0)}m`;
+  return `${(m / 60).toFixed(1)}h`;
+}
+
+function pct(v: number | null): string {
+  return v == null ? "—" : `${Math.round(v * 100)}%`;
+}
+
+/** Map a snapshot to StatCard-ready tile props. Pure. */
+export function queueTileModel(s: QueueSnapshotView): QueueTileModel {
+  const { health } = assessQueueHealth(s);
+  const hintParts = [`p95 wait ${ms(s.waitP95Ms)}`, `cycle ${ms(s.cycleP50Ms)}`];
+  if (s.firstPassYield != null) hintParts.push(`FPY ${pct(s.firstPassYield)}`);
+  if (s.slaAttainment != null) hintParts.push(`SLA ${pct(s.slaAttainment)}`);
+
+  return {
+    label: humanizeQueueKey(s.queueKey),
+    value: `${s.depth} waiting`,
+    hint: hintParts.join(" · "),
+    intent: HEALTH_INTENT[health],
+    delta:
+      s.throughput > 0 || s.arrivals > 0
+        ? { label: `${s.throughput}/${s.arrivals} done/in`, direction: s.throughput >= s.arrivals ? "up" : "down" }
+        : null,
+    health,
+  };
+}

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -186,6 +186,11 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   update_work_capsule_status: ["work_capsule_write"],
   release_capsule_scope: ["work_capsule_write"],
   get_runtime_coordination_map: ["work_capsule_read"],
+  // Queue-awareness reads (EP-3516E23D): platform-coordination visibility over
+  // the shared queue flow-telemetry — same read grant as the sibling ops-read
+  // tool above.
+  get_queue_status: ["work_capsule_read"],
+  list_at_risk_queues: ["work_capsule_read"],
   register_runtime_target: ["work_capsule_write"],
   heartbeat_runtime_target: ["work_capsule_write"],
   release_runtime_target: ["work_capsule_write"],

--- a/docs/superpowers/plans/2026-07-06-queue-awareness-visibility-plan.md
+++ b/docs/superpowers/plans/2026-07-06-queue-awareness-visibility-plan.md
@@ -1,0 +1,57 @@
+# EP-3516E23D Phase 3 — Queue visibility for coworker + human (BI-FD56CC6A)
+
+**Spec:** [docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md](../specs/2026-07-06-reusable-queueing-substrate-design.md) §4.5
+**BI:** BI-FD56CC6A (EP-3516E23D). Depends on Phase 1 (flow-telemetry spine, shipped #2652).
+**Goal:** Make both the AI coworker and the human *informed* about queue state and
+flow metrics — the operator's explicit ask — reading the QueueMetricSnapshot rows
+Phase 1 produces, so both audiences quote the same numbers.
+
+## Architecture
+
+One shared read model (`queue-snapshot-service.ts`) with a pure health assessment;
+every surface reads through it:
+- **Coworker, pull** — a read-only MCP pack (`get_queue_status`, `list_at_risk_queues`).
+- **Coworker, push** — a portal-context resolver that injects at-risk queues as
+  `queue_backpressure` attention signals, plus a `queue-health` proactivity family
+  that nudges assertively when a queue is backing up.
+- **Human** — a `QueueHealthSection` server component of report-kit `StatCard`
+  tiles, mounted on `/platform/ai/runtime-health`.
+
+## Tasks (all complete in this PR)
+
+1. **`lib/queue/queue-snapshot-service.ts`** — shared reader: `readQueueSnapshots`,
+   `readAtRiskQueues`, pure `assessQueueHealth` (idle / healthy / watch / at-risk from
+   depth, first-pass yield, SLA attainment, abandonment). Best-effort (returns [] on
+   failure). 9 unit tests.
+2. **`lib/mcp/packs/queue-awareness-pack.ts`** — read-only pack registered in
+   `composeToolPacks`; grants mirrored in `agent-grants.ts` (`work_capsule_read`, the
+   sibling ops-read grant). Provenance-free descriptions. 4 unit tests.
+3. **`lib/portal-context/queue-awareness-resolver.ts`** + wiring — at-risk queues →
+   `queue_backpressure` AttentionSignal (new kind), injected via `resolveSource`;
+   injectable through `ResolverDeps.getQueueAttention` for hermetic envelope tests.
+   4 unit tests.
+4. **`lib/proactivity/`** — added `queue-health` activity family + a resolver branch
+   (assertive on blocked/degraded queue signal).
+5. **`lib/queue/queue-tile-model.ts`** + **`components/queue/QueueHealthSection.tsx`** —
+   pure snapshot→StatCard-props mapper (3 unit tests) and the server component,
+   mounted on the runtime-health page. `var(--dpf-*)` tokens only.
+
+## Verification
+
+- 22 new unit tests green; existing tool-registry parity, hygiene, agent-grants,
+  proactivity, and portal-context suites green (envelope test made hermetic).
+- `tsc --noEmit` clean across apps/web.
+- Functional (post-merge, live): a coworker answers "how is queue X doing?" via
+  `get_queue_status` with the same numbers the runtime-health tile shows; an at-risk
+  queue surfaces a `queue_backpressure` attention item.
+
+## Not in this phase
+
+Field-service dispatch queue + booking→WorkItem bridge (Phase 4, BI-10E350A6);
+CWQ bridge activation so real work items feed these queues (BI-C585535E) — until
+then the surfaces render the sandbox-pool + any CWQ activity Phase 1 already emits.
+
+UX-Fit-Decision: adds one always-visible read-only metric section to an existing
+platform-admin page (no new route, no new nav entry, no user input). It consolidates
+queue state operators otherwise cannot see at all; the tiles reuse the shared
+report-kit StatCard family. Net surface is one section that removes a blind spot.

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -1,5 +1,5 @@
 {
-  "apps/web/app/api/mcp/v1/route.test.ts": 1241,
+  "apps/web/app/api/mcp/v1/route.test.ts": 1260,
   "apps/web/app/api/v1/edge/discovery-runs/route.test.ts": 982,
   "apps/web/components/admin/BusinessModelBuilder.tsx": 810,
   "apps/web/components/admin/McpTokenManager.tsx": 1373,
@@ -41,7 +41,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16500,
+  "apps/web/lib/mcp-tools.ts": 16517,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1289,

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -1,5 +1,5 @@
 {
-  "apps/web/app/api/mcp/v1/route.test.ts": 1260,
+  "apps/web/app/api/mcp/v1/route.test.ts": 1241,
   "apps/web/app/api/v1/edge/discovery-runs/route.test.ts": 982,
   "apps/web/components/admin/BusinessModelBuilder.tsx": 810,
   "apps/web/components/admin/McpTokenManager.tsx": 1373,
@@ -41,7 +41,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16516,
+  "apps/web/lib/mcp-tools.ts": 16500,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1289,


### PR DESCRIPTION
## Summary

**EP-3516E23D Phase 3 (BI-FD56CC6A)** — the visibility half of the reusable queueing substrate. Makes both the **AI coworker** and the **human** informed about queue state and flow metrics (the operator's explicit ask), reading the `QueueMetricSnapshot` rows the Phase-1 spine (#2652) produces — so both audiences quote the *same* numbers.

## What's in it

One shared read model (`queue-snapshot-service.ts`, with a pure `assessQueueHealth`); every surface reads through it:

- **Coworker (pull)** — read-only MCP pack `queue-awareness-pack.ts`: `get_queue_status` + `list_at_risk_queues`, registered in `composeToolPacks`; grants mirrored in `agent-grants.ts` (`work_capsule_read`, the sibling ops-read grant). Descriptions are provenance-free.
- **Coworker (push)** — `queue-awareness-resolver.ts` injects at-risk queues as a new `queue_backpressure` AttentionSignal into portal context; a new `queue-health` proactivity family nudges assertively when a queue backs up.
- **Human** — `queue-tile-model.ts` (pure snapshot→StatCard mapper) + `QueueHealthSection.tsx` server component, mounted on `/platform/ai/runtime-health`. `var(--dpf-*)` tokens only.

## Verification

- 22 new unit tests; **483 green** across all touched suites (queue, MCP tool-registry parity, tool-description hygiene, agent-grants, portal-context, proactivity); `tsc --noEmit` clean; MCP tool-pack guard OK. Envelope test made hermetic (injectable queue resolver).

## Not in this phase

Field-service dispatch queue (Phase 4, BI-10E350A6) and CWQ bridge activation so real work items feed these queues (BI-C585535E). Until then the surfaces render the sandbox-pool lane + any CWQ activity Phase 1 already emits.

Plan: `docs/superpowers/plans/2026-07-06-queue-awareness-visibility-plan.md`
Spec: `docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: The local-CI sandbox gate could not run — the portal was quiescing for a self-upgrade and refused the lease claim (portal_quiescing), so the gate infra was unavailable, not failing. Verified clean locally instead: tsc --noEmit clean across apps/web; 483 unit tests green across every touched suite; MCP tool-pack guard, tool-description hygiene, and tool-registry parity all pass. GitHub CI runs the authoritative full suite on this PR.
