### PR TITLE
feat(decision-gov): decision-ledger caller attribution — match every consult back to its client and thread (BI-0EEBA669)

### DIFF
--- a/apps/web/app/(shell)/wiki/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/wiki/decisions/[interactionId]/page.tsx
@@ -72,6 +72,18 @@ export default async function DecisionRecordPage({ params }: { params: Params })
     : [];
   const recommendedOptionId =
     typeof payload.recommendedOptionId === "string" ? payload.recommendedOptionId : null;
+  // Caller attribution — who brought this decision (client UA token /
+  // coworker agent / thread), so the row matches back to the activity.
+  const caller = asRecord(payload.caller);
+  const callerParts = [
+    typeof caller.client === "string" && caller.client ? caller.client : null,
+    typeof caller.agentId === "string" && caller.agentId ? `agent ${caller.agentId}` : null,
+    typeof caller.threadId === "string" && caller.threadId ? `thread ${caller.threadId}` : null,
+    typeof caller.apiTokenId === "string" && caller.apiTokenId ? `token ${caller.apiTokenId}` : null,
+    typeof payload.callingSurface === "string" && payload.callingSurface
+      ? `surface ${payload.callingSurface}`
+      : null,
+  ].filter((p): p is string => p !== null);
 
   return (
     <div className="max-w-3xl mx-auto py-6 px-4">
@@ -98,6 +110,11 @@ export default async function DecisionRecordPage({ params }: { params: Params })
           <LocalTime value={row.createdAt} /> · {row.profile?.name ?? row.profileId} ·{" "}
           {row.routeContext ?? "—"} · {row.domainClass} · {row.interactionId}
         </p>
+        {callerParts.length > 0 ? (
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            Caller: {callerParts.join(" · ")}
+          </p>
+        ) : null}
       </header>
 
       {/* Options weighed */}

--- a/apps/web/app/(shell)/wiki/decisions/page.tsx
+++ b/apps/web/app/(shell)/wiki/decisions/page.tsx
@@ -12,6 +12,7 @@ import { LocalTime } from "@/components/ui/LocalTime";
 import { DecisionAuditTable } from "@/components/wiki/DecisionAuditTable";
 import {
   DECISION_AUDIT_TIERS,
+  buildCallerStats,
   buildTierStats,
   profileKindsForTier,
   toAuditRow,
@@ -107,6 +108,7 @@ export default async function DecisionLogPage({
   ]);
 
   const auditRows = rows.map(toAuditRow);
+  const callerStats = buildCallerStats(auditRows);
 
   const tierFilters: Array<{ label: string; tier: DecisionAuditTier | null }> = [
     { label: "All tiers", tier: null },
@@ -155,6 +157,31 @@ export default async function DecisionLogPage({
           />
         ))}
       </div>
+
+      {/* Who consults — a client working outside this list never consulted
+          the kernel at all, which is itself the finding. */}
+      {callerStats.length > 0 ? (
+        <div className="mb-6 rounded-lg border border-[var(--dpf-border)] p-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
+            Consults by caller{activeTier ? ` — ${activeTier.toUpperCase()}` : ""}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {callerStats.map((c) => (
+              <span
+                key={c.label}
+                className="inline-flex items-center gap-1.5 rounded-full border border-[var(--dpf-border)] px-2.5 py-1 text-xs"
+              >
+                <span className="font-medium text-[var(--dpf-text)]">{c.label}</span>
+                <span className="text-[var(--dpf-muted)]">×{c.total}</span>
+              </span>
+            ))}
+          </div>
+          <p className="mt-2 text-[11px] text-[var(--dpf-muted)]">
+            A client or agent that never appears here has never consulted the
+            decision kernel.
+          </p>
+        </div>
+      ) : null}
 
       {/* Tier filter */}
       <div className="flex items-center gap-2 mb-4">

--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -44,6 +44,7 @@ import {
 } from "@/lib/tak/autonomous-work-run";
 import { createTaskMessage } from "@/lib/tak/task-records";
 import { GET, POST } from "./route";
+import { deriveCallerClient } from "@/lib/mcp/caller-client";
 
 const resolveMock = resolveMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const verifySessionMock = verifyMcpSessionToken as unknown as ReturnType<typeof vi.fn>;
@@ -1236,5 +1237,23 @@ describe("POST — tasks/submit", () => {
       data: expect.objectContaining({ status: "input-required" }),
     }));
     expect(executeLoopMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("deriveCallerClient (decision-ledger caller attribution)", () => {
+  it("takes the first product token and strips platform detail", () => {
+    expect(deriveCallerClient("claude-code/2.1 (darwin; arm64)")).toBe("claude-code/2.1");
+    expect(deriveCallerClient("codex-cli/0.9.4")).toBe("codex-cli/0.9.4");
+  });
+
+  it("sanitizes hostile characters and caps the length", () => {
+    expect(deriveCallerClient("<script>alert(1)</script>/1.0 x")).toBe("scriptalert1/script/1.0");
+    expect(deriveCallerClient("a".repeat(200))).toHaveLength(64);
+  });
+
+  it("returns undefined for missing or empty user agents", () => {
+    expect(deriveCallerClient(null)).toBeUndefined();
+    expect(deriveCallerClient("   ")).toBeUndefined();
+    expect(deriveCallerClient("!!!")).toBeUndefined();
   });
 });

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -19,6 +19,7 @@ import {
   type McpTokenScope,
   type ResolvedMcpToken,
 } from "@/lib/auth/mcp-api-token";
+import { deriveCallerClient } from "@/lib/mcp/caller-client";
 import { verifyMcpSessionToken } from "@/lib/mcp/session-token";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { PLATFORM_TOOLS, resolveAnnotations, type ToolDefinition } from "@/lib/mcp-tools";
@@ -362,6 +363,7 @@ async function handleToolsCall(
   id: JsonRpcId,
   token: ResolvedAuth,
   params: Record<string, unknown> | undefined,
+  callerClient?: string,
 ): Promise<Response> {
   if (!params || typeof params["name"] !== "string") {
     return jsonRpcError(id, JSONRPC_INVALID_PARAMS, "tools/call requires params.name (string)");
@@ -421,6 +423,8 @@ async function handleToolsCall(
       apiTokenId: token.tokenId,
       threadId: token.threadId ?? undefined,
       routeContext: token.routeContext ?? undefined,
+      callerClient,
+      authSource: token.source,
     },
     source: token.source === "session-jwt" ? "internal-mcp-session" : "external-jsonrpc",
   });
@@ -578,7 +582,12 @@ export async function POST(request: Request): Promise<Response> {
         if (isNotification) {
           return new Response(null, { status: 202 });
         }
-        return await handleToolsCall(body.id ?? null, token, body.params);
+        return await handleToolsCall(
+          body.id ?? null,
+          token,
+          body.params,
+          deriveCallerClient(request.headers.get("user-agent")),
+        );
 
       case "tasks/submit":
         if (isNotification) {

--- a/apps/web/components/wiki/DecisionAuditTable.tsx
+++ b/apps/web/components/wiki/DecisionAuditTable.tsx
@@ -76,6 +76,22 @@ const columns: Column<DecisionAuditRow>[] = [
     sortAccessor: (r) => (r.principleConflict ? 1 : 0),
   },
   {
+    key: "caller",
+    header: "Caller",
+    cell: (r) => (
+      <span
+        className="block max-w-[11rem] truncate"
+        title={r.callerThreadId ? `${r.callerLabel} · thread ${r.callerThreadId}` : r.callerLabel}
+      >
+        {r.callerLabel}
+        {r.callerThreadId ? (
+          <span className="text-[var(--dpf-muted)]"> · {r.callerThreadId.slice(0, 8)}</span>
+        ) : null}
+      </span>
+    ),
+    sortAccessor: (r) => r.callerLabel,
+  },
+  {
     key: "where",
     header: "Where",
     cell: (r) => (

--- a/apps/web/lib/decision-perspective/org-business-gate.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.ts
@@ -125,6 +125,18 @@ export async function evaluateOrgBusinessDecisionGate(input: {
   fallbackProfileId?: string;
   triggeredByUserId?: string | null;
   taskRunId?: string | null;
+  /**
+   * Caller attribution (BI-0EEBA669): the client/agent/thread that brought
+   * this decision, persisted in outcomePayload.caller so the audit surface
+   * can match the decision back to the activity.
+   */
+  caller?: {
+    client?: string | null;
+    apiTokenId?: string | null;
+    authSource?: string | null;
+    agentId?: string | null;
+    threadId?: string | null;
+  } | null;
   evaluator?: GateEvaluator;
   /** Injectable for tests; defaults to the real (already-tested) org resolver. */
   resolver?: typeof resolveProfileMaterialForOrg;
@@ -180,7 +192,7 @@ export async function evaluateOrgBusinessDecisionGate(input: {
       routeContext: input.routeContext,
       phaseFrom: input.phaseFrom ?? null,
       phaseTo: input.phaseTo ?? null,
-      outcomePayloadExtra: { orgProfileSelected },
+      outcomePayloadExtra: { orgProfileSelected, caller: input.caller ?? null },
     });
     traceWwwd("wwwd.ledger.written", { interactionId, outcomeType: evaluation.outcomeType });
     return {

--- a/apps/web/lib/decision/kernel-consult-ledger.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.ts
@@ -84,6 +84,20 @@ export async function recordKernelConsultInteraction(input: {
   routeContext?: string | null;
   taskRunId?: string | null;
   triggeredByUserId?: string | null;
+  /**
+   * Caller attribution (BI-0EEBA669): who consulted the kernel — the client
+   * product token (from the MCP route's User-Agent derivation), the resolved
+   * auth identity, and the coworker agent/thread when in-portal. Persisted in
+   * outcomePayload.caller so the audit surface can match a decision back to
+   * the activity that produced it.
+   */
+  caller?: {
+    client?: string | null;
+    apiTokenId?: string | null;
+    authSource?: string | null;
+    agentId?: string | null;
+    threadId?: string | null;
+  } | null;
 }): Promise<KernelConsultLedgerOutcome> {
   try {
     const profileId = input.callerContext.governingProfileId;
@@ -161,6 +175,7 @@ export async function recordKernelConsultInteraction(input: {
         tool: "principle_decide",
         callingPopulation: input.callerContext.callingPopulation,
         callingSurface: input.callingSurface ?? null,
+        caller: input.caller ?? null,
         recommendedOptionId: input.result.recommendation?.optionId ?? null,
         composite: input.result.recommendation?.composite ?? null,
         margin: input.result.recommendation?.margin ?? null,

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -34,6 +34,12 @@ export type GovernedExecuteContext = {
   routeContext?: string;
   taskRunId?: string;
   apiTokenId?: string;
+  /** Client product token from the caller's User-Agent (BI-0EEBA669);
+   *  persisted by decision-ledger writers so a decision can be matched back
+   *  to the client/session that consulted the kernel. */
+  callerClient?: string;
+  /** How the caller authenticated ("pat" | "session-jwt"), from the MCP route. */
+  authSource?: string;
   /**
    * Build the user is currently messaging from. Plumbed by runAgenticLoop
    * (via its `featureBuildId` param) so phase-scoped tools like

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -100,6 +100,16 @@ type ToolExecutionContext = {
   agentId?: string;
   threadId?: string;
   taskRunId?: string;
+  /**
+   * Caller attribution for the decision ledger (BI-0EEBA669). The MCP route
+   * derives `callerClient` from the request User-Agent product token (e.g.
+   * "claude-code/2.1", "codex-cli/0.9") and sets `authSource`/`apiTokenId`
+   * from the resolved auth. In-portal callers leave these unset — the ledger
+   * falls back to agentId/threadId, which the coworker loop already plumbs.
+   */
+  callerClient?: string;
+  apiTokenId?: string;
+  authSource?: string;
   suppressDesignReviewAutoRepair?: boolean; suppressPlanReviewAutoRepair?: boolean;
   /**
    * Build the user is currently messaging from. Plumbed by agentic-loop.ts
@@ -13318,6 +13328,13 @@ export async function executeTool(
         callingSurface,
         routeContext: context?.routeContext ?? null,
         taskRunId: context?.taskRunId ?? null,
+        caller: {
+          client: context?.callerClient ?? null,
+          apiTokenId: context?.apiTokenId ?? null,
+          authSource: context?.authSource ?? null,
+          agentId: context?.agentId ?? null,
+          threadId: context?.threadId ?? null,
+        },
       });
 
       return {

--- a/apps/web/lib/mcp/caller-client.ts
+++ b/apps/web/lib/mcp/caller-client.ts
@@ -1,0 +1,19 @@
+// Caller-client derivation for decision-ledger attribution (BI-0EEBA669).
+// Lives outside the route module because Next.js app-router route files may
+// only export HTTP handlers/segment config.
+
+/**
+ * Derive a stable client identifier from a request User-Agent product token:
+ * "claude-code/2.1 (darwin)" → "claude-code/2.1". Decision-ledger writers
+ * persist it so a consult can be matched back to the client that made it —
+ * and a client that never appears visibly never consulted. Sanitized to a
+ * conservative charset and capped so a hostile UA cannot smuggle markup or
+ * bloat into the audit payload.
+ */
+export function deriveCallerClient(userAgent: string | null): string | undefined {
+  if (!userAgent) return undefined;
+  const first = userAgent.trim().split(/\s+/)[0] ?? "";
+  const cleaned = first.replace(/[^A-Za-z0-9._/@+-]/g, "");
+  if (!cleaned) return undefined;
+  return cleaned.slice(0, 64);
+}

--- a/apps/web/lib/mcp/packs/org-decision-pack.ts
+++ b/apps/web/lib/mcp/packs/org-decision-pack.ts
@@ -67,9 +67,30 @@ const definitions: ToolDefinition[] = [
   },
 ];
 
+type PackCallerContext = {
+  routeContext?: string;
+  threadId?: string;
+  agentId?: string;
+  callerClient?: string;
+  apiTokenId?: string;
+  authSource?: string;
+};
+
+/** Shape the dispatch context into the ledger's caller-attribution block. */
+function callerFromContext(context: PackCallerContext | undefined) {
+  return {
+    client: context?.callerClient ?? null,
+    apiTokenId: context?.apiTokenId ?? null,
+    authSource: context?.authSource ?? null,
+    agentId: context?.agentId ?? null,
+    threadId: context?.threadId ?? null,
+  };
+}
+
 async function evaluateOrgBusinessDecision(
   params: Record<string, unknown>,
   userId: string,
+  context?: PackCallerContext,
 ): Promise<ToolResult> {
   const { evaluateOrgBusinessDecisionGate } = await import("@/lib/decision-perspective/org-business-gate");
   const { DECISION_DOMAIN_CLASSES, DECISION_RISK_TIERS } = await import("@/lib/decision-perspective/types");
@@ -102,8 +123,9 @@ async function evaluateOrgBusinessDecision(
     options,
     domainClass: domainClass as Parameters<typeof evaluateOrgBusinessDecisionGate>[0]["domainClass"],
     riskTier: riskTier as Parameters<typeof evaluateOrgBusinessDecisionGate>[0]["riskTier"],
-    routeContext: "/coworker-business",
+    routeContext: context?.routeContext ?? "/coworker-business",
     triggeredByUserId: userId,
+    caller: callerFromContext(context),
   });
 
   const rationale = decision.evaluation.rationale;
@@ -191,7 +213,8 @@ export const orgDecisionPack: ToolPack = {
   packId: "org-decision",
   definitions,
   handlers: {
-    evaluate_org_business_decision: (params, userId) => evaluateOrgBusinessDecision(params, userId),
+    evaluate_org_business_decision: (params, userId, context) =>
+      evaluateOrgBusinessDecision(params, userId, context),
     record_org_business_answer: (params, userId, context) =>
       recordOrgBusinessAnswer(params, userId, context?.agentId ?? null),
   },

--- a/apps/web/lib/mcp/tool-pack.ts
+++ b/apps/web/lib/mcp/tool-pack.ts
@@ -23,7 +23,16 @@ import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 export type ToolPackHandler = (
   params: Record<string, unknown>,
   userId: string,
-  context?: { routeContext?: string; threadId?: string; agentId?: string },
+  context?: {
+    routeContext?: string;
+    threadId?: string;
+    agentId?: string;
+    /** Caller attribution from the MCP route (client UA token + auth identity)
+     *  for decision-ledger writers. */
+    callerClient?: string;
+    apiTokenId?: string;
+    authSource?: string;
+  },
 ) => Promise<ToolResult>;
 
 export type ToolPack = {

--- a/apps/web/lib/wiki/decision-audit.test.ts
+++ b/apps/web/lib/wiki/decision-audit.test.ts
@@ -6,6 +6,7 @@ import {
   tierForProfileKind,
   toAuditRow,
   type DecisionAuditRowInput,
+  buildCallerStats,
 } from "./decision-audit";
 
 function makeRow(overrides: Partial<DecisionAuditRowInput> = {}): DecisionAuditRowInput {
@@ -117,5 +118,76 @@ describe("buildTierStats", () => {
       lastDecisionAt: new Date("2026-07-01T00:00:00Z"),
     });
     expect(stats.lastDecisionAt).toBe("2026-07-01T00:00:00.000Z");
+  });
+});
+
+describe("caller attribution (BI-0EEBA669)", () => {
+  const baseRow = {
+    interactionId: "DI-1",
+    createdAt: new Date("2026-07-06T08:00:00Z"),
+    question: "Q",
+    options: ["a", "b"],
+    outcomeType: "recommend",
+    riskTier: "low",
+    principleConflict: false,
+    domainClass: "kernel-consult",
+    routeContext: "/build",
+    rationale: null,
+    confidenceAfter: 0.9,
+    humanOutcome: null,
+    profile: { kind: "platform", name: "Mark / DPF Platform" },
+    escalationCapture: null,
+    deferralCapture: null,
+  };
+
+  it("prefers the persisted caller client over everything else", () => {
+    const row = toAuditRow({
+      ...baseRow,
+      outcomePayload: {
+        callingSurface: "claude-code/session-x",
+        caller: { client: "codex-cli/0.9", agentId: "customer-advisor", threadId: "th_123456789" },
+      },
+    });
+    expect(row.callerLabel).toBe("codex-cli/0.9");
+    expect(row.callerThreadId).toBe("th_123456789");
+  });
+
+  it("falls back to the coworker agent, then callingSurface, then unattributed", () => {
+    const agentRow = toAuditRow({
+      ...baseRow,
+      outcomePayload: { caller: { agentId: "customer-advisor" } },
+    });
+    expect(agentRow.callerLabel).toBe("coworker:customer-advisor");
+
+    const surfaceRow = toAuditRow({
+      ...baseRow,
+      outcomePayload: { callingSurface: "claude-code/wwwd-plan" },
+    });
+    expect(surfaceRow.callerLabel).toBe("claude-code/wwwd-plan");
+
+    const bareRow = toAuditRow({ ...baseRow, outcomePayload: {} });
+    expect(bareRow.callerLabel).toBe("—");
+    expect(bareRow.callerThreadId).toBeNull();
+  });
+
+  it("rolls timeline rows up by caller with volume ordering", () => {
+    const rows = [
+      { outcomePayload: { caller: { client: "claude-code/2.1" } } },
+      { outcomePayload: { caller: { client: "claude-code/2.1" } } },
+      { outcomePayload: { caller: { client: "grok-cli/1.0" } } },
+    ].map((extra, i) =>
+      toAuditRow({
+        ...baseRow,
+        interactionId: `DI-${i}`,
+        createdAt: new Date(Date.UTC(2026, 6, 6, 8, i)),
+        ...extra,
+      }),
+    );
+    const stats = buildCallerStats(rows);
+    expect(stats.map((s) => [s.label, s.total])).toEqual([
+      ["claude-code/2.1", 2],
+      ["grok-cli/1.0", 1],
+    ]);
+    expect(stats[0]!.lastAt).toBe("2026-07-06T08:01:00.000Z");
   });
 });

--- a/apps/web/lib/wiki/decision-audit.ts
+++ b/apps/web/lib/wiki/decision-audit.ts
@@ -78,6 +78,10 @@ export type DecisionAuditRow = {
   domainClass: string;
   routeContext: string;
   confidence: number | null;
+  /** Who consulted: client UA token, coworker agent, or calling surface. */
+  callerLabel: string;
+  /** Thread the consult belonged to, when the caller carried one. */
+  callerThreadId: string | null;
 };
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -88,12 +92,67 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 const UNRESOLVED_OUTCOMES = new Set(["defer", "escalate"]);
 
+function asNullableString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Derive the caller attribution for a ledger row. Precedence: the explicit
+ * caller block writers persist (client UA token, else the coworker agent),
+ * then the voluntary callingSurface string, then unattributed. Rows written
+ * before attribution existed resolve the same way — usually to callingSurface
+ * or "—".
+ */
+export function callerForRow(payload: Record<string, unknown>): {
+  label: string;
+  threadId: string | null;
+} {
+  const caller = asRecord(payload.caller);
+  const client = asNullableString(caller.client);
+  const agentId = asNullableString(caller.agentId);
+  const threadId = asNullableString(caller.threadId);
+  const callingSurface = asNullableString(payload.callingSurface);
+
+  const label = client ?? (agentId ? `coworker:${agentId}` : null) ?? callingSurface ?? "—";
+  return { label, threadId };
+}
+
+export type DecisionCallerStat = {
+  label: string;
+  total: number;
+  lastAt: string;
+};
+
+/**
+ * Roll the timeline rows up by caller so the page can show who is (and by
+ * absence, who is not) consulting the kernel. Unattributed rows group under
+ * "—". Sorted by volume.
+ */
+export function buildCallerStats(rows: DecisionAuditRow[]): DecisionCallerStat[] {
+  const byCaller = new Map<string, { total: number; lastAt: string }>();
+  for (const row of rows) {
+    const existing = byCaller.get(row.callerLabel);
+    if (existing) {
+      existing.total += 1;
+      if (row.createdAt > existing.lastAt) existing.lastAt = row.createdAt;
+    } else {
+      byCaller.set(row.callerLabel, { total: 1, lastAt: row.createdAt });
+    }
+  }
+  return [...byCaller.entries()]
+    .map(([label, v]) => ({ label, total: v.total, lastAt: v.lastAt }))
+    .sort((a, b) => b.total - a.total);
+}
+
 export function toAuditRow(row: DecisionAuditRowInput): DecisionAuditRow {
   const tier = tierForProfileKind(row.profile?.kind);
   const payload = asRecord(row.outcomePayload);
   const human = asRecord(row.humanOutcome);
   const resolvedByHuman = Boolean(row.escalationCapture) || Object.keys(human).length > 0;
+  const caller = callerForRow(payload);
   return {
+    callerLabel: caller.label,
+    callerThreadId: caller.threadId,
     interactionId: row.interactionId,
     createdAt: row.createdAt.toISOString(),
     tier,

--- a/docs/superpowers/plans/2026-07-06-wwwd-corpus-onboarding-contextualization-plan.md
+++ b/docs/superpowers/plans/2026-07-06-wwwd-corpus-onboarding-contextualization-plan.md
@@ -7,6 +7,8 @@
 
 **Live-verification finding (post Phase A deploy):** the first backfill run on the reference install failed with a P2003 FK violation — `seedOrgWwwdCorpus` points `fallbackProfileId` at `dpf-organizational-principles`, which only ever existed as an in-code constant ([default-profile.ts](apps/web/lib/decision-perspective/default-profile.ts)); no seed materializes the row (`seed-decision-perspective.ts` creates `mark-dpf-platform` + `wsid-*` only). **This FK throw, swallowed by the fail-open completion chain, is the root cause of the WWWD substrate being dormant on every install — fresh ones included.** Fix: the seeder now upserts the fallback profile row before the org profile (same-BI follow-up PR).
 
+**Follow-on — decision-ledger caller attribution (BI-0EEBA669, operator ask post-verification):** every ledger write now carries a `caller` block in `outcomePayload` — the client product token derived from the MCP request User-Agent (`claude-code/…`, `codex-…`, `grok-…`), the resolved auth identity (`apiTokenId`, `authSource`), and the coworker `agentId`/`threadId` when in-portal — threaded route → `ToolExecutionContext` → both ledger writers (`kernel-consult-ledger`, `org-business-gate`). `/wiki/decisions` gains a Caller column, a "Consults by caller" rollup (a client absent from the rollup never consulted the kernel — the operator's Grok question), and caller detail on the drill-in. No schema change; pre-attribution rows fall back to `callingSurface`/unattributed.
+
 ---
 
 ## 1. What WWWD actually is (verified against code + live install, 2026-07-06)

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -1,5 +1,5 @@
 {
-  "apps/web/app/api/mcp/v1/route.test.ts": 1241,
+  "apps/web/app/api/mcp/v1/route.test.ts": 1260,
   "apps/web/app/api/v1/edge/discovery-runs/route.test.ts": 982,
   "apps/web/components/admin/BusinessModelBuilder.tsx": 810,
   "apps/web/components/admin/McpTokenManager.tsx": 1373,
@@ -41,7 +41,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16499,
+  "apps/web/lib/mcp-tools.ts": 16516,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1289,


### PR DESCRIPTION
## Summary

Operator ask (follow-on to BI-44526F3E + #2647): the decision log needs a **unique client + thread identity** on every consult so a decision matches back to the activity that produced it — and so a client that never consults the kernel (e.g. Grok) is visible **by its absence**.

## Changes

- **MCP route** derives a sanitized client token from the request User-Agent (`claude-code/…`, `codex-…`, `grok-…`; helper in `lib/mcp/caller-client.ts` since route files can't export helpers) and threads it + the resolved auth identity (`apiTokenId`, `pat|session-jwt`) through `GovernedExecuteContext`/`ToolExecutionContext`.
- **Both ledger writers persist `outcomePayload.caller`**: `kernel-consult-ledger` (`principle_decide`) and `org-business-gate` (`evaluate_org_business_decision`, now also honoring dispatch routeContext). In-portal coworker calls carry `agentId`/`threadId`, already plumbed by the loop.
- **/wiki/decisions**: Caller column (+ thread short-id), a **Consults by caller** rollup (absence = never consulted), caller detail on the drill-in.
- **No schema change** (`outcomePayload` Json); pre-attribution rows degrade to `callingSurface`/unattributed.

## Testing

- 93 tests green across the six affected suites (audit read-model incl. caller precedence + rollup ordering, UA sanitizer incl. hostile input, pack/gate/ledger suites against the new signatures); apps/web tsc clean.
- Live after deploy: a consult from this client shows `claude-code/…` in the Caller column and the rollup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)