### PR TITLE
feat(queue): activate CWQ backlog bridge — claims surface as work items with flow telemetry (EP-3516E23D, BI-C585535E)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -6248,6 +6248,26 @@ export async function executeTool(
         triageOutcome: item.triageOutcome,
         hasActiveBuild: item.activeBuildId != null,
       });
+      // EP-3516E23D CWQ activation: a claim-on-start (→ in-progress) surfaces the
+      // BI as a WorkItem in the triage queue and records its arrival into queue
+      // flow-telemetry. Idempotent (no duplicate on re-claim) and best-effort —
+      // queue bridging must never fail the claim it observes.
+      if (target === "in-progress") {
+        void (async () => {
+          try {
+            const { bridgeBacklogItemToWorkItem } = await import(
+              "@/lib/queue/bridges/backlog-bridge"
+            );
+            await bridgeBacklogItemToWorkItem(updated.itemId);
+          } catch (err) {
+            console.warn(
+              `[cwq-bridge] failed to bridge ${updated.itemId} to a work item: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          }
+        })();
+      }
       return {
         success: true,
         entityId: updated.itemId,

--- a/apps/web/lib/queue/bridges/backlog-bridge.test.ts
+++ b/apps/web/lib/queue/bridges/backlog-bridge.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { workItem, backlogItem, workQueue, inngestSend, recordQueueTransition } = vi.hoisted(() => ({
+  workItem: { findFirst: vi.fn(), create: vi.fn() },
+  backlogItem: { findUniqueOrThrow: vi.fn() },
+  workQueue: { upsert: vi.fn() },
+  inngestSend: vi.fn(),
+  recordQueueTransition: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: { workItem, backlogItem, workQueue } }));
+vi.mock("@/lib/queue/inngest-client", () => ({ inngest: { send: inngestSend } }));
+vi.mock("@/lib/queue/queue-telemetry", () => ({ recordQueueTransition }));
+
+import { bridgeBacklogItemToWorkItem } from "./backlog-bridge";
+
+beforeEach(() => {
+  workItem.findFirst.mockReset();
+  workItem.create.mockReset();
+  backlogItem.findUniqueOrThrow.mockReset();
+  workQueue.upsert.mockReset();
+  inngestSend.mockReset();
+  recordQueueTransition.mockReset();
+});
+
+describe("bridgeBacklogItemToWorkItem", () => {
+  it("is idempotent — returns the existing live WorkItem without creating a new one", async () => {
+    workItem.findFirst.mockResolvedValue({ itemId: "WI-existing" });
+    const id = await bridgeBacklogItemToWorkItem("BI-1");
+    expect(id).toBe("WI-existing");
+    expect(workItem.create).not.toHaveBeenCalled();
+    expect(recordQueueTransition).not.toHaveBeenCalled();
+  });
+
+  it("creates a queued WorkItem and records an enqueued transition on first claim", async () => {
+    workItem.findFirst.mockResolvedValue(null);
+    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Do the thing", body: "details" });
+    workQueue.upsert.mockResolvedValue({ id: "wq-internal-id", queueId: "triage-default" });
+    const created = { itemId: "WI-new", createdAt: new Date("2026-07-06T12:00:00Z") };
+    workItem.create.mockResolvedValue(created);
+
+    const id = await bridgeBacklogItemToWorkItem("BI-1", "priority");
+
+    expect(id).toBe("WI-new");
+    const createArg = workItem.create.mock.calls[0]![0];
+    expect(createArg.data.sourceType).toBe("backlog-item");
+    expect(createArg.data.sourceId).toBe("BI-1");
+    expect(createArg.data.status).toBe("queued");
+    expect(createArg.data.urgency).toBe("priority");
+    expect(createArg.data.queueId).toBe("wq-internal-id");
+
+    expect(recordQueueTransition).toHaveBeenCalledOnce();
+    const tel = recordQueueTransition.mock.calls[0]![0];
+    expect(tel.queueKey).toBe("cwq:wq-internal-id");
+    expect(tel.itemKind).toBe("work-item");
+    expect(tel.itemId).toBe("WI-new");
+    expect(tel.transition).toBe("enqueued");
+    expect(tel.occurredAt).toEqual(created.createdAt);
+  });
+
+  it("falls back to the title when the BacklogItem has no body", async () => {
+    workItem.findFirst.mockResolvedValue(null);
+    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Titled only", body: null });
+    workQueue.upsert.mockResolvedValue({ id: "wq", queueId: "triage-default" });
+    workItem.create.mockResolvedValue({ itemId: "WI-2", createdAt: new Date() });
+    await bridgeBacklogItemToWorkItem("BI-2");
+    expect(workItem.create.mock.calls[0]![0].data.description).toBe("Titled only");
+  });
+});

--- a/apps/web/lib/queue/bridges/backlog-bridge.ts
+++ b/apps/web/lib/queue/bridges/backlog-bridge.ts
@@ -1,17 +1,42 @@
 import { prisma } from "@dpf/db";
 import { inngest } from "@/lib/queue/inngest-client";
+import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
 import type { WorkItemUrgency } from "@/lib/queue/queue-types";
 
 const TRIAGE_QUEUE_ID = "triage-default";
 
+/** Statuses that mean a WorkItem is still live (not a candidate for a fresh bridge). */
+const LIVE_WORK_ITEM_STATUSES = [
+  "queued",
+  "assigned",
+  "in-progress",
+  "awaiting-input",
+  "awaiting-approval",
+  "escalated",
+  "deferred",
+];
+
 /**
- * Create a WorkItem from a BacklogItem so it can be tracked
- * through the collaborative work queue.
+ * Create a WorkItem from a BacklogItem so it can be tracked through the
+ * collaborative work queue, and record its arrival into the shared flow
+ * telemetry (EP-3516E23D). Idempotent: if a live WorkItem already exists for
+ * this BacklogItem, it returns that item rather than creating a duplicate — so
+ * a claim → release → re-claim cycle does not spawn multiple queue entries.
  */
 export async function bridgeBacklogItemToWorkItem(
   backlogItemId: string,
   urgency: WorkItemUrgency = "routine",
 ): Promise<string> {
+  const existing = await prisma.workItem.findFirst({
+    where: {
+      sourceType: "backlog-item",
+      sourceId: backlogItemId,
+      status: { in: LIVE_WORK_ITEM_STATUSES },
+    },
+    select: { itemId: true },
+  });
+  if (existing) return existing.itemId;
+
   const item = await prisma.backlogItem.findUniqueOrThrow({
     where: { itemId: backlogItemId },
   });
@@ -49,6 +74,14 @@ export async function bridgeBacklogItemToWorkItem(
   await inngest.send({
     name: "cwq/item.created",
     data: { workItemId: workItem.itemId, sourceType: "backlog-item", urgency },
+  });
+
+  void recordQueueTransition({
+    queueKey: `cwq:${triageQueue.id}`,
+    itemKind: "work-item",
+    itemId: workItem.itemId,
+    transition: "enqueued",
+    occurredAt: workItem.createdAt,
   });
 
   return workItem.itemId;

--- a/apps/web/lib/queue/bridges/task-node-bridge.ts
+++ b/apps/web/lib/queue/bridges/task-node-bridge.ts
@@ -1,13 +1,37 @@
 import { prisma } from "@dpf/db";
 import { inngest } from "@/lib/queue/inngest-client";
+import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
 
 const TRIAGE_QUEUE_ID = "triage-default";
 
+/** Statuses that mean a WorkItem is still live (not a candidate for a fresh bridge). */
+const LIVE_WORK_ITEM_STATUSES = [
+  "queued",
+  "assigned",
+  "in-progress",
+  "awaiting-input",
+  "awaiting-approval",
+  "escalated",
+  "deferred",
+];
+
 /**
- * When a TaskNode transitions to awaiting_human, create a WorkItem
- * so it appears in the collaborative work queue for human action.
+ * When a TaskNode transitions to awaiting_human, create a WorkItem so it appears
+ * in the collaborative work queue for human action, and record its arrival into
+ * the shared flow telemetry (EP-3516E23D). Idempotent: a live WorkItem already
+ * bridged for this TaskNode is returned rather than duplicated.
  */
 export async function bridgeTaskNodeToWorkItem(taskNodeId: string): Promise<string> {
+  const existing = await prisma.workItem.findFirst({
+    where: {
+      sourceType: "task-node",
+      sourceId: taskNodeId,
+      status: { in: LIVE_WORK_ITEM_STATUSES },
+    },
+    select: { itemId: true },
+  });
+  if (existing) return existing.itemId;
+
   const node = await prisma.taskNode.findUniqueOrThrow({
     where: { taskNodeId },
     include: { taskRun: true },
@@ -46,6 +70,14 @@ export async function bridgeTaskNodeToWorkItem(taskNodeId: string): Promise<stri
   await inngest.send({
     name: "cwq/item.created",
     data: { workItemId: item.itemId, sourceType: "task-node", urgency: "routine" },
+  });
+
+  void recordQueueTransition({
+    queueKey: `cwq:${triageQueue.id}`,
+    itemKind: "work-item",
+    itemId: item.itemId,
+    transition: "enqueued",
+    occurredAt: item.createdAt,
   });
 
   return item.itemId;

--- a/docs/superpowers/plans/2026-07-06-cwq-bridge-activation-plan.md
+++ b/docs/superpowers/plans/2026-07-06-cwq-bridge-activation-plan.md
@@ -1,0 +1,41 @@
+# EP-3516E23D — Activate dormant CWQ bridges (BI-C585535E)
+
+**Spec:** [docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md](../specs/2026-07-06-reusable-queueing-substrate-design.md) §2.2 / §4.4
+**BI:** BI-C585535E (EP-3516E23D). Depends on Phase 1 (flow-telemetry spine, #2652).
+**Goal:** Wire the dormant CWQ bridges so real work items flow into the queues the
+Phase-1 spine measures and the Phase-3 surfaces display. Until now only the
+sandbox-pool lane emitted telemetry and the work queues were empty (0 rows,
+bridges had zero callers).
+
+## What changed
+
+- **`lib/queue/bridges/backlog-bridge.ts`** — made idempotent (returns an existing
+  live WorkItem for the BacklogItem instead of duplicating on re-claim) and now
+  records a `recordQueueTransition("enqueued")` into the shared telemetry (it
+  creates WorkItems directly, bypassing the emitting server action). 3 unit tests.
+- **`lib/mcp-tools.ts`** — `update_backlog_item_status` now bridges the BI to a
+  triage-queue WorkItem on a claim-on-start (`→ in-progress`), via a lazy import,
+  best-effort and post-commit (never fails the claim). This is the concrete
+  activation: a coworker starting a BI now surfaces it as queued work with flow
+  telemetry.
+- **`lib/queue/bridges/task-node-bridge.ts`** — same idempotency + telemetry
+  hardening so it is activation-ready. **Not wired**: the current TaskNode
+  lifecycle has no `awaiting_human` transition site to call it from (the only
+  reference is the bridge's own doc), so wiring it now would be inventing a
+  caller. It activates when that transition is introduced.
+
+## Verification
+
+- 46 tests green across the bridges + telemetry + mcp-tools suites; `tsc --noEmit`
+  clean; module-size re-baselined; MCP tool-pack guard OK.
+- Live (post-merge): claim a triaged BI → a WorkItem appears in the triage queue,
+  a `QueueTelemetryEvent` (enqueued) row lands, and after the hourly rollup a
+  `cwq:*` tile shows on `/platform/ai/runtime-health` / `get_queue_status`.
+  Re-claiming the same BI does not create a second WorkItem.
+
+## Not in this phase
+
+Field-service dispatch (Phase 4, BI-10E350A6); routing WorkItems to workers
+(EP-CWQ Phase 2 router); the atomic-claim hardening BI-B62B9F1E (the claim gate
+here is the existing advisory-with-staleness check — the bridge rides on top of it
+and is idempotent, so a claim race produces at most one WorkItem).

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -41,7 +41,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16517,
+  "apps/web/lib/mcp-tools.ts": 16537,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1289,


### PR DESCRIPTION
## Summary

**EP-3516E23D (BI-C585535E)** — activates the dormant CWQ backlog bridge so **real work items flow into the queues** the Phase-1 telemetry spine (#2652) measures and the Phase-3 surfaces (#2658) display. Until now only the sandbox-pool lane emitted telemetry; the collaborative work queues were empty because the bridges had zero callers.

## What's in it

- **`lib/queue/bridges/backlog-bridge.ts`** — made **idempotent** (returns an existing live WorkItem for the BacklogItem instead of duplicating on a claim → release → re-claim cycle) and now records a `recordQueueTransition("enqueued")` into the shared flow telemetry (the bridge creates WorkItems directly, bypassing the emitting server action).
- **`lib/mcp-tools.ts` `update_backlog_item_status`** — on a **claim-on-start** (`→ in-progress`), bridges the BI to a triage-queue WorkItem via a lazy import — **best-effort and post-commit**, so queue bridging never fails the claim it observes. A coworker starting a BI now surfaces it as queued work with flow telemetry.
- **`lib/queue/bridges/task-node-bridge.ts`** — same idempotency + telemetry hardening so it's activation-ready. **Not wired**: the current TaskNode lifecycle has no `awaiting_human` transition site to call it from (the only reference is the bridge's own doc), so wiring it now would invent a caller. It activates when that transition is introduced.

## Verification

- 46 tests green across the bridges + telemetry + mcp-tools suites (3 new bridge tests cover idempotency + the enqueued-telemetry emission); `tsc --noEmit` clean; module-size re-baselined; MCP tool-pack guard OK.
- Live (post-merge): claim a triaged BI → a WorkItem appears in the triage queue, a `QueueTelemetryEvent` (enqueued) row lands, and after the hourly rollup a `cwq:*` tile shows on `/platform/ai/runtime-health` and via `get_queue_status`; re-claiming does not create a second WorkItem.

Plan: `docs/superpowers/plans/2026-07-06-cwq-bridge-activation-plan.md`
Spec: `docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
