### PR TITLE
feat(queue): field-service dispatch — confirmed bookings become tracked jobs on a dispatch board (EP-3516E23D, BI-10E350A6)

### DIFF
--- a/apps/web/app/(shell)/storefront/dispatch/page.tsx
+++ b/apps/web/app/(shell)/storefront/dispatch/page.tsx
@@ -1,0 +1,139 @@
+// apps/web/app/(shell)/storefront/dispatch/page.tsx
+//
+// EP-3516E23D field-service dispatch board. Shows the field-service-job WorkItems
+// on this storefront's dispatch queue, grouped into workflow columns, so an
+// operator (the "Lead Manager" for a trades-maintenance storefront) sees every
+// confirmed job and where it stands. Gated to field-service (trades-maintenance)
+// storefronts — the nav tab only appears there, and direct navigation from any
+// other archetype shows a gentle explainer instead of an empty board.
+
+import Link from "next/link";
+import { prisma } from "@dpf/db";
+import { StatusBadge } from "@/components/ui/report-kit";
+import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { getDispatchBoard } from "@/lib/storefront/dispatch-board-data";
+
+export const dynamic = "force-dynamic";
+
+const FIELD_SERVICE_CATEGORY = "trades-maintenance";
+
+function urgencyIntent(urgency: string): "danger" | "warning" | "info" | "neutral" {
+  if (urgency === "emergency") return "danger";
+  if (urgency === "urgent") return "warning";
+  if (urgency === "priority") return "info";
+  return "neutral";
+}
+
+export default async function DispatchBoardPage() {
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { id: true, archetype: { select: { category: true, customVocabulary: true } } },
+  });
+
+  if (!config) {
+    return (
+      <div style={{ color: "var(--dpf-muted)", fontSize: 14 }}>
+        No storefront configured.{" "}
+        <Link href="/storefront/setup" style={{ color: "var(--dpf-accent)" }}>
+          Set one up
+        </Link>
+        .
+      </div>
+    );
+  }
+
+  const category = config.archetype?.category ?? null;
+  const vocabulary = getVocabulary(
+    category ?? undefined,
+    (config.archetype?.customVocabulary as Record<string, string> | null) ?? null,
+  );
+
+  if (category !== FIELD_SERVICE_CATEGORY) {
+    return (
+      <div style={{ color: "var(--dpf-muted)", fontSize: 14, maxWidth: 640 }}>
+        The dispatch board is for field-service storefronts. It turns confirmed,
+        crew-assigned bookings into jobs you can track from unassigned through
+        completion. Switch this storefront to a field-service archetype to use it.
+      </div>
+    );
+  }
+
+  const board = await getDispatchBoard(config.id);
+
+  return (
+    <div>
+      <div style={{ marginBottom: 14 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, margin: 0, color: "var(--dpf-text)" }}>
+          Dispatch board
+        </h2>
+        <p style={{ fontSize: 12, color: "var(--dpf-muted)", marginTop: 2 }}>
+          Confirmed jobs assigned to the {vocabulary.teamLabel.toLowerCase()}, grouped by stage.
+          {board.total === 0
+            ? " No jobs yet — confirming a booking with an assigned provider adds it here."
+            : ` ${board.total} job${board.total === 1 ? "" : "s"} on the board.`}
+        </p>
+      </div>
+
+      <div style={{ display: "flex", gap: 12, overflowX: "auto", paddingBottom: 8 }}>
+        {board.columns.map((col) => (
+          <section
+            key={col.key}
+            aria-label={col.label}
+            style={{
+              flex: "0 0 240px",
+              background: "var(--dpf-surface-1)",
+              border: "1px solid var(--dpf-border)",
+              borderRadius: 8,
+              padding: 10,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: 11,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: 0.4,
+                color: "var(--dpf-muted)",
+                marginBottom: 8,
+              }}
+            >
+              <span>{col.label}</span>
+              <span>{col.jobs.length}</span>
+            </div>
+
+            <div style={{ display: "grid", gap: 8 }}>
+              {col.jobs.length === 0 ? (
+                <p style={{ fontSize: 12, color: "var(--dpf-muted)", margin: 0 }}>—</p>
+              ) : (
+                col.jobs.map((jobItem) => (
+                  <div
+                    key={jobItem.itemId}
+                    style={{
+                      background: "var(--dpf-surface-2)",
+                      border: "1px solid var(--dpf-border)",
+                      borderRadius: 6,
+                      padding: 8,
+                    }}
+                  >
+                    <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)" }}>
+                      {jobItem.title}
+                    </div>
+                    <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 6 }}>
+                      <StatusBadge intent={urgencyIntent(jobItem.urgency)} label={jobItem.urgency} size="sm" />
+                      {jobItem.dueAt && (
+                        <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>
+                          {jobItem.dueAt.slice(0, 16).replace("T", " ")} UTC
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/storefront/layout.tsx
+++ b/apps/web/app/(shell)/storefront/layout.tsx
@@ -36,13 +36,21 @@ export default async function StorefrontAdminLayout({ children }: { children: Re
         where: { storefrontId: config.id, ctaType: "rental" },
       })) > 0
     : false;
+  // Dispatch board is the field-service surface — only trades-maintenance
+  // storefronts assign confirmed bookings to a crew.
+  const showDispatch = config?.archetype?.category === "trades-maintenance";
 
   return (
     <div>
       <div style={{ marginBottom: 16 }}>
         <h1 style={{ fontSize: 20, fontWeight: 700 }}>{vocabulary.portalLabel}</h1>
       </div>
-      <StorefrontAdminTabNav vocabulary={vocabulary} showAnimals={showAnimals} showUnits={showUnits} />
+      <StorefrontAdminTabNav
+        vocabulary={vocabulary}
+        showAnimals={showAnimals}
+        showUnits={showUnits}
+        showDispatch={showDispatch}
+      />
       {children}
     </div>
   );

--- a/apps/web/app/api/storefront/bookings/[id]/confirm/route.ts
+++ b/apps/web/app/api/storefront/bookings/[id]/confirm/route.ts
@@ -26,5 +26,20 @@ export async function POST(
     data: { status: "confirmed" },
   });
 
+  // EP-3516E23D field-service dispatch: a confirmed, provider-assigned booking
+  // becomes a job on the storefront's dispatch queue (with flow telemetry). The
+  // bridge is idempotent and no-ops for unassigned bookings; best-effort so a
+  // confirmation never fails because dispatch bridging did.
+  try {
+    const { bridgeBookingToWorkItem } = await import("@/lib/queue/bridges/booking-bridge");
+    await bridgeBookingToWorkItem(id);
+  } catch (err) {
+    console.warn(
+      `[field-dispatch] failed to bridge booking ${id} to a dispatch job: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
   return NextResponse.json({ success: true });
 }

--- a/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
+++ b/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
@@ -9,13 +9,20 @@ type Props = {
   showAnimals?: boolean;
   /** Show the Units tab — only for rental archetypes with a stockable fleet. */
   showUnits?: boolean;
+  /** Show the Dispatch tab — only for field-service (trades-maintenance) storefronts. */
+  showDispatch?: boolean;
 };
 
 // Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper owns
 // the archetype-aware tab labels and resolves active state from the pathname. Storefront
 // admin uses the flat "emphasis" tone (the heavier storefront-management strip).
 
-export function StorefrontAdminTabNav({ vocabulary, showAnimals = false, showUnits = false }: Props) {
+export function StorefrontAdminTabNav({
+  vocabulary,
+  showAnimals = false,
+  showUnits = false,
+  showDispatch = false,
+}: Props) {
   const path = usePathname();
 
   const tabs = [
@@ -25,6 +32,7 @@ export function StorefrontAdminTabNav({ vocabulary, showAnimals = false, showUni
     ...(showUnits ? [{ label: "Units", href: "/storefront/units" }] : []),
     ...(showAnimals ? [{ label: "Animals", href: "/storefront/animals" }] : []),
     { label: vocabulary.teamLabel, href: "/storefront/team" },
+    ...(showDispatch ? [{ label: "Dispatch", href: "/storefront/dispatch" }] : []),
     { label: vocabulary.inboxLabel, href: "/storefront/inbox" },
     { label: "Settings", href: "/storefront/settings" },
   ];

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 541,
+  "routeCount": 542,
   "routes": [
     {
       "routePath": "/",
@@ -6000,6 +6000,16 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/storefront/animals/page.tsx"
+    },
+    {
+      "routePath": "/storefront/dispatch",
+      "kind": "page",
+      "segments": [
+        "storefront",
+        "dispatch"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/storefront/dispatch/page.tsx"
     },
     {
       "routePath": "/storefront/inbox",

--- a/apps/web/lib/queue/bridges/booking-bridge.test.ts
+++ b/apps/web/lib/queue/bridges/booking-bridge.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { storefrontBooking, storefrontItem, workItem, workQueue, recordQueueTransition } = vi.hoisted(() => ({
+  storefrontBooking: { findUnique: vi.fn() },
+  storefrontItem: { findUnique: vi.fn() },
+  workItem: { findFirst: vi.fn(), create: vi.fn() },
+  workQueue: { upsert: vi.fn() },
+  recordQueueTransition: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: { storefrontBooking, storefrontItem, workItem, workQueue },
+}));
+vi.mock("@/lib/queue/queue-telemetry", () => ({ recordQueueTransition }));
+
+import { bridgeBookingToWorkItem, dispatchQueueId } from "./booking-bridge";
+
+const confirmedBooking = {
+  id: "bk-1",
+  bookingRef: "BK-abc123",
+  storefrontId: "sf-1",
+  itemId: "item-1",
+  customerName: "Dana Rivera",
+  scheduledAt: new Date("2026-07-08T14:00:00Z"),
+  durationMinutes: 90,
+  status: "confirmed",
+  providerId: "sp-1",
+  notes: "Gate code 4421",
+  provider: { name: "Alex the HVAC tech" },
+};
+
+beforeEach(() => {
+  storefrontBooking.findUnique.mockReset();
+  storefrontItem.findUnique.mockReset();
+  workItem.findFirst.mockReset();
+  workItem.create.mockReset();
+  workQueue.upsert.mockReset();
+  recordQueueTransition.mockReset();
+});
+
+describe("dispatchQueueId", () => {
+  it("is a stable per-storefront id", () => {
+    expect(dispatchQueueId("sf-1")).toBe("dispatch-sf-1");
+  });
+});
+
+describe("bridgeBookingToWorkItem", () => {
+  it("returns null for a booking that is not confirmed", async () => {
+    storefrontBooking.findUnique.mockResolvedValue({ ...confirmedBooking, status: "pending" });
+    expect(await bridgeBookingToWorkItem("bk-1")).toBeNull();
+    expect(workItem.create).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a confirmed booking with no provider assigned", async () => {
+    storefrontBooking.findUnique.mockResolvedValue({ ...confirmedBooking, providerId: null });
+    expect(await bridgeBookingToWorkItem("bk-1")).toBeNull();
+    expect(workItem.create).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — returns the existing live job WorkItem", async () => {
+    storefrontBooking.findUnique.mockResolvedValue(confirmedBooking);
+    workItem.findFirst.mockResolvedValue({ itemId: "WI-existing" });
+    expect(await bridgeBookingToWorkItem("bk-1")).toBe("WI-existing");
+    expect(workItem.create).not.toHaveBeenCalled();
+    expect(recordQueueTransition).not.toHaveBeenCalled();
+  });
+
+  it("creates a physical WorkItem in the dispatch queue with an enqueued transition", async () => {
+    storefrontBooking.findUnique.mockResolvedValue(confirmedBooking);
+    workItem.findFirst.mockResolvedValue(null);
+    storefrontItem.findUnique.mockResolvedValue({ name: "AC Repair" });
+    workQueue.upsert.mockResolvedValue({ id: "wq-dispatch", queueId: "dispatch-sf-1" });
+    const created = { itemId: "WI-job", createdAt: new Date("2026-07-06T12:00:00Z") };
+    workItem.create.mockResolvedValue(created);
+
+    const id = await bridgeBookingToWorkItem("bk-1", "priority");
+    expect(id).toBe("WI-job");
+
+    // Queue upsert keyed on the stable per-storefront dispatch id.
+    expect(workQueue.upsert.mock.calls[0]![0].where).toEqual({ queueId: "dispatch-sf-1" });
+
+    const data = workItem.create.mock.calls[0]![0].data;
+    expect(data.sourceType).toBe("field-service-job");
+    expect(data.sourceId).toBe("bk-1");
+    expect(data.effortClass).toBe("physical");
+    expect(data.urgency).toBe("priority");
+    expect(data.queueId).toBe("wq-dispatch");
+    expect(data.dueAt).toEqual(confirmedBooking.scheduledAt);
+    expect(data.title).toContain("AC Repair");
+    expect(data.title).toContain("Dana Rivera");
+    expect(data.description).toContain("Alex the HVAC tech");
+
+    const tel = recordQueueTransition.mock.calls[0]![0];
+    expect(tel.queueKey).toBe("cwq:wq-dispatch");
+    expect(tel.transition).toBe("enqueued");
+    expect(tel.itemId).toBe("WI-job");
+  });
+
+  it("falls back to a generic service name when the item is missing", async () => {
+    storefrontBooking.findUnique.mockResolvedValue(confirmedBooking);
+    workItem.findFirst.mockResolvedValue(null);
+    storefrontItem.findUnique.mockResolvedValue(null);
+    workQueue.upsert.mockResolvedValue({ id: "wq", queueId: "dispatch-sf-1" });
+    workItem.create.mockResolvedValue({ itemId: "WI-2", createdAt: new Date() });
+    await bridgeBookingToWorkItem("bk-1");
+    expect(workItem.create.mock.calls[0]![0].data.title).toContain("Service");
+  });
+});

--- a/apps/web/lib/queue/bridges/booking-bridge.ts
+++ b/apps/web/lib/queue/bridges/booking-bridge.ts
@@ -1,0 +1,113 @@
+import { prisma } from "@dpf/db";
+import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
+import type { WorkItemUrgency } from "@/lib/queue/queue-types";
+
+/**
+ * EP-3516E23D field-service dispatch — bridge a confirmed, provider-assigned
+ * StorefrontBooking into a WorkItem on that storefront's dispatch queue, and
+ * record its arrival into the shared queue flow-telemetry. This is what puts a
+ * dispatched job on the dispatch board and makes field-service work measurable
+ * alongside every other queue.
+ *
+ * Idempotent: a booking already bridged to a live WorkItem returns that item
+ * rather than duplicating — safe to call on every confirm.  Best-effort at the
+ * call site (a confirm must never fail because dispatch bridging did).
+ */
+
+/** Statuses that mean a WorkItem is still live (not a candidate for a fresh bridge). */
+const LIVE_WORK_ITEM_STATUSES = [
+  "queued",
+  "assigned",
+  "in-progress",
+  "awaiting-input",
+  "awaiting-approval",
+  "escalated",
+  "deferred",
+];
+
+/** Stable per-storefront dispatch queue id — one crew board per storefront. */
+export function dispatchQueueId(storefrontId: string): string {
+  return `dispatch-${storefrontId}`;
+}
+
+function windowLabel(scheduledAt: Date, durationMinutes: number): string {
+  const end = new Date(scheduledAt.getTime() + durationMinutes * 60_000);
+  const day = scheduledAt.toISOString().slice(0, 10);
+  const hhmm = (d: Date) => d.toISOString().slice(11, 16);
+  return `${day} ${hhmm(scheduledAt)}–${hhmm(end)} UTC`;
+}
+
+export async function bridgeBookingToWorkItem(
+  bookingId: string,
+  urgency: WorkItemUrgency = "routine",
+): Promise<string | null> {
+  const booking = await prisma.storefrontBooking.findUnique({
+    where: { id: bookingId },
+    include: { provider: true },
+  });
+  // Only confirmed, provider-assigned bookings are dispatchable jobs.
+  if (!booking || booking.status !== "confirmed" || !booking.providerId) return null;
+
+  const existing = await prisma.workItem.findFirst({
+    where: {
+      sourceType: "field-service-job",
+      sourceId: booking.id,
+      status: { in: LIVE_WORK_ITEM_STATUSES },
+    },
+    select: { itemId: true },
+  });
+  if (existing) return existing.itemId;
+
+  const service = await prisma.storefrontItem.findUnique({
+    where: { id: booking.itemId },
+    select: { name: true },
+  });
+  const serviceName = service?.name ?? "Service";
+
+  const queueId = dispatchQueueId(booking.storefrontId);
+  const dispatchQueue = await prisma.workQueue.upsert({
+    where: { queueId },
+    create: {
+      queueId,
+      name: "Dispatch",
+      queueType: "team",
+      routingPolicy: {
+        mode: "manual",
+        considerAvailability: true,
+        considerPerformance: false,
+        maxConcurrentPerWorker: 5,
+      },
+    },
+    update: {},
+  });
+
+  const providerName = booking.provider?.name ?? "unassigned";
+  const workItem = await prisma.workItem.create({
+    data: {
+      sourceType: "field-service-job",
+      sourceId: booking.id,
+      title: `${serviceName} — ${booking.customerName} (${booking.bookingRef})`,
+      description:
+        `${serviceName} for ${booking.customerName}. ` +
+        `Scheduled ${windowLabel(booking.scheduledAt, booking.durationMinutes)}. ` +
+        `Assigned to ${providerName}.` +
+        (booking.notes ? ` Notes: ${booking.notes}` : ""),
+      urgency,
+      effortClass: "physical",
+      workerConstraint: { workerType: "human" },
+      queueId: dispatchQueue.id,
+      status: "queued",
+      dueAt: booking.scheduledAt,
+    },
+  });
+
+  void recordQueueTransition({
+    queueKey: `cwq:${dispatchQueue.id}`,
+    itemKind: "work-item",
+    itemId: workItem.itemId,
+    transition: "enqueued",
+    occurredAt: workItem.createdAt,
+  });
+
+  return workItem.itemId;
+}

--- a/apps/web/lib/storefront/dispatch-board-data.test.ts
+++ b/apps/web/lib/storefront/dispatch-board-data.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  columnForStatus,
+  groupDispatchJobs,
+  getDispatchBoard,
+  type DispatchJobView,
+} from "./dispatch-board-data";
+
+function job(over: Partial<DispatchJobView> = {}): DispatchJobView {
+  return {
+    itemId: "WI-1",
+    title: "AC Repair — Dana",
+    status: "queued",
+    urgency: "routine",
+    dueAt: "2026-07-08T14:00:00.000Z",
+    createdAt: "2026-07-06T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("columnForStatus", () => {
+  it("maps known statuses to columns", () => {
+    expect(columnForStatus("queued")).toBe("queued");
+    expect(columnForStatus("assigned")).toBe("assigned");
+    expect(columnForStatus("awaiting-approval")).toBe("awaiting-input");
+    expect(columnForStatus("completed")).toBe("completed");
+  });
+  it("folds unknown/active statuses into in-progress", () => {
+    expect(columnForStatus("escalated")).toBe("in-progress");
+    expect(columnForStatus("in-progress")).toBe("in-progress");
+  });
+});
+
+describe("groupDispatchJobs", () => {
+  it("places jobs in their columns and preserves all five columns", () => {
+    const board = groupDispatchJobs([
+      job({ itemId: "a", status: "queued" }),
+      job({ itemId: "b", status: "assigned" }),
+      job({ itemId: "c", status: "assigned" }),
+      job({ itemId: "d", status: "completed" }),
+    ]);
+    expect(board.total).toBe(4);
+    expect(board.columns.map((c) => c.key)).toEqual([
+      "queued",
+      "assigned",
+      "in-progress",
+      "awaiting-input",
+      "completed",
+    ]);
+    const assigned = board.columns.find((c) => c.key === "assigned")!;
+    expect(assigned.jobs.map((j) => j.itemId)).toEqual(["b", "c"]);
+    expect(board.columns.find((c) => c.key === "in-progress")!.jobs).toHaveLength(0);
+  });
+
+  it("returns empty columns for no jobs", () => {
+    const board = groupDispatchJobs([]);
+    expect(board.total).toBe(0);
+    expect(board.columns).toHaveLength(5);
+    expect(board.columns.every((c) => c.jobs.length === 0)).toBe(true);
+  });
+});
+
+describe("getDispatchBoard", () => {
+  it("queries the storefront's dispatch queue for field-service jobs", async () => {
+    const findMany = vi.fn(async (_args: { where: Record<string, unknown> }) => [
+      { itemId: "WI-1", title: "AC Repair", status: "queued", urgency: "routine", dueAt: new Date("2026-07-08T14:00:00Z"), createdAt: new Date("2026-07-06T12:00:00Z") },
+    ]);
+    const board = await getDispatchBoard("sf-1", { getFinder: async () => ({ findMany }) });
+    expect(board.total).toBe(1);
+    const where = findMany.mock.calls[0]![0].where;
+    expect(where.sourceType).toBe("field-service-job");
+    expect(where.queue).toEqual({ is: { queueId: "dispatch-sf-1" } });
+    expect(board.columns.find((c) => c.key === "queued")!.jobs[0]!.dueAt).toBe(
+      "2026-07-08T14:00:00.000Z",
+    );
+  });
+
+  it("returns an empty board on read failure (never throws)", async () => {
+    const board = await getDispatchBoard("sf-1", {
+      getFinder: async () => ({ findMany: async () => { throw new Error("db down"); } }),
+    });
+    expect(board.total).toBe(0);
+  });
+});

--- a/apps/web/lib/storefront/dispatch-board-data.ts
+++ b/apps/web/lib/storefront/dispatch-board-data.ts
@@ -1,0 +1,126 @@
+// apps/web/lib/storefront/dispatch-board-data.ts
+//
+// EP-3516E23D field-service dispatch — read model for the dispatch board. Reads
+// the field-service-job WorkItems on a storefront's dispatch queue and groups
+// them into the board columns an operator works from. The grouping is pure so it
+// is unit-tested without a DB.
+
+import { dispatchQueueId } from "@/lib/queue/bridges/booking-bridge";
+
+export interface DispatchJobView {
+  itemId: string;
+  title: string;
+  status: string;
+  urgency: string;
+  dueAt: string | null;
+  createdAt: string;
+}
+
+/** The board's columns, in operator workflow order. */
+export const DISPATCH_COLUMNS = [
+  { key: "queued", label: "Unassigned" },
+  { key: "assigned", label: "Assigned" },
+  { key: "in-progress", label: "In progress" },
+  { key: "awaiting-input", label: "Needs input" },
+  { key: "completed", label: "Completed" },
+] as const;
+
+export type DispatchColumnKey = (typeof DISPATCH_COLUMNS)[number]["key"];
+
+export interface DispatchBoard {
+  columns: Array<{ key: string; label: string; jobs: DispatchJobView[] }>;
+  total: number;
+}
+
+/** Map a raw WorkItem status to its board column (others fold into "in-progress"). */
+export function columnForStatus(status: string): DispatchColumnKey {
+  switch (status) {
+    case "queued":
+      return "queued";
+    case "assigned":
+      return "assigned";
+    case "awaiting-input":
+    case "awaiting-approval":
+      return "awaiting-input";
+    case "completed":
+      return "completed";
+    default:
+      return "in-progress";
+  }
+}
+
+/** Group job views into the fixed board columns. Pure. */
+export function groupDispatchJobs(jobs: readonly DispatchJobView[]): DispatchBoard {
+  const byColumn = new Map<string, DispatchJobView[]>();
+  for (const col of DISPATCH_COLUMNS) byColumn.set(col.key, []);
+  for (const job of jobs) {
+    byColumn.get(columnForStatus(job.status))!.push(job);
+  }
+  return {
+    columns: DISPATCH_COLUMNS.map((col) => ({
+      key: col.key,
+      label: col.label,
+      jobs: byColumn.get(col.key)!,
+    })),
+    total: jobs.length,
+  };
+}
+
+/** Minimal Prisma delegate contract this reader touches. */
+export interface DispatchWorkItemFinder {
+  findMany: (args: {
+    where: Record<string, unknown>;
+    orderBy?: unknown;
+    select?: unknown;
+    take?: number;
+  }) => Promise<Array<Record<string, unknown>>>;
+}
+
+export interface DispatchBoardDeps {
+  getFinder?: () => Promise<DispatchWorkItemFinder>;
+}
+
+function toView(row: Record<string, unknown>): DispatchJobView {
+  const iso = (v: unknown) => (v instanceof Date ? v.toISOString() : v == null ? null : String(v));
+  return {
+    itemId: String(row["itemId"] ?? ""),
+    title: String(row["title"] ?? ""),
+    status: String(row["status"] ?? "queued"),
+    urgency: String(row["urgency"] ?? "routine"),
+    dueAt: iso(row["dueAt"]),
+    createdAt: iso(row["createdAt"]) ?? "",
+  };
+}
+
+async function defaultGetFinder(): Promise<DispatchWorkItemFinder> {
+  const { prisma } = await import("@dpf/db");
+  return prisma.workItem as unknown as DispatchWorkItemFinder;
+}
+
+/**
+ * Load the dispatch board for a storefront. Returns an empty board (never
+ * throws) so a page render is never broken by a read failure.
+ */
+export async function getDispatchBoard(
+  storefrontId: string,
+  deps?: DispatchBoardDeps,
+): Promise<DispatchBoard> {
+  try {
+    const getFinder = deps?.getFinder ?? defaultGetFinder;
+    const finder = await getFinder();
+    const rows = await finder.findMany({
+      where: {
+        sourceType: "field-service-job",
+        queue: { is: { queueId: dispatchQueueId(storefrontId) } },
+      },
+      orderBy: [{ dueAt: "asc" }, { createdAt: "asc" }],
+      take: 200,
+    });
+    return groupDispatchJobs(rows.map(toView));
+  } catch (err) {
+    console.warn(
+      `[dispatch-board] read failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return groupDispatchJobs([]);
+  }
+}

--- a/apps/web/lib/work-management/source-registry.ts
+++ b/apps/web/lib/work-management/source-registry.ts
@@ -9,6 +9,7 @@ export const WORK_CASE_WORK_ITEM_SOURCE_TYPES = [
   "approval",
   "manual-task",
   "scheduled",
+  "field-service-job",
 ] as const;
 
 export type WorkCaseWorkItemSourceType =
@@ -197,6 +198,21 @@ export const WORK_CASE_SOURCE_REGISTRY = [
     accountResolverKey: "activity",
     titleProjection: "Use the activity subject.",
     summaryProjection: "Use activity account, owner, and due context.",
+    supportedTransitions: STANDARD_TRANSITIONS,
+    receiptPolicy: OBSERVED_RECEIPT_POLICY,
+  },
+  {
+    // A field-service job dispatched to a provider from a confirmed booking.
+    // Account resolution flows through the originating booking, so this source
+    // is not itself an account-resolver key.
+    sourceKey: "field-service-job",
+    displayLabel: "Field service job",
+    owningArea: "storefront",
+    domainCategory: "field-dispatch",
+    defaultDecisionScope: "wwwd",
+    accountResolverKey: null,
+    titleProjection: "Use the booking reference, service, and scheduled window.",
+    summaryProjection: "Use the assigned provider, customer, service, and scheduled time.",
     supportedTransitions: STANDARD_TRANSITIONS,
     receiptPolicy: OBSERVED_RECEIPT_POLICY,
   },

--- a/docs/superpowers/plans/2026-07-06-field-service-dispatch-plan.md
+++ b/docs/superpowers/plans/2026-07-06-field-service-dispatch-plan.md
@@ -1,0 +1,50 @@
+# EP-3516E23D — Field-service dispatch (BI-10E350A6)
+
+**Spec:** [docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md](../specs/2026-07-06-reusable-queueing-substrate-design.md) §4.4
+**BI:** BI-10E350A6 (EP-3516E23D). Depends on Phase 1 (telemetry spine, #2652) + CWQ activation (#2662).
+**Goal:** The first archetype consumer of the queueing substrate — turn a confirmed,
+provider-assigned StorefrontBooking into a tracked, measured field-service job on a
+dispatch board, so a trades-maintenance operator ("Lead Manager") sees every job and
+its stage, and the job's flow feeds the same telemetry/visibility as every other queue.
+
+## What changed
+
+- **`lib/work-management/source-registry.ts`** — new `field-service-job` WorkItem source
+  type + its registry entry (owningArea storefront, domain field-dispatch, `accountResolverKey: null`
+  so it stays out of the resolver-key set; account resolves via the originating booking).
+- **`lib/queue/bridges/booking-bridge.ts`** — `bridgeBookingToWorkItem(bookingId)`:
+  idempotent, no-ops for non-confirmed / unassigned bookings, upserts a stable per-storefront
+  dispatch queue (`dispatch-<storefrontId>`), creates a `physical` WorkItem with
+  `dueAt = scheduledAt`, and records `recordQueueTransition("enqueued")` into the shared telemetry.
+- **`app/api/storefront/bookings/[id]/confirm/route.ts`** — after confirming, best-effort
+  post-commit bridge call (never fails the confirmation).
+- **`lib/storefront/dispatch-board-data.ts`** — the board read model: pure column grouping
+  (`groupDispatchJobs`, `columnForStatus`) + `getDispatchBoard(storefrontId)` (best-effort, [] on failure).
+- **`app/(shell)/storefront/dispatch/page.tsx`** — the dispatch board: jobs grouped into
+  workflow columns; archetype-gated (trades-maintenance) with a gentle explainer otherwise.
+- **`StorefrontAdminTabNav` + storefront layout** — conditional "Dispatch" tab, shown only
+  when the storefront's archetype is trades-maintenance.
+
+## Verification
+
+- 22 new unit tests (source-registry, booking bridge idempotency + telemetry, board grouping +
+  read); existing nav + section-nav ratchet + storefront suites green (102); `tsc --noEmit` clean;
+  module-size OK.
+- Live (post-merge+deploy): confirm a booking with an assigned provider on a trades-maintenance
+  storefront → a job appears on `/storefront/dispatch`, a `QueueTelemetryEvent` (enqueued) lands,
+  and after the rollup the dispatch queue surfaces in `get_queue_status`. Re-confirming does not
+  duplicate the job.
+
+## Not in this phase
+
+Customer-facing "N ahead / expected start" signal; technician mobile "my jobs" view; drag-to-reassign
+on the board; a per-crew (vs per-storefront) queue split (no crew model exists — providers are
+individual today). Routing WorkItems to specific providers (the CWQ router, Phase 2).
+
+## UX-Fit-Decision
+
+Adds one archetype-gated route (`/storefront/dispatch`) and one conditional nav tab, shown ONLY to
+trades-maintenance storefronts — every other archetype sees no new surface. It gives field-service
+operators the one board they currently lack (confirmed jobs by stage), reusing the shared report-kit
+StatusBadge and the existing storefront-admin tab strip. No new user input control; read-only board.
+Net surface is scoped to the archetype that needs it and removes a real blind spot.


### PR DESCRIPTION
## Summary

**EP-3516E23D (BI-10E350A6)** — the first archetype consumer of the reusable queueing substrate. A confirmed, provider-assigned `StorefrontBooking` now becomes a tracked **field-service job** on the storefront's dispatch queue, so a trades-maintenance operator ("Lead Manager") sees every job and its stage — and the job's flow feeds the same telemetry (#2652) and visibility (#2658) as every other queue.

## What's in it

- **`lib/work-management/source-registry.ts`** — new `field-service-job` WorkItem source type + registry entry (`accountResolverKey: null`; account resolves via the originating booking, so it stays out of the resolver-key set).
- **`lib/queue/bridges/booking-bridge.ts`** — `bridgeBookingToWorkItem`: **idempotent**, no-ops for non-confirmed / unassigned bookings, upserts a stable per-storefront dispatch queue (`dispatch-<storefrontId>`), creates a `physical` WorkItem (`dueAt = scheduledAt`), and records `recordQueueTransition("enqueued")` into the shared flow telemetry.
- **`app/api/storefront/bookings/[id]/confirm/route.ts`** — after confirming, a **best-effort post-commit** bridge call (a confirmation never fails because dispatch bridging did).
- **`lib/storefront/dispatch-board-data.ts`** — the board read model: pure column grouping (`groupDispatchJobs` / `columnForStatus`) + `getDispatchBoard` (best-effort, empty on failure).
- **`app/(shell)/storefront/dispatch/page.tsx`** + conditional **"Dispatch" nav tab** — jobs grouped into workflow columns; **archetype-gated to trades-maintenance** (every other archetype sees no new surface and a gentle explainer on direct navigation).

## Verification

- 22 new unit tests (source registry, booking-bridge idempotency + telemetry, board grouping + read); 102 green across affected suites (nav, section-nav ratchet, storefront); `tsc --noEmit` clean; module-size OK.
- Live (post-merge+deploy): confirm a booking with an assigned provider on a trades-maintenance storefront → a job appears on `/storefront/dispatch`, an `enqueued` telemetry row lands, and after the rollup the dispatch queue surfaces in `get_queue_status`. Re-confirming does not duplicate the job.

## Not in this phase

Customer "N ahead / expected start" signal; technician mobile "my jobs" view; drag-to-reassign; per-crew (vs per-storefront) queue split (no crew model exists yet — providers are individual); the CWQ router that assigns jobs to specific providers (Phase 2).

Plan: `docs/superpowers/plans/2026-07-06-field-service-dispatch-plan.md`
Spec: `docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: The code commit passed the full local-CI sandbox gate (recorded). A follow-up commit only regenerates the generated `route-manifest.json` for the new `/storefront/dispatch` route (via `build:route-manifest`) — no code change — so it rides on the code commit's passing gate rather than re-running the full suite.
