### PR TITLE
feat(queue): ResourceLane compute-admission primitive + local-inference bounded lane (EP-3516E23D Phase 2, BI-6112DDE0)

### DIFF
--- a/apps/web/lib/queue/resource-lane.test.ts
+++ b/apps/web/lib/queue/resource-lane.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  ResourceLane,
+  LaneBusyError,
+  getResourceLane,
+  localInferenceMaxQueueDepth,
+} from "./resource-lane";
+import type { QueueTransitionInput } from "./queue-telemetry";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("ResourceLane serialization", () => {
+  it("runs one call at a time in FIFO order", async () => {
+    const lane = new ResourceLane("compute:test", { record: () => {} });
+    const order: string[] = [];
+    const a = deferred<void>();
+    const b = deferred<void>();
+
+    const p1 = lane.run(async () => {
+      order.push("a-start");
+      await a.promise;
+      order.push("a-end");
+    });
+    const p2 = lane.run(async () => {
+      order.push("b-start");
+      await b.promise;
+      order.push("b-end");
+    });
+
+    // b must not start until a finishes.
+    await Promise.resolve();
+    expect(order).toEqual(["a-start"]);
+    a.resolve();
+    await p1;
+    expect(order).toEqual(["a-start", "a-end", "b-start"]);
+    b.resolve();
+    await p2;
+    expect(order).toEqual(["a-start", "a-end", "b-start", "b-end"]);
+  });
+
+  it("a failing call never wedges the lane", async () => {
+    const lane = new ResourceLane("compute:test", { record: () => {} });
+    await expect(lane.run(async () => { throw new Error("boom"); })).rejects.toThrow("boom");
+    // The next call still runs.
+    await expect(lane.run(async () => 42)).resolves.toBe(42);
+  });
+
+  it("returns the fn's resolved value", async () => {
+    const lane = new ResourceLane("compute:test", { record: () => {} });
+    await expect(lane.run(async () => "ok")).resolves.toBe("ok");
+  });
+});
+
+describe("ResourceLane bounded admission", () => {
+  it("is unbounded by default (never rejects, matches the promise chain)", async () => {
+    const lane = new ResourceLane("compute:test", { record: () => {} });
+    const gate = deferred<void>();
+    const runs = [
+      lane.run(() => gate.promise),
+      lane.run(async () => "second"),
+      lane.run(async () => "third"),
+    ];
+    // None reject despite three queued behind a held slot.
+    gate.resolve();
+    await expect(Promise.all(runs)).resolves.toEqual([undefined, "second", "third"]);
+  });
+
+  it("rejects with LaneBusyError once waiting exceeds maxQueueDepth", async () => {
+    const lane = new ResourceLane("compute:test", { record: () => {} });
+    const gate = deferred<void>();
+    // First call takes the slot (waiting goes 1 then 0 as it starts).
+    const held = lane.run(() => gate.promise, { maxQueueDepth: 1 });
+    // Let the first call start (waiting drops to 0).
+    await Promise.resolve();
+    // One more may WAIT (waiting → 1). A third at depth 1 is refused.
+    const waiter = lane.run(async () => "queued", { maxQueueDepth: 1 });
+    await expect(
+      lane.run(async () => "refused", { maxQueueDepth: 1 }),
+    ).rejects.toBeInstanceOf(LaneBusyError);
+
+    gate.resolve();
+    await expect(held).resolves.toBeUndefined();
+    await expect(waiter).resolves.toBe("queued");
+  });
+
+  it("LaneBusyError carries the lane key and depth", async () => {
+    const lane = new ResourceLane("compute:gpu", { record: () => {} });
+    const gate = deferred<void>();
+    lane.run(() => gate.promise, { maxQueueDepth: 0 }).catch(() => {});
+    await Promise.resolve();
+    try {
+      await lane.run(async () => "x", { maxQueueDepth: 0 });
+      throw new Error("expected LaneBusyError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LaneBusyError);
+      expect((err as LaneBusyError).laneKey).toBe("compute:gpu");
+      expect((err as LaneBusyError).code).toBe("lane_busy");
+    }
+    gate.resolve();
+  });
+});
+
+describe("ResourceLane telemetry", () => {
+  it("emits enqueued → started → finished with lane key and durations", async () => {
+    const events: QueueTransitionInput[] = [];
+    let clock = 1000;
+    const lane = new ResourceLane("compute:gpu", {
+      record: (e) => events.push(e),
+      now: () => (clock += 5),
+    });
+    await lane.run(async () => "done");
+
+    expect(events.map((e) => e.transition)).toEqual(["enqueued", "started", "finished"]);
+    expect(events.every((e) => e.queueKey === "compute:gpu")).toBe(true);
+    expect(events.every((e) => e.itemKind === "compute")).toBe(true);
+    const finished = events[2]!;
+    expect(finished.outcome).toBe("success");
+    expect(typeof finished.durations?.processMs).toBe("number");
+  });
+
+  it("records a failed outcome when fn throws", async () => {
+    const events: QueueTransitionInput[] = [];
+    const lane = new ResourceLane("compute:gpu", { record: (e) => events.push(e) });
+    await lane.run(async () => { throw new Error("x"); }).catch(() => {});
+    expect(events.at(-1)!.outcome).toBe("failed");
+  });
+});
+
+describe("getResourceLane", () => {
+  it("returns the same instance for a key", () => {
+    const a = getResourceLane("compute:shared");
+    const b = getResourceLane("compute:shared");
+    expect(a).toBe(b);
+  });
+});
+
+describe("localInferenceMaxQueueDepth", () => {
+  const KEY = "DPF_LOCAL_INFERENCE_MAX_QUEUE_DEPTH";
+  it("is null when unset (unbounded)", () => {
+    delete process.env[KEY];
+    expect(localInferenceMaxQueueDepth()).toBeNull();
+  });
+  it("parses a positive integer", () => {
+    process.env[KEY] = "8";
+    expect(localInferenceMaxQueueDepth()).toBe(8);
+    delete process.env[KEY];
+  });
+  it("is null for invalid values", () => {
+    process.env[KEY] = "-1";
+    expect(localInferenceMaxQueueDepth()).toBeNull();
+    process.env[KEY] = "abc";
+    expect(localInferenceMaxQueueDepth()).toBeNull();
+    delete process.env[KEY];
+  });
+});

--- a/apps/web/lib/queue/resource-lane.ts
+++ b/apps/web/lib/queue/resource-lane.ts
@@ -1,0 +1,177 @@
+// apps/web/lib/queue/resource-lane.ts
+//
+// EP-3516E23D Phase 2 — the reusable compute-admission primitive. A ResourceLane
+// serializes access to a scarce in-process compute resource (the local GPU is
+// the motivating one) to a concurrency of ONE, with two things the bare
+// promise-chain serializer it replaces never had:
+//   1. an OPTIONAL bounded queue depth — over the cap, `run` rejects immediately
+//      with a typed LaneBusyError (the "honest busy" signal BI-6112DDE0 asks for)
+//      instead of letting callers pile up unboundedly and time out while waiting;
+//   2. flow telemetry — enqueued/started/finished transitions into the shared
+//      spine, so lane wait time and throughput are finally measurable.
+//
+// DEFAULT BEHAVIOR IS UNCHANGED: with no maxQueueDepth configured the lane is an
+// unbounded FIFO serializer — byte-for-byte the semantics of the promise chain it
+// replaces (each call gets the full resource; one failure never wedges the rest).
+// Bounded admission is strictly opt-in, mirroring the config-gated build-pipeline
+// lane in admission.ts. Spec §4.3.
+
+import type { QueueTransitionInput } from "./queue-telemetry";
+
+/** Thrown by `run` when the lane's bounded queue is full. */
+export class LaneBusyError extends Error {
+  readonly code = "lane_busy";
+  constructor(
+    readonly laneKey: string,
+    readonly depth: number,
+  ) {
+    super(`Resource lane ${laneKey} is at capacity (${depth} waiting).`);
+    this.name = "LaneBusyError";
+  }
+}
+
+export interface ResourceLaneRunOptions {
+  /**
+   * Max number of calls allowed to be WAITING (queued but not yet started). When
+   * the waiting count is at or above this, `run` throws LaneBusyError instead of
+   * enqueuing. null/undefined ⇒ unbounded (default, zero behavior change).
+   */
+  maxQueueDepth?: number | null;
+  /** Correlation id for the telemetry rows; defaults to a per-lane sequence. */
+  itemId?: string;
+}
+
+export interface ResourceLaneDeps {
+  /** Injectable telemetry sink (defaults to recordQueueTransition). */
+  record?: (input: QueueTransitionInput) => void;
+  /** Injectable clock for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * A single-slot, FIFO admission lane for a scarce in-process resource.
+ * Instances are keyed by `laneKey` via `getResourceLane` so every caller sharing
+ * a resource shares one lane (and one aggregate queue depth).
+ */
+export class ResourceLane {
+  private chain: Promise<unknown> = Promise.resolve();
+  private waiting = 0;
+  private seq = 0;
+  private readonly record: (input: QueueTransitionInput) => void;
+  private readonly now: () => number;
+
+  constructor(
+    readonly laneKey: string,
+    deps: ResourceLaneDeps = {},
+  ) {
+    this.record = deps.record ?? defaultRecord;
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /** Current number of calls waiting (queued, not yet started). */
+  depth(): number {
+    return this.waiting;
+  }
+
+  /**
+   * Run `fn` with exclusive access to the lane. Serialized to concurrency 1.
+   * Rejects with LaneBusyError if a bounded depth is configured and exceeded;
+   * otherwise queues (unbounded) exactly like the promise chain it replaces.
+   */
+  async run<T>(fn: () => Promise<T>, opts: ResourceLaneRunOptions = {}): Promise<T> {
+    const maxQueueDepth = opts.maxQueueDepth ?? null;
+    if (maxQueueDepth != null && this.waiting >= maxQueueDepth) {
+      throw new LaneBusyError(this.laneKey, this.waiting);
+    }
+
+    const itemId = opts.itemId ?? `${this.laneKey}#${++this.seq}`;
+    const enqueuedAt = this.now();
+    this.waiting += 1;
+    this.emit({ itemId, transition: "enqueued", occurredAt: new Date(enqueuedAt), depth: this.waiting });
+
+    // Run the body whether the previous link resolved OR rejected (mirrors the
+    // original `chain.then(fn, fn)`), so one failure never wedges the lane.
+    const body = async (): Promise<T> => {
+      this.waiting -= 1;
+      const startedAt = this.now();
+      this.emit({
+        itemId,
+        transition: "started",
+        occurredAt: new Date(startedAt),
+        durations: { waitMs: startedAt - enqueuedAt },
+        depth: this.waiting,
+      });
+      try {
+        const value = await fn();
+        this.emit({
+          itemId,
+          transition: "finished",
+          outcome: "success",
+          durations: { processMs: this.now() - startedAt, waitMs: startedAt - enqueuedAt },
+        });
+        return value;
+      } catch (err) {
+        this.emit({
+          itemId,
+          transition: "finished",
+          outcome: "failed",
+          durations: { processMs: this.now() - startedAt },
+        });
+        throw err;
+      }
+    };
+
+    const run = this.chain.then(body, body);
+    this.chain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private emit(
+    partial: Omit<QueueTransitionInput, "queueKey" | "itemKind"> & { itemId: string },
+  ): void {
+    try {
+      this.record({
+        queueKey: this.laneKey,
+        itemKind: "compute",
+        actorType: "system",
+        ...partial,
+      });
+    } catch {
+      // Telemetry is best-effort; never let it disturb the lane.
+    }
+  }
+}
+
+function defaultRecord(input: QueueTransitionInput): void {
+  // Lazy import so this module (and its tests) does not pull the telemetry
+  // module — and through it prom-client / the db client — unless actually used.
+  void import("./queue-telemetry").then(({ recordQueueTransition }) => {
+    void recordQueueTransition(input);
+  });
+}
+
+const LANES = new Map<string, ResourceLane>();
+
+/** Get (or create) the shared lane for a resource key. One lane per key. */
+export function getResourceLane(laneKey: string, deps?: ResourceLaneDeps): ResourceLane {
+  let lane = LANES.get(laneKey);
+  if (!lane) {
+    lane = new ResourceLane(laneKey, deps);
+    LANES.set(laneKey, lane);
+  }
+  return lane;
+}
+
+/** Canonical lane key for the single local-GPU inference resource. */
+export const LOCAL_INFERENCE_LANE_KEY = "compute:local-inference";
+
+/** Bounded-depth config for the local-inference lane (opt-in; unset ⇒ unbounded). */
+export function localInferenceMaxQueueDepth(): number | null {
+  const raw = process.env.DPF_LOCAL_INFERENCE_MAX_QUEUE_DEPTH;
+  if (raw == null || raw === "") return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -26,6 +26,12 @@ import {
 import { isAnthropic } from "./provider-utils";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { extractToolCalls as extractTextualToolUse } from "./extract-tool-calls";
+import {
+  getResourceLane,
+  LOCAL_INFERENCE_LANE_KEY,
+  localInferenceMaxQueueDepth,
+} from "@/lib/queue/resource-lane";
+import type { QueueTransitionInput } from "@/lib/queue/queue-telemetry";
 import { buildAnthropicSystem } from "./anthropic-cache";
 
 // ─── Inference HTTP timeouts ──────────────────────────────────────────────────
@@ -48,17 +54,30 @@ function resolveInferenceTimeoutMs(providerId: string): number {
 // blow past the per-call timeout while still waiting, and 502 the endpoint under
 // load. Observed live: "Both review agents failed to respond" on every local
 // build because both reviewers aborted with "operation was aborted due to timeout".
-// Serialize local inference through a promise chain so each call gets the full GPU
-// and its timeout (created by the caller, inside this lock) covers real inference,
-// not queue-wait. Cloud providers are unaffected — only providerId === "local"
-// goes through the lock.
-let localInferenceChain: Promise<unknown> = Promise.resolve();
+// Serialize local inference so each call gets the full GPU and its timeout
+// (created by the caller, inside this lock) covers real inference, not queue-wait.
+// Cloud providers are unaffected — only providerId === "local" goes through it.
+//
+// This now delegates to the shared ResourceLane (EP-3516E23D Phase 2), which is
+// the same single-slot FIFO serializer with two opt-in additions: a bounded queue
+// depth (set DPF_LOCAL_INFERENCE_MAX_QUEUE_DEPTH to reject over-capacity calls with
+// a LaneBusyError — the honest busy signal, BI-6112DDE0 — instead of letting them
+// pile up and time out while waiting), and flow telemetry so lane wait/process
+// time is measurable. Both are gated on that env: UNSET ⇒ unbounded serialize with
+// no telemetry writes, byte-for-byte the prior behavior.
+const localInferenceLane = getResourceLane(LOCAL_INFERENCE_LANE_KEY, {
+  record: (input: QueueTransitionInput) => {
+    // Only emit on the hot inference path when an operator has opted into managing
+    // the lane — avoids per-inference DB writes in the default configuration.
+    if (localInferenceMaxQueueDepth() == null) return;
+    void import("@/lib/queue/queue-telemetry").then(({ recordQueueTransition }) => {
+      void recordQueueTransition(input);
+    });
+  },
+});
+
 export function withLocalInferenceLock<T>(fn: () => Promise<T>): Promise<T> {
-  const run = localInferenceChain.then(fn, fn);
-  // Keep the chain alive regardless of this call's outcome so one failure/timeout
-  // never wedges every subsequent local call.
-  localInferenceChain = run.then(() => undefined, () => undefined);
-  return run;
+  return localInferenceLane.run(fn, { maxQueueDepth: localInferenceMaxQueueDepth() });
 }
 
 // ─── Gemini part types ───────────────────────────────────────────────────────

--- a/docs/superpowers/plans/2026-07-06-compute-resource-lane-plan.md
+++ b/docs/superpowers/plans/2026-07-06-compute-resource-lane-plan.md
@@ -1,0 +1,41 @@
+# EP-3516E23D Phase 2 — Compute ResourceLane + local-inference admission (BI-6112DDE0)
+
+**Spec:** [docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md](../specs/2026-07-06-reusable-queueing-substrate-design.md) §4.3
+**BI:** BI-6112DDE0 (EP-056D2A5E / EP-3516E23D). Depends on Phase 1 (telemetry spine, #2652).
+**Goal:** Give scarce in-process compute the reusable admission primitive the spec calls
+for, and put the local-GPU inference path on it — with a bounded queue + honest busy
+signal (the root cause of the "both reviewers timed out" incident) and flow telemetry —
+without changing default behavior.
+
+## What changed
+
+- **`lib/queue/resource-lane.ts`** — `ResourceLane`: a single-slot FIFO admission gate
+  with (1) an optional bounded queue depth (over-cap ⇒ `LaneBusyError`, the honest busy
+  signal) and (2) enqueued/started/finished flow telemetry. `getResourceLane(key)` shares
+  one lane per resource key. **Unbounded + no telemetry by default ⇒ byte-for-byte the
+  promise-chain serializer it replaces.** 12 unit tests (FIFO order, failure-doesn't-wedge,
+  bounded reject, telemetry, singleton, config parsing).
+- **`lib/routing/chat-adapter.ts`** — `withLocalInferenceLock` now delegates to the shared
+  `compute:local-inference` lane. Bounded admission + telemetry are gated on
+  `DPF_LOCAL_INFERENCE_MAX_QUEUE_DEPTH`: **unset ⇒ unbounded serialize, no per-inference DB
+  writes** (identical to before); set ⇒ over-capacity calls get `LaneBusyError` (and fall
+  back to a cloud provider via the existing error path) instead of piling up and timing out,
+  and lane wait/process time becomes measurable. The existing serialization test is unchanged
+  and still green.
+
+## Verification
+
+- 33 tests green (12 new resource-lane + the existing 21 chat-adapter incl. the serialization
+  contract); `tsc --noEmit` clean; module-size OK.
+- Live (post-merge+deploy, opt-in): set `DPF_LOCAL_INFERENCE_MAX_QUEUE_DEPTH` and saturate the
+  local lane with N+2 concurrent inferences → excess get an honest busy signal + fall back,
+  none silently time out waiting; `get_queue_status` shows the `compute:local-inference` lane.
+
+## Not in this phase — BI-98572A51 (deferred with rationale)
+
+Unifying the two local-GPU serializers (chat HTTP inference vs the build orchestrator's local
+Opencode engine) is NOT shipped here. Routing a long-running build task (up to 30 min holding
+the GPU) and interactive chat inference through one lane is a **policy decision** — should chat
+wait behind a build, or get a busy signal and fall back to cloud? — that needs an operator/kernel
+call and a real load test, not an autonomous guess. The `ResourceLane` primitive this PR ships is
+exactly what that coordination will use once the policy is decided. Filed under EP-056D2A5E.


### PR DESCRIPTION
## Summary

**EP-3516E23D Phase 2 (BI-6112DDE0)** — the reusable **compute-admission primitive** the spec calls for, with the local-GPU inference path put on it: a bounded queue + **honest busy signal** (the root cause of the "both reviewers timed out" incident) and flow telemetry — **without changing default behavior**.

## What's in it

- **`lib/queue/resource-lane.ts`** — `ResourceLane`: a single-slot FIFO admission gate with (1) an optional **bounded queue depth** (over-cap ⇒ `LaneBusyError`, the honest busy signal) and (2) enqueued/started/finished **flow telemetry**. `getResourceLane(key)` shares one lane per resource key. **Unbounded + no telemetry by default ⇒ byte-for-byte the promise-chain serializer it replaces.**
- **`lib/routing/chat-adapter.ts`** — `withLocalInferenceLock` now delegates to the shared `compute:local-inference` lane. Bounded admission + telemetry are gated on `DPF_LOCAL_INFERENCE_MAX_QUEUE_DEPTH`: **unset ⇒ unbounded serialize, no per-inference DB writes** (identical to before); set ⇒ over-capacity calls get a `LaneBusyError` and fall back to a cloud provider (via the existing error path) instead of piling up and timing out, and lane wait/process time becomes measurable through `get_queue_status`.

## Verification

- 33 tests green — 12 new `resource-lane` (FIFO order, failure-doesn't-wedge, bounded reject, telemetry, singleton, config parsing) + the existing 21 `chat-adapter` tests **including the serialization contract, unchanged**; `tsc --noEmit` clean; module-size OK.

## Deferred with rationale — BI-98572A51

Unifying the two local-GPU serializers (chat HTTP inference vs the build orchestrator's local Opencode engine) is **not** shipped here. Routing a long-running build task (up to 30 min holding the GPU) and interactive chat through one lane is a **policy decision** — should chat wait behind a build, or get a busy signal and fall back to cloud? — that needs an operator/kernel call and a real load test, not an autonomous guess. The `ResourceLane` primitive this PR ships is exactly what that coordination will use once the policy is decided.

Plan: `docs/superpowers/plans/2026-07-06-compute-resource-lane-plan.md`
Spec: `docs/superpowers/specs/2026-07-06-reusable-queueing-substrate-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: The original commit passed the full local-CI sandbox gate (recorded). It was then rebased onto latest main (no content conflict — the branch was merely behind), and re-verified on the rebased tree: `tsc --noEmit` clean and 33 tests green (12 resource-lane + the unchanged chat-adapter serialization contract). The rebase carries no new code, so it rides on the original passing gate.
