### PR TITLE
fix(providers): dead OAuth sign-in link, stale expiry status, self-heal refresh on view (BI-2DD7042A)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -6,7 +6,8 @@ import { can } from "@/lib/permissions";
 import { getProviderById, getProviders, getDiscoveredModels, getModelProfiles, getRecipesForProvider, getModelClassCounts, getTokenSpendByProvider } from "@/lib/ai-provider-data";
 import { ProviderDetailForm } from "@/components/platform/ProviderDetailForm";
 import { ProviderCostSourcePanel } from "@/components/platform/ProviderCostSourcePanel";
-import { getInfraCIs } from "@dpf/db";
+import { getInfraCIs, prisma } from "@dpf/db";
+import { getProviderBearerToken } from "@/lib/inference/ai-provider-internals";
 import { getEndpointPerformance, getRoutingProfiles, getRecentRouteDecisions } from "@/lib/actions/endpoint-performance";
 import EndpointPerformancePanel from "@/components/platform/EndpointPerformancePanel";
 import RouteDecisionLog from "@/components/platform/RouteDecisionLog";
@@ -31,6 +32,27 @@ export default async function ProviderDetailPage({ params }: Props) {
   const { providerId } = await params;
   const now = new Date();
   const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+
+  // BI-2DD7042A: self-heal expired OAuth tokens on view. Token refresh is lazy —
+  // getProviderBearerToken refreshes only when a dispatch actually uses the
+  // provider — so a provider that sat idle or disabled lapses and this page used
+  // to demand a sign-in the operator doesn't need. Attempt the refresh here,
+  // BEFORE the cached data reads below, so the page renders the healed state.
+  // Best-effort: a failed refresh marks the credential "expired" and the UI
+  // falls back to the sign-in flow.
+  const oauthPeek = await prisma.modelProvider.findUnique({
+    where: { providerId },
+    select: { authMethod: true },
+  });
+  if (oauthPeek?.authMethod === "oauth2_authorization_code") {
+    const credPeek = await prisma.credentialEntry.findUnique({
+      where: { providerId },
+      select: { tokenExpiresAt: true, refreshToken: true },
+    });
+    if (credPeek?.refreshToken && credPeek.tokenExpiresAt && credPeek.tokenExpiresAt.getTime() <= now.getTime()) {
+      await getProviderBearerToken(providerId).catch(() => null);
+    }
+  }
   const [pw, models, profiles, allProviders, perfData, routingProfiles, routeDecisions, recipes, modelClassCounts, financeDetail, tokenSpend] = await Promise.all([
     getProviderById(providerId),
     getDiscoveredModels(providerId),

--- a/apps/web/components/platform/OAuthConnectionStatus.test.tsx
+++ b/apps/web/components/platform/OAuthConnectionStatus.test.tsx
@@ -1,0 +1,97 @@
+// BI-2DD7042A: the OAuth connection card used to (a) link its Sign in button to
+// /api/oauth/authorize/{providerId} — a route that has never existed → 404 —
+// and (b) demand a sign-in for any expired token even when a stored refresh
+// token means the platform heals itself on next use.
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { CredentialRow } from "@/lib/ai-provider-types";
+import { OAuthConnectionStatus } from "./OAuthConnectionStatus";
+
+vi.mock("@/lib/actions/provider-oauth", () => ({
+  startProviderOAuth: vi.fn(),
+}));
+
+function credentialFixture(overrides: Partial<CredentialRow> = {}): CredentialRow {
+  return {
+    providerId: "anthropic-sub",
+    secretHint: null,
+    clientId: null,
+    clientSecretHint: null,
+    tokenEndpoint: null,
+    scope: null,
+    status: "ok",
+    tokenExpiresAt: null,
+    hasRefreshToken: false,
+    ...overrides,
+  };
+}
+
+const HOUR = 60 * 60 * 1000;
+
+function render(credential: CredentialRow) {
+  return renderToStaticMarkup(
+    <OAuthConnectionStatus
+      credential={credential}
+      authMethod="oauth2_authorization_code"
+      authorizeUrl="https://claude.ai/oauth/authorize"
+      providerId="anthropic-sub"
+    />,
+  );
+}
+
+describe("OAuthConnectionStatus", () => {
+  it("renders a Sign in button wired to the server action, not the dead authorize URL", () => {
+    const html = render(credentialFixture({ status: "unconfigured" }));
+    expect(html).toContain("Sign in");
+    expect(html).toContain("<button");
+    // The old dead link — must never come back.
+    expect(html).not.toContain("/api/oauth/authorize");
+  });
+
+  it("says the token refreshes automatically when expired but a refresh token exists", () => {
+    const html = render(
+      credentialFixture({
+        tokenExpiresAt: new Date(Date.now() - 2 * HOUR).toISOString(),
+        hasRefreshToken: true,
+      }),
+    );
+    expect(html).toContain("refreshes automatically on next use");
+    expect(html).not.toContain("sign in again");
+    // Sign-in stays available as a fallback (refresh may be revoked upstream).
+    expect(html).toContain("Sign in");
+  });
+
+  it("demands a sign-in when expired with no refresh token", () => {
+    const html = render(
+      credentialFixture({
+        tokenExpiresAt: new Date(Date.now() - 2 * HOUR).toISOString(),
+        hasRefreshToken: false,
+      }),
+    );
+    expect(html).toContain("Token expired — sign in again");
+  });
+
+  it("shows Connected for a valid unexpired token", () => {
+    const html = render(
+      credentialFixture({
+        tokenExpiresAt: new Date(Date.now() + 24 * HOUR).toISOString(),
+        hasRefreshToken: true,
+      }),
+    );
+    expect(html).toContain("Connected");
+    expect(html).not.toContain("expired");
+  });
+
+  it("renders nothing for non-OAuth auth methods", () => {
+    const html = renderToStaticMarkup(
+      <OAuthConnectionStatus
+        credential={credentialFixture()}
+        authMethod="api_key"
+        authorizeUrl={null}
+        providerId="anthropic-sub"
+      />,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/components/platform/OAuthConnectionStatus.tsx
+++ b/apps/web/components/platform/OAuthConnectionStatus.tsx
@@ -1,7 +1,9 @@
 // apps/web/components/platform/OAuthConnectionStatus.tsx
 "use client";
 
+import { useState, useTransition } from "react";
 import type { CredentialRow } from "@/lib/ai-provider-types";
+import { startProviderOAuth } from "@/lib/actions/provider-oauth";
 
 function relativeTime(isoDate: string): string {
   const diff = new Date(isoDate).getTime() - Date.now();
@@ -26,12 +28,35 @@ type Props = {
 };
 
 export function OAuthConnectionStatus({ credential, authMethod, authorizeUrl, providerId }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [signInError, setSignInError] = useState<string | null>(null);
+
   if (authMethod !== "oauth2_authorization_code") return null;
 
   const isConnected = (credential.status === "configured" || credential.status === "ok") && credential.tokenExpiresAt;
   const isExpired = credential.tokenExpiresAt
     ? new Date(credential.tokenExpiresAt).getTime() < Date.now()
     : false;
+  // An expired access token with a stored refresh token is NOT an operator
+  // problem — getProviderBearerToken refreshes it on the next dispatch (and the
+  // provider detail page attempts it on view). Only demand a sign-in when there
+  // is no refresh token to heal with. (BI-2DD7042A)
+  const willSelfHeal = isExpired && credential.hasRefreshToken;
+
+  // BI-2DD7042A: this was previously an <a href="/api/oauth/authorize/…">,
+  // a route that never existed (404). The real flow is the startProviderOAuth
+  // server action — the same one ProviderDetailForm's sign-in button uses.
+  function handleSignIn() {
+    setSignInError(null);
+    startTransition(async () => {
+      const result = await startProviderOAuth(providerId);
+      if ("authorizeUrl" in result) {
+        window.open(result.authorizeUrl, "_self");
+      } else {
+        setSignInError(result.error);
+      }
+    });
+  }
 
   return (
     <div
@@ -63,9 +88,11 @@ export function OAuthConnectionStatus({ credential, authMethod, authorizeUrl, pr
         <span style={{ fontSize: 12, color: "var(--dpf-text)" }}>
           {isConnected && !isExpired
             ? `Connected · ${relativeTime(credential.tokenExpiresAt!)}`
-            : isExpired
-              ? "Token expired"
-              : "Not connected"}
+            : willSelfHeal
+              ? "Access token expired — refreshes automatically on next use"
+              : isExpired
+                ? "Token expired — sign in again"
+                : "Not connected"}
         </span>
 
         {/* Refresh token indicator */}
@@ -85,21 +112,32 @@ export function OAuthConnectionStatus({ credential, authMethod, authorizeUrl, pr
       </div>
 
       {/* Actions */}
-      <div style={{ display: "flex", gap: 8, marginTop: 10 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 10 }}>
         {(!isConnected || isExpired) && authorizeUrl && (
-          <a
-            href={`/api/oauth/authorize/${providerId}`}
-            style={{
-              fontSize: 11,
-              color: "var(--dpf-accent)",
-              padding: "4px 10px",
-              border: "1px solid var(--dpf-accent)",
-              borderRadius: 4,
-              textDecoration: "none",
-            }}
-          >
-            Sign in
-          </a>
+          <div>
+            <button
+              type="button"
+              onClick={handleSignIn}
+              disabled={isPending}
+              style={{
+                fontSize: 11,
+                color: "var(--dpf-accent)",
+                padding: "4px 10px",
+                border: "1px solid var(--dpf-accent)",
+                borderRadius: 4,
+                background: "transparent",
+                cursor: isPending ? "default" : "pointer",
+                opacity: isPending ? 0.5 : 1,
+              }}
+            >
+              {isPending ? "Redirecting…" : "Sign in"}
+            </button>
+          </div>
+        )}
+        {signInError && (
+          <div role="alert" style={{ fontSize: 11, color: "var(--dpf-error)" }}>
+            {signInError}
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/components/platform/ProviderDetailForm.test.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.test.tsx
@@ -90,4 +90,59 @@ describe("ProviderDetailForm", () => {
     expect(html).not.toContain("Discover &amp; Profile Models");
     expect(html).not.toContain("Advanced: model families");
   });
+
+  // BI-2DD7042A: connected/expired must be judged by the tokenExpiresAt
+  // timestamp, not the stored status enum. The enum only flips to "expired"
+  // when a refresh attempt FAILS — an idle provider's lapsed token kept
+  // status="ok", rendered green "Connected", and hid the working sign-in
+  // button while the OAuth card above said "Token expired".
+  const HOUR = 60 * 60 * 1000;
+  const oauthFixture = (tokenExpiresAt: string, hasRefreshToken: boolean): ProviderWithCredential => ({
+    provider: {
+      ...providerFixture.provider,
+      providerId: "anthropic-sub",
+      name: "Claude / Anthropic (OAuth Subscription)",
+      authMethod: "oauth2_authorization_code",
+      supportedAuthMethods: ["oauth2_authorization_code"],
+      authorizeUrl: "https://claude.ai/oauth/authorize",
+      tokenUrl: "https://platform.claude.com/v1/oauth/token",
+      oauthClientId: "client-id",
+    },
+    credential: {
+      ...providerFixture.credential!,
+      providerId: "anthropic-sub",
+      status: "ok",
+      tokenExpiresAt,
+      hasRefreshToken,
+    },
+  });
+
+  it("treats a timestamp-expired token as expired even when the status enum still says ok", () => {
+    const html = renderToStaticMarkup(
+      <ProviderDetailForm
+        pw={oauthFixture(new Date(Date.now() - 2 * HOUR).toISOString(), true)}
+        canWrite={true}
+        models={[]}
+        profiles={[]}
+        hasActiveProvider={true}
+      />,
+    );
+    expect(html).not.toContain("Connected · token expires");
+    expect(html).toContain("refreshes automatically on next use");
+    // The WORKING sign-in path (startProviderOAuth) must be reachable.
+    expect(html).toContain("Sign in with");
+  });
+
+  it("shows Connected for a valid unexpired OAuth token", () => {
+    const html = renderToStaticMarkup(
+      <ProviderDetailForm
+        pw={oauthFixture(new Date(Date.now() + 24 * HOUR).toISOString(), true)}
+        canWrite={true}
+        models={[]}
+        profiles={[]}
+        hasActiveProvider={true}
+      />,
+    );
+    expect(html).toContain("Connected · token expires");
+  });
 });

--- a/apps/web/components/platform/ProviderDetailForm.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.tsx
@@ -455,7 +455,13 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
 
       {selectedAuthMethod === "oauth2_authorization_code" && (
         <div style={{ marginBottom: 16 }}>
-          {credential?.status === "ok" && credential?.tokenExpiresAt ? (
+          {/* BI-2DD7042A: judge connected/expired by the tokenExpiresAt TIMESTAMP,
+              not the stored status enum — the enum only flips to "expired" when a
+              refresh attempt fails, so an idle provider's lapsed token used to
+              render green "Connected" here while the OAuth card above said
+              "Token expired", and the working sign-in button stayed hidden. */}
+          {credential?.status === "ok" && credential?.tokenExpiresAt &&
+           new Date(credential.tokenExpiresAt).getTime() > Date.now() ? (
             <div>
               <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                 <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--dpf-success)", display: "inline-block" }} />
@@ -503,10 +509,13 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
                 </button>
               )}
             </div>
-          ) : credential?.status === "expired" ? (
+          ) : credential?.status === "expired" ||
+              (credential?.tokenExpiresAt && new Date(credential.tokenExpiresAt).getTime() <= Date.now()) ? (
             <div>
               <div style={{ color: "var(--dpf-warning)", fontSize: 13, marginBottom: 8 }}>
-                Token expired — sign in again
+                {credential?.hasRefreshToken && credential?.status !== "expired"
+                  ? "Access token expired — it refreshes automatically on next use, or sign in again now"
+                  : "Token expired — sign in again"}
               </div>
               <button
                 type="button"


### PR DESCRIPTION
## Summary

Three defects on `/platform/ai/providers/[providerId]` for OAuth-subscription providers (observed live on `anthropic-sub`):

1. **Dead Sign in link (404).** `OAuthConnectionStatus`'s Sign in button linked to `/api/oauth/authorize/{providerId}` — a route that has never existed in the app. Rewired to the `startProviderOAuth` server action, the same working flow `ProviderDetailForm` uses.

2. **Expiry judged by stale enum.** `ProviderDetailForm` decided connected/expired from `CredentialEntry.status`, which only flips to `expired` when a refresh attempt *fails*. An idle provider's lapsed token kept `status=ok`, rendered green **Connected · token expires \<past date\>**, and hid the working sign-in button — while the OAuth card above said **Token expired**. Both cards now judge by the `tokenExpiresAt` timestamp.

3. **No self-heal.** Token refresh is lazy (`getProviderBearerToken` refreshes only when a dispatch uses the provider), so a provider that sat disabled lapsed and the UI demanded a sign-in the operator didn't need — a valid refresh token was present the whole time. The detail page now attempts the refresh server-side on view (best-effort; a failed refresh marks the credential `expired` and the UI falls back to sign-in), and both cards say *"refreshes automatically on next use"* instead of demanding re-auth when a refresh token exists.

## Test plan
- `OAuthConnectionStatus.test.tsx` (new): no dead `/api/oauth/authorize` href, button wired to server action, self-heal copy vs sign-in-demand copy vs Connected, non-OAuth renders nothing.
- `ProviderDetailForm.test.tsx`: timestamp-expired-but-status-ok renders expired state with the working sign-in button; unexpired renders Connected.
- All 8 pass locally; scoped typecheck green; local pregate CI gate passed.

UX-Fit-Decision: repairs broken/contradictory states on an existing surface; no new routes, tabs, or component families — reuses existing card/form patterns and the existing startProviderOAuth flow.

Backlog: BI-2DD7042A

🤖 Generated with [Claude Code](https://claude.com/claude-code)