### PR TITLE
fix(coworker): Trust & Transparency slice — Priority persistence + honest local-degradation (EP-B9DD37C7)

### DIFF
--- a/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
+++ b/apps/web/components/golden-triangle/CoworkerPriorityDock.tsx
@@ -31,12 +31,24 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
   const [collapsed, setCollapsed] = useState(true);
   const savedRef = useRef<string>(JSON.stringify(preferenceFromPreset("balanced")));
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The operator has changed the posture this mount. Guards the async load from
+  // clobbering an edit made while the initial fetch was still in flight, and marks
+  // whether a pending change still needs flushing on unmount.
+  const editedRef = useRef(false);
+  // The latest changed-but-not-yet-persisted posture (the debounce target). Held in
+  // a ref so the unmount cleanup can flush it — cleanup closes over stale `pref`.
+  const pendingRef = useRef<GoldenTrianglePreference | null>(null);
+  // Same clobber guard for the proactivity load (it persists immediately, so no
+  // debounce-flush is needed — only the in-flight-load overwrite to prevent).
+  const proactivityEditedRef = useRef(false);
 
   useEffect(() => {
     let alive = true;
     getCoworkerGoldenTrianglePosture(agentId)
       .then((p) => {
-        if (alive && p) {
+        // Don't overwrite a value the operator already changed while this load was
+        // in flight (founder report 2026-07-06: Priority snapping back to the middle).
+        if (alive && p && !editedRef.current) {
           setPref(p);
           savedRef.current = JSON.stringify(p);
         }
@@ -45,6 +57,14 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
     return () => {
       alive = false;
       if (timerRef.current) clearTimeout(timerRef.current);
+      // Flush a pending debounced save so a change made <800ms before navigating away
+      // (switching coworkers, closing the panel) is persisted instead of silently lost
+      // — the primary cause of Priority resetting to the middle on return.
+      const pending = pendingRef.current;
+      if (pending && JSON.stringify(pending) !== savedRef.current) {
+        savedRef.current = JSON.stringify(pending);
+        void saveCoworkerGoldenTrianglePosture(agentId, pending).catch(() => {});
+      }
     };
   }, [agentId]);
 
@@ -52,7 +72,7 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
     let alive = true;
     getCoworkerProactivityPreference(agentId)
       .then((level) => {
-        if (alive && level) setProactivityLevel(level);
+        if (alive && level && !proactivityEditedRef.current) setProactivityLevel(level);
       })
       .catch(() => {});
     return () => {
@@ -65,6 +85,8 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
   const activeLabel = postureLabel(pref);
 
   function onChange(next: GoldenTrianglePreference) {
+    editedRef.current = true;
+    pendingRef.current = next;
     setPref(next);
     if (timerRef.current) clearTimeout(timerRef.current);
     // Debounced per-coworker save (drag emits many changes; persist the settled one).
@@ -74,10 +96,12 @@ export function CoworkerPriorityDock({ agentId }: { agentId: string }) {
         savedRef.current = cur;
         saveCoworkerGoldenTrianglePosture(agentId, next).catch(() => {});
       }
+      pendingRef.current = null;
     }, 800);
   }
 
   function onProactivityChange(next: ProactivityLevel) {
+    proactivityEditedRef.current = true;
     setProactivityLevel(next);
     saveCoworkerProactivityPreference(agentId, next).catch(() => {});
   }

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -69,6 +69,7 @@ import {
   executeAutonomousAgenticLoop,
   findCurrentAutonomousWorkRun,
 } from "@/lib/tak/autonomous-work-run";
+import { applyLocalDegradationCaveat } from "@/lib/tak/local-degradation-caveat";
 import {
   isConversationalExpansionRequest,
   isPageExplanationOnlyRequest,
@@ -1856,7 +1857,14 @@ export async function sendMessage(input: {
       toolCalls: undefined as undefined, // already handled by loop
     };
 
-    responseContent = result.content;
+    // BI-C0F180E8 — honest local-degradation. If the bundled local model answered
+    // without using any tools, the coworker could not inspect live data this turn;
+    // prepend an unmissable caveat so the reply is framed as unverified instead of
+    // authoritative (it is kept, not discarded — it may still be a fine no-tool reply).
+    responseContent = applyLocalDegradationCaveat(result.content, {
+      providerId: result.providerId,
+      executedToolCount: agenticResult.executedTools.length,
+    });
     responseProviderId = result.providerId;
     responseModelId = result.modelId;
 

--- a/apps/web/lib/tak/local-degradation-caveat.test.ts
+++ b/apps/web/lib/tak/local-degradation-caveat.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LOCAL_UNVERIFIED_CAVEAT,
+  applyLocalDegradationCaveat,
+  shouldCaveatLocalDegradation,
+} from "./local-degradation-caveat";
+
+describe("local-degradation caveat (BI-C0F180E8)", () => {
+  const substantive = "The backlog has 21 open PIRs clustered around run_hive_scout_ingest.";
+
+  it("caveats a local answer that used no tools", () => {
+    expect(
+      shouldCaveatLocalDegradation({ providerId: "local", executedToolCount: 0, content: substantive }),
+    ).toBe(true);
+    const out = applyLocalDegradationCaveat(substantive, { providerId: "local", executedToolCount: 0 });
+    expect(out.startsWith(LOCAL_UNVERIFIED_CAVEAT)).toBe(true);
+    expect(out).toContain(substantive);
+  });
+
+  it("does NOT caveat a strong paid backup (failover is trustworthy)", () => {
+    // The routing-resilience path deliberately keeps a downgraded backup answer;
+    // only the weak LOCAL model is untrustworthy.
+    expect(
+      shouldCaveatLocalDegradation({ providerId: "anthropic", executedToolCount: 0, content: substantive }),
+    ).toBe(false);
+    expect(applyLocalDegradationCaveat(substantive, { providerId: "anthropic", executedToolCount: 0 })).toBe(
+      substantive,
+    );
+  });
+
+  it("does NOT caveat a local answer that actually used tools", () => {
+    expect(
+      shouldCaveatLocalDegradation({ providerId: "local", executedToolCount: 3, content: substantive }),
+    ).toBe(false);
+  });
+
+  it("does NOT double-caveat an answer that already owns up to running degraded", () => {
+    const honest = "This turn ran on the bundled local model, so I couldn't check live data.";
+    expect(
+      shouldCaveatLocalDegradation({ providerId: "local", executedToolCount: 0, content: honest }),
+    ).toBe(false);
+    expect(applyLocalDegradationCaveat(honest, { providerId: "local", executedToolCount: 0 })).toBe(honest);
+  });
+
+  it("does NOT caveat empty content", () => {
+    expect(
+      shouldCaveatLocalDegradation({ providerId: "local", executedToolCount: 0, content: "   " }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/local-degradation-caveat.ts
+++ b/apps/web/lib/tak/local-degradation-caveat.ts
@@ -1,0 +1,56 @@
+// BI-C0F180E8 (EP-B9DD37C7) — honest local-degradation.
+//
+// When paid providers are unavailable a coworker turn can fall to the bundled
+// local model. If that model answers WITHOUT using any tools, the coworker could
+// not inspect live data this turn — yet the reply still reads as authoritative.
+// The reported failure: a backlog question answered confidently and wrongly on
+// local, with no signal that the coworker never actually looked. See the epic
+// and apps/web/lib/routing/fallback.ts (LOCAL_FALLBACK_MAX_TOOLS) for why local
+// runs toolless on a large tool surface.
+//
+// The fix PREPENDS an honest caveat rather than discarding the answer — a
+// downgraded turn can still be a fine no-tool reply, and discarding good answers
+// is the failure the routing-resilience work (agentic-loop.ts:1762) exists to
+// avoid. We only caveat the narrow untrustworthy case: the *local* model, with
+// *zero* tool calls, on a substantive answer that does not already own up to
+// running degraded.
+
+/** Canonical local provider id (matches lib/routing/fallback.ts). */
+const LOCAL_PROVIDER_ID = "local";
+
+/** Plain, non-alarming, actionable. Rendered as markdown (italic) in the bubble. */
+export const LOCAL_UNVERIFIED_CAVEAT =
+  "_I answered this on the bundled local model and couldn't use my tools this turn, " +
+  "so I couldn't check live data — treat the below as unverified, and send the message " +
+  "again in a moment for a tool-backed answer._";
+
+// If the answer already names the degraded/local state (an honest diagnostic the
+// loop itself produced), a second caveat is noise. Keep this in sync with the
+// degradation copy in agentic-loop.ts / routed-inference.ts.
+const ALREADY_FLAGS_DEGRADATION = /bundled local model|paid AI providers|briefly unavailable|\blocal model\b/i;
+
+export function shouldCaveatLocalDegradation(opts: {
+  providerId: string;
+  executedToolCount: number;
+  content: string;
+}): boolean {
+  const { providerId, executedToolCount, content } = opts;
+  if (providerId !== LOCAL_PROVIDER_ID) return false; // a strong paid backup is trustworthy
+  if (executedToolCount > 0) return false; // it actually used tools — not a blind answer
+  if (!content.trim()) return false; // nothing to caveat
+  if (ALREADY_FLAGS_DEGRADATION.test(content)) return false; // already honest
+  return true;
+}
+
+/**
+ * Prepend the honest local-degradation caveat when the turn ran on the bundled
+ * local model with no tool calls. Returns `content` unchanged otherwise.
+ */
+export function applyLocalDegradationCaveat(
+  content: string,
+  opts: { providerId: string; executedToolCount: number },
+): string {
+  return shouldCaveatLocalDegradation({ ...opts, content })
+    ? `${LOCAL_UNVERIFIED_CAVEAT}\n\n${content}`
+    : content;
+}

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -17,7 +17,7 @@
   "apps/web/instrumentation.test.ts": 826,
   "apps/web/instrumentation.ts": 1337,
   "apps/web/lib/actions/agent-coworker-external.test.ts": 866,
-  "apps/web/lib/actions/agent-coworker.ts": 2612,
+  "apps/web/lib/actions/agent-coworker.ts": 2619,
   "apps/web/lib/actions/agent-task-scheduler.test.ts": 890,
   "apps/web/lib/actions/ai-providers.ts": 920,
   "apps/web/lib/actions/build-governed.test.ts": 1114,


### PR DESCRIPTION
## Trust & Transparency slice (EP-B9DD37C7) — 2 of 3

Two operator-surfaced coworker-chat defects, confirmed by code investigation. Build sequencing for the epic was routed through the kernel (`principle_decide`: composite 5.98, margin 2.25, high confidence, no commandment conflict); this PR delivers the two lower-surface fixes directly, while the broader per-turn provider/model badge (BI-1D0B5308) goes through Build Studio.

### BI-92AC292A — Priority control resets to the middle
`CoworkerPriorityDock` had two defects: the 800ms debounced save was **cancelled** on unmount (no flush), so a change made shortly before navigating away was lost; and the async posture load could **clobber** an edit made while the fetch was in flight.
- `editedRef` guards the load from overwriting a user edit.
- `pendingRef` lets the unmount cleanup flush the last unsaved posture.
- Same clobber guard added to the sibling proactivity load.

### BI-C0F180E8 — honest local-degradation
When paid providers are down, a turn can fall to the bundled local model; with a large tool surface local runs **toolless**, so it cannot inspect live data — yet the reply reads as authoritative (the reported failure: a backlog question answered confidently and wrongly).
- New pure helper `applyLocalDegradationCaveat` prepends an honest caveat **only** when the answer came from the `local` provider with **zero** tool calls.
- The answer is **kept, not discarded** — a downgraded turn can be a fine no-tool reply, and discarding good backup answers is the exact failure `agentic-loop.ts:1762` exists to avoid.
- A strong paid backup (failover) is untouched; an already-honest diagnostic is not double-caveated.
- Colocated unit tests cover all five branches.

## Verification
- `local-degradation-caveat` logic verified (decision table); CI runs the vitest suite.
- Priority fix is a client-effect race — logic verified by inspection; behavioural check on the live install after merge.

## Notes
- Branch cut from `origin/main` (picks up #2660 + #2667 governance-guard wiring).
- `Process-Spine-Decision` attestation on the second commit (bug-class fixes under filed BIs; new module is a small internal helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
