### PR TITLE
fix(build): gate Build Studio local engine on runtime presence, not bakeInDefault (BI-9394E7C5)

### DIFF
--- a/apps/web/lib/build/build-studio-capability-db.test.ts
+++ b/apps/web/lib/build/build-studio-capability-db.test.ts
@@ -136,4 +136,30 @@ describe("loadBuildStudioCapability", () => {
       expect(result.reason).toBe("only_local_provider_active");
     }
   });
+
+  it("keeps the gate closed when opencode is bakeInDefault but NOT actually present (image drift → BI-9394E7C5)", async () => {
+    // The exact failure that hard-crashes builds at exit 127: the engine is
+    // marked baked-in-by-default, but its binary is missing from the image.
+    // Availability must follow runtime presence, not the config-intent flag.
+    mockModelProfileFindMany.mockResolvedValue([
+      {
+        providerId: "local",
+        modelId: "docker.io/ai/qwen3-coder:latest",
+        supportsToolUse: false,
+        maxInputTokens: null,
+        provider: { name: "Docker Model Runner (local)" },
+      },
+    ] as unknown as Awaited<ReturnType<typeof prisma.modelProfile.findMany>>);
+    mockBuildEngineFindFirst.mockResolvedValue(
+      { bakeInDefault: true, state: { present: false } } as unknown as Awaited<
+        ReturnType<typeof prisma.buildEngine.findFirst>
+      >,
+    );
+
+    const result = await loadBuildStudioCapability();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("only_local_provider_active");
+    }
+  });
 });

--- a/apps/web/lib/build/build-studio-capability.ts
+++ b/apps/web/lib/build/build-studio-capability.ts
@@ -235,15 +235,22 @@ export async function loadBuildStudioCapability(): Promise<BuildStudioCapability
     }),
     // The opencode build engine — the deterministic tool-calling runner that
     // makes a local model viable for Build Studio. "Available" = its binary is
-    // present in the sandbox (probed) OR it is baked into the image by default.
+    // actually PRESENT in the sandbox (probed at boot). We deliberately do NOT
+    // trust bakeInDefault here: that flag is config *intent* ("this engine should
+    // be baked into the image"), not runtime *fact*. When an image drifts and a
+    // bakeInDefault engine is missing (opencode absent → `which opencode` fails),
+    // trusting the flag opens the gate, the orchestrator dispatches to a binary
+    // that isn't there, and the build hard-fails at deps_installed with exit 127
+    // instead of degrading to a present cloud engine. Gate on presence so a
+    // missing engine closes the local gate and builds fall back gracefully.
+    // (BI-9394E7C5 — evidence over config-intent.)
     prisma.buildEngine.findFirst({
       where: { engineId: "opencode" },
       select: { bakeInDefault: true, state: { select: { present: true } } },
     }),
   ]);
 
-  const localBuildEngineAvailable =
-    !!localEngine && (localEngine.state?.present === true || localEngine.bakeInDefault === true);
+  const localBuildEngineAvailable = localEngine?.state?.present === true;
 
   const models: ActiveProviderModel[] = profiles.map((p) => ({
     providerId: p.providerId,


### PR DESCRIPTION
## Summary

**BI-9394E7C5** — Build Studio hard-fails at `deps_installed` with `OpenCode dispatch failed: Exit code 127` whenever the `opencode` engine is marked `bakeInDefault` but its binary is absent from the sandbox image (image drift). This blocks **every local-engine build**.

`build-studio-capability.ts` computed `localBuildEngineAvailable = present===true || bakeInDefault===true`, so a baked-in-**by-default**-but-**missing** engine opened the local-model gate; the orchestrator then dispatched to a binary that isn't there instead of degrading to a present cloud engine (codex/grok were present the whole time).

## Fix

Availability follows **runtime presence only** (`state?.present === true`). `bakeInDefault` is config *intent*, not runtime *fact* — trusting it turns a missing engine into a crash rather than a graceful cloud fallback. Adds the missing regression test: `bakeInDefault:true + present:false → gate closed`.

## Verification

- 25 capability tests green (incl. the new drift case); `tsc --noEmit` clean; local-CI gate passed.

## Context

Discovered while tending Build Studio (its one active build, FB-673BF54B, was failing all session on this). Root infra — the `opencode` binary genuinely missing from this install's image (`which opencode` fails; `/opt/dpf-engines/opencode` absent) — is tracked in **BI-9394E7C5**. A live-DB mitigation (`build_engine.bakeInDefault=false` for opencode) was applied to unblock builds immediately; this code fix makes the gate robust so config drift can't cause the crash again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)