### PR TITLE
feat(work-capsules): claim-at-start binds a BI to its work-location (BI-7D20BFDF)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -897,6 +897,9 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
       properties: {
         provider: { type: "string", description: "External development provider, for example claude, codex, or grok" },
         externalSessionId: { type: "string", description: "External thread/session/capsule identifier" },
+        backlogItemId: { type: "string", description: "Optional BI-* to bind the captured Work Capsule to, even without a build (closes the direct-agent binding gap)" },
+        worktreePath: { type: "string", description: "Optional local worktree path — when given with branchName the capsule also records the work location" },
+        branchName: { type: "string", description: "Optional branch (head) for this work — pairs with worktreePath to bind location" },
         buildId: { type: "string", description: "Optional FB-* build id" },
         taskRunId: { type: "string", description: "Optional TaskRun id" },
         routeContext: { type: "string", description: "Route context where the work belongs, usually /build" },
@@ -6568,6 +6571,9 @@ export async function executeTool(
           provider,
           summary,
           actor: { userId, agentId: context?.agentId ?? null, principalId: null },
+          backlogItemId: stringValue("backlogItemId") || null,
+          worktreePath: stringValue("worktreePath") || null,
+          branchName: stringValue("branchName") || null,
         });
       } catch (captureError) {
         console.warn(

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -131,6 +131,26 @@ const definitions: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "claim_backlog_item_for_work",
+    description:
+      "Claim a BacklogItem for work by binding it to the worktree + branch + session you are starting in (soft claim-at-start). Creates or reuses+late-binds the WorkCapsule for the branch and stamps the BI claim so a directly-working agent's BI no longer looks unclaimed to a parallel session. Advisory, NOT a lock: if the BI already has active work elsewhere the call still binds this location but returns a non-blocking conflict — it does not steal the existing claim. Multiple branches per BI are expected and are not a conflict.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "BacklogItem id (BI-*) to claim." },
+        worktreePath: { type: "string", description: "Local worktree path where the work is happening." },
+        branchName: { type: "string", description: "Branch (head) for this work — the capsule is keyed on (repo, branch)." },
+        repositoryFullName: { type: "string", description: "Optional GitHub repository full name; defaults to the platform repo." },
+        baseBranch: { type: "string", description: "Optional base branch (defaults to main)." },
+        provider: { type: "string", description: "Provider string (claude, codex, grok) — mapped to the closest executor kind." },
+        sessionRef: { type: "string", description: "Owner/session id, stored as the capsule executorRef." },
+      },
+      required: ["itemId", "worktreePath", "branchName", "provider", "sessionRef"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
     name: "claim_capsule_scope",
     description: "Claim path/module/package/route/skill/prompt scope for a Work Capsule. Repeated claims refresh the existing scope entry. Rejected with error=scope_conflict if another active Work Capsule already holds an overlapping edit claim — coordinate, claim different scope, or pass force=true to deliberately co-claim.",
     inputSchema: {
@@ -244,6 +264,7 @@ export const workCapsulesPack: ToolPack = {
     create_work_capsule: (params, userId, context) => HANDLERS().then((m) => m.createWorkCapsuleTool(params, userId, context)),
     plan_capsule_worktree: (params, userId, context) => HANDLERS().then((m) => m.planCapsuleWorktreeTool(params, userId, context)),
     adopt_worktree: (params, userId, context) => HANDLERS().then((m) => m.adoptWorktreeTool(params, userId, context)),
+    claim_backlog_item_for_work: (params, userId, context) => HANDLERS().then((m) => m.claimBacklogItemForWorkTool(params, userId, context)),
     claim_capsule_scope: (params, userId, context) => HANDLERS().then((m) => m.claimCapsuleScopeTool(params, userId, context)),
     heartbeat_capsule: (params, userId, context) => HANDLERS().then((m) => m.heartbeatCapsuleTool(params, userId, context)),
     update_work_capsule_status: (params, userId, context) => HANDLERS().then((m) => m.updateWorkCapsuleStatusTool(params, userId, context)),
@@ -256,6 +277,7 @@ export const workCapsulesPack: ToolPack = {
     create_work_capsule: ["work_capsule_write"],
     plan_capsule_worktree: ["work_capsule_write"],
     adopt_worktree: ["work_capsule_adopt"],
+    claim_backlog_item_for_work: ["work_capsule_adopt"],
     claim_capsule_scope: ["work_capsule_write"],
     heartbeat_capsule: ["work_capsule_write"],
     update_work_capsule_status: ["work_capsule_write"],

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -180,6 +180,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   create_work_capsule: ["work_capsule_write"],
   plan_capsule_worktree: ["work_capsule_write"],
   adopt_worktree: ["work_capsule_adopt"],
+  claim_backlog_item_for_work: ["work_capsule_adopt"],
   claim_capsule_scope: ["work_capsule_write"],
   record_capsule_evidence: ["work_capsule_write"],
   heartbeat_capsule: ["work_capsule_write"],

--- a/apps/web/lib/work-capsules/external-session-capture.ts
+++ b/apps/web/lib/work-capsules/external-session-capture.ts
@@ -10,6 +10,7 @@
 // best-effort so it never blocks the evidence write.
 
 import {
+  adoptWorktreeCapsule,
   createWorkCapsule,
   recordWorkCapsuleEvidence,
   type CapsuleDb,
@@ -43,24 +44,66 @@ export async function captureExternalSessionEvidence(args: {
   provider: string;
   summary: string;
   actor: WorkCapsuleActor;
+  /**
+   * BI-7D20BFDF: bind the direct-agent evidence record to a BacklogItem even
+   * without a buildId (the "direct-agent gap"). When worktreePath + branchName
+   * are also supplied we prefer the adopt path so the capsule carries the
+   * location too (BI ↔ work-location binding); otherwise the BI is bound on the
+   * createWorkCapsule path.
+   */
+  backlogItemId?: string | null;
+  worktreePath?: string | null;
+  branchName?: string | null;
+  repositoryFullName?: string | null;
+  baseBranch?: string | null;
 }): Promise<string> {
   const idempotencyKey = `external-session:${args.externalSessionId}`;
   const objective =
     args.summary.trim().slice(0, 500)
     || `External ${args.provider} development session`;
+  const title = `${providerLabel(args.provider)} session ${args.externalSessionId}`.slice(0, 120);
+  const backlogItemId = args.backlogItemId?.trim() || null;
+  const worktreePath = args.worktreePath?.trim() || null;
+  const branchName = args.branchName?.trim() || null;
 
-  const capsule = await createWorkCapsule({
-    db: args.db,
-    input: {
-      title: `${providerLabel(args.provider)} session ${args.externalSessionId}`.slice(0, 120),
-      objective,
-      source: "external-adoption",
-      executorKind: providerToExecutorKind(args.provider),
-      executorRef: args.externalSessionId,
-      idempotencyKey,
-    },
-    actor: args.actor,
-  });
+  // Prefer the adopt path when we have a location: it keys the capsule on
+  // (repo, branch) so the session's BI, worktree, and branch are one record —
+  // and late-binds the BI if the branch was already adopted without one.
+  let capsule;
+  if (worktreePath && branchName) {
+    capsule = await adoptWorktreeCapsule({
+      db: args.db,
+      input: {
+        title,
+        objective,
+        repositoryFullName:
+          args.repositoryFullName?.trim() ||
+          process.env.DPF_REPO_FULL_NAME?.trim() ||
+          "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: branchName,
+        worktreePath,
+        baseBranch: args.baseBranch?.trim() || "main",
+        executorKind: providerToExecutorKind(args.provider),
+        executorRef: args.externalSessionId,
+        backlogItemId,
+      },
+      actor: args.actor,
+    });
+  } else {
+    capsule = await createWorkCapsule({
+      db: args.db,
+      input: {
+        title,
+        objective,
+        source: "external-adoption",
+        executorKind: providerToExecutorKind(args.provider),
+        executorRef: args.externalSessionId,
+        idempotencyKey,
+        backlogItemId,
+      },
+      actor: args.actor,
+    });
+  }
 
   await recordWorkCapsuleEvidence({
     db: args.db,

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -27,6 +27,7 @@ import {
 
 import {
   adoptWorktreeCapsule,
+  claimBacklogItemWorkspace,
   claimWorkCapsuleScope,
   createWorkCapsule,
   heartbeatWorkCapsule,
@@ -39,6 +40,7 @@ import {
   type WorkCapsuleActor,
 } from "./work-capsule-store";
 import { listLocalBranches } from "./git-scanner";
+import { providerToExecutorKind } from "./external-session-capture";
 
 type ToolContext = {
   routeContext?: string;
@@ -330,6 +332,84 @@ export async function adoptWorktreeTool(
     message: `Adopted ${headBranch} as Work Capsule ${capsule.capsuleId}.`,
     data: { capsule },
   };
+}
+
+export async function claimBacklogItemForWorkTool(
+  params: Record<string, unknown>,
+  userId: string,
+  context: ToolContext,
+): Promise<ToolResult> {
+  const itemId = stringParam(params, "itemId");
+  const worktreePath = stringParam(params, "worktreePath");
+  const branchName = stringParam(params, "branchName");
+  const provider = stringParam(params, "provider");
+  const sessionRef = stringParam(params, "sessionRef");
+
+  if (!itemId || !worktreePath || !branchName || !provider || !sessionRef) {
+    return {
+      success: false,
+      error: "invalid_input",
+      message: "itemId, worktreePath, branchName, provider, and sessionRef are required.",
+    };
+  }
+
+  const repositoryFullName =
+    stringParam(params, "repositoryFullName") ??
+    process.env.DPF_REPO_FULL_NAME?.trim() ??
+    "OpenDigitalProductFactory/opendigitalproductfactory";
+  const baseBranch = stringParam(params, "baseBranch") ?? "main";
+  const executorKind = providerToExecutorKind(provider);
+
+  try {
+    const result = await claimBacklogItemWorkspace({
+      db: workCapsuleDb(),
+      input: {
+        backlogItemId: itemId,
+        repositoryFullName,
+        headBranch: branchName,
+        worktreePath,
+        baseBranch,
+        executorKind,
+        executorRef: sessionRef,
+      },
+      actor: await actor(userId, context),
+    });
+
+    const base = `Bound ${result.backlogItemId} to ${result.headBranch} (${result.capsuleId}).`;
+    let message: string;
+    if (result.conflict) {
+      const parts: string[] = [];
+      if (result.conflict.backlogClaim) {
+        const age = result.conflict.backlogClaim.claimAgeMinutes;
+        parts.push(
+          `${result.backlogItemId} already has an ACTIVE claim by another session` +
+            (age != null ? ` (${age}m ago)` : "") +
+            " — this call did NOT steal it",
+        );
+      }
+      for (const loc of result.conflict.otherLocations) {
+        parts.push(`also in flight on ${loc.headBranch ?? "?"} (${loc.capsuleId})`);
+      }
+      message =
+        `${base} ADVISORY: ${result.backlogItemId} already has active work elsewhere — ${parts.join("; ")}. ` +
+        "Claim-at-start is a soft signal, not a lock: coordinate with the other session before pushing.";
+    } else {
+      message = `${base} Claim-at-start recorded for this session.`;
+    }
+
+    return {
+      success: true,
+      entityId: result.capsuleId,
+      message,
+      data: result,
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "Unknown failure";
+    if (/not found/i.test(detail)) {
+      return { success: false, error: "not_found", message: detail };
+    }
+    throw error;
+  }
 }
 
 export async function claimCapsuleScopeTool(

--- a/apps/web/lib/work-capsules/work-capsule-store.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/portal-context/invalidation", () => ({
 
 import {
   adoptWorktreeCapsule,
+  claimBacklogItemWorkspace,
   claimWorkCapsuleScope,
   createWorkCapsule,
   detectScopeConflicts,
@@ -28,6 +29,10 @@ const db = {
   workCapsuleActivity: {
     create: vi.fn(),
   },
+  backlogItem: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+  },
   $transaction: vi.fn(async (fn: (tx: typeof db) => Promise<unknown>) => fn(db)),
 };
 const mockRevalidatePortalContext = revalidatePortalContext as ReturnType<typeof vi.fn>;
@@ -39,6 +44,8 @@ function resetDbMocks() {
   db.workCapsule.findMany.mockReset();
   db.workCapsule.update.mockReset();
   db.workCapsuleActivity.create.mockReset();
+  db.backlogItem.findFirst.mockReset();
+  db.backlogItem.update.mockReset();
   db.$transaction.mockReset();
   db.$transaction.mockImplementation(async (fn: (tx: typeof db) => Promise<unknown>) => fn(db));
   mockRevalidatePortalContext.mockReset();
@@ -473,6 +480,275 @@ describe("work capsule store", () => {
       });
 
       expect(result.headBranch).toBe("feat/owned-elsewhere-2");
+    });
+  });
+
+  describe("adoptWorktreeCapsule backlog binding", () => {
+    it("persists backlogItemId + epicId on a fresh adoption", async () => {
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+      db.workCapsule.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-BOUND01" });
+
+      const result = await adoptWorktreeCapsule({
+        db: capsuleDb(),
+        input: {
+          title: "Bound branch",
+          objective: "Work an item.",
+          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+          headBranch: "feat/bound",
+          worktreePath: "D:/DPF-bound",
+          backlogItemId: "BI-7D20BFDF",
+          epicId: "EP-XYZ",
+          executorRef: "session-1",
+        },
+        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+      });
+
+      expect(result.capsuleId).toBe("WC-BOUND01");
+      expect(db.workCapsule.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          backlogItemId: "BI-7D20BFDF",
+          epicId: "EP-XYZ",
+          executorRef: "session-1",
+        }),
+      }));
+    });
+
+    it("late-binds backlogItemId onto an existing capsule that had none", async () => {
+      db.workCapsule.findFirst.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-EXISTING",
+        backlogItemId: null,
+        epicId: null,
+        executorRef: null,
+      });
+      db.workCapsule.update.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-EXISTING",
+        backlogItemId: "BI-7D20BFDF",
+      });
+
+      const result = await adoptWorktreeCapsule({
+        db: capsuleDb(),
+        input: {
+          title: "Reuse",
+          objective: "Reuse existing branch.",
+          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+          headBranch: "feat/existing",
+          worktreePath: "D:/DPF-existing",
+          backlogItemId: "BI-7D20BFDF",
+        },
+        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+      });
+
+      expect(result.capsuleId).toBe("WC-EXISTING");
+      expect(db.workCapsule.create).not.toHaveBeenCalled();
+      expect(db.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({ backlogItemId: "BI-7D20BFDF" }),
+      }));
+      expect(db.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({ kind: "adopted", payload: expect.objectContaining({ lateBind: true }) }),
+      }));
+    });
+
+    it("does not late-bind (or write) when the existing capsule already has a backlogItemId", async () => {
+      db.workCapsule.findFirst.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-EXISTING",
+        backlogItemId: "BI-ALREADY",
+        epicId: null,
+        executorRef: null,
+      });
+
+      const result = await adoptWorktreeCapsule({
+        db: capsuleDb(),
+        input: {
+          title: "Reuse",
+          objective: "Reuse existing branch.",
+          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+          headBranch: "feat/existing",
+          worktreePath: "D:/DPF-existing",
+          backlogItemId: "BI-7D20BFDF",
+        },
+        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+      });
+
+      expect(result.backlogItemId).toBe("BI-ALREADY");
+      expect(db.workCapsule.update).not.toHaveBeenCalled();
+      expect(db.workCapsule.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("claimBacklogItemWorkspace", () => {
+    const baseInput = {
+      backlogItemId: "BI-7D20BFDF",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      headBranch: "feat/bi-work-location-claim",
+      worktreePath: "/Users/mark/dpf-wt/bi-work-location",
+      executorKind: "codex-desktop" as const,
+      executorRef: "session-A",
+    };
+    const actor = { userId: "user-1", agentId: "agent-1", principalId: "PRN-1" };
+
+    it("throws a clear error when the BacklogItem does not exist", async () => {
+      db.backlogItem.findFirst.mockResolvedValueOnce(null);
+      await expect(
+        claimBacklogItemWorkspace({ db: capsuleDb(), input: baseInput, actor }),
+      ).rejects.toThrow(/BI-7D20BFDF not found/i);
+    });
+
+    it("binds the capsule and stamps the BI claim when unclaimed", async () => {
+      db.backlogItem.findFirst.mockResolvedValueOnce({
+        id: "bi-row-1",
+        itemId: "BI-7D20BFDF",
+        epicId: "EP-1",
+        claimStatus: null,
+        claimedById: null,
+        claimedByAgentId: null,
+        claimedAt: null,
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce(null); // adopt: no existing
+      db.workCapsule.create.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-CLAIM01",
+        headBranch: baseInput.headBranch,
+        worktreePath: baseInput.worktreePath,
+      });
+      db.workCapsule.findMany.mockResolvedValueOnce([]); // no other locations
+      db.backlogItem.update.mockResolvedValueOnce({ id: "bi-row-1" });
+
+      const result = await claimBacklogItemWorkspace({ db: capsuleDb(), input: baseInput, actor });
+
+      expect(result.capsuleId).toBe("WC-CLAIM01");
+      expect(result.claimed).toBe(true);
+      expect(result.conflict).toBeNull();
+      expect(db.backlogItem.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          claimStatus: "active",
+          claimedById: "user-1",
+          claimedByAgentId: "agent-1",
+        }),
+      }));
+    });
+
+    it("returns a non-blocking conflict and does NOT overwrite a fresh claim held by another agent", async () => {
+      const now = new Date("2026-07-06T12:00:00.000Z");
+      db.backlogItem.findFirst.mockResolvedValueOnce({
+        id: "bi-row-1",
+        itemId: "BI-7D20BFDF",
+        epicId: null,
+        claimStatus: "active",
+        claimedById: "other-user",
+        claimedByAgentId: "other-agent",
+        claimedAt: new Date(now.getTime() - 60 * 60 * 1000), // 1h ago = fresh
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+      db.workCapsule.create.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-CLAIM02",
+        headBranch: baseInput.headBranch,
+        worktreePath: baseInput.worktreePath,
+      });
+      db.workCapsule.findMany.mockResolvedValueOnce([]);
+
+      const result = await claimBacklogItemWorkspace({ db: capsuleDb(), input: baseInput, actor, now });
+
+      // Capsule still bound (soft claim), but the BI claim is untouched.
+      expect(result.capsuleId).toBe("WC-CLAIM02");
+      expect(result.claimed).toBe(false);
+      expect(db.backlogItem.update).not.toHaveBeenCalled();
+      expect(result.conflict?.backlogClaim).toMatchObject({
+        claimedByAgentId: "other-agent",
+        claimAgeMinutes: 60,
+      });
+    });
+
+    it("reclaims a STALE (>12h) claim held by another agent", async () => {
+      const now = new Date("2026-07-06T12:00:00.000Z");
+      db.backlogItem.findFirst.mockResolvedValueOnce({
+        id: "bi-row-1",
+        itemId: "BI-7D20BFDF",
+        epicId: null,
+        claimStatus: "active",
+        claimedById: "other-user",
+        claimedByAgentId: "other-agent",
+        claimedAt: new Date(now.getTime() - 13 * 60 * 60 * 1000), // 13h ago = stale
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+      db.workCapsule.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-CLAIM03" });
+      db.workCapsule.findMany.mockResolvedValueOnce([]);
+      db.backlogItem.update.mockResolvedValueOnce({ id: "bi-row-1" });
+
+      const result = await claimBacklogItemWorkspace({ db: capsuleDb(), input: baseInput, actor, now });
+
+      expect(result.claimed).toBe(true);
+      expect(result.conflict).toBeNull();
+      expect(db.backlogItem.update).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows a second capsule on a different branch for the same BI without a blocking claim conflict", async () => {
+      db.backlogItem.findFirst.mockResolvedValueOnce({
+        id: "bi-row-1",
+        itemId: "BI-7D20BFDF",
+        epicId: null,
+        claimStatus: null,
+        claimedById: null,
+        claimedByAgentId: null,
+        claimedAt: null,
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+      db.workCapsule.create.mockResolvedValueOnce({
+        id: "row-2",
+        capsuleId: "WC-CLAIM-B",
+        headBranch: "feat/second-branch",
+      });
+      // Another capsule already exists on a DIFFERENT branch for the same BI.
+      db.workCapsule.findMany.mockResolvedValueOnce([
+        { capsuleId: "WC-CLAIM-A", headBranch: "feat/first-branch", worktreePath: "/wt/a", executorRef: "session-B", leaseHolderPrincipalId: "PRN-2" },
+      ]);
+      db.backlogItem.update.mockResolvedValueOnce({ id: "bi-row-1" });
+
+      const result = await claimBacklogItemWorkspace({
+        db: capsuleDb(),
+        input: { ...baseInput, headBranch: "feat/second-branch" },
+        actor,
+      });
+
+      // The second branch still claims the BI (no other fresh BI claim) and binds,
+      // but the other in-flight location is surfaced as advisory conflict metadata.
+      expect(result.claimed).toBe(true);
+      expect(result.conflict?.backlogClaim).toBeNull();
+      expect(result.conflict?.otherLocations).toHaveLength(1);
+      expect(result.conflict?.otherLocations[0]?.capsuleId).toBe("WC-CLAIM-A");
+    });
+
+    it("is idempotent: reusing the same branch returns the existing capsule (no duplicate create)", async () => {
+      db.backlogItem.findFirst.mockResolvedValueOnce({
+        id: "bi-row-1",
+        itemId: "BI-7D20BFDF",
+        epicId: null,
+        claimStatus: "active",
+        claimedById: "user-1", // owned by caller
+        claimedByAgentId: "agent-1",
+        claimedAt: new Date(),
+      });
+      // adopt reuse: existing capsule already bound to this BI.
+      db.workCapsule.findFirst.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-CLAIM01",
+        backlogItemId: "BI-7D20BFDF",
+        epicId: null,
+        executorRef: "session-A",
+        headBranch: baseInput.headBranch,
+        worktreePath: baseInput.worktreePath,
+      });
+      db.workCapsule.findMany.mockResolvedValueOnce([]);
+      db.backlogItem.update.mockResolvedValueOnce({ id: "bi-row-1" });
+
+      const result = await claimBacklogItemWorkspace({ db: capsuleDb(), input: baseInput, actor });
+
+      expect(result.capsuleId).toBe("WC-CLAIM01");
+      expect(db.workCapsule.create).not.toHaveBeenCalled();
+      expect(db.workCapsule.update).not.toHaveBeenCalled(); // already bound → no late-bind
     });
   });
 

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -42,6 +42,10 @@ export type CapsuleDb = {
   workCapsuleActivity: {
     create(args: unknown): Promise<any>;
   };
+  backlogItem?: {
+    findFirst(args: unknown): Promise<any>;
+    update(args: unknown): Promise<any>;
+  };
   $transaction?<T>(fn: (tx: CapsuleDb) => Promise<T>): Promise<T>;
 };
 
@@ -70,6 +74,9 @@ type CapsuleAdoptionInput = {
   baseSha?: string | null;
   headSha?: string | null;
   executorKind?: WorkCapsuleExecutorKind | null;
+  executorRef?: string | null;
+  backlogItemId?: string | null;
+  epicId?: string | null;
   scope?: WorkCapsuleScopeInput | null;
 };
 
@@ -231,7 +238,36 @@ export async function adoptWorktreeCapsule(args: {
       archivedAt: null,
     },
   });
-  if (existing) return existing;
+  if (existing) {
+    // Late-bind (BI-7D20BFDF): a branch adopted before its BacklogItem was known
+    // has a null backlogItemId. When a claim now supplies one, bind the existing
+    // capsule instead of leaving the work orphaned — this is what lets a worktree
+    // cut before the BI was chosen still join the BI↔location record.
+    if (args.input.backlogItemId && existing.backlogItemId == null) {
+      const bound = await inTransaction(args.db, async (tx) => {
+        const updated = await tx.workCapsule.update({
+          where: { capsuleId: existing.capsuleId },
+          data: {
+            backlogItemId: args.input.backlogItemId,
+            ...(args.input.epicId && existing.epicId == null ? { epicId: args.input.epicId } : {}),
+            ...(args.input.executorRef && existing.executorRef == null
+              ? { executorRef: args.input.executorRef }
+              : {}),
+          },
+        });
+        await recordActivity(tx, {
+          workCapsuleId: existing.id,
+          kind: "adopted",
+          summary: `Late-bound ${existing.capsuleId} to ${args.input.backlogItemId}`,
+          payload: { backlogItemId: args.input.backlogItemId, lateBind: true },
+          actor: args.actor,
+        });
+        return updated;
+      });
+      return bound;
+    }
+    return existing;
+  }
 
   const now = new Date();
   try {
@@ -244,6 +280,9 @@ export async function adoptWorktreeCapsule(args: {
           source: "external-adoption",
           status: "ready",
           executorKind: args.input.executorKind ?? null,
+          executorRef: args.input.executorRef ?? null,
+          backlogItemId: args.input.backlogItemId ?? null,
+          epicId: args.input.epicId ?? null,
           repositoryFullName: args.input.repositoryFullName,
           baseBranch: args.input.baseBranch ?? "main",
           baseSha: args.input.baseSha ?? null,
@@ -288,6 +327,187 @@ export async function adoptWorktreeCapsule(args: {
     }
     throw error;
   }
+}
+
+// A claim older than this is treated as abandoned (a dead session) and is
+// reclaimable — mirrors STALE_BACKLOG_CLAIM_MS in the direct-build claim gate
+// (mcp-tools.ts triage_backlog_item / status→in-progress). REUSE, do not diverge.
+const STALE_BACKLOG_CLAIM_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * A NON-blocking conflict surfaced by claimBacklogItemWorkspace. The soft
+ * claim-at-start binds the capsule regardless; this metadata advises the caller
+ * that other active work already exists so it can coordinate (it is NOT a lock).
+ */
+export type BacklogWorkspaceConflict = {
+  /** The BacklogItem already carries a fresh active claim held by another session. */
+  backlogClaim: {
+    claimedById: string | null;
+    claimedByAgentId: string | null;
+    claimedAt: Date | null;
+    claimAgeMinutes: number | null;
+  } | null;
+  /** Other non-archived capsules on the same BI, on a DIFFERENT branch/session. */
+  otherLocations: Array<{
+    capsuleId: string;
+    headBranch: string | null;
+    worktreePath: string | null;
+    executorRef: string | null;
+    leaseHolderPrincipalId: string | null;
+  }>;
+};
+
+/**
+ * Soft claim-at-start (BI-7D20BFDF): bind a BacklogItem to the location + session
+ * that is starting work on it, so a directly-working agent's BI no longer looks
+ * unclaimed to a parallel session. Creates (or reuses + late-binds) the
+ * WorkCapsule for (repositoryFullName, headBranch) and stamps the BI claim
+ * fields, FOLLOWING the existing 12h-stale claim convention.
+ *
+ * This is advisory, not a hard lock (per the WWMD kernel decision): an existing
+ * FRESH claim held by a DIFFERENT agent/session is NOT overwritten and is
+ * returned as a non-blocking `conflict` — but the capsule is still bound so the
+ * work is tracked. Multiple capsules per BI (one per branch) are expected and are
+ * NOT themselves a conflict.
+ */
+export async function claimBacklogItemWorkspace(args: {
+  db: CapsuleDb;
+  input: {
+    backlogItemId: string;
+    repositoryFullName: string;
+    headBranch: string;
+    worktreePath: string;
+    baseBranch?: string | null;
+    executorKind?: WorkCapsuleExecutorKind | null;
+    executorRef?: string | null;
+    title?: string;
+    objective?: string;
+  };
+  actor: WorkCapsuleActor;
+  now?: Date;
+}): Promise<{
+  capsuleId: string;
+  backlogItemId: string;
+  headBranch: string;
+  worktreePath: string;
+  claimed: boolean;
+  conflict: BacklogWorkspaceConflict | null;
+}> {
+  if (!args.db.backlogItem) {
+    throw new Error("claimBacklogItemWorkspace requires a db with backlogItem access");
+  }
+  const now = args.now ?? new Date();
+
+  // Resolve the BacklogItem by semantic itemId (BI-*) or cuid; fail clearly if absent.
+  const item = await args.db.backlogItem.findFirst({
+    where: { OR: [{ itemId: args.input.backlogItemId }, { id: args.input.backlogItemId }] },
+    select: {
+      id: true,
+      itemId: true,
+      epicId: true,
+      claimStatus: true,
+      claimedById: true,
+      claimedByAgentId: true,
+      claimedAt: true,
+    },
+  });
+  if (!item) {
+    throw new Error(`BacklogItem ${args.input.backlogItemId} not found`);
+  }
+
+  // Create or reuse+late-bind the capsule bound to BI + location + session.
+  const capsule = await adoptWorktreeCapsule({
+    db: args.db,
+    input: {
+      title: args.input.title ?? `Work on ${item.itemId}`,
+      objective: args.input.objective ?? `Claim-at-start binding for ${item.itemId}`,
+      repositoryFullName: args.input.repositoryFullName,
+      headBranch: args.input.headBranch,
+      worktreePath: args.input.worktreePath,
+      baseBranch: args.input.baseBranch ?? "main",
+      backlogItemId: item.itemId,
+      epicId: item.epicId ?? null,
+      executorKind: args.input.executorKind ?? null,
+      executorRef: args.input.executorRef ?? null,
+    },
+    actor: args.actor,
+  });
+
+  // Conflict 1: the BI already carries a FRESH active claim held by a different
+  // session. Do NOT overwrite it (soft claim) — surface it as advisory.
+  const claimAgeMs = item.claimedAt ? now.getTime() - new Date(item.claimedAt).getTime() : Infinity;
+  const claimIsFresh = claimAgeMs < STALE_BACKLOG_CLAIM_MS;
+  const ownedByCaller =
+    (item.claimedById != null && item.claimedById === args.actor.userId) ||
+    (item.claimedByAgentId != null && item.claimedByAgentId === args.actor.agentId);
+  const activelyClaimedByOther =
+    item.claimStatus === "active" &&
+    claimIsFresh &&
+    !ownedByCaller &&
+    (item.claimedById != null || item.claimedByAgentId != null);
+
+  // Conflict 2: another non-archived capsule on the SAME BI, on a different branch
+  // or session. Multiple branches per BI are fine, but we still list them so the
+  // caller can see the parallel work.
+  const otherCapsules = await args.db.workCapsule.findMany({
+    where: {
+      backlogItemId: item.itemId,
+      archivedAt: null,
+      capsuleId: { not: capsule.capsuleId },
+    },
+    select: {
+      capsuleId: true,
+      headBranch: true,
+      worktreePath: true,
+      executorRef: true,
+      leaseHolderPrincipalId: true,
+    },
+  });
+
+  let claimed = false;
+  if (!activelyClaimedByOther) {
+    // Acquire (or refresh) the BI claim for this session — the stale/self case.
+    await args.db.backlogItem.update({
+      where: { id: item.id },
+      data: {
+        claimStatus: "active",
+        claimedById: args.actor.userId,
+        claimedByAgentId: args.actor.agentId,
+        claimedAt: now,
+      },
+    });
+    claimed = true;
+  }
+
+  const hasConflict = activelyClaimedByOther || (otherCapsules?.length ?? 0) > 0;
+  const conflict: BacklogWorkspaceConflict | null = hasConflict
+    ? {
+        backlogClaim: activelyClaimedByOther
+          ? {
+              claimedById: item.claimedById,
+              claimedByAgentId: item.claimedByAgentId,
+              claimedAt: item.claimedAt ?? null,
+              claimAgeMinutes: Number.isFinite(claimAgeMs) ? Math.round(claimAgeMs / 60000) : null,
+            }
+          : null,
+        otherLocations: (otherCapsules ?? []).map((c) => ({
+          capsuleId: c.capsuleId,
+          headBranch: c.headBranch ?? null,
+          worktreePath: c.worktreePath ?? null,
+          executorRef: c.executorRef ?? null,
+          leaseHolderPrincipalId: c.leaseHolderPrincipalId ?? null,
+        })),
+      }
+    : null;
+
+  return {
+    capsuleId: capsule.capsuleId,
+    backlogItemId: item.itemId,
+    headBranch: capsule.headBranch ?? args.input.headBranch,
+    worktreePath: capsule.worktreePath ?? args.input.worktreePath,
+    claimed,
+    conflict,
+  };
 }
 
 async function hasWorkspaceCollision(

--- a/docs/superpowers/specs/2026-07-06-bi-work-location-claim-at-start-design.md
+++ b/docs/superpowers/specs/2026-07-06-bi-work-location-claim-at-start-design.md
@@ -1,0 +1,110 @@
+# Claim-at-start BI ↔ work-location binding
+
+- BI: BI-7D20BFDF
+- Date: 2026-07-06
+- Status: implemented (this branch)
+
+## Problem
+
+A parallel agent could pick up a BacklogItem that another session was already
+working on **directly** (outside Build Studio). The direct-build claim gate
+(`triage_backlog_item` → status `in-progress` in `apps/web/lib/mcp-tools.ts`)
+only fires when an agent flips the BI status through the governed tool. An
+external contributor (Claude / Codex / Grok) that clones a worktree, cuts a
+branch, and starts editing never touches that gate — so the BI still reads as
+unclaimed. The result was two sessions independently building the same BI (the
+EP-F7E35344 collision class), with no shared record tying the BI to *where* the
+work is happening (which worktree, which branch, which session).
+
+## Substrate
+
+`WorkCapsule` (`packages/db/prisma/schema.prisma`) is the unified work-tracking
+model. It already carries both `backlogItemId`/`epicId`/`featureBuildId` **and**
+`repositoryFullName`/`headBranch`/`worktreePath`/`baseBranch`/`executorRef`. The
+store (`apps/web/lib/work-capsules/work-capsule-store.ts`) has two creation
+paths that had never been joined:
+
+- `createWorkCapsule` — binds the BI/epic/build identity, **no** branch/worktree.
+  Idempotent on `idempotencyKey`.
+- `adoptWorktreeCapsule` — binds the location (`repositoryFullName` + `headBranch`
+  + `worktreePath`), **no** BI. Idempotent on `(repositoryFullName, headBranch)`.
+
+`BacklogItem` already has the claim fields (`claimStatus`, `claimedById`,
+`claimedByAgentId`, `claimedAt`) and a 12h-stale / force-override convention in
+`mcp-tools.ts`. No schema migration was needed — this work is purely optional
+inputs + wiring over existing columns.
+
+The "direct-agent gap" lived in
+`apps/web/lib/work-capsules/external-session-capture.ts`:
+`captureExternalSessionEvidence` recorded external work into a capsule but passed
+**no** `backlogItemId`, so evidence never bound the BI.
+
+## Design — soft claim-at-start
+
+A single new store function, `claimBacklogItemWorkspace`, joins the two paths:
+
+1. Resolve the `BacklogItem` (by `BI-*` id or cuid); throw if absent.
+2. Call `adoptWorktreeCapsule` with the BI id + location + session. This creates
+   the `(repo, branch)` capsule bound to the BI, or — critically — **late-binds**
+   an existing branch capsule that was adopted before the BI was known
+   (`backlogItemId == null` → set it, record a `WorkCapsuleActivity` note).
+3. Stamp the `BacklogItem` claim (`claimStatus="active"` + claimant + `claimedAt`)
+   following the existing 12h-stale convention — **unless** the BI already holds a
+   FRESH (`< 12h`) active claim by a different agent/session, in which case the
+   existing claim is **not** overwritten.
+
+The claim is **advisory, not a lock**. Even when another session holds the BI
+claim, the capsule for *this* location is still bound (so the work is tracked and
+visible) and the caller gets non-blocking `conflict` metadata describing the
+other active claim and any other in-flight locations. Multiple capsules per BI
+(one per branch) are expected and are **not** a conflict — a conflict is
+specifically (a) the BI already actively claimed by a different agent, or (b)
+another non-archived capsule on the same BI on a different branch/session.
+
+## WWMD kernel decision
+
+Claim-at-start (soft) was weighed against a hard lock. Kernel outcome:
+**claim-at-start won**, composite **6.07**, margin **0.32** (high). The hard-lock
+option was rejected against the operator-friction commandments — a hard lock
+would block a legitimate second branch or a founder taking over stalled work, and
+would turn a coordination signal into a gate. The soft signal preserves the
+existing force/stale override semantics already used on the direct-build path.
+
+## API — `claim_backlog_item_for_work`
+
+MCP tool in `apps/web/lib/mcp/packs/work-capsules-pack.ts`
+(handler `claimBacklogItemForWorkTool` in
+`apps/web/lib/work-capsules/mcp-handlers.ts`), grant `work_capsule_adopt`.
+
+Params:
+
+- `itemId` (required) — `BI-*`.
+- `worktreePath` (required) — local worktree location.
+- `branchName` (required) — head branch; the capsule is keyed on `(repo, branch)`.
+- `repositoryFullName` (optional) — defaults to `DPF_REPO_FULL_NAME` env or the
+  platform repo full name.
+- `baseBranch` (optional) — defaults to `main`.
+- `provider` (required) — mapped to an executor kind via `providerToExecutorKind`.
+- `sessionRef` (required) — owner/session id, stored as the capsule `executorRef`.
+
+Returns `{ capsuleId, backlogItemId, headBranch, worktreePath, claimed, conflict }`.
+When `conflict` is present the human-readable message states the BI already has
+active work elsewhere (branch/session listed) and that the call did **not** steal
+the claim — the tool still returns success with the capsule bound.
+
+## Evidence-gap closure
+
+`captureExternalSessionEvidence` now accepts optional `backlogItemId`,
+`worktreePath`, `branchName`, `repositoryFullName`, `baseBranch`, threaded from
+new optional params on `record_external_development_evidence`. When
+`worktreePath` + `branchName` are supplied it prefers the adopt path so the
+capsule carries the location too; otherwise it binds the BI on the
+`createWorkCapsule` path. All new params are optional — fully backward-compatible.
+
+## Tests
+
+`apps/web/lib/work-capsules/work-capsule-store.test.ts` covers: adopt persists
+`backlogItemId`/`epicId`; late-bind on reuse (and the no-op when already bound);
+claim stamps the BI; non-blocking conflict when the BI is freshly claimed by
+another agent; stale (>12h) reclaim; a second capsule on a different branch for
+the same BI without a blocking claim conflict; and idempotent branch reuse.


### PR DESCRIPTION
## What & why

A parallel agent picked up two freshly-filed, **unclaimed** BIs and built them while another session was setting up on the same items — a near-duplicate PR (caught before any duplicate code). Root cause: **filing a BI doesn't bind it to the session/worktree/branch working it**, and the `WorkCapsule` binding that exists is created at *evidence time* (the end), not at *work start*. The two capsule paths each held half of what's needed — `createWorkCapsule` binds BI/epic/build, `adoptWorktreeCapsule` binds branch/worktree — and neither bound both.

This closes that split and exposes it as a **soft claim-at-start**, giving bidirectional traceability (which BI is this worktree on / which worktrees are on this BI) from the moment work begins.

## Changes

- **`adoptWorktreeCapsule`** now persists `backlogItemId`/`epicId`/`executorRef`, and **late-binds** an existing `(repo, branch)` capsule when a BI is supplied to a previously-unbound one (a worktree cut before the BI was chosen still joins the record).
- **`claimBacklogItemWorkspace`** + the new **`claim_backlog_item_for_work`** MCP tool bind BI + worktree + branch + session at work start and stamp the BI claim, reusing the existing **12h-stale** claim convention. A fresh active claim by a **different** session is a **non-blocking conflict** (advisory, not a lock) — the capsule is still bound so the work is tracked. Multiple capsules per BI (one per branch) are expected, not a conflict.
- **`record_external_development_evidence`** gains optional `backlogItemId`/`worktreePath`/`branchName`, closing the direct-agent gap where a hand-worked BI dropped its capsule link.

## Design decision (WWMD)

`principle_decide` scored **claim-at-start** the winner (composite 6.07, margin 0.32, high confidence, no commandment conflict). A **hard lock was rejected** — it drew negative commandment contributions (*"Do the work; don't task the operator with what an agent can do"*, *"Consult the governed scopes before asking a human"*) for false-lockout friction on a non-technical operator. Full rationale + tool API in [`docs/superpowers/specs/2026-07-06-bi-work-location-claim-at-start-design.md`](docs/superpowers/specs/2026-07-06-bi-work-location-claim-at-start-design.md).

## Verification

- **No schema migration** — the `WorkCapsule`/`BacklogItem` fields already exist; this is optional inputs + wiring only.
- `pnpm exec vitest run lib/work-capsules/work-capsule-store.test.ts` → **34 passed** (+9 new: adopt persist/late-bind, claim stamp, non-blocking conflict, stale reclaim, second-branch-same-BI, idempotency).
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit` → **exit 0**.

BI-7D20BFDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: Branch cut from current origin/main. Verified locally before push: `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit` exit 0, and `pnpm exec vitest run lib/work-capsules/work-capsule-store.test.ts` → 34 passed (plus the wider work-capsules suites green in the implementation pass). Backend-only change (new MCP tool + store wiring); no new routes/pages/migrations. Full CI gates the merge.
