### PR TITLE
feat(mdm): Autonomous Data Steward — coworker + scheduled sweep + auto-resolution (EP-4A12A7CB slice 4)

### DIFF
--- a/apps/web/app/(shell)/admin/data-stewardship/page.tsx
+++ b/apps/web/app/(shell)/admin/data-stewardship/page.tsx
@@ -6,17 +6,20 @@
 import { listOpenStewardTasks } from "@/lib/mdm/steward";
 import { getCustomerMasterDataQuality } from "@/lib/mdm/publish";
 import { loadMatchConfig } from "@/lib/mdm/match-config";
+import { listRecentAutoResolutions } from "@/lib/mdm/autonomous-steward";
 import { StewardTaskList, type StewardTaskRow } from "@/components/admin/StewardTaskList";
 import { MatchConfigCard } from "@/components/admin/MatchConfigCard";
+import { DataStewardPanel, type AutoResolution } from "@/components/admin/DataStewardPanel";
 
 export const dynamic = "force-dynamic";
 
 export default async function DataStewardshipPage() {
-  const [tasks, quality, accountConfig, contactConfig] = await Promise.all([
+  const [tasks, quality, accountConfig, contactConfig, recentAuto] = await Promise.all([
     listOpenStewardTasks(),
     getCustomerMasterDataQuality(),
     loadMatchConfig("customer-account"),
     loadMatchConfig("customer-contact"),
+    listRecentAutoResolutions(),
   ]);
 
   const tiles = [
@@ -47,6 +50,12 @@ export default async function DataStewardshipPage() {
             <p className="text-sm font-semibold text-[var(--dpf-text)]">{tile.value}</p>
           </div>
         ))}
+      </div>
+
+      <div className="mb-6">
+        <DataStewardPanel
+          recent={recentAuto.map((r) => ({ ...r, at: r.at.toISOString() })) as AutoResolution[]}
+        />
       </div>
 
       <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-2">Review queue</h2>

--- a/apps/web/components/admin/DataStewardPanel.tsx
+++ b/apps/web/components/admin/DataStewardPanel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { runDataStewardAction } from "@/lib/actions/data-stewardship";
+
+export type AutoResolution = {
+  activityId: string;
+  subject: string;
+  survivorId: string | null;
+  loserId: string | null;
+  reason: string | null;
+  at: string;
+};
+
+/**
+ * Autonomous Data Steward control + retro-review digest (BI-87C655D1).
+ * The scheduled coworker works the queue down daily; this shows what it did
+ * (each auto-merge undo-able via the tombstone's Undo-merge) and lets an
+ * operator trigger a pass on demand (dry-run first).
+ */
+export function DataStewardPanel({ recent }: { recent: AutoResolution[] }) {
+  const [result, setResult] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function run(dryRun: boolean) {
+    setResult(null);
+    startTransition(async () => {
+      const r = await runDataStewardAction(dryRun);
+      setResult(r.ok ? r.summary : r.message);
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3">
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <div>
+          <p className="text-sm font-semibold text-[var(--dpf-text)]">Autonomous Data Steward</p>
+          <p className="text-xs text-[var(--dpf-muted)]">
+            Runs daily: sweeps, then auto-merges confident duplicates and escalates the rest. Every
+            auto-merge is reversible from the merged account&apos;s page.
+          </p>
+        </div>
+        <div className="flex gap-1.5 shrink-0">
+          <button
+            onClick={() => run(true)}
+            disabled={isPending}
+            className="px-2.5 py-1 rounded-md text-xs border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-50"
+          >
+            Preview
+          </button>
+          <button
+            onClick={() => run(false)}
+            disabled={isPending}
+            className="px-2.5 py-1 rounded-md text-xs font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {isPending ? "Running…" : "Run now"}
+          </button>
+        </div>
+      </div>
+
+      {result && <p className="text-xs text-[var(--dpf-text)] mb-2">{result}</p>}
+
+      {recent.length > 0 && (
+        <div className="mt-2">
+          <p className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)] mb-1">
+            Auto-resolved (last 7 days)
+          </p>
+          <ul className="space-y-1">
+            {recent.map((r) => (
+              <li key={r.activityId} className="text-xs text-[var(--dpf-muted)]">
+                {r.survivorId ? (
+                  <Link href={`/customer/${r.survivorId}`} className="text-[var(--dpf-accent)] hover:underline">
+                    {r.subject}
+                  </Link>
+                ) : (
+                  r.subject
+                )}
+                {r.reason && ` — ${r.reason}`}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/data-stewardship.ts
+++ b/apps/web/lib/actions/data-stewardship.ts
@@ -17,6 +17,7 @@ import { runStewardSweep, resolveStewardTask, type StewardResolution } from "@/l
 import { mergeRecords, MergeValidationFailure, type MergeableDomain } from "@/lib/mdm/merge";
 import { saveMatchConfig, matchConfigSchema, type MatchConfig } from "@/lib/mdm/match-config";
 import type { DedupGatedDomain } from "@/lib/mdm/dedup-gate";
+import { runAutonomousStewardship } from "@/lib/mdm/autonomous-steward";
 
 type ActionResult<T = undefined> = { ok: true; data?: T } | { ok: false; message: string };
 
@@ -95,4 +96,19 @@ export async function saveMatchConfigAction(
   const next = await saveMatchConfig(domain, parsed.data, gate.userId);
   revalidatePath("/admin/data-stewardship");
   return { ok: true, data: next };
+}
+
+/** Trigger one autonomous Data Steward pass on demand (admin). */
+export async function runDataStewardAction(
+  dryRun: boolean,
+): Promise<{ ok: true; summary: string } | { ok: false; message: string }> {
+  const gate = await requireAdmin();
+  if ("denied" in gate) return gate.denied;
+  const s = await runAutonomousStewardship({ dryRun });
+  revalidatePath("/admin/data-stewardship");
+  const merges = s.autoMerged.map((m) => `${m.loserLabel}→${m.survivorLabel}`).join(", ") || "none";
+  return {
+    ok: true,
+    summary: `${dryRun ? "[preview] " : ""}Swept ${s.sweep.duplicatesFound} duplicate pair(s), ${s.sweep.staleFound} stale; ${dryRun ? "would merge" : "merged"} ${s.autoMerged.length} (${merges}); ${s.escalated.length} escalated${s.capped ? "; cap hit" : ""}.`,
+  };
 }

--- a/apps/web/lib/mcp/packs/mdm-stewardship-pack.ts
+++ b/apps/web/lib/mcp/packs/mdm-stewardship-pack.ts
@@ -103,7 +103,34 @@ const definitions: ToolDefinition[] = [
     sideEffect: true,
     requiresExternalAccess: true,
   },
+  {
+    name: "run_data_steward",
+    description:
+      "Run one autonomous data-stewardship pass: sweep for duplicates + stale records, then auto-merge the account duplicates it is confident about (keeping the best survivor), leaving ambiguous or identity cases for a human. Everything auto-merged is audit-logged and reversible with unmerge_customer_accounts. Use when asked to clean up customer data end-to-end. Pass dryRun=true to preview what WOULD be auto-merged without changing anything. This is the same pass the scheduled Data Steward runs daily.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dryRun: { type: "boolean", description: "Preview only — report what would auto-merge without merging. Default false." },
+      },
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+  },
 ];
+
+async function runDataStewardTool(params: Record<string, unknown>): Promise<ToolResult> {
+  const dryRun = params["dryRun"] === true;
+  const { runAutonomousStewardship } = await import("@/lib/mdm/autonomous-steward");
+  const summary = await runAutonomousStewardship({ dryRun });
+  const merges = summary.autoMerged
+    .map((m) => `${m.loserLabel}→${m.survivorLabel} (${m.reason})`)
+    .join("; ") || "none";
+  return {
+    success: true,
+    message: `${dryRun ? "[dry-run] " : ""}Data Steward pass: swept ${summary.sweep.duplicatesFound} duplicate pair(s) + ${summary.sweep.staleFound} stale record(s); ${dryRun ? "would auto-merge" : "auto-merged"} ${summary.autoMerged.length} (${merges}); escalated ${summary.escalated.length} to human review${summary.capped ? " (per-run cap hit)" : ""}.`,
+    data: summary,
+  };
+}
 
 async function mergeCustomerContactsTool(params: Record<string, unknown>): Promise<ToolResult> {
   const survivorId = typeof params["survivorContactId"] === "string" ? params["survivorContactId"].trim() : "";
@@ -313,6 +340,7 @@ export const mdmStewardshipPack: ToolPack = {
     run_mdm_steward_sweep: () => runStewardSweepTool(),
     list_mdm_steward_tasks: () => listStewardTasksTool(),
     enrich_customer_account: (params) => enrichCustomerAccountTool(params),
+    run_data_steward: (params) => runDataStewardTool(params),
   },
   grants: {
     // Mirrors agent-grants.ts TOOL_TO_GRANTS (the gating source): merging
@@ -326,5 +354,7 @@ export const mdmStewardshipPack: ToolPack = {
     list_mdm_steward_tasks: ["crm_read"],
     // Enrichment fetches an external site: gated by the web toggle AND grant.
     enrich_customer_account: ["web_search"],
+    // The autonomous pass merges records: crm_write, same envelope as merge.
+    run_data_steward: ["crm_write"],
   },
 };

--- a/apps/web/lib/mdm/autonomous-steward.test.ts
+++ b/apps/web/lib/mdm/autonomous-steward.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    mdmStewardTask: { findMany: vi.fn(), update: vi.fn() },
+    customerAccount: { findUnique: vi.fn() },
+    activity: { create: vi.fn(), findMany: vi.fn() },
+  },
+}));
+vi.mock("./steward", () => ({ runStewardSweep: vi.fn() }));
+vi.mock("./merge", () => ({
+  mergeRecords: vi.fn(),
+  MergeValidationFailure: class extends Error {
+    constructor(public reason: string) {
+      super(reason);
+    }
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { runStewardSweep } from "./steward";
+import { mergeRecords } from "./merge";
+import {
+  chooseSurvivor,
+  runAutonomousStewardship,
+  MAX_AUTO_MERGES_PER_RUN,
+} from "./autonomous-steward";
+
+const SWEEP = { duplicatesFound: 0, duplicateTasksOpened: 0, staleFound: 0, staleTasksOpened: 0 };
+
+function acct(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "a",
+    name: "Acme",
+    status: "prospect",
+    domainNormalized: "",
+    createdAt: new Date("2026-01-01"),
+    _count: { contacts: 0, opportunities: 0, invoices: 0 },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(runStewardSweep).mockResolvedValue(SWEEP);
+  vi.mocked(prisma.mdmStewardTask.findMany).mockResolvedValue([] as never);
+  vi.mocked(mergeRecords).mockResolvedValue({
+    repointed: {}, repointedIds: {}, repointedIdsTruncated: [], nestedSiteMerges: [],
+    loserSnapshot: {}, survivorship: {}, domain: "customer-account", loserId: "l", survivorId: "s",
+  } as never);
+});
+
+describe("chooseSurvivor", () => {
+  it("keeps the higher-status record (customer beats prospect)", () => {
+    const r = chooseSurvivor(acct({ id: "a", status: "prospect" }), acct({ id: "b", status: "active" }));
+    expect(r.survivor.id).toBe("b");
+    expect(r.reason).toMatch(/active over prospect/);
+  });
+  it("breaks status ties by relationship count", () => {
+    const r = chooseSurvivor(
+      acct({ id: "a", status: "active", _count: { contacts: 1, opportunities: 0, invoices: 0 } }),
+      acct({ id: "b", status: "active", _count: { contacts: 5, opportunities: 2, invoices: 1 } }),
+    );
+    expect(r.survivor.id).toBe("b");
+    expect(r.reason).toMatch(/more-connected/);
+  });
+  it("breaks full ties by age (older survives)", () => {
+    const r = chooseSurvivor(
+      acct({ id: "a", createdAt: new Date("2026-01-01") }),
+      acct({ id: "b", createdAt: new Date("2026-06-01") }),
+    );
+    expect(r.survivor.id).toBe("a");
+    expect(r.reason).toMatch(/older/);
+  });
+});
+
+describe("runAutonomousStewardship", () => {
+  function queueDuplicate(over: Partial<Record<string, unknown>> = {}) {
+    vi.mocked(prisma.mdmStewardTask.findMany).mockResolvedValue([
+      { id: "row1", taskId: "STEW-1", domain: "customer-account", kind: "duplicate", subjectId: "a", candidateId: "b", ...over },
+    ] as never);
+  }
+
+  it("auto-merges a clean account duplicate and resolves the task", async () => {
+    queueDuplicate();
+    vi.mocked(prisma.customerAccount.findUnique).mockImplementation(
+      ((args: any) => Promise.resolve(acct({ id: args.where.id, status: args.where.id === "b" ? "active" : "prospect" }))) as never,
+    );
+    const s = await runAutonomousStewardship();
+    expect(s.autoMerged).toHaveLength(1);
+    // survivor is the active account "b"; loser "a" merged into it
+    expect(mergeRecords).toHaveBeenCalledWith("customer-account", "a", "b");
+    expect(prisma.mdmStewardTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "resolved_merged" }) }),
+    );
+    expect(prisma.activity.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ type: "account_auto_merged" }) }),
+    );
+  });
+
+  it("ESCALATES a fuzzy match with different domains (distinct companies)", async () => {
+    queueDuplicate();
+    vi.mocked(prisma.customerAccount.findUnique).mockImplementation(
+      ((args: any) => Promise.resolve(acct({ id: args.where.id, domainNormalized: args.where.id === "a" ? "acme.com" : "acme.io" }))) as never,
+    );
+    const s = await runAutonomousStewardship();
+    expect(s.autoMerged).toHaveLength(0);
+    expect(s.escalated[0]?.reason).toMatch(/different domains/);
+    expect(mergeRecords).not.toHaveBeenCalled();
+  });
+
+  it("ESCALATES contact duplicates (identity carve-out)", async () => {
+    queueDuplicate({ domain: "customer-contact" });
+    const s = await runAutonomousStewardship();
+    expect(s.autoMerged).toHaveLength(0);
+    expect(s.escalated[0]?.reason).toMatch(/identity/);
+    expect(mergeRecords).not.toHaveBeenCalled();
+  });
+
+  it("caps auto-merges per run and escalates the overflow", async () => {
+    const many = Array.from({ length: MAX_AUTO_MERGES_PER_RUN + 3 }, (_, i) => ({
+      id: `row${i}`, taskId: `STEW-${i}`, domain: "customer-account", kind: "duplicate",
+      subjectId: `a${i}`, candidateId: `b${i}`,
+    }));
+    vi.mocked(prisma.mdmStewardTask.findMany).mockResolvedValue(many as never);
+    vi.mocked(prisma.customerAccount.findUnique).mockImplementation(
+      ((args: any) => Promise.resolve(acct({ id: args.where.id }))) as never,
+    );
+    const s = await runAutonomousStewardship();
+    expect(s.autoMerged).toHaveLength(MAX_AUTO_MERGES_PER_RUN);
+    expect(s.capped).toBe(true);
+    expect(s.escalated.some((e) => /cap/.test(e.reason))).toBe(true);
+  });
+
+  it("dry-run reports would-merge without calling mergeRecords", async () => {
+    queueDuplicate();
+    vi.mocked(prisma.customerAccount.findUnique).mockImplementation(
+      ((args: any) => Promise.resolve(acct({ id: args.where.id }))) as never,
+    );
+    const s = await runAutonomousStewardship({ dryRun: true });
+    expect(s.autoMerged).toHaveLength(1);
+    expect(s.dryRun).toBe(true);
+    expect(mergeRecords).not.toHaveBeenCalled();
+    expect(prisma.activity.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/mdm/autonomous-steward.ts
+++ b/apps/web/lib/mdm/autonomous-steward.ts
@@ -1,0 +1,244 @@
+/**
+ * Autonomous MDM stewardship engine (EP-4A12A7CB slice 4, BI-87C655D1).
+ *
+ * The steward queue (steward.ts) is the human workflow; THIS is the coworker
+ * that works it down without being asked. Run on a schedule (the Inngest
+ * mdm-steward-sweep cron) or on demand by the Data Steward coworker, it:
+ *   1. runs the sweep (populates MdmStewardTask),
+ *   2. auto-resolves account duplicates it is confident about — full autonomy
+ *      incl. fuzzy matches (operator decision 2026-07-06),
+ *   3. leaves genuinely ambiguous / higher-risk cases for a human.
+ *
+ * "Full autonomy" here is autonomous-AND-accountable, not blind:
+ *   - every auto-merge writes an `account_auto_merged` Activity + attribute
+ *     history, and is reversible via unmerge (the undo);
+ *   - a per-run CAP bounds blast radius — a scoring regression can corrupt at
+ *     most MAX_AUTO_MERGES_PER_RUN records before the overflow escalates;
+ *   - a conflicting-domain guardrail escalates instead of merging: if a fuzzy
+ *     name match has two DIFFERENT web domains, that is two real companies
+ *     whose names collide, not a duplicate;
+ *   - contact duplicates are identity-bearing (credentials, social identities)
+ *     — a carve-out escalates them to a human even under full autonomy.
+ * Everything auto-resolved surfaces in the retro-review digest.
+ */
+import { prisma } from "@dpf/db";
+import * as crypto from "crypto";
+import { runStewardSweep, type SweepSummary } from "./steward";
+import { mergeRecords, MergeValidationFailure } from "./merge";
+
+/** Blast-radius cap: at most this many auto-merges per run; rest escalate. */
+export const MAX_AUTO_MERGES_PER_RUN = 25;
+
+/** System actor id recorded on autonomous actions. */
+export const DATA_STEWARD_ACTOR = "data-steward";
+
+export type AutoMergeRecord = {
+  taskId: string;
+  survivorId: string;
+  loserId: string;
+  survivorLabel: string;
+  loserLabel: string;
+  reason: string;
+};
+
+export type AutoStewardSummary = {
+  sweep: SweepSummary;
+  autoMerged: AutoMergeRecord[];
+  /** Duplicates left for a human, with why. */
+  escalated: Array<{ taskId: string; reason: string }>;
+  /** True when the per-run cap was hit (overflow escalated). */
+  capped: boolean;
+  dryRun: boolean;
+};
+
+type AccountForDecision = {
+  id: string;
+  name: string;
+  status: string;
+  domainNormalized: string;
+  createdAt: Date;
+  _count: { contacts: number; opportunities: number; invoices: number };
+};
+
+/** Relationship weight — a more-connected record is the better survivor. */
+function relations(a: AccountForDecision): number {
+  return a._count.contacts + a._count.opportunities + a._count.invoices;
+}
+
+/** Status rank — a real customer outranks a prospect as the survivor. */
+const STATUS_RANK: Record<string, number> = {
+  active: 4,
+  at_risk: 3,
+  onboarding: 3,
+  qualified: 2,
+  prospect: 1,
+};
+function statusRank(s: string): number {
+  return STATUS_RANK[s] ?? 0;
+}
+
+/**
+ * Deterministically pick which of two accounts survives a merge:
+ * higher status → more relationships → older (the original). Total order, so
+ * the choice is reproducible and defensible in the audit trail.
+ */
+export function chooseSurvivor(
+  a: AccountForDecision,
+  b: AccountForDecision,
+): { survivor: AccountForDecision; loser: AccountForDecision; reason: string } {
+  const byStatus = statusRank(b.status) - statusRank(a.status);
+  if (byStatus !== 0) {
+    const [survivor, loser] = byStatus > 0 ? [b, a] : [a, b];
+    return { survivor, loser, reason: `kept ${survivor.status} over ${loser.status}` };
+  }
+  const byRel = relations(b) - relations(a);
+  if (byRel !== 0) {
+    const [survivor, loser] = byRel > 0 ? [b, a] : [a, b];
+    return { survivor, loser, reason: `kept the more-connected record (${relations(survivor)} vs ${relations(loser)} related)` };
+  }
+  const [survivor, loser] = a.createdAt.getTime() <= b.createdAt.getTime() ? [a, b] : [b, a];
+  return { survivor, loser, reason: "kept the older record" };
+}
+
+async function loadAccount(id: string): Promise<AccountForDecision | null> {
+  return prisma.customerAccount.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      domainNormalized: true,
+      createdAt: true,
+      _count: { select: { contacts: true, opportunities: true, invoices: true } },
+    },
+  }) as Promise<AccountForDecision | null>;
+}
+
+/**
+ * Run one autonomous stewardship pass. Idempotent through the sweep's task
+ * dedup; safe to run on a schedule. `dryRun` decides nothing destructively —
+ * it reports what WOULD auto-merge.
+ */
+export async function runAutonomousStewardship(
+  opts: { dryRun?: boolean } = {},
+): Promise<AutoStewardSummary> {
+  const dryRun = opts.dryRun ?? false;
+  const sweep = await runStewardSweep();
+
+  const openDuplicates = await prisma.mdmStewardTask.findMany({
+    where: { status: "open", kind: "duplicate" },
+    orderBy: [{ score: "desc" }, { createdAt: "asc" }],
+  });
+
+  const autoMerged: AutoMergeRecord[] = [];
+  const escalated: Array<{ taskId: string; reason: string }> = [];
+  let capped = false;
+
+  for (const task of openDuplicates) {
+    // Identity carve-out: contact merges combine credentials/social identities
+    // — a human decides those even under full autonomy.
+    if (task.domain !== "customer-account") {
+      escalated.push({ taskId: task.taskId, reason: "contact identity merge — human review" });
+      continue;
+    }
+    if (!task.candidateId) {
+      escalated.push({ taskId: task.taskId, reason: "no candidate on task" });
+      continue;
+    }
+    if (autoMerged.length >= MAX_AUTO_MERGES_PER_RUN) {
+      capped = true;
+      escalated.push({ taskId: task.taskId, reason: "per-run cap reached — deferred to next run / human" });
+      continue;
+    }
+
+    const [a, b] = await Promise.all([loadAccount(task.subjectId), loadAccount(task.candidateId)]);
+    if (!a || !b) {
+      escalated.push({ taskId: task.taskId, reason: "a record no longer exists" });
+      continue;
+    }
+
+    // Conflicting-domain guardrail: a fuzzy NAME match whose two records carry
+    // DIFFERENT web domains is two real companies, not a duplicate. Escalate.
+    if (a.domainNormalized && b.domainNormalized && a.domainNormalized !== b.domainNormalized) {
+      escalated.push({
+        taskId: task.taskId,
+        reason: `different domains (${a.domainNormalized} vs ${b.domainNormalized}) — likely distinct companies`,
+      });
+      continue;
+    }
+
+    const { survivor, loser, reason } = chooseSurvivor(a, b);
+    const record: AutoMergeRecord = {
+      taskId: task.taskId,
+      survivorId: survivor.id,
+      loserId: loser.id,
+      survivorLabel: survivor.name,
+      loserLabel: loser.name,
+      reason,
+    };
+
+    if (dryRun) {
+      autoMerged.push(record);
+      continue;
+    }
+
+    try {
+      const result = await mergeRecords("customer-account", loser.id, survivor.id);
+      await prisma.activity.create({
+        data: {
+          activityId: `ACT-${crypto.randomUUID()}`,
+          type: "account_auto_merged",
+          subject: `Data Steward auto-merged "${loser.name}" into "${survivor.name}"`,
+          body: JSON.stringify({ ...result, autonomyReason: reason, taskId: task.taskId }),
+          accountId: survivor.id,
+          createdById: null,
+        },
+      });
+      await prisma.mdmStewardTask.update({
+        where: { id: task.id },
+        data: {
+          status: "resolved_merged",
+          resolvedBy: DATA_STEWARD_ACTOR,
+          resolvedAt: new Date(),
+          note: `Auto-merged by Data Steward: ${reason}.`,
+        },
+      });
+      autoMerged.push(record);
+    } catch (err) {
+      const why = err instanceof MergeValidationFailure ? err.reason : String(err);
+      escalated.push({ taskId: task.taskId, reason: `merge failed (${why})` });
+    }
+  }
+
+  return { sweep, autoMerged, escalated, capped, dryRun };
+}
+
+/** Recently auto-resolved actions for the retro-review digest surface. */
+export async function listRecentAutoResolutions(sinceDays = 7, take = 50) {
+  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
+  const rows = await prisma.activity.findMany({
+    where: { type: "account_auto_merged", createdAt: { gte: since } },
+    orderBy: { createdAt: "desc" },
+    take,
+    select: { activityId: true, subject: true, body: true, accountId: true, createdAt: true },
+  });
+  return rows.map((r) => {
+    let loserId: string | null = null;
+    let reason: string | null = null;
+    try {
+      const parsed = JSON.parse(r.body ?? "{}") as { loserId?: string; autonomyReason?: string };
+      loserId = parsed.loserId ?? null;
+      reason = parsed.autonomyReason ?? null;
+    } catch {
+      // legacy/non-JSON body — leave nulls
+    }
+    return {
+      activityId: r.activityId,
+      subject: r.subject,
+      survivorId: r.accountId,
+      loserId,
+      reason,
+      at: r.createdAt,
+    };
+  });
+}

--- a/apps/web/lib/mdm/steward-schedule-constants.ts
+++ b/apps/web/lib/mdm/steward-schedule-constants.ts
@@ -8,6 +8,12 @@ export const MDM_STEWARD_JOB_NAME = "MDM Data Steward sweep";
 export const MDM_STEWARD_SCHEDULED_INNGEST_ID = "ops/mdm-steward-sweep-scheduled";
 export const MDM_STEWARD_REQUESTED_INNGEST_ID = "ops/mdm-steward-sweep-requested";
 export const MDM_STEWARD_REQUESTED_EVENT = "ops/mdm-steward.requested";
-/** Daily at 05:00 UTC — after the 04:00 retention sweep, low-traffic window. */
-export const MDM_STEWARD_CRON = "0 5 * * *";
-export const MDM_STEWARD_CADENCE = "Daily at 05:00 UTC";
+/**
+ * Daily at 04:50 UTC — after the 03:00 data-model mirror and 04:00 SysML
+ * projection so the sweep runs on freshly reconciled data, and on a distinct
+ * minute offset so it never shares a tick with the 05:00 jobs (scheduling-map
+ * contention guard: no cron shared by 3+ jobs). Keep this literal in sync with
+ * the catalog entry in scheduled-jobs/catalog.ts.
+ */
+export const MDM_STEWARD_CRON = "50 4 * * *";
+export const MDM_STEWARD_CADENCE = "Daily at 04:50 UTC";

--- a/apps/web/lib/mdm/steward-schedule-constants.ts
+++ b/apps/web/lib/mdm/steward-schedule-constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Autonomous Data Steward schedule constants (EP-4A12A7CB slice 4).
+ * Kept separate from the Inngest function so the scheduled-jobs catalog and
+ * the parity test can import the ids without pulling the queue runtime.
+ */
+export const MDM_STEWARD_JOB_ID = "mdm-steward-sweep";
+export const MDM_STEWARD_JOB_NAME = "MDM Data Steward sweep";
+export const MDM_STEWARD_SCHEDULED_INNGEST_ID = "ops/mdm-steward-sweep-scheduled";
+export const MDM_STEWARD_REQUESTED_INNGEST_ID = "ops/mdm-steward-sweep-requested";
+export const MDM_STEWARD_REQUESTED_EVENT = "ops/mdm-steward.requested";
+/** Daily at 05:00 UTC — after the 04:00 retention sweep, low-traffic window. */
+export const MDM_STEWARD_CRON = "0 5 * * *";
+export const MDM_STEWARD_CADENCE = "Daily at 05:00 UTC";

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -213,6 +213,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: "ops/data-retention.requested",
   },
   {
+    jobId: "mdm-steward-sweep",
+    inngestId: "ops/mdm-steward-sweep-scheduled",
+    name: "MDM Data Steward sweep",
+    purpose:
+      "Runs the master-data quality sweep and lets the Data Steward coworker auto-resolve confident account duplicates (full autonomy incl. fuzzy, with audit trail + unmerge undo + per-run cap + conflicting-domain guardrail). If it stops, duplicates and stale customer records accumulate unreviewed. Editable so an operator can pause or run-now the autonomous steward.",
+    cron: "0 5 * * *",
+    cadence: "Daily at 05:00",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: "ops/mdm-steward.requested",
+  },
+  {
     jobId: "discovery-prometheus-poll",
     inngestId: "ops/prometheus-poll",
     name: "Discovery: Prometheus poll",

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -218,8 +218,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     name: "MDM Data Steward sweep",
     purpose:
       "Runs the master-data quality sweep and lets the Data Steward coworker auto-resolve confident account duplicates (full autonomy incl. fuzzy, with audit trail + unmerge undo + per-run cap + conflicting-domain guardrail). If it stops, duplicates and stale customer records accumulate unreviewed. Editable so an operator can pause or run-now the autonomous steward.",
-    cron: "0 5 * * *",
-    cadence: "Daily at 05:00",
+    cron: "50 4 * * *",
+    cadence: "Daily at 04:50",
     category: "editable",
     tracksRunData: false,
     runNowEvent: "ops/mdm-steward.requested",

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -34,6 +34,7 @@ import {
   contributorInventorySyncOnDemand,
 } from "./contributor-inventory-sync";
 import { selfUpgradeScheduled, selfUpgradeManual } from "./self-upgrade";
+import { mdmStewardSweepScheduled, mdmStewardSweepRequested } from "./mdm-steward-sweep";
 import { quiescenceRun } from "./quiescence-run";
 import { wikiLint } from "./wiki-lint";
 import { gitPromotionSandboxVerification } from "./git-promotion-sandbox-verification";
@@ -93,6 +94,7 @@ export const scheduledFunctions = [
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
   dataRetentionSweepScheduled, // EP-DATA-RETENTION: daily DB purge of aged logs/telemetry/chat, 04:00
+  mdmStewardSweepScheduled, // EP-4A12A7CB slice 4: autonomous Data Steward — sweep + auto-resolve account dupes, daily 05:00
   logSignatureScanner,   // BI-5FE8656F: EP-FULL-OBS Tier 2 novel-signature log scan, every 15m
   edgeIncidentCorrelation, // EP-MSP-FEDERATION A2+A3: correlate edge alerts->incidents->customer tickets, every 10m (flag-gated)
   alertDeliveryBridge,   // BI-5FE8656F: EP-FULL-OBS Tier 2 item #6 — Prometheus+Loki firing alerts -> PortfolioQualityIssue, every 1m
@@ -130,6 +132,7 @@ export const eventFunctions = [
   selfUpgradeManual,
   quiescenceRun,
   dataRetentionSweepRequested, // EP-DATA-RETENTION: operator "run now" / dry-run
+  mdmStewardSweepRequested, // EP-4A12A7CB slice 4: Data Steward "run now" / dry-run
 ];
 
 export const allFunctions = [...scheduledFunctions, ...eventFunctions];

--- a/apps/web/lib/queue/functions/mdm-steward-sweep.ts
+++ b/apps/web/lib/queue/functions/mdm-steward-sweep.ts
@@ -1,0 +1,69 @@
+// EP-4A12A7CB slice 4 — Autonomous Data Steward scheduled sweep (inngest).
+//
+// Spec: docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md §10
+//
+// Daily pass that runs the MDM sweep and lets the Data Steward coworker
+// auto-resolve account duplicates it is confident about (full autonomy incl.
+// fuzzy matches, operator decision 2026-07-06) — accountable via audit trail,
+// unmerge undo, a per-run cap, and a conflicting-domain guardrail (see
+// lib/mdm/autonomous-steward.ts). Quiescence-gated (skips during a
+// self-upgrade drain), concurrency 1, honors the ScheduledJob.enabled kill
+// switch inside the runner.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  MDM_STEWARD_CRON,
+  MDM_STEWARD_REQUESTED_EVENT,
+  MDM_STEWARD_SCHEDULED_INNGEST_ID,
+  MDM_STEWARD_REQUESTED_INNGEST_ID,
+  MDM_STEWARD_JOB_ID,
+} from "@/lib/mdm/steward-schedule-constants";
+
+/** Kill switch: operators pause the Data Steward via ScheduledJob.enabled=false. */
+async function isEnabled(): Promise<boolean> {
+  const { prisma } = await import("@dpf/db");
+  const row = await prisma.scheduledJob.findUnique({
+    where: { jobId: MDM_STEWARD_JOB_ID },
+    select: { enabled: true },
+  });
+  // Default-on: no row means never toggled, so it runs.
+  return row?.enabled ?? true;
+}
+
+export const mdmStewardSweepScheduled = inngest.createFunction(
+  {
+    id: MDM_STEWARD_SCHEDULED_INNGEST_ID,
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(MDM_STEWARD_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    if (!(await step.run("mdm-steward-enabled", isEnabled))) {
+      return { skipped: true, reason: "disabled" };
+    }
+    return step.run("mdm-steward-sweep", async () => {
+      const { runAutonomousStewardship } = await import("@/lib/mdm/autonomous-steward");
+      return runAutonomousStewardship({ dryRun: false });
+    });
+  },
+);
+
+// Manual one-shot trigger for the admin "run now" action; supports dry-run.
+export const mdmStewardSweepRequested = inngest.createFunction(
+  {
+    id: MDM_STEWARD_REQUESTED_INNGEST_ID,
+    retries: 1,
+    triggers: [{ event: MDM_STEWARD_REQUESTED_EVENT }],
+  },
+  async ({ event, step }) => {
+    const dryRun = Boolean((event.data as { dryRun?: boolean } | undefined)?.dryRun);
+    return step.run("mdm-steward-sweep-manual", async () => {
+      const { runAutonomousStewardship } = await import("@/lib/mdm/autonomous-steward");
+      return runAutonomousStewardship({ dryRun });
+    });
+  },
+);

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -484,6 +484,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   run_mdm_steward_sweep: ["crm_write"],
   list_mdm_steward_tasks: ["crm_read"],
   enrich_customer_account: ["web_search"],
+  run_data_steward: ["crm_write"],
 
   // Security Operations / SIEM (EP-SOVEREIGN-SOC). Writes are propose-only +
   // coworkerArtifact; siem_investigate/siem_tune/incident_respond imply siem_read.

--- a/docs/professions/registry.json
+++ b/docs/professions/registry.json
@@ -5,7 +5,7 @@
     {
       "professionKey": "data-architect",
       "label": "Data Architect",
-      "roles": ["build-data-architect", "data-architect"],
+      "roles": ["build-data-architect", "data-architect", "data-steward"],
       "contextSlugs": ["data-model", "data-security"],
       "sources": [
         {

--- a/docs/superpowers/plans/2026-07-04-mdm-write-time-dedup-and-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-07-04-mdm-write-time-dedup-and-lifecycle-plan.md
@@ -154,3 +154,15 @@ run_mdm_steward_sweep, list_mdm_steward_tasks, enrich_customer_account).
 Covers BI-FEA49EC1, BI-28577CD1, BI-130EF887, BI-37F52B70, BI-16450BB2,
 BI-F71DBE84, BI-A4B73F87, BI-77489158, BI-1ABF6443, BI-2D435AFC (v1 scope
 noted per-BI in spec §9).
+
+## Slice 4 (2026-07-06): Autonomous Data Steward (BI-87C655D1)
+
+Files: lib/mdm/autonomous-steward.ts (engine + survivor selection + cap +
+guardrails + retro digest), lib/mdm/steward-schedule-constants.ts,
+lib/queue/functions/mdm-steward-sweep.ts (scheduled + manual Inngest),
+registered in queue/functions/index.ts, catalog entry in
+operate/scheduled-jobs/catalog.ts (parity test). Persona: data-steward in
+workforce-seed.ts + grants. Surfaces: DataStewardPanel + runDataStewardAction
+on /admin/data-stewardship; run_data_steward pack tool. Tests:
+autonomous-steward.test.ts (8: survivor selection, domain guardrail, identity
+carve-out, cap, dry-run). No migration — reuses slice-3 substrate.

--- a/docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md
@@ -409,3 +409,40 @@ account's OWN stored website (no search; 8s timeout; 200KB cap), extracts
 title/description, and files the proposal as a steward task — enrichment
 never writes master data directly. Tool `enrich_customer_account` requires
 the web toggle + `web_search` grant (two-gate, matching the research tools).
+
+## 10. Slice 4 (2026-07-06): Autonomous Data Steward
+
+Operator directive: MDM activities should be *assigned to and automated by* an
+AI coworker, not human-staffed — most can be automated in full. Slice 3 made
+the work coworker-capable (tools + grants); this slice makes it autonomous and
+owned.
+
+**Dedicated coworker.** A `data-steward` tier-2 cross-cutting coworker
+(workforce-seed.ts + HARDCODED_COWORKER_GRANTS: crm_read/crm_write/
+consumer_read/web_search) whose whole job is master-data quality.
+
+**Scheduled sweep.** `mdmStewardSweepScheduled` (Inngest cron, daily 05:00
+UTC, after the 04:00 retention sweep) on the standard scheduled-job pattern:
+quiescence-gated, concurrency 1, ScheduledJob.enabled kill switch, catalog
+entry (parity-tested). Manual `ops/mdm-steward.requested` event for run-now +
+dry-run.
+
+**Autonomy engine** (`lib/mdm/autonomous-steward.ts`). Runs the sweep, then
+auto-resolves account duplicates. Operator chose FULL autonomy incl. fuzzy
+matches — implemented as autonomous-AND-accountable:
+- **Deterministic survivor** — status rank (customer > prospect) → relationship
+  count → age. A total order, reproducible in the audit trail.
+- **Conflicting-domain guardrail** — a fuzzy name match whose two records carry
+  DIFFERENT web domains is two real companies, not a duplicate → escalate.
+- **Per-run cap** (`MAX_AUTO_MERGES_PER_RUN=25`) — bounds blast radius; a
+  scoring regression can mis-merge at most the cap before overflow escalates.
+- **Identity carve-out** — contact merges (credentials/social identities)
+  escalate to a human even under full autonomy.
+- Every auto-merge writes an `account_auto_merged` Activity + attribute history
+  and is reversible via unmerge (the undo).
+
+**Surfaces.** `/admin/data-stewardship` gains a Data Steward panel (Run now /
+Preview + a "auto-resolved, last 7 days" retro-review digest with links to the
+survivor). Coworker tool `run_data_steward` (dryRun param) for the on-demand
+path. Deferred: `mdm-steward` PlatformCapability (still on view_admin); tuning
+the auto-merge confidence floor separately from the queue thresholds.

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -75,6 +75,19 @@ export const COWORKER_AGENT_SEEDS: readonly CoworkerAgentSeed[] = [
     sensitivity: "confidential",
   },
   {
+    // EP-4A12A7CB slice 4: owns master-data quality — dedup review, merge,
+    // staleness, enrichment. Runs autonomously on a daily schedule and works
+    // the steward queue down; escalates the ambiguous cases to a human.
+    agentId: "data-steward",
+    slugId: "data-steward",
+    name: "Data Steward",
+    tier: 2,
+    type: "coworker",
+    description: "Master-data quality: duplicate resolution, record refresh, and merge governance",
+    valueStream: "cross-cutting",
+    sensitivity: "confidential",
+  },
+  {
     agentId: "marketing-specialist",
     slugId: "marketing-specialist",
     name: "Marketing Strategist",
@@ -241,6 +254,11 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
   // agentId "customer-advisor"), not from agent_registry.json — so the CRM
   // grants must live here to actually reach the coworker's tool surface.
   "customer-advisor": ["crm_read", "crm_write", "consumer_read", "registry_read", "backlog_read", "web_search"],
+  // The Data Steward owns master-data quality: it runs the dedup/staleness
+  // sweep, merges duplicates, and proposes enrichment. crm_write reaches the
+  // mdm-stewardship pack tools (run_mdm_steward_sweep, merge_customer_*,
+  // list_mdm_steward_tasks); web_search gates the enrich_customer_account door.
+  "data-steward": ["crm_read", "crm_write", "consumer_read", "registry_read", "backlog_read", "web_search"],
   "marketing-specialist": ["marketing_read", "marketing_write", "consumer_read", "registry_read"],
   "storefront-advisor": [
     "consumer_read",


### PR DESCRIPTION
## Summary

Answers a direct operator challenge: *are MDM activities assigned to and automated by an AI coworker?* As of slice 3 they were coworker-**capable** but human-**triggered** — nothing auto-ran the sweep or owned the queue. This slice assigns and automates them (BI-87C655D1).

- **Dedicated Data Steward coworker** (`data-steward`, tier-2 cross-cutting) whose whole job is master-data quality — seeded with CRM + web grants.
- **Scheduled daily sweep** (Inngest cron 05:00 UTC) on the platform's standard scheduled-job pattern: quiescence-gated, concurrency 1, **operator kill switch** (`ScheduledJob.enabled`, pausable from the Scheduled Jobs admin surface), catalog entry (parity-tested), manual run-now + dry-run event.
- **Autonomy engine** (`lib/mdm/autonomous-steward.ts`): runs the sweep, then auto-merges account duplicates. Operator chose **full autonomy incl. fuzzy matches** — built as autonomous-*and*-accountable:
  - **Deterministic survivor** — status (customer > prospect) → relationship count → age; a total order, reproducible in the audit trail.
  - **Conflicting-domain guardrail** — a fuzzy name match whose two records have *different* websites is two real companies → escalate, don't merge.
  - **Per-run cap** (25) — a scoring regression can mis-merge at most the cap before overflow escalates.
  - **Identity carve-out** — contact merges (credentials/social identities) escalate to a human even under full autonomy.
  - Every auto-merge → `account_auto_merged` Activity + attribute history, reversible via unmerge.
- **Surfaces**: a Data Steward panel (Run now / Preview + a *7-day retro-review digest* of what it auto-resolved, linking each survivor) on `/admin/data-stewardship`, and a `run_data_steward` coworker tool (dryRun param) for the on-demand path.

No migration — reuses the slice-3 substrate (MdmStewardTask, MdmAttributeChange, merge orchestrator).

## Test plan
- 147 tests green across affected suites; 8 new in `autonomous-steward.test.ts` (survivor selection, conflicting-domain guardrail, identity carve-out, per-run cap, dry-run)
- Scheduled-jobs catalog↔registry parity test green (new cron is catalogued)
- tsc clean; module-size + tool-pack ratchets green
- Post-merge: self-upgrade, then browser-verify on `/admin/data-stewardship` — seed duplicates, Run now, confirm auto-merge + digest + escalation of a conflicting-domain pair

UX-Fit-Decision: retro-review digest + Run-now/Preview reuse the existing admin-card pattern on the current stewardship page (no new surface); autonomy is operator-pausable via the existing Scheduled Jobs surface; auto-merges are visible (digest) and reversible (unmerge) so autonomy stays accountable to a non-technical operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)