### PR TITLE
fix(decision-gov): zero-signal consults escalate honestly instead of recommending by input order (BI-5CE7CF0B)

### DIFF
--- a/apps/web/app/(shell)/wiki/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/wiki/decisions/[interactionId]/page.tsx
@@ -70,8 +70,19 @@ export default async function DecisionRecordPage({ params }: { params: Params })
   const options = Array.isArray(row.options)
     ? row.options.filter((o): o is string => typeof o === "string")
     : [];
+  // Insufficient-signal consults (every contribution zero) carry no real
+  // recommendation. New records set the explicit payload flag; records from
+  // before the guard existed are recognised by their all-zero composite +
+  // margin so the misleading "recommended" chip disappears from history too.
+  const insufficientSignal =
+    payload.insufficientSignal === true ||
+    (typeof payload.recommendedOptionId === "string" &&
+      payload.composite === 0 &&
+      payload.margin === 0);
   const recommendedOptionId =
-    typeof payload.recommendedOptionId === "string" ? payload.recommendedOptionId : null;
+    !insufficientSignal && typeof payload.recommendedOptionId === "string"
+      ? payload.recommendedOptionId
+      : null;
   // Caller attribution — who brought this decision (client UA token /
   // coworker agent / thread), so the row matches back to the activity.
   const caller = asRecord(payload.caller);
@@ -101,6 +112,9 @@ export default async function DecisionRecordPage({ params }: { params: Params })
           <StatusBadge domain="decisionRisk" status={row.riskTier} variant="soft" />
           {row.principleConflict ? (
             <StatusBadge intent="danger" label="principle conflict" variant="soft" />
+          ) : null}
+          {insufficientSignal ? (
+            <StatusBadge intent="warning" label="insufficient signal" variant="soft" />
           ) : null}
         </div>
         <h1 className="mt-3 text-xl font-semibold text-[var(--dpf-text)]">
@@ -162,6 +176,14 @@ export default async function DecisionRecordPage({ params }: { params: Params })
         <p className="text-sm text-[var(--dpf-text)] whitespace-pre-wrap">
           {row.rationale || "No rationale recorded."}
         </p>
+        {insufficientSignal ? (
+          <p className="mt-2 text-sm text-[var(--dpf-warning)]">
+            No option was actually scored: every principle contribution was
+            zero, so no recommendation stands. This usually means the consult
+            was submitted without per-option feature values. The decision
+            needs human judgment — or a re-run with scoreable options.
+          </p>
+        ) : null}
         {contributors.length > 0 ? (
           <div className="mt-3 rounded-lg border border-[var(--dpf-border)] overflow-hidden">
             <table className="w-full text-xs">

--- a/apps/web/lib/decision/kernel-consult-ledger.test.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.test.ts
@@ -113,6 +113,19 @@ describe("mapConsultOutcome", () => {
     expect(mapConsultOutcome(result).outcomeType).toBe("defer");
     expect(mapConsultOutcome(result).confidenceScore).toBe(0);
   });
+
+  // BI-5CE7CF0B: zero-contribution consults escalate to human review — the
+  // gate was asked a real question it could not weigh, which is not the same
+  // as no principles applying (defer).
+  it("maps an insufficient-signal result to escalate, not defer", () => {
+    const result = makeResult({ recommendation: null });
+    result.flags.insufficientSignal = true;
+    expect(mapConsultOutcome(result)).toEqual({
+      outcomeType: "escalate",
+      riskTier: "medium",
+      confidenceScore: 0,
+    });
+  });
 });
 
 describe("recordKernelConsultInteraction", () => {

--- a/apps/web/lib/decision/kernel-consult-ledger.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.ts
@@ -58,6 +58,12 @@ export function mapConsultOutcome(result: DecisionResult): {
   confidenceScore: number;
 } {
   if (!result.recommendation) {
+    // BI-5CE7CF0B: insufficient signal is a real question the gate could not
+    // weigh (options carried nothing scoreable) — that needs a human review,
+    // not a coverage-gap shrug.
+    if (result.flags.insufficientSignal) {
+      return { outcomeType: "escalate", riskTier: "medium", confidenceScore: 0 };
+    }
     return { outcomeType: "defer", riskTier: "medium", confidenceScore: 0 };
   }
   if (result.flags.commandmentConflict) {
@@ -180,6 +186,7 @@ export async function recordKernelConsultInteraction(input: {
         composite: input.result.recommendation?.composite ?? null,
         margin: input.result.recommendation?.margin ?? null,
         recommendationConfidence: input.result.recommendation?.confidence ?? null,
+        insufficientSignal: input.result.flags.insufficientSignal === true,
         commandmentConflictPrinciples: input.result.flags.commandmentConflictPrinciples,
         structuredCoverage: input.result.flags.structuredCoverage,
         optionDescriptions: input.optionDescriptions,

--- a/apps/web/lib/decision/option-scoring.insufficient-signal.test.ts
+++ b/apps/web/lib/decision/option-scoring.insufficient-signal.test.ts
@@ -1,0 +1,70 @@
+// BI-5CE7CF0B: a consult where every contribution is zero must not crown a
+// winner. Before this fix, decide() ranked by composite and "recommended"
+// ranked[0] — input order — at composite 0.000, and the ledger recorded
+// "Recommends warn_only (composite 0.000, margin 0.000)" (DI-417AA19D37C9).
+// Zero signal is now an explicit no-recommendation outcome the caller and
+// the audit surface can name honestly.
+
+import { describe, it, expect } from "vitest";
+
+import { decide, type DecisionPrinciple } from "./option-scoring";
+
+const structuredPrinciple = (id: string): DecisionPrinciple => ({
+  id,
+  name: `Principle ${id}`,
+  tier: "commandment",
+  weight: 1,
+  dimensionVector: { reusability: 1, governance_compliance: 0.5 },
+});
+
+describe("decide() zero-signal guard (BI-5CE7CF0B)", () => {
+  it("returns no recommendation when every contribution is zero", () => {
+    // Options with no features and no embeddings: structured alignment is 0
+    // against every principle, and the semantic path cannot fire.
+    const result = decide(
+      [
+        { id: "warn_only", description: "", features: {} },
+        { id: "hard_gate_all", description: "", features: {} },
+      ],
+      [structuredPrinciple("p1"), structuredPrinciple("p2")],
+    );
+
+    expect(result.recommendation).toBeNull();
+    expect(result.flags.insufficientSignal).toBe(true);
+    expect(result.reasoning).toMatch(/insufficient signal/i);
+    // The ledger still gets the full zero ledger for the drill-in.
+    expect(result.scores).toHaveLength(2);
+  });
+
+  it("still recommends normally when options carry scoreable features", () => {
+    const result = decide(
+      [
+        { id: "a", description: "", features: { reusability: 0.9 } },
+        { id: "b", description: "", features: { reusability: 0.1 } },
+      ],
+      [structuredPrinciple("p1")],
+    );
+
+    expect(result.recommendation?.optionId).toBe("a");
+    expect(result.flags.insufficientSignal).toBe(false);
+  });
+
+  it("offsetting non-zero contributions are signal, not silence", () => {
+    // A composite of zero built from real positive and negative pulls is a
+    // genuine tie, not an unscored decision — the guard must not fire.
+    const result = decide(
+      [
+        {
+          id: "a",
+          description: "",
+          features: { reusability: 1, governance_compliance: -2 },
+        },
+        { id: "b", description: "", features: { reusability: 0.5 } },
+      ],
+      [structuredPrinciple("p1")],
+    );
+
+    expect(result.flags.insufficientSignal).toBe(false);
+    expect(result.recommendation).not.toBeNull();
+  });
+});

--- a/apps/web/lib/decision/option-scoring.ts
+++ b/apps/web/lib/decision/option-scoring.ts
@@ -167,6 +167,14 @@ export type DecisionFlags = {
   commandmentConflict: boolean;
   /** ids of commandments triggering the commandmentConflict flag. */
   commandmentConflictPrinciples: string[];
+  /**
+   * True when principles applied but every option × principle contribution
+   * was exactly zero — typically options passed without `features` maps and
+   * with no semantic path available (BI-5CE7CF0B). No recommendation is made
+   * in this state: ranking all-zero composites just crowns input order.
+   * Optional so older stored result shapes remain valid.
+   */
+  insufficientSignal?: boolean;
 };
 
 export type DecisionRecommendation = {
@@ -232,12 +240,40 @@ export function decide(
       structuredCoverage: "strong",
       commandmentConflict: false,
       commandmentConflictPrinciples: [],
+      insufficientSignal: false,
     };
     const reasoning =
       principles.length === 0
         ? "No applicable principles to evaluate. The decision needs human judgment instead of advisory math."
         : "No options supplied. Nothing to score.";
     return { recommendation: null, scores, flags, reasoning };
+  }
+
+  // Zero-signal guard (BI-5CE7CF0B): principles applied, but every single
+  // contribution is exactly zero — no option carried features along any
+  // scored dimension and the semantic path never fired. Ranking would crown
+  // whichever option came first at composite 0.000; refuse instead and tell
+  // the caller what was missing. Offsetting positive/negative contributions
+  // that net to zero are genuine signal and do not trip this (the check is
+  // per-contribution, not per-composite).
+  const hasAnySignal = scores.some((s) =>
+    s.contributions.some((c) => c.contribution !== 0),
+  );
+  if (!hasAnySignal) {
+    const flags: DecisionFlags = {
+      tieMargin,
+      semanticFallbackRatio: 0,
+      structuredCoverage: "strong",
+      commandmentConflict: false,
+      commandmentConflictPrinciples: [],
+      insufficientSignal: true,
+    };
+    return {
+      recommendation: null,
+      scores,
+      flags,
+      reasoning: `Insufficient signal: ${principles.length} principle(s) applied but every contribution is zero — the options carry no scoreable features and semantic alignment was unavailable. Provide per-option \`features\` maps (or embeddings), or decide by human judgment.`,
+    };
   }
 
   // Rank by composite descending.
@@ -272,6 +308,7 @@ export function decide(
     structuredCoverage,
     commandmentConflict: conflictingPrinciples.length > 0,
     commandmentConflictPrinciples: conflictingPrinciples,
+    insufficientSignal: false,
   };
 
   // Reasoning: name the winner, the top two contributing principles, and

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -13322,9 +13322,12 @@ export async function executeTool(
         agentId: context?.agentId ?? null,
       });
 
+      // When there is no recommendation, result.reasoning names why —
+      // insufficient signal (zero contributions, BI-5CE7CF0B) vs no
+      // applicable principles vs no options — instead of a one-size message.
       const summary = result.recommendation
         ? `Recommends ${result.recommendation.optionId} (confidence: ${result.recommendation.confidence}, composite ${result.recommendation.composite.toFixed(3)}; governing profile: ${governingProfile.governingProfileKind})`
-        : "No applicable principles to evaluate.";
+        : result.reasoning;
 
       // Persist the consult to the DecisionInteraction ledger so the decision
       // governance hub can audit that the gate is in use (per-tier log at


### PR DESCRIPTION
## Summary

Fixes **BI-5CE7CF0B** — the operator, reviewing the new `/wiki/decisions` audit log, found a kernel consult (DI-417AA19D37C9) showing **"RECOMMENDED warn_only" with every principle contribution at 0.000**. The COO coworker confirmed and filed it: a zero-score ledger was being routed to a recommendation instead of an explicit insufficient-signal state. The "winner" at composite 0.000 was just input order.

## Changes

- **`decide()` zero-signal guard** (`option-scoring.ts`): when principles applied but every option × principle contribution is exactly zero (options passed without `features` maps and no semantic path available), return `recommendation: null` with a new `flags.insufficientSignal` and a reasoning string naming what was missing. Offsetting positive/negative contributions that net to zero are genuine signal and do **not** trip the guard (per-contribution check, not per-composite).
- **Ledger mapping** (`kernel-consult-ledger.ts`): insufficient-signal consults record as **escalate** (a real question the gate could not weigh → human review), distinct from **defer** (no applicable principles = coverage gap). `outcomePayload.insufficientSignal` persisted for the audit surface.
- **Tool response** (`mcp-tools.ts`): with no recommendation, `principle_decide` now surfaces `result.reasoning` (names the actual cause) instead of the blanket "No applicable principles to evaluate."
- **Audit drill-in** (`/wiki/decisions/[interactionId]`): "insufficient signal" badge + plain-language explanation; the "recommended" chip is suppressed — including for **historical** records, recognised by `composite === 0 && margin === 0`.

## Tests

- New `option-scoring.insufficient-signal.test.ts`: zero-signal → no recommendation; features present → normal recommendation; offsetting contributions → not flagged.
- `kernel-consult-ledger.test.ts`: insufficient-signal → escalate (new), no-signal → defer (unchanged).
- Golden-decisions gate + situational backtest green (20/20); full `tsc --noEmit` clean; sandbox local-CI gate passed (recorded by pregate).

UX-Fit-Decision: advisory-honesty change inside the existing decision audit drill-in; no new surface, no new controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
