### PR TITLE
feat(coworker): Proactivity → autonomous scheduled self-tasks (BI-3F09BDD4)

### DIFF
--- a/apps/web/lib/actions/proactivity.ts
+++ b/apps/web/lib/actions/proactivity.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/proactivity/proactivity-override-preferences";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 import { isProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import { reconcileCoworkerSelfTask } from "@/lib/operate/scheduled-jobs/coworker-self-tasks";
 
 type ManualProactivityPreferenceValue = {
   scope: "agent";
@@ -65,6 +66,16 @@ export async function saveCoworkerProactivityPreference(
     sourceAgentId: agentId,
     lastValidatedAt: now,
   });
+
+  // Bridge the setting to autonomous work: a coworker with a registered
+  // self-task self-drives on a cadence (assertive=daily, balanced=weekly,
+  // quiet=stand down) via the ScheduledAgentTask engine. Best-effort — a
+  // scheduling hiccup must not fail saving the preference itself.
+  try {
+    await reconcileCoworkerSelfTask(user.id, agentId, level);
+  } catch (err) {
+    console.error("[proactivity] reconcileCoworkerSelfTask failed", err);
+  }
 
   revalidatePath("/platform/ai");
   revalidatePath(`/platform/ai/agent/${agentId}`);

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    scheduledAgentTask: {
+      findMany: vi.fn().mockResolvedValue([]),
+      upsert: vi.fn().mockResolvedValue({}),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    scheduledJob: {
+      upsert: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+// Imported after the mock so the module picks up mocked prisma. The cron /
+// allocator helpers it imports are pure (no DB), so they run for real.
+import {
+  reconcileCoworkerSelfTask,
+  coworkerSelfTaskId,
+  COWORKER_SELF_TASKS,
+} from "./coworker-self-tasks";
+
+const MKT = "marketing-specialist";
+
+describe("coworkerSelfTaskId", () => {
+  it("is deterministic per (agent, user) so reconcile stays idempotent", () => {
+    expect(coworkerSelfTaskId(MKT, "u1")).toBe("self-marketing-specialist-u1");
+    expect(coworkerSelfTaskId(MKT, "u1")).toBe(coworkerSelfTaskId(MKT, "u1"));
+    expect(coworkerSelfTaskId(MKT, "u1")).not.toBe(coworkerSelfTaskId(MKT, "u2"));
+  });
+});
+
+describe("reconcileCoworkerSelfTask", () => {
+  it("does nothing for a coworker with no registered self-task", async () => {
+    const { prisma } = await import("@dpf/db");
+    const upsert = prisma.scheduledAgentTask.upsert as ReturnType<typeof vi.fn>;
+    upsert.mockClear();
+
+    const r = await reconcileCoworkerSelfTask("u1", "some-other-coworker", "assertive");
+
+    expect(r).toEqual({ ok: true, action: "none" });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("assertive schedules a daily task owned by the caller", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.scheduledAgentTask.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const upsert = prisma.scheduledAgentTask.upsert as ReturnType<typeof vi.fn>;
+    upsert.mockClear();
+
+    const r = await reconcileCoworkerSelfTask("u1", MKT, "assertive");
+
+    expect(r.action).toBe("scheduled");
+    expect(r.taskId).toBe("self-marketing-specialist-u1");
+    const call = upsert.mock.calls[0]![0];
+    expect(call.where).toEqual({ taskId: "self-marketing-specialist-u1" });
+    expect(call.create.ownerUserId).toBe("u1");
+    expect(call.create.agentId).toBe(MKT);
+    expect(call.create.routeContext).toBe("/customer/marketing");
+    expect(call.create.isActive).toBe(true);
+    // Daily cadence: cron day-of-week field is a wildcard.
+    expect(call.create.schedule.split(" ")[4]).toBe("*");
+  });
+
+  it("balanced schedules a weekly task (day-of-week pinned)", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.scheduledAgentTask.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const upsert = prisma.scheduledAgentTask.upsert as ReturnType<typeof vi.fn>;
+    upsert.mockClear();
+
+    const r = await reconcileCoworkerSelfTask("u1", MKT, "balanced");
+
+    expect(r.action).toBe("scheduled");
+    const call = upsert.mock.calls[0]![0];
+    // Weekly cadence: day-of-week field is a specific day, not a wildcard.
+    expect(call.create.schedule.split(" ")[4]).not.toBe("*");
+  });
+
+  it("quiet stands the coworker down without creating a task", async () => {
+    const { prisma } = await import("@dpf/db");
+    const upsert = prisma.scheduledAgentTask.upsert as ReturnType<typeof vi.fn>;
+    const updateMany = prisma.scheduledAgentTask.updateMany as ReturnType<typeof vi.fn>;
+    upsert.mockClear();
+    updateMany.mockClear();
+
+    const r = await reconcileCoworkerSelfTask("u1", MKT, "quiet");
+
+    expect(r.action).toBe("removed");
+    expect(upsert).not.toHaveBeenCalled();
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { taskId: "self-marketing-specialist-u1" },
+      data: { isActive: false },
+    });
+  });
+
+  it("registers the Marketing Strategist seed self-task", () => {
+    expect(COWORKER_SELF_TASKS[MKT]).toBeDefined();
+    expect(COWORKER_SELF_TASKS[MKT]!.routeContext).toBe("/customer/marketing");
+    expect(COWORKER_SELF_TASKS[MKT]!.prompt).toMatch(/create_marketing_campaign_brief/);
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
@@ -1,0 +1,161 @@
+// Proactivity → autonomous coworker self-tasks (BI-3F09BDD4, EP-B9DD37C7).
+//
+// The per-coworker Proactivity setting (quiet | balanced | assertive) is a promise
+// about how hard a coworker works. Until now it only shaped the in-conversation
+// prompt (the Initiative block) and notification cadence — an Assertive coworker
+// that no one messaged still did nothing, so pages like /customer/marketing stayed
+// empty. This wires the setting into the existing ScheduledAgentTask engine so an
+// Assertive coworker self-drives a recurring, role-appropriate task without a human
+// in the loop; the every-5-min agent-task-dispatch cron runs it.
+//
+// This is intentionally a small curated registry, NOT "every coworker gets a cron".
+// A coworker earns an autonomous self-task only when there is a concrete,
+// idempotent, non-destructive unit of work that is genuinely useful to run on a
+// cadence. The seed entry is the Marketing Strategist producing/refreshing a
+// campaign brief so the Campaigns page fills itself.
+
+import { prisma } from "@dpf/db";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import { SCHEDULING_MAP } from "@/lib/operate/scheduled-jobs/scheduling-map";
+import { occupiedTicks, deconflictCron } from "@/lib/operate/scheduled-jobs/scheduling-allocator";
+import { computeNextCronRun } from "@/lib/operate/cron-next-run";
+
+/**
+ * A coworker self-task definition. `cadence` maps the two work-producing
+ * proactivity levels to a cron expression; `quiet` never produces a task.
+ * Balanced runs weekly, Assertive runs daily — the operator's setting picks
+ * the intensity, the coworker does the same unit of work either way.
+ */
+export type CoworkerSelfTask = {
+  title: string;
+  /** The prompt the coworker runs on each tick. Must describe idempotent work. */
+  prompt: string;
+  /** Drives which coworker + which page-scoped tools the agentic loop attaches. */
+  routeContext: string;
+  cadence: {
+    balanced: string;
+    assertive: string;
+  };
+};
+
+/**
+ * Registry of coworkers that self-drive when their Proactivity is turned up.
+ * Keyed by agentId (the interactive coworker slug, e.g. "marketing-specialist").
+ */
+export const COWORKER_SELF_TASKS: Record<string, CoworkerSelfTask> = {
+  "marketing-specialist": {
+    title: "Refresh the acquisition campaign brief",
+    prompt: [
+      "You are running as a scheduled, autonomous task — no human is watching this",
+      "turn, so finish the work rather than asking questions.",
+      "",
+      "Goal: keep a current acquisition campaign brief on the Campaigns page so the",
+      "marketing surface is never empty. Steps:",
+      "1. Review the saved acquisition assumptions / ICP / positioning available to you",
+      "   (org context, prior campaigns, product catalog).",
+      "2. If there is NO active or recent campaign brief, create one with",
+      "   create_marketing_campaign_brief: a focused brief for the most promising",
+      "   segment, with objective, audience, channels, core message, and 3–5 concrete",
+      "   next actions.",
+      "3. If a recent brief already exists, do NOT duplicate it — instead refresh it",
+      "   only if assumptions have changed, otherwise stop.",
+      "Keep it grounded in real saved context; do not invent customers or numbers.",
+    ].join("\n"),
+    routeContext: "/customer/marketing",
+    cadence: {
+      // Weekly Monday and daily, both at 14:07 UTC — an off-peak minute the
+      // allocator is unlikely to collide, and deconflictCron shifts it if it does.
+      balanced: "7 14 * * 1",
+      assertive: "7 14 * * *",
+    },
+  },
+};
+
+/** Deterministic per-(agent, owner) taskId so reconcile is idempotent. */
+export function coworkerSelfTaskId(agentId: string, userId: string): string {
+  return `self-${agentId}-${userId}`;
+}
+
+export type ReconcileSelfTaskResult =
+  | { ok: true; action: "none" | "removed" | "scheduled"; taskId?: string; schedule?: string };
+
+/**
+ * Bring the coworker's autonomous self-task in line with `level`:
+ *   - no registry entry for this coworker → nothing to do;
+ *   - quiet → deactivate any existing self-task (coworker goes silent);
+ *   - balanced → weekly cadence; assertive → daily cadence (upsert, de-conflicted).
+ *
+ * Idempotent: keyed on a deterministic taskId, so flipping the setting back and
+ * forth never piles up duplicate schedules. userId-parameterized and not a
+ * "use server" export, so the caller must have already authorized `userId`.
+ */
+export async function reconcileCoworkerSelfTask(
+  userId: string,
+  agentId: string,
+  level: ProactivityLevel,
+): Promise<ReconcileSelfTaskResult> {
+  const entry = COWORKER_SELF_TASKS[agentId];
+  if (!entry) return { ok: true, action: "none" };
+
+  const taskId = coworkerSelfTaskId(agentId, userId);
+
+  // Quiet (or any non-producing level) → stand the coworker down.
+  if (level === "quiet") {
+    await prisma.scheduledAgentTask.updateMany({
+      where: { taskId },
+      data: { isActive: false },
+    });
+    await prisma.scheduledJob
+      .update({ where: { jobId: taskId }, data: { schedule: "disabled" } })
+      .catch(() => {});
+    return { ok: true, action: "removed", taskId };
+  }
+
+  const baseCron = level === "assertive" ? entry.cadence.assertive : entry.cadence.balanced;
+  const now = new Date();
+
+  // De-conflict against the canonical scheduling map and other live tasks
+  // (excluding this task's own row so a re-save doesn't collide with itself).
+  const liveTasks = await prisma.scheduledAgentTask.findMany({
+    where: { isActive: true, taskId: { not: taskId } },
+    select: { schedule: true },
+  });
+  const occupied = occupiedTicks([
+    ...SCHEDULING_MAP.map((e) => e.cron),
+    ...liveTasks.map((t) => t.schedule),
+  ]);
+  const { cron: schedule } = deconflictCron(baseCron, occupied);
+  const nextRunAt = computeNextCronRun(schedule, now);
+
+  await prisma.scheduledAgentTask.upsert({
+    where: { taskId },
+    create: {
+      taskId,
+      agentId,
+      title: entry.title,
+      prompt: entry.prompt,
+      routeContext: entry.routeContext,
+      schedule,
+      timezone: "UTC",
+      ownerUserId: userId,
+      nextRunAt,
+      isActive: true,
+    },
+    update: {
+      title: entry.title,
+      prompt: entry.prompt,
+      routeContext: entry.routeContext,
+      schedule,
+      nextRunAt,
+      isActive: true,
+    },
+  });
+
+  await prisma.scheduledJob.upsert({
+    where: { jobId: taskId },
+    create: { jobId: taskId, name: `Agent: ${entry.title}`, schedule, nextRunAt },
+    update: { name: `Agent: ${entry.title}`, schedule, nextRunAt },
+  });
+
+  return { ok: true, action: "scheduled", taskId, schedule };
+}

--- a/docs/superpowers/plans/2026-07-07-proactivity-autonomous-coworker-tasks-plan.md
+++ b/docs/superpowers/plans/2026-07-07-proactivity-autonomous-coworker-tasks-plan.md
@@ -1,0 +1,67 @@
+# Plan — Proactivity → autonomous coworker self-tasks (BI-3F09BDD4)
+
+Date: 2026-07-07. Epic: EP-B9DD37C7 (coworker trust / autonomy).
+
+## Problem
+
+The per-coworker **Proactivity** setting (quiet | balanced | assertive) reads as a
+promise that an Assertive coworker works harder on its own. It did not. The setting
+fed only two things: the in-conversation Initiative block (PR #2571) and notification
+cadence. With no human message, an Assertive coworker did nothing — so the Marketing
+Strategist sat at Assertive + Higher Reasoning while `/customer/marketing` stayed empty.
+The operator: *"Is the proactivity setting completely broken? I fail to see how it
+helps given what it was meant to help deliver in terms of autonomous activity."*
+
+The autonomous substrate already exists and is healthy — `ScheduledAgentTask` rows are
+run every 5 minutes by the `agent/task-dispatch` Inngest cron via
+`executeScheduledAgentTask`, which runs the named `agentId` in **act** mode with that
+coworker's granted tools. Four system tasks (Data Model Mirror, SysML Reconcile,
+External Catalog Scout, Discovery Taxonomy Triage) ride it nightly. Nothing connected
+the Proactivity toggle to it.
+
+## Substrate finding (dpf-verify-substrate-first)
+
+- Create/cancel API: `scheduleAgentTaskFor` / `cancelAgentTaskFor` in
+  `apps/web/lib/operate/scheduled-jobs/agent-task-core.ts` — userId-parameterized, not
+  `"use server"`. De-conflicts ticks (`occupiedTicks` + `deconflictCron`), mirrors a
+  `ScheduledJob` for calendar projection, computes `nextRunAt` via `computeNextCronRun`.
+- The Marketing Strategist (`marketing-specialist`) **already holds** `marketing_write`
+  and the `create_marketing_campaign_brief` tool. **No new tool or grant is needed** —
+  only something to trigger the work on a cadence.
+- Hook point: `saveCoworkerProactivityPreference` in `apps/web/lib/actions/proactivity.ts`.
+
+## Design
+
+- **`apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts`** (new):
+  - `COWORKER_SELF_TASKS`: a small curated registry keyed by agentId. A coworker earns
+    an autonomous self-task only when there is a concrete, **idempotent, non-destructive**
+    unit of work worth running on a cadence. Seed entry: `marketing-specialist` →
+    refresh/create a campaign brief on `/customer/marketing`, with a prompt that says to
+    finish (no human is watching) and to **not duplicate** an existing recent brief.
+  - `coworkerSelfTaskId(agentId, userId)` → deterministic `self-<agentId>-<userId>`, so
+    reconcile is idempotent (flipping the setting never piles up duplicate schedules).
+  - `reconcileCoworkerSelfTask(userId, agentId, level)`:
+    - no registry entry → `none`;
+    - `quiet` → deactivate the self-task (`isActive:false`) + disable its ScheduledJob;
+    - `balanced` → weekly cron; `assertive` → daily cron. De-conflicted, upserted by the
+      deterministic taskId, ScheduledJob mirrored. Cadence is the only difference between
+      balanced and assertive — same unit of work, dialed intensity.
+- **Hook**: `saveCoworkerProactivityPreference` calls `reconcileCoworkerSelfTask` after
+  persisting the fact, wrapped best-effort so a scheduling hiccup can't fail the save.
+
+No schema change: the deterministic taskId gives idempotency without a new column.
+
+## Verification
+
+- Unit tests (`coworker-self-tasks.test.ts`): deterministic id; no-entry no-op; assertive
+  = daily (DOW wildcard); balanced = weekly (DOW pinned); quiet = deactivate, no upsert;
+  seed entry shape.
+- Live: set the Marketing Strategist to Assertive → confirm a `self-marketing-specialist-*`
+  ScheduledAgentTask appears (active, daily) → on the next dispatch tick a campaign brief
+  populates `/customer/marketing`. Flip to Quiet → task deactivates.
+
+## Deliberately deferred
+
+- Broadening the registry beyond Marketing (CRM follow-up sweeps, etc.) — add entries as
+  each coworker gets a proven idempotent unit of work.
+- Per-user timezone for the cadence (engine is UTC-only today).


### PR DESCRIPTION
## Why

The per-coworker **Proactivity** setting (quiet / balanced / assertive) reads as a promise that an Assertive coworker works harder on its own — but it only shaped the in-conversation Initiative block and notification cadence. With no human message, an Assertive coworker did nothing, so the Marketing Strategist sat at Assertive + Higher Reasoning while `/customer/marketing` stayed empty. Operator: *"Is the proactivity setting completely broken? I fail to see how it helps given what it was meant to help deliver in terms of autonomous activity."*

## What

Bridge the setting to the **existing** `ScheduledAgentTask` engine (run every 5 min by the `agent/task-dispatch` cron, which runs the coworker in **act** mode with its granted tools):

- New `coworker-self-tasks.ts`: a small curated registry (`COWORKER_SELF_TASKS`) + `reconcileCoworkerSelfTask(userId, agentId, level)`.
  - `quiet` → deactivate the self-task; `balanced` → weekly; `assertive` → daily.
  - Deterministic `self-<agentId>-<userId>` taskId → idempotent (flipping the setting never piles up duplicate schedules). De-conflicted + ScheduledJob-mirrored like the manual create path.
- `saveCoworkerProactivityPreference` calls it (best-effort) after persisting the fact.
- **Seed entry**: `marketing-specialist` refreshes an acquisition campaign brief on `/customer/marketing` via `create_marketing_campaign_brief` — a tool it **already holds**. So the Campaigns page fills itself. **No new tool, grant, or schema change.**

## Verify

- Unit tests: deterministic id; no-entry no-op; assertive=daily (DOW wildcard); balanced=weekly (DOW pinned); quiet=deactivate (no upsert); seed shape. `6 passed`.
- Live (post-deploy): set Marketing Strategist → Assertive → a `self-marketing-specialist-*` task appears (active, daily) → next dispatch tick populates a campaign brief. Flip to Quiet → task deactivates.

Plan: `docs/superpowers/plans/2026-07-07-proactivity-autonomous-coworker-tasks-plan.md`. Epic EP-B9DD37C7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)