### PR TITLE
fix(reliability): grant-starvation loop breaker + sandbox cache-storm hardening

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -108,4 +108,7 @@ WORKDIR /workspace
 # Start the Next.js dev server if workspace is bootstrapped,
 # otherwise wait for it. The dev server keeps the container alive
 # and serves the app on port 3000 for the Build Studio preview.
-CMD ["sh", "-c", "while [ ! -f /workspace/.dpf-version ]; do echo 'Waiting for workspace bootstrap...'; sleep 5; done; cd /workspace && pnpm --filter web dev 2>&1 || sleep infinity"]
+# Clear any stale turbopack cache on boot: it lives on the persistent
+# /workspace volume, so a container restart would otherwise re-open a cache
+# a prior process left corrupt (deleted .sst files) and wedge in a CPU storm.
+CMD ["sh", "-c", "while [ ! -f /workspace/.dpf-version ]; do echo 'Waiting for workspace bootstrap...'; sleep 5; done; rm -rf /workspace/apps/web/.next/dev/cache 2>/dev/null || true; cd /workspace && pnpm --filter web dev 2>&1 || sleep infinity"]

--- a/apps/web/lib/actions/agent-thread-dispatcher-runtime.ts
+++ b/apps/web/lib/actions/agent-thread-dispatcher-runtime.ts
@@ -162,6 +162,37 @@ export async function runChildThreadExecution(context: ChildRuntimeContext): Pro
       mode: "act",
     });
 
+    // Grant preflight: if this agent holds no grant for a single tool it was
+    // handed, every tool call in the loop would be rejected with
+    // forbidden_grant. Fail fast with an actionable message instead of
+    // dispatching a loop that can only spin (the runAgenticLoop circuit breaker
+    // is the backstop; this avoids paying for the wasted inference calls). Only
+    // short-circuits total grant-starvation — an agent that can call even one
+    // tool proceeds normally.
+    const { agentHasAnyGrant } = await import("@/lib/mcp-governed-execute");
+    if (!(await agentHasAnyGrant(resolvedAgentId, tools.map((t) => t.name)))) {
+      const blockedMessage =
+        `Blocked — this agent's profile (${resolvedAgentId}) lacks a grant for any of the tools it needs, ` +
+        `so it cannot act on this work. A platform operator must grant it the required tools ` +
+        `(or route the work to a peer that already holds them).`;
+      console.warn(
+        `[agent-thread-dispatcher] grant-preflight blocked agent=${JSON.stringify(resolvedAgentId)} ` +
+        `thread=${JSON.stringify(context.threadId)} toolCount=${tools.length}`,
+      );
+      await prisma.agentMessage.create({
+        data: {
+          threadId: context.threadId,
+          taskRunId: context.taskRunId,
+          role: "assistant",
+          content: blockedMessage,
+          agentId: resolvedAgentId,
+          routeContext: context.routeContext,
+        },
+      });
+      await markChildThreadFailed(context, blockedMessage);
+      return;
+    }
+
     const result = await executeAutonomousAgenticLoop({
       systemPrompt: agentInfo.systemPrompt,
       chatHistory,

--- a/apps/web/lib/integrate/sandbox/sandbox.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildSandboxAppsWebCopyCommand,
+  buildSandboxDevServerStopCommand,
   buildDockerExecSandboxCommand,
   buildSandboxDiffForFilesCommand,
   buildSandboxCreateArgs,
@@ -258,6 +259,30 @@ describe("sandbox workspace initialization helpers", () => {
     expect(command).toContain("rm -rf /workspace/apps/web/node_modules");
     expect(command).toContain("/workspace/apps/web/.next");
     expect(command).toContain("/workspace/apps/web/tsconfig.tsbuildinfo");
+  });
+
+  it("stops the dev server BEFORE deleting .next so turbopack's cache is never yanked mid-run", () => {
+    const command = buildSandboxWorkspaceCleanupCommand();
+
+    // The dev-server stop must precede the destructive rm of .next.
+    const stopIdx = command.indexOf("pkill");
+    const rmIdx = command.indexOf("rm -rf");
+    expect(stopIdx).toBeGreaterThanOrEqual(0);
+    expect(rmIdx).toBeGreaterThan(stopIdx);
+    // Best-effort, never fails the sequence.
+    expect(command).toContain("|| true");
+  });
+
+  it("builds a best-effort dev-server stop command that frees the turbopack process", () => {
+    const command = buildSandboxDevServerStopCommand();
+
+    expect(command).toContain("pkill -f 'next dev'");
+    expect(command).toContain("pkill -f next-server");
+    expect(command).toContain("sleep 1");
+    // Every stanza tolerates "no such process" so a clean sandbox is a no-op.
+    expect(command).toContain("|| true");
+    // Must not hard-quote in a way that breaks the JSON.stringify exec sites.
+    expect(command).not.toContain('"');
   });
 
   it("copies root scripts so workspace postinstall hooks can run in the sandbox", () => {

--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -191,9 +191,32 @@ export function buildSandboxRootScriptsCopyCommand(
   return `docker exec ${portalContainer} tar -cf - -C /app scripts | docker exec -i ${containerId} tar -xf - -C /workspace`;
 }
 
-export function buildSandboxWorkspaceCleanupCommand(workspace: string = SANDBOX_WORKSPACE): string {
+/**
+ * Stop any running Next.js/Turbopack dev server in the sandbox before the
+ * workspace is mutated. Deleting apps/web/.next out from under a live turbopack
+ * process yanks its persistent cache (.sst files) and wedges it in a retry
+ * storm (~485% CPU) that a container restart does NOT clear — the corrupt cache
+ * lives on the persistent /workspace volume. Each stanza is best-effort so a
+ * container image without a given signal (or with nothing running) is a no-op;
+ * the `sleep` lets the process release file handles before the caller deletes
+ * the tree. Uses only single-quoted patterns so it is safe both under
+ * quotePosixArg (execInSandbox) and under the JSON.stringify exec sites.
+ */
+export function buildSandboxDevServerStopCommand(): string {
   return [
-    `rm -rf ${workspace}/apps/web/node_modules`,
+    "pkill -f 'next dev' 2>/dev/null || true",
+    "pkill -f next-server 2>/dev/null || true",
+    "pkill -f 'filter web dev' 2>/dev/null || true",
+    "sleep 1",
+    "true",
+  ].join("; ");
+}
+
+export function buildSandboxWorkspaceCleanupCommand(workspace: string = SANDBOX_WORKSPACE): string {
+  // Stop the dev server FIRST so the rm below never corrupts a live turbopack
+  // cache (the 2026-07-06 sandbox CPU-storm root cause).
+  return [
+    `${buildSandboxDevServerStopCommand()}; rm -rf ${workspace}/apps/web/node_modules`,
     `${workspace}/apps/web/.next`,
     `${workspace}/apps/web/tsconfig.tsbuildinfo`,
   ].join(" ");
@@ -391,8 +414,22 @@ export async function startSandboxDevServer(containerId: string): Promise<void> 
       `docker exec ${containerId} sh -c "ss -tlnp 2>/dev/null | grep ':3000' || echo none"`,
     );
     if (stdout.trim() !== "none") {
-      console.log("[sandbox] port 3000 already in use — server running");
-      return;
+      // Bound — but a turbopack process wedged on a corrupt cache stays BOUND
+      // while erroring on every request (the ~485% CPU storm). Skipping
+      // relaunch on "bound" alone is why such a wedge never auto-recovered.
+      // Only skip if it is actually SERVING; otherwise kill it and fall
+      // through to a clean relaunch.
+      const healthy = await exec(
+        `docker exec ${containerId} sh -c "wget -qO /dev/null http://127.0.0.1:3000/api/health"`,
+      ).then(() => true).catch(() => false);
+      if (healthy) {
+        console.log("[sandbox] port 3000 already in use — server healthy");
+        return;
+      }
+      console.warn("[sandbox] port 3000 bound but not serving — killing wedged dev server and relaunching");
+      await exec(
+        `docker exec ${containerId} sh -c ${JSON.stringify(buildSandboxDevServerStopCommand())}`,
+      ).catch(() => { /* best-effort; relaunch attempts regardless */ });
     }
   } catch { /* proceed to start */ }
 

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _setGovernanceForTests,
+  agentHasAnyGrant,
   governedExecuteTool,
   registerToolLifecycleHook,
 } from "./mcp-governed-execute";
@@ -619,5 +620,30 @@ describe("governedExecuteTool — Work Case receipt context", () => {
         toolExecutionId: "tool-exec-work-case-2",
       }),
     );
+  });
+});
+
+describe("agentHasAnyGrant (autonomous dispatch preflight)", () => {
+  it("returns false when the agent can call none of its tools", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => [],
+      isAllowedByGrants: () => false,
+    });
+    const result = await agentHasAnyGrant("build-architect", ["read_sandbox_file", "run_sandbox_command"]);
+    expect(result).toBe(false);
+  });
+
+  it("returns true when the agent can call at least one tool", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["sandbox_read"],
+      isAllowedByGrants: (toolName: string) => toolName === "read_sandbox_file",
+    });
+    const result = await agentHasAnyGrant("build-architect", ["run_sandbox_command", "read_sandbox_file"]);
+    expect(result).toBe(true);
+  });
+
+  it("returns true (nothing to gate) when no tools are attached", async () => {
+    _setGovernanceForTests({ resolveAgentGrants: async () => [], isAllowedByGrants: () => false });
+    expect(await agentHasAnyGrant("any-agent", [])).toBe(true);
   });
 });

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -194,6 +194,23 @@ async function isAllowedByGrants(toolName: string, grants: string[]): Promise<bo
   return isToolAllowedByGrants(toolName, grants);
 }
 
+/**
+ * Preflight for autonomous dispatch: does this agent hold a grant for at least
+ * one of the given tools? An agent that can call NOTHING it was handed will
+ * have every tool call rejected with `forbidden_grant` — entering an agentic
+ * loop just burns inference calls before the circuit breaker stops it. Callers
+ * use this to fail fast with an actionable "needs grant" message instead.
+ * Read-only; uses the same grant resolution as the execution-time check.
+ */
+export async function agentHasAnyGrant(agentId: string, toolNames: string[]): Promise<boolean> {
+  if (toolNames.length === 0) return true; // no tools attached → nothing to gate
+  const grants = await resolveGrants(agentId);
+  for (const name of toolNames) {
+    if (await isAllowedByGrants(name, grants)) return true;
+  }
+  return false;
+}
+
 async function callExecuteTool(
   toolName: string,
   params: Record<string, unknown>,

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -569,6 +569,40 @@ describe("runAgenticLoop", () => {
     );
   });
 
+  it("breaks early with a blocked status when every tool call is forbidden_grant (no full-duration spin)", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+
+    // Model keeps emitting tool calls with VARYING args (as the real
+    // grant-starved loop did) so the exact-args repetition detector never
+    // fires — only the grant-starvation circuit breaker should stop it.
+    let call = 0;
+    mockRoute.mockImplementation(async () =>
+      mockResult({
+        content: "Let me use a tool.",
+        toolCalls: [
+          { id: `toolu_${call}`, name: "search_project_files", arguments: { query: `attempt-${call++}` } },
+        ],
+      }),
+    );
+
+    // Every governed execution is rejected for a missing grant.
+    vi.mocked(governedExecuteTool).mockResolvedValue({
+      success: false,
+      error: "forbidden_grant",
+      message: "search_project_files rejected: agent lacks a required grant",
+    } as never);
+
+    const result = await runAgenticLoop({ ...baseParams, agentId: "build-architect" });
+
+    // Honest, actionable blocked message that names the agent + the tool.
+    expect(result.content).toContain("Blocked");
+    expect(result.content).toContain("forbidden_grant");
+    expect(result.content).toContain("search_project_files");
+    expect(result.content).toContain("build-architect");
+    // Broke on the streak (3), did NOT burn toward MAX_ITERATIONS (200).
+    expect(vi.mocked(governedExecuteTool).mock.calls.length).toBeLessThan(10);
+  });
+
   it("returns a visible diagnostic instead of issuing a second local-model nudge on non-build tool turns", async () => {
     const mockRoute = vi.mocked(routeAndCall);
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1279,6 +1279,17 @@ export async function runAgenticLoop(params: {
   let ctxPeakTokens = 0; // Peak assembled context (est. tokens) this turn — dumb-zone gauge.
   let resolvedMaxContextTokens: number | null = null; // BI-9679EB1A: learned from the first dispatch; sizes compaction + the gauge to the real window.
   let sandboxUnavailableCount = 0; // Circuit breaker: stop trying sandbox tools if unavailable
+  // Grant-starvation circuit breaker: an agent whose profile lacks the grants
+  // for the tools it was handed keeps emitting tool calls that all return
+  // `forbidden_grant`. Without this, the loop burns the full MAX_ITERATIONS /
+  // MAX_DURATION with executedTools=0 (observed 2026-07-06: build-architect on
+  // a build-pipeline thread spun ~500s, iter=200, zero tools executed). The
+  // repetition detector doesn't fire because the model keeps trying DIFFERENT
+  // forbidden tools; the nudge cap (1) is spent after the first iteration. We
+  // count consecutive forbidden_grant rejections and reset on ANY tool success,
+  // so a legitimately mixed grant surface (some tools allowed) never trips it.
+  let forbiddenGrantStreak = 0;
+  const forbiddenGrantTools = new Set<string>(); // names seen rejected, for the blocked message
   let previousResponseId: string | undefined; // Responses API conversation chaining
 
   // Per-turn observability: one structured summary line with the correlation
@@ -1361,6 +1372,35 @@ export async function runAgenticLoop(params: {
       console.warn(`[agentic-loop] sandbox unavailable after ${sandboxUnavailableCount} attempts. Aborting loop.`);
       return {
         content: "The sandbox is not available — no slots are free. Please ensure the sandbox container is running (check Docker Desktop), then try again.",
+        providerId: lastResult?.providerId ?? "",
+        modelId: lastResult?.modelId ?? "",
+        downgraded: lastResult?.downgraded ?? false,
+        downgradeMessage: lastResult?.downgradeMessage ?? null,
+        totalInputTokens,
+        totalOutputTokens,
+        executedTools,
+        proposal: null,
+      };
+    }
+
+    // Grant-starvation circuit breaker — after 3 consecutive forbidden_grant
+    // rejections with no intervening success, this agent's profile is missing
+    // the grants for the work it was handed. Continuing only burns iterations
+    // (repetition detector won't fire — the model varies which forbidden tool
+    // it tries). Exit with an actionable, honest blocked status that names the
+    // held-back tools so the operator can grant them, rather than spinning to
+    // MAX_DURATION with executedTools=0.
+    if (forbiddenGrantStreak >= 3) {
+      const blockedTools = Array.from(forbiddenGrantTools).sort();
+      console.warn(
+        `[agentic-loop] grant-starved: ${forbiddenGrantStreak} consecutive forbidden_grant rejections. ` +
+        `agent=${JSON.stringify(agentId)} route=${JSON.stringify(routeContext)} tools=${JSON.stringify(blockedTools)}. Aborting loop.`,
+      );
+      return {
+        content:
+          `Blocked — hard stop, not a retry situation. This agent's profile lacks the grant(s) required for ` +
+          `the tools it needs: ${blockedTools.join(", ")}. Every attempt was rejected with \`forbidden_grant\`. ` +
+          `A platform operator needs to grant \`${agentId}\` access to these tools (or hand the work to a peer that already holds them) before it can proceed.`,
         providerId: lastResult?.providerId ?? "",
         modelId: lastResult?.modelId ?? "",
         downgraded: lastResult?.downgraded ?? false,
@@ -2279,6 +2319,17 @@ export async function runAgenticLoop(params: {
       // Sandbox circuit breaker: track consecutive unavailable responses
       if (!toolResult.success && (toolResult.error ?? toolResult.message ?? "").includes("No sandbox slots available")) {
         sandboxUnavailableCount++;
+      }
+
+      // Grant-starvation circuit breaker: governedExecuteTool returns the
+      // rejection code in `error` ("forbidden_grant"). Count consecutive
+      // rejections; any successful tool clears the streak so a mixed surface
+      // (some grants present) never trips it.
+      if (!toolResult.success && toolResult.error === "forbidden_grant") {
+        forbiddenGrantStreak++;
+        forbiddenGrantTools.add(tc.name);
+      } else if (toolResult.success) {
+        forbiddenGrantStreak = 0;
       }
 
       executedTools.push({ name: tc.name, args: tc.arguments, result: toolResult });


### PR DESCRIPTION
## Why

Incident 2026-07-06: "portal unresponsive in the browser" + an AI coworker stuck at 500s. Root-caused to **three independent failure modes**, none of which was the portal itself (which stayed healthy at ~15ms). Each shared one anti-pattern — *the system detected the failure but never recovered from it*.

## The three failures & fixes

**1. Coworker spins to timeout on a grant-starved loop** (`fix(coworker)`)
An agent whose profile lacks grants for its tools keeps emitting calls that all return `forbidden_grant`. The loop treated each as an ordinary failure: the repetition detector never fires (the model varies which forbidden tool it tries) and the nudge cap is spent after iteration 1 — so it burned the full `MAX_ITERATIONS(200)`/`MAX_DURATION` with `executedTools=0` (observed: `build-architect` spun ~500s).
- `runAgenticLoop`: a **`forbidden_grant` circuit breaker** — counts consecutive rejections, resets on any tool success, and after 3 exits with an honest *"blocked — needs grant X"* message naming the held-back tools. Universal across chat/autonomous/build/proactive paths; cannot false-block a baseline-read chat coworker.
- `mcp-governed-execute`: exports `agentHasAnyGrant()` reusing the execution-time grant resolution.
- `agent-thread-dispatcher-runtime`: **fast-fail preflight** — a dispatched child agent with no grant for any handed tool is blocked *before* the loop.

**2. Sandbox CPU storm from a yanked Turbopack cache** (`fix(sandbox)`)
Build workspace-init ran `rm -rf apps/web/.next` while the long-lived Turbopack dev server on the shared `/workspace` volume still held it → `TurbopackInternalError` retry storm (~485% CPU). A container restart didn't clear it (cache lives on the persistent volume), and `startSandboxDevServer` returned early whenever `:3000` was merely *bound* — so a wedged process was never relaunched.
- Stop the dev server **before** the `.next` cleanup (folded into `buildSandboxWorkspaceCleanupCommand`).
- `startSandboxDevServer` now probes `/api/health`; skips relaunch only if actually *serving*, else kills + relaunches (self-heal).
- `Dockerfile.sandbox`: clears a stale turbopack cache on boot (defense-in-depth).

**3. Zombie `working` TaskRuns — dormant watchdog** *(applied live, no code diff)*
The stall watchdog is fully built (cron `* * * * *`, thresholds seeded) but gated behind `STALL_WATCHDOG_ENABLED`, which was unset → off. Enabled via the `PlatformConfig` row (the intended operator-controlled path) and **verified live end-to-end**: a synthetic stale run was reaped to `stalled` within ~30s with a `StallEvent` written.

## Verification
- 151 unit tests pass (incl. new regression tests for the breaker, preflight, and sandbox stop-before-cleanup).
- `tsc --noEmit` clean; pre-commit typecheck green on both commits.
- Local-CI pregate: **gate passed** (full production build compiled).
- #3 verified live on this install.

## Deploy note
The portal-side code (#1 loop/dispatch, #2 sandbox) goes live on the next portal image deploy. The watchdog activation (#3) is already live now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
