### PR TITLE
fix(coworker-grants): durable grant-drift fix — AI Ops Engineer backlog access + estate-specialist least-privilege

### DIFF
--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -75,6 +75,26 @@ describe("coworker seed invariants", () => {
     expect(grants).not.toContain("marketing_read");
   });
 
+  it("grants platform-engineer (AI Ops Engineer) backlog_read + backlog_write so it can file readiness findings", () => {
+    // The AI Ops Engineer resolves its runtime grants from THIS map, not
+    // agent_registry.json. Regression guard for BI-CAP-CBC41758: it observed
+    // capability needs on /platform/ai/readiness but its grant set had dropped
+    // backlog_read/backlog_write, so it could not file or track the issues it found.
+    const grants = HARDCODED_COWORKER_GRANTS["platform-engineer"];
+    expect(grants).toEqual(expect.arrayContaining(["backlog_read", "backlog_write"]));
+  });
+
+  it("keeps inventory-specialist scoped to estate stewardship — no AI-ops agent_control_read", () => {
+    // Regression guard for BI-CAP-C2565D94 (tool-surface overload). The Digital
+    // Product Estate Specialist stewards products via registry_*/backlog; the
+    // AI-ops agent_control_read grant (add_provider, configure_gateway_scan,
+    // manage_coworker_tool_grant, …) was out-of-role and only inflated its surface.
+    const grants = HARDCODED_COWORKER_GRANTS["inventory-specialist"];
+    expect(grants).toEqual(expect.arrayContaining(["registry_read", "registry_write", "backlog_read", "backlog_write"]));
+    expect(grants).not.toContain("agent_control_read");
+    expect(grants).not.toContain("portfolio_read");
+  });
+
   it("binds every hardcoded coworker seed to one profession family", () => {
     const registeredRoles = new Map<string, string>();
     const duplicates: string[] = [];

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -237,13 +237,17 @@ export const COWORKER_AGENT_SEEDS: readonly CoworkerAgentSeed[] = [
 export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
   "portfolio-advisor": ["portfolio_read", "registry_read", "backlog_read"],
   "external-catalog-scout": ["backlog_read", "backlog_write", "registry_read"],
+  // The Digital Product Estate Specialist stewards the product estate (discovery
+  // triage, portfolio quality) via registry_read/registry_write + backlog. It does
+  // NOT do AI-ops: agent_control_read (add_provider, configure_gateway_scan,
+  // manage_coworker_tool_grant, grok_signin, …) was out-of-role and only inflated
+  // its tool surface (BI-CAP-C2565D94). portfolio_read added no reachable tool that
+  // registry_read didn't already cover. Both removed for least-privilege.
   "inventory-specialist": [
-    "portfolio_read",
     "registry_read",
     "registry_write",
     "backlog_read",
     "backlog_write",
-    "agent_control_read",
   ],
   "ea-architect": ["ea_graph_read", "ea_graph_write", "architecture_read", "file_read", "registry_read"],
   "hr-specialist": ["registry_read", "consumer_read", "consumer_write"],
@@ -270,7 +274,12 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
     "web_search",
   ],
   "ops-coordinator": ["backlog_read", "backlog_write", "backlog_triage", "registry_read", "portfolio_read"],
-  "platform-engineer": ["agent_control_read", "admin_read", "admin_write", "registry_read", "telemetry_read"],
+  // The AI Ops Engineer runs the /platform/ai/readiness surface: it observes
+  // coworker capability needs and must be able to file/track backlog items for the
+  // issues it detects. Its runtime grants resolve from THIS map (not
+  // agent_registry.json, which already intends backlog access), so backlog_read/
+  // backlog_write must live here to reach its tool surface (BI-CAP-CBC41758).
+  "platform-engineer": ["agent_control_read", "admin_read", "admin_write", "registry_read", "telemetry_read", "backlog_read", "backlog_write"],
   "build-specialist": [
     "file_read",
     "code_graph_read",


### PR DESCRIPTION
## What

Durable fix for two stuck AI-coworker capability-need backlog items, both caused by the same mechanism: **coworker runtime grants resolve from `HARDCODED_COWORKER_GRANTS` in `packages/db/src/workforce-seed.ts`, which is re-applied on every portal boot.** So `manage_coworker_tool_grant` (MCP door) and admin-console writes that deviate from this map are reverted on the next reconcile — the change has to be made here to stick.

| Coworker | Change | Closes |
|---|---|---|
| `platform-engineer` (AI Ops Engineer) | **+ `backlog_read`, `backlog_write`** | BI-CAP-CBC41758 |
| `inventory-specialist` (Digital Product Estate Specialist) | **− `agent_control_read`, `portfolio_read`** | BI-CAP-C2565D94 (partial) |

## Why

- **platform-engineer** runs `/platform/ai/readiness`: it observes coworker capability needs but its grant set had dropped backlog access, so it could not file or track the issues it detected (its own reported gap). `agent_registry.json` already intends backlog access for it; the runtime map had drifted.
- **inventory-specialist** carried the AI-ops `agent_control_read` grant (`add_provider`, `configure_gateway_scan`, `manage_coworker_tool_grant`, `grok_signin`, …) plus a redundant `portfolio_read` — both out-of-role for product-estate stewardship and only inflating its tool surface. Least-privilege trim; `registry_*` + `backlog` stewardship grants retained.

## Scope note — this does NOT clear the "tool-surface overload" signal

The two `[tool]` capability-needs recur because the overload classifier's local-selection cliff (**15**) sits **below the mandatory coworker read surface** (`registry_read` alone → 30 tools; full read baseline ≈ 68), so `classifyToolSurfaceOverload` fires on essentially every coworker regardless of grants. And `external-catalog-scout` cannot be trimmed at all — its `backlog_write` carries `run_hive_scout_ingest` (its daily catalog pass). That calibration defect is the real remediation and is tracked separately in **BI-3346DC28**. This PR is the durable grant-provisioning half only.

## Tests

Regression guards added in `seed.test.ts` for both grant sets (matches the existing per-coworker guard convention, e.g. customer-advisor). Local run skipped (fresh worktree without installed deps); relying on CI for the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)