### PR TITLE
chore(ci): re-baseline module-size guard to green — make it enforceable

### DIFF
--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -17,7 +17,7 @@
   "apps/web/instrumentation.test.ts": 826,
   "apps/web/instrumentation.ts": 1337,
   "apps/web/lib/actions/agent-coworker-external.test.ts": 866,
-  "apps/web/lib/actions/agent-coworker.ts": 2620,
+  "apps/web/lib/actions/agent-coworker.ts": 2632,
   "apps/web/lib/actions/agent-task-scheduler.test.ts": 890,
   "apps/web/lib/actions/ai-providers.ts": 920,
   "apps/web/lib/actions/build-governed.test.ts": 1114,


### PR DESCRIPTION
Second re-baseline (see #2681). #2680 grew `agent-coworker.ts` (2620→2632) while the guard was still advisory, re-reddening main minutes after #2681 greened it — the churn that proves an advisory ratchet can't hold.

This greens main; immediately after it lands, **Module Size Guard** is promoted to a **required** status check so no PR can grow a baselined file again without re-baselining in the same PR (drift stops at the source).

Kernel: `principle_decide` → **make_required**, high confidence (composite 6.93, margin 5.59; Architecture Over Shortcuts + Build Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)