### PR TITLE
fix(pattern-observer): tool-surface overload must not fire on the raw count alone (BI-3346DC28)

### DIFF
--- a/apps/web/lib/tak/context-economy-metrics.test.ts
+++ b/apps/web/lib/tak/context-economy-metrics.test.ts
@@ -50,6 +50,21 @@ describe("assessToolSurface", () => {
     expect(a.windowShare).not.toBeNull();
     expect(a.zone).toBe("overload");
   });
+
+  it("a known LARGE window supersedes the raw-count cliff (BI-3346DC28)", () => {
+    // 20 tools (past the cliff) but they occupy a trivial share of a big cloud
+    // window → genuinely lean for the model that serves it, NOT overload.
+    const a = assessToolSurface({ tools: mk(LOCAL_TOOL_SELECTION_CLIFF + 5), windowTokens: 200_000 });
+    expect(a.exceedsLocalCliff).toBe(true); // still reported for observability
+    expect(a.windowShare).toBeLessThan(0.15);
+    expect(a.zone).toBe("lean");
+  });
+
+  it("the same surface in a SMALL window is still overload (via windowShare)", () => {
+    const a = assessToolSurface({ tools: mk(LOCAL_TOOL_SELECTION_CLIFF + 5), windowTokens: 600 });
+    expect(a.windowShare).toBeGreaterThanOrEqual(0.25);
+    expect(a.zone).toBe("overload");
+  });
 });
 
 describe("computeToolSelectionAccuracy", () => {

--- a/apps/web/lib/tak/context-economy-metrics.ts
+++ b/apps/web/lib/tak/context-economy-metrics.ts
@@ -78,13 +78,23 @@ export function assessToolSurface(input: {
   const win = typeof input.windowTokens === "number" && input.windowTokens > 0 ? input.windowTokens : 0;
   const windowShare = win > 0 ? estDefinitionTokens / win : null;
 
+  // The raw-count cliff (LOCAL_TOOL_SELECTION_CLIFF) is a PROXY for "a small
+  // local model with a small window" — the regime where selection accuracy
+  // collapses past ~15 tools. When the REAL window is known, its definition-
+  // share is the authoritative signal and supersedes the proxy: a 68-tool
+  // surface that occupies 8% of a large cloud window is genuinely lean for the
+  // model that will serve it, even though it exceeds the local cliff. Applying
+  // the count cliff unconditionally mis-flagged every cloud-served coworker as
+  // "overload" forever (BI-3346DC28), because the mandatory read baseline alone
+  // already exceeds the cliff. So band by windowShare when the window is known;
+  // fall back to the count cliff only when it is not.
   let zone: ToolSurfaceZone = "lean";
-  if (exceedsLocalCliff || (windowShare !== null && windowShare >= SURFACE_OVERLOAD_WINDOW_SHARE)) {
+  if (windowShare !== null) {
+    if (windowShare >= SURFACE_OVERLOAD_WINDOW_SHARE) zone = "overload";
+    else if (windowShare >= SURFACE_CAUTION_WINDOW_SHARE) zone = "caution";
+  } else if (exceedsLocalCliff) {
     zone = "overload";
-  } else if (
-    toolCount > Math.floor(LOCAL_TOOL_SELECTION_CLIFF * SURFACE_CAUTION_COUNT_RATIO) ||
-    (windowShare !== null && windowShare >= SURFACE_CAUTION_WINDOW_SHARE)
-  ) {
+  } else if (toolCount > Math.floor(LOCAL_TOOL_SELECTION_CLIFF * SURFACE_CAUTION_COUNT_RATIO)) {
     zone = "caution";
   }
   return { toolCount, estDefinitionTokens, exceedsLocalCliff, windowShare, zone };

--- a/apps/web/lib/tak/pattern-observer/classifiers.test.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.test.ts
@@ -152,6 +152,49 @@ describe("pattern observer classifiers", () => {
         }),
       ).toBeNull();
     });
+
+    // BI-3346DC28: a surface past the raw-count cliff with an UNKNOWN window is
+    // only a PROXY for local-model overload. It must not fire on the count alone.
+    const proxyOverload: ToolSurfaceAssessment = {
+      toolCount: 68,
+      estDefinitionTokens: 16000,
+      exceedsLocalCliff: true,
+      windowShare: null,
+      zone: "overload",
+    };
+
+    it("suppresses a count-proxy overload when tool selection is demonstrably healthy", () => {
+      const healthy: ToolSelectionAccuracy = { total: 20, succeeded: 20, accuracy: 1, perTool: {} };
+      expect(classifyToolSurfaceOverload(proxyOverload, healthy)).toBeNull();
+    });
+
+    it("suppresses a count-proxy overload when there is no corroborating evidence", () => {
+      expect(classifyToolSurfaceOverload(proxyOverload, null)).toBeNull();
+      const tinySample: ToolSelectionAccuracy = { total: 1, succeeded: 0, accuracy: 0, perTool: {} };
+      expect(classifyToolSurfaceOverload(proxyOverload, tinySample)).toBeNull();
+    });
+
+    it("fires a count-proxy overload only when selection is actually degrading", () => {
+      const degraded: ToolSelectionAccuracy = { total: 10, succeeded: 6, accuracy: 0.6, perTool: {} };
+      const need = classifyToolSurfaceOverload(proxyOverload, degraded);
+      expect(need).toMatchObject({ kind: "tool", severity: "important" });
+      expect(need?.evidenceJson).toMatchObject({ observedSelectionAccuracy: 0.6, observedSelectionSample: 10 });
+    });
+
+    it("fires a window-known overload directly — definitions crowd the real window", () => {
+      const knownOverload: ToolSurfaceAssessment = {
+        toolCount: 40,
+        estDefinitionTokens: 9000,
+        exceedsLocalCliff: true,
+        windowShare: 0.4,
+        zone: "overload",
+      };
+      // No selection evidence needed: windowShare is mechanistic, not a proxy.
+      expect(classifyToolSurfaceOverload(knownOverload)).toMatchObject({
+        kind: "tool",
+        severity: "important",
+      });
+    });
   });
 
   describe("classifyRepeatedSuccess", () => {

--- a/apps/web/lib/tak/pattern-observer/classifiers.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.ts
@@ -64,13 +64,23 @@ export function classifyGrantDenial(
   };
 }
 
-function toolSurfaceEvidence(assessment: ToolSurfaceAssessment): Record<string, unknown> {
+// Minimum executed tool-call sample before observed selection accuracy is
+// trustworthy enough to CONFIRM or REFUTE a count-proxy overload prediction.
+const MIN_SELECTION_SAMPLE_FOR_OVERLOAD = 3;
+
+function toolSurfaceEvidence(
+  assessment: ToolSurfaceAssessment,
+  selection?: ToolSelectionAccuracy | null,
+): Record<string, unknown> {
   return {
     toolCount: assessment.toolCount,
     estDefinitionTokens: assessment.estDefinitionTokens,
     windowShare: assessment.windowShare,
     zone: assessment.zone,
     exceedsLocalCliff: assessment.exceedsLocalCliff,
+    ...(selection
+      ? { observedSelectionAccuracy: selection.accuracy, observedSelectionSample: selection.total }
+      : {}),
   };
 }
 
@@ -78,22 +88,48 @@ function isNearLocalCliff(toolCount: number): boolean {
   return toolCount >= LOCAL_TOOL_SELECTION_CLIFF - NEAR_LOCAL_CLIFF_DISTANCE;
 }
 
+/** True only when there is a meaningful sample AND accuracy is below healthy —
+ *  i.e. positive evidence that selection is actually degrading on this surface. */
+function selectionIsDegraded(selection?: ToolSelectionAccuracy | null): boolean {
+  if (!selection || selection.total < MIN_SELECTION_SAMPLE_FOR_OVERLOAD) return false;
+  return selection.accuracy < MIN_SUCCESSFUL_WORKFLOW_ACCURACY;
+}
+
 export function classifyToolSurfaceOverload(
   assessment: ToolSurfaceAssessment,
+  selection?: ToolSelectionAccuracy | null,
 ): CoworkerCapabilityNeedInput | null {
-  if (assessment.zone === "overload" || assessment.exceedsLocalCliff) {
+  const windowKnown = assessment.windowShare !== null;
+
+  // Two overload regimes, only one of which is self-evidently real:
+  //  • window KNOWN and definitions crowd it (zone === "overload") — mechanistic
+  //    evidence the surface eats the model's window; fire directly.
+  //  • window UNKNOWN and past the raw-count local cliff — the cliff is only a
+  //    PROXY for a small local window. Fire ONLY with corroborating evidence
+  //    that tool selection is actually degrading. A large surface a model
+  //    selects across accurately is not overloaded; asserting otherwise on the
+  //    count alone mis-flagged every cloud-served coworker forever (BI-3346DC28).
+  const knownOverload = windowKnown && assessment.zone === "overload";
+  const proxyOverload = !windowKnown && assessment.exceedsLocalCliff;
+
+  if (knownOverload || (proxyOverload && selectionIsDegraded(selection))) {
     return {
       kind: "tool",
       severity: "important",
       need: "Reduce or phase-scope the coworker's tool surface before local selection degrades.",
       blocks: "The current tool surface risks unreliable tool selection.",
-      evidenceJson: toolSurfaceEvidence(assessment),
+      evidenceJson: toolSurfaceEvidence(assessment, selection),
     };
   }
 
+  // A count-proxy overload we could not corroborate is SUPPRESSED (not
+  // downgraded): asserting overload without evidence is exactly the recurring
+  // false-positive this fixes. Evidence-before-diagnosis.
+  if (proxyOverload) return null;
+
   const cautionIsActionable =
     assessment.zone === "caution" &&
-    (isNearLocalCliff(assessment.toolCount) || assessment.windowShare !== null);
+    (isNearLocalCliff(assessment.toolCount) || windowKnown);
 
   if (!cautionIsActionable) return null;
 
@@ -102,7 +138,7 @@ export function classifyToolSurfaceOverload(
     severity: "minor",
     need: "Trim or phase the caution-zone tool surface before it reaches overload.",
     blocks: "The tool surface is approaching the local selection cliff.",
-    evidenceJson: toolSurfaceEvidence(assessment),
+    evidenceJson: toolSurfaceEvidence(assessment, selection),
   };
 }
 

--- a/apps/web/lib/tak/pattern-observer/observer.ts
+++ b/apps/web/lib/tak/pattern-observer/observer.ts
@@ -520,7 +520,10 @@ export async function observeCoworkerPatterns(
   );
 
   const grantCandidates = classifyGrantDenials(toolExecutions);
-  const toolSurfaceNeed = classifyToolSurfaceOverload(toolSurfaceAssessment);
+  // Pass observed tool-selection accuracy so a count-proxy overload (window
+  // unknown, surface past the local cliff) is only asserted when selection is
+  // actually degrading — not on the raw count alone (BI-3346DC28).
+  const toolSurfaceNeed = classifyToolSurfaceOverload(toolSurfaceAssessment, toolSelectionAccuracy);
   const toolSurfaceCandidates: CandidateNeed[] = toolSurfaceNeed
     ? [{ classifier: "tool-surface-overload", need: toolSurfaceNeed }]
     : [];


### PR DESCRIPTION
## Problem

The tool-surface **"overload" capability-need fired on `toolCount > LOCAL_TOOL_SELECTION_CLIFF` (15) unconditionally** — so it flagged essentially *every* coworker, forever. The mandatory coworker read baseline alone (`registry_read` → 30 tools; full baseline ≈ 68) already exceeds 15, and no amount of grant-trimming can cross it. That's the recurring, un-actionable `[tool]` "reduce or phase-scope your tool surface" needs behind:

- **BI-CAP-7F2AE411** (external-catalog-scout, 68 tools) — and this coworker *can't* be trimmed anyway: its `backlog_write` carries `run_hive_scout_ingest`, its daily catalog pass.
- **BI-CAP-C2565D94** (inventory-specialist, 85 tools).

Root issue: the count cliff is only a **proxy for "a small local model with a small window"** (the regime where selection accuracy collapses past ~15 tools — see the module's own docs). It was applied regardless of the model that actually served the run.

## Fix (two coherent changes)

1. **`assessToolSurface`** — when the real window is known, its definition-*share* governs the zone; the raw-count cliff is the fallback only when the window is unknown. A 68-tool surface at ~8% of a large cloud window is genuinely lean; the same surface in a small local window still trips overload via `windowShare`.

2. **`classifyToolSurfaceOverload`** — a window-*known* overload (definitions crowd the real window) is mechanistic and fires directly. A window-*unknown*, past-the-cliff surface is a proxy and now fires **only with corroborating evidence that tool selection is actually degrading** (observed selection accuracy, already computed by the observer). No / insufficient / healthy evidence → suppressed. *Evidence before diagnosis.*

Genuine local overload is still caught (small window → high share, or degraded observed accuracy). This is the calibration half of the two overload BIs; the grant-provisioning half shipped in #2680.

## Tests

`assessToolSurface`: large-window-supersedes-cliff + same-surface-small-window-still-overloads. Classifier: proxy-overload suppressed when healthy / when no evidence, fires only when selection is degrading, and window-known fires directly. Ran locally — `pattern-observer` + `context-economy-metrics` suites green (36 tests).

Closes BI-3346DC28; unblocks BI-CAP-7F2AE411 and BI-CAP-C2565D94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)