### PR TITLE
fix(coworker): scheduled self-tasks fabricate — plumb model floor + recency-guarded required tool (BI-3F09BDD4)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -35,6 +35,9 @@ const mocks = vi.hoisted(() => ({
     toolExecution: {
       findFirst: vi.fn(),
     },
+    marketingCampaignBrief: {
+      findFirst: vi.fn(),
+    },
   },
   resolveAgentForRouteWithPrompts: vi.fn(),
   resolveAgentByIdWithPrompts: vi.fn(),
@@ -354,6 +357,131 @@ function arrangeHiveScoutTask() {
   mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
   mocks.prisma.scheduledJob.update.mockResolvedValue({});
 }
+
+// Marketing Strategist coworker self-task (Proactivity → autonomous, BI-3F09BDD4).
+// taskId is the deterministic self-<agentId>-<userId>; routeContext carries the
+// route's frontier modelRequirements floor.
+function arrangeMarketingSelfTask() {
+  mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+    taskId: "self-marketing-specialist-user-1",
+    agentId: "marketing-specialist",
+    title: "Refresh the acquisition campaign brief",
+    prompt: "Keep a current acquisition campaign brief on the Campaigns page.",
+    routeContext: "/customer/marketing",
+    schedule: "7 14 * * *",
+    timezone: "UTC",
+    isActive: true,
+    ownerUserId: "user-1",
+  });
+  mocks.prisma.agentThread.upsert.mockResolvedValue({ id: "thread-1" });
+  mocks.prisma.agentMessage.create.mockResolvedValue({});
+  mocks.prisma.user.findUnique.mockResolvedValue({ id: "user-1", isSuperuser: true });
+  mocks.prisma.userFact.findMany.mockResolvedValue([]);
+  // The route resolver returns the Marketing Strategist WITH its frontier floor
+  // (agent-routing.ts "/customer/marketing").
+  mocks.resolveAgentForRouteWithPrompts.mockResolvedValue({
+    agentId: "marketing-specialist",
+    systemPrompt: "You are the Marketing Strategist.",
+    sensitivity: "confidential",
+    modelRequirements: { defaultMinimumTier: "frontier", defaultBudgetClass: "balanced" },
+  });
+  mocks.resolveAgentByIdWithPrompts.mockResolvedValue({
+    agentId: "marketing-specialist",
+    agentName: "Marketing Strategist",
+    agentDescription: "Marketing",
+    canAssist: true,
+    systemPrompt: "You are the Marketing Strategist.",
+    sensitivity: "confidential",
+    skills: [],
+  });
+  mocks.prisma.agentMessage.findMany.mockResolvedValue([]);
+  mocks.getAvailableTools.mockResolvedValue([
+    {
+      name: "create_marketing_campaign_brief",
+      description: "Create a campaign brief",
+      inputSchema: {},
+      requiredCapability: "operate_marketing",
+      executionMode: "immediate",
+      sideEffect: true,
+    },
+  ]);
+  mocks.toolsToOpenAIFormat.mockReturnValue([]);
+  mocks.governedExecuteTool.mockResolvedValue({
+    success: true,
+    message: "Saved marketing campaign brief brief-1",
+  });
+  mocks.prisma.taskRun.create.mockResolvedValue({
+    id: "task-run-row-1",
+    taskRunId: "TR-SCHED-MKTG1",
+    contextId: "thread-1",
+  });
+  mocks.prisma.taskMessage.create.mockResolvedValue({});
+  mocks.prisma.taskRun.update.mockResolvedValue({});
+  mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
+  mocks.prisma.scheduledJob.update.mockResolvedValue({});
+}
+
+describe("executeScheduledAgentTask — coworker self-task model + required-tool guarantee (BI-3F09BDD4)", () => {
+  it("carries the coworker's frontier modelRequirements into the scheduled run", async () => {
+    arrangeMarketingSelfTask();
+    mocks.prisma.toolExecution.findFirst.mockResolvedValue({ id: "te-1" });
+    mocks.prisma.marketingCampaignBrief.findFirst.mockResolvedValue({ briefId: "brief-1" });
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "Saved campaign brief.",
+      executedTools: [
+        { name: "create_marketing_campaign_brief", args: {}, result: { success: true } },
+      ],
+    });
+
+    await executeScheduledAgentTask("self-marketing-specialist-user-1");
+
+    const loopArgs = mocks.runAgenticLoop.mock.calls[0]?.[0];
+    expect(loopArgs?.modelRequirements).toMatchObject({
+      defaultMinimumTier: "frontier",
+      defaultBudgetClass: "balanced",
+    });
+  });
+
+  it("force-creates a brief when the loop narrated without calling the tool and no recent brief exists", async () => {
+    arrangeMarketingSelfTask();
+    // No successful tool call recorded this run, and no recent brief anywhere.
+    mocks.prisma.toolExecution.findFirst.mockResolvedValue(null);
+    mocks.prisma.marketingCampaignBrief.findFirst.mockResolvedValue(null);
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "Campaign brief recorded. Done.",
+      executedTools: [],
+    });
+
+    await executeScheduledAgentTask("self-marketing-specialist-user-1");
+
+    expect(mocks.governedExecuteTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "create_marketing_campaign_brief",
+        context: expect.objectContaining({
+          routeContext: "/customer/marketing",
+          agentId: "marketing-specialist",
+          taskRunId: "TR-SCHED-MKTG1",
+        }),
+      }),
+    );
+  });
+
+  it("does NOT force-create a brief when a recent brief already exists (recency guard)", async () => {
+    arrangeMarketingSelfTask();
+    // The loop didn't record a tool call this run, but a recent brief exists —
+    // forcing would duplicate a placeholder, so the fallback must stand down.
+    mocks.prisma.toolExecution.findFirst.mockResolvedValue(null);
+    mocks.prisma.marketingCampaignBrief.findFirst.mockResolvedValue({ briefId: "brief-existing" });
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "Campaign brief recorded. Done.",
+      executedTools: [],
+    });
+
+    await executeScheduledAgentTask("self-marketing-specialist-user-1");
+
+    expect(mocks.governedExecuteTool).not.toHaveBeenCalled();
+  });
+});
 
 describe("executeScheduledAgentTask TaskRun lifecycle", () => {
   it("creates a TaskRun before the first runAgenticLoop call and links it back to ScheduledAgentTask", async () => {

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -26,6 +26,11 @@ import {
   resolveAutonomousWorkTools,
 } from "@/lib/tak/autonomous-work-run";
 import { resolveUserAwareProactivityPlan } from "@/lib/proactivity/proactivity-resolver.server";
+import { applyProviderRouteModelPreference } from "@/lib/ai-provider-route-context";
+import {
+  isCoworkerSelfTaskId,
+  coworkerSelfTaskRequiredTool,
+} from "@/lib/operate/scheduled-jobs/coworker-self-tasks";
 
 // ─── Cron helpers ───────────────────────────────────────────────────────────
 
@@ -35,15 +40,34 @@ import { resolveUserAwareProactivityPlan } from "@/lib/proactivity/proactivity-r
 // module honors all five cron fields and is unit-tested outside this
 // "use server" file.
 
-function getRequiredProceduralToolForScheduledTask(taskId: string): {
+type RequiredProceduralTool = {
   name: string;
   args: Record<string, unknown>;
-} | null {
+  /**
+   * Optional recency guard for artifact tools with no write-time dedup. When it
+   * resolves true, the forced fallback is skipped so a placeholder is not
+   * duplicated on every tick. See CoworkerSelfTaskProceduralTool.
+   */
+  hasRecentArtifact?: () => Promise<boolean>;
+};
+
+function getRequiredProceduralToolForScheduledTask(
+  taskId: string,
+  agentId: string,
+): RequiredProceduralTool | null {
   if (taskId === "discovery-taxonomy-gap-triage-daily") {
     return {
       name: "run_discovery_triage",
       args: { trigger: "cadence" },
     };
+  }
+
+  // Coworker self-tasks (Proactivity → autonomous, BI-3F09BDD4) get their own
+  // required-tool guarantee, keyed by the coworker's agentId. Unlike the
+  // deterministic discovery-triage tool, the marketing artifact tool has no
+  // dedup, so the returned descriptor carries a recency guard the caller honors.
+  if (isCoworkerSelfTaskId(taskId)) {
+    return coworkerSelfTaskRequiredTool(agentId);
   }
 
   return null;
@@ -240,6 +264,25 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       agentId: task.agentId,
     });
 
+    // Mirror the interactive coworker path (agent-coworker.sendMessage): carry the
+    // coworker's configured model requirements into the scheduled run. Without
+    // this, executeAutonomousAgenticLoop routes at the default tier — for the
+    // Marketing Strategist that drops its route's frontier floor
+    // (defaultMinimumTier: "frontier", set precisely because weaker models were
+    // observed refusing to call tools) and the loop fabricates "Done" with zero
+    // tool calls (BI-3F09BDD4). The Golden Triangle posture is still applied
+    // independently at prepareRoute via agentId; this restores the per-coworker
+    // floor the interactive path sends, and benefits every autonomous coworker
+    // whose route declares modelRequirements.
+    const rawModelRequirements =
+      agentInfo.modelRequirements && typeof agentInfo.modelRequirements === "object"
+        ? (agentInfo.modelRequirements as Record<string, unknown>)
+        : {};
+    const modelRequirements = applyProviderRouteModelPreference(
+      { ...rawModelRequirements },
+      task.routeContext,
+    );
+
     const result = await executeAutonomousAgenticLoop({
       systemPrompt: agentInfo.systemPrompt,
       chatHistory,
@@ -251,10 +294,11 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       agentId: task.agentId,
       threadId: thread.id,
       taskRunId: taskRunRef.taskRunId,
+      ...(Object.keys(modelRequirements).length > 0 ? { modelRequirements } : {}),
     });
     const executedTools = [...(result.executedTools ?? [])];
 
-    const requiredTool = getRequiredProceduralToolForScheduledTask(task.taskId);
+    const requiredTool = getRequiredProceduralToolForScheduledTask(task.taskId, task.agentId);
     if (requiredTool) {
       const hasPersistedRequiredTool = await prisma.toolExecution.findFirst({
         where: {
@@ -265,7 +309,16 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         select: { id: true },
       });
 
-      if (!hasPersistedRequiredTool) {
+      // Recency guard: for artifact tools with no write-time dedup (the marketing
+      // brief tool is a plain .create), skip the forced fallback when a fresh
+      // artifact already exists — the coworker just produced one this run, or a
+      // recent run did. Without this, the daily self-task would duplicate a
+      // placeholder brief every tick (BI-3F09BDD4).
+      const artifactAlreadyFresh = requiredTool.hasRecentArtifact
+        ? await requiredTool.hasRecentArtifact().catch(() => false)
+        : false;
+
+      if (!hasPersistedRequiredTool && !artifactAlreadyFresh) {
         const alreadyCountedRequiredTool = executedTools.some(
           (tool) => tool.name === requiredTool.name,
         );

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
@@ -76,6 +76,80 @@ export function coworkerSelfTaskId(agentId: string, userId: string): string {
   return `self-${agentId}-${userId}`;
 }
 
+/** True when a taskId is a coworker self-task (see {@link coworkerSelfTaskId}). */
+export function isCoworkerSelfTaskId(taskId: string): boolean {
+  return taskId.startsWith("self-");
+}
+
+/**
+ * A procedural tool the scheduled runner force-executes as a LAST-RESORT
+ * guarantee when the coworker's own agentic loop finished the self-task without
+ * calling it (e.g. a weak model fabricated "Done" with zero tool calls). This is
+ * the same "required procedural tool" mechanism the discovery-triage daily task
+ * uses — extended to coworker self-tasks so an Assertive coworker never leaves
+ * its page empty.
+ */
+export type CoworkerSelfTaskProceduralTool = {
+  /** Tool name to force, resolved via governed execute. */
+  name: string;
+  /**
+   * Args for the forced fallback call. These are honest, generic placeholders —
+   * the fallback only ever fires when the page is otherwise empty, and the
+   * coworker (on a capable model) produces the real, contextual artifact itself.
+   */
+  args: Record<string, unknown>;
+  /**
+   * Recency guard for the forced fallback. The self-task's artifact tool (e.g.
+   * create_marketing_campaign_brief → a plain prisma.create with NO write-time
+   * dedup) would otherwise create a duplicate placeholder on every tick. Returns
+   * true when a fresh artifact already exists — the coworker just created one
+   * this run, or a recent run did — so the fallback MUST be skipped.
+   */
+  hasRecentArtifact: () => Promise<boolean>;
+};
+
+// A brief created within this window counts as "recent", so the forced fallback
+// stands down. Wider than the daily assertive cadence so a single placeholder is
+// never re-created tick-over-tick; the coworker's own (capable-model) briefs land
+// well inside it and suppress the fallback entirely.
+const RECENT_CAMPAIGN_BRIEF_WINDOW_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+
+/**
+ * Required-tool guarantee for a coworker self-task, keyed by agentId. Null when
+ * the coworker's self-task has no procedural guarantee (the loop's own output is
+ * sufficient). Mirrors getRequiredProceduralToolForScheduledTask for the curated
+ * self-task registry above.
+ */
+export function coworkerSelfTaskRequiredTool(
+  agentId: string,
+): CoworkerSelfTaskProceduralTool | null {
+  if (agentId === "marketing-specialist") {
+    return {
+      name: "create_marketing_campaign_brief",
+      // Honest, generic placeholder. Only reached when the marketing page has no
+      // recent brief AND the coworker's loop failed to produce one — so a clearly
+      // provisional brief beats an empty Campaigns page. required: title, objective.
+      args: {
+        title: "Acquisition campaign brief (needs refresh)",
+        objective:
+          "Provisional acquisition brief created automatically because the Campaigns page had no recent brief. Refresh with a segment-specific objective, audience, and channel mix.",
+        notes:
+          "Auto-generated fallback so the Campaigns page is not empty. The Marketing Strategist should replace this with a grounded, ICP-specific brief on its next run.",
+      },
+      hasRecentArtifact: async () => {
+        const since = new Date(Date.now() - RECENT_CAMPAIGN_BRIEF_WINDOW_MS);
+        const recent = await prisma.marketingCampaignBrief.findFirst({
+          where: { createdAt: { gte: since } },
+          select: { briefId: true },
+        });
+        return recent !== null;
+      },
+    };
+  }
+
+  return null;
+}
+
 export type ReconcileSelfTaskResult =
   | { ok: true; action: "none" | "removed" | "scheduled"; taskId?: string; schedule?: string };
 

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -18,7 +18,7 @@
   "apps/web/instrumentation.ts": 1337,
   "apps/web/lib/actions/agent-coworker-external.test.ts": 866,
   "apps/web/lib/actions/agent-coworker.ts": 2632,
-  "apps/web/lib/actions/agent-task-scheduler.test.ts": 890,
+  "apps/web/lib/actions/agent-task-scheduler.test.ts": 1018,
   "apps/web/lib/actions/ai-providers.ts": 920,
   "apps/web/lib/actions/build-governed.test.ts": 1114,
   "apps/web/lib/actions/build.ts": 1770,


### PR DESCRIPTION
## Problem

The Proactivity→autonomous `ScheduledAgentTask` bridge (#2674, BI-3F09BDD4) wired coworkers to self-drive, and the wiring is proven — but the **output** was fabricated. Repro: the Marketing Strategist self-task (`agentId=marketing-specialist`, route `/customer/marketing`, prompt to call `create_marketing_campaign_brief`) dispatched via `executeScheduledAgentTask`, ran 3 agentic-loop iterations with **toolCalls=0** on `claude-haiku-4-5`, emitted *"Campaign brief recorded… Done"*, and left `MarketingCampaignBrief` at **0 rows**.

## Root causes (both in `executeScheduledAgentTask`)

**1. The coworker's model floor was dropped.** The scheduler called `executeAutonomousAgenticLoop` *without* `modelRequirements`. The `/customer/marketing` route declares `defaultMinimumTier: "frontier"` [precisely because weaker tiers were observed refusing to call tools from their own schema](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/apps/web/lib/tak/agent-routing.ts#L279). Dropping it routed the scheduled run to a weak model that narrates instead of acting.
→ Mirror the interactive path (`agent-coworker.sendMessage`): carry `agentInfo.modelRequirements` through `applyProviderRouteModelPreference` into the loop. Benefits **every** autonomous coworker whose route declares a floor. (The Golden Triangle posture is still applied independently at `prepareRoute` via `agentId`; this restores the static per-coworker floor the interactive path already sends.)

**2. No required-tool guarantee for self-tasks.** `getRequiredProceduralToolForScheduledTask` only matched the hardcoded `discovery-taxonomy-gap-triage-daily`. Coworker self-tasks (`self-<agentId>-<userId>`) had none.
→ Add a per-agent guarantee. Because `createMarketingCampaignBrief` is a plain `.create()` with **no write-time dedup**, the forced fallback is **recency-guarded**: it fires only when the loop did not record the tool this run *and* no brief exists within the recency window — so a daily self-task never duplicates a placeholder brief.

## Fabrication guard check (BI-3E92B28B)

Confirmed the guard **does** arm on the scheduled autonomous path (`interactionMode` defaults to `"autonomous"`), but for the non-build marketing route it retries once then keeps the advice — it never forces the tool. So fixes 1+2 are what actually close the empty-page gap; the guard alone can't.

## Tests

- New scheduler tests: frontier `modelRequirements` flows into the loop; forced create when the loop narrated with no recent brief; **no** forced create when a recent brief exists (recency guard).
- `pnpm exec vitest run` for both touched suites: 26 passed. Scoped `tsc`: clean.

## Live verification

Pending deploy of this branch — the fix must ship before setting the Marketing Strategist to Assertive and confirming a real, contextual `MarketingCampaignBrief` lands on `/customer/marketing` after the next dispatch tick.

EP-B9DD37C7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)