### PR TITLE
feat(ops-map): humanize routing + attention-first review queue (BI-E3969A69)

### DIFF
--- a/apps/web/components/platform/ActivityRoutingPresentation.tsx
+++ b/apps/web/components/platform/ActivityRoutingPresentation.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * Presentation subcomponents for the Activity Routing Workbench
+ * (BI-E3969A69). Kept out of ActivityRoutingWorkbench.tsx per the plan's
+ * module-size guardrail; all humanization comes from the pure
+ * lib/ai-operations-map/route-labels module so the unified topology canvas
+ * can reuse it at cutover.
+ */
+
+import { useState } from "react";
+
+export type TechnicalEntry = {
+  label: string;
+  value: string | null | undefined;
+};
+
+/**
+ * Raw substrate ids (recipe keys, telemetry ids, route decision ids) behind a
+ * collapsed disclosure with a copy affordance — visible to the engineer who
+ * needs them, invisible to the operator who doesn't.
+ */
+export function TechnicalDetails({ entries }: { entries: TechnicalEntry[] }) {
+  const shown = entries.filter((entry): entry is { label: string; value: string } => Boolean(entry.value));
+  const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
+  if (shown.length === 0) return null;
+
+  const copy = async (entry: { label: string; value: string }) => {
+    try {
+      await navigator.clipboard.writeText(entry.value);
+      setCopiedLabel(entry.label);
+      window.setTimeout(() => setCopiedLabel((current) => (current === entry.label ? null : current)), 1500);
+    } catch {
+      // Clipboard unavailable (permissions/http) — the id is still selectable text.
+    }
+  };
+
+  return (
+    <details data-technical-details className="mt-2">
+      <summary className="cursor-pointer select-none text-[11px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+        Technical details
+      </summary>
+      <dl className="mt-1 space-y-1 text-[11px]">
+        {shown.map((entry) => (
+          <div key={entry.label} className="flex items-center gap-2">
+            <dt className="shrink-0 text-[var(--dpf-muted)]">{entry.label}</dt>
+            <dd
+              className="min-w-0 flex-1 truncate text-right font-mono text-[var(--dpf-text)]"
+              title={entry.value}
+            >
+              {entry.value}
+            </dd>
+            <button
+              type="button"
+              onClick={() => void copy(entry)}
+              aria-label={`Copy ${entry.label}`}
+              className="shrink-0 rounded border border-[var(--dpf-border)] px-1.5 py-0.5 text-[10px] text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)]"
+            >
+              {copiedLabel === entry.label ? "Copied" : "Copy"}
+            </button>
+          </div>
+        ))}
+      </dl>
+    </details>
+  );
+}

--- a/apps/web/components/platform/ActivityRoutingWorkbench.test.tsx
+++ b/apps/web/components/platform/ActivityRoutingWorkbench.test.tsx
@@ -163,25 +163,164 @@ describe("ActivityRoutingWorkbench", () => {
     expect(screen.getByRole("region", { name: "Activity routing workbench" })).toBeTruthy();
     expect(screen.getByLabelText("Activity routing flow")).toBeTruthy();
     const nodes = screen.getAllByRole("button");
-    expect(nodes).toHaveLength(2);
-    expect(within(nodes[0]).getByText("Summarize transcript")).toBeTruthy();
-    expect(within(nodes[0]).getByText("zai")).toBeTruthy();
-    expect(within(nodes[0]).getByText("glm-5.2")).toBeTruthy();
-    expect(within(nodes[1]).getByText("Review architecture implications")).toBeTruthy();
+    // Two flow nodes + each node card carries a "Technical details" disclosure summary.
+    const flowNodes = nodes.filter((node) => node.hasAttribute("data-activity-flow-node"));
+    expect(flowNodes).toHaveLength(2);
+    expect(within(flowNodes[0]).getByText("Summarize transcript")).toBeTruthy();
+    // Humanized model route, not the raw provider/model ids.
+    expect(within(flowNodes[0]).getByText("Z.ai · GLM 5.2")).toBeTruthy();
+    expect(within(flowNodes[0]).queryByText("zai")).toBeNull();
+    expect(within(flowNodes[0]).queryByText("glm-5.2")).toBeNull();
+    expect(within(flowNodes[1]).getByText("Review architecture implications")).toBeTruthy();
 
     const drawer = screen.getByRole("region", { name: "Activity decision details" });
     expect(within(drawer).getByText("Summarize transcript")).toBeTruthy();
+    // Raw route decision id is preserved behind the technical-details disclosure.
     expect(within(drawer).getByText("RD-SUMMARY")).toBeTruthy();
     expect(within(drawer).getByText("1,280")).toBeTruthy();
     expect(within(drawer).getByText("$0.0042")).toBeTruthy();
     expect(within(drawer).getByText(/Excluded frontier model/)).toBeTruthy();
 
-    fireEvent.click(nodes[1]);
+    fireEvent.click(flowNodes[1]);
 
     expect(within(drawer).getByText("Review architecture implications")).toBeTruthy();
     expect(within(drawer).getByText("RD-REVIEW")).toBeTruthy();
     expect(within(drawer).getByText("4,820")).toBeTruthy();
     expect(within(drawer).getByText("$0.0310")).toBeTruthy();
     expect(within(drawer).getByText(/Excluded GLM/)).toBeTruthy();
+  });
+
+  it("humanizes routing internals and hides raw ids behind technical disclosure (BI-E3969A69)", () => {
+    render(<ActivityRoutingWorkbench activityRouting={ACTIVITY_ROUTING_FIXTURE} />);
+
+    // Recipe key is presented as a sentence, not the raw dotted key.
+    expect(
+      screen.getAllByText(/trial recipe for summarizing/i).length,
+    ).toBeGreaterThan(0);
+
+    // Flow nodes never show the raw dotted key as operator-facing text.
+    const flowNodes = screen
+      .getAllByRole("button")
+      .filter((node) => node.hasAttribute("data-activity-flow-node"));
+    for (const node of flowNodes) {
+      expect(node.textContent ?? "").not.toContain("glm.center.summarize.provisional");
+    }
+
+    // The raw recipe key still exists in the DOM so an engineer can copy it,
+    // but every occurrence is inside a collapsed Technical-details disclosure.
+    const rawKeyOccurrences = screen.queryAllByText("glm.center.summarize.provisional");
+    expect(rawKeyOccurrences.length).toBeGreaterThan(0);
+    for (const occurrence of rawKeyOccurrences) {
+      expect(occurrence.closest("details[data-technical-details]")).toBeTruthy();
+    }
+
+    // Confidence enum is rendered in operator language.
+    const drawer = screen.getByRole("region", { name: "Activity decision details" });
+    expect(within(drawer).getByText("Trial")).toBeTruthy();
+  });
+
+  it("opens an attention-first review queue with the right action per row (BI-E3969A69)", () => {
+    const base = ACTIVITY_ROUTING_FIXTURE.activities[0];
+    const routing: OperationsMapActivityRouting = {
+      ...ACTIVITY_ROUTING_FIXTURE,
+      taskRef: { buildId: "FB-QUEUE" },
+      activities: [
+        // Failed, no proposal → link to originating build.
+        {
+          ...base,
+          activityId: "activity:failed",
+          label: "Generate migration",
+          successSignal: "failed",
+          actionProposalId: null,
+          actionProposalSummary: null,
+          actionProposalRecommendedConfidence: null,
+          approvedConfidenceOverrideId: null,
+        },
+        // Attention with a full proposal → queue approval.
+        {
+          ...base,
+          activityId: "activity:attention",
+          label: "Draft release notes",
+          successSignal: "attention",
+          actionProposalId: "PROP-1",
+          actionProposalSummary: "Promote this route to calibrating.",
+          actionProposalRecommendedConfidence: "calibrating",
+          approvedConfidenceOverrideId: null,
+        },
+        // A healthy activity that must NOT appear in the queue.
+        { ...base, activityId: "activity:ok", label: "Summarize call", successSignal: "valid" },
+      ],
+    };
+    render(<ActivityRoutingWorkbench activityRouting={routing} />);
+
+    // Queue is collapsed until the badge is pressed.
+    expect(screen.queryByRole("region", { name: "Activities needing review" })).toBeNull();
+    const badge = screen.getByRole("button", { name: /2 need review/i });
+    fireEvent.click(badge);
+
+    const queue = screen.getByRole("region", { name: "Activities needing review" });
+    const rows = within(queue)
+      .getAllByRole("listitem")
+      .filter((row) => row.hasAttribute("data-review-queue-row"));
+    expect(rows).toHaveLength(2);
+
+    // Failed row (no proposal) links to the originating build.
+    const failedRow = rows.find((row) => within(row).queryByText("Generate migration"));
+    expect(failedRow).toBeTruthy();
+    const buildLink = within(failedRow!).getByRole("link", { name: "Open originating build" });
+    expect(buildLink.getAttribute("href")).toBe("/build?buildId=FB-QUEUE");
+
+    // Attention row (proposal present) offers a governed queue-approval action.
+    const attentionRow = rows.find((row) => within(row).queryByText("Draft release notes"));
+    expect(within(attentionRow!).getByRole("button", { name: "Queue approval" })).toBeTruthy();
+
+    // Healthy activity is never listed.
+    expect(within(queue).queryByText("Summarize call")).toBeNull();
+  });
+
+  it("labels an unactionable flagged activity as informational when no work ref exists", () => {
+    const base = ACTIVITY_ROUTING_FIXTURE.activities[0];
+    const routing: OperationsMapActivityRouting = {
+      ...ACTIVITY_ROUTING_FIXTURE,
+      taskRef: {},
+      activities: [
+        {
+          ...base,
+          activityId: "activity:orphan",
+          label: "Orphan step",
+          successSignal: "failed",
+          actionProposalId: null,
+          actionProposalSummary: null,
+          actionProposalRecommendedConfidence: null,
+          approvedConfidenceOverrideId: null,
+        },
+      ],
+    };
+    render(<ActivityRoutingWorkbench activityRouting={routing} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /1 needs review/i }));
+    const queue = screen.getByRole("region", { name: "Activities needing review" });
+    expect(within(queue).getByText("Informational — no action available yet")).toBeTruthy();
+    expect(within(queue).queryByRole("link")).toBeNull();
+  });
+
+  it("collapses an all-unknown outcome grid into one honest sentence", () => {
+    const noOutcome: OperationsMapActivityRouting = {
+      ...ACTIVITY_ROUTING_FIXTURE,
+      activities: [
+        {
+          ...ACTIVITY_ROUTING_FIXTURE.activities[0],
+          successSignal: "unknown",
+          routeDecisionId: null,
+          tokenTotal: null,
+          costUsd: null,
+        },
+      ],
+    };
+    render(<ActivityRoutingWorkbench activityRouting={noOutcome} />);
+
+    expect(
+      screen.getByText("No outcome recorded yet — this route hasn't run."),
+    ).toBeTruthy();
   });
 });

--- a/apps/web/components/platform/ActivityRoutingWorkbench.tsx
+++ b/apps/web/components/platform/ActivityRoutingWorkbench.tsx
@@ -3,6 +3,71 @@
 import { useState, useTransition } from "react";
 import type { OperationsMapActivityRouting } from "@/lib/ai-operations-map/types";
 import { proposeActivityHarnessOverrideAction } from "@/lib/actions/activity-harness-routing";
+import {
+  ACTIVITY_CLASS_COPY,
+  CONFIDENCE_COPY,
+  DISTRIBUTION_COPY,
+  RISK_COPY,
+  SUCCESS_SIGNAL_COPY,
+  emptyOutcomeEvidenceSummary,
+  presentModelRoute,
+  presentRecipeKey,
+} from "@/lib/ai-operations-map/route-labels";
+import { TechnicalDetails } from "./ActivityRoutingPresentation";
+
+type ActivityStep = OperationsMapActivityRouting["activities"][number];
+
+/** "summarizing · routine work · Low stakes" — the card subtitle in operator words. */
+function describeActivityShape(activity: ActivityStep): string {
+  return [
+    ACTIVITY_CLASS_COPY[activity.activityClass],
+    DISTRIBUTION_COPY[activity.distributionShape].label,
+    RISK_COPY[activity.riskClass].label,
+  ].join(" · ");
+}
+
+/** Short recipe phrase for tight card real estate; full sentence lives in the drawer. */
+function shortRecipeLabel(activity: ActivityStep): string {
+  const presentation = presentRecipeKey(activity.harnessRecipeKey, {
+    providerId: activity.selectedProviderId,
+    modelId: activity.selectedModelId,
+  });
+  if (presentation.parsed) {
+    return `${CONFIDENCE_COPY[presentation.parsed.confidence].label} recipe for ${ACTIVITY_CLASS_COPY[presentation.parsed.activity]}`;
+  }
+  return presentation.technicalId ? "Custom recipe" : "No recipe bound yet";
+}
+
+function modelRouteLabel(activity: ActivityStep): string {
+  if (!activity.selectedProviderId && !activity.selectedModelId) {
+    return "No model selected yet";
+  }
+  return presentModelRoute(activity.selectedProviderId, activity.selectedModelId).label;
+}
+
+/** Whether this activity has a governed action proposal an operator can queue. */
+function canQueueApproval(activity: ActivityStep): boolean {
+  return Boolean(
+    activity.actionProposalId &&
+    activity.actionProposalSummary &&
+    activity.harnessRecipeKey &&
+    activity.selectedProviderId &&
+    activity.actionProposalRecommendedConfidence &&
+    !activity.approvedConfidenceOverrideId,
+  );
+}
+
+/** One plain-language line explaining why a flagged activity needs a look. */
+function reviewReason(activity: ActivityStep): string {
+  return activity.tuningRationale?.trim() || activity.decisionSummary.trim() || SUCCESS_SIGNAL_COPY[activity.successSignal].description;
+}
+
+/** Link to the build/task this activity ran under, using the shared parent ref. */
+function originatingWorkHref(taskRef: OperationsMapActivityRouting["taskRef"]): string | null {
+  if (taskRef.buildId) return `/build?buildId=${encodeURIComponent(taskRef.buildId)}`;
+  if (taskRef.workCaseId) return `/build/work/${encodeURIComponent(taskRef.workCaseId)}`;
+  return null;
+}
 
 export function ActivityRoutingWorkbench({
   activityRouting,
@@ -13,6 +78,7 @@ export function ActivityRoutingWorkbench({
   const [pendingProposalId, setPendingProposalId] = useState<string | null>(null);
   const [selectedActivityId, setSelectedActivityId] = useState<string | null>(null);
   const [approvalStatusByActivity, setApprovalStatusByActivity] = useState<Record<string, string>>({});
+  const [showReviewQueue, setShowReviewQueue] = useState(false);
 
   if (!activityRouting || activityRouting.activities.length === 0) {
     return (
@@ -51,9 +117,10 @@ export function ActivityRoutingWorkbench({
   const selectedActivity =
     activityRouting.activities.find((activity) => activity.activityId === selectedActivityId) ??
     activityRouting.activities[0];
-  const attentionCount = activityRouting.activities.filter((activity) =>
-    activity.successSignal === "attention" || activity.successSignal === "failed",
-  ).length;
+  const attentionActivities = activityRouting.activities.filter(
+    (activity) => activity.successSignal === "attention" || activity.successSignal === "failed",
+  );
+  const attentionCount = attentionActivities.length;
   const queueApproval = (activity: OperationsMapActivityRouting["activities"][number]) => {
     if (
       !activity.actionProposalId ||
@@ -114,12 +181,34 @@ export function ActivityRoutingWorkbench({
             Updated {formatReplayTime(Date.parse(activityRouting.generatedAt))}
           </span>
           {attentionCount > 0 ? (
-            <span className="rounded border border-[var(--dpf-warning)] bg-[color-mix(in_srgb,var(--dpf-warning)_12%,var(--dpf-surface-1))] px-2 py-1 text-[var(--dpf-text)]">
-              {attentionCount} needs review
-            </span>
+            <button
+              type="button"
+              onClick={() => setShowReviewQueue((open) => !open)}
+              aria-expanded={showReviewQueue}
+              aria-controls="activity-review-queue"
+              className="inline-flex items-center gap-1 rounded border border-[var(--dpf-warning)] bg-[color-mix(in_srgb,var(--dpf-warning)_12%,var(--dpf-surface-1))] px-2 py-1 font-medium text-[var(--dpf-text)] transition-colors hover:bg-[color-mix(in_srgb,var(--dpf-warning)_20%,var(--dpf-surface-1))] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-warning)]"
+            >
+              {attentionCount} {attentionCount === 1 ? "needs" : "need"} review
+              <span aria-hidden="true">{showReviewQueue ? "▾" : "▸"}</span>
+            </button>
           ) : null}
         </div>
       </div>
+
+      {showReviewQueue && attentionCount > 0 ? (
+        <ActivityReviewQueue
+          activities={attentionActivities}
+          taskRef={activityRouting.taskRef}
+          approvalStatusByActivity={approvalStatusByActivity}
+          isApprovalPending={isApprovalPending}
+          pendingProposalId={pendingProposalId}
+          onQueueApproval={queueApproval}
+          onInspect={(activityId) => {
+            setSelectedActivityId(activityId);
+            setShowReviewQueue(false);
+          }}
+        />
+      ) : null}
 
       <ActivityFlowRail
         activities={activityRouting.activities}
@@ -131,14 +220,7 @@ export function ActivityRoutingWorkbench({
 
       <div className="mt-3 grid gap-2 lg:grid-cols-2 xl:grid-cols-3">
         {activityRouting.activities.map((activity) => {
-          const canQueueApproval = Boolean(
-            activity.actionProposalId &&
-            activity.actionProposalSummary &&
-            activity.harnessRecipeKey &&
-            activity.selectedProviderId &&
-            activity.actionProposalRecommendedConfidence &&
-            !activity.approvedConfidenceOverrideId,
-          );
+          const cardCanQueueApproval = canQueueApproval(activity);
           return (
             <article
               key={activity.activityId}
@@ -151,7 +233,7 @@ export function ActivityRoutingWorkbench({
                     {activity.label}
                   </h3>
                   <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-                    {activity.activityClass} / {activity.distributionShape} / {activity.riskClass}
+                    {describeActivityShape(activity)}
                   </p>
                 </div>
                 <span
@@ -159,18 +241,29 @@ export function ActivityRoutingWorkbench({
                     "shrink-0 rounded border px-2 py-1 text-[10px] uppercase tracking-[0.14em]",
                     activitySignalClass(activity.successSignal),
                   ].join(" ")}
+                  title={SUCCESS_SIGNAL_COPY[activity.successSignal].description}
                 >
-                  {activity.successSignal}
+                  {SUCCESS_SIGNAL_COPY[activity.successSignal].label}
                 </span>
               </div>
 
               <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
-                <InspectorFact label="Provider" value={activity.selectedProviderId ?? "Unresolved"} />
-                <InspectorFact label="Model" value={activity.selectedModelId ?? "Unresolved"} />
-                <InspectorFact label="Harness" value={activity.harnessRecipeKey ?? "Unbound"} />
-                <InspectorFact label="Confidence" value={activity.confidence ?? "Unknown"} />
+                <InspectorFact label="Model route" value={modelRouteLabel(activity)} />
+                <InspectorFact label="Harness" value={shortRecipeLabel(activity)} />
+                <InspectorFact
+                  label="Confidence"
+                  value={activity.confidence ? CONFIDENCE_COPY[activity.confidence].label : "Unrated"}
+                  title={activity.confidence ? CONFIDENCE_COPY[activity.confidence].description : undefined}
+                />
                 <InspectorFact label="Tuning" value={activity.tuningRecommendation ?? "Observe"} />
               </dl>
+              <TechnicalDetails
+                entries={[
+                  { label: "Recipe key", value: activity.harnessRecipeKey },
+                  { label: "Provider id", value: activity.selectedProviderId },
+                  { label: "Model id", value: activity.selectedModelId },
+                ]}
+              />
 
               <div className="mt-3 border-t border-[var(--dpf-border)] pt-3">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
@@ -192,7 +285,7 @@ export function ActivityRoutingWorkbench({
                         Proposed confidence: {activity.actionProposalRecommendedConfidence}
                       </p>
                     ) : null}
-                    {canQueueApproval ? (
+                    {cardCanQueueApproval ? (
                       <button
                         type="button"
                         onClick={() => queueApproval(activity)}
@@ -228,6 +321,104 @@ export function ActivityRoutingWorkbench({
           );
         })}
       </div>
+    </section>
+  );
+}
+
+function ActivityReviewQueue({
+  activities,
+  taskRef,
+  approvalStatusByActivity,
+  isApprovalPending,
+  pendingProposalId,
+  onQueueApproval,
+  onInspect,
+}: {
+  activities: ActivityStep[];
+  taskRef: OperationsMapActivityRouting["taskRef"];
+  approvalStatusByActivity: Record<string, string>;
+  isApprovalPending: boolean;
+  pendingProposalId: string | null;
+  onQueueApproval: (activity: ActivityStep) => void;
+  onInspect: (activityId: string) => void;
+}) {
+  const buildHref = originatingWorkHref(taskRef);
+  return (
+    <section
+      id="activity-review-queue"
+      aria-label="Activities needing review"
+      className="mt-3 rounded-md border border-[var(--dpf-warning)] bg-[color-mix(in_srgb,var(--dpf-warning)_6%,var(--dpf-surface-1))] p-3"
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+        Needs review — {activities.length} {activities.length === 1 ? "activity" : "activities"}
+      </p>
+      <ul className="mt-2 space-y-2">
+        {activities.map((activity) => {
+          const status = approvalStatusByActivity[activity.activityId];
+          const queueable = canQueueApproval(activity);
+          const pending = isApprovalPending && pendingProposalId === activity.actionProposalId;
+          return (
+            <li
+              key={activity.activityId}
+              data-review-queue-row
+              className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+            >
+              <div className="flex items-start gap-2">
+                <span
+                  className={[
+                    "mt-0.5 shrink-0 rounded border px-2 py-1 text-[10px] uppercase tracking-[0.14em]",
+                    activitySignalClass(activity.successSignal),
+                  ].join(" ")}
+                  title={SUCCESS_SIGNAL_COPY[activity.successSignal].description}
+                >
+                  {SUCCESS_SIGNAL_COPY[activity.successSignal].label}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <h3 className="truncate text-sm font-semibold text-[var(--dpf-text)]">
+                    {activity.label}
+                  </h3>
+                  <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+                    {reviewReason(activity)}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                {queueable ? (
+                  <button
+                    type="button"
+                    onClick={() => onQueueApproval(activity)}
+                    disabled={pending}
+                    className="inline-flex min-h-8 items-center rounded border border-[var(--dpf-accent)] px-2 py-1 text-xs font-medium text-[var(--dpf-text)] transition-colors hover:bg-[var(--dpf-accent-soft)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)] disabled:cursor-wait disabled:opacity-60"
+                  >
+                    {pending ? "Queueing..." : "Queue approval"}
+                  </button>
+                ) : buildHref ? (
+                  <a
+                    href={buildHref}
+                    className="inline-flex min-h-8 items-center rounded border border-[var(--dpf-border)] px-2 py-1 text-xs font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+                  >
+                    Open originating build
+                  </a>
+                ) : (
+                  <span className="text-[11px] text-[var(--dpf-muted)]">
+                    Informational — no action available yet
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => onInspect(activity.activityId)}
+                  className="inline-flex min-h-8 items-center rounded border border-[var(--dpf-border)] px-2 py-1 text-xs font-medium text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+                >
+                  Inspect decision
+                </button>
+                {status ? (
+                  <span className="text-[11px] text-[var(--dpf-muted)]">{status}</span>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </section>
   );
 }
@@ -278,33 +469,32 @@ function ActivityFlowRail({
                       "rounded border px-2 py-1 text-[10px] font-medium uppercase tracking-[0.12em]",
                       activityFlowRiskClass(activity.riskClass),
                     ].join(" ")}
+                    title={RISK_COPY[activity.riskClass].description}
                   >
-                    {activity.riskClass}
+                    {RISK_COPY[activity.riskClass].label}
                   </span>
                   <span
                     className={[
                       "rounded border px-2 py-1 text-[10px] font-medium uppercase tracking-[0.12em]",
                       activityFlowConfidenceClass(activity.confidence),
                     ].join(" ")}
+                    title={activity.confidence ? CONFIDENCE_COPY[activity.confidence].description : "This route has not been rated yet."}
                   >
-                    {activity.confidence ?? "unknown"}
+                    {activity.confidence ? CONFIDENCE_COPY[activity.confidence].label : "Unrated"}
                   </span>
                 </div>
                 <p className="mt-3 line-clamp-2 text-sm font-semibold leading-5 text-[var(--dpf-text)]">
                   {activity.label}
                 </p>
                 <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-                  {activity.activityClass} / {activity.distributionShape}
+                  {ACTIVITY_CLASS_COPY[activity.activityClass]} · {DISTRIBUTION_COPY[activity.distributionShape].label}
                 </p>
                 <div className="mt-auto space-y-1 pt-3 text-[11px] leading-4 text-[var(--dpf-muted)]">
-                  <p className="truncate text-[var(--dpf-text)]">
-                    {activity.selectedProviderId ?? "Unresolved provider"}
+                  <p className="truncate text-[var(--dpf-text)]" title={`${activity.selectedProviderId ?? "unresolved"} / ${activity.selectedModelId ?? "unresolved"}`}>
+                    {modelRouteLabel(activity)}
                   </p>
-                  <p className="truncate">
-                    {activity.selectedModelId ?? "Unresolved model"}
-                  </p>
-                  <p className="truncate">
-                    {activity.harnessRecipeKey ?? "Unbound harness"}
+                  <p className="truncate" title={activity.harnessRecipeKey ?? undefined}>
+                    {shortRecipeLabel(activity)}
                   </p>
                 </div>
               </button>
@@ -333,6 +523,11 @@ function ActivityDecisionDrawer({
 }: {
   activity: OperationsMapActivityRouting["activities"][number];
 }) {
+  const recipePresentation = presentRecipeKey(activity.harnessRecipeKey, {
+    providerId: activity.selectedProviderId,
+    modelId: activity.selectedModelId,
+  });
+  const emptyEvidence = emptyOutcomeEvidenceSummary(activity);
   return (
     <section
       aria-label="Activity decision details"
@@ -360,10 +555,18 @@ function ActivityDecisionDrawer({
         </div>
 
         <dl className="grid grid-cols-2 gap-2 text-xs">
-          <InspectorFact label="Activity" value={activity.activityClass} />
-          <InspectorFact label="Shape" value={`${activity.distributionShape} / ${activity.riskClass}`} />
-          <InspectorFact label="Model route" value={`${activity.selectedProviderId ?? "Unresolved"} / ${activity.selectedModelId ?? "Unresolved"}`} />
-          <InspectorFact label="Routing confidence" value={activity.confidence ?? "Unknown"} />
+          <InspectorFact label="Activity" value={ACTIVITY_CLASS_COPY[activity.activityClass]} />
+          <InspectorFact
+            label="Shape"
+            value={`${DISTRIBUTION_COPY[activity.distributionShape].label} · ${RISK_COPY[activity.riskClass].label}`}
+            title={`${DISTRIBUTION_COPY[activity.distributionShape].description} ${RISK_COPY[activity.riskClass].description}`}
+          />
+          <InspectorFact label="Model route" value={modelRouteLabel(activity)} />
+          <InspectorFact
+            label="Routing confidence"
+            value={activity.confidence ? CONFIDENCE_COPY[activity.confidence].label : "Unrated"}
+            title={activity.confidence ? CONFIDENCE_COPY[activity.confidence].description : "This route has not been rated yet."}
+          />
         </dl>
       </div>
 
@@ -372,44 +575,68 @@ function ActivityDecisionDrawer({
           <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
             Outcome evidence
           </p>
-          <dl className="mt-2 space-y-1 text-xs text-[var(--dpf-muted)]">
-            <ActivityEvidenceFact label="Signal" value={activity.successSignal} />
-            <ActivityEvidenceFact label="Route decision" value={activity.routeDecisionId ?? "No route evidence"} />
-            <ActivityEvidenceFact label="Tokens" value={activity.tokenTotal == null ? "Unknown" : activity.tokenTotal.toLocaleString()} />
-            <ActivityEvidenceFact label="Cost" value={activity.costUsd == null ? "Unknown" : `$${activity.costUsd.toFixed(4)}`} />
-          </dl>
+          {emptyEvidence ? (
+            <p className="mt-2 text-xs leading-5 text-[var(--dpf-muted)]">{emptyEvidence}</p>
+          ) : (
+            <dl className="mt-2 space-y-1 text-xs text-[var(--dpf-muted)]">
+              <ActivityEvidenceFact
+                label="Signal"
+                value={SUCCESS_SIGNAL_COPY[activity.successSignal].label}
+              />
+              <ActivityEvidenceFact label="Tokens" value={activity.tokenTotal == null ? "Not recorded" : activity.tokenTotal.toLocaleString()} />
+              <ActivityEvidenceFact label="Cost" value={activity.costUsd == null ? "Not recorded" : `$${activity.costUsd.toFixed(4)}`} />
+            </dl>
+          )}
+          <TechnicalDetails
+            entries={[{ label: "Route decision", value: activity.routeDecisionId }]}
+          />
         </div>
 
         <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
           <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
             Harness
           </p>
+          <p className="mt-2 text-xs leading-5 text-[var(--dpf-text)]">
+            {recipePresentation.label ??
+              (recipePresentation.technicalId
+                ? "Custom recipe — see technical details."
+                : "No recipe bound to this route yet.")}
+          </p>
           <dl className="mt-2 space-y-1 text-xs text-[var(--dpf-muted)]">
-            <ActivityEvidenceFact label="Recipe" value={activity.harnessRecipeKey ?? "Unbound"} />
-            <ActivityEvidenceFact label="Adapter run" value={activity.adapterTelemetryId ?? "No telemetry"} />
+            <ActivityEvidenceFact label="Adapter run" value={activity.adapterTelemetryId ? "Telemetry recorded" : "No telemetry yet"} />
             <ActivityEvidenceFact label="Tuning" value={activity.tuningRecommendation ?? "observe"} />
-            <ActivityEvidenceFact label="Approved override" value={activity.approvedConfidenceOverrideId ?? "None"} />
+            <ActivityEvidenceFact label="Approved override" value={activity.approvedConfidenceOverrideId ? "Approved" : "None"} />
           </dl>
+          <TechnicalDetails
+            entries={[
+              { label: "Recipe key", value: activity.harnessRecipeKey },
+              { label: "Adapter run", value: activity.adapterTelemetryId },
+              { label: "Override", value: activity.approvedConfidenceOverrideId },
+            ]}
+          />
         </div>
 
-        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
-            Alternatives excluded
-          </p>
-          {activity.exclusions.length > 0 ? (
+        {activity.exclusions.length > 0 ? (
+          <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+              Alternatives excluded
+            </p>
             <ul className="mt-2 space-y-1 text-xs leading-5 text-[var(--dpf-muted)]">
               {activity.exclusions.slice(0, 3).map((exclusion, index) => (
                 <li key={`${activity.activityId}:decision-exclusion:${index}`}>
-                  {exclusion.providerId}/{exclusion.modelId ?? "default"}: {exclusion.reason}
+                  <span className="text-[var(--dpf-text)]">
+                    {presentModelRoute(exclusion.providerId, exclusion.modelId).label}:
+                  </span>{" "}
+                  {exclusion.reason}
                 </li>
               ))}
             </ul>
-          ) : (
-            <p className="mt-2 text-xs leading-5 text-[var(--dpf-muted)]">
-              No exclusions recorded for this activity route.
-            </p>
-          )}
-        </div>
+          </div>
+        ) : (
+          <p className="p-3 text-xs leading-5 text-[var(--dpf-muted)]">
+            No alternatives were excluded for this route.
+          </p>
+        )}
       </div>
     </section>
   );
@@ -433,9 +660,9 @@ function EmptyStateStep({ label, detail }: { label: string; detail: string }) {
   );
 }
 
-function InspectorFact({ label, value }: { label: string; value: string }) {
+function InspectorFact({ label, value, title }: { label: string; value: string; title?: string }) {
   return (
-    <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+    <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2" title={title}>
       <dt className="text-[10px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">{label}</dt>
       <dd className="mt-1 break-words font-medium text-[var(--dpf-text)]">{value}</dd>
     </div>

--- a/apps/web/lib/agent/provider-model-label.test.ts
+++ b/apps/web/lib/agent/provider-model-label.test.ts
@@ -45,9 +45,13 @@ describe("providerModelLabel", () => {
     });
   });
 
-  it("prefers a resolved provider display name for unknown providers", () => {
+  it("labels the Z.ai / GLM family natively (BI-E3969A69 convergence)", () => {
     expect(providerModelLabel("zai", "glm-5.2", "Z.ai")).toEqual({
-      label: "Z.ai · Glm 5.2",
+      label: "Z.ai · GLM 5.2",
+      title: "zai / glm-5.2",
+    });
+    expect(providerModelLabel("zai", "glm-5.2")).toEqual({
+      label: "Z.ai · GLM 5.2",
       title: "zai / glm-5.2",
     });
   });

--- a/apps/web/lib/agent/provider-model-label.ts
+++ b/apps/web/lib/agent/provider-model-label.ts
@@ -95,6 +95,7 @@ function shortModel(providerFamily: string, modelId: string): string {
     .filter(Boolean)
     .map((seg) => {
       if (/^gpt$/i.test(seg)) return "GPT";
+      if (/^glm$/i.test(seg)) return "GLM";
       if (/^\d/.test(seg)) return seg;
       return titleCaseWord(seg);
     })
@@ -141,6 +142,9 @@ export function providerModelLabel(
   } else if (matches("google") || matches("gemini")) {
     providerLabel = "Gemini";
     family = "gemini";
+  } else if (matches("zai") || matches("z.ai") || matches("glm")) {
+    providerLabel = "Z.ai";
+    family = "zai";
   } else if (providerName && providerName.trim()) {
     providerLabel = providerName.trim();
     family = key || nameKey;

--- a/apps/web/lib/ai-operations-map/route-labels.test.ts
+++ b/apps/web/lib/ai-operations-map/route-labels.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  emptyOutcomeEvidenceSummary,
+  parseHarnessRecipeKey,
+  presentModelRoute,
+  presentRecipeKey,
+  shortenContainerImageRef,
+} from "./route-labels";
+
+describe("parseHarnessRecipeKey", () => {
+  it("parses the live fixture keys", () => {
+    expect(parseHarnessRecipeKey("glm.center.summarize.provisional")).toEqual({
+      providerFamily: "glm",
+      distribution: "center",
+      activity: "summarize",
+      confidence: "provisional",
+    });
+    expect(parseHarnessRecipeKey("frontier.edge.critique.trusted")).toEqual({
+      providerFamily: "frontier",
+      distribution: "edge",
+      activity: "critique",
+      confidence: "trusted",
+    });
+    expect(parseHarnessRecipeKey("glm.mixed.code-edit.provisional")).toEqual({
+      providerFamily: "glm",
+      distribution: "mixed",
+      activity: "code-edit",
+      confidence: "provisional",
+    });
+  });
+
+  it("returns null for malformed keys instead of throwing", () => {
+    expect(parseHarnessRecipeKey(null)).toBeNull();
+    expect(parseHarnessRecipeKey(undefined)).toBeNull();
+    expect(parseHarnessRecipeKey("")).toBeNull();
+    expect(parseHarnessRecipeKey("just-a-slug")).toBeNull();
+    expect(parseHarnessRecipeKey("too.many.parts.here.extra")).toBeNull();
+    expect(parseHarnessRecipeKey("glm.NOPE.summarize.provisional")).toBeNull();
+    expect(parseHarnessRecipeKey("glm.center.unknown-activity.provisional")).toBeNull();
+    expect(parseHarnessRecipeKey("glm.center.summarize.certain")).toBeNull();
+    expect(parseHarnessRecipeKey(".center.summarize.provisional")).toBeNull();
+  });
+});
+
+describe("presentRecipeKey", () => {
+  it("humanizes a parseable key grounded on the step's provider/model ids", () => {
+    const presentation = presentRecipeKey("glm.center.summarize.provisional", {
+      providerId: "zai",
+      modelId: "glm-5.2",
+    });
+    expect(presentation.label).toBe(
+      "Z.ai · GLM 5.2 — trial recipe for summarizing (routine work)",
+    );
+    expect(presentation.technicalId).toBe("glm.center.summarize.provisional");
+    expect(presentation.parsed?.confidence).toBe("provisional");
+  });
+
+  it("still reads sensibly without resolved provider/model ids", () => {
+    const presentation = presentRecipeKey("frontier.edge.critique.trusted");
+    expect(presentation.label).toContain("trusted recipe for review & critique");
+    expect(presentation.label).toContain("hard/novel work");
+  });
+
+  it("falls back to technicalId-only for unparseable keys", () => {
+    const presentation = presentRecipeKey("legacy-recipe-42");
+    expect(presentation.label).toBeNull();
+    expect(presentation.parsed).toBeNull();
+    expect(presentation.technicalId).toBe("legacy-recipe-42");
+  });
+});
+
+describe("shortenContainerImageRef", () => {
+  it("shortens the live container ref", () => {
+    expect(shortenContainerImageRef("docker.io/ai/qwen3.6:latest")).toBe(
+      "Qwen 3.6 (local container)",
+    );
+  });
+
+  it("handles name-version and versionless images", () => {
+    expect(shortenContainerImageRef("docker.io/ai/llama3:8b")).toBe("Llama 3 (local container)");
+    expect(shortenContainerImageRef("registry.local/models/mistral:latest")).toBe(
+      "Mistral (local container)",
+    );
+  });
+
+  it("returns null for plain model ids", () => {
+    expect(shortenContainerImageRef("glm-5.2")).toBeNull();
+    expect(shortenContainerImageRef(null)).toBeNull();
+    expect(shortenContainerImageRef("")).toBeNull();
+  });
+});
+
+describe("presentModelRoute", () => {
+  it("prefers the container shortener for image refs", () => {
+    expect(presentModelRoute("dmr", "docker.io/ai/qwen3.6:latest").label).toBe(
+      "Qwen 3.6 (local container)",
+    );
+  });
+
+  it("labels the Z.ai / GLM pair without leaking raw ids", () => {
+    const route = presentModelRoute("zai", "glm-5.2");
+    expect(route.label).toBe("Z.ai · GLM 5.2");
+    expect(route.technicalId).toBe("zai / glm-5.2");
+  });
+});
+
+describe("emptyOutcomeEvidenceSummary", () => {
+  it("collapses an all-unknown evidence grid into one sentence", () => {
+    expect(
+      emptyOutcomeEvidenceSummary({
+        successSignal: "unknown",
+        routeDecisionId: null,
+        tokenTotal: null,
+        costUsd: null,
+      }),
+    ).toBe("No outcome recorded yet — this route hasn't run.");
+  });
+
+  it("returns null as soon as any evidence exists", () => {
+    expect(
+      emptyOutcomeEvidenceSummary({
+        successSignal: "valid",
+        routeDecisionId: null,
+        tokenTotal: null,
+        costUsd: null,
+      }),
+    ).toBeNull();
+    expect(
+      emptyOutcomeEvidenceSummary({
+        successSignal: "unknown",
+        routeDecisionId: "RD-1",
+        tokenTotal: null,
+        costUsd: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/ai-operations-map/route-labels.ts
+++ b/apps/web/lib/ai-operations-map/route-labels.ts
@@ -1,0 +1,245 @@
+/**
+ * Human-readable presentation for Operations Map routing internals
+ * (BI-E3969A69).
+ *
+ * The Operations Map renders routing substrate ids raw — harness recipe keys
+ * like `glm.center.summarize.provisional`, container image refs like
+ * `docker.io/ai/qwen3.6:latest`, and bare confidence enums. Operators can't
+ * act on those. This module is the pure translation layer: parse the ids,
+ * say what they mean in the operator's language, and never throw — an
+ * unparseable id falls back to being shown as a technical id.
+ *
+ * Pure and client-safe by design (no React, no server imports): the unified
+ * topology canvas (three-band spec, Stage B–E) consumes this same module at
+ * cutover, per the kernel decision recorded in
+ * docs/superpowers/plans/2026-07-06-ops-map-digestibility-and-coworker-panel-honesty-plan.md.
+ */
+
+import { providerModelLabel } from "@/lib/agent/provider-model-label";
+import type {
+  ActivityClass,
+  ActivityDistributionShape,
+  ActivityRiskClass,
+} from "@/lib/routing/activity-contract";
+import type { OperationsMapActivitySuccessSignal } from "./types";
+
+export type ActivityConfidence = "provisional" | "calibrating" | "trusted" | "degraded";
+
+const DISTRIBUTION_SHAPES: ReadonlySet<string> = new Set(["center", "mixed", "edge"]);
+const CONFIDENCE_TIERS: ReadonlySet<string> = new Set([
+  "provisional",
+  "calibrating",
+  "trusted",
+  "degraded",
+]);
+const ACTIVITY_CLASSES: ReadonlySet<string> = new Set([
+  "classify",
+  "summarize",
+  "extract",
+  "synthesize",
+  "critique",
+  "plan",
+  "code-edit",
+  "tool-act",
+  "verify",
+  "handoff",
+]);
+
+// ── Plain-language copy registries ──────────────────────────────────────────
+
+/** What kind of work each activity class is, in operator words. */
+export const ACTIVITY_CLASS_COPY: Record<ActivityClass, string> = {
+  classify: "classification",
+  summarize: "summarizing",
+  extract: "data extraction",
+  synthesize: "drafting & synthesis",
+  critique: "review & critique",
+  plan: "planning",
+  "code-edit": "code editing",
+  "tool-act": "tool actions",
+  verify: "verification",
+  handoff: "handoff",
+};
+
+/** Where the work sits on the routine↔novel spectrum. */
+export const DISTRIBUTION_COPY: Record<ActivityDistributionShape, { label: string; description: string }> = {
+  center: {
+    label: "routine work",
+    description: "Routine, well-understood work — safe ground for trialing cheaper models.",
+  },
+  mixed: {
+    label: "mixed work",
+    description: "A blend of routine and novel work.",
+  },
+  edge: {
+    label: "hard/novel work",
+    description: "Hard or novel work where the strongest models are used.",
+  },
+};
+
+/** How much trust each harness confidence tier has earned, and what that means. */
+export const CONFIDENCE_COPY: Record<ActivityConfidence, { label: string; description: string }> = {
+  provisional: {
+    label: "Trial",
+    description: "Trial run — this model route is being evaluated and hasn't earned trust yet.",
+  },
+  calibrating: {
+    label: "Calibrating",
+    description: "Gathering outcome evidence to decide whether this route should be trusted.",
+  },
+  trusted: {
+    label: "Trusted",
+    description: "Proven route — outcomes have consistently met the bar.",
+  },
+  degraded: {
+    label: "Degraded",
+    description: "Recent outcomes fell below the bar — this route is being backed off.",
+  },
+};
+
+/** Priority/risk chips (HIGH / LOW on the node cards). */
+export const RISK_COPY: Record<ActivityRiskClass, { label: string; description: string }> = {
+  low: { label: "Low stakes", description: "Mistakes here are cheap to catch and fix." },
+  medium: { label: "Medium stakes", description: "Worth a second look, but not gating." },
+  high: { label: "High stakes", description: "Errors here are costly — routed conservatively." },
+  critical: { label: "Critical", description: "Must not fail — strongest route and checks apply." },
+};
+
+/** What each outcome signal means for the operator. */
+export const SUCCESS_SIGNAL_COPY: Record<OperationsMapActivitySuccessSignal, { label: string; description: string }> = {
+  valid: { label: "Succeeded", description: "Output passed validation." },
+  accepted: { label: "Accepted", description: "Output was accepted downstream." },
+  "review-passed": { label: "Review passed", description: "Output passed review." },
+  failed: { label: "Failed", description: "This step failed and needs attention." },
+  retried: { label: "Retried", description: "Needed at least one retry before settling." },
+  attention: { label: "Needs attention", description: "Outcome was flagged for a human look." },
+  unknown: { label: "No outcome yet", description: "This route hasn't produced a recorded outcome." },
+};
+
+// ── Recipe key parsing ───────────────────────────────────────────────────────
+
+export type ParsedRecipeKey = {
+  providerFamily: string;
+  distribution: ActivityDistributionShape;
+  activity: ActivityClass;
+  confidence: ActivityConfidence;
+};
+
+export type RecipeKeyPresentation = {
+  /** Human sentence when the key parses; null when it doesn't. */
+  label: string | null;
+  /** Parsed parts when available. */
+  parsed: ParsedRecipeKey | null;
+  /** Always set: the raw key for the technical-details disclosure. */
+  technicalId: string;
+};
+
+/**
+ * Parse `<provider>.<distribution>.<activity>.<confidence>` — e.g.
+ * `glm.center.summarize.provisional`. Returns null parts (never throws) for
+ * anything that doesn't match the shape.
+ */
+export function parseHarnessRecipeKey(key: string | null | undefined): ParsedRecipeKey | null {
+  const raw = (key ?? "").trim();
+  if (!raw) return null;
+  const parts = raw.split(".");
+  if (parts.length !== 4) return null;
+  const [providerFamily, distribution, activity, confidence] = parts;
+  if (!providerFamily) return null;
+  if (!DISTRIBUTION_SHAPES.has(distribution)) return null;
+  if (!ACTIVITY_CLASSES.has(activity)) return null;
+  if (!CONFIDENCE_TIERS.has(confidence)) return null;
+  return {
+    providerFamily,
+    distribution: distribution as ActivityDistributionShape,
+    activity: activity as ActivityClass,
+    confidence: confidence as ActivityConfidence,
+  };
+}
+
+/**
+ * Full presentation for a harness recipe key, optionally grounded by the
+ * step's resolved provider/model ids (preferred for the model name).
+ *
+ *   ("glm.center.summarize.provisional", { providerId: "zai", modelId: "glm-5.2" })
+ *   → "GLM 5.2 via Z.ai — trial recipe for summarizing (routine work)"
+ */
+export function presentRecipeKey(
+  key: string | null | undefined,
+  step?: { providerId?: string | null; modelId?: string | null },
+): RecipeKeyPresentation {
+  const technicalId = (key ?? "").trim();
+  const parsed = parseHarnessRecipeKey(technicalId);
+  if (!parsed) {
+    return { label: null, parsed: null, technicalId };
+  }
+  const { label: modelLabel } = providerModelLabel(
+    step?.providerId ?? parsed.providerFamily,
+    step?.modelId ?? null,
+  );
+  const confidence = CONFIDENCE_COPY[parsed.confidence];
+  const activity = ACTIVITY_CLASS_COPY[parsed.activity];
+  const distribution = DISTRIBUTION_COPY[parsed.distribution];
+  return {
+    label: `${modelLabel} — ${confidence.label.toLowerCase()} recipe for ${activity} (${distribution.label})`,
+    parsed,
+    technicalId,
+  };
+}
+
+// ── Model / container id shortening ─────────────────────────────────────────
+
+/**
+ * Shorten a container image ref to a human model name.
+ *   "docker.io/ai/qwen3.6:latest" → "Qwen 3.6 (local container)"
+ * Non-container ids pass through providerModelLabel-style prettifying by the
+ * caller; this returns null when the id doesn't look like an image ref.
+ */
+export function shortenContainerImageRef(modelId: string | null | undefined): string | null {
+  const raw = (modelId ?? "").trim();
+  if (!raw || !raw.includes("/")) return null;
+  const lastSegment = raw.split("/").pop() ?? "";
+  const name = lastSegment.split(":")[0];
+  if (!name) return null;
+  // "qwen3.6" → "Qwen 3.6"; "llama3" → "Llama 3"; keep unknown shapes as-is.
+  const match = name.match(/^([a-zA-Z][a-zA-Z-]*?)[-_]?(\d[\d.]*)?$/);
+  if (!match) return `${name} (local container)`;
+  const family = match[1].charAt(0).toUpperCase() + match[1].slice(1);
+  const version = match[2] ? ` ${match[2]}` : "";
+  return `${family}${version} (local container)`;
+}
+
+/** Compact human label for a step's selected provider+model pair. */
+export function presentModelRoute(
+  providerId: string | null | undefined,
+  modelId: string | null | undefined,
+): { label: string; technicalId: string | null } {
+  const containerLabel = shortenContainerImageRef(modelId);
+  if (containerLabel) {
+    return { label: containerLabel, technicalId: modelId ?? null };
+  }
+  const { label, title } = providerModelLabel(providerId, modelId);
+  return { label, technicalId: title === label ? null : title };
+}
+
+// ── Outcome evidence ─────────────────────────────────────────────────────────
+
+/**
+ * One honest sentence when there is no outcome evidence at all — replaces a
+ * grid of four "Unknown" facts. Returns null when any real evidence exists
+ * (caller renders the facts as before).
+ */
+export function emptyOutcomeEvidenceSummary(step: {
+  successSignal: OperationsMapActivitySuccessSignal;
+  routeDecisionId: string | null;
+  tokenTotal: number | null;
+  costUsd: number | null;
+}): string | null {
+  const hasEvidence =
+    step.successSignal !== "unknown" ||
+    step.routeDecisionId !== null ||
+    step.tokenTotal !== null ||
+    step.costUsd !== null;
+  if (hasEvidence) return null;
+  return "No outcome recorded yet — this route hasn't run.";
+}


### PR DESCRIPTION
## Why

An operator reported `/platform/ai/operations-map` as "difficult to process… internal IDs… not actionable": raw harness recipe keys like `glm.center.summarize.provisional`, bare provider/model ids, four "Unknown" outcome facts on unrun routes, and a "N needs review" badge that named a problem but offered no way to act on it.

Plan: `docs/superpowers/plans/2026-07-06-ops-map-digestibility-and-coworker-panel-honesty-plan.md` (Workstream 2). Per the recorded kernel decision, this is the **pure presentation layer + attention queue now**; the first-viewport structural re-layout stays deferred to the unified-canvas cutover, which will consume this same module.

## What

**Phase 2 — pure presentation module** (`lib/ai-operations-map/route-labels.ts`): parses recipe keys into operator sentences, plain-language copy registries for confidence/risk/distribution/outcome-signal, a container-image shortener (`docker.io/ai/qwen3.6:latest` → "Qwen 3.6 (local container)"), and an empty-outcome sentence. Never throws — unparseable ids fall back to the raw technical id. Client-safe so the topology canvas reuses it at cutover. Z.ai/GLM added to `provider-model-label`.

**Phase 3 — apply in the workbench**: cards and drawer show humanized labels; raw ids (recipe key, telemetry id, route-decision id) move behind a **"Technical details"** disclosure with a copy affordance. An all-unknown outcome grid collapses to *"No outcome recorded yet — this route hasn't run."* No panel re-layout (guardrail).

**Phase 4 — attention-first review queue**: the "N needs review" badge becomes a toggle opening a queue of flagged activities. Each row shows a plain reason and its action — **Queue approval** (existing governed proposal path, confirmation preserved), **Open originating build** (via `taskRef`), or an explicit *"Informational — no action available yet"*. Inspect-decision jumps to the drawer.

## Scope

UI layer only; zero schema/read-model change.

## Tests

- `route-labels.test.ts` — recipe parsing, copy registries, container shortening, malformed-input fallback.
- `ActivityRoutingWorkbench.test.tsx` — humanized render + raw key only inside technical-details disclosure; all-unknown collapse; review-queue action-per-row (build link / queue approval / informational).

UX-Fit-Decision: fits-with-guardrails (local page nav only; report-kit/status primitives reused; page stays read-only; approval keeps explicit confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Process-Spine-Decision: UI presentation layer only — new lib/route-labels.ts is a pure display module governed by the merged plan (2026-07-06-ops-map-digestibility...); no contract/schema/read-model surface changed.
