### PR TITLE
fix(decision-gov): forward caller attribution into executeTool — the ledger recorded all-null callers (BI-0EEBA669)

### DIFF
--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -194,6 +194,40 @@ describe("governedExecuteTool — happy path", () => {
     expect(auditRows[0]!.agentId).toBe("AGT-100");
   });
 
+  it("forwards caller attribution (callerClient/apiTokenId/authSource) into executeTool (BI-0EEBA669)", async () => {
+    // Regression: governedExecuteTool built the executeTool context from only
+    // {agentId, threadId, routeContext, taskRunId, featureBuildId} and dropped
+    // the three caller-attribution fields, so every principle_decide consult
+    // recorded an all-null caller and the decision ledger could not match a
+    // decision back to the client/thread that made it.
+    await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: { status: "open" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: {
+        agentId: "AGT-100",
+        threadId: "thread-9",
+        callerClient: "claude-code/2.1",
+        apiTokenId: "tok_xyz",
+        authSource: "pat",
+      },
+      source: "external-jsonrpc",
+    });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      "query_backlog",
+      { status: "open" },
+      "user-1",
+      expect.objectContaining({
+        callerClient: "claude-code/2.1",
+        apiTokenId: "tok_xyz",
+        authSource: "pat",
+        threadId: "thread-9",
+      }),
+    );
+  });
+
   it("propagates the source field unchanged for each transport", async () => {
     for (const source of ["rest", "jsonrpc", "external-jsonrpc", "agentic-loop"] as const) {
       auditRows.length = 0;

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -221,6 +221,9 @@ async function callExecuteTool(
     routeContext?: string;
     taskRunId?: string;
     featureBuildId?: string;
+    callerClient?: string;
+    apiTokenId?: string;
+    authSource?: string;
   },
 ): Promise<ToolResult> {
   if (_executeToolOverride) return _executeToolOverride(toolName, params, userId, ctx);
@@ -535,6 +538,13 @@ export async function governedExecuteTool(
       routeContext: args.context?.routeContext,
       taskRunId: args.context?.taskRunId,
       featureBuildId: args.context?.featureBuildId,
+      // Caller attribution for the decision ledger (BI-0EEBA669). Without these
+      // three, every principle_decide consult recorded an all-null caller — the
+      // route builds them from the request UA + resolved token, but this
+      // forwarding dropped them on the floor, so the ledger never saw them.
+      callerClient: args.context?.callerClient,
+      apiTokenId: args.context?.apiTokenId,
+      authSource: args.context?.authSource,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown tool error";


### PR DESCRIPTION
## Summary

Live verification of caller attribution (#2659) caught that **every `principle_decide` consult recorded an all-null caller**:

```
outcomePayload.caller = {client:null, apiTokenId:null, threadId:null, authSource:null, agentId:null}
```

Root cause is one dropped hop. `app/api/mcp/v1/route.ts` correctly derives `callerClient` from the request User-Agent and `apiTokenId`/`authSource`/`threadId`/`agentId` from the resolved token, and passes them to `governedExecuteTool` as `args.context`. But `governedExecuteTool` rebuilt the `executeTool` context from only `{agentId, threadId, routeContext, taskRunId, featureBuildId}` — dropping `callerClient`/`apiTokenId`/`authSource`. So the `principle_decide` handler read `context?.callerClient === undefined` and persisted an all-null caller, defeating the point of #2659 (match a decision back to the client + thread that made it).

## Fix

Forward the three fields through `callExecuteTool` (both the forwarding call and its `ctx` type). The `GovernedExecuteContext` type and the exec handler already declare/read them — only this hop dropped them.

## Testing

- New regression test in `mcp-governed-execute.test.ts` asserts `executeTool` receives `callerClient`/`apiTokenId`/`authSource`; it fails on the pre-fix forwarding (`objectContaining` over absent keys). 25/25 green.
- apps/web tsc clean.
- Post-deploy live proof: a `principle_decide` consult over MCP records `outcomePayload.caller.client = "claude-code/…"` + the token id, and `/wiki/decisions` shows the Caller column populated.

Companion to #2659 (which shipped the writer + UI) and the WWWD activation work (BI-44526F3E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)