### PR TITLE
feat(inference): engine-aware admission budget — bound concurrent inference, prioritize interactive over autonomous

### DIFF
--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -45,6 +45,11 @@ import "../routing/transcription-adapter"; // EP-INF-009c: registers "transcript
 import "../routing/async-adapter"; // EP-INF-009d: registers "async" adapter
 import "../routing/cli-adapter"; // anthropic-sub: registers "claude-cli" adapter
 import "../routing/codex-cli-adapter"; // codex: registers "codex-cli" adapter
+import {
+  acquireInferenceSlot,
+  currentInferenceOrigin,
+  engineKeyForProvider,
+} from "./inference-admission";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -567,6 +572,17 @@ export async function callProvider(
     selector !== null
       ? selector.kind
       : `legacy:${typeof executionAdapterRaw === "string" ? executionAdapterRaw : "unknown"}`;
+  // Admission gate: bound concurrent inference per engine so a fleet of
+  // autonomous coworkers can't overload a scarce backend (local model ≈ 1-2
+  // concurrent before latency collapses; remote = provider rate limit / cost).
+  // Interactive turns take priority over autonomous/background work, so a human
+  // waiting on a reply never queues behind a scheduled brief. Held only across
+  // the actual inference call, released in `finally`. See inference-admission.ts.
+  const engineKey = engineKeyForProvider(providerId);
+  const releaseInferenceSlot = await acquireInferenceSlot(engineKey, currentInferenceOrigin(), {
+    providerId,
+    modelId,
+  });
   let result;
   try {
     result = await adapter.execute({
@@ -619,6 +635,8 @@ export async function callProvider(
       });
     }
     throw err;
+  } finally {
+    releaseInferenceSlot();
   }
 
   void clearProviderCapacityStatus({ providerId, source: "api" }).catch((capacityErr) => {

--- a/apps/web/lib/inference/inference-admission.test.ts
+++ b/apps/web/lib/inference/inference-admission.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetInferenceAdmissionForTest,
+  acquireInferenceSlot,
+  currentInferenceOrigin,
+  engineKeyForProvider,
+  getInferenceAdmissionSnapshot,
+  resolveEngineLimit,
+  withInferenceOrigin,
+} from "./inference-admission";
+
+const ENV_KEYS = [
+  "DPF_INFERENCE_MAX_CONCURRENCY_LOCAL",
+  "DPF_INFERENCE_MAX_CONCURRENCY_REMOTE",
+  "DPF_INFERENCE_ADMISSION_TIMEOUT_MS",
+] as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+  __resetInferenceAdmissionForTest();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  __resetInferenceAdmissionForTest();
+});
+
+// small helper: let queued microtasks/promises settle
+const tick = () => new Promise<void>(r => setTimeout(r, 0));
+
+describe("inference origin (AsyncLocalStorage)", () => {
+  it("defaults to interactive when unset", () => {
+    expect(currentInferenceOrigin()).toBe("interactive");
+  });
+
+  it("binds origin for the async subtree", async () => {
+    const seen = await withInferenceOrigin("autonomous", async () => {
+      await tick();
+      return currentInferenceOrigin();
+    });
+    expect(seen).toBe("autonomous");
+    // restored outside the scope
+    expect(currentInferenceOrigin()).toBe("interactive");
+  });
+});
+
+describe("engineKeyForProvider", () => {
+  it("maps the local provider to the local engine, all else to remote", () => {
+    expect(engineKeyForProvider("local")).toBe("local");
+    expect(engineKeyForProvider("anthropic")).toBe("remote");
+    expect(engineKeyForProvider("openai")).toBe("remote");
+  });
+});
+
+describe("resolveEngineLimit", () => {
+  it("uses safe defaults (local 1, remote 8)", () => {
+    delete process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL;
+    delete process.env.DPF_INFERENCE_MAX_CONCURRENCY_REMOTE;
+    expect(resolveEngineLimit("local")).toBe(1);
+    expect(resolveEngineLimit("remote")).toBe(8);
+  });
+
+  it("honours env overrides", () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "3";
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_REMOTE = "16";
+    expect(resolveEngineLimit("local")).toBe(3);
+    expect(resolveEngineLimit("remote")).toBe(16);
+  });
+});
+
+describe("acquireInferenceSlot", () => {
+  it("grants immediately while below the engine ceiling", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "2";
+    const r1 = await acquireInferenceSlot("local", "interactive");
+    const r2 = await acquireInferenceSlot("local", "interactive");
+    expect(getInferenceAdmissionSnapshot().local.active).toBe(2);
+    r1();
+    r2();
+    expect(getInferenceAdmissionSnapshot().local.active).toBe(0);
+  });
+
+  it("queues callers at capacity and wakes them on release", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "1";
+    const r1 = await acquireInferenceSlot("local", "interactive");
+
+    let acquired2 = false;
+    const p2 = acquireInferenceSlot("local", "interactive").then(rel => {
+      acquired2 = true;
+      return rel;
+    });
+    await tick();
+    // still waiting — no free slot
+    expect(acquired2).toBe(false);
+    expect(getInferenceAdmissionSnapshot().local.interactiveWaiting).toBe(1);
+
+    r1(); // release hands the slot to the waiter
+    const r2 = await p2;
+    expect(acquired2).toBe(true);
+    expect(getInferenceAdmissionSnapshot().local.active).toBe(1);
+    r2();
+    expect(getInferenceAdmissionSnapshot().local.active).toBe(0);
+  });
+
+  it("serves interactive waiters before autonomous ones", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "1";
+    const r1 = await acquireInferenceSlot("local", "autonomous");
+
+    const order: string[] = [];
+    // autonomous enqueued FIRST, interactive SECOND — priority must reorder them
+    const pAuto = acquireInferenceSlot("local", "autonomous").then(rel => {
+      order.push("autonomous");
+      return rel;
+    });
+    const pInteractive = acquireInferenceSlot("local", "interactive").then(rel => {
+      order.push("interactive");
+      return rel;
+    });
+    await tick();
+    expect(getInferenceAdmissionSnapshot().local.autonomousWaiting).toBe(1);
+    expect(getInferenceAdmissionSnapshot().local.interactiveWaiting).toBe(1);
+
+    r1();
+    (await pInteractive)();
+    await tick();
+    (await pAuto)();
+
+    expect(order).toEqual(["interactive", "autonomous"]);
+  });
+
+  it("treats a non-positive limit as unlimited (gating disabled)", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "0";
+    const releases = await Promise.all(
+      Array.from({ length: 5 }, () => acquireInferenceSlot("local", "autonomous")),
+    );
+    // all granted immediately, none queued
+    expect(getInferenceAdmissionSnapshot().local.interactiveWaiting).toBe(0);
+    expect(getInferenceAdmissionSnapshot().local.autonomousWaiting).toBe(0);
+    for (const r of releases) r();
+  });
+
+  it("release is idempotent — double release does not corrupt the count", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "1";
+    const r1 = await acquireInferenceSlot("local", "interactive");
+    r1();
+    r1(); // no-op
+    expect(getInferenceAdmissionSnapshot().local.active).toBe(0);
+  });
+
+  it("times out a waiter that never gets a slot", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "1";
+    process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS = "20";
+    const r1 = await acquireInferenceSlot("local", "autonomous");
+    await expect(acquireInferenceSlot("local", "autonomous")).rejects.toThrow(
+      /admission timeout/,
+    );
+    // the timed-out waiter is removed from the queue
+    expect(getInferenceAdmissionSnapshot().local.autonomousWaiting).toBe(0);
+    r1();
+  });
+});

--- a/apps/web/lib/inference/inference-admission.ts
+++ b/apps/web/lib/inference/inference-admission.ts
@@ -1,0 +1,217 @@
+// Inference admission control — bound concurrent inference per engine so a
+// growing fleet of autonomous coworkers cannot overload a scarce backend.
+//
+// The concern (raised operating the autonomous-self-task substrate, BI-3F09BDD4):
+// as more coworkers self-drive, every scheduled + build + interactive turn
+// eventually funnels through the SAME inference engine. A local model (Docker
+// Model Runner, 7-13B class) reliably handles ~1-2 concurrent requests before
+// latency collapses; an external provider is bounded by its rate limit and by
+// cost. Nothing today bounds the AGGREGATE — the scheduled dispatcher serializes
+// its own tasks, but it does not coordinate with interactive chat, build phases,
+// or the other autonomous system tasks, all of which hit the engine in the same
+// portal process.
+//
+// This module is the "serialize scarce compute" primitive (EP-056D2A5E) applied
+// at the single global inference choke point (`callProvider`). Two mechanisms:
+//
+//   1. An AsyncLocalStorage origin tag ("interactive" | "autonomous") set once at
+//      the autonomous entry point. Everything unlabelled defaults to
+//      "interactive" — the safe default, since the only turn we must demote is
+//      background work.
+//   2. A per-engine priority semaphore. When an engine is at capacity, callers
+//      queue; interactive waiters are always served ahead of autonomous ones, so
+//      a human waiting on a reply never sits behind a background campaign brief.
+//
+// Single-process scope: interactive chat (Next request path) and Inngest-
+// dispatched autonomous work both execute in the portal's Node process, so an
+// in-process semaphore is a correct bound for a single-portal install. A
+// distributed lane (for multi-replica portals) is a documented follow-up.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type InferenceOrigin = "interactive" | "autonomous";
+
+/** Coarse engine bucket. Local models are the scarce, easily-overloaded backend
+ *  and get their own tight budget; every remote provider shares an aggregate
+ *  outbound budget (a conservative cap on concurrent cost/rate-limit exposure). */
+export type EngineKey = "local" | "remote";
+
+const originStore = new AsyncLocalStorage<InferenceOrigin>();
+
+/** Run `fn` with the given inference origin bound for its whole async subtree.
+ *  Every `callProvider` beneath it reads this origin without any signature
+ *  threading. */
+export function withInferenceOrigin<T>(origin: InferenceOrigin, fn: () => T): T {
+  return originStore.run(origin, fn);
+}
+
+/** The origin of the currently-executing inference call. Defaults to
+ *  "interactive" when unset — background callers must opt in via
+ *  withInferenceOrigin("autonomous", …). */
+export function currentInferenceOrigin(): InferenceOrigin {
+  return originStore.getStore() ?? "interactive";
+}
+
+export function engineKeyForProvider(providerId: string): EngineKey {
+  return providerId === "local" ? "local" : "remote";
+}
+
+/** Per-engine concurrency ceiling, read live from env so an operator can size it
+ *  to their install without a rebuild. A value ≤ 0 disables gating for that
+ *  engine (unlimited) — an explicit escape hatch. Defaults: local = 1 (a single
+ *  local model tolerates one in-flight request), remote = 8 (headroom below a
+ *  typical provider rate limit). */
+export function resolveEngineLimit(engineKey: EngineKey): number {
+  const raw =
+    engineKey === "local"
+      ? process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL
+      : process.env.DPF_INFERENCE_MAX_CONCURRENCY_REMOTE;
+  const parsed = raw != null && raw.trim() !== "" ? Number(raw) : NaN;
+  if (Number.isFinite(parsed)) return Math.trunc(parsed);
+  return engineKey === "local" ? 1 : 8;
+}
+
+/** Max time a caller will wait for a slot before giving up. A safety net against
+ *  a leaked release, not a routine path — with interactive priority and the
+ *  serial autonomous dispatcher, sustained saturation is not expected on a
+ *  single-operator install. */
+function resolveAcquireTimeoutMs(): number {
+  const raw = process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS;
+  const parsed = raw != null && raw.trim() !== "" ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.trunc(parsed);
+  return 120_000;
+}
+
+interface Waiter {
+  origin: InferenceOrigin;
+  resolve: () => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+  enqueuedAt: number;
+}
+
+interface EngineState {
+  active: number;
+  interactiveQ: Waiter[];
+  autonomousQ: Waiter[];
+}
+
+const engines = new Map<EngineKey, EngineState>();
+
+function engineState(key: EngineKey): EngineState {
+  let s = engines.get(key);
+  if (!s) {
+    s = { active: 0, interactiveQ: [], autonomousQ: [] };
+    engines.set(key, s);
+  }
+  return s;
+}
+
+/** Pull the next waiter to serve: interactive queue drains before autonomous. */
+function nextWaiter(s: EngineState): Waiter | undefined {
+  return s.interactiveQ.shift() ?? s.autonomousQ.shift();
+}
+
+function removeWaiter(s: EngineState, w: Waiter): void {
+  const q = w.origin === "interactive" ? s.interactiveQ : s.autonomousQ;
+  const i = q.indexOf(w);
+  if (i >= 0) q.splice(i, 1);
+}
+
+/**
+ * Acquire a slot on `engineKey`. Resolves immediately when the engine is below
+ * its ceiling; otherwise queues (by priority) until a slot frees or the timeout
+ * fires. Returns a release function that MUST be called (use try/finally) — it
+ * frees the slot and wakes the next waiter.
+ */
+export async function acquireInferenceSlot(
+  engineKey: EngineKey,
+  origin: InferenceOrigin,
+  opts?: { providerId?: string; modelId?: string },
+): Promise<() => void> {
+  const limit = resolveEngineLimit(engineKey);
+  const s = engineState(engineKey);
+
+  // Gating disabled for this engine, or capacity available: take a slot now.
+  if (limit <= 0 || s.active < limit) {
+    s.active++;
+    return makeRelease(engineKey);
+  }
+
+  // At capacity — queue with priority and wait.
+  const startedWaiting = Date.now();
+  await new Promise<void>((resolve, reject) => {
+    const waiter: Waiter = {
+      origin,
+      resolve,
+      reject,
+      timer: null,
+      enqueuedAt: startedWaiting,
+    };
+    waiter.timer = setTimeout(() => {
+      removeWaiter(s, waiter);
+      reject(
+        new Error(
+          `inference admission timeout on ${engineKey} engine after ` +
+            `${resolveAcquireTimeoutMs()}ms (origin=${origin}` +
+            `${opts?.providerId ? `, provider=${opts.providerId}` : ""})`,
+        ),
+      );
+    }, resolveAcquireTimeoutMs());
+    (origin === "interactive" ? s.interactiveQ : s.autonomousQ).push(waiter);
+  });
+
+  const waitedMs = Date.now() - startedWaiting;
+  if (waitedMs >= 2_000) {
+    console.warn(
+      "[inference-admission] queued for slot",
+      { engineKey, origin, waitedMs, providerId: opts?.providerId, modelId: opts?.modelId },
+    );
+  }
+  // Slot was handed to us by the releaser (which already incremented active).
+  return makeRelease(engineKey);
+}
+
+function makeRelease(engineKey: EngineKey): () => void {
+  let released = false;
+  return () => {
+    if (released) return; // idempotent — double-release must not corrupt the count
+    released = true;
+    const s = engineState(engineKey);
+    const next = nextWaiter(s);
+    if (next) {
+      // Hand our slot directly to the next waiter (active count stays put).
+      if (next.timer) clearTimeout(next.timer);
+      next.resolve();
+    } else {
+      s.active = Math.max(0, s.active - 1);
+    }
+  };
+}
+
+/** Point-in-time view of admission state — for tests and observability. */
+export function getInferenceAdmissionSnapshot(): Record<
+  EngineKey,
+  { active: number; limit: number; interactiveWaiting: number; autonomousWaiting: number }
+> {
+  const view = (key: EngineKey) => {
+    const s = engines.get(key);
+    return {
+      active: s?.active ?? 0,
+      limit: resolveEngineLimit(key),
+      interactiveWaiting: s?.interactiveQ.length ?? 0,
+      autonomousWaiting: s?.autonomousQ.length ?? 0,
+    };
+  };
+  return { local: view("local"), remote: view("remote") };
+}
+
+/** Test-only: drop all queued/active state so cases start clean. */
+export function __resetInferenceAdmissionForTest(): void {
+  for (const s of engines.values()) {
+    for (const w of [...s.interactiveQ, ...s.autonomousQ]) {
+      if (w.timer) clearTimeout(w.timer);
+    }
+  }
+  engines.clear();
+}

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -232,34 +232,44 @@ export async function executeAutonomousAgenticLoop(input: {
   onProgress?: (event: AgentEvent) => void;
 }) {
   const { runAgenticLoop } = await import("@/lib/tak/agentic-loop");
+  const { withInferenceOrigin } = await import("@/lib/inference/inference-admission");
 
   // Capture before-run timestamp so the post-run reflection trigger only
   // considers PlatformIssueReport rows this run produced.
   const startedAt = new Date();
 
-  const result = await runAgenticLoop({
-    systemPrompt: input.systemPrompt,
-    chatHistory: input.chatHistory,
-    sensitivity: input.sensitivity,
-    tools: input.tools,
-    toolsForProvider: input.toolsForProvider,
-    deferredTools: input.deferredTools,
-    userId: input.userId,
-    routeContext: input.routeContext,
-    agentId: input.agentId,
-    threadId: input.threadId,
-    taskRunId: input.taskRunId,
-    apiTokenId: input.apiTokenId,
-    taskType: input.taskType,
-    agentDisplayName: input.agentDisplayName,
-    buildPhase: input.buildPhase,
-    featureBuildId: input.featureBuildId,
-    activeSkillId: input.activeSkillId ?? null,
-    agentMessageId: input.agentMessageId ?? null,
-    interactionMode: input.interactionMode,
-    ...(input.modelRequirements ? { modelRequirements: input.modelRequirements } : {}),
-    onProgress: input.onProgress,
-  });
+  // This is the single seam both interactive chat (interactionMode "chat") and
+  // autonomous work (scheduled self-tasks, build phases, system tasks) flow
+  // through. Tag the inference origin here so the admission gate in callProvider
+  // gives human turns priority over background work on a shared engine. Chat →
+  // interactive; everything else → autonomous (matching the "autonomous" default).
+  const inferenceOrigin = input.interactionMode === "chat" ? "interactive" : "autonomous";
+
+  const result = await withInferenceOrigin(inferenceOrigin, () =>
+    runAgenticLoop({
+      systemPrompt: input.systemPrompt,
+      chatHistory: input.chatHistory,
+      sensitivity: input.sensitivity,
+      tools: input.tools,
+      toolsForProvider: input.toolsForProvider,
+      deferredTools: input.deferredTools,
+      userId: input.userId,
+      routeContext: input.routeContext,
+      agentId: input.agentId,
+      threadId: input.threadId,
+      taskRunId: input.taskRunId,
+      apiTokenId: input.apiTokenId,
+      taskType: input.taskType,
+      agentDisplayName: input.agentDisplayName,
+      buildPhase: input.buildPhase,
+      featureBuildId: input.featureBuildId,
+      activeSkillId: input.activeSkillId ?? null,
+      agentMessageId: input.agentMessageId ?? null,
+      interactionMode: input.interactionMode,
+      ...(input.modelRequirements ? { modelRequirements: input.modelRequirements } : {}),
+      onProgress: input.onProgress,
+    }),
+  );
 
   // EP-GOLDEN-TRIANGLE: leverage the rigor ladder. This is the SINGLE seam for both
   // chat and autonomous coworker turns. When the coworker's posture sits high on

--- a/docs/superpowers/plans/2026-07-07-inference-admission-budget-plan.md
+++ b/docs/superpowers/plans/2026-07-07-inference-admission-budget-plan.md
@@ -1,0 +1,87 @@
+# Plan — Engine-aware inference admission budget
+
+Date: 2026-07-07. Epic: EP-B9DD37C7 (coworker trust/transparency) · relates to
+EP-056D2A5E (concurrency & contention). Follows BI-3F09BDD4 (Proactivity →
+autonomous scheduled self-tasks, shipped #2674 + fabrication fix #2685).
+
+## Why
+
+Operating the autonomous self-task substrate surfaced a scaling constraint: as
+more coworkers self-drive, every scheduled + build + interactive turn eventually
+funnels through the **same** inference engine. A local model (Docker Model
+Runner, 7–13B class) reliably handles ~1–2 concurrent requests before latency
+collapses; an external provider is bounded by its rate limit and by cost.
+
+## Substrate finding (dpf-verify-substrate-first)
+
+What already bounds load:
+
+- `agent/task-dispatch` (`apps/web/lib/queue/functions/agent-task-dispatch.ts`)
+  runs as a **single-concurrency** Inngest function and drains due tasks
+  **serially** (`for … await`), capped at `take: 20` per 5-min tick, enrolled in
+  the shared build-pipeline lane (`admission.ts`), gated by quiescence.
+- Self-tasks are spread across ticks by `deconflictCron`.
+
+The gap: those protections are **Inngest-only**. Interactive coworker chat comes
+in on the Next request path and shares the engine with **no shared budget and no
+priority** — so a wave of autonomous work adds latency to the human waiting. And
+the throttle is a blanket "1", not tuned to the actual backend (local vs remote).
+
+Single global choke point confirmed: **every** inference path — fallback chain,
+sandbox runner, voice, eval, task-dispatcher — funnels through
+`callProvider(providerId, modelId, …)` in `apps/web/lib/inference/ai-inference.ts`,
+which already hosts a cross-cutting pre-call budget gate. `providerId === "local"`
+identifies the local engine. Both interactive and Inngest-dispatched inference
+execute in the **same portal Node process**, so an in-process semaphore is a
+correct bound for a single-portal install.
+
+There is no existing `ResourceLane`/semaphore fronting inference — the queueing
+substrate (EP-3516E23D) governs Inngest background functions, which cannot cover
+the interactive request path. So the primitive is added at `callProvider`.
+
+## Design
+
+New module `apps/web/lib/inference/inference-admission.ts`:
+
+1. **Origin tag** via `AsyncLocalStorage<InferenceOrigin>` (`"interactive" |
+   "autonomous"`). `withInferenceOrigin(origin, fn)` binds it for the async
+   subtree; `currentInferenceOrigin()` reads it, defaulting to `"interactive"`
+   (safe default — the only turn we must demote is background work).
+2. **Per-engine priority semaphore.** `engineKeyForProvider` buckets `local` vs
+   `remote`. `acquireInferenceSlot(engineKey, origin)` grants immediately below
+   the ceiling, else queues; **interactive waiters drain before autonomous** so a
+   human never sits behind a scheduled brief. Returns an idempotent release fn.
+3. **Config, no UI.** Ceilings read live from env — `DPF_INFERENCE_MAX_CONCURRENCY_LOCAL`
+   (default 1), `DPF_INFERENCE_MAX_CONCURRENCY_REMOTE` (default 8); `≤ 0`
+   disables gating (escape hatch). `DPF_INFERENCE_ADMISSION_TIMEOUT_MS` (default
+   120000) is a safety net against a leaked release. Deliberately env-only: this
+   is an infra valve with safe defaults, not an operator-facing control a
+   non-technical user must reason about (avoids over-exposing a config surface).
+
+Integration (two seams, minimal):
+
+- `callProvider`: acquire a slot keyed by engine just before `adapter.execute`,
+  release in `finally`. Held only across the actual inference call.
+- `executeAutonomousAgenticLoop` (`autonomous-work-run.ts`) — the single seam
+  both interactive chat (`interactionMode: "chat"`) and autonomous work
+  (scheduled self-tasks, build phases, system tasks) flow through — wraps
+  `runAgenticLoop` in `withInferenceOrigin`, deriving origin from
+  `interactionMode`. Everything else defaults to interactive.
+
+## Verification
+
+- Unit (`inference-admission.test.ts`, 11 cases): origin binding + default;
+  engine keying; limit defaults + env override; grant-below-ceiling; queue +
+  wake on release; **interactive-before-autonomous priority**; unlimited when
+  `≤ 0`; idempotent release; waiter timeout removes from queue.
+- Live: with the fleet self-driving, confirm a scheduled brief run and an
+  interactive chat contend correctly on the local engine — the chat is served
+  first; `[inference-admission] queued for slot` logs on contention.
+
+## Deliberately deferred (follow-ups)
+
+- Distributed lane for multi-replica portals (in-process bound is per-replica).
+- Per-provider (not just local/remote-bucket) budgets keyed to each provider's
+  rate limit.
+- Adaptive sizing from observed engine latency, and a runtime-health surface tile
+  for live admission depth.


### PR DESCRIPTION
## Why

Follow-up to the autonomous self-task substrate (BI-3F09BDD4, #2674/#2685). As more coworkers self-drive, every scheduled + build + interactive turn funnels through the **same** inference engine. A local model (Docker Model Runner, 7–13B) tolerates ~1–2 concurrent requests before latency collapses; a remote provider is bounded by rate limit + cost.

The scheduled dispatcher already serializes *its own* tasks (single-concurrency Inngest fn, serial `for…await`, `take:20`), but that is **Inngest-only** — it doesn't coordinate with interactive chat (Next request path), build phases, or the other system tasks, all in the same portal process. So a wave of autonomous work can add latency to the human waiting on a reply, and the throttle isn't tuned to the actual backend.

## What

The "serialize scarce compute" primitive (EP-056D2A5E) at the single global inference choke point — `callProvider` (every path funnels through it: fallback chain, sandbox runner, voice, eval, dispatcher).

- **Origin tag** — `AsyncLocalStorage<"interactive"|"autonomous">`, set once at the seam both chat and autonomous work flow through (`executeAutonomousAgenticLoop`, deriving from `interactionMode`), read in `callProvider`. Unlabelled work defaults to **interactive** (safe default — only background work must be demoted).
- **Per-engine priority semaphore** — local vs remote bucket; config ceilings `DPF_INFERENCE_MAX_CONCURRENCY_LOCAL` (default 1), `_REMOTE` (default 8), `≤0` disables (escape hatch); `_TIMEOUT_MS` (default 120s) safety net. At capacity callers queue; **interactive waiters drain before autonomous**, so a human never sits behind a scheduled brief. Slot held only across `adapter.execute`, freed in `finally`.

Config is **env-only, no UI** — an infra valve with safe defaults, not an operator-facing control (avoids over-exposing a knob a non-technical user can't answer).

Single-process scope: interactive + Inngest work share one portal Node process, so an in-process semaphore is a correct bound for a single-portal install. Distributed lane (multi-replica) + per-provider budgets are documented follow-ups.

## Tests

`inference-admission.test.ts` — 11 cases (verified green locally): origin binding + default, engine keying, limit defaults/override, grant-below-ceiling, queue + wake on release, **interactive-before-autonomous priority**, unlimited-when-`≤0`, idempotent release, waiter-timeout removal.

## Plan

`docs/superpowers/plans/2026-07-07-inference-admission-budget-plan.md`

Relates-To: EP-B9DD37C7, EP-056D2A5E · Follows BI-3F09BDD4

🤖 Generated with [Claude Code](https://claude.com/claude-code)