### PR TITLE
fix(hooks): lease guards match executable command text, not quoted data (BI-4B8710CD)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,8 @@ jobs:
         run: node --test packages/dpf-skill-pack/hooks/spec-plan-doc-precheck.test.mjs
       - name: Test lease-guard hook
         run: node --test packages/dpf-skill-pack/hooks/lease-guard.test.mjs
+      - name: Test lease-punt-guard hook + shared command-text helper
+        run: node --test packages/dpf-skill-pack/hooks/lease-punt-guard.test.mjs packages/dpf-skill-pack/hooks/command-text.test.mjs
       - name: Test root-clone-guard hook
         run: node --test packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs
       - name: Test compose-guard hook

--- a/docs/superpowers/specs/2026-07-03-harness-enforced-decision-routing-and-lease-punt-gates-design.md
+++ b/docs/superpowers/specs/2026-07-03-harness-enforced-decision-routing-and-lease-punt-gates-design.md
@@ -141,3 +141,23 @@ Gate A was bypassed in the wild three days after it merged, and the failure was 
 **Grok — Gate B NOT live; two layered causes.** Probe (`grok -p`, session `019f39a1-ffb9-7310-bc02-58a6376d0226`): the same probe **RAN**. Root causes, both isolated with throwaway plugins: (1) **manifest path bug** — `.grok-plugin/plugin.json` shipped `../skills/ · ../hooks/hooks.json · ../grok.mcp.json`; Grok resolves component paths from the *package root* (the dir containing `.grok-plugin/`), so `../` escaped the package and Grok loaded **zero** components (`grok inspect`: `dpf-platform (user, enabled)  -`). A `./`-path throwaway loaded its hooks correctly. **Fixed in this PR** (`../`→`./`, plus a conformance test `surface-manifest-paths.test.mjs` asserting all three surface manifests are plugin-root-relative). (2) **harness contract gap** — even with hooks loaded, a captured-payload throwaway confirmed Grok does **not** invoke the Claude `${CLAUDE_PLUGIN_ROOT}` PreToolUse *blocking* command-hook (`x.ai/hooks` advertises `blockingEvents:["pre_tool_use"]` but not via this contract). So fix (1) restores **skill** loading and is necessary-but-not-sufficient for the runtime gate; full Grok Gate-B enforcement needs Grok-native blocking-hook support. Classification: **guards-dead (path bug fixed; blocking-hook contract residual).** Follow-up: **BI-3157516C**. Until then the DPF MCP connector (plane 2) is the enforcing path on Grok.
 
 **Scope decision (kernel-ratified: `implement_toolchain_fixes_now`, `principle_decide` 2026-07-07 `DI-5846C7848762`, composite 8.280, margin 0.723, high confidence, no commandment conflict; vs `document_and_file_followups` 6.706, `build_liveness_verifier` 7.557).** Implement the restorative fixes now (Grok manifest correction + version-skew close + installer Grok-install and per-surface liveness advisory) rather than document-only, with the two harness-limited residuals filed as follow-ups above. In-portal coworker / Build Studio remain server-side always-fresh (plane 2, unaffected).
+## 12. Addendum (2026-07-06) — match executable text, not quoted data
+
+**Observed false positive:** Gate B's patterns ran against the raw Bash command
+string, so quoted DATA that merely *mentioned* a gate command was denied like a
+real invocation. Live case: a `curl` POST recording MCP evidence whose JSON
+summary contained the words "prisma migrate deploy" was blocked — and the Bash
+command writing the backlog item *about* the bug was blocked too, then the
+sibling `lease-guard` blocked the command writing the regression-test files
+because they mention "pnpm dev". Same class in both guards.
+
+**Fix (shared helper `hooks/command-text.mjs`):** deny/block patterns now match
+`executableCommandText(command)` — the command with single/double-quoted
+segments and heredoc bodies removed, and with `sh|bash|zsh|dash -c '<payload>'`
+payloads unquoted and re-appended (a `-c` payload IS a command; one recursion
+level). `GOVERNED_MARKERS` deliberately still match the RAW text: they act in
+the allow direction, so an over-match fails open, consistent with the guards'
+never-wedge-the-session contract. Known accepted misses (fail-open by design):
+a command smuggled inside a heredoc piped to a shell, and unmatched quotes
+(strip to end). Regression tests: `hooks/command-text.test.mjs` plus new cases
+in both guard test files — including the evidence-post repro verbatim.

--- a/packages/dpf-skill-pack/hooks/command-text.mjs
+++ b/packages/dpf-skill-pack/hooks/command-text.mjs
@@ -1,0 +1,87 @@
+// packages/dpf-skill-pack/hooks/command-text.mjs
+//
+// Shared helper for Bash-command guards (lease-guard, lease-punt-guard):
+// reduce a shell command to the text that can actually EXECUTE, so block/deny
+// patterns stop firing on quoted DATA. Observed live 2026-07-06: recording an
+// MCP evidence record whose JSON summary contained the words "prisma migrate
+// deploy" was denied by lease-punt-guard — and filing the bug about it was
+// blocked too, because the BI body quoted the same words.
+//
+// What is removed before pattern matching:
+//   - single-quoted segments (POSIX: no escapes inside)
+//   - double-quoted segments (backslash escapes respected)
+//   - heredoc bodies (<<EOF / <<-EOF / <<'EOF' … EOF)
+// What is added back:
+//   - the payload of `sh|bash|zsh|dash [-flags] -c '<payload>'` — a quoted
+//     -c payload IS a command, so it is unquoted and re-scanned (one level).
+//
+// Direction of error is deliberate: an unmatched quote strips to end-of-string
+// and a command smuggled inside a heredoc piped to a shell is missed — both
+// fail OPEN (allow), matching the guards' never-wedge-the-session contract.
+// Allow-direction markers (GOVERNED_MARKERS) should keep matching the RAW text.
+
+const SHELL_C_PAYLOAD_RE =
+  /\b(?:sh|bash|zsh|dash)\b(?:\s+-{1,2}[\w=-]*)*?\s+-\w*c\w*\s+('(?:[^'])*'|"(?:[^"\\]|\\.)*")/g;
+
+function unquote(quoted) {
+  const q = quoted[0];
+  const body = quoted.slice(1, -1);
+  return q === '"' ? body.replace(/\\(.)/g, "$1") : body;
+}
+
+function stripHeredocBodies(command) {
+  const lines = command.split("\n");
+  const out = [];
+  let terminator = null;
+  for (const line of lines) {
+    if (terminator !== null) {
+      if (line.trim() === terminator) terminator = null;
+      continue;
+    }
+    const heredoc = /<<-?\s*(?:'(\w+)'|"(\w+)"|(\w+))/.exec(line);
+    out.push(line);
+    if (heredoc) terminator = heredoc[1] ?? heredoc[2] ?? heredoc[3];
+  }
+  return out.join("\n");
+}
+
+function stripQuotedSegments(command) {
+  let out = "";
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === "'") {
+      const close = command.indexOf("'", i + 1);
+      if (close === -1) break; // unmatched — strip to end (fail open)
+      i = close + 1;
+    } else if (ch === '"') {
+      let j = i + 1;
+      while (j < command.length && (command[j] !== '"' || command[j - 1] === "\\")) j++;
+      if (j >= command.length) break; // unmatched — strip to end (fail open)
+      i = j + 1;
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * The command's executable text: quoted data and heredoc bodies removed,
+ * shell `-c` payloads unquoted and appended for re-scanning.
+ * @param {string} command
+ * @param {number} depth internal recursion bound for nested `sh -c`
+ * @returns {string}
+ */
+export function executableCommandText(command, depth = 0) {
+  if (typeof command !== "string" || command === "") return "";
+  const payloads = [];
+  if (depth < 2) {
+    for (const match of command.matchAll(SHELL_C_PAYLOAD_RE)) {
+      payloads.push(executableCommandText(unquote(match[1]), depth + 1));
+    }
+  }
+  const stripped = stripQuotedSegments(stripHeredocBodies(command));
+  return payloads.length ? `${stripped}\n${payloads.join("\n")}` : stripped;
+}

--- a/packages/dpf-skill-pack/hooks/command-text.test.mjs
+++ b/packages/dpf-skill-pack/hooks/command-text.test.mjs
@@ -1,0 +1,35 @@
+// node --test — executableCommandText contract (quoted-data false positives).
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { executableCommandText } from "./command-text.mjs";
+
+test("removes single- and double-quoted segments", () => {
+  assert.equal(executableCommandText(`echo 'prisma migrate deploy'`), "echo ");
+  assert.equal(executableCommandText(`git commit -m "mention pnpm dev in docs"`), "git commit -m ");
+});
+
+test("respects backslash escapes inside double quotes", () => {
+  assert.equal(executableCommandText(`echo "a \\" prisma migrate dev"`), "echo ");
+});
+
+test("removes heredoc bodies but keeps following commands", () => {
+  const cmd = `node - <<'EOF'\nconst s = "prisma migrate deploy";\nEOF\ngit status`;
+  const out = executableCommandText(cmd);
+  assert.ok(!out.includes("prisma migrate"), out);
+  assert.ok(out.includes("git status"), out);
+});
+
+test("re-scans sh -c payloads — those ARE commands", () => {
+  assert.match(executableCommandText(`sh -c 'prisma migrate dev'`), /prisma migrate dev/);
+  assert.match(executableCommandText(`bash -lc "pnpm prisma db push"`), /pnpm prisma db push/);
+});
+
+test("unmatched quote strips to end (fail open)", () => {
+  assert.equal(executableCommandText(`echo 'unterminated prisma migrate dev`), "echo ");
+});
+
+test("non-string / empty input yields empty text", () => {
+  assert.equal(executableCommandText(""), "");
+  assert.equal(executableCommandText(undefined), "");
+});

--- a/packages/dpf-skill-pack/hooks/lease-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/lease-guard.mjs
@@ -21,6 +21,8 @@
 
 import { readFileSync } from "node:fs";
 
+import { executableCommandText } from "./command-text.mjs";
+
 // Raw dev-server / preview launchers that spawn an untracked long-lived process.
 // Deliberately NOT docker-compose (legit platform-stack infra) — scoped to the
 // dev-server vectors behind the rogue-server incidents.
@@ -59,7 +61,11 @@ export function decide(command, env = {}) {
   if (typeof command !== "string" || command.trim() === "") return { block: false };
   if (env.DPF_ALLOW_UNGATED_SERVER === "1") return { block: false };
   if (GOVERNED_MARKERS.some((re) => re.test(command))) return { block: false };
-  const hit = BLOCK_PATTERNS.some((re) => re.test(command));
+  // Block patterns run against the EXECUTABLE text only — a commit message or
+  // echoed string mentioning `pnpm dev` is data, not a server launch; a real
+  // launch (incl. `sh -c '…'` payloads) still matches. Markers above stay
+  // raw-matched (allow-direction).
+  const hit = BLOCK_PATTERNS.some((re) => re.test(executableCommandText(command)));
   if (!hit) return { block: false };
   return { block: true, reason: GUIDANCE };
 }

--- a/packages/dpf-skill-pack/hooks/lease-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/lease-guard.test.mjs
@@ -54,3 +54,15 @@ test("does not match 'dev' inside an unrelated word (devDependencies, devops)", 
   assert.equal(decide("pnpm add -D devDependencies-thing").block, false);
   assert.equal(decide("echo devops").block, false);
 });
+
+// ── quoted DATA mentioning a dev-server launch must not block ────────────────
+
+test("allows quoted mentions of dev-server commands (data, not a launch)", () => {
+  assert.equal(decide(`git commit -m "block raw pnpm dev launches"`).block, false);
+  assert.equal(decide(`echo "next dev is gated now"`).block, false);
+  assert.equal(decide(`node - <<'EOD'\nconst tip = "run pnpm dev";\nEOD`).block, false);
+});
+
+test("still blocks a launch smuggled through sh -c", () => {
+  assert.equal(decide(`sh -c 'pnpm dev'`).block, true);
+});

--- a/packages/dpf-skill-pack/hooks/lease-punt-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/lease-punt-guard.mjs
@@ -26,6 +26,8 @@
 
 import { readFileSync } from "node:fs";
 
+import { executableCommandText } from "./command-text.mjs";
+
 // Gates that CANNOT meaningfully run in a source-only worktree (need a live DB /
 // shadow DB). A hard deny + lease redirect — they fail without a DB regardless.
 const HARD_GATE_PATTERNS = [
@@ -72,8 +74,13 @@ export function decide(command, env = {}) {
   if (GOVERNED_MARKERS.some((re) => re.test(command))) return { action: "allow" };
   // DATABASE_URL present => a runnable runtime (canonical or leased). Not our case.
   if (typeof env.DATABASE_URL === "string" && env.DATABASE_URL.trim() !== "") return { action: "allow" };
-  if (HARD_GATE_PATTERNS.some((re) => re.test(command))) return { action: "deny", reason: DENY_GUIDANCE };
-  if (WARN_GATE_PATTERNS.some((re) => re.test(command))) return { action: "warn", reason: WARN_GUIDANCE };
+  // Gate patterns run against the EXECUTABLE text only — quoted data (evidence
+  // summaries, commit messages, node -e scripts, heredoc bodies) mentioning
+  // `prisma migrate` must not deny; a real invocation (incl. `sh -c '…'`
+  // payloads) still does. Markers above stay raw-matched (allow-direction).
+  const executable = executableCommandText(command);
+  if (HARD_GATE_PATTERNS.some((re) => re.test(executable))) return { action: "deny", reason: DENY_GUIDANCE };
+  if (WARN_GATE_PATTERNS.some((re) => re.test(executable))) return { action: "warn", reason: WARN_GUIDANCE };
   return { action: "allow" };
 }
 

--- a/packages/dpf-skill-pack/hooks/lease-punt-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/lease-punt-guard.test.mjs
@@ -55,3 +55,20 @@ test("does not touch unrelated commands", () => {
   assert.equal(decide("").action, "allow");
   assert.equal(decide(undefined).action, "allow");
 });
+
+// ── quoted DATA mentioning a gate command must not deny (2026-07-06 false positive) ──
+
+test("allows a curl/MCP evidence post whose JSON summary mentions the migrate gate (live repro)", () => {
+  const cmd = `REQ=$(node -e 'process.stdout.write(JSON.stringify({summary: "plan: fetch/merge, freshness converge, prisma migrate deploy (CI-parity DB), vitest"}))'); curl -sS -X POST http://127.0.0.1:3000/api/mcp/v1 --data "$REQ"`;
+  assert.equal(decide(cmd).action, "allow");
+});
+
+test("allows commit messages and heredoc bodies that mention gate commands", () => {
+  assert.equal(decide(`git commit -m "docs: explain prisma migrate deploy step"`).action, "allow");
+  assert.equal(decide(`node - <<'EOD'\nconst summary = "prisma migrate deploy step green";\nEOD`).action, "allow");
+});
+
+test("still denies a real invocation smuggled through sh -c", () => {
+  assert.equal(decide(`sh -c 'prisma migrate dev'`).action, "deny");
+  assert.equal(decide(`bash -lc "pnpm prisma db push"`).action, "deny");
+});

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -41,6 +41,13 @@ export function createLocalIntegrationPlan(input) {
     // test/build result counts as product evidence. Exits 3/4 (sandbox drift /
     // not ready) instead of letting a stale install masquerade as a red build.
     ["node", "scripts/sandbox-freshness-preflight.mjs", "--converge", "--branch", branch],
+    // CI parity: the workflow runs `prisma generate` explicitly before every
+    // typecheck/build (ci.yml). The freshness preflight only converges when the
+    // LOCKFILE drifts — a merge that changes schema.prisma without touching
+    // dependencies leaves the generated client stale, and tsc then floods with
+    // false "Property X does not exist" errors (observed live 2026-07-06 right
+    // after #2636 landed a schema change on main). Cheap and idempotent.
+    ["pnpm", "--filter", "@dpf/db", "exec", "prisma", "generate"],
     // CI parity (BI-157DC9B2): the Unit Tests job applies migrations before the
     // suite — a handful of web tests exercise real Prisma reads. Callers that
     // resolved a test DATABASE_URL opt in via includeMigrateDeploy.

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -19,6 +19,7 @@ describe("createLocalIntegrationPlan", () => {
       "git checkout -B local-integration/doc-build-studio-decision-skill-packs origin/main",
       "git merge --no-ff --no-edit doc/build-studio-decision-skill-packs",
       "node scripts/sandbox-freshness-preflight.mjs --converge --branch local-integration/doc-build-studio-decision-skill-packs",
+      "pnpm --filter @dpf/db exec prisma generate",
       "pnpm --filter web exec vitest run",
       "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
       "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build",


### PR DESCRIPTION
## Summary

Fixes **BI-4B8710CD** / EP-5560770F: `lease-punt-guard` and `lease-guard` no longer deny/block Bash commands just because quoted data (JSON summaries, commit messages, heredoc bodies, `node -e` scripts) mentions gate vocabulary like `prisma migrate deploy` or `pnpm dev`.

## Problem

Observed live 2026-07-06 during PR #2635 close-out: posting MCP execution evidence was denied because the JSON summary named the migrate-deploy gate. The guard regexes ran against raw command text, so quoted strings triggered the same deny as real invocations.

## Fix

- New shared helper `packages/dpf-skill-pack/hooks/command-text.mjs` — `executableCommandText()` strips quoted segments and heredoc bodies, then re-scans `sh|bash|zsh|dash -c` payloads (those ARE commands).
- Deny/block patterns match executable text only; `GOVERNED_MARKERS` stay raw-matched (allow-direction, fail open).
- Regression tests for the live evidence-post repro + `sh -c` smuggling cases.
- Wired `lease-punt-guard.test.mjs` + `command-text.test.mjs` into CI.
- Spec addendum in `2026-07-03-harness-enforced-decision-routing-and-lease-punt-gates-design.md`.

## Companion commit

`local-integration-ci.mjs` now runs `prisma generate` after merge so the gate lane does not false-red on a stale Prisma client (discovered while running this branch's own gate).

## Verification

- **Hook tests (node:22-alpine, worktree):** 25/25 pass (`lease-punt-guard`, `lease-guard`, `command-text` test files).
- Full CI pending on this PR.

Process-Spine-Decision: spec addendum included; implements BI-4B8710CD.