### PR TITLE
fix(storefront): conventional timezone picker on operations settings

### DIFF
--- a/apps/web/components/admin/OperatingHoursEditor.test.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.test.tsx
@@ -24,3 +24,27 @@ describe("OperatingHoursEditor save feedback", () => {
     await waitFor(() => expect(screen.getByText(/operating hours saved/i)).toBeTruthy());
   });
 });
+
+describe("OperatingHoursEditor timezone options", () => {
+  it("labels zones with a UTC-offset prefix and a de-underscored name", () => {
+    render(<OperatingHoursEditor defaultSchedule={schedule} timezone="America/New_York" onSave={vi.fn()} />);
+    const select = screen.getByLabelText("Operating hours timezone") as HTMLSelectElement;
+    const selected = Array.from(select.options).find((o) => o.value === "America/New_York");
+    // Orthodox: "(UTC−05:00) America/New York" — offset prefix, no underscore.
+    expect(selected?.textContent).toMatch(/^\(UTC[+−±]\d{2}:\d{2}\) America\/New York$/);
+    expect(selected?.textContent).not.toContain("_");
+  });
+
+  it("orders options by UTC offset, not raw alphabetical", () => {
+    render(<OperatingHoursEditor defaultSchedule={schedule} timezone="America/Chicago" onSave={vi.fn()} />);
+    const select = screen.getByLabelText("Operating hours timezone") as HTMLSelectElement;
+    const offsets = Array.from(select.options).map((o) => {
+      const m = o.textContent?.match(/^\(UTC([+−±])(\d{2}):(\d{2})\)/);
+      if (!m) return 0;
+      const sign = m[1] === "−" ? -1 : 1;
+      return sign * (parseInt(m[2], 10) * 60 + parseInt(m[3], 10));
+    });
+    const sorted = [...offsets].sort((a, b) => a - b);
+    expect(offsets).toEqual(sorted);
+  });
+});

--- a/apps/web/components/admin/OperatingHoursEditor.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.tsx
@@ -50,6 +50,48 @@ function listTimeZones(current: string, detected: string | null): string[] {
   return zones;
 }
 
+/**
+ * The current UTC offset for a zone as a display string ("UTC−05:00") plus its
+ * signed minutes, so options can be sorted by offset like a conventional picker.
+ */
+function zoneOffset(zone: string): { label: string; minutes: number } {
+  try {
+    const name =
+      new Intl.DateTimeFormat("en-US", { timeZone: zone, timeZoneName: "longOffset" })
+        .formatToParts(new Date())
+        .find((p) => p.type === "timeZoneName")?.value ?? "GMT";
+    const m = name.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+    let minutes = 0;
+    if (m) {
+      const sign = m[1] === "-" ? -1 : 1;
+      minutes = sign * (parseInt(m[2], 10) * 60 + parseInt(m[3] ?? "0", 10));
+    }
+    const hh = String(Math.floor(Math.abs(minutes) / 60)).padStart(2, "0");
+    const mm = String(Math.abs(minutes) % 60).padStart(2, "0");
+    const body = minutes === 0 ? "±00:00" : `${minutes < 0 ? "−" : "+"}${hh}:${mm}`;
+    return { label: `UTC${body}`, minutes };
+  } catch {
+    return { label: "UTC±00:00", minutes: 0 };
+  }
+}
+
+type ZoneOption = { value: string; label: string; minutes: number };
+
+/**
+ * Turn the raw IANA catalog into conventional picker options — each labelled
+ * "(UTC−06:00) America/Chicago" (offset prefix + de-underscored name) and ordered
+ * by offset, so the operator scans a familiar list instead of raw zone ids in
+ * "Africa/Abidjan first" alphabetical order.
+ */
+function buildZoneOptions(current: string, detected: string | null): ZoneOption[] {
+  return listTimeZones(current, detected)
+    .map((z) => {
+      const { label, minutes } = zoneOffset(z);
+      return { value: z, label: `(${label}) ${z.replace(/_/g, " ")}`, minutes };
+    })
+    .sort((a, b) => a.minutes - b.minutes || a.value.localeCompare(b.value));
+}
+
 /** The browser's own timezone — the sensible default a layman shouldn't have to type. */
 function detectBrowserTimeZone(): string | null {
   try {
@@ -76,7 +118,7 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
   const [tz, setTz] = useState<string>(
     timezone && timezone !== "UTC" ? timezone : detected ?? timezone,
   );
-  const zones = useMemo(() => listTimeZones(tz, detected), [tz, detected]);
+  const zones = useMemo(() => buildZoneOptions(tz, detected), [tz, detected]);
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -147,8 +189,8 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
             className="px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
           >
             {zones.map((z) => (
-              <option key={z} value={z} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
-                {z}
+              <option key={z.value} value={z.value} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                {z.label}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## What

The operating-hours timezone picker at **/storefront/settings/operations** rendered the raw IANA catalog: ~400 bare zone ids like `America/New_York` — underscores, **no UTC offset**, in raw alphabetical order so `Africa/Abidjan` led the list. Unorthodox and hard to scan for a non-technical operator.

This presents the **same full catalog** conventionally:
- each option labelled `(UTC−06:00) America/Chicago` — current-offset prefix + de-underscored name
- ordered by UTC offset (−12 → +14) instead of raw alphabetical

## What is *not* changed

No behavior lost. `Intl.supportedValuesOf` catalog, the older-engine `FALLBACK_TIMEZONES` list, browser-zone detection, the "Use detected" quick-set, and forced inclusion of the stored/detected zone all still apply. Only the option **label** and **order** change — the persisted value is still the bare IANA id (`America/Chicago`), so stored data and the maintenance/upgrade-window evaluation are unaffected.

## Implementation

`OperatingHoursEditor.tsx`: new `zoneOffset()` (current offset via `Intl.DateTimeFormat` `longOffset`, with a graceful `UTC±00:00` fallback) and `buildZoneOptions()` (label + offset-sort). The `<select>` now maps `{value,label}` options.

## Testing

- New unit tests assert the orthodox label shape `(UTC±HH:MM) Region/City` (no underscore) and that options are ordered by offset, not alphabetical.
- Full suite for `OperatingHoursEditor.test.tsx`: 3 passed.
- `tsc --noEmit` clean (verified in the deps-present root clone; the isolated worktree lacks `node_modules`).

UX-Fit-Decision: Presentation-only fix on an existing settings control — no new surface, tab, route, or operator-configurable option is introduced; the timezone field already existed and this only makes its choices legible (offset prefix + conventional ordering). Fit preserved, complexity not added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)