### PR TITLE
feat(installer): named hook roster so operators grant hook-trust informed (BI-276EC984)

### DIFF
--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -409,6 +410,65 @@ def install_grok_hooks(managed: Path, home: Path, dry_run: bool) -> str:
     return f"wired {len(entries)} guard(s) -> {path}" + ("" if changed else " (unchanged)")
 
 
+# One-line purpose per hook script. The operator granting hook-trust on Codex/Grok
+# sees an opaque numbered list ("Hook 1..N") because the hook-object schema has no
+# name/description field (BI-276EC984; upstream asks openai/codex#31469 and
+# xai-org/plugin-marketplace#71). Until those land, the installer prints this roster
+# so the trust decision is informed. Keyed by script basename; a CI test asserts
+# every command hook in hooks.json has an entry here (kept in sync mechanically).
+HOOK_PURPOSES = {
+    "lease-guard.mjs": "blocks launching a long-running server without a nonprod lease",
+    "root-clone-guard.mjs": "blocks destructive rm / git clean aimed at the root clone",
+    "compose-guard.mjs": "blocks docker compose commands that tear down shared services",
+    "lease-punt-guard.mjs": "blocks a runtime-bound gate (prisma migrate / db push) in a source-only worktree",
+    "decision-routing-guard.mjs": "blocks asking the operator a platform decision with no kernel consultation",
+    "ux-fit-precheck.mjs": "reminds to run a UX-fit review when editing UI surfaces",
+    "spec-plan-doc-precheck.mjs": "reminds to attach a spec/plan/doc when writing gated files",
+    "tool-economy-precheck.mjs": "reminds about tool-economy budget when adding tool surface",
+    "worktree-create.mjs": "seeds a new worktree with MCP config on WorktreeCreate",
+    "governance-freshness-check.mjs": "SessionStart: warns if governance guard wiring is stale",
+}
+
+
+def hook_script_basename(command: str) -> str | None:
+    """Extract the `*.mjs` script name from a hook `command` string."""
+    match = re.search(r"([A-Za-z0-9_.-]+\.mjs)", command or "")
+    return match.group(1) if match else None
+
+
+def hook_roster(skill_pack: Path) -> list[str]:
+    """Human-readable roster of the plugin's hooks (name + purpose), grouped by event.
+
+    Printed so an operator granting hook-trust on Codex/Grok knows what each numbered
+    "Hook N" actually is (BI-276EC984). Order matches hooks.json, which is the order
+    the trust UIs number them.
+    """
+    hooks_json = skill_pack / "hooks" / "hooks.json"
+    try:
+        data = json.loads(hooks_json.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    events = data.get("hooks", {})
+    if not isinstance(events, dict):
+        return []
+    lines = ["Plugin hooks — what each numbered 'Hook N' in the Codex/Grok trust UI is:"]
+    for event, groups in events.items():
+        entry_lines = []
+        n = 0
+        for group in groups if isinstance(groups, list) else []:
+            matcher = group.get("matcher") if isinstance(group, dict) else None
+            for hook in group.get("hooks", []) if isinstance(group, dict) else []:
+                n += 1
+                base = hook_script_basename(hook.get("command", "")) or "?"
+                purpose = HOOK_PURPOSES.get(base, "(undescribed — add to HOOK_PURPOSES)")
+                mtag = f" [{matcher}]" if matcher else ""
+                entry_lines.append(f"    Hook {n}{mtag}: {base} — {purpose}")
+        if entry_lines:
+            lines.append(f"  {event}:")
+            lines.extend(entry_lines)
+    return lines
+
+
 def guard_liveness_advisory() -> list[str]:
     """Per-surface caveats about whether the plane-1 guards actually FIRE.
 
@@ -491,6 +551,8 @@ def main(argv: list[str]) -> int:
     token_present = bool(os.environ.get(TOKEN_ENV_VAR))
     print(f"  MCP token  : {'present' if token_present else 'missing'} ({TOKEN_ENV_VAR})")
     for line in guard_liveness_advisory():
+        print(line)
+    for line in hook_roster(skill_pack):
         print(line)
     print("Done. Start a new Codex/Claude/Grok session to load updated skills.")
     return 0

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -86,6 +86,39 @@ class InstallGrokHooksTest(unittest.TestCase):
             self.assertFalse(updater.grok_hooks_file(home).exists())
 
 
+class HookRosterTest(unittest.TestCase):
+    """The trust-UI roster must name+describe every hook (BI-276EC984)."""
+
+    def test_every_hooks_json_command_hook_has_a_purpose(self) -> None:
+        skill_pack = Path(__file__).resolve().parents[1]
+        data = json.loads((skill_pack / "hooks" / "hooks.json").read_text())
+        missing = []
+        for groups in data.get("hooks", {}).values():
+            for group in groups if isinstance(groups, list) else []:
+                for hook in group.get("hooks", []) if isinstance(group, dict) else []:
+                    base = updater.hook_script_basename(hook.get("command", ""))
+                    if base and base not in updater.HOOK_PURPOSES:
+                        missing.append(base)
+        self.assertEqual(missing, [], f"hooks missing a HOOK_PURPOSES entry: {missing}")
+
+    def test_roster_enumerates_named_hooks(self) -> None:
+        skill_pack = Path(__file__).resolve().parents[1]
+        lines = updater.hook_roster(skill_pack)
+        self.assertTrue(lines and lines[0].startswith("Plugin hooks"))
+        blob = "\n".join(lines)
+        self.assertIn("lease-punt-guard.mjs", blob)
+        self.assertIn("decision-routing-guard.mjs", blob)
+        # numbered like the trust UI, and carries a purpose (em dash separator)
+        self.assertRegex(blob, r"Hook 1[^\n]*: [A-Za-z0-9_.-]+\.mjs — ")
+
+    def test_basename_extractor(self) -> None:
+        self.assertEqual(
+            updater.hook_script_basename('node "${CLAUDE_PLUGIN_ROOT}/hooks/lease-punt-guard.mjs"'),
+            "lease-punt-guard.mjs",
+        )
+        self.assertIsNone(updater.hook_script_basename("echo hi"))
+
+
 class UpdateAgentToolchainTest(unittest.TestCase):
     @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
     def test_converges_codex_and_claude_marketplaces_in_temp_home(self) -> None:


### PR DESCRIPTION
## What & why

Operator-reported: granting **hook-trust** on Codex meant approving eight opaque `Hook 1..8` rows with no idea what they were. Enabling a hook is a code-execution grant, so approving anonymous entries is a trust/security-UX gap, not cosmetic.

**Root cause (verified, BI-276EC984):** the hook-object schema has no `name`/`description` field — confirmed against Codex's own `figma`/`replayio` example plugins (`{type, command}` only), and Grok *ignores* an added `name` (labels positionally). So there's no `hooks.json` change that surfaces names; the display fix is upstream.

## Two tracks

**Upstream (the real fix):**
- Codex → openai/codex#31469
- Grok → xai-org/plugin-marketplace#71

**DPF-side mitigation (this PR):** the installer prints a roster derived from `hooks.json` — name + one-line purpose per hook, in the same order the trust UI numbers them — so an operator hitting the numbered trust prompt has a reference:

```
Plugin hooks — what each numbered 'Hook N' in the Codex/Grok trust UI is:
  PreToolUse:
    Hook 1 [Bash]: lease-guard.mjs — blocks launching a long-running server without a nonprod lease
    Hook 4 [Bash]: lease-punt-guard.mjs — blocks a runtime-bound gate (prisma migrate / db push) in a source-only worktree
    Hook 5 [AskUserQuestion]: decision-routing-guard.mjs — blocks asking the operator a platform decision with no kernel consultation
    …
```

A CI test asserts **every** `hooks.json` command hook has a `HOOK_PURPOSES` entry, so a newly added guard can't ship undescribed.

## Verification
17 installer tests pass (3 new: sync-guard, roster render, basename extractor). No behavior change to the guards themselves.

Relates: BI-276EC984 (EP-5560770F); follows the Grok-liveness fix (#2692).

🤖 Generated with [Claude Code](https://claude.com/claude-code)