### PR TITLE
feat(coworker-lifecycle): CoworkerDefinition contract + CI conformance gate (EP-COWORKER-LIFECYCLE Phase 1 slice 1, BI-53ABC4A4)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/coworker-definition-baseline.json
+++ b/apps/web/lib/coworker-lifecycle/coworker-definition-baseline.json
@@ -1,0 +1,13 @@
+{
+  "comment": "Pre-existing coworker definition gaps (EP-COWORKER-LIFECYCLE). May only shrink. Regenerate: UPDATE_COWORKER_DEFINITION_BASELINE=1 pnpm exec vitest run lib/coworker-lifecycle",
+  "findings": [
+    "LIFE-003:compliance-officer",
+    "LIFE-003:data-architect",
+    "LIFE-003:data-steward",
+    "LIFE-003:dispatcher",
+    "LIFE-003:doc-specialist",
+    "LIFE-003:external-catalog-scout",
+    "LIFE-003:finance-controller",
+    "LIFE-003:legal-operations-counsel"
+  ]
+}

--- a/apps/web/lib/coworker-lifecycle/coworker-definition-conformance.test.ts
+++ b/apps/web/lib/coworker-lifecycle/coworker-definition-conformance.test.ts
@@ -1,0 +1,186 @@
+// EP-COWORKER-LIFECYCLE Phase 1 conformance gate (BI-53ABC4A4).
+//
+// This test IS the CI gate: it assembles the real scattered coworker
+// definition sources and fails on any conformance finding that is not in the
+// committed baseline. The baseline captures pre-existing gaps only — it may
+// shrink, never grow. Adding a new coworker incompletely (no grants, no route,
+// no model floor, dead grant keys, skills that never reach it) fails the
+// required Unit Tests job with a message naming the missing piece.
+//
+// To fix a failure: complete the definition (see
+// docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md for
+// the checklist). Only if the gap is intentionally deferred may you add the
+// finding to coworker-definition-baseline.json — with a comment in your PR
+// explaining why.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  COWORKER_AGENT_SEEDS,
+  HARDCODED_COWORKER_GRANTS,
+  ONBOARDING_AGENT_GRANTS,
+} from "@dpf/db/workforce-seed";
+import { AGENT_MODEL_CONFIG_DEFAULTS } from "@dpf/db/agent-model-defaults";
+import { SKILL_WILDCARD_AGENT_IDS } from "@dpf/db/seed-skills";
+
+import { knownGrantKeys } from "@/lib/tak/agent-grants";
+import { ROUTE_AGENT_MAP_ENTRIES } from "@/lib/tak/agent-routing";
+import { ROUTE_CONTEXT_MAP } from "@/lib/tak/route-context-map";
+import { COWORKER_SELF_TASKS } from "@/lib/operate/scheduled-jobs/coworker-self-tasks";
+
+import {
+  assembleCoworkerDefinitions,
+  checkDefinitionConformance,
+  findingKey,
+  type CoworkerDefinitionSources,
+} from "./coworker-definition";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..", "..");
+
+type RegistryAgent = { agent_id: string; agent_name: string };
+
+function loadRegistryMirrors(): { agentId: string; agentName: string }[] {
+  const raw = readFileSync(
+    join(REPO_ROOT, "packages", "db", "data", "agent_registry.json"),
+    "utf8",
+  );
+  const parsed = JSON.parse(raw) as { agents?: RegistryAgent[] } | RegistryAgent[];
+  const agents = Array.isArray(parsed) ? parsed : (parsed.agents ?? []);
+  return agents.map((a) => ({ agentId: a.agent_id, agentName: a.agent_name }));
+}
+
+function realSources(): CoworkerDefinitionSources {
+  return {
+    roster: COWORKER_AGENT_SEEDS.map((seed) => ({
+      agentId: seed.agentId,
+      slugId: seed.slugId,
+      name: seed.name,
+      sensitivity: seed.sensitivity,
+    })),
+    bootstrapAgentIds: Object.keys(ONBOARDING_AGENT_GRANTS),
+    grantsByAgent: { ...HARDCODED_COWORKER_GRANTS, ...ONBOARDING_AGENT_GRANTS },
+    knownGrantKeys: knownGrantKeys(),
+    routePersonas: ROUTE_AGENT_MAP_ENTRIES.map(([routePrefix, entry]) => ({
+      routePrefix,
+      agentId: entry.agentId,
+      sensitivity: entry.sensitivity,
+    })),
+    routeContexts: Object.entries(ROUTE_CONTEXT_MAP).map(([routePrefix, def]) => ({
+      routePrefix,
+      sensitivity: def.sensitivity,
+    })),
+    modelFloors: AGENT_MODEL_CONFIG_DEFAULTS.map((row) => ({
+      agentId: row.agentId,
+      minimumTier: row.minimumTier,
+    })),
+    skillWildcardAgentIds: SKILL_WILDCARD_AGENT_IDS,
+    registryMirrors: loadRegistryMirrors(),
+    selfTasks: Object.keys(COWORKER_SELF_TASKS).map((agentId) => ({ agentId })),
+  };
+}
+
+describe("coworker definition conformance gate (EP-COWORKER-LIFECYCLE)", () => {
+  it("produces no findings beyond the committed baseline, and the baseline is not stale", () => {
+    if (process.env.UPDATE_COWORKER_DEFINITION_BASELINE === "1") {
+      // Sanctioned regeneration path (mirrors the Module Size Guard --update
+      // pattern). The baseline diff is reviewed in the PR; growing it for a
+      // NEW coworker instead of completing the definition is a review reject.
+      const regenerated = {
+        comment:
+          "Pre-existing coworker definition gaps (EP-COWORKER-LIFECYCLE). May only shrink. Regenerate: UPDATE_COWORKER_DEFINITION_BASELINE=1 pnpm exec vitest run lib/coworker-lifecycle",
+        findings: checkDefinitionConformance(realSources()).map(findingKey),
+      };
+      writeFileSync(
+        join(HERE, "coworker-definition-baseline.json"),
+        `${JSON.stringify(regenerated, null, 2)}\n`,
+      );
+      return;
+    }
+    const baseline = JSON.parse(
+      readFileSync(join(HERE, "coworker-definition-baseline.json"), "utf8"),
+    ) as { findings: string[] };
+    const baselineKeys = new Set(baseline.findings);
+
+    const findings = checkDefinitionConformance(realSources());
+    const currentKeys = new Set(findings.map(findingKey));
+
+    const newFindings = findings.filter((f) => !baselineKeys.has(findingKey(f)));
+    const staleBaseline = [...baselineKeys].filter((k) => !currentKeys.has(k));
+
+    expect(
+      newFindings,
+      `New coworker definition conformance findings (complete the definition — see the checklist in docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md — do not just extend the baseline):\n${newFindings
+        .map((f) => `  [${f.checkId}] ${f.message}`)
+        .join("\n")}`,
+    ).toHaveLength(0);
+
+    expect(
+      staleBaseline,
+      `Baseline entries no longer reproduce — the gaps were fixed. Remove them from coworker-definition-baseline.json so the ratchet only tightens:\n${staleBaseline
+        .map((k) => `  ${k}`)
+        .join("\n")}`,
+    ).toHaveLength(0);
+  });
+
+  it("wildcard skill assignment reaches every roster coworker (docs-specialist typo fixed)", () => {
+    expect(SKILL_WILDCARD_AGENT_IDS).not.toContain("docs-specialist");
+    for (const seed of COWORKER_AGENT_SEEDS) {
+      expect(SKILL_WILDCARD_AGENT_IDS).toContain(seed.agentId);
+    }
+    expect(SKILL_WILDCARD_AGENT_IDS).toContain("onboarding-coo");
+  });
+
+  it("assembles one definition per roster coworker with routes, floor, and grants joined", () => {
+    const defs = assembleCoworkerDefinitions(realSources());
+    expect(defs).toHaveLength(COWORKER_AGENT_SEEDS.length);
+    const marketing = defs.find((d) => d.agentId === "marketing-specialist");
+    expect(marketing?.grants).toContain("marketing_write");
+    expect(marketing?.boundRoutes.length).toBeGreaterThan(0);
+    expect(marketing?.modelFloor?.minimumTier).toBeTruthy();
+    expect(marketing?.hasSelfTask).toBe(true);
+  });
+
+  it("flags an incomplete new coworker on every missing axis", () => {
+    const sources = realSources();
+    const incomplete: CoworkerDefinitionSources = {
+      ...sources,
+      roster: [
+        ...sources.roster,
+        {
+          agentId: "brand-new-specialist",
+          slugId: "brand-new-specialist",
+          name: "Brand New Specialist",
+          sensitivity: "internal",
+        },
+      ],
+    };
+    const findings = checkDefinitionConformance(incomplete);
+    const forNew = findings.filter((f) => f.subject.startsWith("brand-new-specialist"));
+    const checks = forNew.map((f) => f.checkId).sort();
+    expect(checks).toEqual(["LIFE-001", "LIFE-003", "LIFE-005", "LIFE-008"]);
+  });
+
+  it("flags dead grant keys on a new coworker", () => {
+    const sources = realSources();
+    const withDeadGrant: CoworkerDefinitionSources = {
+      ...sources,
+      grantsByAgent: {
+        ...sources.grantsByAgent,
+        "marketing-specialist": [
+          ...(sources.grantsByAgent["marketing-specialist"] ?? []),
+          "grant_no_tool_honors",
+        ],
+      },
+    };
+    const findings = checkDefinitionConformance(withDeadGrant);
+    expect(
+      findings.some(
+        (f) => f.checkId === "LIFE-002" && f.subject === "marketing-specialist/grant_no_tool_honors",
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/coworker-lifecycle/coworker-definition.ts
+++ b/apps/web/lib/coworker-lifecycle/coworker-definition.ts
@@ -1,0 +1,258 @@
+// Coworker definition contract + conformance checks (EP-COWORKER-LIFECYCLE
+// Phase 1, BI-53ABC4A4).
+//
+// A coworker's definition is scattered across independently hand-edited
+// sources: the roster (COWORKER_AGENT_SEEDS), the grants map
+// (HARDCODED_COWORKER_GRANTS), the route persona map (ROUTE_AGENT_MAP), the
+// unified route-context map, the model-floor defaults
+// (AGENT_MODEL_CONFIG_DEFAULTS), the skill wildcard list, the registry mirror
+// (agent_registry.json), and the curated self-task registry. Historically
+// nothing cross-checked them, so a new coworker could ship with a persona but
+// no model floor, grants no tool honors, or a skills list that never reached
+// it — defects discovered live, one at a time (see the BI-PIR-* false-refusal
+// cluster and docs/superpowers/specs/2026-04-28-eliminate-seed-as-data-load-design.md).
+//
+// This module assembles the scattered sources into one CoworkerDefinition
+// view per coworker and checks conformance. The colocated vitest gate runs in
+// the required Unit Tests CI job and fails on any NEW finding; known
+// pre-existing gaps live in coworker-definition-baseline.json and may only
+// shrink. Complementary to (not duplicating) the advisory static audits
+// audit-coworker-personas.ts / audit-coworker-tool-grants.ts (registry↔persona
+// and grant-catalog axes) and the seed.test.ts profession-binding invariant.
+//
+// The module is pure: all sources are injected so it stays importable from
+// tests and future surfaces (roster UI, factory door) without dragging in
+// prisma or filesystem access.
+
+export type CoworkerRosterEntry = {
+  agentId: string;
+  slugId: string;
+  name: string;
+  sensitivity: string;
+};
+
+export type RoutePersonaEntry = {
+  routePrefix: string;
+  agentId: string;
+  sensitivity: string;
+};
+
+export type RouteContextEntry = {
+  routePrefix: string;
+  sensitivity: string;
+};
+
+export type ModelFloorEntry = {
+  agentId: string;
+  minimumTier: string;
+};
+
+export type RegistryMirrorEntry = {
+  agentId: string;
+  agentName: string;
+};
+
+export type SelfTaskEntry = {
+  agentId: string;
+};
+
+export type CoworkerDefinitionSources = {
+  roster: readonly CoworkerRosterEntry[];
+  /** Bootstrap-created agents that are legitimate grant/skill targets but not roster rows. */
+  bootstrapAgentIds: readonly string[];
+  grantsByAgent: Readonly<Record<string, readonly string[]>>;
+  /** The closed grant vocabulary actually honored by at least one tool. */
+  knownGrantKeys: readonly string[];
+  routePersonas: readonly RoutePersonaEntry[];
+  routeContexts: readonly RouteContextEntry[];
+  modelFloors: readonly ModelFloorEntry[];
+  skillWildcardAgentIds: readonly string[];
+  registryMirrors: readonly RegistryMirrorEntry[];
+  selfTasks: readonly SelfTaskEntry[];
+};
+
+/** The assembled single view of one coworker's definition. */
+export type CoworkerDefinition = {
+  agentId: string;
+  displayName: string;
+  sensitivity: string;
+  grants: readonly string[];
+  boundRoutes: readonly string[];
+  modelFloor: ModelFloorEntry | null;
+  inSkillWildcard: boolean;
+  registryMirror: RegistryMirrorEntry | null;
+  hasSelfTask: boolean;
+};
+
+export type ConformanceFinding = {
+  /** Stable check id — LIFE-NNN. */
+  checkId: string;
+  /** The coworker (or source row) the finding is about. */
+  subject: string;
+  message: string;
+};
+
+/** Stable serialization used for baseline comparison. */
+export function findingKey(finding: ConformanceFinding): string {
+  return `${finding.checkId}:${finding.subject}`;
+}
+
+export function assembleCoworkerDefinitions(
+  sources: CoworkerDefinitionSources,
+): CoworkerDefinition[] {
+  const mirrorByName = new Map<string, RegistryMirrorEntry>();
+  for (const mirror of sources.registryMirrors) {
+    mirrorByName.set(mirror.agentName, mirror);
+  }
+  const selfTaskAgents = new Set(sources.selfTasks.map((t) => t.agentId));
+
+  return sources.roster.map((seed) => {
+    const boundRoutes = sources.routePersonas
+      .filter((p) => p.agentId === seed.agentId)
+      .map((p) => p.routePrefix);
+    return {
+      agentId: seed.agentId,
+      displayName: seed.name,
+      sensitivity: seed.sensitivity,
+      grants: sources.grantsByAgent[seed.agentId] ?? [],
+      boundRoutes,
+      modelFloor: sources.modelFloors.find((m) => m.agentId === seed.agentId) ?? null,
+      inSkillWildcard: sources.skillWildcardAgentIds.includes(seed.agentId),
+      registryMirror: mirrorByName.get(seed.agentId) ?? null,
+      hasSelfTask: selfTaskAgents.has(seed.agentId),
+    };
+  });
+}
+
+/**
+ * Cross-source conformance. Every check answers one question a new coworker's
+ * author would otherwise discover live:
+ *
+ * - LIFE-001 grants-present   — roster coworker has a grants entry.
+ * - LIFE-002 grant-honored    — every granted key is honored by ≥1 tool
+ *                               (dead grants authorize nothing; the coworker
+ *                               refuses "available" tools at call time).
+ * - LIFE-003 route-persona    — roster coworker is reachable via ≥1 route.
+ * - LIFE-004 persona-real     — every route persona points at a real agent
+ *                               (roster, bootstrap, or registry) so a route
+ *                               never binds to a ghost.
+ * - LIFE-005 model-floor      — roster coworker has a model-floor default
+ *                               (missing floor = weak local model = the #2685
+ *                               fabrication class).
+ * - LIFE-006 model-floor-real — every model-floor row references a real agent.
+ * - LIFE-007 sensitivity-agree— ROUTE_AGENT_MAP and ROUTE_CONTEXT_MAP agree on
+ *                               sensitivity for shared routes (the unified-path
+ *                               transition contract; divergence flips data
+ *                               boundaries with USE_UNIFIED_COWORKER).
+ * - LIFE-008 skill-wildcard   — wildcard skill assignment reaches every roster
+ *                               coworker and targets only real agents.
+ * - LIFE-009 self-task-real   — every curated self-task references a roster
+ *                               coworker.
+ */
+export function checkDefinitionConformance(
+  sources: CoworkerDefinitionSources,
+): ConformanceFinding[] {
+  const findings: ConformanceFinding[] = [];
+  const definitions = assembleCoworkerDefinitions(sources);
+  const rosterIds = new Set(sources.roster.map((seed) => seed.agentId));
+  const knownAgentIds = new Set<string>([
+    ...rosterIds,
+    ...sources.bootstrapAgentIds,
+    ...sources.registryMirrors.flatMap((m) => [m.agentId, m.agentName]),
+  ]);
+  const knownGrants = new Set(sources.knownGrantKeys);
+
+  for (const def of definitions) {
+    if (def.grants.length === 0) {
+      findings.push({
+        checkId: "LIFE-001",
+        subject: def.agentId,
+        message: `${def.agentId} has no entry in HARDCODED_COWORKER_GRANTS — it boots with no tool surface`,
+      });
+    }
+    for (const grant of def.grants) {
+      if (!knownGrants.has(grant)) {
+        findings.push({
+          checkId: "LIFE-002",
+          subject: `${def.agentId}/${grant}`,
+          message: `${def.agentId} is granted "${grant}" but no tool honors that key — dead grant, tools will refuse at call time`,
+        });
+      }
+    }
+    if (def.boundRoutes.length === 0) {
+      findings.push({
+        checkId: "LIFE-003",
+        subject: def.agentId,
+        message: `${def.agentId} is not bound to any route in ROUTE_AGENT_MAP — users can never reach it in a workspace`,
+      });
+    }
+    if (!def.modelFloor) {
+      findings.push({
+        checkId: "LIFE-005",
+        subject: def.agentId,
+        message: `${def.agentId} has no AGENT_MODEL_CONFIG_DEFAULTS row — no minimum model tier, so a weak local model can serve it`,
+      });
+    }
+    if (!def.inSkillWildcard) {
+      findings.push({
+        checkId: "LIFE-008",
+        subject: def.agentId,
+        message: `${def.agentId} is missing from SKILL_WILDCARD_AGENT_IDS — wildcard skills never reach it`,
+      });
+    }
+  }
+
+  for (const persona of sources.routePersonas) {
+    if (!knownAgentIds.has(persona.agentId)) {
+      findings.push({
+        checkId: "LIFE-004",
+        subject: `${persona.routePrefix}/${persona.agentId}`,
+        message: `Route ${persona.routePrefix} binds persona agentId "${persona.agentId}" which exists in no roster, bootstrap list, or registry`,
+      });
+    }
+  }
+
+  for (const floor of sources.modelFloors) {
+    if (!knownAgentIds.has(floor.agentId)) {
+      findings.push({
+        checkId: "LIFE-006",
+        subject: floor.agentId,
+        message: `AGENT_MODEL_CONFIG_DEFAULTS row "${floor.agentId}" references an agent that exists in no roster, bootstrap list, or registry`,
+      });
+    }
+  }
+
+  const contextByRoute = new Map(sources.routeContexts.map((c) => [c.routePrefix, c]));
+  for (const persona of sources.routePersonas) {
+    const context = contextByRoute.get(persona.routePrefix);
+    if (context && context.sensitivity !== persona.sensitivity) {
+      findings.push({
+        checkId: "LIFE-007",
+        subject: persona.routePrefix,
+        message: `Route ${persona.routePrefix} sensitivity disagrees: ROUTE_AGENT_MAP=${persona.sensitivity} vs ROUTE_CONTEXT_MAP=${context.sensitivity} — the USE_UNIFIED_COWORKER flag would flip the data boundary`,
+      });
+    }
+  }
+
+  for (const wildcardId of sources.skillWildcardAgentIds) {
+    if (!knownAgentIds.has(wildcardId)) {
+      findings.push({
+        checkId: "LIFE-008",
+        subject: wildcardId,
+        message: `SKILL_WILDCARD_AGENT_IDS contains "${wildcardId}" which exists in no roster, bootstrap list, or registry — wildcard skills assigned to a ghost`,
+      });
+    }
+  }
+
+  for (const task of sources.selfTasks) {
+    if (!rosterIds.has(task.agentId)) {
+      findings.push({
+        checkId: "LIFE-009",
+        subject: task.agentId,
+        message: `COWORKER_SELF_TASKS entry "${task.agentId}" references a non-roster coworker`,
+      });
+    }
+  }
+
+  return findings.sort((a, b) => findingKey(a).localeCompare(findingKey(b)));
+}

--- a/docs/superpowers/plans/2026-07-07-coworker-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-07-07-coworker-lifecycle-plan.md
@@ -1,0 +1,47 @@
+# AI Coworker Lifecycle — implementation plan
+
+- **Epic:** EP-COWORKER-LIFECYCLE · **Spec:** docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md
+- **Kernel decision:** principle_decide 2026-07-07 → option C (full lifecycle epic), confidence high.
+
+## Phase 1 — Definition contract + conformance gate (BI-53ABC4A4)
+
+**Slice 1 (this PR):**
+1. `@dpf/db` subpath exports for `workforce-seed`, `agent-model-defaults`, `seed-skills`.
+2. Derive `SKILL_WILDCARD_AGENT_IDS` from the roster + bootstrap agents (fixes `docs-specialist`
+   phantom + five missing coworkers); `reconcileSkillAssignments` accepts readonly lists.
+3. `apps/web/lib/coworker-lifecycle/coworker-definition.ts` — pure contract + LIFE-001…009 checks.
+4. Conformance vitest gate + committed baseline (8 LIFE-003 route gaps remain; may only shrink).
+5. Model floors for data-steward / dispatcher / legal-operations-counsel.
+6. Spec + this plan; epic/BI wiring via MCP.
+
+**Slice 2 (follow-up):**
+- Fold `coworker-service-catalog-seed` + professions-registry + registry-mirror alignment checks
+  into the gate (LIFE-010…) once their owners confirm intended shape.
+- Decide route placement for the 8 unbound coworkers (UX decision per coworker, dpf-ux-fit-review)
+  and shrink the baseline to zero.
+- Begin the `catalog/agents.ts` single-source consolidation from the 2026-04-28 design, with the
+  contract type as the catalog row type.
+
+## Phase 2 — Certification harness (BI-DE9CC88B)
+1. `goldenJourneys` on the contract (per coworker: prompt, mode, expected tool call(s), oracle).
+2. Runner: iterate roster → real chat/scheduled path → oracles (real-tool-call, no-false-refusal,
+   no-fabrication via detectFabrication patterns + sim-harness O1–O7, advise-no-side-effect).
+3. Persist as `AssuranceRun(scopeType='agent', adapterKey='coworker-cert')` + findings.
+4. Nightly + post-deploy trigger (scheduled-jobs catalog); inference budget via the existing
+   admission/budget gates; local-model floor respected via AgentModelConfig.
+5. Roster surface: certification state chip (certified/stale/failed/never) on WorkforceRosterPanel.
+
+## Phase 3 — Enforced activation (BI-2C4056BF)
+1. lifecycleStage state machine + summonability gate in resolveAgentForRoute/summon_coworker.
+2. Factory door: server action + MCP tool `establish_coworker` instantiating the template;
+   Build Studio + seed converge on it. Grandfather existing agents to `defined`.
+
+## Phase 4 — Template/skill/docs (BI-14E4F9AF)
+1. Starter template + `dpf-establish-coworker` skill (dual-surface, dpf-skill-pack).
+2. AGENTS.md lifecycle contract section; retire the deferred HS-D716F1D52EB3E69F archetype item.
+
+## Verification
+- Phase 1: gate runs in required Unit Tests; new-coworker simulation test proves all axes flag.
+- Phase 2: certification run against the live install produces AssuranceRun rows for all roster
+  coworkers; the 76-never-exercised census drops to zero for roster coworkers.
+- Phase 3: an uncertified coworker cannot be summoned (functional test), roster shows stage.

--- a/docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md
+++ b/docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md
@@ -1,0 +1,115 @@
+# AI Coworker Lifecycle Standard — definition contract, conformance gate, behavioral certification, enforced activation
+
+- **Epic:** EP-COWORKER-LIFECYCLE
+- **Backlog:** BI-53ABC4A4 (Phase 1), BI-DE9CC88B (Phase 2), BI-2C4056BF (Phase 3), BI-14E4F9AF (Phase 4)
+- **Kernel decision:** `principle_decide` 2026-07-07, option `C-full-lifecycle-epic`, confidence high (composite 11.13, margin 3.44 over the static-gate-only runner-up); governing profile: platform. Top-aligned commandments: Research and Use Standards, Never Assume — Verify, Single Source of Truth, Ship Real Functionality.
+- **Status:** Phase 1 slice 1 shipped in this spec's PR; Phases 2–4 designed here, built per plan.
+
+## 1. Problem
+
+Coworker defects surface incrementally, late, and in production, because a coworker has no
+defined lifecycle. Evidence gathered 2026-07-07 against the live install and origin/main:
+
+- **88 registered agents; 76 (86%) have never been exercised** — no message, scheduled task,
+  engagement, or task run, ever. Only 2 (inventory-specialist, external-catalog-scout) have real
+  volume.
+- **Definition is scattered across ≥10 hand-aligned places** (roster, grants map, registry mirror,
+  route persona map, route-context map, model floors, skill wildcard list, service catalog,
+  self-task registry, professions registry). The four-place grant problem is already documented in
+  `docs/superpowers/specs/2026-04-28-eliminate-seed-as-data-load-design.md` ("Class B") and its
+  consolidation was never implemented.
+- **Definition completeness was uneven**: 5/88 agents had any skill assignment (the wildcard list
+  had drifted: a phantom `docs-specialist` plus five roster coworkers missing); 18/88 had model
+  configs; `AgentGovernanceProfile` has 0 rows; `AgentPerformance` has 0 rows.
+- **Mechanism tests are thick, journey coverage is zero-in-CI**: grant vocabulary, advise-mode
+  stripping, fabrication detection, and self-task reconcile are all unit-tested, but no pipeline
+  ever sends a coworker a message and asserts a real tool call. The playwright e2e specs are
+  manual; the coworker-sim-harness is an island consumed only by its own tests.
+- **The recurring failure classes are all definition/verification gaps found late**: grant
+  drift and false refusals (~13 duplicate `BI-PIR-*` items for one tool), fabrication on weak
+  models (#2685), advise-strip surprises (#2576), dropped `modelRequirements` on new dispatch
+  paths, fail-open governance profiles.
+
+Without a lifecycle substrate, every new coworker recreates these classes.
+
+## 2. Architecture (kernel-ratified option C)
+
+Four phases, each independently landable; each later phase consumes the earlier one.
+
+### Phase 1 — CoworkerDefinition contract + conformance gate (BI-53ABC4A4)
+
+One assembled, typed view per coworker (`CoworkerDefinition`) plus a cross-source conformance
+checker that runs as a **required Unit Tests** vitest gate — not an advisory workflow.
+
+- Module: `apps/web/lib/coworker-lifecycle/coworker-definition.ts` (pure; sources injected).
+- Gate: `apps/web/lib/coworker-lifecycle/coworker-definition-conformance.test.ts`.
+- Baseline: `coworker-definition-baseline.json` — pre-existing gaps only; the gate fails on any
+  NEW finding **and** on stale baseline entries, so the ratchet only tightens. Regeneration is
+  sanctioned via `UPDATE_COWORKER_DEFINITION_BASELINE=1` (Module Size Guard `--update` pattern);
+  the diff is reviewed in the PR.
+
+Checks (slice 1): LIFE-001 grants present · LIFE-002 every granted key honored by ≥1 tool ·
+LIFE-003 reachable via ≥1 route · LIFE-004 route personas bind real agents · LIFE-005 model floor
+present · LIFE-006 model-floor rows reference real agents · LIFE-007 ROUTE_AGENT_MAP ↔
+ROUTE_CONTEXT_MAP sensitivity agreement (the USE_UNIFIED_COWORKER transition contract) · LIFE-008
+skill wildcard reaches every roster coworker and only real agents · LIFE-009 self-tasks reference
+roster coworkers.
+
+Complementary, not duplicative: `audit-coworker-personas.ts` / `audit-coworker-tool-grants.ts`
+(advisory, registry↔persona and grant-catalog axes) and the seed.test.ts profession-binding
+invariant stay as-is. Later slices fold the full single-source `catalog/agents.ts` end-state from
+the 2026-04-28 design into this contract.
+
+Slice 1 also fixes drift the gate exposed:
+- `SKILL_WILDCARD_AGENT_IDS` is now **derived** from `COWORKER_AGENT_SEEDS` +
+  `ONBOARDING_AGENT_GRANTS` (Single Source of Truth) — fixing the `docs-specialist` phantom and
+  reaching five previously skill-less coworkers.
+- Model floors added for data-steward, dispatcher, legal-operations-counsel (LIFE-005).
+- Remaining baseline: 8 LIFE-003 route-binding gaps (compliance-officer, data-architect,
+  data-steward, dispatcher, doc-specialist, external-catalog-scout, finance-controller,
+  legal-operations-counsel) — route placement is a UX decision handled in the epic, not silently
+  invented by the gate.
+
+### Phase 2 — Behavioral certification harness (BI-DE9CC88B)
+
+Per-coworker certification runs hosted on the **existing** `AssuranceRun`/`AssuranceFinding`
+substrate (`scopeType='agent'`, `adapterKey='coworker-cert'` — today used only by
+`estate/patch-intel`). For each roster coworker: N golden journey prompts through the REAL chat
+path (advise and act) and the scheduled-task path. Oracles assert: a real tool call occurred
+(the anti-fabrication oracle reuses `detectFabrication` patterns and the sim-harness O1–O7
+oracles), granted tools are not falsely refused (kills the BI-PIR duplicate class at the root),
+structured output lands, mode contract respected (advise runs produce no side effects).
+Trigger: nightly + post-deploy; results surface as certification state (certified / stale /
+failed / never-certified) on the workforce roster. Golden journeys live next to the definition —
+the contract from Phase 1 gains a `goldenJourneys` field.
+
+### Phase 3 — Enforced activation lifecycle (BI-2C4056BF)
+
+`Agent.lifecycleStage` becomes load-bearing: `draft → defined → certified → active`. A coworker
+that is not definition-conformant and certified is not summonable and renders honestly on the
+roster. One **factory door** (server action + MCP tool) instantiates the canonical template from
+any dev surface — Build Studio, MCP clients, seed — closing the two-population drift (19 roster
+vs 67 registry agents). Existing agents grandfather to `defined`.
+
+### Phase 4 — Template, skill, docs (BI-14E4F9AF)
+
+Coworker starter template (supersedes deferred HS-D716F1D52EB3E69F), a `dpf-establish-coworker`
+skill walking the factory door + certification, and the AGENTS.md lifecycle contract section.
+Convention backed by the gates, not by trust.
+
+## 3. The de-facto creation checklist (until Phases 3–4 replace it)
+
+A new coworker today touches, in order: `COWORKER_AGENT_SEEDS` → `HARDCODED_COWORKER_GRANTS`
+(keys must be honored by `TOOL_TO_GRANTS`) → `agent_registry.json` mirror (if EA/exec profile
+needed) → `ROUTE_AGENT_MAP` persona + `route-context-map` sensitivity mirror →
+`AGENT_MODEL_CONFIG_DEFAULTS` → skills (`.skill.md` / dpf-skill-pack; wildcard list is now
+derived) → `coworker-service-catalog-seed` (if offered as a service) → `COWORKER_SELF_TASKS`
+(optional autonomy) → `docs/professions/registry.json`. The Phase 1 gate now fails CI when the
+load-bearing subset is incomplete.
+
+## 4. Non-goals (this spec)
+
+- Scoring model/endpoint capability (the golden-set eval substrate does that; it certifies
+  models, not coworkers).
+- Replacing the advisory persona/grant audits.
+- Route-placement UX for the 8 unbound coworkers (epic work items, decided per-coworker).

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -42,6 +42,9 @@
     "./capability-maturity": "./src/capability-maturity.ts",
     "./business-capability-perspectives": "./src/business-capability-perspectives.ts",
     "./workforce-portfolio": "./src/workforce-portfolio.ts",
+    "./workforce-seed": "./src/workforce-seed.ts",
+    "./agent-model-defaults": "./src/agent-model-defaults.ts",
+    "./seed-skills": "./src/seed-skills.ts",
     "./patch": "./src/patch/index.ts"
   },
   "scripts": {

--- a/packages/db/src/agent-model-defaults.ts
+++ b/packages/db/src/agent-model-defaults.ts
@@ -29,6 +29,12 @@ export const AGENT_MODEL_CONFIG_DEFAULTS: AgentModelConfigDefault[] = [
   { agentId: "data-architect", minimumTier: "adequate", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
   { agentId: "compliance-officer", minimumTier: "strong", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
   { agentId: "finance-controller", minimumTier: "strong", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 16000 },
+  // Floors added by the EP-COWORKER-LIFECYCLE conformance gate (LIFE-005):
+  // these three roster coworkers had no minimum tier at all, so a weak local
+  // model could serve confidential merge/dispatch/legal work.
+  { agentId: "data-steward", minimumTier: "adequate", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 16000 },
+  { agentId: "dispatcher", minimumTier: "adequate", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 16000 },
+  { agentId: "legal-operations-counsel", minimumTier: "strong", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 16000 },
   { agentId: "finance-agent", minimumTier: "strong", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 16000 },
   { agentId: "licensing-specialist", minimumTier: "strong", budgetClass: "balanced", minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
 ];

--- a/packages/db/src/seed-skills.ts
+++ b/packages/db/src/seed-skills.ts
@@ -6,6 +6,7 @@
 import { readdirSync, readFileSync } from "fs";
 import { join, basename } from "path";
 import type { PrismaClient } from "../generated/client/client";
+import { COWORKER_AGENT_SEEDS, ONBOARDING_AGENT_GRANTS } from "./workforce-seed.js";
 
 const REPO_ROOT = join(__dirname, "..", "..", "..");
 const SKILLS_DIR = join(REPO_ROOT, "skills");
@@ -80,26 +81,18 @@ export type NormalizedSkillSeed = {
   assignTo: string[];
 };
 
-// All known agent IDs — used when assignTo includes "*"
-const ALL_AGENT_IDS = [
-  "portfolio-advisor",
-  "external-catalog-scout",
-  "inventory-specialist",
-  "ea-architect",
-  "hr-specialist",
-  "customer-advisor",
-  "ops-coordinator",
-  "platform-engineer",
-  "build-specialist",
-  "admin-assistant",
-  "marketing-specialist",
-  "storefront-advisor",
-  "onboarding-coo",
-  "coo",
-  "compliance-officer",
-  "docs-specialist",
-  "data-architect",
+// All known agent IDs — used when assignTo includes "*". Derived from the
+// canonical coworker roster (plus the bootstrap-created onboarding agent)
+// instead of a hand-copied list: the previous literal list had drifted to a
+// nonexistent "docs-specialist" (roster id is "doc-specialist") and silently
+// omitted five roster coworkers (data-steward, doc-specialist,
+// legal-operations-counsel, finance-controller, dispatcher), so wildcard
+// skills never reached them (EP-COWORKER-LIFECYCLE Phase 1, BI-53ABC4A4).
+export const SKILL_WILDCARD_AGENT_IDS: readonly string[] = [
+  ...COWORKER_AGENT_SEEDS.map((seed) => seed.agentId),
+  ...Object.keys(ONBOARDING_AGENT_GRANTS),
 ];
+const ALL_AGENT_IDS = SKILL_WILDCARD_AGENT_IDS;
 
 /**
  * Simple YAML frontmatter parser for .skill.md files.
@@ -501,7 +494,7 @@ type SkillAssignmentSeedClient = Pick<PrismaClient, "skillAssignment">;
 export async function reconcileSkillAssignments(
   prisma: SkillAssignmentSeedClient,
   skillId: string,
-  targetAgents: string[],
+  targetAgents: readonly string[],
   priority = 10,
 ): Promise<{ created: number; removed: number }> {
   const existingAssignments = await prisma.skillAssignment.findMany({


### PR DESCRIPTION
## Summary

Phase 1 slice 1 of **EP-COWORKER-LIFECYCLE** (BI-53ABC4A4) — makes AI-coworker definition→verification a durable substrate instead of a scattered convention.

**Why now (evidence, 2026-07-07):** 88 registered coworkers, **76 never exercised** (no message/task/engagement ever); definition spread across 10+ hand-aligned sources with real drift found: a phantom `docs-specialist` in the skill wildcard list while five real coworkers (`data-steward`, `doc-specialist`, `legal-operations-counsel`, `finance-controller`, `dispatcher`) received no wildcard skills; three coworkers doing confidential work had **no minimum model tier** (the #2685 weak-local-model fabrication class); recurring late-discovered failure families (~13 duplicate BI-PIR false-refusal items for one tool). Kernel-ratified via `principle_decide` (option C full-lifecycle, confidence high, margin 3.44).

## What this PR does

- **`CoworkerDefinition` contract** (`apps/web/lib/coworker-lifecycle/coworker-definition.ts`): pure module assembling roster, grants, route personas, route contexts, model floors, skill wildcard, registry mirrors, self-tasks into one typed view per coworker, with cross-source conformance checks **LIFE-001…009** (grants present, every grant honored by a tool, route reachability, no ghost personas, model floor present/real, unified-path sensitivity agreement, wildcard reach, self-task validity).
- **CI conformance gate** in the required Unit Tests job (`coworker-definition-conformance.test.ts`) with a **shrink-only baseline**: fails on any NEW finding and on stale baseline entries; sanctioned regeneration via `UPDATE_COWORKER_DEFINITION_BASELINE=1` (Module Size Guard `--update` pattern). An incomplete new coworker now fails CI naming the missing axis. Remaining baseline: 8 LIFE-003 route-binding gaps (route placement = UX decision, handled per-coworker in the epic).
- **Drift fixes the gate exposed:** `SKILL_WILDCARD_AGENT_IDS` is now derived from `COWORKER_AGENT_SEEDS` + `ONBOARDING_AGENT_GRANTS` (Single Source of Truth — kills the phantom + reaches the five missing coworkers); model floors added for `data-steward`, `dispatcher`, `legal-operations-counsel`.
- **`@dpf/db` subpath exports** for `workforce-seed`, `agent-model-defaults`, `seed-skills`.
- **Spec + plan** (same-PR doc gate): `docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md`, `docs/superpowers/plans/2026-07-07-coworker-lifecycle-plan.md` — covering Phases 2–4 (behavioral certification on the existing `AssuranceRun` substrate, enforced draft→defined→certified→active activation + factory door, template/skill/docs).

Complementary to (not duplicating) the advisory `audit-coworker-personas` / `audit-coworker-tool-grants` workflows and the seed.test.ts profession-binding invariant.

## Test plan

- `pnpm exec vitest run lib/coworker-lifecycle` (apps/web) — 5 tests incl. a simulated incomplete new coworker flagged on every axis.
- `pnpm exec vitest run src/seed.test.ts src/agent-model-defaults.test.ts src/seed-skills.test.ts src/agent-identity.test.ts src/workforce-seed.test.ts src/coworker-service-catalog-seed.test.ts` (packages/db) — green.
- `tsc --noEmit` green for apps/web and packages/db.

Backlog: BI-53ABC4A4 (claimed, capsule WC-0EBEF3F7) · Epic EP-COWORKER-LIFECYCLE (spec/plan linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
