### PR TITLE
feat(coworker): Proactivity self-tasks for Estate + Docs specialists + toggle-desync self-heal (BI-E962B9CD)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
     scheduledAgentTask: {
       findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
       upsert: vi.fn().mockResolvedValue({}),
       updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     },
@@ -11,6 +12,15 @@ vi.mock("@dpf/db", () => ({
       upsert: vi.fn().mockResolvedValue({}),
       update: vi.fn().mockResolvedValue({}),
     },
+    userFact: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue({}),
+      create: vi.fn().mockResolvedValue({}),
+    },
+    marketingCampaignBrief: { findFirst: vi.fn().mockResolvedValue(null) },
+    knowledgeArticle: { findFirst: vi.fn().mockResolvedValue(null) },
+    document: { findFirst: vi.fn().mockResolvedValue(null) },
   },
 }));
 
@@ -18,11 +28,23 @@ vi.mock("@dpf/db", () => ({
 // allocator helpers it imports are pure (no DB), so they run for real.
 import {
   reconcileCoworkerSelfTask,
+  reconcileAllCoworkerSelfTasks,
   coworkerSelfTaskId,
+  coworkerSelfTaskRequiredTool,
+  inferLevelFromSelfTaskSchedule,
   COWORKER_SELF_TASKS,
+  DOCS_HEALTH_DOCUMENT_ID,
 } from "./coworker-self-tasks";
 
 const MKT = "marketing-specialist";
+const INV = "inventory-specialist";
+const DOC = "doc-specialist";
+const PROACTIVITY_KEY = (agentId: string) => `aiCoworkerProactivity:agent:${agentId}`;
+const factRow = (userId: string, agentId: string, level: string) => ({
+  userId,
+  key: PROACTIVITY_KEY(agentId),
+  value: JSON.stringify({ level }),
+});
 
 describe("coworkerSelfTaskId", () => {
   it("is deterministic per (agent, user) so reconcile stays idempotent", () => {
@@ -99,5 +121,185 @@ describe("reconcileCoworkerSelfTask", () => {
     expect(COWORKER_SELF_TASKS[MKT]).toBeDefined();
     expect(COWORKER_SELF_TASKS[MKT]!.routeContext).toBe("/customer/marketing");
     expect(COWORKER_SELF_TASKS[MKT]!.prompt).toMatch(/create_marketing_campaign_brief/);
+  });
+});
+
+describe("rollout registry (BI-E962B9CD)", () => {
+  it("registers the Estate Specialist knowledge-article self-task on /inventory", () => {
+    const entry = COWORKER_SELF_TASKS[INV];
+    expect(entry).toBeDefined();
+    expect(entry!.routeContext).toBe("/inventory");
+    expect(entry!.prompt).toMatch(/create_knowledge_article/);
+  });
+
+  it("registers the Documentation Specialist doc-overview self-task on /workspace/documents", () => {
+    const entry = COWORKER_SELF_TASKS[DOC];
+    expect(entry).toBeDefined();
+    expect(entry!.routeContext).toBe("/workspace/documents");
+    expect(entry!.prompt).toMatch(/doc_save/);
+    // The stable upsert id must appear in the prompt so the coworker refreshes the
+    // one overview instead of creating a new document each run.
+    expect(entry!.prompt).toContain(DOCS_HEALTH_DOCUMENT_ID);
+  });
+
+  it("keeps the new coworkers sub-daily even at Assertive (conservative cadence)", () => {
+    for (const agentId of [INV, DOC]) {
+      const dowField = COWORKER_SELF_TASKS[agentId]!.cadence.assertive.split(" ")[4];
+      // A daily task has a wildcard day-of-week; these must NOT (sub-daily).
+      expect(dowField).not.toBe("*");
+    }
+  });
+});
+
+describe("coworkerSelfTaskRequiredTool (anti-fabrication floor)", () => {
+  it("forces a knowledge article for the Estate Specialist, recency-guarded on KnowledgeArticle", async () => {
+    const { prisma } = await import("@dpf/db");
+    const tool = coworkerSelfTaskRequiredTool(INV);
+    expect(tool?.name).toBe("create_knowledge_article");
+    expect(tool!.args).toHaveProperty("title");
+    expect(tool!.args).toHaveProperty("body");
+
+    (prisma.knowledgeArticle.findFirst as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ articleId: "KA-001" });
+    expect(await tool!.hasRecentArtifact!()).toBe(true);
+    (prisma.knowledgeArticle.findFirst as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    expect(await tool!.hasRecentArtifact!()).toBe(false);
+  });
+
+  it("forces an idempotent doc_save (stable id) for the Documentation Specialist", async () => {
+    const { prisma } = await import("@dpf/db");
+    const tool = coworkerSelfTaskRequiredTool(DOC);
+    expect(tool?.name).toBe("doc_save");
+    // Stable documentId → upsert, so the fallback never duplicates the overview.
+    expect(tool!.args["documentId"]).toBe(DOCS_HEALTH_DOCUMENT_ID);
+    expect(tool!.args).toHaveProperty("contentText");
+
+    const findFirst = prisma.document.findFirst as ReturnType<typeof vi.fn>;
+    findFirst.mockResolvedValueOnce({ id: "d1" });
+    expect(await tool!.hasRecentArtifact!()).toBe(true);
+    // Guard must scope to the stable overview id.
+    expect(findFirst.mock.calls[0]![0].where.documentId).toBe(DOCS_HEALTH_DOCUMENT_ID);
+  });
+
+  it("returns null for a coworker with no self-task", () => {
+    expect(coworkerSelfTaskRequiredTool("some-advisor")).toBeNull();
+  });
+});
+
+describe("inferLevelFromSelfTaskSchedule", () => {
+  it("reads a daily cron (day-of-week wildcard) as assertive", () => {
+    expect(inferLevelFromSelfTaskSchedule("7 14 * * *")).toBe("assertive");
+  });
+  it("reads a pinned day-of-week (weekly / twice-weekly) as balanced", () => {
+    expect(inferLevelFromSelfTaskSchedule("7 14 * * 1")).toBe("balanced");
+    expect(inferLevelFromSelfTaskSchedule("31 15 * * 2,5")).toBe("balanced");
+  });
+});
+
+describe("reconcileAllCoworkerSelfTasks (toggle ⇆ task convergence)", () => {
+  beforeEach(async () => {
+    const { prisma } = await import("@dpf/db");
+    for (const fn of [
+      prisma.userFact.findMany,
+      prisma.userFact.findFirst,
+      prisma.userFact.update,
+      prisma.userFact.create,
+      prisma.scheduledAgentTask.findMany,
+      prisma.scheduledAgentTask.findUnique,
+      prisma.scheduledAgentTask.upsert,
+      prisma.scheduledAgentTask.updateMany,
+    ]) {
+      (fn as ReturnType<typeof vi.fn>).mockClear();
+    }
+    (prisma.userFact.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (prisma.scheduledAgentTask.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (prisma.userFact.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  });
+
+  it("Direction A: creates a missing task for an active Assertive fact (idle coworker)", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.userFact.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      factRow("u1", INV, "assertive"),
+    ]);
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const r = await reconcileAllCoworkerSelfTasks();
+
+    expect(r.created).toBe(1);
+    const upsert = prisma.scheduledAgentTask.upsert as ReturnType<typeof vi.fn>;
+    expect(upsert.mock.calls[0]![0].where).toEqual({ taskId: coworkerSelfTaskId(INV, "u1") });
+  });
+
+  it("Direction A: leaves an already-active task untouched (no schedule churn)", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.userFact.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      factRow("u1", INV, "assertive"),
+    ]);
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({ isActive: true });
+
+    const r = await reconcileAllCoworkerSelfTasks();
+
+    expect(r.created).toBe(0);
+    expect(prisma.scheduledAgentTask.upsert as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("Direction A: deactivates a live task whose toggle is now quiet", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.userFact.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      factRow("u1", INV, "quiet"),
+    ]);
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({ isActive: true });
+
+    const r = await reconcileAllCoworkerSelfTasks();
+
+    expect(r.deactivated).toBe(1);
+    expect(prisma.scheduledAgentTask.updateMany as ReturnType<typeof vi.fn>).toHaveBeenCalledWith({
+      where: { taskId: coworkerSelfTaskId(INV, "u1") },
+      data: { isActive: false },
+    });
+  });
+
+  it("ignores facts for coworkers with no registered self-task", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.userFact.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      factRow("u1", "coo", "assertive"),
+    ]);
+    const r = await reconcileAllCoworkerSelfTasks();
+    expect(r.created).toBe(0);
+    expect(prisma.scheduledAgentTask.upsert as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("Direction B: restores a missing toggle from an orphaned daily self-task", async () => {
+    const { prisma } = await import("@dpf/db");
+    // No facts, but a live daily marketing self-task exists (fact went missing).
+    (prisma.userFact.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (prisma.scheduledAgentTask.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { taskId: coworkerSelfTaskId(MKT, "u1"), agentId: MKT, ownerUserId: "u1", schedule: "7 14 * * *" },
+    ]);
+
+    const r = await reconcileAllCoworkerSelfTasks();
+
+    expect(r.backfilledFacts).toBe(1);
+    // A daily orphan → Assertive toggle restored via a UserFact write.
+    const created = prisma.userFact.create as ReturnType<typeof vi.fn>;
+    expect(created).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(created.mock.calls[0]![0].data.value).level).toBe("assertive");
+    expect(created.mock.calls[0]![0].data.key).toBe(PROACTIVITY_KEY(MKT));
+  });
+
+  it("Direction B: does NOT backfill a task that already has an active fact", async () => {
+    const { prisma } = await import("@dpf/db");
+    (prisma.userFact.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      factRow("u1", MKT, "assertive"),
+    ]);
+    (prisma.scheduledAgentTask.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({ isActive: true });
+    (prisma.scheduledAgentTask.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { taskId: coworkerSelfTaskId(MKT, "u1"), agentId: MKT, ownerUserId: "u1", schedule: "7 14 * * *" },
+    ]);
+
+    const r = await reconcileAllCoworkerSelfTasks();
+
+    expect(r.backfilledFacts).toBe(0);
+    expect(prisma.userFact.create as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
@@ -16,6 +16,12 @@
 
 import { prisma } from "@dpf/db";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import { isProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import {
+  PROACTIVITY_FACT_CATEGORY,
+  PROACTIVITY_OVERRIDE_FACT_PREFIX,
+  persistProactivityFact,
+} from "@/lib/proactivity/proactivity-override-preferences";
 import { SCHEDULING_MAP } from "@/lib/operate/scheduled-jobs/scheduling-map";
 import { occupiedTicks, deconflictCron } from "@/lib/operate/scheduled-jobs/scheduling-allocator";
 import { computeNextCronRun } from "@/lib/operate/cron-next-run";
@@ -37,6 +43,14 @@ export type CoworkerSelfTask = {
     assertive: string;
   };
 };
+
+/**
+ * Stable documentId the Documentation Specialist self-task upserts. A fixed id
+ * makes the refresh idempotent: doc_save updates this one overview (appending a
+ * version) instead of creating a fresh Document every run. Declared before the
+ * registry so the prompt template can reference it at module load.
+ */
+export const DOCS_HEALTH_DOCUMENT_ID = "DOC-COWORKER-DOCS-HEALTH";
 
 /**
  * Registry of coworkers that self-drive when their Proactivity is turned up.
@@ -67,6 +81,73 @@ export const COWORKER_SELF_TASKS: Record<string, CoworkerSelfTask> = {
       // allocator is unlikely to collide, and deconflictCron shifts it if it does.
       balanced: "7 14 * * 1",
       assertive: "7 14 * * *",
+    },
+  },
+
+  // Digital Product Estate Specialist keeps a current estate-posture knowledge
+  // article on /inventory. This is a DISTINCT artifact from its existing
+  // discovery-taxonomy-gap-triage-daily autonomy (that files backlog gaps; this
+  // publishes a human-readable posture summary). A knowledge article is an
+  // internal reference doc — benign if the model produces a generic one — which
+  // is why this coworker qualifies where CRM/HR/EA coworkers (whose write tools
+  // create business-fact rows) do not. registry_write is already granted.
+  "inventory-specialist": {
+    title: "Refresh the estate-posture knowledge article",
+    prompt: [
+      "You are running as a scheduled, autonomous task — no human is watching this",
+      "turn, so finish the work rather than asking questions.",
+      "",
+      "Goal: keep a current estate-posture knowledge article on the Discovery /",
+      "Inventory surface so the estate's health is legible without a human asking.",
+      "Steps:",
+      "1. Review the real discovered estate available to you (posture, freshness,",
+      "   attribution confidence, support/version risks) using your read tools.",
+      "2. Search existing knowledge articles first (search_knowledge_base). If there",
+      "   is NO recent estate-posture article, create ONE with create_knowledge_article:",
+      "   a concise reference article (category 'reference') titled for the estate",
+      "   posture, summarizing the top risks and what needs review, grounded ONLY in",
+      "   real discovered evidence.",
+      "3. If a recent posture article already exists, do NOT duplicate it — refresh",
+      "   the assessment only if the estate has materially changed, otherwise stop.",
+      "Do not invent products, vendors, or numbers; cite only real discovered data.",
+    ].join("\n"),
+    routeContext: "/inventory",
+    cadence: {
+      // Weekly (Tue) and twice-weekly (Tue+Fri) at 15:31 UTC. Knowledge does not
+      // need a daily refresh, so even Assertive stays sub-daily — conservative by
+      // design (BI-E962B9CD: prefer Balanced-weekly, daily only where useful).
+      balanced: "31 15 * * 2",
+      assertive: "31 15 * * 2,5",
+    },
+  },
+
+  // Documentation Specialist keeps a single living "documentation health" overview
+  // document fresh on the Workspace documents surface. doc_save UPSERTS by a stable
+  // documentId, so refreshing this overview never accumulates duplicates — it just
+  // appends a new version. document_write is already granted.
+  "doc-specialist": {
+    title: "Refresh the documentation-health overview",
+    prompt: [
+      "You are running as a scheduled, autonomous task — no human is watching this",
+      "turn, so finish the work rather than asking questions.",
+      "",
+      "Goal: keep ONE living documentation-health overview document current so the",
+      "Workspace documents surface reflects real doc coverage and gaps. Steps:",
+      "1. Review the real documentation available to you (doc_search, and the project",
+      "   docs you can read) to assess coverage, staleness, and structural gaps.",
+      `2. Refresh the SAME overview document by calling doc_save with documentId`,
+      `   "${DOCS_HEALTH_DOCUMENT_ID}" (a stable id — this UPDATES the one overview,`,
+      "   it does NOT create a new document each run): documentKind 'overview',",
+      "   contentFormat 'markdown', a contentText summary of what is well-documented,",
+      "   what is stale, and the top 3 documentation gaps to close next.",
+      "Ground every claim in real docs; do not invent documents or coverage numbers.",
+    ].join("\n"),
+    routeContext: "/workspace/documents",
+    cadence: {
+      // Weekly (Wed) and twice-weekly (Wed+Sat) at 16:43 UTC. Documentation health
+      // changes slowly, so Assertive stays sub-daily.
+      balanced: "43 16 * * 3",
+      assertive: "43 16 * * 3,6",
     },
   },
 };
@@ -114,6 +195,12 @@ export type CoworkerSelfTaskProceduralTool = {
 // well inside it and suppress the fallback entirely.
 const RECENT_CAMPAIGN_BRIEF_WINDOW_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 
+// Recency windows for the sub-daily self-tasks. Each is wider than that
+// coworker's Assertive cadence gap (twice-weekly) so a single placeholder is
+// never re-created between two consecutive runs.
+const RECENT_KNOWLEDGE_ARTICLE_WINDOW_MS = 5 * 24 * 60 * 60 * 1000; // 5 days
+const RECENT_DOCS_OVERVIEW_WINDOW_MS = 5 * 24 * 60 * 60 * 1000; // 5 days
+
 /**
  * Required-tool guarantee for a coworker self-task, keyed by agentId. Null when
  * the coworker's self-task has no procedural guarantee (the loop's own output is
@@ -141,6 +228,58 @@ export function coworkerSelfTaskRequiredTool(
         const recent = await prisma.marketingCampaignBrief.findFirst({
           where: { createdAt: { gte: since } },
           select: { briefId: true },
+        });
+        return recent !== null;
+      },
+    };
+  }
+
+  if (agentId === "inventory-specialist") {
+    return {
+      name: "create_knowledge_article",
+      // Honest, provisional placeholder — only reached when the estate surface has
+      // no recent posture article AND the coworker's loop failed to produce one.
+      // required: title, body. category defaults to 'reference'.
+      args: {
+        title: "Estate posture summary (needs refresh)",
+        body:
+          "Provisional estate-posture article created automatically because the Discovery/Inventory surface had no recent posture summary. The Digital Product Estate Specialist should replace this with a grounded assessment of real discovered posture, freshness, and top risks on its next run.",
+        category: "reference",
+      },
+      hasRecentArtifact: async () => {
+        const since = new Date(Date.now() - RECENT_KNOWLEDGE_ARTICLE_WINDOW_MS);
+        const recent = await prisma.knowledgeArticle.findFirst({
+          where: { createdAt: { gte: since } },
+          select: { articleId: true },
+        });
+        return recent !== null;
+      },
+    };
+  }
+
+  if (agentId === "doc-specialist") {
+    return {
+      name: "doc_save",
+      // Upsert by the stable overview id — the fallback refreshes the SAME document
+      // (appending a version) rather than creating a duplicate. required by the
+      // store: title, documentKind, contentFormat, contentText.
+      args: {
+        documentId: DOCS_HEALTH_DOCUMENT_ID,
+        title: "Documentation health overview (needs refresh)",
+        documentKind: "overview",
+        contentFormat: "markdown",
+        contentText:
+          "# Documentation health overview\n\nProvisional overview created automatically because no recent documentation-health summary existed. The Documentation Specialist should replace this with a grounded assessment of coverage, staleness, and the top documentation gaps to close next.",
+        summary: "Auto-generated placeholder documentation-health overview.",
+      },
+      hasRecentArtifact: async () => {
+        // doc_save upserts by DOCS_HEALTH_DOCUMENT_ID, so duplication is already
+        // impossible; this simply stands the fallback down when the coworker (or a
+        // recent run) already refreshed the overview this window.
+        const since = new Date(Date.now() - RECENT_DOCS_OVERVIEW_WINDOW_MS);
+        const recent = await prisma.document.findFirst({
+          where: { documentId: DOCS_HEALTH_DOCUMENT_ID, updatedAt: { gte: since } },
+          select: { id: true },
         });
         return recent !== null;
       },
@@ -232,4 +371,152 @@ export async function reconcileCoworkerSelfTask(
   });
 
   return { ok: true, action: "scheduled", taskId, schedule };
+}
+
+// ─── Toggle ⇆ self-task convergence (desync self-heal, BI-E962B9CD) ──────────
+//
+// reconcileCoworkerSelfTask only fires on SAVE (saveCoworkerProactivityPreference).
+// That leaves two ways the Proactivity toggle and the scheduled self-task drift
+// apart, both observed live:
+//   A. A coworker was set to Balanced/Assertive BEFORE it had a registry entry
+//      (or before the fact was ever bridged) — the fact exists but no task does,
+//      and the coworker sits idle despite the UI showing it working.
+//   B. A self-task keeps running after its backing Proactivity fact disappeared
+//      (the Marketing Strategist's fact went missing while its daily task still
+//      ran) — the toggle silently lies about what the coworker is doing.
+// The periodic sweep below converges both directions from the UserFact, which is
+// the operator's expressed intent. It is additive and non-destructive: it creates
+// missing tasks, deactivates tasks a now-quiet toggle should stop, and — for an
+// orphaned task with no fact — RESTORES the toggle from the task's cadence rather
+// than silently stopping the coworker.
+
+const PROACTIVITY_AGENT_KEY_PREFIX = `${PROACTIVITY_OVERRIDE_FACT_PREFIX}:agent:`;
+
+/** Parse the persisted proactivity fact value → its level, or null if unreadable. */
+function readSelfTaskFactLevel(value: string | null | undefined): ProactivityLevel | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as { level?: unknown };
+    return isProactivityLevel(parsed.level) ? parsed.level : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort level a self-task's cadence implies, for healing an orphaned task
+ * (Direction B). A daily cron (day-of-week wildcard) is Assertive; anything
+ * narrower is Balanced. Sub-daily Assertive cadences (e.g. twice-weekly) infer
+ * Balanced — acceptable for a rare heal case; the operator can re-toggle.
+ */
+export function inferLevelFromSelfTaskSchedule(schedule: string): ProactivityLevel {
+  const fields = schedule.trim().split(/\s+/);
+  return fields[4] === "*" ? "assertive" : "balanced";
+}
+
+/** Write (or refresh) the manual Proactivity fact for a coworker to `level`. */
+async function backfillProactivityFact(
+  userId: string,
+  agentId: string,
+  level: ProactivityLevel,
+): Promise<void> {
+  const now = new Date();
+  const value = JSON.stringify({
+    scope: "agent",
+    scopeKey: `agent:${agentId}`,
+    level,
+    source: "reconcile-backfill",
+    acknowledgedByUserId: userId,
+    acknowledgedAt: now.toISOString(),
+  });
+  await persistProactivityFact(userId, {
+    category: PROACTIVITY_FACT_CATEGORY,
+    key: `${PROACTIVITY_AGENT_KEY_PREFIX}${agentId}`,
+    value,
+    sourceRoute: "/platform/ai",
+    sourceAgentId: agentId,
+    lastValidatedAt: now,
+  });
+}
+
+export type ReconcileAllSelfTasksResult = {
+  /** Missing self-tasks created for an active non-quiet fact (Direction A). */
+  created: number;
+  /** Live self-tasks stood down because the toggle is now quiet (Direction A). */
+  deactivated: number;
+  /** Orphaned live self-tasks whose toggle was restored from cadence (Direction B). */
+  backfilledFacts: number;
+};
+
+/**
+ * Converge every coworker self-task with its owner's current Proactivity toggle.
+ * Safe to run on a cadence: it only creates missing tasks, deactivates tasks a
+ * quiet toggle should stop, and restores a missing toggle from an orphaned task —
+ * it never perturbs the schedule of a task that is already correctly active.
+ */
+export async function reconcileAllCoworkerSelfTasks(): Promise<ReconcileAllSelfTasksResult> {
+  const result: ReconcileAllSelfTasksResult = { created: 0, deactivated: 0, backfilledFacts: 0 };
+
+  // Direction A — every active Proactivity fact for a REGISTERED coworker should
+  // have a matching self-task (create when missing; stand down when quiet).
+  const facts = await prisma.userFact.findMany({
+    where: {
+      category: PROACTIVITY_FACT_CATEGORY,
+      key: { startsWith: PROACTIVITY_AGENT_KEY_PREFIX },
+      supersededAt: null,
+    },
+    select: { userId: true, key: true, value: true },
+  });
+
+  // (taskId) that legitimately SHOULD be active — used to spot orphans below.
+  const desiredActive = new Set<string>();
+
+  for (const fact of facts) {
+    const agentId = fact.key.slice(PROACTIVITY_AGENT_KEY_PREFIX.length);
+    if (!COWORKER_SELF_TASKS[agentId]) continue;
+    const level = readSelfTaskFactLevel(fact.value);
+    if (!level) continue;
+
+    const taskId = coworkerSelfTaskId(agentId, fact.userId);
+    const existing = await prisma.scheduledAgentTask.findUnique({
+      where: { taskId },
+      select: { isActive: true },
+    });
+
+    if (level === "quiet") {
+      if (existing?.isActive) {
+        await reconcileCoworkerSelfTask(fact.userId, agentId, "quiet");
+        result.deactivated++;
+      }
+      continue;
+    }
+
+    desiredActive.add(taskId);
+    if (!existing?.isActive) {
+      // Missing or deactivated → (re)schedule it. Leave already-active tasks
+      // untouched so the sweep never churns their schedule / nextRunAt.
+      await reconcileCoworkerSelfTask(fact.userId, agentId, level);
+      result.created++;
+    }
+  }
+
+  // Direction B — an active self-task with no backing active fact is an orphan
+  // (the toggle desynced from the task). Restore the toggle from the task's
+  // cadence so the UI tells the truth, rather than stopping the coworker.
+  const liveSelfTasks = await prisma.scheduledAgentTask.findMany({
+    where: { isActive: true, taskId: { startsWith: "self-" } },
+    select: { taskId: true, agentId: true, ownerUserId: true, schedule: true },
+  });
+  for (const task of liveSelfTasks) {
+    if (desiredActive.has(task.taskId)) continue;
+    const level = inferLevelFromSelfTaskSchedule(task.schedule);
+    await backfillProactivityFact(task.ownerUserId, task.agentId, level);
+    result.backfilledFacts++;
+    console.info(
+      "[coworker-self-tasks] restored missing Proactivity toggle from orphaned self-task",
+      { taskId: task.taskId, agentId: task.agentId, level },
+    );
+  }
+
+  return result;
 }

--- a/apps/web/lib/queue/functions/agent-task-dispatch.ts
+++ b/apps/web/lib/queue/functions/agent-task-dispatch.ts
@@ -18,6 +18,21 @@ export const agentTaskDispatch = inngest.createFunction(
     const gate = await gateAtEntry(step);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
+    // Once an hour (on the top-of-hour :00 tick of this */5 poll), converge every
+    // coworker self-task with its owner's Proactivity toggle so the two can't
+    // silently desync — create tasks for coworkers turned up before they were
+    // registered, stand down quiet ones, and restore a toggle from an orphaned
+    // task (BI-E962B9CD). Cheap, non-destructive DB reconcile; isolated in its
+    // own step so a hiccup never blocks dispatch.
+    await step.run("reconcile-coworker-self-tasks-hourly", async () => {
+      const now = new Date();
+      if (now.getUTCMinutes() >= 5) return { skipped: true };
+      const { reconcileAllCoworkerSelfTasks } = await import(
+        "@/lib/operate/scheduled-jobs/coworker-self-tasks"
+      );
+      return reconcileAllCoworkerSelfTasks();
+    });
+
     const dueTaskIds = await step.run("find-due-tasks", async () => {
       const { prisma } = await import("@dpf/db");
       const now = new Date();

--- a/docs/superpowers/plans/2026-07-07-coworker-self-task-rollout-plan.md
+++ b/docs/superpowers/plans/2026-07-07-coworker-self-task-rollout-plan.md
@@ -1,0 +1,79 @@
+# Coworker Proactivity → autonomous self-task rollout (BI-E962B9CD)
+
+**Epic:** EP-B9DD37C7 — Coworker chat: runtime truthfulness, transparency & controls
+**BI:** BI-E962B9CD (large / build) — extend the Marketing Strategist autonomous self-task pattern to all *applicable* interactive coworkers, with a per-coworker anti-fabrication floor.
+**Author:** Claude (in-platform coworker) · 2026-07-07
+**Kernel decision:** `principle_decide` → **moderate** rollout (composite 7.43 vs conservative 7.29 vs aggressive 4.05; governing profile "organization"; ringScope ring-2-workflow + ring-5-hive). The thin moderate↔conservative margin is resolved by the BI's own guardrails ("where applicable", "fabrication is the failure mode").
+
+---
+
+## 1. What already exists (verified substrate)
+
+- **Registry:** `apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts`
+  - `COWORKER_SELF_TASKS` (agentId → `{title, prompt, routeContext, cadence:{balanced,assertive}}`) — only `marketing-specialist` before this change.
+  - `coworkerSelfTaskRequiredTool(agentId)` — the anti-fabrication FLOOR: a forced-fallback artifact tool + `hasRecentArtifact()` recency guard, so a real DB row is guaranteed even if the model produces nothing, and duplicates are suppressed.
+  - `reconcileCoworkerSelfTask(userId, agentId, level)` — fires from `saveCoworkerProactivityPreference` (`proactivity.ts`): quiet → deactivate, balanced → weekly cron, assertive → daily cron, de-conflicted against `SCHEDULING_MAP`.
+- **Dispatch:** Inngest `agent/task-dispatch` (`*/5`) → `executeScheduledAgentTask` → `executeAutonomousAgenticLoop`. #2685 plumbs the route `modelRequirements` (frontier floor) + the required-tool guarantee.
+- **Tool/agent binding (decisive):** the scheduled loop binds the acting coworker and its tool surface to **`task.agentId` (explicit)** via `resolveAutonomousWorkTools({ agentId })` and `resolveAutonomousWorkAgent({ agentId, routeContext })`. `routeContext.domainTools` is only a **prompt hint** (`prompt-assembler.ts`); the hard gate is the coworker's capability **grant**. The force-execute floor runs through `governedExecuteTool`, which enforces grants. → A coworker qualifies only if it is **granted** the artifact capability.
+
+## 2. The applicability bar (why "where applicable", not "for all")
+
+The marketing brief works because it is a **planning/analysis artifact** the coworker regenerates from real org context — benign if generic, useful when grounded. Most other write-tools create **business-fact rows** (Opportunity, Quote, CustomerAccount, Employee, EaElement). Auto-generating *those* on a cadence **is** the fabrication failure mode — inventing deals, employees, or architecture. A coworker earns a self-task only when it has:
+
+1. a role-appropriate **recurring artifact that is safe to regenerate** (an internal analysis/reference/plan, not a business-fact and not a false-alarm-risk finding);
+2. a **granted** create/write MCP tool for it;
+3. a primary **routeContext** surface; and
+4. it is **not already autonomous** by another path.
+
+The only domain-agnostic "save review/analysis" artifact class in the codebase is marketing's (`save_marketing_review`, `create_marketing_campaign_brief`, `record_marketing_kpi_checkpoint`). So the safely-applicable additive set is small — this is a genuine finding, not under-delivery.
+
+## 3. Per-coworker determination (all 12 evaluated)
+
+| coworker | grant | verdict | rationale |
+|---|---|---|---|
+| **inventory-specialist** | registry_write | **INCLUDE** | `create_knowledge_article` → `KnowledgeArticle` (no dedup → recency guard). Internal reference doc grounded in the real discovered estate. `/inventory`. Distinct from its already-autonomous discovery-triage. |
+| **doc-specialist** | document_write | **INCLUDE** | `doc_save` with a **stable documentId** (`DOC-COWORKER-DOCS-HEALTH`) → upsert = one living "docs-health overview", versioned, never duplicated. `/workspace/documents`. |
+| marketing-specialist | marketing_write | (baseline) | Already shipped (#2674/#2685). |
+| customer-advisor | crm_write | SKIP | `create_opportunity`/`create_quote`/`create_customer_account` are **business-fact rows** — auto-creating = fabricating deals/accounts. No safe CRM analysis artifact exists. |
+| ops-coordinator / coo / platform-engineer | backlog_write | SKIP | Only `create_backlog_item` (deduped). Auto-filing backlog items is work-creation noise, not a "keep-my-surface-fresh" artifact. |
+| compliance-officer | policy_write | SKIP | `create_licensing_readiness_issue` is a **finding**; a fabricated compliance flag is a false alarm (worse than an empty page — implies legal exposure that isn't real). Fails "safe-if-fabricated". |
+| ea-architect | ea_graph_write | SKIP | `create_ea_element` = fabricating architecture; `/ea` has no agent tools. |
+| storefront-advisor | marketing_write | SKIP | Its marketing artifacts surface on `/customer/marketing` (marketing-specialist's page), not `/storefront` — page/artifact mismatch. |
+| hr-specialist | consumer_write | SKIP | `create_employee` = fabricating people. |
+| dispatcher | consumer_write | SKIP | No field-service/dispatch create tool exists; `consumer_write` reaches only HR `create_employee`. |
+| data-steward | crm_write | SKIP | Already autonomous — dedicated Inngest `mdmStewardSweepScheduled` cron. |
+
+Neither included coworker needs a **new grant** (both already granted) — lowest blast radius.
+
+## 4. Toggle ⇆ self-task desync fix (BI guardrail: "must not silently desync")
+
+Live DB confirmed **both** desync directions:
+- **A.** 5 coworkers set to Assertive (ops-coordinator, coo, customer-advisor, inventory-specialist, build-specialist) had **no self-task** — `reconcileCoworkerSelfTask` only fires on *save*, and pre-existing facts never re-trigger it.
+- **B.** `marketing-specialist` had a **running daily self-task but zero proactivity facts** — the task ran decoupled from the (missing) toggle.
+
+**Fix:** `reconcileAllCoworkerSelfTasks()` — a periodic, additive, non-destructive convergence from the UserFact (operator intent):
+- Direction A: active non-quiet fact for a registered coworker with no active task → create it; quiet fact with a live task → deactivate. Already-active tasks are **left untouched** (no schedule/nextRunAt churn).
+- Direction B: active self-task with no backing fact → **restore the toggle** from the task's cadence (`inferLevelFromSelfTaskSchedule`: daily→assertive, else balanced) so the UI tells the truth, rather than silently stopping the coworker mid-demo.
+
+**Host:** an hourly-gated step at the top of `agent/task-dispatch` (`now.getUTCMinutes() < 5`), isolated in its own Inngest step — no new cron, no catalog/parity churn.
+
+## 5. Cadences (conservative, de-conflicted, off-peak)
+
+| coworker | balanced | assertive |
+|---|---|---|
+| marketing-specialist (existing) | `7 14 * * 1` | `7 14 * * *` (daily) |
+| inventory-specialist | `31 15 * * 2` (Tue) | `31 15 * * 2,5` (Tue+Fri) |
+| doc-specialist | `43 16 * * 3` (Wed) | `43 16 * * 3,6` (Wed+Sat) |
+
+The new coworkers stay **sub-daily even at Assertive** — knowledge/docs don't need a daily refresh (BI: "Balanced-weekly default, daily only where useful"). `deconflictCron` shifts on any tick collision.
+
+## 6. Tests (`coworker-self-tasks.test.ts`, 20 cases)
+
+Registry (routeContext + prompt names the exact tool + stable doc id + sub-daily Assertive); required-tool floor (correct tool, honest placeholder args, recency guard scoped to the right table/id); `inferLevelFromSelfTaskSchedule`; and `reconcileAllCoworkerSelfTasks` Direction-A create/leave-alone/deactivate + Direction-B restore-vs-skip. All green locally (97/97 across scheduled-jobs + proactivity suites).
+
+## 7. Deploy & live-verify
+
+1. DCO PR → babysit CI to green → self-upgrade deploy.
+2. Live-verify each included coworker produces a **REAL DB row** on dispatch (not a chat claim): trigger the self-task and confirm a fresh `KnowledgeArticle` / `Document` (`DOC-COWORKER-DOCS-HEALTH`) row, per the marketing-run lesson.
+3. Confirm the desync sweep on the hourly tick: inventory-specialist's pre-existing Assertive fact gains a task (Direction A); marketing's orphaned task gets its toggle restored to Assertive (Direction B).
+4. If dispatch isn't firing, drain the Inngest executor wedge (BI-0AB96FE7).


### PR DESCRIPTION
## What & why

Generalizes the Marketing Strategist autonomous self-task pattern (#2674 / #2685) to the interactive coworkers where it is **genuinely applicable**, carrying the same anti-fabrication floor — and fixes the toggle⇆self-task **desync** the marketing run exposed.

Closes **BI-E962B9CD** (EP-B9DD37C7). Plan: [`docs/superpowers/plans/2026-07-07-coworker-self-task-rollout-plan.md`](docs/superpowers/plans/2026-07-07-coworker-self-task-rollout-plan.md).

## Applicability — kernel-routed, fabrication-first

`principle_decide` → **moderate** (composite 7.43 vs conservative 7.29 vs aggressive 4.05; ringScope ring-2-workflow + ring-5-hive).

The marketing brief is safe to auto-generate because it's a **planning/analysis artifact**. Most other write-tools create **business-fact rows** (Opportunity, Quote, Employee, EaElement) — auto-generating *those* on a cadence **is** the fabrication failure mode. So a coworker qualifies only with a safe, regenerable analysis/reference artifact + the grant + a route + not-already-autonomous. Two clear the bar:

| coworker | tool → artifact | route | cadence |
|---|---|---|---|
| **inventory-specialist** | `create_knowledge_article` → `KnowledgeArticle` (recency-guarded) | `/inventory` | weekly / twice-weekly |
| **doc-specialist** | `doc_save` (stable `DOC-COWORKER-DOCS-HEALTH` id → upsert, never duplicates) | `/workspace/documents` | weekly / twice-weekly |

Both already hold the needed grant → **no new grants** (lowest blast radius). New coworkers stay **sub-daily even at Assertive** (knowledge/docs don't need daily). Every other coworker is documented-skipped in the plan (business-fact fabrication, false-alarm findings, backlog noise, already-autonomous, or no tool).

## Desync self-heal

Live DB showed both directions: 5 coworkers set Assertive with **no task** (reconcile only fires on save), and marketing running a task with **no backing fact**. `reconcileAllCoworkerSelfTasks()` (hourly-gated in `agent/task-dispatch`) converges non-destructively:
- **A** active fact, no task → create; quiet fact, live task → deactivate; already-active tasks left untouched (no schedule churn).
- **B** live task, no fact → restore the toggle from the task cadence instead of silently stopping the coworker.

## Tests
20 new cases (registry, required-tool floor + recency guards, `inferLevelFromSelfTaskSchedule`, reconcile both directions). **97/97 green locally** across the scheduled-jobs + proactivity suites.

## Verification plan
After merge + self-upgrade: trigger each coworker's self-task and confirm a **real** `KnowledgeArticle` / `Document` row (not a chat claim), and that the hourly sweep activates inventory-specialist's pre-existing Assertive fact + restores marketing's orphaned toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)