### PR TITLE
refactor(actions): consolidate 15 local auth guards onto shared/guards + CI ratchet (BI-991D4DC8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,13 @@ jobs:
           node-version: 24
       - name: Run guard
         run: node scripts/check-no-raw-event-source.mjs
+      # BI-991D4DC8 (EP-8DC217EB, BET-2): server actions must use the canonical
+      # requireUser/requireUserId from apps/web/lib/actions/shared/guards.ts
+      # rather than re-implementing the session-auth preamble locally (which
+      # drifted on both the null-check and the error string). This guard fails
+      # any PR that (re)introduces a local requireAuth/requireUser guard.
+      - name: Run local auth-guard ratchet
+        run: node scripts/check-no-local-auth-guard.mjs
 
   package-boundary-guard:
     name: Package Boundary Guard

--- a/apps/web/lib/actions/address.ts
+++ b/apps/web/lib/actions/address.ts
@@ -2,7 +2,7 @@
 
 import { prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
-import { auth } from "@/lib/auth";
+import { requireUserId } from "@/lib/actions/shared/guards";
 import type { WorkforceActionResult } from "./workforce";
 
 // ---------------------------------------------------------------------------
@@ -25,10 +25,6 @@ const VALID_LABELS = ["home", "work", "billing", "shipping", "headquarters", "si
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function requireAuth(): Promise<void> {
-  const session = await auth();
-  if (!session?.user?.id) throw new Error("Not authenticated");
-}
 
 function denied(message: string): WorkforceActionResult {
   return { ok: false, message };
@@ -43,7 +39,7 @@ function isValidLabel(label: string): boolean {
 // ---------------------------------------------------------------------------
 
 export async function createEmployeeAddress(input: AddressInput): Promise<WorkforceActionResult> {
-  await requireAuth();
+  await requireUserId();
   if (!isValidLabel(input.label)) {
     return denied(`Invalid label. Must be one of: ${VALID_LABELS.join(", ")}`);
   }
@@ -96,7 +92,7 @@ export async function updateAddress(
   addressId: string,
   data: Partial<Pick<AddressInput, "label" | "addressLine1" | "addressLine2" | "cityId" | "postalCode">>,
 ): Promise<WorkforceActionResult> {
-  await requireAuth();
+  await requireUserId();
   if (data.label !== undefined && !isValidLabel(data.label)) {
     return denied(`Invalid label. Must be one of: ${VALID_LABELS.join(", ")}`);
   }
@@ -115,7 +111,7 @@ export async function updateAddress(
 // ---------------------------------------------------------------------------
 
 export async function deleteEmployeeAddress(employeeAddressId: string): Promise<WorkforceActionResult> {
-  await requireAuth();
+  await requireUserId();
   const link = await prisma.employeeAddress.findUnique({
     where: { id: employeeAddressId },
     select: { id: true, addressId: true },
@@ -142,7 +138,7 @@ export async function deleteEmployeeAddress(employeeAddressId: string): Promise<
 // ---------------------------------------------------------------------------
 
 export async function setPrimaryAddress(employeeAddressId: string): Promise<WorkforceActionResult> {
-  await requireAuth();
+  await requireUserId();
   const link = await prisma.employeeAddress.findUnique({
     where: { id: employeeAddressId },
     select: { id: true, employeeProfileId: true },

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { randomUUID } from "node:crypto";
-import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { validateMessageInput } from "@/lib/agent-coworker-types";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
@@ -86,14 +85,8 @@ import {
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
 import { filterToolsForCoworkerRuntime, adviseHeldBackTools } from "./coworker-tool-filter";
+import { requireUser } from "./shared/guards";
 export { filterToolsForCoworkerRuntime };
-
-async function requireAuthUser() {
-  const session = await auth();
-  const user = session?.user;
-  if (!user?.id) throw new Error("Unauthorized");
-  return user;
-}
 
 
 async function buildPortalContextPromptSection(input: {
@@ -323,7 +316,7 @@ async function summariseIdeateOutcome(
 export async function getThreadSnapshotById(input: {
   threadId: string;
 }): Promise<{ threadId: string; messages: AgentMessageRow[] } | null> {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   const thread = await prisma.agentThread.findFirst({
     where: { id: input.threadId, userId: user.id },
@@ -363,7 +356,7 @@ export async function getThreadSnapshotById(input: {
 export async function getOrCreateThreadSnapshot(input: {
   routeContext: string;
 }): Promise<{ threadId: string; messages: AgentMessageRow[] } | null> {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   // Verify user exists in DB (JWT may reference a stale user after re-seed)
   const dbUser = await prisma.user.findUnique({
@@ -432,7 +425,7 @@ export async function sendMessage(input: {
   | { userMessage: AgentMessageRow; agentMessage: AgentMessageRow; systemMessage?: AgentMessageRow; formAssistUpdate?: Record<string, unknown> }
   | { error: string }
 > {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   // Verify thread ownership
   const thread = await prisma.agentThread.findUnique({
@@ -2339,7 +2332,7 @@ export async function loadEarlierMessages(input: {
   before: string;
   limit?: number;
 }): Promise<{ messages: AgentMessageRow[]; hasMore: boolean } | { error: string }> {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   const thread = await prisma.agentThread.findUnique({
     where: { id: input.threadId },
@@ -2382,7 +2375,7 @@ export async function recordAgentTransition(input: {
   agentName: string;
   routeContext: string;
 }): Promise<{ message: AgentMessageRow } | { error: string }> {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   const thread = await prisma.agentThread.findUnique({
     where: { id: input.threadId },
@@ -2416,7 +2409,7 @@ export async function recordAgentTransition(input: {
 export async function clearConversation(input: {
   threadId: string;
 }): Promise<{ ok: true } | { error: string }> {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   const thread = await prisma.agentThread.findUnique({
     where: { id: input.threadId },

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -2,7 +2,6 @@
 
 import { lazyFs, lazyPath, lazyFsPromises } from "@/lib/shared/lazy-node";
 import { prisma } from "@dpf/db";
-import { auth } from "@/lib/auth";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import {
   computeNextRunAt,
@@ -51,11 +50,6 @@ function getLinkedActivationOptions(
 
 async function requireManageProviders(): Promise<string> {
   return (await requireCapability("manage_provider_connections")).userId;
-}
-
-async function requireSession(): Promise<void> {
-  const session = await auth();
-  if (!session?.user) throw new Error("Unauthorized");
 }
 
 // ─── Registry sync ────────────────────────────────────────────────────────────

--- a/apps/web/lib/actions/conversation-participants-action.ts
+++ b/apps/web/lib/actions/conversation-participants-action.ts
@@ -14,15 +14,8 @@
  * does not pick or task peers. The portal only SHOWS what the active coworker is
  * tasking and a summary of what each peer is doing.
  */
-import { auth } from "@/lib/auth";
+import { requireUserId } from "@/lib/actions/shared/guards";
 import { projectParticipants, type ConversationParticipant } from "@/lib/tak/conversation-participants";
-
-async function requireUserId(): Promise<string> {
-  const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) throw new Error("Unauthorized");
-  return userId;
-}
 
 /**
  * Project the live participant roster for a conversation (owner + the

--- a/apps/web/lib/actions/expenses.ts
+++ b/apps/web/lib/actions/expenses.ts
@@ -2,9 +2,8 @@
 
 import { nanoid } from "nanoid";
 import { prisma } from "@dpf/db";
-import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { requireCapability } from "@/lib/actions/shared/guards";
+import { requireCapability, requireUser } from "@/lib/actions/shared/guards";
 import { revalidatePath } from "next/cache";
 import { sendEmail, composeExpenseApprovalEmail } from "@/lib/email";
 import { getOrgIdentity } from "@/lib/org-identity";
@@ -12,12 +11,6 @@ import { resolveAppBaseUrl } from "@/lib/app-url";
 import type { CreateExpenseClaimInput } from "@/lib/expense-validation";
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
-
-async function getSessionUser() {
-  const session = await auth();
-  if (!session?.user?.id) throw new Error("Unauthorized");
-  return session.user;
-}
 
 async function requireManageFinance(): Promise<string> {
   return (await requireCapability("manage_finance")).userId;
@@ -35,7 +28,7 @@ async function generateClaimId(): Promise<string> {
 // ─── createExpenseClaim ───────────────────────────────────────────────────────
 
 export async function createExpenseClaim(input: CreateExpenseClaimInput) {
-  const user = await getSessionUser();
+  const user = await requireUser();
 
   // Look up employee profile by session userId
   const employeeProfile = await prisma.employeeProfile.findFirst({
@@ -83,7 +76,7 @@ export async function createExpenseClaim(input: CreateExpenseClaimInput) {
 // ─── getExpenseClaim ──────────────────────────────────────────────────────────
 
 export async function getExpenseClaim(id: string) {
-  await getSessionUser();
+  await requireUser();
 
   return prisma.expenseClaim.findUnique({
     where: { id },
@@ -107,7 +100,7 @@ interface ListExpenseClaimsFilters {
 }
 
 export async function listExpenseClaims(filters?: ListExpenseClaimsFilters) {
-  const user = await getSessionUser();
+  const user = await requireUser();
 
   const isManager = can(
     { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
@@ -145,7 +138,7 @@ export async function listExpenseClaims(filters?: ListExpenseClaimsFilters) {
 // ─── submitExpenseClaim ───────────────────────────────────────────────────────
 
 export async function submitExpenseClaim(id: string): Promise<void> {
-  const user = await getSessionUser();
+  const user = await requireUser();
 
   const claim = await prisma.expenseClaim.findUnique({
     where: { id },

--- a/apps/web/lib/actions/feedback-escalation.ts
+++ b/apps/web/lib/actions/feedback-escalation.ts
@@ -9,8 +9,7 @@
 
 import { createHash } from "node:crypto";
 import { prisma } from "@dpf/db";
-import { auth } from "@/lib/auth";
-import { requireCapability } from "@/lib/actions/shared/guards";
+import { requireCapability, requireUserId } from "@/lib/actions/shared/guards";
 import { getDisplayPseudonym, resolveHiveToken } from "@/lib/integrate/identity-privacy";
 import { loadSource } from "@/lib/integrate/issue-bridge";
 import { buildRedactedFeedbackPayload, selectTransport } from "@/lib/integrate/feedback-transport";
@@ -27,13 +26,6 @@ export type FileUpstreamFeedbackResult =
   | { ok: true; status: "filed"; issueNumber: number | null; url: string }
   | { ok: true; status: "already-filed"; issueNumber: number; url: string | null }
   | { ok: false; status: "blocked" | "skipped" | "failed" | "rate-limited"; reason: string };
-
-async function requireAuthUserId(): Promise<string> {
-  const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) throw new Error("Unauthorized");
-  return userId;
-}
 
 async function requireManagePlatformUserId(): Promise<string> {
   return (await requireCapability("manage_platform")).userId;
@@ -70,7 +62,7 @@ async function enforceEscalationRateLimit(contributor: string): Promise<boolean>
 export async function fileUpstreamFeedback(input: {
   reportId: string;
 }): Promise<FileUpstreamFeedbackResult> {
-  await requireAuthUserId();
+  await requireUserId();
   return escalateReportUpstream(input);
 }
 
@@ -171,7 +163,7 @@ export type UpstreamFeedbackConsent = {
 
 /** Read the current upstream-feedback consent + availability for the UI/coworker. */
 export async function getUpstreamFeedbackConsent(): Promise<UpstreamFeedbackConsent> {
-  await requireAuthUserId();
+  await requireUserId();
   const config = await prisma.platformDevConfig.findUnique({
     where: { id: "singleton" },
     select: {

--- a/apps/web/lib/actions/feedback-support.ts
+++ b/apps/web/lib/actions/feedback-support.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { auth } from "@/lib/auth";
+import { requireUserId } from "@/lib/actions/shared/guards";
 import { isFeedbackEventDetail, type FeedbackEventDetail } from "@/lib/feedback/feedback-event";
 import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
 import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
@@ -51,17 +51,6 @@ function requireValidDetail(detail: unknown): FeedbackEventDetail {
   }
 
   return detail;
-}
-
-async function requireAuthUserId(): Promise<string> {
-  const session = await auth();
-  const userId = session?.user?.id;
-
-  if (!userId) {
-    throw new Error("Unauthorized");
-  }
-
-  return userId;
 }
 
 function normalizeOptionalId(value: string | null | undefined, label: string): string | null {
@@ -243,7 +232,7 @@ async function enforceSupportStartRateLimit(userId: string): Promise<void> {
 }
 
 export async function startFeedbackSupport(input: StartFeedbackSupportInput): Promise<FeedbackSupportResult> {
-  const userId = await requireAuthUserId();
+  const userId = await requireUserId();
   const detail = requireValidDetail(input.detail);
   const threadId = normalizeOptionalId(input.threadId, "threadId");
   const requestedFeatureBuildId = normalizeOptionalId(input.featureBuildId, "featureBuildId");
@@ -301,7 +290,7 @@ export async function startFeedbackSupport(input: StartFeedbackSupportInput): Pr
 export async function reconcileFeedbackSupportFallback(
   input: ReconcileFeedbackSupportFallbackInput,
 ): Promise<FeedbackSupportResult> {
-  const userId = await requireAuthUserId();
+  const userId = await requireUserId();
   const detail = requireValidDetail(input.detail);
   const threadId = normalizeOptionalId(input.threadId, "threadId");
 

--- a/apps/web/lib/actions/knowledge.ts
+++ b/apps/web/lib/actions/knowledge.ts
@@ -1,18 +1,10 @@
 "use server";
 
 import { prisma } from "@dpf/db";
-import { auth } from "@/lib/auth";
-import { requireCapability } from "@/lib/actions/shared/guards";
+import { requireCapability, requireUserId } from "@/lib/actions/shared/guards";
 import { revalidatePath } from "next/cache";
 
 // ─── Auth guards ──────────────────────────────────────────────────────────────
-
-async function requireAuth(): Promise<string> {
-  const session = await auth();
-  const user = session?.user;
-  if (!user) throw new Error("Unauthorized");
-  return user.id;
-}
 
 async function requireManageKnowledge(): Promise<string> {
   return (await requireCapability("manage_backlog")).userId;
@@ -215,7 +207,7 @@ export async function publishKnowledgeArticle(id: string): Promise<void> {
 // ─── Confirm Review ───────────────────────────────────────────────────────────
 
 export async function confirmKnowledgeArticleReview(id: string): Promise<void> {
-  await requireAuth();
+  await requireUserId();
 
   await prisma.knowledgeArticle.update({
     where: { id },

--- a/apps/web/lib/actions/mcp-services.ts
+++ b/apps/web/lib/actions/mcp-services.ts
@@ -1,20 +1,14 @@
 "use server";
 
 import { prisma } from "@dpf/db";
-import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
+import { requireUser } from "@/lib/actions/shared/guards";
 import { checkMcpServerHealth } from "@/lib/mcp-server-health";
 import { discoverMcpServerTools } from "@/lib/mcp-server-tools";
 import { validateConnectionConfig, redactConfig, type McpConnectionConfig } from "@/lib/mcp-server-types";
 
-async function requireAuthenticated() {
-  const session = await auth();
-  if (!session?.user) throw new Error("Unauthorized");
-  return session.user;
-}
-
 async function requireManageProviders(): Promise<string> {
-  const user = await requireAuthenticated();
+  const user = await requireUser();
   if (!can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections")) {
     throw new Error("Unauthorized");
   }
@@ -174,7 +168,7 @@ export async function queryMcpServers(options?: {
   status?: string;
   category?: string;
 }) {
-  await requireAuthenticated();
+  await requireUser();
   return prisma.mcpServer.findMany({
     where: {
       ...(options?.status ? { status: options.status } : { status: { not: "deactivated" } }),
@@ -189,7 +183,7 @@ export async function queryMcpServers(options?: {
 }
 
 export async function getMcpServerDetail(serverId: string) {
-  await requireAuthenticated();
+  await requireUser();
   const server = await prisma.mcpServer.findUnique({
     where: { id: serverId },
     include: {

--- a/apps/web/lib/actions/operating-hours.ts
+++ b/apps/web/lib/actions/operating-hours.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { auth } from "@/lib/auth";
+import { requireUserId } from "@/lib/actions/shared/guards";
 import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
@@ -19,13 +19,6 @@ const CLOSED_DAY: DaySchedule = { enabled: false, open: "09:00", close: "17:00" 
 
 // ─── Auth Guard ──────────────────────────────────────────────────────────────
 
-async function requireAccess(): Promise<string> {
-  const session = await auth();
-  const user = session?.user;
-  if (!user) throw new Error("Unauthorized");
-  // Any authenticated user can view/set operating hours during setup
-  return user.id!;
-}
 
 // ─── Helpers: BusinessProfile JSON <-> WeeklySchedule ────────────────────────
 
@@ -173,7 +166,7 @@ export async function getOperatingHours(opts?: {
   timezone: string;
   isConfirmed: boolean;
 }> {
-  await requireAccess();
+  await requireUserId();
 
   const profile = await prisma.businessProfile.findFirst({
     where: { isActive: true },
@@ -323,7 +316,7 @@ export async function saveOperatingHours(input: {
   timezone?: string;
   hasStorefront?: boolean;
 }): Promise<void> {
-  await requireAccess();
+  await requireUserId();
 
   const { schedule, timezone, hasStorefront } = input;
 

--- a/apps/web/lib/actions/proposals.ts
+++ b/apps/web/lib/actions/proposals.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { can } from "@/lib/permissions";
+import { requireUser } from "@/lib/actions/shared/guards";
 import { PLATFORM_TOOLS, executeTool } from "@/lib/mcp-tools";
 import * as crypto from "crypto";
 import {
@@ -16,17 +16,11 @@ import {
   scopeKeyFor,
 } from "@/lib/proactivity/proactivity-override-preferences";
 
-async function requireAuthUser() {
-  const session = await auth();
-  const user = session?.user;
-  if (!user?.id) throw new Error("Unauthorized");
-  return user;
-}
 
 export async function approveProposal(
   proposalId: string,
 ): Promise<{ success: boolean; resultEntityId?: string; error?: string }> {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   const proposal = await prisma.agentActionProposal.findUnique({
     where: { proposalId },
@@ -123,7 +117,7 @@ export async function rejectProposal(
   proposalId: string,
   reason?: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const user = await requireAuthUser();
+  const user = await requireUser();
 
   const proposal = await prisma.agentActionProposal.findUnique({
     where: { proposalId },

--- a/apps/web/lib/actions/reference-data.ts
+++ b/apps/web/lib/actions/reference-data.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { auth } from "@/lib/auth";
+import { requireUserId } from "@/lib/actions/shared/guards";
 import { prisma } from "@dpf/db";
 import {
   createLocality,
@@ -10,12 +10,6 @@ import {
   searchLocalities,
   searchRegionsForLocation,
 } from "@/lib/location-resolution/service";
-
-async function requireAuth(): Promise<string> {
-  const session = await auth();
-  if (!session?.user?.id) throw new Error("Not authenticated");
-  return session.user.id;
-}
 
 export type CreateRefResult = {
   ok: boolean;
@@ -29,17 +23,17 @@ export type CreateRefResult = {
 // ---------------------------------------------------------------------------
 
 export async function searchCountries(query: string) {
-  await requireAuth();
+  await requireUserId();
   return searchCountriesForLocation(query);
 }
 
 export async function searchRegions(countryId: string, query: string) {
-  await requireAuth();
+  await requireUserId();
   return searchRegionsForLocation(countryId, query);
 }
 
 export async function searchCities(regionId: string, query: string) {
-  await requireAuth();
+  await requireUserId();
   return searchLocalities(regionId, query);
 }
 
@@ -52,7 +46,7 @@ export async function createRegion(
   name: string,
   code?: string,
 ): Promise<CreateRefResult> {
-  await requireAuth();
+  await requireUserId();
   const trimmedName = name.trim();
   if (!trimmedName) {
     return { ok: false, message: "Region name is required." };
@@ -98,7 +92,7 @@ export async function createCity(
   regionId: string,
   name: string,
 ): Promise<CreateRefResult> {
-  const userId = await requireAuth();
+  const userId = await requireUserId();
   const result = await createLocality({ regionId, name, addedByUserId: userId });
   revalidatePath("/employee");
   revalidatePath("/admin/reference-data");
@@ -114,7 +108,7 @@ export async function forceCreateRegion(
   name: string,
   code?: string,
 ): Promise<CreateRefResult> {
-  await requireAuth();
+  await requireUserId();
   const trimmedName = name.trim();
   if (!trimmedName) {
     return { ok: false, message: "Region name is required." };
@@ -141,7 +135,7 @@ export async function forceCreateCity(
   regionId: string,
   name: string,
 ): Promise<CreateRefResult> {
-  const userId = await requireAuth();
+  const userId = await requireUserId();
   const result = await forceCreateLocality({ regionId, name, addedByUserId: userId });
   revalidatePath("/employee");
   revalidatePath("/admin/reference-data");

--- a/apps/web/lib/actions/shared/guards.test.ts
+++ b/apps/web/lib/actions/shared/guards.test.ts
@@ -5,7 +5,7 @@ vi.mock("@/lib/permissions", () => ({ can: vi.fn() }));
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { requireCapability, withCapability } from "./guards";
+import { requireCapability, requireUser, requireUserId, withCapability } from "./guards";
 
 const mockAuth = vi.mocked(auth);
 const mockCan = vi.mocked(can);
@@ -59,6 +59,49 @@ describe("requireCapability", () => {
     mockCan.mockReturnValue(true);
 
     await expect(requireCapability("manage_platform")).rejects.toThrow("Unauthorized");
+  });
+});
+
+describe("requireUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the session user when signed in", async () => {
+    signedIn("user-42", "HR-000", true);
+
+    const user = await requireUser();
+    expect(user.id).toBe("user-42");
+    expect(user.platformRole).toBe("HR-000");
+    expect(user.isSuperuser).toBe(true);
+    // The auth check must not depend on the capability primitive.
+    expect(mockCan).not.toHaveBeenCalled();
+  });
+
+  it("throws Unauthorized when there is no session user", async () => {
+    signedOut();
+    await expect(requireUser()).rejects.toThrow("Unauthorized");
+  });
+
+  it("throws Unauthorized (strict !user?.id) when the session user has no id", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "", platformRole: "HR-000", isSuperuser: false } } as never);
+    await expect(requireUser()).rejects.toThrow("Unauthorized");
+  });
+});
+
+describe("requireUserId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns just the id when signed in", async () => {
+    signedIn("user-7");
+    await expect(requireUserId()).resolves.toBe("user-7");
+  });
+
+  it("throws Unauthorized when signed out", async () => {
+    signedOut();
+    await expect(requireUserId()).rejects.toThrow("Unauthorized");
   });
 });
 

--- a/apps/web/lib/actions/shared/guards.ts
+++ b/apps/web/lib/actions/shared/guards.ts
@@ -12,8 +12,48 @@
 // multi-capability OR logic, organization lookups) keep their bespoke bodies
 // and are intentionally NOT routed through here.
 
+import type { Session } from "next-auth";
 import { auth } from "@/lib/auth";
 import { can, type CapabilityKey } from "@/lib/permissions";
+
+/** The authenticated session user, exactly as `auth()` resolves it. */
+export type SessionUser = Session["user"];
+
+/**
+ * Resolve the current session and assert a signed-in user.
+ *
+ * The single authentication preamble for server actions: ~17 files had grown
+ * their own local `requireAuth` / `requireUser` / `requireAuthUser` copies that
+ * drifted on two axes — the null-check (`!user` vs `!user?.id`) and the error
+ * string (`"Unauthorized"` vs `"Not authenticated"`). This helper fixes ONE
+ * contract: the strict `!user?.id` check and `Error("Unauthorized")`.
+ *
+ * Use `requireUser` when the action needs fields off the user (role, email,
+ * accountId); use `requireUserId` when it only needs the id.
+ *
+ * @returns the authenticated session user.
+ * @throws Error("Unauthorized") when there is no user or the user has no id.
+ */
+export async function requireUser(): Promise<SessionUser> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) {
+    throw new Error("Unauthorized");
+  }
+  return user;
+}
+
+/**
+ * Resolve the current session and assert a signed-in user, returning the id.
+ *
+ * The id-only companion to {@link requireUser} with the same error contract.
+ *
+ * @returns the authenticated user's id.
+ * @throws Error("Unauthorized") when there is no user or the user has no id.
+ */
+export async function requireUserId(): Promise<string> {
+  return (await requireUser()).id;
+}
 
 /**
  * Resolve the current session and assert it holds `capability`.

--- a/apps/web/lib/actions/wiki-edit.test.ts
+++ b/apps/web/lib/actions/wiki-edit.test.ts
@@ -41,7 +41,7 @@ describe("saveWikiOverlayEdit — auth + scope", () => {
       title: "Foo",
       body: "## Definition\n\nFoo is something.",
     });
-    expect(result).toEqual({ ok: false, error: expect.stringMatching(/not authenticated/i) });
+    expect(result).toEqual({ ok: false, error: expect.stringMatching(/unauthorized/i) });
   });
 
   it("rejects when there is no Organization row", async () => {

--- a/apps/web/lib/actions/wiki-edit.ts
+++ b/apps/web/lib/actions/wiki-edit.ts
@@ -28,7 +28,7 @@ import {
 } from "@dpf/db/wiki-store";
 import { extractWikilinks } from "@dpf/db/wiki-frontmatter";
 import { revalidatePath } from "next/cache";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/actions/shared/guards";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -62,14 +62,6 @@ export type SaveWikiOverlayEditResult =
   | { ok: false; error: string };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
-async function requireSessionUser(): Promise<{ id: string }> {
-  const session = await auth();
-  if (!session?.user?.id) {
-    throw new Error("Not authenticated");
-  }
-  return { id: session.user.id };
-}
 
 async function requireOrganization(): Promise<{ id: string }> {
   // DPF runs single-org installs today — see (shell)/layout.tsx for the
@@ -160,7 +152,7 @@ export async function saveWikiOverlayEdit(
   input: SaveWikiOverlayEditInput,
 ): Promise<SaveWikiOverlayEditResult> {
   try {
-    const user = await requireSessionUser();
+    const user = await requireUser();
     const org = await requireOrganization();
 
     // Reject empty body / missing title at the action boundary so the form

--- a/apps/web/lib/actions/wiki-publish.test.ts
+++ b/apps/web/lib/actions/wiki-publish.test.ts
@@ -39,7 +39,7 @@ describe("publishWikiOverlayPages — auth + validation", () => {
   it("rejects when not authenticated", async () => {
     (auth as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
     const r = await publishWikiOverlayPages({ pageIds: ["a"] });
-    expect(r).toEqual({ ok: false, error: expect.stringMatching(/not authenticated/i) });
+    expect(r).toEqual({ ok: false, error: expect.stringMatching(/unauthorized/i) });
   });
 
   it("rejects when no organization exists", async () => {
@@ -271,6 +271,6 @@ describe("listOverlayDrafts", () => {
 
   it("rejects when not authenticated", async () => {
     (auth as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
-    await expect(listOverlayDrafts()).rejects.toThrow(/not authenticated/i);
+    await expect(listOverlayDrafts()).rejects.toThrow(/unauthorized/i);
   });
 });

--- a/apps/web/lib/actions/wiki-publish.ts
+++ b/apps/web/lib/actions/wiki-publish.ts
@@ -22,7 +22,7 @@ import {
   type WikiPageStatus,
 } from "@dpf/db/wiki-store";
 import { revalidatePath } from "next/cache";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/actions/shared/guards";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -59,13 +59,6 @@ export type PublishWikiOverlayPagesResult =
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-async function requireSessionUser(): Promise<{ id: string }> {
-  const session = await auth();
-  if (!session?.user?.id) {
-    throw new Error("Not authenticated");
-  }
-  return { id: session.user.id };
-}
 
 async function requireOrganization(): Promise<{ id: string }> {
   const org = await prisma.organization.findFirst({ select: { id: true } });
@@ -93,7 +86,7 @@ export async function publishWikiOverlayPages(
   input: PublishWikiOverlayPagesInput,
 ): Promise<PublishWikiOverlayPagesResult> {
   try {
-    const user = await requireSessionUser();
+    const user = await requireUser();
     const org = await requireOrganization();
 
     if (!Array.isArray(input.pageIds) || input.pageIds.length === 0) {
@@ -205,7 +198,7 @@ export type DraftWikiPageSummary = {
  * session because it's read-only.
  */
 export async function listOverlayDrafts(): Promise<DraftWikiPageSummary[]> {
-  await requireSessionUser();
+  await requireUser();
   const org = await requireOrganization();
 
   const rows = (await prisma.wikiPage.findMany({

--- a/apps/web/lib/actions/work-queue.ts
+++ b/apps/web/lib/actions/work-queue.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { Prisma, prisma } from "@dpf/db";
-import { auth } from "@/lib/auth";
+import { requireUserId } from "@/lib/actions/shared/guards";
 import { inngest } from "@/lib/queue/inngest-client";
 import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
 import { computeFlowDurations } from "@/lib/queue/flow-metrics";
@@ -22,11 +22,6 @@ function cwqQueueKey(queueId: string): string {
   return `cwq:${queueId}`;
 }
 
-async function requireAuth(): Promise<string> {
-  const session = await auth();
-  if (!session?.user?.id) throw new Error("Unauthorized");
-  return session.user.id;
-}
 
 // ─── Queue CRUD ───────────────────────────────────────────────────────────────
 
@@ -39,7 +34,7 @@ export async function createWorkQueue(data: {
   digitalProductId?: string;
   slaMinutes?: Record<string, number>;
 }) {
-  await requireAuth();
+  await requireUserId();
   return prisma.workQueue.create({
     data: {
       ...data,
@@ -64,7 +59,7 @@ export async function createWorkItem(data: {
   dueAt?: Date;
   parentItemId?: string;
 }) {
-  await requireAuth();
+  await requireUserId();
 
   const item = await prisma.workItem.create({
     data: {
@@ -104,7 +99,7 @@ export async function createWorkItem(data: {
 }
 
 export async function claimWorkItem(itemId: string) {
-  const userId = await requireAuth();
+  const userId = await requireUserId();
 
   const item = await prisma.workItem.update({
     where: { itemId, status: "queued" },
@@ -137,7 +132,7 @@ export async function completeWorkItem(
   itemId: string,
   evidence?: Record<string, unknown>,
 ) {
-  await requireAuth();
+  await requireUserId();
 
   const item = await prisma.workItem.update({
     where: { itemId },
@@ -174,7 +169,7 @@ export async function completeWorkItem(
 // ─── Queries ──────────────────────────────────────────────────────────────────
 
 export async function getMyQueue() {
-  const userId = await requireAuth();
+  const userId = await requireUserId();
 
   return prisma.workItem.findMany({
     where: {
@@ -193,7 +188,7 @@ export async function getMyQueue() {
 }
 
 export async function getTriageQueue() {
-  await requireAuth();
+  await requireUserId();
 
   return prisma.workItem.findMany({
     where: {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:no-native-dialogs": "node scripts/check-no-native-dialogs.mjs",
     "check:no-dialog-in-transition": "node scripts/check-no-dialog-in-transition.mjs",
     "check:no-raw-event-source": "node scripts/check-no-raw-event-source.mjs",
+    "check:no-local-auth-guard": "node scripts/check-no-local-auth-guard.mjs",
     "check:architecture-parity": "pnpm --filter web exec tsx scripts/audit-architecture-parity.ts --baseline docs/superpowers/audits/2026-06-14-architecture-parity-baseline.json",
     "sbom": "node scripts/sbom/generate-platform-sbom.mjs",
     "check:sbom-drift": "node scripts/sbom/check-sbom-drift.mjs",

--- a/scripts/check-no-local-auth-guard.mjs
+++ b/scripts/check-no-local-auth-guard.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * BI-991D4DC8 — Static guard: no local `requireAuth` / `requireUser` re-implementations
+ * inside server actions (EP-8DC217EB, "Vertical Integration Inward", BET-2 mechanical
+ * adoption leaf).
+ *
+ * Background: ~17 action files had each grown their own copy of the session-auth
+ * preamble under a slightly different name (`requireAuth`, `requireAuthUser`,
+ * `requireAuthUserId`, `requireAuthenticated`, `requireUserId`, `requireSessionUser`,
+ * `getSessionUser`, `requireSession`). They drifted on two axes that matter:
+ *
+ *   - the null-check: `!user` (loose) vs `!user?.id` (strict), and
+ *   - the error string: `Error("Unauthorized")` vs `Error("Not authenticated")`.
+ *
+ * That divergence means two callers of "the same" guard get different behaviour and
+ * different error copy. The canonical primitives now live in one place:
+ *
+ *     import { requireUser, requireUserId } from "@/lib/actions/shared/guards";
+ *
+ * with ONE contract — the strict `!user?.id` check and `Error("Unauthorized")`.
+ *
+ * This guard fails the build the moment a new local copy reappears. It matches the
+ * ZERO-ARG guard shape only, so the two intentionally-bespoke helpers that take an
+ * argument keep working without an allow-list:
+ *
+ *   - deliberation.ts `requireUser(userId: string)`  — looks a user up in the DB.
+ *   - workbooks.ts    `requireUser(capability)`      — throws a typed WorkbookError(401).
+ *
+ * Run: node scripts/check-no-local-auth-guard.mjs
+ * Exit 0 = clean; exit 1 = violations (with a clear, actionable report).
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = process.cwd();
+const SCAN_DIR = join(ROOT, "apps", "web", "lib", "actions");
+
+// A zero-arg local guard whose name is in the requireAuth / requireUser family,
+// declared as either a `function` or a `const … = () =>` arrow. The empty parens
+// `\(\s*\)` are load-bearing: the two legitimate keepers take an argument, so they
+// are excluded without needing a file allow-list.
+const GUARD_NAMES =
+  "requireAuth|requireUser|requireUserId|requireAuthUser|requireAuthUserId|" +
+  "requireAuthenticated|requireSessionUser|getSessionUser|requireSession";
+const FN_GUARD = new RegExp(
+  `\\b(?:async\\s+)?function\\s+(?:${GUARD_NAMES})\\s*\\(\\s*\\)`,
+);
+const ARROW_GUARD = new RegExp(
+  `\\bconst\\s+(?:${GUARD_NAMES})\\s*(?::[^=]+)?=\\s*(?:async\\s+)?\\(\\s*\\)\\s*(?::[^=]+)?=>`,
+);
+
+// The single sanctioned home for these primitives, plus this guard itself (which
+// documents the banned names). Keep tiny.
+const ALLOW = new Set([
+  "apps/web/lib/actions/shared/guards.ts",
+  "scripts/check-no-local-auth-guard.mjs",
+]);
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let s;
+    try {
+      s = statSync(full);
+    } catch {
+      continue;
+    }
+    if (s.isDirectory()) {
+      if (["node_modules", ".next", "__snapshots__", "dist", "coverage"].includes(entry)) continue;
+      yield* walk(full);
+    } else if (s.isFile()) {
+      // Tests legitimately stub auth guards.
+      if (/\.(test|spec)\.[cm]?tsx?$/.test(full) || full.endsWith(".d.ts")) continue;
+      if (!full.endsWith(".ts") && !full.endsWith(".tsx")) continue;
+      yield full;
+    }
+  }
+}
+
+const violations = [];
+
+for (const file of walk(SCAN_DIR)) {
+  const rel = relative(ROOT, file).replace(/\\/g, "/");
+  if (ALLOW.has(rel)) continue;
+  let body;
+  try {
+    body = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  const lines = body.split(/\r?\n/);
+  lines.forEach((line, i) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*")) return;
+    if (FN_GUARD.test(line) || ARROW_GUARD.test(line)) {
+      violations.push(`${rel}:${i + 1}  ${trimmed.slice(0, 100)}`);
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error("");
+  console.error("ERROR: BI-991D4DC8 — local `requireAuth` / `requireUser` guard found in a server action.");
+  console.error("");
+  console.error("These local copies of the session-auth preamble drift on the null-check");
+  console.error("(`!user` vs `!user?.id`) and the error string (`Unauthorized` vs");
+  console.error("`Not authenticated`). Use the single canonical contract instead:");
+  console.error("");
+  console.error('    import { requireUser, requireUserId } from "@/lib/actions/shared/guards";');
+  console.error("");
+  console.error("    const userId = await requireUserId();   // id only");
+  console.error("    const user = await requireUser();       // full session user");
+  console.error("");
+  for (const v of violations) console.error("  " + v);
+  console.error("");
+  console.error("Both throw Error(\"Unauthorized\") on the strict `!user?.id` check. A guard that");
+  console.error("genuinely does more (DB lookup, capability, a typed error) takes an argument and");
+  console.error("is not matched — see deliberation.ts / workbooks.ts.");
+  console.error("");
+  process.exit(1);
+}
+
+console.log("✓ No local requireAuth/requireUser guards: server actions use shared/guards.ts (one Unauthorized contract).");


### PR DESCRIPTION
## What

The **mechanical-adoption leaf of BET-2** (EP-8DC217EB "Vertical Integration Inward", BI-991D4DC8). This is NOT the authorization-engine unification (blocked on a parallel thread) — it consolidates the ~17 divergent local `requireAuth`/`requireUser` copies onto the existing shared primitive.

~17 server-action files had each grown their own copy of the session-auth preamble under a different name (`requireAuth`, `requireAuthUser`, `requireAuthUserId`, `requireAuthenticated`, `requireUserId`, `requireSessionUser`, `getSessionUser`, `requireSession`, `requireAccess`). They drifted on two axes that matter to callers: the null-check (`!user` vs `!user?.id`) and the error string (`"Unauthorized"` vs `"Not authenticated"`).

- **Add** canonical `requireUser()` / `requireUserId()` to `apps/web/lib/actions/shared/guards.ts` with ONE contract: the strict `!user?.id` check and `Error("Unauthorized")`. `requireUserId` is the id-only companion to `requireUser`.
- **Migrate 15 files** onto the shared primitive: `knowledge`, `proposals`, `conversation-participants-action`, `mcp-services`, `feedback-support`, `reference-data`, `agent-coworker`, `work-queue`, `feedback-escalation`, `address`, `wiki-edit`, `wiki-publish`, `operating-hours`, `expenses`, and `ai-providers` (whose guard was dead code — removed). Semantics preserved; only the message + null-check are unified. This flips `reference-data`/`address`/`wiki-edit`/`wiki-publish` from `"Not authenticated"` to `"Unauthorized"` (two wiki tests updated to match).
- **Left as-is** (genuinely different behaviour, noted): `deliberation.ts` `requireUser(userId)` — a DB lookup keyed by an explicit arg; `workbooks.ts` `requireUser(capability)` — takes a capability arg and throws a typed `WorkbookError(401)`.
- **Add** `scripts/check-no-local-auth-guard.mjs` (modelled on `check-no-raw-event-source.mjs`): a CI ratchet banning new zero-arg `requireAuth`/`requireUser` guards in `apps/web/lib/actions`. Wired into `.github/workflows/ci.yml` (raw-event-source-guard job) + `package.json` scripts. The zero-arg match naturally excludes the two arg-taking keepers, so no file allow-list beyond `shared/guards.ts` is needed.

No `packages/db/prisma/schema.prisma`, `lib/tak/*`, `lib/govern/*`, `lib/routing/*`, or `lib/queue/*` touched (collision boundary respected).

## Verification (source-local)

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (guards.test.ts + 14 affected action suites) → **153 passed / 2 skipped, exit 0**
- `node scripts/check-no-local-auth-guard.mjs` → **exit 0** (positive-tested: catches a reintroduced zero-arg guard; ignores the two arg-taking keepers)

## Local-CI-Override attestation

The pre-push sandbox gate was overridden with `DPF_SKIP_PREPUSH_GATE=1` because verification was performed source-local in an isolated worktree: web typecheck exit 0, affected vitest 153 passed, and the new ratchet exit 0. GitHub CI remains the authoritative gate for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)