### PR TITLE
refactor(finance): migrate finance list tables to report-kit DataTable (EP-8DC217EB BET-7)

### DIFF
--- a/apps/web/app/(shell)/finance/assets/AssetsTable.tsx
+++ b/apps/web/app/(shell)/finance/assets/AssetsTable.tsx
@@ -1,0 +1,184 @@
+// apps/web/app/(shell)/finance/assets/AssetsTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for fixed assets. The page
+// (a Server Component) fetches + serializes rows and passes them here. The
+// depreciation progress bar is a small presentational child rendered per row.
+
+"use client";
+
+import Link from "next/link";
+
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface AssetRow {
+  id: string;
+  assetId: string;
+  name: string;
+  category: string;
+  purchaseCost: number;
+  currentBookValue: number;
+  pctDepreciated: number;
+  status: string;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+function DepreciationBar({ pct }: { pct: number }) {
+  const colour =
+    pct >= 80
+      ? "var(--dpf-error)"
+      : pct >= 50
+        ? "var(--dpf-warning)"
+        : "var(--dpf-success)";
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-1.5 rounded-full bg-[var(--dpf-border)] overflow-hidden">
+        <div
+          className="h-full rounded-full"
+          style={{ width: `${Math.min(pct, 100)}%`, backgroundColor: colour }}
+        />
+      </div>
+      <span className="text-[9px] text-[var(--dpf-muted)] w-8 text-right">
+        {pct.toFixed(0)}%
+      </span>
+    </div>
+  );
+}
+
+export function AssetsTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: AssetRow[];
+  currencySymbol: string;
+}) {
+  const columns: Column<AssetRow>[] = [
+    {
+      key: "assetId",
+      header: "Asset ID",
+      cell: (a) => (
+        <Link
+          href={`/finance/assets/${a.id}`}
+          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {a.assetId}
+        </Link>
+      ),
+      sortAccessor: (a) => a.assetId,
+    },
+    {
+      key: "name",
+      header: "Name",
+      cell: (a) => (
+        <Link
+          href={`/finance/assets/${a.id}`}
+          className="text-[var(--dpf-text)] hover:underline"
+        >
+          {a.name}
+        </Link>
+      ),
+      sortAccessor: (a) => a.name,
+    },
+    {
+      key: "category",
+      header: "Category",
+      cell: (a) => (
+        <StatusBadge
+          domain="financeAssetCategory"
+          status={a.category}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (a) => a.category,
+    },
+    {
+      key: "purchaseCost",
+      header: "Purchase Cost",
+      align: "right",
+      cell: (a) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(a.purchaseCost)}
+        </span>
+      ),
+      sortAccessor: (a) => a.purchaseCost,
+    },
+    {
+      key: "bookValue",
+      header: "Book Value",
+      align: "right",
+      cell: (a) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(a.currentBookValue)}
+        </span>
+      ),
+      sortAccessor: (a) => a.currentBookValue,
+    },
+    {
+      key: "depreciated",
+      header: "Depreciated",
+      width: "10rem",
+      cell: (a) => <DepreciationBar pct={a.pctDepreciated} />,
+      sortAccessor: (a) => a.pctDepreciated,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (a) => (
+        <StatusBadge
+          domain="financeAsset"
+          status={a.status}
+          label={a.status.replace(/_/g, " ")}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (a) => a.status,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((a) => ({
+            assetId: a.assetId,
+            name: a.name,
+            category: a.category,
+            purchaseCost: a.purchaseCost,
+            bookValue: a.currentBookValue,
+            depreciatedPct: Number(a.pctDepreciated.toFixed(0)),
+            status: a.status,
+          }))}
+          columns={[
+            { key: "assetId", header: "Asset ID" },
+            { key: "name", header: "Name" },
+            { key: "category", header: "Category" },
+            { key: "purchaseCost", header: "Purchase Cost" },
+            { key: "bookValue", header: "Book Value" },
+            { key: "depreciatedPct", header: "Depreciated %" },
+            { key: "status", header: "Status" },
+          ]}
+          filename="assets.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(a) => a.id}
+          empty="No assets found."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/assets/page.tsx
+++ b/apps/web/app/(shell)/finance/assets/page.tsx
@@ -5,6 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 import Link from "next/link";
+import { AssetsTable, type AssetRow } from "./AssetsTable";
 
 const CATEGORY_COLOURS: Record<string, string> = {
   equipment: "#38bdf8",
@@ -26,23 +27,6 @@ const ALL_CATEGORIES = ["equipment", "vehicle", "furniture", "IT", "property", "
 
 type Props = { searchParams: Promise<{ status?: string; category?: string; view?: string }> };
 
-function DepreciationBar({ pct }: { pct: number }) {
-  const colour = pct >= 80 ? "#ef4444" : pct >= 50 ? "#fbbf24" : "#4ade80";
-  return (
-    <div className="flex items-center gap-2">
-      <div className="flex-1 h-1.5 rounded-full bg-[var(--dpf-border)] overflow-hidden">
-        <div
-          className="h-full rounded-full"
-          style={{ width: `${Math.min(pct, 100)}%`, backgroundColor: colour }}
-        />
-      </div>
-      <span className="text-[9px] text-[var(--dpf-muted)] w-8 text-right">
-        {pct.toFixed(0)}%
-      </span>
-    </div>
-  );
-}
-
 export default async function AssetsPage({ searchParams }: Props) {
   const sp = await searchParams;
   const { status, category } = sp;
@@ -57,8 +41,21 @@ export default async function AssetsPage({ searchParams }: Props) {
   ]);
   const sym = getCurrencySymbol(orgSettings.baseCurrency);
 
-  const formatMoney = (amount: unknown) =>
-    Number(amount).toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const rows: AssetRow[] = assets.map((asset) => {
+    const purchaseCost = Number(asset.purchaseCost);
+    const accumulatedDepreciation = Number(asset.accumulatedDepreciation);
+    return {
+      id: asset.id,
+      assetId: asset.assetId,
+      name: asset.name,
+      category: asset.category,
+      purchaseCost,
+      currentBookValue: Number(asset.currentBookValue),
+      pctDepreciated:
+        purchaseCost > 0 ? (accumulatedDepreciation / purchaseCost) * 100 : 0,
+      status: asset.status,
+    };
+  });
 
   return (
     <div>
@@ -171,95 +168,7 @@ export default async function AssetsPage({ searchParams }: Props) {
           </Link>
         </div>
       ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Asset ID
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Name
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Category
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Purchase Cost
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Book Value
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal w-40">
-                  Depreciated
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {assets.map((asset) => {
-                const purchaseCost = Number(asset.purchaseCost);
-                const currentBookValue = Number(asset.currentBookValue);
-                const accumulatedDepreciation = Number(asset.accumulatedDepreciation);
-                const pctDepreciated =
-                  purchaseCost > 0 ? (accumulatedDepreciation / purchaseCost) * 100 : 0;
-                const categoryColour = CATEGORY_COLOURS[asset.category] ?? "#6b7280";
-                const statusColour = STATUS_COLOURS[asset.status] ?? "#6b7280";
-
-                return (
-                  <tr
-                    key={asset.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/assets/${asset.id}`}
-                        className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                      >
-                        {asset.assetId}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/assets/${asset.id}`}
-                        className="text-[var(--dpf-text)] hover:underline"
-                      >
-                        {asset.name}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{ color: categoryColour, backgroundColor: `${categoryColour}20` }}
-                      >
-                        {asset.category}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(purchaseCost)}
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(currentBookValue)}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <DepreciationBar pct={pctDepreciated} />
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{ color: statusColour, backgroundColor: `${statusColour}20` }}
-                      >
-                        {asset.status.replace(/_/g, " ")}
-                      </span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <AssetsTable rows={rows} currencySymbol={sym} />
       )}
       </>)}
     </div>

--- a/apps/web/app/(shell)/finance/bills/BillsTable.tsx
+++ b/apps/web/app/(shell)/finance/bills/BillsTable.tsx
@@ -1,0 +1,132 @@
+// apps/web/app/(shell)/finance/bills/BillsTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for AP bills. The page
+// (a Server Component) fetches + serializes rows and passes them here.
+
+"use client";
+
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface BillRow {
+  id: string;
+  billRef: string;
+  supplierName: string;
+  status: string;
+  dueDateISO: string;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function BillsTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: BillRow[];
+  currencySymbol: string;
+}) {
+  const columns: Column<BillRow>[] = [
+    {
+      key: "ref",
+      header: "Ref",
+      cell: (bill) => (
+        <Link
+          href={`/finance/bills/${bill.id}`}
+          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {bill.billRef}
+        </Link>
+      ),
+      sortAccessor: (bill) => bill.billRef,
+    },
+    {
+      key: "supplier",
+      header: "Supplier",
+      cell: (bill) => (
+        <Link
+          href={`/finance/bills/${bill.id}`}
+          className="text-[var(--dpf-text)] hover:underline"
+        >
+          {bill.supplierName}
+        </Link>
+      ),
+      sortAccessor: (bill) => bill.supplierName,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (bill) => (
+        <StatusBadge
+          domain="financeBill"
+          status={bill.status}
+          label={bill.status.replace(/_/g, " ")}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (bill) => bill.status,
+    },
+    {
+      key: "dueDate",
+      header: "Due Date",
+      cell: (bill) => (
+        <span className="text-[var(--dpf-muted)]">
+          <LocalTime value={bill.dueDateISO} utc />
+        </span>
+      ),
+      sortAccessor: (bill) => bill.dueDateISO,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      align: "right",
+      cell: (bill) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(bill.amount)}
+        </span>
+      ),
+      sortAccessor: (bill) => bill.amount,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((bill) => ({
+            ref: bill.billRef,
+            supplier: bill.supplierName,
+            status: bill.status,
+            amount: bill.amount,
+          }))}
+          columns={[
+            { key: "ref", header: "Ref" },
+            { key: "supplier", header: "Supplier" },
+            { key: "status", header: "Status" },
+            { key: "amount", header: "Amount" },
+          ]}
+          filename="bills.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(bill) => bill.id}
+          empty="No bills found."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/bills/page.tsx
+++ b/apps/web/app/(shell)/finance/bills/page.tsx
@@ -5,7 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
-import { LocalTime } from "@/components/ui/LocalTime";
+import { BillsTable, type BillRow } from "./BillsTable";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -34,8 +34,14 @@ export default async function BillsPage({ searchParams }: Props) {
   ]);
   const sym = getCurrencySymbol(orgSettings.baseCurrency);
 
-  const formatMoney = (amount: unknown) =>
-    Number(amount).toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const rows: BillRow[] = bills.map((bill) => ({
+    id: bill.id,
+    billRef: bill.billRef,
+    supplierName: bill.supplier.name,
+    status: bill.status,
+    dueDateISO: new Date(bill.dueDate).toISOString(),
+    amount: Number(bill.totalAmount),
+  }));
 
   return (
     <div>
@@ -98,75 +104,7 @@ export default async function BillsPage({ searchParams }: Props) {
       </div>
 
       {/* Bills table */}
-      {bills.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No bills found.</p>
-      ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Ref
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Supplier
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Due Date
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Amount
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {bills.map((bill) => {
-                const colour = STATUS_COLOURS[bill.status] ?? "#6b7280";
-                return (
-                  <tr
-                    key={bill.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/bills/${bill.id}`}
-                        className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                      >
-                        {bill.billRef}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/bills/${bill.id}`}
-                        className="text-[var(--dpf-text)] hover:underline"
-                      >
-                        {bill.supplier.name}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{ color: colour, backgroundColor: `${colour}20` }}
-                      >
-                        {bill.status.replace(/_/g, " ")}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      <LocalTime value={bill.dueDate} utc />
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(bill.totalAmount)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <BillsTable rows={rows} currencySymbol={sym} />
       </>)}
     </div>
   );

--- a/apps/web/app/(shell)/finance/expense-claims/ExpenseClaimsTable.tsx
+++ b/apps/web/app/(shell)/finance/expense-claims/ExpenseClaimsTable.tsx
@@ -1,0 +1,140 @@
+// apps/web/app/(shell)/finance/expense-claims/ExpenseClaimsTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for expense claims
+// (manager view). The page (a Server Component) fetches + serializes rows.
+
+"use client";
+
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface ExpenseClaimRow {
+  id: string;
+  claimId: string;
+  employeeName: string;
+  title: string;
+  status: string;
+  submittedAtISO: string | null;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function ExpenseClaimsTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: ExpenseClaimRow[];
+  currencySymbol: string;
+}) {
+  const columns: Column<ExpenseClaimRow>[] = [
+    {
+      key: "claimId",
+      header: "Claim ID",
+      cell: (c) => (
+        <Link
+          href={`/finance/expense-claims/${c.id}`}
+          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {c.claimId}
+        </Link>
+      ),
+      sortAccessor: (c) => c.claimId,
+    },
+    {
+      key: "employee",
+      header: "Employee",
+      cell: (c) => <span className="text-[var(--dpf-text)]">{c.employeeName}</span>,
+      sortAccessor: (c) => c.employeeName,
+    },
+    {
+      key: "title",
+      header: "Title",
+      cell: (c) => (
+        <Link
+          href={`/finance/expense-claims/${c.id}`}
+          className="text-[var(--dpf-text)] hover:underline"
+        >
+          {c.title}
+        </Link>
+      ),
+      sortAccessor: (c) => c.title,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (c) => (
+        <StatusBadge
+          domain="financeExpenseClaim"
+          status={c.status}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (c) => c.status,
+    },
+    {
+      key: "submitted",
+      header: "Submitted",
+      cell: (c) => (
+        <span className="text-[var(--dpf-muted)]">
+          {c.submittedAtISO ? <LocalTime value={c.submittedAtISO} mode="date" /> : "—"}
+        </span>
+      ),
+      sortAccessor: (c) => c.submittedAtISO ?? "",
+    },
+    {
+      key: "total",
+      header: "Total",
+      align: "right",
+      cell: (c) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(c.amount)}
+        </span>
+      ),
+      sortAccessor: (c) => c.amount,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((c) => ({
+            claimId: c.claimId,
+            employee: c.employeeName,
+            title: c.title,
+            status: c.status,
+            total: c.amount,
+          }))}
+          columns={[
+            { key: "claimId", header: "Claim ID" },
+            { key: "employee", header: "Employee" },
+            { key: "title", header: "Title" },
+            { key: "status", header: "Status" },
+            { key: "total", header: "Total" },
+          ]}
+          filename="expense-claims.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(c) => c.id}
+          empty="No expense claims found."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/expense-claims/page.tsx
+++ b/apps/web/app/(shell)/finance/expense-claims/page.tsx
@@ -6,8 +6,8 @@ import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
-import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
+import { ExpenseClaimsTable, type ExpenseClaimRow } from "./ExpenseClaimsTable";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -36,8 +36,15 @@ export default async function ExpenseClaimsPage({ searchParams }: Props) {
     ? 0
     : claims.filter((c) => c.status === "submitted").length;
 
-  const formatMoney = (amount: unknown) =>
-    Number(amount).toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const rows: ExpenseClaimRow[] = claims.map((claim) => ({
+    id: claim.id,
+    claimId: claim.claimId,
+    employeeName: claim.employee.displayName,
+    title: claim.title,
+    status: claim.status,
+    submittedAtISO: claim.submittedAt ? new Date(claim.submittedAt).toISOString() : null,
+    amount: Number(claim.totalAmount),
+  }));
 
   return (
     <div>
@@ -124,85 +131,7 @@ export default async function ExpenseClaimsPage({ searchParams }: Props) {
       </div>
 
       {/* Claims table */}
-      {claims.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No expense claims found.</p>
-      ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Claim ID
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Employee
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Title
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Submitted
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Total
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {claims.map((claim) => {
-                const colour = STATUS_COLOURS[claim.status] ?? "#6b7280";
-                return (
-                  <tr
-                    key={claim.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/expense-claims/${claim.id}`}
-                        className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                      >
-                        {claim.claimId}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-text)]">
-                      {claim.employee.displayName}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/expense-claims/${claim.id}`}
-                        className="text-[var(--dpf-text)] hover:underline"
-                      >
-                        {claim.title}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{ color: colour, backgroundColor: `${colour}20` }}
-                      >
-                        {claim.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {claim.submittedAt ? (
-                        <LocalTime value={claim.submittedAt} mode="date" />
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(claim.totalAmount)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <ExpenseClaimsTable rows={rows} currencySymbol={sym} />
       </>)}
     </div>
   );

--- a/apps/web/app/(shell)/finance/invoices/InvoicesTable.tsx
+++ b/apps/web/app/(shell)/finance/invoices/InvoicesTable.tsx
@@ -1,0 +1,129 @@
+// apps/web/app/(shell)/finance/invoices/InvoicesTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for invoices. The page
+// (a Server Component) fetches + serializes rows and passes them here; DataTable
+// needs a client boundary for sort, and its function-based columns can't cross
+// the server→client boundary, so the columns live here.
+
+"use client";
+
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface InvoiceRow {
+  id: string;
+  invoiceRef: string;
+  accountName: string;
+  status: string;
+  dueDateISO: string;
+  currencySymbol: string;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function InvoicesTable({ rows }: { rows: InvoiceRow[] }) {
+  const columns: Column<InvoiceRow>[] = [
+    {
+      key: "ref",
+      header: "Ref",
+      cell: (inv) => (
+        <Link
+          href={`/finance/invoices/${inv.id}`}
+          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {inv.invoiceRef}
+        </Link>
+      ),
+      sortAccessor: (inv) => inv.invoiceRef,
+    },
+    {
+      key: "account",
+      header: "Account",
+      cell: (inv) => (
+        <Link
+          href={`/finance/invoices/${inv.id}`}
+          className="text-[var(--dpf-text)] hover:underline"
+        >
+          {inv.accountName}
+        </Link>
+      ),
+      sortAccessor: (inv) => inv.accountName,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (inv) => (
+        <StatusBadge
+          domain="finance"
+          status={inv.status}
+          label={inv.status.replace("_", " ")}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (inv) => inv.status,
+    },
+    {
+      key: "dueDate",
+      header: "Due Date",
+      cell: (inv) => (
+        <span className="text-[var(--dpf-muted)]">
+          <LocalTime value={inv.dueDateISO} utc />
+        </span>
+      ),
+      sortAccessor: (inv) => inv.dueDateISO,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      align: "right",
+      cell: (inv) => (
+        <span className="text-[var(--dpf-text)]">
+          {inv.currencySymbol}
+          {formatMoney(inv.amount)}
+        </span>
+      ),
+      sortAccessor: (inv) => inv.amount,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((inv) => ({
+            ref: inv.invoiceRef,
+            account: inv.accountName,
+            status: inv.status,
+            amount: inv.amount,
+          }))}
+          columns={[
+            { key: "ref", header: "Ref" },
+            { key: "account", header: "Account" },
+            { key: "status", header: "Status" },
+            { key: "amount", header: "Amount" },
+          ]}
+          filename="invoices.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(inv) => inv.id}
+          empty="No invoices found."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/invoices/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/page.tsx
@@ -3,8 +3,8 @@ import { prisma } from "@dpf/db";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
-import { LocalTime } from "@/components/ui/LocalTime";
 import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
+import { InvoicesTable, type InvoiceRow } from "./InvoicesTable";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -57,8 +57,15 @@ export default async function InvoicesPage({ searchParams }: Props) {
   );
   const totalCount = statusCounts.reduce((sum, s) => sum + s._count, 0);
 
-  const formatMoney = (amount: number) =>
-    amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const rows: InvoiceRow[] = invoices.map((inv) => ({
+    id: inv.id,
+    invoiceRef: inv.invoiceRef,
+    accountName: inv.account.name,
+    status: inv.status,
+    dueDateISO: inv.dueDate.toISOString(),
+    currencySymbol: getCurrencySymbol(inv.currency),
+    amount: Number(inv.totalAmount),
+  }));
 
   return (
     <div>
@@ -127,78 +134,7 @@ export default async function InvoicesPage({ searchParams }: Props) {
       </div>
 
       {/* Invoices table */}
-      {invoices.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No invoices found.</p>
-      ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Ref
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Account
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Due Date
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Amount
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {invoices.map((inv) => {
-                const colour = STATUS_COLOURS[inv.status] ?? "#6b7280";
-                return (
-                  <tr
-                    key={inv.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/invoices/${inv.id}`}
-                        className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                      >
-                        {inv.invoiceRef}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/invoices/${inv.id}`}
-                        className="text-[var(--dpf-text)] hover:underline"
-                      >
-                        {inv.account.name}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{
-                          color: colour,
-                          backgroundColor: `${colour}20`,
-                        }}
-                      >
-                        {inv.status.replace("_", " ")}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      <LocalTime value={inv.dueDate} utc />
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {getCurrencySymbol(inv.currency)}{formatMoney(Number(inv.totalAmount))}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <InvoicesTable rows={rows} />
         </>
       )}
     </div>

--- a/apps/web/app/(shell)/finance/my-expenses/MyExpensesTable.tsx
+++ b/apps/web/app/(shell)/finance/my-expenses/MyExpensesTable.tsx
@@ -1,0 +1,131 @@
+// apps/web/app/(shell)/finance/my-expenses/MyExpensesTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for the employee's own
+// expense claims. The page (a Server Component) fetches + serializes rows.
+
+"use client";
+
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface MyExpenseRow {
+  id: string;
+  claimId: string;
+  title: string;
+  status: string;
+  submittedAtISO: string | null;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function MyExpensesTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: MyExpenseRow[];
+  currencySymbol: string;
+}) {
+  const columns: Column<MyExpenseRow>[] = [
+    {
+      key: "claimId",
+      header: "Claim ID",
+      cell: (c) => (
+        <Link
+          href={`/finance/my-expenses/${c.id}`}
+          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {c.claimId}
+        </Link>
+      ),
+      sortAccessor: (c) => c.claimId,
+    },
+    {
+      key: "title",
+      header: "Title",
+      cell: (c) => (
+        <Link
+          href={`/finance/my-expenses/${c.id}`}
+          className="text-[var(--dpf-text)] hover:underline"
+        >
+          {c.title}
+        </Link>
+      ),
+      sortAccessor: (c) => c.title,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (c) => (
+        <StatusBadge
+          domain="financeExpenseClaim"
+          status={c.status}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (c) => c.status,
+    },
+    {
+      key: "submitted",
+      header: "Submitted",
+      cell: (c) => (
+        <span className="text-[var(--dpf-muted)]">
+          {c.submittedAtISO ? <LocalTime value={c.submittedAtISO} mode="date" /> : "—"}
+        </span>
+      ),
+      sortAccessor: (c) => c.submittedAtISO ?? "",
+    },
+    {
+      key: "total",
+      header: "Total",
+      align: "right",
+      cell: (c) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(c.amount)}
+        </span>
+      ),
+      sortAccessor: (c) => c.amount,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((c) => ({
+            claimId: c.claimId,
+            title: c.title,
+            status: c.status,
+            total: c.amount,
+          }))}
+          columns={[
+            { key: "claimId", header: "Claim ID" },
+            { key: "title", header: "Title" },
+            { key: "status", header: "Status" },
+            { key: "total", header: "Total" },
+          ]}
+          filename="my-expenses.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(c) => c.id}
+          empty="No expense claims yet."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/my-expenses/page.tsx
+++ b/apps/web/app/(shell)/finance/my-expenses/page.tsx
@@ -5,16 +5,8 @@ import { listExpenseClaims } from "@/lib/actions/expenses";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
-import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
-
-const STATUS_COLOURS: Record<string, string> = {
-  draft: "#8888a0",
-  submitted: "#a78bfa",
-  approved: "#4ade80",
-  rejected: "#ef4444",
-  paid: "#22c55e",
-};
+import { MyExpensesTable, type MyExpenseRow } from "./MyExpensesTable";
 
 export default async function MyExpensesPage() {
   const [claims, orgSettings] = await Promise.all([
@@ -23,8 +15,14 @@ export default async function MyExpensesPage() {
   ]);
   const sym = getCurrencySymbol(orgSettings.baseCurrency);
 
-  const formatMoney = (amount: unknown) =>
-    Number(amount).toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const rows: MyExpenseRow[] = claims.map((claim) => ({
+    id: claim.id,
+    claimId: claim.claimId,
+    title: claim.title,
+    status: claim.status,
+    submittedAtISO: claim.submittedAt ? new Date(claim.submittedAt).toISOString() : null,
+    amount: Number(claim.totalAmount),
+  }));
 
   return (
     <div>
@@ -58,75 +56,7 @@ export default async function MyExpensesPage() {
           </Link>
         </div>
       ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Claim ID
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Title
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Submitted
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Total
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {claims.map((claim) => {
-                const colour = STATUS_COLOURS[claim.status] ?? "#6b7280";
-                return (
-                  <tr
-                    key={claim.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/my-expenses/${claim.id}`}
-                        className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                      >
-                        {claim.claimId}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/my-expenses/${claim.id}`}
-                        className="text-[var(--dpf-text)] hover:underline"
-                      >
-                        {claim.title}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{ color: colour, backgroundColor: `${colour}20` }}
-                      >
-                        {claim.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {claim.submittedAt ? (
-                        <LocalTime value={claim.submittedAt} mode="date" />
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(claim.totalAmount)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <MyExpensesTable rows={rows} currencySymbol={sym} />
       )}
     </div>
   );

--- a/apps/web/app/(shell)/finance/payment-runs/PaymentRunsTable.tsx
+++ b/apps/web/app/(shell)/finance/payment-runs/PaymentRunsTable.tsx
@@ -1,0 +1,115 @@
+// apps/web/app/(shell)/finance/payment-runs/PaymentRunsTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for past payment runs.
+// The page (a Server Component) fetches + serializes rows and passes them here.
+// The "New Payment Run" builder above the list stays in the page unchanged.
+
+"use client";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface PaymentRunRow {
+  id: string;
+  paymentRef: string;
+  receivedAtISO: string | null;
+  status: string;
+  billCount: number;
+  currency: string;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function PaymentRunsTable({ rows }: { rows: PaymentRunRow[] }) {
+  const columns: Column<PaymentRunRow>[] = [
+    {
+      key: "paymentRef",
+      header: "Payment Ref",
+      cell: (run) => (
+        <span className="text-[9px] font-mono text-[var(--dpf-muted)]">
+          {run.paymentRef}
+        </span>
+      ),
+      sortAccessor: (run) => run.paymentRef,
+    },
+    {
+      key: "date",
+      header: "Date",
+      cell: (run) => (
+        <span className="text-[var(--dpf-muted)]">
+          <LocalTime value={run.receivedAtISO} mode="date" />
+        </span>
+      ),
+      sortAccessor: (run) => run.receivedAtISO ?? "",
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (run) => (
+        <StatusBadge
+          domain="financePaymentRun"
+          status={run.status}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (run) => run.status,
+    },
+    {
+      key: "bills",
+      header: "Bills",
+      align: "right",
+      cell: (run) => <span className="text-[var(--dpf-muted)]">{run.billCount}</span>,
+      sortAccessor: (run) => run.billCount,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      align: "right",
+      cell: (run) => (
+        <span className="text-[var(--dpf-text)]">
+          {run.currency} {formatMoney(run.amount)}
+        </span>
+      ),
+      sortAccessor: (run) => run.amount,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((run) => ({
+            paymentRef: run.paymentRef,
+            status: run.status,
+            bills: run.billCount,
+            amount: run.amount,
+          }))}
+          columns={[
+            { key: "paymentRef", header: "Payment Ref" },
+            { key: "status", header: "Status" },
+            { key: "bills", header: "Bills" },
+            { key: "amount", header: "Amount" },
+          ]}
+          filename="payment-runs.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(run) => run.id}
+          empty="No payment runs yet."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/payment-runs/page.tsx
+++ b/apps/web/app/(shell)/finance/payment-runs/page.tsx
@@ -2,8 +2,8 @@
 import { listPaymentRuns, listBills } from "@/lib/actions/ap";
 import { PaymentRunBuilder } from "@/components/finance/PaymentRunBuilder";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
-import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
+import { PaymentRunsTable, type PaymentRunRow } from "./PaymentRunsTable";
 
 export default async function PaymentRunsPage() {
   const [runs, approvedBills] = await Promise.all([
@@ -11,8 +11,15 @@ export default async function PaymentRunsPage() {
     listBills({ status: "approved" }),
   ]);
 
-  const formatMoney = (amount: unknown) =>
-    Number(amount).toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const runRows: PaymentRunRow[] = runs.map((run) => ({
+    id: run.id,
+    paymentRef: run.paymentRef,
+    receivedAtISO: run.receivedAt ? new Date(run.receivedAt).toISOString() : null,
+    status: run.status,
+    billCount: run.allocations.length,
+    currency: run.currency,
+    amount: Number(run.amount),
+  }));
 
   return (
     <div>
@@ -52,75 +59,7 @@ export default async function PaymentRunsPage() {
           Past Payment Runs
         </h2>
 
-        {runs.length === 0 ? (
-          <p className="text-sm text-[var(--dpf-muted)]">No payment runs yet.</p>
-        ) : (
-          <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-[var(--dpf-border)]">
-                  <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Payment Ref
-                  </th>
-                  <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Date
-                  </th>
-                  <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Status
-                  </th>
-                  <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Bills
-                  </th>
-                  <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Amount
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {runs.map((run) => {
-                  const statusColour =
-                    run.status === "completed"
-                      ? "#4ade80"
-                      : run.status === "failed"
-                        ? "#ef4444"
-                        : "#fbbf24";
-                  return (
-                    <tr
-                      key={run.id}
-                      className="border-b border-[var(--dpf-border)] last:border-0"
-                    >
-                      <td className="px-4 py-2.5">
-                        <span className="text-[9px] font-mono text-[var(--dpf-muted)]">
-                          {run.paymentRef}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                        <LocalTime value={run.receivedAt} mode="date" />
-                      </td>
-                      <td className="px-4 py-2.5">
-                        <span
-                          className="text-[9px] px-1.5 py-0.5 rounded-full"
-                          style={{
-                            color: statusColour,
-                            backgroundColor: `${statusColour}20`,
-                          }}
-                        >
-                          {run.status}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-[var(--dpf-muted)]">
-                        {run.allocations.length}
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                        {run.currency} {formatMoney(run.amount)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
+        <PaymentRunsTable rows={runRows} />
       </section>
     </div>
   );

--- a/apps/web/app/(shell)/finance/purchase-orders/PurchaseOrdersTable.tsx
+++ b/apps/web/app/(shell)/finance/purchase-orders/PurchaseOrdersTable.tsx
@@ -1,0 +1,132 @@
+// apps/web/app/(shell)/finance/purchase-orders/PurchaseOrdersTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for purchase orders. The
+// page (a Server Component) fetches + serializes rows and passes them here.
+
+"use client";
+
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface PurchaseOrderRow {
+  id: string;
+  poNumber: string;
+  supplierName: string;
+  status: string;
+  deliveryDateISO: string | null;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function PurchaseOrdersTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: PurchaseOrderRow[];
+  currencySymbol: string;
+}) {
+  const columns: Column<PurchaseOrderRow>[] = [
+    {
+      key: "poNumber",
+      header: "PO Number",
+      cell: (po) => (
+        <Link
+          href={`/finance/purchase-orders/${po.id}`}
+          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {po.poNumber}
+        </Link>
+      ),
+      sortAccessor: (po) => po.poNumber,
+    },
+    {
+      key: "supplier",
+      header: "Supplier",
+      cell: (po) => (
+        <Link
+          href={`/finance/purchase-orders/${po.id}`}
+          className="text-[var(--dpf-text)] hover:underline"
+        >
+          {po.supplierName}
+        </Link>
+      ),
+      sortAccessor: (po) => po.supplierName,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (po) => (
+        <StatusBadge
+          domain="financePurchaseOrder"
+          status={po.status}
+          label={po.status.replace(/_/g, " ")}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (po) => po.status,
+    },
+    {
+      key: "deliveryDate",
+      header: "Delivery Date",
+      cell: (po) => (
+        <span className="text-[var(--dpf-muted)]">
+          <LocalTime value={po.deliveryDateISO} utc />
+        </span>
+      ),
+      sortAccessor: (po) => po.deliveryDateISO ?? "",
+    },
+    {
+      key: "total",
+      header: "Total",
+      align: "right",
+      cell: (po) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(po.amount)}
+        </span>
+      ),
+      sortAccessor: (po) => po.amount,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((po) => ({
+            poNumber: po.poNumber,
+            supplier: po.supplierName,
+            status: po.status,
+            total: po.amount,
+          }))}
+          columns={[
+            { key: "poNumber", header: "PO Number" },
+            { key: "supplier", header: "Supplier" },
+            { key: "status", header: "Status" },
+            { key: "total", header: "Total" },
+          ]}
+          filename="purchase-orders.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(po) => po.id}
+          empty="No purchase orders found."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/purchase-orders/page.tsx
+++ b/apps/web/app/(shell)/finance/purchase-orders/page.tsx
@@ -3,8 +3,8 @@ import { listPurchaseOrders } from "@/lib/actions/ap";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
-import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
+import { PurchaseOrdersTable, type PurchaseOrderRow } from "./PurchaseOrdersTable";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -30,8 +30,14 @@ export default async function PurchaseOrdersPage({ searchParams }: Props) {
   ]);
   const sym = getCurrencySymbol(orgSettings.baseCurrency);
 
-  const formatMoney = (amount: unknown) =>
-    Number(amount).toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const rows: PurchaseOrderRow[] = orders.map((po) => ({
+    id: po.id,
+    poNumber: po.poNumber,
+    supplierName: po.supplier.name,
+    status: po.status,
+    deliveryDateISO: po.deliveryDate ? new Date(po.deliveryDate).toISOString() : null,
+    amount: Number(po.totalAmount),
+  }));
 
   return (
     <div>
@@ -91,75 +97,7 @@ export default async function PurchaseOrdersPage({ searchParams }: Props) {
       </div>
 
       {/* PO table */}
-      {orders.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No purchase orders found.</p>
-      ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  PO Number
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Supplier
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Delivery Date
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Total
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {orders.map((po) => {
-                const colour = STATUS_COLOURS[po.status] ?? "#6b7280";
-                return (
-                  <tr
-                    key={po.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/purchase-orders/${po.id}`}
-                        className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                      >
-                        {po.poNumber}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/purchase-orders/${po.id}`}
-                        className="text-[var(--dpf-text)] hover:underline"
-                      >
-                        {po.supplier.name}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{ color: colour, backgroundColor: `${colour}20` }}
-                      >
-                        {po.status.replace(/_/g, " ")}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      <LocalTime value={po.deliveryDate} utc />
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(po.totalAmount)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <PurchaseOrdersTable rows={rows} currencySymbol={sym} />
     </div>
   );
 }

--- a/apps/web/app/(shell)/finance/recurring/RecurringTable.tsx
+++ b/apps/web/app/(shell)/finance/recurring/RecurringTable.tsx
@@ -1,0 +1,150 @@
+// apps/web/app/(shell)/finance/recurring/RecurringTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for recurring schedules.
+// The page (a Server Component) fetches + serializes rows and passes them here.
+
+"use client";
+
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  weekly: "Weekly",
+  fortnightly: "Fortnightly",
+  monthly: "Monthly",
+  quarterly: "Quarterly",
+  annually: "Annually",
+};
+
+export interface RecurringRow {
+  id: string;
+  scheduleId: string;
+  name: string;
+  customerName: string;
+  frequency: string;
+  currency: string;
+  amount: number;
+  nextInvoiceDateISO: string;
+  status: string;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function RecurringTable({ rows }: { rows: RecurringRow[] }) {
+  const columns: Column<RecurringRow>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (s) => (
+        <div>
+          <Link
+            href={`/finance/recurring/${s.id}`}
+            className="text-[var(--dpf-text)] hover:underline font-medium"
+          >
+            {s.name}
+          </Link>
+          <div className="text-[9px] font-mono text-[var(--dpf-muted)] mt-0.5">
+            {s.scheduleId}
+          </div>
+        </div>
+      ),
+      sortAccessor: (s) => s.name,
+    },
+    {
+      key: "customer",
+      header: "Customer",
+      cell: (s) => <span className="text-[var(--dpf-muted)]">{s.customerName}</span>,
+      sortAccessor: (s) => s.customerName,
+    },
+    {
+      key: "frequency",
+      header: "Frequency",
+      cell: (s) => (
+        <StatusBadge
+          intent="info"
+          label={FREQUENCY_LABELS[s.frequency] ?? s.frequency}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (s) => s.frequency,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      align: "right",
+      cell: (s) => (
+        <span className="text-[var(--dpf-text)]">
+          {s.currency} {formatMoney(s.amount)}
+        </span>
+      ),
+      sortAccessor: (s) => s.amount,
+    },
+    {
+      key: "nextInvoice",
+      header: "Next Invoice",
+      cell: (s) => (
+        <span className="text-[var(--dpf-muted)]">
+          <LocalTime value={s.nextInvoiceDateISO} utc />
+        </span>
+      ),
+      sortAccessor: (s) => s.nextInvoiceDateISO,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (s) => (
+        <StatusBadge
+          domain="financeRecurring"
+          status={s.status}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (s) => s.status,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((s) => ({
+            name: s.name,
+            scheduleId: s.scheduleId,
+            customer: s.customerName,
+            frequency: s.frequency,
+            amount: s.amount,
+            status: s.status,
+          }))}
+          columns={[
+            { key: "name", header: "Name" },
+            { key: "scheduleId", header: "Schedule ID" },
+            { key: "customer", header: "Customer" },
+            { key: "frequency", header: "Frequency" },
+            { key: "amount", header: "Amount" },
+            { key: "status", header: "Status" },
+          ]}
+          filename="recurring-schedules.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(s) => s.id}
+          empty="No recurring schedules found."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/recurring/page.tsx
+++ b/apps/web/app/(shell)/finance/recurring/page.tsx
@@ -1,22 +1,14 @@
 // apps/web/app/(shell)/finance/recurring/page.tsx
 import { listRecurringSchedules } from "@/lib/actions/recurring";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
-import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
+import { RecurringTable, type RecurringRow } from "./RecurringTable";
 
 const SCHEDULE_STATUS_COLOURS: Record<string, string> = {
   active: "#4ade80",
   paused: "#fbbf24",
   cancelled: "#ef4444",
   completed: "#8888a0",
-};
-
-const FREQUENCY_LABELS: Record<string, string> = {
-  weekly: "Weekly",
-  fortnightly: "Fortnightly",
-  monthly: "Monthly",
-  quarterly: "Quarterly",
-  annually: "Annually",
 };
 
 const ALL_STATUSES = ["active", "paused", "cancelled", "completed"];
@@ -30,8 +22,17 @@ export default async function RecurringPage({ searchParams }: Props) {
     ? await listRecurringSchedules({ status })
     : await listRecurringSchedules();
 
-  const formatMoney = (amount: number) =>
-    amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+  const rows: RecurringRow[] = schedules.map((sched) => ({
+    id: sched.id,
+    scheduleId: sched.scheduleId,
+    name: sched.name,
+    customerName: sched.account.name,
+    frequency: sched.frequency,
+    currency: sched.currency,
+    amount: Number(sched.amount),
+    nextInvoiceDateISO: new Date(sched.nextInvoiceDate).toISOString(),
+    status: sched.status,
+  }));
 
   return (
     <div>
@@ -101,87 +102,7 @@ export default async function RecurringPage({ searchParams }: Props) {
           No recurring schedules found. Create one to automate your invoicing.
         </p>
       ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Name
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Customer
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Frequency
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Amount
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Next Invoice
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {schedules.map((sched) => {
-                const statusColour =
-                  SCHEDULE_STATUS_COLOURS[sched.status] ?? "#6b7280";
-                return (
-                  <tr
-                    key={sched.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/recurring/${sched.id}`}
-                        className="text-[var(--dpf-text)] hover:underline font-medium"
-                      >
-                        {sched.name}
-                      </Link>
-                      <div className="text-[9px] font-mono text-[var(--dpf-muted)] mt-0.5">
-                        {sched.scheduleId}
-                      </div>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {sched.account.name}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{
-                          color: "#38bdf8",
-                          backgroundColor: "#38bdf820",
-                        }}
-                      >
-                        {FREQUENCY_LABELS[sched.frequency] ?? sched.frequency}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sched.currency} {formatMoney(Number(sched.amount))}
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      <LocalTime value={sched.nextInvoiceDate} utc />
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{
-                          color: statusColour,
-                          backgroundColor: `${statusColour}20`,
-                        }}
-                      >
-                        {sched.status}
-                      </span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <RecurringTable rows={rows} />
       )}
     </div>
   );

--- a/apps/web/app/(shell)/finance/suppliers/SuppliersTable.tsx
+++ b/apps/web/app/(shell)/finance/suppliers/SuppliersTable.tsx
@@ -1,0 +1,113 @@
+// apps/web/app/(shell)/finance/suppliers/SuppliersTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for suppliers. The page
+// (a Server Component) fetches + serializes rows and passes them here.
+
+"use client";
+
+import Link from "next/link";
+
+import {
+  DataTable,
+  ExportButton,
+  StatusBadge,
+  type Column,
+} from "@/components/ui/report-kit";
+
+export interface SupplierRow {
+  id: string;
+  supplierId: string;
+  name: string;
+  status: string;
+  paymentTerms: string | null;
+  billCount: number;
+}
+
+export function SuppliersTable({ rows }: { rows: SupplierRow[] }) {
+  const columns: Column<SupplierRow>[] = [
+    {
+      key: "id",
+      header: "ID",
+      cell: (s) => (
+        <Link
+          href={`/finance/suppliers/${s.id}`}
+          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {s.supplierId}
+        </Link>
+      ),
+      sortAccessor: (s) => s.supplierId,
+    },
+    {
+      key: "name",
+      header: "Name",
+      cell: (s) => (
+        <Link
+          href={`/finance/suppliers/${s.id}`}
+          className="text-[var(--dpf-text)] hover:underline"
+        >
+          {s.name}
+        </Link>
+      ),
+      sortAccessor: (s) => s.name,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (s) => (
+        <StatusBadge
+          domain="financeSupplier"
+          status={s.status}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (s) => s.status,
+    },
+    {
+      key: "paymentTerms",
+      header: "Payment Terms",
+      cell: (s) => <span className="text-[var(--dpf-muted)]">{s.paymentTerms}</span>,
+      sortAccessor: (s) => s.paymentTerms ?? "",
+    },
+    {
+      key: "bills",
+      header: "Bills",
+      align: "right",
+      cell: (s) => <span className="text-[var(--dpf-muted)]">{s.billCount}</span>,
+      sortAccessor: (s) => s.billCount,
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <ExportButton
+          rows={rows.map((s) => ({
+            id: s.supplierId,
+            name: s.name,
+            status: s.status,
+            paymentTerms: s.paymentTerms,
+            bills: s.billCount,
+          }))}
+          columns={[
+            { key: "id", header: "ID" },
+            { key: "name", header: "Name" },
+            { key: "status", header: "Status" },
+            { key: "paymentTerms", header: "Payment Terms" },
+            { key: "bills", header: "Bills" },
+          ]}
+          filename="suppliers.csv"
+        />
+      </div>
+      <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowKey={(s) => s.id}
+          empty="No suppliers yet."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/suppliers/page.tsx
+++ b/apps/web/app/(shell)/finance/suppliers/page.tsx
@@ -4,14 +4,9 @@ import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
 import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 import Link from "next/link";
+import { SuppliersTable, type SupplierRow } from "./SuppliersTable";
 
 export const dynamic = "force-dynamic";
-
-const SUPPLIER_STATUS_COLOURS: Record<string, string> = {
-  active: "#4ade80",
-  inactive: "#8888a0",
-  blocked: "#ef4444",
-};
 
 export default async function SuppliersPage({
   searchParams,
@@ -21,6 +16,15 @@ export default async function SuppliersPage({
   const sp = await searchParams;
   const view = sp?.view === "grid" || sp?.view === "board" ? sp.view : null;
   const suppliers = await listSuppliers();
+
+  const rows: SupplierRow[] = suppliers.map((s) => ({
+    id: s.id,
+    supplierId: s.supplierId,
+    name: s.name,
+    status: s.status,
+    paymentTerms: s.paymentTerms,
+    billCount: s._count.bills,
+  }));
 
   return (
     <div>
@@ -50,77 +54,8 @@ export default async function SuppliersPage({
 
       {view ? (
         <SurfacePlatformGrid entityType="supplier" view={view} />
-      ) : suppliers.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No suppliers yet.</p>
       ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  ID
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Name
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Status
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Payment Terms
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Bills
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {suppliers.map((s) => {
-                const colour = SUPPLIER_STATUS_COLOURS[s.status] ?? "#6b7280";
-                return (
-                  <tr
-                    key={s.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/suppliers/${s.id}`}
-                        className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                      >
-                        {s.supplierId}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <Link
-                        href={`/finance/suppliers/${s.id}`}
-                        className="text-[var(--dpf-text)] hover:underline"
-                      >
-                        {s.name}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full"
-                        style={{
-                          color: colour,
-                          backgroundColor: `${colour}20`,
-                        }}
-                      >
-                        {s.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {s.paymentTerms}
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-muted)]">
-                      {s._count.bills}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <SuppliersTable rows={rows} />
       )}
     </div>
   );

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -91,6 +91,66 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     void: "neutral",
     written_off: "neutral",
   },
+  // Finance AP bill lifecycle (was app/(shell)/finance/bills STATUS_COLOURS).
+  financeBill: {
+    draft: "neutral",
+    awaiting_approval: "accent",
+    approved: "info",
+    partially_paid: "warning",
+    paid: "success",
+    void: "neutral",
+  },
+  // Finance supplier lifecycle (was app/(shell)/finance/suppliers SUPPLIER_STATUS_COLOURS).
+  financeSupplier: {
+    active: "success",
+    inactive: "neutral",
+    blocked: "danger",
+  },
+  // Finance purchase-order lifecycle (was app/(shell)/finance/purchase-orders STATUS_COLOURS).
+  financePurchaseOrder: {
+    draft: "neutral",
+    sent: "info",
+    acknowledged: "accent",
+    received: "success",
+    cancelled: "neutral",
+  },
+  // Finance expense-claim lifecycle (was app/(shell)/finance/expense-claims + my-expenses STATUS_COLOURS).
+  financeExpenseClaim: {
+    draft: "neutral",
+    submitted: "accent",
+    approved: "success",
+    rejected: "danger",
+    paid: "success",
+  },
+  // Finance recurring-schedule lifecycle (was app/(shell)/finance/recurring SCHEDULE_STATUS_COLOURS).
+  financeRecurring: {
+    active: "success",
+    paused: "warning",
+    cancelled: "danger",
+    completed: "neutral",
+  },
+  // Finance payment-run lifecycle (was inline ternary in app/(shell)/finance/payment-runs).
+  financePaymentRun: {
+    pending: "warning",
+    processing: "warning",
+    completed: "success",
+    failed: "danger",
+  },
+  // Finance fixed-asset lifecycle (was app/(shell)/finance/assets STATUS_COLOURS).
+  financeAsset: {
+    active: "success",
+    disposed: "neutral",
+    written_off: "danger",
+  },
+  // Finance fixed-asset category taxonomy (was app/(shell)/finance/assets CATEGORY_COLOURS).
+  financeAssetCategory: {
+    equipment: "info",
+    vehicle: "warning",
+    furniture: "accent",
+    IT: "success",
+    property: "warning",
+    other: "neutral",
+  },
   // Complaints (was raw hex in ComplaintsClient — now token-backed).
   complaintSeverity: {
     low: "success",


### PR DESCRIPTION
## What
BET-7 leaf (**BI-C5EEC0B1**) of **EP-8DC217EB · Vertical Integration Inward**. Reference pattern: #2701.

Nine hand-rolled `<table className="w-full text-xs">` finance **list** surfaces migrate to the shared report-kit **`DataTable`**, gaining opt-in client sort + a per-list CSV **`ExportButton`**, and retiring nine private status→hex colour maps in favour of token-backed **`StatusBadge`** + the central **`resolveIntent`** registry.

**Converted (9 of the 25 candidate pages):**
`invoices` · `bills` · `suppliers` · `purchase-orders` · `expense-claims` · `my-expenses` · `recurring` · `payment-runs` (past-runs list) · `assets` (depreciation bar tokenised, kept as a per-row cell)

- Each page stays a **Server Component** (Prisma/action fetch + serialize) and hands plain rows to a co-located `"use client"` `*Table.tsx`, mirroring the existing `PaymentsTable` reference.
- **Columns, ordering, and money formatting preserved exactly** — `toLocaleString("en-GB", { minimumFractionDigits: 2 })`, per-row currency symbol on invoices, currency-code prefix on recurring/payment-runs.
- Added finance status domains to `report-kit/statusColors.ts` (`financeBill` / `financeSupplier` / `financePurchaseOrder` / `financeExpenseClaim` / `financeRecurring` / `financePaymentRun` / `financeAsset` / `financeAssetCategory`) — additive one-line registry edits, the documented extension point. No raw hex remains in the migrated tables (filter pills are unchanged and out of scope).

**Skipped (bespoke — `DataTable` models none of these, so forcing them would regress):**
- `reports/{aged-creditors,aged-debtors}` — `<tfoot>` grand-total rows.
- `reports/{profit-loss,vat-summary,cash-flow,general-ledger,revenue-by-customer}` — grouped financial statements with subtotals.
- `reports/outstanding` — graded days-overdue urgency ramp + existing server-side CSV export.
- All `[id]` detail pages + `banking/[id]` — line-item tables embedded inside multi-section detail views, not standalone lists.

## Verification (source-local)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run components/ui/report-kit` → **49/49 pass**
- `pnpm --filter web exec vitest run "app/(shell)/finance"` → **8/8 pass**
- Scoped pre-commit typecheck + gitleaks → clean.

UX I would verify on a running portal (cannot drive it here): each list renders identical columns/order, money strings byte-identical, status pills token-coloured in light+dark, sort toggles on header click, CSV export downloads the visible columns, and empty states match (incl. the custom `recurring` / `assets` / `my-expenses` empty copy preserved via page-level conditionals).

## Local-CI-Override attestation
Pushed with `DPF_SKIP_PREPUSH_GATE=1` — no sandbox in this isolated worktree. Verified-clean source-local: typecheck exit 0 + report-kit 49/49 + finance 8/8 vitest. Full CI (Typecheck / Prod Build / DCO / Unit Tests / Module Size Guard) is authoritative on this PR.

Plan: `docs/superpowers/plans/2026-07-07-vertical-integration-inward-plan.md` §4 BET-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)