### PR TITLE
fix(ops): Inngest history-retention + orphan-reaper janitor (BI-0AB96FE7)

### DIFF
--- a/apps/web/lib/operate/inngest-retention/constants.ts
+++ b/apps/web/lib/operate/inngest-retention/constants.ts
@@ -1,0 +1,112 @@
+// BI-0AB96FE7 (EP-B9DD37C7) — Inngest history-retention + orphan-reaper janitor.
+//
+// Root cause (evidence-verified 2026-07-07): self-hosted Inngest v1.30 splits
+// state — live run state in Redis under a ~12–16h TTL; durable history in
+// Postgres db=inngest (function_runs, spans, history, …) with NO TTL and NO GC.
+// A run whose Redis {estate} state TTL-expires strands its Postgres rows; the
+// single executor retries the orphan forever ("run not found in state store" +
+// "duplicate key spans_pkey") and the orphans accumulate unbounded (21,838
+// unfinished function_runs / ~987k spans at the choke point) until the executor
+// chokes and drives ZERO executions — a silent, total outage of all scheduled
+// and autonomous dispatch. This janitor bounds the history and reaps the
+// orphans BEFORE they can starve the executor. Non-destructive: it deletes only
+// Inngest's own aged/orphaned bookkeeping rows, never application data.
+//
+// The scheduled-job identifiers are duplicated (intentionally — packages/db
+// cannot import from apps/web) in packages/db/src/seed-platform-inngest-retention.ts.
+// If you change one, change both, or the ScheduledJob heartbeat row will be
+// orphaned. This mirrors the data-retention / postgres-backup constants convention.
+
+export const INNGEST_RETENTION_JOB_ID = "inngest-retention-sweep";
+export const INNGEST_RETENTION_JOB_NAME =
+  "Inngest retention sweep (platform-managed)";
+export const INNGEST_RETENTION_SCHEDULE = "every-6-hours";
+
+/** Inngest function ids. */
+export const INNGEST_RETENTION_SCHEDULED_INNGEST_ID =
+  "ops/inngest-retention-sweep-scheduled";
+export const INNGEST_RETENTION_REQUESTED_INNGEST_ID =
+  "ops/inngest-retention-sweep-requested";
+
+/** Event that triggers a one-shot manual run (operator "run now" / dry-run). */
+export const INNGEST_RETENTION_REQUESTED_EVENT = "ops/inngest-retention.requested";
+
+/** Every 6 hours at :17 past (00/06/12/18 UTC). Frequent enough that orphans
+ *  never approach the choke threshold; :17 offset avoids the top-of-hour cron
+ *  pileup. Widen/disable via the operator kill switch, not a code edit. */
+export const INNGEST_RETENTION_CRON = "17 */6 * * *";
+
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 86_400_000;
+const SIX_HOURS_MS = 6 * MS_PER_HOUR;
+
+/**
+ * Age past which an UNFINISHED function_runs row is a genuine orphan: its Redis
+ * {estate} state has certainly TTL-expired (observed TTLs ~12–16h), so the run
+ * can never complete and the executor is only retrying a corpse. 24h sits
+ * comfortably above the TTL ceiling AND above any legitimate long-running
+ * function (self-upgrade < 1h; quiescence waits are budget-bounded), so nothing
+ * live is ever reaped.
+ */
+export const ORPHAN_REAP_AGE_HOURS = 24;
+
+/** Finished/aged Inngest bookkeeping older than this is trimmed to bound the DB.
+ *  Inngest history is pure operational telemetry — 7 days is ample for
+ *  debugging a recent run while keeping the tables tiny. */
+export const INNGEST_HISTORY_RETENTION_DAYS = 7;
+
+/** Rows deleted per batch. Keeps each DELETE small so the sweep never takes a
+ *  long lock on a hot Inngest table. */
+export const INNGEST_RETENTION_BATCH_SIZE = 2_000;
+
+/** Upper bound on rows purged per table per run. A fresh install with a huge
+ *  accumulated backlog catches up over several runs rather than one enormous
+ *  delete. A table that hits this is flagged `capped` in the report. */
+export const INNGEST_RETENTION_PER_TABLE_CAP = 200_000;
+
+/** Returns `now - hours`. */
+export function cutoffForHours(hours: number, now: Date): Date {
+  return new Date(now.getTime() - hours * MS_PER_HOUR);
+}
+
+/** Returns `now - days`. */
+export function cutoffForDays(days: number, now: Date): Date {
+  return new Date(now.getTime() - days * MS_PER_DAY);
+}
+
+/** Next :17 past the next 6-hour UTC boundary (00/06/12/18) strictly after
+ *  `from`. The 6h grid divides the day evenly, so flooring to a 6h block aligns
+ *  to UTC midnight. */
+export function nextInngestRetentionRunAt(from: Date): Date {
+  const blockStart = Math.floor(from.getTime() / SIX_HOURS_MS) * SIX_HOURS_MS;
+  let slot = blockStart + 17 * 60_000;
+  if (slot <= from.getTime()) slot += SIX_HOURS_MS;
+  return new Date(slot);
+}
+
+/**
+ * Resolve the connection string for the Inngest Postgres database (db=inngest).
+ * Prefers an explicit INNGEST_POSTGRES_URI (present on the inngest container);
+ * otherwise derives it from the portal's DATABASE_URL by swapping the database
+ * name to `inngest` — the two databases live on the same server. Prisma-only
+ * query params (schema, connection_limit, pgbouncer, …) are stripped so the
+ * plain `pg` client is not confused. Returns null when no source is available.
+ */
+export function resolveInngestDatabaseUrl(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  const explicit = env.INNGEST_POSTGRES_URI?.trim();
+  if (explicit) {
+    return /^postgres(ql)?:\/\//.test(explicit) ? explicit : `postgresql://${explicit}`;
+  }
+  const base = env.DATABASE_URL?.trim();
+  if (!base) return null;
+  try {
+    const u = new URL(base);
+    u.pathname = "/inngest";
+    u.search = "";
+    return u.toString();
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/operate/inngest-retention/execute.test.ts
+++ b/apps/web/lib/operate/inngest-retention/execute.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+
+import { runInngestRetentionSweep, type SqlRunner, type SqlResult } from "./execute";
+import {
+  resolveInngestDatabaseUrl,
+  nextInngestRetentionRunAt,
+} from "./constants";
+
+interface RecordedQuery {
+  text: string;
+  params: unknown[];
+}
+
+/**
+ * Fake SqlRunner. `deleteRowCounts` maps a table name to the sequence of
+ * rowCounts its batched DELETEs return (consumed in order); `counts` maps a
+ * table to the SELECT count(*) value for dry-run. A table missing from a map
+ * defaults to a single 0.
+ */
+function fakeSql(opts: {
+  deleteRowCounts?: Record<string, number[]>;
+  counts?: Record<string, number>;
+  throwOn?: string;
+}): { sql: SqlRunner; queries: RecordedQuery[] } {
+  const queries: RecordedQuery[] = [];
+  const deleteCursors: Record<string, number> = {};
+
+  function tableOf(text: string): string {
+    // "DELETE FROM <t> WHERE ctid …" or "SELECT count(*)::int AS c FROM <t> …"
+    const del = text.match(/DELETE FROM (\w+)/);
+    if (del) return del[1];
+    const sel = text.match(/FROM (\w+) WHERE/);
+    return sel ? sel[1] : "?";
+  }
+  // The orphan reap targets function_runs but must be distinguishable from the
+  // function_runs history trim. Both hit table "function_runs"; the orphan one
+  // carries the NOT EXISTS predicate.
+  function keyOf(text: string): string {
+    const t = tableOf(text);
+    if (t === "function_runs" && text.includes("NOT EXISTS")) {
+      return "function_runs:orphans";
+    }
+    return t;
+  }
+
+  const sql: SqlRunner = {
+    async query(text: string, params: unknown[] = []): Promise<SqlResult> {
+      queries.push({ text, params });
+      const key = keyOf(text);
+      if (opts.throwOn && key === opts.throwOn) {
+        throw new Error(`boom:${key}`);
+      }
+      if (text.startsWith("SELECT count")) {
+        const c = opts.counts?.[key] ?? 0;
+        return { rowCount: 1, rows: [{ c }] };
+      }
+      // batched DELETE
+      const seq = opts.deleteRowCounts?.[key] ?? [0];
+      const i = deleteCursors[key] ?? 0;
+      deleteCursors[key] = i + 1;
+      const n = i < seq.length ? seq[i] : 0;
+      return { rowCount: n, rows: [] };
+    },
+  };
+  return { sql, queries };
+}
+
+const NOW = new Date("2026-07-08T12:00:00.000Z");
+
+describe("runInngestRetentionSweep", () => {
+  it("dry run only counts — never issues a DELETE", async () => {
+    const { sql, queries } = fakeSql({
+      counts: {
+        "function_runs:orphans": 3,
+        function_runs: 5,
+        spans: 100,
+        traces: 400,
+        trace_runs: 7,
+        history: 20,
+        function_finishes: 5,
+      },
+    });
+    const report = await runInngestRetentionSweep({ sql, now: NOW, dryRun: true });
+
+    expect(queries.every((q) => q.text.startsWith("SELECT count"))).toBe(true);
+    expect(report.orphansReaped).toBe(3);
+    // historyTrimmed sums every history table (not the orphan reap)
+    expect(report.historyTrimmed).toBe(5 + 100 + 20 + 400 + 5 + 7);
+    expect(report.byTable["function_runs:orphans"]).toBe(3);
+    expect(report.byTable["spans"]).toBe(100);
+    expect(report.errorCount).toBe(0);
+  });
+
+  it("real run reaps orphans first, then trims each history table", async () => {
+    const { sql, queries } = fakeSql({
+      deleteRowCounts: {
+        "function_runs:orphans": [10, 0],
+        function_runs: [4, 0],
+        spans: [50, 0],
+        traces: [200, 0],
+        history: [0],
+        trace_runs: [7, 0],
+        function_finishes: [0],
+      },
+    });
+    const report = await runInngestRetentionSweep({ sql, now: NOW, dryRun: false });
+
+    const firstDelete = queries.find((q) => q.text.startsWith("DELETE"));
+    expect(firstDelete?.text).toContain("function_runs");
+    expect(firstDelete?.text).toContain("NOT EXISTS");
+
+    expect(report.orphansReaped).toBe(10);
+    expect(report.byTable["spans"]).toBe(50);
+    expect(report.byTable["traces"]).toBe(200);
+    expect(report.historyTrimmed).toBe(4 + 50 + 200 + 0 + 7 + 0);
+    expect(report.capped).toEqual([]);
+    expect(report.errorCount).toBe(0);
+  });
+
+  it("passes a Date cutoff for timestamp tables and a unix-ms number for trace_runs", async () => {
+    const { sql, queries } = fakeSql({ deleteRowCounts: {} });
+    await runInngestRetentionSweep({ sql, now: NOW, dryRun: false });
+
+    const spans = queries.find((q) => q.text.includes("DELETE FROM spans"));
+    expect(spans?.params[0]).toBeInstanceOf(Date);
+
+    const traceRuns = queries.find((q) => q.text.includes("DELETE FROM trace_runs"));
+    expect(typeof traceRuns?.params[0]).toBe("number");
+    // 7-day cutoff in unix ms
+    expect(traceRuns?.params[0]).toBe(NOW.getTime() - 7 * 86_400_000);
+    // trace_runs also guards ended_at > 0
+    expect(traceRuns?.text).toContain("ended_at > 0");
+  });
+
+  it("respects the per-table cap and flags the capped table", async () => {
+    // Every batch returns a full batch → never short → capped by count.
+    const { sql } = fakeSql({
+      deleteRowCounts: { spans: Array(1000).fill(10) },
+    });
+    const report = await runInngestRetentionSweep({
+      sql,
+      now: NOW,
+      dryRun: false,
+      batchSize: 10,
+      perTableCap: 50,
+    });
+    expect(report.byTable["spans"]).toBe(50);
+    expect(report.capped).toContain("spans");
+  });
+
+  it("a failing table is recorded and does not abort the rest", async () => {
+    const { sql } = fakeSql({
+      throwOn: "spans",
+      deleteRowCounts: {
+        "function_runs:orphans": [2, 0],
+        traces: [9, 0],
+      },
+    });
+    const report = await runInngestRetentionSweep({ sql, now: NOW, dryRun: false });
+
+    expect(report.errorCount).toBe(1);
+    expect(report.errors[0].table).toBe("spans");
+    // work after the failure still ran
+    expect(report.orphansReaped).toBe(2);
+    expect(report.byTable["traces"]).toBe(9);
+  });
+
+  it("partitions the finished-run history trim (EXISTS) from the orphan reap (NOT EXISTS)", async () => {
+    const { sql, queries } = fakeSql({ deleteRowCounts: {} });
+    await runInngestRetentionSweep({ sql, now: NOW, dryRun: false });
+
+    const fnRunsQueries = queries.filter((q) =>
+      q.text.includes("DELETE FROM function_runs"),
+    );
+    const orphanReap = fnRunsQueries.find((q) => q.text.includes("NOT EXISTS"));
+    const historyTrim = fnRunsQueries.find((q) => !q.text.includes("NOT EXISTS"));
+
+    expect(orphanReap).toBeTruthy();
+    expect(historyTrim).toBeTruthy();
+    // the history trim still requires a finish row to exist
+    expect(historyTrim?.text).toContain("EXISTS");
+  });
+});
+
+describe("resolveInngestDatabaseUrl", () => {
+  it("derives db=inngest from DATABASE_URL and strips prisma-only params", () => {
+    const url = resolveInngestDatabaseUrl({
+      DATABASE_URL:
+        "postgresql://dpf:secret@postgres:5432/dpf?schema=public&connection_limit=5",
+    });
+    expect(url).toBe("postgresql://dpf:secret@postgres:5432/inngest");
+  });
+
+  it("prefers an explicit INNGEST_POSTGRES_URI", () => {
+    const url = resolveInngestDatabaseUrl({
+      INNGEST_POSTGRES_URI: "postgres://u:p@postgres:5432/inngest",
+      DATABASE_URL: "postgresql://dpf:secret@postgres:5432/dpf",
+    });
+    expect(url).toBe("postgres://u:p@postgres:5432/inngest");
+  });
+
+  it("adds a scheme to a bare INNGEST_POSTGRES_URI", () => {
+    const url = resolveInngestDatabaseUrl({
+      INNGEST_POSTGRES_URI: "u:p@postgres:5432/inngest",
+    });
+    expect(url).toBe("postgresql://u:p@postgres:5432/inngest");
+  });
+
+  it("returns null with no source", () => {
+    expect(resolveInngestDatabaseUrl({})).toBeNull();
+  });
+});
+
+describe("nextInngestRetentionRunAt", () => {
+  it("returns the next :17 past a 6-hour UTC boundary", () => {
+    // 12:00 → next slot 12:17
+    expect(nextInngestRetentionRunAt(new Date("2026-07-08T12:00:00Z")).toISOString()).toBe(
+      "2026-07-08T12:17:00.000Z",
+    );
+    // 12:17 exactly → advance to 18:17
+    expect(nextInngestRetentionRunAt(new Date("2026-07-08T12:17:00Z")).toISOString()).toBe(
+      "2026-07-08T18:17:00.000Z",
+    );
+    // 23:30 → next day 00:17
+    expect(nextInngestRetentionRunAt(new Date("2026-07-08T23:30:00Z")).toISOString()).toBe(
+      "2026-07-09T00:17:00.000Z",
+    );
+  });
+});

--- a/apps/web/lib/operate/inngest-retention/execute.ts
+++ b/apps/web/lib/operate/inngest-retention/execute.ts
@@ -1,0 +1,252 @@
+// BI-0AB96FE7 — Pure Inngest-retention engine.
+//
+// Testable in isolation: everything the sweep does is expressed against an
+// injected `SqlRunner`, so unit tests assert the reap/trim behavior with a fake
+// runner and no live database. run.ts wires the real `pg` client (db=inngest)
+// and the operator kill switch around this.
+//
+// Design notes on the Inngest schema (verified against the live db=inngest):
+//   • run_id is encoded DIFFERENTLY per table — bytea in function_runs /
+//     function_finishes / history, text in spans, char(26) in trace_runs /
+//     traces. So we NEVER cross-join on run_id; every table is trimmed by its
+//     OWN timestamp column. This is both correct and lock-friendly.
+//   • Orphans (the executor-wedge root cause) live in function_runs: an
+//     UNFINISHED row older than the Redis-TTL ceiling. Reaping those rows stops
+//     the executor's infinite retry.
+//   • Table/column names below are compile-time constants from this module's
+//     own allowlist — never caller input — so interpolating them into SQL
+//     carries no injection surface; the time cutoff is always a bound param.
+
+import {
+  ORPHAN_REAP_AGE_HOURS,
+  INNGEST_HISTORY_RETENTION_DAYS,
+  INNGEST_RETENTION_BATCH_SIZE,
+  INNGEST_RETENTION_PER_TABLE_CAP,
+  cutoffForHours,
+  cutoffForDays,
+} from "./constants";
+
+export interface SqlResult {
+  rowCount: number | null;
+  rows: Array<Record<string, unknown>>;
+}
+
+/** Minimal surface of a `pg` client the engine needs. */
+export interface SqlRunner {
+  query(text: string, params?: unknown[]): Promise<SqlResult>;
+}
+
+export interface InngestRetentionSweepReport {
+  dryRun: boolean;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  /** Unfinished, Redis-orphaned function_runs removed (the wedge fix). */
+  orphansReaped: number;
+  /** Aged bookkeeping rows removed across all history tables. */
+  historyTrimmed: number;
+  /** Per-table removal counts (includes the `function_runs` orphan reap). */
+  byTable: Record<string, number>;
+  /** Tables that hit INNGEST_RETENTION_PER_TABLE_CAP this run (more remains). */
+  capped: string[];
+  errorCount: number;
+  errors: Array<{ table: string; error: string }>;
+}
+
+type TimeKind = "timestamp" | "unix_ms";
+
+interface HistoryTable {
+  table: string;
+  column: string;
+  kind: TimeKind;
+  /** Extra predicate ANDed with the age filter (constant SQL, no params). */
+  extra?: string;
+}
+
+// Aged-history trim targets. `function_runs` is restricted to FINISHED rows so
+// the partition with the orphan reap is clean (unfinished → reap at 24h;
+// finished → trim at the history window). `trace_runs.ended_at` is unix-ms and
+// 0 for a still-running trace, so it is guarded > 0.
+const HISTORY_TABLES: readonly HistoryTable[] = [
+  {
+    table: "function_runs",
+    column: "run_started_at",
+    kind: "timestamp",
+    extra:
+      "EXISTS (SELECT 1 FROM function_finishes f WHERE f.run_id = function_runs.run_id)",
+  },
+  { table: "function_finishes", column: "created_at", kind: "timestamp" },
+  { table: "spans", column: "start_time", kind: "timestamp" },
+  { table: "history", column: "created_at", kind: "timestamp" },
+  { table: "traces", column: "timestamp", kind: "timestamp" },
+  { table: "trace_runs", column: "ended_at", kind: "unix_ms", extra: "ended_at > 0" },
+];
+
+/** The orphan predicate: unfinished function_runs older than the cutoff. */
+const ORPHAN_PREDICATE =
+  "run_started_at < $1 AND NOT EXISTS " +
+  "(SELECT 1 FROM function_finishes f WHERE f.run_id = function_runs.run_id)";
+
+function agePredicate(t: HistoryTable): string {
+  const age = `${t.column} < $1`;
+  return t.extra ? `${age} AND ${t.extra}` : age;
+}
+
+/** Bound value for a table's age predicate: a Date for timestamp columns, a
+ *  unix-ms number for bigint columns. */
+function ageBound(kind: TimeKind, cutoff: Date): Date | number {
+  return kind === "unix_ms" ? cutoff.getTime() : cutoff;
+}
+
+async function countEligible(
+  sql: SqlRunner,
+  table: string,
+  predicate: string,
+  bound: Date | number,
+): Promise<number> {
+  const res = await sql.query(
+    `SELECT count(*)::int AS c FROM ${table} WHERE ${predicate}`,
+    [bound],
+  );
+  const c = res.rows[0]?.c;
+  return typeof c === "number" ? c : Number(c ?? 0);
+}
+
+/**
+ * Batched delete: repeatedly removes up to `batchSize` matching rows (selected
+ * by ctid so the LIMIT is honored) until a batch comes back short or the
+ * per-table cap is reached. Returns `{ deleted, capped }`.
+ */
+async function deleteBatched(
+  sql: SqlRunner,
+  table: string,
+  predicate: string,
+  bound: Date | number,
+  batchSize: number,
+  cap: number,
+): Promise<{ deleted: number; capped: boolean }> {
+  let deleted = 0;
+  for (;;) {
+    const remaining = cap - deleted;
+    if (remaining <= 0) return { deleted, capped: true };
+    const limit = Math.min(batchSize, remaining);
+    const res = await sql.query(
+      `DELETE FROM ${table} WHERE ctid IN ` +
+        `(SELECT ctid FROM ${table} WHERE ${predicate} LIMIT ${limit})`,
+      [bound],
+    );
+    const n = res.rowCount ?? 0;
+    deleted += n;
+    if (n < limit) return { deleted, capped: false };
+  }
+}
+
+/**
+ * Reap orphans, then trim aged history. Best-effort per table: a failure on one
+ * table is recorded and the sweep continues, so a single bad table can never
+ * abort the whole janitor (and re-wedge the executor). In dryRun mode nothing
+ * is deleted — each target is COUNTED instead, so the operator preview shows
+ * exactly what a real run would remove.
+ */
+export async function runInngestRetentionSweep(opts: {
+  sql: SqlRunner;
+  now: Date;
+  dryRun: boolean;
+  orphanAgeHours?: number;
+  retentionDays?: number;
+  batchSize?: number;
+  perTableCap?: number;
+}): Promise<InngestRetentionSweepReport> {
+  const {
+    sql,
+    now,
+    dryRun,
+    orphanAgeHours = ORPHAN_REAP_AGE_HOURS,
+    retentionDays = INNGEST_HISTORY_RETENTION_DAYS,
+    batchSize = INNGEST_RETENTION_BATCH_SIZE,
+    perTableCap = INNGEST_RETENTION_PER_TABLE_CAP,
+  } = opts;
+
+  const startedAt = now;
+  const orphanCutoff = cutoffForHours(orphanAgeHours, now);
+  const historyCutoff = cutoffForDays(retentionDays, now);
+
+  const byTable: Record<string, number> = {};
+  const capped: string[] = [];
+  const errors: Array<{ table: string; error: string }> = [];
+  let orphansReaped = 0;
+  let historyTrimmed = 0;
+
+  // 1) Orphan reap — the executor-wedge fix. Runs first and unconditionally.
+  try {
+    if (dryRun) {
+      orphansReaped = await countEligible(
+        sql,
+        "function_runs",
+        ORPHAN_PREDICATE,
+        orphanCutoff,
+      );
+    } else {
+      const r = await deleteBatched(
+        sql,
+        "function_runs",
+        ORPHAN_PREDICATE,
+        orphanCutoff,
+        batchSize,
+        perTableCap,
+      );
+      orphansReaped = r.deleted;
+      if (r.capped) capped.push("function_runs:orphans");
+    }
+    byTable["function_runs:orphans"] = orphansReaped;
+  } catch (err) {
+    errors.push({
+      table: "function_runs:orphans",
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // 2) Aged-history trim, per table by its own timestamp.
+  for (const t of HISTORY_TABLES) {
+    const predicate = agePredicate(t);
+    const bound = ageBound(t.kind, historyCutoff);
+    try {
+      let removed: number;
+      if (dryRun) {
+        removed = await countEligible(sql, t.table, predicate, bound);
+      } else {
+        const r = await deleteBatched(
+          sql,
+          t.table,
+          predicate,
+          bound,
+          batchSize,
+          perTableCap,
+        );
+        removed = r.deleted;
+        if (r.capped) capped.push(t.table);
+      }
+      byTable[t.table] = (byTable[t.table] ?? 0) + removed;
+      historyTrimmed += removed;
+    } catch (err) {
+      errors.push({
+        table: t.table,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const finishedAt = new Date();
+  return {
+    dryRun,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: finishedAt.getTime() - startedAt.getTime(),
+    orphansReaped,
+    historyTrimmed,
+    byTable,
+    capped,
+    errorCount: errors.length,
+    errors,
+  };
+}

--- a/apps/web/lib/operate/inngest-retention/run.ts
+++ b/apps/web/lib/operate/inngest-retention/run.ts
@@ -1,0 +1,161 @@
+// BI-0AB96FE7 — Scheduled Inngest-retention orchestration.
+//
+// Wraps the pure engine (execute.ts) with the live-system concerns the inngest
+// function needs: the operator kill switch (ScheduledJob.enabled), the
+// connection to the SEPARATE db=inngest database (the portal's Prisma client
+// only speaks db=dpf), and persistence of the run heartbeat + a compact,
+// durable summary of what was reaped (ScheduledJob.metadata outlives Loki's
+// 14-day log retention).
+
+import { type Prisma } from "@dpf/db";
+
+import {
+  runInngestRetentionSweep,
+  type InngestRetentionSweepReport,
+  type SqlRunner,
+} from "./execute";
+import {
+  INNGEST_RETENTION_JOB_ID,
+  nextInngestRetentionRunAt,
+  resolveInngestDatabaseUrl,
+} from "./constants";
+
+export interface ScheduledInngestRetentionResult
+  extends InngestRetentionSweepReport {
+  /** True when the operator disabled the job (ScheduledJob.enabled=false). */
+  skipped?: boolean;
+  skipReason?: string;
+}
+
+/** Keep the last N per-run summaries on the heartbeat row for the admin view. */
+const MAX_RECENT_RUNS = 10;
+
+function emptyReport(
+  now: Date,
+  dryRun: boolean,
+  skipReason: string,
+): ScheduledInngestRetentionResult {
+  return {
+    dryRun,
+    startedAt: now.toISOString(),
+    finishedAt: now.toISOString(),
+    durationMs: 0,
+    orphansReaped: 0,
+    historyTrimmed: 0,
+    byTable: {},
+    capped: [],
+    errorCount: skipReason === "disabled-by-operator" ? 0 : 1,
+    errors:
+      skipReason === "disabled-by-operator"
+        ? []
+        : [{ table: "(connection)", error: skipReason }],
+    skipped: true,
+    skipReason,
+  };
+}
+
+function summarizeForMetadata(report: InngestRetentionSweepReport) {
+  return {
+    at: report.finishedAt,
+    dryRun: report.dryRun,
+    orphansReaped: report.orphansReaped,
+    historyTrimmed: report.historyTrimmed,
+    byTable: report.byTable,
+    capped: report.capped,
+    errorCount: report.errorCount,
+    durationMs: report.durationMs,
+    errors: report.errors,
+  };
+}
+
+/**
+ * Execute an Inngest-retention sweep as the scheduled/manual job would.
+ * - Honors the operator kill switch (ScheduledJob.enabled === false → skip).
+ * - Opens a short-lived `pg` connection to db=inngest (derived from
+ *   DATABASE_URL, or an explicit INNGEST_POSTGRES_URI).
+ * - On a real (non-dry) run, persists lastRunAt/lastStatus/nextRunAt and pushes
+ *   a compact summary onto ScheduledJob.metadata.recentRuns.
+ *
+ * Never throws for an expected operational condition (job disabled, DB
+ * unreachable): those return a `skipped` report so the Inngest function stays
+ * green and does not retry a wedge into existence.
+ */
+export async function executeScheduledInngestRetentionSweep(opts: {
+  dryRun: boolean;
+  now?: Date;
+  env?: Record<string, string | undefined>;
+}): Promise<ScheduledInngestRetentionResult> {
+  const { dryRun } = opts;
+  const now = opts.now ?? new Date();
+  const env = opts.env ?? process.env;
+
+  const { prisma } = await import("@dpf/db");
+
+  // Operator kill switch. A maintenance sweep MUST be disableable without code.
+  const job = await prisma.scheduledJob
+    .findUnique({
+      where: { jobId: INNGEST_RETENTION_JOB_ID },
+      select: { enabled: true, metadata: true },
+    })
+    .catch(() => null);
+
+  if (job && job.enabled === false) {
+    return emptyReport(now, dryRun, "disabled-by-operator");
+  }
+
+  const connectionString = resolveInngestDatabaseUrl(env);
+  if (!connectionString) {
+    return emptyReport(now, dryRun, "no-inngest-db-url");
+  }
+
+  let report: InngestRetentionSweepReport;
+  let client: { end: () => Promise<void> } | null = null;
+  try {
+    const { Client } = await import("pg");
+    const pgClient = new Client({ connectionString });
+    client = pgClient;
+    await pgClient.connect();
+    report = await runInngestRetentionSweep({
+      sql: pgClient as unknown as SqlRunner,
+      now,
+      dryRun,
+    });
+  } catch (err) {
+    return emptyReport(
+      now,
+      dryRun,
+      err instanceof Error ? err.message : "inngest-db-connect-failed",
+    );
+  } finally {
+    await client?.end().catch(() => {});
+  }
+
+  if (!dryRun) {
+    const prior = (job?.metadata ?? {}) as { recentRuns?: unknown[] };
+    const recentRuns = Array.isArray(prior.recentRuns) ? prior.recentRuns : [];
+    const nextRecent = [summarizeForMetadata(report), ...recentRuns].slice(
+      0,
+      MAX_RECENT_RUNS,
+    );
+
+    await prisma.scheduledJob
+      .update({
+        where: { jobId: INNGEST_RETENTION_JOB_ID },
+        data: {
+          lastRunAt: new Date(report.finishedAt),
+          lastStatus: report.errorCount > 0 ? "error" : "ok",
+          lastError:
+            report.errorCount > 0
+              ? `${report.errorCount} table error(s)`
+              : null,
+          nextRunAt: nextInngestRetentionRunAt(now),
+          metadata: { recentRuns: nextRecent } as Prisma.InputJsonValue,
+        },
+      })
+      .catch(() => {
+        // Heartbeat is best-effort; the reap itself already happened.
+      });
+  }
+
+  return report;
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -213,6 +213,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: "ops/data-retention.requested",
   },
   {
+    jobId: "inngest-retention-sweep",
+    inngestId: "ops/inngest-retention-sweep-scheduled",
+    name: "Inngest retention sweep",
+    purpose:
+      "Bounds the self-hosted Inngest history database (function_runs, spans, traces, …) and reaps runs orphaned when their Redis state TTL-expires. Without it the orphans accumulate unbounded until the single executor chokes and drives ZERO executions — a silent, total outage of all scheduled and autonomous dispatch (BI-0AB96FE7). Editable so an operator can disable or run-now this maintenance sweep.",
+    cron: "17 */6 * * *",
+    cadence: "Every 6 hours",
+    category: "editable",
+    tracksRunData: true,
+    runNowEvent: "ops/inngest-retention.requested",
+  },
+  {
     jobId: "mdm-steward-sweep",
     inngestId: "ops/mdm-steward-sweep-scheduled",
     name: "MDM Data Steward sweep",

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -55,6 +55,10 @@ import {
   dataRetentionSweepScheduled,
   dataRetentionSweepRequested,
 } from "./data-retention-sweep";
+import {
+  inngestRetentionSweepScheduled,
+  inngestRetentionSweepRequested,
+} from "./inngest-retention-sweep";
 import { logSignatureScanner } from "./log-signature-scanner";
 import { edgeIncidentCorrelation } from "./edge-incident-correlation";
 import { remoteActionClaimTimeout } from "./remote-action-claim-timeout";
@@ -94,6 +98,7 @@ export const scheduledFunctions = [
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
   dataRetentionSweepScheduled, // EP-DATA-RETENTION: daily DB purge of aged logs/telemetry/chat, 04:00
+  inngestRetentionSweepScheduled, // BI-0AB96FE7: bound db=inngest history + reap Redis-TTL orphans that wedge the executor, every 6h
   mdmStewardSweepScheduled, // EP-4A12A7CB slice 4: autonomous Data Steward — sweep + auto-resolve account dupes, daily 05:00
   logSignatureScanner,   // BI-5FE8656F: EP-FULL-OBS Tier 2 novel-signature log scan, every 15m
   edgeIncidentCorrelation, // EP-MSP-FEDERATION A2+A3: correlate edge alerts->incidents->customer tickets, every 10m (flag-gated)
@@ -132,6 +137,7 @@ export const eventFunctions = [
   selfUpgradeManual,
   quiescenceRun,
   dataRetentionSweepRequested, // EP-DATA-RETENTION: operator "run now" / dry-run
+  inngestRetentionSweepRequested, // BI-0AB96FE7: operator "run now" / dry-run for the Inngest retention sweep
   mdmStewardSweepRequested, // EP-4A12A7CB slice 4: Data Steward "run now" / dry-run
 ];
 

--- a/apps/web/lib/queue/functions/inngest-retention-sweep.ts
+++ b/apps/web/lib/queue/functions/inngest-retention-sweep.ts
@@ -1,0 +1,65 @@
+// BI-0AB96FE7 (EP-B9DD37C7) — Scheduled Inngest history-retention + orphan reap.
+//
+// Prevention item #1 for the Inngest executor wedge: the self-hosted Inngest
+// Postgres history (function_runs, spans, …) has no TTL/GC, and runs whose
+// Redis {estate} state TTL-expires strand as orphans the single executor
+// retries forever — until it chokes and drives ZERO executions (a silent, total
+// outage of all scheduled + autonomous dispatch). This janitor bounds the
+// history and reaps the orphans on a schedule so the executor can never starve.
+//
+// Runs every 6 hours. Quiescence-gated (skips cleanly during a self-upgrade
+// drain) and concurrency-limited to one in-flight run. The operator kill switch
+// (ScheduledJob.enabled=false) is honored inside the runner.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  INNGEST_RETENTION_CRON,
+  INNGEST_RETENTION_REQUESTED_EVENT,
+  INNGEST_RETENTION_SCHEDULED_INNGEST_ID,
+  INNGEST_RETENTION_REQUESTED_INNGEST_ID,
+} from "@/lib/operate/inngest-retention/constants";
+
+export const inngestRetentionSweepScheduled = inngest.createFunction(
+  {
+    id: INNGEST_RETENTION_SCHEDULED_INNGEST_ID,
+    retries: 1,
+    // One sweep at a time. A still-running sweep (catching up a large backlog)
+    // must not overlap the next trigger.
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(INNGEST_RETENTION_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("inngest-retention-sweep", async () => {
+      const { executeScheduledInngestRetentionSweep } = await import(
+        "@/lib/operate/inngest-retention/run"
+      );
+      return executeScheduledInngestRetentionSweep({ dryRun: false });
+    });
+  },
+);
+
+// Manual one-shot trigger for the admin "run now" action. Supports a dry-run
+// (count-only) preview via `event.data.dryRun = true`.
+export const inngestRetentionSweepRequested = inngest.createFunction(
+  {
+    id: INNGEST_RETENTION_REQUESTED_INNGEST_ID,
+    retries: 1,
+    triggers: [{ event: INNGEST_RETENTION_REQUESTED_EVENT }],
+  },
+  async ({ event, step }) => {
+    const dryRun = Boolean(
+      (event.data as { dryRun?: boolean } | undefined)?.dryRun,
+    );
+    return step.run("inngest-retention-sweep-manual", async () => {
+      const { executeScheduledInngestRetentionSweep } = await import(
+        "@/lib/operate/inngest-retention/run"
+      );
+      return executeScheduledInngestRetentionSweep({ dryRun });
+    });
+  },
+);

--- a/apps/web/lib/queue/inngest-client.ts
+++ b/apps/web/lib/queue/inngest-client.ts
@@ -175,6 +175,14 @@ export interface PortalSelfUpgradeRequestedEvent {
   };
 }
 
+/** BI-0AB96FE7: operator "run now" / dry-run for the Inngest history-retention
+ *  + orphan-reaper sweep (handled by inngest-retention-sweep.ts). `dryRun`
+ *  counts eligible rows without deleting. */
+export interface OpsInngestRetentionRequestedEvent {
+  name: "ops/inngest-retention.requested";
+  data: { dryRun?: boolean };
+}
+
 // ─── Activity Quiescence Protocol events (BI-QUIESCE-002) ────────────────
 
 /** Sent by callers to start a quiescence drain. The coordinator function

--- a/docs/superpowers/plans/2026-07-08-inngest-retention-janitor-plan.md
+++ b/docs/superpowers/plans/2026-07-08-inngest-retention-janitor-plan.md
@@ -1,0 +1,76 @@
+# Inngest history-retention + orphan-reaper janitor (BI-0AB96FE7, EP-B9DD37C7)
+
+**Status:** Slice 1 implemented — this PR.
+**BI:** BI-0AB96FE7 (priority-1 bug, triage: build). Claim capsule WC-AD5235EF.
+**Kernel decision:** `principle_decide` (reliability-hardening-scope) recommended
+**janitor-first-slice** with high confidence (composite 11.13, margin 3.05) over
+"all-three-now" (6.36) and "promote-build-studio" (8.09).
+
+## Problem
+
+Self-hosted Inngest v1.30 splits run state: live state in Redis under a
+~12–16h TTL; durable history in Postgres `db=inngest` (`function_runs`, `spans`,
+`traces`, `history`, `trace_runs`, `function_finishes`) with **no TTL and no
+GC**. When a run's Redis `{estate}` state TTL-expires, its Postgres rows strand;
+the single executor retries the orphan forever (`run not found in state store` +
+`duplicate key spans_pkey`). Orphans accumulate unbounded (21,838 unfinished
+`function_runs` / ~987k spans at the choke point) until the executor chokes and
+drives **zero** executions — a silent, total outage of all scheduled and
+autonomous dispatch. A self-upgrade is only the tipping point, not the cause.
+
+The 2026-07-07 manual drain recovered the system but is a one-shot runbook.
+Notably it truncated `trace_runs` but **not** `traces`, which still holds
+338,514 rows older than 7 days — the largest single unbounded table.
+
+## Slice 1 — this PR (non-destructive prevention)
+
+A scheduled janitor that bounds the history and reaps orphans before they can
+starve the executor. Modeled exactly on the `data-retention-sweep` pattern.
+
+- `apps/web/lib/operate/inngest-retention/constants.ts` — ids, `17 */6 * * *`
+  cron, 24h orphan-age / 7d history windows, `resolveInngestDatabaseUrl` (derive
+  `db=inngest` from `DATABASE_URL`, or explicit `INNGEST_POSTGRES_URI`).
+- `execute.ts` — pure engine over an injected `SqlRunner`: reap unfinished
+  `function_runs` older than 24h (Redis state provably gone), then trim each
+  history table by its **own** timestamp (run_id is encoded differently per
+  table — bytea/text/char(26) — so never cross-join). Batched ctid deletes,
+  per-table cap, best-effort per table, dry-run = count-only.
+- `run.ts` — operator kill switch (`ScheduledJob.enabled`), short-lived `pg`
+  connection to `db=inngest`, heartbeat + recent-run summary persistence.
+- `apps/web/lib/queue/functions/inngest-retention-sweep.ts` — scheduled +
+  requested Inngest functions, quiescence-gated, concurrency 1.
+- Registry: `functions/index.ts`, catalog: `scheduled-jobs/catalog.ts`
+  (parity-tested), seed: `packages/db/src/seed-platform-inngest-retention.ts`.
+
+### Why 24h orphan age
+
+Observed Redis `{estate}` TTLs are ~12–16h. An unfinished `function_runs` row
+older than 24h has certainly lost its Redis state (so it can never complete),
+while no legitimate function runs that long (self-upgrade < 1h; quiescence waits
+are budget-bounded). 24h is therefore both safe and exactly equivalent to the
+BI's "Redis state is gone" signal — reachable without Redis credentials.
+
+## Deferred to follow-up slices (filed intent, not this PR)
+
+2. **Executor-starvation probe + auto-recovery.** A health probe that detects
+   "cron timers firing but 0 executions in N min" **cannot** be an Inngest cron
+   (chicken-and-egg when Inngest is wedged) — it must be an external portal-side
+   watchdog, and auto-drain is destructive (Redis `FLUSHALL` + container
+   restart) needing a docker capability the portal does not hold today. Higher
+   blast radius; belt-and-suspenders once Slice 1 keeps orphans from ever
+   reaching the choke point.
+3. **Config hardening.** Align Redis run-state TTL with Postgres, audit
+   every-minute crons (`taskrun-watchdog` is a deliberate liveness guard — do
+   not widen carelessly), consider an Inngest version bump.
+
+## Verification
+
+- Unit: `execute.test.ts` (11) — reap-then-trim ordering, dry-run counts only,
+  Date vs unix-ms bounds, per-table cap flag, per-table error isolation,
+  EXISTS/NOT-EXISTS partition; plus `resolveInngestDatabaseUrl` +
+  `nextInngestRetentionRunAt`.
+- Live schema: every predicate run against `db=inngest` returns valid counts;
+  the ctid batched DELETE plan is valid. First real run trims 338,514 stale
+  `traces` rows (capped over 2 runs).
+- Post-deploy: operator "run now" with `dryRun:true` preview, then a real run;
+  confirm `ScheduledJob(inngest-retention-sweep)` heartbeat + `recentRuns`.

--- a/packages/db/src/seed-platform-inngest-retention.ts
+++ b/packages/db/src/seed-platform-inngest-retention.ts
@@ -1,0 +1,70 @@
+import type { PrismaClient } from "../generated/client/client";
+
+/**
+ * Schedule + identifier constants for the platform-managed Inngest-retention
+ * sweep (BI-0AB96FE7).
+ *
+ * The ScheduledJob row is the live heartbeat surfaced in the Scheduled Jobs
+ * admin view (carries recent-run summaries in `metadata`) AND the operator kill
+ * switch (`enabled=false` disables the sweep without a code change).
+ *
+ * These identifiers are duplicated (intentionally — packages/db cannot import
+ * from apps/web) in apps/web/lib/operate/inngest-retention/constants.ts. If you
+ * change one, change both, or the heartbeat row will be orphaned.
+ */
+export const INNGEST_RETENTION_JOB_ID = "inngest-retention-sweep";
+export const INNGEST_RETENTION_JOB_NAME =
+  "Inngest retention sweep (platform-managed)";
+export const INNGEST_RETENTION_SCHEDULE = "every-6-hours";
+
+type ScheduledJobSeedClient = Pick<PrismaClient, "scheduledJob">;
+
+const SIX_HOURS_MS = 6 * 3_600_000;
+
+/** Next :17 past the next 6-hour UTC boundary (00/06/12/18) after `from`. */
+function nextInngestRetentionRunAt(from: Date): Date {
+  const blockStart = Math.floor(from.getTime() / SIX_HOURS_MS) * SIX_HOURS_MS;
+  let slot = blockStart + 17 * 60_000;
+  if (slot <= from.getTime()) slot += SIX_HOURS_MS;
+  return new Date(slot);
+}
+
+/**
+ * Idempotent: create the Inngest-retention ScheduledJob heartbeat row if
+ * missing; refresh name/schedule/nextRunAt on every seed run. Does not clobber
+ * lastRunAt / lastStatus / lastError / metadata / enabled — those are owned by
+ * the runner and the operator (the `enabled` flag is the kill switch).
+ */
+export async function ensureInngestRetentionScheduledJob(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  const nextRunAt = nextInngestRetentionRunAt(now);
+
+  const existing = await prisma.scheduledJob.findUnique({
+    where: { jobId: INNGEST_RETENTION_JOB_ID },
+    select: { jobId: true, nextRunAt: true },
+  });
+
+  if (existing) {
+    await prisma.scheduledJob.update({
+      where: { jobId: INNGEST_RETENTION_JOB_ID },
+      data: {
+        name: INNGEST_RETENTION_JOB_NAME,
+        schedule: INNGEST_RETENTION_SCHEDULE,
+        nextRunAt: existing.nextRunAt ?? nextRunAt,
+      },
+    });
+    return { created: false };
+  }
+
+  await prisma.scheduledJob.create({
+    data: {
+      jobId: INNGEST_RETENTION_JOB_ID,
+      name: INNGEST_RETENTION_JOB_NAME,
+      schedule: INNGEST_RETENTION_SCHEDULE,
+      nextRunAt,
+    },
+  });
+  return { created: true };
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -67,6 +67,7 @@ import { ensureSysmlProjectionScheduledTask } from "./seed-sysml-projection.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
 import { ensureAllBackupScheduledJobs } from "./seed-platform-backup.js";
 import { ensureDataRetentionScheduledJob } from "./seed-platform-retention.js";
+import { ensureInngestRetentionScheduledJob } from "./seed-platform-inngest-retention.js";
 import { ensureContributorInventoryScheduledJob } from "./seed-contributor-inventory.js";
 import { seedAgentControlPlaneMaturity } from "./seed-agent-control-plane-maturity.js";
 import { seedCoworkerServiceCatalog } from "./coworker-service-catalog-seed.js";
@@ -2419,6 +2420,7 @@ async function main(): Promise<void> {
   await step("hiveScoutScheduledTask", () => ensureHiveScoutScheduledTask(prisma));
   await step("allBackupScheduledJobs", () => ensureAllBackupScheduledJobs(prisma));
   await step("dataRetentionScheduledJob", () => ensureDataRetentionScheduledJob(prisma));
+  await step("inngestRetentionScheduledJob", () => ensureInngestRetentionScheduledJob(prisma));
   await step("contributorInventoryScheduledJob", () => ensureContributorInventoryScheduledJob(prisma));
   await step("mcpServers", () => seedMcpServers());
   await step("sandboxPool", () => seedSandboxPool());


### PR DESCRIPTION
## Problem (BI-0AB96FE7, EP-B9DD37C7 — priority-1 build bug)

Self-hosted Inngest v1.30 splits run state: live state in Redis under a ~12–16h TTL; durable history in Postgres `db=inngest` (`function_runs`, `spans`, `traces`, `history`, `trace_runs`, `function_finishes`) with **no TTL and no GC**. When a run's Redis `{estate}` state TTL-expires, its Postgres rows strand and the single executor retries the orphan forever (`run not found in state store` + `duplicate key spans_pkey`). Orphans accumulate unbounded (21,838 unfinished `function_runs` / ~987k spans at the choke point) until the executor chokes and drives **zero** executions — a silent, total outage of all scheduled + autonomous dispatch. A self-upgrade is only the tipping point, not the cause.

The 2026-07-07 manual drain recovered the system but is a one-shot runbook — and notably truncated `trace_runs` but **not** `traces`, which still holds **338,514 rows older than 7 days** (the single largest unbounded table).

## This PR — Slice 1 (non-destructive prevention)

Kernel `principle_decide` chose **janitor-first** with high confidence (composite 11.13, margin 3.05) over an all-at-once build and Build-Studio promotion.

A scheduled janitor, modeled exactly on `data-retention-sweep`, that bounds the history and reaps orphans **before** they can starve the executor:

- **Orphan reap** — deletes unfinished `function_runs` older than **24h**. Observed Redis TTLs are ~12–16h, so a 24h-old unfinished run has provably lost its Redis state (can never complete) while no legitimate function runs that long. This is the BI's "Redis state is gone" signal, reachable **without** Redis credentials.
- **History trim** — deletes aged rows from each table by its **own** timestamp (run_id is encoded differently per table — bytea/text/char(26) — so it never cross-joins). Batched `ctid` deletes, per-table cap (catches up a huge backlog over several runs), best-effort per table, **dry-run = count-only**.
- Operator kill switch (`ScheduledJob.enabled`), quiescence-gated, concurrency 1, runs every 6h. Short-lived `pg` connection to `db=inngest` derived from `DATABASE_URL`.

### Deferred to follow-up slices (documented in the plan, not this PR)
2. **Executor-starvation probe + auto-recovery** — a "cron firing but 0 executions" probe **cannot** be an Inngest cron (chicken-and-egg when Inngest is wedged); it must be an external portal watchdog, and auto-drain is destructive (Redis `FLUSHALL` + container restart) needing a docker capability the portal lacks today.
3. **Config hardening** — Redis TTL alignment, cron audit (`taskrun-watchdog` is a deliberate every-minute liveness guard — do not widen carelessly), possible version bump.

## Verification

- **Unit:** `execute.test.ts` (11) — reap-then-trim ordering, dry-run counts only, `Date` vs unix-ms bounds, per-table cap flag, per-table error isolation, EXISTS/NOT-EXISTS partition; plus `resolveInngestDatabaseUrl` + `nextInngestRetentionRunAt`.
- **Live schema:** every predicate run against `db=inngest` returns valid counts; the batched `ctid` DELETE plan is valid; first real run trims the 338k stale `traces` rows (capped over 2 runs).
- **Typecheck:** `apps/web` + `@dpf/db` clean.
- **Post-deploy:** operator "run now" with `dryRun:true` preview, then a real run; confirm the `inngest-retention-sweep` heartbeat + `recentRuns`.

Plan: `docs/superpowers/plans/2026-07-08-inngest-retention-janitor-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)