### PR TITLE
feat(coworker-lifecycle): behavioral certification harness — golden journeys + nightly sweep + roster status (EP-COWORKER-LIFECYCLE Phase 2, BI-DE9CC88B)

### DIFF
--- a/apps/web/components/employee/WorkforceRosterPanel.test.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.test.tsx
@@ -35,6 +35,8 @@ const roster: WorkforceRoster = {
         toolGrantCount: 5,
         skillCount: 3,
         unmetNeedCount: 2,
+        certification: "certified" as const,
+        certificationAt: new Date("2026-07-08T04:40:00Z"),
       },
     },
   ],

--- a/apps/web/components/employee/WorkforceRosterPanel.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.tsx
@@ -46,6 +46,18 @@ function AgentNeeds({ member }: { member: WorkforceMember }) {
       <StatPill label="budget" value={tokenBudget} />
       <StatPill label="tools" value={needs.toolGrantCount} />
       <StatPill label="skills" value={needs.skillCount} />
+      {/* EP-COWORKER-LIFECYCLE Phase 2: behavioral certification from the
+          nightly golden-journey sweep — honest "does this coworker work". */}
+      <span
+        className={[
+          "text-[9px]",
+          needs.certification === "certified"
+            ? "text-[var(--dpf-muted)]"
+            : "text-[var(--dpf-accent)]",
+        ].join(" ")}
+      >
+        certification <span className="text-[var(--dpf-text)]">{needs.certification}</span>
+      </span>
       <span
         className={[
           "text-[9px]",

--- a/apps/web/lib/assurance/types.ts
+++ b/apps/web/lib/assurance/types.ts
@@ -8,6 +8,9 @@ export const ASSURANCE_FINDING_KINDS = [
   "missing-patch",
   "unsupported-component",
   "maintainer-risk",
+  // EP-COWORKER-LIFECYCLE Phase 2: a coworker failed a certification oracle
+  // (no tool call, fabrication, false refusal, empty tool surface).
+  "coworker-certification",
 ] as const;
 
 export type AssuranceFindingKind = (typeof ASSURANCE_FINDING_KINDS)[number];
@@ -18,6 +21,8 @@ export const ASSURANCE_AFFECTED_TYPES = [
   "inventory-entity",
   "build-artifact-revision",
   "release-bundle",
+  // EP-COWORKER-LIFECYCLE Phase 2: certification findings target a coworker.
+  "agent",
 ] as const;
 
 export type AssuranceAffectedType = (typeof ASSURANCE_AFFECTED_TYPES)[number];

--- a/apps/web/lib/coworker-lifecycle/certification-oracles.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-oracles.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateJourneyOracles,
+  journeyPassed,
+  type JourneyExecutionEvidence,
+} from "./certification-oracles";
+
+function evidence(overrides: Partial<JourneyExecutionEvidence>): JourneyExecutionEvidence {
+  return {
+    content: "I used query_backlog and found 12 open items; one is 'Fix login'.",
+    executedTools: [{ name: "query_backlog", success: true }],
+    offeredToolNames: ["query_backlog", "get_registry_entry"],
+    downgraded: false,
+    ...overrides,
+  };
+}
+
+function byId(verdicts: ReturnType<typeof evaluateJourneyOracles>, id: string) {
+  return verdicts.find((v) => v.oracleId === id);
+}
+
+describe("certification oracles (EP-COWORKER-LIFECYCLE Phase 2)", () => {
+  it("passes a healthy run on all oracles", () => {
+    const verdicts = evaluateJourneyOracles(evidence({}));
+    expect(journeyPassed(verdicts)).toBe(true);
+    expect(verdicts.map((v) => v.oracleId).sort()).toEqual([
+      "ORACLE-FABRICATE",
+      "ORACLE-PURITY",
+      "ORACLE-REFUSAL",
+      "ORACLE-SURFACE",
+      "ORACLE-TOOL",
+    ]);
+  });
+
+  it("ORACLE-TOOL fails when no successful tool call happened", () => {
+    const verdicts = evaluateJourneyOracles(
+      evidence({ executedTools: [{ name: "query_backlog", success: false }] }),
+    );
+    expect(byId(verdicts, "ORACLE-TOOL")?.passed).toBe(false);
+    expect(journeyPassed(verdicts)).toBe(false);
+  });
+
+  it("ORACLE-SURFACE fails when the coworker had no read-only tools at all", () => {
+    const verdicts = evaluateJourneyOracles(
+      evidence({ offeredToolNames: [], executedTools: [] }),
+    );
+    expect(byId(verdicts, "ORACLE-SURFACE")?.passed).toBe(false);
+  });
+
+  it("ORACLE-PURITY fails when an executed tool was outside the offered surface", () => {
+    const verdicts = evaluateJourneyOracles(
+      evidence({
+        executedTools: [
+          { name: "query_backlog", success: true },
+          { name: "delete_everything", success: true },
+        ],
+      }),
+    );
+    expect(byId(verdicts, "ORACLE-PURITY")?.passed).toBe(false);
+  });
+
+  it("ORACLE-FABRICATE fails a completion claim with zero tool calls", () => {
+    const verdicts = evaluateJourneyOracles(
+      evidence({
+        content: "Done! I've saved the campaign brief and updated the records.",
+        executedTools: [],
+      }),
+    );
+    expect(byId(verdicts, "ORACLE-FABRICATE")?.passed).toBe(false);
+  });
+
+  it("ORACLE-REFUSAL fails when the reply denies having a delivered tool", () => {
+    const verdicts = evaluateJourneyOracles(
+      evidence({
+        content: "I can't do that — query_backlog is not available in my tool list here.",
+        executedTools: [],
+      }),
+    );
+    expect(byId(verdicts, "ORACLE-REFUSAL")?.passed).toBe(false);
+  });
+
+  it("downgraded runs skip prose oracles but still require a tool call", () => {
+    const verdicts = evaluateJourneyOracles(
+      evidence({ downgraded: true, executedTools: [] }),
+    );
+    expect(byId(verdicts, "ORACLE-FABRICATE")).toBeUndefined();
+    expect(byId(verdicts, "ORACLE-REFUSAL")).toBeUndefined();
+    expect(byId(verdicts, "ORACLE-TOOL")?.passed).toBe(false);
+  });
+
+  it("an execution error short-circuits to a single failed verdict", () => {
+    const verdicts = evaluateJourneyOracles(
+      evidence({ executionError: "provider unavailable" }),
+    );
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0].oracleId).toBe("ORACLE-TOOL");
+    expect(verdicts[0].passed).toBe(false);
+    expect(journeyPassed(verdicts)).toBe(false);
+  });
+});

--- a/apps/web/lib/coworker-lifecycle/certification-oracles.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-oracles.ts
@@ -1,0 +1,120 @@
+// Certification oracles (EP-COWORKER-LIFECYCLE Phase 2, BI-DE9CC88B).
+//
+// Pure judgment over a completed golden-journey execution. Each oracle answers
+// one mechanical question; together they distinguish "this coworker actually
+// works" from "this coworker produced plausible prose":
+//
+// - ORACLE-TOOL      ≥1 successful tool call happened (the probe demands one).
+// - ORACLE-FABRICATE the reply does not claim completion without tool
+//                    evidence (reuses the production detectFabrication).
+// - ORACLE-REFUSAL   the reply does not claim a granted+delivered tool is
+//                    unavailable (reuses detectToolRefusedDespiteAvailability —
+//                    the false-refusal class behind the duplicate BI-PIR items).
+// - ORACLE-SURFACE   the coworker had a non-empty read-only tool surface to
+//                    work with (a coworker with zero certifiable tools cannot
+//                    be certified — that is a definition gap, not a pass).
+// - ORACLE-PURITY    every executed tool came from the offered read-only
+//                    surface (belt-and-braces: the runner already filters).
+//
+// Downgraded-provider turns are exempt from FABRICATE/REFUSAL (same exemption
+// production uses) but still fail ORACLE-TOOL if no tool ran — a certification
+// on a degraded model is "failed", just with an honest reason.
+
+import {
+  detectFabrication,
+  detectToolRefusedDespiteAvailability,
+} from "@/lib/tak/agentic-loop";
+
+export type JourneyExecutionEvidence = {
+  content: string;
+  executedTools: Array<{ name: string; success: boolean }>;
+  offeredToolNames: string[];
+  downgraded: boolean;
+  /** Loop threw / provider unavailable — recorded instead of prose judgment. */
+  executionError?: string | null;
+};
+
+export type OracleVerdict = {
+  oracleId: string;
+  passed: boolean;
+  detail: string;
+};
+
+export function evaluateJourneyOracles(evidence: JourneyExecutionEvidence): OracleVerdict[] {
+  const verdicts: OracleVerdict[] = [];
+
+  if (evidence.executionError) {
+    return [
+      {
+        oracleId: "ORACLE-TOOL",
+        passed: false,
+        detail: `Execution failed before judgment: ${evidence.executionError}`,
+      },
+    ];
+  }
+
+  const successfulTools = evidence.executedTools.filter((t) => t.success);
+
+  verdicts.push({
+    oracleId: "ORACLE-SURFACE",
+    passed: evidence.offeredToolNames.length > 0,
+    detail:
+      evidence.offeredToolNames.length > 0
+        ? `${evidence.offeredToolNames.length} read-only tools offered`
+        : "No read-only tools available to this coworker — definition gap, cannot certify",
+  });
+
+  verdicts.push({
+    oracleId: "ORACLE-TOOL",
+    passed: successfulTools.length > 0,
+    detail:
+      successfulTools.length > 0
+        ? `Successful tool calls: ${[...new Set(successfulTools.map((t) => t.name))].join(", ")}`
+        : `No successful tool call (attempted: ${
+            evidence.executedTools.map((t) => t.name).join(", ") || "none"
+          })`,
+  });
+
+  const offered = new Set(evidence.offeredToolNames);
+  const outsideSurface = evidence.executedTools.filter((t) => !offered.has(t.name));
+  verdicts.push({
+    oracleId: "ORACLE-PURITY",
+    passed: outsideSurface.length === 0,
+    detail:
+      outsideSurface.length === 0
+        ? "All executed tools were within the offered read-only surface"
+        : `Executed outside the offered surface: ${outsideSurface.map((t) => t.name).join(", ")}`,
+  });
+
+  if (!evidence.downgraded) {
+    const fabricated = detectFabrication(
+      evidence.content,
+      evidence.executedTools.length,
+      false,
+      evidence.executedTools.map((t) => t.name),
+    );
+    verdicts.push({
+      oracleId: "ORACLE-FABRICATE",
+      passed: !fabricated,
+      detail: fabricated
+        ? "Reply claims completion without tool evidence"
+        : "No fabrication pattern detected",
+    });
+
+    const refusal = detectToolRefusedDespiteAvailability(
+      evidence.content,
+      evidence.offeredToolNames.map((name) => ({ name })),
+    );
+    verdicts.push({
+      oracleId: "ORACLE-REFUSAL",
+      passed: refusal === null,
+      detail: refusal ?? "No false-refusal pattern detected",
+    });
+  }
+
+  return verdicts;
+}
+
+export function journeyPassed(verdicts: OracleVerdict[]): boolean {
+  return verdicts.length > 0 && verdicts.every((v) => v.passed);
+}

--- a/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import { COWORKER_AGENT_SEEDS } from "@dpf/db/workforce-seed";
+import {
+  certificationRouteFor,
+  runCoworkerCertificationSweep,
+  type CertificationDeps,
+} from "./certification-runner";
+import { deriveCertificationStates } from "./certification-status";
+
+type FindingRow = { findingKey: string; status: string };
+
+function makeDeps(overrides?: {
+  loopContent?: string;
+  executedTools?: Array<{ name: string; result: { success: boolean } }>;
+  tools?: Array<{ name: string; sideEffect?: boolean }>;
+  existingFindings?: FindingRow[];
+  superuser?: { id: string } | null;
+}) {
+  const created: { runs: unknown[]; findings: unknown[] } = { runs: [], findings: [] };
+  const updates: unknown[] = [];
+  const updateManyCalls: unknown[] = [];
+  const existing = new Map<string, FindingRow>(
+    (overrides?.existingFindings ?? []).map((f) => [f.findingKey, f]),
+  );
+
+  const deps: CertificationDeps = {
+    resolveAgent: vi.fn().mockResolvedValue({
+      agentId: "x",
+      systemPrompt: "You are a coworker.",
+      sensitivity: "internal",
+      modelRequirements: { minimumTier: "adequate" },
+    }),
+    resolveTools: vi.fn().mockResolvedValue({
+      tools: overrides?.tools ?? [
+        { name: "query_backlog", sideEffect: false },
+        { name: "create_backlog_item", sideEffect: true },
+      ],
+      toolsForProvider: [],
+    }),
+    runLoop: vi.fn().mockResolvedValue({
+      content:
+        overrides?.loopContent ??
+        "I used query_backlog and found 3 items; one is titled 'Certify coworkers'.",
+      downgraded: false,
+      executedTools: overrides?.executedTools ?? [
+        { name: "query_backlog", result: { success: true } },
+      ],
+    }),
+    db: {
+      user: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValue(overrides?.superuser === undefined ? { id: "usr-1" } : overrides.superuser),
+      },
+      assuranceRun: {
+        create: vi.fn().mockImplementation(async (args: { data: unknown }) => {
+          created.runs.push(args.data);
+          return args.data;
+        }),
+      },
+      assuranceFinding: {
+        findUnique: vi
+          .fn()
+          .mockImplementation(async (args: { where: { findingKey: string } }) =>
+            existing.get(args.where.findingKey) ?? null,
+          ),
+        create: vi.fn().mockImplementation(async (args: { data: { findingKey: string } }) => {
+          created.findings.push(args.data);
+          return args.data;
+        }),
+        update: vi.fn().mockImplementation(async (args: unknown) => {
+          updates.push(args);
+          return args;
+        }),
+        updateMany: vi.fn().mockImplementation(async (args: unknown) => {
+          updateManyCalls.push(args);
+          return { count: 0 };
+        }),
+      },
+    } as unknown as CertificationDeps["db"],
+    now: () => new Date("2026-07-08T04:40:00Z"),
+  };
+  return { deps, created, updates, updateManyCalls };
+}
+
+describe("coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2)", () => {
+  it("certifies the full roster: one AssuranceRun per coworker, all passed on healthy loops", async () => {
+    const { deps, created } = makeDeps();
+    const sweep = await runCoworkerCertificationSweep({ deps });
+
+    expect(sweep.results).toHaveLength(COWORKER_AGENT_SEEDS.length);
+    expect(sweep.failed).toBe(0);
+    expect(created.runs).toHaveLength(COWORKER_AGENT_SEEDS.length);
+    for (const run of created.runs as Array<Record<string, unknown>>) {
+      expect(run.scopeType).toBe("agent");
+      expect(run.adapterKey).toBe("coworker-cert");
+      expect(run.status).toBe("passed");
+    }
+    expect(created.findings).toHaveLength(0);
+  });
+
+  it("offers only side-effect-free tools to the loop", async () => {
+    const { deps } = makeDeps();
+    await runCoworkerCertificationSweep({ agentIds: ["dispatcher"], deps });
+
+    const loopCall = (deps.runLoop as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(loopCall.tools.map((t: { name: string }) => t.name)).toEqual(["query_backlog"]);
+  });
+
+  it("a failed oracle produces a failed run plus an open finding keyed to the oracle", async () => {
+    const { deps, created } = makeDeps({
+      loopContent: "Done! Everything has been updated successfully.",
+      executedTools: [],
+    });
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(sweep.failed).toBe(1);
+    expect((created.runs[0] as Record<string, unknown>).status).toBe("failed");
+    const keys = (created.findings as Array<{ findingKey: string }>).map((f) => f.findingKey);
+    expect(keys.some((k) => k.startsWith("coworker-cert:coo:") && k.endsWith("ORACLE-TOOL"))).toBe(
+      true,
+    );
+  });
+
+  it("a recovered oracle is absent-cleaned via updateMany scoped to the agent", async () => {
+    const { deps, updateManyCalls } = makeDeps();
+    await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(updateManyCalls).toHaveLength(1);
+    const call = updateManyCalls[0] as {
+      where: { findingKey: { startsWith: string } };
+      data: { status: string };
+    };
+    expect(call.where.findingKey.startsWith).toBe("coworker-cert:coo:");
+    expect(call.data.status).toBe("resolved");
+  });
+
+  it("reopens a previously resolved finding instead of duplicating it", async () => {
+    const journeyId = "coo/derived-read-probe";
+    const { deps, created, updates } = makeDeps({
+      loopContent: "Done! Everything has been updated successfully.",
+      executedTools: [],
+      existingFindings: [
+        { findingKey: `coworker-cert:coo:${journeyId}:ORACLE-TOOL`, status: "resolved" },
+      ],
+    });
+    await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    const createdKeys = (created.findings as Array<{ findingKey: string }>).map(
+      (f) => f.findingKey,
+    );
+    expect(createdKeys).not.toContain(`coworker-cert:coo:${journeyId}:ORACLE-TOOL`);
+    const reopen = updates.find(
+      (u) =>
+        (u as { where: { findingKey: string } }).where.findingKey ===
+        `coworker-cert:coo:${journeyId}:ORACLE-TOOL`,
+    ) as { data: Record<string, unknown> };
+    expect(reopen.data.status).toBe("open");
+  });
+
+  it("returns an empty sweep when no superuser exists (fresh install)", async () => {
+    const { deps, created } = makeDeps({ superuser: null });
+    const sweep = await runCoworkerCertificationSweep({ deps });
+    expect(sweep.results).toHaveLength(0);
+    expect(created.runs).toHaveLength(0);
+  });
+
+  it("a loop crash records a failed run, not a thrown sweep", async () => {
+    const { deps, created } = makeDeps();
+    (deps.runLoop as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("provider down"));
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(sweep.failed).toBe(1);
+    expect((created.runs[0] as Record<string, unknown>).status).toBe("failed");
+  });
+
+  it("routes certification through the coworker's bound route, workspace otherwise", () => {
+    expect(certificationRouteFor("marketing-specialist")).not.toBe("/workspace");
+    expect(certificationRouteFor("dispatcher")).toBe("/workspace");
+  });
+});
+
+describe("certification state derivation", () => {
+  const now = new Date("2026-07-08T12:00:00Z");
+
+  it("latest run wins; pass=certified, fail=failed, old pass=stale, none=never", () => {
+    const states = deriveCertificationStates(
+      ["a", "b", "c", "d"],
+      [
+        { scopeId: "a", status: "passed", startedAt: new Date("2026-07-08T04:40:00Z") },
+        { scopeId: "a", status: "failed", startedAt: new Date("2026-07-07T04:40:00Z") },
+        { scopeId: "b", status: "failed", startedAt: new Date("2026-07-08T04:40:00Z") },
+        { scopeId: "c", status: "passed", startedAt: new Date("2026-06-01T04:40:00Z") },
+      ],
+      now,
+    );
+    expect(states.get("a")?.status).toBe("certified");
+    expect(states.get("b")?.status).toBe("failed");
+    expect(states.get("c")?.status).toBe("stale");
+    expect(states.get("d")?.status).toBe("never");
+  });
+});

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -1,0 +1,347 @@
+// Coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2, BI-DE9CC88B).
+//
+// Sends each roster coworker's golden journeys through the REAL execution
+// path — real persona resolution, real grant-filtered tool surface, real
+// routing/model floor — judges the outcome with the certification oracles,
+// and persists one AssuranceRun per coworker (scopeType="agent",
+// adapterKey="coworker-cert") plus AssuranceFindings for each failed oracle.
+//
+// Non-destructive by construction: the tool surface is post-filtered to
+// sideEffect=false tools, journeys instruct read-only behavior, and
+// ORACLE-PURITY asserts nothing ran outside that surface. Execution goes
+// through runAgenticLoop directly (not executeAutonomousAgenticLoop) with
+// interactionMode "chat" and a synthetic threadId, so no AgentThread /
+// AgentMessage / TaskRun / reflection-observer rows are created — the only
+// writes are the governed ToolExecution audit rows and the assurance records
+// this module owns.
+
+import { prisma } from "@dpf/db";
+import { COWORKER_AGENT_SEEDS } from "@dpf/db/workforce-seed";
+import { runAgenticLoop } from "@/lib/tak/agentic-loop";
+import {
+  resolveAutonomousWorkAgent,
+  resolveAutonomousWorkTools,
+  type AutonomousWorkUserContext,
+} from "@/lib/tak/autonomous-work-run";
+import { toolsToOpenAIFormat } from "@/lib/mcp-tools";
+import { applyProviderRouteModelPreference } from "@/lib/ai-provider-route-context";
+import { ROUTE_AGENT_MAP_ENTRIES } from "@/lib/tak/agent-routing";
+import { journeysForCoworker, type GoldenJourney } from "./golden-journeys";
+import {
+  evaluateJourneyOracles,
+  journeyPassed,
+  type OracleVerdict,
+} from "./certification-oracles";
+
+import { COWORKER_CERT_ADAPTER_KEY } from "./certification-status";
+
+export { COWORKER_CERT_ADAPTER_KEY };
+export const COWORKER_CERT_ADAPTER_VERSION = "1.0.0";
+
+export type JourneyResult = {
+  journeyId: string;
+  mode: GoldenJourney["mode"];
+  passed: boolean;
+  verdicts: OracleVerdict[];
+  executedToolNames: string[];
+  downgraded: boolean;
+  durationMs: number;
+};
+
+export type CoworkerCertificationResult = {
+  agentId: string;
+  status: "passed" | "failed";
+  runId: string;
+  journeys: JourneyResult[];
+};
+
+export type CertificationSweepResult = {
+  startedAt: Date;
+  completedAt: Date;
+  results: CoworkerCertificationResult[];
+  passed: number;
+  failed: number;
+};
+
+/** First route bound to the agent in ROUTE_AGENT_MAP; workspace as fallback. */
+export function certificationRouteFor(agentId: string): string {
+  const bound = ROUTE_AGENT_MAP_ENTRIES.find(([, entry]) => entry.agentId === agentId);
+  return bound ? bound[0] : "/workspace";
+}
+
+type LoopResult = {
+  content: string;
+  downgraded: boolean;
+  executedTools: Array<{ name: string; result: { success: boolean } }>;
+};
+
+export type CertificationDeps = {
+  resolveAgent: typeof resolveAutonomousWorkAgent;
+  resolveTools: typeof resolveAutonomousWorkTools;
+  runLoop: (params: {
+    journey: GoldenJourney;
+    systemPrompt: string;
+    sensitivity: "public" | "internal" | "confidential" | "restricted";
+    tools: Parameters<typeof toolsToOpenAIFormat>[0];
+    toolsForProvider: Array<Record<string, unknown>>;
+    userId: string;
+    routeContext: string;
+    modelRequirements?: Record<string, unknown>;
+  }) => Promise<LoopResult>;
+  db: typeof prisma;
+  now: () => Date;
+};
+
+async function defaultRunLoop(
+  params: Parameters<CertificationDeps["runLoop"]>[0],
+): Promise<LoopResult> {
+  const result = await runAgenticLoop({
+    chatHistory: [{ role: "user", content: params.journey.prompt }],
+    systemPrompt: params.systemPrompt,
+    sensitivity: params.sensitivity,
+    tools: params.tools,
+    toolsForProvider: params.toolsForProvider,
+    userId: params.userId,
+    routeContext: params.routeContext,
+    agentId: params.journey.agentId,
+    threadId: `certification:${params.journey.journeyId}`,
+    interactionMode: "chat",
+    ...(params.modelRequirements && Object.keys(params.modelRequirements).length > 0
+      ? { modelRequirements: params.modelRequirements }
+      : {}),
+  });
+  return {
+    content: result.content,
+    downgraded: result.downgraded,
+    executedTools: result.executedTools.map((t) => ({
+      name: t.name,
+      result: { success: t.result.success },
+    })),
+  };
+}
+
+function defaultDeps(): CertificationDeps {
+  return {
+    resolveAgent: resolveAutonomousWorkAgent,
+    resolveTools: resolveAutonomousWorkTools,
+    runLoop: defaultRunLoop,
+    db: prisma,
+    now: () => new Date(),
+  };
+}
+
+async function executeJourney(
+  journey: GoldenJourney,
+  userContext: AutonomousWorkUserContext & { userId: string },
+  deps: CertificationDeps,
+): Promise<JourneyResult> {
+  const startedAt = deps.now().getTime();
+  const routeContext = certificationRouteFor(journey.agentId);
+
+  try {
+    const agentInfo = await deps.resolveAgent({
+      agentId: journey.agentId,
+      routeContext,
+      userContext,
+    });
+    const resolved = await deps.resolveTools({
+      userContext,
+      mode: journey.mode,
+      agentId: journey.agentId,
+    });
+    // Non-destructive surface: certification only ever offers read-only tools.
+    const readOnlyTools = resolved.tools.filter((t) => !t.sideEffect);
+    const toolsForProvider = toolsToOpenAIFormat(readOnlyTools);
+
+    const rawRequirements =
+      (agentInfo.modelRequirements as Record<string, unknown> | undefined) ?? undefined;
+    const modelRequirements = rawRequirements
+      ? applyProviderRouteModelPreference(rawRequirements, routeContext)
+      : undefined;
+
+    const loop = await deps.runLoop({
+      journey,
+      systemPrompt: agentInfo.systemPrompt,
+      sensitivity: agentInfo.sensitivity ?? "internal",
+      tools: readOnlyTools,
+      toolsForProvider,
+      userId: userContext.userId,
+      routeContext,
+      modelRequirements,
+    });
+
+    const verdicts = evaluateJourneyOracles({
+      content: loop.content,
+      executedTools: loop.executedTools.map((t) => ({
+        name: t.name,
+        success: t.result.success,
+      })),
+      offeredToolNames: readOnlyTools.map((t) => t.name),
+      downgraded: loop.downgraded,
+    });
+
+    return {
+      journeyId: journey.journeyId,
+      mode: journey.mode,
+      passed: journeyPassed(verdicts),
+      verdicts,
+      executedToolNames: [...new Set(loop.executedTools.map((t) => t.name))],
+      downgraded: loop.downgraded,
+      durationMs: deps.now().getTime() - startedAt,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const verdicts = evaluateJourneyOracles({
+      content: "",
+      executedTools: [],
+      offeredToolNames: [],
+      downgraded: false,
+      executionError: message,
+    });
+    return {
+      journeyId: journey.journeyId,
+      mode: journey.mode,
+      passed: false,
+      verdicts,
+      executedToolNames: [],
+      downgraded: false,
+      durationMs: deps.now().getTime() - startedAt,
+    };
+  }
+}
+
+function certFindingKey(agentId: string, oracleId: string, journeyId: string): string {
+  return `coworker-cert:${agentId}:${journeyId}:${oracleId}`;
+}
+
+async function persistCoworkerRun(
+  agentId: string,
+  journeys: JourneyResult[],
+  deps: CertificationDeps,
+): Promise<CoworkerCertificationResult> {
+  const at = deps.now();
+  const status: "passed" | "failed" = journeys.every((j) => j.passed) ? "passed" : "failed";
+  const runId = `assurance_coworker_cert_${agentId}_${at.toISOString().replace(/[^a-zA-Z0-9]/g, "_")}`;
+
+  await deps.db.assuranceRun.create({
+    data: {
+      runId,
+      scopeType: "agent",
+      scopeId: agentId,
+      adapterKey: COWORKER_CERT_ADAPTER_KEY,
+      adapterVersion: COWORKER_CERT_ADAPTER_VERSION,
+      status,
+      startedAt: at,
+      completedAt: deps.now(),
+      summary: {
+        agentId,
+        journeys: journeys.map((j) => ({
+          journeyId: j.journeyId,
+          passed: j.passed,
+          executedToolNames: j.executedToolNames,
+          downgraded: j.downgraded,
+          durationMs: j.durationMs,
+          verdicts: j.verdicts,
+        })),
+      },
+    },
+  });
+
+  const failedVerdicts = journeys.flatMap((j) =>
+    j.verdicts.filter((v) => !v.passed).map((v) => ({ journey: j, verdict: v })),
+  );
+  const activeKeys: string[] = [];
+  for (const { journey, verdict } of failedVerdicts) {
+    const findingKey = certFindingKey(agentId, verdict.oracleId, journey.journeyId);
+    activeKeys.push(findingKey);
+    const base = {
+      findingKind: "coworker-certification",
+      title: `${agentId}: ${verdict.oracleId} failed on ${journey.journeyId}`,
+      description: verdict.detail,
+      affectedType: "agent",
+      affectedId: agentId,
+      adapterKey: COWORKER_CERT_ADAPTER_KEY,
+      vendorIdentifier: verdict.oracleId,
+      policySeverity: verdict.oracleId === "ORACLE-SURFACE" ? "medium" : "high",
+      releaseImpact: "track",
+      lastSeenAt: at,
+      source: { adapterKey: COWORKER_CERT_ADAPTER_KEY, journeyId: journey.journeyId },
+      evidence: { verdicts: journey.verdicts, executedToolNames: journey.executedToolNames },
+    };
+    const existing = await deps.db.assuranceFinding.findUnique({ where: { findingKey } });
+    if (existing) {
+      await deps.db.assuranceFinding.update({
+        where: { findingKey },
+        data: {
+          ...base,
+          ...(existing.status === "resolved"
+            ? { status: "open", resolvedAt: null, reopenCount: { increment: 1 } }
+            : {}),
+        },
+      });
+    } else {
+      await deps.db.assuranceFinding.create({
+        data: { ...base, findingKey, status: "open", firstSeenAt: at },
+      });
+    }
+  }
+
+  // Absent-clean: oracle findings for this agent that did not reproduce are resolved.
+  await deps.db.assuranceFinding.updateMany({
+    where: {
+      findingKey: { startsWith: `coworker-cert:${agentId}:`, notIn: activeKeys },
+      status: { in: ["open", "planned", "blocked"] },
+    },
+    data: { status: "resolved", resolvedAt: at },
+  });
+
+  return { agentId, status, runId, journeys };
+}
+
+/** Resolve the operator identity certification runs execute as. */
+export async function resolveCertificationUserContext(
+  db: typeof prisma = prisma,
+): Promise<(AutonomousWorkUserContext & { userId: string }) | null> {
+  const owner = await db.user.findFirst({
+    where: { isSuperuser: true },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  if (!owner) return null;
+  return { userId: owner.id, platformRole: null, isSuperuser: true };
+}
+
+export async function runCoworkerCertificationSweep(options?: {
+  agentIds?: string[];
+  deps?: Partial<CertificationDeps>;
+}): Promise<CertificationSweepResult> {
+  const deps: CertificationDeps = { ...defaultDeps(), ...options?.deps };
+  const startedAt = deps.now();
+
+  const roster = COWORKER_AGENT_SEEDS.map((seed) => seed.agentId).filter(
+    (agentId) => !options?.agentIds || options.agentIds.includes(agentId),
+  );
+
+  const userContext = await resolveCertificationUserContext(deps.db);
+  if (!userContext) {
+    return { startedAt, completedAt: deps.now(), results: [], passed: 0, failed: 0 };
+  }
+
+  const results: CoworkerCertificationResult[] = [];
+  for (const agentId of roster) {
+    const journeyResults: JourneyResult[] = [];
+    for (const journey of journeysForCoworker(agentId)) {
+      journeyResults.push(await executeJourney(journey, userContext, deps));
+    }
+    results.push(await persistCoworkerRun(agentId, journeyResults, deps));
+  }
+
+  return {
+    startedAt,
+    completedAt: deps.now(),
+    results,
+    passed: results.filter((r) => r.status === "passed").length,
+    failed: results.filter((r) => r.status === "failed").length,
+  };
+}
+

--- a/apps/web/lib/coworker-lifecycle/certification-status.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-status.ts
@@ -1,0 +1,71 @@
+// Coworker certification status reader (EP-COWORKER-LIFECYCLE Phase 2).
+//
+// Light module: derives per-coworker certification state from the latest
+// coworker-cert AssuranceRuns. Kept separate from certification-runner so
+// read-side consumers (workforce roster) don't import the agentic loop.
+
+export const COWORKER_CERT_ADAPTER_KEY = "coworker-cert";
+/** Certifications older than this are "stale" — the coworker needs a re-run. */
+export const CERTIFICATION_FRESHNESS_DAYS = 8;
+
+export type CoworkerCertificationStatus = "certified" | "failed" | "stale" | "never";
+
+export type CoworkerCertificationState = {
+  status: CoworkerCertificationStatus;
+  lastRunAt: Date | null;
+};
+
+export type CertificationRunRow = {
+  scopeId: string;
+  status: string;
+  startedAt: Date;
+};
+
+type CertificationRunClient = {
+  assuranceRun?: { findMany: (args: unknown) => Promise<unknown> };
+};
+
+/**
+ * Pure derivation from run rows ordered by startedAt desc — first row per
+ * agent wins (the latest run).
+ */
+export function deriveCertificationStates(
+  agentIds: string[],
+  runsNewestFirst: CertificationRunRow[],
+  now: Date,
+): Map<string, CoworkerCertificationState> {
+  const states = new Map<string, CoworkerCertificationState>();
+  for (const agentId of agentIds) states.set(agentId, { status: "never", lastRunAt: null });
+  const freshnessMs = CERTIFICATION_FRESHNESS_DAYS * 24 * 60 * 60 * 1000;
+  for (const run of runsNewestFirst) {
+    const current = states.get(run.scopeId);
+    if (!current || current.lastRunAt) continue; // unknown agent or already latest
+    const stale = now.getTime() - run.startedAt.getTime() > freshnessMs;
+    states.set(run.scopeId, {
+      status: run.status === "passed" ? (stale ? "stale" : "certified") : "failed",
+      lastRunAt: run.startedAt,
+    });
+  }
+  return states;
+}
+
+/** Latest certification state per agent — consumed by the workforce roster. */
+export async function loadCertificationStates(
+  agentIds: string[],
+  db: CertificationRunClient,
+  now: Date = new Date(),
+): Promise<Map<string, CoworkerCertificationState>> {
+  if (agentIds.length === 0 || !db.assuranceRun) {
+    return deriveCertificationStates(agentIds, [], now);
+  }
+  const runs = (await db.assuranceRun.findMany({
+    where: {
+      scopeType: "agent",
+      adapterKey: COWORKER_CERT_ADAPTER_KEY,
+      scopeId: { in: agentIds },
+    },
+    orderBy: { startedAt: "desc" },
+    select: { scopeId: true, status: true, startedAt: true },
+  })) as CertificationRunRow[];
+  return deriveCertificationStates(agentIds, runs, now);
+}

--- a/apps/web/lib/coworker-lifecycle/golden-journeys.test.ts
+++ b/apps/web/lib/coworker-lifecycle/golden-journeys.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { COWORKER_AGENT_SEEDS } from "@dpf/db/workforce-seed";
+import { CURATED_JOURNEYS, derivedReadProbe, journeysForCoworker } from "./golden-journeys";
+
+describe("golden journeys (EP-COWORKER-LIFECYCLE Phase 2)", () => {
+  it("every roster coworker gets at least one journey with zero authoring", () => {
+    for (const seed of COWORKER_AGENT_SEEDS) {
+      const journeys = journeysForCoworker(seed.agentId);
+      expect(journeys.length).toBeGreaterThan(0);
+      for (const journey of journeys) {
+        expect(journey.agentId).toBe(seed.agentId);
+        expect(journey.journeyId.startsWith(`${seed.agentId}/`)).toBe(true);
+      }
+    }
+  });
+
+  it("curated journeys replace the derived probe", () => {
+    const journeys = journeysForCoworker("marketing-specialist");
+    expect(journeys.every((j) => j.kind === "curated")).toBe(true);
+    expect(journeys.map((j) => j.journeyId)).not.toContain(
+      derivedReadProbe("marketing-specialist").journeyId,
+    );
+  });
+
+  it("a coworker without curated journeys falls back to the derived probe", () => {
+    const journeys = journeysForCoworker("dispatcher");
+    expect(journeys).toEqual([derivedReadProbe("dispatcher")]);
+    expect(journeys[0].kind).toBe("derived");
+  });
+
+  it("all journeys are read-only by instruction", () => {
+    const allJourneys = [
+      ...COWORKER_AGENT_SEEDS.flatMap((seed) => journeysForCoworker(seed.agentId)),
+    ];
+    for (const journey of allJourneys) {
+      expect(journey.prompt.toLowerCase()).toContain("do not create");
+    }
+  });
+
+  it("curated journey ids are namespaced to their coworker", () => {
+    for (const [agentId, journeys] of Object.entries(CURATED_JOURNEYS)) {
+      for (const journey of journeys) {
+        expect(journey.journeyId.startsWith(`${agentId}/`)).toBe(true);
+      }
+    }
+  });
+
+  it("curated coworkers exist in the roster (no ghost journeys)", () => {
+    const rosterIds = new Set(COWORKER_AGENT_SEEDS.map((seed) => seed.agentId));
+    for (const agentId of Object.keys(CURATED_JOURNEYS)) {
+      expect(rosterIds.has(agentId), `${agentId} is not a roster coworker`).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/coworker-lifecycle/golden-journeys.ts
+++ b/apps/web/lib/coworker-lifecycle/golden-journeys.ts
@@ -1,0 +1,85 @@
+// Golden journeys — the per-coworker certification probes (EP-COWORKER-LIFECYCLE
+// Phase 2, BI-DE9CC88B).
+//
+// A golden journey is a small, non-destructive prompt sent through the REAL
+// coworker execution path (real persona, real tool surface, real routing) whose
+// outcome the certification oracles can judge mechanically. Every roster
+// coworker gets a DERIVED journey automatically — generated from its Phase 1
+// definition rather than hand-authored — so a newly established coworker is
+// exercised on the next certification sweep with zero extra work. Curated
+// journeys can be added per coworker where a domain-specific probe is more
+// valuable; they replace the derived one.
+//
+// Journeys must stay side-effect free: the runner restricts the tool surface
+// to sideEffect=false tools, and prompts instruct read-only behavior. A
+// journey that needs a write does not belong here — that is sim-harness
+// territory.
+
+export type GoldenJourney = {
+  /** Stable id — used in AssuranceRun summaries and finding keys. */
+  journeyId: string;
+  agentId: string;
+  mode: "act" | "advise";
+  prompt: string;
+  kind: "derived" | "curated";
+};
+
+/**
+ * The derived probe: role-agnostic, works for any coworker with at least one
+ * read-only tool. The oracles judge it by evidence, not by prose: a passing
+ * run has ≥1 successful tool call and no fabrication/false-refusal pattern.
+ */
+export function derivedReadProbe(agentId: string): GoldenJourney {
+  return {
+    journeyId: `${agentId}/derived-read-probe`,
+    agentId,
+    mode: "act",
+    kind: "derived",
+    prompt: [
+      "Certification probe (read-only).",
+      "Use one of your available tools to retrieve one concrete piece of current data relevant to your role,",
+      "then report which tool you used and one specific fact from its output.",
+      "Do not invent data. If every tool call fails, reply with TOOL-FAILURE and name the tool you tried.",
+      "Do not create, modify, or delete anything.",
+    ].join(" "),
+  };
+}
+
+/**
+ * Curated journeys — richer domain probes that replace the derived one.
+ * Keyed by agentId; each entry must remain read-only.
+ */
+export const CURATED_JOURNEYS: Readonly<Record<string, readonly Omit<GoldenJourney, "agentId" | "kind">[]>> = {
+  "marketing-specialist": [
+    {
+      journeyId: "marketing-specialist/campaign-readiness-review",
+      mode: "act",
+      prompt:
+        "Certification probe (read-only). Review the current marketing campaigns using your tools and report: how many campaigns exist, and one concrete detail of the most recent one. Do not create or modify anything. If tools fail, reply TOOL-FAILURE and name the tool.",
+    },
+  ],
+  "inventory-specialist": [
+    {
+      journeyId: "inventory-specialist/estate-census",
+      mode: "act",
+      prompt:
+        "Certification probe (read-only). Using your registry tools, report how many digital products are currently tracked and name one of them. Do not create or modify anything. If tools fail, reply TOOL-FAILURE and name the tool.",
+    },
+  ],
+  "ops-coordinator": [
+    {
+      journeyId: "ops-coordinator/backlog-pulse",
+      mode: "act",
+      prompt:
+        "Certification probe (read-only). Using your backlog tools, report how many open backlog items you can see and the title of one of them. Do not create, triage, or modify anything. If tools fail, reply TOOL-FAILURE and name the tool.",
+    },
+  ],
+};
+
+export function journeysForCoworker(agentId: string): GoldenJourney[] {
+  const curated = CURATED_JOURNEYS[agentId];
+  if (curated && curated.length > 0) {
+    return curated.map((j) => ({ ...j, agentId, kind: "curated" as const }));
+  }
+  return [derivedReadProbe(agentId)];
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -489,6 +489,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     tracksRunData: false,
     runNowEvent: null,
   },
+  {
+    jobId: "coworker-certification",
+    inngestId: "ops/coworker-certification-nightly",
+    name: "Coworker certification",
+    purpose:
+      "EP-COWORKER-LIFECYCLE Phase 2 (BI-DE9CC88B): exercises every roster coworker's golden journeys through the real execution path (read-only tool surface) and records per-coworker pass/fail AssuranceRuns the workforce roster shows. If it stops, coworker certification goes stale and broken coworkers surface late again.",
+    cron: "40 4 * * *",
+    cadence: "Daily at 04:40",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: "ops/coworker-certification.requested",
+  },
 ] as const;
 
 const CATALOG_BY_JOB_ID = new Map<string, ScheduledJobCatalogEntry>(

--- a/apps/web/lib/queue/functions/coworker-certification.ts
+++ b/apps/web/lib/queue/functions/coworker-certification.ts
@@ -1,0 +1,57 @@
+// apps/web/lib/queue/functions/coworker-certification.ts
+// EP-COWORKER-LIFECYCLE Phase 2 (BI-DE9CC88B) — nightly coworker certification.
+//
+// Exercises every roster coworker's golden journeys through the real
+// execution path (read-only tool surface) and persists per-coworker
+// AssuranceRun/AssuranceFinding records the workforce roster reads. This is
+// the job that keeps "defined but never exercised" from recurring: a coworker
+// that stops working is a failed certification the next night, not a
+// production surprise weeks later.
+//
+// Mirrors patch-assessment-sweep.ts: pure exported sweep + thin Inngest
+// wrappers (cron + run-now event) behind the quiescence gate.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+export async function runCoworkerCertificationJob() {
+  const { runCoworkerCertificationSweep } = await import(
+    "@/lib/coworker-lifecycle/certification-runner"
+  );
+  const sweep = await runCoworkerCertificationSweep();
+  return {
+    passed: sweep.passed,
+    failed: sweep.failed,
+    agents: sweep.results.map((r) => ({ agentId: r.agentId, status: r.status })),
+  };
+}
+
+export const coworkerCertificationNightly = inngest.createFunction(
+  {
+    id: "ops/coworker-certification-nightly",
+    retries: 1,
+    // Serialize with itself; certification runs real inference per coworker.
+    concurrency: [{ limit: 1 }],
+    triggers: [cron("40 4 * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return await step.run("coworker-certification", runCoworkerCertificationJob);
+  },
+);
+
+export const coworkerCertificationRunNow = inngest.createFunction(
+  {
+    id: "ops/coworker-certification-run-now",
+    retries: 0,
+    concurrency: [{ limit: 1 }],
+    triggers: [{ event: "ops/coworker-certification.requested" }],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return await step.run("coworker-certification", runCoworkerCertificationJob);
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -64,6 +64,10 @@ import { marketingSchedulerDispatch } from "./marketing-scheduler-dispatch";
 import { recurringInvoiceDispatch } from "./recurring-invoice-dispatch";
 import { siemCorrelationSweep } from "./siem-correlation-sweep";
 import { patchAssessmentSweep } from "./patch-assessment-sweep";
+import {
+  coworkerCertificationNightly,
+  coworkerCertificationRunNow,
+} from "./coworker-certification";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 export const scheduledFunctions = [
@@ -104,6 +108,7 @@ export const scheduledFunctions = [
   siemCorrelationSweep,       // BI-6D9496F1: EP-SOVEREIGN-SOC P1 — project internal audit -> SecurityEvent + run detection rules, every 15m
   patchAssessmentSweep,       // EP-PATCH-MANAGEMENT P0: daily estate patch posture sweep (OSV+KEV -> AssuranceFinding), 05:00
   remoteActionClaimTimeout,   // EP-REMOTE-ACTION P2: time out stale claimed RemoteActions so the pull queue can't wedge, every 10m (flag-gated)
+  coworkerCertificationNightly, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): nightly golden-journey certification of every roster coworker, 04:40
 ];
 
 export const eventFunctions = [
@@ -133,6 +138,7 @@ export const eventFunctions = [
   quiescenceRun,
   dataRetentionSweepRequested, // EP-DATA-RETENTION: operator "run now" / dry-run
   mdmStewardSweepRequested, // EP-4A12A7CB slice 4: Data Steward "run now" / dry-run
+  coworkerCertificationRunNow, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): operator "run now" certification sweep
 ];
 
 export const allFunctions = [...scheduledFunctions, ...eventFunctions];

--- a/apps/web/lib/workforce/workforce-roster.test.ts
+++ b/apps/web/lib/workforce/workforce-roster.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 
 import { loadWorkforceRoster } from "./workforce-roster";
 
-function makeDb(opts: { employees?: unknown[]; agents?: unknown[]; roles?: unknown[] }) {
+function makeDb(opts: {
+  employees?: unknown[];
+  agents?: unknown[];
+  roles?: unknown[];
+  certificationRuns?: unknown[];
+}) {
   return {
     employeeProfile: { findMany: vi.fn().mockResolvedValue(opts.employees ?? []) },
     agent: { findMany: vi.fn().mockResolvedValue(opts.agents ?? []) },
     platformRole: { findMany: vi.fn().mockResolvedValue(opts.roles ?? []) },
+    assuranceRun: { findMany: vi.fn().mockResolvedValue(opts.certificationRuns ?? []) },
   };
 }
 
@@ -101,7 +107,27 @@ describe("loadWorkforceRoster (BI-554E1A14, BI-9A5F0EA3)", () => {
       skillCount: 3,
       // 2 of 3 needs are not resolved (submitted + in-progress)
       unmetNeedCount: 2,
+      // No coworker-cert AssuranceRuns in the fixture → never certified.
+      certification: "never",
+      certificationAt: null,
     });
+  });
+
+  it("surfaces certification state from the latest coworker-cert run (EP-COWORKER-LIFECYCLE P2)", async () => {
+    const recent = new Date();
+    const db = makeDb({
+      employees: [],
+      agents: [AGENT],
+      certificationRuns: [
+        { scopeId: "AGT-COO", status: "passed", startedAt: recent },
+        { scopeId: "AGT-COO", status: "failed", startedAt: new Date(recent.getTime() - 86400000) },
+      ],
+    });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0].agentNeeds?.certification).toBe("certified");
+    expect(members[0].agentNeeds?.certificationAt).toEqual(recent);
   });
 
   it("resolves the human-role parity anchor from the supervising role's name", async () => {

--- a/apps/web/lib/workforce/workforce-roster.ts
+++ b/apps/web/lib/workforce/workforce-roster.ts
@@ -21,6 +21,10 @@
 // Pure projection: no schema change, no mutation.
 
 import { prisma } from "@dpf/db";
+import {
+  loadCertificationStates,
+  type CoworkerCertificationState,
+} from "@/lib/coworker-lifecycle/certification-status";
 
 export type WorkforceMemberKind = "human" | "agent";
 
@@ -72,6 +76,13 @@ export type AgentNeeds = {
   skillCount: number;
   /** Capability needs the agent has flagged that are not yet resolved. */
   unmetNeedCount: number;
+  /**
+   * Behavioral certification state from the nightly coworker-cert sweep
+   * (EP-COWORKER-LIFECYCLE Phase 2): certified | failed | stale | never.
+   * "never" for agents outside the certified roster or before the first sweep.
+   */
+  certification: "certified" | "failed" | "stale" | "never";
+  certificationAt: Date | null;
 };
 
 export type WorkforceMember = {
@@ -107,6 +118,8 @@ export type WorkforceRosterClient = {
   agent: { findMany: (args: unknown) => Promise<unknown> };
   /** Optional — resolves the specific/broad approval owner for supervising roles. */
   platformRole?: { findMany: (args: unknown) => Promise<unknown> };
+  /** Optional — latest coworker-cert AssuranceRuns for certification status. */
+  assuranceRun?: { findMany: (args: unknown) => Promise<unknown> };
 };
 
 /**
@@ -206,7 +219,11 @@ function resolveParityAndOwner(
   };
 }
 
-function agentToMember(row: AgentRow, roles: Map<string, RoleResolution>): WorkforceMember {
+function agentToMember(
+  row: AgentRow,
+  roles: Map<string, RoleResolution>,
+  certification: CoworkerCertificationState | undefined,
+): WorkforceMember {
   const unmetNeedCount = row.coworkerNeeds.filter(
     (n) => !RESOLVED_NEED_STATUSES.has(n.status),
   ).length;
@@ -236,6 +253,8 @@ function agentToMember(row: AgentRow, roles: Map<string, RoleResolution>): Workf
       toolGrantCount: row._count.toolGrants,
       skillCount: row._count.skills,
       unmetNeedCount,
+      certification: certification?.status ?? "never",
+      certificationAt: certification?.lastRunAt ?? null,
     },
   };
 }
@@ -334,9 +353,15 @@ export async function loadWorkforceRoster(input?: {
     ),
   ];
   const roles = await resolveSupervisingRoles(db, supervisorIds);
+  const certificationStates = await loadCertificationStates(
+    agents.map((a) => a.agentId),
+    db,
+  );
 
   const humanMembers = employees.map(humanToMember);
-  const agentMembers = agents.map((a) => agentToMember(a, roles));
+  const agentMembers = agents.map((a) =>
+    agentToMember(a, roles, certificationStates.get(a.agentId)),
+  );
   const members = [...humanMembers, ...agentMembers];
 
   return {

--- a/docs/superpowers/plans/2026-07-07-coworker-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-07-07-coworker-lifecycle-plan.md
@@ -22,14 +22,34 @@
 - Begin the `catalog/agents.ts` single-source consolidation from the 2026-04-28 design, with the
   contract type as the catalog row type.
 
-## Phase 2 — Certification harness (BI-DE9CC88B)
-1. `goldenJourneys` on the contract (per coworker: prompt, mode, expected tool call(s), oracle).
-2. Runner: iterate roster → real chat/scheduled path → oracles (real-tool-call, no-false-refusal,
-   no-fabrication via detectFabrication patterns + sim-harness O1–O7, advise-no-side-effect).
-3. Persist as `AssuranceRun(scopeType='agent', adapterKey='coworker-cert')` + findings.
-4. Nightly + post-deploy trigger (scheduled-jobs catalog); inference budget via the existing
-   admission/budget gates; local-model floor respected via AgentModelConfig.
-5. Roster surface: certification state chip (certified/stale/failed/never) on WorkforceRosterPanel.
+## Phase 2 — Certification harness (BI-DE9CC88B) — SHIPPED (slice 1)
+
+As-built (apps/web/lib/coworker-lifecycle/):
+1. `golden-journeys.ts` — every roster coworker gets a DERIVED read-only probe automatically
+   (zero authoring for new coworkers); curated domain journeys replace it where richer
+   (marketing/inventory/ops seeded). Journeys are read-only by contract.
+2. `certification-oracles.ts` — pure verdicts per journey: ORACLE-SURFACE (non-empty read-only
+   tool surface), ORACLE-TOOL (≥1 successful call), ORACLE-PURITY (nothing ran outside the
+   surface), ORACLE-FABRICATE / ORACLE-REFUSAL (reuse the production `detectFabrication` /
+   `detectToolRefusedDespiteAvailability`); downgraded-provider runs skip prose oracles but
+   still require the tool call.
+3. `certification-runner.ts` — composes the REAL path (`resolveAutonomousWorkAgent` →
+   `resolveAutonomousWorkTools` post-filtered to `sideEffect=false` → `runAgenticLoop` with
+   `interactionMode:"chat"`, synthetic threadId, model floor via
+   `applyProviderRouteModelPreference`); persists one `AssuranceRun(scopeType='agent',
+   adapterKey='coworker-cert')` per coworker + oracle findings (prefix
+   `coworker-cert:<agent>:<journey>:<oracle>`, reopen-on-regress, absent-clean per agent —
+   patch-intel conventions). Runs as the first superuser; empty sweep on fresh installs.
+4. `certification-status.ts` — light reader deriving certified/failed/stale(>8d)/never;
+   consumed by the workforce roster without importing the loop.
+5. Nightly Inngest job `ops/coworker-certification-nightly` (04:40, quiescence-gated,
+   self-serialized) + `ops/coworker-certification.requested` run-now event; catalog entry
+   `coworker-certification`.
+6. Roster surface: `AgentNeeds.certification`/`certificationAt` + pill on WorkforceRosterPanel.
+
+Deferred to later Phase 2 slices: advise-mode journey variants, sim-harness O1–O7 composition
+for the dispatch domain, post-deploy trigger hook, per-coworker journey authoring in the
+Phase 1 contract file.
 
 ## Phase 3 — Enforced activation (BI-2C4056BF)
 1. lifecycleStage state machine + summonability gate in resolveAgentForRoute/summon_coworker.

--- a/docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md
+++ b/docs/superpowers/specs/2026-07-07-coworker-lifecycle-standard-design.md
@@ -70,7 +70,7 @@ Slice 1 also fixes drift the gate exposed:
   legal-operations-counsel) — route placement is a UX decision handled in the epic, not silently
   invented by the gate.
 
-### Phase 2 — Behavioral certification harness (BI-DE9CC88B)
+### Phase 2 — Behavioral certification harness (BI-DE9CC88B) — slice 1 shipped 2026-07-08
 
 Per-coworker certification runs hosted on the **existing** `AssuranceRun`/`AssuranceFinding`
 substrate (`scopeType='agent'`, `adapterKey='coworker-cert'` — today used only by


### PR DESCRIPTION
## Summary

**EP-COWORKER-LIFECYCLE Phase 2 slice 1** (BI-DE9CC88B) — the behavioral certification layer of the kernel-ratified coworker lifecycle. Phase 1 ([#2696](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2696), merged) made an incomplete coworker *definition* fail CI; this PR makes a coworker that doesn't actually *work* visible within a day instead of weeks: every roster coworker is exercised nightly through the real execution path and judged by evidence.

**Why:** 76 of 88 registered coworkers had never been exercised — mechanisms are unit-tested, but nothing ever sent a coworker a prompt and verified a real tool call came back. Every recurring failure class (fabrication, false refusals with ~13 duplicate BI-PIR items, dead grants) was discovered live, late.

## What this PR does

- **Golden journeys** (`apps/web/lib/coworker-lifecycle/golden-journeys.ts`): every roster coworker automatically gets a derived read-only probe — a new coworker is certified on the next sweep with zero authoring. Curated domain journeys (marketing, inventory, ops) replace the derived probe where a richer check is worth it.
- **Oracles** (`certification-oracles.ts`): pure, evidence-based verdicts — ORACLE-SURFACE (non-empty read-only tool surface), ORACLE-TOOL (≥1 successful call), ORACLE-PURITY (nothing outside the offered surface), ORACLE-FABRICATE / ORACLE-REFUSAL reusing the production `detectFabrication` / `detectToolRefusedDespiteAvailability` detectors. Downgraded-provider runs skip prose oracles but still require the tool call.
- **Runner** (`certification-runner.ts`): composes the REAL path — `resolveAutonomousWorkAgent` → `resolveAutonomousWorkTools` post-filtered to `sideEffect=false` → `runAgenticLoop` (`interactionMode:"chat"`, synthetic threadId, model floor via `applyProviderRouteModelPreference`). Persists one `AssuranceRun(scopeType="agent", adapterKey="coworker-cert")` per coworker plus per-oracle `AssuranceFinding`s with reopen-on-regress and per-agent absent-clean (patch-intel conventions). No AgentThread/AgentMessage/TaskRun rows; non-destructive by construction.
- **Nightly job**: `ops/coworker-certification-nightly` (04:40, quiescence-gated, self-serialized) + `ops/coworker-certification.requested` run-now event; registered in the function index and `SCHEDULED_JOB_CATALOG` (parity tests cover both).
- **Roster honesty**: `AgentNeeds.certification` / `certificationAt` (certified / failed / stale >8d / never) via a light status reader (`certification-status.ts`, no loop import), rendered as a pill on `WorkforceRosterPanel`.
- **Assurance vocabulary**: `coworker-certification` finding kind, `agent` affected type.

Docs updated in-PR: plan Phase 2 as-built section; spec stamped. Deferred to later slices: advise-mode journey variants, sim-harness O1–O7 composition for dispatch, post-deploy trigger.

UX-Fit-Decision: reuse existing AgentNeeds pill row on WorkforceRosterPanel (no new surface; one status token, accent color only on non-certified states)

## Test plan

- `pnpm exec vitest run lib/coworker-lifecycle lib/workforce/workforce-roster.test.ts lib/queue/functions/index.test.ts lib/operate/scheduled-jobs` — 108 tests green (journeys coverage for every roster coworker, all oracle failure modes, runner persistence incl. reopen + absent-clean + no-superuser + loop-crash paths, roster derivation, registry/catalog parity).
- `tsc --noEmit` green (apps/web); local CI-equivalent pregate run before push.

Backlog: BI-DE9CC88B (claimed, capsule WC-F2CEFF22) · Epic EP-COWORKER-LIFECYCLE · Prior: [#2696](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2696) (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
