### PR TITLE
feat(coworker): goal / stop-condition primitive — verifiable completion gate (BI-D6F6A313)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -54,6 +54,7 @@ import { selfUpgradePack } from "@/lib/mcp/packs/self-upgrade-pack";
 import { coworkerServiceCatalogPack } from "@/lib/mcp/packs/coworker-service-catalog-pack";
 import { coworkerToolGrantPack } from "@/lib/mcp/packs/coworker-tool-grant-pack";
 import { coworkerMemoryPack } from "@/lib/mcp/packs/coworker-memory-pack";
+import { coworkerGoalPack } from "@/lib/mcp/packs/coworker-goal-pack";
 import { queueAwarenessPack } from "@/lib/mcp/packs/queue-awareness-pack";
 import { composeToolPacks } from "@/lib/mcp/tool-registry";
 import {
@@ -451,7 +452,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerMemoryPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerMemoryPack, coworkerGoalPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,

--- a/apps/web/lib/mcp/packs/coworker-goal-pack.ts
+++ b/apps/web/lib/mcp/packs/coworker-goal-pack.ts
@@ -1,0 +1,152 @@
+// Coworker goal / stop-condition pack — BI-D6F6A313 (EP-CLAUDE-INSIDE-OUT).
+//
+// Self-scoped door to a coworker's own verifiable completion conditions:
+//   • set_task_goal      — the calling coworker attaches a goal to ITSELF
+//   • list_task_goals    — the calling coworker reads its OWN active goals
+//   • evaluate_task_goal — judge a produced output against one of the caller's
+//                          OWN goals; persists met|unmet + rationale
+//
+// Self-scoped by construction: every handler resolves the target from
+// context.agentId and ignores any caller-supplied agent, so a coworker can only
+// touch its own goals. Like record_working_note, these need no special grant — a
+// coworker setting or checking its own completion condition cannot exceed its
+// authority. A non-agent caller (no context.agentId) is rejected.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "set_task_goal",
+    description:
+      "Attach a verifiable completion condition (a 'goal') to YOURSELF (the calling coworker). State the condition so it can be judged literally satisfied or not — e.g. 'A MarketingCampaignBrief row for the summer campaign exists with a non-empty body'. Use before autonomous work so completion is judged against the condition, not self-declared.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        condition: {
+          type: "string",
+          description: "The verifiable completion condition, stated so a judge can decide MET or UNMET.",
+        },
+        scheduledTaskId: {
+          type: "string",
+          description: "Optional id of the ScheduledAgentTask this goal gates.",
+        },
+      },
+      required: ["condition"],
+    },
+    requiredCapability: null,
+    sideEffect: true,
+  },
+  {
+    name: "list_task_goals",
+    description: "List YOUR OWN active goals (the calling coworker's unresolved completion conditions), newest first.",
+    inputSchema: { type: "object", properties: {} },
+    requiredCapability: null,
+    sideEffect: false,
+  },
+  {
+    name: "evaluate_task_goal",
+    description:
+      "Judge a produced OUTPUT against one of YOUR OWN goals. Returns met|unmet plus a rationale and records the verdict. Use to check whether work actually satisfies the condition before declaring done.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        goalId: { type: "string", description: "The id of your goal to evaluate (from list_task_goals)." },
+        output: { type: "string", description: "The produced output to judge against the goal condition." },
+      },
+      required: ["goalId", "output"],
+    },
+    requiredCapability: null,
+    sideEffect: true,
+  },
+];
+
+async function resolveCallerCuid(agentId: string | undefined): Promise<string | null> {
+  if (!agentId) return null;
+  const { resolveCoworkerAgent } = await import("@/lib/tak/coworker-tool-grant-core");
+  const target = await resolveCoworkerAgent(agentId);
+  return target?.id ?? null;
+}
+
+const NO_COWORKER: ToolResult = {
+  success: false,
+  error: "no_calling_coworker",
+  message: "Only a coworker can manage its own goals.",
+};
+
+async function setTaskGoalHandler(
+  params: Record<string, unknown>,
+  userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const agentCuid = await resolveCallerCuid(context?.agentId);
+  if (!agentCuid) return NO_COWORKER;
+  const { createCoworkerGoal } = await import("@/lib/tak/coworker-task-goal");
+  const res = await createCoworkerGoal({
+    agentCuid,
+    condition: String(params["condition"] ?? ""),
+    scheduledTaskId: params["scheduledTaskId"] != null ? String(params["scheduledTaskId"]) : null,
+    createdBy: userId || null,
+  });
+  if (!res.ok) return { success: false, error: "goal_write_failed", message: res.error };
+  return { success: true, message: "Goal set.", data: { goalId: res.goalId } };
+}
+
+async function listTaskGoalsHandler(
+  _params: Record<string, unknown>,
+  _userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const agentCuid = await resolveCallerCuid(context?.agentId);
+  if (!agentCuid) return NO_COWORKER;
+  const { listActiveGoals } = await import("@/lib/tak/coworker-task-goal");
+  const goals = await listActiveGoals(agentCuid);
+  return {
+    success: true,
+    message: goals.length ? `You have ${goals.length} active goal(s).` : "You have no active goals.",
+    data: { goals: goals.map((g) => ({ goalId: g.id, condition: g.condition })) },
+  };
+}
+
+async function evaluateTaskGoalHandler(
+  params: Record<string, unknown>,
+  _userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const agentCuid = await resolveCallerCuid(context?.agentId);
+  if (!agentCuid) return NO_COWORKER;
+  const goalId = String(params["goalId"] ?? "").trim();
+  if (!goalId) return { success: false, error: "missing_goal", message: "Provide the goalId to evaluate." };
+
+  // Self-scope guard: the goal must belong to the calling coworker.
+  const { prisma } = await import("@dpf/db");
+  const owner = await prisma.coworkerTaskGoal.findUnique({ where: { id: goalId }, select: { agentId: true } });
+  if (!owner || owner.agentId !== agentCuid) {
+    return { success: false, error: "goal_not_found", message: "No goal of yours matches that id." };
+  }
+
+  const { evaluateCoworkerGoal } = await import("@/lib/tak/coworker-task-goal");
+  const res = await evaluateCoworkerGoal({
+    goalId,
+    output: String(params["output"] ?? ""),
+    sensitivity: "internal",
+  });
+  if (!res.ok) return { success: false, error: "goal_eval_failed", message: res.error };
+  return {
+    success: true,
+    message: res.status === "met" ? "Goal met." : "Goal not yet met.",
+    data: { status: res.status, rationale: res.rationale },
+  };
+}
+
+export const coworkerGoalPack: ToolPack = {
+  packId: "coworker-goal",
+  definitions,
+  handlers: {
+    set_task_goal: (params, userId, context) => setTaskGoalHandler(params, userId, context),
+    list_task_goals: (params, userId, context) => listTaskGoalsHandler(params, userId, context),
+    evaluate_task_goal: (params, userId, context) => evaluateTaskGoalHandler(params, userId, context),
+  },
+  // Ungated (self-scoped): no agent-grant gating, mirroring coworker-memory.
+  grants: {},
+};

--- a/apps/web/lib/tak/coworker-task-goal.test.ts
+++ b/apps/web/lib/tak/coworker-task-goal.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    coworkerTaskGoal: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+
+import {
+  buildGoalJudgePrompt,
+  classifyGoalStatus,
+  createCoworkerGoal,
+  evaluateCoworkerGoal,
+  interpretGoalVerdict,
+} from "./coworker-task-goal";
+
+const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("interpretGoalVerdict", () => {
+  it("reads an explicit MET verdict and its rationale", () => {
+    expect(interpretGoalVerdict("VERDICT: MET — the row exists")).toEqual({
+      met: true,
+      rationale: "the row exists",
+    });
+  });
+
+  it("reads an explicit UNMET verdict", () => {
+    expect(interpretGoalVerdict("VERDICT: UNMET — no such row")).toEqual({
+      met: false,
+      rationale: "no such row",
+    });
+  });
+
+  it("defaults to UNMET when the verdict is missing or ambiguous", () => {
+    expect(interpretGoalVerdict("I think it's probably fine")).toMatchObject({ met: false });
+    expect(interpretGoalVerdict("")).toEqual({ met: false, rationale: "No judge verdict." });
+  });
+
+  it("is case- and separator-tolerant", () => {
+    expect(interpretGoalVerdict("verdict: met: done").met).toBe(true);
+    expect(interpretGoalVerdict("Preamble.\nVERDICT: UNMET - nope").met).toBe(false);
+  });
+});
+
+describe("classifyGoalStatus", () => {
+  it("maps the boolean verdict to the persisted status", () => {
+    expect(classifyGoalStatus(true)).toBe("met");
+    expect(classifyGoalStatus(false)).toBe("unmet");
+  });
+});
+
+describe("buildGoalJudgePrompt", () => {
+  it("embeds the condition and output and demands a leading VERDICT token", () => {
+    const { system, user } = buildGoalJudgePrompt("row exists", "I made the row");
+    expect(system).toMatch(/VERDICT: MET/);
+    expect(user).toContain("row exists");
+    expect(user).toContain("I made the row");
+  });
+});
+
+describe("createCoworkerGoal", () => {
+  it("rejects an empty condition before any write", async () => {
+    const res = await createCoworkerGoal({ agentCuid: "cuid-a", condition: "   " });
+    expect(res).toEqual({ ok: false, error: expect.stringMatching(/must not be empty/i) });
+    expect(prisma.coworkerTaskGoal.create).not.toHaveBeenCalled();
+  });
+
+  it("persists a trimmed condition and returns the new id", async () => {
+    asMock(prisma.coworkerTaskGoal.create).mockResolvedValueOnce({ id: "goal-1" });
+    const res = await createCoworkerGoal({ agentCuid: "cuid-a", condition: "  row exists  ", createdBy: "user_1" });
+    expect(res).toEqual({ ok: true, goalId: "goal-1" });
+    expect(prisma.coworkerTaskGoal.create).toHaveBeenCalledWith({
+      data: { agentId: "cuid-a", condition: "row exists", scheduledTaskId: null, createdBy: "user_1" },
+      select: { id: true },
+    });
+  });
+});
+
+describe("evaluateCoworkerGoal", () => {
+  it("marks the goal met and stamps resolvedAt on a MET verdict", async () => {
+    asMock(prisma.coworkerTaskGoal.findUnique).mockResolvedValueOnce({ id: "goal-1", condition: "row exists" });
+    asMock(prisma.coworkerTaskGoal.update).mockResolvedValueOnce({});
+    const judge = vi.fn().mockResolvedValue("VERDICT: MET — the row exists");
+
+    const res = await evaluateCoworkerGoal({ goalId: "goal-1", output: "done", sensitivity: "internal", judge });
+
+    expect(res).toEqual({ ok: true, status: "met", rationale: "the row exists" });
+    const call = asMock(prisma.coworkerTaskGoal.update).mock.calls[0][0];
+    expect(call.data.status).toBe("met");
+    expect(call.data.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  it("marks the goal unmet WITHOUT resolvedAt on an UNMET verdict", async () => {
+    asMock(prisma.coworkerTaskGoal.findUnique).mockResolvedValueOnce({ id: "goal-1", condition: "row exists" });
+    asMock(prisma.coworkerTaskGoal.update).mockResolvedValueOnce({});
+    const judge = vi.fn().mockResolvedValue("VERDICT: UNMET — nothing was created");
+
+    const res = await evaluateCoworkerGoal({ goalId: "goal-1", output: "I will do it later", sensitivity: "internal", judge });
+
+    expect(res).toMatchObject({ ok: true, status: "unmet" });
+    const call = asMock(prisma.coworkerTaskGoal.update).mock.calls[0][0];
+    expect(call.data.status).toBe("unmet");
+    expect(call.data.resolvedAt).toBeUndefined();
+  });
+
+  it("fails closed (no status write) when the judge throws", async () => {
+    asMock(prisma.coworkerTaskGoal.findUnique).mockResolvedValueOnce({ id: "goal-1", condition: "row exists" });
+    const judge = vi.fn().mockRejectedValue(new Error("provider down"));
+
+    const res = await evaluateCoworkerGoal({ goalId: "goal-1", output: "x", sensitivity: "internal", judge });
+
+    expect(res).toMatchObject({ ok: false });
+    expect(prisma.coworkerTaskGoal.update).not.toHaveBeenCalled();
+  });
+
+  it("returns not-found for an unknown goal", async () => {
+    asMock(prisma.coworkerTaskGoal.findUnique).mockResolvedValueOnce(null);
+    const res = await evaluateCoworkerGoal({ goalId: "ghost", output: "x", sensitivity: "internal", judge: vi.fn() });
+    expect(res).toMatchObject({ ok: false });
+  });
+});

--- a/apps/web/lib/tak/coworker-task-goal.ts
+++ b/apps/web/lib/tak/coworker-task-goal.ts
@@ -1,0 +1,166 @@
+// Coworker goal / stop-condition primitive — BI-D6F6A313 (EP-CLAUDE-INSIDE-OUT).
+//
+// The external Claude harness /goal attaches a natural-language completion
+// condition to a task and blocks stopping until that condition verifiably holds,
+// re-invoking the agent each turn. The DPF analog persists the condition as a
+// CoworkerTaskGoal and evaluates a produced output against it with a real judge
+// (the coworker-inline-review shape) — so an autonomous coworker is judged
+// "met/unmet" against a verifiable condition instead of self-declaring done.
+//
+// This module keeps the prompt-build + verdict-interpret logic PURE (testable
+// without the inference layer); the single IO function `evaluateCoworkerGoal`
+// wires the judge (routeAndCall) and persistence. Slice 1 evaluates on demand
+// via the MCP door; wiring the autonomous completion seam to auto-evaluate and
+// gate re-dispatch is Slice 2 (tracked as a follow-up BI).
+
+import { prisma } from "@dpf/db";
+
+import type { RouteSensitivity } from "@/lib/agent-sensitivity";
+import type { ChatMessage } from "@/lib/ai-inference";
+import { routeAndCall } from "@/lib/inference/routed-inference";
+
+/** Closed status vocabulary for a goal's lifecycle. */
+export const GOAL_STATUSES = ["active", "met", "unmet", "abandoned"] as const;
+export type GoalStatus = (typeof GOAL_STATUSES)[number];
+
+export type GoalVerdict = {
+  /** Whether the judge decided the condition is satisfied by the output. */
+  met: boolean;
+  /** The judge's one-line rationale (for audit + operator visibility). */
+  rationale: string;
+};
+
+/**
+ * Pure: build the judge prompt that decides whether `output` satisfies the
+ * goal `condition`. The judge must answer with a leading VERDICT token so the
+ * interpretation is deterministic and provider-agnostic.
+ */
+export function buildGoalJudgePrompt(condition: string, output: string): { system: string; user: string } {
+  const system =
+    "You are a strict completion judge. You are given a GOAL (a verifiable " +
+    "completion condition) and the OUTPUT a worker produced. Decide whether the " +
+    "output actually satisfies the goal. Be literal — do not give credit for " +
+    "intent, partial progress, or a promise to do it later. Respond with exactly " +
+    "one line: 'VERDICT: MET — <reason>' or 'VERDICT: UNMET — <reason>'.";
+  const user = `GOAL:\n${condition}\n\nOUTPUT:\n${output}`;
+  return { system, user };
+}
+
+/**
+ * Pure: interpret a judge reply into a verdict. Defaults to UNMET when the reply
+ * is missing or ambiguous — a goal is only "met" on an explicit MET verdict, so
+ * an unparseable judge reply never lets an unfinished goal pass.
+ */
+export function interpretGoalVerdict(raw: string): GoalVerdict {
+  const text = (raw ?? "").trim();
+  const match = text.match(/VERDICT:\s*(MET|UNMET)\s*(?:[—:-]\s*)?(.*)$/im);
+  if (!match) {
+    return { met: false, rationale: text ? `Unparseable judge verdict: ${text.slice(0, 200)}` : "No judge verdict." };
+  }
+  const met = match[1].toUpperCase() === "MET";
+  const rationale = (match[2] ?? "").trim() || (met ? "Condition satisfied." : "Condition not satisfied.");
+  return { met, rationale };
+}
+
+/** Pure: map a boolean verdict to the persisted goal status. */
+export function classifyGoalStatus(met: boolean): Extract<GoalStatus, "met" | "unmet"> {
+  return met ? "met" : "unmet";
+}
+
+/**
+ * Create a goal for a coworker (by Agent.id cuid). `condition` is required; an
+ * empty condition is rejected so a goal always carries something to judge.
+ */
+export async function createCoworkerGoal(params: {
+  agentCuid: string;
+  condition: string;
+  scheduledTaskId?: string | null;
+  createdBy?: string | null;
+}): Promise<{ ok: true; goalId: string } | { ok: false; error: string }> {
+  const condition = (params.condition ?? "").trim();
+  if (!condition) return { ok: false, error: "Goal condition must not be empty." };
+  const goal = await prisma.coworkerTaskGoal.create({
+    data: {
+      agentId: params.agentCuid,
+      condition,
+      scheduledTaskId: params.scheduledTaskId ?? null,
+      createdBy: params.createdBy ?? null,
+    },
+    select: { id: true },
+  });
+  return { ok: true, goalId: goal.id };
+}
+
+export type CoworkerGoalRecord = {
+  id: string;
+  condition: string;
+  status: GoalStatus;
+  verdictRationale: string | null;
+};
+
+/** List a coworker's active (unresolved) goals, newest first. */
+export async function listActiveGoals(agentCuid: string): Promise<CoworkerGoalRecord[]> {
+  const rows = await prisma.coworkerTaskGoal.findMany({
+    where: { agentId: agentCuid, status: "active" },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, condition: true, status: true, verdictRationale: true },
+  });
+  return rows.map((r) => ({ ...r, status: r.status as GoalStatus }));
+}
+
+/**
+ * Evaluate one goal against a produced `output`. Loads the goal, runs the judge
+ * (routeAndCall — the same bounded, capable-model call the inline-review pass
+ * uses, with NO agentId so it cannot recurse into a coworker's posture), then
+ * persists the verdict (status met|unmet, rationale, lastEvaluatedAt; resolvedAt
+ * when met). Fail-closed on error: the goal stays active and unmet so a failed
+ * judge never marks a goal satisfied. `judge` is injectable for tests.
+ */
+export async function evaluateCoworkerGoal(params: {
+  goalId: string;
+  output: string;
+  sensitivity: RouteSensitivity;
+  judge?: (system: string, user: string, sensitivity: RouteSensitivity) => Promise<string>;
+}): Promise<{ ok: true; status: GoalStatus; rationale: string } | { ok: false; error: string }> {
+  const goal = await prisma.coworkerTaskGoal.findUnique({
+    where: { id: params.goalId },
+    select: { id: true, condition: true },
+  });
+  if (!goal) return { ok: false, error: `No goal ${params.goalId}.` };
+
+  const { system, user } = buildGoalJudgePrompt(goal.condition, params.output ?? "");
+  const judge = params.judge ?? defaultGoalJudge;
+
+  let verdict: GoalVerdict;
+  try {
+    const raw = await judge(system, user, params.sensitivity);
+    verdict = interpretGoalVerdict(raw);
+  } catch (err) {
+    console.warn("[coworker-goal] judge failed (fail-closed, goal stays unmet):", err);
+    return { ok: false, error: err instanceof Error ? err.message : "Goal judge failed." };
+  }
+
+  const status = classifyGoalStatus(verdict.met);
+  await prisma.coworkerTaskGoal.update({
+    where: { id: goal.id },
+    data: {
+      status,
+      verdictRationale: verdict.rationale,
+      lastEvaluatedAt: new Date(),
+      ...(verdict.met ? { resolvedAt: new Date() } : {}),
+    },
+  });
+  return { ok: true, status, rationale: verdict.rationale };
+}
+
+/** The production judge: one bounded, capable-model call, no agentId. */
+async function defaultGoalJudge(system: string, user: string, sensitivity: RouteSensitivity): Promise<string> {
+  const messages: ChatMessage[] = [{ role: "user", content: user }];
+  const result = await routeAndCall(messages, system, sensitivity, {
+    taskType: "review",
+    modelTier: "robust",
+    effort: "high",
+    routingActor: { kind: "system", id: "coworker-goal-judge" },
+  });
+  return result.content;
+}

--- a/docs/superpowers/plans/2026-07-08-coworker-goal-stop-condition-plan.md
+++ b/docs/superpowers/plans/2026-07-08-coworker-goal-stop-condition-plan.md
@@ -1,0 +1,58 @@
+# Coworker goal / stop-condition primitive — plan (BI-D6F6A313)
+
+- **Date:** 2026-07-08
+- **Epic:** EP-CLAUDE-INSIDE-OUT (harness-parity Cluster 1, matrix row #11)
+- **BI:** BI-D6F6A313
+- **Kernel altitude ledger:** DI-D1C96829E6BD (deliver-tractable-block-rest)
+
+## Problem
+
+The Claude harness `/goal` attaches a natural-language completion condition to a
+task and blocks *stopping* until that condition verifiably holds, re-invoking the
+agent each turn. DPF coworkers have no equivalent: an autonomous run self-declares
+"done" with only the inline-review deliberation pass (`coworker-inline-review.ts`)
+approximating a check. There is no persisted, judged completion condition.
+
+## Approach (substrate-first)
+
+Reuse the existing judge seam (`routeAndCall`, the same bounded capable-model call
+the inline-review pass uses with no `agentId`, so it cannot recurse into a
+coworker's posture). Add the smallest primitive that is genuinely functional, not
+a dormant table.
+
+### Slice 1 (this PR)
+
+1. **Schema** — `CoworkerTaskGoal` (agentId FK→Agent, condition, status
+   active|met|unmet|abandoned, optional scheduledTaskId link, verdictRationale,
+   lastEvaluatedAt, resolvedAt). Additive migration, data-safe.
+2. **Core** — `lib/tak/coworker-task-goal.ts`:
+   - Pure: `buildGoalJudgePrompt`, `interpretGoalVerdict` (defaults UNMET on an
+     ambiguous/missing verdict so an unfinished goal never passes),
+     `classifyGoalStatus`.
+   - IO: `createCoworkerGoal`, `listActiveGoals`, `evaluateCoworkerGoal`
+     (fail-closed — the goal stays unmet if the judge throws; `judge` injectable
+     for tests).
+3. **MCP door** — `coworker-goal-pack.ts`, self-scoped to the calling coworker
+   (mirrors `coworker-memory` — ungated, resolves target from `context.agentId`,
+   ignores caller-supplied agent): `set_task_goal`, `list_task_goals`,
+   `evaluate_task_goal`.
+4. **Tests** — pure verdict/classifier/prompt + core create/evaluate
+   (met stamps resolvedAt; unmet does not; judge-throw fails closed; unknown goal
+   not-found) + pack self-scope.
+
+### Slice 2 (follow-up BI, not this PR)
+
+Wire the autonomous completion seam (`autonomous-work-run.ts`, beside the
+deliberation pass + reflection trigger — additive, fail-open, void) to
+auto-evaluate a run's active goal against its output and gate re-dispatch of the
+linked `ScheduledAgentTask` (met → resolve/deactivate; unmet → leave active so the
+existing cron re-fires, bounded by existing attempt caps). Deferred because it
+touches the shared run seam and the scheduler dispatch path — its own reviewable
+slice, same discipline as the working-memory BI's prompt-injection Slice 2.
+
+## Safety
+
+- No change to the hot agentic loop or any authorization read path.
+- Judge call is bounded, single, no `agentId` (no posture recursion).
+- Fail-closed evaluation: a goal is only `met` on an explicit MET verdict.
+- Self-scoped door: a coworker can only touch its own goals.

--- a/packages/db/prisma/migrations/20260708130000_add_coworker_task_goal/migration.sql
+++ b/packages/db/prisma/migrations/20260708130000_add_coworker_task_goal/migration.sql
@@ -1,0 +1,28 @@
+-- BI-D6F6A313: coworker goal / stop-condition primitive. Persists a verifiable
+-- completion condition attached to a coworker so an autonomous run can be judged
+-- met/unmet against it instead of self-declaring done. Additive-only.
+--
+-- @migration-safety: data-safe: creates one new table with FK to Agent
+-- (ON DELETE CASCADE) and no changes to existing tables or rows; nothing to
+-- backfill and no existing row can violate the new indexes.
+
+CREATE TABLE "CoworkerTaskGoal" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "scheduledTaskId" TEXT,
+    "condition" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastEvaluatedAt" TIMESTAMP(3),
+    "verdictRationale" TEXT,
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "CoworkerTaskGoal_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "CoworkerTaskGoal_agentId_status_idx" ON "CoworkerTaskGoal"("agentId", "status");
+
+CREATE INDEX "CoworkerTaskGoal_scheduledTaskId_idx" ON "CoworkerTaskGoal"("scheduledTaskId");
+
+ALTER TABLE "CoworkerTaskGoal" ADD CONSTRAINT "CoworkerTaskGoal_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2306,6 +2306,7 @@ model Agent {
   toolGrants           AgentToolGrant[]
   toolGrantRevocations AgentToolGrantRevocation[]
   memoryNotes          CoworkerMemoryNote[]      @relation("CoworkerMemoryNoteAgent")
+  taskGoals            CoworkerTaskGoal[]        @relation("CoworkerTaskGoalAgent")
   coworkerServices     CoworkerService[]
   coworkerEngagements  CoworkerEngagement[]
   coworkerAssessments  CoworkerSelfAssessment[]    @relation("CoworkerSelfAssessmentAgent")
@@ -2479,6 +2480,30 @@ model AgentToolGrantRevocation {
 // prior active row so the note stays current instead of accumulating. Confirmed
 // durable learnings should be routed onward to WWMD/WWWD via
 // dpf-route-learning-to-commons; this store is the staging/working layer.
+// BI-D6F6A313 (EP-CLAUDE-INSIDE-OUT): a verifiable completion condition attached
+// to a coworker. The external harness /goal blocks stopping until a natural-
+// language condition holds and re-invokes; the DPF analog persists that condition
+// here so an autonomous run can be judged "met/unmet" against a real evaluation
+// (the coworker-inline-review judge shape) instead of self-declaring done. Slice 1
+// persists + evaluates goals on demand via the MCP door; Slice 2 wires the
+// completion seam to auto-evaluate and gate re-dispatch (see BI follow-up).
+model CoworkerTaskGoal {
+  id               String    @id @default(cuid())
+  agentId          String // Agent.id (cuid) — the coworker this goal is for
+  scheduledTaskId  String? // optional link to the ScheduledAgentTask this goal gates
+  condition        String // the natural-language verifiable completion condition
+  status           String    @default("active") // active|met|unmet|abandoned
+  createdBy        String? // userId if a human set it; null = the coworker itself
+  createdAt        DateTime  @default(now())
+  lastEvaluatedAt  DateTime?
+  verdictRationale String? // the judge's rationale from the most recent evaluation
+  resolvedAt       DateTime?
+  agent            Agent     @relation("CoworkerTaskGoalAgent", fields: [agentId], references: [id], onDelete: Cascade)
+
+  @@index([agentId, status])
+  @@index([scheduledTaskId])
+}
+
 model CoworkerMemoryNote {
   id             String    @id @default(cuid())
   agentId        String // Agent.id (cuid) — the coworker this note belongs to

--- a/scripts/module-size-baseline.json
+++ b/scripts/module-size-baseline.json
@@ -41,7 +41,7 @@
   "apps/web/lib/integrate/sandbox/build-branch.ts": 854,
   "apps/web/lib/marketing.ts": 1367,
   "apps/web/lib/mcp-tools-backlog.test.ts": 901,
-  "apps/web/lib/mcp-tools.ts": 16548,
+  "apps/web/lib/mcp-tools.ts": 16549,
   "apps/web/lib/navigation/portal-navigation-model.ts": 936,
   "apps/web/lib/operate/coworker-regression-detector.ts": 935,
   "apps/web/lib/queue/functions/self-upgrade.test.ts": 1289,


### PR DESCRIPTION
## Summary
EP-CLAUDE-INSIDE-OUT harness-parity matrix row #11. Gives coworkers a DPF analog to the harness `/goal`: a persisted, judged completion condition instead of self-declaring done.

**Slice 1 (this PR):** `CoworkerTaskGoal` model + `coworker-task-goal.ts` core (pure verdict logic + fail-closed IO evaluation reusing the inline-review `routeAndCall` judge, no agentId) + self-scoped ungated MCP door (`set_task_goal`/`list_task_goals`/`evaluate_task_goal`, mirrors coworker-memory) + 12 tests.

**Slice 2 (follow-up):** wire the autonomous completion seam to auto-evaluate and gate `ScheduledAgentTask` re-dispatch — deferred as its own reviewable slice (see plan doc §Slice 2). No change to the hot agentic loop or any authorization read path.

Additive migration (data-safe). Kernel altitude ledger DI-D1C96829E6BD. Plan: docs/superpowers/plans/2026-07-08-coworker-goal-stop-condition-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)