### PR TITLE
feat(notifications): user-configurable subscription rules (BI-997503EC)

### DIFF
--- a/apps/web/lib/actions/notification-rules.ts
+++ b/apps/web/lib/actions/notification-rules.ts
@@ -1,0 +1,42 @@
+"use server";
+
+// User-facing server actions for notification subscription rules — BI-997503EC.
+// Each action is scoped to the authenticated user via requireUserId, so a user
+// can only create, list, or remove their OWN rules. The rule logic + matcher
+// live in lib/notifications/subscription-rules.ts.
+
+import {
+  createSubscription,
+  deleteSubscription,
+  listSubscriptions,
+  type SubscriptionCadence,
+  type SubscriptionFilter,
+  type SubscriptionRecord,
+} from "@/lib/notifications/subscription-rules";
+
+import { requireUserId } from "./shared/guards";
+
+export async function createNotificationRule(input: {
+  eventCategory: string;
+  filter?: SubscriptionFilter;
+  cadence?: SubscriptionCadence;
+}): Promise<{ ok: boolean; subscriptionId?: string; error?: string }> {
+  const userId = await requireUserId();
+  const res = await createSubscription({
+    userId,
+    eventCategory: input.eventCategory,
+    filter: input.filter,
+    cadence: input.cadence,
+  });
+  return res.ok ? { ok: true, subscriptionId: res.subscriptionId } : { ok: false, error: res.error };
+}
+
+export async function listNotificationRules(): Promise<SubscriptionRecord[]> {
+  const userId = await requireUserId();
+  return listSubscriptions(userId);
+}
+
+export async function deleteNotificationRule(subscriptionId: string): Promise<{ ok: boolean }> {
+  const userId = await requireUserId();
+  return deleteSubscription(userId, subscriptionId);
+}

--- a/apps/web/lib/notifications/subscription-rules.test.ts
+++ b/apps/web/lib/notifications/subscription-rules.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    notificationSubscription: { create: vi.fn(), findMany: vi.fn(), deleteMany: vi.fn() },
+    notification: { createMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+
+import {
+  createSubscription,
+  dispatchEventToSubscribers,
+  matchesSubscriptionFilter,
+} from "./subscription-rules";
+
+const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("matchesSubscriptionFilter", () => {
+  it("matches everything in the category when the filter is null or empty", () => {
+    expect(matchesSubscriptionFilter(null, { status: "open" })).toBe(true);
+    expect(matchesSubscriptionFilter({}, { status: "open" })).toBe(true);
+  });
+
+  it("requires every filter key to be present AND strictly equal", () => {
+    expect(matchesSubscriptionFilter({ status: "open" }, { status: "open", pri: "P1" })).toBe(true);
+    expect(matchesSubscriptionFilter({ status: "open", pri: "P1" }, { status: "open", pri: "P2" })).toBe(false);
+  });
+
+  it("does not fire on an attribute the event never reported", () => {
+    expect(matchesSubscriptionFilter({ status: "open" }, { pri: "P1" })).toBe(false);
+  });
+
+  it("uses strict equality (no type coercion)", () => {
+    expect(matchesSubscriptionFilter({ count: 1 }, { count: 1 })).toBe(true);
+    // number filter vs string attribute must NOT match
+    expect(matchesSubscriptionFilter({ count: 1 }, { count: "1" as unknown as number })).toBe(false);
+  });
+});
+
+describe("createSubscription", () => {
+  it("rejects an empty category and an unknown cadence before any write", async () => {
+    expect(await createSubscription({ userId: "u1", eventCategory: "  " })).toMatchObject({ ok: false });
+    expect(
+      await createSubscription({ userId: "u1", eventCategory: "backlog", cadence: "hourly" as never }),
+    ).toMatchObject({ ok: false });
+    expect(prisma.notificationSubscription.create).not.toHaveBeenCalled();
+  });
+
+  it("persists a trimmed category and returns the id", async () => {
+    asMock(prisma.notificationSubscription.create).mockResolvedValueOnce({ id: "sub-1" });
+    const res = await createSubscription({ userId: "u1", eventCategory: " backlog ", filter: { status: "open" } });
+    expect(res).toEqual({ ok: true, subscriptionId: "sub-1" });
+    expect(prisma.notificationSubscription.create).toHaveBeenCalledWith({
+      data: { userId: "u1", eventCategory: "backlog", filter: { status: "open" }, channel: "in_app", cadence: "immediate" },
+      select: { id: true },
+    });
+  });
+});
+
+describe("dispatchEventToSubscribers", () => {
+  const event = {
+    eventCategory: "backlog",
+    attributes: { status: "done", pri: "P1" },
+    title: "A backlog item you follow is done",
+  };
+
+  it("notifies only owners whose filter matches, one notification per user", async () => {
+    asMock(prisma.notificationSubscription.findMany).mockResolvedValueOnce([
+      { id: "s1", userId: "alice", filter: { status: "done" } }, // match
+      { id: "s2", userId: "bob", filter: { status: "open" } }, // no match
+      { id: "s3", userId: "alice", filter: null }, // match (all) — same user, de-duped
+      { id: "s4", userId: "carol", filter: { pri: "P1" } }, // match
+    ]);
+    asMock(prisma.notification.createMany).mockResolvedValueOnce({ count: 2 });
+
+    const res = await dispatchEventToSubscribers(event);
+
+    expect(res).toEqual({ notified: 2 });
+    const created = asMock(prisma.notification.createMany).mock.calls[0][0].data;
+    expect(created.map((d: { userId: string }) => d.userId).sort()).toEqual(["alice", "carol"]);
+    expect(created[0].type).toBe("subscription:backlog");
+  });
+
+  it("creates nothing when no active rule matches", async () => {
+    asMock(prisma.notificationSubscription.findMany).mockResolvedValueOnce([
+      { id: "s1", userId: "bob", filter: { status: "open" } },
+    ]);
+    const res = await dispatchEventToSubscribers(event);
+    expect(res).toEqual({ notified: 0 });
+    expect(prisma.notification.createMany).not.toHaveBeenCalled();
+  });
+
+  it("only queries active immediate rules in the category", async () => {
+    asMock(prisma.notificationSubscription.findMany).mockResolvedValueOnce([]);
+    await dispatchEventToSubscribers(event);
+    expect(prisma.notificationSubscription.findMany).toHaveBeenCalledWith({
+      where: { eventCategory: "backlog", active: true, cadence: "immediate" },
+      select: { id: true, userId: true, filter: true },
+    });
+  });
+});

--- a/apps/web/lib/notifications/subscription-rules.ts
+++ b/apps/web/lib/notifications/subscription-rules.ts
@@ -1,0 +1,118 @@
+// User-configurable notification / subscription rules — BI-997503EC
+// (EP-CLAUDE-INSIDE-OUT). "Notify me when a record in category X matching filter
+// Y changes." A rule is a durable NotificationSubscription owned by a user; when
+// an event is dispatched, active immediate rules whose equality filter matches
+// the event attributes produce a Notification row for the owner.
+//
+// The matcher is PURE (testable without a DB). The IO layer is CRUD +
+// dispatchEventToSubscribers, which reuses the existing Notification model. Slice
+// 1 makes the primitive callable; wiring concrete record-change event sources
+// (backlog status, ticket updates, build phase) is Slice 2 (follow-up BI).
+
+import { prisma } from "@dpf/db";
+
+/** Closed cadence vocabulary. `digest` batching is Slice 2 — only `immediate` fires today. */
+export const SUBSCRIPTION_CADENCES = ["immediate", "digest"] as const;
+export type SubscriptionCadence = (typeof SUBSCRIPTION_CADENCES)[number];
+
+export type SubscriptionFilter = Record<string, string | number | boolean> | null | undefined;
+
+/** A record-change event a subscription can match against. */
+export type SubscriptionEvent = {
+  eventCategory: string;
+  /** Flat attributes matched by equality against a rule's filter. */
+  attributes: Record<string, string | number | boolean>;
+  /** Notification payload used when a rule matches. */
+  title: string;
+  body?: string | null;
+  deepLink?: string | null;
+};
+
+/**
+ * Pure: does an event satisfy a subscription's filter? A null/empty filter
+ * matches every event in the category (subscribe-to-all). Otherwise EVERY filter
+ * key must be present in the event attributes AND equal (strict, primitive
+ * equality). A filter key the event lacks is a non-match — a rule never fires on
+ * an attribute that was not reported.
+ */
+export function matchesSubscriptionFilter(filter: SubscriptionFilter, attributes: Record<string, unknown>): boolean {
+  if (!filter) return true;
+  const keys = Object.keys(filter);
+  if (keys.length === 0) return true;
+  return keys.every((k) => Object.prototype.hasOwnProperty.call(attributes, k) && attributes[k] === filter[k]);
+}
+
+export async function createSubscription(params: {
+  userId: string;
+  eventCategory: string;
+  filter?: SubscriptionFilter;
+  channel?: string;
+  cadence?: SubscriptionCadence;
+}): Promise<{ ok: true; subscriptionId: string } | { ok: false; error: string }> {
+  const eventCategory = (params.eventCategory ?? "").trim();
+  if (!eventCategory) return { ok: false, error: "eventCategory must not be empty." };
+  const cadence = params.cadence ?? "immediate";
+  if (!SUBSCRIPTION_CADENCES.includes(cadence)) return { ok: false, error: `Unknown cadence: ${cadence}` };
+  const row = await prisma.notificationSubscription.create({
+    data: {
+      userId: params.userId,
+      eventCategory,
+      filter: (params.filter ?? undefined) as object | undefined,
+      channel: params.channel ?? "in_app",
+      cadence,
+    },
+    select: { id: true },
+  });
+  return { ok: true, subscriptionId: row.id };
+}
+
+export type SubscriptionRecord = {
+  id: string;
+  eventCategory: string;
+  filter: SubscriptionFilter;
+  cadence: string;
+  active: boolean;
+};
+
+export async function listSubscriptions(userId: string): Promise<SubscriptionRecord[]> {
+  const rows = await prisma.notificationSubscription.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, eventCategory: true, filter: true, cadence: true, active: true },
+  });
+  return rows.map((r) => ({ ...r, filter: r.filter as SubscriptionFilter }));
+}
+
+/** Delete a subscription, scoped to its owner so a user can only remove their own. */
+export async function deleteSubscription(userId: string, subscriptionId: string): Promise<{ ok: boolean }> {
+  await prisma.notificationSubscription.deleteMany({ where: { id: subscriptionId, userId } });
+  return { ok: true };
+}
+
+/**
+ * Dispatch an event to all matching active immediate subscriptions, creating one
+ * Notification per matching owner. Returns the number of notifications created.
+ * `digest`-cadence rules are intentionally skipped here (Slice 2 batches them).
+ * This is the seam concrete record-change sources call in Slice 2.
+ */
+export async function dispatchEventToSubscribers(event: SubscriptionEvent): Promise<{ notified: number }> {
+  const subs = await prisma.notificationSubscription.findMany({
+    where: { eventCategory: event.eventCategory, active: true, cadence: "immediate" },
+    select: { id: true, userId: true, filter: true },
+  });
+  const matched = subs.filter((s) => matchesSubscriptionFilter(s.filter as SubscriptionFilter, event.attributes));
+  if (matched.length === 0) return { notified: 0 };
+
+  // De-dup by user: one Notification per user even if multiple of their rules match.
+  const userIds = [...new Set(matched.map((s) => s.userId))];
+  await prisma.notification.createMany({
+    data: userIds.map((userId) => ({
+      userId,
+      type: `subscription:${event.eventCategory}`,
+      title: event.title,
+      body: event.body ?? null,
+      deepLink: event.deepLink ?? null,
+    })),
+  });
+  return { notified: userIds.length };
+}

--- a/docs/superpowers/plans/2026-07-08-notification-subscription-rules-plan.md
+++ b/docs/superpowers/plans/2026-07-08-notification-subscription-rules-plan.md
@@ -1,0 +1,54 @@
+# User-configurable notification / subscription rules — plan (BI-997503EC)
+
+- **Date:** 2026-07-08
+- **Epic:** EP-CLAUDE-INSIDE-OUT (declarative-admin-layer, top-10 gap #10 / matrix residue)
+- **BI:** BI-997503EC
+- **Kernel altitude ledger:** DI-D1C96829E6BD (deliver-tractable-block-rest)
+
+## Problem
+
+Notification delivery is code-driven: `lib/attention/notify.ts`, the self-upgrade
+notifiers, and alert bridges each create `Notification`/`PlatformNotification`
+rows from hardcoded call sites. An end user cannot express "notify me when a
+record in category X matching filter Y changes." Per the config-vs-standard
+research (PR #2699), notification rules are irreducible per-user residue — they
+belong to a first-class rule engine, not to code.
+
+## Approach (substrate-first)
+
+Reuse the existing per-user `Notification` model as the delivery target; add a
+durable rule + a pure matcher + a dispatch seam.
+
+### Slice 1 (this PR)
+
+1. **Schema** — `NotificationSubscription` (userId FK→User, eventCategory,
+   optional JSON equality filter, channel, cadence immediate|digest, active).
+   Additive migration, data-safe.
+2. **Core** — `lib/notifications/subscription-rules.ts`:
+   - Pure `matchesSubscriptionFilter` (null/empty filter = all-in-category; else
+     every filter key present AND strictly equal — a rule never fires on an
+     attribute the event did not report; no type coercion).
+   - IO `createSubscription` / `listSubscriptions` / `deleteSubscription`
+     (owner-scoped delete).
+   - IO `dispatchEventToSubscribers` — finds active immediate rules in the
+     category, filters by the matcher, creates one Notification per matching
+     owner (de-duped by user). This is the seam Slice 2 event sources call.
+3. **User actions** — `lib/actions/notification-rules.ts`, each scoped to the
+   authenticated user via `requireUserId` (create/list/delete own rules).
+4. **Tests** — pure matcher (all-in, strict equality, missing-attr, no coercion)
+   + create validation + dispatch (per-user de-dup, no-match no-op, active/
+   immediate query shape).
+
+### Slice 2 (follow-up BI, not this PR)
+
+- Wire `dispatchEventToSubscribers` into concrete record-change sources (backlog
+  status change, ServiceTicket updates, build phase transitions) so rules
+  auto-fire. Each call site is additive and named by `eventCategory`.
+- `digest` cadence batching (a scheduled job that rolls up matched events).
+- A management UI (settings surface) over the user actions.
+
+## Safety
+
+- No change to existing notification call sites (additive dispatch seam).
+- Owner-scoped everywhere: users touch only their own rules.
+- Strict, fail-safe matcher: an under-specified event never over-notifies.

--- a/packages/db/prisma/migrations/20260708140000_add_notification_subscription/migration.sql
+++ b/packages/db/prisma/migrations/20260708140000_add_notification_subscription/migration.sql
@@ -1,0 +1,27 @@
+-- BI-997503EC: user-configurable notification subscription rules. A user-owned
+-- rule = event category + optional equality filter + channel + cadence; matching
+-- immediate rules produce a Notification row when an event is dispatched.
+-- Additive-only.
+--
+-- @migration-safety: data-safe: creates one new table with FK to "User"
+-- (ON DELETE CASCADE) and no changes to existing tables or rows; nothing to
+-- backfill and no existing row can violate the new indexes.
+
+CREATE TABLE "NotificationSubscription" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "eventCategory" TEXT NOT NULL,
+    "filter" JSONB,
+    "channel" TEXT NOT NULL DEFAULT 'in_app',
+    "cadence" TEXT NOT NULL DEFAULT 'immediate',
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "NotificationSubscription_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "NotificationSubscription_userId_active_idx" ON "NotificationSubscription"("userId", "active");
+
+CREATE INDEX "NotificationSubscription_eventCategory_active_idx" ON "NotificationSubscription"("eventCategory", "active");
+
+ALTER TABLE "NotificationSubscription" ADD CONSTRAINT "NotificationSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
   improvementReviews            ImprovementProposal[]         @relation("ImprovementReviews")
   improvementSubmissions        ImprovementProposal[]         @relation("ImprovementSubmissions")
   notifications                 Notification[]
+  notificationSubscriptions     NotificationSubscription[] @relation("NotificationSubscriptionUser")
   requestedPasswordResetTokens  PasswordResetToken[]          @relation("PasswordResetRequestedBy")
   passwordResetTokens           PasswordResetToken[]          @relation("PasswordResetForUser")
   issueReports                  PlatformIssueReport[]
@@ -4914,6 +4915,29 @@ model Notification {
 
   @@index([userId, read])
   @@index([createdAt])
+}
+
+// BI-997503EC (EP-CLAUDE-INSIDE-OUT): user-configurable notification rules —
+// "notify me when a record in category X matching filter Y changes". A rule is a
+// durable subscription owned by a user: an event category, an optional equality
+// filter over event attributes, a channel, and a cadence. When an event is
+// dispatched, active immediate rules whose filter matches produce a Notification
+// row for the owner. Replaces code-only notification delivery with an end-user
+// rule surface. Slice 1 = model + matcher + dispatch + door; wiring concrete
+// record-change event sources is Slice 2 (see BI follow-up).
+model NotificationSubscription {
+  id            String   @id @default(cuid())
+  userId        String
+  eventCategory String // e.g. "backlog", "service-ticket", "build"
+  filter        Json? // equality filter {attr: value}; null/empty = all in category
+  channel       String   @default("in_app") // in_app (Notification row); extensible
+  cadence       String   @default("immediate") // immediate | digest (digest = Slice 2)
+  active        Boolean  @default(true)
+  createdAt     DateTime @default(now())
+  user          User     @relation("NotificationSubscriptionUser", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, active])
+  @@index([eventCategory, active])
 }
 
 model PlatformNotification {


### PR DESCRIPTION
## Summary
EP-CLAUDE-INSIDE-OUT declarative-admin-layer (top-10 gap #10). Turns code-driven notifications into an end-user rule engine: 'notify me when a record in category X matching filter Y changes'.

**Slice 1 (this PR):** `NotificationSubscription` model + `subscription-rules.ts` (pure `matchesSubscriptionFilter` + CRUD + `dispatchEventToSubscribers` reusing the existing `Notification` model) + owner-scoped server actions + 9 tests.

**Slice 2 (follow-up):** wire the dispatch seam into concrete record-change sources (backlog/ticket/build), digest cadence batching, management UI. No existing notification call site changes — additive seam.

Additive migration (data-safe). Per the config-vs-standard research (#2699), notification rules are irreducible per-user residue → first-class engine. Kernel ledger DI-D1C96829E6BD. Plan: docs/superpowers/plans/2026-07-08-notification-subscription-rules-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)