### PR TITLE
fix(ux): global deployment-skew sentinel — recover stale tabs (BI-F381D902)

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -11,6 +11,7 @@ import { AgentCoworkerShell } from "@/components/agent/AgentCoworkerShell";
 import { QueueFlusher } from "@/components/feedback/QueueFlusher";
 import { StatusBanner } from "@/components/shell/StatusBanner";
 import { UpdatePendingBanner } from "@/components/shell/UpdatePendingBanner";
+import { DeploymentSkewBanner } from "@/components/shell/DeploymentSkewBanner";
 import { PlatformBanner } from "@/components/platform/PlatformBanner";
 import { ShellBannerOverlay } from "@/components/shell/ShellBannerOverlay";
 import { ModelWarmup } from "@/components/shell/ModelWarmup";
@@ -169,6 +170,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
           />
         )}
         <ShellBannerOverlay>
+          <DeploymentSkewBanner />
           <PlatformBanner />
           <StatusBanner />
           <UpdatePendingBanner />

--- a/apps/web/components/shell/DeploymentSkewBanner.test.tsx
+++ b/apps/web/components/shell/DeploymentSkewBanner.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// BI-F381D902: the global sentinel must surface a Reload prompt for a stale tab
+// even when the failure is SWALLOWED (no error bubbles to the crash boundary),
+// and must stay silent when the tab is current.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { DeploymentSkewBanner } from "./DeploymentSkewBanner";
+
+function setBoot(identity: { version: string; bundleHash: string } | null) {
+  if (identity) {
+    (window as { __DPF_BOOT__?: unknown }).__DPF_BOOT__ = identity;
+  } else {
+    delete (window as { __DPF_BOOT__?: unknown }).__DPF_BOOT__;
+  }
+}
+
+function mockServed(identity: { version: string; bundleHash: string }) {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => identity });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+/** Fire a tab-refocus so the proactive boot-vs-served check runs immediately
+ *  (jsdom reports visibilityState "visible" by default). */
+function refocus() {
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+describe("DeploymentSkewBanner", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setBoot(null);
+    cleanup();
+  });
+
+  it("stays hidden when the running deployment matches the tab (no false positive)", async () => {
+    setBoot({ version: "1", bundleHash: "aaa" });
+    const fetchMock = mockServed({ version: "1", bundleHash: "aaa" });
+    render(<DeploymentSkewBanner />);
+
+    refocus();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByTestId("deployment-skew-banner")).toBeNull();
+  });
+
+  it("shows the reload prompt when the served bundle differs — the SWALLOWED case", async () => {
+    setBoot({ version: "1", bundleHash: "aaa" });
+    mockServed({ version: "2", bundleHash: "bbb" });
+    render(<DeploymentSkewBanner />);
+
+    // No error was thrown anywhere; detection is purely the proactive
+    // boot-vs-served comparison.
+    refocus();
+    await waitFor(() => expect(screen.getByTestId("deployment-skew-banner")).toBeTruthy());
+    expect(screen.getByRole("button", { name: /reload to continue/i })).toBeTruthy();
+  });
+
+  it("shows the reload prompt on a window-level skew error (the non-swallowed case)", async () => {
+    setBoot({ version: "1", bundleHash: "aaa" });
+    mockServed({ version: "1", bundleHash: "aaa" }); // identity matches; the error is the trigger
+    render(<DeploymentSkewBanner />);
+
+    act(() => {
+      window.dispatchEvent(
+        new ErrorEvent("error", {
+          message:
+            'Failed to find Server Action "abc". This request might be from an older or newer deployment.',
+        }),
+      );
+    });
+
+    await waitFor(() => expect(screen.getByTestId("deployment-skew-banner")).toBeTruthy());
+  });
+
+  it("ignores an ordinary (non-skew) window error", async () => {
+    setBoot({ version: "1", bundleHash: "aaa" });
+    const fetchMock = mockServed({ version: "1", bundleHash: "aaa" });
+    render(<DeploymentSkewBanner />);
+
+    act(() => {
+      window.dispatchEvent(new ErrorEvent("error", { message: "Cannot read properties of undefined" }));
+    });
+    refocus();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByTestId("deployment-skew-banner")).toBeNull();
+  });
+});

--- a/apps/web/components/shell/DeploymentSkewBanner.tsx
+++ b/apps/web/components/shell/DeploymentSkewBanner.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * DeploymentSkewBanner — global recovery prompt for a browser tab left open
+ * across a self-upgrade container swap (BI-F381D902).
+ *
+ * DPF self-upgrades autonomously, so every long-lived tab eventually crosses a
+ * deployment boundary and its next server action fails ("Failed to find Server
+ * Action … from an older or newer deployment"). The crash boundary
+ * (app/(shell)/error.tsx, BI-D22D4607) already auto-reloads once — but only for
+ * errors that BUBBLE UP to it. The coworker composer and other surfaces catch
+ * the failure locally and flip to a "failed" state, so the boundary never sees
+ * it and the user is left with a dead button and no hint.
+ *
+ * This sentinel closes that gap without duplicating the reload logic:
+ *   1. Reactive — listens for skew errors at the window level (`error` and
+ *      `unhandledrejection`), covering the throws that aren't swallowed.
+ *   2. Proactive — compares the tab's boot identity (window.__DPF_BOOT__)
+ *      against the running deployment (/api/internal/quiescence-state) shortly
+ *      after mount, on every tab refocus, and on a slow poll while the tab is
+ *      visible. This catches the SWALLOWED case (a stale tab is detectable even
+ *      when no error surfaces) including a tab that stayed focused through the
+ *      swap and never re-fired a visibility event.
+ *
+ * On detection it shows a friendly, non-dismissible "Reload to continue"
+ * banner. Reload is user-initiated (a button, not an auto-reload) so a
+ * half-typed message or unsaved input is never discarded out from under the
+ * user, and there is no reload-loop risk.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import {
+  fetchServedIdentity,
+  isBundleMismatch,
+  isDeploymentSkewReason,
+  readBootIdentity,
+} from "@/lib/deployment-skew";
+
+export function DeploymentSkewBanner(): React.ReactElement | null {
+  const [skewed, setSkewed] = useState(false);
+
+  const checkServedIdentity = useCallback(async () => {
+    // Only meaningful once we have a known boot identity to compare against;
+    // in `next dev` boot is "unknown" and isBundleMismatch never fires.
+    const boot = readBootIdentity();
+    if (!boot) return;
+    const served = await fetchServedIdentity();
+    if (isBundleMismatch(boot, served)) setSkewed(true);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const trip = () => {
+      if (!cancelled) setSkewed(true);
+    };
+
+    const onError = (event: ErrorEvent) => {
+      if (isDeploymentSkewReason(event)) trip();
+    };
+    const onRejection = (event: PromiseRejectionEvent) => {
+      if (isDeploymentSkewReason(event.reason)) trip();
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") void checkServedIdentity();
+    };
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    // One proactive check shortly after mount catches a tab that was already
+    // stale before this sentinel loaded (e.g. reopened after the swap).
+    const initialCheck = window.setTimeout(() => void checkServedIdentity(), 2_000);
+
+    // Slow poll while visible closes the focused-through-swap case: a tab that
+    // never blurs and swallows its server-action error would otherwise never
+    // learn it is stale. Only fetches when visible, so a backgrounded tab costs
+    // nothing.
+    const poll = window.setInterval(() => {
+      if (document.visibilityState === "visible") void checkServedIdentity();
+    }, 60_000);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(initialCheck);
+      window.clearInterval(poll);
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [checkServedIdentity]);
+
+  if (!skewed) return null;
+
+  return (
+    <div
+      role="alert"
+      data-testid="deployment-skew-banner"
+      className="pointer-events-auto flex w-[min(960px,calc(100vw-24px))] flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-[var(--dpf-warning)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs text-[var(--dpf-text)] shadow-[0_10px_30px_color-mix(in_srgb,var(--dpf-text)_14%,transparent)]"
+    >
+      <RefreshCw aria-hidden="true" className="size-4 shrink-0 text-[var(--dpf-warning)]" />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">The platform was updated in the background.</p>
+        <p className="text-[var(--dpf-muted)]">
+          This page is running an older version. Reload to continue — anything you were typing may be
+          lost, so copy it first if you need to.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="inline-flex min-h-8 shrink-0 items-center gap-1 rounded border border-[var(--dpf-warning)] bg-[color-mix(in_srgb,var(--dpf-warning)_12%,var(--dpf-surface-1))] px-3 py-1 font-medium text-[var(--dpf-text)] transition-colors hover:bg-[color-mix(in_srgb,var(--dpf-warning)_20%,var(--dpf-surface-1))] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-warning)]"
+      >
+        <RefreshCw aria-hidden="true" className="size-3.5" />
+        Reload to continue
+      </button>
+    </div>
+  );
+}

--- a/apps/web/lib/deployment-skew.test.ts
+++ b/apps/web/lib/deployment-skew.test.ts
@@ -1,6 +1,12 @@
 // BI-D22D4607: stale-tab deployment-skew detection for the crash boundary.
+// BI-F381D902: identity comparison + event-aware matcher for the global sentinel.
 import { describe, expect, it } from "vitest";
-import { isDeploymentSkewError } from "./deployment-skew";
+import {
+  isBundleMismatch,
+  isDeploymentSkewError,
+  isDeploymentSkewReason,
+  skewMessageFromReason,
+} from "./deployment-skew";
 
 describe("isDeploymentSkewError", () => {
   it.each([
@@ -35,5 +41,80 @@ describe("isDeploymentSkewError", () => {
   it("handles null/undefined", () => {
     expect(isDeploymentSkewError(null)).toBe(false);
     expect(isDeploymentSkewError(undefined)).toBe(false);
+  });
+});
+
+describe("skewMessageFromReason", () => {
+  it("extracts a message from Error, string, ErrorEvent-like, and rejection-like objects", () => {
+    expect(skewMessageFromReason("plain string")).toBe("plain string");
+    expect(skewMessageFromReason(new Error("boom"))).toBe("boom");
+    // ErrorEvent shape.
+    expect(skewMessageFromReason({ message: "evented" })).toBe("evented");
+    // PromiseRejectionEvent shape → unwrap .reason.
+    expect(skewMessageFromReason({ reason: new Error("rejected") })).toBe("rejected");
+    // Wrapped .error.
+    expect(skewMessageFromReason({ error: "wrapped" })).toBe("wrapped");
+  });
+
+  it("returns empty string for values it cannot read", () => {
+    expect(skewMessageFromReason(null)).toBe("");
+    expect(skewMessageFromReason(undefined)).toBe("");
+    expect(skewMessageFromReason(42)).toBe("");
+    expect(skewMessageFromReason({})).toBe("");
+  });
+});
+
+describe("isDeploymentSkewReason", () => {
+  it("matches skew inside Error, ErrorEvent, and PromiseRejectionEvent shapes", () => {
+    expect(
+      isDeploymentSkewReason(new Error("An unexpected response was received from the server.")),
+    ).toBe(true);
+    // ErrorEvent.
+    expect(isDeploymentSkewReason({ message: "ChunkLoadError: Loading chunk 4 failed." })).toBe(true);
+    // PromiseRejectionEvent.reason as an Error.
+    expect(
+      isDeploymentSkewReason({
+        reason: new Error('Failed to find Server Action "abc". This request might be from an older or newer deployment.'),
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores non-skew reasons", () => {
+    expect(isDeploymentSkewReason(new Error("Failed to fetch"))).toBe(false);
+    expect(isDeploymentSkewReason({ message: "Cannot read properties of undefined" })).toBe(false);
+    expect(isDeploymentSkewReason(null)).toBe(false);
+  });
+});
+
+describe("isBundleMismatch", () => {
+  it("is true when a known bundleHash or version changed", () => {
+    expect(
+      isBundleMismatch({ version: "1", bundleHash: "aaa" }, { version: "1", bundleHash: "bbb" }),
+    ).toBe(true);
+    expect(
+      isBundleMismatch({ version: "1", bundleHash: "aaa" }, { version: "2", bundleHash: "aaa" }),
+    ).toBe(true);
+  });
+
+  it("is false when identities match", () => {
+    expect(
+      isBundleMismatch({ version: "1", bundleHash: "aaa" }, { version: "1", bundleHash: "aaa" }),
+    ).toBe(false);
+  });
+
+  it("never treats 'unknown' or missing values as a mismatch (anti-loop invariant)", () => {
+    // `next dev` reports "unknown" on both sides — must not loop-reload.
+    expect(
+      isBundleMismatch({ version: "unknown", bundleHash: "unknown" }, { version: "unknown", bundleHash: "unknown" }),
+    ).toBe(false);
+    // One side unknown → indeterminate, not a mismatch.
+    expect(
+      isBundleMismatch({ version: "1", bundleHash: "unknown" }, { version: "1", bundleHash: "bbb" }),
+    ).toBe(false);
+    expect(
+      isBundleMismatch({ bundleHash: "aaa" }, { bundleHash: null }),
+    ).toBe(false);
+    expect(isBundleMismatch(null, { bundleHash: "aaa" })).toBe(false);
+    expect(isBundleMismatch({ bundleHash: "aaa" }, null)).toBe(false);
   });
 });

--- a/apps/web/lib/deployment-skew.ts
+++ b/apps/web/lib/deployment-skew.ts
@@ -32,3 +32,96 @@ export const SKEW_RELOAD_KEY = "dpf-skew-reload-at";
  *  reload didn't fix it, so the boundary must fall through to the real crash
  *  screen instead of loop-reloading. */
 export const SKEW_RELOAD_WINDOW_MS = 60_000;
+
+// ── BI-F381D902: catch skew that never reaches the crash boundary ────────────
+//
+// The crash boundary (app/(shell)/error.tsx) only auto-recovers skew errors
+// that BUBBLE UP to it. Many interactions swallow the failure instead — the
+// coworker composer, for example, catches its send error and flips the message
+// to a "failed" state, so the boundary never sees it and the user is left with
+// a dead button and no recovery hint. The global skew sentinel
+// (components/shell/DeploymentSkewBanner) closes that gap two ways, both built
+// on the helpers below: it listens for skew errors at the window level (for the
+// throws that aren't swallowed) AND proactively compares the tab's boot
+// identity to the running deployment on tab refocus (for the swallowed case).
+
+/** Pulls a message string out of an Error, string, ErrorEvent, or
+ *  PromiseRejectionEvent so window-level listeners can be matched with
+ *  {@link isDeploymentSkewError}. */
+export function skewMessageFromReason(reason: unknown): string {
+  if (reason == null) return "";
+  if (typeof reason === "string") return reason;
+  if (reason instanceof Error) return reason.message;
+  if (typeof reason === "object") {
+    const record = reason as { message?: unknown; reason?: unknown; error?: unknown };
+    if (typeof record.message === "string" && record.message) return record.message;
+    if (record.reason != null && record.reason !== reason) return skewMessageFromReason(record.reason);
+    if (record.error != null && record.error !== reason) return skewMessageFromReason(record.error);
+  }
+  return "";
+}
+
+/** True when an arbitrary error/event object carries a deployment-skew
+ *  signature (convenience wrapper over {@link isDeploymentSkewError} for
+ *  `unhandledrejection` / `error` listeners). */
+export function isDeploymentSkewReason(reason: unknown): boolean {
+  return isDeploymentSkewError(skewMessageFromReason(reason));
+}
+
+/** The version/bundle identity of a specific deployment. */
+export type DeploymentIdentity = { version?: string | null; bundleHash?: string | null };
+
+function isKnownIdentityValue(value: string | null | undefined): value is string {
+  return Boolean(value) && value !== "unknown";
+}
+
+/**
+ * True when the running deployment's identity differs from the tab's boot
+ * identity. Only a change between two *known* values counts — any "unknown" or
+ * missing value on either side returns false.
+ *
+ * Anti-loop invariant (BI-864E83B0-followup): boot hash and the API hash both
+ * derive from getDeployedSha/DEPLOYED_SHA, and a bare `next dev` reports
+ * "unknown" on both. Treating "unknown" as a mismatch would drive a permanent
+ * reload loop, so it never counts.
+ */
+export function isBundleMismatch(
+  boot: DeploymentIdentity | null | undefined,
+  served: DeploymentIdentity | null | undefined,
+): boolean {
+  if (!boot || !served) return false;
+  const versionChanged =
+    isKnownIdentityValue(served.version) &&
+    isKnownIdentityValue(boot.version) &&
+    served.version !== boot.version;
+  const bundleChanged =
+    isKnownIdentityValue(served.bundleHash) &&
+    isKnownIdentityValue(boot.bundleHash) &&
+    served.bundleHash !== boot.bundleHash;
+  return versionChanged || bundleChanged;
+}
+
+/** Reads the boot identity injected as window.__DPF_BOOT__ by the root layout. */
+export function readBootIdentity(): DeploymentIdentity | null {
+  if (typeof window === "undefined") return null;
+  const boot = (window as { __DPF_BOOT__?: DeploymentIdentity }).__DPF_BOOT__;
+  return boot ?? null;
+}
+
+/**
+ * Fetches the running deployment's identity from the internal quiescence-state
+ * route (the same endpoint PlatformBanner compares against). Best-effort:
+ * returns null on any failure — the route can be briefly unreachable mid-swap —
+ * so callers treat null as "can't tell yet", never as a mismatch.
+ */
+export async function fetchServedIdentity(): Promise<DeploymentIdentity | null> {
+  if (typeof window === "undefined") return null;
+  try {
+    const res = await fetch("/api/internal/quiescence-state", { cache: "no-store" });
+    if (!res.ok) return null;
+    const body = (await res.json()) as DeploymentIdentity;
+    return { version: body.version ?? null, bundleHash: body.bundleHash ?? null };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Why

DPF self-upgrades autonomously, so every long-lived browser tab eventually crosses a container swap. Its next server action then fails with *"Failed to find Server Action … This request might be from an older or newer deployment."* From the user's chair the button just does nothing — no toast, no error, no recovery hint (observed live 2026-07-06 on the coworker panel: the exact **"Sending…" dead-panel** an operator hit this week).

The crash boundary (BI-D22D4607, #2670) already auto-reloads once — **but only for errors that bubble up to it.** The coworker composer and other surfaces catch the failure locally and flip to a "failed" state, so the boundary never sees it. That swallowed case is the gap this closes.

## What

A global `DeploymentSkewBanner` mounted in the shell banner overlay, built on the **existing** `lib/deployment-skew` module (no duplication):

- **Reactive** — window-level `error` / `unhandledrejection` listeners catch skew throws that are *not* swallowed.
- **Proactive** — compares the tab's boot identity (`window.__DPF_BOOT__`) against the running deployment (`/api/internal/quiescence-state`) shortly after mount, on tab refocus, and on a **visible-only 60s poll**. This catches the **swallowed** case, including a tab that stayed focused straight through the swap.

On detection it shows a friendly, non-dismissible **"Reload to continue"** banner. Reload is **user-initiated** (a button, not auto-reload) so a half-typed message is never discarded, and there is **no reload-loop risk**.

The `"unknown"`-is-never-a-mismatch anti-loop invariant (BI-864E83B0-followup) is preserved and unit-tested.

## Scope

UI layer only; zero schema/read-model change. Extends `lib/deployment-skew.ts` and reuses `ShellBannerOverlay` + the already-injected boot identity.

## Tests

- `lib/deployment-skew.test.ts` — new identity-comparison + event-aware matcher cases (mismatch logic, unknown-guard, Error/ErrorEvent/PromiseRejectionEvent extraction).
- `components/shell/DeploymentSkewBanner.test.tsx` — swallowed case (served-bundle mismatch with no thrown error → prompt), non-swallowed case (window skew error → prompt), no-false-positive (matching identity → hidden), ordinary error ignored.

UX-Fit-Decision: fits-with-guardrails — portal-global chrome under EP-BS-UX-HARDENING (honest status surfaces); no new route; extends existing skew module; reload is an explicit user action.

Process-Spine-Decision: UI recovery affordance only — extends the existing lib/deployment-skew module and shell overlay; no contract/schema/read-model/doc surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)