### PR TITLE
docs(founder-kernel): finish WWMD recontextualization — it4it-substrate + data-spine (EP-0AF96937, BI-37C8E50B)

### DIFF
--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,5 +1,5 @@
 {
-  "kernelVersion": "0.4.1",
+  "kernelVersion": "0.4.2",
   "schemaVersion": "0.3.0",
   "pageCount": 94,
   "sourceCount": 15,

--- a/docs/founder-kernel/wiki/heuristics/auto-populate-or-its-wrong.md
+++ b/docs/founder-kernel/wiki/heuristics/auto-populate-or-its-wrong.md
@@ -2,7 +2,7 @@
 title: Auto-populate or it's already wrong
 pageKind: heuristic
 status: published
-abstract: It is not humanly possible to manually track the rapid inflation and deflation of virtualised cloud, hybrid, and on-prem resources. If your CMDB depends on humans to enter records, it's already lying to you.
+abstract: Any operational record that depends on a human to keep it current is already lying to you — the rate of change outruns manual entry. Auto-populate or accept that the record is decoration. Applies to a CMDB, and equally to DPF's own data spine that its coworkers reason off.
 sources:
   - frameworks/csdm
 ---
@@ -13,7 +13,7 @@ sources:
 
 ## When it applies
 
-Designing a CMDB, an asset inventory, a software catalog, a service registry, or any operational data source that needs to reflect current reality. Also: AI-co-worker context surfaces that rely on platform data being accurate.
+Designing any operational data source that needs to reflect current reality — a CMDB, an asset inventory, a software catalog, a service registry, or the DPF data spine and context surfaces a coworker recalls from. If a decision will be made off the record, the record has to keep itself current.
 
 ## Why it works
 

--- a/docs/founder-kernel/wiki/heuristics/find-at-least-one-champion.md
+++ b/docs/founder-kernel/wiki/heuristics/find-at-least-one-champion.md
@@ -11,9 +11,7 @@ sources:
 
 > Any standard or framework adoption needs **at least one internal champion** — preferably more — who will evangelise the standard between meetings. Without that, adoption stalls regardless of how good the standard is.
 
-## When it applies
-
-Adopting `[[entities/it4it]]`, TOGAF, `[[entities/csdm]]`, or any operating-model framework inside an organisation that doesn&#39;t yet use it. Also: introducing a new architectural pattern, a new tooling category, or a new portfolio discipline.
+This is a **human** adoption tactic — it governs how people take up a new way of working, not how an agent operates. It applies when adopting `[[entities/it4it]]`, TOGAF, `[[entities/csdm]]`, or any operating-model framework inside an organisation that doesn&#39;t yet use it; introducing a new architectural pattern, tooling category, or portfolio discipline; and — most concretely for DPF — **onboarding a company onto the platform**. Rolling out DPF is a standards adoption like any other: the champion is the operator who actually starts giving a coworker real work and comes back the next week, not the executive who approved the pilot. Find that person and the adoption has continuity between sessions.
 
 ## Why it works
 

--- a/docs/founder-kernel/wiki/heuristics/pitch-simple-adjust-per-audience.md
+++ b/docs/founder-kernel/wiki/heuristics/pitch-simple-adjust-per-audience.md
@@ -2,7 +2,7 @@
 title: Pitch simple, adjust per audience
 pageKind: heuristic
 status: published
-abstract: Lead with the simplest framing the audience can ingest. Adjust language per audience — "framework for managing IT," "operating model," "reference architecture." Never lead with the model itself.
+abstract: Lead with the simplest framing the audience can ingest, and adjust language per audience — never lead with the model itself. Originally a framework-evangelism tactic; in DPF it is how a coworker frames a recommendation for the operator in front of it.
 sources:
   - articles/open-group-2017-managing-business-of-it
   - articles/briefings-direct-it4it-2019
@@ -10,31 +10,34 @@ sources:
 
 ## The heuristic
 
-> When evangelising a standard or framework, **lead with the simplest framing the specific audience can ingest** and adjust per audience. Never lead with the model.
->
-> *"I pitch it as a framework for managing IT and leave it at that. I might also say it&#39;s an operating model."*
+> When explaining anything built on a model — a framework, an architecture, a recommendation — **lead with the simplest framing the specific audience can ingest** and adjust per audience. Never lead with the model.
 
 ## When it applies
 
-Introducing `[[entities/it4it]]`, TOGAF, `[[entities/csdm]]`, or any framework to a new audience. Executive briefings. Board-level investment conversations. Cross-functional alignment meetings where the audience is mixed.
+- **A DPF coworker reporting to an operator.** The same call — "retire this product," "consolidate these two" — should be framed for its reader: an outcome for a founder, a trade-off for an operator, a mechanism for an engineer. This is the operational partner of `[[stances/ea-is-meteorology]]`: deliver the forecast, and phrase the forecast for whoever receives it.
+- **Introducing a standard or framework** (`[[entities/it4it]]`, TOGAF, `[[entities/csdm]]`) to a new audience — the original setting for this rule.
+- Executive briefings, board-level investment conversations, and cross-functional alignment meetings where the audience is mixed.
 
 ## Why it works
 
-Frameworks have layers. The audience doesn&#39;t need the whole stack on first contact — they need the entry point that lets them place the framework in their existing mental model. Once it&#39;s placed, depth follows naturally as questions surface.
+Anything built on a model has layers. The audience doesn&#39;t need the whole stack on first contact — they need the entry point that lets them place it in their existing mental model. Once it&#39;s placed, depth follows naturally as questions surface.
 
-For executives at commercial enterprises, "framework for managing IT" or "operating model" works. For federal CIOs, connect to FITARA and FEA — those are the words that map onto the framework they&#39;re already operating in. For architects in a TOGAF-fluent org, lead with reference architecture; the value-stream layer follows.
+The original evangelism example makes the mechanic concrete: *"I pitch IT4IT as a framework for managing IT and leave it at that. I might also say it&#39;s an operating model."* For executives at commercial enterprises, "framework for managing IT" or "operating model" works. For federal CIOs, connect to FITARA and FEA — those are the words that map onto the framework they&#39;re already operating in. For architects in a TOGAF-fluent org, lead with reference architecture; the value-stream layer follows.
 
-The corollary: **don&#39;t evangelise depth that the audience didn&#39;t ask for**. If they engage, they&#39;ll ask. If they don&#39;t engage, more detail won&#39;t change their mind.
+The same discipline governs a coworker&#39;s output. A coworker that dumps its full reasoning chain on every operator has led with the model. Lead with the call and the one framing that operator can act on; keep the model one click away for whoever asks.
+
+The corollary: **don&#39;t evangelise depth the audience didn&#39;t ask for**. If they engage, they&#39;ll ask. If they don&#39;t, more detail won&#39;t change their mind.
 
 ## Counterexamples
 
-- Peer-to-peer technical reviews where everyone already knows the framework — pitch the depth.
+- Peer-to-peer technical reviews where everyone already knows the model — pitch the depth. (Two architects, or two agents exchanging a structured handoff, need the model itself.)
 - Compliance contexts where the standard&#39;s specific structure matters for audit.
-- Adoption planning sessions where you&#39;re past the "what is this?" stage and into the "how do we contextualise it?" stage.
+- Adoption-planning sessions past the "what is this?" stage and into the "how do we contextualise it?" stage.
 
 ## See also
 
 - Parent stance: `[[stances/contextualize-dont-transform]]`
 - Parent stance: `[[stances/it4it-is-substrate]]`
+- Related stance: `[[stances/ea-is-meteorology]]` — deliver the forecast, not the raw model.
 - Related heuristic: `[[heuristics/find-at-least-one-champion]]`
 - Related heuristic: `[[heuristics/contextualize-before-transforming]]`

--- a/docs/founder-kernel/wiki/index.md
+++ b/docs/founder-kernel/wiki/index.md
@@ -45,9 +45,9 @@ The judgment kernel. Cite these when grounding an answer in his thinking.
 
 - `[[stances/digital-product-is-the-unit-of-organization]]` — Digital Product is the right primitive for portfolio, team, funding, lifecycle, governance.
 - `[[stances/persistent-product-teams-over-projects]]` — Replace project teams with persistent teams; annual budgets with rolling investment.
-- `[[stances/it4it-is-substrate]]` — IT4IT integrates ITIL, COBIT, TOGAF, DevOps, SAFe at the operating-model layer. It does not compete.
+- `[[stances/it4it-is-substrate]]` — IT4IT integrates ITIL, COBIT, TOGAF, DevOps, SAFe at the operating-model layer. It does not compete. DPF is built on it: the platform&#39;s lifecycle, teams, and coworker routing key off IT4IT&#39;s seven value streams.
 - `[[stances/dont-integrate-ea-platform]]` — Consolidate on one canonical data model; don&#39;t integrate two systems of record for the same entities. The integration goes through Independent → Honeymoon → Ugly Reckoning. This is why DPF is one platform, not a hub.
-- `[[stances/trust-the-cmdb-or-rebuild-it]]` — Most organisations have a CMDB; very few trust it. Trust requires three pillars: Ingestion, Insight, Governance.
+- `[[stances/trust-the-cmdb-or-rebuild-it]]` — A coworker&#39;s decisions are only as trustworthy as the record beneath them. A trusted data spine needs three pillars: Ingestion, Insight, Governance. The CMDB is the war-story where the lesson was learned.
 - `[[stances/ea-is-meteorology]]` — Deliver forecasts, not raw models. A coworker reports a recommendation with confidence and trade-offs; WWMD/WWWD/WSID are forecast questions.
 - `[[stances/contextualize-dont-transform]]` — When introducing a standard or onboarding a company onto DPF, map the current operating model first. Adoption follows mapping; the map becomes the org&#39;s WWWD overlay.
 
@@ -57,7 +57,7 @@ Smaller and more specific than stances. Useful when an agent needs to act, not j
 
 - `[[heuristics/contextualize-before-transforming]]` — map existing operations onto the standard first.
 - `[[heuristics/find-at-least-one-champion]]` — adoption without an internal evangelist stalls.
-- `[[heuristics/pitch-simple-adjust-per-audience]]` — lead with the simplest framing; adjust language per audience.
+- `[[heuristics/pitch-simple-adjust-per-audience]]` — lead with the simplest framing; adjust per audience. Also how a coworker frames a recommendation for the operator in front of it.
 - `[[heuristics/model-what-naturally-happens]]` — connect relationships that already exist; don&#39;t build a data lake.
 - `[[heuristics/auto-populate-or-its-wrong]]` — manually-maintained inventory data is already lying to you.
 - `[[heuristics/reuse-the-camera-in-your-pocket]]` — platform-native usually wins over specialist best-of-breed.

--- a/docs/founder-kernel/wiki/stances/it4it-is-substrate.md
+++ b/docs/founder-kernel/wiki/stances/it4it-is-substrate.md
@@ -2,7 +2,7 @@
 title: IT4IT is the substrate — a hub of frameworks, not a competitor
 pageKind: stance
 status: published
-abstract: IT4IT integrates ITIL, COBIT, TOGAF, DevOps, and SAFe at the operating-model layer. It does not replace them. Pitch it as a framework for managing IT, or as an operating model, depending on audience.
+abstract: IT4IT integrates ITIL, COBIT, TOGAF, DevOps, and SAFe at the operating-model layer — it does not replace them. This is why DPF's own lifecycle, teams, and coworker routing are organised around IT4IT's seven value streams rather than a home-grown process model.
 sources:
   - articles/briefings-direct-it4it-2019
   - articles/open-group-2017-managing-business-of-it
@@ -16,19 +16,30 @@ sources:
 
 This positioning matters because every framework conversation tends to devolve into framework-vs-framework debate. IT4IT short-circuits that: ITIL owns service operations; COBIT owns governance; TOGAF owns the modeling vocabulary; DevOps and SAFe own delivery; IT4IT owns the integration between them.
 
+This is not an abstract framework preference — it is the operating-model spine DPF is built on. DPF does not invent a bespoke lifecycle; it adopts IT4IT&#39;s seven `[[entities/value-stream]]` flows as the canonical shape that every product, team, and coworker keys off. The stance below is why the platform has that shape.
+
 ## Why
 
 I&#39;ve worked with IT4IT since the forum&#39;s 2014 inception (100+ engagements since 2013). Every successful adoption I&#39;ve seen starts with the same insight: the customer already has ITIL, already has some flavour of COBIT, often has TOGAF, and increasingly has DevOps and SAFe. The question isn&#39;t "which framework wins?" — it&#39;s "how do they coexist without contradicting each other?"
 
-IT4IT&#39;s seven value streams (Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume) are the seam where the other frameworks plug in. ITIL processes attach to Operate. DevOps practices attach to Integrate/Deploy/Release. TOGAF models attach to Explore. COBIT controls thread through all seven.
+IT4IT&#39;s seven value streams (Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume) are the seam where the other frameworks plug in. ITIL processes attach to Operate. DevOps practices attach to Integrate/Deploy/Release. TOGAF models attach to Explore. COBIT controls thread through all seven. Adopt the substrate and the framework-vs-framework fight simply stops — each one keeps its job and attaches where it belongs.
 
-The executive pitch reflects this: **"I pitch it as a framework for managing IT and leave it at that. I might also say it&#39;s an operating model."** Lead with the simple framing the audience can ingest; let the integration value reveal itself through use.
+## How DPF uses it
+
+The "substrate" claim is not rhetorical in DPF — it is wired into the data model. The platform keys off the seven canonical value-stream slugs (`evaluate`, `explore`, `integrate`, `deploy`, `release`, `operate`, `consume`) everywhere a flow appears:
+
+- **Teams and gates are value-stream-shaped.** Value-stream teams, their roles, and their human-in-the-loop gates are first-class rows, not tags bolted onto a generic project object.
+- **Coworkers route by value stream.** A coworker tags each unit of work with the value stream it belongs to, so the platform can reason about — and report on — activity by flow rather than by ticket.
+- **Capabilities and portfolios crosswalk to the seven streams.** Business-capability perspectives and the IT4IT crosswalk map onto the same slugs, so a `[[entities/digital-product]]` can be read by its value-stream coverage.
+
+Because the spine is IT4IT rather than a DPF invention, a company adopting DPF is never asked to abandon the frameworks it already runs. ITIL keeps working and attaches at Operate; TOGAF keeps working and attaches at Explore. That is `[[stances/contextualize-dont-transform]]` applied to the platform itself: DPF gives the customer the integrating substrate they were missing, not a rival framework to migrate onto.
 
 ## When this applies
 
 - Any conversation that&#39;s starting to turn into framework-vs-framework.
-- Executive sponsor briefings where the audience is fluent in ITIL or TOGAF but not IT4IT.
-- Standards adoption decisions where the question is "which standard do we pick?"
+- Designing or extending a DPF surface that touches lifecycle, team structure, or work routing — reach for the seven value streams, not a new bespoke process model.
+- Standards-adoption decisions where the question is "which standard do we pick?"
+- Onboarding a company that already runs ITIL or TOGAF onto DPF — position DPF as the substrate their frameworks plug into.
 
 ## When it doesn&#39;t
 
@@ -38,11 +49,12 @@ The executive pitch reflects this: **"I pitch it as a framework for managing IT 
 ## Heuristics derived from this stance
 
 - `[[heuristics/contextualize-before-transforming]]` — map IT4IT onto current operations, don&#39;t flip the operating model.
-- `[[heuristics/pitch-simple-adjust-per-audience]]` — the executive-pitch tactic.
+- `[[heuristics/pitch-simple-adjust-per-audience]]` — how to frame IT4IT (or DPF) for the audience in front of you.
 - `[[heuristics/find-at-least-one-champion]]` — adoption needs an evangelist.
 
 ## See also
 
 - Entity: `[[entities/it4it]]`
 - Entity: `[[entities/value-stream]]`
+- Stance: `[[stances/digital-product-is-the-unit-of-organization]]` — the spine operates on Digital Products.
 - Raw source: `[raw-sources/articles/briefings-direct-it4it-2019](../../raw-sources/articles/briefings-direct-it4it-2019.md)`

--- a/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
+++ b/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
@@ -1,39 +1,41 @@
 ---
-title: Trust the CMDB or rebuild it on the three pillars
+title: Trust your data spine or rebuild it on the three pillars
 pageKind: stance
 status: published
-abstract: Most organisations have a CMDB; very few actually trust it. Trust is built through Ingestion (auto-populate), Insight (actually use the data), and Governance & Health (people and process). If any pillar is missing, the CMDB is lying to you.
+abstract: A coworker's decisions are only as trustworthy as the record beneath them. A trusted data spine rests on three pillars — Ingestion (auto-populate), Insight (actually use it), and Governance & Health (someone owns and prunes it). Miss any pillar and the record is lying to you. The CMDB is the war-story where this lesson was learned.
 sources:
   - frameworks/csdm
 ---
 
 ## The position
 
-Most organisations have a CMDB. Very few actually trust it. **Trust is the only quality of a CMDB that matters** — an untrusted CMDB is technical debt that compounds.
+Any system that reasons off a record of what an organisation runs — a CMDB, a `[[entities/digital-product]]` model, DPF&#39;s own canonical data spine — is **only as trustworthy as that record**. Most organisations have such a record. Very few actually trust it. **Trust is the only quality of the record that matters** — an untrusted spine is technical debt that compounds, and every decision grounded on it inherits the lie.
 
 Trust rests on three pillars:
 
 1. **Ingestion** — auto-populate. It is not humanly possible to manually track the rapid inflation and deflation of virtualised cloud resources, hybrid environments, and on-premises infrastructure.
-2. **Insight** — actually use the data for operations and planning. A CMDB nobody queries is a CMDB nobody fixes.
+2. **Insight** — actually use the data for operations and planning. A record nobody queries is a record nobody fixes.
 3. **Governance &amp; Health** — people and process, not just tech. Someone has to own the model, someone has to triage discoveries, someone has to retire stale rows.
 
-If any pillar is missing, the CMDB is lying to you — and acting on it produces wrong decisions you&#39;ll only discover months later.
+If any pillar is missing, the record is lying to you — and acting on it produces wrong decisions you&#39;ll only discover months later.
 
 ## Why
 
-The CMDB problem isn&#39;t that the data model is hard. `[[entities/csdm]]` (currently at v5) has settled the model question — it&#39;s the canonical spine. The problem is that organisations stand up the data model without standing up the three pillars, then are surprised when the CMDB stops being useful.
+In DPF this is not an analogy — it is the acceptance test for the platform&#39;s own spine. DPF&#39;s coworkers reason off its canonical data model the way an ITSM team reasons off a CMDB. So the three pillars apply directly: if DPF&#39;s model isn&#39;t auto-populated (Ingestion), actually used by the coworkers making calls (Insight), and owned and pruned (Governance), then every `[[stances/ea-is-meteorology]]` forecast — every WWMD, WWWD, and WSID recommendation — is grounded on decoration. A decision surface is only as trustworthy as the record beneath it; this stance is that constraint made explicit.
 
-The technical-debt use case was where this lesson originally landed. The early ServiceNow Technology Portfolio Management work hit the wall on technical-debt reporting because there was no single source of truth across asset, dev, ops, ITSM, and CSM. **The vision was to create a common model that connects what naturally happens. CSDM was born.** The same lesson kept replaying across every customer: model alone isn&#39;t enough.
+The failure is never that the data model is hard. `[[entities/csdm]]` (currently at v5) settled the model question a decade ago. The failure is standing up the model without standing up the three pillars, then being surprised when the record stops being useful.
 
-The ROI conversation that lands with executives is tool consolidation: organisations routinely have 300+ tools doing the same IT function (monitoring is the canonical example). You can&#39;t rationalise that without a trusted CMDB to tell you which tool does what. Build the three pillars; the rationalisation funds itself.
+### The war-story: the CMDB and technical-debt reporting
 
-The lesson generalises past the CMDB. "CMDB" is the ITSM name for *the record of what you run*; DPF has the same record in its own canonical data model, and its coworkers reason off it. The three pillars are the acceptance test for any such record: if DPF&#39;s model isn&#39;t auto-populated (Ingestion), actually used by the coworkers making calls (Insight), and owned and pruned (Governance), then every WWMD/WWWD/WSID recommendation grounded in it inherits the same lie. A decision surface is only as trustworthy as the record beneath it.
+The lesson originally landed on the CMDB. The early ServiceNow Technology Portfolio Management work hit the wall on technical-debt reporting because there was no single source of truth across asset, dev, ops, ITSM, and CSM. **The vision was to create a common model that connects what naturally happens. CSDM was born.** The same lesson replayed across every customer: model alone isn&#39;t enough.
+
+The ROI conversation that landed with executives was tool consolidation — organisations routinely run 300+ tools doing the same IT function (monitoring is the canonical example), and you can&#39;t rationalise that without a trusted record to tell you which tool does what. Build the three pillars; the rationalisation funds itself. "CMDB" was simply the ITSM name for *the record of what you run* — the pillars are the same wherever that record lives.
 
 ## When this applies
 
-- Standing up a new CMDB.
-- Rescuing a CMDB that&#39;s lost the team&#39;s trust.
-- Designing data foundations for cross-product reasoning, AI co-workers, or rationalisation initiatives.
+- Designing data foundations for cross-product reasoning, AI coworkers, or rationalisation initiatives — including DPF&#39;s own canonical model.
+- Standing up a new CMDB, or rescuing one that&#39;s lost the team&#39;s trust.
+- Any decision surface whose recommendations are only as good as the record they read from.
 
 ## When it doesn&#39;t
 
@@ -48,5 +50,6 @@ The lesson generalises past the CMDB. "CMDB" is the ITSM name for *the record of
 ## See also
 
 - Entity: `[[entities/csdm]]`
-- Stance: `[[stances/dont-integrate-ea-platform]]` — why one trusted CMDB beats two integrated ones.
+- Stance: `[[stances/dont-integrate-ea-platform]]` — why one trusted record beats two integrated ones.
+- Stance: `[[stances/ea-is-meteorology]]` — the forecast inherits the trust of the record beneath it.
 - Raw source: `[raw-sources/frameworks/csdm](../../raw-sources/frameworks/csdm.md)`

--- a/docs/superpowers/plans/2026-07-08-wwmd-corpus-residual-recontextualization-plan.md
+++ b/docs/superpowers/plans/2026-07-08-wwmd-corpus-residual-recontextualization-plan.md
@@ -1,0 +1,95 @@
+# WWMD Corpus — Residual Recontextualization: Review & Plan
+
+**Date:** 2026-07-08
+**Scope:** The founder-kernel WWMD corpus under `docs/founder-kernel/wiki/` — finish the ServiceNow/EA → DPF recontextualization the prior pass (PRs #2591, #2623) left uneven. WWWD (per-org overlay at onboarding) is explicitly **out of scope for this pass** — deferred follow-on per the operator's "do this for WWMD for now."
+**Status:** Review + plan. Not yet a filed BI. §5 covers filing/execution.
+**Supersedes:** [2026-07-04-wwmd-corpus-recontextualization-plan.md](2026-07-04-wwmd-corpus-recontextualization-plan.md) — that plan predates the two merges; this one is re-grounded against current `origin/main`.
+
+---
+
+## 0. The reframe (read this first)
+
+The `/wiki` screenshot that triggered this shows the **stale live portal**, not un-done work. The live install only updates via self-upgrade, and it is behind `origin/main`. On `origin/main` the two genuinely ServiceNow-narrow stances are **already rewritten**:
+
+| Live portal (stale) shows | `origin/main` actually says |
+|---|---|
+| "Don't integrate a third-party EA platform with ServiceNow…" | **"Consolidate on one canonical data model — don't integrate two systems of record"** — ServiceNow demoted to an explicit `### The war-story` subsection; body opens "This is the conviction DPF is built on." |
+| "EA is meteorology — provide forecasts, not raw models" | **"Deliver forecasts, not raw models"** — body reframed around WWMD/WWWD/WSID as "forecast questions" and "how every coworker reports to an operator." |
+
+So the first action is **not** authoring — it's recognizing that a self-upgrade will make the live surface match main for those two. The prior pass was real and good on those two.
+
+**But it was uneven.** A cluster of pages still teaches in pure EA-consultant terms with zero DPF tie-in. That residual is this plan.
+
+## 1. Evidence — where ServiceNow framing still dominates the *body*
+
+Measured on `origin/main` (body mentions of ServiceNow/CMDB/executive/pitch/briefing/engagement, excluding `sources:` and cited raw-source links, vs. count of DPF/coworker/operator refs):
+
+| Page | SN-terms | DPF-refs | Verdict |
+|---|---|---|---|
+| `stances/it4it-is-substrate` | 3 | **0** | ❌ **Pure consultant voice** — "I pitch it as a framework for managing IT," "100+ engagements since 2013," executive-sponsor briefings. No DPF tie-in at all. **The clear miss.** |
+| `stances/trust-the-cmdb-or-rebuild-it` | 9 | 1 | ⚠️ Has one good "generalises past the CMDB → DPF's own model" paragraph, but title, abstract, and the whole "Why" still lead CMDB/ServiceNow-first. |
+| `heuristics/pitch-simple-adjust-per-audience` | 4 | 0 | ⚠️ Executive-pitch / federal-CIO / FITARA tactic. Never mentions a coworker adjusting framing for an operator. |
+| `heuristics/find-at-least-one-champion` | 3 | 0 | ⚠️ Human change-management tactic (hand out the printed IT4IT book). Genuinely human — re-scope, don't over-DPF-ify. |
+| `heuristics/auto-populate-or-its-wrong` | 5 | 1 | 🟡 Already has a DPF paragraph; only the lead is CMDB-first. Light tightening. |
+| `entities/csdm` | — | 2 | 🟡 Already has a "How DPF uses it" section mapping to Prisma `DigitalProduct`/`Portfolio`/`Service`. Reasonable; optional reframe only. |
+| `stances/digital-product-is-the-unit-of-organization` | 1 | 0 | 🟡 Already the canonical DPF primitive; body's 25-yr Dell/Troux/HPE/SN arc is legit *provenance*. Leave, or one-line DPF anchor. |
+
+**False positives (do not touch):** `principles/consult-scopes-before-asking`, `consult-specs-first` — "consult" = "consult scopes/specs" (DPF engineering doctrine), not "consultant." `trust-the-data-spine` — already the genericized DPF sibling. These are clean; the earlier "0 of 92 principles are SN-narrow" verdict holds.
+
+## 2. The distilled vector (unchanged from prior pass — restated so authoring stays on-target)
+
+> **Product-centric, one cohesive data model, and — in the age of agentic AI — the deliverable is guidance and action on the *whole*, not reports, diagrams, or integrations between silos.**
+
+The two exemplars remain the templates:
+- **Genericize** → [principles/optimize-for-the-whole.md](../../founder-kernel/wiki/principles/optimize-for-the-whole.md): lift the lesson to a substrate-agnostic rule; ServiceNow becomes *one example*.
+- **Contextualize** → [principles/native-cohesion-over-interfacing.md](../../founder-kernel/wiki/principles/native-cohesion-over-interfacing.md): rewrite the primary example in DPF terms; keep the SN origin as cited provenance.
+
+The already-done `dont-integrate-ea-platform` and `ea-is-meteorology` are now *also* reference-quality exemplars — mirror their structure (generic Position → DPF anchor → SN kept as `### The war-story`).
+
+## 3. Per-page disposition (residual only)
+
+| Page | Disposition | Concrete change |
+|---|---|---|
+| **`stances/it4it-is-substrate`** | **Contextualize (primary work item)** | IT4IT genuinely *is* DPF's operating-model spine — its seven value streams (Evaluate…Consume) already route the platform. Add a "How DPF uses it" section that says so (tie to the value-stream routing that exists in the platform). Move the "I pitch it as…" / executive-briefing content **out** of the stance and into `pitch-simple-adjust-per-audience` where a pitch tactic belongs. Keep the 100+-engagements line only as first-person provenance, demoted below the DPF framing. |
+| **`stances/trust-the-cmdb-or-rebuild-it`** | **Contextualize** | Retitle away from "CMDB" → the trusted **data spine** (align with existing `principles/trust-the-data-spine`). Lead with the generic three-pillar rule (Ingestion / Insight / Governance); demote the ServiceNow TPM/CSDM origin to a war-story block. Promote the existing "every WWMD/WWWD/WSID recommendation inherits the lie if the spine is untrusted" paragraph to the top of "Why." Keep slug stable (retitle via frontmatter only — ~160 inbound wikilinks). |
+| **`heuristics/pitch-simple-adjust-per-audience`** | **Genericize** | Recast as: a coworker leads with the simplest framing the *operator* can ingest and adjusts per audience — the persona/voice rule. Absorb the IT4IT executive-pitch example relocated from `it4it-is-substrate` as *one* illustration, not the subject. |
+| **`heuristics/find-at-least-one-champion`** | **Keep, re-scope (light)** | Genuinely a human change-management tactic. Scope it to the `human`/onboarding population; add one line that in a DPF adoption the "champion" is the operator who actually starts using a coworker. Do **not** force-fit an agent framing. |
+| **`heuristics/auto-populate-or-its-wrong`** | **Genericize (light)** | Already 80% there. Flip the lead from CMDB-first to "any record a coworker recalls from"; keep the CMDB as the ITSM instance. |
+| `entities/csdm` | **Optional** | Already contextualized. Only touch if we reframe the title to "DPF's canonical data model (CSDM-lineage)"; otherwise leave. Low value. |
+| `stances/digital-product-is-the-unit-of-organization` | **Optional** | Leave, or add a single sentence anchoring to the Prisma `DigitalProduct` row as the canonical primitive. Provenance arc is fine as-is. |
+
+## 4. Hard authoring constraints (verified against SCHEMA.md / AUTHORING.md and the prior pass)
+
+1. **`raw-sources/` is immutable.** The ServiceNow origin stays *cited*; it just stops being the *frame*.
+2. **Slugs are stable.** Retitle via frontmatter `title:` only — never rename a file. `dangling-xref` is publish-blocking, and there are ~160 inbound `[[wikilinks]]`.
+3. **Corpus conventions:** wrap wikilinks in backticks `` `[[slug]]` `` (renderer keys on the code-span form); HTML-encode apostrophes as `&#39;`. Match the existing files or a reviewer flags inconsistency.
+4. **Voice:** stances stay first-person "Mark" (SCHEMA §8); heuristics/principles neutral.
+5. **The golden-decisions gate (CI "Decision Baseline", `apps/web/lib/decision/golden-decisions.test.ts`) fires ONLY on `principle`-page `principleDimensionVector` edits.** **This residual pass touches only stances, heuristics, and one entity — zero principle-vector edits — so the gate does not apply.** (If we later touch `one-data-model` examples, it does; not in this scope.)
+6. Bump `manifest.json` `kernelVersion` per content batch (`pageCount` only for genuinely new pages — none here). Embeddings regen is deploy-time, not CI.
+
+## 5. Execution (phased, one PR per phase, DCO-signed, babysat to green)
+
+**Phase 0 — File the work.** Open a `doc`/content BI under the decision-governance epic **EP-0AF96937** (`dpf-file-backlog-item`). Small scope — a single BI covering the residual is right; no new epic.
+
+**Phase 1 — The one clear miss.** `it4it-is-substrate` contextualize + relocate its pitch content into `pitch-simple-adjust-per-audience`. Highest value; these two move together (content leaves one, lands in the other). No principle vectors.
+
+**Phase 2 — Data-spine retitle.** `trust-the-cmdb-or-rebuild-it` (retitle + reframe) + `auto-populate-or-its-wrong` lead-flip. Verify no `[[stances/trust-the-cmdb-or-rebuild-it]]` inbound link breaks (slug unchanged; only title changes).
+
+**Phase 3 — Adoption heuristic re-scope + optional tidy.** `find-at-least-one-champion` re-scope; optionally `csdm` / `digital-product-is-the-unit-of-organization` one-liners if we decide they're worth it (defer if not).
+
+**Per phase — rebuild & verify:**
+1. Re-seed: `pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts` (idempotent; advances revision only on body change).
+2. Bump `manifest.json` `kernelVersion`.
+3. Lint: `wiki_lint` MCP tool / `/admin/wiki/lint` — clear `dangling-xref` (blocking), check `orphan`/`stale`.
+4. Confirm a coworker retrieval surfaces the rewritten page (`dpf-verify-on-live-install`) — deferred to operator on live, since live only updates via self-upgrade.
+5. **No golden-decisions run needed** (no principle edits) — see §4.6.
+
+## 6. WWWD — the deferred parallel (noted, not this pass)
+
+The operator flagged the same treatment "when a new company installs and onboards." That is the org-overlay layer: per-org `WikiPage` rows (`organizationId != null`), authored via the "How your business decides" surface, **empty on a fresh single-tenant install**. The bridge is already in place: the merged `contextualize-dont-transform` rewrite frames onboarding as "map the new company's operating model into DPF before transforming it" — that map *becomes* the org's WWWD overlay. Treat WWWD as a separate thread: a seed-at-onboarding starter set of business stances + an elicitation flow (`dpf-elicit-tacit-knowledge`), planned once this residual WWMD pass lands. See `[[wwwd-corpus-lever-is-org-wikipages]]`.
+
+## 7. Bottom line
+
+- **Not** "the corpus is still all ServiceNow" — the live surface is stale; a self-upgrade fixes the two headline stances.
+- The **real residual** is ~4 pages, led by `it4it-is-substrate` (the only page with *zero* DPF tie-in) and the CMDB→data-spine retitle.
+- Zero principle-vector edits → **no decision-baseline risk**, low-blast-radius, ~1–2 small PRs.


### PR DESCRIPTION
## What

Closes the residual gap the prior WWMD recontextualization (#2591, #2623) left uneven. Those PRs rewrote the two headline stances (`dont-integrate-ea-platform`, `ea-is-meteorology`) to exemplar quality, but a cluster of pages was still framed in pure EA-consultant terms with ~0 DPF tie-in. This finishes the job.

**Note on the live surface:** the `/wiki` screenshot that still shows "…with ServiceNow" / "EA is meteorology" is the *stale live portal* (behind `origin/main`; live updates only via self-upgrade). Those two are already fixed on main — this PR is about the pages that genuinely weren't.

## Changes

| Page | Disposition |
|---|---|
| `stances/it4it-is-substrate` | **Contextualize** — was pure consultant voice ("I pitch it as…", 100+ engagements), zero DPF. Adds **How DPF uses it**: IT4IT's seven value streams are the platform's operating-model spine — grounded in real substrate (`ValueStreamTeam`/`ValueStreamHitlGate` models, coworker `itValueStream` tags in `mcp-tools.ts`, capability crosswalk). Executive-pitch content relocated to the pitch heuristic; provenance demoted to a first-person line. |
| `stances/trust-the-cmdb-or-rebuild-it` | **Retitle → "Trust your data spine or rebuild it"** (slug stable). Leads with the generic three-pillar rule; promotes the "every WWMD/WWWD/WSID recommendation inherits the lie" constraint; ServiceNow TPM/CSDM origin demoted to a `### The war-story` block. |
| `heuristics/pitch-simple-adjust-per-audience` | **Genericize** — primary application is now a coworker framing a recommendation for its operator; the IT4IT exec pitch is one cited example. |
| `heuristics/auto-populate-or-its-wrong` | Lead flipped from CMDB-first to any record a coworker reasons off. |
| `heuristics/find-at-least-one-champion` | Scoped to human/onboarding; in a DPF adoption the champion is the operator who starts using a coworker. |
| `index.md` | One-liners synced to the reframed pages. |
| `manifest.json` | `kernelVersion` 0.4.1 → 0.4.2. |

Plan doc included: `docs/superpowers/plans/2026-07-08-wwmd-corpus-residual-recontextualization-plan.md`.

## Safety / scope

- **No `principle`-page `principleDimensionVector` edits** → the golden-decisions gate (CI "Decision Baseline") does not fire.
- **Slugs unchanged** — retitles are frontmatter-only; all ~25 wikilinks in touched files resolve (zero dangling refs, verified locally).
- `raw-sources/` untouched — the ServiceNow origin stays cited, just no longer the frame.
- `embeddings.jsonl` left for deploy-time regen (matches the prior passes' contract).

## Verification

Corpus content isn't exercised by blocking CI; the founder-kernel lint is a daily/`/admin/wiki/lint` job. Live UX verification deferred to the operator on `:3000` after the next self-upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)