### PR TITLE
fix(coworker-lifecycle): use canonical getErrorMessage in certification-runner (un-red main)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -34,6 +34,7 @@ import {
 } from "./certification-oracles";
 
 import { COWORKER_CERT_ADAPTER_KEY } from "./certification-status";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 export { COWORKER_CERT_ADAPTER_KEY };
 export const COWORKER_CERT_ADAPTER_VERSION = "1.0.0";
@@ -190,7 +191,7 @@ async function executeJourney(
       durationMs: deps.now().getTime() - startedAt,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = getErrorMessage(error);
     const verdicts = evaluateJourneyOracles({
       content: "",
       executedTools: [],


### PR DESCRIPTION
## What

`apps/web/lib/coworker-lifecycle/certification-runner.ts:193` reintroduced the banned raw ternary:

```ts
const message = error instanceof Error ? error.message : String(error);
```

This trips the `check-no-raw-error-message` ratchet inside the **Raw EventSource Guard** CI job, so **`main` has been red on that guard since #2709** (it merged because the guard is non-required). Every PR branched off main inherits the red.

## Fix

Import and use the canonical `getErrorMessage(error)` from `@/lib/shared/get-error-message` — the single-extraction helper the ratchet exists to protect. One line + one import.

## Why separate

Found while babysitting an unrelated founder-kernel docs PR (#2714) whose EventSource-guard check was red purely from this inherited main violation. Kept as its own single-concern PR rather than folding into the docs change; merging it un-reds the guard for every open PR.

Local typecheck was skipped (fresh worktree, no `node_modules`); the change is a swap to an existing exported helper and CI typecheck is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)