### PR TITLE
fix(coworker-lifecycle): route certification-runner error through getErrorMessage (ratchet)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -27,6 +27,7 @@ import { toolsToOpenAIFormat } from "@/lib/mcp-tools";
 import { applyProviderRouteModelPreference } from "@/lib/ai-provider-route-context";
 import { ROUTE_AGENT_MAP_ENTRIES } from "@/lib/tak/agent-routing";
 import { journeysForCoworker, type GoldenJourney } from "./golden-journeys";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 import {
   evaluateJourneyOracles,
   journeyPassed,
@@ -190,7 +191,7 @@ async function executeJourney(
       durationMs: deps.now().getTime() - startedAt,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = getErrorMessage(error);
     const verdicts = evaluateJourneyOracles({
       content: "",
       executedTools: [],


### PR DESCRIPTION
One-line fix for the whole-tree error-message ratchet (BI-991D4DC8, #2703) tripping on certification-runner.ts (#2709) — the two crossed in the merge queue, so every open PR currently inherits a red **Raw EventSource Guard** job (verified locally: `node scripts/check-no-raw-error-message.mjs` fails on main, passes with this change).

Swap the raw `error instanceof Error ? error.message : String(error)` ternary for the canonical `getErrorMessage(error)` from `@/lib/shared/get-error-message` (93 existing importers).

Process-Spine-Decision: one-line ratchet conformance fix; rule spec lives with BI-991D4DC8 (EP-8DC217EB BET-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)