### PR TITLE
feat(sim): business-activity simulator P1 — field-service flow + financial oracles (BI-FDAD8788)

### DIFF
--- a/apps/web/lib/business-activity-sim/coverage.ts
+++ b/apps/web/lib/business-activity-sim/coverage.ts
@@ -1,0 +1,63 @@
+// apps/web/lib/business-activity-sim/coverage.ts
+//
+// Coverage runner: run a set of scenarios through the flow + all oracles and
+// produce a pass/fail report. P1 covers the field-service archetype; P2 extends
+// this to a cross-archetype matrix. EP-BUSINESS-ACTIVITY-SIM.
+
+import { runFieldServiceFlow, type FieldServiceScenario } from "./field-service-flow";
+import { FIELD_SERVICE_ORACLES, type SimOracleResult } from "./oracles";
+
+export type ScenarioCoverage = {
+  scenarioId: string;
+  oracles: SimOracleResult[];
+  passed: boolean;
+};
+
+export type CoverageReport = {
+  archetype: string;
+  scenarios: ScenarioCoverage[];
+  passed: boolean;
+  /** Fraction of scenarios with every oracle green (0..1). */
+  passRate: number;
+};
+
+/**
+ * Run every scenario through the field-service flow and all oracles, collecting a
+ * diagnosable pass/fail report. Never throws — a scenario that violates an oracle
+ * is reported as `passed: false` with the specific violations, not an exception.
+ */
+export function runFieldServiceCoverage(
+  scenarios: FieldServiceScenario[],
+  archetype = "field-service",
+): CoverageReport {
+  const rows: ScenarioCoverage[] = scenarios.map((scenario) => {
+    const result = runFieldServiceFlow(scenario);
+    const oracles = FIELD_SERVICE_ORACLES.map((oracle) => oracle(result));
+    return { scenarioId: scenario.id, oracles, passed: oracles.every((o) => o.ok) };
+  });
+  const passedCount = rows.filter((r) => r.passed).length;
+  return {
+    archetype,
+    scenarios: rows,
+    passed: rows.every((r) => r.passed),
+    passRate: rows.length ? passedCount / rows.length : 1,
+  };
+}
+
+/** Every oracle violation across a report, flattened for a one-line failure summary. */
+export function coverageViolations(report: CoverageReport): string[] {
+  return report.scenarios.flatMap((s) =>
+    s.oracles.filter((o) => !o.ok).flatMap((o) => o.violations.map((v) => `[${s.scenarioId}] ${o.id}: ${v}`)),
+  );
+}
+
+/**
+ * A representative field-service scenario set: full-payment with tax, full-payment
+ * without tax, and a legitimate partial payment (leaves a correct outstanding
+ * receivable). All are valid business states and must pass every oracle.
+ */
+export const DEFAULT_FIELD_SERVICE_SCENARIOS: FieldServiceScenario[] = [
+  { id: "fs-taxed-full", customerAccountId: "cust-1", subtotal: 300, taxAmount: 30 },
+  { id: "fs-untaxed-full", customerAccountId: "cust-2", subtotal: 450 },
+  { id: "fs-partial-payment", customerAccountId: "cust-3", subtotal: 200, taxAmount: 20, paymentAmount: 150 },
+];

--- a/apps/web/lib/business-activity-sim/field-service-flow.test.ts
+++ b/apps/web/lib/business-activity-sim/field-service-flow.test.ts
@@ -1,0 +1,95 @@
+// apps/web/lib/business-activity-sim/field-service-flow.test.ts
+import { describe, expect, it } from "vitest";
+import { runFieldServiceFlow, type FieldServiceFlowResult } from "./field-service-flow";
+import {
+  FIELD_SERVICE_ORACLES,
+  FIN1_ledgerBalanced,
+  FIN2_revenueRecognized,
+  FIN3_receivableReconciles,
+  FIN5_noPhantomBilling,
+  LC1_terminalPaid,
+} from "./oracles";
+import {
+  DEFAULT_FIELD_SERVICE_SCENARIOS,
+  coverageViolations,
+  runFieldServiceCoverage,
+} from "./coverage";
+
+const allGreen = (r: FieldServiceFlowResult) => FIELD_SERVICE_ORACLES.every((o) => o(r).ok);
+
+describe("runFieldServiceFlow — end-to-end operational spine", () => {
+  it("drives a taxed job to paid, posts a balanced GL, and settles AR to zero", () => {
+    const r = runFieldServiceFlow({ id: "t", customerAccountId: "c1", subtotal: 300, taxAmount: 30 });
+    expect(r.finalStatus).toBe("paid");
+    expect(r.lifecycle).toContain("complete");
+    expect(r.trialBalance.balanced).toBe(true);
+    expect(r.revenueRecognized).toBe(300); // tax is NOT revenue
+    expect(r.cashReceived).toBe(330); // gross
+    expect(r.receivableBalance).toBe(0); // fully settled
+    expect(allGreen(r)).toBe(true);
+  });
+
+  it("handles a job with no tax", () => {
+    const r = runFieldServiceFlow({ id: "u", customerAccountId: "c2", subtotal: 450 });
+    expect(r.revenueRecognized).toBe(450);
+    expect(r.cashReceived).toBe(450);
+    expect(r.receivableBalance).toBe(0);
+    expect(allGreen(r)).toBe(true);
+  });
+
+  it("leaves a correct outstanding receivable on a legitimate partial payment", () => {
+    const r = runFieldServiceFlow({ id: "p", customerAccountId: "c3", subtotal: 200, taxAmount: 20, paymentAmount: 150 });
+    expect(r.gross).toBe(220);
+    expect(r.receivableBalance).toBe(70); // 220 gross − 150 paid
+    expect(r.trialBalance.balanced).toBe(true); // each posting balances regardless
+    expect(allGreen(r)).toBe(true); // a partial payment is a valid business state
+  });
+});
+
+describe("runFieldServiceCoverage", () => {
+  it("passes every oracle across the default scenario set", () => {
+    const report = runFieldServiceCoverage(DEFAULT_FIELD_SERVICE_SCENARIOS);
+    expect(report.passed).toBe(true);
+    expect(report.passRate).toBe(1);
+    expect(coverageViolations(report)).toEqual([]);
+    expect(report.scenarios).toHaveLength(3);
+  });
+});
+
+// The oracles are only worth running if they can catch a broken flow. These prove
+// each one has teeth by handing it a deliberately corrupted result.
+describe("oracles catch broken flows (teeth)", () => {
+  const good = () => runFieldServiceFlow({ id: "g", customerAccountId: "c", subtotal: 300, taxAmount: 30 });
+
+  it("FIN1 catches an unbalanced ledger", () => {
+    const r = good();
+    r.trialBalance = { ...r.trialBalance, balanced: false, totalDebit: 330, totalCredit: 300 };
+    expect(FIN1_ledgerBalanced(r).ok).toBe(false);
+  });
+
+  it("FIN2 catches tax booked as revenue", () => {
+    const r = good();
+    r.revenueRecognized = r.gross; // 330 instead of 300 — tax wrongly recognised as income
+    const res = FIN2_revenueRecognized(r);
+    expect(res.ok).toBe(false);
+    expect(res.violations[0]).toContain("revenue recognised");
+  });
+
+  it("FIN3 catches a mis-stated receivable", () => {
+    const r = good();
+    r.receivableBalance = 100; // should be 0 after full settlement
+    expect(FIN3_receivableReconciles(r).ok).toBe(false);
+  });
+
+  it("FIN5 catches phantom billing (invoice without a completed visit)", () => {
+    const r = good();
+    r.workCompletedBeforeInvoice = false; // revenue posted but job never completed
+    expect(FIN5_noPhantomBilling(r).ok).toBe(false);
+  });
+
+  it("LC1 catches a job that did not reach paid", () => {
+    const r = good();
+    r.finalStatus = "complete";
+    expect(LC1_terminalPaid(r).ok).toBe(false);
+  });
+});

--- a/apps/web/lib/business-activity-sim/field-service-flow.ts
+++ b/apps/web/lib/business-activity-sim/field-service-flow.ts
@@ -1,0 +1,161 @@
+// apps/web/lib/business-activity-sim/field-service-flow.ts
+//
+// Business Activity Simulator — field-service end-to-end flow (P1).
+// EP-BUSINESS-ACTIVITY-SIM · spec: docs/superpowers/specs/2026-07-04-business-activity-simulator-design.md
+//
+// Composes the REAL field-dispatch lifecycle (@dpf/validators) with the REAL
+// pure GL posting (@/lib/finance/ledger) into one orchestrated business flow —
+// dispatched job → invoice → payment → GL — with no DB and no auth, so the
+// accounting invariants of the operational spine can be asserted deterministically
+// in CI. The write-side counterpart to the living-business workforce view, and the
+// re-runnable confidence tool for "does the operational surface actually work?".
+// Drives real capability paths; nothing here is faked but the customer + payment.
+
+import {
+  isTerminalStatus,
+  isWorkComplete,
+  type FieldDispatchJobStatus,
+} from "@dpf/validators";
+import {
+  buildInvoicePostingLines,
+  buildPaymentPostingLines,
+  computeTrialBalance,
+  type JournalLineInput,
+  type LedgerAccountType,
+  type TrialBalance,
+  type TrialBalanceAccount,
+} from "@/lib/finance/ledger";
+
+/** Minimal fixed chart of accounts for the sim (mirrors the finance-template roles). */
+export const SIM_ACCOUNTS = {
+  bank: { accountId: "sim-bank", code: "1000", name: "Bank", type: "asset" },
+  receivables: { accountId: "sim-ar", code: "1100", name: "Accounts Receivable", type: "asset" },
+  revenue: { accountId: "sim-rev", code: "4000", name: "Service Revenue", type: "revenue" },
+  taxPayable: { accountId: "sim-tax", code: "2100", name: "Sales Tax Payable", type: "liability" },
+} as const satisfies Record<string, TrialBalanceAccount>;
+
+const SIM_ACCOUNT_LIST: TrialBalanceAccount[] = Object.values(SIM_ACCOUNTS).map((a) => ({
+  ...a,
+  type: a.type as LedgerAccountType,
+}));
+
+export type FieldServiceScenario = {
+  id: string;
+  customerAccountId: string;
+  /** Net-of-tax service revenue for the job (major units). */
+  subtotal: number;
+  /** Sales tax charged on the job (0 when none). */
+  taxAmount?: number;
+  /** How much the customer actually pays. Defaults to the gross (full settlement). */
+  paymentAmount?: number;
+};
+
+export type FieldServiceFlowResult = {
+  scenarioId: string;
+  /** The lifecycle statuses the job passed through, in order. */
+  lifecycle: FieldDispatchJobStatus[];
+  finalStatus: FieldDispatchJobStatus;
+  /** True once the job reached a work-complete state before it was invoiced. */
+  workCompletedBeforeInvoice: boolean;
+  journal: JournalLineInput[];
+  trialBalance: TrialBalance;
+  /** Revenue recognised (credit balance on the revenue account), major units. */
+  revenueRecognized: number;
+  /** Outstanding receivable after settlement (gross − paid when partial), major units. */
+  receivableBalance: number;
+  /** Cash received into the bank account, major units. */
+  cashReceived: number;
+  subtotal: number;
+  taxAmount: number;
+  gross: number;
+  paymentAmount: number;
+};
+
+// The canonical happy-path lifecycle the flow drives a job through (excludes the
+// cancelled / needs-review exception states). Kept local so the flow's intent is
+// explicit; the vocabulary itself is owned by @dpf/validators.
+const HAPPY_PATH: FieldDispatchJobStatus[] = [
+  "quoted",
+  "scheduled",
+  "confirmed",
+  "en-route",
+  "on-site",
+  "complete",
+  "invoiced",
+  "paid",
+];
+
+/**
+ * Drive one field-service job through its full lifecycle and record the real GL
+ * postings for the invoice (on reaching `invoiced`) and the customer receipt (on
+ * reaching `paid`). Pure and deterministic — no DB, no clock, no auth — so it is
+ * a CI-runnable proof of the operational spine's accounting invariants.
+ */
+export function runFieldServiceFlow(scenario: FieldServiceScenario): FieldServiceFlowResult {
+  const subtotal = Math.max(scenario.subtotal, 0);
+  const taxAmount = Math.max(scenario.taxAmount ?? 0, 0);
+  const gross = subtotal + taxAmount;
+  const paymentAmount = scenario.paymentAmount ?? gross;
+
+  const journal: JournalLineInput[] = [];
+  const lifecycle: FieldDispatchJobStatus[] = [];
+  let workCompletedBeforeInvoice = false;
+
+  for (const status of HAPPY_PATH) {
+    lifecycle.push(status);
+    if (isWorkComplete(status) && status !== "invoiced" && status !== "paid") {
+      workCompletedBeforeInvoice = true;
+    }
+    if (status === "invoiced") {
+      // SD → FI billing document: Dr AR (gross) / Cr Revenue (subtotal) / Cr Tax.
+      journal.push(
+        ...buildInvoicePostingLines(
+          { subtotal, taxAmount, customerAccountId: scenario.customerAccountId },
+          {
+            revenueAccountId: SIM_ACCOUNTS.revenue.accountId,
+            receivablesAccountId: SIM_ACCOUNTS.receivables.accountId,
+            taxPayableAccountId: SIM_ACCOUNTS.taxPayable.accountId,
+          },
+        ),
+      );
+    }
+    if (status === "paid") {
+      // Customer receipt: Dr Bank / Cr AR — the settlement half of the cash cycle.
+      journal.push(
+        ...buildPaymentPostingLines(
+          { direction: "inbound", amount: paymentAmount, customerAccountId: scenario.customerAccountId },
+          {
+            bankAccountId: SIM_ACCOUNTS.bank.accountId,
+            receivablesAccountId: SIM_ACCOUNTS.receivables.accountId,
+          },
+        ),
+      );
+    }
+  }
+
+  const trialBalance = computeTrialBalance(SIM_ACCOUNT_LIST, journal);
+  const balanceOf = (accountId: string) =>
+    trialBalance.rows.find((r) => r.accountId === accountId)?.balance ?? 0;
+
+  const finalStatus = lifecycle[lifecycle.length - 1];
+  return {
+    scenarioId: scenario.id,
+    lifecycle,
+    finalStatus,
+    workCompletedBeforeInvoice,
+    journal,
+    trialBalance,
+    revenueRecognized: balanceOf(SIM_ACCOUNTS.revenue.accountId),
+    receivableBalance: balanceOf(SIM_ACCOUNTS.receivables.accountId),
+    cashReceived: balanceOf(SIM_ACCOUNTS.bank.accountId),
+    subtotal,
+    taxAmount,
+    gross,
+    paymentAmount,
+  };
+}
+
+/** Convenience: is the job in a terminal state at the end of the flow? */
+export function flowReachedTerminal(result: FieldServiceFlowResult): boolean {
+  return isTerminalStatus(result.finalStatus);
+}

--- a/apps/web/lib/business-activity-sim/oracles.ts
+++ b/apps/web/lib/business-activity-sim/oracles.ts
@@ -1,0 +1,97 @@
+// apps/web/lib/business-activity-sim/oracles.ts
+//
+// Financial + lifecycle oracles for the field-service flow (P1).
+// EP-BUSINESS-ACTIVITY-SIM.
+//
+// Each oracle is a pure predicate over a FieldServiceFlowResult that names exactly
+// what broke, so a failing coverage run is diagnosable. Modelled on the existing
+// dispatch harness (packages/coworker-sim-harness/src/oracles.ts): a harness whose
+// oracles cannot catch a broken flow is useless — the negative tests prove they can.
+
+import { toMinorUnits } from "@/lib/finance/ledger";
+import { isTerminalStatus } from "@dpf/validators";
+import { SIM_ACCOUNTS, type FieldServiceFlowResult } from "./field-service-flow";
+
+export type SimOracleResult = {
+  id: string;
+  description: string;
+  ok: boolean;
+  violations: string[];
+};
+
+export type SimOracle = (result: FieldServiceFlowResult) => SimOracleResult;
+
+/** Equal to the cent — compares in integer minor units so float drift never lies. */
+function moneyEq(a: number, b: number): boolean {
+  return toMinorUnits(a) === toMinorUnits(b);
+}
+
+/** FIN1 — the ledger is internally consistent (total debits === total credits). */
+export const FIN1_ledgerBalanced: SimOracle = (r) => {
+  const violations: string[] = [];
+  if (!r.trialBalance.balanced) {
+    violations.push(
+      `trial balance unbalanced: debits ${r.trialBalance.totalDebit.toFixed(2)} ≠ credits ${r.trialBalance.totalCredit.toFixed(2)}`,
+    );
+  }
+  return { id: "FIN1", description: "the ledger balances (debits = credits)", ok: violations.length === 0, violations };
+};
+
+/** FIN2 — revenue recognised equals the net-of-tax subtotal (tax is a liability, not income). */
+export const FIN2_revenueRecognized: SimOracle = (r) => {
+  const violations: string[] = [];
+  if (!moneyEq(r.revenueRecognized, r.subtotal)) {
+    violations.push(`revenue recognised ${r.revenueRecognized.toFixed(2)} ≠ subtotal ${r.subtotal.toFixed(2)}`);
+  }
+  return { id: "FIN2", description: "revenue recognised equals the net subtotal", ok: violations.length === 0, violations };
+};
+
+/** FIN3 — the outstanding receivable equals exactly what the customer has not paid. */
+export const FIN3_receivableReconciles: SimOracle = (r) => {
+  const violations: string[] = [];
+  const expectedOutstanding = Math.max(r.gross - r.paymentAmount, 0);
+  if (!moneyEq(r.receivableBalance, expectedOutstanding)) {
+    violations.push(
+      `receivable ${r.receivableBalance.toFixed(2)} ≠ outstanding (gross ${r.gross.toFixed(2)} − paid ${r.paymentAmount.toFixed(2)} = ${expectedOutstanding.toFixed(2)})`,
+    );
+  }
+  return { id: "FIN3", description: "outstanding receivable equals gross − paid", ok: violations.length === 0, violations };
+};
+
+/** FIN4 — cash received into the bank equals the payment amount. */
+export const FIN4_cashMatchesPayment: SimOracle = (r) => {
+  const violations: string[] = [];
+  if (!moneyEq(r.cashReceived, r.paymentAmount)) {
+    violations.push(`cash received ${r.cashReceived.toFixed(2)} ≠ payment ${r.paymentAmount.toFixed(2)}`);
+  }
+  return { id: "FIN4", description: "cash received equals the payment", ok: violations.length === 0, violations };
+};
+
+/** FIN5 — no phantom billing: revenue is only posted for a job that reached work-complete. */
+export const FIN5_noPhantomBilling: SimOracle = (r) => {
+  const violations: string[] = [];
+  const revenuePosted = r.journal.some((l) => l.accountId === SIM_ACCOUNTS.revenue.accountId && (l.credit ?? 0) > 0);
+  if (revenuePosted && !r.workCompletedBeforeInvoice) {
+    violations.push("an invoice was raised without a completed on-site visit (phantom billing)");
+  }
+  return { id: "FIN5", description: "no invoice without a completed job", ok: violations.length === 0, violations };
+};
+
+/** LC1 — the job ends in a terminal, paid state (the flow ran to completion). */
+export const LC1_terminalPaid: SimOracle = (r) => {
+  const violations: string[] = [];
+  if (r.finalStatus !== "paid" || !isTerminalStatus(r.finalStatus)) {
+    violations.push(`job ended in '${r.finalStatus}', expected terminal 'paid'`);
+  }
+  return { id: "LC1", description: "the job ends terminal-paid", ok: violations.length === 0, violations };
+};
+
+/** All oracles run on every field-service scenario. */
+export const FIELD_SERVICE_ORACLES: SimOracle[] = [
+  FIN1_ledgerBalanced,
+  FIN2_revenueRecognized,
+  FIN3_receivableReconciles,
+  FIN4_cashMatchesPayment,
+  FIN5_noPhantomBilling,
+  LC1_terminalPaid,
+];

--- a/docs/superpowers/specs/2026-07-04-business-activity-simulator-design.md
+++ b/docs/superpowers/specs/2026-07-04-business-activity-simulator-design.md
@@ -1,0 +1,69 @@
+# Business Activity Simulator — design spec
+
+**Status:** draft · 2026-07-04
+**Epic:** EP-BUSINESS-ACTIVITY-SIM (to be filed)
+**Author:** platform (via Claude Code, operator Mark)
+**Related:** [[living-business-workforce-activity]] concept (the read-side viz); EP-TRADES-FIELD-SERVICE; the finance spine (PRs #2546/#2548/#2559)
+
+## 1. Problem
+
+DPF targets **20 business archetypes** (`packages/storefront-templates/src/archetypes/`) — field-service/trades, software-platform, retail, MSP-shaped, professional services, etc. Each archetype exercises a different slice of the platform's operational surface: dispatch, invoicing, payments, AR/AP, GL. There are **not enough manual cycles to know the full functional surface is solid in every archetype**. A regression in, say, payment→GL settlement for retail could sit undetected because nobody ran that path this week.
+
+There is also no synthetic source of realistic operational activity to (a) populate demos and (b) drive the "living business" workforce-activity visualization.
+
+## 2. Goal
+
+A **Business Activity Simulator**: a test/dogfood harness that drives the *real* platform capabilities through end-to-end operational flows — *create customer → dispatch/subscribe/sell → invoice → send → payment → AR/AP → GL* — **parameterized by archetype**, producing:
+
+1. **A cross-archetype coverage report** (archetype × capability = pass/fail) so we gain re-runnable confidence.
+2. **Realistic activity** emitted to the observability substrate (the write-side of the living-business viz).
+3. A reusable **demo/seed + load** input.
+
+### Design principle (load-bearing)
+**Drive real capability paths; stub only the outer edges.** The confidence signal only exists if the harness exercises the *actual* domain logic (real GL postings that really balance, real lifecycle transitions), faking only what is genuinely external: the customer, the payment gateway, inbound demand. A harness that fakes the internals proves nothing.
+
+## 3. What already exists (reuse, do not rebuild)
+
+- **`packages/coworker-sim-harness`** — deterministic field-dispatch world + **oracles** (pure invariant predicates over a `WorldSnapshot`) + scenarios + virtual clock. Field-dispatch only; no invoice→payment→GL. The world+oracle *pattern* is the model to extend.
+- **`packages/validators/src/field-dispatch.ts`** — the job lifecycle enum (quoted→scheduled→confirmed→en-route→on-site→complete→invoiced→paid) + pure predicates (`isTerminalStatus`, `isWorkComplete`). No DB.
+- **`apps/web/lib/finance/ledger.ts`** — **pure, DB-free** GL: `buildInvoicePostingLines` (Dr AR/Cr Revenue/Cr Tax), `buildPaymentPostingLines` (inbound: Dr Bank/Cr AR), `validateJournalEntry` (balance rule), `computeTrialBalance` (→ `balanced`).
+- **`apps/web/lib/finance/ledger-service.ts`** — DB persistence: `postInvoiceIssued`, `postPaymentRecorded`, `seedChartOfAccounts`.
+- **Server actions** — `createCustomerAccount` (crm.ts), `createInvoice`/`sendInvoice`/`recordPayment` (finance.ts), `createSupplier`/`createBill` (ap.ts).
+- **`packages/finance-templates/src/profiles.ts`** — per-archetype chart-of-accounts templates.
+- **`apps/web/lib/tak/agent-event-bus.ts`** — the live event taxonomy (`tool:start`, `plan:update`, `collaboration:*`, `taskrun:stalled`) the sim emits to for the viz. (Recon missed this under the classifier outage; it exists.)
+
+## 4. The gap
+
+1. A **cross-flow orchestrator** chaining dispatch → invoice → payment → GL in one run (pieces exist; nothing runs them together end-to-end).
+2. **Archetype factories** generalizing beyond field-dispatch (SaaS subscription, retail POS…).
+3. A **coverage report** (archetype × capability) with **financial oracles** as the assertions.
+4. The **invocation seam** decision (see §6).
+
+## 5. Phases
+
+- **P1 — one archetype, end-to-end, real, DB-free (this PR).** Field-service: compose the *real* `field-dispatch` lifecycle with the *real* pure `ledger.ts` posting into a single orchestrated flow, with **financial oracles** (GL balanced, AR settles to zero, revenue recognized, cash received, no phantom billing, job terminal-paid). Deterministic, runs in CI, no DB, no auth. Proves the model + gives the first re-runnable confidence run. Ships with a self-test proving the oracles have teeth (a deliberately broken flow must fail them).
+- **P2 — generalize.** Archetype factories + scenario templates (software-platform subscriptions, retail POS) → the cross-archetype coverage matrix.
+- **P3 — DB-backed fidelity.** Drive the service layer (`ledger-service`, invoice/payment services) against a test Postgres with a real seeded COA, so persistence + account-resolution are covered too. Requires the auth-context shim (§6).
+- **P4 — observability + viz.** Emit business events to `agent-event-bus`/`TaskRun`; wire the test-only archetype toggle in the living-business viz (read-side).
+
+## 6. Invocation seam (the one real design question)
+
+Three seams to drive flows headlessly:
+- **Pure domain functions** (`ledger.ts`, `field-dispatch.ts`) — no DB, no auth. **Chosen for P1**: highest determinism, real invariants, CI-friendly.
+- **Service layer** (`ledger-service`, invoice/payment services) — real persistence + account resolution; needs a test DB + a thin auth/actor context shim. **P3.**
+- **Server actions** — full auth/capability path; highest fidelity but session-bound. Reserved for e2e.
+- Raw Prisma — rejected: bypasses business logic, proves nothing.
+
+## 7. P1 shape (this PR)
+
+`apps/web/lib/business-activity-sim/` (home is apps/web because the pure ledger layer lives there; P2 may extract a `packages/business-activity-sim` once the ledger pure layer is packaged):
+- `field-service-flow.ts` — `runFieldServiceFlow(scenario)`: advances a job through the lifecycle to `paid`, builds the real invoice + payment journal lines, accumulates the journal, computes the trial balance. Returns a `FlowResult` (job status, journal lines, trial balance, revenue recognized, AR balance, cash received).
+- `oracles.ts` — pure financial oracles over `FlowResult`.
+- `coverage.ts` — run N scenarios → a pass/fail coverage report.
+- `*.test.ts` — positive scenarios (with/without tax, multi-line) all-oracles-green **plus a negative test** (underpayment leaves AR ≠ 0) proving the oracles catch a broken flow.
+
+## 8. Non-goals (P1)
+No DB, no server actions, no UI, no non-field-service archetypes, no volume/load. Those are P2–P4.
+
+## 9. Test-only archetype toggle
+The multi-archetype toggle (in the viz) is **test-instance-only** — a real customer install is exactly one archetype. Gated so production single-archetype installs never see it. Lands in P4 alongside the observability wiring.


### PR DESCRIPTION
## Why

Operator concern from the self-upgrade thread: **not enough cycles to know the operational surface actually works across every archetype**, and no single view of live business activity by archetype. This lands **P1 of EP-BUSINESS-ACTIVITY-SIM** — the write-side confidence harness that also feeds the later graphical "living business" activity view.

## What

A pure, deterministic, **CI-runnable** harness (`apps/web/lib/business-activity-sim/`) that drives one field-service job through the **real** `@dpf/validators` dispatch lifecycle (`quoted → … → paid`) and posts the invoice + customer receipt through the **real** pure `@/lib/finance/ledger` functions (`buildInvoicePostingLines` / `buildPaymentPostingLines` / `computeTrialBalance`). No DB, no auth, no clock — it proves the operational spine every CI run, not a mock of it.

- **`field-service-flow.ts`** — composes dispatch lifecycle + GL posting into one flow; returns journal, trial balance, revenue/AR/cash for assertion.
- **`oracles.ts`** — FIN1 ledger balances · FIN2 revenue = subtotal (tax is a liability, not income) · FIN3 receivable = gross − paid · FIN4 cash = payment · FIN5 no phantom billing (no invoice without a completed visit) · LC1 terminal-paid.
- **`coverage.ts`** — pass/fail runner + default taxed / untaxed / partial-payment scenarios.
- **test** — positive scenarios **+ a "teeth" suite** that corrupts each result and asserts the matching oracle catches it (mirrors `packages/coworker-sim-harness`).

## Substrate reuse, not green-field

Dispatch vocabulary stays owned by `@dpf/validators`; GL posting by `finance/ledger.ts`. The harness only *composes* them, so it exercises the same paths the live portal uses.

## Roadmap (spec)

`docs/superpowers/specs/2026-07-04-business-activity-simulator-design.md` — **P2** cross-archetype matrix · **P3** graphical living-business activity view (archetype TAM + AI-coworker / human / partner activity, drill-in) · **P4** stubbed live-portal activity simulation, behind a **testing-install toggle**. Each a follow-up BI.

## Verification
- **9/9** vitest green · `tsc --noEmit` clean · Module Size Guard OK · local pre-push CI gate passed.

BI-FDAD8788 · EP-BUSINESS-ACTIVITY-SIM

🤖 Generated with [Claude Code](https://claude.com/claude-code)