### PR TITLE
feat(ea): optimization cockpit — project the 14 consolidation bets onto live architecture surfaces (BI-D9B58004)

### DIFF
--- a/apps/web/app/(shell)/ea/capabilities/page.tsx
+++ b/apps/web/app/(shell)/ea/capabilities/page.tsx
@@ -1,11 +1,16 @@
 // apps/web/app/(shell)/ea/capabilities/page.tsx
 import { BusinessCapabilityForms } from "@/components/portfolio/architecture/BusinessCapabilityForms";
 import { BusinessCapabilityMap } from "@/components/portfolio/architecture/BusinessCapabilityMap";
+import { OptimizationCockpitSection } from "@/components/portfolio/architecture/OptimizationCockpitSection";
 import { EaTabNav } from "@/components/ea/EaTabNav";
 import { getBusinessCapabilityMapData } from "@/lib/business-capabilities/data";
+import { loadOptimizationCockpitData } from "@/lib/optimization/load-cockpit-data";
 
 export default async function EaCapabilitiesPage() {
-  const data = await getBusinessCapabilityMapData();
+  const [data, cockpit] = await Promise.all([
+    getBusinessCapabilityMapData(),
+    loadOptimizationCockpitData(),
+  ]);
 
   return (
     <div>
@@ -19,6 +24,8 @@ export default async function EaCapabilitiesPage() {
       <EaTabNav />
 
       <BusinessCapabilityMap mapRows={data.mapRows} summary={data.summary} provenance={data.provenance} />
+
+      <OptimizationCockpitSection data={cockpit} />
 
       <details className="mt-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
         <summary className="cursor-pointer text-sm font-semibold text-[var(--dpf-text)]">

--- a/apps/web/components/portfolio/architecture/OptimizationCockpitSection.tsx
+++ b/apps/web/components/portfolio/architecture/OptimizationCockpitSection.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+// Optimization cockpit — BI-D9B58004 (EP-8DC217EB BET-0a).
+//
+// Projects the consolidation-bet registry onto live architecture surfaces on
+// the /ea/capabilities page (kernel-scored UX-fit decision: overlay/extension
+// of the capability map, not a new route). Composes report-kit only.
+
+import { useMemo } from "react";
+
+import { DataTable, type Column } from "@/components/ui/report-kit/DataTable";
+import { EmptyState } from "@/components/ui/report-kit/EmptyState";
+import { Notice } from "@/components/ui/report-kit/Notice";
+import { StatCard } from "@/components/ui/report-kit/StatCard";
+import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
+import type { BetProjection, OptimizationCockpitData } from "@/lib/optimization/load-cockpit-data";
+
+type Props = { data: OptimizationCockpitData };
+
+function betStatusSummary(projection: BetProjection): {
+  label: string;
+  intentStatus: string;
+} {
+  const statuses = projection.backlogItems.map((item) => item.status);
+  const done = statuses.filter((status) => status === "done").length;
+  const total = statuses.length;
+  if (total > 0 && done === total) return { label: "done", intentStatus: "done" };
+  if (statuses.some((status) => status === "in-progress")) {
+    return { label: `in-progress ${done}/${total}`, intentStatus: "in-progress" };
+  }
+  if (done > 0) return { label: `partial ${done}/${total}`, intentStatus: "in-progress" };
+  return { label: "open", intentStatus: "open" };
+}
+
+export function OptimizationCockpitSection({ data }: Props) {
+  const columns = useMemo<Column<BetProjection>[]>(
+    () => [
+      {
+        key: "bet",
+        header: "Bet",
+        mono: true,
+        cell: (row) => row.bet.betKey,
+        sortAccessor: (row) => row.bet.betKey,
+      },
+      {
+        key: "title",
+        header: "Consolidation",
+        cell: (row) => (
+          <div>
+            <div className="text-[var(--dpf-text)]">{row.bet.title}</div>
+            <div className="mt-0.5 text-[10px] text-[var(--dpf-muted)]">
+              {row.bet.moveTypes.join(" · ")} · wave {row.bet.wave} · {row.bet.effort}/
+              {row.bet.leverage} · ~{row.bet.leafEstimate} leaf sites
+            </div>
+          </div>
+        ),
+      },
+      {
+        key: "status",
+        header: "Delivery",
+        cell: (row) => {
+          const summary = betStatusSummary(row);
+          return <StatusBadge domain="backlogItem" status={summary.intentStatus} label={summary.label} />;
+        },
+        sortAccessor: (row) => betStatusSummary(row).label,
+      },
+      {
+        key: "blast",
+        header: "Blast radius",
+        align: "right",
+        cell: (row) =>
+          row.blastRadius ? (
+            <span title={row.blastRadius.unresolvedSelectors.join(", ") || undefined}>
+              {row.blastRadius.implementationFileCount} files
+              {row.blastRadius.unresolvedSelectors.length > 0
+                ? ` (+${row.blastRadius.unresolvedSelectors.length} unresolved)`
+                : ""}
+            </span>
+          ) : (
+            <span className="text-[var(--dpf-muted)]">graph offline</span>
+          ),
+        sortAccessor: (row) => row.blastRadius?.implementationFileCount ?? -1,
+      },
+      {
+        key: "tests",
+        header: "Linked tests",
+        align: "right",
+        cell: (row) =>
+          row.blastRadius ? (
+            row.blastRadius.relatedTestCount
+          ) : (
+            <span className="text-[var(--dpf-muted)]">—</span>
+          ),
+        sortAccessor: (row) => row.blastRadius?.relatedTestCount ?? -1,
+      },
+      {
+        key: "coverage",
+        header: "Anchor files indexed",
+        align: "right",
+        cell: (row) =>
+          row.fileCoverage ? (
+            `${row.fileCoverage.indexedCount}/${row.fileCoverage.indexedCount + row.fileCoverage.unindexedCount}`
+          ) : (
+            <span className="text-[var(--dpf-muted)]">—</span>
+          ),
+        sortAccessor: (row) => row.fileCoverage?.indexedCount ?? -1,
+      },
+      {
+        key: "items",
+        header: "Backlog",
+        cell: (row) => (
+          <div className="space-y-0.5">
+            {row.backlogItems.map((item) => (
+              <div key={item.itemId} className="flex items-center gap-1.5">
+                <span className="font-mono text-[10px] text-[var(--dpf-muted)]">{item.itemId}</span>
+                {item.status ? (
+                  <StatusBadge domain="backlogItem" status={item.status} />
+                ) : (
+                  <StatusBadge intent="neutral" label="unknown" />
+                )}
+              </div>
+            ))}
+          </div>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <section className="mt-6 space-y-4" aria-label="Optimization cockpit">
+      <div>
+        <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+          Optimization cockpit — Vertical Integration Inward
+        </h2>
+        <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">
+          The EP-8DC217EB consolidation bets projected onto the live code graph and backlog. Switch
+          the map overlay above to “Optimization Impact” to see which capabilities sit in a bet's
+          blast path.
+        </p>
+      </div>
+
+      {!data.freshness.available ? (
+        <Notice variant="warn" title="Code graph unavailable">
+          {data.freshness.summary} Blast-radius columns are hidden until the graph index is built.
+        </Notice>
+      ) : data.freshness.warnings.length > 0 ? (
+        <Notice variant="info" title="Code graph freshness">
+          {data.freshness.warnings.join(" ")}
+        </Notice>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatCard label="Consolidation bets" value={data.totals.betCount} />
+        <StatCard
+          label="Backlog done"
+          value={data.totals.backlogDone}
+          hint={`${data.totals.backlogInProgress} in progress · ${data.totals.backlogOpen} open`}
+          intent={data.totals.backlogDone > 0 ? "success" : "neutral"}
+        />
+        <StatCard
+          label="Blast-radius files"
+          value={data.freshness.available ? data.totals.implementationFileCount : "—"}
+          hint={data.freshness.available ? "distinct traced implementation files" : "graph offline"}
+        />
+        <StatCard
+          label="Linked tests"
+          value={data.freshness.available ? data.totals.relatedTestCount : "—"}
+          hint={data.freshness.available ? "tests covering traced surfaces" : "graph offline"}
+        />
+      </div>
+
+      <details className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4" open>
+        <summary className="cursor-pointer text-sm font-semibold text-[var(--dpf-text)]">
+          Bets ({data.bets.length})
+        </summary>
+        <div className="mt-3">
+          {data.bets.length === 0 ? (
+            <EmptyState title="No consolidation bets registered" />
+          ) : (
+            <DataTable
+              columns={columns}
+              rows={data.bets}
+              getRowKey={(row) => row.bet.betKey}
+              dense
+              initialSort={{ key: "bet", dir: "asc" }}
+            />
+          )}
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/apps/web/lib/business-capabilities/types.ts
+++ b/apps/web/lib/business-capabilities/types.ts
@@ -35,6 +35,7 @@ export const CAPABILITY_OVERLAY_MODES = [
   { value: "coverage", label: "Operational Coverage" },
   { value: "planning", label: "Planning Impact" },
   { value: "it4it", label: "IT4IT Alignment" },
+  { value: "optimization", label: "Optimization Impact" },
 ] as const;
 
 export type It4itValueStream = (typeof IT4IT_VALUE_STREAMS)[number]["slug"];

--- a/apps/web/lib/business-capabilities/view-model.test.ts
+++ b/apps/web/lib/business-capabilities/view-model.test.ts
@@ -1,0 +1,74 @@
+// Overlay-state tests for the "Optimization Impact" capability overlay
+// (BI-D9B58004): a capability lights up when a linked backlog item belongs to
+// the EP-8DC217EB consolidation-bet registry.
+
+import { describe, expect, it } from "vitest";
+
+import type { BusinessCapabilityNode } from "./data";
+import { deriveCapabilityOverlayState } from "./view-model";
+
+function makeNode(
+  backlogLinks: Array<{ label: string; status: "open" | "in-progress" | "done" | null }>,
+): BusinessCapabilityNode {
+  return {
+    id: "cap-1",
+    capabilityId: "CAP-1",
+    name: "Test Capability",
+    slug: "test-capability",
+    description: null,
+    level: 2,
+    sortOrder: 0,
+    status: "active",
+    parentId: null,
+    currentMaturity: 2,
+    targetMaturity: 3,
+    maturityRationale: null,
+    it4itValueStreams: [],
+    traceLinks: [],
+    children: [],
+    maturityGap: 1,
+    maturityBand: "watch",
+    traceGroups: {
+      taxonomy_node: [],
+      digital_product: [],
+      backlog_item: backlogLinks.map((link, index) => ({
+        id: `trace-${index}`,
+        targetType: "backlog_item" as const,
+        relationship: "impacted_by",
+        note: null,
+        label: link.label,
+        href: null,
+        status: link.status,
+      })),
+      ea_element: [],
+    },
+  };
+}
+
+describe("optimization overlay mode", () => {
+  it("marks a capability active when a linked bet backlog item is in flight", () => {
+    // BI-B6157FB7 is BET-10's live backlog item in the registry.
+    const node = makeNode([{ label: "BI-B6157FB7 Build one live health/run read-model", status: "open" }]);
+    const state = deriveCapabilityOverlayState(node, "optimization");
+    expect(state.tone).toBe("active");
+    expect(state.shortLabel).toBe("1 bet");
+  });
+
+  it("marks a capability covered when its bet links are all completed", () => {
+    const node = makeNode([{ label: "BI-3B0AD9CF Consolidate per-PR CI ratchet aggregators", status: "done" }]);
+    const state = deriveCapabilityOverlayState(node, "optimization");
+    expect(state.tone).toBe("covered");
+  });
+
+  it("stays neutral for backlog links outside the bet registry", () => {
+    const node = makeNode([{ label: "BI-00000000 Unrelated work", status: "open" }]);
+    const state = deriveCapabilityOverlayState(node, "optimization");
+    expect(state.tone).toBe("neutral");
+    expect(state.sortWeight).toBe(0);
+  });
+
+  it("stays neutral with no backlog links at all", () => {
+    const state = deriveCapabilityOverlayState(makeNode([]), "optimization");
+    expect(state.tone).toBe("neutral");
+  });
+});

--- a/apps/web/lib/business-capabilities/view-model.ts
+++ b/apps/web/lib/business-capabilities/view-model.ts
@@ -1,5 +1,6 @@
 import type { BusinessCapabilityNode } from "./data";
 import type { CapabilityOverlayMode, CapabilityOverlayTone } from "./types";
+import { CONSOLIDATION_BET_ITEM_IDS } from "@/lib/optimization/consolidation-bets";
 
 export type CapabilityEvidenceSummary = {
   taxonomyCount: number;
@@ -101,6 +102,46 @@ export function deriveCapabilityOverlayState(
       label: "Aligned without active work",
       shortLabel: "Aligned",
       description: "Capability is at target state and has no active backlog trace.",
+      sortWeight: 0,
+    };
+  }
+
+  if (mode === "optimization") {
+    // Backlog trace labels are `${itemId} ${title}` (see data.ts), so a
+    // capability is "in a consolidation bet's path" when a linked backlog
+    // item belongs to the EP-8DC217EB bet registry.
+    const betLinks = node.traceGroups.backlog_item.filter((link) =>
+      CONSOLIDATION_BET_ITEM_IDS.has(link.label.split(" ")[0] ?? ""),
+    );
+    const activeBetLinks = betLinks.filter(
+      (link) => link.status === "open" || link.status === "in-progress" || link.status === "triaging",
+    );
+
+    if (activeBetLinks.length > 0) {
+      return {
+        tone: "active",
+        label: `${activeBetLinks.length} active consolidation bet link${activeBetLinks.length === 1 ? "" : "s"}`,
+        shortLabel: `${activeBetLinks.length} bet${activeBetLinks.length === 1 ? "" : "s"}`,
+        description: "Capability is in the blast path of an in-flight consolidation bet.",
+        sortWeight: activeBetLinks.length + betLinks.length,
+      };
+    }
+
+    if (betLinks.length > 0) {
+      return {
+        tone: "covered",
+        label: `${betLinks.length} completed consolidation bet link${betLinks.length === 1 ? "" : "s"}`,
+        shortLabel: `${betLinks.length} done`,
+        description: "Linked consolidation work on this capability has completed.",
+        sortWeight: betLinks.length,
+      };
+    }
+
+    return {
+      tone: "neutral",
+      label: "No consolidation bet link",
+      shortLabel: "None",
+      description: "No EP-8DC217EB consolidation bet is traced to this capability.",
       sortWeight: 0,
     };
   }

--- a/apps/web/lib/optimization/consolidation-bets.test.ts
+++ b/apps/web/lib/optimization/consolidation-bets.test.ts
@@ -1,0 +1,94 @@
+// Contract tests for the consolidation-bet registry (BI-D9B58004).
+//
+// The registry's value is that every selector points at a REAL artifact — a
+// file on disk, a Prisma model in schema.prisma, an MCP tool in mcp-tools.ts.
+// These tests enforce that mechanically so the registry cannot drift into
+// fabrication as consolidations rename or remove their targets.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  CONSOLIDATION_BETS,
+  CONSOLIDATION_BET_ITEM_IDS,
+  CONSOLIDATION_MOVE_TYPES,
+  CONSOLIDATION_WAVES,
+  getConsolidationBet,
+} from "./consolidation-bets";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const SCHEMA = readFileSync(join(REPO_ROOT, "packages/db/prisma/schema.prisma"), "utf8");
+const MCP_TOOLS = readFileSync(join(REPO_ROOT, "apps/web/lib/mcp-tools.ts"), "utf8");
+
+describe("consolidation-bets registry", () => {
+  it("has unique, well-formed bet keys", () => {
+    const keys = CONSOLIDATION_BETS.map((bet) => bet.betKey);
+    expect(new Set(keys).size).toBe(keys.length);
+    for (const key of keys) expect(key).toMatch(/^BET-\d+$/);
+  });
+
+  it("has unique, well-formed backlog item ids", () => {
+    const ids = CONSOLIDATION_BETS.flatMap((bet) => bet.backlogItemIds);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^BI-[0-9A-F]{8}$/);
+    expect(CONSOLIDATION_BET_ITEM_IDS.size).toBe(ids.length);
+  });
+
+  it("uses only closed-vocabulary move types, waves, effort, leverage", () => {
+    for (const bet of CONSOLIDATION_BETS) {
+      expect(bet.moveTypes.length).toBeGreaterThan(0);
+      for (const move of bet.moveTypes) {
+        expect(CONSOLIDATION_MOVE_TYPES).toContain(move);
+      }
+      expect(CONSOLIDATION_WAVES).toContain(bet.wave);
+      expect(["S", "M", "L", "XL"]).toContain(bet.effort);
+      expect(["H", "M", "L"]).toContain(bet.leverage);
+      expect(bet.leafEstimate).toBeGreaterThan(0);
+    }
+  });
+
+  it("every file selector exists in the tree (no fabricated paths)", () => {
+    for (const bet of CONSOLIDATION_BETS) {
+      for (const file of bet.selectors.files) {
+        expect(existsSync(join(REPO_ROOT, file)), `${bet.betKey}: missing ${file}`).toBe(true);
+      }
+    }
+  });
+
+  it("every model selector is a declared Prisma model", () => {
+    for (const bet of CONSOLIDATION_BETS) {
+      for (const model of bet.selectors.models) {
+        expect(
+          new RegExp(`^model ${model} `, "m").test(SCHEMA),
+          `${bet.betKey}: model ${model} not in schema.prisma`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("every tool selector is a registered MCP tool name", () => {
+    for (const bet of CONSOLIDATION_BETS) {
+      for (const tool of bet.selectors.tools) {
+        expect(
+          MCP_TOOLS.includes(`"${tool}"`),
+          `${bet.betKey}: tool ${tool} not in mcp-tools.ts`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("every bet carries at least one projectable selector", () => {
+    for (const bet of CONSOLIDATION_BETS) {
+      const total =
+        bet.selectors.models.length + bet.selectors.tools.length + bet.selectors.files.length;
+      expect(total, `${bet.betKey} has no selectors`).toBeGreaterThan(0);
+    }
+  });
+
+  it("getConsolidationBet resolves by key", () => {
+    expect(getConsolidationBet("BET-6")?.leafEstimate).toBe(1000);
+    expect(getConsolidationBet("BET-99")).toBeUndefined();
+  });
+});

--- a/apps/web/lib/optimization/consolidation-bets.ts
+++ b/apps/web/lib/optimization/consolidation-bets.ts
@@ -1,0 +1,379 @@
+// Consolidation bets — the closed registry of EP-8DC217EB "Vertical
+// Integration Inward" structural bets, projected onto live architecture
+// surfaces by the optimization cockpit (BI-D9B58004).
+//
+// Pure data module in the build-process-matrix idiom: no imports from app
+// code, consumed by the cockpit loader (load-cockpit-data.ts) and the
+// capability-map "Optimization Impact" overlay (view-model.ts).
+//
+// Every selector is a REAL artifact: `models` are Prisma model names (fed to
+// traceCodeSurface({model})), `tools` are MCP tool names
+// (traceCodeSurface({tool})), `files` are repo-relative paths
+// (summarizeCodeGraphCoverage) — the contract test asserts each path exists
+// and each model is declared in schema.prisma, so the registry cannot drift
+// into fabrication. Grounding: the bet evidence tables in
+// docs/superpowers/plans/2026-07-07-vertical-integration-inward-plan.md §4.
+//
+// Adding or changing a bet requires: (1) the bet exists in the plan (or the
+// plan is amended first), (2) backlogItemIds point at live BI-… ids under
+// EP-8DC217EB, (3) selectors verified against the tree — the contract test
+// (consolidation-bets.test.ts) enforces (3) mechanically.
+
+export const CONSOLIDATION_MOVE_TYPES = [
+  "T1", // internalize (vendor)
+  "T2", // dedup
+  "T3", // hybridize
+  "T4", // extract primitive
+  "T5", // collapse surface
+  "T6", // retire
+  "T7", // portfolio-generalize
+] as const;
+
+export type ConsolidationMoveType = (typeof CONSOLIDATION_MOVE_TYPES)[number];
+
+export const CONSOLIDATION_WAVES = ["0", "1", "2", "3", "continuous", "enablement"] as const;
+export type ConsolidationWave = (typeof CONSOLIDATION_WAVES)[number];
+
+export type ConsolidationEffort = "S" | "M" | "L" | "XL";
+export type ConsolidationLeverage = "H" | "M" | "L";
+
+export type ConsolidationBet = {
+  /** Stable bet key from the plan (BET-0 … BET-14). */
+  betKey: string;
+  title: string;
+  /** Live BacklogItem.itemId values under EP-8DC217EB delivering this bet. */
+  backlogItemIds: string[];
+  moveTypes: ConsolidationMoveType[];
+  wave: ConsolidationWave;
+  effort: ConsolidationEffort;
+  leverage: ConsolidationLeverage;
+  /** Grounded Σleaf estimate of change sites, from the plan §4. */
+  leafEstimate: number;
+  selectors: {
+    /** Prisma model names — traceCodeSurface({ model }). */
+    models: string[];
+    /** MCP tool names — traceCodeSurface({ tool }). */
+    tools: string[];
+    /** Repo-relative file paths — summarizeCodeGraphCoverage. */
+    files: string[];
+  };
+};
+
+export const CONSOLIDATION_BETS: readonly ConsolidationBet[] = [
+  {
+    betKey: "BET-0",
+    title: "Self-optimization engine — cockpit, WSID profiles, parity targets, dispatch, sweep, feedback",
+    backlogItemIds: [
+      "BI-D9B58004",
+      "BI-ED9AC5A6",
+      "BI-9900B365",
+      "BI-C350F8B0",
+      "BI-F95222FA",
+      "BI-5C01F920",
+    ],
+    moveTypes: ["T4"],
+    wave: "enablement",
+    effort: "L",
+    leverage: "H",
+    leafEstimate: 6,
+    selectors: {
+      models: [],
+      tools: ["trace_code_surface", "get_code_graph_freshness"],
+      files: [
+        "apps/web/lib/optimization/consolidation-bets.ts",
+        "apps/web/lib/ea/architecture-parity-steward.ts",
+        "apps/web/lib/decision-perspective/resolve-profession-profile.ts",
+      ],
+    },
+  },
+  {
+    betKey: "BET-1",
+    title: "Work-Unit spine — one spine + typed roles + shared claim + one ActivityEvent",
+    backlogItemIds: ["BI-B6DD63A4"],
+    moveTypes: ["T3", "T7"],
+    wave: "3",
+    effort: "XL",
+    leverage: "H",
+    leafEstimate: 40,
+    selectors: {
+      models: [
+        "BacklogItem",
+        "Epic",
+        "WorkCapsule",
+        "FeatureBuild",
+        "TaskRun",
+        "WorkItem",
+        "WorkEngagement",
+      ],
+      tools: [],
+      files: [
+        "apps/web/lib/work-management/portal-case-loader.ts",
+        "apps/web/lib/work-management/workspace-case-loader.ts",
+        "apps/web/lib/integrate/build-orchestrator.ts",
+        "apps/web/lib/integrate/build-pipeline.ts",
+        "apps/web/lib/queue/functions/build-execute.ts",
+      ],
+    },
+  },
+  {
+    betKey: "BET-2",
+    title: "Authorization/decision spine — one EffectivePermission resolver, fused gates",
+    backlogItemIds: ["BI-F4156099"],
+    moveTypes: ["T3"],
+    wave: "1",
+    effort: "L",
+    leverage: "H",
+    leafEstimate: 25,
+    selectors: {
+      models: ["DecisionInteraction"],
+      tools: ["principle_decide"],
+      files: [
+        "apps/web/lib/govern/governance-resolver.ts",
+        "apps/web/lib/authority/effective-authority.ts",
+        "apps/web/lib/decision-perspective/evaluator.ts",
+        "apps/web/lib/actions/shared/guards.ts",
+        "apps/web/lib/api/auth-middleware.ts",
+        "apps/web/lib/tak/agent-grants.ts",
+      ],
+    },
+  },
+  {
+    betKey: "BET-3",
+    title: "Integration/adapter substrate — @dpf/integration-shared absorbs the clones",
+    backlogItemIds: ["BI-ABC88965"],
+    moveTypes: ["T2", "T4"],
+    wave: "2",
+    effort: "M",
+    leverage: "H",
+    leafEstimate: 60,
+    selectors: {
+      models: [],
+      tools: [],
+      files: [
+        "apps/web/lib/integrate/quickbooks/token-client.ts",
+        "apps/web/lib/integrate/adp/token-client.ts",
+        "apps/web/lib/integrate/microsoft365-communications/token-client.ts",
+        "apps/web/lib/integrate/google-marketing-intelligence/token-client.ts",
+        "packages/integration-shared/src/credential-crypto.ts",
+        "apps/web/lib/govern/credential-crypto.ts",
+        "apps/web/lib/routing/adapter-registry.ts",
+      ],
+    },
+  },
+  {
+    betKey: "BET-4",
+    title: "MCP tool surface + one-validation-source — drain the switch into packs",
+    backlogItemIds: ["BI-2B7EE073"],
+    moveTypes: ["T5", "T1"],
+    wave: "2",
+    effort: "L",
+    leverage: "H",
+    leafEstimate: 40,
+    selectors: {
+      models: [],
+      tools: [],
+      files: ["apps/web/lib/mcp-tools.ts", "apps/web/lib/mcp/tool-registry.ts"],
+    },
+  },
+  {
+    betKey: "BET-5",
+    title: "Datastore hybridization — Neo4j + Qdrant onto Postgres",
+    backlogItemIds: ["BI-A1E864A5"],
+    moveTypes: ["T3"],
+    wave: "3",
+    effort: "XL",
+    leverage: "H",
+    leafEstimate: 15,
+    selectors: {
+      models: [],
+      tools: [],
+      files: [
+        "packages/db/src/neo4j.ts",
+        "packages/db/src/qdrant.ts",
+        "apps/web/lib/wiki/ppr.ts",
+        "apps/web/lib/inference/embedding.ts",
+        "scripts/backup-neo4j.sh",
+        "scripts/backup-qdrant.sh",
+      ],
+    },
+  },
+  {
+    betKey: "BET-6",
+    title: "Cross-cutting micro-primitives — getErrorMessage, coercion, staleness, envelopes",
+    backlogItemIds: ["BI-6A505BFF"],
+    moveTypes: ["T4"],
+    wave: "0",
+    effort: "S",
+    leverage: "H",
+    leafEstimate: 1000,
+    selectors: {
+      models: [],
+      tools: [],
+      files: [
+        "apps/web/lib/shared/get-error-message.ts",
+        "apps/web/lib/shared/coerce.ts",
+        "apps/web/lib/shared/index.ts",
+      ],
+    },
+  },
+  {
+    betKey: "BET-7",
+    title: "UI primitive plane — report-kit adoption + feedback primitives",
+    backlogItemIds: ["BI-6182950F"],
+    moveTypes: ["T2", "T4"],
+    wave: "0",
+    effort: "M",
+    leverage: "H",
+    leafEstimate: 320,
+    selectors: {
+      models: [],
+      tools: [],
+      files: [
+        "apps/web/components/ui/report-kit/index.ts",
+        "apps/web/components/ui/report-kit/statusColors.ts",
+      ],
+    },
+  },
+  {
+    betKey: "BET-8",
+    title: "Model-routing/dispatch spine — one loop, one sensitivity source",
+    backlogItemIds: ["BI-0C4486A5"],
+    moveTypes: ["T2", "T6"],
+    wave: "1",
+    effort: "L",
+    leverage: "H",
+    leafEstimate: 55,
+    selectors: {
+      models: [],
+      tools: [],
+      files: [
+        "apps/web/lib/routing/pipeline.ts",
+        "apps/web/lib/routing/pipeline-v2.ts",
+        "apps/web/lib/routing/task-router.ts",
+        "apps/web/lib/tak/agent-router.ts",
+        "apps/web/lib/inference/ai-provider-priority.ts",
+        "apps/web/lib/routing/task-dispatcher.ts",
+      ],
+    },
+  },
+  {
+    betKey: "BET-9",
+    title: "Financial-document family + canonical Money",
+    backlogItemIds: ["BI-9D4A5D22"],
+    moveTypes: ["T3", "T4"],
+    wave: "3",
+    effort: "XL",
+    leverage: "H",
+    leafEstimate: 50,
+    selectors: {
+      models: [
+        "Quote",
+        "Invoice",
+        "Bill",
+        "PurchaseOrder",
+        "SalesOrder",
+        "StorefrontOrder",
+        "LedgerAccount",
+      ],
+      tools: [],
+      files: ["apps/web/lib/finance/setup-profile.ts"],
+    },
+  },
+  {
+    betKey: "BET-10",
+    title: "Live health/run read-model — OperationsRunReadModel + one reaper framework",
+    backlogItemIds: ["BI-B6157FB7"],
+    moveTypes: ["T4", "T5"],
+    wave: "1",
+    effort: "L",
+    leverage: "H",
+    leafEstimate: 40,
+    selectors: {
+      models: ["TaskRun"],
+      tools: [],
+      files: ["apps/web/lib/ai-operations-map/load-map-data.ts"],
+    },
+  },
+  {
+    betKey: "BET-11",
+    title: "Backup/restore/scheduling substrate — runManagedBackup + one metric family",
+    backlogItemIds: ["BI-B72328D5"],
+    moveTypes: ["T4", "T5"],
+    wave: "2",
+    effort: "M",
+    leverage: "H",
+    leafEstimate: 90,
+    selectors: {
+      models: [],
+      tools: [],
+      files: [
+        "scripts/backup-postgres.sh",
+        "scripts/backup-neo4j.sh",
+        "scripts/backup-qdrant.sh",
+      ],
+    },
+  },
+  {
+    betKey: "BET-12",
+    title: "Governance findings/evidence plane — one GovernanceFinding contract",
+    backlogItemIds: ["BI-7CD647B0"],
+    moveTypes: ["T3", "T7"],
+    wave: "2",
+    effort: "M",
+    leverage: "M",
+    leafEstimate: 45,
+    selectors: {
+      models: ["WikiLintFinding", "ComplianceEvidence", "DecisionInteraction"],
+      tools: [],
+      files: ["apps/web/lib/wiki/lint.ts"],
+    },
+  },
+  {
+    betKey: "BET-13",
+    title: "Identity & vocabulary convergence — fold identity onto Principal/Address",
+    backlogItemIds: ["BI-75B31594"],
+    moveTypes: ["T2", "T3", "T7"],
+    wave: "3",
+    effort: "XL",
+    leverage: "H",
+    leafEstimate: 45,
+    selectors: {
+      models: [
+        "Principal",
+        "PrincipalAlias",
+        "CustomerContact",
+        "Organization",
+        "CustomerAccount",
+      ],
+      tools: [],
+      files: ["apps/web/lib/shared/org-address.ts"],
+    },
+  },
+  {
+    betKey: "BET-14",
+    title: "External-surface rationalization — deps, engines, MCP fleet, services, skills",
+    backlogItemIds: ["BI-C0CEB377", "BI-3B0AD9CF"],
+    moveTypes: ["T1", "T5", "T6"],
+    wave: "continuous",
+    effort: "M",
+    leverage: "M",
+    leafEstimate: 45,
+    selectors: {
+      models: [],
+      tools: [],
+      files: [
+        "scripts/sbom/internalization-candidates.mjs",
+        "sbom/dependency-allowlist.json",
+      ],
+    },
+  },
+];
+
+/** Every BacklogItem.itemId delivering a consolidation bet (overlay matching). */
+export const CONSOLIDATION_BET_ITEM_IDS: ReadonlySet<string> = new Set(
+  CONSOLIDATION_BETS.flatMap((bet) => bet.backlogItemIds),
+);
+
+export function getConsolidationBet(betKey: string): ConsolidationBet | undefined {
+  return CONSOLIDATION_BETS.find((bet) => bet.betKey === betKey);
+}

--- a/apps/web/lib/optimization/load-cockpit-data.test.ts
+++ b/apps/web/lib/optimization/load-cockpit-data.test.ts
@@ -1,0 +1,152 @@
+// Loader tests for the optimization cockpit (BI-D9B58004). All dependencies
+// are injected, so these exercise the aggregation + degradation logic without
+// a graph store or database.
+
+import { describe, expect, it } from "vitest";
+
+import { CONSOLIDATION_BETS } from "./consolidation-bets";
+import { loadOptimizationCockpitData, type CockpitLoaderDeps } from "./load-cockpit-data";
+
+const BASE_FRESHNESS = {
+  graphKey: "source-code",
+  available: true,
+  indexStatus: "ready",
+  lastIndexedAt: new Date("2026-07-09T00:00:00Z"),
+  lastIndexedBranch: "main",
+  lastIndexedHeadSha: "abc",
+  workspaceDirty: false,
+  indexedFileCount: 4406,
+  lastError: null,
+  warnings: [],
+  summary: "Code graph is ready.",
+};
+
+function makeDeps(overrides: Partial<CockpitLoaderDeps> = {}): CockpitLoaderDeps {
+  return {
+    getFreshness: async () => ({ ...BASE_FRESHNESS }),
+    trace: async (input) => ({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      warnings: [],
+      summary: "ok",
+      selector: input.model
+        ? { kind: "model" as const, value: input.model }
+        : input.tool
+          ? { kind: "tool" as const, value: input.tool }
+          : { kind: "route" as const, value: input.route ?? "" },
+      surface: {
+        kind: "PrismaModel" as never,
+        name: input.model ?? input.tool ?? input.route ?? "",
+        path: "packages/db/prisma/schema.prisma",
+        startLine: 1,
+        endLine: 2,
+      },
+      implementationFiles: [
+        { path: `impl/${input.model ?? input.tool}.ts`, relationship: "DEFINES" },
+        { path: "impl/shared.ts", relationship: "DEFINES" },
+      ],
+      relatedTests: [{ path: `impl/${input.model ?? input.tool}.test.ts`, confidence: "high" as never }],
+    }),
+    coverage: async (files) => ({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      indexedFiles: files.slice(0, 1),
+      unindexedFiles: files.slice(1),
+      warnings: [],
+      summary: "ok",
+    }),
+    findBacklogItems: async (itemIds) =>
+      itemIds.map((itemId, index) => ({
+        itemId,
+        status: index === 0 ? "done" : "open",
+        title: `Item ${itemId}`,
+      })),
+    ...overrides,
+  };
+}
+
+describe("loadOptimizationCockpitData", () => {
+  it("projects every registered bet with blast radius and live status", async () => {
+    const data = await loadOptimizationCockpitData(makeDeps());
+
+    expect(data.bets).toHaveLength(CONSOLIDATION_BETS.length);
+    expect(data.freshness.available).toBe(true);
+    expect(data.totals.betCount).toBe(CONSOLIDATION_BETS.length);
+    expect(data.totals.backlogDone).toBeGreaterThan(0);
+
+    const bet1 = data.bets.find((projection) => projection.bet.betKey === "BET-1");
+    expect(bet1).toBeDefined();
+    // 7 model selectors, each tracing 2 impl files (1 shared) -> 8 distinct.
+    expect(bet1?.blastRadius?.tracedSelectorCount).toBe(7);
+    expect(bet1?.blastRadius?.implementationFileCount).toBe(8);
+    expect(bet1?.blastRadius?.unresolvedSelectors).toEqual([]);
+    expect(bet1?.fileCoverage?.indexedCount).toBe(1);
+    expect(bet1?.fileCoverage?.unindexedCount).toBe(bet1!.bet.selectors.files.length - 1);
+  });
+
+  it("degrades to null projections when the graph is unavailable", async () => {
+    const deps = makeDeps({
+      getFreshness: async () => ({
+        ...BASE_FRESHNESS,
+        available: false,
+        indexStatus: "missing",
+        warnings: ["The code graph has not been built yet."],
+        summary: "The code graph has not been built yet.",
+      }),
+      trace: async () => {
+        throw new Error("must not trace when unavailable");
+      },
+      coverage: async () => {
+        throw new Error("must not summarize when unavailable");
+      },
+    });
+
+    const data = await loadOptimizationCockpitData(deps);
+    expect(data.freshness.available).toBe(false);
+    for (const projection of data.bets) {
+      expect(projection.blastRadius).toBeNull();
+      expect(projection.fileCoverage).toBeNull();
+      expect(projection.backlogItems.length).toBeGreaterThan(0);
+    }
+    expect(data.totals.implementationFileCount).toBe(0);
+  });
+
+  it("treats per-selector graph errors as unresolved instead of failing the page", async () => {
+    const deps = makeDeps({
+      trace: async (input) => {
+        if (input.model === "TaskRun") throw new Error("neo4j hiccup");
+        return {
+          graphKey: "source-code",
+          available: true,
+          indexStatus: "ready",
+          warnings: [],
+          summary: "ok",
+          selector: { kind: "model" as const, value: input.model ?? input.tool ?? "" },
+          surface: null,
+          implementationFiles: [],
+          relatedTests: [],
+        };
+      },
+      coverage: async () => {
+        throw new Error("coverage down");
+      },
+    });
+
+    const data = await loadOptimizationCockpitData(deps);
+    const bet10 = data.bets.find((projection) => projection.bet.betKey === "BET-10");
+    expect(bet10?.blastRadius?.unresolvedSelectors).toContain("model:TaskRun");
+    expect(bet10?.fileCoverage).toBeNull();
+  });
+
+  it("marks missing backlog rows with null status", async () => {
+    const deps = makeDeps({ findBacklogItems: async () => [] });
+    const data = await loadOptimizationCockpitData(deps);
+    for (const projection of data.bets) {
+      for (const item of projection.backlogItems) {
+        expect(item.status).toBeNull();
+      }
+    }
+  });
+});

--- a/apps/web/lib/optimization/load-cockpit-data.ts
+++ b/apps/web/lib/optimization/load-cockpit-data.ts
@@ -1,0 +1,227 @@
+// Optimization cockpit loader — BI-D9B58004 (EP-8DC217EB BET-0a).
+//
+// Projects the consolidation-bet registry onto live architecture surfaces:
+// code-graph blast radius (traceCodeSurface per model/tool selector +
+// summarizeCodeGraphCoverage per file set), live BacklogItem status, and the
+// code-graph freshness/trust banner. Composed by the /ea/capabilities page.
+//
+// Degrades gracefully: when the code graph is unavailable (fresh install,
+// Neo4j down, index never built) every projection is null and the freshness
+// warnings explain why — the cockpit renders the registry + live BI status
+// and labels the blast-radius columns as unavailable.
+
+import { prisma } from "@dpf/db";
+
+import {
+  getCodeGraphFreshness,
+  summarizeCodeGraphCoverage,
+  type CodeGraphCoverageSummary,
+  type CodeGraphFreshness,
+} from "@/lib/integrate/code-graph-access";
+import { traceCodeSurface, type CodeSurfaceTraceResult } from "@/lib/integrate/code-graph";
+import { CONSOLIDATION_BETS, type ConsolidationBet } from "./consolidation-bets";
+
+export type BetBacklogStatus = {
+  itemId: string;
+  status: string | null;
+  title: string | null;
+};
+
+export type BetBlastRadius = {
+  /** Distinct implementation files across all traced model/tool selectors. */
+  implementationFileCount: number;
+  /** Distinct linked test files across traced selectors. */
+  relatedTestCount: number;
+  /** Selectors that resolved to a surface node in the graph. */
+  tracedSelectorCount: number;
+  /** Selectors the graph could not resolve (rename/drift signal). */
+  unresolvedSelectors: string[];
+};
+
+export type BetFileCoverage = {
+  indexedCount: number;
+  unindexedCount: number;
+};
+
+export type BetProjection = {
+  bet: ConsolidationBet;
+  backlogItems: BetBacklogStatus[];
+  /** null when the code graph is unavailable. */
+  blastRadius: BetBlastRadius | null;
+  /** null when the code graph is unavailable or the bet lists no files. */
+  fileCoverage: BetFileCoverage | null;
+};
+
+export type OptimizationCockpitData = {
+  freshness: Pick<
+    CodeGraphFreshness,
+    "available" | "indexStatus" | "lastIndexedAt" | "indexedFileCount" | "warnings" | "summary"
+  >;
+  bets: BetProjection[];
+  totals: {
+    betCount: number;
+    backlogDone: number;
+    backlogInProgress: number;
+    backlogOpen: number;
+    implementationFileCount: number;
+    relatedTestCount: number;
+  };
+};
+
+export type CockpitLoaderDeps = {
+  getFreshness: typeof getCodeGraphFreshness;
+  trace: typeof traceCodeSurface;
+  coverage: typeof summarizeCodeGraphCoverage;
+  findBacklogItems: (
+    itemIds: string[],
+  ) => Promise<Array<{ itemId: string; status: string; title: string }>>;
+};
+
+const defaultDeps: CockpitLoaderDeps = {
+  getFreshness: getCodeGraphFreshness,
+  trace: traceCodeSurface,
+  coverage: summarizeCodeGraphCoverage,
+  findBacklogItems: async (itemIds) =>
+    prisma.backlogItem.findMany({
+      where: { itemId: { in: itemIds } },
+      select: { itemId: true, status: true, title: true },
+    }),
+};
+
+function selectorLabel(kind: "model" | "tool", value: string): string {
+  return `${kind}:${value}`;
+}
+
+function aggregateTraces(
+  traces: Array<{ kind: "model" | "tool"; value: string; result: CodeSurfaceTraceResult | null }>,
+): BetBlastRadius {
+  const files = new Set<string>();
+  const tests = new Set<string>();
+  let traced = 0;
+  const unresolved: string[] = [];
+
+  for (const { kind, value, result } of traces) {
+    if (result?.surface) {
+      traced += 1;
+      for (const file of result.implementationFiles) files.add(file.path);
+      for (const test of result.relatedTests) tests.add(test.path);
+    } else {
+      unresolved.push(selectorLabel(kind, value));
+    }
+  }
+
+  return {
+    implementationFileCount: files.size,
+    relatedTestCount: tests.size,
+    tracedSelectorCount: traced,
+    unresolvedSelectors: unresolved,
+  };
+}
+
+function toFileCoverage(summary: CodeGraphCoverageSummary): BetFileCoverage {
+  return {
+    indexedCount: summary.indexedFiles.length,
+    unindexedCount: summary.unindexedFiles.length,
+  };
+}
+
+async function projectBet(
+  bet: ConsolidationBet,
+  graphAvailable: boolean,
+  statusByItemId: Map<string, BetBacklogStatus>,
+  deps: CockpitLoaderDeps,
+): Promise<BetProjection> {
+  const backlogItems = bet.backlogItemIds.map(
+    (itemId) => statusByItemId.get(itemId) ?? { itemId, status: null, title: null },
+  );
+
+  if (!graphAvailable) {
+    return { bet, backlogItems, blastRadius: null, fileCoverage: null };
+  }
+
+  const selectorInputs: Array<{ kind: "model" | "tool"; value: string }> = [
+    ...bet.selectors.models.map((value) => ({ kind: "model" as const, value })),
+    ...bet.selectors.tools.map((value) => ({ kind: "tool" as const, value })),
+  ];
+
+  // A graph-store error mid-page (e.g. Neo4j restarting) degrades that
+  // selector to "unresolved" instead of failing the whole capabilities page.
+  const traces: Array<{ kind: "model" | "tool"; value: string; result: CodeSurfaceTraceResult | null }> =
+    await Promise.all(
+      selectorInputs.map(async ({ kind, value }) => {
+        try {
+          return {
+            kind,
+            value,
+            result: await deps.trace(kind === "model" ? { model: value } : { tool: value }),
+          };
+        } catch {
+          return { kind, value, result: null };
+        }
+      }),
+    );
+
+  let fileCoverage: BetFileCoverage | null = null;
+  if (bet.selectors.files.length > 0) {
+    try {
+      fileCoverage = toFileCoverage(await deps.coverage(bet.selectors.files));
+    } catch {
+      fileCoverage = null;
+    }
+  }
+
+  return {
+    bet,
+    backlogItems,
+    blastRadius: aggregateTraces(traces),
+    fileCoverage,
+  };
+}
+
+export async function loadOptimizationCockpitData(
+  deps: CockpitLoaderDeps = defaultDeps,
+): Promise<OptimizationCockpitData> {
+  const freshness = await deps.getFreshness();
+
+  const allItemIds = CONSOLIDATION_BETS.flatMap((bet) => bet.backlogItemIds);
+  const rows = await deps.findBacklogItems(allItemIds);
+  const statusByItemId = new Map<string, BetBacklogStatus>(
+    rows.map((row) => [row.itemId, { itemId: row.itemId, status: row.status, title: row.title }]),
+  );
+
+  const bets: BetProjection[] = [];
+  for (const bet of CONSOLIDATION_BETS) {
+    // Sequential on purpose: each bet already fans out its selectors in
+    // parallel, and the graph store is a shared singleton.
+    bets.push(await projectBet(bet, freshness.available, statusByItemId, deps));
+  }
+
+  const statuses = bets.flatMap((projection) => projection.backlogItems);
+  const totals = {
+    betCount: bets.length,
+    backlogDone: statuses.filter((item) => item.status === "done").length,
+    backlogInProgress: statuses.filter((item) => item.status === "in-progress").length,
+    backlogOpen: statuses.filter((item) => item.status === "open").length,
+    implementationFileCount: bets.reduce(
+      (sum, projection) => sum + (projection.blastRadius?.implementationFileCount ?? 0),
+      0,
+    ),
+    relatedTestCount: bets.reduce(
+      (sum, projection) => sum + (projection.blastRadius?.relatedTestCount ?? 0),
+      0,
+    ),
+  };
+
+  return {
+    freshness: {
+      available: freshness.available,
+      indexStatus: freshness.indexStatus,
+      lastIndexedAt: freshness.lastIndexedAt,
+      indexedFileCount: freshness.indexedFileCount,
+      warnings: freshness.warnings,
+      summary: freshness.summary,
+    },
+    bets,
+    totals,
+  };
+}

--- a/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
@@ -1,0 +1,64 @@
+# Optimization Cockpit — projecting the Vertical-Integration bets onto live architecture surfaces
+
+_Status: implemented with BI-D9B58004 · EP-8DC217EB BET-0a · 2026-07-09_
+_Parent plan: [`2026-07-07-vertical-integration-inward-plan.md`](../plans/2026-07-07-vertical-integration-inward-plan.md) §9 (self-optimization engine, kernel-gated enablement-first)_
+
+## What
+
+The EP-8DC217EB consolidation bets become a **live, projected registry** instead of
+a static plan table:
+
+- **Registry** — `apps/web/lib/optimization/consolidation-bets.ts`: the closed
+  set of bets (BET-0 … BET-14), each carrying its plan grounding (move types
+  T1–T7, wave, effort/leverage, Σleaf estimate), its live `BacklogItem.itemId`s,
+  and **projection selectors**: Prisma model names, MCP tool names, and
+  repo-relative anchor files. The contract test
+  (`consolidation-bets.test.ts`) asserts every selector resolves — file exists,
+  model is declared in `schema.prisma`, tool is registered in `mcp-tools.ts` —
+  so the registry cannot drift into fabrication.
+- **Projection loader** — `apps/web/lib/optimization/load-cockpit-data.ts`:
+  per bet, real code-graph blast radius via `traceCodeSurface` (model/tool
+  selectors → distinct implementation files + linked tests) and
+  `summarizeCodeGraphCoverage` (anchor-file index coverage), joined with live
+  backlog status from Postgres. Uses the same server-side query layer the MCP
+  tools wrap — no MCP round-trip. Degrades gracefully: graph unavailable ⇒
+  null projections + the freshness trust banner; a per-selector graph error ⇒
+  that selector reported `unresolved`, never a 500.
+- **Surface** — the existing `/ea/capabilities` page:
+  `OptimizationCockpitSection` (report-kit `StatCard`/`DataTable`/`Notice`/
+  `StatusBadge` only) below the capability map, plus a new capability-map
+  overlay mode **“Optimization Impact”** (`CAPABILITY_OVERLAY_MODES` +
+  `deriveCapabilityOverlayState`) that lights up capabilities whose traced
+  backlog items belong to the bet registry (labels are `"BI-… title"`, matched
+  by id prefix against `CONSOLIDATION_BET_ITEM_IDS`).
+
+## Kernel decisions (recorded)
+
+- **Placement/UX-fit** (`principle_decide`, governing profile platform):
+  **capability-map overlay/extension** over a new `/platform` page or a new
+  top-level route — HIGH confidence, composite 4.015, margin 0.435. Hence: no
+  new route, no new nav entry, no new component family; the cockpit composes
+  report-kit on the existing EA capabilities tab with progressive disclosure.
+- BET-0 enablement-first sequencing was kernel-gated in the parent plan
+  (HIGH confidence, composite 9.10, margin 0.30).
+
+## Contract for future bets
+
+Adding/renaming a bet requires: the parent plan amended first; live BI ids
+under EP-8DC217EB; selectors verified (the contract test enforces this). When a
+consolidation lands and renames/deletes a selector target, the contract test
+fails on the stale selector — update the registry in the same PR that moves the
+artifact. BET-0b (BI-ED9AC5A6) extends this registry into the
+architecture-parity baseline so duplication becomes a measurable conformance
+issue; BET-0d/0e route bets to WSID-profiled coworkers — they consume this
+registry and MUST NOT grow a parallel one.
+
+## Research & benchmarking
+
+Composition follows the in-repo precedents rather than external dashboards:
+`build-process-matrix.ts` (closed pure data module + contract), the
+`ai-operations-map` loader→page shape, and the capability-map overlay-mode
+pattern (`maturity`/`coverage`/`planning`/`it4it`, now `optimization`).
+External comparison (LeanIX/Ardoq initiative-to-capability overlays) matches
+the chosen shape: initiatives as a first-class registry projected onto the
+capability map, not a separate reporting silo.


### PR DESCRIPTION
## What

EP-8DC217EB **BET-0a** (BI-D9B58004). The Vertical-Integration consolidation bets become a live, projected registry on `/ea/capabilities`:

- **`apps/web/lib/optimization/consolidation-bets.ts`** — closed pure registry (BET-0…BET-14): plan grounding (T1–T7 moves, wave, effort/leverage, Σleaf), live `BacklogItem.itemId`s, and projection selectors (Prisma models, MCP tools, anchor files). The **contract test** asserts every selector resolves (file exists, model in schema.prisma, tool in mcp-tools.ts) — no fabricated selectors, and a consolidation that renames a target fails the test until the registry is updated in the same PR.
- **`load-cockpit-data.ts`** — per-bet blast radius via the server-side `traceCodeSurface` / `summarizeCodeGraphCoverage` query layer (the same functions the MCP tools wrap — no round-trip) + live backlog status join. Degrades gracefully: graph offline ⇒ null projections + freshness trust banner; a per-selector Neo4j error ⇒ that selector reported unresolved, page never 500s.
- **`OptimizationCockpitSection`** — report-kit-only (StatCard band / DataTable / Notice / StatusBadge) below the capability map, disclosed via the page's existing `details` idiom.
- **New capability-map overlay mode “Optimization Impact”** — capabilities light up when a traced backlog item belongs to the bet registry (label-prefix match on BI id).
- Spec: `docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md` (records both kernel decisions).

## Verification

Substrate: source-local, worktree `opt-cockpit` (origin/main @ 7b6ce8a13, includes #2723):
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (full suite, twice) → **1713 files / 14701 tests passed, 0 failures** both runs; exit 1 both times is the pre-existing `portal-context.test.ts` worker-teardown unhandled rejection (reproduced standalone 1-in-3 on clean main; filed **BI-AE6AFE3D**)
- New tests: consolidation-bets contract (7), loader (4), overlay view-model (4) — green
- `node scripts/check-module-size.mjs` + `pnpm check:guards` → green

## UX-Fit-Decision

principle_decide scored placement: **capability-map overlay/extension** over a new /platform page or a new top-level route — HIGH confidence, composite 4.015, margin 0.435. Report-kit-only composition, no new route, no new nav entry, progressive disclosure.

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): full typecheck exit 0 + full vitest 14701 passed (only the filed flake) + ratchets green. CI is the canonical run.

Process-Spine-Decision: EP-8DC217EB plan §9 BET-0a (kernel-gated enablement-first, HIGH 9.10); spec included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)