### PR TITLE
feat(ea): consolidation bets as architecture-parity targets (BI-ED9AC5A6)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -47,6 +47,7 @@ const mocks = vi.hoisted(() => ({
   executeTool: vi.fn(),
   governedExecuteTool: vi.fn(),
   runArchitectureParitySteward: vi.fn(),
+  runConsolidationParitySteward: vi.fn(),
 }));
 
 vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
@@ -76,6 +77,9 @@ vi.mock("@/lib/mcp-governed-execute", () => ({
 }));
 vi.mock("@/lib/ea/architecture-parity-steward", () => ({
   runArchitectureParitySteward: mocks.runArchitectureParitySteward,
+}));
+vi.mock("@/lib/ea/consolidation-parity-steward", () => ({
+  runConsolidationParitySteward: mocks.runConsolidationParitySteward,
 }));
 
 import { executeScheduledAgentTask, scheduleAgentTask } from "./agent-task-scheduler";
@@ -903,12 +907,16 @@ describe("executeScheduledAgentTask — SysML projection reconcile branch", () =
       },
       steward: { created: 1, updated: 0, resolved: 0 },
     });
+    mocks.runConsolidationParitySteward.mockResolvedValue({
+      created: 0, updated: 0, resolved: 0, outstandingBets: [], completedBets: [],
+    });
     mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
     mocks.prisma.scheduledJob.update.mockResolvedValue({});
 
     await executeScheduledAgentTask("sysml-projection-nightly");
 
     expect(mocks.runArchitectureParitySteward).toHaveBeenCalledOnce();
+    expect(mocks.runConsolidationParitySteward).toHaveBeenCalledOnce();
     expect(mocks.runAgenticLoop).not.toHaveBeenCalled();
     expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/operate/scheduled-jobs/agent-task-core";
 import { runDataModelMirror } from "@/lib/ea/run-data-model-mirror";
 import { runArchitectureParitySteward } from "@/lib/ea/architecture-parity-steward";
+import { runConsolidationParitySteward } from "@/lib/ea/consolidation-parity-steward";
 import { computeNextCronRun, isOneShotCron } from "@/lib/operate/cron-next-run";
 import { extractScheduledTaskSummary } from "./agent-task-scheduler-summary";
 import {
@@ -154,6 +155,18 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         result.projections.mcpAuthority.toolCount,
         result.projections.coworkerAuthority.created + result.projections.coworkerAuthority.updated,
         result.steward.created + result.steward.updated + result.steward.resolved,
+      );
+      // BET-0b: the same parity sweep reconciles the consolidation-bet
+      // conformance issues, so duplication drift-reduces on the same cadence
+      // projection health does.
+      const consolidation = await runConsolidationParitySteward();
+      console.info(
+        "[agent-task-scheduler] consolidation parity outstanding=%d completed=%d (created=%d updated=%d resolved=%d)",
+        consolidation.outstandingBets.length,
+        consolidation.completedBets.length,
+        consolidation.created,
+        consolidation.updated,
+        consolidation.resolved,
       );
       const nextRunAt = computeNextCronRun(task.schedule, startedAt);
       await prisma.scheduledAgentTask.update({

--- a/apps/web/lib/ea/consolidation-parity-steward.test.ts
+++ b/apps/web/lib/ea/consolidation-parity-steward.test.ts
@@ -1,0 +1,119 @@
+// Tests for the consolidation parity steward (BI-ED9AC5A6): bets with
+// outstanding backlog work are open conformance issues; fully-delivered bets
+// auto-resolve through the shared reconciler.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { CONSOLIDATION_BETS } from "@/lib/optimization/consolidation-bets";
+import { runConsolidationParitySteward } from "./consolidation-parity-steward";
+
+type IssueRow = {
+  id: string;
+  issueType: string;
+  message: string;
+  severity: string;
+  detailsJson: Record<string, unknown>;
+  status: string;
+};
+
+function makeDb(input: {
+  statuses: Record<string, string>;
+  existingIssues?: IssueRow[];
+}) {
+  const issues: IssueRow[] = [...(input.existingIssues ?? [])];
+  return {
+    issues,
+    backlogItem: {
+      findMany: vi.fn().mockImplementation(async (args: { where: { itemId: { in: string[] } } }) =>
+        args.where.itemId.in
+          .filter((itemId) => itemId in input.statuses)
+          .map((itemId) => ({ itemId, status: input.statuses[itemId] })),
+      ),
+    },
+    eaConformanceIssue: {
+      findMany: vi.fn().mockImplementation(async () => issues.filter((row) => row.status === "open")),
+      create: vi.fn().mockImplementation(async (args: { data: IssueRow }) => {
+        const row = { ...args.data, id: `issue-${issues.length + 1}`, status: "open" };
+        issues.push(row as IssueRow);
+        return { id: row.id };
+      }),
+      update: vi.fn().mockImplementation(async (args: { where: { id: string }; data: Partial<IssueRow> }) => {
+        const row = issues.find((candidate) => candidate.id === args.where.id);
+        if (row) Object.assign(row, args.data);
+        return row;
+      }),
+    },
+  };
+}
+
+function allDoneStatuses(): Record<string, string> {
+  return Object.fromEntries(
+    CONSOLIDATION_BETS.flatMap((bet) => bet.backlogItemIds.map((itemId) => [itemId, "done"])),
+  );
+}
+
+describe("runConsolidationParitySteward", () => {
+  it("opens one issue per bet with outstanding work, keyed consolidation-parity:<betKey>", async () => {
+    const statuses = allDoneStatuses();
+    // Make BET-11's single item open again.
+    statuses["BI-B72328D5"] = "open";
+    const db = makeDb({ statuses });
+
+    const result = await runConsolidationParitySteward({ db: db as never });
+
+    expect(result.outstandingBets).toEqual(["BET-11"]);
+    expect(result.created).toBe(1);
+    const issue = db.issues[0]!;
+    expect(issue.detailsJson.issueKey).toBe("consolidation-parity:BET-11");
+    expect(issue.issueType).toBe("consolidation-outstanding");
+    expect(issue.message).toMatch(/BET-11/);
+  });
+
+  it("auto-resolves the issue when every delivery item reaches a terminal state", async () => {
+    const db = makeDb({
+      statuses: allDoneStatuses(),
+      existingIssues: [
+        {
+          id: "issue-old",
+          issueType: "consolidation-outstanding",
+          severity: "warn",
+          message: "Consolidation BET-11 …",
+          detailsJson: { issueKey: "consolidation-parity:BET-11" },
+          status: "open",
+        },
+      ],
+    });
+
+    const result = await runConsolidationParitySteward({ db: db as never });
+
+    expect(result.outstandingBets).toEqual([]);
+    expect(result.completedBets).toContain("BET-11");
+    expect(result.resolved).toBe(1);
+    expect(db.issues.find((row) => row.id === "issue-old")?.status).toBe("resolved");
+  });
+
+  it("treats a registry item id missing from the live backlog as outstanding drift", async () => {
+    const statuses = allDoneStatuses();
+    delete statuses["BI-A1E864A5"]; // BET-5's item vanishes from the backlog
+    const db = makeDb({ statuses });
+
+    const result = await runConsolidationParitySteward({ db: db as never });
+
+    expect(result.outstandingBets).toEqual(["BET-5"]);
+    const issue = db.issues[0]!;
+    expect(issue.detailsJson.openItemIds).toEqual(["BI-A1E864A5"]);
+  });
+
+  it("severity follows leverage (H → warn, M → info)", async () => {
+    const statuses = allDoneStatuses();
+    statuses["BI-B72328D5"] = "open"; // BET-11, leverage H
+    statuses["BI-C0CEB377"] = "open"; // BET-14, leverage M
+    const db = makeDb({ statuses });
+
+    await runConsolidationParitySteward({ db: db as never });
+
+    const byKey = new Map(db.issues.map((row) => [row.detailsJson.issueKey, row.severity]));
+    expect(byKey.get("consolidation-parity:BET-11")).toBe("warn");
+    expect(byKey.get("consolidation-parity:BET-14")).toBe("info");
+  });
+});

--- a/apps/web/lib/ea/consolidation-parity-steward.ts
+++ b/apps/web/lib/ea/consolidation-parity-steward.ts
@@ -1,0 +1,113 @@
+// Consolidation parity steward (BI-ED9AC5A6, EP-8DC217EB BET-0b).
+//
+// Registers the Vertical-Integration consolidation bets as architecture-parity
+// targets: each bet with outstanding delivery work is a live EA conformance
+// issue (stable key `consolidation-parity:<betKey>`), and the shared
+// reconciler auto-resolves the issue when every backlog item delivering the
+// bet reaches a terminal state. Duplication thereby becomes a MEASURABLE
+// conformance signal that drift-reduces as consolidations land — the same
+// contract the projection-unavailable steward already follows.
+//
+// Runs piggybacked on the scheduled SysML parity sweep (agent-task-scheduler),
+// so no new cron/task surface is added.
+
+import { prisma } from "@dpf/db";
+
+import {
+  CONSOLIDATION_BETS,
+  type ConsolidationBet,
+} from "@/lib/optimization/consolidation-bets";
+import {
+  reconcileConformanceIssues,
+  type ConformanceIssueClient,
+  type ConformanceIssueReconcileResult,
+} from "./conformance-issue-reconciler";
+
+const CONSOLIDATION_STEWARD = "consolidation-parity";
+const CONSOLIDATION_OUTSTANDING = "consolidation-outstanding";
+const MANAGED_ISSUE_TYPES = [CONSOLIDATION_OUTSTANDING];
+
+/** Statuses that count as "delivery finished" for a bet's backlog item. */
+const TERMINAL_STATUSES = new Set(["done", "deferred"]);
+
+export type ConsolidationBacklogClient = {
+  backlogItem: {
+    findMany(args: {
+      where: { itemId: { in: string[] } };
+      select: { itemId: true; status: true };
+    }): Promise<Array<{ itemId: string; status: string }>>;
+  };
+};
+
+export type ConsolidationParityStewardClient = ConformanceIssueClient & ConsolidationBacklogClient;
+
+export type ConsolidationParityStewardResult = ConformanceIssueReconcileResult & {
+  outstandingBets: string[];
+  completedBets: string[];
+};
+
+function severityFor(bet: ConsolidationBet): string {
+  return bet.leverage === "H" ? "warn" : "info";
+}
+
+export async function runConsolidationParitySteward(
+  opts: { db?: ConsolidationParityStewardClient } = {},
+): Promise<ConsolidationParityStewardResult> {
+  const db = opts.db ?? (prisma as unknown as ConsolidationParityStewardClient);
+
+  const allItemIds = CONSOLIDATION_BETS.flatMap((bet) => bet.backlogItemIds);
+  const rows = await db.backlogItem.findMany({
+    where: { itemId: { in: allItemIds } },
+    select: { itemId: true, status: true },
+  });
+  const statusByItemId = new Map(rows.map((row) => [row.itemId, row.status]));
+
+  const outstandingBets: string[] = [];
+  const completedBets: string[] = [];
+  const findings = [];
+
+  for (const bet of CONSOLIDATION_BETS) {
+    const itemStatuses = bet.backlogItemIds.map((itemId) => ({
+      itemId,
+      status: statusByItemId.get(itemId) ?? null,
+    }));
+    // An item id missing from the live backlog counts as outstanding: the
+    // registry claims work the backlog does not know about, which is itself
+    // a drift worth keeping visible rather than silently marking complete.
+    const open = itemStatuses.filter(
+      (item) => item.status === null || !TERMINAL_STATUSES.has(item.status),
+    );
+
+    if (open.length === 0) {
+      completedBets.push(bet.betKey);
+      continue;
+    }
+
+    outstandingBets.push(bet.betKey);
+    const issueKey = `${CONSOLIDATION_STEWARD}:${bet.betKey}`;
+    findings.push({
+      issueKey,
+      issueType: CONSOLIDATION_OUTSTANDING,
+      severity: severityFor(bet),
+      message: `Consolidation ${bet.betKey} (${bet.title}) has ${open.length} of ${bet.backlogItemIds.length} delivery item(s) outstanding — the duplication it collapses is still live (~${bet.leafEstimate} leaf sites).`,
+      detailsJson: {
+        issueKey,
+        steward: CONSOLIDATION_STEWARD,
+        betKey: bet.betKey,
+        wave: bet.wave,
+        effort: bet.effort,
+        leverage: bet.leverage,
+        leafEstimate: bet.leafEstimate,
+        items: itemStatuses,
+        openItemIds: open.map((item) => item.itemId),
+      },
+    });
+  }
+
+  const result = await reconcileConformanceIssues(db, {
+    issueTypes: MANAGED_ISSUE_TYPES,
+    findings,
+  });
+
+  return { ...result, outstandingBets, completedBets };
+}

--- a/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
@@ -53,6 +53,21 @@ architecture-parity baseline so duplication becomes a measurable conformance
 issue; BET-0d/0e route bets to WSID-profiled coworkers — they consume this
 registry and MUST NOT grow a parallel one.
 
+## BET-0b — consolidation bets as architecture-parity targets (BI-ED9AC5A6)
+
+Landed as `apps/web/lib/ea/consolidation-parity-steward.ts`:
+`runConsolidationParitySteward` reads the bet registry, joins live
+`BacklogItem` status, and reconciles one `eaConformanceIssue` per bet with
+outstanding delivery work (stable key `consolidation-parity:<betKey>`,
+severity = leverage: H→warn, M→info) through the shared
+`reconcileConformanceIssues` contract — so the issue auto-resolves the moment
+every item delivering the bet reaches a terminal state, and duplication is a
+measurable, drift-reducing conformance signal on the EA surface. A registry
+item id missing from the live backlog counts as outstanding drift (never a
+silent completion). It runs piggybacked on the scheduled SysML parity sweep
+(`agent-task-scheduler.ts`, `SYSML_PROJECTION_TASK_ID` branch) — no new
+cron/task surface.
+
 ## Research & benchmarking
 
 Composition follows the in-repo precedents rather than external dashboards:

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -17,7 +17,7 @@ apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1338
 apps/web/lib/actions/agent-coworker-external.test.ts	866
 apps/web/lib/actions/agent-coworker.ts	2638
-apps/web/lib/actions/agent-task-scheduler.test.ts	1018
+apps/web/lib/actions/agent-task-scheduler.test.ts	1026
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1114
 apps/web/lib/actions/build.ts	1770


### PR DESCRIPTION
## What

EP-8DC217EB **BET-0b** (BI-ED9AC5A6). Registers the Vertical-Integration consolidation bets as architecture-parity targets so duplication is a **measurable conformance issue that drift-reduces as work lands**:

- `apps/web/lib/ea/consolidation-parity-steward.ts` — `runConsolidationParitySteward` reads the bet registry (#2724), joins live `BacklogItem` status, and reconciles one `eaConformanceIssue` per bet with outstanding delivery work (stable key `consolidation-parity:<betKey>`, severity = leverage H→warn / M→info) through the shared `reconcileConformanceIssues` contract. The issue **auto-resolves** the moment every item delivering the bet reaches a terminal state. A registry item id missing from the live backlog counts as outstanding drift — never a silent completion.
- Runs piggybacked on the scheduled SysML parity sweep (`agent-task-scheduler.ts` `SYSML_PROJECTION_TASK_ID` branch) — **no new cron/task surface**; conformance issues surface on the existing EA data-model page like every other steward's.
- Spec: BET-0b section added to `docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md`.
- Scheduler test updated to mock + assert the consolidation steward runs in the SysML branch.

## Verification

Substrate: source-local, worktree `parity-targets` (main @ cd608b4da, includes #2724):
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (full suite) → **exit 0, 1714 files / 14705 tests passed** (an earlier run showed 3 unrelated failures at 900+s timings with 8 'Failed to start forks worker' errors — machine-resource starvation artifacts; the clean re-run passes everything)
- Steward tests 4/4 (open-issue per outstanding bet, auto-resolve on completion, missing-item = drift, severity mapping)
- `node scripts/check-module-size.mjs` (single-line re-baseline: scheduler test +8 LOC) + `pnpm check:guards` → green

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): full typecheck + full vitest exit 0 + ratchets green. CI is the canonical run.

Process-Spine-Decision: EP-8DC217EB plan §9 BET-0b (kernel-gated enablement-first, HIGH 9.10); spec section included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)