### PR TITLE
feat(ops-map): live refresh + timeline history depth (BI-44D3203D, BI-40EFC7DE)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -4,17 +4,17 @@ vi.mock("@dpf/db", () => ({
   prisma: {
     storefrontConfig: { findFirst: vi.fn() },
     agent: { findMany: vi.fn() },
-    taskRun: { findMany: vi.fn() },
-    toolExecution: { findMany: vi.fn() },
+    taskRun: { findMany: vi.fn(), aggregate: vi.fn() },
+    toolExecution: { findMany: vi.fn(), aggregate: vi.fn() },
     toolExecutionReceipt: { findMany: vi.fn() },
     backlogItemActivity: { findMany: vi.fn() },
     externalEvidenceRecord: { findMany: vi.fn() },
-    routeDecisionLog: { findMany: vi.fn() },
-    routeOutcome: { findMany: vi.fn() },
+    routeDecisionLog: { findMany: vi.fn(), aggregate: vi.fn() },
+    routeOutcome: { findMany: vi.fn(), aggregate: vi.fn() },
     agentMessage: { findMany: vi.fn() },
     modelProvider: { findMany: vi.fn() },
     modelProfile: { findMany: vi.fn() },
-    tokenUsage: { findMany: vi.fn() },
+    tokenUsage: { findMany: vi.fn(), aggregate: vi.fn() },
     scheduledAgentTask: { findMany: vi.fn() },
     scheduledJob: { findMany: vi.fn() },
     delegationChain: { findMany: vi.fn() },
@@ -134,10 +134,18 @@ describe("AI operations map page", () => {
     vi.mocked(prisma.phaseHandoff.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.deliberationRun.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.agentActionProposal.findMany).mockResolvedValue([] as never);
+    const emptyCreatedBounds = { _min: { createdAt: null }, _max: { createdAt: null } };
+    vi.mocked(prisma.routeDecisionLog.aggregate).mockResolvedValue(emptyCreatedBounds as never);
+    vi.mocked(prisma.tokenUsage.aggregate).mockResolvedValue(emptyCreatedBounds as never);
+    vi.mocked(prisma.routeOutcome.aggregate).mockResolvedValue(emptyCreatedBounds as never);
+    vi.mocked(prisma.toolExecution.aggregate).mockResolvedValue(emptyCreatedBounds as never);
+    vi.mocked(prisma.taskRun.aggregate).mockResolvedValue({ _min: { startedAt: null }, _max: { startedAt: null } } as never);
 
     const { default: OperationsMapPage } = await import("./page");
     const element = await OperationsMapPage();
-    const props = element.props;
+    // The page now renders the live-refresh shell (BI-44D3203D); the loaded
+    // snapshot arrives as its initialData prop.
+    const props = element.props.initialData;
 
     expect(props.template.label).toBe("Generic Value Chain");
     expect(props.template.stations.map((station: { label: string }) => station.label)).toContain("Demand");

--- a/apps/web/app/(shell)/platform/ai/operations-map/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.tsx
@@ -1,4 +1,4 @@
-import { AiOperationsMap } from "@/components/platform/AiOperationsMap";
+import { OperationsMapLiveShell } from "@/components/platform/OperationsMapLiveShell";
 import { loadOperationsMapData } from "@/lib/ai-operations-map/load-map-data";
 
 export const dynamic = "force-dynamic";
@@ -6,13 +6,5 @@ export const dynamic = "force-dynamic";
 export default async function OperationsMapPage() {
   const data = await loadOperationsMapData();
 
-  return (
-    <AiOperationsMap
-      template={data.template}
-      agents={data.agents}
-      projections={data.projections}
-      routingTopology={data.routingTopology}
-      recentWindowLabel={data.recentWindowLabel}
-    />
-  );
+  return <OperationsMapLiveShell initialData={data} />;
 }

--- a/apps/web/app/api/platform/operations-map/route.test.ts
+++ b/apps/web/app/api/platform/operations-map/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  loadOperationsMapData: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@/lib/ai-operations-map/load-map-data", () => ({
+  loadOperationsMapData: mocks.loadOperationsMapData,
+}));
+
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeRequest(query = ""): NextRequest {
+  return new NextRequest(`http://localhost/api/platform/operations-map${query}`);
+}
+
+const platformSession = {
+  user: { platformRole: "HR-000", isSuperuser: true },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.auth.mockResolvedValue(platformSession);
+  mocks.loadOperationsMapData.mockResolvedValue({ recentWindowLabel: "stub" });
+});
+
+describe("GET /api/platform/operations-map", () => {
+  it("404s without a view_platform session (mirrors the shell layout gate)", async () => {
+    mocks.auth.mockResolvedValue(null);
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(404);
+    expect(mocks.loadOperationsMapData).not.toHaveBeenCalled();
+  });
+
+  it("loads the default snapshot when no window params are given", async () => {
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(200);
+    expect(mocks.loadOperationsMapData).toHaveBeenCalledWith(undefined);
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+  });
+
+  it("passes a parsed evidence window through (epoch-ms params)", async () => {
+    const start = Date.parse("2026-06-01T00:00:00.000Z");
+    const end = Date.parse("2026-06-15T00:00:00.000Z");
+    const response = await GET(makeRequest(`?start=${start}&end=${end}`));
+    expect(response.status).toBe(200);
+    expect(mocks.loadOperationsMapData).toHaveBeenCalledWith({
+      window: { start: new Date(start), end: new Date(end) },
+    });
+  });
+
+  it("accepts ISO-8601 window params", async () => {
+    const response = await GET(
+      makeRequest("?start=2026-06-01T00:00:00.000Z&end=2026-06-15T00:00:00.000Z"),
+    );
+    expect(response.status).toBe(200);
+    expect(mocks.loadOperationsMapData).toHaveBeenCalledWith({
+      window: {
+        start: new Date("2026-06-01T00:00:00.000Z"),
+        end: new Date("2026-06-15T00:00:00.000Z"),
+      },
+    });
+  });
+
+  it("400s on a lone start param", async () => {
+    const response = await GET(makeRequest("?start=1750000000000"));
+    expect(response.status).toBe(400);
+    expect(mocks.loadOperationsMapData).not.toHaveBeenCalled();
+  });
+
+  it("400s on unparseable or inverted windows", async () => {
+    expect((await GET(makeRequest("?start=nonsense&end=alsononsense"))).status).toBe(400);
+    expect((await GET(makeRequest("?start=2000&end=1000"))).status).toBe(400);
+    expect(mocks.loadOperationsMapData).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/platform/operations-map/route.ts
+++ b/apps/web/app/api/platform/operations-map/route.ts
@@ -1,0 +1,76 @@
+// GET /api/platform/operations-map — Ops Map data refresh endpoint.
+// BI-44D3203D / BI-40EFC7DE: the operations-map page renders a one-shot
+// server snapshot; this route lets the client shell re-fetch the same
+// projected payload on a live-refresh interval and re-scope it to the
+// replay window the operator is viewing (?start=...&end=... ISO/epoch-ms).
+// Auth mirrors the (shell)/platform layout gate: view_platform or 404.
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  loadOperationsMapData,
+  type OperationsMapEvidenceWindow,
+} from "@/lib/ai-operations-map/load-map-data";
+
+export const dynamic = "force-dynamic";
+
+const NO_CACHE_HEADERS = {
+  "Cache-Control": "no-cache, no-store, must-revalidate",
+  Pragma: "no-cache",
+};
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_platform",
+    )
+  ) {
+    // Same posture as the platform shell layout: don't reveal the surface.
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const window = parseEvidenceWindow(searchParams.get("start"), searchParams.get("end"));
+  if (window instanceof Error) {
+    return NextResponse.json({ error: window.message }, { status: 400 });
+  }
+
+  const data = await loadOperationsMapData(window ? { window } : undefined);
+  return NextResponse.json(data, { headers: NO_CACHE_HEADERS });
+}
+
+/**
+ * Parse the optional window params. Accepts ISO-8601 or epoch milliseconds.
+ * Both-or-neither: a lone start/end is a caller bug and 400s rather than
+ * silently loading the default view.
+ */
+function parseEvidenceWindow(
+  start: string | null,
+  end: string | null,
+): OperationsMapEvidenceWindow | null | Error {
+  if (start === null && end === null) return null;
+  if (start === null || end === null) {
+    return new Error("start and end must be provided together");
+  }
+  const startDate = parseTimestamp(start);
+  const endDate = parseTimestamp(end);
+  if (!startDate || !endDate) {
+    return new Error("start and end must be ISO-8601 dates or epoch milliseconds");
+  }
+  if (startDate.getTime() >= endDate.getTime()) {
+    return new Error("start must be before end");
+  }
+  return { start: startDate, end: endDate };
+}
+
+function parseTimestamp(value: string): Date | null {
+  const asNumber = Number(value);
+  const date = Number.isFinite(asNumber) && value.trim() !== ""
+    ? new Date(asNumber)
+    : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -51,12 +51,29 @@ type SelectedItem =
   | { kind: "agent"; id: string }
   | { kind: "projection"; id: string };
 
+export type OperationsMapEvidenceRange = {
+  earliest: string | null;
+  latest: string | null;
+};
+
 type Props = {
   template: OperationsMapTemplate;
   agents: StationedOperationsMapAgent[];
   projections: OperationsMapProjection[];
   routingTopology: OperationsMapRoutingTopology;
   recentWindowLabel: string;
+  /**
+   * Global evidence bounds (window-independent). When provided, the replay
+   * timeline anchors its base range to these instead of only the loaded
+   * events, so a windowed refetch can't shrink the scrubber, and a
+   * "data begins" boundary marker renders at the earliest timestamp.
+   */
+  evidenceRange?: OperationsMapEvidenceRange | null;
+  /**
+   * Publishes the provider panel's visible replay window upward (live-shell
+   * refresh loop, BI-44D3203D) alongside the existing internal A2A share.
+   */
+  onReplayWindowChange?: (window: { time: number; start: number; end: number }) => void;
 };
 
 const SEVERITY_CLASS: Record<OperationsMapProjection["severity"], string> = {
@@ -206,7 +223,7 @@ const PROVIDER_LOGO_MATCHERS: Array<{ match: RegExp; logo: ProviderLogoDefinitio
   { match: /portkey/, logo: { key: "portkey", mark: "P", wordmark: "Portkey" } },
 ];
 
-export function AiOperationsMap({ template, agents, projections, routingTopology, recentWindowLabel }: Props) {
+export function AiOperationsMap({ template, agents, projections, routingTopology, recentWindowLabel, evidenceRange, onReplayWindowChange }: Props) {
   const [selected, setSelected] = useState<SelectedItem>({ kind: "station", id: template.stations[0]?.id ?? "" });
   const [activeQuickViewId, setActiveQuickViewId] = useState<OperationsMapStoredQuickViewId>(
     DEFAULT_QUICK_VIEW_ID,
@@ -261,8 +278,11 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
   // publishes its playhead here so the A2A interaction band scrubs in step.
   const [sharedReplay, setSharedReplay] = useState<{ time: number; range: RoutingTimelineRange } | null>(null);
   const handleReplayChange = useCallback(
-    (time: number, range: RoutingTimelineRange) => setSharedReplay({ time, range }),
-    [],
+    (time: number, range: RoutingTimelineRange) => {
+      setSharedReplay({ time, range });
+      onReplayWindowChange?.({ time, start: range.start, end: range.end });
+    },
+    [onReplayWindowChange],
   );
 
   // Stage D temporary preview switch: render the unified OperationsTopologyCanvas
@@ -391,6 +411,7 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
         {showProvider ? (
           <RoutingTopologyPanel
             routingTopology={routingTopology}
+            evidenceRange={evidenceRange ?? null}
             onReplayChange={handleReplayChange}
             onControlFilterChange={handleRoutingControlChange}
           />
@@ -604,10 +625,12 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
 
 function RoutingTopologyPanel({
   routingTopology,
+  evidenceRange,
   onReplayChange,
   onControlFilterChange,
 }: {
   routingTopology: OperationsMapRoutingTopology;
+  evidenceRange?: OperationsMapEvidenceRange | null;
   onReplayChange?: (selectedTime: number, range: RoutingTimelineRange) => void;
   onControlFilterChange?: (criteria: RoutingControlCriteria) => void;
 }) {
@@ -625,7 +648,11 @@ function RoutingTopologyPanel({
   const [symbolDetailAnchor, setSymbolDetailAnchor] = useState<RoutingSymbolAnchor | null>(null);
   const zoomLevel = ROUTING_ZOOM_LEVELS[zoomIndex] ?? 1;
   const timelineZoomLevel = ROUTING_TIMELINE_ZOOM_LEVELS[timelineZoomIndex] ?? 1;
-  const baseTimelineRange = useMemo(() => buildTimelineRange(routingTopology), [routingTopology]);
+  const baseTimelineRange = useMemo(
+    () => buildTimelineRange(routingTopology, evidenceRange ?? null),
+    [routingTopology, evidenceRange],
+  );
+  const historyBoundary = parseRoutingTimestamp(evidenceRange?.earliest ?? null);
   const selectedReplayTime = clampTimelineTimestamp(replayTimestamp ?? baseTimelineRange.current, baseTimelineRange);
   const timelineWindowAnchor = clampTimelineTimestamp(timelineCenterTimestamp ?? baseTimelineRange.current, baseTimelineRange);
   const timelineRange = useMemo(
@@ -1310,6 +1337,7 @@ function RoutingTopologyPanel({
           </div>
           <RoutingReplayTimeline
             markers={routingTopology.timeline}
+            historyBoundary={historyBoundary}
             range={timelineRange}
             selectedTime={selectedReplayTime}
             value={selectedTimelinePercent}
@@ -1512,6 +1540,7 @@ function RoutingReplayTimeline({
   canResetZoom,
   canZoomIn,
   canZoomOut,
+  historyBoundary,
   markers,
   onChange,
   onResetZoom,
@@ -1525,6 +1554,7 @@ function RoutingReplayTimeline({
   canResetZoom: boolean;
   canZoomIn: boolean;
   canZoomOut: boolean;
+  historyBoundary?: number | null;
   markers: OperationsMapRoutingTopology["timeline"];
   onChange: (value: number) => void;
   onResetZoom: () => void;
@@ -1543,6 +1573,10 @@ function RoutingReplayTimeline({
     () => markers.filter((marker) => timelineMarkerInRange(marker.occurredAt, range)),
     [markers, range],
   );
+  const boundaryVisible = typeof historyBoundary === "number"
+    && historyBoundary >= range.start
+    && historyBoundary <= range.end;
+  const boundaryPosition = boundaryVisible ? timelineMarkerPosition(historyBoundary, range) : null;
 
   return (
     <div
@@ -1589,6 +1623,23 @@ function RoutingReplayTimeline({
             className="absolute top-1 h-11 w-px bg-[var(--dpf-muted)]"
             style={{ left: `${currentPosition}%` }}
           />
+          {boundaryPosition !== null ? (
+            <span
+              data-routing-history-boundary
+              role="img"
+              aria-label={`Data begins ${formatReplayTime(historyBoundary as number)} — no evidence recorded before this point`}
+              title={`Data begins ${formatReplayTime(historyBoundary as number)} — no evidence recorded before this point`}
+              className="absolute top-1 z-30 h-11 w-0 border-l border-dashed border-[var(--dpf-warning)]"
+              style={{ left: `${boundaryPosition}%` }}
+            >
+              <span
+                aria-hidden="true"
+                className="absolute -top-0.5 left-0 -translate-x-1/2 whitespace-nowrap rounded bg-[color-mix(in_srgb,var(--dpf-warning)_18%,var(--dpf-surface-1))] px-1 text-[9px] font-semibold text-[var(--dpf-warning)]"
+              >
+                Data begins
+              </span>
+            </span>
+          ) : null}
           <span
             data-routing-playhead
             aria-label="Selected replay time"
@@ -2001,12 +2052,20 @@ function anchorSymbolDetail(event: RoutingSymbolEvent, container: HTMLDivElement
   };
 }
 
-function buildTimelineRange(topology: OperationsMapRoutingTopology): RoutingTimelineRange {
+function buildTimelineRange(
+  topology: OperationsMapRoutingTopology,
+  evidenceRange?: OperationsMapEvidenceRange | null,
+): RoutingTimelineRange {
   const fallbackNow = Date.now();
+  // Global evidence bounds pin the base range so a windowed refetch (which
+  // only carries events inside the fetched window) can't shrink the scrubber
+  // — that would feedback-loop: shrink → narrower window fetch → shrink.
   const timestamps = [
     ...topology.timeline.map((marker) => parseRoutingTimestamp(marker.occurredAt)),
     ...topology.routes.map((route) => parseRoutingTimestamp(route.occurredAt)),
     ...topology.markers.map((marker) => parseRoutingTimestamp(marker.occurredAt)),
+    parseRoutingTimestamp(evidenceRange?.earliest ?? null),
+    parseRoutingTimestamp(evidenceRange?.latest ?? null),
   ].filter((timestamp): timestamp is number => timestamp !== null);
   const currentTimelineMarker = topology.timeline.find((marker) => marker.lane === "current");
   const current = parseRoutingTimestamp(currentTimelineMarker?.occurredAt ?? null) ?? fallbackNow;

--- a/apps/web/components/platform/OperationsMapLiveShell.test.ts
+++ b/apps/web/components/platform/OperationsMapLiveShell.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { formatRefreshAge, windowMateriallyDiffers } from "./OperationsMapLiveShell";
+
+const HOUR = 60 * 60_000;
+
+describe("windowMateriallyDiffers", () => {
+  it("always fetches when nothing has been fetched yet", () => {
+    expect(windowMateriallyDiffers(null, { start: 0, end: HOUR })).toBe(true);
+  });
+
+  it("ignores padding-sized drift from the panel's post-swap republish", () => {
+    const previous = { start: 0, end: 24 * HOUR };
+    // 5% of a 24h span is 72min; a 30min end drift (new events + padding)
+    // must NOT trigger another fetch, or refresh would feedback-loop.
+    expect(windowMateriallyDiffers(previous, { start: 0, end: previous.end + 30 * 60_000 })).toBe(false);
+  });
+
+  it("fetches when the operator scrubs to a different window", () => {
+    const previous = { start: 0, end: 24 * HOUR };
+    expect(windowMateriallyDiffers(previous, { start: -10 * 24 * HOUR, end: -9 * 24 * HOUR })).toBe(true);
+  });
+
+  it("fetches when the operator zooms materially", () => {
+    const previous = { start: 0, end: 24 * HOUR };
+    expect(windowMateriallyDiffers(previous, { start: 8 * HOUR, end: 16 * HOUR })).toBe(true);
+  });
+
+  it("uses at least a one-minute tolerance for tiny spans", () => {
+    const previous = { start: 0, end: 15 * 60_000 };
+    expect(windowMateriallyDiffers(previous, { start: 30_000, end: 15 * 60_000 + 30_000 })).toBe(false);
+  });
+});
+
+describe("formatRefreshAge", () => {
+  it("labels fresh data as just now", () => {
+    expect(formatRefreshAge(3_000)).toBe("just now");
+  });
+
+  it("labels seconds, minutes, and hours", () => {
+    expect(formatRefreshAge(30_000)).toBe("30s ago");
+    expect(formatRefreshAge(5 * 60_000)).toBe("5m ago");
+    expect(formatRefreshAge(3 * HOUR)).toBe("3h ago");
+  });
+});

--- a/apps/web/components/platform/OperationsMapLiveShell.tsx
+++ b/apps/web/components/platform/OperationsMapLiveShell.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+// Live-refresh shell around the AI Operations Map (BI-44D3203D + BI-40EFC7DE).
+//
+// The map page server-renders one snapshot; this shell keeps it honest about
+// time afterwards:
+//  - polls /api/platform/operations-map on an interval (paused while the tab
+//    is hidden and held off right after the operator scrubs),
+//  - re-fetches with an explicit ?start&end evidence window when the operator
+//    scrubs/zooms the replay timeline to a materially different window, so
+//    history depth comes from the DB rather than the newest-40 boot snapshot,
+//  - surfaces a last-refreshed indicator + manual refresh.
+//
+// Feedback-loop guards (the panel republishes its window after every data
+// swap, and new data shifts the range end by padding): swap-echo publishes are
+// ignored for a short beat, and only materially different windows re-fetch.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { AiOperationsMap } from "./AiOperationsMap";
+import type { OperationsMapData } from "@/lib/ai-operations-map/load-map-data";
+
+const REFRESH_INTERVAL_MS = 45_000;
+const SCRUB_SETTLE_MS = 600;
+const SCRUB_POLL_HOLDOFF_MS = 5_000;
+const SWAP_ECHO_IGNORE_MS = 1_200;
+/** A fetched window whose end is this close to "now" is following the live edge. */
+const LIVE_EDGE_SLACK_MS = 10 * 60_000;
+/** Live-edge refetches extend past now so forecast/scheduled entries stay visible. */
+const LIVE_EDGE_FORECAST_PAD_MS = 60 * 60_000;
+
+export type EvidenceWindowMs = { start: number; end: number };
+
+/**
+ * Whether a requested evidence window differs enough from the one the current
+ * data was fetched with to justify another round-trip. Tolerance absorbs the
+ * padding/new-event drift the panel's republish carries after a data swap.
+ * Exported for unit tests.
+ */
+export function windowMateriallyDiffers(
+  previous: EvidenceWindowMs | null,
+  next: EvidenceWindowMs,
+): boolean {
+  if (!previous) return true;
+  const span = Math.max(next.end - next.start, previous.end - previous.start, 1);
+  const tolerance = Math.max(60_000, span * 0.05);
+  return (
+    Math.abs(next.start - previous.start) > tolerance ||
+    Math.abs(next.end - previous.end) > tolerance
+  );
+}
+
+/** Human age label for the freshness bar. Exported for unit tests. */
+export function formatRefreshAge(ageMs: number): string {
+  if (ageMs < 15_000) return "just now";
+  if (ageMs < 60_000) return `${Math.round(ageMs / 1000)}s ago`;
+  if (ageMs < 60 * 60_000) return `${Math.round(ageMs / 60_000)}m ago`;
+  return `${Math.round(ageMs / (60 * 60_000))}h ago`;
+}
+
+export function OperationsMapLiveShell({ initialData }: { initialData: OperationsMapData }) {
+  const [data, setData] = useState(initialData);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  const fetchedWindowRef = useRef<EvidenceWindowMs | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const swapAtRef = useRef(0);
+  const scrubAtRef = useRef(0);
+  const scrubTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastUpdatedRef = useRef(0);
+
+  const fetchSnapshot = useCallback(async (window: EvidenceWindowMs | null) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setRefreshing(true);
+    try {
+      const params = window
+        ? `?start=${Math.round(window.start)}&end=${Math.round(window.end)}`
+        : "";
+      const response = await fetch(`/api/platform/operations-map${params}`, {
+        signal: controller.signal,
+        cache: "no-store",
+      });
+      if (!response.ok) throw new Error(`Refresh failed (${response.status})`);
+      const next = (await response.json()) as OperationsMapData;
+      fetchedWindowRef.current = window;
+      swapAtRef.current = Date.now();
+      lastUpdatedRef.current = Date.now();
+      setData(next);
+      setLastUpdatedAt(Date.now());
+      setRefreshError(null);
+    } catch (error) {
+      if ((error as Error).name !== "AbortError") {
+        setRefreshError(error instanceof Error ? error.message : "Refresh failed");
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        setRefreshing(false);
+        abortRef.current = null;
+      }
+    }
+  }, []);
+
+  const refreshNow = useCallback(() => {
+    const fetched = fetchedWindowRef.current;
+    const now = Date.now();
+    // Follow the live edge: when the current window reaches (or predates by
+    // only a little) now, slide its end forward so fresh events land inside.
+    // A window parked deep in history refetches as-is — a no-op data-wise,
+    // but keeps the freshness indicator honest.
+    const window = fetched
+      ? fetched.end >= now - LIVE_EDGE_SLACK_MS
+        ? { start: fetched.start, end: now + LIVE_EDGE_FORECAST_PAD_MS }
+        : fetched
+      : null;
+    void fetchSnapshot(window);
+  }, [fetchSnapshot]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (document.hidden) return;
+      if (Date.now() - scrubAtRef.current < SCRUB_POLL_HOLDOFF_MS) return;
+      refreshNow();
+    }, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [refreshNow]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.hidden) return;
+      if (Date.now() - lastUpdatedRef.current < REFRESH_INTERVAL_MS) return;
+      refreshNow();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [refreshNow]);
+
+  useEffect(
+    () => () => {
+      if (scrubTimerRef.current) clearTimeout(scrubTimerRef.current);
+      abortRef.current?.abort();
+    },
+    [],
+  );
+
+  const handleReplayWindowChange = useCallback(
+    ({ start, end }: { time: number; start: number; end: number }) => {
+      // The panel republishes its window right after every data swap (the
+      // range recomputes from the new events); that echo is not a scrub.
+      if (Date.now() - swapAtRef.current < SWAP_ECHO_IGNORE_MS) return;
+      const next: EvidenceWindowMs = { start, end };
+      if (!windowMateriallyDiffers(fetchedWindowRef.current, next)) return;
+      scrubAtRef.current = Date.now();
+      if (scrubTimerRef.current) clearTimeout(scrubTimerRef.current);
+      scrubTimerRef.current = setTimeout(() => {
+        void fetchSnapshot(next);
+      }, SCRUB_SETTLE_MS);
+    },
+    [fetchSnapshot],
+  );
+
+  return (
+    <div className="space-y-2">
+      <OpsMapFreshnessBar
+        lastUpdatedAt={lastUpdatedAt}
+        refreshing={refreshing}
+        error={refreshError}
+        onRefresh={refreshNow}
+      />
+      <AiOperationsMap
+        template={data.template}
+        agents={data.agents}
+        projections={data.projections}
+        routingTopology={data.routingTopology}
+        recentWindowLabel={data.recentWindowLabel}
+        evidenceRange={data.evidenceRange}
+        onReplayWindowChange={handleReplayWindowChange}
+      />
+    </div>
+  );
+}
+
+/**
+ * Freshness indicator + manual refresh. Its own component so the 10s "age"
+ * ticker re-renders this strip alone, not the whole map tree.
+ */
+function OpsMapFreshnessBar({
+  lastUpdatedAt,
+  refreshing,
+  error,
+  onRefresh,
+}: {
+  lastUpdatedAt: number | null;
+  refreshing: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((value) => value + 1), 10_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const ageLabel = lastUpdatedAt === null
+    ? "showing the page-load snapshot"
+    : `refreshed ${formatRefreshAge(Date.now() - lastUpdatedAt)}`;
+
+  return (
+    <div
+      data-opsmap-freshness
+      className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs text-[var(--dpf-muted)]"
+    >
+      <span aria-live="polite">
+        {refreshing ? "Refreshing…" : `Live view · ${ageLabel} · auto-refresh every ${Math.round(REFRESH_INTERVAL_MS / 1000)}s`}
+        {error ? (
+          <span className="ml-2 text-[var(--dpf-error)]">Last refresh failed: {error}</span>
+        ) : null}
+      </span>
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={refreshing}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-2 py-1 font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)] disabled:opacity-50"
+      >
+        <RefreshCw aria-hidden className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+        Refresh now
+      </button>
+    </div>
+  );
+}

--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -14,12 +14,14 @@ vi.mock("@dpf/db", () => ({
     },
     toolExecution: {
       findMany: vi.fn(),
+      aggregate: vi.fn(),
     },
     toolExecutionReceipt: {
       findMany: vi.fn(),
     },
     taskRun: {
       findMany: vi.fn(),
+      aggregate: vi.fn(),
     },
     backlogItemActivity: {
       findMany: vi.fn(),
@@ -29,6 +31,7 @@ vi.mock("@dpf/db", () => ({
     },
     routeDecisionLog: {
       findMany: vi.fn(),
+      aggregate: vi.fn(),
     },
     agentMessage: {
       findMany: vi.fn(),
@@ -41,9 +44,11 @@ vi.mock("@dpf/db", () => ({
     },
     tokenUsage: {
       findMany: vi.fn(),
+      aggregate: vi.fn(),
     },
     routeOutcome: {
       findMany: vi.fn(),
+      aggregate: vi.fn(),
     },
     scheduledAgentTask: {
       findMany: vi.fn(),
@@ -70,7 +75,12 @@ vi.mock("@/lib/inference/phase-model-resolution", () => ({
 }));
 
 import { prisma } from "@dpf/db";
-import { loadOperationsMapData } from "./load-map-data";
+import {
+  RECENT_TOOL_LIMIT,
+  WINDOWED_SOURCE_LIMIT,
+  loadOperationsMapData,
+  resolveEvidenceRange,
+} from "./load-map-data";
 
 describe("loadOperationsMapData", () => {
   beforeEach(() => {
@@ -78,6 +88,12 @@ describe("loadOperationsMapData", () => {
     vi.mocked(prisma.agentMessage.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.modelProfile.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.routeOutcome.findMany).mockResolvedValue([] as never);
+    // Evidence-range aggregates default to an empty install.
+    vi.mocked(prisma.routeDecisionLog.aggregate).mockResolvedValue({ _min: { createdAt: null }, _max: { createdAt: null } } as never);
+    vi.mocked(prisma.tokenUsage.aggregate).mockResolvedValue({ _min: { createdAt: null }, _max: { createdAt: null } } as never);
+    vi.mocked(prisma.routeOutcome.aggregate).mockResolvedValue({ _min: { createdAt: null }, _max: { createdAt: null } } as never);
+    vi.mocked(prisma.toolExecution.aggregate).mockResolvedValue({ _min: { createdAt: null }, _max: { createdAt: null } } as never);
+    vi.mocked(prisma.taskRun.aggregate).mockResolvedValue({ _min: { startedAt: null }, _max: { startedAt: null } } as never);
     mockResolveModelSelectionByPhase.mockResolvedValue({
       generatedAt: "2026-06-28T20:00:00.000Z",
       phases: [],
@@ -203,6 +219,7 @@ describe("loadOperationsMapData", () => {
       },
     });
     expect(prisma.toolExecutionReceipt.findMany).toHaveBeenCalledWith({
+      where: {},
       orderBy: { createdAt: "desc" },
       take: 40,
       select: {
@@ -255,6 +272,7 @@ describe("loadOperationsMapData", () => {
       },
     });
     expect(prisma.externalEvidenceRecord.findMany).toHaveBeenCalledWith({
+      where: {},
       orderBy: { createdAt: "desc" },
       take: 40,
       select: {
@@ -581,7 +599,119 @@ describe("loadOperationsMapData", () => {
       expect.objectContaining({ orderBy: { startedAt: "desc" }, take: 40 }),
     );
     });
+
+  it("windows every evidence source and raises the per-source cap when a window is provided (BI-40EFC7DE)", async () => {
+    mockEmptySources();
+    const window = {
+      start: new Date("2026-06-01T00:00:00.000Z"),
+      end: new Date("2026-06-15T00:00:00.000Z"),
+    };
+
+    const data = await loadOperationsMapData({ window });
+
+    const createdAtWindow = { createdAt: { gte: window.start, lte: window.end } };
+    expect(prisma.toolExecution.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: createdAtWindow, take: WINDOWED_SOURCE_LIMIT }),
+    );
+    expect(prisma.routeDecisionLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: createdAtWindow, take: WINDOWED_SOURCE_LIMIT }),
+    );
+    expect(prisma.tokenUsage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: createdAtWindow, take: WINDOWED_SOURCE_LIMIT }),
+    );
+    expect(prisma.routeOutcome.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining(createdAtWindow),
+        take: WINDOWED_SOURCE_LIMIT,
+      }),
+    );
+    expect(prisma.taskRun.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          source: "proactive",
+          startedAt: { gte: window.start, lte: window.end },
+        }),
+        take: WINDOWED_SOURCE_LIMIT,
+      }),
+    );
+    // The stalled lift stays unwindowed: operator recovery (Retry/Abandon/
+    // Escalate) must see every stalled row regardless of the viewed window.
+    expect(prisma.taskRun.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { archivedAt: null, status: "stalled" },
+      }),
+    );
+    expect(data.queriedWindow).toEqual({
+      start: "2026-06-01T00:00:00.000Z",
+      end: "2026-06-15T00:00:00.000Z",
+    });
+    expect(data.recentWindowLabel).toBe(
+      `Up to ${WINDOWED_SOURCE_LIMIT} records per evidence source in the selected window`,
+    );
   });
+
+  it("keeps the newest-N default without a window and reports global evidence bounds", async () => {
+    mockEmptySources();
+    vi.mocked(prisma.routeDecisionLog.aggregate).mockResolvedValue({
+      _min: { createdAt: new Date("2026-06-08T00:00:00.000Z") },
+      _max: { createdAt: new Date("2026-07-01T00:00:00.000Z") },
+    } as never);
+    vi.mocked(prisma.toolExecution.aggregate).mockResolvedValue({
+      _min: { createdAt: new Date("2026-06-10T00:00:00.000Z") },
+      _max: { createdAt: new Date("2026-07-09T06:00:00.000Z") },
+    } as never);
+
+    const data = await loadOperationsMapData();
+
+    expect(prisma.toolExecution.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: {}, take: RECENT_TOOL_LIMIT }),
+    );
+    expect(data.evidenceRange).toEqual({
+      earliest: "2026-06-08T00:00:00.000Z",
+      latest: "2026-07-09T06:00:00.000Z",
+    });
+    expect(data.queriedWindow).toBeNull();
+    expect(data.recentWindowLabel).toBe("Last 40 records per evidence source");
+  });
+  });
+
+describe("resolveEvidenceRange", () => {
+  it("folds per-table bounds into the global min/max", () => {
+    expect(
+      resolveEvidenceRange([
+        { min: new Date("2026-06-10T00:00:00.000Z"), max: new Date("2026-07-01T00:00:00.000Z") },
+        { min: new Date("2026-06-08T00:00:00.000Z"), max: new Date("2026-06-20T00:00:00.000Z") },
+        { min: null, max: null },
+      ]),
+    ).toEqual({
+      earliest: "2026-06-08T00:00:00.000Z",
+      latest: "2026-07-01T00:00:00.000Z",
+    });
+  });
+
+  it("returns nulls for a fully empty install", () => {
+    expect(resolveEvidenceRange([{ min: null, max: null }])).toEqual({
+      earliest: null,
+      latest: null,
+    });
+  });
+});
+
+function mockEmptySources() {
+  vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
+  vi.mocked(prisma.agent.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.routeDecisionLog.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.modelProvider.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.tokenUsage.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.routeOutcome.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.scheduledAgentTask.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.scheduledJob.findMany).mockResolvedValue([] as never);
+}
 
 function makeAgentRow() {
   return {

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -24,6 +24,14 @@ import {
   projectDeliberations,
   type DeliberationSourceRow,
 } from "./project-deliberations";
+import {
+  extractBranchModelProvider,
+  getActivationProfileType,
+  mergeCoworkersById,
+  mergeTaskRunsDedupeById,
+  resolveEvidenceRange,
+  resolveGateResult,
+} from "./load-map-support";
 import type {
   OperationsMapRoutingTopology,
   OperationsMapAgent,
@@ -38,6 +46,25 @@ import type {
 } from "./types";
 
 export const RECENT_TOOL_LIMIT = 40;
+
+/**
+ * Per-source row budget when the caller scopes the load to an explicit
+ * evidence window (BI-40EFC7DE). The flat RECENT_TOOL_LIMIT cap silently
+ * discarded months of routing history — a 37-day timeline rendered only the
+ * newest 40 rows of each source. Windowed loads trade the global cap for a
+ * bounded per-window budget: newest-first within [start, end], so a dense
+ * window degrades to "most recent N inside the window" rather than an
+ * unbounded payload. Raw route-decision traces never leave the server (the
+ * projectors distill them into markers), so the budget bounds marker count,
+ * not trace bytes.
+ */
+export const WINDOWED_SOURCE_LIMIT = 400;
+
+export type OperationsMapEvidenceWindow = { start: Date; end: Date };
+
+export type LoadOperationsMapDataOptions = {
+  window?: OperationsMapEvidenceWindow | null;
+};
 
 /**
  * Cap on how many stalled TaskRuns are lifted into the projection set
@@ -60,9 +87,32 @@ export type OperationsMapData = {
   projections: OperationsMapProjection[];
   routingTopology: OperationsMapRoutingTopology;
   recentWindowLabel: string;
+  /**
+   * Global min/max evidence timestamps across the routing evidence tables,
+   * independent of the queried window. The timeline anchors its base range
+   * to this so windowed refetches can't shrink the scrubber's span, and the
+   * "data begins here" boundary marker is honest about how far back this
+   * install's history actually goes.
+   */
+  evidenceRange: { earliest: string | null; latest: string | null };
+  queriedWindow: { start: string; end: string } | null;
 };
 
-export async function loadOperationsMapData(): Promise<OperationsMapData> {
+export async function loadOperationsMapData(
+  options?: LoadOperationsMapDataOptions,
+): Promise<OperationsMapData> {
+  const evidenceWindow = options?.window ?? null;
+  const evidenceTake = evidenceWindow ? WINDOWED_SOURCE_LIMIT : RECENT_TOOL_LIMIT;
+  const createdAtWindow = evidenceWindow
+    ? { createdAt: { gte: evidenceWindow.start, lte: evidenceWindow.end } }
+    : {};
+  const startedAtWindow = evidenceWindow
+    ? { startedAt: { gte: evidenceWindow.start, lte: evidenceWindow.end } }
+    : {};
+  const recordedAtWindow = evidenceWindow
+    ? { recordedAt: { gte: evidenceWindow.start, lte: evidenceWindow.end } }
+    : {};
+
   const [
     storefrontConfig,
     agents,
@@ -85,6 +135,7 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     deliberationRuns,
     activityHarnessApprovalProposals,
     phaseModelSelection,
+    evidenceRange,
   ] = await Promise.all([
     prisma.storefrontConfig.findFirst({
       include: {
@@ -124,9 +175,10 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       where: {
         archivedAt: null,
         source: "proactive",
+        ...startedAtWindow,
       },
       orderBy: { startedAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         taskRunId: true,
@@ -170,8 +222,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     prisma.toolExecution.findMany({
+      where: { ...createdAtWindow },
       orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         threadId: true,
@@ -189,8 +242,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     prisma.toolExecutionReceipt.findMany({
+      where: { ...createdAtWindow },
       orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         toolExecutionId: true,
@@ -220,9 +274,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     prisma.backlogItemActivity.findMany({
-      where: { kind: "evidence" },
+      where: { kind: "evidence", ...recordedAtWindow },
       orderBy: { recordedAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         backlogItemId: true,
@@ -241,8 +295,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     prisma.externalEvidenceRecord.findMany({
+      where: { ...createdAtWindow },
       orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         actorUserId: true,
@@ -255,8 +310,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     prisma.routeDecisionLog.findMany({
+      where: { ...createdAtWindow },
       orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         agentMessageId: true,
@@ -303,8 +359,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     prisma.tokenUsage.findMany({
+      where: { ...createdAtWindow },
       orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         agentId: true,
@@ -323,9 +380,10 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
           { providerErrorCode: { not: null } },
           { fallbackOccurred: true },
         ],
+        ...createdAtWindow,
       },
       orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         agentId: true,
@@ -370,8 +428,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     // Deliberation fan-out is deferred until branch-persona identity is
     // captured (TaskNode has no agentId column today) — see Slice 4.
     prisma.delegationChain.findMany({
+      where: { ...startedAtWindow },
       orderBy: { startedAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         chainId: true,
@@ -387,8 +446,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     prisma.phaseHandoff.findMany({
+      where: { ...createdAtWindow },
       orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         buildId: true,
@@ -414,9 +474,10 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
             ],
           },
         ],
+        ...startedAtWindow,
       },
       orderBy: { startedAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         taskRunId: true,
@@ -435,8 +496,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     // provider from each branch's routeDecision) rather than A2A edges. The
     // coordinator is the parent TaskRun's current/initiating agent.
     prisma.deliberationRun.findMany({
+      where: { ...startedAtWindow },
       orderBy: { startedAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
+      take: evidenceTake,
       select: {
         id: true,
         diversityMode: true,
@@ -466,6 +528,33 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
     }),
     resolveModelSelectionByPhase(),
+    // Global evidence bounds (window-independent): anchors the client
+    // timeline's base range so windowed refetches can't shrink the scrubber,
+    // and powers the "data begins here" boundary marker (BI-40EFC7DE).
+    Promise.all([
+      prisma.routeDecisionLog.aggregate({ _min: { createdAt: true }, _max: { createdAt: true } }),
+      prisma.tokenUsage.aggregate({ _min: { createdAt: true }, _max: { createdAt: true } }),
+      prisma.routeOutcome.aggregate({ _min: { createdAt: true }, _max: { createdAt: true } }),
+      prisma.toolExecution.aggregate({ _min: { createdAt: true }, _max: { createdAt: true } }),
+      prisma.taskRun.aggregate({
+        _min: { startedAt: true },
+        _max: { startedAt: true },
+        where: { archivedAt: null },
+      }),
+    ]).then((aggregates) =>
+      resolveEvidenceRange(
+        aggregates.map((aggregate) => {
+          const bounds = aggregate as {
+            _min: Record<string, Date | null>;
+            _max: Record<string, Date | null>;
+          };
+          return {
+            min: Object.values(bounds._min)[0] ?? null,
+            max: Object.values(bounds._max)[0] ?? null,
+          };
+        }),
+      ),
+    ),
   ]);
 
   const routeDecisionAgentMessageIds = [
@@ -663,112 +752,14 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       deliberations,
       timeline: mergedTimeline,
     },
-    recentWindowLabel: `Last ${RECENT_TOOL_LIMIT} records per evidence source`,
+    recentWindowLabel: evidenceWindow
+      ? `Up to ${WINDOWED_SOURCE_LIMIT} records per evidence source in the selected window`
+      : `Last ${RECENT_TOOL_LIMIT} records per evidence source`,
+    evidenceRange,
+    queriedWindow: evidenceWindow
+      ? { start: evidenceWindow.start.toISOString(), end: evidenceWindow.end.toISOString() }
+      : null,
   };
 }
 
-/**
- * Recover a deliberation branch's model/provider from its persisted
- * `TaskNode.routeDecision` JSON. Provider falls back to the endpoint-id prefix
- * ("provider:model") when not stored explicitly — consistent with the routing
- * topology projector's provider resolution. Returns nulls for non-diverse runs
- * (single-model-multi-persona branches share one model and may carry neither).
- */
-function extractBranchModelProvider(value: unknown): { modelId: string | null; providerId: string | null } {
-  const parsed = typeof value === "string" ? safeJsonObject(value) : value;
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { modelId: null, providerId: null };
-  }
-  const record = parsed as Record<string, unknown>;
-  const modelId = typeof record.selectedModelId === "string" ? record.selectedModelId : null;
-  let providerId = typeof record.providerId === "string" ? record.providerId : null;
-  if (!providerId && typeof record.selectedEndpoint === "string" && record.selectedEndpoint.includes(":")) {
-    providerId = record.selectedEndpoint.split(":")[0] || null;
-  }
-  return { modelId, providerId };
-}
-
-function safeJsonObject(value: string): unknown {
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Resolve a PhaseHandoff.gateResult JSON blob into a pass/fail signal + a
- * short label. Conservative: an explicit boolean wins; otherwise a status
- * string is pattern-matched; otherwise the gate state is unknown (null).
- */
-function resolveGateResult(value: unknown): { passed: boolean | null; label: string | null } {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return { passed: null, label: null };
-  }
-  const record = value as Record<string, unknown>;
-  const explicit = record.passed ?? record.allowed ?? record.advanced;
-  const statusText = [record.result, record.status, record.outcome, record.decision]
-    .find((entry): entry is string => typeof entry === "string");
-
-  let passed: boolean | null = null;
-  if (typeof explicit === "boolean") {
-    passed = explicit;
-  } else if (statusText) {
-    if (/pass|advanc|approv|ok|success/i.test(statusText)) passed = true;
-    else if (/fail|block|reject|deny|error/i.test(statusText)) passed = false;
-  }
-
-  return { passed, label: statusText ?? null };
-}
-
-/**
- * Union two coworker-node lists by agentId, preserving the provider-topology
- * entry when an agent appears in both. Keeps a stable label sort.
- */
-function mergeCoworkersById<T extends { agentId: string; label: string }>(
-  primary: T[],
-  secondary: T[],
-): T[] {
-  const byId = new Map<string, T>();
-  for (const coworker of primary) byId.set(coworker.agentId, coworker);
-  for (const coworker of secondary) {
-    if (!byId.has(coworker.agentId)) byId.set(coworker.agentId, coworker);
-  }
-  return [...byId.values()].sort((left, right) => left.label.localeCompare(right.label));
-}
-
-function getActivationProfileType(value: unknown): string | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const profileType = (value as { profileType?: unknown }).profileType;
-  return typeof profileType === "string" ? profileType : null;
-}
-
-/**
- * Merge the recent-40 task-run window with the stalled-200 window,
- * keeping each cuid id once. Exported so the unit test can lock in the
- * dedup behavior — the AI Operations Map's correctness depends on a row
- * appearing exactly once in the projection set.
- *
- * Both inputs share the same row shape (the Prisma select clauses match).
- * Recent rows are inserted first, then stalled rows that haven't already
- * appeared — this keeps existing test snapshots stable and matches the
- * mental model "stalled is added on top of recent."
- */
-export function mergeTaskRunsDedupeById<T extends { id: string }>(
-  recent: T[],
-  stalled: T[],
-): T[] {
-  const seen = new Set<string>();
-  const merged: T[] = [];
-  for (const row of recent) {
-    if (seen.has(row.id)) continue;
-    seen.add(row.id);
-    merged.push(row);
-  }
-  for (const row of stalled) {
-    if (seen.has(row.id)) continue;
-    seen.add(row.id);
-    merged.push(row);
-  }
-  return merged;
-}
+export { mergeTaskRunsDedupeById, resolveEvidenceRange } from "./load-map-support";

--- a/apps/web/lib/ai-operations-map/load-map-support.ts
+++ b/apps/web/lib/ai-operations-map/load-map-support.ts
@@ -1,0 +1,129 @@
+// Pure row-shaping helpers backing loadOperationsMapData. Extracted from
+// load-map-data.ts to keep that module under the size ceiling; no behavior
+// lives here that touches Prisma — everything is pure and unit-testable.
+
+/**
+ * Fold per-table min/max timestamp bounds into a single global evidence
+ * range. Null-safe: tables with no rows contribute nothing; a fully empty
+ * install yields { earliest: null, latest: null }.
+ */
+export function resolveEvidenceRange(
+  bounds: Array<{ min: Date | null; max: Date | null }>,
+): { earliest: string | null; latest: string | null } {
+  let earliest: Date | null = null;
+  let latest: Date | null = null;
+  for (const bound of bounds) {
+    if (bound.min && (!earliest || bound.min < earliest)) earliest = bound.min;
+    if (bound.max && (!latest || bound.max > latest)) latest = bound.max;
+  }
+  return {
+    earliest: earliest ? earliest.toISOString() : null,
+    latest: latest ? latest.toISOString() : null,
+  };
+}
+
+/**
+ * Recover a deliberation branch's model/provider from its persisted
+ * `TaskNode.routeDecision` JSON. Provider falls back to the endpoint-id prefix
+ * ("provider:model") when not stored explicitly — consistent with the routing
+ * topology projector's provider resolution. Returns nulls for non-diverse runs
+ * (single-model-multi-persona branches share one model and may carry neither).
+ */
+export function extractBranchModelProvider(value: unknown): { modelId: string | null; providerId: string | null } {
+  const parsed = typeof value === "string" ? safeJsonObject(value) : value;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { modelId: null, providerId: null };
+  }
+  const record = parsed as Record<string, unknown>;
+  const modelId = typeof record.selectedModelId === "string" ? record.selectedModelId : null;
+  let providerId = typeof record.providerId === "string" ? record.providerId : null;
+  if (!providerId && typeof record.selectedEndpoint === "string" && record.selectedEndpoint.includes(":")) {
+    providerId = record.selectedEndpoint.split(":")[0] || null;
+  }
+  return { modelId, providerId };
+}
+
+function safeJsonObject(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a PhaseHandoff.gateResult JSON blob into a pass/fail signal + a
+ * short label. Conservative: an explicit boolean wins; otherwise a status
+ * string is pattern-matched; otherwise the gate state is unknown (null).
+ */
+export function resolveGateResult(value: unknown): { passed: boolean | null; label: string | null } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { passed: null, label: null };
+  }
+  const record = value as Record<string, unknown>;
+  const explicit = record.passed ?? record.allowed ?? record.advanced;
+  const statusText = [record.result, record.status, record.outcome, record.decision]
+    .find((entry): entry is string => typeof entry === "string");
+
+  let passed: boolean | null = null;
+  if (typeof explicit === "boolean") {
+    passed = explicit;
+  } else if (statusText) {
+    if (/pass|advanc|approv|ok|success/i.test(statusText)) passed = true;
+    else if (/fail|block|reject|deny|error/i.test(statusText)) passed = false;
+  }
+
+  return { passed, label: statusText ?? null };
+}
+
+/**
+ * Union two coworker-node lists by agentId, preserving the provider-topology
+ * entry when an agent appears in both. Keeps a stable label sort.
+ */
+export function mergeCoworkersById<T extends { agentId: string; label: string }>(
+  primary: T[],
+  secondary: T[],
+): T[] {
+  const byId = new Map<string, T>();
+  for (const coworker of primary) byId.set(coworker.agentId, coworker);
+  for (const coworker of secondary) {
+    if (!byId.has(coworker.agentId)) byId.set(coworker.agentId, coworker);
+  }
+  return [...byId.values()].sort((left, right) => left.label.localeCompare(right.label));
+}
+
+export function getActivationProfileType(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const profileType = (value as { profileType?: unknown }).profileType;
+  return typeof profileType === "string" ? profileType : null;
+}
+
+/**
+ * Merge the recent-40 task-run window with the stalled-200 window,
+ * keeping each cuid id once. Exported so the unit test can lock in the
+ * dedup behavior — the AI Operations Map's correctness depends on a row
+ * appearing exactly once in the projection set.
+ *
+ * Both inputs share the same row shape (the Prisma select clauses match).
+ * Recent rows are inserted first, then stalled rows that haven't already
+ * appeared — this keeps existing test snapshots stable and matches the
+ * mental model "stalled is added on top of recent."
+ */
+export function mergeTaskRunsDedupeById<T extends { id: string }>(
+  recent: T[],
+  stalled: T[],
+): T[] {
+  const seen = new Set<string>();
+  const merged: T[] = [];
+  for (const row of recent) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    merged.push(row);
+  }
+  for (const row of stalled) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    merged.push(row);
+  }
+  return merged;
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 542,
+  "routeCount": 543,
   "routes": [
     {
       "routePath": "/",
@@ -1116,6 +1116,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/platform/metrics/targets/route.ts"
+    },
+    {
+      "routePath": "/api/platform/operations-map",
+      "kind": "route",
+      "segments": [
+        "api",
+        "platform",
+        "operations-map"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/platform/operations-map/route.ts"
     },
     {
       "routePath": "/api/platform/security/overview",

--- a/docs/superpowers/plans/2026-07-09-ops-map-live-refresh-history-depth-plan.md
+++ b/docs/superpowers/plans/2026-07-09-ops-map-live-refresh-history-depth-plan.md
@@ -1,0 +1,77 @@
+# Ops Map live refresh + timeline history depth — implementation plan
+
+- **Date:** 2026-07-09
+- **Backlog items:** BI-44D3203D (live refresh), BI-40EFC7DE (history depth)
+- **Epic:** EP-B9DD37C7 (runtime truthfulness, transparency & controls — extended from chat surfaces to the platform Ops Map; rationale recorded at filing)
+- **Kernel decision:** `principle_decide` scoped this as two separable BIs delivered together (high confidence, margin 0.69); operator directed delivery outside Build Studio in-session.
+
+## Problem
+
+The `/platform/ai/operations-map` provider routing topology labels itself
+"LIVE ROUTING TRAFFIC" but was a one-shot server snapshot: no polling, no
+SSE, no re-fetch — the canvas animates a static payload. Separately, every
+evidence source was capped at its newest 40 rows (`RECENT_TOOL_LIMIT`), so
+the replay timeline claimed a multi-week span while rendering only the last
+hours-to-days of events; the live DB held ~15k route outcomes / ~1.4k route
+decisions since 2026-06-08 that the surface silently discarded.
+
+## Shape
+
+**Phase 1 — windowed loader (BI-40EFC7DE), `apps/web/lib/ai-operations-map/load-map-data.ts`:**
+
+- `loadOperationsMapData(options?: { window?: { start; end } })` — when a
+  window is given, every time-anchored evidence query filters to it
+  (`createdAt` / `startedAt` / `recordedAt`) and the per-source cap rises
+  from `RECENT_TOOL_LIMIT` (40) to `WINDOWED_SOURCE_LIMIT` (400), newest-first
+  within the window. A dense window degrades to "newest 400 inside the
+  window", never an unbounded payload. Raw route-decision traces never leave
+  the server — projectors distill them — so the budget bounds marker count,
+  not trace bytes.
+- The stalled-TaskRun lift (BI-OPS-MAP-STALLED-WINDOW) and forecast sources
+  (scheduled tasks/jobs) stay unwindowed by design.
+- New `evidenceRange` (global min/max across the five main evidence tables,
+  via aggregates) and `queriedWindow` fields on `OperationsMapData`;
+  `recentWindowLabel` reflects the actual query shape.
+
+**Phase 2 — refresh API:** `GET /api/platform/operations-map[?start&end]`
+(`apps/web/app/api/platform/operations-map/route.ts`). Auth mirrors the
+platform shell layout gate (`auth()` + `can(view_platform)`, 404 posture).
+Window params accept ISO-8601 or epoch-ms; both-or-neither; 400 on invalid.
+
+**Phase 3 — live shell (BI-44D3203D), `apps/web/components/platform/OperationsMapLiveShell.tsx`:**
+
+- Wraps `AiOperationsMap` on the page; polls the API every 45s, paused while
+  the tab is hidden and held off 5s after a scrub; re-fetches on tab
+  re-focus when stale; manual "Refresh now"; last-refreshed indicator in a
+  sibling component so its ticker doesn't re-render the map tree.
+- Scrub/zoom to a materially different replay window re-fetches with that
+  window (600ms settle debounce), giving the timeline true history depth.
+- Feedback-loop guards: the panel republishes its window after every data
+  swap, so swap-echo publishes are ignored for 1.2s and only materially
+  different windows (>max(60s, 5% of span) edge delta) re-fetch; the base
+  timeline range is anchored to the global `evidenceRange` so windowed
+  payloads can't shrink the scrubber (shrink → narrower fetch → shrink).
+- Live-edge follow: when the fetched window reaches "now", poll refetches
+  slide its end forward (+60min forecast pad) so new events land in-window.
+
+**Phase 4 — honest timeline:** `AiOperationsMap` gains optional
+`evidenceRange` / `onReplayWindowChange` props; `buildTimelineRange` pins the
+base range to the global evidence bounds; a dashed "Data begins" boundary
+marker renders at the earliest evidence timestamp (this install: 2026-06-08),
+so the scrubber no longer implies history that predates the data.
+
+## Verification
+
+- Unit: windowed query shapes + caps, `resolveEvidenceRange` folding,
+  route param validation + auth gate, `windowMateriallyDiffers` /
+  `formatRefreshAge` (all in sibling `.test.ts` files).
+- Functional: drive `/platform/ai/operations-map` on the contributor
+  preview — observe auto-refresh tick, scrub-to-history fetch, boundary
+  marker.
+
+## Out of scope
+
+- SSE/WebSocket push (poll is the substrate-lighter first step; the API
+  contract doesn't preclude swapping the transport later).
+- Retention/archival policy; A2A band re-windowing beyond what the shared
+  replay window already provides.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -8,7 +8,7 @@ apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031
 apps/web/components/ops/SelfUpgradeClient.test.tsx	997
 apps/web/components/ops/SelfUpgradeClient.tsx	1377
-apps/web/components/platform/AiOperationsMap.tsx	2790
+apps/web/components/platform/AiOperationsMap.tsx	2849
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
@@ -30,7 +30,7 @@ apps/web/lib/actions/promotions.self-upgrade.test.ts	1021
 apps/web/lib/actions/promotions.ts	998
 apps/web/lib/actions/tax-remittance.test.ts	1080
 apps/web/lib/actions/tax-remittance.ts	1788
-apps/web/lib/ai-operations-map/load-map-data.test.ts	813
+apps/web/lib/ai-operations-map/load-map-data.test.ts	943
 apps/web/lib/explore/build-process-matrix.ts	811
 apps/web/lib/explore/feature-build-types.ts	1106
 apps/web/lib/finance/ai-provider-finance.ts	1309


### PR DESCRIPTION
## Summary

The Ops Map provider routing topology labeled itself **LIVE ROUTING TRAFFIC** but was a one-shot server snapshot (no poll/SSE/refetch — the canvas animates static data), and its replay timeline silently discarded months of routing evidence behind a flat newest-40-rows-per-source cap: the live DB held ~15k route outcomes / ~1.4k route decisions / ~19k tool executions since Jun 8 that never rendered. Operator watched the "live" map and saw nothing change; rewinding showed near-empty history.

**BI-40EFC7DE — timeline history depth**
- `loadOperationsMapData` accepts an optional evidence window: every time-anchored source filters to `[start, end]` with the cap raised from `RECENT_TOOL_LIMIT` (40) to a documented `WINDOWED_SOURCE_LIMIT` (400), newest-first inside the window — dense windows degrade gracefully, never unbounded. Route-decision traces stay server-side (projectors distill them), so the budget bounds marker count, not trace bytes.
- Stalled-TaskRun lift (BI-OPS-MAP-STALLED-WINDOW) and forecast sources stay unwindowed by design.
- New global `evidenceRange` (min/max across the five evidence tables) + `queriedWindow` + honest `recentWindowLabel`.
- Pure helpers split to `load-map-support.ts` to honor the module-size ceiling.

**BI-44D3203D — live refresh**
- New `GET /api/platform/operations-map[?start&end]` — auth mirrors the platform shell layout gate (`view_platform` or 404); ISO/epoch-ms params validated (400 on lone/invalid/inverted).
- `OperationsMapLiveShell` wraps the map: 45s poll (paused while tab hidden, held off 5s after a scrub, refetch on refocus when stale), scrub/zoom-to-window refetch (600ms settle debounce), manual "Refresh now", last-refreshed indicator isolated so its ticker doesn't re-render the map tree.
- Feedback-loop guards: swap-echo publishes ignored 1.2s; only materially-different windows (>max(60s, 5% of span)) refetch; base timeline range anchored to global `evidenceRange` so windowed payloads can't shrink the scrubber.
- Replay timeline renders a dashed **"Data begins"** boundary marker at the earliest evidence timestamp — the scrubber no longer implies history that predates this install's data (starts 2026-06-08).

## Verification

- 121 unit tests green across 15 files (windowed query shapes/caps, `resolveEvidenceRange`, route auth + param validation, materiality/age helpers; existing suites updated).
- `tsc --noEmit` green (×2, incl. post-split); module-size guard green (new-file ceiling honored via split; two intentional growths re-baselined).
- **Functionally verified on the Contributor preview (:3001, lease NPEL-F4C37258DB claimed/released):** unauth API/page → 404/redirect; initial windowed upgrade fetch 200 (panel richness jumped 5 → 185 events, 658.3K tokens, 23 coworkers, 36 routes); manual refresh slid the live-edge window forward; freshness bar ticks; hidden-tab poll pause held (zero background requests); scrub to Jun 16 + 2x zoom issued exactly one windowed refetch (Jun 5→Jun 27, 102ms); "Data begins" marker renders at Jun 5. Four API calls total across the whole session — no refresh storm.

Plan: `docs/superpowers/plans/2026-07-09-ops-map-live-refresh-history-depth-plan.md`
Epic: EP-B9DD37C7 · Kernel scoping: principle_decide → two separable BIs (high confidence)

UX-Fit-Decision: extends the existing Ops Map surface in place — no new route/tab/dashboard; adds one freshness strip + one timeline boundary marker, both using existing design tokens (`--dpf-*`); no new operator-facing configuration (interval/caps are code constants); honesty-of-surface fix aligned with EP-B9DD37C7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
