### PR TITLE
feat(optimization): consolidation-bet dispatch harness — bet → WSID coworker → Build Studio (BI-C350F8B0)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -48,6 +48,7 @@ import { marketingPack } from "@/lib/mcp/packs/marketing-pack";
 import { workCapturePack } from "@/lib/mcp/packs/work-capture-pack";
 import { orgDecisionPack } from "@/lib/mcp/packs/org-decision-pack";
 import { professionDecisionPack } from "@/lib/mcp/packs/profession-decision-pack";
+import { optimizationPack } from "@/lib/mcp/packs/optimization-pack";
 import { activityRoutingPack } from "@/lib/mcp/packs/activity-routing-pack";
 import { mdmStewardshipPack } from "@/lib/mcp/packs/mdm-stewardship-pack";
 import { crmContactsPack } from "@/lib/mcp/packs/crm-contacts-pack";
@@ -455,7 +456,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, professionDecisionPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerEstablishPack, coworkerMemoryPack, coworkerGoalPack, subagentFanoutPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, professionDecisionPack, optimizationPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerEstablishPack, coworkerMemoryPack, coworkerGoalPack, subagentFanoutPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,

--- a/apps/web/lib/mcp/packs/optimization-pack.ts
+++ b/apps/web/lib/mcp/packs/optimization-pack.ts
@@ -1,0 +1,77 @@
+// Optimization tool pack (BI-C350F8B0, EP-8DC217EB BET-0d).
+//
+// Coworker/operator-callable surface of the self-optimization engine: dispatch
+// a consolidation bet to Build Studio, attributed to its WSID-profiled
+// coworker. Pack-registered (not the frozen mcp-tools.ts inline switch); the
+// handler defers to the dispatch harness lib, which reuses the same governed
+// promotion core as promote_to_build_studio (WIP cap, governed auto-approve,
+// Ideate auto-dispatch).
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "dispatch_consolidation_bet",
+    description:
+      "Dispatch a platform consolidation bet into Build Studio: promotes the bet's open, build-triaged backlog items to governed build drafts and attributes the work to the profession-matched coworker. Returns what was promoted and what was skipped with reasons (untriaged, already building, WIP cap). Use when a consolidation bet is ready to move from registry to active delivery.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        betKey: {
+          type: "string",
+          description: "The consolidation bet key, e.g. 'BET-11'.",
+        },
+      },
+      required: ["betKey"],
+    },
+    requiredCapability: "manage_backlog",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+];
+
+async function dispatchBet(
+  params: Record<string, unknown>,
+  userId: string,
+): Promise<ToolResult> {
+  const { dispatchConsolidationBet } = await import("@/lib/optimization/dispatch-bet");
+
+  const betKey = String(params["betKey"] ?? "").trim().toUpperCase();
+  if (!/^BET-\d+$/.test(betKey)) {
+    return {
+      success: false,
+      error: "invalid_params",
+      message: "Provide a betKey like 'BET-11'.",
+    };
+  }
+
+  const result = await dispatchConsolidationBet({ betKey, userId });
+  if ("error" in result) {
+    return { success: false, error: result.error, message: result.message };
+  }
+
+  const promotedList = result.promoted.map((entry) => `${entry.itemId}→${entry.buildId}`).join(", ");
+  const skippedList = result.skipped.map((entry) => `${entry.itemId} (${entry.reason})`).join(", ");
+  return {
+    success: true,
+    entityId: result.betKey,
+    message:
+      `${result.betKey}: promoted ${result.promoted.length} item(s)` +
+      (promotedList ? ` [${promotedList}]` : "") +
+      (result.skipped.length > 0 ? `; skipped ${result.skipped.length} [${skippedList}]` : "") +
+      (result.coworker ? `; craft owner ${result.coworker.name} (${result.professionKey})` : ""),
+    data: result,
+  };
+}
+
+export const optimizationPack: ToolPack = {
+  packId: "optimization",
+  definitions,
+  handlers: {
+    dispatch_consolidation_bet: (params, userId) => dispatchBet(params, userId),
+  },
+  grants: {
+    dispatch_consolidation_bet: ["build_promote"],
+  },
+};

--- a/apps/web/lib/optimization/dispatch-bet.test.ts
+++ b/apps/web/lib/optimization/dispatch-bet.test.ts
@@ -1,0 +1,149 @@
+// Tests for the consolidation-bet dispatch harness (BI-C350F8B0): eligible
+// items promote through the governed core, ineligible items are reported
+// with reasons, and the profession coworker is attributed.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    agent: { findFirst: vi.fn() },
+    platformDevConfig: { findUnique: vi.fn() },
+    backlogItem: { findUnique: vi.fn() },
+    featureBuild: { count: vi.fn() },
+    $transaction: vi.fn(),
+  },
+  promoteBacklogItemToBuildDraft: vi.fn(),
+  wipCapReached: vi.fn(),
+  dispatchIdeateForApprovedBuild: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("@/lib/governed-backlog-tee-up", () => ({
+  promoteBacklogItemToBuildDraft: mocks.promoteBacklogItemToBuildDraft,
+}));
+vi.mock("@/lib/build/wip-cap", () => ({
+  wipCapReached: mocks.wipCapReached,
+  TERMINAL_BUILD_PHASES: ["shipped", "abandoned"],
+}));
+vi.mock("@/lib/integrate/ideate-on-approval", () => ({
+  dispatchIdeateForApprovedBuild: mocks.dispatchIdeateForApprovedBuild,
+}));
+
+import { dispatchConsolidationBet, resolveCoworkerForProfession } from "./dispatch-bet";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.prisma.platformDevConfig.findUnique.mockResolvedValue({ governedBacklogEnabled: true });
+  mocks.prisma.featureBuild.count.mockResolvedValue(0);
+  mocks.wipCapReached.mockReturnValue(false);
+  mocks.prisma.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn({}));
+  mocks.prisma.agent.findFirst.mockResolvedValue({
+    agentId: "AGT-SW-ENG",
+    name: "Software Engineer",
+    slugId: "build-software-engineer",
+  });
+});
+
+describe("dispatchConsolidationBet", () => {
+  it("rejects an unknown bet", async () => {
+    const result = await dispatchConsolidationBet({ betKey: "BET-99", userId: "u1" });
+    expect(result).toMatchObject({ error: "unknown_bet" });
+  });
+
+  it("promotes an open build-triaged item and attributes the profession coworker", async () => {
+    // BET-11 has exactly one backlog item (BI-B72328D5).
+    mocks.prisma.backlogItem.findUnique.mockResolvedValue({
+      itemId: "BI-B72328D5",
+      status: "open",
+      triageOutcome: "build",
+      activeBuildId: null,
+    });
+    mocks.promoteBacklogItemToBuildDraft.mockResolvedValue({
+      kind: "success",
+      build: { id: "row", buildId: "FB-123" },
+      autoApprovedDispatchEligible: true,
+    });
+
+    const result = await dispatchConsolidationBet({ betKey: "BET-11", userId: "u1" });
+    if ("error" in result) throw new Error("unexpected error result");
+
+    expect(result.promoted).toEqual([
+      { itemId: "BI-B72328D5", buildId: "FB-123", ideateDispatched: true },
+    ]);
+    expect(result.skipped).toEqual([]);
+    expect(result.professionKey).toBe("software-engineer");
+    expect(result.coworker?.agentId).toBe("AGT-SW-ENG");
+    expect(mocks.promoteBacklogItemToBuildDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ itemId: "BI-B72328D5", userId: "u1", governedBacklogEnabled: true }),
+    );
+  });
+
+  it("skips with reasons instead of silently dropping ineligible items", async () => {
+    mocks.prisma.backlogItem.findUnique.mockResolvedValue({
+      itemId: "BI-B72328D5",
+      status: "open",
+      triageOutcome: null,
+      activeBuildId: null,
+    });
+
+    const result = await dispatchConsolidationBet({ betKey: "BET-11", userId: "u1" });
+    if ("error" in result) throw new Error("unexpected error result");
+
+    expect(result.promoted).toEqual([]);
+    expect(result.skipped).toEqual([
+      { itemId: "BI-B72328D5", reason: "not-triaged-build", detail: "untriaged" },
+    ]);
+    expect(mocks.promoteBacklogItemToBuildDraft).not.toHaveBeenCalled();
+  });
+
+  it("reports the WIP cap instead of promoting past it", async () => {
+    mocks.prisma.backlogItem.findUnique.mockResolvedValue({
+      itemId: "BI-B72328D5",
+      status: "open",
+      triageOutcome: "build",
+      activeBuildId: null,
+    });
+    mocks.wipCapReached.mockReturnValue(true);
+
+    const result = await dispatchConsolidationBet({ betKey: "BET-11", userId: "u1" });
+    if ("error" in result) throw new Error("unexpected error result");
+
+    expect(result.skipped).toEqual([
+      { itemId: "BI-B72328D5", reason: "promotion-error", detail: "wip_cap_reached" },
+    ]);
+  });
+
+  it("surfaces promotion-core errors per item", async () => {
+    mocks.prisma.backlogItem.findUnique.mockResolvedValue({
+      itemId: "BI-B72328D5",
+      status: "open",
+      triageOutcome: "build",
+      activeBuildId: null,
+    });
+    mocks.promoteBacklogItemToBuildDraft.mockResolvedValue({
+      kind: "error",
+      error: "Item already has an active build",
+      message: "…",
+    });
+
+    const result = await dispatchConsolidationBet({ betKey: "BET-11", userId: "u1" });
+    if ("error" in result) throw new Error("unexpected error result");
+
+    expect(result.skipped[0]).toMatchObject({ reason: "promotion-error" });
+  });
+});
+
+describe("resolveCoworkerForProfession", () => {
+  it("walks the registry roles in order and returns the first live agent", async () => {
+    mocks.prisma.agent.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ agentId: "AGT-2", name: "Second Role", slugId: "role-2" });
+
+    const coworker = await resolveCoworkerForProfession("software-engineer");
+    expect(coworker?.agentId).toBe("AGT-2");
+  });
+
+  it("returns null for an unknown profession", async () => {
+    expect(await resolveCoworkerForProfession("not-a-family")).toBeNull();
+  });
+});

--- a/apps/web/lib/optimization/dispatch-bet.ts
+++ b/apps/web/lib/optimization/dispatch-bet.ts
@@ -1,0 +1,165 @@
+// Consolidation-bet dispatch harness (BI-C350F8B0, EP-8DC217EB BET-0d).
+//
+// Routes a consolidation bet to its WSID-profiled coworker via Build Studio:
+// bet → profession (bet-professions.ts) → coworker (profession registry
+// roles[] → live Agent row) → promote each eligible backlog item into a Build
+// Studio draft through the SAME governed core the promote_to_build_studio
+// tool uses (promoteBacklogItemToBuildDraft — WIP cap, governed auto-approve,
+// Ideate auto-dispatch).
+//
+// Deliberately THIN: the Inside-Out workflow primitives (agent-authored
+// orchestration / user-definable workflow) are not built yet, so this is a
+// composition of existing lib functions with attribution — when the workflow
+// primitive lands, this harness becomes an instance of it, not a rival.
+
+import { prisma } from "@dpf/db";
+
+import { getConsolidationBet } from "./consolidation-bets";
+import { professionsForBet } from "./bet-professions";
+import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
+import { promoteBacklogItemToBuildDraft } from "@/lib/governed-backlog-tee-up";
+
+export type DispatchSkipReason =
+  | "not-open"
+  | "not-triaged-build"
+  | "already-has-active-build"
+  | "not-found"
+  | "promotion-error";
+
+export type BetDispatchResult = {
+  betKey: string;
+  professionKey: string | null;
+  coworker: { agentId: string; name: string; slugId: string | null } | null;
+  promoted: Array<{ itemId: string; buildId: string; ideateDispatched: boolean }>;
+  skipped: Array<{ itemId: string; reason: DispatchSkipReason; detail?: string }>;
+};
+
+/**
+ * Resolve the live coworker for a profession family: the first `roles[]`
+ * entry that matches an existing Agent row (by slugId or agentId). Registry
+ * order is the preference order.
+ */
+export async function resolveCoworkerForProfession(
+  professionKey: string,
+): Promise<{ agentId: string; name: string; slugId: string | null } | null> {
+  const family = PROFESSION_REGISTRY.families.find(
+    (candidate) => candidate.professionKey === professionKey,
+  );
+  if (!family) return null;
+
+  for (const role of family.roles) {
+    const agent = await prisma.agent.findFirst({
+      where: { OR: [{ slugId: role }, { agentId: role }] },
+      select: { agentId: true, name: true, slugId: true },
+    });
+    if (agent) return agent;
+  }
+  return null;
+}
+
+/**
+ * Dispatch one consolidation bet: promote its open, build-triaged backlog
+ * items into Build Studio drafts, attributed to the bet's primary-profession
+ * coworker. Items that are not eligible are reported, never silently skipped.
+ */
+export async function dispatchConsolidationBet(input: {
+  betKey: string;
+  userId: string;
+}): Promise<BetDispatchResult | { error: string; message: string }> {
+  const bet = getConsolidationBet(input.betKey);
+  if (!bet) {
+    return { error: "unknown_bet", message: `${input.betKey} is not a registered consolidation bet.` };
+  }
+
+  const professionKeys = professionsForBet(input.betKey);
+  const professionKey = professionKeys[0] ?? null;
+  const coworker = professionKey ? await resolveCoworkerForProfession(professionKey) : null;
+
+  const governedConfig = await prisma.platformDevConfig.findUnique({
+    where: { id: "singleton" },
+    select: { governedBacklogEnabled: true },
+  });
+  const governedBacklogEnabled = governedConfig?.governedBacklogEnabled === true;
+
+  const promoted: BetDispatchResult["promoted"] = [];
+  const skipped: BetDispatchResult["skipped"] = [];
+
+  for (const itemId of bet.backlogItemIds) {
+    const item = await prisma.backlogItem.findUnique({
+      where: { itemId },
+      select: { itemId: true, status: true, triageOutcome: true, activeBuildId: true },
+    });
+    if (!item) {
+      skipped.push({ itemId, reason: "not-found" });
+      continue;
+    }
+    if (item.status !== "open") {
+      skipped.push({ itemId, reason: "not-open", detail: item.status });
+      continue;
+    }
+    if (item.triageOutcome !== "build") {
+      skipped.push({ itemId, reason: "not-triaged-build", detail: item.triageOutcome ?? "untriaged" });
+      continue;
+    }
+    if (item.activeBuildId) {
+      skipped.push({ itemId, reason: "already-has-active-build", detail: item.activeBuildId });
+      continue;
+    }
+
+    // WIP cap check per item, same shape as the promote_to_build_studio tool:
+    // the cap can fill mid-dispatch, so re-check before each promotion.
+    const { wipCapReached, TERMINAL_BUILD_PHASES } = await import("@/lib/build/wip-cap");
+    const activeBuilds = await prisma.featureBuild.count({
+      where: { phase: { notIn: [...TERMINAL_BUILD_PHASES] }, abandonedAt: null, parentEpicId: null },
+    });
+    if (wipCapReached(activeBuilds)) {
+      skipped.push({ itemId, reason: "promotion-error", detail: "wip_cap_reached" });
+      continue;
+    }
+
+    const result = await prisma.$transaction(async (tx) =>
+      promoteBacklogItemToBuildDraft({
+        tx,
+        itemId,
+        userId: input.userId,
+        governedBacklogEnabled,
+      }),
+    );
+
+    if (result.kind === "error") {
+      skipped.push({ itemId, reason: "promotion-error", detail: result.error });
+      continue;
+    }
+
+    let ideateDispatched = false;
+    if (result.autoApprovedDispatchEligible) {
+      ideateDispatched = true;
+      void (async () => {
+        try {
+          const { dispatchIdeateForApprovedBuild } = await import("@/lib/integrate/ideate-on-approval");
+          await dispatchIdeateForApprovedBuild({ buildId: result.build.buildId, userId: input.userId });
+        } catch (err) {
+          console.error(
+            "[dispatch-bet] auto-dispatch Ideate failed:",
+            { buildId: result.build.buildId },
+            err,
+          );
+        }
+      })();
+    }
+
+    promoted.push({ itemId, buildId: result.build.buildId, ideateDispatched });
+  }
+
+  console.info(
+    `[tool-trace] vertint.dispatch ${JSON.stringify({
+      betKey: bet.betKey,
+      professionKey,
+      coworkerAgentId: coworker?.agentId ?? null,
+      promoted: promoted.map((entry) => entry.itemId),
+      skipped: skipped.map((entry) => `${entry.itemId}:${entry.reason}`),
+    })}`,
+  );
+
+  return { betKey: bet.betKey, professionKey, coworker, promoted, skipped };
+}

--- a/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
@@ -53,6 +53,23 @@ architecture-parity baseline so duplication becomes a measurable conformance
 issue; BET-0d/0e route bets to WSID-profiled coworkers — they consume this
 registry and MUST NOT grow a parallel one.
 
+## BET-0d — dispatch harness (BI-C350F8B0)
+
+Landed as `apps/web/lib/optimization/dispatch-bet.ts` +
+`dispatch_consolidation_bet` (pack `optimization`). Route: bet →
+primary profession (`bet-professions.ts`) → live coworker (profession
+registry `roles[]` walked in order against the Agent table) → each open,
+build-triaged backlog item promoted through the SAME governed core as
+`promote_to_build_studio` (`promoteBacklogItemToBuildDraft`: WIP cap
+re-checked per item, governed auto-approve, Ideate auto-dispatch).
+Ineligible items are reported with reasons (`not-open` /
+`not-triaged-build` / `already-has-active-build` / `promotion-error`),
+never silently dropped. Deliberately THIN per the cross-epic
+build-it-once rule: when the Inside-Out workflow primitive
+(BI-8E07CCA5 / BI-D80D16C4) lands, this harness becomes an instance of it.
+Kernel-scored shape: lib + one pack tool + third scheduled task for the
+sweep (HIGH confidence, composite 9.76, margin 0.35).
+
 ## Research & benchmarking
 
 Composition follows the in-repo precedents rather than external dashboards:

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -40,7 +40,7 @@ apps/web/lib/integrate/build-orchestrator.ts	1780
 apps/web/lib/integrate/sandbox/build-branch.ts	854
 apps/web/lib/marketing.ts	1367
 apps/web/lib/mcp-tools-backlog.test.ts	901
-apps/web/lib/mcp-tools.ts	16552
+apps/web/lib/mcp-tools.ts	16553
 apps/web/lib/navigation/portal-navigation-model.ts	936
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1328


### PR DESCRIPTION
## What

EP-8DC217EB **BET-0d** (BI-C350F8B0). Thin dispatch harness composing existing primitives (Inside-Out workflow primitives BI-8E07CCA5/BI-D80D16C4 are unbuilt — when they land this becomes an instance of them, per the cross-epic build-it-once rule):

- `apps/web/lib/optimization/dispatch-bet.ts` — `dispatchConsolidationBet`: bet → primary profession (`bet-professions`, #2725) → live coworker (profession registry `roles[]` walked in order against the Agent table) → each open, build-triaged backlog item promoted through the **same governed core** as `promote_to_build_studio` (`promoteBacklogItemToBuildDraft`: per-item WIP-cap re-check, governed auto-approve, Ideate auto-dispatch). Ineligible items reported with reasons — never silently dropped. `[tool-trace] vertint.dispatch` audit line.
- `dispatch_consolidation_bet` MCP tool in a new `optimization` pack (`manage_backlog` capability, `build_promote` grant) — pack-registered, not the inline switch.
- Spec: BET-0d section added to `2026-07-09-optimization-cockpit-design.md` (kernel-scored shape: lib + one pack tool + third scheduled task for the 0e sweep — HIGH confidence, composite 9.76, margin 0.35).
- `mcp-tools.ts` +2 LOC pack registration → single-line module-size re-baseline.

## Verification

Substrate: source-local, worktree `opt-dispatch` (main @ 3beb3f1d4, includes #2725):
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (full suite) → **exit 0, 1716 files / 14719 tests passed**
- Scoped: dispatch harness (6: promote+attribution, skip reasons, WIP cap, promotion errors, coworker role-walk), bet registry + hygiene — 25/25
- `node scripts/check-module-size.mjs` + `pnpm check:guards` → green

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): full typecheck + full vitest exit 0 + ratchets green. CI is the canonical run.

Process-Spine-Decision: EP-8DC217EB plan §9 BET-0d (kernel-gated enablement-first HIGH 9.10; shape HIGH 9.76); spec section included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)