### PR TITLE
feat(optimization): weekly self-optimization sweep as third deterministic scheduled task (BI-F95222FA)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -48,6 +48,7 @@ const mocks = vi.hoisted(() => ({
   governedExecuteTool: vi.fn(),
   runArchitectureParitySteward: vi.fn(),
   runConsolidationParitySteward: vi.fn(),
+  runSelfOptimizationSweep: vi.fn(),
 }));
 
 vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
@@ -59,6 +60,7 @@ vi.mock("@dpf/db", () => ({
   // these tests use the mirror task id, so any non-matching value is fine.
   DATA_MODEL_MIRROR_TASK_ID: "data-model-mirror-nightly",
   SYSML_PROJECTION_TASK_ID: "sysml-projection-nightly",
+  SELF_OPTIMIZATION_SWEEP_TASK_ID: "self-optimization-sweep-weekly",
 }));
 vi.mock("@/lib/tak/agent-routing-server", () => ({
   resolveAgentForRouteWithPrompts: mocks.resolveAgentForRouteWithPrompts,
@@ -80,6 +82,9 @@ vi.mock("@/lib/ea/architecture-parity-steward", () => ({
 }));
 vi.mock("@/lib/ea/consolidation-parity-steward", () => ({
   runConsolidationParitySteward: mocks.runConsolidationParitySteward,
+}));
+vi.mock("@/lib/optimization/self-optimization-sweep", () => ({
+  runSelfOptimizationSweep: mocks.runSelfOptimizationSweep,
 }));
 
 import { executeScheduledAgentTask, scheduleAgentTask } from "./agent-task-scheduler";
@@ -1021,5 +1026,57 @@ describe("scheduleAgentTask UTC-only timezone", () => {
       error: expect.stringMatching(/Non-UTC timezones are not yet supported/),
     });
     expect(mocks.prisma.scheduledAgentTask.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeScheduledAgentTask — self-optimization sweep branch", () => {
+  it("runs the deterministic sweep directly (no LLM loop) and records ok status", async () => {
+    mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+      taskId: "self-optimization-sweep-weekly",
+      isActive: true,
+      schedule: "0 5 * * 1",
+    });
+    mocks.runSelfOptimizationSweep.mockResolvedValue({
+      ranAt: "2026-07-09T05:00:00.000Z",
+      graphAvailable: true,
+      outstandingBets: ["BET-11"],
+      completedBets: ["BET-6"],
+      stalledBets: [],
+      parity: { created: 0, updated: 0, resolved: 0 },
+      blastRadius: { implementationFileCount: 1, relatedTestCount: 1 },
+    });
+    mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
+    mocks.prisma.scheduledJob.update.mockResolvedValue({});
+
+    await executeScheduledAgentTask("self-optimization-sweep-weekly");
+
+    expect(mocks.runSelfOptimizationSweep).toHaveBeenCalledOnce();
+    expect(mocks.runAgenticLoop).not.toHaveBeenCalled();
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "self-optimization-sweep-weekly" },
+        data: expect.objectContaining({ lastStatus: "ok", lastError: null }),
+      }),
+    );
+  });
+
+  it("records error status when the sweep throws", async () => {
+    mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+      taskId: "self-optimization-sweep-weekly",
+      isActive: true,
+      schedule: "0 5 * * 1",
+    });
+    mocks.runSelfOptimizationSweep.mockRejectedValue(new Error("graph store down"));
+    mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
+    mocks.prisma.scheduledJob.update.mockResolvedValue({});
+
+    await executeScheduledAgentTask("self-optimization-sweep-weekly");
+
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "self-optimization-sweep-weekly" },
+        data: expect.objectContaining({ lastStatus: "error", lastError: "graph store down" }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { auth } from "@/lib/auth";
-import { prisma, DATA_MODEL_MIRROR_TASK_ID, SYSML_PROJECTION_TASK_ID } from "@dpf/db";
+import { prisma, DATA_MODEL_MIRROR_TASK_ID, SYSML_PROJECTION_TASK_ID, SELF_OPTIMIZATION_SWEEP_TASK_ID } from "@dpf/db";
 import {
   scheduleAgentTaskFor,
   getScheduledAgentTasksFor,
@@ -167,6 +167,42 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         consolidation.created,
         consolidation.updated,
         consolidation.resolved,
+      );
+      const nextRunAt = computeNextCronRun(task.schedule, startedAt);
+      await prisma.scheduledAgentTask.update({
+        where: { taskId },
+        data: { lastRunAt: startedAt, lastStatus: "ok", lastError: null, nextRunAt },
+      });
+      await prisma.scheduledJob
+        .update({ where: { jobId: taskId }, data: { lastRunAt: startedAt, lastStatus: "ok", lastError: null, nextRunAt } })
+        .catch(() => {});
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : "unknown error";
+      const nextRunAt = computeNextCronRun(task.schedule, startedAt);
+      await prisma.scheduledAgentTask.update({
+        where: { taskId },
+        data: { lastRunAt: startedAt, lastStatus: "error", lastError: errMsg, nextRunAt },
+      });
+      await prisma.scheduledJob
+        .update({ where: { jobId: taskId }, data: { lastRunAt: startedAt, lastStatus: "error", lastError: errMsg, nextRunAt } })
+        .catch(() => {});
+    }
+    return;
+  }
+
+  // Self-optimization sweep (BET-0e): deterministic — reconcile consolidation
+  // parity, re-measure bet blast radius, derive stalled bets, persist the
+  // summary. No LLM loop; mirrors the SysML projection branch above.
+  if (task.taskId === SELF_OPTIMIZATION_SWEEP_TASK_ID) {
+    const startedAt = new Date();
+    try {
+      const { runSelfOptimizationSweep } = await import("@/lib/optimization/self-optimization-sweep");
+      const summary = await runSelfOptimizationSweep();
+      console.info(
+        "[agent-task-scheduler] self-optimization sweep outstanding=%d stalled=%d graph=%s",
+        summary.outstandingBets.length,
+        summary.stalledBets.length,
+        summary.graphAvailable,
       );
       const nextRunAt = computeNextCronRun(task.schedule, startedAt);
       await prisma.scheduledAgentTask.update({

--- a/apps/web/lib/optimization/self-optimization-sweep.test.ts
+++ b/apps/web/lib/optimization/self-optimization-sweep.test.ts
@@ -1,0 +1,96 @@
+// Tests for the weekly self-optimization sweep (BI-F95222FA): parity + blast
+// radius + stalled-bet derivation + summary persistence, all via injected deps.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  runSelfOptimizationSweep,
+  type SelfOptimizationSweepSummary,
+} from "./self-optimization-sweep";
+
+function stewardResult(over: Record<string, unknown> = {}) {
+  return {
+    created: 1,
+    updated: 0,
+    resolved: 2,
+    outstandingBets: ["BET-11", "BET-12"],
+    completedBets: ["BET-6"],
+    ...over,
+  };
+}
+
+function cockpitResult(bets: Array<{ betKey: string; statuses: Array<string | null> }>) {
+  return {
+    freshness: {
+      available: true,
+      indexStatus: "ready",
+      lastIndexedAt: new Date("2026-07-09T00:00:00Z"),
+      indexedFileCount: 4000,
+      warnings: [],
+      summary: "ok",
+    },
+    bets: bets.map(({ betKey, statuses }) => ({
+      bet: { betKey } as never,
+      backlogItems: statuses.map((status, index) => ({
+        itemId: `BI-${betKey}-${index}`,
+        status,
+        title: null,
+      })),
+      blastRadius: null,
+      fileCoverage: null,
+    })),
+    totals: {
+      betCount: bets.length,
+      backlogDone: 0,
+      backlogInProgress: 0,
+      backlogOpen: 0,
+      implementationFileCount: 42,
+      relatedTestCount: 7,
+    },
+  };
+}
+
+describe("runSelfOptimizationSweep", () => {
+  it("derives stalled bets (outstanding with no in-progress item) and persists the summary", async () => {
+    const written: SelfOptimizationSweepSummary[] = [];
+    const summary = await runSelfOptimizationSweep({
+      steward: vi.fn().mockResolvedValue(stewardResult()) as never,
+      loadCockpit: vi.fn().mockResolvedValue(
+        cockpitResult([
+          { betKey: "BET-11", statuses: ["open"] }, // outstanding, nothing moving -> stalled
+          { betKey: "BET-12", statuses: ["in-progress"] }, // outstanding but moving
+          { betKey: "BET-6", statuses: ["done"] }, // completed
+        ]),
+      ) as never,
+      writeSummary: async (entry) => {
+        written.push(entry);
+      },
+      now: () => new Date("2026-07-09T05:00:00Z"),
+    });
+
+    expect(summary.stalledBets).toEqual(["BET-11"]);
+    expect(summary.outstandingBets).toEqual(["BET-11", "BET-12"]);
+    expect(summary.completedBets).toEqual(["BET-6"]);
+    expect(summary.parity).toEqual({ created: 1, updated: 0, resolved: 2 });
+    expect(summary.blastRadius).toEqual({ implementationFileCount: 42, relatedTestCount: 7 });
+    expect(summary.ranAt).toBe("2026-07-09T05:00:00.000Z");
+    expect(written).toEqual([summary]);
+  });
+
+  it("propagates graph unavailability into the summary", async () => {
+    const cockpit = cockpitResult([{ betKey: "BET-11", statuses: ["open"] }]);
+    cockpit.freshness.available = false;
+    cockpit.totals.implementationFileCount = 0;
+    cockpit.totals.relatedTestCount = 0;
+
+    const summary = await runSelfOptimizationSweep({
+      steward: vi.fn().mockResolvedValue(stewardResult({ outstandingBets: ["BET-11"] })) as never,
+      loadCockpit: vi.fn().mockResolvedValue(cockpit) as never,
+      writeSummary: async () => {},
+      now: () => new Date("2026-07-09T05:00:00Z"),
+    });
+
+    expect(summary.graphAvailable).toBe(false);
+    expect(summary.blastRadius.implementationFileCount).toBe(0);
+  });
+});

--- a/apps/web/lib/optimization/self-optimization-sweep.ts
+++ b/apps/web/lib/optimization/self-optimization-sweep.ts
@@ -1,0 +1,85 @@
+// Weekly self-optimization sweep (BI-F95222FA, EP-8DC217EB BET-0e).
+//
+// The plan §6 standing discipline as a deterministic scheduled task: each run
+// (1) reconciles the consolidation-parity conformance issues (BET-0b steward),
+// (2) re-measures every bet's code-graph blast radius via the cockpit loader
+// (graph offline degrades gracefully), (3) derives STALLED bets — outstanding
+// bets with zero in-progress delivery items — and (4) persists a compact
+// summary to the platformConfig singleton so operators and the cockpit can see
+// when the platform last measured itself. No LLM loop; the deep 8-way mining
+// fan-out remains a session-scale activity, this sweep keeps its outputs
+// honest between runs.
+
+import { prisma } from "@dpf/db";
+
+import { runConsolidationParitySteward } from "@/lib/ea/consolidation-parity-steward";
+import { loadOptimizationCockpitData } from "./load-cockpit-data";
+
+export const SELF_OPTIMIZATION_SWEEP_CONFIG_KEY = "optimization.selfSweep.lastRun";
+
+export type SelfOptimizationSweepSummary = {
+  ranAt: string;
+  graphAvailable: boolean;
+  outstandingBets: string[];
+  completedBets: string[];
+  /** Outstanding bets whose delivery items are all open/untouched (no in-progress). */
+  stalledBets: string[];
+  parity: { created: number; updated: number; resolved: number };
+  blastRadius: { implementationFileCount: number; relatedTestCount: number };
+};
+
+export type SelfOptimizationSweepDeps = {
+  steward: typeof runConsolidationParitySteward;
+  loadCockpit: typeof loadOptimizationCockpitData;
+  writeSummary: (summary: SelfOptimizationSweepSummary) => Promise<void>;
+  now: () => Date;
+};
+
+const defaultDeps: SelfOptimizationSweepDeps = {
+  steward: runConsolidationParitySteward,
+  loadCockpit: loadOptimizationCockpitData,
+  writeSummary: async (summary) => {
+    await prisma.platformConfig.upsert({
+      where: { key: SELF_OPTIMIZATION_SWEEP_CONFIG_KEY },
+      update: { value: summary },
+      create: { key: SELF_OPTIMIZATION_SWEEP_CONFIG_KEY, value: summary },
+    });
+  },
+  now: () => new Date(),
+};
+
+export async function runSelfOptimizationSweep(
+  deps: Partial<SelfOptimizationSweepDeps> = {},
+): Promise<SelfOptimizationSweepSummary> {
+  const resolved: SelfOptimizationSweepDeps = { ...defaultDeps, ...deps };
+
+  const parity = await resolved.steward();
+  const cockpit = await resolved.loadCockpit();
+
+  const outstanding = new Set(parity.outstandingBets);
+  const stalledBets = cockpit.bets
+    .filter(
+      (projection) =>
+        outstanding.has(projection.bet.betKey) &&
+        !projection.backlogItems.some((item) => item.status === "in-progress"),
+    )
+    .map((projection) => projection.bet.betKey);
+
+  const summary: SelfOptimizationSweepSummary = {
+    ranAt: resolved.now().toISOString(),
+    graphAvailable: cockpit.freshness.available,
+    outstandingBets: parity.outstandingBets,
+    completedBets: parity.completedBets,
+    stalledBets,
+    parity: { created: parity.created, updated: parity.updated, resolved: parity.resolved },
+    blastRadius: {
+      implementationFileCount: cockpit.totals.implementationFileCount,
+      relatedTestCount: cockpit.totals.relatedTestCount,
+    },
+  };
+
+  await resolved.writeSummary(summary);
+
+  console.info(`[tool-trace] vertint.sweep ${JSON.stringify(summary)}`);
+  return summary;
+}

--- a/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
@@ -68,6 +68,21 @@ silent completion). It runs piggybacked on the scheduled SysML parity sweep
 (`agent-task-scheduler.ts`, `SYSML_PROJECTION_TASK_ID` branch) — no new
 cron/task surface.
 
+## BET-0e — weekly self-optimization sweep (BI-F95222FA)
+
+Landed as `apps/web/lib/optimization/self-optimization-sweep.ts` + the third
+deterministic scheduled task (`self-optimization-sweep-weekly`, config/seed in
+`packages/db/src/self-optimization-sweep-config.ts` /
+`seed-self-optimization-sweep.ts`, scheduler branch in
+`agent-task-scheduler.ts` — no LLM loop, mirroring the SysML/mirror tasks).
+Each run reconciles consolidation parity (BET-0b steward), re-measures bet
+blast radius via the cockpit loader, derives STALLED bets (outstanding with no
+in-progress item), and persists the summary to the platformConfig singleton
+(`optimization.selfSweep.lastRun`). The deep 8-way mining fan-out stays a
+session-scale activity; the sweep keeps its outputs honest between runs
+(plan §6 standing discipline). Kernel-scored: third-task shape, HIGH
+confidence, composite 9.76.
+
 ## Research & benchmarking
 
 Composition follows the in-repo precedents rather than external dashboards:

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -238,6 +238,7 @@ export {
 } from "./schema-source";
 export { DATA_MODEL_MIRROR_TASK_ID } from "./data-model-mirror-config";
 export { SYSML_PROJECTION_TASK_ID } from "./sysml-projection-config";
+export { SELF_OPTIMIZATION_SWEEP_TASK_ID } from "./self-optimization-sweep-config";
 // Canonical SysML projection applier — shared by seed-time views (packages/db
 // seed-ea-sysml-*.ts) and runtime extractors (apps/web/lib/ea, via this barrel).
 export {

--- a/packages/db/src/seed-self-optimization-sweep.ts
+++ b/packages/db/src/seed-self-optimization-sweep.ts
@@ -1,0 +1,112 @@
+// Self-optimization engine: seed the weekly consolidation sweep scheduled
+// task. The deterministic handler lives in apps/web's scheduler
+// (executeScheduledAgentTask early-branches on this task id and runs
+// runSelfOptimizationSweep without an LLM loop). Mirrors
+// seed-sysml-projection.ts.
+import type { PrismaClient } from "../generated/client/client";
+
+import {
+  SELF_OPTIMIZATION_SWEEP_AGENT_ID,
+  SELF_OPTIMIZATION_SWEEP_DEFAULT_TIMEZONE,
+  SELF_OPTIMIZATION_SWEEP_PROMPT,
+  SELF_OPTIMIZATION_SWEEP_ROUTE_CONTEXT,
+  SELF_OPTIMIZATION_SWEEP_SCHEDULE,
+  SELF_OPTIMIZATION_SWEEP_SCHEDULED_JOB_NAME,
+  SELF_OPTIMIZATION_SWEEP_TASK_ID,
+  SELF_OPTIMIZATION_SWEEP_TASK_TITLE,
+} from "./self-optimization-sweep-config";
+
+type ScheduledTaskSeedClient = Pick<PrismaClient, "user" | "scheduledAgentTask" | "scheduledJob">;
+
+function computeNextWeeklyRun(cronExpr: string, from: Date): Date {
+  const parts = cronExpr.trim().split(/\s+/);
+  const fallback = () => {
+    const next = new Date(from);
+    next.setUTCDate(next.getUTCDate() + 7);
+    return next;
+  };
+  if (parts.length !== 5) return fallback();
+  const [minPart, hourPart, , , dowPart] = parts;
+  const minute = minPart === "*" ? 0 : parseInt(minPart!, 10);
+  const hour = hourPart === "*" ? 0 : parseInt(hourPart!, 10);
+  const dow = dowPart === "*" ? from.getUTCDay() : parseInt(dowPart!, 10);
+  if ([minute, hour, dow].some((value) => Number.isNaN(value))) return fallback();
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(minute);
+  next.setUTCHours(hour);
+  const dayDelta = (dow - next.getUTCDay() + 7) % 7;
+  next.setUTCDate(next.getUTCDate() + dayDelta);
+  if (next <= from) next.setUTCDate(next.getUTCDate() + 7);
+  return next;
+}
+
+export async function ensureSelfOptimizationSweepScheduledTask(
+  prisma: ScheduledTaskSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  const owner = await prisma.user.findFirst({
+    where: { isSuperuser: true },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  if (!owner) {
+    throw new Error("seed: no superuser found - cannot seed self-optimization sweep scheduled task");
+  }
+
+  const timezone = process.env.INSTALL_TIMEZONE ?? SELF_OPTIMIZATION_SWEEP_DEFAULT_TIMEZONE;
+  const nextRunAt = computeNextWeeklyRun(SELF_OPTIMIZATION_SWEEP_SCHEDULE, now);
+
+  const existing = await prisma.scheduledAgentTask.findUnique({
+    where: { taskId: SELF_OPTIMIZATION_SWEEP_TASK_ID },
+    select: { taskId: true, nextRunAt: true },
+  });
+
+  if (existing) {
+    await prisma.scheduledAgentTask.update({
+      where: { taskId: SELF_OPTIMIZATION_SWEEP_TASK_ID },
+      data: {
+        agentId: SELF_OPTIMIZATION_SWEEP_AGENT_ID,
+        title: SELF_OPTIMIZATION_SWEEP_TASK_TITLE,
+        prompt: SELF_OPTIMIZATION_SWEEP_PROMPT,
+        routeContext: SELF_OPTIMIZATION_SWEEP_ROUTE_CONTEXT,
+        schedule: SELF_OPTIMIZATION_SWEEP_SCHEDULE,
+        timezone,
+        ownerUserId: owner.id,
+        isActive: true,
+        nextRunAt: existing.nextRunAt ?? nextRunAt,
+      },
+    });
+  } else {
+    await prisma.scheduledAgentTask.create({
+      data: {
+        taskId: SELF_OPTIMIZATION_SWEEP_TASK_ID,
+        agentId: SELF_OPTIMIZATION_SWEEP_AGENT_ID,
+        title: SELF_OPTIMIZATION_SWEEP_TASK_TITLE,
+        prompt: SELF_OPTIMIZATION_SWEEP_PROMPT,
+        routeContext: SELF_OPTIMIZATION_SWEEP_ROUTE_CONTEXT,
+        schedule: SELF_OPTIMIZATION_SWEEP_SCHEDULE,
+        timezone,
+        ownerUserId: owner.id,
+        nextRunAt,
+      },
+    });
+  }
+
+  await prisma.scheduledJob.upsert({
+    where: { jobId: SELF_OPTIMIZATION_SWEEP_TASK_ID },
+    create: {
+      jobId: SELF_OPTIMIZATION_SWEEP_TASK_ID,
+      name: SELF_OPTIMIZATION_SWEEP_SCHEDULED_JOB_NAME,
+      schedule: SELF_OPTIMIZATION_SWEEP_SCHEDULE,
+      nextRunAt: existing?.nextRunAt ?? nextRunAt,
+    },
+    update: {
+      name: SELF_OPTIMIZATION_SWEEP_SCHEDULED_JOB_NAME,
+      schedule: SELF_OPTIMIZATION_SWEEP_SCHEDULE,
+      nextRunAt: existing?.nextRunAt ?? nextRunAt,
+    },
+  });
+
+  return { created: !existing };
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -64,6 +64,7 @@ import { seedStallThresholds } from "./seed-stall-thresholds.js";
 import { ensureDiscoveryTriageScheduledTask } from "./seed-discovery-triage.js";
 import { ensureDataModelMirrorScheduledTask } from "./seed-data-model-mirror.js";
 import { ensureSysmlProjectionScheduledTask } from "./seed-sysml-projection.js";
+import { ensureSelfOptimizationSweepScheduledTask } from "./seed-self-optimization-sweep.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
 import { ensureAllBackupScheduledJobs } from "./seed-platform-backup.js";
 import { ensureDataRetentionScheduledJob } from "./seed-platform-retention.js";
@@ -2426,6 +2427,7 @@ async function main(): Promise<void> {
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));
   await step("dataModelMirrorScheduledTask", () => ensureDataModelMirrorScheduledTask(prisma));
   await step("sysmlProjectionScheduledTask", () => ensureSysmlProjectionScheduledTask(prisma));
+  await step("selfOptimizationSweepScheduledTask", () => ensureSelfOptimizationSweepScheduledTask(prisma));
   await step("hiveScoutScheduledTask", () => ensureHiveScoutScheduledTask(prisma));
   await step("allBackupScheduledJobs", () => ensureAllBackupScheduledJobs(prisma));
   await step("dataRetentionScheduledJob", () => ensureDataRetentionScheduledJob(prisma));

--- a/packages/db/src/self-optimization-sweep-config.ts
+++ b/packages/db/src/self-optimization-sweep-config.ts
@@ -1,0 +1,20 @@
+// packages/db/src/self-optimization-sweep-config.ts
+// Self-optimization engine: shared identity for the weekly consolidation
+// sweep (the standing discipline: re-measure bet blast radius, reconcile
+// consolidation-parity conformance, surface stalled bets). Imported by the
+// seed (packages/db) and the scheduler branch (apps/web) so both agree on
+// the task id. The deterministic handler lives in apps/web's scheduler
+// (executeScheduledAgentTask early-branches on this task id and runs
+// runSelfOptimizationSweep without an LLM loop), mirroring the SysML
+// projection reconcile.
+
+export const SELF_OPTIMIZATION_SWEEP_TASK_ID = "self-optimization-sweep-weekly";
+export const SELF_OPTIMIZATION_SWEEP_AGENT_ID = "AGT-WS-EA"; // Enterprise Architect
+export const SELF_OPTIMIZATION_SWEEP_TASK_TITLE = "Self-Optimization Sweep (weekly)";
+export const SELF_OPTIMIZATION_SWEEP_ROUTE_CONTEXT = "/ea/capabilities";
+export const SELF_OPTIMIZATION_SWEEP_SCHEDULE = "0 5 * * 1"; // 05:00 UTC Mondays (after the nightly parity jobs)
+export const SELF_OPTIMIZATION_SWEEP_DEFAULT_TIMEZONE = "UTC";
+export const SELF_OPTIMIZATION_SWEEP_SCHEDULED_JOB_NAME = "Self-Optimization Sweep Weekly";
+export const SELF_OPTIMIZATION_SWEEP_PROMPT =
+  "Re-measure the consolidation-bet registry against the live code graph and backlog, reconcile the " +
+  "consolidation-parity conformance issues, and record the sweep summary. Deterministic — runs without an LLM loop.";

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -17,7 +17,7 @@ apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1338
 apps/web/lib/actions/agent-coworker-external.test.ts	866
 apps/web/lib/actions/agent-coworker.ts	2638
-apps/web/lib/actions/agent-task-scheduler.test.ts	1026
+apps/web/lib/actions/agent-task-scheduler.test.ts	1083
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1114
 apps/web/lib/actions/build.ts	1770


### PR DESCRIPTION
## What

EP-8DC217EB **BET-0e** (BI-F95222FA). The plan §6 standing discipline as a deterministic scheduled platform function — no LLM loop, kernel-scored third-task shape (HIGH, composite 9.76):

- `apps/web/lib/optimization/self-optimization-sweep.ts` — `runSelfOptimizationSweep`: reconciles consolidation-parity conformance (BET-0b steward, #2726), re-measures bet blast radius via the cockpit loader (#2724, graph-offline degrades), derives **stalled** bets (outstanding with no in-progress delivery item), persists the summary to platformConfig `optimization.selfSweep.lastRun`, emits a `[tool-trace] vertint.sweep` audit line.
- Third deterministic task id `self-optimization-sweep-weekly` (05:00 UTC Mondays): config + seed in `packages/db` (mirrors `seed-sysml-projection`), exported from `@dpf/db`, wired into `seed.ts`, deterministic branch in `agent-task-scheduler.ts` mirroring the SysML/data-model-mirror branches. The existing every-5-min dispatcher picks it up — no new cron surface.
- Spec: BET-0e section added to `2026-07-09-optimization-cockpit-design.md`.

## Verification

Substrate: source-local, worktree `opt-sweep` (main @ ece238600, includes #2726):
- Web typecheck (8GB) **exit 0**; `@dpf/db` typecheck **exit 0**
- Full web vitest → **exit 0, 1717 files / 14720 tests passed**
- Scoped: sweep (2), scheduler deterministic branches incl. the new one (24) — green
- `@dpf/db` vitest: 148 files passed; the 5 failing files are **live-database-bound** (`$executeRawUnsafe` table checks / adapter delegates) that cannot run in a source-only worktree and are untouched by this diff — unrun gate, not red (AGENTS §5); CI Unit Tests is the canonical run
- Module-size (single-line re-baseline) + guard loop green

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): attestation above. CI is the canonical run.

Process-Spine-Decision: EP-8DC217EB plan §9 BET-0e / §6 standing discipline (enablement-first HIGH 9.10; task shape HIGH 9.76); spec section included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)