### PR TITLE
feat(optimization): WSID feedback loop — completed bets enrich the profession corpus (BI-5C01F920)

### DIFF
--- a/apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx
+++ b/apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx
@@ -15,6 +15,7 @@ const REASON_INTENT: Record<string, Intent> = {
   "empty-corpus": "danger",
   "low-relevance": "warning",
   deferred: "info",
+  "bet-completed": "success",
 };
 
 const REASON_LABEL: Record<string, string> = {
@@ -22,6 +23,7 @@ const REASON_LABEL: Record<string, string> = {
   "empty-corpus": "Empty corpus",
   "low-relevance": "Not covered",
   deferred: "Deferred",
+  "bet-completed": "Bet learning",
 };
 
 const GAP_COLUMNS: Column<CorpusGapRow>[] = [

--- a/apps/web/components/platform/coworker-record/panels.tsx
+++ b/apps/web/components/platform/coworker-record/panels.tsx
@@ -19,6 +19,7 @@ const GAP_REASON_LABEL: Record<string, string> = {
   "empty-corpus": "Empty corpus",
   "low-relevance": "Not covered",
   deferred: "Deferred",
+  "bet-completed": "Bet learning",
 };
 
 // ─── Shared primitives ───────────────────────────────────────────────────────

--- a/apps/web/lib/decision-perspective/profession-corpus-evidence.ts
+++ b/apps/web/lib/decision-perspective/profession-corpus-evidence.ts
@@ -28,7 +28,11 @@ export type ProfessionCorpusGapReason =
   | "unmapped"
   | "empty-corpus"
   | "low-relevance"
-  | "deferred";
+  | "deferred"
+  // A consolidation bet this profession worked has completed; its technique is
+  // a learning the corpus does not yet capture (BI-5C01F920, EP-8DC217EB
+  // BET-0f). Recorded by the self-optimization sweep, not a coworker turn.
+  | "bet-completed";
 
 // ─── Structural DB client (satisfied by PrismaClient + test fakes) ────────────
 

--- a/apps/web/lib/optimization/bet-completion-feedback.test.ts
+++ b/apps/web/lib/optimization/bet-completion-feedback.test.ts
@@ -1,0 +1,71 @@
+// Tests for the BET-0f WSID feedback loop (BI-5C01F920): completed bets record
+// a deduped `bet-completed` corpus-growth signal per mapped profession.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { professionsForBet } from "./bet-professions";
+import { recordBetCompletionLearnings } from "./bet-completion-feedback";
+
+function makeDb() {
+  const upsert = vi.fn().mockResolvedValue({});
+  return {
+    upsert,
+    client: {
+      professionCorpusGap: { upsert },
+      professionCorpusUsageStat: { upsert: vi.fn() },
+    },
+  };
+}
+
+describe("recordBetCompletionLearnings", () => {
+  it("records one bet-completed gap per mapped profession, keyed to the bet", async () => {
+    const db = makeDb();
+    // BET-9 maps to data-architect + finance (2 professions).
+    const result = await recordBetCompletionLearnings(["BET-9"], { db: db.client as never });
+
+    const professions = professionsForBet("BET-9");
+    expect(professions.length).toBe(2);
+    expect(result.learnings).toHaveLength(2);
+    expect(result.recordedCount).toBe(2);
+    expect(db.upsert).toHaveBeenCalledTimes(2);
+
+    const created = db.upsert.mock.calls[0]![0].create as Record<string, unknown>;
+    expect(created.reason).toBe("bet-completed");
+    expect(created.professionKey).toBe(professions[0]);
+    expect(String(created.query)).toMatch(/BET-9/);
+    expect(String(created.suggestedSource)).toMatch(/BET-9/);
+    expect(created.routeContext).toBe("vertint.sweep");
+  });
+
+  it("skips unknown bet keys and bets with no profession mapping", async () => {
+    const db = makeDb();
+    const result = await recordBetCompletionLearnings(["BET-999", "NOPE"], {
+      db: db.client as never,
+    });
+    expect(result.learnings).toHaveLength(0);
+    expect(db.upsert).not.toHaveBeenCalled();
+  });
+
+  it("aggregates across several completed bets", async () => {
+    const db = makeDb();
+    // BET-6 -> software-engineer (1); BET-2 -> enterprise-architecture + security (2).
+    const result = await recordBetCompletionLearnings(["BET-6", "BET-2"], {
+      db: db.client as never,
+    });
+    expect(result.learnings).toHaveLength(
+      professionsForBet("BET-6").length + professionsForBet("BET-2").length,
+    );
+    expect(result.recordedCount).toBe(result.learnings.length);
+  });
+
+  it("counts a failed (fail-open) gap write as not recorded", async () => {
+    const upsert = vi.fn().mockRejectedValue(new Error("db down"));
+    const client = {
+      professionCorpusGap: { upsert },
+      professionCorpusUsageStat: { upsert: vi.fn() },
+    };
+    const result = await recordBetCompletionLearnings(["BET-6"], { db: client as never });
+    expect(result.recordedCount).toBe(0);
+    expect(result.learnings.every((learning) => !learning.recorded)).toBe(true);
+  });
+});

--- a/apps/web/lib/optimization/bet-completion-feedback.ts
+++ b/apps/web/lib/optimization/bet-completion-feedback.ts
@@ -1,0 +1,89 @@
+// WSID feedback loop — completed consolidation bets enrich the profession
+// corpus (BI-5C01F920, EP-8DC217EB BET-0f).
+//
+// Closes the self-optimization loop: when a consolidation bet completes, the
+// technique it demonstrated is a learning the professions that worked it do
+// not yet have in their WSID corpus. This records that as a deterministic,
+// deduped growth signal (`ProfessionCorpusGap`, reason `bet-completed`) for
+// each mapped profession — routed through the SAME governed corpus-growth
+// surface operators already review (coworker-record ProfessionCorpusPanel),
+// so no craft content is fabricated: the sweep only flags "capture BET-N's
+// technique here, source = its spec + anchor files" and where to find it.
+//
+// Invoked by the self-optimization sweep (BET-0e) for bets that newly
+// completed since the prior run. No LLM loop — the mining stays session-scale;
+// this keeps the corpus honest between runs (plan §9).
+
+import {
+  recordProfessionCorpusGap,
+  type ProfessionCorpusEvidenceClient,
+} from "@/lib/decision-perspective/profession-corpus-evidence";
+import { getConsolidationBet } from "./consolidation-bets";
+import { professionsForBet } from "./bet-professions";
+
+export type BetCompletionLearning = {
+  betKey: string;
+  professionKey: string;
+  recorded: boolean;
+  fingerprint: string;
+};
+
+export type BetCompletionFeedbackResult = {
+  learnings: BetCompletionLearning[];
+  recordedCount: number;
+};
+
+function learningQuery(betKey: string, title: string): string {
+  return `Capture the technique from completed consolidation ${betKey}: ${title}`;
+}
+
+function learningSource(betKey: string, files: string[]): string {
+  const anchors = files.slice(0, 6).join(", ");
+  return anchors
+    ? `${betKey} delivery: review the change (spec + anchor files ${anchors}) and distil the reusable technique into the corpus.`
+    : `${betKey} delivery: review the change and distil the reusable technique into the corpus.`;
+}
+
+/**
+ * Record a `bet-completed` corpus-growth signal for every profession mapped to
+ * each newly-completed bet. Deduped by the underlying gap fingerprint
+ * (profession × normalized topic × reason), so re-running the sweep coalesces
+ * rather than piling up. Fail-open per record (never throws).
+ */
+export async function recordBetCompletionLearnings(
+  newlyCompletedBetKeys: string[],
+  deps: { db?: ProfessionCorpusEvidenceClient; routeContext?: string } = {},
+): Promise<BetCompletionFeedbackResult> {
+  const learnings: BetCompletionLearning[] = [];
+
+  for (const betKey of newlyCompletedBetKeys) {
+    const bet = getConsolidationBet(betKey);
+    if (!bet) continue; // unknown bet key — nothing to attribute
+    const professions = professionsForBet(betKey);
+    if (professions.length === 0) continue;
+
+    for (const professionKey of professions) {
+      const result = await recordProfessionCorpusGap(
+        {
+          professionKey,
+          reason: "bet-completed",
+          query: learningQuery(betKey, bet.title),
+          routeContext: deps.routeContext ?? "vertint.sweep",
+          suggestedSource: learningSource(betKey, bet.selectors.files),
+        },
+        { db: deps.db },
+      );
+      learnings.push({
+        betKey,
+        professionKey,
+        recorded: result.recorded,
+        fingerprint: result.fingerprint,
+      });
+    }
+  }
+
+  return {
+    learnings,
+    recordedCount: learnings.filter((learning) => learning.recorded).length,
+  };
+}

--- a/apps/web/lib/optimization/self-optimization-sweep.test.ts
+++ b/apps/web/lib/optimization/self-optimization-sweep.test.ts
@@ -50,6 +50,9 @@ function cockpitResult(bets: Array<{ betKey: string; statuses: Array<string | nu
   };
 }
 
+const noPriorCompleted = () => Promise.resolve<string[]>([]);
+const noopRecordLearnings = vi.fn().mockResolvedValue({ learnings: [], recordedCount: 0 });
+
 describe("runSelfOptimizationSweep", () => {
   it("derives stalled bets (outstanding with no in-progress item) and persists the summary", async () => {
     const written: SelfOptimizationSweepSummary[] = [];
@@ -62,6 +65,8 @@ describe("runSelfOptimizationSweep", () => {
           { betKey: "BET-6", statuses: ["done"] }, // completed
         ]),
       ) as never,
+      readPriorCompleted: noPriorCompleted,
+      recordLearnings: noopRecordLearnings as never,
       writeSummary: async (entry) => {
         written.push(entry);
       },
@@ -86,11 +91,56 @@ describe("runSelfOptimizationSweep", () => {
     const summary = await runSelfOptimizationSweep({
       steward: vi.fn().mockResolvedValue(stewardResult({ outstandingBets: ["BET-11"] })) as never,
       loadCockpit: vi.fn().mockResolvedValue(cockpit) as never,
+      readPriorCompleted: noPriorCompleted,
+      recordLearnings: noopRecordLearnings as never,
       writeSummary: async () => {},
       now: () => new Date("2026-07-09T05:00:00Z"),
     });
 
     expect(summary.graphAvailable).toBe(false);
     expect(summary.blastRadius.implementationFileCount).toBe(0);
+  });
+
+  it("records learnings only for bets that completed since the prior sweep (BET-0f)", async () => {
+    const recordLearnings = vi.fn().mockResolvedValue({ learnings: [], recordedCount: 3 });
+    const summary = await runSelfOptimizationSweep({
+      steward: vi.fn().mockResolvedValue(
+        stewardResult({ completedBets: ["BET-6", "BET-3"], outstandingBets: [] }),
+      ) as never,
+      loadCockpit: vi.fn().mockResolvedValue(
+        cockpitResult([
+          { betKey: "BET-6", statuses: ["done"] },
+          { betKey: "BET-3", statuses: ["done"] },
+        ]),
+      ) as never,
+      // BET-6 was already completed last run; only BET-3 is newly completed.
+      readPriorCompleted: async () => ["BET-6"],
+      recordLearnings: recordLearnings as never,
+      writeSummary: async () => {},
+      now: () => new Date("2026-07-09T05:00:00Z"),
+    });
+
+    expect(recordLearnings).toHaveBeenCalledWith(["BET-3"]);
+    expect(summary.newlyCompletedBets).toEqual(["BET-3"]);
+    expect(summary.learningsRecorded).toBe(3);
+  });
+
+  it("first-ever run (no prior summary) treats the whole completed set as newly completed", async () => {
+    const recordLearnings = vi.fn().mockResolvedValue({ learnings: [], recordedCount: 2 });
+    const summary = await runSelfOptimizationSweep({
+      steward: vi.fn().mockResolvedValue(
+        stewardResult({ completedBets: ["BET-6"], outstandingBets: [] }),
+      ) as never,
+      loadCockpit: vi.fn().mockResolvedValue(
+        cockpitResult([{ betKey: "BET-6", statuses: ["done"] }]),
+      ) as never,
+      readPriorCompleted: noPriorCompleted,
+      recordLearnings: recordLearnings as never,
+      writeSummary: async () => {},
+      now: () => new Date("2026-07-09T05:00:00Z"),
+    });
+
+    expect(recordLearnings).toHaveBeenCalledWith(["BET-6"]);
+    expect(summary.newlyCompletedBets).toEqual(["BET-6"]);
   });
 });

--- a/apps/web/lib/optimization/self-optimization-sweep.ts
+++ b/apps/web/lib/optimization/self-optimization-sweep.ts
@@ -14,6 +14,7 @@ import { prisma } from "@dpf/db";
 
 import { runConsolidationParitySteward } from "@/lib/ea/consolidation-parity-steward";
 import { loadOptimizationCockpitData } from "./load-cockpit-data";
+import { recordBetCompletionLearnings } from "./bet-completion-feedback";
 
 export const SELF_OPTIMIZATION_SWEEP_CONFIG_KEY = "optimization.selfSweep.lastRun";
 
@@ -22,15 +23,21 @@ export type SelfOptimizationSweepSummary = {
   graphAvailable: boolean;
   outstandingBets: string[];
   completedBets: string[];
+  /** Bets that completed since the prior sweep (the corpus-enrichment trigger). */
+  newlyCompletedBets: string[];
   /** Outstanding bets whose delivery items are all open/untouched (no in-progress). */
   stalledBets: string[];
   parity: { created: number; updated: number; resolved: number };
   blastRadius: { implementationFileCount: number; relatedTestCount: number };
+  /** Profession-corpus learnings recorded for newly-completed bets (BET-0f). */
+  learningsRecorded: number;
 };
 
 export type SelfOptimizationSweepDeps = {
   steward: typeof runConsolidationParitySteward;
   loadCockpit: typeof loadOptimizationCockpitData;
+  readPriorCompleted: () => Promise<string[]>;
+  recordLearnings: typeof recordBetCompletionLearnings;
   writeSummary: (summary: SelfOptimizationSweepSummary) => Promise<void>;
   now: () => Date;
 };
@@ -38,6 +45,16 @@ export type SelfOptimizationSweepDeps = {
 const defaultDeps: SelfOptimizationSweepDeps = {
   steward: runConsolidationParitySteward,
   loadCockpit: loadOptimizationCockpitData,
+  readPriorCompleted: async () => {
+    const row = await prisma.platformConfig.findUnique({
+      where: { key: SELF_OPTIMIZATION_SWEEP_CONFIG_KEY },
+      select: { value: true },
+    });
+    const value = row?.value as { completedBets?: unknown } | null;
+    const prior = value?.completedBets;
+    return Array.isArray(prior) ? prior.filter((key): key is string => typeof key === "string") : [];
+  },
+  recordLearnings: recordBetCompletionLearnings,
   writeSummary: async (summary) => {
     await prisma.platformConfig.upsert({
       where: { key: SELF_OPTIMIZATION_SWEEP_CONFIG_KEY },
@@ -53,6 +70,7 @@ export async function runSelfOptimizationSweep(
 ): Promise<SelfOptimizationSweepSummary> {
   const resolved: SelfOptimizationSweepDeps = { ...defaultDeps, ...deps };
 
+  const priorCompleted = new Set(await resolved.readPriorCompleted());
   const parity = await resolved.steward();
   const cockpit = await resolved.loadCockpit();
 
@@ -65,17 +83,25 @@ export async function runSelfOptimizationSweep(
     )
     .map((projection) => projection.bet.betKey);
 
+  // BET-0f: bets that completed since the prior sweep enrich the WSID corpus of
+  // the professions that worked them. First-ever run (no prior) records for the
+  // whole completed set, which the gap fingerprint dedupes on later runs.
+  const newlyCompletedBets = parity.completedBets.filter((betKey) => !priorCompleted.has(betKey));
+  const feedback = await resolved.recordLearnings(newlyCompletedBets);
+
   const summary: SelfOptimizationSweepSummary = {
     ranAt: resolved.now().toISOString(),
     graphAvailable: cockpit.freshness.available,
     outstandingBets: parity.outstandingBets,
     completedBets: parity.completedBets,
+    newlyCompletedBets,
     stalledBets,
     parity: { created: parity.created, updated: parity.updated, resolved: parity.resolved },
     blastRadius: {
       implementationFileCount: cockpit.totals.implementationFileCount,
       relatedTestCount: cockpit.totals.relatedTestCount,
     },
+    learningsRecorded: feedback.recordedCount,
   };
 
   await resolved.writeSummary(summary);

--- a/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-09-optimization-cockpit-design.md
@@ -100,6 +100,24 @@ session-scale activity; the sweep keeps its outputs honest between runs
 (plan §6 standing discipline). Kernel-scored: third-task shape, HIGH
 confidence, composite 9.76.
 
+## BET-0f — WSID feedback loop (BI-5C01F920)
+
+Closes the self-optimization loop: a completed consolidation bet's technique is
+a learning the professions that worked it (`bet-professions.ts`) do not yet
+hold in their WSID corpus. `apps/web/lib/optimization/bet-completion-feedback.ts`
+(`recordBetCompletionLearnings`) records a deterministic, deduped
+`ProfessionCorpusGap` (new reason `bet-completed`) per mapped profession —
+query "capture the technique from completed BET-N", `suggestedSource` = the
+bet's spec + anchor files — routed through the SAME governed corpus-growth
+surface operators already review (coworker-record `ProfessionCorpusPanel`). No
+craft content is fabricated: the sweep only flags *that* a learning is
+available and *where*. The BET-0e sweep computes bets that completed since its
+prior run (diffing `completedBets` in the `optimization.selfSweep.lastRun`
+singleton) and drives the recorder; the gap fingerprint coalesces re-runs. UI
+label/tone for the new reason added in both corpus panels. This addresses the
+under-exercised-substrate root cause (plan §9): optimization work makes the
+WSID coworkers measurably better-sourced for the next round.
+
 ## Research & benchmarking
 
 Composition follows the in-repo precedents rather than external dashboards:


### PR DESCRIPTION
## What

EP-8DC217EB **BET-0f** (BI-5C01F920) — closes the self-optimization enablement wave. A completed consolidation bet's technique is a learning the professions that worked it don't yet hold in their WSID corpus.

- `bet-completion-feedback.ts` (`recordBetCompletionLearnings`) — per newly-completed bet, records a deterministic, deduped `ProfessionCorpusGap` (new reason `bet-completed`) for each profession from `bet-professions.ts`: query "capture the technique from completed BET-N", `suggestedSource` = the bet's spec + anchor files. Routed through the SAME governed corpus-growth surface operators already review (coworker-record `ProfessionCorpusPanel`). **No craft content is fabricated** — it flags *that* a learning exists and *where*.
- `self-optimization-sweep.ts` (BET-0e) now diffs `completedBets` against its prior `optimization.selfSweep.lastRun` summary to find newly-completed bets and drives the recorder; summary gains `newlyCompletedBets` + `learningsRecorded`. The gap fingerprint coalesces re-runs.
- `bet-completed` added to `ProfessionCorpusGapReason` + both corpus panels (label + success tone). `reason` is a free string column — **no migration**.
- Spec: extends the cockpit design doc with the BET-0f section.

## Verification

Substrate: source-local, worktree `wsid-feedback` (merged current origin/main @ 177d41fb7):
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (full suite) → **exit 0, 1723 files / 14792 tests passed**
- Scoped: bet-completion-feedback (4), sweep (4, incl. newly-completed diff + first-run), corpus-evidence — 20/20
- guard loop 9 + module-size green

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): full typecheck + full vitest exit 0 + ratchets green. CI is the canonical run.

Process-Spine-Decision: EP-8DC217EB plan §9 BET-0f; spec section included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)