### PR TITLE
feat(coworker): make unified prompt path the default (BI-45514C4E)

### DIFF
--- a/apps/web/lib/shared/feature-flags.test.ts
+++ b/apps/web/lib/shared/feature-flags.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: { platformConfig: { findUnique: vi.fn() } },
+}));
+
+import { prisma } from "@dpf/db";
+
+import { isStallWatchdogEnabled, isUnifiedCoworkerEnabled } from "./feature-flags";
+
+const findUnique = prisma.platformConfig.findUnique as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("isUnifiedCoworkerEnabled (BI-45514C4E: unified is the default)", () => {
+  it("defaults to unified when there is no PlatformConfig row", async () => {
+    findUnique.mockResolvedValueOnce(null);
+    expect(await isUnifiedCoworkerEnabled()).toBe(true);
+  });
+
+  it("defaults to unified when the row has no enabled field", async () => {
+    findUnique.mockResolvedValueOnce({ value: {} });
+    expect(await isUnifiedCoworkerEnabled()).toBe(true);
+  });
+
+  it("stays unified when explicitly enabled", async () => {
+    findUnique.mockResolvedValueOnce({ value: { enabled: true } });
+    expect(await isUnifiedCoworkerEnabled()).toBe(true);
+  });
+
+  it("falls back to legacy ONLY when an operator explicitly disables it", async () => {
+    findUnique.mockResolvedValueOnce({ value: { enabled: false } });
+    expect(await isUnifiedCoworkerEnabled()).toBe(false);
+  });
+});
+
+describe("isStallWatchdogEnabled (unchanged: opt-in, defaults off)", () => {
+  it("defaults off with no row", async () => {
+    findUnique.mockResolvedValueOnce(null);
+    expect(await isStallWatchdogEnabled()).toBe(false);
+  });
+
+  it("is on only when explicitly enabled", async () => {
+    findUnique.mockResolvedValueOnce({ value: { enabled: true } });
+    expect(await isStallWatchdogEnabled()).toBe(true);
+  });
+});

--- a/apps/web/lib/shared/feature-flags.ts
+++ b/apps/web/lib/shared/feature-flags.ts
@@ -5,7 +5,11 @@ export async function isUnifiedCoworkerEnabled(): Promise<boolean> {
     where: { key: "USE_UNIFIED_COWORKER" },
   });
   const val = config?.value as { enabled?: boolean } | null;
-  return val?.enabled === true;
+  // BI-45514C4E: unified is now the DEFAULT. The legacy prompt path strips the
+  // whole skill plane (including decision-routing), so a fresh install with no
+  // PlatformConfig row must get the unified assembler. Legacy is opt-in only: an
+  // operator must explicitly persist {enabled:false} to fall back. Reversible.
+  return val?.enabled !== false;
 }
 
 /**

--- a/docs/superpowers/plans/2026-07-09-unified-coworker-default-plan.md
+++ b/docs/superpowers/plans/2026-07-09-unified-coworker-default-plan.md
@@ -1,0 +1,51 @@
+# Unified coworker prompt path — default flip (BI-45514C4E)
+
+- **Date:** 2026-07-09
+- **Epic:** EP-CLAUDE-INSIDE-OUT (harness-parity matrix row #2 — skill activation)
+- **BI:** BI-45514C4E
+- **Related:** EP-F7E35344; coworker-decision-routing-gap ([[coworker-decision-routing-gap]])
+
+## Problem
+
+`isUnifiedCoworkerEnabled()` returned `val?.enabled === true`, so the **install
+default** (no `PlatformConfig` row for `USE_UNIFIED_COWORKER`) was the **legacy**
+prompt path. The legacy path in `agent-coworker.ts` strips the entire skill plane
+— including decision-routing (WWMD/WWWD/WSID) and every DB-native skill. This is
+the single highest-leverage unblock for EP-CLAUDE-INSIDE-OUT: until it flips, most
+of Cluster 1's value (skills, goal gates, memory injection) is dark on default
+installs.
+
+## Approach — flip the default (minimal, reversible)
+
+Change one predicate: `return val?.enabled !== false`. Truth table:
+
+| PlatformConfig row | old (=== true) | new (!== false) |
+|---|---|---|
+| none | legacy | **unified** |
+| `{}` | legacy | **unified** |
+| `{enabled:true}` | unified | unified |
+| `{enabled:false}` | legacy | **legacy** (opt-out preserved) |
+
+Legacy becomes opt-in: an operator must explicitly persist `{enabled:false}` to
+fall back. Fully reversible via that config row — no schema change, no data
+migration.
+
+## Why not retire the legacy branch now
+
+Deleting the legacy branch in `agent-coworker.ts` (hundreds of lines) is a larger,
+harder-to-reverse change. The kernel-preferred sequence is: flip the default
+(reversible), validate unified parity on the live install, then retire legacy as a
+follow-up once proven. Kept as a follow-up BI.
+
+## Tests
+
+`feature-flags.test.ts` (new): asserts the default is unified across no-row /
+empty / explicit-true, and legacy only on explicit `{enabled:false}`; plus a guard
+that `isStallWatchdogEnabled` remains opt-in (defaults off) so the shared shape
+change did not leak.
+
+## Follow-ups
+
+- Live-validate unified-path parity on the running install (drive a coworker turn,
+  confirm skills + decision-routing engage).
+- Retire the legacy `agent-coworker.ts` branch once unified is proven.


### PR DESCRIPTION
## Summary
EP-CLAUDE-INSIDE-OUT harness-parity matrix row #2 — the highest-leverage skill-activation unblock. `isUnifiedCoworkerEnabled()` defaulted to the **legacy** path (no PlatformConfig row → false), which strips the whole skill plane including decision-routing. This flips the default to unified.

One predicate: `return val?.enabled !== false`.

| PlatformConfig row | old | new |
|---|---|---|
| none / `{}` / `{enabled:true}` | legacy / legacy / unified | **unified** |
| `{enabled:false}` | legacy | legacy (opt-out preserved) |

Legacy becomes opt-in; fully reversible via the config row — no schema change, no migration. Retiring the legacy branch is a follow-up (flip → validate → retire).

Tests: `feature-flags.test.ts` (new, 6) — default unified across no-row/empty/explicit-true, legacy only on explicit disable; `isStallWatchdogEnabled` stays opt-in.

Kernel ledger DI-F66BD800E5FB (flip-default, high confidence). Plan: docs/superpowers/plans/2026-07-09-unified-coworker-default-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)