### PR TITLE
feat(coworker-memory): durable rolling compaction checkpoint (BI-FDECBE0A)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -646,6 +646,20 @@ export async function sendMessage(input: {
     const { applyRollingCompaction } = await import("@/lib/actions/thread-compaction");
     chatHistory = await applyRollingCompaction(chatHistory);
   }
+
+  // BI-FDECBE0A (EP-8C706944 P1): prepend the thread's durable rolling checkpoint
+  // — a persisted running summary of every turn older than the recency window —
+  // so long threads keep continuity that does not depend on vector recall. Strict
+  // no-op until a checkpoint exists; non-fatal on any error.
+  try {
+    const { loadThreadCheckpointMessage } = await import("@/lib/tak/thread-checkpoint-runner");
+    const checkpointMessage = await loadThreadCheckpointMessage(input.threadId);
+    if (checkpointMessage) {
+      chatHistory = [checkpointMessage, ...chatHistory];
+    }
+  } catch (err) {
+    console.warn("[thread-checkpoint] inject failed:", getErrorMessage(err));
+  }
   const recentContentForClassification = chatHistory
     .slice(-3)
     .map((m) => typeof m.content === "string" ? m.content : JSON.stringify(m.content));
@@ -2316,6 +2330,20 @@ export async function sendMessage(input: {
         operatingProfileFingerprint: memoryOperatingProfileFingerprint,
       }).catch((e) => console.warn("[user-facts] extract failed:", getErrorMessage(e)));
     }).catch((e) => console.warn("[user-facts] import failed:", getErrorMessage(e)));
+  }
+
+  // BI-FDECBE0A (EP-8C706944 P1): fire-and-forget advance of the durable rolling
+  // checkpoint. Folds turns that have just aged out of the recency window into the
+  // persisted summary (a no-op until a batch has accumulated), so the fold is paid
+  // once per batch instead of re-summarized every turn. keepRecentCount mirrors the
+  // window this route loads above.
+  {
+    const keepRecentCount = isBuildPhase ? 20 : 8;
+    import("@/lib/tak/thread-checkpoint-runner")
+      .then(({ advanceThreadCheckpointForThread }) =>
+        advanceThreadCheckpointForThread(input.threadId, keepRecentCount),
+      )
+      .catch((e) => console.warn("[thread-checkpoint] advance failed:", getErrorMessage(e)));
   }
 
   // Fire-and-forget: process observer

--- a/apps/web/lib/tak/thread-checkpoint-runner.ts
+++ b/apps/web/lib/tak/thread-checkpoint-runner.ts
@@ -1,0 +1,99 @@
+// apps/web/lib/tak/thread-checkpoint-runner.ts
+// Server-side wiring for the durable rolling checkpoint (BI-FDECBE0A).
+// Binds the pure fold logic in thread-checkpoint.ts to prisma + the routed
+// summarizer. Kept separate from the pure core so the fold math stays
+// DB-and-model-free for unit tests, and so the P2 sleep-time pass can reuse the
+// same advance without going through the coworker send path.
+
+import { prisma } from "@dpf/db";
+import {
+  advanceThreadCheckpoint,
+  formatCheckpointMessage,
+  type AdvanceDeps,
+  type ThreadCheckpointState,
+} from "./thread-checkpoint";
+
+function prismaDeps(): AdvanceDeps {
+  return {
+    loadState: async (threadId) => {
+      const t = await prisma.agentThread.findUnique({
+        where: { id: threadId },
+        select: {
+          compactedSummary: true,
+          compactionWatermarkAt: true,
+          compactedTurnCount: true,
+        },
+      });
+      return t as ThreadCheckpointState | null;
+    },
+    loadMessagesAfter: async (threadId, after) => {
+      const rows = await prisma.agentMessage.findMany({
+        where: {
+          threadId,
+          role: { in: ["user", "assistant"] },
+          ...(after ? { createdAt: { gt: after } } : {}),
+        },
+        orderBy: { createdAt: "asc" },
+        select: { id: true, role: true, content: true, createdAt: true },
+      });
+      return rows;
+    },
+    saveState: async (threadId, state) => {
+      await prisma.agentThread.update({
+        where: { id: threadId },
+        data: {
+          compactedSummary: state.compactedSummary,
+          compactionWatermarkAt: state.compactionWatermarkAt,
+          compactedTurnCount: state.compactedTurnCount,
+        },
+      });
+    },
+    summarize: async ({ priorSummary, transcript }) => {
+      const { routeAndCall } = await import("@/lib/inference/routed-inference");
+      const priorBlock = priorSummary
+        ? `Existing running summary (extend it, do not repeat it):\n${priorSummary}\n\n`
+        : "";
+      const result = await routeAndCall(
+        [
+          {
+            role: "user",
+            content:
+              `${priorBlock}New conversation turns to fold into the running summary. ` +
+              `Produce ONE updated running summary in 3–6 sentences. Preserve every ` +
+              `decision, commitment, open question, and durable fact; drop pleasantries ` +
+              `and superseded detail.\n\n${transcript}`,
+          },
+        ],
+        "You maintain a durable rolling summary of a work conversation. Output only the updated summary — no preamble.",
+        "internal",
+        { taskType: "analysis" },
+      );
+      return result.content;
+    },
+  };
+}
+
+/**
+ * Fold aged-out turns into the thread's durable checkpoint. Safe to call
+ * fire-and-forget after a turn; a no-op until a batch has aged out.
+ */
+export async function advanceThreadCheckpointForThread(
+  threadId: string,
+  keepRecentCount: number,
+): Promise<void> {
+  await advanceThreadCheckpoint(threadId, keepRecentCount, prismaDeps());
+}
+
+/**
+ * Load the durable checkpoint as a history message to prepend ahead of the
+ * recency window. Null when the thread has no checkpoint yet (strict no-op).
+ */
+export async function loadThreadCheckpointMessage(
+  threadId: string,
+): Promise<{ role: "user"; content: string } | null> {
+  const t = await prisma.agentThread.findUnique({
+    where: { id: threadId },
+    select: { compactedSummary: true, compactedTurnCount: true },
+  });
+  return formatCheckpointMessage(t);
+}

--- a/apps/web/lib/tak/thread-checkpoint.test.ts
+++ b/apps/web/lib/tak/thread-checkpoint.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  advanceThreadCheckpoint,
+  formatCheckpointMessage,
+  CHECKPOINT_FOLD_BATCH,
+  CHECKPOINT_SUMMARY_CHAR_CAP,
+  type AdvanceDeps,
+  type CheckpointMessage,
+  type ThreadCheckpointState,
+} from "./thread-checkpoint";
+
+function msg(id: number, role: "user" | "assistant", ms: number): CheckpointMessage {
+  return { id: `m${id}`, role, content: `${role} message ${id}`, createdAt: new Date(ms) };
+}
+
+function makeDeps(over: Partial<AdvanceDeps> & { state: ThreadCheckpointState | null; messages: CheckpointMessage[] }): {
+  deps: AdvanceDeps;
+  saved: { value: ThreadCheckpointState | null };
+  summarizeSpy: ReturnType<typeof vi.fn>;
+} {
+  const saved = { value: null as ThreadCheckpointState | null };
+  const summarizeSpy = vi.fn(async ({ priorSummary, transcript }: { priorSummary: string | null; transcript: string }) =>
+    `${priorSummary ? priorSummary + " | " : ""}folded(${transcript.split("\n\n").length})`,
+  );
+  const deps: AdvanceDeps = {
+    loadState: async () => over.state,
+    loadMessagesAfter: async (_t, after) =>
+      after ? over.messages.filter((m) => m.createdAt.getTime() > after.getTime()) : over.messages,
+    saveState: async (_t, s) => {
+      saved.value = s;
+    },
+    summarize: summarizeSpy,
+    ...over,
+  };
+  return { deps, saved, summarizeSpy };
+}
+
+const EMPTY_STATE: ThreadCheckpointState = {
+  compactedSummary: null,
+  compactionWatermarkAt: null,
+  compactedTurnCount: 0,
+};
+
+describe("advanceThreadCheckpoint", () => {
+  it("no-ops when the thread does not exist", async () => {
+    const { deps } = makeDeps({ state: null, messages: [] });
+    const r = await advanceThreadCheckpoint("t1", 8, deps);
+    expect(r).toEqual({ advanced: false, reason: "no-thread" });
+  });
+
+  it("no-ops until CHECKPOINT_FOLD_BATCH messages have aged out of the window", async () => {
+    // keepRecentCount=8, and only 8+ (BATCH-1) messages → nothing eligible enough
+    const messages = Array.from({ length: 8 + (CHECKPOINT_FOLD_BATCH - 1) }, (_, i) =>
+      msg(i, i % 2 ? "assistant" : "user", 1000 + i),
+    );
+    const { deps, summarizeSpy } = makeDeps({ state: EMPTY_STATE, messages });
+    const r = await advanceThreadCheckpoint("t1", 8, deps);
+    expect(r).toEqual({ advanced: false, reason: "not-enough" });
+    expect(summarizeSpy).not.toHaveBeenCalled();
+  });
+
+  it("folds aged-out messages, keeping the newest keepRecentCount untouched", async () => {
+    const keep = 8;
+    const aged = CHECKPOINT_FOLD_BATCH; // exactly enough to fold
+    const messages = Array.from({ length: aged + keep }, (_, i) =>
+      msg(i, i % 2 ? "assistant" : "user", 1000 + i),
+    );
+    const { deps, saved } = makeDeps({ state: EMPTY_STATE, messages });
+    const r = await advanceThreadCheckpoint("t1", keep, deps);
+    expect(r.advanced).toBe(true);
+    if (!r.advanced) throw new Error("unreachable");
+    expect(r.foldedCount).toBe(aged);
+    // watermark = createdAt of the newest FOLDED message (index aged-1)
+    expect(r.watermarkAt.getTime()).toBe(1000 + (aged - 1));
+    expect(saved.value?.compactedTurnCount).toBe(aged);
+    expect(saved.value?.compactionWatermarkAt?.getTime()).toBe(1000 + (aged - 1));
+  });
+
+  it("never re-reads messages behind the watermark (folds incrementally)", async () => {
+    const keep = 8;
+    // watermark already at ms=1005; only messages after it are provided by loadMessagesAfter
+    const state: ThreadCheckpointState = {
+      compactedSummary: "prior",
+      compactionWatermarkAt: new Date(1005),
+      compactedTurnCount: 6,
+    };
+    const messages = Array.from({ length: CHECKPOINT_FOLD_BATCH + keep }, (_, i) =>
+      msg(100 + i, i % 2 ? "assistant" : "user", 2000 + i),
+    );
+    const { deps, saved, summarizeSpy } = makeDeps({ state, messages });
+    const r = await advanceThreadCheckpoint("t1", keep, deps);
+    expect(r.advanced).toBe(true);
+    // prior summary is threaded into the next fold
+    expect(summarizeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ priorSummary: "prior" }),
+    );
+    expect(saved.value?.compactedTurnCount).toBe(6 + CHECKPOINT_FOLD_BATCH);
+  });
+
+  it("caps the persisted summary length", async () => {
+    const keep = 2;
+    const messages = Array.from({ length: CHECKPOINT_FOLD_BATCH + keep }, (_, i) =>
+      msg(i, "user", 1000 + i),
+    );
+    const { deps, saved } = makeDeps({
+      state: EMPTY_STATE,
+      messages,
+      summarize: async () => "x".repeat(CHECKPOINT_SUMMARY_CHAR_CAP + 500),
+    });
+    await advanceThreadCheckpoint("t1", keep, deps);
+    expect(saved.value?.compactedSummary?.length).toBe(CHECKPOINT_SUMMARY_CHAR_CAP);
+  });
+
+  it("is non-fatal when summarization throws", async () => {
+    const keep = 2;
+    const messages = Array.from({ length: CHECKPOINT_FOLD_BATCH + keep }, (_, i) =>
+      msg(i, "user", 1000 + i),
+    );
+    const { deps } = makeDeps({
+      state: EMPTY_STATE,
+      messages,
+      summarize: async () => {
+        throw new Error("model down");
+      },
+    });
+    const r = await advanceThreadCheckpoint("t1", keep, deps);
+    expect(r).toEqual({ advanced: false, reason: "error" });
+  });
+});
+
+describe("formatCheckpointMessage", () => {
+  it("returns null when there is no summary (strict no-op)", () => {
+    expect(formatCheckpointMessage(null)).toBeNull();
+    expect(formatCheckpointMessage({ compactedSummary: null, compactedTurnCount: 0 })).toBeNull();
+  });
+
+  it("renders a durable-summary message with the turn count", () => {
+    const m = formatCheckpointMessage({ compactedSummary: "did X and Y", compactedTurnCount: 12 });
+    expect(m).not.toBeNull();
+    expect(m!.role).toBe("user");
+    expect(m!.content).toContain("12 earlier turns");
+    expect(m!.content).toContain("did X and Y");
+  });
+
+  it("uses singular phrasing for a single turn", () => {
+    const m = formatCheckpointMessage({ compactedSummary: "s", compactedTurnCount: 1 });
+    expect(m!.content).toContain("1 earlier turn]");
+  });
+});

--- a/apps/web/lib/tak/thread-checkpoint.ts
+++ b/apps/web/lib/tak/thread-checkpoint.ts
@@ -1,0 +1,146 @@
+// apps/web/lib/tak/thread-checkpoint.ts
+// Durable rolling compaction checkpoint — BI-FDECBE0A (EP-8C706944 Phase 1).
+//
+// The coworker send path loads only a bounded recency window (8 chat / 20 build
+// messages) plus vector recall; everything older is invisible unless semantic
+// recall happens to surface it, and the in-flight `thread-compaction.ts` summary
+// is recomputed from scratch every turn and never persisted.
+//
+// This module maintains a PERSISTED running summary of every turn older than the
+// recency window, on AgentThread.compactedSummary. A watermark
+// (compactionWatermarkAt = createdAt of the newest message already folded)
+// guarantees each message is summarized at most once: the advance job only reads
+// messages strictly newer than the watermark, folds a batch into the summary, and
+// moves the watermark forward. Injecting the checkpoint gives long threads
+// continuity that does not depend on vector recall, and stops the per-turn
+// re-summarization spend.
+//
+// Both the summarizer and the store are dependency-injected so the fold logic is
+// unit-testable without a model or a database.
+
+/** A message the fold job considers, oldest-first. */
+export type CheckpointMessage = {
+  id: string;
+  role: string;
+  content: string;
+  createdAt: Date;
+};
+
+/** Persisted checkpoint state for a thread. */
+export type ThreadCheckpointState = {
+  compactedSummary: string | null;
+  compactionWatermarkAt: Date | null;
+  compactedTurnCount: number;
+};
+
+/**
+ * Minimum number of aged-out (older-than-window, newer-than-watermark) messages
+ * that must accumulate before we spend an LLM call to fold them. Keeps the fold
+ * coarse-grained and cache-friendly rather than one summary call per turn.
+ */
+export const CHECKPOINT_FOLD_BATCH = 10;
+
+/** Hard cap on the persisted summary length so it can never dominate context. */
+export const CHECKPOINT_SUMMARY_CHAR_CAP = 4000;
+
+export type Summarize = (args: {
+  priorSummary: string | null;
+  transcript: string;
+}) => Promise<string>;
+
+export type AdvanceDeps = {
+  /** Load the thread's current checkpoint state. */
+  loadState: (threadId: string) => Promise<ThreadCheckpointState | null>;
+  /**
+   * Load conversation messages (role user/assistant) with createdAt strictly
+   * greater than `after` (or all, when null), oldest-first.
+   */
+  loadMessagesAfter: (
+    threadId: string,
+    after: Date | null,
+  ) => Promise<CheckpointMessage[]>;
+  /** Persist the advanced checkpoint. */
+  saveState: (threadId: string, state: ThreadCheckpointState) => Promise<void>;
+  summarize: Summarize;
+};
+
+export type AdvanceResult =
+  | { advanced: false; reason: "no-thread" | "not-enough" | "error" }
+  | { advanced: true; foldedCount: number; watermarkAt: Date };
+
+function renderTranscript(messages: CheckpointMessage[]): string {
+  return messages
+    .map((m) => {
+      const who = m.role === "assistant" ? "Agent" : "User";
+      const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+      return `${who}: ${text.slice(0, 800)}`;
+    })
+    .join("\n\n");
+}
+
+/**
+ * Fold the aged-out messages (older than the newest `keepRecentCount`, newer than
+ * the watermark) into the durable summary. Idempotent and safe to call
+ * fire-and-forget after every turn: a no-op until CHECKPOINT_FOLD_BATCH messages
+ * have aged out, and it never re-reads messages already behind the watermark.
+ */
+export async function advanceThreadCheckpoint(
+  threadId: string,
+  keepRecentCount: number,
+  deps: AdvanceDeps,
+): Promise<AdvanceResult> {
+  try {
+    const state = await deps.loadState(threadId);
+    if (!state) return { advanced: false, reason: "no-thread" };
+
+    const sinceWatermark = await deps.loadMessagesAfter(
+      threadId,
+      state.compactionWatermarkAt,
+    );
+    // Only messages that have aged OUT of the live recency window are eligible —
+    // keep the newest `keepRecentCount` untouched (they are still sent verbatim).
+    const eligible =
+      keepRecentCount > 0 ? sinceWatermark.slice(0, -keepRecentCount) : sinceWatermark;
+
+    if (eligible.length < CHECKPOINT_FOLD_BATCH) {
+      return { advanced: false, reason: "not-enough" };
+    }
+
+    const newestFolded = eligible[eligible.length - 1]!;
+    const summary = await deps.summarize({
+      priorSummary: state.compactedSummary,
+      transcript: renderTranscript(eligible),
+    });
+    const capped =
+      summary.length > CHECKPOINT_SUMMARY_CHAR_CAP
+        ? summary.slice(0, CHECKPOINT_SUMMARY_CHAR_CAP)
+        : summary;
+
+    await deps.saveState(threadId, {
+      compactedSummary: capped,
+      compactionWatermarkAt: newestFolded.createdAt,
+      compactedTurnCount: state.compactedTurnCount + eligible.length,
+    });
+
+    return { advanced: true, foldedCount: eligible.length, watermarkAt: newestFolded.createdAt };
+  } catch (err) {
+    // Non-fatal: a failed fold must never break the coworker turn.
+    console.warn("[thread-checkpoint] advance failed:", err);
+    return { advanced: false, reason: "error" };
+  }
+}
+
+/**
+ * Render the persisted checkpoint as a single history message to prepend ahead of
+ * the recency window. Returns null when there is no checkpoint (strict no-op).
+ */
+export function formatCheckpointMessage(
+  state: Pick<ThreadCheckpointState, "compactedSummary" | "compactedTurnCount"> | null,
+): { role: "user"; content: string } | null {
+  if (!state?.compactedSummary) return null;
+  const turns = state.compactedTurnCount;
+  return {
+    role: "user",
+    content: `[CONVERSATION SO FAR — durable summary of ${turns} earlier turn${turns === 1 ? "" : "s"}]: ${state.compactedSummary}`,
+  };
+}

--- a/docs/superpowers/plans/2026-07-09-thread-compaction-checkpoint-plan.md
+++ b/docs/superpowers/plans/2026-07-09-thread-compaction-checkpoint-plan.md
@@ -1,0 +1,37 @@
+# Durable rolling compaction checkpoint — implementation plan
+
+- **BI:** BI-FDECBE0A (EP-8C706944 — AI Coworker Memory & Context Architecture, Phase 1)
+- **Date:** 2026-07-09
+- **Kernel ledger:** DI-F69AE978B70C (program-level; hybrid-lifecycle-plus-projections)
+- **Status:** Substrate + core + send-path wiring (this PR)
+
+## Problem
+
+The coworker send path (`apps/web/lib/actions/agent-coworker.ts`) loads only a bounded recency window — `RECENT_WINDOW` = 8 (chat) / 20 (build) messages — plus Qdrant semantic recall. Everything older is invisible unless recall happens to surface it. The in-flight `thread-compaction.ts` summary only fires when the *assembled window* exceeds 20, and when it does it recomputes the summary from scratch every turn and discards it. So: no durable "conversation so far", and any summarization spend is repaid each turn. The DB `AgentMessage` log itself is unbounded (retention is BI-153F7E4A, Phase 2).
+
+## Design
+
+A persisted running summary of every turn **older than the recency window**, advanced incrementally behind a watermark.
+
+1. **Schema** (`AgentThread`, additive migration `20260709120000_add_thread_compaction_checkpoint`):
+   - `compactedSummary String?` — the durable running summary.
+   - `compactionWatermarkAt DateTime?` — createdAt of the newest message already folded; the advance only reads messages strictly newer, so no span is summarized twice.
+   - `compactedTurnCount Int @default(0)` — how many turns the summary condenses.
+   All nullable/defaulted → safe against existing rows (attested in-file).
+
+2. **Pure core** (`apps/web/lib/tak/thread-checkpoint.ts`): `advanceThreadCheckpoint(threadId, keepRecentCount, deps)` folds the messages that have aged out of the window (all-but-newest-`keepRecentCount`, newer than the watermark) once `CHECKPOINT_FOLD_BATCH` (10) have accumulated; folds the prior summary + new transcript into one updated summary; caps at `CHECKPOINT_SUMMARY_CHAR_CAP` (4000). `formatCheckpointMessage` renders it as a prependable history message, null when empty. Summarizer + store are dependency-injected → unit-tested with no DB/model (`thread-checkpoint.test.ts`, 9 cases).
+
+3. **Server runner** (`thread-checkpoint-runner.ts`): binds prisma + the routed `analysis`-tier summarizer to the core. `loadThreadCheckpointMessage` (read) and `advanceThreadCheckpointForThread` (advance). Kept separate so the P2 sleep-time pass reuses the same advance.
+
+4. **Send-path wiring** (`agent-coworker.ts`): after the recency window is assembled, prepend the checkpoint message (strict no-op when absent, non-fatal on error); after the turn, fire-and-forget `advanceThreadCheckpointForThread` with `keepRecentCount` matching the route's window.
+
+## Non-goals (own BIs)
+
+- Retention/pruning of the raw `AgentMessage` log now that summaries are durable → BI-153F7E4A.
+- Per-thread token/cost accounting of the fold spend → BI-CCF1ACBB.
+- Consolidation/dedup of the summary content across threads → BI-840FDD43 / BI-907C4327.
+
+## Verification
+
+- Unit: `thread-checkpoint.test.ts` — no-thread/not-enough no-ops, exact fold boundary, incremental (watermark-respecting) fold, summary cap, non-fatal summarizer failure, message formatting.
+- Runtime (post-merge, canonical install): a >30-turn chat thread accumulates a non-null `compactedSummary`, `compactionWatermarkAt` advances monotonically, and the fold LLM call fires once per batch (not per turn).

--- a/packages/db/prisma/migrations/20260709120000_add_thread_compaction_checkpoint/migration.sql
+++ b/packages/db/prisma/migrations/20260709120000_add_thread_compaction_checkpoint/migration.sql
@@ -1,0 +1,6 @@
+-- BI-FDECBE0A (EP-8C706944 P1): durable rolling compaction checkpoint on AgentThread.
+-- Additive, nullable + defaulted — safe against any existing row (no backfill needed).
+-- @migration-safety: data-safe: all three columns are nullable or have a DEFAULT, so no existing AgentThread row can violate them.
+ALTER TABLE "AgentThread" ADD COLUMN "compactedSummary" TEXT;
+ALTER TABLE "AgentThread" ADD COLUMN "compactionWatermarkAt" TIMESTAMP(3);
+ALTER TABLE "AgentThread" ADD COLUMN "compactedTurnCount" INTEGER NOT NULL DEFAULT 0;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4435,6 +4435,18 @@ model AgentThread {
   parent         AgentThread?  @relation("AgentThreadChildren", fields: [parentThreadId], references: [id], onDelete: Restrict)
   children       AgentThread[] @relation("AgentThreadChildren")
 
+  // BI-FDECBE0A (EP-8C706944 P1): durable rolling compaction checkpoint.
+  // `compactedSummary` is a persisted running summary of every turn OLDER than
+  // the live recency window, so long-thread continuity does not depend solely
+  // on vector recall. `compactionWatermarkAt` is the createdAt of the newest
+  // message already folded into the summary — the advance job only summarizes
+  // messages strictly newer than it, so a span is never re-summarized (the old
+  // in-flight compaction recomputed the same span every turn). `compactedTurnCount`
+  // is how many messages the summary condenses (display + refold heuristics).
+  compactedSummary      String?
+  compactionWatermarkAt DateTime?
+  compactedTurnCount    Int       @default(0)
+
   @@unique([userId, contextKey])
   @@index([cliSessionLastUsedAt])
   @@index([parentThreadId])

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -16,7 +16,7 @@ apps/web/components/workbooks/Grid.tsx	924
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1338
 apps/web/lib/actions/agent-coworker-external.test.ts	866
-apps/web/lib/actions/agent-coworker.ts	2638
+apps/web/lib/actions/agent-coworker.ts	2666
 apps/web/lib/actions/agent-task-scheduler.test.ts	1083
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1114


### PR DESCRIPTION
## Summary
EP-8C706944 Phase 1, first of 9 BIs in the kernel-scored memory architecture program (ledger DI-F69AE978B70C).

The coworker send path loads only a bounded recency window (8 chat / 20 build messages) + Qdrant recall; everything older is invisible unless recall surfaces it, and the in-flight `thread-compaction.ts` summary is recomputed every turn and never persisted. This adds a **persisted running summary** of every turn older than the window, advanced incrementally behind a watermark so no span is summarized twice.

- **Schema:** `AgentThread.compactedSummary / compactionWatermarkAt / compactedTurnCount` — additive, data-safe attested migration.
- **Pure core** `thread-checkpoint.ts`: `advanceThreadCheckpoint` folds aged-out turns once `CHECKPOINT_FOLD_BATCH` (10) accumulate, caps summary at 4000 chars, dependency-injected summarizer+store → 9 unit tests, no DB/model.
- **Server runner** `thread-checkpoint-runner.ts`: prisma + analysis-tier summarizer; reused by the P2 sleep-time pass.
- **Send path:** prepend the checkpoint ahead of the window (strict no-op when absent, non-fatal on error); fire-and-forget advance after the turn.

## Verification
Worktree deps-bootstrapped: `vitest lib/tak/thread-checkpoint.test.ts` 9/9, `pnpm --filter web typecheck` clean (8GB heap), migration-safety + timestamp-collision guards green. Runtime proof (post-merge, canonical install): a >30-turn thread accumulates a non-null `compactedSummary` and the fold LLM call fires once per batch, not per turn.

Plan: docs/superpowers/plans/2026-07-09-thread-compaction-checkpoint-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)