### PR TITLE
feat(coworker-memory): per-thread/effort token+cost rollup (BI-CCF1ACBB)

### DIFF
--- a/apps/web/lib/tak/thread-cost-ledger-runner.ts
+++ b/apps/web/lib/tak/thread-cost-ledger-runner.ts
@@ -1,0 +1,70 @@
+// apps/web/lib/tak/thread-cost-ledger-runner.ts
+// Server-side query for the per-thread / per-effort spend rollup (BI-CCF1ACBB).
+// Runs the indexed groupBy over AdapterRunTelemetry + ToolExecution and folds the
+// results with the pure summarizer. Kept separate from the pure core so the fold
+// stays DB-free for unit tests.
+
+import { prisma } from "@dpf/db";
+import {
+  summarizeThreadSpend,
+  combineThreadSpend,
+  type SpendRow,
+  type ThreadSpend,
+} from "./thread-cost-ledger";
+
+async function loadSpendRows(threadIds: string[]): Promise<SpendRow[]> {
+  if (threadIds.length === 0) return [];
+  const [inference, tools] = await Promise.all([
+    prisma.adapterRunTelemetry.findMany({
+      where: { threadId: { in: threadIds } },
+      select: { inputTokens: true, outputTokens: true, estimatedCostUsd: true },
+    }),
+    prisma.toolExecution.findMany({
+      where: { threadId: { in: threadIds } },
+      select: { inputTokens: true, outputTokens: true, costUsd: true },
+    }),
+  ]);
+  const rows: SpendRow[] = [];
+  for (const r of inference) {
+    rows.push({
+      source: "inference",
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      // estimatedCostUsd is a Prisma Decimal | null.
+      costUsd: r.estimatedCostUsd != null ? Number(r.estimatedCostUsd) : null,
+    });
+  }
+  for (const r of tools) {
+    rows.push({
+      source: "tool",
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      costUsd: r.costUsd,
+    });
+  }
+  return rows;
+}
+
+/** Cumulative spend for a single coworker thread. */
+export async function getThreadSpend(threadId: string): Promise<ThreadSpend> {
+  return summarizeThreadSpend(await loadSpendRows([threadId]));
+}
+
+/**
+ * Cumulative spend for an effort spanning many threads (e.g. a shared
+ * multi-coworker effort — BI-23A65B81). Aggregates all threads at once.
+ */
+export async function getEffortSpend(threadIds: string[]): Promise<ThreadSpend> {
+  return summarizeThreadSpend(await loadSpendRows(threadIds));
+}
+
+/** Per-thread breakdown for an effort, plus the combined total. */
+export async function getEffortSpendBreakdown(
+  threadIds: string[],
+): Promise<{ perThread: Record<string, ThreadSpend>; total: ThreadSpend }> {
+  const perThread: Record<string, ThreadSpend> = {};
+  for (const id of threadIds) {
+    perThread[id] = await getThreadSpend(id);
+  }
+  return { perThread, total: combineThreadSpend(Object.values(perThread)) };
+}

--- a/apps/web/lib/tak/thread-cost-ledger.test.ts
+++ b/apps/web/lib/tak/thread-cost-ledger.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  summarizeThreadSpend,
+  combineThreadSpend,
+  formatThreadSpend,
+  EMPTY_THREAD_SPEND,
+  type SpendRow,
+} from "./thread-cost-ledger";
+
+describe("summarizeThreadSpend", () => {
+  it("returns empty spend for no rows", () => {
+    expect(summarizeThreadSpend([])).toEqual(EMPTY_THREAD_SPEND);
+  });
+
+  it("sums inference and tool rows and counts each source", () => {
+    const rows: SpendRow[] = [
+      { source: "inference", inputTokens: 100, outputTokens: 50, costUsd: 0.01 },
+      { source: "inference", inputTokens: 200, outputTokens: 80, costUsd: 0.02 },
+      { source: "tool", inputTokens: 10, outputTokens: 5, costUsd: 0.001 },
+    ];
+    const s = summarizeThreadSpend(rows);
+    expect(s.inputTokens).toBe(310);
+    expect(s.outputTokens).toBe(135);
+    expect(s.totalTokens).toBe(445);
+    expect(s.costUsd).toBeCloseTo(0.031, 6);
+    expect(s.inferenceRuns).toBe(2);
+    expect(s.toolCalls).toBe(1);
+  });
+
+  it("treats null token/cost fields as zero", () => {
+    const rows: SpendRow[] = [
+      { source: "inference", inputTokens: null, outputTokens: null, costUsd: null },
+      { source: "tool", inputTokens: 7, outputTokens: null, costUsd: null },
+    ];
+    const s = summarizeThreadSpend(rows);
+    expect(s.inputTokens).toBe(7);
+    expect(s.outputTokens).toBe(0);
+    expect(s.costUsd).toBe(0);
+    expect(s.inferenceRuns).toBe(1);
+    expect(s.toolCalls).toBe(1);
+  });
+});
+
+describe("combineThreadSpend", () => {
+  it("sums several thread rollups into an effort total", () => {
+    const a = summarizeThreadSpend([
+      { source: "inference", inputTokens: 100, outputTokens: 40, costUsd: 0.01 },
+    ]);
+    const b = summarizeThreadSpend([
+      { source: "tool", inputTokens: 20, outputTokens: 10, costUsd: 0.002 },
+      { source: "inference", inputTokens: 50, outputTokens: 25, costUsd: 0.005 },
+    ]);
+    const total = combineThreadSpend([a, b]);
+    expect(total.inputTokens).toBe(170);
+    expect(total.outputTokens).toBe(75);
+    expect(total.totalTokens).toBe(245);
+    expect(total.costUsd).toBeCloseTo(0.017, 6);
+    expect(total.inferenceRuns).toBe(2);
+    expect(total.toolCalls).toBe(1);
+  });
+
+  it("is empty for no threads", () => {
+    expect(combineThreadSpend([])).toEqual(EMPTY_THREAD_SPEND);
+  });
+});
+
+describe("formatThreadSpend", () => {
+  it("uses 2-decimal dollars above a cent and singular/plural counts", () => {
+    const s = summarizeThreadSpend([
+      { source: "inference", inputTokens: 1000, outputTokens: 500, costUsd: 1.5 },
+    ]);
+    const out = formatThreadSpend(s);
+    expect(out).toContain("1,500 tokens");
+    expect(out).toContain("$1.50");
+    expect(out).toContain("1 inference run");
+    expect(out).toContain("0 tool calls");
+  });
+
+  it("uses 4-decimal dollars for sub-cent spend", () => {
+    const s = summarizeThreadSpend([
+      { source: "tool", inputTokens: 10, outputTokens: 5, costUsd: 0.0012 },
+    ]);
+    expect(formatThreadSpend(s)).toContain("$0.0012");
+  });
+});

--- a/apps/web/lib/tak/thread-cost-ledger.ts
+++ b/apps/web/lib/tak/thread-cost-ledger.ts
@@ -1,0 +1,80 @@
+// apps/web/lib/tak/thread-cost-ledger.ts
+// Per-thread (and per-effort) cumulative token/cost rollup — BI-CCF1ACBB
+// (EP-8C706944 Phase 1).
+//
+// Raw spend already lives in two well-indexed tables: AdapterRunTelemetry
+// (per-inference-run inputTokens/outputTokens/estimatedCostUsd, joined to
+// threadId) and ToolExecution (per-tool-call inputTokens/outputTokens/costUsd,
+// joined to threadId). What was missing is a cumulative rollup — endless threads
+// had per-turn metrics but no "how much has this conversation cost" total, so
+// spend was bounded only by the provider window.
+//
+// This module derives the rollup rather than denormalizing a counter that could
+// drift (single-source-of-truth): the pure `summarizeThreadSpend` folds the two
+// row sources into one ThreadSpend, and the server runner runs the indexed
+// groupBy. Admins read it for visibility; the runtime reads it to make
+// compaction/consolidation spend-aware.
+
+/** One contributor to a thread's spend (an inference run or a tool call). */
+export type SpendRow = {
+  source: "inference" | "tool";
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+};
+
+export type ThreadSpend = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  inferenceRuns: number;
+  toolCalls: number;
+};
+
+export const EMPTY_THREAD_SPEND: ThreadSpend = {
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+  costUsd: 0,
+  inferenceRuns: 0,
+  toolCalls: 0,
+};
+
+/**
+ * Fold raw spend rows (from both sources) into one cumulative ThreadSpend.
+ * Pure — no DB, no rounding surprises: costs are summed as-is and null
+ * token/cost fields count as zero.
+ */
+export function summarizeThreadSpend(rows: SpendRow[]): ThreadSpend {
+  const acc = { ...EMPTY_THREAD_SPEND };
+  for (const r of rows) {
+    acc.inputTokens += r.inputTokens ?? 0;
+    acc.outputTokens += r.outputTokens ?? 0;
+    acc.costUsd += r.costUsd ?? 0;
+    if (r.source === "inference") acc.inferenceRuns += 1;
+    else acc.toolCalls += 1;
+  }
+  acc.totalTokens = acc.inputTokens + acc.outputTokens;
+  return acc;
+}
+
+/** Sum several thread rollups into one effort-level total. */
+export function combineThreadSpend(spends: ThreadSpend[]): ThreadSpend {
+  const acc = { ...EMPTY_THREAD_SPEND };
+  for (const s of spends) {
+    acc.inputTokens += s.inputTokens;
+    acc.outputTokens += s.outputTokens;
+    acc.costUsd += s.costUsd;
+    acc.inferenceRuns += s.inferenceRuns;
+    acc.toolCalls += s.toolCalls;
+  }
+  acc.totalTokens = acc.inputTokens + acc.outputTokens;
+  return acc;
+}
+
+/** Human-readable one-line rollup for admin display / spend-aware prompts. */
+export function formatThreadSpend(spend: ThreadSpend): string {
+  const cost = spend.costUsd >= 0.01 ? `$${spend.costUsd.toFixed(2)}` : `$${spend.costUsd.toFixed(4)}`;
+  return `${spend.totalTokens.toLocaleString()} tokens (${spend.inputTokens.toLocaleString()} in / ${spend.outputTokens.toLocaleString()} out), ${cost} across ${spend.inferenceRuns} inference run${spend.inferenceRuns === 1 ? "" : "s"} + ${spend.toolCalls} tool call${spend.toolCalls === 1 ? "" : "s"}`;
+}

--- a/docs/superpowers/plans/2026-07-09-thread-cost-ledger-plan.md
+++ b/docs/superpowers/plans/2026-07-09-thread-cost-ledger-plan.md
@@ -1,0 +1,35 @@
+# Per-thread token/cost ledger — implementation plan
+
+- **BI:** BI-CCF1ACBB (EP-8C706944 — AI Coworker Memory & Context Architecture, Phase 1)
+- **Date:** 2026-07-09
+- **Kernel ledger:** DI-F69AE978B70C
+- **Status:** Derived rollup module + tests (this PR)
+
+## Problem
+
+Endless coworker threads have per-turn telemetry (`CoworkerTurnMetric`) but no cumulative "how much has this conversation cost" total — spend is bounded only by the provider window. The founder's stated gap: no per-conversation token/cost accounting.
+
+## Substrate-first finding
+
+The raw spend already exists, well-indexed by `threadId`, in two tables — so a new per-turn token table would duplicate them (single-source-of-truth):
+
+- `AdapterRunTelemetry` — per-inference-run `inputTokens` / `outputTokens` / `estimatedCostUsd`, `@@index([threadId, startedAt])`.
+- `ToolExecution` — per-tool-call `inputTokens` / `outputTokens` / `costUsd`, `@@index([threadId])`.
+
+There is per-*provider* spend aggregation (`ai-provider-finance.ts`) but **no per-thread rollup**. So BI-CCF1ACBB is a derived rollup, not new storage — no migration.
+
+## Design
+
+1. **Pure core** `apps/web/lib/tak/thread-cost-ledger.ts`: `SpendRow` / `ThreadSpend` types, `summarizeThreadSpend(rows)` folding both sources into one total (null tokens/cost → 0), `combineThreadSpend` for effort-level sums, `formatThreadSpend` for display. Fully unit-tested, no DB.
+2. **Server runner** `thread-cost-ledger-runner.ts`: `getThreadSpend(threadId)`, `getEffortSpend(threadIds)`, `getEffortSpendBreakdown(threadIds)` — indexed `findMany` over the two tables, folded by the pure core. Consumed by (a) the runtime to make compaction/consolidation spend-aware (P2), and (b) admin surfaces.
+
+## Non-goals (own BIs / natural homes)
+
+- Denormalized cumulative counters on `AgentThread` — deliberately avoided; the derived query cannot drift. Revisit only if per-turn aggregation cost is measured to matter.
+- Surfacing spend in the operator UI — composes with the memory transparency/audit surface (BI-DC8B03AB, P4), which already renders per-thread/per-coworker detail; this PR ships the read API it consumes.
+- Effort-scoped thread grouping — the `getEffortSpend(threadIds[])` shape is ready for the effort context (BI-23A65B81, P3), which owns the thread→effort mapping.
+
+## Verification
+
+- Unit: `thread-cost-ledger.test.ts` — empty, mixed-source sum, null coalescing, effort combine, formatting (dollar precision + singular/plural).
+- Runtime (post-merge): `getThreadSpend(threadId)` on a live coworker thread returns a total matching a hand SUM over the two tables.


### PR DESCRIPTION
## Summary
EP-8C706944 Phase 1 (2/9), kernel ledger DI-F69AE978B70C.

Endless coworker threads had per-turn metrics but no cumulative spend total — cost was bounded only by the provider window.

**Substrate-first:** the raw spend already exists, indexed by `threadId`, in `AdapterRunTelemetry` (inference tokens + `estimatedCostUsd`) and `ToolExecution` (tool-call tokens + `costUsd`). There is per-*provider* aggregation but no per-thread rollup, so this is a **derived rollup, not a new per-turn table** (single-source-of-truth) — no migration.

- **Pure core** `thread-cost-ledger.ts`: `summarizeThreadSpend` / `combineThreadSpend` / `formatThreadSpend`, null-coalescing → 7 unit tests, no DB.
- **Server runner** `thread-cost-ledger-runner.ts`: `getThreadSpend` / `getEffortSpend` / `getEffortSpendBreakdown` via indexed `findMany`; consumed by runtime spend-awareness (P2) and the memory audit surface (P4).

## Verification
vitest 7/7, `pnpm --filter web typecheck` clean. Runtime proof (post-merge): `getThreadSpend` matches a hand SUM over the two tables.

Plan: docs/superpowers/plans/2026-07-09-thread-cost-ledger-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)