### PR TITLE
feat(coworker-memory): write-time consolidation gate (BI-840FDD43)

### DIFF
--- a/apps/web/lib/tak/coworker-memory.test.ts
+++ b/apps/web/lib/tak/coworker-memory.test.ts
@@ -26,6 +26,10 @@ const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
 beforeEach(() => {
   vi.clearAllMocks();
   asMock(prisma.coworkerMemoryNote.create).mockResolvedValue({ id: "note-new" });
+  // BI-840FDD43: the consolidation gate loads sibling notes when there is no
+  // exact-key match; default to an empty store so the exact-key/no-match cases
+  // behave as before unless a test seeds siblings.
+  asMock(prisma.coworkerMemoryNote.findMany).mockResolvedValue([]);
 });
 
 describe("isKnownNoteKind", () => {
@@ -110,6 +114,42 @@ describe("recordCoworkerNote", () => {
       where: { id: "note-old" },
       data: { supersededAt: expect.any(Date), supersededById: "note-new" },
     });
+  });
+
+  it("supersedes a different-key near-duplicate via the consolidation gate (BI-840FDD43)", async () => {
+    // No exact-key match, but an active sibling states the same concept under a
+    // different key with a changed value → the gate supersedes the sibling.
+    asMock(prisma.coworkerMemoryNote.findFirst).mockResolvedValueOnce(null);
+    asMock(prisma.coworkerMemoryNote.findMany).mockResolvedValueOnce([
+      { id: "note-near", noteKey: "preferred_review_style", content: "terse bullet points" },
+    ]);
+    const res = await recordCoworkerNote({
+      agentCuid: "cuid-scout",
+      noteKind: "preference",
+      noteKey: "review_style_preferred",
+      content: "detailed prose",
+    });
+    expect(res).toEqual({ ok: true, status: "updated" });
+    expect(prisma.coworkerMemoryNote.create).toHaveBeenCalledTimes(1);
+    expect(prisma.coworkerMemoryNote.update).toHaveBeenCalledWith({
+      where: { id: "note-near" },
+      data: { supersededAt: expect.any(Date), supersededById: "note-new" },
+    });
+  });
+
+  it("no-ops a different-key near-duplicate that restates the same content", async () => {
+    asMock(prisma.coworkerMemoryNote.findFirst).mockResolvedValueOnce(null);
+    asMock(prisma.coworkerMemoryNote.findMany).mockResolvedValueOnce([
+      { id: "note-near", noteKey: "preferred_review_style", content: "terse bullet points" },
+    ]);
+    const res = await recordCoworkerNote({
+      agentCuid: "cuid-scout",
+      noteKind: "preference",
+      noteKey: "review_style_preferred",
+      content: "Terse bullet points",
+    });
+    expect(res).toEqual({ ok: true, status: "unchanged" });
+    expect(prisma.coworkerMemoryNote.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/tak/coworker-memory.ts
+++ b/apps/web/lib/tak/coworker-memory.ts
@@ -88,6 +88,28 @@ export async function recordCoworkerNote(params: {
     return { ok: true, status: "unchanged" };
   }
 
+  // BI-840FDD43 (EP-8C706944 P2): when there is no exact-key match, consult the
+  // write-time consolidation gate against active notes of the same kind so a
+  // different-key near-duplicate supersedes rather than piles up.
+  let nearNeighborTargetId: string | null = null;
+  if (!existing) {
+    const { classifyConsolidation } = await import("./memory-consolidation");
+    const siblings = await prisma.coworkerMemoryNote.findMany({
+      where: { agentId: params.agentCuid, noteKind: params.noteKind, supersededAt: null },
+      select: { id: true, noteKey: true, content: true },
+    });
+    const decision = classifyConsolidation(
+      { key: noteKey, value: content },
+      siblings.map((s) => ({ id: s.id, key: s.noteKey, value: s.content })),
+    );
+    if (decision.action === "noop") {
+      return { ok: true, status: "unchanged" };
+    }
+    if (decision.action === "supersede") {
+      nearNeighborTargetId = decision.targetId;
+    }
+  }
+
   const created = await prisma.coworkerMemoryNote.create({
     data: {
       agentId: params.agentCuid,
@@ -99,9 +121,10 @@ export async function recordCoworkerNote(params: {
     },
   });
 
-  if (existing) {
+  const supersedeTargetId = existing?.id ?? nearNeighborTargetId;
+  if (supersedeTargetId) {
     await prisma.coworkerMemoryNote.update({
-      where: { id: existing.id },
+      where: { id: supersedeTargetId },
       data: { supersededAt: new Date(), supersededById: created.id },
     });
     return { ok: true, status: "updated" };

--- a/apps/web/lib/tak/memory-consolidation.test.ts
+++ b/apps/web/lib/tak/memory-consolidation.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyConsolidation,
+  entrySimilarity,
+  DEFAULT_SUPERSEDE_THRESHOLD,
+  type ExistingEntry,
+} from "./memory-consolidation";
+
+describe("entrySimilarity", () => {
+  it("is 1 for identical key+value", () => {
+    expect(entrySimilarity({ key: "k", value: "v" }, { key: "k", value: "v" })).toBe(1);
+  });
+  it("is 0 for disjoint tokens", () => {
+    expect(entrySimilarity({ key: "cloud", value: "aws" }, { key: "editor", value: "vim" })).toBe(0);
+  });
+  it("rises with shared tokens", () => {
+    const s = entrySimilarity(
+      { key: "preferred_meeting_time", value: "9am" },
+      { key: "meeting_time", value: "9am" },
+    );
+    expect(s).toBeGreaterThan(0.3);
+  });
+});
+
+describe("classifyConsolidation", () => {
+  const existing: ExistingEntry[] = [
+    { id: "e1", key: "cloud_provider", value: "AWS" },
+    { id: "e2", key: "testing_approach", value: "TDD" },
+  ];
+
+  it("ADDs when there is no equivalent or near neighbor", () => {
+    const d = classifyConsolidation({ key: "editor", value: "neovim" }, existing);
+    expect(d.action).toBe("add");
+    expect(d.targetId).toBeNull();
+  });
+
+  it("NOOPs on exact key with equivalent value (case/space-insensitive)", () => {
+    const d = classifyConsolidation({ key: "cloud_provider", value: "aws" }, existing);
+    expect(d.action).toBe("noop");
+    expect(d.targetId).toBe("e1");
+  });
+
+  it("UPDATEs on exact key with changed value", () => {
+    const d = classifyConsolidation({ key: "cloud_provider", value: "GCP" }, existing);
+    expect(d.action).toBe("update");
+    expect(d.targetId).toBe("e1");
+  });
+
+  it("SUPERSEDEs a different-key near-duplicate with a changed value", () => {
+    // High lexical overlap on key+value, different value → supersede the neighbor.
+    const near: ExistingEntry[] = [
+      { id: "n1", key: "preferred_cloud_provider", value: "AWS us-east-1" },
+    ];
+    const d = classifyConsolidation(
+      { key: "cloud_provider_preferred", value: "AWS us-west-2" },
+      near,
+    );
+    expect(d.action).toBe("supersede");
+    expect(d.targetId).toBe("n1");
+  });
+
+  it("NOOPs a different-key near-duplicate that restates the same value", () => {
+    const near: ExistingEntry[] = [
+      { id: "n1", key: "preferred_cloud_provider", value: "AWS us-east-1" },
+    ];
+    const d = classifyConsolidation(
+      { key: "cloud_provider_preferred", value: "aws us-east-1" },
+      near,
+    );
+    expect(d.action).toBe("noop");
+    expect(d.targetId).toBe("n1");
+  });
+
+  it("respects a custom supersede threshold", () => {
+    const near: ExistingEntry[] = [{ id: "n1", key: "a b c", value: "x y" }];
+    // Moderately similar candidate; a very high threshold forces ADD.
+    const d = classifyConsolidation({ key: "a b", value: "z" }, near, {
+      supersedeThreshold: 0.99,
+    });
+    expect(d.action).toBe("add");
+  });
+
+  it("ADDs against an empty store", () => {
+    expect(classifyConsolidation({ key: "k", value: "v" }, []).action).toBe("add");
+  });
+
+  it("uses the documented default threshold", () => {
+    expect(DEFAULT_SUPERSEDE_THRESHOLD).toBeGreaterThan(0.5);
+    expect(DEFAULT_SUPERSEDE_THRESHOLD).toBeLessThan(1);
+  });
+});

--- a/apps/web/lib/tak/memory-consolidation.ts
+++ b/apps/web/lib/tak/memory-consolidation.ts
@@ -1,0 +1,120 @@
+// apps/web/lib/tak/memory-consolidation.ts
+// Write-time memory consolidation gate — BI-840FDD43 (EP-8C706944 Phase 2).
+//
+// Both UserFact (upsertUserFact) and CoworkerMemoryNote (recordCoworkerNote)
+// supersede only on an EXACT key match, so two entries that mean the same thing
+// under different keys ("preferred_meeting_time" vs "meeting_time") both persist,
+// and the stores accumulate near-duplicates and unresolved contradictions.
+//
+// This gate generalizes the exact-key rule: given a candidate entry and the
+// active entries in its scope, it classifies the write as ADD / NOOP / UPDATE /
+// SUPERSEDE against the nearest neighbor (mem0's consolidation controller,
+// adapted to a deterministic lexical similarity so the decision is unit-testable
+// without a model). The caller applies the decision with its existing
+// supersede-with-provenance machinery — this module decides, it does not write.
+
+export type ConsolidationAction = "add" | "noop" | "update" | "supersede";
+
+export type ExistingEntry = {
+  id: string;
+  key: string;
+  value: string;
+};
+
+export type ConsolidationDecision =
+  | { action: "add"; targetId: null; reason: string }
+  | { action: "noop"; targetId: string; reason: string }
+  | { action: "update"; targetId: string; reason: string }
+  | { action: "supersede"; targetId: string; reason: string };
+
+/**
+ * Key-token similarity at or above which two entries are treated as the same
+ * concept. Matching is driven by the KEY, not the value: two facts about the
+ * same thing share key tokens ("preferred_cloud_provider" ≈ "cloud_provider"),
+ * and whether the VALUE differs is what separates supersede from noop. Including
+ * value tokens here would dilute the signal exactly in the supersede case (same
+ * concept, changed value), so the value is compared separately for equality.
+ */
+export const DEFAULT_SUPERSEDE_THRESHOLD = 0.6;
+
+/** Normalize text to a comparable token set (lowercase, alphanumeric words). */
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 0),
+  );
+}
+
+/** Jaccard similarity over two token sets (0..1). */
+function jaccard(ta: Set<string>, tb: Set<string>): number {
+  if (ta.size === 0 && tb.size === 0) return 1;
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let inter = 0;
+  for (const t of ta) if (tb.has(t)) inter += 1;
+  const union = ta.size + tb.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+/** Jaccard similarity over the entries' KEY token sets (the same-concept signal). */
+export function entrySimilarity(
+  a: { key: string; value: string },
+  b: { key: string; value: string },
+): number {
+  return jaccard(tokenize(a.key), tokenize(b.key));
+}
+
+function normalizedEqual(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/**
+ * Classify a candidate write against the active entries in its scope.
+ *
+ * - NOOP: an existing entry has the same key and an equivalent value, OR a
+ *   near-duplicate (different key) already states the same value — nothing to do.
+ * - UPDATE: same key, different value — refresh the existing entry in place.
+ * - SUPERSEDE: a different-key near-neighbor (>= threshold) holds a different
+ *   value — replace it so the store keeps one canonical entry, not two.
+ * - ADD: no equivalent or near neighbor — store fresh.
+ */
+export function classifyConsolidation(
+  candidate: { key: string; value: string },
+  existing: ExistingEntry[],
+  opts?: { supersedeThreshold?: number },
+): ConsolidationDecision {
+  const threshold = opts?.supersedeThreshold ?? DEFAULT_SUPERSEDE_THRESHOLD;
+
+  // 1. Exact-key handling (preserves the current behavior of both stores).
+  const exact = existing.find((e) => e.key === candidate.key);
+  if (exact) {
+    return normalizedEqual(exact.value, candidate.value)
+      ? { action: "noop", targetId: exact.id, reason: "exact key, equivalent value" }
+      : { action: "update", targetId: exact.id, reason: "exact key, changed value" };
+  }
+
+  // 2. Nearest different-key neighbor.
+  let best: { entry: ExistingEntry; sim: number } | null = null;
+  for (const e of existing) {
+    const sim = entrySimilarity(candidate, e);
+    if (!best || sim > best.sim) best = { entry: e, sim };
+  }
+
+  if (best && best.sim >= threshold) {
+    return normalizedEqual(best.entry.value, candidate.value)
+      ? {
+          action: "noop",
+          targetId: best.entry.id,
+          reason: `near-duplicate (sim ${best.sim.toFixed(2)}) with equivalent value`,
+        }
+      : {
+          action: "supersede",
+          targetId: best.entry.id,
+          reason: `near-duplicate (sim ${best.sim.toFixed(2)}) with changed value`,
+        };
+  }
+
+  return { action: "add", targetId: null, reason: "no equivalent or near neighbor" };
+}

--- a/apps/web/lib/tak/user-facts.ts
+++ b/apps/web/lib/tak/user-facts.ts
@@ -374,8 +374,30 @@ export async function upsertUserFact(params: {
       },
     });
   } else {
-    // New fact
-    await prisma.userFact.create({
+    // No exact-key match. BI-840FDD43 (EP-8C706944 P2): before blindly adding,
+    // consult the write-time consolidation gate against other active facts in
+    // this category — a different-key near-duplicate ("meeting_time" vs
+    // "preferred_meeting_time") should supersede rather than pile up.
+    const { classifyConsolidation } = await import("./memory-consolidation");
+    const siblings = await prisma.userFact.findMany({
+      where: {
+        userId: params.userId,
+        category: params.category,
+        supersededAt: null,
+      },
+      select: { id: true, key: true, value: true },
+    });
+    const decision = classifyConsolidation(
+      { key: params.key, value: params.value },
+      siblings,
+    );
+
+    if (decision.action === "noop") {
+      // A near-duplicate already states this — nothing to persist.
+      return;
+    }
+
+    const newFact = await prisma.userFact.create({
       data: {
         userId: params.userId,
         category: params.category,
@@ -390,6 +412,14 @@ export async function upsertUserFact(params: {
         lastValidatedAt: params.sourceOperatingProfileFingerprint ? new Date() : null,
       },
     });
+
+    if (decision.action === "supersede") {
+      // Retire the superseded near-duplicate, preserving the provenance chain.
+      await prisma.userFact.update({
+        where: { id: decision.targetId },
+        data: { supersededAt: new Date(), supersededById: newFact.id },
+      });
+    }
   }
 }
 

--- a/docs/superpowers/plans/2026-07-09-memory-consolidation-gate-plan.md
+++ b/docs/superpowers/plans/2026-07-09-memory-consolidation-gate-plan.md
@@ -1,0 +1,35 @@
+# Write-time memory consolidation gate — implementation plan
+
+- **BI:** BI-840FDD43 (EP-8C706944 — AI Coworker Memory & Context Architecture, Phase 2)
+- **Date:** 2026-07-09
+- **Kernel ledger:** DI-F69AE978B70C
+- **Status:** Gate core + wiring into both stores (this PR)
+
+## Problem
+
+`upsertUserFact` (UserFact) and `recordCoworkerNote` (CoworkerMemoryNote) both supersede only on an **exact key match**. Two entries that mean the same thing under different keys — `preferred_meeting_time` vs `meeting_time`, `review_style_preferred` vs `preferred_review_style` — both persist, so the stores accumulate near-duplicates and unresolved contradictions.
+
+## Design
+
+A pure write-time gate (mem0's ADD/UPDATE/DELETE/NOOP controller, adapted to a deterministic lexical signal so it is unit-testable without a model).
+
+1. **Pure core** `apps/web/lib/tak/memory-consolidation.ts`: `classifyConsolidation(candidate, existing, opts)` →
+   - **NOOP** — exact key with an equivalent value, or a near-duplicate that restates the same value.
+   - **UPDATE** — exact key, changed value (preserves current behavior).
+   - **SUPERSEDE** — a different-key near-neighbor (key-token Jaccard ≥ `DEFAULT_SUPERSEDE_THRESHOLD` = 0.6) with a changed value.
+   - **ADD** — no equivalent or near neighbor.
+
+   Matching is driven by the **key** token set, not key+value: two entries about the same concept share key tokens, and whether the value differs is exactly what separates SUPERSEDE from NOOP — folding value tokens in would dilute the signal in the supersede case. 11 unit tests.
+
+2. **Wiring** (additive, exact-key behavior unchanged): when neither store finds an exact-key match, it loads the active siblings in scope (UserFact: same `userId`+`category`; CoworkerMemoryNote: same `agentId`+`noteKind`), runs the gate, and applies NOOP (skip) / SUPERSEDE (create + retire the near-neighbor with the provenance chain) / ADD (create).
+
+## Non-goals (own BIs)
+
+- Batch consolidation / contradiction resolution across the whole store → the sleep-time pass (BI-907C4327) reuses this same gate in batch mode.
+- Expiry/pruning of superseded rows → BI-153F7E4A.
+- Embedding-based similarity — deliberately deterministic lexical for now; an embedding signal can be layered behind the same `classifyConsolidation` seam later without changing callers.
+
+## Verification
+
+- Unit: `memory-consolidation.test.ts` (11 — similarity, all four actions, custom threshold, empty store) + `coworker-memory.test.ts` (2 new — near-dup supersede + near-dup noop). Existing user-facts/coworker-memory suites green (24 total across the three files).
+- Runtime (post-merge): recording `review_style_preferred` when `preferred_review_style` is active supersedes the latter instead of creating a second active note.


### PR DESCRIPTION
## Summary
EP-8C706944 Phase 2 (3/9), kernel ledger DI-F69AE978B70C.

`upsertUserFact` and `recordCoworkerNote` supersede only on an **exact key match**, so entries meaning the same thing under different keys (`preferred_meeting_time` vs `meeting_time`) both persist and the stores accumulate near-duplicates/contradictions.

- **Pure core** `memory-consolidation.ts`: `classifyConsolidation` → ADD / NOOP / UPDATE / SUPERSEDE against the nearest neighbor, matched on **key-token Jaccard** (≥ 0.6) so "same concept, changed value" supersedes rather than piles up; value equality separates supersede from noop. Deterministic (no model) → 11 unit tests. mem0's consolidation controller, adapted.
- **Wiring** (additive, exact-key behavior unchanged): when no exact-key match, load active siblings in scope (UserFact: userId+category; CoworkerMemoryNote: agentId+noteKind), classify, apply NOOP/SUPERSEDE(+provenance)/ADD.

The sleep-time pass (BI-907C4327) reuses this gate in batch mode.

## Verification
vitest 24/24 (memory-consolidation 11 + coworker-memory incl. 2 new + user-facts), `pnpm --filter web typecheck` clean.

Plan: docs/superpowers/plans/2026-07-09-memory-consolidation-gate-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)