### PR TITLE
feat(coworker): inject durable working notes into the prompt (BI-15FE2F07)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -922,6 +922,21 @@ export async function sendMessage(input: {
       });
     }
 
+    // BI-15FE2F07 (working-memory Slice 2): surface the coworker's own durable
+    // working notes into the prompt. Fail-open — notes must never break a reply,
+    // and a coworker with no notes yields null (a strict no-op in the assembler).
+    let workingNotes: string | null = null;
+    try {
+      const { resolveCoworkerAgent } = await import("@/lib/tak/coworker-tool-grant-core");
+      const { loadCoworkerNotes, formatNotesAsContext } = await import("@/lib/tak/coworker-memory");
+      const resolvedCoworker = await resolveCoworkerAgent(agent.agentId);
+      if (resolvedCoworker) {
+        workingNotes = formatNotesAsContext(await loadCoworkerNotes(resolvedCoworker.id));
+      }
+    } catch (err) {
+      console.warn("[coworker-memory] working-note injection failed (fail-open):", err);
+    }
+
     populatedPrompt = await assembleSystemPrompt({
       hrRole: user.platformRole ?? "none",
       grantedCapabilities: granted,
@@ -934,6 +949,7 @@ export async function sendMessage(input: {
       attachmentContext: selectedAttachments,
       professionContext: selectedProfessionContext,
       wikiContext,
+      workingNotes,
       skills: skillSummaries,
       questionPacket: input.questionPacket ?? null,
       // BI-8F8C5F28: on customer-copy surfaces, hold the coworker to the org's

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -71,6 +71,28 @@ describe("assembleSystemPrompt", () => {
     expect(routeIdx).toBeLessThan(attachIdx);
   });
 
+  // BI-15FE2F07 (working-memory Slice 2): pre-rendered working notes land in
+  // Block 5 (domain), after wiki recall and before route data.
+  it("injects working notes into Block 5 when present", async () => {
+    const notes = "\nYOUR WORKING NOTES:\n- [technique] retry-flow: escalate after 2 failures";
+    const prompt = await assembleSystemPrompt({ ...fullInput, wikiContext: "WIKI CONTEXT HERE", workingNotes: notes });
+
+    const wikiIdx = indexOf(prompt, "WIKI CONTEXT HERE");
+    const notesIdx = indexOf(prompt, "YOUR WORKING NOTES:");
+    const routeIdx = indexOf(prompt, "--- PAGE DATA ---");
+    expect(notesIdx).toBeGreaterThanOrEqual(0);
+    expect(wikiIdx).toBeLessThan(notesIdx); // below wiki recall
+    expect(notesIdx).toBeLessThan(routeIdx); // still within Block 5, before route data
+  });
+
+  it("is a strict no-op when workingNotes is null or omitted", async () => {
+    const withNull = await assembleSystemPrompt({ ...minimalInput, workingNotes: null });
+    const without = await assembleSystemPrompt(minimalInput);
+    expect(withNull).not.toContain("YOUR WORKING NOTES:");
+    // Omitting the field produces the identical prompt as passing null.
+    expect(withNull).toBe(without);
+  });
+
   // Test 2: Advise mode text is injected correctly
   it("injects advise mode text when mode is 'advise'", async () => {
     const prompt = await assembleSystemPrompt(minimalInput);

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -34,6 +34,15 @@ export type PromptInput = {
    */
   wikiContext?: string | null;
   /**
+   * BI-15FE2F07 (working-memory Slice 2): the calling coworker's durable
+   * role-local working notes, pre-rendered by the caller via
+   * `formatNotesAsContext(await loadCoworkerNotes(agentCuid))`
+   * (apps/web/lib/tak/coworker-memory.ts). Injected into Block 5 below wiki
+   * recall — role-local memory grounds the coworker's own prior learning.
+   * Null/empty when the coworker has no notes, so the block is a strict no-op.
+   */
+  workingNotes?: string | null;
+  /**
    * WSID Phase 3: the coworker's profession corpus — graded, cited excerpts of
    * its professional knowledge base, resolved from the agent's profession family
    * (apps/web/lib/decision-perspective/profession-corpus.ts). Rendered at the TOP
@@ -211,6 +220,12 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
   }
   if (input.wikiContext) {
     domainBlock += `\n\n${input.wikiContext}`;
+  }
+  // BI-15FE2F07: the coworker's own durable working notes — role-local memory,
+  // below generic recall. formatNotesAsContext returns null when there are no
+  // notes, so this is a strict no-op for coworkers without memory.
+  if (input.workingNotes) {
+    domainBlock += `\n\n${input.workingNotes}`;
   }
   if (input.domainTools.length > 0) {
     domainBlock += `\nAvailable domain tools: ${input.domainTools.join(", ")}`;

--- a/docs/superpowers/plans/2026-07-09-coworker-working-memory-prompt-injection-plan.md
+++ b/docs/superpowers/plans/2026-07-09-coworker-working-memory-prompt-injection-plan.md
@@ -1,0 +1,42 @@
+# Coworker working-memory prompt injection — plan (BI-15FE2F07)
+
+- **Date:** 2026-07-09
+- **Epic:** EP-CLAUDE-INSIDE-OUT (harness-parity Cluster 1, matrix row #3)
+- **BI:** BI-15FE2F07 (Slice 2 of BI-F9025BA0)
+- **Kernel altitude ledger:** DI-D1C96829E6BD (deliver-tractable-block-rest)
+
+## Problem
+
+BI-F9025BA0 Slice 1 (PR #2702) shipped the working-memory substrate:
+`CoworkerMemoryNote`, `loadCoworkerNotes`, `formatNotesAsContext`, and a
+self-scoped MCP door. But nothing injected those notes into the prompt — a
+coworker could record and read its notes via the door, yet its own durable
+memory never reached its system prompt. This slice closes that loop.
+
+## Approach (substrate-first — the formatter already exists)
+
+1. **Assembler** — `prompt-assembler.ts`: add `workingNotes?: string | null` to
+   `PromptInput`; inject it into Block 5 (domain), directly below wiki recall.
+   `formatNotesAsContext` already returns `null` when there are no notes, so the
+   block is a **strict no-op** for coworkers without memory (the null and omitted
+   cases produce an identical prompt).
+2. **Caller** — `agent-coworker.ts`, unified branch (`if (useUnified)`): before
+   `assembleSystemPrompt`, resolve the coworker cuid (`resolveCoworkerAgent`) and
+   load + format its notes, passing `workingNotes`. **Fail-open** — wrapped in
+   try/catch so a memory-load error can never break a reply.
+3. **Tests** — assembler: notes land in Block 5 below wiki and before route data;
+   null/omitted is a strict no-op (byte-identical prompt).
+
+## Scope boundary
+
+- **Unified path only.** The legacy path (`USE_UNIFIED_COWORKER=false`) assembles
+  its prompt separately and is the retirement target of BI-45514C4E; wiring
+  memory there would be throwaway. Once the unified default flips, every install
+  inherits memory injection.
+
+## Safety
+
+- Additive optional field; no change to any existing block or caller behavior
+  when `workingNotes` is absent.
+- Fail-open load: notes never break a response.
+- No schema change (Slice 1 already shipped the model + loaders).

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -16,7 +16,7 @@ apps/web/components/workbooks/Grid.tsx	924
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1338
 apps/web/lib/actions/agent-coworker-external.test.ts	866
-apps/web/lib/actions/agent-coworker.ts	2666
+apps/web/lib/actions/agent-coworker.ts	2682
 apps/web/lib/actions/agent-task-scheduler.test.ts	1083
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1114


### PR DESCRIPTION
## Summary
Slice 2 of BI-F9025BA0 (EP-CLAUDE-INSIDE-OUT matrix row #3). Closes the working-memory loop: Slice 1 (#2702) made notes recordable/readable via the door; this surfaces them into the coworker's system prompt.

- `prompt-assembler.ts`: optional `workingNotes` on `PromptInput`, injected into Block 5 below wiki recall. Strict no-op when null/omitted (byte-identical prompt) since `formatNotesAsContext` returns null with no notes.
- `agent-coworker.ts` (unified branch): resolve cuid + load/format notes before `assembleSystemPrompt`, **fail-open**.
- 2 new assembler tests (Block-5 placement below wiki + before route data; null/omitted no-op). 39/39 green.

Unified path only — legacy is the BI-45514C4E retirement target. No schema change. Kernel ledger DI-D1C96829E6BD. Plan: docs/superpowers/plans/2026-07-09-coworker-working-memory-prompt-injection-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)