### PR TITLE
feat(coworker-memory): sleep-time consolidation pass — autoDream (BI-907C4327)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -525,6 +525,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     tracksRunData: false,
     runNowEvent: "ops/coworker-certification.requested",
   },
+  {
+    jobId: "memory-consolidation-nightly",
+    inngestId: "coworker/memory-consolidation-nightly",
+    name: "Coworker memory consolidation",
+    purpose:
+      "EP-8C706944 Phase 2 (BI-907C4327): the sleep-time 'autoDream' pass — batch-collapses near-duplicate coworker working notes and user facts to one canonical each, then expires entries unused past the retention window (supersession, never a hard delete). If it stops, the memory stores accumulate near-duplicates and stale facts.",
+    cron: "20 4 * * *",
+    cadence: "Daily at 04:20",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
 ] as const;
 
 const CATALOG_BY_JOB_ID = new Map<string, ScheduledJobCatalogEntry>(

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -73,6 +73,7 @@ import {
   coworkerCertificationNightly,
   coworkerCertificationRunNow,
 } from "./coworker-certification";
+import { memoryConsolidationNightly } from "./memory-consolidation-nightly";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 export const scheduledFunctions = [
@@ -116,6 +117,7 @@ export const scheduledFunctions = [
   remoteActionClaimTimeout,   // EP-REMOTE-ACTION P2: time out stale claimed RemoteActions so the pull queue can't wedge, every 10m (flag-gated)
   coworkerCertificationNightly, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): nightly golden-journey certification of every roster coworker, 04:40
   canonicalImprovementDigest, // BI-8996BBBB: weekly [reference-doc] proposal digest -> canonical-source chore BI
+  memoryConsolidationNightly, // BI-907C4327: EP-8C706944 P2 autoDream — nightly batch-dedupe + expire coworker notes / user facts, 04:20
 ];
 
 export const eventFunctions = [

--- a/apps/web/lib/queue/functions/memory-consolidation-nightly.ts
+++ b/apps/web/lib/queue/functions/memory-consolidation-nightly.ts
@@ -1,0 +1,101 @@
+// apps/web/lib/queue/functions/memory-consolidation-nightly.ts
+// Sleep-time memory consolidation pass ("autoDream") — BI-907C4327
+// (EP-8C706944 Phase 2). Nightly, low-priority reflection that reorganizes the
+// memory stores while nobody is waiting: batch-collapse near-duplicate facts and
+// notes, then expire entries unused past the retention window. Mirrors Letta's
+// sleep-time compute and the generative-agents reflection loop, reusing DPF's
+// existing nightly-Inngest + quiescence-gate substrate.
+//
+// Design: idempotent and additive. Consolidation supersedes near-duplicates
+// (provenance preserved); expiry supersedes stale entries (never a hard delete).
+// Runs behind the quiescence gate so it never contends with an upgrade.
+
+import { cron } from "inngest";
+import { prisma } from "@dpf/db";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import { dedupeCoworkerNotes, dedupeUserFacts } from "@/lib/tak/memory-consolidation-runner";
+import {
+  expireStaleCoworkerNotes,
+  expireStaleUserFacts,
+} from "@/lib/tak/memory-expiry-runner";
+
+/** 04:20 UTC daily — off-peak, clear of the 03:00 backup + 04:00 retention slots. */
+export const MEMORY_CONSOLIDATION_CRON = "20 4 * * *";
+
+export interface MemoryConsolidationResult {
+  coworkersSwept: number;
+  usersSwept: number;
+  notesDeduped: number;
+  factsDeduped: number;
+  notesExpired: number;
+  factsExpired: number;
+}
+
+/**
+ * Sweep every coworker's notes and every user's facts: batch-dedupe then expire.
+ * Each entity is handled independently; one failure is logged and does not abort
+ * the pass.
+ */
+export async function runMemoryConsolidationSweep(): Promise<MemoryConsolidationResult> {
+  const result: MemoryConsolidationResult = {
+    coworkersSwept: 0,
+    usersSwept: 0,
+    notesDeduped: 0,
+    factsDeduped: 0,
+    notesExpired: 0,
+    factsExpired: 0,
+  };
+
+  // Coworkers with at least one active note.
+  const noteAgents = await prisma.coworkerMemoryNote.findMany({
+    where: { supersededAt: null },
+    distinct: ["agentId"],
+    select: { agentId: true },
+  });
+  for (const { agentId } of noteAgents) {
+    try {
+      result.notesDeduped += await dedupeCoworkerNotes(agentId);
+      result.notesExpired += await expireStaleCoworkerNotes(agentId);
+      result.coworkersSwept += 1;
+    } catch (err) {
+      console.warn(`[autoDream] coworker ${agentId} sweep failed:`, err);
+    }
+  }
+
+  // Users with at least one active fact.
+  const factUsers = await prisma.userFact.findMany({
+    where: { supersededAt: null },
+    distinct: ["userId"],
+    select: { userId: true },
+  });
+  for (const { userId } of factUsers) {
+    try {
+      result.factsDeduped += await dedupeUserFacts(userId);
+      result.factsExpired += await expireStaleUserFacts(userId);
+      result.usersSwept += 1;
+    } catch (err) {
+      console.warn(`[autoDream] user ${userId} sweep failed:`, err);
+    }
+  }
+
+  return result;
+}
+
+export const memoryConsolidationNightly = inngest.createFunction(
+  {
+    id: "coworker/memory-consolidation-nightly",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(MEMORY_CONSOLIDATION_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    const swept = await step.run("memory-consolidation-sweep", async () =>
+      runMemoryConsolidationSweep(),
+    );
+    return swept;
+  },
+);

--- a/apps/web/lib/tak/memory-consolidation-runner.ts
+++ b/apps/web/lib/tak/memory-consolidation-runner.ts
@@ -1,0 +1,60 @@
+// apps/web/lib/tak/memory-consolidation-runner.ts
+// Applies the batch dedupe plan to the live stores (BI-907C4327). Binds prisma to
+// the pure planner; supersession preserves the provenance chain (loser points at
+// the canonical winner). Reused by the nightly sleep-time pass.
+
+import { prisma } from "@dpf/db";
+import { planBatchDedupe, type SweepEntry } from "./memory-consolidation-sweep";
+
+/** Collapse a coworker's near-duplicate active notes to one canonical each. */
+export async function dedupeCoworkerNotes(agentCuid: string): Promise<number> {
+  const notes = await prisma.coworkerMemoryNote.findMany({
+    where: { agentId: agentCuid, supersededAt: null },
+    select: { id: true, noteKey: true, content: true, createdAt: true, noteKind: true },
+  });
+  // Dedupe within each noteKind — a technique and a preference are never dupes.
+  const byKind = new Map<string, SweepEntry[]>();
+  for (const n of notes) {
+    const list = byKind.get(n.noteKind) ?? [];
+    list.push({ id: n.id, key: n.noteKey, value: n.content, createdAt: n.createdAt });
+    byKind.set(n.noteKind, list);
+  }
+  let superseded = 0;
+  for (const entries of byKind.values()) {
+    const plan = planBatchDedupe(entries);
+    for (const item of plan) {
+      await prisma.coworkerMemoryNote.update({
+        where: { id: item.loserId },
+        data: { supersededAt: new Date(), supersededById: item.winnerId },
+      });
+      superseded += 1;
+    }
+  }
+  return superseded;
+}
+
+/** Collapse a user's near-duplicate active facts (per category) to one canonical each. */
+export async function dedupeUserFacts(userId: string): Promise<number> {
+  const facts = await prisma.userFact.findMany({
+    where: { userId, supersededAt: null },
+    select: { id: true, key: true, value: true, createdAt: true, category: true },
+  });
+  const byCategory = new Map<string, SweepEntry[]>();
+  for (const f of facts) {
+    const list = byCategory.get(f.category) ?? [];
+    list.push({ id: f.id, key: f.key, value: f.value, createdAt: f.createdAt });
+    byCategory.set(f.category, list);
+  }
+  let superseded = 0;
+  for (const entries of byCategory.values()) {
+    const plan = planBatchDedupe(entries);
+    for (const item of plan) {
+      await prisma.userFact.update({
+        where: { id: item.loserId },
+        data: { supersededAt: new Date(), supersededById: item.winnerId },
+      });
+      superseded += 1;
+    }
+  }
+  return superseded;
+}

--- a/apps/web/lib/tak/memory-consolidation-sweep.test.ts
+++ b/apps/web/lib/tak/memory-consolidation-sweep.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { planBatchDedupe, type SweepEntry } from "./memory-consolidation-sweep";
+
+const at = (iso: string) => new Date(iso);
+
+describe("planBatchDedupe", () => {
+  it("returns no plan when all entries are distinct concepts", () => {
+    const entries: SweepEntry[] = [
+      { id: "a", key: "cloud_provider", value: "AWS", createdAt: at("2026-07-01") },
+      { id: "b", key: "editor", value: "neovim", createdAt: at("2026-07-02") },
+      { id: "c", key: "testing_approach", value: "TDD", createdAt: at("2026-07-03") },
+    ];
+    expect(planBatchDedupe(entries)).toEqual([]);
+  });
+
+  it("supersedes an older near-duplicate in favor of the newest as canonical", () => {
+    const entries: SweepEntry[] = [
+      { id: "old", key: "preferred_cloud_provider", value: "AWS", createdAt: at("2026-07-01") },
+      { id: "new", key: "cloud_provider_preferred", value: "GCP", createdAt: at("2026-07-05") },
+    ];
+    const plan = planBatchDedupe(entries);
+    expect(plan).toHaveLength(1);
+    expect(plan[0]).toMatchObject({ loserId: "old", winnerId: "new" });
+  });
+
+  it("collapses a cluster of three near-duplicates to one canonical winner", () => {
+    const entries: SweepEntry[] = [
+      { id: "v1", key: "review_style", value: "terse", createdAt: at("2026-07-01") },
+      { id: "v2", key: "review_style_preferred", value: "bullets", createdAt: at("2026-07-02") },
+      { id: "v3", key: "preferred_review_style", value: "prose", createdAt: at("2026-07-03") },
+    ];
+    const plan = planBatchDedupe(entries);
+    // v3 is newest → winner; v1 and v2 superseded by it.
+    expect(plan).toHaveLength(2);
+    expect(plan.every((p) => p.winnerId === "v3")).toBe(true);
+    expect(plan.map((p) => p.loserId).sort()).toEqual(["v1", "v2"]);
+  });
+
+  it("keeps two clusters separate", () => {
+    const entries: SweepEntry[] = [
+      { id: "cloud-old", key: "cloud_provider", value: "AWS", createdAt: at("2026-07-01") },
+      { id: "cloud-new", key: "preferred_cloud_provider", value: "GCP", createdAt: at("2026-07-04") },
+      { id: "editor", key: "editor_choice", value: "vim", createdAt: at("2026-07-02") },
+    ];
+    const plan = planBatchDedupe(entries);
+    expect(plan).toHaveLength(1);
+    expect(plan[0]).toMatchObject({ loserId: "cloud-old", winnerId: "cloud-new" });
+  });
+
+  it("is stable regardless of input order", () => {
+    const base: SweepEntry[] = [
+      { id: "old", key: "preferred_cloud_provider", value: "AWS", createdAt: at("2026-07-01") },
+      { id: "new", key: "cloud_provider_preferred", value: "GCP", createdAt: at("2026-07-05") },
+    ];
+    const forward = planBatchDedupe(base);
+    const reversed = planBatchDedupe([...base].reverse());
+    expect(reversed).toEqual(forward);
+  });
+
+  it("returns no plan for an empty scope", () => {
+    expect(planBatchDedupe([])).toEqual([]);
+  });
+});

--- a/apps/web/lib/tak/memory-consolidation-sweep.ts
+++ b/apps/web/lib/tak/memory-consolidation-sweep.ts
@@ -1,0 +1,55 @@
+// apps/web/lib/tak/memory-consolidation-sweep.ts
+// Batch consolidation planner for the sleep-time pass — BI-907C4327
+// (EP-8C706944 Phase 2).
+//
+// The write-time gate (memory-consolidation.ts) only compares a NEW entry to the
+// existing set. Over time, entries written before their eventual duplicates
+// still coexist. The nightly pass sweeps a whole scope and collapses
+// near-duplicate clusters to one canonical entry, keeping the most recent and
+// superseding the rest.
+//
+// Pure and deterministic: given the active entries (newest-first) it returns the
+// supersede plan; the runner applies it with the existing provenance machinery.
+
+import { classifyConsolidation, type ExistingEntry } from "./memory-consolidation";
+
+/** An active entry to consider, carrying its recency for canonical selection. */
+export type SweepEntry = ExistingEntry & { createdAt: Date };
+
+/** One planned supersession: `loserId` is retired in favor of `winnerId`. */
+export type SupersedePlanItem = { loserId: string; winnerId: string; reason: string };
+
+/**
+ * Plan the supersessions needed to collapse near-duplicate clusters in one
+ * scope. Entries are processed newest-first; the first representative of each
+ * cluster is the canonical "winner" and later (older) near-duplicates are
+ * superseded by it. An entry that matches no kept winner becomes a new winner.
+ */
+export function planBatchDedupe(
+  entries: SweepEntry[],
+  opts?: { supersedeThreshold?: number },
+): SupersedePlanItem[] {
+  const byNewest = [...entries].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  const winners: ExistingEntry[] = [];
+  const plan: SupersedePlanItem[] = [];
+
+  for (const entry of byNewest) {
+    const decision = classifyConsolidation(
+      { key: entry.key, value: entry.value },
+      winners,
+      opts,
+    );
+    if (decision.action === "add") {
+      winners.push({ id: entry.id, key: entry.key, value: entry.value });
+    } else {
+      // noop / update / supersede all mean "same concept as an existing winner":
+      // this older entry is redundant → supersede it in favor of the winner.
+      plan.push({
+        loserId: entry.id,
+        winnerId: decision.targetId,
+        reason: `batch dedupe: ${decision.reason}`,
+      });
+    }
+  }
+  return plan;
+}

--- a/docs/superpowers/plans/2026-07-09-autodream-sleep-time-consolidation-plan.md
+++ b/docs/superpowers/plans/2026-07-09-autodream-sleep-time-consolidation-plan.md
@@ -1,0 +1,29 @@
+# Sleep-time memory consolidation ("autoDream") — implementation plan
+
+- **BI:** BI-907C4327 (EP-8C706944 — AI Coworker Memory & Context Architecture, Phase 2)
+- **Date:** 2026-07-09
+- **Kernel ledger:** DI-F69AE978B70C
+- **Status:** Nightly pass wired (this PR)
+
+## Problem
+
+The autonomous memory-consolidation loop ("autoDream") was designed in `docs/superpowers/specs/2026-04-02-agentic-architecture-patterns-design.md` and never shipped. The write-time gate (BI-840FDD43) only compares a *new* entry to the existing set, so duplicates that predate their eventual twins still coexist, and stale entries never expire without a sweep.
+
+## Design
+
+A nightly, low-priority reflection pass — Letta's sleep-time compute / generative-agents reflection — reusing DPF's existing nightly-Inngest + quiescence-gate + scheduled-job-catalog substrate.
+
+1. **Pure batch planner** `memory-consolidation-sweep.ts`: `planBatchDedupe(entries)` processes a scope newest-first, keeps the first representative of each near-duplicate cluster as the canonical winner (reusing the BI-840FDD43 `classifyConsolidation` similarity), and returns the supersede plan for the rest. Deterministic, order-independent → 6 unit tests.
+2. **Runner** `memory-consolidation-runner.ts`: `dedupeCoworkerNotes` (per `noteKind`) and `dedupeUserFacts` (per `category`) apply the plan with the provenance chain intact.
+3. **Nightly function** `queue/functions/memory-consolidation-nightly.ts`: `runMemoryConsolidationSweep` iterates coworkers with active notes and users with active facts — batch-dedupe then expire (reusing BI-153F7E4A `expireStale*`) — each entity independent (one failure logged, pass continues). Registered behind the quiescence gate, cron **04:20 UTC** (clear of the 03:00 backup and 04:00 retention slots), concurrency 1.
+4. **Catalog + registration**: added to `scheduledFunctions` and `SCHEDULED_JOB_CATALOG` (the drift guard requires both; the admin Scheduled Jobs surface renders the catalog entry).
+
+## Non-goals (future slices)
+
+- Promoting confirmed durable learnings to the WWWD/WSID commons via `dpf-route-learning-to-commons` — a heavier routing step; this pass consolidates and expires, and the commons-promotion hook lands once the two-scope model (BI-1772D0B7) defines what is org-shareable.
+- Raw-message pruning across all threads — `pruneSummarizedThreadMessages` (BI-153F7E4A) is ready; wiring it per-thread into this pass is deferred until effort-scoped threads (BI-23A65B81) define the active-thread set to sweep.
+
+## Verification
+
+- Unit: `memory-consolidation-sweep.test.ts` (6 — distinct entries, cluster collapse, cluster separation, order-independence, empty) + `index.test.ts` cron↔catalog parity guard green.
+- Runtime (post-merge): after the pass, a coworker with two near-duplicate active notes has one; a user fact unused > 28 days is superseded; the admin Scheduled Jobs surface lists "Coworker memory consolidation" at 04:20.


### PR DESCRIPTION
## Summary
EP-8C706944 Phase 2 (5/9), kernel ledger DI-F69AE978B70C. **Stacked on #2738 (BI-153F7E4A)** — base retargets to main once that merges.

The autoDream consolidation loop was designed in `2026-04-02-agentic-architecture-patterns-design.md` and never shipped. The write-time gate only compares a *new* entry to the set, so duplicates predating their twins coexist and stale entries never expire without a sweep.

Nightly reflection pass (Letta sleep-time compute / generative-agents reflection) on DPF's nightly-Inngest + quiescence-gate substrate:
- **Pure planner** `memory-consolidation-sweep.ts`: `planBatchDedupe` collapses near-duplicate clusters newest-first to one canonical, returns the supersede plan (reuses BI-840FDD43 similarity) → 6 unit tests.
- **Runner**: `dedupeCoworkerNotes` (per noteKind) / `dedupeUserFacts` (per category) apply with provenance intact.
- **Nightly fn** `memory-consolidation-nightly.ts`: sweep every coworker's notes + every user's facts (dedupe then expire via BI-153F7E4A), per-entity isolated, quiescence-gated, cron **04:20 UTC**, concurrency 1.
- **Registered** in `scheduledFunctions` + `SCHEDULED_JOB_CATALOG` (drift guard requires both).

## Verification
vitest sweep 6/6 + `index.test.ts` cron↔catalog parity 3/3, `pnpm --filter web typecheck` clean.

Plan: docs/superpowers/plans/2026-07-09-autodream-sleep-time-consolidation-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)